### PR TITLE
feat(workflow): knowledge base, lifecycle hooks, enforcement triplet

### DIFF
--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -5,8 +5,13 @@ dependencies:
   - docs/CONVENTIONS.md#contract-tests-vs-construction-tests
   - docs/CONVENTIONS.md#work-loop-state
   - docs/CONVENTIONS.md#supervisor-mode
+  - docs/CONVENTIONS.md#knowledge-base
   - docs/_templates/state.json
+  - docs/knowledge/README.md
+  - docs/knowledge/patterns.jsonl
   - tools/check-done.py
+  - tools/hooks/session-start.sh
+  - tools/hooks/pre-pr.sh
   - .claude/agents/adversarial-reviewer.md
   - .claude/agents/security-reviewer.md
   - .claude/agents/quality-engineer.md
@@ -399,16 +404,27 @@ silently expand scope to make a finding go away.
 ## Capture what was learned
 
 Before the PR is opened, ask: *what would have made this loop go faster?*
-Common answers and where they go:
+Where the answer goes depends on the *shape* of the learning:
 
+- **Practitioner lessons** — a repeatable pattern that worked, a
+  gotcha that bit you, or an antipattern that looked good but rotted —
+  go in [`docs/knowledge/patterns.jsonl`](../../../docs/knowledge/patterns.jsonl)
+  as a new entry. The schema is in
+  [`docs/knowledge/README.md`](../../../docs/knowledge/README.md);
+  one JSON object per line, scoped to a file glob. The
+  `session-start` hook reads these so the next agent starts with the
+  relevant ones already in context.
 - "I had to grep for `<thing>` repeatedly" → add a pointer in
   `docs/architecture/<subsystem>.md`.
 - "The test command for this package is unusual" → add it to the package's
   `AGENTS.md`.
-- "I made the same wrong assumption twice" → add a line to the relevant
-  `AGENTS.md` (root or per-package) so the next agent doesn't repeat it.
-  If it's a vocabulary issue (a term that means something specific here),
-  it goes in `docs/guides/reference/` as a glossary entry.
+- "I made the same wrong assumption twice" → if it's a
+  knowledge-base-shaped lesson (a pattern/gotcha/antipattern), record
+  it in `patterns.jsonl`; if it's project-conventions context, add a
+  line to the relevant `AGENTS.md` (root or per-package) so the next
+  agent doesn't repeat it. If it's a vocabulary issue (a term that
+  means something specific here), it goes in `docs/guides/reference/`
+  as a glossary entry.
 - "This workflow is now the third time I've done it" → propose it as a new
   skill in `.claude/skills/`.
 

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -524,6 +524,54 @@ schema** must perform an actual `git worktree add` + parallel-dispatch
 round against a throwaway spec before merging — read-only walk-through
 is not sufficient for those surfaces.
 
+### Knowledge base
+
+The repo accumulates practitioner-level lessons in
+`docs/knowledge/patterns.jsonl`: patterns ("when you touch X, also
+remember Y"), gotchas ("the auth middleware caches tokens for 15
+minutes"), and antipatterns ("don't mock the database in integration
+tests"). One JSON object per line, scoped to a file glob. The schema
+and curation conventions live in
+[`docs/knowledge/README.md`](knowledge/README.md).
+
+**Why a separate bucket.** ADRs answer *why we decided X*;
+`architecture/` describes *current structure*; `guides/` is for
+*users*. Knowledge entries are practitioner residue — the things you
+learn by building, not by deciding or documenting. They earn a home
+because they're scoped to globs (an agent priming for `packages/auth`
+should see the auth gotchas, not every lesson the repo ever learned)
+and append-only (a lesson that stops being true gets a *new* entry
+citing the old one, not an edit — which keeps history honest).
+
+**How agents see it.** `tools/hooks/session-start.sh` reads the file
+at session open and prints the entries — optionally filtered by a
+path or narrower glob. Matching uses Python's `fnmatch` with the
+caller's `--scope` value as the *path* argument and the entry's
+stored glob as the *pattern*, so an agent working in
+`packages/auth/server.ts` gets entries scoped to `packages/auth/**`
+plus any repo-wide `*` entries. The work-loop SKILL's
+[`Capture what was learned`](../.claude/skills/work-loop/SKILL.md#capture-what-was-learned)
+section points contributors at this file as the destination for
+pattern/gotcha/antipattern-shaped learnings; other shapes still go
+where they already belong (AGENTS.md, skill bodies, architecture/).
+
+### Enforcement (the triplet)
+
+Three layered mechanisms enforce the project's discipline. They are
+named together so contributors and reviewers can refer to "the
+enforcement triplet" and mean the same three things:
+
+| Layer | Mechanism | What it gates |
+|---|---|---|
+| Caps | [`tools/check-done.py`](../tools/check-done.py) | Iteration cap, token budget, plan approval, fingerprint stasis (see [§ Work-loop state](#work-loop-state)). |
+| Artifacts | `tools/lint-agents-md.sh`, `lint-agent-artifacts.sh`, `lint-skill-deps.sh`, `lint-knowledge.sh` | Shape, manifest, and content hygiene for every `.claude/`, `AGENTS.md`, and `docs/knowledge/` artifact. |
+| Aggregation | [`tools/hooks/pre-pr.sh`](../tools/hooks/pre-pr.sh) | Runs caps + artifact linters together before a PR opens. The local gate is a superset of CI today — CI runs `lint-agents-md.sh` and `lint-agent-artifacts.sh`; the local hook adds `lint-skill-deps.sh`, `lint-knowledge.sh`, and `check-done.py`. Keep the local hook green and CI follows. |
+
+`pre-pr.sh` is the hook downstream consumers wire into their tool's
+lifecycle (see [`tools/hooks/README.md`](../tools/hooks/README.md)).
+The template ships the script; it does **not** ship a committed
+`.claude/settings.json` — wiring is consumer-specific.
+
 ### When to reach for Ralph
 
 The same loop can run unattended — fresh Claude Code session per

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -1,0 +1,102 @@
+# Knowledge base
+
+The repository's accumulating record of *patterns, gotchas, and
+antipatterns* — the things a project learns about itself as code lands.
+It lives at `patterns.jsonl` next to this file; agents prime from it at
+session start, contributors curate it by hand.
+
+This is deliberately different from the documents that already exist:
+
+| Where | What goes there |
+|---|---|
+| `docs/adr/` | Decisions ("we chose X over Y because…"). Immutable. |
+| `docs/architecture/` | Current code structure. Living. |
+| `docs/guides/` | User-facing docs. Diátaxis. |
+| **`docs/knowledge/patterns.jsonl`** | **Practitioner-level lessons: patterns, gotchas, antipatterns. Scoped to file globs.** |
+
+ADRs answer *why was this decided*. Knowledge entries answer *what
+should the next person avoid stepping on, or repeat*.
+
+## When to add an entry
+
+A loop has finished. You ask: *what would have made this go faster?*
+Three answers worth recording here:
+
+- **Pattern.** "When you touch X, also remember Y." A repeatable shape
+  that worked once and will work again. Example: "Every package's
+  `bootstrap()` should call `validateConfig()` first."
+- **Gotcha.** A non-obvious cost or constraint that bit you. Example:
+  "The auth middleware caches tokens for 15 minutes — invalidate it
+  manually after a role change."
+- **Antipattern.** A shape that looked appealing but rotted. Example:
+  "Don't mock the database in integration tests; we got burned last
+  quarter when mocked tests passed but the prod migration failed."
+
+If the lesson is about *current code structure*, it belongs in
+`architecture/`. If it's a *decision*, it belongs in `adr/`. If it's
+*how to use the product*, it belongs in `guides/`. Knowledge entries
+are the residue that doesn't fit those buckets — *practice* rather
+than structure, decision, or instruction.
+
+## Schema
+
+`patterns.jsonl` is line-delimited JSON. Each non-empty line is one
+entry:
+
+```json
+{"id": "K-0001", "kind": "pattern", "scope": "packages/auth/**", "title": "Always parameterize SQL queries", "body": "Use parameterized queries everywhere — string-concatenated SQL has bitten us twice. The `db.query()` helper enforces this; reach for it instead of raw drivers.", "source": "PR#42"}
+```
+
+<!-- schema-drift test in tools/test-lint-knowledge.sh parses the field
+     table below and the `kind` row. Keep each field's name backticked
+     in the first column on a single line; keep every kind backticked
+     on the kind row. Don't split rows across lines. -->
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | `K-\d{4,}` | Unique, zero-padded to four digits. Conventionally sequential, but the linter only enforces uniqueness — gaps are fine. |
+| `kind` | `pattern` \| `gotcha` \| `antipattern` | Exactly one of these three values. |
+| `scope` | glob | Path pattern this applies to — `packages/auth/**`, `src/cli/*.py`, or `*` for repo-wide. |
+| `title` | string | One-line summary; aim for under 80 characters. |
+| `body` | string | The lesson itself. A paragraph or two is enough; if you find yourself writing more, the entry probably wants to be split. |
+| `source` | string | Where this came from: `PR#42`, `ADR-0007`, `issue#13`, etc. |
+
+The format is JSONL (one JSON object per line, no commas, no wrapping
+array) so it grows by append and reads line-by-line. `tools/lint-knowledge.sh`
+validates the file; `tools/hooks/session-start.sh` reads it.
+
+## Curation
+
+Entries are *append-only by default*. If a lesson stops being true (the
+underlying code changed, the constraint went away), the right move is
+to **add a new entry** that says so, citing the old `id` in the body —
+not to edit the old one. This keeps the knowledge base honest about
+*when* a lesson was true.
+
+**Supersession lives in the body, by design.** The schema has no
+`supersedes` field; the linter rejects unknown keys. Citing the old
+entry's id in the new entry's `body` is the convention. We chose
+human-readable prose over a machine-checkable field because
+supersession is rare enough that the cost of curating a separate
+field outweighed the legibility gain.
+
+Genuine corrections (typo, wrong file path) are fine to fix in place;
+those are clerical, not historical.
+
+When an entry's scope no longer matches anything (the package was
+removed), leave it as-is. The next reader can see the path is gone and
+infer the entry is historical. Removing entries hides the history of
+what you used to worry about.
+
+## Where this fits in the work-loop
+
+[`.claude/skills/work-loop/SKILL.md`](../../.claude/skills/work-loop/SKILL.md)
+§ "Capture what was learned" points back at this file. When a loop
+captures a learning that fits the pattern/gotcha/antipattern shape, the
+canonical home is here. Other kinds of learning still go where they
+already belong (AGENTS.md, skill bodies, architecture/).
+
+The session-start hook ([`tools/hooks/session-start.sh`](../../tools/hooks/session-start.sh))
+reads this file and prints the entries — optionally filtered by glob —
+so a fresh agent session starts with the relevant patterns already in
+context.

--- a/tools/hooks/README.md
+++ b/tools/hooks/README.md
@@ -1,0 +1,134 @@
+# Lifecycle hooks
+
+Two agent-lifecycle hooks ship in this directory. Runtime: bash plus
+`python3` (already required by the artifact linters and
+`check-done.py`); neither depends on any one agent tool's runtime.
+Wiring lives in the consumer's hook surface (Claude Code's
+`.claude/settings.json`, Gemini CLI's config, etc.); this README
+documents the contracts and shows an example wiring.
+
+## What's here
+
+### `session-start.sh`
+
+Runs at the open of an agent session. Reads
+`docs/knowledge/patterns.jsonl` and prints the entries — optionally
+filtered to a path or narrower glob — so the agent starts with
+accumulated patterns / gotchas / antipatterns already in context.
+
+Output goes to stdout as a `=== knowledge ===` block. Empty knowledge
+file produces no output and exits 0 — wire it unconditionally; the
+hook is a no-op until you start accumulating entries.
+
+Usage:
+
+```bash
+bash tools/hooks/session-start.sh                                  # every entry
+bash tools/hooks/session-start.sh --scope packages/auth/server.ts  # entries whose stored scope covers this path
+```
+
+The `--scope` argument is the caller's path or narrower glob; the
+hook returns every entry whose **stored** scope covers it. A caller
+of `packages/auth/server.ts` gets entries scoped to
+`packages/auth/**` plus the repo-wide `*`. An empty or dash-prefixed
+value exits 2 with `--scope requires a path or glob value`.
+
+See [`docs/knowledge/README.md`](../../docs/knowledge/README.md) for
+the schema and curation conventions.
+
+### `pre-pr.sh`
+
+Runs before a PR opens — the local mirror of CI's artifact-hygiene
+checks plus the work-loop's mechanical termination check.
+
+What it runs, in order:
+
+1. `tools/lint-agents-md.sh` — root `AGENTS.md` hygiene, drift-watch
+2. `tools/lint-agent-artifacts.sh` — skill/agent/command frontmatter
+3. `tools/lint-skill-deps.sh` — manifest dependency resolution
+4. `tools/lint-knowledge.sh` — `patterns.jsonl` validation
+5. `tools/check-done.py` against every `docs/specs/*/state.json`, in
+   both `--phase implement` and `--phase review` modes
+
+Exits non-zero on the first failure with a one-line reason. If there
+are no active `state.json` files, the check-done step is skipped.
+
+These three layers — `check-done.py` (caps) + the four linters
+(artifact hygiene) + `pre-pr.sh` (the gate that runs them together) —
+make up the project's **enforcement triplet**. Documented in
+[`docs/CONVENTIONS.md` § Enforcement](../../docs/CONVENTIONS.md#enforcement-the-triplet).
+
+## Wiring
+
+The hooks are configured at the consumer side. The template does not
+ship a committed `.claude/settings.json` (or equivalent for other
+tools) — consumers may want to customize differently, and config
+files are not portable across agent tools.
+
+### Claude Code
+
+Add to your project-local `.claude/settings.json` (gitignored):
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "bash tools/hooks/session-start.sh" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+`pre-pr.sh` is most useful as a manual or git-hook command rather than
+an agent-lifecycle hook — Claude Code doesn't fire on `git push`, so
+wire it via `.git/hooks/pre-push` if you want it automatic, or run it
+by hand before opening a PR:
+
+```bash
+bash tools/hooks/pre-pr.sh
+```
+
+### Other tools
+
+Gemini CLI, Codex, Kiro, and other agent tools each have their own
+hook surfaces. The scripts are bash plus `python3` — wire whatever
+event your tool exposes (session-open, pre-commit, etc.) to invoke
+them.
+
+## Testing the hooks
+
+Run them directly against the working tree:
+
+```bash
+bash tools/hooks/session-start.sh
+bash tools/hooks/pre-pr.sh
+```
+
+Two dedicated self-tests cover the hook scripts themselves:
+
+- `tools/test-pre-pr.sh` — corrupts each of the five enforcement
+  layers in turn (the four linters plus `check-done.py`, in a sandbox
+  copy of the repo) and asserts `pre-pr.sh` fails with the right
+  label.
+- `tools/test-session-start.sh` — exercises `--scope` validation, the
+  malformed-line warning, the `KNOWLEDGE_FILE` override, and the
+  empty/missing-file silent-exit paths.
+
+The umbrella `tools/test-all.sh` runs every self-test in `tools/`
+(both of the above plus `test-check-done.sh`, `test-lint-knowledge.sh`,
+`test-lint-agent-artifacts.sh`, `test-bootstrap-targets.sh`). Run it
+by hand whenever a linter, hook, or `check-done.py` changes.
+
+**CI parity.** `pre-pr.sh` is a superset of CI: CI runs only the
+agent-artifact and AGENTS.md linters; the local hook also runs the
+skill-dep, knowledge, and `check-done.py` checks. **Self-tests are
+also asymmetric** — CI runs `test-lint-agent-artifacts.sh` and
+`test-bootstrap-targets.sh`; the four self-tests added in later
+phases (`test-check-done.sh`, `test-lint-knowledge.sh`,
+`test-pre-pr.sh`, `test-session-start.sh`) are *not yet* wired into
+CI. Run `tools/test-all.sh` locally before opening a PR so the
+asymmetry doesn't catch you.

--- a/tools/hooks/pre-pr.sh
+++ b/tools/hooks/pre-pr.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Pre-PR hook: runs every artifact linter and the work-loop's
+# mechanical termination check against any active spec state. Exits
+# non-zero on the first failure so a contributor can't open a PR
+# whose artifacts are inconsistent with the conventions.
+#
+# What it runs:
+#   - tools/lint-agents-md.sh        — root AGENTS.md hygiene, drift-watch
+#   - tools/lint-agent-artifacts.sh  — skill/agent/command frontmatter
+#   - tools/lint-skill-deps.sh       — manifest dependency resolution
+#   - tools/lint-knowledge.sh        — docs/knowledge/patterns.jsonl
+#   - tools/check-done.py            — for each docs/specs/*/state.json,
+#                                       --phase implement and --phase review
+#
+# Runtime: bash + python3 (already required by the artifact linters and
+# check-done.py). Wiring lives in each tool's hook surface (Claude
+# Code: .claude/settings.json; see tools/hooks/README.md).
+
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+run() {
+  local label="$1"
+  shift
+  if ! "$@" > /dev/null; then
+    echo "pre-pr: ✖ $label failed" >&2
+    exit 1
+  fi
+  echo "pre-pr: ✓ $label"
+}
+
+run "agents-md hygiene"    bash tools/lint-agents-md.sh
+run "agent-artifact lint"  bash tools/lint-agent-artifacts.sh
+run "skill-deps lint"      bash tools/lint-skill-deps.sh
+run "knowledge lint"       bash tools/lint-knowledge.sh
+
+shopt -s nullglob
+state_files=(docs/specs/*/state.json)
+shopt -u nullglob
+
+if (( ${#state_files[@]} == 0 )); then
+  echo "pre-pr: (no active state.json — skipping check-done)"
+else
+  for state in "${state_files[@]}"; do
+    for phase in implement review; do
+      if ! python3 tools/check-done.py "$state" --phase "$phase" > /dev/null; then
+        echo "pre-pr: ✖ check-done.py $state --phase $phase failed" >&2
+        exit 1
+      fi
+      echo "pre-pr: ✓ check-done $state ($phase)"
+    done
+  done
+fi
+
+echo "pre-pr: all checks passed"

--- a/tools/hooks/session-start.sh
+++ b/tools/hooks/session-start.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Session-start hook: prints the knowledge-base entries from
+# docs/knowledge/patterns.jsonl as a context block. Agents read the
+# block at session open so accumulated patterns / gotchas / antipatterns
+# are in working memory before any work begins.
+#
+# Optional argument: --scope <path-or-glob>
+#   When set, only entries whose stored `scope` glob *covers* the
+#   given path are printed (e.g. --scope packages/auth/server.ts
+#   returns entries scoped to packages/auth/**, packages/**, and the
+#   repo-wide *). Without --scope, every entry is printed.
+#
+# Output goes to stdout; missing or empty knowledge file produces no
+# output and exits 0. Malformed lines are skipped with a one-line
+# warning to stderr (so the rot is visible) and do not abort the hook.
+# Runtime: bash + python3 (already required by the artifact linters
+# and check-done.py). Wiring lives in each tool's hook surface
+# (Claude Code: .claude/settings.json; see tools/hooks/README.md).
+#
+# Fixture mode: set KNOWLEDGE_FILE=<path> to read a different file.
+
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+KNOWLEDGE_FILE="${KNOWLEDGE_FILE:-$REPO_ROOT/docs/knowledge/patterns.jsonl}"
+
+scope_filter=""
+while (( $# > 0 )); do
+  case "$1" in
+    --scope)
+      shift
+      if [[ -z "${1:-}" || "${1:-}" == -* ]]; then
+        echo "session-start.sh: --scope requires a path or glob value" >&2
+        exit 2
+      fi
+      scope_filter="$1"
+      ;;
+    --help|-h)
+      sed -n '2,22p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "session-start.sh: unknown argument $1" >&2
+      exit 2
+      ;;
+  esac
+  shift || true
+done
+
+if [[ ! -f "$KNOWLEDGE_FILE" ]]; then
+  exit 0
+fi
+
+if [[ ! -s "$KNOWLEDGE_FILE" ]]; then
+  exit 0
+fi
+
+python3 - "$KNOWLEDGE_FILE" "$scope_filter" <<'PY'
+import fnmatch
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+scope_filter = sys.argv[2] if len(sys.argv) > 2 else ""
+
+entries = []
+malformed = 0
+for line_no, line in enumerate(path.read_text().splitlines(), start=1):
+    if not line.strip():
+        continue
+    try:
+        entry = json.loads(line)
+    except json.JSONDecodeError:
+        malformed += 1
+        continue
+    if scope_filter:
+        # The caller passed a path or narrower glob; only emit entries
+        # whose stored scope *covers* it. Python's fnmatch is greedy
+        # across `/` (a `*` matches path separators too), so a stored
+        # `packages/auth/**` correctly matches a caller path like
+        # `packages/auth/server.ts`. Literal `/` in the stored scope
+        # still acts as the package boundary — caller
+        # `packages/auth-other/x.ts` does NOT match stored
+        # `packages/auth/**` because the prefix doesn't line up.
+        scope = entry.get("scope", "")
+        if not fnmatch.fnmatch(scope_filter, scope):
+            continue
+    entries.append(entry)
+
+if malformed:
+    print(
+        f"session-start: skipped {malformed} malformed line(s) — "
+        f"run tools/lint-knowledge.sh",
+        file=sys.stderr,
+    )
+
+if not entries:
+    sys.exit(0)
+
+print("=== knowledge ===")
+for e in entries:
+    print(f"[{e.get('id', '?')}] ({e.get('kind', '?')}, {e.get('scope', '?')}) "
+          f"{e.get('title', '')}")
+    body = e.get("body", "").strip()
+    if body:
+        for ln in body.splitlines():
+            print(f"    {ln}")
+    source = e.get("source", "")
+    if source:
+        print(f"    — {source}")
+    print()
+PY

--- a/tools/lint-knowledge.sh
+++ b/tools/lint-knowledge.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Lints docs/knowledge/patterns.jsonl. Every non-empty line must be a
+# JSON object with the required keys, the right `kind` value, and an
+# id that matches the K-NNNN format. Exit non-zero on any error.
+#
+# The empty file is valid (no learnings yet).
+#
+# Fixture mode: set KNOWLEDGE_FILE=<path> to lint a different file
+# (used by the self-test).
+
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+KNOWLEDGE_FILE="${KNOWLEDGE_FILE:-docs/knowledge/patterns.jsonl}"
+
+python3 - "$KNOWLEDGE_FILE" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+error_count = 0
+
+REQUIRED_KEYS = {"id", "kind", "scope", "title", "body", "source"}
+ALLOWED_KINDS = {"pattern", "gotcha", "antipattern"}
+ID_PATTERN = re.compile(r"^K-\d{4,}$")
+
+
+def err(line_no, msg):
+    global error_count
+    print(f"✖ {path}:{line_no}: {msg}", file=sys.stderr)
+    error_count += 1
+
+
+if not path.exists():
+    print(f"⚠ {path}: file does not exist — knowledge base not initialized", file=sys.stderr)
+    sys.exit(1)
+
+seen_ids = {}
+
+for line_no, raw in enumerate(path.read_text().splitlines(), start=1):
+    if not raw.strip():
+        continue
+
+    try:
+        entry = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        err(line_no, f"not valid JSON: {exc.msg}")
+        continue
+
+    if not isinstance(entry, dict):
+        err(line_no, "must be a JSON object, not a list or scalar")
+        continue
+
+    keys = set(entry)
+    missing = REQUIRED_KEYS - keys
+    if missing:
+        err(line_no, f"missing required keys: {sorted(missing)}")
+
+    extra = keys - REQUIRED_KEYS
+    if extra:
+        err(line_no, f"unknown keys: {sorted(extra)} "
+                     f"(allowed: {sorted(REQUIRED_KEYS)})")
+
+    # Run the remaining content checks against whatever fields are
+    # present — surfacing every problem on the line in one lint pass
+    # rather than making the author re-run the linter per fix.
+
+    id_val = entry.get("id")
+    if isinstance(id_val, str) and not ID_PATTERN.match(id_val):
+        err(line_no, f"id {id_val!r} must match ^K-\\d{{4,}}$ (e.g. K-0001)")
+    elif isinstance(id_val, str):
+        if id_val in seen_ids:
+            err(line_no, f"duplicate id {id_val!r} "
+                         f"(first seen on line {seen_ids[id_val]})")
+        else:
+            seen_ids[id_val] = line_no
+
+    kind_val = entry.get("kind")
+    if isinstance(kind_val, str) and kind_val not in ALLOWED_KINDS:
+        err(line_no, f"kind {kind_val!r} must be one of {sorted(ALLOWED_KINDS)}")
+
+    for k in ("scope", "title", "body", "source"):
+        if k not in entry:
+            continue  # missing-key error already fired above
+        v = entry[k]
+        if not isinstance(v, str) or not v.strip():
+            err(line_no, f"{k!r} must be a non-empty string")
+
+print(f"\nKnowledge entries checked: {len(seen_ids)}.")
+if error_count:
+    print(f"Knowledge lint: failed ({error_count} error(s)).", file=sys.stderr)
+    sys.exit(1)
+print("Knowledge lint: passed.")
+PY

--- a/tools/test-all.sh
+++ b/tools/test-all.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Umbrella runner: every self-test in tools/. Run by hand when a
+# linter, hook, or check-done.py changes; CI runs a subset, so this is
+# the local-side belt-and-braces.
+#
+# Distinct from tools/hooks/pre-pr.sh — that's a *gate* against the
+# working tree (does the diff pass the linters?); this is a *suite*
+# of self-tests against the linters and hooks themselves (do the
+# tools still do what they claim?). Both have a place; both green is
+# the contract.
+
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+# Each entry: "<label>:<command>". Order is alphabetical for stability;
+# nothing in the chain depends on a particular order.
+tests=(
+  "bootstrap-targets:bash tools/test-bootstrap-targets.sh"
+  "check-done:bash tools/test-check-done.sh"
+  "lint-agent-artifacts:bash tools/test-lint-agent-artifacts.sh"
+  "lint-knowledge:bash tools/test-lint-knowledge.sh"
+  "pre-pr:bash tools/test-pre-pr.sh"
+  "session-start:bash tools/test-session-start.sh"
+)
+
+failures=0
+ran=0
+
+for entry in "${tests[@]}"; do
+  label="${entry%%:*}"
+  cmd="${entry#*:}"
+  ran=$((ran + 1))
+  if $cmd > /dev/null 2>&1; then
+    echo "✓ $label"
+  else
+    echo "✖ $label — re-run \`$cmd\` for output" >&2
+    failures=$((failures + 1))
+  fi
+done
+
+echo
+if (( failures > 0 )); then
+  echo "test-all: $failures of $ran failed" >&2
+  exit 1
+fi
+echo "test-all: $ran passed"

--- a/tools/test-lint-knowledge.sh
+++ b/tools/test-lint-knowledge.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# Self-test for tools/lint-knowledge.sh. Builds tempdir fixtures
+# tripping each validation rule and asserts the right error fires.
+
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+LINTER="$REPO_ROOT/tools/lint-knowledge.sh"
+
+failures=0
+ran=0
+
+run_case() {
+  # run_case <name> <file-contents> <expected-exit> <expected-substr>
+  local name="$1" body="$2" want_exit="$3" want_substr="$4"
+  ran=$((ran + 1))
+
+  local path="$TMP/$name.jsonl"
+  printf '%s' "$body" > "$path"
+
+  local out
+  set +e
+  out=$(KNOWLEDGE_FILE="$path" bash "$LINTER" 2>&1)
+  local got=$?
+  set -e
+
+  if [[ "$got" -ne "$want_exit" ]]; then
+    echo "FAIL [$name]: expected exit $want_exit, got $got" >&2
+    echo "  output: $out" >&2
+    failures=$((failures + 1))
+    return
+  fi
+  if [[ -n "$want_substr" && "$out" != *"$want_substr"* ]]; then
+    echo "FAIL [$name]: output missing '$want_substr'" >&2
+    echo "  output: $out" >&2
+    failures=$((failures + 1))
+    return
+  fi
+  echo "ok   [$name]"
+}
+
+VALID='{"id": "K-0001", "kind": "pattern", "scope": "src/**", "title": "T", "body": "B", "source": "PR#1"}'
+
+# Empty file (no learnings yet) is valid.
+run_case "empty"            ""                   0 "Knowledge lint: passed"
+
+# Trailing newlines / blank lines are tolerated.
+run_case "valid-one-entry"  "$VALID"$'\n'        0 "Knowledge lint: passed"
+run_case "blank-lines"      $'\n\n'"$VALID"$'\n\n' 0 "Knowledge lint: passed"
+
+# Malformed JSON.
+run_case "malformed-json"   '{not json'          1 "not valid JSON"
+
+# Not an object.
+run_case "scalar-line"      '"just a string"'    1 "must be a JSON object"
+run_case "list-line"        '[1, 2, 3]'          1 "must be a JSON object"
+
+# Missing required keys.
+run_case "missing-keys"     '{"id": "K-0001"}'   1 "missing required keys"
+
+# Unknown extra keys.
+EXTRA='{"id": "K-0001", "kind": "pattern", "scope": "x", "title": "t", "body": "b", "source": "s", "extra": 1}'
+run_case "unknown-keys"     "$EXTRA"             1 "unknown keys"
+
+# Bad id format.
+BAD_ID='{"id": "K-1", "kind": "pattern", "scope": "x", "title": "t", "body": "b", "source": "s"}'
+run_case "bad-id"           "$BAD_ID"            1 "must match"
+
+# Duplicate id.
+DUP='{"id": "K-0001", "kind": "pattern", "scope": "x", "title": "t", "body": "b", "source": "s"}'
+run_case "duplicate-id"     "$DUP"$'\n'"$DUP"    1 "duplicate id"
+
+# Bad kind.
+BAD_KIND='{"id": "K-0001", "kind": "tip", "scope": "x", "title": "t", "body": "b", "source": "s"}'
+run_case "bad-kind"         "$BAD_KIND"          1 "must be one of"
+
+# Empty string field.
+EMPTY_FIELD='{"id": "K-0001", "kind": "pattern", "scope": "", "title": "t", "body": "b", "source": "s"}'
+run_case "empty-scope"      "$EMPTY_FIELD"       1 "must be a non-empty string"
+
+# Non-string field.
+NONSTR='{"id": "K-0001", "kind": "pattern", "scope": "x", "title": 42, "body": "b", "source": "s"}'
+run_case "non-string-title" "$NONSTR"            1 "must be a non-empty string"
+
+# Two valid entries with sequential ids.
+TWO="$VALID"$'\n''{"id": "K-0002", "kind": "gotcha", "scope": "*", "title": "T2", "body": "B2", "source": "PR#2"}'
+run_case "two-valid"        "$TWO"               0 "passed"
+
+# null-valued required field (JSON null is not a string).
+NULL_TITLE='{"id": "K-0001", "kind": "pattern", "scope": "x", "title": null, "body": "b", "source": "s"}'
+run_case "null-title" "$NULL_TITLE" 1 "must be a non-empty string"
+
+# Trailing garbage after a valid JSON object on the same line: json.loads
+# rejects it ("Extra data") — locks the behaviour.
+TRAILING="$VALID"' garbage-after'
+run_case "trailing-garbage" "$TRAILING" 1 "not valid JSON"
+
+# Duplicate id where the two entries differ in body — dedup is by id alone.
+DUP_DIFF='{"id": "K-0001", "kind": "pattern", "scope": "x", "title": "first",  "body": "B1", "source": "s"}'$'\n'\
+'{"id": "K-0001", "kind": "pattern", "scope": "x", "title": "second", "body": "B2", "source": "s"}'
+run_case "duplicate-id-different-body" "$DUP_DIFF" 1 "duplicate id"
+
+# Multiple shape errors on a single line surface in one lint run.
+MULTI='{"id": "bad", "scope": "x", "title": "t", "body": "b", "source": "s", "stray": 1}'
+ran=$((ran + 1))
+path="$TMP/multi.jsonl"
+printf '%s' "$MULTI" > "$path"
+set +e
+multi_out=$(KNOWLEDGE_FILE="$path" bash "$LINTER" 2>&1)
+multi_exit=$?
+set -e
+if [[ "$multi_exit" -eq 1 \
+   && "$multi_out" == *"missing required keys"* \
+   && "$multi_out" == *"unknown keys"* \
+   && "$multi_out" == *"must match"* ]]; then
+  echo "ok   [multi-error-one-line]"
+else
+  echo "FAIL [multi-error-one-line]: expected three error categories in one run" >&2
+  echo "  exit=$multi_exit" >&2
+  echo "  output: $multi_out" >&2
+  failures=$((failures + 1))
+fi
+
+# Schema drift: the README's field table and the linter's REQUIRED_KEYS /
+# ALLOWED_KINDS must stay in sync. Phase 1's precedent — see
+# tools/test-check-done.sh schema-keys-match.
+ran=$((ran + 1))
+if python3 - "$REPO_ROOT/docs/knowledge/README.md" "$REPO_ROOT/tools/lint-knowledge.sh" <<'PY'
+import pathlib, re, sys
+readme = pathlib.Path(sys.argv[1]).read_text()
+script = pathlib.Path(sys.argv[2]).read_text()
+
+# Extract the linter's enforced sets.
+req = re.search(r"REQUIRED_KEYS\s*=\s*\{([^}]+)\}", script)
+kinds = re.search(r"ALLOWED_KINDS\s*=\s*\{([^}]+)\}", script)
+if not req or not kinds:
+    print("schema-drift: could not find REQUIRED_KEYS / ALLOWED_KINDS in script", file=sys.stderr)
+    sys.exit(1)
+script_keys = set(re.findall(r'"([^"]+)"', req.group(1)))
+script_kinds = set(re.findall(r'"([^"]+)"', kinds.group(1)))
+
+# Extract the README's field table keys (first column, backticked words).
+table_keys = set(re.findall(r"^\|\s*`([a-zA-Z_]+)`\s*\|", readme, re.MULTILINE))
+# The README's kind row lists each kind backticked on the same line. Split
+# by line and grab every backticked lowercase word from the kind row.
+kind_lines = [l for l in readme.splitlines() if re.match(r"^\|\s*`kind`\s*\|", l)]
+if not kind_lines:
+    print("schema-drift: README missing the canonical kind row", file=sys.stderr)
+    sys.exit(1)
+readme_kinds = set(re.findall(r"`([a-z]+)`", kind_lines[0])) - {"kind"}
+
+missing_keys = script_keys - table_keys
+extra_keys = table_keys - script_keys
+if missing_keys or extra_keys:
+    print(f"schema-drift keys: script={sorted(script_keys)} readme={sorted(table_keys)} "
+          f"missing_from_readme={sorted(missing_keys)} extra_in_readme={sorted(extra_keys)}",
+          file=sys.stderr)
+    sys.exit(1)
+
+if script_kinds != readme_kinds:
+    print(f"schema-drift kinds: script={sorted(script_kinds)} readme={sorted(readme_kinds)}",
+          file=sys.stderr)
+    sys.exit(1)
+PY
+then
+  echo "ok   [schema-drift-readme-vs-script]"
+else
+  echo "FAIL [schema-drift-readme-vs-script]" >&2
+  failures=$((failures + 1))
+fi
+
+# Production file lints clean (regression guard).
+ran=$((ran + 1))
+set +e
+out=$(bash "$LINTER" 2>&1)
+got=$?
+set -e
+if [[ "$got" -eq 0 ]]; then
+  echo "ok   [production-file]"
+else
+  echo "FAIL [production-file]: real docs/knowledge/patterns.jsonl is not clean" >&2
+  echo "  output: $out" >&2
+  failures=$((failures + 1))
+fi
+
+echo
+if [[ "$failures" -gt 0 ]]; then
+  echo "✖ Self-test: $failures of $ran cases failed" >&2
+  exit 1
+fi
+echo "✓ Self-test: passed ($ran cases)."

--- a/tools/test-pre-pr.sh
+++ b/tools/test-pre-pr.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Self-test for tools/hooks/pre-pr.sh. For each of the four layers the
+# aggregator runs, plant a single-character corruption in a sandbox
+# copy of the repo, invoke pre-pr.sh against it, and assert it fails
+# with the matching `pre-pr: ✖ <label> failed` line. Catches the
+# regression where a refactor silently drops a layer.
+
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Clone the working tree into a real git sandbox so the drift-watch
+# can call `git check-ignore` against the same .gitignore. Preserve
+# symlinks (CLAUDE.md → AGENTS.md) with cp -P.
+SANDBOX="$TMP/repo"
+seed_sandbox() {
+  rm -rf "$SANDBOX"
+  mkdir -p "$SANDBOX"
+  { git ls-files -z; git ls-files -z --others --exclude-standard; } \
+    | while IFS= read -r -d '' f; do
+    mkdir -p "$SANDBOX/$(dirname "$f")"
+    cp -P "$f" "$SANDBOX/$f"
+  done
+  (cd "$SANDBOX" \
+    && git init -q \
+    && git -c user.email=t@t -c user.name=t add -A \
+    && git -c user.email=t@t -c user.name=t commit -q -m baseline)
+}
+seed_sandbox
+
+# A baseline run against the clean sandbox must succeed — sanity-check.
+set +e
+out=$(cd "$SANDBOX" && bash tools/hooks/pre-pr.sh 2>&1)
+got=$?
+set -e
+if [[ "$got" -ne 0 ]]; then
+  echo "FAIL [baseline]: clean sandbox should pass, got exit $got" >&2
+  echo "  output: $out" >&2
+  exit 1
+fi
+echo "ok   [baseline]"
+
+failures=0
+ran=1
+
+# run_corruption <label> <corruption-shell> <expected-failure-substr>
+run_corruption() {
+  local label="$1" corrupt="$2" want="$3"
+  ran=$((ran + 1))
+
+  # Restore clean sandbox each time (cheap; small tree).
+  seed_sandbox
+  (cd "$SANDBOX" && eval "$corrupt")
+
+  set +e
+  out=$(cd "$SANDBOX" && bash tools/hooks/pre-pr.sh 2>&1)
+  got=$?
+  set -e
+
+  if [[ "$got" -eq 0 ]]; then
+    echo "FAIL [$label]: pre-pr.sh exited 0 on corrupted sandbox" >&2
+    echo "  output: $out" >&2
+    failures=$((failures + 1))
+    return
+  fi
+  if [[ "$out" != *"$want"* ]]; then
+    echo "FAIL [$label]: missing expected failure substring '$want'" >&2
+    echo "  output: $out" >&2
+    failures=$((failures + 1))
+    return
+  fi
+  echo "ok   [$label]"
+}
+
+# 1. agents-md hygiene — corrupt the root AGENTS.md so the linter trips.
+#    Removing the file is the surest single-step corruption.
+run_corruption "agents-md-fail" \
+  'rm AGENTS.md' \
+  'pre-pr: ✖ agents-md hygiene failed'
+
+# 2. agent-artifact lint — corrupt an agent file's frontmatter.
+#    Strip the model: line; the linter requires it.
+run_corruption "agent-artifact-fail" \
+  "sed -i.bak '/^model:/d' .claude/agents/adversarial-reviewer.md && rm .claude/agents/adversarial-reviewer.md.bak" \
+  'pre-pr: ✖ agent-artifact lint failed'
+
+# 3. skill-deps lint — break a dep path in the work-loop SKILL.
+run_corruption "skill-deps-fail" \
+  "sed -i.bak 's|tools/check-done.py|tools/does-not-exist.py|' .claude/skills/work-loop/SKILL.md && rm .claude/skills/work-loop/SKILL.md.bak" \
+  'pre-pr: ✖ skill-deps lint failed'
+
+# 4. knowledge lint — plant a malformed JSONL line.
+run_corruption "knowledge-fail" \
+  "printf '%s\n' '{not json' > docs/knowledge/patterns.jsonl" \
+  'pre-pr: ✖ knowledge lint failed'
+
+# 5. check-done.py — plant a state.json with plan_review_status=pending,
+#    which trips the gate for both --phase implement and --phase review.
+#    Drops the test if pre-pr ever stops iterating state.json files.
+run_corruption "check-done-fail" \
+  "mkdir -p docs/specs/example && cp docs/_templates/state.json docs/specs/example/state.json" \
+  'pre-pr: ✖ check-done'
+
+echo
+if [[ "$failures" -gt 0 ]]; then
+  echo "✖ Self-test: $failures of $ran cases failed" >&2
+  exit 1
+fi
+echo "✓ Self-test: passed ($ran cases)."

--- a/tools/test-session-start.sh
+++ b/tools/test-session-start.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Self-test for tools/hooks/session-start.sh. Exercises the
+# malformed-line warning, the --scope validation, and the empty-file
+# silent-exit. Uses KNOWLEDGE_FILE override against tempdir fixtures so
+# the production patterns.jsonl is never touched.
+
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+HOOK="$REPO_ROOT/tools/hooks/session-start.sh"
+
+failures=0
+ran=0
+
+# run_case <name> <file-contents> <want-exit> <want-stdout-substr> <want-stderr-substr>
+# Empty want-*-substr means "don't assert on that stream".
+run_case() {
+  local name="$1" body="$2" want_exit="$3" want_stdout="$4" want_stderr="$5"
+  ran=$((ran + 1))
+
+  local path="$TMP/$name.jsonl"
+  printf '%s' "$body" > "$path"
+
+  local out_stdout out_stderr
+  set +e
+  out_stdout=$(KNOWLEDGE_FILE="$path" bash "$HOOK" 2>"$TMP/$name.err")
+  local got_exit=$?
+  out_stderr=$(< "$TMP/$name.err")
+  set -e
+
+  if [[ "$got_exit" -ne "$want_exit" ]]; then
+    echo "FAIL [$name]: expected exit $want_exit, got $got_exit" >&2
+    echo "  stdout: $out_stdout" >&2
+    echo "  stderr: $out_stderr" >&2
+    failures=$((failures + 1))
+    return
+  fi
+  if [[ -n "$want_stdout" && "$out_stdout" != *"$want_stdout"* ]]; then
+    echo "FAIL [$name]: stdout missing '$want_stdout'" >&2
+    echo "  stdout: $out_stdout" >&2
+    failures=$((failures + 1))
+    return
+  fi
+  if [[ -n "$want_stderr" && "$out_stderr" != *"$want_stderr"* ]]; then
+    echo "FAIL [$name]: stderr missing '$want_stderr'" >&2
+    echo "  stderr: $out_stderr" >&2
+    failures=$((failures + 1))
+    return
+  fi
+  echo "ok   [$name]"
+}
+
+VALID='{"id": "K-0001", "kind": "pattern", "scope": "src/**", "title": "T", "body": "B", "source": "PR#1"}'
+
+# Clean file with one valid entry — prints the block, no warning.
+run_case "clean-one-entry" "$VALID" 0 "=== knowledge ===" ""
+
+# Mixed file — one malformed, one valid. Valid entry prints; warning fires.
+MIXED='{not json'$'\n'"$VALID"
+run_case "mixed-valid-and-malformed" "$MIXED" 0 "[K-0001]" "skipped 1 malformed"
+
+# All malformed — no entries print, warning still fires on stderr.
+ALL_BAD='{not json'$'\n''also not'$'\n''broken too'
+run_case "all-malformed" "$ALL_BAD" 0 "" "skipped 3 malformed"
+
+# Empty file — silent exit 0, no warning.
+run_case "empty-file" "" 0 "" ""
+
+# Missing file — silent exit 0 (hook is a no-op).
+ran=$((ran + 1))
+set +e
+out_stdout=$(KNOWLEDGE_FILE="$TMP/does-not-exist.jsonl" bash "$HOOK" 2>"$TMP/miss.err")
+got=$?
+set -e
+out_stderr=$(< "$TMP/miss.err")
+if [[ "$got" -eq 0 && -z "$out_stdout" && -z "$out_stderr" ]]; then
+  echo "ok   [missing-file]"
+else
+  echo "FAIL [missing-file]: exit=$got stdout=$out_stdout stderr=$out_stderr" >&2
+  failures=$((failures + 1))
+fi
+
+# --scope with no value — exits 2 with usage message.
+ran=$((ran + 1))
+set +e
+out_stderr=$(bash "$HOOK" --scope 2>&1)
+got=$?
+set -e
+if [[ "$got" -eq 2 && "$out_stderr" == *"--scope requires a path or glob value"* ]]; then
+  echo "ok   [scope-no-value]"
+else
+  echo "FAIL [scope-no-value]: exit=$got stderr=$out_stderr" >&2
+  failures=$((failures + 1))
+fi
+
+# --scope filter (positive): caller path covered by stored glob.
+COVERAGE='{"id": "K-0001", "kind": "pattern", "scope": "packages/auth/**", "title": "T1", "body": "B1", "source": "S1"}'$'\n''{"id": "K-0002", "kind": "gotcha", "scope": "src/other/x.ts", "title": "T2", "body": "B2", "source": "S2"}'
+printf '%s' "$COVERAGE" > "$TMP/cov.jsonl"
+ran=$((ran + 1))
+set +e
+out=$(KNOWLEDGE_FILE="$TMP/cov.jsonl" bash "$HOOK" --scope 'packages/auth/server.ts' 2>"$TMP/cov.err")
+got=$?
+set -e
+if [[ "$got" -eq 0 && "$out" == *"K-0001"* && "$out" != *"K-0002"* ]]; then
+  echo "ok   [scope-coverage-positive]"
+else
+  echo "FAIL [scope-coverage-positive]: caller path didn't match stored glob correctly" >&2
+  echo "  stdout: $out" >&2
+  failures=$((failures + 1))
+fi
+
+# --scope filter (negative): caller path NOT covered by other-package glob.
+ran=$((ran + 1))
+set +e
+out=$(KNOWLEDGE_FILE="$TMP/cov.jsonl" bash "$HOOK" --scope 'packages/billing/charge.ts' 2>"$TMP/cov2.err")
+got=$?
+set -e
+if [[ "$got" -eq 0 && "$out" != *"K-0001"* && "$out" != *"K-0002"* ]]; then
+  echo "ok   [scope-coverage-negative]"
+else
+  echo "FAIL [scope-coverage-negative]: unrelated path matched stored glob" >&2
+  echo "  stdout: $out" >&2
+  failures=$((failures + 1))
+fi
+
+echo
+if [[ "$failures" -gt 0 ]]; then
+  echo "✖ Self-test: $failures of $ran cases failed" >&2
+  exit 1
+fi
+echo "✓ Self-test: passed ($ran cases)."


### PR DESCRIPTION
## What does this change?

Phase 3 of the work-loop architecture. Three load-bearing additions:

- **Knowledge base** at `docs/knowledge/patterns.jsonl` — practitioner-level lessons (patterns / gotchas / antipatterns), one JSON object per line, scoped to a file glob. `docs/knowledge/README.md` documents the schema and curation conventions (append-only by default; supersession lives in body prose). `tools/lint-knowledge.sh` enforces shape (required keys, K-NNNN id format, unique ids, kind enum, non-empty strings); `tools/test-lint-knowledge.sh` covers 20 cases including the schema-drift-vs-README assertion that catches divergence between docs and linter.
- **Lifecycle hooks (Path B — agnostic shell, no committed wiring).** `tools/hooks/session-start.sh` prints knowledge entries at session open, optionally `--scope`-filtered against a path/glob (matched via Python's `fnmatch` with the caller as path and the entry's stored glob as pattern). `tools/hooks/pre-pr.sh` aggregates the four artifact linters + `check-done.py` into a single PR gate, exits non-zero on first failure. `tools/hooks/README.md` documents both contracts and shows a Claude-Code `.claude/settings.json` wiring example without committing one — consumers opt in via their tool's hook surface.
- **Enforcement triplet** named in CONVENTIONS — `check-done.py` (caps), the four artifact linters (artifact hygiene), `pre-pr.sh` (the gate that aggregates them). Single label readers can reference; the three pieces stay in sync because they all run together.

The work-loop SKILL's "Capture what was learned" section now points at `patterns.jsonl` as the canonical destination for pattern/gotcha/antipattern-shaped learnings; other shapes still go where they already belong (`AGENTS.md`, skill bodies, `architecture/`).

## Why?

Phase 1 made caps mechanical; Phase 2 made the loop fan out mechanically; Phase 3 closes the capture-learnings → enforcement loop. Patterns the project has bled to learn live in a single file that primes future agents at session-start; the lint-and-cap surface gets a name and a single-entry hook that mirrors CI locally.

The proposal called for `.claude/settings.json` wiring — explicitly rejected here as consumer-specific. The hooks ship as shell+python3 the consumer wires into whatever their tool exposes.

## How do I verify it?

```bash
bash tools/test-all.sh        # 6/6: bootstrap, check-done, lint-agent-artifacts, lint-knowledge, pre-pr, session-start
bash tools/hooks/pre-pr.sh    # the new aggregator — runs the four linters + check-done against any state.json
```

Smoke-test the knowledge base end-to-end:

```bash
# Drop a few sample entries into patterns.jsonl, then:
bash tools/hooks/session-start.sh                                  # all entries
bash tools/hooks/session-start.sh --scope packages/auth/server.ts  # entries whose stored scope covers this path

# Lint catches drift:
bash tools/lint-knowledge.sh
```

## What did you not change that you considered?

- **`.claude/settings.json` committed wiring.** Path B was chosen explicitly — consumers may want to wire differently, and `settings.json` isn't portable across agent tools. The README shows the wiring as an example.
- **3d (PluginEval-style lint categories: `OVER_CONSTRAINED`, `MISSING_TRIGGER`, `BLOATED_SKILL`, etc.).** Most duplicate existing checks (`EMPTY_DESCRIPTION` is already an error, `ORPHAN_REFERENCE` is `lint-skill-deps`, `DEAD_CROSS_REF` is `lint-agent-artifacts`). The genuinely new ones — `MISSING_TRIGGER` especially — had high false-positive risk. Skipped; can be re-opened if a real false-positive case shows up.
- **`.github/workflows/docs.yml` updates to wire the new self-tests into CI.** The CI-parity gap is documented explicitly in `tools/hooks/README.md §Testing the hooks` and `CONVENTIONS.md §Enforcement` — both layer asymmetry (CI runs 2 of 5 linters) and self-test asymmetry (CI runs 2 of 6 self-tests). Closing the gap is a follow-up PR; this one stays focused on the knowledge-and-hooks charter.
- **`new-reviewer` skill, `tools/supervise.py` Python orchestration.** Three-times rule still fails; deferred per proposal.
- **Schema field for supersession** (`supersedes: K-0007`). Considered, rejected — the README says supersession lives in body prose by design, single-sourcing the convention in one place. The linter rejects unknown keys to make the contract explicit.

## Review iterations

Three rounds of `adversarial-reviewer` + `quality-engineer` dispatched in parallel (eating the dispatch discipline this template added in Phase 2):

| Round | Blockers | Concerns | Nits |
|---|---|---|---|
| iter-1 | 2 | 7 | 3 |
| iter-2 | 0 | 4 | 4 |
| iter-3 | 0 | 3 | 2 |
| iter-4 | clean |

Notable in-flight:
- iter-1 → iter-2: `--scope` semantics switched from exact-string equality to `fnmatch`-coverage match (the whole point of glob entries). Schema-vs-script drift assertion added between `docs/knowledge/README.md` and `lint-knowledge.sh` (caught a real cross-doc bug on first run, fixed). `test-pre-pr.sh` extended from 4 to 5 enforcement-layer fixtures.
- iter-2 → iter-3: `KNOWLEDGE_FILE` override added so the malformed-warning path could be tested; `tools/test-session-start.sh` added (8 cases). "POSIX shell" claim corrected across four locations to "bash + python3."
- iter-3 fixes: umbrella `tools/test-all.sh` runner added so the four phase-2/phase-3 self-tests stay discoverable; CI-self-test-asymmetry documented explicitly; HTML-comment marker added in `docs/knowledge/README.md` flagging the canonical structure to the schema-drift test.

Local validation: hand-stepped the knowledge base + session-start flow with 3 sample entries in `.context/phase-3-demo/` (gitignored). End-to-end correct: positive coverage (`packages/auth/server.ts` matches `packages/auth/**`), negative coverage (`packages/billing/charge.ts` doesn't), malformed-line warning, empty-file silent exit.