### PR TITLE
chore(workflow): lint-skill-deps self-test + tier→multi-agent mapping

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,7 @@ on:
       - 'tools/lint-agent-artifacts.sh'
       - 'tools/test-lint-agent-artifacts.sh'
       - 'tools/lint-skill-deps.sh'
+      - 'tools/test-lint-skill-deps.sh'
       - 'tools/lint-knowledge.sh'
       - 'tools/test-lint-knowledge.sh'
       - 'tools/check-done.py'
@@ -63,6 +64,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run skill-dep linter
         run: bash tools/lint-skill-deps.sh
+      - name: Self-test the linter (asserts expected errors fire)
+        run: bash tools/test-lint-skill-deps.sh
 
   lint-knowledge:
     name: Knowledge base

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -656,6 +656,30 @@ This is the design target — everything in the template is in active use.
 - ADRs are routine — likely 30+ in the project's history.
 - Multiple specs in flight; spec/plan/review discipline carries weight.
 
+### Multi-agent shape by profile
+
+The mechanisms — supervisor mode, parallel reviewer dispatch, the
+knowledge base — are defined in their own sections above. The mapping
+below says *which of them you actually use* at each profile, so a
+template adopter knows when to wire each one up.
+
+- **Profile A** — single-agent work-loop. Supervisor mode is available
+  but rarely triggers; most plans at this size have sequential
+  `Depends on:` chains, and the parallel-dispatch payoff doesn't beat
+  the coordination overhead. Specialist reviewers are usually skipped,
+  and `adversarial-reviewer` itself is optional at this size.
+- **Profile B** — [supervisor mode](#supervisor-mode) earns its keep
+  when a plan produces two or more `Depends on: none` tasks. Reviewer
+  fan-out follows the
+  [parallel-dispatch discipline](../.claude/skills/work-loop/SKILL.md#parallel-dispatch-discipline)
+  in the work-loop skill: one tool-call message, one Agent use per
+  reviewer, barrier-wait, merge in the orchestrator's context.
+- **Profile C** — same as B, plus the [knowledge base](#knowledge-base)
+  is actively populated (`docs/knowledge/patterns.jsonl`) and the
+  `session-start` hook is wired in the consumer's `.claude/settings.json`
+  per [`tools/hooks/README.md`](../tools/hooks/README.md). The template
+  ships the script, not the wiring.
+
 ### Above Profile C
 
 If your repo is heading past ~50 active contributors with multiple teams

--- a/tools/test-all.sh
+++ b/tools/test-all.sh
@@ -21,6 +21,7 @@ tests=(
   "check-done:bash tools/test-check-done.sh"
   "lint-agent-artifacts:bash tools/test-lint-agent-artifacts.sh"
   "lint-knowledge:bash tools/test-lint-knowledge.sh"
+  "lint-skill-deps:bash tools/test-lint-skill-deps.sh"
   "pre-pr:bash tools/test-pre-pr.sh"
   "session-start:bash tools/test-session-start.sh"
 )

--- a/tools/test-lint-skill-deps.sh
+++ b/tools/test-lint-skill-deps.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Self-test for tools/lint-skill-deps.sh.
+#
+# Generates broken skill/agent manifests in a tempdir, runs the linter
+# against them, and asserts that each of the linter's three err() sites
+# (missing file, missing anchor, dep-is-a-directory) fires. Then runs the
+# linter against a happy-path fixture and asserts exit 0. Finally runs
+# the linter against the real in-tree state as a regression guard — a
+# refactor that broke the parser would otherwise land green here even
+# while it broke real installs.
+#
+# Fixtures live in the tempdir, not in the repo, so Claude Code's skill
+# discovery does not pick them up (a broken fixture skill would otherwise
+# appear in the skills list).
+
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+LINTER="$REPO_ROOT/tools/lint-skill-deps.sh"
+
+# ── Tempdirs (both up front so the EXIT trap can clean both safely) ──────
+
+BAD="$(mktemp -d)"
+GOOD="$(mktemp -d)"
+trap 'rm -rf "$BAD" "$GOOD"' EXIT
+
+# ── Broken-fixture tree ───────────────────────────────────────────────────
+
+mkdir -p \
+  "$BAD/.claude/skills/missing-file" \
+  "$BAD/.claude/skills/missing-anchor" \
+  "$BAD/.claude/skills/dep-is-dir" \
+  "$BAD/docs" \
+  "$BAD/some-dir-target"
+
+# A real file the missing-anchor fixture can point at (so we hit the
+# anchor-resolution err(), not the missing-file err()).
+cat > "$BAD/docs/real.md" <<'EOF'
+# A real heading
+
+Body content. The slug for the heading above is `a-real-heading`.
+EOF
+
+# Skill: dependency points at a file that does not exist.
+cat > "$BAD/.claude/skills/missing-file/SKILL.md" <<'EOF'
+---
+name: missing-file
+description: Dep points at a file that does not exist.
+dependencies:
+  - docs/does-not-exist.md
+---
+
+Body.
+EOF
+
+# Skill: dependency cites a file that exists, but with an anchor the
+# file does not define.
+cat > "$BAD/.claude/skills/missing-anchor/SKILL.md" <<'EOF'
+---
+name: missing-anchor
+description: Dep file exists but anchor does not.
+dependencies:
+  - docs/real.md#nope-not-here
+---
+
+Body.
+EOF
+
+# Skill: dependency points at a directory rather than a file.
+cat > "$BAD/.claude/skills/dep-is-dir/SKILL.md" <<'EOF'
+---
+name: dep-is-dir
+description: Dep points at a directory, not a file.
+dependencies:
+  - some-dir-target
+---
+
+Body.
+EOF
+
+# ── Run linter against broken fixtures ────────────────────────────────────
+
+set +e
+bad_output="$(LINT_ROOT="$BAD" bash "$LINTER" 2>&1)"
+bad_exit=$?
+set -e
+
+fail=0
+
+if (( bad_exit == 0 )); then
+  echo "✖ linter exited 0 against broken fixtures; expected non-zero." >&2
+  fail=1
+fi
+
+EXPECTED_PATTERNS=(
+  "dependency points at missing file: docs/does-not-exist.md"
+  "anchor #nope-not-here not found in docs/real.md"
+  "dependency points at a directory: some-dir-target"
+)
+
+for pattern in "${EXPECTED_PATTERNS[@]}"; do
+  if ! grep -qF -- "$pattern" <<< "$bad_output"; then
+    echo "✖ expected error pattern not found: $pattern" >&2
+    fail=1
+  fi
+done
+
+# ── Happy-path fixture ────────────────────────────────────────────────────
+
+mkdir -p \
+  "$GOOD/.claude/skills/happy" \
+  "$GOOD/docs"
+
+cat > "$GOOD/docs/real.md" <<'EOF'
+# A real heading
+
+Body.
+EOF
+
+cat > "$GOOD/.claude/skills/happy/SKILL.md" <<'EOF'
+---
+name: happy
+description: Valid deps; should lint clean.
+dependencies:
+  - docs/real.md
+  - docs/real.md#a-real-heading
+---
+
+Body.
+EOF
+
+set +e
+good_output="$(LINT_ROOT="$GOOD" bash "$LINTER" 2>&1)"
+good_exit=$?
+set -e
+
+if (( good_exit != 0 )); then
+  echo "✖ linter exited $good_exit against happy-path fixture; expected 0." >&2
+  echo "Output was:" >&2
+  echo "$good_output" >&2
+  fail=1
+fi
+
+# ── Production-tree regression guard ──────────────────────────────────────
+# Run the real linter against the real tree (no LINT_ROOT override). A
+# regression in the parser or anchor resolver that flipped a working
+# manifest red would otherwise land green here.
+
+set +e
+real_output="$(bash "$LINTER" 2>&1)"
+real_exit=$?
+set -e
+
+if (( real_exit != 0 )); then
+  echo "✖ linter failed against in-tree manifests (production regression guard)." >&2
+  echo "Output was:" >&2
+  echo "$real_output" >&2
+  fail=1
+fi
+
+# ── Report ────────────────────────────────────────────────────────────────
+
+if (( fail )); then
+  echo
+  echo "Self-test: failed." >&2
+  echo "Broken-fixture linter output was:" >&2
+  echo "---" >&2
+  echo "$bad_output" >&2
+  echo "---" >&2
+  exit 1
+fi
+
+echo "✓ Self-test: passed (${#EXPECTED_PATTERNS[@]} broken-fixture patterns observed, happy-path clean, in-tree clean)."


### PR DESCRIPTION
## What does this change?

Two small follow-ups left over from the work-loop architecture landings (PRs #6–#9). Adds a self-test for `tools/lint-skill-deps.sh` and a tier→multi-agent-shape mapping in `docs/CONVENTIONS.md § Scaling profiles`.

## Why?

Pre-existing gaps flagged by reviewers but out of scope at the time:

1. **Self-test gap.** `quality-engineer` flagged the missing self-test for `lint-skill-deps.sh` in both the Phase 2 and Phase 3 reviews — the linter validates dep paths and anchors for every skill and subagent manifest, but a regression in the YAML parser, anchor resolver, or directory-rejection path would land green without fixtures of its own.
2. **Scaling-profiles Q4.** The architecture proposal flagged that `docs/CONVENTIONS.md § Scaling profiles` described which folders fill up at each tier without saying which *multi-agent shape* each tier actually uses (single-agent vs. supervisor mode vs. supervisor + knowledge base).

## How do I verify it?

```bash
bash tools/test-lint-skill-deps.sh       # 3 broken-fixture patterns observed, happy clean, in-tree clean
bash tools/test-all.sh                   # 7 passed, including the new `lint-skill-deps` entry
bash tools/hooks/pre-pr.sh               # all checks passed
```

Eyeball:
- `docs/CONVENTIONS.md § Scaling profiles → Multi-agent shape by profile` — new subsection sits between Profile C and "Above Profile C".
- `.github/workflows/docs.yml` — `lint-skill-deps` job now has a `Self-test the linter…` second step matching the peer `lint-agent-artifacts` and `lint-knowledge` jobs; `tools/test-lint-skill-deps.sh` added to `paths:`.

## What did you not change that you considered?

- **The linter itself** (`tools/lint-skill-deps.sh`). Out of scope; the gap is coverage, not behavior.
- **`.claude/settings.json`.** The Path B convention from Phase 3 stands — the template ships the hook script; consumers wire it.
- **Workflow `paths:` glob.** Did not broaden to `tools/**`; the existing convention is selective per-script, and a per-script entry preserves change-locality.
- **Duplicating mechanism definitions in § Scaling profiles.** The new subsection links to existing § Supervisor mode, § Knowledge base, and the SKILL's parallel-dispatch section rather than restating their internals — same single-source rule the rest of CONVENTIONS follows.