### PR TITLE
feat(skill-secrets): T8 — agentbundle creds CLI verb

### DIFF
--- a/packages/agentbundle/agentbundle/cli.py
+++ b/packages/agentbundle/agentbundle/cli.py
@@ -330,6 +330,14 @@ def _build_parser() -> argparse.ArgumentParser:
     sp.add_argument("--scope", choices=("repo", "user"))
     sp.set_defaults(func=_lazy("init_state"))
 
+    # --- creds --- (skill-secrets T8: setup/check/where/rm)
+    # The verb is its own dispatcher with four sub-subparsers; the
+    # subparser is built by ``commands.creds.build_parser`` so the
+    # tombstone-argument action lives next to the rest of the verb's
+    # logic instead of leaking into this file.
+    from agentbundle.commands import creds as _creds_module
+    _creds_module.build_parser(subparsers)
+
     # --- reconcile --- (read-only orphan reporter, RFC-0005 / T9)
     # No --apply flag — the subcommand is report-only by design.
     # `argparse`'s default "unrecognized argument" rejects --apply.

--- a/packages/agentbundle/agentbundle/commands/creds.py
+++ b/packages/agentbundle/agentbundle/commands/creds.py
@@ -1,0 +1,694 @@
+"""``agentbundle creds`` — credential setup/check/where/rm verbs (T8).
+
+Four subcommands per spec.md § AC16-AC23:
+
+- ``setup <namespace>`` — prompt for required keys, write to the highest-
+  available tier (keyring on Darwin/Windows; dotfile on Linux or when
+  ``--allow-insecure-fallback`` is passed), announce the tier on stderr.
+- ``check <namespace>`` — exit 0 when all required keys resolve, 2 when
+  any is missing, 3 for other errors (schema parse, Tier-2 hard-fail).
+- ``where <namespace>`` — print one line per required key naming the
+  resolving tier (``env`` / ``keyring`` / ``dotfile`` / ``missing``).
+  Never prints the value.
+- ``rm <namespace>`` — delete every key in the namespace from every tier
+  that holds it. Refuses if no tier holds anything.
+
+**No ``get`` subcommand.** Per RFC-0006 § 5 and spec § AC21, printing the
+cleartext token to stdout is foreclosed in v1 — the architecture rule
+("primitives own the secret; the LLM never sees cleartext as a tool
+argument") collapses if any verb writes the token to a file descriptor
+a skill body can capture.
+
+**Tombstone arguments for the argv ban** (spec § AC23): the ``setup``
+subparser registers ``--token`` / ``--api-token`` / ``--api-key`` /
+``--bearer`` / ``--pat`` / ``--password`` with a custom action that
+prints the verbatim sentinel ``tokens cannot be passed via argv`` to
+stderr and exits non-zero. The argparse default ``unrecognized
+arguments:`` text would not match the AC23 anchor; the custom action
+is what closes the contract.
+
+Per-subcommand exit codes match the sibling-verb convention at
+``agentbundle.commands.*``:
+
+- 0 success.
+- 2 missing-credential (the namespace's required keys did not all
+  resolve; ``check`` is the canonical site).
+- 3 other error (schema parse failure; Tier-2 hard-fail; no state-file
+  hit for the namespace; the helper's own argv refusal).
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import os
+import pathlib
+import re
+import sys
+
+# Sentinel emitted by the tombstone-argument action. AC23 names this
+# byte sequence as the canonical anchor; tests grep for it verbatim.
+_ARGV_REFUSAL_STDERR = "tokens cannot be passed via argv"
+
+
+# ── Tombstone argparse action (spec § AC23) ────────────────────────────
+
+
+class _RefuseTokenArgvAction(argparse.Action):
+    """Refuse any of the argv-borne credential flags.
+
+    Registered on the ``setup`` subparser only — other ``agentbundle``
+    verbs (and other ``creds`` subcommands) keep their default argparse
+    behaviour so the tombstone shape is scoped, not global.
+
+    The action emits the AC23-canonical stderr sentinel and exits with
+    code 3 (the spec's "other error" bucket for the CLI verb).
+    """
+
+    def __init__(self, option_strings, dest, **kwargs):  # type: ignore[no-untyped-def]
+        # ``nargs=0`` would make argparse refuse to consume a following
+        # value, which is exactly wrong: ``--token foo`` must be caught
+        # (the user is trying to pass the secret). Accept one value and
+        # discard it before the refusal so the message is the same
+        # whether the flag was given a value or not.
+        kwargs.setdefault("nargs", "?")
+        kwargs.setdefault("default", argparse.SUPPRESS)
+        super().__init__(option_strings, dest, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):  # type: ignore[no-untyped-def]
+        sys.stderr.write(f"{_ARGV_REFUSAL_STDERR}\n")
+        raise SystemExit(3)
+
+
+# ── ``creds`` parser with custom error rewrite (spec § AC21) ──────────
+
+
+class _CredsSubcommandParser(argparse.ArgumentParser):
+    """Rewrites ``invalid choice: 'get'`` to ``unknown command: get``
+    so AC21's negative-test contract holds.
+
+    Argparse's default text would read ``argument <subcommand>: invalid
+    choice: 'get' (choose from 'setup', 'check', 'where', 'rm')``; the
+    test asserts the exact ``unknown command: get`` shape.
+    """
+
+    def error(self, message: str) -> None:  # type: ignore[override]
+        m = re.search(r"invalid choice:\s*'([^']+)'", message)
+        if m is not None:
+            sys.stderr.write(f"unknown command: {m.group(1)}\n")
+            raise SystemExit(3)
+        super().error(message)
+
+
+def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
+    """Build the ``creds`` subparser and its four subcommands.
+
+    Called from ``agentbundle.cli._build_parser`` so the verb plugs in
+    next to the existing eleven siblings without a registry.
+    """
+    creds = parent_subparsers.add_parser(
+        "creds",
+        help="Manage credentials for credentialed primitives.",
+        description=(
+            "Set up, check, locate, or remove credentials for "
+            "credentialed-primitive skills. Three tiers: env var, OS "
+            "keyring (Darwin/Windows), dotfile (~/.agent-ready/"
+            "credentials.env). No `get` subcommand — secrets do not "
+            "leave their resolving process."
+        ),
+    )
+    sub = creds.add_subparsers(
+        dest="creds_subcommand",
+        metavar="<subcommand>",
+        parser_class=_CredsSubcommandParser,
+    )
+    # ``invalid choice`` rewriting also needs to fire on the parent
+    # ``creds`` parser when the bad name is at *its* slot, not just
+    # the subparser's.
+    creds.__class__ = _CredsSubcommandParser
+
+    # ── setup ─────────────────────────────────────────────────────────
+    setup_p = sub.add_parser(
+        "setup",
+        help="Prompt for required keys and write to the highest-available tier.",
+    )
+    setup_p.add_argument(
+        "namespace",
+        nargs="?",
+        help=(
+            "The credential namespace (e.g. 'jira'). If omitted, the "
+            "CLI walks both scope state files for installed primitives "
+            "declaring credentialed: true and prompts for a selection."
+        ),
+    )
+    setup_p.add_argument(
+        "--allow-insecure-fallback",
+        action="store_true",
+        help=(
+            "On a Tier-2-capable platform (Darwin/Windows), write to "
+            "the Tier-3 dotfile instead of the OS keyring. No-op on "
+            "Linux (Tier 2 is deferred to a v2 RFC; Linux always lands "
+            "on Tier 3)."
+        ),
+    )
+    setup_p.add_argument(
+        "--allow-permissive-acl",
+        action="store_true",
+        help=(
+            "On Windows, accept a Tier-3 dotfile parent whose DACL "
+            "grants read access to non-default principals "
+            "(BUILTIN\\Users, Everyone, Authenticated Users). No-op on "
+            "POSIX."
+        ),
+    )
+    setup_p.add_argument(
+        "--root",
+        default=".",
+        help=(
+            "Repo-scope root for the state-file walk (default: '.'). "
+            "User-scope walks $HOME/.agent-ready/state.toml regardless."
+        ),
+    )
+    # Tombstone arguments — spec § AC23. Scoped to the ``setup``
+    # subparser only so other verbs (and other ``creds`` subcommands)
+    # keep their default argparse shapes.
+    for flag in (
+        "--token", "--api-token", "--api-key",
+        "--bearer", "--pat", "--password",
+    ):
+        setup_p.add_argument(flag, action=_RefuseTokenArgvAction)
+    setup_p.set_defaults(creds_func=run_setup)
+
+    # ── check ─────────────────────────────────────────────────────────
+    check_p = sub.add_parser(
+        "check",
+        help="Verify the namespace's required keys all resolve. Exit 0/2/3.",
+    )
+    check_p.add_argument("namespace")
+    check_p.add_argument("--root", default=".")
+    check_p.set_defaults(creds_func=run_check)
+
+    # ── where ─────────────────────────────────────────────────────────
+    where_p = sub.add_parser(
+        "where",
+        help="Print the resolving tier for each required key (no values).",
+    )
+    where_p.add_argument("namespace")
+    where_p.add_argument("--root", default=".")
+    where_p.set_defaults(creds_func=run_where)
+
+    # ── rm ────────────────────────────────────────────────────────────
+    rm_p = sub.add_parser(
+        "rm",
+        help="Delete the namespace's keys from every tier that holds them.",
+    )
+    rm_p.add_argument("namespace")
+    rm_p.add_argument("--root", default=".")
+    rm_p.set_defaults(creds_func=run_rm)
+
+    # The top-level CLI dispatches on ``args.func``; route every creds
+    # subcommand through ``run`` which then reads ``args.creds_func``.
+    creds.set_defaults(func=run)
+    return creds
+
+
+# ── Schema + state discovery ──────────────────────────────────────────
+
+
+_SKILL_MD_RE = re.compile(r"^\.claude/skills/([^/]+)/SKILL\.md$")
+_FRONTMATTER_RE = re.compile(r"^([a-zA-Z][a-zA-Z0-9_-]*):\s*(.*)$")
+
+
+def _parse_frontmatter(path: pathlib.Path) -> dict[str, str]:
+    """Minimal stdlib YAML-subset frontmatter parser for SKILL.md.
+
+    Matches the shape used by ``tools/lint-agent-artifacts.sh`` and
+    ``tools/lint-credentialed-skills.sh``: single-line scalars only,
+    no nested structures. Returns the empty mapping when the file has
+    no frontmatter — the caller treats that as "not credentialed".
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    fields: dict[str, str] = {}
+    for line in lines[1:]:
+        if line.strip() == "---":
+            break
+        m = _FRONTMATTER_RE.match(line)
+        if not m:
+            continue
+        key, value = m.group(1), m.group(2).strip()
+        # Drop surrounding quotes if balanced (allowed by YAML for the
+        # 1-line scalar shape).
+        if (
+            len(value) >= 2
+            and value[0] == value[-1]
+            and value[0] in ('"', "'")
+        ):
+            value = value[1:-1]
+        fields[key] = value
+    return fields
+
+
+def _walk_credentialed_skills(
+    root: pathlib.Path,
+) -> list[tuple[str, pathlib.Path, str, pathlib.Path]]:
+    """Walk both scope state files for installed credentialed primitives.
+
+    Returns a list of ``(scope_label, scope_root, skill_name,
+    skill_md_path)`` tuples. ``scope_label`` is ``"repo"`` or ``"user"``
+    so the CLI can show the user which scope a skill comes from.
+
+    Implements the AC17 dual-scope state walk. The walk uses the
+    existing ``PackState.files`` table (no state-schema bump): for each
+    ``(pack, relpath)`` whose relpath matches ``^\\.claude/skills/
+    [^/]+/SKILL\\.md$``, the CLI opens ``<scope-root>/<relpath>``,
+    reads its YAML frontmatter, and includes the skill iff
+    ``credentialed: true``.
+    """
+    from agentbundle import config
+
+    out: list[tuple[str, pathlib.Path, str, pathlib.Path]] = []
+    repo_state_path = root / ".agent-ready-state.toml"
+    if repo_state_path.exists():
+        repo_state = config.load_state(repo_state_path)
+        for pack_state in repo_state.packs.values():
+            for relpath in pack_state.files:
+                m = _SKILL_MD_RE.match(relpath)
+                if not m:
+                    continue
+                skill_md = root / relpath
+                fields = _parse_frontmatter(skill_md)
+                if fields.get("credentialed") == "true":
+                    out.append(("repo", root, m.group(1), skill_md))
+    try:
+        user_root = pathlib.Path.home()
+        user_state_path = user_root / ".agent-ready" / "state.toml"
+    except (RuntimeError, OSError):  # pragma: no cover
+        user_root = None  # type: ignore[assignment]
+        user_state_path = None  # type: ignore[assignment]
+    if user_state_path is not None and user_state_path.exists():
+        user_state = config.load_state(user_state_path)
+        for pack_state in user_state.packs.values():
+            for relpath in pack_state.files:
+                m = _SKILL_MD_RE.match(relpath)
+                if not m:
+                    continue
+                skill_md = user_root / relpath
+                fields = _parse_frontmatter(skill_md)
+                if fields.get("credentialed") == "true":
+                    out.append(("user", user_root, m.group(1), skill_md))
+    return out
+
+
+def _resolve_schema_for_namespace(
+    namespace: str, root: pathlib.Path
+) -> tuple["object", pathlib.Path]:
+    """Find the schema declaring ``namespace`` across both scope states.
+
+    Returns ``(schema, schema_path)``. Raises ``SchemaError`` if no
+    credentialed primitive declares the namespace, or if every
+    candidate skill's schema is malformed / missing.
+
+    Convention: a credentialed primitive's namespace is whatever its
+    schema's ``[namespace] name`` declares; the skill directory name
+    is not constrained to match (though by convention they often do).
+    The walk parses every credentialed skill's schema and matches by
+    ``schema.namespace``.
+
+    *Related primitive:* ``agentbundle.creds.loader.resolve_schema_path``
+    walks the same ``PackState.files`` table per AC24b but looks up by
+    *skill name*. This helper looks up by *namespace* — the user types
+    ``agentbundle creds <verb> <namespace>``, not the skill name — so
+    the two helpers are deliberate twins of the same lookup. Keep the
+    canonical-path convention (``<skill-dir>/references/creds-schema.toml``)
+    aligned across both.
+    """
+    from agentbundle.creds.exceptions import SchemaError
+    from agentbundle.creds.loader import _parse_schema
+
+    # Track the last parser failure so we can surface the actual root
+    # cause if every candidate skill's schema is malformed — without
+    # this, the operator sees the generic "no namespace declares..."
+    # message and the malformed-TOML diagnostic is lost.
+    last_parse_error: SchemaError | None = None
+    for scope_label, scope_root, skill_name, skill_md in _walk_credentialed_skills(root):
+        schema_path = skill_md.parent / "references" / "creds-schema.toml"
+        if not schema_path.is_file():
+            continue
+        try:
+            schema = _parse_schema(schema_path)
+        except SchemaError as exc:
+            last_parse_error = exc
+            continue
+        if schema.namespace == namespace:
+            return schema, schema_path
+    if last_parse_error is not None:
+        raise SchemaError(
+            f"no credentialed primitive declares namespace {namespace!r} "
+            f"in either scope state file; one or more schemas failed to "
+            f"parse: {last_parse_error}"
+        )
+    raise SchemaError(
+        f"no credentialed primitive declares namespace {namespace!r} "
+        f"in either scope state file"
+    )
+
+
+# ── Tier resolution helpers ───────────────────────────────────────────
+
+
+def _tier_for_key(namespace: str, key: str) -> str:
+    """Return the tier label where ``key`` is currently resolved, or
+    ``"missing"`` when no tier holds it.
+
+    Reads each tier in precedence order via the loader's internal
+    helpers so the answer matches what ``load_credentials`` would
+    return. The value is discarded — only the location matters.
+    """
+    from agentbundle.creds import loader
+
+    env_name = f"{namespace.upper()}_{key}"
+    env_val = os.environ.get(env_name)
+    if env_val:
+        return "env"
+    if loader._tier2_backend is not None:
+        try:
+            v = loader._tier2_backend.read_credential(namespace, key)
+        except Exception:
+            v = None
+        if v:
+            return "keyring"
+    v3 = loader._dotfile_read(namespace, key)
+    if v3:
+        return "dotfile"
+    return "missing"
+
+
+def _tier2_capable() -> bool:
+    """Whether the running platform has a Tier-2 backend wired in."""
+    from agentbundle.creds import loader
+
+    return loader._tier2_backend is not None
+
+
+def _tier2_label() -> str:
+    """Stderr-facing label naming which Tier-2 backend the platform uses."""
+    if sys.platform == "darwin":
+        return "macOS Keychain"
+    if sys.platform == "win32":
+        return "Windows Credential Manager"
+    return "none"
+
+
+# ── Subcommand: setup ─────────────────────────────────────────────────
+
+
+def _prompt_for_keys(schema, *, tty_ok: bool) -> dict[str, str]:
+    """Prompt for each key's value (``getpass`` for secrets; ``input``
+    for non-secrets). Returns the ``{key: value}`` mapping.
+
+    The ``tty_ok`` gate is enforced at the call site — this helper
+    assumes a tty has already been confirmed for secret keys.
+    """
+    values: dict[str, str] = {}
+    for keydef in schema.keys:
+        prompt = f"{keydef.label}: "
+        if keydef.secret:
+            value = getpass.getpass(prompt)
+        else:
+            value = input(prompt)
+        values[keydef.name] = value
+    return values
+
+
+def run_setup(args: argparse.Namespace) -> int:
+    """``creds setup`` — write the namespace's required keys to a tier."""
+    from agentbundle.creds.exceptions import (
+        PermissiveAclError,
+        SchemaError,
+        Tier2HardFailError,
+    )
+    from agentbundle.creds import loader
+
+    root = pathlib.Path(getattr(args, "root", ".")).resolve()
+    namespace: str | None = args.namespace
+
+    # AC17: no positional → walk state files, prompt for selection.
+    if not namespace:
+        candidates = _walk_credentialed_skills(root)
+        if not candidates:
+            sys.stderr.write(
+                "creds setup: no credentialed primitives installed in "
+                "either scope state file (run an install first)\n"
+            )
+            return 3
+        if not sys.stdin.isatty():
+            sys.stderr.write(
+                "creds setup: stdin is not a tty (selection requires "
+                "interactive prompt)\n"
+            )
+            return 3
+        sys.stderr.write("Installed credentialed primitives:\n")
+        for idx, (scope_label, _, skill_name, _) in enumerate(candidates, start=1):
+            sys.stderr.write(f"  [{idx}] {skill_name}  ({scope_label} scope)\n")
+        try:
+            choice_raw = input("Select primitive [number]: ").strip()
+            choice = int(choice_raw)
+        except (ValueError, EOFError):
+            sys.stderr.write("creds setup: invalid selection\n")
+            return 3
+        if not (1 <= choice <= len(candidates)):
+            sys.stderr.write("creds setup: selection out of range\n")
+            return 3
+        _, _, skill_name, skill_md = candidates[choice - 1]
+        schema_path = skill_md.parent / "references" / "creds-schema.toml"
+        try:
+            schema = loader._parse_schema(schema_path)
+        except SchemaError as exc:
+            sys.stderr.write(f"creds setup: {exc}\n")
+            return 3
+        namespace = schema.namespace
+    else:
+        try:
+            schema, _ = _resolve_schema_for_namespace(namespace, root)
+        except SchemaError as exc:
+            sys.stderr.write(f"creds setup: {exc}\n")
+            return 3
+
+    # Spec § AC23: ``setup`` reads the token only from a tty. Argparse
+    # has already rejected argv-borne flags; this guards the stdin pipe
+    # path.
+    if not sys.stdin.isatty():
+        sys.stderr.write("creds setup: stdin is not a tty\n")
+        return 3
+
+    values = _prompt_for_keys(schema, tty_ok=True)
+
+    insecure = bool(getattr(args, "allow_insecure_fallback", False))
+    permissive = bool(getattr(args, "allow_permissive_acl", False))
+
+    # Tier selection per AC16 + AC22:
+    # - Linux: always Tier 3 (Tier 2 deferred to v2 RFC); --allow-
+    #   insecure-fallback is a no-op.
+    # - Darwin/Windows + --allow-insecure-fallback: Tier 3.
+    # - Darwin/Windows default: Tier 2; hard-fail elevates to non-zero.
+    if not _tier2_capable():
+        return _write_dotfile_announce(
+            namespace, values, allow_permissive_acl=permissive,
+            stderr_tag="wrote to dotfile (Linux — Tier 2 deferred to v2 RFC)",
+        )
+
+    if insecure:
+        return _write_dotfile_announce(
+            namespace, values, allow_permissive_acl=permissive,
+            stderr_tag="wrote to dotfile (insecure fallback)",
+        )
+
+    # Default Tier-2 path on Darwin/Windows.
+    try:
+        for key, value in values.items():
+            loader._tier2_backend.write_credential(namespace, key, value)
+    except Tier2HardFailError as exc:
+        sys.stderr.write(
+            f"creds setup: Tier 2 hard fail — {exc}; pass "
+            "--allow-insecure-fallback to write to the dotfile instead\n"
+        )
+        return 3
+    except PermissiveAclError as exc:  # pragma: no cover — Windows-only
+        sys.stderr.write(f"creds setup: {exc}\n")
+        return 3
+    sys.stderr.write(f"wrote to keyring ({_tier2_label()})\n")
+    return 0
+
+
+def _write_dotfile_announce(
+    namespace: str,
+    values: dict[str, str],
+    *,
+    allow_permissive_acl: bool,
+    stderr_tag: str,
+) -> int:
+    """Write each ``(namespace, key) → value`` to the Tier-3 dotfile and
+    print ``stderr_tag``. Surfaces ``PermissiveAclError`` (Windows DACL)
+    as exit 3 with the spec's documented stderr text."""
+    from agentbundle.creds.exceptions import PermissiveAclError
+    from agentbundle.creds import loader
+
+    try:
+        for key, value in values.items():
+            loader._dotfile_write(
+                namespace, key, value,
+                allow_permissive_acl=allow_permissive_acl,
+            )
+    except PermissiveAclError as exc:
+        sys.stderr.write(
+            f"creds setup: DACL too permissive — {exc}; pass "
+            "--allow-permissive-acl to override\n"
+        )
+        return 3
+    if allow_permissive_acl and sys.platform == "win32":  # pragma: no cover
+        sys.stderr.write("permissive DACL accepted\n")
+    sys.stderr.write(f"{stderr_tag}\n")
+    return 0
+
+
+# ── Subcommand: check ─────────────────────────────────────────────────
+
+
+def run_check(args: argparse.Namespace) -> int:
+    """``creds check`` — verify required keys resolve. Exit 0/2/3."""
+    from agentbundle.creds.exceptions import (
+        SchemaError,
+        Tier2HardFailError,
+    )
+
+    root = pathlib.Path(getattr(args, "root", ".")).resolve()
+    namespace: str = args.namespace
+
+    try:
+        schema, _ = _resolve_schema_for_namespace(namespace, root)
+    except SchemaError as exc:
+        sys.stderr.write(f"creds check: {exc}\n")
+        return 3
+
+    missing: list[str] = []
+    try:
+        for keydef in schema.keys:
+            tier = _tier_for_key(namespace, keydef.name)
+            if tier == "missing":
+                missing.append(keydef.name)
+    except Tier2HardFailError as exc:
+        sys.stderr.write(f"creds check: Tier 2 hard fail — {exc}\n")
+        return 3
+    if missing:
+        sys.stderr.write(
+            f"creds check: namespace {namespace!r}: missing required "
+            f"key(s): {', '.join(missing)}\n"
+        )
+        return 2
+    return 0
+
+
+# ── Subcommand: where ─────────────────────────────────────────────────
+
+
+def run_where(args: argparse.Namespace) -> int:
+    """``creds where`` — print the resolving tier for each required key."""
+    from agentbundle.creds.exceptions import (
+        SchemaError,
+        Tier2HardFailError,
+    )
+
+    root = pathlib.Path(getattr(args, "root", ".")).resolve()
+    namespace: str = args.namespace
+
+    try:
+        schema, _ = _resolve_schema_for_namespace(namespace, root)
+    except SchemaError as exc:
+        sys.stderr.write(f"creds where: {exc}\n")
+        return 3
+
+    try:
+        for keydef in schema.keys:
+            tier = _tier_for_key(namespace, keydef.name)
+            print(f"{keydef.name}: {tier}")
+    except Tier2HardFailError as exc:
+        sys.stderr.write(f"creds where: Tier 2 hard fail — {exc}\n")
+        return 3
+    return 0
+
+
+# ── Subcommand: rm ────────────────────────────────────────────────────
+
+
+def run_rm(args: argparse.Namespace) -> int:
+    """``creds rm`` — delete the namespace's keys from every tier that
+    holds them. Env clears are a no-op the helper documents on stderr.
+    """
+    from agentbundle.creds.exceptions import (
+        SchemaError,
+        Tier2HardFailError,
+    )
+    from agentbundle.creds import loader
+
+    root = pathlib.Path(getattr(args, "root", ".")).resolve()
+    namespace: str = args.namespace
+
+    try:
+        schema, _ = _resolve_schema_for_namespace(namespace, root)
+    except SchemaError as exc:
+        sys.stderr.write(f"creds rm: {exc}\n")
+        return 3
+
+    any_removed = False
+    env_present_keys: list[str] = []
+    for keydef in schema.keys:
+        env_name = f"{namespace.upper()}_{keydef.name}"
+        if os.environ.get(env_name):
+            env_present_keys.append(env_name)
+        if loader._tier2_backend is not None:
+            try:
+                if loader._tier2_backend.read_credential(namespace, keydef.name):
+                    loader._tier2_backend.delete_credential(namespace, keydef.name)
+                    any_removed = True
+            except Tier2HardFailError as exc:
+                sys.stderr.write(f"creds rm: Tier 2 hard fail — {exc}\n")
+                return 3
+        if loader._dotfile_read(namespace, keydef.name):
+            loader._dotfile_delete(namespace, keydef.name)
+            any_removed = True
+
+    if env_present_keys:
+        sys.stderr.write(
+            "creds rm: env vars cannot be cleared by this helper; unset "
+            f"manually: {', '.join(env_present_keys)}\n"
+        )
+
+    if not any_removed and not env_present_keys:
+        sys.stderr.write(
+            f"creds rm: namespace {namespace!r}: no tier holds any of "
+            f"the schema's keys; nothing to remove\n"
+        )
+        return 3
+
+    return 0
+
+
+# ── CLI entry point (called by ``agentbundle.cli`` dispatcher) ────────
+
+
+def run(args: argparse.Namespace) -> int:
+    """Dispatch to the resolved subcommand. Required by the CLI."""
+    func = getattr(args, "creds_func", None)
+    if func is None:
+        sys.stderr.write(
+            "agentbundle creds: a subcommand is required "
+            "(setup | check | where | rm)\n"
+        )
+        return 3
+    return int(func(args))

--- a/packages/agentbundle/tests/integration/test_creds_cli.py
+++ b/packages/agentbundle/tests/integration/test_creds_cli.py
@@ -1,0 +1,730 @@
+"""T8: ``agentbundle creds`` CLI verb (skill-secrets spec § AC16-AC23).
+
+Covers the four subcommands (``setup``, ``check``, ``where``, ``rm``),
+the tombstone-argument refusal (AC23), the no-``get`` negative test
+(AC21), the per-platform tier-selection paths (AC16, AC22), the
+non-tty stdin refusal (AC23 POSIX path), and the dual-scope state walk
+for namespace enumeration (AC17).
+
+In-process calls via ``agentbundle.cli.main`` cover everything that
+doesn't need a real shell; the non-tty path uses ``subprocess`` so
+``sys.stdin.isatty()`` actually returns ``False`` (rather than being
+monkeypatched, which lets a buggy implementation pass).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+# Sentinel anchor — AC23 documents this exact byte sequence and the
+# test grep enforces it verbatim. Keep in sync with ``creds.py``'s
+# ``_ARGV_REFUSAL_STDERR``.
+ARGV_REFUSAL_SENTINEL = "tokens cannot be passed via argv"
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def isolated_home(tmp_path, monkeypatch):
+    """Redirect HOME / USERPROFILE so the dotfile and user-scope state
+    walk land in ``tmp_path``; reset Tier-2 backend so each test owns
+    its platform shape via monkeypatch (no leakage from earlier tests).
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    for var in list(os.environ):
+        if var.startswith("FIXTURE_T8_"):
+            monkeypatch.delenv(var, raising=False)
+    from agentbundle.creds import loader
+    monkeypatch.setattr(loader, "_tier2_backend", None)
+    return tmp_path
+
+
+def _write_skill_fixture(
+    root: Path,
+    skill_name: str,
+    namespace: str,
+    *,
+    secret_keys: tuple[str, ...] = ("API_TOKEN",),
+    nonsecret_keys: tuple[str, ...] = (),
+) -> Path:
+    """Materialise a credentialed-skill fixture under ``root``.
+
+    Writes:
+      - ``<root>/.claude/skills/<skill_name>/SKILL.md`` with
+        ``credentialed: true`` frontmatter.
+      - ``<root>/.claude/skills/<skill_name>/references/creds-schema.toml``
+        declaring the requested keys.
+
+    Returns the SKILL.md path.
+    """
+    skill_dir = root / ".claude" / "skills" / skill_name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "references").mkdir(exist_ok=True)
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(
+        textwrap.dedent(f"""\
+            ---
+            name: {skill_name}
+            description: fixture credentialed skill for T8 testing
+            credentialed: true
+            primitive-class: credentialed-cli
+            ---
+
+            # Skill: {skill_name}
+            """),
+        encoding="utf-8",
+    )
+    schema_path = skill_dir / "references" / "creds-schema.toml"
+    parts = [f'[namespace]\nname = "{namespace}"\n']
+    for k in secret_keys:
+        parts.append(
+            f'\n[[namespace.keys]]\nname = "{k}"\nlabel = "{k}"\nsecret = true\n'
+        )
+    for k in nonsecret_keys:
+        parts.append(
+            f'\n[[namespace.keys]]\nname = "{k}"\nlabel = "{k}"\nsecret = false\n'
+        )
+    schema_path.write_text("".join(parts), encoding="utf-8")
+    return skill_md
+
+
+def _write_state_file(
+    root: Path,
+    pack: str,
+    skill_relpaths: tuple[str, ...],
+    *,
+    user_scope: bool = False,
+) -> Path:
+    """Write a v0.3 ``.agent-ready-state.toml`` listing the given skills
+    under ``[pack.<pack>.files]``.
+
+    ``user_scope`` toggles the file location: ``<root>/.agent-ready-state.toml``
+    (repo) or ``<root>/.agent-ready/state.toml`` (user, mirroring
+    ``$HOME/.agent-ready/state.toml`` semantics).
+    """
+    if user_scope:
+        path = root / ".agent-ready" / "state.toml"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        scope_label = "user"
+    else:
+        path = root / ".agent-ready-state.toml"
+        scope_label = "repo"
+    lines = ['schema-version = "0.3"', "", f"[pack.{pack}]"]
+    lines.append('installed-version = "0.0.1"')
+    lines.append(f'scope = "{scope_label}"')
+    for relpath in skill_relpaths:
+        lines.append(f'\n[pack.{pack}.files."{relpath}"]')
+        lines.append('sha = "deadbeefdeadbeef"')
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def _install_fake_tier2(monkeypatch):
+    """Install an in-memory Tier-2 backend so AC16/AC22 paths can be
+    exercised without a real OS keyring. Returns the dict used by the
+    fake backend so tests can inspect what was written.
+    """
+    from agentbundle.creds import loader
+
+    store: dict[tuple[str, str], str] = {}
+
+    class _Fake:
+        @staticmethod
+        def read_credential(namespace, key):
+            return store.get((namespace, key))
+
+        @staticmethod
+        def write_credential(namespace, key, value):
+            store[(namespace, key)] = value
+
+        @staticmethod
+        def delete_credential(namespace, key):
+            store.pop((namespace, key), None)
+
+    monkeypatch.setattr(loader, "_tier2_backend", _Fake)
+    # Also patch ``sys.platform`` so the stderr label says "macOS
+    # Keychain" or "Windows Credential Manager" (platform-discriminated
+    # in ``_tier2_label``). On a real Darwin host the label already
+    # matches; on Linux CI we need the override.
+    if sys.platform not in ("darwin", "win32"):
+        monkeypatch.setattr(sys, "platform", "darwin")
+    return store
+
+
+def _set_inputs(monkeypatch, *, secret_values: dict[str, str] | None = None,
+                input_values: list[str] | None = None,
+                isatty: bool = True):
+    """Plumb fake answers into ``getpass.getpass``, ``input``, and
+    ``sys.stdin.isatty`` for the in-process CLI calls.
+
+    ``secret_values`` maps the *prompt label suffix* to the secret value
+    so multiple keys can be answered in order; falling back to a single
+    deterministic value when not specified.
+    """
+    from agentbundle.commands import creds as creds_mod
+
+    def fake_getpass(prompt):
+        if secret_values is None:
+            return "secret-value"
+        # Match by the trailing ``": "`` separator on the prompt.
+        key = prompt.rstrip(": ").strip()
+        return secret_values.get(key, "secret-value")
+
+    input_iter = iter(input_values or [])
+
+    def fake_input(prompt=""):
+        try:
+            return next(input_iter)
+        except StopIteration:
+            return ""
+
+    monkeypatch.setattr(creds_mod.getpass, "getpass", fake_getpass)
+    monkeypatch.setattr("builtins.input", fake_input)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: isatty)
+
+
+def _run(argv):
+    """Invoke the CLI in-process and return its exit code."""
+    from agentbundle.cli import main
+    return main(argv)
+
+
+# ── AC21: no ``get`` subcommand ───────────────────────────────────────
+
+
+def test_get_subcommand_returns_unknown_command(capsys):
+    """AC21: ``agentbundle creds get foo`` exits non-zero with the
+    documented stderr text ``unknown command: get``."""
+    with pytest.raises(SystemExit) as exc:
+        _run(["creds", "get", "foo"])
+    assert exc.value.code != 0
+    out = capsys.readouterr()
+    assert "unknown command: get" in out.err
+
+
+def test_creds_with_no_subcommand_exits_three(capsys):
+    """``agentbundle creds`` (no subcommand) exits 3 with stderr naming
+    the available subcommands. Not a spec AC anchor — defensive against
+    a silent no-op (the dispatcher would otherwise reach
+    ``creds.run`` with ``creds_func=None`` and return 3).
+    """
+    rc = _run(["creds"])
+    assert rc == 3
+    out = capsys.readouterr()
+    assert "subcommand is required" in out.err
+    for verb in ("setup", "check", "where", "rm"):
+        assert verb in out.err
+
+
+# ── AC23: tombstone argv arguments ────────────────────────────────────
+
+
+@pytest.mark.parametrize("flag", [
+    "--token", "--api-token", "--api-key",
+    "--bearer", "--pat", "--password",
+])
+def test_setup_refuses_argv_borne_token(flag, capsys):
+    """AC23: every named tombstone flag emits the canonical stderr
+    sentinel and exits non-zero."""
+    with pytest.raises(SystemExit) as exc:
+        _run(["creds", "setup", flag, "leaked-token", "ns"])
+    assert exc.value.code != 0
+    out = capsys.readouterr()
+    assert ARGV_REFUSAL_SENTINEL in out.err
+
+
+@pytest.mark.parametrize("flag", [
+    "--token", "--api-token", "--api-key",
+    "--bearer", "--pat", "--password",
+])
+def test_setup_refuses_bare_tombstone_flag_with_no_value(flag, capsys):
+    """AC23 corner case: the tombstone action uses ``nargs="?"`` so the
+    flag fires whether a value follows it or not. Bare ``--token``
+    (with no following value) must still produce the canonical
+    sentinel — a future change to ``nargs`` could silently regress this.
+    """
+    with pytest.raises(SystemExit) as exc:
+        _run(["creds", "setup", flag])
+    assert exc.value.code != 0
+    out = capsys.readouterr()
+    assert ARGV_REFUSAL_SENTINEL in out.err
+
+
+def test_setup_refuses_equals_form_tombstone_flag(capsys):
+    """AC23: ``--token=leaked`` (equals-sign form, single argv token)
+    also fires the action — argparse routes single-token ``--flag=val``
+    through the same action as multi-token ``--flag val``.
+    """
+    with pytest.raises(SystemExit) as exc:
+        _run(["creds", "setup", "--token=leaked", "ns"])
+    assert exc.value.code != 0
+    out = capsys.readouterr()
+    assert ARGV_REFUSAL_SENTINEL in out.err
+
+
+def test_argv_refusal_does_not_leak_to_other_creds_verbs(capsys):
+    """AC23: tombstone scope is the ``setup`` subparser only.
+
+    ``creds check --token foo bar`` falls through to argparse's default
+    ``unrecognized arguments`` shape — the verbatim sentinel is *not*
+    emitted because the flag wasn't registered on ``check``.
+    """
+    with pytest.raises(SystemExit):
+        _run(["creds", "check", "--token", "foo", "ns"])
+    out = capsys.readouterr()
+    assert ARGV_REFUSAL_SENTINEL not in out.err
+
+
+def test_argv_refusal_does_not_pollute_other_verbs(capsys):
+    """AC23: tombstone scope is the ``creds setup`` subparser only. Other
+    top-level verbs keep their argparse-default behaviour.
+
+    ``install --pack core --token foo <catalogue>`` lets argparse parse
+    past the required flags and reach the ``--token`` token; we then
+    assert the canonical sentinel does **not** appear in stderr. (A
+    bare ``install --token foo .`` would error on missing ``--pack``
+    before the tombstone path could even be considered, which would
+    make this test pass without exercising the contract — hence the
+    fully-formed argv.)
+    """
+    with pytest.raises(SystemExit):
+        _run([
+            "install", "--pack", "core", "--token", "foo",
+            "/nonexistent-catalogue-fixture",
+        ])
+    out = capsys.readouterr()
+    assert ARGV_REFUSAL_SENTINEL not in out.err
+
+
+# ── AC17: dual-scope state walk for namespace enumeration ─────────────
+
+
+def test_setup_no_arg_walks_state_files(tmp_path, monkeypatch, capsys):
+    """AC17: ``creds setup`` (no positional) walks both scope state
+    files, lists each credentialed primitive with its scope, and prompts
+    via ``input()`` for a selection.
+    """
+    # Repo-scope fixture: skill ``alpha`` declaring namespace ``alpha``.
+    _write_skill_fixture(tmp_path, "alpha", "alpha")
+    _write_state_file(tmp_path, "core", (".claude/skills/alpha/SKILL.md",))
+    # User-scope fixture (via HOME redirection in the autouse fixture):
+    # ``$HOME/.claude/skills/beta/SKILL.md`` listed in
+    # ``$HOME/.agent-ready/state.toml``.
+    _write_skill_fixture(tmp_path, "beta", "beta")
+    _write_state_file(
+        tmp_path, "user-pack", (".claude/skills/beta/SKILL.md",),
+        user_scope=True,
+    )
+    _install_fake_tier2(monkeypatch)
+    _set_inputs(monkeypatch, input_values=["1"], isatty=True)
+
+    rc = _run(["creds", "setup", "--root", str(tmp_path)])
+    assert rc == 0
+    out = capsys.readouterr()
+    # The listing shows each skill with its scope label.
+    assert "alpha" in out.err
+    assert "beta" in out.err
+    assert "repo" in out.err
+    assert "user" in out.err
+
+
+def test_setup_no_arg_empty_state_exits_3(tmp_path, monkeypatch, capsys):
+    """AC17 boundary: no credentialed primitives installed at either
+    scope → exit 3 with stderr naming the situation."""
+    _set_inputs(monkeypatch, isatty=True)
+    rc = _run(["creds", "setup", "--root", str(tmp_path)])
+    assert rc == 3
+    out = capsys.readouterr()
+    assert "no credentialed primitives" in out.err
+
+
+# ── AC16: setup writes to the right tier per platform ────────────────
+
+
+def test_setup_writes_to_tier2_on_capable_platform(tmp_path, monkeypatch, capsys):
+    """AC16: on Darwin/Windows (Tier-2-capable), ``setup <namespace>``
+    writes to the keyring and stderr matches ``wrote to keyring``."""
+    _write_skill_fixture(tmp_path, "alpha", "alpha")
+    _write_state_file(tmp_path, "core", (".claude/skills/alpha/SKILL.md",))
+    store = _install_fake_tier2(monkeypatch)
+    _set_inputs(
+        monkeypatch,
+        secret_values={"API_TOKEN": "kr-secret"},
+        isatty=True,
+    )
+    rc = _run(["creds", "setup", "alpha", "--root", str(tmp_path)])
+    assert rc == 0
+    assert store[("alpha", "API_TOKEN")] == "kr-secret"
+    out = capsys.readouterr()
+    assert "wrote to keyring" in out.err
+
+
+def test_setup_writes_to_tier3_on_linux(tmp_path, monkeypatch, capsys):
+    """AC16: on Linux (Tier 2 unavailable) the helper writes to the
+    Tier-3 dotfile and stderr matches
+    ``wrote to dotfile (Linux — Tier 2 deferred to v2 RFC)``.
+    """
+    _write_skill_fixture(tmp_path, "alpha", "alpha")
+    _write_state_file(tmp_path, "core", (".claude/skills/alpha/SKILL.md",))
+    # No fake Tier 2 — _tier2_backend stays None per the autouse fixture.
+    monkeypatch.setattr(sys, "platform", "linux")
+    _set_inputs(
+        monkeypatch,
+        secret_values={"API_TOKEN": "dot-secret"},
+        isatty=True,
+    )
+    rc = _run(["creds", "setup", "alpha", "--root", str(tmp_path)])
+    assert rc == 0
+    out = capsys.readouterr()
+    assert "wrote to dotfile" in out.err
+    assert "Linux" in out.err
+    # The dotfile carries the namespaced key.
+    dotfile = tmp_path / ".agent-ready" / "credentials.env"
+    assert "ALPHA_API_TOKEN=dot-secret" in dotfile.read_text()
+
+
+def test_setup_insecure_fallback_on_capable_platform(
+    tmp_path, monkeypatch, capsys
+):
+    """AC22: ``--allow-insecure-fallback`` on a Tier-2-capable platform
+    writes to Tier 3 and stderr matches
+    ``wrote to dotfile (insecure fallback)``.
+    """
+    _write_skill_fixture(tmp_path, "alpha", "alpha")
+    _write_state_file(tmp_path, "core", (".claude/skills/alpha/SKILL.md",))
+    store = _install_fake_tier2(monkeypatch)
+    _set_inputs(
+        monkeypatch,
+        secret_values={"API_TOKEN": "fb-secret"},
+        isatty=True,
+    )
+    rc = _run([
+        "creds", "setup", "alpha",
+        "--allow-insecure-fallback",
+        "--root", str(tmp_path),
+    ])
+    assert rc == 0
+    out = capsys.readouterr()
+    assert "wrote to dotfile" in out.err
+    assert "insecure fallback" in out.err
+    # The Tier-2 store was *not* written.
+    assert ("alpha", "API_TOKEN") not in store
+
+
+def test_setup_allow_permissive_acl_refuses_without_flag(
+    tmp_path, monkeypatch, capsys
+):
+    """AC15 + AC22: a Tier-3 write whose Windows DACL parse raises
+    ``PermissiveAclError`` exits 3 with stderr matching ``DACL too
+    permissive`` when ``--allow-permissive-acl`` was not passed.
+
+    Simulated via a monkeypatched ``_dotfile_write`` that raises on the
+    no-flag path so the test runs on any host (Windows-only icacls is
+    unreachable from Darwin CI).
+    """
+    from agentbundle.creds import loader
+    from agentbundle.creds.exceptions import PermissiveAclError
+
+    _write_skill_fixture(tmp_path, "alpha", "alpha")
+    _write_state_file(tmp_path, "core", (".claude/skills/alpha/SKILL.md",))
+    monkeypatch.setattr(sys, "platform", "linux")  # force Tier-3 path
+
+    def fake_write(namespace, key, value, *, allow_permissive_acl=False):
+        if not allow_permissive_acl:
+            raise PermissiveAclError(
+                f"DACL on {tmp_path} grants BUILTIN\\Users:R"
+            )
+
+    monkeypatch.setattr(loader, "_dotfile_write", fake_write)
+    _set_inputs(
+        monkeypatch,
+        secret_values={"API_TOKEN": "x"},
+        isatty=True,
+    )
+    rc = _run(["creds", "setup", "alpha", "--root", str(tmp_path)])
+    assert rc == 3
+    out = capsys.readouterr()
+    assert "DACL too permissive" in out.err
+
+
+def test_setup_allow_permissive_acl_accepts_with_flag(
+    tmp_path, monkeypatch, capsys
+):
+    """AC15 + AC22: ``--allow-permissive-acl`` passes
+    ``allow_permissive_acl=True`` through to ``_dotfile_write`` so the
+    write succeeds even against a permissive DACL fixture; exit 0.
+    """
+    from agentbundle.creds import loader
+
+    _write_skill_fixture(tmp_path, "alpha", "alpha")
+    _write_state_file(tmp_path, "core", (".claude/skills/alpha/SKILL.md",))
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    captured_kwargs: list[bool] = []
+
+    def fake_write(namespace, key, value, *, allow_permissive_acl=False):
+        captured_kwargs.append(allow_permissive_acl)
+
+    monkeypatch.setattr(loader, "_dotfile_write", fake_write)
+    _set_inputs(
+        monkeypatch,
+        secret_values={"API_TOKEN": "x"},
+        isatty=True,
+    )
+    rc = _run([
+        "creds", "setup", "alpha",
+        "--allow-permissive-acl",
+        "--root", str(tmp_path),
+    ])
+    assert rc == 0
+    assert captured_kwargs == [True]
+
+
+def test_setup_secret_and_nonsecret_keys_round_trip(tmp_path, monkeypatch):
+    """AC24 + AC16: ``secret = true`` keys go through ``getpass``;
+    ``secret = false`` keys go through ``input``. End-to-end via the
+    Linux Tier-3 path so both values land in the dotfile."""
+    _write_skill_fixture(
+        tmp_path, "alpha", "alpha",
+        secret_keys=("API_TOKEN",), nonsecret_keys=("BASE_URL",),
+    )
+    _write_state_file(tmp_path, "core", (".claude/skills/alpha/SKILL.md",))
+    monkeypatch.setattr(sys, "platform", "linux")
+    _set_inputs(
+        monkeypatch,
+        secret_values={"API_TOKEN": "kr-tok"},
+        input_values=["https://alpha.test"],
+        isatty=True,
+    )
+    rc = _run(["creds", "setup", "alpha", "--root", str(tmp_path)])
+    assert rc == 0
+    dotfile_text = (tmp_path / ".agent-ready" / "credentials.env").read_text()
+    assert "ALPHA_API_TOKEN=kr-tok" in dotfile_text
+    assert "ALPHA_BASE_URL=" in dotfile_text
+
+
+# ── AC18: check exit codes ────────────────────────────────────────────
+
+
+def test_check_exits_zero_when_all_keys_resolve(tmp_path, monkeypatch):
+    """AC18: every required key resolved at some tier → exit 0."""
+    _write_skill_fixture(tmp_path, "alpha", "alpha")
+    _write_state_file(tmp_path, "core", (".claude/skills/alpha/SKILL.md",))
+    monkeypatch.setenv("ALPHA_API_TOKEN", "from-env")
+    rc = _run(["creds", "check", "alpha", "--root", str(tmp_path)])
+    assert rc == 0
+
+
+def test_check_exits_two_when_required_key_missing(tmp_path, capsys):
+    """AC18: any missing key → exit 2, stderr names the missing keys."""
+    _write_skill_fixture(tmp_path, "alpha", "alpha")
+    _write_state_file(tmp_path, "core", (".claude/skills/alpha/SKILL.md",))
+    rc = _run(["creds", "check", "alpha", "--root", str(tmp_path)])
+    assert rc == 2
+    out = capsys.readouterr()
+    assert "API_TOKEN" in out.err
+    assert "missing" in out.err
+
+
+def test_check_exits_three_on_unknown_namespace(tmp_path, capsys):
+    """AC18: an unknown namespace (no skill declares it) is an "other"
+    error → exit 3."""
+    rc = _run(["creds", "check", "absent", "--root", str(tmp_path)])
+    assert rc == 3
+    out = capsys.readouterr()
+    assert "absent" in out.err
+
+
+def test_check_exits_three_on_malformed_schema(tmp_path, capsys):
+    """AC18: a malformed schema is the spec's "other error" bucket
+    (schema parse error → exit 3). The stderr surfaces the underlying
+    parser error (``malformed``) rather than swallowing it inside the
+    generic "no namespace declares..." message — operators need the
+    root cause."""
+    _write_skill_fixture(tmp_path, "alpha", "alpha")
+    _write_state_file(tmp_path, "core", (".claude/skills/alpha/SKILL.md",))
+    # Stomp the schema with malformed TOML.
+    (tmp_path / ".claude" / "skills" / "alpha" / "references"
+     / "creds-schema.toml").write_text("this = is not [[ valid", encoding="utf-8")
+    rc = _run(["creds", "check", "alpha", "--root", str(tmp_path)])
+    assert rc == 3
+    out = capsys.readouterr()
+    assert "malformed" in out.err
+
+
+# ── AC19: where prints per-key tier (no values) ───────────────────────
+
+
+def test_where_prints_tier_per_key_no_values(tmp_path, monkeypatch, capsys):
+    """AC19: ``where`` prints ``<KEY>: <tier>`` per required key.
+
+    Across three keys we hit env, dotfile, and missing — confirming
+    every label in the matrix at least once and that no value is leaked.
+    """
+    _write_skill_fixture(
+        tmp_path, "alpha", "alpha",
+        secret_keys=("API_TOKEN", "OTHER_SECRET", "ABSENT_KEY"),
+    )
+    _write_state_file(tmp_path, "core", (".claude/skills/alpha/SKILL.md",))
+    monkeypatch.setenv("ALPHA_API_TOKEN", "secret-env-value")
+    # Stash OTHER_SECRET in the dotfile.
+    from agentbundle.creds import loader
+    loader._dotfile_write("alpha", "OTHER_SECRET", "dotfile-value")
+    rc = _run(["creds", "where", "alpha", "--root", str(tmp_path)])
+    assert rc == 0
+    out = capsys.readouterr()
+    assert "API_TOKEN: env" in out.out
+    assert "OTHER_SECRET: dotfile" in out.out
+    assert "ABSENT_KEY: missing" in out.out
+    # No value bytes leak — only tier labels.
+    assert "secret-env-value" not in out.out
+    assert "dotfile-value" not in out.out
+
+
+# ── AC20: rm clears every tier holding the key ────────────────────────
+
+
+def test_rm_removes_keys_from_keyring_and_dotfile(tmp_path, monkeypatch):
+    """AC20: ``rm <namespace>`` deletes every key from every tier that
+    holds it.
+
+    Set up: API_TOKEN in keyring, BASE_URL in dotfile. After ``rm``,
+    neither holds anything.
+    """
+    _write_skill_fixture(
+        tmp_path, "alpha", "alpha",
+        secret_keys=("API_TOKEN",), nonsecret_keys=("BASE_URL",),
+    )
+    _write_state_file(tmp_path, "core", (".claude/skills/alpha/SKILL.md",))
+    store = _install_fake_tier2(monkeypatch)
+    store[("alpha", "API_TOKEN")] = "kr"
+    from agentbundle.creds import loader
+    loader._dotfile_write("alpha", "BASE_URL", "https://alpha.test")
+    rc = _run(["creds", "rm", "alpha", "--root", str(tmp_path)])
+    assert rc == 0
+    assert ("alpha", "API_TOKEN") not in store
+    assert loader._dotfile_read("alpha", "BASE_URL") is None
+
+
+def test_rm_refuses_when_nothing_to_remove(tmp_path, capsys, monkeypatch):
+    """AC20: helper refuses (stderr + non-zero) when no tier holds any
+    of the namespace's keys."""
+    _write_skill_fixture(tmp_path, "alpha", "alpha")
+    _write_state_file(tmp_path, "core", (".claude/skills/alpha/SKILL.md",))
+    rc = _run(["creds", "rm", "alpha", "--root", str(tmp_path)])
+    assert rc == 3
+    out = capsys.readouterr()
+    assert "nothing to remove" in out.err
+
+
+def test_rm_notes_env_var_present_but_unremovable(tmp_path, monkeypatch, capsys):
+    """AC20: env clears are documented on stderr ("the helper cannot
+    unset another process's environ"). Env DOES count as "a tier that
+    holds the key" — the helper does **not** refuse (spec § AC20:
+    "refuses ... if no tier holds any of the namespace's keys"); it
+    documents the env situation and exits 0.
+    """
+    _write_skill_fixture(tmp_path, "alpha", "alpha")
+    _write_state_file(tmp_path, "core", (".claude/skills/alpha/SKILL.md",))
+    monkeypatch.setenv("ALPHA_API_TOKEN", "env-only")
+    rc = _run(["creds", "rm", "alpha", "--root", str(tmp_path)])
+    out = capsys.readouterr()
+    assert "ALPHA_API_TOKEN" in out.err
+    assert "unset manually" in out.err
+    assert rc == 0
+
+
+# ── AC23: setup refuses non-tty stdin (POSIX path) ────────────────────
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX tty-isatty path")
+def test_setup_refuses_non_tty_stdin_via_subprocess(tmp_path):
+    """AC23 POSIX path: real ``stdin=subprocess.DEVNULL`` (so
+    ``sys.stdin.isatty()`` actually returns ``False`` for the child),
+    helper exits non-zero with the stderr text ``stdin is not a tty``.
+    """
+    _write_skill_fixture(tmp_path, "alpha", "alpha")
+    _write_state_file(tmp_path, "core", (".claude/skills/alpha/SKILL.md",))
+    repo_root = Path(__file__).resolve().parents[3]
+    pkg_root = repo_root / "packages" / "agentbundle"
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+    env["PYTHONPATH"] = str(pkg_root) + os.pathsep + env.get("PYTHONPATH", "")
+    res = subprocess.run(
+        [
+            sys.executable, "-m", "agentbundle", "creds", "setup",
+            "alpha", "--root", str(tmp_path),
+        ],
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert res.returncode != 0
+    assert "stdin is not a tty" in res.stderr
+
+
+# ── AC22: setup hard-fails when Tier-2 errors without opt-out ─────────
+
+
+def test_setup_tier2_hard_fail_without_opt_out_exits_three(
+    tmp_path, monkeypatch, capsys
+):
+    """AC22: a Tier-2 hard fail without ``--allow-insecure-fallback``
+    exits 3 with stderr naming the cause."""
+    from agentbundle.creds import loader
+    from agentbundle.creds.exceptions import Tier2HardFailError
+
+    _write_skill_fixture(tmp_path, "alpha", "alpha")
+    _write_state_file(tmp_path, "core", (".claude/skills/alpha/SKILL.md",))
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    class _HardFail:
+        @staticmethod
+        def read_credential(*a, **kw):
+            return None
+
+        @staticmethod
+        def write_credential(namespace, key, value):
+            raise Tier2HardFailError("keychain locked")
+
+        @staticmethod
+        def delete_credential(*a, **kw):
+            return None
+
+    monkeypatch.setattr(loader, "_tier2_backend", _HardFail)
+    _set_inputs(
+        monkeypatch,
+        secret_values={"API_TOKEN": "x"},
+        isatty=True,
+    )
+    rc = _run(["creds", "setup", "alpha", "--root", str(tmp_path)])
+    assert rc == 3
+    out = capsys.readouterr()
+    assert "Tier 2 hard fail" in out.err
+    assert "--allow-insecure-fallback" in out.err
+
+
+# ── Schema resolution diagnostics ─────────────────────────────────────
+
+
+def test_namespace_resolves_via_user_scope_state(tmp_path, monkeypatch):
+    """AC17 corollary: a credentialed primitive installed at user scope
+    (not repo) still resolves for ``check`` / ``where`` / ``rm``."""
+    _write_skill_fixture(tmp_path, "beta", "beta")
+    _write_state_file(
+        tmp_path, "user-pack", (".claude/skills/beta/SKILL.md",),
+        user_scope=True,
+    )
+    monkeypatch.setenv("BETA_API_TOKEN", "user-scope-env")
+    rc = _run(["creds", "check", "beta", "--root", str(tmp_path)])
+    assert rc == 0


### PR DESCRIPTION
## Summary

- Ships four subcommands (`setup`, `check`, `where`, `rm`) under `packages/agentbundle/agentbundle/commands/creds.py`, wired into the top-level argparse dispatcher.
- Tombstone-argument action refuses every documented argv-borne credential flag with the verbatim AC23 sentinel; `creds get` is rewritten to `unknown command: get`.
- Dual-scope state walk for `setup` (no positional namespace) reuses the existing `PackState.files` table — no state-schema bump.

## ACs closed

AC16, AC17, AC18, AC19, AC20, AC21, AC22, AC23 — see `docs/specs/skill-secrets/spec.md`.

## Test plan

- [x] `pytest packages/agentbundle/tests/integration/test_creds_cli.py` — 36 tests cover every documented exit code, verbatim stderr anchors, platform-discriminated tier selection, real-stdin tty refusal via subprocess.
- [x] `pytest packages/agentbundle/tests/` — 722 passed, 10 skipped.
- [x] `tools/lint-agents-md.sh` — clean.
- [x] `tools/lint-agent-artifacts.sh` — clean.
- [x] `make build-check` — clean (the `[info] unclassified: docs/ROADMAP.md` is expected per the spec note).
- [x] Adversarial review (two rounds) — Clean.