### PR TITLE
feat(agentbundle): land install-marker new-companions tally

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -118,15 +118,6 @@ classes 2–4 LLM-judgment writes under the per-scope path-jail).
   `adapt.run`. The spec is explicit (CLI-only contract), but the
   RFC-0004 parity work would close this gap. **Unblocks when:**
   APM/Claude-plugins adapter parity lands.
-- **Install-marker `new-companions` tally.** `commands/install.py`'s
-  install loop classifies Tier-2 collisions on the fly and doesn't
-  keep a tally; `_append_install_marker` writes `new-companions = []`
-  unconditionally. The spec's install-marker schema example names
-  this field as load-bearing, but the session-start nudge doesn't
-  surface companion paths in v1. **Unblocks when:** the first Tier-2
-  collision needs to surface through the install→adapt nudge — at
-  that point, capture the relpaths during the step-9 write loop and
-  pass them through.
 - **AC4b — deferred manual-QA rows (three trigger classes).**
   v1 ships the AC4a automation/grep rows; AC4b enumerates 21 rows
   deferred under three trigger classes (see

--- a/packages/agentbundle/agentbundle/commands/install.py
+++ b/packages/agentbundle/agentbundle/commands/install.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import functools
 import re
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -57,6 +57,11 @@ class _ScopePlan:
     allowed_prefixes: list[str] | None
     state: "State"  # the loaded state at this scope (read-only mode)
     already_installed: bool
+    # `.upstream.<ext>` companion relpaths written during this scope's
+    # step-9 projection loop. Threaded to the install marker so the
+    # adapt-to-project skill can surface class-2 work without re-walking
+    # the tree. Stays empty when nothing collided.
+    new_companions: list[str] = field(default_factory=list)
 
 
 def run(args: "argparse.Namespace") -> int:
@@ -427,6 +432,9 @@ def run(args: "argparse.Namespace") -> int:
                 except safety.PathJailError as exc:
                     print(f"install: {exc}", file=sys.stderr)
                     return 1
+                plan.new_companions.append(
+                    safety.companion_path(Path(relpath)).as_posix()
+                )
             else:
                 try:
                     safety.write_jailed(
@@ -496,7 +504,6 @@ def run(args: "argparse.Namespace") -> int:
         if repo_projection is not None
         else []
     )
-    new_companions: list[str] = []  # AC19a field; v1 tally deferred (ROADMAP).
     for plan in plans:
         scope_markers = repo_unresolved_markers if plan.scope == "repo" else []
         try:
@@ -506,7 +513,7 @@ def run(args: "argparse.Namespace") -> int:
                 pack_name=pack_name,
                 pack_version=pack_version,
                 unresolved_markers=scope_markers,
-                new_companions=new_companions,
+                new_companions=plan.new_companions,
                 allowed_prefixes=plan.allowed_prefixes,
             )
         except (OSError, safety.PathJailError) as exc:

--- a/packages/agentbundle/tests/integration/test_install_adapt_chain.py
+++ b/packages/agentbundle/tests/integration/test_install_adapt_chain.py
@@ -58,6 +58,84 @@ def _install(args_dict) -> tuple[int, str, str]:
     return rc, out.getvalue(), err.getvalue()
 
 
+def _stage_pack_with_skill(catalogue_root: Path, name: str, body: str) -> Path:
+    """Stage a pack whose `.apm/skills/<name>/SKILL.md` is non-trivial so
+    the projection lands files at the adopter target (needed to drive a
+    Tier-2 collision in install.py:_classify_for_install)."""
+    pack = catalogue_root / "packs" / name
+    (pack / ".apm" / "skills" / name).mkdir(parents=True)
+    (pack / "pack.toml").write_text(body, encoding="utf-8")
+    (pack / ".apm" / "skills" / name / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: x\n---\nbody-from-bundle\n",
+        encoding="utf-8",
+    )
+    return pack
+
+
+def test_install_marker_records_new_companions(tmp_path):
+    """A Tier-2 collision during install (projection lands on an
+    adopter file that already exists with different content) must
+    surface the companion relpath in the marker's `new-companions`
+    list. The companion path is the `.upstream.<ext>` shape the
+    class-2 adapt skill walks, not the projection relpath itself.
+    """
+    cat = tmp_path / "cat"
+    _stage_pack_with_skill(cat, "demo", ADDON_NO_DEPENDENCIES.replace("addon", "demo"))
+    target = tmp_path / "repo"
+    target.mkdir()
+
+    # Pre-seed an adopter file at one of the projection targets with
+    # different content, forcing the Tier-2 branch.
+    collision_relpath = "claude-plugins/demo/.claude/skills/demo/SKILL.md"
+    collision_full = target / collision_relpath
+    collision_full.parent.mkdir(parents=True)
+    collision_full.write_text("adopter-edited\n", encoding="utf-8")
+
+    rc, _, _ = _install(
+        dict(pack="demo", catalogue=str(cat), output=str(target), scope=None, force=False)
+    )
+    assert rc == 0
+
+    # The companion file landed next to the original.
+    companion_path = target / "claude-plugins/demo/.claude/skills/demo/SKILL.upstream.md"
+    assert companion_path.exists(), (
+        "Tier-2 collision did not write `.upstream` companion; the marker "
+        "assertion below would be untrustworthy without this"
+    )
+
+    marker = tomllib.loads(
+        (target / ".adapt-install-marker.toml").read_text(encoding="utf-8")
+    )
+    entries = marker.get("packs-installed", [])
+    assert len(entries) == 1
+    assert entries[0]["new-companions"] == [
+        "claude-plugins/demo/.claude/skills/demo/SKILL.upstream.md"
+    ]
+
+
+def test_install_marker_companions_empty_on_clean_install(tmp_path):
+    """An install into an empty target produces no Tier-2 collisions;
+    `new-companions = []` survives as a literal in the TOML so the
+    skill reader has a uniform shape to consume."""
+    cat = tmp_path / "cat"
+    _stage_pack_with_skill(cat, "demo", ADDON_NO_DEPENDENCIES.replace("addon", "demo"))
+    target = tmp_path / "repo"
+    target.mkdir()
+
+    rc, _, _ = _install(
+        dict(pack="demo", catalogue=str(cat), output=str(target), scope=None, force=False)
+    )
+    assert rc == 0
+
+    marker_text = (target / ".adapt-install-marker.toml").read_text(encoding="utf-8")
+    assert "new-companions = []" in marker_text, (
+        "regression pin: the field must be emitted even when empty so "
+        "the skill consumer doesn't have to handle a missing-key shape"
+    )
+    marker = tomllib.loads(marker_text)
+    assert marker["packs-installed"][0]["new-companions"] == []
+
+
 def test_install_writes_marker_at_repo_scope_root(tmp_path):
     """Repo-scope install writes the marker at `<repo>/.adapt-install-marker.toml`
     with a single `[[packs-installed]]` entry for the installed pack."""


### PR DESCRIPTION
## Summary

- Threads the actual Tier-2 companion relpaths through `_ScopePlan` into `_append_install_marker`, replacing the hard-coded `new_companions = []`.
- Per-scope: each scope's marker carries only the companions written at that scope (mirrors the `unresolved_markers` shape).
- Closes the `Install-marker new-companions tally` open item on `docs/ROADMAP.md` under `## adapt-to-project — drafted`.

## Why now

The v1 spec example at `docs/specs/adapt-to-project/spec.md:229` names `new-companions = ["packages/_example/AGENTS.upstream.md"]` as load-bearing on every `[[packs-installed]]` entry — the field shape was correct, but the tally itself was deferred at install time. Pure mechanism change; no contract amendment, no new abstraction layer, no spec edit.

## Shape

- `_ScopePlan` gains `new_companions: list[str] = field(default_factory=list)`.
- Step 9's projection-write loop appends `safety.companion_path(Path(relpath)).as_posix()` whenever the Tier-2 branch fires, after a successful `safety.write_companion(...)` call.
- Step 11's marker write passes `plan.new_companions` per scope.
- The empty-collision case still emits `new-companions = []` literally so the adapt-to-project skill consumer reads a uniform shape.

## Test plan

- [x] `test_install_marker_records_new_companions` — pack staged with a non-trivial skill; an adopter file at `claude-plugins/demo/.claude/skills/demo/SKILL.md` pre-exists with different content, forcing Tier-2; the marker's `new-companions` carries `["claude-plugins/demo/.claude/skills/demo/SKILL.upstream.md"]`.
- [x] `test_install_marker_companions_empty_on_clean_install` — install into an empty target produces `new-companions = []` as a literal in the TOML (regression pin against accidentally collapsing empty lists to a missing key).
- [x] `make build-check` — clean.
- [x] `python3 -m pytest packages/agentbundle/tests/ --ignore=packages/agentbundle/tests/integration/test_version_gate_matrix.py` — 361 passed, 1 pre-existing skip.
- [x] Adversarial-reviewer — clean on first pass.

## Out of scope

- Surfacing companion paths in the session-start hook nudge (the field lives on disk for the skill to read; the hook stays at pack-name-union shape).
- A dual-scope test for v1 — user-scope projection is Claude-Code-only and v1 has no realistic pre-existing collision under `~/.claude/...`; the brief gates this row on whether the code actually produces user-scope companions.
- Per-companion metadata (sha, source) — spec contract is `list[str]`, not `list[dict]`.