### PR TITLE
feat(skills): research gate for new-rfc + Prior art in RFC template

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -19,7 +19,7 @@ tool, used often enough to stick — live in
 | ----- | ------------ |
 | [`work-loop`](work-loop/SKILL.md) | The standard plan → execute → verify → review loop for non-trivial work. Start here for any feature, fix, or refactor. |
 | [`new-adr`](new-adr/SKILL.md) | Create a new ADR with the next available number, from the template |
-| [`new-rfc`](new-rfc/SKILL.md) | Create a new RFC with the next available number, from the template |
+| [`new-rfc`](new-rfc/SKILL.md) | Open a new RFC with a research-phase gate (repo + external sweep, recommendations on unresolved questions) before drafting |
 | [`new-spec`](new-spec/SKILL.md) | Scaffold a new spec directory, surface assumptions, then fill `spec.md` and `plan.md` |
 | [`bug-fix`](bug-fix/SKILL.md) | Fix a defect — reproduce → failing test → root cause → minimum fix → root-vs-symptom verify → commit body documents *why* |
 | [`new-package`](new-package/SKILL.md) | Scaffold a new package in `packages/` |

--- a/.claude/skills/new-rfc/SKILL.md
+++ b/.claude/skills/new-rfc/SKILL.md
@@ -6,7 +6,11 @@ dependencies: []
 
 # Skill: new-rfc
 
-Open a new RFC in `docs/rfc/` from the template.
+Open a new RFC in `docs/rfc/` from the template — with a research phase
+before drafting, so reviewers don't get handed bare unresolved questions
+the author hadn't yet looked into. Modeled on `new-spec`'s assumption
+checkpoint, plus a per-question recommendation pass that RFCs need and
+specs don't.
 
 ## When to invoke
 
@@ -35,15 +39,79 @@ push back: a normal PR (or a spec, if it's a feature) is enough.
    `assets/` folder lives next to this `SKILL.md` wherever your IDE
    installed the skill.)
 
-3. Help the user draft the sections. The two sections most often
-   under-developed are:
-   - **Alternatives considered.** Including "do nothing." If the user can't
-     articulate any, the proposal isn't yet honest.
-   - **Drawbacks.** If they say "none", push back. There are always drawbacks.
+3. **Research phase — gated checkpoint.** With the file scaffolded, stop.
+   Don't write a single body sentence yet. The point of an RFC is to weigh
+   a proposal against what's already been tried; bare unresolved questions
+   handed to reviewers are research the author should have done first.
 
-4. Set status to `Draft` until the user is ready to circulate, then `Open`.
+   Emit the findings *in chat* (not into the RFC file — the body is gated
+   below) under the structure shown. Two sweeps and a synthesis pass:
 
-5. Update `docs/rfc/README.md` table.
+   - **Repo sweep.** Grep `docs/CHARTER.md`, `docs/CONVENTIONS.md`,
+     `docs/adr/`, `docs/rfc/`, `docs/specs/`, and `docs/architecture/`
+     for precedent and conflicts — prior decisions the proposal touches,
+     related specs, conventions the proposal would alter. Cite each hit
+     with file path.
+   - **External sweep.** If web search is available (`WebSearch` in
+     Claude Code; the equivalent in other harnesses), look up how
+     comparable projects, languages, or processes have handled this shape
+     of problem (Rust RFCs, PEPs, IETF BCPs, internal RFCs from similar
+     orgs — whatever maps). Cite each source as a markdown link. If web
+     search isn't available, skip this sweep and say so explicitly under
+     the heading rather than producing fabricated citations.
+   - **Recommendations on unresolved questions.** For every question the
+     user's intent raises (from the conversation that triggered this
+     skill — the RFC body is still empty at this stage), surface: the
+     question, what repo precedent suggests, what external prior art
+     suggests, and a recommended answer with one-sentence reasoning.
+
+   Emit the findings under exactly these three headings:
+
+   ```
+   RESEARCH FINDINGS:
+
+   ## Prior art (in repo)
+   - …
+
+   ## Prior art (external)
+   - …
+
+   ## Recommendations on unresolved questions
+   1. **Question.** …
+      - Repo precedent: …
+      - External prior art: …
+      - Recommendation: …
+   ```
+
+   Then **wait for human confirmation, rejection, or revision per
+   recommendation.** Do not write into *any* body section until the user
+   has signed off. The scaffolded headers can stay; the bodies are gated.
+   Recommendations the user accepts fold into the body; ones the user
+   rejects without an alternative, or genuinely defers, stay in
+   `Unresolved questions` — with the author's lean noted. Treat
+   unanswered recommendations as deferred (same destination, lean kept).
+
+4. Draft the body, now informed by the research. Route the findings:
+   repo precedent lands as citations in `Motivation`; external precedent
+   lands in `Prior art`. (The chat block split the two for legibility;
+   the body has a single `Prior art` section.) Sections to push hardest
+   on:
+   - **Motivation.** Cite repo precedent where it argues for or against
+     the proposal.
+   - **Alternatives considered.** Including "do nothing." If the user
+     can't articulate any, the proposal isn't yet honest.
+   - **Prior art.** Land the external-sweep citations here. Empty prior
+     art is a finding (no one has done anything like this) — surface
+     that explicitly rather than leaving the section blank.
+   - **Drawbacks.** If they say "none", push back. There are always
+     drawbacks.
+   - **Unresolved questions.** Each carries the author's lean from the
+     research phase, even if the lean is "punt to reviewers."
+
+5. Set status to `Draft` until the user is ready to circulate, then `Open`.
+
+6. Update `docs/rfc/README.md` table (create the file with the standard
+   header row if absent).
 
 ## After acceptance
 
@@ -55,3 +123,15 @@ concrete next steps — usually:
 - Edits to `docs/CONVENTIONS.md` if the RFC changes conventions.
 
 The RFC itself is then "done" and stays as historical record.
+
+## Anti-patterns to refuse
+
+- Writing into the RFC body before the checkpoint clears → see step 3.
+- Bare unresolved questions with no author lean → if the question
+  hasn't been searched against repo + external prior art, the research
+  phase wasn't done. Send it back.
+- Empty `Prior art` while web search was available and comparable
+  processes plainly exist → the external sweep produces this section;
+  "we didn't look" isn't an answer. When web search *wasn't*
+  available, the section can be empty — but say so explicitly under
+  the heading and never fabricate citations to fill it.

--- a/.claude/skills/new-rfc/assets/rfc.md
+++ b/.claude/skills/new-rfc/assets/rfc.md
@@ -53,11 +53,29 @@ giving up?
 If you can't think of any drawbacks, the proposal isn't yet honest.
 -->
 
+## Prior art
+
+<!--
+What other projects, languages, or processes have tackled the same shape of
+problem? What worked, what didn't, what should we learn?
+
+Land prior-art citations here — both from this repo (related ADRs, RFCs,
+specs) and from external precedent. "We considered X and it's a poor fit
+because Y" beats unsourced assertion.
+
+Empty prior art is itself a signal — no one has tried this — but call it
+out rather than leaving the section blank.
+-->
+
 ## Unresolved questions
 
 <!--
 What did you punt on? What are you hoping reviewers will weigh in on? Listing
 these explicitly focuses the discussion.
+
+Each question should carry the author's lean — even if the lean is "punt to
+reviewers." A bare question with no author position means the homework
+wasn't done.
 -->
 
 ## Follow-on artifacts

--- a/packs/governance-extras/.apm/skills/new-rfc/SKILL.md
+++ b/packs/governance-extras/.apm/skills/new-rfc/SKILL.md
@@ -6,7 +6,11 @@ dependencies: []
 
 # Skill: new-rfc
 
-Open a new RFC in `docs/rfc/` from the template.
+Open a new RFC in `docs/rfc/` from the template — with a research phase
+before drafting, so reviewers don't get handed bare unresolved questions
+the author hadn't yet looked into. Modeled on `new-spec`'s assumption
+checkpoint, plus a per-question recommendation pass that RFCs need and
+specs don't.
 
 ## When to invoke
 
@@ -35,15 +39,79 @@ push back: a normal PR (or a spec, if it's a feature) is enough.
    `assets/` folder lives next to this `SKILL.md` wherever your IDE
    installed the skill.)
 
-3. Help the user draft the sections. The two sections most often
-   under-developed are:
-   - **Alternatives considered.** Including "do nothing." If the user can't
-     articulate any, the proposal isn't yet honest.
-   - **Drawbacks.** If they say "none", push back. There are always drawbacks.
+3. **Research phase — gated checkpoint.** With the file scaffolded, stop.
+   Don't write a single body sentence yet. The point of an RFC is to weigh
+   a proposal against what's already been tried; bare unresolved questions
+   handed to reviewers are research the author should have done first.
 
-4. Set status to `Draft` until the user is ready to circulate, then `Open`.
+   Emit the findings *in chat* (not into the RFC file — the body is gated
+   below) under the structure shown. Two sweeps and a synthesis pass:
 
-5. Update `docs/rfc/README.md` table.
+   - **Repo sweep.** Grep `docs/CHARTER.md`, `docs/CONVENTIONS.md`,
+     `docs/adr/`, `docs/rfc/`, `docs/specs/`, and `docs/architecture/`
+     for precedent and conflicts — prior decisions the proposal touches,
+     related specs, conventions the proposal would alter. Cite each hit
+     with file path.
+   - **External sweep.** If web search is available (`WebSearch` in
+     Claude Code; the equivalent in other harnesses), look up how
+     comparable projects, languages, or processes have handled this shape
+     of problem (Rust RFCs, PEPs, IETF BCPs, internal RFCs from similar
+     orgs — whatever maps). Cite each source as a markdown link. If web
+     search isn't available, skip this sweep and say so explicitly under
+     the heading rather than producing fabricated citations.
+   - **Recommendations on unresolved questions.** For every question the
+     user's intent raises (from the conversation that triggered this
+     skill — the RFC body is still empty at this stage), surface: the
+     question, what repo precedent suggests, what external prior art
+     suggests, and a recommended answer with one-sentence reasoning.
+
+   Emit the findings under exactly these three headings:
+
+   ```
+   RESEARCH FINDINGS:
+
+   ## Prior art (in repo)
+   - …
+
+   ## Prior art (external)
+   - …
+
+   ## Recommendations on unresolved questions
+   1. **Question.** …
+      - Repo precedent: …
+      - External prior art: …
+      - Recommendation: …
+   ```
+
+   Then **wait for human confirmation, rejection, or revision per
+   recommendation.** Do not write into *any* body section until the user
+   has signed off. The scaffolded headers can stay; the bodies are gated.
+   Recommendations the user accepts fold into the body; ones the user
+   rejects without an alternative, or genuinely defers, stay in
+   `Unresolved questions` — with the author's lean noted. Treat
+   unanswered recommendations as deferred (same destination, lean kept).
+
+4. Draft the body, now informed by the research. Route the findings:
+   repo precedent lands as citations in `Motivation`; external precedent
+   lands in `Prior art`. (The chat block split the two for legibility;
+   the body has a single `Prior art` section.) Sections to push hardest
+   on:
+   - **Motivation.** Cite repo precedent where it argues for or against
+     the proposal.
+   - **Alternatives considered.** Including "do nothing." If the user
+     can't articulate any, the proposal isn't yet honest.
+   - **Prior art.** Land the external-sweep citations here. Empty prior
+     art is a finding (no one has done anything like this) — surface
+     that explicitly rather than leaving the section blank.
+   - **Drawbacks.** If they say "none", push back. There are always
+     drawbacks.
+   - **Unresolved questions.** Each carries the author's lean from the
+     research phase, even if the lean is "punt to reviewers."
+
+5. Set status to `Draft` until the user is ready to circulate, then `Open`.
+
+6. Update `docs/rfc/README.md` table (create the file with the standard
+   header row if absent).
 
 ## After acceptance
 
@@ -55,3 +123,15 @@ concrete next steps — usually:
 - Edits to `docs/CONVENTIONS.md` if the RFC changes conventions.
 
 The RFC itself is then "done" and stays as historical record.
+
+## Anti-patterns to refuse
+
+- Writing into the RFC body before the checkpoint clears → see step 3.
+- Bare unresolved questions with no author lean → if the question
+  hasn't been searched against repo + external prior art, the research
+  phase wasn't done. Send it back.
+- Empty `Prior art` while web search was available and comparable
+  processes plainly exist → the external sweep produces this section;
+  "we didn't look" isn't an answer. When web search *wasn't*
+  available, the section can be empty — but say so explicitly under
+  the heading and never fabricate citations to fill it.

--- a/packs/governance-extras/.apm/skills/new-rfc/assets/rfc.md
+++ b/packs/governance-extras/.apm/skills/new-rfc/assets/rfc.md
@@ -53,11 +53,29 @@ giving up?
 If you can't think of any drawbacks, the proposal isn't yet honest.
 -->
 
+## Prior art
+
+<!--
+What other projects, languages, or processes have tackled the same shape of
+problem? What worked, what didn't, what should we learn?
+
+Land prior-art citations here — both from this repo (related ADRs, RFCs,
+specs) and from external precedent. "We considered X and it's a poor fit
+because Y" beats unsourced assertion.
+
+Empty prior art is itself a signal — no one has tried this — but call it
+out rather than leaving the section blank.
+-->
+
 ## Unresolved questions
 
 <!--
 What did you punt on? What are you hoping reviewers will weigh in on? Listing
 these explicitly focuses the discussion.
+
+Each question should carry the author's lean — even if the lean is "punt to
+reviewers." A bare question with no author position means the homework
+wasn't done.
 -->
 
 ## Follow-on artifacts


### PR DESCRIPTION
## Summary

- `new-rfc` skill gains a **Research phase — gated checkpoint** between scaffolding and drafting. Modeled on `new-spec`'s assumption-checkpoint pattern, plus a per-question recommendation pass that RFCs need and specs don't. The agent runs two sweeps (repo + external) and a synthesis pass, then emits `RESEARCH FINDINGS:` *in chat* for human sign-off before any RFC body section fills in.
- `rfc.md` template (in the new `.claude/skills/new-rfc/assets/` location post-#48) gains a **Prior art** section between Drawbacks and Unresolved questions, and Unresolved questions now requires the author's lean.
- `.claude/skills/README.md` index entry updated to describe the gate.
- Pack mirror at `packs/governance-extras/.apm/skills/new-rfc/` synced; `agentbundle self --dry-run` reports no drift.

## Rationale

Prior RFCs (0001–0006) shipped without this gate; the existing skill handed reviewers bare unresolved questions instead of doing the prior-art and repo-precedent work first. The adversarial reviewer flagged a fair "three-times rule" question on whether this discipline is preemptive scaffolding — the answer is that every existing RFC's _Unresolved questions_ and _Alternatives considered_ sections would have been stronger with the research-phase output in hand, and the convention-change criterion in *When to invoke* (line 22) makes the omission of `CHARTER.md`/`CONVENTIONS.md` from the sweep an obvious gap going forward.

Aligns with the project's discipline parity: `new-spec` already has its assumption-list checkpoint at the earlier lifecycle stage; this is the RFC-stage analogue.

## Work-loop trace

- PLAN: trio + 5-item declined-pattern register.
- EXECUTE → GATES: `tools/lint-agent-artifacts.sh` ✓, `tools/lint-skill-deps.sh` ✓.
- REVIEW: `adversarial-reviewer` ran 4 iterations; findings shrank 1B+6C+1N → 0B+2C+2N → 0B+1C+3N → clean. One nit declined with rationale (cross-skill consistency with `new-adr`).
- Specialist reviewers skipped — no security boundary, no engineering surface.
- Post-rebase against #48 (template relocation) and #49 (wave7): regenerated step-2 wording for skill-relative paths, dropped frontmatter dep, synced pack mirror.

## Test plan

- [x] `bash tools/lint-agent-artifacts.sh` — passed
- [x] `bash tools/lint-skill-deps.sh` — passed
- [x] `python3 -m agentbundle.build self --dry-run --packs-dir packs` — no drift
- [ ] Spot-check: invoke `new-rfc` on a fresh proposal and confirm the agent emits `RESEARCH FINDINGS:` in chat before touching the file body