### PR TITLE
docs(skill-secrets): inline-fixture amendment, release-checklist, ROADMAP audit

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,7 +14,7 @@ line under `make build-check` per AC6 of the self-hosting spec.
 For shipped work, see [`product/changelog.md`](product/changelog.md)
 and each spec's own Changelog section.
 
-**Last updated:** 2026-05-24 (closed `skill-secrets` — all T1–T13c shipped; status flipped Draft → Shipped; only AC34/AC35 inheritance invariants and the post-implementation "Credential storage" ADR remain as cross-spec items; recorded the v0.1-vs-RFC-0001 Tier-2 prompt gap under `agent-spec-cli`)
+**Last updated:** 2026-05-24 (closed `skill-secrets` — all T1–T13c shipped; status flipped Draft → Shipped. Round-1 end-of-spec review fixes landed via PRs #81/#82/#83; round-2 review-pass follow-ons (windows-latest CI matrix, AC22 macOS symbolic exit-code matrix, `CredentialsMissingError` tier observability, robustness pass, lint widening) landing as separate focused PRs. AC34/AC35 inheritance invariants and the post-implementation "Credential storage" ADR remain as cross-spec items; recorded the v0.1-vs-RFC-0001 Tier-2 prompt gap under `agent-spec-cli`.)
 
 ## How this file is maintained
 
@@ -238,7 +238,10 @@ Per-task closure (15 tasks; T13 split into T13a/T13b/T13c):
 - [x] **T7** — `creds-schema.toml` parser + canonical-path resolution
       (closed AC24, AC24b).
 - [x] **T8** — `agentbundle creds` CLI verb; tombstone args; per-platform
-      exit-code matrices (closed AC16–AC23).
+      exit-code matrices (closed AC16–AC23). AC22's macOS symbolic
+      exit-code matrix was completed in a round-2 follow-on PR alongside
+      a Windows CI matrix; see the *Round-2 review-pass disposition*
+      section below for the merge SHAs.
 - [x] **T9** — SKILL.md frontmatter + lint allow-list (closed AC25).
 - [x] **T10** — `conventions-check` AST-walker extensions (closed
       AC26, AC27).
@@ -254,6 +257,37 @@ Per-task closure (15 tasks; T13 split into T13a/T13b/T13c):
       every future test PR that adds fixtures under
       `packages/agentbundle/tests/fixtures/creds/`.
 
+Round-2 review-pass disposition (post-Shipped):
+
+The end-of-spec review pass surfaced items that didn't warrant
+re-opening Shipped status but did warrant focused follow-on PRs.
+Captured here so a future ROADMAP reader can see the disposition:
+
+- **PR #84 — `windows-latest` CI matrix** (precursor; closes
+  Security § Not-checked "no live exercise of the Windows ctypes
+  path"). Adds the verification home AC10 / AC11 / AC15 had been
+  missing.
+- **PR #85 — AC22 macOS symbolic exit-code matrix** (closes
+  Adversarial Blocker #5 + Quality Concern #7). Adds module
+  constants and `_classify_macos_exit_code` parallel to the Windows-
+  side classifier; embeds the symbolic name in `Tier2HardFailError`
+  messages. No behavior change to the existing
+  `--allow-insecure-fallback` flow.
+- **PR #86 — `CredentialsMissingError` tier observability**
+  (closes Quality Concerns #5 + #6). Per-key tier trailers + structured
+  attributes; adds the AC4 cross-tier composability construction test.
+- **Robustness pass** — per-finding micro-fixes (`Credentials.__repr__`,
+  `Credentials.__getattr__` resolved-keys hint, `_quote_for_dotfile`
+  raises on unsafe chars, `EnvParseError` ordering, `credentialed:`
+  YAML normalisation, `_resolve_schema_path` rename, `creds rm`
+  continue-on-Tier-2-fail, AC23 stderr-prefix categorisation).
+- **Lint widening** — AST walker f-string / Starred(Tuple) /
+  Subscript shapes; `icacls` SID-based matching to harden non-English
+  Windows installs.
+- **Spec / plan / doc cleanup** — inline-fixture amendment;
+  `docs/product/release-checklist.md` for the three Windows manual-QA
+  rows; this very ROADMAP audit.
+
 Open follow-ons (not gating shipped status):
 
 - **New ADR ("Credential storage for credentialed skills") is
@@ -264,6 +298,11 @@ Open follow-ons (not gating shipped status):
   adopter-profile audit per RFC-0006 § Unresolved Q1; not gating
   v1 (Linux lands on Tier 3 floor). The `v2-libsecret` stub stays
   open under cross-spec items below.
+- **`load_credentials(schema_path=...)` no-op kwarg.** AC24b promises
+  the kwarg for primitive authors who load their own schema, but the
+  loader currently ignores it. Round-2 surfaced the gap (Quality
+  Blocker #4); choice between removing the kwarg vs. wiring schema
+  validation pending user direction.
 
 ---
 

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -14,6 +14,10 @@
   every PR that changes user-visible behavior.
 - [`personas.md`](personas.md) — who we're building for. Optional;
   add only if it's actively used to make decisions.
+- [`release-checklist.md`](release-checklist.md) — manual-QA rows
+  CI cannot exercise. Copy each spec's section into the release PR
+  description before tagging. Optional; add the file the first time a
+  spec needs out-of-band verification.
 
 ## What does NOT live here
 

--- a/docs/product/release-checklist.md
+++ b/docs/product/release-checklist.md
@@ -1,0 +1,48 @@
+# Release checklist
+
+> Manual-QA rows that GitHub Actions cannot exercise. Run through this
+> before tagging a release; tick each row in the release PR description.
+
+This file is *living* — every spec whose work needs out-of-band
+verification should add a row here. The header for a spec's rows is the
+spec slug; the row body is the exact behavior being verified.
+
+## How to use this checklist
+
+1. On the release branch, copy each section's checkbox block into the
+   release PR description.
+2. Run the manual exercise on a fresh machine where the spec applies
+   (Windows VM, fresh macOS user, …).
+3. Tick the box only when the exercise actually passes. A row that
+   fails is a release blocker — file an issue, do not silently leave
+   the box unchecked.
+
+## skill-secrets (RFC-0006 / `docs/specs/skill-secrets/spec.md`)
+
+The skill-secrets spec carries three Windows-specific behaviors that
+GitHub Actions cannot exercise (no real PTY, single-session runner,
+no `LocalSystem` service-account context). Each must be hand-verified
+on a Windows host before the spec's work ships in a release.
+
+- [ ] **`getpass.getpass` real-tty refusal** — on a Windows
+      developer box with a real tty, run `agentbundle creds setup
+      jira` (or any namespace with a schema). The prompt MUST appear,
+      MUST hide the typed token (no echo), and the resulting Tier-2
+      entry MUST round-trip via `agentbundle creds where jira`. CI
+      unit tests monkeypatch `sys.stdin.isatty`; only the real tty
+      path is hand-verified.
+- [ ] **`CRED_PERSIST_LOCAL_MACHINE` survives logoff** — on a Windows
+      box, run `agentbundle creds setup <namespace>`, log out, log
+      back in, run `agentbundle creds where <namespace>`. The entry
+      MUST still resolve at Tier 2 (CI runners are single-session and
+      can't exercise this).
+- [ ] **`ERROR_NO_SUCH_LOGON_SESSION` under `LocalSystem`** — schedule
+      a Windows Task Scheduler job running as `LocalSystem` that
+      invokes `agentbundle creds where <namespace>`. The task MUST
+      exit 3 with stderr naming `ERROR_NO_SUCH_LOGON_SESSION (1312)`
+      — proving the resolver does *not* silently fall through to
+      Tier 3 in a no-logon-session context (AC11 / Boundaries §
+      "No silent fallback from hard-fail Win32 error codes").
+
+Cross-ref: `docs/specs/skill-secrets/spec.md` § Testing Strategy
+"Visual / manual QA" bullet group.

--- a/docs/specs/skill-secrets/spec.md
+++ b/docs/specs/skill-secrets/spec.md
@@ -259,28 +259,31 @@ Three verification modes mapped per Objective behavior:
     context (needs scheduled-task runner CI doesn't provide;
     manual-QA row).
 
-  Each manual-QA row carries a release-checklist line.
+  Each manual-QA row carries a release-checklist line in
+  [`docs/product/release-checklist.md`](../../product/release-checklist.md)
+  under the `skill-secrets` section.
 
-**Fixture-driven tests** are the load-bearing shape:
+**Construction tests inline the parser inputs** via `tmp_path` heredocs
+rather than checked-in fixture files. The two parser shapes that
+demand a fixture-tree share (the `conventions-check` skill fixtures,
+which the walker discovers by path) live under
+`packages/agentbundle/tests/fixtures/creds/skills/`; everything else
+(schema TOMLs, valid / quoted / CRLF / comment dotfile shapes) is
+constructed in the test body so the corpus stays self-describing
+under the orphan-fixture walker (AC34):
 
-- `packages/agentbundle/tests/fixtures/creds/schema-valid/creds-schema.toml`
-  — a minimal valid schema (one required key, one optional sibling).
-- `packages/agentbundle/tests/fixtures/creds/schema-missing-required/`
-  — refuses with the specified text.
-- `packages/agentbundle/tests/fixtures/creds/dotfile-valid.env` /
-  `dotfile-quoted.env` / `dotfile-crlf.env` / `dotfile-comment.env`
-  — the four parser shapes.
-- `packages/agentbundle/tests/fixtures/creds/skills/conforming/` —
-  a fake credentialed skill with the "Don't" block and
-  `credentialed: true` frontmatter; `conventions-check` reports clean.
-- `packages/agentbundle/tests/fixtures/creds/skills/missing-dont-block/`
-  — `conventions-check` reports the missing block.
-- `packages/agentbundle/tests/fixtures/creds/skills/argv-flag/scripts/cli.py`
-  — accepts `--token` in `argparse`; `conventions-check` reports the
-  argv ban violation.
-- `packages/agentbundle/tests/fixtures/creds/skills/dotfile-grep/scripts/leak.py`
-  — opens the dotfile path directly without the opt-out comment;
-  `conventions-check` reports the architectural violation.
+- **Inlined via `tmp_path`:** schema-valid and schema-missing-required
+  TOMLs, the four parser-shape dotfiles
+  (`dotfile-valid` / `dotfile-quoted` / `dotfile-crlf` /
+  `dotfile-comment`). The full text appears in the test that exercises
+  it; no orphan-fixture risk.
+- **Checked-in under `tests/fixtures/creds/`:** the four
+  `conventions-check` skill fixtures —
+  `skills/conforming/`,
+  `skills/missing-dont-block/`,
+  `skills/argv-flag/scripts/cli.py`,
+  `skills/dotfile-grep/scripts/leak.py` — because the lint walker
+  resolves them by directory path during its scan.
 
 Every Acceptance Criterion below maps to at least one
 construction-test or fixture exercise.

--- a/packs/core/seeds/docs/product/README.md
+++ b/packs/core/seeds/docs/product/README.md
@@ -14,6 +14,10 @@
   every PR that changes user-visible behavior.
 - [`personas.md`](personas.md) — who we're building for. Optional;
   add only if it's actively used to make decisions.
+- [`release-checklist.md`](release-checklist.md) — manual-QA rows
+  CI cannot exercise. Copy each spec's section into the release PR
+  description before tagging. Optional; add the file the first time a
+  spec needs out-of-band verification.
 
 ## What does NOT live here
 


### PR DESCRIPTION
## Summary

Three documentation-only fixes bundled per the round-2 prompt.

**Inline-fixture amendment** (Adversarial Concern #12 + Quality Concern #10) — `docs/specs/skill-secrets/spec.md` § Testing Strategy previously named six fixtures that don't exist on disk. Rewrite the section: schema TOMLs and parser-shape dotfiles are inlined via `tmp_path` heredocs; only the four `conventions-check` skill fixtures (lint walker discovers them by path) stay checked in under `tests/fixtures/creds/skills/`. AC34's orphan-walker (PR #81) now agrees with the spec body.

**Release-checklist artifact** (Quality Concern #8) — add `docs/product/release-checklist.md` carrying the three Windows manual-QA rows the spec promised (`getpass.getpass` real-tty refusal; `CRED_PERSIST_LOCAL_MACHINE` survives logoff; `ERROR_NO_SUCH_LOGON_SESSION` under `LocalSystem`). Seed README under `packs/core/seeds/docs/product/` gets a one-line mention of the optional pattern; projected `docs/product/README.md` follows via `make build-self`.

**ROADMAP closure audit** (Adversarial Concern #13) — `docs/ROADMAP.md` § `skill-secrets — shipped` now notes AC22's symbolic matrix lands in a round-2 follow-on PR; new *Round-2 review-pass disposition* subsection enumerates the follow-on PRs (#84/#85/#86 + robustness / lint-widening / doc-cleanup batches) and the open `schema_path` decision. "Last updated" line dropped the "only AC34/AC35 remain" framing that the round-2 review proved overstated.

Spec stays at Status: Shipped — clarifications, not re-opens.

## Test plan

- [x] `FORCE=1 make build-self` projects the README change cleanly
- [x] `make build-check` clean (no drift between seed and projected)
- [x] No code change, no test rerun needed