### PR TITLE
chore(self-hosting): record AC1b artifact — branch protection on main

### DIFF
--- a/docs/specs/self-hosting/notes/ac1b-branch-protection.json
+++ b/docs/specs/self-hosting/notes/ac1b-branch-protection.json
@@ -1,0 +1,46 @@
+{
+    "url": "https://api.github.com/repos/eugenelim/agent-ready-repo/branches/main/protection",
+    "required_status_checks": {
+        "url": "https://api.github.com/repos/eugenelim/agent-ready-repo/branches/main/protection/required_status_checks",
+        "strict": true,
+        "contexts": [
+            "make build-check"
+        ],
+        "contexts_url": "https://api.github.com/repos/eugenelim/agent-ready-repo/branches/main/protection/required_status_checks/contexts",
+        "checks": [
+            {
+                "context": "make build-check",
+                "app_id": 15368
+            }
+        ]
+    },
+    "required_signatures": {
+        "url": "https://api.github.com/repos/eugenelim/agent-ready-repo/branches/main/protection/required_signatures",
+        "enabled": false
+    },
+    "enforce_admins": {
+        "url": "https://api.github.com/repos/eugenelim/agent-ready-repo/branches/main/protection/enforce_admins",
+        "enabled": false
+    },
+    "required_linear_history": {
+        "enabled": false
+    },
+    "allow_force_pushes": {
+        "enabled": false
+    },
+    "allow_deletions": {
+        "enabled": false
+    },
+    "block_creations": {
+        "enabled": false
+    },
+    "required_conversation_resolution": {
+        "enabled": false
+    },
+    "lock_branch": {
+        "enabled": false
+    },
+    "allow_fork_syncing": {
+        "enabled": false
+    }
+}

--- a/docs/specs/self-hosting/plan.md
+++ b/docs/specs/self-hosting/plan.md
@@ -533,6 +533,15 @@ T6's PR diff.
   hook references in RFC-0002; add ACs anchoring marker
   resolution under `--self` with the stderr failure message
   format).
+- 2026-05-22 (post-merge, AC1b): registered `make build-check` as a
+  required status check on `main` via
+  `gh api -X PUT repos/eugenelim/agent-ready-repo/branches/main/protection`.
+  Config: `required_status_checks.strict = true`,
+  `required_status_checks.contexts = ["make build-check"]`,
+  `enforce_admins = false`, no required PR reviews, no push
+  restrictions. Artifact captured at
+  `docs/specs/self-hosting/notes/ac1b-branch-protection.json`. AC1b
+  closed.
 - 2026-05-22 (EXECUTE fix-pass): user requested follow-up additions to
   the same PR. Lifted from Phase 2 to Phase 1: seed projection
   (`_project_seeds` with collision check), marketplace aggregation

--- a/docs/specs/self-hosting/spec.md
+++ b/docs/specs/self-hosting/spec.md
@@ -348,12 +348,16 @@ and the Codex multi-pack aggregation fix land.
 - [x] **AC1a (workflow) — Phase 1.** `.github/workflows/build-check.yml` runs
   `make build-check` on PRs targeting `main` and exits 0 when the
   Phase-1 projection is up-to-date. Verified goal-based by T4.
-- [ ] **AC1b (branch protection) — Phase 1, post-merge.** GitHub branch
+- [x] **AC1b (branch protection) — Phase 1, post-merge.** GitHub branch
   protection on `main` lists `make build-check` (the workflow's job
-  name) as a required status check. Verified manually; the recorded
-  artifact is the output of `gh api repos/{owner}/{repo}/branches/main/protection`
-  showing the job under `required_status_checks.contexts` (or an
-  equivalent screenshot). Captured *after* this PR merges.
+  name) as a required status check. Configured 2026-05-22 via
+  `gh api -X PUT repos/eugenelim/agent-ready-repo/branches/main/protection`
+  with `strict: true` (PRs must be up-to-date with main) and
+  `enforce_admins: false` (admins retain a hotfix escape hatch).
+  Artifact at
+  [`notes/ac1b-branch-protection.json`](notes/ac1b-branch-protection.json)
+  — the captured `gh api .../branches/main/protection` output showing
+  `make build-check` under `required_status_checks.contexts`.
 - [x] **AC2 (no-op build) — Phase 1.** `make build-self` on a clean
   checkout of `main` produces no on-disk change. `git status
   --porcelain` emits zero lines. Verified locally on the


### PR DESCRIPTION
## Summary

Post-merge follow-up to PR #18 (self-hosting Phase 1). Records the AC1b artifact: \`make build-check\` is now a required status check on \`main\`.

## What landed

- **Branch protection configured** via \`gh api -X PUT repos/eugenelim/agent-ready-repo/branches/main/protection\`:
  - \`required_status_checks.strict = true\` (PRs must be up-to-date with main before merge)
  - \`required_status_checks.contexts = [\"make build-check\"]\`
  - \`enforce_admins = false\` (preserves admin hotfix escape hatch)
  - No required PR reviews, no push restrictions
- **Artifact captured** at \`docs/specs/self-hosting/notes/ac1b-branch-protection.json\` — the \`gh api .../branches/main/protection\` output showing \`make build-check\` under \`required_status_checks.contexts\`.
- **spec.md AC1b flipped** to \`[x]\` with the artifact link.
- **plan.md changelog** records the configuration command + values.

## Why a separate PR

PR #18's plan.md and spec.md explicitly noted that AC1b cannot land in the parent PR because branch protection is configured against the *merged* \`main\` branch. This PR captures the artifact after the cutover took effect.

## Remaining open

- **AC3** — first real pack-side edit landing through the pipeline (small post-merge gesture)
- **Phase 2** — AGENTS.md body+footer composition (needs Codex multi-pack fix in sibling spec); LF/mode/lstat comparison-rule strengthening

## Test plan

- [x] \`make build-check\` is configured as required (the workflow on this very PR is now enforcing it)
- [x] PR will only become mergeable once \`make build-check\` passes — meta-verification of the gate