### PR TITLE
fix(skill-secrets): lint widening — AST walker + icacls SID-based DACL

### DIFF
--- a/.claude/skills/add-credentialed-skill/SKILL.md
+++ b/.claude/skills/add-credentialed-skill/SKILL.md
@@ -96,18 +96,27 @@ slash command) reports findings on:
 - `### Security rules (non-negotiable)` heading absent, or the three
   RFC-0006 § 4 substrings missing inside that section.
 - Any `argparse.ArgumentParser.add_argument` call in `scripts/**/*.py`
-  whose normalised name matches the banned set. Casing variants and
-  `"--" + "name"` literal concatenation are caught; deeper obfuscation
-  is out of scope.
+  whose first positional collapses to a banned name after AC27
+  normalisation. The walker recognises every shape that reduces to a
+  literal string at parse time:
+  - Direct `Constant(str)` — `"--token"`.
+  - `BinOp(op=Add)` chain of literal strings — `"--" + "token"`.
+  - `JoinedStr` (f-string) with literal-only `FormattedValue` parts —
+    `f"--{'token'}"`.
+  - `Starred(Tuple)` argument spread of a literal tuple/list —
+    `add_argument(*("--token",))`.
+  - `Subscript` constant indexing into a literal tuple/list —
+    `("--token",)[0]`.
 - **Argparse-only scope.** The lint walks `argparse.ArgumentParser.add_argument`
   calls; it does NOT see `click.option(...)`, `typer.Option(...)`,
-  decorator-style flag declarations, f-string flag names, `*args`-spread
-  forms, or other dynamic shapes. If your credentialed-CLI primitive
-  uses `click` or `typer`, the lint reports zero findings and PR review
-  is the only enforcement. Prefer `argparse` for credentialed-CLI
-  primitives so the lint can do its job; if you reach for `click` or
-  `typer` anyway, name the choice in the PR description so reviewers
-  know to spot-check the flag set by hand.
+  decorator-style flag declarations, name-via-variable lookups, or
+  flag names assembled from runtime sources (env reads, function
+  return values). If your credentialed-CLI primitive uses `click` or
+  `typer`, the lint reports zero findings and PR review is the only
+  enforcement. Prefer `argparse` for credentialed-CLI primitives so
+  the lint can do its job; if you reach for `click` or `typer`
+  anyway, name the choice in the PR description so reviewers know to
+  spot-check the flag set by hand.
 - Any `scripts/**/*.py` line containing `.agent-ready/credentials.env`
   without the opt-out marker `# credentialed-primitive: reads-creds-directly`
   on the same line.

--- a/packages/agentbundle/agentbundle/creds/loader.py
+++ b/packages/agentbundle/agentbundle/creds/loader.py
@@ -214,39 +214,62 @@ def _quote_for_dotfile(value: str) -> str:
     return value
 
 
+# Well-known SIDs (Windows). Locale-invariant — non-English Windows
+# installs translate the *display name* of these principals (Tout le
+# monde, Jeder, Все), so any matching by name-substring becomes a
+# silent bypass on those locales. SIDs do not translate.
+#
+#   S-1-1-0    — Everyone
+#   S-1-5-7    — Anonymous Logon
+#   S-1-5-11   — Authenticated Users
+#   S-1-5-32-545 — BUILTIN\Users (the local Users group)
+#   S-1-5-32-546 — BUILTIN\Guests
+_PERMISSIVE_SIDS = (
+    "S-1-1-0",
+    "S-1-5-7",
+    "S-1-5-11",
+    "S-1-5-32-545",
+    "S-1-5-32-546",
+)
+
+
 def _verify_icacls(
     path: pathlib.Path, *, allow_permissive_acl: bool = False
 ) -> None:
-    """Run ``icacls`` on the path and refuse if any non-default ACE grants
-    read access (spec § AC15). No-op on POSIX.
+    """Run ``icacls /findsid`` and refuse if any well-known "broad
+    access" SID is granted access on the path (spec § AC15). No-op on
+    POSIX.
 
     Default ACEs on a per-user file are the inheriting user,
-    ``NT AUTHORITY\\SYSTEM``, and ``BUILTIN\\Administrators``. Any other
-    principal granted access is flagged unless the caller opts in.
+    ``NT AUTHORITY\\SYSTEM``, and ``BUILTIN\\Administrators``. The
+    locale-invariant check uses ``icacls <path> /findsid <SID>``
+    against the well-known "broad access" SIDs (Everyone,
+    Authenticated Users, BUILTIN\\Users, BUILTIN\\Guests, Anonymous
+    Logon); the prior name-substring scan was a silent bypass on
+    non-English Windows installs (e.g. ``Tout le monde`` for
+    Everyone on French Windows).
     """
     if os.name != "nt":  # pragma: no cover — POSIX path
         return
-    res = subprocess.run(  # pragma: no cover — exercised only on Windows
-        ["icacls", str(path)], capture_output=True, text=True, check=False
-    )
-    if res.returncode != 0:
-        raise PermissiveAclError(
-            f"icacls inspection failed for {path}: rc={res.returncode} "
-            f"stderr={res.stderr.strip()}"
+    suspect: list[str] = []
+    for sid in _PERMISSIVE_SIDS:  # pragma: no cover — exercised only on Windows
+        res = subprocess.run(
+            ["icacls", str(path), "/findsid", sid],
+            capture_output=True,
+            text=True,
+            check=False,
         )
-    suspect = []
-    for line in res.stdout.splitlines():
-        stripped = line.strip()
-        # Flag any ACE granting access to non-default principals.
-        if (
-            "BUILTIN\\Users" in stripped
-            or "Everyone" in stripped
-            or "Authenticated Users" in stripped
-        ):
-            suspect.append(stripped)
+        # ``icacls /findsid`` exits 0 with the path listed when the SID
+        # is granted access on at least one ACE; exits non-zero (with
+        # "No matching files were found" stderr) when the SID is not
+        # present. The path appearing in stdout is the load-bearing
+        # signal: a successful find prints the path on one line.
+        if res.returncode == 0 and str(path) in res.stdout:
+            suspect.append(sid)
     if suspect and not allow_permissive_acl:
         raise PermissiveAclError(
-            f"DACL too permissive on {path}: {suspect}; pass "
+            f"DACL too permissive on {path}: well-known broad-access "
+            f"SIDs granted access: {suspect}; pass "
             f"allow_permissive_acl=True to override"
         )
 

--- a/packages/agentbundle/tests/fixtures/creds/skills/argv-flag-derived/SKILL.md
+++ b/packages/agentbundle/tests/fixtures/creds/skills/argv-flag-derived/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: argv-flag-derived
+description: Credentialed-CLI fixture exercising round-2 lint widening — f-string, Starred(Tuple), Subscript shapes. All three should produce AC26(b) findings.
+credentialed: true
+primitive-class: credentialed-cli
+---
+
+Body with the full "Don't" block so only AC26(b) variants fire:
+
+### Security rules (non-negotiable)
+
+- Secrets live only in `~/.agent-ready/credentials.env`
+  (mode 0600 on POSIX; DACL-restricted on Windows), the OS keyring,
+  or process environment variables.
+  **Never** read that file, print it, or echo the token.
+- **Never** put the token on the command line. The primitive
+  refuses flags like `--token` / `--api-token` / `--bearer` /
+  `--pat` / `--password` and exits — do not work around it.
+- If `check` exits with the "missing credentials" code, tell the
+  user to run `agentbundle creds setup <namespace>` themselves.
+  It's interactive — do not run it for them.

--- a/packages/agentbundle/tests/fixtures/creds/skills/argv-flag-derived/scripts/cli.py
+++ b/packages/agentbundle/tests/fixtures/creds/skills/argv-flag-derived/scripts/cli.py
@@ -1,0 +1,28 @@
+"""argv-flag-derived: round-2 lint widening fixtures.
+
+Three obfuscation shapes the original walker missed; each is still
+literal-derivable at parse time so the widened walker MUST flag them:
+
+  - ``JoinedStr``  — f-string with literal-only parts.
+  - ``Starred(Tuple)`` argument spread.
+  - ``Subscript`` constant indexing into a literal tuple.
+"""
+from __future__ import annotations
+
+import argparse
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    # JoinedStr with a literal-only FormattedValue.
+    parser.add_argument(f"--{'token'}")
+    # Starred(Tuple) argument spread.
+    parser.add_argument(*("--api-key",))
+    # Subscript constant indexing on a literal tuple.
+    parser.add_argument(("--bearer",)[0])
+    parser.parse_args()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/agentbundle/tests/integration/test_conventions_check_creds.py
+++ b/packages/agentbundle/tests/integration/test_conventions_check_creds.py
@@ -88,6 +88,21 @@ def test_argv_flag_normalised_catches_all_three_variants(tmp_path):
     assert "'--password'" in res.stderr
 
 
+def test_argv_flag_derived_shapes_are_flagged(tmp_path):
+    """Round-2 lint widening (Adversarial Concern #8): the walker catches
+    JoinedStr (literal-only f-string), Starred(Tuple) argument spread,
+    and Subscript constant indexing into a literal tuple. Each shape
+    collapses to a banned flag at parse time."""
+    res = _run_lint("argv-flag-derived", tmp_path)
+    assert res.returncode != 0
+    # JoinedStr — f"--{'token'}" collapses to "--token".
+    assert "'--token'" in res.stderr
+    # Starred(Tuple) — *("--api-key",) collapses to "--api-key".
+    assert "'--api-key'" in res.stderr
+    # Subscript — ("--bearer",)[0] collapses to "--bearer".
+    assert "'--bearer'" in res.stderr
+
+
 def test_mcp_server_headers_clean(tmp_path):
     """AC26(b) is scoped to credentialed-cli only; header-naming flags on
     mcp-server class must not be flagged."""

--- a/packs/core/.apm/skills/add-credentialed-skill/SKILL.md
+++ b/packs/core/.apm/skills/add-credentialed-skill/SKILL.md
@@ -96,18 +96,27 @@ slash command) reports findings on:
 - `### Security rules (non-negotiable)` heading absent, or the three
   RFC-0006 § 4 substrings missing inside that section.
 - Any `argparse.ArgumentParser.add_argument` call in `scripts/**/*.py`
-  whose normalised name matches the banned set. Casing variants and
-  `"--" + "name"` literal concatenation are caught; deeper obfuscation
-  is out of scope.
+  whose first positional collapses to a banned name after AC27
+  normalisation. The walker recognises every shape that reduces to a
+  literal string at parse time:
+  - Direct `Constant(str)` — `"--token"`.
+  - `BinOp(op=Add)` chain of literal strings — `"--" + "token"`.
+  - `JoinedStr` (f-string) with literal-only `FormattedValue` parts —
+    `f"--{'token'}"`.
+  - `Starred(Tuple)` argument spread of a literal tuple/list —
+    `add_argument(*("--token",))`.
+  - `Subscript` constant indexing into a literal tuple/list —
+    `("--token",)[0]`.
 - **Argparse-only scope.** The lint walks `argparse.ArgumentParser.add_argument`
   calls; it does NOT see `click.option(...)`, `typer.Option(...)`,
-  decorator-style flag declarations, f-string flag names, `*args`-spread
-  forms, or other dynamic shapes. If your credentialed-CLI primitive
-  uses `click` or `typer`, the lint reports zero findings and PR review
-  is the only enforcement. Prefer `argparse` for credentialed-CLI
-  primitives so the lint can do its job; if you reach for `click` or
-  `typer` anyway, name the choice in the PR description so reviewers
-  know to spot-check the flag set by hand.
+  decorator-style flag declarations, name-via-variable lookups, or
+  flag names assembled from runtime sources (env reads, function
+  return values). If your credentialed-CLI primitive uses `click` or
+  `typer`, the lint reports zero findings and PR review is the only
+  enforcement. Prefer `argparse` for credentialed-CLI primitives so
+  the lint can do its job; if you reach for `click` or `typer`
+  anyway, name the choice in the PR description so reviewers know to
+  spot-check the flag set by hand.
 - Any `scripts/**/*.py` line containing `.agent-ready/credentials.env`
   without the opt-out marker `# credentialed-primitive: reads-creds-directly`
   on the same line.

--- a/tools/lint-credentialed-skills.sh
+++ b/tools/lint-credentialed-skills.sh
@@ -22,10 +22,19 @@
 #     first positional argument is normalised per AC27 (strip leading
 #     `-`, casefold, replace `-` with `_`) and matched against the
 #     banned set {token, api_token, api_key, bearer, pat, password}.
-#     Two first-arg shapes are recognised: literal string constants
-#     and `BinOp(op=Add)` concatenation of two literal constants
-#     (the `"--" + "token"` obfuscation in AC27). Deeper obfuscation
-#     (formatted strings, computed names) is out of scope.
+#     First-arg shapes recognised (all reducible to a literal string
+#     at parse time — no name lookups, no runtime evaluation):
+#       - ``Constant(value=str)`` — direct literal.
+#       - ``BinOp(op=Add)`` chains of literal-string constants
+#         (``"--" + "token"`` obfuscation in AC27).
+#       - ``JoinedStr`` (f-string) whose pieces are all literal
+#         constants — `f"--{'token'}"` and similar.
+#       - ``Starred(Tuple)`` argument spread when the inner tuple is
+#         literal — `add_argument(*("--token",))`.
+#       - ``Subscript`` constant indexing — `("--token",)[0]` shapes.
+#     Names that reach `add_argument` through a variable, an `os.environ`
+#     read, or a function call remain out of scope; PR-review picks
+#     those up as a defence in depth.
 #
 #   AC26(c) Dotfile substring + opt-out marker.
 #     Per-line substring scan of every `scripts/**/*.py` under a
@@ -157,7 +166,11 @@ def add_argument_flags(py_path):
         if not node.args:
             continue
         first = node.args[0]
+        # Direct literal / BinOp / f-string / subscript-of-tuple shapes.
         value = _literal_string(first)
+        if value is None:
+            # Argument-spread shape: add_argument(*("--token",))
+            value = _starred_first_literal(first)
         if value is None:
             continue
         if not value.startswith("-"):
@@ -166,8 +179,20 @@ def add_argument_flags(py_path):
 
 
 def _literal_string(node):
-    """Return a string if ``node`` is a string literal or a chain of
-    string-literal additions; ``None`` otherwise."""
+    """Return a string if ``node`` reduces to a string literal at parse
+    time, ``None`` otherwise.
+
+    Shapes handled:
+      - ``Constant(value=str)`` — direct literal.
+      - ``BinOp(op=Add)`` chain of literal strings.
+      - ``JoinedStr`` (f-string) whose ``FormattedValue`` parts are
+        all literal constants (``f"--{'token'}"`` collapses to
+        ``"--token"``); a non-literal `{name}` returns ``None``.
+      - ``Tuple(elts=[Constant(str), ...])`` returning the first
+        element — covers the inner shape of ``Starred(Tuple)``.
+      - ``Subscript(value=Tuple|List, slice=Constant(int))`` — pulls
+        the indexed element when both sides are literal.
+    """
     if isinstance(node, ast.Constant) and isinstance(node.value, str):
         return node.value
     if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
@@ -175,7 +200,49 @@ def _literal_string(node):
         right = _literal_string(node.right)
         if left is not None and right is not None:
             return left + right
+        return None
+    if isinstance(node, ast.JoinedStr):
+        parts: list[str] = []
+        for piece in node.values:
+            if isinstance(piece, ast.Constant) and isinstance(piece.value, str):
+                parts.append(piece.value)
+                continue
+            if isinstance(piece, ast.FormattedValue):
+                inner = _literal_string(piece.value)
+                if inner is None:
+                    return None
+                parts.append(inner)
+                continue
+            return None
+        return "".join(parts)
+    if isinstance(node, ast.Subscript):
+        # ("--token",)[0] / ["--token"][0] — only pull when both
+        # sides are literal.
+        container = node.value
+        if not isinstance(container, (ast.Tuple, ast.List)):
+            return None
+        slice_node = node.slice
+        if not (
+            isinstance(slice_node, ast.Constant)
+            and isinstance(slice_node.value, int)
+        ):
+            return None
+        if not (0 <= slice_node.value < len(container.elts)):
+            return None
+        return _literal_string(container.elts[slice_node.value])
     return None
+
+
+def _starred_first_literal(node):
+    """If ``node`` is ``Starred(Tuple(elts=[Constant(str), ...]))``,
+    return that first literal — argparse sees it as the flag name.
+    Anything else returns ``None``."""
+    if not isinstance(node, ast.Starred):
+        return None
+    inner = node.value
+    if not isinstance(inner, (ast.Tuple, ast.List)) or not inner.elts:
+        return None
+    return _literal_string(inner.elts[0])
 
 
 # Discovery: three glob patterns covering production paths + fixture trees.


### PR DESCRIPTION
## Summary

Two round-2 lint-related findings that share the "locale/shape-invariant tightening" surface.

**AST walker — literal-derivable shapes** (Adversarial Concern #8) — `tools/lint-credentialed-skills.sh` extends `_literal_string` recursively to handle `JoinedStr` (literal-only f-string), `Subscript` constant indexing into literal tuples, and a sibling `_starred_first_literal` helper unwraps `Starred(Tuple)` argument spread. The argparse-only scope note in `add-credentialed-skill/SKILL.md` enumerates the literal-derivable shapes explicitly.

| Shape | Example | Caught before | Caught now |
| --- | --- | --- | --- |
| `Constant(str)` | `"--token"` | ✓ | ✓ |
| `BinOp(Add)` | `"--" + "token"` | ✓ | ✓ |
| `JoinedStr` | `f"--{'token'}"` | ✗ | ✓ |
| `Starred(Tuple)` | `*("--token",)` | ✗ | ✓ |
| `Subscript` | `("--token",)[0]` | ✗ | ✓ |
| Name lookup / runtime | `f"--{var}"` | ✗ | ✗ (PR review) |

**icacls — SID-based matching** (Security Concern #4) — `_verify_icacls` switched from English-locale display-name substring scan (`BUILTIN\\Users`, `Everyone`, `Authenticated Users`) to `icacls <path> /findsid <SID>` against the well-known broad-access SIDs. SIDs are locale-invariant by Win32 contract — non-English Windows installs (Tout le monde, Jeder, Все) no longer silently bypass the check.

| SID | Principal |
| --- | --- |
| `S-1-1-0` | Everyone |
| `S-1-5-7` | Anonymous Logon |
| `S-1-5-11` | Authenticated Users |
| `S-1-5-32-545` | BUILTIN\\Users |
| `S-1-5-32-546` | BUILTIN\\Guests |

Verification home: windows-latest CI matrix landed in PR #84.

## Test plan

- [x] `make build-check` clean locally
- [x] `tests/integration/test_conventions_check_creds.py` covers the three new shapes via a new `argv-flag-derived` fixture
- [x] Full suite: same 1 pre-existing fail as PR #84 baseline (`test_pre_pr_skill_deps_fail`)
- [ ] Windows CI matrix green (icacls SID-based path)