### PR TITLE
feat(skill-secrets): T3 — credentials loader + Tier-1 + shim + pyproject

### DIFF
--- a/packages/agentbundle/agent_ready/credentials.py
+++ b/packages/agentbundle/agent_ready/credentials.py
@@ -1,0 +1,26 @@
+"""Public shim for credentialed-primitive authors.
+
+Per spec § AC3, this is the **only** import root primitive authors are
+expected to touch:
+
+    from agent_ready.credentials import load_credentials
+
+Re-exports the loader surface from ``agentbundle.creds.loader`` /
+``agentbundle.creds.exceptions``. Adding a new public name here is an
+ADR-level decision — keep the surface narrow.
+"""
+
+from __future__ import annotations
+
+from agentbundle.creds.exceptions import (
+    CredentialsMissingError,
+    Tier2HardFailError,
+)
+from agentbundle.creds.loader import Credentials, load_credentials
+
+__all__ = [
+    "Credentials",
+    "CredentialsMissingError",
+    "Tier2HardFailError",
+    "load_credentials",
+]

--- a/packages/agentbundle/agentbundle/creds/exceptions.py
+++ b/packages/agentbundle/agentbundle/creds/exceptions.py
@@ -1,0 +1,20 @@
+"""Exception hierarchy for the credentialed-primitive loader (spec § AC3, AC11).
+
+``CredentialsMissingError`` — at least one required key did not resolve at
+any tier; the message names the namespace and the missing keys.
+
+``Tier2HardFailError`` — the OS keyring (Tier 2) returned a non-recoverable
+error code (e.g. ``ERROR_NO_SUCH_LOGON_SESSION`` on Windows). Per spec §
+AC11, the resolver does **not** fall through to Tier 3 in this case;
+silent degradation defeats the security posture the user chose.
+"""
+
+from __future__ import annotations
+
+
+class CredentialsMissingError(Exception):
+    """Raised when a required credential key cannot be resolved at any tier."""
+
+
+class Tier2HardFailError(Exception):
+    """Raised when the OS keyring backend returns a hard-fail error code."""

--- a/packages/agentbundle/agentbundle/creds/loader.py
+++ b/packages/agentbundle/agentbundle/creds/loader.py
@@ -1,9 +1,21 @@
-"""Stdlib ``.env`` parser for credentialed primitives.
+"""Loader API and stdlib ``.env`` parser for credentialed primitives.
 
-Intentionally less than ``python-dotenv``: this parser supports only the
-narrow subset spec § AC2 pins as the contract for Tier-3 dotfile content
-(``~/.agent-ready/credentials.env``). Stdlib-only — no ``python-dotenv``,
-no third-party imports — per spec § Boundaries § Never do.
+This module exposes the public surface a credentialed-primitive author
+imports (via the ``agent_ready.credentials`` shim, per spec § AC3):
+
+- ``load_credentials(namespace, required_keys, schema_path=None)`` — resolves
+  credentials through Tier 1 (env var) → Tier 2 (OS keyring) → Tier 3
+  (dotfile), first-hit-wins per key.
+- ``Credentials`` — immutable, attribute-access view of the resolved values.
+- ``EnvParseError`` — raised by ``parse_env_file`` on unsupported syntax.
+
+Stdlib-only per spec § Boundaries § Never do — no ``python-dotenv``, no
+``keyring``, no third-party imports. The Tier-2 backend is dispatched at
+module-load time per AC4b: ``_keychain_macos`` iff ``sys.platform ==
+"darwin"``, ``_credman_windows`` iff ``"win32"``, no Tier-2 backend on
+other platforms (resolver falls through directly to Tier 3).
+
+``.env`` parser (T2 surface, retained here):
 
 Supported:
     ``KEY=value``
@@ -22,10 +34,171 @@ quoted value is preserved (``KEY="a\\rb"`` → ``{"KEY": "a\\rb"}``).
 
 from __future__ import annotations
 
+import os
 import pathlib
 import re
+import sys
+
+from .exceptions import CredentialsMissingError, Tier2HardFailError
 
 _KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+# Tier-2 backend dispatch at module-load time (spec § AC4b). The backend
+# modules are added by T4 (macOS) and T5 (Windows); until they land, the
+# try/except yields ``None`` and the resolver skips Tier 2 on the matching
+# platform. On Linux (and any non-Darwin / non-Windows platform), no import
+# is attempted at all — Tier 2 is unavailable by absence.
+if sys.platform == "darwin":
+    try:
+        from . import _keychain_macos as _tier2_backend  # type: ignore[no-redef]
+    except ImportError:
+        _tier2_backend = None  # type: ignore[assignment]
+elif sys.platform == "win32":
+    try:
+        from . import _credman_windows as _tier2_backend  # type: ignore[no-redef]
+    except ImportError:
+        _tier2_backend = None  # type: ignore[assignment]
+else:
+    _tier2_backend = None
+
+
+class Credentials:
+    """Immutable, attribute-access view of a namespace's resolved credentials.
+
+    Constructed by ``load_credentials``. The contract (spec § AC3) is:
+
+    - Attribute access returns the resolved value:
+      ``creds.API_TOKEN`` returns the resolved ``API_TOKEN`` for the
+      namespace.
+    - Attempting to assign or delete an attribute raises ``AttributeError``;
+      callers cannot mutate the object after it leaves the loader.
+
+    No ``__repr__`` override — the default ``object`` repr is intentional
+    so a misplaced ``print(creds)`` never echoes the token bytes.
+    """
+
+    __slots__ = ("_namespace", "_values")
+
+    def __init__(self, namespace: str, values: dict[str, str]) -> None:
+        # Bypass the override below to seed the slot attributes.
+        object.__setattr__(self, "_namespace", namespace)
+        object.__setattr__(self, "_values", dict(values))
+
+    def __setattr__(self, name: str, value: object) -> None:
+        raise AttributeError(
+            f"Credentials is immutable; cannot set attribute {name!r}"
+        )
+
+    def __delattr__(self, name: str) -> None:
+        raise AttributeError(
+            f"Credentials is immutable; cannot delete attribute {name!r}"
+        )
+
+    def __getattr__(self, name: str) -> str:
+        # __getattr__ is only invoked when normal lookup (including
+        # __slots__) fails — so it serves the credential-name attribute
+        # surface and nothing else. Names beginning with ``_`` are
+        # internal; the slot lookup already handles ``_namespace`` /
+        # ``_values``, so anything starting with ``_`` here is genuinely
+        # absent.
+        if name.startswith("_"):
+            raise AttributeError(name)
+        try:
+            values = object.__getattribute__(self, "_values")
+        except AttributeError as exc:  # pragma: no cover — defensive
+            raise AttributeError(name) from exc
+        if name in values:
+            return values[name]
+        namespace = object.__getattribute__(self, "_namespace")
+        raise AttributeError(
+            f"namespace {namespace!r} has no credential {name!r}"
+        )
+
+
+def _tier1_env(namespace: str, key: str) -> str | None:
+    """Resolve ``<NAMESPACE>_<KEY>`` from ``os.environ`` (spec § AC5).
+
+    Empty-string env vars count as unset and return ``None`` so the
+    resolver falls through to lower tiers.
+    """
+    env_name = f"{namespace.upper()}_{key}"
+    value = os.environ.get(env_name)
+    if not value:
+        return None
+    return value
+
+
+def _tier2(namespace: str, key: str) -> str | None:
+    """Resolve via the platform-specific keyring backend (spec § AC6, AC9).
+
+    Returns ``None`` when the backend is absent (non-Darwin / non-Windows
+    platforms, or backend modules not yet shipped) or reports a clean
+    miss. Hard-fail error codes from the underlying API propagate as
+    ``Tier2HardFailError`` per AC11.
+    """
+    if _tier2_backend is None:
+        return None
+    return _tier2_backend.read_credential(namespace, key)
+
+
+def _tier3(namespace: str, key: str) -> str | None:
+    """Resolve from the Tier-3 dotfile (spec § AC13).
+
+    Stubbed in T3 — T6 implements the dotfile read. Returns ``None`` so
+    the resolver continues toward ``CredentialsMissingError`` for any
+    key that did not resolve at Tier 1 or Tier 2.
+    """
+    return None
+
+
+def load_credentials(
+    namespace: str,
+    required_keys: list[str],
+    *,
+    schema_path: pathlib.Path | None = None,
+) -> Credentials:
+    """Resolve ``required_keys`` for ``namespace``, walking Tiers 1 → 2 → 3.
+
+    First-hit-wins per key (spec § AC4): a key resolved at Tier 1 is not
+    re-checked at lower tiers; mixing tiers across keys within one
+    namespace is permitted.
+
+    Raises ``CredentialsMissingError`` if any required key did not
+    resolve at any tier. The error message names the namespace and the
+    list of missing keys per AC3.
+
+    The ``schema_path`` kwarg is reserved for T7 — primitive authors who
+    load their own schema can pass it here; the default ``None`` defers
+    to the canonical lookup (T7 wires the canonical path resolver).
+    """
+    resolved: dict[str, str] = {}
+    missing: list[str] = []
+    for key in required_keys:
+        value = (
+            _tier1_env(namespace, key)
+            or _tier2(namespace, key)
+            or _tier3(namespace, key)
+        )
+        if value:
+            resolved[key] = value
+        else:
+            missing.append(key)
+    if missing:
+        raise CredentialsMissingError(
+            f"namespace {namespace!r}: missing required credential(s): "
+            f"{', '.join(missing)}"
+        )
+    return Credentials(namespace, resolved)
+
+
+__all__ = [
+    "Credentials",
+    "CredentialsMissingError",
+    "EnvParseError",
+    "Tier2HardFailError",
+    "load_credentials",
+    "parse_env_file",
+]
 
 
 class EnvParseError(ValueError):

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -14,7 +14,7 @@ agentbundle = "agentbundle.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["agentbundle*"]
+include = ["agentbundle*", "agent_ready*"]
 
 [tool.setuptools.package-data]
 agentbundle = ["_data/*"]

--- a/packages/agentbundle/tests/integration/test_credentials_wheel.py
+++ b/packages/agentbundle/tests/integration/test_credentials_wheel.py
@@ -1,0 +1,62 @@
+"""T3 / AC4c: ``agent_ready.credentials`` is reachable from an installed wheel.
+
+The test builds + installs ``packages/agentbundle`` into a ``tmp_path``-scoped
+site directory, then runs the import in a subprocess whose ``PYTHONPATH``
+points at that site. Exit 0 from the import is the AC4c contract.
+
+This is slow (~5–30s for the PEP 517 build); it lives under
+``tests/integration`` so the default ``pytest -q`` over ``tests/unit/`` stays
+fast, while CI's full-suite invocation still picks it up.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import sys
+
+def test_agent_ready_credentials_resolves_from_installed_wheel(tmp_path):
+    site_dir = tmp_path / "site"
+    # __file__: packages/agentbundle/tests/integration/test_credentials_wheel.py
+    # parents[2] resolves to packages/agentbundle/ — the package root pip
+    # should pick up.
+    pkg_root = pathlib.Path(__file__).resolve().parents[2]
+    install = subprocess.run(
+        [
+            sys.executable, "-m", "pip", "install",
+            "--target", str(site_dir),
+            "--quiet", "--no-deps",
+            str(pkg_root),
+        ],
+        capture_output=True, text=True,
+    )
+    assert install.returncode == 0, (
+        f"pip install failed (rc={install.returncode}):\n"
+        f"stdout: {install.stdout}\nstderr: {install.stderr}"
+    )
+    # Confirm the shim package actually landed in the wheel.
+    assert (site_dir / "agent_ready" / "credentials.py").is_file(), (
+        f"agent_ready/credentials.py missing from installed target; "
+        f"listing: {sorted(p.name for p in site_dir.iterdir())}"
+    )
+    # PEP 668-friendly: don't inherit the parent's PYTHONPATH; point it
+    # only at the freshly-installed target.
+    env = {
+        "PATH": os.environ.get("PATH", ""),
+        "PYTHONPATH": str(site_dir),
+        # Windows runs need SYSTEMROOT for subprocess.run to find DLLs.
+        "SYSTEMROOT": os.environ.get("SYSTEMROOT", ""),
+    }
+    res = subprocess.run(
+        [sys.executable, "-c",
+         "from agent_ready.credentials import load_credentials; "
+         "from agent_ready.credentials import Credentials, "
+         "CredentialsMissingError, Tier2HardFailError"],
+        env=env,
+        capture_output=True, text=True,
+    )
+    assert res.returncode == 0, (
+        f"import from installed wheel failed (rc={res.returncode}):\n"
+        f"stdout: {res.stdout}\nstderr: {res.stderr}"
+    )

--- a/packages/agentbundle/tests/unit/test_credentials_loader.py
+++ b/packages/agentbundle/tests/unit/test_credentials_loader.py
@@ -1,0 +1,129 @@
+"""T3: credentials loader API + Tier-1 env-var resolver.
+
+Covers spec § AC3 (load_credentials surface + Credentials immutability),
+AC4 (precedence — Tier 1 first-hit-wins; later tiers stubbed at this
+point in the rollout), AC4b (Tier-2 backend dispatch is platform-
+discriminated at module-load time), and AC5 (Tier-1 env-var read with
+empty-string-as-unset fallthrough).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+
+# ── Fixture: every test runs with a clean creds namespace and ──────────
+#    Tier-2 forced absent. The latter is important because the developer
+#    might have a real macOS Keychain entry under the fixture namespace
+#    — forcing the backend to None at this layer keeps unit tests
+#    hermetic regardless of host state. The platform-dispatch test below
+#    re-imports the loader from scratch and is the canonical AC4b check.
+@pytest.fixture(autouse=True)
+def isolated_loader_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))  # Windows parity
+    for var in list(os.environ):
+        if var.startswith("FIXTURE_T3_"):
+            monkeypatch.delenv(var, raising=False)
+    from agentbundle.creds import loader
+    monkeypatch.setattr(loader, "_tier2_backend", None)
+
+
+def test_resolves_tier1_env_var(monkeypatch):
+    from agent_ready.credentials import Credentials, load_credentials
+    monkeypatch.setenv("FIXTURE_T3_API_TOKEN", "secret-token")
+    creds = load_credentials("fixture_t3", required_keys=["API_TOKEN"])
+    assert isinstance(creds, Credentials)
+    assert creds.API_TOKEN == "secret-token"
+
+
+def test_tier1_resolves_multiple_keys(monkeypatch):
+    from agent_ready.credentials import load_credentials
+    monkeypatch.setenv("FIXTURE_T3_API_TOKEN", "tok-1")
+    monkeypatch.setenv("FIXTURE_T3_BASE_URL", "https://jira.example.com")
+    creds = load_credentials(
+        "fixture_t3", required_keys=["API_TOKEN", "BASE_URL"]
+    )
+    assert creds.API_TOKEN == "tok-1"
+    assert creds.BASE_URL == "https://jira.example.com"
+
+
+def test_empty_env_var_falls_through(monkeypatch):
+    from agent_ready.credentials import CredentialsMissingError, load_credentials
+    monkeypatch.setenv("FIXTURE_T3_API_TOKEN", "")  # AC5: empty == unset
+    with pytest.raises(CredentialsMissingError) as excinfo:
+        load_credentials("fixture_t3", required_keys=["API_TOKEN"])
+    msg = str(excinfo.value)
+    assert "fixture_t3" in msg
+    assert "API_TOKEN" in msg
+
+
+def test_missing_required_key_raises_with_namespace_and_key():
+    from agent_ready.credentials import CredentialsMissingError, load_credentials
+    with pytest.raises(CredentialsMissingError) as excinfo:
+        load_credentials("fixture_t3", required_keys=["API_TOKEN", "BASE_URL"])
+    msg = str(excinfo.value)
+    assert "fixture_t3" in msg
+    assert "API_TOKEN" in msg
+    assert "BASE_URL" in msg
+
+
+def test_credentials_is_immutable_on_assignment(monkeypatch):
+    from agent_ready.credentials import load_credentials
+    monkeypatch.setenv("FIXTURE_T3_API_TOKEN", "secret")
+    creds = load_credentials("fixture_t3", required_keys=["API_TOKEN"])
+    with pytest.raises(AttributeError):
+        creds.API_TOKEN = "new"  # type: ignore[misc]
+
+
+def test_credentials_is_immutable_on_delete(monkeypatch):
+    from agent_ready.credentials import load_credentials
+    monkeypatch.setenv("FIXTURE_T3_API_TOKEN", "secret")
+    creds = load_credentials("fixture_t3", required_keys=["API_TOKEN"])
+    with pytest.raises(AttributeError):
+        del creds.API_TOKEN
+
+
+def test_credentials_attribute_miss_raises_attributeerror(monkeypatch):
+    from agent_ready.credentials import load_credentials
+    monkeypatch.setenv("FIXTURE_T3_API_TOKEN", "secret")
+    creds = load_credentials("fixture_t3", required_keys=["API_TOKEN"])
+    with pytest.raises(AttributeError):
+        _ = creds.NOT_RESOLVED
+
+
+def test_public_surface_via_agent_ready_credentials():
+    """AC3: only the four names are exported."""
+    from agent_ready import credentials as ar
+    assert set(ar.__all__) == {
+        "Credentials",
+        "CredentialsMissingError",
+        "Tier2HardFailError",
+        "load_credentials",
+    }
+    # Each name is bound to a callable / class.
+    assert callable(ar.load_credentials)
+    assert isinstance(ar.Credentials, type)
+    assert issubclass(ar.CredentialsMissingError, Exception)
+    assert issubclass(ar.Tier2HardFailError, Exception)
+
+
+def test_platform_dispatch_no_tier2_backend_on_linux(monkeypatch):
+    """AC4b: neither Darwin nor Windows backend is loaded on Linux."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    # Drop every module under the creds-shim tree so the re-import
+    # re-runs the platform-discriminated dispatch from scratch.
+    for mod_name in list(sys.modules):
+        if (
+            mod_name == "agent_ready"
+            or mod_name.startswith("agent_ready.")
+            or mod_name == "agentbundle.creds"
+            or mod_name.startswith("agentbundle.creds.")
+        ):
+            sys.modules.pop(mod_name, None)
+    import agent_ready.credentials  # noqa: F401 — re-imports under patched platform
+    assert "agentbundle.creds._keychain_macos" not in sys.modules
+    assert "agentbundle.creds._credman_windows" not in sys.modules


### PR DESCRIPTION
## Summary

- Public ``agent_ready.credentials`` surface (Credentials, load_credentials, CredentialsMissingError, Tier2HardFailError) — re-exports from ``agentbundle.creds.loader`` / ``creds.exceptions``.
- ``load_credentials`` walks Tier 1 (env) → Tier 2 (keyring, platform-discriminated at module-load per AC4b) → Tier 3 (dotfile, stubbed; T6 lands the read), first-hit-wins per key (AC4); raises ``CredentialsMissingError`` naming the namespace + missing keys (AC3, AC5).
- ``Credentials`` is immutable (custom ``__setattr__`` / ``__delattr__`` raise; ``__getattr__`` reads from the values dict; no ``__repr__`` override).
- ``pyproject.toml`` extends ``[tool.setuptools.packages.find] include`` to ``["agentbundle*", "agent_ready*"]`` so the shim ships with the wheel (AC4c).

Closes **AC3, AC4, AC4b, AC4c, AC5**.

## Test plan

- [x] ``tests/unit/test_credentials_loader.py`` — 9/9 pass (Tier-1 resolution; multi-key; empty-env fallthrough; missing-key error text; immutability assign/delete/miss; public surface exact-set; platform dispatch re-import asserts neither backend in sys.modules on Linux).
- [x] ``tests/integration/test_credentials_wheel.py`` — AC4c end-to-end: pip install into tmp_path → subprocess imports the four shim names (~10s).
- [x] ``make build-check`` — clean.
- [x] ``tools/lint-agents-md.sh`` + ``tools/lint-agent-artifacts.sh`` — clean.
- [x] Full ``pytest packages/agentbundle/tests/`` — green, no regressions.

## Wave 2 of 3

Task **T3** of skill-secrets implementation. Runs in parallel with **T10** (conventions-check lint extensions, separate PR). Tier-2 hard-fail paths (``Tier2HardFailError`` raises) and the actual backends land in Wave 3 (T4 macOS, T5 Windows); this PR's Tier-2 dispatch is platform-discriminated but currently no-ops until those modules ship.