### PR TITLE
test(adapt-to-project): back-fill AC4b automation pins from PR #28

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,8 +14,7 @@ line under `make build-check` per AC6 of the self-hosting spec.
 For shipped work, see [`product/changelog.md`](product/changelog.md)
 and each spec's own Changelog section.
 
-**Last updated:** 2026-05-23 (adapt-to-project spec lands; cross-spec
-`adapt-to-project` bullet re-cited as a per-spec section)
+**Last updated:** 2026-05-23 (adapt-to-project AC4b automation pins land)
 
 ## How this file is maintained
 
@@ -137,35 +136,6 @@ classes 2–4 LLM-judgment writes under the per-scope path-jail).
   catalogues); fix shape is a tested `_emit_basic_string`
   serialiser + a runtime regex assertion on every pack-sourced
   field that lands in a TOML basic-string position.
-- **AC18 schema-validation tests for shipped packs.** `make
-  build-self` already invokes `validate_pack_metadata` per pack at
-  build time, so a malformed shipped manifest breaks CI. There is
-  no separate pytest pinning the four manifests carry
-  `[pack.adapter-contract] version = "0.2"` + `[[pack.dependencies.required]]`
-  (addons) + `[pack.install]` (all four). **Unblocks when:**
-  someone adds a parametrised `test_addon_manifests_carry_required_dependency`
-  + `test_all_packs_declare_install_table` against
-  `packs/{core,governance-extras,user-guide-diataxis,monorepo-extras}/pack.toml`.
-- **AC19c scaffold-driven test.** `tests/integration/test_install_adapt_chain.py::test_marker_in_seed_gitignore`
-  checks the seed file directly rather than invoking
-  `agentbundle scaffold` against a tmp output dir. A refactor that
-  silently dropped dotfile projection would not trip the test.
-  **Unblocks when:** the test is rewritten to invoke
-  `scaffold_run` and assert `(tmp/.gitignore).read_text()`.
-- **AC10 deterministic-pending-md byte-identity with non-empty
-  state.** `test_idempotent_re_run` exercises the trivial empty-
-  companion case. The interesting case (sorted lexicographically,
-  no timestamps, byte-identical across re-runs) is unpinned.
-  **Unblocks when:** a fixture seeds two `.upstream.<ext>` files
-  and a test asserts the pending.md is byte-identical *and*
-  contains the companion paths in lex order.
-- **User-scope-only install chain test.** `_chain_adapt`'s
-  fallback `Path(args.output).resolve()` is the path used when an
-  adopter runs `agentbundle install --pack <user-pack> --scope user`
-  (no repo plan). No test exercises this. **Unblocks when:** a
-  test seeds a user-scope-only install and asserts the chained
-  adapt either fires correctly against the install's output root
-  or is skipped explicitly.
 - **APM / Claude-plugins install-route nudge parity.** Adopters
   installing via APM or Claude-plugins routes (rather than
   `agentbundle install`) never hit the install marker write, never

--- a/packages/agentbundle/tests/integration/test_brownfield_adapt_end_to_end.py
+++ b/packages/agentbundle/tests/integration/test_brownfield_adapt_end_to_end.py
@@ -109,3 +109,93 @@ def test_idempotent_re_run(tmp_path):
         + ", ".join(sorted(set(before) ^ set(after))
                     + [k for k in before if k in after and before[k] != after[k]])
     )
+
+
+def test_pending_report_byte_identical_with_multiple_companions(tmp_path):
+    """AC10: `.adapt-pending.md` is byte-identical across re-runs and
+    lists companion paths in lex order — load-bearing for the
+    deterministic-sort contract, not the trivial one-element case.
+
+    The fixture records three projected paths chosen so the lex sort
+    of their companion relpaths is non-trivial:
+
+      Projected paths:    AGENTS.md, docs/CHARTER.md, AAA-extra.md
+      Companion lex sort: AAA-extra.upstream.md, AGENTS.upstream.md,
+                          docs/CHARTER.upstream.md
+
+    The byte-identity check pins the no-timestamp contract; the
+    sequence-equals-sorted check pins lex ordering. Caveat:
+    `State.projected_paths()` returns a `set[str]`, and `adapt.py`
+    currently sorts at *two* sites (`_find_upstream_companions` and
+    the report-write loop). Dropping *one* sort leaves the other to
+    recover lex order, so this test is not load-bearing against a
+    single-site regression. It is load-bearing against dropping
+    *both* sites, where set iteration of `projected_paths()` (hash-
+    dependent) takes over and almost always disagrees with lex order
+    for three or more relpaths.
+    """
+    from agentbundle.config import PackState, State, dump_state
+    from agentbundle.safety import companion_path, sha256_bytes
+
+    work = tmp_path / "repo"
+    work.mkdir()
+    (work / "docs").mkdir()
+
+    # Three projected files (original + companion each). The three
+    # relpaths have a non-trivial lex sort (capital-A < capital-A-then-G
+    # < lowercase-d).
+    bodies = {
+        "AGENTS.md": "# AGENTS\nbody\n",
+        "docs/CHARTER.md": "# CHARTER\nbody\n",
+        "AAA-extra.md": "# AAA extra\nbody\n",
+    }
+    files: dict = {}
+    for rel, body in bodies.items():
+        (work / rel).write_text(body, encoding="utf-8")
+        comp_rel = companion_path(Path(rel)).as_posix()
+        (work / comp_rel).parent.mkdir(parents=True, exist_ok=True)
+        (work / comp_rel).write_text(
+            f"upstream variant of {rel}\n", encoding="utf-8"
+        )
+        files[rel] = {
+            "sha": sha256_bytes(body.encode("utf-8")),
+            "from-pack-version": "0.1.0",
+        }
+
+    state = State()
+    state.packs["core"] = PackState(installed_version="0.1.0", files=files)
+    (work / ".agent-ready-state.toml").write_text(
+        dump_state(state), encoding="utf-8"
+    )
+    (work / ".adapt-discovery.toml").write_text(
+        'discovery-schema-version = "0.1"\n[markers]\n', encoding="utf-8"
+    )
+
+    assert adapt.run(_ns(work)) == 0
+    first = (work / ".adapt-pending.md").read_bytes()
+
+    assert adapt.run(_ns(work)) == 0
+    second = (work / ".adapt-pending.md").read_bytes()
+
+    assert first == second, (
+        "pending.md must be byte-identical across runs "
+        "(deterministic sort, no timestamps); diff:\n"
+        f"first:  {first!r}\nsecond: {second!r}"
+    )
+
+    # Parse the companion entries; assert the full sequence equals the
+    # lex-sorted variant. With the deliberate insertion-vs-lex
+    # inversion, this assertion fails on a dropped sort.
+    text = first.decode("utf-8")
+    listed = [
+        line.split("`")[1]
+        for line in text.splitlines()
+        if line.startswith("- `")
+    ]
+    assert len(listed) == 3, (
+        f"expected 3 companion entries; got {listed!r}\nreport:\n{text}"
+    )
+    assert listed == sorted(listed), (
+        f"companion entries not in lex order — sort regression?\n"
+        f"got:    {listed!r}\nsorted: {sorted(listed)!r}\n{text}"
+    )

--- a/packages/agentbundle/tests/integration/test_install_adapt_chain.py
+++ b/packages/agentbundle/tests/integration/test_install_adapt_chain.py
@@ -213,19 +213,110 @@ def test_install_chains_adapt_in_process_no_subprocess(tmp_path, monkeypatch):
 
 
 def test_marker_in_seed_gitignore(tmp_path):
-    """AC19c: the core pack's seeded `.gitignore` contains
-    `.adapt-install-marker.toml` so adopters running `agentbundle scaffold`
-    don't accidentally commit the local scratch."""
-    pack_gitignore = (
-        Path(__file__).parent.parent.parent.parent.parent
-        / "packs"
-        / "core"
-        / "seeds"
-        / ".gitignore"
+    """AC19c: invoking `agentbundle scaffold` against the core pack lays
+    down a `.gitignore` containing `.adapt-install-marker.toml`.
+
+    Drives the scaffold command end-to-end against a tmp output dir
+    rather than checking the seed file directly — so a refactor that
+    silently dropped dotfile projection (e.g., a switch from
+    `Path.rglob` to a glob library that needs `include_hidden=True`,
+    an added dotfile filter in the seeds walk, or a `.gitignore`-
+    specific skip) would trip the test instead of slipping past.
+    """
+    from agentbundle.commands.scaffold import run as scaffold_run
+
+    packs_dir = Path(__file__).resolve().parents[4] / "packs"
+    output = tmp_path / "out"
+    output.mkdir()
+    ns = argparse.Namespace(
+        pack="core",
+        packs_dir=str(packs_dir),
+        output=str(output),
     )
-    assert pack_gitignore.exists(), (
-        f".gitignore seed not found at {pack_gitignore} — scaffold "
-        "AC19c can't lay it down."
+    rc = scaffold_run(ns)
+    assert rc == 0, "scaffold against core pack should succeed"
+    projected = output / ".gitignore"
+    assert projected.exists(), (
+        f"scaffold did not project .gitignore from packs/core/seeds/ "
+        f"into {output}"
     )
-    body = pack_gitignore.read_text(encoding="utf-8")
-    assert ".adapt-install-marker.toml" in body
+    body = projected.read_text(encoding="utf-8")
+    assert ".adapt-install-marker.toml" in body, (
+        "projected .gitignore is missing the install-marker line; "
+        f"scaffold output was:\n{body}"
+    )
+
+
+USER_ONLY_PACK = """\
+[pack]
+name = "user-only"
+version = "0.1.0"
+
+[pack.adapter-contract]
+version = "0.2"
+
+[pack.install]
+default-scope = "user"
+allowed-scopes = ["user"]
+"""
+
+
+def test_user_scope_only_install_chains_adapt_against_args_output(tmp_path, monkeypatch):
+    """User-scope-only install exercises `_chain_adapt`'s fallback path
+    (no repo plan in `plans`, so `repo_root_for_adapt =
+    Path(args.output).resolve()`).
+
+    Contract pinned: the fallback resolves to `args.output`, not to
+    `cwd`, `$HOME`, or any other path. To make that load-bearing the
+    test seeds a sentinel `.adapt-discovery.toml` at `args.output`
+    *only* and asserts two positive signals from the chained adapt:
+
+      1. No no-discovery nudge in stderr — the chain found the
+         discovery file at the path it resolved.
+      2. `.adapt-pending.md` lands at `<args.output>/.adapt-pending.md`
+         — the per-scope walk ran with `repo_root = args.output`,
+         not some sibling path.
+
+    A refactor that swapped the fallback to `Path.cwd()`, `$HOME`, or
+    `Path("/tmp/whatever")` would trip *both* assertions in this
+    fixture: no discovery file at those paths, no pending.md at
+    target. The user-scope state file at `<HOME>/.agent-ready/state.toml`
+    confirms the user-scope write path ran independently of the chain.
+    """
+    cat = tmp_path / "cat"
+    _stage_pack(cat, "user-only", USER_ONLY_PACK)
+    target = tmp_path / "repo"
+    target.mkdir()
+    # Sentinel discovery file at args.output. The fallback path must
+    # resolve here for the chained adapt to find it.
+    (target / ".adapt-discovery.toml").write_text(
+        'discovery-schema-version = "0.1"\n[markers]\nowner = "octocat"\n',
+        encoding="utf-8",
+    )
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    rc, _, err = _install(
+        dict(pack="user-only", catalogue=str(cat), output=str(target), scope="user", force=False)
+    )
+    assert rc == 0, f"user-scope-only install failed: {err}"
+    # User-scope state file landed at the namespaced dot-directory.
+    assert (fake_home / ".agent-ready" / "state.toml").exists(), (
+        "user-scope install did not write state.toml at <HOME>/.agent-ready/"
+    )
+    # Discriminating assertion (1): the chain found the seeded discovery,
+    # so the no-discovery nudge stays out of stderr.
+    assert (
+        "no .adapt-discovery.toml at repo root" not in err
+    ), (
+        "chain emitted the no-discovery nudge, meaning the fallback "
+        "resolved to a path other than args.output; stderr was:\n" + err
+    )
+    # Discriminating assertion (2): the per-scope walk ran with
+    # repo_root = args.output (the only place pending.md can land for
+    # the repo scope of the chained adapt).
+    assert (target / ".adapt-pending.md").exists(), (
+        "chained adapt did not write pending.md at args.output; the "
+        "fallback may have resolved to a different path"
+    )

--- a/packages/agentbundle/tests/unit/test_shipped_pack_manifests.py
+++ b/packages/agentbundle/tests/unit/test_shipped_pack_manifests.py
@@ -1,0 +1,90 @@
+"""AC18 schema-validation pins for shipped packs.
+
+`make build-self` already invokes ``validate_pack_metadata`` per pack at
+build time, so a malformed shipped manifest breaks CI. These pytests
+pin the *positive* shape — the four shipped packs declare the v0.2
+contract metadata and the three addon packs carry the required-dep on
+``core`` — so a silent metadata removal (or a botched bump) trips a
+test rather than slipping through.
+
+Scope is deliberately narrow: enumerate the four shipped packs by
+name. Three addons / four total is small enough not to warrant a
+helper.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+PACKS_DIR = REPO_ROOT / "packs"
+
+ALL_SHIPPED_PACKS = ("core", "governance-extras", "user-guide-diataxis", "monorepo-extras")
+ADDON_PACKS = ("governance-extras", "user-guide-diataxis", "monorepo-extras")
+
+
+def _load(pack_name: str) -> dict:
+    path = PACKS_DIR / pack_name / "pack.toml"
+    assert path.exists(), f"shipped pack {pack_name!r} missing pack.toml at {path}"
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("pack_name", ADDON_PACKS)
+def test_addon_manifests_carry_required_dependency(pack_name):
+    """Every addon pack declares `[[pack.dependencies.required]]` against
+    `core` with the `^0.1` caret-minor range (adapt-to-project AC18).
+
+    Scope: this test pins the *manifest shape*. The install-time gate
+    behavior (refusing an addon install when core is absent from the
+    union of repo+user state) is covered separately by
+    `test_install_dependencies_gate.py`.
+    """
+    data = _load(pack_name)
+    required = data.get("pack", {}).get("dependencies", {}).get("required")
+    assert isinstance(required, list) and required, (
+        f"{pack_name}: expected non-empty [[pack.dependencies.required]] list"
+    )
+    matches = [
+        e for e in required
+        if isinstance(e, dict)
+        and e.get("catalogue") == "agent-ready-repo"
+        and e.get("pack") == "core"
+        and e.get("version") == "^0.1"
+    ]
+    assert matches, (
+        f"{pack_name}: required-dep entry "
+        '{catalogue="agent-ready-repo", pack="core", version="^0.1"} not found; '
+        f"got {required!r}"
+    )
+
+
+@pytest.mark.parametrize("pack_name", ALL_SHIPPED_PACKS)
+def test_all_packs_declare_install_table(pack_name):
+    """Every shipped pack declares the v0.2 contract + the `[pack.install]`
+    table with `default-scope = "repo"` and `allowed-scopes = ["repo"]`.
+    RFC-0004 sets the install-scope dimension; all four shipped packs
+    are repo-only by content (core ships hooks, addons scaffold project
+    directories) so the four packs land in lockstep with the contract.
+    """
+    data = _load(pack_name)
+    contract = data.get("pack", {}).get("adapter-contract", {})
+    assert contract.get("version") == "0.2", (
+        f"{pack_name}: [pack.adapter-contract] version must be \"0.2\"; "
+        f"got {contract!r}"
+    )
+    install = data.get("pack", {}).get("install")
+    assert isinstance(install, dict), (
+        f"{pack_name}: [pack.install] table missing"
+    )
+    assert install.get("default-scope") == "repo", (
+        f"{pack_name}: [pack.install] default-scope must be \"repo\"; "
+        f"got {install!r}"
+    )
+    assert install.get("allowed-scopes") == ["repo"], (
+        f"{pack_name}: [pack.install] allowed-scopes must be [\"repo\"]; "
+        f"got {install!r}"
+    )


### PR DESCRIPTION
## Summary

Four small test additions that pin contracts AC4b deferred from PR #28 (commit 9251792). Pure tests + ROADMAP cleanup; no production code.

- **AC18 manifest shape** — `packages/agentbundle/tests/unit/test_shipped_pack_manifests.py`. Parametrised pins on all four shipped packs: addon packs carry the `core` required-dep at `^0.1`; every pack declares `[pack.adapter-contract] version = "0.2"` + `[pack.install]` with `default-scope = "repo"` / `allowed-scopes = ["repo"]`.
- **AC19c scaffold-driven gitignore** — `tests/integration/test_install_adapt_chain.py::test_marker_in_seed_gitignore` rewritten to drive `agentbundle.commands.scaffold.run` against a tmp output dir, asserting the projected `.gitignore` contains `.adapt-install-marker.toml`. The prior version read the seed file directly and would not trip on a dotfile-projection regression.
- **AC10 non-empty pending.md byte-identity** — `tests/integration/test_brownfield_adapt_end_to_end.py::test_pending_report_byte_identical_with_multiple_companions`. Three projected paths + companions, two adapt runs, asserts byte-identity + full sequence equals lex-sort. Load-bearing against dropping both `sorted()` sites in `adapt.py` where hash-dependent set iteration of `State.projected_paths()` takes over.
- **User-scope-only install chain** — `tests/integration/test_install_adapt_chain.py::test_user_scope_only_install_chains_adapt_against_args_output`. Pins `_chain_adapt`'s `Path(args.output).resolve()` fallback when no repo plan exists. Seeds a sentinel `.adapt-discovery.toml` at `args.output` and asserts the no-discovery nudge is absent + pending.md lands at `args.output` — discriminates the fallback path from cwd/HOME/other resolutions.

ROADMAP cleanup: the four landed bullets removed from `docs/ROADMAP.md`'s `adapt-to-project` section.

## Test plan

- [x] `make build-check` clean (info line for `docs/ROADMAP.md` is the expected unclassified entry per self-hosting AC6)
- [x] `python3 -m pytest packages/agentbundle/tests/ --ignore=packages/agentbundle/tests/integration/test_version_gate_matrix.py` → 293 passed, 1 skipped
- [x] All 17 tests in the three touched files pass (7 from new file, 7 + 3 from the edited integration tests)
- [x] Adversarial-reviewer clean after three iterations (Concerns/Nits about claim-vs-reality alignment in docstrings; no logic bugs)
- [x] Pre-existing 8 version-gate symlink errors reproduce on `main` (out of scope; explicitly excluded)