### PR TITLE
fix(skill-secrets): AC22 macOS exit-code symbolic matrix

### DIFF
--- a/packages/agentbundle/agentbundle/creds/_keychain_macos.py
+++ b/packages/agentbundle/agentbundle/creds/_keychain_macos.py
@@ -36,9 +36,59 @@ SERVICE = "agent-ready"
 # keychain-positional approach to test isolation; the service-prefix
 # approach lets the canonical AC6 argv shape stay untouched.
 
-# errSecItemNotFound (44) — legitimate "no such credential", falls
-# through to Tier 3 per AC4 / AC11's macOS-side matrix in AC22.
+# macOS Security framework OSStatus codes (spec § AC22):
+#   44      errSecItemNotFound          — legitimate "no such credential",
+#                                         falls through to Tier 3.
+#   45      errSecDuplicateItem         — only relevant on add; the ``-U``
+#                                         upsert flag means we never see it.
+#   25308   errSecInteractionNotAllowed — Keychain locked / no UI.
+#   -25291  errSecNotAvailable          — Keychain service unavailable.
+#
+# Names taken from ``<Security/SecBase.h>``. The two "Keychain locked /
+# unavailable" codes (25308 / -25291) MUST raise ``Tier2HardFailError``
+# so ``run_setup`` can route the AC22 fallback gate — silently
+# degrading to Tier 3 defeats the security posture the user chose.
 EXIT_NOT_FOUND = 44
+EXIT_DUPLICATE_ITEM = 45
+EXIT_INTERACTION_NOT_ALLOWED = 25308
+EXIT_NOT_AVAILABLE = -25291
+
+
+def _classify_macos_exit_code(rc: int, op: str) -> str | None:
+    """Map a ``security`` exit code to a symbolic name string.
+
+    Returns the symbolic name (e.g. ``"errSecInteractionNotAllowed
+    (25308) — Keychain locked or no UI available"``) so the caller can
+    embed it in a ``Tier2HardFailError`` message. Returns ``None`` for
+    ``EXIT_NOT_FOUND`` (the caller treats that as a legitimate miss).
+
+    Parallel in shape to ``_credman_windows._classify_last_error``;
+    AC22 cites this matrix explicitly.
+    """
+    if rc == 0:
+        return None
+    if rc == EXIT_NOT_FOUND:
+        return None
+    if rc == EXIT_INTERACTION_NOT_ALLOWED:
+        return (
+            f"errSecInteractionNotAllowed ({EXIT_INTERACTION_NOT_ALLOWED}) "
+            f"— Keychain locked or no UI available"
+        )
+    if rc == EXIT_NOT_AVAILABLE:
+        return (
+            f"errSecNotAvailable ({EXIT_NOT_AVAILABLE}) "
+            f"— Keychain service unavailable"
+        )
+    if rc == EXIT_DUPLICATE_ITEM:
+        # The ``-U`` upsert flag means add-generic-password should never
+        # surface this; document anyway so a future argv change that
+        # drops ``-U`` produces a readable error rather than a generic
+        # "rc=45".
+        return (
+            f"errSecDuplicateItem ({EXIT_DUPLICATE_ITEM}) "
+            f"— entry already exists (missing ``-U`` upsert flag?)"
+        )
+    return f"security exit code {rc}"
 
 
 def _account(namespace: str, key: str) -> str:
@@ -58,10 +108,12 @@ def read_credential(namespace: str, key: str) -> str | None:
     if proc.returncode == EXIT_NOT_FOUND:
         return None
     if proc.returncode != 0:
-        msg = proc.stderr.strip() or proc.stdout.strip()
+        symbolic = _classify_macos_exit_code(proc.returncode, "read")
+        stderr = proc.stderr.strip() or proc.stdout.strip()
         raise Tier2HardFailError(
-            f"macOS Keychain read failed for {_account(namespace, key)!r} "
-            f"(rc={proc.returncode}): {msg}"
+            f"macOS Keychain read failed for {_account(namespace, key)!r}: "
+            f"{symbolic}"
+            + (f": {stderr}" if stderr else "")
         )
     # ``security -w`` prints the password to stdout, then a newline.
     return proc.stdout.rstrip("\n")
@@ -108,10 +160,12 @@ def write_credential(namespace: str, key: str, value: str) -> None:
     stdin_payload = token_bytes + b"\n" + token_bytes + b"\n"
     _, err = proc.communicate(input=stdin_payload)
     if proc.returncode != 0:
-        msg = err.decode("utf-8", errors="replace").strip()
+        symbolic = _classify_macos_exit_code(proc.returncode, "write")
+        stderr = err.decode("utf-8", errors="replace").strip()
         raise Tier2HardFailError(
-            f"macOS Keychain write failed for {_account(namespace, key)!r} "
-            f"(rc={proc.returncode}): {msg}"
+            f"macOS Keychain write failed for {_account(namespace, key)!r}: "
+            f"{symbolic}"
+            + (f": {stderr}" if stderr else "")
         )
 
 
@@ -126,7 +180,9 @@ def delete_credential(namespace: str, key: str) -> None:
     if proc.returncode == EXIT_NOT_FOUND:
         return
     if proc.returncode != 0:
+        symbolic = _classify_macos_exit_code(proc.returncode, "delete")
+        stderr = proc.stderr.strip()
         raise Tier2HardFailError(
-            f"macOS Keychain delete failed (rc={proc.returncode}): "
-            f"{proc.stderr.strip()}"
+            f"macOS Keychain delete failed: {symbolic}"
+            + (f": {stderr}" if stderr else "")
         )

--- a/packages/agentbundle/tests/unit/test_keychain_macos_logic.py
+++ b/packages/agentbundle/tests/unit/test_keychain_macos_logic.py
@@ -1,0 +1,144 @@
+"""macOS Keychain Tier-2 backend — pure-logic tests (spec § AC22).
+
+Parallel in shape to ``test_credman_windows_logic.py``: covers the
+exit-code classifier matrix and the account-label format on every
+platform. The actual ``security`` subprocess round-trip is exercised
+on the developer's macOS box via ``tests/integration/test_keychain_macos.py``
+(gated on ``sys.platform == "darwin"``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentbundle.creds import _keychain_macos as km
+from agentbundle.creds.exceptions import Tier2HardFailError
+
+
+def test_account_label_format():
+    """AC6: account label is ``<namespace>:<key>``."""
+    assert km._account("jira", "API_TOKEN") == "jira:API_TOKEN"
+    assert km._account("ns", "K") == "ns:K"
+
+
+def test_classify_zero_returns_none():
+    """Success — caller treats ``None`` as "no error to embed"."""
+    assert km._classify_macos_exit_code(0, "read") is None
+
+
+def test_classify_not_found_returns_none():
+    """AC22: ``44`` (errSecItemNotFound) is a legitimate miss; caller
+    short-circuits before calling the classifier in read/delete paths,
+    but the classifier itself also returns ``None`` so a defensive call
+    doesn't spuriously raise."""
+    assert km._classify_macos_exit_code(km.EXIT_NOT_FOUND, "read") is None
+
+
+def test_classify_interaction_not_allowed_names_symbolic():
+    """AC22: ``25308`` (errSecInteractionNotAllowed) — Keychain locked.
+    The classifier returns a symbolic name string so the
+    ``Tier2HardFailError`` message embeds it.
+    """
+    msg = km._classify_macos_exit_code(km.EXIT_INTERACTION_NOT_ALLOWED, "read")
+    assert msg is not None
+    assert "errSecInteractionNotAllowed" in msg
+    assert "25308" in msg
+
+
+def test_classify_not_available_names_symbolic():
+    """AC22: ``-25291`` (errSecNotAvailable) — Keychain service unavailable."""
+    msg = km._classify_macos_exit_code(km.EXIT_NOT_AVAILABLE, "write")
+    assert msg is not None
+    assert "errSecNotAvailable" in msg
+    assert "-25291" in msg
+
+
+def test_classify_duplicate_item_names_symbolic():
+    """AC22: ``45`` (errSecDuplicateItem) — defensive; ``-U`` upsert
+    means the write path should never surface this, but a future argv
+    change dropping ``-U`` produces a readable error."""
+    msg = km._classify_macos_exit_code(km.EXIT_DUPLICATE_ITEM, "write")
+    assert msg is not None
+    assert "errSecDuplicateItem" in msg
+    assert "45" in msg
+
+
+def test_classify_unknown_code_falls_back_to_raw():
+    """Defensive: any uncategorised non-zero rc surfaces as a hard fail
+    naming the raw exit code rather than ``None`` (silent miss)."""
+    msg = km._classify_macos_exit_code(9999, "read")
+    assert msg is not None
+    assert "9999" in msg
+
+
+@pytest.mark.parametrize(
+    "rc, expected_symbol",
+    [
+        (km.EXIT_INTERACTION_NOT_ALLOWED, "errSecInteractionNotAllowed"),
+        (km.EXIT_NOT_AVAILABLE, "errSecNotAvailable"),
+        (km.EXIT_DUPLICATE_ITEM, "errSecDuplicateItem"),
+    ],
+)
+def test_classify_matrix(rc, expected_symbol):
+    """Parametric pin on the AC22 matrix — one row per known code."""
+    msg = km._classify_macos_exit_code(rc, "read")
+    assert msg is not None
+    assert expected_symbol in msg
+
+
+def test_write_credential_embeds_symbolic_name_on_hard_fail(monkeypatch):
+    """Integration of classifier with ``write_credential``: a non-zero
+    ``security`` exit must produce a ``Tier2HardFailError`` whose
+    message embeds the symbolic name (not just the raw rc).
+
+    Fakes ``subprocess.Popen`` so this test runs on every platform.
+    """
+    class FakeProc:
+        returncode = km.EXIT_INTERACTION_NOT_ALLOWED
+
+        def communicate(self, input=None):
+            return (b"", b"User interaction is not allowed.")
+
+    monkeypatch.setattr(
+        "subprocess.Popen",
+        lambda *a, **kw: FakeProc(),
+    )
+    with pytest.raises(Tier2HardFailError) as excinfo:
+        km.write_credential("jira", "API_TOKEN", "tok-abc")
+    assert "errSecInteractionNotAllowed" in str(excinfo.value)
+    assert "25308" in str(excinfo.value)
+
+
+def test_read_credential_embeds_symbolic_name_on_hard_fail(monkeypatch):
+    """Integration of classifier with ``read_credential``: a non-zero,
+    non-``EXIT_NOT_FOUND`` exit produces a ``Tier2HardFailError``
+    embedding the symbolic name.
+    """
+    class FakeResult:
+        returncode = km.EXIT_NOT_AVAILABLE
+        stdout = ""
+        stderr = "Keychain not available"
+
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *a, **kw: FakeResult(),
+    )
+    with pytest.raises(Tier2HardFailError) as excinfo:
+        km.read_credential("jira", "API_TOKEN")
+    assert "errSecNotAvailable" in str(excinfo.value)
+    assert "-25291" in str(excinfo.value)
+
+
+def test_read_credential_returns_none_on_not_found(monkeypatch):
+    """AC22: ``EXIT_NOT_FOUND`` falls through to Tier 3 — caller sees
+    ``None``, no exception."""
+    class FakeResult:
+        returncode = km.EXIT_NOT_FOUND
+        stdout = ""
+        stderr = "The specified item could not be found in the keychain."
+
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *a, **kw: FakeResult(),
+    )
+    assert km.read_credential("jira", "API_TOKEN") is None


### PR DESCRIPTION
## Summary

Closes Adversarial Blocker #5 + Quality Concern #7 from `docs/specs/skill-secrets/notes/review-round1-{adversarial,quality}.md`.

Spec § AC22 pins a symbolic exit-code matrix for `/usr/bin/security` parallel to Windows AC11. Pre-existing implementation only knew `EXIT_NOT_FOUND = 44` and folded every other non-zero into a generic `Tier2HardFailError(rc=X)`, so a locked-Keychain stderr message was indistinguishable from any other Tier-2 failure.

This PR adds module constants and a `_classify_macos_exit_code(rc, op)` helper parallel in shape to `_credman_windows._classify_last_error`. The helper returns a symbolic-name string that `read_credential` / `write_credential` / `delete_credential` embed in the `Tier2HardFailError` message.

No behavior change for the existing `--allow-insecure-fallback` flow — `run_setup` already routes any `Tier2HardFailError` to exit 3.

| rc | symbolic | disposition |
| --- | --- | --- |
| `0` | success | n/a |
| `44` | `errSecItemNotFound` | falls through to Tier 3 |
| `45` | `errSecDuplicateItem` | `-U` upsert means writes never see this (defensive) |
| `25308` | `errSecInteractionNotAllowed` | hard fail unless `--allow-insecure-fallback` |
| `-25291` | `errSecNotAvailable` | hard fail unless `--allow-insecure-fallback` |
| other non-zero | raw rc | hard fail naming the exit code |

## Test plan

- [x] `make build-check` clean locally
- [x] New `tests/unit/test_keychain_macos_logic.py` covers each row of the AC22 matrix + classifier ↔ `read_credential` / `write_credential` integration via fake `subprocess` (13 tests)
- [x] Full suite: 771 passed, 10 skipped