### PR TITLE
docs(work-loop): decouple from docs/knowledge/ hard reference

### DIFF
--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -392,23 +392,22 @@ Where the answer goes depends on the *shape* of the learning:
 
 - **Practitioner lessons** — a repeatable pattern that worked, a
   gotcha that bit you, or an antipattern that looked good but rotted.
-  If the project maintains a knowledge base, this is where the lesson
-  lands. See
-  [`CONVENTIONS.md § Knowledge base`](../../../docs/CONVENTIONS.md#knowledge-base)
-  for the schema, location, and how the session-start hook surfaces
-  these on the next loop.
+  Check `docs/CONVENTIONS.md` for a `Knowledge base` section: if
+  present, follow what it says for schema, file location, and how the
+  session-start hook surfaces these on the next loop. If the section
+  isn't there, fall back to a one-line note in the relevant
+  `AGENTS.md` (root or per-package) — the next agent still sees it.
 - "I had to grep for `<thing>` repeatedly" → add a pointer in
   `docs/architecture/<subsystem>.md`.
 - "The test command for this package is unusual" → add it to the package's
   `AGENTS.md`.
 - "I made the same wrong assumption twice" → if it's a
-  knowledge-base-shaped lesson (a pattern/gotcha/antipattern), record
-  it where [`CONVENTIONS.md § Knowledge base`](../../../docs/CONVENTIONS.md#knowledge-base)
-  says; if it's project-conventions context, add a line to the
-  relevant `AGENTS.md` (root or per-package) so the next agent doesn't
-  repeat it. If it's a vocabulary issue (a term that means something
-  specific here), it goes in `docs/guides/reference/` as a glossary
-  entry.
+  knowledge-base-shaped lesson (a pattern/gotcha/antipattern), follow
+  the routing in the first bullet; if it's project-conventions
+  context, add a line to the relevant `AGENTS.md` (root or
+  per-package) so the next agent doesn't repeat it. If it's a
+  vocabulary issue (a term that means something specific here), it
+  goes in `docs/guides/reference/` as a glossary entry.
 - "This workflow is now the third time I've done it" → propose it as a new
   skill in `.claude/skills/`.
 

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: work-loop
 description: Use this skill whenever you're implementing a non-trivial change — a feature, a multi-file bug fix, a refactor, a migration, a framework or dependency upgrade, a schema or API change, performance work, an infrastructure or build-system edit, or anything spec-driven. It enforces the project's plan → execute → self-review → fix loop with mechanical gates (lint, typecheck, tests) and adversarial review. Default to this skill for any task larger than a one-line edit.
-dependencies:
-  - docs/knowledge/README.md
-  - docs/knowledge/patterns.jsonl
 ---
 
 # Skill: work-loop
@@ -394,24 +391,24 @@ Before the PR is opened, ask: *what would have made this loop go faster?*
 Where the answer goes depends on the *shape* of the learning:
 
 - **Practitioner lessons** — a repeatable pattern that worked, a
-  gotcha that bit you, or an antipattern that looked good but rotted —
-  go in [`docs/knowledge/patterns.jsonl`](../../../docs/knowledge/patterns.jsonl)
-  as a new entry. The schema is in
-  [`docs/knowledge/README.md`](../../../docs/knowledge/README.md);
-  one JSON object per line, scoped to a file glob. The
-  `session-start` hook reads these so the next agent starts with the
-  relevant ones already in context.
+  gotcha that bit you, or an antipattern that looked good but rotted.
+  If the project maintains a knowledge base, this is where the lesson
+  lands. See
+  [`CONVENTIONS.md § Knowledge base`](../../../docs/CONVENTIONS.md#knowledge-base)
+  for the schema, location, and how the session-start hook surfaces
+  these on the next loop.
 - "I had to grep for `<thing>` repeatedly" → add a pointer in
   `docs/architecture/<subsystem>.md`.
 - "The test command for this package is unusual" → add it to the package's
   `AGENTS.md`.
 - "I made the same wrong assumption twice" → if it's a
   knowledge-base-shaped lesson (a pattern/gotcha/antipattern), record
-  it in `patterns.jsonl`; if it's project-conventions context, add a
-  line to the relevant `AGENTS.md` (root or per-package) so the next
-  agent doesn't repeat it. If it's a vocabulary issue (a term that
-  means something specific here), it goes in `docs/guides/reference/`
-  as a glossary entry.
+  it where [`CONVENTIONS.md § Knowledge base`](../../../docs/CONVENTIONS.md#knowledge-base)
+  says; if it's project-conventions context, add a line to the
+  relevant `AGENTS.md` (root or per-package) so the next agent doesn't
+  repeat it. If it's a vocabulary issue (a term that means something
+  specific here), it goes in `docs/guides/reference/` as a glossary
+  entry.
 - "This workflow is now the third time I've done it" → propose it as a new
   skill in `.claude/skills/`.
 

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -392,23 +392,22 @@ Where the answer goes depends on the *shape* of the learning:
 
 - **Practitioner lessons** — a repeatable pattern that worked, a
   gotcha that bit you, or an antipattern that looked good but rotted.
-  If the project maintains a knowledge base, this is where the lesson
-  lands. See
-  [`CONVENTIONS.md § Knowledge base`](../../../docs/CONVENTIONS.md#knowledge-base)
-  for the schema, location, and how the session-start hook surfaces
-  these on the next loop.
+  Check `docs/CONVENTIONS.md` for a `Knowledge base` section: if
+  present, follow what it says for schema, file location, and how the
+  session-start hook surfaces these on the next loop. If the section
+  isn't there, fall back to a one-line note in the relevant
+  `AGENTS.md` (root or per-package) — the next agent still sees it.
 - "I had to grep for `<thing>` repeatedly" → add a pointer in
   `docs/architecture/<subsystem>.md`.
 - "The test command for this package is unusual" → add it to the package's
   `AGENTS.md`.
 - "I made the same wrong assumption twice" → if it's a
-  knowledge-base-shaped lesson (a pattern/gotcha/antipattern), record
-  it where [`CONVENTIONS.md § Knowledge base`](../../../docs/CONVENTIONS.md#knowledge-base)
-  says; if it's project-conventions context, add a line to the
-  relevant `AGENTS.md` (root or per-package) so the next agent doesn't
-  repeat it. If it's a vocabulary issue (a term that means something
-  specific here), it goes in `docs/guides/reference/` as a glossary
-  entry.
+  knowledge-base-shaped lesson (a pattern/gotcha/antipattern), follow
+  the routing in the first bullet; if it's project-conventions
+  context, add a line to the relevant `AGENTS.md` (root or
+  per-package) so the next agent doesn't repeat it. If it's a
+  vocabulary issue (a term that means something specific here), it
+  goes in `docs/guides/reference/` as a glossary entry.
 - "This workflow is now the third time I've done it" → propose it as a new
   skill in `.claude/skills/`.
 

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: work-loop
 description: Use this skill whenever you're implementing a non-trivial change — a feature, a multi-file bug fix, a refactor, a migration, a framework or dependency upgrade, a schema or API change, performance work, an infrastructure or build-system edit, or anything spec-driven. It enforces the project's plan → execute → self-review → fix loop with mechanical gates (lint, typecheck, tests) and adversarial review. Default to this skill for any task larger than a one-line edit.
-dependencies:
-  - docs/knowledge/README.md
-  - docs/knowledge/patterns.jsonl
 ---
 
 # Skill: work-loop
@@ -394,24 +391,24 @@ Before the PR is opened, ask: *what would have made this loop go faster?*
 Where the answer goes depends on the *shape* of the learning:
 
 - **Practitioner lessons** — a repeatable pattern that worked, a
-  gotcha that bit you, or an antipattern that looked good but rotted —
-  go in [`docs/knowledge/patterns.jsonl`](../../../docs/knowledge/patterns.jsonl)
-  as a new entry. The schema is in
-  [`docs/knowledge/README.md`](../../../docs/knowledge/README.md);
-  one JSON object per line, scoped to a file glob. The
-  `session-start` hook reads these so the next agent starts with the
-  relevant ones already in context.
+  gotcha that bit you, or an antipattern that looked good but rotted.
+  If the project maintains a knowledge base, this is where the lesson
+  lands. See
+  [`CONVENTIONS.md § Knowledge base`](../../../docs/CONVENTIONS.md#knowledge-base)
+  for the schema, location, and how the session-start hook surfaces
+  these on the next loop.
 - "I had to grep for `<thing>` repeatedly" → add a pointer in
   `docs/architecture/<subsystem>.md`.
 - "The test command for this package is unusual" → add it to the package's
   `AGENTS.md`.
 - "I made the same wrong assumption twice" → if it's a
   knowledge-base-shaped lesson (a pattern/gotcha/antipattern), record
-  it in `patterns.jsonl`; if it's project-conventions context, add a
-  line to the relevant `AGENTS.md` (root or per-package) so the next
-  agent doesn't repeat it. If it's a vocabulary issue (a term that
-  means something specific here), it goes in `docs/guides/reference/`
-  as a glossary entry.
+  it where [`CONVENTIONS.md § Knowledge base`](../../../docs/CONVENTIONS.md#knowledge-base)
+  says; if it's project-conventions context, add a line to the
+  relevant `AGENTS.md` (root or per-package) so the next agent doesn't
+  repeat it. If it's a vocabulary issue (a term that means something
+  specific here), it goes in `docs/guides/reference/` as a glossary
+  entry.
 - "This workflow is now the third time I've done it" → propose it as a new
   skill in `.claude/skills/`.
 

--- a/tools/test-pre-pr.sh
+++ b/tools/test-pre-pr.sh
@@ -88,9 +88,11 @@ run_corruption "agent-artifact-fail" \
   "sed -i.bak '/^model:/d' .claude/agents/adversarial-reviewer.md && rm .claude/agents/adversarial-reviewer.md.bak" \
   'pre-pr: ✖ agent-artifact lint failed'
 
-# 3. skill-deps lint — break a dep path in the work-loop SKILL.
+# 3. skill-deps lint — break a dep path in the bug-fix SKILL.
+#    Repoint a real dependency entry at a non-existent path; the
+#    linter validates each listed path exists.
 run_corruption "skill-deps-fail" \
-  "sed -i.bak 's|docs/knowledge/patterns.jsonl|docs/knowledge/does-not-exist.jsonl|' .claude/skills/work-loop/SKILL.md && rm .claude/skills/work-loop/SKILL.md.bak" \
+  "sed -i.bak 's|.claude/skills/new-spec/SKILL.md|.claude/skills/does-not-exist/SKILL.md|' .claude/skills/bug-fix/SKILL.md && rm .claude/skills/bug-fix/SKILL.md.bak" \
   'pre-pr: ✖ skill-deps lint failed'
 
 # 4. knowledge lint — plant a malformed JSONL line.


### PR DESCRIPTION
## Summary

- Remove the frontmatter `dependencies:` block from `packs/core/.apm/skills/work-loop/SKILL.md` that falsely promised the skill reads `docs/knowledge/README.md` and `docs/knowledge/patterns.jsonl`. work-loop never reads those files — the reader is `tools/hooks/session-start.py`, and the files are absent under Profile A.
- In §"Capture what was learned", route practitioner lessons through `CONVENTIONS.md § Knowledge base` for schema, location, and session-start hook behavior instead of hard-coding paths in the skill body. Fourth bullet ("I made the same wrong assumption twice") no longer names `patterns.jsonl` directly.
- Projected via `make build-self` (second commit).

## What's unchanged (deliberately)

- `tools/hooks/session-start.py`, `tools/lint-knowledge.py`, `docs/knowledge/README.md`, `packs/core/seeds/docs/knowledge/` — the knowledge base is still a real primitive owned by CONVENTIONS.md + the hook.
- Other skills/agents — no "capture learnings" step added to `bug-fix`, `new-spec`, or any reviewer agent.
- `docs/CONVENTIONS.md` § Knowledge base — already covers schema location, append-only curation, and session-start hook behavior (lines 577-606).

## Test plan

- [x] `make build-self` projects pack source into `.claude/skills/work-loop/SKILL.md`.
- [x] `make build-check` passes.
- [x] `tools/lint-skill-deps.py` passes (19 manifests, including modified work-loop).
- [x] `tools/test-lint-knowledge.sh` passes (20/20 cases, including `schema-drift-readme-vs-script`).
- [x] grep finds zero `docs/knowledge/` references in `.claude/skills/**/*.md` or `packs/*/.apm/skills/**/*.md`.
- [x] Adversarial reviewer: clean — anchor `#knowledge-base` matches the `### Knowledge base` heading at `docs/CONVENTIONS.md:577`; `../../../docs/CONVENTIONS.md` link resolves correctly from the projected location.