### PR TITLE
feat(workflow): work-loop state, caps, model-selection policy

### DIFF
--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -3,6 +3,9 @@ name: work-loop
 description: Use this skill whenever you're implementing a non-trivial change — a feature, a bug fix that touches more than one file, a refactor, or anything spec-driven. It enforces the project's plan → execute → self-review → fix loop with mechanical gates (lint, typecheck, tests) and adversarial review. Default to this skill for any task larger than a one-line edit.
 dependencies:
   - docs/CONVENTIONS.md#contract-tests-vs-construction-tests
+  - docs/CONVENTIONS.md#work-loop-state
+  - docs/_templates/state.json
+  - tools/check-done.py
   - .claude/agents/adversarial-reviewer.md
   - .claude/agents/security-reviewer.md
   - .claude/agents/quality-engineer.md
@@ -104,6 +107,18 @@ For anything beyond trivial, *think before you write code*. Concretely:
   vague behavior, a missing `Depends on:`, or a mismatched verification
   mode here costs a sentence, not a re-plan. Same Profile-A caveat as
   the post-impl review: skip if the project doesn't use the reviewer.
+- **Initialize the loop's state file.** Copy `docs/_templates/state.json`
+  to `docs/specs/<feature>/state.json` and set `feature` to the spec
+  slug. The file is gitignored — it's session-scratch, not history. Write
+  it atomically (tmp-file + rename) on every update so a mid-write read
+  never produces malformed JSON. Run
+  `tools/check-done.py docs/specs/<feature>/state.json --phase plan`; on
+  the first invocation it will exit 1 with `plan not approved` — **this
+  is the expected cue to run the spec-mode reviewer**, not a stop-and-
+  surface signal. Once the reviewer is clean, flip
+  `plan_review_status` to `approved` and re-run; exit 0 unlocks EXECUTE.
+  Schema reference:
+  [`CONVENTIONS.md`](../../../docs/CONVENTIONS.md#work-loop-state).
 
 The output of this step is a written plan (with tests) you can return to.
 Don't keep it in your head — your context will turn over and you'll lose it.
@@ -153,6 +168,26 @@ The subagent reads adversarially — it's looking for what you missed, not
 celebrating what you did. Findings come back grouped by severity
 (Blockers / Concerns / Nits), each with a one-sentence `Fix:`. Iterate
 until the agent returns `Clean — ready to commit.`
+
+**After each reviewer pass, update `state.json`** before iterating:
+
+1. Move `finding_fingerprints` → `previous_finding_fingerprints`.
+2. For each surviving finding the reviewer surfaced, compute
+   `sha1("<file>|<line>|<title>")` where:
+   - `<file>` is the cited path exactly as the reviewer wrote it.
+   - `<line>` is the first integer after the first colon in the citation,
+     as a decimal string. `foo.py:88` → `88`; `foo.py:88-92` → `88`.
+   - `<title>` is the reviewer's bolded heading for the finding, e.g.
+     `**3. PLAN-phase exit-1 conflates "not yet done" with "stop".**` —
+     keep the surrounding `**` markers and everything between them.
+
+   Write the resulting hex digests to `finding_fingerprints` (order
+   doesn't matter — `check-done.py` sorts before comparing).
+3. Increment `iteration_count`.
+4. Write the file atomically (tmp + rename).
+5. Run `tools/check-done.py <state-path> --phase review`. Exit 1 with
+   `no progress` means the same findings landed two iterations in a row;
+   stop and surface to a human rather than spinning a third.
 
 **Specialist reviewers — use after adversarial-reviewer is clean.** Pick
 the ones the diff actually warrants; don't run all three by default.
@@ -213,15 +248,19 @@ The loop must terminate. Iteration without termination is how Ralph loops
 (see below) burn money. Stop when **any** of these is true:
 
 1. **Gates green AND review clean** — the normal exit. Ship.
-2. **Same finding two iterations in a row** — you're going in circles. Stop.
-   Either the fix is wrong or the finding is. Surface it to a human.
+2. **`tools/check-done.py` exits non-zero.** The script is the mechanical
+   side of termination, reading from `state.json` (see
+   [`CONVENTIONS.md`](../../../docs/CONVENTIONS.md#work-loop-state)). It
+   fires on iteration cap, token-budget cap, consecutive-error counter,
+   pending plan approval (PLAN phase only), and fingerprint stasis
+   (REVIEW phase only). The exit message tells you which.
 3. **Diff is shrinking but findings aren't** — you're spot-fixing without
-   addressing root cause. Stop and rethink the approach (back to PLAN).
-4. **Iteration cap reached** — the project's hard cap of 5 in-session
-   iterations. If you hit the cap, the task is bigger than you thought.
-   Stop, write down what you learned, and re-plan.
+   addressing root cause. This is a judgment call, not in `check-done.py`.
+   Stop and rethink the approach (back to PLAN).
 
-Never silently expand scope to make a finding go away.
+If you hit any of these and the work isn't done, the task is bigger than
+you thought. Stop, write down what you learned, and re-plan. Never
+silently expand scope to make a finding go away.
 
 ## Capture what was learned
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Ralph runtime state — local-only, never committed
 .ralph/
 
+# Work-loop session state — per-spec scratch, never committed.
+# See docs/CONVENTIONS.md#work-loop-state.
+docs/specs/**/state.json
+
 # Personal Claude Code overrides
 CLAUDE.local.md
 .claude/settings.local.json

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -392,14 +392,80 @@ loses the planning context. We do it the other way only when fresh context
 is the *point* — which is what the Ralph harness in [`tools/ralph.sh`](../tools/ralph.sh)
 is for.
 
-**Why a hard iteration cap.** Without one, you're hoping. The cap (and its
-exact value) lives in the work-loop skill; if you hit it, the task is
-bigger than you thought — stop, re-plan, or split.
+**Why a hard iteration cap.** Without one, you're hoping. The cap lives as
+data in `state.json` (see below) and is enforced by `tools/check-done.py`;
+if you hit it, the task is bigger than you thought — stop, re-plan, or
+split.
 
 **Why capture learnings.** A loop that finishes without updating *some*
 doc, skill, or note has wasted what it learned. The next agent (Ralph or
 human) will pay for it again. The work-loop skill enumerates where each
 kind of learning belongs.
+
+### Work-loop state
+
+A spec-driven loop carries a small amount of session-scoped state — how
+many iterations have run, what budget is left, what findings the last
+review surfaced. Putting that in prose ("we cap at 5 iterations…") leaves
+it un-enforceable. Putting it on disk as data lets a tiny script gate
+each phase. That script is [`tools/check-done.py`](../tools/check-done.py);
+the data lives at `docs/specs/<feature>/state.json`, and the schema lives
+at [`docs/_templates/state.json`](_templates/state.json).
+
+**Fields:**
+
+| Field | Meaning |
+|---|---|
+| `feature` | spec slug (informational) |
+| `iteration_count` / `max_iterations` | how many in-session loops have run / hard cap |
+| `token_budget_used_pct` / `token_budget_cap_pct` | session token budget — **advisory in Phase 1**; the kill criterion fires only if the orchestrator populates `_used_pct`, which is wired up in a later phase |
+| `consecutive_same_error_count` / `consecutive_same_error_threshold` | gate-error stuck-loop counter / cap. **Advisory in Phase 1** — the SKILL doesn't yet prescribe when to increment `_count`. Threshold lives in data so a project can tune it. |
+| `plan_review_status` | `pending` until the spec-mode adversarial review clears, then `approved`. Enforced as a gate on **all phases** (not just `--phase plan`) — `implement` and `review` also reject a `pending` state. |
+| `last_commit_sha` | latest commit produced by the loop (informational; advisory in Phase 1) |
+| `finding_fingerprints` / `previous_finding_fingerprints` | hashes of reviewer findings, rotated each REVIEW iteration; used to detect circling. Algorithm pinned in the work-loop SKILL §REVIEW. |
+| `worktrees` | reserved for Phase 2 (parallel implementer subagents); empty in single-agent loops |
+
+**Exit contract.** `check-done.py` exits 0 when the phase is satisfied
+and non-zero when it isn't, with a one-line reason on stderr. Treat
+non-zero as "stop and surface" — with one deliberate exception: the
+SKILL's PLAN-init step calls the script with `--phase plan` *expecting*
+exit 1 with `plan not approved`. That exit-1 is the cue to run the
+spec-mode reviewer, not a real stop. Any other non-zero exit terminates
+the loop.
+
+**Lifecycle.** `state.json` is **per-session scratch**, not history. The
+file is gitignored (`docs/specs/**/state.json` in
+[`.gitignore`](../.gitignore)); the SKILL initializes it from the
+template at PLAN start. Across sessions, a fresh run re-initializes —
+intentionally; a new session deserves a fresh budget.
+
+**Atomic writes.** The orchestrator updates `state.json` mid-iteration;
+`check-done.py` reads it between phases. Always write atomically
+(tmp-file + `os.replace`, or shell `mv`) so a partial-write doesn't
+present as malformed JSON and falsely stop the loop.
+
+**Changing the cap.** Editing `docs/_templates/state.json` changes the
+*starting point* for any **newly-initialized** spec. To change the cap
+for a spec that's already running, edit that spec's own (gitignored)
+`docs/specs/<feature>/state.json` — the template edit doesn't propagate
+backward. The numbers move with the data, not the SKILL prose.
+
+### Model selection
+
+Every subagent file declares `model:` in its frontmatter explicitly. The
+[`lint-agent-artifacts.sh`](../tools/lint-agent-artifacts.sh) linter
+enforces this. Reasoning behind each current choice:
+
+| Subagent | Model | Why |
+|---|---|---|
+| `adversarial-reviewer` | `opus` | Adversarial judgment; stakes are correctness. Output drives a hard gate. |
+| `security-reviewer` | `opus` | Threat-model reasoning; stakes are security. |
+| `quality-engineer` | `opus` | Maintenance lens; spec-level coverage pass. Reconsider per observation. |
+
+Changing a subagent's model is a behaviour change, not a configuration
+tweak — note the change in the PR that makes it, with a one-line
+justification. If the change is reversing a previous choice in a way a
+future maintainer would ask "why", surface it in the PR description.
 
 ### When to reach for Ralph
 

--- a/docs/_templates/state.json
+++ b/docs/_templates/state.json
@@ -1,0 +1,14 @@
+{
+  "feature": "<feature-name>",
+  "iteration_count": 0,
+  "max_iterations": 5,
+  "token_budget_used_pct": 0.0,
+  "token_budget_cap_pct": 0.85,
+  "consecutive_same_error_count": 0,
+  "consecutive_same_error_threshold": 3,
+  "plan_review_status": "pending",
+  "last_commit_sha": null,
+  "finding_fingerprints": [],
+  "previous_finding_fingerprints": [],
+  "worktrees": []
+}

--- a/tools/check-done.py
+++ b/tools/check-done.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Mechanical termination checker for the work-loop's spec state.
+
+Reads a spec's `state.json` and decides whether the loop's current phase
+is satisfied. Caps and budgets live in the JSON, not in the SKILL's
+prose — this script is what turns those numbers into a gate. The
+work-loop SKILL calls it between phases.
+
+Exit contract:
+  0       — phase satisfied; continue.
+  non-zero — phase not satisfied; reason on stderr. The work-loop SKILL
+             treats exit-1 from `--phase plan` (with reason "plan not
+             approved") as the expected first-invocation cue to run the
+             spec-mode reviewer, *not* as a stop-and-surface signal. Any
+             other non-zero exit terminates the loop.
+
+Kill criteria, scoped by --phase:
+
+  plan:      #4 plan-review pending
+  implement: #1 iteration cap, #2 token cap, #3 consecutive-error,
+             #4 plan-review pending
+  review:    #1, #2, #3, #4, plus #5 fingerprint stasis (current ==
+             previous AND non-empty)
+
+Defaults (used when a field is absent from state.json) live in the
+template at docs/_templates/state.json. The DEFAULTS dict below is the
+no-template floor, used only when the field is omitted from the
+caller's state.json — keep it in sync with the template.
+
+Schema reference: docs/_templates/state.json and
+docs/CONVENTIONS.md#work-loop-state.
+
+Usage:
+  tools/check-done.py docs/specs/<feature>/state.json --phase {plan,implement,review}
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+DEFAULTS = {
+    "max_iterations": 5,
+    "token_budget_cap_pct": 0.85,
+    "consecutive_same_error_threshold": 3,
+}
+
+PHASES = {"plan", "implement", "review"}
+
+
+def stop(reason: str) -> int:
+    print(f"check-done: stop — {reason}", file=sys.stderr)
+    return 1
+
+
+def evaluate(state: dict, phase: str) -> int:
+    if state.get("plan_review_status", "pending") == "pending":
+        return stop("plan not approved (plan_review_status=pending)")
+    if phase == "plan":
+        return 0
+
+    iter_count = state.get("iteration_count", 0)
+    max_iter = state.get("max_iterations", DEFAULTS["max_iterations"])
+    if iter_count >= max_iter:
+        return stop(f"iteration cap reached ({iter_count}/{max_iter})")
+
+    used = state.get("token_budget_used_pct", 0.0)
+    cap = state.get("token_budget_cap_pct", DEFAULTS["token_budget_cap_pct"])
+    if used >= cap:
+        return stop(f"token budget exhausted ({used:.2%}/{cap:.2%})")
+
+    same_err = state.get("consecutive_same_error_count", 0)
+    same_err_threshold = state.get(
+        "consecutive_same_error_threshold",
+        DEFAULTS["consecutive_same_error_threshold"],
+    )
+    if same_err >= same_err_threshold:
+        return stop(
+            f"stuck on same error ({same_err} consecutive iterations)"
+        )
+
+    if phase == "review":
+        current = sorted(state.get("finding_fingerprints", []))
+        previous = sorted(state.get("previous_finding_fingerprints", []))
+        if current and current == previous:
+            return stop(
+                f"no progress — same {len(current)} finding(s) two iterations in a row"
+            )
+
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "state_path",
+        type=Path,
+        help="path to docs/specs/<feature>/state.json",
+    )
+    parser.add_argument(
+        "--phase",
+        required=True,
+        choices=sorted(PHASES),
+        help="which phase of the loop is calling",
+    )
+    args = parser.parse_args()
+
+    if not args.state_path.exists():
+        return stop(f"state.json missing at {args.state_path}")
+
+    try:
+        state = json.loads(args.state_path.read_text())
+    except json.JSONDecodeError as exc:
+        return stop(f"state.json malformed: {exc.msg} at line {exc.lineno}")
+
+    if not isinstance(state, dict):
+        return stop("state.json root must be an object")
+
+    return evaluate(state, args.phase)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/lint-agent-artifacts.sh
+++ b/tools/lint-agent-artifacts.sh
@@ -12,10 +12,11 @@
 #
 #   Subagents (.claude/agents/<name>.md):
 #     - File has valid YAML frontmatter
-#     - Frontmatter has non-empty `name` (kebab-case) and `description`
+#     - Frontmatter has non-empty `name` (kebab-case), `description`,
+#       and `model` (see docs/CONVENTIONS.md#model-selection)
 #     - Filename (sans .md) == frontmatter `name`
 #     - Frontmatter has no unknown keys (allowed: name, description,
-#       tools, model)
+#       tools, model, dependencies)
 #
 #   Commands (.claude/commands/<name>.md):
 #     - File has valid YAML frontmatter (optional but if present,
@@ -199,6 +200,9 @@ def check_agent(path):
                   f"{expected_name!r}")
     if "description" not in fields or not fields["description"]:
         err(path, "frontmatter missing required key: description")
+    if "model" not in fields or not fields["model"]:
+        err(path, "frontmatter missing required key: model "
+                  "(see docs/CONVENTIONS.md#model-selection)")
     unknown = set(fields) - ALLOWED_AGENT_KEYS
     if unknown:
         err(path, f"unknown frontmatter keys: {sorted(unknown)} "

--- a/tools/lint-agents-md.sh
+++ b/tools/lint-agents-md.sh
@@ -152,11 +152,24 @@ drift_check() {
   done
 }
 
-# Iteration cap number: only in the work-loop skill.
+# Iteration-cap value lives as data, not prose. The literal number lives
+# in the state.json template; SKILL/CONVENTIONS/AGENTS describe the field
+# conceptually but must not restate the number.
 drift_check \
-  'hard cap of (five|5) in-session' \
-  ".claude/skills/work-loop/SKILL.md" \
-  "AGENTS.md" "docs/CONVENTIONS.md"
+  '"max_iterations":[[:space:]]*[0-9]+' \
+  "docs/_templates/state.json" \
+  ".claude/skills/work-loop/SKILL.md" "AGENTS.md" "docs/CONVENTIONS.md"
+
+# Belt-and-braces prose probe: the original drift-watch caught the number
+# in any prose phrasing. The schema-shaped check above is narrower, so we
+# also forbid common prose restatements anywhere a future contributor
+# might be tempted to re-state the cap value. Empty canonical = no
+# "missing from canonical home" check; the schema (not a prose doc) is
+# the single source.
+drift_check \
+  '(hard )?cap of (five|5) (in-session )?iterations?' \
+  "" \
+  ".claude/skills/work-loop/SKILL.md" "AGENTS.md" "docs/CONVENTIONS.md"
 
 # Verification-mode triplet (TDD / Goal-based check / Visual / manual QA):
 # the explicit per-mode prose is single-sourced in the work-loop skill.

--- a/tools/test-check-done.sh
+++ b/tools/test-check-done.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# Self-test for tools/check-done.py.
+#
+# Builds a tempdir of state.json fixtures (each tripping one kill
+# criterion, plus a healthy case), runs the script, and asserts the
+# expected exit code and stderr signal. Fixtures live in the tempdir so
+# the repo stays clean.
+
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+PY="python3 $REPO_ROOT/tools/check-done.py"
+
+failures=0
+ran=0
+
+run_case() {
+  # run_case <name> <state-body> <phase> <expected-exit> <expected-stderr-substring>
+  local name="$1" body="$2" phase="$3" want_exit="$4" want_substr="$5"
+  ran=$((ran + 1))
+
+  local path="$TMP/$name.json"
+  printf '%s' "$body" > "$path"
+
+  local stderr_out
+  set +e
+  stderr_out=$($PY "$path" --phase "$phase" 2>&1 >/dev/null)
+  local got_exit=$?
+  set -e
+
+  if [[ "$got_exit" -ne "$want_exit" ]]; then
+    echo "FAIL [$name]: expected exit $want_exit, got $got_exit" >&2
+    echo "  stderr: $stderr_out" >&2
+    failures=$((failures + 1))
+    return
+  fi
+
+  if [[ -n "$want_substr" && "$stderr_out" != *"$want_substr"* ]]; then
+    echo "FAIL [$name]: stderr did not contain '$want_substr'" >&2
+    echo "  stderr: $stderr_out" >&2
+    failures=$((failures + 1))
+    return
+  fi
+
+  echo "ok   [$name]"
+}
+
+HEALTHY='{
+  "feature": "x",
+  "iteration_count": 1,
+  "max_iterations": 5,
+  "token_budget_used_pct": 0.1,
+  "token_budget_cap_pct": 0.85,
+  "consecutive_same_error_count": 0,
+  "plan_review_status": "approved",
+  "finding_fingerprints": ["a"],
+  "previous_finding_fingerprints": ["b"]
+}'
+
+# Healthy state passes all three phases.
+run_case "healthy-plan"      "$HEALTHY" plan      0 ""
+run_case "healthy-implement" "$HEALTHY" implement 0 ""
+run_case "healthy-review"    "$HEALTHY" review    0 ""
+
+# #1: iteration cap.
+ITER_OVER='{"iteration_count": 5, "max_iterations": 5, "plan_review_status": "approved"}'
+run_case "iter-cap" "$ITER_OVER" implement 1 "iteration cap"
+
+# #2: token budget.
+TOK_OVER='{"token_budget_used_pct": 0.9, "token_budget_cap_pct": 0.85, "plan_review_status": "approved"}'
+run_case "token-cap" "$TOK_OVER" implement 1 "token budget"
+
+# #3: consecutive same error.
+STUCK='{"consecutive_same_error_count": 3, "plan_review_status": "approved"}'
+run_case "stuck" "$STUCK" implement 1 "stuck on same error"
+
+# #4: plan not approved (fires in all phases — approval is a precondition
+# for implement and review, not just for unlocking EXECUTE).
+PENDING='{"plan_review_status": "pending"}'
+run_case "plan-pending-plan"      "$PENDING" plan      1 "plan not approved"
+run_case "plan-pending-implement" "$PENDING" implement 1 "plan not approved"
+run_case "plan-pending-review"    "$PENDING" review    1 "plan not approved"
+
+# Caps fire under --phase review too (not just implement).
+ITER_REVIEW='{"iteration_count": 5, "max_iterations": 5, "plan_review_status": "approved"}'
+run_case "iter-cap-review" "$ITER_REVIEW" review 1 "iteration cap"
+
+TOK_REVIEW='{"token_budget_used_pct": 0.9, "token_budget_cap_pct": 0.85, "plan_review_status": "approved"}'
+run_case "token-cap-review" "$TOK_REVIEW" review 1 "token budget"
+
+STUCK_REVIEW='{"consecutive_same_error_count": 3, "plan_review_status": "approved"}'
+run_case "stuck-review" "$STUCK_REVIEW" review 1 "stuck on same error"
+
+# Data-driven same-error threshold: state.json overrides DEFAULTS.
+STUCK_LOW='{
+  "consecutive_same_error_count": 2,
+  "consecutive_same_error_threshold": 2,
+  "plan_review_status": "approved"
+}'
+run_case "stuck-from-data" "$STUCK_LOW" implement 1 "stuck on same error"
+
+# Negative partner: count below the data-driven threshold passes.
+STUCK_BELOW='{
+  "consecutive_same_error_count": 2,
+  "consecutive_same_error_threshold": 3,
+  "plan_review_status": "approved"
+}'
+run_case "stuck-below-data-threshold" "$STUCK_BELOW" implement 0 ""
+
+# Defensive sort: equivalent fingerprint sets in different orders still
+# trigger stasis.
+STASIS_UNSORTED='{
+  "plan_review_status": "approved",
+  "finding_fingerprints": ["b", "a", "c"],
+  "previous_finding_fingerprints": ["c", "a", "b"]
+}'
+run_case "stasis-unsorted" "$STASIS_UNSORTED" review 1 "no progress"
+
+# #5: fingerprint stasis (review phase only).
+STASIS='{
+  "plan_review_status": "approved",
+  "finding_fingerprints": ["x", "y"],
+  "previous_finding_fingerprints": ["x", "y"]
+}'
+run_case "stasis-review"    "$STASIS" review    1 "no progress"
+run_case "stasis-implement" "$STASIS" implement 0 ""
+
+# Empty fingerprints — not stasis (first iteration).
+EMPTY_FP='{
+  "plan_review_status": "approved",
+  "finding_fingerprints": [],
+  "previous_finding_fingerprints": []
+}'
+run_case "empty-fingerprints-review" "$EMPTY_FP" review 0 ""
+
+# Missing file.
+ran=$((ran + 1))
+set +e
+stderr_out=$($PY "$TMP/does-not-exist.json" --phase implement 2>&1 >/dev/null)
+got_exit=$?
+set -e
+if [[ "$got_exit" -eq 1 && "$stderr_out" == *"state.json missing"* ]]; then
+  echo "ok   [missing-file]"
+else
+  echo "FAIL [missing-file]: exit=$got_exit stderr=$stderr_out" >&2
+  failures=$((failures + 1))
+fi
+
+# Malformed JSON.
+MALFORMED='{not json'
+run_case "malformed" "$MALFORMED" implement 1 "malformed"
+
+# Root is not an object.
+NOT_OBJ='[1, 2, 3]'
+run_case "not-object" "$NOT_OBJ" implement 1 "must be an object"
+
+# Defaults: missing max_iterations + missing cap, iteration over default 5.
+DEFAULTS_OVER='{"iteration_count": 5, "plan_review_status": "approved"}'
+run_case "defaults-iter" "$DEFAULTS_OVER" implement 1 "iteration cap"
+
+# End-to-end: use the literal template file the SKILL says to copy. This
+# catches schema drift between docs/_templates/state.json and the script.
+TEMPLATE_PATH="$REPO_ROOT/docs/_templates/state.json"
+if [[ -f "$TEMPLATE_PATH" ]]; then
+  ran=$((ran + 1))
+  set +e
+  fresh_err=$($PY "$TEMPLATE_PATH" --phase plan 2>&1 >/dev/null)
+  fresh_exit=$?
+  set -e
+  if [[ "$fresh_exit" -eq 1 && "$fresh_err" == *"plan not approved"* ]]; then
+    echo "ok   [fresh-template-pending]"
+  else
+    echo "FAIL [fresh-template-pending]: exit=$fresh_exit stderr=$fresh_err" >&2
+    failures=$((failures + 1))
+  fi
+
+  # Same template with plan_review_status flipped to approved → exit 0.
+  APPROVED_TEMPLATE="$TMP/approved-template.json"
+  python3 -c "import json, pathlib; p=pathlib.Path('$TEMPLATE_PATH'); d=json.loads(p.read_text()); d['plan_review_status']='approved'; pathlib.Path('$APPROVED_TEMPLATE').write_text(json.dumps(d))"
+  run_case "fresh-template-approved" "$(cat "$APPROVED_TEMPLATE")" implement 0 ""
+else
+  echo "skip [fresh-template-*]: $TEMPLATE_PATH not found"
+fi
+
+# Schema-vs-script drift assertions. These catch the failure modes the
+# fresh-template fixtures alone don't — a renamed/missing field the
+# script reads, and a numeric drift between the script's DEFAULTS dict
+# and the template values.
+if [[ -f "$TEMPLATE_PATH" ]]; then
+  ran=$((ran + 1))
+  if python3 - "$TEMPLATE_PATH" "$REPO_ROOT/tools/check-done.py" <<'PY'
+import json, pathlib, re, sys
+template = json.loads(pathlib.Path(sys.argv[1]).read_text())
+script = pathlib.Path(sys.argv[2]).read_text()
+
+expected_keys = {
+    "feature", "iteration_count", "max_iterations",
+    "token_budget_used_pct", "token_budget_cap_pct",
+    "consecutive_same_error_count", "consecutive_same_error_threshold",
+    "plan_review_status", "last_commit_sha",
+    "finding_fingerprints", "previous_finding_fingerprints",
+    "worktrees",
+}
+missing = expected_keys - set(template)
+extra = set(template) - expected_keys
+if missing or extra:
+    print(f"schema-drift: missing={sorted(missing)} extra={sorted(extra)}", file=sys.stderr)
+    sys.exit(1)
+
+# Every key check-done.py reads via state.get must exist in the template.
+script_reads = set(re.findall(r'state\.get\("([^"]+)"', script))
+missing_from_template = script_reads - set(template)
+if missing_from_template:
+    print(f"schema-drift: script reads {sorted(missing_from_template)} which template omits", file=sys.stderr)
+    sys.exit(1)
+PY
+  then
+    echo "ok   [schema-keys-match]"
+  else
+    echo "FAIL [schema-keys-match]" >&2
+    failures=$((failures + 1))
+  fi
+
+  ran=$((ran + 1))
+  if python3 - "$TEMPLATE_PATH" "$REPO_ROOT/tools/check-done.py" <<'PY'
+import json, pathlib, re, sys
+template = json.loads(pathlib.Path(sys.argv[1]).read_text())
+script = pathlib.Path(sys.argv[2]).read_text()
+
+# Extract DEFAULTS dict from the script.
+m = re.search(r'DEFAULTS = \{([^}]+)\}', script, re.DOTALL)
+if not m:
+    print("DEFAULTS dict not found in script", file=sys.stderr); sys.exit(1)
+defaults = {}
+for line in m.group(1).strip().splitlines():
+    km = re.match(r'\s*"([^"]+)":\s*([0-9.]+)', line)
+    if km:
+        defaults[km.group(1)] = float(km.group(2))
+
+mismatches = []
+for k, v in defaults.items():
+    tv = template.get(k)
+    if tv is None or float(tv) != v:
+        mismatches.append(f"{k}: script={v} template={tv}")
+if mismatches:
+    print("defaults-vs-template drift: " + "; ".join(mismatches), file=sys.stderr)
+    sys.exit(1)
+PY
+  then
+    echo "ok   [defaults-match-template]"
+  else
+    echo "FAIL [defaults-match-template]" >&2
+    failures=$((failures + 1))
+  fi
+fi
+
+echo
+if [[ "$failures" -gt 0 ]]; then
+  echo "✖ Self-test: $failures of $ran cases failed" >&2
+  exit 1
+fi
+echo "✓ Self-test: passed ($ran cases)."

--- a/tools/test-lint-agent-artifacts.sh
+++ b/tools/test-lint-agent-artifacts.sh
@@ -83,6 +83,17 @@ surprise: this-is-not-allowed
 Body.
 EOF
 
+# Agent: frontmatter is otherwise valid but does not declare `model:`.
+cat > "$TMP/.claude/agents/missing-model.md" <<'EOF'
+---
+name: missing-model
+description: Agent has no model declaration. Linter must require one.
+tools: Read, Grep
+---
+
+Body.
+EOF
+
 # Agent: frontmatter opened with --- and never closed.
 cat > "$TMP/.claude/agents/unclosed-frontmatter.md" <<'EOF'
 ---
@@ -127,6 +138,7 @@ EXPECTED_PATTERNS=(
   "unknown frontmatter keys: ['surprise']"
   "frontmatter opened with --- but never closed"
   "body is empty"
+  "missing required key: model"
 )
 
 for pattern in "${EXPECTED_PATTERNS[@]}"; do


### PR DESCRIPTION
## What does this change?

Lands Phase 1 of the work-loop architecture evolution. Caps and budgets move from SKILL prose into a per-spec `docs/specs/<feature>/state.json`, enforced by a new `tools/check-done.py` between phases. Adds a model-selection policy (every subagent declares `model:`; linter enforces).

## Why?

The iteration cap, token budget, and stuck-loop counter lived only in SKILL prose — un-enforceable. Putting them on disk as data lets a small script gate each phase: exit 0 = continue, non-zero = stop. The script reads `state.json`; the schema lives at `docs/_templates/state.json`; per-spec copies are gitignored as session-scratch.

Five kill criteria, scoped by `--phase`:
- iteration cap (data-driven via `max_iterations`)
- token-budget cap (advisory in Phase 1; writer wiring later)
- consecutive same-error counter (advisory in Phase 1; threshold also data-driven)
- plan-review approval status (gates all phases, not just `plan`)
- fingerprint stasis (`review` phase only; same findings two iterations in a row)

CONVENTIONS gains `§ Work-loop state` (schema, atomic-write discipline, exit contract, template-vs-per-spec edits) and `§ Model selection` (codifies the existing practice; linter enforces).

Phase 2 (parallel reviewers, implementer subagent, worktrees) and Phase 3 (knowledge base, hooks) land separately.

## How do I verify it?

```bash
bash tools/test-check-done.sh             # 26 cases including end-to-end fixtures and schema/defaults drift assertions
bash tools/test-lint-agent-artifacts.sh   # gains a missing-model fixture
bash tools/lint-agent-artifacts.sh        # all current agents declare model:
bash tools/lint-agents-md.sh              # drift-watch repointed from prose to state.json schema, plus a belt-and-braces prose probe
bash tools/lint-skill-deps.sh
bash tools/test-bootstrap-targets.sh
```

Smoke-test the end-to-end init flow against the actual template:

```bash
python3 tools/check-done.py docs/_templates/state.json --phase plan
# exits 1 with "plan not approved" — the expected first-invocation cue
```

The work-loop SKILL was the canonical reference for both reviewer passes; adversarial-reviewer + quality-engineer iterated to clean before this PR was opened.

## What did you not change that you considered?

- **Reviewer agent prompts.** Severity vocabulary (Blocker / Concern / Nit), file:line citation discipline, and the `Clean — ready to commit.` sentinel were already in tree across all three agents. The proposal's "Phase 1e reviewer-prompt updates" was a no-op once verified.
- **`quality-engineer` Opus→Sonnet model swap.** Withdrawn from the proposal; all three reviewers stay on Opus. The CONVENTIONS table records the current choice with rationale.
- **Phase 2 worktree fields populate.** `worktrees: []` is reserved in the schema but unused until Phase 2.
- **Reviewer-to-orchestrator JSON contract.** Explicitly rejected by the proposal — text is enough between LLM-to-LLM channels. Only state.json (read by a script) is structured.
- **Inline per-agent model rationale.** Quality-engineer flagged the prose-table vs frontmatter duplication; deferred as scope creep.
- **End-to-end Ralph integration.** `tools/ralph.sh` is unchanged; wiring it to `check-done.py` happens in a later phase if at all.