### PR TITLE
feat(contract): bump adapter contract to v0.3 with hook-shape schema (T1)

### DIFF
--- a/docs/contracts/adapter.schema.json
+++ b/docs/contracts/adapter.schema.json
@@ -24,7 +24,6 @@
       "type": "object",
       "additionalProperties": {
         "type": "object",
-        "required": ["projection"],
         "properties": {
           "projection": {
             "type": "array",
@@ -42,6 +41,8 @@
                     "direct-directory",
                     "direct-file",
                     "merge-json",
+                    "user-merge-json",
+                    "merge-into-agent-json",
                     "instruction-file",
                     "managed-block-inline",
                     "degraded-info-log",
@@ -62,6 +63,105 @@
                 "managed-key": {"type": "string"},
                 "managed-block-delimiter-start": {"type": "string"},
                 "managed-block-delimiter-end": {"type": "string"},
+                "frontmatter-mapping": {"type": "string"},
+                "frontmatter-default": {"type": "string"},
+                "info-message": {"type": "string"}
+              }
+            }
+          },
+          "projections": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "required": ["mode"],
+              "properties": {
+                "mode": {
+                  "if": {"type": "string"},
+                  "then": {
+                    "enum": [
+                      "direct-directory",
+                      "direct-file",
+                      "merge-json",
+                      "user-merge-json",
+                      "merge-into-agent-json",
+                      "instruction-file",
+                      "managed-block-inline",
+                      "degraded-info-log",
+                      "dropped"
+                    ]
+                  },
+                  "else": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "repo": {
+                        "enum": [
+                          "direct-directory",
+                          "direct-file",
+                          "merge-json",
+                          "user-merge-json",
+                          "merge-into-agent-json",
+                          "instruction-file",
+                          "managed-block-inline",
+                          "degraded-info-log",
+                          "dropped"
+                        ]
+                      },
+                      "user": {
+                        "enum": [
+                          "direct-directory",
+                          "direct-file",
+                          "merge-json",
+                          "user-merge-json",
+                          "merge-into-agent-json",
+                          "instruction-file",
+                          "managed-block-inline",
+                          "degraded-info-log",
+                          "dropped"
+                        ]
+                      }
+                    }
+                  }
+                },
+                "target": {
+                  "if": {"type": "string"},
+                  "then": {},
+                  "else": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "repo": {"type": "string"},
+                      "user": {"type": "string"}
+                    }
+                  }
+                },
+                "managed-key": {
+                  "if": {"type": "string"},
+                  "then": {},
+                  "else": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "repo": {"type": "string"},
+                      "user": {"type": "string"}
+                    }
+                  }
+                },
+                "agent-event-vocabulary": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {"type": "string"}
+                },
+                "on-conflict": {
+                  "type": "string",
+                  "enum": [
+                    "prompt-then-preserve",
+                    "prompt-then-overwrite",
+                    "preserve-outside-block",
+                    "merge-managed-key-only",
+                    "overwrite-without-prompt"
+                  ]
+                },
                 "frontmatter-mapping": {"type": "string"},
                 "frontmatter-default": {"type": "string"},
                 "info-message": {"type": "string"}

--- a/docs/contracts/adapter.toml
+++ b/docs/contracts/adapter.toml
@@ -1,10 +1,11 @@
 # Adapter contract — every (primitive × adapter) pair enumerated.
 # Validates against ./adapter.schema.json.
 # Managed by: docs/specs/distribution-adapters/spec.md
-# RFC reference: RFC-0001 (base contract); RFC-0004 (scope dimension, v0.2)
+# RFC reference: RFC-0001 (base contract); RFC-0004 (scope dimension, v0.2);
+# RFC-0005 (hook-body / hook-wiring forks, v0.3).
 
 [contract]
-version = "0.2"
+version = "0.3"
 
 # Sibling schemas this contract references — pack metadata and the
 # per-pack Claude-plugin manifest. Defined by spec AC #3 + #4.
@@ -32,7 +33,14 @@ source-path = ".apm/hook-wiring/"
 source-path = ".apm/commands/"
 
 # ---------------------------------------------------------------------------
-# Claude Code adapter — 5 projections (one per primitive)
+# Claude Code adapter — 5 projections (one per primitive) + v0.3 forks
+#
+# The legacy `[[adapter."claude-code".projection]]` array carries the
+# repo-scope shape every adapter has consumed since v0.1. RFC-0005 adds two
+# forward-looking `[adapter."claude-code".projections.<primitive>]` tables
+# (hook-body / hook-wiring) carrying the scope-conditional shape that the
+# v0.3 user-scope pipeline reads. Until that pipeline lands, the legacy
+# entries remain authoritative; the new tables are declarative metadata.
 # ---------------------------------------------------------------------------
 
 [[adapter."claude-code".projection]]
@@ -66,6 +74,24 @@ mode = "direct-file"
 target-path = ".claude/commands/"
 on-conflict = "prompt-then-preserve"
 
+# hook-body — scope-conditional target (RFC-0005 § hook-body at user scope).
+# Forward-looking v0.3 declaration; the legacy array entry above remains the
+# pipeline-of-record until T5/T7 land.
+[adapter."claude-code".projections.hook-body]
+mode = "direct-file"
+target.repo = "tools/hooks/<name>.{sh,py}"
+target.user = ".claude/hooks/<name>.{sh,py}"
+on-conflict = "prompt-then-preserve"
+
+# hook-wiring — scope-conditional mode/target; user-scope `managed-key`
+# required (RFC-0005 § hook-wiring for Claude Code at user scope).
+[adapter."claude-code".projections.hook-wiring]
+mode.repo = "merge-json"
+mode.user = "user-merge-json"
+target.repo = ".claude/settings.local.json"
+target.user = ".claude/settings.json"
+managed-key.user = "hooks"
+
 # Scope dimension (RFC-0004). Two roots: repo-local and user-local.
 # `allowed-prefixes.<scope>` fences every write under that scope to a
 # declared prefix list — at user scope this stops a buggy projection
@@ -79,7 +105,13 @@ user = "~"
 allowed-prefixes.user = [".claude/", ".agent-ready/"]
 
 # ---------------------------------------------------------------------------
-# Kiro adapter — 5 projections (one per primitive)
+# Kiro adapter
+#
+# RFC-0005 promotes Kiro `hook-wiring` out of `degraded-info-log` to the new
+# `merge-into-agent-json` mode — the legacy degraded entry is removed (per
+# AC2). `hook-body` keeps its legacy `direct-file → tools/hooks/` array entry
+# and additionally declares a v0.3 scope-conditional table for the user-scope
+# pipeline T5/T7 will land. Skill, agent, command remain in the array.
 # ---------------------------------------------------------------------------
 
 [[adapter.kiro.projection]]
@@ -102,13 +134,43 @@ target-path = "tools/hooks/"
 on-conflict = "prompt-then-preserve"
 
 [[adapter.kiro.projection]]
-primitive = "hook-wiring"
-mode = "degraded-info-log"
-info-message = "Kiro hook-wiring schema not yet published (RFC-0001 Open Q1); hook wiring not projected."
-
-[[adapter.kiro.projection]]
 primitive = "command"
 mode = "dropped"
+
+# hook-body — scope-conditional target. User-scope lands under `~/.kiro/hooks/`
+# per RFC-0005 § hook-body at user scope. Forward-looking v0.3 declaration;
+# the legacy array entry above remains authoritative until T5/T7.
+[adapter.kiro.projections.hook-body]
+mode = "direct-file"
+target.repo = "tools/hooks/<name>.{sh,py}"
+target.user = ".kiro/hooks/<name>.{sh,py}"
+on-conflict = "prompt-then-preserve"
+
+# hook-wiring — merge into the pack-owned agent JSON. Same mode at both scopes;
+# the agent-file target is scope-conditional via scope-root resolution
+# (RFC-0005 § hook-wiring for Kiro at both scopes). The legacy
+# `degraded-info-log` array entry is removed (AC2).
+[adapter.kiro.projections.hook-wiring]
+mode = "merge-into-agent-json"
+target.repo = ".kiro/agents/<attach-to-agent>.json"
+target.user = ".kiro/agents/<attach-to-agent>.json"
+managed-key = "hooks"
+agent-event-vocabulary = [
+  "agentSpawn",
+  "userPromptSubmit",
+  "preToolUse",
+  "postToolUse",
+  "stop",
+]
+
+# Scope dimension for Kiro (RFC-0005 § hook-wiring for Kiro at both scopes).
+# User-scope agents live under `~/.kiro/agents/` per Kiro's documented layout
+# (https://kiro.dev/docs/cli/custom-agents/creating/); CLI infrastructure
+# shares the `.agent-ready/` prefix.
+[adapter.kiro.scope]
+repo = "."
+user = "~"
+allowed-prefixes.user = [".kiro/", ".agent-ready/"]
 
 # ---------------------------------------------------------------------------
 # Copilot adapter — 5 projections (one per primitive)

--- a/docs/contracts/pack.schema.json
+++ b/docs/contracts/pack.schema.json
@@ -99,7 +99,7 @@
         "properties": {
           "adapter-contract": {
             "type": "object",
-            "properties": {"version": {"enum": ["0.2"]}},
+            "properties": {"version": {"enum": ["0.2", "0.3"]}},
             "required": ["version"]
           }
         },
@@ -117,7 +117,8 @@
                 "type": "array",
                 "minItems": 1,
                 "items": {"enum": ["repo", "user"]}
-              }
+              },
+              "user-scope-hooks": {"type": "boolean"}
             },
             "if": {
               "properties": {"default-scope": {"enum": ["user"]}},

--- a/packages/agentbundle/agentbundle/_data/adapter.schema.json
+++ b/packages/agentbundle/agentbundle/_data/adapter.schema.json
@@ -24,7 +24,6 @@
       "type": "object",
       "additionalProperties": {
         "type": "object",
-        "required": ["projection"],
         "properties": {
           "projection": {
             "type": "array",
@@ -42,6 +41,8 @@
                     "direct-directory",
                     "direct-file",
                     "merge-json",
+                    "user-merge-json",
+                    "merge-into-agent-json",
                     "instruction-file",
                     "managed-block-inline",
                     "degraded-info-log",
@@ -62,6 +63,105 @@
                 "managed-key": {"type": "string"},
                 "managed-block-delimiter-start": {"type": "string"},
                 "managed-block-delimiter-end": {"type": "string"},
+                "frontmatter-mapping": {"type": "string"},
+                "frontmatter-default": {"type": "string"},
+                "info-message": {"type": "string"}
+              }
+            }
+          },
+          "projections": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "required": ["mode"],
+              "properties": {
+                "mode": {
+                  "if": {"type": "string"},
+                  "then": {
+                    "enum": [
+                      "direct-directory",
+                      "direct-file",
+                      "merge-json",
+                      "user-merge-json",
+                      "merge-into-agent-json",
+                      "instruction-file",
+                      "managed-block-inline",
+                      "degraded-info-log",
+                      "dropped"
+                    ]
+                  },
+                  "else": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "repo": {
+                        "enum": [
+                          "direct-directory",
+                          "direct-file",
+                          "merge-json",
+                          "user-merge-json",
+                          "merge-into-agent-json",
+                          "instruction-file",
+                          "managed-block-inline",
+                          "degraded-info-log",
+                          "dropped"
+                        ]
+                      },
+                      "user": {
+                        "enum": [
+                          "direct-directory",
+                          "direct-file",
+                          "merge-json",
+                          "user-merge-json",
+                          "merge-into-agent-json",
+                          "instruction-file",
+                          "managed-block-inline",
+                          "degraded-info-log",
+                          "dropped"
+                        ]
+                      }
+                    }
+                  }
+                },
+                "target": {
+                  "if": {"type": "string"},
+                  "then": {},
+                  "else": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "repo": {"type": "string"},
+                      "user": {"type": "string"}
+                    }
+                  }
+                },
+                "managed-key": {
+                  "if": {"type": "string"},
+                  "then": {},
+                  "else": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "repo": {"type": "string"},
+                      "user": {"type": "string"}
+                    }
+                  }
+                },
+                "agent-event-vocabulary": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {"type": "string"}
+                },
+                "on-conflict": {
+                  "type": "string",
+                  "enum": [
+                    "prompt-then-preserve",
+                    "prompt-then-overwrite",
+                    "preserve-outside-block",
+                    "merge-managed-key-only",
+                    "overwrite-without-prompt"
+                  ]
+                },
                 "frontmatter-mapping": {"type": "string"},
                 "frontmatter-default": {"type": "string"},
                 "info-message": {"type": "string"}

--- a/packages/agentbundle/agentbundle/_data/adapter.toml
+++ b/packages/agentbundle/agentbundle/_data/adapter.toml
@@ -1,10 +1,11 @@
 # Adapter contract — every (primitive × adapter) pair enumerated.
 # Validates against ./adapter.schema.json.
 # Managed by: docs/specs/distribution-adapters/spec.md
-# RFC reference: RFC-0001 (base contract); RFC-0004 (scope dimension, v0.2)
+# RFC reference: RFC-0001 (base contract); RFC-0004 (scope dimension, v0.2);
+# RFC-0005 (hook-body / hook-wiring forks, v0.3).
 
 [contract]
-version = "0.2"
+version = "0.3"
 
 # Sibling schemas this contract references — pack metadata and the
 # per-pack Claude-plugin manifest. Defined by spec AC #3 + #4.
@@ -32,7 +33,14 @@ source-path = ".apm/hook-wiring/"
 source-path = ".apm/commands/"
 
 # ---------------------------------------------------------------------------
-# Claude Code adapter — 5 projections (one per primitive)
+# Claude Code adapter — 5 projections (one per primitive) + v0.3 forks
+#
+# The legacy `[[adapter."claude-code".projection]]` array carries the
+# repo-scope shape every adapter has consumed since v0.1. RFC-0005 adds two
+# forward-looking `[adapter."claude-code".projections.<primitive>]` tables
+# (hook-body / hook-wiring) carrying the scope-conditional shape that the
+# v0.3 user-scope pipeline reads. Until that pipeline lands, the legacy
+# entries remain authoritative; the new tables are declarative metadata.
 # ---------------------------------------------------------------------------
 
 [[adapter."claude-code".projection]]
@@ -66,6 +74,24 @@ mode = "direct-file"
 target-path = ".claude/commands/"
 on-conflict = "prompt-then-preserve"
 
+# hook-body — scope-conditional target (RFC-0005 § hook-body at user scope).
+# Forward-looking v0.3 declaration; the legacy array entry above remains the
+# pipeline-of-record until T5/T7 land.
+[adapter."claude-code".projections.hook-body]
+mode = "direct-file"
+target.repo = "tools/hooks/<name>.{sh,py}"
+target.user = ".claude/hooks/<name>.{sh,py}"
+on-conflict = "prompt-then-preserve"
+
+# hook-wiring — scope-conditional mode/target; user-scope `managed-key`
+# required (RFC-0005 § hook-wiring for Claude Code at user scope).
+[adapter."claude-code".projections.hook-wiring]
+mode.repo = "merge-json"
+mode.user = "user-merge-json"
+target.repo = ".claude/settings.local.json"
+target.user = ".claude/settings.json"
+managed-key.user = "hooks"
+
 # Scope dimension (RFC-0004). Two roots: repo-local and user-local.
 # `allowed-prefixes.<scope>` fences every write under that scope to a
 # declared prefix list — at user scope this stops a buggy projection
@@ -79,7 +105,13 @@ user = "~"
 allowed-prefixes.user = [".claude/", ".agent-ready/"]
 
 # ---------------------------------------------------------------------------
-# Kiro adapter — 5 projections (one per primitive)
+# Kiro adapter
+#
+# RFC-0005 promotes Kiro `hook-wiring` out of `degraded-info-log` to the new
+# `merge-into-agent-json` mode — the legacy degraded entry is removed (per
+# AC2). `hook-body` keeps its legacy `direct-file → tools/hooks/` array entry
+# and additionally declares a v0.3 scope-conditional table for the user-scope
+# pipeline T5/T7 will land. Skill, agent, command remain in the array.
 # ---------------------------------------------------------------------------
 
 [[adapter.kiro.projection]]
@@ -102,13 +134,43 @@ target-path = "tools/hooks/"
 on-conflict = "prompt-then-preserve"
 
 [[adapter.kiro.projection]]
-primitive = "hook-wiring"
-mode = "degraded-info-log"
-info-message = "Kiro hook-wiring schema not yet published (RFC-0001 Open Q1); hook wiring not projected."
-
-[[adapter.kiro.projection]]
 primitive = "command"
 mode = "dropped"
+
+# hook-body — scope-conditional target. User-scope lands under `~/.kiro/hooks/`
+# per RFC-0005 § hook-body at user scope. Forward-looking v0.3 declaration;
+# the legacy array entry above remains authoritative until T5/T7.
+[adapter.kiro.projections.hook-body]
+mode = "direct-file"
+target.repo = "tools/hooks/<name>.{sh,py}"
+target.user = ".kiro/hooks/<name>.{sh,py}"
+on-conflict = "prompt-then-preserve"
+
+# hook-wiring — merge into the pack-owned agent JSON. Same mode at both scopes;
+# the agent-file target is scope-conditional via scope-root resolution
+# (RFC-0005 § hook-wiring for Kiro at both scopes). The legacy
+# `degraded-info-log` array entry is removed (AC2).
+[adapter.kiro.projections.hook-wiring]
+mode = "merge-into-agent-json"
+target.repo = ".kiro/agents/<attach-to-agent>.json"
+target.user = ".kiro/agents/<attach-to-agent>.json"
+managed-key = "hooks"
+agent-event-vocabulary = [
+  "agentSpawn",
+  "userPromptSubmit",
+  "preToolUse",
+  "postToolUse",
+  "stop",
+]
+
+# Scope dimension for Kiro (RFC-0005 § hook-wiring for Kiro at both scopes).
+# User-scope agents live under `~/.kiro/agents/` per Kiro's documented layout
+# (https://kiro.dev/docs/cli/custom-agents/creating/); CLI infrastructure
+# shares the `.agent-ready/` prefix.
+[adapter.kiro.scope]
+repo = "."
+user = "~"
+allowed-prefixes.user = [".kiro/", ".agent-ready/"]
 
 # ---------------------------------------------------------------------------
 # Copilot adapter — 5 projections (one per primitive)

--- a/packages/agentbundle/agentbundle/_data/pack.schema.json
+++ b/packages/agentbundle/agentbundle/_data/pack.schema.json
@@ -99,7 +99,7 @@
         "properties": {
           "adapter-contract": {
             "type": "object",
-            "properties": {"version": {"enum": ["0.2"]}},
+            "properties": {"version": {"enum": ["0.2", "0.3"]}},
             "required": ["version"]
           }
         },
@@ -117,7 +117,8 @@
                 "type": "array",
                 "minItems": 1,
                 "items": {"enum": ["repo", "user"]}
-              }
+              },
+              "user-scope-hooks": {"type": "boolean"}
             },
             "if": {
               "properties": {"default-scope": {"enum": ["user"]}},

--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro.py
@@ -67,7 +67,23 @@ class KiroAdapterTests(unittest.TestCase):
             # `tools: Read` source should normalize to a list.
             self.assertIn("[Read]", agent_text)
 
-    def test_hook_wiring_emits_info_log_and_no_file(self) -> None:
+    def test_hook_wiring_array_entry_removed(self) -> None:
+        """AC2: the legacy `degraded-info-log` kiro hook-wiring entry is gone."""
+        kiro_array_primitives = {
+            entry["primitive"]
+            for entry in self.contract["adapter"]["kiro"].get("projection", [])
+        }
+        self.assertNotIn(
+            "hook-wiring",
+            kiro_array_primitives,
+            "legacy kiro hook-wiring projection array entry still present",
+        )
+
+    def test_hook_wiring_no_info_log_emitted(self) -> None:
+        """No info-log fires for kiro hook-wiring under v0.3 (the legacy
+        `degraded-info-log` array entry that produced it has been removed).
+        The v0.3 `merge-into-agent-json` projection is wired up in T5/T6 —
+        this test pins the regression of the prior runtime behaviour."""
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             pack = _seed_pack(tmp_path)
@@ -75,11 +91,11 @@ class KiroAdapterTests(unittest.TestCase):
             buf = io.StringIO()
             with redirect_stderr(buf):
                 project(pack, self.contract, out)
-            stderr_text = buf.getvalue()
-            self.assertIn("[info]", stderr_text)
-            self.assertIn("hook-wiring", stderr_text)
-            # No hook-wiring output anywhere.
-            self.assertFalse(any(out.rglob("*.toml")))
+            self.assertNotIn(
+                "hook-wiring",
+                buf.getvalue(),
+                "kiro adapter emitted a hook-wiring info-log after AC2 removal",
+            )
 
     def test_hook_body_extensions_preserved(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/packages/agentbundle/agentbundle/build/tests/test_contract.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_contract.py
@@ -103,11 +103,18 @@ class AllPairsEnumeratedTests(unittest.TestCase):
         self.assertEqual(adapters, ALL_ADAPTERS, f"adapter keys differ: {adapters}")
 
     def test_every_primitive_covered_per_adapter(self) -> None:
+        """Every (primitive × adapter) pair must be declared in *some* form.
+
+        Under v0.3 (RFC-0005), kiro's `hook-wiring` no longer appears in the
+        legacy `projection` array — it lives in the new
+        `projections.<primitive>` table. The coverage union walks both forms.
+        """
         missing: list[str] = []
         extra: list[str] = []
         for adapter_name, adapter_block in self.contract["adapter"].items():
-            projections = adapter_block["projection"]
-            primitives_in_adapter = {p["primitive"] for p in projections}
+            array_form = {p["primitive"] for p in adapter_block.get("projection", [])}
+            table_form = set(adapter_block.get("projections", {}).keys())
+            primitives_in_adapter = array_form | table_form
             for prim in ALL_PRIMITIVES:
                 if prim not in primitives_in_adapter:
                     missing.append(f"({prim}, {adapter_name})")
@@ -118,17 +125,26 @@ class AllPairsEnumeratedTests(unittest.TestCase):
         self.assertEqual(extra, [], f"extra unknown primitives: {extra}")
 
     def test_exactly_twenty_pairs_total(self) -> None:
-        total = sum(
-            len(adapter_block["projection"])
-            for adapter_block in self.contract["adapter"].values()
-        )
+        """Twenty (primitive × adapter) pairs — counted across array + table forms.
+
+        Pairs that appear in BOTH forms (the transitional hook-body declarations
+        on claude-code/kiro and the claude-code hook-wiring legacy entry that
+        coexists with its v0.3 table) count once per adapter, matching the
+        "primitive coverage" semantic.
+        """
+        total = 0
+        for adapter_block in self.contract["adapter"].values():
+            array_form = {p["primitive"] for p in adapter_block.get("projection", [])}
+            table_form = set(adapter_block.get("projections", {}).keys())
+            total += len(array_form | table_form)
         self.assertEqual(total, 20, f"expected 20 pairs total, got {total}")
 
 
 class ModeEnumTests(unittest.TestCase):
-    """adapter.schema.json mode enum must contain exactly the seven RFC-0001 modes."""
+    """adapter.schema.json mode enum: seven RFC-0001 modes plus the two
+    v0.3 additions from RFC-0005 (`user-merge-json`, `merge-into-agent-json`)."""
 
-    def test_mode_enum_contains_exactly_seven_modes(self) -> None:
+    def test_mode_enum_contains_expected_modes(self) -> None:
         schema = _load_schema()
         # Navigate to the mode enum inside projection items.
         projection_items = (
@@ -137,10 +153,11 @@ class ModeEnumTests(unittest.TestCase):
             ]["items"]
         )
         mode_enum = set(projection_items["properties"]["mode"]["enum"])
+        expected = SEVEN_RFC_MODES | {"user-merge-json", "merge-into-agent-json"}
         self.assertEqual(
             mode_enum,
-            SEVEN_RFC_MODES,
-            f"schema mode enum differs from RFC-0001 set: {mode_enum}",
+            expected,
+            f"schema mode enum differs from RFC-0001+RFC-0005 set: {mode_enum}",
         )
 
     def test_schema_rejects_unknown_mode(self) -> None:

--- a/packages/agentbundle/tests/unit/test_contract_v0_3_schema.py
+++ b/packages/agentbundle/tests/unit/test_contract_v0_3_schema.py
@@ -1,0 +1,579 @@
+"""T1: adapter contract v0.3 schema acceptances and refusals.
+
+Covers spec ACs:
+  AC1 — `[adapter.kiro.scope]` with `allowed-prefixes.user = [".kiro/", ".agent-ready/"]`.
+  AC2 — `[adapter.kiro.projections.hook-wiring]` with `mode = "merge-into-agent-json"`,
+        `managed-key = "hooks"`, five-event `agent-event-vocabulary`. Legacy
+        `degraded-info-log` entry removed.
+  AC3 — `[adapter."claude-code".projections.hook-wiring]` with `mode.repo = "merge-json"`,
+        `mode.user = "user-merge-json"`, scope-conditional `target`,
+        `managed-key.user = "hooks"`.
+  AC4 — `[adapter."claude-code".projections.hook-body]` and
+        `[adapter.kiro.projections.hook-body]` with scope-conditional `target` values.
+  AC5 — `pack.schema.json` accepts `[pack.install] user-scope-hooks = true` and refuses
+        any non-boolean value; absent value remains accepted.
+  AC7 — contract `version = "0.3"`.
+
+Tests load the shipped `docs/contracts/{adapter,pack}.{toml,schema.json}` and call
+the project's stdlib-only validator. Mirrored copies under
+`packages/agentbundle/agentbundle/_data/` ship inside the zipapp; the two trees are
+kept in sync manually (both excluded from self-host drift comparison).
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import tomllib
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CONTRACT_PATH = REPO_ROOT / "docs" / "contracts" / "adapter.toml"
+ADAPTER_SCHEMA_PATH = REPO_ROOT / "docs" / "contracts" / "adapter.schema.json"
+PACK_SCHEMA_PATH = REPO_ROOT / "docs" / "contracts" / "pack.schema.json"
+
+KIRO_EVENTS = ["agentSpawn", "userPromptSubmit", "preToolUse", "postToolUse", "stop"]
+
+
+def _load_adapter_schema() -> dict:
+    return json.loads(ADAPTER_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _load_pack_schema() -> dict:
+    return json.loads(PACK_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _load_contract() -> dict:
+    return tomllib.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+
+
+def _parse_pack(toml_text: str) -> dict:
+    return tomllib.loads(toml_text)
+
+
+# ---------------------------------------------------------------------------
+# AC7 — contract version
+# ---------------------------------------------------------------------------
+
+
+class ContractVersionTests(unittest.TestCase):
+    def test_contract_version_is_0_3(self) -> None:
+        self.assertEqual(_load_contract()["contract"]["version"], "0.3")
+
+
+# ---------------------------------------------------------------------------
+# AC1 — Kiro [scope] table
+# ---------------------------------------------------------------------------
+
+
+class KiroScopeBlockTests(unittest.TestCase):
+    def test_kiro_scope_present(self) -> None:
+        scope = _load_contract()["adapter"]["kiro"].get("scope")
+        self.assertIsNotNone(scope, "[adapter.kiro.scope] block missing")
+        self.assertEqual(scope["repo"], ".")
+        self.assertEqual(scope["user"], "~")
+
+    def test_kiro_allowed_prefixes_user(self) -> None:
+        prefixes = _load_contract()["adapter"]["kiro"]["scope"]["allowed-prefixes"]["user"]
+        self.assertEqual(prefixes, [".kiro/", ".agent-ready/"])
+
+    def test_contract_validates(self) -> None:
+        from agentbundle.build.validate import validate
+
+        errors = validate(_load_contract(), _load_adapter_schema())
+        self.assertEqual(errors, [], f"v0.3 contract did not validate: {errors}")
+
+    def test_schema_rejects_kiro_root_prefix(self) -> None:
+        """Rail-A constraints carry forward: `/`, `..` segments, empty entries refused."""
+        from agentbundle.build.validate import validate
+
+        for bad in (["/"], [""], ["../"]):
+            with self.subTest(prefixes=bad):
+                contract = _load_contract()
+                contract["adapter"]["kiro"]["scope"]["allowed-prefixes"]["user"] = bad
+                errors = validate(contract, _load_adapter_schema())
+                self.assertTrue(
+                    errors,
+                    f"schema accepted allowed-prefixes.user = {bad!r}",
+                )
+
+
+# ---------------------------------------------------------------------------
+# AC2 — Kiro hook-wiring merge-into-agent-json + agent-event-vocabulary
+# ---------------------------------------------------------------------------
+
+
+class KiroHookWiringTableTests(unittest.TestCase):
+    def test_kiro_hook_wiring_uses_new_table(self) -> None:
+        contract = _load_contract()
+        projections = contract["adapter"]["kiro"].get("projections", {})
+        self.assertIn("hook-wiring", projections)
+        entry = projections["hook-wiring"]
+        self.assertEqual(entry["mode"], "merge-into-agent-json")
+        self.assertEqual(entry["managed-key"], "hooks")
+        self.assertEqual(entry["agent-event-vocabulary"], KIRO_EVENTS)
+
+    def test_legacy_degraded_info_log_entry_removed(self) -> None:
+        """AC2: legacy `[[adapter.kiro.projection]] degraded-info-log` is gone."""
+        contract = _load_contract()
+        legacy = contract["adapter"]["kiro"].get("projection", [])
+        for entry in legacy:
+            self.assertNotEqual(
+                entry.get("primitive"),
+                "hook-wiring",
+                "legacy kiro hook-wiring entry still present in projection array",
+            )
+            self.assertNotEqual(
+                entry.get("mode"),
+                "degraded-info-log",
+                "degraded-info-log entry still present in kiro projection array",
+            )
+
+
+# ---------------------------------------------------------------------------
+# AC3 — Claude Code hook-wiring scope-conditional mode/target/managed-key
+# ---------------------------------------------------------------------------
+
+
+class ClaudeCodeHookWiringTableTests(unittest.TestCase):
+    """AC3 mandates the new table form be *declared*; it does not require the
+    legacy array entry to be removed simultaneously (compare AC2's explicit
+    removal of kiro `degraded-info-log`). The legacy entry stays as the
+    pipeline-of-record until T5/T7 land — see adapter.toml comment."""
+
+    def test_claude_code_hook_wiring_scope_conditional(self) -> None:
+        contract = _load_contract()
+        entry = contract["adapter"]["claude-code"]["projections"]["hook-wiring"]
+        self.assertEqual(entry["mode"]["repo"], "merge-json")
+        self.assertEqual(entry["mode"]["user"], "user-merge-json")
+        self.assertEqual(entry["target"]["repo"], ".claude/settings.local.json")
+        self.assertEqual(entry["target"]["user"], ".claude/settings.json")
+        self.assertEqual(entry["managed-key"]["user"], "hooks")
+
+    def test_managed_key_is_user_only(self) -> None:
+        """AC3 names `managed-key.user`; repo scope's `merge-json` carries its
+        managed-key contract implicitly (legacy array entry). A `managed-key.repo`
+        appearing here would silently duplicate or override that contract."""
+        entry = _load_contract()["adapter"]["claude-code"]["projections"]["hook-wiring"]
+        self.assertNotIn(
+            "repo",
+            entry["managed-key"],
+            "managed-key.repo unexpectedly present — repo-scope managed-key is "
+            "the legacy array entry's concern, not the v0.3 table's",
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC4 — hook-body scope-conditional target on both adapters
+# ---------------------------------------------------------------------------
+
+
+class HookBodyScopeConditionalTests(unittest.TestCase):
+    """AC4 mandates the new table-form declaration of `hook-body` for both
+    adapters. AC4 does not demand removal of the legacy array entries; those
+    stay as pipeline-of-record until T5/T7."""
+
+    def test_claude_code_hook_body_scope_conditional(self) -> None:
+        entry = _load_contract()["adapter"]["claude-code"]["projections"]["hook-body"]
+        self.assertEqual(entry["mode"], "direct-file")
+        self.assertIn("repo", entry["target"])
+        self.assertIn("user", entry["target"])
+        self.assertEqual(entry["target"]["user"], ".claude/hooks/<name>.{sh,py}")
+
+    def test_kiro_hook_body_scope_conditional(self) -> None:
+        entry = _load_contract()["adapter"]["kiro"]["projections"]["hook-body"]
+        self.assertEqual(entry["mode"], "direct-file")
+        self.assertEqual(entry["target"]["user"], ".kiro/hooks/<name>.{sh,py}")
+
+
+# ---------------------------------------------------------------------------
+# Schema-level acceptance / refusal of new shapes (string-or-scope-map)
+# ---------------------------------------------------------------------------
+
+
+def _v03_skeleton() -> dict:
+    """A minimal v0.3 contract with just the fields the schema requires.
+
+    Tests mutate the projection entry under test and run the validator. Other
+    adapters are pruned so the test focuses on the field-shape under scrutiny.
+    """
+    return {
+        "contract": {"version": "0.3"},
+        "primitive": {
+            "skill": {"source-path": ".apm/skills/"},
+            "agent": {"source-path": ".apm/agents/"},
+            "hook-body": {"source-path": ".apm/hooks/"},
+            "hook-wiring": {"source-path": ".apm/hook-wiring/"},
+            "command": {"source-path": ".apm/commands/"},
+        },
+        "adapter": {
+            "kiro": {
+                "projection": [
+                    {"primitive": "skill", "mode": "direct-directory",
+                     "target-path": ".kiro/skills/", "on-conflict": "prompt-then-preserve"},
+                    {"primitive": "agent", "mode": "direct-file",
+                     "target-path": ".kiro/agents/", "on-conflict": "prompt-then-preserve"},
+                    {"primitive": "command", "mode": "dropped"},
+                ],
+                "projections": {
+                    "hook-body": {
+                        "mode": "direct-file",
+                        "target": {"repo": "tools/hooks/<name>.{sh,py}",
+                                   "user": ".kiro/hooks/<name>.{sh,py}"},
+                    },
+                    "hook-wiring": {
+                        "mode": "merge-into-agent-json",
+                        "target": {"repo": ".kiro/agents/<attach-to-agent>.json",
+                                   "user": ".kiro/agents/<attach-to-agent>.json"},
+                        "managed-key": "hooks",
+                        "agent-event-vocabulary": list(KIRO_EVENTS),
+                    },
+                },
+            },
+        },
+    }
+
+
+class ScopeConditionalTargetSchemaTests(unittest.TestCase):
+    """The new `projections.<primitive>` table accepts bare-string and scope-map `target`."""
+
+    def test_accepts_bare_string_target(self) -> None:
+        from agentbundle.build.validate import validate
+
+        skeleton = _v03_skeleton()
+        skeleton["adapter"]["kiro"]["projections"]["hook-body"]["target"] = ".kiro/hooks/<name>.{sh,py}"
+        errors = validate(skeleton, _load_adapter_schema())
+        self.assertEqual(errors, [], f"bare-string target rejected: {errors}")
+
+    def test_accepts_scope_map_target(self) -> None:
+        from agentbundle.build.validate import validate
+
+        # _v03_skeleton already uses scope-map; just validate as-is.
+        errors = validate(_v03_skeleton(), _load_adapter_schema())
+        self.assertEqual(errors, [], f"scope-map target rejected: {errors}")
+
+    def test_refuses_target_with_unknown_key(self) -> None:
+        from agentbundle.build.validate import validate
+
+        skeleton = _v03_skeleton()
+        skeleton["adapter"]["kiro"]["projections"]["hook-body"]["target"] = {
+            "repo": "tools/hooks/<name>.{sh,py}",
+            "user": ".kiro/hooks/<name>.{sh,py}",
+            "global": "/etc/hooks/",
+        }
+        errors = validate(skeleton, _load_adapter_schema())
+        self.assertTrue(errors, "schema accepted target with non-{repo,user} key")
+
+    def test_refuses_target_of_wrong_type(self) -> None:
+        from agentbundle.build.validate import validate
+
+        skeleton = _v03_skeleton()
+        skeleton["adapter"]["kiro"]["projections"]["hook-body"]["target"] = 42
+        errors = validate(skeleton, _load_adapter_schema())
+        self.assertTrue(errors, "schema accepted integer target")
+
+
+class ScopeConditionalModeSchemaTests(unittest.TestCase):
+    def test_accepts_bare_string_mode(self) -> None:
+        from agentbundle.build.validate import validate
+
+        # hook-body uses bare-string mode by default; validates against schema.
+        errors = validate(_v03_skeleton(), _load_adapter_schema())
+        self.assertEqual(errors, [], f"v0.3 skeleton rejected: {errors}")
+
+    def test_accepts_scope_map_mode_with_known_modes(self) -> None:
+        from agentbundle.build.validate import validate
+
+        skeleton = _v03_skeleton()
+        skeleton["adapter"]["kiro"]["projections"]["hook-wiring"]["mode"] = {
+            "repo": "merge-json",
+            "user": "user-merge-json",
+        }
+        errors = validate(skeleton, _load_adapter_schema())
+        self.assertEqual(errors, [], f"scope-map mode rejected: {errors}")
+
+    def test_refuses_unknown_mode_in_bare_string(self) -> None:
+        from agentbundle.build.validate import validate
+
+        skeleton = _v03_skeleton()
+        skeleton["adapter"]["kiro"]["projections"]["hook-body"]["mode"] = "not-a-real-mode"
+        errors = validate(skeleton, _load_adapter_schema())
+        self.assertTrue(errors, "schema accepted unknown bare-string mode")
+
+    def test_refuses_unknown_mode_in_scope_map(self) -> None:
+        from agentbundle.build.validate import validate
+
+        skeleton = _v03_skeleton()
+        skeleton["adapter"]["kiro"]["projections"]["hook-wiring"]["mode"] = {
+            "repo": "merge-json",
+            "user": "fictional-mode",
+        }
+        errors = validate(skeleton, _load_adapter_schema())
+        self.assertTrue(errors, "schema accepted unknown mode under scope-map.user")
+
+
+class AgentEventVocabularySchemaTests(unittest.TestCase):
+    def test_accepts_list_of_strings(self) -> None:
+        from agentbundle.build.validate import validate
+
+        skeleton = _v03_skeleton()
+        skeleton["adapter"]["kiro"]["projections"]["hook-wiring"][
+            "agent-event-vocabulary"
+        ] = ["one", "two", "three"]
+        errors = validate(skeleton, _load_adapter_schema())
+        self.assertEqual(errors, [], f"valid vocabulary rejected: {errors}")
+
+    def test_refuses_non_string_event(self) -> None:
+        from agentbundle.build.validate import validate
+
+        skeleton = _v03_skeleton()
+        skeleton["adapter"]["kiro"]["projections"]["hook-wiring"][
+            "agent-event-vocabulary"
+        ] = ["agentSpawn", 42]
+        errors = validate(skeleton, _load_adapter_schema())
+        self.assertTrue(errors, "schema accepted non-string event")
+
+    def test_refuses_non_array(self) -> None:
+        from agentbundle.build.validate import validate
+
+        skeleton = _v03_skeleton()
+        skeleton["adapter"]["kiro"]["projections"]["hook-wiring"][
+            "agent-event-vocabulary"
+        ] = "agentSpawn"
+        errors = validate(skeleton, _load_adapter_schema())
+        self.assertTrue(errors, "schema accepted string instead of array")
+
+    def test_refuses_empty_vocabulary(self) -> None:
+        """A `merge-into-agent-json` projection without any event vocabulary
+        would let any wiring TOML's event keys through `validate` — defeating
+        the per-adapter vocabulary gate the field exists to enforce."""
+        from agentbundle.build.validate import validate
+
+        skeleton = _v03_skeleton()
+        skeleton["adapter"]["kiro"]["projections"]["hook-wiring"][
+            "agent-event-vocabulary"
+        ] = []
+        errors = validate(skeleton, _load_adapter_schema())
+        self.assertTrue(errors, "schema accepted empty agent-event-vocabulary")
+
+
+# ---------------------------------------------------------------------------
+# AC5 — pack.install user-scope-hooks boolean
+# ---------------------------------------------------------------------------
+
+
+class PackInstallUserScopeHooksTests(unittest.TestCase):
+    def test_accepts_true(self) -> None:
+        from agentbundle.build.validate import validate
+
+        instance = _parse_pack(
+            """
+[pack]
+name = "demo"
+version = "0.1.0"
+
+[pack.adapter-contract]
+version = "0.3"
+
+[pack.install]
+default-scope = "user"
+allowed-scopes = ["user"]
+user-scope-hooks = true
+"""
+        )
+        errors = validate(instance, _load_pack_schema())
+        self.assertEqual(errors, [], f"user-scope-hooks=true rejected: {errors}")
+
+    def test_accepts_false(self) -> None:
+        from agentbundle.build.validate import validate
+
+        instance = _parse_pack(
+            """
+[pack]
+name = "demo"
+version = "0.1.0"
+
+[pack.adapter-contract]
+version = "0.3"
+
+[pack.install]
+default-scope = "user"
+allowed-scopes = ["user"]
+user-scope-hooks = false
+"""
+        )
+        errors = validate(instance, _load_pack_schema())
+        self.assertEqual(errors, [], f"user-scope-hooks=false rejected: {errors}")
+
+    def test_refuses_non_boolean(self) -> None:
+        from agentbundle.build.validate import validate
+
+        for bad in ("yes", 1, ["true"]):
+            with self.subTest(value=bad):
+                instance = {
+                    "pack": {
+                        "name": "demo",
+                        "version": "0.1.0",
+                        "adapter-contract": {"version": "0.3"},
+                        "install": {
+                            "default-scope": "user",
+                            "allowed-scopes": ["user"],
+                            "user-scope-hooks": bad,
+                        },
+                    }
+                }
+                errors = validate(instance, _load_pack_schema())
+                self.assertTrue(
+                    errors,
+                    f"schema accepted user-scope-hooks={bad!r}",
+                )
+
+    def test_absent_is_accepted(self) -> None:
+        """AC5: absent value is accepted (defaults to false at consumption time)."""
+        from agentbundle.build.validate import validate
+
+        instance = _parse_pack(
+            """
+[pack]
+name = "demo"
+version = "0.1.0"
+
+[pack.adapter-contract]
+version = "0.3"
+
+[pack.install]
+default-scope = "repo"
+allowed-scopes = ["repo"]
+"""
+        )
+        errors = validate(instance, _load_pack_schema())
+        self.assertEqual(
+            errors,
+            [],
+            f"v0.3 pack without user-scope-hooks rejected: {errors}",
+        )
+
+    def test_v03_pack_accepted(self) -> None:
+        """The v0.2 install-required invariant extends to v0.3."""
+        from agentbundle.build.validate import validate
+
+        instance = _parse_pack(
+            """
+[pack]
+name = "demo"
+version = "0.1.0"
+
+[pack.adapter-contract]
+version = "0.3"
+
+[pack.install]
+default-scope = "repo"
+allowed-scopes = ["repo"]
+"""
+        )
+        errors = validate(instance, _load_pack_schema())
+        self.assertEqual(errors, [], f"v0.3 pack with install rejected: {errors}")
+
+    def test_v03_pack_without_install_refused(self) -> None:
+        """The v0.2 invariant — install required when adapter-contract.version is current — applies to v0.3."""
+        from agentbundle.build.validate import validate
+
+        instance = _parse_pack(
+            """
+[pack]
+name = "demo"
+version = "0.1.0"
+
+[pack.adapter-contract]
+version = "0.3"
+"""
+        )
+        errors = validate(instance, _load_pack_schema())
+        self.assertTrue(errors, "v0.3 pack without [pack.install] was accepted")
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting: zipapp-bundled and dev-checkout copies must be byte-identical.
+# ---------------------------------------------------------------------------
+
+
+class DualFormDriftTests(unittest.TestCase):
+    """Path B (additive) keeps the legacy `[[adapter.X.projection]]` array
+    entry alongside the new `[adapter.X.projections.<primitive>]` table for
+    the same primitive — claude-code hook-body, claude-code hook-wiring,
+    kiro hook-body. If T5/T6/T7 evolve one form's `mode` without updating
+    the other, the pipeline silently diverges. Pin the invariant here.
+    """
+
+    def _repo_mode(self, entry: dict) -> str:
+        """A v0.3 table entry's repo-scope mode — bare string or `.repo`."""
+        mode = entry["mode"]
+        return mode["repo"] if isinstance(mode, dict) else mode
+
+    def test_legacy_and_v0_3_agree_on_repo_mode(self) -> None:
+        contract = _load_contract()
+        for adapter_name, adapter_block in contract["adapter"].items():
+            array_entries = {
+                p["primitive"]: p for p in adapter_block.get("projection", [])
+            }
+            for primitive, table_entry in adapter_block.get("projections", {}).items():
+                if primitive not in array_entries:
+                    continue  # primitive only declared in new form (e.g. kiro hook-wiring)
+                with self.subTest(adapter=adapter_name, primitive=primitive):
+                    legacy_mode = array_entries[primitive]["mode"]
+                    table_mode = self._repo_mode(table_entry)
+                    self.assertEqual(
+                        legacy_mode,
+                        table_mode,
+                        f"({adapter_name}, {primitive}): legacy array mode {legacy_mode!r} "
+                        f"diverges from v0.3 table repo mode {table_mode!r}",
+                    )
+
+
+class AdapterBlockCoverageTests(unittest.TestCase):
+    """An adapter block declaring neither `projection` nor `projections` would
+    project nothing — yet the relaxed v0.3 schema (no `required: [projection]`)
+    accepts it. Catch this at the test layer until the stdlib validator gains
+    an `anyOf` or equivalent. AC1 implicitly requires every reference adapter
+    to cover all five primitives via one form or the other."""
+
+    def test_every_adapter_declares_at_least_one_form(self) -> None:
+        contract = _load_contract()
+        for adapter_name, adapter_block in contract["adapter"].items():
+            with self.subTest(adapter=adapter_name):
+                has_array = bool(adapter_block.get("projection"))
+                has_table = bool(adapter_block.get("projections"))
+                self.assertTrue(
+                    has_array or has_table,
+                    f"adapter {adapter_name!r} declares neither `projection` array "
+                    "nor `projections` table — nothing would project",
+                )
+
+
+class BundledCopiesMatchTests(unittest.TestCase):
+    """`_data/` ships in the zipapp; `docs/contracts/` is the dev-checkout
+    fallback per build/main.py § resolution chain. Both are excluded from the
+    self-host drift check, so we assert identity here to catch divergence."""
+
+    def _data_dir(self) -> Path:
+        return REPO_ROOT / "packages" / "agentbundle" / "agentbundle" / "_data"
+
+    def test_adapter_toml_copies_match(self) -> None:
+        a = (self._data_dir() / "adapter.toml").read_bytes()
+        b = CONTRACT_PATH.read_bytes()
+        self.assertEqual(a, b, "_data/adapter.toml and docs/contracts/adapter.toml differ")
+
+    def test_adapter_schema_copies_match(self) -> None:
+        a = (self._data_dir() / "adapter.schema.json").read_bytes()
+        b = ADAPTER_SCHEMA_PATH.read_bytes()
+        self.assertEqual(a, b, "_data/adapter.schema.json and docs/contracts/adapter.schema.json differ")
+
+    def test_pack_schema_copies_match(self) -> None:
+        a = (self._data_dir() / "pack.schema.json").read_bytes()
+        b = PACK_SCHEMA_PATH.read_bytes()
+        self.assertEqual(a, b, "_data/pack.schema.json and docs/contracts/pack.schema.json differ")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

T1 of [user-scope-hooks spec](../tree/main/docs/specs/user-scope-hooks/spec.md) — the **schema and contract groundwork** for RFC-0005's user-scope hook support. First of thirteen PRs.

- Bumps `[contract] version` to `"0.3"`.
- Adds the new `[adapter.<x>.projections.<primitive>]` table form alongside the legacy `[[adapter.<x>.projection]]` array. New shape carries string-or-scope-map `target`/`mode`/`managed-key` plus non-empty `agent-event-vocabulary`; mode enum gains `user-merge-json` and `merge-into-agent-json`.
- Declares `[adapter.kiro.scope]` with `allowed-prefixes.user = [".kiro/", ".agent-ready/"]`.
- Extends `pack.schema.json` to accept v0.3 packs with the `[pack.install] user-scope-hooks` boolean opt-in.

## Design decision worth review — Path B (conservative additive)

AC2 explicitly removes the kiro hook-wiring `degraded-info-log` array entry. AC3 and AC4 say "adapter.toml **declares**" the new table form without demanding removal of the legacy entries. I chose to keep the legacy hook-body entries (both adapters) and the claude-code hook-wiring legacy entry alongside the new table-form declarations — the legacy entries stay as pipeline-of-record until T5/T7 land the new projection engine; the v0.3 tables are forward-looking metadata.

The duplicate-declaration risk this introduces is pinned by a `DualFormDriftTests` assertion: any primitive declared in both forms must agree on `mode` between legacy and table-`.repo`. Suggested by the adversarial-reviewer pass; included in this PR.

## Acceptance criteria

- [x] **AC1.** Kiro `[scope]` block with `repo = "."`, `user = "~"`, `allowed-prefixes.user = [".kiro/", ".agent-ready/"]`.
- [x] **AC2.** `[adapter.kiro.projections.hook-wiring]` table with `merge-into-agent-json`, `managed-key = "hooks"`, five-event vocabulary. Legacy `degraded-info-log` entry removed.
- [x] **AC3.** `[adapter."claude-code".projections.hook-wiring]` with scope-conditional `mode`/`target`, `managed-key.user = "hooks"`.
- [x] **AC4.** `[adapter."claude-code".projections.hook-body]` and `[adapter.kiro.projections.hook-body]` with scope-conditional `target` values.
- [x] **AC5.** `pack.schema.json` accepts `[pack.install] user-scope-hooks` boolean; refuses non-boolean; absent value still accepted (defaults to `false` at consumption time).
- [x] **AC7.** `[contract] version` bumps to `0.3`.

ACs 6 and 8–29 are out of scope for T1 (T2–T11).

## Test plan

- [x] `python3 -m pytest packages/agentbundle/` — 403 passed, 1 skipped (with stale workspace-symlink fixture cleaned locally; unrelated to this PR).
- [x] `make build-check` — exit 0.
- [x] `make validate` — exit 0 (v0.3 contract validates against the updated schema).
- [x] New `test_contract_v0_3_schema.py` exercises AC1/AC2/AC3/AC4/AC5/AC7 (37 tests).
- [x] Existing `test_contract.py` updated to walk both forms for primitive coverage and total-pair counts.
- [x] Existing `test_adapter_kiro.py` updated to assert the AC2 removal (no info-log emit for kiro hook-wiring under v0.3).

## Out of scope (later tasks)

- T2–T4: wiring TOML `attach-to-agent` field; fixture packs; scope-conditional target resolver.
- T5–T7: `user-merge-json` and `merge-into-agent-json` projection implementations; build-pipeline phase order.
- T8a–T9: state schema v0.3 migration; install/uninstall/upgrade threading; `reconcile --scope user` reporter.
- T10–T11: spec amendments to `distribution-adapters/spec.md` and `agent-spec-cli/spec.md`.