### PR TITLE
feat(skill-secrets): T4 — macOS Keychain Tier-2 backend

### DIFF
--- a/packages/agentbundle/agentbundle/creds/_keychain_macos.py
+++ b/packages/agentbundle/agentbundle/creds/_keychain_macos.py
@@ -1,0 +1,117 @@
+"""macOS Keychain Tier-2 backend (spec § AC6-AC8).
+
+Stdlib subprocess against ``/usr/bin/security`` — the system-shipped
+Keychain CLI. Guaranteed present on every macOS install per spec §
+Boundaries § Never do (no third-party ``keyring`` dependency).
+
+Token bytes never reach argv:
+
+- **Read** uses ``find-generic-password ... -w`` and captures the
+  password from stdout.
+- **Write** uses ``add-generic-password -U ... -w`` with the trailing
+  ``-w`` as the *last* argument — per the ``security(1)`` man page
+  ("Put at end of command to be prompted (recommended)"). The token is
+  fed to the child via ``subprocess.Popen(stdin=PIPE)`` +
+  ``proc.communicate(input=token.encode())``.
+- **Delete** uses ``delete-generic-password`` (idempotent on miss).
+
+The loader (``agentbundle.creds.loader``) imports this module **only**
+when ``sys.platform == "darwin"`` per AC4b. Tests monkeypatch
+``SERVICE`` to a ``tmp_path``-derived prefix so test entries never
+collide with the developer's real ``agent-ready`` Keychain entries.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+from .exceptions import Tier2HardFailError
+
+SECURITY_BIN = "/usr/bin/security"
+SERVICE = "agent-ready"
+# Tests monkeypatch ``SERVICE`` to a ``tmp_path``-derived prefix so test
+# entries can't collide with real ``agent-ready`` entries in the
+# developer's login Keychain. ``security``'s ``-w`` prompt mode requires
+# ``-w`` as the trailing argv element, which forecloses the trailing-
+# keychain-positional approach to test isolation; the service-prefix
+# approach lets the canonical AC6 argv shape stay untouched.
+
+# errSecItemNotFound (44) — legitimate "no such credential", falls
+# through to Tier 3 per AC4 / AC11's macOS-side matrix in AC22.
+EXIT_NOT_FOUND = 44
+
+
+def _account(namespace: str, key: str) -> str:
+    """Compose the Keychain account label per spec § AC6."""
+    return f"{namespace}:{key}"
+
+
+def read_credential(namespace: str, key: str) -> str | None:
+    """Read ``(namespace, key)`` from the Keychain (spec § AC6, AC7)."""
+    argv = [
+        SECURITY_BIN, "find-generic-password",
+        "-s", SERVICE,
+        "-a", _account(namespace, key),
+        "-w",
+    ]
+    proc = subprocess.run(argv, capture_output=True, text=True, check=False)
+    if proc.returncode == EXIT_NOT_FOUND:
+        return None
+    if proc.returncode != 0:
+        msg = proc.stderr.strip() or proc.stdout.strip()
+        raise Tier2HardFailError(
+            f"macOS Keychain read failed for {_account(namespace, key)!r} "
+            f"(rc={proc.returncode}): {msg}"
+        )
+    # ``security -w`` prints the password to stdout, then a newline.
+    return proc.stdout.rstrip("\n")
+
+
+def write_credential(namespace: str, key: str, value: str) -> None:
+    """Write ``value`` to ``(namespace, key)``. Token enters via child stdin
+    only — never argv (spec § AC6, AC7).
+    """
+    argv = [
+        SECURITY_BIN, "add-generic-password",
+        "-U",  # upsert: replace if entry already exists
+        "-s", SERVICE,
+        "-a", _account(namespace, key),
+        "-w",  # MUST be the last argv element — triggers prompt-from-stdin
+    ]
+    proc = subprocess.Popen(
+        argv,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    # ``security add-generic-password -w`` prompts twice ("password data
+    # for new item:" then "retype password for new item:") — both lines
+    # must match for the write to succeed. Mismatched lines silently
+    # write an empty password. The value is sent twice on stdin with
+    # newline terminators; the token still never reaches argv.
+    token_bytes = value.encode("utf-8")
+    stdin_payload = token_bytes + b"\n" + token_bytes + b"\n"
+    _, err = proc.communicate(input=stdin_payload)
+    if proc.returncode != 0:
+        msg = err.decode("utf-8", errors="replace").strip()
+        raise Tier2HardFailError(
+            f"macOS Keychain write failed for {_account(namespace, key)!r} "
+            f"(rc={proc.returncode}): {msg}"
+        )
+
+
+def delete_credential(namespace: str, key: str) -> None:
+    """Idempotent delete — missing entry is not an error."""
+    argv = [
+        SECURITY_BIN, "delete-generic-password",
+        "-s", SERVICE,
+        "-a", _account(namespace, key),
+    ]
+    proc = subprocess.run(argv, capture_output=True, text=True, check=False)
+    if proc.returncode == EXIT_NOT_FOUND:
+        return
+    if proc.returncode != 0:
+        raise Tier2HardFailError(
+            f"macOS Keychain delete failed (rc={proc.returncode}): "
+            f"{proc.stderr.strip()}"
+        )

--- a/packages/agentbundle/tests/integration/test_keychain_macos.py
+++ b/packages/agentbundle/tests/integration/test_keychain_macos.py
@@ -1,0 +1,223 @@
+"""T4: macOS Keychain Tier-2 backend (spec § AC6-AC8).
+
+Tests are gated on ``sys.platform == "darwin"`` — the backend module
+imports nothing platform-specific itself (it just shells out to
+``/usr/bin/security``), but the binary only exists on macOS and the
+test isolation uses ``security create-keychain``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "darwin",
+    reason="macOS Keychain backend — Darwin-only",
+)
+
+
+@pytest.fixture
+def backend(tmp_path, monkeypatch):
+    """Import the backend and scope ``SERVICE`` to a ``tmp_path``-derived
+    prefix so test entries can't collide with the developer's real
+    ``agent-ready`` Keychain entries.
+
+    The ``security -w`` prompt mode requires ``-w`` as the trailing argv
+    element, which forecloses test isolation via a trailing keychain
+    positional — hence the service-prefix approach. AC35's strict
+    reading ("no Keychain entry persists outside a ``tmp_path``-scoped
+    Keychain") is satisfied by the cleanup loop below; entries are
+    namespaced *and* removed in teardown so nothing persists.
+    """
+    from agentbundle.creds import _keychain_macos
+    unique_service = f"agent-ready-test-{abs(hash(str(tmp_path))) & 0xffffffff:08x}"
+    monkeypatch.setattr(_keychain_macos, "SERVICE", unique_service)
+
+    # Track every account written so teardown can delete them.
+    written: list[tuple[str, str]] = []
+    real_write = _keychain_macos.write_credential
+
+    def tracking_write(namespace, key, value):
+        written.append((namespace, key))
+        return real_write(namespace, key, value)
+
+    monkeypatch.setattr(_keychain_macos, "write_credential", tracking_write)
+    yield _keychain_macos
+    # Best-effort cleanup — the unique service prefix prevents collisions
+    # with real entries; the explicit deletes prevent accumulation.
+    for namespace, key in written:
+        try:
+            _keychain_macos.delete_credential(namespace, key)
+        except Exception:
+            pass
+
+
+# ── Round-trip + miss ──────────────────────────────────────────────────
+
+
+def test_write_then_read_byte_equal(backend):
+    """AC7: round-trip — write a value, read it, compare bytes."""
+    backend.write_credential("fixture_t4", "API_TOKEN", "round-trip-secret-1")
+    assert backend.read_credential("fixture_t4", "API_TOKEN") == "round-trip-secret-1"
+
+
+def test_read_missing_returns_none(backend):
+    """AC8 inverse: missing entry returns ``None`` so the resolver falls
+    through to Tier 3."""
+    assert backend.read_credential("fixture_t4_absent", "API_TOKEN") is None
+
+
+def test_write_upsert_replaces_value(backend):
+    """``-U`` flag: a second write with the same account replaces the value."""
+    backend.write_credential("fixture_t4", "API_TOKEN", "first")
+    backend.write_credential("fixture_t4", "API_TOKEN", "second")
+    assert backend.read_credential("fixture_t4", "API_TOKEN") == "second"
+
+
+def test_delete_removes_entry_and_subsequent_read_is_none(backend):
+    backend.write_credential("fixture_t4", "API_TOKEN", "to-delete")
+    backend.delete_credential("fixture_t4", "API_TOKEN")
+    assert backend.read_credential("fixture_t4", "API_TOKEN") is None
+
+
+def test_delete_missing_is_idempotent(backend):
+    """A delete on an absent entry must not raise (spec — idempotent)."""
+    backend.delete_credential("fixture_t4_never_set", "API_TOKEN")
+    # No raise expected.
+
+
+def test_multiple_keys_per_namespace_round_trip(backend):
+    backend.write_credential("fixture_t4", "API_TOKEN", "tok")
+    backend.write_credential("fixture_t4", "BASE_URL", "https://x.test")
+    assert backend.read_credential("fixture_t4", "API_TOKEN") == "tok"
+    assert backend.read_credential("fixture_t4", "BASE_URL") == "https://x.test"
+
+
+# ── Argv shape + token-not-on-argv ─────────────────────────────────────
+
+
+def test_find_argv_shape_matches_ac6(backend, monkeypatch):
+    """AC6: read argv has the canonical shape — service, account, ``-w``
+    (no trailing keychain positional)."""
+    captured = []
+    real_run = subprocess.run
+
+    def recording_run(argv, *args, **kwargs):
+        captured.append(list(argv))
+        return real_run(argv, *args, **kwargs)
+
+    backend.write_credential("fixture_t4", "API_TOKEN", "v")
+    captured.clear()
+    monkeypatch.setattr(backend.subprocess, "run", recording_run)
+    backend.read_credential("fixture_t4", "API_TOKEN")
+    assert len(captured) == 1
+    argv = captured[0]
+    # SERVICE is monkeypatched per-test; the rest of the shape is canonical.
+    assert argv == [
+        "/usr/bin/security", "find-generic-password",
+        "-s", backend.SERVICE,
+        "-a", "fixture_t4:API_TOKEN",
+        "-w",
+    ]
+
+
+def test_add_argv_shape_matches_ac6_no_trailing_token(backend, monkeypatch):
+    """AC6: write argv has the canonical shape and never carries the
+    token bytes; the trailing ``-w`` (no value) triggers prompt-from-stdin."""
+    captured_argv = []
+    real_popen = subprocess.Popen
+
+    def recording_popen(argv, *args, **kwargs):
+        captured_argv.append(list(argv))
+        return real_popen(argv, *args, **kwargs)
+
+    monkeypatch.setattr(backend.subprocess, "Popen", recording_popen)
+    secret = "super-secret-must-not-appear-on-argv-xyz"
+    backend.write_credential("fixture_t4_argv", "API_TOKEN", secret)
+    assert len(captured_argv) == 1
+    argv = captured_argv[0]
+    assert argv == [
+        "/usr/bin/security", "add-generic-password", "-U",
+        "-s", backend.SERVICE,
+        "-a", "fixture_t4_argv:API_TOKEN",
+        "-w",
+    ]
+    # No element of argv contains the secret.
+    for item in argv:
+        assert secret not in item, f"token leaked to argv element: {item!r}"
+
+
+def test_token_not_in_argv_via_proc_inspection(backend):
+    """AC6 ``psutil``-shaped check: while ``security`` runs, inspect
+    ``ps -axo args`` and assert the token bytes are absent. ``psutil``
+    is not stdlib; this test uses the system ``ps`` instead.
+    """
+    secret = "non-argv-token-abc123"
+    argv = [
+        "/usr/bin/security", "add-generic-password", "-U",
+        "-s", backend.SERVICE,
+        "-a", "fixture_t4_argv2:API_TOKEN",
+        "-w",  # last argv element — triggers prompt-from-stdin
+    ]
+    proc = subprocess.Popen(
+        argv,
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    try:
+        ps_out = subprocess.run(
+            ["ps", "-axo", "args"], capture_output=True, text=True
+        )
+        assert secret not in ps_out.stdout, (
+            "secret appeared in ps -axo args output"
+        )
+    finally:
+        _, err = proc.communicate(input=secret.encode("utf-8"))
+        # Best-effort cleanup of the entry written above.
+        try:
+            backend.delete_credential("fixture_t4_argv2", "API_TOKEN")
+        except Exception:
+            pass
+    assert proc.returncode == 0, err.decode("utf-8", errors="replace")
+
+
+# ── Loader-level platform dispatch (AC8 cross-ref) ─────────────────────
+
+
+def test_loader_imports_macos_backend_on_darwin():
+    """AC4b/AC8: when ``sys.platform == "darwin"``, the loader has the
+    ``_keychain_macos`` backend in ``sys.modules`` after a fresh import."""
+    # The test process is already running on darwin (skipif gated the
+    # whole module), so the backend should already be loaded by the
+    # loader's module-level dispatch.
+    for mod_name in list(sys.modules):
+        if mod_name == "agent_ready" or mod_name.startswith("agent_ready."):
+            sys.modules.pop(mod_name, None)
+        if (
+            mod_name == "agentbundle.creds"
+            or mod_name.startswith("agentbundle.creds")
+        ):
+            sys.modules.pop(mod_name, None)
+    import agent_ready.credentials  # noqa: F401 — re-import
+    assert "agentbundle.creds._keychain_macos" in sys.modules
+    assert "agentbundle.creds._credman_windows" not in sys.modules
+
+
+def test_loader_does_not_import_macos_backend_on_linux(monkeypatch):
+    """AC4b: when ``sys.platform`` is monkeypatched to a non-Darwin
+    value, the ``_keychain_macos`` import is skipped on fresh re-import."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    for mod_name in list(sys.modules):
+        if mod_name == "agent_ready" or mod_name.startswith("agent_ready."):
+            sys.modules.pop(mod_name, None)
+        if (
+            mod_name == "agentbundle.creds"
+            or mod_name.startswith("agentbundle.creds")
+        ):
+            sys.modules.pop(mod_name, None)
+    import agent_ready.credentials  # noqa: F401
+    assert "agentbundle.creds._keychain_macos" not in sys.modules


### PR DESCRIPTION
## Summary

- New ``agentbundle.creds._keychain_macos`` module shelling out to ``/usr/bin/security`` (stdlib subprocess; no ``keyring`` library).
- Token bytes never reach argv. The trailing ``-w`` triggers ``security``'s prompt-from-stdin mode (per ``security(1)`` man page).
- ``errSecItemNotFound`` (44) → ``None`` (Tier 3 fallthrough). Any other non-zero → ``Tier2HardFailError``.

**Discovery during implementation:** ``security add-generic-password -w`` actually prompts for the password **twice** (confirmation). Sending the token only once on stdin silently writes an empty password. The backend now sends ``token + "\n" + token + "\n"``; token still never crosses argv. Documented in the module + commit message.

Closes **AC6, AC7, AC8**.

## Test plan

- [x] ``pytest tests/integration/test_keychain_macos.py`` (Darwin only) — 11/11 pass: round-trip, miss, upsert, multi-key, idempotent-delete, AC6 argv shape, ``ps -axo args`` token-absence, loader-side platform dispatch (Darwin imports backend; Linux skips it).
- [x] ``make build-check`` — clean.
- [x] Full ``pytest packages/agentbundle/tests/`` — green.
- [x] Lints — clean.

## Wave 3 of 3

Task **T4**. Independent of T5 / T6 / T11 — no file overlap. Loader-side dispatch was already added in T3.

## Test isolation deviation

Strict AC35 (``tmp_path``-scoped Keychain via ``security create-keychain``) is foreclosed by AC6's mandatory trailing ``-w`` (security CLI consumes the next positional as the password value, conflicting with the trailing keychain positional). Tests use a ``tmp_path``-derived unique ``SERVICE`` prefix plus explicit cleanup so entries can't collide with the developer's real ``agent-ready`` Keychain entries and nothing persists. Documented in the test fixture docstring.