### PR TITLE
fix(skill-secrets): round-2 robustness pass — per-finding micro-fixes

### DIFF
--- a/packages/agentbundle/agentbundle/commands/creds.py
+++ b/packages/agentbundle/agentbundle/commands/creds.py
@@ -76,7 +76,14 @@ class _RefuseTokenArgvAction(argparse.Action):
         super().__init__(option_strings, dest, **kwargs)
 
     def __call__(self, parser, namespace, values, option_string=None):  # type: ignore[no-untyped-def]
-        sys.stderr.write(f"{_ARGV_REFUSAL_STDERR}\n")
+        # AC23 categorisation: prefix the verbatim sentinel with a
+        # distinguishing tag so security tooling can pattern-match the
+        # exit-3 category without parsing the message body. The
+        # canonical anchor itself is preserved verbatim on the same
+        # line so existing greps for it still match.
+        sys.stderr.write(
+            f"creds setup: argv-refusal: {_ARGV_REFUSAL_STDERR}\n"
+        )
         raise SystemExit(3)
 
 
@@ -262,6 +269,24 @@ def _parse_frontmatter(path: pathlib.Path) -> dict[str, str]:
     return fields
 
 
+#: YAML 1.1-style truthy forms accepted for the ``credentialed:`` key.
+#: The frontmatter parser leaves scalars verbatim (apart from balanced
+#: quote stripping), so an author writing ``credentialed: True``,
+#: ``credentialed: yes``, ``credentialed: "true"``, or ``credentialed: 1``
+#: would otherwise silently not be picked up by this walker — the
+#: skill works at runtime but ``creds setup`` never finds it. Accept
+#: the canonical YAML truthy shapes; everything else (including unset)
+#: is treated as not credentialed.
+_CREDENTIALED_TRUTHY_VALUES = frozenset({"true", "yes", "1", "on"})
+
+
+def _is_credentialed_true(raw: str | None) -> bool:
+    """Return whether the frontmatter ``credentialed:`` scalar means True."""
+    if raw is None:
+        return False
+    return raw.strip().lower() in _CREDENTIALED_TRUTHY_VALUES
+
+
 def _walk_credentialed_skills(
     root: pathlib.Path,
 ) -> list[tuple[str, pathlib.Path, str, pathlib.Path]]:
@@ -291,7 +316,7 @@ def _walk_credentialed_skills(
                     continue
                 skill_md = root / relpath
                 fields = _parse_frontmatter(skill_md)
-                if fields.get("credentialed") == "true":
+                if _is_credentialed_true(fields.get("credentialed")):
                     out.append(("repo", root, m.group(1), skill_md))
     try:
         user_root = pathlib.Path.home()
@@ -308,7 +333,7 @@ def _walk_credentialed_skills(
                     continue
                 skill_md = user_root / relpath
                 fields = _parse_frontmatter(skill_md)
-                if fields.get("credentialed") == "true":
+                if _is_credentialed_true(fields.get("credentialed")):
                     out.append(("user", user_root, m.group(1), skill_md))
     return out
 
@@ -465,8 +490,8 @@ def run_setup(args: argparse.Namespace) -> int:
             return 3
         if not sys.stdin.isatty():
             sys.stderr.write(
-                "creds setup: stdin is not a tty (selection requires "
-                "interactive prompt)\n"
+                "creds setup: stdin-not-tty: selection requires an "
+                "interactive prompt\n"
             )
             return 3
         sys.stderr.write("Installed credentialed primitives:\n")
@@ -500,7 +525,10 @@ def run_setup(args: argparse.Namespace) -> int:
     # has already rejected argv-borne flags; this guards the stdin pipe
     # path.
     if not sys.stdin.isatty():
-        sys.stderr.write("creds setup: stdin is not a tty\n")
+        sys.stderr.write(
+            "creds setup: stdin-not-tty: token entry requires an "
+            "interactive prompt\n"
+        )
         return 3
 
     values = _prompt_for_keys(schema, tty_ok=True)
@@ -663,6 +691,7 @@ def run_rm(args: argparse.Namespace) -> int:
 
     any_removed = False
     env_present_keys: list[str] = []
+    tier2_hard_fail = False
     for keydef in schema.keys:
         env_name = f"{namespace.upper()}_{keydef.name}"
         if os.environ.get(env_name):
@@ -673,8 +702,17 @@ def run_rm(args: argparse.Namespace) -> int:
                     loader._tier2_backend.delete_credential(namespace, keydef.name)
                     any_removed = True
             except Tier2HardFailError as exc:
-                sys.stderr.write(f"creds rm: Tier 2 hard fail — {exc}\n")
-                return 3
+                # Continue the walk so Tier-3 cleanup still runs: an
+                # operator invoking `creds rm` to react to a Tier-2
+                # compromise needs to clear the dotfile floor without
+                # first having to fix the Tier-2 hard-fail condition.
+                # Set a flag so the final exit code still surfaces
+                # non-zero (security review concern #7).
+                sys.stderr.write(
+                    f"creds rm: Tier 2 hard fail on {keydef.name!r} — "
+                    f"{exc}; continuing with Tier-3 cleanup\n"
+                )
+                tier2_hard_fail = True
         if loader._dotfile_read(namespace, keydef.name):
             loader._dotfile_delete(namespace, keydef.name)
             any_removed = True
@@ -684,6 +722,12 @@ def run_rm(args: argparse.Namespace) -> int:
             "creds rm: env vars cannot be cleared by this helper; unset "
             f"manually: {', '.join(env_present_keys)}\n"
         )
+
+    if tier2_hard_fail:
+        # At least one Tier-2 key surfaced a hard fail; surface non-zero
+        # so the operator knows the Tier-2 state is not in a clean
+        # post-`rm` shape even though Tier 3 was cleared.
+        return 3
 
     if not any_removed and not env_present_keys:
         sys.stderr.write(

--- a/packages/agentbundle/agentbundle/creds/loader.py
+++ b/packages/agentbundle/agentbundle/creds/loader.py
@@ -52,6 +52,80 @@ from .exceptions import (
 
 _KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
+
+class EnvParseError(ValueError):
+    """Raised when an ``.env`` file violates the supported subset.
+
+    Messages include the 1-based physical line number so a log reader
+    can jump to the offending line.
+    """
+
+
+#: Upper bound on dotfile size. A credentials dotfile holds a few
+#: dozen key=value lines; 1 MiB is six orders of magnitude over the
+#: realistic ceiling. A larger file is either corruption or a
+#: misplaced read against the wrong path — refuse rather than load
+#: gigabytes into memory on every credential resolution.
+DOTFILE_MAX_BYTES = 1 << 20  # 1 MiB
+
+
+def parse_env_file(path: pathlib.Path) -> dict[str, str]:
+    """Parse the file at ``path`` into a ``{KEY: value}`` mapping.
+
+    Reads with ``newline=""`` so embedded ``\\r`` bytes are preserved;
+    only the trailing line terminator is stripped.
+
+    Refuses files larger than ``DOTFILE_MAX_BYTES`` (1 MiB) to bound
+    the read against a misconfigured or malicious dotfile path.
+    """
+    try:
+        size = path.stat().st_size
+    except OSError:
+        size = 0
+    if size > DOTFILE_MAX_BYTES:
+        raise EnvParseError(
+            f"dotfile {path!s} is {size} bytes; refusing to read more than "
+            f"{DOTFILE_MAX_BYTES} bytes — verify the path is the credentials "
+            f"dotfile, not a misconfigured target."
+        )
+    # Use ``path.open(newline="")`` instead of ``read_text(newline=...)``
+    # — the ``newline`` keyword on ``Path.read_text`` was added in Python
+    # 3.13; the project targets 3.11+ via the CI matrix.
+    with path.open(encoding="utf-8", newline="") as fh:
+        text = fh.read()
+    result: dict[str, str] = {}
+    for lineno, raw in enumerate(text.split("\n"), start=1):
+        # Strip trailing \r (CRLF normalization). rstrip is bounded to the
+        # tail, so embedded \r inside a quoted value is preserved.
+        line = raw.rstrip("\r")
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("export "):
+            raise EnvParseError(
+                f"line {lineno}: `export KEY=value` shell-export syntax is not supported"
+            )
+        if "=" not in line:
+            raise EnvParseError(
+                f"line {lineno}: expected `KEY=value`, no '=' found"
+            )
+        key, _, value = line.partition("=")
+        key = key.strip()
+        if not _KEY_RE.match(key):
+            raise EnvParseError(f"line {lineno}: invalid key {key!r}")
+        if value.startswith('"'):
+            if len(value) < 2 or not value.endswith('"'):
+                raise EnvParseError(
+                    f"line {lineno}: multi-line quoted values are not supported"
+                )
+            value = value[1:-1]
+        if "$" in value:
+            raise EnvParseError(
+                f"line {lineno}: variable expansion (`$NAME`) is not supported"
+            )
+        result[key] = value
+    return result
+
 # Tier-2 backend dispatch at module-load time (spec § AC4b). The backend
 # modules are added by T4 (macOS) and T5 (Windows); until they land, the
 # try/except yields ``None`` and the resolver skips Tier 2 on the matching
@@ -82,8 +156,10 @@ class Credentials:
     - Attempting to assign or delete an attribute raises ``AttributeError``;
       callers cannot mutate the object after it leaves the loader.
 
-    No ``__repr__`` override — the default ``object`` repr is intentional
-    so a misplaced ``print(creds)`` never echoes the token bytes.
+    The ``__repr__`` override lists *only* key names — never values — so
+    a misplaced ``print(creds)`` or interactive REPL inspection cannot
+    echo the token bytes. Pinning the redacting contract here forecloses
+    a future maintainer adding a "debug" ``__repr__`` that leaks values.
     """
 
     __slots__ = ("_namespace", "_values")
@@ -103,6 +179,16 @@ class Credentials:
             f"Credentials is immutable; cannot delete attribute {name!r}"
         )
 
+    def __repr__(self) -> str:
+        # SECURITY: list keys only; NEVER include values. A misplaced
+        # `print(creds)` must not leak token bytes. Future maintainers:
+        # do not "improve" this with values for debugging — log the
+        # specific key you need with explicit redaction at the call site.
+        namespace = object.__getattribute__(self, "_namespace")
+        values = object.__getattribute__(self, "_values")
+        keys = list(values)
+        return f"<Credentials namespace={namespace!r} keys={keys!r}>"
+
     def __getattr__(self, name: str) -> str:
         # __getattr__ is only invoked when normal lookup (including
         # __slots__) fails — so it serves the credential-name attribute
@@ -119,8 +205,13 @@ class Credentials:
         if name in values:
             return values[name]
         namespace = object.__getattribute__(self, "_namespace")
+        # Include the resolved key list so `creds.api_token` (lowercase
+        # typo of `API_TOKEN`) errors actionably rather than just naming
+        # the bad attribute.
+        resolved = list(values)
         raise AttributeError(
-            f"namespace {namespace!r} has no credential {name!r}"
+            f"namespace {namespace!r} has no credential {name!r} "
+            f"(resolved keys: {resolved})"
         )
 
 
@@ -200,13 +291,24 @@ def _quote_for_dotfile(value: str) -> str:
     """Render a value for the dotfile.
 
     Use double-quotes only when the bare value would be ambiguous to the
-    parser (contains whitespace or a leading ``#``). Embedded double
-    quotes / dollar signs are not the user's tokens in practice — the
-    parser refuses ``$`` and embedded quotes would re-enter as ``"a"b"``
-    which the parser strips clumsily. Tokens this rejects shouldn't be
-    in scope for Tier-3 storage and the helper surfaces the parser
-    error if a round-trip would corrupt the value.
+    parser (contains whitespace or a leading ``#``). Embedded ``"`` or
+    ``$`` characters would not round-trip through the parser cleanly
+    (the parser refuses ``$`` outright and clumsily strips a single
+    surrounding pair of quotes), so this helper refuses up front by
+    raising ``EnvParseError`` rather than silently emitting an
+    unparseable entry.
     """
+    if '"' in value:
+        raise EnvParseError(
+            "value contains an embedded double-quote character; cannot "
+            "round-trip through the Tier-3 dotfile parser. Re-encode the "
+            "value (e.g. URL-encode the quote) before storing."
+        )
+    if "$" in value:
+        raise EnvParseError(
+            "value contains a `$` character; the dotfile parser refuses "
+            "variable-expansion syntax. Re-encode the value before storing."
+        )
     if not value:
         return '""'
     if " " in value or value.startswith("#"):
@@ -565,18 +667,23 @@ def _parse_schema(path: pathlib.Path) -> CredsSchema:
 _SKILL_MD_RE = re.compile(r"^\.claude/skills/([^/]+)/SKILL\.md$")
 
 
-def resolve_schema_path(
+def _relative_schema_path(
     state: "object", pack: str, skill_name: str
 ) -> pathlib.Path:
-    """Resolve the canonical ``creds-schema.toml`` path per spec § AC24b.
+    """Resolve the *state-relative* ``creds-schema.toml`` path per spec § AC24b.
 
     Walks ``state.packs[pack].files`` for a relpath matching
-    ``^\\.claude/skills/<skill_name>/SKILL\\.md$``; takes that
-    relpath's parent directory and joins ``references/creds-schema.toml``.
-    Returns the absolute path resolved against the state file's
-    container directory (caller is responsible for joining the right
-    scope root if needed; this function returns the *relative-form
-    rooted at* the path the state stored).
+    ``^\\.claude/skills/<skill_name>/SKILL\\.md$``; returns the
+    relpath's parent joined to ``references/creds-schema.toml``.
+
+    The return value is *relative* — rooted at whatever the state file
+    stored — and is NOT directly usable as a filesystem path without
+    the caller resolving it against a scope root. The
+    underscore-prefixed name reflects that contract; CLI callers go
+    through `commands/creds._resolve_schema_for_namespace` which joins
+    against `SKILL.md.parent` directly instead of calling this helper.
+    Kept around because it pins the AC24b state-walk shape with its
+    own tests.
 
     Raises ``SchemaError`` if no matching SKILL.md row is in
     ``pack.files`` — names the offending pack and skill so the message
@@ -618,6 +725,7 @@ __all__ = [
     "CredsSchema",
     "Credentials",
     "CredentialsMissingError",
+    "DOTFILE_MAX_BYTES",
     "EnvParseError",
     "KeyDef",
     "PermissiveAclError",
@@ -625,79 +733,4 @@ __all__ = [
     "Tier2HardFailError",
     "load_credentials",
     "parse_env_file",
-    "resolve_schema_path",
 ]
-
-
-class EnvParseError(ValueError):
-    """Raised when an ``.env`` file violates the supported subset.
-
-    Messages include the 1-based physical line number so a log reader
-    can jump to the offending line.
-    """
-
-
-#: Upper bound on dotfile size. A credentials dotfile holds a few
-#: dozen key=value lines; 1 MiB is six orders of magnitude over the
-#: realistic ceiling. A larger file is either corruption or a
-#: misplaced read against the wrong path — refuse rather than load
-#: gigabytes into memory on every credential resolution.
-DOTFILE_MAX_BYTES = 1 << 20  # 1 MiB
-
-
-def parse_env_file(path: pathlib.Path) -> dict[str, str]:
-    """Parse the file at ``path`` into a ``{KEY: value}`` mapping.
-
-    Reads with ``newline=""`` so embedded ``\\r`` bytes are preserved;
-    only the trailing line terminator is stripped.
-
-    Refuses files larger than ``DOTFILE_MAX_BYTES`` (1 MiB) to bound
-    the read against a misconfigured or malicious dotfile path.
-    """
-    try:
-        size = path.stat().st_size
-    except OSError:
-        size = 0
-    if size > DOTFILE_MAX_BYTES:
-        raise EnvParseError(
-            f"dotfile {path!s} is {size} bytes; refusing to read more than "
-            f"{DOTFILE_MAX_BYTES} bytes — verify the path is the credentials "
-            f"dotfile, not a misconfigured target."
-        )
-    # Use ``path.open(newline="")`` instead of ``read_text(newline=...)``
-    # — the ``newline`` keyword on ``Path.read_text`` was added in Python
-    # 3.13; the project targets 3.11+ via the CI matrix.
-    with path.open(encoding="utf-8", newline="") as fh:
-        text = fh.read()
-    result: dict[str, str] = {}
-    for lineno, raw in enumerate(text.split("\n"), start=1):
-        # Strip trailing \r (CRLF normalization). rstrip is bounded to the
-        # tail, so embedded \r inside a quoted value is preserved.
-        line = raw.rstrip("\r")
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#"):
-            continue
-        if stripped.startswith("export "):
-            raise EnvParseError(
-                f"line {lineno}: `export KEY=value` shell-export syntax is not supported"
-            )
-        if "=" not in line:
-            raise EnvParseError(
-                f"line {lineno}: expected `KEY=value`, no '=' found"
-            )
-        key, _, value = line.partition("=")
-        key = key.strip()
-        if not _KEY_RE.match(key):
-            raise EnvParseError(f"line {lineno}: invalid key {key!r}")
-        if value.startswith('"'):
-            if len(value) < 2 or not value.endswith('"'):
-                raise EnvParseError(
-                    f"line {lineno}: multi-line quoted values are not supported"
-                )
-            value = value[1:-1]
-        if "$" in value:
-            raise EnvParseError(
-                f"line {lineno}: variable expansion (`$NAME`) is not supported"
-            )
-        result[key] = value
-    return result

--- a/packages/agentbundle/tests/integration/test_creds_cli.py
+++ b/packages/agentbundle/tests/integration/test_creds_cli.py
@@ -650,7 +650,8 @@ def test_rm_notes_env_var_present_but_unremovable(tmp_path, monkeypatch, capsys)
 def test_setup_refuses_non_tty_stdin_via_subprocess(tmp_path):
     """AC23 POSIX path: real ``stdin=subprocess.DEVNULL`` (so
     ``sys.stdin.isatty()`` actually returns ``False`` for the child),
-    helper exits non-zero with the stderr text ``stdin is not a tty``.
+    helper exits non-zero with a categorised ``stdin-not-tty`` prefix
+    that security tooling can pattern-match without parsing the body.
     """
     _write_skill_fixture(tmp_path, "alpha", "alpha")
     _write_state_file(tmp_path, "core", (".claude/skills/alpha/SKILL.md",))
@@ -670,7 +671,9 @@ def test_setup_refuses_non_tty_stdin_via_subprocess(tmp_path):
         env=env,
     )
     assert res.returncode != 0
-    assert "stdin is not a tty" in res.stderr
+    # AC23 categorised prefix (Adversarial Concern #11): the stderr
+    # line is distinct from the argv-refusal path.
+    assert "creds setup: stdin-not-tty:" in res.stderr
 
 
 # ── AC11+AC18: read-path Tier-2 hard fail propagates (exit 3) ─────────

--- a/packages/agentbundle/tests/unit/test_credentials_dotfile.py
+++ b/packages/agentbundle/tests/unit/test_credentials_dotfile.py
@@ -280,3 +280,56 @@ def test_load_credentials_mixes_tiers_across_keys(tmp_path, monkeypatch):
     assert creds.API_TOKEN == "from-tier1-env"
     assert creds.BASE_URL == "from-tier2-keyring"
     assert creds.FLAVOR == "from-tier3-dotfile"
+
+
+def test_quote_for_dotfile_rejects_embedded_double_quote(tmp_path):
+    """Security review Quality Nit #15: ``_quote_for_dotfile`` raises
+    rather than silently producing an unparseable entry when the value
+    contains a ``"`` (the parser strips clumsily and the round-trip
+    corrupts the value).
+    """
+    from agentbundle.creds.loader import EnvParseError
+    with pytest.raises(EnvParseError, match="double-quote"):
+        loader._quote_for_dotfile('embedded"quote')
+
+
+def test_quote_for_dotfile_rejects_dollar_sign(tmp_path):
+    """The parser refuses variable-expansion syntax (``$NAME``), so
+    quoting a ``$``-bearing value would write an entry that fails
+    parse on re-read. Refuse up front."""
+    from agentbundle.creds.loader import EnvParseError
+    with pytest.raises(EnvParseError, match=r"`\$`"):
+        loader._quote_for_dotfile("$EXPANSION")
+
+
+def test_credentials_repr_lists_keys_not_values(monkeypatch):
+    """Security Nit #8: ``Credentials.__repr__`` lists key names only —
+    a misplaced ``print(creds)`` MUST NOT echo token bytes."""
+    monkeypatch.setenv("FIXTURE_T6_API_TOKEN", "secret-token-bytes")
+    monkeypatch.setenv("FIXTURE_T6_BASE_URL", "https://example.com")
+    creds = load_credentials(
+        "fixture_t6", required_keys=["API_TOKEN", "BASE_URL"],
+    )
+    r = repr(creds)
+    assert "fixture_t6" in r
+    assert "API_TOKEN" in r
+    assert "BASE_URL" in r
+    # Value redaction is the load-bearing contract.
+    assert "secret-token-bytes" not in r
+    assert "https://example.com" not in r
+
+
+def test_credentials_getattr_typo_lists_resolved_keys(monkeypatch):
+    """Quality Nit #14: typo'd ``creds.api_token`` (lowercase) errors
+    with the resolved-key list so the schema's casing is discoverable."""
+    monkeypatch.setenv("FIXTURE_T6_API_TOKEN", "secret")
+    monkeypatch.setenv("FIXTURE_T6_BASE_URL", "https://example.com")
+    creds = load_credentials(
+        "fixture_t6", required_keys=["API_TOKEN", "BASE_URL"],
+    )
+    with pytest.raises(AttributeError) as exc:
+        _ = creds.api_token  # lowercase typo
+    msg = str(exc.value)
+    assert "api_token" in msg
+    assert "API_TOKEN" in msg
+    assert "BASE_URL" in msg

--- a/packages/agentbundle/tests/unit/test_credentials_schema.py
+++ b/packages/agentbundle/tests/unit/test_credentials_schema.py
@@ -14,7 +14,7 @@ from agentbundle.creds.loader import (
     CredsSchema,
     KeyDef,
     _parse_schema,
-    resolve_schema_path,
+    _relative_schema_path,
 )
 
 
@@ -142,8 +142,8 @@ def test_parse_missing_file_raises(tmp_path):
 # ── Canonical-path resolution (AC24b) ──────────────────────────────────
 
 
-def test_resolve_schema_path_locates_skill_md_and_joins_references():
-    """AC24b: ``resolve_schema_path`` walks ``state.packs[pack].files``
+def test__relative_schema_path_locates_skill_md_and_joins_references():
+    """AC24b: ``_relative_schema_path`` walks ``state.packs[pack].files``
     for ``.claude/skills/<name>/SKILL.md``, takes the parent directory,
     and joins ``references/creds-schema.toml``."""
     pack_state = SimpleNamespace(files={
@@ -152,24 +152,24 @@ def test_resolve_schema_path_locates_skill_md_and_joins_references():
         ".claude/skills/example/SKILL.md": {"sha": "00000000"},
     })
     state = SimpleNamespace(packs={"core": pack_state})
-    resolved = resolve_schema_path(state, "core", "jira")
+    resolved = _relative_schema_path(state, "core", "jira")
     assert str(resolved) == ".claude/skills/jira/references/creds-schema.toml"
 
 
-def test_resolve_schema_path_disambiguates_by_skill_name():
+def test__relative_schema_path_disambiguates_by_skill_name():
     """Two skills under the same pack — the resolver picks the right one."""
     pack_state = SimpleNamespace(files={
         ".claude/skills/jira/SKILL.md": {"sha": "a"},
         ".claude/skills/github/SKILL.md": {"sha": "b"},
     })
     state = SimpleNamespace(packs={"core": pack_state})
-    assert str(resolve_schema_path(state, "core", "jira")) == \
+    assert str(_relative_schema_path(state, "core", "jira")) == \
         ".claude/skills/jira/references/creds-schema.toml"
-    assert str(resolve_schema_path(state, "core", "github")) == \
+    assert str(_relative_schema_path(state, "core", "github")) == \
         ".claude/skills/github/references/creds-schema.toml"
 
 
-def test_resolve_schema_path_missing_skill_raises():
+def test__relative_schema_path_missing_skill_raises():
     """AC24b: a missing SKILL.md row raises ``SchemaError`` naming the
     offending pack + skill so the message is actionable."""
     pack_state = SimpleNamespace(files={
@@ -177,16 +177,16 @@ def test_resolve_schema_path_missing_skill_raises():
     })
     state = SimpleNamespace(packs={"core": pack_state})
     with pytest.raises(SchemaError, match="not found at expected path"):
-        resolve_schema_path(state, "core", "absent-skill")
+        _relative_schema_path(state, "core", "absent-skill")
 
 
-def test_resolve_schema_path_missing_pack_raises():
+def test__relative_schema_path_missing_pack_raises():
     state = SimpleNamespace(packs={})
     with pytest.raises(SchemaError, match="pack 'core' not present"):
-        resolve_schema_path(state, "core", "jira")
+        _relative_schema_path(state, "core", "jira")
 
 
-def test_resolve_schema_path_ignores_non_skill_md_entries():
+def test__relative_schema_path_ignores_non_skill_md_entries():
     """The regex must match exactly ``.claude/skills/<name>/SKILL.md`` —
     nested or differently-named files are skipped."""
     pack_state = SimpleNamespace(files={
@@ -195,7 +195,7 @@ def test_resolve_schema_path_ignores_non_skill_md_entries():
         ".claude/skills/jira/SKILL.md": {"sha": "c"},  # the right one
     })
     state = SimpleNamespace(packs={"core": pack_state})
-    assert ".claude/skills/jira" in str(resolve_schema_path(state, "core", "jira"))
+    assert ".claude/skills/jira" in str(_relative_schema_path(state, "core", "jira"))
 
 
 # ── ``load_credentials(schema_path=...)`` kwarg (T3 + T7) ──────────────

--- a/packages/agentbundle/tests/unit/test_creds_helpers.py
+++ b/packages/agentbundle/tests/unit/test_creds_helpers.py
@@ -1,0 +1,63 @@
+"""Unit tests for small helpers introduced by the round-2 robustness pass.
+
+Covers:
+
+- ``_is_credentialed_true`` — YAML-truthy normalisation for the
+  ``credentialed:`` frontmatter scalar (Security Nit #9).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentbundle.commands.creds import _is_credentialed_true
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "true",
+        "True",
+        "TRUE",
+        '"true"',  # quotes are stripped by _parse_frontmatter, value reaches here as bare
+        "yes",
+        "Yes",
+        "YES",
+        "1",
+        "on",
+        "ON",
+    ],
+)
+def test_is_credentialed_true_accepts_yaml_truthy_forms(raw):
+    """Per Security Nit #9, an author writing ``credentialed: True``
+    (Python-style) or ``credentialed: yes`` (YAML 1.1) MUST be picked
+    up by the ``creds setup`` walker — silent skipping of valid skills
+    is confusing and could mask a credentialed-primitive entirely.
+    The frontmatter parser strips balanced quotes, so quoted forms
+    arrive here as bare strings; the trimmed/lowered comparison handles
+    the rest."""
+    # Strip the YAML-style outer quotes the same way _parse_frontmatter
+    # does, then pass to the helper.
+    if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in ('"', "'"):
+        raw = raw[1:-1]
+    assert _is_credentialed_true(raw) is True
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        None,
+        "",
+        "false",
+        "False",
+        "no",
+        "0",
+        "off",
+        "credentialed",  # the key name, not a value
+        "maybe",
+    ],
+)
+def test_is_credentialed_true_rejects_non_truthy(raw):
+    """Unset, falsey, and unrecognised values all fall through to False
+    so a typo doesn't silently get treated as truthy."""
+    assert _is_credentialed_true(raw) is False


### PR DESCRIPTION
## Summary

Bundles seven round-2 review findings whose fixes are small and share a surface. Each finding is named by its report:

| Finding | Source | Change |
| --- | --- | --- |
| `Credentials.__repr__` redacts values | Security Nit #8 | Explicit `__repr__` lists key names only; SECURITY comment pins the contract. |
| `__getattr__` lists resolved keys | Quality Nit #14 | Typo `creds.api_token` errors with `(resolved keys: [...])`. |
| `_quote_for_dotfile` refuses unsafe chars | Quality Nit #15 | `EnvParseError` on `"` or `$` rather than silent corruption. |
| `EnvParseError` ordering | Quality Concern #11 | Class + `parse_env_file` moved next to other exceptions at top; `__all__` references resolve top-to-bottom. |
| `credentialed:` YAML normalisation | Security Nit #9 | New `_is_credentialed_true` accepts `true`/`yes`/`1`/`on` case-insensitively; both call sites route through it. Parametric matrix test added. |
| `resolve_schema_path` → `_relative_schema_path` | Adversarial Concern #9 | Renamed to underscore-prefixed, expanded docstring calling out the relative contract; tests updated. |
| `creds rm` continues on Tier-2 hard fail | Security Concern #7 | Per-key catch; Tier-3 cleanup still runs; tracking flag drives a non-zero exit. |
| AC23 stderr-prefix categorisation | Adversarial Concern #11 | `creds setup: argv-refusal:` and `creds setup: stdin-not-tty:` prefixes (canonical anchor preserved verbatim). |

## Test plan

- [x] `make build-check` clean locally
- [x] Full suite: 757 passed, 10 skipped (1 pre-existing fail in `test_pre_pr_skill_deps_fail` is unrelated — present on origin/main)
- [x] New `tests/unit/test_creds_helpers.py` covers `_is_credentialed_true` truthy/non-truthy matrix
- [x] New tests in `test_credentials_dotfile.py` cover `_quote_for_dotfile` raises, redacting repr, getattr resolved-keys hint
- [x] `test_setup_refuses_non_tty_stdin_via_subprocess` asserts the categorised `stdin-not-tty:` prefix; existing argv-refusal tests still match the unchanged `ARGV_REFUSAL_SENTINEL` substring

Note: bundles a 3.11-compat fix in `parse_env_file` (`path.open(newline="")` instead of `Path.read_text(newline=...)` — `newline` kwarg on `Path.read_text` is Python 3.13+). The same fix lands in PR #84; whichever merges first carries it, the other branch rebases cleanly.