### PR TITLE
feat(agents): extend quality-engineer fuzz coverage to backend and agent surfaces

### DIFF
--- a/.claude/agents/quality-engineer.md
+++ b/.claude/agents/quality-engineer.md
@@ -114,7 +114,12 @@ gap at spec close is the kind of thing that ships an invisible bug.
 6. **Edge-case coverage.** Empty input, max input, malformed input,
    zero / negative / NaN where numeric, concurrent access, partial
    failure. Cite the specific cases tested and the specific cases
-   that aren't.
+   that aren't. When the surface is invariant-shaped — parser,
+   deserializer, schema/protocol boundary, prompt template, or
+   tool-input handler with a "parses-or-rejects, no crash, no
+   overflow" contract — propose a fuzz or property target instead
+   of an enumerated case list. Pure-logic functions with a small
+   enumerable input space get a fixture table, not a fuzzer.
 7. **Flaky-by-design.** Tests that depend on wall-clock time, sleeps,
    network, real DBs without isolation, or test-order. Flag with the
    determinism technique that fixes it (clock injection, fakes,
@@ -200,7 +205,13 @@ When asked to draft tests, follow the repo's split:
   given/when/then, plus a code block if helpful.
 - **Construction tests** go in the package's normal test path.
   Per-task, derived from the plan's task list. Include the boring
-  edge cases (empty, max, malformed) explicitly.
+  edge cases (empty, max, malformed) explicitly. When the surface
+  is invariant-shaped — parser, deserializer, schema/protocol
+  boundary, prompt template, or tool-input handler with a
+  "parses-or-rejects, no crash, no overflow" contract — draft a
+  fuzz or property target instead of an enumerated case list. The
+  UI counterpart (exploratory / visual fuzz) lives in the
+  visual/manual mode below.
 - **Respect the verification mode.** TDD-mode tasks get a failing
   test first. Goal-based tasks get a one-line verifier, not a test
   file. Visual/manual tasks get a recorded check by default;


### PR DESCRIPTION
## Summary

- Adds fuzz/property-target guidance to `quality-engineer` review-mode item 6 (edge-case coverage), gated on invariant-shaped trigger surfaces — parser, deserializer, schema/protocol boundary, prompt template, tool-input handler — with a negative example so pure-logic functions with small enumerable input spaces still get a fixture table.
- Mirrors the same trigger list in test-author mode's construction-tests bullet so the review→author handoff is coherent across UI, backend, and agent surfaces.
- UI's *exploratory / visual fuzz* stays in the visual/manual verification mode where it already lives; the test-author bullet cross-references it.

## Why

QE already owned UI fuzz (`work-loop`, `adversarial-reviewer`, and `quality-engineer` test-author mode all name *exploratory / visual fuzz*). Backend fuzz was disclaimed by `security-reviewer` as out of scope ("Did not fuzz the parser; recommend adding a fuzz target in CI"), and agent input surfaces weren't named anywhere. Extending QE — rather than adding a new mode or agent — keeps fuzz as a flavor of test, not a separate discipline.

Gating tactic: structural (folded into existing edge-case bullet, only fires when QE is already evaluating input coverage) plus a named trigger list and a negative example. "Only if relevant" alone would have been too weak.

## Test plan

- [ ] Skim the updated `quality-engineer.md` end-to-end and confirm both edits read coherently with surrounding checklist items.
- [ ] Spot-check that review-mode item 6 and test-author mode's construction-tests bullet use the same trigger vocabulary so review→author handoff stays coherent.
- [ ] On the next QE invocation against a diff that touches a parser, deserializer, or prompt template, confirm QE proposes a fuzz/property target.
- [ ] On a QE invocation against a pure-logic function with a small input space, confirm QE proposes a fixture table (not a fuzzer).