### PR TITLE
docs(rfc): sync RFC statuses — 0005/0008 Accepted, index 0004 + 0009

### DIFF
--- a/docs/rfc/0005-user-scope-hook-support.md
+++ b/docs/rfc/0005-user-scope-hook-support.md
@@ -1,9 +1,9 @@
 # RFC-0005: Hook support across Claude Code and Kiro
 
-- **Status:** Draft
+- **Status:** Accepted
 - **Author:** eugenelim
 - **Date opened:** 2026-05-23
-- **Date closed:**
+- **Date closed:** 2026-05-25
 - **Extends:** [RFC-0004](0004-install-scope-per-pack.md) — lifts the
   conditional Rail-B refusal it parked.
 - **Amends [`docs/specs/distribution-adapters/spec.md`](../specs/distribution-adapters/spec.md):**

--- a/docs/rfc/0008-claude-plugins-install-route-parity.md
+++ b/docs/rfc/0008-claude-plugins-install-route-parity.md
@@ -1,9 +1,9 @@
 # RFC-0008: Claude-plugins install-route parity — per-pack SessionStart writer for the install→adapt chain
 
-- **Status:** Draft
+- **Status:** Accepted
 - **Author:** eugenelim
 - **Date opened:** 2026-05-24
-- **Date closed:**
+- **Date closed:** 2026-05-25
 - **Related:** [RFC-0001](0001-bundle-distribution-by-adapter-spec.md)
   (Claude-plugins as a canonical install route);
   [RFC-0003](0003-spec-and-cli.md) (CLI install→adapt chain;

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -9,11 +9,12 @@
 | [0001](0001-bundle-distribution-by-adapter-spec.md) | Bundle distribution by adapter spec + ecosystem build pipeline | Accepted | 2026-05-21 | 2026-05-22 |
 | [0002](0002-self-hosting.md) | Self-hosting via the ecosystem build pipeline | Accepted | 2026-05-21 | 2026-05-22 |
 | [0003](0003-spec-and-cli.md) | Adapter contract publication + reference CLI | Accepted | 2026-05-21 | 2026-05-22 |
-| [0004](0004-install-scope-per-pack.md) | Install-scope dimension — repo or user — defaulted and constrained per pack | Draft | 2026-05-23 | |
-| [0005](0005-user-scope-hook-support.md) | User-scope hook support — body reroot + wiring merge mode | Draft | 2026-05-23 | |
+| [0004](0004-install-scope-per-pack.md) | Install-scope dimension — repo or user — defaulted and constrained per pack | Accepted | 2026-05-23 | 2026-05-23 |
+| [0005](0005-user-scope-hook-support.md) | User-scope hook support — body reroot + wiring merge mode | Accepted | 2026-05-23 | 2026-05-25 |
 | [0006](0006-skill-secrets-storage.md) | Credential storage for credentialed skills — tiered env/keyring/dotfile + two-layer architecture | Accepted | 2026-05-24 | 2026-05-24 |
 | [0007](0007-user-scope-converter-pack.md) | First user-scope pack — `converters` (file-to-markdown, markdown-to-html, msg-to-markdown) | Accepted | 2026-05-24 | 2026-05-24 |
-| [0008](0008-claude-plugins-install-route-parity.md) | Claude-plugins install-route parity — per-pack SessionStart writer for the install→adapt chain | Draft | 2026-05-24 | |
+| [0008](0008-claude-plugins-install-route-parity.md) | Claude-plugins install-route parity — per-pack SessionStart writer for the install→adapt chain | Accepted | 2026-05-24 | 2026-05-25 |
+| [0009](0009-codex-native-skills.md) | Migrate Codex adapter from managed-block AGENTS.md to native `.agents/skills/` | Draft | 2026-05-25 | |
 
 ## Adding a new RFC
 

--- a/packs/governance-extras/seeds/docs/rfc/README.md
+++ b/packs/governance-extras/seeds/docs/rfc/README.md
@@ -9,11 +9,12 @@
 | [0001](0001-bundle-distribution-by-adapter-spec.md) | Bundle distribution by adapter spec + ecosystem build pipeline | Accepted | 2026-05-21 | 2026-05-22 |
 | [0002](0002-self-hosting.md) | Self-hosting via the ecosystem build pipeline | Accepted | 2026-05-21 | 2026-05-22 |
 | [0003](0003-spec-and-cli.md) | Adapter contract publication + reference CLI | Accepted | 2026-05-21 | 2026-05-22 |
-| [0004](0004-install-scope-per-pack.md) | Install-scope dimension — repo or user — defaulted and constrained per pack | Draft | 2026-05-23 | |
-| [0005](0005-user-scope-hook-support.md) | User-scope hook support — body reroot + wiring merge mode | Draft | 2026-05-23 | |
+| [0004](0004-install-scope-per-pack.md) | Install-scope dimension — repo or user — defaulted and constrained per pack | Accepted | 2026-05-23 | 2026-05-23 |
+| [0005](0005-user-scope-hook-support.md) | User-scope hook support — body reroot + wiring merge mode | Accepted | 2026-05-23 | 2026-05-25 |
 | [0006](0006-skill-secrets-storage.md) | Credential storage for credentialed skills — tiered env/keyring/dotfile + two-layer architecture | Accepted | 2026-05-24 | 2026-05-24 |
 | [0007](0007-user-scope-converter-pack.md) | First user-scope pack — `converters` (file-to-markdown, markdown-to-html, msg-to-markdown) | Accepted | 2026-05-24 | 2026-05-24 |
-| [0008](0008-claude-plugins-install-route-parity.md) | Claude-plugins install-route parity — per-pack SessionStart writer for the install→adapt chain | Draft | 2026-05-24 | |
+| [0008](0008-claude-plugins-install-route-parity.md) | Claude-plugins install-route parity — per-pack SessionStart writer for the install→adapt chain | Accepted | 2026-05-24 | 2026-05-25 |
+| [0009](0009-codex-native-skills.md) | Migrate Codex adapter from managed-block AGENTS.md to native `.agents/skills/` | Draft | 2026-05-25 | |
 
 ## Adding a new RFC
 


### PR DESCRIPTION
## Summary

- RFC-0005 and RFC-0008 have shipped — flip both to `Accepted` and fill close dates (2026-05-25).
- `docs/rfc/README.md` was out of sync: RFC-0004 file said Accepted but the index row still said Draft; RFC-0009 was missing from the index entirely. Both fixed.

## Test plan

- [x] `head` each `docs/rfc/000*.md` to confirm Status + Date closed fields look right
- [x] `docs/rfc/README.md` table matches each file's Status + Date closed