### PR TITLE
feat(work-loop): route structural changes through pre-EXECUTE review

### DIFF
--- a/.claude/agents/adversarial-reviewer.md
+++ b/.claude/agents/adversarial-reviewer.md
@@ -14,8 +14,20 @@ to find what they missed.
 
 You handle three modes — sometimes one, often more than one in the same PR:
 
-- **Spec / plan review** before any code is written, or as part of a spec
-  amendment.
+- **Spec / plan review** before any code is written. Two triggers route
+  here, both first-class:
+  - A spec amendment in this PR (the original case).
+  - A plan that introduces structural surface area without amending a
+    spec — new module boundary, new dependency, new abstraction layer,
+    or new top-level directory. The trigger is the plan's task shape,
+    not a spec edit.
+
+  The work-loop skill's PLAN step enumerates the four trigger conditions
+  and the standard to measure against (Constraints subsection if
+  present; otherwise a documented fallback chain); that section is the
+  canonical source — don't restate it here. Same mode, same spec-stage
+  checklist below — the routing rule widens *when* you're invoked, not
+  *what* you check.
 - **Implementation review** after gates pass but before declaring done.
 - **Mixed-mode review** (the dominant case) — spec amendments + implementation
   landing in the same PR.

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -131,14 +131,54 @@ For anything beyond trivial, *think before you write code*. Concretely:
   sharpen the plan first. Discovering a missing or wrong construction test
   during EXECUTE is fine, but the fix is "update plan.md, then resume
   EXECUTE", not "skip ahead".
-- **Spec-mode adversarial review before EXECUTE.** If PLAN produced or
-  modified a spec (i.e. you ran `new-spec`, or you sharpened an existing
-  `spec.md` / `plan.md`), invoke `adversarial-reviewer` in spec mode
-  against the spec + plan and iterate to clean before EXECUTE begins.
-  Cheap-to-fix-early applies harder to specs than to code — catching a
-  vague behavior, a missing `Depends on:`, or a mismatched verification
-  mode here costs a sentence, not a re-plan. Same Profile-A caveat as
-  the post-impl review: skip if the project doesn't use the reviewer.
+- **Pre-EXECUTE adversarial review.** Invoke `adversarial-reviewer` in
+  spec/plan-review mode against the spec + plan and iterate to clean
+  before EXECUTE begins when **either** trigger fires:
+
+  1. **Spec amendment.** PLAN produced or modified a spec — you ran
+     `new-spec`, or you sharpened an existing `spec.md` / `plan.md`.
+  2. **Structural change.** Any plan task introduces structural surface
+     area. Walk this checklist; if **any** condition matches, the
+     trigger fires:
+     - New module boundary — a new directory under `packages/` or
+       `apps/`.
+     - New dependency added to package code — especially a framework,
+       ORM, or runtime.
+     - New abstraction layer — a new interface mediating between two
+       existing concrete things; a new factory, registry, locator, or
+       service-locator pattern.
+     - New top-level directory (already an RFC item per AGENTS.md;
+       restated as a trigger here because it's the most expensive of
+       the four to undo).
+
+  The structural-change trigger fires even when no spec is amended in
+  this PR — the trigger is the **plan's task shape**, not a spec edit.
+  Both triggers route to the same reviewer mode and the same spec-stage
+  checklist; what differs is the standard the reviewer measures against.
+  When the structural-change trigger fires, the reviewer checks the
+  plan against the spec's **Constraints** subsection (see
+  [`docs/_templates/spec.md`](../../../docs/_templates/spec.md)). If
+  the spec has no Constraints subsection, fall back in order to: the
+  spec's **Non-goals**, the PLAN step's **declined-pattern register**
+  (above), and the AGENTS.md **"Check before acting"** list.
+
+  **Re-fire on mid-EXECUTE re-plan.** If EXECUTE discovers a missing or
+  wrong task and updates `plan.md` per the *Design tests up front* rule
+  above, re-evaluate the structural-change checklist against the
+  updated plan. If a re-plan introduces any of the four conditions that
+  the original plan did not, the trigger re-fires and the reviewer
+  re-runs before EXECUTE resumes. This is where most over-engineering
+  emerges in practice — a tempting abstraction surfaces mid-flight, not
+  during the original PLAN — so the one-shot trigger is not enough.
+
+  Cheap-to-fix-early applies harder to specs and structural decisions
+  than to code — catching a vague behavior, a missing `Depends on:`,
+  a mismatched verification mode, or a misplaced module boundary here
+  costs a sentence; catching it post-EXECUTE costs a re-do. Gate
+  mechanism is unchanged: `state.json.plan_review_status` flips to
+  `approved` once clean; `check-done.py --phase plan` unlocks EXECUTE.
+  No new state fields. **Both triggers respect the Profile-A opt-out:**
+  skip if the project doesn't use the reviewer at all.
 - **Initialize the loop's state file.** Copy `docs/_templates/state.json`
   to `docs/specs/<feature>/state.json` and set `feature` to the spec
   slug. The file is gitignored — it's session-scratch, not history. Write
@@ -146,7 +186,7 @@ For anything beyond trivial, *think before you write code*. Concretely:
   never produces malformed JSON. Run
   `tools/check-done.py docs/specs/<feature>/state.json --phase plan`; on
   the first invocation it will exit 1 with `plan not approved` — **this
-  is the expected cue to run the spec-mode reviewer**, not a stop-and-
+  is the expected cue to run the pre-EXECUTE reviewer**, not a stop-and-
   surface signal. Once the reviewer is clean, flip
   `plan_review_status` to `approved` and re-run; exit 0 unlocks EXECUTE.
   Schema reference:
@@ -489,6 +529,13 @@ before running Ralph.** AFK doesn't mean *unconsidered* — it means
   On any non-trivial change something was tempting — a layer, a flag, a
   helper, a defensive wrapper, a tidy abstraction. A register with nothing
   in it means you weren't looking, not that there was nothing to find.
+- **Skipping pre-EXECUTE review on a structural change because "the plan
+  looks fine".** That's exactly when it doesn't. The cost of catching a
+  misplaced module boundary or an unjustified abstraction layer at PLAN
+  is a sentence; at REVIEW it's a re-do. The four structural triggers
+  (new module boundary, new dependency, new abstraction layer, new
+  top-level directory) are the cases where over-engineering is most
+  expensive to undo — that's the whole reason the trigger exists.
 - **Writing code before deciding how it'll be verified.** "I'll figure out
   the test after" is how features ship with the wrong contract. Every task
   picks its verification mode (TDD / goal-based / manual QA) during PLAN;


### PR DESCRIPTION
## What changed

A **routing extension**, not a new reviewer capability.

- `.claude/skills/work-loop/SKILL.md` — the existing pre-EXECUTE adversarial-reviewer bullet now fires on **either** trigger:
  1. **Spec amendment** (the original case), OR
  2. **Structural change** — any plan task introduces a new module boundary (new dir under `packages/` or `apps/`), new dependency (framework / ORM / runtime), new abstraction layer (interface mediating two existing concretes, factory / registry / locator / service-locator pattern), or new top-level directory.
- The structural-change trigger fires **even when no spec is amended in the PR** — the trigger is the plan's task shape, not a spec edit. Both routes call the same reviewer mode and the same spec-stage checklist below.
- When the structural trigger fires, the reviewer measures the plan against the spec's **Constraints** subsection (added in #13) if present; otherwise falls back in order to spec **Non-goals** → PLAN's **declined-pattern register** (`acea0d5`) → AGENTS.md **"Check before acting"**.
- **Re-fires on mid-EXECUTE re-plan.** If EXECUTE discovers a missing or wrong task and updates `plan.md`, the structural checklist re-evaluates against the updated plan and re-runs the reviewer if a new condition is met. Most over-engineering surfaces mid-implementation, not during the original PLAN — a one-shot trigger isn't enough.
- One anti-pattern bullet added: *"Skipping pre-EXECUTE review on a structural change because 'the plan looks fine'"*.
- `.claude/agents/adversarial-reviewer.md` — the three-modes intro acknowledges the structural-change trigger as a first-class case alongside spec-amendment. SKILL.md is the canonical source for the trigger checklist and fallback chain; the reviewer file points to it rather than restating it.

## Why

Source: recommendation **#6** in the local anti-over-engineering report. Chains off #2 (Constraints subsection in spec template, PR #13) and #3 (named-and-declined-pattern register in PLAN, `acea0d5`). The reviewer was structurally capable of spec/plan-mode review since `9c87294`, but nothing in the work-loop *routed* to it at planning time for the specific case where over-engineering is most expensive to undo: tasks that introduce new structural surface area.

## How verified

- **Goal-based check:** the two files contain the intended sections; AGENTS.md, CONVENTIONS.md, RALPH.md, and `docs/_templates/state.json` byte-identical to `main`. No new files.
- **Lint:** `tools/lint-agent-artifacts.sh`, `tools/lint-skill-deps.sh`, `tools/lint-agents-md.sh`, `tools/lint-knowledge.sh` all pass.
- **Protected regions byte-identical:** in `adversarial-reviewer.md`, the "Spec-stage checks" / "Implementation-stage checks" / "Verification-mode awareness" / "Report numbered findings" / Blockers-Concerns-Nits format / "Vague feedback" / "What you do not do" sections are unchanged. Diff is confined to the three-modes intro.
- **Adversarial-reviewer ran twice in mixed mode** (the change touches both spec-like SKILL.md content and the reviewer agent's own definition). Iteration 1: 2 Concerns + 4 Nits (1 flagged as a potential reviewer-scope-expansion finding and intentionally left). Iteration 2: 1 Concern (broken bracket-link syntax). All non-deferred findings fixed; final fix was typographic so no iteration 3 per the FIX-phase rule. Reflexive-review caveat applied — no scope-expansion findings adopted.
- **Trigger sanity-check on git log:** would correctly **not** fire on the three most recent merges (`acea0d5`, `56e71c1`, `3b678a3` — all doc/SKILL prose edits). Would correctly fire on `55b9f96` (implementer subagent = new abstraction) and `9c87294` (new `docs/knowledge/` directory + tools/hooks/).

## What's deferred

- **`tools/RALPH.md` cost-model update.** Ralph runs the loop unattended; structural-trigger re-fires on mid-EXECUTE re-plans add reviewer cycles the current cost guidance doesn't model. Out of scope for this PR per the source recommendation's "Done when"; worth a follow-up.
- **`docs/CONVENTIONS.md` promotion.** "Structural changes go through pre-EXECUTE review" arguably belongs as a durable convention rather than buried in a skill. Not in the source recommendation's "Done when"; defer until the rule has been exercised at least once in practice.
- **Knowledge-base entry.** Considered adding "extending an existing trigger is almost always better than adding a parallel mechanism" as the first `patterns.jsonl` entry. Held back per the three-times rule — this is the first occurrence. Revisit if the pattern recurs.
- **`bug-fix` skill not extended.** Existing escalation rule (bug fixes that need structural change route through `new-spec`) covers it; not duplicating the trigger.

## Test plan

- [x] `tools/lint-agent-artifacts.sh` passes
- [x] `tools/lint-skill-deps.sh` passes
- [x] `tools/lint-agents-md.sh` passes
- [x] `tools/lint-knowledge.sh` passes
- [x] AGENTS.md, CONVENTIONS.md, RALPH.md, `docs/_templates/state.json` byte-identical to `main`
- [x] No new files; diff is two files modified
- [x] adversarial-reviewer returned clean after fixes