### PR TITLE
feat(skill-secrets): T5 — Windows Credential Manager Tier-2 backend

### DIFF
--- a/packages/agentbundle/agentbundle/creds/_credman_windows.py
+++ b/packages/agentbundle/agentbundle/creds/_credman_windows.py
@@ -1,0 +1,208 @@
+"""Windows Credential Manager Tier-2 backend (spec § AC9-AC12).
+
+In-process ``ctypes`` against ``advapi32.dll``'s ``CredReadW`` /
+``CredWriteW`` / ``CredDeleteW`` / ``CredFree`` — stdlib only, no
+``pywin32`` dependency. Token bytes never cross a process boundary;
+the entire flow stays inside the Python heap.
+
+Struct layout: per ``wincred.h``, ``CREDENTIAL`` carries 12 fields.
+For a generic password the load-bearing ones are ``TargetName``,
+``UserName``, ``CredentialBlob`` / ``CredentialBlobSize``, ``Type``
+and ``Persist``; the rest (``Flags``, ``Comment``, ``LastWritten``,
+``AttributeCount``, ``Attributes``, ``TargetAlias``) are
+zero-initialised via ``ctypes.Structure`` defaults — required by
+``CRED_TYPE_GENERIC`` (``Flags`` must be 0; ``Attributes`` must be
+NULL when ``AttributeCount`` is 0; ``LastWritten`` is set by the API
+and ignored on write).
+
+Per spec § AC4b the loader imports this module **only** when
+``sys.platform == "win32"``. The advapi32 binding is platform-guarded
+below so the module itself stays importable on every platform; tests
+that don't actually call the OS can construct ``CREDENTIAL`` instances
+and exercise the helpers without a real Windows host.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.wintypes as wt
+import sys
+from ctypes import POINTER, Structure, byref
+
+from .exceptions import Tier2HardFailError
+
+# Constants from ``wincred.h`` (spec § AC9):
+CRED_TYPE_GENERIC = 1
+CRED_PERSIST_LOCAL_MACHINE = 2
+
+# Win32 error codes — sourced from ``winerror.h`` and AC11:
+ERROR_NOT_FOUND = 1168          # falls through to Tier 3
+ERROR_NO_SUCH_LOGON_SESSION = 1312
+ERROR_INVALID_FLAGS = 1004
+ERROR_LOGON_FAILURE = 1326
+
+TARGET_PREFIX = "agent-ready"
+# Tests can monkeypatch this to a ``tmp_path``-derived value so test
+# target-names can't collide with the developer's real Credential
+# Manager entries (spec § AC35 / plan T5 § Test isolation).
+SERVICE_PREFIX_OVERRIDE: str | None = None
+
+
+class CREDENTIAL(Structure):
+    """Mirror of the Win32 ``CREDENTIAL`` struct (wincred.h, ``CredW``).
+
+    Field order and types must match the Win32 ABI exactly — a wrong-
+    sized field on Windows returns garbage rather than raising, which
+    is why AC10 mandates a byte-equality round-trip test on every field.
+    """
+
+    _fields_ = [
+        ("Flags", wt.DWORD),
+        ("Type", wt.DWORD),
+        ("TargetName", wt.LPWSTR),
+        ("Comment", wt.LPWSTR),
+        ("LastWritten", wt.FILETIME),
+        ("CredentialBlobSize", wt.DWORD),
+        ("CredentialBlob", POINTER(wt.BYTE)),
+        ("Persist", wt.DWORD),
+        ("AttributeCount", wt.DWORD),
+        ("Attributes", ctypes.c_void_p),
+        ("TargetAlias", wt.LPWSTR),
+        ("UserName", wt.LPWSTR),
+    ]
+
+
+def _bind_advapi32():
+    """Bind the four ``advapi32.dll`` entry points used by this backend.
+
+    Pinned to a single function so tests that don't need the real DLL
+    (struct shape, target-name format, error classifier) can run on
+    any platform.
+    """
+    advapi32 = ctypes.WinDLL("advapi32", use_last_error=True)  # type: ignore[attr-defined]
+    advapi32.CredReadW.restype = wt.BOOL
+    advapi32.CredReadW.argtypes = [
+        wt.LPCWSTR, wt.DWORD, wt.DWORD, POINTER(POINTER(CREDENTIAL))
+    ]
+    advapi32.CredWriteW.restype = wt.BOOL
+    advapi32.CredWriteW.argtypes = [POINTER(CREDENTIAL), wt.DWORD]
+    advapi32.CredDeleteW.restype = wt.BOOL
+    advapi32.CredDeleteW.argtypes = [wt.LPCWSTR, wt.DWORD, wt.DWORD]
+    advapi32.CredFree.restype = None
+    advapi32.CredFree.argtypes = [ctypes.c_void_p]
+    return advapi32
+
+
+# Platform-guarded binding. ``ctypes.WinDLL`` only exists on Windows;
+# importing this module on non-Windows leaves ``_advapi32`` as ``None``
+# so test files can still inspect struct shape + helpers without the
+# DLL present.
+if sys.platform == "win32":  # pragma: no cover — only exercised on Windows
+    _advapi32 = _bind_advapi32()
+else:
+    _advapi32 = None
+
+
+def _target_name(namespace: str, key: str) -> str:
+    """Compose the Win32 ``TargetName`` per spec § AC9."""
+    prefix = SERVICE_PREFIX_OVERRIDE or TARGET_PREFIX
+    return f"{prefix}:{namespace}:{key}"
+
+
+def _classify_last_error(rc: int, op: str) -> None:
+    """Map the Win32 last-error code to the AC11 dispatch matrix.
+
+    ``ERROR_NOT_FOUND`` is the caller's responsibility (it indicates a
+    legitimate miss — caller returns ``None``). Every other code on
+    this matrix raises ``Tier2HardFailError`` so the resolver does not
+    silently degrade to Tier 3 (spec § Never do).
+    """
+    if rc == ERROR_NO_SUCH_LOGON_SESSION:
+        raise Tier2HardFailError(
+            f"Windows Credential Manager {op} failed: "
+            f"ERROR_NO_SUCH_LOGON_SESSION (1312) — no logon session "
+            f"(running under LocalSystem or similar service context)"
+        )
+    if rc == ERROR_INVALID_FLAGS:
+        raise Tier2HardFailError(
+            f"Windows Credential Manager {op} failed: "
+            f"ERROR_INVALID_FLAGS (1004) — invalid flag value"
+        )
+    if rc == ERROR_LOGON_FAILURE:
+        raise Tier2HardFailError(
+            f"Windows Credential Manager {op} failed: "
+            f"ERROR_LOGON_FAILURE (1326) — DPAPI key-derivation failure"
+        )
+    raise Tier2HardFailError(
+        f"Windows Credential Manager {op} failed: "
+        f"unexpected Win32 error code {rc}"
+    )
+
+
+def read_credential(namespace: str, key: str) -> str | None:
+    """Read ``(namespace, key)`` from Credential Manager.
+
+    Returns ``None`` on ``ERROR_NOT_FOUND`` (resolver falls through to
+    Tier 3); raises ``Tier2HardFailError`` on every other documented
+    failure (AC11).
+    """
+    target = _target_name(namespace, key)
+    out_ptr = POINTER(CREDENTIAL)()
+    ok = _advapi32.CredReadW(target, CRED_TYPE_GENERIC, 0, byref(out_ptr))
+    if not ok:
+        rc = ctypes.get_last_error()
+        if rc == ERROR_NOT_FOUND:
+            return None
+        _classify_last_error(rc, "read")
+        return None  # unreachable — _classify always raises
+    try:
+        cred = out_ptr.contents
+        size = int(cred.CredentialBlobSize)
+        if size == 0 or not cred.CredentialBlob:
+            return ""
+        # Copy ``size`` bytes from the blob pointer; the token is stored
+        # as UTF-16-LE (matches the encoding used on write).
+        blob_bytes = ctypes.string_at(cred.CredentialBlob, size)
+        return blob_bytes.decode("utf-16-le")
+    finally:
+        _advapi32.CredFree(out_ptr)
+
+
+def write_credential(namespace: str, key: str, value: str) -> None:
+    """Write ``value`` to ``(namespace, key)`` (AC9, AC10).
+
+    The token is UTF-16-LE encoded and stored in a writable buffer
+    pointed to by ``CredentialBlob``; ``CredentialBlobSize`` is the
+    byte length of that buffer. The token never leaves the Python heap.
+    """
+    target = _target_name(namespace, key)
+    blob = value.encode("utf-16-le")
+    blob_buf = ctypes.create_string_buffer(blob, len(blob))
+
+    cred = CREDENTIAL()
+    # All other fields stay at ctypes.Structure's zero-init defaults
+    # (Flags=0, Comment=None, LastWritten=FILETIME(0,0),
+    # AttributeCount=0, Attributes=None, TargetAlias=None) — required
+    # by CRED_TYPE_GENERIC per spec § AC9.
+    cred.Type = CRED_TYPE_GENERIC
+    cred.TargetName = target
+    cred.CredentialBlobSize = len(blob)
+    cred.CredentialBlob = ctypes.cast(blob_buf, POINTER(wt.BYTE))
+    cred.Persist = CRED_PERSIST_LOCAL_MACHINE
+    cred.UserName = namespace
+
+    ok = _advapi32.CredWriteW(byref(cred), 0)
+    if not ok:
+        rc = ctypes.get_last_error()
+        _classify_last_error(rc, "write")
+
+
+def delete_credential(namespace: str, key: str) -> None:
+    """Idempotent delete — ``ERROR_NOT_FOUND`` is swallowed."""
+    target = _target_name(namespace, key)
+    ok = _advapi32.CredDeleteW(target, CRED_TYPE_GENERIC, 0)
+    if not ok:
+        rc = ctypes.get_last_error()
+        if rc == ERROR_NOT_FOUND:
+            return
+        _classify_last_error(rc, "delete")

--- a/packages/agentbundle/tests/integration/test_credman_windows.py
+++ b/packages/agentbundle/tests/integration/test_credman_windows.py
@@ -1,0 +1,126 @@
+"""T5: Windows Credential Manager Tier-2 backend — Windows-only round-trip.
+
+Gated on ``sys.platform == "win32"`` because ``ctypes.WinDLL`` only
+exists on Windows. The pure-logic tests
+(``tests/unit/test_credman_windows_logic.py``) cover struct shape,
+constants, target-name format, and the error classifier on every
+platform — those run on Darwin / Linux CI even though no real
+Credential Manager is present.
+
+CI matrix note: this repo's current build-check workflow does not
+include a ``windows-latest`` runner; this test will be exercised when
+that matrix lands (tracked as a follow-up to spec § AC10). Locally on
+a Windows dev box, ``pytest packages/agentbundle/tests/integration/test_credman_windows.py``
+will run.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="Windows Credential Manager backend — Windows-only",
+)
+
+
+@pytest.fixture
+def backend(tmp_path, monkeypatch):
+    """Scope target-name prefix to a ``tmp_path`` hash so test entries
+    can't collide with real ``agent-ready:`` entries in the developer's
+    Credential Manager (spec § AC35 / plan T5 § Test isolation)."""
+    from agentbundle.creds import _credman_windows as cm
+    unique = f"agent-ready-test-{abs(hash(str(tmp_path))) & 0xffffffff:08x}"
+    monkeypatch.setattr(cm, "SERVICE_PREFIX_OVERRIDE", unique)
+
+    written: list[tuple[str, str]] = []
+    real_write = cm.write_credential
+
+    def tracking_write(namespace, key, value):
+        written.append((namespace, key))
+        return real_write(namespace, key, value)
+
+    monkeypatch.setattr(cm, "write_credential", tracking_write)
+    yield cm
+    for namespace, key in written:
+        try:
+            cm.delete_credential(namespace, key)
+        except Exception:
+            pass
+
+
+def test_round_trip_byte_equality(backend):
+    """AC10: write a value, read it, ``assert read_back == value`` (the
+    UTF-16-LE encoding round-trips through ``CredentialBlob``)."""
+    token = "round-trip-tok-1"
+    backend.write_credential("fixture_t5", "API_TOKEN", token)
+    assert backend.read_credential("fixture_t5", "API_TOKEN") == token
+
+
+def test_unicode_round_trip(backend):
+    """AC10: non-ASCII values round-trip cleanly via UTF-16-LE."""
+    token = "unicode-tok-ünïcödé-π-字"
+    backend.write_credential("fixture_t5", "API_TOKEN", token)
+    assert backend.read_credential("fixture_t5", "API_TOKEN") == token
+
+
+def test_missing_credential_returns_none(backend):
+    """AC11: ``ERROR_NOT_FOUND`` (1168) → ``None`` so the resolver falls
+    through to Tier 3."""
+    assert backend.read_credential("fixture_t5_never_set", "API_TOKEN") is None
+
+
+def test_upsert_replaces_value(backend):
+    """A second write to the same target replaces the value
+    (Credential Manager's default semantics for ``CredWriteW``)."""
+    backend.write_credential("fixture_t5", "API_TOKEN", "first")
+    backend.write_credential("fixture_t5", "API_TOKEN", "second")
+    assert backend.read_credential("fixture_t5", "API_TOKEN") == "second"
+
+
+def test_multiple_keys_per_namespace_round_trip(backend):
+    backend.write_credential("fixture_t5", "API_TOKEN", "tok")
+    backend.write_credential("fixture_t5", "BASE_URL", "https://x.test")
+    assert backend.read_credential("fixture_t5", "API_TOKEN") == "tok"
+    assert backend.read_credential("fixture_t5", "BASE_URL") == "https://x.test"
+
+
+def test_delete_removes_entry(backend):
+    backend.write_credential("fixture_t5", "API_TOKEN", "secret")
+    backend.delete_credential("fixture_t5", "API_TOKEN")
+    assert backend.read_credential("fixture_t5", "API_TOKEN") is None
+
+
+def test_delete_missing_is_idempotent(backend):
+    """``ERROR_NOT_FOUND`` on delete is swallowed (idempotent)."""
+    backend.delete_credential("fixture_t5_never_set", "API_TOKEN")
+
+
+def test_credential_metadata_after_write(backend):
+    """AC9: after write, the stored credential carries the expected
+    ``TargetName``, ``UserName``, ``Type``, ``Persist`` values.
+
+    We re-read via ``CredReadW`` and inspect the returned struct's
+    fields (using ``ctypes.string_at`` for the blob copy on read).
+    """
+    import ctypes
+    from ctypes import POINTER, byref
+    backend.write_credential("fixture_t5_meta", "API_TOKEN", "secret")
+    out_ptr = POINTER(backend.CREDENTIAL)()
+    target = backend._target_name("fixture_t5_meta", "API_TOKEN")
+    ok = backend._advapi32.CredReadW(
+        target, backend.CRED_TYPE_GENERIC, 0, byref(out_ptr)
+    )
+    assert ok
+    try:
+        cred = out_ptr.contents
+        assert cred.TargetName == target
+        assert cred.UserName == "fixture_t5_meta"
+        assert cred.Type == backend.CRED_TYPE_GENERIC
+        assert cred.Persist == backend.CRED_PERSIST_LOCAL_MACHINE
+    finally:
+        backend._advapi32.CredFree(out_ptr)

--- a/packages/agentbundle/tests/unit/test_credman_windows_logic.py
+++ b/packages/agentbundle/tests/unit/test_credman_windows_logic.py
@@ -1,0 +1,155 @@
+"""T5 — pure-logic tests for the Windows Credential Manager backend.
+
+These tests inspect struct shapes, target-name formatting, and the
+error-code classifier WITHOUT calling the real Win32 API. They run on
+every platform so the structure / classifier contracts are exercised
+on Darwin + Linux CI even though no end-to-end Credential Manager
+round-trip is possible there.
+
+The actual API tests (``test_credman_windows.py``) gate on
+``sys.platform == "win32"``.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.wintypes as wt
+
+import pytest
+
+from agentbundle.creds import _credman_windows as cm
+from agentbundle.creds.exceptions import Tier2HardFailError
+
+
+def test_credential_struct_field_order_matches_wincred_h():
+    """AC9: field order must match the Win32 ``CREDENTIAL`` ABI.
+
+    Wrong-order or wrong-sized fields don't raise — they return
+    garbage on real Win32. Pinning the field order in a test is the
+    only catch-net.
+    """
+    names = [name for name, _typ in cm.CREDENTIAL._fields_]
+    assert names == [
+        "Flags",
+        "Type",
+        "TargetName",
+        "Comment",
+        "LastWritten",
+        "CredentialBlobSize",
+        "CredentialBlob",
+        "Persist",
+        "AttributeCount",
+        "Attributes",
+        "TargetAlias",
+        "UserName",
+    ]
+
+
+def test_credential_struct_field_types():
+    """AC9: each field is the correct ctypes wintypes alias."""
+    fields = dict(cm.CREDENTIAL._fields_)
+    assert fields["Flags"] is wt.DWORD
+    assert fields["Type"] is wt.DWORD
+    assert fields["TargetName"] is wt.LPWSTR
+    assert fields["Comment"] is wt.LPWSTR
+    assert fields["LastWritten"] is wt.FILETIME
+    assert fields["CredentialBlobSize"] is wt.DWORD
+    assert fields["Persist"] is wt.DWORD
+    assert fields["AttributeCount"] is wt.DWORD
+    assert fields["Attributes"] is ctypes.c_void_p
+    assert fields["TargetAlias"] is wt.LPWSTR
+    assert fields["UserName"] is wt.LPWSTR
+
+
+def test_credential_zero_initialised_defaults():
+    """AC9: ``CREDENTIAL()`` zero-inits every field — required by
+    ``CRED_TYPE_GENERIC`` (Flags must be 0; Attributes NULL when
+    AttributeCount==0)."""
+    cred = cm.CREDENTIAL()
+    assert cred.Flags == 0
+    assert cred.Type == 0  # caller sets to CRED_TYPE_GENERIC explicitly
+    assert cred.TargetName is None
+    assert cred.Comment is None
+    # FILETIME is a struct with dwLowDateTime/dwHighDateTime — both zero.
+    assert cred.LastWritten.dwLowDateTime == 0
+    assert cred.LastWritten.dwHighDateTime == 0
+    assert cred.CredentialBlobSize == 0
+    assert not cred.CredentialBlob  # NULL pointer
+    assert cred.Persist == 0
+    assert cred.AttributeCount == 0
+    assert cred.Attributes in (None, 0)  # c_void_p NULL
+    assert cred.TargetAlias is None
+    assert cred.UserName is None
+
+
+def test_constants_match_wincred_h():
+    """AC9: numeric constants match the Win32 header values."""
+    assert cm.CRED_TYPE_GENERIC == 1
+    assert cm.CRED_PERSIST_LOCAL_MACHINE == 2
+
+
+def test_error_code_constants_match_winerror_h():
+    """AC11: numeric error codes match the Win32 header values."""
+    assert cm.ERROR_NOT_FOUND == 1168
+    assert cm.ERROR_NO_SUCH_LOGON_SESSION == 1312
+    assert cm.ERROR_INVALID_FLAGS == 1004
+    assert cm.ERROR_LOGON_FAILURE == 1326
+
+
+def test_target_name_format():
+    """AC9: ``TargetName == "agent-ready:<namespace>:<key>"``."""
+    assert cm._target_name("jira", "API_TOKEN") == "agent-ready:jira:API_TOKEN"
+    assert cm._target_name("ns", "K") == "agent-ready:ns:K"
+
+
+def test_target_name_honours_service_prefix_override(monkeypatch):
+    """AC35 test-isolation: tests can scope the target-name prefix to a
+    ``tmp_path``-derived unique value."""
+    monkeypatch.setattr(cm, "SERVICE_PREFIX_OVERRIDE", "agent-ready-test-abcd1234")
+    assert (
+        cm._target_name("jira", "API_TOKEN")
+        == "agent-ready-test-abcd1234:jira:API_TOKEN"
+    )
+
+
+def test_classify_last_error_no_such_logon_session_raises():
+    """AC11: ERROR_NO_SUCH_LOGON_SESSION (1312) raises ``Tier2HardFailError``.
+
+    Resolver MUST NOT fall through to Tier 3 — silent degradation
+    defeats the security posture the user chose.
+    """
+    with pytest.raises(Tier2HardFailError, match="1312"):
+        cm._classify_last_error(cm.ERROR_NO_SUCH_LOGON_SESSION, "read")
+
+
+def test_classify_last_error_invalid_flags_raises():
+    """AC11: ERROR_INVALID_FLAGS (1004) raises ``Tier2HardFailError``."""
+    with pytest.raises(Tier2HardFailError, match="1004"):
+        cm._classify_last_error(cm.ERROR_INVALID_FLAGS, "write")
+
+
+def test_classify_last_error_logon_failure_raises():
+    """AC11: ERROR_LOGON_FAILURE (1326) raises ``Tier2HardFailError``
+    naming DPAPI key-derivation failure."""
+    with pytest.raises(Tier2HardFailError, match="1326"):
+        cm._classify_last_error(cm.ERROR_LOGON_FAILURE, "read")
+
+
+def test_classify_last_error_unknown_code_raises():
+    """Defensive: any uncategorised non-zero rc surfaces as a hard fail
+    rather than silently degrading."""
+    with pytest.raises(Tier2HardFailError, match="unexpected"):
+        cm._classify_last_error(9999, "read")
+
+
+def test_blob_round_trip_via_utf16le():
+    """AC10 inverse: the encoding round-trip (without calling Win32)
+    matches the wire format the spec mandates — UTF-16-LE byte
+    sequence equals what ``decode("utf-16-le")`` reverses."""
+    token = "tok-abc-ünïcödé"
+    blob = token.encode("utf-16-le")
+    # Each UTF-16 code unit is 2 bytes; LE means low byte first.
+    assert len(blob) == 2 * len(token)
+    assert blob[0:2] == b"t\x00"
+    # Round-trip:
+    assert blob.decode("utf-16-le") == token


### PR DESCRIPTION
## Summary

- In-process ``ctypes`` against ``advapi32.dll`` (``CredReadW`` / ``CredWriteW`` / ``CredDeleteW`` / ``CredFree``). Stdlib only — no ``pywin32``.
- ``CREDENTIAL`` ``ctypes.Structure`` mirrors the wincred.h ABI field order; ``Type = CRED_TYPE_GENERIC (1)``, ``Persist = CRED_PERSIST_LOCAL_MACHINE (2)``, ``TargetName = "agent-ready:<namespace>:<key>"``, ``UserName = <namespace>``, ``CredentialBlob`` points at UTF-16-LE-encoded token bytes.
- Token bytes never cross a process boundary; argv stays empty of the token.
- Win32 error matrix per AC11: 1168 → ``None`` (Tier 3 fallthrough); 1312 / 1004 / 1326 → ``Tier2HardFailError`` (no silent degrade).

Closes **AC9, AC10, AC11, AC12** (AC12 cross-covered by T3's loader dispatch test).

## Test plan

- [x] ``tests/unit/test_credman_windows_logic.py`` — **12 platform-agnostic tests pass on Darwin**: struct field-order + types match AC9; ``CREDENTIAL()`` zero-init defaults; constants match Win32 headers; target-name format; error classifier raises for each AC11 code + unknown.
- [x] ``tests/integration/test_credman_windows.py`` — 8 Windows-only tests **collected + skipped on Darwin** (round-trip byte equality, Unicode, missing-returns-None, upsert, multi-key, delete, idempotent-delete-on-miss, post-write metadata via re-read).
- [x] ``make build-check`` — clean.
- [x] Full ``pytest packages/agentbundle/tests/`` — green.
- [x] Lints — clean.

## Verification gap surfaced

This repo's CI matrix does not yet include a ``windows-latest`` runner. The 8 integration tests are structurally complete but exercise nowhere automated until that matrix lands. The 12 pure-logic tests catch struct-shape / classifier drift — the silent-corruption failure mode AC9 specifically warns about. The risk note in the user's session prompt acknowledged this CI-matrix gap; the test layout makes the boundary explicit so a future Windows-CI PR only needs to add the runner.

## Wave 3 of 3

Task **T5**. Independent of T4 / T6 / T11.