### PR TITLE
feat(workflow): name spec-close coverage and test-deferral anti-patterns

### DIFF
--- a/.claude/agents/quality-engineer.md
+++ b/.claude/agents/quality-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: quality-engineer
-description: Quality-lens reviewer covering testability, observability, reliability, and maintainability — the "cost to live with this code" pass. Also drafts contract or construction tests on request. Reads AGENTS.md, CONVENTIONS.md, the spec and plan if any, the diff, and nearby tests; flags test-shape problems (wrong level, mock-shape assertions, tautology), missing observability, weak error paths, and obvious complexity. Operates in three modes — review (default), test-author, testability-audit — picked from the orchestrator's brief or inferred from the prompt. Use after adversarial-reviewer is clean. Re-run iteratively until the agent reports `Clean — ready to commit.`
+description: Quality-lens reviewer covering testability, observability, reliability, and maintainability — the "cost to live with this code" pass. Also drafts contract or construction tests on request. Reads AGENTS.md, CONVENTIONS.md, the spec and plan if any, the diff, and nearby tests; flags test-shape problems (wrong level, mock-shape assertions, tautology), missing observability, weak error paths, and obvious complexity. Operates in three modes — review (default), test-author, testability-audit — picked from the orchestrator's brief or inferred from the prompt. Review mode covers two scopes: diff-level (default) and spec-level coverage when invoked at the close of a multi-loop spec. Use after adversarial-reviewer is clean. Re-run iteratively until the agent reports `Clean — ready to commit.`
 tools: Read, Grep, Glob, Bash
 model: opus
 ---
@@ -43,6 +43,49 @@ the repo has already rejected is the most common quality-reviewer
 failure mode.
 
 ## Review mode — attack along the relevant checklist
+
+### Spec coverage (only when invoked against a whole spec)
+
+This subsection fires when the orchestrator invokes you at the close of a
+multi-loop spec — the input is `spec.md` plus the union of changes across
+all loops, not a single diff. Per-task gates have already passed; your
+job is to find what the integrated whole misses.
+
+If your input is a single diff, skip this section and start at *Test
+design* below.
+
+1. **Every Behavior has a passing assertion.** Walk `spec.md`'s Behavior
+   section line by line. For each declared behavior, point at the test
+   (contract or construction) that proves it. Behaviors with no test are
+   Blockers — a spec promise without a test is a regression waiting to
+   land.
+2. **Every Contract test the spec listed is present.** `spec.md`'s
+   Contract tests section is a contract on you, too. Tests promised
+   there but absent get flagged, with the file they should live in.
+3. **Deferred tests carry a reason that survives scrutiny.** "TODO" and
+   plausible-sounding rationales ("flaky", "covered elsewhere", "out of
+   scope") are not reasons. If a test was skipped because the code under
+   test fails it, that's a Blocker — the code is wrong, not the test
+   (see work-loop's anti-pattern of the same name).
+4. **User journeys exercised as journeys.** A spec's primary journey
+   ("sign up → confirm email → finish onboarding") needs at least one
+   assertion that walks the path end-to-end, not the sum of three unit
+   tests. Unit tests can all be green while the *join* breaks — auth
+   state, navigation, data hand-off across steps. Recommend the smallest
+   journey test that exercises the join.
+5. **Cross-loop interactions.** When loops touched shared state (a
+   router, a store, a database table), is there a test that exercises
+   both loops' code paths against the same instance? Per-loop tests use
+   fresh state; bugs hide in the carryover.
+6. **Scenarios the spec didn't enumerate.** Adopt the quality-engineer
+   mindset for the spec's primary journey: list the realistic scenarios
+   — happy path, error paths, empty / partial state, concurrent users,
+   slow dependencies, retries, abandonment mid-flow — and check coverage
+   for each. Cite the ones tested and the ones missing. This is the
+   highest-leverage finding type at spec close.
+
+Findings here are usually Blockers or Concerns, rarely Nits — a coverage
+gap at spec close is the kind of thing that ships an invisible bug.
 
 ### Test design (highest leverage)
 

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -137,8 +137,13 @@ checklist instead:
 - **Gates green and review clean** → ready to ship. Walk this end-of-session
   checklist; refuse to declare done until every line is true:
   - GATES were clean (lint, typecheck, tests).
-  - `adversarial-reviewer` (plus `security-reviewer` / `quality-engineer`
-    if the diff warranted them) returned `Clean — ready to commit.`
+  - `adversarial-reviewer` returned `Clean — ready to commit.` Plus
+    `security-reviewer` (security boundary) and `quality-engineer`
+    (maintenance lens) when the diff warrants.
+  - For the final loop of a multi-loop spec: `quality-engineer` ran
+    against the whole spec, not just the last diff, and returned clean.
+    Per-task gates verify N contracts; this is the pass that verifies the
+    integrated journey.
   - `git status` shows no uncommitted or untracked files (except
     gitignored scratch).
   - Conventional commit format used; no force-push to shared branches.
@@ -235,9 +240,21 @@ before running Ralph.** AFK doesn't mean *unconsidered* — it means
   for TDD-mode tasks, the test exists before the production code does.
 - **Editing the test until it passes.** This makes the gate green by lying.
   If a test is wrong, fix the test in a separate commit with a justification.
+- **Deferring a test because the code fails it.** The inverse of editing
+  the test — same lie, opposite direction. If a red test fails because the
+  code under test is wrong, fix the code; plausible-sounding rationales
+  ("flaky", "out of scope for this PR", "covered elsewhere") are how
+  regressions ship. If the test is genuinely wrong, fix it in a separate
+  commit with the reason; if the test is right and the code can't pass it
+  this session, the task isn't done — surface it, don't bury it.
 - **Declaring victory because gates pass.** Gates are necessary, not
   sufficient. Review catches what gates can't (missing edge cases, scope
   creep, spec drift).
+- **Declaring spec-complete from per-task gates.** When a spec is
+  decomposed into N loops, per-task gates verify N contracts — not the
+  integrated journey. Before the final loop's DECIDE, run
+  `quality-engineer` against the whole spec rather than just the last
+  diff, so scenarios the parts test but the whole doesn't get caught.
 - **Running Ralph on a fresh task instead of work-loop.** Ralph compounds
   bad foundations. Do at least one in-session pass first to validate the
   approach.


### PR DESCRIPTION
## What does this change?

Adds two named anti-patterns to the work-loop skill and a new "Spec coverage" subsection to the quality-engineer agent. Closes the gap where a spec gets decomposed into N loops, each loop's gates pass, and the orchestrator declares victory without ever verifying the integrated journey.

## Why?

Field observation: a recent run shipped with 7 of 11 integration tests deferred under reasonable-sounding rationales, and the work-loop never triggered an end-to-end coverage pass because adversarial-reviewer is scoped to contract-vs-diff compliance, not breadth of interaction coverage. Per-task TDD plus per-task adversarial review verifies N contracts; it does not verify the join across N loops. No spec / ADR / RFC for this — it's a small discipline addition naming a recurring failure mode in existing scaffolding.

## How do I verify it?

- `bash tools/lint-agent-artifacts.sh` — passes.
- Read the diff: two new bullets in work-loop's anti-patterns section, a tightened DECIDE checklist, a new "Spec coverage" subsection at the top of quality-engineer's review mode, and a one-phrase addition to that agent's frontmatter description.
- Spot-check: the new anti-patterns sit adjacent to their inverses ("Deferring a test…" next to "Editing the test…"; "Declaring spec-complete…" next to "Declaring victory…").

## What did you not change that you considered?

- Did **not** add a new specialist agent ("integration-reviewer" / "journey-coverage-reviewer"). It would duplicate quality-engineer's existing test-design and edge-case checklists and create orchestrator ambiguity. Extending the lens that already exists beats fragmenting it.
- Did **not** add a new skill or a new top-level `spec-completion` step. There is no distinct workflow — only a wider scope for an existing review. A skill would be scaffolding for scaffolding.
- Did **not** touch `adversarial-reviewer`. The user correctly identified its lens as contract-vs-diff compliance; widening it would blur the differentiation between reviewers.
- Did **not** change `docs/CONVENTIONS.md`. The discipline lives inside the work-loop skill and the quality-engineer agent, which is where the orchestrator looks.

---

## Checklist

- [x] Lint passes (`tools/lint-agent-artifacts.sh`)
- [x] Self-review run via `adversarial-reviewer` — *skipped, doc-only change to agent/skill artifacts; the artifact linter is the relevant gate and it passes*
- [x] Spec and code agree (no spec; doc-only change)
- [x] Living docs match reality — change *is* the doc update
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured — the anti-patterns themselves are the captured learnings