### PR TITLE
fix(skill-secrets): quality review — propagate Tier-2 hard-fail through `_tier_for_key`

### DIFF
--- a/packages/agentbundle/agentbundle/commands/creds.py
+++ b/packages/agentbundle/agentbundle/commands/creds.py
@@ -369,6 +369,16 @@ def _tier_for_key(namespace: str, key: str) -> str:
     Reads each tier in precedence order via the loader's internal
     helpers so the answer matches what ``load_credentials`` would
     return. The value is discarded — only the location matters.
+
+    A ``Tier2HardFailError`` raised by the Tier-2 backend's read is
+    **propagated**, not swallowed. AC11 mandates that hard-fail Win32
+    error codes (``ERROR_NO_SUCH_LOGON_SESSION``, ``ERROR_INVALID_FLAGS``,
+    ``ERROR_LOGON_FAILURE``) and macOS Keychain-locked exits do not
+    silently fall through to Tier 3; the Boundaries § Never do clause
+    "No silent fallback from hard-fail Win32 error codes" forbids it.
+    Callers (``run_check``, ``run_where``, ``run_rm``) already wrap
+    this helper in a ``Tier2HardFailError`` handler that returns exit
+    3 with stderr.
     """
     from agentbundle.creds import loader
 
@@ -377,10 +387,8 @@ def _tier_for_key(namespace: str, key: str) -> str:
     if env_val:
         return "env"
     if loader._tier2_backend is not None:
-        try:
-            v = loader._tier2_backend.read_credential(namespace, key)
-        except Exception:
-            v = None
+        # Tier2HardFailError propagates — see docstring.
+        v = loader._tier2_backend.read_credential(namespace, key)
         if v:
             return "keyring"
     v3 = loader._dotfile_read(namespace, key)

--- a/packages/agentbundle/tests/integration/test_creds_cli.py
+++ b/packages/agentbundle/tests/integration/test_creds_cli.py
@@ -673,6 +673,54 @@ def test_setup_refuses_non_tty_stdin_via_subprocess(tmp_path):
     assert "stdin is not a tty" in res.stderr
 
 
+# ── AC11+AC18: read-path Tier-2 hard fail propagates (exit 3) ─────────
+
+
+def test_check_exits_three_on_tier2_hard_fail_during_read(
+    tmp_path, monkeypatch, capsys
+):
+    """AC11 + AC18: a Tier-2 ``read_credential`` that raises
+    ``Tier2HardFailError`` must not be swallowed by ``_tier_for_key``
+    and reported as ``"missing"`` (exit 2). The contract is exit 3,
+    stderr names the cause; the Boundaries § Never do clause
+    "No silent fallback from hard-fail Win32 error codes" depends on
+    this propagation.
+    """
+    from agentbundle.creds import loader
+    from agentbundle.creds.exceptions import Tier2HardFailError
+
+    _write_skill_fixture(tmp_path, "alpha", "alpha")
+    _write_state_file(tmp_path, "core", (".claude/skills/alpha/SKILL.md",))
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    class _ReadHardFail:
+        @staticmethod
+        def read_credential(*a, **kw):
+            raise Tier2HardFailError(
+                "ERROR_NO_SUCH_LOGON_SESSION (1312) — no logon session"
+            )
+
+        @staticmethod
+        def write_credential(*a, **kw):
+            return None
+
+        @staticmethod
+        def delete_credential(*a, **kw):
+            return None
+
+    monkeypatch.setattr(loader, "_tier2_backend", _ReadHardFail)
+    rc = _run(["creds", "check", "alpha", "--root", str(tmp_path)])
+    assert rc == 3, (
+        "AC11 + AC18 contract: read-path Tier-2 hard fail must exit 3 "
+        "(not 2 / missing). _tier_for_key swallowed the exception if "
+        "this assertion fired with rc=2."
+    )
+    out = capsys.readouterr()
+    assert "ERROR_NO_SUCH_LOGON_SESSION" in out.err or "Tier 2" in out.err, (
+        f"stderr should name the Tier-2 hard-fail cause; got: {out.err!r}"
+    )
+
+
 # ── AC22: setup hard-fails when Tier-2 errors without opt-out ─────────
 
 


### PR DESCRIPTION
## Summary

Quality-review round 1 Blocker #3 from `docs/specs/skill-secrets/notes/review-round1-quality.md`.

## What changed

`_tier_for_key` in `agentbundle/commands/creds.py` previously wrapped the Tier-2 `read_credential` call in `try / except Exception: v = None`, converting `Tier2HardFailError` into a `"missing"` tier label. `run_check` then returned exit 2 (missing) instead of the AC18-mandated exit 3 (Tier-2 hard fail).

This silently degrades the security posture the user chose and violates **Boundaries § Never do "No silent fallback from hard-fail Win32 error codes"**.

Remove the swallow. `run_check` / `run_where` / `run_rm` already wrap this helper in a `Tier2HardFailError` handler that exits 3 with stderr naming the cause.

Add `test_check_exits_three_on_tier2_hard_fail_during_read` covering the read path that the existing `test_setup_tier2_hard_fail_without_opt_out_exits_three` didn't exercise.

## Out of scope (deferred to follow-ups or surfaced for user decision)

- **Quality #4** — `schema_path` no-op kwarg: spec AC24b accepts it but the loader never consumes it. Decision needed: remove or wire.
- **Quality #5** — AC4 mixing-tiers construction test.
- **Quality #6** — `CredentialsMissingError` should name tiers tried.
- **Quality #7** — AC22 macOS symbolic exit codes (cross-ref Adversarial Blocker #5).
- **Quality #11** — move `EnvParseError` definition above its first use.
- **Quality #12** — refactor `_tier_for_key` to delegate to `load_credentials` (deeper refactor).

## Test plan

- [x] `make build-check` clean
- [x] `pytest tests/integration/test_creds_cli.py` (37 tests) passes including new read-path hard-fail test