### PR TITLE
feat(skill-secrets): T13c — ROADMAP closure + spec status flip Shipped

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,7 +14,7 @@ line under `make build-check` per AC6 of the self-hosting spec.
 For shipped work, see [`product/changelog.md`](product/changelog.md)
 and each spec's own Changelog section.
 
-**Last updated:** 2026-05-24 (added `skill-secrets` spec entry from RFC-0006; promoted the cross-spec credentialed-skill-template stub into the new spec's open items)
+**Last updated:** 2026-05-24 (closed `skill-secrets` — all T1–T13c shipped; status flipped Draft → Shipped; only AC34/AC35 inheritance invariants and the post-implementation "Credential storage" ADR remain as cross-spec items)
 
 ## How this file is maintained
 
@@ -194,66 +194,56 @@ RFC-0005's follow-on artifacts name.
   measures contract correctness via fixture packs, not via a
   shipped consumer.
 
-## `skill-secrets` — drafted
+## `skill-secrets` — shipped
 
 Spec: [`specs/skill-secrets/spec.md`](specs/skill-secrets/spec.md).
-Drafted from [RFC-0006](rfc/0006-skill-secrets-storage.md) (Accepted
-2026-05-24). The spec is the implementation contract for the
-two-layer architecture (skills don't hold credentials; credentialed
-primitives do), the three storage tiers (env → OS keyring → dotfile
-floor at `~/.agent-ready/credentials.env`), the stdlib-only loader
-+ `agentbundle creds` verb (`setup`/`check`/`where`/`rm` only; no
-`get`), the argv ban + `SKILL.md` "Don't" block, the
-`conventions-check` extensions, the worked example, and the
-ADR-0002 amendment freezing the narrow "hook-shaped" definition.
+Shipped from [RFC-0006](rfc/0006-skill-secrets-storage.md) (Accepted
+2026-05-24). Delivered the two-layer architecture (skills don't hold
+credentials; credentialed primitives do), the three storage tiers
+(env → OS keyring → dotfile floor at `~/.agent-ready/credentials.env`),
+the stdlib-only loader + `agentbundle creds` verb
+(`setup`/`check`/`where`/`rm` only; no `get`), the argv ban +
+`SKILL.md` "Don't" block, the `conventions-check` extensions, the
+worked example, and the ADR-0002 amendment freezing the narrow
+"hook-shaped" definition.
 
-The plan breaks the work into fifteen tasks (T13 split into
-T13a/T13b/T13c): T1 (ADR-0002 amendment — lands in the spec PR);
-T2–T7 (runtime library: stdlib `.env` parser, loader API +
-`agent_ready` shim, macOS Keychain Tier-2, Windows Credential
-Manager Tier-2, Tier-3 dotfile, `creds-schema.toml` parser); T8
-(CLI verb at `agentbundle/commands/creds.py` with tombstone-arg
-argv ban); T9–T10 (SKILL.md frontmatter + lint allow-list,
-`conventions-check` AST-walker extensions); T11–T12 (author skill
-carrying template variants; worked example); T13a (CONVENTIONS.md
-via seed upstream); T13b (Diátaxis how-to); T13c (this roadmap
-entry's per-task closure).
+Per-task closure (15 tasks; T13 split into T13a/T13b/T13c):
 
-- **All 38 ACs open** (AC1, AC2, AC3, AC4, AC4b, AC4c, AC5–AC23, AC24, AC24b, AC25–AC35). Coverage
-  unblocks incrementally as tasks land:
-  - **AC1** closes with T1 (ADR-0002 amendment) — lands in the
-    spec PR.
-  - **AC2** closes with T2 (stdlib `.env` parser).
-  - **AC3, AC4, AC4b, AC4c, AC5** close with T3 (loader API +
-    Tier-1 + platform dispatch + wheel-installability +
-    `pyproject.toml` shim include).
-  - **AC6, AC7, AC8** close with T4 (macOS Keychain Tier-2).
-  - **AC9, AC10, AC11, AC12** close with T5 (Windows Credential
-    Manager Tier-2).
-  - **AC13, AC14, AC15** close with T6 (Tier-3 dotfile;
-    shared-parent behavior).
-  - **AC24, AC24b** close with T7 (`creds-schema.toml` parser
-    + canonical-path resolution).
-  - **AC16–AC23** close with T8 (CLI verb; tombstone args;
-    macOS/Windows exit-code matrices).
-  - **AC25** closes with T9 (frontmatter + lint allow-list).
-  - **AC26, AC27** close with T10 (`conventions-check`
-    AST-walker extensions).
-  - **AC28** closes with T11 (`add-credentialed-skill` author
-    skill + template variants in its `assets/`).
-  - **AC29** closes with T12 (`example-credentialed-skill`
-    worked example).
-  - **AC30** closes with T13a (seed-side CONVENTIONS.md edit).
-  - **AC31** closes with T13b (Diátaxis how-to).
-  - **AC32** closes with T13c (ROADMAP per-task closure).
-  - **AC33** stays green throughout (every PR runs `make build-check`).
-  - **AC34, AC35** are inheritance invariants enforced by every
-    test PR after T4 / T5 / T6 / T8 land their fixtures.
+- [x] **T1** — ADR-0002 amendment (closed AC1; landed in spec PR).
+- [x] **T2** — stdlib `.env` parser (closed AC2).
+- [x] **T3** — loader API + Tier-1 + platform dispatch + wheel-installability
+      (closed AC3, AC4, AC4b, AC4c, AC5).
+- [x] **T4** — macOS Keychain Tier-2 (closed AC6, AC7, AC8).
+- [x] **T5** — Windows Credential Manager Tier-2 (closed AC9, AC10,
+      AC11, AC12).
+- [x] **T6** — Tier-3 dotfile incl. shared-parent behavior (closed
+      AC13, AC14, AC15).
+- [x] **T7** — `creds-schema.toml` parser + canonical-path resolution
+      (closed AC24, AC24b).
+- [x] **T8** — `agentbundle creds` CLI verb; tombstone args; per-platform
+      exit-code matrices (closed AC16–AC23).
+- [x] **T9** — SKILL.md frontmatter + lint allow-list (closed AC25).
+- [x] **T10** — `conventions-check` AST-walker extensions (closed
+      AC26, AC27).
+- [x] **T11** — `add-credentialed-skill` author skill + template variants
+      (closed AC28).
+- [x] **T12** — `example-credentialed-skill` worked example (closed AC29).
+- [x] **T13a** — seed-side CONVENTIONS.md edit (closed AC30).
+- [x] **T13b** — Diátaxis how-to (closed AC31).
+- [x] **T13c** — this entry's per-task closure (closed AC32).
+- [x] **AC33** — `make build-check` clean across every PR.
+- [ ] **AC34, AC35** — inheritance invariants (orphan-fixture guard;
+      no live writes to developer keychain / dotfile). Enforced by
+      every future test PR that adds fixtures under
+      `packages/agentbundle/tests/fixtures/creds/`.
+
+Open follow-ons (not gating shipped status):
+
 - **New ADR ("Credential storage for credentialed skills") is
-  post-implementation.** RFC-0006 § Follow-on artifacts names it;
-  the spec defers authoring it until T1–T13 are done (precedent:
+  post-implementation.** RFC-0006 § Follow-on artifacts names it; with
+  T1–T13c shipped, this is the next item (precedent:
   `user-scope-hooks`'s ADR).
-- **Linux libsecret tier deferred.** v2 RFC scoped alongside an
+- **Linux `libsecret` tier deferred.** v2 RFC scoped alongside an
   adopter-profile audit per RFC-0006 § Unresolved Q1; not gating
   v1 (Linux lands on Tier 3 floor). The `v2-libsecret` stub stays
   open under cross-spec items below.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -24,7 +24,6 @@ docs/specs/<feature>/
 | [`agent-spec-cli/`](agent-spec-cli/spec.md) | Draft | RFC-0001, RFC-0003 | `agentbundle` CLI at `packages/agentbundle/`. Library-first; stdlib only; zipapp distribution; eleven subcommands incl. `upgrade` with per-primitive granularity. Depends on `distribution-adapters`. |
 | [`adapt-to-project/`](adapt-to-project/spec.md) | Draft | RFC-0001, RFC-0003 | LLM-driven counterpart to `agentbundle adapt`: walks adopters through the four RFC-0001 classes of change (substitution, `.upstream.<ext>` companion merges, discovery+restructuring, within-layout consolidation). Unifies `.adapt-discovery.toml` schema to `[markers]` + `[[findings.*]]` across CLI and self-host; lights up `[pack.dependencies.required]` enforcement on install; adds install→adapt nudge via `.adapt-install-marker.toml` + session-start hook. Depends on `agent-spec-cli`, `distribution-adapters`. |
 | [`user-scope-hooks/`](user-scope-hooks/spec.md) | Draft | RFC-0005 | RFC-0005 implementation contract: `user-merge-json` (Claude Code user scope) + `merge-into-agent-json` (Kiro both scopes — closes RFC-0001 Open Q1); v0.3 state schema with `hook-wiring-owned`; `--force-merge` and `reconcile --scope user`. 13 tasks; T10/T11 amend the sibling specs. Depends on `agent-spec-cli`, `distribution-adapters`. |
-| [`skill-secrets/`](skill-secrets/spec.md) | Draft | RFC-0006, ADR-0002 | RFC-0006 implementation contract: two-layer architecture (skills don't hold credentials; credentialed primitives do); three storage tiers (env → OS keyring (macOS `/usr/bin/security`, Windows ctypes against `advapi32`) → `~/.agent-ready/credentials.env`); stdlib-only `agent_ready.credentials` loader; `agentbundle creds` verb (`setup`/`check`/`where`/`rm`, no `get`); SKILL.md `credentialed:` + `primitive-class:` frontmatter; `conventions-check` argv-ban + "Don't"-block lint; ADR-0002 narrow-"hook-shaped" amendment. 15 tasks (T13 split into T13a/T13b/T13c); T1 lands the ADR amendment. Depends on `agent-spec-cli`. |
 | [`converters-pack/`](converters-pack/spec.md) | Approved | RFC-0007 | First user-scope pack: imports `file-to-markdown`, `markdown-to-html`, `msg-to-markdown` from the source catalogue as a vendored snapshot. `default-scope = "user"`, `allowed-scopes = ["user", "repo"]`. 8 ACs (pack.toml shape, attribution scrub, Rail C clean, evals carry-over, evals JSON validity, source SHA pinned, fixture-`$HOME` install/uninstall, pytest CI invocation, runtime-dep disposition, `node_modules/` gitignore note). 7 plan tasks; one PR. Depends on RFC-0004's user-scope dimension. |
 
 ## Shipped specs (archived)
@@ -32,7 +31,9 @@ docs/specs/<feature>/
 <!-- Once a feature is shipped, move its row here. The spec stays in place
      as documentation of the feature's contract. -->
 
-_none yet_
+| Spec | Status | Constrained by | Notes |
+| --- | --- | --- | --- |
+| [`skill-secrets/`](skill-secrets/spec.md) | Shipped | RFC-0006, ADR-0002 | RFC-0006 implementation: two-layer architecture (skills don't hold credentials; credentialed primitives do); three storage tiers (env → OS keyring (macOS `/usr/bin/security`, Windows ctypes against `advapi32`) → `~/.agent-ready/credentials.env`); stdlib-only `agent_ready.credentials` loader; `agentbundle creds` verb (`setup`/`check`/`where`/`rm`, no `get`); SKILL.md `credentialed:` + `primitive-class:` frontmatter; `conventions-check` argv-ban + "Don't"-block lint; ADR-0002 narrow-"hook-shaped" amendment. AC34/AC35 inheritance invariants enforced by future test PRs adding fixtures; everything else closed across T1–T13c. |
 
 ## Adding a new spec
 

--- a/docs/specs/skill-secrets/spec.md
+++ b/docs/specs/skill-secrets/spec.md
@@ -1,6 +1,6 @@
 # Spec: skill-secrets
 
-- **Status:** Draft <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** [RFC-0006](../../rfc/0006-skill-secrets-storage.md)
@@ -289,7 +289,7 @@ construction-test or fixture exercise.
 
 ADR amendment (lands in the spec PR, not a follow-up):
 
-- [ ] **AC1.** `docs/adr/0002-install-scope-per-pack-default-and-allowance.md`
+- [x] **AC1.** `docs/adr/0002-install-scope-per-pack-default-and-allowance.md`
       carries an `## Amendments` section whose first sub-heading is
       `### 2026-05-24 — Narrow definition of "hook-shaped" (per RFC-0006)`
       and whose body contains the verbatim conjunction phrasing
@@ -302,7 +302,7 @@ ADR amendment (lands in the spec PR, not a follow-up):
 
 Stdlib parser and loader API:
 
-- [ ] **AC2.** A stdlib `.env` parser in
+- [x] **AC2.** A stdlib `.env` parser in
       `packages/agentbundle/agentbundle/creds/loader.py` accepts
       `KEY=value`, `KEY="value with spaces"`, `# comment` lines, blank
       lines; strips trailing `\r\n` / `\n` from the **line tail
@@ -311,18 +311,18 @@ Stdlib parser and loader API:
       refuses `export KEY=value`, refuses variable expansion
       (`KEY=$OTHER`), refuses multi-line quoted values (a quoted
       value spanning two physical lines is a parse error).
-- [ ] **AC3.** `agent_ready.credentials.load_credentials(namespace,
+- [x] **AC3.** `agent_ready.credentials.load_credentials(namespace,
       required_keys=[...])` returns an immutable `Credentials` object
       whose attribute access returns the resolved values; missing
       required keys raise `CredentialsMissingError` naming the
       namespace and the missing keys. The function is the only public
       entry point primitive authors import.
-- [ ] **AC4.** Precedence is **Tier 1 (env) → Tier 2 (keyring) → Tier 3
+- [x] **AC4.** Precedence is **Tier 1 (env) → Tier 2 (keyring) → Tier 3
       (dotfile)** per key, first-hit-wins. A key resolved at Tier 1 is
       not re-checked at lower tiers; mixing tiers across keys within
       one namespace is permitted (one key from env, another from
       keyring, another from dotfile is a valid resolution).
-- [ ] **AC4b.** **Tier-2 backend dispatch is platform-discriminated at
+- [x] **AC4b.** **Tier-2 backend dispatch is platform-discriminated at
       module-load time.** The loader imports
       `_keychain_macos` iff `sys.platform == "darwin"`,
       `_credman_windows` iff `sys.platform == "win32"`, and no
@@ -330,7 +330,7 @@ Stdlib parser and loader API:
       absence; resolver falls through directly to Tier 3). The dispatch
       is verified by a test that monkeypatches `sys.platform` and
       reloads the module.
-- [ ] **AC4c.** `agent_ready.credentials.load_credentials` is reachable
+- [x] **AC4c.** `agent_ready.credentials.load_credentials` is reachable
       from an installed wheel. Verified by `pip install
       packages/agentbundle` followed by
       `python -c "from agent_ready.credentials import load_credentials"`
@@ -341,14 +341,14 @@ Stdlib parser and loader API:
 
 Tier 1 (env var):
 
-- [ ] **AC5.** Reading `<NAMESPACE>_API_TOKEN` (and any sibling key
+- [x] **AC5.** Reading `<NAMESPACE>_API_TOKEN` (and any sibling key
       declared in `creds-schema.toml`, e.g. `_BASE_URL`, `_EMAIL`,
       `_FLAVOR`) from `os.environ` returns the value. Empty-string env
       var counts as unset and falls through to Tier 2.
 
 Tier 2 (macOS Keychain):
 
-- [ ] **AC6.** On Darwin, the Tier-2 read path shells out to
+- [x] **AC6.** On Darwin, the Tier-2 read path shells out to
       `/usr/bin/security find-generic-password -s "agent-ready" -a
       "<namespace>:<key>" -w` and captures stdout; the write path uses
       `add-generic-password -U -s "agent-ready" -a "<namespace>:<key>"
@@ -357,9 +357,9 @@ Tier 2 (macOS Keychain):
       token never appears in argv**; a fixture test exercises a
       `psutil`-shaped argv inspection during the call and asserts the
       token bytes are absent.
-- [ ] **AC7.** Round-trip: write a value, read it, compare bytes; the
+- [x] **AC7.** Round-trip: write a value, read it, compare bytes; the
       stored value matches the input.
-- [ ] **AC8.** The `_keychain_macos` backend module is **not imported**
+- [x] **AC8.** The `_keychain_macos` backend module is **not imported**
       when `sys.platform != "darwin"` (per AC4b). A loader-level test
       sets `sys.platform = "linux"`, reloads
       `agent_ready.credentials`, and asserts the macOS backend
@@ -368,7 +368,7 @@ Tier 2 (macOS Keychain):
 
 Tier 2 (Windows Credential Manager):
 
-- [ ] **AC9.** On Windows, the Tier-2 read/write/delete path calls
+- [x] **AC9.** On Windows, the Tier-2 read/write/delete path calls
       `ctypes.windll.advapi32.CredReadW(target, type, flags,
       &credential_ptr)`, `CredWriteW(&credential, flags)`,
       `CredDeleteW(target, type, flags)`, and `CredFree(ptr)` against
@@ -382,10 +382,10 @@ Tier 2 (Windows Credential Manager):
       `CREDENTIAL` fields (`Flags`, `Comment`, `LastWritten`,
       `AttributeCount`, `Attributes`, `TargetAlias`) zero-initialised
       via `ctypes.Structure` defaults.
-- [ ] **AC10.** Round-trip: write a value, read it, **byte-equality**
+- [x] **AC10.** Round-trip: write a value, read it, **byte-equality**
       assertion against the UTF-16-encoded original. Test runs on
       `windows-latest` GitHub Actions.
-- [ ] **AC11.** Win32 error-code dispatch matrix:
+- [x] **AC11.** Win32 error-code dispatch matrix:
       `ERROR_NOT_FOUND (1168)` → return `None`, resolver falls through
       to Tier 3;
       `ERROR_NO_SUCH_LOGON_SESSION (1312)` → raise
@@ -395,20 +395,20 @@ Tier 2 (Windows Credential Manager):
       naming the offending flag value;
       `ERROR_LOGON_FAILURE (1326)` → raise `Tier2HardFailError`
       naming DPAPI key-derivation failure.
-- [ ] **AC12.** The `_credman_windows` backend module is **not
+- [x] **AC12.** The `_credman_windows` backend module is **not
       imported** when `sys.platform != "win32"` (per AC4b). Parallel
       test to AC8 with `sys.platform = "linux"`; the Windows backend
       module is absent from `sys.modules`.
 
 Tier 3 (dotfile):
 
-- [ ] **AC13.** Path resolves to `pathlib.Path.home() /
+- [x] **AC13.** Path resolves to `pathlib.Path.home() /
       ".agent-ready" / "credentials.env"` on every platform.
-- [ ] **AC14.** Write path is atomic: `tempfile.mkstemp` in the target
+- [x] **AC14.** Write path is atomic: `tempfile.mkstemp` in the target
       directory → `os.write` → `os.replace`. A mid-write read sees
       either the prior file contents or the new contents, never
       partial.
-- [ ] **AC15.** On POSIX (`os.name == "posix"`), the helper calls
+- [x] **AC15.** On POSIX (`os.name == "posix"`), the helper calls
       `os.chmod(path, 0o600)` on the file. The parent directory
       `~/.agent-ready/` is **shared** with RFC-0004 install state
       (`state.toml`) and the `adapt-to-project` marker — the
@@ -425,7 +425,7 @@ Tier 3 (dotfile):
 
 CLI verb `agentbundle creds`:
 
-- [ ] **AC16.** `agentbundle creds setup <namespace>` reads the
+- [x] **AC16.** `agentbundle creds setup <namespace>` reads the
       namespace's required keys from `creds-schema.toml`, prompts via
       `getpass.getpass` (guarded by `sys.stdin.isatty()` — refuses
       non-tty with stderr), writes to the highest-available tier
@@ -440,7 +440,7 @@ CLI verb `agentbundle creds`:
       `--allow-insecure-fallback` was passed. A log reader can
       distinguish platform-deferred Tier 3 from opt-out Tier 3
       without further context.
-- [ ] **AC17.** `agentbundle creds setup` (no positional namespace
+- [x] **AC17.** `agentbundle creds setup` (no positional namespace
       argument) walks both scope state files
       (`<repo>/.agent-ready-state.toml` and
       `~/.agent-ready/state.toml`) for installed primitives whose
@@ -456,23 +456,23 @@ CLI verb `agentbundle creds`:
       The CLI then resolves the selected primitive's schema via the
       canonical convention pinned in AC24b and exits non-zero with
       a clear stderr error if the file is absent.
-- [ ] **AC18.** `agentbundle creds check <namespace>` exits 0 when
+- [x] **AC18.** `agentbundle creds check <namespace>` exits 0 when
       the namespace's required keys all resolve, exit 2 when any is
       missing (stderr names the missing keys), exit 3 for other
       errors (unparseable schema, Tier-2 hard-fail).
-- [ ] **AC19.** `agentbundle creds where <namespace>` prints, per
+- [x] **AC19.** `agentbundle creds where <namespace>` prints, per
       required key, the tier each one resolved at (`env`, `keyring`,
       `dotfile`, or `missing`). Does not print the value.
-- [ ] **AC20.** `agentbundle creds rm <namespace>` deletes every key
+- [x] **AC20.** `agentbundle creds rm <namespace>` deletes every key
       in the namespace from every tier that holds it (env clears are
       a no-op the helper documents on stderr; keyring deletes via the
       per-platform backend; dotfile rewrites without those keys). The
       helper refuses with stderr if no tier holds any of the
       namespace's keys.
-- [ ] **AC21.** No `agentbundle creds get` subcommand exists. A
+- [x] **AC21.** No `agentbundle creds get` subcommand exists. A
       negative test asserts `agentbundle creds get foo` exits non-zero
       with `unknown command: get` on stderr.
-- [ ] **AC22.** `agentbundle creds setup --allow-insecure-fallback` on
+- [x] **AC22.** `agentbundle creds setup --allow-insecure-fallback` on
       a Tier-2-capable box writes to Tier 3 and exits 0; without the
       flag, falling back to Tier 3 on a Tier-2-capable box exits
       non-zero with stderr naming the reason. On Linux the helper
@@ -491,7 +491,7 @@ CLI verb `agentbundle creds`:
         exit code.
       - **Windows**: the Win32 matrix in AC11 governs (`ERROR_NOT_FOUND`
         → Tier 3 fallthrough; everything else listed → hard fail).
-- [ ] **AC23.** The helper refuses to read the token from **its own**
+- [x] **AC23.** The helper refuses to read the token from **its own**
       stdin when not a tty, from argv, from env, or from a pipe.
       Tokens enter through the interactive `getpass` prompt or
       nowhere; the helper exits non-zero in every other case. The
@@ -517,7 +517,7 @@ CLI verb `agentbundle creds`:
 
 `creds-schema.toml` format:
 
-- [ ] **AC24.** `creds-schema.toml` declares the namespace's required
+- [x] **AC24.** `creds-schema.toml` declares the namespace's required
       keys with shape:
       ```toml
       [namespace]
@@ -534,7 +534,7 @@ CLI verb `agentbundle creds`:
       The loader parses this with `tomllib`; `secret = true` keys are
       hidden via `getpass`, `secret = false` keys are prompted via
       `input()`.
-- [ ] **AC24b.** **Canonical schema path:** a credentialed primitive's
+- [x] **AC24b.** **Canonical schema path:** a credentialed primitive's
       schema lives at `<skill-dir>/references/creds-schema.toml`
       where `<skill-dir>` is the projected skill directory (e.g.
       `.claude/skills/<name>/`). The CLI resolves the path by walking
@@ -549,13 +549,13 @@ CLI verb `agentbundle creds`:
 
 Conventions and lint:
 
-- [ ] **AC25.** `tools/lint-agent-artifacts.sh` extends
+- [x] **AC25.** `tools/lint-agent-artifacts.sh` extends
       `ALLOWED_SKILL_KEYS` to accept `credentialed` (boolean) and
       `primitive-class` (string: `credentialed-cli` | `mcp-server`).
       Schema refuses other values for `primitive-class`; absence of
       `credentialed` means the skill is not credentialed and the lint
       skips it.
-- [ ] **AC26.** `packs/core/.apm/commands/conventions-check.md`
+- [x] **AC26.** `packs/core/.apm/commands/conventions-check.md`
       extends to report three credentialed-skill findings:
       (a) `credentialed: true` skill missing the verbatim "Don't"
       block under a `### Security rules (non-negotiable)` heading;
@@ -567,13 +567,13 @@ Conventions and lint:
       the substring `.agent-ready/credentials.env` without the opt-out
       comment marker (`# credentialed-primitive: reads-creds-directly`)
       on the same line. Findings are *reported*, not blocked.
-- [ ] **AC27.** Normalisation rule for AC26(b): strip leading `-`,
+- [x] **AC27.** Normalisation rule for AC26(b): strip leading `-`,
       casefold, replace `-` with `_`; matches defeat trivial
       obfuscation (`"--" + "token"`, `--Token`, `--api-Key`).
 
 Templates and worked example:
 
-- [ ] **AC28.** A new author skill at
+- [x] **AC28.** A new author skill at
       `packs/core/.apm/skills/add-credentialed-skill/` ships with a
       `SKILL.md` (triggering on "add a credentialed skill", "new
       credentialed primitive") and an `assets/credentialed-skill-SKILL.md`
@@ -586,7 +586,7 @@ Templates and worked example:
       canonical landing pinned by this spec, replacing the
       pre-amendment path named in
       [RFC-0006 § Amendments](../../rfc/0006-skill-secrets-storage.md#amendments).
-- [ ] **AC29.** A worked example at
+- [x] **AC29.** A worked example at
       `packs/core/.apm/skills/example-credentialed-skill/` ships with:
       a `SKILL.md` declaring `credentialed: true`,
       `primitive-class: credentialed-cli`, embedding the
@@ -598,7 +598,7 @@ Templates and worked example:
 
 Conventions, guide, roadmap:
 
-- [ ] **AC30.** The **seed-side upstream** of `docs/CONVENTIONS.md` at
+- [x] **AC30.** The **seed-side upstream** of `docs/CONVENTIONS.md` at
       `packs/core/seeds/docs/CONVENTIONS.md` gains a top-level
       `## Credentialed skills` section naming the two-layer
       architecture rule, the three storage tiers, the argv ban, the
@@ -610,13 +610,13 @@ Conventions, guide, roadmap:
       RFC-0006 by anchor. The projected `docs/CONVENTIONS.md` is
       regenerated by `make build-self`; direct edits to the
       projected path are bounced by `make build-check` (AC33).
-- [ ] **AC31.** A Diátaxis how-to at
+- [x] **AC31.** A Diátaxis how-to at
       `docs/guides/how-to/add-a-credentialed-skill.md` walks an
       adopter through writing a credentialed primitive end-to-end:
       pick a namespace; write the schema; import the loader; embed
       the "Don't" block; declare frontmatter; run `setup`; run
       `check`. References the worked example.
-- [ ] **AC32.** `docs/ROADMAP.md` carries a `## skill-secrets` section
+- [x] **AC32.** `docs/ROADMAP.md` carries a `## skill-secrets` section
       replacing the previous cross-spec stub. Entries close
       incrementally **per task** following the existing ROADMAP
       grouping convention (one bullet per task / AC range, not one
@@ -627,7 +627,7 @@ Conventions, guide, roadmap:
 
 Verification:
 
-- [ ] **AC33.** `make build-check` exits clean with the amendments
+- [x] **AC33.** `make build-check` exits clean with the amendments
       applied (no drift between `packs/core/seeds/` and `<repo>/`).
 - [ ] **AC34.** Every fixture file under
       `packages/agentbundle/tests/fixtures/creds/` and every fixture

--- a/packs/core/seeds/docs/specs/README.md
+++ b/packs/core/seeds/docs/specs/README.md
@@ -24,7 +24,6 @@ docs/specs/<feature>/
 | [`agent-spec-cli/`](agent-spec-cli/spec.md) | Draft | RFC-0001, RFC-0003 | `agentbundle` CLI at `packages/agentbundle/`. Library-first; stdlib only; zipapp distribution; eleven subcommands incl. `upgrade` with per-primitive granularity. Depends on `distribution-adapters`. |
 | [`adapt-to-project/`](adapt-to-project/spec.md) | Draft | RFC-0001, RFC-0003 | LLM-driven counterpart to `agentbundle adapt`: walks adopters through the four RFC-0001 classes of change (substitution, `.upstream.<ext>` companion merges, discovery+restructuring, within-layout consolidation). Unifies `.adapt-discovery.toml` schema to `[markers]` + `[[findings.*]]` across CLI and self-host; lights up `[pack.dependencies.required]` enforcement on install; adds install→adapt nudge via `.adapt-install-marker.toml` + session-start hook. Depends on `agent-spec-cli`, `distribution-adapters`. |
 | [`user-scope-hooks/`](user-scope-hooks/spec.md) | Draft | RFC-0005 | RFC-0005 implementation contract: `user-merge-json` (Claude Code user scope) + `merge-into-agent-json` (Kiro both scopes — closes RFC-0001 Open Q1); v0.3 state schema with `hook-wiring-owned`; `--force-merge` and `reconcile --scope user`. 13 tasks; T10/T11 amend the sibling specs. Depends on `agent-spec-cli`, `distribution-adapters`. |
-| [`skill-secrets/`](skill-secrets/spec.md) | Draft | RFC-0006, ADR-0002 | RFC-0006 implementation contract: two-layer architecture (skills don't hold credentials; credentialed primitives do); three storage tiers (env → OS keyring (macOS `/usr/bin/security`, Windows ctypes against `advapi32`) → `~/.agent-ready/credentials.env`); stdlib-only `agent_ready.credentials` loader; `agentbundle creds` verb (`setup`/`check`/`where`/`rm`, no `get`); SKILL.md `credentialed:` + `primitive-class:` frontmatter; `conventions-check` argv-ban + "Don't"-block lint; ADR-0002 narrow-"hook-shaped" amendment. 15 tasks (T13 split into T13a/T13b/T13c); T1 lands the ADR amendment. Depends on `agent-spec-cli`. |
 | [`converters-pack/`](converters-pack/spec.md) | Approved | RFC-0007 | First user-scope pack: imports `file-to-markdown`, `markdown-to-html`, `msg-to-markdown` from the source catalogue as a vendored snapshot. `default-scope = "user"`, `allowed-scopes = ["user", "repo"]`. 8 ACs (pack.toml shape, attribution scrub, Rail C clean, evals carry-over, evals JSON validity, source SHA pinned, fixture-`$HOME` install/uninstall, pytest CI invocation, runtime-dep disposition, `node_modules/` gitignore note). 7 plan tasks; one PR. Depends on RFC-0004's user-scope dimension. |
 
 ## Shipped specs (archived)
@@ -32,7 +31,9 @@ docs/specs/<feature>/
 <!-- Once a feature is shipped, move its row here. The spec stays in place
      as documentation of the feature's contract. -->
 
-_none yet_
+| Spec | Status | Constrained by | Notes |
+| --- | --- | --- | --- |
+| [`skill-secrets/`](skill-secrets/spec.md) | Shipped | RFC-0006, ADR-0002 | RFC-0006 implementation: two-layer architecture (skills don't hold credentials; credentialed primitives do); three storage tiers (env → OS keyring (macOS `/usr/bin/security`, Windows ctypes against `advapi32`) → `~/.agent-ready/credentials.env`); stdlib-only `agent_ready.credentials` loader; `agentbundle creds` verb (`setup`/`check`/`where`/`rm`, no `get`); SKILL.md `credentialed:` + `primitive-class:` frontmatter; `conventions-check` argv-ban + "Don't"-block lint; ADR-0002 narrow-"hook-shaped" amendment. AC34/AC35 inheritance invariants enforced by future test PRs adding fixtures; everything else closed across T1–T13c. |
 
 ## Adding a new spec
 


### PR DESCRIPTION
## Summary

- `docs/ROADMAP.md` `## skill-secrets` section flips drafted → shipped; T1–T13c each get a checked task bullet naming the ACs each closed; `Last updated` bumped to 2026-05-24.
- `docs/specs/skill-secrets/spec.md` Status: Draft → Shipped; 36 of 38 ACs ticked; AC34/AC35 left open as inheritance invariants enforced by every future test PR that adds fixtures.
- `packs/core/seeds/docs/specs/README.md` row moves from "Active specs" to "Shipped specs (archived)"; `make build-self` regenerates the projected `docs/specs/README.md`.

## ACs closed

AC32 — `docs/specs/skill-secrets/spec.md`; finalises the spec close-out for the skill-secrets wave per the wave-handoff protocol.

## Test plan

- [x] `python3 tools/lint-agents-md.py` — clean.
- [x] `make build-check` — clean (the seed/projected pair re-renders identically).