### PR TITLE
feat(workflow): supervisor mode + implementer subagent + parallel dispatch

### DIFF
--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -1,0 +1,128 @@
+---
+name: implementer
+description: Single-task implementer for the work-loop's supervisor mode. Given a plan task, a worktree path, and references to the spec and plan, implements only that task inside the worktree, runs the project's gates (lint, typecheck, tests), and returns a markdown status report (ready / blocked / failed) with a short summary. Does not review its own work. Does not invoke other subagents. Used by `work-loop` when a plan has multiple tasks declaring `Depends on: none`; the supervisor merges the worktree back and runs gates independently before review.
+tools: Read, Edit, Write, Grep, Glob, Bash
+model: sonnet
+dependencies:
+  - AGENTS.md
+  - docs/CONVENTIONS.md#supervisor-mode
+  - .claude/skills/work-loop/SKILL.md
+---
+
+# Implementer
+
+You are an implementer subagent. The supervisor (an instance of the
+`work-loop` skill running in the primary worktree) has given you exactly
+one plan task to land. Your job is narrow: build the task, run the
+gates, report status. Nothing more.
+
+You are not a reviewer. You do not pass judgment on the spec, the plan,
+or other tasks. You do not dispatch other subagents. You do not merge
+your branch — the supervisor does that.
+
+## Load context first
+
+In this order:
+
+1. `AGENTS.md` and `docs/CONVENTIONS.md` — project conventions. The
+   verification-mode discipline (TDD / goal-based / visual-manual)
+   applies to your task too.
+2. The targeted spec at `docs/specs/<feature>/spec.md`.
+3. The targeted plan at `docs/specs/<feature>/plan.md`, focusing on the
+   single task you were assigned. The task body declares its
+   verification mode and tests.
+4. Any files the task body cites.
+
+If the supervisor's brief omits the spec/plan paths, ask — don't guess.
+
+## Operating envelope
+
+- **Worktree:** the supervisor created `.worktrees/<task-id>/` and
+  checked out branch `<base>-<task-id>` there. All your edits happen
+  inside that directory. Use `cd` or absolute paths; do not edit files
+  in the primary worktree.
+- **One task:** implement only the task you were assigned. If you
+  notice an unrelated issue, note it in your report under "Out of
+  scope observed" — do not fix it.
+- **Gates:** run the project's lint, typecheck, and test commands as
+  documented in `AGENTS.md` and the project's root README. Capture
+  pass/fail and any failing output. Your gate results are **advisory**
+  — the supervisor reruns gates after merging. Don't edit a gate to
+  make it pass. If `AGENTS.md` still contains the template placeholders
+  (`<lint command>`, `<test command>`), the project hasn't wired up its
+  gates yet — report `blocked` rather than guessing.
+- **Commits:** commit inside the worktree using the project's
+  Conventional Commits format. One coherent commit per task is the
+  default; split if the task body explicitly calls for separate
+  red/green/refactor commits.
+- **No reviewers, no other subagents.** Reviewing is the supervisor's
+  job after merge. If you find yourself wanting a reviewer, your task
+  is too big — surface that in the report.
+
+## Verification-mode discipline
+
+- **TDD tasks** — red-green-refactor. Write the failing construction
+  test from `plan.md` first; commit if non-trivial. Make it pass; commit.
+  Refactor with the test as safety net; commit.
+- **Goal-based tasks** — write the code, run the one-liner the task's
+  `Done when:` specifies. No production test file. Capture the
+  one-liner's output in your report.
+- **Visual / manual QA tasks** — implement, run the manual check the
+  task records, capture the result. If the task is part of the spec's
+  contract, assert what the user sees, not internal state.
+
+## Report shape (return this back to the supervisor)
+
+Return a single markdown block with these sections, in this order. Be
+terse — the supervisor reads N reports in one context.
+
+```
+## Task <task-id>: <one-line task title>
+
+**Status:** ready | blocked | failed
+
+**Summary**
+<one to three sentences: what you built, which files changed.>
+
+**Gates (advisory)**
+- lint: pass | fail (<one-line reason if fail>)
+- typecheck: pass | fail (<one-line reason if fail>)
+- tests: pass | fail (<one-line reason if fail>)
+
+**Deviations from the task body**
+<bullet list, or "none">
+
+**Out of scope observed**
+<bullet list of issues you noticed but did not fix, or "none">
+
+**Blockers (only if status != ready)**
+<one to three sentences explaining why you stopped.>
+```
+
+### Status values
+
+- **`ready`** — task body's `Done when:` is satisfied, gates pass
+  inside the worktree, no blockers.
+- **`blocked`** — you can't proceed without a decision the supervisor
+  or a human must make (ambiguous spec, missing dependency, plan-task
+  pre-condition unmet). Explain.
+- **`failed`** — you tried, gates don't pass (or `Done when:` isn't
+  satisfied even though gates do), and the cause isn't a decision
+  someone else needs to make — it's that the approach in the task body
+  doesn't work and you can't see the fix. Explain.
+
+The supervisor decides what to do with `blocked` and `failed`
+statuses; it does not redispatch you on the same task.
+
+## Anti-patterns to refuse
+
+- **Implementing more than the assigned task.** Scope creep is the
+  single biggest failure mode of multi-implementer workflows. Note
+  unrelated work; don't do it.
+- **Running reviewers.** The supervisor runs reviewers after merge.
+- **Editing files outside your worktree.** The supervisor relies on
+  your worktree being self-contained for merge to be clean.
+- **Reporting `ready` when gates fail.** `ready` requires gates pass
+  inside the worktree. If they don't, status is `failed`.
+- **Silently expanding the plan task.** If the task body is wrong,
+  surface it under "Deviations" — don't paper over it.

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -4,11 +4,13 @@ description: Use this skill whenever you're implementing a non-trivial change �
 dependencies:
   - docs/CONVENTIONS.md#contract-tests-vs-construction-tests
   - docs/CONVENTIONS.md#work-loop-state
+  - docs/CONVENTIONS.md#supervisor-mode
   - docs/_templates/state.json
   - tools/check-done.py
   - .claude/agents/adversarial-reviewer.md
   - .claude/agents/security-reviewer.md
   - .claude/agents/quality-engineer.md
+  - .claude/agents/implementer.md
   - .claude/skills/new-spec/SKILL.md
   - tools/ralph.sh
   - tools/RALPH.md
@@ -20,6 +22,14 @@ This is the project's standard inner loop for non-trivial work. It exists
 because LLM self-assessment is unreliable: agents declare victory when they
 *feel* done, not when objective gates pass. This skill replaces "feel" with
 verifiable termination criteria.
+
+> **Vocabulary.** "Surface" throughout this skill means: stop the
+> current loop, emit a short description of the situation in your final
+> message (what happened, what you tried, what state things are in),
+> and wait for human direction. It is the project's house verb for
+> "stop and report." Do not retry, do not redispatch, do not silently
+> reset. (Reviewers also "surface" findings in the descriptive sense
+> — "raised" — when they return their report; context disambiguates.)
 
 ## When this skill applies
 
@@ -141,6 +151,120 @@ goal. Resist the urge to fix unrelated things you notice along the way;
 note them in `notes/` for later. Scope creep is the single biggest source
 of plan-vs-implementation drift.
 
+#### Parallel dispatch discipline
+
+When this skill fans out — multiple implementers in supervisor mode, or
+multiple specialist reviewers in REVIEW — the rules are the same and
+they live here, single-sourced. Both call sites below reference this
+discipline rather than restating it.
+
+- **One tool-call message, one Agent use per target.** Issue all
+  subagent invocations in a single message. Do not call them
+  sequentially. The participants are independent, the lenses are
+  independent, and sequencing tempts you to react to the first return
+  before the rest land — which gives each subagent a different state.
+- **Barrier-wait.** Don't issue follow-on Agent calls until every
+  subagent in the round has returned.
+- **Harness-level non-returns are failures.** A timeout, a tool error,
+  or a missing report counts as `failed` for that target. Treat it the
+  same as a substantive `failed` status; do not retry silently.
+- **Merge results in your own context.** The subagents return markdown.
+  You read N reports, group findings or status by your own bookkeeping
+  (state.json for implementers; severity buckets for reviewers), then
+  decide.
+
+#### Supervisor mode (parallel implementers)
+
+If the plan has **two or more tasks declaring `Depends on: none`**, the
+loop branches into supervisor mode for EXECUTE. You become the
+supervisor; each independent task gets an `implementer` subagent (see
+[`.claude/agents/implementer.md`](../../../.claude/agents/implementer.md))
+in its own worktree. The full rationale, boundary, and merge discipline
+live in
+[`CONVENTIONS.md § Supervisor mode`](../../../docs/CONVENTIONS.md#supervisor-mode).
+Throughout this procedure, **"task-id order" means numeric where IDs
+look like `T1`, `T2`, … ; lexicographic otherwise.**
+
+The procedure:
+
+0. **Pre-flight: check for stale worktrees.** Run `git worktree list`
+   and `git worktree prune`. If `.worktrees/<task-id>/` exists or the
+   branch `<base-branch>-<task-id>` exists for any task you're about
+   to dispatch, a prior session left scratch behind. **Surface to a
+   human; do not silently reuse or destroy** — the scratch may carry
+   in-flight work the previous run was about to commit. Resume happens
+   manually.
+1. **Set up worktrees.** For each independent task `<task-id>`:
+   ```bash
+   git worktree add .worktrees/<task-id> \
+     -b "$(git branch --show-current)-<task-id>"
+   ```
+   Append
+   `{task_id, branch, path, status: "in-progress", report_path: null}`
+   to `state.json.worktrees`.
+2. **Dispatch implementers in parallel** per the parallel-dispatch
+   discipline above. Each brief includes: the task ID, the plan-task
+   body, the worktree path, and paths to the spec + plan.
+3. **Persist each report and update state.** For each returning
+   subagent, in this order — match first, write second, update state
+   last:
+   1. Parse the report's opening `## Task <task-id>` heading and match
+      that `<task-id>` against `state.json.worktrees[i].task_id`. If
+      no entry matches, surface as `failed` for an unknown task —
+      never silently append a new entry, and never write the file
+      under an unvalidated name.
+   2. Write the report verbatim to
+      `docs/specs/<feature>/notes/implementer-<task-id>-<iteration>.md`,
+      where `<iteration>` is the current `state.json.iteration_count`.
+      On a fresh loop the value is `0`, so the first attempt lands as
+      `…-0.md` ("before any review iteration has run"); subsequent
+      re-plans see the counter bumped (see step 4 below) so reports
+      never overwrite one another. Create `docs/specs/<feature>/notes/`
+      if it doesn't yet exist (the directory is optional per the
+      [Specs and Plans](#4-specs-and-plans--docs-specs-feature)
+      convention).
+   3. Atomically update `state.json.worktrees[i]`: set `status`
+      (`ready` / `blocked` / `failed`) and `report_path` to the path
+      you just wrote.
+
+   The match-first ordering means a parse failure never produces an
+   orphan report on disk; the write-before-update means a crash
+   between substeps 2 and 3 leaves a recoverable signal — the report
+   file exists, the entry still says `in-progress`, and the next
+   supervisor session's stale-worktree pre-flight treats that as
+   leftover scratch and surfaces it.
+4. **Handle non-ready tasks first.** If any implementer reports
+   `blocked` or `failed`, do not merge. Surface the failed-task list
+   (with `report_path` pointers), **increment `state.json.iteration_count`**
+   so the next attempt's report filename won't collide with this
+   one's, then return to PLAN and revise the offending task. Do not
+   redispatch the same implementer on the same task — the assumption
+   that produced the failure is what needs revising, not the attempt.
+5. **Merge ready tasks sequentially.** From the primary worktree, in
+   task-id order:
+   ```bash
+   git merge --no-ff "$(git branch --show-current)-<task-id>"
+   ```
+   A conflict means the tasks weren't actually independent. Abort
+   (`git merge --abort`), return to PLAN, fix the `Depends on:`
+   declarations.
+6. **Clean up worktrees.** After all merges succeed:
+   ```bash
+   git worktree remove .worktrees/<task-id>
+   ```
+   If that fails (uncommitted files, locked index, build artifacts),
+   retry once with `--force`. On persistent failure, leave the
+   directory in place, note the path in your end-of-loop summary, and
+   proceed to gates — don't block on cleanup. Worktree entries in
+   `state.json.worktrees` keep their terminal status for the rest of
+   the loop so the next reader can reconstruct what each task did.
+7. **Run gates yourself** (next phase). The implementers' gate results
+   were advisory; the gates of record run in the primary against the
+   merged state.
+
+In single-agent mode (no independent tasks), skip the supervisor branch
+entirely and execute as the sole agent — that's the default flow above.
+
 ### 3. GATES — mechanical verification
 
 Run, in order, and only proceed if each passes:
@@ -200,6 +324,16 @@ the ones the diff actually warrants; don't run all three by default.
   maintainability lens. Also drafts contract or construction tests on
   request. Different lens from adversarial-reviewer — don't skip it
   because the spec already shipped.
+
+**Dispatch reviewers in parallel when you invoke more than one** per
+the [Parallel dispatch discipline](#parallel-dispatch-discipline)
+documented under EXECUTE — the same rules cover both fan-out sites in
+this skill. Fan-out works here because reviewer output is markdown the
+orchestrator reads, not a structured contract: you read N reports,
+group findings by severity yourself, deduplicate where two reviewers
+caught the same thing, then iterate on the merged list. Fingerprint
+computation (state.json) happens once per fan-out round, not once per
+reviewer.
 
 If reviewing a spec-less change (a refactor, say), self-review against this
 checklist instead:

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,14 @@
 # See docs/CONVENTIONS.md#work-loop-state.
 docs/specs/**/state.json
 
+# Supervisor-mode worktrees — each task gets its own checkout; never
+# committed. See docs/CONVENTIONS.md#supervisor-mode.
+.worktrees/
+
+# Implementer reports — per-task chatter the supervisor wrote for its
+# own observability; session-scratch like state.json, not history.
+docs/specs/**/notes/implementer-*.md
+
 # Personal Claude Code overrides
 CLAUDE.local.md
 .claude/settings.local.json

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -423,7 +423,7 @@ at [`docs/_templates/state.json`](_templates/state.json).
 | `plan_review_status` | `pending` until the spec-mode adversarial review clears, then `approved`. Enforced as a gate on **all phases** (not just `--phase plan`) — `implement` and `review` also reject a `pending` state. |
 | `last_commit_sha` | latest commit produced by the loop (informational; advisory in Phase 1) |
 | `finding_fingerprints` / `previous_finding_fingerprints` | hashes of reviewer findings, rotated each REVIEW iteration; used to detect circling. Algorithm pinned in the work-loop SKILL §REVIEW. |
-| `worktrees` | reserved for Phase 2 (parallel implementer subagents); empty in single-agent loops |
+| `worktrees` | one entry per `implementer` subagent dispatched in the current session's supervisor pass: `{task_id, branch, path, status, report_path}` where status is `in-progress` / `ready` / `blocked` / `failed` and `report_path` points at the implementer's markdown report under `docs/specs/<feature>/notes/`. Report files are gitignored (`docs/specs/**/notes/implementer-*.md`) — session-scratch like `state.json`, not history. Entries persist with their terminal status for the rest of the loop so a future reader can reconstruct what each task did. Empty in single-agent loops. See [§ Supervisor mode](#supervisor-mode). |
 
 **Exit contract.** `check-done.py` exits 0 when the phase is satisfied
 and non-zero when it isn't, with a one-line reason on stderr. Treat
@@ -461,11 +461,68 @@ enforces this. Reasoning behind each current choice:
 | `adversarial-reviewer` | `opus` | Adversarial judgment; stakes are correctness. Output drives a hard gate. |
 | `security-reviewer` | `opus` | Threat-model reasoning; stakes are security. |
 | `quality-engineer` | `opus` | Maintenance lens; spec-level coverage pass. Reconsider per observation. |
+| `implementer` | `sonnet` | One narrow plan task per dispatch; gates rerun in the primary; supervisor judges merge readiness. Cost beats capability here. |
 
 Changing a subagent's model is a behaviour change, not a configuration
 tweak — note the change in the PR that makes it, with a one-line
 justification. If the change is reversing a previous choice in a way a
 future maintainer would ask "why", surface it in the PR description.
+
+### Supervisor mode
+
+When a plan has multiple tasks declaring `Depends on: none`, the
+work-loop enters **supervisor mode**: one primary orchestrator
+dispatches `implementer` subagents in parallel, each working in its own
+git worktree, then merges the results back and runs gates in the
+primary. The mechanics live in the
+[`work-loop` skill](../.claude/skills/work-loop/SKILL.md) §EXECUTE; this
+section is the why and the boundary.
+
+**Why a separate mode instead of a separate skill.** The trigger is
+structural (the plan's shape), not a choice the user makes. Branching
+inside `work-loop` means contributors never pick the wrong skill, and
+the 80% overlap with single-agent flow stays single-sourced.
+
+**Why an implementer subagent, not a recursive work-loop.** The
+implementer's job is narrow — build one task, run gates, report.
+Reviewing, dispatch decisions, and merge belong to the supervisor. A
+recursive work-loop would let an implementer spawn its own
+implementers; that's nested coordination overhead with no clear win.
+Keep the tree two levels deep: supervisor → leaf implementers.
+
+**Worktrees as the coordination primitive.** Each independent task gets
+`.worktrees/<task-id>/` checked out on its own branch
+(`<base-branch>-<task-id>`). Worktrees are git-native, support parallel
+checkout of the same repo, and avoid lockfile contention. The directory
+is gitignored ([`.gitignore`](../.gitignore)); branches live in git
+history for traceability.
+
+**Merge discipline.** The supervisor merges with `git merge --no-ff
+<base>-<task-id>` into the primary branch, **sequentially in task-id
+order**. The SKILL has the procedural form (including how to order
+non-numeric IDs). If a sequential merge conflicts, the tasks weren't
+actually independent — the plan was wrong. Surface that as a
+PLAN-level escalation, not a `git mergetool` session.
+
+**Gates run in the primary, not the worktree.** Each implementer runs
+gates inside its worktree and reports the result, but those results are
+**advisory**. The supervisor reruns lint / typecheck / tests against
+the merged state — that's the only signal that counts.
+
+**Escalating implementer failures.** If an implementer reports
+`blocked` or `failed`, the supervisor surfaces the failure list to a
+human and returns to PLAN. It does **not** redispatch the same
+implementer on the same task — the assumption that produced the
+failure is what needs revising, not the attempt.
+
+**Known limitation.** This section's procedure has been validated by
+prose walk-through, not by an executed end-to-end dry-run. Any change
+to **pre-flight (SKILL §EXECUTE step 0)**, **worktree creation (step 1)**,
+**report persistence ordering (step 3)**, **merge order (step 5)**,
+**cleanup recovery (step 6)**, or the **`state.json` `worktrees`
+schema** must perform an actual `git worktree add` + parallel-dispatch
+round against a throwaway spec before merging — read-only walk-through
+is not sufficient for those surfaces.
 
 ### When to reach for Ralph
 

--- a/tools/lint-agents-md.sh
+++ b/tools/lint-agents-md.sh
@@ -188,6 +188,17 @@ for f in AGENTS.md docs/CONVENTIONS.md docs/CHARTER.md docs/APPROACH.md; do
   fi
 done
 
+# Session-scratch artifacts must be gitignored — the docs claim it, the
+# linter verifies. Probe one representative path per glob.
+for probe in \
+  "docs/specs/example/state.json" \
+  "docs/specs/example/notes/implementer-T1-0.md" \
+  ".worktrees/T1/README.md"; do
+  if ! git check-ignore --quiet "$probe" 2>/dev/null; then
+    note "drift-watch: '$probe' should be gitignored (session-scratch — see CONVENTIONS.md#work-loop-state, CONVENTIONS.md#supervisor-mode)."
+  fi
+done
+
 if (( fail )); then
   echo
   echo "Docs lint: failed."


### PR DESCRIPTION
## What does this change?

Phase 2 of the work-loop architecture. When a plan has multiple tasks declaring `Depends on: none`, the work-loop now branches into **supervisor mode**: one orchestrator dispatches `implementer` subagents in parallel, each in its own git worktree, then merges results sequentially back into the primary branch and runs gates against the merged state. Reviewer fan-out in REVIEW uses the same parallel-dispatch discipline.

New artifacts:
- `.claude/agents/implementer.md` — narrow single-task subagent (`model: sonnet`). Reports `ready` / `blocked` / `failed` with a short summary. Doesn't review itself; doesn't dispatch other subagents.
- `.gitignore` entries for `.worktrees/` and `docs/specs/**/notes/implementer-*.md` (both session-scratch, never history).
- `docs/CONVENTIONS.md` §Supervisor mode (why + boundary) + updated §work-loop-state row + §Model selection row for `implementer`.
- `.claude/skills/work-loop/SKILL.md`: 7-step supervisor-mode procedure under EXECUTE; new "Parallel dispatch discipline" sub-section single-sourcing the fan-out rules; REVIEW points at it.

## Why?

Phase 1 made loop state mechanical; Phase 2 makes the loop *fan out* mechanically. The proposal had been describing parallel reviewer dispatch and implementer/supervisor patterns in prose; the references (Kiro, Gemini CLI, Claude Code Agent Teams, Codex worktrees) all use the same shape, and the work-loop already had every prerequisite — state.json, parallel `Agent` tool calls, gitignored scratch — except a named subagent and a documented procedure.

The supervisor-mode trigger is *structural* (the plan's shape), not a user choice — branching inside `work-loop` keeps contributors from picking the wrong skill. Implementer reports persist to `docs/specs/<feature>/notes/implementer-<task-id>-<iteration>.md` (gitignored) so a supervisor crash mid-dispatch leaves recoverable signal: report file on disk, state entry still `in-progress`, next session's stale-worktree pre-flight surfaces it.

## How do I verify it?

```bash
bash tools/lint-agent-artifacts.sh   # implementer.md passes shape + model: checks
bash tools/lint-skill-deps.sh         # implementer's deps + work-loop SKILL deps all resolve (incl. anchors)
bash tools/lint-agents-md.sh          # new drift-watch probes session-scratch gitignore globs
bash tools/test-lint-agent-artifacts.sh
bash tools/test-check-done.sh         # unchanged from Phase 1 (26 cases)
bash tools/test-bootstrap-targets.sh
```

Run the gitignore probes manually:

```bash
git check-ignore docs/specs/example/notes/implementer-T1-0.md
git check-ignore .worktrees/T1/README.md
# both should print the path (ignored)
```

## What did you not change that you considered?

- **Knowledge-base priming.** The proposal's Phase 2 mentions implementer + supervisor "prime from `docs/knowledge/patterns.jsonl`". That artifact lands in Phase 3. Implementer reads `AGENTS.md` + spec + plan only.
- **`tools/check-done.py` worktree-aware kill criteria.** The schema carries `worktrees[]` populated; no new kill check. Punted because no realistic supervisor-mode failure mode is unaddressed by the existing five criteria + the SKILL's escalation paths.
- **Self-test for `tools/lint-skill-deps.sh`.** Reviewers flagged it as a pre-existing gap, exacerbated by Phase 2 adding a new manifest. Real, but Phase-2 scope creep. Filed as a follow-up.
- **Committed throwaway demo spec.** The proposal said "hand-built 3-task mock, end-to-end demo, throw away." In a template repo we don't author specs. The walk-through lives in `.context/phase-2-demo/` (gitignored). A "Known limitation" paragraph in CONVENTIONS §Supervisor mode names the specific surfaces — pre-flight, worktree creation, report-persistence ordering, merge order, cleanup recovery, schema — that require an actual `git worktree add` + dispatch dry-run before changes ship.
- **Recursive orchestration.** Implementers can't spawn implementers. Tree stays two levels deep (supervisor → leaves).
- **Knowledge-base / hooks / lint-vocabulary expansion.** Phase 3.

## Review iterations

Three rounds of adversarial-reviewer + quality-engineer dispatched in parallel (eating my own dogfood for the parallel-dispatch discipline this PR introduces):

| Round | Blockers | Concerns | Nits |
|---|---|---|---|
| iter-1 | 0 | 11 | 4 |
| iter-2 | 1 | 8 | 5 |
| iter-3 | 0 | 2 | 4 |
| iter-4 | clean |

Notable in-flight changes:
- iter-1 → iter-2: `report_path` field added to `state.json.worktrees[]` schema so failure context survives the supervisor's context window. Parallel-dispatch discipline extracted as a named sub-section. Pre-flight + cleanup-recovery procedures documented.
- iter-2 → iter-3: step-3 ordering reworked (match → write → state-update) to eliminate orphan-report failure mode. Reports gitignored + iteration-suffixed filenames. "Surface" verb defined inline.
- iter-3 fixes: `iteration_count` bump on the blocked-then-re-plan edge (closed a subtle filename-clobber hole). Weasel-word "materially changes" replaced with specific procedural surface list. Drift-watch for gitignore globs.