### PR TITLE
fix(skill-secrets): name tier-by-tier why-missed in CredentialsMissingError

### DIFF
--- a/packages/agentbundle/agentbundle/creds/exceptions.py
+++ b/packages/agentbundle/agentbundle/creds/exceptions.py
@@ -13,7 +13,36 @@ from __future__ import annotations
 
 
 class CredentialsMissingError(Exception):
-    """Raised when a required credential key cannot be resolved at any tier."""
+    """Raised when a required credential key cannot be resolved at any tier.
+
+    Carries structured per-key tier diagnostics so programmatic callers can
+    render their own remediation; the default ``str()`` form (built by
+    ``load_credentials``) embeds the per-key trailer for human readers.
+
+    Attributes:
+        namespace: the namespace requested.
+        missing: the list of keys that did not resolve.
+        tiers_tried: ``{key: [trailer_line, ...]}`` — for each missing
+            key, an ordered list of strings describing which tier was
+            checked and why it missed. ``trailer_line`` shape is
+            ``"<tier-label>: <reason>"`` (e.g. ``"Tier 1 env
+            'JIRA_API_TOKEN' not set"``, ``"Tier 2 macOS Keychain: not
+            present"``, ``"Tier 3 dotfile /home/u/.agent-ready/credentials.env
+            absent"``).
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        namespace: str | None = None,
+        missing: list[str] | None = None,
+        tiers_tried: dict[str, list[str]] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.namespace = namespace
+        self.missing = list(missing) if missing else []
+        self.tiers_tried = dict(tiers_tried) if tiers_tried else {}
 
 
 class Tier2HardFailError(Exception):

--- a/packages/agentbundle/agentbundle/creds/loader.py
+++ b/packages/agentbundle/agentbundle/creds/loader.py
@@ -355,6 +355,15 @@ def _dotfile_delete(namespace: str, key: str) -> None:
         raise
 
 
+def _tier2_backend_label() -> str:
+    """Human-readable label for the Tier-2 backend on this platform."""
+    if sys.platform == "darwin":
+        return "macOS Keychain"
+    if sys.platform == "win32":
+        return "Windows Credential Manager"
+    return "(no Tier-2 backend on this platform)"
+
+
 def load_credentials(
     namespace: str,
     required_keys: list[str],
@@ -368,8 +377,11 @@ def load_credentials(
     namespace is permitted.
 
     Raises ``CredentialsMissingError`` if any required key did not
-    resolve at any tier. The error message names the namespace and the
-    list of missing keys per AC3.
+    resolve at any tier. The exception carries a ``tiers_tried``
+    attribute mapping each missing key to an ordered list of trailer
+    lines (which tier was checked and why it missed); the default
+    ``str()`` form embeds those trailers under the key name so a
+    user who ran ``creds setup`` can triage from the message alone.
 
     The ``schema_path`` kwarg is reserved for T7 — primitive authors who
     load their own schema can pass it here; the default ``None`` defers
@@ -377,20 +389,66 @@ def load_credentials(
     """
     resolved: dict[str, str] = {}
     missing: list[str] = []
+    tiers_tried: dict[str, list[str]] = {}
+    dotfile_path = _dotfile_path()
+    dotfile_present = dotfile_path.is_file()
+    backend_label = _tier2_backend_label()
     for key in required_keys:
-        value = (
-            _tier1_env(namespace, key)
-            or _tier2(namespace, key)
-            or _tier3(namespace, key)
-        )
-        if value:
-            resolved[key] = value
+        attempts: list[str] = []
+        env_name = f"{namespace.upper()}_{key}"
+
+        # Tier 1 — env var.
+        v = _tier1_env(namespace, key)
+        if v:
+            resolved[key] = v
+            continue
+        attempts.append(f"Tier 1: env {env_name!r} not set")
+
+        # Tier 2 — OS keyring (when loaded). Tier2HardFailError
+        # propagates per AC11 (no silent fallback to Tier 3 on hard
+        # fail); only a clean miss falls through.
+        if _tier2_backend is None:
+            attempts.append("Tier 2: not loaded (no keyring backend on this platform)")
         else:
-            missing.append(key)
+            v = _tier2_backend.read_credential(namespace, key)
+            if v:
+                resolved[key] = v
+                continue
+            attempts.append(f"Tier 2: {backend_label} — entry not present")
+
+        # Tier 3 — dotfile.
+        v = _tier3(namespace, key)
+        if v:
+            resolved[key] = v
+            continue
+        if dotfile_present:
+            attempts.append(
+                f"Tier 3: dotfile {dotfile_path} present but "
+                f"{_dotfile_env_name(namespace, key)!r} not in it"
+            )
+        else:
+            attempts.append(f"Tier 3: dotfile {dotfile_path} absent")
+
+        missing.append(key)
+        tiers_tried[key] = attempts
+
     if missing:
-        raise CredentialsMissingError(
+        # One-line preamble preserves the AC3 contract (message names
+        # namespace and the missing-keys list); the per-key trailer
+        # block comes below for triage.
+        lines = [
             f"namespace {namespace!r}: missing required credential(s): "
             f"{', '.join(missing)}"
+        ]
+        for key in missing:
+            lines.append(f"  {key}:")
+            for trailer in tiers_tried[key]:
+                lines.append(f"    {trailer}")
+        raise CredentialsMissingError(
+            "\n".join(lines),
+            namespace=namespace,
+            missing=missing,
+            tiers_tried=tiers_tried,
         )
     return Credentials(namespace, resolved)
 

--- a/packages/agentbundle/tests/unit/test_credentials_dotfile.py
+++ b/packages/agentbundle/tests/unit/test_credentials_dotfile.py
@@ -202,3 +202,76 @@ def test_value_with_spaces_round_trips_via_quoting(tmp_path):
     """Values containing spaces round-trip via the parser's quoted form."""
     loader._dotfile_write("fixture_t6", "BASE_URL", "https://jira example com")
     assert loader._dotfile_read("fixture_t6", "BASE_URL") == "https://jira example com"
+
+
+def test_credentials_missing_names_tiers_tried_no_dotfile(tmp_path):
+    """Quality Concern #6: ``CredentialsMissingError`` names per-key
+    which tier was checked and why. With no Tier-1 env, no Tier-2
+    backend, and no Tier-3 dotfile on disk, the trailers must surface
+    all three reasons."""
+    with pytest.raises(CredentialsMissingError) as exc:
+        load_credentials("fixture_t6", required_keys=["API_TOKEN", "BASE_URL"])
+    msg = str(exc.value)
+    # Preamble preserves the AC3 contract.
+    assert "fixture_t6" in msg
+    assert "API_TOKEN" in msg
+    assert "BASE_URL" in msg
+    # Per-key trailer names the missing tier-1 env var by full name.
+    assert "FIXTURE_T6_API_TOKEN" in msg
+    assert "FIXTURE_T6_BASE_URL" in msg
+    # Tier 2 trailer reports "not loaded" since the fixture nukes the
+    # backend.
+    assert "Tier 2:" in msg
+    assert "not loaded" in msg
+    # Tier 3 trailer names the dotfile path and "absent".
+    assert "Tier 3:" in msg
+    assert ".agent-ready" in msg
+    assert "absent" in msg
+    # Structured attribute carries the same info programmatically.
+    assert exc.value.namespace == "fixture_t6"
+    assert set(exc.value.missing) == {"API_TOKEN", "BASE_URL"}
+    assert "API_TOKEN" in exc.value.tiers_tried
+    assert "BASE_URL" in exc.value.tiers_tried
+    assert len(exc.value.tiers_tried["API_TOKEN"]) == 3
+    assert len(exc.value.tiers_tried["BASE_URL"]) == 3
+
+
+def test_credentials_missing_names_dotfile_present_when_file_exists(tmp_path):
+    """When the Tier-3 dotfile exists but doesn't carry the key, the
+    trailer says ``present but ... not in it`` so the user understands
+    Tier 3 was reached but missed — different from absent."""
+    # Write some other key so the file is on disk.
+    loader._dotfile_write("fixture_t6", "OTHER_KEY", "x")
+    with pytest.raises(CredentialsMissingError) as exc:
+        load_credentials("fixture_t6", required_keys=["API_TOKEN"])
+    msg = str(exc.value)
+    assert "Tier 3:" in msg
+    assert "present but" in msg
+    assert "FIXTURE_T6_API_TOKEN" in msg
+
+
+def test_load_credentials_mixes_tiers_across_keys(tmp_path, monkeypatch):
+    """Quality Concern #5 (AC4 cross-tier composability): one key resolves
+    at Tier 1, another at Tier 2, another at Tier 3 — all three arrive on
+    the ``Credentials`` object with values from the right sources.
+
+    Uses a fake Tier-2 backend so the test runs on every platform.
+    """
+    class FakeTier2:
+        @staticmethod
+        def read_credential(namespace, key):
+            if namespace == "fixture_t6" and key == "BASE_URL":
+                return "from-tier2-keyring"
+            return None
+
+    monkeypatch.setattr(loader, "_tier2_backend", FakeTier2)
+    monkeypatch.setenv("FIXTURE_T6_API_TOKEN", "from-tier1-env")
+    loader._dotfile_write("fixture_t6", "FLAVOR", "from-tier3-dotfile")
+
+    creds = load_credentials(
+        "fixture_t6",
+        required_keys=["API_TOKEN", "BASE_URL", "FLAVOR"],
+    )
+    assert creds.API_TOKEN == "from-tier1-env"
+    assert creds.BASE_URL == "from-tier2-keyring"
+    assert creds.FLAVOR == "from-tier3-dotfile"


### PR DESCRIPTION
## Summary

Closes Quality Concerns #5 + #6 from `docs/specs/skill-secrets/notes/review-round1-quality.md`.

Previously, `CredentialsMissingError`'s message was just `"namespace 'jira': missing required credential(s): API_TOKEN, BASE_URL"` — a user who ran `creds setup` could not triage whether Tier 1 was skipped (typo in env-var name?), Tier 2 hit but returned empty, Tier 3's dotfile was missing, or some combination.

Extend `load_credentials` to track which tier was checked per key and why it missed. The exception now embeds a per-key trailer block under the AC3 preamble:

```
namespace 'jira': missing required credential(s): API_TOKEN, BASE_URL
  API_TOKEN:
    Tier 1: env 'JIRA_API_TOKEN' not set
    Tier 2: macOS Keychain — entry not present
    Tier 3: dotfile /Users/u/.agent-ready/credentials.env absent
  BASE_URL:
    …
```

`CredentialsMissingError` gains three structured attributes (`namespace`, `missing`, `tiers_tried`) so programmatic callers can render their own remediation without parsing the message. `Tier 2: ... entry not present` (clean miss) is distinct from `Tier2HardFailError` (which still propagates per AC11).

Adds three tests in `tests/unit/test_credentials_dotfile.py`:

- `test_credentials_missing_names_tiers_tried_no_dotfile` — all three trailers, attribute shape pinned.
- `test_credentials_missing_names_dotfile_present_when_file_exists` — trailer distinguishes "absent" from "present but key not in it".
- `test_load_credentials_mixes_tiers_across_keys` — **AC4 cross-tier composability** (Quality Concern #5): one key from Tier 1, another from a fake Tier-2 backend, a third from Tier 3.

## Test plan

- [x] `make build-check` clean locally
- [x] Full suite: 761 passed, 10 skipped
- [x] AC3 contract preserved — message still names the namespace and the missing-keys list (existing tests pass)