### PR TITLE
docs(architecture): point contributors at pack source-of-truth split (closes AC3)

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -15,3 +15,10 @@ Architecture docs are the *rolled-up snapshot* — the answer to "what
 does this codebase look like today" without replaying ADR history.
 Lifecycle: living. Update whenever the layout or major dependencies
 change.
+
+Note for contributors: the bundle's source-of-truth split (skills,
+agents, hooks, commands, hook-wiring, and pack seeds all live under
+`packs/<pack>/`) is described in
+[`../CONVENTIONS.md` § Pack source-of-truth split](../CONVENTIONS.md#pack-source-of-truth-split).
+Anything in this directory documents the *projected* layout adopters
+end up with; the pack-side authoring rules are in CONVENTIONS.

--- a/packs/core/seeds/docs/architecture/README.md
+++ b/packs/core/seeds/docs/architecture/README.md
@@ -15,3 +15,10 @@ Architecture docs are the *rolled-up snapshot* — the answer to "what
 does this codebase look like today" without replaying ADR history.
 Lifecycle: living. Update whenever the layout or major dependencies
 change.
+
+Note for contributors: the bundle's source-of-truth split (skills,
+agents, hooks, commands, hook-wiring, and pack seeds all live under
+`packs/<pack>/`) is described in
+[`../CONVENTIONS.md` § Pack source-of-truth split](../CONVENTIONS.md#pack-source-of-truth-split).
+Anything in this directory documents the *projected* layout adopters
+end up with; the pack-side authoring rules are in CONVENTIONS.


### PR DESCRIPTION
## Summary

Self-hosting **AC3** ("first real pack-side edit lands through the pipeline"). The muscle-memory check that the source-of-truth split actually works end-to-end on this repo.

## What changed

One paragraph added to \`docs/architecture/README.md\`:

> Note for contributors: the bundle's source-of-truth split (skills, agents, hooks, commands, hook-wiring, and pack seeds all live under \`packs/<pack>/\`) is described in [\`../CONVENTIONS.md\` § Pack source-of-truth split](../CONVENTIONS.md#pack-source-of-truth-split). Anything in this directory documents the *projected* layout adopters end up with; the pack-side authoring rules are in CONVENTIONS.

## How the edit was made (the actual point of AC3)

\`\`\`bash
# 1. Edit pack-side source
vim packs/core/seeds/docs/architecture/README.md

# 2. Dry-run shows drift between seed and on-disk projection
make build-self DRY_RUN=1 PACKS_DIR=packs FORCE=1
# → [drift] docs/architecture/README.md: edit packs/core/seeds/docs/architecture/README.md; run: make build-self

# 3. Real write projects the seed to disk
make build-self PACKS_DIR=packs FORCE=1

# 4. Dry-run is clean
make build-self DRY_RUN=1 PACKS_DIR=packs FORCE=1
# → exit 0

# 5. Commit both files together
git add docs/architecture/README.md packs/core/seeds/docs/architecture/README.md
\`\`\`

The drift message correctly named the source path and regen command — AC17 (drift source-naming) verified live.

## Diff shape

\`\`\`
docs/architecture/README.md                  | 7 +++++++
packs/core/seeds/docs/architecture/README.md | 7 +++++++
\`\`\`

Both files modified, identical 7-line addition. The merged commit will satisfy AC3's requirement that \"the merged commit modifies both a \`packs/*/\` source path and its corresponding *Projected* path.\"

## Test plan

- [x] Drift detected when only the seed was edited; correct message
- [x] Real-write updated the projection byte-identically
- [x] \`make build-check PACKS_DIR=packs\` exit 0 locally
- [ ] CI \`make build-check\` workflow exit 0 (the required status check)

After merge, this PR's URL goes into spec.md AC3's artifact field (separate small follow-up).