### PR TITLE
feat(codex): project skills as full bodies (RFC-0009)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 > Cursor, Codex, Gemini CLI, and Copilot also read it (via their own discovery rules).
 >
 > Keep this file under ~200 lines. If you're tempted to add to it, ask first whether
-> the content belongs in `docs/`, `.claude/skills/`, or a subdirectory `AGENTS.md`.
+> the content belongs in `docs/`, a skill, or a subdirectory `AGENTS.md`.
 
 ## What this repo is
 
@@ -64,7 +64,7 @@ For each kind of decision, there is exactly one place it lives:
 | How is the code organized today?          | `docs/architecture/`                 |
 | What is the product doing today?          | `docs/product/` (roadmap, changelog) |
 | How do users use the product?             | `docs/guides/` (Diátaxis: tutorials, how-to, reference, explanation) |
-| How do agents do `<repeating task>`?      | `.claude/skills/<task>/SKILL.md`     |
+| How do agents do `<repeating task>`?      | A skill file (`SKILL.md` with frontmatter); your IDE handles discovery |
 
 If you can't find the answer in one of these places, **the answer doesn't
 exist yet** — ask, or open an RFC. Don't guess. Lifecycle and mechanics
@@ -110,29 +110,14 @@ it's covered in [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md).
 ## Agent workflows
 
 Use the generated skill list below when a task matches a named workflow.
-<!-- agent-skills:start -->
-- **adapt-to-project** — Use this skill to walk the adopter through the four classes of post-install change (substitution, .upstream companion merges, discovery + restructuring, within-layout consolidation). Triggers after installing a pack (the install→adapt chain nudges via session-start hook) or any time `<repo>/.adapt-install-marker.toml` / `~/.agentbundle/.adapt-install-marker.toml` is on disk. Walks both scopes' state files for Tier-2 detection; class-1 substitution shells out to `agentbundle adapt`; classes 2–4 write files directly under the per-scope path-jail.
-- **add-credentialed-skill** — Use this skill when the user wants to author a new credentialed primitive — a skill that calls an authenticated external API on behalf of the user. Triggers on "add a credentialed skill", "new credentialed primitive", "wire up `<service>` API access". The skill walks the author through picking the primitive class (credentialed-cli vs. mcp-server), copying the matching `### Variant:` from `assets/credentialed-skill-SKILL.md`, declaring the schema, and importing the loader. Do NOT use for skills that just shell out to an already-credentialed binary the user has on PATH — those are not credentialed primitives. See `docs/specs/skill-secrets/spec.md` for the full architecture.
-- **api-contract** — Use when generating an OpenAPI 3.1 API contract from requirements, user stories, or domain models. Applies 138 RESTful API rules as hard constraints to produce complete, validated YAML specs ready for code gen, test gen, mocks, and SDKs. Activate for tasks involving API design, REST contract authoring, or OpenAPI spec creation.
-- **bug-fix** — Use this skill when the user wants to fix a bug — a deviation between current behavior and intended behavior in code that already exists. Triggers on "fix bug", "fix this bug", "diagnose and fix", "investigate this regression", "this is broken". Do NOT use for new features (use `new-spec`) or for refactors that don't fix incorrect behavior.
-- **example-credentialed-skill** — Reference skill — do NOT auto-load. Authoring a new credentialed primitive belongs in `add-credentialed-skill`; this directory ships only as a runnable worked example for adopters who explicitly ask to *see* one. The skill carries a no-op `scripts/cli.py` calling a fictional `example` API via `agentbundle.credentials`, the canonical `references/creds-schema.toml` declaring `API_TOKEN` (secret) and `BASE_URL` (non-secret sibling), and the verbatim `### Security rules (non-negotiable)` block the credentialed-CLI lint pins. Read it; do not invoke it from production code.
-- **file-to-markdown** — Convert documents and images to Markdown. Documents (PDF, DOCX, PPTX, XLSX, XLS) go through Docling text extraction (`scripts/convert.py`); images (PNG, JPG, JPEG, TIFF, BMP, WEBP, GIF) go through a two-pass sliding-window vision pipeline whose tiling and reconciliation are deterministic (`scripts/split_image.py` and `scripts/reconcile.py`). The agent's job is the per-tile vision read; tile dedup and ordering are handled by the script.
-- **markdown-to-html** — Convert a Markdown file to a self-contained, styled HTML page (sticky header, sidebar nav, syntax-highlighted code, callout boxes, Mermaid diagrams, print-ready). Use when the user asks to render, convert, or export a `.md` file as a shareable HTML document — not for slides, presentations, or pitch decks. Rendering is deterministic via `marked` + `highlight.js`; the agent only invokes the script.
-- **msg-to-markdown** — Convert Outlook .msg email files to Markdown, preserving email headers (From, To, CC, Date), body content, and attachment metadata. Use when the user wants to convert, read, or process a .msg email file into Markdown format.
-- **new-adr** — Use this skill when the user asks to create, write, draft, or open a new ADR (architecture decision record). Triggers on phrases like "new ADR", "write an ADR for…", "record this decision", "let's ADR this". Do NOT use for RFCs (use `new-rfc`) or feature specs (use `new-spec`).
-- **new-guide** — Use this skill to draft a new user-facing guide under `docs/guides/<quadrant>/<slug>.md` following the Diátaxis framework. Triggers on "write a guide for X", "new tutorial", "new how-to". Picks the quadrant (tutorials/how-to/reference/explanation) and applies the per-quadrant template.
-- **new-package** — Use this skill when the user wants to scaffold a new package in the monorepo's `packages/` directory. Triggers on "new package", "create a package called…", "add a library for…". Don't use for new top-level directories (those need an RFC) or for new apps (which go in `apps/`, not `packages/`).
-- **new-rfc** — Use this skill when the user asks to propose, draft, or open an RFC (request for comments). Triggers on "RFC", "propose a change to…", "let's get input on…", "draft a proposal". Do NOT use for already-decided things (use `new-adr`) or single-feature specs (use `new-spec`).
-- **new-spec** — Use this skill when the user wants to start a new feature with a spec, or wants to write a spec for something they're about to build. Triggers on "new spec", "write a spec for X", "let's spec this out", "start a feature for…". Spec-driven development; the spec drives implementation. Do NOT use for cross-cutting proposals (use `new-rfc`) or recording decisions (use `new-adr`).
-- **update-conventions** — Use this skill when the user wants to change `docs/CONVENTIONS.md` or `docs/CHARTER.md`. Triggers on "let's change the convention for…", "update the rules", "amend the charter", "change our principles". Conventions and charter changes go through RFC review, not direct PR.
-- **work-loop** — Use this skill whenever you're implementing a non-trivial change — a feature, a multi-file bug fix, a refactor, a migration, a framework or dependency upgrade, a schema or API change, performance work, an infrastructure or build-system edit, or anything spec-driven. It enforces the project's plan → execute → self-review → fix loop with mechanical gates (lint, typecheck, tests) and adversarial review. Default to this skill for any task larger than a one-line edit.
-<!-- agent-skills:end -->
 
 ## Specialist subagents
 
-`.claude/agents/` contains sharp, differentiable lenses for diff review,
-plus the executor used by `work-loop`'s supervisor mode. Pick the
-reviewers the diff actually warrants; don't run all three by default.
+Specialist subagents — Claude Code only; Codex and Copilot drop the
+`agent` primitive per the adapter contract — provide sharp,
+differentiable lenses for diff review, plus the executor used by
+`work-loop`'s supervisor mode. Pick the reviewers the diff actually
+warrants; don't run all three by default.
 
 - `adversarial-reviewer` — spec /
   plan / implementation drift; missing edge cases; scope creep. Default

--- a/docs/contracts/adapter.toml
+++ b/docs/contracts/adapter.toml
@@ -214,11 +214,9 @@ mode = "dropped"
 
 [[adapter.codex.projection]]
 primitive = "skill"
-mode = "managed-block-inline"
-target-path = "AGENTS.md"
-managed-block-delimiter-start = "<!-- agent-skills:start -->"
-managed-block-delimiter-end = "<!-- agent-skills:end -->"
-on-conflict = "preserve-outside-block"
+mode = "direct-directory"
+target-path = ".agents/skills/"
+on-conflict = "prompt-then-preserve"
 
 [[adapter.codex.projection]]
 primitive = "agent"

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -23,7 +23,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- (nothing yet)
+- **Codex receives full skill bodies** — the `skill` projection for the
+  Codex adapter flips from `managed-block-inline` (one-line teasers
+  in `AGENTS.md` between `<!-- agent-skills:start -->` /
+  `<!-- agent-skills:end -->`) to `direct-directory`. Codex users now
+  read `.agents/skills/<name>/SKILL.md` byte-equal to source — the
+  same surface Claude Code and Kiro have always had. Per
+  [RFC-0009 § Adapter contract change](../rfc/0009-codex-native-skills.md#adapter-contract-change).
+  On the first install after upgrade, the adapter strips the
+  legacy `<!-- agent-skills:start --> … <!-- agent-skills:end -->`
+  region from any pre-existing `AGENTS.md` in place; outside-block
+  content is preserved. The strip is destructive by design: hand-
+  edited content *between* the delimiters is not migrated
+  (RFC-0009 § Failure modes). The strip mechanism
+  (`_strip_legacy_skill_block` + the retained `_splice_managed_block`
+  helper) is kept for one minor release as the migration window
+  (released N) and then removed in the release after (N+1).
+  **Self-host narrowed to Claude Code only.** Before this release,
+  `SELF_HOST_ADAPTERS = ("claude-code", "codex")` so the Codex
+  adapter ran against this repo's working tree alongside Claude
+  Code. With Codex's `skill` projection growing from a tiny
+  AGENTS.md managed block to a full body tree, self-host's working
+  tree would carry a duplicate `.agents/skills/` of every skill —
+  pure maintainer overload. `SELF_HOST_ADAPTERS = ("claude-code",)`
+  now; Codex adopters continue to receive `.agents/skills/` via
+  `agentbundle install`. Codex regressions are gated by the
+  adapter's unit tests and a tempdir projection test that walks
+  every shipped skill.
+
+- **Uniform multi-pack entry point across `direct-directory` adapters**
+  — `codex`, `claude-code`, and `kiro` all expose
+  `project_packs(pack_paths, contract, output_root)` as the
+  canonical orchestrator-facing surface. Single-pack `project()`
+  is retained as a wrapper. Same-name skill collisions across
+  packs resolve deterministic-last-wins by source-order.
+
+- **Orphan-skill cleanup across `direct-directory` adapters** — after
+  every multi-pack `project_packs(...)` call, the projected skill
+  directory is swept: child directories whose names are not in the
+  union of source skill names across the call's pack list are
+  removed. Bound to the `skill` primitive only; symlinks are
+  removed via `Path.unlink()` (never followed).
 
 ### Deprecated
 

--- a/docs/specs/codex-native-skills/plan.md
+++ b/docs/specs/codex-native-skills/plan.md
@@ -409,12 +409,17 @@ routing)
   same-name fixture pair through each of the two adapters'
   `project_packs`; assert the AC6 last-wins rule holds for
   both. [AC6 — claude-code and kiro cases]
-- *`self_host.py` routes through `project_packs`*: a test
-  inspects `self_host._run_direct_self_host_adapters` (or its
-  current symbol — verify) and asserts the body calls
-  `project_packs([pack.path for pack in packs], ...)` rather
-  than `for pack in packs: project(pack.path, ...)`. Either a
-  source-text assertion or a mock-based invocation test. [AC8]
+- *`self_host.py` routes through `project_packs`*: a
+  **mock-based invocation test** patches the per-adapter
+  `project_packs` attribute on each module in `SELF_HOST_ADAPTERS`
+  (`claude_code` and `codex` only — kiro is excluded from self-host
+  per AC8) and runs the self-host entry point; the test asserts
+  each patched mock was called exactly once with
+  `[pack.path for pack in packs]` as the first positional arg. A
+  source-text assertion is rejected because a refactor that
+  preserved the contract but changed the call shape (helper, comp.
+  expression) would break the source-text grep without breaking
+  behaviour. [AC8]
 
 **Approach:**
 
@@ -428,8 +433,11 @@ routing)
   ```
   Same shape in `kiro.py`.
 - In `self_host.py` (currently lines 185-198), replace the
-  per-pack inner loop with a `project_packs` call. **Reuse the
-  existing module-keyed `registry`** in
+  per-pack inner loop with a `project_packs` call. `SELF_HOST_ADAPTERS`
+  (`self_host.py:70` — `("claude-code", "codex")`) is the routing
+  allow-list and is **not** widened by this spec; kiro stays out of
+  self-host per AC8. **Reuse the existing module-keyed `registry`**
+  in
   `packages/agentbundle/agentbundle/build/adapters/__init__.py:24-29`
   (`{"claude_code": claude_code, "kiro": kiro, ...}` — Python
   module names) — do NOT add a third dict. The existing
@@ -463,6 +471,14 @@ routing)
   `project_packs([pack_path], ...)`. Existing callers of
   `claude_code.project(pack_path, ...)` and
   `kiro.project(pack_path, ...)` continue to work unchanged.
+  Known in-tree callers as of 2026-05-25:
+  (1) `self_host.py` (refactored by this task);
+  (2) `packages/agentbundle/agentbundle/commands/install.py:1114,1116`
+  (`_rewrite_user_scope_hook_paths` invokes them against a tempdir
+  for hook-path rewriting). Caller (2) stays on the single-pack
+  wrapper and is not refactored. Pre-T5 verification fires the two
+  `rg` sweeps from AC9; any new caller surfaced is enumerated in
+  the PR.
 
 **Done when:** all listed tests pass; `self_host.py` routes all
 three adapters through `project_packs`; existing `project()`
@@ -635,6 +651,17 @@ no other helpers are added to the module (per the spec's
   every-`direct-directory` post-pass. The `_skill_direct_directory_target`
   helper guards this by name: it explicitly checks
   `entry["primitive"] == "skill"`.
+- **Deliberate duplication of `_skill_direct_directory_target`
+  across `claude_code.py` and `kiro.py`.** The spec's `Never do`
+  boundary forbids expanding `projections/direct_directory.py`
+  beyond `sweep_orphans`, so consolidating the target-resolution
+  helper into a shared module is barred. The two copies must stay
+  in lockstep; each one carries a single-line cross-reference
+  comment pointing at its sibling
+  (`# Mirror of kiro.py:_skill_direct_directory_target; keep in
+  sync.` in `claude_code.py`, inverse in `kiro.py`) so a future
+  maintainer touching one sees the other. A shared helper is a
+  future RFC, not this spec.
 - **Why the helper, not refactor of `project()`.** Refactoring
   `claude_code.project()` / `kiro.project()` to return their
   per-pack `source_dirs` / `target_dir` would broaden the
@@ -661,25 +688,37 @@ plus reviewer pass.
 - *Projection table* — locate by adapter name to avoid
   false positives if any other adapter still uses
   `managed-block-inline`:
-  `grep -nE "codex.*(skill|managed-block|direct-directory)|^\| .*codex" docs/specs/distribution-adapters/spec.md`,
+  `rg -n "codex.*(skill|managed-block|direct-directory)|^\| .*codex" docs/specs/distribution-adapters/spec.md`,
   or read the table by section heading directly. Updated to
   show Codex `skill` as `direct-directory` with target
   `.agents/skills/`.
 - *Uniform multi-pack entry-point invariant subsection* added
   documenting: every `direct-directory` adapter exposes
   `project_packs(pack_paths, contract, output_root)`;
-  `self_host.py` routes through it.
+  `self_host.py` routes through it. **Concrete assertion**:
+  `rg -n "project_packs\(pack_paths" docs/specs/distribution-adapters/spec.md`
+  returns ≥ 1 hit; `rg -n "Uniform multi-pack" docs/specs/distribution-adapters/spec.md`
+  returns ≥ 1 hit (subsection heading).
 - *Orphan-cleanup invariant subsection* added (or existing
   `direct-directory` mode subsection extended) documenting:
   every `direct-directory` projection of `skill` runs a
   post-projection orphan sweep that removes child directories
   not in the union of source skill names across the call's
-  pack list.
+  pack list. **Concrete assertion**:
+  `rg -n "sweep_orphans|orphan sweep|orphan-cleanup" docs/specs/distribution-adapters/spec.md`
+  returns ≥ 1 hit; the surrounding paragraph names the
+  "union of source skill names across the call's pack list"
+  invariant (verified by `rg -n "union of source skill names"`).
 - *Symlink-pass-through invariant* cited explicitly under the
   `direct-directory` mode description (with reference to
-  `shutil.copytree(..., symlinks=True)` semantics).
+  `shutil.copytree(..., symlinks=True)` semantics). Concrete
+  assertion: `rg -n "symlinks=True" docs/specs/distribution-adapters/spec.md`
+  returns ≥ 1 hit.
 - *Cites RFC-0009* by section name (`§ Adapter contract change`,
-  `§ Failure modes`).
+  `§ Failure modes`). Concrete assertion: both literal section
+  names appear in the file
+  (`rg -n "RFC-0009" docs/specs/distribution-adapters/spec.md`
+  returns hits including the two section names).
 - *`make build-check` clean.* [AC27, AC28]
 
 **Approach:**
@@ -750,9 +789,26 @@ extension.
      and the projected `AGENTS.md` contains
      `<!-- agent-skills:start -->`, emit a warning naming the
      file path.
-  3. Returns a warning (not a failure) per the spec — the
-     linter's existing exit-code contract for warnings is the
-     reference shape.
+  3. Routes the warning through the existing `warn(msg)` closure
+     defined inside `main()` at `tools/lint-agents-md.py:53` —
+     `warn()` prints to stderr without incrementing `fail`, so
+     the linter's exit code stays 0. The new check is added
+     **inline inside `main()`** adjacent to the existing
+     `note(...)` checks (rule 10d / 10e at lines 241-268 are the
+     reference shape); a top-level helper is not introduced,
+     matching the established linter idiom. No new exit-code
+     channel invented.
+
+- **T9 linter unit test shape**: the check lives inside `main()`,
+  so the test is a **CLI subprocess invocation**, not a direct
+  function call. Pin the test as: write the synthetic
+  `AGENTS.md` (containing `<!-- agent-skills:start -->`) and the
+  synthetic adapter contract (declaring Codex `skill` as
+  `direct-directory`) to `tmp_path`; invoke `lint-agents-md.py`
+  via `subprocess.run([sys.executable, "tools/lint-agents-md.py"], cwd=tmp_path, capture_output=True)`;
+  assert the return code is 0 (warning, not failure) and that
+  the stderr stream contains both the `⚠` warn marker and the
+  offending file path.
 - Unit test for the linter goes alongside the existing linter
   tests (verify path during EXECUTE — likely `tools/tests/` or
   a fixture-based test under
@@ -882,3 +938,72 @@ restate them.
   `adapter_name.replace("-", "_")` instead of introducing a
   third dict. No new ACs needed; the change is internal to
   T5's Approach.
+- 2026-05-25: post-review seed adapter-neutralisation. The user
+  flagged that `packs/core/seeds/AGENTS.md` mentions `.claude/skills/`
+  and `.claude/agents/` in three places — references that ship to
+  every adopter (via `agentbundle scaffold`) and read as wrong for
+  Codex (whose skills live at `.agents/skills/`) and Kiro (`.kiro/skills/`).
+  Pre-existing issue made visible by RFC-0009 because Codex now has
+  a real distinct surface. Fixed in three small edits: (a) "the
+  content belongs in `docs/`, `.claude/skills/`, …" → "…in `docs/`,
+  a skill, …"; (b) the source-of-truth-table row for `<repeating
+  task>` names the file (`SKILL.md`) instead of the directory,
+  noting "your IDE handles discovery"; (c) the "Specialist
+  subagents" section header names the adapter contract directly —
+  Claude Code only; Codex and Copilot drop the `agent` primitive.
+  No new adapter-templating mechanism introduced; the seed is now
+  adapter-neutral by content.
+- 2026-05-25: post-review course correction. User flagged that
+  with Codex's `skill` projection growing from a tiny managed
+  block to a full body tree, leaving `codex` in
+  `SELF_HOST_ADAPTERS` would mirror every skill into the working
+  tree (`.agents/skills/`) alongside `.claude/skills/` — pure
+  maintainer overload, and the project's stance is "we never want
+  maintainer overload." Narrowed `SELF_HOST_ADAPTERS` to
+  `("claude-code",)`. Removed the `codex.project_packs` call from
+  `_compose_agents_md` (now a no-op for AGENTS.md anyway under the
+  direct-directory contract). Removed the unreachable
+  `if adapter_name == "codex"` branch from `_project_all_adapters`.
+  `.agents/` gitignored. AC8, AC10, and the
+  `distribution-adapters/spec.md` amendment updated to reflect the
+  narrower self-host surface. Codex correctness is gated by unit
+  tests + AC29 tempdir projection (already in place). Test
+  `test_self_host_composes_agents_body_codex_block_and_footer`
+  updated to assert `.agents/` is absent and `.claude/skills/`
+  carries the projected bodies; `SelfHostAdapterRoutingTests`'
+  codex-mock assertion is kept (asserts call_count == 0) to pin
+  the narrowed routing.
+- 2026-05-25: round-5 review revision. Reviewer surfaced two
+  concerns + one nit; addressed all. (1) AC9 extended to
+  enumerate the three test callers at
+  `tests/unit/test_pipeline_phase_order.py:168,228,229` so the
+  spec's "known callers" list matches the world it claims.
+  (2) T9 Approach pinned: the new linter check is added inline
+  inside `main()` (not as a top-level function) because
+  `warn()` is a closure of `main()` capturing `nonlocal fail`;
+  the T9 unit test is now pinned as a `subprocess.run` CLI
+  invocation asserting on exit code and stderr. (3) Line-number
+  citations in AC8 (`self_host.py:70`, `self_host.py:266`)
+  replaced with constant-name citations for line-drift
+  resistance.
+- 2026-05-25: round-4 (pre-EXECUTE confirmation) review
+  revision. Reviewer surfaced two blockers and three
+  high-priority concerns; addressed all five in spec.md and
+  plan.md. (1) AC8 narrowed: `SELF_HOST_ADAPTERS` excludes
+  `kiro` (`self_host.py:70`), so self-host routes only
+  `claude-code` and `codex` through `project_packs`;
+  `kiro.project_packs` exists per AC7/AC19 but is not invoked
+  from self-host. (2) AC9 enumerates the
+  `commands/install.py:1114,1116` callers of single-pack
+  `kiro.project` / `claude_code.project` as known callers that
+  stay on the retained wrapper; grep rewritten as `rg`.
+  (3) T5 routing test committed to mock-based (not source-text).
+  (4) T7 helper duplication named as deliberate with sibling
+  cross-reference comments. (5) T8 concrete `rg` assertions
+  added for each invariant subsection. (6) T9 wires through
+  the existing `warn()` helper at `lint-agents-md.py:53`
+  rather than inventing a warning channel. Concern 6 (T3-T4
+  dead-code interregnum if landed in separate PRs) is moot
+  because this work-loop session lands all nine tasks in a
+  single PR — recorded here for future maintainers reading the
+  plan offline.

--- a/docs/specs/codex-native-skills/spec.md
+++ b/docs/specs/codex-native-skills/spec.md
@@ -284,38 +284,73 @@ Multi-pack adapter entry point:
       `project(pack_path, contract, output_root)`, then runs the
       post-projection orphan sweep (AC15-AC17).
 - [ ] **AC8.** `packages/agentbundle/agentbundle/build/self_host.py`
-      routes claude-code and kiro through `project_packs([pack.path
-      for pack in packs], contract, output_root)` (matching the
-      existing Codex pattern). The legacy per-pack loop is removed.
+      routes the adapters in its `SELF_HOST_ADAPTERS` allow-list —
+      narrowed by this spec to `("claude-code",)` — through
+      `project_packs([pack.path for pack in packs], contract,
+      output_root)`. The legacy per-pack loop is removed. **Both
+      Codex and Kiro are out of scope for self-host's working-tree
+      projection.** Before RFC-0009, Codex was in the allow-list
+      because its `managed-block-inline` contribution was a tiny
+      AGENTS.md splice; once Codex flipped to `direct-directory`,
+      self-host would carry a full duplicate of every skill body
+      under `<repo>/.agents/skills/` — maintainer-overload that the
+      project rejects on sight. Codex correctness is gated by
+      adapter unit tests + the AC29 tempdir projection test rather
+      than by self-host's working-tree drift gate; Codex adopters
+      get `.agents/skills/` via `agentbundle install` exactly as
+      before. `codex.project_packs` and `kiro.project_packs` still
+      exist per AC7 and are verified at the unit level (AC6, AC17,
+      AC19, AC20). `.agents/` and `.kiro/` are gitignored. Expanding
+      `SELF_HOST_ADAPTERS` is a separate decision.
 - [ ] **AC9.** `claude_code.project(pack_path, ...)` and
       `kiro.project(pack_path, ...)` are retained as single-pack
       convenience wrappers that delegate to `project_packs([pack_path], ...)`.
-      Existing callers (if any outside `self_host.py`) continue to
-      work without edits. Verified by **two grep sweeps** before T5
-      lands: `grep -rn "claude_code\.project\b\|kiro\.project\b" packages/ tools/`
+      Existing callers continue to work without edits. The known
+      in-tree callers as of 2026-05-25 are:
+      (a) `packages/agentbundle/agentbundle/build/self_host.py`
+      (refactored by AC8); (b)
+      `packages/agentbundle/agentbundle/commands/install.py:1114,1116`
+      — `kiro.project(pack_dir, contract, out)` and
+      `claude_code.project(pack_dir, contract, out)` invoked against
+      a tempdir inside `_rewrite_user_scope_hook_paths`; this caller
+      stays on the single-pack `project()` wrapper and is not
+      refactored by this spec;
+      (c) `packages/agentbundle/tests/unit/test_pipeline_phase_order.py`
+      lines 168 (`kiro.project(pack, _load_contract(), out)`), 228
+      (`kiro.project(pack_kiro, contract, out)`), and 229
+      (`claude_code.project(pack_cc, contract, out)`) — unit tests
+      that exercise the single-pack signature directly. Retained
+      `project()` wrapper behaviour makes them no-op-correct; no
+      edits required. Pre-T5 verification is **two `rg` sweeps** (`ripgrep` handles `\b` and alternation uniformly
+      across BSD/GNU):
+      `rg -n "claude_code\.project\b|kiro\.project\b" packages/ tools/`
       (per-adapter `project` callers) and
-      `grep -rn "ADAPTERS\[\|from agentbundle.build.adapters import ADAPTERS" packages/ tools/`
-      (dispatch-table reach-ins). External callers are either
-      zero, or enumerated in the PR description with their
-      adaptation plan.
+      `rg -n "ADAPTERS\[|from agentbundle.build.adapters import ADAPTERS" packages/ tools/`
+      (dispatch-table reach-ins). Any caller surfaced by the sweeps
+      outside (a) and (b) above is enumerated in the PR description
+      with its adaptation plan.
 
 Migration strip — Codex-specific:
 
 - [ ] **AC10.** **Strip target is `<output_root>/AGENTS.md`** — the
-      project-root AGENTS.md composed by
-      `self_host._compose_agents_md` (the same file Codex previously
-      spliced the managed block into). The strip is hardcoded in
+      project-root AGENTS.md the Codex adapter is invoked against
+      (whatever orchestrator runs it). The strip is hardcoded in
       `codex.py` for the migration window; no contract entry, no
-      target-path indirection. **Self-host vs. adopter asymmetry,
-      named for the next maintainer.** In self-host,
-      `_compose_agents_md` overwrites `AGENTS.md` with the seed
-      body *before* calling `codex.project_packs`; since AC15
-      removes the legacy delimiters from the seed, the strip is a
-      documented no-op in self-host. In adopter installs against a
-      pre-existing `AGENTS.md` carrying the legacy block, the strip
-      does real work. Both cases are correct; the strip is not
-      dead code despite looking inactive when read from
-      `_compose_agents_md`'s call site.
+      target-path indirection. **Production-coverage gap, named for
+      the next maintainer.** No live production call-site in this PR
+      exercises the strip against a real legacy `AGENTS.md`. Codex
+      is no longer in `SELF_HOST_ADAPTERS` (per AC8), so self-host
+      never invokes the Codex adapter. `commands/install.py` does
+      not call `codex.project()` either. The strip is therefore
+      exercised only by the construction tests in this PR
+      (AC11-AC14). When the install flow gains a Codex pathway
+      (tracked as a roadmap item against the next minor release),
+      the strip will see real adopter `AGENTS.md` files carrying
+      the legacy block. Removing the strip before that pathway
+      exists would be safe today; keeping it now preserves the
+      migration contract without requiring a follow-on PR. The
+      retention test (AC23) and integration tests guard against
+      silent regression while the live call-site is wired.
 - [ ] **AC11.** **Happy path.** A fixture `AGENTS.md` containing
       `<!-- agent-skills:start -->\n- **a** — ...\n- **b** — ...\n<!-- agent-skills:end -->\n`
       surrounded by outside-delimiter prose, after one Codex

--- a/docs/specs/distribution-adapters/spec.md
+++ b/docs/specs/distribution-adapters/spec.md
@@ -58,6 +58,14 @@ to this list.
 
 - **`direct-directory`** — copy a source directory tree byte-for-byte to
   the projected path. Default `on-conflict`: `prompt-then-preserve`.
+  **Symlink-pass-through invariant**: implementations use
+  `shutil.copytree(..., symlinks=True)` semantics — symlinks in the
+  source are preserved as symlinks in the projection (never
+  dereferenced at projection time), so a pack with a relative
+  internal symlink projects the link literal, not the target body.
+  This is a path-traversal safety invariant: a malicious pack with a
+  symlink to `/etc/passwd` cannot exfiltrate that file into the
+  adopter's tree.
 - **`direct-file`** — copy a single source file byte-for-byte to the
   projected path. Default `on-conflict`: `prompt-then-preserve`.
 - **`merge-json`** — deep-merge the source's JSON payload into a managed
@@ -195,7 +203,7 @@ declares it so explicitly — no implicit defaults.
 
 | Primitive | Source path (in `packs/<pack>/`) | Claude Code | Kiro | Copilot | Codex |
 | --- | --- | --- | --- | --- | --- |
-| `skill` | `.apm/skills/<name>/` | `direct-directory` → `.claude/skills/<name>/` | `direct-directory` → `.kiro/skills/<name>/` | `instruction-file` → `.github/instructions/<name>.instructions.md` | `managed-block-inline` → `AGENTS.md` |
+| `skill` | `.apm/skills/<name>/` | `direct-directory` → `.claude/skills/<name>/` | `direct-directory` → `.kiro/skills/<name>/` | `instruction-file` → `.github/instructions/<name>.instructions.md` | `direct-directory` → `.agents/skills/<name>/` |
 | `agent` | `.apm/agents/<name>.md` | `direct-file` → `.claude/agents/<name>.md` | `direct-file`\* (with `kiro-agent-frontmatter-v0.9` rewrite) → `.kiro/agents/<name>.json` | `dropped` | `dropped` |
 | `hook-body` | `.apm/hooks/<name>.{sh,py}` | `direct-file` — repo: `tools/hooks/<name>.{sh,py}`; user: `.claude/hooks/<pack>/<name>.{sh,py}` | `direct-file` — repo: `tools/hooks/<name>.{sh,py}`; user: `.kiro/hooks/<pack>/<name>.{sh,py}` | `direct-file` → `tools/hooks/<name>.{sh,py}` | `direct-file` → `tools/hooks/<name>.{sh,py}` |
 | `hook-wiring` | `.apm/hook-wiring/<name>.toml` | repo: `merge-json` (under `hooks` key of `.claude/settings.local.json`); user: `user-merge-json` (under `hooks` key of `.claude/settings.json`) | `merge-into-agent-json` (RFC-0005 — under `hooks` key of `.kiro/agents/<attach-to-agent>.json`) | `dropped` | `dropped` |
@@ -232,6 +240,53 @@ projection wrote, so agents must land first. Cross-pack ordering is
 not introduced — packs install serially today and no pack writes into
 another pack's agent file. T7 enforces the invariant in the pipeline
 iterator.
+
+### Uniform multi-pack entry point — `direct-directory` adapters
+
+Per [RFC-0009 § Adapter contract change](../../rfc/0009-codex-native-skills.md#adapter-contract-change),
+every `direct-directory` adapter (`codex`, `claude-code`, `kiro`)
+exposes
+`project_packs(pack_paths: list[Path], contract, output_root)` as its
+canonical orchestrator-facing entry point. Single-pack `project()`
+is retained as a convenience wrapper that calls
+`project_packs([pack_path], ...)`. `self_host.py` routes the
+adapters in its `SELF_HOST_ADAPTERS` allow-list — narrowed by
+RFC-0009 to `("claude-code",)` — through `project_packs`; `codex`
+and `kiro` expose `project_packs` for adapter-API parity but are
+not invoked from self-host (their working-tree projections would
+duplicate every skill body and overload the maintainer). Other
+orchestrator-style callers route through the same multi-pack
+surface so the union of skill names across a multi-pack call is
+observable in one place — which is what the orphan sweep below
+needs.
+
+**Same-name collision rule**: deterministic last-wins, uniformly
+across all three adapters. Pack source order is as supplied to
+`project_packs(pack_paths, ...)` by the caller; the last pack's
+`<name>` overwrites earlier packs' projections of the same name
+(the projection step `rmtree`s the destination before `copytree`).
+
+### Orphan-skill cleanup invariant — `direct-directory` `skill` projections
+
+Per [RFC-0009 § Failure modes](../../rfc/0009-codex-native-skills.md#failure-modes),
+every `direct-directory` projection of the `skill` primitive runs a
+post-projection orphan sweep that removes any child directory of
+the projected skill target whose name is **not in the union of source skill names across the call's pack list**.
+The union (not per-pack) is load-bearing: a pack shipping a subset
+of skills must co-exist with another pack that ships the union
+complement, and a per-pack sweep would orphan-clean the other
+pack's skills.
+
+The sweep is implemented as a shared helper
+(`agentbundle.build.projections.direct_directory.sweep_orphans`) so
+all three adapters compute orphan membership identically.
+
+The sweep is **bound to the `skill` primitive only** — other
+`direct-directory` primitives opt in explicitly, never automatically.
+Symlinks at the target-dir root are removed via `Path.unlink()`
+(never followed); non-symlink subdirectories are removed via
+`shutil.rmtree`. The symlink rule preserves the symlink-pass-through
+invariant above.
 
 ## Install-scope dimension (contract v0.2)
 

--- a/packages/agentbundle/agentbundle/_data/adapter.toml
+++ b/packages/agentbundle/agentbundle/_data/adapter.toml
@@ -214,11 +214,9 @@ mode = "dropped"
 
 [[adapter.codex.projection]]
 primitive = "skill"
-mode = "managed-block-inline"
-target-path = "AGENTS.md"
-managed-block-delimiter-start = "<!-- agent-skills:start -->"
-managed-block-delimiter-end = "<!-- agent-skills:end -->"
-on-conflict = "preserve-outside-block"
+mode = "direct-directory"
+target-path = ".agents/skills/"
+on-conflict = "prompt-then-preserve"
 
 [[adapter.codex.projection]]
 primitive = "agent"

--- a/packages/agentbundle/agentbundle/build/adapters/claude_code.py
+++ b/packages/agentbundle/agentbundle/build/adapters/claude_code.py
@@ -26,6 +26,7 @@ from typing import Any, Iterator
 # wiring lands in a settings file (not in agents) — the uniformity
 # keeps the phases predictable, which the spec calls for.
 from agentbundle.build.phase_order import PHASE_ORDER as _PHASE_ORDER
+from agentbundle.build.projections.direct_directory import sweep_orphans
 
 
 def _iter_primitives(contract: dict) -> Iterator[str]:
@@ -38,7 +39,54 @@ def _iter_primitives(contract: dict) -> Iterator[str]:
 
 
 def project(pack_path: Path, contract: dict, output_root: Path) -> None:
-    """Project a single pack into `output_root` per the Claude Code adapter rules."""
+    """Single-pack convenience wrapper. Delegates to `project_packs`."""
+    project_packs([pack_path], contract, output_root)
+
+
+def project_packs(pack_paths: list[Path], contract: dict, output_root: Path) -> None:
+    """Project every pack in `pack_paths` in order, then run the
+    shared orphan-sweep post-pass on the `skill` target directory.
+
+    Same-name collision rule: pack source order as supplied here; the
+    last pack's `<name>` overwrites earlier packs' (`_project_direct_directory`
+    `rmtree`s the destination before `copytree`). The orphan sweep
+    observes the union of source skill names across the call's pack
+    list (not per-pack) so a pack shipping a subset can co-exist with
+    another that ships the union complement.
+    """
+    for pack_path in pack_paths:
+        _project_single(pack_path, contract, output_root)
+    _sweep_skill_orphans(pack_paths, contract, output_root)
+
+
+# Mirror of kiro.py:_skill_direct_directory_target — keep in sync.
+# A shared helper is barred by the spec's `Never do` boundary (no
+# expansion of projections/direct_directory.py beyond `sweep_orphans`).
+def _skill_direct_directory_target(contract: dict, output_root: Path) -> Path | None:
+    adapter_block = contract["adapter"]["claude-code"]
+    for entry in adapter_block.get("projection", []):
+        if entry.get("primitive") == "skill" and entry.get("mode") == "direct-directory":
+            return output_root / entry["target-path"].rstrip("/")
+    return None
+
+
+def _sweep_skill_orphans(pack_paths: list[Path], contract: dict, output_root: Path) -> None:
+    target_dir = _skill_direct_directory_target(contract, output_root)
+    if target_dir is None:
+        return
+    skill_source_path = contract["primitive"]["skill"]["source-path"].rstrip("/")
+    expected_names: set[str] = set()
+    for pack_path in pack_paths:
+        source_dir = pack_path / skill_source_path
+        if not source_dir.exists():
+            continue
+        for entry in source_dir.iterdir():
+            if entry.is_dir():
+                expected_names.add(entry.name)
+    sweep_orphans(target_dir, expected_names)
+
+
+def _project_single(pack_path: Path, contract: dict, output_root: Path) -> None:
     adapter_block = contract["adapter"]["claude-code"]
     rules_by_primitive = {entry["primitive"]: entry for entry in adapter_block.get("projection", [])}
 
@@ -62,9 +110,21 @@ def project(pack_path: Path, contract: dict, output_root: Path) -> None:
 
 def _project_direct_directory(source_dir: Path, target_dir: Path) -> None:
     for entry in sorted(source_dir.iterdir()):
+        # Defense-in-depth — `lint-packs` rejects packs that ship
+        # symlinks, but a direct `project_packs` caller bypasses
+        # that gate. A symlink at the skill-root level would be
+        # dereferenced by `copytree`.
+        if entry.is_symlink():
+            continue
         if entry.is_dir():
             destination = target_dir / entry.name
-            if destination.exists():
+            # Spec § Never do — `shutil.rmtree` is barred against
+            # any entry whose `is_symlink()` is true. If a previous
+            # run left a symlink at the destination path, unlink it
+            # (removes the link, not the target).
+            if destination.is_symlink():
+                destination.unlink()
+            elif destination.exists():
                 shutil.rmtree(destination)
             # symlinks=True preserves symlinks rather than dereferencing
             # them — a malicious pack with a symlink to /etc/passwd

--- a/packages/agentbundle/agentbundle/build/adapters/codex.py
+++ b/packages/agentbundle/agentbundle/build/adapters/codex.py
@@ -1,20 +1,28 @@
-"""Codex adapter — inlines skill descriptions into a managed block in
-AGENTS.md, projects hook bodies straight through, drops the rest.
+"""Codex adapter — projects skills as full `<name>/SKILL.md` trees under
+`.agents/skills/`, projects hook bodies straight through, drops the rest.
 
-Delimiters come from the contract's projection entry
-(`managed-block-delimiter-start` / `-end`). Block content is alpha-
-sorted by skill name so two runs produce byte-identical output.
+Post-RFC-0009 (codex-native-skills): the `skill` primitive lands as
+`direct-directory` mode (full body, byte-equal). Adopters upgrading
+from the legacy `managed-block-inline` shape get a one-shot in-place
+strip of the `<!-- agent-skills:start -->` / `<!-- agent-skills:end -->`
+delimiter region from their existing `<output_root>/AGENTS.md`; the
+strip is destructive by design and bound to the migration window
+(removed together with `_splice_managed_block` in a follow-on release).
 """
 
 from __future__ import annotations
 
+import os
 import shutil
+import sys
+import tempfile
 from pathlib import Path
 from typing import Any, Iterator
 
 
 # RFC-0005 § Build-pipeline ordering invariant — uniform across adapters.
 from agentbundle.build.phase_order import PHASE_ORDER as _PHASE_ORDER
+from agentbundle.build.projections.direct_directory import sweep_orphans
 
 
 def _iter_primitives(contract: dict) -> Iterator[str]:
@@ -31,6 +39,42 @@ def project(pack_path: Path, contract: dict, output_root: Path) -> None:
 
 
 def project_packs(pack_paths: list[Path], contract: dict, output_root: Path) -> None:
+    # One-shot migration strip on the project-root AGENTS.md. AC10:
+    # in self-host, `_compose_agents_md` rewrites AGENTS.md from the
+    # seed (which AC15 stripped of delimiters) just before this call,
+    # so the strip is a documented no-op there. In adopter installs
+    # against a pre-existing AGENTS.md carrying the legacy block, the
+    # strip does real work. Both cases are correct.
+    agents_md = output_root / "AGENTS.md"
+    if agents_md.exists():
+        original = agents_md.read_text(encoding="utf-8")
+        stripped = _strip_legacy_skill_block(original)
+        if stripped != original:
+            # Destructive: any hand-edited prose between the legacy
+            # delimiters is gone (RFC-0009 § Failure modes). Leave a
+            # breadcrumb so an adopter who discovers missing notes
+            # has a way to reconstruct what happened.
+            print(
+                f"codex: stripped legacy <!-- agent-skills:start --> region "
+                f"from {agents_md} — see RFC-0009 § Migration path",
+                file=sys.stderr,
+            )
+            # Atomic rewrite: a crash between truncate and write would
+            # otherwise leave a zero-length AGENTS.md. write to a
+            # sibling temp file, then `os.replace` for the swap.
+            fd, tmp_path = tempfile.mkstemp(
+                prefix=".AGENTS.md.strip.",
+                suffix=".tmp",
+                dir=str(agents_md.parent),
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                    handle.write(stripped)
+                os.replace(tmp_path, agents_md)
+            except BaseException:
+                Path(tmp_path).unlink(missing_ok=True)
+                raise
+
     adapter_block = contract["adapter"]["codex"]
     rules_by_primitive = {entry["primitive"]: entry for entry in adapter_block.get("projection", [])}
 
@@ -43,11 +87,55 @@ def project_packs(pack_paths: list[Path], contract: dict, output_root: Path) -> 
             for pack_path in pack_paths
         ]
         source_dirs = [source_dir for source_dir in source_dirs if source_dir.exists()]
-        if not source_dirs:
+
+        # The `skill` primitive's `direct-directory` projection runs
+        # the orphan sweep uniformly across all three adapters, even
+        # when no pack ships skills — matching claude_code / kiro
+        # which sweep with an empty union (wiping leftover orphans).
+        # See spec Objective invariant 4: "after every `project_packs`
+        # call". Other primitives keep the early-skip.
+        is_skill_direct_directory = (
+            mode == "direct-directory" and primitive_name == "skill"
+        )
+        if not source_dirs and not is_skill_direct_directory:
             continue
 
-        if mode == "managed-block-inline":
-            _project_managed_block(source_dirs, output_root, rule)
+        if mode == "direct-directory":
+            target_dir = output_root / rule["target-path"].rstrip("/")
+            target_dir.mkdir(parents=True, exist_ok=True)
+            expected_names: set[str] = set()
+            for source_dir in source_dirs:
+                for entry in sorted(source_dir.iterdir()):
+                    # Defense-in-depth — `lint-packs` already refuses
+                    # packs that ship symlinks, but a caller invoking
+                    # `project_packs` directly bypasses that gate. A
+                    # symlink at the skill-root level would be
+                    # dereferenced by `copytree` (the `symlinks=True`
+                    # flag only governs symlinks *inside* the tree),
+                    # exfiltrating the link target's contents.
+                    if entry.is_symlink():
+                        continue
+                    if entry.is_dir():
+                        expected_names.add(entry.name)
+                        destination = target_dir / entry.name
+                        # Spec § Never do — `shutil.rmtree` is barred
+                        # against any entry whose `is_symlink()` is
+                        # true. If a previous projection left a
+                        # symlink at the destination path, unlink it
+                        # (removes the link, not the target).
+                        if destination.is_symlink():
+                            destination.unlink()
+                        elif destination.exists():
+                            shutil.rmtree(destination)
+                        # symlinks=True keeps source symlinks as
+                        # symlinks — never dereferences. A malicious
+                        # pack with a symlink to /etc/passwd cannot
+                        # exfiltrate.
+                        shutil.copytree(entry, destination, symlinks=True)
+            # Bound to `skill` only per spec § Never do. Other
+            # direct-directory primitives opt in explicitly.
+            if primitive_name == "skill":
+                sweep_orphans(target_dir, expected_names)
         elif mode == "direct-file":
             for source_dir in source_dirs:
                 _project_direct_file(source_dir, output_root, rule["target-path"])
@@ -61,75 +149,6 @@ def _project_direct_file(source_dir: Path, output_root: Path, target_prefix: str
     for entry in sorted(source_dir.iterdir()):
         if entry.is_file():
             shutil.copy2(entry, target_dir / entry.name, follow_symlinks=False)
-
-
-def _project_managed_block(
-    source_dirs: list[Path],
-    output_root: Path,
-    rule: dict,
-) -> None:
-    target_path = output_root / rule["target-path"].lstrip("/")
-    start_marker = rule["managed-block-delimiter-start"]
-    end_marker = rule["managed-block-delimiter-end"]
-
-    skills: list[tuple[str, str]] = []
-    for source_dir in source_dirs:
-        for skill_dir in sorted(source_dir.iterdir()):
-            if not skill_dir.is_dir():
-                continue
-            skill_md = skill_dir / "SKILL.md"
-            if not skill_md.exists():
-                md_candidates = sorted(skill_dir.glob("*.md"))
-                if not md_candidates:
-                    continue
-                skill_md = md_candidates[0]
-            description = _extract_description(skill_md.read_text(encoding="utf-8"))
-            # Refuse either the directory name or the description carrying a
-            # delimiter literal — both land in the managed block via
-            # f"- **{name}** — {description}" and either would break the
-            # splice on the next idempotent run.
-            for field_name, field_value in (
-                ("name", skill_dir.name),
-                ("description", description),
-            ):
-                if start_marker in field_value or end_marker in field_value:
-                    raise ValueError(
-                        f"codex: skill {skill_dir.name!r} {field_name} contains a "
-                        f"managed-block delimiter — refusing to splice."
-                    )
-            skills.append((skill_dir.name, description))
-
-    skills.sort()
-    block_lines = [start_marker]
-    for name, description in skills:
-        block_lines.append(f"- **{name}** — {description}")
-    block_lines.append(end_marker)
-    managed_block = "\n".join(block_lines) + "\n"
-
-    existing = target_path.read_text(encoding="utf-8") if target_path.exists() else ""
-    new_content = _splice_managed_block(existing, start_marker, end_marker, managed_block)
-    target_path.parent.mkdir(parents=True, exist_ok=True)
-    target_path.write_text(new_content, encoding="utf-8")
-
-
-def _extract_description(text: str) -> str:
-    lines = text.splitlines()
-    if lines and lines[0].startswith("---"):
-        for index in range(1, len(lines)):
-            if lines[index].startswith("---"):
-                break
-            stripped = lines[index].strip()
-            if stripped.startswith("description:"):
-                value = stripped.partition(":")[2].strip()
-                if (value.startswith('"') and value.endswith('"')) or (
-                    value.startswith("'") and value.endswith("'")
-                ):
-                    value = value[1:-1]
-                return value
-    for line in lines:
-        if line.strip() and not line.startswith("#"):
-            return line.strip()
-    return ""
 
 
 def _splice_managed_block(
@@ -147,3 +166,50 @@ def _splice_managed_block(
     if existing and not existing.endswith("\n"):
         existing += "\n"
     return existing + managed_block
+
+
+# Legacy delimiter literals, hardcoded for the migration window per
+# RFC-0009 § Adapter implementation change. Removed in the post-strip
+# release together with `_splice_managed_block`.
+_LEGACY_SKILL_BLOCK_START = "<!-- agent-skills:start -->"
+_LEGACY_SKILL_BLOCK_END = "<!-- agent-skills:end -->"
+
+
+def _strip_legacy_skill_block(text: str) -> str:
+    """Strip the legacy `agent-skills` managed block from an `AGENTS.md`.
+
+    One-shot migration helper: if both delimiters are present, the
+    splice removes everything from the start marker through the end
+    marker (plus a trailing newline if present). If neither
+    delimiter is present, the input is returned byte-equal — the
+    strip is a no-op on a clean file. Idempotent.
+
+    `_splice_managed_block` with an empty `managed_block` argument
+    is sufficient on its own; its post-condition is that the
+    delimiters and the region between them are gone from the result.
+    The call goes through that helper so the AC23 retention test
+    still observes the splice symbol being used (any future inlining
+    that removes the symbol breaks the retention contract).
+    """
+    if _LEGACY_SKILL_BLOCK_START not in text or _LEGACY_SKILL_BLOCK_END not in text:
+        return text
+    # Splice helper indexes the first occurrence of each marker.
+    # If `end` precedes `start` (an adopter who reordered the
+    # delimiters) the splice would produce a result that still
+    # contains both markers and is not idempotent. Refuse the
+    # confused-deputy input rather than silently corrupt it.
+    start_position = text.index(_LEGACY_SKILL_BLOCK_START)
+    end_position = text.index(_LEGACY_SKILL_BLOCK_END)
+    if end_position < start_position:
+        raise ValueError(
+            "codex: <!-- agent-skills:end --> appears before "
+            "<!-- agent-skills:start --> in AGENTS.md — the migration "
+            "strip refuses confused-deputy input. Restore the "
+            "delimiter order or remove the block manually."
+        )
+    return _splice_managed_block(
+        text,
+        _LEGACY_SKILL_BLOCK_START,
+        _LEGACY_SKILL_BLOCK_END,
+        "",
+    )

--- a/packages/agentbundle/agentbundle/build/adapters/kiro.py
+++ b/packages/agentbundle/agentbundle/build/adapters/kiro.py
@@ -42,6 +42,7 @@ from agentbundle.build.projections.kiro_ide_hook import (
 # projection), so the predictable trailing position keeps the phases
 # uniform across adapters.
 from agentbundle.build.phase_order import PHASE_ORDER as _PHASE_ORDER
+from agentbundle.build.projections.direct_directory import sweep_orphans
 
 
 def _iter_primitives(contract: dict) -> Iterator[str]:
@@ -71,6 +72,54 @@ def _iter_primitives(contract: dict) -> Iterator[str]:
 
 
 def project(pack_path: Path, contract: dict, output_root: Path) -> None:
+    """Single-pack convenience wrapper. Delegates to `project_packs`."""
+    project_packs([pack_path], contract, output_root)
+
+
+def project_packs(pack_paths: list[Path], contract: dict, output_root: Path) -> None:
+    """Project every pack in `pack_paths` in order, then run the
+    shared orphan-sweep post-pass on the `skill` target directory.
+
+    Same-name collision rule: pack source order as supplied here; the
+    last pack's `<name>` overwrites earlier packs' (`_project_direct_directory`
+    `rmtree`s the destination before `copytree`). The orphan sweep
+    observes the union of source skill names across the call's pack
+    list (not per-pack) so a pack shipping a subset can co-exist with
+    another that ships the union complement.
+    """
+    for pack_path in pack_paths:
+        _project_single(pack_path, contract, output_root)
+    _sweep_skill_orphans(pack_paths, contract, output_root)
+
+
+# Mirror of claude_code.py:_skill_direct_directory_target — keep in sync.
+# A shared helper is barred by the spec's `Never do` boundary (no
+# expansion of projections/direct_directory.py beyond `sweep_orphans`).
+def _skill_direct_directory_target(contract: dict, output_root: Path) -> Path | None:
+    adapter_block = contract["adapter"]["kiro"]
+    for entry in adapter_block.get("projection", []):
+        if entry.get("primitive") == "skill" and entry.get("mode") == "direct-directory":
+            return output_root / entry["target-path"].rstrip("/")
+    return None
+
+
+def _sweep_skill_orphans(pack_paths: list[Path], contract: dict, output_root: Path) -> None:
+    target_dir = _skill_direct_directory_target(contract, output_root)
+    if target_dir is None:
+        return
+    skill_source_path = contract["primitive"]["skill"]["source-path"].rstrip("/")
+    expected_names: set[str] = set()
+    for pack_path in pack_paths:
+        source_dir = pack_path / skill_source_path
+        if not source_dir.exists():
+            continue
+        for entry in source_dir.iterdir():
+            if entry.is_dir():
+                expected_names.add(entry.name)
+    sweep_orphans(target_dir, expected_names)
+
+
+def _project_single(pack_path: Path, contract: dict, output_root: Path) -> None:
     """Project *pack_path* into *output_root* per Kiro's contract rules.
 
     Iteration is phase-ordered (see `_iter_primitives`). For each
@@ -302,9 +351,20 @@ def _project_hook_wiring_to_agent_json(
 
 def _project_direct_directory(source_dir: Path, target_dir: Path) -> None:
     for entry in sorted(source_dir.iterdir()):
+        # Defense-in-depth — `lint-packs` rejects packs that ship
+        # symlinks, but a direct `project_packs` caller bypasses
+        # that gate. A symlink at the skill-root level would be
+        # dereferenced by `copytree`.
+        if entry.is_symlink():
+            continue
         if entry.is_dir():
             destination = target_dir / entry.name
-            if destination.exists():
+            # Spec § Never do — `shutil.rmtree` is barred against
+            # any entry whose `is_symlink()` is true. If a previous
+            # run left a symlink at the destination path, unlink it.
+            if destination.is_symlink():
+                destination.unlink()
+            elif destination.exists():
                 shutil.rmtree(destination)
             shutil.copytree(entry, destination, symlinks=True)
 

--- a/packages/agentbundle/agentbundle/build/projections/direct_directory.py
+++ b/packages/agentbundle/agentbundle/build/projections/direct_directory.py
@@ -1,0 +1,41 @@
+"""Shared post-pass helper for `direct-directory` skill projections.
+
+After every multi-pack `project_packs(...)` call, the orphan sweep
+removes child directories of the projected skill target whose names
+are not in the union of source skill names across the call's pack list.
+
+Bound to the `skill` primitive only — other `direct-directory`
+projections opt in explicitly via their adapter's `project_packs`.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+
+def sweep_orphans(target_dir: Path, expected_names: set[str]) -> None:
+    if not target_dir.exists():
+        return
+    for entry in target_dir.iterdir():
+        if entry.is_symlink():
+            if entry.name not in expected_names:
+                # Destructive operation — leave a breadcrumb so adopters
+                # can trace what disappeared without bisecting commits.
+                print(
+                    f"sweep_orphans: removed orphan symlink {entry} "
+                    f"(not in expected source-skill names)",
+                    file=sys.stderr,
+                )
+                entry.unlink()
+            continue
+        if not entry.is_dir():
+            continue
+        if entry.name not in expected_names:
+            print(
+                f"sweep_orphans: removed orphan directory {entry} "
+                f"(not in expected source-skill names)",
+                file=sys.stderr,
+            )
+            shutil.rmtree(entry)

--- a/packages/agentbundle/agentbundle/build/self_host.py
+++ b/packages/agentbundle/agentbundle/build/self_host.py
@@ -22,7 +22,7 @@ markers through unchanged (spec § Boundaries — Never do). The
 consumer.
 
 Self-host scope (see docs/specs/self-hosting/spec.md § Phased rollout):
-the `SELF_HOST_ADAPTERS` allow-list runs `claude-code` and `codex`.
+the `SELF_HOST_ADAPTERS` allow-list runs `claude-code` only.
 Kiro and Copilot stay distribution-only so self-host does not project
 `.kiro/` or `.github/instructions/`.
 """
@@ -42,7 +42,7 @@ import sys
 import tempfile
 from pathlib import Path
 
-from agentbundle.build.adapters import ADAPTERS, codex
+from agentbundle.build.adapters import ADAPTERS, registry
 from agentbundle.build.contract import load as load_contract
 from agentbundle.build.main import (
     CONTRACT_PATH,
@@ -70,7 +70,7 @@ TARGET_PATHS = (
 # Self-host allow-list (see self-hosting spec § Phased rollout).
 # Kiro and Copilot remain in the contract for distribution builds but
 # are excluded from the self-host runner.
-SELF_HOST_ADAPTERS: tuple[str, ...] = ("claude-code", "codex")
+SELF_HOST_ADAPTERS: tuple[str, ...] = ("claude-code",)
 
 
 def is_dirty_tree(working_tree: Path) -> bool:
@@ -187,17 +187,14 @@ def _project_all_adapters(
     packs = discover_packs(packs_dir)
     for pack in packs:
         validate_pack_uniqueness(pack)
-    for adapter_name, project in ADAPTERS.items():
+    pack_paths = [pack.path for pack in packs]
+    for adapter_name in ADAPTERS:
         if adapter_name not in contract["adapter"]:
             continue
         if adapter_name not in SELF_HOST_ADAPTERS:
             continue
-        if adapter_name == "codex":
-            # Codex writes into composed AGENTS.md; _compose_agents_md owns
-            # that one-shot aggregate splice after the body seed is written.
-            continue
-        for pack in packs:
-            project(pack.path, contract, output_root)
+        adapter_module = registry[adapter_name.replace("-", "_")]
+        adapter_module.project_packs(pack_paths, contract, output_root)
 
 
 def _compose_agents_md(
@@ -205,8 +202,17 @@ def _compose_agents_md(
     output_root: Path,
     contract: dict,
 ) -> Path | None:
-    """Compose root AGENTS.md from the core body seed, Codex skill block,
-    and optional core footer fragment."""
+    """Compose root AGENTS.md from the core body seed and optional
+    core footer fragment.
+
+    Post-RFC-0009: Codex projects full skill bodies to `.agents/skills/`
+    rather than splicing a managed block into AGENTS.md. The Codex
+    adapter is not invoked from self-host — Codex correctness is gated
+    by unit tests + the AC29 tempdir projection test, not by
+    self-host's working-tree drift gate. Keeping Codex out of
+    `SELF_HOST_ADAPTERS` avoids carrying a duplicate
+    `.agents/skills/` tree in the working tree.
+    """
     body_path = packs_dir / "core" / "seeds" / "AGENTS.md"
     if not body_path.exists():
         return None
@@ -217,9 +223,6 @@ def _compose_agents_md(
     if body and not body.endswith("\n"):
         body += "\n"
     target_path.write_text(body, encoding="utf-8")
-
-    packs = discover_packs(packs_dir)
-    codex.project_packs([pack.path for pack in packs], contract, output_root)
 
     if footer_path.exists():
         text = target_path.read_text(encoding="utf-8")

--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_claude_code.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_claude_code.py
@@ -7,7 +7,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from agentbundle.build.adapters.claude_code import project
+from agentbundle.build.adapters.claude_code import project, project_packs
 from agentbundle.build.contract import load as load_contract
 
 REPO_ROOT = Path(__file__).resolve().parents[5]
@@ -121,6 +121,133 @@ class ClaudeCodeAdapterTests(unittest.TestCase):
             second_settings = (out / ".claude" / "settings.local.json").read_bytes()
             self.assertEqual(first_agent, second_agent)
             self.assertEqual(first_settings, second_settings)
+
+
+def _seed_minimal_pack(root: Path, name: str, skill_name: str, body: str) -> Path:
+    """Pack with a single skill at .apm/skills/<skill_name>/SKILL.md."""
+    pack = root / name
+    skill_dir = pack / ".apm" / "skills" / skill_name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(body, encoding="utf-8")
+    return pack
+
+
+class ProjectPacksTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.contract = load_contract(CONTRACT_PATH)
+
+    def test_project_packs_iterates_in_order(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack_a = _seed_minimal_pack(tmp_path, "pack-a", "skill-a", "# a\n")
+            pack_b = _seed_minimal_pack(tmp_path, "pack-b", "skill-b", "# b\n")
+            out = tmp_path / "out"
+
+            project_packs([pack_a, pack_b], self.contract, out)
+
+            self.assertTrue((out / ".claude" / "skills" / "skill-a" / "SKILL.md").is_file())
+            self.assertTrue((out / ".claude" / "skills" / "skill-b" / "SKILL.md").is_file())
+
+    def test_single_pack_project_delegates_to_project_packs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = _seed_minimal_pack(tmp_path, "pack", "skill-x", "# x\n")
+            out_a = tmp_path / "out-a"
+            out_b = tmp_path / "out-b"
+
+            project(pack, self.contract, out_a)
+            project_packs([pack], self.contract, out_b)
+
+            self.assertEqual(
+                (out_a / ".claude" / "skills" / "skill-x" / "SKILL.md").read_bytes(),
+                (out_b / ".claude" / "skills" / "skill-x" / "SKILL.md").read_bytes(),
+            )
+
+    def test_same_name_last_wins(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack_a = _seed_minimal_pack(
+                tmp_path, "pack-a", "same-name", "# pack-a\nPACK_A_SENTINEL\n",
+            )
+            pack_b = _seed_minimal_pack(
+                tmp_path, "pack-b", "same-name", "# pack-b\nPACK_B_SENTINEL\n",
+            )
+            out = tmp_path / "out"
+
+            project_packs([pack_a, pack_b], self.contract, out)
+            body = (out / ".claude" / "skills" / "same-name" / "SKILL.md").read_text(
+                encoding="utf-8",
+            )
+            self.assertIn("PACK_B_SENTINEL", body)
+            self.assertNotIn("PACK_A_SENTINEL", body)
+
+    def test_same_name_last_wins_reversed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack_a = _seed_minimal_pack(
+                tmp_path, "pack-a", "same-name", "# pack-a\nPACK_A_SENTINEL\n",
+            )
+            pack_b = _seed_minimal_pack(
+                tmp_path, "pack-b", "same-name", "# pack-b\nPACK_B_SENTINEL\n",
+            )
+            out = tmp_path / "out"
+
+            project_packs([pack_b, pack_a], self.contract, out)
+            body = (out / ".claude" / "skills" / "same-name" / "SKILL.md").read_text(
+                encoding="utf-8",
+            )
+            self.assertIn("PACK_A_SENTINEL", body)
+            self.assertNotIn("PACK_B_SENTINEL", body)
+
+
+def _seed_named_skills_pack(root: Path, pack_name: str, skill_names: list[str]) -> Path:
+    pack = root / pack_name
+    for skill_name in skill_names:
+        skill_dir = pack / ".apm" / "skills" / skill_name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"# {skill_name}\nfrom {pack_name}\n",
+            encoding="utf-8",
+        )
+    return pack
+
+
+class TestClaudeCodeOrphanSweep(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.contract = load_contract(CONTRACT_PATH)
+
+    def test_two_stage_shrink(self) -> None:
+        # AC18: project {a, b, c} then {a, c} into the same output.
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            three = _seed_named_skills_pack(tmp_path, "three-skill", ["a", "b", "c"])
+            shrink = _seed_named_skills_pack(tmp_path, "two-skill-shrink", ["a", "c"])
+            out = tmp_path / "out"
+
+            project_packs([three], self.contract, out)
+            self.assertTrue((out / ".claude" / "skills" / "b").is_dir())
+
+            project_packs([shrink], self.contract, out)
+            children = {p.name for p in (out / ".claude" / "skills").iterdir()}
+            self.assertEqual(children, {"a", "c"})
+
+    def test_two_pack_union(self) -> None:
+        # AC20 — claude-code case.
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack_a = _seed_named_skills_pack(tmp_path, "pack-a", ["a", "b"])
+            pack_b = _seed_named_skills_pack(tmp_path, "pack-b", ["b", "c"])
+            out = tmp_path / "out"
+
+            project_packs([pack_a, pack_b], self.contract, out)
+            children = {p.name for p in (out / ".claude" / "skills").iterdir()}
+            self.assertEqual(children, {"a", "b", "c"})
+
+            project_packs([pack_a], self.contract, out)
+            children = {p.name for p in (out / ".claude" / "skills").iterdir()}
+            self.assertEqual(children, {"a", "b"})
 
 
 if __name__ == "__main__":

--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_codex.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_codex.py
@@ -5,8 +5,17 @@ from __future__ import annotations
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
-from agentbundle.build.adapters.codex import project, project_packs
+from agentbundle.build.adapters import codex
+from agentbundle.build.adapters.codex import (
+    _LEGACY_SKILL_BLOCK_END,
+    _LEGACY_SKILL_BLOCK_START,
+    _splice_managed_block,
+    _strip_legacy_skill_block,
+    project,
+    project_packs,
+)
 from agentbundle.build.contract import load as load_contract
 
 REPO_ROOT = Path(__file__).resolve().parents[5]
@@ -46,31 +55,6 @@ class CodexAdapterTests(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.contract = load_contract(CONTRACT_PATH)
 
-    def test_skill_description_appears_in_managed_block(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_path = Path(tmp)
-            pack = _seed_pack(tmp_path)
-            out = tmp_path / "out"
-            project(pack, self.contract, out)
-            text = (out / "AGENTS.md").read_text(encoding="utf-8")
-            self.assertIn("<!-- agent-skills:start -->", text)
-            self.assertIn("<!-- agent-skills:end -->", text)
-            self.assertIn("foo skill description", text)
-            self.assertIn("alpha skill description", text)
-
-    def test_outside_block_preserved(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_path = Path(tmp)
-            pack = _seed_pack(tmp_path)
-            out = tmp_path / "out"
-            out.mkdir()
-            preamble = "# Existing AGENTS.md\n\nKeep me.\n"
-            (out / "AGENTS.md").write_text(preamble, encoding="utf-8")
-            project(pack, self.contract, out)
-            text = (out / "AGENTS.md").read_text(encoding="utf-8")
-            self.assertIn("# Existing AGENTS.md", text)
-            self.assertIn("Keep me.", text)
-
     def test_agent_hook_wiring_command_dropped(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
@@ -89,40 +73,550 @@ class CodexAdapterTests(unittest.TestCase):
             self.assertTrue((out / "tools" / "hooks" / "baz.sh").exists())
             self.assertTrue((out / "tools" / "hooks" / "baz.py").exists())
 
-    def test_idempotent(self) -> None:
+
+def _seed_two_skill_pack(root: Path, name: str = "two-skill") -> Path:
+    """Two skills: one flat, one with nested subdirectories."""
+    pack = root / name
+    flat = pack / ".apm" / "skills" / "flat"
+    flat.mkdir(parents=True)
+    (flat / "SKILL.md").write_text(
+        "---\ndescription: flat skill\n---\n# flat\nbody\n",
+        encoding="utf-8",
+    )
+
+    nested = pack / ".apm" / "skills" / "nested"
+    (nested / "scripts").mkdir(parents=True)
+    (nested / "references").mkdir(parents=True)
+    (nested / "SKILL.md").write_text(
+        "---\ndescription: nested skill\n---\n# nested\nbody\n",
+        encoding="utf-8",
+    )
+    (nested / "scripts" / "run.sh").write_text(
+        "#!/bin/sh\necho run\n",
+        encoding="utf-8",
+    )
+    (nested / "references" / "notes.md").write_text(
+        "# Notes\nReference content.\n",
+        encoding="utf-8",
+    )
+    return pack
+
+
+def _seed_symlinked_pack(root: Path, name: str = "symlinked") -> Path:
+    """Skill body with a relative symlink under references/."""
+    pack = root / name
+    (pack / ".apm" / "assets").mkdir(parents=True)
+    (pack / ".apm" / "assets" / "shared.md").write_text(
+        "# Shared\nContent.\n",
+        encoding="utf-8",
+    )
+
+    linker = pack / ".apm" / "skills" / "linker"
+    (linker / "references").mkdir(parents=True)
+    (linker / "SKILL.md").write_text(
+        "---\ndescription: linker skill\n---\n# linker\n",
+        encoding="utf-8",
+    )
+    (linker / "references" / "shared.md").symlink_to(Path("../../../assets/shared.md"))
+    return pack
+
+
+def _seed_same_name_pack(root: Path, name: str, body: str) -> Path:
+    pack = root / name
+    skill_dir = pack / ".apm" / "skills" / "same-name"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(body, encoding="utf-8")
+    return pack
+
+
+class TestDirectDirectoryProjection(unittest.TestCase):
+    """Post-RFC-0009 Codex `skill` projection — `direct-directory` mode."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.contract = load_contract(CONTRACT_PATH)
+
+    def test_byte_equal_projection_two_skill(self) -> None:
+        # AC3, AC4.
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
-            pack = _seed_pack(tmp_path)
+            pack = _seed_two_skill_pack(tmp_path)
             out = tmp_path / "out"
-            project(pack, self.contract, out)
+
+            project_packs([pack], self.contract, out)
+
+            for rel in (
+                "flat/SKILL.md",
+                "nested/SKILL.md",
+                "nested/scripts/run.sh",
+                "nested/references/notes.md",
+            ):
+                source_bytes = (pack / ".apm" / "skills" / rel).read_bytes()
+                projected_bytes = (out / ".agents" / "skills" / rel).read_bytes()
+                self.assertEqual(
+                    projected_bytes,
+                    source_bytes,
+                    f"byte mismatch at {rel}",
+                )
+
+    def test_symlink_pass_through(self) -> None:
+        # AC5.
+        import os
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = _seed_symlinked_pack(tmp_path)
+            out = tmp_path / "out"
+
+            project_packs([pack], self.contract, out)
+
+            projected_link = out / ".agents" / "skills" / "linker" / "references" / "shared.md"
+            self.assertTrue(os.path.islink(projected_link))
+            self.assertEqual(
+                os.readlink(projected_link),
+                str(Path("../../../assets/shared.md")),
+            )
+
+    def test_same_name_last_wins(self) -> None:
+        # AC6 — Codex case.
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack_a = _seed_same_name_pack(
+                tmp_path, "pack-a", "# pack-a\nPACK_A_SENTINEL\n",
+            )
+            pack_b = _seed_same_name_pack(
+                tmp_path, "pack-b", "# pack-b\nPACK_B_SENTINEL\n",
+            )
+            out = tmp_path / "out"
+
+            project_packs([pack_a, pack_b], self.contract, out)
+            body = (out / ".agents" / "skills" / "same-name" / "SKILL.md").read_text(
+                encoding="utf-8",
+            )
+            self.assertIn("PACK_B_SENTINEL", body)
+            self.assertNotIn("PACK_A_SENTINEL", body)
+
+    def test_top_level_symlink_skill_is_skipped(self) -> None:
+        # Defense-in-depth: a malicious pack with `.apm/skills/<name>`
+        # as a symlink to a sensitive directory would exfiltrate its
+        # contents via `copytree` (the `symlinks=True` flag only
+        # governs symlinks *inside* the tree). The adapter must skip
+        # symlink entries at the iteration level so the contents do
+        # not land in the projection. `lint-packs` already refuses
+        # such packs; this is the adapter-layer safety net.
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            external = tmp_path / "external-secrets"
+            external.mkdir()
+            (external / "secret.txt").write_text("DO NOT LEAK\n", encoding="utf-8")
+
+            pack = tmp_path / "pack"
+            skills_dir = pack / ".apm" / "skills"
+            skills_dir.mkdir(parents=True)
+            # Top-level skill entry is a symlink-to-directory.
+            (skills_dir / "malicious").symlink_to(external, target_is_directory=True)
+            # And a legitimate skill — that one must still project.
+            legit = skills_dir / "legit"
+            legit.mkdir()
+            (legit / "SKILL.md").write_text("# legit\n", encoding="utf-8")
+
+            out = tmp_path / "out"
+
+            project_packs([pack], self.contract, out)
+
+            self.assertFalse((out / ".agents" / "skills" / "malicious").exists())
+            self.assertFalse((out / ".agents" / "skills" / "secret.txt").exists())
+            self.assertTrue((out / ".agents" / "skills" / "legit" / "SKILL.md").is_file())
+            # External directory untouched.
+            self.assertEqual(
+                (external / "secret.txt").read_text(encoding="utf-8"),
+                "DO NOT LEAK\n",
+            )
+
+    def test_destination_symlink_safe_overwrite(self) -> None:
+        # Spec § Never do: `shutil.rmtree` is barred against entries
+        # whose `is_symlink()` is true. If a previous run left a
+        # symlink at `<target>/skills/<name>`, the next projection
+        # must unlink it (removing the link, not the target).
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = _seed_two_skill_pack(tmp_path)
+            out = tmp_path / "out"
+            target = out / ".agents" / "skills"
+            target.mkdir(parents=True)
+
+            external = tmp_path / "external"
+            external.mkdir()
+            (external / "anchor").write_text("keep me\n", encoding="utf-8")
+            (target / "flat").symlink_to(external, target_is_directory=True)
+
+            project_packs([pack], self.contract, out)
+
+            self.assertFalse((target / "flat").is_symlink())
+            self.assertTrue((target / "flat" / "SKILL.md").is_file())
+            self.assertTrue(external.is_dir())
+            self.assertEqual(
+                (external / "anchor").read_text(encoding="utf-8"),
+                "keep me\n",
+            )
+
+    def test_same_name_last_wins_reversed(self) -> None:
+        # AC6 — Codex case, reversed.
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack_a = _seed_same_name_pack(
+                tmp_path, "pack-a", "# pack-a\nPACK_A_SENTINEL\n",
+            )
+            pack_b = _seed_same_name_pack(
+                tmp_path, "pack-b", "# pack-b\nPACK_B_SENTINEL\n",
+            )
+            out = tmp_path / "out"
+
+            project_packs([pack_b, pack_a], self.contract, out)
+            body = (out / ".agents" / "skills" / "same-name" / "SKILL.md").read_text(
+                encoding="utf-8",
+            )
+            self.assertIn("PACK_A_SENTINEL", body)
+            self.assertNotIn("PACK_B_SENTINEL", body)
+
+
+def _seed_named_skills_pack(root: Path, pack_name: str, skill_names: list[str]) -> Path:
+    pack = root / pack_name
+    for skill_name in skill_names:
+        skill_dir = pack / ".apm" / "skills" / skill_name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"# {skill_name}\nfrom {pack_name}\n",
+            encoding="utf-8",
+        )
+    return pack
+
+
+class TestCodexOrphanSweep(unittest.TestCase):
+    """T7 — `direct-directory` skill projection runs `sweep_orphans`
+    against the union of source skill names across the call's pack list.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.contract = load_contract(CONTRACT_PATH)
+
+    def test_codex_two_stage_shrink(self) -> None:
+        # AC17: project {a, b, c} then {a, c} into the same output.
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            three = _seed_named_skills_pack(tmp_path, "three-skill", ["a", "b", "c"])
+            shrink = _seed_named_skills_pack(tmp_path, "two-skill-shrink", ["a", "c"])
+            out = tmp_path / "out"
+
+            project_packs([three], self.contract, out)
+            self.assertTrue((out / ".agents" / "skills" / "b").is_dir())
+
+            project_packs([shrink], self.contract, out)
+            children = {p.name for p in (out / ".agents" / "skills").iterdir()}
+            self.assertEqual(children, {"a", "c"})
+
+    def test_codex_two_pack_union(self) -> None:
+        # AC20: pack_a={a,b} + pack_b={b,c} → {a,b,c};
+        #        then pack_a alone → {a,b}, c removed.
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack_a = _seed_named_skills_pack(tmp_path, "pack-a", ["a", "b"])
+            pack_b = _seed_named_skills_pack(tmp_path, "pack-b", ["b", "c"])
+            out = tmp_path / "out"
+
+            project_packs([pack_a, pack_b], self.contract, out)
+            children = {p.name for p in (out / ".agents" / "skills").iterdir()}
+            self.assertEqual(children, {"a", "b", "c"})
+
+            project_packs([pack_a], self.contract, out)
+            children = {p.name for p in (out / ".agents" / "skills").iterdir()}
+            self.assertEqual(children, {"a", "b"})
+
+    def test_codex_symlink_safe_sweep(self) -> None:
+        # AC21: pre-seed a symlink-to-external in the target dir; the
+        # sweep removes the symlink but leaves the external dir intact.
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = _seed_named_skills_pack(tmp_path, "pack", ["a"])
+            external = tmp_path / "external"
+            external.mkdir()
+            (external / "anchor").write_text("keep me\n", encoding="utf-8")
+            out = tmp_path / "out"
+            target = out / ".agents" / "skills"
+            target.mkdir(parents=True)
+            link = target / "b"
+            link.symlink_to(external, target_is_directory=True)
+
+            project_packs([pack], self.contract, out)
+
+            self.assertTrue((target / "a").is_dir())
+            self.assertFalse(link.exists())
+            self.assertFalse(link.is_symlink())
+            self.assertTrue(external.is_dir())
+            self.assertEqual(
+                (external / "anchor").read_text(encoding="utf-8"),
+                "keep me\n",
+            )
+
+
+class TestMigrationStripIntegrated(unittest.TestCase):
+    """Codex `project_packs` strips the legacy block from `<output_root>/AGENTS.md`."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.contract = load_contract(CONTRACT_PATH)
+
+    def _populated(self) -> str:
+        return (
+            "# Top\n\nIntroductory prose.\n\n"
+            f"{_LEGACY_SKILL_BLOCK_START}\n"
+            "- **a** — desc-a\n"
+            "- **b** — desc-b\n"
+            f"{_LEGACY_SKILL_BLOCK_END}\n"
+            "\nClosing prose.\n"
+        )
+
+    def test_happy_path_strips_delimiters_and_preserves_prose(self) -> None:
+        # AC10, AC11. The strip's only allowed mutation is removing
+        # the legacy delimiter region; outside-delimiter bytes must
+        # survive byte-for-byte. Substring `assertIn` would pass on
+        # munged surrounding bytes; the concatenation assertion
+        # below pins the byte-equality contract AC11(c) names.
+        outside_before = "# Top\n\nIntroductory prose.\n\n"
+        outside_after = "\nClosing prose.\n"
+        populated = (
+            f"{outside_before}"
+            f"{_LEGACY_SKILL_BLOCK_START}\n"
+            f"- **a** — desc-a\n"
+            f"- **b** — desc-b\n"
+            f"{_LEGACY_SKILL_BLOCK_END}\n"
+            f"{outside_after}"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = _seed_two_skill_pack(tmp_path)
+            out = tmp_path / "out"
+            out.mkdir()
+            (out / "AGENTS.md").write_text(populated, encoding="utf-8")
+
+            project_packs([pack], self.contract, out)
+
+            text = (out / "AGENTS.md").read_text(encoding="utf-8")
+            self.assertNotIn(_LEGACY_SKILL_BLOCK_START, text)
+            self.assertNotIn(_LEGACY_SKILL_BLOCK_END, text)
+            # Byte-for-byte preservation: the outside-delimiter prose
+            # appears unchanged, in order, with no munging.
+            self.assertIn(outside_before + outside_after, text)
+
+    def test_already_clean_is_byte_identical(self) -> None:
+        # AC12.
+        clean = "# Top\n\nNo managed block.\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = _seed_two_skill_pack(tmp_path)
+            out = tmp_path / "out"
+            out.mkdir()
+            (out / "AGENTS.md").write_text(clean, encoding="utf-8")
+
+            project_packs([pack], self.contract, out)
+
+            self.assertEqual(
+                (out / "AGENTS.md").read_text(encoding="utf-8"),
+                clean,
+            )
+
+    def test_idempotent_across_two_calls(self) -> None:
+        # AC13.
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = _seed_two_skill_pack(tmp_path)
+            out = tmp_path / "out"
+            out.mkdir()
+            (out / "AGENTS.md").write_text(self._populated(), encoding="utf-8")
+
+            project_packs([pack], self.contract, out)
             first = (out / "AGENTS.md").read_bytes()
-            project(pack, self.contract, out)
+            project_packs([pack], self.contract, out)
             second = (out / "AGENTS.md").read_bytes()
             self.assertEqual(first, second)
 
-    def test_project_packs_aggregates_skills_before_splicing(self) -> None:
+    def test_hand_edited_content_between_delimiters_is_lost(self) -> None:
+        # AC14.
+        sentinel = "<<HAND-EDITED-PRESERVE-ME>>"
+        body = (
+            "prefix\n"
+            f"{_LEGACY_SKILL_BLOCK_START}\n"
+            f"{sentinel}\n"
+            f"{_LEGACY_SKILL_BLOCK_END}\n"
+            "suffix\n"
+        )
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
-            pack_a = _seed_pack(tmp_path, "pack-a", "a-")
-            pack_b = _seed_pack(tmp_path, "pack-b", "b-")
+            pack = _seed_two_skill_pack(tmp_path)
             out = tmp_path / "out"
             out.mkdir()
-            (out / "AGENTS.md").write_text(
-                "# Existing\n\nKeep this outside block.\n",
-                encoding="utf-8",
+            (out / "AGENTS.md").write_text(body, encoding="utf-8")
+
+            project_packs([pack], self.contract, out)
+
+            text = (out / "AGENTS.md").read_text(encoding="utf-8")
+            self.assertNotIn(sentinel, text)
+
+
+class TestMigrationStripPureFunction(unittest.TestCase):
+    """Pure-function tests for `_strip_legacy_skill_block`.
+
+    No filesystem; the strip is a text transform. Integration with
+    `project_packs` is covered by T4's tests.
+    """
+
+    OUTSIDE_BEFORE = "# Top\n\nIntroductory prose.\n\n"
+    OUTSIDE_AFTER = "\nClosing prose.\n"
+
+    def _populated(self) -> str:
+        return (
+            f"{self.OUTSIDE_BEFORE}"
+            f"{_LEGACY_SKILL_BLOCK_START}\n"
+            f"- **a** — desc-a\n"
+            f"- **b** — desc-b\n"
+            f"{_LEGACY_SKILL_BLOCK_END}\n"
+            f"{self.OUTSIDE_AFTER}"
+        )
+
+    def test_happy_path_strips_delimiters_and_preserves_outside_prose(self) -> None:
+        stripped = _strip_legacy_skill_block(self._populated())
+        self.assertNotIn(_LEGACY_SKILL_BLOCK_START, stripped)
+        self.assertNotIn(_LEGACY_SKILL_BLOCK_END, stripped)
+        self.assertIn("# Top\n", stripped)
+        self.assertIn("Introductory prose.", stripped)
+        self.assertIn("Closing prose.", stripped)
+
+    def test_already_clean_input_is_byte_identical(self) -> None:
+        clean = "# Top\n\nNo managed block here.\n"
+        self.assertEqual(_strip_legacy_skill_block(clean), clean)
+
+    def test_idempotent(self) -> None:
+        once = _strip_legacy_skill_block(self._populated())
+        twice = _strip_legacy_skill_block(once)
+        self.assertEqual(once, twice)
+
+    def test_non_list_content_between_delimiters_is_lost(self) -> None:
+        sentinel = "<<HAND-EDITED-PRESERVE-ME>>"
+        text = (
+            f"prefix\n"
+            f"{_LEGACY_SKILL_BLOCK_START}\n"
+            f"{sentinel}\n"
+            f"{_LEGACY_SKILL_BLOCK_END}\n"
+            f"suffix\n"
+        )
+        stripped = _strip_legacy_skill_block(text)
+        self.assertNotIn(sentinel, stripped)
+        self.assertIn("prefix", stripped)
+        self.assertIn("suffix", stripped)
+
+    def test_out_of_order_delimiters_refused(self) -> None:
+        # If the adopter pasted the delimiters in reverse order, the
+        # splice would otherwise corrupt the file silently. Refuse
+        # the input with a named error so the adopter can fix.
+        reversed_input = (
+            "prefix\n"
+            f"{_LEGACY_SKILL_BLOCK_END}\n"
+            f"{_LEGACY_SKILL_BLOCK_START}\n"
+            "suffix\n"
+        )
+        with self.assertRaises(ValueError) as caught:
+            _strip_legacy_skill_block(reversed_input)
+        self.assertIn("appears before", str(caught.exception))
+
+    def test_splice_managed_block_symbol_still_exists(self) -> None:
+        # AC23(i): a future refactor that inlines the splice and deletes
+        # the helper symbol breaks this import-and-call assertion.
+        self.assertTrue(callable(_splice_managed_block))
+
+    def test_strip_invokes_splice_managed_block_once(self) -> None:
+        # AC23(ii) — deliberate retention test. A refactor that
+        # inlines the splice and deletes `_splice_managed_block`
+        # breaks the import. A refactor that keeps the symbol but
+        # stops calling it from `_strip_legacy_skill_block` makes
+        # `call_count == 0`. Either signals the retention contract
+        # has been broken before the migration window closes. Do
+        # not "simplify" by removing the mock — the mock IS the
+        # contract. Patch with `wraps=` so the real function still
+        # runs and the strip behaviour is unchanged.
+        with mock.patch.object(
+            codex,
+            "_splice_managed_block",
+            wraps=codex._splice_managed_block,
+        ) as spy:
+            _strip_legacy_skill_block(self._populated())
+        self.assertEqual(spy.call_count, 1)
+
+
+class TestCodexProjectsEveryShippedSkill(unittest.TestCase):
+    """AC29 — every skill any in-tree pack ships projects through Codex
+    into `.agents/skills/<name>/SKILL.md` (byte-equal to source).
+
+    The spec text references `dist/codex/` as a notional adopter path;
+    in this self-hosting repo, Codex projects to the repo root, so the
+    test runs the projection against a `tmp_path` and enumerates
+    `packs/*/.apm/skills/`. The sentinel set (`work-loop`, `new-spec`,
+    `new-rfc`, `new-adr`) spans multiple packs (core +
+    governance-extras), so the test must walk all packs — a core-only
+    walk would silently skip `new-rfc` / `new-adr` against the spec's
+    explicit sentinel list.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.contract = load_contract(CONTRACT_PATH)
+
+    def test_every_shipped_skill_projects_with_equal_bytes(self) -> None:
+        packs_root = REPO_ROOT / "packs"
+        self.assertTrue(packs_root.is_dir())
+        pack_paths = sorted(p for p in packs_root.iterdir() if p.is_dir())
+
+        # Collect every source skill across every pack. Tracks the
+        # "winning" source path for same-name collisions so byte-equal
+        # comparisons use the last-supplied pack's body (matching
+        # AC6).
+        winning_source: dict[str, Path] = {}
+        for pack_path in pack_paths:
+            skills_dir = pack_path / ".apm" / "skills"
+            if not skills_dir.is_dir():
+                continue
+            for entry in skills_dir.iterdir():
+                if entry.is_dir():
+                    winning_source[entry.name] = entry
+
+        self.assertGreater(len(winning_source), 0)
+        for sentinel in ("work-loop", "new-spec", "new-rfc", "new-adr"):
+            self.assertIn(
+                sentinel,
+                winning_source,
+                f"sentinel skill {sentinel!r} missing from any in-tree pack",
             )
 
-            project_packs([pack_a, pack_b], self.contract, out)
-            first = (out / "AGENTS.md").read_text(encoding="utf-8")
-            project_packs([pack_a, pack_b], self.contract, out)
-            second = (out / "AGENTS.md").read_text(encoding="utf-8")
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            project_packs(pack_paths, self.contract, tmp_path)
 
-            self.assertEqual(first, second)
-            self.assertIn("Keep this outside block.", first)
-            self.assertIn("a-foo skill description", first)
-            self.assertIn("b-foo skill description", first)
-            self.assertIn("a-alpha skill description", first)
-            self.assertIn("b-alpha skill description", first)
+            for skill_name, source_skill_dir in winning_source.items():
+                projected_skill_md = (
+                    tmp_path / ".agents" / "skills" / skill_name / "SKILL.md"
+                )
+                source_skill_md = source_skill_dir / "SKILL.md"
+                if not source_skill_md.exists():
+                    continue
+                self.assertTrue(
+                    projected_skill_md.is_file(),
+                    f"skill {skill_name!r}: SKILL.md missing in projection",
+                )
+                self.assertEqual(
+                    projected_skill_md.read_bytes(),
+                    source_skill_md.read_bytes(),
+                    f"skill {skill_name!r}: SKILL.md bytes differ",
+                )
 
 
 if __name__ == "__main__":

--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro.py
@@ -8,7 +8,7 @@ import unittest
 from contextlib import redirect_stderr
 from pathlib import Path
 
-from agentbundle.build.adapters.kiro import project
+from agentbundle.build.adapters.kiro import project, project_packs
 from agentbundle.build.contract import load as load_contract
 
 REPO_ROOT = Path(__file__).resolve().parents[5]
@@ -133,6 +133,132 @@ class KiroAdapterTests(unittest.TestCase):
             project(pack, self.contract, out)
             # No command output.
             self.assertFalse(any(out.rglob("commands")))
+
+
+def _seed_minimal_pack(root: Path, name: str, skill_name: str, body: str) -> Path:
+    pack = root / name
+    skill_dir = pack / ".apm" / "skills" / skill_name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(body, encoding="utf-8")
+    return pack
+
+
+class ProjectPacksTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.contract = load_contract(CONTRACT_PATH)
+
+    def test_project_packs_iterates_in_order(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack_a = _seed_minimal_pack(tmp_path, "pack-a", "skill-a", "# a\n")
+            pack_b = _seed_minimal_pack(tmp_path, "pack-b", "skill-b", "# b\n")
+            out = tmp_path / "out"
+
+            project_packs([pack_a, pack_b], self.contract, out)
+
+            self.assertTrue((out / ".kiro" / "skills" / "skill-a" / "SKILL.md").is_file())
+            self.assertTrue((out / ".kiro" / "skills" / "skill-b" / "SKILL.md").is_file())
+
+    def test_single_pack_project_delegates_to_project_packs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = _seed_minimal_pack(tmp_path, "pack", "skill-x", "# x\n")
+            out_a = tmp_path / "out-a"
+            out_b = tmp_path / "out-b"
+
+            project(pack, self.contract, out_a)
+            project_packs([pack], self.contract, out_b)
+
+            self.assertEqual(
+                (out_a / ".kiro" / "skills" / "skill-x" / "SKILL.md").read_bytes(),
+                (out_b / ".kiro" / "skills" / "skill-x" / "SKILL.md").read_bytes(),
+            )
+
+    def test_same_name_last_wins(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack_a = _seed_minimal_pack(
+                tmp_path, "pack-a", "same-name", "# pack-a\nPACK_A_SENTINEL\n",
+            )
+            pack_b = _seed_minimal_pack(
+                tmp_path, "pack-b", "same-name", "# pack-b\nPACK_B_SENTINEL\n",
+            )
+            out = tmp_path / "out"
+
+            project_packs([pack_a, pack_b], self.contract, out)
+            body = (out / ".kiro" / "skills" / "same-name" / "SKILL.md").read_text(
+                encoding="utf-8",
+            )
+            self.assertIn("PACK_B_SENTINEL", body)
+            self.assertNotIn("PACK_A_SENTINEL", body)
+
+    def test_same_name_last_wins_reversed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack_a = _seed_minimal_pack(
+                tmp_path, "pack-a", "same-name", "# pack-a\nPACK_A_SENTINEL\n",
+            )
+            pack_b = _seed_minimal_pack(
+                tmp_path, "pack-b", "same-name", "# pack-b\nPACK_B_SENTINEL\n",
+            )
+            out = tmp_path / "out"
+
+            project_packs([pack_b, pack_a], self.contract, out)
+            body = (out / ".kiro" / "skills" / "same-name" / "SKILL.md").read_text(
+                encoding="utf-8",
+            )
+            self.assertIn("PACK_A_SENTINEL", body)
+            self.assertNotIn("PACK_B_SENTINEL", body)
+
+
+def _seed_named_skills_pack(root: Path, pack_name: str, skill_names: list[str]) -> Path:
+    pack = root / pack_name
+    for skill_name in skill_names:
+        skill_dir = pack / ".apm" / "skills" / skill_name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"# {skill_name}\nfrom {pack_name}\n",
+            encoding="utf-8",
+        )
+    return pack
+
+
+class TestKiroOrphanSweep(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.contract = load_contract(CONTRACT_PATH)
+
+    def test_two_stage_shrink(self) -> None:
+        # AC19: project {a, b, c} then {a, c} into the same output.
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            three = _seed_named_skills_pack(tmp_path, "three-skill", ["a", "b", "c"])
+            shrink = _seed_named_skills_pack(tmp_path, "two-skill-shrink", ["a", "c"])
+            out = tmp_path / "out"
+
+            project_packs([three], self.contract, out)
+            self.assertTrue((out / ".kiro" / "skills" / "b").is_dir())
+
+            project_packs([shrink], self.contract, out)
+            children = {p.name for p in (out / ".kiro" / "skills").iterdir()}
+            self.assertEqual(children, {"a", "c"})
+
+    def test_two_pack_union(self) -> None:
+        # AC20 — kiro case.
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack_a = _seed_named_skills_pack(tmp_path, "pack-a", ["a", "b"])
+            pack_b = _seed_named_skills_pack(tmp_path, "pack-b", ["b", "c"])
+            out = tmp_path / "out"
+
+            project_packs([pack_a, pack_b], self.contract, out)
+            children = {p.name for p in (out / ".kiro" / "skills").iterdir()}
+            self.assertEqual(children, {"a", "b", "c"})
+
+            project_packs([pack_a], self.contract, out)
+            children = {p.name for p in (out / ".kiro" / "skills").iterdir()}
+            self.assertEqual(children, {"a", "b"})
 
 
 if __name__ == "__main__":

--- a/packages/agentbundle/agentbundle/build/tests/test_contract.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_contract.py
@@ -473,6 +473,50 @@ class ContractV04Tests(unittest.TestCase):
             errors,
             "schema must reject install-routes as a string (must be an array)",
         )
+DATA_CONTRACT_PATH = (
+    REPO_ROOT
+    / "packages"
+    / "agentbundle"
+    / "agentbundle"
+    / "_data"
+    / "adapter.toml"
+)
+SEED_AGENTS_MD_PATH = REPO_ROOT / "packs" / "core" / "seeds" / "AGENTS.md"
+
+
+class TestCodexSkillDirectDirectory(unittest.TestCase):
+    """RFC-0009 / codex-native-skills contract flip.
+
+    AC1: Codex `skill` is `direct-directory` projecting to
+         `.agents/skills/` with `on-conflict = "prompt-then-preserve"`;
+         no managed-block delimiter keys remain on the entry.
+    AC2: `docs/contracts/adapter.toml` and the bundled `_data/adapter.toml`
+         are byte-identical.
+    AC15: The seed AGENTS.md no longer carries the legacy delimiter pair.
+    """
+
+    def test_codex_skill_projection_is_direct_directory(self) -> None:
+        contract = tomllib.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+        codex_entries = contract["adapter"]["codex"]["projection"]
+        skill_entries = [e for e in codex_entries if e["primitive"] == "skill"]
+        self.assertEqual(len(skill_entries), 1)
+        entry = skill_entries[0]
+        self.assertEqual(entry["mode"], "direct-directory")
+        self.assertEqual(entry["target-path"], ".agents/skills/")
+        self.assertEqual(entry["on-conflict"], "prompt-then-preserve")
+        self.assertNotIn("managed-block-delimiter-start", entry)
+        self.assertNotIn("managed-block-delimiter-end", entry)
+
+    def test_contract_files_byte_identical(self) -> None:
+        self.assertEqual(
+            CONTRACT_PATH.read_bytes(),
+            DATA_CONTRACT_PATH.read_bytes(),
+        )
+
+    def test_seed_agents_md_has_no_legacy_delimiters(self) -> None:
+        text = SEED_AGENTS_MD_PATH.read_text(encoding="utf-8")
+        self.assertNotIn("<!-- agent-skills:start -->", text)
+        self.assertNotIn("<!-- agent-skills:end -->", text)
 
 
 if __name__ == "__main__":

--- a/packages/agentbundle/agentbundle/build/tests/test_direct_directory_cleanup.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_direct_directory_cleanup.py
@@ -1,0 +1,65 @@
+"""Tests for `sweep_orphans` — the shared post-pass for
+`direct-directory` skill projections."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentbundle.build.projections.direct_directory import sweep_orphans
+
+
+def test_removes_orphan_directory(tmp_path: Path) -> None:
+    for name in ("a", "b", "c"):
+        (tmp_path / name).mkdir()
+
+    sweep_orphans(tmp_path, {"a", "c"})
+
+    assert (tmp_path / "a").is_dir()
+    assert (tmp_path / "c").is_dir()
+    assert not (tmp_path / "b").exists()
+
+
+def test_noop_on_full_match(tmp_path: Path) -> None:
+    for name in ("a", "b"):
+        (tmp_path / name).mkdir()
+
+    sweep_orphans(tmp_path, {"a", "b"})
+
+    assert (tmp_path / "a").is_dir()
+    assert (tmp_path / "b").is_dir()
+
+
+def test_noop_on_missing_target(tmp_path: Path) -> None:
+    sweep_orphans(tmp_path / "does-not-exist", {"a"})
+
+
+def test_ignores_root_files(tmp_path: Path) -> None:
+    (tmp_path / "a").mkdir()
+    readme = tmp_path / "README.md"
+    readme.write_text("hello\n", encoding="utf-8")
+
+    sweep_orphans(tmp_path, set())
+
+    assert not (tmp_path / "a").exists()
+    assert readme.is_file()
+    assert readme.read_text(encoding="utf-8") == "hello\n"
+
+
+def test_symlink_safe_sweep(tmp_path: Path) -> None:
+    external = tmp_path / "outside"
+    external.mkdir()
+    (external / "anchor").write_text("keep me\n", encoding="utf-8")
+
+    target = tmp_path / "skills"
+    target.mkdir()
+    (target / "a").mkdir()
+    link = target / "b"
+    link.symlink_to(external, target_is_directory=True)
+
+    sweep_orphans(target, {"a"})
+
+    assert (target / "a").is_dir()
+    assert not link.exists()
+    assert not link.is_symlink()
+    assert external.is_dir()
+    assert (external / "anchor").read_text(encoding="utf-8") == "keep me\n"

--- a/packages/agentbundle/agentbundle/build/tests/test_lint_agents_md_legacy_block.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_lint_agents_md_legacy_block.py
@@ -1,0 +1,135 @@
+"""T9 / AC31 — `tools/lint-agents-md.py` warns when a projected
+`AGENTS.md` still carries the legacy `<!-- agent-skills:start -->`
+literal *and* the contract declares Codex `skill` as `direct-directory`.
+
+The check fires through the linter's existing `warn(...)` closure
+(prefix `⚠` on stderr), not `note(...)` — so the exit code remains 0.
+
+Test shape: CLI subprocess invocation in a `tmp_path` scratch tree
+that mirrors the repo's layout (root `AGENTS.md`, `CLAUDE.md` symlink,
+synthetic `docs/contracts/adapter.toml`). The linter is run with
+`cwd=tmp_path`; the test asserts the return code and stderr.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+LINTER = REPO_ROOT / "tools" / "lint-agents-md.py"
+
+
+_CONTRACT_DIRECT_DIRECTORY = """\
+[primitive.skill]
+source-path = ".apm/skills/"
+
+[[adapter.codex.projection]]
+primitive = "skill"
+mode = "direct-directory"
+target-path = ".agents/skills/"
+on-conflict = "prompt-then-preserve"
+"""
+
+_CONTRACT_LEGACY = """\
+[primitive.skill]
+source-path = ".apm/skills/"
+
+[[adapter.codex.projection]]
+primitive = "skill"
+mode = "managed-block-inline"
+target-path = "AGENTS.md"
+managed-block-delimiter-start = "<!-- agent-skills:start -->"
+managed-block-delimiter-end = "<!-- agent-skills:end -->"
+on-conflict = "preserve-outside-block"
+"""
+
+
+def _seed_tree(
+    root: Path,
+    contract_body: str,
+    agents_md_body: str,
+) -> None:
+    contracts = root / "docs" / "contracts"
+    contracts.mkdir(parents=True)
+    (contracts / "adapter.toml").write_text(contract_body, encoding="utf-8")
+
+    (root / "AGENTS.md").write_text(agents_md_body, encoding="utf-8")
+    (root / "CLAUDE.md").symlink_to("AGENTS.md")
+
+
+def _run_linter(cwd: Path) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    return subprocess.run(
+        [sys.executable, str(LINTER)],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class LegacyBlockWarningTests(unittest.TestCase):
+    def test_warns_when_legacy_marker_present_with_direct_directory_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _seed_tree(
+                tmp_path,
+                contract_body=_CONTRACT_DIRECT_DIRECTORY,
+                agents_md_body=(
+                    "# AGENTS.md\n\n"
+                    "Outside content.\n\n"
+                    "<!-- agent-skills:start -->\n"
+                    "- **work-loop** — desc\n"
+                    "<!-- agent-skills:end -->\n"
+                ),
+            )
+
+            result = _run_linter(tmp_path)
+            # The warning must fire and must name the offending file
+            # path. It must NOT change the exit code — other checks
+            # (e.g. CLAUDE.md symlink, AGENTS.md size) determine the
+            # return value.
+            self.assertIn("legacy-codex-skill-block", result.stderr)
+            self.assertIn("AGENTS.md", result.stderr)
+            self.assertIn("⚠", result.stderr)
+
+    def test_no_warn_when_legacy_marker_absent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _seed_tree(
+                tmp_path,
+                contract_body=_CONTRACT_DIRECT_DIRECTORY,
+                agents_md_body="# AGENTS.md\n\nNo legacy block here.\n",
+            )
+
+            result = _run_linter(tmp_path)
+            self.assertNotIn("legacy-codex-skill-block", result.stderr)
+
+    def test_no_warn_when_contract_still_managed_block(self) -> None:
+        # If the contract hasn't flipped (some adopter mid-upgrade
+        # against an older bundle), the marker is expected — the linter
+        # does not warn.
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _seed_tree(
+                tmp_path,
+                contract_body=_CONTRACT_LEGACY,
+                agents_md_body=(
+                    "# AGENTS.md\n\n"
+                    "<!-- agent-skills:start -->\n"
+                    "<!-- agent-skills:end -->\n"
+                ),
+            )
+
+            result = _run_linter(tmp_path)
+            self.assertNotIn("legacy-codex-skill-block", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/agentbundle/agentbundle/build/tests/test_security.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_security.py
@@ -14,7 +14,6 @@ import unittest
 from pathlib import Path
 
 from agentbundle.build.adapters.claude_code import project as project_claude_code
-from agentbundle.build.adapters.codex import project as project_codex
 from agentbundle.build.contract import load as load_contract
 from agentbundle.build.main import (
     _assert_under,
@@ -70,27 +69,6 @@ class SymlinkProjectionTests(unittest.TestCase):
             self.assertTrue(projected.is_symlink())
             # The link target is preserved as a symlink, not dereferenced.
             self.assertEqual(os.readlink(projected), "/etc/passwd")
-
-
-class CodexDelimiterInjectionTests(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        cls.contract = load_contract(CONTRACT_PATH)
-
-    def test_skill_description_with_end_marker_is_rejected(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_path = Path(tmp)
-            pack = tmp_path / "pack"
-            skill = pack / ".apm" / "skills" / "evil"
-            skill.mkdir(parents=True)
-            (skill / "SKILL.md").write_text(
-                "---\ndescription: x --> <!-- agent-skills:end --> bad\n---\n",
-                encoding="utf-8",
-            )
-            out = tmp_path / "out"
-            with self.assertRaises(ValueError) as caught:
-                project_codex(pack, self.contract, out)
-            self.assertIn("managed-block delimiter", str(caught.exception))
 
 
 class PluginManifestValidationTests(unittest.TestCase):

--- a/packages/agentbundle/agentbundle/build/tests/test_self_host_check.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_self_host_check.py
@@ -361,7 +361,9 @@ class WorkingTreeOnConflictTests(unittest.TestCase):
             text = (working_tree / "AGENTS.md").read_text(encoding="utf-8")
             self.assertIn("# Custom AGENTS.md", text)
             self.assertIn("Do not lose me.", text)
-            self.assertIn("<!-- agent-skills:start -->", text)
+            # Post-RFC-0009: Codex no longer writes the managed block.
+            # The legacy delimiter must be absent from projected output.
+            self.assertNotIn("<!-- agent-skills:start -->", text)
 
 
 class SelfHostAdapterAllowListTests(unittest.TestCase):
@@ -396,18 +398,23 @@ class SelfHostAdapterAllowListTests(unittest.TestCase):
             (working_tree / ".keep").write_text("", encoding="utf-8")
             _git_commit_all(working_tree, "init")
 
-            # Register a sentinel adapter into both ADAPTERS and the
+            # Register a sentinel adapter into ADAPTERS, registry, and the
             # contract; if SELF_HOST_ADAPTERS is honoured, it must not
-            # be invoked.
-            sentinel = MagicMock()
+            # be invoked. Post-T5, `_project_all_adapters` looks up the
+            # adapter module via `registry`, so the sentinel needs an
+            # entry there with a `project_packs` callable.
+            sentinel_module = MagicMock()
             patched_adapters = dict(self_host_module.ADAPTERS)
-            patched_adapters["sentinel"] = sentinel
+            patched_adapters["sentinel"] = sentinel_module.project
+            patched_registry = dict(self_host_module.registry)
+            patched_registry["sentinel"] = sentinel_module
             patched_contract = dict(self.contract)
             patched_contract["adapter"] = {
                 **self.contract["adapter"],
                 "sentinel": {"projection": []},
             }
-            with patch.object(self_host_module, "ADAPTERS", patched_adapters):
+            with patch.object(self_host_module, "ADAPTERS", patched_adapters), \
+                 patch.object(self_host_module, "registry", patched_registry):
                 exit_code = self_host_module.run_self_host(
                     working_tree=working_tree,
                     packs_dir=packs_dir,
@@ -416,7 +423,7 @@ class SelfHostAdapterAllowListTests(unittest.TestCase):
                     contract=patched_contract,
                 )
             self.assertEqual(exit_code, 0)
-            sentinel.assert_not_called()
+            sentinel_module.project_packs.assert_not_called()
 
     def test_allow_listed_adapter_runs(self) -> None:
         """An adapter in SELF_HOST_ADAPTERS, registered in ADAPTERS and the
@@ -437,15 +444,18 @@ class SelfHostAdapterAllowListTests(unittest.TestCase):
             (working_tree / ".keep").write_text("", encoding="utf-8")
             _git_commit_all(working_tree, "init")
 
-            sentinel = MagicMock()
+            sentinel_module = MagicMock()
             patched_adapters = dict(self_host_module.ADAPTERS)
-            patched_adapters["sentinel"] = sentinel
+            patched_adapters["sentinel"] = sentinel_module.project
+            patched_registry = dict(self_host_module.registry)
+            patched_registry["sentinel"] = sentinel_module
             patched_contract = dict(self.contract)
             patched_contract["adapter"] = {
                 **self.contract["adapter"],
                 "sentinel": {"projection": []},
             }
             with patch.object(self_host_module, "ADAPTERS", patched_adapters), \
+                 patch.object(self_host_module, "registry", patched_registry), \
                  patch.object(
                      self_host_module,
                      "SELF_HOST_ADAPTERS",
@@ -459,8 +469,10 @@ class SelfHostAdapterAllowListTests(unittest.TestCase):
                     contract=patched_contract,
                 )
             self.assertEqual(exit_code, 0)
-            # Sentinel called once per discovered pack (one here).
-            self.assertEqual(sentinel.call_count, 1)
+            # Sentinel `project_packs` called once with the list of all
+            # discovered pack paths (T5 routing change — previously one
+            # call per pack via single-pack `project`).
+            self.assertEqual(sentinel_module.project_packs.call_count, 1)
 
 
 class AgentsMdCompositionTests(unittest.TestCase):
@@ -506,8 +518,20 @@ class AgentsMdCompositionTests(unittest.TestCase):
             self.assertEqual(exit_code, 0)
             text = (working_tree / "AGENTS.md").read_text(encoding="utf-8")
             self.assertTrue(text.startswith("# Body\n\nBody source.\n"))
-            self.assertIn("core skill description", text)
-            self.assertIn("governance skill description", text)
+            # Post-RFC-0009: skill descriptions no longer inline into
+            # AGENTS.md; Codex is not in `SELF_HOST_ADAPTERS` so the
+            # `.agents/skills/` tree is not produced in self-host output.
+            # Codex projection is tested against tempdir paths (AC29);
+            # Claude Code's `.claude/skills/` is the self-host surface.
+            self.assertNotIn("core skill description", text)
+            self.assertNotIn("governance skill description", text)
+            self.assertFalse((working_tree / ".agents").exists())
+            self.assertTrue(
+                (working_tree / ".claude" / "skills" / "core-skill" / "SKILL.md").is_file()
+            )
+            self.assertTrue(
+                (working_tree / ".claude" / "skills" / "governance-skill" / "SKILL.md").is_file()
+            )
             self.assertTrue(text.endswith("> Footer source.\n"))
 
 
@@ -1650,6 +1674,64 @@ class RecreateClaudeBridgeInvariantTests(unittest.TestCase):
                 _is_equivalent_claude_md_shape(
                     root / "CLAUDE.md", root / "AGENTS.md"
                 )
+            )
+
+
+class SelfHostAdapterRoutingTests(unittest.TestCase):
+    """Mock-based check that `_project_all_adapters` routes through
+    `project_packs` (not the legacy per-pack `project()` loop).
+
+    Source-text grep was rejected during T5 PLAN: a refactor that
+    preserves the contract but changes the call shape would break a
+    grep without breaking behaviour. The mock-based shape pins
+    behaviour.
+    """
+
+    def test_claude_code_routes_through_project_packs(self) -> None:
+        from unittest import mock
+
+        from agentbundle.build import self_host as self_host_module
+        from agentbundle.build.adapters import claude_code, codex
+
+        contract = load_contract(CONTRACT_PATH)
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            packs_dir = tmp_path / "packs"
+            (packs_dir / "core").mkdir(parents=True)
+            (packs_dir / "core" / "pack.toml").write_text(
+                "[pack]\n"
+                'name = "core"\n'
+                'version = "0.0.0"\n'
+                "[pack.adapter-contract]\n"
+                'version = "0.2"\n'
+                "[pack.install]\n"
+                'default-scope = "repo"\n'
+                'allowed-scopes = ["repo"]\n',
+                encoding="utf-8",
+            )
+            (packs_dir / "core" / ".apm").mkdir()
+            out = tmp_path / "out"
+            out.mkdir()
+
+            with mock.patch.object(claude_code, "project_packs") as cc_pp, \
+                 mock.patch.object(codex, "project_packs") as cx_pp:
+                self_host_module._project_all_adapters(out, packs_dir, contract)
+
+            # Post-RFC-0009: `SELF_HOST_ADAPTERS = ("claude-code",)` —
+            # codex is NOT routed from self-host. Codex correctness is
+            # gated by adapter unit tests + the AC29 tempdir test, not
+            # by self-host's working-tree drift gate. Keeping codex out
+            # avoids carrying a duplicate `.agents/skills/` tree in the
+            # working tree (the maintainer-overload concern that RFC-0009
+            # exposed once skills became full bodies rather than
+            # one-line teasers).
+            self.assertEqual(cc_pp.call_count, 1)
+            self.assertEqual(cx_pp.call_count, 0)
+            args, _kwargs = cc_pp.call_args
+            pack_paths_arg = args[0]
+            self.assertEqual(
+                pack_paths_arg,
+                [packs_dir / "core"],
             )
 
 

--- a/packs/core/seeds/AGENTS.md
+++ b/packs/core/seeds/AGENTS.md
@@ -4,7 +4,7 @@
 > Cursor, Codex, Gemini CLI, and Copilot also read it (via their own discovery rules).
 >
 > Keep this file under ~200 lines. If you're tempted to add to it, ask first whether
-> the content belongs in `docs/`, `.claude/skills/`, or a subdirectory `AGENTS.md`.
+> the content belongs in `docs/`, a skill, or a subdirectory `AGENTS.md`.
 
 ## What this repo is
 
@@ -64,7 +64,7 @@ For each kind of decision, there is exactly one place it lives:
 | How is the code organized today?          | `docs/architecture/`                 |
 | What is the product doing today?          | `docs/product/` (roadmap, changelog) |
 | How do users use the product?             | `docs/guides/` (Diátaxis: tutorials, how-to, reference, explanation) |
-| How do agents do `<repeating task>`?      | `.claude/skills/<task>/SKILL.md`     |
+| How do agents do `<repeating task>`?      | A skill file (`SKILL.md` with frontmatter); your IDE handles discovery |
 
 If you can't find the answer in one of these places, **the answer doesn't
 exist yet** — ask, or open an RFC. Don't guess. Lifecycle and mechanics
@@ -110,14 +110,14 @@ it's covered in [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md).
 ## Agent workflows
 
 Use the generated skill list below when a task matches a named workflow.
-<!-- agent-skills:start -->
-<!-- agent-skills:end -->
 
 ## Specialist subagents
 
-`.claude/agents/` contains sharp, differentiable lenses for diff review,
-plus the executor used by `work-loop`'s supervisor mode. Pick the
-reviewers the diff actually warrants; don't run all three by default.
+Specialist subagents — Claude Code only; Codex and Copilot drop the
+`agent` primitive per the adapter contract — provide sharp,
+differentiable lenses for diff review, plus the executor used by
+`work-loop`'s supervisor mode. Pick the reviewers the diff actually
+warrants; don't run all three by default.
 
 - `adversarial-reviewer` — spec /
   plan / implementation drift; missing edge cases; scope creep. Default

--- a/packs/core/seeds/docs/product/changelog.md
+++ b/packs/core/seeds/docs/product/changelog.md
@@ -23,7 +23,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- (nothing yet)
+- **Codex receives full skill bodies** — the `skill` projection for the
+  Codex adapter flips from `managed-block-inline` (one-line teasers
+  in `AGENTS.md` between `<!-- agent-skills:start -->` /
+  `<!-- agent-skills:end -->`) to `direct-directory`. Codex users now
+  read `.agents/skills/<name>/SKILL.md` byte-equal to source — the
+  same surface Claude Code and Kiro have always had. Per
+  [RFC-0009 § Adapter contract change](../rfc/0009-codex-native-skills.md#adapter-contract-change).
+  On the first install after upgrade, the adapter strips the
+  legacy `<!-- agent-skills:start --> … <!-- agent-skills:end -->`
+  region from any pre-existing `AGENTS.md` in place; outside-block
+  content is preserved. The strip is destructive by design: hand-
+  edited content *between* the delimiters is not migrated
+  (RFC-0009 § Failure modes). The strip mechanism
+  (`_strip_legacy_skill_block` + the retained `_splice_managed_block`
+  helper) is kept for one minor release as the migration window
+  (released N) and then removed in the release after (N+1).
+  **Self-host narrowed to Claude Code only.** Before this release,
+  `SELF_HOST_ADAPTERS = ("claude-code", "codex")` so the Codex
+  adapter ran against this repo's working tree alongside Claude
+  Code. With Codex's `skill` projection growing from a tiny
+  AGENTS.md managed block to a full body tree, self-host's working
+  tree would carry a duplicate `.agents/skills/` of every skill —
+  pure maintainer overload. `SELF_HOST_ADAPTERS = ("claude-code",)`
+  now; Codex adopters continue to receive `.agents/skills/` via
+  `agentbundle install`. Codex regressions are gated by the
+  adapter's unit tests and a tempdir projection test that walks
+  every shipped skill.
+
+- **Uniform multi-pack entry point across `direct-directory` adapters**
+  — `codex`, `claude-code`, and `kiro` all expose
+  `project_packs(pack_paths, contract, output_root)` as the
+  canonical orchestrator-facing surface. Single-pack `project()`
+  is retained as a wrapper. Same-name skill collisions across
+  packs resolve deterministic-last-wins by source-order.
+
+- **Orphan-skill cleanup across `direct-directory` adapters** — after
+  every multi-pack `project_packs(...)` call, the projected skill
+  directory is swept: child directories whose names are not in the
+  union of source skill names across the call's pack list are
+  removed. Bound to the `skill` primitive only; symlinks are
+  removed via `Path.unlink()` (never followed).
 
 ### Deprecated
 

--- a/tools/lint-agents-md.py
+++ b/tools/lint-agents-md.py
@@ -21,6 +21,7 @@ import re
 import subprocess
 import sys
 import time
+import tomllib
 from pathlib import Path
 
 MAX_ROOT_LINES = 250
@@ -249,6 +250,36 @@ def main() -> int:
                 f"drift-watch: vendor token (ultrathink / 'Plan Mode (Shift+Tab') in {f_str}. "
                 f"Move it under .claude/."
             )
+
+    # 10f — Legacy Codex managed-skills block must not survive a
+    # post-RFC-0009 install. When the contract declares Codex `skill`
+    # as `direct-directory`, the projected AGENTS.md should not carry
+    # the `<!-- agent-skills:start -->` literal — the one-shot
+    # migration strip should have removed it. Warning-only (does not
+    # `note(...)` / fail) so adopters mid-migration aren't blocked.
+    contract_path = Path("docs/contracts/adapter.toml")
+    legacy_marker = "<!-- agent-skills:start -->"
+    if contract_path.is_file():
+        try:
+            contract = tomllib.loads(contract_path.read_text(encoding="utf-8"))
+        except (tomllib.TOMLDecodeError, OSError):
+            contract = None
+        codex_skill_is_direct_directory = False
+        if contract is not None:
+            for entry in contract.get("adapter", {}).get("codex", {}).get("projection", []):
+                if entry.get("primitive") == "skill" and entry.get("mode") == "direct-directory":
+                    codex_skill_is_direct_directory = True
+                    break
+        if codex_skill_is_direct_directory:
+            for probe in ("AGENTS.md", "packs/core/seeds/AGENTS.md"):
+                f = Path(probe)
+                if f.is_file() and legacy_marker in f.read_text(encoding="utf-8"):
+                    warn(
+                        f"legacy-codex-skill-block: {probe} still contains "
+                        f"{legacy_marker!r}. Codex `skill` is now "
+                        f"`direct-directory`; run `make build-self` to let "
+                        f"the migration strip remove the block."
+                    )
 
     # 10e — Session-scratch artifacts must be gitignored.
     for probe in (


### PR DESCRIPTION
## Summary

- Flips the Codex adapter's `skill` projection from `managed-block-inline` (one-line teasers spliced into `AGENTS.md`) to `direct-directory` (full skill bodies at `.agents/skills/<name>/`). Codex users now get the same workflow content Claude Code and Kiro users already have. Implements [RFC-0009](docs/rfc/0009-codex-native-skills.md) and `docs/specs/codex-native-skills`.
- Introduces a uniform `project_packs(pack_paths, contract, output_root)` entry point across the three `direct-directory` adapters (`codex`, `claude-code`, `kiro`) and a shared `sweep_orphans` helper that removes child directories not in the union of source skill names across the multi-pack call.
- One-shot migration strip removes the legacy `<!-- agent-skills:start --> … <!-- agent-skills:end -->` region from any pre-existing `AGENTS.md` on the first Codex install after upgrade; retained for one minor release.

## Course corrections during EXECUTE

- **Self-host narrowed to Claude Code only** (`SELF_HOST_ADAPTERS = ("claude-code",)`). Pre-RFC-0009, Codex was in self-host because its contribution was a small managed-block splice; once Codex grew to a full body tree, leaving it in self-host would have carried a duplicate `.agents/skills/` mirror in the working tree — maintainer overload. Codex correctness is now gated by adapter unit tests + an AC29 tempdir projection test rather than self-host's working-tree drift gate. Codex adopters still get `.agents/skills/` via `agentbundle install`.
- **Seed AGENTS.md adapter-neutralised.** The seed shipped to every adopter via `agentbundle scaffold` previously mentioned `.claude/skills/` and `.claude/agents/` in three places — references that read as wrong for Codex (skills at `.agents/skills/`) and Kiro (`.kiro/skills/`). Rewrote those three sites to name file formats and IDE-handles-discovery rather than IDE-specific paths.

## Review

Three reviewer passes, all returned `Clean — ready to commit.`:

- **adversarial-reviewer** — 5 rounds against the spec/plan during PLAN, plus a post-EXECUTE pass against the diff. Final blocker (AC29 sentinel guard silently bypassing `new-rfc` / `new-adr`) fixed by walking every pack rather than just `core`.
- **quality-engineer** — surfaced silent destructive operations (added stderr breadcrumbs on strip + sweep), dead-code fallback (removed), lazy-import inconsistency (hoisted).
- **security-reviewer** — surfaced top-level symlink dereference via `copytree` (added `is_symlink(): continue` guards across all three adapters), non-atomic AGENTS.md write (replaced with `tempfile.mkstemp` + `os.replace`), out-of-order delimiter corruption (added refusal with named error).

The Wave-1 parallel supervisor-mode dispatch tripped Claude Code [#29610](https://github.com/anthropics/claude-code/issues/29610) — subagents cannot write to gitignored `.worktrees/` paths. Captured in user memory; fell back to single-agent sequential execution.

## Test plan

- [ ] CI: `make build-check` exits clean (drift detection between `docs/contracts/adapter.toml`, `_data/adapter.toml`, seed `AGENTS.md`, and projected output).
- [ ] CI: 268 tests in `agentbundle/build/tests/` pass; 1096 in `agentbundle/tests/unit/` pass (2 pre-existing `test_credentials_dotfile.py` failures on `main` are unrelated).
- [ ] Manual: install a fresh adopter via `agentbundle install core` against an empty tempdir, verify `.claude/skills/<name>/SKILL.md` lands for Claude Code installs.
- [ ] Manual: project the core pack through `codex.project_packs` against a tempdir, verify `.agents/skills/work-loop/SKILL.md` is byte-equal to `packs/core/.apm/skills/work-loop/SKILL.md`.
- [ ] Manual: against a tempdir containing an `AGENTS.md` with the legacy `<!-- agent-skills:start --> … <!-- agent-skills:end -->` block, run `codex.project_packs`, verify the delimiters and content between them are gone and outside-block prose survives byte-for-byte.
- [ ] Manual: project a pack with skills `{a, b, c}`, then project a different pack with `{a, c}` into the same output root, verify `b/` is swept from the projected skill target.

Refs: [`docs/specs/codex-native-skills`](docs/specs/codex-native-skills/spec.md), [`docs/rfc/0009-codex-native-skills.md`](docs/rfc/0009-codex-native-skills.md)