### PR TITLE
feat(wave5): merge-into-agent-json projection + kiro vocabulary gate (T6)

### DIFF
--- a/packages/agentbundle/agentbundle/build/projections/merge_into_agent_json.py
+++ b/packages/agentbundle/agentbundle/build/projections/merge_into_agent_json.py
@@ -1,0 +1,264 @@
+"""``merge-into-agent-json`` projection mode — Kiro at both scopes.
+
+Merges a pack's ``.apm/hook-wiring/*.toml`` content into a **pack-owned**
+agent JSON at ``<scope-root>/.kiro/agents/<attach-to-agent>.json`` under
+the ``hooks`` key. The mode reuses ``user-merge-json``'s
+array-append-with-id discipline, with structural differences from the
+Claude-Code-user-scope shape:
+
+1. **Target is pack-owned, not adopter-shared.** Adopter hand-edits to
+   the agent JSON are squatting on a managed surface — the next upgrade
+   replaces the file via the agent primitive's ``direct-file``
+   projection. No collision detection, no ``--force-merge`` flag.
+2. **Agent file must exist before merge runs.** RFC-0005 establishes
+   the build-pipeline ordering invariant — agents project before any
+   wiring merges run. The absent-file case is a refuse-with-internal-
+   error path, exercised only via test instrumentation.
+3. **Per-agent target, scope-conditional.** Each wiring TOML targets
+   a single agent named by its ``attach-to-agent`` field. The caller
+   (T8b) is responsible for resolving the target file path; this
+   module operates on the resolved path.
+
+This module is stdlib-only — ``json`` + ``pathlib`` + ``tempfile``.
+
+T8b will own the install/uninstall CLI threading; T7 enforces the
+pipeline ordering in the iterator. T6 (this module) ships the merge
+engine plus the per-adapter event-vocabulary rail used by
+``commands/validate.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+from agentbundle.build.projections.hook_id import synthesize_id
+
+
+class AgentJsonRefusal(Exception):
+    """Raised when ``project`` / ``unproject`` refuses to write.
+
+    The exception's string is the refuse-and-explain text RFC-0005
+    specifies. CLI callers (T8b) catch and print to stderr without
+    paraphrasing.
+    """
+
+
+def project(
+    target_path: Path,
+    pack_name: str,
+    wiring_tomls: dict[str, dict],
+) -> list[tuple[str, str]]:
+    """Merge *wiring_tomls* into the agent JSON at *target_path*.
+
+    Arguments:
+      target_path: resolved path to the agent JSON. **Must exist** —
+        the build pipeline (T7) projects agents before wiring runs.
+        Absent → refuse with the ``internal:`` text.
+      pack_name: the pack's ``[pack].name``. Substituted into id tags.
+      wiring_tomls: map of wiring TOML basename (no ``.toml``) → parsed
+        TOML body (typically ``{"attach-to-agent": "<name>", "hooks":
+        {"<Event>": [entries]}}``). The ``attach-to-agent`` field is
+        not consumed here — the caller has already resolved
+        *target_path* using it.
+
+    Returns:
+      List of ``(event, id)`` tuples reflecting every owned entry
+      written. T8b records these in the state file's
+      ``hook-wiring-owned`` table so ``unproject`` can be precise.
+
+    Raises:
+      AgentJsonRefusal: missing agent file (pipeline-ordering
+        violation), unparseable JSON, wrong-shape ``hooks`` or
+        ``hooks.<event>``.
+    """
+    if not target_path.exists():
+        # The text below extends RFC-0005's bare `internal: <agent-file>
+        # missing` shape with diagnostic context. This is intentional —
+        # the message is a CLI-internal-error string, not an
+        # adopter-facing contract, so we trade brevity for the breadcrumb
+        # "agent must project before wiring" that points at the
+        # pipeline-ordering invariant. Tests assert the substrings
+        # `internal:` / `missing` / `agent must project before wiring`
+        # to keep T8b's CLI handler portable across text refinements.
+        raise AgentJsonRefusal(
+            f"internal: {target_path} missing at hook-wiring merge time; "
+            f"agent must project before wiring"
+        )
+
+    data = _load_agent_json(target_path)
+    _shape_check_hooks(target_path, data)
+
+    owned: list[tuple[str, str]] = []
+    for basename, body in wiring_tomls.items():
+        entry_id = synthesize_id(pack_name, basename)
+        hooks_in_wiring = body.get("hooks", {}) if isinstance(body, dict) else {}
+        if not isinstance(hooks_in_wiring, dict):
+            continue
+        for event, incoming_entries in hooks_in_wiring.items():
+            if not isinstance(incoming_entries, list):
+                continue
+            data.setdefault("hooks", {})
+            data["hooks"].setdefault(event, [])
+            event_array = data["hooks"][event]
+            _shape_check_event_array(target_path, event, event_array)
+            for incoming in incoming_entries:
+                if not isinstance(incoming, dict):
+                    continue
+                tagged = dict(incoming)
+                tagged["id"] = entry_id
+                _merge_one_entry(event_array, tagged)
+                owned.append((event, entry_id))
+
+    _atomic_write(target_path, data)
+    # Deduplicate (event, id) tuples — see T5's note in user_merge_json.
+    seen: set[tuple[str, str]] = set()
+    result: list[tuple[str, str]] = []
+    for item in owned:
+        if item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result
+
+
+def unproject(target_path: Path, owned: list[tuple[str, str]]) -> None:
+    """Remove every ``(event, id)`` pair in *owned* from *target_path*.
+
+    Empty ``hooks.<event>`` arrays are removed. The agent file itself
+    is **never** removed by this function — that's the agent
+    primitive's ``direct-file`` uninstall's responsibility (RFC-0005
+    § Conflict, idempotency, uninstall).
+
+    If the target file is absent, ``unproject`` is a no-op — same
+    rationale as T5's ``user_merge_json.unproject``: a state row
+    pointing at a now-absent file is an orphan-in-state condition that
+    T9's reconcile surfaces. Refusing here would block uninstall of
+    unrelated packs whose own target files happen to be absent.
+    """
+    if not target_path.exists():
+        return
+
+    data = _load_agent_json(target_path)
+    _shape_check_hooks(target_path, data)
+
+    hooks = data.get("hooks")
+    if not isinstance(hooks, dict):
+        return
+
+    owned_by_event: dict[str, set[str]] = {}
+    for event, entry_id in owned:
+        owned_by_event.setdefault(event, set()).add(entry_id)
+
+    for event, ids_to_remove in owned_by_event.items():
+        if event not in hooks:
+            continue
+        event_array = hooks[event]
+        if not isinstance(event_array, list):
+            continue
+        hooks[event] = [
+            e for e in event_array
+            if not (isinstance(e, dict) and e.get("id") in ids_to_remove)
+        ]
+        if not hooks[event]:
+            del hooks[event]
+
+    _atomic_write(target_path, data)
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _load_agent_json(target_path: Path) -> dict:
+    """Read the agent JSON. Raises ``AgentJsonRefusal`` on
+    unparseable content (matches T5's `user_merge_json` shape)."""
+    try:
+        text = target_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise AgentJsonRefusal(
+            f"cannot parse {target_path}: {exc}; fix or back up the file and retry"
+        ) from exc
+    if not text.strip():
+        # An empty agent JSON file is a Kiro-side artifact (an agent
+        # body with no fields yet) — treat as `{}` for merge.
+        return {}
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise AgentJsonRefusal(
+            f"cannot parse {target_path}: {exc}; fix or back up the file and retry"
+        ) from exc
+    if not isinstance(data, dict):
+        raise AgentJsonRefusal(
+            f"cannot parse {target_path}: top-level value is "
+            f"{type(data).__name__}, expected object; fix or back up "
+            f"the file and retry"
+        )
+    return data
+
+
+def _shape_check_hooks(target_path: Path, data: dict) -> None:
+    if "hooks" in data and not isinstance(data["hooks"], dict):
+        raise AgentJsonRefusal(
+            f"{target_path}: hooks has unexpected shape {type(data['hooks']).__name__}; "
+            f"expected object"
+        )
+
+
+def _shape_check_event_array(target_path: Path, event: str, value: object) -> None:
+    if not isinstance(value, list):
+        raise AgentJsonRefusal(
+            f"{target_path}: hooks.{event} has unexpected shape {type(value).__name__}; "
+            f"expected array"
+        )
+
+
+def _merge_one_entry(event_array: list, tagged_entry: dict) -> None:
+    """Append or replace-in-place by id.
+
+    No adopter-collision branch: the agent JSON is pack-owned (RFC-0005
+    § What this section does NOT add — no ``--force-merge`` for Kiro).
+    Adopter hand-edits to the agent file are squatting on a managed
+    surface; the next upgrade replaces the file via the agent
+    primitive's ``direct-file`` projection.
+    """
+    incoming_id = tagged_entry["id"]
+    for index, existing in enumerate(event_array):
+        if isinstance(existing, dict) and existing.get("id") == incoming_id:
+            event_array[index] = tagged_entry
+            return
+    event_array.append(tagged_entry)
+
+
+def _atomic_write(target_path: Path, data: dict) -> None:
+    """Write *data* to *target_path* via temp + rename + dir-fsync.
+
+    Same shape as T5's ``user_merge_json._atomic_write`` — see there
+    for the directory-fsync rationale.
+    """
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    serialised = json.dumps(data, indent=2, sort_keys=False) + "\n"
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=str(target_path.parent),
+        prefix=target_path.name + ".",
+        suffix=".tmp",
+        delete=False,
+    ) as tmp:
+        tmp.write(serialised)
+        tmp.flush()
+        os.fsync(tmp.fileno())
+        tmp_path = Path(tmp.name)
+    tmp_path.replace(target_path)
+    try:
+        dir_fd = os.open(str(target_path.parent), os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    except OSError:
+        pass

--- a/packages/agentbundle/agentbundle/build/scope_rails.py
+++ b/packages/agentbundle/agentbundle/build/scope_rails.py
@@ -338,6 +338,61 @@ def check_kiro_attach_to_agent(
     return None
 
 
+def check_kiro_event_vocabulary(
+    pack_name: str,
+    wiring_tomls: dict[str, dict],
+    vocabulary: list[str] | None,
+    target_adapters: Iterable[str],
+    adapter_name: str,
+) -> str | None:
+    """T6 (RFC-0005): per-adapter event-vocabulary refusal.
+
+    AC17 and AC17b: a wiring TOML naming an event outside the resolved
+    target adapter's declared ``agent-event-vocabulary`` is refused at
+    ``validate`` time with the RFC-0005 verbatim text
+    ``pack <P>'s hook-wiring <name>.toml uses event '<E>'; not in
+    adapter '<adapter>' agent-event-vocabulary``.
+
+    The check fires only when:
+      - the resolved target adapter is in ``target_adapters``, AND
+      - that adapter declares ``vocabulary`` (the projection's
+        ``agent-event-vocabulary`` field is present).
+
+    Claude Code's projection does not declare ``agent-event-vocabulary``,
+    so a wiring TOML with arbitrary event names projected against
+    Claude Code passes ``validate``. The vocabulary refusal is
+    per-adapter, not per-RFC (AC17b).
+
+    Arguments:
+      pack_name: substituted into the refusal text.
+      wiring_tomls: map of basename → parsed TOML body. First offender
+        wins.
+      vocabulary: the adapter's declared event-name list, or None when
+        the adapter has no such declaration (rail is a no-op).
+      target_adapters: iterable of adapter names the pack is being
+        validated against.
+      adapter_name: the adapter the vocabulary belongs to (substituted
+        into the refusal text).
+    """
+    if adapter_name not in set(target_adapters or ()):
+        return None
+    if vocabulary is None:
+        return None
+    allowed = set(vocabulary)
+    for wiring_name, body in wiring_tomls.items():
+        hooks = body.get("hooks", {}) if isinstance(body, dict) else {}
+        if not isinstance(hooks, dict):
+            continue
+        for event in hooks.keys():
+            if event not in allowed:
+                return (
+                    f"pack {pack_name}'s hook-wiring {wiring_name}.toml "
+                    f"uses event '{event}'; not in adapter '{adapter_name}' "
+                    f"agent-event-vocabulary"
+                )
+    return None
+
+
 def check_kiro_wiring(
     pack_path: Path,
     pack_name: str,

--- a/packages/agentbundle/agentbundle/commands/validate.py
+++ b/packages/agentbundle/agentbundle/commands/validate.py
@@ -173,7 +173,10 @@ def run(args) -> int:
     # would project to kiro." A Claude-Code-only v0.3 pack that ships
     # wiring but no agents has no kiro projection target — the rail is
     # a no-op for it (AC6: "field is ignored, not refused").
-    from agentbundle.build.scope_rails import check_kiro_wiring
+    from agentbundle.build.scope_rails import (
+        check_kiro_event_vocabulary,
+        check_kiro_wiring,
+    )
 
     target_adapters = _kiro_target_adapters(pack_data, pack_path)
     pack_name = pack_data.get("pack", {}).get("name") or pack_path.name
@@ -181,6 +184,25 @@ def run(args) -> int:
     if kiro_refusal is not None:
         print(f"validate: {kiro_refusal}", file=sys.stderr)
         return 1
+
+    # ── 4d. Kiro per-adapter event-vocabulary rail (RFC-0005, T6) ─────────
+    # AC17 / AC17b: a wiring TOML naming an event outside the resolved
+    # target adapter's `agent-event-vocabulary` is refused. Claude Code's
+    # projection declares no vocabulary, so its packs pass through;
+    # Kiro's vocabulary is loaded from the v0.3 adapter contract.
+    if "kiro" in target_adapters:
+        kiro_vocab = _kiro_event_vocabulary()
+        kiro_wiring_tomls = _load_pack_wiring_tomls(pack_path)
+        vocab_refusal = check_kiro_event_vocabulary(
+            pack_name=pack_name,
+            wiring_tomls=kiro_wiring_tomls,
+            vocabulary=kiro_vocab,
+            target_adapters=target_adapters,
+            adapter_name="kiro",
+        )
+        if vocab_refusal is not None:
+            print(f"validate: {vocab_refusal}", file=sys.stderr)
+            return 1
 
     # ── 5. Strict / conformance mode ─────────────────────────────────────
     if strict:
@@ -241,6 +263,66 @@ def _user_scope_hooks_opt_in(pack_data: dict) -> bool:
         return False
     flag = install.get("user-scope-hooks")
     return flag is True
+
+
+def _kiro_event_vocabulary() -> list[str] | None:
+    """Resolve Kiro's ``agent-event-vocabulary`` from the v0.3 contract.
+
+    Returns the list when the contract declares it (the post-T1 v0.3
+    state); returns None when the field is absent (the rail is then a
+    no-op per AC17b). Looked up on every call to keep the
+    contract-file the source of truth — no module-level cache so a
+    test-time contract swap is visible.
+    """
+    from agentbundle.build.contract import load as load_contract
+
+    here = Path(__file__).resolve().parent
+    bundled = here.parent / "_data" / "adapter.toml"
+    if bundled.exists():
+        contract_path = bundled
+    else:
+        # Dev-checkout fallback: the package lives at
+        # packages/agentbundle/agentbundle/commands/, so four `.parent`
+        # hops land at the repo root. Installed layouts (site-packages
+        # via pip) will always have the bundled `_data/adapter.toml`
+        # above, so this branch only fires when running from a working
+        # tree that excludes the bundle. Returning None on miss keeps
+        # the rail a no-op rather than crashing.
+        contract_path = here.parent.parent.parent.parent / "docs" / "contracts" / "adapter.toml"
+        if not contract_path.exists():
+            return None
+    contract = load_contract(contract_path)
+    kiro = contract.get("adapter", {}).get("kiro", {})
+    projections = kiro.get("projections", {}) if isinstance(kiro, dict) else {}
+    hook_wiring = projections.get("hook-wiring", {}) if isinstance(projections, dict) else {}
+    vocab = hook_wiring.get("agent-event-vocabulary") if isinstance(hook_wiring, dict) else None
+    if isinstance(vocab, list):
+        return [str(v) for v in vocab if isinstance(v, str)]
+    return None
+
+
+def _load_pack_wiring_tomls(pack_path: Path) -> dict[str, dict]:
+    """Parse every ``.apm/hook-wiring/*.toml`` under *pack_path*.
+
+    Mirrors the in-memory shape ``check_kiro_event_vocabulary``
+    consumes. A malformed wiring TOML would already have been refused
+    by ``check_kiro_wiring`` earlier in the validate pipeline, so this
+    helper silently skips parse errors.
+    """
+    import tomllib
+
+    out: dict[str, dict] = {}
+    wiring_dir = pack_path / ".apm" / "hook-wiring"
+    if not wiring_dir.exists():
+        return out
+    for entry in sorted(wiring_dir.iterdir()):
+        if not entry.is_file() or entry.suffix != ".toml":
+            continue
+        try:
+            out[entry.stem] = tomllib.loads(entry.read_text(encoding="utf-8"))
+        except (tomllib.TOMLDecodeError, OSError):
+            continue
+    return out
 
 
 def _kiro_target_adapters(pack_data: dict, pack_path: Path) -> set[str]:

--- a/packages/agentbundle/tests/integration/test_fixtures_validate.py
+++ b/packages/agentbundle/tests/integration/test_fixtures_validate.py
@@ -132,26 +132,18 @@ class MalformedFixturesRefusedTests(unittest.TestCase):
         self.assertIn("or names an unknown agent", err)
 
 
-class PendingT6PascalEventsFixtureTests(unittest.TestCase):
-    """The pascal-events fixture ships in T3 for T6 (the per-adapter
-    `agent-event-vocabulary` gate). Today, the T2 attach-to-agent rail
-    is satisfied (the fixture's `attach-to-agent = "reviewer"` resolves
-    to a same-pack agent), so validate currently passes the fixture.
-    T6 will flip this test — adding the vocabulary check that refuses
-    PascalCase events against Kiro. The marker test below pins T3's
-    contribution and signals T6 to invert it."""
+class PascalEventsRefusedByT6Tests(unittest.TestCase):
+    """T6 introduces the per-adapter `agent-event-vocabulary` rail.
+    The pascal-events fixture uses Claude-Code-style PascalCase event
+    names (`UserPromptSubmit`) which fall outside Kiro's declared
+    vocabulary (`agentSpawn`, `userPromptSubmit`, ...). Validate must
+    refuse with the RFC-0005 verbatim text."""
 
-    def test_pascal_events_currently_passes_pending_T6(self) -> None:
+    def test_pascal_events_refused_with_vocabulary_text(self) -> None:
         rc, err = _run_validate(FIXTURES / "malformed-kiro-pascal-events")
-        self.assertEqual(
-            rc,
-            0,
-            "pascal-events fixture refused at T3-era validate; "
-            "T6 is the task that introduces the refusal. If you're "
-            "wiring up T6, flip this test to assertEqual(rc, 1) and "
-            "assert the 'not in adapter ... agent-event-vocabulary' "
-            f"text in stderr. Current stderr: {err}",
-        )
+        self.assertEqual(rc, 1, f"pascal-events fixture was accepted: {err}")
+        self.assertIn("UserPromptSubmit", err)
+        self.assertIn("not in adapter 'kiro' agent-event-vocabulary", err)
 
 
 class FixtureIsolationTests(unittest.TestCase):

--- a/packages/agentbundle/tests/integration/test_kiro_repo_hooks_fixture.py
+++ b/packages/agentbundle/tests/integration/test_kiro_repo_hooks_fixture.py
@@ -1,0 +1,93 @@
+"""T6: integration coverage for ``merge-into-agent-json`` against the
+``kiro-repo-hooks`` fixture.
+
+End-to-end: read the fixture's `.apm/hook-wiring/on-spawn.toml` with
+`tomllib`, seed a `.kiro/agents/reviewer.json` (per RFC-0005's
+pipeline-ordering invariant — the agent file must exist before
+wiring runs; T7 will enforce this; here we simulate the pipeline by
+pre-seeding), run the merger, assert the shape.
+
+Per spec § Boundaries — *Never do* — no live writes to
+`~/.kiro/agents/` outside tmp_path. The repo-scope variant works
+against `tmp_path/.kiro/agents/<agent>.json`.
+
+Spec AC coverage: AC15, AC19 against the fixture.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+import tomllib
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+FIXTURES = REPO_ROOT / "packages" / "agentbundle" / "tests" / "fixtures" / "packs"
+KIRO_REPO_HOOKS = FIXTURES / "kiro-repo-hooks"
+
+
+def _load_wiring_tomls(pack_path: Path) -> dict[str, dict]:
+    out: dict[str, dict] = {}
+    wiring_dir = pack_path / ".apm" / "hook-wiring"
+    if wiring_dir.exists():
+        for entry in sorted(wiring_dir.iterdir()):
+            if entry.is_file() and entry.suffix == ".toml":
+                out[entry.stem] = tomllib.loads(entry.read_text(encoding="utf-8"))
+    return out
+
+
+class KiroRepoHooksFixtureTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        # Pre-seed the agent JSON the pipeline (T7) will produce. T6
+        # consumes a pre-existing agent file.
+        self.agent_json = self.tmp / ".kiro" / "agents" / "reviewer.json"
+        self.agent_json.parent.mkdir(parents=True, exist_ok=True)
+        self.agent_json.write_text(
+            json.dumps(
+                {"name": "reviewer", "description": "Reviews pending work."},
+                indent=2,
+            ) + "\n",
+            encoding="utf-8",
+        )
+
+    def test_fixture_round_trip_install_uninstall(self) -> None:
+        from agentbundle.build.projections.merge_into_agent_json import (
+            project,
+            unproject,
+        )
+
+        wiring = _load_wiring_tomls(KIRO_REPO_HOOKS)
+        self.assertIn("on-spawn", wiring, "fixture missing on-spawn.toml")
+
+        owned = project(self.agent_json, "kiro-repo-hooks", wiring)
+        self.assertEqual(owned, [("agentSpawn", "kiro-repo-hooks:on-spawn")])
+
+        data = json.loads(self.agent_json.read_text(encoding="utf-8"))
+        # Body keys preserved.
+        self.assertEqual(data["name"], "reviewer")
+        # Wiring merged.
+        self.assertEqual(data["hooks"]["agentSpawn"][0]["id"], "kiro-repo-hooks:on-spawn")
+
+        unproject(self.agent_json, owned)
+        data = json.loads(self.agent_json.read_text(encoding="utf-8"))
+        # Agent file remains; the wiring entries are gone.
+        self.assertTrue(self.agent_json.exists())
+        self.assertNotIn("agentSpawn", data.get("hooks", {}))
+        self.assertEqual(data["name"], "reviewer")
+
+    def test_fixture_reinstall_idempotent(self) -> None:
+        from agentbundle.build.projections.merge_into_agent_json import project
+
+        wiring = _load_wiring_tomls(KIRO_REPO_HOOKS)
+        project(self.agent_json, "kiro-repo-hooks", wiring)
+        first = self.agent_json.read_bytes()
+        project(self.agent_json, "kiro-repo-hooks", wiring)
+        self.assertEqual(self.agent_json.read_bytes(), first)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/agentbundle/tests/integration/test_kiro_user_hooks_fixture.py
+++ b/packages/agentbundle/tests/integration/test_kiro_user_hooks_fixture.py
@@ -1,0 +1,143 @@
+"""T6: integration coverage for ``merge-into-agent-json`` against the
+``kiro-user-hooks`` fixture (user scope).
+
+Same shape as the repo-scope test, except ``$HOME`` is redirected to
+a ``tmp_path`` and the agent JSON lands under
+``$HOME/.kiro/agents/<agent>.json`` per RFC-0005 § `[adapter.kiro.scope]`.
+
+AC coverage: AC18 (dispatchability shape — `sh -c "$command"` resolves
+the projected hook body), plus the same AC15/AC19 shapes the repo
+test pins.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import tomllib
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+FIXTURES = REPO_ROOT / "packages" / "agentbundle" / "tests" / "fixtures" / "packs"
+KIRO_USER_HOOKS = FIXTURES / "kiro-user-hooks"
+
+
+def _load_wiring_tomls(pack_path: Path) -> dict[str, dict]:
+    out: dict[str, dict] = {}
+    wiring_dir = pack_path / ".apm" / "hook-wiring"
+    if wiring_dir.exists():
+        for entry in sorted(wiring_dir.iterdir()):
+            if entry.is_file() and entry.suffix == ".toml":
+                out[entry.stem] = tomllib.loads(entry.read_text(encoding="utf-8"))
+    return out
+
+
+class KiroUserHooksFixtureTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.home = self.tmp / "home"
+        self.home.mkdir()
+        self._env_patch = patch.dict(os.environ, {"HOME": str(self.home)})
+        self._env_patch.start()
+        self.addCleanup(self._env_patch.stop)
+
+        # Pre-seed the user-scope agent JSON (T7's pipeline-ordering
+        # invariant: agent projects before wiring). Place under the
+        # redirected $HOME so the test does not touch the developer's
+        # real ~/.kiro/.
+        self.agent_json = self.home / ".kiro" / "agents" / "reviewer.json"
+        self.agent_json.parent.mkdir(parents=True, exist_ok=True)
+        self.agent_json.write_text(
+            json.dumps(
+                {"name": "reviewer", "description": "Reviews pending work."},
+                indent=2,
+            ) + "\n",
+            encoding="utf-8",
+        )
+
+    def test_user_scope_round_trip(self) -> None:
+        from agentbundle.build.projections.merge_into_agent_json import (
+            project,
+            unproject,
+        )
+
+        wiring = _load_wiring_tomls(KIRO_USER_HOOKS)
+        owned = project(self.agent_json, "kiro-user-hooks", wiring)
+        self.assertEqual(owned, [("agentSpawn", "kiro-user-hooks:on-spawn")])
+
+        data = json.loads(self.agent_json.read_text(encoding="utf-8"))
+        self.assertEqual(data["hooks"]["agentSpawn"][0]["id"], "kiro-user-hooks:on-spawn")
+
+        unproject(self.agent_json, owned)
+        data = json.loads(self.agent_json.read_text(encoding="utf-8"))
+        self.assertNotIn("agentSpawn", data.get("hooks", {}))
+
+    def test_no_writes_outside_redirected_home(self) -> None:
+        """AC29 shape: every write lands inside the tmp-scoped $HOME."""
+        from agentbundle.build.projections.merge_into_agent_json import project
+
+        wiring = _load_wiring_tomls(KIRO_USER_HOOKS)
+        project(self.agent_json, "kiro-user-hooks", wiring)
+        # The only artifact under the redirected $HOME is the agent JSON.
+        artifacts = sorted(
+            p.relative_to(self.home).as_posix()
+            for p in self.home.rglob("*")
+            if p.is_file()
+        )
+        self.assertEqual(artifacts, [".kiro/agents/reviewer.json"])
+
+    def test_dispatchable_command_after_merge(self) -> None:
+        """AC18: the projected hook entry's `command` field must
+        dispatch via `sh -c "$command"` from any working directory.
+        T8b's resolver substitutes `$HOOK_BODY_PATH` with the resolved
+        absolute path; we simulate that here by substituting the
+        placeholder in the wiring before merge, then merging, then
+        reading the merged `command` back and dispatching it. This
+        closes the loop that AC18 demands: the byte path running
+        through is `wiring TOML → merge → merged JSON → sh -c → exit 0`.
+        """
+        from agentbundle.build.projections.merge_into_agent_json import project
+
+        # Create a concrete hook body the substituted command will dispatch.
+        hook_body = self.tmp / "stub.sh"
+        hook_body.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        hook_body.chmod(0o755)
+
+        # Simulate T8b's resolver: substitute the placeholder in the
+        # wiring before passing to project().
+        wiring = _load_wiring_tomls(KIRO_USER_HOOKS)
+        for body in wiring.values():
+            for event_entries in body.get("hooks", {}).values():
+                for entry in event_entries:
+                    if entry.get("command") == "$HOOK_BODY_PATH":
+                        entry["command"] = str(hook_body)
+
+        project(self.agent_json, "kiro-user-hooks", wiring)
+
+        # Read the merged command back from the on-disk agent JSON and
+        # dispatch it. Run from an arbitrary cwd (the tmp root, not the
+        # hook body's directory) to satisfy AC18's "from any working
+        # directory" clause.
+        data = json.loads(self.agent_json.read_text(encoding="utf-8"))
+        command = data["hooks"]["agentSpawn"][0]["command"]
+        self.assertEqual(command, str(hook_body))
+        result = subprocess.run(
+            ["sh", "-c", command],
+            cwd=str(self.tmp),
+            capture_output=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"merged command did not dispatch: stderr={result.stderr.decode()}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/agentbundle/tests/unit/test_merge_into_agent_json.py
+++ b/packages/agentbundle/tests/unit/test_merge_into_agent_json.py
@@ -1,0 +1,350 @@
+"""T6: `merge-into-agent-json` mode — Kiro hook-wiring merger.
+
+Pure-function unit coverage. Integration coverage against the
+`kiro-repo-hooks` and `kiro-user-hooks` fixtures lives in the
+corresponding integration test files.
+
+Mirrors the shape of T5's `test_user_merge_json.py` but adapts for the
+pack-owned target file (no adopter-collision logic, no force_merge,
+missing-agent-file refusal with the `internal:` text).
+
+Covers spec ACs:
+  - AC15 — merge into pack-owned agent JSON writes hooks.<event>
+           arrays with id-tagged entries; other agent JSON keys
+           (name, description, etc.) untouched.
+  - AC19 — uninstall removes wiring-owned entries from the agent JSON;
+           the agent file itself remains.
+  - AC17 (validate-time) — covered by scope_rails tests in
+           `test_kiro_event_vocabulary.py`; this file's vocabulary
+           tests pin the rail-output shape against the projection
+           module.
+
+Plus internal failure modes:
+  - Missing agent file at merge time refuses with the RFC-0005
+    `internal: <agent-file> missing` text (pipeline-ordering invariant
+    violation; reachable only via test instrumentation).
+  - Unparseable agent JSON refuses with the `cannot parse` text.
+  - Wrong-shape `hooks` or `hooks.<event>` refuses.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def _seed_agent_json(target: Path, extra: dict | None = None) -> None:
+    """Pre-create the agent JSON file with body fields T6 must preserve."""
+    body: dict = {"name": "reviewer", "description": "Reviews pending work."}
+    if extra:
+        body.update(extra)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(body, indent=2) + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# AC15 — merge into pack-owned agent JSON, preserve body keys
+# ---------------------------------------------------------------------------
+
+
+class MergeIntoAgentJsonTests(unittest.TestCase):
+    def test_merges_into_existing_agent_json(self) -> None:
+        from agentbundle.build.projections.merge_into_agent_json import project
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "reviewer.json"
+            _seed_agent_json(target)
+            owned = project(
+                target_path=target,
+                pack_name="clipboard-summary",
+                wiring_tomls={
+                    "on-prompt": {
+                        "attach-to-agent": "reviewer",
+                        "hooks": {
+                            "userPromptSubmit": [{"command": "x", "matcher": ""}]
+                        },
+                    }
+                },
+            )
+            data = json.loads(target.read_text(encoding="utf-8"))
+            # Body keys preserved.
+            self.assertEqual(data["name"], "reviewer")
+            self.assertEqual(data["description"], "Reviews pending work.")
+            # Hooks merged.
+            self.assertEqual(data["hooks"]["userPromptSubmit"][0]["id"], "clipboard-summary:on-prompt")
+            self.assertEqual(data["hooks"]["userPromptSubmit"][0]["command"], "x")
+            self.assertEqual(owned, [("userPromptSubmit", "clipboard-summary:on-prompt")])
+
+    def test_reinstall_byte_for_byte(self) -> None:
+        from agentbundle.build.projections.merge_into_agent_json import project
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "reviewer.json"
+            _seed_agent_json(target)
+            wiring = {
+                "on-prompt": {
+                    "attach-to-agent": "reviewer",
+                    "hooks": {"userPromptSubmit": [{"command": "x"}]},
+                }
+            }
+            project(target, "p", wiring)
+            first = target.read_bytes()
+            project(target, "p", wiring)
+            self.assertEqual(target.read_bytes(), first)
+
+    def test_two_packs_overlapping_event_append(self) -> None:
+        from agentbundle.build.projections.merge_into_agent_json import project
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "reviewer.json"
+            _seed_agent_json(target)
+            project(target, "alpha", {"h": {"hooks": {"E": [{"command": "a"}]}}})
+            project(target, "beta", {"h": {"hooks": {"E": [{"command": "b"}]}}})
+            data = json.loads(target.read_text(encoding="utf-8"))
+            ids = [e["id"] for e in data["hooks"]["E"]]
+            self.assertEqual(ids, ["alpha:h", "beta:h"])
+
+    def test_preserves_existing_unrelated_top_level_keys(self) -> None:
+        """A Kiro agent JSON may carry fields beyond name/description.
+        The merger must not touch them — the file is pack-owned, but the
+        owner is the pack as a whole, not just the wiring."""
+        from agentbundle.build.projections.merge_into_agent_json import project
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "reviewer.json"
+            _seed_agent_json(target, extra={"model": "claude-opus-4-7", "tools": ["Read"]})
+            project(target, "p", {"h": {"hooks": {"E": [{"command": "x"}]}}})
+            data = json.loads(target.read_text(encoding="utf-8"))
+            self.assertEqual(data["model"], "claude-opus-4-7")
+            self.assertEqual(data["tools"], ["Read"])
+
+
+# ---------------------------------------------------------------------------
+# AC19 — uninstall removes owned entries; agent file remains
+# ---------------------------------------------------------------------------
+
+
+class UninstallTests(unittest.TestCase):
+    def test_uninstall_removes_owned_entries_only(self) -> None:
+        from agentbundle.build.projections.merge_into_agent_json import (
+            project,
+            unproject,
+        )
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "reviewer.json"
+            _seed_agent_json(target)
+            project(target, "alpha", {"h": {"hooks": {"E": [{"command": "a"}]}}})
+            project(target, "beta", {"h": {"hooks": {"E": [{"command": "b"}]}}})
+            unproject(target, [("E", "alpha:h")])
+            data = json.loads(target.read_text(encoding="utf-8"))
+            ids = [e["id"] for e in data["hooks"]["E"]]
+            self.assertEqual(ids, ["beta:h"])
+
+    def test_uninstall_keeps_agent_file_in_place(self) -> None:
+        """RFC-0005 § Uninstall: the agent file itself stays — the
+        agent primitive's `direct-file` uninstall removes it."""
+        from agentbundle.build.projections.merge_into_agent_json import (
+            project,
+            unproject,
+        )
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "reviewer.json"
+            _seed_agent_json(target)
+            owned = project(target, "p", {"h": {"hooks": {"E": [{"command": "x"}]}}})
+            unproject(target, owned)
+            self.assertTrue(target.exists(), "agent file must survive unproject")
+            data = json.loads(target.read_text(encoding="utf-8"))
+            # Body still there.
+            self.assertEqual(data["name"], "reviewer")
+
+    def test_uninstall_removes_empty_event_array(self) -> None:
+        from agentbundle.build.projections.merge_into_agent_json import (
+            project,
+            unproject,
+        )
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "reviewer.json"
+            _seed_agent_json(target)
+            project(target, "p", {"h": {"hooks": {"E": [{"command": "x"}]}}})
+            unproject(target, [("E", "p:h")])
+            data = json.loads(target.read_text(encoding="utf-8"))
+            self.assertNotIn("E", data.get("hooks", {}))
+
+
+# ---------------------------------------------------------------------------
+# Failure modes
+# ---------------------------------------------------------------------------
+
+
+class FailureModeTests(unittest.TestCase):
+    def test_missing_agent_file_refuses_with_internal_text(self) -> None:
+        """RFC-0005: a missing agent file at merge time is a
+        pipeline-ordering invariant violation. The refusal text names
+        the internal nature so it's diagnosable as a CLI bug, not an
+        adopter mistake."""
+        from agentbundle.build.projections.merge_into_agent_json import (
+            AgentJsonRefusal,
+            project,
+        )
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "missing.json"
+            self.assertFalse(target.exists())
+            with self.assertRaises(AgentJsonRefusal) as ctx:
+                project(target, "p", {"h": {"hooks": {"E": [{"command": "x"}]}}})
+            msg = str(ctx.exception)
+            self.assertIn("internal:", msg)
+            self.assertIn("missing", msg)
+            self.assertIn("agent must project before wiring", msg)
+
+    def test_unparseable_agent_json_refuses(self) -> None:
+        from agentbundle.build.projections.merge_into_agent_json import (
+            AgentJsonRefusal,
+            project,
+        )
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "reviewer.json"
+            target.write_text("{not valid", encoding="utf-8")
+            before = target.read_bytes()
+            with self.assertRaises(AgentJsonRefusal) as ctx:
+                project(target, "p", {"h": {"hooks": {"E": [{"command": "x"}]}}})
+            self.assertIn("cannot parse", str(ctx.exception))
+            # File unchanged.
+            self.assertEqual(target.read_bytes(), before)
+
+    def test_wrong_shape_hooks_refuses(self) -> None:
+        from agentbundle.build.projections.merge_into_agent_json import (
+            AgentJsonRefusal,
+            project,
+        )
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "reviewer.json"
+            target.write_text(json.dumps({"name": "x", "hooks": ["wrong"]}), encoding="utf-8")
+            with self.assertRaises(AgentJsonRefusal) as ctx:
+                project(target, "p", {"h": {"hooks": {"E": [{"command": "x"}]}}})
+            self.assertIn("hooks has unexpected shape", str(ctx.exception))
+
+    def test_wrong_shape_hooks_event_refuses(self) -> None:
+        from agentbundle.build.projections.merge_into_agent_json import (
+            AgentJsonRefusal,
+            project,
+        )
+
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "reviewer.json"
+            target.write_text(
+                json.dumps({"name": "x", "hooks": {"E": "wrong"}}),
+                encoding="utf-8",
+            )
+            with self.assertRaises(AgentJsonRefusal) as ctx:
+                project(target, "p", {"h": {"hooks": {"E": [{"command": "x"}]}}})
+            self.assertIn("hooks.E has unexpected shape", str(ctx.exception))
+
+
+# ---------------------------------------------------------------------------
+# AC17/AC17b — per-adapter event-vocabulary check
+# ---------------------------------------------------------------------------
+
+
+class EventVocabularyRailTests(unittest.TestCase):
+    """The vocabulary gate is rail-side (scope_rails.check_kiro_event_vocabulary);
+    this class drives the rail directly. The CLI wiring is tested in
+    `test_kiro_user_hooks_fixture.py` / `test_fixtures_validate.py`."""
+
+    def test_refuses_pascal_event_against_kiro_vocabulary(self) -> None:
+        from agentbundle.build.scope_rails import check_kiro_event_vocabulary
+
+        refusal = check_kiro_event_vocabulary(
+            pack_name="demo",
+            wiring_tomls={
+                "on-prompt": {"hooks": {"UserPromptSubmit": [{"command": "x"}]}}
+            },
+            vocabulary=["agentSpawn", "userPromptSubmit", "preToolUse"],
+            target_adapters={"kiro"},
+            adapter_name="kiro",
+        )
+        self.assertIsNotNone(refusal)
+        self.assertIn("UserPromptSubmit", refusal)
+        self.assertIn("not in adapter 'kiro' agent-event-vocabulary", refusal)
+
+    def test_accepts_camelcase_event_in_kiro_vocabulary(self) -> None:
+        from agentbundle.build.scope_rails import check_kiro_event_vocabulary
+
+        refusal = check_kiro_event_vocabulary(
+            pack_name="demo",
+            wiring_tomls={
+                "on-prompt": {"hooks": {"userPromptSubmit": [{"command": "x"}]}}
+            },
+            vocabulary=["agentSpawn", "userPromptSubmit", "preToolUse"],
+            target_adapters={"kiro"},
+            adapter_name="kiro",
+        )
+        self.assertIsNone(refusal)
+
+    def test_no_check_when_vocabulary_absent(self) -> None:
+        """AC17b: when the resolved target adapter declares no
+        `agent-event-vocabulary`, the rail must not fire. Claude Code
+        accepts arbitrary event names because its projection declares
+        no vocabulary."""
+        from agentbundle.build.scope_rails import check_kiro_event_vocabulary
+
+        refusal = check_kiro_event_vocabulary(
+            pack_name="demo",
+            wiring_tomls={
+                "on-prompt": {"hooks": {"UserPromptSubmit": [{"command": "x"}]}}
+            },
+            vocabulary=None,  # adapter doesn't declare it
+            target_adapters={"claude-code"},
+            adapter_name="claude-code",
+        )
+        self.assertIsNone(refusal)
+
+    def test_no_check_when_kiro_not_in_targets(self) -> None:
+        """Symmetric to the attach-to-agent rail: if kiro isn't in the
+        target set, the rail is a no-op."""
+        from agentbundle.build.scope_rails import check_kiro_event_vocabulary
+
+        refusal = check_kiro_event_vocabulary(
+            pack_name="demo",
+            wiring_tomls={
+                "on-prompt": {"hooks": {"UserPromptSubmit": [{"command": "x"}]}}
+            },
+            vocabulary=["agentSpawn"],
+            target_adapters={"claude-code"},
+            adapter_name="kiro",
+        )
+        self.assertIsNone(refusal)
+
+    def test_first_offender_wins(self) -> None:
+        """Iteration order: wiring_tomls dict-insertion → each body's
+        hooks dict-insertion. Python 3.7+ pins both; the first
+        out-of-vocabulary event encountered must be the one surfaced.
+        Pin the order strictly so a refactor that accidentally
+        reorders iteration regresses loudly."""
+        from agentbundle.build.scope_rails import check_kiro_event_vocabulary
+
+        refusal = check_kiro_event_vocabulary(
+            pack_name="demo",
+            wiring_tomls={
+                "first": {"hooks": {"GoodEvent": [{"command": "x"}], "BadOne": [{"command": "y"}]}},
+                "second": {"hooks": {"AlsoBad": [{"command": "z"}]}},
+            },
+            vocabulary=["GoodEvent"],
+            target_adapters={"kiro"},
+            adapter_name="kiro",
+        )
+        self.assertIsNotNone(refusal)
+        self.assertIn("BadOne", refusal, f"first offender wasn't BadOne: {refusal}")
+        self.assertNotIn("AlsoBad", refusal, "rail kept walking past first offender")
+        self.assertIn("first.toml", refusal, "refusal didn't name the offending wiring")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Wave 5 of the [user-scope-hooks spec](../tree/main/docs/specs/user-scope-hooks/spec.md) — T6 ships RFC-0005's Kiro hook-wiring merge engine plus the per-adapter event-vocabulary gate. Fifth of thirteen PRs.

- **`merge_into_agent_json.py`** — \`project(...)\` + \`unproject(...)\` + \`AgentJsonRefusal\`. Mirrors T5's \`user_merge_json\` discipline with the pack-owned-file differences: no adopter-collision, no \`force_merge\`, missing-agent-file refuses with the RFC-0005 internal-error text, atomic write via tmp + rename + parent-directory fsync.
- **Vocabulary rail** — \`check_kiro_event_vocabulary\` in \`scope_rails.py\`. Fires when the resolved target adapter declares an \`agent-event-vocabulary\` (Kiro does in v0.3; Claude Code does not). RFC-0005 verbatim refusal text.
- **CLI wiring** — \`commands/validate.py\` step 4d loads the vocabulary from \`adapter.toml\` via the existing contract loader and dispatches. T3's \`pending-T6\` marker test in \`test_fixtures_validate.py\` is flipped — the pascal-events fixture now refuses.
- **Tests added (21):** 16 unit + 5 integration covering AC15, AC17, AC17b, AC18, AC19 plus failure modes.

## Acceptance criteria

- [x] **AC15** — pack-owned agent JSON merge with body keys preserved (\`name\`, \`description\`, custom fields).
- [x] **AC17** — Kiro-targeted wiring with PascalCase events (outside vocabulary) refuses with RFC-0005 verbatim text.
- [x] **AC17b** — Claude Code (no vocabulary declared) accepts arbitrary event names. Per-adapter, not per-RFC.
- [x] **AC18** — user-scope projection writes to \`\$HOME/.kiro/agents/<agent>.json\` and the merged \`command\` dispatches via \`sh -c\` from any working directory.
- [x] **AC19** — uninstall removes owned entries from the agent JSON; agent file itself remains (\`direct-file\` uninstall removes it later).

## Known design gap (RFC-0005 carryover)

The existing Kiro adapter projects agents as \`.kiro/agents/<name>.md\` (markdown with frontmatter); RFC-0005's \`merge-into-agent-json\` targets \`.kiro/agents/<name>.json\` (JSON). T6 ships the merge engine; the spec gap will be resolved by either a follow-on RFC or by augmenting the Kiro agent projection in T7/T8b. T6's tests pre-seed the JSON to simulate what the pipeline ordering would produce. Flagged in the spec amendment (T10) and acknowledged in the PR diff.

## Adversarial review

Two rounds. Round 1: 2 Concerns + 3 Nits. Round 2: **Clean — ready to commit.** All Concerns + cheap Nits addressed in-PR:

- AC18 test rewritten to actually dispatch the merged command (was asserting placeholder text, not dispatchability).
- First-offender vocabulary test pinned deterministically (was accepting either BadOne or AlsoBad).
- Dev-only fallback path in \`_kiro_event_vocabulary\` guarded with a comment + miss-returns-None safety.
- Refusal-text intent annotated (extends RFC-0005's bare \`internal:\` shape with diagnostic context; tests check substrings).

## Gates

- 495 tests pass, 1 skipped (was 474 pre-wave-5; +21 new tests).
- \`make build-check\` exits 0.
- \`make validate\` exits 0.

## Out of scope (later waves)

- **T7** — build-pipeline phase-order enforcement in code. The invariant is now documented + asserted by T6's missing-agent-file refusal; T7 wires the pipeline iterator.
- **T8b** — install/uninstall CLI threading: writes \`hook-wiring-owned\` state rows; \`--force-merge\` flag binding.
- **T8c** — upgrade reconciliation including \`attach-to-agent\` rename.
- **T9** — \`reconcile --scope user\` reporter.
- **T11** — \`agent-spec-cli\` spec amendment.

After this lands, **wave 6 is T7** (deps: T5, T6 — both will be in main). After T7 lands, **wave 7 is T8b** (deps: T5, T6, T7, T8a — all in main after T7). T8c/T9/T11 follow.