### PR TITLE
feat(specs): add Constraints subsection to spec template

### DIFF
--- a/.claude/skills/new-spec/SKILL.md
+++ b/.claude/skills/new-spec/SKILL.md
@@ -43,6 +43,12 @@ look like?" before any code.
    - **No non-goals listed.** Specs without explicit non-goals get
      scope-crept by both humans and agents. Make the user list at least
      two things this feature explicitly will not do.
+   - **No constraints listed.** Non-goals control behavioral scope;
+     Constraints control structural scope — a spec tight on behaviors
+     can still produce a diff with three new abstraction layers if
+     implementation strategies aren't ruled out. Make the user name at
+     least one structural choice this feature won't make; examples live
+     in the template.
    - **No acceptance criteria.** Without a checklist, "done" is opinion.
 
 4. Fill in the plan second. The plan should:

--- a/docs/_templates/spec.md
+++ b/docs/_templates/spec.md
@@ -96,9 +96,44 @@ helpers — live in `plan.md`, not here.
 ## Non-goals
 
 <!--
-What are we explicitly NOT doing? This is the section that prevents scope
-creep — both from humans and from agents who'd otherwise "helpfully" expand
-the feature.
+What *behaviors* are we explicitly NOT shipping? Features, use cases, and
+user-visible capabilities the spec rules out. This is the section that
+prevents behavioral scope creep — both from humans and from agents who'd
+otherwise "helpfully" expand the feature.
+
+If the item is a whole subsystem we're declining to build (telemetry,
+i18n, SSO, offline support), file it here even though it doubles as a
+structural cut — Constraints below is for structures we'd otherwise be
+tempted to *add* in service of this feature.
+-->
+
+## Constraints
+
+<!--
+What *implementation strategies* are off the table for this feature?
+Where Non-goals enumerates behaviors we won't ship, Constraints enumerates
+the structural choices we won't make — the dependencies, module
+boundaries, or architectural surface area that this feature must not
+introduce.
+
+This is what protects the diff from sprawl. A spec can be tight on
+non-goals (no OAuth in v1) and still produce three new abstraction
+layers; Constraints is what prevents that.
+
+Distinct from the `Constrained by:` field in the header above, which
+cites external ADRs/RFCs this spec inherits from. Constraints here are
+self-imposed and feature-scoped.
+
+Each entry should name a *specific* structural choice. Generic
+guardrails ("keep it simple", "avoid over-engineering") belong in code
+review, not here.
+
+Examples:
+- No new persistence layer — extend the existing one or fail closed.
+- No new top-level dependency.
+- No new module boundary under `packages/`.
+- No new MCP server, queue, or out-of-process worker for this feature.
+- No new public API surface beyond the one Behavior describes.
 -->
 
 ## Open questions


### PR DESCRIPTION
## What does this change?

Adds a `## Constraints` subsection to `docs/_templates/spec.md`, positioned immediately after `## Non-goals`, and one new failure-mode bullet under step 3 of `.claude/skills/new-spec/SKILL.md` flagging an empty Constraints section.

## Why?

**Non-goals enumerate _behaviors_ out of scope; Constraints enumerate _implementation strategies_ out of scope.** These are different axes, and conflating them is what lets specs produce structural sprawl even when behaviors are tight.

A spec can say "no OAuth in v1" (a behavioral non-goal) and the implementation can still ship three new abstraction layers, a fresh top-level dependency, and a new module boundary under `packages/` — none of which violate any non-goal. Constraints names that second axis: structural choices the feature must not make ("no new persistence layer", "no new top-level dependency", "no new module boundary"). The new-spec failure-mode bullet ensures the author actually fills in at least one rather than leaving the section empty.

This is item #2 of the anti-over-engineering report (`workspace-personal/agent-ready-anti-overengineering-report`); item #1 (the "Keeping changes minimal" block in `AGENTS.md`) landed in `04e1f8d`.

## How do I verify it?

```bash
bash tools/hooks/pre-pr.sh   # all four layers green
```

Read the diff. Specifically:

- `docs/_templates/spec.md` — `## Constraints` appears between `## Non-goals` and `## Open questions`. The Non-goals inline guidance now names "behaviors" explicitly and points borderline cases (telemetry, i18n, SSO) at the right section. The Constraints inline guidance distinguishes itself from both Non-goals (behaviors vs strategies) and the header's `Constrained by:` field (external ADR/RFC inheritance vs self-imposed feature-scoped cuts).
- `.claude/skills/new-spec/SKILL.md` — one new bullet under step 3 spec-stage failure modes, positioned between "No non-goals listed" and "No acceptance criteria" so failure-mode order mirrors template-section order. Three sentences, matching the rhythm of "No non-goals listed".

Adversarial-reviewer ran in spec-review mode and returned `Clean — ready to commit.` after one fix round.

## What did you not change that you considered?

- **`docs/_templates/plan.md`** — Constraints are contract-level (spec). Per-task implementation choices already live in plan tasks. Adding constraint syntax to plan tasks would split the concept across two artifacts.
- **`.claude/agents/adversarial-reviewer.md`** — The reviewer's existing implementation-stage check #7 ("Architectural fit — structural pattern the spec hasn't justified") naturally fires on Constraints violations: a spec that explicitly forbids X is the strongest form of "not justified". Adding a Constraints-aware addendum is a real follow-up — it would let the reviewer mechanically promote explicit-prohibition violations to Blocker — but it's out of scope here. Follow-up issue if it matters in practice.
- **`docs/CONVENTIONS.md`** — The Constraints concept belongs in the template + skill, not in governance prose. Adding it to CONVENTIONS would split the source of truth.
- **`.claude/skills/README.md`** — The new-spec description line is about trigger phrases ("new spec", "write a spec for X"). The strengthened failure-mode check doesn't change those triggers.
- **Backfilling an existing spec** — `docs/specs/` contains only `README.md`. No specs exist to backfill; this template-shape change validates itself once the first real spec lands.
- **A new "constraints check" in the reviewer or a new sibling skill** — both would duplicate. The existing checks compose; the spec template + the new failure-mode bullet are the surgical edit.