### PR TITLE
docs(readme,guides): agentbundle pip-install for routes 1-3

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,23 @@ Four routes, depending on the agent harness you use and whether you want the cat
 /plugin install core@agent-ready-repo
 ```
 
+`/plugin install` lands the markdown and scripts but not the `agentbundle` Python module those scripts import — see [installing `agentbundle` from a clone](docs/guides/how-to/install-agentbundle-from-clone.md) before invoking `jira`, `figma`, or any credentialed skill.
+
 **Any IDE via APM:**
 
 ```bash
 apm install eugenelim/agent-ready-repo/core
 ```
 
-**Reference CLI** ([RFC-0003](docs/rfc/0003-spec-and-cli.md)) — once `agentbundle` is on your PATH:
+`apm install` lands the same pack content but not the `agentbundle` module credentialed skills import — same pip-install step the clone route documents, see [installing `agentbundle` from a clone](docs/guides/how-to/install-agentbundle-from-clone.md).
+
+**Reference CLI** ([RFC-0003](docs/rfc/0003-spec-and-cli.md)) — once you've pip-installed `agentbundle` (see route 4):
 
 ```bash
 agentbundle install --pack core git+https://github.com/eugenelim/agent-ready-repo
 ```
+
+Route 3 still requires route 4's pip install today — RFC-0003 § F-cli-dist's release artifact (zipapp / wheel / Homebrew) isn't shipped yet, so "on your PATH" resolves to the editable install from the clone. The route's distinction from route 4 — fetching the catalogue from a remote `git+https://` URL instead of a local clone — still applies once `agentbundle` is importable.
 
 **From a local clone** — clone the catalogue, install the runtime library, and project straight into your target repo:
 

--- a/docs/guides/how-to/install-agentbundle-from-clone.md
+++ b/docs/guides/how-to/install-agentbundle-from-clone.md
@@ -1,8 +1,10 @@
 # How to install `agentbundle` from a clone
 
-You're here because you cloned the catalogue ([README route 4](../../../README.md#install))
-and want credentialed skills like `jira` or `figma` to work when an
-agent harness invokes their scripts.
+You're here because credentialed skills like `jira` or `figma` need
+the `agentbundle` Python module importable on the interpreter that
+runs them. All four [README install routes](../../../README.md#install)
+ship pack content — skills, agents, hooks — but not that Python
+module, so every route converges here for the pip install.
 
 Every credentialed skill in this catalogue (`jira`, `figma`,
 `confluence-publisher`, `confluence-crawler`, `jira-align`, plus the


### PR DESCRIPTION
## Summary

Closes the README install-route gap for routes 1-3 — the same gap PR #123 just closed for route 4.

- **Route 1** (Claude Code marketplace + plugins): one-line note after the command block, naming the runtime-dep on the `agentbundle` Python module and cross-linking to the existing how-to.
- **Route 2** (APM): same shape — `apm install` lands pack content per the adapter contract but not the Python module; cross-link.
- **Route 3** (Reference CLI): headline previously hand-waved "once `agentbundle` is on your PATH" with no resolution. Reword to "once you've pip-installed `agentbundle` (see route 4)"; add a trailing paragraph naming RFC-0003 § F-cli-dist as the unshipped release artifact and preserving the route's real distinction from route 4 (remote `git+https://` URL fetch vs local clone).
- **How-to opener** broadened so all four README install routes can converge there for the pip install (was: "you cloned the catalogue (route 4)").

## Research answers (the brief's four questions)

**Q1. Does `/plugin install` do anything Python-related?** No. The per-pack `.claude-plugin/plugin.json` files carry only `{name, version, description}`; `.claude-plugin/marketplace.json` is pure metadata. The plugin install machinery copies skill / agent / hook / command markdown into target paths.

**Q2. What does `apm install` do?** Projects pack primitives per the adapter contract at `packages/agentbundle/agentbundle/_data/adapter.toml` (v0.5). Five primitive projections (skill, agent, hook-body, hook-wiring, command); none is "install a Python package." Spec `apm-install-route-parity` (Approved → Shipped) adds a SessionStart install-marker hook for install→adapt parity, not a pip step.

**Q3. What is route 3's "on your PATH" precondition?** RFC-0003 § Distribution named three paths for the CLI on PATH: zipapp via GitHub Releases (load-bearing for constrained networks), pip install via Artifactory, Homebrew formula. Reality today:

- `pip install -e packages/agentbundle/` from a clone works.
- `make zipapp` builds `dist/agentbundle.pyz` locally.
- The **released** zipapp, the published wheel, and the Homebrew formula RFC-0003 § F-cli-dist names **have not shipped**.

Route 3 therefore presupposes route 4's pip install today. Surfaced honestly in the route-3 paragraph rather than silently papered over. **Follow-up suggested:** RFC against 0003 to either ship the F-cli-dist release artifact (so route 3 can stand on its own) or rewrite the distribution section to match what exists. Route 3 itself is **not vestigial** — it carries a real distinction from route 4 (CLI fetches the catalogue via remote VCS URL, no local clone needed for the catalogue source).

**Q4. Inline smoke check per route, or cross-link?** Cross-link. The how-to is the canonical home for the install procedure (pip vs zipapp, editable vs snapshot, venv guidance, smoke check, pitfalls). Three routes pointing at one canonical doc beats three places to keep in sync.

## Out of scope (per the brief)

- Publishing the wheel, building release artifacts, adding Makefile targets (the route-3 paragraph flags this as RFC follow-up).
- Restructuring the four-route section or reordering routes.
- Merging routes 3 and 4.
- Changing what `agentbundle.credentials` exports.

## Test plan

- [x] `make build-check` clean (no projection drift — README and the how-to are both hand-authored).
- [x] `tools/lint-agents-md.py` clean.
- [x] `tools/lint-agent-artifacts.py` clean.
- [x] Adversarial-reviewer pass clean (two rounds — first surfaced two Blockers on route 3 honesty + a wrong zipapp pointer; both addressed; re-review returned `Clean — ready to commit.`).
- [ ] Reviewer reads the route-3 paragraph and confirms the F-cli-dist follow-up framing is the right shape, vs a tracked-issue / separate RFC PR.