### PR TITLE
fix(skill-secrets): security review — newline guard, dotfile size cap, argv-flag posture comments

### DIFF
--- a/.claude/skills/add-credentialed-skill/SKILL.md
+++ b/.claude/skills/add-credentialed-skill/SKILL.md
@@ -99,6 +99,15 @@ slash command) reports findings on:
   whose normalised name matches the banned set. Casing variants and
   `"--" + "name"` literal concatenation are caught; deeper obfuscation
   is out of scope.
+- **Argparse-only scope.** The lint walks `argparse.ArgumentParser.add_argument`
+  calls; it does NOT see `click.option(...)`, `typer.Option(...)`,
+  decorator-style flag declarations, f-string flag names, `*args`-spread
+  forms, or other dynamic shapes. If your credentialed-CLI primitive
+  uses `click` or `typer`, the lint reports zero findings and PR review
+  is the only enforcement. Prefer `argparse` for credentialed-CLI
+  primitives so the lint can do its job; if you reach for `click` or
+  `typer` anyway, name the choice in the PR description so reviewers
+  know to spot-check the flag set by hand.
 - Any `scripts/**/*.py` line containing `.agent-ready/credentials.env`
   without the opt-out marker `# credentialed-primitive: reads-creds-directly`
   on the same line.

--- a/packages/agentbundle/agentbundle/commands/creds.py
+++ b/packages/agentbundle/agentbundle/commands/creds.py
@@ -141,6 +141,14 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
             "declaring credentialed: true and prompts for a selection."
         ),
     )
+    # SECURITY: the two posture-lowering flags below are argv-only by
+    # design. The user's choice to weaken the storage posture must be
+    # visible on the command line so an operator reading shell history,
+    # a CI log, or an audit trail sees it. Do NOT add an env-var
+    # equivalent (``AGENT_READY_ALLOW_INSECURE``-shaped), a TOML config
+    # alternative, or a default-on toggle — silent posture lowering
+    # defeats the protection. Widening this contract requires an RFC
+    # amendment, not a one-line PR.
     setup_p.add_argument(
         "--allow-insecure-fallback",
         action="store_true",

--- a/packages/agentbundle/agentbundle/creds/_keychain_macos.py
+++ b/packages/agentbundle/agentbundle/creds/_keychain_macos.py
@@ -70,7 +70,22 @@ def read_credential(namespace: str, key: str) -> str | None:
 def write_credential(namespace: str, key: str, value: str) -> None:
     """Write ``value`` to ``(namespace, key)``. Token enters via child stdin
     only — never argv (spec § AC6, AC7).
+
+    Refuses values containing ``\\n`` or ``\\r`` up front. ``security -w``
+    prompts twice and the stdin payload is ``token + b"\\n" + token + b"\\n"``;
+    a token containing a newline mismatches the confirmation and
+    ``security`` silently stores an empty password. Tier-3 dotfile quoting
+    (``_quote_for_dotfile``) likewise cannot safely round-trip embedded
+    newlines. One early refusal beats two silent corruption paths.
     """
+    if "\n" in value or "\r" in value:
+        raise Tier2HardFailError(
+            f"macOS Keychain write refused for {_account(namespace, key)!r}: "
+            f"token value contains an embedded newline (\\n or \\r). The "
+            f"`security -w` re-prompt confirmation and Tier-3 dotfile "
+            f"quoting both break on newlines; strip or replace the "
+            f"character before writing."
+        )
     argv = [
         SECURITY_BIN, "add-generic-password",
         "-U",  # upsert: replace if entry already exists

--- a/packages/agentbundle/agentbundle/creds/loader.py
+++ b/packages/agentbundle/agentbundle/creds/loader.py
@@ -556,12 +556,33 @@ class EnvParseError(ValueError):
     """
 
 
+#: Upper bound on dotfile size. A credentials dotfile holds a few
+#: dozen key=value lines; 1 MiB is six orders of magnitude over the
+#: realistic ceiling. A larger file is either corruption or a
+#: misplaced read against the wrong path — refuse rather than load
+#: gigabytes into memory on every credential resolution.
+DOTFILE_MAX_BYTES = 1 << 20  # 1 MiB
+
+
 def parse_env_file(path: pathlib.Path) -> dict[str, str]:
     """Parse the file at ``path`` into a ``{KEY: value}`` mapping.
 
     Reads with ``newline=""`` so embedded ``\\r`` bytes are preserved;
     only the trailing line terminator is stripped.
+
+    Refuses files larger than ``DOTFILE_MAX_BYTES`` (1 MiB) to bound
+    the read against a misconfigured or malicious dotfile path.
     """
+    try:
+        size = path.stat().st_size
+    except OSError:
+        size = 0
+    if size > DOTFILE_MAX_BYTES:
+        raise EnvParseError(
+            f"dotfile {path!s} is {size} bytes; refusing to read more than "
+            f"{DOTFILE_MAX_BYTES} bytes — verify the path is the credentials "
+            f"dotfile, not a misconfigured target."
+        )
     text = path.read_text(encoding="utf-8", newline="")
     result: dict[str, str] = {}
     for lineno, raw in enumerate(text.split("\n"), start=1):

--- a/packs/core/.apm/skills/add-credentialed-skill/SKILL.md
+++ b/packs/core/.apm/skills/add-credentialed-skill/SKILL.md
@@ -99,6 +99,15 @@ slash command) reports findings on:
   whose normalised name matches the banned set. Casing variants and
   `"--" + "name"` literal concatenation are caught; deeper obfuscation
   is out of scope.
+- **Argparse-only scope.** The lint walks `argparse.ArgumentParser.add_argument`
+  calls; it does NOT see `click.option(...)`, `typer.Option(...)`,
+  decorator-style flag declarations, f-string flag names, `*args`-spread
+  forms, or other dynamic shapes. If your credentialed-CLI primitive
+  uses `click` or `typer`, the lint reports zero findings and PR review
+  is the only enforcement. Prefer `argparse` for credentialed-CLI
+  primitives so the lint can do its job; if you reach for `click` or
+  `typer` anyway, name the choice in the PR description so reviewers
+  know to spot-check the flag set by hand.
 - Any `scripts/**/*.py` line containing `.agent-ready/credentials.env`
   without the opt-out marker `# credentialed-primitive: reads-creds-directly`
   on the same line.


### PR DESCRIPTION
## Summary

Security-review round 1 Concerns from `docs/specs/skill-secrets/notes/review-round1-security.md`.

## What changed

- **Concern #1** — macOS `_keychain_macos.write_credential` refuses tokens containing `\n` or `\r` up front. `security -w` re-prompts and the stdin payload doubles the token; embedded newlines mismatch confirmation and `security` silently stores an empty password. Tier-3 dotfile quoting likewise breaks. One early refusal beats two silent corruption paths.
- **Concern #5** — new `DOTFILE_MAX_BYTES = 1 MiB` ceiling in `parse_env_file`. A larger file is corruption or a misconfigured read path; raise `EnvParseError` rather than allocate gigabytes per credential resolution.
- **Concern #6** — SECURITY block-comment above `--allow-insecure-fallback` / `--allow-permissive-acl` declarations forbidding any env-var or TOML-config equivalent. Posture lowering must be visible in argv; widening requires an RFC amendment.
- **Concern #2** — argparse-only scope note in `add-credentialed-skill/SKILL.md`. The lint walker matches `argparse.ArgumentParser.add_argument` only; click / typer / decorator / f-string / `*args`-spread shapes are not seen.

## Out of scope (deferred)

- **Concern #3** — USERPROFILE+HOME autouse fixture for Windows tests (no `windows-latest` CI matrix yet).
- **Concern #4** — `icacls` SID-based matching for non-English Windows locales (Windows-only, deeper refactor).
- **Concern #7** — `creds rm` continue-on-tier2-fail.

## Test plan

- [x] `make build-check` clean
- [x] Full creds test suite passes (146+ tests across unit + integration)