### PR TITLE
docs(spec): close out user-scope-hooks — T11 + status flips

### DIFF
--- a/docs/specs/agent-spec-cli/spec.md
+++ b/docs/specs/agent-spec-cli/spec.md
@@ -73,6 +73,7 @@ section pins the CLI surface that consumes them.
 | `validate`     | No `--scope` — validates the pack's declared `default-scope ∈ allowed-scopes`, the seeds/hooks/`allowed-scopes` consistency, and the schema. |
 | `render`       | No `--scope` — pack-local primitive rendering; scope only matters at install.                                  |
 | `adapt`        | No `--scope` — walks **both** state files; reads `<repo>/.adapt-discovery.toml` at repo scope and `~/.agent-ready/.adapt-discovery.toml` at user scope. |
+| `reconcile`    | **User-scope-only (RFC-0005).** Read-only orphan reporter; `--scope user` is the only accepted value. No `--apply` flag — write-mode reconciliation would re-create the merge-discipline problems RFC-0005 is designed to avoid. |
 
 ### Scope-resolution precedence
 
@@ -111,18 +112,25 @@ Windows support is deferred per the existing stdlib-only commitment;
 `pathlib.expanduser` handles `%USERPROFILE%`, but cross-platform
 conformance is not gated by this amendment.
 
-### `.agent-ready-state.toml` write-time refusal at v0.1
+### `.agent-ready-state.toml` write-time refusal at legacy schemas
 
-The CLI **reads** any `schema-version = "0.1"` state file as
-all-repo-scope without forcing migration. Any **write-capable**
-invocation (`install`, `uninstall`, `upgrade`, `init-state` *without*
-`--migrate`) against a v0.1 file exits non-zero with stderr `state
-file at <path> is schema-version 0.1; run 'agentbundle init-state
---migrate' first`. No silent rewrite — migration is destructive
-(irreversible without backup) and an adopter running mixed CLI
-versions across CI and local must opt into the file-format change
-explicitly. The refuse-and-explain shape matches the major-version
-refusal rail this spec already pins.
+The CLI **reads** any legacy state file (`schema-version = "0.1"` —
+all-repo-scope; `schema-version = "0.2"` — full v0.2 read with v0.3's
+new fields read-time-defaulted) without forcing migration. Any
+**write-capable** invocation (`install`, `uninstall`, `upgrade`,
+`init-state` *without* `--migrate`) against a legacy file exits
+non-zero with stderr `state file at <path> is schema-version
+<X>; run 'agentbundle init-state --migrate' first` (where `<X>`
+names the actual version found). No silent rewrite — migrations are
+additive but adopters running mixed CLI versions across CI and local
+must opt in explicitly. The refuse-and-explain shape matches the
+major-version refusal rail this spec already pins. v0.2 → v0.3 is
+the cheapest possible additive migration (header-only-additive per
+[RFC-0005 § State-file
+impact](../../rfc/0005-user-scope-hook-support.md#state-file-impact));
+v0.1 → v0.3 is performed as a single `init-state --migrate` invocation
+that covers both the v0.1 → v0.2 scope-column backfill and the
+v0.2 → v0.3 header bump in one re-serialize.
 
 ### `installed: <pack> @ <scope>` output
 
@@ -241,6 +249,164 @@ match the per-scope state-file locations from the sibling
 User-scope reports live inside the namespaced
 `~/.agent-ready/` dot-directory (the same one that holds the
 user-scope state file), not as a bare dotfile in `$HOME`.
+
+## v0.3 user-scope hook handling (RFC-0005)
+
+The v0.3 contract bump (RFC-0005) extends the CLI surface with
+user-scope hook-wiring support: `install` / `uninstall` / `upgrade`
+thread hook-wiring through the v0.3 merge engines
+(`user-merge-json` for Claude Code at user scope;
+`merge-into-agent-json` for Kiro at both scopes), `install` gains a
+`--force-merge` flag, and a new `reconcile --scope user` subcommand
+reports orphans. The full design rationale lives in
+[RFC-0005](../../rfc/0005-user-scope-hook-support.md); this section
+pins the **CLI surface** the rationale produces.
+
+### `--force-merge` flag on `install`
+
+```
+agentbundle install <catalogue> --pack <P> --scope user --force-merge
+```
+
+Binding rules (RFC-0005 § Binding and interaction with `--force`):
+
+- **Bound to `install` only.** Passing `--force-merge` to any other
+  verb is rejected with stderr `unknown flag for <verb>:
+  --force-merge` (mirrors the `--force` binding shape RFC-0004
+  established).
+- **Bound to `--scope user`.** At repo scope the hook-wiring target
+  is a pack-owned file (`.claude/settings.local.json` for Claude
+  Code), so adopter collision is structurally a non-case. Refused
+  with stderr `--force-merge is bound to user scope; pass --scope
+  user or omit --force-merge`. Both the explicit `--scope repo`
+  case and the pack-default-resolves-to-repo case refuse.
+- **Claude-Code-targeted packs only.** Refused with stderr
+  `--force-merge applies only to Claude-Code-targeted packs; pack
+  <P> resolves to adapter 'kiro' at user scope`. Kiro's
+  `merge-into-agent-json` target is pack-owned (the per-agent
+  JSON), so adopter collision is again structurally a non-case.
+- **Orthogonal to `--force`.** The two flags address different
+  refusals — `--force` is the cross-scope-conflict bypass
+  (RFC-0004), `--force-merge` is the adopter-collision bypass
+  (RFC-0005). `install --force --force-merge` is permitted and each
+  flag covers its own refusal.
+- **No-op when no textual collision is detected.** Same
+  idempotent-when-no-conflict shape as `--force`, so wrapper
+  scripts can pass `--force-merge` unconditionally.
+
+The flag's runtime semantics — adopt the adopter-authored entry,
+preserve the original `command` in the state-file snapshot — are
+pinned by [RFC-0005 § User-already-set-this-key collision
+rule](../../rfc/0005-user-scope-hook-support.md#user-already-set-this-key-collision-rule)
+and implemented inside the `user-merge-json` merger.
+
+### `reconcile --scope user` — read-only orphan reporter
+
+```
+agentbundle reconcile --scope user
+```
+
+Walks two surfaces and reports two classes of orphan grouped by
+adapter:
+
+- `~/.claude/settings.json` (Claude Code) and every Kiro agent
+  JSON named in user-scope state's `[[installed.hook-wiring-owned]]`
+  rows.
+- **orphan-in-file** — an `id`-tagged entry the target file claims
+  but no installed pack's `hook-wiring-owned` row owns. Surfaces
+  when a hand-edit on the settings file (or a Kiro agent JSON) adds
+  an entry with an id no pack records.
+- **orphan-in-state** — a state row claiming ownership of an entry
+  the target file no longer has. Surfaces on hand-delete, on
+  multi-machine sync drift, or when the merge target file was
+  removed out-of-band.
+
+Output format (stdout):
+
+- `reconcile: all clean` when no orphans exist.
+- One `reconcile: <adapter>` heading per adapter with orphans,
+  followed by indented per-orphan lines.
+
+**Read-only contract.** The subcommand does **not** register an
+`--apply` flag — `argparse` rejects it with the standard
+"unrecognized argument" exit code. A write-mode reconciler would
+recreate the merge-discipline problems RFC-0005 is designed to
+avoid; the adopter takes manual action from the report. The
+exclusion is pinned by [RFC-0005 § Follow-on
+artifacts](../../rfc/0005-user-scope-hook-support.md#follow-on-artifacts)
+("a write-mode `reconcile --apply` is explicitly **not** in this
+RFC's scope") and by the user-scope-hooks spec's *Never do*
+boundary.
+
+### State schema v0.3 — `[[installed]]` field additions
+
+The state file's `schema-version` bumps from `0.2` to `0.3` per
+RFC-0005 § State-file impact. `[[installed]]` rows grow three
+optional fields, all with read-time defaults so v0.2-vintage rows
+preserved across the header-only migration read correctly without
+backfill:
+
+| Field                 | Type                  | Required? | Read-time default                                              |
+| --------------------- | --------------------- | --------- | -------------------------------------------------------------- |
+| `adapter`             | string                | optional  | `"claude-code"`                                                 |
+| `target-file`         | string                | optional  | `"~/.claude/settings.json"` when `adapter` is `"claude-code"`; **required (no default)** when `adapter` is `"kiro"` |
+| `hook-wiring-owned`   | array-of-tables       | optional  | `[]`                                                            |
+
+Each `[[installed.hook-wiring-owned]]` entry carries `event` and `id`
+(both required strings) and optionally `target-file` (Kiro rows
+always carry it; Claude Code rows defaulted at read).
+
+### Migration shape (v0.2 → v0.3)
+
+`init-state --migrate` against a v0.2 state file is
+**header-only-additive**: only the `schema-version = "0.2"` line is
+rewritten to `"0.3"`. Body bytes are byte-for-byte preserved; no
+per-row backfill. Existing rows read with the v0.3 read-time
+defaults above. v0.1 → v0.3 retains the full re-serialize shape
+(the v0.1 → v0.2 scope-column backfill plus the header bump in one
+step). The migration is idempotent — running `--migrate` against an
+already-v0.3 file is a byte no-op.
+
+### Refuse-and-explain texts (user-scope merge surfaces)
+
+The v0.3 merge engines surface refuse-and-explain text the CLI
+emits verbatim. Both engines are implemented in
+`agentbundle/build/projections/` and propagate
+`UserMergeRefusal` / `AgentJsonRefusal` to the CLI; install /
+uninstall / upgrade catch the exception and print to stderr:
+
+- **Unparseable JSON target** (`~/.claude/settings.json` or
+  `<scope-root>/.kiro/agents/<agent>.json`):
+  `cannot parse <path>: <error>; fix or back up the file and retry`.
+  The file is **not** rewritten; no state is recorded.
+- **Wrong-shape `hooks` key** (e.g. `hooks` is an array, or
+  `hooks.<event>` is a string): `<path>: <key-path> has unexpected
+  shape <type>; expected <expected>`. Where `<key-path>` is
+  `hooks` or `hooks.<event>` as relevant.
+- **Adopter command collision (Claude Code only)**: `pack <P>'s
+  hook <name> at event <event> appears to be already wired in
+  <path>; remove the manual entry or pass --force-merge to take
+  ownership`. Whitespace-normalised string match per RFC-0005 §
+  User-already-set-this-key collision rule.
+- **Missing agent file at Kiro merge time** (pipeline-ordering
+  invariant violation; reachable only via test instrumentation
+  today): `internal: <agent-file> missing at hook-wiring merge
+  time; agent must project before wiring`.
+- **Path-traversal `attach-to-agent`** (defence-in-depth at install
+  and upgrade time): `pack <P>'s hook-wiring <name>.toml declares
+  attach-to-agent=<value> which violates the agent-name grammar
+  ^[a-z0-9][a-z0-9-]*$ — refusing`.
+
+### Cross-adapter upgrade — refused
+
+`upgrade` refuses when the new pack version resolves to a different
+adapter than the recorded `pack_state.adapter` (e.g. Kiro → Claude
+Code or vice versa, detected via the
+`.apm/agents/`-presence heuristic). Stderr: `pack adapter changed
+from '<old>' → '<new>' between versions; run uninstall + install
+instead (cross-adapter upgrade is not supported)`. AC19b covers
+within-Kiro `attach-to-agent` renames; adapter switches need an
+explicit recovery gesture.
 
 ## Boundaries
 

--- a/docs/specs/user-scope-hooks/plan.md
+++ b/docs/specs/user-scope-hooks/plan.md
@@ -1,7 +1,7 @@
 # Plan: user-scope-hooks
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Drafting <!-- Drafting | Executing | Done -->
+- **Status:** Done <!-- Drafting | Executing | Done -->
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
 > document is allowed to change as you learn. When it changes substantially

--- a/docs/specs/user-scope-hooks/spec.md
+++ b/docs/specs/user-scope-hooks/spec.md
@@ -1,6 +1,6 @@
 # Spec: user-scope-hooks
 
-- **Status:** Draft <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** [RFC-0005](../../rfc/0005-user-scope-hook-support.md)
@@ -178,86 +178,86 @@ exercise.
 
 Schema and contract:
 
-- [ ] **AC1.** `adapter.toml` declares `[adapter.kiro.scope]` with
+- [x] **AC1.** `adapter.toml` declares `[adapter.kiro.scope]` with
       `repo = "."`, `user = "~"`,
       `allowed-prefixes.user = [".kiro/", ".agent-ready/"]`.
       Schema validation passes.
-- [ ] **AC2.** `adapter.toml` declares
+- [x] **AC2.** `adapter.toml` declares
       `[adapter.kiro.projections.hook-wiring]` with
       `mode = "merge-into-agent-json"`, `managed-key = "hooks"`, and
       `agent-event-vocabulary` containing the five Kiro events
       verbatim. The legacy `[[adapter.kiro.projection]]`
       `degraded-info-log` entry is removed.
-- [ ] **AC3.** `adapter.toml` declares
+- [x] **AC3.** `adapter.toml` declares
       `[adapter."claude-code".projections.hook-wiring]` with
       `mode.repo = "merge-json"`, `mode.user = "user-merge-json"`,
       scope-conditional `target`, `managed-key.user = "hooks"`.
-- [ ] **AC4.** `adapter.toml` declares
+- [x] **AC4.** `adapter.toml` declares
       `[adapter."claude-code".projections.hook-body]` and
       `[adapter.kiro.projections.hook-body]` with
       scope-conditional `target` values per RFC-0005.
-- [ ] **AC5.** `pack.schema.json` accepts `[pack.install]
+- [x] **AC5.** `pack.schema.json` accepts `[pack.install]
       user-scope-hooks = true` and refuses any non-boolean value;
       defaults to `false` when absent.
-- [ ] **AC6.** The `hook-wiring` TOML schema accepts an optional
+- [x] **AC6.** The `hook-wiring` TOML schema accepts an optional
       top-level `attach-to-agent` string field. `validate` against a
       Kiro-targeted pack refuses wiring without `attach-to-agent` or
       naming a non-same-pack agent with the exact refusal text
       RFC-0005 § Repo-scope Kiro promotion specifies.
-- [ ] **AC7.** Adapter contract version bumps to `0.3`.
+- [x] **AC7.** Adapter contract version bumps to `0.3`.
 
 Merge behavior (Claude Code user scope):
 
-- [ ] **AC8.** Installing a Claude Code user-scope pack into an
+- [x] **AC8.** Installing a Claude Code user-scope pack into an
       empty `~/.claude/settings.json` writes the file with
       `hooks.<event>` arrays containing the pack's entries, each
       tagged with `id = "<pack>:<hook-basename>"`. No other top-level
       keys are touched.
-- [ ] **AC9.** Reinstalling the same pack at the same version is a
+- [x] **AC9.** Reinstalling the same pack at the same version is a
       byte-for-byte no-op on the settings file.
-- [ ] **AC10.** Installing a *second* pack with overlapping events
+- [x] **AC10.** Installing a *second* pack with overlapping events
       appends its entries after the first pack's; the first pack's
       entries are not reordered. Both packs' IDs coexist.
-- [ ] **AC11.** Uninstalling one of two packs sharing an event
+- [x] **AC11.** Uninstalling one of two packs sharing an event
       removes that pack's entries only; the other pack's entries
       remain in their original positions; empty `hooks.<event>`
       arrays are removed (not left as `[]`).
-- [ ] **AC12.** A pre-existing adopter entry whose `command` field
+- [x] **AC12.** A pre-existing adopter entry whose `command` field
       matches the pack's hook (after whitespace normalisation)
       causes `install` to refuse with the RFC-0005-specified text.
       `install --force-merge` adopts the entry; the original is
       preserved in a state-file snapshot.
-- [ ] **AC13.** Unparseable `~/.claude/settings.json` causes
+- [x] **AC13.** Unparseable `~/.claude/settings.json` causes
       `install` to refuse non-zero without rewriting the file or
       recording state.
-- [ ] **AC14.** A `hooks` key present-with-wrong-type (e.g. array)
+- [x] **AC14.** A `hooks` key present-with-wrong-type (e.g. array)
       causes `install` to refuse with the
       `<key-path> has unexpected shape` text. Same refusal for any
       `hooks.<event>` of wrong type.
 
 Merge behavior (Kiro):
 
-- [ ] **AC15.** Installing a Kiro repo-scope pack with one agent and
+- [x] **AC15.** Installing a Kiro repo-scope pack with one agent and
       one wiring TOML writes the agent JSON to
       `.kiro/agents/<agent>.json` and merges the wiring's hook
       entries into that file's `hooks.<event>` array under the same
       array-append-with-id discipline as Claude Code.
-- [ ] **AC16.** The build pipeline projects the agent file before
+- [x] **AC16.** The build pipeline projects the agent file before
       wiring projection runs (phase order
       `hook-body` → `agent` → `hook-wiring` → `command` → `skill`).
       A test asserting the file's existence at the wiring step's
       entry point passes.
-- [ ] **AC17.** A wiring TOML naming events outside Kiro's
+- [x] **AC17.** A wiring TOML naming events outside Kiro's
       `agent-event-vocabulary` (e.g. PascalCase `UserPromptSubmit`)
       refuses at `validate` with the
       "not in adapter ... agent-event-vocabulary" text.
-- [ ] **AC17b.** The event-vocabulary check fires **only** when
+- [x] **AC17b.** The event-vocabulary check fires **only** when
       the resolved target adapter declares `agent-event-vocabulary`.
       Claude Code's projection does not declare the field
       (RFC-0005 § Declaration), so a wiring TOML with arbitrary
       event names projected against Claude Code passes `validate`.
       The vocabulary refusal is per-adapter, not per-RFC.
-- [ ] **AC18.** Kiro user-scope install writes to
+- [x] **AC18.** Kiro user-scope install writes to
       `~/.kiro/agents/<agent>.json` with hook entries whose
       `command` field resolves to the projected hook body on a
       fresh shell — i.e. running `sh -c "$command"` from any
@@ -265,11 +265,11 @@ Merge behavior (Kiro):
       the field carries an absolute path or a `~`-relative path
       is an implementation choice; the observable is
       dispatchability.
-- [ ] **AC19.** Uninstalling a Kiro pack removes its
+- [x] **AC19.** Uninstalling a Kiro pack removes its
       `hook-wiring-owned` entries from the agent JSON and removes
       the agent file itself via the `direct-file` projection's
       uninstall.
-- [ ] **AC19b.** Upgrading a Kiro pack whose `attach-to-agent`
+- [x] **AC19b.** Upgrading a Kiro pack whose `attach-to-agent`
       value changes between versions (agent renamed, removed, or
       added) walks the OLD `target-file` to remove orphan entries
       AND the NEW `target-file` to add the new entries; state
@@ -281,11 +281,11 @@ Merge behavior (Kiro):
 
 State schema and migration:
 
-- [ ] **AC20.** State-file `schema-version` bumps from `0.2` →
+- [x] **AC20.** State-file `schema-version` bumps from `0.2` →
       `0.3`. `[[installed]]` rows grow optional `adapter` and
       `hook-wiring-owned` fields. The `hook-wiring-owned` table
       rows carry `event`, `id`, and optional `target-file`.
-- [ ] **AC21.** `init-state --migrate` against a v0.2 file rewrites
+- [x] **AC21.** `init-state --migrate` against a v0.2 file rewrites
       the `schema-version` line only. Existing rows are not
       backfilled. A v0.3 reader sees absent `adapter` as
       `claude-code`. For absent `target-file`: when the implied
@@ -293,23 +293,23 @@ State schema and migration:
       (settings-file binding); `target-file` is **required** for
       Kiro rows (no implicit default — Kiro rows always carry the
       pack-owned `.kiro/agents/<agent>.json` path explicitly).
-- [ ] **AC22.** Write against a v0.2 state file refuses with the
+- [x] **AC22.** Write against a v0.2 state file refuses with the
       "run `agentbundle init-state --migrate` first" text.
 
 CLI surface:
 
-- [ ] **AC23.** `install --scope user` against a pack with
+- [x] **AC23.** `install --scope user` against a pack with
       `user-scope-hooks = true` and a working user-scope target
       adapter (Claude Code with `mode.user = "user-merge-json"` or
       Kiro with `mode = "merge-into-agent-json"`) succeeds. Rail B
       no longer refuses such packs.
-- [ ] **AC24.** `install --scope user` against a pack lacking the
+- [x] **AC24.** `install --scope user` against a pack lacking the
       `user-scope-hooks` flag refuses at `validate` with Rail B's
       existing refusal text.
-- [ ] **AC25.** `install --scope user` against an adapter that
+- [x] **AC25.** `install --scope user` against an adapter that
       doesn't declare a working user-scope `hook-wiring` mode
       refuses with the RFC-0005-specified text.
-- [ ] **AC26.** `reconcile --scope user` reads both the Claude
+- [x] **AC26.** `reconcile --scope user` reads both the Claude
       Code settings file (if exists) and every Kiro agent JSON
       named in user-scope `hook-wiring-owned` state. It reports two
       orphan classes: (a) entries the target file claims own but
@@ -319,11 +319,11 @@ CLI surface:
 
 Verification:
 
-- [ ] **AC27.** `make build-check` exits clean with the amendments
+- [x] **AC27.** `make build-check` exits clean with the amendments
       applied (no drift between `packs/<P>/seeds/` and `<repo>/`).
-- [ ] **AC28.** Every fixture pack named in § Testing Strategy is
+- [x] **AC28.** Every fixture pack named in § Testing Strategy is
       shipped under `tests/fixtures/packs/` and exercised by at
       least one test.
-- [ ] **AC29.** No test or CI step writes to `~/.claude/`,
+- [x] **AC29.** No test or CI step writes to `~/.claude/`,
       `~/.kiro/`, or `~/.agent-ready/` outside a `tmp_path`-scoped
       `$HOME`.


### PR DESCRIPTION
## Summary

**Final wave (T11) of the user-scope-hooks spec.** Documentation-only PR closing out RFC-0005: amends \`docs/specs/agent-spec-cli/spec.md\` with the v0.3 CLI surface (\`--force-merge\` flag, \`reconcile\` subcommand, state schema migration, refuse-and-explain texts, cross-adapter upgrade refusal), flips the user-scope-hooks spec to **Shipped**, and ticks all 31 acceptance criteria.

After this lands: 13 tasks across 9 waves shipped, RFC-0005 is fully implemented.

## What landed

- **\`reconcile\` row** added to the \`--scope\` per-subcommand table.
- **\`.agent-ready-state.toml\` write-time refusal section** generalised from v0.1-only to legacy schemas (v0.1 + v0.2).
- **New section: v0.3 user-scope hook handling** — \`--force-merge\` binding rules, \`reconcile --scope user\` contract, state schema v0.3 field-additions table, migration shape, refuse-and-explain text table, cross-adapter upgrade refusal.
- **Spec status flips**: \`user-scope-hooks/spec.md\` Draft → Shipped; \`plan.md\` Drafting → Done; all 31 ACs checked.

## Acceptance criteria

- [x] \`--force-merge\` documented with binding rules.
- [x] \`reconcile --scope user\` documented as read-only reporter.
- [x] v0.3 state-schema migration shape + \`[[installed]]\` field additions documented.
- [x] Refuse-and-explain texts spelled out (unparseable settings, wrong-shape \`hooks\`).
- [x] \`make build-check\` clean.

## Adversarial review

One round: 1 Concern + 3 Nits. **Clean — ready to commit.** Substantive Concern fixed: the \`reconcile --apply\` exclusion was incorrectly cited as pinned by \`distribution-adapters/spec.md § Never do\` — that section doesn't actually mention \`reconcile\`. Replaced with the correct citation to RFC-0005 § Follow-on artifacts.

## Gates

524 tests pass, 1 skipped. \`make build-check\` and \`make validate\` exit 0.

---

## RFC-0005 shipping summary

| Wave | Tasks | Highlight |
|---|---|---|
| 1 | T1 | v0.3 contract bump + schema acceptances |
| 2 | T2 + T4 + T8a | attach-to-agent rail + target resolver + state v0.3 |
| 3 | T3 | fixture packs + conditional Rail B lift |
| 4 | T5 + T10 | user-merge-json + distribution-adapters amendment |
| 5 | T6 | merge-into-agent-json + vocabulary gate |
| 6 | T7 | pipeline phase order + Kiro agent .md → .json reform (design-gap research closed via published Kiro reference) |
| 7 | T8b | install/uninstall threading + \`--force-merge\` |
| 8 | T8c + T9 | upgrade reconciliation + reconcile reporter |
| 9 | T11 | this — agent-spec-cli amendment |

**13 tasks, 9 waves, ~6000 net LOC, 524 tests.**

Single deferred follow-up: the multi-pack Kiro shared-agent ownership hazard (two packs declaring the same agent name) — documented in \`install._resolve_user_scope_target_adapter\` and not in any AC's scope. A follow-on RFC will close it.