### PR TITLE
fix(skill-secrets): remove load_credentials schema_path kwarg; loader is resolver-only

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -279,7 +279,8 @@ Captured here so a future ROADMAP reader can see the disposition:
 - **Robustness pass** — per-finding micro-fixes (`Credentials.__repr__`,
   `Credentials.__getattr__` resolved-keys hint, `_quote_for_dotfile`
   raises on unsafe chars, `EnvParseError` ordering, `credentialed:`
-  YAML normalisation, `_resolve_schema_path` rename, `creds rm`
+  YAML normalisation, `resolve_schema_path` → `_relative_schema_path`
+  rename, `creds rm`
   continue-on-Tier-2-fail, AC23 stderr-prefix categorisation).
 - **Lint widening** — AST walker f-string / Starred(Tuple) /
   Subscript shapes; `icacls` SID-based matching to harden non-English
@@ -287,6 +288,10 @@ Captured here so a future ROADMAP reader can see the disposition:
 - **Spec / plan / doc cleanup** — inline-fixture amendment;
   `docs/product/release-checklist.md` for the three Windows manual-QA
   rows; this very ROADMAP audit.
+- **PR #97 — `schema_path=` kwarg removal** (closes Quality Blocker
+  #4). Path (a) chosen: `load_credentials` is *resolution only*; schema
+  validation lives in `agentbundle creds check`, not on the loader's
+  public surface. AC24b amended accordingly.
 
 Open follow-ons (not gating shipped status):
 
@@ -298,11 +303,6 @@ Open follow-ons (not gating shipped status):
   adopter-profile audit per RFC-0006 § Unresolved Q1; not gating
   v1 (Linux lands on Tier 3 floor). The `v2-libsecret` stub stays
   open under cross-spec items below.
-- **`load_credentials(schema_path=...)` no-op kwarg.** AC24b promises
-  the kwarg for primitive authors who load their own schema, but the
-  loader currently ignores it. Round-2 surfaced the gap (Quality
-  Blocker #4); choice between removing the kwarg vs. wiring schema
-  validation pending user direction.
 
 ---
 

--- a/docs/specs/skill-secrets/notes/review-round2-summary.md
+++ b/docs/specs/skill-secrets/notes/review-round2-summary.md
@@ -27,6 +27,7 @@ follow-up prompt's PR order):
 | **#88** | `eugenelim/skill-secrets-doc-cleanup` | `45523cc` | Inline-fixture amendment to spec § Testing Strategy; `docs/product/release-checklist.md` for the three Windows manual-QA rows; ROADMAP closure audit + Round-2 disposition subsection. |
 | **#89** | `eugenelim/skill-secrets-robustness` | `05de963` | `Credentials.__repr__` redacts values; `__getattr__` lists resolved keys; `_quote_for_dotfile` refuses `"` / `$`; `EnvParseError` ordering; `credentialed:` YAML normalisation; `resolve_schema_path` → `_relative_schema_path`; `creds rm` continues on Tier-2 hard fail; AC23 stderr-prefix categorisation. |
 | **#93** | `eugenelim/skill-secrets-lint-widening` | `061a26f` | AST walker recognises `JoinedStr`, `Starred(Tuple)`, `Subscript` literal-derivable shapes; `_verify_icacls` SID-based DACL check (locale-invariant on non-English Windows). |
+| **#97** | `eugenelim/skill-secrets-schema-path-remove` | _pending_ | Remove `schema_path=` kwarg from `load_credentials`; amend AC24b to call out the resolver-only contract; schema validation lives in `creds check`, not on the loader's public surface. |
 
 ## Adversarial review round 1 — disposition
 
@@ -75,7 +76,7 @@ follow-up prompt's PR order):
 | 1 | AC34 unchecked (orphan-fixture walker) | **Closed in PR #81** — see Adversarial #1. |
 | 2 | AC35 unchecked (no-live-writes assertion) | **Closed in PR #81** — see Adversarial #2. |
 | 3 | `_tier_for_key` swallows Tier-2 hard fail | **Closed in PR #82** — see Adversarial #10. |
-| 4 | `load_credentials(schema_path=...)` no-op kwarg | **Pending user direction** — either (a) remove kwarg + amend AC24b, or (b) wire schema validation. Tracked under `docs/ROADMAP.md` § `skill-secrets` *Round-2 disposition* and named in `notes/review-round2-summary.md` *Pending decisions* below. |
+| 4 | `load_credentials(schema_path=...)` no-op kwarg | **Closed in PR #97** — path (a) chosen after long-term-vs-tactical reasoning: `load_credentials` resolves, schema describes — crossing the two through a kwarg couples concerns that should evolve independently. Kwarg removed; signature is now `(namespace, required_keys)`; AC24b amended to make the resolution-only contract explicit; schema validation belongs in `agentbundle creds check`, not in the loader's public surface. |
 | 5 | AC4 cross-tier composability test missing | **Closed in PR #86** — `test_load_credentials_mixes_tiers_across_keys`. |
 | 6 | `CredentialsMissingError` doesn't name tiers tried | **Closed in PR #86** — per-key tier trailer + structured `tiers_tried` attribute. |
 | 7 | AC22 macOS exit-code matrix not symbolic | **Closed in PR #85** — see Adversarial #5. |
@@ -88,30 +89,11 @@ follow-up prompt's PR order):
 | 14 | `__getattr__` doesn't list resolved keys | **Closed in PR #89** — see Security #8 sibling change. |
 | 15 | `_quote_for_dotfile` doesn't refuse unsafe chars | **Closed in PR #89** — `EnvParseError` on `"` or `$`. |
 
-## Pending decisions
-
-One item still requires user direction:
-
-- **`load_credentials(schema_path=...)` no-op kwarg** (Quality Blocker
-  #4). Two valid paths:
-  - **(a)** Remove `schema_path=` from the `load_credentials`
-    signature; delete the no-op signature test at
-    `tests/unit/test_credentials_schema.py:204-215`; amend AC24b's
-    final clause to drop the promise. Smallest surface;
-    primitive authors who load their own schema still call
-    `parse_schema` directly.
-  - **(b)** Wire the kwarg: when `schema_path` is not `None`, parse the
-    schema and validate every entry in `required_keys` appears in
-    `schema.keys`; raise `SchemaError` on mismatch. Adds a real check;
-    new failure mode for callers; deepens the public surface.
-
-  Awaiting user direction before opening the PR.
-
 ## Convergence note
 
 Round-2 closed every reviewer-flagged item with either a landed fix
 or a one-line deferral rationale. The four explicitly-deferred items
-above (Security #3, Quality #9, #12, #13) carry no current
-regression vector; each is tracked for re-evaluation if the
+in the tables above (Security #3, Quality #9, #12, #13) carry no
+current regression vector; each is tracked for re-evaluation if the
 triggering condition (real Windows CI suite, Linux threshold change,
 loader's second consumer, macOS CI matrix) ever lands.

--- a/docs/specs/skill-secrets/plan.md
+++ b/docs/specs/skill-secrets/plan.md
@@ -213,10 +213,11 @@ test file: `packages/agentbundle/tests/unit/test_credentials_loader.py`)
 **Approach:**
 
 - Implement `Credentials` as a frozen `dataclass` (slots, immutable).
-- Implement `load_credentials(namespace, required_keys,
-  schema_path=None)` with the precedence resolver; Tier 2 dispatch
-  follows AC4b's platform discrimination at module-load time; Tier 3
-  is stubbed to return `None` in this task.
+- Implement `load_credentials(namespace, required_keys)` with the
+  precedence resolver; Tier 2 dispatch follows AC4b's platform
+  discrimination at module-load time; Tier 3 is stubbed to return
+  `None` in this task. Signature is *resolution only* — schema
+  concerns stay out of this surface per the AC24b clarification.
 - Define exception hierarchy in
   `packages/agentbundle/agentbundle/creds/exceptions.py`.
 - Create shim package
@@ -424,11 +425,11 @@ test file: `packages/agentbundle/tests/unit/test_credentials_schema.py`)
 - *Canonical-path resolution:* given a fixture state-file
   conforming to the **existing** v0.3 `PackState` schema with
   `files = { ".claude/skills/<name>/SKILL.md" = { sha = "...", ... } }`,
-  `resolve_schema_path(state, pack, name)` walks `pack.files` for
+  `_relative_schema_path(state, pack, name)` walks `pack.files` for
   the SKILL.md relpath matching
   `^\.claude/skills/[^/]+/SKILL\.md$` (matching the skill name),
   takes its parent dir, joins `references/creds-schema.toml`, and
-  returns the absolute path. Missing file raises
+  returns the state-relative path. Missing file raises
   `SchemaError("creds-schema.toml not found at expected path:
   <path>")`. No new state-schema fields are required. [AC24b]
 
@@ -437,12 +438,17 @@ test file: `packages/agentbundle/tests/unit/test_credentials_schema.py`)
 - Add `_parse_schema(path: Path) -> CredsSchema` to `loader.py`
   using `tomllib`.
 - Add `CredsSchema` and `KeyDef` dataclasses.
+- Add `_relative_schema_path(state, pack, skill_name) -> Path` for
+  AC24b's state-walk; underscore-prefixed because CLI callers route
+  through `commands/creds._resolve_schema_for_namespace` (the
+  by-namespace twin); see the loader docstring for the contract.
 - Document the schema shape in `loader.py` docstring; the canonical
   format definition lives in `spec.md` § AC24.
 
-**Done when:** schema tests pass; `load_credentials` accepts a
-`schema_path` kwarg for primitive authors to point at their own
-schema file.
+**Done when:** schema tests pass. `load_credentials` itself stays
+*resolution-only* per AC24b's clarification — schema validation
+lives in the `agentbundle creds check` CLI surface, not on the
+loader.
 
 ### T8: `agentbundle creds` CLI verb
 

--- a/docs/specs/skill-secrets/spec.md
+++ b/docs/specs/skill-secrets/spec.md
@@ -52,7 +52,7 @@ Concretely the implementing PRs deliver:
    Tier 3 in v1.
 
 3. **A stdlib-only loader and CLI verb** — `agent_ready.credentials`
-   exposes `load_credentials(namespace, required_keys=[...])` for
+   exposes `load_credentials(namespace, required_keys)` for
    primitive authors to import; `agentbundle creds` ships four
    subcommands (`setup`, `check`, `where`, `rm` — **no `get`**); both
    are stdlib-only (`getpass`, `os`, `pathlib`, `subprocess`,
@@ -315,7 +315,7 @@ Stdlib parser and loader API:
       (`KEY=$OTHER`), refuses multi-line quoted values (a quoted
       value spanning two physical lines is a parse error).
 - [x] **AC3.** `agent_ready.credentials.load_credentials(namespace,
-      required_keys=[...])` returns an immutable `Credentials` object
+      required_keys)` returns an immutable `Credentials` object
       whose attribute access returns the resolved values; missing
       required keys raise `CredentialsMissingError` naming the
       namespace and the missing keys. The function is the only public
@@ -546,9 +546,14 @@ CLI verb `agentbundle creds`:
       SKILL.md), taking its parent directory, and joining
       `references/creds-schema.toml`. The resolution uses the
       **existing** v0.3 state-file schema — no new fields are added.
-      `load_credentials` accepts a `schema_path: Path | None` kwarg
-      for primitive authors who load the schema themselves; passing
-      `None` (the default) defers to the canonical lookup.
+      `load_credentials(namespace, required_keys)` is *resolution
+      only* — schema concerns (validating `required_keys` against
+      the schema's declared keys, prompting, secret/non-secret
+      labels) live in the `agentbundle creds setup` / `creds check`
+      CLI surface, not on the loader's signature. Primitive code is
+      not expected to validate against the schema at load time; the
+      `creds check` verb is the canonical way to surface a
+      schema/required-keys mismatch.
 
 Conventions and lint:
 

--- a/packages/agentbundle/agentbundle/commands/creds.py
+++ b/packages/agentbundle/agentbundle/commands/creds.py
@@ -353,9 +353,10 @@ def _resolve_schema_for_namespace(
     The walk parses every credentialed skill's schema and matches by
     ``schema.namespace``.
 
-    *Related primitive:* ``agentbundle.creds.loader.resolve_schema_path``
+    *Related primitive:* ``agentbundle.creds.loader._relative_schema_path``
     walks the same ``PackState.files`` table per AC24b but looks up by
-    *skill name*. This helper looks up by *namespace* — the user types
+    *skill name* and returns a state-relative path. This helper looks
+    up by *namespace* and returns an absolute path — the user types
     ``agentbundle creds <verb> <namespace>``, not the skill name — so
     the two helpers are deliberate twins of the same lookup. Keep the
     canonical-path convention (``<skill-dir>/references/creds-schema.toml``)

--- a/packages/agentbundle/agentbundle/creds/loader.py
+++ b/packages/agentbundle/agentbundle/creds/loader.py
@@ -3,9 +3,9 @@
 This module exposes the public surface a credentialed-primitive author
 imports (via the ``agent_ready.credentials`` shim, per spec § AC3):
 
-- ``load_credentials(namespace, required_keys, schema_path=None)`` — resolves
-  credentials through Tier 1 (env var) → Tier 2 (OS keyring) → Tier 3
-  (dotfile), first-hit-wins per key.
+- ``load_credentials(namespace, required_keys)`` — resolves credentials
+  through Tier 1 (env var) → Tier 2 (OS keyring) → Tier 3 (dotfile),
+  first-hit-wins per key.
 - ``Credentials`` — immutable, attribute-access view of the resolved values.
 - ``EnvParseError`` — raised by ``parse_env_file`` on unsupported syntax.
 
@@ -492,8 +492,6 @@ def _tier2_backend_label() -> str:
 def load_credentials(
     namespace: str,
     required_keys: list[str],
-    *,
-    schema_path: pathlib.Path | None = None,
 ) -> Credentials:
     """Resolve ``required_keys`` for ``namespace``, walking Tiers 1 → 2 → 3.
 
@@ -508,9 +506,14 @@ def load_credentials(
     ``str()`` form embeds those trailers under the key name so a
     user who ran ``creds setup`` can triage from the message alone.
 
-    The ``schema_path`` kwarg is reserved for T7 — primitive authors who
-    load their own schema can pass it here; the default ``None`` defers
-    to the canonical lookup (T7 wires the canonical path resolver).
+    Single responsibility: this function *resolves*. Schema concerns
+    (which keys a namespace declares, how to prompt for them, whether
+    ``required_keys`` matches the declared key set) live in the
+    ``agentbundle creds setup`` / ``creds check`` CLI surface — they
+    are not crossed through this signature. Primitive code is not
+    expected to validate against the schema at load time; if you
+    suspect a namespace / required-keys mismatch, run
+    ``agentbundle creds check <namespace>`` from the shell.
     """
     resolved: dict[str, str] = {}
     missing: list[str] = []

--- a/packages/agentbundle/tests/unit/test_credentials_schema.py
+++ b/packages/agentbundle/tests/unit/test_credentials_schema.py
@@ -198,19 +198,30 @@ def test__relative_schema_path_ignores_non_skill_md_entries():
     assert ".claude/skills/jira" in str(_relative_schema_path(state, "core", "jira"))
 
 
-# ── ``load_credentials(schema_path=...)`` kwarg (T3 + T7) ──────────────
+# ── ``load_credentials`` signature (T3) ────────────────────────────────
 
 
-def test_load_credentials_accepts_schema_path_kwarg(tmp_path, monkeypatch):
-    """Primitive authors can pass ``schema_path`` for their own schema
-    file — verified by signature inspection (the resolver-vs-passthrough
-    logic is exercised by the CLI in T8)."""
+def test_load_credentials_signature_is_minimal():
+    """The loader's public signature carries only ``namespace`` and
+    ``required_keys``, both positional-or-keyword with no defaults, no
+    `*args`, no `**kwargs`. Schema concerns (validating
+    ``required_keys`` against an on-disk schema) live in
+    ``agentbundle creds check``, not on the loader. Pin the *shape* of
+    each parameter — names alone don't defend the contract: a future
+    change to keyword-only, positional-only, or a default would slip
+    past a name-only assertion and break call-sites that pass
+    positionally.
+    """
     import inspect
 
     from agentbundle.creds.loader import load_credentials
     sig = inspect.signature(load_credentials)
-    assert "schema_path" in sig.parameters
-    param = sig.parameters["schema_path"]
-    # Keyword-only per AC3.
-    assert param.kind == inspect.Parameter.KEYWORD_ONLY
-    assert param.default is None
+    POK = inspect.Parameter.POSITIONAL_OR_KEYWORD
+    empty = inspect.Parameter.empty
+    actual = [
+        (p.name, p.kind, p.default) for p in sig.parameters.values()
+    ]
+    assert actual == [
+        ("namespace", POK, empty),
+        ("required_keys", POK, empty),
+    ]


### PR DESCRIPTION
## Summary

Closes Quality Blocker #4 from `docs/specs/skill-secrets/notes/review-round1-quality.md` — the last deferred item from the round-2 review pass. After a long-term-vs-tactical discussion, path **(a)** (remove the kwarg) is the right architectural call:

- **Single responsibility.** `load_credentials` *resolves* credentials across three tiers. Schema (which keys exist, how to prompt, whether `required_keys` matches the declared set) is a CLI concern owned by `creds setup` / `creds check`. Crossing the two through a kwarg couples concerns that should evolve independently.
- **Public-API minimality.** `agent_ready.credentials` is the only import primitive authors touch. Every parameter on its main function is a forever-supported contract that ends up in third-party code. Adding a consumer later is cheap; removing one is impossible.
- **No trapping APIs.** A no-op kwarg is worse than absent. If schema validation ever becomes genuinely useful, the right shape is a separate composable helper, not a kwarg on the resolver. The CLI's `creds check` verb already covers the immediate need.

## Changes

| File | Change |
| --- | --- |
| `agentbundle/creds/loader.py` | Drop `schema_path` from `load_credentials`; rewrite docstring to pin single-responsibility and point authors at `agentbundle creds check`. |
| `tests/unit/test_credentials_schema.py` | Delete `test_load_credentials_accepts_schema_path_kwarg`; replace with `test_load_credentials_signature_is_minimal` pinning `(name, kind, default)` tuples — a name-only assertion would slip past kind/default drift. |
| `docs/specs/skill-secrets/spec.md` | AC24b rewritten — resolver-only contract; AC3 and § Solution Sketch drop `=[...]` placeholder. |
| `docs/specs/skill-secrets/plan.md` | T3 Approach drops the kwarg mention; T7 Done-when redirects validation to the CLI; T7 Approach now lists `_relative_schema_path` (catches the stale name from PR #89's rename). |
| `agentbundle/commands/creds.py` | Docstring fix: `resolve_schema_path` → `_relative_schema_path`. |
| `docs/specs/skill-secrets/notes/review-round2-summary.md` | Quality #4 → Closed in PR #97; Pending decisions section removed; PR-list table gains row #97. |
| `docs/ROADMAP.md` | Open-follow-on bullet removed; Round-2 disposition entry added; stale `_resolve_schema_path` rename reference fixed. |

## Test plan

- [x] `make build-check` clean locally
- [x] 88/88 creds-related tests pass (`test_credentials_{schema,dotfile,loader}` + `test_creds_cli`)
- [x] `test_load_credentials_signature_is_minimal` pins the resolver-only contract structurally — kind + default drift is now caught, not just name drift
- [x] Adversarial reviewer ran twice; second pass returned all prior findings closed with a single Nit (markdown blank-line hygiene, fixed in the same commit)
- [x] No `schema_path=` call-site remains anywhere in the codebase, tests, fixtures, docs, guides, or worked-example