### PR TITLE
docs(specs): draft specs for RFC-0001/0002/0003

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -17,7 +17,11 @@ docs/specs/<feature>/
 
 <!-- Update this list as features are added. -->
 
-_none yet_
+| Spec | Status | Constrained by | Notes |
+| --- | --- | --- | --- |
+| [`distribution-adapters/`](distribution-adapters/spec.md) | Draft | RFC-0001 | F-spec + F-build: adapter contract, build pipeline, four reference adapters, pack.toml/plugin.json schemas, Tier-1/2/3 model. Format source-of-truth for the other two. |
+| [`self-hosting/`](self-hosting/spec.md) | Draft | RFC-0001, RFC-0002 | `make build --self` + `--check` gate; this repo eats its own dog food. Owns LF/mode/symlink comparison-rule unit tests. Depends on `distribution-adapters`. |
+| [`agent-spec-cli/`](agent-spec-cli/spec.md) | Draft | RFC-0001, RFC-0003 | `agentbundle` CLI at `packages/agentbundle/`. Library-first; stdlib only; zipapp distribution; eleven subcommands incl. `upgrade` with per-primitive granularity. Depends on `distribution-adapters`. |
 
 ## Shipped specs (archived)
 

--- a/docs/specs/agent-spec-cli/plan.md
+++ b/docs/specs/agent-spec-cli/plan.md
@@ -1,0 +1,628 @@
+# Plan: agent-spec-cli (`agentbundle`)
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Drafting
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn. When it changes substantially
+> (a different approach, not just a re-ordering), note why in the changelog
+> at the bottom.
+
+## Approach
+
+Build `packages/agentbundle/` library-first: a thin `argparse` dispatcher
+over an `agentbundle` Python package whose modules implement each subcommand
+on top of a shared core (config loading, pack discovery, the F-build render
+pipeline imported as a sibling library, the path-jail enforcement, and the
+Tier-1/2/3 file-safety primitives). The sibling `distribution-adapters` spec
+has carved F-build to live under `packages/agentbundle/agentbundle/build/`
+(four reference adapters at `agentbundle/build/adapters/{claude_code,kiro,
+copilot,codex}.py`); this CLI imports it as a regular Python package — no
+`sys.path` tricks, no subprocess to `tools/build/build.py` (that path
+remains as a thin shim calling `python -m agentbundle.build`). Land the
+shared core first as task T1 (split into T1a/T1b/T1c), the eleven
+subcommands then fan out in canonical install-workflow order — each with
+`Depends on: T1c`, parallelisable in supervisor mode. After all subcommands
+are green, T13 wires up `zipapp` distribution and T14 runs the manual QA
+round-trip on a corporate-network sandbox.
+
+## Constraints
+
+- [RFC-0003](../../rfc/0003-spec-and-cli.md) is the source RFC; its F-cli
+  enumerates the eleven subcommands and their semantics.
+- [RFC-0001](../../rfc/0001-bundle-distribution-by-adapter-spec.md) defines
+  the Tier-1/2/3 file-safety contract.
+- Sibling spec [`docs/specs/distribution-adapters/spec.md`](../distribution-adapters/spec.md)
+  owns the canonical `pack.toml` / `contract.toml` schemas, the Tier-1/2/3
+  contract details, the `.agent-ready-state.toml` schema, the
+  `.upstream.<ext>` companion semantics, the six-recipe enumeration, the
+  five primitive types (including `command`), and the location of the
+  F-build library at `packages/agentbundle/agentbundle/build/`. The CLI
+  consumes them; it does not redefine them. **This spec cannot move to
+  Approved until `distribution-adapters` is at least Approved** — see Risks.
+- Python 3.11+ stdlib only (`tomllib`, `argparse`, `hashlib`, `pathlib`).
+  Hard rule from the spec's `Never do`.
+- Library-first per RFC-0003 Unresolved Question 3's working assumption,
+  resolved by the sibling spec's relocation of F-build into this package.
+
+## Construction tests
+
+Per-task tests carry the bulk of coverage. Cross-cutting work:
+
+**Integration tests:**
+- End-to-end brownfield round-trip: `install → adapt → diff → render` against
+  `packages/agentbundle/tests/fixtures/brownfield/` (verifies AC #7, #8, #9).
+- F-build parity: byte-for-byte diff of `agentbundle render packs/core` vs.
+  `make build` output (verifies AC #4).
+- **Cross-cutting Tier-1/2/3 invariant test:** one parametrised integration
+  test walks every write-capable subcommand (`scaffold`, `install`,
+  `render`, `adapt`, `init-state`, `upgrade`, `uninstall`) against a single
+  shared fixture; asserts the Tier invariants per command. Fixture includes
+  both a `.sh` hook and a `.py` hook to pin extension preservation. Verifies
+  AC #5 across the surface.
+
+**Manual verification:**
+- Corporate-network sandbox round-trip: `gh release download` → `python
+  agentbundle.pyz install --pack core` against a brownfield repo on a host
+  that only sees Artifactory + git (verifies AC #11's manual QA tail).
+  Recorded in `packages/agentbundle/tests/manual/sandbox-round-trip.md`.
+
+## Tasks
+
+### T1a: Package scaffold + argparse skeleton + version
+
+**Depends on:** none
+
+**Tests:**
+- Goal-based check: `python -c "import agentbundle; print(agentbundle.__version__)"`
+  exits 0 and prints a version string (verifies AC #2's package shape).
+- Goal-based check: `python -c "import agentbundle.build"` exits 0 — proves
+  the F-build library (landed by `distribution-adapters` T1a) is importable
+  as a regular package from this CLI, no `sys.path` tricks (verifies AC #1's
+  library-first import boundary).
+- Unit test: `python -m agentbundle --version` prints a value parsed
+  **at import time** from the bundled `contract.toml`'s `[contract] version`
+  field. The test reads the on-disk value, imports the package, mutates
+  the on-disk `contract.toml` to a different version, then asserts that
+  `--version` still prints the original (import-time) value — proves
+  read-at-import, not read-on-every-call (verifies AC #2's parsed-and-pinned
+  invariant).
+
+**Approach:**
+- Create `packages/agentbundle/{pyproject.toml,agentbundle/__init__.py,tests/}`
+  following `packages/_example/` layout; declare zero runtime deps in
+  `pyproject.toml`. **Build backend: `setuptools` with PEP 621 metadata;
+  no plugins.**
+- Add `cli.py` (argparse skeleton with all eleven subcommands registered as
+  no-op stubs, in canonical install-workflow order — discovery-first:
+  `list-packs`, `list-targets`, `scaffold`, `install`, `validate`, `render`,
+  `adapt`, `diff`, `upgrade`, `uninstall`, `init-state`).
+- Register a `validate` subcommand stub now (sibling `distribution-adapters`
+  fix-pass 2 commits to `validate` being present at T1a).
+- Add `version.py` parsing the spec version at import time from the bundled
+  canonical `contract.toml` (`[contract] version`); the CLI version is a
+  package-level constant.
+- Assert F-build's location: `agentbundle.build` resolves under
+  `packages/agentbundle/agentbundle/build/`. If `distribution-adapters` T1a
+  hasn't landed the relocation yet, this task blocks on it (escalate, don't
+  workaround).
+
+**Done when:** the three tests above pass; `pip install -e .` inside
+`packages/agentbundle/` succeeds; `pip list --format=freeze` shows zero
+runtime deps (AC #13).
+
+### T1b: Config loader + safety primitives (Tier classifier + path-jail)
+
+**Depends on:** T1a
+
+**Tests:**
+- Unit test: `agentbundle.config.load_pack_toml(path)` returns a parsed dict
+  for the `core` pack's `pack.toml`; raises a typed error on malformed TOML
+  (verifies the config-loading invariant under AC #3's contract).
+- Unit test: `agentbundle.config.load_state(path)` round-trips a
+  `.agent-ready-state.toml` per the schema documented in the sibling
+  `distribution-adapters` spec (Tier-contract / state-file AC).
+- Unit test: `agentbundle.safety.classify(path, state)` returns
+  `Tier1 | Tier2 | Tier3` for a fixture set covering each tier (verifies
+  AC #5's classification primitive against the sibling spec's Tier
+  contract).
+- Unit test: `agentbundle.safety.write_jailed(root, relpath, content)`
+  refuses any `relpath` that resolves outside `root` (e.g. `../../foo`),
+  exiting with a typed error; verifies AC #6 (no-writes-outside-root) at
+  the primitive level.
+
+**Approach:**
+- Add `config.py`: TOML loaders for `pack.toml`, `.agent-ready-state.toml`,
+  `.adapt-discovery.toml`, `--values-from`.
+- Add `safety.py`: Tier classifier per the sibling spec's contract;
+  `.upstream.<ext>` companion writer; content-hash helpers (SHA-256);
+  path-jail enforcement (`write_jailed`) fences every write call site in
+  later tasks.
+
+**Done when:** the four unit tests pass.
+
+### T1c: `render.py` library wrapper over `agentbundle.build`
+
+**Depends on:** T1b; **also depends on** the sibling
+`distribution-adapters` task that lands the F-build render module at its
+final path under `agentbundle/build/`.
+
+**Tests:**
+- Unit test: `agentbundle.render.render_pack(pack, target)` calls into the
+  imported `agentbundle.build` render entry-point and returns the same
+  dict-of-bytes that `make build` would produce for the same pack/target
+  (verifies the library-first invariant under AC #4).
+- Unit test: the adapter list surfaced by `agentbundle.render.list_adapters()`
+  matches the registry exposed by `agentbundle.build.adapters` at runtime
+  (no baked-in constants).
+
+**Approach:**
+- Add `render.py` as a thin wrapper / re-export over `agentbundle.build`'s
+  render entry point. The F-build module path resolves at the sibling
+  `distribution-adapters` T1c (expected `agentbundle.build.render`); cite
+  that task's outcome and import the path it lands. If the sibling lands
+  it under a different module name, update this task before T2–T12 land.
+
+**Done when:** both unit tests green; T2–T12 can `from agentbundle.render
+import render_pack`.
+
+### T2: `validate` subcommand
+
+**Depends on:** T1c
+
+**Tests:**
+- TDD: `agentbundle validate packs/core` exits 0 on a valid fixture pack;
+  exits 1 with a one-line stderr reason on a fixture with malformed
+  `contract.toml` (verifies AC #12 happy + sad path, schema portion).
+- TDD: `agentbundle validate packs/core` checks recipes against the
+  six-recipe enumerated set from the sibling `distribution-adapters` spec
+  — a fixture with an unknown recipe type fails with a one-line stderr
+  naming the offending recipe.
+- TDD: `--strict` runs the conformance fixtures when present and reports
+  per-target pass/fail; when fixtures are absent (F-conformance from
+  RFC-0003 not yet landed at v1), `--strict` warns on stderr and exits zero
+  on the schema portion (verifies AC #12's partial-at-v1 carve-out).
+- TDD: a version-mismatch fixture (pack declares `[pack.adapter-contract]
+  version = "2.0"`, CLI ships `0.1`) causes `validate` to refuse with a
+  stderr line naming both versions; same refusal applies uniformly to
+  every other subcommand via the shared core gate (verifies AC #14).
+
+**Approach:**
+- Implement `agentbundle.commands.validate.run(args)`; wire it into the
+  `cli.py` dispatcher.
+- Schema conformance: parse `contract.toml`, assert required keys per the
+  schema documented in the sibling `distribution-adapters` spec; validate
+  recipe types against the six-type set.
+- Semantic conformance (`--strict`): import conformance fixtures from
+  `packages/agentbundle/tests/fixtures/conformance/` when they exist; call
+  `render.render_pack`; diff against expected output trees. When fixtures
+  are missing (v1 ship state), warn on stderr and skip.
+- **Depends on:** F-conformance fixtures from RFC-0003 (deferred to v1.1)
+  for full `--strict` mode; v1 ships schema conformance + partial strict.
+
+**Done when:** all four tests green; AC #12 holds in its partial-at-v1
+shape.
+
+### T3: `render` subcommand + F-build parity gate
+
+**Depends on:** T1c
+
+**Tests:**
+- TDD: `agentbundle render packs/core --output <tmpdir>` writes the expected
+  file tree for the `core` pack (per-target), covering all five primitive
+  types (`skill`, `agent`, `hook-body`, `hook-wiring`, `command`).
+- TDD: hooks under `packs/core/.apm/hooks/*.sh` project as `.sh`; hooks
+  under `*.py` project as `.py` (extension preservation under AC #4 and
+  the cross-cutting Tier invariant test under AC #5).
+- Goal-based: `diff -r <tmpdir>/apm/core <make-build-output>/apm/core` is
+  empty (AC #4 — F-build parity).
+
+**Approach:**
+- Wire `agentbundle.commands.render.run(args)` to call
+  `render.render_pack(pack, target)` and write the result to disk via
+  `safety.write_jailed` (path-jail enforcement is non-optional).
+- Honour `--output <dir>` (defaults to `dist/<target>/<pack>/`).
+
+**Done when:** parity diff is empty for `core` against current `make build`;
+both hook extensions preserved.
+
+### T4: `scaffold` subcommand
+
+**Depends on:** T1c
+
+**Tests:**
+- TDD: `agentbundle scaffold --output <tmpdir>` against an empty target
+  renders the `core` pack's `seeds/` tree byte-identical to expected.
+- TDD: against a target with a pre-existing `AGENTS.md`, `scaffold` leaves
+  it untouched and writes `AGENTS.upstream.md` (Tier-2 fast-path; covered
+  by the cross-cutting Tier invariant test under AC #5).
+
+**Approach:**
+- Iterate the `seeds/` content of installed packs; for each file, classify
+  the target path via `safety.classify` and either write (Tier-1 / absent)
+  or emit a companion (Tier-2 fast-path), all through `safety.write_jailed`.
+
+**Done when:** both tests green; cross-cutting Tier test (under T15) covers
+this command.
+
+### T5: `install` subcommand (constrained-network)
+
+**Depends on:** T1c
+
+**Tests:**
+- TDD: `agentbundle install --pack core <fixture-catalogue-uri>` into the
+  brownfield fixture leaves all pre-existing files unchanged and produces
+  `.upstream.<ext>` companions for every collision (AC #7).
+- TDD: after install, `.agent-ready-state.toml` records a SHA-256 hash for
+  every Tier-1 path the install wrote, per the schema owned by the sibling
+  `distribution-adapters` spec.
+- TDD: install pack B into a tree that already has pack A installed; the
+  resulting `.agent-ready-state.toml` contains both `[pack.A]` and
+  `[pack.B]` tables — existing tables untouched, new table merged (AC #7
+  merge clause).
+- TDD: catalogue URI grammar — one test row each for:
+  - Local relative path (`./catalogues/foo`) — resolved directly; **assert
+    no `subprocess` is invoked** (mock-or-trace at `subprocess.run` /
+    `subprocess.Popen`, asserting zero invocations).
+  - Local absolute path (`/abs/path/to/catalogue`).
+  - Git over HTTPS with tag (`git+https://github.com/owner/repo@v1.0`) —
+    fetched via `urllib.request` against
+    `https://github.com/owner/repo/archive/refs/tags/v1.0.tar.gz`,
+    extracted via `tarfile`; assert no `subprocess` invocation.
+  - Git over HTTPS with branch (`git+https://github.com/owner/repo@main`)
+    — fetched via `.../archive/refs/heads/main.tar.gz`; assert no
+    `subprocess` invocation.
+  - Git over HTTPS with SHA (`git+https://github.com/owner/repo@deadbeef`)
+    — fetched via `.../archive/deadbeef.tar.gz`; assert no `subprocess`
+    invocation.
+  - Git over HTTPS pointing at unreachable host — exits non-zero with a
+    one-line stderr naming the tarball URL the CLI tried to fetch.
+  - Git over SSH (`git+ssh://git@github.com:owner/repo`) — exits
+    non-zero with stderr "SSH git URLs deferred to v1.1; use https or
+    local path." (Deferred at v1 per Option A.)
+- TDD: a malicious fixture pack whose projection rule resolves to
+  `../../malicious` is refused with exit non-zero (cross-cutting AC #6
+  no-writes-outside-root).
+
+**Approach:**
+- Resolve the catalogue URI to a local pack directory:
+  - Local paths: used directly.
+  - `git+https://github.com/<owner>/<repo>[@<ref>]`: parse with `urllib`;
+    construct the GitHub archive URL
+    (`https://github.com/<owner>/<repo>/archive/refs/tags/<ref>.tar.gz`
+    for tags, `…/archive/refs/heads/<ref>.tar.gz` for branches,
+    `…/archive/<ref>.tar.gz` for commit SHAs — disambiguate by trying
+    tag first, then branch, then SHA, with a small retry budget); fetch
+    via `urllib.request`; extract via `tarfile` into a tempdir.
+  - `git+ssh://...`: refuse with the v1.1-deferral message.
+  - No `subprocess` invocation in any `install` path.
+- For each file in the pack's projection, apply the Tier-1/2/3 contract via
+  `safety.classify`; write hashes to `.agent-ready-state.toml` atomically
+  (tmp-file + `os.replace`); merge into existing tables rather than
+  overwriting.
+
+**Done when:** all five test rows green; AC #7 holds (no-clobber + merge);
+state file is valid TOML.
+
+### T6: `adapt` subcommand
+
+**Depends on:** T1c, T5
+
+**Tests:**
+- TDD: against a fixture with `<adapt:PROJECT_NAME>` markers, `adapt
+  --values-from values.toml` substitutes every marker (AC #8). The CLI is
+  the resolver for adopter installs per the sibling spec's carve-out.
+- TDD: for every `.upstream.<ext>` companion in the fixture, the resulting
+  `.adapt-pending.md` lists the companion path and a one-line diff summary
+  (AC #8).
+- TDD: `adapt` reads `.adapt-discovery.toml` accepted/declined entries and
+  applies accepted ones; the file is byte-identical before and after the run
+  (AC #8 — CLI never writes it).
+- TDD: `adapt --ci` against a fixture with unresolved `.upstream.<ext>`
+  companions exits non-zero with stderr listing the pending companions
+  (AC #9).
+- TDD: `adapt --ci` against a fixture where every companion has been
+  removed exits zero (AC #9 — "resolved" means no companion file on disk).
+
+**Approach:**
+- Walk projected files for substitution; walk `.upstream.<ext>` companions
+  for report generation; read `.adapt-discovery.toml` and apply accepted
+  moves deterministically.
+- Refuse to write `.adapt-discovery.toml` — surface in tests via a
+  pre/post hash comparison.
+
+**Done when:** AC #8 and AC #9 both hold; cross-cutting Tier test (under
+T15) covers Tier invariants for this command.
+
+### T7: `list-targets` subcommand
+
+**Depends on:** T1c
+
+**Tests:**
+- TDD: `agentbundle list-targets` prints one row per adapter the CLI
+  supports, in stable order; exit 0.
+- TDD: the printed adapter list matches the runtime registry exposed by
+  `agentbundle.build.adapters` (no baked-in constants — a test injects a
+  monkey-patched extra adapter and the output reflects it).
+
+**Approach:**
+- Query the imported `agentbundle.build.adapters` registry at runtime;
+  format as a stable table.
+
+**Done when:** both tests green; output is deterministic across runs.
+
+### T8: `list-packs` subcommand
+
+**Depends on:** T1c
+
+**Tests:**
+- TDD: against a fixture catalogue with two packs, `list-packs <uri>`
+  prints both rows with name, version, description, dependencies.
+
+**Approach:**
+- Resolve the catalogue URI (same grammar as T5); enumerate
+  `packs/*/pack.toml`; format as a stable table.
+
+**Done when:** test green.
+
+### T9: `diff` subcommand
+
+**Depends on:** T1c, T3
+
+**Tests:**
+- TDD: against a pack whose projection is in sync with `pack.toml`, `diff`
+  exits 0; against a tampered projection, exits 1 with a one-line list of
+  drifted paths.
+
+**Approach:**
+- Re-run `render.render_pack` in memory; compare against on-disk projection
+  byte-by-byte; report drift.
+
+**Done when:** both rows of the test green.
+
+### T10: `init-state` subcommand
+
+**Depends on:** T1c
+
+**Tests:**
+- TDD: against a directory whose tree matches a known pack's projection,
+  `init-state --pack core` writes `.agent-ready-state.toml` with the right
+  SHA-256 hashes (matches T5's hashing logic).
+- TDD (Tier invariant — local; cross-cutting test in T15 also covers this):
+  `init-state` writes only `.agent-ready-state.toml` (a Tier-1 path per the
+  sibling spec's contract); no Tier-2 or Tier-3 path is touched.
+
+**Approach:**
+- Hash every projected path; write the state file atomically via
+  `safety.write_jailed`.
+
+**Done when:** both tests green; state file is parseable by
+`config.load_state`.
+
+### T11: `uninstall` subcommand
+
+**Depends on:** T1c, T5
+
+**Tests:**
+- TDD: `uninstall --pack core` against the post-install brownfield fixture
+  removes every Tier-1 file the install wrote, warns on Tier-2 (offers
+  keep-or-remove-with-backup; defaults to keep in non-interactive mode),
+  and leaves all Tier-3 files **byte-identical** before and after (explicit
+  byte-identity assertion, not just an existence check). Covered by the
+  cross-cutting Tier invariant test in T15.
+- TDD: `.agent-ready-state.toml` no longer references the uninstalled pack
+  after the run (the `[pack.<name>]` table is removed; other packs'
+  tables remain untouched).
+
+**Approach:**
+- Read `.agent-ready-state.toml` for the pack's Tier-1 paths; for each,
+  hash-compare against current content; if matched, remove; if drifted
+  (Tier-2), preserve and warn.
+
+**Done when:** both tests green.
+
+### T12: `upgrade` subcommand with per-primitive granularity
+
+**Depends on:** T1c, T5
+
+**Tests:**
+- TDD: `upgrade --pack core --to v0.2` against the post-install fixture
+  applies the whole-pack delta and updates `.agent-ready-state.toml`.
+- TDD (parametrised over primitive type): `upgrade --pack core --skill X
+  --to v0.2`, `--agent X`, `--hook X`, `--seed X`, `--command X` each
+  move only that primitive's files; `.agent-ready-state.toml` records the
+  mixed-version pack state with per-primitive `tier-1-files` /
+  `tier-2-files` lists under e.g. `[pack.core.skill.X]` (verifies AC #10
+  first clause across all five primitive types).
+- TDD: a subsequent whole-pack `upgrade --pack core --to v0.3` against the
+  mixed-state fixture surfaces the mixed state on stderr before proceeding
+  (verifies AC #10 second clause).
+- TDD: `--skill foo` where `foo` is not a primitive in the pack exits
+  non-zero with one-line stderr "primitive 'foo' not in pack core"
+  (verifies AC #10 error clause). Equivalent test for each of the other
+  four primitive flags.
+- TDD: a `.sh` hook upgraded retains its `.sh` extension; a `.py` hook
+  upgraded retains its `.py` extension (extension-preservation under
+  AC #4 / AC #5).
+
+**Approach:**
+- Identify a primitive's file set from `pack.toml`: the named primitive's
+  `source-path` (or equivalent key per the sibling spec) is resolved to a
+  glob, intersected with the projection adapter set the install used.
+- Compare current pack version (from `.agent-ready-state.toml`) against
+  `--to`; compute file delta; apply Tier-1/2/3 contract per file via
+  `safety.classify` + `safety.write_jailed`; record per-primitive versions
+  in the state file when `--skill`/`--agent`/`--hook`/`--seed`/`--command`
+  is passed.
+- State-file shape for mixed-version: under `[pack.<name>]`, sub-tables
+  per primitive (e.g. `[pack.core.skill.work-loop]` with `tier-1-files =
+  [...]`, `tier-2-files = [...]`, `version = "v0.2"`) when that primitive's
+  version diverges from the pack-wide version.
+
+**Done when:** all test rows green.
+
+### T13: `zipapp` distribution build
+
+**Depends on:** T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T15
+
+(T15 added so `zipapp` distribution can't ship before the Tier invariants
+are proven across the write-capable subcommand matrix.)
+
+**Tests:**
+- Goal-based: `python -m zipapp packages/agentbundle/agentbundle -o
+  dist/agentbundle.pyz -m agentbundle.cli:main` produces a runnable file.
+- Goal-based: `python dist/agentbundle.pyz --version` exits 0 and prints
+  the CLI + spec versions (AC #2, AC #11).
+
+**Approach:**
+- Add a `make zipapp` target (or `scripts/build-zipapp.sh`) that bundles
+  `agentbundle/` (including the embedded `agentbundle/build/` library)
+  into a single `.pyz`; verify it loads with stdlib only.
+
+**Done when:** both checks green; the `.pyz` runs on a Python 3.11 venv
+with `--no-site-packages`.
+
+### T14: Manual QA — corporate-network sandbox round-trip
+
+**Depends on:** T13
+
+**Tests:**
+- Manual QA: `gh release download` → `python agentbundle.pyz install --pack
+  core <catalogue-git-url>` against a brownfield repo on a host that only
+  reaches Artifactory + git. Result recorded at
+  `packages/agentbundle/tests/manual/sandbox-round-trip.md` per the
+  *Visual / manual QA* contract in the work-loop skill.
+
+**Approach:**
+- Provision a sandbox VM (corporate-network image); follow the recorded
+  steps; capture stdout/stderr and resulting tree state; note any
+  deviation in the recorded report.
+
+**Done when:** the recorded report shows all install + adapt steps
+succeeded; AC #11's manual QA tail holds.
+
+### T15: Cross-cutting Tier-1/2/3 invariant integration test
+
+**Depends on:** T4, T5, T3, T6, T10, T12, T11
+
+**Tests:**
+- One parametrised integration test walks every write-capable subcommand
+  against a single shared fixture and asserts the three Tier invariants per
+  command: Tier-1 may change; Tier-2 produces a `.upstream.<ext>` companion
+  (original byte-identical); Tier-3 paths are byte-identical before and
+  after. The parametrisation pins the **exact invocation** tested per
+  subcommand:
+  - `scaffold --output <root>`
+  - `install --pack core <fixture-catalogue-uri>`
+  - `render packs/core --output <root>`
+  - `adapt --values-from <fixture-values.toml>` (the write-capable form)
+  - `init-state --pack core`
+  - `upgrade --pack core --to v0.2`
+  - `uninstall --pack core`
+- Negative invariant row: `adapt` **without** `--values-from` makes no
+  Tier-1 changes (read-only mode — only writes `.adapt-pending.md`, which
+  is a Tier-1 path; assert no other Tier-1 file is modified).
+- Fixture includes one `.sh` hook and one `.py` hook to pin
+  extension-preservation across `render` and `upgrade`.
+- Fixture includes a path-jail probe pack (projection rule resolving to
+  `../../malicious`) that every write-capable command refuses with exit
+  non-zero (cross-cutting AC #6).
+
+**Approach:**
+- Lives at `packages/agentbundle/tests/integration/test_tier_invariants.py`;
+  parametrises over the seven subcommands and the two hook extensions.
+
+**Done when:** matrix of (subcommand × tier × hook-extension) all green.
+
+## Rollout
+
+`packages/agentbundle/` lands as a new package — no behaviour change to
+existing surfaces. Distribution channels light up in order: `zipapp` via
+GitHub Releases (T13) → `pip install` via Artifactory (deferred past v1)
+→ Homebrew formula (deferred past v1). The CLI is opt-in by definition;
+adopters who installed via APM or Claude plugins keep using those tools.
+No flag-gating required.
+
+## Risks
+
+- **Hard dependency on `distribution-adapters` spec.** This spec consumes
+  `pack.toml`'s `[pack.adapter-contract]` table, the Tier-1/2/3 file-safety
+  contract, the `.agent-ready-state.toml` schema, the `.upstream.<ext>`
+  semantics, the six-recipe enumeration, the five primitive types, and the
+  relocated F-build library at `packages/agentbundle/agentbundle/build/`.
+  If `distribution-adapters` lands with a different shape than this plan
+  assumes, every subcommand reading those structures has to chase it.
+  **Mitigation:** don't move this spec to Approved until
+  `distribution-adapters` is at least Approved; track its status during
+  PLAN review; T1c explicitly blocks on the sibling's F-build relocation
+  task.
+- **F-build render code not importable as a regular package.** Resolved by
+  the sibling spec's relocation to `packages/agentbundle/agentbundle/build/`.
+  T1a's second test (`import agentbundle.build` exits 0) is the canary;
+  if the sibling lands the relocation differently (e.g. under a different
+  module name), pin the import path in T1c and update this plan.
+- **Conformance fixtures not yet defined.** T2's `--strict` mode needs the
+  F-conformance fixtures (sibling work under RFC-0003, deferred to v1.1).
+  v1 ships schema conformance now and `--strict` is partial — warns on
+  stderr when fixtures absent. **Mitigation:** explicit `Depends on:`
+  marker in T2; AC #12 carves out the partial-at-v1 behaviour.
+- **Tier-2 hash-comparison cost on large projections.** Hashing every
+  projected file on every `install`/`upgrade` call is O(projection size).
+  Acceptable at the `core` pack scale; revisit if a future pack ships
+  hundreds of files. **Mitigation:** measure on the brownfield fixture and
+  surface if it exceeds a perceptible threshold.
+- **`zipapp` distribution under stdlib-only is unusual.** Most Python CLIs
+  carry dependencies; the stdlib-only constraint is harder to maintain
+  over time (every contributor will want to add `click` or `rich`).
+  **Mitigation:** the `Never do` rail catches this in review, and the
+  sibling `distribution-adapters` spec's `lint-build.sh` stdlib-import
+  audit catches non-stdlib imports structurally.
+- **GitHub archive endpoint availability.** If GitHub's
+  `archive/refs/tags/...`, `archive/refs/heads/...`, or `archive/<sha>...`
+  endpoint changes path, rate-limits, or quota-restricts unauthenticated
+  fetches, `install` for `git+https://` breaks. **Mitigation:** small
+  retry budget on transient errors; on failure, the one-line stderr names
+  the exact tarball URL the CLI tried to fetch, so the adopter can
+  reproduce out-of-band. If the endpoint is permanently displaced, ship a
+  patch release switching to whichever GitHub-supported HTTPS path works
+  — still stdlib, still no `git` subprocess.
+
+## Changelog
+
+- 2026-05-22: initial plan.
+- 2026-05-22: fix-pass 2. Switched `install` `git+https://` fetch from a
+  documented single `git` subprocess call site to pure stdlib
+  `urllib.request` + `tarfile` against GitHub's archive endpoint — closes
+  the `Never do` subprocess carve-out entirely. `git+ssh://` deferred to
+  v1.1 with an explicit refuse-and-explain message. T5 test grammar
+  rewritten to cover tag/branch/SHA HTTPS, SSH-deferred refusal,
+  unreachable URL, plus a `subprocess`-not-invoked assertion. T13 now
+  depends on T15 so `zipapp` can't ship before Tier invariants are
+  proven. T15 parametrisation pins exact invocations per subcommand and
+  adds a negative-invariant row (`adapt` without `--values-from` makes no
+  Tier-1 changes). Spec `--version` AC and T1a test rephrased to verify
+  read-at-import (mutate-on-disk-after-import check). Added AC for
+  `agentbundle.build.adapters` registry contract (`name → AdapterModule`
+  at import time). Promoted "tag the repo at release" from a Risk
+  mitigation to a ship-time AC. Reordered the canonical subcommand list
+  discovery-first across spec and plan, with a note acknowledging
+  RFC-0003's descriptive ordering. Cited the sibling spec's
+  stdlib-import audit (`lint-build.sh`) as the structural enforcement
+  for the no-third-party-dep rail. Added GitHub archive endpoint risk
+  row.
+- 2026-05-22: post-adversarial-review fix pass. T1 split into T1a/T1b/T1c
+  (scaffold, safety primitives, render wrapper). Added T15 (cross-cutting
+  Tier invariant integration test). Pinned setuptools/PEP 621 as build
+  backend. Tightened subprocess rail to "never except `gh`" (with a
+  documented single `git` call site in `install`). Added explicit
+  dependencies on the sibling `distribution-adapters` spec for F-build
+  relocation, Tier contract, `.agent-ready-state.toml` schema,
+  `.upstream.<ext>` semantics, the six-recipe enumeration, and the five
+  primitive types (including `command`). Canonicalised subcommand order
+  to install-workflow sequence. Expanded T5 with full catalogue URI
+  grammar test rows and state-file merge semantics. Expanded T12 with
+  per-primitive file-set identification, mixed-version state shape, and
+  primitive-not-found error. Added F-conformance dependency marker to T2.
+  Added `command` primitive to T3 and T12. Added hook extension
+  preservation (`.sh` and `.py`) across T3, T12, and T15. Added
+  spec-version-tag risk row.

--- a/docs/specs/agent-spec-cli/spec.md
+++ b/docs/specs/agent-spec-cli/spec.md
@@ -1,0 +1,284 @@
+# Spec: agent-spec-cli (`agentbundle`)
+
+- **Status:** Draft
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** [RFC-0003](../../rfc/0003-spec-and-cli.md) (source);
+  hard-depends on [RFC-0001](../../rfc/0001-bundle-distribution-by-adapter-spec.md)
+  (F-spec + F-build) and the sibling spec
+  [`docs/specs/distribution-adapters/spec.md`](../distribution-adapters/spec.md)
+  (defines `pack.toml`, `contract.toml`, the **Tier-1/2/3 file-safety
+  contract**, the **`.agent-ready-state.toml` schema**, the
+  **`.upstream.<ext>` companion semantics**, the **six-recipe enumeration**,
+  and the **five primitive types** this CLI honours).
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+Ship `agentbundle`, the reference CLI for the published adapter contract, as a
+Python 3.11+ stdlib-only package at `packages/agentbundle/`. The CLI is the
+deterministic counterpart to the LLM `adapt-to-project` skill: it imports the
+render pipeline from `agentbundle.build` (the F-build library introduced by
+the sibling `distribution-adapters` spec) and exposes eleven pack-aware
+subcommands — in canonical install-workflow order (discovery-first):
+`list-packs`, `list-targets`, `scaffold`, `install`, `validate`, `render`,
+`adapt`, `diff`, `upgrade`, `uninstall`, `init-state` — to adopters in constrained-network or CI
+environments. Success means an adopter on a corporate-network sandbox can
+(1) fetch a `zipapp` build via `gh release download`, (2) `install` the `core`
+pack into a brownfield repo without clobbering pre-existing files, (3) `adapt`
+against a `--values-from` TOML to resolve `<adapt:NAME>` markers from
+`.adapt-discovery.toml` and surface `.upstream.<ext>` companions for human
+merge, and (4) round-trip `validate` + `render` against the conformance
+fixtures with byte-identical output to RFC-0001's `make build`. The CLI is
+library-first: F-build's render code is imported as `agentbundle.build`, not
+invoked via `subprocess`. Every subcommand respects the Tier-1/2/3 file-safety
+contract defined in the sibling `distribution-adapters` spec — Tier-1 may be
+written, Tier-2 is preserved with a `.upstream.<ext>` companion, Tier-3 is
+never touched. The CLI handles **five** primitive types (`skill`, `agent`,
+`hook-body`, `hook-wiring`, `command`) and **six** recipe types as enumerated
+in the sibling spec. No LLM calls, no third-party Python dependencies, no
+writes outside the adopter's repo root.
+
+## Boundaries
+
+The three-tier guard that keeps an implementing agent inside the lines.
+*Always do* applies without asking; *Ask first* requires human sign-off
+before proceeding; *Never do* is a hard rule, even under time pressure.
+
+### Always do
+
+- Honour the Tier-1/2/3 file-safety contract on every subcommand that writes:
+  Tier-1 paths (adapter-contract-projected, recorded in
+  `.agent-ready-state.toml`) may be created or overwritten; Tier-2 paths (same
+  paths, but adopter-edited since install per content-hash comparison) get a
+  `.upstream.<ext>` companion next to the original; Tier-3 paths (everything
+  else) are read-only to the CLI. The contract, the
+  `.agent-ready-state.toml` schema, and the `.upstream.<ext>` semantics are
+  owned by the sibling `distribution-adapters` spec (see its Tier-contract
+  AC and state-file AC); this CLI consumes them verbatim.
+- Import the render pipeline from `agentbundle.build` (the F-build library
+  introduced by the sibling spec when it moved F-build under
+  `packages/agentbundle/agentbundle/build/`); reuse one implementation rather
+  than calling `make build` via `subprocess`. Adapters resolve via the
+  imported `agentbundle.build.adapters` registry at runtime, not from baked-in
+  constants. The registry contract: `agentbundle.build.adapters` exposes a
+  mapping `name → AdapterModule` populated at import time (sibling
+  `distribution-adapters` spec pins the `AdapterModule` shape).
+- Fetch `git+https://` catalogue URIs via `urllib.request` against GitHub's
+  archive endpoint (`https://github.com/<owner>/<repo>/archive/refs/tags/<tag>.tar.gz`,
+  `…/archive/refs/heads/<branch>.tar.gz`, or `…/archive/<sha>.tar.gz`) and
+  extract with `tarfile` — pure stdlib, no `git`/`gh` subprocess. SSH git URLs
+  are deferred to v1.1.
+- Resolve the spec version a pack declares by reading `[pack.adapter-contract]
+  version` in its `pack.toml`; refuse to operate on packs whose major version
+  disagrees with the CLI's own and emit a clear refuse-and-explain message.
+  The CLI's own spec version is parsed at import time from the bundled
+  canonical `contract.toml` (`[contract] version`), not hardcoded.
+- Confine every write-capable subcommand to paths under the configured
+  `--output <dir>` or the resolved repo root; refuse and exit non-zero on any
+  attempt to project outside that root (e.g. a malicious projection rule
+  resolving to `../../`).
+- Preserve the source extension of hook files when projecting and upgrading:
+  `.sh` hooks remain `.sh`, `.py` hooks remain `.py`.
+- Exit non-zero with a one-line stderr reason on any failure (validation,
+  hash mismatch refusal, version mismatch, missing pack, primitive-not-found,
+  unreachable catalogue URI); exit zero only when the subcommand's contract
+  was satisfied.
+- Read configuration and state exclusively from TOML files (`pack.toml`,
+  `.agent-ready-state.toml`, `.adapt-discovery.toml`, `--values-from <file.toml>`).
+
+### Ask first
+
+- Adding a new subcommand or flag beyond the eleven enumerated in
+  RFC-0003's F-cli. The shape is fixed at this RFC's resolution; expansion
+  goes through a new RFC or spec amendment.
+- Changing the CLI's name from `agentbundle` (committed at this spec) or the
+  package path from `packages/agentbundle/`.
+- Introducing a new persisted on-disk artifact (file the CLI writes that
+  isn't already in this list: Tier-1 projected files, `.agent-ready-state.toml`,
+  `.adapt-pending.md`, `.upstream.<ext>` companions).
+
+### Never do
+
+- Never write outside the adopter's repo root (the directory containing
+  `pack.toml` for the operative pack, or the `--output <dir>` target if
+  explicitly passed). A path-jail check fences every write call site.
+- Never clobber a Tier-2 file (content hash differs from
+  `.agent-ready-state.toml`); always emit a `.upstream.<ext>` companion
+  instead and let `adapt` or the LLM skill resolve the merge.
+- Never touch a Tier-3 file (a path not recorded in
+  `.agent-ready-state.toml` under any installed pack's projection).
+- Never add a third-party Python dependency. Stdlib only — `tomllib`,
+  `argparse`, `hashlib`, `pathlib`, `urllib`, `tarfile`. The sibling
+  `distribution-adapters` spec commits to a stdlib-import audit in its build
+  (`lint-build.sh` or equivalent); that audit is the structural enforcement
+  for this rail — cite it rather than re-implement here.
+- Never `subprocess` anything except `gh` for release download. No shelling
+  out to `make`, `git`, `diff`, or any other host binary. `git+https://`
+  fetch goes through `urllib.request` + `tarfile`, not a `git` subprocess.
+- Never invoke an LLM, spawn a Claude session, or call any external
+  inference API. The CLI is the deterministic counterpart to LLM skills.
+- Never write `.adapt-discovery.toml` from the CLI; the CLI only *reads*
+  it (the `adapt-to-project` LLM skill writes it). `<adapt:NAME>` marker
+  resolution is the CLI's job (per the sibling `distribution-adapters` spec
+  carve-out: `make build --self` resolves markers; adopter installs leave
+  markers unresolved for `agentbundle adapt` to consume). Plugin-installed
+  pack marker resolution is deferred to the `adapt-to-project` LLM skill;
+  out of scope for v1 (RFC-0001 Open Q3).
+
+## Testing Strategy
+
+Each user-visible outcome from the Objective is paired with a mode:
+
+- **Per-subcommand contract — TDD.** Each of the eleven subcommands has a
+  contract (inputs, on-disk outputs, exit code, stderr message on failure)
+  small enough to pin with a fast unit/integration test. Tests drive the
+  implementation; the test asserts on the post-state of a fixture directory
+  and on the captured stdout/stderr, not on internal calls.
+- **Tier-1/2/3 file-safety invariants — TDD (cross-cutting integration).**
+  A single parametrised integration test walks every write-capable
+  subcommand (`scaffold`, `install`, `render`, `adapt`, `init-state`,
+  `upgrade`, `uninstall`) against the same Tier-1/2/3 fixture and asserts
+  the three invariants per command: Tier-1 may change; Tier-2 produces a
+  `.upstream.<ext>` companion (original byte-identical); Tier-3 paths are
+  byte-identical before and after. The fixture covers both hook extensions
+  (`.sh` and `.py`) to pin extension-preservation for `render` and `upgrade`.
+- **F-build parity — goal-based check.** A one-liner diffs `agentbundle render
+  packs/core --output /tmp/out` against `make build` output for the `core`
+  pack; the two outputs must match byte-for-byte. This pins that the CLI uses
+  the same render code as F-build (imported as `agentbundle.build`), not a
+  fork.
+- **Brownfield end-to-end — TDD on fixture + manual QA on a real sandbox.**
+  A fixture repo at `packages/agentbundle/tests/fixtures/brownfield/` carries
+  pre-existing `AGENTS.md`, `docs/CHARTER.md`, and adopter-owned source files;
+  an integration test runs `install` → `adapt --values-from values.toml` →
+  `diff` and asserts the resulting tree. The corporate-network sandbox path
+  (`gh release download` → `python agentbundle.pyz install`) is **manual QA**
+  recorded in the plan because we can't simulate Artifactory + PAT in CI.
+- **`zipapp` distribution — goal-based check.** A build step produces
+  `dist/agentbundle.pyz`; `python dist/agentbundle.pyz --version` prints the
+  CLI version plus the spec version it ships against. Exit 0 is the check.
+- **Conformance suite execution — TDD (partial at v1).** `agentbundle
+  validate packs/core` runs schema conformance now. `agentbundle validate
+  --strict packs/core` runs the conformance fixtures (one per target adapter
+  at v0.1) and asserts pass/fail; **behavioural `--strict` is partial at v1
+  because the F-conformance fixtures are owned by RFC-0003's deferred
+  conformance work** — when fixtures are absent, `--strict` warns and exits
+  zero on the schema portion. Full `--strict` lands at v1.1 once
+  F-conformance ships.
+
+The typical mix is heavy on TDD because most CLI behaviour is contract-shaped;
+`zipapp` distribution and the sandbox round-trip are the goal-based and manual
+QA tails respectively.
+
+## Acceptance Criteria
+
+- [ ] `packages/agentbundle/` exists with `pyproject.toml`, `agentbundle/`,
+      and `tests/`, following the `packages/_example/` layout. The package
+      contains `agentbundle/build/` (F-build library, owned by the sibling
+      `distribution-adapters` spec) and the CLI imports it cleanly as
+      `import agentbundle.build` — no `sys.path` manipulation, no subprocess
+      to `tools/build/build.py`.
+- [ ] `python -m agentbundle --version` prints both the CLI version and the
+      spec version it ships against (`v0.1` at first release). The spec
+      version value is parsed **at import time** from the bundled canonical
+      `contract.toml`'s `[contract] version` field. A test proves the
+      read-at-import semantics: it captures the on-disk value, imports the
+      package, mutates `contract.toml` on disk to a different version, then
+      asserts that `python -m agentbundle --version` still prints the
+      original (import-time) value — not the post-mutation value.
+- [ ] All eleven subcommands from RFC-0003 F-cli, in canonical
+      install-workflow order (discovery-first: `list-packs`, `list-targets`,
+      `scaffold`, `install`, `validate`, `render`, `adapt`, `diff`,
+      `upgrade`, `uninstall`, `init-state`), are implemented, each with a
+      passing contract test asserting exit code, stdout/stderr, and on-disk
+      post-state for at least one happy-path fixture. RFC-0003 enumerates
+      the same eleven subcommands in a different (descriptive) order; this
+      spec freezes the canonical install-workflow order.
+- [ ] `agentbundle render packs/core --output /tmp/out` produces a tree that
+      is byte-identical to `make build` output for `packs/core` (F-build parity
+      gate). `render` handles all five primitive types (`skill`, `agent`,
+      `hook-body`, `hook-wiring`, `command`) and preserves source extensions
+      for hook files (`.sh` and `.py`).
+- [ ] A single cross-cutting integration test proves the Tier-1/2/3
+      invariants hold for every write-capable subcommand (`scaffold`,
+      `install`, `render`, `adapt`, `init-state`, `upgrade`, `uninstall`)
+      against one shared fixture: Tier-1 may change; Tier-2 paths produce a
+      `.upstream.<ext>` companion and the original is unchanged; Tier-3
+      paths are byte-identical before and after. The fixture covers both
+      `.sh` and `.py` hooks to pin extension preservation.
+- [ ] Every write-capable subcommand refuses to write outside the configured
+      `--output` / repo root: a fixture pack with a projection rule
+      attempting `../../malicious` is rejected with exit non-zero and a
+      one-line stderr "refusing to write outside repo root: <path>".
+- [ ] `agentbundle install --pack core <catalogue-uri>` at v1 accepts two
+      catalogue URI forms: local paths (relative or absolute, e.g.
+      `./catalogues/foo` or `/abs/path`) and git over HTTPS
+      (`git+https://github.com/<owner>/<repo>[@<ref>]` where `<ref>` is a
+      tag, branch, or commit SHA). HTTPS fetch goes through
+      `urllib.request` + `tarfile` against GitHub's
+      `https://github.com/<owner>/<repo>/archive/...` endpoint (no `git`
+      subprocess). Unreachable URLs exit non-zero with a one-line stderr
+      naming the tarball URL the CLI tried to fetch. `git+ssh://...` URLs
+      exit non-zero with stderr "SSH git URLs deferred to v1.1; use https
+      or local path."
+- [ ] `agentbundle install --pack <new>` against the brownfield fixture
+      leaves all pre-existing adopter files unchanged and drops
+      `.upstream.<ext>` companions for every Tier-2 collision. When an
+      `.agent-ready-state.toml` already exists (e.g. from a prior `install
+      --pack <other>`), the new install **merges**: adds a `[pack.<new>]`
+      table without modifying existing `[pack.<other>]` tables.
+- [ ] `agentbundle adapt --values-from tests/fixtures/values.toml` resolves
+      every `<adapt:NAME>` marker in projected files (the CLI is the
+      resolver for adopter installs, per the sibling spec's carve-out),
+      writes a `.adapt-pending.md` report listing each `.upstream.<ext>`
+      companion with a one-line diff summary, and reads
+      `.adapt-discovery.toml` accepted/declined entries without writing to
+      it.
+- [ ] `agentbundle adapt --ci` exits non-zero whenever any `.upstream.<ext>`
+      companion remains on disk (so CI flags pending companions for human
+      review). "Resolved" means the companion file no longer exists; the
+      `--ci` exits-zero path is verified by a fixture where every companion
+      has been removed.
+- [ ] `agentbundle upgrade --pack <name> --skill <skill> --to <version>`
+      moves only the named primitive; `.agent-ready-state.toml` records the
+      resulting mixed-version pack state and subsequent whole-pack upgrades
+      surface the mixed state before proceeding. The same flag shape works
+      for `--agent`, `--hook`, `--seed`, and `--command` (five primitive
+      types). Naming a non-existent primitive (`--skill foo` where `foo`
+      isn't in the pack) exits non-zero with one-line stderr "primitive
+      'foo' not in pack <pack>".
+- [ ] `agentbundle validate packs/core` exits 0 on schema-valid v0.1
+      fixtures and exits 1 with a one-line reason on a schema-invalid
+      fixture. `agentbundle validate --strict packs/core` additionally runs
+      the v0.1 conformance fixtures **when they exist** (full strict
+      behaviour deferred to v1.1 alongside F-conformance from RFC-0003);
+      when fixtures are absent, `--strict` warns on stderr and exits zero
+      on the schema portion. `validate` checks recipes against the
+      six-type enumerated set defined in the sibling `distribution-adapters`
+      spec.
+- [ ] `dist/agentbundle.pyz` runs end-to-end on a Python 3.11 environment
+      with no third-party packages installed (`pip list` shows only stdlib).
+      Manual QA in a corporate-network sandbox confirms `gh release download`
+      → `python agentbundle.pyz install` works.
+- [ ] **Ship-time prerequisite:** the git tag `contract-v<version>` (e.g.
+      `contract-v0.1`) exists in this repo's history before
+      `dist/agentbundle.pyz` is uploaded as a release asset, so the
+      `--version` spec field has a canonical referential anchor in git
+      history.
+- [ ] `pip list --format=freeze` inside `packages/agentbundle/` lists zero
+      runtime dependencies (test-only dev-deps allowed). The sibling
+      `distribution-adapters` spec's stdlib-import audit (its build's
+      `lint-build.sh` equivalent) provides the structural lint that
+      catches drift; cite it here rather than duplicate.
+- [ ] `agentbundle.build.adapters` exposes a mapping `name → AdapterModule`
+      populated at import time (the `AdapterModule` shape is pinned by the
+      sibling `distribution-adapters` spec's registry contract AC). A test
+      asserts: `import agentbundle.build.adapters as A; assert isinstance(
+      A.registry, Mapping); assert set(A.registry).issuperset({"claude_code",
+      "kiro", "copilot", "codex"})`.
+- [ ] A version-mismatch fixture (pack declares spec `v2.0`, CLI ships
+      `v0.1`) causes every subcommand to refuse with a stderr line naming
+      both versions; no partial behaviour observed.

--- a/docs/specs/distribution-adapters/plan.md
+++ b/docs/specs/distribution-adapters/plan.md
@@ -1,0 +1,653 @@
+# Plan: distribution-adapters
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Drafting
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn. When it changes substantially
+> (a different approach, not just a re-ordering), note why in the changelog
+> at the bottom.
+
+## Approach
+
+Build inside-out, from data to pipeline. First land the **scaffolds and
+schemas** (T1a) — `packages/agentbundle/` package layout, `pyproject.toml`,
+the shared build-pipeline scaffolds (`build/__init__.py`, `build/contract.py`,
+`build/adapters/__init__.py`, `build/validate.py`, and the fixtures-layout
+convention), plus `schema.json` for the adapter contract. Then populate
+the **contract data** (T1b) — every (primitive, adapter) pair in
+`contract.toml`, plus the `kiro-agent-frontmatter-v0.9` mapping and the
+Copilot `frontmatter-default`. Then land the **sibling schemas** (T1c) —
+`pack-schema.json` and `plugin-manifest-schema.json`. Splitting T1 into
+three keeps each commit reviewable and lets T2–T5 enter supervisor mode
+as soon as T1b lands.
+
+Then land the **four reference adapters** in parallel — each is a
+self-contained pure-stdlib Python module that takes a primitive (from a
+pack's `.apm/`) plus the adapter's projection rules (from the contract) and
+emits the projected output. The adapters share nothing but the contract;
+they can be built independently. Finally, land the **build pipeline** that
+wires recipes, pack discovery, adapter dispatch, marketplace aggregation,
+and self-host mode together — including the `make build --check` round-trip
+diff. The riskiest part is the contract's shape: get the projection-mode
+enum, the (primitive, adapter) pair enumeration, and the `on-conflict` table
+right *before* writing any adapter, or every adapter re-derives them.
+
+## Constraints
+
+- **RFC-0001** — [Bundle distribution by adapter spec + ecosystem build
+  pipeline](../../rfc/0001-bundle-distribution-by-adapter-spec.md). The
+  contract path, the seven projection modes, the four reference adapters,
+  the five primitive types (`skill`, `agent`, `hook-body`, `hook-wiring`,
+  `command`), the Tier-1/2/3 model, the per-mode `on-conflict` defaults,
+  and three of the six recipe types all come from there. Open question Q1
+  (Kiro hook wiring schema) stays at `degraded-info-log` per the RFC.
+- **RFC-0002** — [Self-hosting](../../rfc/0002-self-hosting.md) consumes
+  this spec's `make build --check` gate and supplies the other three
+  recipe types (`per-pack-overlay`, `composite-agents-md`,
+  `composite-marketplace`). We define the command surface and the
+  six-recipe set; RFC-0002's spec wires the CI gate and authors the
+  composite self-host recipe content.
+- **RFC-0003** — [Adapter contract publication + reference CLI](../../rfc/0003-spec-and-cli.md)
+  consumes the contract this spec produces and imports
+  `agentbundle.build` as a library (no `sys.path` tricks, no fork). The
+  CLI is `packages/agentbundle/`'s public surface; this spec ships the
+  build module under the same package.
+- **CONVENTIONS.md** — Profile B+ work-loop discipline applies. Tests
+  before approach; `Depends on:` on every task; verification mode
+  named per task.
+
+## Construction tests
+
+Most construction tests live under **Tasks** below (per-task `Tests:`
+subsections). This top-level section is only for cross-cutting tests that
+span tasks.
+
+**Integration tests:**
+- **End-to-end `make build`** (verifies Acceptance Criterion 7).
+  Drives the full pipeline against the four reference packs on a clean
+  checkout (with the four reference packs materialised in `packs/`) in a
+  temp dir; asserts the `dist/apm/<pack>/` and `dist/claude-plugins/<pack>/`
+  shapes and a single `marketplace.json`. Lives at
+  `packages/agentbundle/agentbundle/build/tests/test_end_to_end_build.py`.
+  **Authored by T8**; T7 reads it as a regression check but does not author it.
+- **End-to-end `make build --check`** (verifies Acceptance Criterion 10).
+  Runs the self-host dry-run against the current source tree; asserts
+  exit zero on a clean tree; mutates one source file in a temp checkout
+  and asserts non-zero exit with a per-file drift listing. Lives at
+  `packages/agentbundle/agentbundle/build/tests/test_self_host_check.py`.
+  **Authored by T7**; T8 imports it as a regression gate. Comparison-rule
+  unit tests (LF normalisation, mode-bit comparison, symlink-via-lstat)
+  are owned by sibling spec `self-hosting` — this file imports them as a
+  regression gate rather than duplicating them.
+
+**Manual verification:** none — both the build and the self-host gate
+have machine-checkable goal artifacts.
+
+## Tasks
+
+The work-breakdown. Tasks are sized so each one is a coherent commit or PR.
+**Phrase each task as a verifiable goal, not a procedure.** The task name
+*is* the success criterion: *"Add validation"* → *"All invalid-input tests
+pass"*; *"Refactor X"* → *"Tests for X green before and after; public
+surface unchanged"*. **Within each task, `Tests:` comes before `Approach:`** —
+tests drive implementation, not the other way around. Use red-green-refactor
+with separate commits when the change is non-trivial.
+
+**Every task must declare `Depends on:` explicitly** — list prior task IDs
+or `none`. Don't omit the field; "obvious from order" is the failure mode
+that hides serial-by-default thinking. `none` is a valid and common answer.
+
+### T1a: Package scaffolds + adapter-contract `schema.json` + stdlib validator
+
+**Depends on:** none
+
+**Verification mode:** TDD.
+
+**Tests:**
+- `python -c "import agentbundle.build"` succeeds from a clean checkout
+  (the `packages/agentbundle/` layout resolves under default `PYTHONPATH`
+  or via editable install).
+- `validate.py` accepts a minimal hand-rolled JSON-Schema document and
+  rejects a malformed one covering each of the supported keywords:
+  `type` (`object`, `array`, `string`, `integer`, `boolean`), `enum`,
+  `required`, `pattern`, and `items` for arrays.
+- A draft `schema.json` (object + enum + required) loads without error;
+  a mutated copy (unknown `mode` enum member; missing `required` field)
+  is rejected by `validate.py`.
+
+**Approach:**
+- Lay down `packages/agentbundle/` with `pyproject.toml` (stdlib-only,
+  empty `dependencies = []`, sets `name = "agentbundle"` and the package
+  layout). `packages/agentbundle/agentbundle/__init__.py` is the
+  importable root.
+- Scaffold the build module:
+  - `packages/agentbundle/agentbundle/build/__init__.py` (exports
+    `main` so `python -m agentbundle.build` works).
+  - `packages/agentbundle/agentbundle/build/__main__.py` — argparse
+    scaffold. `main()` configures a top-level parser with `--help`
+    and an `argparse` subparser dispatch. **`validate <path>`
+    subcommand lands here in T1a** (loads the contract at `<path>`
+    via `tomllib`, validates against `schema.json`, exits 0 on valid
+    and 1 on invalid with a one-line stderr message). T1b's
+    Done-when invokes this subcommand against `contract.toml`.
+    Other subcommands (build, recipe dispatch, `--self`, `--check`,
+    `--scaffold`) land in T6–T8.
+  - `packages/agentbundle/agentbundle/build/contract.py` — the
+    contract loader that adapters import (parses TOML via `tomllib`,
+    returns typed dicts; no validation logic, that's `validate.py`).
+  - `packages/agentbundle/agentbundle/build/adapters/__init__.py`
+    (registry stub; adapters land in T2–T5).
+  - `packages/agentbundle/agentbundle/build/validate.py` — the
+    stdlib JSON-Schema subset validator. **Subset commitment:**
+    `type` (object/array/string/integer/boolean), `enum`, `required`,
+    `pattern` (via `re`), `items`. No `$ref`, no `oneOf`/`anyOf`, no
+    format keywords. Documented in this Approach so reviewers know
+    not to ask for more. Spec AC #6 names the same subset.
+  - `packages/agentbundle/agentbundle/build/tests/fixtures/README.md`
+    — fixture layout convention (one pack per subdirectory under
+    `fixtures/packs/`, named for the test it serves).
+- Author `docs/specs/adapter-contract/schema.json` (JSON-Schema-shaped,
+  validated by `validate.py`) defining `[contract]`, `[primitive.*]`,
+  `[adapter.<target>]` with `[[adapter.<target>.projection]]` array,
+  `[frontmatter-mapping.*]`, `[frontmatter-default.*]`.
+- Add `tools/build/build.py` as a thin shim:
+  ```python
+  from agentbundle.build import main
+  main()
+  ```
+
+**Done when:** `python -m agentbundle.build --help` exits zero;
+`python -m agentbundle.build validate --help` exits zero (the
+subparser is wired); `validate.py`'s test file passes; `schema.json`
+loads under `validate.py` against itself.
+
+---
+
+### T1b: Populate `contract.toml` with every (primitive × adapter) pair
+
+**Depends on:** T1a
+
+**Verification mode:** TDD.
+
+**Tests:**
+- Loading `docs/specs/adapter-contract/contract.toml` with `tomllib` and
+  validating against `schema.json` returns no errors (verifies AC 1).
+- Every (5 primitives × 4 adapters) = 20 pairs appears in the contract
+  as a `[[adapter.<target>.projection]]` table; the test enumerates the
+  expected set and asserts no missing pair, no extra.
+- The `mode` enum in `schema.json` contains exactly the seven RFC-0001
+  modes; a contract entry with any other mode value is rejected
+  (verifies AC 2).
+- Every `[[adapter.<t>.projection]]` table in `contract.toml` carries
+  an `on-conflict` value drawn from the legal set
+  (`prompt-then-preserve`, `prompt-then-overwrite`,
+  `preserve-outside-block`, `merge-managed-key-only`,
+  `overwrite-without-prompt`) — and matches the per-mode default
+  unless explicitly overridden (verifies AC 2).
+- The `hook-wiring` primitive's `source-path` is
+  `.apm/hook-wiring/` (one TOML file per hook listing the `[hooks]`
+  entries to merge into `.claude/settings.local.json` for Claude
+  Code's `merge-json` mode).
+- The `command` primitive's `source-path` is `.apm/commands/`; the
+  Claude Code projection is `direct-file` to `.claude/commands/`;
+  Copilot / Codex / Kiro projections are `dropped`.
+- `frontmatter-mapping` table for `kiro-agent-frontmatter-v0.9`
+  validates against the schema; a `frontmatter-default` table for
+  Copilot's `applyTo: "**"` validates and is structurally distinct
+  from `frontmatter-mapping` (mapping = rewrite rules, default =
+  inject when missing).
+
+**Approach:**
+- Populate `docs/specs/adapter-contract/contract.toml`:
+  - `[primitive.skill]`, `[primitive.agent]`, `[primitive.hook-body]`,
+    `[primitive.hook-wiring]`, `[primitive.command]` — each with its
+    `source-path`.
+  - Four `[adapter.<target>]` blocks, each with five
+    `[[adapter.<target>.projection]]` entries (one per primitive).
+    Per the spec's projection table.
+  - `[frontmatter-mapping.kiro-agent-frontmatter-v0.9]` table.
+  - `[frontmatter-default.copilot-instruction]` table.
+- Author `packages/agentbundle/agentbundle/build/tests/test_contract.py`
+  — the contract-validation test suite.
+
+**Done when:** `python -m agentbundle.build validate
+docs/specs/adapter-contract/contract.toml` exits zero, and every test
+in `test_contract.py` passes.
+
+---
+
+### T1c: `pack-schema.json` + `plugin-manifest-schema.json`
+
+**Depends on:** T1a
+
+**Verification mode:** TDD.
+
+**Tests:**
+- `pack-schema.json` accepts an example `pack.toml` modeled on
+  RFC-0001's `governance-extras` recommended-on-core example
+  (verifies AC 3).
+- `pack-schema.json` rejects a `pack.toml` missing `[pack]`.
+- `pack-schema.json` rejects a `pack.toml` whose `[pack.adaptation]
+  infer-from` value is a non-string (shape-only check; the semantic
+  set of legal values lives in the `adapt-to-project` skill, out of
+  scope here).
+- `pack-schema.json` accepts a `pack.toml` *without* a
+  `[pack.dependencies.required]` array — the field is optional
+  (negative-case companion: missing-optional ≠ malformed).
+- `pack-schema.json` accepts a `pack.toml` whose `[pack.seeds]`
+  entries are relative-path strings (e.g. `"AGENTS.md"`,
+  `"docs/CHARTER.md"`), and rejects one whose `[pack.seeds]` entry
+  is an absolute path (e.g. `"/etc/foo"`) or a non-string (e.g. an
+  inline table). Verifies the `[pack.seeds]` shape clause of AC 3.
+- `plugin-manifest-schema.json` accepts a minimal hand-authored
+  `.claude-plugin/plugin.json` (verifies AC 4).
+
+**Approach:**
+- Author `docs/specs/adapter-contract/pack-schema.json` capturing the
+  `[pack]`, `[pack.dependencies]` (with `required`/`recommended`/
+  `conflicts` arrays of `{catalogue, pack, version}` objects),
+  `[pack.adaptation]` (substitutions + augmentation-points), and
+  `[pack.seeds]` tables.
+- Author `docs/specs/adapter-contract/plugin-manifest-schema.json` for
+  `.claude-plugin/plugin.json`.
+- Extend `test_contract.py` (or add `test_pack_schema.py` /
+  `test_plugin_manifest_schema.py`) for the new tests.
+
+**Done when:** all schema-validation tests pass.
+
+---
+
+### T2: Claude Code adapter projects every primitive to its declared output
+
+**Depends on:** T1b
+
+**Verification mode:** TDD (per spec's Testing Strategy — per-adapter
+projection rules).
+
+**Tests:**
+- A `skill` primitive at `packs/<p>/.apm/skills/foo/` projects to
+  `.claude/skills/foo/` with full directory preservation
+  (`direct-directory` mode).
+- An `agent` primitive at `packs/<p>/.apm/agents/bar.md` projects to
+  `.claude/agents/bar.md` (`direct-file`); frontmatter passes through
+  unchanged (Claude-Code-shape is the source shape).
+- A `hook-body` primitive at `packs/<p>/.apm/hooks/baz.sh` projects to
+  `tools/hooks/baz.sh` (`direct-file`); the `.sh` extension is
+  preserved byte-for-byte.
+- A `hook-body` primitive at `packs/<p>/.apm/hooks/baz.py` projects to
+  `tools/hooks/baz.py` (`direct-file`); the `.py` extension is
+  preserved byte-for-byte. No conversion between extensions.
+- A `hook-wiring` primitive at `packs/<p>/.apm/hook-wiring/baz.toml`
+  merges under the `hooks` key of `.claude/settings.local.json`
+  (`merge-json`) and never touches other keys (on-conflict
+  `merge-managed-key-only`).
+- A `command` primitive at `packs/<p>/.apm/commands/qux.md` projects
+  to `.claude/commands/qux.md` (`direct-file`).
+- Idempotence: running the adapter twice against the same fixture
+  produces byte-identical output for both `direct-file` and
+  `merge-json` projections (the `settings.local.json` merge is
+  deterministic).
+
+**Approach:**
+- `packages/agentbundle/agentbundle/build/adapters/claude_code.py` —
+  single module exporting `project(pack_path, contract, output_root)`.
+  Reads the `claude-code` adapter block, iterates source primitives,
+  copies or merges per rule.
+- `packages/agentbundle/agentbundle/build/tests/test_adapter_claude_code.py`
+  drives it against fixture packs under
+  `packages/agentbundle/agentbundle/build/tests/fixtures/`.
+
+**Done when:** every test in `test_adapter_claude_code.py` is green
+and the adapter reads its rules only from the contract (no hardcoded
+paths).
+
+---
+
+### T3: Kiro adapter projects skills, agents (with frontmatter mapping), and degrades hook wiring
+
+**Depends on:** T1b
+
+**Verification mode:** TDD.
+
+**Tests:**
+- A `skill` primitive projects to `.kiro/skills/<name>/`
+  (`direct-directory`).
+- An `agent` primitive's frontmatter is rewritten via the
+  `kiro-agent-frontmatter-v0.9` mapping from the contract (no
+  hardcoded mapping in Python); `tools` field normalized via the
+  declared `normalize = "to-list"` rule.
+- A `hook-wiring` primitive in `degraded-info-log` mode emits an
+  `[info]` log line at build time to stderr and writes no file.
+- A `hook-body` primitive projects to `tools/hooks/<name>.{sh,py}`
+  (extension preserved; consistent across adapters per RFC §
+  Per-IDE adapter contracts).
+- A `command` primitive is `dropped` (no output file, no warning).
+
+**Approach:**
+- `packages/agentbundle/agentbundle/build/adapters/kiro.py`.
+  Frontmatter rewrite reads the named mapping table from the contract;
+  the adapter has no per-target field dictionary.
+- `packages/agentbundle/agentbundle/build/tests/test_adapter_kiro.py`
+  drives it; one fixture pack carries `hook-wiring` to exercise the
+  degraded path.
+
+**Done when:** every test in `test_adapter_kiro.py` is green.
+
+---
+
+### T4: Copilot adapter projects skills to per-file instructions and drops subagents
+
+**Depends on:** T1b
+
+**Verification mode:** TDD.
+
+**Tests:**
+- A `skill` primitive projects to
+  `.github/instructions/<name>.instructions.md`
+  (`instruction-file` mode) with the default `applyTo: "**"`
+  frontmatter from the contract's `frontmatter-default` table.
+- An `agent` primitive in `dropped` mode produces no output file and
+  no warning (it's an explicit no-op).
+- A `hook-body` primitive projects to `tools/hooks/<name>.{sh,py}`
+  (extension preserved); `hook-wiring` is `dropped`; `command` is
+  `dropped`.
+
+**Approach:**
+- `packages/agentbundle/agentbundle/build/adapters/copilot.py`.
+  Default frontmatter comes from the contract's `frontmatter-default`
+  table — adapter does not hardcode `applyTo`.
+- `packages/agentbundle/agentbundle/build/tests/test_adapter_copilot.py`.
+
+**Done when:** every test in `test_adapter_copilot.py` is green.
+
+---
+
+### T5: Codex adapter inlines skill descriptions into a managed block in AGENTS.md
+
+**Depends on:** T1b
+
+**Verification mode:** TDD.
+
+**Tests:**
+- A `skill` primitive's description appears between
+  `<!-- agent-skills:start -->` and `<!-- agent-skills:end -->` in
+  the projected `AGENTS.md` (`managed-block-inline` mode).
+- Content *outside* the managed block in a pre-existing `AGENTS.md`
+  is preserved byte-for-byte (`preserve-outside-block` on-conflict).
+- `agent`, `hook-wiring`, and `command` primitives in `dropped` mode
+  produce no output.
+- A `hook-body` primitive projects to `tools/hooks/<name>.{sh,py}`
+  (`direct-file`; extension preserved). Codex matches the cross-adapter
+  hook-body convention.
+- Re-running the adapter is idempotent: the block content stabilizes
+  on the second run (byte-identical output).
+
+**Approach:**
+- `packages/agentbundle/agentbundle/build/adapters/codex.py`. Delimiter
+  strings come from the contract's `managed-block-delimiter-start` /
+  `-end` fields.
+- `packages/agentbundle/agentbundle/build/tests/test_adapter_codex.py`.
+
+**Done when:** every test in `test_adapter_codex.py` is green.
+
+---
+
+### T6: Build pipeline reads recipes and dispatches per-pack rendering
+
+**Depends on:** T2, T3, T4, T5
+
+**Verification mode:** Goal-based for the artifact-shape tests
+(each recipe's output directory exists and matches the expected layout);
+TDD for the recipe loader's unit invariants (unknown adapter target
+raises; unknown recipe type raises; pack-internal name collisions are
+rejected).
+
+**Tests:**
+- Goal: `python -m agentbundle.build --recipe per-pack-claude-plugin`
+  against a single-pack fixture produces a `dist/claude-plugins/<pack>/`
+  directory containing the pack's hand-authored
+  `.claude-plugin/plugin.json` (copied unmodified from
+  `packs/<pack>/.claude-plugin/plugin.json`) and the projected `.apm/`
+  content.
+- Goal: `python -m agentbundle.build --recipe per-pack-apm-package`
+  produces `dist/apm/<pack>/` with a generated `apm.yml` derived from
+  `pack.toml`.
+- Goal: `python -m agentbundle.build --recipe marketplace` aggregates
+  every rendered per-pack plugin under `dist/claude-plugins/*/` into a
+  single `dist/claude-plugins/marketplace.json`.
+- Unit: pack-internal name collision (two skills, agents, hooks,
+  hook-wiring files, or commands with the same local name inside one
+  pack) is rejected by a pre-render validation step with non-zero exit
+  and a stderr message naming both paths (verifies AC 9 — the rule is
+  pipeline-level, not per-adapter).
+- Unit: unknown recipe name → non-zero exit + stderr message.
+- Unit: unknown adapter target in a recipe → non-zero exit + stderr.
+- Goal (RFC-0002 recipe — `per-pack-overlay`): loading
+  `per-pack-overlay.toml` against a fixture pack produces an overlay
+  description naming the pack's `.apm/` content and `seeds/` list as
+  the units to be projected into the working tree. Asserts expansion
+  shape, not on-disk overlay (T7 owns the on-disk side).
+- Goal (RFC-0002 recipe — `composite-agents-md`): loading
+  `composite-agents-md.toml` against two fixture packs each carrying
+  a `seeds/AGENTS.fragment.md` produces a composed `AGENTS.md`
+  description whose body concatenates both fragments in declared
+  order. Asserts expansion shape.
+- Goal (RFC-0002 recipe — `composite-marketplace`): loading
+  `composite-marketplace.toml` against three fixture per-pack
+  `.claude-plugin/plugin.json` files produces a composite
+  marketplace description enumerating all three. Asserts expansion
+  shape; distinct from the `marketplace` recipe's aggregation goal
+  above (RFC-0001's recipe aggregates rendered output;
+  `composite-marketplace` composes the self-host marketplace).
+- Goal (empty-pack edge case): a fixture pack missing one or more
+  `.apm/<primitive>/` directories (e.g. `governance-extras` with no
+  `command/`) drives the pipeline to emit no error and no output for
+  the absent primitives — adapters skip the missing directory
+  silently rather than failing.
+
+**Approach:**
+- `packages/agentbundle/agentbundle/build/main.py` (or extend
+  `__init__.py`) — recipe loader (TOML), pack discovery via glob
+  `packs/*/`, adapter dispatch keyed by `[recipe.adapter] target`.
+- `packages/agentbundle/agentbundle/build/recipes/per-pack-claude-plugin.toml`,
+  `per-pack-apm-package.toml`, `marketplace.toml`,
+  `per-pack-overlay.toml`, `composite-agents-md.toml`,
+  `composite-marketplace.toml` — the six enumerated recipe types.
+  (T7 exercises the self-host trio; T6 lands the recipe files.)
+- `packages/agentbundle/agentbundle/build/tests/test_pipeline.py`
+  covers the dispatcher's unit invariants and the artifact-shape goals.
+
+**Done when:** all three RFC-0001 recipes round-trip against fixture
+packs; the three RFC-0002 recipe files land and have unit tests
+verifying their expansion shape; the empty-pack edge case passes; the
+unknown-recipe path exits non-zero.
+
+---
+
+### T7: `make build --self --dry-run` writes to temp and emits a diff against on-disk
+
+**Depends on:** T6
+
+**Verification mode:** Goal-based check (the artifact diff against the
+working tree is the verification artifact).
+
+**Tests:**
+- Goal: on a clean source tree, the self-host dry-run produces zero
+  diff lines and exits zero.
+- Goal: after mutating one source file in a temp checkout, the dry-run
+  exits non-zero and the stderr names that file's projected path with
+  the per-file drift.
+- Goal: the dry-run never modifies the working tree (verified by
+  comparing `git status` before and after).
+- Goal (marker resolution): a fixture source file containing
+  `<adapt:project-name>` plus a fixture `.adapt-discovery.toml`
+  mapping `project-name = "demo"` makes `make build --self` (not
+  `--dry-run`) project a file containing the literal string `demo`
+  — markers are resolved during `--self` writes. Counter-test: plain
+  `make build` (no `--self`) against the same fixture copies the
+  marker through unchanged. Verifies the `<adapt:NAME>` clause of
+  the new `make build --self` AC.
+- Unit (TDD): `--self` writes use each adapter's *declared* on-conflict
+  mode (e.g. `merge-managed-key-only` for Claude Code's
+  `settings.local.json`); `--force` bypasses the dirty-tree refusal
+  only — it never overrides the per-adapter on-conflict policy.
+
+**Approach:**
+- Add `--self`, `--dry-run`, and `--force` flags to the build CLI
+  (`agentbundle.build`).
+- Self-host mode renders to a `tempfile.TemporaryDirectory()` and
+  diffs against the repo's on-disk projection paths
+  (`.claude/skills/`, `.claude/agents/`, `tools/hooks/`,
+  `AGENTS.md`, `.claude/commands/`). The diff output names per-file
+  drift one line at a time.
+- `--self` is the *one authorised mode* that runs `<adapt:NAME>`
+  marker resolution as a final build step (per spec Boundaries §
+  Never do); the resolver itself lives in `adapt-to-project` and
+  consumes `.adapt-discovery.toml`.
+- Author `packages/agentbundle/agentbundle/build/tests/test_self_host_check.py`
+  — the cross-cutting self-host integration test. T8 imports this
+  file as a regression gate; T7 owns it.
+- Comparison-rule unit tests (LF normalisation, mode-bit comparison,
+  symlink-via-lstat) are owned by sibling spec `self-hosting`; this
+  task imports them as a regression gate, doesn't duplicate. The
+  dry-run diff in this task uses whatever comparison rules
+  `self-hosting` defines for its detector.
+
+**Done when:** test cases above pass; `git status` shows no changes
+after `python -m agentbundle.build --self --dry-run`.
+
+---
+
+### T8: `Makefile` exposes the seven subcommands and `make build --check` rounds-trip green
+
+**Depends on:** T6, T7
+
+**Verification mode:** Goal-based check (per spec's Testing Strategy —
+end-to-end build).
+
+**Tests:**
+- Goal: `make build` on the four reference packs produces the
+  expected directory shape (verifies AC 7) — the integration test
+  at `packages/agentbundle/agentbundle/build/tests/test_end_to_end_build.py`
+  is the verification artifact. **T8 authors this file.**
+- Goal: `make build --check` exits zero on the clean tree (verifies
+  AC 10) — imports `test_self_host_check.py` (authored by T7) as a
+  regression gate.
+- `make build PACK=core` limits output to the `core` pack only.
+- `make build RECIPE=per-pack-claude-plugin` runs that recipe across
+  all packs.
+- `make build --scaffold OUTPUT=<tmp>` drops the `core` pack's
+  `seeds/` into the named output directory.
+- Unknown subcommand or flag → non-zero exit with stderr.
+
+**Approach:**
+- Author `Makefile` targets that shell out to `python3 -m
+  agentbundle.build` with the matching flags. The Makefile is the
+  thin user surface; argument parsing happens in `agentbundle.build`.
+- Extend the build CLI arg parser with `--check`, `--scaffold`,
+  `PACK=`, `RECIPE=` (Make-style passthrough).
+- Author `packages/agentbundle/agentbundle/build/tests/test_end_to_end_build.py`
+  — drives the full pipeline against
+  `packs/{core,governance-extras,user-guide-diataxis,monorepo-extras}/`.
+  "Clean checkout" for AC 7 means with the four reference packs
+  materialised in `packs/` (in scope here, per CC4 / RFC-0002).
+
+**Done when:** `make build && make build --check` exits zero on the
+clean tree; mutating a source file makes `make build --check` exit
+non-zero.
+
+---
+
+### T9: Stdlib-only enforcement and no-new-top-level audit
+
+**Depends on:** T1a (the enforcement lands with the package scaffolds)
+
+**Verification mode:** Goal-based check (per spec's Boundaries — Never do
+floor).
+
+**Tests:**
+- Goal: a `pre-pr.sh` hook runs the stdlib-import audit against
+  `packages/agentbundle/agentbundle/build/` and exits non-zero on any
+  non-stdlib import. The CI workflow runs the same hook. A wrong
+  `import yaml` surfaces in the offending PR — *not* at end-of-stream.
+  (Verifies AC 5.)
+- Goal: the no-new-top-level audit runs as part of `pre-pr.sh`:
+  `comm -23 <(git ls-tree --name-only HEAD | sort) <(git ls-tree
+  --name-only main | sort)` returns empty (verifies the
+  no-new-top-level AC). `dist/` is git-ignored and doesn't count.
+  Both inputs are sorted because `comm` requires sorted input.
+
+**Approach:**
+- Author `tools/lint-build.sh` with two checks: the stdlib-import
+  audit (walks every `.py` under
+  `packages/agentbundle/agentbundle/build/`, parses imports, asserts
+  every top-level package is in `sys.stdlib_module_names`) and the
+  top-level-directory audit.
+- Wire `tools/lint-build.sh` into `pre-pr.sh` (an existing hook in
+  this repo) so it runs on every PR. Same script runs in CI.
+- Authoring this task at T1a-time (rather than after T6/T7/T8) means
+  any stray non-stdlib import in T2–T8 surfaces in that PR.
+
+**Done when:** `tools/lint-build.sh` exits zero on a clean tree;
+introducing a non-stdlib import in a fixture file makes it exit
+non-zero.
+
+---
+
+## Rollout
+
+The pipeline ships once, behind no flag — it's developer tooling, not
+runtime behavior. The first `make build` run produces `dist/` (added
+to `.gitignore` as part of T6); CI starts running `make build --check`
+once RFC-0002's spec wires it in. Reversible: removing
+`packages/agentbundle/agentbundle/build/`,
+`docs/specs/adapter-contract/`, and the `tools/build/build.py` shim
+rolls everything back; no adopter has consumed an artifact yet (the
+catalogue isn't published until follow-on work).
+
+## Risks
+
+- **JSON-Schema validation in stdlib.** Python's stdlib doesn't ship a
+  draft-2020-12 validator. **Resolved:** T1a commits to a defined
+  stdlib-only subset (object, array, string, integer, boolean, enum,
+  required, pattern, items) and ships `validate.py` against that
+  subset. Spec AC #6 names the same subset. No "fallback to type
+  checks" — the subset is the contract.
+- **Idempotence of `managed-block-inline`** *and* **`merge-json`**.
+  Codex's inline-block mode and Claude Code's `settings.local.json`
+  merge must converge in one run; otherwise `make build --check`
+  oscillates on a clean tree. T5 and T2 both pin idempotence with
+  byte-identical-output tests; if either fails, the relevant
+  serialisation needs deterministic ordering (alpha by skill name for
+  Codex; sorted JSON key order for Claude Code).
+- **Frontmatter mapping for Kiro is the most fragile adapter rule.**
+  Mapping table lives in the contract, but the adapter still has to
+  apply it correctly across skill files with varying frontmatter
+  shapes. T3's tests cover the documented mapping; surprises in
+  real source primitives surface during T8's end-to-end run.
+- **Recipe globbing on `packs/*/`.** If the repo doesn't yet have
+  the four reference packs materialized (separate work — RFC-0001's
+  F-dist follow-on includes the migration), T8's end-to-end test
+  needs fixture packs under
+  `packages/agentbundle/agentbundle/build/tests/fixtures/`.
+  Mitigation: fixtures ship with this spec; production packs land
+  separately and exercise the pipeline incrementally.
+
+## Changelog
+
+- 2026-05-22: initial plan.
+- 2026-05-22: incorporated adversarial review (CC1–CC6, B1–B6, C7–C15,
+  N16–N20). T1 split into T1a/T1b/T1c; build code moved to
+  `packages/agentbundle/agentbundle/build/`; `command` primitive added;
+  Tier model and `.agent-ready-state.toml` schema pinned in spec;
+  recipe set enumerated; T9 hoisted to run as a pre-PR hook.
+- 2026-05-22: fix-pass 2 (3 Blockers, 9 Concerns, 3 Nits + cross-spec
+  coordination patches A/B/C). Aligned validator subset between spec
+  AC #6 and plan T1a; folded `validate <path>` subparser into T1a;
+  added numbered ACs for `make build --self` and the six-recipe set;
+  weakened `infer-from` schema check to shape-only; added `[pack.seeds]`
+  schema test pair; added T6 tests for RFC-0002 recipes and the
+  empty-pack edge case; added T7 marker-resolution test; ceded
+  comparison-rule unit tests to sibling `self-hosting`; fixed
+  `comm -23` to sort inputs.

--- a/docs/specs/distribution-adapters/spec.md
+++ b/docs/specs/distribution-adapters/spec.md
@@ -1,0 +1,356 @@
+# Spec: distribution-adapters
+
+- **Status:** Draft
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** [RFC-0001](../../rfc/0001-bundle-distribution-by-adapter-spec.md), [RFC-0002](../../rfc/0002-self-hosting.md)
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+Stand up the in-repo distribution machinery RFC-0001 commits to: a canonical
+per-IDE **adapter contract** (TOML + JSON-Schema validator), a stdlib-only
+Python **build pipeline** that consumes it, and four **reference adapters**
+(Claude Code, Kiro, Copilot, Codex) that together project each of the four
+packs (`core`, `governance-extras`, `user-guide-diataxis`, `monorepo-extras`)
+into ecosystem-native distribution artifacts. The user is the contributor or
+adopter who runs `make build`: a single command must turn the source tree
+under `packs/` into one installable APM package per pack at `dist/apm/<pack>/`
+and one installable Claude Code plugin per pack at
+`dist/claude-plugins/<pack>/`, plus a shared
+`dist/claude-plugins/marketplace.json` aggregating every per-pack plugin
+entry. The same pipeline, invoked as `make build --check`, must run in
+dry-run mode against this repo's own self-host projection and exit non-zero
+on any drift between source and on-disk projection — the gate RFC-0002 wires
+into CI. Success is shaped by RFC-0001's three Success criteria: contract
+validates against its own schema for all four reference targets; the build
+pipeline produces installable artifacts on a clean checkout; the self-host
+diff is a no-op.
+
+This spec also pins:
+
+- The **shape** of two schemas the rest of the catalogue reads: `pack.toml`
+  (per-pack metadata, dependencies, adaptation manifest, and `seeds/` list)
+  and `.claude-plugin/plugin.json` (the per-pack Claude Code plugin
+  manifest). RFC-0002's self-host spec and RFC-0003's CLI spec reference
+  these definitions — they are not redefined elsewhere.
+- The **Tier-1/2/3 contract** (which files the bundle owns, which it shares
+  with adopter edits, which it never touches) and the
+  `.agent-ready-state.toml` schema and `.upstream.<ext>` companion semantics
+  that operationalise it. These are bundle-format concerns; sibling specs
+  (self-hosting, CLI) consume the definitions defined here.
+- The enumerated **recipe set** — the six recipe types RFC-0001 and RFC-0002
+  jointly define. Any seventh recipe type requires an RFC or spec amendment.
+
+## Tier model and adopter-edit semantics
+
+The Tier model is the bundle-format contract for "what a file's owner is at
+any moment." All adapters, recipes, the CLI, and `adapt-to-project` consume
+it identically. RFC-0001 § Catalogue boundaries and update model is the
+upstream source.
+
+- **Tier-1 — bundle-owned, projected.** Files at adapter-contract paths
+  that the adopter does not edit. The CLI install, `make build`, and the
+  adapt step are free to (re)write these. Examples: `.claude/skills/<pack>/`,
+  generated `dist/` content, `.kiro/skills/<name>/`. Tier-1 is the default
+  for any output an adapter projects from a primitive.
+- **Tier-2 — bundle-origin, adopter-edited.** Files that the bundle
+  originally seeded but the adopter has since modified. Detection: the
+  per-file SHA-256 in `.agent-ready-state.toml` no longer matches the
+  bundle's last-installed content. Writes never clobber: an update drops a
+  companion file at `<filename>.upstream.<ext>` (e.g. `AGENTS.md` stays;
+  `AGENTS.upstream.md` is dropped next to it). `adapt-to-project` walks
+  these companions, prompts the adopter per file, and removes the
+  `.upstream.<ext>` once resolved.
+- **Tier-3 — adopter-owned, untouched.** Files outside adapter-contract
+  paths. The bundle never writes these; the adapt step may propose changes
+  but only with per-file approval.
+
+**`.upstream.<ext>` companion semantics.**
+- *Filename rule:* `<stem>.upstream.<ext>` for a file at `<stem>.<ext>`
+  (e.g. `AGENTS.md` → `AGENTS.upstream.md`; `docs/CHARTER.md` →
+  `docs/CHARTER.upstream.md`). For files without an extension, the rule is
+  `<stem>.upstream` with no extension.
+- *Lifecycle:* created by `make build` (in `--self` mode) or by a CLI
+  install/update when the target is detected as Tier-2; removed by
+  `adapt-to-project` after the adopter resolves the conflict (keep, merge,
+  or overwrite). Companions are tracked in `.agent-ready-state.toml`.
+- *Initial install:* when a fresh install lands on a pre-existing
+  adopter-edited file (Tier-3 → Tier-2 fast-path), the install drops a
+  `.upstream.<ext>` companion rather than overwriting.
+
+**`.agent-ready-state.toml` schema (this spec, v0.1).**
+
+```toml
+schema-version = "0.1"
+
+[pack.<name>]                       # one section per installed pack
+installed-version = "0.2.0"          # the pack version that produced the recorded hashes
+source = "agent-ready-repo"          # catalogue identifier
+install-route = "cli"                # "cli" | "apm" | "claude-plugin"
+primitives = ["skill", "agent", "hook-body", "hook-wiring", "command"]
+                                     # the primitive types this pack projects (subset of: skill, agent, hook-body, hook-wiring, command)
+
+[pack.<name>.files]                  # per-file SHA-256 hash recorded at install time
+"<projected-path>" = { sha = "<hex64>", from-pack-version = "<semver>" }
+```
+
+The CLI spec (RFC-0003) consumes this schema; this spec pins it. Per-pack
+version drift (the third file in RFC-0001's sketch) is permitted —
+`from-pack-version` is per-file. Subsequent schema evolution moves the
+`schema-version` field forward.
+
+## Recipe set (enumerated)
+
+The recipe types this spec supports — and the only ones the build pipeline
+recognises without an RFC or spec amendment:
+
+| Recipe type | Source RFC | Output |
+| --- | --- | --- |
+| `per-pack-claude-plugin` | RFC-0001 | `dist/claude-plugins/<pack>/` (one per pack) |
+| `per-pack-apm-package` | RFC-0001 | `dist/apm/<pack>/` (one per pack) |
+| `marketplace` | RFC-0001 | `dist/claude-plugins/marketplace.json` (aggregate) |
+| `per-pack-overlay` | RFC-0002 | self-host overlay of `.apm/` + `seeds/` into the working tree |
+| `composite-agents-md` | RFC-0002 | composed `AGENTS.md` (or any composite text file) at the repo root |
+| `composite-marketplace` | RFC-0002 | composite of per-pack plugin manifests for the self-host marketplace |
+
+Any seventh recipe type requires a new RFC or a spec amendment — see
+Boundaries *Ask first*.
+
+## Primitive types and per-adapter projections
+
+Five primitive types, projected by four reference adapters. Every (primitive,
+adapter) pair has an explicit projection rule; the contract enumerates all
+twenty pairs. Missing pairs default to `dropped` only when the contract
+declares it so explicitly — no implicit defaults.
+
+| Primitive | Source path (in `packs/<pack>/`) | Claude Code | Kiro | Copilot | Codex |
+| --- | --- | --- | --- | --- | --- |
+| `skill` | `.apm/skills/<name>/` | `direct-directory` → `.claude/skills/<name>/` | `direct-directory` → `.kiro/skills/<name>/` | `instruction-file` → `.github/instructions/<name>.instructions.md` | `managed-block-inline` → `AGENTS.md` |
+| `agent` | `.apm/agents/<name>.md` | `direct-file` → `.claude/agents/<name>.md` | `direct-file` (with `kiro-agent-frontmatter-v0.9` rewrite) → `.kiro/agents/<name>.md` | `dropped` | `dropped` |
+| `hook-body` | `.apm/hooks/<name>.{sh,py}` | `direct-file` → `tools/hooks/<name>.{sh,py}` | `direct-file` → `tools/hooks/<name>.{sh,py}` | `direct-file` → `tools/hooks/<name>.{sh,py}` | `direct-file` → `tools/hooks/<name>.{sh,py}` |
+| `hook-wiring` | `.apm/hook-wiring/<name>.toml` | `merge-json` (under `hooks` key of `.claude/settings.local.json`) | `degraded-info-log` (RFC-0001 Open Q1 — until Kiro publishes a schema) | `dropped` | `dropped` |
+| `command` | `.apm/commands/<name>.md` | `direct-file` → `.claude/commands/<name>.md` | `dropped` | `dropped` | `dropped` |
+
+**Hook extensions.** A hook is a script; the runtime is determined by the
+file extension. The build pipeline projects `hook-body` byte-for-byte —
+`.sh` stays `.sh`, `.py` stays `.py`. No conversion. Both extensions are
+valid in `packs/<pack>/.apm/hooks/`.
+
+**`hook-wiring` source format.** One TOML file per hook at
+`.apm/hook-wiring/<name>.toml`. Each file declares the `[hooks]` entries
+to merge into `.claude/settings.local.json` (Claude Code) under the
+`merge-managed-key-only` on-conflict policy. Other adapters consume the
+same source path and project per the table above.
+
+## Boundaries
+
+The three-tier guard that keeps an implementing agent inside the lines.
+*Always do* applies without asking; *Ask first* requires human sign-off
+before proceeding; *Never do* is a hard rule, even under time pressure.
+
+### Always do
+
+- Place the canonical adapter contract at
+  `docs/specs/adapter-contract/contract.toml` with a sibling `schema.json`.
+  This path is RFC-0001's convention; do not move it under
+  `docs/specs/distribution-adapters/`.
+- Use Python stdlib only (target 3.11+ for `tomllib`). Every adapter, every
+  recipe consumer, every validator runs without `pip install`.
+- Place build-pipeline code at `packages/agentbundle/agentbundle/build/`,
+  with recipes under `packages/agentbundle/agentbundle/build/recipes/`,
+  adapter implementations at
+  `packages/agentbundle/agentbundle/build/adapters/{claude_code,kiro,copilot,codex}.py`,
+  and the validator harness at
+  `packages/agentbundle/agentbundle/build/validate.py`. The CLI imports
+  `agentbundle.build` as a library; `tools/build/build.py` is a thin shim
+  (≤ 10 lines, no logic) that calls `python -m agentbundle.build`.
+- Implement all seven projection modes from RFC-0001
+  (`direct-directory`, `direct-file`, `merge-json`, `instruction-file`,
+  `managed-block-inline`, `degraded-info-log`, `dropped`) and honor each
+  mode's per-RFC default `on-conflict` value.
+- Enumerate every (primitive, adapter) pair in `contract.toml`. Missing
+  pairs default to `dropped` only when the contract states so explicitly.
+- Validate pack-internal name uniqueness (no two skills with the same local
+  name inside the same pack) at build time; allow cross-pack name reuse.
+- Source named frontmatter mappings (e.g. `kiro-agent-frontmatter-v0.9`)
+  from the contract TOML's `[frontmatter-mapping.*]` tables — adapters
+  consume them generically, never via Python lookup tables.
+- Source per-adapter frontmatter defaults (e.g. Copilot's `applyTo: "**"`)
+  from `[frontmatter-default.*]` tables — adapters never hardcode the
+  default.
+- Exit non-zero with a one-line stderr message when validation or drift
+  detection fails (so CI and the work-loop's `check-done.py` see the signal).
+- Treat `make build --check` as exactly `make build --self --dry-run` plus
+  a strict exit code: non-zero on any drift, regardless of warning level.
+  The two commands share rendering; `--check` only differs in its gate
+  contract.
+- When sibling specs reference `pack.toml` or `.claude-plugin/plugin.json`
+  shapes, they must link to this spec — flag in PR review if they inline
+  the schema instead.
+
+### Ask first
+
+- Adding any projection mode beyond the seven RFC-0001 lists.
+- Adding any adapter target beyond the four reference adapters.
+- Adding any recipe type beyond the six enumerated in *Recipe set*.
+- Schema changes to `pack.toml` or `.claude-plugin/plugin.json` beyond
+  the RFC-named fields (these are consumed by RFC-0002 and RFC-0003).
+- Any change to `make build`'s seven-subcommand surface (`build`, `build
+  PACK=`, `build RECIPE=`, `--self`, `--self --dry-run`, `--check`,
+  `--scaffold OUTPUT=`).
+- Promoting Kiro hook *wiring* projection out of `degraded-info-log`
+  (RFC-0001 Unresolved Q1 keeps it degraded until Kiro publishes a schema).
+
+### Never do
+
+- **No new top-level directory.** Everything lands under existing
+  `docs/`, `packages/`, `tools/`, `packs/`, or `dist/` (and `dist/` is
+  git-ignored build output, not source). New top-level paths go through RFC.
+- **No Python module outside `packages/agentbundle/` for build-pipeline
+  code.** `tools/build/build.py` is a thin shim only (no logic, ≤ 10
+  lines, imports and calls `agentbundle.build.main`). Adapters, recipes,
+  the validator, the contract loader, and tests all live under
+  `packages/agentbundle/agentbundle/build/`.
+- **No non-stdlib Python dependency.** No `requirements.txt`, no
+  third-party imports, no vendored libraries. `packages/agentbundle/`
+  has a `pyproject.toml` for packaging metadata only — its `dependencies`
+  array is empty. The build pipeline imports only from the standard library.
+- **No install-time placeholder substitution — except `make build --self`.**
+  Every other mode (`make build`, adopter `agentbundle install`, APM
+  `apm install`, Claude `/plugin install`) copies `<adapt:NAME>` markers
+  through unchanged. `make build --self` is the *one authorised mode*
+  that runs marker resolution as a final build step against this repo's
+  concrete values; the resolver itself belongs to the `adapt-to-project`
+  skill, which materialises `.adapt-discovery.toml` from this repo's
+  values before the build step consumes it. RFC-0001 Open Q3
+  (`<adapt:NAME>` for plugin-installed packs) stays deferred to
+  `adapt-to-project`.
+- **No edits to `docs/_templates/`.** Templates are governance scaffolding
+  that ships to adopters; this spec produces distribution machinery, not
+  template changes.
+- **No silent overwrite semantics encoded outside the contract.** Every
+  projection rule's `on-conflict` value lives in `contract.toml` and is
+  carried through into the rendered artifact's manifest (so downstream
+  install tools and the adapt step honor RFC-0001's per-mode defaults).
+  Adapters never hardcode an `on-conflict` policy.
+- **No conformance test suite in this spec.** A *full* per-adapter
+  conformance suite is RFC-0003's work; this spec ships unit-level
+  projection tests per adapter only.
+
+## Testing Strategy
+
+Three behaviors close this spec; each gets one mode and one verification
+artifact.
+
+- **Contract + schema validation — TDD.** The `contract.toml`/`schema.json`
+  pair is pure data with a compressible invariant ("the contract validates
+  against the schema; every adapter block enumerates every (primitive,
+  adapter) pair; every projection rule has a defined `on-conflict`"). TDD
+  because the invariant is what we ship; the test pins it directly, and
+  the same harness powers the validator the build pipeline calls at startup.
+- **Per-adapter projection rules — TDD.** Each of the four adapters maps
+  source primitives to outputs by deterministic rules — pure functions
+  with edge cases (collisions, frontmatter normalization, managed-block
+  delimiters, dropped primitives, degraded-info-log emission). TDD because
+  each rule is a compressible invariant and the rule set is what the
+  contract calls out as the *specification*.
+- **End-to-end build pipeline — goal-based check.** `make build` against
+  the four reference packs on a clean checkout produces the expected
+  `dist/apm/<pack>/` and `dist/claude-plugins/<pack>/` directory shapes
+  plus `dist/claude-plugins/marketplace.json`. The one-liner *is* the
+  contract: `make build && test -f dist/claude-plugins/marketplace.json
+  && test -d dist/apm/core && …`. No mocking layer, no internal
+  assertions; the artifact-on-disk verifies. Same for `make build
+  --check` (the self-host gate): one-liner asserts the command exits zero
+  on a clean tree.
+
+No manual QA: there is no UI surface, no human gesture under test.
+
+## Acceptance Criteria
+
+- [ ] `docs/specs/adapter-contract/contract.toml` exists, covers all four
+  reference adapters (`claude-code`, `kiro`, `copilot`, `codex`), names
+  the five primitive types (`skill`, `agent`, `hook-body`, `hook-wiring`,
+  `command`), enumerates every (primitive, adapter) pair explicitly, and
+  validates against a sibling `docs/specs/adapter-contract/schema.json`.
+- [ ] All seven projection modes (`direct-directory`, `direct-file`,
+  `merge-json`, `instruction-file`, `managed-block-inline`,
+  `degraded-info-log`, `dropped`) appear in `schema.json` as the enum of
+  legal `mode` values, and every projection rule in `contract.toml`
+  carries an `on-conflict` value matching RFC-0001's per-mode default
+  table (or an explicit override from the legal set).
+- [ ] `pack.toml` shape is pinned in
+  `docs/specs/adapter-contract/pack-schema.json` and referenced from
+  `contract.toml`. The schema accepts `[pack]`, `[pack.dependencies]`
+  (with `required`/`recommended`/`conflicts` keys), `[pack.adaptation]`,
+  and `[pack.seeds]` tables per RFC-0001. The schema enforces shape
+  only: `[pack.adaptation] infer-from` must be a string (a non-string
+  is rejected); the semantic set of legal `infer-from` values lives in
+  the `adapt-to-project` skill, not in this schema. A missing
+  `[pack.dependencies.required]` array is *optional* (no required
+  field). The schema's pass/fail tests pin both outcomes plus a
+  `[pack.seeds]` shape check (entries must be relative-path strings;
+  an absolute path or a non-string is rejected).
+- [ ] `.claude-plugin/plugin.json` shape is pinned in a sibling
+  `plugin-manifest-schema.json` validating the hand-authored per-pack
+  manifests. Each pack's manifest is hand-authored at
+  `packs/<pack>/.claude-plugin/plugin.json`; the build copies it
+  unmodified into `dist/claude-plugins/<pack>/`.
+- [ ] `packages/agentbundle/agentbundle/build/` runs under `python3
+  --version` 3.11+ with zero non-stdlib imports (verified by
+  `tools/lint-build.sh` and the `pre-pr.sh` hook — a wrong `import yaml`
+  surfaces in the offending PR, not at end-of-stream). The CI job that
+  runs `pre-pr.sh` exits non-zero on any non-stdlib import under
+  `packages/agentbundle/agentbundle/build/`.
+- [ ] `validate.py` implements a stdlib-only JSON-Schema subset (object,
+  array, string, integer, boolean, enum, required, pattern, items — and
+  only these). The subset is documented in T1a's *Approach*. AC #1
+  verifies `validate.py` accepts the conforming `contract.toml` and
+  rejects each mutation enumerated in `test_contract.py`.
+- [ ] `make build` on a clean checkout (the four reference packs
+  materialised in `packs/`) produces `dist/apm/<pack>/` and
+  `dist/claude-plugins/<pack>/` directories for each of the four
+  reference packs and a single `dist/claude-plugins/marketplace.json`
+  listing every per-pack plugin entry; exit code zero.
+- [ ] Each adapter (`claude_code`, `kiro`, `copilot`, `codex`) has a
+  per-adapter unit-test file under
+  `packages/agentbundle/agentbundle/build/tests/` covering every
+  projection mode that adapter's `contract.toml` block uses (e.g.
+  Copilot exercises `instruction-file`, `direct-file`, and `dropped`;
+  Codex exercises `managed-block-inline`, `direct-file`, and `dropped`)
+  plus the named frontmatter mapping or default where the contract
+  declares one. Idempotence is asserted for `merge-json` (Claude Code)
+  as well as `managed-block-inline` (Codex): running each adapter twice
+  against the same fixture yields byte-identical output.
+- [ ] The build pipeline's validation step (not any individual adapter)
+  rejects a pack whose `.apm/skills/`, `.apm/agents/`, `.apm/hooks/`,
+  `.apm/hook-wiring/`, or `.apm/commands/` contains two primitives with
+  the same local name (pack-internal uniqueness per RFC-0001 §
+  Pack-internal naming and collision policy), with a non-zero exit and
+  a stderr message naming both paths.
+- [ ] `make build --check` (dry-run self-host build + diff against
+  on-disk projection) exits zero on a clean tree and exits non-zero
+  with a per-file drift listing on any divergence. CI wiring of this
+  gate is RFC-0002's spec's job; this spec ships the command.
+- [ ] `make build --self` writes projected output to the working tree,
+  resolves `<adapt:NAME>` markers against `.adapt-discovery.toml` as a
+  final step (the one authorised mode for marker resolution per
+  Boundaries § Never do), refuses on a dirty tree without `--force`,
+  and (with `--force`) honours each adapter's declared `on-conflict`
+  policy from `contract.toml` — `--force` overrides only the dirty-tree
+  refusal, never the per-adapter on-conflict default. Sibling spec
+  `self-hosting` cites this AC.
+- [ ] The supported recipe set is exactly the six types named in
+  § Recipe set (`per-pack-claude-plugin`, `per-pack-apm-package`,
+  `marketplace`, `per-pack-overlay`, `composite-agents-md`,
+  `composite-marketplace`); a seventh requires an amendment to this
+  spec or a new RFC. Sibling specs (self-hosting, CLI) cite this AC
+  when consuming the recipe set.
+- [ ] No new top-level source directory is introduced. Verified by
+  `comm -23 <(git ls-tree --name-only HEAD | sort) <(git ls-tree
+  --name-only main | sort)` returning an empty set after the change
+  lands. `dist/` is git-ignored and does not count. No non-stdlib
+  Python import is added (verified by the import-audit check above).

--- a/docs/specs/self-hosting/plan.md
+++ b/docs/specs/self-hosting/plan.md
@@ -1,0 +1,502 @@
+# Plan: self-hosting
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Drafting
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn. When it changes substantially
+> (a different approach, not just a re-ordering), note why in the changelog
+> at the bottom.
+
+## Approach
+
+The plan executes RFC-0002's four-step migration on top of RFC-0001's
+build pipeline. **T1 cannot start until the sibling distribution-adapters
+spec lands its enumerated-set Acceptance Criterion under § *Recipe set*
+(pinning the six recipe types including the three composite types this
+spec needs) and its Tier-1/2/3 contract definition in this same
+coordinated update.** Sibling AC numbers may shift across reviewer
+passes; this plan cites by description rather than number, and the
+orchestrator reconciles after both fix-passes merge.
+The build pipeline lives at `packages/agentbundle/agentbundle/build/`
+with a thin shim at `tools/build/build.py`; user-facing entry points
+are `make build --self` and `make build --check`. Once the sibling
+amendments and pipeline machinery exist, the self-host work is:
+(1) author the four packs, (2) write the `self-host.toml` recipe using
+the three composite section types defined in the distribution-adapters
+spec, (3) author `.adapt-discovery.toml` so `make build --self` can
+resolve this repo's `<adapt:NAME>` markers as the final build step,
+(4) reconcile pack-side sources until `make build --self --dry-run` is
+a byte-identical no-op, (5) flip the cutover commit, then (6) wire
+`make build --check` as a required CI status and amend
+`docs/CONVENTIONS.md`. The riskiest piece is the reconcile loop —
+every inadvertent whitespace, line-ending, or ordering delta between
+the current hand-maintained projection and the pack-side source
+surfaces as drift. The migration PR pays that cost once.
+
+## Constraints
+
+- [RFC-0002](../../rfc/0002-self-hosting.md) — source-of-truth split,
+  the `--self` flag's semantics, the `make build --check` CI gate, the
+  `self-host.toml` recipe shape, and the migration plan. RFC-0002's
+  *Projected* and *Excluded* tables are the load-bearing list this plan
+  implements.
+- [RFC-0001](../../rfc/0001-bundle-distribution-by-adapter-spec.md) — the
+  adapter contract and build pipeline this plan depends on. The
+  distribution-adapters sibling spec at
+  [`docs/specs/distribution-adapters/spec.md`](../distribution-adapters/spec.md)
+  defines `pack.toml`, `.claude-plugin/plugin.json`, and the recipe
+  schema. This plan references those without redefining them.
+- [`docs/CONVENTIONS.md`](../../CONVENTIONS.md) — the pack source-of-truth
+  split lands as an amendment in the migration PR (T6 below); RFC-0002
+  authorises this without a separate RFC.
+
+**Cross-spec dependency:** tasks below cite distribution-adapters task
+IDs directly. The sibling spec's tasks are: T1a (adapter contract +
+schemas), T1b (`pack.toml` schema), T1c (`plugin.json` schema), T2
+(Claude Code adapter), T3 (Kiro adapter), T4 (Copilot adapter), T5
+(Codex adapter), T6 (build pipeline + recipe dispatch covering all
+six recipe types), T7 (`make build --self --dry-run` + comparison
+gate machinery), T8 (Makefile surface + `make build --check`), T9
+(stdlib-only + no-new-top-level audit). The minimum dependency set
+for each self-hosting task is named under its `Depends on:` field.
+
+## Construction tests
+
+Most construction tests live under each Task's `Tests:` subsection.
+The cross-cutting ones:
+
+**Integration tests:**
+
+- End-to-end self-host smoke: from a clean checkout post-cutover,
+  `make build --self` exits 0 with `git status --porcelain` empty.
+- End-to-end drift detection: introduce a one-character edit to a
+  projected path (e.g. `.claude/skills/work-loop/SKILL.md`), run `make
+  build --check`, assert non-zero exit and a `[drift]` line naming the
+  pack-side source.
+- End-to-end forward-flow: introduce a one-character edit to the
+  pack-side source for the same file, run `make build --self`, assert
+  the projected path is updated to match, assert `make build --check`
+  is then clean.
+
+**Manual verification:**
+
+- Acceptance Criterion 3's first-real-edit gesture (recorded PR URL in
+  the spec's manual-QA artifact list).
+- Visual inspection of the migration PR's `docs/CONVENTIONS.md` diff.
+
+## Tasks
+
+### T1: Pack sources authored under `packs/*/`
+
+**Depends on:** `distribution-adapters` T1a (adapter contract +
+schemas), T1b (`pack.toml` schema), T1c (`plugin.json` schema).
+
+**Tests:**
+
+- Per-pack: `pack.toml` parses against the adapter contract's schema
+  (goal-based, invokes the sibling spec's validator from F-spec).
+- Per-pack: `.claude-plugin/plugin.json` parses against the schema
+  defined in the sibling spec (goal-based).
+- Hand-extracted skill / agent / hook files retain their existing test
+  coverage (TDD, unchanged tests still green post-move).
+- Verifies Acceptance Criterion: pre-requisite for the no-op build.
+
+**Approach:**
+
+- For each pack (`core`, `governance-extras`, `user-guide-diataxis`,
+  `monorepo-extras`), per RFC-0002's *Migration plan* step 1:
+  - Move skills into `packs/<pack>/.apm/skills/<name>/`.
+  - Move agents into `packs/<pack>/.apm/agents/<name>.md`.
+  - Move hook bodies into `packs/<pack>/.apm/hooks/<name>.<ext>`
+    preserving today's source extension. Today's hooks ship as `.sh`
+    under `tools/hooks/`; they move as `.sh`. The `[primitive.hook-body]`
+    projection in the distribution-adapters spec preserves the source
+    extension, so future `.py` hooks are equally valid. No conversion
+    happens in this migration.
+  - Move commands: `.claude/commands/<name>.md` →
+    `packs/<pack>/.apm/commands/<name>.md` (RFC-0002 *Migration plan*
+    step 1 calls out `.claude/commands/conventions-check.md` →
+    `packs/core/.apm/commands/conventions-check.md` explicitly).
+    The sibling spec defines `command` as a first-class primitive
+    with a Claude Code projection back to `.claude/commands/`.
+  - Move hook wiring: each entry under the `hooks` key of
+    `.claude/settings.local.json` →
+    `packs/<pack>/.apm/hook-wiring/<name>.toml` (one TOML per hook).
+    The sibling spec defines `hook-wiring` as a first-class primitive;
+    the Claude Code adapter projects these back via `merge-json` into
+    the `hooks` key of `.claude/settings.local.json`. Per-instance
+    keys in `.claude/settings.local.json` (everything outside the
+    `hooks` key) remain Source category.
+  - Move seed content (`AGENTS.md`, `docs/CHARTER.md`,
+    `docs/CONVENTIONS.md`, template files, seed READMEs) into
+    `packs/<pack>/seeds/...`. Seed paths use the repo's singular
+    convention: `docs/rfc/` and `docs/adr/`, not `docs/rfcs/` or
+    `docs/adrs/`. Normalise any drafting-drift names from RFC-0002
+    during the move; T5 verifies no plural paths remain under
+    `packs/*/seeds/`.
+  - Write `pack.toml` with `[pack.metadata]`, `[pack.adaptation]`, and
+    `recommends` per RFC-0002's enumeration.
+  - Write `.claude-plugin/plugin.json` per the sibling spec's schema.
+- Write `packs/core/seeds/_agents-footer.md` containing the
+  `AGENTS.local.md` pointer line (the working assumption in RFC-0002's
+  *Unresolved questions* #1, adopted as the spec's commitment).
+- Move repo-specific contributor paragraphs out of the current
+  `AGENTS.md` into a new root `AGENTS.local.md` (Source category).
+
+**Done when:** every pack directory under `packs/` has its `pack.toml`,
+`.claude-plugin/plugin.json`, and the `.apm/` + `seeds/` content
+RFC-0002 enumerates. `AGENTS.local.md` exists at the repo root.
+
+### T2: `self-host.toml` recipe authored against distribution-adapters' six-recipe set
+
+**Depends on:** T1, `distribution-adapters` T1c (`plugin.json` schema —
+T2 below loads and aggregates `plugin.json` files), T2 (Claude Code
+adapter), T5 (Codex adapter), T6 (recipe loader + dispatch covering
+all six recipe types per the sibling spec's enumerated-set Acceptance
+Criterion under § *Recipe set*).
+
+**Tests:**
+
+- TDD: `[recipe.per-pack-overlay]` iterates `packs/*/`, copies
+  `.apm/skills/`, `.apm/agents/`, `.apm/hooks/` to the configured
+  targets; copies `seeds/**` to the repo root at seed-relative paths.
+- TDD: file-level collision between two packs' `seeds/` trees (same
+  target path, different content) produces a non-zero exit with both
+  source paths named. Verifies Acceptance Criterion 7.
+- TDD: `[recipe.composite-agents-md]` composes the projected root
+  `AGENTS.md` from BOTH `packs/core/seeds/AGENTS.md` (body) AND
+  `packs/core/seeds/_agents-footer.md` (footer, appended after body),
+  invokes the Codex adapter for the managed block where the contract
+  declares one, writes the assembled file to the configured output
+  path. Two assertions: (a) the head of the projected file matches the
+  body source; (b) the tail of the projected file matches the footer
+  source byte-for-byte after LF normalisation. Verifies Acceptance
+  Criterion 8.
+- TDD: `[recipe.composite-marketplace]` reads
+  `packs/*/.claude-plugin/plugin.json` and emits
+  `.claude-plugin/marketplace.json` with the aggregated entries and the
+  configured `owner` block.
+- TDD: section execution order follows source order in the recipe TOML.
+
+**Approach:**
+
+- Author `packages/agentbundle/agentbundle/build/recipes/self-host.toml`
+  per RFC-0002's *The self-build command* section, verbatim shape.
+- The distribution-adapters spec's enumerated-set Acceptance
+  Criterion under § *Recipe set* pins all six recipe types (the three
+  RFC-0001 types plus the three composite types this recipe uses);
+  the pipeline implementation recognises them per that spec's T6.
+  No extension point is needed on this side.
+- Wire the Claude Code adapter (for `.claude/` projection) and the
+  Codex adapter (for `AGENTS.md`'s managed block) per
+  `[recipe.adapters].targets`.
+
+**Done when:** unit tests above are green. The build pipeline accepts
+`self-host.toml` and produces output into a temp directory without
+error against the T1 pack sources.
+
+### T3: `--self` CLI flag, dirty-tree refusal, `--force` semantics, `.adapt-discovery.toml`
+
+**Depends on:** T2, `distribution-adapters` T7 (`--self --dry-run`
+machinery), T8 (Makefile + `--check` surface).
+
+**Tests:**
+
+- TDD: `make build --self` on clean tree exits 0; output root is the
+  repo (not `dist/`); recipe selection is implicit (`self-host.toml`).
+- TDD: `make build --self` on dirty tree exits non-zero with a stderr
+  line containing the named dirty-tree refusal reason. Verifies
+  Acceptance Criterion 4.
+- TDD: `make build --self --force` on dirty tree proceeds; the
+  byte-equality comparison still runs (no bypass). Verifies Acceptance
+  Criterion 4.
+- TDD: `make build` without `--self` writes to `dist/` (the existing
+  distribution build is preserved).
+- TDD: with `.adapt-discovery.toml` present, `make build --self`
+  resolves every `<adapt:NAME>` marker in source to its repo-local
+  concrete value as the final build step (per the distribution-adapters
+  spec's Acceptance Criterion for `make build --self`, which pins that
+  `--self` writes to the tree, resolves markers, refuses dirty trees
+  without `--force`, and honours on-conflict). Without the file, the
+  build fails fast with a stderr message in the form
+  `missing .adapt-discovery.toml required by --self`.
+- TDD: marker resolution runs only under `--self`. `make build` (no
+  `--self`) copies `<adapt:NAME>` markers through unchanged.
+
+**Approach:**
+
+- The `--self` flag, dirty-tree refusal, and `--force` semantics are
+  implemented in `distribution-adapters` T7 / T8. This task verifies
+  the behaviour from the self-host vantage and pins the
+  `.adapt-discovery.toml` exception for this repo.
+- Author `.adapt-discovery.toml` at the repo root with the concrete
+  values for every `<adapt:NAME>` marker that appears in
+  `packs/*/seeds/` (project name, repo URL, owner, etc.). The resolver
+  itself belongs to the deferred `adapt-to-project` skill; here we
+  materialize the config.
+- `--force` flag toggles only the dirty-tree refusal; the comparison
+  gate is unconditional.
+
+**Done when:** the unit tests above are green; the existing
+distribution build (no `--self`) continues to write into `dist/`;
+`<adapt:NAME>` markers in source resolve to repo-local values only
+under `--self`.
+
+### T4: `make build --check` gate behaviour
+
+**Depends on:** T2, `distribution-adapters` T7 (`--check` command),
+T8 (Makefile surface).
+
+**Tests:**
+
+- TDD: byte-equality after LF normalisation — a file with CRLF on disk
+  and LF in source produces no drift; same content with extra trailing
+  space drifts.
+- TDD: CRLF + `git status` interaction — a CRLF-on-disk file passes
+  the gate (the gate normalises before comparison) but produces a
+  `git status` line because `git status` does not normalise. Documents
+  the `core.autocrlf` expectation for contributors on Windows.
+- TDD: file mode comparison for regular files — `0755` on disk vs
+  `0644` projected drifts.
+- TDD: symlink target comparison via `lstat` — `CLAUDE.md → AGENTS.md`
+  on disk vs `CLAUDE.md → README.md` projected drifts; the gate never
+  follows the link.
+- TDD: missing-on-disk drift — a *Projected* path with no on-disk
+  counterpart produces drift labelled "expected projected output, none
+  on disk".
+- TDD: enumeration uses `git ls-files --cached --others
+  --exclude-standard`; gitignored editor scratch in the worktree does
+  not surface.
+- TDD: unclassified paths (neither *Projected* nor *Excluded*) emit
+  `[info]` lines on stderr and do not fail the build. Verifies
+  Acceptance Criterion 6.
+- TDD: drift failure message names the source path and the
+  regeneration command, per the example in RFC-0002 § Round-trip
+  safety.
+- TDD (regression): a fixture injects drift on a projected path;
+  `make build --check` exits non-zero regardless of `--force` or any
+  other flag combination. The gate has no bypass surface.
+- Goal-based (CI lint): `grep -E 'skip|bypass|SKIP_'` over the build
+  code under `packages/agentbundle/agentbundle/build/` fails CI if any
+  unguarded exit branch with those tokens is introduced.
+- Goal-based: `.github/workflows/build-check.yml` exists and runs
+  `make build --check` on PRs targeting `main`; the workflow exits 0
+  when the projection is up-to-date. Verifies Acceptance Criterion 1a.
+
+**Approach:**
+
+- Implement `make build --check` as a separate sub-command (or as
+  `make build --self --check` — settle in T3's CLI design, but the
+  externally-named contract is `make build --check`). The
+  implementation lives in `packages/agentbundle/agentbundle/build/`;
+  `tools/build/build.py` is a thin shim.
+- Implementation: project into a temp directory, walk the *Projected*
+  table, compare per the rules above. Failure path emits one `[drift]`
+  block per drifting path, naming source and re-run command.
+- Wire into `.github/workflows/build-check.yml`. Registering the
+  workflow as a required status check on `main` is Acceptance
+  Criterion 1b and is recorded by manual QA in T6.
+
+**Done when:** unit tests above are green; a deliberately-introduced
+drift on a feature branch produces a red CI status (covers Acceptance
+Criterion 1a); the `--force` regression test and the `grep` lint both
+fail CI when violated.
+
+### T5: Reconcile pack-side sources until `make build --self --dry-run` is a byte-identical no-op
+
+**Depends on:** T1, T2, T3, T4 (no additional sibling-spec deps
+beyond those carried by T1–T4).
+
+**Tests:**
+
+- Goal-based: `make build --self --dry-run` on the feature branch
+  exits 0 and reports zero would-be-changed paths.
+- Goal-based: integration test under *Construction tests* above
+  (drift introduction + forward-flow) passes locally.
+- Goal-based (path-normalisation): no `docs/rfcs/` or `docs/adrs/`
+  paths remain under `packs/*/seeds/` (covering the singular/plural
+  drafting drift in RFC-0002). Verified by a `find packs -path
+  '*seeds*' \( -path '*/docs/rfcs/*' -o -path '*/docs/adrs/*' \)`
+  one-liner returning empty.
+
+**Approach:**
+
+- Per RFC-0002's *Migration plan* step 2: iterate edit-projection-diff
+  on `packs/*/.apm/` and `packs/*/seeds/` until projected output
+  matches on-disk content under LF-normalised byte rule.
+- Expected delta sources: trailing whitespace, line endings, list
+  ordering, header capitalisation, missing front-matter, missing
+  `_agents-footer.md` content. Each is paid once.
+- The repo's own RFC/ADR/spec entries (e.g. this spec) stay Manual at
+  the projected paths; do not migrate them into `packs/`. Confirm by
+  enumerating `docs/rfc/NNNN-*.md`, `docs/adr/NNNN-*.md`,
+  `docs/specs/<feature>/*` against the *Excluded* table.
+
+**Done when:** `make build --self --dry-run` reports zero changes;
+`git diff` against base shows only `packs/`,
+`packages/agentbundle/agentbundle/build/` (and the `tools/build/`
+shim), and adapter-contract edits.
+
+### T6: Cutover commit, `docs/CONVENTIONS.md` amendment, CI gate required
+
+**Depends on:** T5.
+
+**Tests:**
+
+- Goal-based: post-merge, `make build --self` on `main` exits 0 with
+  `git status --porcelain` empty. Verifies Acceptance Criterion 2.
+- Manual QA: post-merge, `make build --check` is registered as a
+  required status check on branch protection for `main`. Artifact: the
+  output of `gh api repos/{owner}/{repo}/branches/main/protection`
+  showing the workflow's job under
+  `required_status_checks.contexts` (or a screenshot). Verifies
+  Acceptance Criterion 1b.
+- Goal-based: `docs/CONVENTIONS.md` contains a section heading
+  `§ Pack source-of-truth split`; the section text mentions both
+  `packs/*/.apm/` and `packs/*/seeds/` as upstream sources for
+  projected paths; it cites RFC-0002 as the authority; it cites
+  `make build --check` as the enforcing gate. Each claim is verified
+  by a separate `grep` one-liner. Verifies Acceptance Criterion 5.
+- Goal-based: the projected root `AGENTS.md` is composed from BOTH
+  `packs/core/seeds/AGENTS.md` (head matches body source) AND
+  `packs/core/seeds/_agents-footer.md` (tail matches footer source,
+  appended after the body, after LF normalisation). Verifies
+  Acceptance Criterion 8.
+- Goal-based: every seed README path under `docs/architecture/`,
+  `docs/specs/`, `docs/knowledge/`, `docs/product/`, `docs/guides/`,
+  `docs/rfc/`, `docs/adr/`, `docs/_templates/`, and `packages/` listed
+  in RFC-0002's *Projected* table exists on disk and matches its
+  pack-side source under the gate's comparison rules. Verifies
+  Acceptance Criterion 9.
+
+**Approach:**
+
+- Per RFC-0002's *Migration plan* step 3: run `make build --self` for
+  real; commit the result. The commit records that projected content
+  matches source.
+- Amend `docs/CONVENTIONS.md` to describe the pack source-of-truth
+  split (a new sub-section under § *Document hierarchy* or a sibling
+  section, whichever the reviewer prefers). Cite RFC-0002.
+- Per RFC-0002's *Migration plan* step 4: flip `make build --check`
+  to *required* in branch protection for `main`. **PR ordering is
+  pinned:** T6's main PR closes Acceptance Criterion 1a (the workflow
+  file exists and runs green); Acceptance Criterion 1b's branch-
+  protection artifact (the `gh api
+  repos/<repo>/branches/main/protection` output showing `make build
+  --check` under `required_status_checks.contexts`) is captured
+  *after merge* during the Rollout step and recorded against this
+  plan's Changelog — it is not part of T6's PR diff, because branch
+  protection cannot be configured by a PR that hasn't merged yet.
+- Update `docs/specs/README.md` to mark this spec as Implementing
+  (then Shipped after T7).
+
+**Done when:** the post-merge `make build --self` no-op check passes
+on `main`; the `docs/CONVENTIONS.md` amendment is present with all
+four claims; the `AGENTS.md` composition check passes; the seed
+README byte-equality check passes. Acceptance Criterion 1a is
+closed by this task's PR; Acceptance Criterion 1b's artifact is
+recorded in the post-merge Rollout step.
+
+### T7: First real pack-side edit lands through the pipeline
+
+**Depends on:** T6.
+
+**Tests:**
+
+- Manual QA: per the spec's *Testing Strategy*, make a small
+  observable edit to a `packs/*/` source, run `make build --self`,
+  commit, open PR, verify `make build --check` green, merge. Record
+  the PR URL in this plan's changelog and in the spec's Acceptance
+  Criterion 3 artifact.
+- Construction (direct-edit-bounces): on a feature branch, make a
+  one-character edit to a *Projected* path (not its source); run
+  `make build --check`; assert non-zero exit and a `[drift]` line.
+  Verifies the gate *enforces*, not merely *runs*. Pair with the
+  forward-flow integration test in *Construction tests* above to
+  confirm round-trip safety end-to-end on the real repo.
+
+**Approach:**
+
+- Pick a low-stakes edit. Candidates: a one-sentence addition to
+  `packs/core/seeds/docs/CHARTER.md`'s principles, a typo fix in
+  `packs/core/.apm/skills/work-loop/SKILL.md`, a clarification in a
+  seed README.
+- The point is not the edit's content; it's that the muscle-memory
+  works end-to-end and the CI gate is observed green on a real PR.
+
+**Done when:** PR is merged to `main` and its URL is recorded under
+*Changelog* below and in spec.md's Acceptance Criterion 3 artifact
+list.
+
+## Rollout
+
+One-shot, forward-only. RFC-0002's *Migration plan* step 3 is the
+cutover; there is no grace period. After T6, all bundle changes flow
+through `packs/*/`; the CI gate enforces this. Reversal would mean
+re-vendoring the hand-maintained projections as canonical (which loses
+the structural property RFC-0002 exists to gain) or accepting
+build-derived output as the new floor. Plan for forward only.
+
+CI workflow flips to *required* in branch protection at T6. Until
+that flip, the gate runs but does not block — informational only.
+The flip is the moment self-hosting becomes load-bearing. The flip
+itself is configured against the merged `main` branch through the
+GitHub repo settings UI (or `gh api ... -X PATCH`); the artifact
+that closes Acceptance Criterion 1b is the output of
+`gh api repos/<repo>/branches/main/protection` showing
+`make build --check` under `required_status_checks.contexts`,
+captured after the flip and recorded in this plan's Changelog and
+in spec.md's Acceptance Criterion 1b artifact field. This step is
+explicitly post-merge — Acceptance Criterion 1b is not closed by
+T6's PR diff.
+
+## Risks
+
+- **Reconciliation effort exceeds estimate.** RFC-0002 estimates a
+  half-day for T5's reconcile loop. Whitespace / line-ending / list-
+  ordering deltas may compound across the four packs. Mitigation: if
+  T5 stretches past two days of triage, stop and split — land the
+  least-divergent pack first (likely `monorepo-extras` since it's
+  smallest), then the others in subsequent PRs.
+- **Recipe-schema bikeshed.** The six-recipe set is enumerated in the
+  distribution-adapters spec, but exact field shapes inside
+  `[recipe.composite-agents-md]` and `[recipe.composite-marketplace]`
+  may shift during T2 as the recipe is exercised against real pack
+  sources. Mitigation: track shape changes in the
+  distribution-adapters spec; this spec consumes whatever shape lands
+  and adjusts `self-host.toml` accordingly. No new section types
+  introduced here.
+- **CI gate latency.** Re-running the build pipeline and walking every
+  projected path adds seconds to every PR. Implementation cost
+  negligible per RFC-0002 § *Drawbacks*; if it grows past ~30s,
+  cache the temp-directory projection across CI runs.
+- **`.adapt-discovery.toml` correctness.** `make build --self`
+  resolves `<adapt:NAME>` markers using this file; if a marker in
+  source has no entry, the build fails fast (T3 test). Risk is human:
+  someone introduces a new marker in `packs/*/seeds/` without updating
+  `.adapt-discovery.toml`. Mitigation: T3's missing-config test catches
+  this on PR; reviewers add the corresponding entry in the same PR.
+
+## Changelog
+
+- 2026-05-22: initial plan.
+- 2026-05-22: applied cross-cutting decisions CC1–CC6 (canonical
+  spec directory `docs/specs/self-hosting/`; singular `docs/rfc/` /
+  `docs/adr/` paths; the literal CONVENTIONS heading is
+  `## Pack source-of-truth split`; recipes live under
+  `packages/agentbundle/agentbundle/build/recipes/`; hook source
+  extensions `.sh` and `.py` both valid; `<adapt:NAME>` resolution
+  scoped to `make build --self`). Applied adversarial-reviewer
+  pass-1 findings (T1 hook-extension preservation, T3
+  `.adapt-discovery.toml` and missing-config failure semantics, T6
+  branch-protection artifact, composite-recipe field flux risk).
+  Applied adversarial-reviewer pass-2 findings (cite sibling ACs
+  by description rather than number; add `command` and
+  `hook-wiring` primitives to T1 migration; add T1c to T2's
+  Depends-on; pin AC1a/AC1b PR ordering with the branch-protection
+  artifact captured post-merge in Rollout; extend the
+  drafting-drift note to cover stale recipe path and `.py`-only
+  hook references in RFC-0002; add ACs anchoring marker
+  resolution under `--self` with the stderr failure message
+  format).

--- a/docs/specs/self-hosting/spec.md
+++ b/docs/specs/self-hosting/spec.md
@@ -1,0 +1,317 @@
+# Spec: self-hosting
+
+- **Status:** Draft
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** [RFC-0001](../../rfc/0001-bundle-distribution-by-adapter-spec.md), [RFC-0002](../../rfc/0002-self-hosting.md)
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+> **Naming note (drafting drift in RFC-0002).** RFC-0002 contains four
+> drafting-drift items this spec normalises against the on-disk scaffold:
+> (1) it refers to this work as `self-hosting-bootstrap` in some places
+> (Composition with RFC-0001, Follow-on artifacts) — the canonical spec
+> directory is `docs/specs/self-hosting/`; (2) it uses plural
+> `docs/rfcs/` / `docs/adrs/` paths — this spec adopts the singular
+> `docs/rfc/` / `docs/adr/` that match the repo on disk; (3) it points
+> at `tools/build/recipes/self-host.toml` — recipes live under
+> `packages/agentbundle/agentbundle/build/recipes/` per the sibling
+> distribution-adapters spec's *Always do* enumeration; (4) it shows
+> hook bodies as `packs/<pack>/.apm/hooks/<name>.py` — both `.sh` and
+> `.py` are valid per the sibling spec's hook extension policy, and
+> today's hooks ship as `.sh`. `§` in this spec means "section."
+>
+> **Schema authority.** The sibling spec at
+> [`docs/specs/distribution-adapters/spec.md`](../distribution-adapters/spec.md)
+> defines `pack.toml`, `.claude-plugin/plugin.json`, the Tier-1/2/3 contract,
+> the `.agent-ready-state.toml` schema, and the `.upstream.<ext>` semantics.
+> It also enumerates the six projection recipe types
+> (`per-pack-claude-plugin`, `per-pack-apm-package`, `marketplace`,
+> `per-pack-overlay`, `composite-agents-md`, `composite-marketplace`) and
+> the five primitive types (`skill`, `agent`, `hook-body`, `hook-wiring`,
+> `command`). This spec references those definitions; it does not redefine
+> them.
+
+## Objective
+
+This repo becomes the first consumer of its own build pipeline. A single
+command, `make build --self`, reads every `packs/<pack>/.apm/` and
+`packs/<pack>/seeds/` tree plus the adapter contract and projects a Claude
+Code overlay onto the repo itself — every path listed in RFC-0002's
+*Projected* table lands at its target location, byte-for-byte identical to
+what would result if an adopter had installed every pack and run the
+adaptation step against this repo's concrete values. A CI gate,
+`make build --check`, runs on every PR and refuses to merge if any
+projected path on disk diverges from what the pipeline would emit. After
+cutover, the only legitimate way to change a projected path's content is
+to edit its pack-side source and re-project; direct edits to projected
+paths are caught and bounced. Success for a maintainer is that the same
+muscle memory used by adopters — edit `packs/<pack>/.apm/...` or
+`packs/<pack>/seeds/...`, run `make build --self`, commit — is the only
+muscle memory that produces a green PR for changes to the bundle.
+
+## Boundaries
+
+### Always do
+
+- Read source-of-truth from `packs/*/.apm/` (including
+  `packs/<pack>/.apm/skills/`, `packs/<pack>/.apm/agents/`,
+  `packs/<pack>/.apm/hooks/`, `packs/<pack>/.apm/commands/`, and
+  `packs/<pack>/.apm/hook-wiring/`), `packs/*/seeds/`, the adapter
+  contract at `docs/specs/adapter-contract/`, and the build pipeline at
+  `packages/agentbundle/agentbundle/build/` (with a thin shim at
+  `tools/build/build.py`; the user-facing entry points are still
+  `make build --self` and `make build --check`). Project to the paths
+  enumerated in RFC-0002's *Projected* table — which includes
+  `.claude/commands/<name>.md` (projected from
+  `packs/*/.apm/commands/`) and the `hooks` key of
+  `.claude/settings.local.json` (projected from
+  `packs/*/.apm/hook-wiring/` via the Claude Code adapter's
+  `merge-json` projection).
+- Compose root `AGENTS.md` from BOTH `packs/core/seeds/AGENTS.md` (the
+  body) AND `packs/core/seeds/_agents-footer.md` (the pointer footer,
+  appended after the body, LF-normalised). The `composite-agents-md`
+  recipe defined in the distribution-adapters spec drives this
+  composition.
+- Preserve hook source extension. A hook is a script; the build pipeline's
+  `[primitive.hook-body]` projection copies `.sh` or `.py` through
+  unchanged. Today's `tools/hooks/*.sh` are valid; future `.py` hooks are
+  also valid. No conversion happens during migration.
+- Resolve `<adapt:NAME>` markers as a final build step under
+  `make build --self` only — the one authorised mode that runs marker
+  resolution per the distribution-adapters spec's Acceptance Criterion
+  for `make build --self` (the AC pinning that `--self` writes to the
+  tree, resolves markers, refuses dirty trees without `--force`, and
+  honours on-conflict policy). The resolver itself belongs to the
+  `adapt-to-project` skill (deferred); for self-host, materialize a
+  repo-local `.adapt-discovery.toml` with this repo's concrete values
+  and apply it. All other build modes copy markers through unchanged.
+- Compare projected output against on-disk content byte-for-byte after
+  CRLF→LF normalisation, with file mode bits compared for regular files
+  and symlink targets compared via `lstat` (never follow symlinks).
+- Enumerate candidate paths from the git-tracked + untracked-but-not-
+  ignored set, so editor scratch and gitignored build outputs do not
+  surface in either the comparison or the unclassified-path report.
+- Emit `[info]` lines to stderr for on-disk paths that fall in neither
+  the *Projected* nor *Excluded* categories. Info-level messages do not
+  fail the build; they surface omissions so the next PR can classify
+  them.
+- On drift, name the source path and the regeneration command in the
+  failure message (`Edit <source>; run: make build --self`).
+- Refuse `make build --self` on a dirty working tree unless `--force` is
+  passed. `--force` bypasses only the dirty-tree refusal; it never
+  bypasses the comparison gate.
+- Update `docs/CONVENTIONS.md` in the same migration PR to record the
+  pack source-of-truth split as a convention. The literal markdown
+  heading is `## Pack source-of-truth split` (no `§` in the heading
+  itself; `§` elsewhere in this spec is shorthand for "section"). Its
+  minimum claims are: names `packs/*/.apm/` and `packs/*/seeds/` as the
+  upstream for every projected path; cites RFC-0002; cites
+  `make build --check` as the gate that enforces the split. RFC-0002
+  authorises this amendment; no separate RFC is needed.
+
+### Ask first
+
+- Reclassifying any path between *Source*, *Projected*, and *Excluded*
+  beyond what RFC-0002's tables specify. Edits to the *Projected* table
+  itself need human sign-off (and may need an RFC if structural).
+- Introducing a new `[recipe.*]` section type beyond the enumerated
+  six-recipe set defined in the distribution-adapters spec
+  (`per-pack-claude-plugin`, `per-pack-apm-package`, `marketplace`,
+  `per-pack-overlay`, `composite-agents-md`, `composite-marketplace`).
+  The sibling spec pins this set in its dedicated enumerated-set
+  Acceptance Criterion under § *Recipe set*. New section types require
+  an RFC and a coordinated update to the distribution-adapters spec;
+  they affect the recipe schema shared across the bundle.
+- Treating a file-level collision between two packs' `seeds/` trees as
+  anything other than a build-time error. RFC-0002 mandates surfacing
+  these for human resolution by rename or consolidation.
+- Any deviation from byte-for-byte equality as the comparison standard
+  (e.g. ignore-whitespace, ignore-ordering). The comparison standard is
+  the gate's load-bearing property.
+
+### Never do
+
+- **Direct edits to any *Projected* path post-cutover.** After step 3 of
+  the migration plan, every change to a projected path flows through
+  `packs/*/`. The CI gate enforces this; no local override exists.
+- **New top-level directories outside the RFC-0001 / RFC-0002 layout.**
+  Top-level structure is governed by RFC; new top-level entries need
+  their own RFC, not a self-host change.
+- **Local hooks that enforce the gate.** Enforcement is CI-only by
+  design. No `pre-commit`, no `pre-push`, no `Stop` hook that runs
+  `make build --check`. The maintainer-side ergonomics rely on the gate
+  being a CI signal, not a local interruption.
+- **Retroactive re-attribution of past commits to pack-side paths.**
+  Migration is forward-only per RFC-0002's *Migration plan* step 3. The
+  one-shot cutover commit records that projected content matches source;
+  history before that commit is not rewritten.
+- **Bypassing the comparison gate via `--force`.** `--force` is scoped
+  to the dirty-tree refusal. The gate's byte-equality check has no
+  bypass flag.
+- **Adapters or recipes beyond the enumerated set.** `make build --self`
+  uses only the `claude-code` and `codex` adapters and the six
+  enumerated projection recipes from the distribution-adapters spec
+  (`per-pack-claude-plugin`, `per-pack-apm-package`, `marketplace`,
+  `per-pack-overlay`, `composite-agents-md`, `composite-marketplace`).
+  New adapters or recipes require an RFC.
+
+### Excluded paths
+
+The full *Excluded* table (paths that live on disk but are not derived
+from `packs/*/`) is defined in RFC-0002's *What stays out* table and
+referenced here without copy. The gate emits neither drift nor `[info]`
+for these paths. The classes are: per-instance state
+(`AGENTS.local.md`, `.claude/settings.local.json`,
+`.claude-plugin/marketplace.json` when not generated, `dist/`,
+`.adapt-discovery.toml`), governance under `docs/rfc/`, `docs/adr/`,
+`docs/specs/`, `docs/architecture/overview.md`, the migration commit
+metadata, and `packs/*/` themselves (sources, not projections). New
+classifications go through RFC-0002 amendment.
+
+## Testing Strategy
+
+Each user-visible outcome from the Objective pairs with a verification
+mode below. Modes align with the work-loop skill's three (TDD,
+goal-based check, visual / manual QA).
+
+- **`make build --check` gate behaviour** — TDD plus goal-based. Unit
+  tests cover the comparison rules (LF normalisation, mode-bit
+  comparison, symlink-target comparison via `lstat`, missing-counterpart
+  drift, info-level unclassified-path reporting, file-collision error).
+  This spec owns these unit tests; the distribution-adapters spec's T7
+  imports them as a regression gate rather than re-implementing them.
+  The comparison rules are properties of the gate, which this spec
+  delivers. Why TDD: each rule is a compressible invariant
+  with named inputs and outputs. A construction test verifies the gate
+  *enforces*, not just runs: make a one-character edit to a projected
+  path (not its source), run `make build --check`, assert non-zero exit
+  and a `[drift]` line. A regression test asserts `--force` and any
+  flag combination never bypass the comparison gate (a fixture injects
+  drift; `make build --check` exits non-zero regardless of flags). A
+  CI-side static check greps build code for `skip|bypass|SKIP_` exit
+  branches and fails if any are introduced. A CRLF/`core.autocrlf` test
+  asserts that a CRLF-on-disk file passes the gate (because the gate
+  normalises CRLF→LF before comparison) but still produces a `git
+  status` change (because `git status` does not). A goal-based check
+  asserts the workflow file exists and runs `make build --check`.
+- **Branch-protection required-status registration** — manual QA. The
+  required-status registration is a GitHub setting, not a repo file;
+  capture `gh api
+  repos/{owner}/{repo}/branches/main/protection` output (or a
+  screenshot) showing `make build --check` listed under
+  `required_status_checks.contexts`. Recorded as the artifact for
+  Acceptance Criterion 1b.
+- **`make build --self` is a no-op on a clean checkout** — goal-based.
+  The one-liner: on `main` after cutover, `make build --self` produces
+  zero changes to the working tree (`git status --porcelain` emits no
+  lines). Why goal-based: the outcome is observable as a single
+  filesystem condition; an extra unit test asserting the same thing
+  would mirror the implementation.
+- **Dirty-tree refusal and `--force` semantics** — TDD. Unit tests for
+  the CLI surface: dirty tree without `--force` exits non-zero with a
+  named reason; dirty tree with `--force` proceeds but the resulting
+  build still runs the comparison gate. Why TDD: small invariant,
+  state-machine shape (clean/dirty × with-force/without-force).
+- **`AGENTS.md` composition (body + footer)** — goal-based. After
+  `make build --self` on a clean checkout, the projected root
+  `AGENTS.md` consists of `packs/core/seeds/AGENTS.md` (the body)
+  followed by `packs/core/seeds/_agents-footer.md` (the pointer
+  footer), composed by the `composite-agents-md` recipe per the
+  distribution-adapters spec. Two one-liners verify: (1) the head of
+  the projected `AGENTS.md` matches the body source; (2) the tail of
+  the projected `AGENTS.md` equals the contents of the footer source
+  (after the same LF normalisation the gate uses).
+- **First real pack-side edit lands through the pipeline** — manual QA.
+  After cutover, a maintainer makes a small, observable edit to a
+  projected path's source (e.g. a one-sentence addition in
+  `packs/core/seeds/docs/CHARTER.md` or a typo fix in
+  `packs/core/.apm/skills/work-loop/SKILL.md`), runs `make build
+  --self`, commits the resulting diff, opens a PR, and observes that
+  `make build --check` is green. The PR description records that the
+  edit was made pack-side, not at the projected path. This QA gesture
+  closes Acceptance Criterion 3; the recorded PR URL is the artifact.
+- **CONVENTIONS.md amendment** — goal-based. The migration PR contains
+  a `docs/CONVENTIONS.md` diff adding a `§ Pack source-of-truth split`
+  section. A `grep` against the post-merge file verifies the section
+  heading exists, that it names both `packs/*/.apm/` and `packs/*/seeds/`
+  as the upstream for projected paths, that it cites RFC-0002, and that
+  it cites `make build --check` as the enforcing gate. Each claim is a
+  separate grep one-liner.
+
+Tests for the build pipeline's projection logic itself (path
+iteration, file copy semantics, `[recipe.per-pack-overlay]` /
+`[recipe.composite-agents-md]` / `[recipe.composite-marketplace]`
+expansion) live with the sibling distribution-adapters spec, which
+owns the pipeline implementation. This spec consumes the pipeline; it
+verifies the self-host shape on top. The unit tests for the
+comparison rules themselves (LF normalisation, mode-bit comparison,
+symlink-via-`lstat`) are owned by this spec, as noted above; the
+distribution-adapters spec's T7 imports them as a regression gate.
+
+## Acceptance Criteria
+
+- [ ] **AC1a (workflow).** `.github/workflows/build-check.yml` runs
+  `make build --check` on PRs targeting `main` and exits 0 when the
+  projection is up-to-date. The workflow runs the build pipeline with
+  `--self` into a temporary directory and compares every *Projected*
+  path byte-for-byte after LF normalisation, including file mode bits
+  for regular files and symlink targets via `lstat`. Verified
+  goal-based by T4.
+- [ ] **AC1b (branch protection).** GitHub branch protection on `main`
+  lists `make build --check` (the workflow's job name) as a required
+  status check. Verified manually; the recorded artifact is the output
+  of `gh api repos/{owner}/{repo}/branches/main/protection` showing
+  the job under `required_status_checks.contexts` (or an equivalent
+  screenshot).
+- [ ] `make build --self` on a clean checkout of `main` produces no
+  on-disk change. `git status --porcelain` emits zero lines.
+- [ ] At least one real pack-side edit has landed on `main` via the
+  pipeline: the merged commit modifies both a `packs/*/` source path
+  and its corresponding *Projected* path, and no commit on `main` after
+  the cutover commit modifies a *Projected* path without a
+  corresponding `packs/*/` edit. A linked PR URL records the manual-QA
+  gesture.
+- [ ] `make build --self` refuses on a dirty working tree with a named
+  reason (non-zero exit; stderr contains the dirty-tree refusal
+  message). `--force` bypasses the dirty-tree refusal only; the
+  byte-equality comparison runs regardless.
+- [ ] The migration PR contains a `docs/CONVENTIONS.md` amendment
+  whose literal markdown heading is `## Pack source-of-truth split`.
+  At minimum the section names `packs/*/.apm/` and `packs/*/seeds/`
+  as the upstream for every projected path, cites RFC-0002 as the
+  authority, and cites `make build --check` as the enforcing gate.
+- [ ] On-disk paths that fall in neither *Projected* nor *Excluded*
+  surface as `[info]` lines on stderr during `make build --check`,
+  without failing the build.
+- [ ] File-level collisions across packs' `seeds/` trees (same target
+  path, different content) cause `make build --self` to exit non-zero
+  with a named error identifying the colliding source files.
+- [ ] The projected root `AGENTS.md` is composed from BOTH
+  `packs/core/seeds/AGENTS.md` (the body) AND
+  `packs/core/seeds/_agents-footer.md` (the pointer footer, appended
+  after the body). The composition is performed by the
+  `composite-agents-md` recipe defined in the distribution-adapters
+  spec; T2 tests verify both the body match and the footer append.
+- [ ] Seed READMEs under `docs/architecture/`, `docs/specs/`,
+  `docs/knowledge/`, `docs/product/`, `docs/guides/`, `docs/rfc/`,
+  `docs/adr/`, `docs/_templates/`, and `packages/` are *Projected*;
+  the gate enforces byte-equality with their pack-side sources.
+- [ ] `.claude/commands/<name>.md` is *Projected* from
+  `packs/*/.apm/commands/<name>.md` per the Claude Code adapter's
+  `command` primitive projection. The gate enforces byte-equality;
+  any direct edit to `.claude/commands/<name>.md` drifts.
+- [ ] The `hooks` key of `.claude/settings.local.json` is *Projected*
+  from `packs/*/.apm/hook-wiring/<name>.toml` via the Claude Code
+  adapter's `merge-json` projection. Other keys in
+  `.claude/settings.local.json` remain per-instance state and are
+  *Excluded*. The gate compares the `hooks` key only.
+- [ ] `make build --self` resolves `<adapt:NAME>` markers in source
+  to concrete values from `.adapt-discovery.toml` as the final build
+  step before writing.
+- [ ] `make build` without `--self` copies `<adapt:NAME>` markers
+  through unchanged; no resolution runs.
+- [ ] Missing `.adapt-discovery.toml` under `make build --self`
+  causes fail-fast with a named stderr message in the form
+  `missing .adapt-discovery.toml required by --self`.


### PR DESCRIPTION
## Summary

Three coordinated specs translating the accepted RFCs into verifiable contracts and implementation plans. Drafted via the `new-spec` skill, three adversarial-reviewer passes, converged clean at pass 3 (the cap).

- **`distribution-adapters/`** (RFC-0001) — F-spec + F-build. Adapter contract, build pipeline, four reference adapters (claude-code, kiro, copilot, codex), pack.toml/plugin.json schemas, Tier-1/2/3 model, 6-recipe set, five primitives × four adapters projection table. Format source-of-truth for the other two.
- **`self-hosting/`** (RFC-0002) — `make build --self` / `--check` gate; this repo builds its own bundle. Owns LF/mode/symlink comparison-rule unit tests; AC1a/AC1b split honest (workflow vs branch protection).
- **`agent-spec-cli/`** (RFC-0003) — `agentbundle` CLI at `packages/agentbundle/`. Library-first, stdlib only, zipapp. Eleven subcommands incl. per-primitive `upgrade`. Option A for git URL fetch (urllib+tarfile; SSH deferred to v1.1).

User decisions captured along the way:
- CC1–CC6: `<adapt:NAME>` carve-out for `--self`; F-build co-locates with the CLI at `packages/agentbundle/agentbundle/build/`; this spec defines Tier model + state schema + companion-file semantics; 6-recipe set enumerated; `command` is the 5th primitive; hook extensions support both `.sh` and `.py`.
- Option A for git URL fetch: `urllib.request` + `tarfile` against GitHub's archive endpoint; SSH deferred to v1.1.

Cross-spec citations are **by description**, not by AC number, since numbers shifted across passes.

## Test plan

- [x] Three reviewer passes per spec (adversarial-reviewer in spec mode); all converged clean
- [x] `docs/specs/README.md` active-specs table updated
- [ ] Reader sanity check: skim each spec's Objective + Boundaries + AC; flag anything that reads like implementation creep