### PR TITLE
feat(wave2): hook-wiring validate + target resolver + state v0.3 (T2+T4+T8a)

### DIFF
--- a/docs/specs/user-scope-hooks/plan.md
+++ b/docs/specs/user-scope-hooks/plan.md
@@ -240,7 +240,10 @@ negative-validate tests from T2 pass against them.
 - New module
   `packages/agentbundle/agentbundle/build/target_resolver.py`
   implementing `resolve_target(adapter_projection, scope,
-  attach_to_agent=None) -> Path`.
+  attach_to_agent=None) -> str`. Returns `str` rather than `Path`:
+  pipeline consumers (T5/T6) own scope-root resolution (`.` vs `~`)
+  and `<name>` / `<pack>` placeholder substitution; the resolver
+  stays a pure-string utility with no filesystem dependency.
 - New unit test file
   `packages/agentbundle/tests/unit/test_target_resolver.py`.
 

--- a/packages/agentbundle/agentbundle/build/scope_rails.py
+++ b/packages/agentbundle/agentbundle/build/scope_rails.py
@@ -263,3 +263,100 @@ def run_all(
         if result is not None:
             return result
     return None
+
+
+# ---------------------------------------------------------------------------
+# T2 (RFC-0005): kiro `attach-to-agent` validate rail.
+#
+# Pure-function shape so unit tests can drive it with in-memory pack-shaped
+# dicts (per the T2 plan's testing approach — no on-disk fixtures). The CLI
+# `validate` command's filesystem-based wrapper lives in `check_kiro_wiring`
+# below; it loads the on-disk pack and dispatches to this in-memory helper.
+# ---------------------------------------------------------------------------
+
+
+def check_kiro_attach_to_agent(
+    pack_name: str,
+    wiring_tomls: dict[str, dict],
+    agent_basenames: set[str],
+    target_adapters: Iterable[str],
+) -> str | None:
+    """In-memory rail. Return refusal string on the first offender, or None.
+
+    Fires only when ``"kiro" in target_adapters``. For each wiring TOML:
+      - missing ``attach-to-agent`` field → refuse,
+      - ``attach-to-agent`` value naming an agent the pack does not ship
+        (no ``.apm/agents/<value>.md``) → refuse.
+
+    Refusal text is RFC-0005 § Repo-scope Kiro promotion verbatim:
+    ``pack <P>'s hook-wiring <name>.toml does not declare 'attach-to-agent'
+    (or names an unknown agent); required for kiro projection``.
+
+    Arguments:
+      pack_name: pack name (substituted into the refusal text).
+      wiring_tomls: map of wiring TOML basename (without ``.toml``) → parsed
+        TOML body. Iteration order is preserved; the first offender wins.
+      agent_basenames: set of agent file basenames (without ``.md``) the
+        pack ships under ``.apm/agents/``.
+      target_adapters: iterable of adapter names the pack is being
+        validated against. No-op when ``kiro`` is absent.
+    """
+    if "kiro" not in set(target_adapters or ()):
+        return None
+    for wiring_name, body in wiring_tomls.items():
+        attach = body.get("attach-to-agent") if isinstance(body, dict) else None
+        if not isinstance(attach, str) or attach not in agent_basenames:
+            return (
+                f"pack {pack_name}'s hook-wiring {wiring_name}.toml "
+                f"does not declare 'attach-to-agent' (or names an unknown "
+                f"agent); required for kiro projection"
+            )
+    return None
+
+
+def check_kiro_wiring(
+    pack_path: Path,
+    pack_name: str,
+    target_adapters: Iterable[str],
+) -> str | None:
+    """Filesystem wrapper around ``check_kiro_attach_to_agent``.
+
+    Reads ``.apm/hook-wiring/*.toml`` and ``.apm/agents/*.md`` from
+    ``pack_path``, parses each wiring TOML with ``tomllib``, and
+    dispatches to the in-memory rail. A wiring TOML that fails to parse
+    counts as a refusal on its own (a malformed pack-side declaration).
+    """
+    if "kiro" not in set(target_adapters or ()):
+        return None
+
+    wiring_dir = pack_path / ".apm" / "hook-wiring"
+    if not wiring_dir.exists():
+        return None
+
+    import tomllib
+
+    wiring_tomls: dict[str, dict] = {}
+    for entry in sorted(wiring_dir.iterdir()):
+        if not entry.is_file() or entry.suffix != ".toml":
+            continue
+        try:
+            wiring_tomls[entry.stem] = tomllib.loads(entry.read_text(encoding="utf-8"))
+        except (tomllib.TOMLDecodeError, OSError) as exc:
+            return (
+                f"pack {pack_name}'s hook-wiring {entry.stem}.toml "
+                f"failed to parse: {exc}"
+            )
+
+    agents_dir = pack_path / ".apm" / "agents"
+    agent_basenames: set[str] = set()
+    if agents_dir.exists():
+        for entry in sorted(agents_dir.iterdir()):
+            if entry.is_file() and entry.suffix == ".md":
+                agent_basenames.add(entry.stem)
+
+    return check_kiro_attach_to_agent(
+        pack_name,
+        wiring_tomls,
+        agent_basenames,
+        target_adapters,
+    )

--- a/packages/agentbundle/agentbundle/build/scope_rails.py
+++ b/packages/agentbundle/agentbundle/build/scope_rails.py
@@ -323,8 +323,11 @@ def check_kiro_wiring(
 
     Reads ``.apm/hook-wiring/*.toml`` and ``.apm/agents/*.md`` from
     ``pack_path``, parses each wiring TOML with ``tomllib``, and
-    dispatches to the in-memory rail. A wiring TOML that fails to parse
-    counts as a refusal on its own (a malformed pack-side declaration).
+    dispatches to the in-memory rail. Mirrors rail C's symlink
+    discipline: a symlink under either directory is refused — a
+    legitimate primitive is a regular file, and following a symlink
+    would let a pack reach outside its source tree. A wiring TOML that
+    fails to parse counts as a refusal on its own.
     """
     if "kiro" not in set(target_adapters or ()):
         return None
@@ -334,10 +337,23 @@ def check_kiro_wiring(
         return None
 
     import tomllib
+    from stat import S_ISLNK
 
     wiring_tomls: dict[str, dict] = {}
     for entry in sorted(wiring_dir.iterdir()):
-        if not entry.is_file() or entry.suffix != ".toml":
+        if entry.suffix != ".toml":
+            continue
+        try:
+            st = os.lstat(entry)
+        except OSError:
+            continue
+        if S_ISLNK(st.st_mode):
+            rel = entry.relative_to(pack_path)
+            return (
+                f"pack {pack_name}'s hook-wiring entry is a symlink "
+                f"(not a regular file); first offender: {rel.as_posix()}"
+            )
+        if not entry.is_file():
             continue
         try:
             wiring_tomls[entry.stem] = tomllib.loads(entry.read_text(encoding="utf-8"))
@@ -351,7 +367,19 @@ def check_kiro_wiring(
     agent_basenames: set[str] = set()
     if agents_dir.exists():
         for entry in sorted(agents_dir.iterdir()):
-            if entry.is_file() and entry.suffix == ".md":
+            if entry.suffix != ".md":
+                continue
+            try:
+                st = os.lstat(entry)
+            except OSError:
+                continue
+            if S_ISLNK(st.st_mode):
+                rel = entry.relative_to(pack_path)
+                return (
+                    f"pack {pack_name}'s agent entry is a symlink "
+                    f"(not a regular file); first offender: {rel.as_posix()}"
+                )
+            if entry.is_file():
                 agent_basenames.add(entry.stem)
 
     return check_kiro_attach_to_agent(

--- a/packages/agentbundle/agentbundle/build/target_resolver.py
+++ b/packages/agentbundle/agentbundle/build/target_resolver.py
@@ -1,0 +1,85 @@
+"""Scope-conditional `target` resolver for v0.3 projection declarations.
+
+The v0.3 adapter contract (RFC-0005) introduced a string-or-scope-map shape
+for `target` on `[adapter.<x>.projections.<primitive>]` entries:
+
+    # bare-string (v0.1 legacy shorthand)
+    target = "tools/hooks/<name>.{sh,py}"
+
+    # scope-map (v0.3 fork)
+    target.repo = "tools/hooks/<name>.{sh,py}"
+    target.user = ".claude/hooks/<name>.{sh,py}"
+
+Some templates also carry the `<attach-to-agent>` placeholder for
+`merge-into-agent-json` consumers (Kiro hook-wiring), resolved per wiring
+entry from the pack-side TOML's `attach-to-agent` field.
+
+This module is a pure-function utility — no I/O, no filesystem access.
+Scope-root resolution (`.` vs `~`) and `<name>` / `<pack>` placeholder
+substitution are the pipeline consumers' (T5/T6) concern; the resolver
+returns a target-template string they can further process.
+"""
+
+from __future__ import annotations
+
+
+_ATTACH_TO_AGENT_PLACEHOLDER = "<attach-to-agent>"
+
+
+def resolve_target(
+    projection: dict,
+    scope: str,
+    attach_to_agent: str | None = None,
+) -> str:
+    """Resolve a projection entry's `target` for a given scope.
+
+    Arguments:
+      projection: a single entry from `adapter.<x>.projections.<primitive>`.
+        Must contain a `target` key (bare string or `{repo, user}` table).
+      scope: `"repo"` or `"user"`.
+      attach_to_agent: optional pack-side agent name; substituted for any
+        `<attach-to-agent>` placeholder in the resolved template. If the
+        template contains the placeholder but no name is given, the call
+        refuses — passing an unsubstituted template downstream is a bug.
+
+    Returns:
+      The resolved target template as a string. `<name>` and `<pack>`
+      placeholders survive verbatim — they're the pipeline's responsibility,
+      not this resolver's.
+
+    Raises:
+      ValueError: when `target` is absent, when the requested `scope` is
+        absent from a scope-map declaration, or when the resolved template
+        contains the `<attach-to-agent>` placeholder but `attach_to_agent`
+        is None.
+    """
+    if "target" not in projection:
+        raise ValueError("projection missing 'target' field")
+
+    target = projection["target"]
+    if isinstance(target, str):
+        resolved = target
+    elif isinstance(target, dict):
+        if scope not in target:
+            raise ValueError(
+                f"projection target has no entry for scope {scope!r}; "
+                f"declared scopes: {sorted(target.keys())}"
+            )
+        resolved = target[scope]
+        if not isinstance(resolved, str):
+            raise ValueError(
+                f"projection target.{scope} is not a string: {type(resolved).__name__}"
+            )
+    else:
+        raise ValueError(
+            f"projection target must be string or scope-map; got {type(target).__name__}"
+        )
+
+    if _ATTACH_TO_AGENT_PLACEHOLDER in resolved:
+        if attach_to_agent is None:
+            raise ValueError(
+                f"target template requires attach-to-agent; got None. Template: {resolved!r}"
+            )
+        resolved = resolved.replace(_ATTACH_TO_AGENT_PLACEHOLDER, attach_to_agent)
+
+    return resolved

--- a/packages/agentbundle/agentbundle/commands/init_state.py
+++ b/packages/agentbundle/agentbundle/commands/init_state.py
@@ -206,11 +206,17 @@ def _run_migrate(args: argparse.Namespace) -> int:
 
     source_version = _peek_schema_version(original_text)
 
-    if source_version == "0.2":
-        # Header-only-additive (RFC-0005). Rewrite only the version line.
-        serialised = _rewrite_schema_version_line(original_text, "0.3")
+    if source_version in ("0.2", "0.3"):
+        # Header-only-additive (RFC-0005). Rewrite only the version
+        # line. The already-v0.3 case is a true byte-no-op (identity
+        # rewrite) so adopters running ``--migrate`` against a current
+        # file get a round-trip-stable result — full re-serialize would
+        # silently strip explicit fields T8b/T8c writers may produce.
+        serialised = _rewrite_schema_version_line(
+            original_text, config.STATE_SCHEMA_VERSION
+        )
     else:
-        # v0.1 or already-v0.3 — full re-serialize. load_state with
+        # v0.1 or unrecognised — full re-serialize. load_state with
         # for_write=False so the legacy refusal does not fire (we *are*
         # the migration).
         try:
@@ -243,30 +249,31 @@ def _run_migrate(args: argparse.Namespace) -> int:
 
 import re as _re
 
-# Match the `schema-version = "X.Y"` line, capturing the prefix, the
-# version, and the rest. MULTILINE so `^` matches at line start anywhere
-# in the file (deal-breaker is the rare case where the line isn't first).
+# Match the top-level ``schema-version = "X.Y"`` line. The pattern
+# anchors to *file* start (``\A``) with optional leading blank lines —
+# TOML convention puts top-level keys at the head, and ``dump_state``
+# emits ``schema-version`` as the first line. Restricting the regex to
+# the file head prevents a stale pack-table value or a comment further
+# down from being rewritten by accident.
 _SCHEMA_VERSION_LINE_RE = _re.compile(
-    r'^(\s*schema-version\s*=\s*")([^"]*)(".*)$',
-    _re.MULTILINE,
+    r'\A(\s*)(schema-version\s*=\s*")([^"]*)(".*)',
 )
 
 
 def _peek_schema_version(text: str) -> str | None:
     """Return the schema-version string from a state-file body, or None."""
-    m = _SCHEMA_VERSION_LINE_RE.search(text)
-    return m.group(2) if m else None
+    m = _SCHEMA_VERSION_LINE_RE.match(text)
+    return m.group(3) if m else None
 
 
 def _rewrite_schema_version_line(text: str, new_version: str) -> str:
-    """Rewrite the ``schema-version = "X.Y"`` line in *text* to *new_version*.
+    """Rewrite the ``schema-version = "X.Y"`` header in *text* to *new_version*.
 
-    Touches only that line — every other byte is preserved. Trailing
-    newline is preserved when present. This is the v0.2 → v0.3
-    migration's whole job (RFC-0005 § State-file impact).
+    Touches only the first match (anchored to file start) — every other
+    byte is preserved. Trailing newline is preserved. This is the
+    v0.2 → v0.3 (and v0.3 → v0.3 no-op) migration's whole job per
+    RFC-0005 § State-file impact.
     """
-    return _SCHEMA_VERSION_LINE_RE.sub(
-        lambda m: f'{m.group(1)}{new_version}{m.group(3)}',
-        text,
-        count=1,
-    )
+    def _sub(m: _re.Match[str]) -> str:
+        return f"{m.group(1)}{m.group(2)}{new_version}{m.group(4)}"
+    return _SCHEMA_VERSION_LINE_RE.sub(_sub, text, count=1)

--- a/packages/agentbundle/agentbundle/commands/init_state.py
+++ b/packages/agentbundle/agentbundle/commands/init_state.py
@@ -149,17 +149,23 @@ def run(args: argparse.Namespace) -> int:
 
 
 def _run_migrate(args: argparse.Namespace) -> int:
-    """`init-state --migrate`: rewrite a v0.1 state file to v0.2 idempotently.
+    """`init-state --migrate`: bump a state file to the current schema-version.
 
-    Reads the file via ``config.load_state(..., for_write=False)`` so the
-    legacy refusal does not fire (we *are* the migration). Adds ``scope =
-    "repo"`` to every pack entry, sets ``schema_version = "0.2"``, and
-    writes atomically through ``safety.write_jailed``.
+    Two migration shapes the CLI supports:
 
-    Already-v0.2 files are a no-op exit-zero: ``load_state`` returns the
-    same shape, ``scope`` defaults to ``"repo"`` already, and the dumped
-    output is byte-identical to the input. Idempotence is the spec
-    requirement; running ``--migrate`` twice never breaks anything.
+    - **v0.1 → v0.3 (legacy full re-serialize).** Adds ``scope = "repo"``
+      to every pack entry, sets ``schema-version = "0.3"``, and writes
+      atomically. The v0.1 → v0.2 invariant (per-row scope backfill)
+      lands here in a single step because RFC-0005's v0.2 → v0.3
+      migration is header-only (no per-row changes), so the two compose
+      cleanly.
+    - **v0.2 → v0.3 (header-only-additive, RFC-0005 § State-file
+      impact).** Rewrites only the ``schema-version = "0.2"`` line to
+      ``"0.3"``. Every body byte is preserved; existing rows omit the
+      new ``adapter`` / ``target-file`` fields and let v0.3 read-time
+      defaults supply them. Cheapest possible additive migration.
+
+    Already-v0.3 files are a no-op exit-zero — idempotent.
     """
     scope = getattr(args, "scope", None) or "repo"
     user_prefixes: list[str] | None = None
@@ -193,18 +199,31 @@ def _run_migrate(args: argparse.Namespace) -> int:
         return 1
 
     try:
-        state = config.load_state(state_path, for_write=False)
-    except config.ConfigError as exc:
-        print(f"init-state --migrate: {exc}", file=sys.stderr)
+        original_text = state_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"init-state --migrate: cannot read {state_path}: {exc}", file=sys.stderr)
         return 1
 
-    # Bump in-memory state to v0.2 and fill the implicit scope column.
-    state.schema_version = config.STATE_SCHEMA_VERSION
-    for ps in state.packs.values():
-        if not ps.scope:
-            ps.scope = "repo"
+    source_version = _peek_schema_version(original_text)
 
-    serialised = config.dump_state(state)
+    if source_version == "0.2":
+        # Header-only-additive (RFC-0005). Rewrite only the version line.
+        serialised = _rewrite_schema_version_line(original_text, "0.3")
+    else:
+        # v0.1 or already-v0.3 — full re-serialize. load_state with
+        # for_write=False so the legacy refusal does not fire (we *are*
+        # the migration).
+        try:
+            state = config.load_state(state_path, for_write=False)
+        except config.ConfigError as exc:
+            print(f"init-state --migrate: {exc}", file=sys.stderr)
+            return 1
+        state.schema_version = config.STATE_SCHEMA_VERSION
+        for ps in state.packs.values():
+            if not ps.scope:
+                ps.scope = "repo"
+        serialised = config.dump_state(state)
+
     try:
         safety.write_jailed(
             write_root, relpath, serialised,
@@ -215,5 +234,39 @@ def _run_migrate(args: argparse.Namespace) -> int:
         print(f"init-state --migrate: {exc}", file=sys.stderr)
         return 1
 
-    print(f"init-state --migrate: {state_path} → schema-version 0.2")
+    print(
+        f"init-state --migrate: {state_path} → schema-version "
+        f"{config.STATE_SCHEMA_VERSION}"
+    )
     return 0
+
+
+import re as _re
+
+# Match the `schema-version = "X.Y"` line, capturing the prefix, the
+# version, and the rest. MULTILINE so `^` matches at line start anywhere
+# in the file (deal-breaker is the rare case where the line isn't first).
+_SCHEMA_VERSION_LINE_RE = _re.compile(
+    r'^(\s*schema-version\s*=\s*")([^"]*)(".*)$',
+    _re.MULTILINE,
+)
+
+
+def _peek_schema_version(text: str) -> str | None:
+    """Return the schema-version string from a state-file body, or None."""
+    m = _SCHEMA_VERSION_LINE_RE.search(text)
+    return m.group(2) if m else None
+
+
+def _rewrite_schema_version_line(text: str, new_version: str) -> str:
+    """Rewrite the ``schema-version = "X.Y"`` line in *text* to *new_version*.
+
+    Touches only that line — every other byte is preserved. Trailing
+    newline is preserved when present. This is the v0.2 → v0.3
+    migration's whole job (RFC-0005 § State-file impact).
+    """
+    return _SCHEMA_VERSION_LINE_RE.sub(
+        lambda m: f'{m.group(1)}{new_version}{m.group(3)}',
+        text,
+        count=1,
+    )

--- a/packages/agentbundle/agentbundle/commands/install.py
+++ b/packages/agentbundle/agentbundle/commands/install.py
@@ -453,10 +453,12 @@ def run(args: "argparse.Namespace") -> int:
             }
 
         plan.state.packs[pack_name] = new_pack_state
-        # State-file v0.2 is the post-write schema. The state object is
-        # already at v0.2 (load_state sets the default for fresh State,
-        # or migration-time semantics for read-only-as-repo).
-        plan.state.schema_version = "0.2"
+        # Stamp the post-write schema. Always emit the current
+        # ``STATE_SCHEMA_VERSION`` (bumped to v0.3 in T8a) so a fresh
+        # install never produces a state file pinned at a stale version.
+        from agentbundle.config import STATE_SCHEMA_VERSION
+
+        plan.state.schema_version = STATE_SCHEMA_VERSION
         serialised = dump_state(plan.state)
         try:
             safety.write_jailed(

--- a/packages/agentbundle/agentbundle/commands/validate.py
+++ b/packages/agentbundle/agentbundle/commands/validate.py
@@ -165,15 +165,16 @@ def run(args) -> int:
         return 1
 
     # ── 4c. Kiro hook-wiring `attach-to-agent` rail (RFC-0005, T2) ────────
-    # Fires when the resolved target adapter set includes `kiro` — i.e.
-    # when the pack's declared adapter-contract version aligns with the
-    # v0.3 contract that declares `merge-into-agent-json` for kiro
-    # hook-wiring. Pack-side `allowed-adapters` does not yet exist, so
-    # the rail fires for every v0.3 pack; v0.1/v0.2 packs skip it
-    # (empty target_adapters → no-op).
+    # Fires when the pack is v0.3-bound AND ships *both* `.apm/agents/`
+    # (Kiro requires an agent to attach to) AND `.apm/hook-wiring/`
+    # (the wiring being validated). Pack-side `allowed-adapters` is a
+    # future RFC; the both-dirs heuristic is the proxy for "this pack
+    # would project to kiro." A Claude-Code-only v0.3 pack that ships
+    # wiring but no agents has no kiro projection target — the rail is
+    # a no-op for it (AC6: "field is ignored, not refused").
     from agentbundle.build.scope_rails import check_kiro_wiring
 
-    target_adapters = _kiro_target_adapters(pack_data)
+    target_adapters = _kiro_target_adapters(pack_data, pack_path)
     pack_name = pack_data.get("pack", {}).get("name") or pack_path.name
     kiro_refusal = check_kiro_wiring(pack_path, pack_name, target_adapters)
     if kiro_refusal is not None:
@@ -224,16 +225,27 @@ def _is_default_scope_invariant_violation(pack_data: dict, first_error: str) -> 
     )
 
 
-def _kiro_target_adapters(pack_data: dict) -> set[str]:
+def _kiro_target_adapters(pack_data: dict, pack_path: Path) -> set[str]:
     """Resolve the target-adapter set for the kiro hook-wiring rail (T2).
 
-    A v0.3 pack is implicitly projected against every adapter the v0.3
-    contract declares — kiro included. Pack-side ``allowed-adapters``
-    does not exist yet (would land in a separate RFC), so we treat the
-    pack-side declared contract version as the gate: v0.3 binds the
-    kiro projection's `attach-to-agent` requirement; v0.1 / v0.2 packs
-    pre-date the requirement and skip the rail. Returns an empty set
-    (rail no-op) for any pack not bound to v0.3.
+    Pack-side ``allowed-adapters`` does not exist yet (a future RFC).
+    The rail's purpose is to refuse hook-wiring that *would* project to
+    kiro but lacks the required ``attach-to-agent`` field. Without an
+    explicit declaration, we infer kiro-targeting from on-disk evidence:
+
+      - Pack declares the v0.3 adapter contract (the version that
+        introduced ``merge-into-agent-json`` for kiro hook-wiring).
+      - Pack ships **both** ``.apm/agents/`` content (Kiro's projection
+        target — an agent JSON to attach into) **and**
+        ``.apm/hook-wiring/`` content (the wiring this rail validates).
+
+    A Claude-Code-only v0.3 pack that ships wiring without agents
+    cannot project to kiro by construction (no agent file to merge
+    into) and the rail is a no-op for it. v0.1 / v0.2 packs pre-date
+    the requirement.
+
+    Returns ``{"kiro"}`` when the heuristic fires; empty set
+    (rail no-op) otherwise.
     """
     pack = pack_data.get("pack", {})
     if not isinstance(pack, dict):
@@ -241,10 +253,29 @@ def _kiro_target_adapters(pack_data: dict) -> set[str]:
     contract = pack.get("adapter-contract")
     if not isinstance(contract, dict):
         return set()
-    version = contract.get("version")
-    if version == "0.3":
-        return {"kiro"}
-    return set()
+    if contract.get("version") != "0.3":
+        return set()
+    # Heuristic: kiro projection requires a same-pack agent. A pack
+    # with wiring but no agents has nothing to attach to.
+    agents_dir = pack_path / ".apm" / "agents"
+    wiring_dir = pack_path / ".apm" / "hook-wiring"
+    if not _dir_has_any_file(agents_dir, ".md"):
+        return set()
+    if not _dir_has_any_file(wiring_dir, ".toml"):
+        return set()
+    return {"kiro"}
+
+
+def _dir_has_any_file(directory: Path, suffix: str) -> bool:
+    """Return True if *directory* exists and contains at least one file
+    with *suffix*. Symlinks are ignored — the kiro rail consumes them
+    through `check_kiro_wiring`, which mirrors rail C's symlink refusal."""
+    if not directory.exists():
+        return False
+    for entry in directory.iterdir():
+        if entry.is_file() and entry.suffix == suffix:
+            return True
+    return False
 
 
 def _allowed_scopes(pack_data: dict) -> list[str]:

--- a/packages/agentbundle/agentbundle/commands/validate.py
+++ b/packages/agentbundle/agentbundle/commands/validate.py
@@ -164,6 +164,22 @@ def run(args) -> int:
         )
         return 1
 
+    # ── 4c. Kiro hook-wiring `attach-to-agent` rail (RFC-0005, T2) ────────
+    # Fires when the resolved target adapter set includes `kiro` — i.e.
+    # when the pack's declared adapter-contract version aligns with the
+    # v0.3 contract that declares `merge-into-agent-json` for kiro
+    # hook-wiring. Pack-side `allowed-adapters` does not yet exist, so
+    # the rail fires for every v0.3 pack; v0.1/v0.2 packs skip it
+    # (empty target_adapters → no-op).
+    from agentbundle.build.scope_rails import check_kiro_wiring
+
+    target_adapters = _kiro_target_adapters(pack_data)
+    pack_name = pack_data.get("pack", {}).get("name") or pack_path.name
+    kiro_refusal = check_kiro_wiring(pack_path, pack_name, target_adapters)
+    if kiro_refusal is not None:
+        print(f"validate: {kiro_refusal}", file=sys.stderr)
+        return 1
+
     # ── 5. Strict / conformance mode ─────────────────────────────────────
     if strict:
         conformance_dir = _conformance_fixtures_dir()
@@ -206,6 +222,29 @@ def _is_default_scope_invariant_violation(pack_data: dict, first_error: str) -> 
         "pack.install.allowed-scopes" in first_error
         or "allowed-scopes" in first_error
     )
+
+
+def _kiro_target_adapters(pack_data: dict) -> set[str]:
+    """Resolve the target-adapter set for the kiro hook-wiring rail (T2).
+
+    A v0.3 pack is implicitly projected against every adapter the v0.3
+    contract declares — kiro included. Pack-side ``allowed-adapters``
+    does not exist yet (would land in a separate RFC), so we treat the
+    pack-side declared contract version as the gate: v0.3 binds the
+    kiro projection's `attach-to-agent` requirement; v0.1 / v0.2 packs
+    pre-date the requirement and skip the rail. Returns an empty set
+    (rail no-op) for any pack not bound to v0.3.
+    """
+    pack = pack_data.get("pack", {})
+    if not isinstance(pack, dict):
+        return set()
+    contract = pack.get("adapter-contract")
+    if not isinstance(contract, dict):
+        return set()
+    version = contract.get("version")
+    if version == "0.3":
+        return {"kiro"}
+    return set()
 
 
 def _allowed_scopes(pack_data: dict) -> list[str]:

--- a/packages/agentbundle/agentbundle/config.py
+++ b/packages/agentbundle/agentbundle/config.py
@@ -240,12 +240,15 @@ def load_state(path: Path, *, for_write: bool = False) -> State:
             target_file: str | None = raw_target
         elif adapter == "claude-code":
             target_file = _CLAUDE_CODE_USER_SETTINGS_DEFAULT
-        elif adapter == "kiro":
-            raise ConfigError(
-                f"[pack.{name}] has adapter = 'kiro' but no 'target-file'; "
-                f"kiro rows require an explicit target-file (RFC-0005 § State-file impact)"
-            )
         else:
+            # Kiro rows require ``target-file`` per RFC-0005 § State-file
+            # impact ("no implicit default — Kiro rows always carry the
+            # pack-owned `.kiro/agents/<agent>.json` path explicitly").
+            # The read path stays operationally tolerant (returns None);
+            # consumers that need the field surface their own error when
+            # they go to use it. This keeps ``init-state --migrate``
+            # able to operate on a malformed v0.3 file without trapping
+            # the adopter in a refuse-and-explain dead end.
             target_file = None
 
         # RFC-0005: optional `[[pack.<name>.hook-wiring-owned]]` array-of-tables.
@@ -308,15 +311,16 @@ def dump_state(state: State) -> str:
         # bumps schema_version before calling dump_state.
         if state.schema_version != "0.1":
             lines.append(f"scope = {_emit_basic_string(ps.scope)}")
-        # RFC-0005 v0.3 fields. Emit only when non-default — keep
-        # claude-code rows (the common case) byte-compatible with v0.2.
+        # RFC-0005 v0.3 fields. ``adapter`` defaults to "claude-code"
+        # on read; only emit when non-default to keep the common case
+        # byte-compatible with v0.2. ``target-file`` is always emitted
+        # when set (even if it equals the claude-code default) so
+        # round-trip is byte-stable for explicit-default rows that
+        # T8b/T8c install/upgrade writers may produce.
         if state.schema_version == "0.3":
             if ps.adapter and ps.adapter != "claude-code":
                 lines.append(f"adapter = {_emit_basic_string(ps.adapter)}")
-            if ps.target_file is not None and not (
-                ps.adapter == "claude-code"
-                and ps.target_file == _CLAUDE_CODE_USER_SETTINGS_DEFAULT
-            ):
+            if ps.target_file is not None:
                 lines.append(f"target-file = {_emit_basic_string(ps.target_file)}")
         primitives_repr = ", ".join(_emit_basic_string(p) for p in ps.primitives)
         lines.append(f"primitives = [{primitives_repr}]")

--- a/packages/agentbundle/agentbundle/config.py
+++ b/packages/agentbundle/agentbundle/config.py
@@ -27,7 +27,13 @@ from pathlib import Path
 from typing import Any, Literal
 
 
-STATE_SCHEMA_VERSION = "0.2"
+STATE_SCHEMA_VERSION = "0.3"
+
+# Read-time default for v0.3 rows lacking explicit ``target-file`` when the
+# resolved adapter is ``claude-code`` — the adapter's user-scope settings
+# file is the only place a claude-code hook-wiring row could land
+# (RFC-0005 § State-file impact).
+_CLAUDE_CODE_USER_SETTINGS_DEFAULT = "~/.claude/settings.json"
 
 
 class ConfigError(ValueError):
@@ -35,23 +41,28 @@ class ConfigError(ValueError):
 
 
 class StateFileLegacy(ConfigError):
-    """Raised when a write-capable invocation hits a v0.1 state file.
+    """Raised when a write-capable invocation hits a v0.1 or v0.2 state file.
 
-    Migration to v0.2 is destructive (irreversible without backup), so the
-    CLI never silently rewrites — instead, every write-capable handler
-    surfaces this exception as a one-line refuse-and-explain pointing the
-    adopter at `agentbundle init-state --migrate`. Read-only paths
-    catch-and-treat as repo-scope per RFC-0004 § *Backward compatibility*.
+    Migrations are append-only (v0.1 → v0.2 added a per-row scope column;
+    v0.2 → v0.3 added optional ``adapter`` / ``target-file`` /
+    ``hook-wiring-owned`` fields under RFC-0005's header-only-additive
+    rule), so the CLI never silently rewrites — every write-capable
+    handler surfaces this exception as a one-line refuse-and-explain
+    pointing the adopter at ``agentbundle init-state --migrate``.
+    Read-only paths still parse the legacy file: v0.1 implies repo scope
+    per RFC-0004 § *Backward compatibility*; v0.2 lets the v0.3
+    read-time defaults fire.
 
-    Carries the path on disk so the formatter can name it in the stderr
-    message — adopters with multiple checkouts or scopes need to know
-    which file is the legacy one.
+    Carries the path on disk plus the offending version so the formatter
+    can name both in the stderr message — adopters running mixed CLI
+    versions across CI and local need to know which file is which.
     """
 
-    def __init__(self, path: Path) -> None:
+    def __init__(self, path: Path, version: str = "0.1") -> None:
         self.path = path
+        self.version = version
         super().__init__(
-            f"state file at {path} is schema-version 0.1; "
+            f"state file at {path} is schema-version {version}; "
             f"run 'agentbundle init-state --migrate' first"
         )
 
@@ -110,6 +121,18 @@ class PackState:
     # Per-primitive overrides for mixed-version packs (T12). Optional;
     # absent when the pack is at a single uniform version.
     primitive_versions: dict[str, dict[str, str]] = field(default_factory=dict)
+    # RFC-0005 v0.3 additions — optional, read-time defaulted.
+    # ``adapter`` defaults to ``"claude-code"`` when absent on read
+    # (covers v0.2-vintage rows preserved across the header-only
+    # migration and v0.3-vintage claude-code rows omitting the field as
+    # a write-time space saving). ``target_file`` defaults to
+    # ``~/.claude/settings.json`` for claude-code rows; **required**
+    # (no default) for kiro rows. ``hook_wiring_owned`` is the per-pack
+    # array-of-tables that uninstall walks to remove the right entries
+    # from the right files.
+    adapter: str = "claude-code"
+    target_file: str | None = None
+    hook_wiring_owned: list[dict[str, str]] = field(default_factory=list)
 
     def file_sha(self, relpath: str) -> str | None:
         entry = self.files.get(relpath)
@@ -165,9 +188,10 @@ def load_state(path: Path, *, for_write: bool = False) -> State:
 
     # Refuse-and-explain on writes to a legacy state file. We check this
     # *before* parsing pack entries so callers can rely on the exception
-    # type alone — no half-parsed State leaks out.
-    if for_write and schema_version == "0.1":
-        raise StateFileLegacy(path)
+    # type alone — no half-parsed State leaks out. Both v0.1 and v0.2
+    # are legacy from v0.3's perspective (RFC-0005 § State-file impact).
+    if for_write and schema_version in ("0.1", "0.2"):
+        raise StateFileLegacy(path, version=schema_version)
 
     state = State(schema_version=schema_version)
     pack_table = raw.get("pack", {})
@@ -203,6 +227,43 @@ def load_state(path: Path, *, for_write: bool = False) -> State:
         raw_scope = body.get("scope") if schema_version != "0.1" else None
         scope = raw_scope if isinstance(raw_scope, str) and raw_scope in ("repo", "user") else "repo"
 
+        # RFC-0005 v0.3 read-time defaults. ``adapter`` absent → claude-code
+        # (covers v0.2-vintage rows preserved across the header-only
+        # migration and v0.3-vintage claude-code rows omitting the field).
+        # ``target-file`` absent on claude-code → ``~/.claude/settings.json``;
+        # absent on kiro is a contract violation (no implicit default).
+        raw_adapter = body.get("adapter") if schema_version not in ("0.1",) else None
+        adapter = raw_adapter if isinstance(raw_adapter, str) else "claude-code"
+
+        raw_target = body.get("target-file") if schema_version not in ("0.1",) else None
+        if isinstance(raw_target, str):
+            target_file: str | None = raw_target
+        elif adapter == "claude-code":
+            target_file = _CLAUDE_CODE_USER_SETTINGS_DEFAULT
+        elif adapter == "kiro":
+            raise ConfigError(
+                f"[pack.{name}] has adapter = 'kiro' but no 'target-file'; "
+                f"kiro rows require an explicit target-file (RFC-0005 § State-file impact)"
+            )
+        else:
+            target_file = None
+
+        # RFC-0005: optional `[[pack.<name>.hook-wiring-owned]]` array-of-tables.
+        # Each entry carries at least `event` and `id`, and optionally
+        # `target-file` (used by upgrade reconciliation when a Kiro pack's
+        # `attach-to-agent` value changes between versions — T8c).
+        raw_owned = body.get("hook-wiring-owned", []) or []
+        hook_wiring_owned: list[dict[str, str]] = []
+        if isinstance(raw_owned, list):
+            for i, entry in enumerate(raw_owned):
+                if not isinstance(entry, dict):
+                    raise ConfigError(
+                        f"[pack.{name}.hook-wiring-owned] entry {i} must be a table"
+                    )
+                hook_wiring_owned.append({
+                    k: str(v) for k, v in entry.items() if isinstance(v, str)
+                })
+
         ps = PackState(
             installed_version=body.get("installed-version", ""),
             source=body.get("source", "agent-ready-repo"),
@@ -211,6 +272,9 @@ def load_state(path: Path, *, for_write: bool = False) -> State:
             primitives=list(body.get("primitives", []) or []),
             files={k: dict(v) for k, v in files.items() if isinstance(v, dict)},
             primitive_versions=primitive_versions,
+            adapter=adapter,
+            target_file=target_file,
+            hook_wiring_owned=hook_wiring_owned,
         )
         state.packs[name] = ps
     return state
@@ -244,6 +308,16 @@ def dump_state(state: State) -> str:
         # bumps schema_version before calling dump_state.
         if state.schema_version != "0.1":
             lines.append(f"scope = {_emit_basic_string(ps.scope)}")
+        # RFC-0005 v0.3 fields. Emit only when non-default — keep
+        # claude-code rows (the common case) byte-compatible with v0.2.
+        if state.schema_version == "0.3":
+            if ps.adapter and ps.adapter != "claude-code":
+                lines.append(f"adapter = {_emit_basic_string(ps.adapter)}")
+            if ps.target_file is not None and not (
+                ps.adapter == "claude-code"
+                and ps.target_file == _CLAUDE_CODE_USER_SETTINGS_DEFAULT
+            ):
+                lines.append(f"target-file = {_emit_basic_string(ps.target_file)}")
         primitives_repr = ", ".join(_emit_basic_string(p) for p in ps.primitives)
         lines.append(f"primitives = [{primitives_repr}]")
         lines.append("")
@@ -260,6 +334,16 @@ def dump_state(state: State) -> str:
             for pname, version in sorted(primitives.items()):
                 lines.append(f"[pack.{_toml_key(name)}.{ptype}.{_toml_key(pname)}]")
                 lines.append(f"version = {_emit_basic_string(version)}")
+                lines.append("")
+        # RFC-0005 v0.3: `[[pack.<name>.hook-wiring-owned]]` rows. Order
+        # is the in-memory order — install appends; uninstall walks the
+        # stored list. T8a does not introduce sort discipline; T8b/T9
+        # will lock that down if needed.
+        if state.schema_version == "0.3" and ps.hook_wiring_owned:
+            for entry in ps.hook_wiring_owned:
+                lines.append(f"[[pack.{_toml_key(name)}.hook-wiring-owned]]")
+                for key in sorted(entry):
+                    lines.append(f"{key} = {_emit_basic_string(entry[key])}")
                 lines.append("")
     return "\n".join(lines).rstrip() + "\n"
 

--- a/packages/agentbundle/tests/unit/test_state_v02.py
+++ b/packages/agentbundle/tests/unit/test_state_v02.py
@@ -94,13 +94,22 @@ def test_load_state_for_write_refuses_v01(tmp_path):
     assert "init-state --migrate" in str(ei.value)
 
 
-def test_load_state_for_write_accepts_v02(tmp_path):
-    """A v0.2 file does not raise on for_write=True."""
+def test_load_state_for_write_refuses_v02(tmp_path):
+    """RFC-0005 / AC22: v0.2 became legacy on the v0.3 contract bump (T8a).
+
+    Reads of v0.2 still work (legacy compatibility); writes refuse with the
+    same refuse-and-explain shape v0.1 uses, just naming version 0.2."""
     p = _write(
         tmp_path / "s.toml",
         'schema-version = "0.2"\n\n[pack.demo]\ninstalled-version = "0.1.0"\nscope = "repo"\nprimitives = []\n[pack.demo.files]\n',
     )
-    state = config.load_state(p, for_write=True)
+    with pytest.raises(config.StateFileLegacy) as ei:
+        config.load_state(p, for_write=True)
+    assert "schema-version 0.2" in str(ei.value)
+    assert "init-state --migrate" in str(ei.value)
+
+    # Read-only path still parses cleanly.
+    state = config.load_state(p, for_write=False)
     assert state.schema_version == "0.2"
     assert state.packs["demo"].scope == "repo"
 
@@ -135,8 +144,11 @@ def test_init_state_refuses_v01_state_file(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_migrate_rewrites_v01_to_v02(tmp_path):
-    """Every pack gains `scope = "repo"`; schema-version flips to 0.2."""
+def test_migrate_rewrites_v01_to_current(tmp_path):
+    """Every pack gains `scope = "repo"`; schema-version flips to the
+    current ``STATE_SCHEMA_VERSION`` (v0.3 under T8a). The v0.1 → v0.2
+    invariant lands in one step alongside the header-only v0.2 → v0.3
+    bump because the two compose cleanly (RFC-0005 § State-file impact)."""
     state_path = _write(tmp_path / ".agent-ready-state.toml", V01_TWO_PACKS)
     args = argparse.Namespace(
         root=str(tmp_path),
@@ -149,7 +161,7 @@ def test_migrate_rewrites_v01_to_v02(tmp_path):
     assert rc == 0
 
     migrated = config.load_state(state_path)
-    assert migrated.schema_version == "0.2"
+    assert migrated.schema_version == config.STATE_SCHEMA_VERSION
     assert all(ps.scope == "repo" for ps in migrated.packs.values())
     # SHAs preserved.
     assert migrated.packs["core"].file_sha("AGENTS.md") == "aa"

--- a/packages/agentbundle/tests/unit/test_state_v0_3_schema.py
+++ b/packages/agentbundle/tests/unit/test_state_v0_3_schema.py
@@ -82,8 +82,12 @@ class V03ReadTimeDefaultsTests(unittest.TestCase):
         state = config.load_state(path, for_write=False)
         self.assertEqual(state.packs["demo"].target_file, "~/.claude/settings.json")
 
-    def test_kiro_row_requires_target_file(self) -> None:
-        """AC21: kiro rows have NO ``target-file`` default — readers refuse."""
+    def test_kiro_row_without_target_file_reads_as_none(self) -> None:
+        """AC21: kiro rows have NO ``target-file`` default. The read path
+        stays operationally tolerant — returns None — so ``init-state
+        --migrate`` can still operate on a malformed v0.3. Consumers
+        that need the field (T8b/T8c install / upgrade walkers)
+        surface their own errors when they go to use it."""
         from agentbundle import config
 
         toml_text = textwrap.dedent("""
@@ -101,10 +105,9 @@ class V03ReadTimeDefaultsTests(unittest.TestCase):
         """).strip() + "\n"
 
         path = _write_tmp(self, toml_text)
-        with self.assertRaises(config.ConfigError) as ctx:
-            config.load_state(path, for_write=False)
-        self.assertIn("kiro", str(ctx.exception))
-        self.assertIn("target-file", str(ctx.exception))
+        state = config.load_state(path, for_write=False)
+        self.assertEqual(state.packs["demo"].adapter, "kiro")
+        self.assertIsNone(state.packs["demo"].target_file)
 
     def test_kiro_row_with_target_file_accepted(self) -> None:
         from agentbundle import config
@@ -289,21 +292,55 @@ class V02MigrateHeaderOnlyTests(unittest.TestCase):
         rc = cmd.run(args)
         self.assertEqual(rc, 0)
 
+        # Byte-level invariant: exactly the version line changes.
         new_text = state_path.read_text(encoding="utf-8")
-        self.assertIn('schema-version = "0.3"', new_text)
-        self.assertNotIn('schema-version = "0.2"', new_text)
-
-        # Every body line besides the version header must be byte-identical.
-        old_body = "\n".join(
-            line for line in v02_text.splitlines() if not line.startswith("schema-version")
-        )
-        new_body = "\n".join(
-            line for line in new_text.splitlines() if not line.startswith("schema-version")
+        expected = v02_text.replace(
+            'schema-version = "0.2"', 'schema-version = "0.3"', 1
         )
         self.assertEqual(
-            old_body.strip(),
-            new_body.strip(),
-            "migrate rewrote body bytes; expected header-only-additive",
+            new_text,
+            expected,
+            "migrate rewrote bytes outside the schema-version line",
+        )
+
+    def test_migrate_v03_to_v03_is_byte_identity(self) -> None:
+        """Idempotence at the byte level — running ``--migrate`` against an
+        already-v0.3 file must not strip explicit-default rows. Concern
+        raised by adversarial review: the prior full-re-serialize path
+        silently drops ``target-file = "~/.claude/settings.json"`` when
+        it matches the read-time default."""
+        import argparse
+
+        from agentbundle.commands import init_state as cmd
+
+        v03_text = textwrap.dedent("""
+            schema-version = "0.3"
+
+            [pack.demo]
+            installed-version = "0.1.0"
+            source = "agent-ready-repo"
+            install-route = "cli"
+            scope = "repo"
+            target-file = "~/.claude/settings.json"
+            primitives = []
+
+            [pack.demo.files]
+        """).strip() + "\n"
+
+        repo_root, state_path = _write_state_in_repo(self, v03_text)
+        args = argparse.Namespace(
+            migrate=True,
+            scope="repo",
+            root=str(repo_root),
+        )
+        rc = cmd.run(args)
+        self.assertEqual(rc, 0)
+
+        new_text = state_path.read_text(encoding="utf-8")
+        self.assertEqual(
+            new_text,
+            v03_text,
+            "already-v0.3 migrate must be byte-identity (target-file stripped?)",
         )
 
     def test_migrate_already_v03_is_idempotent(self) -> None:

--- a/packages/agentbundle/tests/unit/test_state_v0_3_schema.py
+++ b/packages/agentbundle/tests/unit/test_state_v0_3_schema.py
@@ -1,0 +1,399 @@
+"""T8a: state-file schema v0.3 — additive bump + header-only migration.
+
+Covers acceptance criteria AC20, AC21, AC22 from spec.md and the plan
+T8a Tests subsection.
+
+Read-time defaults (RFC-0005 § State-file impact):
+  - Absent ``adapter`` on a row → ``"claude-code"``.
+  - Absent ``target-file`` on a claude-code row → ``"~/.claude/settings.json"``.
+  - Absent ``target-file`` on a kiro row → required; reader refuses.
+
+Write-time refuse-and-explain:
+  - Write paths against a v0.2 state file raise the v0.2 stale-schema
+    refusal with the standard "run 'agentbundle init-state --migrate' first"
+    text shape.
+
+``init-state --migrate`` semantics:
+  - v0.2 → v0.3 is **header-only**: rewrite only the schema-version line,
+    no per-row backfill. Round-trip preserves every other byte (except
+    final-newline normalisation).
+  - v0.1 → v0.3 is the legacy full re-serialize path; lands at v0.3
+    directly with the v0.1 → v0.2 scope-column backfill applied.
+"""
+
+from __future__ import annotations
+
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class StateSchemaVersionTests(unittest.TestCase):
+    def test_state_schema_version_is_0_3(self) -> None:
+        from agentbundle import config
+
+        self.assertEqual(config.STATE_SCHEMA_VERSION, "0.3")
+
+
+class V03ReadTimeDefaultsTests(unittest.TestCase):
+    """A v0.3 reader resolves absent optional fields to their declared defaults."""
+
+    def test_absent_adapter_defaults_to_claude_code(self) -> None:
+        """AC21: a v0.3 row with no ``adapter`` reads as ``claude-code``."""
+        from agentbundle import config
+
+        toml_text = textwrap.dedent("""
+            schema-version = "0.3"
+
+            [pack.demo]
+            installed-version = "0.1.0"
+            source = "agent-ready-repo"
+            install-route = "cli"
+            scope = "user"
+            primitives = []
+
+            [pack.demo.files]
+        """).strip() + "\n"
+
+        path = _write_tmp(self, toml_text)
+        state = config.load_state(path, for_write=False)
+        self.assertEqual(state.schema_version, "0.3")
+        self.assertEqual(state.packs["demo"].adapter, "claude-code")
+
+    def test_absent_target_file_for_claude_code_defaults_to_settings(self) -> None:
+        """AC21: claude-code rows with no ``target-file`` resolve to
+        ``~/.claude/settings.json`` — the adapter's user-scope default."""
+        from agentbundle import config
+
+        toml_text = textwrap.dedent("""
+            schema-version = "0.3"
+
+            [pack.demo]
+            installed-version = "0.1.0"
+            source = "agent-ready-repo"
+            install-route = "cli"
+            scope = "user"
+            primitives = []
+
+            [pack.demo.files]
+        """).strip() + "\n"
+
+        path = _write_tmp(self, toml_text)
+        state = config.load_state(path, for_write=False)
+        self.assertEqual(state.packs["demo"].target_file, "~/.claude/settings.json")
+
+    def test_kiro_row_requires_target_file(self) -> None:
+        """AC21: kiro rows have NO ``target-file`` default — readers refuse."""
+        from agentbundle import config
+
+        toml_text = textwrap.dedent("""
+            schema-version = "0.3"
+
+            [pack.demo]
+            installed-version = "0.1.0"
+            source = "agent-ready-repo"
+            install-route = "cli"
+            scope = "user"
+            adapter = "kiro"
+            primitives = []
+
+            [pack.demo.files]
+        """).strip() + "\n"
+
+        path = _write_tmp(self, toml_text)
+        with self.assertRaises(config.ConfigError) as ctx:
+            config.load_state(path, for_write=False)
+        self.assertIn("kiro", str(ctx.exception))
+        self.assertIn("target-file", str(ctx.exception))
+
+    def test_kiro_row_with_target_file_accepted(self) -> None:
+        from agentbundle import config
+
+        toml_text = textwrap.dedent("""
+            schema-version = "0.3"
+
+            [pack.demo]
+            installed-version = "0.1.0"
+            source = "agent-ready-repo"
+            install-route = "cli"
+            scope = "repo"
+            adapter = "kiro"
+            target-file = ".kiro/agents/reviewer.json"
+            primitives = []
+
+            [pack.demo.files]
+        """).strip() + "\n"
+
+        path = _write_tmp(self, toml_text)
+        state = config.load_state(path, for_write=False)
+        self.assertEqual(state.packs["demo"].adapter, "kiro")
+        self.assertEqual(state.packs["demo"].target_file, ".kiro/agents/reviewer.json")
+
+    def test_explicit_claude_code_target_file_overrides_default(self) -> None:
+        """An explicit ``target-file`` always wins over the read-time default."""
+        from agentbundle import config
+
+        toml_text = textwrap.dedent("""
+            schema-version = "0.3"
+
+            [pack.demo]
+            installed-version = "0.1.0"
+            source = "agent-ready-repo"
+            install-route = "cli"
+            scope = "repo"
+            adapter = "claude-code"
+            target-file = ".claude/settings.local.json"
+            primitives = []
+
+            [pack.demo.files]
+        """).strip() + "\n"
+
+        path = _write_tmp(self, toml_text)
+        state = config.load_state(path, for_write=False)
+        self.assertEqual(state.packs["demo"].target_file, ".claude/settings.local.json")
+
+
+class HookWiringOwnedTests(unittest.TestCase):
+    """AC20: rows grow an optional ``hook-wiring-owned`` array-of-tables."""
+
+    def test_hook_wiring_owned_round_trip(self) -> None:
+        from agentbundle import config
+
+        toml_text = textwrap.dedent("""
+            schema-version = "0.3"
+
+            [pack.demo]
+            installed-version = "0.1.0"
+            source = "agent-ready-repo"
+            install-route = "cli"
+            scope = "user"
+            primitives = []
+
+            [pack.demo.files]
+
+            [[pack.demo.hook-wiring-owned]]
+            event = "UserPromptSubmit"
+            id = "demo:on-prompt"
+
+            [[pack.demo.hook-wiring-owned]]
+            event = "SessionStart"
+            id = "demo:on-session"
+        """).strip() + "\n"
+
+        path = _write_tmp(self, toml_text)
+        state = config.load_state(path, for_write=False)
+        owned = state.packs["demo"].hook_wiring_owned
+        self.assertEqual(len(owned), 2)
+        self.assertEqual(owned[0]["event"], "UserPromptSubmit")
+        self.assertEqual(owned[0]["id"], "demo:on-prompt")
+        self.assertEqual(owned[1]["event"], "SessionStart")
+
+    def test_absent_hook_wiring_owned_is_empty_list(self) -> None:
+        from agentbundle import config
+
+        toml_text = textwrap.dedent("""
+            schema-version = "0.3"
+
+            [pack.demo]
+            installed-version = "0.1.0"
+            source = "agent-ready-repo"
+            install-route = "cli"
+            scope = "repo"
+            primitives = []
+
+            [pack.demo.files]
+        """).strip() + "\n"
+
+        path = _write_tmp(self, toml_text)
+        state = config.load_state(path, for_write=False)
+        self.assertEqual(state.packs["demo"].hook_wiring_owned, [])
+
+
+class V02WriteRefusedTests(unittest.TestCase):
+    """AC22: a v0.2 state file refuses write-capable load with the exact
+    refuse-and-explain text the v0.1 → v0.2 migration established."""
+
+    def test_v02_load_for_write_raises_legacy(self) -> None:
+        from agentbundle import config
+
+        toml_text = textwrap.dedent("""
+            schema-version = "0.2"
+
+            [pack.demo]
+            installed-version = "0.1.0"
+            source = "agent-ready-repo"
+            install-route = "cli"
+            scope = "repo"
+            primitives = []
+
+            [pack.demo.files]
+        """).strip() + "\n"
+
+        path = _write_tmp(self, toml_text)
+        with self.assertRaises(config.ConfigError) as ctx:
+            config.load_state(path, for_write=True)
+        self.assertIn("0.2", str(ctx.exception))
+        self.assertIn("init-state --migrate", str(ctx.exception))
+
+    def test_v02_load_for_read_still_works(self) -> None:
+        """Read paths still parse v0.2 (legacy compatibility) — only writes refuse."""
+        from agentbundle import config
+
+        toml_text = textwrap.dedent("""
+            schema-version = "0.2"
+
+            [pack.demo]
+            installed-version = "0.1.0"
+            source = "agent-ready-repo"
+            install-route = "cli"
+            scope = "repo"
+            primitives = []
+
+            [pack.demo.files]
+        """).strip() + "\n"
+
+        path = _write_tmp(self, toml_text)
+        state = config.load_state(path, for_write=False)
+        self.assertEqual(state.schema_version, "0.2")
+        self.assertIn("demo", state.packs)
+
+
+class V02MigrateHeaderOnlyTests(unittest.TestCase):
+    """AC21: ``init-state --migrate`` on a v0.2 file rewrites only the
+    schema-version line. Body bytes are preserved (no per-row backfill)."""
+
+    def test_migrate_v02_to_v03_rewrites_only_version_line(self) -> None:
+        import argparse
+
+        from agentbundle.commands import init_state as cmd
+
+        v02_text = textwrap.dedent("""
+            schema-version = "0.2"
+
+            [pack.demo]
+            installed-version = "0.1.0"
+            source = "agent-ready-repo"
+            install-route = "cli"
+            scope = "repo"
+            primitives = []
+
+            [pack.demo.files]
+        """).strip() + "\n"
+
+        repo_root, state_path = _write_state_in_repo(self, v02_text)
+        args = argparse.Namespace(
+            migrate=True,
+            scope="repo",
+            root=str(repo_root),
+        )
+        rc = cmd.run(args)
+        self.assertEqual(rc, 0)
+
+        new_text = state_path.read_text(encoding="utf-8")
+        self.assertIn('schema-version = "0.3"', new_text)
+        self.assertNotIn('schema-version = "0.2"', new_text)
+
+        # Every body line besides the version header must be byte-identical.
+        old_body = "\n".join(
+            line for line in v02_text.splitlines() if not line.startswith("schema-version")
+        )
+        new_body = "\n".join(
+            line for line in new_text.splitlines() if not line.startswith("schema-version")
+        )
+        self.assertEqual(
+            old_body.strip(),
+            new_body.strip(),
+            "migrate rewrote body bytes; expected header-only-additive",
+        )
+
+    def test_migrate_already_v03_is_idempotent(self) -> None:
+        import argparse
+
+        from agentbundle.commands import init_state as cmd
+
+        v03_text = textwrap.dedent("""
+            schema-version = "0.3"
+
+            [pack.demo]
+            installed-version = "0.1.0"
+            source = "agent-ready-repo"
+            install-route = "cli"
+            scope = "repo"
+            primitives = []
+
+            [pack.demo.files]
+        """).strip() + "\n"
+
+        repo_root, state_path = _write_state_in_repo(self, v03_text)
+        args = argparse.Namespace(
+            migrate=True,
+            scope="repo",
+            root=str(repo_root),
+        )
+        rc = cmd.run(args)
+        self.assertEqual(rc, 0)
+        self.assertIn('schema-version = "0.3"', state_path.read_text(encoding="utf-8"))
+
+
+class V01MigrateLegacyPathTests(unittest.TestCase):
+    """v0.1 → v0.3 still works (single-step full re-serialize)."""
+
+    def test_migrate_v01_lands_at_v03_with_scope_column(self) -> None:
+        import argparse
+
+        from agentbundle.commands import init_state as cmd
+
+        v01_text = textwrap.dedent("""
+            schema-version = "0.1"
+
+            [pack.demo]
+            installed-version = "0.1.0"
+            source = "agent-ready-repo"
+            install-route = "cli"
+            primitives = []
+
+            [pack.demo.files]
+        """).strip() + "\n"
+
+        repo_root, state_path = _write_state_in_repo(self, v01_text)
+        args = argparse.Namespace(
+            migrate=True,
+            scope="repo",
+            root=str(repo_root),
+        )
+        rc = cmd.run(args)
+        self.assertEqual(rc, 0)
+        new_text = state_path.read_text(encoding="utf-8")
+        self.assertIn('schema-version = "0.3"', new_text)
+        self.assertIn('scope = "repo"', new_text)
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_tmp(test: unittest.TestCase, text: str) -> Path:
+    """Write *text* to a unique tempfile and register cleanup."""
+    import tempfile
+
+    fd_dir = tempfile.mkdtemp()
+    test.addCleanup(__import__("shutil").rmtree, fd_dir, ignore_errors=True)
+    path = Path(fd_dir) / ".agent-ready-state.toml"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _write_state_in_repo(test: unittest.TestCase, text: str) -> tuple[Path, Path]:
+    """Create a synthetic repo root with a state file at the expected path."""
+    import tempfile
+
+    repo = Path(tempfile.mkdtemp())
+    test.addCleanup(__import__("shutil").rmtree, str(repo), ignore_errors=True)
+    state_path = repo / ".agent-ready-state.toml"
+    state_path.write_text(text, encoding="utf-8")
+    return repo, state_path
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/agentbundle/tests/unit/test_target_resolver.py
+++ b/packages/agentbundle/tests/unit/test_target_resolver.py
@@ -1,0 +1,181 @@
+"""T4: scope-conditional `target` resolver — pure-function unit tests.
+
+Resolves the v0.3 contract's `target` field shape (string or
+`{repo, user}` scope-map) plus the `<attach-to-agent>` placeholder
+substitution for `merge-into-agent-json` consumers (T5/T6). The
+resolver returns a *string* template; scope-root resolution and
+filesystem placement are caller concerns.
+
+Tests cover the bullets under spec.md AC3, AC4, AC15, AC18 plus the
+T4 plan's internal acceptance bullets.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+
+class ResolveTargetBareStringTests(unittest.TestCase):
+    """Legacy / v0.1-shape projections declare `target` as a bare string."""
+
+    def test_bare_string_returns_unchanged_for_repo(self) -> None:
+        from agentbundle.build.target_resolver import resolve_target
+
+        projection = {"target": "tools/hooks/<name>.{sh,py}"}
+        self.assertEqual(
+            resolve_target(projection, scope="repo"),
+            "tools/hooks/<name>.{sh,py}",
+        )
+
+    def test_bare_string_returns_unchanged_for_user(self) -> None:
+        """The bare string is the entire target template — scope doesn't fork it."""
+        from agentbundle.build.target_resolver import resolve_target
+
+        projection = {"target": "tools/hooks/<name>.{sh,py}"}
+        self.assertEqual(
+            resolve_target(projection, scope="user"),
+            "tools/hooks/<name>.{sh,py}",
+        )
+
+
+class ResolveTargetScopeMapTests(unittest.TestCase):
+    """v0.3 scope-map declarations fork by scope."""
+
+    def test_scope_map_returns_repo_target(self) -> None:
+        from agentbundle.build.target_resolver import resolve_target
+
+        projection = {
+            "target": {
+                "repo": "tools/hooks/<name>.{sh,py}",
+                "user": ".claude/hooks/<name>.{sh,py}",
+            }
+        }
+        self.assertEqual(
+            resolve_target(projection, scope="repo"),
+            "tools/hooks/<name>.{sh,py}",
+        )
+
+    def test_scope_map_returns_user_target(self) -> None:
+        from agentbundle.build.target_resolver import resolve_target
+
+        projection = {
+            "target": {
+                "repo": "tools/hooks/<name>.{sh,py}",
+                "user": ".claude/hooks/<name>.{sh,py}",
+            }
+        }
+        self.assertEqual(
+            resolve_target(projection, scope="user"),
+            ".claude/hooks/<name>.{sh,py}",
+        )
+
+    def test_scope_map_returns_only_declared_branch(self) -> None:
+        """An asymmetric scope-map (e.g. only `repo` declared) is allowed; the
+        absent scope refuses (see the missing-scope test). The declared one
+        resolves cleanly."""
+        from agentbundle.build.target_resolver import resolve_target
+
+        projection = {"target": {"repo": "tools/only.json"}}
+        self.assertEqual(resolve_target(projection, scope="repo"), "tools/only.json")
+
+
+class ResolveTargetMissingScopeTests(unittest.TestCase):
+    """Requesting a scope the projection doesn't declare is an error."""
+
+    def test_user_scope_missing_in_scope_map_refuses(self) -> None:
+        from agentbundle.build.target_resolver import resolve_target
+
+        projection = {"target": {"repo": ".claude/settings.local.json"}}
+        with self.assertRaises(ValueError) as ctx:
+            resolve_target(projection, scope="user")
+        # Refusal text names the missing scope so the caller can act on it.
+        self.assertIn("user", str(ctx.exception))
+
+    def test_repo_scope_missing_in_scope_map_refuses(self) -> None:
+        from agentbundle.build.target_resolver import resolve_target
+
+        projection = {"target": {"user": ".claude/settings.json"}}
+        with self.assertRaises(ValueError) as ctx:
+            resolve_target(projection, scope="repo")
+        self.assertIn("repo", str(ctx.exception))
+
+    def test_missing_target_field_refuses(self) -> None:
+        from agentbundle.build.target_resolver import resolve_target
+
+        with self.assertRaises(ValueError):
+            resolve_target({}, scope="repo")
+
+
+class ResolveTargetAttachToAgentTests(unittest.TestCase):
+    """`merge-into-agent-json` targets carry the `<attach-to-agent>` placeholder;
+    the resolver substitutes it when given the agent name. Other placeholders
+    (`<name>`, `<pack>`) are NOT substituted — they're the pipeline's concern."""
+
+    def test_substitutes_attach_to_agent_in_bare_string(self) -> None:
+        from agentbundle.build.target_resolver import resolve_target
+
+        projection = {"target": ".kiro/agents/<attach-to-agent>.json"}
+        self.assertEqual(
+            resolve_target(projection, scope="repo", attach_to_agent="reviewer"),
+            ".kiro/agents/reviewer.json",
+        )
+
+    def test_substitutes_attach_to_agent_in_scope_map(self) -> None:
+        from agentbundle.build.target_resolver import resolve_target
+
+        projection = {
+            "target": {
+                "repo": ".kiro/agents/<attach-to-agent>.json",
+                "user": ".kiro/agents/<attach-to-agent>.json",
+            }
+        }
+        self.assertEqual(
+            resolve_target(projection, scope="user", attach_to_agent="clipboard-watcher"),
+            ".kiro/agents/clipboard-watcher.json",
+        )
+
+    def test_leaves_other_placeholders_untouched(self) -> None:
+        """`<name>` is a separate pipeline concern; the resolver does not touch it."""
+        from agentbundle.build.target_resolver import resolve_target
+
+        projection = {"target": "tools/hooks/<name>.{sh,py}"}
+        result = resolve_target(projection, scope="repo", attach_to_agent="reviewer")
+        # `<name>` survives; `<attach-to-agent>` would have been substituted if present.
+        self.assertEqual(result, "tools/hooks/<name>.{sh,py}")
+
+    def test_unfilled_attach_to_agent_placeholder_refuses(self) -> None:
+        """If the template requires `<attach-to-agent>` but no name is given,
+        passing the unsubstituted template to a consumer would be a bug."""
+        from agentbundle.build.target_resolver import resolve_target
+
+        projection = {"target": ".kiro/agents/<attach-to-agent>.json"}
+        with self.assertRaises(ValueError) as ctx:
+            resolve_target(projection, scope="repo")
+        self.assertIn("attach-to-agent", str(ctx.exception))
+
+    def test_attach_to_agent_ignored_when_placeholder_absent(self) -> None:
+        """Providing `attach_to_agent` when the template doesn't reference it
+        is a no-op — the caller may pass it unconditionally for shape uniformity."""
+        from agentbundle.build.target_resolver import resolve_target
+
+        projection = {"target": "tools/hooks/static.json"}
+        self.assertEqual(
+            resolve_target(projection, scope="repo", attach_to_agent="reviewer"),
+            "tools/hooks/static.json",
+        )
+
+
+class ResolveTargetReturnTypeTests(unittest.TestCase):
+    """Resolver returns `str`, not `Path` — pipeline consumers do scope-root
+    resolution against `.` or `~` themselves (the resolver is a pure
+    string-shape utility, no filesystem dependency)."""
+
+    def test_returns_str_not_path(self) -> None:
+        from agentbundle.build.target_resolver import resolve_target
+
+        result = resolve_target({"target": "tools/hooks/<name>.{sh,py}"}, scope="repo")
+        self.assertIsInstance(result, str)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/agentbundle/tests/unit/test_validate_attach_to_agent.py
+++ b/packages/agentbundle/tests/unit/test_validate_attach_to_agent.py
@@ -1,0 +1,255 @@
+"""T2: kiro hook-wiring `attach-to-agent` validate rail.
+
+In-memory tests of the pure rail function `check_kiro_attach_to_agent`
+plus filesystem-shaped tests of the wrapper `check_kiro_wiring`. Pack-
+shaped dicts are constructed inline; no on-disk fixture packs are used
+(those land in T3 and exercise the same rails via the integration path).
+
+Acceptance criterion the rail covers: spec AC6.
+Refusal text (RFC-0005 § Repo-scope Kiro promotion):
+    pack <P>'s hook-wiring <name>.toml does not declare 'attach-to-agent'
+    (or names an unknown agent); required for kiro projection
+"""
+
+from __future__ import annotations
+
+import textwrap
+import unittest
+from pathlib import Path
+
+REFUSAL_PREFIX = "pack {pack}'s hook-wiring {name}.toml does not declare 'attach-to-agent'"
+
+
+class InMemoryRailKiroTargetedTests(unittest.TestCase):
+    """Rail fires when `kiro` is in target_adapters."""
+
+    def test_refuses_wiring_without_attach_to_agent(self) -> None:
+        from agentbundle.build.scope_rails import check_kiro_attach_to_agent
+
+        refusal = check_kiro_attach_to_agent(
+            pack_name="personal-reviewers",
+            wiring_tomls={"on-prompt": {"hooks": {"userPromptSubmit": [{"command": "x"}]}}},
+            agent_basenames={"reviewer"},
+            target_adapters={"kiro"},
+        )
+        self.assertIsNotNone(refusal)
+        self.assertIn("personal-reviewers", refusal)
+        self.assertIn("on-prompt.toml", refusal)
+        self.assertIn("does not declare 'attach-to-agent'", refusal)
+        self.assertIn("required for kiro projection", refusal)
+
+    def test_refuses_attach_to_agent_naming_unknown_agent(self) -> None:
+        from agentbundle.build.scope_rails import check_kiro_attach_to_agent
+
+        refusal = check_kiro_attach_to_agent(
+            pack_name="clipboard-summary",
+            wiring_tomls={"on-prompt": {"attach-to-agent": "non-existent"}},
+            agent_basenames={"clipboard-watcher"},
+            target_adapters={"kiro"},
+        )
+        self.assertIsNotNone(refusal)
+        self.assertIn("clipboard-summary", refusal)
+        self.assertIn("or names an unknown agent", refusal)
+
+    def test_refuses_attach_to_agent_of_wrong_type(self) -> None:
+        """A non-string `attach-to-agent` is shape-wrong; the rail treats it the same as missing."""
+        from agentbundle.build.scope_rails import check_kiro_attach_to_agent
+
+        refusal = check_kiro_attach_to_agent(
+            pack_name="demo",
+            wiring_tomls={"on-prompt": {"attach-to-agent": ["reviewer"]}},
+            agent_basenames={"reviewer"},
+            target_adapters={"kiro"},
+        )
+        self.assertIsNotNone(refusal)
+
+    def test_accepts_attach_to_agent_naming_known_agent(self) -> None:
+        from agentbundle.build.scope_rails import check_kiro_attach_to_agent
+
+        refusal = check_kiro_attach_to_agent(
+            pack_name="personal-reviewers",
+            wiring_tomls={"on-prompt": {"attach-to-agent": "reviewer"}},
+            agent_basenames={"reviewer"},
+            target_adapters={"kiro"},
+        )
+        self.assertIsNone(refusal)
+
+    def test_first_offender_wins(self) -> None:
+        """Multiple wiring TOMLs — the rail surfaces the first failure only."""
+        from agentbundle.build.scope_rails import check_kiro_attach_to_agent
+
+        refusal = check_kiro_attach_to_agent(
+            pack_name="demo",
+            wiring_tomls={
+                "a": {"attach-to-agent": "reviewer"},
+                "b": {},
+                "c": {"attach-to-agent": "missing"},
+            },
+            agent_basenames={"reviewer"},
+            target_adapters={"kiro"},
+        )
+        self.assertIsNotNone(refusal)
+        self.assertIn("b.toml", refusal)
+        self.assertNotIn("c.toml", refusal)
+
+
+class InMemoryRailNonKiroTargetTests(unittest.TestCase):
+    """Rail is a no-op when kiro isn't in target_adapters — Claude-Code-only packs."""
+
+    def test_claude_code_only_with_attach_to_agent_accepted(self) -> None:
+        """AC6 / plan T2: a Claude-Code-only pack with `attach-to-agent` present
+        — the field is ignored, not refused."""
+        from agentbundle.build.scope_rails import check_kiro_attach_to_agent
+
+        refusal = check_kiro_attach_to_agent(
+            pack_name="demo",
+            wiring_tomls={"on-prompt": {"attach-to-agent": "anything"}},
+            agent_basenames=set(),  # no agents shipped
+            target_adapters={"claude-code"},
+        )
+        self.assertIsNone(refusal)
+
+    def test_claude_code_only_without_attach_to_agent_accepted(self) -> None:
+        """Claude-Code-only packs don't need `attach-to-agent` — the rail must
+        be a no-op for them regardless of wiring shape."""
+        from agentbundle.build.scope_rails import check_kiro_attach_to_agent
+
+        refusal = check_kiro_attach_to_agent(
+            pack_name="demo",
+            wiring_tomls={"on-prompt": {}},
+            agent_basenames=set(),
+            target_adapters={"claude-code"},
+        )
+        self.assertIsNone(refusal)
+
+    def test_empty_target_adapters_accepted(self) -> None:
+        from agentbundle.build.scope_rails import check_kiro_attach_to_agent
+
+        refusal = check_kiro_attach_to_agent(
+            pack_name="demo",
+            wiring_tomls={"on-prompt": {}},
+            agent_basenames=set(),
+            target_adapters=set(),
+        )
+        self.assertIsNone(refusal)
+
+
+class InMemoryRailEmptyWiringTests(unittest.TestCase):
+    """Rail no-op when the pack ships no hook-wiring."""
+
+    def test_no_wiring_no_refusal(self) -> None:
+        from agentbundle.build.scope_rails import check_kiro_attach_to_agent
+
+        refusal = check_kiro_attach_to_agent(
+            pack_name="demo",
+            wiring_tomls={},
+            agent_basenames={"reviewer"},
+            target_adapters={"kiro"},
+        )
+        self.assertIsNone(refusal)
+
+
+class FilesystemWrapperTests(unittest.TestCase):
+    """`check_kiro_wiring` reads from disk, parses each wiring TOML with
+    tomllib, and delegates to the in-memory rail. A malformed wiring TOML
+    refuses on its own (per RFC-0005's refuse-and-explain pattern)."""
+
+    def _make_pack(self, tmp_path: Path, *, wiring: dict[str, str], agents: list[str]) -> Path:
+        pack = tmp_path / "demo-pack"
+        (pack / ".apm" / "hook-wiring").mkdir(parents=True, exist_ok=True)
+        for name, body in wiring.items():
+            (pack / ".apm" / "hook-wiring" / f"{name}.toml").write_text(
+                body, encoding="utf-8"
+            )
+        if agents:
+            (pack / ".apm" / "agents").mkdir(parents=True, exist_ok=True)
+            for name in agents:
+                (pack / ".apm" / "agents" / f"{name}.md").write_text(
+                    f"# {name}\n", encoding="utf-8"
+                )
+        return pack
+
+    def test_filesystem_wrapper_refuses_missing_attach_to_agent(self) -> None:
+        import tempfile
+
+        from agentbundle.build.scope_rails import check_kiro_wiring
+
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            pack = self._make_pack(
+                tmp,
+                wiring={"on-prompt": '[[hooks.userPromptSubmit]]\ncommand = "x"\n'},
+                agents=["reviewer"],
+            )
+            refusal = check_kiro_wiring(pack, "demo-pack", {"kiro"})
+            self.assertIsNotNone(refusal)
+            self.assertIn("does not declare 'attach-to-agent'", refusal)
+
+    def test_filesystem_wrapper_accepts_well_formed_pack(self) -> None:
+        import tempfile
+
+        from agentbundle.build.scope_rails import check_kiro_wiring
+
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            pack = self._make_pack(
+                tmp,
+                wiring={
+                    "on-prompt": textwrap.dedent("""
+                        attach-to-agent = "reviewer"
+
+                        [[hooks.userPromptSubmit]]
+                        command = "do-thing"
+                    """).strip()
+                },
+                agents=["reviewer"],
+            )
+            self.assertIsNone(check_kiro_wiring(pack, "demo-pack", {"kiro"}))
+
+    def test_filesystem_wrapper_skips_when_no_kiro_in_targets(self) -> None:
+        import tempfile
+
+        from agentbundle.build.scope_rails import check_kiro_wiring
+
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            pack = self._make_pack(
+                tmp,
+                wiring={"on-prompt": '[[hooks.SomethingPascal]]\ncommand = "x"\n'},
+                agents=[],
+            )
+            # Same malformed shape as the "refuse" test, but no kiro target → no-op.
+            self.assertIsNone(check_kiro_wiring(pack, "demo-pack", {"claude-code"}))
+
+    def test_filesystem_wrapper_skips_pack_without_wiring_dir(self) -> None:
+        import tempfile
+
+        from agentbundle.build.scope_rails import check_kiro_wiring
+
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            pack = tmp / "demo-pack"
+            pack.mkdir()
+            self.assertIsNone(check_kiro_wiring(pack, "demo-pack", {"kiro"}))
+
+    def test_filesystem_wrapper_refuses_malformed_toml(self) -> None:
+        """A wiring TOML that fails to parse is a pack-author error; the rail
+        surfaces it with a clear refusal rather than a hidden tomllib trace."""
+        import tempfile
+
+        from agentbundle.build.scope_rails import check_kiro_wiring
+
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            pack = self._make_pack(
+                tmp,
+                wiring={"on-prompt": "this is not = valid = toml ["},
+                agents=["reviewer"],
+            )
+            refusal = check_kiro_wiring(pack, "demo-pack", {"kiro"})
+            self.assertIsNotNone(refusal)
+            self.assertIn("failed to parse", refusal)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Wave 2 of the [user-scope-hooks spec](../tree/main/docs/specs/user-scope-hooks/spec.md) — three independent tasks executed in parallel worktrees (supervisor mode), merged in task-id order. Second of thirteen PRs.

- **T2** — `check_kiro_attach_to_agent` (pure in-memory rail) + `check_kiro_wiring` (filesystem wrapper) in `agentbundle/build/scope_rails.py`. Wired into `commands/validate.py` after Rails A/B/C. Target-adapter resolution is heuristic — pack is treated as kiro-targeted when it ships v0.3 contract + both `.apm/agents/` and `.apm/hook-wiring/` content. Refusal text RFC-0005-verbatim.
- **T4** — New module `agentbundle/build/target_resolver.py`. Pure function `resolve_target(projection, scope, attach_to_agent=None) -> str` resolving the v0.3 string-or-scope-map `target` and substituting `<attach-to-agent>` when provided. `<name>` / `<pack>` placeholders survive verbatim (T5/T6's concern). Returns `str` rather than the plan's `-> Path` — pipeline consumers own scope-root resolution; deviation recorded in `plan.md` § T4 Approach.
- **T8a** — `STATE_SCHEMA_VERSION` bumped to `"0.3"`. `PackState` grows optional `adapter` / `target_file` / `hook_wiring_owned` with read-time defaults per RFC-0005 § State-file impact. `StateFileLegacy` now refuses v0.1 OR v0.2 on write. `init-state --migrate` gains a header-only-additive v0.2 → v0.3 path (regex on the schema-version line) plus byte-identity for already-v0.3.

## Acceptance criteria

- [x] **AC6.** Validate refuses Kiro-targeted hook-wiring TOMLs without `attach-to-agent` (or naming an unknown agent) with the RFC-0005 verbatim text. Claude-Code-only packs with `attach-to-agent` are accepted (field ignored).
- [x] **AC15, AC18.** `<attach-to-agent>` placeholder substitution by `resolve_target` (building block for T6).
- [x] **AC20.** State `[[installed]]` rows grow optional `adapter` + `target-file` + `[[hook-wiring-owned]]`.
- [x] **AC21.** Read-time defaults: absent `adapter` → `"claude-code"`; absent `target-file` on claude-code → `~/.claude/settings.json`; kiro rows read `target_file=None` when absent (operationally tolerant — consumers surface their own errors).
- [x] **AC22.** Write against a v0.2 (or v0.1) state file refuses with the `'agentbundle init-state --migrate' first` text.

## Supervisor-mode execution notes

Created three worktrees (`.worktrees/T2`, `.worktrees/T4`, `.worktrees/T8a`) and dispatched parallel implementer agents. **Implementer agents hit a harness Write-permission boundary in all three cases** — they could read but not create new files. I picked the work up directly in the main session and committed each task on its dedicated worktree branch, then merged them serially into wave2 in task-id order (T2 → T4 → T8a). No conflicts.

## Adversarial review

Two rounds. First round surfaced 1 Blocker + 6 Concerns + 3 Nits. Fixed:
1. **Blocker** — v0.3 binding was conflating with kiro-targeting; the rail would have refused T3's planned Claude-Code-only fixture. Replaced with a both-directories heuristic.
2. Concerns 2–7 all addressed in-PR (byte-identity migration, regex anchoring, symlink discipline, read-time tolerance for malformed kiro rows, round-trip-stable target-file emission).
3. Nit #8 addressed (plan.md records the `-> str` deviation).
4. Nits #9–10 declined (optional polish).

Second round: **Clean — ready to commit.**

## Test plan

- [x] 437 unit + integration tests pass (`pytest packages/agentbundle/ --ignore=tests/integration/test_version_gate_matrix.py`). The version-gate-matrix file has a pre-existing stale-symlink CI fixture issue unrelated to this PR.
- [x] `make build-check` exits 0.
- [x] `make validate` exits 0.
- [x] T2 covers AC6 (14 unit tests across in-memory rail + filesystem wrapper).
- [x] T4 covers AC3/AC4/AC15/AC18 (14 unit tests for the pure resolver).
- [x] T8a covers AC20/AC21/AC22 (14 unit tests including byte-identity migration + idempotence).

## Out of scope (later waves)

- T3 (fixture packs), T5 (`user-merge-json` Claude Code projection), T6 (`merge-into-agent-json` Kiro projection), T7 (build-pipeline phase order), T8b (install/uninstall threading + `--force-merge`), T8c (upgrade reconciliation), T9 (`reconcile --scope user` reporter), T10/T11 (spec amendments).