### PR TITLE
feat(skill-secrets): T9 — SKILL.md frontmatter + lint allow-list

### DIFF
--- a/tools/lint-agent-artifacts.sh
+++ b/tools/lint-agent-artifacts.sh
@@ -8,7 +8,12 @@
 #     - File exists, has valid YAML frontmatter delimited by ---
 #     - Frontmatter has non-empty `name` (kebab-case) and `description`
 #     - Directory name == frontmatter `name`
-#     - Frontmatter has no unknown keys (allowed: name, description)
+#     - Frontmatter has no unknown keys (allowed: name, description,
+#       dependencies, credentialed, primitive-class)
+#     - If `credentialed` is present, its value must be a YAML boolean
+#       (`true` or `false`); absence means the skill is not credentialed.
+#     - If `primitive-class` is present, its value must be one of
+#       `credentialed-cli` or `mcp-server`.
 #
 #   Subagents (.claude/agents/<name>.md):
 #     - File has valid YAML frontmatter
@@ -49,7 +54,9 @@ error_count = 0
 KEBAB = re.compile(r"^[a-z][a-z0-9-]*$")
 LINK = re.compile(r"\]\(([^)]+)\)")
 
-ALLOWED_SKILL_KEYS = {"name", "description", "dependencies"}
+ALLOWED_SKILL_KEYS = {"name", "description", "dependencies",
+                      "credentialed", "primitive-class"}
+ALLOWED_PRIMITIVE_CLASSES = {"credentialed-cli", "mcp-server"}
 ALLOWED_AGENT_KEYS = {"name", "description", "tools", "model", "dependencies"}
 ALLOWED_COMMAND_KEYS = {"description", "allowed-tools", "model", "argument-hint"}
 
@@ -177,6 +184,22 @@ def check_skill(path):
     if unknown:
         err(path, f"unknown frontmatter keys: {sorted(unknown)} "
                   f"(allowed: {sorted(ALLOWED_SKILL_KEYS)})")
+    # Credentialed-skill frontmatter keys (per skill-secrets spec § AC25).
+    # Absence of `credentialed` means the skill is not credentialed; the
+    # lint skips the credentialed-specific checks. When present, the value
+    # must be a literal YAML boolean — strings like "yes" or "true" are
+    # rejected so the type-check is unambiguous.
+    if "credentialed" in fields:
+        cval = fields["credentialed"]
+        if cval not in ("true", "false"):
+            err(path, f"frontmatter key 'credentialed' must be boolean "
+                      f"(true|false), got {cval!r}")
+    if "primitive-class" in fields:
+        pval = fields["primitive-class"]
+        if pval not in ALLOWED_PRIMITIVE_CLASSES:
+            err(path, f"frontmatter key 'primitive-class' must be one of: "
+                      f"{', '.join(sorted(ALLOWED_PRIMITIVE_CLASSES))} "
+                      f"(got {pval!r})")
     if not body.strip():
         err(path, "body is empty")
     check_links(path, body, body_start)

--- a/tools/test-lint-agent-artifacts.sh
+++ b/tools/test-lint-agent-artifacts.sh
@@ -159,3 +159,119 @@ if (( fail )); then
 fi
 
 echo "✓ Self-test: passed (all ${#EXPECTED_PATTERNS[@]} expected error patterns observed)."
+
+# ── Credentialed-skill frontmatter fixtures (per skill-secrets spec § AC25) ──
+# These three cases need separate trees because the positive and negative
+# cases must produce different lint exit codes — the existing harness above
+# mixes pass-and-fail fixtures in one tree and grep-asserts patterns; that
+# shape can't carry an "exit 0" assertion for a single conforming skill.
+
+TMP_CRED_OK="$(mktemp -d)"
+TMP_CRED_BAD_BOOL="$(mktemp -d)"
+TMP_CRED_BAD_CLASS="$(mktemp -d)"
+trap 'rm -rf "$TMP" "$TMP_CRED_OK" "$TMP_CRED_BAD_BOOL" "$TMP_CRED_BAD_CLASS"' EXIT
+
+# Positive: a conforming credentialed skill with boolean true + valid class.
+mkdir -p "$TMP_CRED_OK/.claude/skills/conforming-credentialed"
+cat > "$TMP_CRED_OK/.claude/skills/conforming-credentialed/SKILL.md" <<'EOF'
+---
+name: conforming-credentialed
+description: A credentialed skill with valid frontmatter keys; the lint must accept it.
+credentialed: true
+primitive-class: credentialed-cli
+---
+
+Body content.
+EOF
+
+set +e
+out_ok="$(LINT_ROOT="$TMP_CRED_OK" bash "$REPO_ROOT/tools/lint-agent-artifacts.sh" 2>&1)"
+exit_ok=$?
+set -e
+
+if (( exit_ok != 0 )); then
+  echo "✖ conforming-credentialed: lint exited $exit_ok; expected 0." >&2
+  echo "Linter output was:" >&2
+  echo "---" >&2
+  echo "$out_ok" >&2
+  echo "---" >&2
+  exit 1
+fi
+
+# Negative: credentialed value is a quoted string, not a YAML boolean.
+mkdir -p "$TMP_CRED_BAD_BOOL/.claude/skills/bad-credentialed"
+cat > "$TMP_CRED_BAD_BOOL/.claude/skills/bad-credentialed/SKILL.md" <<'EOF'
+---
+name: bad-credentialed
+description: credentialed key is a string, not a boolean; lint must reject.
+credentialed: "yes"
+---
+
+Body content.
+EOF
+
+set +e
+out_bad_bool="$(LINT_ROOT="$TMP_CRED_BAD_BOOL" bash "$REPO_ROOT/tools/lint-agent-artifacts.sh" 2>&1)"
+exit_bad_bool=$?
+set -e
+
+fail=0
+if (( exit_bad_bool == 0 )); then
+  echo "✖ bad-credentialed: lint exited 0; expected non-zero." >&2
+  fail=1
+fi
+if ! grep -qF -- "credentialed" <<< "$out_bad_bool"; then
+  echo "✖ bad-credentialed: stderr missing substring 'credentialed'" >&2
+  fail=1
+fi
+if ! grep -qF -- "must be boolean" <<< "$out_bad_bool"; then
+  echo "✖ bad-credentialed: stderr missing substring 'must be boolean'" >&2
+  fail=1
+fi
+
+# Negative: primitive-class value is not one of the two allowed strings.
+mkdir -p "$TMP_CRED_BAD_CLASS/.claude/skills/bad-primitive-class"
+cat > "$TMP_CRED_BAD_CLASS/.claude/skills/bad-primitive-class/SKILL.md" <<'EOF'
+---
+name: bad-primitive-class
+description: primitive-class value is unknown; lint must reject.
+credentialed: true
+primitive-class: mcp-broker
+---
+
+Body content.
+EOF
+
+set +e
+out_bad_class="$(LINT_ROOT="$TMP_CRED_BAD_CLASS" bash "$REPO_ROOT/tools/lint-agent-artifacts.sh" 2>&1)"
+exit_bad_class=$?
+set -e
+
+if (( exit_bad_class == 0 )); then
+  echo "✖ bad-primitive-class: lint exited 0; expected non-zero." >&2
+  fail=1
+fi
+if ! grep -qF -- "primitive-class" <<< "$out_bad_class"; then
+  echo "✖ bad-primitive-class: stderr missing substring 'primitive-class'" >&2
+  fail=1
+fi
+if ! grep -qE -- "credentialed-cli|mcp-server" <<< "$out_bad_class"; then
+  echo "✖ bad-primitive-class: stderr missing one of: credentialed-cli, mcp-server" >&2
+  fail=1
+fi
+
+if (( fail )); then
+  echo
+  echo "Self-test (credentialed-skill cases): failed." >&2
+  echo "bad-bool output was:" >&2
+  echo "---" >&2
+  echo "$out_bad_bool" >&2
+  echo "---" >&2
+  echo "bad-class output was:" >&2
+  echo "---" >&2
+  echo "$out_bad_class" >&2
+  echo "---" >&2
+  exit 1
+fi
+
+echo "✓ Self-test (credentialed-skill cases): passed (conforming clean; bad-bool + bad-class refused with expected stderr)."


### PR DESCRIPTION
## Summary

- ``tools/lint-agent-artifacts.sh`` ``ALLOWED_SKILL_KEYS`` gains ``credentialed`` and ``primitive-class`` (spec § AC25).
- Type-check branches: ``credentialed`` must be a YAML boolean (``true`` | ``false``); ``primitive-class`` must be one of ``credentialed-cli`` or ``mcp-server``. Absence of ``credentialed`` keeps the skill as not-credentialed and the lint skips the specialized checks.
- ``tools/test-lint-agent-artifacts.sh`` gains three new fixture trees (positive + bad-bool + bad-class) in separate tempdirs — the existing single-tree pattern can't carry an exit-0 assertion for a single conforming skill.

Closes **AC25** of [skill-secrets spec](../blob/main/docs/specs/skill-secrets/spec.md).

## Test plan

- [x] ``tools/test-lint-agent-artifacts.sh`` — 11 legacy patterns observed; 3 new credentialed-skill cases (conforming clean; bad-bool + bad-class refused with expected stderr substrings).
- [x] ``make build-check`` — clean.
- [x] ``tools/lint-agents-md.sh`` — clean.
- [x] ``tools/lint-agent-artifacts.sh`` (repo-wide) — clean.
- [x] ``PYTHONPATH=packages/agentbundle python3 -m pytest packages/agentbundle/tests/`` — full suite green (no regressions).

## Wave 1 of 3

This PR is task **T9** of skill-secrets implementation (RFC-0006). It runs in parallel with **T2** (.env parser, separate PR). Lint-only changes; no runtime coupling.