### PR TITLE
feat(skill-secrets): T7 — creds-schema.toml parser + canonical path resolver

### DIFF
--- a/packages/agentbundle/agentbundle/creds/exceptions.py
+++ b/packages/agentbundle/agentbundle/creds/exceptions.py
@@ -28,3 +28,13 @@ class PermissiveAclError(Exception):
     ``BUILTIN\\Administrators``) cause the helper to refuse unless
     ``allow_permissive_acl=True`` was passed.
     """
+
+
+class SchemaError(Exception):
+    """Raised when a ``creds-schema.toml`` file is malformed or missing.
+
+    Per spec § AC24 / AC24b — names the offending file path and the
+    specific shape violation (missing ``[namespace]``, empty
+    ``namespace.keys``, non-boolean ``secret``, or unresolvable
+    canonical path).
+    """

--- a/packages/agentbundle/agentbundle/creds/loader.py
+++ b/packages/agentbundle/agentbundle/creds/loader.py
@@ -34,16 +34,19 @@ quoted value is preserved (``KEY="a\\rb"`` → ``{"KEY": "a\\rb"}``).
 
 from __future__ import annotations
 
+import dataclasses
 import os
 import pathlib
 import re
 import subprocess
 import sys
 import tempfile
+import tomllib
 
 from .exceptions import (
     CredentialsMissingError,
     PermissiveAclError,
+    SchemaError,
     Tier2HardFailError,
 )
 
@@ -392,14 +395,156 @@ def load_credentials(
     return Credentials(namespace, resolved)
 
 
+# ── creds-schema.toml parser (spec § AC24, AC24b) ─────────────────────
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class KeyDef:
+    """A single required key declared in ``creds-schema.toml``.
+
+    ``secret=True`` keys are prompted via ``getpass.getpass`` (no echo);
+    ``secret=False`` keys are prompted via ``input()`` per spec § AC24.
+    """
+
+    name: str
+    label: str
+    secret: bool
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class CredsSchema:
+    """A parsed ``creds-schema.toml`` for a single namespace."""
+
+    namespace: str
+    keys: tuple[KeyDef, ...]
+
+
+def _parse_schema(path: pathlib.Path) -> CredsSchema:
+    """Parse a ``creds-schema.toml`` file into a typed ``CredsSchema``.
+
+    Per spec § AC24, the expected shape is::
+
+        [namespace]
+        name = "<namespace>"
+
+        [[namespace.keys]]
+        name = "API_TOKEN"
+        label = "<service> API token"
+        secret = true
+
+    The parser raises ``SchemaError`` (naming the path) on missing
+    ``[namespace]``, empty ``namespace.keys``, or non-boolean ``secret``.
+    """
+    try:
+        with path.open("rb") as fh:
+            data = tomllib.load(fh)
+    except FileNotFoundError as exc:
+        raise SchemaError(f"creds-schema.toml not found: {path}") from exc
+    except tomllib.TOMLDecodeError as exc:
+        raise SchemaError(f"creds-schema.toml malformed ({path}): {exc}") from exc
+
+    ns_table = data.get("namespace")
+    if not isinstance(ns_table, dict):
+        raise SchemaError(f"creds-schema.toml missing [namespace] ({path})")
+    namespace = ns_table.get("name")
+    if not isinstance(namespace, str) or not namespace:
+        raise SchemaError(
+            f"creds-schema.toml missing namespace.name ({path})"
+        )
+    raw_keys = ns_table.get("keys")
+    if not isinstance(raw_keys, list) or not raw_keys:
+        raise SchemaError(
+            f"creds-schema.toml namespace.keys must declare at least one key ({path})"
+        )
+    keys: list[KeyDef] = []
+    for idx, entry in enumerate(raw_keys):
+        if not isinstance(entry, dict):
+            raise SchemaError(
+                f"creds-schema.toml namespace.keys[{idx}] is not a table ({path})"
+            )
+        name = entry.get("name")
+        label = entry.get("label")
+        secret = entry.get("secret")
+        if not isinstance(name, str) or not name:
+            raise SchemaError(
+                f"creds-schema.toml namespace.keys[{idx}].name missing or non-string ({path})"
+            )
+        if not isinstance(label, str):
+            raise SchemaError(
+                f"creds-schema.toml namespace.keys[{idx}].label missing or non-string ({path})"
+            )
+        if not isinstance(secret, bool):
+            raise SchemaError(
+                f"creds-schema.toml namespace.keys[{idx}].secret must be boolean ({path})"
+            )
+        keys.append(KeyDef(name=name, label=label, secret=secret))
+    return CredsSchema(namespace=namespace, keys=tuple(keys))
+
+
+_SKILL_MD_RE = re.compile(r"^\.claude/skills/([^/]+)/SKILL\.md$")
+
+
+def resolve_schema_path(
+    state: "object", pack: str, skill_name: str
+) -> pathlib.Path:
+    """Resolve the canonical ``creds-schema.toml`` path per spec § AC24b.
+
+    Walks ``state.packs[pack].files`` for a relpath matching
+    ``^\\.claude/skills/<skill_name>/SKILL\\.md$``; takes that
+    relpath's parent directory and joins ``references/creds-schema.toml``.
+    Returns the absolute path resolved against the state file's
+    container directory (caller is responsible for joining the right
+    scope root if needed; this function returns the *relative-form
+    rooted at* the path the state stored).
+
+    Raises ``SchemaError`` if no matching SKILL.md row is in
+    ``pack.files`` — names the offending pack and skill so the message
+    is actionable.
+
+    Uses the **existing** v0.3 state-file schema — no new fields are
+    added.
+    """
+    packs = getattr(state, "packs", None)
+    if not isinstance(packs, dict):
+        raise SchemaError(
+            f"state has no ``packs`` attribute or wrong type "
+            f"(got {type(state).__name__})"
+        )
+    pack_state = packs.get(pack)
+    if pack_state is None:
+        raise SchemaError(
+            f"pack {pack!r} not present in state.packs "
+            f"(known: {sorted(packs)})"
+        )
+    files = getattr(pack_state, "files", None)
+    if not isinstance(files, dict):
+        raise SchemaError(
+            f"state.packs[{pack!r}].files is missing or not a dict"
+        )
+    for relpath in files:
+        m = _SKILL_MD_RE.match(relpath)
+        if m and m.group(1) == skill_name:
+            parent = pathlib.PurePosixPath(relpath).parent
+            return pathlib.Path(str(parent / "references" / "creds-schema.toml"))
+    raise SchemaError(
+        f"creds-schema.toml not found at expected path: no "
+        f"``.claude/skills/{skill_name}/SKILL.md`` row in pack "
+        f"{pack!r}'s files table"
+    )
+
+
 __all__ = [
+    "CredsSchema",
     "Credentials",
     "CredentialsMissingError",
     "EnvParseError",
+    "KeyDef",
     "PermissiveAclError",
+    "SchemaError",
     "Tier2HardFailError",
     "load_credentials",
     "parse_env_file",
+    "resolve_schema_path",
 ]
 
 

--- a/packages/agentbundle/tests/unit/test_credentials_schema.py
+++ b/packages/agentbundle/tests/unit/test_credentials_schema.py
@@ -1,0 +1,216 @@
+"""T7: ``creds-schema.toml`` parser + canonical-path resolver
+(skill-secrets spec § AC24, AC24b).
+"""
+
+from __future__ import annotations
+
+import pathlib
+from types import SimpleNamespace
+
+import pytest
+
+from agentbundle.creds.exceptions import SchemaError
+from agentbundle.creds.loader import (
+    CredsSchema,
+    KeyDef,
+    _parse_schema,
+    resolve_schema_path,
+)
+
+
+def _write(tmp_path: pathlib.Path, content: str) -> pathlib.Path:
+    target = tmp_path / "creds-schema.toml"
+    target.write_text(content, encoding="utf-8")
+    return target
+
+
+def test_parse_valid_schema(tmp_path):
+    """AC24: a well-formed schema parses into ``CredsSchema`` with the
+    expected ``namespace`` and ``KeyDef`` entries."""
+    path = _write(tmp_path, """
+        [namespace]
+        name = "jira"
+
+        [[namespace.keys]]
+        name = "API_TOKEN"
+        label = "Jira API token"
+        secret = true
+
+        [[namespace.keys]]
+        name = "BASE_URL"
+        label = "Jira instance base URL"
+        secret = false
+    """)
+    schema = _parse_schema(path)
+    assert isinstance(schema, CredsSchema)
+    assert schema.namespace == "jira"
+    assert len(schema.keys) == 2
+    assert schema.keys[0] == KeyDef(name="API_TOKEN", label="Jira API token", secret=True)
+    assert schema.keys[1] == KeyDef(name="BASE_URL", label="Jira instance base URL", secret=False)
+
+
+def test_credentials_schema_is_immutable():
+    """``CredsSchema`` and ``KeyDef`` are frozen dataclasses."""
+    schema = CredsSchema(namespace="x", keys=(KeyDef("A", "lbl", True),))
+    with pytest.raises(dataclasses_FrozenInstanceError := __import__("dataclasses").FrozenInstanceError):
+        schema.namespace = "y"  # type: ignore[misc]
+    with pytest.raises(dataclasses_FrozenInstanceError):
+        schema.keys[0].name = "B"  # type: ignore[misc]
+
+
+def test_parse_missing_namespace_table_raises(tmp_path):
+    """``SchemaError`` names the file path."""
+    path = _write(tmp_path, "")
+    with pytest.raises(SchemaError, match="missing \\[namespace\\]"):
+        _parse_schema(path)
+
+
+def test_parse_missing_namespace_name_raises(tmp_path):
+    path = _write(tmp_path, "[namespace]\n")
+    with pytest.raises(SchemaError, match="namespace.name"):
+        _parse_schema(path)
+
+
+def test_parse_empty_keys_list_raises(tmp_path):
+    path = _write(tmp_path, """
+        [namespace]
+        name = "x"
+        keys = []
+    """)
+    with pytest.raises(SchemaError, match="declare at least one key"):
+        _parse_schema(path)
+
+
+def test_parse_missing_keys_table_raises(tmp_path):
+    path = _write(tmp_path, """
+        [namespace]
+        name = "x"
+    """)
+    with pytest.raises(SchemaError, match="declare at least one key"):
+        _parse_schema(path)
+
+
+def test_parse_non_boolean_secret_raises(tmp_path):
+    path = _write(tmp_path, """
+        [namespace]
+        name = "x"
+        [[namespace.keys]]
+        name = "A"
+        label = "A label"
+        secret = "yes"
+    """)
+    with pytest.raises(SchemaError, match="secret must be boolean"):
+        _parse_schema(path)
+
+
+def test_parse_missing_label_raises(tmp_path):
+    path = _write(tmp_path, """
+        [namespace]
+        name = "x"
+        [[namespace.keys]]
+        name = "A"
+        secret = true
+    """)
+    with pytest.raises(SchemaError, match="label"):
+        _parse_schema(path)
+
+
+def test_parse_missing_name_raises(tmp_path):
+    path = _write(tmp_path, """
+        [namespace]
+        name = "x"
+        [[namespace.keys]]
+        label = "lbl"
+        secret = true
+    """)
+    with pytest.raises(SchemaError, match=r"keys\[0\]\.name"):
+        _parse_schema(path)
+
+
+def test_parse_malformed_toml_raises(tmp_path):
+    path = _write(tmp_path, "this is not = valid toml [[")
+    with pytest.raises(SchemaError, match="malformed"):
+        _parse_schema(path)
+
+
+def test_parse_missing_file_raises(tmp_path):
+    path = tmp_path / "does-not-exist.toml"
+    with pytest.raises(SchemaError, match="not found"):
+        _parse_schema(path)
+
+
+# ── Canonical-path resolution (AC24b) ──────────────────────────────────
+
+
+def test_resolve_schema_path_locates_skill_md_and_joins_references():
+    """AC24b: ``resolve_schema_path`` walks ``state.packs[pack].files``
+    for ``.claude/skills/<name>/SKILL.md``, takes the parent directory,
+    and joins ``references/creds-schema.toml``."""
+    pack_state = SimpleNamespace(files={
+        ".claude/skills/jira/SKILL.md": {"sha": "deadbeef"},
+        ".claude/skills/jira/scripts/cli.py": {"sha": "cafef00d"},
+        ".claude/skills/example/SKILL.md": {"sha": "00000000"},
+    })
+    state = SimpleNamespace(packs={"core": pack_state})
+    resolved = resolve_schema_path(state, "core", "jira")
+    assert str(resolved) == ".claude/skills/jira/references/creds-schema.toml"
+
+
+def test_resolve_schema_path_disambiguates_by_skill_name():
+    """Two skills under the same pack — the resolver picks the right one."""
+    pack_state = SimpleNamespace(files={
+        ".claude/skills/jira/SKILL.md": {"sha": "a"},
+        ".claude/skills/github/SKILL.md": {"sha": "b"},
+    })
+    state = SimpleNamespace(packs={"core": pack_state})
+    assert str(resolve_schema_path(state, "core", "jira")) == \
+        ".claude/skills/jira/references/creds-schema.toml"
+    assert str(resolve_schema_path(state, "core", "github")) == \
+        ".claude/skills/github/references/creds-schema.toml"
+
+
+def test_resolve_schema_path_missing_skill_raises():
+    """AC24b: a missing SKILL.md row raises ``SchemaError`` naming the
+    offending pack + skill so the message is actionable."""
+    pack_state = SimpleNamespace(files={
+        ".claude/skills/jira/SKILL.md": {"sha": "a"},
+    })
+    state = SimpleNamespace(packs={"core": pack_state})
+    with pytest.raises(SchemaError, match="not found at expected path"):
+        resolve_schema_path(state, "core", "absent-skill")
+
+
+def test_resolve_schema_path_missing_pack_raises():
+    state = SimpleNamespace(packs={})
+    with pytest.raises(SchemaError, match="pack 'core' not present"):
+        resolve_schema_path(state, "core", "jira")
+
+
+def test_resolve_schema_path_ignores_non_skill_md_entries():
+    """The regex must match exactly ``.claude/skills/<name>/SKILL.md`` —
+    nested or differently-named files are skipped."""
+    pack_state = SimpleNamespace(files={
+        ".claude/skills/jira/scripts/cli.py": {"sha": "a"},
+        ".claude/agents/foo.md": {"sha": "b"},
+        ".claude/skills/jira/SKILL.md": {"sha": "c"},  # the right one
+    })
+    state = SimpleNamespace(packs={"core": pack_state})
+    assert ".claude/skills/jira" in str(resolve_schema_path(state, "core", "jira"))
+
+
+# ── ``load_credentials(schema_path=...)`` kwarg (T3 + T7) ──────────────
+
+
+def test_load_credentials_accepts_schema_path_kwarg(tmp_path, monkeypatch):
+    """Primitive authors can pass ``schema_path`` for their own schema
+    file — verified by signature inspection (the resolver-vs-passthrough
+    logic is exercised by the CLI in T8)."""
+    import inspect
+
+    from agentbundle.creds.loader import load_credentials
+    sig = inspect.signature(load_credentials)
+    assert "schema_path" in sig.parameters
+    param = sig.parameters["schema_path"]
+    # Keyword-only per AC3.
+    assert param.kind == inspect.Parameter.KEYWORD_ONLY
+    assert param.default is None


### PR DESCRIPTION
## Summary

- ``_parse_schema(path) -> CredsSchema`` using ``tomllib`` (stdlib).
- ``CredsSchema`` / ``KeyDef`` frozen dataclasses — immutable so primitive authors and the CLI can pass them around without worrying about silent mutation.
- ``resolve_schema_path(state, pack, skill_name)`` walks ``state.packs[pack].files`` for ``.claude/skills/<name>/SKILL.md``, takes the parent directory, and joins ``references/creds-schema.toml``. Uses the **existing** v0.3 ``PackState.files`` table — no new state-schema fields.
- New ``SchemaError`` exception class.
- Verifies ``load_credentials``'s ``schema_path`` kwarg is keyword-only with default ``None`` (the T3 surface, now exercised).

Closes **AC24, AC24b**.

## Test plan

- [x] ``pytest packages/agentbundle/tests/unit/test_credentials_schema.py`` — 17/17 pass: 11 parser cases (valid + immutability + 9 error shapes), 5 canonical-path cases, 1 ``load_credentials`` signature regression.
- [x] ``make build-check`` — clean.
- [x] Full ``pytest packages/agentbundle/tests/`` — green.
- [x] Lints — clean.

## Wave 3 of 3 — final task

Task **T7**. Lands AFTER T6 per the user prompt's risk note (both edit ``loader.py``; T6 added Tier-3 dotfile in the same file). Rebased on top of T6 already; no merge conflicts expected.