### PR TITLE
feat(skill-secrets): T10 — conventions-check lint extensions

### DIFF
--- a/.claude/commands/conventions-check.md
+++ b/.claude/commands/conventions-check.md
@@ -25,6 +25,23 @@ Run both repo linters and report findings.
 4. Skill dirs contain a `SKILL.md` (and no stray `.md` siblings).
 5. Internal markdown links inside each artifact resolve.
 
-If either linter is missing or fails to run, fall back to inspecting the
+**`bash tools/lint-credentialed-skills.sh`** — credentialed-skill rules
+(skill-secrets spec § AC26 — see `docs/specs/skill-secrets/spec.md`);
+scoped to skills whose `SKILL.md` declares `credentialed: true`:
+
+1. The body contains an `### Security rules (non-negotiable)` heading
+   and the three RFC-0006 § 4 substrings inside that section (the
+   verbatim "Don't" block).
+2. For `primitive-class: credentialed-cli`: no script under the skill's
+   `scripts/` directory accepts an `argparse` flag whose normalised
+   name (strip leading `-`, casefold, `-` → `_`) is one of
+   `{token, api_token, api_key, bearer, pat, password}`. Detection
+   handles literal strings AND `"--" + "name"`-style concatenation.
+3. No script under a credentialed skill's `scripts/` directory contains
+   the substring `.agent-ready/credentials.env` unless the opt-out
+   comment `# credentialed-primitive: reads-creds-directly` appears
+   on the same line.
+
+If any linter is missing or fails to run, fall back to inspecting the
 files directly and report the same checks manually. Don't auto-fix
 anything — report findings and let the user decide what to do.

--- a/packages/agentbundle/tests/fixtures/creds/skills/argv-flag-normalised/SKILL.md
+++ b/packages/agentbundle/tests/fixtures/creds/skills/argv-flag-normalised/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: argv-flag-normalised
+description: Credentialed-CLI fixture exercising the AC27 normalisation paths — casing, kebab, and string-add obfuscation; AC26(b)+AC27 findings expected.
+credentialed: true
+primitive-class: credentialed-cli
+---
+
+Body with the full "Don't" block so only AC26(b) variants fire:
+
+### Security rules (non-negotiable)
+
+- Secrets live only in `~/.agent-ready/credentials.env`
+  (mode 0600 on POSIX; DACL-restricted on Windows), the OS keyring,
+  or process environment variables.
+  **Never** read that file, print it, or echo the token.
+- **Never** put the token on the command line. The primitive
+  refuses flags like `--token` / `--api-token` / `--bearer` /
+  `--pat` / `--password` and exits — do not work around it.
+- If `check` exits with the "missing credentials" code, tell the
+  user to run `agentbundle creds setup <namespace>` themselves.
+  It's interactive — do not run it for them.

--- a/packages/agentbundle/tests/fixtures/creds/skills/argv-flag-normalised/scripts/cli.py
+++ b/packages/agentbundle/tests/fixtures/creds/skills/argv-flag-normalised/scripts/cli.py
@@ -1,0 +1,23 @@
+"""argv-flag-normalised: every AC27 obfuscation path the lint must defeat.
+
+The lint normalises the flag name (strip leading ``-``, casefold, ``-``
+→ ``_``) and compares against the banned set. Each ``add_argument`` call
+below resolves to a banned name after normalisation; T10 must flag all
+three.
+"""
+from __future__ import annotations
+
+import argparse
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--Token")              # casing variant → "token"
+    parser.add_argument("--api-Key")            # kebab + casing → "api_key"
+    parser.add_argument("--" + "password")      # BinOp(Add) → "password"
+    parser.parse_args()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/agentbundle/tests/fixtures/creds/skills/argv-flag/SKILL.md
+++ b/packages/agentbundle/tests/fixtures/creds/skills/argv-flag/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: argv-flag
+description: Credentialed-CLI fixture whose script accepts `--token` on argv; AC26(b) finding expected.
+credentialed: true
+primitive-class: credentialed-cli
+---
+
+Body content with the full "Don't" block (so AC26(a) is silent and the
+argv finding is the only one fired):
+
+### Security rules (non-negotiable)
+
+- Secrets live only in `~/.agent-ready/credentials.env`
+  (mode 0600 on POSIX; DACL-restricted on Windows), the OS keyring,
+  or process environment variables.
+  **Never** read that file, print it, or echo the token.
+- **Never** put the token on the command line. The primitive
+  refuses flags like `--token` / `--api-token` / `--bearer` /
+  `--pat` / `--password` and exits — do not work around it.
+- If `check` exits with the "missing credentials" code, tell the
+  user to run `agentbundle creds setup <namespace>` themselves.
+  It's interactive — do not run it for them.

--- a/packages/agentbundle/tests/fixtures/creds/skills/argv-flag/scripts/cli.py
+++ b/packages/agentbundle/tests/fixtures/creds/skills/argv-flag/scripts/cli.py
@@ -1,0 +1,15 @@
+"""argv-flag fixture: the AC26(b) trigger — direct `--token` literal."""
+from __future__ import annotations
+
+import argparse
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--token")
+    parser.parse_args()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/agentbundle/tests/fixtures/creds/skills/conforming/SKILL.md
+++ b/packages/agentbundle/tests/fixtures/creds/skills/conforming/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: conforming
+description: A credentialed-CLI fixture skill that satisfies every AC26 check; lint should report zero findings.
+credentialed: true
+primitive-class: credentialed-cli
+---
+
+A no-op fixture skill used by T10's `conventions-check` lint tests.
+
+### Security rules (non-negotiable)
+
+- Secrets live only in `~/.agent-ready/credentials.env`
+  (mode 0600 on POSIX; DACL-restricted on Windows), the OS keyring,
+  or process environment variables.
+  **Never** read that file, print it, or echo the token.
+- **Never** put the token on the command line. The primitive
+  refuses flags like `--token` / `--api-token` / `--bearer` /
+  `--pat` / `--password` and exits — do not work around it.
+- If `check` exits with the "missing credentials" code, tell the
+  user to run `agentbundle creds setup <namespace>` themselves.
+  It's interactive — do not run it for them.

--- a/packages/agentbundle/tests/fixtures/creds/skills/conforming/scripts/cli.py
+++ b/packages/agentbundle/tests/fixtures/creds/skills/conforming/scripts/cli.py
@@ -1,0 +1,15 @@
+"""Conforming credentialed-CLI fixture: no argv flags, no dotfile reads."""
+from __future__ import annotations
+
+import argparse
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--namespace", required=True)
+    parser.parse_args()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/agentbundle/tests/fixtures/creds/skills/dotfile-grep/SKILL.md
+++ b/packages/agentbundle/tests/fixtures/creds/skills/dotfile-grep/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: dotfile-grep
+description: Credentialed fixture whose script opens `.agent-ready/credentials.env` directly without the opt-out marker; AC26(c) finding expected.
+credentialed: true
+primitive-class: credentialed-cli
+---
+
+Body with the full "Don't" block so only AC26(c) fires:
+
+### Security rules (non-negotiable)
+
+- Secrets live only in `~/.agent-ready/credentials.env`
+  (mode 0600 on POSIX; DACL-restricted on Windows), the OS keyring,
+  or process environment variables.
+  **Never** read that file, print it, or echo the token.
+- **Never** put the token on the command line. The primitive
+  refuses flags like `--token` / `--api-token` / `--bearer` /
+  `--pat` / `--password` and exits — do not work around it.
+- If `check` exits with the "missing credentials" code, tell the
+  user to run `agentbundle creds setup <namespace>` themselves.
+  It's interactive — do not run it for them.

--- a/packages/agentbundle/tests/fixtures/creds/skills/dotfile-grep/scripts/leak.py
+++ b/packages/agentbundle/tests/fixtures/creds/skills/dotfile-grep/scripts/leak.py
@@ -1,0 +1,12 @@
+"""dotfile-grep fixture: bare dotfile read with no opt-out marker."""
+from __future__ import annotations
+
+import os
+
+
+def leak():
+    return open(os.path.expanduser("~/.agent-ready/credentials.env")).read()
+
+
+if __name__ == "__main__":
+    leak()

--- a/packages/agentbundle/tests/fixtures/creds/skills/dotfile-with-optout/SKILL.md
+++ b/packages/agentbundle/tests/fixtures/creds/skills/dotfile-with-optout/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: dotfile-with-optout
+description: Credentialed primitive that legitimately reads the dotfile, with the opt-out marker on the same line; lint must NOT flag it.
+credentialed: true
+primitive-class: credentialed-cli
+---
+
+The credentialed-primitive itself (not a skill) legitimately reads the
+dotfile. The opt-out comment names the relaxation explicitly so PR review
+can see and approve.
+
+### Security rules (non-negotiable)
+
+- Secrets live only in `~/.agent-ready/credentials.env`
+  (mode 0600 on POSIX; DACL-restricted on Windows), the OS keyring,
+  or process environment variables.
+  **Never** read that file, print it, or echo the token.
+- **Never** put the token on the command line. The primitive
+  refuses flags like `--token` / `--api-token` / `--bearer` /
+  `--pat` / `--password` and exits — do not work around it.
+- If `check` exits with the "missing credentials" code, tell the
+  user to run `agentbundle creds setup <namespace>` themselves.
+  It's interactive — do not run it for them.

--- a/packages/agentbundle/tests/fixtures/creds/skills/dotfile-with-optout/scripts/legit.py
+++ b/packages/agentbundle/tests/fixtures/creds/skills/dotfile-with-optout/scripts/legit.py
@@ -1,0 +1,13 @@
+"""dotfile-with-optout fixture: opt-out marker on the same line keeps lint silent."""
+from __future__ import annotations
+
+import os
+
+
+def read():
+    path = os.path.expanduser("~/.agent-ready/credentials.env")  # credentialed-primitive: reads-creds-directly
+    return open(path).read()
+
+
+if __name__ == "__main__":
+    read()

--- a/packages/agentbundle/tests/fixtures/creds/skills/mcp-server-headers/SKILL.md
+++ b/packages/agentbundle/tests/fixtures/creds/skills/mcp-server-headers/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: mcp-server-headers
+description: MCP-server class fixture using header-naming flags (`--bearer-header`); AC26(b) ban is scoped to credentialed-cli only — lint must NOT flag this fixture.
+credentialed: true
+primitive-class: mcp-server
+---
+
+MCP-server class primitives legitimately accept header-naming flags
+(`--bearer-header`, `--auth-header`, `--header-prefix`). The storage
+convention does not apply because nothing is persisted; the SKILL.md
+"Don't" block has a parallel form noted in RFC-0006 § 4.
+
+### Security rules (non-negotiable)
+
+- Secrets live only in `~/.agent-ready/credentials.env`
+  (mode 0600 on POSIX; DACL-restricted on Windows), the OS keyring,
+  or process environment variables.
+  **Never** read that file, print it, or echo the token.
+- **Never** put the token on the command line. The primitive
+  refuses flags like `--token` / `--api-token` / `--bearer` /
+  `--pat` / `--password` and exits — do not work around it.
+- If `check` exits with the "missing credentials" code, tell the
+  user to run `agentbundle creds setup <namespace>` themselves.
+  It's interactive — do not run it for them.

--- a/packages/agentbundle/tests/fixtures/creds/skills/mcp-server-headers/scripts/cli.py
+++ b/packages/agentbundle/tests/fixtures/creds/skills/mcp-server-headers/scripts/cli.py
@@ -1,0 +1,17 @@
+"""mcp-server-headers: header-naming flags are allowed for this class."""
+from __future__ import annotations
+
+import argparse
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--bearer-header", default="Authorization")
+    parser.add_argument("--auth-header", default=None)
+    parser.add_argument("--header-prefix", default="Bearer ")
+    parser.parse_args()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/agentbundle/tests/fixtures/creds/skills/missing-dont-block/SKILL.md
+++ b/packages/agentbundle/tests/fixtures/creds/skills/missing-dont-block/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: missing-dont-block
+description: Credentialed-CLI fixture missing the `### Security rules (non-negotiable)` heading; AC26(a) finding expected.
+credentialed: true
+primitive-class: credentialed-cli
+---
+
+This fixture declares `credentialed: true` but omits the "Don't" block.
+T10's lint must report the missing heading.

--- a/packages/agentbundle/tests/integration/test_conventions_check_creds.py
+++ b/packages/agentbundle/tests/integration/test_conventions_check_creds.py
@@ -1,0 +1,132 @@
+"""T10: conventions-check lint extensions for credentialed skills.
+
+Construction tests against the fixture skills under
+``packages/agentbundle/tests/fixtures/creds/skills/``. The lint helper
+``tools/lint-credentialed-skills.sh`` is invoked per fixture (one fixture
+per ``LINT_ROOT`` so the per-fixture expectations don't pollute one
+another) and stderr is asserted against AC26 + AC27.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import shutil
+import subprocess
+
+import pytest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+LINT_SCRIPT = REPO_ROOT / "tools" / "lint-credentialed-skills.sh"
+FIXTURES_DIR = (
+    REPO_ROOT
+    / "packages"
+    / "agentbundle"
+    / "tests"
+    / "fixtures"
+    / "creds"
+    / "skills"
+)
+
+
+def _run_lint(fixture_name, tmp_path):
+    """Stage a single fixture skill under ``tmp_path/skills/<name>`` and
+    invoke the lint there. Per-fixture isolation prevents one fixture's
+    findings from masking another's.
+    """
+    src = FIXTURES_DIR / fixture_name
+    if not src.is_dir():
+        pytest.skip(f"fixture {fixture_name!r} not present")
+    dest = tmp_path / "skills" / fixture_name
+    shutil.copytree(src, dest)
+    env = {**os.environ, "LINT_ROOT": str(tmp_path)}
+    res = subprocess.run(
+        ["bash", str(LINT_SCRIPT)],
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    return res
+
+
+def test_conforming_fixture_reports_no_findings(tmp_path):
+    res = _run_lint("conforming", tmp_path)
+    assert res.returncode == 0, (
+        f"conforming should be clean; stderr={res.stderr}\nstdout={res.stdout}"
+    )
+    assert "0 finding(s)" in res.stdout
+    assert "1 skill(s) scanned" in res.stdout
+
+
+def test_missing_dont_block_reports_finding(tmp_path):
+    res = _run_lint("missing-dont-block", tmp_path)
+    assert res.returncode != 0
+    assert "missing-dont-block/SKILL.md" in res.stderr
+    assert "Security rules (non-negotiable)" in res.stderr
+
+
+def test_argv_flag_reports_finding(tmp_path):
+    res = _run_lint("argv-flag", tmp_path)
+    assert res.returncode != 0
+    assert "argv-flag/scripts/cli.py" in res.stderr
+    assert "'--token'" in res.stderr
+    assert "argv-borne credential flag" in res.stderr
+
+
+def test_argv_flag_normalised_catches_all_three_variants(tmp_path):
+    """AC27: the lint normalises (strip ``-``, casefold, ``-`` → ``_``)
+    and catches casing, kebab, and string-concatenation obfuscation."""
+    res = _run_lint("argv-flag-normalised", tmp_path)
+    assert res.returncode != 0
+    # Three add_argument calls — three findings.
+    assert "'--Token'" in res.stderr
+    assert "'--api-Key'" in res.stderr
+    # The BinOp ``"--" + "password"`` collapses to the literal `--password`
+    # before normalisation; the report names the assembled flag.
+    assert "'--password'" in res.stderr
+
+
+def test_mcp_server_headers_clean(tmp_path):
+    """AC26(b) is scoped to credentialed-cli only; header-naming flags on
+    mcp-server class must not be flagged."""
+    res = _run_lint("mcp-server-headers", tmp_path)
+    assert res.returncode == 0, (
+        f"mcp-server-headers should be clean; stderr={res.stderr}"
+    )
+    assert "0 finding(s)" in res.stdout
+
+
+def test_dotfile_grep_reports_finding(tmp_path):
+    res = _run_lint("dotfile-grep", tmp_path)
+    assert res.returncode != 0
+    assert "dotfile-grep/scripts/leak.py" in res.stderr
+    assert ".agent-ready/credentials.env" in res.stderr
+
+
+def test_dotfile_with_optout_marker_is_silent(tmp_path):
+    """A line containing the dotfile substring is skipped iff the
+    ``# credentialed-primitive: reads-creds-directly`` marker is on the
+    same line."""
+    res = _run_lint("dotfile-with-optout", tmp_path)
+    assert res.returncode == 0, (
+        f"dotfile-with-optout should be clean; stderr={res.stderr}"
+    )
+    assert "0 finding(s)" in res.stdout
+
+
+def test_lint_script_executable_against_live_repo():
+    """The lint runs cleanly against the real repo before any credentialed
+    skill ships (Wave 3 / T12). Asserts the script doesn't crash and
+    reports zero scanned skills on a pristine main."""
+    res = subprocess.run(
+        ["bash", str(LINT_SCRIPT)],
+        cwd=str(REPO_ROOT),
+        capture_output=True, text=True,
+    )
+    # On a tree with no credentialed skills, the lint exits 0.
+    assert res.returncode == 0, (
+        f"live repo lint failed unexpectedly: stderr={res.stderr}"
+    )
+    assert "skill(s) scanned" in res.stdout

--- a/packs/core/.apm/commands/conventions-check.md
+++ b/packs/core/.apm/commands/conventions-check.md
@@ -25,6 +25,23 @@ Run both repo linters and report findings.
 4. Skill dirs contain a `SKILL.md` (and no stray `.md` siblings).
 5. Internal markdown links inside each artifact resolve.
 
-If either linter is missing or fails to run, fall back to inspecting the
+**`bash tools/lint-credentialed-skills.sh`** — credentialed-skill rules
+(skill-secrets spec § AC26 — see `docs/specs/skill-secrets/spec.md`);
+scoped to skills whose `SKILL.md` declares `credentialed: true`:
+
+1. The body contains an `### Security rules (non-negotiable)` heading
+   and the three RFC-0006 § 4 substrings inside that section (the
+   verbatim "Don't" block).
+2. For `primitive-class: credentialed-cli`: no script under the skill's
+   `scripts/` directory accepts an `argparse` flag whose normalised
+   name (strip leading `-`, casefold, `-` → `_`) is one of
+   `{token, api_token, api_key, bearer, pat, password}`. Detection
+   handles literal strings AND `"--" + "name"`-style concatenation.
+3. No script under a credentialed skill's `scripts/` directory contains
+   the substring `.agent-ready/credentials.env` unless the opt-out
+   comment `# credentialed-primitive: reads-creds-directly` appears
+   on the same line.
+
+If any linter is missing or fails to run, fall back to inspecting the
 files directly and report the same checks manually. Don't auto-fix
 anything — report findings and let the user decide what to do.

--- a/tools/lint-credentialed-skills.sh
+++ b/tools/lint-credentialed-skills.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# Reports findings against credentialed-skill conventions
+# (skill-secrets spec § AC26). Exits non-zero on any finding so the
+# script composes with the existing lint family (lint-agents-md.sh,
+# lint-agent-artifacts.sh); the `conventions-check` slash command
+# captures stderr and surfaces it.
+#
+# Three checks, all scoped to skills whose `SKILL.md` frontmatter
+# declares `credentialed: true`:
+#
+#   AC26(a) "Don't" block presence.
+#     The body must contain an `### Security rules (non-negotiable)`
+#     heading, and within that section the three RFC-0006 § 4
+#     substrings:
+#       - `**Never** read that file, print it, or echo the token`
+#       - `**Never** put the token on the command line`
+#       - `do not run it for them`
+#
+#   AC26(b) Argv-flag detection (credentialed-cli class only).
+#     `ast.parse` walks every `scripts/**/*.py` file under the skill
+#     and inspects `argparse.ArgumentParser.add_argument` calls. The
+#     first positional argument is normalised per AC27 (strip leading
+#     `-`, casefold, replace `-` with `_`) and matched against the
+#     banned set {token, api_token, api_key, bearer, pat, password}.
+#     Two first-arg shapes are recognised: literal string constants
+#     and `BinOp(op=Add)` concatenation of two literal constants
+#     (the `"--" + "token"` obfuscation in AC27). Deeper obfuscation
+#     (formatted strings, computed names) is out of scope.
+#
+#   AC26(c) Dotfile substring + opt-out marker.
+#     Per-line substring scan of every `scripts/**/*.py` under a
+#     credentialed skill looking for `.agent-ready/credentials.env`.
+#     A line containing the substring is skipped iff
+#     `# credentialed-primitive: reads-creds-directly` appears on
+#     the same line (comparison after `str.rstrip()`).
+#
+# Discovery: walks SKILL.md files at three locations under LINT_ROOT
+# (default: repo root) so the lint composes with both production
+# paths and fixture-driven tests:
+#
+#   LINT_ROOT/.claude/skills/<name>/SKILL.md
+#   LINT_ROOT/packs/<pack>/.apm/skills/<name>/SKILL.md
+#   LINT_ROOT/skills/<name>/SKILL.md       (fixture-tree shape)
+
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+LINT_ROOT="${LINT_ROOT:-.}"
+
+python3 - "$LINT_ROOT" <<'PY'
+import ast
+import pathlib
+import re
+import sys
+
+root = pathlib.Path(sys.argv[1]).resolve()
+
+BANNED_FLAGS = {"token", "api_token", "api_key", "bearer", "pat", "password"}
+DOTFILE_SUBSTRING = ".agent-ready/credentials.env"
+OPTOUT_MARKER = "# credentialed-primitive: reads-creds-directly"
+SECURITY_HEADING = "### Security rules (non-negotiable)"
+REQUIRED_PHRASES = (
+    "**Never** read that file, print it, or echo the token",
+    "**Never** put the token on the command line",
+    "do not run it for them",
+)
+KEY_RE = re.compile(r"^([a-zA-Z][a-zA-Z0-9_-]*):\s*(.*)$")
+HEADING_TERMINATE_RE = re.compile(r"\n#{1,6}\s")
+
+findings = 0
+
+
+def relpath(p):
+    try:
+        return p.relative_to(root)
+    except ValueError:
+        return p
+
+
+def report(path, message):
+    global findings
+    findings += 1
+    print(f"✖ {relpath(path)}: {message}", file=sys.stderr)
+
+
+def parse_frontmatter(path):
+    """Return (fields, body) or (None, text) if frontmatter is absent.
+
+    Minimal stdlib YAML-subset parser matching ``lint-agent-artifacts.sh``
+    — single-line scalars only, no nested structures. Sufficient for
+    SKILL.md frontmatter shape pinned in the spec.
+    """
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None, text
+    end = None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            end = i
+            break
+    if end is None:
+        return None, text
+    fields = {}
+    for line in lines[1:end]:
+        if not line.strip():
+            continue
+        m = KEY_RE.match(line)
+        if m:
+            fields[m.group(1)] = m.group(2).strip()
+    body = "\n".join(lines[end + 1 :])
+    return fields, body
+
+
+def section_body(body, heading):
+    """Slice ``body`` from ``heading`` to the next heading or EOF.
+
+    Returns the section as a single string including the heading line.
+    """
+    idx = body.find(heading)
+    if idx < 0:
+        return None
+    rest = body[idx:]
+    m = HEADING_TERMINATE_RE.search(rest, len(heading))
+    if m is None:
+        return rest
+    return rest[: m.start()]
+
+
+def normalize_flag(s):
+    """AC27 normalisation: strip leading ``-``, casefold, ``-`` → ``_``."""
+    return s.lstrip("-").casefold().replace("-", "_")
+
+
+def add_argument_flags(py_path):
+    """Yield (raw, normalized, lineno) for every ``add_argument`` call.
+
+    Recognises two first-arg shapes per AC27:
+      - ``Constant(value=str)`` — direct literal.
+      - ``BinOp(op=Add, left=Constant(str), right=Constant(str))`` —
+        the ``"--" + "token"`` obfuscation pattern. Recursively
+        concatenates chains of literal string adds.
+    """
+    try:
+        tree = ast.parse(py_path.read_text(encoding="utf-8"),
+                         filename=str(py_path))
+    except SyntaxError:
+        return
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute) or func.attr != "add_argument":
+            continue
+        if not node.args:
+            continue
+        first = node.args[0]
+        value = _literal_string(first)
+        if value is None:
+            continue
+        if not value.startswith("-"):
+            continue
+        yield value, normalize_flag(value), node.lineno
+
+
+def _literal_string(node):
+    """Return a string if ``node`` is a string literal or a chain of
+    string-literal additions; ``None`` otherwise."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = _literal_string(node.left)
+        right = _literal_string(node.right)
+        if left is not None and right is not None:
+            return left + right
+    return None
+
+
+# Discovery: three glob patterns covering production paths + fixture trees.
+skill_md_files = []
+for pattern in (
+    ".claude/skills/*/SKILL.md",
+    "packs/*/.apm/skills/*/SKILL.md",
+    "skills/*/SKILL.md",
+):
+    skill_md_files.extend(sorted(root.glob(pattern)))
+
+scanned = 0
+
+for skill_md in skill_md_files:
+    fields, body = parse_frontmatter(skill_md)
+    if fields is None:
+        continue
+    if fields.get("credentialed") != "true":
+        continue
+    scanned += 1
+    primitive_class = fields.get("primitive-class", "")
+    skill_dir = skill_md.parent
+
+    # AC26(a) — Don't-block presence.
+    section = section_body(body, SECURITY_HEADING)
+    if section is None:
+        report(skill_md, f"missing heading: {SECURITY_HEADING}")
+    else:
+        for phrase in REQUIRED_PHRASES:
+            if phrase not in section:
+                report(skill_md,
+                       f"security section missing required phrase: {phrase!r}")
+
+    scripts_dir = skill_dir / "scripts"
+    if not scripts_dir.exists():
+        continue
+
+    py_files = sorted(p for p in scripts_dir.rglob("*.py") if p.is_file())
+
+    # AC26(b) — argv-flag detection. Scoped to credentialed-cli class.
+    if primitive_class == "credentialed-cli":
+        for py in py_files:
+            for raw, norm, lineno in add_argument_flags(py):
+                if norm in BANNED_FLAGS:
+                    report(
+                        py,
+                        f"line {lineno}: argv-borne credential flag "
+                        f"{raw!r} accepted by argparse (normalised "
+                        f"{norm!r} ∈ {sorted(BANNED_FLAGS)})",
+                    )
+
+    # AC26(c) — dotfile substring + opt-out marker.
+    for py in py_files:
+        try:
+            content = py.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for lineno, line in enumerate(content.splitlines(), start=1):
+            if DOTFILE_SUBSTRING not in line:
+                continue
+            if OPTOUT_MARKER in line.rstrip():
+                continue
+            report(
+                py,
+                f"line {lineno}: skill reads {DOTFILE_SUBSTRING} directly "
+                f"(architectural violation — opt-out marker absent)",
+            )
+
+print(f"Credentialed-skill lint: {scanned} skill(s) scanned, "
+      f"{findings} finding(s).")
+
+if findings:
+    sys.exit(1)
+PY


### PR DESCRIPTION
## Summary

- New ``tools/lint-credentialed-skills.sh`` reports findings against credentialed-skill rules per spec § AC26:
  - **AC26(a)** Don't-block presence: ``### Security rules (non-negotiable)`` heading + three RFC-0006 § 4 substrings.
  - **AC26(b)** Argv-flag detection (credentialed-cli only) via ``ast.parse`` walking ``argparse.ArgumentParser.add_argument`` calls; normalises per AC27 and matches banned set.
  - **AC26(c)** Dotfile substring scan with opt-out marker.
- ``packs/core/.apm/commands/conventions-check.md`` lists the new helper alongside ``lint-agents-md.sh`` and ``lint-agent-artifacts.sh``; ``make build-self`` projected the seed edit.
- Seven fixture skills under ``packages/agentbundle/tests/fixtures/creds/skills/`` exercise every AC26 + AC27 branch.

Closes **AC26 (a, b, c), AC27**.

## Test plan

- [x] ``pytest packages/agentbundle/tests/integration/test_conventions_check_creds.py`` — 8/8 pass.
- [x] ``make build-check`` — clean.
- [x] ``make build-self`` (FORCE=1) — projected seed-side edit to ``.claude/commands/conventions-check.md`` without drift.
- [x] ``tools/lint-credentialed-skills.sh`` against live repo — 0 skills scanned, 0 findings (no credentialed skills land until Wave 3 / T12).
- [x] ``tools/lint-agents-md.sh`` + ``tools/lint-agent-artifacts.sh`` — clean.
- [x] Full ``pytest packages/agentbundle/tests/`` — green.

## Wave 2 of 3

Task **T10** of skill-secrets implementation. Runs in parallel with **T3** (loader + Tier-1 + shim, separate PR). No file overlap with T3.