### PR TITLE
refactor(skill-new-spec): use subagent-matching pattern for spec review

### DIFF
--- a/.claude/skills/new-spec/SKILL.md
+++ b/.claude/skills/new-spec/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: new-spec
 description: Use this skill when the user wants to start a new feature with a spec, or wants to write a spec for something they're about to build. Triggers on "new spec", "write a spec for X", "let's spec this out", "start a feature for…". Spec-driven development; the spec drives implementation. Do NOT use for cross-cutting proposals (use `new-rfc`) or recording decisions (use `new-adr`).
-dependencies:
-  - .claude/agents/adversarial-reviewer.md
 ---
 
 # Skill: new-spec
@@ -97,15 +95,15 @@ look like?" before any code.
      in `parser/lex.ts:Lexer.next`" is the right level.
 
 6. Spec-mode adversarial review. Before announcing the spec in the README,
-   invoke `adversarial-reviewer` against the freshly drafted `spec.md` +
-   `plan.md` in spec mode — the agent supports this explicitly (see
-   `.claude/agents/adversarial-reviewer.md`). Iterate on findings until the
-   reviewer returns `Clean — ready to commit.` Spec-mode reviews should
-   converge in 1-2 passes; if you can't reach clean in 3, the spec has a
-   structural problem — surface to a human rather than grinding. This step
-   is contingent on the project using `adversarial-reviewer` at all (Profile
-   B+ per `docs/CONVENTIONS.md`); at Profile A the reviewer is typically
-   absent and this step is moot.
+   select a subagent matching `adversarial-reviewer` and ask it to review
+   the freshly drafted `spec.md` + `plan.md` in spec mode — the role
+   supports this explicitly. Iterate on findings until the reviewer returns
+   `Clean — ready to commit.` Spec-mode reviews should converge in 1-2
+   passes; if you can't reach clean in 3, the spec has a structural problem
+   — surface to a human rather than grinding. Absence of any subagent
+   matching this role is a note in the final summary
+   (`adversarial-reviewer: no matching subagent installed; review skipped`),
+   not a blocker.
 
 7. Update `docs/specs/README.md` to add the feature to the active list.
 

--- a/AGENTS.local.md
+++ b/AGENTS.local.md
@@ -21,6 +21,10 @@ trips `make build-check` and blocks every PR.
 | `docs/rfc/README.md`                 | `packs/governance-extras/seeds/docs/rfc/README.md`           |
 | `docs/adr/README.md`                 | `packs/governance-extras/seeds/docs/adr/README.md`           |
 | `docs/guides/**/README.md`           | `packs/user-guide-diataxis/seeds/docs/guides/**/README.md`   |
+| `.claude/skills/<name>/**`           | `packs/<pack>/.apm/skills/<name>/**` (e.g. `packs/core/.apm/skills/new-spec/SKILL.md`) |
+| `.claude/agents/<name>.md`           | `packs/<pack>/.apm/agents/<name>.md`                         |
+| `.claude/commands/<name>.md`         | `packs/<pack>/.apm/commands/<name>.md`                       |
+| `.claude/hooks/...`                  | `packs/<pack>/.apm/hooks/...`                                |
 
 **The workflow when you touch any of the above:**
 
@@ -43,11 +47,15 @@ The `make build-check` error message names the seed path you should
 have edited — so if you do trip it, the fix is mechanical (edit the
 seed it names, re-run `make build-self`, re-commit).
 
-**Drift fixed twice already** (each time a CI cycle wasted):
+**Drift fixed three times already** (each time a CI cycle wasted):
 - RFC-0007 PR (#53) added a row to `docs/rfc/README.md`; fixed by
   propagating to `packs/governance-extras/seeds/docs/rfc/README.md`.
 - converters-pack spec PR (#57) added a row to `docs/specs/README.md`;
   fixed by propagating to `packs/core/seeds/docs/specs/README.md`.
+- new-spec subagent-matching PR (#67) edited `.claude/skills/new-spec/SKILL.md`
+  directly; fixed by propagating to `packs/core/.apm/skills/new-spec/SKILL.md`.
+  Note: `.claude/skills/` and `.claude/agents/` project from
+  `packs/<pack>/.apm/...`, **not** from `packs/<pack>/seeds/...`.
 
 If you edit any README, table, or doc under the projected paths above,
 **check the seed first**.

--- a/packs/core/.apm/skills/new-spec/SKILL.md
+++ b/packs/core/.apm/skills/new-spec/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: new-spec
 description: Use this skill when the user wants to start a new feature with a spec, or wants to write a spec for something they're about to build. Triggers on "new spec", "write a spec for X", "let's spec this out", "start a feature for…". Spec-driven development; the spec drives implementation. Do NOT use for cross-cutting proposals (use `new-rfc`) or recording decisions (use `new-adr`).
-dependencies:
-  - .claude/agents/adversarial-reviewer.md
 ---
 
 # Skill: new-spec
@@ -97,15 +95,15 @@ look like?" before any code.
      in `parser/lex.ts:Lexer.next`" is the right level.
 
 6. Spec-mode adversarial review. Before announcing the spec in the README,
-   invoke `adversarial-reviewer` against the freshly drafted `spec.md` +
-   `plan.md` in spec mode — the agent supports this explicitly (see
-   `.claude/agents/adversarial-reviewer.md`). Iterate on findings until the
-   reviewer returns `Clean — ready to commit.` Spec-mode reviews should
-   converge in 1-2 passes; if you can't reach clean in 3, the spec has a
-   structural problem — surface to a human rather than grinding. This step
-   is contingent on the project using `adversarial-reviewer` at all (Profile
-   B+ per `docs/CONVENTIONS.md`); at Profile A the reviewer is typically
-   absent and this step is moot.
+   select a subagent matching `adversarial-reviewer` and ask it to review
+   the freshly drafted `spec.md` + `plan.md` in spec mode — the role
+   supports this explicitly. Iterate on findings until the reviewer returns
+   `Clean — ready to commit.` Spec-mode reviews should converge in 1-2
+   passes; if you can't reach clean in 3, the spec has a structural problem
+   — surface to a human rather than grinding. Absence of any subagent
+   matching this role is a note in the final summary
+   (`adversarial-reviewer: no matching subagent installed; review skipped`),
+   not a blocker.
 
 7. Update `docs/specs/README.md` to add the feature to the active list.
 


### PR DESCRIPTION
## Summary

- Replace the direct `invoke \`adversarial-reviewer\`` instruction in `new-spec` step 6 with the **"select a subagent matching `adversarial-reviewer`"** idiom already used in `work-loop` (SKILL.md lines 120, 268, 302).
- Drop the `.claude/agents/adversarial-reviewer.md` entry from the skill's frontmatter `dependencies:` — the skill no longer requires that agent file to be installed.
- Absence of a matching subagent is now a final-summary note (`adversarial-reviewer: no matching subagent installed; review skipped`), not a blocker. Removes the Profile-A/B+ branching since the select-or-note pattern handles both uniformly.

## Why

`new-spec` was the last skill carrying a hard dependency on a specific agent file. The `subagent matching <role>` pattern is the project's standard idiom for reviewer dispatch — it lets the same skill work whether the adopter ships our `adversarial-reviewer.md`, their own variant, or no matching subagent at all.

## Test plan

- [x] `git diff` shows only the intended frontmatter + step-6 changes
- [x] Phrasing matches the wording at `work-loop/SKILL.md:120-124` and `:268-273`
- [x] Final-summary label matches the format in `work-loop/SKILL.md:346` (`<role>: no matching subagent installed; review skipped`)