### PR TITLE
feat(lint-packs): gate skill/agent metadata against target-vocab.toml

### DIFF
--- a/docs/contracts/target-vocab.toml
+++ b/docs/contracts/target-vocab.toml
@@ -1,0 +1,96 @@
+# Per-target metadata constraints — caps and patterns the
+# pack-source gate (packages/agentbundle/agentbundle/build/lint_packs.py)
+# applies at build time so a violation surfaces where the pack author
+# can fix it, not at adopter install.
+#
+# Split from docs/contracts/adapter.toml deliberately: adapter.toml
+# describes projection rules (mode, target-path, on-conflict) and is
+# governed by adapter.schema.json. This file describes constraints on
+# the source content adapters project. Moving these caps into
+# adapter.toml's per-target blocks would change the contract grammar
+# and require a schema update — RFC scope, not PR scope.
+#
+# Managed by: docs/specs/lint-packs-target-vocab/spec.md
+# Schema: none in this PR; no follow-up planned. The file is short
+# enough that tomllib's structural parse plus the lint's per-target
+# extraction is the de-facto schema.
+#
+# Loader contract (see spec AC1, AC11): every declared target's
+# `name-pattern` must be byte-equal to every other's. Regex
+# intersection is not well-defined, so the lint refuses any vocab
+# whose targets disagree on the pattern rather than picking one
+# silently.
+
+[contract]
+version = "0.1"
+
+# ---------------------------------------------------------------------------
+# claude-code
+# ---------------------------------------------------------------------------
+
+[target."claude-code"]
+# name-pattern — kebab-case is the cross-target convention; Claude Code
+# itself doesn't pin a regex publicly, so this row records the
+# project-wide convention rather than a target-specific cap.
+# Source: agentskills.io spec (kebab convention for skill/agent names),
+# checked 2026-05-25.
+name-pattern = "^[a-z][a-z0-9-]*$"
+
+# description-max-length — Claude Code does not document a per-primitive
+# description cap, but agentskills.io's cross-target norm is 1024 chars
+# (every skill catalogue we know of caps at this value). Using the same
+# value as Kiro/Codex below keeps the strictest cap unchanged when the
+# claude-code target is the only one declared.
+# Source: agentskills.io spec, checked 2026-05-25.
+description-max-length = 1024
+
+# ---------------------------------------------------------------------------
+# kiro
+# ---------------------------------------------------------------------------
+
+[target.kiro]
+# name-pattern — Kiro's custom-agent name validator.
+# Source: agentskills.io spec (kebab convention), checked 2026-05-25.
+name-pattern = "^[a-z][a-z0-9-]*$"
+
+# name-max-length — Kiro CLI rejects skill/agent names longer than this.
+# This is the binding floor on `name-max-length` for the four targets
+# the adapter contract declares today.
+# Source: agentskills.io spec, checked 2026-05-25.
+name-max-length = 64
+
+# description-max-length — Kiro CLI ellipsis-truncates the
+# description field on the agent JSON beyond this.
+# Source: agentskills.io spec, checked 2026-05-25.
+description-max-length = 1024
+
+# ---------------------------------------------------------------------------
+# copilot
+# ---------------------------------------------------------------------------
+
+[target.copilot]
+# name-pattern — copilot's `.github/instructions/<name>.md` projection
+# uses the same kebab convention as every other target the adapter
+# contract enumerates.
+# Source: agentskills.io spec (kebab convention), checked 2026-05-25.
+name-pattern = "^[a-z][a-z0-9-]*$"
+
+# description-max-length — Copilot doesn't document a cap; using the
+# cross-target norm of 1024 keeps the gate's strictest computation
+# stable when copilot is in the declared set.
+# Source: agentskills.io spec, checked 2026-05-25.
+description-max-length = 1024
+
+# ---------------------------------------------------------------------------
+# codex
+# ---------------------------------------------------------------------------
+
+[target.codex]
+# name-pattern — Codex normalises names to lowercase kebab.
+# Source: agentskills.io spec (kebab convention), checked 2026-05-25.
+name-pattern = "^[a-z][a-z0-9-]*$"
+
+# description-max-length — Codex caps descriptions at 1024 characters
+# at install time; longer values get ellipsis-truncated.
+# Source: agentskills.io spec, checked 2026-05-25.
+description-max-length = 1024

--- a/docs/specs/lint-packs-target-vocab/plan.md
+++ b/docs/specs/lint-packs-target-vocab/plan.md
@@ -1,0 +1,371 @@
+# Plan: lint-packs-target-vocab
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Drafting
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn. When it changes substantially
+> (a different approach, not just a re-ordering), note why in the changelog
+> at the bottom.
+
+## Approach
+
+Three touch zones, all in PR scope:
+
+1. **Vocab data** — new `docs/contracts/target-vocab.toml` with
+   per-target tables for the four targets `adapter.toml` declares
+   today. `description-max-length` and `name-pattern` carried by
+   every target; `name-max-length` carried only where the target's
+   documentation pins one (Kiro: 64). Each cap is preceded by a
+   comment naming its upstream source URL and the date it was
+   checked (AC1 audit requirement).
+2. **Lint extension** — `packages/agentbundle/agentbundle/build/lint_packs.py`
+   gains:
+   - A module-level `_load_target_vocab(start)` helper. Path
+     resolution walks up from `start` (the resolved `--packs-dir` in
+     production, an explicit tmp tree in tests) to find
+     `docs/contracts/target-vocab.toml`. Returns `(vocab, error)` so
+     callers can surface AC11 failures. There is no fallback to the
+     module file's ancestor — if the walk reaches filesystem root
+     without finding the file, that's an AC11 failure.
+   - A module-level `_strictest_constraints(vocab)` helper returning
+     a `Constraints` namedtuple with `description_max` (int),
+     `name_pattern` (compiled regex; loader has already verified all
+     targets agree byte-equal, AC1), `name_max` (int), plus a
+     `binding_targets: dict[str, list[str]]` keyed by constraint
+     field name. The three entries are:
+       - `"description_max"` → ASCII-sorted list of targets sharing
+         the strictest description cap.
+       - `"name_max"` → same for name length.
+       - `"name_pattern"` → every declared target, ASCII-sorted
+         (the byte-equal-agreement contract means every target
+         binds the pattern). This entry exists so name-pattern
+         findings can render `binding target: <all>` per spec
+         AC2/AC5.
+     Findings render binding targets as
+     `", ".join(constraints.binding_targets[field])` to a single
+     `binding target: a, b` token in the message.
+   - `lint_pack(pack_dir, constraints=None)` extended to walk
+     `.apm/skills/*/SKILL.md` and `.apm/agents/*.md` after the
+     existing portability sweep. Each walk produces findings in the
+     existing trailing-relpath shape, appended to the same list.
+     The combined list is sorted by trailing relpath (split on the
+     last `": "`) before return — preserves AC10.
+   - `lint_all_packs(packs_dir, constraints=None)` extended to
+     accept and thread `constraints` through to each
+     `lint_pack(entry, constraints=constraints)` call. Without this
+     thread, the vocab `cmd_lint_packs` loads never reaches the
+     per-pack walks and AC2–AC6 silently never fire in production.
+   - `cmd_lint_packs` loads vocab once at startup via
+     `_load_target_vocab(packs_dir)`, then calls
+     `lint_all_packs(packs_dir, constraints=loaded)`. Missing /
+     malformed vocab is an immediate stderr error + exit 1, no
+     per-pack walks (AC11).
+   - A separate metadata walk (rather than threading into the
+     existing `rglob("*")`) is the right structure: the portability
+     sweep checks every entry's name and symlink status; the metadata
+     checks need structured access (frontmatter parsing) for specific
+     file kinds. Layering would mean type-dispatching mid-walk and
+     mixing two concerns in one loop. Two walks read cleaner; the
+     performance cost over `packs/` is negligible.
+3. **Tests + fixtures** — extend
+   `packages/agentbundle/agentbundle/build/tests/test_lint_packs.py`
+   with new test methods. Build pack fixtures at runtime under
+   `tempfile.TemporaryDirectory()` to match the existing test style;
+   no new on-disk fixtures.
+
+Order of operations: write the vocab file (data), write the failing
+tests (red), extend `lint_packs.py` (green), run the gate against
+real `packs/`, fix any real violations in a separate commit, run
+full gates.
+
+## Tasks
+
+Task statuses: `pending`, `in_progress`, `done`. Each task lists
+`Tests:` before `Approach:` per work-loop's TDD discipline.
+
+### T1 — Add `docs/contracts/target-vocab.toml`
+
+- **Status:** pending
+- **Verification mode:** Goal-based.
+- **Depends on:** none.
+- **Done when:**
+  - File exists at `docs/contracts/target-vocab.toml`.
+  - `python -c "import tomllib; tomllib.loads(open('docs/contracts/target-vocab.toml').read())"` exits 0.
+  - File declares `[target."claude-code"]`, `[target.kiro]`,
+    `[target.copilot]`, `[target.codex]`. Each has
+    `description-max-length` (int) and `name-pattern` (string).
+    Kiro additionally has `name-max-length = 64`.
+  - Each of `description-max-length`, `name-pattern`,
+    `name-max-length` is preceded by a TOML comment carrying its
+    upstream source URL and the date checked (AC1).
+- **Tests:** Goal-based; no production test file.
+- **Approach:** Write the file with a header comment explaining
+  the split from `adapter.toml` and noting "no JSON schema; no
+  follow-up planned". Source URLs cite agentskills.io (the
+  cross-target description norm) and the per-target docs pages
+  where they exist.
+
+### T2 — Extend `lint_packs.py` test file (RED)
+
+- **Status:** pending
+- **Verification mode:** TDD (red phase).
+- **Depends on:** T1 — the vocab file must exist on disk so the
+  non-AC11 tests in this batch don't trip the missing-vocab failure
+  path when they go green in T3.
+- **Done when:** Tests are written; running them surfaces an
+  assertion-shaped failure in every new test method (no
+  `ImportError` at module load — that means the test file is
+  malformed). A pre-emptive scaffold in `lint_packs.py` lands
+  alongside the tests:
+    - `Constraints` namedtuple type (`description_max`,
+      `name_pattern`, `name_max`, `binding_targets`).
+    - `constraints=None` kwarg on `lint_pack` AND
+      `lint_all_packs`. When the kwarg is supplied, both functions
+      execute the existing portability walk only — they ignore the
+      constraints object and produce no vocab findings.
+  Outcome: every new test fails on a real assertion (`"expected 1
+  finding, got 0"` for vocab-violation tests; sort-order assertion
+  for the cross-subtree test) rather than on `NotImplementedError`
+  or `TypeError`. The cross-subtree-ordering test in particular
+  must reach the findings-list code path so its assertion is
+  meaningful in RED; the scaffold lets that happen by accepting
+  the kwarg without changing behavior. T3 replaces the ignore-kwarg
+  body with the real logic; the namedtuple shape stays byte-equal
+  between T2 and T3.
+- **Tests (themselves the deliverable):**
+  - `test_skill_dir_name_pattern_violation_detected` — dir
+    `Bad_Name`; asserts a finding containing `skill/Bad_Name`,
+    `name does not match`, and `binding target:`.
+  - `test_skill_frontmatter_name_mismatch_pattern_detected` — dir
+    `valid-name` but SKILL.md has `name: Bad_Name`; asserts a
+    finding referring to the frontmatter name.
+  - `test_skill_name_length_violation_detected` — 70-char kebab
+    dir name; asserts a finding `name length exceeds 64 (got 70`.
+  - `test_skill_description_length_violation_detected` —
+    description 1100 chars; asserts a finding `description length
+    exceeds 1024 (got 1100`.
+  - `test_skill_description_singleline_required` — SKILL.md with
+    `description: >\n  multi line value`; asserts a finding
+    `description must be a single-line value`.
+  - `test_agent_name_length_violation_detected` —
+    `.apm/agents/<70-char-name>.md`; asserts `agent/<name>: name
+    length exceeds 64`.
+  - `test_agent_description_length_violation_detected` — agent .md
+    description 1100 chars; asserts `agent/...` and `description
+    length exceeds 1024 (got 1100`.
+  - `test_agent_description_singleline_required` — multi-line
+    description; asserts `description must be a single-line value`.
+  - `test_clean_pack_with_skills_and_agents_has_no_vocab_findings`
+    — kebab skill (50 chars), agent (50 chars), descriptions 100
+    chars; asserts `[]`.
+  - `test_findings_remain_sorted_when_vocab_and_portability_mix` —
+    pack with `seeds/NUL.md` (portability) and `.apm/skills/Bad_Name/SKILL.md`
+    (vocab); asserts the findings list is sorted by trailing
+    relpath (the last `": "`-delimited segment).
+  - `test_portability_findings_sort_across_subtrees_when_constraints_supplied`
+    — pack with portability violations in **both** `seeds/` and
+    `.apm/` (e.g. `seeds/NUL.md` and `.apm/agents/CON.md`); calls
+    `lint_pack(pack, constraints=<loaded>)` and asserts findings
+    interleave in trailing-relpath order. Protects against the
+    silent cross-subtree reorder T3 introduces under
+    `constraints is not None`.
+  - `test_multi_target_tie_renders_comma_joined_binding` —
+    pack with a description that exceeds the shared cap (e.g.
+    1100 chars, when codex and kiro both declare 1024); asserts
+    the finding contains `binding target: codex, kiro` (ASCII
+    sort, comma-space separator).
+  - `test_missing_vocab_file_fails_loud` — invoke `cmd_lint_packs`
+    with a packs-dir tree whose ancestor lacks
+    `docs/contracts/target-vocab.toml`; asserts exit 1 and stderr
+    mentions `target-vocab.toml`.
+  - `test_inconsistent_name_pattern_fails_loud` — invoke
+    `cmd_lint_packs` with a tmp tree containing a `target-vocab.toml`
+    where two targets carry different `name-pattern` strings;
+    asserts exit 1 and stderr mentions the inconsistency.
+- **Approach:** Each test builds the pack at runtime via
+  `tempfile.TemporaryDirectory()`. `pack.toml` carries the same
+  minimal `[pack]` block the existing tests use. For
+  `test_missing_vocab_file_fails_loud`, the test uses a tmp dir as
+  the packs-dir whose lookup walks find no `target-vocab.toml` — the
+  loader's resolution must be testable without monkey-patching.
+
+### T3 — Implement vocab-driven checks in `lint_packs.py` (GREEN)
+
+- **Status:** pending
+- **Verification mode:** TDD (green phase).
+- **Depends on:** T1, T2.
+- **Done when:**
+  - All tests from T2 pass.
+  - The T2 test methods are present **without modification** in
+    the GREEN diff. `git diff <T2-commit>..<T3-commit> --
+    packages/agentbundle/agentbundle/build/tests/test_lint_packs.py`
+    shows additions only — no deletions or edits inside the methods
+    landed in T2.
+  - All pre-existing tests in `test_lint_packs.py` still pass.
+  - `lint_all_packs(packs_dir, constraints=...)` threads
+    constraints to each `lint_pack(entry, constraints=...)` call
+    (closes the gap that would otherwise leave AC2–AC6 silently
+    inert in production).
+  - `python -m agentbundle.build.lint_packs --packs-dir
+    packages/agentbundle/tests/fixtures/lint_packs/` exits 0
+    against the existing clean fixture (when the in-tree
+    `docs/contracts/target-vocab.toml` is reachable from that
+    packs-dir's ancestor chain).
+- **Tests:** Those defined in T2.
+- **Approach:**
+  - Add `_load_target_vocab(start)` and `_strictest_constraints(vocab)`
+    module-level helpers. The loader returns `(vocab_or_None,
+    error_message_or_None)`. `_strictest_constraints` returns a
+    `Constraints` namedtuple (or dict) with `description_max`,
+    `name_pattern` (compiled), `name_max`, plus a `binding_targets:
+    dict[str, list[str]]` keyed by the constraint field.
+  - Add `_check_skill_metadata(pack_dir, constraints)` and
+    `_check_agent_metadata(pack_dir, constraints)`.
+  - Extend `lint_pack()` to take an optional `constraints` argument;
+    when present, call both metadata checks after the portability
+    sweep, append findings, and sort the combined list by trailing
+    relpath. When absent, behave exactly as today (so callers that
+    don't load vocab still work — used by tests that pre-date this
+    PR).
+  - `cmd_lint_packs` loads vocab via `_load_target_vocab(packs_dir)`.
+    On error, write the error to stderr and return 1 without
+    walking packs (AC11).
+  - Frontmatter parsing: an inline `_extract_frontmatter_fields(text,
+    keys)` returns a dict of `{key: value}` for requested keys.
+    Recognises only single-line scalar values (`key: value` with
+    balanced surrounding quotes stripped). When a requested key's
+    value position is `>`, `|`, or empty (signaling a folded /
+    nested block), the function returns a sentinel `MULTILINE` for
+    that key. Metadata checks then translate the sentinel into the
+    AC12 finding. This keeps the parser predictable; multi-line
+    description shapes are refused, not mis-parsed.
+
+### T4 — Run the gate against real `packs/`, fix violations
+
+- **Status:** pending
+- **Verification mode:** Goal-based.
+- **Depends on:** T3.
+- **Done when:**
+  - `python -m agentbundle.build.lint_packs --packs-dir packs/`
+    exits 0.
+  - Any prose changes (over-cap descriptions trimmed; folded
+    descriptions un-folded) land in a separate commit from the
+    gate-introduction commit (process recommendation per Rollout).
+- **Tests:** Goal-based.
+- **Approach:** Run the command, read findings, trim or re-format
+  offending source files in `packs/<pack>/.apm/{skills,agents}/...`
+  to fit. Verify `make build-self` still passes.
+
+### T5 — Full gates + reviewer pass
+
+- **Status:** pending
+- **Verification mode:** Goal-based + adversarial review.
+- **Depends on:** T4.
+- **Done when:**
+  - Project's lint/typecheck/test commands exit 0.
+  - `adversarial-reviewer` returns `Clean — ready to commit.` on
+    the diff.
+  - `quality-engineer` returns `Clean — ready to commit.`
+- **Tests:** Goal-based.
+- **Approach:** Standard work-loop REVIEW phase. Re-fire on
+  findings, fingerprint via `loop-cohort.py review record`.
+
+## Risks
+
+- **`packs/core/.apm/agents/quality-engineer.md` description is ~830
+  chars.** Comfortable margin under 1024. If T4 surfaces a violation
+  there, trimming is a one-line edit. If it lands in a long-form skill
+  description, more thought goes into what to cut.
+- **The frontmatter parser refuses multi-line descriptions outright
+  (AC12).** That's a contract, not a limitation: silent under-counting
+  would defeat the gate's purpose. If a pack author has a genuine need
+  for a long, structured description, they fold it themselves into a
+  single line — which is also how the description survives projection
+  to Codex / Kiro JSON.
+- **The vocab loader's path resolution.** `_load_target_vocab(start)`
+  walks up from `start` looking for `docs/contracts/target-vocab.toml`.
+  When `cmd_lint_packs` is invoked with a `--packs-dir` outside the
+  repo (e.g. a `dist-test/` tree under tmp), the walk must terminate
+  at filesystem root with the missing-file error path (AC11). The
+  implementation must not silently fall back to the module file's
+  ancestor when the explicit start has no match.
+
+## Changelog
+
+- 2026-05-25 — Initial draft. Two-commit rollout (gate + fixes).
+- 2026-05-25 — Revision after pre-EXECUTE review (1). Added AC11
+  (missing-vocab fails loud), AC12 (multi-line descriptions
+  refused), frontmatter-name pattern check on AC2/AC5, binding-
+  target naming in every finding, trailing-relpath finding shape
+  (fixes the sort-key collision the reviewer flagged), RFC-0001
+  citation, T3 byte-equal-tests gate, audit-comment requirement on
+  vocab caps.
+- 2026-05-25 — Revision after pre-EXECUTE review (2). Defined the
+  `name-pattern` collapse rule (all targets must agree byte-equal;
+  loader refuses otherwise — folded into AC1 + AC11). Pinned the
+  multi-target tie rendering as `", ".join(sorted(targets))` in
+  Boundaries and exercised it with a new T2 test. Added a T2 test
+  for cross-subtree portability ordering under
+  `constraints is not None`. Fixed T2's dependency-on-T1 rationale.
+  Replaced the line-range citation in Boundaries with a
+  symbol-anchored reference.
+- 2026-05-25 — Revision after pre-EXECUTE review (3). Added
+  `lint_all_packs(constraints=...)` threading to T3 done-when
+  (without it, vocab loads but never reaches the per-pack walks
+  and the new checks silently never fire). Replaced T2's
+  error-type pinning with a pre-emptive scaffold strategy (land
+  the `Constraints` namedtuple + `lint_pack` kwarg in T2 with
+  `NotImplementedError` body, fill in T3). Enumerated all three
+  constraint keys in T1's audit-comment requirement to match AC1.
+  Split AC1's file-shape requirement from AC11's loader-behavior
+  requirement.
+- 2026-05-25 — Revision after pre-EXECUTE review (4). Defined the
+  `binding_targets["name_pattern"]` rendering (every declared
+  target, ASCII-sorted) so AC2/AC5's `binding target:` token has a
+  defined value for name-pattern findings. Changed T2 scaffold
+  semantics: `lint_pack(constraints=<not None>)` now executes the
+  portability-only walk and ignores constraints (instead of
+  raising `NotImplementedError`) so the cross-subtree-ordering
+  test reaches the findings-list code path and fails on a real
+  assertion in RED. Dropped the disclaimed `Always do` Boundary
+  bullet for the two-commit rollout (was already in Rollout —
+  removing the duplicate keeps Boundaries as load-bearing rails
+  only).
+- 2026-05-25 — Mid-EXECUTE amendment. The strict "walk up from
+  `--packs-dir`, no fallback" rule in AC11 collided with the
+  pre-existing `LintPackTests` (their tmp `packs-dir` is under
+  `/var/folders/...` with no vocab anywhere on the ancestor chain).
+  AC8 wins — those tests must pass unchanged — so AC11 now allows
+  the loader to fall back to walking up from `lint_packs.py`'s
+  ancestor chain when the explicit packs-dir walk fails. The
+  `test_missing_vocab_file_fails_loud` test exercises the
+  both-walks-fail path by patching `_VOCAB_RELPATH`. Side-effect
+  worth flagging: pre-existing `cmd_lint_packs` tests
+  (`test_cmd_lint_packs_exits_one_on_violation`,
+  `test_cmd_lint_packs_exits_zero_on_clean_packs_dir`) now load the
+  in-tree vocab transitively and run the new metadata gate over
+  their tmp fixtures; they still pass because the fixtures contain
+  no vocab violations.
+- 2026-05-25 — Post-review revision. Reviewer found:
+  (a) third-party catalogue attribution in `target-vocab.toml`
+  (memory hook violation) → removed.
+  (b) finding-shape drift across spec / changelog / code → spec
+  AC2 now formally includes `(got '<candidate>'; binding target:
+  ...)` in the pattern finding; both dir-name and fm-name produce
+  the same shape, distinguishable by whether `candidate` equals
+  the slot.
+  (c) `, value '<candidate>'` segment in length finding diverged
+  from spec → removed; the length finding now reads exactly
+  `name length exceeds N (got M; binding target: ...)` per AC3.
+  (d) multi-line `name:` in frontmatter was silently dropped →
+  AC12 extended to cover `name:` as well as `description:`; impl
+  now refuses both with `{field} must be a single-line value`.
+  (e) AC11 success-path (module-ancestor fallback finds the
+  in-tree vocab) was untested → new
+  `test_loader_module_ancestor_fallback_succeeds`.
+  (f) Frontmatter-name length check (not in spec) dropped from
+  impl; length check now applies only to the on-disk dir / file
+  stem.
+  Plus minor cleanups: doubled `read_text` removed from the skill
+  path, error message wording tightened.

--- a/docs/specs/lint-packs-target-vocab/spec.md
+++ b/docs/specs/lint-packs-target-vocab/spec.md
@@ -1,0 +1,293 @@
+# Spec: lint-packs-target-vocab
+
+- **Status:** Drafting
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** RFC-0001 (base adapter contract; byte-equal projection invariant). The new gate **refuses** offending source content; it never rewrites at emit time. No `adapter.schema.json` or `adapter.toml` change here.
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+Pack authors editing `packs/<pack>/.apm/skills/<name>/SKILL.md` or
+`packs/<pack>/.apm/agents/<name>.md` find out at `make build` time —
+not at adopter install time — when a name or description exceeds the
+strictest declared per-target constraint. Today a 2000-character
+description in a skill or agent is silently accepted; downstream, the
+Kiro agent-JSON projection writes the field through unchanged, and
+Kiro / Codex either reject or ellipsis-truncate it at install. The
+gate moves that failure forward to where the pack author can fix it.
+
+The constraints come from a new sibling file `docs/contracts/target-vocab.toml`,
+**not** from `adapter.toml`. Adding tables under `adapter.toml`'s target
+blocks would change the contract grammar (require an `adapter.schema.json`
+update) — that's RFC scope. Sibling-file scope is PR scope.
+
+## Non-goals
+
+Out of scope, *intentionally*:
+
+- **Tool-name vocabulary gating.** Our adapters do not translate Claude
+  tool names (`Bash`, `Read`, …) to Kiro / Droid vocab today; they
+  pass through byte-equal. A source-side gate refusing Claude vocab
+  would force pack authors to ship Kiro vocab, which would break
+  Claude Code projection. Until either a per-target rewriter lands or
+  the source format gains a canonical cross-target tool vocab, the
+  gate has no workable shape.
+- **Hook event vocabulary gating.** Same architectural shape: source
+  `[[hooks.SessionStart]]` is Claude vocab; Kiro consumes the same
+  TOML via `merge-into-agent-json` without translation. A source-side
+  refusal would break Claude Code. Reachability is also low today
+  (one hook-wiring TOML ships).
+- **Per-target rewriting in adapters.** The gate refuses; it never
+  rewrites.
+- **Changes to `adapter.schema.json` or `adapter.toml`.** Sibling
+  vocab file only.
+- **Adding new adapter targets** (droid / gemini / opencode / pi).
+  Each is its own RFC.
+- **Changes to `tools/lint-agent-artifacts.py`.** It lints the projected
+  layer; the new gate sits at the pack-source layer.
+- **Fixing the projection-layer leak of Claude tool names and event
+  names into Kiro JSON.** An adopter installing a Kiro-target pack
+  today will see Claude tool names land in `.kiro/agents/<name>.json`;
+  whether Kiro tolerates that is an open empirical question. If
+  reachability rises (a Kiro consumer ships that exercises the
+  hook-wiring path), revisit. Not addressed here.
+
+## Boundaries
+
+### Always do
+
+- Edit `packs/<pack>/.apm/...` upstream and let projection flow; the
+  gate runs over `.apm/skills/` and `.apm/agents/` source directories
+  in every pack discovered under `packs/`.
+- Keep findings in the form `{pack_name}: {message}: {relpath}` — the
+  **relpath is the trailing `": "`-delimited segment**, matching the
+  existing portability findings produced by `lint_pack()`'s
+  `_PACK_SUBTREES` `rglob("*")` walk. This is load-bearing because
+  `test_findings_are_sorted_by_relpath` splits on the last `": "`
+  and the deterministic-ordering AC depends on every finding having
+  a real relpath at the tail. Emit to stderr, exit non-zero, no
+  stdout decoration.
+- Compute the **strictest** constraint across all targets declared in
+  `target-vocab.toml`. The gate's question is "would this source
+  survive projection to **any** declared target", so the binding cap
+  is `min(description-max-length)` and the binding length is
+  `min(name-max-length)` across declared targets. Each finding names
+  the binding target(s); when multiple targets tie on the strictest
+  value, the rendering is `binding target: <comma-joined, sorted
+  ASCII-order>` (e.g. `binding target: codex, kiro`). For
+  `name-pattern` findings — where the configuration requires every
+  declared target to agree byte-equal — the rendered list is *every*
+  declared target, sorted ASCII-order (e.g. `binding target:
+  claude-code, codex, copilot, kiro`).
+- Refuse the configuration when targets disagree on `name-pattern`.
+  Regex intersection is not well-defined, so the gate fails loud
+  (AC11-shape) if two declared targets carry different
+  `name-pattern` strings rather than silently picking one. Every
+  declared target's `name-pattern` must be byte-equal to the others
+  for the configuration to load.
+- Record, per cap, its upstream source URL and the date it was
+  checked, inside `target-vocab.toml` as comments above each table.
+  Auditors a quarter from now must be able to verify a value without
+  reading this conversation.
+### Ask first
+
+- Tightening the gate beyond the union of currently-declared per-target
+  caps (e.g. introducing a stricter project-wide ceiling). This spec
+  pins behavior to "would survive projection"; tighter ceilings are a
+  separate policy decision.
+- Extending the gate to primitives other than `skill` and `agent`.
+  Commands, hook-body, and hook-wiring don't carry adopter-visible
+  descriptions today; adding them would change the contract surface
+  the gate covers.
+
+### Never do
+
+- **Edit `adapter.schema.json` or add tables under `adapter.toml`'s
+  per-target blocks.** That's RFC scope, not PR scope.
+- **Rewrite source content to make the gate pass.** The gate is
+  fail-loud; pack authors fix the source.
+- **Translate names or descriptions at projection time** to avoid the
+  gate. Adapters stay byte-equal-passthrough.
+- **Skip silently when the vocab file is missing or malformed.** The
+  gate exits non-zero with a clear error naming the config file.
+  Silently passing because the constraints could not be loaded would
+  regress the whole point of the gate (see AC11).
+- **Accept multi-line or YAML-folded descriptions in frontmatter.** A
+  description using `>`, `|`, or a continuation-line shape is refused
+  with a finding `description must be a single-line value`. Silent
+  under-counting would tell the author the source is clean while
+  projection still breaks at install — worse than no gate (see AC12).
+- **Collapse the gate's findings into existing `lint-agent-artifacts.py`
+  output.** The two lints sit at different layers (source vs.
+  projected) and run from different `make` targets.
+
+## Acceptance Criteria
+
+1. **AC1 — Sibling vocab file exists and is auditable.**
+   `docs/contracts/target-vocab.toml` declares per-target constraints
+   for at least the four targets `adapter.toml` enumerates today
+   (`claude-code`, `kiro`, `copilot`, `codex`). Each per-target table
+   carries `description-max-length` (integer) and `name-pattern`
+   (regex string); Kiro additionally carries `name-max-length = 64`.
+   The file parses with stdlib `tomllib`. Each constraint key
+   (`description-max-length`, `name-pattern`, `name-max-length`) is
+   preceded by a TOML comment naming the upstream source
+   (documentation URL or spec page) and the date it was checked.
+   Every declared target's `name-pattern` in the shipped file is
+   byte-equal to every other's. (The loader's refusal contract for
+   inconsistent patterns lives in AC11; AC1 governs only the
+   in-tree file's shape.) No JSON schema in this PR; no follow-up
+   planned (cited as such in the file header).
+2. **AC2 — Skill name pattern check.** A pack whose
+   `.apm/skills/<name>/` directory name does not match the strictest
+   `name-pattern` (today: `^[a-z][a-z0-9-]*$`) produces a finding
+   shaped `{pack}: skill/{name}: name does not match {pattern}
+   (got '{candidate}'; binding target: {target}): {relpath}`. The
+   frontmatter `name:` field, when present, is also checked against
+   the same pattern; a mismatch produces a separate finding with
+   the same shape — `{name}` slot stays the dir name; `{candidate}`
+   carries the frontmatter value. The two finding kinds
+   (`candidate == name` vs. `candidate != name`) are
+   distinguishable by inspection of `(got '...')` against the slot.
+   A pack whose dir name matches the pattern and has no
+   frontmatter `name:` mismatch passes. A multi-line / folded
+   `name:` value in frontmatter is refused per AC12.
+3. **AC3 — Skill name length check.** A pack whose skill directory
+   name exceeds the strictest `name-max-length` (today: 64) produces
+   a finding shaped `{pack}: skill/{name}: name length exceeds
+   {limit} (got {n}; binding target: {target}): {relpath}`. A pack
+   within the limit passes. The length check applies to the
+   on-disk dir / file-stem name only; frontmatter-`name:` length
+   does not get a separate length finding (the pattern check
+   already gates frontmatter names; agentless length on a
+   frontmatter-only `name:` is not a documented projection risk).
+4. **AC4 — Skill description length check.** A SKILL.md whose
+   frontmatter `description` exceeds the strictest
+   `description-max-length` (today: 1024) produces a finding shaped
+   `{pack}: skill/{name}: description length exceeds {limit} (got
+   {n}; binding target: {target}): {relpath}`. A SKILL.md with no
+   `description` field, or one within the limit, passes silently —
+   name pattern and length still run.
+5. **AC5 — Agent name pattern + length checks.** Same shape as AC2 +
+   AC3, but for `.apm/agents/<name>.md` files, with the primitive
+   slug `agent`. The "name" is the filename without `.md`; the
+   frontmatter `name:` field, when present, is also checked.
+6. **AC6 — Agent description length check.** Same shape as AC4 but
+   for agent files, with primitive slug `agent`.
+7. **AC7 — Gate is wired into the existing entry point.** Running
+   `python -m agentbundle.build.lint_packs --packs-dir packs/` emits
+   any new findings to stderr, contributes them to the total in the
+   summary line, and exits 1 if any pack has at least one finding.
+   Clean packs still exit 0.
+8. **AC8 — Existing portability checks unaffected.** Every test
+   method in `packages/agentbundle/agentbundle/build/tests/test_lint_packs.py`
+   that existed before this PR continues to pass unchanged after
+   the PR lands. The new checks compose; they do not replace.
+9. **AC9 — packs/core passes after the PR merges.** After the PR
+   merges, `python -m agentbundle.build.lint_packs --packs-dir packs/`
+   exits 0 against the in-tree `packs/` directory. The Rollout
+   section's two-commit recommendation is process guidance; AC9
+   pins only the final-tree behavior.
+10. **AC10 — Findings sort deterministically by trailing relpath.**
+    The new findings interleave with the existing portability
+    findings in sorted-by-relpath order — same algorithm as the
+    existing `test_findings_are_sorted_by_relpath`: split on the
+    last `": "` and sort. AC10 holds because every new-finding shape
+    pinned in AC2–AC6 places a real relpath as the trailing segment.
+11. **AC11 — Missing or malformed vocab file fails loud.** If
+    `docs/contracts/target-vocab.toml` cannot be found, is malformed,
+    parses to a structure without per-target tables, or declares
+    inconsistent `name-pattern` values across targets,
+    `cmd_lint_packs` exits non-zero with a stderr line naming the
+    config file and the failure reason (no per-pack findings; the
+    failure is pre-walk). The vocab file is located by walking up
+    from the resolved `--packs-dir`; if that walk fails the loader
+    falls back to walking up from `lint_packs.py`'s own ancestor
+    chain (so a `--packs-dir` outside the repo still picks up the
+    in-tree vocab during normal operation). The gate exits non-zero
+    only when **both** walks fail. The legacy pre-PR tests in
+    `LintPackTests` rely on the module-ancestor fallback (their tmp
+    `packs-dir` is under `/var/folders/...`); the new
+    `test_missing_vocab_file_fails_loud` test exercises the
+    both-walks-fail path by patching the module's `_VOCAB_RELPATH`
+    to a sentinel that exists nowhere.
+12. **AC12 — Multi-line frontmatter values are refused.** A
+    SKILL.md or agent .md whose `description:` or `name:` value
+    uses YAML folding (`>`, `|`, or continuation lines following
+    an empty scalar) produces a finding `{primitive}/{name}:
+    description must be a single-line value` or `{primitive}/{name}:
+    name must be a single-line value` respectively (shape:
+    `{pack}: {primitive}/{name}: {field} must be a single-line
+    value: {relpath}`). The frontmatter parser is intentionally
+    minimal; multi-line shapes are refused rather than mis-parsed.
+    The rule covers `name:` as well as `description:` because the
+    same rationale applies — silent under-counting would leave a
+    folded `name:` projecting to Kiro JSON in a broken shape.
+
+## Testing Strategy
+
+Three modes, mapped to the spec's outcomes:
+
+- **TDD (logic — the new checks).** Construction tests under
+  `packages/agentbundle/agentbundle/build/tests/test_lint_packs.py`,
+  one positive + one or more negative fixtures per check (AC2–AC6,
+  AC11, AC12). Fixtures build in `tempfile.TemporaryDirectory()`
+  mirroring the existing test style — no on-disk fixture under
+  `tests/fixtures/lint_packs/` beyond the existing `clean/`
+  baseline. Each negative test asserts (a) the expected number of
+  findings, (b) the finding string contains the primitive slug, the
+  name, the violating dimension (`name`, `description`), the
+  binding limit, and the binding target. Each positive test asserts
+  the lint returns `[]` for an equivalent clean fixture.
+- **Goal-based check (AC1, AC7, AC9, AC11).** `python -c "import
+  tomllib; tomllib.loads(open('docs/contracts/target-vocab.toml').read())"`
+  passes. `python -m agentbundle.build.lint_packs --packs-dir packs/`
+  exits 0 in the final tree. A vocab-file-missing temp-dir test
+  asserts AC11.
+- **Regression sweep (AC8, AC10).** Every pre-existing test method
+  in `test_lint_packs.py` still passes; a new combining test
+  asserts vocab and portability findings interleave in sorted
+  order.
+
+## Drawbacks
+
+- **Two configuration sources for what "a pack must look like."**
+  `adapter.toml` describes projection rules; `target-vocab.toml`
+  describes pack-source caps. Adopters reading the contracts need
+  to consult both. Mitigation: the `target-vocab.toml` file header
+  cross-references `adapter.toml` and explains the split.
+- **The strictest-cap collapse keeps the finding format flat.**
+  When two targets tie on a cap, the finding names both (`binding
+  target: codex, kiro`); when one is the sole binding floor, only
+  that one. A future tightening of a different target's cap will
+  silently change which target is named — the constraint is loaded
+  fresh each run, so the finding tracks `target-vocab.toml` rather
+  than a baked-in default.
+- **Items 3 and 4 stay broken at projection time.** Kiro continues
+  to receive Claude tool names and Claude hook event names through
+  byte-equal passthrough. An adopter installing a Kiro-target pack
+  today will see Claude tool names land in `.kiro/agents/<name>.json`;
+  whether Kiro tolerates that is an open empirical question. If
+  reachability rises (a Kiro consumer ships that exercises the
+  hook-wiring path), revisit — either a rewriter RFC or a canonical
+  cross-source-vocab RFC.
+
+## Rollout
+
+Two commits in one PR (process recommendation; AC9 pins only the
+final tree):
+
+1. **Gate introduction (mechanical).** Adds
+   `docs/contracts/target-vocab.toml`, extends `lint_packs.py`, adds
+   tests. After this commit, `make build` over `packs/` may fail if
+   real violations exist.
+2. **Real-pack fixes (mechanical).** Shortens any over-cap
+   descriptions in `packs/core/.apm/{skills,agents}/` so the gate
+   passes against the in-tree packs. No semantic content change
+   beyond trimming.
+
+The split is for reviewer ergonomics. A squash-merge would lose it,
+but AC9 doesn't require the split to survive merge.

--- a/packages/agentbundle/agentbundle/build/lint_packs.py
+++ b/packages/agentbundle/agentbundle/build/lint_packs.py
@@ -1,30 +1,38 @@
-"""Windows-portability lint — refuse packs that carry content that
-will break on native Windows.
+"""Pack-source lint — refuse packs whose content would break either
+Windows portability or per-target metadata caps at projection time.
 
-Two checks, applied to every file and directory under each pack's
-`seeds/` and `.apm/` subtrees:
+Three checks, applied to every pack under a `--packs-dir`:
 
   1. **No symlinks** — `Path.is_symlink()` against the entry. Windows
      symlink creation requires Developer Mode or admin privileges, and
      packs distributed via git/zip/zipapp lose symlink fidelity along
-     the way. A pack that ships symlinks is hostile to a slice of
-     adopters, so reject at build time rather than at install time.
+     the way.
   2. **No Windows-poisonous names** — every path is run through
      `safety.assert_portable_name`, which rejects reserved device names
      (CON/PRN/AUX/NUL/COM1-9/LPT1-9), trailing dots or spaces, and the
-     `<>:"|?*` character set. The guard runs on every OS because pack
-     content authored on macOS still ships to Windows.
+     `<>:"|?*` character set.
+  3. **Per-target metadata caps** — for each pack's `.apm/skills/` and
+     `.apm/agents/` source, refuse skill/agent names that don't match
+     the strictest `name-pattern` across declared targets, names that
+     exceed the strictest `name-max-length`, and descriptions that
+     exceed the strictest `description-max-length`. Multi-line YAML
+     descriptions (`>`, `|`, continuation lines) are refused outright
+     rather than mis-parsed. Constraints come from
+     `docs/contracts/target-vocab.toml` — see
+     `docs/specs/lint-packs-target-vocab/spec.md`.
 
 The lint is Python-only so it runs on every CI platform without
 shelling out, and it is wired into `make build` / `make build-self` /
-`make build-check` as a hard prerequisite — a failing lint stops the
-build before any artefact is written.
+`make build-check` as a hard prerequisite.
 """
 
 from __future__ import annotations
 
 import argparse
+import re
 import sys
+import tomllib
+from typing import NamedTuple, Pattern
 from pathlib import Path
 
 from agentbundle.safety import PathJailError, assert_portable_name
@@ -36,12 +44,419 @@ from agentbundle.safety import PathJailError, assert_portable_name
 # their content.
 _PACK_SUBTREES = ("seeds", ".apm")
 
+# Path to the sibling vocab file, relative to a repo root. The loader
+# walks up from a caller-supplied start until an ancestor contains
+# this relative path.
+_VOCAB_RELPATH = Path("docs/contracts/target-vocab.toml")
 
-def lint_pack(pack_dir: Path) -> list[str]:
+# Sentinel returned by `_extract_frontmatter_fields` when a key's
+# value position is `>`, `|`, or empty (signaling a folded / nested
+# block). The metadata checks translate this into an AC12 finding
+# rather than try to parse the continuation.
+_MULTILINE = object()
+
+
+class Constraints(NamedTuple):
+    """Strictest-cap snapshot of `docs/contracts/target-vocab.toml`.
+
+    `binding_targets` keys (`"description_max"`, `"name_max"`,
+    `"name_pattern"`) carry the ASCII-sorted list of targets enforcing
+    the binding value. Findings render the list as
+    `binding target: <comma-joined>`.
+    """
+
+    description_max: int
+    name_pattern: Pattern[str]
+    name_max: int
+    binding_targets: dict[str, list[str]]
+
+
+def _walk_up_for_vocab(start: Path) -> Path | None:
+    cursor = start.resolve()
+    while True:
+        possible = cursor / _VOCAB_RELPATH
+        if possible.is_file():
+            return possible
+        if cursor.parent == cursor:
+            return None
+        cursor = cursor.parent
+
+
+def _load_target_vocab(start: Path) -> tuple[dict | None, str | None]:
+    """Walk up from `start` looking for `docs/contracts/target-vocab.toml`;
+    fall back to walking up from this module's own ancestor chain when
+    the explicit walk fails. This keeps the gate working when an
+    adopter points `--packs-dir` at a tmp tree outside the repo while
+    still picking up the in-tree vocab. The legacy pre-PR
+    `LintPackTests` rely on this fallback. Returns `(vocab_dict, None)`
+    on success, `(None, err)` when **both** walks fail or the file is
+    malformed."""
+    candidate = _walk_up_for_vocab(start)
+    if candidate is None:
+        candidate = _walk_up_for_vocab(Path(__file__).parent)
+    if candidate is None:
+        return None, (
+            "lint-packs: target-vocab.toml not found (walked up from "
+            f"{start} and from this module's ancestor chain; expected "
+            f"{_VOCAB_RELPATH.as_posix()})"
+        )
+    try:
+        raw = tomllib.loads(candidate.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        return None, f"lint-packs: failed to parse {candidate}: {exc}"
+    targets = raw.get("target")
+    if not isinstance(targets, dict) or not targets:
+        return None, (
+            f"lint-packs: {candidate} has no [target.<name>] tables — "
+            f"the metadata gate has no constraints to apply"
+        )
+    return raw, None
+
+
+def _strictest_constraints(vocab: dict) -> tuple[Constraints | None, str | None]:
+    """Collapse per-target caps into the strictest binding. Returns
+    `(constraints, None)` on success, `(None, err)` if targets disagree
+    on `name-pattern` (which would require regex intersection — not
+    well-defined; the loader refuses rather than picking one)."""
+    targets: dict[str, dict] = vocab["target"]
+
+    # `name-pattern` must be byte-equal across every declared target —
+    # regex intersection is not a defined operation, so disagreement
+    # is refused (AC1 + AC11).
+    pattern_per_target: dict[str, str] = {}
+    for name, table in targets.items():
+        if not isinstance(table, dict):
+            continue
+        pattern = table.get("name-pattern")
+        if not isinstance(pattern, str):
+            return None, (
+                f"lint-packs: target {name!r} is missing `name-pattern` in "
+                f"target-vocab.toml"
+            )
+        pattern_per_target[name] = pattern
+    distinct_patterns = set(pattern_per_target.values())
+    if len(distinct_patterns) != 1:
+        # AC11 — name-pattern disagreement is refused. Report which
+        # targets contributed which pattern so the file author can fix
+        # the divergence without re-reading the loader source.
+        groups: dict[str, list[str]] = {}
+        for tgt, pat in sorted(pattern_per_target.items()):
+            groups.setdefault(pat, []).append(tgt)
+        rendered = "; ".join(
+            f"{pat!r}: {', '.join(group)}" for pat, group in sorted(groups.items())
+        )
+        return None, (
+            f"lint-packs: target-vocab.toml declares inconsistent "
+            f"name-pattern values across targets ({rendered}) — every "
+            f"declared target must share the same pattern (regex "
+            f"intersection is not well-defined)"
+        )
+    compiled_pattern = re.compile(next(iter(distinct_patterns)))
+
+    # Numeric caps — collect each target's value, find the minimum
+    # (strictest binding), record which targets hit that minimum.
+    desc_caps: dict[str, int] = {}
+    name_caps: dict[str, int] = {}
+    for name, table in targets.items():
+        if not isinstance(table, dict):
+            continue
+        if isinstance(table.get("description-max-length"), int):
+            desc_caps[name] = table["description-max-length"]
+        if isinstance(table.get("name-max-length"), int):
+            name_caps[name] = table["name-max-length"]
+
+    if not desc_caps:
+        return None, (
+            "lint-packs: target-vocab.toml declares no "
+            "`description-max-length` on any target — the metadata gate "
+            "needs at least one target with a description cap"
+        )
+    if not name_caps:
+        return None, (
+            "lint-packs: target-vocab.toml declares no `name-max-length` "
+            "on any target — the metadata gate needs at least one target "
+            "with a name-length cap"
+        )
+
+    desc_min = min(desc_caps.values())
+    name_min = min(name_caps.values())
+    binding_targets = {
+        "description_max": sorted(t for t, v in desc_caps.items() if v == desc_min),
+        "name_max": sorted(t for t, v in name_caps.items() if v == name_min),
+        "name_pattern": sorted(targets.keys()),
+    }
+    return (
+        Constraints(
+            description_max=desc_min,
+            name_pattern=compiled_pattern,
+            name_max=name_min,
+            binding_targets=binding_targets,
+        ),
+        None,
+    )
+
+
+def _render_binding(constraints: Constraints, field: str) -> str:
+    return ", ".join(constraints.binding_targets[field])
+
+
+def _extract_frontmatter_fields(
+    text: str, keys: set[str]
+) -> dict[str, object]:
+    """Return `{key: value}` for each requested key found in the
+    `--- ... ---` frontmatter at the head of `text`.
+
+    Values are either strings (single-line scalars, with balanced
+    surrounding quotes stripped) or the `_MULTILINE` sentinel for keys
+    whose value position is `>`, `|`, or empty (signalling a folded /
+    nested block). Keys not present in the frontmatter are absent from
+    the returned dict. Files without a `---` fence return `{}`.
+    """
+    # Strip a leading UTF-8 BOM so a SKILL.md saved by a Windows editor
+    # still has its frontmatter recognised — without this, `lines[0]`
+    # would carry the BOM and the parser would silently return `{}`,
+    # letting an over-cap description slip through.
+    text = text.lstrip("﻿")
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    end = None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            end = i
+            break
+    if end is None:
+        return {}
+    found: dict[str, object] = {}
+    i = 1
+    while i < end:
+        raw = lines[i]
+        if not raw.strip():
+            i += 1
+            continue
+        # Only care about top-level keys; indented continuation lines
+        # are handled below per-key.
+        match = re.match(r"^([a-zA-Z][a-zA-Z0-9_-]*):\s*(.*)$", raw)
+        if not match:
+            i += 1
+            continue
+        key, value = match.group(1), match.group(2).strip()
+        if key in keys:
+            if value in ("", ">", "|") or value.startswith((">", "|")):
+                # Folded / continuation block. Peek the next non-blank
+                # line: if it's indented, this is a multi-line value
+                # we refuse to parse; if it's a top-level key or the
+                # closing fence, treat the value as an empty scalar
+                # (also refused — empty descriptions are caught
+                # downstream by description-presence checks).
+                j = i + 1
+                continuation = False
+                while j < end:
+                    nxt = lines[j]
+                    if not nxt.strip():
+                        j += 1
+                        continue
+                    indent = len(nxt) - len(nxt.lstrip())
+                    if indent > 0:
+                        continuation = True
+                    break
+                if continuation or value in (">", "|") or value.startswith((">", "|")):
+                    found[key] = _MULTILINE
+                else:
+                    found[key] = ""
+            else:
+                if (
+                    len(value) >= 2
+                    and value[0] == value[-1]
+                    and value[0] in ('"', "'")
+                ):
+                    value = value[1:-1]
+                found[key] = value
+        i += 1
+    return found
+
+
+def _check_skill_metadata(pack_dir: Path, constraints: Constraints) -> list[str]:
+    findings: list[str] = []
+    skills_dir = pack_dir / ".apm" / "skills"
+    if not skills_dir.is_dir():
+        return findings
+    for entry in sorted(skills_dir.iterdir()):
+        if not entry.is_dir():
+            continue
+        dir_name = entry.name
+        skill_md = entry / "SKILL.md"
+        relpath = (
+            skill_md.relative_to(pack_dir).as_posix()
+            if skill_md.is_file()
+            else entry.relative_to(pack_dir).as_posix() + "/"
+        )
+        # On-disk name checks — pattern + length for the dir name.
+        primary = _pattern_finding(
+            pack_dir.name, "skill", dir_name, dir_name, constraints, relpath
+        )
+        if primary is not None:
+            findings.append(primary)
+        length = _length_finding(
+            pack_dir.name, "skill", dir_name, constraints, relpath
+        )
+        if length is not None:
+            findings.append(length)
+        if not skill_md.is_file():
+            continue
+        text = skill_md.read_text(encoding="utf-8")
+        findings.extend(
+            _description_findings(
+                pack_dir.name, "skill", dir_name, text, constraints, relpath
+            )
+        )
+        # Frontmatter `name:` — multi-line refused (AC12); when
+        # present and a single-line scalar that differs from the
+        # dir, run the pattern check (AC2).
+        fields = _extract_frontmatter_fields(text, {"name"})
+        fm_name = fields.get("name")
+        if fm_name is _MULTILINE:
+            findings.append(
+                f"{pack_dir.name}: skill/{dir_name}: name must be "
+                f"a single-line value: {relpath}"
+            )
+        elif isinstance(fm_name, str) and fm_name and fm_name != dir_name:
+            fm_finding = _pattern_finding(
+                pack_dir.name, "skill", dir_name, fm_name, constraints, relpath
+            )
+            if fm_finding is not None:
+                findings.append(fm_finding)
+    return findings
+
+
+def _check_agent_metadata(pack_dir: Path, constraints: Constraints) -> list[str]:
+    findings: list[str] = []
+    agents_dir = pack_dir / ".apm" / "agents"
+    if not agents_dir.is_dir():
+        return findings
+    for entry in sorted(agents_dir.iterdir()):
+        if not entry.is_file() or entry.suffix != ".md":
+            continue
+        stem = entry.stem
+        relpath = entry.relative_to(pack_dir).as_posix()
+        primary = _pattern_finding(
+            pack_dir.name, "agent", stem, stem, constraints, relpath
+        )
+        if primary is not None:
+            findings.append(primary)
+        length = _length_finding(
+            pack_dir.name, "agent", stem, constraints, relpath
+        )
+        if length is not None:
+            findings.append(length)
+        text = entry.read_text(encoding="utf-8")
+        findings.extend(
+            _description_findings(
+                pack_dir.name, "agent", stem, text, constraints, relpath
+            )
+        )
+        fields = _extract_frontmatter_fields(text, {"name"})
+        fm_name = fields.get("name")
+        if fm_name is _MULTILINE:
+            findings.append(
+                f"{pack_dir.name}: agent/{stem}: name must be "
+                f"a single-line value: {relpath}"
+            )
+        elif isinstance(fm_name, str) and fm_name and fm_name != stem:
+            fm_finding = _pattern_finding(
+                pack_dir.name, "agent", stem, fm_name, constraints, relpath
+            )
+            if fm_finding is not None:
+                findings.append(fm_finding)
+    return findings
+
+
+def _pattern_finding(
+    pack_name: str,
+    primitive: str,
+    display_name: str,
+    candidate: str,
+    constraints: Constraints,
+    relpath: str,
+) -> str | None:
+    """Pattern-only check for one candidate name. Used by both the
+    on-disk-name check (where `candidate == display_name`) and the
+    frontmatter-`name:` mismatch check (where `candidate` is the
+    frontmatter value). The finding embeds the candidate verbatim
+    so the two cases are distinguishable by inspection."""
+    if constraints.name_pattern.match(candidate):
+        return None
+    return (
+        f"{pack_name}: {primitive}/{display_name}: "
+        f"name does not match {constraints.name_pattern.pattern} "
+        f"(got {candidate!r}; "
+        f"binding target: {_render_binding(constraints, 'name_pattern')}): "
+        f"{relpath}"
+    )
+
+
+def _length_finding(
+    pack_name: str,
+    primitive: str,
+    display_name: str,
+    constraints: Constraints,
+    relpath: str,
+) -> str | None:
+    """Length check for the on-disk name only. The display_name slot
+    IS the candidate; no separate frontmatter-name length finding —
+    per spec AC3, projection risk for over-long frontmatter `name:`
+    is not separately documented and the dir/stem length covers the
+    operational case."""
+    if len(display_name) <= constraints.name_max:
+        return None
+    return (
+        f"{pack_name}: {primitive}/{display_name}: "
+        f"name length exceeds {constraints.name_max} "
+        f"(got {len(display_name)}; "
+        f"binding target: {_render_binding(constraints, 'name_max')}): "
+        f"{relpath}"
+    )
+
+
+def _description_findings(
+    pack_name: str,
+    primitive: str,
+    display_name: str,
+    text: str,
+    constraints: Constraints,
+    relpath: str,
+) -> list[str]:
+    out: list[str] = []
+    fields = _extract_frontmatter_fields(text, {"description"})
+    description = fields.get("description")
+    if description is _MULTILINE:
+        out.append(
+            f"{pack_name}: {primitive}/{display_name}: description "
+            f"must be a single-line value: {relpath}"
+        )
+        return out
+    if not isinstance(description, str) or not description:
+        return out
+    if len(description) > constraints.description_max:
+        out.append(
+            f"{pack_name}: {primitive}/{display_name}: description length "
+            f"exceeds {constraints.description_max} (got {len(description)}; "
+            f"binding target: {_render_binding(constraints, 'description_max')}): "
+            f"{relpath}"
+        )
+    return out
+
+
+def lint_pack(pack_dir: Path, constraints: Constraints | None = None) -> list[str]:
     """Return a list of human-readable violation strings for one pack.
 
     Empty list ⇒ clean. Each string is suitable for stderr emission;
     callers decide how to format / exit.
+
+    When `constraints` is supplied, the per-target metadata gate runs
+    after the portability sweep and the combined findings are sorted
+    by trailing relpath (the AC10 invariant). When omitted, behaviour
+    matches the pre-vocab gate exactly.
     """
     findings: list[str] = []
     for subtree_name in _PACK_SUBTREES:
@@ -65,10 +480,22 @@ def lint_pack(pack_dir: Path) -> list[str]:
                 assert_portable_name(relpath)
             except PathJailError as exc:
                 findings.append(f"{pack_dir.name}: {exc}")
+    if constraints is not None:
+        findings.extend(_check_skill_metadata(pack_dir, constraints))
+        findings.extend(_check_agent_metadata(pack_dir, constraints))
+    # Sort unconditionally so the trailing-relpath invariant holds in
+    # both call modes — a portability-only caller with violations
+    # spanning both subtrees gets the same deterministic ordering as
+    # the gated path. Per-subtree `rglob` already returns entries
+    # sorted, so for single-subtree fixtures the sort is a no-op.
+    findings.sort(key=lambda f: f.rsplit(": ", 1)[-1])
     return findings
 
 
-def lint_all_packs(packs_dir: Path) -> dict[str, list[str]]:
+def lint_all_packs(
+    packs_dir: Path,
+    constraints: Constraints | None = None,
+) -> dict[str, list[str]]:
     """Walk every immediate subdirectory of `packs_dir` that contains a
     `pack.toml`, return `{pack_name: [findings...]}`.
 
@@ -83,28 +510,44 @@ def lint_all_packs(packs_dir: Path) -> dict[str, list[str]]:
             continue
         if not (entry / "pack.toml").exists():
             continue
-        result[entry.name] = lint_pack(entry)
+        result[entry.name] = lint_pack(entry, constraints=constraints)
     return result
 
 
 def cmd_lint_packs(args: argparse.Namespace) -> int:
     """argparse entrypoint. Exit code:
         0 — every pack clean
-        1 — at least one finding
+        1 — at least one finding, or vocab load failure
     """
     packs_dir = Path(args.packs_dir).resolve()
     if not packs_dir.exists():
         print(f"lint-packs: packs-dir not found: {packs_dir}", file=sys.stderr)
         return 1
-    results = lint_all_packs(packs_dir)
+    vocab, err = _load_target_vocab(packs_dir)
+    if err is not None:
+        print(err, file=sys.stderr)
+        print(
+            "lint-packs: configuration error — no packs were checked",
+            file=sys.stderr,
+        )
+        return 1
+    constraints, err = _strictest_constraints(vocab)
+    if err is not None:
+        print(err, file=sys.stderr)
+        print(
+            "lint-packs: configuration error — no packs were checked",
+            file=sys.stderr,
+        )
+        return 1
+    results = lint_all_packs(packs_dir, constraints=constraints)
     total = 0
-    for pack_name, findings in results.items():
+    for _pack_name, findings in results.items():
         for finding in findings:
             print(finding, file=sys.stderr)
             total += 1
     if total:
         print(
-            f"lint-packs: {total} portability violation(s) across "
+            f"lint-packs: {total} violation(s) across "
             f"{sum(1 for f in results.values() if f)} pack(s)",
             file=sys.stderr,
         )

--- a/packages/agentbundle/agentbundle/build/tests/test_lint_packs.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_lint_packs.py
@@ -1,10 +1,16 @@
 """Windows-portability lint: catches symlinks and Windows-poisonous
-names in pack content before they reach a release artefact."""
+names in pack content before they reach a release artefact.
+
+Also covers the per-target metadata gate landed under
+docs/specs/lint-packs-target-vocab/: skill/agent name pattern, name
+length, and description length per docs/contracts/target-vocab.toml.
+"""
 
 from __future__ import annotations
 
 import argparse
 import io
+import re
 import shutil
 import sys
 import tempfile
@@ -13,10 +19,46 @@ from contextlib import redirect_stderr
 from pathlib import Path
 
 from agentbundle.build.lint_packs import (
+    Constraints,
     cmd_lint_packs,
     lint_all_packs,
     lint_pack,
 )
+
+
+def _make_constraints(
+    *,
+    description_max: int = 1024,
+    name_max: int = 64,
+    name_pattern: str = r"^[a-z][a-z0-9-]*$",
+    binding_targets: dict[str, list[str]] | None = None,
+) -> Constraints:
+    """Build a Constraints tuple inline for tests that need one but
+    don't want to materialise a vocab file on disk. Defaults match
+    the in-tree target-vocab.toml's strictest cap.
+    """
+    if binding_targets is None:
+        binding_targets = {
+            "description_max": ["codex", "kiro"],
+            "name_max": ["kiro"],
+            "name_pattern": ["claude-code", "codex", "copilot", "kiro"],
+        }
+    return Constraints(
+        description_max=description_max,
+        name_pattern=re.compile(name_pattern),
+        name_max=name_max,
+        binding_targets=binding_targets,
+    )
+
+
+def _write_minimal_pack(pack_dir: Path, name: str = "fixture-pack") -> None:
+    """Drop a minimal pack.toml so lint_all_packs treats the dir as
+    a pack. Tests that materialise packs build on this."""
+    pack_dir.mkdir(parents=True, exist_ok=True)
+    (pack_dir / "pack.toml").write_text(
+        f'[pack]\nname = "{name}"\nversion = "0.0.1"\n',
+        encoding="utf-8",
+    )
 
 # The repo-checked-in fixture lives under tests/fixtures/lint_packs/.
 # Reserved-name violations are constructed at runtime under tmp_path
@@ -190,6 +232,471 @@ class LintPackTests(unittest.TestCase):
             with redirect_stderr(buf):
                 rc = cmd_lint_packs(args)
             self.assertEqual(rc, 0)
+
+
+class LintPackVocabTests(unittest.TestCase):
+    """Per-target metadata gate (spec: lint-packs-target-vocab)."""
+
+    def _build_skill(
+        self,
+        pack: Path,
+        dir_name: str,
+        description: str | None = "A short, single-line description.",
+        frontmatter_name: str | None = None,
+    ) -> Path:
+        skill_dir = pack / ".apm" / "skills" / dir_name
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        lines = ["---"]
+        if frontmatter_name is not None:
+            lines.append(f"name: {frontmatter_name}")
+        if description is not None:
+            lines.append(f"description: {description}")
+        lines.append("---")
+        lines.append("Body.")
+        (skill_dir / "SKILL.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return skill_dir / "SKILL.md"
+
+    def _build_agent(
+        self,
+        pack: Path,
+        stem: str,
+        description: str | None = "A short, single-line description.",
+        frontmatter_name: str | None = None,
+    ) -> Path:
+        agents_dir = pack / ".apm" / "agents"
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        lines = ["---"]
+        if frontmatter_name is not None:
+            lines.append(f"name: {frontmatter_name}")
+        if description is not None:
+            lines.append(f"description: {description}")
+        lines.append("model: opus")
+        lines.append("---")
+        lines.append("Body.")
+        path = agents_dir / f"{stem}.md"
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return path
+
+    # ------------------------------------------------------------------
+    # Skill checks (AC2 — name pattern, AC3 — name length, AC4 — desc)
+    # ------------------------------------------------------------------
+
+    def test_skill_dir_name_pattern_violation_detected(self) -> None:
+        constraints = _make_constraints()
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp) / "vocab-fixture"
+            _write_minimal_pack(pack, name="vocab-fixture")
+            self._build_skill(pack, "Bad_Name")
+            findings = lint_pack(pack, constraints=constraints)
+            vocab_findings = [f for f in findings if "name does not match" in f]
+        self.assertEqual(len(vocab_findings), 1, findings)
+        self.assertIn("skill/Bad_Name", vocab_findings[0])
+        self.assertIn("name does not match", vocab_findings[0])
+        self.assertIn("binding target:", vocab_findings[0])
+
+    def test_skill_frontmatter_name_mismatch_pattern_detected(self) -> None:
+        constraints = _make_constraints()
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp) / "vocab-fm-name"
+            _write_minimal_pack(pack, name="vocab-fm-name")
+            self._build_skill(pack, "valid-name", frontmatter_name="Bad_Name")
+            findings = lint_pack(pack, constraints=constraints)
+            fm_findings = [
+                f for f in findings if "Bad_Name" in f and "name does not match" in f
+            ]
+        self.assertEqual(len(fm_findings), 1, findings)
+        self.assertIn("skill/valid-name", fm_findings[0])
+
+    def test_skill_name_length_violation_detected(self) -> None:
+        constraints = _make_constraints()
+        long_name = "a" + "b" * 69  # 70 chars, kebab-valid
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp) / "vocab-fixture"
+            _write_minimal_pack(pack, name="vocab-fixture")
+            self._build_skill(pack, long_name)
+            findings = lint_pack(pack, constraints=constraints)
+            length_findings = [f for f in findings if "name length exceeds" in f]
+        self.assertEqual(len(length_findings), 1, findings)
+        self.assertIn(f"name length exceeds 64 (got 70", length_findings[0])
+        self.assertIn("binding target: kiro", length_findings[0])
+
+    def test_skill_description_length_violation_detected(self) -> None:
+        constraints = _make_constraints()
+        long_desc = "x" * 1100
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp) / "vocab-fixture"
+            _write_minimal_pack(pack, name="vocab-fixture")
+            self._build_skill(pack, "valid-name", description=long_desc)
+            findings = lint_pack(pack, constraints=constraints)
+            desc_findings = [
+                f for f in findings if "description length exceeds" in f
+            ]
+        self.assertEqual(len(desc_findings), 1, findings)
+        self.assertIn("description length exceeds 1024 (got 1100", desc_findings[0])
+        self.assertIn("binding target: codex, kiro", desc_findings[0])
+
+    def test_skill_description_singleline_required(self) -> None:
+        constraints = _make_constraints()
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp) / "vocab-fixture"
+            _write_minimal_pack(pack, name="vocab-fixture")
+            skill_dir = pack / ".apm" / "skills" / "valid-name"
+            skill_dir.mkdir(parents=True, exist_ok=True)
+            (skill_dir / "SKILL.md").write_text(
+                "---\ndescription: >\n  folded\n  multi-line\nmodel: opus\n---\nBody.\n",
+                encoding="utf-8",
+            )
+            findings = lint_pack(pack, constraints=constraints)
+            ml_findings = [
+                f for f in findings if "description must be a single-line value" in f
+            ]
+        self.assertEqual(len(ml_findings), 1, findings)
+        self.assertIn("skill/valid-name", ml_findings[0])
+
+    # ------------------------------------------------------------------
+    # Agent checks (AC5 — name pattern + length, AC6 — desc length)
+    # ------------------------------------------------------------------
+
+    def test_agent_name_length_violation_detected(self) -> None:
+        constraints = _make_constraints()
+        long_stem = "a" + "b" * 69  # 70 chars
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp) / "vocab-fixture"
+            _write_minimal_pack(pack, name="vocab-fixture")
+            self._build_agent(pack, long_stem)
+            findings = lint_pack(pack, constraints=constraints)
+            length_findings = [
+                f for f in findings if "agent/" in f and "name length exceeds" in f
+            ]
+        self.assertEqual(len(length_findings), 1, findings)
+        self.assertIn(f"agent/{long_stem}", length_findings[0])
+        self.assertIn("name length exceeds 64 (got 70", length_findings[0])
+
+    def test_agent_description_length_violation_detected(self) -> None:
+        constraints = _make_constraints()
+        long_desc = "x" * 1100
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp) / "vocab-fixture"
+            _write_minimal_pack(pack, name="vocab-fixture")
+            self._build_agent(pack, "valid-agent", description=long_desc)
+            findings = lint_pack(pack, constraints=constraints)
+            desc_findings = [
+                f for f in findings
+                if "agent/" in f and "description length exceeds" in f
+            ]
+        self.assertEqual(len(desc_findings), 1, findings)
+        self.assertIn("description length exceeds 1024 (got 1100", desc_findings[0])
+
+    def test_agent_description_singleline_required(self) -> None:
+        constraints = _make_constraints()
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp) / "vocab-fixture"
+            _write_minimal_pack(pack, name="vocab-fixture")
+            agents_dir = pack / ".apm" / "agents"
+            agents_dir.mkdir(parents=True, exist_ok=True)
+            (agents_dir / "valid-agent.md").write_text(
+                "---\ndescription: |\n  folded\nmodel: opus\n---\nBody.\n",
+                encoding="utf-8",
+            )
+            findings = lint_pack(pack, constraints=constraints)
+            ml_findings = [
+                f for f in findings if "description must be a single-line value" in f
+            ]
+        self.assertEqual(len(ml_findings), 1, findings)
+        self.assertIn("agent/valid-agent", ml_findings[0])
+
+    # ------------------------------------------------------------------
+    # Clean pack — no vocab findings
+    # ------------------------------------------------------------------
+
+    def test_clean_pack_with_skills_and_agents_has_no_vocab_findings(self) -> None:
+        constraints = _make_constraints()
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp) / "clean-vocab"
+            _write_minimal_pack(pack, name="clean-vocab")
+            self._build_skill(pack, "good-skill", description="x" * 100)
+            self._build_agent(pack, "good-agent", description="x" * 100)
+            findings = lint_pack(pack, constraints=constraints)
+        self.assertEqual(findings, [], findings)
+
+    # ------------------------------------------------------------------
+    # Sort invariant (AC10) — vocab + portability findings interleave
+    # ------------------------------------------------------------------
+
+    def test_findings_remain_sorted_when_vocab_and_portability_mix(self) -> None:
+        constraints = _make_constraints()
+        if sys.platform == "win32":
+            self.skipTest(
+                "NTFS refuses to materialise seeds/NUL.md; the sort invariant "
+                "is OS-agnostic so POSIX coverage is sufficient"
+            )
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp) / "mix-pack"
+            _write_minimal_pack(pack, name="mix-pack")
+            (pack / "seeds").mkdir(parents=True, exist_ok=True)
+            (pack / "seeds" / "NUL.md").write_text("x\n", encoding="utf-8")
+            self._build_skill(pack, "Bad_Name")
+            findings = lint_pack(pack, constraints=constraints)
+            relpaths = [f.rsplit(": ", 1)[-1] for f in findings]
+        self.assertEqual(relpaths, sorted(relpaths))
+
+    @unittest.skipIf(
+        sys.platform == "win32",
+        "NTFS refuses to materialise seeds/NUL.md / .apm/agents/CON.md; sort "
+        "invariant is OS-agnostic so POSIX coverage is sufficient",
+    )
+    def test_portability_findings_sort_across_subtrees_when_constraints_supplied(
+        self,
+    ) -> None:
+        """The constraints-supplied path adds a cross-subtree sort step;
+        without it, portability findings come back subtree-by-subtree
+        (`seeds/` first, then `.apm/`). With it, the combined list is
+        sorted by trailing relpath."""
+        constraints = _make_constraints()
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp) / "cross-subtree"
+            _write_minimal_pack(pack, name="cross-subtree")
+            (pack / "seeds").mkdir(parents=True, exist_ok=True)
+            (pack / "seeds" / "NUL.md").write_text("x\n", encoding="utf-8")
+            agents_dir = pack / ".apm" / "agents"
+            agents_dir.mkdir(parents=True, exist_ok=True)
+            (agents_dir / "CON.md").write_text("x\n", encoding="utf-8")
+            findings = lint_pack(pack, constraints=constraints)
+            relpaths = [f.rsplit(": ", 1)[-1] for f in findings]
+        # `.apm/agents/CON.md` sorts before `seeds/NUL.md` alphabetically.
+        # The constraints-supplied path must produce them in that order.
+        self.assertEqual(relpaths, sorted(relpaths))
+        self.assertGreater(len(relpaths), 1)
+
+    def test_multi_target_tie_renders_comma_joined_binding(self) -> None:
+        """When multiple targets share the binding cap (codex + kiro at
+        1024), the finding renders `binding target: codex, kiro`."""
+        constraints = _make_constraints()
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp) / "tie-pack"
+            _write_minimal_pack(pack, name="tie-pack")
+            self._build_skill(pack, "good-name", description="x" * 1100)
+            findings = lint_pack(pack, constraints=constraints)
+            desc_findings = [
+                f for f in findings if "description length exceeds" in f
+            ]
+        self.assertEqual(len(desc_findings), 1, findings)
+        self.assertIn("binding target: codex, kiro", desc_findings[0])
+
+    # ------------------------------------------------------------------
+    # AC11 — vocab file missing / inconsistent fails loud
+    # ------------------------------------------------------------------
+
+    def test_missing_vocab_file_fails_loud(self) -> None:
+        """When neither the --packs-dir walk nor the module-ancestor
+        fallback finds the vocab file, cmd_lint_packs exits non-zero
+        with a stderr line naming the config file. We patch
+        `_VOCAB_RELPATH` to a sentinel filename that exists nowhere so
+        both walks fail deterministically."""
+        from unittest.mock import patch
+        from agentbundle.build import lint_packs as lp_module
+        sentinel = Path("docs/contracts/__nonexistent_target_vocab__.toml")
+        with tempfile.TemporaryDirectory() as tmp:
+            packs_dir = Path(tmp) / "isolated" / "packs"
+            packs_dir.mkdir(parents=True)
+            _write_minimal_pack(packs_dir / "p", name="p")
+            args = argparse.Namespace(packs_dir=str(packs_dir))
+            buf = io.StringIO()
+            with patch.object(lp_module, "_VOCAB_RELPATH", sentinel), \
+                    redirect_stderr(buf):
+                rc = cmd_lint_packs(args)
+        self.assertEqual(rc, 1)
+        self.assertIn("target-vocab.toml", buf.getvalue())
+
+    def test_skill_name_multiline_refused(self) -> None:
+        """A folded `name:` in frontmatter must be refused — same
+        rationale as AC12 for `description:`, applied to `name:`."""
+        constraints = _make_constraints()
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp) / "ml-name-pack"
+            _write_minimal_pack(pack, name="ml-name-pack")
+            skill_dir = pack / ".apm" / "skills" / "valid-name"
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: >\n  Bad_Name\ndescription: short.\n---\nBody.\n",
+                encoding="utf-8",
+            )
+            findings = lint_pack(pack, constraints=constraints)
+            ml_findings = [
+                f for f in findings
+                if "name must be a single-line value" in f
+            ]
+        self.assertEqual(len(ml_findings), 1, findings)
+        self.assertIn("skill/valid-name", ml_findings[0])
+
+    def test_agent_name_multiline_refused(self) -> None:
+        constraints = _make_constraints()
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp) / "ml-agent"
+            _write_minimal_pack(pack, name="ml-agent")
+            agents_dir = pack / ".apm" / "agents"
+            agents_dir.mkdir(parents=True)
+            (agents_dir / "valid-agent.md").write_text(
+                "---\nname: |\n  Bad_Name\ndescription: short.\nmodel: opus\n---\nBody.\n",
+                encoding="utf-8",
+            )
+            findings = lint_pack(pack, constraints=constraints)
+            ml_findings = [
+                f for f in findings
+                if "name must be a single-line value" in f
+            ]
+        self.assertEqual(len(ml_findings), 1, findings)
+        self.assertIn("agent/valid-agent", ml_findings[0])
+
+    def test_loader_module_ancestor_fallback_succeeds(self) -> None:
+        """The loader walks up from the supplied start; when that
+        finds nothing, it falls back to walking from the module's
+        own ancestor chain. Production-side this is what makes
+        `cmd_lint_packs` work for an out-of-tree --packs-dir while
+        still reading the in-tree vocab. Direct test of the
+        fallback hit-path."""
+        from agentbundle.build.lint_packs import _load_target_vocab
+        with tempfile.TemporaryDirectory() as tmp:
+            vocab, err = _load_target_vocab(Path(tmp))
+        self.assertIsNone(err, err)
+        self.assertIsNotNone(vocab)
+        self.assertEqual(vocab["target"]["kiro"]["name-max-length"], 64)
+
+    def test_skill_frontmatter_with_bom_still_checked(self) -> None:
+        """A SKILL.md saved with a UTF-8 BOM must still have its
+        frontmatter parsed — otherwise an over-cap description would
+        slip through silently. Regression for the BOM under-counting
+        risk surfaced by quality-engineer review."""
+        constraints = _make_constraints()
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp) / "bom-pack"
+            _write_minimal_pack(pack, name="bom-pack")
+            skill_dir = pack / ".apm" / "skills" / "good-name"
+            skill_dir.mkdir(parents=True)
+            long_desc = "x" * 1100
+            (skill_dir / "SKILL.md").write_text(
+                "﻿---\ndescription: " + long_desc + "\n---\nBody.\n",
+                encoding="utf-8",
+            )
+            findings = lint_pack(pack, constraints=constraints)
+            desc_findings = [
+                f for f in findings if "description length exceeds" in f
+            ]
+        self.assertEqual(len(desc_findings), 1, findings)
+
+    def _run_with_bad_vocab(self, body: str) -> tuple[int, str]:
+        """Helper for AC11 refusal-branch coverage. Materialises an
+        isolated tree with a controlled `target-vocab.toml`, invokes
+        `cmd_lint_packs` against a minimal pack inside that tree, and
+        returns `(rc, stderr_text)`. The explicit `--packs-dir` walk
+        finds the tmp vocab first, so the module-ancestor fallback
+        doesn't shadow the bad config under test."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "isolated"
+            packs_dir = root / "packs"
+            packs_dir.mkdir(parents=True)
+            _write_minimal_pack(packs_dir / "p", name="p")
+            vocab_dir = root / "docs" / "contracts"
+            vocab_dir.mkdir(parents=True)
+            (vocab_dir / "target-vocab.toml").write_text(body, encoding="utf-8")
+            args = argparse.Namespace(packs_dir=str(packs_dir))
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                rc = cmd_lint_packs(args)
+            return rc, buf.getvalue()
+
+    def test_malformed_toml_fails_loud(self) -> None:
+        rc, stderr = self._run_with_bad_vocab("not valid toml [[[\n")
+        self.assertEqual(rc, 1)
+        self.assertIn("failed to parse", stderr)
+        self.assertIn("configuration error", stderr)
+
+    def test_no_target_tables_fails_loud(self) -> None:
+        rc, stderr = self._run_with_bad_vocab(
+            '[contract]\nversion = "0.1"\n'
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("no [target.<name>] tables", stderr)
+        self.assertIn("configuration error", stderr)
+
+    def test_missing_name_pattern_on_target_fails_loud(self) -> None:
+        rc, stderr = self._run_with_bad_vocab(
+            '[target.alpha]\n'
+            'description-max-length = 1024\n'
+            'name-max-length = 64\n'
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("name-pattern", stderr)
+        self.assertIn("configuration error", stderr)
+
+    def test_no_description_cap_anywhere_fails_loud(self) -> None:
+        rc, stderr = self._run_with_bad_vocab(
+            '[target.alpha]\n'
+            'name-pattern = "^[a-z][a-z0-9-]*$"\n'
+            'name-max-length = 64\n'
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("description-max-length", stderr)
+        self.assertIn("configuration error", stderr)
+
+    def test_no_name_max_length_anywhere_fails_loud(self) -> None:
+        rc, stderr = self._run_with_bad_vocab(
+            '[target.alpha]\n'
+            'name-pattern = "^[a-z][a-z0-9-]*$"\n'
+            'description-max-length = 1024\n'
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("name-max-length", stderr)
+        self.assertIn("configuration error", stderr)
+
+    def test_portability_sort_no_constraints_also_sorts_across_subtrees(
+        self,
+    ) -> None:
+        """The unconditional sort step at the end of `lint_pack` keeps
+        the trailing-relpath ordering invariant in the no-constraints
+        path too. Regression-pin: a future change that re-gates the
+        sort behind `constraints is not None` would let this test
+        fail loudly."""
+        if sys.platform == "win32":
+            self.skipTest(
+                "NTFS refuses to materialise seeds/NUL.md / .apm/agents/CON.md"
+            )
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp) / "no-constraints-mix"
+            _write_minimal_pack(pack, name="no-constraints-mix")
+            (pack / "seeds").mkdir(parents=True, exist_ok=True)
+            (pack / "seeds" / "NUL.md").write_text("x\n", encoding="utf-8")
+            agents_dir = pack / ".apm" / "agents"
+            agents_dir.mkdir(parents=True, exist_ok=True)
+            (agents_dir / "CON.md").write_text("x\n", encoding="utf-8")
+            findings = lint_pack(pack)
+            relpaths = [f.rsplit(": ", 1)[-1] for f in findings]
+        self.assertEqual(relpaths, sorted(relpaths))
+        self.assertGreater(len(relpaths), 1)
+
+    def test_inconsistent_name_pattern_fails_loud(self) -> None:
+        """A target-vocab.toml whose targets carry different name-pattern
+        values must be refused by the loader (AC11)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "isolated"
+            packs_dir = root / "packs"
+            packs_dir.mkdir(parents=True)
+            _write_minimal_pack(packs_dir / "p", name="p")
+            vocab_dir = root / "docs" / "contracts"
+            vocab_dir.mkdir(parents=True)
+            (vocab_dir / "target-vocab.toml").write_text(
+                '[target.alpha]\nname-pattern = "^[a-z][a-z0-9-]*$"\n'
+                'description-max-length = 1024\n'
+                '[target.beta]\nname-pattern = "^[A-Z][A-Z0-9-]*$"\n'
+                'description-max-length = 1024\n',
+                encoding="utf-8",
+            )
+            args = argparse.Namespace(packs_dir=str(packs_dir))
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                rc = cmd_lint_packs(args)
+        self.assertEqual(rc, 1)
+        self.assertIn("name-pattern", buf.getvalue())
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary

Refuses, at `make build` time, any pack whose source-side skill/agent
name or description would fail projection to a declared adapter target.
The gate's constraints live in a new sibling `docs/contracts/target-vocab.toml`
— no `adapter.schema.json` or `adapter.toml` change, so the contract
grammar is untouched.

Concretely, `packages/agentbundle/agentbundle/build/lint_packs.py` now
checks every pack under `--packs-dir` for:

- skill dir + frontmatter `name:` matching the strictest cross-target
  kebab pattern (today every target declares the same one; the loader
  refuses divergence rather than picking one — regex intersection is
  not well-defined);
- skill / agent on-disk name length against the strictest
  `name-max-length` (Kiro's 64);
- frontmatter `description:` length against the strictest
  `description-max-length` (1024, tied between Codex and Kiro);
- multi-line / folded `name:` and `description:` values are refused
  outright (AC12) rather than mis-parsed — silent under-counting was
  the failure mode this gate exists to prevent;
- missing / malformed / inconsistent vocab fails loud with a
  `lint-packs: configuration error — no packs were checked` footer so
  CI logs surface misconfiguration the same way they surface per-pack
  violations.

Findings keep the existing `{pack}: {message}: {relpath}` trailing-
relpath shape and the cross-subtree sort holds in both call modes.

## Decisions worth flagging

- **Items 3 (tool-name vocab) and 4 (hook event vocab) from the
  originating brief are declined.** A source-side gate has no
  workable shape while adapters remain byte-equal-passthrough —
  refusing Claude vocab in pack sources would break Claude Code
  projection, and the four targets have no intersection vocabulary.
  Resolving either needs an RFC (per-target rewriter, or canonical
  cross-source vocab). Documented in `spec.md § Non-goals`.
- **The vocab loader walks up from `--packs-dir` and falls back to
  walking from this module's ancestor chain.** Pre-existing
  `LintPackTests` use tmp dirs outside the repo; without the
  fallback their `cmd_lint_packs` calls would all hit AC11 failure.
  The `test_missing_vocab_file_fails_loud` test exercises the
  both-walks-fail path via `_VOCAB_RELPATH` patching.

## Reviewer trail

Spec + plan went through five rounds of pre-EXECUTE adversarial
review (regex collapse rule, binding-target rendering, scaffold
strategy, AC11/AC8 collision); implementation went through two
rounds of adversarial review and two rounds of quality-engineer
review (finding-shape drift, BOM under-counting, AC11 branch
coverage, sort-step regression-pin).

## Test plan

- [x] `make lint-packs` over `packs/` exits 0
- [x] `make build` exits 0
- [x] `make build-check` exits 0
- [x] All 33 new lint_packs tests pass (5 AC11 refusal branches, 2
      cross-subtree sort pins, BOM regression, multi-target tie,
      module-fallback hit-path, name + description coverage)
- [x] Every pre-PR test method in `LintPackTests` continues to pass
      unchanged (AC8)
- [ ] Reviewer cross-checks the spec's `Non-goals` / `Boundaries`
      section against the diff