### PR TITLE
feat(workflow): wire spec-mode adversarial review into new-spec and work-loop

### DIFF
--- a/.claude/skills/new-spec/SKILL.md
+++ b/.claude/skills/new-spec/SKILL.md
@@ -68,9 +68,20 @@ spec — it forces the question "what does done look like?" before any code.
      "Update the parser" is too coarse to verify; "add a null-check
      in `parser/lex.ts:Lexer.next`" is the right level.
 
-5. Update `docs/specs/README.md` to add the feature to the active list.
+5. Spec-mode adversarial review. Before announcing the spec in the README,
+   invoke `adversarial-reviewer` against the freshly drafted `spec.md` +
+   `plan.md` in spec mode — the agent supports this explicitly (see
+   `.claude/agents/adversarial-reviewer.md`). Iterate on findings until the
+   reviewer returns `Clean — ready to commit.` Spec-mode reviews should
+   converge in 1-2 passes; if you can't reach clean in 3, the spec has a
+   structural problem — surface to a human rather than grinding. This step
+   is contingent on the project using `adversarial-reviewer` at all (Profile
+   B+ per `docs/CONVENTIONS.md`); at Profile A the reviewer is typically
+   absent and this step is moot.
 
-6. Remind the user: when implementation diverges from the spec, the spec is
+6. Update `docs/specs/README.md` to add the feature to the active list.
+
+7. Remind the user: when implementation diverges from the spec, the spec is
    wrong. Update the spec in the same PR.
 
 ## Anti-patterns to refuse

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -58,6 +58,14 @@ For anything beyond trivial, *think before you write code*. Concretely:
   sharpen the plan first. Discovering a missing or wrong construction test
   during EXECUTE is fine, but the fix is "update plan.md, then resume
   EXECUTE", not "skip ahead".
+- **Spec-mode adversarial review before EXECUTE.** If PLAN produced or
+  modified a spec (i.e. you ran `new-spec`, or you sharpened an existing
+  `spec.md` / `plan.md`), invoke `adversarial-reviewer` in spec mode
+  against the spec + plan and iterate to clean before EXECUTE begins.
+  Cheap-to-fix-early applies harder to specs than to code — catching a
+  vague behavior, a missing `Depends on:`, or a mismatched verification
+  mode here costs a sentence, not a re-plan. Same Profile-A caveat as
+  the post-impl review: skip if the project doesn't use the reviewer.
 
 The output of this step is a written plan (with tests) you can return to.
 Don't keep it in your head — your context will turn over and you'll lose it.


### PR DESCRIPTION
## What
Wires `adversarial-reviewer` (spec mode) into the two skills that produce/modify specs, so spec-stage checks fire before EXECUTE — not after gates on a half-built feature.

- `new-spec/SKILL.md` — new step 5 invokes spec-mode review against the freshly drafted `spec.md` + `plan.md` before announcing in the README. Iterate to clean; 3-pass soft ceiling.
- `work-loop/SKILL.md` § PLAN — added bullet gating EXECUTE on a clean spec-mode pass when PLAN produced or modified a spec.

## Why
The agent file (`.claude/agents/adversarial-reviewer.md:3,14-16`) explicitly lists spec/plan review before code as a first-class mode. Neither caller invoked it. The spec-stage checklist (lines 48-83) just doubled in value with the new `Depends on:` (#8) and verification-mode (#9) checks — but those checks only fire if the reviewer actually runs in spec mode. Catching a vague behavior or missing `Depends on:` at spec time costs a sentence; catching it post-implementation burns the 5-iteration cap on a re-plan.

## How to verify
- `tools/lint-agent-artifacts.sh` — passes
- `tools/lint-agents-md.sh` — passes
- Read the two diffs; both insertions are additive, ≤10 lines each, with Profile-A contingency phrasing that matches the existing post-impl reviewer call (no stricter unconditional gate).

## What I didn't change
- `docs/CONVENTIONS.md` Profile A table — already covers reviewer absence; no edit needed.
- The post-implementation reviewer call in work-loop step 4 — unchanged.
- No new iteration cap introduced; the "3 passes then surface" is judgment, not a numeric gate.