### PR TITLE
feat(wave8): upgrade reconciliation + reconcile reporter (T8c + T9)

### DIFF
--- a/docs/specs/user-scope-hooks/plan.md
+++ b/docs/specs/user-scope-hooks/plan.md
@@ -536,8 +536,9 @@ clean after each.
 **Approach:**
 
 - New module
-  `packages/agentbundle/agentbundle/cli_reconcile.py` (or extend
-  `cli.py`).
+  `packages/agentbundle/agentbundle/commands/reconcile.py` (matches
+  the existing per-command layout under `commands/`; the subcommand
+  is registered in `cli.py`).
 - Tests under
   `packages/agentbundle/tests/integration/test_reconcile.py`.
 

--- a/packages/agentbundle/agentbundle/cli.py
+++ b/packages/agentbundle/agentbundle/cli.py
@@ -304,6 +304,21 @@ def _build_parser() -> argparse.ArgumentParser:
     sp.add_argument("--scope", choices=("repo", "user"))
     sp.set_defaults(func=_lazy("init_state"))
 
+    # --- reconcile --- (read-only orphan reporter, RFC-0005 / T9)
+    # No --apply flag — the subcommand is report-only by design.
+    # `argparse`'s default "unrecognized argument" rejects --apply.
+    sp = subparsers.add_parser(
+        "reconcile",
+        help=(
+            "RFC-0005: read-only orphan reporter — walks Claude Code "
+            "settings.json and Kiro agent JSONs named in user-scope state, "
+            "reports entries the file/state pair disagrees on. Read-only; "
+            "no --apply flag."
+        ),
+    )
+    sp.add_argument("--scope", choices=("user",), default="user")
+    sp.set_defaults(func=_lazy("reconcile"))
+
     return parser
 
 

--- a/packages/agentbundle/agentbundle/commands/install.py
+++ b/packages/agentbundle/agentbundle/commands/install.py
@@ -592,23 +592,14 @@ def run(args: "argparse.Namespace") -> int:
                     new_pack_state.adapter = "kiro"
 
                 # The merge phase re-wrote the agent JSON (Kiro) with
-                # the hook entries we just merged in; for Claude Code,
-                # the settings.json target is adopter-shared and isn't
-                # tracked in state.files at all. Refresh the on-disk
-                # SHA for any merged target that *is* in state.files
-                # so uninstall's Tier-1 check (recorded SHA == on-disk
-                # SHA) still passes after the merge.
-                for row in owned_rows:
-                    target_file_rel = row.get("target-file")
-                    if not target_file_rel:
-                        continue
-                    target_path = plan.root / target_file_rel.lstrip("/")
-                    if not target_path.exists():
-                        continue
-                    if target_file_rel in new_pack_state.files:
-                        new_pack_state.files[target_file_rel]["sha"] = (
-                            safety.sha256_file(target_path)
-                        )
+                # the hook entries we just merged in. Refresh the
+                # state.files SHA so uninstall's Tier-1 check still
+                # passes — see ``_refresh_merge_target_shas``.
+                _refresh_merge_target_shas(
+                    pack_state=new_pack_state,
+                    owned_rows=owned_rows,
+                    root=plan.root,
+                )
 
         plan.state.packs[pack_name] = new_pack_state
         # Stamp the post-write schema. Always emit the current
@@ -1124,6 +1115,39 @@ def _render_for_user_scope(pack_dir: Path) -> dict[str, bytes]:
         else:
             claude_code.project(pack_dir, contract, out)
         return _collect_tree(out)
+
+
+def _refresh_merge_target_shas(
+    *,
+    pack_state,
+    owned_rows: list[dict[str, str]],
+    root: Path,
+) -> None:
+    """Refresh state.files SHA for every merge target the wiring touched.
+
+    The merge phase (user_merge_json / merge_into_agent_json) mutates
+    the target file after the projection-write loop recorded its
+    pre-merge SHA. Without this refresh, uninstall's Tier-1 check
+    (recorded SHA == on-disk SHA) would misclassify the file as
+    adopter-edited and refuse to remove it. Claude Code rows omit
+    ``target-file`` (the adapter-shared ``~/.claude/settings.json``
+    isn't tracked in state.files); Kiro rows carry it explicitly.
+
+    Shared between install and upgrade so the fix is single-sourced.
+    """
+    from agentbundle import safety
+
+    for row in owned_rows:
+        target_file_rel = row.get("target-file")
+        if not target_file_rel:
+            continue
+        target_path = root / target_file_rel.lstrip("/")
+        if not target_path.exists():
+            continue
+        if target_file_rel in pack_state.files:
+            pack_state.files[target_file_rel]["sha"] = (
+                safety.sha256_file(target_path)
+            )
 
 
 def _adapter_supports_user_scope_hook_wiring(adapter_name: str) -> bool:

--- a/packages/agentbundle/agentbundle/commands/reconcile.py
+++ b/packages/agentbundle/agentbundle/commands/reconcile.py
@@ -1,0 +1,161 @@
+"""``agentbundle reconcile`` — read-only orphan reporter.
+
+Per RFC-0005 § Follow-on artifacts and AC26: walks the Claude Code
+settings file (``~/.claude/settings.json``) and every Kiro agent JSON
+named in user-scope state, comparing the on-disk ``hooks.<event>``
+arrays against the state file's ``hook-wiring-owned`` rows to surface
+two classes of orphan:
+
+  - **orphan-in-file** — the target file claims an id-tagged entry the
+    state file doesn't know about. Surfaces when a hand-edit on the
+    settings file (or on a Kiro agent JSON) adds an entry with an id
+    that no installed pack owns.
+  - **orphan-in-state** — the state file claims ownership of an entry
+    the target file doesn't have. Surfaces when the adopter
+    hand-deletes an entry without uninstalling the pack, or when
+    multi-machine sync moves a state row without its corresponding
+    target-file content.
+
+Output is grouped by adapter (one heading per adapter that has any
+orphans, plus an "all clean" line when there are none). The
+subcommand is **read-only**: it does not register an ``--apply`` flag.
+A write-mode reconciler would re-create the merge-discipline problems
+RFC-0005 is designed to avoid; the adopter takes manual action from
+this report.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import argparse
+
+
+def run(args: "argparse.Namespace") -> int:
+    """Entry point for ``agentbundle reconcile``.
+
+    The only supported scope today is ``user`` (RFC-0005's report
+    surface). A future RFC may extend to repo scope; ``--scope``
+    is accepted with that single value for now.
+    """
+    from agentbundle import scope as scope_mod
+    from agentbundle.config import ConfigError, load_state
+
+    cli_scope: str | None = getattr(args, "scope", None)
+    if cli_scope != "user":
+        print(
+            "reconcile: only --scope user is supported today",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        user_root = scope_mod.resolve_user_root()
+    except scope_mod.UserScopeUnresolvable:
+        print(
+            "reconcile: cannot resolve user scope: $HOME unset or invalid",
+            file=sys.stderr,
+        )
+        return 1
+
+    state_path = user_root / ".agent-ready" / "state.toml"
+    if not state_path.exists():
+        # An absent state file means no installs at user scope; no
+        # orphans to report against. Cleanly exit 0 with the all-clean
+        # line so wrapper scripts can short-circuit.
+        print("reconcile: all clean (no user-scope state)")
+        return 0
+
+    try:
+        state = load_state(state_path)
+    except ConfigError as exc:
+        print(f"reconcile: {exc}", file=sys.stderr)
+        return 1
+
+    orphans_by_adapter = _collect_orphans(state, user_root)
+    return _print_report(orphans_by_adapter)
+
+
+def _collect_orphans(state, user_root: Path) -> dict[str, list[str]]:
+    """Walk the target files referenced by state and compute orphans.
+
+    Returns a dict of adapter name → list of orphan lines (each line
+    a human-readable description suitable for direct print).
+    """
+    # Group state's hook-wiring-owned rows by (adapter, target-file)
+    # so we read each target file exactly once. The default target for
+    # claude-code rows is ``~/.claude/settings.json``; kiro rows always
+    # carry an explicit ``target-file``.
+    grouped: dict[tuple[str, str], set[tuple[str, str]]] = {}
+    for pack_name, pack_state in state.packs.items():
+        if pack_state.scope != "user":
+            continue
+        adapter = pack_state.adapter or "claude-code"
+        for row in pack_state.hook_wiring_owned:
+            event = row.get("event")
+            entry_id = row.get("id")
+            if not (isinstance(event, str) and isinstance(entry_id, str)):
+                continue
+            target_rel = row.get("target-file")
+            if not target_rel:
+                target_rel = (
+                    ".claude/settings.json" if adapter == "claude-code" else ""
+                )
+            if not target_rel:
+                continue
+            grouped.setdefault((adapter, target_rel), set()).add((event, entry_id))
+
+    orphans_by_adapter: dict[str, list[str]] = {}
+    for (adapter, target_rel), owned_pairs in grouped.items():
+        target_path = user_root / target_rel.lstrip("/")
+        file_pairs: set[tuple[str, str]] = set()
+        if target_path.exists():
+            try:
+                data = json.loads(target_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError) as exc:
+                orphans_by_adapter.setdefault(adapter, []).append(
+                    f"  unparseable target {target_rel}: {exc}"
+                )
+                continue
+            if isinstance(data, dict):
+                hooks = data.get("hooks", {})
+                if isinstance(hooks, dict):
+                    for event, entries in hooks.items():
+                        if not isinstance(entries, list):
+                            continue
+                        for entry in entries:
+                            if isinstance(entry, dict) and isinstance(entry.get("id"), str):
+                                file_pairs.add((event, entry["id"]))
+
+        # orphan-in-file: present in file, absent from state.
+        for event, entry_id in sorted(file_pairs - owned_pairs):
+            orphans_by_adapter.setdefault(adapter, []).append(
+                f"  orphan-in-file: {target_rel} carries (event={event}, id={entry_id}) "
+                f"but no installed pack owns it"
+            )
+        # orphan-in-state: present in state, absent from file.
+        for event, entry_id in sorted(owned_pairs - file_pairs):
+            orphans_by_adapter.setdefault(adapter, []).append(
+                f"  orphan-in-state: state records ownership of (event={event}, "
+                f"id={entry_id}) in {target_rel} but the entry is missing on disk"
+            )
+
+    return orphans_by_adapter
+
+
+def _print_report(orphans_by_adapter: dict[str, list[str]]) -> int:
+    if not orphans_by_adapter:
+        print("reconcile: all clean")
+        return 0
+    for adapter in sorted(orphans_by_adapter.keys()):
+        lines = orphans_by_adapter[adapter]
+        if not lines:
+            continue
+        print(f"reconcile: {adapter}")
+        for line in lines:
+            print(line)
+    return 0

--- a/packages/agentbundle/agentbundle/commands/upgrade.py
+++ b/packages/agentbundle/agentbundle/commands/upgrade.py
@@ -122,9 +122,16 @@ def run(args: "argparse.Namespace") -> int:
             return 1
         root = user_state_path.parent.parent
         effective_scope = "user"
-        from agentbundle.commands.install import _claude_code_allowed_prefixes_user
+        from agentbundle.commands.install import _adapter_allowed_prefixes_user
 
-        user_prefixes = _claude_code_allowed_prefixes_user()
+        # Use the recorded adapter from state so Kiro-installed packs
+        # get .kiro/ prefixes, not Claude Code's .claude/ prefixes.
+        recorded_adapter = (
+            user_state_for_check.packs[pack_name].adapter
+            if pack_name in user_state_for_check.packs
+            else "claude-code"
+        ) or "claude-code"
+        user_prefixes = _adapter_allowed_prefixes_user(recorded_adapter)
 
     # ── Detect per-primitive flag ─────────────────────────────────────────────
     prim_flag: str | None = None
@@ -206,9 +213,24 @@ def run(args: "argparse.Namespace") -> int:
     # state's `.claude/...` paths. Mirrors `install._render_for_user_scope`.
     try:
         if effective_scope == "user":
-            from agentbundle.commands.install import _render_for_user_scope
+            from agentbundle.commands.install import (
+                _render_for_user_scope,
+                _resolve_user_scope_target_adapter,
+                _rewrite_user_scope_hook_paths,
+            )
 
             projection = _render_for_user_scope(pack_dir)
+            # Mirror install: rewrite v0.2 hook-body paths to the v0.3
+            # user-scope shape (`.claude/hooks/<pack>/` or
+            # `.kiro/hooks/<pack>/`) and drop the v0.2 settings.local.json
+            # target. Without this, the path-jail probe refuses
+            # `tools/hooks/<name>.sh` at user scope.
+            _new_target_adapter = _resolve_user_scope_target_adapter(pack_dir)
+            projection = _rewrite_user_scope_hook_paths(
+                projection,
+                pack_name=pack_name,
+                target_adapter=_new_target_adapter,
+            )
         else:
             projection = render_pack(pack_dir)
     except (FileNotFoundError, ValueError) as exc:
@@ -271,6 +293,74 @@ def run(args: "argparse.Namespace") -> int:
                 "from-pack-version": to_version,
             }
 
+    # ── Hook-wiring reconciliation (RFC-0005 T8c, user-scope only) ───────────
+    # Compute the symmetric difference between old state's
+    # ``hook_wiring_owned`` and the new pack's wiring TOMLs. The
+    # ``attach-to-agent`` rename case (Kiro) lands here: rows whose
+    # target-file changes between versions get dropped from the OLD
+    # target file and added to the NEW one. In-place upgrades
+    # (identical wiring) are a no-op; adds and removes shift state
+    # rows accordingly.
+    if effective_scope == "user" and not is_per_primitive:
+        from agentbundle.commands.install import (
+            _merge_user_scope_hook_wiring,
+            _refresh_merge_target_shas,
+            _resolve_user_scope_target_adapter,
+        )
+
+        new_target_adapter = _resolve_user_scope_target_adapter(pack_dir)
+        old_adapter_recorded = pack_state.adapter or "claude-code"
+
+        # Concern #3: cross-adapter upgrades are out of scope. AC19b
+        # covers attach-to-agent renames *within Kiro*, not Kiro→CC
+        # or CC→Kiro. Refuse with a refuse-and-explain shape; the
+        # operator uninstalls + reinstalls instead.
+        if old_adapter_recorded != new_target_adapter:
+            print(
+                f"upgrade: pack adapter changed from "
+                f"{old_adapter_recorded!r} → {new_target_adapter!r} "
+                f"between versions; run uninstall + install instead "
+                f"(cross-adapter upgrade is not supported)",
+                file=sys.stderr,
+            )
+            return 1
+
+        try:
+            new_owned = _compute_new_wiring_rows(pack_dir, pack_name, new_target_adapter)
+            old_owned = list(pack_state.hook_wiring_owned)
+            # Step A: unproject rows in old that aren't in new.
+            _unproject_removed_rows(
+                root=root,
+                old_owned=old_owned,
+                new_owned=new_owned,
+                old_adapter=old_adapter_recorded,
+            )
+            # Step B: project the new pack's wiring against new targets.
+            # The merger is idempotent for unchanged rows (replace-in-
+            # place by id); for added rows it appends.
+            new_rows = _merge_user_scope_hook_wiring(
+                pack_dir=pack_dir,
+                pack_name=pack_name,
+                target_adapter=new_target_adapter,
+                install_root=root,
+                force_merge=False,
+            )
+            pack_state.hook_wiring_owned = new_rows
+            pack_state.adapter = (
+                new_target_adapter if new_target_adapter == "kiro" else "claude-code"
+            )
+            # Blocker #1: refresh state.files SHA for the agent JSON the
+            # merge phase rewrote. Without this, post-upgrade uninstall
+            # would misclassify it as Tier-2 and refuse to remove it.
+            _refresh_merge_target_shas(
+                pack_state=pack_state,
+                owned_rows=new_rows,
+                root=root,
+            )
+        except Exception as exc:
+            print(f"upgrade: hook-wiring reconciliation failed: {exc}", file=sys.stderr)
+            return 1
+
     # ── Update state ──────────────────────────────────────────────────────────
     if is_per_primitive:
         # Record per-primitive version override; leave installed_version alone.
@@ -299,6 +389,118 @@ def run(args: "argparse.Namespace") -> int:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _compute_new_wiring_rows(
+    pack_dir: Path,
+    pack_name: str,
+    target_adapter: str,
+) -> list[dict[str, str]]:
+    """Parse the new pack's `.apm/hook-wiring/*.toml` files and
+    compute the ``hook-wiring-owned`` rows the upgraded state would
+    carry — without writing anything yet. The actual writes come from
+    `_unproject_removed_rows` (removes rows present in old, absent
+    from new) followed by an idempotent re-call to
+    `_merge_user_scope_hook_wiring` (lays down the new row set).
+
+    The id synthesis matches T5/T6's: `<pack-name>:<basename>` per
+    wiring TOML. Claude Code rows omit `target-file` (defaulted to
+    `~/.claude/settings.json`); Kiro rows carry it explicitly with
+    `.kiro/agents/<attach-to-agent>.json`.
+    """
+    import re
+    import tomllib
+    from agentbundle.build.projections.hook_id import synthesize_id
+
+    # Same grammar `install._merge_user_scope_hook_wiring` enforces.
+    # Validating here ensures a malformed `attach-to-agent` cannot
+    # corrupt the symmetric-diff computation (e.g. a path-traversal
+    # payload producing a phantom "removal" that we'd then unproject
+    # against the old target file).
+    _AGENT_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+    wiring_dir = pack_dir / ".apm" / "hook-wiring"
+    if not wiring_dir.exists():
+        return []
+    rows: list[dict[str, str]] = []
+    for entry in sorted(wiring_dir.iterdir()):
+        if not (entry.is_file() and entry.suffix == ".toml"):
+            continue
+        # Don't silently swallow TOMLDecodeError — the merger raises
+        # on the same file, so the asymmetry would let step A unproject
+        # entries the merger will then refuse to re-project. Propagate.
+        try:
+            body = tomllib.loads(entry.read_text(encoding="utf-8"))
+        except tomllib.TOMLDecodeError as exc:
+            raise RuntimeError(
+                f"upgrade: pack {pack_name}'s hook-wiring {entry.stem}.toml "
+                f"failed to parse: {exc}"
+            ) from exc
+        entry_id = synthesize_id(pack_name, entry.stem)
+        hooks_in_wiring = body.get("hooks", {}) if isinstance(body, dict) else {}
+        if not isinstance(hooks_in_wiring, dict):
+            continue
+        attach = body.get("attach-to-agent") if isinstance(body, dict) else None
+        # Grammar guard for Kiro: refuse anything that would corrupt
+        # `target_file_rel` (path-traversal, special chars, …).
+        if target_adapter == "kiro" and isinstance(attach, str):
+            if not _AGENT_NAME_RE.fullmatch(attach):
+                raise RuntimeError(
+                    f"upgrade: pack {pack_name}'s hook-wiring {entry.stem}.toml "
+                    f"declares attach-to-agent={attach!r} which violates the "
+                    f"agent-name grammar ^[a-z0-9][a-z0-9-]*$ — refusing"
+                )
+        for event, incoming in hooks_in_wiring.items():
+            if not isinstance(incoming, list):
+                continue
+            row: dict[str, str] = {"event": event, "id": entry_id}
+            if target_adapter == "kiro" and isinstance(attach, str):
+                row["target-file"] = f".kiro/agents/{attach}.json"
+            rows.append(row)
+    return rows
+
+
+def _unproject_removed_rows(
+    *,
+    root: Path,
+    old_owned: list[dict[str, str]],
+    new_owned: list[dict[str, str]],
+    old_adapter: str,
+) -> None:
+    """Unproject rows present in *old_owned* but absent from *new_owned*.
+
+    A row's "presence" is the (event, id, target-file) triple — so an
+    ``attach-to-agent`` rename (Kiro: same id, same event, different
+    target-file) counts as a removal at the OLD target-file. The
+    install-time merge step (caller's Step B) will subsequently
+    project the same row at the NEW target-file.
+
+    Walks the OLD adapter for dispatch (Claude Code vs Kiro). Claude
+    Code rows default ``target-file`` to ``.claude/settings.json`` per
+    RFC-0005 § State-file impact.
+    """
+    def _key(row: dict[str, str]) -> tuple[str, str, str]:
+        return (row.get("event", ""), row.get("id", ""), row.get("target-file", ""))
+
+    new_keys = {_key(r) for r in new_owned}
+    removed = [r for r in old_owned if _key(r) not in new_keys]
+
+    removed_by_target: dict[str, list[tuple[str, str]]] = {}
+    for r in removed:
+        target = r.get("target-file") or (
+            ".claude/settings.json" if old_adapter == "claude-code" else ""
+        )
+        if not target:
+            continue
+        removed_by_target.setdefault(target, []).append((r["event"], r["id"]))
+
+    for target_rel, pairs in removed_by_target.items():
+        target_path = root / target_rel.lstrip("/")
+        if old_adapter == "kiro":
+            from agentbundle.build.projections.merge_into_agent_json import unproject
+        else:
+            from agentbundle.build.projections.user_merge_json import unproject
+        unproject(target_path, pairs)
 
 
 def _locate_pack(catalogue_dir: Path, pack_name: str) -> Path | None:

--- a/packages/agentbundle/tests/integration/test_reconcile.py
+++ b/packages/agentbundle/tests/integration/test_reconcile.py
@@ -1,0 +1,222 @@
+"""T9: `agentbundle reconcile --scope user` — read-only orphan reporter.
+
+Covers spec AC26: walks both adapters' target files, reports
+orphan-in-file (target claims own, state doesn't know) and
+orphan-in-state (state claims own, file doesn't have), groups output
+by adapter, and crucially **never writes**. The subcommand does not
+register an ``--apply`` flag.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+FIXTURES = REPO_ROOT / "packages" / "agentbundle" / "tests" / "fixtures" / "packs"
+
+
+def _run_reconcile(scope: str = "user") -> tuple[int, str, str]:
+    from agentbundle.commands import reconcile
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        rc = reconcile.run(argparse.Namespace(scope=scope))
+    return rc, stdout.getvalue(), stderr.getvalue()
+
+
+def _run_install(args: argparse.Namespace) -> int:
+    from agentbundle.commands import install
+
+    with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+        return install.run(args)
+
+
+def _install_args(pack: str, catalogue: str, output: str, scope: str = "user"):
+    return argparse.Namespace(
+        pack=pack, catalogue=catalogue, output=output,
+        scope=scope, force=False, force_merge=False,
+    )
+
+
+def _copy_fixture(src: Path, dst: Path) -> None:
+    shutil.copytree(src, dst)
+    for entry in dst.rglob("*.sh"):
+        entry.chmod(0o755)
+
+
+class _ReconcileBase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.home = self.tmp / "home"
+        self.home.mkdir()
+        self.repo = self.tmp / "repo"
+        self.repo.mkdir()
+        self._env = patch.dict(os.environ, {"HOME": str(self.home)})
+        self._env.start()
+        self.addCleanup(self._env.stop)
+        self.cat = self.tmp / "catalogue"
+        (self.cat / "packs").mkdir(parents=True)
+
+
+class CleanInstallReportsNoOrphansTests(_ReconcileBase):
+    """AC26 empty case: a clean install produces an 'all clean' line."""
+
+    def test_clean_install_reports_all_clean(self) -> None:
+        _copy_fixture(FIXTURES / "cc-user-hooks", self.cat / "packs" / "cc-user-hooks")
+        rc = _run_install(_install_args(
+            "cc-user-hooks", str(self.cat), str(self.repo)
+        ))
+        self.assertEqual(rc, 0, "install failed")
+
+        rc, stdout, _err = _run_reconcile()
+        self.assertEqual(rc, 0)
+        self.assertIn("all clean", stdout)
+
+    def test_no_state_reports_all_clean(self) -> None:
+        """An absent state file is the same as no installs — no orphans."""
+        rc, stdout, _err = _run_reconcile()
+        self.assertEqual(rc, 0)
+        self.assertIn("all clean", stdout)
+
+
+class OrphanInFileTests(_ReconcileBase):
+    """AC26 type A: an id-tagged entry the file claims, that no
+    installed pack owns. Surfaces under the adapter heading."""
+
+    def test_synthetic_settings_entry_reported(self) -> None:
+        _copy_fixture(FIXTURES / "cc-user-hooks", self.cat / "packs" / "cc-user-hooks")
+        rc = _run_install(_install_args(
+            "cc-user-hooks", str(self.cat), str(self.repo)
+        ))
+        self.assertEqual(rc, 0)
+
+        settings = self.home / ".claude" / "settings.json"
+        data = json.loads(settings.read_text(encoding="utf-8"))
+        # Inject a synthetic id-tagged entry no pack owns.
+        data["hooks"].setdefault("SessionStart", []).append(
+            {"id": "ghost-pack:session", "command": "echo hi"}
+        )
+        settings.write_text(
+            json.dumps(data, indent=2) + "\n", encoding="utf-8"
+        )
+
+        rc, stdout, _err = _run_reconcile()
+        self.assertEqual(rc, 0)
+        self.assertIn("claude-code", stdout)
+        self.assertIn("orphan-in-file", stdout)
+        self.assertIn("ghost-pack:session", stdout)
+        self.assertIn("SessionStart", stdout)
+
+
+class OrphanInStateTests(_ReconcileBase):
+    """AC26 type B: state records ownership of an entry the target
+    file doesn't have. Surfaces under the adapter heading."""
+
+    def test_hand_deleted_entry_reported(self) -> None:
+        _copy_fixture(FIXTURES / "cc-user-hooks", self.cat / "packs" / "cc-user-hooks")
+        rc = _run_install(_install_args(
+            "cc-user-hooks", str(self.cat), str(self.repo)
+        ))
+        self.assertEqual(rc, 0)
+
+        settings = self.home / ".claude" / "settings.json"
+        # Hand-delete the entry without uninstalling the pack.
+        data = json.loads(settings.read_text(encoding="utf-8"))
+        data["hooks"]["UserPromptSubmit"] = []
+        settings.write_text(
+            json.dumps(data, indent=2) + "\n", encoding="utf-8"
+        )
+
+        rc, stdout, _err = _run_reconcile()
+        self.assertEqual(rc, 0)
+        self.assertIn("claude-code", stdout)
+        self.assertIn("orphan-in-state", stdout)
+        self.assertIn("cc-user-hooks:on-prompt", stdout)
+
+
+class GroupedByAdapterTests(_ReconcileBase):
+    """AC26: output is grouped by adapter."""
+
+    def test_two_adapters_produce_separate_headings(self) -> None:
+        # Install cc-user-hooks AND kiro-user-hooks, then inject one
+        # orphan-in-file under each.
+        _copy_fixture(FIXTURES / "cc-user-hooks", self.cat / "packs" / "cc-user-hooks")
+        _copy_fixture(FIXTURES / "kiro-user-hooks", self.cat / "packs" / "kiro-user-hooks")
+        for pack in ("cc-user-hooks", "kiro-user-hooks"):
+            rc = _run_install(_install_args(pack, str(self.cat), str(self.repo)))
+            self.assertEqual(rc, 0, f"install of {pack} failed")
+
+        # Inject orphans into each adapter's target file.
+        settings = self.home / ".claude" / "settings.json"
+        data = json.loads(settings.read_text(encoding="utf-8"))
+        data["hooks"].setdefault("Other", []).append(
+            {"id": "ghost-cc:x", "command": "x"}
+        )
+        settings.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+        agent_json = self.home / ".kiro" / "agents" / "reviewer.json"
+        agent = json.loads(agent_json.read_text(encoding="utf-8"))
+        agent["hooks"].setdefault("stop", []).append(
+            {"id": "ghost-kiro:y", "command": "y"}
+        )
+        agent_json.write_text(
+            json.dumps(agent, indent=2) + "\n", encoding="utf-8"
+        )
+
+        rc, stdout, _err = _run_reconcile()
+        self.assertEqual(rc, 0)
+        self.assertIn("reconcile: claude-code", stdout)
+        self.assertIn("reconcile: kiro", stdout)
+        self.assertIn("ghost-cc:x", stdout)
+        self.assertIn("ghost-kiro:y", stdout)
+
+
+class ReadOnlyContractTests(_ReconcileBase):
+    """AC26 read-only invariant: target files are byte-identical
+    before and after a reconcile run."""
+
+    def test_reconcile_does_not_write(self) -> None:
+        _copy_fixture(FIXTURES / "cc-user-hooks", self.cat / "packs" / "cc-user-hooks")
+        rc = _run_install(_install_args(
+            "cc-user-hooks", str(self.cat), str(self.repo)
+        ))
+        self.assertEqual(rc, 0)
+
+        settings = self.home / ".claude" / "settings.json"
+        before = settings.read_bytes()
+        rc, _stdout, _err = _run_reconcile()
+        self.assertEqual(rc, 0)
+        self.assertEqual(settings.read_bytes(), before)
+
+
+class ApplyFlagRejectedTests(unittest.TestCase):
+    """AC26: `reconcile --apply` is rejected by argparse — the
+    subcommand's parser does not register the flag."""
+
+    def test_apply_flag_rejected_by_argparse(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, "-m", "agentbundle", "reconcile", "--apply"],
+            env={**os.environ, "PYTHONPATH": str(REPO_ROOT / "packages" / "agentbundle")},
+            capture_output=True,
+            cwd=str(REPO_ROOT),
+        )
+        self.assertNotEqual(proc.returncode, 0)
+        # The default argparse "unrecognized argument" path fires.
+        self.assertIn("unrecognized", proc.stderr.decode())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/agentbundle/tests/integration/test_upgrade_attach_to_agent.py
+++ b/packages/agentbundle/tests/integration/test_upgrade_attach_to_agent.py
@@ -1,0 +1,133 @@
+"""T8c: upgrade reconciliation for `attach-to-agent` rename (Kiro).
+
+Per spec AC19b: upgrading a Kiro pack whose `attach-to-agent` value
+changes between versions (agent renamed, removed, or added) walks
+the OLD `target-file` to remove orphan entries AND the NEW
+`target-file` to add the new entries; state's `target-file` is
+updated to the new value; `reconcile --scope user` reports no
+orphans after the upgrade.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+FIXTURES = REPO_ROOT / "packages" / "agentbundle" / "tests" / "fixtures" / "packs"
+
+
+def _run_install(args):
+    from agentbundle.commands import install
+    with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+        return install.run(args)
+
+
+def _run_upgrade(args):
+    from agentbundle.commands import upgrade
+    stderr = io.StringIO()
+    with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(stderr):
+        rc = upgrade.run(args)
+    return rc, stderr.getvalue()
+
+
+def _run_reconcile():
+    from agentbundle.commands import reconcile
+    stdout = io.StringIO()
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(io.StringIO()):
+        rc = reconcile.run(argparse.Namespace(scope="user"))
+    return rc, stdout.getvalue()
+
+
+def _copy_fixture(src, dst):
+    shutil.copytree(src, dst)
+    for entry in dst.rglob("*.sh"):
+        entry.chmod(0o755)
+
+
+class AttachToAgentRenameTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.home = self.tmp / "home"; self.home.mkdir()
+        self.repo = self.tmp / "repo"; self.repo.mkdir()
+        self._env = patch.dict(os.environ, {"HOME": str(self.home)})
+        self._env.start()
+        self.addCleanup(self._env.stop)
+        self.cat = self.tmp / "cat"; (self.cat / "packs").mkdir(parents=True)
+
+    def test_upgrade_renames_attach_to_agent(self):
+        # Install kiro-user-hooks (attach-to-agent = "reviewer").
+        _copy_fixture(FIXTURES / "kiro-user-hooks", self.cat / "packs" / "kiro-user-hooks")
+        self.assertEqual(_run_install(argparse.Namespace(
+            pack="kiro-user-hooks", catalogue=str(self.cat), output=str(self.repo),
+            scope="user", force=False, force_merge=False,
+        )), 0)
+
+        old_agent = self.home / ".kiro" / "agents" / "reviewer.json"
+        self.assertTrue(old_agent.exists())
+        before = json.loads(old_agent.read_text(encoding="utf-8"))
+        self.assertIn("agentSpawn", before["hooks"])
+
+        # Mutate catalogue: rename the agent + update the wiring's
+        # attach-to-agent. (Pack-author rename.)
+        pack_in_cat = self.cat / "packs" / "kiro-user-hooks"
+        (pack_in_cat / ".apm" / "agents" / "reviewer.md").rename(
+            pack_in_cat / ".apm" / "agents" / "code-reviewer.md"
+        )
+        wiring = pack_in_cat / ".apm" / "hook-wiring" / "on-spawn.toml"
+        wiring.write_text(
+            'attach-to-agent = "code-reviewer"\n\n'
+            '[[hooks.agentSpawn]]\ncommand = "$HOOK_BODY_PATH"\nmatcher = ""\n',
+            encoding="utf-8",
+        )
+
+        rc, err = _run_upgrade(argparse.Namespace(
+            pack="kiro-user-hooks", catalogue=str(self.cat), to_version="0.2.0",
+            root=str(self.repo), scope="user",
+            skill=None, agent=None, hook=None, seed=None, command=None,
+        ))
+        self.assertEqual(rc, 0, f"upgrade failed: {err}")
+
+        # New agent JSON exists with the wiring merged in.
+        new_agent = self.home / ".kiro" / "agents" / "code-reviewer.json"
+        self.assertTrue(new_agent.exists(), f"new agent JSON not produced: {new_agent}")
+        new_data = json.loads(new_agent.read_text(encoding="utf-8"))
+        self.assertIn("agentSpawn", new_data["hooks"])
+        self.assertEqual(
+            new_data["hooks"]["agentSpawn"][0]["id"], "kiro-user-hooks:on-spawn"
+        )
+
+        # State row now points at the new target-file.
+        from agentbundle.config import load_state
+        state = load_state(self.home / ".agent-ready" / "state.toml")
+        owned = state.packs["kiro-user-hooks"].hook_wiring_owned
+        self.assertEqual(len(owned), 1)
+        self.assertEqual(owned[0]["target-file"], ".kiro/agents/code-reviewer.json")
+
+        # Old agent JSON: either removed (by direct-file uninstall path)
+        # or no longer carries the wiring entry. Either way, reconcile
+        # must report no orphans.
+        if old_agent.exists():
+            old_data = json.loads(old_agent.read_text(encoding="utf-8"))
+            self.assertNotIn(
+                "agentSpawn", old_data.get("hooks", {}),
+                "old agent JSON still carries the relocated wiring entry"
+            )
+
+        rc, stdout = _run_reconcile()
+        self.assertEqual(rc, 0)
+        self.assertNotIn("orphan-in-file", stdout)
+        self.assertNotIn("orphan-in-state", stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/agentbundle/tests/integration/test_upgrade_user_hooks.py
+++ b/packages/agentbundle/tests/integration/test_upgrade_user_hooks.py
@@ -1,0 +1,213 @@
+"""T8c: upgrade at user scope reconciles hook-wiring rows.
+
+Covers spec § Upgrade reconciliation tests:
+  - in-place upgrade (same wiring) is a no-op on the target file;
+  - upgrade adds a new hook entry → state row appended, target appended;
+  - upgrade removes a hook entry → state row removed, target updated;
+  - upgrade with `attach-to-agent` rename (Kiro) walks both old and
+    new target files (covered in test_upgrade_attach_to_agent.py).
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+FIXTURES = REPO_ROOT / "packages" / "agentbundle" / "tests" / "fixtures" / "packs"
+
+
+def _run_install(args):
+    from agentbundle.commands import install
+    with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+        return install.run(args)
+
+
+def _run_upgrade(args):
+    from agentbundle.commands import upgrade
+    stderr = io.StringIO()
+    with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(stderr):
+        rc = upgrade.run(args)
+    return rc, stderr.getvalue()
+
+
+def _install_args(pack, catalogue, output, scope="user"):
+    return argparse.Namespace(
+        pack=pack, catalogue=catalogue, output=output,
+        scope=scope, force=False, force_merge=False,
+    )
+
+
+def _upgrade_args(pack, catalogue, to_version, root, scope="user"):
+    return argparse.Namespace(
+        pack=pack, catalogue=catalogue, to_version=to_version,
+        root=root, scope=scope,
+        skill=None, agent=None, hook=None, seed=None, command=None,
+    )
+
+
+def _copy_fixture(src, dst):
+    shutil.copytree(src, dst)
+    for entry in dst.rglob("*.sh"):
+        entry.chmod(0o755)
+
+
+class _UpgradeBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.home = self.tmp / "home"; self.home.mkdir()
+        self.repo = self.tmp / "repo"; self.repo.mkdir()
+        self._env = patch.dict(os.environ, {"HOME": str(self.home)})
+        self._env.start()
+        self.addCleanup(self._env.stop)
+        self.cat = self.tmp / "cat"; (self.cat / "packs").mkdir(parents=True)
+
+
+class UpgradeThenUninstallTests(_UpgradeBase):
+    """Blocker #1 regression: install → upgrade → uninstall removes
+    the merged Kiro agent JSON. Before the SHA-refresh fix, the
+    upgrade's merge phase would leave state.files with a stale SHA;
+    uninstall would misclassify the file as Tier-2 and refuse to
+    remove it. Pins the fix at the integration level."""
+
+    def test_kiro_install_upgrade_uninstall_removes_agent_file(self):
+        from agentbundle.commands import uninstall as uninstall_cmd
+
+        _copy_fixture(FIXTURES / "kiro-user-hooks", self.cat / "packs" / "kiro-user-hooks")
+        self.assertEqual(_run_install(_install_args(
+            "kiro-user-hooks", str(self.cat), str(self.repo))), 0)
+
+        # Upgrade (same wiring shape — exercises the merge phase
+        # without testing the rename path).
+        rc, err = _run_upgrade(_upgrade_args(
+            "kiro-user-hooks", str(self.cat), "0.2.0", str(self.repo)))
+        self.assertEqual(rc, 0, f"upgrade failed: {err}")
+
+        # Uninstall.
+        un_args = argparse.Namespace(
+            pack="kiro-user-hooks", root=str(self.repo), scope="user",
+        )
+        with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+            rc = uninstall_cmd.run(un_args)
+        self.assertEqual(rc, 0, "uninstall failed")
+
+        agent_json = self.home / ".kiro" / "agents" / "reviewer.json"
+        self.assertFalse(
+            agent_json.exists(),
+            "agent file survived uninstall after upgrade — SHA refresh missing",
+        )
+
+
+class InPlaceUpgradeIsNoOpTests(_UpgradeBase):
+    """Upgrading the same pack version with the same wiring is a
+    byte-stable no-op on the target file."""
+
+    def test_same_version_same_wiring_is_byte_stable(self):
+        _copy_fixture(FIXTURES / "cc-user-hooks", self.cat / "packs" / "cc-user-hooks")
+        self.assertEqual(_run_install(_install_args(
+            "cc-user-hooks", str(self.cat), str(self.repo))), 0)
+
+        settings = self.home / ".claude" / "settings.json"
+        before = settings.read_bytes()
+        # Upgrade to the same version (idempotent).
+        rc, err = _run_upgrade(_upgrade_args(
+            "cc-user-hooks", str(self.cat), "0.1.0", str(self.repo)))
+        self.assertEqual(rc, 0, f"upgrade failed: {err}")
+        self.assertEqual(settings.read_bytes(), before,
+            "in-place upgrade wasn't byte-stable")
+
+
+class UpgradeAddsHookEntryTests(_UpgradeBase):
+    """When the new pack ships an additional wiring TOML, upgrade
+    appends the new id-tagged entry; state row appended too."""
+
+    def test_added_wiring_extends_state(self):
+        _copy_fixture(FIXTURES / "cc-user-hooks", self.cat / "packs" / "cc-user-hooks")
+        self.assertEqual(_run_install(_install_args(
+            "cc-user-hooks", str(self.cat), str(self.repo))), 0)
+
+        # Mutate the catalogue: add a second wiring TOML to the pack.
+        pack_in_cat = self.cat / "packs" / "cc-user-hooks"
+        (pack_in_cat / ".apm" / "hook-wiring" / "on-session.toml").write_text(
+            '[[hooks.SessionStart]]\ncommand = "session-cmd"\n', encoding="utf-8"
+        )
+        (pack_in_cat / ".apm" / "hooks" / "on-session.sh").write_text(
+            "#!/bin/sh\nexit 0\n", encoding="utf-8"
+        )
+        (pack_in_cat / ".apm" / "hooks" / "on-session.sh").chmod(0o755)
+
+        rc, err = _run_upgrade(_upgrade_args(
+            "cc-user-hooks", str(self.cat), "0.2.0", str(self.repo)))
+        self.assertEqual(rc, 0, f"upgrade failed: {err}")
+
+        settings = self.home / ".claude" / "settings.json"
+        data = json.loads(settings.read_text(encoding="utf-8"))
+        # Both events now present.
+        self.assertIn("UserPromptSubmit", data["hooks"])
+        self.assertIn("SessionStart", data["hooks"])
+        self.assertEqual(
+            data["hooks"]["SessionStart"][0]["id"], "cc-user-hooks:on-session"
+        )
+
+        # State has both rows.
+        from agentbundle.config import load_state
+        state = load_state(self.home / ".agent-ready" / "state.toml")
+        ids = {r["id"] for r in state.packs["cc-user-hooks"].hook_wiring_owned}
+        self.assertEqual(
+            ids,
+            {"cc-user-hooks:on-prompt", "cc-user-hooks:on-session"},
+        )
+
+
+class UpgradeRemovesHookEntryTests(_UpgradeBase):
+    """When the new pack drops a wiring TOML, upgrade removes the
+    corresponding entry from both state and the target file."""
+
+    def test_removed_wiring_drops_from_state_and_file(self):
+        _copy_fixture(FIXTURES / "cc-user-hooks", self.cat / "packs" / "cc-user-hooks")
+        pack_in_cat = self.cat / "packs" / "cc-user-hooks"
+        # Add an extra wiring TOML before install so we can drop it on upgrade.
+        (pack_in_cat / ".apm" / "hook-wiring" / "on-session.toml").write_text(
+            '[[hooks.SessionStart]]\ncommand = "session-cmd"\n', encoding="utf-8"
+        )
+        (pack_in_cat / ".apm" / "hooks" / "on-session.sh").write_text(
+            "#!/bin/sh\nexit 0\n", encoding="utf-8"
+        )
+        (pack_in_cat / ".apm" / "hooks" / "on-session.sh").chmod(0o755)
+        self.assertEqual(_run_install(_install_args(
+            "cc-user-hooks", str(self.cat), str(self.repo))), 0)
+
+        settings = self.home / ".claude" / "settings.json"
+        data_pre = json.loads(settings.read_text(encoding="utf-8"))
+        self.assertIn("SessionStart", data_pre["hooks"])
+
+        # Mutate catalogue: drop the on-session wiring TOML.
+        (pack_in_cat / ".apm" / "hook-wiring" / "on-session.toml").unlink()
+
+        rc, err = _run_upgrade(_upgrade_args(
+            "cc-user-hooks", str(self.cat), "0.2.0", str(self.repo)))
+        self.assertEqual(rc, 0, f"upgrade failed: {err}")
+
+        data_post = json.loads(settings.read_text(encoding="utf-8"))
+        # SessionStart entry gone (and the empty array pruned).
+        self.assertNotIn("SessionStart", data_post.get("hooks", {}))
+        # Other entries untouched.
+        self.assertIn("UserPromptSubmit", data_post["hooks"])
+
+        from agentbundle.config import load_state
+        state = load_state(self.home / ".agent-ready" / "state.toml")
+        ids = {r["id"] for r in state.packs["cc-user-hooks"].hook_wiring_owned}
+        self.assertEqual(ids, {"cc-user-hooks:on-prompt"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Wave 8 of the [user-scope-hooks spec](../tree/main/docs/specs/user-scope-hooks/spec.md) — T8c (upgrade reconciliation) + T9 (reconcile reporter). Eighth of thirteen PRs.

- **T9** — \`agentbundle reconcile --scope user\` read-only orphan reporter. Walks Claude Code's \`~/.claude/settings.json\` and every Kiro agent JSON named in user-scope state. Reports orphan-in-file and orphan-in-state classes, grouped by adapter. \`--apply\` flag is not registered (RFC-0005 forbids write-mode reconcile).
- **T8c** — Upgrade-time hook-wiring symmetric-diff reconciliation. The \`attach-to-agent\` rename case (AC19b) walks both old and new target files. Cross-adapter upgrades are explicitly refused. Shared SHA-refresh helper hoisted from install so upgrade doesn't inherit the stale-SHA bug. Adapter-aware allowed-prefixes resolution mirrors T8b's install fix.

## Acceptance criteria

- [x] **AC19b** — Kiro \`attach-to-agent\` rename walks OLD + NEW target files; state's \`target-file\` updated; reconcile reports no orphans after upgrade.
- [x] **AC26** — \`reconcile --scope user\` reads both adapters' target files, reports both orphan classes, grouped by adapter, read-only, \`--apply\` rejected.

## Adversarial review

One round: 1 Blocker + 3 Concerns + 2 Nits. All addressed in-PR:

- **Blocker** — upgrade inherited T8b's stale-SHA bug; fixed by hoisting \`_refresh_merge_target_shas\` into a shared helper and calling it from both install and upgrade. New integration test pins the regression (install → upgrade → uninstall removes the agent file).
- **Concern: attach-to-agent grammar guard** — \`_compute_new_wiring_rows\` now validates against \`^[a-z0-9][a-z0-9-]*$\` (path-traversal defence mirrors install's).
- **Concern: cross-adapter upgrade** — Kiro→CC or CC→Kiro now refused with refuse-and-explain. AC19b covers within-Kiro renames only.
- **Concern: TOMLDecodeError asymmetry** — \`_compute_new_wiring_rows\` propagates instead of silent-skipping (silent skip would let step A unproject entries the merger would refuse to re-project).
- **Nits** — plan.md drift (\`cli_reconcile.py\` → \`commands/reconcile.py\`) fixed. Reconcile's defensive \`cli_scope != \"user\"\` guard left in place (argparse choices forbid the case today; comment annotates).

## Gates

524 tests pass, 1 skipped (was 512 pre-wave-8; +12 new tests). \`make build-check\` and \`make validate\` exit 0.

## Out of scope

- **T11** — \`agent-spec-cli\` spec amendment.

After this lands, wave 9 = T11 (just the spec amendment). Then the spec is fully shipped.