### PR TITLE
refactor(seeds): drop .claude/ click-targets from prose

### DIFF
--- a/.claude/skills/markdown-to-html/SKILL.md
+++ b/.claude/skills/markdown-to-html/SKILL.md
@@ -17,15 +17,14 @@ You are not the renderer. The script is. Invoke it and report the path.
 ### Step 1 — Verify dependencies
 
 ```bash
-# From the skill's own directory — user-scope install at
-# ~/.claude/skills/markdown-to-html/, repo-scope at
-# .claude/skills/markdown-to-html/.
+# From the skill's own directory — at the user-scope skills directory,
+# or the repo-scope skills directory.
 npm install   # installs marked + highlight.js per package.json
 ```
 
 (One-time; subsequent runs are cached in `node_modules/`.)
 
-> Note: at repo scope, add `.claude/skills/*/node_modules/` to your project's `.gitignore` to avoid committing the npm install artifacts.
+> Note: on Claude Code installs, add `.claude/skills/*/node_modules/` to your project's `.gitignore` to avoid committing the npm install artifacts.
 
 ### Step 2 — Render
 

--- a/.claude/skills/new-spec/assets/spec.md
+++ b/.claude/skills/new-spec/assets/spec.md
@@ -49,7 +49,7 @@ before proceeding; *Never do* is a hard rule, even under time pressure.
 ## Testing Strategy
 
 Name the verification mode(s) this spec uses. The
-[`work-loop`](../../../.claude/skills/work-loop/SKILL.md) skill defines three:
+`work-loop` skill defines three:
 
 - **TDD** — for logic with a compressible invariant.
 - **Goal-based check** — a one-liner verifies the outcome (a build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,15 +23,15 @@ Scope each change precisely to the request.
 ### Non-negotiables
 
 - **Surface assumptions before building.** Name them in PLAN's trio.
-  The declined-pattern register in [`work-loop`](.claude/skills/work-loop/SKILL.md)
+  The declined-pattern register in the `work-loop` skill
   names temptations; assumptions are different — call them out separately.
 - **Stop and ask when requirements conflict.** Use the Surface verb
-  defined in [`work-loop`](.claude/skills/work-loop/SKILL.md) — emit a
+  defined in the `work-loop` skill — emit a
   short description and wait.
 - **Push back when warranted.** Not a yes-machine. Disagreement goes in
   the PR description, not in silence.
 - **Prefer the boring, obvious solution.** Cleverness is expensive; see
-  the declined-pattern register in [`work-loop`](.claude/skills/work-loop/SKILL.md).
+  the declined-pattern register in the `work-loop` skill.
 - **Touch only what you're asked to touch.** See the rest of this section.
 
 - **Limit the diff to what the request requires — extra changes hide
@@ -76,7 +76,7 @@ exist yet** — ask, or open an RFC. Don't guess. Lifecycle and mechanics
 For anything beyond a one-line edit, follow the **plan → execute → verify →
 review** loop. The mechanics — verification modes, gate sequence, iteration
 cap, capture-learnings, specialist-reviewer pass — live in the
-[`work-loop`](.claude/skills/work-loop/SKILL.md) skill. Load it before
+`work-loop` skill. Load it before
 non-trivial work; that is the canonical source for *how* the loop runs.
 [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md#how-we-do-non-trivial-work)
 covers the *why*. Commits follow Conventional Commits — format and footer
@@ -134,17 +134,17 @@ Use the generated skill list below when a task matches a named workflow.
 plus the executor used by `work-loop`'s supervisor mode. Pick the
 reviewers the diff actually warrants; don't run all three by default.
 
-- [`adversarial-reviewer`](.claude/agents/adversarial-reviewer.md) — spec /
+- `adversarial-reviewer` — spec /
   plan / implementation drift; missing edge cases; scope creep. Default
   reviewer; runs after gates pass.
-- [`security-reviewer`](.claude/agents/security-reviewer.md) — OWASP Top
+- `security-reviewer` — OWASP Top
   10 (web + LLM Apps) and STRIDE lens. Use when the diff touches auth,
   secrets, user input, deserialization, file/network I/O, dependencies,
   or LLM/agent code. Complements SAST/SCA scanners; does not replace them.
-- [`quality-engineer`](.claude/agents/quality-engineer.md) — testability,
+- `quality-engineer` — testability,
   observability, reliability, and maintainability lens. Also drafts
   contract or construction tests on request.
-- [`implementer`](.claude/agents/implementer.md) — single-task executor;
+- `implementer` — single-task executor;
   `work-loop` dispatches one per task in supervisor mode. Not a
   reviewer; not selected by hand.
 
@@ -166,7 +166,7 @@ reviewers the diff actually warrants; don't run all three by default.
 
 Rationalizations the agent hits *before* the work-loop loads — when it's
 deciding whether to load it at all. The in-loop set lives in
-[`work-loop` § Anti-patterns](.claude/skills/work-loop/SKILL.md#anti-patterns-to-refuse).
+the `work-loop` skill's *Anti-patterns* section.
 
 | Excuse | What to do instead |
 | --- | --- |

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -139,7 +139,7 @@ Numbers are sequential and never reused.
 
 **Status values:** `Proposed` → `Accepted` → (`Deprecated` | `Superseded by ADR-NNNN`).
 
-**Template:** [`new-adr/assets/adr.md`](../.claude/skills/new-adr/assets/adr.md) — lives with the `new-adr` skill that creates ADRs from it.
+**Template:** `assets/adr.md` in the `new-adr` skill that creates ADRs from it.
 
 **When to write an ADR:**
 
@@ -183,7 +183,7 @@ After follow-ons exist, the RFC's job is done. It stays in the repo as history.
 
 **Filename:** `NNNN-kebab-case-title.md`. Numbers are sequential.
 
-**Template:** [`new-rfc/assets/rfc.md`](../.claude/skills/new-rfc/assets/rfc.md) — lives with the `new-rfc` skill that creates RFCs from it.
+**Template:** `assets/rfc.md` in the `new-rfc` skill that creates RFCs from it.
 
 **When to open an RFC:**
 
@@ -234,7 +234,7 @@ documentation of the feature's contract — but at that point the *code is the
 truth*, and the spec is reference material that should be updated alongside
 behavior changes.
 
-**Template:** [`new-spec/assets/spec.md`](../.claude/skills/new-spec/assets/spec.md), [`new-spec/assets/plan.md`](../.claude/skills/new-spec/assets/plan.md) — both live with the `new-spec` skill that creates the pair.
+**Template:** `assets/spec.md` and `assets/plan.md` in the `new-spec` skill that creates the pair.
 
 **Cite upward, never downward:** a spec links to the ADRs and RFCs that
 constrain it. ADRs do not link to specs (specs are too small and short-lived
@@ -448,7 +448,7 @@ must be noted in `CHANGELOG.md`.
 
 For anything beyond a one-line edit, follow the **plan → execute → verify →
 review → iterate** loop. The mechanics are in the
-[`work-loop`](../.claude/skills/work-loop/SKILL.md) skill; this section is
+`work-loop` skill; this section is
 the why.
 
 **Why a loop, not a single pass.** LLM self-assessment is unreliable: agents
@@ -484,12 +484,11 @@ kind of learning belongs.
 
 The work-loop's `state.json` schema, exit contract, lifecycle, and
 atomic-write discipline live with the skill that consumes them —
-see [`.claude/skills/work-loop/references/state-schema.md`](../.claude/skills/work-loop/references/state-schema.md).
-The template at [`.claude/skills/work-loop/assets/state.json`](../.claude/skills/work-loop/assets/state.json)
+see `references/state-schema.md` in the `work-loop` skill.
+The template at `assets/state.json` in the `work-loop` skill
 is the starting point `loop-cohort init` copies in. Every state mutation
 (init, plan-approval, fingerprint rotation, worktree coordination) is
-owned by the
-[`loop-cohort`](../.claude/skills/work-loop/scripts/loop-cohort.py) tool;
+owned by the `loop-cohort` tool;
 SKILL prose calls each verb at the appropriate phase rather than
 mutating JSON by hand.
 
@@ -518,10 +517,10 @@ work-loop enters **supervisor mode**: one primary orchestrator
 dispatches `implementer` subagents in parallel, each working in its own
 git worktree, then merges the results back and runs gates in the
 primary. The trigger and one-sentence concept live in the
-[`work-loop` skill](../.claude/skills/work-loop/SKILL.md) §EXECUTE; the
+`work-loop` skill §EXECUTE; the
 step-by-step procedure (pre-flight, worktree setup, dispatch, report
 persistence, non-ready handling, merge, cleanup) lives in the skill's
-[`references/supervisor-mode.md`](../.claude/skills/work-loop/references/supervisor-mode.md).
+`references/supervisor-mode.md`.
 This section is the why and the boundary.
 
 **Why a separate mode instead of a separate skill.** The trigger is
@@ -546,7 +545,7 @@ history for traceability.
 **Merge discipline.** The supervisor merges with `git merge --no-ff
 <base>-<task-id>` into the primary branch, **sequentially in task-id
 order**. The procedure file
-([`references/supervisor-mode.md`](../.claude/skills/work-loop/references/supervisor-mode.md))
+(`references/supervisor-mode.md` in the `work-loop` skill)
 has the executable form (including how to order non-numeric IDs). If a
 sequential merge conflicts, the tasks weren't actually independent —
 the plan was wrong. Surface that as a PLAN-level escalation, not a
@@ -571,8 +570,7 @@ walk-through, not by an executed end-to-end dry-run. Any change to
 schema** must perform an actual `git worktree add` + parallel-dispatch
 round against a throwaway spec before merging — read-only walk-through
 is not sufficient for those surfaces. Step numbers refer to the
-procedure at
-[`work-loop/references/supervisor-mode.md`](../.claude/skills/work-loop/references/supervisor-mode.md).
+procedure at `references/supervisor-mode.md` in the `work-loop` skill.
 
 ### Knowledge base
 
@@ -600,7 +598,7 @@ caller's `--scope` value as the *path* argument and the entry's
 stored glob as the *pattern*, so an agent working in
 `packages/auth/server.ts` gets entries scoped to `packages/auth/**`
 plus any repo-wide `*` entries. The work-loop SKILL's
-[`Capture what was learned`](../.claude/skills/work-loop/SKILL.md#capture-what-was-learned)
+*Capture what was learned*
 section points contributors at this file as the destination for
 pattern/gotcha/antipattern-shaped learnings; other shapes still go
 where they already belong (AGENTS.md, skill bodies, architecture/).
@@ -613,13 +611,13 @@ enforcement triplet" and mean the same three things:
 
 | Layer | Mechanism | What it gates |
 |---|---|---|
-| Caps | [`.claude/skills/work-loop/scripts/loop-cohort.py`](../.claude/skills/work-loop/scripts/loop-cohort.py) `check` | Iteration cap, token budget, plan approval, fingerprint stasis (see [`work-loop/references/state-schema.md`](../.claude/skills/work-loop/references/state-schema.md)). The same tool owns every state mutation upstream of the check. |
+| Caps | `scripts/loop-cohort.py check` in the `work-loop` skill | Iteration cap, token budget, plan approval, fingerprint stasis (see `references/state-schema.md` in the `work-loop` skill). The same tool owns every state mutation upstream of the check. |
 | Artifacts | `tools/lint-agents-md.py`, `lint-agent-artifacts.py`, `lint-knowledge.py`, `lint-build.py` | Shape and content hygiene for every `.claude/`, `AGENTS.md`, and `docs/knowledge/` artifact. |
 | Aggregation | [`tools/hooks/pre-pr.py`](../tools/hooks/pre-pr.py) | Runs caps + artifact linters together before a PR opens. CI mirrors this — `.github/workflows/docs.yml` has a job per enforcement layer, including a `hooks` job that runs the aggregator end-to-end. Keep the local hook green and CI follows. |
 
 The triplet is **Shift Left**: catch problems as early as possible,
 locally before CI, at PLAN before EXECUTE. The
-[pre-EXECUTE adversarial review](../.claude/skills/work-loop/SKILL.md) in
+pre-EXECUTE adversarial review in
 the work-loop skill is the same pattern at a different layer — moving
 review left from after code is written to before it is.
 
@@ -652,7 +650,7 @@ opening an ADR, running a release. They live in `.claude/skills/<name>/SKILL.md`
 Add a skill when you've done the same multi-step thing three times. Don't add
 one speculatively — speculative skills bloat context and degrade adherence.
 
-The skill index is at [`.claude/skills/README.md`](../.claude/skills/README.md).
+The skill index is generated at the bottom of `AGENTS.md`.
 
 ---
 
@@ -733,7 +731,7 @@ template adopter knows when to wire each one up.
 - **Profile B** — [supervisor mode](#supervisor-mode) earns its keep
   when a plan produces two or more `Depends on: none` tasks. Reviewer
   fan-out follows the
-  [parallel-dispatch discipline](../.claude/skills/work-loop/SKILL.md#parallel-dispatch-discipline)
+  *Parallel dispatch discipline* section
   in the work-loop skill: one tool-call message, one Agent use per
   reviewer, barrier-wait, merge in the orchestrator's context.
 - **Profile C** — same as B, plus the [knowledge base](#knowledge-base)
@@ -780,7 +778,7 @@ already lives in this repo. These are the in-loop counterparts to the
 | The lie | The rebuttal |
 | --- | --- |
 | "We'll update the spec after the PR." | Spec drift is a bug, not follow-up work — update spec and code in the same PR. See [`AGENTS.md` § How we work](../AGENTS.md#how-we-work) and the spec lifecycle rule in § 4 above. |
-| "I'll verify this manually, just this once." | Verification mode — TDD, goal-based, or manual QA — is declared in the plan task, not improvised at the keyboard. If manual QA is the right mode, write it down; if it isn't, pick TDD or a goal-based check. See the PLAN phase in [`work-loop`](../.claude/skills/work-loop/SKILL.md). |
+| "I'll verify this manually, just this once." | Verification mode — TDD, goal-based, or manual QA — is declared in the plan task, not improvised at the keyboard. If manual QA is the right mode, write it down; if it isn't, pick TDD or a goal-based check. See the PLAN phase in the `work-loop` skill. |
 | "I can fix this while I'm here." | Out-of-scope changes need a separate PR or an explicit note in the plan. Scope creep is the most common cause of failed adversarial review. See [`AGENTS.md` § Keeping changes minimal](../AGENTS.md#keeping-changes-minimal). |
 | "This decision doesn't need an ADR — it's obvious." | If you're making it, it isn't obvious to the next person. Writing an ADR now costs less than someone re-litigating the decision in six months. See § 2 above and the `new-adr` skill. |
 

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -90,8 +90,8 @@ what you used to worry about.
 
 ## Where this fits in the work-loop
 
-[`.claude/skills/work-loop/SKILL.md`](../../.claude/skills/work-loop/SKILL.md)
-§ "Capture what was learned" points back at this file. When a loop
+The `work-loop` skill's *Capture what was learned*
+section points back at this file. When a loop
 captures a learning that fits the pattern/gotcha/antipattern shape, the
 canonical home is here. Other kinds of learning still go where they
 already belong (AGENTS.md, skill bodies, architecture/).

--- a/packages/README.md
+++ b/packages/README.md
@@ -9,4 +9,4 @@ package; each owns its own build/test surface.
 A package's `AGENTS.md` (if present) describes per-package rules that
 override or extend the root `AGENTS.md`. Cross-package work — anything
 that touches more than one package — goes through the
-[`work-loop`](../.claude/skills/work-loop/SKILL.md) skill.
+`work-loop` skill.

--- a/packs/converters/.apm/skills/markdown-to-html/SKILL.md
+++ b/packs/converters/.apm/skills/markdown-to-html/SKILL.md
@@ -17,15 +17,14 @@ You are not the renderer. The script is. Invoke it and report the path.
 ### Step 1 — Verify dependencies
 
 ```bash
-# From the skill's own directory — user-scope install at
-# ~/.claude/skills/markdown-to-html/, repo-scope at
-# .claude/skills/markdown-to-html/.
+# From the skill's own directory — at the user-scope skills directory,
+# or the repo-scope skills directory.
 npm install   # installs marked + highlight.js per package.json
 ```
 
 (One-time; subsequent runs are cached in `node_modules/`.)
 
-> Note: at repo scope, add `.claude/skills/*/node_modules/` to your project's `.gitignore` to avoid committing the npm install artifacts.
+> Note: on Claude Code installs, add `.claude/skills/*/node_modules/` to your project's `.gitignore` to avoid committing the npm install artifacts.
 
 ### Step 2 — Render
 

--- a/packs/core/.apm/skills/new-spec/assets/spec.md
+++ b/packs/core/.apm/skills/new-spec/assets/spec.md
@@ -49,7 +49,7 @@ before proceeding; *Never do* is a hard rule, even under time pressure.
 ## Testing Strategy
 
 Name the verification mode(s) this spec uses. The
-[`work-loop`](../../../.claude/skills/work-loop/SKILL.md) skill defines three:
+`work-loop` skill defines three:
 
 - **TDD** — for logic with a compressible invariant.
 - **Goal-based check** — a one-liner verifies the outcome (a build

--- a/packs/core/seeds/AGENTS.md
+++ b/packs/core/seeds/AGENTS.md
@@ -23,15 +23,15 @@ Scope each change precisely to the request.
 ### Non-negotiables
 
 - **Surface assumptions before building.** Name them in PLAN's trio.
-  The declined-pattern register in [`work-loop`](.claude/skills/work-loop/SKILL.md)
+  The declined-pattern register in the `work-loop` skill
   names temptations; assumptions are different — call them out separately.
 - **Stop and ask when requirements conflict.** Use the Surface verb
-  defined in [`work-loop`](.claude/skills/work-loop/SKILL.md) — emit a
+  defined in the `work-loop` skill — emit a
   short description and wait.
 - **Push back when warranted.** Not a yes-machine. Disagreement goes in
   the PR description, not in silence.
 - **Prefer the boring, obvious solution.** Cleverness is expensive; see
-  the declined-pattern register in [`work-loop`](.claude/skills/work-loop/SKILL.md).
+  the declined-pattern register in the `work-loop` skill.
 - **Touch only what you're asked to touch.** See the rest of this section.
 
 - **Limit the diff to what the request requires — extra changes hide
@@ -76,7 +76,7 @@ exist yet** — ask, or open an RFC. Don't guess. Lifecycle and mechanics
 For anything beyond a one-line edit, follow the **plan → execute → verify →
 review** loop. The mechanics — verification modes, gate sequence, iteration
 cap, capture-learnings, specialist-reviewer pass — live in the
-[`work-loop`](.claude/skills/work-loop/SKILL.md) skill. Load it before
+`work-loop` skill. Load it before
 non-trivial work; that is the canonical source for *how* the loop runs.
 [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md#how-we-do-non-trivial-work)
 covers the *why*. Commits follow Conventional Commits — format and footer
@@ -119,17 +119,17 @@ Use the generated skill list below when a task matches a named workflow.
 plus the executor used by `work-loop`'s supervisor mode. Pick the
 reviewers the diff actually warrants; don't run all three by default.
 
-- [`adversarial-reviewer`](.claude/agents/adversarial-reviewer.md) — spec /
+- `adversarial-reviewer` — spec /
   plan / implementation drift; missing edge cases; scope creep. Default
   reviewer; runs after gates pass.
-- [`security-reviewer`](.claude/agents/security-reviewer.md) — OWASP Top
+- `security-reviewer` — OWASP Top
   10 (web + LLM Apps) and STRIDE lens. Use when the diff touches auth,
   secrets, user input, deserialization, file/network I/O, dependencies,
   or LLM/agent code. Complements SAST/SCA scanners; does not replace them.
-- [`quality-engineer`](.claude/agents/quality-engineer.md) — testability,
+- `quality-engineer` — testability,
   observability, reliability, and maintainability lens. Also drafts
   contract or construction tests on request.
-- [`implementer`](.claude/agents/implementer.md) — single-task executor;
+- `implementer` — single-task executor;
   `work-loop` dispatches one per task in supervisor mode. Not a
   reviewer; not selected by hand.
 
@@ -151,7 +151,7 @@ reviewers the diff actually warrants; don't run all three by default.
 
 Rationalizations the agent hits *before* the work-loop loads — when it's
 deciding whether to load it at all. The in-loop set lives in
-[`work-loop` § Anti-patterns](.claude/skills/work-loop/SKILL.md#anti-patterns-to-refuse).
+the `work-loop` skill's *Anti-patterns* section.
 
 | Excuse | What to do instead |
 | --- | --- |

--- a/packs/core/seeds/docs/CONVENTIONS.md
+++ b/packs/core/seeds/docs/CONVENTIONS.md
@@ -139,7 +139,7 @@ Numbers are sequential and never reused.
 
 **Status values:** `Proposed` → `Accepted` → (`Deprecated` | `Superseded by ADR-NNNN`).
 
-**Template:** [`new-adr/assets/adr.md`](../.claude/skills/new-adr/assets/adr.md) — lives with the `new-adr` skill that creates ADRs from it.
+**Template:** `assets/adr.md` in the `new-adr` skill that creates ADRs from it.
 
 **When to write an ADR:**
 
@@ -183,7 +183,7 @@ After follow-ons exist, the RFC's job is done. It stays in the repo as history.
 
 **Filename:** `NNNN-kebab-case-title.md`. Numbers are sequential.
 
-**Template:** [`new-rfc/assets/rfc.md`](../.claude/skills/new-rfc/assets/rfc.md) — lives with the `new-rfc` skill that creates RFCs from it.
+**Template:** `assets/rfc.md` in the `new-rfc` skill that creates RFCs from it.
 
 **When to open an RFC:**
 
@@ -234,7 +234,7 @@ documentation of the feature's contract — but at that point the *code is the
 truth*, and the spec is reference material that should be updated alongside
 behavior changes.
 
-**Template:** [`new-spec/assets/spec.md`](../.claude/skills/new-spec/assets/spec.md), [`new-spec/assets/plan.md`](../.claude/skills/new-spec/assets/plan.md) — both live with the `new-spec` skill that creates the pair.
+**Template:** `assets/spec.md` and `assets/plan.md` in the `new-spec` skill that creates the pair.
 
 **Cite upward, never downward:** a spec links to the ADRs and RFCs that
 constrain it. ADRs do not link to specs (specs are too small and short-lived
@@ -448,7 +448,7 @@ must be noted in `CHANGELOG.md`.
 
 For anything beyond a one-line edit, follow the **plan → execute → verify →
 review → iterate** loop. The mechanics are in the
-[`work-loop`](../.claude/skills/work-loop/SKILL.md) skill; this section is
+`work-loop` skill; this section is
 the why.
 
 **Why a loop, not a single pass.** LLM self-assessment is unreliable: agents
@@ -484,12 +484,11 @@ kind of learning belongs.
 
 The work-loop's `state.json` schema, exit contract, lifecycle, and
 atomic-write discipline live with the skill that consumes them —
-see [`.claude/skills/work-loop/references/state-schema.md`](../.claude/skills/work-loop/references/state-schema.md).
-The template at [`.claude/skills/work-loop/assets/state.json`](../.claude/skills/work-loop/assets/state.json)
+see `references/state-schema.md` in the `work-loop` skill.
+The template at `assets/state.json` in the `work-loop` skill
 is the starting point `loop-cohort init` copies in. Every state mutation
 (init, plan-approval, fingerprint rotation, worktree coordination) is
-owned by the
-[`loop-cohort`](../.claude/skills/work-loop/scripts/loop-cohort.py) tool;
+owned by the `loop-cohort` tool;
 SKILL prose calls each verb at the appropriate phase rather than
 mutating JSON by hand.
 
@@ -518,10 +517,10 @@ work-loop enters **supervisor mode**: one primary orchestrator
 dispatches `implementer` subagents in parallel, each working in its own
 git worktree, then merges the results back and runs gates in the
 primary. The trigger and one-sentence concept live in the
-[`work-loop` skill](../.claude/skills/work-loop/SKILL.md) §EXECUTE; the
+`work-loop` skill §EXECUTE; the
 step-by-step procedure (pre-flight, worktree setup, dispatch, report
 persistence, non-ready handling, merge, cleanup) lives in the skill's
-[`references/supervisor-mode.md`](../.claude/skills/work-loop/references/supervisor-mode.md).
+`references/supervisor-mode.md`.
 This section is the why and the boundary.
 
 **Why a separate mode instead of a separate skill.** The trigger is
@@ -546,7 +545,7 @@ history for traceability.
 **Merge discipline.** The supervisor merges with `git merge --no-ff
 <base>-<task-id>` into the primary branch, **sequentially in task-id
 order**. The procedure file
-([`references/supervisor-mode.md`](../.claude/skills/work-loop/references/supervisor-mode.md))
+(`references/supervisor-mode.md` in the `work-loop` skill)
 has the executable form (including how to order non-numeric IDs). If a
 sequential merge conflicts, the tasks weren't actually independent —
 the plan was wrong. Surface that as a PLAN-level escalation, not a
@@ -571,8 +570,7 @@ walk-through, not by an executed end-to-end dry-run. Any change to
 schema** must perform an actual `git worktree add` + parallel-dispatch
 round against a throwaway spec before merging — read-only walk-through
 is not sufficient for those surfaces. Step numbers refer to the
-procedure at
-[`work-loop/references/supervisor-mode.md`](../.claude/skills/work-loop/references/supervisor-mode.md).
+procedure at `references/supervisor-mode.md` in the `work-loop` skill.
 
 ### Knowledge base
 
@@ -600,7 +598,7 @@ caller's `--scope` value as the *path* argument and the entry's
 stored glob as the *pattern*, so an agent working in
 `packages/auth/server.ts` gets entries scoped to `packages/auth/**`
 plus any repo-wide `*` entries. The work-loop SKILL's
-[`Capture what was learned`](../.claude/skills/work-loop/SKILL.md#capture-what-was-learned)
+*Capture what was learned*
 section points contributors at this file as the destination for
 pattern/gotcha/antipattern-shaped learnings; other shapes still go
 where they already belong (AGENTS.md, skill bodies, architecture/).
@@ -613,13 +611,13 @@ enforcement triplet" and mean the same three things:
 
 | Layer | Mechanism | What it gates |
 |---|---|---|
-| Caps | [`.claude/skills/work-loop/scripts/loop-cohort.py`](../.claude/skills/work-loop/scripts/loop-cohort.py) `check` | Iteration cap, token budget, plan approval, fingerprint stasis (see [`work-loop/references/state-schema.md`](../.claude/skills/work-loop/references/state-schema.md)). The same tool owns every state mutation upstream of the check. |
+| Caps | `scripts/loop-cohort.py check` in the `work-loop` skill | Iteration cap, token budget, plan approval, fingerprint stasis (see `references/state-schema.md` in the `work-loop` skill). The same tool owns every state mutation upstream of the check. |
 | Artifacts | `tools/lint-agents-md.py`, `lint-agent-artifacts.py`, `lint-knowledge.py`, `lint-build.py` | Shape and content hygiene for every `.claude/`, `AGENTS.md`, and `docs/knowledge/` artifact. |
 | Aggregation | [`tools/hooks/pre-pr.py`](../tools/hooks/pre-pr.py) | Runs caps + artifact linters together before a PR opens. CI mirrors this — `.github/workflows/docs.yml` has a job per enforcement layer, including a `hooks` job that runs the aggregator end-to-end. Keep the local hook green and CI follows. |
 
 The triplet is **Shift Left**: catch problems as early as possible,
 locally before CI, at PLAN before EXECUTE. The
-[pre-EXECUTE adversarial review](../.claude/skills/work-loop/SKILL.md) in
+pre-EXECUTE adversarial review in
 the work-loop skill is the same pattern at a different layer — moving
 review left from after code is written to before it is.
 
@@ -652,7 +650,7 @@ opening an ADR, running a release. They live in `.claude/skills/<name>/SKILL.md`
 Add a skill when you've done the same multi-step thing three times. Don't add
 one speculatively — speculative skills bloat context and degrade adherence.
 
-The skill index is at [`.claude/skills/README.md`](../.claude/skills/README.md).
+The skill index is generated at the bottom of `AGENTS.md`.
 
 ---
 
@@ -733,7 +731,7 @@ template adopter knows when to wire each one up.
 - **Profile B** — [supervisor mode](#supervisor-mode) earns its keep
   when a plan produces two or more `Depends on: none` tasks. Reviewer
   fan-out follows the
-  [parallel-dispatch discipline](../.claude/skills/work-loop/SKILL.md#parallel-dispatch-discipline)
+  *Parallel dispatch discipline* section
   in the work-loop skill: one tool-call message, one Agent use per
   reviewer, barrier-wait, merge in the orchestrator's context.
 - **Profile C** — same as B, plus the [knowledge base](#knowledge-base)
@@ -780,7 +778,7 @@ already lives in this repo. These are the in-loop counterparts to the
 | The lie | The rebuttal |
 | --- | --- |
 | "We'll update the spec after the PR." | Spec drift is a bug, not follow-up work — update spec and code in the same PR. See [`AGENTS.md` § How we work](../AGENTS.md#how-we-work) and the spec lifecycle rule in § 4 above. |
-| "I'll verify this manually, just this once." | Verification mode — TDD, goal-based, or manual QA — is declared in the plan task, not improvised at the keyboard. If manual QA is the right mode, write it down; if it isn't, pick TDD or a goal-based check. See the PLAN phase in [`work-loop`](../.claude/skills/work-loop/SKILL.md). |
+| "I'll verify this manually, just this once." | Verification mode — TDD, goal-based, or manual QA — is declared in the plan task, not improvised at the keyboard. If manual QA is the right mode, write it down; if it isn't, pick TDD or a goal-based check. See the PLAN phase in the `work-loop` skill. |
 | "I can fix this while I'm here." | Out-of-scope changes need a separate PR or an explicit note in the plan. Scope creep is the most common cause of failed adversarial review. See [`AGENTS.md` § Keeping changes minimal](../AGENTS.md#keeping-changes-minimal). |
 | "This decision doesn't need an ADR — it's obvious." | If you're making it, it isn't obvious to the next person. Writing an ADR now costs less than someone re-litigating the decision in six months. See § 2 above and the `new-adr` skill. |
 

--- a/packs/core/seeds/docs/knowledge/README.md
+++ b/packs/core/seeds/docs/knowledge/README.md
@@ -90,8 +90,8 @@ what you used to worry about.
 
 ## Where this fits in the work-loop
 
-[`.claude/skills/work-loop/SKILL.md`](../../.claude/skills/work-loop/SKILL.md)
-§ "Capture what was learned" points back at this file. When a loop
+The `work-loop` skill's *Capture what was learned*
+section points back at this file. When a loop
 captures a learning that fits the pattern/gotcha/antipattern shape, the
 canonical home is here. Other kinds of learning still go where they
 already belong (AGENTS.md, skill bodies, architecture/).

--- a/packs/monorepo-extras/seeds/packages/README.md
+++ b/packs/monorepo-extras/seeds/packages/README.md
@@ -9,4 +9,4 @@ package; each owns its own build/test surface.
 A package's `AGENTS.md` (if present) describes per-package rules that
 override or extend the root `AGENTS.md`. Cross-package work — anything
 that touches more than one package — goes through the
-[`work-loop`](../.claude/skills/work-loop/SKILL.md) skill.
+`work-loop` skill.


### PR DESCRIPTION
## Summary
- Drops `[label](.claude/skills/...)` and `[label](.claude/agents/...)` click-target links from seed sources in favor of name-only prose references.
- Skill/agent discovery is filesystem-scan + YAML-description-match in every target IDE (Claude Code, Kiro, Copilot, Codex) — markdown links never participated in discovery. They were Claude-Code-specific human affordances.
- Result: seed sources are now adapter-agnostic for skill/agent references. Removes the need for a path-map mechanism to rewrite these links per IDE.

## Scope
- 6 seed files under `packs/*/seeds/` and `packs/*/.apm/skills/{new-spec,markdown-to-html}/`.
- 29 click-target occurrences rewritten across rule classes A–G (see commit message and the source brief for the rule table).
- Projected files (root `AGENTS.md`, `docs/CONVENTIONS.md`, etc.) regenerate via `make build-self FORCE=1` — included in the diff but not separately hand-edited; the projection mirrors the seed diff line-for-line.

## Out of scope (deferred)
- `docs/rfc/`, `docs/adr/`, `docs/specs/` at repo root (this repo's historical governance, not projected; small number of refs, not worth churning).
- Codex adapter's "merge skills into AGENTS.md" model — Codex now natively supports `.agents/skills/`. Tracked in a separate RFC PR opening next.

## Test plan
- [x] `grep -rnE '\]\(\.\.?[\./]*\.claude/' packs/core/seeds/ packs/governance-extras/seeds/ packs/monorepo-extras/seeds/` returns zero hits.
- [x] `make build-self FORCE=1` regenerates projections; projected diff matches seed edits 1:1 (6 seed files → 6 projected files, identical insertion/deletion counts).
- [x] `make lint-packs` and `make validate` pass.
- [x] 5 rewrites spot-checked in projected `AGENTS.md` for natural readability.
- [x] Generated skill list at bottom of `AGENTS.md` still lists `work-loop` (YAML-driven; unchanged).