### PR TITLE
feat(fixtures): six hook-bearing packs + Rail B conditional lift (T3)

### DIFF
--- a/packages/agentbundle/agentbundle/build/scope_rails.py
+++ b/packages/agentbundle/agentbundle/build/scope_rails.py
@@ -110,13 +110,31 @@ def check_seeds(pack_path: Path, allowed_scopes: Iterable[str]) -> str | None:
     return None
 
 
-def check_hooks(pack_path: Path, allowed_scopes: Iterable[str]) -> str | None:
+def check_hooks(
+    pack_path: Path,
+    allowed_scopes: Iterable[str],
+    user_scope_hooks: bool = False,
+) -> str | None:
     """Rail B. Return None on accept; refusal string on refuse.
 
-    A pack containing a non-empty `.apm/hooks/` or `.apm/hook-wiring/`
-    directory cannot declare `"user" ∈ allowed-scopes`.
+    A pack containing a non-empty ``.apm/hooks/`` or
+    ``.apm/hook-wiring/`` directory cannot declare ``"user" ∈
+    allowed-scopes`` **unless** it explicitly opts in via
+    ``[pack.install] user-scope-hooks = true`` (RFC-0005 § Rail B —
+    user-scope lift). The opt-in is the consent gesture: "yes, my
+    hooks land on the adopter's machine outside per-project isolation".
+
+    The lift here is the validate-side half — T8b threads the same
+    flag through install/uninstall so the rail's behaviour stays
+    consistent between the two surfaces.
     """
     if not _allows_user(allowed_scopes):
+        return None
+    if user_scope_hooks:
+        # Pack-author opted in — RFC-0005 says the rail lifts. The
+        # adapter-side gate (hook-wiring mode declares user-scope
+        # capability) is checked later in the projection pipeline
+        # (T5/T6); the rail's job is the consent-gesture check.
         return None
     for hook_subdir in (".apm/hooks", ".apm/hook-wiring"):
         candidate = pack_path / hook_subdir
@@ -249,19 +267,25 @@ def _is_binary(data: bytes) -> bool:
 def run_all(
     pack_path: Path,
     allowed_scopes: Iterable[str],
+    user_scope_hooks: bool = False,
 ) -> str | None:
     """Run Rails A → B → C in spec order; return first refusal or None.
 
     The spec orders them A → B → C so the seeds rail fires before the
     marker rail's input is even computed (the marker rail never sees
-    `seeds/` content — Rail A already refused the pack if `seeds/` was
-    populated). Use this helper from the CLI's `install` and
-    `validate` surfaces to keep the message order consistent.
+    ``seeds/`` content — Rail A already refused the pack if ``seeds/``
+    was populated). Use this helper from the CLI's ``install`` and
+    ``validate`` surfaces to keep the message order consistent.
+
+    ``user_scope_hooks`` propagates to Rail B's conditional lift
+    (RFC-0005 § Rail B — user-scope lift). Rails A and C ignore it.
     """
-    for rail in (check_seeds, check_hooks, check_markers):
-        result = rail(pack_path, allowed_scopes)
-        if result is not None:
-            return result
+    if (result := check_seeds(pack_path, allowed_scopes)) is not None:
+        return result
+    if (result := check_hooks(pack_path, allowed_scopes, user_scope_hooks)) is not None:
+        return result
+    if (result := check_markers(pack_path, allowed_scopes)) is not None:
+        return result
     return None
 
 

--- a/packages/agentbundle/agentbundle/build/tests/test_scope_rails.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_scope_rails.py
@@ -130,6 +130,35 @@ class RailBHooksTests(unittest.TestCase):
             pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
             self.assertIsNone(check_hooks(pack, ["user"]))
 
+    def test_rail_b_lifts_when_user_scope_hooks_true(self) -> None:
+        """RFC-0005 § Rail B — user-scope lift: a pack that opts in via
+        ``user-scope-hooks = true`` is accepted even with hooks at user
+        scope. The flag is the consent gesture."""
+        from agentbundle.build.scope_rails import check_hooks
+
+        with tempfile.TemporaryDirectory() as td:
+            pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
+            (pack / ".apm" / "hooks").mkdir(parents=True)
+            (pack / ".apm" / "hooks" / "pre-pr.sh").write_text("#!/bin/sh\nexit 0\n")
+            self.assertIsNone(
+                check_hooks(pack, ["user"], user_scope_hooks=True),
+                "Rail B did not lift on user_scope_hooks=True",
+            )
+
+    def test_rail_b_refuses_without_user_scope_hooks_default(self) -> None:
+        """The default (user_scope_hooks=False) preserves the v0.2 refusal
+        behaviour — a pack with hooks at user scope is refused."""
+        from agentbundle.build.scope_rails import check_hooks
+
+        with tempfile.TemporaryDirectory() as td:
+            pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
+            (pack / ".apm" / "hooks").mkdir(parents=True)
+            (pack / ".apm" / "hooks" / "pre-pr.sh").write_text("#!/bin/sh\nexit 0\n")
+            # Default (no flag passed) — must refuse.
+            self.assertIsNotNone(check_hooks(pack, ["user"]))
+            # Explicit False — same refusal.
+            self.assertIsNotNone(check_hooks(pack, ["user"], user_scope_hooks=False))
+
 
 class RailCMarkersTests(unittest.TestCase):
     """`<adapt:NAME>` markers under .apm/skills/, /agents/, /commands/ refused."""

--- a/packages/agentbundle/agentbundle/commands/install.py
+++ b/packages/agentbundle/agentbundle/commands/install.py
@@ -326,7 +326,16 @@ def run(args: "argparse.Namespace") -> int:
     for plan in plans:
         if plan.scope == "user":
             allowed_scopes = _resolved_allowed_scopes(pack_install)
-            rail_refusal = scope_rails.run_all(pack_dir, allowed_scopes)
+            # RFC-0005 § Rail B — user-scope lift: the
+            # `[pack.install] user-scope-hooks = true` consent gesture
+            # threads through to the rail at install time too. Without
+            # this, validate and install would disagree on the same
+            # pack: validate would accept (post-T3), install would
+            # refuse — a surface-mismatch class of bug.
+            user_scope_hooks = bool(pack_install.get("user-scope-hooks") is True)
+            rail_refusal = scope_rails.run_all(
+                pack_dir, allowed_scopes, user_scope_hooks
+            )
             if rail_refusal is not None:
                 print(
                     f"install: {pack_name}: {rail_refusal}",

--- a/packages/agentbundle/agentbundle/commands/validate.py
+++ b/packages/agentbundle/agentbundle/commands/validate.py
@@ -153,7 +153,8 @@ def run(args) -> int:
     from agentbundle.build.scope_rails import run_all as run_scope_rails
 
     allowed = _allowed_scopes(pack_data)
-    rail_refusal = run_scope_rails(pack_path, allowed)
+    user_scope_hooks = _user_scope_hooks_opt_in(pack_data)
+    rail_refusal = run_scope_rails(pack_path, allowed, user_scope_hooks)
     if rail_refusal is not None:
         pack_name = (
             pack_data.get("pack", {}).get("name") or pack_path.name
@@ -223,6 +224,23 @@ def _is_default_scope_invariant_violation(pack_data: dict, first_error: str) -> 
         "pack.install.allowed-scopes" in first_error
         or "allowed-scopes" in first_error
     )
+
+
+def _user_scope_hooks_opt_in(pack_data: dict) -> bool:
+    """Return True iff the pack declares ``[pack.install] user-scope-hooks = true``.
+
+    RFC-0005 § Rail B — user-scope lift: the flag is the consent
+    gesture that lets a pack ship hook-shaped primitives at user scope.
+    Absent or non-boolean → False (rail still refuses the pack).
+    """
+    pack = pack_data.get("pack", {})
+    if not isinstance(pack, dict):
+        return False
+    install = pack.get("install", {})
+    if not isinstance(install, dict):
+        return False
+    flag = install.get("user-scope-hooks")
+    return flag is True
 
 
 def _kiro_target_adapters(pack_data: dict, pack_path: Path) -> set[str]:
@@ -302,7 +320,12 @@ def _allowed_scopes(pack_data: dict) -> list[str]:
         if isinstance(pack.get("adapter-contract"), dict)
         else None
     )
-    if contract_version != "0.2":
+    # v0.2 introduced `[pack.install]`; v0.3 (RFC-0005) added the
+    # `user-scope-hooks` flag but did not change scope-resolution
+    # semantics. Treat any contract version >= 0.2 as carrying the
+    # install table. The legacy v0.1 path (and any pack without an
+    # adapter-contract declaration) stays repo-only.
+    if contract_version not in ("0.2", "0.3"):
         return ["repo"]
     install = pack.get("install", {})
     if not isinstance(install, dict):

--- a/packages/agentbundle/tests/fixtures/packs/cc-user-hooks/.apm/hook-wiring/on-prompt.toml
+++ b/packages/agentbundle/tests/fixtures/packs/cc-user-hooks/.apm/hook-wiring/on-prompt.toml
@@ -1,0 +1,8 @@
+# Claude Code hook-wiring. `attach-to-agent` is optional for Claude
+# Code projection (ignored — the wiring lands in the settings file
+# regardless). This fixture omits it to stay focused on the
+# Claude-Code-only path.
+
+[[hooks.UserPromptSubmit]]
+command = "$HOOK_BODY_PATH"
+matcher = ""

--- a/packages/agentbundle/tests/fixtures/packs/cc-user-hooks/.apm/hooks/on-prompt.sh
+++ b/packages/agentbundle/tests/fixtures/packs/cc-user-hooks/.apm/hooks/on-prompt.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0

--- a/packages/agentbundle/tests/fixtures/packs/cc-user-hooks/pack.toml
+++ b/packages/agentbundle/tests/fixtures/packs/cc-user-hooks/pack.toml
@@ -1,0 +1,18 @@
+# Claude Code user-scope hook-bearing fixture pack (T3 / RFC-0005).
+# Ships a single `UserPromptSubmit` wiring that calls a trivial shell
+# hook body. No agent — Claude Code's hook-wiring binds to a settings
+# file, not to a pack-owned agent, so this fixture exists to exercise
+# the user-scope merge path T5 will land.
+
+[pack]
+name = "cc-user-hooks"
+version = "0.1.0"
+description = "Fixture: Claude Code user-scope hook-bearing pack."
+
+[pack.adapter-contract]
+version = "0.3"
+
+[pack.install]
+default-scope = "user"
+allowed-scopes = ["user"]
+user-scope-hooks = true

--- a/packages/agentbundle/tests/fixtures/packs/kiro-repo-hooks/.apm/agents/reviewer.md
+++ b/packages/agentbundle/tests/fixtures/packs/kiro-repo-hooks/.apm/agents/reviewer.md
@@ -1,0 +1,8 @@
+---
+description: Reviews pending work.
+tools: Read
+---
+
+# reviewer
+
+Stub agent body for the kiro-repo-hooks fixture.

--- a/packages/agentbundle/tests/fixtures/packs/kiro-repo-hooks/.apm/hook-wiring/on-spawn.toml
+++ b/packages/agentbundle/tests/fixtures/packs/kiro-repo-hooks/.apm/hook-wiring/on-spawn.toml
@@ -1,0 +1,5 @@
+attach-to-agent = "reviewer"
+
+[[hooks.agentSpawn]]
+command = "$HOOK_BODY_PATH"
+matcher = ""

--- a/packages/agentbundle/tests/fixtures/packs/kiro-repo-hooks/.apm/hooks/on-spawn.sh
+++ b/packages/agentbundle/tests/fixtures/packs/kiro-repo-hooks/.apm/hooks/on-spawn.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0

--- a/packages/agentbundle/tests/fixtures/packs/kiro-repo-hooks/pack.toml
+++ b/packages/agentbundle/tests/fixtures/packs/kiro-repo-hooks/pack.toml
@@ -1,0 +1,16 @@
+# Kiro repo-scope hook-bearing fixture pack (T3 / RFC-0005).
+# Ships a single agent (`reviewer`) plus a hook-body + wiring that
+# attaches to it. This is the canonical Kiro shape: hook-wiring binds
+# inside the agent JSON via `merge-into-agent-json`.
+
+[pack]
+name = "kiro-repo-hooks"
+version = "0.1.0"
+description = "Fixture: Kiro repo-scope pack with agent + hooks."
+
+[pack.adapter-contract]
+version = "0.3"
+
+[pack.install]
+default-scope = "repo"
+allowed-scopes = ["repo"]

--- a/packages/agentbundle/tests/fixtures/packs/kiro-user-hooks/.apm/agents/reviewer.md
+++ b/packages/agentbundle/tests/fixtures/packs/kiro-user-hooks/.apm/agents/reviewer.md
@@ -1,0 +1,8 @@
+---
+description: Reviews pending work.
+tools: Read
+---
+
+# reviewer
+
+Stub agent body for the kiro-user-hooks fixture.

--- a/packages/agentbundle/tests/fixtures/packs/kiro-user-hooks/.apm/hook-wiring/on-spawn.toml
+++ b/packages/agentbundle/tests/fixtures/packs/kiro-user-hooks/.apm/hook-wiring/on-spawn.toml
@@ -1,0 +1,5 @@
+attach-to-agent = "reviewer"
+
+[[hooks.agentSpawn]]
+command = "$HOOK_BODY_PATH"
+matcher = ""

--- a/packages/agentbundle/tests/fixtures/packs/kiro-user-hooks/.apm/hooks/on-spawn.sh
+++ b/packages/agentbundle/tests/fixtures/packs/kiro-user-hooks/.apm/hooks/on-spawn.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0

--- a/packages/agentbundle/tests/fixtures/packs/kiro-user-hooks/pack.toml
+++ b/packages/agentbundle/tests/fixtures/packs/kiro-user-hooks/pack.toml
@@ -1,0 +1,17 @@
+# Kiro user-scope hook-bearing fixture pack (T3 / RFC-0005).
+# Variant of kiro-repo-hooks declaring `user-scope-hooks = true`. The
+# pack-owned agent JSON lands under `~/.kiro/agents/` at user scope;
+# the hook body lands under `~/.kiro/hooks/<pack>/`.
+
+[pack]
+name = "kiro-user-hooks"
+version = "0.1.0"
+description = "Fixture: Kiro user-scope variant with agent + hooks."
+
+[pack.adapter-contract]
+version = "0.3"
+
+[pack.install]
+default-scope = "user"
+allowed-scopes = ["user"]
+user-scope-hooks = true

--- a/packages/agentbundle/tests/fixtures/packs/malformed-kiro-missing-attach/.apm/agents/reviewer.md
+++ b/packages/agentbundle/tests/fixtures/packs/malformed-kiro-missing-attach/.apm/agents/reviewer.md
@@ -1,0 +1,5 @@
+---
+description: Stub.
+---
+
+# reviewer

--- a/packages/agentbundle/tests/fixtures/packs/malformed-kiro-missing-attach/.apm/hook-wiring/on-spawn.toml
+++ b/packages/agentbundle/tests/fixtures/packs/malformed-kiro-missing-attach/.apm/hook-wiring/on-spawn.toml
@@ -1,0 +1,5 @@
+# Deliberately missing `attach-to-agent`. Validate must refuse.
+
+[[hooks.agentSpawn]]
+command = "$HOOK_BODY_PATH"
+matcher = ""

--- a/packages/agentbundle/tests/fixtures/packs/malformed-kiro-missing-attach/.apm/hooks/on-spawn.sh
+++ b/packages/agentbundle/tests/fixtures/packs/malformed-kiro-missing-attach/.apm/hooks/on-spawn.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0

--- a/packages/agentbundle/tests/fixtures/packs/malformed-kiro-missing-attach/pack.toml
+++ b/packages/agentbundle/tests/fixtures/packs/malformed-kiro-missing-attach/pack.toml
@@ -1,0 +1,14 @@
+# Negative fixture: Kiro-projecting pack whose hook-wiring TOML omits
+# `attach-to-agent`. Validate must refuse with the RFC-0005 verbatim
+# text. Ships an agent so the kiro-targeting heuristic (T2) fires.
+
+[pack]
+name = "malformed-kiro-missing-attach"
+version = "0.1.0"
+
+[pack.adapter-contract]
+version = "0.3"
+
+[pack.install]
+default-scope = "repo"
+allowed-scopes = ["repo"]

--- a/packages/agentbundle/tests/fixtures/packs/malformed-kiro-pascal-events/.apm/agents/reviewer.md
+++ b/packages/agentbundle/tests/fixtures/packs/malformed-kiro-pascal-events/.apm/agents/reviewer.md
@@ -1,0 +1,5 @@
+---
+description: Stub.
+---
+
+# reviewer

--- a/packages/agentbundle/tests/fixtures/packs/malformed-kiro-pascal-events/.apm/hook-wiring/on-spawn.toml
+++ b/packages/agentbundle/tests/fixtures/packs/malformed-kiro-pascal-events/.apm/hook-wiring/on-spawn.toml
@@ -1,0 +1,7 @@
+attach-to-agent = "reviewer"
+
+# PascalCase events belong to Claude Code's vocabulary, not Kiro's.
+# T6's per-adapter `agent-event-vocabulary` gate refuses this.
+[[hooks.UserPromptSubmit]]
+command = "$HOOK_BODY_PATH"
+matcher = ""

--- a/packages/agentbundle/tests/fixtures/packs/malformed-kiro-pascal-events/.apm/hooks/on-spawn.sh
+++ b/packages/agentbundle/tests/fixtures/packs/malformed-kiro-pascal-events/.apm/hooks/on-spawn.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0

--- a/packages/agentbundle/tests/fixtures/packs/malformed-kiro-pascal-events/pack.toml
+++ b/packages/agentbundle/tests/fixtures/packs/malformed-kiro-pascal-events/pack.toml
@@ -1,0 +1,16 @@
+# Negative fixture: Kiro-projecting pack whose wiring TOML uses
+# Claude-Code-style PascalCase event names (`UserPromptSubmit`) that
+# fall outside Kiro's `agent-event-vocabulary`. The refusal lives in
+# T6 (per-adapter vocabulary gate); this fixture ships now so T6
+# can light up its own integration test against it.
+
+[pack]
+name = "malformed-kiro-pascal-events"
+version = "0.1.0"
+
+[pack.adapter-contract]
+version = "0.3"
+
+[pack.install]
+default-scope = "repo"
+allowed-scopes = ["repo"]

--- a/packages/agentbundle/tests/fixtures/packs/malformed-kiro-unknown-agent/.apm/agents/reviewer.md
+++ b/packages/agentbundle/tests/fixtures/packs/malformed-kiro-unknown-agent/.apm/agents/reviewer.md
@@ -1,0 +1,5 @@
+---
+description: Stub.
+---
+
+# reviewer

--- a/packages/agentbundle/tests/fixtures/packs/malformed-kiro-unknown-agent/.apm/hook-wiring/on-spawn.toml
+++ b/packages/agentbundle/tests/fixtures/packs/malformed-kiro-unknown-agent/.apm/hook-wiring/on-spawn.toml
@@ -1,0 +1,7 @@
+# `attach-to-agent` names an agent the pack does NOT ship.
+# Validate must refuse.
+attach-to-agent = "does-not-exist"
+
+[[hooks.agentSpawn]]
+command = "$HOOK_BODY_PATH"
+matcher = ""

--- a/packages/agentbundle/tests/fixtures/packs/malformed-kiro-unknown-agent/.apm/hooks/on-spawn.sh
+++ b/packages/agentbundle/tests/fixtures/packs/malformed-kiro-unknown-agent/.apm/hooks/on-spawn.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0

--- a/packages/agentbundle/tests/fixtures/packs/malformed-kiro-unknown-agent/pack.toml
+++ b/packages/agentbundle/tests/fixtures/packs/malformed-kiro-unknown-agent/pack.toml
@@ -1,0 +1,13 @@
+# Negative fixture: Kiro-projecting pack whose `attach-to-agent`
+# names an agent the pack does not ship. Validate must refuse.
+
+[pack]
+name = "malformed-kiro-unknown-agent"
+version = "0.1.0"
+
+[pack.adapter-contract]
+version = "0.3"
+
+[pack.install]
+default-scope = "repo"
+allowed-scopes = ["repo"]

--- a/packages/agentbundle/tests/integration/test_fixtures_validate.py
+++ b/packages/agentbundle/tests/integration/test_fixtures_validate.py
@@ -1,0 +1,188 @@
+"""T3: fixture-pack integration tests for user-scope-hooks.
+
+Six fixture packs under ``packages/agentbundle/tests/fixtures/packs/``
+exercise the validate rails from T1/T2 via the file-on-disk loader (not
+just the in-memory unit-test path T2 covers). The well-formed fixtures
+demonstrate the acceptance paths T8b/T6 will project; the malformed
+fixtures pin the refusal text RFC-0005 mandates.
+
+Pascal-case-event refusal lives in T6 (Kiro's `agent-event-vocabulary`
+gate); its fixture ships here for use by that task. T3 covers the
+two refusal classes the T2 rail already implements:
+attach-to-agent missing, and attach-to-agent naming an unknown agent.
+
+Spec ACs covered: AC6 (refusal text), AC28 (fixtures exist + are
+exercised), AC29 (no test writes to ~/.claude, ~/.kiro, ~/.agent-ready
+outside tmp_path).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+FIXTURES = REPO_ROOT / "packages" / "agentbundle" / "tests" / "fixtures" / "packs"
+
+
+WELL_FORMED = ("cc-user-hooks", "kiro-repo-hooks", "kiro-user-hooks")
+MALFORMED = (
+    "malformed-kiro-missing-attach",
+    "malformed-kiro-pascal-events",  # T6 covers the validate refusal — fixture only
+    "malformed-kiro-unknown-agent",
+)
+
+
+def _run_validate(pack_path: Path) -> tuple[int, str]:
+    """Invoke ``agentbundle validate`` against *pack_path* and return (rc, stderr)."""
+    import argparse
+
+    from agentbundle.commands import validate as cmd
+
+    args = argparse.Namespace(pack_path=str(pack_path), strict=False)
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        rc = cmd.run(args)
+    return rc, buf.getvalue()
+
+
+def _ensure_executable(path: Path) -> None:
+    """Re-apply +x to a hook body whose CI checkout might have stripped it.
+
+    Some CI runners apply restrictive umasks that drop the executable
+    bit on tracked files. Hooks are run via ``sh -c "$command"``, so the
+    bit doesn't affect *projection* shape — but downstream T6 tests
+    that observe dispatchability (AC18) need it. Defensive re-chmod
+    keeps the fixtures self-healing.
+    """
+    if path.exists() and not os.access(path, os.X_OK):
+        path.chmod(0o755)
+
+
+class FixturePresenceTests(unittest.TestCase):
+    """Every fixture named in spec.md § Testing Strategy is on disk."""
+
+    def test_all_well_formed_fixtures_exist(self) -> None:
+        for name in WELL_FORMED:
+            with self.subTest(fixture=name):
+                self.assertTrue(
+                    (FIXTURES / name / "pack.toml").exists(),
+                    f"fixture {name!r} missing pack.toml",
+                )
+
+    def test_all_malformed_fixtures_exist(self) -> None:
+        for name in MALFORMED:
+            with self.subTest(fixture=name):
+                self.assertTrue(
+                    (FIXTURES / name / "pack.toml").exists(),
+                    f"fixture {name!r} missing pack.toml",
+                )
+
+    def test_kiro_repo_hooks_ships_agent_body_and_wiring(self) -> None:
+        """Plan T3: kiro-repo-hooks ships `.apm/agents/reviewer.md`,
+        `.apm/hooks/on-spawn.sh`, `.apm/hook-wiring/on-spawn.toml`."""
+        root = FIXTURES / "kiro-repo-hooks"
+        self.assertTrue((root / ".apm" / "agents" / "reviewer.md").exists())
+        self.assertTrue((root / ".apm" / "hooks" / "on-spawn.sh").exists())
+        self.assertTrue((root / ".apm" / "hook-wiring" / "on-spawn.toml").exists())
+
+
+class WellFormedFixturesValidateTests(unittest.TestCase):
+    """The three well-formed fixtures pass ``agentbundle validate``."""
+
+    def test_cc_user_hooks_validates(self) -> None:
+        pack = FIXTURES / "cc-user-hooks"
+        _ensure_executable(pack / ".apm" / "hooks" / "on-prompt.sh")
+        rc, err = _run_validate(pack)
+        self.assertEqual(rc, 0, f"cc-user-hooks refused: {err}")
+
+    def test_kiro_repo_hooks_validates(self) -> None:
+        pack = FIXTURES / "kiro-repo-hooks"
+        _ensure_executable(pack / ".apm" / "hooks" / "on-spawn.sh")
+        rc, err = _run_validate(pack)
+        self.assertEqual(rc, 0, f"kiro-repo-hooks refused: {err}")
+
+    def test_kiro_user_hooks_validates(self) -> None:
+        pack = FIXTURES / "kiro-user-hooks"
+        _ensure_executable(pack / ".apm" / "hooks" / "on-spawn.sh")
+        rc, err = _run_validate(pack)
+        self.assertEqual(rc, 0, f"kiro-user-hooks refused: {err}")
+
+
+class MalformedFixturesRefusedTests(unittest.TestCase):
+    """The malformed fixtures the T2 rails cover refuse with the
+    RFC-0005 verbatim text. The pascal-events fixture's refusal lives
+    in T6; this test class only exercises the two attach-to-agent
+    refusal classes."""
+
+    def test_missing_attach_to_agent_refused(self) -> None:
+        rc, err = _run_validate(FIXTURES / "malformed-kiro-missing-attach")
+        self.assertEqual(rc, 1, "malformed-kiro-missing-attach was accepted")
+        self.assertIn("does not declare 'attach-to-agent'", err)
+        self.assertIn("required for kiro projection", err)
+
+    def test_unknown_agent_refused(self) -> None:
+        rc, err = _run_validate(FIXTURES / "malformed-kiro-unknown-agent")
+        self.assertEqual(rc, 1, "malformed-kiro-unknown-agent was accepted")
+        # Same refusal text — "or names an unknown agent" disjunct
+        # covers both shapes (RFC-0005 § Repo-scope Kiro promotion).
+        self.assertIn("or names an unknown agent", err)
+
+
+class PendingT6PascalEventsFixtureTests(unittest.TestCase):
+    """The pascal-events fixture ships in T3 for T6 (the per-adapter
+    `agent-event-vocabulary` gate). Today, the T2 attach-to-agent rail
+    is satisfied (the fixture's `attach-to-agent = "reviewer"` resolves
+    to a same-pack agent), so validate currently passes the fixture.
+    T6 will flip this test — adding the vocabulary check that refuses
+    PascalCase events against Kiro. The marker test below pins T3's
+    contribution and signals T6 to invert it."""
+
+    def test_pascal_events_currently_passes_pending_T6(self) -> None:
+        rc, err = _run_validate(FIXTURES / "malformed-kiro-pascal-events")
+        self.assertEqual(
+            rc,
+            0,
+            "pascal-events fixture refused at T3-era validate; "
+            "T6 is the task that introduces the refusal. If you're "
+            "wiring up T6, flip this test to assertEqual(rc, 1) and "
+            "assert the 'not in adapter ... agent-event-vocabulary' "
+            f"text in stderr. Current stderr: {err}",
+        )
+
+
+class FixtureIsolationTests(unittest.TestCase):
+    """AC29: nothing in this test module writes to ``~/.claude``,
+    ``~/.kiro``, or ``~/.agent-ready``. Redirects ``$HOME`` to a
+    ``tmp_path``-scoped directory and asserts the redirected tree is
+    empty after validate runs against each user-scope fixture. This is
+    the AC29-shaped pin: a regression that writes into ``$HOME`` from
+    validate would create artifacts in the tmp tree."""
+
+    def test_validate_does_not_write_to_redirected_home(self) -> None:
+        import os
+        import tempfile
+        from unittest.mock import patch
+
+        with tempfile.TemporaryDirectory() as tmp_home:
+            with patch.dict(os.environ, {"HOME": tmp_home}):
+                for fixture in ("cc-user-hooks", "kiro-user-hooks", "kiro-repo-hooks"):
+                    with self.subTest(fixture=fixture):
+                        _run_validate(FIXTURES / fixture)
+
+            # After every validate run, the redirected home must be
+            # empty — validate is read-only against the pack directory.
+            tmp_path = Path(tmp_home)
+            artifacts = sorted(p.relative_to(tmp_path).as_posix() for p in tmp_path.rglob("*"))
+            self.assertEqual(
+                artifacts,
+                [],
+                f"validate wrote into $HOME during fixture validation: {artifacts}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/agentbundle/tests/unit/test_validate_cmd.py
+++ b/packages/agentbundle/tests/unit/test_validate_cmd.py
@@ -199,3 +199,63 @@ def test_no_adapter_contract_version_passes():
 
     pack_data = {"pack": {"name": "x", "version": "0.1"}}
     assert check_spec_version_gate(pack_data) is None
+
+
+# ---------------------------------------------------------------------------
+# T3 (RFC-0005): _allowed_scopes recognises v0.3 packs.
+#
+# Pre-fix bug: `_allowed_scopes` hardcoded ``contract_version != "0.2"``
+# and returned ``["repo"]`` for any other version — so v0.3 packs
+# (introduced in T1) had their scope rails silently bypassed.
+# ---------------------------------------------------------------------------
+
+
+def test_allowed_scopes_resolves_v0_3_user():
+    """A v0.3 pack declaring ``allowed-scopes = ["user"]`` resolves to
+    ``["user"]``, not the bug-default ``["repo"]``."""
+    from agentbundle.commands.validate import _allowed_scopes
+
+    pack_data = {
+        "pack": {
+            "name": "x",
+            "version": "0.1.0",
+            "adapter-contract": {"version": "0.3"},
+            "install": {
+                "default-scope": "user",
+                "allowed-scopes": ["user"],
+                "user-scope-hooks": True,
+            },
+        }
+    }
+    assert _allowed_scopes(pack_data) == ["user"]
+
+
+def test_allowed_scopes_resolves_v0_2_user_unchanged():
+    """v0.2 packs continue to resolve correctly (regression-protect the fix)."""
+    from agentbundle.commands.validate import _allowed_scopes
+
+    pack_data = {
+        "pack": {
+            "name": "x",
+            "version": "0.1.0",
+            "adapter-contract": {"version": "0.2"},
+            "install": {"default-scope": "user", "allowed-scopes": ["user"]},
+        }
+    }
+    assert _allowed_scopes(pack_data) == ["user"]
+
+
+def test_allowed_scopes_v0_1_stays_repo_only():
+    """v0.1 packs (and packs without an adapter-contract) stay repo-only
+    — the legacy path that the bug-fix is careful not to break."""
+    from agentbundle.commands.validate import _allowed_scopes
+
+    pack_data = {
+        "pack": {
+            "name": "x",
+            "version": "0.1.0",
+            "adapter-contract": {"version": "0.1"},
+            "install": {"allowed-scopes": ["user"]},
+        }
+    }
+    assert _allowed_scopes(pack_data) == ["repo"]


### PR DESCRIPTION
## Summary

Wave 3 of the [user-scope-hooks spec](../tree/main/docs/specs/user-scope-hooks/spec.md) — fixture packs + Rail B conditional lift. Third of thirteen PRs.

- **Six fixture packs** under `packages/agentbundle/tests/fixtures/packs/` per spec § Testing Strategy: 3 well-formed (`cc-user-hooks`, `kiro-repo-hooks`, `kiro-user-hooks`) + 3 malformed (`malformed-kiro-{missing-attach,pascal-events,unknown-agent}`). Each tree is minimal — trivial shell hook bodies (mode 0755), stub agent frontmatter.
- **Rail B conditional lift** (RFC-0005 § Rail B — user-scope lift). `scope_rails.check_hooks` and `run_all` grow an optional `user_scope_hooks: bool = False` parameter. When True, the rail accepts hook-shaped primitives at user scope. Threaded through **both** `commands/validate.py` and `commands/install.py` so the two surfaces cannot disagree on the same pack.
- **Pre-existing bug fix as adjacent change**: `validate.py:_allowed_scopes` was hardcoded to `if contract_version != "0.2": return ["repo"]`. v0.3 packs (introduced in T1) were silently treated as repo-only, making Rail B unreachable. Fixed to `("0.2", "0.3")` with three unit-test cases pinning the path.

## Acceptance criteria T3 implements

- [x] **AC6** — Refusal text for missing / unknown-agent `attach-to-agent` exercised against on-disk fixtures.
- [x] **AC28** — Every fixture named in spec § Testing Strategy is on disk and exercised.
- [x] **AC29** — Tests redirect `\$HOME` via `patch.dict(os.environ, {"HOME": tmp_home})` and assert the tmp tree stays empty after validate runs.

## Tests added

- 9 integration tests in `test_fixtures_validate.py` (presence × 3, well-formed-pass × 3, malformed-refuse × 2, pascal-events-pending-T6 × 1, isolation × 1).
- 2 Rail B lift unit tests in `test_scope_rails.py` (lift-on-True, refuse-on-default/False).
- 3 `_allowed_scopes` regression tests in `test_validate_cmd.py` (v0.3 user → user; v0.2 user → user; v0.1 → repo).

## Adversarial review

Two rounds. First round surfaced 4 Concerns + 3 Nits — install/validate surface drift, weak isolation test, missing unit coverage for Rail B lift and `_allowed_scopes`, missing pascal-events demonstration. All addressed in-PR. Second round: **Clean — ready to commit.**

## Gates

- 450 tests pass, 1 skipped (was 437 pre-wave-3; +13 new tests across this PR).
- `make build-check` exits 0.
- `make validate` exits 0.

## Out of scope (later waves)

- **T5** — `user-merge-json` mode implementation (Claude Code user scope).
- **T6** — `merge-into-agent-json` mode implementation (Kiro). Includes the pascal-events vocabulary refusal — the fixture ships here, the test inversion lands with T6.
- **T7** — build-pipeline phase order.
- **T8b** — install/uninstall threading (writes `hook-wiring-owned` state rows; `--force-merge` flag).
- **T8c** — upgrade reconciliation including `attach-to-agent` rename.
- **T9** — `reconcile --scope user` read-only reporter.
- **T10/T11** — spec amendments to `distribution-adapters/spec.md` and `agent-spec-cli/spec.md`.