### PR TITLE
feat(wave7): install/uninstall CLI threading + --force-merge flag (T8b)

### DIFF
--- a/packages/agentbundle/agentbundle/cli.py
+++ b/packages/agentbundle/agentbundle/cli.py
@@ -36,7 +36,7 @@ from agentbundle.version import CLI_VERSION, SPEC_VERSION
 # from argparse with the documented `unknown flag for <verb>: <flag>`
 # shape. Other unrecognised flags keep argparse's default text so we
 # don't accidentally swallow typos.
-_REWRITE_FLAGS = ("--scope", "--force")
+_REWRITE_FLAGS = ("--scope", "--force", "--force-merge")
 
 
 class _VerbAwareParser(argparse.ArgumentParser):
@@ -187,6 +187,17 @@ def _build_parser() -> argparse.ArgumentParser:
             "the requested scope even when the pack is already installed at "
             "the other scope. Does *not* override the in-place re-install "
             "refusal; use `upgrade` for that."
+        ),
+    )
+    sp.add_argument(
+        "--force-merge",
+        action="store_true",
+        help=(
+            "RFC-0005: adopt an adopter-hand-authored entry under "
+            "`~/.claude/settings.json` whose `command` collides with the "
+            "pack's hook. Bound to `install --scope user` against a "
+            "Claude-Code-targeted pack only; original command preserved "
+            "in the state-file snapshot."
         ),
     )
     sp.set_defaults(func=_lazy("install"))

--- a/packages/agentbundle/agentbundle/commands/install.py
+++ b/packages/agentbundle/agentbundle/commands/install.py
@@ -87,7 +87,20 @@ def run(args: "argparse.Namespace") -> int:
     catalogue_uri: str = args.catalogue
     cli_scope: str | None = getattr(args, "scope", None)
     force: bool = bool(getattr(args, "force", False))
+    force_merge: bool = bool(getattr(args, "force_merge", False))
     output_root = Path(args.output).resolve()
+
+    # `--force-merge` runtime binding (Step 2's resolved scope is the
+    # source of truth — see below). The early check here catches an
+    # explicit ``--scope repo``; the resolved-scope check after
+    # Step 2 catches the case where the pack defaults to repo scope.
+    if force_merge and cli_scope == "repo":
+        print(
+            "install: --force-merge is bound to user scope; pass --scope user "
+            "or omit --force-merge",
+            file=sys.stderr,
+        )
+        return 1
 
     # Range-check the CLI-supplied pack name before any I/O. The manifest's
     # `pack.name` is checked by `_assert_pack_metadata_shape` below; this
@@ -143,7 +156,12 @@ def run(args: "argparse.Namespace") -> int:
     # Mirrors validate.py:_allowed_scopes, kept in sync intentionally.
     from agentbundle.config import pack_spec_version
 
-    if pack_spec_version(pack_toml) == "0.2":
+    # v0.2 introduced `[pack.install]`; v0.3 (RFC-0005) added optional
+    # `user-scope-hooks` but did not change scope-resolution semantics.
+    # Mirror validate.py:_allowed_scopes — both versions carry the
+    # install table. The v0.1 path stays gateless (legacy implied
+    # `default-scope = "repo"`).
+    if pack_spec_version(pack_toml) in ("0.2", "0.3"):
         pack_install = pack_toml.get("pack", {}).get("install")
     else:
         pack_install = None
@@ -155,6 +173,18 @@ def run(args: "argparse.Namespace") -> int:
         print(
             f"install: {exc.pack_name}: scope {exc.requested!r} not in "
             f"allowed-scopes {exc.allowed}",
+            file=sys.stderr,
+        )
+        return 1
+
+    # RFC-0005 § Binding: ``--force-merge`` is bound to user scope only.
+    # Gate on the *resolved* scope (the source of truth post-Step 2)
+    # so a pack defaulting to repo scope also surfaces the refusal,
+    # not just an explicit `--scope repo`.
+    if force_merge and requested_scope != "user":
+        print(
+            "install: --force-merge is bound to user scope; pass --scope user "
+            "or omit --force-merge",
             file=sys.stderr,
         )
         return 1
@@ -260,10 +290,37 @@ def run(args: "argparse.Namespace") -> int:
         scopes_to_install = [requested_scope]
 
     # Probe per-adapter scope metadata (for allowed-prefixes at user
-    # scope). The Claude Code adapter is the only one shipping a
-    # [scope] block today; future adapters would map similarly. We
-    # consult the bundled contract.
-    allowed_prefixes_user = _claude_code_allowed_prefixes_user()
+    # scope). The Claude Code adapter ships a [scope] block from
+    # RFC-0004; RFC-0005's T1 added one to Kiro too. Resolve which
+    # adapter the user-scope install targets and use that adapter's
+    # `allowed-prefixes.user`. Kiro-targeted packs (those shipping
+    # `.apm/agents/`) get Kiro's `.kiro/` prefix; everything else
+    # gets Claude Code's `.claude/` prefix.
+    user_target_adapter = _resolve_user_scope_target_adapter(pack_dir)
+    allowed_prefixes_user = _adapter_allowed_prefixes_user(user_target_adapter)
+
+    # RFC-0005 AC25: refuse install --scope user against an adapter
+    # that doesn't declare a working user-scope hook-wiring mode. The
+    # heuristic above picks kiro/claude-code; this guard catches a
+    # contract-misconfiguration regression (e.g. someone strips
+    # `user-merge-json` from the contract or sets `dropped`) before
+    # any byte is written.
+    user_scope_hooks_opt_in = bool(
+        isinstance(pack_install, dict)
+        and pack_install.get("user-scope-hooks") is True
+    )
+    if (
+        user_scope_hooks_opt_in
+        and requested_scope == "user"
+        and not _adapter_supports_user_scope_hook_wiring(user_target_adapter)
+    ):
+        print(
+            f"install: adapter {user_target_adapter!r} does not declare a "
+            f"hook-wiring mode that supports user scope; pack {pack_name} "
+            f"requires it",
+            file=sys.stderr,
+        )
+        return 1
 
     plans: list[_ScopePlan] = []
     for scope_value in scopes_to_install:
@@ -323,6 +380,20 @@ def run(args: "argparse.Namespace") -> int:
                 return 1
 
     # ── Step 6: Pre-flight — rails A/B/C for any user-scope write ────────────
+    # Also run the kiro attach-to-agent rail (T2's `check_kiro_wiring`)
+    # for user-scope kiro-targeted packs. Catches malformed wiring TOMLs
+    # (missing/typo'd `attach-to-agent`, path-traversal payloads) before
+    # any render — the build-pipeline error message ("internal: <path>
+    # missing") isn't actionable for adopters; this rail surfaces the
+    # actual contract violation.
+    if any(p.scope == "user" for p in plans) and user_target_adapter == "kiro":
+        target_adapters = {"kiro"}
+        kiro_refusal = scope_rails.check_kiro_wiring(
+            pack_dir, pack_name, target_adapters
+        )
+        if kiro_refusal is not None:
+            print(f"install: {kiro_refusal}", file=sys.stderr)
+            return 1
     for plan in plans:
         if plan.scope == "user":
             allowed_scopes = _resolved_allowed_scopes(pack_install)
@@ -355,13 +426,44 @@ def run(args: "argparse.Namespace") -> int:
     # projection target).
     repo_projection: dict[str, bytes] | None = None
     user_projection: dict[str, bytes] | None = None
+    # RFC-0005 § hook-body at user scope: user-scope packs ship hook
+    # bodies that project to `<adapter>/hooks/<pack>/` (not the legacy
+    # `tools/hooks/`); RFC-0005 § hook-wiring lands the wiring merger
+    # against the adopter's settings or pack-owned agent JSON instead
+    # of writing the wiring TOML to disk. Both rewrites happen
+    # post-render and pre-path-jail.
+    # `user_target_adapter` resolved earlier (alongside allowed_prefixes_user).
     try:
         if any(p.scope == "repo" for p in plans):
             repo_projection = render_pack(pack_dir)
         if any(p.scope == "user" for p in plans):
             user_projection = _render_for_user_scope(pack_dir)
+            user_scope_hooks_enabled = bool(
+                isinstance(pack_install, dict)
+                and pack_install.get("user-scope-hooks") is True
+            )
+            if user_scope_hooks_enabled:
+                user_projection = _rewrite_user_scope_hook_paths(
+                    user_projection,
+                    pack_name=pack_name,
+                    target_adapter=user_target_adapter,
+                )
     except (FileNotFoundError, ValueError) as exc:
         print(f"install: render failed for pack {pack_name!r}: {exc}", file=sys.stderr)
+        return 1
+
+    # RFC-0005 § Binding: ``--force-merge`` is Claude-Code-only. The
+    # kiro merge target is a pack-owned agent JSON; adopter collision
+    # is structurally a non-case. Refuse early once the target adapter
+    # is known.
+    if force_merge and user_target_adapter != "claude-code" and any(
+        p.scope == "user" for p in plans
+    ):
+        print(
+            "install: --force-merge applies only to Claude-Code-targeted packs; "
+            f"pack {pack_name} resolves to adapter '{user_target_adapter}' at user scope",
+            file=sys.stderr,
+        )
         return 1
 
     # Full re-check including projection relpaths now that `render_pack`
@@ -460,6 +562,53 @@ def run(args: "argparse.Namespace") -> int:
                 "sha": safety.sha256_bytes(content),
                 "from-pack-version": pack_version,
             }
+
+        # RFC-0005 T8b — user-scope hook-wiring merge phase.
+        # Runs after file writes (so hook bodies exist where wiring
+        # entries reference them via $HOOK_BODY_PATH-style placeholders;
+        # T8b's resolver-time substitution is the consumer's concern).
+        # Captures (event, id[, target-file]) tuples and writes them
+        # to ``hook_wiring_owned`` on the PackState so uninstall can
+        # be precise.
+        if plan.scope == "user":
+            user_scope_hooks_enabled = bool(
+                isinstance(pack_install, dict)
+                and pack_install.get("user-scope-hooks") is True
+            )
+            if user_scope_hooks_enabled:
+                try:
+                    owned_rows = _merge_user_scope_hook_wiring(
+                        pack_dir=pack_dir,
+                        pack_name=pack_name,
+                        target_adapter=user_target_adapter,
+                        install_root=plan.root,
+                        force_merge=force_merge,
+                    )
+                except Exception as exc:
+                    print(f"install: {exc}", file=sys.stderr)
+                    return 1
+                new_pack_state.hook_wiring_owned = owned_rows
+                if user_target_adapter == "kiro":
+                    new_pack_state.adapter = "kiro"
+
+                # The merge phase re-wrote the agent JSON (Kiro) with
+                # the hook entries we just merged in; for Claude Code,
+                # the settings.json target is adopter-shared and isn't
+                # tracked in state.files at all. Refresh the on-disk
+                # SHA for any merged target that *is* in state.files
+                # so uninstall's Tier-1 check (recorded SHA == on-disk
+                # SHA) still passes after the merge.
+                for row in owned_rows:
+                    target_file_rel = row.get("target-file")
+                    if not target_file_rel:
+                        continue
+                    target_path = plan.root / target_file_rel.lstrip("/")
+                    if not target_path.exists():
+                        continue
+                    if target_file_rel in new_pack_state.files:
+                        new_pack_state.files[target_file_rel]["sha"] = (
+                            safety.sha256_file(target_path)
+                        )
 
         plan.state.packs[pack_name] = new_pack_state
         # Stamp the post-write schema. Always emit the current
@@ -949,19 +1098,234 @@ def _render_for_user_scope(pack_dir: Path) -> dict[str, bytes]:
     intentionally out of scope at user-scope install — they're
     dist-time build artifacts that the adopter's `~` should never
     carry.
+
+    Note: for v0.3 packs declaring ``user-scope-hooks = true``, the
+    install handler applies a v0.3 post-projection rewrite via
+    ``_rewrite_user_scope_hook_paths`` to swap legacy hook-body
+    targets (``tools/hooks/``) for the user-scope shape
+    (``.claude/hooks/<pack>/`` or ``.kiro/hooks/<pack>/``) and drop
+    the v0.2 wiring-target file (``.claude/settings.local.json``)
+    from the projection map. The wiring TOMLs themselves are then
+    consumed by ``_merge_user_scope_hook_wiring`` post-write.
     """
     import tempfile
     import tomllib
 
-    from agentbundle.build.adapters import claude_code
+    from agentbundle.build.adapters import claude_code, kiro
     from agentbundle.build.main import _read_bundled
     from agentbundle.render import _collect_tree
 
     contract = tomllib.loads(_read_bundled("adapter.toml"))
+    target_adapter = _resolve_user_scope_target_adapter(pack_dir)
     with tempfile.TemporaryDirectory() as raw:
         out = Path(raw)
-        claude_code.project(pack_dir, contract, out)
+        if target_adapter == "kiro":
+            kiro.project(pack_dir, contract, out)
+        else:
+            claude_code.project(pack_dir, contract, out)
         return _collect_tree(out)
+
+
+def _adapter_supports_user_scope_hook_wiring(adapter_name: str) -> bool:
+    """Return True iff the adapter declares a hook-wiring projection
+    mode that works at user scope (RFC-0005 AC25).
+
+    Two shapes count:
+      - Claude Code: ``mode.user = "user-merge-json"``.
+      - Kiro: ``mode = "merge-into-agent-json"`` (single mode, no
+        scope qualifier — the agent-file target is scope-conditional
+        via `<scope-root>` resolution).
+
+    Anything else (``dropped``, ``degraded-info-log``, absent
+    projection) is refused.
+    """
+    import tomllib
+    from agentbundle.build.main import _read_bundled
+
+    contract = tomllib.loads(_read_bundled("adapter.toml"))
+    adapter_block = contract.get("adapter", {}).get(adapter_name, {})
+    projections = adapter_block.get("projections", {}) if isinstance(adapter_block, dict) else {}
+    hook_wiring = projections.get("hook-wiring") if isinstance(projections, dict) else None
+    if not isinstance(hook_wiring, dict):
+        return False
+    mode = hook_wiring.get("mode")
+    if isinstance(mode, dict):
+        # Claude-Code-shape scope-map: only `user-merge-json` is the
+        # documented user-scope mode. `merge-into-agent-json` would
+        # be a contract misconfiguration (it targets per-agent files,
+        # not a settings file) — refuse it under the scope-map branch.
+        return mode.get("user") == "user-merge-json"
+    # Bare-string mode: only `merge-into-agent-json` (Kiro shape)
+    # implies user-scope support. `merge-json` (the v0.2 repo-only
+    # form) does not.
+    return mode == "merge-into-agent-json"
+
+
+def _resolve_user_scope_target_adapter(pack_dir: Path) -> str:
+    """Heuristic mirroring T2's `_kiro_target_adapters`: a pack ships
+    ``.apm/agents/<name>.md`` iff it intends to project against Kiro
+    (Kiro's hook-wiring binds inside agent JSON). Packs without agents
+    project against Claude Code at user scope.
+
+    TODO(allowed-adapters): A future RFC may add a per-pack
+    ``allowed-adapters`` declaration on `pack.toml`. When it does,
+    resolve via that field instead of the agents-present heuristic
+    — that closes the AC25 corner case where a Copilot-only pack
+    with hooks (no agents) silently resolves to ``claude-code``
+    here. Until then, the heuristic is the proxy.
+
+    Known limitation: two packs claiming the same Kiro agent name
+    (each ships ``.apm/agents/<name>.md``) will both write to the
+    same projected ``.kiro/agents/<name>.json`` and the second
+    install will silently overwrite the first's wiring. T8c upgrade
+    reconciliation (and a follow-on RFC for shared-agent ownership)
+    will need to address this; T8b's single-pack ACs don't cover it.
+    """
+    agents_dir = pack_dir / ".apm" / "agents"
+    if not agents_dir.exists():
+        return "claude-code"
+    for entry in agents_dir.iterdir():
+        if entry.is_file() and entry.suffix == ".md":
+            return "kiro"
+    return "claude-code"
+
+
+def _rewrite_user_scope_hook_paths(
+    projection: dict[str, bytes],
+    pack_name: str,
+    target_adapter: str,
+) -> dict[str, bytes]:
+    """Rewrite legacy hook-body paths in *projection* to v0.3 user-
+    scope targets per RFC-0005 § hook-body at user scope, and drop the
+    v0.2 wiring-target file (the v0.3 merge engine writes through the
+    user-merge-json / merge-into-agent-json path instead).
+
+    Claude Code target: ``.claude/hooks/<pack>/<name>.{sh,py}``.
+    Kiro target: ``.kiro/hooks/<pack>/<name>.{sh,py}``.
+
+    For Kiro user-scope installs, the build pipeline's Kiro adapter
+    has already merged hook-wiring into the dist's
+    ``.kiro/agents/<name>.json``. The install-time merge runs again
+    against the user's actual home — to keep ownership of the writes
+    single-sourced (and avoid a fragile double-merge), we strip the
+    ``hooks`` key from any agent JSON in the user-scope projection
+    here; install copies the body-only JSON, and
+    ``_merge_user_scope_hook_wiring`` re-adds the hook entries with
+    the same id-shape, producing a single set of writes.
+    """
+    import json
+
+    hook_subdir = ".claude/hooks" if target_adapter == "claude-code" else ".kiro/hooks"
+    drop_keys = {".claude/settings.local.json"}
+    hook_body_suffixes = (".sh", ".py")
+    rewritten: dict[str, bytes] = {}
+    for relpath, content in projection.items():
+        if relpath in drop_keys:
+            # The v0.2 wiring target — v0.3 merges directly into
+            # `~/.claude/settings.json` via user_merge_json instead.
+            continue
+        if (
+            relpath.startswith("tools/hooks/")
+            and Path(relpath).suffix in hook_body_suffixes
+        ):
+            basename = Path(relpath).name
+            rewritten[f"{hook_subdir}/{pack_name}/{basename}"] = content
+        elif (
+            target_adapter == "kiro"
+            and relpath.startswith(".kiro/agents/")
+            and relpath.endswith(".json")
+        ):
+            # Strip the `hooks` key — the install-time merge step
+            # re-adds it. Single-writer discipline; double-merge
+            # would be idempotent today but fragile under any
+            # future timestamp/version field on entries.
+            try:
+                data = json.loads(content.decode("utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                rewritten[relpath] = content
+                continue
+            if isinstance(data, dict) and "hooks" in data:
+                data.pop("hooks")
+            rewritten[relpath] = (
+                json.dumps(data, indent=2, sort_keys=False) + "\n"
+            ).encode("utf-8")
+        else:
+            rewritten[relpath] = content
+    return rewritten
+
+
+def _merge_user_scope_hook_wiring(
+    pack_dir: Path,
+    pack_name: str,
+    target_adapter: str,
+    install_root: Path,
+    force_merge: bool,
+) -> list[dict[str, str]]:
+    """Parse the pack's ``.apm/hook-wiring/*.toml`` and dispatch to the
+    appropriate v0.3 merger.
+
+    Returns the list of ``{"event", "id", "target-file"?}`` rows the
+    install handler stores on ``PackState.hook_wiring_owned``. The
+    ``target-file`` field is omitted for Claude Code rows (the
+    adapter's user-scope default target — ``~/.claude/settings.json``
+    — is the implicit target on read; RFC-0005 § State-file impact)
+    and explicit for Kiro rows.
+    """
+    import tomllib
+
+    wiring_dir = pack_dir / ".apm" / "hook-wiring"
+    if not wiring_dir.exists():
+        return []
+    wiring_tomls: dict[str, dict] = {}
+    for entry in sorted(wiring_dir.iterdir()):
+        if entry.is_file() and entry.suffix == ".toml":
+            wiring_tomls[entry.stem] = tomllib.loads(entry.read_text(encoding="utf-8"))
+    if not wiring_tomls:
+        return []
+
+    if target_adapter == "claude-code":
+        from agentbundle.build.projections.user_merge_json import project as _project
+
+        target = install_root / ".claude" / "settings.json"
+        owned = _project(target, pack_name, wiring_tomls, force_merge=force_merge)
+        return [{"event": event, "id": entry_id} for event, entry_id in owned]
+
+    # Kiro: group wiring by attach-to-agent; one merge call per agent.
+    from agentbundle import safety
+    from agentbundle.build.projections.merge_into_agent_json import project as _project
+
+    # Defence-in-depth on the merge target path: a malicious
+    # ``attach-to-agent`` value (e.g. ``"../../../tmp/escape"``) would
+    # otherwise resolve outside the user-scope jail. The Step-8 path-
+    # jail probe walks the projection dict; the merge target is
+    # constructed here, post-probe, so we re-jail manually.
+    _AGENT_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+    wiring_by_agent: dict[str, dict[str, dict]] = {}
+    for basename, body in wiring_tomls.items():
+        attach = body.get("attach-to-agent") if isinstance(body, dict) else None
+        if not isinstance(attach, str):
+            continue
+        if not _AGENT_NAME_RE.fullmatch(attach):
+            raise RuntimeError(
+                f"install: pack {pack_name}'s hook-wiring {basename}.toml "
+                f"declares attach-to-agent={attach!r} which violates the "
+                f"agent-name grammar ^[a-z0-9][a-z0-9-]*$ — refusing"
+            )
+        wiring_by_agent.setdefault(attach, {})[basename] = body
+
+    rows: list[dict[str, str]] = []
+    for attach_to_agent, partitioned in wiring_by_agent.items():
+        target_file_rel = f".kiro/agents/{attach_to_agent}.json"
+        target = install_root / target_file_rel
+        try:
+            safety.assert_under(install_root, target)
+        except safety.PathJailError as exc:
+            raise RuntimeError(f"install: merge target outside jail: {exc}") from exc
+        owned = _project(target, pack_name, partitioned)
+        for event, entry_id in owned:
+            rows.append({"event": event, "id": entry_id, "target-file": target_file_rel})
+    return rows
 
 
 def _resolved_allowed_scopes(pack_install: dict | None) -> list[str]:
@@ -985,6 +1349,24 @@ def _claude_code_allowed_prefixes_user() -> list[str]:
     parsing the contract for the common repo-scope path. Cached so the
     five callers (install, uninstall, upgrade, init-state --migrate,
     adapt) parse the contract at most once per CLI invocation.
+
+    Retained as the Claude-Code-specific shortcut; new callers that
+    need adapter-aware resolution should use
+    ``_adapter_allowed_prefixes_user(adapter_name)`` below.
+    """
+    return _adapter_allowed_prefixes_user("claude-code")
+
+
+def _adapter_allowed_prefixes_user(adapter_name: str) -> list[str]:
+    """Read *adapter_name*'s `allowed-prefixes.user` from the contract.
+
+    RFC-0005's T1 added a `[adapter.kiro.scope]` table alongside Claude
+    Code's existing one; user-scope installs of Kiro-targeted packs
+    need Kiro's prefixes (`.kiro/`, `.agent-ready/`) not Claude Code's
+    (`.claude/`, `.agent-ready/`). The fallback (legacy contract
+    without a scope table for the requested adapter) is the
+    conservative single-prefix list rooted at the adapter's documented
+    directory.
     """
     import tomllib
     from agentbundle.build.main import _read_bundled
@@ -992,13 +1374,14 @@ def _claude_code_allowed_prefixes_user() -> list[str]:
     contract = tomllib.loads(_read_bundled("adapter.toml"))
     try:
         return list(
-            contract["adapter"]["claude-code"]["scope"]["allowed-prefixes"]["user"]
+            contract["adapter"][adapter_name]["scope"]["allowed-prefixes"]["user"]
         )
     except KeyError:
-        # Defensive: legacy contract without scope table. Fall back to
-        # the conservative single-prefix list — the path-jail probe
-        # will still refuse anything outside `.claude/`.
-        return [".claude/"]
+        # Defensive: contract didn't declare a [scope] block for this
+        # adapter. Pick a sensible default rooted at the adapter's
+        # documented user-scope directory.
+        default_prefix = ".kiro/" if adapter_name == "kiro" else ".claude/"
+        return [default_prefix]
 
 
 def _classify_for_install(

--- a/packages/agentbundle/agentbundle/commands/uninstall.py
+++ b/packages/agentbundle/agentbundle/commands/uninstall.py
@@ -97,10 +97,18 @@ def run(args: "argparse.Namespace") -> int:
         state_path = user_state_path
         root = user_state_path.parent.parent  # = ~ (the user-scope projection root)
         # Pull the adapter contract's allowed-prefixes so the user-scope
-        # path-jail fires on the state-file write below.
-        from agentbundle.commands.install import _claude_code_allowed_prefixes_user
+        # path-jail fires on the per-file removal walk below. The
+        # adapter is recorded on the pack's state row (v0.3); fall back
+        # to claude-code when absent (v0.2-vintage rows preserved across
+        # the header-only migration, per RFC-0005 § State-file impact).
+        from agentbundle.commands.install import _adapter_allowed_prefixes_user
 
-        user_prefixes = _claude_code_allowed_prefixes_user()
+        recorded_adapter = (
+            user_state_for_check.packs[pack_name].adapter
+            if pack_name in user_state_for_check.packs
+            else "claude-code"
+        )
+        user_prefixes = _adapter_allowed_prefixes_user(recorded_adapter or "claude-code")
 
     # ── Step 1b: Load state for write (refuse v0.1 here, after disambig) ─────
     try:
@@ -176,6 +184,45 @@ def run(args: "argparse.Namespace") -> int:
                 file=sys.stderr,
             )
             kept.append(relpath)
+
+    # ── Step 2b: RFC-0005 T8b — unproject hook-wiring-owned entries ─────────
+    # When the pack has hook_wiring_owned rows (v0.3 user-scope hooks),
+    # dispatch to the right merge engine's `unproject` to remove those
+    # entries from the merge target file. Empty `hooks.<event>` arrays
+    # are pruned; the target file itself stays in place (Kiro: agent
+    # primitive's direct-file uninstall handles it; Claude Code: the
+    # settings file is adopter-shared and must not be deleted).
+    if pack_state.hook_wiring_owned:
+        adapter = pack_state.adapter or "claude-code"
+        owned_by_target: dict[str, list[tuple[str, str]]] = {}
+        for entry in pack_state.hook_wiring_owned:
+            event = entry.get("event")
+            entry_id = entry.get("id")
+            if not (isinstance(event, str) and isinstance(entry_id, str)):
+                continue
+            target_file_rel = entry.get("target-file")
+            if not target_file_rel:
+                # Claude Code rows default to `~/.claude/settings.json`
+                # per RFC-0005 § State-file impact (resolve via the
+                # user-scope target on the adapter contract).
+                target_file_rel = ".claude/settings.json"
+            owned_by_target.setdefault(target_file_rel, []).append((event, entry_id))
+
+        for target_file_rel, owned in owned_by_target.items():
+            target_path = root / target_file_rel.lstrip("/")
+            if adapter == "kiro":
+                from agentbundle.build.projections.merge_into_agent_json import (
+                    unproject as _unproject,
+                )
+            else:
+                from agentbundle.build.projections.user_merge_json import (
+                    unproject as _unproject,
+                )
+            try:
+                _unproject(target_path, owned)
+            except Exception as exc:
+                print(f"uninstall: hook-wiring unproject failed: {exc}", file=sys.stderr)
+                return 1
 
     # ── Step 3: Best-effort cleanup of empty parent directories ──────────────
     _prune_empty_parents(root, removed)

--- a/packages/agentbundle/tests/integration/test_install_user_hooks.py
+++ b/packages/agentbundle/tests/integration/test_install_user_hooks.py
@@ -1,0 +1,305 @@
+"""T8b: install --scope user routes hook-wiring through the v0.3 merge
+engines (user_merge_json for Claude Code; merge_into_agent_json for
+Kiro) and writes hook-wiring-owned state rows.
+
+Covers spec ACs AC11, AC20, AC23, AC24, AC25; the CLI binding rails
+for the new ``--force-merge`` flag also live here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+FIXTURES = REPO_ROOT / "packages" / "agentbundle" / "tests" / "fixtures" / "packs"
+
+
+def _run_install(args_namespace) -> tuple[int, str, str]:
+    """Invoke install.run() with stdout + stderr capture."""
+    from agentbundle.commands import install
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        rc = install.run(args_namespace)
+    return rc, stdout.getvalue(), stderr.getvalue()
+
+
+def _install_args(
+    *,
+    pack: str,
+    catalogue: str,
+    output: str,
+    scope: str | None = None,
+    force: bool = False,
+    force_merge: bool = False,
+) -> argparse.Namespace:
+    """Build the install command's namespace shape, matching cli.py."""
+    return argparse.Namespace(
+        pack=pack,
+        catalogue=catalogue,
+        output=output,
+        scope=scope,
+        force=force,
+        force_merge=force_merge,
+    )
+
+
+class _UserScopeInstallBase(unittest.TestCase):
+    """Common setup: redirect ``$HOME`` to a tmp_path so the test never
+    touches the developer's real home tree."""
+
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.home = self.tmp / "home"
+        self.home.mkdir()
+        self.repo = self.tmp / "repo"
+        self.repo.mkdir()
+        self._env = patch.dict(os.environ, {"HOME": str(self.home)})
+        self._env.start()
+        self.addCleanup(self._env.stop)
+        # Construct a temporary catalogue layout: <cat>/packs/<pack>/
+        self.cat = self.tmp / "catalogue"
+        (self.cat / "packs").mkdir(parents=True)
+
+
+def _copy_fixture(src: Path, dst: Path) -> None:
+    shutil.copytree(src, dst)
+    # CI checkouts may strip +x; re-apply for hook bodies.
+    for entry in dst.rglob("*.sh"):
+        entry.chmod(0o755)
+
+
+class CCUserHooksInstallTests(_UserScopeInstallBase):
+    """Install the cc-user-hooks fixture; assert the user-scope merge
+    landed and state captured hook-wiring-owned rows (AC23/AC20)."""
+
+    def test_install_cc_user_hooks_writes_settings_and_state(self) -> None:
+        _copy_fixture(FIXTURES / "cc-user-hooks", self.cat / "packs" / "cc-user-hooks")
+        args = _install_args(
+            pack="cc-user-hooks",
+            catalogue=str(self.cat),
+            output=str(self.repo),
+            scope="user",
+        )
+        rc, _stdout, stderr = _run_install(args)
+        self.assertEqual(rc, 0, f"install failed: {stderr}")
+
+        # The Claude Code settings file received the merged entry.
+        settings = self.home / ".claude" / "settings.json"
+        self.assertTrue(settings.exists(), f"settings.json absent under {self.home}")
+        data = json.loads(settings.read_text(encoding="utf-8"))
+        entries = data["hooks"]["UserPromptSubmit"]
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["id"], "cc-user-hooks:on-prompt")
+
+        # State captured a hook-wiring-owned row.
+        from agentbundle.config import load_state
+
+        state = load_state(self.home / ".agent-ready" / "state.toml")
+        owned = state.packs["cc-user-hooks"].hook_wiring_owned
+        self.assertEqual(len(owned), 1)
+        self.assertEqual(owned[0]["event"], "UserPromptSubmit")
+        self.assertEqual(owned[0]["id"], "cc-user-hooks:on-prompt")
+        # adapter defaults to claude-code on read; we don't require an
+        # explicit field on the row.
+
+
+class KiroUserHooksInstallTests(_UserScopeInstallBase):
+    """Install the kiro-user-hooks fixture; assert the agent JSON merge
+    landed and state captured hook-wiring-owned rows with adapter +
+    target-file fields (AC20/AC23)."""
+
+    def test_install_kiro_user_hooks_writes_agent_json_and_state(self) -> None:
+        _copy_fixture(FIXTURES / "kiro-user-hooks", self.cat / "packs" / "kiro-user-hooks")
+        args = _install_args(
+            pack="kiro-user-hooks",
+            catalogue=str(self.cat),
+            output=str(self.repo),
+            scope="user",
+        )
+        rc, _stdout, stderr = _run_install(args)
+        self.assertEqual(rc, 0, f"install failed: {stderr}")
+
+        agent_json = self.home / ".kiro" / "agents" / "reviewer.json"
+        self.assertTrue(agent_json.exists(), f"agent JSON absent: {agent_json}")
+        data = json.loads(agent_json.read_text(encoding="utf-8"))
+        self.assertEqual(data["name"], "reviewer")
+        entries = data["hooks"]["agentSpawn"]
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["id"], "kiro-user-hooks:on-spawn")
+
+        from agentbundle.config import load_state
+
+        state = load_state(self.home / ".agent-ready" / "state.toml")
+        ps = state.packs["kiro-user-hooks"]
+        self.assertEqual(ps.adapter, "kiro")
+        self.assertEqual(len(ps.hook_wiring_owned), 1)
+        self.assertEqual(ps.hook_wiring_owned[0]["event"], "agentSpawn")
+        self.assertEqual(ps.hook_wiring_owned[0]["id"], "kiro-user-hooks:on-spawn")
+        self.assertEqual(
+            ps.hook_wiring_owned[0]["target-file"],
+            ".kiro/agents/reviewer.json",
+        )
+
+
+class ForceMergeFlagBindingTests(unittest.TestCase):
+    """AC12 binding rails for ``--force-merge``:
+       - Bound to ``install`` verb (other verbs refuse with
+         ``unknown flag for <verb>: --force-merge``).
+       - Bound to ``--scope user``.
+       - Claude-Code-only at install time (refused on Kiro-targeted
+         packs since agent JSON is pack-owned)."""
+
+    def test_force_merge_on_uninstall_refuses_with_unknown_flag(self) -> None:
+        import subprocess
+        import sys as _sys
+
+        proc = subprocess.run(
+            [_sys.executable, "-m", "agentbundle", "uninstall", "--pack", "x", "--force-merge"],
+            env={**os.environ, "PYTHONPATH": str(REPO_ROOT / "packages" / "agentbundle")},
+            capture_output=True,
+            cwd=str(REPO_ROOT),
+        )
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn(
+            "unknown flag for uninstall: --force-merge",
+            proc.stderr.decode(),
+        )
+
+    def test_force_merge_at_repo_scope_refuses(self) -> None:
+        """``--force-merge`` only makes sense at user scope (the
+        merge target is a pack-owned file at repo scope). This tests
+        the early gate — explicit `--scope repo` is refused."""
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            (tmp / "catalogue" / "packs").mkdir(parents=True)
+            _copy_fixture(FIXTURES / "cc-user-hooks", tmp / "catalogue" / "packs" / "cc-user-hooks")
+            (tmp / "repo").mkdir()
+            args = _install_args(
+                pack="cc-user-hooks",
+                catalogue=str(tmp / "catalogue"),
+                output=str(tmp / "repo"),
+                scope="repo",
+                force_merge=True,
+            )
+            rc, _stdout, stderr = _run_install(args)
+            self.assertEqual(rc, 1)
+            self.assertIn("--force-merge", stderr)
+            self.assertIn("user scope", stderr)
+
+    def test_force_merge_with_pack_default_repo_scope_refuses(self) -> None:
+        """Tests the post-resolve gate — a pack defaulting to repo
+        scope with `--force-merge` (no `--scope`) must also refuse.
+        Synthesise a minimal pack with `default-scope = "repo"`."""
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            pack = tmp / "catalogue" / "packs" / "repo-default"
+            (pack / ".apm" / "skills" / "x").mkdir(parents=True)
+            (pack / ".apm" / "skills" / "x" / "SKILL.md").write_text(
+                "# x\n", encoding="utf-8"
+            )
+            (pack / "pack.toml").write_text(
+                '[pack]\nname = "repo-default"\nversion = "0.1.0"\n\n'
+                '[pack.adapter-contract]\nversion = "0.3"\n\n'
+                '[pack.install]\ndefault-scope = "repo"\n'
+                'allowed-scopes = ["repo"]\n',
+                encoding="utf-8",
+            )
+            (tmp / "repo").mkdir()
+            args = _install_args(
+                pack="repo-default",
+                catalogue=str(tmp / "catalogue"),
+                output=str(tmp / "repo"),
+                scope=None,
+                force_merge=True,
+            )
+            rc, _stdout, stderr = _run_install(args)
+            self.assertEqual(rc, 1)
+            self.assertIn("--force-merge", stderr)
+            self.assertIn("user scope", stderr)
+
+
+class AttachToAgentPathTraversalRefusedTests(_UserScopeInstallBase):
+    """A malicious pack declaring `attach-to-agent = "../../../tmp/escape"`
+    in its wiring TOML must refuse at install time — the resolved
+    target file would otherwise write outside the user-scope jail."""
+
+    def test_dot_dot_in_attach_to_agent_refuses(self) -> None:
+        pack = self.cat / "packs" / "evil-pack"
+        (pack / ".apm" / "agents").mkdir(parents=True)
+        # Ship an agent so the heuristic resolves to Kiro (the
+        # adapter that consumes `attach-to-agent`).
+        (pack / ".apm" / "agents" / "evil.md").write_text(
+            "---\nname: evil\n---\nbody\n", encoding="utf-8"
+        )
+        (pack / ".apm" / "hooks").mkdir(parents=True)
+        (pack / ".apm" / "hooks" / "on-spawn.sh").write_text(
+            "#!/bin/sh\nexit 0\n", encoding="utf-8"
+        )
+        (pack / ".apm" / "hook-wiring").mkdir(parents=True)
+        (pack / ".apm" / "hook-wiring" / "on-spawn.toml").write_text(
+            # Path-traversal payload.
+            'attach-to-agent = "../../../tmp/escape"\n\n'
+            '[[hooks.agentSpawn]]\ncommand = "x"\n',
+            encoding="utf-8",
+        )
+        (pack / "pack.toml").write_text(
+            '[pack]\nname = "evil-pack"\nversion = "0.1.0"\n\n'
+            '[pack.adapter-contract]\nversion = "0.3"\n\n'
+            '[pack.install]\ndefault-scope = "user"\n'
+            'allowed-scopes = ["user"]\nuser-scope-hooks = true\n',
+            encoding="utf-8",
+        )
+        for entry in pack.rglob("*.sh"):
+            entry.chmod(0o755)
+        args = _install_args(
+            pack="evil-pack",
+            catalogue=str(self.cat),
+            output=str(self.repo),
+            scope="user",
+        )
+        rc, _stdout, stderr = _run_install(args)
+        self.assertEqual(rc, 1, "evil pack was accepted")
+        self.assertIn("attach-to-agent", stderr)
+
+
+class RailBStillRefusesPacksWithoutOptInTests(_UserScopeInstallBase):
+    """AC24: A user-scope install of a pack that ships hooks but does
+    NOT declare ``user-scope-hooks = true`` refuses at validate-rail
+    time (Rail B's pre-T3 text)."""
+
+    def test_install_user_scope_without_opt_in_refuses(self) -> None:
+        # Synthesise a pack that ships hooks but lacks the opt-in flag.
+        pack_dir = self.cat / "packs" / "no-opt-in"
+        (pack_dir / ".apm" / "hooks").mkdir(parents=True)
+        (pack_dir / ".apm" / "hooks" / "x.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+        (pack_dir / "pack.toml").write_text(
+            "[pack]\nname = \"no-opt-in\"\nversion = \"0.1.0\"\n"
+            "[pack.adapter-contract]\nversion = \"0.3\"\n"
+            "[pack.install]\ndefault-scope = \"user\"\nallowed-scopes = [\"user\"]\n",
+            encoding="utf-8",
+        )
+        args = _install_args(
+            pack="no-opt-in",
+            catalogue=str(self.cat),
+            output=str(self.repo),
+            scope="user",
+        )
+        rc, _stdout, stderr = _run_install(args)
+        self.assertEqual(rc, 1, f"install accepted no-opt-in pack: stderr={stderr}")
+        self.assertIn("hook-shaped primitives", stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/agentbundle/tests/integration/test_uninstall_user_hooks.py
+++ b/packages/agentbundle/tests/integration/test_uninstall_user_hooks.py
@@ -1,0 +1,268 @@
+"""T8b: uninstall --scope user removes hook-wiring-owned entries from
+the right target file (settings.json for Claude Code, agent JSON for
+Kiro) and leaves the target file otherwise untouched.
+
+Covers spec ACs AC11 (Claude Code uninstall precision) and AC19
+(Kiro uninstall removes wiring but leaves the agent file in place
+until the agent primitive's own uninstall runs).
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+FIXTURES = REPO_ROOT / "packages" / "agentbundle" / "tests" / "fixtures" / "packs"
+
+
+def _run_install(args_namespace) -> int:
+    from agentbundle.commands import install
+
+    with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+        return install.run(args_namespace)
+
+
+def _run_uninstall(args_namespace) -> tuple[int, str]:
+    from agentbundle.commands import uninstall
+
+    stderr = io.StringIO()
+    with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(stderr):
+        rc = uninstall.run(args_namespace)
+    return rc, stderr.getvalue()
+
+
+def _copy_fixture(src: Path, dst: Path) -> None:
+    shutil.copytree(src, dst)
+    for entry in dst.rglob("*.sh"):
+        entry.chmod(0o755)
+
+
+def _install_args(pack: str, catalogue: str, output: str, scope: str | None = None):
+    return argparse.Namespace(
+        pack=pack,
+        catalogue=catalogue,
+        output=output,
+        scope=scope,
+        force=False,
+        force_merge=False,
+    )
+
+
+def _uninstall_args(pack: str, output: str, scope: str | None = None):
+    return argparse.Namespace(
+        pack=pack,
+        root=output,
+        scope=scope,
+    )
+
+
+class _UninstallBase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.home = self.tmp / "home"
+        self.home.mkdir()
+        self.repo = self.tmp / "repo"
+        self.repo.mkdir()
+        self._env = patch.dict(os.environ, {"HOME": str(self.home)})
+        self._env.start()
+        self.addCleanup(self._env.stop)
+        self.cat = self.tmp / "catalogue"
+        (self.cat / "packs").mkdir(parents=True)
+
+
+class CCUserHooksUninstallTests(_UninstallBase):
+    """AC11: uninstall removes only owned entries from the settings
+    file; empty `hooks.<event>` arrays are pruned. Other top-level
+    keys in the settings file must survive."""
+
+    def test_uninstall_removes_owned_settings_entry(self) -> None:
+        _copy_fixture(FIXTURES / "cc-user-hooks", self.cat / "packs" / "cc-user-hooks")
+
+        # Install first.
+        rc = _run_install(_install_args(
+            pack="cc-user-hooks",
+            catalogue=str(self.cat),
+            output=str(self.repo),
+            scope="user",
+        ))
+        self.assertEqual(rc, 0, "setup install failed")
+
+        settings = self.home / ".claude" / "settings.json"
+        data_before = json.loads(settings.read_text(encoding="utf-8"))
+        self.assertIn("UserPromptSubmit", data_before["hooks"])
+
+        # Now uninstall.
+        rc, err = _run_uninstall(_uninstall_args(
+            pack="cc-user-hooks",
+            output=str(self.repo),
+            scope="user",
+        ))
+        self.assertEqual(rc, 0, f"uninstall failed: {err}")
+
+        data_after = json.loads(settings.read_text(encoding="utf-8"))
+        # The pack's owned entry is gone — and the empty event array
+        # is pruned per RFC-0005 § Uninstall.
+        self.assertNotIn(
+            "UserPromptSubmit",
+            data_after.get("hooks", {}),
+            "uninstall left an empty hooks.UserPromptSubmit",
+        )
+
+
+class MultiPackUninstallPrecisionTests(_UninstallBase):
+    """AC11 precision: uninstalling pack A leaves pack B's entries in
+    place at their original positions. Exercises the end-to-end
+    integration (install A → install B → uninstall A → assert B
+    survives unchanged)."""
+
+    def test_uninstalling_first_pack_leaves_second_pack_entries(self) -> None:
+        # Pack A: cc-user-hooks (the fixture).
+        _copy_fixture(FIXTURES / "cc-user-hooks", self.cat / "packs" / "cc-user-hooks")
+        # Pack B: synthesised variant with a different basename so the
+        # ids are unique (`pack-b:on-prompt-b` vs `cc-user-hooks:on-prompt`).
+        pack_b_dir = self.cat / "packs" / "pack-b"
+        (pack_b_dir / ".apm" / "hooks").mkdir(parents=True)
+        (pack_b_dir / ".apm" / "hooks" / "on-prompt-b.sh").write_text(
+            "#!/bin/sh\nexit 0\n", encoding="utf-8"
+        )
+        (pack_b_dir / ".apm" / "hook-wiring").mkdir(parents=True)
+        (pack_b_dir / ".apm" / "hook-wiring" / "on-prompt-b.toml").write_text(
+            '[[hooks.UserPromptSubmit]]\ncommand = "do-b"\nmatcher = ""\n',
+            encoding="utf-8",
+        )
+        (pack_b_dir / "pack.toml").write_text(
+            '[pack]\nname = "pack-b"\nversion = "0.1.0"\n\n'
+            '[pack.adapter-contract]\nversion = "0.3"\n\n'
+            '[pack.install]\ndefault-scope = "user"\n'
+            'allowed-scopes = ["user"]\nuser-scope-hooks = true\n',
+            encoding="utf-8",
+        )
+        for entry in pack_b_dir.rglob("*.sh"):
+            entry.chmod(0o755)
+
+        # Install both.
+        for pack in ("cc-user-hooks", "pack-b"):
+            rc = _run_install(_install_args(
+                pack=pack, catalogue=str(self.cat),
+                output=str(self.repo), scope="user",
+            ))
+            self.assertEqual(rc, 0, f"install of {pack} failed")
+
+        settings = self.home / ".claude" / "settings.json"
+        data = json.loads(settings.read_text(encoding="utf-8"))
+        entries_before = data["hooks"]["UserPromptSubmit"]
+        ids_before = [e["id"] for e in entries_before]
+        self.assertEqual(
+            ids_before,
+            ["cc-user-hooks:on-prompt", "pack-b:on-prompt-b"],
+            "install sequence didn't append in order",
+        )
+
+        # Uninstall pack A.
+        rc, err = _run_uninstall(_uninstall_args(
+            pack="cc-user-hooks", output=str(self.repo), scope="user",
+        ))
+        self.assertEqual(rc, 0, f"uninstall failed: {err}")
+
+        data_after = json.loads(settings.read_text(encoding="utf-8"))
+        entries_after = data_after["hooks"]["UserPromptSubmit"]
+        # Pack B's entry survives at its position.
+        self.assertEqual(len(entries_after), 1)
+        self.assertEqual(entries_after[0]["id"], "pack-b:on-prompt-b")
+        self.assertEqual(entries_after[0]["command"], "do-b")
+
+
+class KiroUserHooksUninstallTests(_UninstallBase):
+    """AC19: uninstall's hook-wiring unprojection removes the owned
+    entries from the agent JSON. The end-to-end uninstall ALSO runs
+    the agent primitive's `direct-file` uninstall which removes the
+    agent file (because `state.files` recorded it as pack-owned).
+    Both behaviors are exercised below — separately."""
+
+    def test_full_uninstall_removes_both_wiring_and_agent_file(self) -> None:
+        """End-to-end: uninstall removes the agent file (direct-file
+        uninstall handles it via `state.files`)."""
+        _copy_fixture(FIXTURES / "kiro-user-hooks", self.cat / "packs" / "kiro-user-hooks")
+
+        rc = _run_install(_install_args(
+            pack="kiro-user-hooks",
+            catalogue=str(self.cat),
+            output=str(self.repo),
+            scope="user",
+        ))
+        self.assertEqual(rc, 0, "setup install failed")
+
+        agent_json = self.home / ".kiro" / "agents" / "reviewer.json"
+        before = json.loads(agent_json.read_text(encoding="utf-8"))
+        self.assertIn("agentSpawn", before["hooks"])
+
+        rc, err = _run_uninstall(_uninstall_args(
+            pack="kiro-user-hooks",
+            output=str(self.repo),
+            scope="user",
+        ))
+        self.assertEqual(rc, 0, f"uninstall failed: {err}")
+        # The pack owns the agent file (`state.files` recorded it).
+        # End-to-end uninstall removes it.
+        self.assertFalse(
+            agent_json.exists(),
+            "agent file survived uninstall — direct-file uninstall should "
+            "have removed it (state.files entry)",
+        )
+
+    def test_wiring_unproject_leaves_adopter_keys_alone(self) -> None:
+        """Wiring-side AC19: unproject removes only the wiring-owned
+        entries. Construct a scenario where the agent file persists
+        after uninstall (synthetic pre-write of an adopter key the
+        pack doesn't own) and assert the adopter key survives.
+        """
+        _copy_fixture(FIXTURES / "kiro-user-hooks", self.cat / "packs" / "kiro-user-hooks")
+
+        rc = _run_install(_install_args(
+            pack="kiro-user-hooks",
+            catalogue=str(self.cat),
+            output=str(self.repo),
+            scope="user",
+        ))
+        self.assertEqual(rc, 0, "setup install failed")
+
+        agent_json = self.home / ".kiro" / "agents" / "reviewer.json"
+        # Adopter hand-edits the projected agent file with a custom
+        # `notes` field. This breaks pack ownership (the SHA no longer
+        # matches state.files), so end-to-end uninstall PRESERVES the
+        # file as Tier-2 — exactly the case where wiring-only unproject
+        # must remove its rows without taking the body with it.
+        data = json.loads(agent_json.read_text(encoding="utf-8"))
+        data["notes"] = "adopter-added"
+        agent_json.write_text(
+            json.dumps(data, indent=2) + "\n", encoding="utf-8",
+        )
+
+        rc, err = _run_uninstall(_uninstall_args(
+            pack="kiro-user-hooks",
+            output=str(self.repo),
+            scope="user",
+        ))
+        self.assertEqual(rc, 0, f"uninstall failed: {err}")
+
+        # File preserved (Tier-2 adopter edit).
+        self.assertTrue(agent_json.exists(), "Tier-2 file removed by uninstall")
+        after = json.loads(agent_json.read_text(encoding="utf-8"))
+        # Wiring entries gone.
+        self.assertNotIn("agentSpawn", after.get("hooks", {}))
+        # Adopter key survived.
+        self.assertEqual(after.get("notes"), "adopter-added")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Wave 7 of the [user-scope-hooks spec](../tree/main/docs/specs/user-scope-hooks/spec.md) — T8b ships the install/uninstall CLI threading that drives the merge engines T5/T6 built, plus the \`--force-merge\` flag. Seventh of thirteen PRs.

This is the biggest single CLI surface in the spec. It bridges the merge engines (Wave 4 / Wave 5) and the build pipeline (Wave 6) into a working end-to-end \`install --scope user\` for both Claude Code and Kiro packs.

## What landed

- **\`--force-merge\` flag** on \`install\`. Verb-aware error rewriting (\`unknown flag for <verb>: --force-merge\` off-verb). Two-stage binding rails (early gate for explicit \`--scope repo\`; post-resolve gate for pack-default-resolves-to-repo). Refused on Kiro-targeted packs.
- **User-scope hook-wiring threading.** New install-time helpers: \`_resolve_user_scope_target_adapter\`, \`_rewrite_user_scope_hook_paths\`, \`_merge_user_scope_hook_wiring\`, \`_adapter_supports_user_scope_hook_wiring\` (AC25 enforcement), \`_adapter_allowed_prefixes_user\` (generalised from the Claude-Code-only helper).
- **Single-writer discipline for Kiro user-scope.** \`_rewrite_user_scope_hook_paths\` strips \`hooks\` from any agent JSON in the user-scope projection; the install-time merge is the sole writer. State.files SHA is refreshed post-merge so Tier-1 ownership check at uninstall still passes.
- **Uninstall hook-wiring unprojection.** New Step 2b reads \`pack_state.hook_wiring_owned\`, dispatches to the right merge engine's \`unproject\` per \`pack_state.adapter\`. Uses adapter-aware \`allowed-prefixes\` so Kiro paths are reachable.
- **Drive-by fixes.**
  - install.py's \`pack_install\` gate was \`version == \"0.2\"\` only; extended to \`(\"0.2\", \"0.3\")\` mirroring T3's validate.py fix. Without this, no v0.3 user-scope install would work.
  - \`scope_rails.check_kiro_wiring\` now also runs at install time (was validate-only) — catches path-traversal \`attach-to-agent\` payloads before any render.

## Acceptance criteria

- [x] **AC11** — uninstall removes only owned entries; empty arrays pruned; multi-pack precision verified end-to-end.
- [x] **AC12** — \`--force-merge\` binding rails (install verb, scope=user, Claude-Code-only).
- [x] **AC19** — Kiro uninstall removes wiring entries without taking adopter keys with it.
- [x] **AC20** — state's \`hook_wiring_owned\` populated with adapter + target-file.
- [x] **AC23** — install --scope user succeeds against working-mode adapters.
- [x] **AC24** — install refuses packs without \`user-scope-hooks = true\` via Rail B.
- [x] **AC25** — refuses when resolved adapter lacks a working user-scope mode.

## Adversarial review

Two rounds. Round 1: 1 Blocker (AC25) + 4 Concerns + 2 Nits. Round 2: 2 Concerns + 3 Nits. All addressed in-PR except the explicitly deferred:

- **Multi-pack Kiro shared-agent hazard** (round-2 Concern #1): two packs declaring the same Kiro agent name would overwrite each other's wiring. Falls outside T8b's single-pack AC scope; documented in \`_resolve_user_scope_target_adapter\`'s docstring; T8c (upgrade reconciliation) or a follow-on RFC will close it.

## Gates

- 512 tests pass, 1 skipped (was 501 pre-wave-7; +11 new tests).
- \`make build-check\` exits 0.
- \`make validate\` exits 0.

## Out of scope

- **T8c** — upgrade reconciliation including \`attach-to-agent\` rename, multi-pack shared-agent ownership.
- **T9** — \`reconcile --scope user\` reporter.
- **T11** — \`agent-spec-cli\` spec amendment.

After this lands, wave 8 = T8c + T9 (both depend on T8b only; can run in parallel). Wave 9 = T11 (final spec amendment).