### PR TITLE
docs(skills): drop trigger restatements from skill bodies

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -29,8 +29,10 @@ tool, used often enough to stick — live in
 
 Each `SKILL.md` should:
 
-1. Have a tight YAML frontmatter `description` (the trigger surface — what
-   makes Claude invoke this skill vs. another).
+1. Have a tight YAML frontmatter `description` — the *trigger surface*
+   that decides invocation. The body answers the disjoint question of
+   what to do once invoked (preconditions, judgment, procedure); it must
+   not restate the trigger.
 2. Be small. Skills are loaded into context when triggered; bloated skills
    crowd out the user's actual task.
 3. Link out to scripts in the same directory rather than embedding shell.

--- a/.claude/skills/bug-fix/SKILL.md
+++ b/.claude/skills/bug-fix/SKILL.md
@@ -11,10 +11,8 @@ identify root vs symptom, minimum diff, commit body documents why.
 
 ## When to invoke
 
-The user is pointing at a defect — observed behavior differs from
-intended behavior in code that already exists. Even a one-line fix
-benefits from walking this discipline; it forces the question "is
-this fixing the cause or hiding it?"
+Even a one-line fix benefits from walking this discipline; it forces
+the question "is this fixing the cause or hiding it?"
 
 For multi-file changes that go beyond fixing one defect — refactors,
 new features triggered by discovering the bug — stop and use

--- a/.claude/skills/new-adr/SKILL.md
+++ b/.claude/skills/new-adr/SKILL.md
@@ -10,7 +10,7 @@ number.
 
 ## When to invoke
 
-The user wants to record an architectural decision. Before invoking, confirm:
+Before invoking, confirm:
 
 1. The decision is about *architecture or shared infrastructure*, not a
    single feature's internals (that's a spec).

--- a/.claude/skills/new-package/SKILL.md
+++ b/.claude/skills/new-package/SKILL.md
@@ -10,8 +10,7 @@ in this monorepo follows.
 
 ## When to invoke
 
-The user wants a new shared library that other packages or apps will depend
-on. Confirm:
+Confirm:
 
 1. It belongs in `packages/` (shared library), not `apps/` (deployable).
 2. Its name is unique within `packages/` and reasonably descriptive.

--- a/.claude/skills/new-rfc/SKILL.md
+++ b/.claude/skills/new-rfc/SKILL.md
@@ -9,8 +9,7 @@ Open a new RFC in `docs/rfc/` from the template.
 
 ## When to invoke
 
-The user wants to propose a change that's bigger than a normal PR. Before
-invoking, confirm one of:
+Before invoking, confirm one of:
 
 - The change touches multiple packages or affects external users.
 - The change reverses a previous ADR.

--- a/.claude/skills/new-spec/SKILL.md
+++ b/.claude/skills/new-spec/SKILL.md
@@ -10,9 +10,9 @@ and `plan.md`.
 
 ## When to invoke
 
-The user is about to build something nontrivial. The spec is the contract;
-the plan is the strategy. Even a one-day feature benefits from a one-paragraph
-spec — it forces the question "what does done look like?" before any code.
+The spec is the contract; the plan is the strategy. Even a one-day feature
+benefits from a one-paragraph spec — it forces the question "what does done
+look like?" before any code.
 
 ## Procedure
 


### PR DESCRIPTION
## Summary

- Trim the body openers of five skills (`bug-fix`, `new-spec`, `new-adr`, `new-rfc`, `new-package`) that restated the trigger already declared in the YAML frontmatter `description`. Bodies now lead with judgment / preconditions / the H1 framing line — no double-statement.
- Sharpen the authoring rule in `.claude/skills/README.md`: description is the *trigger surface*; the body answers the disjoint question of what to do once invoked.
- `work-loop` and `update-conventions` already followed this contract — left unchanged.

## Why

The frontmatter `description` is the routing surface; it loads unconditionally so the agent can decide whether to invoke. Bodies load only after invocation. Re-stating the trigger in the body opener wastes both context windows without adding signal.

Descriptions are **not** modified, so skill routing behaviour is identical across Claude Code, Codex CLI, and Gemini CLI (all three use the same name+description-injected-at-startup, body-on-activation architecture).

## Test plan

- [ ] Skim each modified `SKILL.md` — confirm no body opener restates the trigger.
- [ ] Confirm `description` frontmatter is byte-identical to before (diff stat shows only body changes).
- [ ] Sanity-invoke one of the trimmed skills in a session to confirm the body still reads cleanly without the opener.