### PR TITLE
feat(wave4): user-merge-json projection + distribution-adapters amendment (T5+T10)

### DIFF
--- a/docs/specs/distribution-adapters/spec.md
+++ b/docs/specs/distribution-adapters/spec.md
@@ -70,8 +70,29 @@ to this list.
   delimiter strings inside a target text file; content outside the
   delimiters is preserved. Default `on-conflict`: `preserve-outside-block`.
 - **`degraded-info-log`** — emit an `[info]` line on stderr at build
-  time, write no file. Used when an adapter lacks a schema for a
-  primitive (RFC-0001 Unresolved Q1, Kiro hook wiring).
+  time, write no file. Used historically when an adapter lacked a
+  schema for a primitive (RFC-0001 Unresolved Q1, Kiro hook wiring —
+  closed by RFC-0005's `merge-into-agent-json`).
+- **`user-merge-json`** — array-append-with-id merge into a
+  hand-edited shared user-settings file (Claude Code user scope —
+  `~/.claude/settings.json` under `managed-key.user`). Distinct from
+  `merge-json`: the target file is **not** pack-owned, so adopter-
+  authored entries are never reordered or rewritten. Owned entries
+  are tagged with a synthetic `id = "<pack>:<basename>"` so uninstall
+  is precise. Defined by [RFC-0005 § `hook-wiring` for Claude Code at
+  user scope](../../rfc/0005-user-scope-hook-support.md#hook-wiring-for-claude-code-at-user-scope--user-merge-json-mode);
+  full merge / idempotency / failure-mode rules in the
+  [`user-merge-json` subsection below](#user-merge-json-mode-claude-code-user-scope).
+- **`merge-into-agent-json`** — array-append-with-id merge into a
+  pack-owned agent JSON (Kiro at both scopes —
+  `<scope-root>/.kiro/agents/<attach-to-agent>.json` under
+  `managed-key = "hooks"`). The agent file is pack-owned, so the
+  shared-file disciplines of `user-merge-json` (adopter-edit
+  preservation) don't apply, but the per-agent target is. Defined by
+  [RFC-0005 § `hook-wiring` for Kiro at both
+  scopes](../../rfc/0005-user-scope-hook-support.md#hook-wiring-for-kiro-at-both-scopes--merge-into-agent-json-mode);
+  full rules in the [`merge-into-agent-json` subsection
+  below](#merge-into-agent-json-mode-kiro-at-both-scopes).
 - **`dropped`** — explicit no-op; no output file, no warning. The
   contract carries the `dropped` rule so the missing pair is intentional,
   not an oversight.
@@ -176,8 +197,8 @@ declares it so explicitly — no implicit defaults.
 | --- | --- | --- | --- | --- | --- |
 | `skill` | `.apm/skills/<name>/` | `direct-directory` → `.claude/skills/<name>/` | `direct-directory` → `.kiro/skills/<name>/` | `instruction-file` → `.github/instructions/<name>.instructions.md` | `managed-block-inline` → `AGENTS.md` |
 | `agent` | `.apm/agents/<name>.md` | `direct-file` → `.claude/agents/<name>.md` | `direct-file` (with `kiro-agent-frontmatter-v0.9` rewrite) → `.kiro/agents/<name>.md` | `dropped` | `dropped` |
-| `hook-body` | `.apm/hooks/<name>.{sh,py}` | `direct-file` → `tools/hooks/<name>.{sh,py}` | `direct-file` → `tools/hooks/<name>.{sh,py}` | `direct-file` → `tools/hooks/<name>.{sh,py}` | `direct-file` → `tools/hooks/<name>.{sh,py}` |
-| `hook-wiring` | `.apm/hook-wiring/<name>.toml` | `merge-json` (under `hooks` key of `.claude/settings.local.json`) | `degraded-info-log` (RFC-0001 Open Q1 — until Kiro publishes a schema) | `dropped` | `dropped` |
+| `hook-body` | `.apm/hooks/<name>.{sh,py}` | `direct-file` — repo: `tools/hooks/<name>.{sh,py}`; user: `.claude/hooks/<pack>/<name>.{sh,py}` | `direct-file` — repo: `tools/hooks/<name>.{sh,py}`; user: `.kiro/hooks/<pack>/<name>.{sh,py}` | `direct-file` → `tools/hooks/<name>.{sh,py}` | `direct-file` → `tools/hooks/<name>.{sh,py}` |
+| `hook-wiring` | `.apm/hook-wiring/<name>.toml` | repo: `merge-json` (under `hooks` key of `.claude/settings.local.json`); user: `user-merge-json` (under `hooks` key of `.claude/settings.json`) | `merge-into-agent-json` (RFC-0005 — under `hooks` key of `.kiro/agents/<attach-to-agent>.json`) | `dropped` | `dropped` |
 | `command` | `.apm/commands/<name>.md` | `direct-file` → `.claude/commands/<name>.md` | `dropped` | `dropped` | `dropped` |
 
 **Hook extensions.** A hook is a script; the runtime is determined by the
@@ -187,9 +208,21 @@ valid in `packs/<pack>/.apm/hooks/`.
 
 **`hook-wiring` source format.** One TOML file per hook at
 `.apm/hook-wiring/<name>.toml`. Each file declares the `[hooks]` entries
-to merge into `.claude/settings.local.json` (Claude Code) under the
-`merge-managed-key-only` on-conflict policy. Other adapters consume the
-same source path and project per the table above.
+the adapter merges into its target file per the table above. The
+optional top-level `attach-to-agent` field names a same-pack agent
+(required for Kiro projection; ignored by Claude Code) — see [RFC-0005
+§ Pack-side schema —
+`attach-to-agent`](../../rfc/0005-user-scope-hook-support.md#pack-side-schema--the-attach-to-agent-field).
+
+**Build-pipeline phase order.** Per [RFC-0005 § Build-pipeline ordering
+invariant](../../rfc/0005-user-scope-hook-support.md#build-pipeline-ordering-invariant),
+the pipeline projects primitives in the fixed order
+**`hook-body` → `agent` → `hook-wiring` → `command` → `skill`** within
+each pack. `merge-into-agent-json` reads the agent JSON the agent
+projection wrote, so agents must land first. Cross-pack ordering is
+not introduced — packs install serially today and no pack writes into
+another pack's agent file. T7 enforces the invariant in the pipeline
+iterator.
 
 ## Install-scope dimension (contract v0.2)
 
@@ -315,18 +348,37 @@ a non-empty `seeds/` directory cannot declare `"user"` in
 project to `~/docs/_templates/`, `~/packages/_example/` — nonsense
 paths. `validate` rejects mismatches.
 
-**Rail B — hook-shaped primitives.** A pack whose source tree
-contains a non-empty `.apm/hooks/` or `.apm/hook-wiring/` directory
-cannot declare `"user"` in `allowed-scopes`. (Source-tree presence
-is the detectable surface; every adapter projects `hook-body` per
-the projection table above, so the projected-set form is constant.)
-Under Claude Code, hook bodies are read from
-`~/.claude/` (not `~/tools/`) at user scope, and the user-scope
-settings file is `~/.claude/settings.json` (no `.local`); the merge
-semantics for hooks under a hand-edited user settings file are not
-designed. Until the user-scope hook-wiring merge story is designed (a
-follow-up RFC, not this one), hook-shaped primitives are refused at
-user scope.
+**Rail B — hook-shaped primitives (conditional, RFC-0005).** A pack
+whose source tree contains a non-empty `.apm/hooks/` or
+`.apm/hook-wiring/` directory cannot declare `"user"` in
+`allowed-scopes` **unless** the pack opts in via `[pack.install]
+user-scope-hooks = true` *and* the target adapter declares a working
+user-scope `hook-wiring` mode. Two adapter shapes satisfy the latter
+condition:
+
+- **Claude Code shape:** adapter declares `target.user` for
+  `hook-body` *and* `mode.user = "user-merge-json"` for `hook-wiring`.
+- **Kiro shape:** adapter declares `target.user` for `hook-body`
+  *and* `mode = "merge-into-agent-json"` for `hook-wiring` (single
+  mode, no scope qualifier — the agent-file target is
+  scope-conditional via `<scope-root>` resolution) *and* an
+  `[adapter.<name>.scope]` table making user scope reachable.
+
+A pack with `user-scope-hooks = true` whose target adapter satisfies
+neither shape is refused at scope-resolution time with
+`adapter <name> does not declare a hook-wiring mode that supports
+user scope; pack <P> requires it` per
+[RFC-0005 § Rail B — user-scope
+lift](../../rfc/0005-user-scope-hook-support.md#rail-b--user-scope-lift).
+
+The opt-in flag (`user-scope-hooks`) is the consent gesture
+RFC-0005 introduces — pack-authoring a user-scope hook is a
+materially different responsibility from authoring a repo-scope one
+(no per-project isolation; harder for the adopter to attribute
+breakage; on Claude Code, shared file with other tools). The flag
+has no meaning at repo scope and is ignored if `"user" ∉
+allowed-scopes`. A pack lacking the flag is refused at user scope
+with the prior v0.2 Rail B text.
 
 **Rail C — `<adapt:NAME>`-marker-bearing primitives.** A primitive
 file containing one or more `<adapt:NAME>` markers cannot install at
@@ -445,6 +497,147 @@ drives the major-version-disagreement refusal for *packs*; state-file
 schema-version drives the refuse-and-explain at write-time. An
 adopter must reason about both.
 
+## v0.3 user-scope hook handling (RFC-0005)
+
+The v0.3 contract bump adds two new projection modes
+(`user-merge-json` for Claude Code at user scope and
+`merge-into-agent-json` for Kiro at both scopes), plus a per-pack
+opt-in flag (`[pack.install] user-scope-hooks`), plus optional
+state-file fields for ownership tracking. The contract version
+[bumps to `"0.3"`](#contract-version-bump-02--03) at the bottom of
+this section.
+
+### `user-merge-json` mode (Claude Code user scope)
+
+Merges a pack's `.apm/hook-wiring/*.toml` content into the
+hand-edited shared `~/.claude/settings.json` under the `hooks` key.
+The mode is distinct from `merge-json` in three load-bearing ways:
+
+1. **Target file is adopter-shared, not pack-owned.** Adopter
+   hand-edits to top-level keys (`theme`, `model`, `env`, …) are never
+   read or rewritten.
+2. **Array-append-with-id, not key-replace.** Each owned entry carries
+   a synthetic `id = "<pack>:<basename>"` (see [RFC-0005 § Merge
+   semantics step 2](../../rfc/0005-user-scope-hook-support.md#merge-semantics)).
+3. **Per-event arrays auto-initialise.** A missing `hooks` object is
+   created as `{}`; a missing `hooks.<event>` is created as `[]`. Only
+   present-with-wrong-type refuses (see *Failure modes* below).
+
+**Idempotency.** Reinstalling the same pack at the same version is a
+no-op: identical `id`s replace in place, position preserved. The
+on-disk file diff is empty for a same-version reinstall. RFC-0005's
+contract is byte-for-byte, not just JSON-equivalent.
+
+**Adopter collision.** An adopter-authored entry under `hooks.<event>`
+whose `command` field matches an incoming pack command (after
+whitespace normalisation) causes `install` to refuse with `pack <P>'s
+hook <name> at event <event> appears to be already wired in <path>;
+remove the manual entry or pass --force-merge to take ownership`.
+`--force-merge` (Claude Code user scope only) adopts the entry; the
+original command is preserved in the state-file snapshot. Binding
+details for `--force-merge` live in [RFC-0005 § User-already-set-this-key
+collision rule](../../rfc/0005-user-scope-hook-support.md#user-already-set-this-key-collision-rule).
+
+**Cross-pack ordering.** Multiple packs may wire entries to the same
+event; their entries coexist as separate items in
+`hooks.<event>`, each tagged with its own `id`. The CLI never reorders
+adopter-touched arrays. Within a single install session, ties break
+by ASCII codepoint order on the lowercased pack name; within a single
+pack wiring N hooks for one event, entries land in
+`sorted(os.walk(...))` order over `.apm/hook-wiring/<name>.toml`
+filenames (the same `sorted(os.walk(...))` determinism rule [skill-
+directory enumeration uses](#primitive-types-and-per-adapter-projections),
+applied to the hook-wiring source surface).
+
+**Uninstall.** `unproject` walks the user-scope state's per-pack
+`hook-wiring-owned` rows, removes every `(event, id)` pair from the
+in-memory `hooks.<event>` arrays, and rewrites the file. Empty
+`hooks.<event>` arrays are removed (not left as `[]`). Adopter-
+authored entries are never inspected beyond identity comparison. The
+implementation lives at
+`packages/agentbundle/agentbundle/build/projections/user_merge_json.py`.
+
+**Failure modes.**
+
+- **Unparseable JSON:** refuse with `cannot parse <path>: <error>;
+  fix or back up the file and retry`. File is not rewritten; no state
+  is recorded.
+- **Wrong-shape `hooks`:** refuse with `<path>: hooks has unexpected
+  shape <type>; expected object`.
+- **Wrong-shape `hooks.<event>`:** refuse with `<path>: hooks.<event>
+  has unexpected shape <type>; expected array`.
+
+Failure-mode rules are RFC-0005 § Failure modes for unparseable user
+settings verbatim.
+
+### `merge-into-agent-json` mode (Kiro at both scopes)
+
+Merges a pack's `.apm/hook-wiring/*.toml` content into a pack-owned
+agent JSON at `<scope-root>/.kiro/agents/<attach-to-agent>.json` under
+the `hooks` key. The mode reuses `user-merge-json`'s
+array-append-with-id discipline, with one structural difference: the
+target file is **pack-owned**, so adopter-edit preservation does not
+apply — adopter hand-edits to the projected agent JSON are squatting on a
+managed surface (the next upgrade replaces the file via the agent
+primitive's `direct-file` projection, dropping the edits).
+
+**Adapter declaration.** Kiro declares the mode plus an
+`agent-event-vocabulary` array (the events the namespace accepts):
+
+```toml
+[adapter.kiro.projections.hook-wiring]
+mode = "merge-into-agent-json"
+target.repo = ".kiro/agents/<attach-to-agent>.json"   # resolves under <repo>/
+target.user = ".kiro/agents/<attach-to-agent>.json"   # resolves under ~/
+managed-key = "hooks"
+agent-event-vocabulary = [
+  "agentSpawn",
+  "userPromptSubmit",
+  "preToolUse",
+  "postToolUse",
+  "stop",
+]
+```
+
+`<attach-to-agent>` is the pack-side TOML's `attach-to-agent` value
+resolved per wiring entry (a same-pack agent name; `validate` refuses
+otherwise — see [RFC-0005 § Pack-side
+schema](../../rfc/0005-user-scope-hook-support.md#pack-side-schema--the-attach-to-agent-field)).
+
+**`agent-event-vocabulary`.** A declarative array of event-name
+strings. `validate` refuses any wiring TOML naming an event outside
+this list with `pack <P>'s hook-wiring <name>.toml uses event '<E>';
+not in adapter 'kiro' agent-event-vocabulary` (RFC-0005 § Repo-scope
+Kiro promotion). The Claude Code projections do not declare
+`agent-event-vocabulary`; the per-adapter vocabulary gate fires only
+when the resolved target adapter declares the field.
+
+**Idempotency, conflict, failure modes.** Same rules as
+`user-merge-json`, except the failure path
+`internal: <agent-file> missing at hook-wiring merge time; agent must
+project before wiring` fires if the build-pipeline ordering invariant
+(see [§ Build-pipeline phase order
+above](#primitive-types-and-per-adapter-projections)) is violated —
+the agent JSON must exist before any wiring merges run.
+
+**Uninstall.** `unproject` walks `hook-wiring-owned` rows whose
+`target-file` matches the agent JSON path, removes the entries, and
+rewrites the file. The agent JSON itself is removed by the `agent`
+primitive's `direct-file` projection uninstall, not by
+`merge-into-agent-json`. The implementation lives at
+`packages/agentbundle/agentbundle/build/projections/merge_into_agent_json.py`
+**(landing in T6 — module does not exist yet at the time of this
+amendment)**.
+
+### `[contract] version` bump 0.2 → 0.3
+
+`docs/contracts/adapter.toml`'s `[contract] version` bumps from
+`"0.2"` to `"0.3"` (T1, RFC-0005). The conformance suite picks up
+the new modes, the scope-conditional `target` shape, the
+`agent-event-vocabulary` field, the `[pack.install] user-scope-hooks`
+flag, and the v0.3 state-file additions (optional `adapter`,
+`target-file`, `hook-wiring-owned`).
+
 ### `[contract] version` bump 0.1 → 0.2
 
 `docs/contracts/adapter.toml`'s `[contract] version` bumps from
@@ -527,15 +720,23 @@ before proceeding; *Never do* is a hard rule, even under time pressure.
 - Any change to `make build`'s seven-subcommand surface (`build`, `build
   PACK=`, `build RECIPE=`, `--self`, `--self --dry-run`, `--check`,
   `--scaffold OUTPUT=`).
-- Promoting Kiro hook *wiring* projection out of `degraded-info-log`
-  (RFC-0001 Unresolved Q1 keeps it degraded until Kiro publishes a schema).
 - Adding a `global` (system-wide) value to the `scope` enum. Not
   reserved, not refused — absent. RFC-0004 § Alternatives considered
   §6 rejects pre-emptive reservation; adding `global` later is a
   one-line schema bump against an already-versioned contract.
-- Promoting hook-shaped primitives out of user-scope refusal (Rail B).
-  The user-scope hook-wiring merge story is deferred to a follow-up
-  RFC; landing it requires that RFC, not a unilateral relaxation.
+- Translating between adapter event vocabularies. The
+  `agent-event-vocabulary` field gates wiring projections at
+  `validate` time; a pack targeting both adapters ships separate
+  wiring TOMLs per adapter. Adding a translation layer that lets a
+  Claude-Code-shaped wiring run on Kiro (or vice versa) needs its own
+  RFC — RFC-0005 § What this RFC does NOT do explicitly excludes it.
+
+*(Two prior items here are now closed by RFC-0005: Kiro hook-wiring
+projection out of `degraded-info-log` is replaced by
+`merge-into-agent-json` at repo scope (T1 contract bump); hook-shaped
+primitives at user scope are no longer unconditionally refused by
+Rail B (it lifts on `[pack.install] user-scope-hooks = true` plus a
+working user-scope adapter mode).)*
 
 ### Never do
 

--- a/packages/agentbundle/agentbundle/build/projections/__init__.py
+++ b/packages/agentbundle/agentbundle/build/projections/__init__.py
@@ -1,0 +1,13 @@
+"""Projection-mode implementations for v0.3 user-scope hook handling.
+
+Each module here implements one projection ``mode`` value from the
+adapter contract: ``user_merge_json`` (Claude Code user scope —
+shared-file merge into ``~/.claude/settings.json``) and
+``merge_into_agent_json`` (Kiro repo + user scope — merge into the
+pack-owned agent JSON). Shared id-synthesis lives in ``hook_id``.
+
+The pipeline (T7) wires these in; the CLI install / uninstall surface
+(T8b) drives them. Per RFC-0005 § Pipeline ordering invariant, the
+build pipeline must project ``agent`` files before any wiring merges
+run — that ordering is the pipeline's concern, not these modules'.
+"""

--- a/packages/agentbundle/agentbundle/build/projections/hook_id.py
+++ b/packages/agentbundle/agentbundle/build/projections/hook_id.py
@@ -1,0 +1,27 @@
+"""Hook-entry id synthesis — shared between ``user_merge_json`` (Claude
+Code user scope) and ``merge_into_agent_json`` (Kiro at both scopes).
+
+Per RFC-0005 § Merge semantics step 2, every hook entry the CLI writes
+carries an ``id`` field of the form ``<pack-name>:<hook-source-basename>``.
+The id is the ownership tag the merger uses to detect "this is mine"
+on reinstall / replace / uninstall. Claude Code today treats unknown
+keys on hook entries as opaque (the synthetic ``id`` survives without
+runtime effect); Kiro's hook-entry schema is observed-but-not-publicly-
+documented and treats it the same. RFC-0005 Unresolved Q1 holds the
+``id`` → ``agent-ready-id`` rename open; this module is the single
+chokepoint to flip if that resolves.
+"""
+
+from __future__ import annotations
+
+
+def synthesize_id(pack_name: str, hook_source_basename: str) -> str:
+    """Return the ownership-tag id for a single (pack, wiring-toml) pair.
+
+    The basename is the wiring TOML filename without ``.toml`` — e.g.
+    ``on-prompt`` for ``.apm/hook-wiring/on-prompt.toml``. Both adapters
+    share this synthesis: id collision across packs means the same pack
+    name + same wiring basename, which is the genuine conflict
+    RFC-0005 § Conflict refuses install on.
+    """
+    return f"{pack_name}:{hook_source_basename}"

--- a/packages/agentbundle/agentbundle/build/projections/user_merge_json.py
+++ b/packages/agentbundle/agentbundle/build/projections/user_merge_json.py
@@ -1,0 +1,324 @@
+"""``user-merge-json`` projection mode — Claude Code user scope.
+
+Merges a pack's ``.apm/hook-wiring/*.toml`` content into the
+hand-edited shared ``~/.claude/settings.json`` under the ``hooks`` key,
+using **array-append-with-id** (not key-replace). The merger respects
+three boundaries documented in RFC-0005 § Merge semantics:
+
+1. Adopter-authored keys at the top level (``theme``, ``model``,
+   ``env``, ...) are never read or rewritten.
+2. Adopter-authored entries under ``hooks.<event>`` (entries without
+   an id matching any installed pack's owned ids) are never reordered,
+   never rewritten, and only inspected for textual collision against
+   incoming pack commands.
+3. Empty ``hooks.<event>`` arrays are removed after ``unproject``, so
+   the file stays tidy across upgrade churn.
+
+The module exposes two callables: ``project`` (install / reinstall)
+and ``unproject`` (uninstall). Both write atomically via tmp + rename.
+
+This module is stdlib-only — ``json`` + ``pathlib`` per the spec's
+*Never do — No new top-level dependency* boundary.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+from pathlib import Path
+
+from agentbundle.build.projections.hook_id import synthesize_id
+
+
+class UserMergeRefusal(Exception):
+    """Raised when ``project`` / ``unproject`` refuses to write.
+
+    The exception's string is the refuse-and-explain text RFC-0005
+    specifies. CLI callers (T8b's install / uninstall handlers) catch
+    and print to stderr without paraphrasing.
+    """
+
+
+# RFC-0005 § Merge semantics: "textual equality after whitespace
+# normalisation". Collapse runs of whitespace to a single space and
+# strip leading/trailing whitespace before comparing commands.
+_WS_RE = re.compile(r"\s+")
+
+
+def _normalize_command(value: object) -> str:
+    if not isinstance(value, str):
+        return ""
+    return _WS_RE.sub(" ", value).strip()
+
+
+def project(
+    target_path: Path,
+    pack_name: str,
+    wiring_tomls: dict[str, dict],
+    force_merge: bool = False,
+) -> list[tuple[str, str]]:
+    """Merge *wiring_tomls* into the JSON file at *target_path*.
+
+    Arguments:
+      target_path: ``~/.claude/settings.json`` (or test-redirected
+        equivalent). Created with ``{}`` if absent.
+      pack_name: the pack's ``[pack].name``. Substituted into id tags
+        and into refusal text.
+      wiring_tomls: map of wiring TOML basename (no ``.toml``) → parsed
+        TOML body (typically ``{"hooks": {"<Event>": [entries]}}``).
+        Iteration order is the call's order.
+      force_merge: when True, an adopter-authored entry whose
+        ``command`` collides with an incoming pack command is replaced
+        rather than refused (RFC-0005 § User-already-set-this-key).
+
+    Returns:
+      List of ``(event, id)`` tuples reflecting every owned entry the
+      call wrote. T8b records these in the state file's
+      ``hook-wiring-owned`` table so ``unproject`` can be precise.
+
+    Raises:
+      UserMergeRefusal: on unparseable settings, wrong-shape ``hooks``
+        or ``hooks.<event>``, adopter collision without ``force_merge``.
+    """
+    data = _load_settings(target_path)
+    _shape_check_hooks(target_path, data)
+
+    owned: list[tuple[str, str]] = []
+    for basename, body in wiring_tomls.items():
+        entry_id = synthesize_id(pack_name, basename)
+        hooks_in_wiring = body.get("hooks", {}) if isinstance(body, dict) else {}
+        if not isinstance(hooks_in_wiring, dict):
+            continue
+        for event, incoming_entries in hooks_in_wiring.items():
+            if not isinstance(incoming_entries, list):
+                continue
+            data.setdefault("hooks", {})
+            data["hooks"].setdefault(event, [])
+            event_array = data["hooks"][event]
+            _shape_check_event_array(target_path, event, event_array)
+            for incoming in incoming_entries:
+                if not isinstance(incoming, dict):
+                    continue
+                tagged = dict(incoming)
+                tagged["id"] = entry_id
+                _merge_one_entry(
+                    target_path=target_path,
+                    pack_name=pack_name,
+                    basename=basename,
+                    event=event,
+                    event_array=event_array,
+                    tagged_entry=tagged,
+                    force_merge=force_merge,
+                )
+                owned.append((event, entry_id))
+
+    _atomic_write(target_path, data)
+    # Deduplicate (event, id) tuples — a single wiring TOML may contribute
+    # multiple entries under one event, but the state-side ownership
+    # record only needs (event, id) once per logical pair.
+    seen: set[tuple[str, str]] = set()
+    result: list[tuple[str, str]] = []
+    for item in owned:
+        if item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result
+
+
+def unproject(target_path: Path, owned: list[tuple[str, str]]) -> None:
+    """Remove every ``(event, id)`` pair in *owned* from *target_path*.
+
+    Empty ``hooks.<event>`` arrays are removed (not left as ``[]``).
+    If the target file is absent, ``unproject`` is a no-op — there's
+    nothing to remove. Unparseable JSON refuses with the same shape
+    ``project`` does.
+
+    Absent-file no-op note: a state row pointing at a now-absent
+    target is an orphan-in-state condition that T9's
+    ``reconcile --scope user`` reporter will surface. Refusing here
+    would block uninstall of unrelated packs whose own target files
+    happen to be absent — too aggressive for the uninstall path.
+    """
+    if not target_path.exists():
+        return
+
+    data = _load_settings(target_path)
+    _shape_check_hooks(target_path, data)
+
+    hooks = data.get("hooks")
+    if not isinstance(hooks, dict):
+        return
+
+    owned_by_event: dict[str, set[str]] = {}
+    for event, entry_id in owned:
+        owned_by_event.setdefault(event, set()).add(entry_id)
+
+    for event, ids_to_remove in owned_by_event.items():
+        if event not in hooks:
+            continue
+        event_array = hooks[event]
+        if not isinstance(event_array, list):
+            continue
+        hooks[event] = [
+            e for e in event_array
+            if not (isinstance(e, dict) and e.get("id") in ids_to_remove)
+        ]
+        if not hooks[event]:
+            del hooks[event]
+
+    if not hooks:
+        # Empty hooks dict is kept (it might still hold un-owned events
+        # other than the ones we just cleared); only purely empty
+        # arrays get pruned. If hooks is itself now empty after the
+        # loop above, leave it as an empty object — other packs may
+        # still target it on a future install.
+        pass
+
+    _atomic_write(target_path, data)
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _load_settings(target_path: Path) -> dict:
+    """Read the settings file. Returns ``{}`` for an absent file;
+    raises ``UserMergeRefusal`` with the RFC-0005 unparseable text
+    when the file exists but is not valid JSON."""
+    if not target_path.exists():
+        return {}
+    try:
+        text = target_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise UserMergeRefusal(
+            f"cannot parse {target_path}: {exc}; fix or back up the file and retry"
+        ) from exc
+    if not text.strip():
+        return {}
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise UserMergeRefusal(
+            f"cannot parse {target_path}: {exc}; fix or back up the file and retry"
+        ) from exc
+    if not isinstance(data, dict):
+        # Root is structurally a different file shape than v0.2 ever
+        # produced; route through the `cannot parse` text so the
+        # refusal aligns with the unparseable case rather than
+        # introducing a third dialect of `<key-path> has unexpected
+        # shape` (the latter only applies under the `hooks` key path
+        # tree, not at the JSON root).
+        raise UserMergeRefusal(
+            f"cannot parse {target_path}: top-level value is "
+            f"{type(data).__name__}, expected object; fix or back up "
+            f"the file and retry"
+        )
+    return data
+
+
+def _shape_check_hooks(target_path: Path, data: dict) -> None:
+    if "hooks" in data and not isinstance(data["hooks"], dict):
+        raise UserMergeRefusal(
+            f"{target_path}: hooks has unexpected shape {type(data['hooks']).__name__}; "
+            f"expected object"
+        )
+
+
+def _shape_check_event_array(target_path: Path, event: str, value: object) -> None:
+    if not isinstance(value, list):
+        raise UserMergeRefusal(
+            f"{target_path}: hooks.{event} has unexpected shape {type(value).__name__}; "
+            f"expected array"
+        )
+
+
+def _merge_one_entry(
+    *,
+    target_path: Path,
+    pack_name: str,
+    basename: str,
+    event: str,
+    event_array: list,
+    tagged_entry: dict,
+    force_merge: bool,
+) -> None:
+    """Append, replace-in-place, or refuse for a single tagged entry.
+
+    Mutates ``event_array`` in place. Three cases per RFC-0005:
+      1. An existing entry with the same ``id`` → replace in place
+         (idempotency / reinstall).
+      2. An existing entry without ``id`` whose ``command`` matches
+         (after whitespace normalisation) → adopter collision. Refuse
+         unless ``force_merge`` (then replace in place).
+      3. Otherwise → append.
+    """
+    incoming_id = tagged_entry["id"]
+    incoming_cmd = _normalize_command(tagged_entry.get("command"))
+
+    for index, existing in enumerate(event_array):
+        if not isinstance(existing, dict):
+            continue
+        if existing.get("id") == incoming_id:
+            event_array[index] = tagged_entry
+            return
+        if existing.get("id") is None:
+            existing_cmd = _normalize_command(existing.get("command"))
+            if existing_cmd and existing_cmd == incoming_cmd:
+                if force_merge:
+                    event_array[index] = tagged_entry
+                    return
+                raise UserMergeRefusal(
+                    f"pack {pack_name}'s hook {basename} at event {event} "
+                    f"appears to be already wired in {target_path}; "
+                    f"remove the manual entry or pass --force-merge to take "
+                    f"ownership"
+                )
+
+    event_array.append(tagged_entry)
+
+
+def _atomic_write(target_path: Path, data: dict) -> None:
+    """Write *data* to *target_path* via a temp file + rename.
+
+    The rename is the atomic step on POSIX — readers either see the
+    old file or the fully-written new file, never a partial. Uses
+    ``tempfile.NamedTemporaryFile`` in the target's parent so the
+    rename stays on the same filesystem (cross-filesystem rename is
+    a copy, not atomic). The serialiser writes pretty JSON with
+    2-space indent so the file diffs cleanly under version control —
+    adopters who track ``~/.claude/settings.json`` in a dotfiles repo
+    are the load-bearing audience here.
+    """
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    serialised = json.dumps(data, indent=2, sort_keys=False) + "\n"
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=str(target_path.parent),
+        prefix=target_path.name + ".",
+        suffix=".tmp",
+        delete=False,
+    ) as tmp:
+        tmp.write(serialised)
+        tmp.flush()
+        os.fsync(tmp.fileno())
+        tmp_path = Path(tmp.name)
+    tmp_path.replace(target_path)
+    # fsync the parent directory so the rename's directory entry hits
+    # disk. Without this, a power loss between `replace()` and the
+    # directory entry being flushed can leave the target absent
+    # despite the rename appearing to succeed — the same byte-stability
+    # concern AC9 / AC13 pin via their "file unchanged on refusal"
+    # contracts. Tolerate OSError on platforms where dir-fsync is a
+    # no-op (some macOS configurations).
+    try:
+        dir_fd = os.open(str(target_path.parent), os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    except OSError:
+        pass

--- a/packages/agentbundle/tests/integration/test_cc_user_hooks_fixture.py
+++ b/packages/agentbundle/tests/integration/test_cc_user_hooks_fixture.py
@@ -1,0 +1,108 @@
+"""T5: integration coverage for ``user-merge-json`` against the
+``cc-user-hooks`` fixture.
+
+Complements ``tests/unit/test_user_merge_json.py``: the unit tests
+construct wiring data in-memory; this test reads the fixture's actual
+``.apm/hook-wiring/*.toml`` content from disk, parses it with
+``tomllib``, and runs the merger end-to-end against a ``tmp_path``-
+scoped ``~/.claude/settings.json``.
+
+Per spec § Boundaries — *Never do* — no live writes to
+``~/.claude/`` outside ``tmp_path``. ``$HOME`` is redirected via
+``patch.dict(os.environ, {"HOME": tmp})`` for the duration of each
+test; the assertion target is the tmp-scoped settings file.
+
+Spec AC coverage: AC8 / AC9 / AC11 against the fixture.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import tomllib
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+FIXTURES = REPO_ROOT / "packages" / "agentbundle" / "tests" / "fixtures" / "packs"
+CC_USER_HOOKS = FIXTURES / "cc-user-hooks"
+
+
+def _load_wiring_tomls(pack_path: Path) -> dict[str, dict]:
+    """Parse every ``.apm/hook-wiring/*.toml`` under *pack_path*."""
+    out: dict[str, dict] = {}
+    wiring_dir = pack_path / ".apm" / "hook-wiring"
+    if not wiring_dir.exists():
+        return out
+    for entry in sorted(wiring_dir.iterdir()):
+        if entry.is_file() and entry.suffix == ".toml":
+            out[entry.stem] = tomllib.loads(entry.read_text(encoding="utf-8"))
+    return out
+
+
+class CCUserHooksFixtureTests(unittest.TestCase):
+    """End-to-end shape: read fixture wiring → project → assert
+    on-disk settings file has the expected merged shape."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(__import__("shutil").rmtree, self.tmp, ignore_errors=True)
+        self.home = Path(self.tmp) / "home"
+        self.home.mkdir()
+        self.settings = self.home / ".claude" / "settings.json"
+        self._env_patch = patch.dict(os.environ, {"HOME": str(self.home)})
+        self._env_patch.start()
+        self.addCleanup(self._env_patch.stop)
+
+    def test_fixture_round_trip_install_uninstall(self) -> None:
+        """Install → settings file has the fixture's `UserPromptSubmit`
+        wiring tagged with `cc-user-hooks:on-prompt`. Uninstall →
+        the entry is gone; the empty event array is removed too."""
+        from agentbundle.build.projections.user_merge_json import (
+            project,
+            unproject,
+        )
+
+        wiring = _load_wiring_tomls(CC_USER_HOOKS)
+        self.assertIn("on-prompt", wiring, "fixture missing on-prompt.toml")
+
+        owned = project(self.settings, "cc-user-hooks", wiring)
+        self.assertEqual(owned, [("UserPromptSubmit", "cc-user-hooks:on-prompt")])
+
+        data = json.loads(self.settings.read_text(encoding="utf-8"))
+        entries = data["hooks"]["UserPromptSubmit"]
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["id"], "cc-user-hooks:on-prompt")
+
+        unproject(self.settings, owned)
+        data = json.loads(self.settings.read_text(encoding="utf-8"))
+        self.assertNotIn("UserPromptSubmit", data.get("hooks", {}))
+
+    def test_fixture_reinstall_idempotent(self) -> None:
+        from agentbundle.build.projections.user_merge_json import project
+
+        wiring = _load_wiring_tomls(CC_USER_HOOKS)
+        project(self.settings, "cc-user-hooks", wiring)
+        first = self.settings.read_bytes()
+        project(self.settings, "cc-user-hooks", wiring)
+        self.assertEqual(self.settings.read_bytes(), first)
+
+    def test_no_writes_outside_redirected_home(self) -> None:
+        """AC29: nothing lands outside the tmp_path-scoped $HOME."""
+        from agentbundle.build.projections.user_merge_json import project
+
+        wiring = _load_wiring_tomls(CC_USER_HOOKS)
+        project(self.settings, "cc-user-hooks", wiring)
+        # The only artifact under tmp is the redirected ~/.claude tree.
+        artifacts = sorted(
+            p.relative_to(self.home).as_posix()
+            for p in self.home.rglob("*")
+            if p.is_file()
+        )
+        self.assertEqual(artifacts, [".claude/settings.json"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/agentbundle/tests/unit/test_user_merge_json.py
+++ b/packages/agentbundle/tests/unit/test_user_merge_json.py
@@ -1,0 +1,414 @@
+"""T5: `user-merge-json` mode — Claude Code user-scope hook-wiring merger.
+
+Pure-function unit coverage. Integration coverage against the
+`cc-user-hooks` fixture lives in
+``packages/agentbundle/tests/integration/test_cc_user_hooks_fixture.py``.
+
+Covers spec ACs:
+  - AC8  — empty file → write hooks.<event> arrays with id-tagged entries.
+  - AC9  — reinstall same version is byte-for-byte no-op.
+  - AC10 — second pack with overlapping event appends; first pack unmoved.
+  - AC11 — uninstall removes only owned entries; empty arrays removed.
+  - AC12 — adopter hand-edit collision refuses; --force-merge adopts.
+  - AC13 — unparseable JSON refuses non-zero; file unchanged.
+  - AC14 — wrong-shape `hooks` or `hooks.<event>` refuses with the
+           `<key-path> has unexpected shape` text.
+  - Plus: auto-init absent `hooks` to `{}` and absent `hooks.<event>`
+    to `[]`. Atomic write via `Path.replace`.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# AC8 — empty file → write hooks.<event> arrays with id-tagged entries
+# ---------------------------------------------------------------------------
+
+
+class EmptyFileTests(unittest.TestCase):
+    def test_empty_settings_writes_hooks_event_array(self) -> None:
+        from agentbundle.build.projections.user_merge_json import project
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "settings.json"
+            target.write_text("{}", encoding="utf-8")
+            owned = project(
+                target_path=target,
+                pack_name="personal-reviewers",
+                wiring_tomls={
+                    "on-prompt": {
+                        "hooks": {
+                            "UserPromptSubmit": [{"command": "do-x", "matcher": ""}]
+                        }
+                    }
+                },
+            )
+            data = json.loads(target.read_text(encoding="utf-8"))
+            self.assertIn("hooks", data)
+            self.assertIn("UserPromptSubmit", data["hooks"])
+            entries = data["hooks"]["UserPromptSubmit"]
+            self.assertEqual(len(entries), 1)
+            self.assertEqual(entries[0]["id"], "personal-reviewers:on-prompt")
+            self.assertEqual(entries[0]["command"], "do-x")
+            # No other top-level keys.
+            self.assertEqual(set(data.keys()), {"hooks"})
+            # Owned-state list reflects what we wrote.
+            self.assertEqual(owned, [("UserPromptSubmit", "personal-reviewers:on-prompt")])
+
+    def test_absent_file_creates_with_empty_object_and_appends(self) -> None:
+        from agentbundle.build.projections.user_merge_json import project
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "settings.json"
+            self.assertFalse(target.exists())
+            project(
+                target_path=target,
+                pack_name="p",
+                wiring_tomls={"h": {"hooks": {"Event": [{"command": "x"}]}}},
+            )
+            self.assertTrue(target.exists())
+            data = json.loads(target.read_text(encoding="utf-8"))
+            self.assertEqual(data["hooks"]["Event"][0]["id"], "p:h")
+
+    def test_other_top_level_keys_preserved(self) -> None:
+        """Adopter-set keys (theme, model, env) must not be touched."""
+        from agentbundle.build.projections.user_merge_json import project
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "settings.json"
+            target.write_text(
+                json.dumps({"theme": "dark", "model": "opus", "env": {"K": "V"}}),
+                encoding="utf-8",
+            )
+            project(
+                target_path=target,
+                pack_name="p",
+                wiring_tomls={"h": {"hooks": {"E": [{"command": "x"}]}}},
+            )
+            data = json.loads(target.read_text(encoding="utf-8"))
+            self.assertEqual(data["theme"], "dark")
+            self.assertEqual(data["model"], "opus")
+            self.assertEqual(data["env"], {"K": "V"})
+            self.assertIn("hooks", data)
+
+
+# ---------------------------------------------------------------------------
+# AC9 — reinstall same version is byte-for-byte no-op
+# ---------------------------------------------------------------------------
+
+
+class IdempotencyTests(unittest.TestCase):
+    def test_reinstall_same_version_byte_for_byte(self) -> None:
+        from agentbundle.build.projections.user_merge_json import project
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "settings.json"
+            target.write_text("{}", encoding="utf-8")
+            wiring = {"on-prompt": {"hooks": {"UserPromptSubmit": [{"command": "x"}]}}}
+            project(target, "p", wiring)
+            first = target.read_bytes()
+            project(target, "p", wiring)
+            second = target.read_bytes()
+            self.assertEqual(first, second, "reinstall changed bytes")
+
+    def test_reinstall_position_preserved(self) -> None:
+        """Reinstalling a pack must not reorder its entries within the array."""
+        from agentbundle.build.projections.user_merge_json import project
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "settings.json"
+            target.write_text("{}", encoding="utf-8")
+            project(target, "a", {"x": {"hooks": {"E": [{"command": "1"}]}}})
+            project(target, "b", {"y": {"hooks": {"E": [{"command": "2"}]}}})
+            project(target, "a", {"x": {"hooks": {"E": [{"command": "1"}]}}})  # reinstall a
+            data = json.loads(target.read_text(encoding="utf-8"))
+            ids = [e["id"] for e in data["hooks"]["E"]]
+            # `a:x` must still be first.
+            self.assertEqual(ids, ["a:x", "b:y"])
+
+
+# ---------------------------------------------------------------------------
+# AC10 — second pack appends; first pack unmoved
+# ---------------------------------------------------------------------------
+
+
+class TwoPacksOverlappingEventTests(unittest.TestCase):
+    def test_second_pack_appends_after_first(self) -> None:
+        from agentbundle.build.projections.user_merge_json import project
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "settings.json"
+            target.write_text("{}", encoding="utf-8")
+            project(target, "alpha", {"hk": {"hooks": {"E": [{"command": "a"}]}}})
+            project(target, "beta", {"hk": {"hooks": {"E": [{"command": "b"}]}}})
+            data = json.loads(target.read_text(encoding="utf-8"))
+            ids = [e["id"] for e in data["hooks"]["E"]]
+            self.assertEqual(ids, ["alpha:hk", "beta:hk"])
+            commands = [e["command"] for e in data["hooks"]["E"]]
+            self.assertEqual(commands, ["a", "b"])
+
+
+# ---------------------------------------------------------------------------
+# AC11 — uninstall removes only owned entries
+# ---------------------------------------------------------------------------
+
+
+class UninstallTests(unittest.TestCase):
+    def test_uninstall_removes_only_owned(self) -> None:
+        from agentbundle.build.projections.user_merge_json import project, unproject
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "settings.json"
+            target.write_text("{}", encoding="utf-8")
+            project(target, "alpha", {"hk": {"hooks": {"E": [{"command": "a"}]}}})
+            project(target, "beta", {"hk": {"hooks": {"E": [{"command": "b"}]}}})
+            unproject(target, [("E", "alpha:hk")])
+            data = json.loads(target.read_text(encoding="utf-8"))
+            ids = [e["id"] for e in data["hooks"]["E"]]
+            self.assertEqual(ids, ["beta:hk"])
+
+    def test_uninstall_position_preserved_for_survivors(self) -> None:
+        from agentbundle.build.projections.user_merge_json import project, unproject
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "settings.json"
+            target.write_text("{}", encoding="utf-8")
+            project(target, "a", {"h": {"hooks": {"E": [{"command": "1"}]}}})
+            project(target, "b", {"h": {"hooks": {"E": [{"command": "2"}]}}})
+            project(target, "c", {"h": {"hooks": {"E": [{"command": "3"}]}}})
+            unproject(target, [("E", "b:h")])
+            data = json.loads(target.read_text(encoding="utf-8"))
+            ids = [e["id"] for e in data["hooks"]["E"]]
+            self.assertEqual(ids, ["a:h", "c:h"])
+
+    def test_uninstall_removes_empty_event_array(self) -> None:
+        """RFC-0005: empty `hooks.<event>` arrays are removed (not left as `[]`)."""
+        from agentbundle.build.projections.user_merge_json import project, unproject
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "settings.json"
+            target.write_text("{}", encoding="utf-8")
+            project(target, "p", {"h": {"hooks": {"E": [{"command": "x"}]}}})
+            unproject(target, [("E", "p:h")])
+            data = json.loads(target.read_text(encoding="utf-8"))
+            self.assertNotIn("E", data.get("hooks", {}))
+
+    def test_uninstall_against_absent_file_is_noop(self) -> None:
+        from agentbundle.build.projections.user_merge_json import unproject
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "settings.json"
+            # No-op: file doesn't exist; nothing to remove.
+            unproject(target, [("E", "p:h")])
+            self.assertFalse(target.exists())
+
+
+# ---------------------------------------------------------------------------
+# AC12 — adopter collision refuses; --force-merge adopts
+# ---------------------------------------------------------------------------
+
+
+class AdopterCollisionTests(unittest.TestCase):
+    def test_collision_with_adopter_entry_refuses(self) -> None:
+        """An adopter-hand-authored entry with matching command must
+        refuse install with the RFC-0005-specified text."""
+        from agentbundle.build.projections.user_merge_json import (
+            UserMergeRefusal,
+            project,
+        )
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "settings.json"
+            target.write_text(
+                json.dumps({"hooks": {"UserPromptSubmit": [{"command": "do-x"}]}}),
+                encoding="utf-8",
+            )
+            with self.assertRaises(UserMergeRefusal) as ctx:
+                project(
+                    target,
+                    "p",
+                    {"on-prompt": {"hooks": {"UserPromptSubmit": [{"command": "do-x"}]}}},
+                )
+            msg = str(ctx.exception)
+            self.assertIn("p's hook on-prompt at event UserPromptSubmit", msg)
+            self.assertIn("appears to be already wired", msg)
+            self.assertIn("--force-merge", msg)
+
+    def test_collision_whitespace_normalised(self) -> None:
+        """Collision detection compares commands after whitespace normalisation
+        per RFC-0005 (`textual equality after whitespace normalisation`)."""
+        from agentbundle.build.projections.user_merge_json import (
+            UserMergeRefusal,
+            project,
+        )
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "settings.json"
+            target.write_text(
+                json.dumps({"hooks": {"E": [{"command": "  do-x   "}]}}),
+                encoding="utf-8",
+            )
+            with self.assertRaises(UserMergeRefusal):
+                project(target, "p", {"h": {"hooks": {"E": [{"command": "do-x"}]}}})
+
+    def test_force_merge_adopts_collision(self) -> None:
+        """--force-merge replaces the adopter entry; original preserved
+        in a state-file snapshot path returned by project()."""
+        from agentbundle.build.projections.user_merge_json import project
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "settings.json"
+            target.write_text(
+                json.dumps({"hooks": {"E": [{"command": "do-x"}]}}),
+                encoding="utf-8",
+            )
+            project(
+                target,
+                "p",
+                {"h": {"hooks": {"E": [{"command": "do-x"}]}}},
+                force_merge=True,
+            )
+            data = json.loads(target.read_text(encoding="utf-8"))
+            # The single entry is now id-tagged (adopter's was untagged).
+            self.assertEqual(len(data["hooks"]["E"]), 1)
+            self.assertEqual(data["hooks"]["E"][0]["id"], "p:h")
+
+    def test_no_collision_when_commands_differ(self) -> None:
+        """An adopter entry with a different command does NOT collide;
+        the pack's entry appends alongside."""
+        from agentbundle.build.projections.user_merge_json import project
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "settings.json"
+            target.write_text(
+                json.dumps({"hooks": {"E": [{"command": "manual-thing"}]}}),
+                encoding="utf-8",
+            )
+            project(target, "p", {"h": {"hooks": {"E": [{"command": "pack-thing"}]}}})
+            data = json.loads(target.read_text(encoding="utf-8"))
+            self.assertEqual(len(data["hooks"]["E"]), 2)
+
+
+# ---------------------------------------------------------------------------
+# AC13 — unparseable JSON refuses; file unchanged
+# ---------------------------------------------------------------------------
+
+
+class UnparseableJsonTests(unittest.TestCase):
+    def test_unparseable_settings_refuses(self) -> None:
+        from agentbundle.build.projections.user_merge_json import (
+            UserMergeRefusal,
+            project,
+        )
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "settings.json"
+            target.write_text("{not valid json", encoding="utf-8")
+            before = target.read_bytes()
+            with self.assertRaises(UserMergeRefusal) as ctx:
+                project(target, "p", {"h": {"hooks": {"E": [{"command": "x"}]}}})
+            msg = str(ctx.exception)
+            self.assertIn("cannot parse", msg)
+            self.assertIn("fix or back up", msg)
+            # File unchanged.
+            self.assertEqual(target.read_bytes(), before)
+
+
+# ---------------------------------------------------------------------------
+# AC14 — wrong-shape hooks key refuses with `unexpected shape` text
+# ---------------------------------------------------------------------------
+
+
+class WrongShapeTests(unittest.TestCase):
+    def test_hooks_as_array_refuses(self) -> None:
+        from agentbundle.build.projections.user_merge_json import (
+            UserMergeRefusal,
+            project,
+        )
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "settings.json"
+            target.write_text(json.dumps({"hooks": ["wrong"]}), encoding="utf-8")
+            with self.assertRaises(UserMergeRefusal) as ctx:
+                project(target, "p", {"h": {"hooks": {"E": [{"command": "x"}]}}})
+            self.assertIn("hooks has unexpected shape", str(ctx.exception))
+
+    def test_hooks_event_as_string_refuses(self) -> None:
+        from agentbundle.build.projections.user_merge_json import (
+            UserMergeRefusal,
+            project,
+        )
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "settings.json"
+            target.write_text(
+                json.dumps({"hooks": {"E": "wrong-shape"}}),
+                encoding="utf-8",
+            )
+            with self.assertRaises(UserMergeRefusal) as ctx:
+                project(target, "p", {"h": {"hooks": {"E": [{"command": "x"}]}}})
+            self.assertIn("hooks.E has unexpected shape", str(ctx.exception))
+
+
+# ---------------------------------------------------------------------------
+# Auto-init absent keys
+# ---------------------------------------------------------------------------
+
+
+class AutoInitTests(unittest.TestCase):
+    def test_absent_hooks_key_auto_initialised(self) -> None:
+        from agentbundle.build.projections.user_merge_json import project
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "settings.json"
+            target.write_text(json.dumps({"theme": "dark"}), encoding="utf-8")
+            project(target, "p", {"h": {"hooks": {"E": [{"command": "x"}]}}})
+            data = json.loads(target.read_text(encoding="utf-8"))
+            self.assertIn("hooks", data)
+            self.assertEqual(data["theme"], "dark")  # preserved
+
+    def test_absent_event_in_existing_hooks_auto_initialised(self) -> None:
+        from agentbundle.build.projections.user_merge_json import project
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "settings.json"
+            target.write_text(
+                json.dumps({"hooks": {"Other": [{"command": "y"}]}}),
+                encoding="utf-8",
+            )
+            project(target, "p", {"h": {"hooks": {"E": [{"command": "x"}]}}})
+            data = json.loads(target.read_text(encoding="utf-8"))
+            self.assertIn("E", data["hooks"])
+            self.assertIn("Other", data["hooks"])
+
+
+# ---------------------------------------------------------------------------
+# hook_id helper
+# ---------------------------------------------------------------------------
+
+
+class HookIdTests(unittest.TestCase):
+    def test_synthesize_id_shape(self) -> None:
+        from agentbundle.build.projections.hook_id import synthesize_id
+
+        self.assertEqual(
+            synthesize_id("personal-reviewers", "on-prompt"),
+            "personal-reviewers:on-prompt",
+        )
+
+    def test_synthesize_id_preserves_hyphens(self) -> None:
+        from agentbundle.build.projections.hook_id import synthesize_id
+
+        self.assertEqual(
+            synthesize_id("my-pack", "long-hook-name"),
+            "my-pack:long-hook-name",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Wave 4 of the [user-scope-hooks spec](../tree/main/docs/specs/user-scope-hooks/spec.md) — T5 (Claude Code user-scope merger) + T10 (distribution-adapters spec amendment). Fourth of thirteen PRs. T5 and T10 are independent file sets and were drafted in parallel.

- **T5 — `user-merge-json` projection mode.** New subpackage \`packages/agentbundle/agentbundle/build/projections/\` with three modules: \`hook_id.py\` (shared id-synthesis, T6 reuses), \`user_merge_json.py\` (\`project\` + \`unproject\` + \`UserMergeRefusal\`), and an \`__init__.py\`. Stdlib-only. Atomic write via tmp + rename + parent-directory fsync. 21 unit tests + 3 integration tests against the \`cc-user-hooks\` fixture (tmp_path-scoped \`\$HOME\`).
- **T10 — distribution-adapters spec amendment.** \`docs/specs/distribution-adapters/spec.md\` grows two new projection-mode entries, a v0.3 user-scope hook handling section with full subsections for both modes, an updated projection table (with the \`<pack>/\` namespacing the user-scope-hooks spec mandates), a conditional-form Rail B, a build-pipeline phase-order callout, and Ask first cleanup. All RFC-0005 references cite the section by name.

## Acceptance criteria

- [x] **AC8.** Empty file install → \`hooks.<event>\` arrays with id-tagged entries; other top-level keys untouched.
- [x] **AC9.** Reinstall same version is byte-for-byte no-op.
- [x] **AC10.** Two packs overlapping event: first unmoved, second appends; both ids coexist.
- [x] **AC11.** Uninstall removes only owned entries; empty arrays pruned.
- [x] **AC12.** Adopter command-text collision refuses with RFC-0005 verbatim text; \`force_merge\` adopts.
- [x] **AC13.** Unparseable JSON refuses; file byte-unchanged.
- [x] **AC14.** Wrong-shape \`hooks\` or \`hooks.<event>\` refuses with the \`<key-path> has unexpected shape\` text.
- [x] **T10 spec bullets:** all six (merge-into-agent-json + user-merge-json subsections, projection table, Rail B conditional text, RFC-0005 citations by name, build-check clean).

## Adversarial review

Two rounds. Round 1 surfaced **2 Blockers** (missing \`<pack>/\` namespacing in the projection table; RFC-0005 anchors using \`---\` where GitHub renders \`--\`) + 5 Concerns + 2 Nits. All Blockers + cheap Concerns (#3 dead intra-doc link, #4 parent-directory fsync, #5 absent-file TODO marker, #6 top-level non-object refusal text dialect) + both Nits addressed in-PR. Concern #7 (empty-command asymmetry) flagged as future T2-territory pack-side validate addition.

## Gates

- 474 tests pass, 1 skipped (was 450 pre-wave-4; +24 new T5 tests).
- \`make build-check\` exits 0.
- \`make validate\` exits 0.

## Out of scope (later waves)

- **T6** — \`merge-into-agent-json\` projection implementation. The spec subsection lands here but the module itself doesn't exist yet (clearly marked in the spec text).
- **T7** — build-pipeline phase-order enforcement in code (the invariant is now documented in the spec; T7 implements).
- **T8b** — install/uninstall CLI threading (writes \`hook-wiring-owned\` state rows; \`--force-merge\` flag binding).
- **T8c** — upgrade reconciliation including \`attach-to-agent\` rename.
- **T9** — \`reconcile --scope user\` reporter (will surface the absent-target-file orphan-in-state case T5's unproject documents).
- **T11** — \`agent-spec-cli\` spec amendment.

After this lands, **wave 5 = T6 + T11 in parallel** (T6's deps: T3, T4, T5 — all in main; T11's deps: T8a/T8b/T8c/T9 — only T8a in main, so T11 actually has to wait). Realistically wave 5 is just T6 alone.