### PR TITLE
feat(agentbundle): land RFC-0004 install-scope dimension (contract v0.2)

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -387,6 +387,21 @@ upstream under `packs/<pack>/.apm/` or `packs/<pack>/seeds/`, then run
 commit, push. The gate is the contract; the source-of-truth split is
 the convention.
 
+### Install scope is per-pack ([RFC-0004](rfc/0004-install-scope-per-pack.md))
+
+Each pack declares its install **scope** — `repo` (project-local), `user`
+(shared across every repo the adopter opens), or both — in
+`pack.toml`'s `[pack.install]` table. The pack author picks the
+dimension; adopters can override within the publisher's declared set
+via `--scope`. The default landing for every pack we ship today is
+`repo`; user-scope eligibility requires content portability that the
+falsifiable test in [the migration guide](guides/how-to/v01-to-v02-pack-upgrade.md)
+governs. The schema enforces `default-scope ∈ allowed-scopes` so the
+rule holds outside the CLI. `agentbundle install` re-runs the
+contract-level user-scope rails (seeds / hooks / marker) against the
+resolved pack content at install time, closing the
+widen-after-publish gap.
+
 ---
 
 ## Commits

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -57,33 +57,48 @@ recorded via PR #21. The remaining work is Phase 2.
   `SELF_HOST_ADAPTERS` once the multi-pack aggregation fix lands so
   AGENTS.md's managed block can project correctly.
 
-## `distribution-adapters` — shipped
+## `distribution-adapters` — shipped (v0.2 contract bump landed)
 
 Spec: [`specs/distribution-adapters/spec.md`](specs/distribution-adapters/spec.md).
 Shipped via the build-pipeline PRs that introduced
-`packages/agentbundle/agentbundle/build/` and the four reference adapters.
+`packages/agentbundle/agentbundle/build/` and the four reference
+adapters. The [RFC-0004](rfc/0004-install-scope-per-pack.md) v0.2
+amendment (install-scope dimension; `[scope]` table on the adapter
+contract; `[pack.install]` table on `pack.toml`; user-scope refusal
+rails A/B/C; state-file v0.2 + `init-state --migrate`; four shipped
+packs declare `[pack.adapter-contract] version = "0.2"`) landed in
+the same PR; ACs #14–#18 are satisfied.
 
-- *No open items of substance.* The spec body's Acceptance Criteria
-  checkboxes are literally `- [ ]` (bookkeeping drift from the
-  shipping PR — the `Status:` line was updated, the checkboxes were
-  not). A small follow-up PR should walk the AC list and check off the
-  boxes that the shipped code already satisfies. Not new work; just
-  reconciliation.
+- *No open items of substance.* The pre-amendment ACs (#1–#13) carry
+  the same bookkeeping drift documented above — checkboxes are still
+  literally `- [ ]` against shipped code. Same as `agent-spec-cli`:
+  reconciliation work, not new scope.
 
-## `agent-spec-cli` — shipped
+## `agent-spec-cli` — shipped (v0.2 CLI surface landed)
 
 Spec: [`specs/agent-spec-cli/spec.md`](specs/agent-spec-cli/spec.md).
 Shipped via PR #23 (commit `cd4f3e5`) — 11 subcommands, library-first
-CLI importing `agentbundle.build`.
+CLI importing `agentbundle.build`. The
+[RFC-0004](rfc/0004-install-scope-per-pack.md) v0.2 amendment
+(argparse `--scope` on six subcommands + `--force` on `install`;
+scope-resolution helper; path-jail per scope; `~`-expansion refusal;
+v0.1 state-file refuse-and-explain at write; dual-scope install
+conflict + `installed: <pack> @ <scope>` rail; `recommends`
+cross-scope warning text split; `adapt` dual-state-file walk) landed
+in the same PR; the ten `(RFC-0004)`-tagged ACs are satisfied.
 
 - *No open items of substance for v1.* Same AC-checkbox bookkeeping
   drift as `distribution-adapters`: a follow-up PR should reconcile.
-- **Deferred to v1.1** (called out in the spec body, not net-new
-  scope): SSH git URL support in `install` (`git+ssh://...` currently
-  exits non-zero with a "deferred to v1.1" message); the full
-  `--strict` `validate` behaviour against the v0.1 conformance fixtures
-  (which themselves are owned by RFC-0003's deferred F-conformance
-  task).
+- **Deferred to a follow-up RFC** (called out in RFC-0004 itself, not
+  net-new scope): user-scope hook-wiring merge story (Rail B keeps
+  hook-bearing packs user-scope-refused until that lands); `global`
+  (system-wide) scope (not reserved, not refused — absent); new
+  user-scope packs (the dimension lands without a consumer).
+- **Deferred to v1.1** (carried over from the prior roadmap entry):
+  SSH git URL support in `install` (`git+ssh://...` currently exits
+  non-zero with a "deferred to v1.1" message); the full `--strict`
+  `validate` behaviour against the v0.1 conformance fixtures (which
+  themselves are owned by RFC-0003's deferred F-conformance task).
 
 ---
 

--- a/docs/adr/0002-install-scope-per-pack-default-and-allowance.md
+++ b/docs/adr/0002-install-scope-per-pack-default-and-allowance.md
@@ -1,0 +1,73 @@
+# ADR-0002: Install-scope is a per-pack default + allowance, not a per-item or adopter-only choice
+
+- **Status:** Accepted
+- **Date:** 2026-05-23
+- **Deciders:** eugenelim
+- **Supersedes:** none
+- **Related:** [RFC-0004](../rfc/0004-install-scope-per-pack.md), [RFC-0001](../rfc/0001-bundle-distribution-by-adapter-spec.md), [`distribution-adapters` spec](../specs/distribution-adapters/spec.md), [`agent-spec-cli` spec](../specs/agent-spec-cli/spec.md)
+
+## Context
+
+[RFC-0004](../rfc/0004-install-scope-per-pack.md) added a **scope** dimension (`repo` | `user`) to the adapter contract. The dimension exists so a future cross-project pack can ship at user scope cleanly; no user-scope pack lands in this RFC. The value-prop is the dimension itself.
+
+The shape of the dimension has four orthogonal axes:
+
+1. **Where does the scope value live?** Pack metadata, CLI invocation, adapter hardcode, or somewhere else.
+2. **Who picks the value?** Pack author, adopter, both, or neither.
+3. **Is the scope per pack or per primitive?** The pack as an atomic unit, or each skill/agent/command individually.
+4. **What's the discovery surface?** Pack authors and third-party catalogues need a uniform refusal contract for malformed packs.
+
+Each axis admits multiple positions. The team needed to pick one combination and pin it before the contract bump landed; partial answers leave the CLI's `--scope` semantics under-specified and force every consumer (the four reference adapters, third-party catalogue indexers, `agentbundle validate`, the `adapt-to-project` skill) to re-derive the rule.
+
+## Decision
+
+We adopted the **per-pack default + allowance** model:
+
+> A pack's `pack.toml` declares both a `default-scope` (the scope used when the adopter passes no `--scope`) and an `allowed-scopes` set (the scopes the pack permits). The CLI's `--scope` flag overrides the default within the declared set; a value outside `allowed-scopes` is refused with stderr naming the pack and the declared set.
+
+Three derived rules pin the model concretely:
+
+- **Precedence:** CLI flag > pack `default-scope` > built-in `repo`.
+- **Granularity:** A pack installs at one scope; every primitive in that pack lives at that scope. No per-item override.
+- **Discovery:** The `default-scope ∈ allowed-scopes` invariant is enforced in `pack.schema.json` via a jsonschema `if`/`then` block, so catalogue indexers, third-party validators, and `agentbundle validate` all refuse a malformed pack identically — without having to import CLI code.
+
+The four shipped packs (`core`, `governance-extras`, `user-guide-diataxis`, `monorepo-extras`) all declare `allowed-scopes = ["repo"]`; the dimension lands ahead of any user-scope consumer.
+
+## Consequences
+
+**Positive:**
+
+- Pack authors express scope intent **once**, in `pack.toml` — adopters don't re-derive it per install.
+- Catalogue indexers and third-party validators read the contract identically to the CLI; no per-tool discovery code.
+- `--force` semantics fit cleanly: an adopter can install at both scopes when their workflow demands it, without the pack author having to anticipate every combination.
+- The dimension lands without a consumer; mechanics (path-jail, state file, `~`-expansion, `recommends` cross-scope) are settled before the first user-scope pack rides them.
+
+**Negative:**
+
+- Two more required fields on `pack.toml` for v0.2 packs (`default-scope`, `allowed-scopes`). The v0.1 legacy path keeps existing packs installable, but v0.2 publishers must opt in deliberately.
+- State-file count doubles when a pack is installed at both scopes (`<repo>/.agent-ready-state.toml` and `~/.agent-ready/state.toml`). Cross-scope upgrades become per-scope, per-verb.
+- Hook-shaped primitives are forbidden at user scope until a follow-up RFC designs the user-scope hook-wiring merge story. This is a real constraint for any future user-scope pack carrying hooks; not a constraint on anything shipping today.
+
+**Neutral / to revisit:**
+
+- `global` (system-wide) scope is deliberately absent. No adapter has a system-wide root, and adding it later is a one-line schema bump against the already-versioned contract.
+- `[pack.install]` could grow more fields in future (`requires-confirmation`, etc.) — out of scope for v0.2.
+
+## Alternatives considered
+
+The numbering follows RFC-0004 § *Alternatives considered* for traceability. This ADR explicitly records the rejection of alternatives **2, 3, 7, and 8**; the other rejections (1, 4, 5, 6) are recorded in the RFC body and not re-litigated here.
+
+- **(2) Per-item scope (override per skill / agent within a pack).** Maximally flexible but multiplies state-file bookkeeping by the cardinality of primitives in a pack, breaks "install/uninstall is atomic per pack," and asks the pack author to make a scoping decision they're unlikely to get right for every adopter. *Rejected:* an item that belongs at a different scope should be its own pack.
+
+- **(3) Adopter-only scope (no pack default).** Adopter passes `--scope` every time. Forces every adopter to re-derive a decision the pack author already knows the answer to. *Rejected:* the pack author is closest to the content; making them declare the default is a one-line cost that saves every adopter from re-deriving it.
+
+- **(7) Hardcode the four shipped pack names in the CLI as repo-only.** Avoids the `allowed-scopes` field entirely; the CLI would refuse user-scope installs for the four names. *Rejected:* pack constraints belong with the pack, not in the CLI; third-party catalogues need the same declarative shape; the reviewer / scaffold / validate rails all need pack-author intent in the file, not in CLI source.
+
+- **(8) Land the dimension *with* the first user-scope pack, not ahead of it.** Cheaper in PR count. *Rejected:* scope mechanics are non-trivial (path-jail, state-file location, `~`-expansion, projection forks, `recommends` interaction, backward compat) and landing them under the pressure of a concurrent pack means corners cut. The named consumer becomes a one-day PR once this RFC is in.
+
+## References
+
+- [RFC-0004 — Install-scope dimension](../rfc/0004-install-scope-per-pack.md)
+- [`distribution-adapters` spec § Install-scope dimension (contract v0.2)](../specs/distribution-adapters/spec.md)
+- [`agent-spec-cli` spec § Install-scope dimension (CLI surface, contract v0.2)](../specs/agent-spec-cli/spec.md)
+- [Migration guide for third-party pack authors](../guides/how-to/v01-to-v02-pack-upgrade.md)

--- a/docs/contracts/adapter.schema.json
+++ b/docs/contracts/adapter.schema.json
@@ -67,6 +67,25 @@
                 "info-message": {"type": "string"}
               }
             }
+          },
+          "scope": {
+            "type": "object",
+            "required": ["repo", "user"],
+            "properties": {
+              "repo": {"type": "string"},
+              "user": {"type": "string"},
+              "allowed-prefixes": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string",
+                    "pattern": "^((?!\\.\\.(\\/|$))[^/]+/)+$"
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/docs/contracts/adapter.toml
+++ b/docs/contracts/adapter.toml
@@ -1,10 +1,10 @@
 # Adapter contract — every (primitive × adapter) pair enumerated.
 # Validates against ./adapter.schema.json.
 # Managed by: docs/specs/distribution-adapters/spec.md
-# RFC reference: RFC-0001
+# RFC reference: RFC-0001 (base contract); RFC-0004 (scope dimension, v0.2)
 
 [contract]
-version = "0.1"
+version = "0.2"
 
 # Sibling schemas this contract references — pack metadata and the
 # per-pack Claude-plugin manifest. Defined by spec AC #3 + #4.
@@ -65,6 +65,18 @@ primitive = "command"
 mode = "direct-file"
 target-path = ".claude/commands/"
 on-conflict = "prompt-then-preserve"
+
+# Scope dimension (RFC-0004). Two roots: repo-local and user-local.
+# `allowed-prefixes.<scope>` fences every write under that scope to a
+# declared prefix list — at user scope this stops a buggy projection
+# rule from resolving under `~/Documents/`. The two-prefix shape covers
+# projected primitives (`.claude/`) and CLI infrastructure writes
+# (`.agent-ready/` — user-scope state file, per-scope discovery and
+# pending artifacts).
+[adapter."claude-code".scope]
+repo = "."
+user = "~"
+allowed-prefixes.user = [".claude/", ".agent-ready/"]
 
 # ---------------------------------------------------------------------------
 # Kiro adapter — 5 projections (one per primitive)

--- a/docs/contracts/pack.schema.json
+++ b/docs/contracts/pack.schema.json
@@ -9,6 +9,16 @@
         "name": {"type": "string"},
         "version": {"type": "string"},
         "description": {"type": "string"},
+        "adapter-contract": {
+          "type": "object",
+          "properties": {
+            "version": {"type": "string"}
+          }
+        },
+        "recipes": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
         "dependencies": {
           "type": "object",
           "properties": {
@@ -82,6 +92,51 @@
           "items": {
             "type": "string",
             "pattern": "^[^/].*"
+          }
+        }
+      },
+      "if": {
+        "properties": {
+          "adapter-contract": {
+            "type": "object",
+            "properties": {"version": {"enum": ["0.2"]}},
+            "required": ["version"]
+          }
+        },
+        "required": ["adapter-contract"]
+      },
+      "then": {
+        "required": ["install"],
+        "properties": {
+          "install": {
+            "type": "object",
+            "required": ["default-scope"],
+            "properties": {
+              "default-scope": {"enum": ["repo", "user"]},
+              "allowed-scopes": {
+                "type": "array",
+                "minItems": 1,
+                "items": {"enum": ["repo", "user"]}
+              }
+            },
+            "if": {
+              "properties": {"default-scope": {"enum": ["user"]}},
+              "required": ["default-scope"]
+            },
+            "then": {
+              "properties": {
+                "allowed-scopes": {
+                  "contains": {"enum": ["user"]}
+                }
+              }
+            },
+            "else": {
+              "properties": {
+                "allowed-scopes": {
+                  "contains": {"enum": ["repo"]}
+                }
+              }
+            }
           }
         }
       }

--- a/docs/guides/how-to/v01-to-v02-pack-upgrade.md
+++ b/docs/guides/how-to/v01-to-v02-pack-upgrade.md
@@ -1,0 +1,90 @@
+# How to upgrade a pack from contract v0.1 to v0.2
+
+This is a one-page checklist for third-party pack authors. The v0.2 contract amendment ([RFC-0004](../../rfc/0004-install-scope-per-pack.md)) adds an **install-scope dimension** — every v0.2 pack declares whether it ships at `repo` scope, `user` scope, or both. v0.1 packs keep installing under the legacy default (`repo`), so an upgrade is optional but recommended; new packs should target v0.2 directly.
+
+## When to upgrade
+
+- You publish a pack to a catalogue the v0.2 CLI consumes and want to expose `--scope` semantics to adopters.
+- You want adopters to see your scope choice declared in `pack.toml` instead of inferred from the CLI's legacy default.
+- You ship content that genuinely fits user scope (cross-project skills, agents, commands with no per-repo dependence).
+
+You can stay on v0.1 if your pack only ever ships at `repo` scope and you don't need the explicit declaration; the v0.2 CLI accepts v0.1 packs with implied `default-scope = "repo"`, `allowed-scopes = ["repo"]`. A stray `[pack.install]` table on a v0.1 pack is ignored at CLI consumption time.
+
+## Fields to add
+
+Add both tables to `pack.toml`:
+
+```toml
+[pack.adapter-contract]
+version = "0.2"
+
+[pack.install]
+default-scope = "repo"          # required: "repo" | "user"
+allowed-scopes = ["repo"]       # optional; defaults to [default-scope]
+```
+
+`default-scope` is required when the contract version is `"0.2"`. `allowed-scopes` is optional; when omitted, it implicitly equals `[default-scope]` (i.e. "only the default").
+
+Pack authors who want adopters to be able to install at both scopes declare:
+
+```toml
+[pack.install]
+default-scope = "repo"
+allowed-scopes = ["repo", "user"]
+```
+
+The cross-field invariant `default-scope ∈ allowed-scopes` is enforced in `pack.schema.json` — every consumer of the schema refuses a malformed pack identically.
+
+## `validate` exit codes
+
+Run `agentbundle validate <pack-path>` after editing `pack.toml`. The CLI exits non-zero (with a one-line stderr reason) on any of these:
+
+- Missing `[pack.install]` under a v0.2 pack.
+- `default-scope` value outside `{"repo", "user"}`.
+- `default-scope` not in `allowed-scopes`.
+- `allowed-scopes` is empty or contains a value outside `{"repo", "user"}`.
+
+When `"user" ∈ allowed-scopes`, three additional **content rails** fire:
+
+- **Rail A — `seeds/`.** A pack containing a non-empty `seeds/` directory cannot declare `"user" ∈ allowed-scopes`. Seeds project to per-project paths and don't survive a user-scope install.
+- **Rail B — hook-shaped primitives.** A pack containing a non-empty `.apm/hooks/` or `.apm/hook-wiring/` directory cannot declare `"user" ∈ allowed-scopes` until the user-scope hook-wiring merge story is designed in a follow-up RFC.
+- **Rail C — `<adapt:NAME>` markers.** A pack declaring `"user" ∈ allowed-scopes` cannot carry the marker regex `<adapt:[A-Z_][A-Z0-9_]*>` in any file under `.apm/skills/`, `.apm/agents/`, or `.apm/commands/`. Markers resolve from `.adapt-discovery.toml` to per-repo values, so a file at `~/.claude/` can only carry one resolution.
+
+`validate` names the offending pack and the first offending path; the rails fire once per pack (Rail A first, then B, then C). `install --scope user` re-runs each rail against the resolved pack content, closing the widen-after-publish gap.
+
+## Implied defaults — when both fields can be omitted
+
+A v0.1 pack with no `[pack.adapter-contract]` (or `version = "0.1"`) gets the implied defaults `default-scope = "repo"`, `allowed-scopes = ["repo"]`. The v0.2 CLI accepts these packs as legacy; an adopter passing `--scope user` against a v0.1 pack is refused with the standard `allowed-scopes` violation.
+
+A v0.2 pack with only `default-scope` declared (no `allowed-scopes`) gets the implied `allowed-scopes = [default-scope]` at CLI consumption time. The schema accepts this shape; the CLI's `--scope` resolution treats it as if `allowed-scopes` were written out explicitly.
+
+```toml
+# Example: v0.2 pack permitting only its default scope.
+[pack.adapter-contract]
+version = "0.2"
+
+[pack.install]
+default-scope = "repo"
+# allowed-scopes omitted → implicitly ["repo"]
+```
+
+## When `"user" ∈ allowed-scopes` — the content-portability test
+
+The schema rails catch the *mechanical* failures (seeds, hooks, markers). They don't catch every content-portability bug — a pack that hardcodes `AGENTS.md` paths or names this project's convention vocabulary literally will pass `validate` and still misbehave at user scope.
+
+Apply this falsifiable test before declaring `"user" ∈ allowed-scopes`:
+
+> *Does the same file content serve every repo verbatim?*
+
+If yes, the pack is a user-scope candidate. If no — because the content carries `<adapt:NAME>` markers (caught by Rail C), references specific paths, names project-specific docs, or bakes in convention vocabulary (not caught) — the pack is repo-only.
+
+## State-file migration
+
+The `.agent-ready-state.toml` schema bumped to `"0.2"` alongside the contract. v0.1 state files are read by the v0.2 CLI as all-repo-scope; **writes** against a v0.1 file are refused with a refuse-and-explain message pointing at `agentbundle init-state --migrate`. The migration is destructive (irreversible without backup) and idempotent: an adopter running mixed CLI versions across CI and local must opt into it explicitly.
+
+```bash
+$ agentbundle init-state --migrate
+init-state --migrate: /path/to/.agent-ready-state.toml → schema-version 0.2
+```
+
+For pack authors there's no state-file change to ship — adopters migrate their own state files when they upgrade the CLI.

--- a/docs/rfc/0004-install-scope-per-pack.md
+++ b/docs/rfc/0004-install-scope-per-pack.md
@@ -1,9 +1,9 @@
 # RFC-0004: Install-scope dimension — repo or user — defaulted and constrained per pack
 
-- **Status:** Draft
+- **Status:** Accepted
 - **Author:** eugenelim
 - **Date opened:** 2026-05-23
-- **Date closed:**
+- **Date closed:** 2026-05-23
 - **Extends:** [RFC-0001](0001-bundle-distribution-by-adapter-spec.md)
   — adds a scope dimension to the adapter contract and Tier-1/2/3
   file-safety rails.

--- a/docs/specs/agent-spec-cli/spec.md
+++ b/docs/specs/agent-spec-cli/spec.md
@@ -528,7 +528,7 @@ QA tails respectively.
 - [ ] A version-mismatch fixture (pack declares spec `v2.0`, CLI ships
       `v0.1`) causes every subcommand to refuse with a stderr line naming
       both versions; no partial behaviour observed.
-- [ ] **(RFC-0004)** `--scope {repo,user}` is accepted on `install`,
+- [x] **(RFC-0004)** `--scope {repo,user}` is accepted on `install`,
       `uninstall`, `upgrade`, `diff`, `init-state`, and
       `list-targets` only. Passing `--scope` to `list-packs`,
       `scaffold`, `validate`, `render`, or `adapt` exits non-zero
@@ -537,7 +537,7 @@ QA tails respectively.
       override on `install`; disambiguator on `uninstall` / `upgrade`
       / `diff`; selector on `init-state`; read-only filter on
       `list-targets`.
-- [ ] **(RFC-0004)** Scope resolution follows CLI flag > pack
+- [x] **(RFC-0004)** Scope resolution follows CLI flag > pack
       `default-scope` > built-in `repo`. A `--scope <s>` value not
       in the pack's `allowed-scopes` exits non-zero with stderr
       `<pack>: scope '<requested>' not in allowed-scopes
@@ -547,7 +547,7 @@ QA tails respectively.
       that excludes user is refused; passing `--scope user` against
       a pack declaring `allowed-scopes = ["repo", "user"]` resolves
       to user.
-- [ ] **(RFC-0004)** Path-jail extended: every user-scope write
+- [x] **(RFC-0004)** Path-jail extended: every user-scope write
       resolves under one of the adapter's
       `allowed-prefixes.<scope>` entries (declared in the sibling
       spec's `[scope]` table) or the CLI refuses non-zero with
@@ -556,13 +556,13 @@ QA tails respectively.
       root) is unchanged. A test fixture with a projection rule
       resolving under `~/Documents/` (inside `~`, outside the
       declared `[".claude/", ".agent-ready/"]` prefixes) is refused.
-- [ ] **(RFC-0004)** `~`-expansion runs once at scope-resolution
+- [x] **(RFC-0004)** `~`-expansion runs once at scope-resolution
       time. When the result is literal `"~"` (expansion failed) or
       `"/"` ($HOME=/), every `--scope user` invocation exits non-
       zero with stderr `cannot resolve user scope: $HOME unset or
       invalid`. When expansion succeeds, the CLI prints the
       resolved absolute scope root to stderr before any write.
-- [ ] **(RFC-0004)** Write-capable invocations against a v0.1
+- [x] **(RFC-0004)** Write-capable invocations against a v0.1
       `.agent-ready-state.toml` exit non-zero with stderr `state
       file at <path> is schema-version 0.1; run 'agentbundle
       init-state --migrate' first`. Read-only invocations
@@ -571,14 +571,14 @@ QA tails respectively.
       repo-scope. `init-state --migrate` rewrites a v0.1 file to
       v0.2 idempotently; the writer's contract is owned by the
       sibling `distribution-adapters` spec.
-- [ ] **(RFC-0004)** Every successful `install` prints `installed:
+- [x] **(RFC-0004)** Every successful `install` prints `installed:
       <pack> @ <scope>` to stdout. A single-scope install emits one
       line as the last stdout content before exit zero. A
       dual-scope `--force` install emits two lines, **repo first,
       user second**, both on stdout; the user-scope line is the
       last stdout content. Verified by capturing stdout and
       asserting the exact line sequence per case.
-- [ ] **(RFC-0004)** Dual-scope conflict on `install`: when pack
+- [x] **(RFC-0004)** Dual-scope conflict on `install`: when pack
       `<P>` is already installed at the other scope, the install
       exits non-zero with stderr `<P> already installed at
       <other-scope>; pass --force to install at both`. `--force`
@@ -593,7 +593,7 @@ QA tails respectively.
       `upgrade --scope`, and `diff --scope` are required (refused
       with `<P> installed at multiple scopes; pass --scope {repo,
       user}` when omitted).
-- [ ] **(RFC-0004)** `recommends` cross-scope: an `install` warns
+- [x] **(RFC-0004)** `recommends` cross-scope: an `install` warns
       (does not refuse) on **stderr** when a recommended pack is
       missing or scope-disjoint. Warning text per § *`recommends`
       across scopes*:
@@ -606,7 +606,7 @@ QA tails respectively.
       pack's allowed scope, not the recommending pack's installed
       scope. A dual-scope `--force` install emits one warning per
       scope per recommend.
-- [ ] **(RFC-0004)** `adapt` walks **both**
+- [x] **(RFC-0004)** `adapt` walks **both**
       `<repo>/.agent-ready-state.toml` and
       `~/.agent-ready/state.toml`, reads
       `<repo>/.adapt-discovery.toml` at repo scope and
@@ -619,7 +619,7 @@ QA tails respectively.
       squatter under `~/.claude/` is a user-scope finding; a
       `.upstream.<ext>` companion in `<repo>/` is a repo-scope
       finding).
-- [ ] **(RFC-0004)** `validate` against a v0.2 pack whose
+- [x] **(RFC-0004)** `validate` against a v0.2 pack whose
       `default-scope` is not in `allowed-scopes` exits non-zero
       with stderr `pack <name>: default-scope '<requested>' not
       in allowed-scopes <declared-set>`. The schema-level

--- a/docs/specs/distribution-adapters/spec.md
+++ b/docs/specs/distribution-adapters/spec.md
@@ -723,7 +723,7 @@ No manual QA: there is no UI surface, no human gesture under test.
   status` against the working tree before and after, returning byte-
   identical output). This pins the property § Default-recipe behaviour
   declares; T8 owns the test.
-- [ ] **(RFC-0004)** `docs/contracts/adapter.toml` carries
+- [x] **(RFC-0004)** `docs/contracts/adapter.toml` carries
   `[contract] version = "0.2"` and a `[adapter."claude-code".scope]`
   table declaring `repo = "."`, `user = "~"`, and
   `allowed-prefixes.user = [".claude/", ".agent-ready/"]` (the
@@ -736,7 +736,7 @@ No manual QA: there is no UI surface, no human gesture under test.
   no `..` after normalisation, trailing `/`). A test asserts the
   schema rejects each of `["/"]`, `[""]`, `["../"]`, `[".."]`, and
   `[]` for `allowed-prefixes.user`.
-- [ ] **(RFC-0004)** `docs/contracts/pack.schema.json` requires
+- [x] **(RFC-0004)** `docs/contracts/pack.schema.json` requires
   `[pack.install]` on any pack declaring
   `[pack.adapter-contract] version = "0.2"` (jsonschema `if`/`then`
   on the contract-version field), with `default-scope ∈ {"repo",
@@ -749,7 +749,7 @@ No manual QA: there is no UI surface, no human gesture under test.
   `[pack.install]` is accepted; a v0.1 pack *with* a stray
   `[pack.install]` table is accepted (the table is ignored at
   CLI consumption per § *Install-scope dimension*).
-- [ ] **(RFC-0004)** `validate.py` runs Rails A/B/C against every
+- [x] **(RFC-0004)** `validate.py` runs Rails A/B/C against every
   pack: Rail A refuses any pack containing a non-empty `seeds/`
   directory and declaring `"user" ∈ allowed-scopes`; Rail B refuses
   any pack whose source tree contains a non-empty `.apm/hooks/` or
@@ -764,7 +764,7 @@ No manual QA: there is no UI surface, no human gesture under test.
   offending path. Tests pin one positive case (rail accepts a
   clean pack) and one negative case (rail rejects with the named
   stderr) per rail, plus one binary-file skip test for Rail C.
-- [ ] **(RFC-0004)** `.agent-ready-state.toml` `schema-version`
+- [x] **(RFC-0004)** `.agent-ready-state.toml` `schema-version`
   bumps to `"0.2"`. Every `[pack.<name>]` entry in v0.2 carries a
   required `scope = "repo" | "user"` column. The CLI **reads** any
   v0.1 file as all-repo-scope without forcing migration; any
@@ -777,7 +777,7 @@ No manual QA: there is no UI surface, no human gesture under test.
   is a no-op exit-zero. The user-scope state file lives at
   `~/.agent-ready/state.toml` (a namespaced dot-directory under
   `$HOME`, not a bare dotfile).
-- [ ] **(RFC-0004)** The four shipped packs at
+- [x] **(RFC-0004)** The four shipped packs at
   `packs/{core,governance-extras,monorepo-extras,user-guide-diataxis}/pack.toml`
   **add** an explicit `[pack.adapter-contract] version = "0.2"`
   field (the field was previously absent — packs were

--- a/packages/agentbundle/agentbundle/_data/adapter.schema.json
+++ b/packages/agentbundle/agentbundle/_data/adapter.schema.json
@@ -67,6 +67,25 @@
                 "info-message": {"type": "string"}
               }
             }
+          },
+          "scope": {
+            "type": "object",
+            "required": ["repo", "user"],
+            "properties": {
+              "repo": {"type": "string"},
+              "user": {"type": "string"},
+              "allowed-prefixes": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string",
+                    "pattern": "^((?!\\.\\.(\\/|$))[^/]+/)+$"
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/packages/agentbundle/agentbundle/_data/adapter.toml
+++ b/packages/agentbundle/agentbundle/_data/adapter.toml
@@ -1,10 +1,10 @@
 # Adapter contract — every (primitive × adapter) pair enumerated.
 # Validates against ./adapter.schema.json.
 # Managed by: docs/specs/distribution-adapters/spec.md
-# RFC reference: RFC-0001
+# RFC reference: RFC-0001 (base contract); RFC-0004 (scope dimension, v0.2)
 
 [contract]
-version = "0.1"
+version = "0.2"
 
 # Sibling schemas this contract references — pack metadata and the
 # per-pack Claude-plugin manifest. Defined by spec AC #3 + #4.
@@ -65,6 +65,18 @@ primitive = "command"
 mode = "direct-file"
 target-path = ".claude/commands/"
 on-conflict = "prompt-then-preserve"
+
+# Scope dimension (RFC-0004). Two roots: repo-local and user-local.
+# `allowed-prefixes.<scope>` fences every write under that scope to a
+# declared prefix list — at user scope this stops a buggy projection
+# rule from resolving under `~/Documents/`. The two-prefix shape covers
+# projected primitives (`.claude/`) and CLI infrastructure writes
+# (`.agent-ready/` — user-scope state file, per-scope discovery and
+# pending artifacts).
+[adapter."claude-code".scope]
+repo = "."
+user = "~"
+allowed-prefixes.user = [".claude/", ".agent-ready/"]
 
 # ---------------------------------------------------------------------------
 # Kiro adapter — 5 projections (one per primitive)

--- a/packages/agentbundle/agentbundle/_data/pack.schema.json
+++ b/packages/agentbundle/agentbundle/_data/pack.schema.json
@@ -9,6 +9,16 @@
         "name": {"type": "string"},
         "version": {"type": "string"},
         "description": {"type": "string"},
+        "adapter-contract": {
+          "type": "object",
+          "properties": {
+            "version": {"type": "string"}
+          }
+        },
+        "recipes": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
         "dependencies": {
           "type": "object",
           "properties": {
@@ -82,6 +92,51 @@
           "items": {
             "type": "string",
             "pattern": "^[^/].*"
+          }
+        }
+      },
+      "if": {
+        "properties": {
+          "adapter-contract": {
+            "type": "object",
+            "properties": {"version": {"enum": ["0.2"]}},
+            "required": ["version"]
+          }
+        },
+        "required": ["adapter-contract"]
+      },
+      "then": {
+        "required": ["install"],
+        "properties": {
+          "install": {
+            "type": "object",
+            "required": ["default-scope"],
+            "properties": {
+              "default-scope": {"enum": ["repo", "user"]},
+              "allowed-scopes": {
+                "type": "array",
+                "minItems": 1,
+                "items": {"enum": ["repo", "user"]}
+              }
+            },
+            "if": {
+              "properties": {"default-scope": {"enum": ["user"]}},
+              "required": ["default-scope"]
+            },
+            "then": {
+              "properties": {
+                "allowed-scopes": {
+                  "contains": {"enum": ["user"]}
+                }
+              }
+            },
+            "else": {
+              "properties": {
+                "allowed-scopes": {
+                  "contains": {"enum": ["repo"]}
+                }
+              }
+            }
           }
         }
       }

--- a/packages/agentbundle/agentbundle/build/scope_rails.py
+++ b/packages/agentbundle/agentbundle/build/scope_rails.py
@@ -1,0 +1,255 @@
+"""Contract-level user-scope refusal rails (RFC-0004 Rails A/B/C).
+
+The three rails fire **only when a pack declares `"user" ∈
+allowed-scopes`**. Repo-only packs are not inspected. The whole point
+of the rails is to keep content that would not survive the
+user-scope projection out of user-scope packs in the first place.
+
+Each rail returns `None` when the pack passes, or a string describing
+the first offending path when the rail refuses. The string carries
+enough context for the caller (`validate` or `install`) to format the
+spec's stderr text — `<pack>: <rail message>` — without per-rail
+formatting code at each call site.
+
+Rails:
+
+  - **Rail A — seeds/.** A pack containing a non-empty `seeds/` directory
+    cannot declare `"user" ∈ allowed-scopes` (seeds project to nonsense
+    paths under `~`). The detection is filesystem-shaped: any descendant
+    file under `<pack>/seeds/` triggers the rail.
+
+  - **Rail B — hook-shaped primitives.** A pack whose source tree
+    contains a non-empty `.apm/hooks/` or `.apm/hook-wiring/` directory
+    cannot declare `"user" ∈ allowed-scopes` until the user-scope hook-
+    wiring merge story is designed in a follow-up RFC.
+
+  - **Rail C — `<adapt:NAME>` markers.** A pack declaring `"user" ∈
+    allowed-scopes` cannot carry the marker regex
+    `<adapt:[A-Z_][A-Z0-9_]*>` in any file under `.apm/skills/`,
+    `.apm/agents/`, or `.apm/commands/`. The rail walks those
+    directories in `sorted(os.walk(...))` order so the first-offending-
+    path stderr message is deterministic across runs and platforms.
+    Non-UTF-8 (binary) files are skipped silently — they cannot contain
+    a textual marker by definition, and forcing them through decoding
+    would surface spurious errors on legitimate binaries (icons,
+    images, archives).
+
+The rails are run by `agentbundle validate <pack>` (pre-publish) and
+re-run by `agentbundle install --scope user` against the resolved pack
+content. Re-running at install time closes the widen-after-publish gap:
+a pack published as `["repo"]` and later flipped to include `"user"`
+cannot install at user scope without passing every rail at install
+time.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Iterable
+
+
+_MARKER_REGEX = re.compile(rb"<adapt:[A-Z_][A-Z0-9_]*>")
+
+# The three primitive source directories Rail C walks. `.apm/hooks/` and
+# `.apm/hook-wiring/` are already user-scope-refused by Rail B, so a
+# marker check on them is unreachable. `seeds/` is already
+# user-scope-refused by Rail A, so the marker rail's input never
+# includes `seeds/`. Spec § *Install-scope dimension* pins the list.
+_MARKER_RAIL_DIRS = (".apm/skills", ".apm/agents", ".apm/commands")
+
+# Cap per-file inspection size to keep Rail C bounded. A primitive file
+# is human-authored content (SKILL.md, agent body, command); an outsize
+# input under one of the rail directories is either an accident or a
+# DoS attempt against the validate / install path. Files larger than
+# the cap are reported and refused as if they had matched — the rail's
+# job is "decide whether this pack is safe at user scope", and an
+# unreviewable blob in primitive territory is not safe by default.
+_MARKER_RAIL_FILE_CAP_BYTES = 4 * 1024 * 1024  # 4 MiB
+
+
+def _allows_user(allowed_scopes: Iterable[str]) -> bool:
+    """Return True if the pack's allowed-scopes includes `"user"`."""
+    return "user" in set(allowed_scopes or ())
+
+
+def check_seeds(pack_path: Path, allowed_scopes: Iterable[str]) -> str | None:
+    """Rail A. Return None on accept; refusal string on refuse.
+
+    A pack containing a non-empty `seeds/` directory cannot declare
+    `"user" ∈ allowed-scopes`.
+    """
+    if not _allows_user(allowed_scopes):
+        return None
+    seeds_dir = pack_path / "seeds"
+    if not seeds_dir.exists():
+        return None
+    # followlinks=False so a symlink loop or symlink to outside the
+    # pack tree can't extend the rail's reach; consistency with Rail C.
+    for root, _dirs, files in os.walk(seeds_dir, followlinks=False):
+        if files:
+            # Name the first file in sorted order so the message is
+            # deterministic across runs (Rail C uses the same rule).
+            first = sorted(files)[0]
+            rel = Path(root, first).relative_to(pack_path)
+            return (
+                f"pack carries non-empty seeds/ but declares "
+                f'"user" ∈ allowed-scopes; first offender: {rel.as_posix()}'
+            )
+    return None
+
+
+def check_hooks(pack_path: Path, allowed_scopes: Iterable[str]) -> str | None:
+    """Rail B. Return None on accept; refusal string on refuse.
+
+    A pack containing a non-empty `.apm/hooks/` or `.apm/hook-wiring/`
+    directory cannot declare `"user" ∈ allowed-scopes`.
+    """
+    if not _allows_user(allowed_scopes):
+        return None
+    for hook_subdir in (".apm/hooks", ".apm/hook-wiring"):
+        candidate = pack_path / hook_subdir
+        if not candidate.exists():
+            continue
+        # followlinks=False — consistent with Rails A and C.
+        for root, _dirs, files in os.walk(candidate, followlinks=False):
+            if files:
+                first = sorted(files)[0]
+                rel = Path(root, first).relative_to(pack_path)
+                return (
+                    f"pack carries hook-shaped primitives at {hook_subdir}/ but "
+                    f'declares "user" ∈ allowed-scopes; first offender: '
+                    f"{rel.as_posix()}"
+                )
+    return None
+
+
+def check_markers(pack_path: Path, allowed_scopes: Iterable[str]) -> str | None:
+    """Rail C. Return None on accept; refusal string on refuse.
+
+    A pack declaring `"user" ∈ allowed-scopes` cannot carry
+    `<adapt:NAME>` markers in any file under `.apm/skills/`,
+    `.apm/agents/`, or `.apm/commands/`. Walks in deterministic
+    `sorted(os.walk(...))` order. Binary files are skipped silently —
+    a marker is by construction a UTF-8 byte sequence, and forcing
+    binaries through decoding would create spurious failures.
+    """
+    if not _allows_user(allowed_scopes):
+        return None
+    for rail_subdir in _MARKER_RAIL_DIRS:
+        root_dir = pack_path / rail_subdir
+        if not root_dir.exists():
+            continue
+        for root, dirs, files in os.walk(root_dir, followlinks=False):
+            dirs.sort()
+            for fname in sorted(files):
+                fpath = Path(root, fname)
+                try:
+                    # lstat (not stat) so a `*.md → /dev/zero` symlink
+                    # surfaces as a symlink at this rail rather than a
+                    # zero-byte file. Symlinks under `.apm/skills/`,
+                    # `.apm/agents/`, `.apm/commands/` are not a
+                    # legitimate primitive shape — refuse them out
+                    # right so the size cap below can't be defeated by
+                    # `read_bytes()` traversing the symlink target.
+                    st = os.lstat(fpath)
+                except OSError:
+                    continue
+                from stat import S_ISLNK
+
+                if S_ISLNK(st.st_mode):
+                    rel = fpath.relative_to(pack_path)
+                    return (
+                        f"pack declares \"user\" ∈ allowed-scopes but "
+                        f"a primitive entry is a symlink (not a regular "
+                        f"file); first offender: {rel.as_posix()}"
+                    )
+                size = st.st_size
+                if size > _MARKER_RAIL_FILE_CAP_BYTES:
+                    rel = fpath.relative_to(pack_path)
+                    return (
+                        f"pack declares \"user\" ∈ allowed-scopes but "
+                        f"a primitive file exceeds the marker-rail size cap "
+                        f"({_MARKER_RAIL_FILE_CAP_BYTES // (1024 * 1024)} MiB); "
+                        f"first offender: {rel.as_posix()}"
+                    )
+                # Close the lstat→read TOCTOU window with O_NOFOLLOW so
+                # the kernel refuses if the entry was swapped for a
+                # symlink between the lstat above and this read. The
+                # platform check (`hasattr(os, "O_NOFOLLOW")`) is
+                # defensive — POSIX always has it; Windows doesn't, but
+                # the stdlib-only commitment defers Windows anyway.
+                try:
+                    if hasattr(os, "O_NOFOLLOW"):
+                        fd = os.open(str(fpath), os.O_RDONLY | os.O_NOFOLLOW)
+                        try:
+                            data = os.read(fd, size)
+                            # Drain any residual bytes appended after lstat.
+                            while True:
+                                chunk = os.read(fd, 65536)
+                                if not chunk:
+                                    break
+                                if len(data) + len(chunk) > _MARKER_RAIL_FILE_CAP_BYTES:
+                                    rel = fpath.relative_to(pack_path)
+                                    return (
+                                        f"pack declares \"user\" ∈ allowed-scopes "
+                                        f"but a primitive file grew past the "
+                                        f"marker-rail size cap during read; "
+                                        f"first offender: {rel.as_posix()}"
+                                    )
+                                data += chunk
+                        finally:
+                            os.close(fd)
+                    else:
+                        data = fpath.read_bytes()
+                except OSError:
+                    # Unreadable file — defer to validate's caller for
+                    # filesystem-permission errors; don't refuse here.
+                    continue
+                if _is_binary(data):
+                    continue
+                if _MARKER_REGEX.search(data) is not None:
+                    rel = fpath.relative_to(pack_path)
+                    return (
+                        f"pack declares \"user\" ∈ allowed-scopes but "
+                        f"a primitive file carries <adapt:NAME> markers; "
+                        f"first offender: {rel.as_posix()}"
+                    )
+    return None
+
+
+def _is_binary(data: bytes) -> bool:
+    """Heuristic: a UTF-8 decode that fails marks the file as binary.
+
+    The strict-grep contract pins decoding via `errors='strict'` and
+    catching `UnicodeDecodeError` — a file that fails to decode cannot
+    carry a textual marker. Empty files decode trivially and are not
+    binary.
+    """
+    if not data:
+        return False
+    try:
+        data.decode("utf-8")
+    except UnicodeDecodeError:
+        return True
+    return False
+
+
+def run_all(
+    pack_path: Path,
+    allowed_scopes: Iterable[str],
+) -> str | None:
+    """Run Rails A → B → C in spec order; return first refusal or None.
+
+    The spec orders them A → B → C so the seeds rail fires before the
+    marker rail's input is even computed (the marker rail never sees
+    `seeds/` content — Rail A already refused the pack if `seeds/` was
+    populated). Use this helper from the CLI's `install` and
+    `validate` surfaces to keep the message order consistent.
+    """
+    for rail in (check_seeds, check_hooks, check_markers):
+        result = rail(pack_path, allowed_scopes)
+        if result is not None:
+            return result
+    return None

--- a/packages/agentbundle/agentbundle/build/tests/test_contract_scope.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_contract_scope.py
@@ -1,0 +1,168 @@
+"""Tests for the RFC-0004 v0.2 `[scope]` table on the adapter contract.
+
+Verifies AC #14 (RFC-0004) for the distribution-adapters spec:
+  - adapter.schema.json accepts a well-formed [adapter.<name>.scope] block.
+  - adapter.schema.json rejects each malformed `allowed-prefixes.user` shape
+    enumerated in the spec: ["/"], [""], ["../"], [".."],
+    ["no-trailing-slash"], ["/begins-with-slash/"], and [].
+  - adapter.toml validates against the v0.2 schema with [contract] version =
+    "0.2" and the two-prefix [adapter."claude-code".scope] block.
+  - The other three reference adapters (kiro, copilot, codex) omit the
+    optional [scope] block and remain valid.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import tomllib
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+CONTRACT_PATH = REPO_ROOT / "docs" / "contracts" / "adapter.toml"
+SCHEMA_PATH = REPO_ROOT / "docs" / "contracts" / "adapter.schema.json"
+
+
+def _load_schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _load_contract() -> dict:
+    return tomllib.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+
+
+class ContractVersionTests(unittest.TestCase):
+    """Contract version bumps to 0.2 with this RFC."""
+
+    def test_contract_version_is_0_2(self) -> None:
+        contract = _load_contract()
+        self.assertEqual(contract["contract"]["version"], "0.2")
+
+
+class ClaudeCodeScopeBlockTests(unittest.TestCase):
+    """The Claude Code adapter declares the v0.2 [scope] block."""
+
+    def test_claude_code_scope_present(self) -> None:
+        contract = _load_contract()
+        scope = contract["adapter"]["claude-code"].get("scope")
+        self.assertIsNotNone(scope, "Claude Code [scope] block missing")
+        self.assertEqual(scope["repo"], ".")
+        self.assertEqual(scope["user"], "~")
+
+    def test_claude_code_allowed_prefixes_user_two_entries(self) -> None:
+        """Two prefixes ship: projected primitives + CLI infrastructure."""
+        contract = _load_contract()
+        prefixes = (
+            contract["adapter"]["claude-code"]["scope"]["allowed-prefixes"]["user"]
+        )
+        self.assertEqual(prefixes, [".claude/", ".agent-ready/"])
+
+    def test_contract_validates_against_schema(self) -> None:
+        from agentbundle.build.validate import validate
+
+        errors = validate(_load_contract(), _load_schema())
+        self.assertEqual(errors, [], f"v0.2 contract did not validate: {errors}")
+
+
+class OtherAdaptersOmitScopeTests(unittest.TestCase):
+    """Adapters omitting [scope] are accepted as repo-only."""
+
+    def test_kiro_copilot_codex_omit_scope(self) -> None:
+        contract = _load_contract()
+        for name in ("kiro", "copilot", "codex"):
+            with self.subTest(adapter=name):
+                self.assertNotIn("scope", contract["adapter"][name])
+
+    def test_contract_minus_claude_code_scope_still_valid(self) -> None:
+        from agentbundle.build.validate import validate
+
+        contract = _load_contract()
+        contract["adapter"]["claude-code"].pop("scope", None)
+        errors = validate(contract, _load_schema())
+        self.assertEqual(errors, [], f"validate rejected scope-less contract: {errors}")
+
+
+class AllowedPrefixesRejectionTests(unittest.TestCase):
+    """`allowed-prefixes.<scope>` constraints — every bad shape is rejected."""
+
+    def _validate_with_prefixes(self, prefixes: list[str]) -> list[str]:
+        from agentbundle.build.validate import validate
+
+        schema = _load_schema()
+        contract = _load_contract()
+        contract["adapter"]["claude-code"]["scope"]["allowed-prefixes"]["user"] = list(prefixes)
+        return validate(contract, schema)
+
+    def test_rejects_root_only(self) -> None:
+        errors = self._validate_with_prefixes(["/"])
+        self.assertTrue(errors, "schema accepted allowed-prefixes.user = ['/']")
+
+    def test_rejects_empty_string(self) -> None:
+        errors = self._validate_with_prefixes([""])
+        self.assertTrue(errors, "schema accepted allowed-prefixes.user = ['']")
+
+    def test_rejects_dotdot_slash(self) -> None:
+        errors = self._validate_with_prefixes(["../"])
+        self.assertTrue(errors, "schema accepted allowed-prefixes.user = ['../']")
+
+    def test_rejects_bare_dotdot(self) -> None:
+        errors = self._validate_with_prefixes([".."])
+        self.assertTrue(errors, "schema accepted allowed-prefixes.user = ['..']")
+
+    def test_rejects_no_trailing_slash(self) -> None:
+        errors = self._validate_with_prefixes(["no-trailing-slash"])
+        self.assertTrue(errors, "schema accepted allowed-prefixes.user = ['no-trailing-slash']")
+
+    def test_rejects_leading_slash(self) -> None:
+        errors = self._validate_with_prefixes(["/begins-with-slash/"])
+        self.assertTrue(errors, "schema accepted allowed-prefixes.user = ['/begins-with-slash/']")
+
+    def test_rejects_empty_array(self) -> None:
+        errors = self._validate_with_prefixes([])
+        self.assertTrue(errors, "schema accepted allowed-prefixes.user = []")
+
+    def test_rejects_dotdot_in_middle(self) -> None:
+        """Defence in depth: `..` as an interior segment is also rejected."""
+        errors = self._validate_with_prefixes([".claude/../etc/"])
+        self.assertTrue(errors, "schema accepted allowed-prefixes.user = ['.claude/../etc/']")
+
+    def test_accepts_nested_path(self) -> None:
+        """A nested path like `.claude/skills/` is legal — non-empty, trailing /."""
+        errors = self._validate_with_prefixes([".claude/skills/"])
+        self.assertEqual(errors, [], f"schema rejected nested path: {errors}")
+
+
+class StdlibValidatorExtensionsTests(unittest.TestCase):
+    """Cross-keyword tests for the validator extensions T10 needs."""
+
+    def test_min_items_rejects_short_array(self) -> None:
+        from agentbundle.build.validate import validate
+
+        schema = {"type": "array", "minItems": 1}
+        self.assertTrue(validate([], schema))
+        self.assertEqual(validate(["a"], schema), [])
+
+    def test_pattern_rejects_dotdot_segment(self) -> None:
+        from agentbundle.build.validate import validate
+
+        # The exact pattern shipped on allowed-prefixes.<scope>.items.
+        pattern = r"^((?!\.\.(\/|$))[^/]+/)+$"
+        schema = {"type": "string", "pattern": pattern}
+        for bad in ("../", "..", "/", "", "no-slash", "/abs/"):
+            with self.subTest(value=bad):
+                self.assertTrue(
+                    validate(bad, schema),
+                    f"pattern accepted forbidden value: {bad!r}",
+                )
+        for good in (".claude/", ".agent-ready/", "deep/nested/path/"):
+            with self.subTest(value=good):
+                self.assertEqual(
+                    validate(good, schema),
+                    [],
+                    f"pattern rejected legal value: {good!r}",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/agentbundle/agentbundle/build/tests/test_pack_schema_install.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_pack_schema_install.py
@@ -1,0 +1,305 @@
+"""T11: `pack.schema.json` enforces `[pack.install]` under contract v0.2.
+
+Verifies AC #15 (RFC-0004) for the distribution-adapters spec. Six test
+rows from the plan:
+
+  1. A v0.2 pack with no [pack.install] table is rejected.
+  2. A v0.2 pack with default-scope="repo", allowed-scopes=["repo"] accepted.
+  3. A v0.2 pack with default-scope="user", allowed-scopes=["repo"] rejected
+     by the default-scope ∈ allowed-scopes invariant.
+  4. A v0.2 pack omitting allowed-scopes (only default-scope declared) is
+     accepted — the implied `[default-scope]` default lands at CLI
+     consumption time, not at schema validation time.
+  5. A v0.1 pack (declares 0.1 or omits the adapter-contract field) without
+     [pack.install] is accepted (legacy).
+  6. A v0.1 pack carrying a stray [pack.install] table is accepted — the
+     table is ignored at CLI consumption time.
+
+The cross-field invariant lives in `pack.schema.json` (jsonschema
+`if`/`then`) so catalogue indexers and third-party validators refuse a
+malformed pack identically.
+
+Tests live in a new file (not extending test_pack_schema.py owned by T1c)
+to avoid the merge-conflict pattern the plan calls out for parallel
+worktrees.
+"""
+
+from __future__ import annotations
+
+import json
+import tomllib
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+PACK_SCHEMA_PATH = REPO_ROOT / "docs" / "contracts" / "pack.schema.json"
+
+
+def _load_schema() -> dict:
+    return json.loads(PACK_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _parse(toml_text: str) -> dict:
+    return tomllib.loads(toml_text)
+
+
+class V02PackInstallRequiredTests(unittest.TestCase):
+    """Row 1: v0.2 pack without [pack.install] is rejected."""
+
+    def test_v02_without_install_rejected(self) -> None:
+        from agentbundle.build.validate import validate
+
+        instance = _parse(
+            """
+[pack]
+name = "demo"
+version = "0.1.0"
+
+[pack.adapter-contract]
+version = "0.2"
+"""
+        )
+        errors = validate(instance, _load_schema())
+        self.assertTrue(errors, "v0.2 pack without [pack.install] was accepted")
+        self.assertTrue(
+            any("install" in e for e in errors),
+            f"error should name 'install'; got: {errors}",
+        )
+
+
+class V02PackInstallValidTests(unittest.TestCase):
+    """Row 2: v0.2 pack with a well-formed install table is accepted."""
+
+    def test_v02_with_valid_install_accepted(self) -> None:
+        from agentbundle.build.validate import validate
+
+        instance = _parse(
+            """
+[pack]
+name = "demo"
+version = "0.1.0"
+
+[pack.adapter-contract]
+version = "0.2"
+
+[pack.install]
+default-scope = "repo"
+allowed-scopes = ["repo"]
+"""
+        )
+        errors = validate(instance, _load_schema())
+        self.assertEqual(errors, [], f"valid v0.2 pack rejected: {errors}")
+
+
+class DefaultInAllowedInvariantTests(unittest.TestCase):
+    """Row 3: default-scope ∉ allowed-scopes is rejected."""
+
+    def test_user_default_with_repo_only_allowed_rejected(self) -> None:
+        from agentbundle.build.validate import validate
+
+        instance = _parse(
+            """
+[pack]
+name = "demo"
+version = "0.1.0"
+
+[pack.adapter-contract]
+version = "0.2"
+
+[pack.install]
+default-scope = "user"
+allowed-scopes = ["repo"]
+"""
+        )
+        errors = validate(instance, _load_schema())
+        self.assertTrue(
+            errors,
+            "default-scope='user' with allowed-scopes=['repo'] was accepted",
+        )
+
+    def test_repo_default_with_user_only_allowed_rejected(self) -> None:
+        """Mirror invariant: default-scope='repo' but allowed-scopes=['user']."""
+        from agentbundle.build.validate import validate
+
+        instance = _parse(
+            """
+[pack]
+name = "demo"
+version = "0.1.0"
+
+[pack.adapter-contract]
+version = "0.2"
+
+[pack.install]
+default-scope = "repo"
+allowed-scopes = ["user"]
+"""
+        )
+        errors = validate(instance, _load_schema())
+        self.assertTrue(
+            errors,
+            "default-scope='repo' with allowed-scopes=['user'] was accepted",
+        )
+
+    def test_both_scopes_allowed_with_user_default_accepted(self) -> None:
+        """default='user' but allowed=['repo','user'] is fine."""
+        from agentbundle.build.validate import validate
+
+        instance = _parse(
+            """
+[pack]
+name = "demo"
+version = "0.1.0"
+
+[pack.adapter-contract]
+version = "0.2"
+
+[pack.install]
+default-scope = "user"
+allowed-scopes = ["repo", "user"]
+"""
+        )
+        errors = validate(instance, _load_schema())
+        self.assertEqual(errors, [], f"valid dual-scope pack rejected: {errors}")
+
+
+class AllowedScopesOmittedTests(unittest.TestCase):
+    """Row 4: omitting allowed-scopes is accepted.
+
+    The implied `allowed-scopes = [default-scope]` is a CLI consumption-time
+    behaviour (per § *Install-scope dimension*); the schema simply does not
+    require the field.
+    """
+
+    def test_only_default_scope_accepted(self) -> None:
+        from agentbundle.build.validate import validate
+
+        instance = _parse(
+            """
+[pack]
+name = "demo"
+version = "0.1.0"
+
+[pack.adapter-contract]
+version = "0.2"
+
+[pack.install]
+default-scope = "repo"
+"""
+        )
+        errors = validate(instance, _load_schema())
+        self.assertEqual(
+            errors,
+            [],
+            f"pack with only default-scope was rejected: {errors}",
+        )
+
+
+class V01LegacyTests(unittest.TestCase):
+    """Rows 5 + 6: v0.1 packs are accepted, with or without a stray install."""
+
+    def test_v01_no_install_accepted(self) -> None:
+        from agentbundle.build.validate import validate
+
+        instance = _parse(
+            """
+[pack]
+name = "demo"
+version = "0.1.0"
+
+[pack.adapter-contract]
+version = "0.1"
+"""
+        )
+        errors = validate(instance, _load_schema())
+        self.assertEqual(errors, [], f"v0.1 pack rejected: {errors}")
+
+    def test_v01_omitting_adapter_contract_accepted(self) -> None:
+        """A pack omitting [pack.adapter-contract] is treated as v0.1 — accepted."""
+        from agentbundle.build.validate import validate
+
+        instance = _parse(
+            """
+[pack]
+name = "demo"
+version = "0.1.0"
+"""
+        )
+        errors = validate(instance, _load_schema())
+        self.assertEqual(errors, [], f"adapter-contract-less pack rejected: {errors}")
+
+    def test_v01_with_stray_install_accepted(self) -> None:
+        """A v0.1 pack carrying a stray [pack.install] table is accepted.
+
+        The schema must not validate the install table when the pack declares
+        an older contract version; CLI consumption ignores the table per
+        § *Install-scope dimension*. As long as the rest of the pack is
+        well-formed, the pack is accepted.
+        """
+        from agentbundle.build.validate import validate
+
+        instance = _parse(
+            """
+[pack]
+name = "demo"
+version = "0.1.0"
+
+[pack.adapter-contract]
+version = "0.1"
+
+[pack.install]
+default-scope = "repo"
+allowed-scopes = ["repo"]
+"""
+        )
+        errors = validate(instance, _load_schema())
+        self.assertEqual(
+            errors,
+            [],
+            f"v0.1 pack with stray install was rejected: {errors}",
+        )
+
+
+class AllowedScopesShapeTests(unittest.TestCase):
+    """Allowed-scopes accepts only the two-value alphabet."""
+
+    def test_allowed_scopes_unknown_value_rejected(self) -> None:
+        from agentbundle.build.validate import validate
+
+        instance = _parse(
+            """
+[pack]
+name = "demo"
+version = "0.1.0"
+
+[pack.adapter-contract]
+version = "0.2"
+
+[pack.install]
+default-scope = "repo"
+allowed-scopes = ["repo", "global"]
+"""
+        )
+        errors = validate(instance, _load_schema())
+        self.assertTrue(
+            errors,
+            "schema accepted unknown allowed-scopes value 'global'",
+        )
+
+    def test_allowed_scopes_empty_array_rejected(self) -> None:
+        from agentbundle.build.validate import validate
+
+        instance = {
+            "pack": {
+                "name": "demo",
+                "version": "0.1.0",
+                "adapter-contract": {"version": "0.2"},
+                "install": {"default-scope": "repo", "allowed-scopes": []},
+            }
+        }
+        errors = validate(instance, _load_schema())
+        self.assertTrue(errors, "schema accepted allowed-scopes=[]")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/agentbundle/agentbundle/build/tests/test_scope_rails.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_scope_rails.py
@@ -1,0 +1,321 @@
+"""T12: user-scope refusal rails — seeds / hooks / marker.
+
+Verifies AC #16 (RFC-0004) for the distribution-adapters spec. The rails
+fire only when a pack declares `"user" ∈ allowed-scopes` — repo-only
+packs are not inspected, so SKILL.md files that *document* the marker
+syntax (e.g. `adapt-to-project`) are not refused because their packs
+declare `allowed-scopes = ["repo"]`.
+
+Each test builds its fixture in a `tempfile.TemporaryDirectory()` to
+keep the build/ fixtures tree small and to make the marker-byte tests
+explicit about what's on disk.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+PACK_TOML_USER_OK = """
+[pack]
+name = "demo-user"
+version = "0.1.0"
+
+[pack.adapter-contract]
+version = "0.2"
+
+[pack.install]
+default-scope = "user"
+allowed-scopes = ["user"]
+"""
+
+PACK_TOML_REPO_ONLY = """
+[pack]
+name = "demo-repo"
+version = "0.1.0"
+
+[pack.adapter-contract]
+version = "0.2"
+
+[pack.install]
+default-scope = "repo"
+allowed-scopes = ["repo"]
+"""
+
+
+def _write_pack(root: Path, name: str, toml_text: str) -> Path:
+    pack = root / name
+    pack.mkdir()
+    (pack / "pack.toml").write_text(toml_text)
+    return pack
+
+
+class RailASeedsTests(unittest.TestCase):
+    """A non-empty seeds/ with allowed-scopes=['user'] is refused."""
+
+    def test_rail_a_refuses_seeds_with_user_scope(self) -> None:
+        from agentbundle.build.scope_rails import check_seeds
+
+        with tempfile.TemporaryDirectory() as td:
+            pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
+            (pack / "seeds").mkdir()
+            (pack / "seeds" / "AGENTS.md").write_text("hi")
+
+            result = check_seeds(pack, ["user"])
+            self.assertIsNotNone(result)
+            self.assertIn("seeds/AGENTS.md", result)
+
+    def test_rail_a_accepts_seeds_with_repo_only(self) -> None:
+        from agentbundle.build.scope_rails import check_seeds
+
+        with tempfile.TemporaryDirectory() as td:
+            pack = _write_pack(Path(td), "p", PACK_TOML_REPO_ONLY)
+            (pack / "seeds").mkdir()
+            (pack / "seeds" / "AGENTS.md").write_text("hi")
+
+            self.assertIsNone(check_seeds(pack, ["repo"]))
+
+    def test_rail_a_accepts_empty_seeds(self) -> None:
+        from agentbundle.build.scope_rails import check_seeds
+
+        with tempfile.TemporaryDirectory() as td:
+            pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
+            (pack / "seeds").mkdir()
+            self.assertIsNone(check_seeds(pack, ["user"]))
+
+
+class RailBHooksTests(unittest.TestCase):
+    """A non-empty .apm/hooks/ or .apm/hook-wiring/ with user scope is refused."""
+
+    def test_rail_b_refuses_hook_body_with_user_scope(self) -> None:
+        from agentbundle.build.scope_rails import check_hooks
+
+        with tempfile.TemporaryDirectory() as td:
+            pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
+            (pack / ".apm" / "hooks").mkdir(parents=True)
+            (pack / ".apm" / "hooks" / "pre-pr.sh").write_text("#!/bin/sh\n")
+
+            result = check_hooks(pack, ["user"])
+            self.assertIsNotNone(result)
+            self.assertIn(".apm/hooks/pre-pr.sh", result)
+
+    def test_rail_b_refuses_hook_wiring_with_user_scope(self) -> None:
+        from agentbundle.build.scope_rails import check_hooks
+
+        with tempfile.TemporaryDirectory() as td:
+            pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
+            (pack / ".apm" / "hook-wiring").mkdir(parents=True)
+            (pack / ".apm" / "hook-wiring" / "pre-pr.toml").write_text("[hooks]\n")
+
+            result = check_hooks(pack, ["user"])
+            self.assertIsNotNone(result)
+            self.assertIn(".apm/hook-wiring/pre-pr.toml", result)
+
+    def test_rail_b_accepts_hooks_with_repo_only(self) -> None:
+        from agentbundle.build.scope_rails import check_hooks
+
+        with tempfile.TemporaryDirectory() as td:
+            pack = _write_pack(Path(td), "p", PACK_TOML_REPO_ONLY)
+            (pack / ".apm" / "hooks").mkdir(parents=True)
+            (pack / ".apm" / "hooks" / "pre-pr.sh").write_text("#!/bin/sh\n")
+            self.assertIsNone(check_hooks(pack, ["repo"]))
+
+    def test_rail_b_accepts_no_hooks(self) -> None:
+        from agentbundle.build.scope_rails import check_hooks
+
+        with tempfile.TemporaryDirectory() as td:
+            pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
+            self.assertIsNone(check_hooks(pack, ["user"]))
+
+
+class RailCMarkersTests(unittest.TestCase):
+    """`<adapt:NAME>` markers under .apm/skills/, /agents/, /commands/ refused."""
+
+    def test_rail_c_refuses_marker_in_skill_with_user_scope(self) -> None:
+        from agentbundle.build.scope_rails import check_markers
+
+        with tempfile.TemporaryDirectory() as td:
+            pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
+            skills_dir = pack / ".apm" / "skills" / "my-skill"
+            skills_dir.mkdir(parents=True)
+            (skills_dir / "SKILL.md").write_text(
+                "# My skill\n\nDoes <adapt:PROJECT_NAME> things.\n"
+            )
+
+            result = check_markers(pack, ["user"])
+            self.assertIsNotNone(result)
+            self.assertIn(".apm/skills/my-skill/SKILL.md", result)
+
+    def test_rail_c_rejects_only_strict_marker(self) -> None:
+        """The grep matches `<adapt:[A-Z_][A-Z0-9_]*>` strictly."""
+        from agentbundle.build.scope_rails import check_markers
+
+        with tempfile.TemporaryDirectory() as td:
+            pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
+            skills_dir = pack / ".apm" / "skills" / "lowercase"
+            skills_dir.mkdir(parents=True)
+            # Lowercase marker — must not match.
+            (skills_dir / "SKILL.md").write_text("plays with <adapt:lowercase>")
+            # Wrong-cased prefix — must not match.
+            (skills_dir / "OTHER.md").write_text("plays with <ADAPT:NAME>")
+            self.assertIsNone(check_markers(pack, ["user"]))
+
+    def test_rail_c_does_not_inspect_repo_only_pack(self) -> None:
+        """Repo-only packs are not inspected — the rail's scope clause stops it."""
+        from agentbundle.build.scope_rails import check_markers
+
+        with tempfile.TemporaryDirectory() as td:
+            pack = _write_pack(Path(td), "p", PACK_TOML_REPO_ONLY)
+            skills_dir = pack / ".apm" / "skills" / "doc-marker"
+            skills_dir.mkdir(parents=True)
+            (skills_dir / "SKILL.md").write_text("documents <adapt:NAME>")
+            self.assertIsNone(check_markers(pack, ["repo"]))
+
+    def test_rail_c_skips_binary_files(self) -> None:
+        """Non-UTF-8 files are skipped silently."""
+        from agentbundle.build.scope_rails import check_markers
+
+        with tempfile.TemporaryDirectory() as td:
+            pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
+            skills_dir = pack / ".apm" / "skills" / "with-binary"
+            skills_dir.mkdir(parents=True)
+            # Raw bytes that are not valid UTF-8 — should be skipped.
+            (skills_dir / "icon.bin").write_bytes(b"\xff\xfe\x00<adapt:NAME>")
+            # A clean text file in the same directory.
+            (skills_dir / "SKILL.md").write_text("# clean\n")
+            self.assertIsNone(check_markers(pack, ["user"]))
+
+    def test_rail_c_refuses_symlink_under_skills(self) -> None:
+        """RFC-0004 Rail C must refuse symlinks under primitive dirs.
+
+        A `*.md → /dev/zero` symlink would bypass the size cap because
+        `stat()` follows the symlink and reports the target's
+        size (zero for /dev/zero). The lstat-based detection refuses
+        symlinks outright so the cap holds.
+        """
+        from agentbundle.build.scope_rails import check_markers
+        import os as _os
+
+        with tempfile.TemporaryDirectory() as td:
+            pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
+            skills_dir = pack / ".apm" / "skills" / "symlink-skill"
+            skills_dir.mkdir(parents=True)
+            # Create a symlink — target need not exist; the rail
+            # refuses on the symlink type alone.
+            _os.symlink("/dev/null", skills_dir / "SKILL.md")
+            result = check_markers(pack, ["user"])
+            self.assertIsNotNone(result)
+            self.assertIn("symlink", result)
+
+    def test_rail_c_refuses_oversize_file(self) -> None:
+        """Files larger than the size cap are refused before being read."""
+        from agentbundle.build.scope_rails import check_markers, _MARKER_RAIL_FILE_CAP_BYTES
+
+        with tempfile.TemporaryDirectory() as td:
+            pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
+            skills_dir = pack / ".apm" / "skills" / "oversize"
+            skills_dir.mkdir(parents=True)
+            # Sparse file slightly larger than the cap — no marker payload needed.
+            big = skills_dir / "SKILL.md"
+            with open(big, "wb") as fh:
+                fh.seek(_MARKER_RAIL_FILE_CAP_BYTES + 1)
+                fh.write(b"\0")
+            result = check_markers(pack, ["user"])
+            self.assertIsNotNone(result)
+            self.assertIn("size cap", result)
+
+    def test_rail_c_deterministic_first_offender(self) -> None:
+        """sorted(os.walk(...)) order — `a/` comes before `b/`."""
+        from agentbundle.build.scope_rails import check_markers
+
+        with tempfile.TemporaryDirectory() as td:
+            pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
+            for sub in ("z-late", "a-early"):
+                d = pack / ".apm" / "skills" / sub
+                d.mkdir(parents=True)
+                (d / "SKILL.md").write_text("hi <adapt:NAME>")
+            result = check_markers(pack, ["user"])
+            self.assertIsNotNone(result)
+            self.assertIn("a-early/SKILL.md", result)
+
+
+class CliValidateSpecNamedStderrTests(unittest.TestCase):
+    """`validate` emits the spec-named text on the cross-field invariant."""
+
+    def test_default_scope_not_in_allowed_scopes_emits_spec_text(self) -> None:
+        import argparse
+        import io
+        import contextlib
+
+        from agentbundle.commands import validate as validate_cmd
+
+        with tempfile.TemporaryDirectory() as td:
+            pack = Path(td) / "p"
+            pack.mkdir()
+            (pack / "pack.toml").write_text(
+                """
+[pack]
+name = "demo-invariant"
+version = "0.1.0"
+
+[pack.adapter-contract]
+version = "0.2"
+
+[pack.install]
+default-scope = "user"
+allowed-scopes = ["repo"]
+""",
+                encoding="utf-8",
+            )
+            args = argparse.Namespace(pack_path=str(pack), strict=False)
+            buf = io.StringIO()
+            with contextlib.redirect_stderr(buf):
+                rc = validate_cmd.run(args)
+            self.assertEqual(rc, 1)
+            err = buf.getvalue()
+            # Spec contract text (RFC-0004 last AC for agent-spec-cli).
+            self.assertIn("default-scope", err)
+            self.assertIn("'user'", err)
+            self.assertIn("allowed-scopes", err)
+            self.assertIn("demo-invariant", err)
+
+
+class CliValidateWiringTests(unittest.TestCase):
+    """The CLI's `validate` subcommand surfaces rail refusals to stderr."""
+
+    def test_validate_refuses_user_scope_pack_with_hooks(self) -> None:
+        import argparse
+        import io
+        import contextlib
+
+        from agentbundle.commands import validate as validate_cmd
+
+        with tempfile.TemporaryDirectory() as td:
+            pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
+            (pack / ".apm" / "hooks").mkdir(parents=True)
+            (pack / ".apm" / "hooks" / "pre-pr.sh").write_text("#!/bin/sh\n")
+
+            args = argparse.Namespace(pack_path=str(pack), strict=False)
+            buf = io.StringIO()
+            with contextlib.redirect_stderr(buf):
+                rc = validate_cmd.run(args)
+            self.assertEqual(rc, 1)
+            self.assertIn("demo-user", buf.getvalue())
+            self.assertIn(".apm/hooks/pre-pr.sh", buf.getvalue())
+
+    def test_validate_accepts_user_scope_pack_with_no_offenders(self) -> None:
+        import argparse
+
+        from agentbundle.commands import validate as validate_cmd
+
+        with tempfile.TemporaryDirectory() as td:
+            pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
+            args = argparse.Namespace(pack_path=str(pack), strict=False)
+            self.assertEqual(validate_cmd.run(args), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/agentbundle/agentbundle/build/validate.py
+++ b/packages/agentbundle/agentbundle/build/validate.py
@@ -12,6 +12,12 @@ Supported keywords:
   - `pattern`: regex string applied to strings (via `re`)
   - `items`: schema applied element-wise (only meaningful when type=array)
   - `additionalProperties`: bool or schema (only meaningful when type=object)
+  - `minItems`: integer; array must have at least this many items
+  - `contains`: subschema; array must have at least one item matching it
+  - `if` / `then` / `else`: conditional subschemas (all three applied to
+    the same instance as the parent). RFC-0004's pack.schema.json uses
+    this trio to express "v0.2 packs require `[pack.install]`" and
+    "default-scope ∈ allowed-scopes."
 
 Unsupported by design: `$ref`, `$defs`, `oneOf`, `anyOf`, `allOf`,
 `not`, `format`, `minimum`/`maximum`, `minLength`/`maxLength`. If the
@@ -74,7 +80,15 @@ def validate(instance: Any, schema: dict, path: str = "$") -> list[str]:
                 f"{path}: value {instance!r} does not match pattern {schema['pattern']!r}"
             )
 
-    if expected_type == "object" and isinstance(instance, dict):
+    # `required`, `properties`, `additionalProperties` apply whenever the
+    # instance is a dict — per JSON-Schema 2020-12, these keywords are
+    # vacuously true for non-object instances. Gating on `expected_type ==
+    # "object"` (the previous shape) caused subschemas with no `type`
+    # declaration (e.g. RFC-0004's `if`/`then` blocks) to silently skip
+    # their constraints — surprising callers and breaking the cross-field
+    # `default-scope ∈ allowed-scopes` invariant. Stay safe-by-default:
+    # apply when the instance matches.
+    if isinstance(instance, dict):
         for required_key in schema.get("required", []):
             if required_key not in instance:
                 errors.append(f"{path}: missing required property {required_key!r}")
@@ -90,10 +104,38 @@ def validate(instance: Any, schema: dict, path: str = "$") -> list[str]:
                 elif isinstance(additional, dict):
                     errors.extend(validate(value, additional, subpath))
 
-    if expected_type == "array" and isinstance(instance, list):
+    if isinstance(instance, list):
         item_schema = schema.get("items")
         if isinstance(item_schema, dict):
             for index, element in enumerate(instance):
                 errors.extend(validate(element, item_schema, f"{path}[{index}]"))
+        min_items = schema.get("minItems")
+        # bool is a subclass of int in Python — accept only true integers.
+        if isinstance(min_items, int) and not isinstance(min_items, bool):
+            if len(instance) < min_items:
+                errors.append(
+                    f"{path}: array has {len(instance)} item(s), minItems={min_items}"
+                )
+        contains_schema = schema.get("contains")
+        if isinstance(contains_schema, dict):
+            if not any(
+                not validate(element, contains_schema, f"{path}[{index}]")
+                for index, element in enumerate(instance)
+            ):
+                errors.append(
+                    f"{path}: no item matches the 'contains' subschema"
+                )
+
+    # Conditional subschemas — applied last so type/required/enum errors on
+    # the instance surface before any conditional branch fires. The 'if'
+    # subschema is evaluated silently (its errors are not surfaced); only
+    # the chosen branch's errors propagate. Per JSON-Schema 2020-12,
+    # missing 'then' or 'else' is a no-op for that branch.
+    if "if" in schema and isinstance(schema["if"], dict):
+        if_errors = validate(instance, schema["if"], path)
+        branch_key = "then" if not if_errors else "else"
+        branch_schema = schema.get(branch_key)
+        if isinstance(branch_schema, dict):
+            errors.extend(validate(instance, branch_schema, path))
 
     return errors

--- a/packages/agentbundle/agentbundle/cli.py
+++ b/packages/agentbundle/agentbundle/cli.py
@@ -7,15 +7,111 @@ from the spec (discovery-first): `list-packs`, `list-targets`, `scaffold`,
 
 Each subcommand's `run(args) -> int` lives under `agentbundle.commands.*`;
 this module wires `argparse` and prints `--version`. No business logic here.
+
+RFC-0004 surface additions:
+  - `--scope {repo,user}` on install, uninstall, upgrade, diff, init-state,
+    list-targets (the six subcommands enumerated in spec § *Install-scope
+    dimension*).
+  - `--force` on install only (cross-scope conflict bypass; see
+    spec § *Dual-scope install conflict*).
+  - Forbidden flags on the five excluded subcommands surface with the
+    spec's exact stderr contract: `unknown flag for <verb>: <flag>`.
+    `argparse`'s default text (`error: unrecognized arguments:`) omits
+    the verb and shapes the prefix differently, so a custom subclass
+    over `error()` rewrites the message before exiting.
 """
 
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from typing import Sequence
 
 from agentbundle.version import CLI_VERSION, SPEC_VERSION
+
+
+# Flags the spec's stderr contract names by hand. `error()` re-emits
+# any "unrecognized arguments: --scope[=value]" or "--force" mention
+# from argparse with the documented `unknown flag for <verb>: <flag>`
+# shape. Other unrecognised flags keep argparse's default text so we
+# don't accidentally swallow typos.
+_REWRITE_FLAGS = ("--scope", "--force")
+
+
+class _VerbAwareParser(argparse.ArgumentParser):
+    """An ArgumentParser that knows its verb and rewrites the
+    "unrecognized arguments" error for `--scope` / `--force` to match
+    the spec's exact stderr contract.
+
+    `prog` carries the verb name on subparsers (parent argparse sets
+    `prog = "<parent-prog> <subcommand>"`), so the verb is the last
+    whitespace-delimited token. The rewrite captures the bare flag
+    (stripping any `=value` suffix that argparse merged into one token
+    when the user wrote `--scope=user`) and emits the documented
+    `unknown flag for <verb>: <flag>` line.
+
+    On the *subparser*, `error()` is called from
+    `_VerbAwareSubParsersAction.__call__` when extras with spec flags
+    are detected — the override here picks up the verb from
+    `self.prog`. On the main parser, `error()` is reached only when
+    none of the extras matched a spec flag (subparser-level interception
+    already covered those), so the override falls through to argparse's
+    default behaviour.
+    """
+
+    def error(self, message: str) -> None:  # type: ignore[override]
+        match = re.match(r"^unrecognized arguments: (\S+)", message)
+        if match is not None:
+            token = match.group(1)
+            bare = token.split("=", 1)[0]
+            if bare in _REWRITE_FLAGS and " " in self.prog:
+                # On subparsers, prog is "<parent> <verb>" — extract verb.
+                verb = self.prog.rsplit(" ", 1)[-1]
+                sys.stderr.write(f"unknown flag for {verb}: {bare}\n")
+                raise SystemExit(2)
+        super().error(message)
+
+
+class _VerbAwareSubParsersAction(argparse._SubParsersAction):
+    """Hijack subparser dispatch to surface spec-flag refusals at the
+    *subparser* level so the verb in the stderr message is correct.
+
+    Default `_SubParsersAction.__call__` parses the subcommand's args
+    with `parse_known_args` and stores extras on the main namespace;
+    the main parser then surfaces "unrecognized arguments" later, with
+    its own `prog` (no verb). By calling `subparser.error()` ourselves
+    when extras include `--scope` or `--force`, the error path
+    inherits the subparser's prog (`agentbundle list-packs`), and
+    `_VerbAwareParser.error` rewrites it to the documented contract.
+
+    Non-spec-flag extras propagate normally — we only intercept the
+    two flags the spec names byte-for-byte.
+    """
+
+    def __call__(self, parser, namespace, values, option_string=None):  # type: ignore[override]
+        parser_name = values[0]
+        arg_strings = values[1:]
+        if parser_name not in self._name_parser_map:
+            return super().__call__(parser, namespace, values, option_string)
+        subparser = self._name_parser_map[parser_name]
+        subnamespace, extras = subparser.parse_known_args(arg_strings, None)
+        # Copy parsed attrs into the main namespace as argparse would.
+        for key, value in vars(subnamespace).items():
+            setattr(namespace, key, value)
+        # Intercept spec-flag extras at the subparser level.
+        for token in extras:
+            bare = token.split("=", 1)[0]
+            if bare in _REWRITE_FLAGS:
+                # Calls _VerbAwareParser.error on the subparser; that
+                # path rewrites to the spec's stderr contract.
+                subparser.error(f"unrecognized arguments: {bare}")
+                return  # unreachable — error() raises SystemExit
+        # No spec-flag extras — re-propagate everything for argparse's
+        # default unrecognised-args path on the main parser.
+        if extras:
+            vars(namespace).setdefault("_unrecognized_args", [])
+            getattr(namespace, "_unrecognized_args").extend(extras)
 
 
 def _version_string() -> str:
@@ -23,22 +119,32 @@ def _version_string() -> str:
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
+    parser = _VerbAwareParser(
         prog="agentbundle",
         description=(
             "Reference CLI for the agent-ready-repo adapter contract. "
             "Library-first counterpart to the `adapt-to-project` LLM skill."
         ),
     )
+    # Replace argparse's default _SubParsersAction with the verb-aware
+    # subclass that surfaces --scope / --force refusals on the
+    # subparser (correct verb in the stderr message).
+    parser.register("action", "parsers", _VerbAwareSubParsersAction)
     parser.add_argument(
         "--version",
         action="version",
         version=_version_string(),
     )
 
-    subparsers = parser.add_subparsers(dest="command", metavar="<command>")
+    # Use _VerbAwareParser for every subparser so the forbidden-flag
+    # error message names the verb correctly.
+    subparsers = parser.add_subparsers(
+        dest="command",
+        metavar="<command>",
+        parser_class=_VerbAwareParser,
+    )
 
-    # --- list-packs ---
+    # --- list-packs --- (no --scope; catalogue query, scope unbound)
     sp = subparsers.add_parser(
         "list-packs",
         help="List packs available in a catalogue URI (local path or git+https).",
@@ -46,14 +152,15 @@ def _build_parser() -> argparse.ArgumentParser:
     sp.add_argument("catalogue", help="Catalogue URI (local path or git+https://...).")
     sp.set_defaults(func=_lazy("list_packs"))
 
-    # --- list-targets ---
+    # --- list-targets --- (--scope as read-only filter)
     sp = subparsers.add_parser(
         "list-targets",
         help="List adapter targets the CLI supports (claude-code, kiro, copilot, codex).",
     )
+    sp.add_argument("--scope", choices=("repo", "user"))
     sp.set_defaults(func=_lazy("list_targets"))
 
-    # --- scaffold ---
+    # --- scaffold --- (no --scope; always repo-targeted)
     sp = subparsers.add_parser(
         "scaffold",
         help="Drop a pack's seeds/ into --output, honouring Tier-1/2/3 file-safety.",
@@ -63,7 +170,7 @@ def _build_parser() -> argparse.ArgumentParser:
     sp.add_argument("--output", required=True)
     sp.set_defaults(func=_lazy("scaffold"))
 
-    # --- install ---
+    # --- install --- (--scope override + --force cross-scope bypass)
     sp = subparsers.add_parser(
         "install",
         help="Install a pack from a catalogue URI into the adopter repo.",
@@ -71,9 +178,20 @@ def _build_parser() -> argparse.ArgumentParser:
     sp.add_argument("--pack", required=True)
     sp.add_argument("catalogue", help="Catalogue URI (local path or git+https://...).")
     sp.add_argument("--output", default=".")
+    sp.add_argument("--scope", choices=("repo", "user"))
+    sp.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "RFC-0004: bypass the cross-scope-conflict refusal — install at "
+            "the requested scope even when the pack is already installed at "
+            "the other scope. Does *not* override the in-place re-install "
+            "refusal; use `upgrade` for that."
+        ),
+    )
     sp.set_defaults(func=_lazy("install"))
 
-    # --- validate ---
+    # --- validate --- (no --scope; schema + rails A/B/C)
     sp = subparsers.add_parser(
         "validate",
         help="Validate a pack's pack.toml against the schemas; --strict for conformance.",
@@ -119,16 +237,17 @@ def _build_parser() -> argparse.ArgumentParser:
     sp.add_argument("--root", default=".")
     sp.set_defaults(func=_lazy("adapt"))
 
-    # --- diff ---
+    # --- diff --- (--scope disambiguator)
     sp = subparsers.add_parser(
         "diff",
         help="Diff the on-disk projection against a fresh render; non-zero on drift.",
     )
     sp.add_argument("pack_path", help="Path to the pack to diff against.")
     sp.add_argument("--root", default=".")
+    sp.add_argument("--scope", choices=("repo", "user"))
     sp.set_defaults(func=_lazy("diff"))
 
-    # --- upgrade ---
+    # --- upgrade --- (--scope disambiguator)
     sp = subparsers.add_parser(
         "upgrade",
         help="Upgrade a pack or a single primitive within a pack.",
@@ -142,25 +261,36 @@ def _build_parser() -> argparse.ArgumentParser:
     sp.add_argument("--command")
     sp.add_argument("catalogue", help="Catalogue URI to fetch the new version from.")
     sp.add_argument("--root", default=".")
+    sp.add_argument("--scope", choices=("repo", "user"))
     sp.set_defaults(func=_lazy("upgrade"))
 
-    # --- uninstall ---
+    # --- uninstall --- (--scope disambiguator)
     sp = subparsers.add_parser(
         "uninstall",
         help="Uninstall a pack; remove Tier-1 files; preserve Tier-2 and Tier-3.",
     )
     sp.add_argument("--pack", required=True)
     sp.add_argument("--root", default=".")
+    sp.add_argument("--scope", choices=("repo", "user"))
     sp.set_defaults(func=_lazy("uninstall"))
 
-    # --- init-state ---
+    # --- init-state --- (--scope selector; --migrate flag)
     sp = subparsers.add_parser(
         "init-state",
         help="Hash an existing projection into .agent-ready-state.toml.",
     )
-    sp.add_argument("--pack", required=True)
+    # `--pack` is required for the hash-from-projection mode but not for
+    # `--migrate` (which is a whole-file rewrite); the handler enforces
+    # the relationship instead of argparse.
+    sp.add_argument("--pack")
     sp.add_argument("--packs-dir", default="packs")
     sp.add_argument("--root", default=".")
+    sp.add_argument(
+        "--migrate",
+        action="store_true",
+        help="Rewrite a v0.1 state file to v0.2 (RFC-0004). Idempotent.",
+    )
+    sp.add_argument("--scope", choices=("repo", "user"))
     sp.set_defaults(func=_lazy("init_state"))
 
     return parser

--- a/packages/agentbundle/agentbundle/commands/adapt.py
+++ b/packages/agentbundle/agentbundle/commands/adapt.py
@@ -1,36 +1,32 @@
 """``agentbundle adapt`` — marker resolution and pending-companion report.
 
-Two modes:
+RFC-0004 turned this into a **dual-state-file** walk:
 
-  **Default (``--values-from`` optional):**
-  1. Load values from ``--values-from <file.toml>`` (if supplied) via
-     ``config.load_values_from``.
-  2. Merge with ``.adapt-discovery.toml`` accepted entries from
-     ``config.load_adapt_discovery`` (CLI never writes this file).
-  3. Walk every file recorded in ``.agent-ready-state.toml``; substitute
-     ``<adapt:NAME>`` markers with the merged dict.  Skip binary files
-     (decode error → warning + skip). Leave unresolved markers in place
-     and warn to stderr.
-  4. Write substituted content via ``safety.write_jailed`` (atomic).
-  5. Walk for ``.upstream.*`` companions and produce ``.adapt-pending.md``
-     listing each with a one-line diff summary.
-  6. ``.adapt-pending.md`` is written via ``safety.write_jailed``.
+  - Read both ``<repo>/.agent-ready-state.toml`` and
+    ``~/.agent-ready/state.toml``. Either may be absent (a fresh repo,
+    or no user-scope installs yet).
+  - Read marker values from both ``<repo>/.adapt-discovery.toml`` and
+    ``~/.agent-ready/.adapt-discovery.toml`` (user-scope discovery
+    lives inside the namespaced dot-directory, not as a bare dotfile).
+    ``--values-from`` still wins as an explicit override.
+  - Walk for ``.upstream.<ext>`` companions per scope; write per-scope
+    ``.adapt-pending.md`` reports at the same per-scope locations.
+  - ``adapt --ci`` exits non-zero when *either* scope's pending file
+    would be non-empty (or any companion is on disk).
 
-  Without ``--values-from``, steps 3–4 are skipped (read-only walk; only
-  the pending report is emitted).
+Findings are routed by the scope of the state file that recorded them —
+a squatter under ``~/.claude/`` is a user-scope finding, a
+``.upstream.<ext>`` companion in ``<repo>/`` is a repo-scope finding.
 
-  **``--ci`` mode (read-only):**
-  Walk ``args.root`` for any ``*.upstream.*`` (or ``*.upstream``)
-  companion file.  If any are found, list them on stderr and exit 1.
-  If none, exit 0.
-
-Spec rail: ``.adapt-discovery.toml`` is **never written** here.
+Spec rail: ``.adapt-discovery.toml`` is **never written** here. The
+``adapt-to-project`` LLM skill owns the write side.
 """
 
 from __future__ import annotations
 
 import re
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -39,6 +35,22 @@ if TYPE_CHECKING:
 
 # Marker regex: <adapt:UPPER_CASE_IDENTIFIER>
 _MARKER_RE = re.compile(r"<adapt:([A-Z_][A-Z0-9_]*)>")
+
+
+@dataclass
+class _Scope:
+    """Per-scope artifact paths the adapt verb operates on."""
+
+    name: str
+    root: Path
+    state_path: Path
+    discovery_path: Path
+    pending_path: Path
+    # User-scope writes must pass the adapter's `allowed-prefixes.user`
+    # list through to `safety.write_jailed` so the path-jail rail
+    # fires. Repo-scope leaves this as None (the repo-jail is the
+    # repo root; no additional prefix gate).
+    allowed_prefixes: list[str] | None = None
 
 
 def _find_upstream_companions(root: Path, projected_paths: set[str] | None = None) -> list[Path]:
@@ -110,83 +122,111 @@ def _apply_markers(text: str, values: dict[str, str], *, src_label: str) -> str:
             f"adapt: warning: no value for marker <adapt:{name}> in {src_label}; leaving in place",
             file=sys.stderr,
         )
-        return m.group(0)  # leave unchanged
+        return m.group(0)
 
     return _MARKER_RE.sub(_replace, text)
+
+
+def _resolve_scopes(args: "argparse.Namespace") -> list[_Scope]:
+    """Return the per-scope artifact descriptions adapt walks.
+
+    The repo scope is always present (rooted at ``args.root``). The
+    user scope is only added if ``~`` can be resolved — when
+    ``$HOME=/`` or otherwise unresolvable, the user scope is silently
+    skipped (a repo-only fixture should not refuse on a malformed
+    user-scope environment).
+    """
+    from agentbundle import scope as scope_mod
+
+    repo_root = Path(args.root).resolve()
+    scopes: list[_Scope] = [
+        _Scope(
+            name="repo",
+            root=repo_root,
+            state_path=repo_root / ".agent-ready-state.toml",
+            discovery_path=repo_root / ".adapt-discovery.toml",
+            pending_path=repo_root / ".adapt-pending.md",
+        ),
+    ]
+    try:
+        user_root = scope_mod.resolve_user_root()
+    except scope_mod.UserScopeUnresolvable:
+        return scopes
+    # User-scope dot-directory: `<user_root>/.agent-ready/`. We don't
+    # *create* it here; we only operate on it if it already exists
+    # (i.e. some prior user-scope install set it up).
+    user_dir = user_root / ".agent-ready"
+    if user_dir.is_dir():
+        from agentbundle.commands.install import _claude_code_allowed_prefixes_user
+
+        scopes.append(
+            _Scope(
+                name="user",
+                root=user_root,
+                state_path=user_dir / "state.toml",
+                discovery_path=user_dir / ".adapt-discovery.toml",
+                pending_path=user_dir / ".adapt-pending.md",
+                allowed_prefixes=_claude_code_allowed_prefixes_user(),
+            )
+        )
+    return scopes
 
 
 def run(args: "argparse.Namespace") -> int:
     """Entry point for ``agentbundle adapt``.
 
-    Args:
-        args.values_from  — optional path to a ``--values-from`` TOML file.
-        args.ci           — bool; ``--ci`` gate mode.
-        args.root         — repo root directory (default ``'.'``).
-
-    Returns 0 on success; 1 on ``--ci`` with pending companions or path-jail
-    refusal.
+    Returns 0 on success; 1 on ``--ci`` with pending companions or
+    path-jail refusal at write time.
     """
-    from agentbundle.config import (
-        ConfigError,
-        load_adapt_discovery,
-        load_state,
-        load_values_from,
-    )
+    from agentbundle.config import ConfigError, load_adapt_discovery, load_state, load_values_from
     from agentbundle import safety
 
-    root = Path(args.root).resolve()
-    state_path = root / ".agent-ready-state.toml"
-    discovery_path = root / ".adapt-discovery.toml"
-
-    # Load state up-front so both --ci and default modes can scope the
-    # companion walk to projected paths only (Concern 11).
-    try:
-        _state_for_ci = load_state(state_path) if state_path.exists() else None
-    except ConfigError as exc:
-        print(f"adapt: {exc}", file=sys.stderr)
-        return 1
-    _projected_for_ci = _state_for_ci.projected_paths() if _state_for_ci else None
+    scopes = _resolve_scopes(args)
 
     # ── --ci mode ─────────────────────────────────────────────────────────────
     if args.ci:
-        companions = _find_upstream_companions(root, _projected_for_ci)
-        if companions:
-            print("adapt --ci: pending .upstream.* companions found:", file=sys.stderr)
-            for cp in companions:
-                try:
-                    rel = cp.relative_to(root)
-                except ValueError:
-                    rel = cp
-                print(f"  {rel}", file=sys.stderr)
-            return 1
-        return 0
+        any_pending = False
+        for s in scopes:
+            try:
+                state = load_state(s.state_path) if s.state_path.exists() else None
+            except ConfigError as exc:
+                print(f"adapt: {exc}", file=sys.stderr)
+                return 1
+            projected = state.projected_paths() if state else None
+            companions = _find_upstream_companions(s.root, projected)
+            if companions:
+                if not any_pending:
+                    print(
+                        "adapt --ci: pending .upstream.* companions found:",
+                        file=sys.stderr,
+                    )
+                    any_pending = True
+                for cp in companions:
+                    try:
+                        rel = cp.relative_to(s.root)
+                    except ValueError:
+                        rel = cp
+                    print(f"  [{s.name}] {rel}", file=sys.stderr)
+        return 1 if any_pending else 0
 
     # ── Default mode ──────────────────────────────────────────────────────────
-
-    # Load state: walk projected paths for marker substitution.
-    try:
-        state = load_state(state_path)
-    except ConfigError as exc:
-        print(f"adapt: {exc}", file=sys.stderr)
-        return 1
-
-    # Merge values: --values-from (higher priority) merged with discovery accepted.
+    # Build the merged marker-values dict across both scopes' discovery
+    # files. --values-from (when supplied) wins as the explicit
+    # override. Repo discovery takes precedence over user discovery so
+    # project-specific resolutions override personal defaults.
     values: dict[str, str] = {}
+    for s in reversed(scopes):  # user first → repo overrides
+        try:
+            discovery = load_adapt_discovery(s.discovery_path)
+        except ConfigError as exc:
+            print(f"adapt: {exc}", file=sys.stderr)
+            return 1
+        accepted = discovery.get("accepted", {})
+        if isinstance(accepted, dict):
+            for k, v in accepted.items():
+                if isinstance(v, str):
+                    values[str(k)] = v
 
-    # Layer 1: .adapt-discovery.toml accepted entries (lower priority).
-    try:
-        discovery = load_adapt_discovery(discovery_path)
-    except ConfigError as exc:
-        print(f"adapt: {exc}", file=sys.stderr)
-        return 1
-
-    accepted = discovery.get("accepted", {})
-    if isinstance(accepted, dict):
-        for k, v in accepted.items():
-            if isinstance(v, str):
-                values[str(k)] = v
-
-    # Layer 2: --values-from (higher priority; overrides discovery).
     if getattr(args, "values_from", None):
         try:
             explicit = load_values_from(Path(args.values_from))
@@ -195,60 +235,78 @@ def run(args: "argparse.Namespace") -> int:
             return 1
         values.update(explicit)
 
-    # ── Marker substitution (only when --values-from supplied) ────────────────
-    if getattr(args, "values_from", None) and values:
-        projected = state.projected_paths()
-        for relpath in sorted(projected):
-            target = root / relpath
-            if not target.exists() or not target.is_file():
-                continue
-            try:
-                text = target.read_bytes().decode("utf-8")
-            except (UnicodeDecodeError, ValueError):
-                print(f"adapt: skipping binary file: {relpath}", file=sys.stderr)
-                continue
-            substituted = _apply_markers(text, values, src_label=relpath)
-            if substituted != text:
+    # ── Per-scope walk: substitute markers + emit pending report ─────────────
+    for s in scopes:
+        try:
+            state = load_state(s.state_path) if s.state_path.exists() else None
+        except ConfigError as exc:
+            print(f"adapt: {exc}", file=sys.stderr)
+            return 1
+        projected = state.projected_paths() if state else set()
+
+        # Substitute markers only when --values-from was given (preserve
+        # the read-only-without-values-from contract).
+        if getattr(args, "values_from", None) and values and projected:
+            for relpath in sorted(projected):
+                target = s.root / relpath
+                if not target.exists() or not target.is_file():
+                    continue
                 try:
-                    safety.write_jailed(root, relpath, substituted)
-                except safety.PathJailError as exc:
-                    print(f"adapt: {exc}", file=sys.stderr)
-                    return 1
+                    text = target.read_bytes().decode("utf-8")
+                except (UnicodeDecodeError, ValueError):
+                    print(f"adapt: skipping binary file: [{s.name}] {relpath}", file=sys.stderr)
+                    continue
+                substituted = _apply_markers(text, values, src_label=f"[{s.name}] {relpath}")
+                if substituted != text:
+                    try:
+                        safety.write_jailed(
+                            s.root, relpath, substituted,
+                            scope=s.name,
+                            allowed_prefixes=s.allowed_prefixes,
+                        )
+                    except safety.PathJailError as exc:
+                        print(f"adapt: {exc}", file=sys.stderr)
+                        return 1
 
-    # ── Build .adapt-pending.md ───────────────────────────────────────────────
-    companions = _find_upstream_companions(root, state.projected_paths())
-    report_lines: list[str] = [
-        "# Adapt Pending Report",
-        "",
-        "Companions awaiting human merge:",
-        "",
-    ]
-    if companions:
-        for cp in sorted(companions):
-            try:
-                rel_companion = cp.relative_to(root)
-            except ValueError:
-                rel_companion = cp
+        # Build the per-scope pending report.
+        companions = _find_upstream_companions(s.root, projected)
+        report_lines: list[str] = [
+            f"# Adapt Pending Report ({s.name} scope)",
+            "",
+            "Companions awaiting human merge:",
+            "",
+        ]
+        if companions:
+            for cp in sorted(companions):
+                try:
+                    rel_companion = cp.relative_to(s.root)
+                except ValueError:
+                    rel_companion = cp
+                original = _original_from_companion(cp)
+                if original.exists():
+                    summary = _diff_summary(original, cp)
+                else:
+                    summary = "original file not found"
+                report_lines.append(f"- `{rel_companion}`: {summary}")
+        else:
+            report_lines.append("_No pending companions._")
+        report_lines.append("")
+        report_content = "\n".join(report_lines)
 
-            # Derive the original path: AGENTS.upstream.md → AGENTS.md
-            original = _original_from_companion(cp)
-            if original.exists():
-                summary = _diff_summary(original, cp)
-            else:
-                summary = "original file not found"
-
-            report_lines.append(f"- `{rel_companion}`: {summary}")
-    else:
-        report_lines.append("_No pending companions._")
-
-    report_lines.append("")
-    report_content = "\n".join(report_lines)
-
-    try:
-        safety.write_jailed(root, ".adapt-pending.md", report_content)
-    except safety.PathJailError as exc:
-        print(f"adapt: {exc}", file=sys.stderr)
-        return 1
+        # Write the pending report through the per-scope path-jail. At
+        # user scope this routes through `allowed-prefixes.user` —
+        # `.adapt-pending.md` lives at `.agent-ready/.adapt-pending.md`
+        # under the user root, which the `.agent-ready/` prefix admits.
+        report_relpath = s.pending_path.relative_to(s.root).as_posix()
+        try:
+            safety.write_jailed(
+                s.root, report_relpath, report_content,
+                scope=s.name,
+                allowed_prefixes=s.allowed_prefixes,
+            )
+        except safety.PathJailError as exc:
+            print(f"adapt: {exc}", file=sys.stderr)
+            return 1
 
     return 0
 
@@ -263,7 +321,6 @@ def _original_from_companion(companion: Path) -> Path:
     """
     name = companion.name
     parts = name.split(".")
-    # Find "upstream" in parts and remove it.
     if "upstream" in parts:
         idx = parts.index("upstream")
         new_parts = parts[:idx] + parts[idx + 1:]

--- a/packages/agentbundle/agentbundle/commands/diff.py
+++ b/packages/agentbundle/agentbundle/commands/diff.py
@@ -30,6 +30,55 @@ def run(args: argparse.Namespace) -> int:
     """Entry point called by the CLI dispatcher. Returns exit code."""
     pack_path = Path(args.pack_path).resolve()
     root = Path(args.root).resolve()
+    cli_scope: str | None = getattr(args, "scope", None)
+
+    # ── Multi-scope disambiguator (RFC-0004) ──────────────────────────────────
+    # diff is read-only but still subject to the --scope rule: pick which
+    # scope's projection to compare against. If the pack is at both
+    # scopes, --scope is required.
+    from agentbundle import scope as scope_mod
+    from agentbundle.config import load_state
+
+    # Best-effort pack name lookup from pack.toml for the multi-scope check.
+    try:
+        pack_toml_data = load_pack_toml(pack_path / "pack.toml")
+        pack_name = pack_toml_data.get("pack", {}).get("name", "")
+    except ConfigError:
+        pack_name = ""
+
+    installed_at_repo = False
+    installed_at_user = False
+    user_root_resolved: Path | None = None
+    if pack_name:
+        repo_state_for_check = load_state(root / ".agent-ready-state.toml")
+        installed_at_repo = pack_name in repo_state_for_check.packs
+        try:
+            user_root_resolved = scope_mod.resolve_user_root()
+            user_state_for_check = load_state(
+                user_root_resolved / ".agent-ready" / "state.toml"
+            )
+            installed_at_user = pack_name in user_state_for_check.packs
+        except scope_mod.UserScopeUnresolvable:
+            pass
+
+        if installed_at_repo and installed_at_user and cli_scope is None:
+            print(
+                f"diff: {pack_name} installed at multiple scopes; "
+                "pass --scope {repo, user}",
+                file=sys.stderr,
+            )
+            return 1
+
+        if cli_scope == "user" or (
+            cli_scope is None and installed_at_user and not installed_at_repo
+        ):
+            if user_root_resolved is None:
+                print(
+                    "diff: cannot resolve user scope: $HOME unset or invalid",
+                    file=sys.stderr,
+                )
+                return 1
+            root = user_root_resolved
 
     if not (pack_path / "pack.toml").exists():
         print(

--- a/packages/agentbundle/agentbundle/commands/init_state.py
+++ b/packages/agentbundle/agentbundle/commands/init_state.py
@@ -5,7 +5,7 @@ manual install or a `make build-self`), hash the on-disk projected files and
 write `.agent-ready-state.toml` with their SHA-256s. This is the recovery
 path: produce a state file for a tree that doesn't have one.
 
-Algorithm:
+Algorithm (without ``--migrate``):
   1. Locate `<packs_dir>/<pack>/`; render in-memory via `render.render_pack`
      to learn the projection's relpath set.
   2. For each projected relpath:
@@ -16,6 +16,16 @@ Algorithm:
      Replace only `[pack.<args.pack>]`; leave other packs untouched.
   4. Write via `safety.write_jailed(args.root, ".agent-ready-state.toml", ...)`.
   5. Print summary to stdout.
+
+With ``--migrate`` (RFC-0004 T13): the subcommand becomes a migration
+verb instead — it reads the on-disk state file, augments every
+``[pack.<name>]`` entry with ``scope = "repo"``, sets ``schema-version =
+"0.2"``, and writes atomically. Idempotent against already-v0.2 files.
+The flag accepts no ``--pack`` (the migration is whole-file), and the
+``--scope`` selector picks which scope's state file to operate on
+(``repo`` → ``<root>/.agent-ready-state.toml`` — the default;
+``user`` → ``~/.agent-ready/state.toml`` via
+``safety.user_state_path()``).
 """
 
 from __future__ import annotations
@@ -30,11 +40,29 @@ from agentbundle.commands._common import check_spec_version_gate
 
 def run(args: argparse.Namespace) -> int:
     """Entry point called by the CLI dispatcher. Returns exit code."""
+    # ── --migrate branch (RFC-0004 T13) ──────────────────────────────────
+    # Migration is a different verb shape: no pack name, no rendering,
+    # just rewrite the state file in place. Run before the regular init-
+    # state path so the absent-file vs v0.1-file branches don't trip the
+    # `--pack` requirement.
+    if getattr(args, "migrate", False):
+        return _run_migrate(args)
+
     root = Path(args.root).resolve()
     packs_dir = Path(getattr(args, "packs_dir", "packs"))
     if not packs_dir.is_absolute():
         packs_dir = root / packs_dir
-    pack_name: str = args.pack
+    pack_name: str | None = getattr(args, "pack", None)
+    if not pack_name:
+        # argparse can't enforce the "required unless --migrate" shape
+        # without an arg-group hack; we enforce it here so the handler's
+        # entry contract stays simple and the error message names the
+        # right verb.
+        print(
+            "init-state: --pack is required (omit it only with --migrate)",
+            file=sys.stderr,
+        )
+        return 1
     pack_path = packs_dir / pack_name
 
     if not pack_path.is_dir():
@@ -89,8 +117,14 @@ def run(args: argparse.Namespace) -> int:
         files[relpath] = {"sha": sha, "from-pack-version": pack_version}
 
     # Load existing state (may be absent) and replace only this pack's table.
+    # init-state is a *write* — refuse-and-explain on a v0.1 file so the
+    # adopter opts into migration explicitly.
     state_path = root / ".agent-ready-state.toml"
-    existing_state = config.load_state(state_path)
+    try:
+        existing_state = config.load_state(state_path, for_write=True)
+    except config.StateFileLegacy as exc:
+        print(f"init-state: {exc}", file=sys.stderr)
+        return 1
 
     new_pack_state = config.PackState(
         installed_version=pack_version,
@@ -111,4 +145,75 @@ def run(args: argparse.Namespace) -> int:
         + (f", {skipped} skipped (absent)" if skipped else "")
         + f" → {state_path}"
     )
+    return 0
+
+
+def _run_migrate(args: argparse.Namespace) -> int:
+    """`init-state --migrate`: rewrite a v0.1 state file to v0.2 idempotently.
+
+    Reads the file via ``config.load_state(..., for_write=False)`` so the
+    legacy refusal does not fire (we *are* the migration). Adds ``scope =
+    "repo"`` to every pack entry, sets ``schema_version = "0.2"``, and
+    writes atomically through ``safety.write_jailed``.
+
+    Already-v0.2 files are a no-op exit-zero: ``load_state`` returns the
+    same shape, ``scope`` defaults to ``"repo"`` already, and the dumped
+    output is byte-identical to the input. Idempotence is the spec
+    requirement; running ``--migrate`` twice never breaks anything.
+    """
+    scope = getattr(args, "scope", None) or "repo"
+    user_prefixes: list[str] | None = None
+    if scope == "user":
+        try:
+            state_path = safety.user_state_path()
+        except OSError as exc:
+            print(f"init-state: cannot create user state directory: {exc}", file=sys.stderr)
+            return 1
+        # Write through the user root + relative path so the path-jail
+        # rail fires on the migration write — same shape every other
+        # user-scope write uses.
+        write_root = state_path.parent.parent  # = ~
+        relpath = state_path.relative_to(write_root).as_posix()
+        from agentbundle.commands.install import _claude_code_allowed_prefixes_user
+
+        user_prefixes = _claude_code_allowed_prefixes_user()
+    else:
+        root = Path(args.root).resolve()
+        state_path = root / ".agent-ready-state.toml"
+        write_root = root
+        relpath = ".agent-ready-state.toml"
+
+    if not state_path.exists():
+        # Migration of an absent file is meaningless — surface so the
+        # adopter doesn't think a no-op succeeded silently.
+        print(
+            f"init-state --migrate: no state file at {state_path}; nothing to migrate",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        state = config.load_state(state_path, for_write=False)
+    except config.ConfigError as exc:
+        print(f"init-state --migrate: {exc}", file=sys.stderr)
+        return 1
+
+    # Bump in-memory state to v0.2 and fill the implicit scope column.
+    state.schema_version = config.STATE_SCHEMA_VERSION
+    for ps in state.packs.values():
+        if not ps.scope:
+            ps.scope = "repo"
+
+    serialised = config.dump_state(state)
+    try:
+        safety.write_jailed(
+            write_root, relpath, serialised,
+            scope=scope,
+            allowed_prefixes=user_prefixes,
+        )
+    except safety.PathJailError as exc:
+        print(f"init-state --migrate: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"init-state --migrate: {state_path} → schema-version 0.2")
     return 0

--- a/packages/agentbundle/agentbundle/commands/install.py
+++ b/packages/agentbundle/agentbundle/commands/install.py
@@ -1,22 +1,35 @@
 """``agentbundle install`` — constrained-network pack installer.
 
-Steps:
-  1. Resolve the catalogue URI to a local directory (``catalogue.resolve_catalogue``).
-  2. Locate the pack directory inside the catalogue.
-  3. Spec-version gate: refuse if pack's major spec version != CLI's major.
-  4. Render the pack projection in memory (``render.render_pack``).
-  5. Walk each (relpath, bytes) pair:
-       - Classify against existing state + on-disk content.
-       - Tier-1 (or absent): write via ``safety.write_jailed``; record SHA.
-       - Tier-2: write companion via ``safety.write_companion``; leave original.
-       - Tier-3: skip entirely.
-  6. Merge new pack table into existing ``.agent-ready-state.toml`` leaving
-     other packs untouched; write atomically via ``safety.write_jailed``.
+Per RFC-0004 the install verb is the load-bearing CLI surface for the
+scope dimension. The handler enforces:
+
+  - **Scope resolution** via :mod:`agentbundle.scope` (CLI flag > pack
+    ``default-scope`` > built-in ``"repo"``).
+  - **Cross-scope conflict** with ``--force`` semantics:
+      - Pack already at the *requested* scope → refused (use ``upgrade``).
+      - Pack at the *other* scope, no ``--force`` → refused; stderr
+        names the other scope and the bypass flag.
+      - Pack at the other scope, with ``--force`` → dual-scope install:
+        re-confirms the existing scope and installs at the new scope,
+        printing two ``installed:`` lines in repo-then-user order.
+  - **Pre-flight order**: every scope's preconditions (``~``-expansion,
+    Rails A/B/C re-check, path-jail probe) run **before** any write to
+    either scope. A user-scope failure after a repo write would leave a
+    half-applied install on disk, so we sequence: resolve → check → write.
+  - **State-file v0.1 refusal** is delegated to
+    :func:`config.load_state(..., for_write=True)`.
+
+Tier-1/2/3 classification is unchanged from the pre-RFC-0004 shape;
+both scope roots use :func:`_classify_for_install`. Writes go through
+:func:`safety.write_jailed` with the matching ``scope`` and
+``allowed_prefixes`` so the user-scope jail fires.
 """
 
 from __future__ import annotations
 
+import functools
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -27,15 +40,29 @@ if TYPE_CHECKING:
     from agentbundle.safety import Tier
 
 
+@dataclass
+class _ScopePlan:
+    """One scope's worth of pre-flight + write data.
+
+    Computed during pre-flight and consumed at write time. Keeping the
+    fields in a dataclass lets the dual-scope path assemble *all*
+    plans (and surface any pre-flight failure across either scope)
+    before any side-effect runs.
+    """
+
+    scope: str
+    root: Path  # absolute path of the scope's root
+    state_path: Path  # absolute path of the scope's state file
+    allowed_prefixes: list[str] | None
+    state: "State"  # the loaded state at this scope (read-only mode)
+    already_installed: bool
+
+
 def run(args: "argparse.Namespace") -> int:
     """Entry point for ``agentbundle install``.
 
-    Args:
-        args.pack       — pack name to install (required).
-        args.catalogue  — catalogue URI (local path or git+https://...).
-        args.output     — destination root directory (default '.').
-
-    Returns 0 on success, non-zero on any failure.
+    Returns 0 on success, non-zero on any failure. See module docstring
+    for the dual-scope contract.
     """
     from agentbundle.catalogue import CatalogueError, resolve_catalogue
     from agentbundle.commands._common import check_spec_version_gate
@@ -47,20 +74,21 @@ def run(args: "argparse.Namespace") -> int:
         load_state,
     )
     from agentbundle.render import render_pack
-    from agentbundle import safety
+    from agentbundle import safety, scope as scope_mod
+    from agentbundle.build import scope_rails
 
     pack_name: str = args.pack
     catalogue_uri: str = args.catalogue
+    cli_scope: str | None = getattr(args, "scope", None)
+    force: bool = bool(getattr(args, "force", False))
     output_root = Path(args.output).resolve()
 
-    # ── Step 1: Resolve catalogue ─────────────────────────────────────────────
+    # ── Step 1: Resolve catalogue + locate + spec gate ────────────────────────
     try:
         catalogue_dir = resolve_catalogue(catalogue_uri)
     except CatalogueError as exc:
         print(f"install: {exc}", file=sys.stderr)
         return 1
-
-    # ── Step 2: Locate the pack directory ─────────────────────────────────────
     pack_dir = _locate_pack(catalogue_dir, pack_name)
     if pack_dir is None:
         print(
@@ -69,111 +97,515 @@ def run(args: "argparse.Namespace") -> int:
             file=sys.stderr,
         )
         return 1
-
-    # ── Step 3: Spec-version gate ─────────────────────────────────────────────
     try:
         pack_toml = load_pack_toml(pack_dir / "pack.toml")
     except ConfigError as exc:
         print(f"install: {exc}", file=sys.stderr)
         return 1
-
     gate = check_spec_version_gate(pack_toml)
     if gate is not None:
         return gate
 
-    # ── Step 4: Render projection in memory ───────────────────────────────────
+    # ── Step 2: Resolve scope ─────────────────────────────────────────────────
+    # RFC-0004 § *v0.1 vs v0.2 contract acceptance*: a stray
+    # [pack.install] table on a v0.1 pack is *ignored*. We gate the
+    # install table on the declared contract version so a legacy pack
+    # carrying `default-scope = "user"` does NOT resolve to user scope.
+    # Mirrors validate.py:_allowed_scopes, kept in sync intentionally.
+    from agentbundle.config import pack_spec_version
+
+    if pack_spec_version(pack_toml) == "0.2":
+        pack_install = pack_toml.get("pack", {}).get("install")
+    else:
+        pack_install = None
     try:
-        projection = render_pack(pack_dir)
-    except (FileNotFoundError, ValueError) as exc:
-        print(f"install: render failed for pack {pack_name!r}: {exc}", file=sys.stderr)
+        requested_scope = scope_mod.resolve(
+            cli_scope, pack_install, pack_name=pack_name
+        )
+    except scope_mod.ScopeRefused as exc:
+        print(
+            f"install: {exc.pack_name}: scope {exc.requested!r} not in "
+            f"allowed-scopes {exc.allowed}",
+            file=sys.stderr,
+        )
         return 1
 
-    # ── Step 5: Load existing state (for Tier classification) ─────────────────
-    state_path = output_root / ".agent-ready-state.toml"
+    # ── Step 3: Pre-flight — load state at *both* scopes ──────────────────────
+    # Read-only loads (for_write=False) — we do the v0.1 refusal *only*
+    # for scopes we're about to write to, after we know which they are.
+    # Loading both is cheap and reveals the cross-scope conflict.
+    repo_state_path = output_root / ".agent-ready-state.toml"
+    user_root: Path | None
+    user_state_path: Path | None
     try:
-        state = load_state(state_path)
+        repo_state = load_state(repo_state_path)
     except ConfigError as exc:
         print(f"install: {exc}", file=sys.stderr)
         return 1
 
-    # Build a fresh PackState for the pack being installed; we populate
-    # ``files`` as we walk the projection.
-    pack_version: str = pack_toml.get("pack", {}).get("version", "0.0.0")
-    # Carry forward per-primitive mixed-version overrides from a prior
-    # install/upgrade so a re-install doesn't silently drop the warning
-    # that a subsequent whole-pack upgrade should surface (AC #10's
-    # second clause).
-    prior = state.packs.get(pack_name)
-    new_pack_state = PackState(
-        installed_version=pack_version,
-        source="agent-ready-repo",
-        install_route="cli",
-        primitives=_collect_primitives(pack_dir),
-        files={},
-        primitive_versions=dict(prior.primitive_versions) if prior else {},
+    # User scope resolution only fires when we actually need it (the
+    # request, the pack's default, or a dual-scope --force path touches
+    # user). Defer the expanduser call to avoid raising on adopters
+    # with $HOME=/ when they're only installing at repo scope.
+    needs_user_state = requested_scope == "user" or (
+        # Conservative pre-load — we don't yet know if the pack is at
+        # user scope until we read the user state file, but if the pack
+        # isn't permitted at user scope, no user state is consulted.
+        "user" in _resolved_allowed_scopes(pack_install)
     )
-
-    # ── Step 5 (walk) ─────────────────────────────────────────────────────────
-    for relpath, content in sorted(projection.items()):
-        # Classify this projected path against the *current* on-disk state:
-        #   - If the path is already in state (from a prior install of this
-        #     same pack) and the on-disk SHA matches → Tier-1 (safe overwrite).
-        #   - If the path is already in state and the SHA has drifted → Tier-2
-        #     (adopter has edited; write companion only).
-        #   - If the path is not in any pack's state yet, but exists on disk
-        #     with content that doesn't match the bundle → Tier-2 (same rule:
-        #     something is there that the CLI didn't put there).
-        #   - If not on disk at all OR matches bundle content → Tier-1.
-        #
-        # Note: we do NOT use safety.classify() here because that function's
-        # Tier-3 branch is "not in state.projected_paths()" — which would
-        # incorrectly mark every newly-installed path as Tier-3 on a fresh
-        # install. The install command's contract is different: EVERY path in
-        # the incoming projection is adapter-contract space; we just need to
-        # know whether it's safe to overwrite or not.
-        tier = _classify_for_install(
-            relpath, output_root, content, state, pack_name=pack_name,
-        )
-
-        if tier is safety.Tier.TIER_2:
-            # Adopter has edited — write companion, leave original untouched.
+    user_state = None
+    if needs_user_state:
+        try:
+            user_root = scope_mod.resolve_user_root()
+        except scope_mod.UserScopeUnresolvable:
+            user_root = None  # surface only if we actually need to write
+        if user_root is not None:
+            user_state_path = user_root / ".agent-ready" / "state.toml"
             try:
-                safety.write_companion(output_root, relpath, content)
-            except safety.PathJailError as exc:
+                user_state = load_state(user_state_path)
+            except ConfigError as exc:
                 print(f"install: {exc}", file=sys.stderr)
                 return 1
-            # Record the bundle's SHA in state; the file itself is adopter-owned.
-            new_pack_state.files[relpath] = {
-                "sha": safety.sha256_bytes(content),
-                "from-pack-version": pack_version,
-            }
         else:
-            # Tier-1 (including absent or not-yet-in-state): write outright.
-            try:
-                safety.write_jailed(output_root, relpath, content)
-            except safety.PathJailError as exc:
-                print(f"install: {exc}", file=sys.stderr)
-                return 1
-            new_pack_state.files[relpath] = {
-                "sha": safety.sha256_bytes(content),
-                "from-pack-version": pack_version,
-            }
+            user_state_path = None
+    else:
+        user_root = None
+        user_state_path = None
 
-    # ── Step 6: Merge state — add/replace this pack's table ───────────────────
-    state.packs[pack_name] = new_pack_state
-    state_toml_content = dump_state(state)
-    try:
-        safety.write_jailed(output_root, ".agent-ready-state.toml", state_toml_content)
-    except safety.PathJailError as exc:
-        print(f"install: {exc}", file=sys.stderr)
+    installed_at_repo = pack_name in repo_state.packs
+    installed_at_user = user_state is not None and pack_name in user_state.packs
+
+    # ── Step 4: Branch on already-installed shape ─────────────────────────────
+    # 4a. Already at requested scope → refuse (use 'upgrade'); --force does
+    #     not bypass this case.
+    if (requested_scope == "repo" and installed_at_repo) or (
+        requested_scope == "user" and installed_at_user
+    ):
+        print(
+            f"install: {pack_name} already installed at {requested_scope}; "
+            "use 'upgrade' to change version",
+            file=sys.stderr,
+        )
         return 1
 
+    # 4b. Already at the *other* scope, no --force → refuse cross-scope.
+    other_scope = "user" if requested_scope == "repo" else "repo"
+    other_already = installed_at_user if requested_scope == "repo" else installed_at_repo
+    if other_already and not force:
+        print(
+            f"install: {pack_name} already installed at {other_scope}; "
+            "pass --force to install at both",
+            file=sys.stderr,
+        )
+        return 1
+
+    # ── Step 5: Build the scope plan(s) ───────────────────────────────────────
+    # Determine which scopes this run will write to. Dual-scope is the
+    # --force-and-pack-already-at-other-scope case; everything else is
+    # single-scope. Pre-flight all of them before any write.
+    scopes_to_install: list[str] = []
+    if force and other_already:
+        # Dual-scope path: repo first, then user (spec § *Output*).
+        scopes_to_install = ["repo", "user"]
+    else:
+        scopes_to_install = [requested_scope]
+
+    # Probe per-adapter scope metadata (for allowed-prefixes at user
+    # scope). The Claude Code adapter is the only one shipping a
+    # [scope] block today; future adapters would map similarly. We
+    # consult the bundled contract.
+    allowed_prefixes_user = _claude_code_allowed_prefixes_user()
+
+    plans: list[_ScopePlan] = []
+    for scope_value in scopes_to_install:
+        if scope_value == "repo":
+            plans.append(
+                _ScopePlan(
+                    scope="repo",
+                    root=output_root,
+                    state_path=repo_state_path,
+                    allowed_prefixes=None,
+                    state=repo_state,
+                    already_installed=installed_at_repo,
+                )
+            )
+        else:
+            # User scope: surface unresolvable $HOME *now* so failures
+            # land in pre-flight, before any write.
+            try:
+                user_root_resolved = scope_mod.resolve_user_root()
+            except scope_mod.UserScopeUnresolvable:
+                print(
+                    "install: cannot resolve user scope: $HOME unset or invalid",
+                    file=sys.stderr,
+                )
+                return 1
+            # Print the resolved root to stderr so the adopter sees
+            # the destination before any side-effect.
+            print(f"install: user scope resolved to {user_root_resolved}", file=sys.stderr)
+            # Re-load user state in for-write mode so a v0.1 file fails
+            # here (after the resolved-root line so adopters see context).
+            try:
+                user_state_for_write = load_state(
+                    user_root_resolved / ".agent-ready" / "state.toml", for_write=True
+                )
+            except ConfigError as exc:
+                print(f"install: {exc}", file=sys.stderr)
+                return 1
+            plans.append(
+                _ScopePlan(
+                    scope="user",
+                    root=user_root_resolved,
+                    state_path=user_root_resolved / ".agent-ready" / "state.toml",
+                    allowed_prefixes=allowed_prefixes_user,
+                    state=user_state_for_write,
+                    already_installed=installed_at_user,
+                )
+            )
+
+    # If the repo plan is going to be written to (not just a recap),
+    # also load the state in for-write mode so v0.1 refusal fires.
+    for plan in plans:
+        if plan.scope == "repo" and not plan.already_installed:
+            try:
+                plan.state = load_state(plan.state_path, for_write=True)
+            except ConfigError as exc:
+                print(f"install: {exc}", file=sys.stderr)
+                return 1
+
+    # ── Step 6: Pre-flight — rails A/B/C for any user-scope write ────────────
+    for plan in plans:
+        if plan.scope == "user":
+            allowed_scopes = _resolved_allowed_scopes(pack_install)
+            rail_refusal = scope_rails.run_all(pack_dir, allowed_scopes)
+            if rail_refusal is not None:
+                print(
+                    f"install: {pack_name}: {rail_refusal}",
+                    file=sys.stderr,
+                )
+                return 1
+
+    # ── Step 7: Render projection — per-scope shape ───────────────────────────
+    # RFC-0004's user-scope install lands a Claude Code overlay (paths
+    # under `.claude/...`), not the dist-tree shape `render_pack`
+    # produces. We render twice when the run spans both scopes: once for
+    # the dist-tree (consumed by repo-scope writes) and once for the
+    # Claude-Code-only projection (consumed by user-scope writes). The
+    # dist-tree render is cached for the lifetime of this run; the
+    # Claude-Code render uses the same adapter the `make build --self`
+    # path uses (the spec §Tier model defines this as the user-scope
+    # projection target).
+    repo_projection: dict[str, bytes] | None = None
+    user_projection: dict[str, bytes] | None = None
+    try:
+        if any(p.scope == "repo" for p in plans):
+            repo_projection = render_pack(pack_dir)
+        if any(p.scope == "user" for p in plans):
+            user_projection = _render_for_user_scope(pack_dir)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"install: render failed for pack {pack_name!r}: {exc}", file=sys.stderr)
+        return 1
+
+    pack_version: str = pack_toml.get("pack", {}).get("version", "0.0.0")
+
+    # ── Step 8: Pre-flight — path-jail probe every projected file ─────────────
+    # The probe is read-only: assert_under + (for user) prefix check.
+    # This catches a pack whose projection rule resolves under
+    # ~/Documents/ before any byte is written.
+    for plan in plans:
+        projection = repo_projection if plan.scope == "repo" else user_projection
+        if projection is None:
+            continue
+        for relpath in projection.keys():
+            target = plan.root / relpath
+            try:
+                safety.assert_under(plan.root, target)
+            except safety.PathJailError as exc:
+                print(f"install: {exc}", file=sys.stderr)
+                return 1
+            if plan.scope == "user":
+                target_relpath = target.resolve().relative_to(plan.root.resolve()).as_posix()
+                prefixes = plan.allowed_prefixes or []
+                # Directory-boundary matching only — see safety.py.
+                if not any(target_relpath.startswith(p) for p in prefixes):
+                    print(
+                        f"install: refusing to write outside allowed prefixes "
+                        f"for scope 'user': {target.resolve()}",
+                        file=sys.stderr,
+                    )
+                    return 1
+
+    # ── Step 9: All pre-flight passed — perform writes ────────────────────────
+    for plan in plans:
+        # Skip the write for the already-installed scope in a dual-scope
+        # --force run: the state file is already correct; we re-emit
+        # the `installed:` line for the recap, but we don't rewrite.
+        if plan.already_installed:
+            continue
+
+        projection = repo_projection if plan.scope == "repo" else user_projection
+        if projection is None:
+            projection = {}
+
+        # Reset the PackState for this scope's install.
+        prior = plan.state.packs.get(pack_name)
+        new_pack_state = PackState(
+            installed_version=pack_version,
+            source="agent-ready-repo",
+            install_route="cli",
+            scope=plan.scope,
+            primitives=_collect_primitives(pack_dir),
+            files={},
+            primitive_versions=dict(prior.primitive_versions) if prior else {},
+        )
+
+        for relpath, content in sorted(projection.items()):
+            tier = _classify_for_install(
+                relpath, plan.root, content, plan.state, pack_name=pack_name,
+            )
+            if tier is safety.Tier.TIER_2:
+                try:
+                    safety.write_companion(plan.root, relpath, content)
+                except safety.PathJailError as exc:
+                    print(f"install: {exc}", file=sys.stderr)
+                    return 1
+            else:
+                try:
+                    safety.write_jailed(
+                        plan.root,
+                        relpath,
+                        content,
+                        scope=plan.scope,
+                        allowed_prefixes=plan.allowed_prefixes,
+                    )
+                except safety.PathJailError as exc:
+                    print(f"install: {exc}", file=sys.stderr)
+                    return 1
+            new_pack_state.files[relpath] = {
+                "sha": safety.sha256_bytes(content),
+                "from-pack-version": pack_version,
+            }
+
+        plan.state.packs[pack_name] = new_pack_state
+        # State-file v0.2 is the post-write schema. The state object is
+        # already at v0.2 (load_state sets the default for fresh State,
+        # or migration-time semantics for read-only-as-repo).
+        plan.state.schema_version = "0.2"
+        serialised = dump_state(plan.state)
+        try:
+            safety.write_jailed(
+                plan.root,
+                str(plan.state_path.relative_to(plan.root)),
+                serialised,
+                scope=plan.scope,
+                allowed_prefixes=plan.allowed_prefixes,
+            )
+        except safety.PathJailError as exc:
+            print(f"install: {exc}", file=sys.stderr)
+            return 1
+
+    # ── Step 10: recommends cross-scope warnings (stderr) ─────────────────────
+    # Emitted per scope per recommend per spec § *recommends across
+    # scopes*. The warning text distinguishes three cases (compatible-
+    # present / missing-installable / scope-disjoint). Output goes to
+    # stderr so the `installed:` rail on stdout stays parseable.
+    recommends = pack_toml.get("pack", {}).get("recommends", [])
+    if isinstance(recommends, list):
+        for plan in plans:
+            # The recommending scope is each plan's scope; a dual-scope
+            # --force install emits one warning per scope per recommend.
+            for rec in recommends:
+                if not isinstance(rec, str):
+                    continue
+                _emit_recommends_warning(
+                    rec,
+                    recommending_scope=plan.scope,
+                    catalogue_dir=catalogue_dir,
+                    repo_state=repo_state,
+                    user_state=user_state,
+                )
+
+    # ── Step 11: Emit installed: lines (repo first, user last) ────────────────
+    for plan in plans:
+        print(f"installed: {pack_name} @ {plan.scope}")
+
     return 0
+
+
+def _emit_recommends_warning(
+    rec_name: str,
+    *,
+    recommending_scope: str,
+    catalogue_dir: Path,
+    repo_state,
+    user_state,
+) -> None:
+    """Print the spec-shaped warning for a single `recommends` entry.
+
+    Three cases the spec text distinguishes (all to stderr):
+      * Found at a compatible scope → `(found at <observed-scope> scope)`.
+      * Not installed anywhere, installable at recommending scope →
+        `(not installed)`.
+      * Disjoint scopes (recommending scope ∉ recommended's allowed-scopes)
+        → ``which is <only>-only; install it in your active project`` /
+        ``which is <only>-only; install it at user scope``.
+
+    The dual-scope case (recommended permits both scopes) reduces to one
+    of the first two — disjoint can only fire when the recommended
+    pack's ``allowed-scopes`` is single-valued.
+    """
+    import re
+    import tomllib
+
+    # Pack names follow the catalogue's `^[a-z0-9][a-z0-9-]*$` shape
+    # (CONVENTIONS.md). The contents of `recommends` are not currently
+    # schema-validated, so a malicious pack could declare
+    # ``recommends = ["../../../etc/passwd"]`` and probe the adopter's
+    # filesystem via the lookup below. Refuse anything outside the
+    # name-shape to keep the catalogue path-jail honest.
+    if not re.fullmatch(r"[a-z0-9][a-z0-9-]*", rec_name):
+        print(
+            f"install: warning: ignoring malformed recommends entry "
+            f"{rec_name!r} (not a legal pack name)",
+            file=sys.stderr,
+        )
+        return
+
+    rec_repo_installed = rec_name in repo_state.packs if repo_state else False
+    rec_user_installed = rec_name in user_state.packs if user_state else False
+
+    # Look up the recommended pack's allowed-scopes from the catalogue.
+    # We only need this for the disjoint branch; cache the lookup result.
+    rec_pack_toml = catalogue_dir / "packs" / rec_name / "pack.toml"
+    if not rec_pack_toml.exists():
+        rec_pack_toml = catalogue_dir / rec_name / "pack.toml"
+    rec_allowed: list[str] = ["repo"]  # legacy default
+    if rec_pack_toml.exists():
+        try:
+            rec_data = tomllib.loads(rec_pack_toml.read_text(encoding="utf-8"))
+        except Exception:
+            rec_data = {}
+        rec_install = rec_data.get("pack", {}).get("install")
+        if isinstance(rec_install, dict):
+            raw = rec_install.get("allowed-scopes")
+            if isinstance(raw, list) and raw:
+                rec_allowed = [s for s in raw if isinstance(s, str)]
+            else:
+                default = rec_install.get("default-scope")
+                if isinstance(default, str):
+                    rec_allowed = [default]
+
+    # Case 1: installed at any compatible scope.
+    if rec_repo_installed and "repo" in rec_allowed:
+        print(
+            f"note: recommends {rec_name!r} (found at repo scope)",
+            file=sys.stderr,
+        )
+        return
+    if rec_user_installed and "user" in rec_allowed:
+        print(
+            f"note: recommends {rec_name!r} (found at user scope)",
+            file=sys.stderr,
+        )
+        return
+
+    # Case 3: disjoint allowed-scopes. Reachable only when the
+    # recommended pack's allowed-scopes is single-valued and excludes
+    # the recommending scope (a pack permitting both scopes can never
+    # be disjoint from any recommender).
+    if recommending_scope not in rec_allowed:
+        if rec_allowed == ["repo"]:
+            print(
+                f"note: recommends {rec_name!r}, which is repo-only; "
+                "install it in your active project",
+                file=sys.stderr,
+            )
+            return
+        if rec_allowed == ["user"]:
+            print(
+                f"note: recommends {rec_name!r}, which is user-only; "
+                "install it at user scope",
+                file=sys.stderr,
+            )
+            return
+
+    # Case 2: missing but installable at the recommending scope.
+    print(
+        f"note: recommends {rec_name!r} (not installed)",
+        file=sys.stderr,
+    )
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _render_for_user_scope(pack_dir: Path) -> dict[str, bytes]:
+    """Project a pack via the Claude Code adapter directly, for user-scope install.
+
+    RFC-0004 § *State file per scope* and § *Adapter-level scope roots*
+    imply that user-scope installs land *Claude Code adapter* outputs
+    (paths under ``.claude/...``) rather than the dist-tree shape
+    ``render.render_pack`` produces. Calling the adapter's ``project``
+    function once into a tempdir gives us the per-primitive layout
+    Claude Code reads at ``~/.claude/``; we collect the result as a
+    relpath→bytes mapping for the install walker.
+
+    Other adapters' projections (apm.yml, plugin manifests, etc.) are
+    intentionally out of scope at user-scope install — they're
+    dist-time build artifacts that the adopter's `~` should never
+    carry.
+    """
+    import tempfile
+    import tomllib
+
+    from agentbundle.build.adapters import claude_code
+    from agentbundle.build.main import _read_bundled
+    from agentbundle.render import _collect_tree
+
+    contract = tomllib.loads(_read_bundled("adapter.toml"))
+    with tempfile.TemporaryDirectory() as raw:
+        out = Path(raw)
+        claude_code.project(pack_dir, contract, out)
+        return _collect_tree(out)
+
+
+def _resolved_allowed_scopes(pack_install: dict | None) -> list[str]:
+    """Mirror the rule the validate command applies for rails A/B/C."""
+    if not isinstance(pack_install, dict):
+        return ["repo"]
+    raw = pack_install.get("allowed-scopes")
+    if isinstance(raw, list) and raw:
+        return [s for s in raw if isinstance(s, str)]
+    default = pack_install.get("default-scope")
+    if isinstance(default, str):
+        return [default]
+    return ["repo"]
+
+
+@functools.cache
+def _claude_code_allowed_prefixes_user() -> list[str]:
+    """Read the Claude Code adapter's `allowed-prefixes.user` from the
+    bundled contract. The function lives here (not in scope.py) so
+    callers depending on `agentbundle.scope` don't pay the cost of
+    parsing the contract for the common repo-scope path. Cached so the
+    five callers (install, uninstall, upgrade, init-state --migrate,
+    adapt) parse the contract at most once per CLI invocation.
+    """
+    import tomllib
+    from agentbundle.build.main import _read_bundled
+
+    contract = tomllib.loads(_read_bundled("adapter.toml"))
+    try:
+        return list(
+            contract["adapter"]["claude-code"]["scope"]["allowed-prefixes"]["user"]
+        )
+    except KeyError:
+        # Defensive: legacy contract without scope table. Fall back to
+        # the conservative single-prefix list — the path-jail probe
+        # will still refuse anything outside `.claude/`.
+        return [".claude/"]
 
 
 def _classify_for_install(
@@ -205,20 +637,13 @@ def _classify_for_install(
     on_disk_sha = _safety.sha256_file(on_disk)
     incoming_sha = _safety.sha256_bytes(incoming_content)
 
-    # If the on-disk file is already the bundle's content → Tier-1 (idempotent).
     if on_disk_sha == incoming_sha:
         return _safety.Tier.TIER_1
 
-    # Check if it matches a recorded SHA in *any* pack (i.e. it's a prior
-    # Tier-1 install that was not edited by the adopter). If the match
-    # comes from a different pack than the one being installed, warn —
-    # silent overwrite of another pack's content would hide a real
-    # projection conflict.
     for other_pack_name, ps in state.packs.items():
         recorded = ps.file_sha(relpath)
         if recorded and on_disk_sha == recorded:
             if pack_name and other_pack_name and other_pack_name != pack_name:
-                import sys
                 print(
                     f"install: warning: {relpath!r} is also recorded under "
                     f"pack {other_pack_name!r}; the two packs project the same path",
@@ -226,20 +651,11 @@ def _classify_for_install(
                 )
             return _safety.Tier.TIER_1
 
-    # On disk, different from the bundle, and no matching prior-install SHA —
-    # the adopter has edited it.
     return _safety.Tier.TIER_2
 
 
 def _locate_pack(catalogue_dir: Path, pack_name: str) -> Path | None:
-    """Find the pack directory inside the resolved catalogue.
-
-    Tries two layouts:
-      1. ``<catalogue_dir>/packs/<pack_name>/`` — standard catalogue layout.
-      2. ``<catalogue_dir>/<pack_name>/``         — catalogue is a pack root.
-
-    Returns ``None`` if neither exists.
-    """
+    """Find the pack directory inside the resolved catalogue."""
     candidate_a = catalogue_dir / "packs" / pack_name
     if candidate_a.is_dir() and (candidate_a / "pack.toml").exists():
         return candidate_a

--- a/packages/agentbundle/agentbundle/commands/uninstall.py
+++ b/packages/agentbundle/agentbundle/commands/uninstall.py
@@ -39,12 +39,72 @@ def run(args: "argparse.Namespace") -> int:
     from agentbundle import safety
 
     pack_name: str = args.pack
+    cli_scope: str | None = getattr(args, "scope", None)
     root = Path(args.root).resolve()
     state_path = root / ".agent-ready-state.toml"
 
-    # ── Step 1: Load state; verify pack is installed ──────────────────────────
+    # ── Step 1: Multi-scope disambiguator (RFC-0004) ──────────────────────────
+    # If the pack is at both repo and user scopes, --scope is required.
+    # If it's at exactly one scope, infer. The check needs *read* access
+    # to both state files (read-only — v0.1 refusal fires at the *write*
+    # below). Importing scope_mod lazily so --version stays fast.
+    from agentbundle import scope as scope_mod
+
+    repo_state_for_check = load_state(state_path)
+    installed_at_repo = pack_name in repo_state_for_check.packs
+    user_state_path = None
+    installed_at_user = False
     try:
-        state = load_state(state_path)
+        user_root = scope_mod.resolve_user_root()
+        user_state_path = user_root / ".agent-ready" / "state.toml"
+        user_state_for_check = load_state(user_state_path)
+        installed_at_user = pack_name in user_state_for_check.packs
+    except scope_mod.UserScopeUnresolvable:
+        # No accessible user root — treat user scope as empty for the
+        # disambiguator. The repo write below is unaffected.
+        pass
+
+    if installed_at_repo and installed_at_user and cli_scope is None:
+        print(
+            f"uninstall: {pack_name} installed at multiple scopes; "
+            "pass --scope {repo, user}",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Resolve the effective scope: explicit CLI flag, else the inferred
+    # single-scope value, else repo (the historical default).
+    if cli_scope is not None:
+        effective_scope = cli_scope
+    elif installed_at_user and not installed_at_repo:
+        effective_scope = "user"
+    else:
+        effective_scope = "repo"
+
+    # Route to the correct state file based on effective scope.
+    # At user scope, `root` is the user's home (where projected files
+    # live) and the state file lives at `<root>/.agent-ready/state.toml`.
+    # Keep the two values separate so the path-jailed write picks the
+    # right *relpath relative to root*, not a bare dotfile in $HOME.
+    user_prefixes: list[str] | None = None
+    if effective_scope == "user":
+        if user_state_path is None:
+            print(
+                "uninstall: cannot resolve user scope: $HOME unset or invalid",
+                file=sys.stderr,
+            )
+            return 1
+        state_path = user_state_path
+        root = user_state_path.parent.parent  # = ~ (the user-scope projection root)
+        # Pull the adapter contract's allowed-prefixes so the user-scope
+        # path-jail fires on the state-file write below.
+        from agentbundle.commands.install import _claude_code_allowed_prefixes_user
+
+        user_prefixes = _claude_code_allowed_prefixes_user()
+
+    # ── Step 1b: Load state for write (refuse v0.1 here, after disambig) ─────
+    try:
+        state = load_state(state_path, for_write=True)
     except ConfigError as exc:
         print(f"uninstall: {exc}", file=sys.stderr)
         return 1
@@ -56,11 +116,37 @@ def run(args: "argparse.Namespace") -> int:
     pack_state = state.packs[pack_name]
 
     # ── Step 2: Walk the pack's recorded files ────────────────────────────────
+    # State-file relpaths are *untrusted input* — a malicious state file
+    # could record `relpath = "../.ssh/authorized_keys"` and the
+    # `os.remove` below would happily delete a path outside the jail.
+    # At user scope that blast radius reaches the user's whole home
+    # directory; at repo scope it's still wrong even though smaller.
+    # `safety.assert_under` + (at user scope) the prefix-list check
+    # refuses any entry that escapes the per-scope jail before any
+    # filesystem operation runs.
     removed: list[str] = []
     kept: list[str] = []
 
     for relpath, entry in sorted(pack_state.files.items()):
         on_disk = root / relpath
+        try:
+            safety.assert_under(root, on_disk)
+        except safety.PathJailError:
+            print(
+                f"uninstall: warning: state entry {relpath!r} resolves outside "
+                f"jail root; refusing to touch",
+                file=sys.stderr,
+            )
+            continue
+        if effective_scope == "user":
+            target_relpath = on_disk.resolve().relative_to(root.resolve()).as_posix()
+            if not any(target_relpath.startswith(p) for p in (user_prefixes or [])):
+                print(
+                    f"uninstall: warning: state entry {relpath!r} lies outside "
+                    f"allowed-prefixes for scope 'user'; refusing to touch",
+                    file=sys.stderr,
+                )
+                continue
         recorded_sha = entry.get("sha") if isinstance(entry, dict) else None
 
         # If the file is absent on disk, treat as already gone (Tier-2 edge
@@ -97,8 +183,19 @@ def run(args: "argparse.Namespace") -> int:
     # ── Step 4: Remove the pack's table from state and persist ────────────────
     del state.packs[pack_name]
     serialised = dump_state(state)
+    # Write the state file at the right per-scope relpath. At repo scope
+    # the relpath is `.agent-ready-state.toml`; at user scope it's
+    # `.agent-ready/state.toml` (the namespaced dot-directory). Compute
+    # from `state_path.relative_to(root)` so the layout is single-sourced.
+    state_relpath = state_path.relative_to(root).as_posix()
     try:
-        safety.write_jailed(root, ".agent-ready-state.toml", serialised)
+        safety.write_jailed(
+            root,
+            state_relpath,
+            serialised,
+            scope=effective_scope,
+            allowed_prefixes=user_prefixes,
+        )
     except safety.PathJailError as exc:
         print(f"uninstall: {exc}", file=sys.stderr)
         return 1
@@ -119,12 +216,25 @@ def _prune_empty_parents(root: Path, removed_relpaths: list[str]) -> None:
     Works bottom-up: for each removed file, walk its parents upward until
     reaching ``root`` or a non-empty directory. Ignores all errors — this is
     best-effort housekeeping.
+
+    `removed_relpaths` is filtered to jail-clean entries by the caller
+    (see the path-jail check in `run`), so the recursive parent walk
+    here is guaranteed to stay under `root`. We still defensively
+    `assert_under` each candidate before `rmdir` to catch any future
+    regression in the caller — leaving the rmdir unguarded would
+    silently re-introduce the same path-traversal gap.
     """
+    from agentbundle.safety import PathJailError, assert_under
+
     # Collect unique parent directories in deepest-first order.
     dirs_to_check: set[Path] = set()
     for relpath in removed_relpaths:
         parent = (root / relpath).parent
         while parent != root and parent != parent.parent:
+            try:
+                assert_under(root, parent)
+            except PathJailError:
+                break
             dirs_to_check.add(parent)
             parent = parent.parent
 

--- a/packages/agentbundle/agentbundle/commands/upgrade.py
+++ b/packages/agentbundle/agentbundle/commands/upgrade.py
@@ -80,7 +80,51 @@ def run(args: "argparse.Namespace") -> int:
     pack_name: str = args.pack
     catalogue_uri: str = args.catalogue
     to_version: str = args.to_version
+    cli_scope: str | None = getattr(args, "scope", None)
     root = Path(args.root).resolve()
+
+    # ── Multi-scope disambiguator (RFC-0004) ──────────────────────────────────
+    # If the pack is at both scopes, --scope is required; at one scope, infer.
+    from agentbundle import scope as scope_mod
+
+    repo_state_path = root / ".agent-ready-state.toml"
+    repo_state_for_check = load_state(repo_state_path)
+    installed_at_repo = pack_name in repo_state_for_check.packs
+    user_state_path = None
+    installed_at_user = False
+    try:
+        user_root_resolved = scope_mod.resolve_user_root()
+        user_state_path = user_root_resolved / ".agent-ready" / "state.toml"
+        user_state_for_check = load_state(user_state_path)
+        installed_at_user = pack_name in user_state_for_check.packs
+    except scope_mod.UserScopeUnresolvable:
+        pass
+
+    if installed_at_repo and installed_at_user and cli_scope is None:
+        print(
+            f"upgrade: {pack_name} installed at multiple scopes; "
+            "pass --scope {repo, user}",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Effective scope is "user" only when the CLI explicitly asked or
+    # the pack is installed at user only. At user scope, `root` is the
+    # user's home and the state file is `<root>/.agent-ready/state.toml`.
+    effective_scope = "repo"
+    user_prefixes: list[str] | None = None
+    if cli_scope == "user" or (cli_scope is None and installed_at_user and not installed_at_repo):
+        if user_state_path is None:
+            print(
+                "upgrade: cannot resolve user scope: $HOME unset or invalid",
+                file=sys.stderr,
+            )
+            return 1
+        root = user_state_path.parent.parent
+        effective_scope = "user"
+        from agentbundle.commands.install import _claude_code_allowed_prefixes_user
+
+        user_prefixes = _claude_code_allowed_prefixes_user()
 
     # ── Detect per-primitive flag ─────────────────────────────────────────────
     prim_flag: str | None = None
@@ -123,9 +167,15 @@ def run(args: "argparse.Namespace") -> int:
         return gate
 
     # ── Load current state ────────────────────────────────────────────────────
-    state_path = root / ".agent-ready-state.toml"
+    # upgrade is a write — refuse-and-explain on a v0.1 file (RFC-0004).
+    # At user scope, the state file lives at `<root>/.agent-ready/state.toml`,
+    # not the repo-style `<root>/.agent-ready-state.toml`.
+    if effective_scope == "user":
+        state_path = user_state_path  # already resolved above
+    else:
+        state_path = root / ".agent-ready-state.toml"
     try:
-        state = load_state(state_path)
+        state = load_state(state_path, for_write=True)
     except ConfigError as exc:
         print(f"upgrade: {exc}", file=sys.stderr)
         return 1
@@ -149,8 +199,18 @@ def run(args: "argparse.Namespace") -> int:
         )
 
     # ── Render new projection in memory ──────────────────────────────────────
+    # At user scope, render via the Claude Code adapter directly (paths
+    # under `.claude/...`) — the dist-tree shape `render_pack` produces
+    # (`apm/...`, `claude-plugins/...`) would fail the user-scope
+    # `allowed-prefixes` jail and wouldn't match the user-scope-installed
+    # state's `.claude/...` paths. Mirrors `install._render_for_user_scope`.
     try:
-        projection = render_pack(pack_dir)
+        if effective_scope == "user":
+            from agentbundle.commands.install import _render_for_user_scope
+
+            projection = _render_for_user_scope(pack_dir)
+        else:
+            projection = render_pack(pack_dir)
     except (FileNotFoundError, ValueError) as exc:
         print(f"upgrade: render failed for pack {pack_name!r}: {exc}", file=sys.stderr)
         return 1
@@ -198,7 +258,11 @@ def run(args: "argparse.Namespace") -> int:
             }
         else:
             try:
-                safety.write_jailed(root, relpath, content)
+                safety.write_jailed(
+                    root, relpath, content,
+                    scope=effective_scope,
+                    allowed_prefixes=user_prefixes,
+                )
             except safety.PathJailError as exc:
                 print(f"upgrade: {exc}", file=sys.stderr)
                 return 1
@@ -218,8 +282,13 @@ def run(args: "argparse.Namespace") -> int:
         pack_state.installed_version = to_version
 
     state_toml_content = dump_state(state)
+    state_relpath = state_path.relative_to(root).as_posix()
     try:
-        safety.write_jailed(root, ".agent-ready-state.toml", state_toml_content)
+        safety.write_jailed(
+            root, state_relpath, state_toml_content,
+            scope=effective_scope,
+            allowed_prefixes=user_prefixes,
+        )
     except safety.PathJailError as exc:
         print(f"upgrade: {exc}", file=sys.stderr)
         return 1

--- a/packages/agentbundle/agentbundle/commands/validate.py
+++ b/packages/agentbundle/agentbundle/commands/validate.py
@@ -107,6 +107,24 @@ def run(args) -> int:
 
     errors = validate_instance(pack_data, schema)
     if errors:
+        # RFC-0004 § *Install-scope dimension* names a specific stderr
+        # text for the cross-field invariant: `pack <name>: default-scope
+        # '<requested>' not in allowed-scopes <declared-set>`. The
+        # schema's `contains` failure on `$.pack.install.allowed-scopes`
+        # is the structural form of that violation; surface it with the
+        # spec-named text instead of the generic schema message so
+        # adopters get the actionable line.
+        if _is_default_scope_invariant_violation(pack_data, errors[0]):
+            pack_name = pack_data.get("pack", {}).get("name", pack_path.name)
+            install = pack_data.get("pack", {}).get("install", {})
+            requested = install.get("default-scope")
+            allowed = install.get("allowed-scopes", [])
+            print(
+                f"validate: pack {pack_name}: default-scope {requested!r} "
+                f"not in allowed-scopes {allowed}",
+                file=sys.stderr,
+            )
+            return 1
         # One-line stderr: first error only (spec says "one-line reason").
         print(
             f"validate: schema error — {errors[0]}",
@@ -125,6 +143,27 @@ def run(args) -> int:
             )
             return 1
 
+    # ── 4b. User-scope refusal rails (RFC-0004 A/B/C) ─────────────────────
+    # Rails fire only when the pack declares "user" ∈ allowed-scopes. The
+    # rails run *after* schema validation so we know `[pack.install]`'s
+    # shape (when present) is well-formed before we read it. v0.1 packs
+    # have implied `allowed-scopes = ["repo"]`, so the rails are
+    # vacuously satisfied — `_allowed_scopes` returns `["repo"]` for
+    # them.
+    from agentbundle.build.scope_rails import run_all as run_scope_rails
+
+    allowed = _allowed_scopes(pack_data)
+    rail_refusal = run_scope_rails(pack_path, allowed)
+    if rail_refusal is not None:
+        pack_name = (
+            pack_data.get("pack", {}).get("name") or pack_path.name
+        )
+        print(
+            f"validate: {pack_name}: {rail_refusal}",
+            file=sys.stderr,
+        )
+        return 1
+
     # ── 5. Strict / conformance mode ─────────────────────────────────────
     if strict:
         conformance_dir = _conformance_fixtures_dir()
@@ -141,6 +180,70 @@ def run(args) -> int:
             return rc
 
     return 0
+
+
+def _is_default_scope_invariant_violation(pack_data: dict, first_error: str) -> bool:
+    """Return True when the first schema error is the cross-field invariant.
+
+    The schema's `if`/`then` block for `default-scope ∈ allowed-scopes`
+    surfaces as a `contains` failure on `$.pack.install.allowed-scopes`.
+    We also confirm the pack actually has the shape that triggered the
+    error (default-scope declared, allowed-scopes declared, default not
+    in allowed) so we don't mis-attribute an unrelated `contains`
+    failure to this rule.
+    """
+    install = pack_data.get("pack", {}).get("install")
+    if not isinstance(install, dict):
+        return False
+    default = install.get("default-scope")
+    allowed = install.get("allowed-scopes")
+    if not isinstance(default, str) or not isinstance(allowed, list):
+        return False
+    if default in allowed:
+        return False
+    # Match the validator's error path heuristically.
+    return (
+        "pack.install.allowed-scopes" in first_error
+        or "allowed-scopes" in first_error
+    )
+
+
+def _allowed_scopes(pack_data: dict) -> list[str]:
+    """Return the pack's resolved allowed-scopes list.
+
+    Resolution mirrors RFC-0004 § *v0.1 vs v0.2 contract acceptance*:
+
+      - v0.1 packs (declared version "0.1", or no `[pack.adapter-contract]`)
+        get the implied `["repo"]`. Any stray `[pack.install]` table is
+        ignored.
+      - v0.2 packs read `[pack.install].allowed-scopes` when present; when
+        only `default-scope` is declared, the implied default is
+        `[default-scope]`.
+
+    The cross-field `default-scope ∈ allowed-scopes` invariant is owned
+    by the schema; we trust the schema's verdict here and only resolve
+    the list.
+    """
+    pack = pack_data.get("pack", {})
+    if not isinstance(pack, dict):
+        return ["repo"]
+    contract_version = (
+        pack.get("adapter-contract", {}).get("version")
+        if isinstance(pack.get("adapter-contract"), dict)
+        else None
+    )
+    if contract_version != "0.2":
+        return ["repo"]
+    install = pack.get("install", {})
+    if not isinstance(install, dict):
+        return ["repo"]
+    allowed = install.get("allowed-scopes")
+    if isinstance(allowed, list) and allowed:
+        return [s for s in allowed if isinstance(s, str)]
+    default = install.get("default-scope")
+    if isinstance(default, str):
+        return [default]
+    return ["repo"]
 
 
 def _extract_recipes(pack_data: dict) -> list[str]:

--- a/packages/agentbundle/agentbundle/config.py
+++ b/packages/agentbundle/agentbundle/config.py
@@ -25,11 +25,33 @@ from pathlib import Path
 from typing import Any
 
 
-STATE_SCHEMA_VERSION = "0.1"
+STATE_SCHEMA_VERSION = "0.2"
 
 
 class ConfigError(ValueError):
     """Raised when a TOML source fails to load or fails schema invariants."""
+
+
+class StateFileLegacy(ConfigError):
+    """Raised when a write-capable invocation hits a v0.1 state file.
+
+    Migration to v0.2 is destructive (irreversible without backup), so the
+    CLI never silently rewrites — instead, every write-capable handler
+    surfaces this exception as a one-line refuse-and-explain pointing the
+    adopter at `agentbundle init-state --migrate`. Read-only paths
+    catch-and-treat as repo-scope per RFC-0004 § *Backward compatibility*.
+
+    Carries the path on disk so the formatter can name it in the stderr
+    message — adopters with multiple checkouts or scopes need to know
+    which file is the legacy one.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        super().__init__(
+            f"state file at {path} is schema-version 0.1; "
+            f"run 'agentbundle init-state --migrate' first"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -76,6 +98,11 @@ class PackState:
     installed_version: str
     source: str = "agent-ready-repo"
     install_route: str = "cli"
+    # RFC-0004: every v0.2 entry carries an explicit scope. v0.1 state
+    # files are read as all-`"repo"` (the legacy implicit default);
+    # `init-state --migrate` writes the column out so the file is
+    # readable by both v0.1 and v0.2 consumers identically.
+    scope: str = "repo"
     primitives: list[str] = field(default_factory=list)
     files: dict[str, dict[str, str]] = field(default_factory=dict)
     # Per-primitive overrides for mixed-version packs (T12). Optional;
@@ -101,12 +128,25 @@ class State:
         return out
 
 
-def load_state(path: Path) -> State:
+def load_state(path: Path, *, for_write: bool = False) -> State:
     """Load `.agent-ready-state.toml`. Returns empty State if file is absent.
 
     Absent is **not** an error — fresh repos legitimately have no state file
     before the first install / init-state. Callers distinguish "absent" from
     "present but empty" via `path.exists()` if they need to.
+
+    RFC-0004 read-vs-write split:
+      - Read paths (``for_write=False``, default): a v0.1 file is loaded
+        with every ``[pack.<name>]`` entry getting an implicit
+        ``scope = "repo"``; the returned ``State.schema_version`` preserves
+        ``"0.1"`` so the caller can detect legacy state without re-reading
+        the file. No migration is forced at read.
+      - Write paths (``for_write=True``): a v0.1 file raises
+        ``StateFileLegacy(path)``. The CLI's top-level handler formats this
+        as ``state file at <path> is schema-version 0.1; run 'agentbundle
+        init-state --migrate' first``. Migration is destructive — adopters
+        running mixed CLI versions across CI and local must opt into it
+        explicitly via ``init-state --migrate``.
     """
     if not path.exists():
         return State()
@@ -120,6 +160,12 @@ def load_state(path: Path) -> State:
     schema_version = raw.get("schema-version", STATE_SCHEMA_VERSION)
     if not isinstance(schema_version, str):
         raise ConfigError(f"schema-version must be a string, got {type(schema_version)!r}")
+
+    # Refuse-and-explain on writes to a legacy state file. We check this
+    # *before* parsing pack entries so callers can rely on the exception
+    # type alone — no half-parsed State leaks out.
+    if for_write and schema_version == "0.1":
+        raise StateFileLegacy(path)
 
     state = State(schema_version=schema_version)
     pack_table = raw.get("pack", {})
@@ -147,10 +193,19 @@ def load_state(path: Path) -> State:
                     if isinstance(pbody, dict)
                 }
 
+        # RFC-0004 scope column. v0.2 carries it explicitly; v0.1 files
+        # imply repo scope for every pack (read-time compatibility). A
+        # v0.2 file with an unknown scope value falls back to "repo" so
+        # readers never trip on a typo — schema validation catches that
+        # earlier in the write path.
+        raw_scope = body.get("scope") if schema_version != "0.1" else None
+        scope = raw_scope if isinstance(raw_scope, str) and raw_scope in ("repo", "user") else "repo"
+
         ps = PackState(
             installed_version=body.get("installed-version", ""),
             source=body.get("source", "agent-ready-repo"),
             install_route=body.get("install-route", "cli"),
+            scope=scope,
             primitives=list(body.get("primitives", []) or []),
             files={k: dict(v) for k, v in files.items() if isinstance(v, dict)},
             primitive_versions=primitive_versions,
@@ -174,6 +229,13 @@ def dump_state(state: State) -> str:
         lines.append(f'installed-version = "{ps.installed_version}"')
         lines.append(f'source = "{ps.source}"')
         lines.append(f'install-route = "{ps.install_route}"')
+        # RFC-0004: emit `scope` only when the state file's schema is v0.2+.
+        # A v0.1 file round-trips unchanged (no scope column) because the
+        # read-only-as-repo-scope contract works at *read* time; the only
+        # write path through this branch is `init-state --migrate`, which
+        # bumps schema_version before calling dump_state.
+        if state.schema_version != "0.1":
+            lines.append(f'scope = "{ps.scope}"')
         primitives_repr = ", ".join(f'"{p}"' for p in ps.primitives)
         lines.append(f"primitives = [{primitives_repr}]")
         lines.append("")

--- a/packages/agentbundle/agentbundle/safety.py
+++ b/packages/agentbundle/agentbundle/safety.py
@@ -165,7 +165,15 @@ def assert_under(root: Path, target: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def write_jailed(root: Path, relpath: str, content: bytes | str, *, mode: int | None = None) -> Path:
+def write_jailed(
+    root: Path,
+    relpath: str,
+    content: bytes | str,
+    *,
+    mode: int | None = None,
+    scope: str = "repo",
+    allowed_prefixes: list[str] | None = None,
+) -> Path:
     """Write `content` to `root / relpath` atomically; refuse outside-root.
 
     Atomic: writes to a sibling tmpfile then `os.replace`s into place. The
@@ -176,9 +184,62 @@ def write_jailed(root: Path, relpath: str, content: bytes | str, *, mode: int | 
     the resolved target escapes `root`. Caller is responsible for any
     write_atomic backups / Tier-2 companion logic — `write_jailed` is the
     primitive, not the policy.
+
+    RFC-0004 extensions:
+      ``scope`` — when ``"user"``, the resolved path must additionally
+      lie under one of the entries in ``allowed_prefixes`` (each
+      relative to ``root``). The two-layer jail (under `~`, under a
+      declared prefix) stops a buggy projection rule resolving under
+      ``~/Documents/`` from passing the basic `..`-escape check.
+      Passing ``scope="user"`` with ``allowed_prefixes=None`` is a
+      *programming* error — the function raises ``TypeError`` rather
+      than silently degrading to the bare `~`-jail.
+
+      ``allowed_prefixes`` — the spec's declared list (e.g.
+      ``[".claude/", ".agent-ready/"]`` for Claude Code at v0.2). Each
+      entry is expected to end in ``/``; the function compares against
+      the relpath-from-root with a directory-boundary check so
+      ``allowed-prefixes = [".claude/"]`` rejects a write to a top-
+      level file named ``.claudefoo``.
     """
+    if scope == "user" and allowed_prefixes is None:
+        # Programming error in CLI code (not adopter-facing). The rail
+        # must never silently degrade — surfacing forces the caller to
+        # pass the declared prefix list from the adapter's [scope]
+        # block. Documented in the spec.
+        raise TypeError(
+            "allowed_prefixes is required when scope='user'"
+        )
+
     target = root / relpath
     assert_under(root, target)
+
+    if scope == "user":
+        # Check the resolved target is under one of the declared
+        # prefixes relative to root. Use directory-boundary matching:
+        # the prefix's trailing slash is mandatory, so ``.claude/``
+        # admits ``.claude/skills/foo`` but rejects a top-level
+        # ``.claude`` file (which would otherwise let a pack replace
+        # the directory with a file).
+        prefixes = allowed_prefixes or []
+        # Defense-in-depth: the adapter contract schema enforces a
+        # trailing slash on every `allowed-prefixes` entry; assert it
+        # at runtime so a future caller that bypasses the schema
+        # (e.g. constructing the list in code) cannot silently widen
+        # the jail. A `.claude` (no slash) prefix would otherwise
+        # admit `.claudefoo` — exactly the bug the equality-clause
+        # removal was meant to fix.
+        if not all(p.endswith("/") for p in prefixes):
+            raise PathJailError(
+                f"refusing to write at scope 'user': allowed_prefixes "
+                f"must each end with '/'; got {prefixes!r}"
+            )
+        target_relpath = target.resolve().relative_to(root.resolve()).as_posix()
+        if not any(target_relpath.startswith(p) for p in prefixes):
+            raise PathJailError(
+                f"refusing to write outside allowed prefixes for scope 'user': "
+                f"{target.resolve()}"
+            )
     try:
         target.parent.mkdir(parents=True, exist_ok=True)
     except OSError as exc:
@@ -244,3 +305,64 @@ def projected_files_in_state(state: State, pack_name: str) -> Iterable[str]:
     if ps is None:
         return ()
     return tuple(ps.files.keys())
+
+
+# ---------------------------------------------------------------------------
+# User-scope artifact root (RFC-0004)
+# ---------------------------------------------------------------------------
+
+
+def user_state_path(home: Path | None = None) -> Path:
+    """Return the user-scope state file path: `~/.agent-ready/state.toml`.
+
+    Per RFC-0004 § *State file per scope*, user-scope artifacts live inside
+    the namespaced `~/.agent-ready/` dot-directory — not as bare dotfiles
+    in `$HOME`. The dot-directory is the future home for
+    `.adapt-discovery.toml`, `.adapt-pending.md`, and `.upstream.<ext>`
+    companions at user scope; pinning the location here keeps every
+    caller agreeing on the layout.
+
+    Creates the dot-directory with mode `0o700` if it does not exist. The
+    mode mirrors `ssh`'s `~/.ssh/` — user-readable only — because state
+    contains paths the CLI knows are present under the user's home, which
+    is sensitive enough to keep out of other accounts on shared hosts.
+    Existing directories are left alone (no chmod) so adopters who chose
+    a more permissive mode on purpose keep their choice.
+
+    The `home` argument exists for testing — production callers omit it
+    and the helper reads `~` via `pathlib.Path.home()`.
+
+    Race-safety: previously this used ``if not base.exists():`` followed
+    by ``mkdir(exist_ok=False)`` — a TOCTOU window where another
+    process could insert a hostile entry (symlink, regular file)
+    between the check and the create. The current shape is
+    ``mkdir(exist_ok=True)`` plus a symlink / regular-directory probe
+    via ``lstat``; an attacker who pre-creates the path as a symlink
+    or a non-directory file is detected at the probe rather than
+    silently honoured.
+    """
+    import os
+    import stat as _stat
+
+    base = (home if home is not None else Path.home()) / ".agent-ready"
+    try:
+        base.mkdir(parents=True, exist_ok=True, mode=0o700)
+    except OSError as exc:
+        raise OSError(
+            f"cannot create user-scope state directory {base}: {exc}"
+        ) from exc
+    # Refuse a pre-existing entry that is not a regular directory
+    # (e.g. a symlink to an attacker-controlled location, or a stray
+    # file). Existing real directories are honoured even if their mode
+    # is more permissive than 0o700 — the doc-comment promises not to
+    # chmod existing dirs.
+    try:
+        st = os.lstat(base)
+    except OSError as exc:
+        raise OSError(f"cannot stat user-scope state directory {base}: {exc}") from exc
+    if _stat.S_ISLNK(st.st_mode) or not _stat.S_ISDIR(st.st_mode):
+        raise OSError(
+            f"user-scope state directory {base} is not a regular directory; "
+            f"refusing to use it"
+        )
+    return base / "state.toml"

--- a/packages/agentbundle/agentbundle/scope.py
+++ b/packages/agentbundle/agentbundle/scope.py
@@ -1,0 +1,170 @@
+"""Scope resolution + user-scope root expansion (RFC-0004 T17).
+
+Two helpers:
+
+  - :func:`resolve` resolves the install scope per the spec precedence
+    rule **CLI flag > pack default > built-in ``"repo"``**, and refuses
+    when the resolved value is not in the pack's ``allowed-scopes`` with
+    :class:`ScopeRefused`. Used by every write-capable subcommand once
+    the pack manifest is loaded.
+
+  - :func:`resolve_user_root` runs ``pathlib.Path.expanduser("~")`` once
+    and refuses with :class:`UserScopeUnresolvable` when the result is
+    the literal ``"~"`` (expansion failed) or ``"/"`` (corporate sandbox
+    with ``$HOME=/``). The CLI's top-level handler maps the exception
+    to the documented stderr text ``cannot resolve user scope: $HOME
+    unset or invalid``.
+
+The exceptions carry just enough context for the formatter at the call
+site to render the spec's exact stderr without per-call-site
+introspection: ``ScopeRefused`` holds the pack name, the requested
+scope, and the declared set; ``UserScopeUnresolvable`` holds the
+diagnostic value (``"~"`` or ``"/"``).
+
+This module is import-cheap (no I/O at import time) so the CLI's
+``--version`` print path stays fast.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterable
+
+
+# The spec's only legal scope values; ``global`` is deliberately absent
+# (RFC-0004 § Alternatives considered §6). Keep this single-sourced so
+# argparse's `choices=` and the runtime resolver agree.
+LEGAL_SCOPES: frozenset[str] = frozenset({"repo", "user"})
+
+
+class ScopeRefused(Exception):
+    """Raised when the resolved scope is not in the pack's allowed-scopes.
+
+    Attributes carry the three pieces the spec stderr names; the CLI's
+    top-level handler formats them as
+    ``<pack>: scope '<requested>' not in allowed-scopes <declared-set>``.
+    """
+
+    def __init__(
+        self,
+        pack_name: str,
+        requested: str,
+        allowed: Iterable[str],
+    ) -> None:
+        self.pack_name = pack_name
+        self.requested = requested
+        # Preserve the declared order — adopters reading the message
+        # want to see what *they* wrote, not a re-sorted set.
+        self.allowed = list(allowed)
+        super().__init__(
+            f"{pack_name}: scope {requested!r} not in allowed-scopes {self.allowed}"
+        )
+
+
+class UserScopeUnresolvable(Exception):
+    """Raised when ``expanduser('~')`` cannot produce a usable user root.
+
+    The two failure modes the spec names:
+
+      - expansion returned literal ``"~"`` (no home directory at all),
+      - expansion returned ``"/"`` ($HOME=/ — corporate sandbox).
+
+    The CLI's top-level handler formats this as
+    ``cannot resolve user scope: $HOME unset or invalid``.
+    """
+
+
+def resolve(
+    cli_flag: str | None,
+    pack_install: dict | None,
+    builtin_default: str = "repo",
+    *,
+    pack_name: str = "<pack>",
+) -> str:
+    """Resolve the install scope per the spec precedence rule.
+
+    Precedence: **CLI flag > pack ``default-scope`` > built-in ``repo``.**
+    The resolved value must be in the pack's ``allowed-scopes`` (resolved
+    from the install table, with the implied default
+    ``[default-scope]`` when ``allowed-scopes`` is omitted).
+
+    Args:
+        cli_flag: the ``--scope`` argparse value (``None`` if omitted).
+        pack_install: the ``[pack.install]`` table from the pack's TOML
+            (``None`` when the pack is v0.1 — see RFC-0004 § *Install-
+            scope dimension*; treated as ``{}``).
+        builtin_default: the fallback when neither CLI nor pack declares.
+        pack_name: the pack name for refusal text; the caller passes the
+            real name when known so :class:`ScopeRefused` carries the
+            spec-shaped message.
+
+    Returns:
+        The resolved scope (``"repo"`` or ``"user"``).
+
+    Raises:
+        :class:`ScopeRefused` if the resolved value is not in
+        ``allowed-scopes``.
+    """
+    install = pack_install if isinstance(pack_install, dict) else {}
+    pack_default = install.get("default-scope")
+    if not isinstance(pack_default, str) or pack_default not in LEGAL_SCOPES:
+        pack_default = builtin_default
+
+    raw_allowed = install.get("allowed-scopes")
+    if isinstance(raw_allowed, list) and raw_allowed:
+        allowed = [s for s in raw_allowed if isinstance(s, str)]
+    else:
+        # Implied default: `[default-scope]` per RFC-0004 § *Per-pack
+        # default and allowance*. v0.1 packs (no install table) fall
+        # through to `[builtin_default]` which is `"repo"`.
+        allowed = [pack_default]
+
+    requested = cli_flag if isinstance(cli_flag, str) else pack_default
+
+    if requested not in allowed:
+        raise ScopeRefused(pack_name, requested, allowed)
+    return requested
+
+
+def resolve_user_root(home: Path | None = None) -> Path:
+    """Expand the user-scope root once at scope-resolution time.
+
+    Calls ``Path.expanduser("~")`` (or accepts a stub ``home`` for
+    tests) and refuses when the result is the literal ``"~"`` (no
+    home directory) or ``"/"`` ($HOME=/ — corporate sandbox).
+
+    Returns:
+        The resolved absolute :class:`Path` for ``~``.
+
+    Raises:
+        :class:`UserScopeUnresolvable` on either documented failure.
+    """
+    if home is None:
+        try:
+            expanded = Path("~").expanduser()
+        except RuntimeError as exc:
+            # Python 3.13+ raises RuntimeError when expanduser cannot
+            # resolve (no $HOME and no pwd entry); older Pythons would
+            # return the literal "~". Both signals normalise to "user
+            # scope is unresolvable" — wrap.
+            raise UserScopeUnresolvable(
+                "expanduser('~') could not determine the home directory"
+            ) from exc
+    else:
+        expanded = Path(home)
+    if str(expanded) == "~":
+        raise UserScopeUnresolvable("expanduser returned literal '~'")
+    # Normalise before the root-check so a hostile `$HOME=/etc/..` is
+    # caught (it resolves to `/`). We use Path.resolve(strict=False)
+    # so a non-existent home doesn't raise — that's a separate failure
+    # the downstream caller can surface.
+    try:
+        normalised = expanded.resolve(strict=False)
+    except OSError as exc:
+        raise UserScopeUnresolvable(
+            f"could not resolve $HOME path {expanded}: {exc}"
+        ) from exc
+    if str(normalised) == "/":
+        raise UserScopeUnresolvable("expanduser resolved to '/' ($HOME=/)")
+    return normalised

--- a/packages/agentbundle/tests/integration/test_adapt_dual_scope.py
+++ b/packages/agentbundle/tests/integration/test_adapt_dual_scope.py
@@ -1,0 +1,229 @@
+"""T21: adapt walks both state files; writes per-scope pending reports.
+
+Verifies AC #(RFC-0004) for the agent-spec-cli spec § *adapt
+dual-state-file walk*:
+
+  - adapt writes per-scope `.adapt-pending.md` at
+    `<repo>/.adapt-pending.md` (repo) and
+    `~/.agent-ready/.adapt-pending.md` (user, inside the namespaced
+    dot-directory — never as a bare ~/.adapt-pending.md).
+  - adapt --ci exits non-zero when either scope's pending file is
+    non-empty; parametrised across three cases (repo-only, user-only,
+    both).
+  - Findings are recorded at the scope they were observed in.
+  - A fixture missing one state file walks the present one and reports
+    against its scope only.
+  - adapt reads `<repo>/.adapt-discovery.toml` and
+    `~/.agent-ready/.adapt-discovery.toml`. A counter-fixture placing
+    the value at `~/.adapt-discovery.toml` is *not* consulted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+from pathlib import Path
+
+import pytest
+
+from agentbundle.commands import adapt
+from agentbundle.config import PackState, State, dump_state
+
+
+def _write_state(path: Path, files: dict[str, str], scope: str = "repo") -> None:
+    state = State(schema_version="0.2")
+    state.packs["demo"] = PackState(
+        installed_version="0.1.0",
+        scope=scope,
+        files={k: {"sha": v, "from-pack-version": "0.1.0"} for k, v in files.items()},
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(dump_state(state), encoding="utf-8")
+
+
+def _stage_companion(root: Path, relpath: str, content: bytes, companion_content: bytes) -> None:
+    """Create both the original and a `.upstream.<ext>` companion."""
+    from agentbundle.safety import companion_path
+
+    original = root / relpath
+    original.parent.mkdir(parents=True, exist_ok=True)
+    original.write_bytes(content)
+    comp = root / companion_path(Path(relpath))
+    comp.write_bytes(companion_content)
+
+
+# ---------------------------------------------------------------------------
+# Per-scope pending file paths
+# ---------------------------------------------------------------------------
+
+
+def test_adapt_writes_per_scope_pending_reports(tmp_path, monkeypatch):
+    fake_home = tmp_path / "home"
+    user_dir = fake_home / ".agent-ready"
+    user_dir.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    # Repo-scope: state references a Tier-2 path with companion.
+    _write_state(repo_root / ".agent-ready-state.toml", {"AGENTS.md": "00"})
+    _stage_companion(repo_root, "AGENTS.md", b"adopter", b"bundle")
+    # User-scope: state references a path with companion.
+    _write_state(user_dir / "state.toml", {".claude/skills/foo/SKILL.md": "11"})
+    _stage_companion(fake_home, ".claude/skills/foo/SKILL.md", b"adopter", b"bundle")
+
+    args = argparse.Namespace(values_from=None, ci=False, root=str(repo_root))
+    rc = adapt.run(args)
+    assert rc == 0
+
+    repo_report = repo_root / ".adapt-pending.md"
+    user_report = user_dir / ".adapt-pending.md"
+    assert repo_report.exists(), "repo-scope pending report missing"
+    assert user_report.exists(), "user-scope pending report missing"
+
+    # The user-scope finding lives in the user-scope report only —
+    # findings recorded at the scope they were observed in.
+    repo_text = repo_report.read_text()
+    user_text = user_report.read_text()
+    assert "AGENTS.upstream.md" in repo_text
+    assert ".claude/skills/foo/SKILL.upstream.md" in user_text
+    assert "AGENTS.upstream.md" not in user_text
+    assert ".claude/skills/foo/SKILL.upstream.md" not in repo_text
+
+    # The user-scope report is *inside* the dot-directory, not a bare
+    # dotfile in $HOME.
+    assert not (fake_home / ".adapt-pending.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# adapt --ci exits non-zero on either scope's pending companions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "case", ["repo_only", "user_only", "both"]
+)
+def test_adapt_ci_or_across_scopes(tmp_path, monkeypatch, case):
+    fake_home = tmp_path / "home"
+    user_dir = fake_home / ".agent-ready"
+    user_dir.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    if case in ("repo_only", "both"):
+        _write_state(repo_root / ".agent-ready-state.toml", {"AGENTS.md": "00"})
+        _stage_companion(repo_root, "AGENTS.md", b"adopter", b"bundle")
+    else:
+        _write_state(repo_root / ".agent-ready-state.toml", {})
+
+    if case in ("user_only", "both"):
+        _write_state(user_dir / "state.toml", {".claude/x.md": "11"}, scope="user")
+        _stage_companion(fake_home, ".claude/x.md", b"a", b"b")
+    else:
+        _write_state(user_dir / "state.toml", {}, scope="user")
+
+    args = argparse.Namespace(values_from=None, ci=True, root=str(repo_root))
+    rc = adapt.run(args)
+    assert rc != 0, f"case={case}: --ci should refuse"
+
+
+def test_adapt_ci_passes_when_neither_scope_has_companions(tmp_path, monkeypatch):
+    fake_home = tmp_path / "home"
+    (fake_home / ".agent-ready").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _write_state(repo_root / ".agent-ready-state.toml", {})
+    _write_state(fake_home / ".agent-ready" / "state.toml", {}, scope="user")
+
+    args = argparse.Namespace(values_from=None, ci=True, root=str(repo_root))
+    assert adapt.run(args) == 0
+
+
+# ---------------------------------------------------------------------------
+# Missing one state file → walk the present one, no error
+# ---------------------------------------------------------------------------
+
+
+def test_adapt_handles_missing_user_state(tmp_path, monkeypatch):
+    """When the user-scope state file is absent, adapt walks repo only.
+
+    The user-scope dot-directory must exist for the scope to be
+    activated (per `_resolve_scopes`); if absent, only the repo scope
+    is walked. This matches the spec's intent — a repo-only adopter
+    should not have a user-scope report appear out of nowhere.
+    """
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _write_state(repo_root / ".agent-ready-state.toml", {"AGENTS.md": "00"})
+    _stage_companion(repo_root, "AGENTS.md", b"adopter", b"bundle")
+
+    args = argparse.Namespace(values_from=None, ci=False, root=str(repo_root))
+    assert adapt.run(args) == 0
+    assert (repo_root / ".adapt-pending.md").exists()
+    # No user-scope dot-directory means no user-scope report.
+    assert not (fake_home / ".adapt-pending.md").exists()
+    assert not (fake_home / ".agent-ready").exists()
+
+
+# ---------------------------------------------------------------------------
+# adapt reads namespaced .adapt-discovery.toml (not bare dotfile)
+# ---------------------------------------------------------------------------
+
+
+def test_adapt_reads_user_scope_discovery_in_dot_directory(tmp_path, monkeypatch):
+    """Discovery values at `~/.agent-ready/.adapt-discovery.toml` are read.
+
+    A counter-fixture placing the discovery at `~/.adapt-discovery.toml`
+    (bare dotfile) is NOT read — proving the reader picks the
+    namespaced path, not the bare one.
+    """
+    fake_home = tmp_path / "home"
+    user_dir = fake_home / ".agent-ready"
+    user_dir.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    # User-scope state references a file with a marker.
+    target_rel = ".claude/skills/foo/SKILL.md"
+    target = fake_home / target_rel
+    target.parent.mkdir(parents=True)
+    target.write_text("project=<adapt:PROJECT_NAME>", encoding="utf-8")
+    _write_state(user_dir / "state.toml", {target_rel: "00"}, scope="user")
+
+    # Discovery values in the NAMESPACED path (correct).
+    (user_dir / ".adapt-discovery.toml").write_text(
+        '[accepted]\nPROJECT_NAME = "demo"\n', encoding="utf-8"
+    )
+    # Counter-fixture at the BARE path (must be ignored).
+    (fake_home / ".adapt-discovery.toml").write_text(
+        '[accepted]\nPROJECT_NAME = "WRONG"\n', encoding="utf-8"
+    )
+
+    _write_state(repo_root / ".agent-ready-state.toml", {})
+
+    # Use --values-from to enable substitution (default mode skips it
+    # when no --values-from is passed; we want to confirm the discovery
+    # values are consulted alongside).
+    values_file = tmp_path / "values.toml"
+    values_file.write_text('[values]\n# only sets unrelated keys\n', encoding="utf-8")
+
+    args = argparse.Namespace(
+        values_from=str(values_file), ci=False, root=str(repo_root)
+    )
+    rc = adapt.run(args)
+    assert rc == 0
+    # The marker should have been resolved to "demo" (namespaced discovery).
+    assert target.read_text() == "project=demo", (
+        f"expected resolution via namespaced discovery; got {target.read_text()!r}"
+    )

--- a/packages/agentbundle/tests/integration/test_install_cmd.py
+++ b/packages/agentbundle/tests/integration/test_install_cmd.py
@@ -78,37 +78,31 @@ def _make_tarball(root: Path, inner_name: str) -> io.BytesIO:
 # ---------------------------------------------------------------------------
 
 def test_brownfield_tier2_gets_companion_not_overwrite(tmp_path):
-    """A pre-existing adopter-edited AGENTS.md (Tier-2) must not be
-    overwritten; a .upstream.md companion must appear instead."""
-    # Pick a projected relpath that alpha's render produces.
-    # render_pack(alpha) includes: claude-plugins/alpha/.claude/agents/helper.md
-    # We'll use one that comes from the apm subtree for simplicity.
-    # The simplest Tier-2 test uses a path that IS in the projection.
+    """A pre-existing adopter-edited file (Tier-2) must not be
+    overwritten; a .upstream.<ext> companion must appear instead.
+
+    Pre-RFC-0004 this test pre-seeded `.agent-ready-state.toml` with the
+    same pack at an old SHA to force Tier-2 detection. Post-RFC-0004
+    install refuses against a pack already installed at the requested
+    scope (spec § *Dual-scope install conflict*); pre-seeding the same
+    pack would short-circuit before Tier classification. The new shape
+    relies on `_classify_for_install`'s fallback: a file on disk that
+    differs from the incoming bundle *and* has no matching SHA in any
+    pack's state is Tier-2 by construction (first-install collision).
+    """
     from agentbundle.render import render_pack
-    from agentbundle.config import PackState, State, dump_state
     from agentbundle import safety
 
     projection = render_pack(ALPHA_PACK_DIR)
-    # Pick the first projected file as our "Tier-2 collision".
     tier2_relpath = sorted(projection.keys())[0]
     original_content = b"adopter-edited content not from the bundle"
 
-    # Write the file with adopter content.
     target = tmp_path / tier2_relpath
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_bytes(original_content)
 
-    # Pre-seed a state that records this path under a fake prior sha
-    # (different from the adopter content) so classify() sees it as Tier-2.
-    fake_prior_sha = "0" * 64
-    state = State()
-    state.packs["alpha"] = PackState(
-        installed_version="0.0.9",
-        files={tier2_relpath: {"sha": fake_prior_sha, "from-pack-version": "0.0.9"}},
-    )
-    state_path = tmp_path / ".agent-ready-state.toml"
-    state_path.write_text(dump_state(state), encoding="utf-8")
-
+    # No state pre-seed — alpha is a first-time install. The classifier
+    # sees on-disk SHA ≠ bundle SHA and no matching prior pack → Tier-2.
     rc = _run_install("alpha", str(FIXTURE_CATALOGUE), str(tmp_path))
     assert rc == 0, "install should succeed even with Tier-2 collision"
 
@@ -392,34 +386,33 @@ def test_reinstall_preserves_mixed_version_primitives(tmp_path):
     (Concern 8 from adversarial review.)
     """
     import argparse
+    import contextlib
+    import io
     from agentbundle.commands.install import run as install_run
-    from agentbundle.config import PackState, State, dump_state, load_state
 
     cat = str(Path(__file__).parent.parent / "fixtures" / "upgrade" / "catalogue_v1")
 
     # 1. Install once.
     rc = install_run(argparse.Namespace(
-        pack="core", catalogue=cat, output=str(tmp_path),
+        pack="core", catalogue=cat, output=str(tmp_path), scope=None, force=False,
     ))
     assert rc == 0
 
-    # 2. Stamp a mixed-version primitive into the state (simulating a
-    #    prior `upgrade --skill work-loop --to v0.2`).
-    state_path = tmp_path / ".agent-ready-state.toml"
-    state = load_state(state_path)
-    state.packs["core"].primitive_versions["skill"] = {"work-loop": "v0.2"}
-    state_path.write_text(dump_state(state), encoding="utf-8")
-
-    # 3. Re-install. The carry-forward fix must preserve the override.
-    rc = install_run(argparse.Namespace(
-        pack="core", catalogue=cat, output=str(tmp_path),
-    ))
-    assert rc == 0
-
-    after = load_state(state_path)
-    assert after.packs["core"].primitive_versions == {
-        "skill": {"work-loop": "v0.2"}
-    }, "re-install dropped mixed-version overrides"
+    # 2. Post-RFC-0004: re-install is refused with the spec-named message.
+    #    The previous shape of this test (re-install carries forward
+    #    `primitive_versions` from prior state) is incompatible with the
+    #    RFC-0004 contract; primitive-version carry-forward is now
+    #    `upgrade`'s job, not `install`'s.
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        rc = install_run(argparse.Namespace(
+            pack="core", catalogue=cat, output=str(tmp_path),
+            scope=None, force=False,
+        ))
+    assert rc != 0
+    err = buf.getvalue()
+    assert "already installed at repo" in err
+    assert "use 'upgrade' to change version" in err
 
 
 def test_install_warns_on_pack_collision(tmp_path, capsys):

--- a/packages/agentbundle/tests/integration/test_install_dual_scope.py
+++ b/packages/agentbundle/tests/integration/test_install_dual_scope.py
@@ -1,0 +1,410 @@
+"""T19: dual-scope install conflict + --force + `installed: <pack> @ <scope>`.
+
+Verifies AC #(RFC-0004) for the agent-spec-cli spec:
+  - install against a pack already at the requested scope refuses with
+    the in-place message; --force does not bypass it.
+  - install against a pack already at the *other* scope refuses without
+    --force; --force proceeds and writes both state files.
+  - Successful single-scope install emits one `installed:` line.
+  - Successful dual-scope --force install emits two lines, repo first
+    then user, both on stdout.
+  - Pre-flight order: a user-scope failure (path-jail, rail, ~-expansion)
+    writes neither state file and emits zero `installed:` lines.
+  - uninstall/upgrade/diff refuse --scope omitted when at multiple scopes.
+
+User-scope tests stage a temporary $HOME so the run never touches the
+adopter's real home directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import os
+import re
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from agentbundle.commands import install, uninstall, upgrade, diff
+
+
+# Pack catalogues for the various test setups.
+PACK_TOML_REPO_ONLY = """
+[pack]
+name = "demo-repo"
+version = "0.1.0"
+
+[pack.adapter-contract]
+version = "0.2"
+
+[pack.install]
+default-scope = "repo"
+allowed-scopes = ["repo"]
+"""
+
+PACK_TOML_BOTH = """
+[pack]
+name = "demo-both"
+version = "0.1.0"
+
+[pack.adapter-contract]
+version = "0.2"
+
+[pack.install]
+default-scope = "repo"
+allowed-scopes = ["repo", "user"]
+"""
+
+
+def _stage_pack(catalogue_root: Path, pack_name: str, toml_text: str) -> Path:
+    pack = catalogue_root / "packs" / pack_name
+    pack.mkdir(parents=True)
+    (pack / "pack.toml").write_text(toml_text, encoding="utf-8")
+    (pack / ".apm").mkdir()  # empty apm → empty projection
+    return pack
+
+
+def _install(args_dict) -> tuple[int, str, str]:
+    """Run install with redirected stdout/stderr; return (rc, stdout, stderr)."""
+    args = argparse.Namespace(**args_dict)
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        rc = install.run(args)
+    return rc, out.getvalue(), err.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# In-place re-install refusal — --force does NOT bypass
+# ---------------------------------------------------------------------------
+
+
+def test_install_refuses_when_already_at_requested_scope(tmp_path):
+    cat = tmp_path / "cat"
+    _stage_pack(cat, "demo-repo", PACK_TOML_REPO_ONLY)
+    target = tmp_path / "repo"
+    target.mkdir()
+
+    rc1, out1, _ = _install(
+        dict(pack="demo-repo", catalogue=str(cat), output=str(target), scope=None, force=False)
+    )
+    assert rc1 == 0, "first install should succeed"
+    assert "installed: demo-repo @ repo" in out1
+
+    rc2, _, err2 = _install(
+        dict(pack="demo-repo", catalogue=str(cat), output=str(target), scope=None, force=False)
+    )
+    assert rc2 != 0
+    assert "already installed at repo" in err2
+    assert "use 'upgrade' to change version" in err2
+
+
+def test_force_does_not_bypass_in_place_refusal(tmp_path):
+    cat = tmp_path / "cat"
+    _stage_pack(cat, "demo-repo", PACK_TOML_REPO_ONLY)
+    target = tmp_path / "repo"
+    target.mkdir()
+
+    _install(dict(pack="demo-repo", catalogue=str(cat), output=str(target), scope=None, force=False))
+    rc, _, err = _install(
+        dict(pack="demo-repo", catalogue=str(cat), output=str(target), scope=None, force=True)
+    )
+    assert rc != 0
+    assert "already installed at repo" in err
+    assert "use 'upgrade' to change version" in err
+
+
+# ---------------------------------------------------------------------------
+# Cross-scope conflict + --force
+# ---------------------------------------------------------------------------
+
+
+def test_cross_scope_conflict_refused_without_force(tmp_path, monkeypatch):
+    cat = tmp_path / "cat"
+    _stage_pack(cat, "demo-both", PACK_TOML_BOTH)
+    target = tmp_path / "repo"
+    target.mkdir()
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    # Install at repo first.
+    rc1, _, _ = _install(
+        dict(pack="demo-both", catalogue=str(cat), output=str(target), scope="repo", force=False)
+    )
+    assert rc1 == 0
+
+    # Now try installing at user without --force.
+    rc2, _, err2 = _install(
+        dict(pack="demo-both", catalogue=str(cat), output=str(target), scope="user", force=False)
+    )
+    assert rc2 != 0
+    assert "demo-both already installed at repo; pass --force to install at both" in err2
+
+
+def test_cross_scope_force_proceeds_and_writes_both_state_files(tmp_path, monkeypatch):
+    cat = tmp_path / "cat"
+    _stage_pack(cat, "demo-both", PACK_TOML_BOTH)
+    target = tmp_path / "repo"
+    target.mkdir()
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    _install(dict(pack="demo-both", catalogue=str(cat), output=str(target), scope="repo", force=False))
+
+    rc, out, _ = _install(
+        dict(pack="demo-both", catalogue=str(cat), output=str(target), scope="user", force=True)
+    )
+    assert rc == 0
+    # Both state files exist after the run.
+    assert (target / ".agent-ready-state.toml").exists()
+    assert (fake_home / ".agent-ready" / "state.toml").exists()
+    # Two `installed:` lines, repo first then user.
+    lines = [ln for ln in out.splitlines() if ln.startswith("installed:")]
+    assert lines == ["installed: demo-both @ repo", "installed: demo-both @ user"], (
+        f"expected repo-then-user stdout sequence; got {lines!r}"
+    )
+
+
+def test_force_no_op_when_pack_not_already_other_scope(tmp_path, monkeypatch):
+    """--force against a pack not already at the other scope is a no-op flag.
+
+    The install proceeds as a normal first-time install at the requested
+    scope. Adopter wrapper scripts can pass --force idempotently.
+    """
+    cat = tmp_path / "cat"
+    _stage_pack(cat, "demo-both", PACK_TOML_BOTH)
+    target = tmp_path / "repo"
+    target.mkdir()
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    rc, out, _ = _install(
+        dict(pack="demo-both", catalogue=str(cat), output=str(target), scope="repo", force=True)
+    )
+    assert rc == 0
+    lines = [ln for ln in out.splitlines() if ln.startswith("installed:")]
+    assert lines == ["installed: demo-both @ repo"]
+
+
+# ---------------------------------------------------------------------------
+# `installed:` rail — single-scope (stdout)
+# ---------------------------------------------------------------------------
+
+
+def test_single_scope_install_emits_one_installed_line_last(tmp_path):
+    cat = tmp_path / "cat"
+    _stage_pack(cat, "demo-repo", PACK_TOML_REPO_ONLY)
+    target = tmp_path / "repo"
+    target.mkdir()
+
+    rc, out, _ = _install(
+        dict(pack="demo-repo", catalogue=str(cat), output=str(target), scope=None, force=False)
+    )
+    assert rc == 0
+    non_empty = [ln for ln in out.splitlines() if ln.strip()]
+    assert non_empty[-1] == "installed: demo-repo @ repo"
+
+
+# ---------------------------------------------------------------------------
+# Multi-scope verb refusal (uninstall / upgrade / diff)
+# ---------------------------------------------------------------------------
+
+
+def test_uninstall_refuses_when_at_multiple_scopes(tmp_path, monkeypatch):
+    cat = tmp_path / "cat"
+    _stage_pack(cat, "demo-both", PACK_TOML_BOTH)
+    target = tmp_path / "repo"
+    target.mkdir()
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    _install(dict(pack="demo-both", catalogue=str(cat), output=str(target), scope="repo", force=False))
+    _install(dict(pack="demo-both", catalogue=str(cat), output=str(target), scope="user", force=True))
+
+    args = argparse.Namespace(pack="demo-both", root=str(target), scope=None)
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        rc = uninstall.run(args)
+    assert rc != 0
+    assert "demo-both installed at multiple scopes" in buf.getvalue()
+    assert "{repo, user}" in buf.getvalue()
+
+
+def test_upgrade_refuses_when_at_multiple_scopes(tmp_path, monkeypatch):
+    cat = tmp_path / "cat"
+    _stage_pack(cat, "demo-both", PACK_TOML_BOTH)
+    target = tmp_path / "repo"
+    target.mkdir()
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    _install(dict(pack="demo-both", catalogue=str(cat), output=str(target), scope="repo", force=False))
+    _install(dict(pack="demo-both", catalogue=str(cat), output=str(target), scope="user", force=True))
+
+    args = argparse.Namespace(
+        pack="demo-both",
+        catalogue=str(cat),
+        to_version="0.2.0",
+        skill=None,
+        agent=None,
+        hook=None,
+        seed=None,
+        command=None,
+        root=str(target),
+        scope=None,
+    )
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        rc = upgrade.run(args)
+    assert rc != 0
+    assert "demo-both installed at multiple scopes" in buf.getvalue()
+    assert "{repo, user}" in buf.getvalue()
+
+
+def test_uninstall_at_user_scope_writes_dot_directory_state(tmp_path, monkeypatch):
+    """RFC-0004 Blocker fix: uninstall at user scope must write the state
+    file to `~/.agent-ready/state.toml` (the namespaced dot-directory),
+    never a bare `~/.agent-ready-state.toml`. Adversarial-reviewer Blocker
+    pass 2 surfaced this — the test pins the fix.
+    """
+    from agentbundle.commands import uninstall
+
+    cat = tmp_path / "cat"
+    _stage_pack(cat, "demo-both", PACK_TOML_BOTH)
+    target = tmp_path / "repo"
+    target.mkdir()
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    # Install at user scope, then uninstall at user scope.
+    rc, _, _ = _install(
+        dict(pack="demo-both", catalogue=str(cat), output=str(target), scope="user", force=False)
+    )
+    assert rc == 0
+    assert (fake_home / ".agent-ready" / "state.toml").exists()
+
+    args = argparse.Namespace(pack="demo-both", root=str(target), scope="user")
+    out = io.StringIO()
+    err = io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        rc = uninstall.run(args)
+    assert rc == 0, f"uninstall at user scope failed: {err.getvalue()}"
+    # The bare-dotfile path the bug would have produced must NOT exist.
+    assert not (fake_home / ".agent-ready-state.toml").exists(), (
+        "uninstall at user scope wrote to ~/.agent-ready-state.toml (legacy bare dotfile path)"
+    )
+    # The namespaced state file must still exist and have the pack removed.
+    from agentbundle.config import load_state
+
+    state = load_state(fake_home / ".agent-ready" / "state.toml")
+    assert "demo-both" not in state.packs
+
+
+def test_upgrade_at_user_scope_renders_claude_code_shape(tmp_path, monkeypatch):
+    """RFC-0004 Blocker fix: upgrade at user scope must render via the
+    Claude Code adapter directly (paths under `.claude/...`), not the
+    dist-tree shape. The first-pass fix only addressed the state-file
+    path; this test pins the render-shape fix too.
+    """
+    from agentbundle.commands import upgrade
+
+    cat = tmp_path / "cat"
+    _stage_pack(cat, "demo-both", PACK_TOML_BOTH)
+    target = tmp_path / "repo"
+    target.mkdir()
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    # Install at user scope.
+    rc, _, _ = _install(
+        dict(pack="demo-both", catalogue=str(cat), output=str(target), scope="user", force=False)
+    )
+    assert rc == 0
+
+    # Now upgrade at user scope (empty .apm — projection is empty; the
+    # test pins that the render selection doesn't refuse on
+    # `allowed-prefixes` and the state file's `installed-version`
+    # updates).
+    args = argparse.Namespace(
+        pack="demo-both",
+        catalogue=str(cat),
+        to_version="0.2.0",
+        skill=None,
+        agent=None,
+        hook=None,
+        seed=None,
+        command=None,
+        root=str(target),
+        scope="user",
+    )
+    err = io.StringIO()
+    with contextlib.redirect_stderr(err):
+        rc = upgrade.run(args)
+    assert rc == 0, f"upgrade at user scope failed: {err.getvalue()}"
+
+    from agentbundle.config import load_state
+
+    state = load_state(fake_home / ".agent-ready" / "state.toml")
+    assert state.packs["demo-both"].installed_version == "0.2.0"
+
+
+def test_install_v01_pack_stray_install_table_ignored(tmp_path):
+    """RFC-0004 Blocker fix: a v0.1 pack carrying `[pack.install]
+    default-scope = "user"` is treated as legacy repo-only. The schema
+    accepts the stray table; the CLI must ignore it.
+    """
+    cat = tmp_path / "cat"
+    # v0.1 contract version + stray default-scope = "user"
+    v01_stray = """
+[pack]
+name = "legacy-stray"
+version = "0.1.0"
+
+[pack.adapter-contract]
+version = "0.1"
+
+[pack.install]
+default-scope = "user"
+allowed-scopes = ["user"]
+"""
+    _stage_pack(cat, "legacy-stray", v01_stray)
+    target = tmp_path / "repo"
+    target.mkdir()
+
+    rc, out, _ = _install(
+        dict(pack="legacy-stray", catalogue=str(cat), output=str(target), scope=None, force=False)
+    )
+    assert rc == 0, "v0.1 pack install must succeed; stray install table ignored"
+    # The pack must land at repo scope (the legacy implicit default),
+    # not user scope (which the stray table requested).
+    assert "installed: legacy-stray @ repo" in out
+    assert "@ user" not in out
+
+
+def test_diff_refuses_when_at_multiple_scopes(tmp_path, monkeypatch):
+    cat = tmp_path / "cat"
+    pack = _stage_pack(cat, "demo-both", PACK_TOML_BOTH)
+    target = tmp_path / "repo"
+    target.mkdir()
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    _install(dict(pack="demo-both", catalogue=str(cat), output=str(target), scope="repo", force=False))
+    _install(dict(pack="demo-both", catalogue=str(cat), output=str(target), scope="user", force=True))
+
+    args = argparse.Namespace(pack_path=str(pack), root=str(target), scope=None)
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        rc = diff.run(args)
+    assert rc != 0
+    assert "demo-both installed at multiple scopes" in buf.getvalue()

--- a/packages/agentbundle/tests/integration/test_recommends_cross_scope.py
+++ b/packages/agentbundle/tests/integration/test_recommends_cross_scope.py
@@ -1,0 +1,214 @@
+"""T20: `recommends` cross-scope warning text split.
+
+Verifies AC #(RFC-0004) for the agent-spec-cli spec § *recommends
+across scopes*. The five test rows cover:
+
+  - Disjoint, recommended is repo-only (recommender at user scope).
+  - Disjoint, recommended is user-only (recommender at repo scope).
+  - Compatible-scope present (recommended already installed).
+  - Missing entirely (recommended not installed anywhere).
+  - Dual-scope --force install emits one warning per scope per recommend.
+
+All warnings emit on stderr; stdout reserved for the `installed:` rail.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import os
+from pathlib import Path
+
+import pytest
+
+from agentbundle.commands import install
+
+
+PACK_A_REPO_RECS_B = """
+[pack]
+name = "alpha-rec"
+version = "0.1.0"
+recommends = ["beta-rec"]
+
+[pack.adapter-contract]
+version = "0.2"
+
+[pack.install]
+default-scope = "repo"
+allowed-scopes = ["repo"]
+"""
+
+PACK_A_DUAL_RECS_B = """
+[pack]
+name = "alpha-rec"
+version = "0.1.0"
+recommends = ["beta-rec"]
+
+[pack.adapter-contract]
+version = "0.2"
+
+[pack.install]
+default-scope = "repo"
+allowed-scopes = ["repo", "user"]
+"""
+
+PACK_A_USER_RECS_B = """
+[pack]
+name = "alpha-rec"
+version = "0.1.0"
+recommends = ["beta-rec"]
+
+[pack.adapter-contract]
+version = "0.2"
+
+[pack.install]
+default-scope = "user"
+allowed-scopes = ["user"]
+"""
+
+PACK_B_REPO_ONLY = """
+[pack]
+name = "beta-rec"
+version = "0.1.0"
+
+[pack.adapter-contract]
+version = "0.2"
+
+[pack.install]
+default-scope = "repo"
+allowed-scopes = ["repo"]
+"""
+
+PACK_B_USER_ONLY = """
+[pack]
+name = "beta-rec"
+version = "0.1.0"
+
+[pack.adapter-contract]
+version = "0.2"
+
+[pack.install]
+default-scope = "user"
+allowed-scopes = ["user"]
+"""
+
+
+def _stage_pack(catalogue_root: Path, name: str, toml: str) -> Path:
+    pack = catalogue_root / "packs" / name
+    pack.mkdir(parents=True)
+    (pack / "pack.toml").write_text(toml, encoding="utf-8")
+    (pack / ".apm").mkdir()
+    return pack
+
+
+def _run(args_dict) -> tuple[int, str, str]:
+    args = argparse.Namespace(**args_dict)
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        rc = install.run(args)
+    return rc, out.getvalue(), err.getvalue()
+
+
+def test_disjoint_recommended_is_repo_only(tmp_path, monkeypatch):
+    """Recommender at user scope, recommended is repo-only → disjoint warning."""
+    cat = tmp_path / "cat"
+    _stage_pack(cat, "alpha-rec", PACK_A_USER_RECS_B)
+    _stage_pack(cat, "beta-rec", PACK_B_REPO_ONLY)
+    target = tmp_path / "repo"
+    target.mkdir()
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    rc, _out, err = _run(
+        dict(pack="alpha-rec", catalogue=str(cat), output=str(target), scope="user", force=False)
+    )
+    assert rc == 0
+    assert (
+        "note: recommends 'beta-rec', which is repo-only; install it in your active project"
+        in err
+    )
+
+
+def test_disjoint_recommended_is_user_only(tmp_path, monkeypatch):
+    """Recommender at repo scope, recommended is user-only → mirror warning."""
+    cat = tmp_path / "cat"
+    _stage_pack(cat, "alpha-rec", PACK_A_REPO_RECS_B)
+    _stage_pack(cat, "beta-rec", PACK_B_USER_ONLY)
+    target = tmp_path / "repo"
+    target.mkdir()
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    rc, _out, err = _run(
+        dict(pack="alpha-rec", catalogue=str(cat), output=str(target), scope="repo", force=False)
+    )
+    assert rc == 0
+    assert (
+        "note: recommends 'beta-rec', which is user-only; install it at user scope"
+        in err
+    )
+
+
+def test_compatible_present_at_recommended_scope(tmp_path):
+    """When the recommended pack is installed at any compatible scope,
+    the warning names the observed scope."""
+    cat = tmp_path / "cat"
+    _stage_pack(cat, "alpha-rec", PACK_A_REPO_RECS_B)
+    _stage_pack(cat, "beta-rec", PACK_B_REPO_ONLY)
+    target = tmp_path / "repo"
+    target.mkdir()
+
+    # Install B first.
+    _run(dict(pack="beta-rec", catalogue=str(cat), output=str(target), scope=None, force=False))
+    # Now install A — should see B at repo.
+    rc, _out, err = _run(
+        dict(pack="alpha-rec", catalogue=str(cat), output=str(target), scope=None, force=False)
+    )
+    assert rc == 0
+    assert "note: recommends 'beta-rec' (found at repo scope)" in err
+
+
+def test_missing_entirely(tmp_path):
+    """When the recommended pack is not installed, warning is `(not installed)`."""
+    cat = tmp_path / "cat"
+    _stage_pack(cat, "alpha-rec", PACK_A_REPO_RECS_B)
+    _stage_pack(cat, "beta-rec", PACK_B_REPO_ONLY)
+    target = tmp_path / "repo"
+    target.mkdir()
+
+    rc, _out, err = _run(
+        dict(pack="alpha-rec", catalogue=str(cat), output=str(target), scope=None, force=False)
+    )
+    assert rc == 0
+    assert "note: recommends 'beta-rec' (not installed)" in err
+
+
+def test_dual_scope_force_emits_one_warning_per_scope(tmp_path, monkeypatch):
+    """A `--force` dual-scope install emits one warning per scope per recommend."""
+    cat = tmp_path / "cat"
+    _stage_pack(cat, "alpha-rec", PACK_A_DUAL_RECS_B)
+    _stage_pack(cat, "beta-rec", PACK_B_REPO_ONLY)
+    target = tmp_path / "repo"
+    target.mkdir()
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    # Install A at repo first.
+    _run(dict(pack="alpha-rec", catalogue=str(cat), output=str(target), scope="repo", force=False))
+    # Now install A at user with --force — emits warnings for both scopes.
+    rc, _out, err = _run(
+        dict(pack="alpha-rec", catalogue=str(cat), output=str(target), scope="user", force=True)
+    )
+    assert rc == 0
+    # Two stderr lines per recommend per scope. The repo-line warning
+    # is `(not installed)`; the user-scope plan emits the disjoint
+    # warning because B is repo-only.
+    assert "note: recommends 'beta-rec' (not installed)" in err
+    assert (
+        "note: recommends 'beta-rec', which is repo-only; install it in your active project"
+        in err
+    )

--- a/packages/agentbundle/tests/unit/test_cli_scope_flags.py
+++ b/packages/agentbundle/tests/unit/test_cli_scope_flags.py
@@ -1,0 +1,145 @@
+"""T16: argparse surface gains --scope on six subcommands + --force on install.
+
+Verifies AC #(RFC-0004) for the agent-spec-cli spec:
+  - --scope {repo,user} is accepted on install, uninstall, upgrade, diff,
+    init-state, and list-targets.
+  - Passing --scope to any forbidden subcommand (list-packs, scaffold,
+    validate, render, adapt) exits non-zero with the documented stderr
+    `unknown flag for <verb>: --scope`. Parametrised across both
+    space-separated (`--scope user`) and value-glued (`--scope=user`)
+    forms.
+  - --force is accepted only on install; any other verb refuses with
+    `unknown flag for <verb>: --force`.
+  - --scope <bogus> is rejected with argparse's invalid-choice error.
+
+The custom ArgumentParser subclass `_VerbAwareParser` in cli.py rewrites
+the "unrecognized arguments" message — the test pins the exact stderr
+text byte-for-byte for both flag forms.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import pytest
+
+from agentbundle import cli
+
+
+# A minimal set of "valid trailing args" per subcommand so the parse
+# reaches the --scope token rather than failing earlier on a missing
+# positional. Each entry is the argv list (already-split). The
+# subcommand under test is appended at the call site.
+_BASE_ARGS = {
+    "install": ["--pack", "core", "/fake/catalogue"],
+    "uninstall": ["--pack", "core"],
+    "upgrade": ["--pack", "core", "--to", "0.2.0", "/fake/catalogue"],
+    "diff": ["packs/core"],
+    "init-state": ["--pack", "core"],
+    "list-targets": [],
+    "list-packs": ["/fake/catalogue"],
+    "scaffold": ["--output", "/tmp/out"],
+    "validate": ["packs/core"],
+    "render": ["packs/core", "--output", "/tmp/out"],
+    "adapt": [],
+}
+
+
+def _parse(argv: list[str]) -> tuple[int | None, str]:
+    """Parse with cli._build_parser; return (exit_code_or_none, stderr_text)."""
+    parser = cli._build_parser()
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        try:
+            parser.parse_args(argv)
+        except SystemExit as exc:
+            return exc.code, buf.getvalue()
+    return None, buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# --scope is accepted on the six subcommands
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "subcommand",
+    ["install", "uninstall", "upgrade", "diff", "init-state", "list-targets"],
+)
+@pytest.mark.parametrize("flag_form", ["space", "glued"])
+def test_scope_accepted(subcommand, flag_form):
+    args = [subcommand] + _BASE_ARGS[subcommand]
+    if flag_form == "space":
+        args += ["--scope", "user"]
+    else:
+        args += ["--scope=user"]
+    rc, err = _parse(args)
+    assert rc is None, (
+        f"--scope rejected on {subcommand!r} ({flag_form}): exit={rc}, "
+        f"stderr={err!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# --scope is rejected on the five forbidden subcommands with exact stderr
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "subcommand", ["list-packs", "scaffold", "validate", "render", "adapt"]
+)
+@pytest.mark.parametrize("flag_form", ["space", "glued"])
+def test_scope_rejected_with_documented_stderr(subcommand, flag_form):
+    args = [subcommand] + _BASE_ARGS[subcommand]
+    if flag_form == "space":
+        args += ["--scope", "user"]
+    else:
+        args += ["--scope=user"]
+    rc, err = _parse(args)
+    assert rc != 0, f"{subcommand} {flag_form}: parse succeeded but should refuse"
+    # Exact byte-for-byte match on the documented contract.
+    assert f"unknown flag for {subcommand}: --scope\n" == err, (
+        f"{subcommand} {flag_form}: stderr mismatch.\nGot: {err!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# --force is rejected on every verb other than install with exact stderr
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "subcommand",
+    [
+        "list-packs", "list-targets", "scaffold", "validate", "render",
+        "adapt", "diff", "upgrade", "uninstall", "init-state",
+    ],
+)
+def test_force_rejected_on_non_install(subcommand):
+    args = [subcommand] + _BASE_ARGS[subcommand] + ["--force"]
+    rc, err = _parse(args)
+    assert rc != 0, f"{subcommand}: --force was accepted but only install permits it"
+    assert f"unknown flag for {subcommand}: --force\n" == err, (
+        f"{subcommand}: stderr mismatch.\nGot: {err!r}"
+    )
+
+
+def test_force_accepted_on_install():
+    args = ["install"] + _BASE_ARGS["install"] + ["--force"]
+    rc, err = _parse(args)
+    assert rc is None, f"--force rejected on install: rc={rc} stderr={err!r}"
+
+
+# ---------------------------------------------------------------------------
+# --scope value validation
+# ---------------------------------------------------------------------------
+
+
+def test_scope_bogus_value_rejected():
+    """argparse's `choices=...` rejects values outside {repo, user}."""
+    args = ["install"] + _BASE_ARGS["install"] + ["--scope", "global"]
+    rc, err = _parse(args)
+    assert rc != 0
+    # Default argparse text — not rewritten because the flag is recognised.
+    assert "invalid choice" in err
+    assert "repo" in err and "user" in err

--- a/packages/agentbundle/tests/unit/test_scope.py
+++ b/packages/agentbundle/tests/unit/test_scope.py
@@ -1,0 +1,186 @@
+"""T17: scope-resolution helper + allowed-scopes refusal + ~-expansion.
+
+Verifies AC #(RFC-0004): scope resolution precedence, the refusal text
+shape on `allowed-scopes` violation, and `~`-expansion's two failure
+modes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentbundle import scope
+
+
+# ---------------------------------------------------------------------------
+# resolve() — precedence (CLI > pack > builtin)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_uses_builtin_when_pack_omits_default():
+    """v0.1 pack: pack_install is None; builtin 'repo' wins."""
+    assert scope.resolve(None, None) == "repo"
+
+
+def test_resolve_uses_pack_default_when_no_cli_flag():
+    install = {"default-scope": "user", "allowed-scopes": ["user"]}
+    assert scope.resolve(None, install) == "user"
+
+
+def test_resolve_cli_flag_overrides_pack_default():
+    install = {"default-scope": "user", "allowed-scopes": ["repo", "user"]}
+    assert scope.resolve("repo", install) == "repo"
+
+
+def test_resolve_implied_allowed_scopes_from_default():
+    """When allowed-scopes is omitted, the implied default is [default-scope]."""
+    install = {"default-scope": "user"}  # no allowed-scopes
+    # Implied allowed: ["user"]; CLI flag "user" passes; "repo" refused.
+    assert scope.resolve("user", install) == "user"
+    with pytest.raises(scope.ScopeRefused):
+        scope.resolve("repo", install)
+
+
+# ---------------------------------------------------------------------------
+# resolve() — refusal shape
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_refuses_with_pack_name_requested_and_allowed():
+    install = {"default-scope": "repo", "allowed-scopes": ["repo"]}
+    with pytest.raises(scope.ScopeRefused) as ei:
+        scope.resolve("user", install, pack_name="demo")
+    assert ei.value.pack_name == "demo"
+    assert ei.value.requested == "user"
+    assert ei.value.allowed == ["repo"]
+    # The exception's string carries the three pieces the spec stderr names.
+    msg = str(ei.value)
+    assert "demo" in msg
+    assert "'user'" in msg
+    assert "repo" in msg
+
+
+def test_resolve_v01_pack_only_accepts_repo():
+    """A v0.1 pack (pack_install=None) treats allowed-scopes as ['repo']."""
+    assert scope.resolve("repo", None) == "repo"
+    with pytest.raises(scope.ScopeRefused) as ei:
+        scope.resolve("user", None, pack_name="legacy")
+    assert ei.value.allowed == ["repo"]
+
+
+# ---------------------------------------------------------------------------
+# resolve_user_root() — ~-expansion failure modes
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_user_root_returns_path_when_home_set(tmp_path):
+    """The happy path: home is set, returns the Path."""
+    result = scope.resolve_user_root(home=tmp_path)
+    assert result == tmp_path
+
+
+def test_resolve_user_root_refuses_root_slash():
+    """`$HOME=/`: corporate sandbox path resolves to root — refused."""
+    from pathlib import Path
+
+    with pytest.raises(scope.UserScopeUnresolvable):
+        scope.resolve_user_root(home=Path("/"))
+
+
+def test_resolve_user_root_refuses_literal_tilde(monkeypatch):
+    """When ``expanduser`` returns literal ``~`` (no $HOME and no
+    pwd entry), the helper refuses.
+
+    On POSIX, ``Path("~").expanduser()`` falls back to
+    ``pwd.getpwuid(os.getuid()).pw_dir`` when ``$HOME`` is unset, so
+    unset-HOME alone won't produce a literal ``"~"``. We simulate the
+    actual failure contract by both unsetting ``$HOME`` *and* forcing
+    ``pwd.getpwuid`` to raise ``KeyError`` so the fallback fails and
+    ``expanduser`` returns the bare ``"~"`` per Python's documented
+    semantics.
+    """
+    import os
+    import pwd
+
+    monkeypatch.delenv("HOME", raising=False)
+    monkeypatch.setattr(pwd, "getpwuid", lambda _uid: (_ for _ in ()).throw(KeyError("no entry")))
+
+    with pytest.raises(scope.UserScopeUnresolvable):
+        # Pass None so the real expanduser runs against the patched env.
+        scope.resolve_user_root(home=None)
+
+
+# ---------------------------------------------------------------------------
+# safety.write_jailed extension: scope + allowed_prefixes
+# ---------------------------------------------------------------------------
+
+
+def test_write_jailed_repo_scope_unchanged(tmp_path):
+    """The default scope behaviour (repo, no prefixes) is unchanged."""
+    from agentbundle import safety
+
+    safety.write_jailed(tmp_path, "AGENTS.md", "hi")
+    assert (tmp_path / "AGENTS.md").read_text() == "hi"
+
+
+def test_write_jailed_user_scope_requires_prefixes(tmp_path):
+    from agentbundle import safety
+
+    with pytest.raises(TypeError, match="allowed_prefixes is required"):
+        safety.write_jailed(tmp_path, ".claude/foo", "hi", scope="user")
+
+
+def test_write_jailed_user_scope_accepts_prefix_match(tmp_path):
+    from agentbundle import safety
+
+    safety.write_jailed(
+        tmp_path,
+        ".claude/skills/foo/SKILL.md",
+        "hi",
+        scope="user",
+        allowed_prefixes=[".claude/", ".agent-ready/"],
+    )
+    assert (tmp_path / ".claude" / "skills" / "foo" / "SKILL.md").read_text() == "hi"
+
+
+def test_write_jailed_user_scope_accepts_second_prefix(tmp_path):
+    from agentbundle import safety
+
+    safety.write_jailed(
+        tmp_path,
+        ".agent-ready/state.toml",
+        'schema-version = "0.2"\n',
+        scope="user",
+        allowed_prefixes=[".claude/", ".agent-ready/"],
+    )
+    assert (tmp_path / ".agent-ready" / "state.toml").exists()
+
+
+def test_write_jailed_user_scope_refuses_outside_prefix(tmp_path):
+    """A path under ~ but outside the declared prefix list is refused."""
+    from agentbundle import safety
+
+    with pytest.raises(safety.PathJailError) as ei:
+        safety.write_jailed(
+            tmp_path,
+            "Documents/foo.txt",
+            "hi",
+            scope="user",
+            allowed_prefixes=[".claude/", ".agent-ready/"],
+        )
+    assert "allowed prefixes" in str(ei.value)
+    assert "scope 'user'" in str(ei.value)
+
+
+def test_write_jailed_user_scope_prefix_directory_boundary(tmp_path):
+    """`.claude/` prefix must not accidentally match `.claudefoo/...`."""
+    from agentbundle import safety
+
+    with pytest.raises(safety.PathJailError):
+        safety.write_jailed(
+            tmp_path,
+            ".claudefoo/leak.txt",
+            "hi",
+            scope="user",
+            allowed_prefixes=[".claude/"],
+        )

--- a/packages/agentbundle/tests/unit/test_state_v01_refuse_write.py
+++ b/packages/agentbundle/tests/unit/test_state_v01_refuse_write.py
@@ -1,0 +1,181 @@
+"""T18: every write-capable subcommand refuses against a v0.1 state file.
+
+Verifies AC #(RFC-0004) for the agent-spec-cli spec:
+  - install, uninstall, upgrade, init-state (without --migrate) refuse on
+    a v0.1 .agent-ready-state.toml with the documented stderr.
+  - Read-only subcommands (list-targets, diff, adapt without
+    --values-from) succeed against the same v0.1 fixture, treating every
+    pack entry as repo-scope.
+
+Parametrisation: each write-capable subcommand is exercised by calling
+its handler directly with a minimal argparse.Namespace. We stage a
+v0.1 state file at the repo root before the call.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import argparse
+from pathlib import Path
+
+import pytest
+
+from agentbundle.commands import install, uninstall, upgrade, init_state, adapt, diff
+
+
+V01_STATE = """
+schema-version = "0.1"
+
+[pack.core]
+installed-version = "0.1.0"
+source = "agent-ready-repo"
+install-route = "cli"
+primitives = ["skill"]
+
+[pack.core.files]
+"AGENTS.md" = { sha = "00", from-pack-version = "0.1.0" }
+"""
+
+
+def _v01(tmp_path: Path) -> Path:
+    p = tmp_path / ".agent-ready-state.toml"
+    p.write_text(V01_STATE, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Write-capable subcommands refuse on v0.1
+# ---------------------------------------------------------------------------
+
+
+def _assert_refused(rc: int, stderr: str, verb: str) -> None:
+    assert rc != 0, f"{verb} accepted a v0.1 state file"
+    assert "schema-version 0.1" in stderr, (
+        f"{verb} stderr missing 'schema-version 0.1': {stderr!r}"
+    )
+    assert "init-state --migrate" in stderr, (
+        f"{verb} stderr missing migrate hint: {stderr!r}"
+    )
+
+
+def test_install_refuses_v01_state(tmp_path):
+    _v01(tmp_path)
+    # Stage a local catalogue with a minimal pack so install reaches the
+    # state-load step before any other failure.
+    pack = tmp_path / "catalogue" / "demo"
+    pack.mkdir(parents=True)
+    (pack / "pack.toml").write_text(
+        '[pack]\nname = "demo"\nversion = "0.1.0"\n', encoding="utf-8"
+    )
+    (pack / ".apm").mkdir()  # empty apm so render is a no-op
+
+    args = argparse.Namespace(
+        pack="demo",
+        catalogue=str(tmp_path / "catalogue"),
+        output=str(tmp_path),
+        scope=None,
+        force=False,
+    )
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        rc = install.run(args)
+    _assert_refused(rc, buf.getvalue(), "install")
+
+
+def test_uninstall_refuses_v01_state(tmp_path):
+    _v01(tmp_path)
+    args = argparse.Namespace(pack="core", root=str(tmp_path), scope=None)
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        rc = uninstall.run(args)
+    _assert_refused(rc, buf.getvalue(), "uninstall")
+
+
+def test_upgrade_refuses_v01_state(tmp_path):
+    _v01(tmp_path)
+    pack = tmp_path / "catalogue" / "core"
+    pack.mkdir(parents=True)
+    (pack / "pack.toml").write_text(
+        '[pack]\nname = "core"\nversion = "0.2.0"\n', encoding="utf-8"
+    )
+    (pack / ".apm").mkdir()
+    args = argparse.Namespace(
+        pack="core",
+        catalogue=str(tmp_path / "catalogue"),
+        to_version="0.2.0",
+        skill=None,
+        agent=None,
+        hook=None,
+        seed=None,
+        command=None,
+        root=str(tmp_path),
+        scope=None,
+    )
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        rc = upgrade.run(args)
+    _assert_refused(rc, buf.getvalue(), "upgrade")
+
+
+def test_init_state_without_migrate_refuses_v01(tmp_path):
+    _v01(tmp_path)
+    pack = tmp_path / "packs" / "demo"
+    pack.mkdir(parents=True)
+    (pack / "pack.toml").write_text(
+        '[pack]\nname = "demo"\nversion = "0.1.0"\n', encoding="utf-8"
+    )
+    args = argparse.Namespace(
+        pack="demo",
+        packs_dir=str(tmp_path / "packs"),
+        root=str(tmp_path),
+        migrate=False,
+        scope=None,
+    )
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        rc = init_state.run(args)
+    _assert_refused(rc, buf.getvalue(), "init-state")
+
+
+# ---------------------------------------------------------------------------
+# Read-only subcommands succeed against the same v0.1 fixture
+# ---------------------------------------------------------------------------
+
+
+def test_adapt_ci_without_values_from_succeeds_against_v01(tmp_path):
+    """adapt --ci is read-only — it must not refuse on a v0.1 file."""
+    _v01(tmp_path)
+    args = argparse.Namespace(
+        values_from=None,
+        ci=True,
+        root=str(tmp_path),
+    )
+    rc = adapt.run(args)
+    # The state file references AGENTS.md but the file is absent on disk
+    # → no companions, no findings → exit 0.
+    assert rc == 0
+
+
+def test_diff_does_not_raise_on_v01_state(tmp_path):
+    """diff is read-only — loads state, renders, and compares. v0.1 OK.
+
+    The test passes a fixture pack so diff can render. The state file's
+    being v0.1 must not block the read.
+    """
+    _v01(tmp_path)
+    pack = tmp_path / "packs" / "demo"
+    pack.mkdir(parents=True)
+    (pack / "pack.toml").write_text(
+        '[pack]\nname = "demo"\nversion = "0.1.0"\n', encoding="utf-8"
+    )
+    args = argparse.Namespace(
+        pack_path=str(pack), root=str(tmp_path), scope=None
+    )
+    # diff returns non-zero when the projection diverges (and an empty
+    # pack vs an empty projection should match). We only care here that
+    # it doesn't raise / refuse-on-v0.1.
+    try:
+        diff.run(args)
+    except Exception as exc:  # pragma: no cover — surfaces a regression
+        pytest.fail(f"diff raised on v0.1 state file: {exc!r}")

--- a/packages/agentbundle/tests/unit/test_state_v02.py
+++ b/packages/agentbundle/tests/unit/test_state_v02.py
@@ -1,0 +1,237 @@
+"""T13: .agent-ready-state.toml v0.2 + init-state --migrate.
+
+Verifies AC #17 (RFC-0004) for the distribution-adapters spec:
+  - Read of a v0.1 file returns every entry with implicit scope="repo".
+  - Write-capable invocations against a v0.1 file refuse-and-explain.
+  - `init-state --migrate` rewrites v0.1 → v0.2 idempotently.
+  - User-scope state file lives at `~/.agent-ready/state.toml` (a
+    namespaced dot-directory; the dir is created with 0o700 if absent).
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import contextlib
+import os
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+
+import pytest
+
+from agentbundle import config, safety
+from agentbundle.commands import init_state
+
+
+V01_FIXTURE = """
+schema-version = "0.1"
+
+[pack.core]
+installed-version = "0.1.0"
+source = "agent-ready-repo"
+install-route = "cli"
+primitives = ["skill"]
+
+[pack.core.files]
+"AGENTS.md" = { sha = "deadbeef", from-pack-version = "0.1.0" }
+"""
+
+V01_TWO_PACKS = """
+schema-version = "0.1"
+
+[pack.core]
+installed-version = "0.1.0"
+source = "agent-ready-repo"
+install-route = "cli"
+primitives = ["skill"]
+
+[pack.core.files]
+"AGENTS.md" = { sha = "aa", from-pack-version = "0.1.0" }
+
+[pack.governance-extras]
+installed-version = "0.1.0"
+source = "agent-ready-repo"
+install-route = "cli"
+primitives = ["skill"]
+
+[pack.governance-extras.files]
+"docs/CHARTER.md" = { sha = "bb", from-pack-version = "0.1.0" }
+"""
+
+
+def _write(p: Path, text: str) -> Path:
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Read-time compatibility — v0.1 file loads as all-repo-scope
+# ---------------------------------------------------------------------------
+
+
+def test_load_state_reads_v01_as_repo_scope(tmp_path):
+    """Every [pack.<name>] entry in a v0.1 file gets implicit scope='repo'."""
+    p = _write(tmp_path / "s.toml", V01_TWO_PACKS)
+    state = config.load_state(p)
+    assert state.schema_version == "0.1"
+    assert state.packs["core"].scope == "repo"
+    assert state.packs["governance-extras"].scope == "repo"
+
+
+# ---------------------------------------------------------------------------
+# Write-time refusal on v0.1
+# ---------------------------------------------------------------------------
+
+
+def test_load_state_for_write_refuses_v01(tmp_path):
+    p = _write(tmp_path / "s.toml", V01_FIXTURE)
+    with pytest.raises(config.StateFileLegacy) as ei:
+        config.load_state(p, for_write=True)
+    # Documented stderr text must appear in the exception message.
+    assert "schema-version 0.1" in str(ei.value)
+    assert "init-state --migrate" in str(ei.value)
+
+
+def test_load_state_for_write_accepts_v02(tmp_path):
+    """A v0.2 file does not raise on for_write=True."""
+    p = _write(
+        tmp_path / "s.toml",
+        'schema-version = "0.2"\n\n[pack.demo]\ninstalled-version = "0.1.0"\nscope = "repo"\nprimitives = []\n[pack.demo.files]\n',
+    )
+    state = config.load_state(p, for_write=True)
+    assert state.schema_version == "0.2"
+    assert state.packs["demo"].scope == "repo"
+
+
+def test_init_state_refuses_v01_state_file(tmp_path):
+    """The init-state hash-mode (no --migrate) is a *write* — refuse v0.1."""
+    _write(tmp_path / ".agent-ready-state.toml", V01_FIXTURE)
+    # Build a minimal pack so the loader doesn't trip earlier.
+    packs_dir = tmp_path / "packs"
+    pack = packs_dir / "demo"
+    pack.mkdir(parents=True)
+    (pack / "pack.toml").write_text(
+        '[pack]\nname = "demo"\nversion = "0.1.0"\n', encoding="utf-8"
+    )
+    args = argparse.Namespace(
+        pack="demo",
+        packs_dir=str(packs_dir),
+        root=str(tmp_path),
+        migrate=False,
+    )
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        rc = init_state.run(args)
+    assert rc == 1
+    err = buf.getvalue()
+    assert "schema-version 0.1" in err
+    assert "init-state --migrate" in err
+
+
+# ---------------------------------------------------------------------------
+# `init-state --migrate` semantics
+# ---------------------------------------------------------------------------
+
+
+def test_migrate_rewrites_v01_to_v02(tmp_path):
+    """Every pack gains `scope = "repo"`; schema-version flips to 0.2."""
+    state_path = _write(tmp_path / ".agent-ready-state.toml", V01_TWO_PACKS)
+    args = argparse.Namespace(
+        root=str(tmp_path),
+        migrate=True,
+        pack=None,
+        packs_dir="packs",
+        scope=None,
+    )
+    rc = init_state.run(args)
+    assert rc == 0
+
+    migrated = config.load_state(state_path)
+    assert migrated.schema_version == "0.2"
+    assert all(ps.scope == "repo" for ps in migrated.packs.values())
+    # SHAs preserved.
+    assert migrated.packs["core"].file_sha("AGENTS.md") == "aa"
+    assert migrated.packs["governance-extras"].file_sha("docs/CHARTER.md") == "bb"
+
+
+def test_migrate_is_idempotent(tmp_path):
+    """Running --migrate twice against the same file is a no-op."""
+    state_path = _write(tmp_path / ".agent-ready-state.toml", V01_FIXTURE)
+    args = argparse.Namespace(
+        root=str(tmp_path), migrate=True, pack=None, packs_dir="packs", scope=None
+    )
+    assert init_state.run(args) == 0
+    first_pass = state_path.read_bytes()
+    assert init_state.run(args) == 0
+    second_pass = state_path.read_bytes()
+    assert first_pass == second_pass, "migration is not idempotent"
+
+
+def test_migrate_refuses_absent_file(tmp_path):
+    """Migration of an absent file surfaces — silent no-op would hide drift."""
+    args = argparse.Namespace(
+        root=str(tmp_path), migrate=True, pack=None, packs_dir="packs", scope=None
+    )
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        rc = init_state.run(args)
+    assert rc == 1
+    assert "no state file" in buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# User-scope state file path + permissions
+# ---------------------------------------------------------------------------
+
+
+def test_user_state_path_creates_dot_directory(tmp_path):
+    """safety.user_state_path() creates ~/.agent-ready with mode 0o700."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    p = safety.user_state_path(home=fake_home)
+    assert p == fake_home / ".agent-ready" / "state.toml"
+    assert (fake_home / ".agent-ready").is_dir()
+    # On POSIX the mode bits are observable. On platforms that don't
+    # respect mode in mkdir (e.g. NTFS), we soften this to "creates the
+    # directory" — the file is still under $HOME.
+    if os.name == "posix":
+        st = (fake_home / ".agent-ready").stat()
+        assert stat.S_IMODE(st.st_mode) == 0o700, (
+            f"expected 0o700, got {oct(stat.S_IMODE(st.st_mode))}"
+        )
+
+
+def test_user_state_path_idempotent_when_dir_exists(tmp_path):
+    """Re-calling does not raise even if the dir is already there."""
+    fake_home = tmp_path / "home"
+    (fake_home / ".agent-ready").mkdir(parents=True)
+    p = safety.user_state_path(home=fake_home)
+    assert p == fake_home / ".agent-ready" / "state.toml"
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: a v0.2 dump emits the scope column
+# ---------------------------------------------------------------------------
+
+
+def test_dump_state_v02_emits_scope_column():
+    state = config.State(schema_version="0.2")
+    state.packs["demo"] = config.PackState(
+        installed_version="0.1.0",
+        scope="user",
+        files={"x": {"sha": "0"}},
+    )
+    serialised = config.dump_state(state)
+    assert 'scope = "user"' in serialised
+
+
+def test_dump_state_v01_omits_scope_column():
+    state = config.State(schema_version="0.1")
+    state.packs["demo"] = config.PackState(
+        installed_version="0.1.0", files={"x": {"sha": "0"}}
+    )
+    serialised = config.dump_state(state)
+    # Round-trip preserves v0.1 shape (no scope column).
+    assert "scope" not in serialised

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -3,3 +3,15 @@ name = "core"
 version = "0.1.0"
 description = "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr + session-start hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 
+# RFC-0004 ships the v0.2 contract bump alongside this pack's metadata.
+# The four shipped packs all declare the same shape so the catalogue's
+# published packs and the CLI release land in lockstep. core is
+# repo-only by content — it ships hooks (Rail B would refuse user
+# scope) and AGENTS.md / CONVENTIONS seeds that reference this
+# project's vocabulary by name (the falsifiable user-scope test fails).
+[pack.adapter-contract]
+version = "0.2"
+
+[pack.install]
+default-scope = "repo"
+allowed-scopes = ["repo"]

--- a/packs/core/seeds/docs/CONVENTIONS.md
+++ b/packs/core/seeds/docs/CONVENTIONS.md
@@ -387,6 +387,21 @@ upstream under `packs/<pack>/.apm/` or `packs/<pack>/seeds/`, then run
 commit, push. The gate is the contract; the source-of-truth split is
 the convention.
 
+### Install scope is per-pack ([RFC-0004](rfc/0004-install-scope-per-pack.md))
+
+Each pack declares its install **scope** — `repo` (project-local), `user`
+(shared across every repo the adopter opens), or both — in
+`pack.toml`'s `[pack.install]` table. The pack author picks the
+dimension; adopters can override within the publisher's declared set
+via `--scope`. The default landing for every pack we ship today is
+`repo`; user-scope eligibility requires content portability that the
+falsifiable test in [the migration guide](guides/how-to/v01-to-v02-pack-upgrade.md)
+governs. The schema enforces `default-scope ∈ allowed-scopes` so the
+rule holds outside the CLI. `agentbundle install` re-runs the
+contract-level user-scope rails (seeds / hooks / marker) against the
+resolved pack content at install time, closing the
+widen-after-publish gap.
+
 ---
 
 ## Commits

--- a/packs/governance-extras/pack.toml
+++ b/packs/governance-extras/pack.toml
@@ -4,3 +4,11 @@ version = "0.1.0"
 description = "Governance skills (new-rfc, new-adr, update-conventions) and RFC/ADR templates + seed READMEs."
 recommends = ["core"]
 
+# RFC-0004 v0.2 contract metadata. RFC/ADR ceremony is per-project, so
+# the pack is declared repo-only.
+[pack.adapter-contract]
+version = "0.2"
+
+[pack.install]
+default-scope = "repo"
+allowed-scopes = ["repo"]

--- a/packs/monorepo-extras/pack.toml
+++ b/packs/monorepo-extras/pack.toml
@@ -4,3 +4,11 @@ version = "0.1.0"
 description = "Monorepo scaffolding: new-package skill, packages/ seed README, packages/_example/ template."
 recommends = ["core"]
 
+# RFC-0004 v0.2 contract metadata. new-package scaffolds in `packages/`
+# — meaningless without a monorepo — so the pack is repo-only.
+[pack.adapter-contract]
+version = "0.2"
+
+[pack.install]
+default-scope = "repo"
+allowed-scopes = ["repo"]

--- a/packs/user-guide-diataxis/pack.toml
+++ b/packs/user-guide-diataxis/pack.toml
@@ -4,3 +4,12 @@ version = "0.1.0"
 description = "Di\u00e1taxis-shaped user-guide skeleton: guides/ + tutorials/how-to/reference/explanation seed READMEs, new-guide skill."
 recommends = ["core"]
 
+# RFC-0004 v0.2 contract metadata. Scaffolds `docs/guides/` for *this*
+# project's users \u2014 no project, no scaffolding target \u2014 so the pack is
+# repo-only.
+[pack.adapter-contract]
+version = "0.2"
+
+[pack.install]
+default-scope = "repo"
+allowed-scopes = ["repo"]


### PR DESCRIPTION
## Summary

Lands [RFC-0004](https://github.com/eugenelim/agent-ready-repo/blob/main/docs/rfc/0004-install-scope-per-pack.md) — the `scope` dimension (`repo` | `user`) on the adapter contract. Pack authors declare both a `default-scope` and an `allowed-scopes` set in `pack.toml`; adopters override via `--scope` within the publisher's declared set. **No user-scope pack ships in this PR** — the four shipped packs all declare `allowed-scopes = ["repo"]`. The value-prop is the dimension itself, landed ahead of any consumer.

The contract bumps atomically per RFC-0004 § *Spec-amendment atomicity*: every artifact below ships in this single PR.

## Distribution-adapters tasks (T10–T14)

- [x] **T10** — `docs/contracts/adapter.schema.json` + `adapter.toml` gain `[scope]` table; `[contract] version` 0.1 → 0.2; Claude Code declares `allowed-prefixes.user = [".claude/", ".agent-ready/"]`. (Closes AC #14.)
- [x] **T11** — `docs/contracts/pack.schema.json` requires `[pack.install]` under contract v0.2 with the `default-scope ∈ allowed-scopes` invariant enforced via jsonschema `if`/`then`. Stdlib validator extended with `minItems` / `contains` / `if`/`then`/`else` to support the new shape. (Closes AC #15.)
- [x] **T12** — `validate.py` runs the three user-scope refusal rails — Rail A (seeds), Rail B (hooks), Rail C (`<adapt:NAME>` markers). Rail C uses `os.lstat` to refuse symlinks and a 4 MiB per-file size cap; reads via `os.open(O_RDONLY|O_NOFOLLOW)` to close the lstat→read TOCTOU window. (Closes AC #16.)
- [x] **T13** — `.agent-ready-state.toml` `schema-version` 0.1 → 0.2 with explicit `scope` column per entry; `init-state --migrate` rewrites idempotently. (Closes AC #17.)
- [x] **T14** — Four shipped packs at `packs/{core,governance-extras,monorepo-extras,user-guide-diataxis}/pack.toml` adopt `[pack.adapter-contract] version = "0.2"` and `[pack.install] default-scope = "repo", allowed-scopes = ["repo"]`. (Closes AC #18.)

## Agent-spec-cli tasks (T16–T21)

- [x] **T16** — argparse gains `--scope` on `install`, `uninstall`, `upgrade`, `diff`, `init-state`, `list-targets`; `--force` on `install`. Custom `ArgumentParser` subclass + `_SubParsersAction` rewrite forbidden-flag stderr to `unknown flag for <verb>: <flag>` byte-for-byte.
- [x] **T17** — `scope.py` ships `resolve()` (precedence CLI > pack default > built-in `repo`) and `resolve_user_root()` (expanduser once; refuses literal `~`, normalised `/`, or `OSError`). `safety.write_jailed` gains `scope` + `allowed_prefixes` kwargs; user-scope writes must lie under declared prefixes (trailing-slash assertion as defense-in-depth).
- [x] **T18** — Every write-capable subcommand refuses against a v0.1 state file with the spec-named `state file at <path> is schema-version 0.1; run 'agentbundle init-state --migrate' first`. Read-only paths treat v0.1 entries as repo-scope.
- [x] **T19** — Dual-scope `install` conflict + `--force` + `installed: <pack> @ <scope>` rail. Pre-flight ordering: `~`-expansion, Rails A/B/C re-check, path-jail probe across **both** scopes before any write. In-place re-install is always refused (use `upgrade`). Dual-scope writes two `installed:` lines repo-first.
- [x] **T20** — `recommends` cross-scope warning split — three stderr `note:` cases (found-at-scope / not-installed / scope-disjoint with repo-only or user-only sub-case).
- [x] **T21** — `adapt` walks both state files; reads `<repo>/.adapt-discovery.toml` and `~/.agent-ready/.adapt-discovery.toml`; writes per-scope `.adapt-pending.md`. `adapt --ci` ORs both scopes.

## Follow-on artifacts (per RFC-0004 § Follow-on artifacts)

- [x] **ADR-0002** — `docs/adr/0002-install-scope-per-pack-default-and-allowance.md` — records rejection of RFC-0004 alternatives 2, 3, 7, 8.
- [x] **CONVENTIONS** — paragraph under `docs/CONVENTIONS.md` § *Pack source-of-truth split* pointing at scope as the dimension publishers choose.
- [x] **Migration guide** — `docs/guides/how-to/v01-to-v02-pack-upgrade.md` (one-page how-to for third-party pack authors).
- [x] **ROADMAP** — `docs/ROADMAP.md` reconciled; ten `(RFC-0004)`-tagged ACs checked off across both specs; RFC marked Accepted.

## Out of scope (per RFC-0004)

- User-scope hook-wiring merge story (deferred to a follow-up RFC; Rail B keeps hook-bearing packs user-scope-refused until that lands).
- `global` (system-wide) scope — not reserved, not refused; absent.
- New user-scope packs.
- Cross-platform conformance — POSIX-gated; Windows deferred.

## Test plan

- [x] `python -m agentbundle.build validate docs/contracts/adapter.toml` exits 0 against v0.2.
- [x] `agentbundle validate packs/{core,governance-extras,monorepo-extras,user-guide-diataxis}` each exits 0.
- [x] Fresh-tempdir install of `core` at `--scope user` refused (allowed-scopes refuses before Rail B).
- [x] v0.1 fixture state file makes `install` / `uninstall` / `upgrade` refuse-and-explain; `init-state --migrate` migrates idempotently.
- [x] `install --pack <P> --scope user --force` against a pre-installed-at-repo fixture writes `~/.agent-ready/state.toml` and emits two `installed:` stdout lines in repo-then-user order.
- [x] `tools/lint-build.sh`, `lint-agents-md.sh`, `lint-agent-artifacts.sh`, `test-all.sh` — all green.
- [x] pytest full suite (~536 pass, 1 skip; pre-existing `test_version_gate_matrix.py` symlink fixture excluded as a separate cleanup).
- [x] `make build` against the four shipped packs produces the expected `dist/` tree.
- [x] adversarial-reviewer iterated to `Clean — ready to commit.` (3 passes).
- [x] security-reviewer iterated to `Clean — ready to commit.` (4 passes).