### PR TITLE
docs(work-loop): broaden skill trigger surface for complex non-trivial work

### DIFF
--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: work-loop
-description: Use this skill whenever you're implementing a non-trivial change — a feature, a bug fix that touches more than one file, a refactor, or anything spec-driven. It enforces the project's plan → execute → self-review → fix loop with mechanical gates (lint, typecheck, tests) and adversarial review. Default to this skill for any task larger than a one-line edit.
+description: Use this skill whenever you're implementing a non-trivial change — a feature, a multi-file bug fix, a refactor, a migration, a framework or dependency upgrade, a schema or API change, performance work, an infrastructure or build-system edit, or anything spec-driven. It enforces the project's plan → execute → self-review → fix loop with mechanical gates (lint, typecheck, tests) and adversarial review. Default to this skill for any task larger than a one-line edit.
 dependencies:
   - docs/CONVENTIONS.md#contract-tests-vs-construction-tests
   - docs/CONVENTIONS.md#work-loop-state
@@ -39,8 +39,11 @@ verifiable termination criteria.
 ## When this skill applies
 
 - Implementing a spec from `docs/specs/`.
-- Bug fixes that touch more than one file.
+- Bug fixes that touch more than one file — including security patches and incident hot-fixes.
 - Refactors.
+- Migrations, framework or dependency upgrades, schema or API changes.
+- Performance work, or infrastructure / build-system changes beyond a single config tweak.
+- Reverting and re-doing a previous change.
 - Any task where you'd otherwise be tempted to "just go".
 
 For genuine one-line edits (typo, config tweak), skip the loop — the overhead


### PR DESCRIPTION
## What does this change?

Broadens the `work-loop` skill's trigger surface so it fires for non-trivial work that doesn't read as "feature / bug fix / refactor" to the harness's skill matcher — migrations, framework or dependency upgrades, schema or API changes, performance work, infrastructure / build-system edits, security patches, incident hot-fixes, and reverts.

## Why?

The harness routes user prompts to skills by matching against each skill's `description` field. The previous description's example list ("a feature, a bug fix that touches more than one file, a refactor, or anything spec-driven") left several common complex shapes without a matching keyword, so the loop didn't always trigger when it should. The `description` field carries the matcher; the `When this skill applies` bullets carry the human-readable contract. Both updated in parallel.

## How do I verify it?

- Read the updated description at `.claude/skills/work-loop/SKILL.md:3` and the bullets at `.claude/skills/work-loop/SKILL.md:41-47`.
- Prompts like "migrate from Express to Fastify", "upgrade to React 19", "optimize this hot path", "patch CVE-XXXX", or "rework the CI pipeline" should now match the skill.

## What did you not change that you considered?

- A "Resuming across sessions" subsection in PLAN to cover multi-session migrations (state.json is per-session-scratch by design, so cross-session memory currently relies on the spec + plan checkboxes — undocumented). Worth doing, deferred per request.
- A separate `migration` skill — fails the three-times rule in this template repo.
- Persisting `state.json` across sessions — its fields are session-scoped by design; persisting would break the no-progress detector.