### PR TITLE
feat(workflow): per-skill dependency manifests and Path B installer

### DIFF
--- a/.claude/agents/adversarial-reviewer.md
+++ b/.claude/agents/adversarial-reviewer.md
@@ -3,6 +3,7 @@ name: adversarial-reviewer
 description: Adversarial reviewer for specs, plans, implementations, or any combination ("spec amendment + implementation in the same PR" is the dominant case). Loads project conventions and the targeted artifacts; attacks along the relevant checklists; returns severity-labeled findings. Use after gates pass but before declaring done; also use any time a spec or plan needs an adversarial read before code starts. Re-run iteratively until the agent reports `Clean — ready to commit.`
 tools: Read, Grep, Glob, Bash
 model: opus
+dependencies: []
 ---
 
 # Adversarial reviewer

--- a/.claude/agents/quality-engineer.md
+++ b/.claude/agents/quality-engineer.md
@@ -3,6 +3,7 @@ name: quality-engineer
 description: Quality-lens reviewer covering testability, observability, reliability, and maintainability — the "cost to live with this code" pass. Also drafts contract or construction tests on request. Reads AGENTS.md, CONVENTIONS.md, the spec and plan if any, the diff, and nearby tests; flags test-shape problems (wrong level, mock-shape assertions, tautology), missing observability, weak error paths, and obvious complexity. Operates in three modes — review (default), test-author, testability-audit — picked from the orchestrator's brief or inferred from the prompt. Review mode covers two scopes: diff-level (default) and spec-level coverage when invoked at the close of a multi-loop spec. Use after adversarial-reviewer is clean. Re-run iteratively until the agent reports `Clean — ready to commit.`
 tools: Read, Grep, Glob, Bash
 model: opus
+dependencies: []
 ---
 
 # Quality engineer

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -3,6 +3,7 @@ name: security-reviewer
 description: Threat-model and OWASP-lens reviewer for diffs that change auth, data handling, dependencies, deserialization, file/network I/O, secrets, or LLM/agent code. Reads AGENTS.md, CONVENTIONS.md, any docs/architecture/security.md, the diff, and the spec if one exists; attacks along OWASP Top 10 (web + LLM Apps 2025) and a STRIDE prompt; returns severity-labeled findings. Complements — does not replace — SAST/SCA scanners and adversarial-reviewer. Use after adversarial-reviewer is clean, before merging anything that touches a security boundary. Re-run iteratively until the agent reports `Clean — ready to commit.`
 tools: Read, Grep, Glob, Bash
 model: opus
+dependencies: []
 ---
 
 # Security reviewer

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -37,3 +37,13 @@ Each `SKILL.md` should:
    crowd out the user's actual task.
 3. Link out to scripts in the same directory rather than embedding shell.
    Code in scripts can be tested; code in markdown can't.
+4. Declare a `dependencies:` list in the frontmatter — every file
+   *outside this skill's folder* the body relies on. Sibling agents the
+   skill invokes (`.claude/agents/<name>.md`), templates it generates
+   from (`docs/_templates/<name>.md`), tools it runs (`tools/<name>.sh`),
+   sections of `docs/CONVENTIONS.md` it cites by anchor
+   (`docs/CONVENTIONS.md#anchor`). Empty list (`dependencies: []`) is
+   valid and honest. The manifest powers `tools/install-skill.py` (Path
+   B in [`USING_THIS_TEMPLATE.md`](../../USING_THIS_TEMPLATE.md)) and is
+   validated by `tools/lint-skill-deps.sh`. Keep it accurate as the body
+   changes — drift is what the linter exists to catch.

--- a/.claude/skills/bug-fix/SKILL.md
+++ b/.claude/skills/bug-fix/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: bug-fix
 description: Use this skill when the user wants to fix a bug — a deviation between current behavior and intended behavior in code that already exists. Triggers on "fix bug", "fix this bug", "diagnose and fix", "investigate this regression", "this is broken". Do NOT use for new features (use `new-spec`) or for refactors that don't fix incorrect behavior.
+dependencies:
+  - .claude/skills/new-spec/SKILL.md
+  - .claude/agents/adversarial-reviewer.md
+  - .claude/agents/quality-engineer.md
 ---
 
 # Skill: bug-fix

--- a/.claude/skills/new-adr/SKILL.md
+++ b/.claude/skills/new-adr/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: new-adr
 description: Use this skill when the user asks to create, write, draft, or open a new ADR (architecture decision record). Triggers on phrases like "new ADR", "write an ADR for…", "record this decision", "let's ADR this". Do NOT use for RFCs (use `new-rfc`) or feature specs (use `new-spec`).
+dependencies:
+  - docs/_templates/adr.md
 ---
 
 # Skill: new-adr

--- a/.claude/skills/new-package/SKILL.md
+++ b/.claude/skills/new-package/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: new-package
 description: Use this skill when the user wants to scaffold a new package in the monorepo's `packages/` directory. Triggers on "new package", "create a package called…", "add a library for…". Don't use for new top-level directories (those need an RFC) or for new apps (which go in `apps/`, not `packages/`).
+dependencies: []
 ---
 
 # Skill: new-package

--- a/.claude/skills/new-rfc/SKILL.md
+++ b/.claude/skills/new-rfc/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: new-rfc
 description: Use this skill when the user asks to propose, draft, or open an RFC (request for comments). Triggers on "RFC", "propose a change to…", "let's get input on…", "draft a proposal". Do NOT use for already-decided things (use `new-adr`) or single-feature specs (use `new-spec`).
+dependencies:
+  - docs/_templates/rfc.md
 ---
 
 # Skill: new-rfc

--- a/.claude/skills/new-spec/SKILL.md
+++ b/.claude/skills/new-spec/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: new-spec
 description: Use this skill when the user wants to start a new feature with a spec, or wants to write a spec for something they're about to build. Triggers on "new spec", "write a spec for X", "let's spec this out", "start a feature for…". Spec-driven development; the spec drives implementation. Do NOT use for cross-cutting proposals (use `new-rfc`) or recording decisions (use `new-adr`).
+dependencies:
+  - docs/_templates/spec.md
+  - docs/_templates/plan.md
+  - .claude/agents/adversarial-reviewer.md
 ---
 
 # Skill: new-spec

--- a/.claude/skills/update-conventions/SKILL.md
+++ b/.claude/skills/update-conventions/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: update-conventions
 description: Use this skill when the user wants to change `docs/CONVENTIONS.md` or `docs/CHARTER.md`. Triggers on "let's change the convention for…", "update the rules", "amend the charter", "change our principles". Conventions and charter changes go through RFC review, not direct PR.
+dependencies:
+  - docs/CONVENTIONS.md
+  - docs/CHARTER.md
+  - .claude/skills/new-rfc/SKILL.md
 ---
 
 # Skill: update-conventions

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -1,6 +1,14 @@
 ---
 name: work-loop
 description: Use this skill whenever you're implementing a non-trivial change — a feature, a bug fix that touches more than one file, a refactor, or anything spec-driven. It enforces the project's plan → execute → self-review → fix loop with mechanical gates (lint, typecheck, tests) and adversarial review. Default to this skill for any task larger than a one-line edit.
+dependencies:
+  - docs/CONVENTIONS.md#contract-tests-vs-construction-tests
+  - .claude/agents/adversarial-reviewer.md
+  - .claude/agents/security-reviewer.md
+  - .claude/agents/quality-engineer.md
+  - .claude/skills/new-spec/SKILL.md
+  - tools/ralph.sh
+  - tools/RALPH.md
 ---
 
 # Skill: work-loop

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ AI coding agents are getting good enough to do real engineering, and the work go
 
 It fits any project — service, library, platform — and scales from solo developer up to a team of fifty without restructuring. For the thinking behind each piece, see [`docs/APPROACH.md`](docs/APPROACH.md).
 
+There are two ways to adopt. Bootstrap a new repo from the full template with `bash tools/bootstrap.sh` (Path A — the documented happy path), or cherry-pick a single skill into your existing repo with `python3 tools/install-skill.py <skill-name> /path/to/your-repo` (Path B). Path B reads each skill's `dependencies:` manifest, walks the closure, copies what's needed, and never clobbers files you already have. See [`USING_THIS_TEMPLATE.md`](USING_THIS_TEMPLATE.md) for both.
+
 ---
 
 **For evaluators**: below is the template scaffold an adopter inherits after running `bash tools/bootstrap.sh`. It shows the kinds of documents, conventions, and structure the template installs.
@@ -72,7 +74,7 @@ load on demand.
 │   ├── product/                    # roadmap, changelog (for maintainers)
 │   ├── guides/                     # user-facing docs (Diátaxis-organized)
 │   └── _templates/                 # blank templates for adr / rfc / spec / plan
-├── tools/                          # bootstrap, linters, self-tests, Ralph harness
+├── tools/                          # bootstrap, single-skill installer, linters, self-tests, Ralph harness
 ├── apps/                           # deployable applications (delete if not used)
 └── packages/                       # shared libraries (delete if not used)
 ```

--- a/USING_THIS_TEMPLATE.md
+++ b/USING_THIS_TEMPLATE.md
@@ -41,7 +41,15 @@ populate more of it.
 
 ## Step 1 — Create your repo from the template
 
-### Option A: GitHub "Use this template" (recommended)
+There are two ways to adopt the template. Pick by what you already have.
+
+### Path A: Bootstrap a fresh repo from the template
+
+The full template — every skill, every reviewer, every doc — wired up
+for a new project. Use this when you're starting greenfield, or when
+you want the structure as a whole.
+
+**Option A1: GitHub "Use this template" (recommended)**
 
 1. On the template's GitHub page, click **Use this template** → **Create a new repository**.
 2. Name your repo, set visibility, click **Create repository from template**.
@@ -51,7 +59,7 @@ populate more of it.
    cd <your-new-repo>
    ```
 
-### Option B: Manual copy
+**Option A2: Manual copy**
 
 ```bash
 # Clone the template
@@ -62,6 +70,37 @@ cd my-project
 rm -rf .git
 git init
 ```
+
+Then continue with Step 2 below.
+
+### Path B: Drop a single skill into an existing repo
+
+Already have a repo and you just want one skill (say, `bug-fix` or
+`work-loop`)? Clone the template anywhere, then run:
+
+```bash
+# macOS / Linux:
+python3 /path/to/template/tools/install-skill.py <skill-name> /path/to/your-repo
+
+# Windows (PowerShell):
+py -3 \path\to\template\tools\install-skill.py <skill-name> \path\to\your-repo
+```
+
+The script reads the skill's dependency manifest, walks the closure,
+and copies every leaf — sibling agents, templates the skill generates
+from, tools it invokes — into your repo at the matching paths. Files
+that already exist are left alone; the script reports each one
+(`= already present` if it matches the source, `! content differs` if
+it doesn't) and moves on. Re-running is safe and shows you the same
+inventory.
+
+A few skills depend on sections of `docs/CONVENTIONS.md` or `AGENTS.md`.
+Those don't get spliced into your governance docs — the script can't
+safely edit prose it didn't write. Instead, it drops the relevant
+slice into `docs/CONVENTIONS.fragments/<skill>.md` and prints a note.
+Merge by hand, then delete the fragment.
+
+Skip the rest of this guide if Path B was all you needed.
 
 ---
 

--- a/tools/install-skill.py
+++ b/tools/install-skill.py
@@ -1,0 +1,478 @@
+#!/usr/bin/env python3
+"""Install one skill (with its transitive dependencies) into an existing repo.
+
+Path B of the bootstrap: when an adopter already has their own repo and
+just wants to pull in one or two skills, they run:
+
+    python3 tools/install-skill.py <skill-or-agent-name> /path/to/their-repo
+
+The script walks the dependency closure declared in each artifact's YAML
+frontmatter (`dependencies:` list) and copies every leaf into the
+destination, preserving the source layout. Existing files at the
+destination are never clobbered; both no-op cases warn and skip so
+the adopter sees exactly what was and wasn't written:
+
+  - byte-identical to source -> warn-and-skip ("already present")
+  - content differs          -> warn-and-skip ("kept your version")
+
+Docs are special. `docs/CONVENTIONS.md` and `AGENTS.md` belong to the
+adopter, not us. If a skill depends on a section of either (e.g.
+`docs/CONVENTIONS.md#contract-tests-vs-construction-tests`) or on the
+whole file (the `update-conventions` case), the script writes the
+relevant slice to `<dest>/docs/CONVENTIONS.fragments/<skill>.md` rather
+than overwriting. The user merges manually; auto-splicing someone else's
+governance doc is a trap.
+
+The script is pure-stdlib Python 3 so PowerShell adopters don't need to
+install bash. Exit non-zero on any hard error (missing source dep,
+unknown target name); skip-with-warning is not an error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import shutil
+import sys
+from dataclasses import dataclass, field
+from typing import Iterable
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+SKILL_DIR = ".claude/skills"
+AGENT_DIR = ".claude/agents"
+# Files that belong to the adopter, not us. Dependencies on these (whole or
+# by anchor) are emitted as fragments rather than copied — auto-splicing
+# governance prose is a trap. The reviewer agents (adversarial-, security-,
+# quality-) intentionally do NOT list these in their `dependencies:` even
+# though their bodies say "read AGENTS.md and docs/CONVENTIONS.md first":
+# they read whatever the adopter has at runtime, not the template's version.
+FRAGMENT_FILES = {"docs/CONVENTIONS.md", "AGENTS.md", "docs/CHARTER.md"}
+
+# Files we'd rather never carry along when copying a skill folder. Skill
+# folders are SKILL.md plus optional support material; OS junk and Python
+# bytecode caches are neither.
+SKILL_FOLDER_IGNORES = (".DS_Store", "Thumbs.db")
+SKILL_FOLDER_IGNORE_DIRS = ("__pycache__", ".git")
+
+
+@dataclass
+class Plan:
+    """What install-skill.py decided to do, ready to be applied."""
+
+    # File-copy entries: (source_relpath, dest_relpath).
+    copies: list[tuple[str, str]] = field(default_factory=list)
+    # Fragment entries: (source_relpath, anchor_or_None, dest_relpath, owning_skill).
+    fragments: list[tuple[str, str | None, str, str]] = field(default_factory=list)
+    # Names already visited so we don't recurse forever.
+    visited: set[str] = field(default_factory=set)
+
+
+# ── Frontmatter parsing ───────────────────────────────────────────────────
+
+
+def parse_frontmatter(path: pathlib.Path) -> dict:
+    """Return frontmatter fields. Supports scalar values and block-style
+    YAML lists (`key:` followed by `  - item` lines). Mirrors the parser
+    in tools/lint-agent-artifacts.sh."""
+    text = path.read_text()
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    end = None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            end = i
+            break
+    if end is None:
+        raise ValueError(f"{path}: frontmatter opened with --- but never closed")
+    fields: dict = {}
+    i = 1
+    while i < end:
+        raw = lines[i]
+        if not raw.strip():
+            i += 1
+            continue
+        m = re.match(r"^([a-zA-Z][a-zA-Z0-9_-]*):\s*(.*)$", raw)
+        if not m:
+            raise ValueError(f"{path}: malformed frontmatter line {i + 1}: {raw!r}")
+        key, val = m.group(1), m.group(2).strip()
+        if val == "[]":
+            fields[key] = []
+            i += 1
+            continue
+        if val == "":
+            items: list[str] = []
+            j = i + 1
+            while j < end:
+                nxt = lines[j]
+                if not nxt.strip():
+                    j += 1
+                    continue
+                lm = re.match(r"^\s+-\s+(.*)$", nxt)
+                if not lm:
+                    break
+                items.append(lm.group(1).strip())
+                j += 1
+            fields[key] = items
+            i = j
+            continue
+        fields[key] = val
+        i += 1
+    return fields
+
+
+# ── Resolving names and dependencies ──────────────────────────────────────
+
+
+def resolve_target(name: str) -> pathlib.Path:
+    """Find the source artifact (skill SKILL.md or agent .md) by name.
+    Names are kebab-case; we accept either."""
+    skill = REPO_ROOT / SKILL_DIR / name / "SKILL.md"
+    agent = REPO_ROOT / AGENT_DIR / f"{name}.md"
+    if skill.exists():
+        return skill
+    if agent.exists():
+        return agent
+    raise SystemExit(
+        f"error: unknown skill or agent {name!r}. "
+        f"Looked for {skill.relative_to(REPO_ROOT)} and {agent.relative_to(REPO_ROOT)}."
+    )
+
+
+def split_anchor(dep: str) -> tuple[str, str | None]:
+    """`path` or `path#anchor` -> (path, anchor-or-None)."""
+    if "#" in dep:
+        path, anchor = dep.split("#", 1)
+        return path, anchor
+    return dep, None
+
+
+def is_skill_md(rel: str) -> bool:
+    return rel.startswith(f"{SKILL_DIR}/") and rel.endswith("/SKILL.md")
+
+
+def is_agent_md(rel: str) -> bool:
+    return rel.startswith(f"{AGENT_DIR}/") and rel.endswith(".md")
+
+
+def skill_name_of(rel: str) -> str:
+    """`.claude/skills/<name>/SKILL.md` -> `<name>`. Caller must verify."""
+    parts = rel.split("/")
+    return parts[2]
+
+
+# ── Building the install plan ─────────────────────────────────────────────
+
+
+def build_plan(target_rel: str, owning_skill: str, plan: Plan) -> None:
+    """Walk the dependency closure rooted at `target_rel` and populate plan.
+    `owning_skill` names the top-level skill we're installing (for naming
+    fragment files)."""
+    if target_rel in plan.visited:
+        return
+    plan.visited.add(target_rel)
+
+    src = REPO_ROOT / target_rel
+    if not src.exists():
+        raise SystemExit(
+            f"error: dependency points at {target_rel} but that file is not "
+            f"present in the template source. The manifest is wrong; run "
+            f"tools/lint-skill-deps.sh."
+        )
+
+    # Skill = whole folder. Copy every file under .claude/skills/<name>/,
+    # skipping OS junk and bytecode caches.
+    if is_skill_md(target_rel):
+        name = skill_name_of(target_rel)
+        for f in sorted((REPO_ROOT / SKILL_DIR / name).rglob("*")):
+            if not f.is_file():
+                continue
+            if f.name in SKILL_FOLDER_IGNORES:
+                continue
+            if any(part in SKILL_FOLDER_IGNORE_DIRS for part in f.relative_to(REPO_ROOT).parts):
+                continue
+            rel = f.relative_to(REPO_ROOT).as_posix()
+            plan.copies.append((rel, rel))
+        # Follow the skill's own deps.
+        for dep in parse_frontmatter(src).get("dependencies", []) or []:
+            recurse_dep(dep, owning_skill, plan)
+        return
+
+    # Agent = single file.
+    if is_agent_md(target_rel):
+        plan.copies.append((target_rel, target_rel))
+        for dep in parse_frontmatter(src).get("dependencies", []) or []:
+            recurse_dep(dep, owning_skill, plan)
+        return
+
+    # Plain leaf (template, tool script, etc.). Refuse directories — they
+    # have no defined copy semantics here and would crash apply() with
+    # IsADirectoryError mid-write.
+    if src.is_dir():
+        raise SystemExit(
+            f"error: dependency {target_rel} resolves to a directory. "
+            f"Manifests must point at individual files; if you need a whole "
+            f"directory, list the files explicitly."
+        )
+    plan.copies.append((target_rel, target_rel))
+
+
+def fragment_dest(dep_path: str, owning_skill: str) -> str:
+    """Where in the adopter's repo a fragment for `dep_path` lands."""
+    parent = pathlib.PurePosixPath(dep_path).parent.as_posix()
+    stem = pathlib.PurePosixPath(dep_path).stem  # CONVENTIONS, AGENTS, CHARTER
+    parent_prefix = f"{parent}/" if parent and parent != "." else ""
+    return f"{parent_prefix}{stem}.fragments/{owning_skill}.md"
+
+
+def recurse_dep(dep: str, owning_skill: str, plan: Plan) -> None:
+    """Add a single dependency entry to the plan."""
+    dep_path, anchor = split_anchor(dep)
+    if dep_path in FRAGMENT_FILES:
+        plan.fragments.append(
+            (dep_path, anchor, fragment_dest(dep_path, owning_skill), owning_skill)
+        )
+        return
+    # Everything else: recursive copy with manifest-following.
+    build_plan(dep_path, owning_skill, plan)
+
+
+# ── Section extraction for fragment emission ──────────────────────────────
+
+
+def slugify(heading: str) -> str:
+    """Convert a markdown heading text to its GitHub-style anchor slug."""
+    s = heading.strip().lower()
+    s = re.sub(r"[^\w\s-]", "", s)
+    s = re.sub(r"\s+", "-", s)
+    return s.strip("-")
+
+
+def extract_section(source_text: str, anchor: str) -> str:
+    """Return the markdown chunk under the heading whose slug matches
+    `anchor`, up to (but not including) the next heading of the same or
+    higher level. Raises if no matching heading is found."""
+    lines = source_text.splitlines()
+    target_level = None
+    start = None
+    for i, line in enumerate(lines):
+        m = re.match(r"^(#+)\s+(.*)$", line)
+        if not m:
+            continue
+        level = len(m.group(1))
+        heading = m.group(2)
+        if slugify(heading) == anchor:
+            target_level = level
+            start = i
+            break
+    if start is None:
+        raise SystemExit(
+            f"error: anchor '#{anchor}' not found in source — "
+            f"manifest claims a section that does not exist."
+        )
+    end = len(lines)
+    for j in range(start + 1, len(lines)):
+        m = re.match(r"^(#+)\s+", lines[j])
+        if m and len(m.group(1)) <= target_level:
+            end = j
+            break
+    # Trim trailing blanks and bare horizontal rules — those belong to the
+    # source doc's section divider, not the section we're extracting.
+    while end > start + 1 and (not lines[end - 1].strip()
+                               or lines[end - 1].strip() == "---"):
+        end -= 1
+    return "\n".join(lines[start:end]).rstrip() + "\n"
+
+
+def render_fragment(source_rel: str, anchor: str | None,
+                    owning_skill: str, body: str) -> str:
+    """Wrap a section (or whole file) in a header explaining what it is
+    and what the adopter should do with it."""
+    header = (
+        f"<!--\n"
+        f"  Fragment emitted by tools/install-skill.py when installing "
+        f"the '{owning_skill}' skill.\n"
+        f"  Source: {source_rel}"
+        f"{(' #' + anchor) if anchor else ''}\n"
+        f"\n"
+        f"  This is the slice the skill depends on. It has NOT been merged\n"
+        f"  into your repo's {source_rel} because doing so safely would\n"
+        f"  require understanding your version. Reconcile manually:\n"
+        f"  copy the relevant prose into your own {source_rel}, then\n"
+        f"  delete this file.\n"
+        f"-->\n\n"
+    )
+    return header + body
+
+
+# ── Apply the plan to the destination ─────────────────────────────────────
+
+
+def safe_join(dest: pathlib.Path, rel: str) -> pathlib.Path:
+    """Join `dest` and `rel`, refusing paths that resolve outside `dest`.
+    Cheap defense against a manifest that contains `..` segments."""
+    target = (dest / rel).resolve()
+    dest_root = dest.resolve()
+    try:
+        target.relative_to(dest_root)
+    except ValueError:
+        raise SystemExit(
+            f"error: dependency path {rel!r} escapes the destination "
+            f"directory. Refusing to write."
+        )
+    return target
+
+
+def apply(plan: Plan, dest: pathlib.Path) -> tuple[list[str], list[str], list[str], list[str]]:
+    """Apply the plan. Returns (installed, already_present, conflicts,
+    fragments) — each a list of dest-relative paths for the summary.
+    Both 'already present' (byte-identical) and 'conflicts' (content
+    differs) print a warn-and-skip line at the moment they're detected;
+    silence on a no-op would let an adopter assume the file was written."""
+    installed: list[str] = []
+    already_present: list[str] = []
+    conflicts: list[str] = []
+    fragments: list[str] = []
+
+    # Dedupe copies while preserving order.
+    seen: set[tuple[str, str]] = set()
+    for src_rel, dest_rel in plan.copies:
+        if (src_rel, dest_rel) in seen:
+            continue
+        seen.add((src_rel, dest_rel))
+        src = REPO_ROOT / src_rel
+        dst = safe_join(dest, dest_rel)
+        if dst.exists():
+            if dst.read_bytes() == src.read_bytes():
+                print(f"= {dest_rel} — already present (identical), skipping",
+                      file=sys.stderr)
+                already_present.append(dest_rel)
+                continue
+            print(f"! {dest_rel} — exists with different content, skipping",
+                  file=sys.stderr)
+            conflicts.append(dest_rel)
+            continue
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)
+        installed.append(dest_rel)
+
+    # Group fragments by destination path so multiple anchors on the same
+    # source file end up in one fragment file rather than racing for the
+    # same path. Whole-file deps (anchor=None) supersede anchored sections
+    # — there's no point shipping a slice when the caller wants the whole
+    # doc.
+    by_dest: dict[str, list[tuple[str, str | None, str]]] = {}
+    for src_rel, anchor, dest_rel, owning_skill in plan.fragments:
+        by_dest.setdefault(dest_rel, []).append((src_rel, anchor, owning_skill))
+
+    for dest_rel, entries in by_dest.items():
+        # Dedupe by (src_rel, anchor); preserve order.
+        seen_keys: set[tuple[str, str | None]] = set()
+        ordered: list[tuple[str, str | None, str]] = []
+        for src_rel, anchor, owning_skill in entries:
+            key = (src_rel, anchor)
+            if key in seen_keys:
+                continue
+            seen_keys.add(key)
+            ordered.append((src_rel, anchor, owning_skill))
+        if any(anchor is None for _, anchor, _ in ordered):
+            ordered = [e for e in ordered if e[1] is None][:1]
+
+        parts: list[str] = []
+        for src_rel, anchor, owning_skill in ordered:
+            src = REPO_ROOT / src_rel
+            if anchor:
+                body = extract_section(src.read_text(), anchor)
+            else:
+                body = src.read_text().rstrip() + "\n"
+            parts.append(render_fragment(src_rel, anchor, owning_skill, body))
+        content = "\n".join(parts)
+
+        dst = safe_join(dest, dest_rel)
+        if dst.exists():
+            if dst.read_text() == content:
+                print(f"= {dest_rel} — fragment already present (identical), skipping",
+                      file=sys.stderr)
+                already_present.append(dest_rel)
+                continue
+            print(f"! {dest_rel} — exists with different content, skipping",
+                  file=sys.stderr)
+            conflicts.append(dest_rel)
+            continue
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        dst.write_text(content)
+        fragments.append(dest_rel)
+
+    return installed, already_present, conflicts, fragments
+
+
+# ── Entrypoint ────────────────────────────────────────────────────────────
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="install-skill.py",
+        description="Install a skill (and its dependency closure) into an existing repo.",
+    )
+    parser.add_argument("name", help="Skill or agent name (kebab-case, e.g. bug-fix).")
+    parser.add_argument(
+        "dest",
+        type=pathlib.Path,
+        help="Destination repo root. Must already exist.",
+    )
+    args = parser.parse_args(argv)
+
+    dest = args.dest.resolve()
+    if not dest.exists() or not dest.is_dir():
+        print(f"error: destination {dest} does not exist or is not a directory.",
+              file=sys.stderr)
+        return 1
+
+    target = resolve_target(args.name)
+    target_rel = target.relative_to(REPO_ROOT).as_posix()
+
+    plan = Plan()
+    build_plan(target_rel, owning_skill=args.name, plan=plan)
+    installed, already_present, conflicts, fragments = apply(plan, dest)
+
+    print()
+    print(f"Installed '{args.name}' into {dest}")
+    print()
+    if installed:
+        print(f"  Copied ({len(installed)}):")
+        for p in installed:
+            print(f"    + {p}")
+    if fragments:
+        print(f"  Fragments ({len(fragments)}):")
+        for p in fragments:
+            print(f"    ~ {p}    (reconcile into your own copy of the source file)")
+    if already_present:
+        print(f"  Already present, identical to source ({len(already_present)}):")
+        for p in already_present:
+            print(f"    = {p}")
+    if conflicts:
+        print(f"  Skipped — destination already has a different version "
+              f"({len(conflicts)}):")
+        for p in conflicts:
+            print(f"    ! {p}")
+        print()
+        print("  These files at the destination differ from the source. They "
+              "were left alone.")
+        print("  If you want the source version, diff against the template "
+              "and merge by hand.")
+    if not (installed or fragments or already_present or conflicts):
+        print("  (Nothing to install — the manifest is empty.)")
+    print()
+    if fragments:
+        print("Next step: merge the fragments above into the matching files "
+              "in your repo, then delete the fragment files. (Re-running "
+              "this command will re-emit them — the script can't tell that "
+              "you've already reconciled.)")
+        print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/lint-agent-artifacts.sh
+++ b/tools/lint-agent-artifacts.sh
@@ -48,8 +48,8 @@ error_count = 0
 KEBAB = re.compile(r"^[a-z][a-z0-9-]*$")
 LINK = re.compile(r"\]\(([^)]+)\)")
 
-ALLOWED_SKILL_KEYS = {"name", "description"}
-ALLOWED_AGENT_KEYS = {"name", "description", "tools", "model"}
+ALLOWED_SKILL_KEYS = {"name", "description", "dependencies"}
+ALLOWED_AGENT_KEYS = {"name", "description", "tools", "model", "dependencies"}
 ALLOWED_COMMAND_KEYS = {"description", "allowed-tools", "model", "argument-hint"}
 
 
@@ -83,8 +83,9 @@ def warn(msg):
 def parse_frontmatter(path):
     """Return (fields, body_start_line, body, error). Frontmatter is the
     block delimited by --- on its own line at the very top of the file.
-    Only supports `key: value` single-line scalars (no nesting, no
-    multiline) — that matches every artifact this repo ships."""
+    Supports `key: value` single-line scalars and `key:` followed by a
+    block-style YAML list (each item on its own line, prefixed `  - `).
+    No deeper nesting — that matches every artifact this repo ships."""
     text = path.read_text()
     lines = text.splitlines()
     if not lines or lines[0].strip() != "---":
@@ -97,9 +98,11 @@ def parse_frontmatter(path):
     if end is None:
         return None, 0, text, "frontmatter opened with --- but never closed"
     fields = {}
-    for i in range(1, end):
+    i = 1
+    while i < end:
         raw = lines[i]
         if not raw.strip():
+            i += 1
             continue
         m = re.match(r"^([a-zA-Z][a-zA-Z0-9_-]*):\s*(.*)$", raw)
         if not m:
@@ -107,7 +110,30 @@ def parse_frontmatter(path):
         key, val = m.group(1), m.group(2).strip()
         if key in fields:
             return None, 0, text, f"duplicate frontmatter key {key!r} (line {i + 1})"
+        # Flow-list shortcut: `key: []` means empty list.
+        if val == "[]":
+            fields[key] = []
+            i += 1
+            continue
+        # Block-style list: `key:` (empty value) followed by `  - item` lines.
+        if val == "":
+            items = []
+            j = i + 1
+            while j < end:
+                nxt = lines[j]
+                if not nxt.strip():
+                    j += 1
+                    continue
+                lm = re.match(r"^\s+-\s+(.*)$", nxt)
+                if not lm:
+                    break
+                items.append(lm.group(1).strip())
+                j += 1
+            fields[key] = items
+            i = j
+            continue
         fields[key] = val
+        i += 1
     body_start_line = end + 2  # 1-indexed line number where body starts
     body = "\n".join(lines[end + 1 :])
     return fields, body_start_line, body, None

--- a/tools/lint-skill-deps.sh
+++ b/tools/lint-skill-deps.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Lints the `dependencies:` block on every skill and subagent manifest.
+# Exit non-zero if any dep cites a path that doesn't exist, or an anchor
+# that the target file doesn't define. Companion to lint-agent-artifacts.sh,
+# which only checks frontmatter shape — this one checks the semantics.
+#
+# Why it exists: manifests rot. Skills are renamed; CONVENTIONS anchors
+# get edited away; templates move. Without a linter, install-skill.py
+# silently produces broken installs.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+LINT_ROOT="${LINT_ROOT:-.}"
+
+python3 - "$LINT_ROOT" <<'PY'
+import pathlib, re, sys
+
+root = pathlib.Path(sys.argv[1]).resolve()
+error_count = 0
+
+
+def err(path, msg):
+    global error_count
+    rel = path.resolve().relative_to(root) if path.is_absolute() else path
+    print(f"✖ {rel}: {msg}", file=sys.stderr)
+    error_count += 1
+
+
+def ok(msg):
+    print(f"✓ {msg}")
+
+
+def parse_frontmatter(path):
+    text = path.read_text()
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    end = None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            end = i
+            break
+    if end is None:
+        return {}
+    fields = {}
+    i = 1
+    while i < end:
+        raw = lines[i]
+        if not raw.strip():
+            i += 1
+            continue
+        m = re.match(r"^([a-zA-Z][a-zA-Z0-9_-]*):\s*(.*)$", raw)
+        if not m:
+            i += 1
+            continue
+        key, val = m.group(1), m.group(2).strip()
+        if val == "[]":
+            fields[key] = []
+            i += 1
+            continue
+        if val == "":
+            items = []
+            j = i + 1
+            while j < end:
+                nxt = lines[j]
+                if not nxt.strip():
+                    j += 1
+                    continue
+                lm = re.match(r"^\s+-\s+(.*)$", nxt)
+                if not lm:
+                    break
+                items.append(lm.group(1).strip())
+                j += 1
+            fields[key] = items
+            i = j
+            continue
+        fields[key] = val
+        i += 1
+    return fields
+
+
+def slugify(heading):
+    s = heading.strip().lower()
+    s = re.sub(r"[^\w\s-]", "", s)
+    s = re.sub(r"\s+", "-", s)
+    return s.strip("-")
+
+
+def file_has_anchor(path, anchor):
+    for line in path.read_text().splitlines():
+        m = re.match(r"^#+\s+(.*)$", line)
+        if m and slugify(m.group(1)) == anchor:
+            return True
+    return False
+
+
+def check(manifest_path):
+    fields = parse_frontmatter(manifest_path)
+    deps = fields.get("dependencies", [])
+    if not isinstance(deps, list):
+        err(manifest_path, "`dependencies:` must be a list (block style `- item` or flow `[]`)")
+        return
+    for dep in deps:
+        path_part, _, anchor = dep.partition("#")
+        anchor = anchor or None
+        target = root / path_part
+        if not target.exists():
+            err(manifest_path, f"dependency points at missing file: {dep}")
+            continue
+        if target.is_dir():
+            err(manifest_path,
+                f"dependency points at a directory: {dep} "
+                f"(manifests must list individual files)")
+            continue
+        if anchor and not file_has_anchor(target, anchor):
+            err(manifest_path, f"anchor #{anchor} not found in {path_part}")
+
+
+checked = 0
+skills_dir = root / ".claude" / "skills"
+agents_dir = root / ".claude" / "agents"
+
+if skills_dir.exists():
+    for skill_md in sorted(skills_dir.glob("*/SKILL.md")):
+        checked += 1
+        before = error_count
+        check(skill_md)
+        if error_count == before:
+            ok(f"{skill_md.relative_to(root)}")
+
+if agents_dir.exists():
+    for agent_md in sorted(agents_dir.glob("*.md")):
+        if agent_md.name.upper() == "README.md":
+            continue
+        checked += 1
+        before = error_count
+        check(agent_md)
+        if error_count == before:
+            ok(f"{agent_md.relative_to(root)}")
+
+print()
+print(f"Manifests checked: {checked}.")
+if error_count:
+    print(f"Skill-dep lint: failed ({error_count} error(s)).")
+    sys.exit(1)
+print("Skill-dep lint: passed.")
+PY


### PR DESCRIPTION
## What changes

Each skill and agent now declares a `dependencies:` list in YAML frontmatter — the files outside its folder it actually relies on. Paired with `tools/install-skill.py`, an adopter can cherry-pick one skill into an existing repo by running `python3 tools/install-skill.py <skill-name> /path/to/their-repo` (Path B), without adopting the full template.

- Manifests on all 7 skills and all 3 agents.
- `tools/install-skill.py` walks the dependency closure and copies leaves. Never clobbers: identical content reports `= already present, skipping`; divergent content reports `! content differs, skipping`. Governance docs (CONVENTIONS.md, CHARTER.md, AGENTS.md) emit to `<parent>/<stem>.fragments/<skill>.md` for the adopter to merge by hand.
- `tools/lint-skill-deps.sh` validates each manifest entry resolves (missing files, missing anchors, and directory paths all fail).
- `tools/lint-agent-artifacts.sh` parser extended to support block-style YAML lists; `dependencies` is now an allowed key.
- `USING_THIS_TEMPLATE.md` exposes Path A (full bootstrap) and Path B (single-skill install) under Step 1.
- `README.md` evaluator-facing intro pitches both; `.claude/skills/README.md` adds manifest authoring as rule #4 for skill authors.

## Why

The undocumented adoption path was "copy `.claude/skills/<name>/` and hope you got the dependencies." This makes it mechanical.

## Decisions captured in the diff

- Dependencies live in YAML frontmatter (not a `## Dependencies` markdown section).
- `update-conventions` lists `docs/CONVENTIONS.md` and `docs/CHARTER.md` as plain whole-file deps — accepted as the special case, no new `full-file:` syntax invented.
- No-op behavior on re-invocation: every existing-file outcome warn-and-skips with a marker (`=` for identical, `!` for divergent). Silence would hide what wasn't written; the previous `silent skip on byte-equal` heuristic was wrong.

## Test plan

- [x] `bash tools/lint-agents-md.sh` — green
- [x] `bash tools/lint-agent-artifacts.sh` — green
- [x] `bash tools/lint-skill-deps.sh` — green (new)
- [x] `bash tools/test-lint-agent-artifacts.sh` — green (self-test, parser change non-regressing)
- [x] Smoke install of `bug-fix`, `work-loop`, `update-conventions`, `new-spec` into tmpdir: closure followed, conflict and identical-file paths both reported visibly, fragments emitted under `docs/CONVENTIONS.fragments/<skill>.md` with the correct section trimmed.
- [x] Path-traversal guard: manifest with `../../etc/passwd` raises SystemExit before any write.
- [x] Two iterations of `adversarial-reviewer` (clean on the second).