### PR TITLE
docs(template): route brownfield adopters to skill dependency closure

### DIFF
--- a/USING_THIS_TEMPLATE.md
+++ b/USING_THIS_TEMPLATE.md
@@ -277,6 +277,11 @@ A few high-leverage moves for the first week:
    default workflow for any feature, fix, or refactor.
 4. **Don't run Ralph yet.** Get a feel for the in-session loop first.
    Ralph amplifies whatever your conventions are; let those settle.
+5. **Adapting one pattern into an existing repo?** Use
+   `tools/install-skill.py` (Path B in Step 1) for an automated copy, or
+   read the skill's `SKILL.md` plus its `dependencies:` closure and port
+   the pattern by hand. README.md plus this file are enough to get the
+   shape; the dependency closure carries the runtime contract.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a 5th bullet to `USING_THIS_TEMPLATE.md` § What to do next.
- Routes agents adapting a pattern into an existing repo at either `tools/install-skill.py` (Path B) or the skill's `SKILL.md` plus its `dependencies:` closure.
- Closes a recurring failure mode: Opus loads `SKILL.md` alone, misses `docs/_templates/state.json` and `docs/knowledge/patterns.jsonl`, and can't reconstruct how supervisor and implementers share state across worktrees.

## Test plan

- [ ] Bullet renders correctly in `USING_THIS_TEMPLATE.md` § What to do next (rendered preview).
- [ ] Diff is one file, +5 lines.