### PR TITLE
feat(skill-secrets): T2 — stdlib .env parser

### DIFF
--- a/packages/agentbundle/agentbundle/creds/loader.py
+++ b/packages/agentbundle/agentbundle/creds/loader.py
@@ -1,0 +1,77 @@
+"""Stdlib ``.env`` parser for credentialed primitives.
+
+Intentionally less than ``python-dotenv``: this parser supports only the
+narrow subset spec § AC2 pins as the contract for Tier-3 dotfile content
+(``~/.agent-ready/credentials.env``). Stdlib-only — no ``python-dotenv``,
+no third-party imports — per spec § Boundaries § Never do.
+
+Supported:
+    ``KEY=value``
+    ``KEY="value with spaces"``
+    ``KEY=value=with=equals``  (only the first ``=`` separates)
+    ``# comment`` lines and blank lines
+
+Refused (raises ``EnvParseError``):
+    ``export KEY=value``         shell-export prefix
+    ``KEY=$OTHER``               variable expansion
+    quoted value spanning two physical lines
+
+Trailing ``\\r`` from CRLF line endings is stripped; ``\\r`` *inside* a
+quoted value is preserved (``KEY="a\\rb"`` → ``{"KEY": "a\\rb"}``).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+class EnvParseError(ValueError):
+    """Raised when an ``.env`` file violates the supported subset.
+
+    Messages include the 1-based physical line number so a log reader
+    can jump to the offending line.
+    """
+
+
+def parse_env_file(path: pathlib.Path) -> dict[str, str]:
+    """Parse the file at ``path`` into a ``{KEY: value}`` mapping.
+
+    Reads with ``newline=""`` so embedded ``\\r`` bytes are preserved;
+    only the trailing line terminator is stripped.
+    """
+    text = path.read_text(encoding="utf-8", newline="")
+    result: dict[str, str] = {}
+    for lineno, raw in enumerate(text.split("\n"), start=1):
+        # Strip trailing \r (CRLF normalization). rstrip is bounded to the
+        # tail, so embedded \r inside a quoted value is preserved.
+        line = raw.rstrip("\r")
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("export "):
+            raise EnvParseError(
+                f"line {lineno}: `export KEY=value` shell-export syntax is not supported"
+            )
+        if "=" not in line:
+            raise EnvParseError(
+                f"line {lineno}: expected `KEY=value`, no '=' found"
+            )
+        key, _, value = line.partition("=")
+        key = key.strip()
+        if not _KEY_RE.match(key):
+            raise EnvParseError(f"line {lineno}: invalid key {key!r}")
+        if value.startswith('"'):
+            if len(value) < 2 or not value.endswith('"'):
+                raise EnvParseError(
+                    f"line {lineno}: multi-line quoted values are not supported"
+                )
+            value = value[1:-1]
+        if "$" in value:
+            raise EnvParseError(
+                f"line {lineno}: variable expansion (`$NAME`) is not supported"
+            )
+        result[key] = value
+    return result

--- a/packages/agentbundle/tests/unit/test_credentials_parser.py
+++ b/packages/agentbundle/tests/unit/test_credentials_parser.py
@@ -1,0 +1,68 @@
+"""T2: stdlib ``.env`` parser — construction tests (skill-secrets spec § AC2)."""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from agentbundle.creds.loader import EnvParseError, parse_env_file
+
+
+def _write(tmp_path: pathlib.Path, content: str) -> pathlib.Path:
+    target = tmp_path / "credentials.env"
+    target.write_text(content, encoding="utf-8", newline="")
+    return target
+
+
+def test_parses_unquoted_key_value(tmp_path):
+    path = _write(tmp_path, "KEY=value\n")
+    assert parse_env_file(path) == {"KEY": "value"}
+
+
+def test_parses_quoted_value_with_spaces(tmp_path):
+    path = _write(tmp_path, 'KEY="value with spaces"\n')
+    assert parse_env_file(path) == {"KEY": "value with spaces"}
+
+
+def test_strips_trailing_cr_on_crlf_line(tmp_path):
+    path = _write(tmp_path, "KEY=value\r\n")
+    assert parse_env_file(path) == {"KEY": "value"}
+
+
+def test_preserves_cr_inside_quoted_value(tmp_path):
+    # AC2 carve-out: \r inside a quoted value is preserved; only the
+    # trailing line terminator is stripped.
+    path = _write(tmp_path, 'KEY="a\rb"\n')
+    assert parse_env_file(path) == {"KEY": "a\rb"}
+
+
+def test_ignores_comments_and_blank_lines(tmp_path):
+    path = _write(
+        tmp_path,
+        "# comment line\n\nKEY=value\n\n# trailing comment\n",
+    )
+    assert parse_env_file(path) == {"KEY": "value"}
+
+
+def test_refuses_export_prefix(tmp_path):
+    path = _write(tmp_path, "export KEY=value\n")
+    with pytest.raises(EnvParseError, match="export"):
+        parse_env_file(path)
+
+
+def test_refuses_variable_expansion(tmp_path):
+    path = _write(tmp_path, "KEY=$OTHER\n")
+    with pytest.raises(EnvParseError, match="variable expansion"):
+        parse_env_file(path)
+
+
+def test_refuses_multi_line_quoted_value(tmp_path):
+    path = _write(tmp_path, 'KEY="line1\nline2"\n')
+    with pytest.raises(EnvParseError, match="multi-line"):
+        parse_env_file(path)
+
+
+def test_accepts_value_with_equals(tmp_path):
+    path = _write(tmp_path, "KEY=value=with=equals\n")
+    assert parse_env_file(path) == {"KEY": "value=with=equals"}


### PR DESCRIPTION
## Summary

- New ``agentbundle.creds.loader`` module with ``EnvParseError`` and ``parse_env_file(path) -> dict[str, str]`` — stdlib-only (``pathlib``, ``re``).
- Parser is intentionally less than ``python-dotenv``: supports the narrow subset spec § AC2 pins as the contract for Tier-3 dotfile content.
- Refuses ``export KEY=value``, ``KEY=\$OTHER`` variable expansion, and quoted values spanning two physical lines; preserves embedded ``\r`` inside a quoted value.

Closes **AC2** of [skill-secrets spec](../blob/main/docs/specs/skill-secrets/spec.md).

## Test plan

- [x] ``PYTHONPATH=packages/agentbundle python3 -m pytest packages/agentbundle/tests/unit/test_credentials_parser.py -v`` — 9/9 pass (one test per AC2 branch).
- [x] ``PYTHONPATH=packages/agentbundle python3 -m pytest packages/agentbundle/tests/`` — full suite green (no regressions).
- [x] ``make build-check`` — clean (only the expected ``[info] unclassified: docs/ROADMAP.md``).
- [x] ``tools/lint-agents-md.sh`` — clean.
- [x] ``tools/lint-agent-artifacts.sh`` — clean.

## Wave 1 of 3

This PR is task **T2** of skill-secrets implementation (RFC-0006). It's the first half of Wave 1; the parallel half is **T9** (lint allow-list, separate PR). No dependencies between the two.