### PR TITLE
docs(agents-md): add Non-negotiables sub-section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,20 @@ The detailed map of what lives where is in [`docs/architecture/overview.md`](doc
 
 Scope each change precisely to the request.
 
+### Non-negotiables
+
+- **Surface assumptions before building.** Name them in PLAN's trio.
+  The declined-pattern register in [`work-loop`](.claude/skills/work-loop/SKILL.md)
+  names temptations; assumptions are different — call them out separately.
+- **Stop and ask when requirements conflict.** Use the Surface verb
+  defined in [`work-loop`](.claude/skills/work-loop/SKILL.md) — emit a
+  short description and wait.
+- **Push back when warranted.** Not a yes-machine. Disagreement goes in
+  the PR description, not in silence.
+- **Prefer the boring, obvious solution.** Cleverness is expensive; see
+  the declined-pattern register in [`work-loop`](.claude/skills/work-loop/SKILL.md).
+- **Touch only what you're asked to touch.** See the rest of this section.
+
 - **Limit the diff to what the request requires — extra changes hide
   the real one from review.** If the request needs it — or would ship
   broken without it — it's in scope, even discoveries you make


### PR DESCRIPTION
## Summary

- Lists the five non-negotiables at the top of `AGENTS.md § Keeping changes minimal` so the complete set is visible in one place.
- #1 (surface assumptions) and #4 (prefer boring solutions) cross-link to the `work-loop` skill's declined-pattern register.
- #2 (stop on conflict) cross-links to the `work-loop` skill's Surface verb.
- #5 (touch only what you're asked) points to the rest of the section — its canonical home.
- AGENTS.md grew 161 → 175 lines, still under the 200-line cap.

## Test plan

- [x] `grep -A 14 "Non-negotiables" AGENTS.md` shows the heading + five bullets
- [x] `wc -l AGENTS.md` reports < 200
- [x] Cross-link anchors exist in `.claude/skills/work-loop/SKILL.md` (Surface verb at top; declined-pattern register in PLAN)