### PR TITLE
feat(scope-rails): widen Rail C marker regex to canonical lowercase-hyphen

### DIFF
--- a/packages/agentbundle/agentbundle/build/scope_rails.py
+++ b/packages/agentbundle/agentbundle/build/scope_rails.py
@@ -24,9 +24,13 @@ Rails:
     wiring merge story is designed in a follow-up RFC.
 
   - **Rail C — `<adapt:NAME>` markers.** A pack declaring `"user" ∈
-    allowed-scopes` cannot carry the marker regex
-    `<adapt:[A-Z_][A-Z0-9_]*>` in any file under `.apm/skills/`,
-    `.apm/agents/`, or `.apm/commands/`. The rail walks those
+    allowed-scopes` cannot carry either the legacy UPPER_SNAKE marker
+    form `<adapt:[A-Z_][A-Z0-9_]*>` *or* the canonical lowercase-hyphen
+    form `<adapt:[a-z][a-z0-9-]*>` in any file under `.apm/skills/`,
+    `.apm/agents/`, or `.apm/commands/`. Both casings are recognised
+    per `adapt-to-project` spec AC14 (canonical syntax) and AC21
+    (cross-spec widening) so a user-scope pack carrying lowercase-
+    hyphen markers cannot bypass the rail. The rail walks those
     directories in `sorted(os.walk(...))` order so the first-offending-
     path stderr message is deterministic across runs and platforms.
     Non-UTF-8 (binary) files are skipped silently — they cannot contain
@@ -50,7 +54,13 @@ from pathlib import Path
 from typing import Iterable
 
 
-_MARKER_REGEX = re.compile(rb"<adapt:[A-Z_][A-Z0-9_]*>")
+# Both legacy UPPER_SNAKE and canonical lowercase-hyphen marker forms
+# are recognised per adapt-to-project spec AC14 + AC21. The canonical
+# form is what self_host.resolve_markers writes; the legacy form is
+# tolerated with a one-shot per-file warning during the migration
+# window. Rail C refuses either form in user-scope packs because both
+# would survive into a user-scope projection and bypass the contract.
+_MARKER_REGEX = re.compile(rb"<adapt:(?:[A-Z_][A-Z0-9_]*|[a-z][a-z0-9-]*)>")
 
 # The three primitive source directories Rail C walks. `.apm/hooks/` and
 # `.apm/hook-wiring/` are already user-scope-refused by Rail B, so a

--- a/packages/agentbundle/agentbundle/build/tests/test_scope_rails.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_scope_rails.py
@@ -134,7 +134,8 @@ class RailBHooksTests(unittest.TestCase):
 class RailCMarkersTests(unittest.TestCase):
     """`<adapt:NAME>` markers under .apm/skills/, /agents/, /commands/ refused."""
 
-    def test_rail_c_refuses_marker_in_skill_with_user_scope(self) -> None:
+    def test_rail_c_refuses_upper_snake_marker_in_skill_with_user_scope(self) -> None:
+        """Legacy UPPER_SNAKE form `<adapt:NAME>` is refused."""
         from agentbundle.build.scope_rails import check_markers
 
         with tempfile.TemporaryDirectory() as td:
@@ -149,18 +150,60 @@ class RailCMarkersTests(unittest.TestCase):
             self.assertIsNotNone(result)
             self.assertIn(".apm/skills/my-skill/SKILL.md", result)
 
-    def test_rail_c_rejects_only_strict_marker(self) -> None:
-        """The grep matches `<adapt:[A-Z_][A-Z0-9_]*>` strictly."""
+    def test_rail_c_refuses_lowercase_hyphen_marker_in_skill_with_user_scope(self) -> None:
+        """Canonical lowercase-hyphen form `<adapt:project-name>` is refused.
+
+        Closes the AC21 carve-out: until the code-side widening, a
+        user-scope pack carrying the canonical marker form passed
+        `validate` in code even though the spec contract refused it.
+        """
         from agentbundle.build.scope_rails import check_markers
 
         with tempfile.TemporaryDirectory() as td:
             pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
-            skills_dir = pack / ".apm" / "skills" / "lowercase"
+            skills_dir = pack / ".apm" / "skills" / "my-skill"
             skills_dir.mkdir(parents=True)
-            # Lowercase marker — must not match.
-            (skills_dir / "SKILL.md").write_text("plays with <adapt:lowercase>")
-            # Wrong-cased prefix — must not match.
-            (skills_dir / "OTHER.md").write_text("plays with <ADAPT:NAME>")
+            (skills_dir / "SKILL.md").write_text(
+                "# My skill\n\nDoes <adapt:project-name> things.\n"
+            )
+
+            result = check_markers(pack, ["user"])
+            self.assertIsNotNone(result)
+            self.assertIn(".apm/skills/my-skill/SKILL.md", result)
+
+    def test_rail_c_refuses_lowercase_marker_in_agent_with_user_scope(self) -> None:
+        """Canonical form is refused under `.apm/agents/` too (rail directory coverage)."""
+        from agentbundle.build.scope_rails import check_markers
+
+        with tempfile.TemporaryDirectory() as td:
+            pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
+            agents_dir = pack / ".apm" / "agents"
+            agents_dir.mkdir(parents=True)
+            (agents_dir / "reviewer.md").write_text("Owner: <adapt:owner>\n")
+
+            result = check_markers(pack, ["user"])
+            self.assertIsNotNone(result)
+            self.assertIn(".apm/agents/reviewer.md", result)
+
+    def test_rail_c_accepts_non_marker_strings(self) -> None:
+        """Strings that resemble markers but don't match either grammar pass.
+
+        Wrong-cased prefix `<ADAPT:NAME>` and mixed-case names like
+        `<adapt:MixedCase>` are not valid markers under either casing
+        and must not trigger the rail.
+        """
+        from agentbundle.build.scope_rails import check_markers
+
+        with tempfile.TemporaryDirectory() as td:
+            pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
+            skills_dir = pack / ".apm" / "skills" / "non-markers"
+            skills_dir.mkdir(parents=True)
+            # Wrong-cased prefix — must not match either grammar.
+            (skills_dir / "A.md").write_text("plays with <ADAPT:NAME>")
+            # Mixed-case name — matches neither UPPER_SNAKE nor lowercase-hyphen.
+            (skills_dir / "B.md").write_text("plays with <adapt:MixedCase>")
+            # Empty name — matches neither grammar.
+            (skills_dir / "C.md").write_text("plays with <adapt:>")
             self.assertIsNone(check_markers(pack, ["user"]))
 
     def test_rail_c_does_not_inspect_repo_only_pack(self) -> None:


### PR DESCRIPTION
## Summary

Closes the AC21 carve-out from \`adapt-to-project/spec.md\` and the *Rail C grep widening to canonical syntax* entry under \`distribution-adapters\` in \`docs/ROADMAP.md\`.

Before this change, \`agentbundle.build.scope_rails._MARKER_REGEX\` matched only the legacy UPPER_SNAKE form \`<adapt:[A-Z_][A-Z0-9_]*>\`. A user-scope pack carrying canonical lowercase-hyphen markers (\`<adapt:project-name>\`) — the form \`self_host.resolve_markers\` writes — passed \`validate\` in code even though the spec contract refused it. The regex now accepts either grammar via alternation:

\`\`\`python
_MARKER_REGEX = re.compile(rb\"<adapt:(?:[A-Z_][A-Z0-9_]*|[a-z][a-z0-9-]*)>\")
\`\`\`

Mixed-case names and wrong-cased prefixes (\`<ADAPT:NAME>\`) still fail the rail because neither inner grammar matches them.

## Test plan

- [x] \`test_rail_c_refuses_upper_snake_marker_in_skill_with_user_scope\` — legacy UPPER_SNAKE form still refused (renamed from \`test_rail_c_refuses_marker_in_skill_with_user_scope\`)
- [x] \`test_rail_c_refuses_lowercase_hyphen_marker_in_skill_with_user_scope\` — canonical form now refused (new)
- [x] \`test_rail_c_refuses_lowercase_marker_in_agent_with_user_scope\` — coverage under \`.apm/agents/\` (new)
- [x] \`test_rail_c_accepts_non_marker_strings\` — wrong-cased prefix, mixed-case names, empty names all pass (replaces \`test_rail_c_rejects_only_strict_marker\`)
- [x] All 19 tests in \`test_scope_rails.py\` green
- [x] \`make build-check\` clean (one expected \`[info] unclassified: docs/ROADMAP.md\`)

The 8 pre-existing test failures in the agentbundle suite (\`test_end_to_end_build.py\`, \`test_validate.py\`, \`test_pipeline.py::UnknownRecipeTests\`) exist on \`origin/main\` and are unrelated to this change — confirmed by running the same suite against a clean stash.