### PR TITLE
feat(skill-secrets): T6 — Tier-3 dotfile read + write

### DIFF
--- a/packages/agentbundle/agentbundle/creds/exceptions.py
+++ b/packages/agentbundle/agentbundle/creds/exceptions.py
@@ -18,3 +18,13 @@ class CredentialsMissingError(Exception):
 
 class Tier2HardFailError(Exception):
     """Raised when the OS keyring backend returns a hard-fail error code."""
+
+
+class PermissiveAclError(Exception):
+    """Raised when the Windows DACL on the Tier-3 dotfile is too permissive.
+
+    Per spec § AC15: ``icacls`` is invoked after each write; non-default
+    ACEs (anything beyond the inherited user / ``NT AUTHORITY\\SYSTEM`` /
+    ``BUILTIN\\Administrators``) cause the helper to refuse unless
+    ``allow_permissive_acl=True`` was passed.
+    """

--- a/packages/agentbundle/agentbundle/creds/loader.py
+++ b/packages/agentbundle/agentbundle/creds/loader.py
@@ -37,9 +37,15 @@ from __future__ import annotations
 import os
 import pathlib
 import re
+import subprocess
 import sys
+import tempfile
 
-from .exceptions import CredentialsMissingError, Tier2HardFailError
+from .exceptions import (
+    CredentialsMissingError,
+    PermissiveAclError,
+    Tier2HardFailError,
+)
 
 _KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
@@ -144,11 +150,206 @@ def _tier2(namespace: str, key: str) -> str | None:
 def _tier3(namespace: str, key: str) -> str | None:
     """Resolve from the Tier-3 dotfile (spec § AC13).
 
-    Stubbed in T3 — T6 implements the dotfile read. Returns ``None`` so
-    the resolver continues toward ``CredentialsMissingError`` for any
-    key that did not resolve at Tier 1 or Tier 2.
+    Reads ``~/.agent-ready/credentials.env`` via the stdlib parser and
+    looks up ``<NAMESPACE>_<KEY>``. Returns ``None`` on miss; a malformed
+    dotfile also returns ``None`` (the upstream resolver raises
+    ``CredentialsMissingError`` if the key was required, naming the
+    namespace and the missing key list).
     """
-    return None
+    return _dotfile_read(namespace, key)
+
+
+# ── Tier 3 — dotfile ───────────────────────────────────────────────────
+
+
+def _dotfile_path() -> pathlib.Path:
+    """Canonical Tier-3 dotfile path per spec § AC13.
+
+    Resolves to ``pathlib.Path.home() / ".agent-ready" / "credentials.env"``
+    on every platform. Tests redirect ``HOME`` (and ``USERPROFILE`` on
+    Windows) to a ``tmp_path``-scoped directory so the developer's real
+    ``~/.agent-ready/`` is never touched.
+    """
+    return pathlib.Path.home() / ".agent-ready" / "credentials.env"
+
+
+def _dotfile_env_name(namespace: str, key: str) -> str:
+    """Compose the dotfile entry name — same shape as the Tier-1 env var."""
+    return f"{namespace.upper()}_{key}"
+
+
+def _dotfile_read(namespace: str, key: str) -> str | None:
+    """Look up ``<NAMESPACE>_<KEY>`` in the Tier-3 dotfile."""
+    path = _dotfile_path()
+    if not path.is_file():
+        return None
+    try:
+        values = parse_env_file(path)
+    except EnvParseError:
+        return None
+    raw = values.get(_dotfile_env_name(namespace, key))
+    if not raw:
+        return None
+    return raw
+
+
+def _quote_for_dotfile(value: str) -> str:
+    """Render a value for the dotfile.
+
+    Use double-quotes only when the bare value would be ambiguous to the
+    parser (contains whitespace or a leading ``#``). Embedded double
+    quotes / dollar signs are not the user's tokens in practice — the
+    parser refuses ``$`` and embedded quotes would re-enter as ``"a"b"``
+    which the parser strips clumsily. Tokens this rejects shouldn't be
+    in scope for Tier-3 storage and the helper surfaces the parser
+    error if a round-trip would corrupt the value.
+    """
+    if not value:
+        return '""'
+    if " " in value or value.startswith("#"):
+        return f'"{value}"'
+    return value
+
+
+def _verify_icacls(
+    path: pathlib.Path, *, allow_permissive_acl: bool = False
+) -> None:
+    """Run ``icacls`` on the path and refuse if any non-default ACE grants
+    read access (spec § AC15). No-op on POSIX.
+
+    Default ACEs on a per-user file are the inheriting user,
+    ``NT AUTHORITY\\SYSTEM``, and ``BUILTIN\\Administrators``. Any other
+    principal granted access is flagged unless the caller opts in.
+    """
+    if os.name != "nt":  # pragma: no cover — POSIX path
+        return
+    res = subprocess.run(  # pragma: no cover — exercised only on Windows
+        ["icacls", str(path)], capture_output=True, text=True, check=False
+    )
+    if res.returncode != 0:
+        raise PermissiveAclError(
+            f"icacls inspection failed for {path}: rc={res.returncode} "
+            f"stderr={res.stderr.strip()}"
+        )
+    suspect = []
+    for line in res.stdout.splitlines():
+        stripped = line.strip()
+        # Flag any ACE granting access to non-default principals.
+        if (
+            "BUILTIN\\Users" in stripped
+            or "Everyone" in stripped
+            or "Authenticated Users" in stripped
+        ):
+            suspect.append(stripped)
+    if suspect and not allow_permissive_acl:
+        raise PermissiveAclError(
+            f"DACL too permissive on {path}: {suspect}; pass "
+            f"allow_permissive_acl=True to override"
+        )
+
+
+def _ensure_parent(parent: pathlib.Path) -> None:
+    """Create the dotfile parent at mode 0o700 if absent (spec § AC15).
+
+    If the parent already exists, do **not** rewrite its mode — the
+    directory is shared with RFC-0004 install state. On POSIX warn on
+    stderr if the existing mode is more permissive than 0o755.
+    """
+    if not parent.exists():
+        parent.mkdir(mode=0o700, parents=True)
+        return
+    if os.name == "posix":
+        mode = parent.stat().st_mode & 0o777
+        if mode > 0o755:
+            sys.stderr.write(
+                f"warning: {parent} mode is {oct(mode)} (more permissive "
+                f"than 0o755); leaving in place — shared with install state\n"
+            )
+
+
+def _dotfile_write(
+    namespace: str,
+    key: str,
+    value: str,
+    *,
+    allow_permissive_acl: bool = False,
+) -> None:
+    """Write ``(namespace, key) → value`` to the Tier-3 dotfile atomically.
+
+    Atomic write contract per spec § AC14:
+    ``tempfile.mkstemp(dir=target_dir)`` → ``os.write`` →
+    ``os.fchmod`` (POSIX) → ``os.close`` → ``os.replace``. A mid-write
+    read sees either the prior contents or the new contents, never
+    partial.
+    """
+    path = _dotfile_path()
+    parent = path.parent
+    _ensure_parent(parent)
+
+    existing: dict[str, str] = {}
+    if path.is_file():
+        try:
+            existing = parse_env_file(path)
+        except EnvParseError:
+            existing = {}
+    existing[_dotfile_env_name(namespace, key)] = value
+    content = "".join(
+        f"{k}={_quote_for_dotfile(v)}\n" for k, v in existing.items()
+    )
+
+    fd, tmp_path_str = tempfile.mkstemp(dir=str(parent), prefix=".creds.")
+    tmp_path = pathlib.Path(tmp_path_str)
+    try:
+        os.write(fd, content.encode("utf-8"))
+        if os.name == "posix":
+            os.fchmod(fd, 0o600)
+        os.close(fd)
+        if os.name == "nt":
+            _verify_icacls(tmp_path, allow_permissive_acl=allow_permissive_acl)
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _dotfile_delete(namespace: str, key: str) -> None:
+    """Remove ``(namespace, key)`` from the dotfile atomically.
+
+    No-op if the dotfile is absent or the key isn't present. Atomic
+    rewrite shape matches ``_dotfile_write``.
+    """
+    path = _dotfile_path()
+    if not path.is_file():
+        return
+    try:
+        existing = parse_env_file(path)
+    except EnvParseError:
+        return
+    target = _dotfile_env_name(namespace, key)
+    if target not in existing:
+        return
+    del existing[target]
+    content = "".join(
+        f"{k}={_quote_for_dotfile(v)}\n" for k, v in existing.items()
+    )
+    parent = path.parent
+    fd, tmp_path_str = tempfile.mkstemp(dir=str(parent), prefix=".creds.")
+    tmp_path = pathlib.Path(tmp_path_str)
+    try:
+        os.write(fd, content.encode("utf-8"))
+        if os.name == "posix":
+            os.fchmod(fd, 0o600)
+        os.close(fd)
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
 
 def load_credentials(
@@ -195,6 +396,7 @@ __all__ = [
     "Credentials",
     "CredentialsMissingError",
     "EnvParseError",
+    "PermissiveAclError",
     "Tier2HardFailError",
     "load_credentials",
     "parse_env_file",

--- a/packages/agentbundle/tests/unit/test_credentials_dotfile.py
+++ b/packages/agentbundle/tests/unit/test_credentials_dotfile.py
@@ -1,0 +1,204 @@
+"""T6: Tier-3 dotfile read + write (skill-secrets spec § AC13-AC15).
+
+Tests are platform-aware:
+- Path resolution and atomic-write contract run unguarded (POSIX + Windows).
+- POSIX-specific permission assertions (0o600 file, 0o700 parent on
+  create, shared-parent warning) are guarded with
+  ``@pytest.mark.skipif(sys.platform == "win32", ...)``.
+- Windows-specific ``icacls`` assertions are guarded the opposite way;
+  this fixture host is Darwin so those tests skip locally — they are
+  written for the eventual macos/windows CI matrix per the prompt's
+  risk note.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+
+import pytest
+
+from agentbundle.creds import loader
+from agent_ready.credentials import CredentialsMissingError, load_credentials
+
+
+@pytest.fixture(autouse=True)
+def isolated_home(tmp_path, monkeypatch):
+    """Redirect HOME / USERPROFILE per spec § Boundaries; force Tier-2
+    backend to None so this suite exercises only Tier 1 + Tier 3."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    for var in list(os.environ):
+        if var.startswith("FIXTURE_T6_"):
+            monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(loader, "_tier2_backend", None)
+
+
+def test_dotfile_path_resolves_under_home(tmp_path):
+    """AC13: path is ``$HOME/.agent-ready/credentials.env``."""
+    assert loader._dotfile_path() == tmp_path / ".agent-ready" / "credentials.env"
+
+
+def test_dotfile_write_creates_file_and_parent(tmp_path):
+    loader._dotfile_write("fixture_t6", "API_TOKEN", "secret-1")
+    path = tmp_path / ".agent-ready" / "credentials.env"
+    assert path.is_file()
+    assert path.parent.is_dir()
+    assert "FIXTURE_T6_API_TOKEN=secret-1" in path.read_text(encoding="utf-8")
+
+
+def test_dotfile_read_round_trips_value(tmp_path):
+    loader._dotfile_write("fixture_t6", "API_TOKEN", "round-trip-value")
+    assert loader._dotfile_read("fixture_t6", "API_TOKEN") == "round-trip-value"
+
+
+def test_dotfile_read_missing_file_returns_none(tmp_path):
+    """AC4 fallback: no dotfile → ``None`` → ``CredentialsMissingError``
+    when the loader treats the key as required."""
+    assert loader._dotfile_read("fixture_t6", "API_TOKEN") is None
+
+
+def test_dotfile_read_missing_key_returns_none(tmp_path):
+    loader._dotfile_write("fixture_t6", "API_TOKEN", "set")
+    assert loader._dotfile_read("fixture_t6", "BASE_URL") is None
+
+
+def test_dotfile_write_preserves_other_entries(tmp_path):
+    loader._dotfile_write("fixture_t6", "API_TOKEN", "tok-1")
+    loader._dotfile_write("fixture_t6", "BASE_URL", "https://example.com")
+    assert loader._dotfile_read("fixture_t6", "API_TOKEN") == "tok-1"
+    assert loader._dotfile_read("fixture_t6", "BASE_URL") == "https://example.com"
+
+
+def test_dotfile_write_replaces_value_for_same_key(tmp_path):
+    loader._dotfile_write("fixture_t6", "API_TOKEN", "old")
+    loader._dotfile_write("fixture_t6", "API_TOKEN", "new")
+    assert loader._dotfile_read("fixture_t6", "API_TOKEN") == "new"
+
+
+def test_dotfile_delete_removes_key(tmp_path):
+    loader._dotfile_write("fixture_t6", "API_TOKEN", "set")
+    loader._dotfile_write("fixture_t6", "BASE_URL", "url")
+    loader._dotfile_delete("fixture_t6", "API_TOKEN")
+    assert loader._dotfile_read("fixture_t6", "API_TOKEN") is None
+    assert loader._dotfile_read("fixture_t6", "BASE_URL") == "url"
+
+
+def test_dotfile_delete_missing_file_is_noop(tmp_path):
+    # No raise, no side effect.
+    loader._dotfile_delete("fixture_t6", "API_TOKEN")
+    assert not (tmp_path / ".agent-ready" / "credentials.env").exists()
+
+
+def test_atomic_write_via_mkstemp_and_replace(tmp_path, monkeypatch):
+    """AC14: the temp file lives in the target directory (so
+    ``os.replace`` is a rename, atomic on POSIX), not in /tmp.
+    """
+    recorded = []
+    real_replace = os.replace
+
+    def recording_replace(src, dst):
+        recorded.append((str(src), str(dst)))
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(os, "replace", recording_replace)
+    loader._dotfile_write("fixture_t6", "API_TOKEN", "secret")
+    assert len(recorded) == 1
+    src, dst = recorded[0]
+    target_dir = str(tmp_path / ".agent-ready")
+    assert src.startswith(target_dir + os.sep), (
+        f"temp file {src!r} not in target dir {target_dir!r}"
+    )
+    assert dst == str(tmp_path / ".agent-ready" / "credentials.env")
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only chmod path")
+def test_file_mode_is_0o600_on_posix(tmp_path):
+    """AC15: file mode is exactly ``0o600``."""
+    loader._dotfile_write("fixture_t6", "API_TOKEN", "secret")
+    path = tmp_path / ".agent-ready" / "credentials.env"
+    mode = path.stat().st_mode & 0o777
+    assert mode == 0o600, f"expected 0o600, got {oct(mode)}"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only mkdir path")
+def test_parent_mode_is_0o700_on_create_on_posix(tmp_path):
+    """AC15: when the parent is created, it's at mode ``0o700``."""
+    loader._dotfile_write("fixture_t6", "API_TOKEN", "secret")
+    parent = tmp_path / ".agent-ready"
+    mode = parent.stat().st_mode & 0o777
+    assert mode == 0o700, f"expected 0o700, got {oct(mode)}"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only chmod path")
+def test_existing_parent_mode_is_not_rewritten_on_posix(tmp_path, capsys):
+    """AC15: a brownfield parent (shared with install state) keeps its
+    mode; the helper warns on stderr if more permissive than 0o755."""
+    parent = tmp_path / ".agent-ready"
+    parent.mkdir(mode=0o755)
+    os.chmod(parent, 0o775)  # group-write — more permissive than 0o755
+    loader._dotfile_write("fixture_t6", "API_TOKEN", "secret")
+    # Parent mode preserved.
+    final_mode = parent.stat().st_mode & 0o777
+    assert final_mode == 0o775
+    captured = capsys.readouterr()
+    assert "more permissive than 0o755" in captured.err
+    assert str(parent) in captured.err
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only icacls path")
+def test_windows_icacls_does_not_call_chmod(tmp_path, monkeypatch):
+    """AC15: on Windows, ``os.chmod`` is not used — the file's DACL is
+    inherited from the parent and verified post-write via ``icacls``."""
+    calls = []
+    real_chmod = os.chmod
+    real_fchmod = os.fchmod
+
+    monkeypatch.setattr(os, "chmod", lambda *a, **kw: calls.append(("chmod", a)))
+    monkeypatch.setattr(os, "fchmod", lambda *a, **kw: calls.append(("fchmod", a)))
+    # icacls invocation succeeds with empty stdout (no suspect ACEs).
+    monkeypatch.setattr(loader, "_verify_icacls", lambda *a, **kw: None)
+    loader._dotfile_write("fixture_t6", "API_TOKEN", "secret")
+    assert not calls, f"chmod / fchmod called on Windows: {calls}"
+
+
+def test_tier3_fallback_via_load_credentials(tmp_path):
+    """AC4: Tier 1 absent + Tier 2 absent → loader reads Tier 3."""
+    loader._dotfile_write("fixture_t6", "API_TOKEN", "from-dotfile")
+    creds = load_credentials("fixture_t6", required_keys=["API_TOKEN"])
+    assert creds.API_TOKEN == "from-dotfile"
+
+
+def test_tier1_wins_over_tier3(tmp_path, monkeypatch):
+    """AC4 first-hit-wins: env present + dotfile present → env value."""
+    loader._dotfile_write("fixture_t6", "API_TOKEN", "from-dotfile")
+    monkeypatch.setenv("FIXTURE_T6_API_TOKEN", "from-env")
+    creds = load_credentials("fixture_t6", required_keys=["API_TOKEN"])
+    assert creds.API_TOKEN == "from-env"
+
+
+def test_tier3_miss_raises_credentials_missing(tmp_path):
+    """AC4: no Tier-1, no Tier-2, no Tier-3 → CredentialsMissingError."""
+    with pytest.raises(CredentialsMissingError) as exc:
+        load_credentials("fixture_t6", required_keys=["API_TOKEN"])
+    assert "fixture_t6" in str(exc.value)
+    assert "API_TOKEN" in str(exc.value)
+
+
+def test_malformed_dotfile_returns_none_not_raise(tmp_path):
+    """A corrupt dotfile is treated as a miss (parser ``EnvParseError``
+    swallowed). The loader surface still raises
+    ``CredentialsMissingError`` for a required key — never propagates
+    the parser error to the primitive author."""
+    path = tmp_path / ".agent-ready" / "credentials.env"
+    path.parent.mkdir(mode=0o700)
+    path.write_text("export FIXTURE_T6_API_TOKEN=secret\n", encoding="utf-8")
+    assert loader._dotfile_read("fixture_t6", "API_TOKEN") is None
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX permission shape")
+def test_value_with_spaces_round_trips_via_quoting(tmp_path):
+    """Values containing spaces round-trip via the parser's quoted form."""
+    loader._dotfile_write("fixture_t6", "BASE_URL", "https://jira example com")
+    assert loader._dotfile_read("fixture_t6", "BASE_URL") == "https://jira example com"


### PR DESCRIPTION
## Summary

Extends ``agentbundle.creds.loader`` with the Tier-3 dotfile path per spec § AC13-AC15:

- Path resolves to ``~/.agent-ready/credentials.env``; same ``<NAMESPACE>_<KEY>`` shape as Tier 1.
- Atomic write: ``tempfile.mkstemp(dir=parent)`` → ``os.write`` → ``os.fchmod`` (POSIX) → ``os.close`` → ``os.replace`` (AC14).
- POSIX file mode ``0o600``, parent ``0o700`` on create; existing parent **not** rewritten (shared with RFC-0004 install state); stderr warning when existing mode exceeds ``0o755`` (AC15).
- Windows: ``icacls`` post-write verification; ``BUILTIN\Users`` / ``Everyone`` / ``Authenticated Users`` ACEs raise ``PermissiveAclError`` unless opt-in flag passed. No ``os.chmod`` (AC15).
- New ``PermissiveAclError``; ``_tier3`` (previously stubbed) now calls ``_dotfile_read``.

Closes **AC13, AC14, AC15**.

## Test plan

- [x] ``pytest packages/agentbundle/tests/unit/test_credentials_dotfile.py`` — 18 pass + 1 Windows-only skip on Darwin.
- [x] Full ``pytest packages/agentbundle/tests/`` — green.
- [x] ``make build-check`` — clean.
- [x] Lints — clean.

## Wave 3 of 3

Task **T6**. Lands FIRST in Wave 3 per the prompt's risk note — T7 (schema parser) edits the same ``loader.py``; T7 rebases on top of this merge. Runs in parallel with T4 (macOS Keychain), T5 (Windows Credential Manager), T11 (author skill).