### PR TITLE
feat(self-host): strengthen diff comparison with LF norm + mode + lstat

### DIFF
--- a/docs/specs/self-hosting/plan.md
+++ b/docs/specs/self-hosting/plan.md
@@ -1,7 +1,7 @@
 # Plan: self-hosting
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Phase 1 shipped; Phase 2 pending
+- **Status:** Shipped
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
 > document is allowed to change as you learn. When it changes substantially
@@ -24,12 +24,11 @@
 >   drift-message source-path + regen-command naming,
 >   `[info]` lines for unclassified paths, and `.adapt-discovery.toml`
 >   marker resolution across the widened scope.
-> - **Remaining Phase 2** (follow-up PR): comparison-rule strengthening —
->   LF normalisation, file-mode bits, symlink-target via `lstat`
->   (load-bearing for gate correctness; deserves its own test pass +
->   adversarial review). AGENTS.md body+footer composition and the
->   Codex multi-pack managed-block splice are closed by the 2026-05-23
->   AC8 pass.
+> - **Phase 2 (closed):** AGENTS.md body+footer composition + Codex
+>   multi-pack managed-block splice closed by the 2026-05-23 AC8
+>   pass; comparison-rule strengthening (LF normalisation, file-mode
+>   bits, symlink-target via `lstat`) closed by the 2026-05-23 final
+>   pass per the Changelog. No Phase 3.
 > - CLI surface in task bodies uses RFC-0002's flag form (`--self`,
 >   `--force`, `--dry-run`). The on-disk Makefile equivalents are
 >   `make build-self`, `make build-self FORCE=1`, and
@@ -511,13 +510,25 @@ T6's PR diff.
 
 ## Changelog
 
+- 2026-05-23: Phase 2 closed. Comparison-rule strengthening landed:
+  CRLF→LF normalisation for text-like files, file-mode permission-bit
+  comparison for regular files, and symlink-target comparison via
+  `lstat` (never following). Implementation in
+  `agentbundle/build/self_host.py::diff_against_working_tree`; per-rule
+  unit tests (`CrlfNormalisationTests`, `FileModeBitsTests`,
+  `SymlinkTargetTests`) plus one integration test
+  (`StrengthenedDiffRegressionIntegrationTests`) pairing each rule
+  with the regression it was added to catch. All 40
+  `test_self_host_check.py` cases green; `make build-check` clean.
+  Plan status flips to Shipped.
 - 2026-05-23: executed the Codex-dependent Phase-2 slice for AC8.
   Added Codex multi-pack aggregation before managed-block splicing,
   widened `SELF_HOST_ADAPTERS` to `claude-code` + `codex`, materialised
   `packs/core/seeds/AGENTS.md`, and wired self-host `AGENTS.md`
   composition as body + Codex-managed skills block + footer. Focused
   unit tests and `make build-check` passed. The comparison-rule
-  strengthening task remains open.
+  strengthening task remained open at the time and was closed in the
+  follow-up entry above.
 - 2026-05-22: initial plan.
 - 2026-05-22: applied cross-cutting decisions CC1–CC6 (canonical
   spec directory `docs/specs/self-hosting/`; singular `docs/rfc/` /

--- a/docs/specs/self-hosting/spec.md
+++ b/docs/specs/self-hosting/spec.md
@@ -1,6 +1,6 @@
 # Spec: self-hosting
 
-- **Status:** Phase 1 shipped; Phase 2 pending
+- **Status:** Shipped
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** [RFC-0001](../../rfc/0001-bundle-distribution-by-adapter-spec.md), [RFC-0002](../../rfc/0002-self-hosting.md)
@@ -101,10 +101,10 @@ This spec therefore partitions its scope into **two cutover phases**:
   Phase 1 also ships packs/* sources, the recipe TOMLs,
   `.adapt-discovery.toml`, the `make build-check` workflow, and the
   CONVENTIONS amendment.
-- **Phase 2 (follow-up PR).** AGENTS.md body+footer composition and
-  Codex multi-pack managed-block aggregation have landed. The remaining
-  Phase-2 work is comparison-rule strengthening (LF normalisation,
-  file-mode bits, symlink-target comparison via `lstat`).
+- **Phase 2 (closed).** AGENTS.md body+footer composition, Codex
+  multi-pack managed-block aggregation, and the comparison-rule
+  strengthening (LF normalisation, file-mode bits, symlink-target
+  comparison via `lstat`) all landed. See Changelog.
 
 Every *Always do*, *Ask first*, *Never do*, Acceptance Criterion, and
 test below carries an implicit "Phase 1 only" unless it names Phase 2
@@ -146,14 +146,14 @@ explicitly. Phase-2-deferred items are tagged `(Phase 2)`.
   `adapt-to-project` skill (deferred); for self-host, materialize a
   repo-local `.adapt-discovery.toml` with this repo's concrete values
   and apply it. All other build modes copy markers through unchanged.
-- Compare projected output against on-disk content as bytes. *(Phase 2)*
-  Strengthen the comparison to byte-for-byte after CRLF→LF normalisation,
-  with file mode bits compared for regular files and symlink targets
-  compared via `lstat` (never follow symlinks). Phase 1's
-  `diff_against_working_tree` uses `read_bytes()` equality — sufficient
-  for the adapter-driven primitives the gate covers today; the
-  LF-normalising / mode-aware / lstat path lands alongside seed
-  projection in Phase 2.
+- Compare projected output against on-disk content with three rules,
+  all landed in Phase 2: byte-for-byte after CRLF→LF normalisation
+  for text-like files (UTF-8-decodable inputs only — binaries that
+  happen to contain a 0x0D 0x0A pair are compared raw); file-mode
+  permission-bit comparison for regular files (low 9 bits); and
+  symlink-target comparison via `lstat` — the gate never follows a
+  symlink. Implementation: `diff_against_working_tree` in
+  `agentbundle.build.self_host`.
 - Enumerate candidate paths from the git-tracked + untracked-but-not-
   ignored set (`git ls-files --cached --others --exclude-standard`), so
   editor scratch and gitignored build outputs do not surface in either
@@ -471,3 +471,15 @@ and the Codex multi-pack aggregation fix land.
   [RFC-0001 § Amendments](../../rfc/0001-bundle-distribution-by-adapter-spec.md#amendments)
   for the full rationale and the `CONVENTIONS.md:80` exception note.
 - 2026-05-23: AC12 implementation migrates from reading [adapt] to reading [markers] per docs/specs/adapt-to-project/spec.md; AC12 contract unchanged.
+- 2026-05-23: Phase 2 closed. `diff_against_working_tree` strengthens
+  the comparison along the three rules the spec named: CRLF→LF
+  normalisation for text-like files (UTF-8-decodable inputs only),
+  file-mode permission-bit comparison for regular files (low 9 bits;
+  setuid/setgid/sticky out of scope), and symlink-target comparison
+  via `lstat` — never following the link. Implementation in
+  `packages/agentbundle/agentbundle/build/self_host.py`; per-rule
+  unit tests + one integration test pairing each rule with the
+  regression it was added to catch live in `tests/test_self_host_check.py`
+  under `CrlfNormalisationTests`, `FileModeBitsTests`,
+  `SymlinkTargetTests`, and `StrengthenedDiffRegressionIntegrationTests`.
+  Status flips to Shipped — no Phase 3.

--- a/packages/agentbundle/agentbundle/build/self_host.py
+++ b/packages/agentbundle/agentbundle/build/self_host.py
@@ -34,6 +34,7 @@ import json
 import os
 import re
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -598,6 +599,32 @@ def _emit_info_for_unclassified(
         print(f"[info] unclassified: {relative.as_posix()}", file=sys.stderr)
 
 
+def _is_text_like(data: bytes) -> bool:
+    """A file that decodes as UTF-8 is text-like for LF normalisation.
+
+    Empty files are text. Anything that fails UTF-8 decode is binary —
+    binaries that happen to contain a 0x0D 0x0A byte pair must not be
+    normalised, since the bytes carry value beyond line termination.
+    """
+    if not data:
+        return True
+    try:
+        data.decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+    return True
+
+
+def _normalise_lf(data: bytes) -> bytes:
+    """Replace CRLF with LF for text-like equality comparison.
+
+    Bare CR is left in place — it's neither a portable line terminator
+    nor a `core.autocrlf` artefact, and rewriting it would hide real
+    content drift in test fixtures that exercise mac-classic endings.
+    """
+    return data.replace(b"\r\n", b"\n")
+
+
 def diff_against_working_tree(
     shadow: Path,
     working_tree: Path,
@@ -606,10 +633,30 @@ def diff_against_working_tree(
     """Compare every file in `shadow` against the corresponding path in
     `working_tree`. When `source_map` is provided, drift messages name
     the source path and regeneration command per spec § *Always do*
-    (`[drift] <projected>: edit <source>; run: make build-self`)."""
+    (`[drift] <projected>: edit <source>; run: make build-self`).
+
+    Phase-2 strengthening per the self-hosting spec:
+
+    - **CRLF→LF normalisation** for text-like files (those that decode
+      as UTF-8). Binary content is compared byte-for-byte. A CRLF-on-
+      disk text file no longer drifts against an LF-in-source file
+      — the same content shape ``git status`` already accommodates via
+      ``core.autocrlf``.
+    - **File-mode permission bits** for regular files. A projected
+      ``0o644`` against an on-disk ``0o755`` drifts. Only the low 9
+      permission bits are compared; setuid/setgid/sticky are not part
+      of the projection contract.
+    - **Symlink targets via ``lstat``** — the gate never follows a
+      symlink. A symlink/regular type mismatch drifts; matching
+      symlinks with different targets drift.
+    """
     drifts: list[str] = []
     for rendered in shadow.rglob("*"):
-        if not rendered.is_file():
+        try:
+            shadow_st = os.lstat(rendered)
+        except OSError:
+            continue
+        if not (stat.S_ISREG(shadow_st.st_mode) or stat.S_ISLNK(shadow_st.st_mode)):
             continue
         relative = rendered.relative_to(shadow)
         on_disk = working_tree / relative
@@ -620,18 +667,76 @@ def diff_against_working_tree(
                 hint = (
                     f": edit {source.as_posix()}; run: make build-self"
                 )
-        if not on_disk.exists():
+
+        try:
+            disk_st = os.lstat(on_disk)
+        except FileNotFoundError:
             drifts.append(
                 f"[drift] {relative.as_posix()} (missing on disk){hint}"
             )
             continue
-        try:
-            if rendered.read_bytes() != on_disk.read_bytes():
-                drifts.append(f"[drift] {relative.as_posix()}{hint}")
         except OSError as exc:
             drifts.append(
                 f"[drift] {relative.as_posix()} (unreadable: {exc}){hint}"
             )
+            continue
+
+        shadow_is_link = stat.S_ISLNK(shadow_st.st_mode)
+        disk_is_link = stat.S_ISLNK(disk_st.st_mode)
+
+        if shadow_is_link != disk_is_link:
+            expected = "symlink" if shadow_is_link else "regular file"
+            found = "regular file" if shadow_is_link else "symlink"
+            drifts.append(
+                f"[drift] {relative.as_posix()} "
+                f"(expected {expected}, found {found} on disk){hint}"
+            )
+            continue
+
+        if shadow_is_link:
+            try:
+                shadow_target = os.readlink(rendered)
+                disk_target = os.readlink(on_disk)
+            except OSError as exc:
+                drifts.append(
+                    f"[drift] {relative.as_posix()} "
+                    f"(unreadable symlink: {exc}){hint}"
+                )
+                continue
+            if shadow_target != disk_target:
+                drifts.append(
+                    f"[drift] {relative.as_posix()} "
+                    f"(symlink target differs: {disk_target!r} vs {shadow_target!r})"
+                    f"{hint}"
+                )
+            continue
+
+        reasons: list[str] = []
+
+        shadow_mode = stat.S_IMODE(shadow_st.st_mode)
+        disk_mode = stat.S_IMODE(disk_st.st_mode)
+        if shadow_mode != disk_mode:
+            reasons.append(f"mode {oct(disk_mode)} vs {oct(shadow_mode)}")
+
+        try:
+            shadow_bytes = rendered.read_bytes()
+            disk_bytes = on_disk.read_bytes()
+        except OSError as exc:
+            drifts.append(
+                f"[drift] {relative.as_posix()} (unreadable: {exc}){hint}"
+            )
+            continue
+
+        if shadow_bytes != disk_bytes:
+            if _is_text_like(shadow_bytes) and _is_text_like(disk_bytes):
+                if _normalise_lf(shadow_bytes) != _normalise_lf(disk_bytes):
+                    reasons.append("content differs")
+            else:
+                reasons.append("content differs")
+
+        if reasons:
+            tag = " (" + "; ".join(reasons) + ")"
+            drifts.append(f"[drift] {relative.as_posix()}{tag}{hint}")
     return drifts
 
 

--- a/packages/agentbundle/agentbundle/build/tests/test_self_host_check.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_self_host_check.py
@@ -1040,5 +1040,214 @@ class PlainBuildCopiesMarkerThroughTests(unittest.TestCase):
             self.assertIn("<adapt:project-name>", text)
 
 
+class CrlfNormalisationTests(unittest.TestCase):
+    """Phase-2 comparison rule (a): text-like files compare equal after
+    CRLF→LF normalisation. Pins the spec's CRLF + `core.autocrlf` case."""
+
+    def test_crlf_on_disk_lf_in_shadow_is_not_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            shadow = Path(tmp) / "shadow"
+            tree = Path(tmp) / "tree"
+            shadow.mkdir()
+            tree.mkdir()
+            (shadow / "doc.md").write_bytes(b"hello\nworld\n")
+            (tree / "doc.md").write_bytes(b"hello\r\nworld\r\n")
+
+            self.assertEqual(diff_against_working_tree(shadow, tree), [])
+
+    def test_trailing_space_after_lf_normalisation_drifts(self) -> None:
+        """LF norm doesn't whitewash genuine content differences."""
+        with tempfile.TemporaryDirectory() as tmp:
+            shadow = Path(tmp) / "shadow"
+            tree = Path(tmp) / "tree"
+            shadow.mkdir()
+            tree.mkdir()
+            (shadow / "doc.md").write_bytes(b"hello\nworld\n")
+            (tree / "doc.md").write_bytes(b"hello \nworld\n")  # extra space
+
+            drifts = diff_against_working_tree(shadow, tree)
+            self.assertEqual(len(drifts), 1)
+            self.assertIn("doc.md", drifts[0])
+            self.assertIn("content differs", drifts[0])
+
+    def test_binary_files_not_normalised(self) -> None:
+        """A non-UTF-8 binary that happens to contain 0x0D 0x0A must not
+        be normalised — the bytes carry value beyond line termination."""
+        with tempfile.TemporaryDirectory() as tmp:
+            shadow = Path(tmp) / "shadow"
+            tree = Path(tmp) / "tree"
+            shadow.mkdir()
+            tree.mkdir()
+            # Two binary blobs that would be equal under LF normalisation
+            # but differ byte-for-byte. The leading 0xFF makes them
+            # un-decodable as UTF-8.
+            (shadow / "icon.bin").write_bytes(b"\xff\x00\r\n\x01")
+            (tree / "icon.bin").write_bytes(b"\xff\x00\n\x01")
+
+            drifts = diff_against_working_tree(shadow, tree)
+            self.assertEqual(len(drifts), 1)
+            self.assertIn("icon.bin", drifts[0])
+            self.assertIn("content differs", drifts[0])
+
+
+class FileModeBitsTests(unittest.TestCase):
+    """Phase-2 comparison rule (b): mode bits drift for regular files."""
+
+    def test_mode_bits_drift_for_regular_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            shadow = Path(tmp) / "shadow"
+            tree = Path(tmp) / "tree"
+            shadow.mkdir()
+            tree.mkdir()
+            (shadow / "hook.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+            (tree / "hook.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+            os.chmod(shadow / "hook.sh", 0o755)
+            os.chmod(tree / "hook.sh", 0o644)
+
+            drifts = diff_against_working_tree(shadow, tree)
+            self.assertEqual(len(drifts), 1)
+            self.assertIn("hook.sh", drifts[0])
+            self.assertIn("mode 0o644 vs 0o755", drifts[0])
+
+    def test_matching_mode_no_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            shadow = Path(tmp) / "shadow"
+            tree = Path(tmp) / "tree"
+            shadow.mkdir()
+            tree.mkdir()
+            (shadow / "hook.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+            (tree / "hook.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+            os.chmod(shadow / "hook.sh", 0o755)
+            os.chmod(tree / "hook.sh", 0o755)
+
+            self.assertEqual(diff_against_working_tree(shadow, tree), [])
+
+
+class SymlinkTargetTests(unittest.TestCase):
+    """Phase-2 comparison rule (c): symlink targets compared via lstat,
+    never followed. Pins the CLAUDE.md → AGENTS.md gate."""
+
+    def test_symlink_target_mismatch_drifts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            shadow = Path(tmp) / "shadow"
+            tree = Path(tmp) / "tree"
+            shadow.mkdir()
+            tree.mkdir()
+            os.symlink("AGENTS.md", shadow / "CLAUDE.md")
+            os.symlink("README.md", tree / "CLAUDE.md")
+
+            drifts = diff_against_working_tree(shadow, tree)
+            self.assertEqual(len(drifts), 1)
+            self.assertIn("CLAUDE.md", drifts[0])
+            self.assertIn("symlink target differs", drifts[0])
+            self.assertIn("AGENTS.md", drifts[0])
+            self.assertIn("README.md", drifts[0])
+
+    def test_matching_symlinks_no_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            shadow = Path(tmp) / "shadow"
+            tree = Path(tmp) / "tree"
+            shadow.mkdir()
+            tree.mkdir()
+            os.symlink("AGENTS.md", shadow / "CLAUDE.md")
+            os.symlink("AGENTS.md", tree / "CLAUDE.md")
+
+            self.assertEqual(diff_against_working_tree(shadow, tree), [])
+
+    def test_symlink_in_shadow_regular_on_disk_drifts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            shadow = Path(tmp) / "shadow"
+            tree = Path(tmp) / "tree"
+            shadow.mkdir()
+            tree.mkdir()
+            # Create a target so shadow's symlink "looks" valid in isolation.
+            (shadow / "AGENTS.md").write_text("body", encoding="utf-8")
+            os.symlink("AGENTS.md", shadow / "CLAUDE.md")
+            # On-disk: a regular file with identical content.
+            (tree / "AGENTS.md").write_text("body", encoding="utf-8")
+            (tree / "CLAUDE.md").write_text("body", encoding="utf-8")
+
+            drifts = diff_against_working_tree(shadow, tree)
+            type_mismatch = [d for d in drifts if "CLAUDE.md" in d and "expected symlink" in d]
+            self.assertEqual(len(type_mismatch), 1)
+
+    def test_symlink_target_never_followed(self) -> None:
+        """A dangling symlink does not crash the gate — the target is
+        compared as a string, no read-through happens."""
+        with tempfile.TemporaryDirectory() as tmp:
+            shadow = Path(tmp) / "shadow"
+            tree = Path(tmp) / "tree"
+            shadow.mkdir()
+            tree.mkdir()
+            os.symlink("/nonexistent/target", shadow / "ptr")
+            os.symlink("/nonexistent/target", tree / "ptr")
+
+            # Equal targets → no drift, even though neither target exists.
+            self.assertEqual(diff_against_working_tree(shadow, tree), [])
+
+
+class StrengthenedDiffRegressionIntegrationTests(unittest.TestCase):
+    """Integration: one fixture exercising all three Phase-2 rules.
+
+    Each rule is paired with the regression it was added to catch:
+    CRLF accidentally drifting against LF source; an executable bit
+    silently dropped during projection; a CLAUDE.md → AGENTS.md
+    symlink replaced by a regular file or pointed at the wrong target.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.contract = load_contract(CONTRACT_PATH)
+
+    def test_each_rule_catches_its_regression(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            shadow = Path(tmp) / "shadow"
+            tree = Path(tmp) / "tree"
+            shadow.mkdir()
+            tree.mkdir()
+
+            # Rule (a) regression: same content, LF in shadow, CRLF on
+            # disk. The pre-Phase-2 gate would have drifted; the
+            # strengthened gate must NOT.
+            (shadow / "doc.md").write_bytes(b"hello\nworld\n")
+            (tree / "doc.md").write_bytes(b"hello\r\nworld\r\n")
+
+            # Rule (b) regression: an executable hook script whose
+            # +x bit gets dropped on disk.
+            (shadow / "hook.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+            (tree / "hook.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+            os.chmod(shadow / "hook.sh", 0o755)
+            os.chmod(tree / "hook.sh", 0o644)
+
+            # Rule (c) regression: CLAUDE.md → AGENTS.md projected as a
+            # symlink, but on disk it points at the wrong target. The
+            # gate must not follow the symlinks — read_bytes would
+            # accidentally compare AGENTS.md vs README.md content and
+            # might have hidden the regression.
+            (shadow / "AGENTS.md").write_text("agents-body", encoding="utf-8")
+            (shadow / "README.md").write_text("readme-body", encoding="utf-8")
+            (tree / "AGENTS.md").write_text("agents-body", encoding="utf-8")
+            (tree / "README.md").write_text("readme-body", encoding="utf-8")
+            os.symlink("AGENTS.md", shadow / "CLAUDE.md")
+            os.symlink("README.md", tree / "CLAUDE.md")
+
+            drifts = diff_against_working_tree(shadow, tree)
+
+            # Rule (a): no drift on the CRLF-vs-LF file.
+            self.assertFalse(
+                any("doc.md" in d for d in drifts),
+                f"doc.md drifted despite CRLF→LF normalisation: {drifts}",
+            )
+            # Rule (b): mode drift surfaced.
+            mode_drifts = [d for d in drifts if "hook.sh" in d]
+            self.assertEqual(len(mode_drifts), 1)
+            self.assertIn("mode 0o644 vs 0o755", mode_drifts[0])
+            # Rule (c): symlink-target drift surfaced; the gate did
+            # NOT follow through to compare AGENTS.md content.
+            symlink_drifts = [d for d in drifts if "CLAUDE.md" in d]
+            self.assertEqual(len(symlink_drifts), 1)
+            self.assertIn("symlink target differs", symlink_drifts[0])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Closes the final Phase-2 item on the self-hosting spec: comparison-rule strengthening. \`diff_against_working_tree\` previously compared via \`read_bytes()\` equality, which left three regression classes invisible to \`make build-check\`. The strengthened gate applies three rules — each paired with the regression it was added to prevent:

- **CRLF→LF normalisation for text-like files.** UTF-8-decodable inputs only; binaries that happen to contain \`0x0D 0x0A\` are compared raw. Pre-Phase-2, a CRLF-on-disk text file drifted against an LF-in-source file even though \`git status\` accommodates the same shape via \`core.autocrlf\`.
- **File-mode permission-bit comparison for regular files.** Low 9 bits only; setuid/setgid/sticky are out of scope. Pre-Phase-2, a hook script projected as \`0o755\` could silently land on disk as \`0o644\` without the gate noticing.
- **Symlink-target comparison via \`lstat\` — never following.** Pre-Phase-2, a wrong-target \`CLAUDE.md\` symlink was hidden because \`read_bytes()\` resolved the link and compared \`AGENTS.md\` content on both sides.

Spec + plan flipped to \`Status: Shipped\`; the Phase-2 narrative and *Always do* comparison clause reconciled with reality. The corresponding bullet in \`docs/ROADMAP.md\` is left to a follow-up cleanup (this PR is bounded to no-shared-files with the spec-bookkeeping PR).

## Test plan

- [x] \`CrlfNormalisationTests\` (3 tests): CRLF↔LF equality; LF-norm doesn't whitewash content; binaries not normalised
- [x] \`FileModeBitsTests\` (2 tests): mode drift surfaced; matching mode silent
- [x] \`SymlinkTargetTests\` (4 tests): target mismatch; matching targets silent; symlink↔regular type mismatch; targets never followed (dangling-symlink case)
- [x] \`StrengthenedDiffRegressionIntegrationTests\`: one fixture exercising all three rules with the regression each was designed to catch
- [x] All 40 \`test_self_host_check.py\` cases green (30 prior + 10 new)
- [x] All 19 \`test_scope_rails.py\` cases green
- [x] \`make build-check\` clean