### PR TITLE
ci(workflow): wire Phase 1/2/3 self-tests into docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,14 @@ on:
       - 'tools/lint-agents-md.sh'
       - 'tools/lint-agent-artifacts.sh'
       - 'tools/test-lint-agent-artifacts.sh'
+      - 'tools/lint-skill-deps.sh'
+      - 'tools/lint-knowledge.sh'
+      - 'tools/test-lint-knowledge.sh'
+      - 'tools/check-done.py'
+      - 'tools/test-check-done.sh'
+      - 'tools/hooks/**'
+      - 'tools/test-pre-pr.sh'
+      - 'tools/test-session-start.sh'
       - 'tools/bootstrap.sh'
       - 'tools/test-bootstrap-targets.sh'
       - '.github/workflows/docs.yml'
@@ -47,6 +55,53 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run bootstrap-targets self-test
         run: bash tools/test-bootstrap-targets.sh
+
+  lint-skill-deps:
+    name: Skill-dep manifests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run skill-dep linter
+        run: bash tools/lint-skill-deps.sh
+
+  lint-knowledge:
+    name: Knowledge base
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run knowledge-base linter
+        run: bash tools/lint-knowledge.sh
+      - name: Self-test the linter (schema-drift + content guards)
+        run: bash tools/test-lint-knowledge.sh
+
+  check-done:
+    name: Caps enforcer self-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Self-test the caps enforcer
+        run: bash tools/test-check-done.sh
+
+  # Aggregator end-to-end. Duplicates the per-layer linter jobs by design —
+  # those each surface with their own check name in PR UI; this one catches
+  # regressions in pre-pr.sh's composition (a layer dropped, a reorder
+  # breaking a dependency, exit-code propagation).
+  hooks:
+    name: Lifecycle hooks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Seed a healthy state.json so the aggregator exercises check-done.py
+        run: |
+          mkdir -p docs/specs/_ci-smoke
+          sed 's/"pending"/"approved"/' docs/_templates/state.json \
+            > docs/specs/_ci-smoke/state.json
+      - name: Run pre-pr aggregator (mirrors local enforcement triplet)
+        run: bash tools/hooks/pre-pr.sh
+      - name: Self-test the aggregator (each layer corruption surfaces)
+        run: bash tools/test-pre-pr.sh
+      - name: Self-test session-start (scope filter + malformed warning)
+        run: bash tools/test-session-start.sh
 
   check-adr-immutability:
     name: ADRs are immutable

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -565,7 +565,7 @@ enforcement triplet" and mean the same three things:
 |---|---|---|
 | Caps | [`tools/check-done.py`](../tools/check-done.py) | Iteration cap, token budget, plan approval, fingerprint stasis (see [§ Work-loop state](#work-loop-state)). |
 | Artifacts | `tools/lint-agents-md.sh`, `lint-agent-artifacts.sh`, `lint-skill-deps.sh`, `lint-knowledge.sh` | Shape, manifest, and content hygiene for every `.claude/`, `AGENTS.md`, and `docs/knowledge/` artifact. |
-| Aggregation | [`tools/hooks/pre-pr.sh`](../tools/hooks/pre-pr.sh) | Runs caps + artifact linters together before a PR opens. The local gate is a superset of CI today — CI runs `lint-agents-md.sh` and `lint-agent-artifacts.sh`; the local hook adds `lint-skill-deps.sh`, `lint-knowledge.sh`, and `check-done.py`. Keep the local hook green and CI follows. |
+| Aggregation | [`tools/hooks/pre-pr.sh`](../tools/hooks/pre-pr.sh) | Runs caps + artifact linters together before a PR opens. CI mirrors this — `.github/workflows/docs.yml` has a job per enforcement layer, including a `hooks` job that runs the aggregator end-to-end. Keep the local hook green and CI follows. |
 
 `pre-pr.sh` is the hook downstream consumers wire into their tool's
 lifecycle (see [`tools/hooks/README.md`](../tools/hooks/README.md)).

--- a/tools/hooks/README.md
+++ b/tools/hooks/README.md
@@ -123,12 +123,10 @@ The umbrella `tools/test-all.sh` runs every self-test in `tools/`
 `test-lint-agent-artifacts.sh`, `test-bootstrap-targets.sh`). Run it
 by hand whenever a linter, hook, or `check-done.py` changes.
 
-**CI parity.** `pre-pr.sh` is a superset of CI: CI runs only the
-agent-artifact and AGENTS.md linters; the local hook also runs the
-skill-dep, knowledge, and `check-done.py` checks. **Self-tests are
-also asymmetric** — CI runs `test-lint-agent-artifacts.sh` and
-`test-bootstrap-targets.sh`; the four self-tests added in later
-phases (`test-check-done.sh`, `test-lint-knowledge.sh`,
-`test-pre-pr.sh`, `test-session-start.sh`) are *not yet* wired into
-CI. Run `tools/test-all.sh` locally before opening a PR so the
-asymmetry doesn't catch you.
+**CI parity.** `pre-pr.sh` and CI run the same set of checks in
+parallel. CI's `.github/workflows/docs.yml` has a job per
+enforcement layer — the four linters, the caps-enforcer self-test,
+and a `hooks` job that exercises the aggregator end-to-end (after
+seeding a healthy `state.json` so `check-done.py` actually runs).
+Run `tools/test-all.sh` and `tools/hooks/pre-pr.sh` locally before
+opening a PR; CI runs the same checks afterward.


### PR DESCRIPTION
## What does this change?

Closes the CI-parity gap that Phase 3 documented but didn't close. CI was running 2 of 5 enforcement-layer linters and 2 of 6 self-tests; the rest were hand-run only. This PR adds the four missing jobs to `.github/workflows/docs.yml` and updates the two doc locations that called out the asymmetry.

Four new jobs (each mirrors the existing linter+self-test pattern):

- **`lint-skill-deps`** — runs `tools/lint-skill-deps.sh` against the working tree (skill/agent manifest dependency resolution).
- **`lint-knowledge`** — runs `tools/lint-knowledge.sh` + `tools/test-lint-knowledge.sh` (20 cases including schema-drift between README and linter).
- **`check-done`** — runs `tools/test-check-done.sh` (the caps-enforcer self-test, 26 cases).
- **`hooks`** — end-to-end aggregator check. Seeds a healthy `state.json` inline so `pre-pr.sh` actually exercises `check-done.py` (not just the four artifact linters); then runs the aggregator, `test-pre-pr.sh`, and `test-session-start.sh`.

The `hooks` job intentionally duplicates the per-layer jobs — those each surface with their own check name in PR UI; this one catches regressions in `pre-pr.sh`'s composition. A YAML comment records the intent.

`paths:` triggers extended so editing any of the now-CI-wired scripts fires the workflow.

## Why?

Phase 3's PR description called this out as a deferred follow-up:
> Wiring the four phase-2/phase-3 self-tests into `.github/workflows/docs.yml` — scope creep beyond the knowledge-and-hooks charter; future PR.

This is that PR. The asymmetry between local `tools/test-all.sh` and CI was already a maintainability liability — contributors had to remember to run `test-all.sh` by hand before opening a PR, and a regression in a CI-unwired test would land green.

## How do I verify it?

```bash
python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/docs.yml').read_text())"  # yaml ok
bash tools/hooks/pre-pr.sh    # 4 layers green; check-done skipped (no state.json)
bash tools/test-all.sh        # 6/6 self-tests green
```

Simulate the `hooks` job's seed-then-aggregate sequence:

```bash
mkdir -p docs/specs/_ci-smoke
sed 's/"pending"/"approved"/' docs/_templates/state.json > docs/specs/_ci-smoke/state.json
bash tools/hooks/pre-pr.sh    # all 5 layers green; check-done fires on implement + review
rm -rf docs/specs/_ci-smoke
```

When this PR opens on GitHub, you should see eight check runs instead of four.

## What did you not change that you considered?

- **Broaden `paths:` to `tools/**`.** Considered; rejected. The existing convention is selective (per-script include), and changing it is scope creep beyond the gap-closing charter. Future PRs that add a tool wire its path explicitly.
- **Collapse the per-layer jobs since `hooks` runs the aggregator end-to-end.** Considered; rejected. The per-layer jobs give each enforcement surface its own check name in PR UI — useful for a contributor diagnosing which layer failed without scrolling a longer log. The duplication is deliberate; a YAML comment now records the intent.
- **Add a self-test for `lint-skill-deps.sh`.** Out of scope. Phase 3's QE review flagged this as a separate gap (a pre-existing linter without a self-test); the right home is its own PR, not this one.
- **Block the ADR-immutability warning instead of leaving it advisory.** Untouched — that job's logic is pre-existing and a separate concern.

Adversarial-reviewer pass surfaced 3 Concerns + 2 Nits, all addressed in-flight: the seed-step recipe was added to fix missing `check-done.py` coverage in CI, the `check-done` job was renamed for honesty (it runs the self-test, not the linter, since CI has no real `state.json`), a YAML comment explains the intentional duplication, the stale `tools/test-all.sh` paths entry was dropped, and the README/CONVENTIONS prose was tightened so the rationale doesn't read as a vestige of the prior asymmetry.