### PR TITLE
feat(wave6): pipeline phase order + Kiro agent .md → .json reform (T7)

### DIFF
--- a/docs/rfc/0005-user-scope-hook-support.md
+++ b/docs/rfc/0005-user-scope-hook-support.md
@@ -963,21 +963,43 @@ either example.
   risk doesn't get lost.
 
 - **Kiro's hook-entry schema is observed-but-not-publicly-documented.**
-  The Kiro user-scope agent directory is documented at
-  [`kiro.dev/docs/cli/custom-agents/creating/`](https://kiro.dev/docs/cli/custom-agents/creating/),
-  but that page does *not* document a `hooks` field — the events
-  (`agentSpawn`, `userPromptSubmit`, `preToolUse`, `postToolUse`,
-  `stop`) and entry shape (`command`, `matcher`, `timeout_ms`,
-  `max_output_size`, `cache_ttl_seconds`) are known from in-IDE
-  observation. The Kiro runtime accepts the field today but the
-  schema is not under contract. If Kiro renames the key, restructures
-  the entries, or starts validating against a documented schema
-  that rejects the synthetic `id` tag, the projection regresses
-  silently. Same risk class as the Claude Code `id`-as-tag
-  drawback, just for a different field. Mitigation: pin the
-  Kiro mode to a single-source-of-truth in the spec amendment and
-  re-verify against Kiro's published docs at each contract version
-  bump.
+  *(Partially closed — `hooks`/events. Residual risk on optional
+  hook-entry fields and on full agent-field coverage; see T7 research,
+  2026-05-24.)*
+  When this RFC was drafted, the
+  [`kiro.dev/docs/cli/custom-agents/creating/`](https://kiro.dev/docs/cli/custom-agents/creating/)
+  page documented agent files but not the `hooks` field; events and
+  entry shape were known from in-IDE observation only.
+  [`kiro.dev/docs/cli/custom-agents/configuration-reference/`](https://kiro.dev/docs/cli/custom-agents/configuration-reference/)
+  now publishes the `hooks` field schema with the same five events
+  this RFC names (`agentSpawn`, `userPromptSubmit`, `preToolUse`,
+  `postToolUse`, `stop`) and confirms `command` (required) + `matcher`
+  (optional) as the hook-entry fields. Three classes of residual risk
+  remain:
+
+  1. **Optional hook-entry fields** (`timeout_ms`, `max_output_size`,
+     `cache_ttl_seconds`) the original drawback named are accepted by
+     the Kiro runtime but remain absent from the public reference.
+     The merger preserves any incoming entry fields verbatim, so
+     packs declaring them round-trip cleanly today.
+  2. **Agent-field coverage on the v0.3 reform.** T7's
+     `_project_agent_as_json` emits `name`, `prompt`, plus whatever
+     the `kiro-agent-frontmatter-v0.9` mapping table renames
+     through (`description`, `tools`, `model`). Other Kiro agent
+     fields documented in the reference (`allowedTools`,
+     `resources`, additional inheritance keys) are silently dropped
+     when a pack author declares them in markdown frontmatter — the
+     mapping table doesn't know about them. Pack authors who need
+     these fields can extend the mapping table; a follow-on RFC
+     would widen the default coverage to all reference fields.
+  3. **The `id` ownership-tag assumption** stays the same shape as
+     before — Unresolved Q1.
+
+  The same Kiro-docs research surfaced that agents are `.json` files
+  (not `.md` with frontmatter as the v0.2 contract claimed) — T7
+  reforms the agent projection to emit JSON; spec
+  [`distribution-adapters/spec.md`](../specs/distribution-adapters/spec.md)
+  line 178 is updated.
 
 - **Build-pipeline ordering becomes a new invariant the pipeline
   has to enforce.** Today the pipeline (per RFC-0002) projects

--- a/docs/specs/distribution-adapters/spec.md
+++ b/docs/specs/distribution-adapters/spec.md
@@ -196,10 +196,19 @@ declares it so explicitly — no implicit defaults.
 | Primitive | Source path (in `packs/<pack>/`) | Claude Code | Kiro | Copilot | Codex |
 | --- | --- | --- | --- | --- | --- |
 | `skill` | `.apm/skills/<name>/` | `direct-directory` → `.claude/skills/<name>/` | `direct-directory` → `.kiro/skills/<name>/` | `instruction-file` → `.github/instructions/<name>.instructions.md` | `managed-block-inline` → `AGENTS.md` |
-| `agent` | `.apm/agents/<name>.md` | `direct-file` → `.claude/agents/<name>.md` | `direct-file` (with `kiro-agent-frontmatter-v0.9` rewrite) → `.kiro/agents/<name>.md` | `dropped` | `dropped` |
+| `agent` | `.apm/agents/<name>.md` | `direct-file` → `.claude/agents/<name>.md` | `direct-file`\* (with `kiro-agent-frontmatter-v0.9` rewrite) → `.kiro/agents/<name>.json` | `dropped` | `dropped` |
 | `hook-body` | `.apm/hooks/<name>.{sh,py}` | `direct-file` — repo: `tools/hooks/<name>.{sh,py}`; user: `.claude/hooks/<pack>/<name>.{sh,py}` | `direct-file` — repo: `tools/hooks/<name>.{sh,py}`; user: `.kiro/hooks/<pack>/<name>.{sh,py}` | `direct-file` → `tools/hooks/<name>.{sh,py}` | `direct-file` → `tools/hooks/<name>.{sh,py}` |
 | `hook-wiring` | `.apm/hook-wiring/<name>.toml` | repo: `merge-json` (under `hooks` key of `.claude/settings.local.json`); user: `user-merge-json` (under `hooks` key of `.claude/settings.json`) | `merge-into-agent-json` (RFC-0005 — under `hooks` key of `.kiro/agents/<attach-to-agent>.json`) | `dropped` | `dropped` |
 | `command` | `.apm/commands/<name>.md` | `direct-file` → `.claude/commands/<name>.md` | `dropped` | `dropped` | `dropped` |
+
+\* The Kiro `agent` row's `mode = "direct-file"` is retained for v0.3
+contract continuity; the implementation is semantically a
+*markdown-frontmatter → JSON-field rewrite*, not a byte-for-byte copy.
+RFC-0005 / T7 introduced the JSON emission once Kiro published the
+[custom-agents configuration reference](https://kiro.dev/docs/cli/custom-agents/configuration-reference/)
+confirming agents are JSON. A future contract bump could rename the
+mode (e.g. `agent-md-to-json`); the rename is deferred behind landing
+the implementation.
 
 **Hook extensions.** A hook is a script; the runtime is determined by the
 file extension. The build pipeline projects `hook-body` byte-for-byte —

--- a/packages/agentbundle/agentbundle/build/adapters/claude_code.py
+++ b/packages/agentbundle/agentbundle/build/adapters/claude_code.py
@@ -18,18 +18,33 @@ import json
 import shutil
 import tomllib
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
+
+
+# Phase order from RFC-0005 § Build-pipeline ordering invariant.
+# Uniform across all reference adapters even though Claude Code's
+# wiring lands in a settings file (not in agents) — the uniformity
+# keeps the phases predictable, which the spec calls for.
+from agentbundle.build.phase_order import PHASE_ORDER as _PHASE_ORDER
+
+
+def _iter_primitives(contract: dict) -> Iterator[str]:
+    """Yield Claude Code's projected primitive names in phase order."""
+    adapter_block = contract["adapter"]["claude-code"]
+    array_form = {entry["primitive"]: entry for entry in adapter_block.get("projection", [])}
+    for primitive_name in _PHASE_ORDER:
+        if primitive_name in array_form and array_form[primitive_name].get("mode") != "dropped":
+            yield primitive_name
 
 
 def project(pack_path: Path, contract: dict, output_root: Path) -> None:
     """Project a single pack into `output_root` per the Claude Code adapter rules."""
-    rules = contract["adapter"]["claude-code"]["projection"]
-    rules_by_primitive = {rule["primitive"]: rule for rule in rules}
+    adapter_block = contract["adapter"]["claude-code"]
+    rules_by_primitive = {entry["primitive"]: entry for entry in adapter_block.get("projection", [])}
 
-    for primitive_name, rule in rules_by_primitive.items():
+    for primitive_name in _iter_primitives(contract):
+        rule = rules_by_primitive[primitive_name]
         mode = rule["mode"]
-        if mode == "dropped":
-            continue
         primitive = contract["primitive"][primitive_name]
         source_dir = pack_path / primitive["source-path"].rstrip("/")
         if not source_dir.exists():

--- a/packages/agentbundle/agentbundle/build/adapters/codex.py
+++ b/packages/agentbundle/agentbundle/build/adapters/codex.py
@@ -10,7 +10,20 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
+
+
+# RFC-0005 § Build-pipeline ordering invariant — uniform across adapters.
+from agentbundle.build.phase_order import PHASE_ORDER as _PHASE_ORDER
+
+
+def _iter_primitives(contract: dict) -> Iterator[str]:
+    """Yield Codex's projected primitive names in phase order."""
+    adapter_block = contract["adapter"]["codex"]
+    array_form = {entry["primitive"]: entry for entry in adapter_block.get("projection", [])}
+    for primitive_name in _PHASE_ORDER:
+        if primitive_name in array_form and array_form[primitive_name].get("mode") != "dropped":
+            yield primitive_name
 
 
 def project(pack_path: Path, contract: dict, output_root: Path) -> None:
@@ -18,13 +31,12 @@ def project(pack_path: Path, contract: dict, output_root: Path) -> None:
 
 
 def project_packs(pack_paths: list[Path], contract: dict, output_root: Path) -> None:
-    rules = contract["adapter"]["codex"]["projection"]
-    rules_by_primitive = {rule["primitive"]: rule for rule in rules}
+    adapter_block = contract["adapter"]["codex"]
+    rules_by_primitive = {entry["primitive"]: entry for entry in adapter_block.get("projection", [])}
 
-    for primitive_name, rule in rules_by_primitive.items():
+    for primitive_name in _iter_primitives(contract):
+        rule = rules_by_primitive[primitive_name]
         mode = rule["mode"]
-        if mode == "dropped":
-            continue
         primitive = contract["primitive"][primitive_name]
         source_dirs = [
             pack_path / primitive["source-path"].rstrip("/")

--- a/packages/agentbundle/agentbundle/build/adapters/copilot.py
+++ b/packages/agentbundle/agentbundle/build/adapters/copilot.py
@@ -10,17 +10,29 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
+
+
+# RFC-0005 § Build-pipeline ordering invariant — uniform across adapters.
+from agentbundle.build.phase_order import PHASE_ORDER as _PHASE_ORDER
+
+
+def _iter_primitives(contract: dict) -> Iterator[str]:
+    """Yield Copilot's projected primitive names in phase order."""
+    adapter_block = contract["adapter"]["copilot"]
+    array_form = {entry["primitive"]: entry for entry in adapter_block.get("projection", [])}
+    for primitive_name in _PHASE_ORDER:
+        if primitive_name in array_form and array_form[primitive_name].get("mode") != "dropped":
+            yield primitive_name
 
 
 def project(pack_path: Path, contract: dict, output_root: Path) -> None:
-    rules = contract["adapter"]["copilot"]["projection"]
-    rules_by_primitive = {rule["primitive"]: rule for rule in rules}
+    adapter_block = contract["adapter"]["copilot"]
+    rules_by_primitive = {entry["primitive"]: entry for entry in adapter_block.get("projection", [])}
 
-    for primitive_name, rule in rules_by_primitive.items():
+    for primitive_name in _iter_primitives(contract):
+        rule = rules_by_primitive[primitive_name]
         mode = rule["mode"]
-        if mode == "dropped":
-            continue
         primitive = contract["primitive"][primitive_name]
         source_dir = pack_path / primitive["source-path"].rstrip("/")
         if not source_dir.exists():

--- a/packages/agentbundle/agentbundle/build/adapters/kiro.py
+++ b/packages/agentbundle/agentbundle/build/adapters/kiro.py
@@ -1,44 +1,291 @@
-"""Kiro adapter — projects skills, agents (with frontmatter mapping),
-hook bodies, degrades hook wiring (RFC-0001 Q1), drops commands.
+"""Kiro adapter — projects primitives in the v0.3 phase order.
 
-Frontmatter rewrite rules for `agent` primitives come from the contract's
-`frontmatter-mapping["kiro-agent-frontmatter-v0.9"]` table — never
-hardcoded here. Stdlib only: a minimal YAML-frontmatter parser handles
-the leading `---` block of each agent file.
+Per RFC-0005 § Build-pipeline ordering invariant, primitives project in
+the fixed order **`hook-body` → `agent` → `hook-wiring` → `command` →
+`skill`** within each pack. The order matters because Kiro's
+`merge-into-agent-json` projection reads the agent JSON the agent
+primitive's projection wrote — agents must land first.
+
+Agents project as `.kiro/agents/<name>.json` per Kiro's documented
+schema (https://kiro.dev/docs/cli/custom-agents/configuration-reference/),
+**not** as `.md` with frontmatter. The pack-side source format stays
+`.apm/agents/<name>.md` with frontmatter; this adapter parses the
+markdown body + frontmatter and emits JSON with the documented Kiro
+fields (`name`, `description`, `tools`, `model`, `prompt`). The
+`kiro-agent-frontmatter-v0.9` mapping table is reinterpreted as
+*frontmatter-key → JSON-field* rather than *frontmatter → frontmatter*.
+
+Hook-wiring projection delegates to
+`agentbundle.build.projections.merge_into_agent_json` per RFC-0005.
 """
 
 from __future__ import annotations
 
+import json
 import shutil
-import sys
+import tomllib
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
+
+from agentbundle.build.projections.merge_into_agent_json import (
+    project as merge_into_agent_json_project,
+)
+
+
+# Phase order from RFC-0005 § Build-pipeline ordering invariant.
+# `agent` precedes `hook-wiring` so `merge-into-agent-json` finds the
+# agent JSON in place. `command` and `skill` land last; their position
+# relative to wiring is free (neither reads the agent JSON during
+# projection), so the predictable trailing position keeps the phases
+# uniform across adapters.
+from agentbundle.build.phase_order import PHASE_ORDER as _PHASE_ORDER
+
+
+def _iter_primitives(contract: dict) -> Iterator[str]:
+    """Yield Kiro's projected primitive names in phase order.
+
+    Walks both the legacy `[[adapter.kiro.projection]]` array (v0.2
+    primitives that didn't migrate to the new shape) and the v0.3
+    `[adapter.kiro.projections.<primitive>]` table form (hook-body and
+    hook-wiring per RFC-0005). Skipped: primitives whose mode is
+    `dropped` — they have no projection work.
+
+    Returns an iterator in PHASE_ORDER so callers (project,
+    test_pipeline_phase_order) get a deterministic sequence.
+    """
+    adapter_block = contract["adapter"]["kiro"]
+    array_form = {entry["primitive"]: entry for entry in adapter_block.get("projection", [])}
+    table_form = adapter_block.get("projections", {}) if isinstance(adapter_block.get("projections"), dict) else {}
+
+    for primitive_name in _PHASE_ORDER:
+        if primitive_name in array_form:
+            mode = array_form[primitive_name].get("mode")
+            if mode == "dropped":
+                continue
+            yield primitive_name
+        elif primitive_name in table_form:
+            yield primitive_name
 
 
 def project(pack_path: Path, contract: dict, output_root: Path) -> None:
-    rules = contract["adapter"]["kiro"]["projection"]
-    rules_by_primitive = {rule["primitive"]: rule for rule in rules}
+    """Project *pack_path* into *output_root* per Kiro's contract rules.
 
-    for primitive_name, rule in rules_by_primitive.items():
-        mode = rule["mode"]
-        if mode == "dropped":
-            continue
+    Iteration is phase-ordered (see `_iter_primitives`). For each
+    primitive in the contract, dispatch on mode:
+
+      - `direct-directory` → recursive copy
+      - `direct-file` (agent) → markdown frontmatter + body → JSON
+      - `direct-file` (other) → byte-for-byte file copy
+      - `merge-into-agent-json` → delegate to the v0.3 projection module
+      - `dropped` → no-op (filtered at iter time)
+    """
+    adapter_block = contract["adapter"]["kiro"]
+    array_form = {entry["primitive"]: entry for entry in adapter_block.get("projection", [])}
+    table_form = adapter_block.get("projections", {}) if isinstance(adapter_block.get("projections"), dict) else {}
+
+    for primitive_name in _iter_primitives(contract):
         primitive = contract["primitive"][primitive_name]
         source_dir = pack_path / primitive["source-path"].rstrip("/")
         if not source_dir.exists():
             continue
 
-        if mode == "direct-directory":
-            _project_direct_directory(source_dir, output_root / rule["target-path"].rstrip("/"))
-        elif mode == "direct-file":
-            if primitive_name == "agent":
-                _project_agent_with_frontmatter(source_dir, output_root, rule, contract)
-            else:
-                _project_direct_file(source_dir, output_root, rule["target-path"])
-        elif mode == "degraded-info-log":
-            _emit_info_log(primitive_name, source_dir)
+        if primitive_name in array_form:
+            rule = array_form[primitive_name]
+            _dispatch_array_form(primitive_name, source_dir, output_root, rule, contract)
         else:
-            raise ValueError(f"kiro: unhandled mode {mode!r} for {primitive_name}")
+            rule = table_form[primitive_name]
+            _dispatch_table_form(primitive_name, source_dir, output_root, rule, pack_path)
+
+
+def _dispatch_array_form(
+    primitive_name: str,
+    source_dir: Path,
+    output_root: Path,
+    rule: dict,
+    contract: dict,
+) -> None:
+    mode = rule["mode"]
+    if mode == "direct-directory":
+        _project_direct_directory(source_dir, output_root / rule["target-path"].rstrip("/"))
+    elif mode == "direct-file":
+        if primitive_name == "agent":
+            _project_agent_as_json(source_dir, output_root, rule, contract)
+        else:
+            _project_direct_file(source_dir, output_root, rule["target-path"])
+    else:
+        raise ValueError(f"kiro: unhandled array-form mode {mode!r} for {primitive_name}")
+
+
+def _dispatch_table_form(
+    primitive_name: str,
+    source_dir: Path,
+    output_root: Path,
+    rule: dict,
+    pack_path: Path,
+) -> None:
+    mode = rule.get("mode")
+    # `mode` may be a string or a scope-map per RFC-0005; at build time
+    # we project the repo-scope shape (the user-scope path is resolved
+    # at install time by T8b). For string-or-scope-map fields, prefer
+    # the repo branch.
+    effective_mode = mode["repo"] if isinstance(mode, dict) else mode
+
+    if primitive_name == "hook-wiring" and effective_mode == "merge-into-agent-json":
+        _project_hook_wiring_to_agent_json(source_dir, output_root, rule, pack_path)
+    elif primitive_name == "hook-body" and effective_mode == "direct-file":
+        # Resolve the scope-conditional target. The build pipeline
+        # writes the repo-scope shape; user-scope projection is T8b's
+        # install-time concern.
+        target = rule.get("target")
+        if isinstance(target, dict):
+            target_template = target.get("repo")
+        else:
+            target_template = target
+        if target_template:
+            _project_direct_file_template(source_dir, output_root, target_template)
+    else:
+        # Other table-form modes (or scope-only declarations the legacy
+        # array still owns) — silent skip.
+        return
+
+
+# ---------------------------------------------------------------------------
+# Agent .md → .json reform
+# ---------------------------------------------------------------------------
+
+
+def _project_agent_as_json(
+    source_dir: Path,
+    output_root: Path,
+    rule: dict,
+    contract: dict,
+) -> None:
+    """Read `.apm/agents/<name>.md` and emit `<output>/.kiro/agents/<name>.json`.
+
+    Source layout: `.apm/agents/<name>.md` with YAML-style frontmatter
+    (`---` fence) + markdown body. Output layout: JSON object with
+    Kiro's documented fields per
+    https://kiro.dev/docs/cli/custom-agents/configuration-reference/:
+
+      - `name`: derived from the source filename (without `.md`),
+        or overridden by a `name` frontmatter field if present.
+      - `description`: frontmatter `description` (renamed per the
+        contract's `kiro-agent-frontmatter-v0.9` mapping).
+      - `tools`: frontmatter `tools` normalized to a list.
+      - `model`: frontmatter `model`, if declared.
+      - `prompt`: the markdown body after the closing `---` fence.
+
+    The mapping table on the contract retains its `rename` / `normalize`
+    grammar; what changes from v0.2 is the *emission* — JSON instead
+    of frontmatter-with-body markdown — which closes the spec/Kiro-docs
+    drift RFC-0005's "observed-but-not-publicly-documented" drawback
+    flagged.
+    """
+    target_dir = output_root / rule["target-path"].rstrip("/")
+    target_dir.mkdir(parents=True, exist_ok=True)
+    mapping_name = rule.get("frontmatter-mapping")
+    mapping = (
+        contract.get("frontmatter-mapping", {}).get(mapping_name, {})
+        if mapping_name
+        else {}
+    )
+    for entry in sorted(source_dir.iterdir()):
+        if not (entry.is_file() and entry.suffix == ".md"):
+            continue
+        frontmatter, body = _split_frontmatter(entry.read_text(encoding="utf-8"))
+        rewritten = _apply_mapping(frontmatter, mapping)
+        agent_name = rewritten.get("name") or entry.stem
+        agent_json: dict[str, Any] = {"name": agent_name}
+        # Preserve any rewritten fields that aren't `name` (already
+        # placed above). Iterate sorted for deterministic output.
+        # An explicit `prompt` in frontmatter wins over the
+        # body-derived prompt — pack authors writing Kiro JSON
+        # directly may put the prompt there per the published
+        # reference, and silently overwriting their value would be
+        # data loss.
+        for key in sorted(rewritten.keys()):
+            if key == "name":
+                continue
+            agent_json[key] = rewritten[key]
+        if "prompt" not in agent_json:
+            # Body fallback: the markdown body becomes the agent's
+            # prompt when frontmatter doesn't declare one.
+            prompt = body.rstrip("\n")
+            if prompt:
+                agent_json["prompt"] = prompt
+        destination = target_dir / (entry.stem + ".json")
+        destination.write_text(
+            json.dumps(agent_json, indent=2, sort_keys=False) + "\n",
+            encoding="utf-8",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Hook-wiring → agent JSON merge
+# ---------------------------------------------------------------------------
+
+
+def _project_hook_wiring_to_agent_json(
+    source_dir: Path,
+    output_root: Path,
+    rule: dict,
+    pack_path: Path,
+) -> None:
+    """For each `.apm/hook-wiring/<name>.toml`, merge into the resolved
+    agent JSON at `<output>/.kiro/agents/<attach-to-agent>.json`.
+
+    The agent JSON is **guaranteed to exist** at this point — the
+    phase-order invariant ensures agent projection ran first
+    (`_iter_primitives` yields `agent` before `hook-wiring`). If the
+    wiring TOML's `attach-to-agent` names an agent the pack didn't
+    ship, the merge module refuses with the RFC-0005 `internal:` text.
+
+    Pack-side validation already refused malformed wiring TOMLs at
+    `validate` time (T2's `check_kiro_wiring`), so by the time we
+    reach this code path, every wiring TOML has a same-pack agent
+    target. Build-time defense-in-depth: re-check `attach-to-agent`
+    against shipped agents and skip silently if the field is missing.
+    """
+    pack_name = pack_path.name
+
+    target_template = rule.get("target")
+    if isinstance(target_template, dict):
+        target_template = target_template.get("repo")
+    if not target_template:
+        return
+
+    # Group wiring TOMLs by their `attach-to-agent` so we can call
+    # merge-into-agent-json once per agent. The merge module takes a
+    # batch of `wiring_tomls` for one target file.
+    wiring_by_agent: dict[str, dict[str, dict]] = {}
+    for entry in sorted(source_dir.iterdir()):
+        if not (entry.is_file() and entry.suffix == ".toml"):
+            continue
+        try:
+            body = tomllib.loads(entry.read_text(encoding="utf-8"))
+        except tomllib.TOMLDecodeError:
+            continue
+        attach = body.get("attach-to-agent") if isinstance(body, dict) else None
+        if not isinstance(attach, str):
+            continue
+        wiring_by_agent.setdefault(attach, {})[entry.stem] = body
+
+    for attach_to_agent, wiring_tomls in wiring_by_agent.items():
+        resolved = target_template.replace("<attach-to-agent>", attach_to_agent)
+        target_path = output_root / resolved.lstrip("/")
+        # Let AgentJsonRefusal propagate. RFC-0005 names the reachable
+        # cases — missing agent (pipeline-ordering invariant violation),
+        # unparseable JSON, wrong-shape `hooks` — all of which are bugs
+        # at build time, not adopter-fixable conditions. Silently
+        # swallowing them would let `make build` produce
+        # silently-incomplete artifacts; the existing pipeline shape
+        # is fail-fast, and that's the right shape here too.
+        merge_into_agent_json_project(target_path, pack_name, wiring_tomls)
+
+
+# ---------------------------------------------------------------------------
+# Existing helpers (preserved from v0.2 with small adjustments)
+# ---------------------------------------------------------------------------
 
 
 def _project_direct_directory(source_dir: Path, target_dir: Path) -> None:
@@ -59,40 +306,34 @@ def _project_direct_file(source_dir: Path, output_root: Path, target_prefix: str
             shutil.copy2(entry, destination, follow_symlinks=False)
 
 
-def _project_agent_with_frontmatter(
+def _project_direct_file_template(
     source_dir: Path,
     output_root: Path,
-    rule: dict,
-    contract: dict,
+    target_template: str,
 ) -> None:
-    target_dir = output_root / rule["target-path"].rstrip("/")
-    target_dir.mkdir(parents=True, exist_ok=True)
-    mapping_name = rule.get("frontmatter-mapping")
-    mapping = (
-        contract.get("frontmatter-mapping", {}).get(mapping_name, {})
-        if mapping_name
-        else {}
-    )
-    for entry in sorted(source_dir.iterdir()):
-        if entry.is_file() and entry.suffix == ".md":
-            frontmatter, body = _split_frontmatter(entry.read_text(encoding="utf-8"))
-            rewritten = _apply_mapping(frontmatter, mapping)
-            destination = target_dir / entry.name
-            destination.write_text(
-                _emit_frontmatter(rewritten) + body,
-                encoding="utf-8",
-            )
+    """Project each file under *source_dir* to a path derived from
+    *target_template* by substituting `<name>` with the filename's
+    basename.
 
-
-def _emit_info_log(primitive_name: str, source_dir: Path) -> None:
+    The v0.3 contract introduces `target = "tools/hooks/<name>.{sh,py}"`-
+    style templates that preserve the source extension. The braces are
+    illustrative; the actual output uses the source file's actual
+    extension (`.sh` or `.py`)."""
     for entry in sorted(source_dir.iterdir()):
-        if entry.is_file():
-            stem = entry.stem
-            print(
-                f"[info] kiro: {primitive_name} {stem} not projected — "
-                "kiro hook schema unresolved (RFC-0001 Q1)",
-                file=sys.stderr,
-            )
+        if not entry.is_file():
+            continue
+        # Replace `<name>.{sh,py}` (or any `.{...}` choice block) with
+        # the actual filename. The simplest substitution: replace the
+        # whole `<name>.{...}` template with `<actual filename>`.
+        resolved = target_template
+        if "<name>" in resolved:
+            # Strip everything from `<name>` onward and re-append the
+            # source filename — the source's actual extension wins.
+            prefix, _, _suffix = resolved.partition("<name>")
+            resolved = prefix + entry.name
+        target_path = output_root / resolved.lstrip("/")
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(entry, target_path, follow_symlinks=False)
 
 
 def _split_frontmatter(text: str) -> tuple[dict, str]:
@@ -134,6 +375,11 @@ def _parse_frontmatter(lines: list[str]) -> dict[str, Any]:
 
 
 def _apply_mapping(frontmatter: dict[str, Any], mapping: dict) -> dict[str, Any]:
+    """Apply the contract's `kiro-agent-frontmatter-v0.9` rename /
+    normalize / default rules. The rules are now interpreted as
+    *markdown-frontmatter → JSON-field* rather than the v0.2
+    interpretation of *frontmatter → frontmatter*; the mapping table
+    grammar is unchanged."""
     rewritten: dict[str, Any] = {}
     for source_key, value in frontmatter.items():
         rule = mapping.get(source_key, {})
@@ -148,18 +394,3 @@ def _apply_mapping(frontmatter: dict[str, Any], mapping: dict) -> dict[str, Any]
         if new_key not in rewritten and default_value is not None:
             rewritten[new_key] = default_value
     return rewritten
-
-
-def _emit_frontmatter(frontmatter: dict[str, Any]) -> str:
-    if not frontmatter:
-        return ""
-    lines = ["---"]
-    for key in sorted(frontmatter.keys()):
-        value = frontmatter[key]
-        if isinstance(value, list):
-            rendered = "[" + ", ".join(value) + "]"
-            lines.append(f"{key}: {rendered}")
-        else:
-            lines.append(f"{key}: {value}")
-    lines.append("---\n")
-    return "\n".join(lines)

--- a/packages/agentbundle/agentbundle/build/phase_order.py
+++ b/packages/agentbundle/agentbundle/build/phase_order.py
@@ -1,0 +1,23 @@
+"""Build-pipeline phase order (RFC-0005 § Build-pipeline ordering invariant).
+
+Single source of truth for the order primitives project within each
+pack: ``hook-body`` → ``agent`` → ``hook-wiring`` → ``command`` →
+``skill``. The order matters because Kiro's ``merge-into-agent-json``
+projection reads the agent JSON the agent projection wrote, so agents
+must land first.
+
+Each reference adapter (``claude_code``, ``kiro``, ``copilot``,
+``codex``) imports ``PHASE_ORDER`` from this module so a future
+contract revision changes one line, not four.
+"""
+
+from __future__ import annotations
+
+
+PHASE_ORDER: tuple[str, ...] = (
+    "hook-body",
+    "agent",
+    "hook-wiring",
+    "command",
+    "skill",
+)

--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro.py
@@ -57,15 +57,34 @@ class KiroAdapterTests(unittest.TestCase):
             project(pack, self.contract, out)
             self.assertTrue((out / ".kiro" / "skills" / "foo" / "SKILL.md").exists())
 
-    def test_agent_frontmatter_normalized_via_mapping(self) -> None:
+    def test_agent_projects_as_json_per_kiro_schema(self) -> None:
+        """RFC-0005 / T7: Kiro agents are JSON files per the documented
+        Kiro schema (https://kiro.dev/docs/cli/custom-agents/configuration-reference/),
+        not markdown-with-frontmatter as v0.2 used to project. The
+        `kiro-agent-frontmatter-v0.9` mapping table is reinterpreted as
+        *markdown-frontmatter → JSON-field* — the rename / to-list
+        normalize semantics carry over to JSON emission."""
+        import json
+
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             pack = _seed_pack(tmp_path)
             out = tmp_path / "out"
             project(pack, self.contract, out)
-            agent_text = (out / ".kiro" / "agents" / "bar.md").read_text(encoding="utf-8")
-            # `tools: Read` source should normalize to a list.
-            self.assertIn("[Read]", agent_text)
+            # File is .json, not .md.
+            agent_json_path = out / ".kiro" / "agents" / "bar.json"
+            self.assertTrue(agent_json_path.exists(), "agent projected as .md instead of .json")
+            self.assertFalse(
+                (out / ".kiro" / "agents" / "bar.md").exists(),
+                "stale .md projection left behind",
+            )
+            data = json.loads(agent_json_path.read_text(encoding="utf-8"))
+            # `tools: Read` source normalises to a list per the mapping
+            # table's `normalize: to-list` rule.
+            self.assertEqual(data["tools"], ["Read"])
+            # `name` from filename (or frontmatter); body becomes prompt.
+            self.assertEqual(data["name"], "bar")
+            self.assertEqual(data.get("prompt", "").strip(), "agent body")
 
     def test_hook_wiring_array_entry_removed(self) -> None:
         """AC2: the legacy `degraded-info-log` kiro hook-wiring entry is gone."""

--- a/packages/agentbundle/agentbundle/build/tests/test_contract_scope.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_contract_scope.py
@@ -33,11 +33,11 @@ def _load_contract() -> dict:
 
 
 class ContractVersionTests(unittest.TestCase):
-    """Contract version bumps to 0.2 with this RFC."""
+    """Contract version: bumped to 0.2 by RFC-0004, then to 0.3 by RFC-0005."""
 
-    def test_contract_version_is_0_2(self) -> None:
+    def test_contract_version_is_0_3(self) -> None:
         contract = _load_contract()
-        self.assertEqual(contract["contract"]["version"], "0.2")
+        self.assertEqual(contract["contract"]["version"], "0.3")
 
 
 class ClaudeCodeScopeBlockTests(unittest.TestCase):
@@ -66,13 +66,22 @@ class ClaudeCodeScopeBlockTests(unittest.TestCase):
 
 
 class OtherAdaptersOmitScopeTests(unittest.TestCase):
-    """Adapters omitting [scope] are accepted as repo-only."""
+    """Adapters omitting [scope] are accepted as repo-only. v0.3 (RFC-0005)
+    adds a `[scope]` table to Kiro alongside Claude Code's existing one;
+    only Copilot and Codex remain scope-less."""
 
-    def test_kiro_copilot_codex_omit_scope(self) -> None:
+    def test_copilot_codex_omit_scope(self) -> None:
         contract = _load_contract()
-        for name in ("kiro", "copilot", "codex"):
+        for name in ("copilot", "codex"):
             with self.subTest(adapter=name):
                 self.assertNotIn("scope", contract["adapter"][name])
+
+    def test_kiro_has_scope_per_rfc_0005(self) -> None:
+        contract = _load_contract()
+        scope = contract["adapter"]["kiro"].get("scope")
+        self.assertIsNotNone(scope, "Kiro [scope] block missing")
+        self.assertEqual(scope["repo"], ".")
+        self.assertEqual(scope["user"], "~")
 
     def test_contract_minus_claude_code_scope_still_valid(self) -> None:
         from agentbundle.build.validate import validate

--- a/packages/agentbundle/tests/unit/test_pipeline_phase_order.py
+++ b/packages/agentbundle/tests/unit/test_pipeline_phase_order.py
@@ -1,0 +1,249 @@
+"""T7: build-pipeline phase-order invariant — RFC-0005.
+
+Per RFC-0005 § Build-pipeline ordering invariant, the pipeline projects
+primitives in fixed order **`hook-body` → `agent` → `hook-wiring` →
+`command` → `skill`** within each pack. `merge-into-agent-json` reads
+the agent JSON the agent projection wrote, so agents must land first.
+
+This test file instruments the adapter `project()` functions and
+asserts the iteration order. It runs against every reference adapter
+(claude-code, kiro, copilot, codex) so the invariant holds uniformly,
+not just for Kiro. Per the plan, "cross-pack ordering is not
+introduced" — the invariant is intra-pack.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CONTRACT_PATH = REPO_ROOT / "docs" / "contracts" / "adapter.toml"
+
+
+PHASE_ORDER = ("hook-body", "agent", "hook-wiring", "command", "skill")
+
+
+def _multi_primitive_pack(root: Path) -> Path:
+    """A pack carrying every primitive type so phase-order assertions
+    have meaningful structure to walk."""
+    pack = root / "pack"
+    (pack / ".apm" / "skills" / "demo").mkdir(parents=True)
+    (pack / ".apm" / "skills" / "demo" / "SKILL.md").write_text(
+        "# demo\n", encoding="utf-8"
+    )
+    (pack / ".apm" / "agents").mkdir(parents=True)
+    (pack / ".apm" / "agents" / "reviewer.md").write_text(
+        "---\nname: reviewer\ndescription: Demo agent.\ntools: Read\n---\nbody\n",
+        encoding="utf-8",
+    )
+    (pack / ".apm" / "hooks").mkdir(parents=True)
+    (pack / ".apm" / "hooks" / "on-spawn.sh").write_text(
+        "#!/bin/sh\nexit 0\n", encoding="utf-8"
+    )
+    (pack / ".apm" / "hook-wiring").mkdir(parents=True)
+    (pack / ".apm" / "hook-wiring" / "on-spawn.toml").write_text(
+        'attach-to-agent = "reviewer"\n\n'
+        '[[hooks.agentSpawn]]\ncommand = "$HOOK_BODY_PATH"\n',
+        encoding="utf-8",
+    )
+    (pack / ".apm" / "commands").mkdir(parents=True)
+    (pack / ".apm" / "commands" / "qux.md").write_text("# qux\n", encoding="utf-8")
+    return pack
+
+
+class PhaseOrderExecutionTests(unittest.TestCase):
+    """Each adapter's ``project()`` walks primitives in PHASE_ORDER.
+    These tests instrument the adapter's primitive-iterator entry
+    point at runtime — wrapping ``_iter_primitives`` so we capture
+    what the live ``project()`` call actually consumes, not just what
+    the helper would yield in isolation. AC16 demands the
+    *observed* order from the *running* pipeline; tautological tests
+    that just iterate the helper in isolation would pass a no-op
+    implementation."""
+
+    def _run_with_recorder(self, adapter_module, pack: Path, out: Path) -> list[str]:
+        """Run ``adapter_module.project()`` with the iterator instrumented.
+
+        We monkey-patch ``_iter_primitives`` on the adapter module to
+        wrap the real generator and capture each yielded primitive in
+        a recording list. The real generator's behaviour is preserved
+        — the wrap only observes. After ``project()`` returns, the
+        recorder reflects the actual production iteration order.
+        """
+        from agentbundle.build.contract import load as load_contract
+
+        contract = load_contract(CONTRACT_PATH)
+        out.mkdir(parents=True, exist_ok=True)
+
+        original_iter = adapter_module._iter_primitives
+        recorded: list[str] = []
+
+        def recording_iter(contract):
+            for primitive in original_iter(contract):
+                recorded.append(primitive)
+                yield primitive
+
+        adapter_module._iter_primitives = recording_iter
+        try:
+            adapter_module.project(pack, contract, out)
+        finally:
+            adapter_module._iter_primitives = original_iter
+        return recorded
+
+    def test_kiro_project_iterates_in_phase_order(self) -> None:
+        from agentbundle.build.adapters import kiro
+
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = _multi_primitive_pack(Path(tmp))
+            order = self._run_with_recorder(kiro, pack, Path(tmp) / "out")
+            self._assert_phase_order(order, "kiro")
+            # Kiro projects all five primitives: hook-body, agent,
+            # hook-wiring, command (dropped, skipped), skill.
+            self.assertIn("agent", order)
+            self.assertIn("hook-wiring", order)
+            self.assertIn("hook-body", order)
+            # `agent` must precede `hook-wiring` — the merge target
+            # invariant. AC16's load-bearing assertion.
+            self.assertLess(
+                order.index("agent"),
+                order.index("hook-wiring"),
+                "kiro projected hook-wiring before agent — merge target absent",
+            )
+
+    def test_claude_code_project_iterates_in_phase_order(self) -> None:
+        from agentbundle.build.adapters import claude_code
+
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = _multi_primitive_pack(Path(tmp))
+            order = self._run_with_recorder(claude_code, pack, Path(tmp) / "out")
+            self._assert_phase_order(order, "claude-code")
+
+    def test_copilot_project_iterates_in_phase_order(self) -> None:
+        from agentbundle.build.adapters import copilot
+
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = _multi_primitive_pack(Path(tmp))
+            order = self._run_with_recorder(copilot, pack, Path(tmp) / "out")
+            self._assert_phase_order(order, "copilot")
+
+    def test_codex_project_iterates_in_phase_order(self) -> None:
+        from agentbundle.build.adapters import codex
+
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = _multi_primitive_pack(Path(tmp))
+            order = self._run_with_recorder(codex, pack, Path(tmp) / "out")
+            self._assert_phase_order(order, "codex")
+
+    def _assert_phase_order(self, recorded: list[str], adapter_name: str) -> None:
+        """Recorded primitives must appear in PHASE_ORDER. Primitives
+        the adapter doesn't project legitimately don't appear; ones
+        it does project must respect the order. Equivalent to: the
+        recorded sequence is a subsequence of PHASE_ORDER."""
+        recorded_indices = [PHASE_ORDER.index(p) for p in recorded]
+        self.assertEqual(
+            recorded_indices,
+            sorted(recorded_indices),
+            f"{adapter_name}: primitives iterated out of phase order: "
+            f"{recorded} (PHASE_ORDER={PHASE_ORDER})",
+        )
+
+
+class KiroHookWiringMergeDuringBuildTests(unittest.TestCase):
+    """AC15 end-to-end: ``merge-into-agent-json`` fires during
+    ``kiro.project()`` when a pack ships both an agent and a wiring
+    TOML naming that agent. T6 shipped the merge engine; T7 wires it
+    into the kiro adapter's pipeline. This test pins the integration:
+    a real pack on disk produces a real merged agent JSON in dist/."""
+
+    def test_kiro_pipeline_merges_wiring_into_agent_json(self) -> None:
+        import json as _json
+
+        from agentbundle.build.adapters import kiro
+
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = _multi_primitive_pack(Path(tmp))
+            out = Path(tmp) / "out"
+            kiro.project(pack, _load_contract(), out)
+
+            # Agent landed.
+            agent_path = out / ".kiro" / "agents" / "reviewer.json"
+            self.assertTrue(agent_path.exists(), "kiro pipeline didn't produce agent JSON")
+
+            data = _json.loads(agent_path.read_text(encoding="utf-8"))
+            # Body fields from agent .md frontmatter present.
+            self.assertEqual(data["name"], "reviewer")
+            self.assertEqual(data["description"], "Demo agent.")
+            self.assertEqual(data["tools"], ["Read"])
+
+            # Wiring merged: hooks.agentSpawn with an id-tagged entry.
+            self.assertIn("hooks", data, "wiring did not merge into agent JSON")
+            self.assertIn("agentSpawn", data["hooks"])
+            entries = data["hooks"]["agentSpawn"]
+            self.assertEqual(len(entries), 1)
+            # Id tag follows the <pack>:<basename> shape from T5/T6.
+            self.assertEqual(entries[0]["id"], "pack:on-spawn")
+            self.assertEqual(entries[0]["command"], "$HOOK_BODY_PATH")
+
+
+class CrossAdapterIndependenceTests(unittest.TestCase):
+    """RFC-0005: cross-pack ordering is not introduced. The build
+    pipeline's *adapter-level* independence is the load-bearing
+    guarantee — pack X projecting against Claude Code never touches
+    pack Y's Kiro outputs (different target paths). Cross-pack
+    contamination *within the same adapter* is prevented at validate
+    time by T2's `check_kiro_wiring` rail (refuses
+    `attach-to-agent` that names an agent the same pack doesn't ship),
+    not at build time — once a pack passes validate, the pipeline
+    trusts its `attach-to-agent` is same-pack.
+
+    This test pins the adapter-level boundary: pack X's Claude Code
+    wiring lands in `.claude/settings.local.json`; pack Y's Kiro
+    agent lands in `.kiro/agents/<name>.json`. Even if both packs
+    project against the same `output_root`, their outputs occupy
+    distinct paths.
+    """
+
+    def test_kiro_agent_path_disjoint_from_claude_settings_path(self) -> None:
+        from agentbundle.build.adapters import claude_code, kiro
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+
+            pack_kiro = tmp_path / "pack-kiro"
+            (pack_kiro / ".apm" / "agents").mkdir(parents=True)
+            (pack_kiro / ".apm" / "agents" / "reviewer.md").write_text(
+                "---\nname: reviewer\n---\nbody\n", encoding="utf-8"
+            )
+
+            pack_cc = tmp_path / "pack-cc"
+            (pack_cc / ".apm" / "hook-wiring").mkdir(parents=True)
+            (pack_cc / ".apm" / "hook-wiring" / "on-prompt.toml").write_text(
+                '[hooks]\nUserPromptSubmit = ["do-thing"]\n', encoding="utf-8"
+            )
+
+            out = tmp_path / "out"
+            contract = _load_contract()
+            kiro.project(pack_kiro, contract, out)
+            claude_code.project(pack_cc, contract, out)
+
+            # Kiro produces the agent JSON at .kiro/agents/<name>.json.
+            self.assertTrue((out / ".kiro" / "agents" / "reviewer.json").exists())
+            # Claude Code's settings (if any) live elsewhere — and
+            # critically, never touch the Kiro agent JSON.
+            kiro_agent_text = (out / ".kiro" / "agents" / "reviewer.json").read_text(encoding="utf-8")
+            self.assertNotIn(
+                "do-thing",
+                kiro_agent_text,
+                "Claude Code adapter's wiring leaked into Kiro agent JSON",
+            )
+
+
+def _load_contract() -> dict:
+    from agentbundle.build.contract import load as load_contract
+    return load_contract(CONTRACT_PATH)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Wave 6 of the [user-scope-hooks spec](../tree/main/docs/specs/user-scope-hooks/spec.md) — T7 ships RFC-0005's build-pipeline phase-order invariant and reforms the Kiro agent projection from \`.md\` (incorrect against actual Kiro behavior) to \`.json\` (per [Kiro's published configuration reference](https://kiro.dev/docs/cli/custom-agents/configuration-reference/)). Sixth of thirteen PRs.

**Scope expanded per design-gap research:** The wave-5 PR flagged a real spec/code drift — the existing Kiro adapter projected agents as \`.md\` files with frontmatter, but Kiro actually expects JSON files. Online research against [kiro.dev](https://kiro.dev/docs/cli/custom-agents/configuration-reference/) confirmed the discrepancy. T7 absorbs the reform.

## What landed

- **Phase-order invariant uniformly across all four adapters.** New \`_iter_primitives(contract)\` helper in each of \`claude_code.py\`, \`kiro.py\`, \`copilot.py\`, \`codex.py\` yields primitives in the fixed order \`hook-body\` → \`agent\` → \`hook-wiring\` → \`command\` → \`skill\`. Shared \`PHASE_ORDER\` constant lives in new module \`agentbundle/build/phase_order.py\` (single source of truth — was 4-way duplicated in the first draft).
- **Kiro agent \`.md\` → \`.json\` reform.** The existing \`_project_agent_with_frontmatter\` became \`_project_agent_as_json\`. Parses markdown frontmatter + body, emits JSON with Kiro's documented fields (\`name\`, \`description\`, \`tools\`, \`model\`, \`prompt\`). The \`kiro-agent-frontmatter-v0.9\` mapping table is reinterpreted as *markdown-frontmatter → JSON-field*. Pack-side source format unchanged (\`.apm/agents/<name>.md\`).
- **Kiro hook-wiring projection during build.** New \`_project_hook_wiring_to_agent_json\` reads \`.apm/hook-wiring/*.toml\`, groups by \`attach-to-agent\`, and delegates to \`merge_into_agent_json.project()\` from T6. Refusals propagate (fail-fast \`make build\`).
- **Spec amendment** (\`docs/specs/distribution-adapters/spec.md\` line 199 agent row) — Kiro agent target updated to \`.kiro/agents/<name>.json\` with a footnote explaining the \`direct-file\` mode label is retained for contract continuity though the implementation is semantically md→json.
- **RFC-0005 drawback closure** — \"Kiro's hook-entry schema is observed-but-not-publicly-documented\" narrowed to \"partially closed\" with three enumerated residual-risk classes (optional hook-entry fields not in public reference; agent-field coverage on the reform; \`id\`-as-tag assumption from Unresolved Q1).
- **T1-era stale-test repairs (adjacent).** Two tests under \`agentbundle/build/tests/test_contract_scope.py\` were broken since T1's contract bump but missed in T1's session because they live inside the package rather than the standard pytest discovery root. Updated to v0.3 + kiro-has-scope shape.

## Tests added (6)

- \`tests/unit/test_pipeline_phase_order.py\` — four per-adapter phase-order execution tests (monkey-patched recording of the live \`project()\` iteration), one end-to-end Kiro merge-into-agent-json integration test, one cross-adapter independence test.

## Adversarial review

Three rounds. Round 1: 2 Blockers (mirror-tests not execution-order; AC15 lacked end-to-end) + 4 Concerns + 2 Nits. Round 2: 1 Blocker (footnote prose broke the markdown table). Round 3: **Clean — ready to commit.**

All addressed:

1. Phase-order tests now monkey-patch \`_iter_primitives\` and run the real \`project()\`.
2. New \`KiroHookWiringMergeDuringBuildTests::test_kiro_pipeline_merges_wiring_into_agent_json\` exercises AC15 end-to-end.
3. Build-time merge refusals propagate (fail-fast); \`sys\` import removed.
4. RFC closure narrowed to \"partially closed\" with three explicit residual-risk classes.
5. Frontmatter \`prompt:\` wins over body-derived prompt.
6. Spec footnote moved out of the table to keep markdown rendering valid.
7. Shared \`PHASE_ORDER\` constant in new \`phase_order.py\`.

## Acceptance criteria

- [x] **AC15 (deferred from T6)** — \`merge-into-agent-json\` fires during \`make build\` for Kiro packs with hook-wiring. End-to-end test pins.
- [x] **AC16** — Phase order \`hook-body\` → \`agent\` → \`hook-wiring\` → \`command\` → \`skill\` enforced uniformly. Four per-adapter execution-order tests.

## Gates

501 tests pass, 1 skipped. \`make build-check\` and \`make validate\` exit 0.

## Out of scope

T8b (install/uninstall CLI threading + \`--force-merge\`), T8c (upgrade reconciliation), T9 (\`reconcile --scope user\` reporter), T11 (agent-spec-cli spec amendment).