### PR TITLE
refactor(skills): drop install-path prefixes from SKILL.md bodies

### DIFF
--- a/.claude/skills/add-credentialed-skill/SKILL.md
+++ b/.claude/skills/add-credentialed-skill/SKILL.md
@@ -133,5 +133,5 @@ catches what the lint can't.
 
 - Spec: `docs/specs/skill-secrets/spec.md` (this skill is canonical for AC28)
 - RFC: `docs/rfc/0006-skill-secrets-storage.md` § 4 (the "Don't" block source)
-- Worked example: `packs/core/.apm/skills/example-credentialed-skill/`
+- Worked example: the `example-credentialed-skill` skill
   (ships in T12; until then, this skill's template is the reference)

--- a/.claude/skills/example-credentialed-skill/SKILL.md
+++ b/.claude/skills/example-credentialed-skill/SKILL.md
@@ -95,5 +95,5 @@ are load-bearing pattern you leave alone.
 ## Reference
 
 - Spec: `docs/specs/skill-secrets/spec.md` (§ AC29 pins this skill's shape)
-- Author skill: `packs/core/.apm/skills/add-credentialed-skill/`
+- Author skill: the `add-credentialed-skill` skill
 - RFC: `docs/rfc/0006-skill-secrets-storage.md`

--- a/.claude/skills/markdown-to-html/SKILL.md
+++ b/.claude/skills/markdown-to-html/SKILL.md
@@ -24,7 +24,7 @@ npm install   # installs marked + highlight.js per package.json
 
 (One-time; subsequent runs are cached in `node_modules/`.)
 
-> Note: on Claude Code installs, add `.claude/skills/*/node_modules/` to your project's `.gitignore` to avoid committing the npm install artifacts.
+> Note: if your installer drops this skill into a tracked directory, add the skill's `node_modules/` to your project's `.gitignore` to avoid committing the npm install artifacts.
 
 ### Step 2 — Render
 

--- a/.claude/skills/new-spec/SKILL.md
+++ b/.claude/skills/new-spec/SKILL.md
@@ -23,9 +23,8 @@ look like?" before any code.
 2. Create the directory and copy this skill's bundled `assets/spec.md`
    and `assets/plan.md` into it as `docs/specs/<feature>/spec.md` and
    `docs/specs/<feature>/plan.md`. (Paths are skill-relative — the
-   `assets/` folder lives next to this `SKILL.md` wherever your IDE
-   installed the skill: `.claude/skills/new-spec/assets/` on Claude
-   Code, `.kiro/skills/new-spec/assets/` on Kiro, etc.)
+   `assets/` folder lives next to this `SKILL.md` wherever your
+   installer placed the skill.)
 
 3. **Surface assumptions before writing any spec body.** With the
    directory scaffolded, stop. Emit a numbered list under the heading

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -409,7 +409,7 @@ Where the answer goes depends on the *shape* of the learning:
   vocabulary issue (a term that means something specific here), it
   goes in `docs/guides/reference/` as a glossary entry.
 - "This workflow is now the third time I've done it" → propose it as a new
-  skill in `.claude/skills/`.
+  skill.
 
 This is the part of the loop that makes the *project* smarter, not just the
 current PR. Skipping it means the next agent (or you, next month) will

--- a/packs/converters/.apm/skills/markdown-to-html/SKILL.md
+++ b/packs/converters/.apm/skills/markdown-to-html/SKILL.md
@@ -24,7 +24,7 @@ npm install   # installs marked + highlight.js per package.json
 
 (One-time; subsequent runs are cached in `node_modules/`.)
 
-> Note: on Claude Code installs, add `.claude/skills/*/node_modules/` to your project's `.gitignore` to avoid committing the npm install artifacts.
+> Note: if your installer drops this skill into a tracked directory, add the skill's `node_modules/` to your project's `.gitignore` to avoid committing the npm install artifacts.
 
 ### Step 2 — Render
 

--- a/packs/core/.apm/skills/add-credentialed-skill/SKILL.md
+++ b/packs/core/.apm/skills/add-credentialed-skill/SKILL.md
@@ -133,5 +133,5 @@ catches what the lint can't.
 
 - Spec: `docs/specs/skill-secrets/spec.md` (this skill is canonical for AC28)
 - RFC: `docs/rfc/0006-skill-secrets-storage.md` § 4 (the "Don't" block source)
-- Worked example: `packs/core/.apm/skills/example-credentialed-skill/`
+- Worked example: the `example-credentialed-skill` skill
   (ships in T12; until then, this skill's template is the reference)

--- a/packs/core/.apm/skills/example-credentialed-skill/SKILL.md
+++ b/packs/core/.apm/skills/example-credentialed-skill/SKILL.md
@@ -95,5 +95,5 @@ are load-bearing pattern you leave alone.
 ## Reference
 
 - Spec: `docs/specs/skill-secrets/spec.md` (§ AC29 pins this skill's shape)
-- Author skill: `packs/core/.apm/skills/add-credentialed-skill/`
+- Author skill: the `add-credentialed-skill` skill
 - RFC: `docs/rfc/0006-skill-secrets-storage.md`

--- a/packs/core/.apm/skills/new-spec/SKILL.md
+++ b/packs/core/.apm/skills/new-spec/SKILL.md
@@ -23,9 +23,8 @@ look like?" before any code.
 2. Create the directory and copy this skill's bundled `assets/spec.md`
    and `assets/plan.md` into it as `docs/specs/<feature>/spec.md` and
    `docs/specs/<feature>/plan.md`. (Paths are skill-relative — the
-   `assets/` folder lives next to this `SKILL.md` wherever your IDE
-   installed the skill: `.claude/skills/new-spec/assets/` on Claude
-   Code, `.kiro/skills/new-spec/assets/` on Kiro, etc.)
+   `assets/` folder lives next to this `SKILL.md` wherever your
+   installer placed the skill.)
 
 3. **Surface assumptions before writing any spec body.** With the
    directory scaffolded, stop. Emit a numbered list under the heading

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -409,7 +409,7 @@ Where the answer goes depends on the *shape* of the learning:
   vocabulary issue (a term that means something specific here), it
   goes in `docs/guides/reference/` as a glossary entry.
 - "This workflow is now the third time I've done it" → propose it as a new
-  skill in `.claude/skills/`.
+  skill.
 
 This is the part of the loop that makes the *project* smarter, not just the
 current PR. Skipping it means the next agent (or you, next month) will


### PR DESCRIPTION
## Summary

Five SKILL.md bodies still baked install paths (`.claude/skills/...` or `packs/<pack>/.apm/skills/...`) into their prose. After this PR, no SKILL.md body in the repo references those paths. Recent precursors (`drop-seed-claude-links`, `strip-leading-dot-api-contract`) handled most of the surface; this closes the residual five.

## Rewrites (before → after)

- **`markdown-to-html`** — *"on Claude Code installs, add `.claude/skills/*/node_modules/` to your project's `.gitignore`"* → *"if your installer drops this skill into a tracked directory, add the skill's `node_modules/` to your project's `.gitignore`"*.
- **`add-credentialed-skill`** — *"Worked example: `packs/core/.apm/skills/example-credentialed-skill/`"* → *"Worked example: the `example-credentialed-skill` skill"*.
- **`example-credentialed-skill`** — *"Author skill: `packs/core/.apm/skills/add-credentialed-skill/`"* → *"Author skill: the `add-credentialed-skill` skill"*.
- **`new-spec`** — parenthetical enumerating *"`.claude/skills/new-spec/assets/` on Claude Code, `.kiro/skills/new-spec/assets/` on Kiro, etc."* → single clause *"the `assets/` folder lives next to this `SKILL.md` wherever your installer placed the skill"*.
- **`work-loop`** — *"propose it as a new skill in `.claude/skills/`"* → *"propose it as a new skill"*.

## Rationale

[agentskills.io/specification § "File references"](https://agentskills.io/specification) — skills are self-describing and cross-installer portable. Inside a SKILL.md body, paths must be either skill-relative (`scripts/foo.py`, `assets/`, `references/REF.md`) or referenced by skill name. Installer-specific layouts leak the host install's shape into the skill itself, so a skill that bakes `.claude/skills/<name>/...` into its prose can't move cleanly into an adopter project where skills may live elsewhere.

Allowed (not touched here): `~/.claude/...` (user-scope) and `.claude/agents/<name>` — these are not skill plumbing.

## Follow-up

A `tools/lint-skill-spec.py` PR will encode the rule mechanically (and pin the SKILL.md frontmatter shape). This PR is the prose-cleanup precursor — the linter is intentionally out of scope here.

## Test plan

- [x] Audit grep returns zero hits in `packs/*/.apm/skills/*/SKILL.md` and `.claude/skills/*/SKILL.md`.
- [x] `make build-self && make build-check` exits 0; seed/projection pairs byte-identical.
- [x] `tools/test-all.sh` exits 0 (5/5: loop-cohort, lint-agent-artifacts, lint-knowledge, pre-pr, session-start).
- [x] `adversarial-reviewer` returned `Clean — ready to commit.`