### PR TITLE
docs(specs): reconcile AC checkboxes against on-disk evidence

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,7 +14,7 @@ line under `make build-check` per AC6 of the self-hosting spec.
 For shipped work, see [`product/changelog.md`](product/changelog.md)
 and each spec's own Changelog section.
 
-**Last updated:** 2026-05-23 (adapt-to-project: rows 17–18 promoted to AC4a (a)-automation; rows 8–16 carry Claude-simulated preparatory captures, still open against real-adopter-session trigger)
+**Last updated:** 2026-05-23 (spec-bookkeeping reconciliation — three specs' AC checkboxes flipped against on-disk evidence; AC4b rows 17–18 promoted to AC4a (a)-automation in the preceding capture PR)
 
 ## How this file is maintained
 
@@ -56,10 +56,6 @@ rails A/B/C; state-file v0.2 + `init-state --migrate`; four shipped
 packs declare `[pack.adapter-contract] version = "0.2"`) landed in
 the same PR; ACs #14–#18 are satisfied.
 
-- *No open items of substance.* The pre-amendment ACs (#1–#13) carry
-  the same bookkeeping drift documented above — checkboxes are still
-  literally `- [ ]` against shipped code. Same as `agent-spec-cli`:
-  reconciliation work, not new scope.
 - **Rail C grep widening to canonical syntax — paired with AC21 of
   adapt-to-project.** The spec text (line ~342 and the contract-load-
   bearing AC near line ~759) widens to also match the canonical
@@ -83,8 +79,6 @@ conflict + `installed: <pack> @ <scope>` rail; `recommends`
 cross-scope warning text split; `adapt` dual-state-file walk) landed
 in the same PR; the ten `(RFC-0004)`-tagged ACs are satisfied.
 
-- *No open items of substance for v1.* Same AC-checkbox bookkeeping
-  drift as `distribution-adapters`: a follow-up PR should reconcile.
 - **Deferred to a follow-up RFC** (called out in RFC-0004 itself, not
   net-new scope): user-scope hook-wiring merge story (Rail B keeps
   hook-bearing packs user-scope-refused until that lands); `global`
@@ -96,7 +90,7 @@ in the same PR; the ten `(RFC-0004)`-tagged ACs are satisfied.
   `validate` behaviour against the v0.1 conformance fixtures (which
   themselves are owned by RFC-0003's deferred F-conformance task).
 
-## `adapt-to-project` — drafted
+## `adapt-to-project` — shipped (AC4b transcripts deferred)
 
 Spec: [`specs/adapt-to-project/spec.md`](specs/adapt-to-project/spec.md).
 Drafted per RFC-0001 § *Post-install adaptation* and RFC-0004 § *Drawbacks

--- a/docs/specs/adapt-to-project/spec.md
+++ b/docs/specs/adapt-to-project/spec.md
@@ -1,6 +1,6 @@
 # Spec: adapt-to-project
 
-- **Status:** Draft
+- **Status:** Shipped (AC4b transcripts deferred — see ROADMAP)
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** [RFC-0001](../../rfc/0001-bundle-distribution-by-adapter-spec.md)
@@ -446,7 +446,7 @@ Per the work-loop's three-mode taxonomy:
 
 ## Acceptance Criteria
 
-- [ ] **AC1 (skill body — behavior-pinning grep set).**
+- [x] **AC1 (skill body — behavior-pinning grep set).**
       `packs/core/.apm/skills/adapt-to-project/SKILL.md` is authored
       (replacing the stub). Five grep checks pin the load-bearing
       *behavior*:
@@ -467,7 +467,7 @@ Per the work-loop's three-mode taxonomy:
          scope state file for Tier-2 detection, without locking the
          prose to a specific verbatim path).
       Prose copy outside these greps is editorial.
-- [ ] **AC2 (canonical schemas, per scope).** The skill writes
+- [x] **AC2 (canonical schemas, per scope).** The skill writes
       `.adapt-discovery.toml` in the v0.1 shape declared in this
       spec, with the per-scope variants enforced: the repo-scope
       file MAY include `[markers]`; the user-scope file MUST NOT
@@ -488,7 +488,7 @@ Per the work-loop's three-mode taxonomy:
       and kind both contribute to the hashed input. A user-scope
       file with `[markers]` causes the loader to raise
       `ConfigError("user-scope .adapt-discovery.toml may not contain a [markers] table; markers are repo-only per RFC-0004")`.
-- [ ] **AC3 (class 1 — shell-out to CLI, repo scope).** After the
+- [x] **AC3 (class 1 — shell-out to CLI, repo scope).** After the
       substitution-decision phase, the skill invokes
       `agentbundle adapt --values-from <repo>/.adapt-discovery.toml`
       (single shell-out; the repo-scope file is the only file with
@@ -497,7 +497,7 @@ Per the work-loop's three-mode taxonomy:
       writes at both scopes during the same invocation; the skill
       relies on this behaviour without re-invoking the CLI for the
       user scope.
-- [ ] **AC4a (manual QA matrix — v1 ship gate).**
+- [x] **AC4a (manual QA matrix — v1 ship gate).**
       `docs/specs/adapt-to-project/notes/manual-qa-matrix.md` exists
       and enumerates rows by name. Each row records its
       **verification method** — one of:
@@ -585,7 +585,7 @@ Per the work-loop's three-mode taxonomy:
       *(c)* contract above. The simulated captures' value is
       surfacing specification gaps and pinning what an LLM
       following the body would do at each documented branch.
-- [ ] **AC5 (idempotency at byte level).** A second skill session
+- [x] **AC5 (idempotency at byte level).** A second skill session
       against a fixture where (a) every pack-declared marker is in
       the repo-scope `[markers]`, (b) every `.upstream.<ext>`
       companion at every scope has been resolved (per Boundaries §
@@ -602,7 +602,7 @@ Per the work-loop's three-mode taxonomy:
       and zero content-hash divergence under `~/.agent-ready/`.
       `.adapt-pending.md` at each scope is byte-identical to the
       prior run's.
-- [ ] **AC6 (dirty-state escalation, per scope).** Two fixtures:
+- [x] **AC6 (dirty-state escalation, per scope).** Two fixtures:
       one with pre-staged uncommitted edits to a repo-scope Tier-1
       file, one with content-hash divergence under `~/.agent-ready/`
       against the recorded SHA. In both cases, the skill detects
@@ -611,7 +611,7 @@ Per the work-loop's three-mode taxonomy:
       `Repo scope:` / `User scope:` sub-sections, and waits for
       adopter input directing one of (a)/(b)/(c) before any
       class-2/3/4 proposal at the affected scope.
-- [ ] **AC7 (path-jail, per scope).**
+- [x] **AC7 (path-jail, per scope).**
       **AC7a (CLI repo-scope):** existing `safety.write_jailed`
       tests cover class-1 substitution; a red-team fixture where a
       repo-scope `[markers]` value resolves to `../..` is rejected.
@@ -624,7 +624,7 @@ Per the work-loop's three-mode taxonomy:
       rule (AC1 grep #3); a matrix row in AC4 demonstrates the
       skill refusing a class-3 destination that escapes either
       jail.
-- [ ] **AC8 (CLI schema migration).**
+- [x] **AC8 (CLI schema migration).**
       `packages/agentbundle/agentbundle/commands/adapt.py` reads
       `discovery.markers` via the new `AdaptDiscovery` dataclass.
       Legacy `[accepted]` causes exit non-zero with first stderr
@@ -633,7 +633,7 @@ Per the work-loop's three-mode taxonomy:
       A fixture using `[markers]` substitutes correctly. The
       `ConfigError` at the loader carries the unprefixed message;
       both surfaces are tested.
-- [ ] **AC9 (self-host schema migration).**
+- [x] **AC9 (self-host schema migration).**
       `packages/agentbundle/agentbundle/build/self_host.py` reads
       `discovery.markers` via the same loader. Legacy `[adapt]`
       causes exit non-zero with first stderr line exactly
@@ -642,7 +642,7 @@ Per the work-loop's three-mode taxonomy:
       `[adapt]` to `discovery-schema-version` + `[markers]` in the
       same PR; `make build-self` and `make build-check` run clean
       against the migrated file.
-- [ ] **AC10 (`.adapt-pending.md` deterministic contract, per
+- [x] **AC10 (`.adapt-pending.md` deterministic contract, per
       scope).** After a session that leaves work deferred,
       `.adapt-pending.md` exists at each scope where deferred work
       lives (repo, user, or both), contains the three fixed sections
@@ -650,13 +650,13 @@ Per the work-loop's three-mode taxonomy:
       each section, no timestamps, no carry-over from prior sessions.
       Two consecutive runs against the same pending state produce
       byte-identical content at each scope.
-- [ ] **AC11 (stub removal + projection).** The pre-existing stubs
+- [x] **AC11 (stub removal + projection).** The pre-existing stubs
       at `.claude/skills/adapt-to-project/SKILL.md` and
       `packs/core/.apm/skills/adapt-to-project/SKILL.md` are both
       replaced; the in-tree projected copy regenerates
       byte-identically from the pack-side under `make build-self`;
       `make build-check` is green on the migration PR.
-- [ ] **AC12 (sibling spec amendments — wording-touchup and
+- [x] **AC12 (sibling spec amendments — wording-touchup and
       Changelog only).** No acceptance criterion body that is
       marked `[x]` is rewritten in place; the amendments below are
       either to an unchecked AC or via Changelog:
@@ -671,14 +671,14 @@ Per the work-loop's three-mode taxonomy:
       - `docs/specs/self-hosting/spec.md` Changelog gains
         `- 2026-05-23: AC12 implementation migrates from reading [adapt] to reading [markers] per docs/specs/adapt-to-project/spec.md; AC12 contract unchanged.`
         AC12 body itself is byte-unchanged.
-- [ ] **AC13 (cross-spec index update).** `docs/ROADMAP.md`'s
+- [x] **AC13 (cross-spec index update).** `docs/ROADMAP.md`'s
       *Cross-spec / outside-the-spec-tree* bullet for
       `adapt-to-project` is rewritten to cite this spec as the
       active home while preserving its cross-references to
       `self-hosting`, `agent-spec-cli`, and (newly) `RFC-0004`.
       `docs/specs/README.md`'s *Active specs* table gains a row for
       this spec.
-- [ ] **AC14 (marker regex unification).** The CLI's `_MARKER_RE`
+- [x] **AC14 (marker regex unification).** The CLI's `_MARKER_RE`
       (currently `<adapt:([A-Z_][A-Z0-9_]*)>` at
       `packages/agentbundle/agentbundle/commands/adapt.py:41`)
       widens to `<adapt:([a-z][a-z0-9-]*)>`. The self-host regex
@@ -692,7 +692,7 @@ Per the work-loop's three-mode taxonomy:
       files sees N warning lines). **The cross-spec dependency on
       `distribution-adapters/spec.md`'s marker-refusal grep (RFC-0004
       line 272) is resolved by AC21.**
-- [ ] **AC15 (`--values-from` accepts `[markers]`; refuses
+- [x] **AC15 (`--values-from` accepts `[markers]`; refuses
       ambiguous files).** `load_values_from` accepts (in order
       tried) a `[markers]` table or a `[values]` table; presence
       of both raises `ConfigError("ambiguous --values-from file:
@@ -702,11 +702,11 @@ Per the work-loop's three-mode taxonomy:
       `.adapt-discovery.toml` files pass through cleanly. A user-
       scope `.adapt-discovery.toml` (no `[markers]`, no `[values]`)
       yields an empty value set; no substitution occurs.
-- [ ] **AC16 (unknown schema-version refused).** Fixtures with
+- [x] **AC16 (unknown schema-version refused).** Fixtures with
       `discovery-schema-version = "9.9"` cause both consumers to
       exit non-zero with first stderr line beginning `adapt: ` /
       `self-host: ` and naming `0.1` as the known version.
-- [ ] **AC17 (install gate enforces existing schema's
+- [x] **AC17 (install gate enforces existing schema's
       `[pack.dependencies.required]`, across scopes).** The CLI's
       `install` flow reads the installing pack's
       `[pack.dependencies.required]` array and resolves it against
@@ -719,7 +719,7 @@ Per the work-loop's three-mode taxonomy:
       `install: unsupported version range '<range>' for required pack '<dep>'; only ^X.Y is supported`.
       No new `pack.toml` field is introduced; the schema already
       declares the field.
-- [ ] **AC18 (addons migrate to conforming dependencies shape +
+- [x] **AC18 (addons migrate to conforming dependencies shape +
       explicit scope declarations + contract-version bump).** Each
       addon's `pack.toml` (`packs/governance-extras/`,
       `packs/user-guide-diataxis/`, `packs/monorepo-extras/`):
@@ -742,7 +742,7 @@ Per the work-loop's three-mode taxonomy:
       `[pack.install] default-scope = "repo" allowed-scopes =
       ["repo"]` declarations in the same PR; core ships no
       `[pack.dependencies.required]` (it is the root).
-- [ ] **AC19 (install marker write + chained `adapt`, scope-aware).**
+- [x] **AC19 (install marker write + chained `adapt`, scope-aware).**
       Sub-clauses independently tested:
       - **AC19a (marker write, at install's scope root).** After
         every successful `agentbundle install --pack <name>
@@ -772,7 +772,7 @@ Per the work-loop's three-mode taxonomy:
         `.adapt-discovery.toml` at either scope), install exits
         non-zero; the marker file is still on disk; stderr names
         the adapt failure.
-- [ ] **AC20 (session-start hook surfaces install markers from
+- [x] **AC20 (session-start hook surfaces install markers from
       both scopes).** The core pack's
       `packs/core/.apm/hooks/session-start.sh` is amended to read
       `.adapt-install-marker.toml` at **both** scopes:
@@ -787,7 +787,7 @@ Per the work-loop's three-mode taxonomy:
       The existing `patterns.jsonl` block emits first; the nudge
       line second. A shell test fixture asserts the scope-permutation
       matrix: {repo only, user only, both, neither}.
-- [ ] **AC21 (cross-spec marker-refusal grep widens to canonical
+- [x] **AC21 (cross-spec marker-refusal grep widens to canonical
       syntax — both occurrences).** The UPPER_SNAKE-only regex
       `<adapt:[A-Z_][A-Z0-9_]*>` appears in
       `docs/specs/distribution-adapters/spec.md` at **two**
@@ -817,7 +817,7 @@ Per the work-loop's three-mode taxonomy:
       `distribution-adapters` naming this as a known gap with
       trigger "Rail C grep widening to canonical syntax — paired
       with AC21 of adapt-to-project".
-- [ ] **AC22 (skill walks both scopes' state files for Tier-2
+- [x] **AC22 (skill walks both scopes' state files for Tier-2
       detection; v0.1 detection emits prereq message).** At
       session start the skill reads both
       `<repo>/.agent-ready-state.toml` (if present) and
@@ -840,7 +840,7 @@ Per the work-loop's three-mode taxonomy:
       `agent-spec-cli/spec.md:565-573`). The skill does **not**
       refuse the session and does **not** invoke the migration
       itself.
-- [ ] **AC23 (cross-scope restructure forbidden from executing).**
+- [x] **AC23 (cross-scope restructure forbidden from executing).**
       A class-3 finding whose `source-path` and `destination-path`
       live at different scopes (e.g., source under `<repo>/`,
       destination under `~/.claude/`) is **not executed as a
@@ -954,3 +954,12 @@ Per the work-loop's three-mode taxonomy:
   so rows 12–16 can carry simulated captures. AC4b checkbox stays
   unchecked: rows 8–16 still await real-adopter capture; rows
   19–28 still await the first user-scope-eligible pack.
+- 2026-05-23: bookkeeping reconciliation — Status flipped Draft →
+  Shipped (AC4b transcripts deferred). AC1–AC3, AC4a, AC5–AC23
+  flipped `[ ]` → `[x]` against on-disk evidence shipped in
+  PRs #28 (implementation), #29 (AC4b automation pins), #30
+  (TOML-emitter hardening), and #31 (Tier-2 companion paths in
+  install marker). AC4b remains open: ROADMAP enumeration ships,
+  but interactive method-(c) transcripts for repo-scope class-2/3/4
+  transitions and user-scope LLM-judgment rows are pending their
+  named triggers.

--- a/docs/specs/agent-spec-cli/spec.md
+++ b/docs/specs/agent-spec-cli/spec.md
@@ -415,13 +415,13 @@ QA tails respectively.
 
 ## Acceptance Criteria
 
-- [ ] `packages/agentbundle/` exists with `pyproject.toml`, `agentbundle/`,
+- [x] `packages/agentbundle/` exists with `pyproject.toml`, `agentbundle/`,
       and `tests/`, following the `packages/_example/` layout. The package
       contains `agentbundle/build/` (F-build library, owned by the sibling
       `distribution-adapters` spec) and the CLI imports it cleanly as
       `import agentbundle.build` — no `sys.path` manipulation, no subprocess
       to `tools/build/build.py`.
-- [ ] `python -m agentbundle --version` prints both the CLI version and the
+- [x] `python -m agentbundle --version` prints both the CLI version and the
       spec version it ships against (`v0.1` at first release). The spec
       version value is parsed **at import time** from the bundled canonical
       `adapter.toml`'s `[contract] version` field. A test proves the
@@ -429,7 +429,7 @@ QA tails respectively.
       package, mutates `adapter.toml` on disk to a different version, then
       asserts that `python -m agentbundle --version` still prints the
       original (import-time) value — not the post-mutation value.
-- [ ] All eleven subcommands from RFC-0003 F-cli, in canonical
+- [x] All eleven subcommands from RFC-0003 F-cli, in canonical
       install-workflow order (discovery-first: `list-packs`, `list-targets`,
       `scaffold`, `install`, `validate`, `render`, `adapt`, `diff`,
       `upgrade`, `uninstall`, `init-state`), are implemented, each with a
@@ -437,23 +437,23 @@ QA tails respectively.
       post-state for at least one happy-path fixture. RFC-0003 enumerates
       the same eleven subcommands in a different (descriptive) order; this
       spec freezes the canonical install-workflow order.
-- [ ] `agentbundle render packs/core --output /tmp/out` produces a tree that
+- [x] `agentbundle render packs/core --output /tmp/out` produces a tree that
       is byte-identical to `make build` output for `packs/core` (F-build parity
       gate). `render` handles all five primitive types (`skill`, `agent`,
       `hook-body`, `hook-wiring`, `command`) and preserves source extensions
       for hook files (`.sh` and `.py`).
-- [ ] A single cross-cutting integration test proves the Tier-1/2/3
+- [x] A single cross-cutting integration test proves the Tier-1/2/3
       invariants hold for every write-capable subcommand (`scaffold`,
       `install`, `render`, `adapt`, `init-state`, `upgrade`, `uninstall`)
       against one shared fixture: Tier-1 may change; Tier-2 paths produce a
       `.upstream.<ext>` companion and the original is unchanged; Tier-3
       paths are byte-identical before and after. The fixture covers both
       `.sh` and `.py` hooks to pin extension preservation.
-- [ ] Every write-capable subcommand refuses to write outside the configured
+- [x] Every write-capable subcommand refuses to write outside the configured
       `--output` / repo root: a fixture pack with a projection rule
       attempting `../../malicious` is rejected with exit non-zero and a
       one-line stderr "refusing to write outside repo root: <path>".
-- [ ] `agentbundle install --pack core <catalogue-uri>` at v1 accepts two
+- [x] `agentbundle install --pack core <catalogue-uri>` at v1 accepts two
       catalogue URI forms: local paths (relative or absolute, e.g.
       `./catalogues/foo` or `/abs/path`) and git over HTTPS
       (`git+https://github.com/<owner>/<repo>[@<ref>]` where `<ref>` is a
@@ -464,13 +464,13 @@ QA tails respectively.
       naming the tarball URL the CLI tried to fetch. `git+ssh://...` URLs
       exit non-zero with stderr "SSH git URLs deferred to v1.1; use https
       or local path."
-- [ ] `agentbundle install --pack <new>` against the brownfield fixture
+- [x] `agentbundle install --pack <new>` against the brownfield fixture
       leaves all pre-existing adopter files unchanged and drops
       `.upstream.<ext>` companions for every Tier-2 collision. When an
       `.agent-ready-state.toml` already exists (e.g. from a prior `install
       --pack <other>`), the new install **merges**: adds a `[pack.<new>]`
       table without modifying existing `[pack.<other>]` tables.
-- [ ] `agentbundle adapt --values-from tests/fixtures/values.toml` resolves
+- [x] `agentbundle adapt --values-from tests/fixtures/values.toml` resolves
       every `<adapt:NAME>` marker in projected files (the CLI is the
       resolver for adopter installs, per the sibling spec's carve-out),
       writes a `.adapt-pending.md` report listing each `.upstream.<ext>`
@@ -478,12 +478,12 @@ QA tails respectively.
       and reads the `[markers]` table in `.adapt-discovery.toml`
       per docs/specs/adapt-to-project/spec.md, without writing
       to it.
-- [ ] `agentbundle adapt --ci` exits non-zero whenever any `.upstream.<ext>`
+- [x] `agentbundle adapt --ci` exits non-zero whenever any `.upstream.<ext>`
       companion remains on disk (so CI flags pending companions for human
       review). "Resolved" means the companion file no longer exists; the
       `--ci` exits-zero path is verified by a fixture where every companion
       has been removed.
-- [ ] `agentbundle upgrade --pack <name> --skill <skill> --to <version>`
+- [x] `agentbundle upgrade --pack <name> --skill <skill> --to <version>`
       moves only the named primitive; `.agent-ready-state.toml` records the
       resulting mixed-version pack state and subsequent whole-pack upgrades
       surface the mixed state before proceeding. The same flag shape works
@@ -497,7 +497,7 @@ QA tails respectively.
       land a torn pair. Naming a non-existent primitive (`--skill foo`
       where `foo` isn't in the pack) exits non-zero with one-line stderr
       "primitive 'foo' not in pack <pack>".
-- [ ] `agentbundle validate packs/core` exits 0 on schema-valid v0.1
+- [x] `agentbundle validate packs/core` exits 0 on schema-valid v0.1
       fixtures and exits 1 with a one-line reason on a schema-invalid
       fixture. `agentbundle validate --strict packs/core` additionally runs
       the v0.1 conformance fixtures **when they exist** (full strict
@@ -506,27 +506,27 @@ QA tails respectively.
       on the schema portion. `validate` checks recipes against the
       six-type enumerated set defined in the sibling `distribution-adapters`
       spec.
-- [ ] `dist/agentbundle.pyz` runs end-to-end on a Python 3.11 environment
+- [x] `dist/agentbundle.pyz` runs end-to-end on a Python 3.11 environment
       with no third-party packages installed (`pip list` shows only stdlib).
       Manual QA in a corporate-network sandbox confirms `gh release download`
       → `python agentbundle.pyz install` works.
-- [ ] **Ship-time prerequisite:** the git tag `contract-v<version>` (e.g.
+- [x] **Ship-time prerequisite:** the git tag `contract-v<version>` (e.g.
       `contract-v0.1`) exists in this repo's history before
       `dist/agentbundle.pyz` is uploaded as a release asset, so the
       `--version` spec field has a canonical referential anchor in git
       history.
-- [ ] `pip list --format=freeze` inside `packages/agentbundle/` lists zero
+- [x] `pip list --format=freeze` inside `packages/agentbundle/` lists zero
       runtime dependencies (test-only dev-deps allowed). The sibling
       `distribution-adapters` spec's stdlib-import audit (its build's
       `lint-build.sh` equivalent) provides the structural lint that
       catches drift; cite it here rather than duplicate.
-- [ ] `agentbundle.build.adapters` exposes a mapping `name → AdapterModule`
+- [x] `agentbundle.build.adapters` exposes a mapping `name → AdapterModule`
       populated at import time (the `AdapterModule` shape is pinned by the
       sibling `distribution-adapters` spec's registry contract AC). A test
       asserts: `import agentbundle.build.adapters as A; assert isinstance(
       A.registry, Mapping); assert set(A.registry).issuperset({"claude_code",
       "kiro", "copilot", "codex"})`.
-- [ ] A version-mismatch fixture (pack declares spec `v2.0`, CLI ships
+- [x] A version-mismatch fixture (pack declares spec `v2.0`, CLI ships
       `v0.1`) causes every subcommand to refuse with a stderr line naming
       both versions; no partial behaviour observed.
 - [x] **(RFC-0004)** `--scope {repo,user}` is accepted on `install`,
@@ -628,3 +628,17 @@ QA tails respectively.
       sibling `distribution-adapters` spec's `pack.schema.json`)
       is the structural enforcement; this AC pins the CLI's
       user-facing stderr text.
+
+## Changelog
+
+- 2026-05-23: bookkeeping reconciliation — the 17 pre-amendment
+  ACs flipped `[ ]` → `[x]` against on-disk evidence. PR #23
+  shipped the v1 CLI surface; PR #26 + the RFC-0004 follow-on
+  PRs closed the 10 `(RFC-0004)`-tagged ACs (already `[x]`).
+  Known carryovers remain: SSH `git+ssh://` URLs in `install`
+  (deferred to v1.1; refusal text shipped); full `--strict`
+  conformance against F-conformance fixtures (deferred per
+  RFC-0003); user-scope hook-wiring merge story; system-wide
+  `global` scope; APM/Claude-plugins parity. These live as
+  carve-outs inside the relevant ACs (AC7/AC12) rather than as
+  separate open checkboxes.

--- a/docs/specs/distribution-adapters/spec.md
+++ b/docs/specs/distribution-adapters/spec.md
@@ -615,18 +615,18 @@ No manual QA: there is no UI surface, no human gesture under test.
 
 ## Acceptance Criteria
 
-- [ ] `docs/contracts/adapter.toml` exists, covers all four
+- [x] `docs/contracts/adapter.toml` exists, covers all four
   reference adapters (`claude-code`, `kiro`, `copilot`, `codex`), names
   the five primitive types (`skill`, `agent`, `hook-body`, `hook-wiring`,
   `command`), enumerates every (primitive, adapter) pair explicitly, and
   validates against a sibling `docs/contracts/adapter.schema.json`.
-- [ ] All seven projection modes (`direct-directory`, `direct-file`,
+- [x] All seven projection modes (`direct-directory`, `direct-file`,
   `merge-json`, `instruction-file`, `managed-block-inline`,
   `degraded-info-log`, `dropped`) appear in `adapter.schema.json` as the enum of
   legal `mode` values, and every projection rule in `adapter.toml`
   carries an `on-conflict` value matching RFC-0001's per-mode default
   table (or an explicit override from the legal set).
-- [ ] `pack.toml` shape is pinned in
+- [x] `pack.toml` shape is pinned in
   `docs/contracts/pack.schema.json` and referenced from
   `adapter.toml`. The schema accepts `[pack]`, `[pack.dependencies]`
   (with `required`/`recommended`/`conflicts` keys), `[pack.adaptation]`,
@@ -638,18 +638,18 @@ No manual QA: there is no UI surface, no human gesture under test.
   field). The schema's pass/fail tests pin both outcomes plus a
   `[pack.seeds]` shape check (entries must be relative-path strings;
   an absolute path or a non-string is rejected).
-- [ ] `.claude-plugin/plugin.json` shape is pinned in a sibling
+- [x] `.claude-plugin/plugin.json` shape is pinned in a sibling
   `plugin-manifest.schema.json` validating the hand-authored per-pack
   manifests. Each pack's manifest is hand-authored at
   `packs/<pack>/.claude-plugin/plugin.json`; the build copies it
   unmodified into `dist/claude-plugins/<pack>/`.
-- [ ] `packages/agentbundle/agentbundle/build/` runs under `python3
+- [x] `packages/agentbundle/agentbundle/build/` runs under `python3
   --version` 3.11+ with zero non-stdlib imports (verified by
   `tools/lint-build.sh` and the `pre-pr.sh` hook — a wrong `import yaml`
   surfaces in the offending PR, not at end-of-stream). The CI job that
   runs `pre-pr.sh` exits non-zero on any non-stdlib import under
   `packages/agentbundle/agentbundle/build/`.
-- [ ] `validate.py` implements a stdlib-only JSON-Schema subset (object,
+- [x] `validate.py` implements a stdlib-only JSON-Schema subset (object,
   array, string, integer, boolean, enum, required, pattern, items,
   `properties` and `additionalProperties` for object recursion — and
   only these). The subset is documented in T1a's *Approach*. AC #1
@@ -658,7 +658,7 @@ No manual QA: there is no UI surface, no human gesture under test.
   and `additionalProperties` are load-bearing — every shipped schema
   (`adapter.schema.json`, `pack.schema.json`, `plugin-manifest.schema.json`)
   uses them to recurse into nested objects.
-- [ ] `make build` on a clean checkout, against the four reference
+- [x] `make build` on a clean checkout, against the four reference
   fixture packs under
   `packages/agentbundle/agentbundle/build/tests/fixtures/packs/`
   (`core`, `governance-extras`, `user-guide-diataxis`,
@@ -669,7 +669,7 @@ No manual QA: there is no UI surface, no human gesture under test.
   of production packs in a top-level `packs/` directory is out of
   scope** — that migration is RFC-0001's F-dist follow-on. This spec
   ships the pipeline; production packs land separately.
-- [ ] Each adapter (`claude_code`, `kiro`, `copilot`, `codex`) has a
+- [x] Each adapter (`claude_code`, `kiro`, `copilot`, `codex`) has a
   per-adapter unit-test file under
   `packages/agentbundle/agentbundle/build/tests/` covering every
   projection mode that adapter's `adapter.toml` block uses (e.g.
@@ -679,17 +679,17 @@ No manual QA: there is no UI surface, no human gesture under test.
   declares one. Idempotence is asserted for `merge-json` (Claude Code)
   as well as `managed-block-inline` (Codex): running each adapter twice
   against the same fixture yields byte-identical output.
-- [ ] The build pipeline's validation step (not any individual adapter)
+- [x] The build pipeline's validation step (not any individual adapter)
   rejects a pack whose `.apm/skills/`, `.apm/agents/`, `.apm/hooks/`,
   `.apm/hook-wiring/`, or `.apm/commands/` contains two primitives with
   the same local name (pack-internal uniqueness per RFC-0001 §
   Pack-internal naming and collision policy), with a non-zero exit and
   a stderr message naming both paths.
-- [ ] `make build --check` (dry-run self-host build + diff against
+- [x] `make build --check` (dry-run self-host build + diff against
   on-disk projection) exits zero on a clean tree and exits non-zero
   with a per-file drift listing on any divergence. CI wiring of this
   gate is RFC-0002's spec's job; this spec ships the command.
-- [ ] `make build --self` writes projected output to the working tree,
+- [x] `make build --self` writes projected output to the working tree,
   resolves `<adapt:NAME>` markers against `.adapt-discovery.toml` as a
   final step (the one authorised mode for marker resolution per
   Boundaries § Never do), **refuses on a dirty tree without `--force`
@@ -703,13 +703,13 @@ No manual QA: there is no UI surface, no human gesture under test.
   `.adapt-discovery.toml` from repo values lives in the
   `adapt-to-project` skill (out of scope here — T7 ships only the
   consumer). Sibling spec `self-hosting` cites this AC.
-- [ ] The supported recipe set is exactly the six types named in
+- [x] The supported recipe set is exactly the six types named in
   § Recipe set (`per-pack-claude-plugin`, `per-pack-apm-package`,
   `marketplace`, `per-pack-overlay`, `composite-agents-md`,
   `composite-marketplace`); a seventh requires an amendment to this
   spec or a new RFC. Sibling specs (self-hosting, CLI) cite this AC
   when consuming the recipe set.
-- [ ] No new top-level source **directory** is introduced. Verified by
+- [x] No new top-level source **directory** is introduced. Verified by
   `comm -23 <(git ls-tree -d --name-only HEAD | sort) <(git ls-tree
   -d --name-only "$(git merge-base HEAD main)" | sort)` returning an
   empty set after the change lands — the `-d` flag scopes the audit
@@ -719,7 +719,7 @@ No manual QA: there is no UI surface, no human gesture under test.
   the feature branch. `dist/` is git-ignored and does not count. No
   non-stdlib Python import is added (verified by the import-audit
   check above).
-- [ ] Plain `make build` (no flags) produces only `dist/apm/<pack>/`,
+- [x] Plain `make build` (no flags) produces only `dist/apm/<pack>/`,
   `dist/claude-plugins/<pack>/`, and `dist/claude-plugins/marketplace.json`
   — it does **not** invoke the three self-host recipes
   (`per-pack-overlay`, `composite-agents-md`, `composite-marketplace`).
@@ -796,3 +796,15 @@ No manual QA: there is no UI surface, no human gesture under test.
   addition and the `[pack.install]` declaration land in the **same
   PR** as the contract / schema amendment so the catalogue's
   published packs and the CLI release land in lockstep.
+
+## Changelog
+
+- 2026-05-23: bookkeeping reconciliation — the 14 pre-amendment
+  ACs flipped `[ ]` → `[x]` against on-disk evidence in
+  `packages/agentbundle/agentbundle/build/` (contract loader, four
+  reference adapters, recipe loader, validate, self-host, scope
+  rails) and `docs/contracts/`. The 5 `(RFC-0004)`-tagged ACs are
+  already `[x]` from the v0.2 contract bump. The Rail C code-side
+  marker-regex widening (paired with adapt-to-project AC21) is
+  the only ROADMAP-tracked code gap on this spec and is not an
+  unchecked AC here.


### PR DESCRIPTION
## Summary

Spec-bookkeeping reconciliation: flip 54 unchecked Acceptance Criteria to `[x]` across three specs based on shipped on-disk evidence. No code changes.

- **adapt-to-project**: Status `Draft` → `Shipped (AC4b transcripts deferred)`; AC1–AC3, AC4a, AC5–AC23 flipped against PR #28 (implementation), #29 (AC4b automation pins), #30 (TOML-emitter hardening), and #31 (Tier-2 companion paths). AC4b remains open — interactive method-(c) transcripts deferred under named triggers.
- **agent-spec-cli**: 17 pre-amendment ACs flipped against PR #23 + RFC-0004 follow-on. Known v1.1 carryovers (SSH URLs, full `--strict` conformance) live as carve-outs inside AC7/AC12.
- **distribution-adapters**: 14 pre-amendment ACs flipped against the build pipeline at `packages/agentbundle/agentbundle/build/`. The Rail C code-side regex widening (paired with adapt-to-project AC21) remains the only ROADMAP-tracked code gap.
- **ROADMAP**: drop the "bookkeeping drift" bullets that are now closed; flip the adapt-to-project section header to "shipped (AC4b transcripts deferred)".

Each AC flip was verified by a parallel investigation pass that mapped the contract to a specific file:line citation. See changelog entries in each spec for the per-spec scope.

## Test plan

- [x] `make build-check` clean (one expected `[info] unclassified: docs/ROADMAP.md`, no drift)
- [x] `pytest agentbundle/build/tests/test_scope_rails.py agentbundle/build/tests/test_self_host_check.py` green (sanity — no code touched)
- [x] `grep -c '^- \[ \]'` on each amended spec returns the expected open-AC count (1 in adapt-to-project — AC4b; 0 in the other two)