### PR TITLE
docs(rfc): open RFC-0011 — per-pack allowed-adapters declaration

### DIFF
--- a/.claude/skills/flow-metrics/scripts/flow_metrics/config.py
+++ b/.claude/skills/flow-metrics/scripts/flow_metrics/config.py
@@ -42,7 +42,11 @@ def _find_skill_root(start: Optional[Path] = None) -> Path:
     both ``SKILL.md`` and ``references/`` is found.
 
     Layout-agnostic so the same resolver works for user-scope installs
-    (``~/.claude/skills/flow-metrics/``) and in-pack development trees
+    under any of the three user-scope-capable adapters
+    (``~/.claude/skills/flow-metrics/`` for claude-code,
+    ``~/.kiro/skills/flow-metrics/`` for kiro,
+    ``~/.agents/skills/flow-metrics/`` for codex per Codex's upstream
+    skills docs) and in-pack development trees
     (``<repo>/packs/atlassian/.apm/skills/flow-metrics/``). During
     development the
     ``SKILL.md`` file may not exist yet (T12 ships it); in that case we

--- a/.claude/skills/flow-metrics/scripts/flow_metrics/upstream.py
+++ b/.claude/skills/flow-metrics/scripts/flow_metrics/upstream.py
@@ -117,18 +117,36 @@ def _module_name_for_script(name: str) -> str:
     return name.replace("-", "_")
 
 
+_USER_SCOPE_CAPABLE_ADAPTER_DIRS: Tuple[str, ...] = (".claude", ".kiro", ".agents")
+
+
 def discover_skill_path(name: str, *, env: Optional[Mapping[str, str]] = None, cwd: Optional[Path] = None) -> Path:
     """Locate the upstream skill's CLI entry script.
 
-    Probe order (per spec/plan):
+    Probe order:
 
     1. ``$FLOW_METRICS_<NAME>_SCRIPT`` env var (testing override).
-    2. ``<this-skill-dir>/../<name>/scripts/<name>.py`` (sibling layout).
-    3. ``~/.claude/skills/<name>/scripts/<name>.py`` (user scope).
-    4. ``<cwd>/.claude/skills/<name>/scripts/<name>.py`` (project scope).
+    2. ``<this-skill-dir>/../<name>/scripts/<name>.py`` (sibling layout —
+       covers same-adapter user-scope installs *and* in-pack development).
+    3. ``~/<adapter-dir>/skills/<name>/scripts/<name>.py`` (user scope),
+       walked across every user-scope-capable adapter directory:
+       ``.claude`` (claude-code), ``.kiro`` (kiro), ``.agents`` (codex —
+       per Codex's upstream skills documentation, skills land under the
+       shared ``$HOME/.agents/skills/`` not under ``~/.codex/``).
+    4. ``<cwd>/<adapter-dir>/skills/<name>/scripts/<name>.py`` (project
+       scope), same three adapter directories.
 
     First hit wins. None match → :class:`UpstreamNotFoundError` naming
     every candidate.
+
+    **Multi-root precedence.** When the same upstream skill is installed
+    under more than one adapter root (e.g. both ``~/.claude/skills/jira/``
+    and ``~/.kiro/skills/jira/``), priority 3's declared order is
+    ``claude → kiro → codex`` — claude wins by default. Adopters who
+    want a specific adapter set the priority-1 env override
+    ``FLOW_METRICS_<NAME>_SCRIPT`` to the exact script path; that's the
+    documented runtime escape valve. The install-time analogue lives in
+    ``agentbundle install --scope user --adapter <name>`` per RFC-0011.
     """
     e = env if env is not None else os.environ
     base_cwd = cwd if cwd is not None else Path.cwd()
@@ -136,22 +154,33 @@ def discover_skill_path(name: str, *, env: Optional[Mapping[str, str]] = None, c
 
     candidates: List[Tuple[str, Path]] = []
 
-    # 1. Env override. Honored even if the file doesn't exist *iff* the
-    #    user explicitly set it — but we still require the file to be a
-    #    real file before returning, so a typo'd override falls through
-    #    to the next candidate rather than silently failing later.
+    # 1. Env override appended as a candidate. The `is_file()` check
+    #    below means a typo'd override falls through to the next
+    #    candidate rather than silently failing later.
     env_value = e.get(_env_var_name(name))
     if env_value:
         candidates.append(("env:" + _env_var_name(name), Path(env_value)))
 
-    # 2. Sibling layout under this skill's parent dir.
+    # 2. Sibling layout under this skill's parent dir. This already
+    #    handles the common case where flow-metrics and its upstream
+    #    sibling skill are co-installed under the same adapter root
+    #    (the sibling walk lands one level above flow-metrics' own dir,
+    #    so it works for any adapter the install put us under).
     candidates.append(("sibling", _THIS_SKILL_DIR.parent / name / "scripts" / script))
 
-    # 3. User scope.
-    candidates.append(("user", Path.home() / ".claude" / "skills" / name / "scripts" / script))
+    # 3. User scope — walked across all three user-scope-capable adapter
+    #    directories. Order is claude/kiro/codex, matching the probe
+    #    order in `_resolve_user_scope_target_adapter`.
+    for adapter_dir in _USER_SCOPE_CAPABLE_ADAPTER_DIRS:
+        candidates.append(
+            ("user:" + adapter_dir, Path.home() / adapter_dir / "skills" / name / "scripts" / script)
+        )
 
-    # 4. Project scope.
-    candidates.append(("project", base_cwd / ".claude" / "skills" / name / "scripts" / script))
+    # 4. Project scope — same three adapter directories.
+    for adapter_dir in _USER_SCOPE_CAPABLE_ADAPTER_DIRS:
+        candidates.append(
+            ("project:" + adapter_dir, base_cwd / adapter_dir / "skills" / name / "scripts" / script)
+        )
 
     for _kind, path in candidates:
         if path.is_file():

--- a/docs/rfc/0009-codex-native-skills.md
+++ b/docs/rfc/0009-codex-native-skills.md
@@ -1,9 +1,9 @@
 # RFC-0009: Migrate Codex adapter from managed-block AGENTS.md to native .agents/skills/
 
-- **Status:** Draft
+- **Status:** Accepted
 - **Author:** eugenelim
 - **Date opened:** 2026-05-25
-- **Date closed:**
+- **Date closed:** 2026-05-25
 - **Related:** [RFC-0001](0001-bundle-distribution-by-adapter-spec.md)
   introduced the per-IDE adapter contract this RFC modifies.
   [RFC-0005](0005-user-scope-hook-support.md) is precedent for the same

--- a/docs/rfc/0011-pack-allowed-adapters.md
+++ b/docs/rfc/0011-pack-allowed-adapters.md
@@ -1,0 +1,274 @@
+# RFC-0011: Per-pack `allowed-adapters` declaration for user-scope adapter resolution
+
+- **Status:** Open
+- **Author:** eugenelim
+- **Date opened:** 2026-05-25
+- **Date closed:**
+- **Builds on:**
+  - [RFC-0004](0004-install-scope-per-pack.md) — defines the `[pack.install]` table this RFC extends with a new field (existing fields unchanged).
+  - [RFC-0005](0005-user-scope-hook-support.md) — precedent for an adapter-targeted contract bump.
+  - [RFC-0004 § Unresolved questions](0004-install-scope-per-pack.md#unresolved-questions) — implements the open lean *"Should `[pack.install]` carry more fields than `default-scope` and `allowed-scopes`?"*.
+- **Builds on (continued):** [RFC-0009](0009-codex-native-skills.md) (Accepted 2026-05-25). RFC-0009's code shipped in commit `49061e6` (PR #113) and is governance-ratified; the codex `direct-directory` skill projection at `.agents/skills/` is the live contract entry RFC-0011 extends with a `[adapter.codex.scope]` user-root table. No standalone `Depends on:` — RFC-0009 closed before RFC-0011 opens for review.
+
+## Summary
+
+Add a per-pack `[pack.install] allowed-adapters = [...]` declaration to `pack.toml`, applied uniformly at both scopes: at user scope it picks the target adapter (`claude-code` / `kiro` / `codex`); at repo scope it constrains the projection fan-out to the adapters' directories named in the list. Adds an adopter-side `--adapter` CLI flag on `install` for the user-scope multi-IDE adopter and a module-level constant `agentbundle.scope.DEFAULT_USER_SCOPE_ADAPTER` (default: `"claude-code"`) as the greenfield fallback. Replaces the agents-presence heuristic at `_resolve_user_scope_target_adapter` in `packages/agentbundle/agentbundle/commands/install.py:1249-1275`, whose docstring already names this RFC as the intended fix. Adds an `[adapter.codex.scope]` table to the contract pointing user-scope codex installs at `~/.agents/skills/` (per [Codex's skills documentation](https://developers.openai.com/codex/skills): *"`$HOME/.agents/skills` — any skills checked into the user's personal folder. Use to curate skills relevant to a user that apply to any repository the user may work in."*). Adapter-contract bump `0.5 → 0.6`; `allowed-adapters` is **optional** — omitting it defaults to "all shipped adapters" (current behaviour at repo scope, agents-presence heuristic at user scope). Codex plugins (`~/.codex/plugins/cache/...`, `.codex-plugin/plugin.json`) are a separate install route, addressed by a sibling RFC modeled on RFC-0008's Claude-plugins parity — not this RFC.
+
+## Motivation
+
+A Kiro-only adopter installing `agentbundle install --pack atlassian --scope user .` against this catalogue today lands the pack's skills in `~/.claude/skills/` — for an IDE they do not run. The four user-scope-capable packs we ship (`atlassian`, `figma`, `converters`, `contracts`) all resolve to Claude Code through the agents-presence heuristic, because none of them ships `.apm/agents/*.md` (they are skills-only). There is no override.
+
+The cost of inaction:
+
+- **The catalogue's user-scope dimension is silently single-adapter.** RFC-0004 landed user scope deliberately ahead of any consumer; RFC-0005 lifted Kiro out of `degraded-info-log` and gave it a working `[scope]` table; RFC-0007 brought the first user-scope pack home; RFC-0009 (Accepted) flipped Codex to filesystem-discovered skills at `.agents/skills/` whose `$HOME` variant is itself the third user-scope target. The integration test all four RFCs paid for *does not actually exercise Kiro or Codex at user scope* — every user-scope pack we ship resolves to Claude Code by construction. The Kiro work is dead code from the adopter's perspective; Codex hasn't even been admitted into the user-scope set.
+- **Adopter copies files by hand.** A Kiro user wanting the `jira` skill today copies `dist/apm/atlassian/skills/jira/` into `~/.kiro/skills/jira/`; a Codex user copies into `~/.agents/skills/jira/` — both outside the CLI, outside upgrade, outside uninstall, outside the Tier model. Exactly the Tier-3 squatter problem RFC-0001 set out to prevent and RFC-0004 extended to user scope for every primitive *except* the one that mattered to them. (Notwithstanding the hand-copy workaround, the `atlassian/flow-metrics` skill's sibling-script discovery was Claude-Code-only by hardcode — see the *Atlassian portability fix* note in § *Follow-on artifacts*. Fixed on this RFC's branch.)
+- **The install-time TODO is load-bearing.** `_resolve_user_scope_target_adapter`'s docstring (install.py:1255-1260) names a corner case the heuristic provably mishandles: *"a Copilot-only pack with hooks (no agents) silently resolves to `claude-code` here."* The heuristic is a proxy that worked for the v0.2/v0.3/v0.4 packs we shipped and stops working the moment a pack's content portability does not correlate with its agents-presence.
+- **The validate-time twin is the same shape.** `_kiro_target_adapters` in `validate.py:351-389` infers Kiro targeting from "`.apm/agents/` + `.apm/hook-wiring/` + v0.3 contract" — another heuristic that would simplify against an explicit declaration. Both call sites converge on `allowed-adapters` cleanly.
+
+Why now: the dimension has shipped, two adapters declare working user-scope roots ([RFC-0005 § Adapter-level scope roots](0005-user-scope-hook-support.md#proposal)), Codex's user-scope shape (`~/.agents/skills/`) is documented upstream and reachable as soon as RFC-0009's projection flip lands, and four packs are sitting on the user-scope shelf already declaring `default-scope = "user"`. The asymmetry is fully built; the resolver is the missing piece.
+
+## Proposal
+
+### The `allowed-adapters` field
+
+`[pack.install]` gains an `allowed-adapters` array under the new adapter-contract version `0.6`:
+
+```toml
+[pack]
+name = "atlassian"
+version = "0.1.0"
+
+[pack.adapter-contract]
+version = "0.6"
+
+[pack.install]
+default-scope = "user"
+allowed-scopes = ["user", "repo"]
+allowed-adapters = ["claude-code", "kiro", "codex"]
+```
+
+The semantic is **uniform across both scopes**: `allowed-adapters` declares the set of adapters this pack's content is shaped for. The `allowed-scopes` field controls *where* the install lands (repo / user / both); `allowed-adapters` controls *which adapters' projection targets get written to*.
+
+- **Optional.** Omitting `allowed-adapters` means "any shipped adapter that has a projection target for the install's scope." This matches current behaviour: repo-scope `agentbundle install` fans out to every adapter's projection-target directory (`.claude/skills/`, `.kiro/skills/`, `.agents/skills/`, `.github/instructions/`); user-scope resolution falls through to the legacy agents-presence heuristic at `_resolve_user_scope_target_adapter`. Legacy `< 0.6` packs (including the four shipped repo-only packs) need no migration — they continue to project everywhere by default.
+- **Declared = constrain at both scopes.**
+  - **At repo scope:** `agentbundle install` projects only into the declared adapters' directories. A pack declaring `allowed-adapters = ["claude-code", "kiro", "codex"]` does *not* write `<repo>/.github/instructions/<name>.md` at repo scope. The Copilot projection target is skipped.
+  - **At user scope:** the resolver walks `allowed-adapters` in declared order against the adapter-root probe (CLI home directories: `~/.claude/`, `~/.kiro/`, `~/.codex/`). The `--adapter` flag overrides the probe — see § *Resolution at install time*.
+- **Adapter values constrained by the live contract.** The pack-schema validator reads `adapter.toml` and refuses any value that does not name a shipped adapter. For user-scope use (when `"user" ∈ allowed-scopes`), the named adapter must also declare an `[adapter.<name>.scope]` table with a `user` root — otherwise the schema refuses with `pack.toml: [pack.install] allowed-adapters contains '<name>', which does not declare a user-scope root in the v0.6 adapter contract`. For repo-scope-only packs, any shipped adapter is admissible (Copilot is fine here even though it has no user-scope projection). Under v0.6, user-scope-capable: `{"claude-code", "kiro", "codex"}`; repo-scope-capable: those three plus `"copilot"`.
+- **No separate `default-adapter` scalar.** A separate field would duplicate the array's first element in nearly every case and add a `default-adapter ∈ allowed-adapters` cross-field invariant the schema would need to enforce. The greenfield default — for adopters whose machines have *no* matching CLI home — comes from a module-level constant (see § *Resolution at install time*), not the pack's TOML.
+
+### Resolution at install time
+
+User-scope adapter resolution is a four-step lookup, in order:
+
+1. **`--adapter` CLI flag.** Highest priority. `agentbundle install --pack <name> --scope user --adapter kiro .` resolves to `kiro` unconditionally, bypassing the probe and the greenfield fallback. Bound to `--scope user` only — at repo scope, the flag is rejected with `install: --adapter is bound to --scope user`. Adapter-vs-pack admissibility check:
+   - If the pack declares `allowed-adapters`, the requested adapter must be in that set. Otherwise refused: `install: --adapter <name> not in pack's allowed-adapters set`.
+   - If the pack omits `allowed-adapters` (either a `< 0.6` pack or a v0.6 pack that didn't declare the field), the requested adapter must name a shipped *user-scope-capable* adapter under the live contract — i.e. an adapter declaring `[adapter.<name>.scope].user`. Today: `{"claude-code", "kiro", "codex"}`. A `--adapter copilot` invocation is refused regardless because Copilot has no user-scope root. This matches the schema's `__derived_from_adapter_toml__` enum semantics: when the pack does not constrain, the live contract does. See § *CLI surface* for the argparse entry.
+2. **Contract version gate.** If the pack's `[pack.adapter-contract] version >= "0.6"` and `allowed-adapters` is declared, consult it. If the pack is `< 0.6` *or* declares no `allowed-adapters`, fall through to step 4 (legacy heuristic) — no migration forced.
+3. **Adapter-root probe.** Walk `allowed-adapters` in declared order; for each candidate, check whether the adopter's home shows evidence the adapter is in use. The probe signal per adapter — its **CLI home directory**, created when the adopter first runs the IDE:
+   - `claude-code` ⇒ `~/.claude/` exists?
+   - `kiro` ⇒ `~/.kiro/` exists?
+   - `codex` ⇒ `~/.codex/` exists *or* `~/.agents/skills/` exists?
+     *(Codex stores plugins and config under `~/.codex/`; skills land under the shared `~/.agents/skills/` per upstream convention. The probe checks both because the upstream docs do not pin whether the Codex CLI creates `~/.codex/` on a skills-only first run independent of plugins use — an empirical gap captured in § *Unresolved questions*. The OR-probe ensures a Codex adopter with either signal resolves correctly.)*
+
+   The first matching adapter wins. **Greenfield fallback:** if no CLI home matches, the resolver picks the value of the module-level constant `agentbundle.scope.DEFAULT_USER_SCOPE_ADAPTER` (default: `"claude-code"`) if that value is in the pack's `allowed-adapters`, otherwise `allowed-adapters[0]`. Install prints `installed: <pack> @ <scope> via <adapter>` on success (extending the `installed: <pack> @ <scope>` rail RFC-0004 set; the `via <adapter>` clause fires only at user scope, where adapter selection is non-obvious).
+4. **Legacy heuristic (`< 0.6` packs or v0.6 packs omitting `allowed-adapters`).** Unchanged: `.apm/agents/*.md` present ⇒ `kiro`; else `claude-code`. **Inherited bug:** the legacy heuristic carries a documented same-name-Kiro-agent silent-overwrite limitation at `install.py:1262-1267`. This RFC retains the legacy path *as-is* — the limitation is not re-litigated here. v0.6 packs that *declare* `allowed-adapters` bypass the heuristic entirely; a future RFC retires the heuristic and addresses the limitation when no live pack relies on it.
+
+The function `_resolve_user_scope_target_adapter` keeps its name. Its docstring TODO block is rewritten to: *"RFC-0011 landed `[pack.install] allowed-adapters` under contract v0.6 plus the `--adapter` CLI flag and the `DEFAULT_USER_SCOPE_ADAPTER` module constant. v0.6+ packs declaring `allowed-adapters` resolve via the four-step lookup; this function's legacy branch covers `< 0.6` packs and v0.6 packs omitting the field."*
+
+The user-scope projection dispatch at install.py:1170-1178 (currently a two-arm `if target_adapter == "kiro": kiro.project(...) else: claude_code.project(...)`) gains a third arm calling `codex.project(...)`. The codex adapter's user-scope projection is the same `direct-directory` tree-copy logic the live `[[adapter.codex.projection]]` entry at adapter.toml:217-237 already uses for repo scope, rooted at `~/.agents/skills/` instead of `<repo>/.agents/skills/`.
+
+### Repo-scope projection fan-out
+
+`agentbundle install --scope repo` projects pack content into every adapter's per-IDE directory simultaneously (today's behaviour, unchanged for `< 0.6` packs and v0.6 packs that omit `allowed-adapters`). When a v0.6 pack *declares* `allowed-adapters`, the projection filter skips adapters not in the declared list — no write to their repo-scope projection target. A pack declaring `allowed-adapters = ["claude-code", "kiro", "codex"]` at repo scope writes `<repo>/.claude/skills/<name>/`, `<repo>/.kiro/skills/<name>/`, and `<repo>/.agents/skills/<name>/`, but does NOT write `<repo>/.github/instructions/<name>.md` (Copilot's projection target).
+
+**Implementation surface.** Repo-scope projection fan-out is driven by the recipe pipeline at `packages/agentbundle/agentbundle/render.py` (`render_pack` → `render_pack_to_dir` → `run_recipe`). Each recipe runs per-adapter projections through `agentbundle.build.adapters.<name>.project()`. The filter lands at the recipe-level adapter loop: before invoking `<adapter>.project(...)` for a given pack, the runner reads the pack's `[pack.install] allowed-adapters` and skips the call when the adapter is not in the list. The exact line(s) the filter touches are picked by the implementation spec — candidates are `run_recipe` and `render_pack_to_dir` at `render.py:63-97`, plus whatever the per-adapter projection-target enumeration loop lands at in `install.py`. Same skip applies symmetrically inside any adapter-iterating loop that pre-dates this RFC.
+
+### CLI surface
+
+`agentbundle install`'s argparse setup at `cli.py:199-229` gains:
+
+```python
+sp.add_argument(
+    "--adapter",
+    choices=_user_scope_capable_adapters_from_contract(),  # derived at CLI-load
+    help=(
+        "Override the auto-detected adapter at user scope. "
+        "Bound to --scope user; rejected at repo scope. "
+        "Refused if the named adapter is not in the pack's allowed-adapters."
+    ),
+)
+```
+
+The `choices` tuple is **derived from the bundled `adapter.toml`** at CLI-load time — same hydration pattern as the schema's `__derived_from_adapter_toml__` enum (§ *Schema validation*). It enumerates adapters declaring `[adapter.<name>.scope].user`. Today: `("claude-code", "kiro", "codex")`. When a future RFC adds Copilot user-scope (or any other adapter's scope table), the argparse choices widen automatically — no `cli.py` edit required. A test pins the derivation against the live contract so contract drift breaks the test rather than silently producing wrong CLI behaviour.
+
+The module-level constant lives at `packages/agentbundle/agentbundle/scope.py`:
+
+```python
+# Greenfield-fallback default for user-scope installs when no CLI home
+# matches and --adapter was not passed. Treated by the resolver as a
+# preference, not a hard pick — the value must be in the pack's
+# allowed-adapters set; otherwise the resolver picks allowed-adapters[0].
+DEFAULT_USER_SCOPE_ADAPTER: str = "claude-code"
+```
+
+### Contract bump `0.5 → 0.6`
+
+`packages/agentbundle/agentbundle/_data/adapter.toml`'s `[contract] version` bumps from `"0.5"` to `"0.6"` and gains two changes:
+
+1. The pack-schema requirement above (`allowed-adapters` required for v0.6 user-scope packs).
+2. A new `[adapter.codex.scope]` table mirroring `claude-code` and `kiro`:
+
+   ```toml
+   [adapter.codex.scope]
+   repo = "."
+   user = "~"
+   allowed-prefixes.user = [".agents/skills/", ".agentbundle/"]
+   ```
+
+   The `.agents/skills/` prefix matches Codex's documented skills location (`$HOME/.agents/skills/`); `.agentbundle/` matches the cross-adapter convention RFC-0004 set for the user-scope state file at `~/.agentbundle/state.toml`. The prefix is intentionally narrowed to `.agents/skills/` rather than `.agents/` — a broader prefix would permit writes anywhere under `~/.agents/`, including the Codex marketplace catalogue at `~/.agents/plugins/marketplace.json` (a file this RFC does not write and a sibling RFC will own). Narrowing now keeps the write-jail discipline of *"each RFC's contract opens only the subtrees it actually needs."* When the codex-plugins-install-route-parity sibling RFC lands, it widens to add `.agents/plugins/` per its own decisions.
+
+There are no other projection-table changes, no new `mode` values, no rail shifts in this bump. RFC-0009's projection-mode flip for the codex `skill` primitive (from `managed-block-inline` to `direct-directory`) already shipped in commit `49061e6`; this RFC builds on the live `[[adapter.codex.projection]]` entry at lines 217-221 of the current `adapter.toml` and does not re-author it.
+
+The four shipped user-scope packs (`atlassian`, `figma`, `converters`, `contracts`) — which currently declare `[pack.adapter-contract] version = "0.2"` because they consume only the user-scope dimension RFC-0004 landed — bump straight to `"0.6"` and declare `allowed-adapters = ["claude-code", "kiro", "codex"]` in the implementation PR. The jump skips v0.3/v0.4/v0.5 cleanly because those bumps were forks for hook-wiring (RFC-0005), claude-plugins-install-route (RFC-0008), and apm-install-route (RFC-0010) — none of which affects skill-only user-scope packs. Repo-only packs (`core`, `governance-extras`, `user-guide-diataxis`, `monorepo-extras`) do **not** bump — their content is unchanged.
+
+The repo's other heuristic, `_kiro_target_adapters` in `validate.py:351`, is similarly augmented: for v0.6+ packs, the rail consults `allowed-adapters` (Kiro in the set ⇒ Kiro-targeted); for `< 0.6` packs, the existing on-disk inference (agents + wiring + v0.3) stays. Both heuristics are kept; both gain an early-return for v0.6+ packs.
+
+### Schema validation
+
+`pack.schema.json` gains under `[pack.install]`:
+
+```json
+{
+  "allowed-adapters": {
+    "type": "array",
+    "items": {"type": "string", "enum": ["__derived_from_adapter_toml__"]},
+    "minItems": 1,
+    "uniqueItems": true
+  }
+}
+```
+
+The `enum` is hydrated at validate time from `adapter.toml`'s set of all shipped adapters — `{"claude-code", "kiro", "codex", "copilot"}` under v0.6. The validator's per-value check is scope-aware: any shipped adapter name is admissible *if* the pack's `allowed-scopes` does not include `"user"`; for user-scope-eligible packs, each value must also name an adapter that declares an `[adapter.<name>.scope]` table with a `user` root (today: `{"claude-code", "kiro", "codex"}`). A user-scope-eligible pack listing `"copilot"` in `allowed-adapters` is refused: `pack.toml: [pack.install] allowed-adapters contains 'copilot', which does not declare a user-scope root in the v0.6 adapter contract; either remove 'copilot' or drop 'user' from allowed-scopes`.
+
+`allowed-adapters` itself is **optional** — no required-when-user-scope rule. The schema accepts omission and the resolver falls back per § *Resolution at install time*.
+
+**Publisher-vs-installer contract drift.** Schema validation runs in two places — `agentbundle validate` at publish time (against whatever `adapter.toml` is on disk in the catalogue clone) and `agentbundle install` at install time (against the bundled contract in the installed CLI). A pack validated against an older contract checkout can declare an adapter the *current* contract no longer admits — e.g. a v0.6 pack written before a hypothetical future RFC narrows the set. Install re-runs the enum check against the bundled contract and refuses with stderr: `install: pack '<name>' declares allowed-adapter '<adapter>' which is not admitted by adapter contract v<X.Y> shipped with agentbundle <cli-version>`. The publisher-vs-installer version-skew rail is named in `agent-spec-cli/spec.md` and inherited here; the message is the new addition.
+
+### What this RFC does NOT do
+
+- **No new `[pack.install]` constraints beyond `allowed-adapters`.** Future per-pack fields (e.g. a `requires-confirmation` flag for user-scope packs, named in RFC-0004's Unresolved Questions) are out of scope.
+- **No Codex *plugins* install route.** Codex ships [a plugins surface separate from skills](https://developers.openai.com/codex/plugins/build) — package format `.codex-plugin/plugin.json`, install location `~/.codex/plugins/cache/$MARKETPLACE/$PLUGIN/$VERSION/`, marketplace catalogue at `~/.agents/plugins/marketplace.json`. This is a *new install route* analogous to Claude plugins ([RFC-0008](0008-claude-plugins-install-route-parity.md)) and APM ([RFC-0010](0010-apm-install-route-parity.md)), not an adapter-resolution decision. A sibling RFC modeled on RFC-0008's shape — *codex-plugins-install-route-parity* — adds `codex-plugins` to the codex adapter's `install-routes`, lands per-pack `dist/codex-plugins/<pack>/.codex-plugin/plugin.json`, aggregates a marketplace, and wires the install→adapt chain. That work is orthogonal to this RFC; the two can land in either order.
+- **No re-resolution on upgrade.** A pack installed at user scope is upgraded against the same adapter root it was installed under, recorded in state. Switching adapters at upgrade time is a re-install, not an upgrade — `agentbundle uninstall --scope user` followed by `agentbundle install --scope user --adapter <name>`. Upgrade's existing `_resolve_user_scope_target_adapter` call (upgrade.py:218, 228, 308, 311) reads `allowed-adapters` through the same lookup but only for the adapter the pack is already installed under.
+- **No deletion of the legacy heuristic.** The agents-presence heuristic at `_resolve_user_scope_target_adapter` stays for `< 0.6` packs and v0.6 packs that omit `allowed-adapters`. Deleting it earns its own future RFC once no live pack relies on it.
+
+## Alternatives considered
+
+1. **Do nothing — keep the heuristic.** The four shipped user-scope packs continue to land in `~/.claude/` for every adopter; Kiro adopters keep hand-copying. RFC-0004's and RFC-0005's investment in the user-scope dimension and Kiro's `[scope]` table stays partially-realized. The install.py TODO stays open indefinitely. *Rejected.* The asymmetry between "Kiro can host user-scope content per the contract" and "no shipped pack ever lands there" is the load-bearing motivation; doing nothing perpetuates it.
+
+2. **Imperative `--adapter` flag on `install`, no `pack.toml` field.** Adopter passes `--adapter kiro` against any user-scope-eligible pack; install writes to `~/.kiro/skills/` regardless of pack-author intent. *Rejected as the sole mechanism* — but the imperative flag is **adopted as the escape valve** in combination with the declarative field (see item 3). The flag without the field loses the publisher's portability declaration; a pack whose content is Claude-Code-specific cannot signal that, and `--adapter kiro` against it writes broken content to `~/.kiro/skills/`. The field constrains *which* adapters the flag can target.
+
+3. **Both declarative `allowed-adapters` and imperative `--adapter`.** *Adopted as the v1 surface.* Original Draft of this RFC rejected this in favour of declarative-only; adversarial review surfaced that the declarative-only resolution routes the modal multi-IDE adopter (anyone with `~/.claude/` already on disk) silently to Claude Code with no escape valve. Adopting the flag closes that gap. The flag is `--adapter <name>`, bound to `--scope user`, refused if the requested adapter is not in the pack's `allowed-adapters`. Docker `--platform` + manifest list is the closest external precedent: manifest declares supported platforms, client picks among them. The flag's footgun (Kiro adopter passes `--adapter claude-code` against a Kiro-only pack) is closed by the schema check — `allowed-adapters` is the constraint.
+
+4. **Auto-detect from `~/.<ide>/` presence; no `pack.toml` field.** Drop `allowed-adapters` entirely; pick whichever adapter root exists on the adopter's machine. Cheaper still. *Rejected.* Loses the publisher's portability declaration — a pack whose content is Claude-Code-specific (an agent body referencing Claude Code's `model:` frontmatter shape, a skill that names `.claude/agents/`) cannot signal that to the installer; auto-detect would land it under a Kiro adopter's `~/.kiro/`, half-broken. The four shipped user-scope packs happen to be portable; a future personal-reviewer pack with Claude-Code-shaped agents would not be, and the contract has to support both.
+
+5. **Reuse `allowed-scopes` semantics — overload the scope field with adapter pairs (e.g. `allowed-scopes = ["repo", "user@claude-code", "user@kiro"]`).** Avoids a new field. *Rejected.* Mixes two dimensions (scope, adapter) into one string-formatted array; the schema validator has to parse the `@` separator; existing call sites that read `allowed-scopes` as a `{repo, user}` set would have to dispatch on whether each entry contains an `@`. A separate array on the same `[pack.install]` table is the boring, obvious shape.
+
+6. **Originally rejected — `allowed-adapters` at repo scope.** The original Draft of this RFC treated `allowed-adapters` as scope-conditional (user-scope only) and rejected extending the constraint to repo scope as "a different decision with different motivation." *Adopted in the final design.* The single-field uniform semantic (apply the constraint at whichever scope the adopter installs into) is cleaner than two parallel fields or a scope-conditional field whose name doesn't reflect the conditional. Repo-scope projection now skips adapters not in `allowed-adapters`. Per "Don't write two fields where one will do" — and the name-vs-semantic surprise the scope-conditional shape would have created is gone.
+
+7. **Land `allowed-adapters` under v0.5 (no contract bump).** Add the field as optional under the existing contract version; existing packs need no version change. *Rejected.* RFC-0004's precedent is strict: a new required field gets a contract bump so adopters can detect compatibility at the schema level (a v0.5 CLI consuming a v0.6 pack rightly refuses; a v0.6 CLI consuming a v0.5 pack falls through to the heuristic). An optional field under v0.5 leaves no signal for either direction, and the AC25 corner case (Copilot-only pack with hooks, no agents) the install-time TODO names stays open because the field is opt-in.
+
+8. **Land `allowed-adapters` for `{claude-code, kiro}` only; add Codex via amendment once RFC-0009 Accepts.** Ship two adapters now, add the third later. *Rejected* — moot now that RFC-0009 is Accepted (closed 2026-05-25). Codex's user-scope shape (`~/.agents/skills/`, per the upstream skills documentation) is documented, stable, and the live adapter-contract entry (commit 49061e6, adapter.toml:217-237). The `[adapter.codex.scope]` table is a four-line addition with no design question still open. Splitting it into an amendment would mean two contract bumps (v0.5 → v0.6 → v0.7) for what is genuinely one decision — *"which adapters are user-scope-capable, and where does each one's user root live?"*
+
+9. **Bundle Codex *plugins* into this RFC.** Cover the `~/.codex/plugins/` install route alongside the `~/.agents/skills/` user-scope target. *Rejected.* The plugins surface is a new install route — same architectural shape as RFC-0008 (Claude plugins) and RFC-0010 (APM). Each of those landed as a single-route RFC with a per-pack `SessionStart` writer, marketplace aggregation, dist-route emission, and the install→adapt chain wiring. Folding all of that into this RFC would mix two decisions (adapter resolution at user scope; new install-route plumbing) into one PR — exactly the bundling-failure mode RFC-0008 and RFC-0010 were each split out from. See § *What this RFC does NOT do* for the sibling-RFC pointer.
+
+10. **Heuristic refuse-and-explain — no contract bump, no pack-side field.** The smallest possible fix: amend `_resolve_user_scope_target_adapter` to refuse-and-explain when the heuristic cannot decide (multiple `~/.<ide>/` populated, pack has no agents but ships hook-wiring for a non-default adapter, etc.), instead of silently guessing. No contract bump, no `allowed-adapters` field, no four-pack updates, no RFC-0009 dependency. *Rejected for two reasons.* (a) It closes the AC25 corner case named in the install.py TODO — *but only that corner case.* The load-bearing motivation isn't AC25; it's that *the catalogue's user-scope dimension is single-adapter for skills-only packs by construction*. Refuse-and-explain on the heuristic doesn't open Kiro or Codex; it just makes the silent failure noisier. Adopters wanting `jira` in Kiro still cannot get there. (b) The heuristic's domain is bounded by what filesystem evidence the pack provides (presence of `.apm/agents/`); for skills-only packs, no amount of refuse-and-explain disambiguates which adapter the *author* wrote the pack for. The four shipped skills-only packs would either be uniformly refused (everyone now blocked) or uniformly silent-defaulted (status quo, with extra error prose). Neither closes the motivation. *Worth recording* because the heuristic-refinement path is the steelman alternative-1 ("do nothing useful") that this RFC has to beat — and the rebuttal is the load-bearing motivation, not the AC25 corner case.
+
+## Drawbacks
+
+- **Contract bump cost.** v0.5 → v0.6 is the fourth contract bump since RFC-0004 (v0.1 → v0.2, then v0.3 / v0.4 / v0.5 for hooks / claude-plugins / apm). The four shipped user-scope packs jump from `[pack.adapter-contract] version = "0.2"` straight to `"0.6"`; CLI versions older than the v0.6 cut cannot install them. Mitigation: the refuse-and-explain message names the required CLI version. Adopters on older CLI versions who do not need adapter selection (Claude Code users on default behaviour) can stay on the older CLI and install older versions of the four packs — but new pack versions ship under v0.6 and are not backportable. The bump is also small in surface area (one new field, one new validator branch) compared to the v0.2 / v0.3 bumps.
+
+- **First v0.6 pack is the integration test.** Like RFC-0004 was for user scope and RFC-0005 was for Kiro user-scope hooks, this RFC's contract bump has no production consumer until the four shipped user-scope packs bump and declare `allowed-adapters`. The integration test runs against fixture `~/.kiro/`, `~/.claude/`, and `~/.agents/skills/` trees in the implementation spec; production exposure is the first Kiro or Codex adopter installing `atlassian` at user scope post-merge. The first real-adopter transcripts close documented gaps, not open them — but they do expose whatever environment-specific failure modes exist (locked `~/.kiro/`, Windows path handling for `~/.kiro/skills/`, Kiro IDE running while the install writes; for Codex, the `~/.agents/skills/` tree's interaction with whatever else writes there, since `.agents/` is also where Codex's plugins marketplace lives).
+
+- **Builds on RFC-0009.** The codex `direct-directory` projection at `.agents/skills/` (RFC-0009, Accepted 2026-05-25, commit `49061e6`) is the live adapter-contract entry this RFC's `[adapter.codex.scope]` table extends. No standalone sequencing dependency remains.
+
+- **The multi-IDE adopter needs to know about `--adapter`.** An adopter with `~/.claude/` already on disk (anyone who has ever used Claude Code) running `agentbundle install --pack atlassian --scope user .` resolves to Claude Code by probe order, regardless of whether they're actually trying to install into Kiro or Codex. The `--adapter` flag (§ *CLI surface*) is the documented escape valve, but adopters need to know it exists. The `installed: ... via claude-code` print line names which adapter the resolver picked but does not surface the flag's existence. **Mitigation:** the README install section and the per-adapter how-to guides name `--adapter` explicitly in their worked examples; the install-time print line is candidate for a one-line `(other declared adapters: kiro, codex; use --adapter to override)` suffix when `allowed-adapters` has more than one matching entry and `--adapter` was not passed. The implementation spec freezes whether the suffix ships in v1 or stays prose-only.
+
+- **Two heuristics stay alive for legacy packs.** `_resolve_user_scope_target_adapter` (install.py:1249) and `_kiro_target_adapters` (validate.py:351) keep their pre-RFC behaviour for `< 0.6` packs. The repo carries both a declarative and a heuristic resolver indefinitely — `< 0.6` packs never go away (RFC-0004 set the same precedent for `< 0.2`). Mitigation: code paths are clearly versioned; the docstring TODO is rewritten to point at the v0.6 path. Deleting the heuristic earns its own future RFC once no live pack declares `< 0.6`.
+
+- **Out-of-tree packs need to know about the change.** A third-party catalogue publishing user-scope packs under v0.6 must declare `allowed-adapters`; an out-of-tree pack at an earlier contract version continues to work via the heuristic. The migration note (see § *Follow-on artifacts*) covers the upgrade; the schema's refuse-and-explain message names the field by full path.
+
+- **v0.6 pack with `default-scope = "user"` but omitted `allowed-adapters` falls through to the legacy heuristic.** The optional-field shape (chosen for backward-compatibility) means a v0.6 pack that *intends* user-scope use but forgets to declare `allowed-adapters` re-introduces the AC25 corner case (Copilot-only pack with hooks, no agents → silent `claude-code` resolution). The four shipped user-scope packs declare the field explicitly; third-party packs may not. **Mitigation:** the `v05-to-v06-pack-upgrade.md` how-to recommends declaring `allowed-adapters` whenever `default-scope = "user"` is set; the `agentbundle validate` warning surface (deferred per § *Drawbacks* "ignored on repo-only packs" predecessor) could escalate to a Warning here in a future minor bump. Not strict-refusal in v1 because that would break backward-compat for any v0.6 third-party pack that intentionally wants the heuristic.
+
+- **Repo-scope projection skip is a behaviour change for v0.6 packs.** Today's repo-scope `agentbundle install` fans out to every shipped adapter's projection-target directory (`.claude/skills/`, `.kiro/skills/`, `.agents/skills/`, `.github/instructions/`). Under v0.6 with `allowed-adapters` declared, adapters not in the list are skipped. The four shipped user-scope packs declaring `allowed-adapters = ["claude-code", "kiro", "codex"]` would no longer project to `<repo>/.github/instructions/<name>.md` at repo scope. This is arguably an improvement (Copilot's instruction-file shape for skills-only packs is a degraded artifact), but it IS a behaviour change adopters running `--scope repo` for the four packs will notice. Legacy `< 0.6` packs and v0.6 packs omitting `allowed-adapters` are unaffected.
+
+- **Adapter set is read from `adapter.toml` at schema-validation time, not at install time.** See § *Schema validation — Publisher-vs-installer contract drift* for the rail and the install-time refuse-and-explain message; this Drawbacks bullet exists to surface the *cost*, not restate the mechanism. The cost is one additional refusal mode at install time that an adopter can hit on a previously-validated pack — small, but a real cliff if a future contract narrowing drops an adapter.
+
+- **Reversal cost if RFC-0009 is later superseded.** RFC-0009 is Accepted (2026-05-25), so this is a hypothetical safety net. If a future RFC supersedes RFC-0009 and reverts the codex `direct-directory` projection mode, RFC-0011's codex paragraphs amend out: drop the `[adapter.codex.scope]` table from `adapter.toml`, remove the codex arm of `_resolve_user_scope_target_adapter` and the user-scope projection dispatch, narrow the schema's adapter enum to `{claude-code, kiro}`, and drop `"codex"` from each shipped user-scope pack's `allowed-adapters`. The flow-metrics three-adapter probe stays (correctness work independent of codex's user-scope governance). PR commit history is the executable trace; no separate inventory section needed.
+
+## Prior art
+
+**In repo:**
+
+- [RFC-0004 § Per-pack default and allowance](0004-install-scope-per-pack.md#per-pack-default-and-allowance) — establishes `[pack.install]` as the declarative home for pack-author install constraints; pins the anti-silent-default rule this RFC follows for `allowed-adapters`.
+- [RFC-0004 § Unresolved questions](0004-install-scope-per-pack.md#unresolved-questions) — explicitly asked: *"Should `[pack.install]` carry more fields than `default-scope` and `allowed-scopes`?"* This RFC is one answer.
+- [RFC-0005 § Adapter-level scope roots](0005-user-scope-hook-support.md#proposal) — adds Kiro's `[scope]` table with `~/.kiro/` user-root; without this RFC's declarative resolver, the table is reachable only by the agents-presence heuristic.
+- [RFC-0007 § Pack shape](0007-user-scope-converter-pack.md#pack-shape) — first user-scope pack (`converters`) was the first that demonstrably could not reach Kiro at user scope via the heuristic (skills-only, no `.apm/agents/`).
+- [RFC-0005](0005-user-scope-hook-support.md), [RFC-0008](0008-claude-plugins-install-route-parity.md), and [RFC-0010](0010-apm-install-route-parity.md) — the three intervening contract bumps (v0.2 → v0.3 → v0.4 → v0.5) that the four shipped user-scope packs skipped past at `[pack.adapter-contract] version = "0.2"` (their content doesn't touch hooks, claude-plugins, or APM install routes). This RFC bumps them straight to v0.6.
+- [RFC-0009 § Adapter contract change](0009-codex-native-skills.md#adapter-contract-change) (Accepted 2026-05-25) — flipped Codex skill projection to `direct-directory` at `.agents/skills/`. This RFC builds on that flip: the `[adapter.codex.scope]` table this RFC adds reuses the same projection target, rerooted at `$HOME`.
+- `_resolve_user_scope_target_adapter` (install.py:1249) and `_kiro_target_adapters` (validate.py:351) — sibling heuristics the v0.6 path replaces; both keep their pre-RFC behaviour for legacy packs.
+- `feedback_pressure_test_before_adding` — the four-question test the user-task framing invokes; applied to both candidate shapes in § *Alternatives considered* items 2 and 3.
+
+**External:**
+
+- [PEP 621 — Declaring project metadata](https://peps.python.org/pep-0621/) — `requires-python` is purely declarative; no install-time `--python` override. Authoritative precedent for declarative-only when the publisher has the information.
+- [Cargo features](https://doc.rust-lang.org/cargo/reference/features.html) — packages declare named features; unknown features are refused at parse time. Schema-validated enum derived from the project itself — same shape as this RFC's `adapter.toml`-derived enum.
+- [Cargo `--target` + `[target.'cfg(...)'.dependencies]`](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies) — hybrid declarative + imperative, but the imperative half exists because the *machine* (CPU architecture) has authoritative information the publisher lacks. For IDE adapters, the adopter's filesystem provides that signal already, justifying the asymmetry: declarative-only here is not "we skipped half the pattern," it's "the imperative half was never load-bearing."
+- [npm `engines`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#engines) — declares supported Node/npm versions; soft warning by default, hard refusal with `engineStrict`. No `--node` override. Precedent for the soft/hard split (we land hard; soft can wait for a documented use).
+- [Docker manifest lists / `--platform`](https://docs.docker.com/build/building/multi-platform/) — closest hybrid analogue; client passes `--platform` when multiple match. Different problem: image runtime is a CPU/OS pair the publisher cannot detect; IDE adapter is a filesystem signal we *can* detect. Cited for why the analogy fails, not for why it applies.
+- [Homebrew bottle DSL](https://docs.brew.sh/Bottles) — formulas declare supported macOS versions; installer picks. Pure declarative, no override flag in the user-facing CLI. Strong precedent for "publisher declares, installer picks."
+- [Codex Skills documentation](https://developers.openai.com/codex/skills) — pins `$HOME/.agents/skills` as the user-level location ("any skills checked into the user's personal folder. Use to curate skills relevant to a user that apply to any repository the user may work in"), with project-level locations at `$CWD/.agents/skills`, `$CWD/../.agents/skills`, and `$REPO_ROOT/.agents/skills`. The `[adapter.codex.scope]` table in this RFC consumes that pin directly.
+- [Codex Plugins documentation](https://developers.openai.com/codex/plugins/build) — separate surface; pins `~/.codex/plugins/cache/$MARKETPLACE/$PLUGIN/$VERSION/` for installed plugins and `~/.agents/plugins/marketplace.json` for the personal marketplace catalogue. Cited here as the shape a sibling RFC (codex-plugins-install-route-parity) will consume; out of scope for this RFC per § *What this RFC does NOT do*.
+
+No external precedent found for an imperative-only adapter override without a corresponding declarative manifest — every comparable ecosystem either pairs the flag with a manifest or omits the flag entirely. § *Alternatives considered* item 2 names that absence as supporting evidence.
+
+## Unresolved questions
+
+- **Should the `installed: ... via <adapter>` print line surface the other eligible adapters?** When `allowed-adapters` has more than one matching CLI home and `--adapter` was not passed, the resolver picks one silently in declared order. A `(other declared adapters: ...; use --adapter to override)` suffix would make the alternatives visible. Author's lean: **yes — the suffix ships in v1.** It's two lines of code, the cost is stderr verbosity for an audience that has explicitly opted into multi-IDE complexity. The implementation spec freezes the exact wording.
+- **What happens when none of `~/.claude/`, `~/.kiro/`, or `~/.agents/skills/` exists?** Author's lean: **create `allowed-adapters[0]`'s root and proceed.** Same shape as Claude Code's greenfield handling today (`~/.claude/skills/` is created on first install). The first-listed adapter becomes the implicit default for fresh-machine adopters, which gives pack authors a meaningful ordering choice. The implementation spec pins a Tests entry for the three-way greenfield case.
+- **Does the `~/.codex/` probe signal hold for skills-only Codex adopters?** Author's lean: **probe both `~/.codex/` and `~/.agents/skills/` (OR-condition) until the upstream behaviour is pinned.** The upstream Codex docs name `~/.agents/skills/` as the skills home and `~/.codex/plugins/cache/` as the plugins cache, but do not pin whether the Codex CLI creates `~/.codex/` on a skills-only first run. If empirical testing shows `~/.codex/` is plugins-only, the OR-probe collapses to `~/.agents/skills/` alone (which leaves the fresh-Codex-skills-adopter case for the implicit greenfield default). The implementation spec adds a test against a fixture `$HOME` with only `~/.agents/skills/` populated, plus one with only `~/.codex/` populated, plus one with both.
+- **Does the schema validator's enum hydration belong in `pack.schema.json` or in `agentbundle validate`?**  Author's lean: **in the validator** (Python code reads the contract; the JSON schema's `enum` is a documentation hint, not the load-bearing rule). Pure JSON schema can't express "enum derived from another file"; the validator already runs adapter-aware rails (RFC-0004's marker grep, RFC-0005's hook-wiring checks). Keeping the rule in code is the lower-friction shape.
+- **Should the migration note for third-party pack authors live in the same how-to as the v0.1 → v0.2 upgrade?** Author's lean: **separate how-to.** The v0.1 → v0.2 guide is structured around the contract bump *and* the new `[pack.install]` table; this RFC's v0.5 → v0.6 upgrade is a one-field add against an existing table, much smaller scope. A new `docs/guides/how-to/v05-to-v06-pack-upgrade.md` keeps the cross-bump diff legible and avoids overloading the older guide.
+- **Should this RFC absorb RFC-0009 outright?** Author's lean: **no — sequence, don't bundle.** RFC-0009 carries its own load-bearing decisions (orphan-skill cleanup policy, same-name-skill collision rule, legacy AGENTS.md managed-block strip, retained-vs-removed test inventory across two test roots) that have nothing to do with adapter resolution at user scope. Bundling would make this RFC a 600-line decision artifact instead of a focused one. The hard `Depends on:` declaration and the implementation-spec task ordering are sufficient to keep the work sequenced without conflating the two decision sets.
+
+## Follow-on artifacts
+
+On acceptance — **single PR per RFC-0004's spec-amendment-atomicity precedent** ([RFC-0004 Drawbacks line 547](0004-install-scope-per-pack.md#drawbacks)). The CLI changes, schema changes, contract bump, and pack-toml updates ship together so a partially-landed RFC does not leave the CLI in an incoherent state.
+
+- **Spec:** `docs/specs/pack-allowed-adapters/spec.md` (via `new-spec`) — defines the work as a sequence of plan tasks. Acceptance Criteria cover: the v0.5 → v0.6 contract bump in `_data/adapter.toml` (including the new `[adapter.codex.scope]` table with `user = "~"`, `allowed-prefixes.user = [".agents/skills/", ".agentbundle/"]`); the `allowed-adapters` schema in `pack.schema.json` with `adapter.toml`-derived enum (field optional; default-to-all when omitted); the four-step dispatch in `_resolve_user_scope_target_adapter` (flag → contract gate → CLI-home probe → greenfield-constant fallback); the parallel dispatch in `_kiro_target_adapters`; the user-scope projection dispatch at install.py:1170-1178 gaining a third arm for `codex.project`; the repo-scope projection filter that skips adapters not in `allowed-adapters`; the `--adapter` argparse entry on `install`; the `DEFAULT_USER_SCOPE_ADAPTER` module constant at `agentbundle/scope.py`; the four shipped user-scope packs' `[pack.adapter-contract] version` bump (0.2 → 0.6) and `allowed-adapters = ["claude-code", "kiro", "codex"]` declaration; the install-time print `installed: <pack> @ <scope> via <adapter>` and its multi-eligible suffix; the schema refuse-and-explain messages for unknown adapter, non-user-scope-adapter-in-user-scope-pack, `--adapter`-not-in-allowed-adapters, `--adapter`-at-repo-scope; the install-time publisher-vs-installer version-skew refuse-and-explain message; and the integration test matrix that installs each of the four packs against fixture `~/.claude/`, `~/.kiro/`, `~/.codex/`, and `~/.agents/skills/` trees (greenfield, single-IDE, two-of-three combinations, all-three, plus the `--adapter <name>` override). **Atlassian portability fix landed alongside this RFC.** Adversarial review surfaced that `discover_skill_path` in `packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/upstream.py` hardcoded `~/.claude/skills/<name>/` and `<cwd>/.claude/skills/<name>/` as the user-scope and project-scope sibling-skill probe candidates — an atlassian install at user scope under Kiro or Codex would have silently failed at runtime when flow-metrics tried to resolve `jira` or `jira-align`. **Fixed in this RFC's branch** (commit on `eugenelim/pack-allowed-adapters`): user-scope and project-scope probes now walk all three user-scope-capable adapter directories (`.claude/`, `.kiro/`, `.agents/`) in declared order, with priority-2 sibling lookup still winning when flow-metrics and its sibling skill are co-installed under the same root. The `config.py` docstring example updated alongside. Pinned in this PR by `packages/agentbundle/tests/unit/test_flow_metrics_upstream_probe.py` — 8 parametrized cases covering all three adapter dirs at user-scope, all three at project-scope, env-override precedence, and the all-miss error case. `pytest` passes locally. The implementation spec inherits this test; no new module needed. **The test surface spans two test roots** per the repo's existing convention — `packages/agentbundle/tests/` (CLI / resolver / install / upgrade integration) and `packages/agentbundle/agentbundle/build/tests/` (contract / schema / adapter-projection). The implementation spec splits its Tests entries accordingly.
+
+- **ADR:** *Adapter selection at user scope is declarative+imperative — per-pack `allowed-adapters` declares the supported set; the adopter's `--adapter` flag picks among them at install time. A module-level constant supplies the greenfield fallback. Codex user-scope skills land in `~/.agents/skills/` per the upstream Codex skills documentation.* Records the rejection of § *Alternatives considered* items 4, 5, 7, 8, 9, 10 and the adoption of items 2/3 (combined) and 6.
+
+- **CLI changes** (inside the implementation spec, not a separate artifact): `_resolve_user_scope_target_adapter` rewrite (install.py:1249 — four-step lookup with `--adapter` flag, contract-version gate, three-arm CLI-home probe, and module-constant greenfield fallback); `_kiro_target_adapters` v0.6 early-return (validate.py:351); user-scope projection dispatch at install.py:1170-1178 gains a `codex.project` branch; repo-scope projection filter that skips adapters not in `allowed-adapters` when the field is declared; install-time print line with optional `(other declared adapters: ...; use --adapter to override)` suffix; refuse-and-explain on schema violations and adapter-vs-allowed-adapters mismatches. The argparse setup at `cli.py:199-229` gains `--adapter` (choices: user-scope-capable adapters from the live contract; bound to `--scope user`). A new module-level constant `DEFAULT_USER_SCOPE_ADAPTER` lands at `packages/agentbundle/agentbundle/scope.py` (default value: `"claude-code"`).
+
+- **Pack updates** (same PR): four shipped user-scope packs (`atlassian`, `figma`, `converters`, `contracts`) bump `[pack.adapter-contract] version = "0.6"` and add `allowed-adapters = ["claude-code", "kiro", "codex"]`. Repo-only packs are unchanged.
+
+- **README updates** (file: `README.md`):
+  - The `Packs` table row for each user-scope pack notes the adapter targets explicitly (e.g. "lands in `~/.claude/skills/`, `~/.kiro/skills/`, or `~/.agents/skills/` depending on which IDE you run").
+  - The `Install` section's `Where to run these` paragraph picks up a one-line note about user-scope adapter resolution.
+  - The `Where primitives land` table at `README.md` § *Where primitives land* makes user-scope adapter selection explicit and adds the Codex row (which today the table abbreviates with "Copilot omitted for brevity" — Codex is shown but the row dates from before RFC-0009; refresh the cell content to reflect the post-RFC-0009 `.agents/skills/` shape and add the `~/.agents/skills/` user-scope target alongside).
+
+- **How-to guides** (one per non-Claude-Code adapter at user scope):
+  - `docs/guides/how-to/install-user-scope-pack-into-kiro.md` — Kiro adopter's install path: prerequisites (`~/.kiro/` exists), the `agentbundle install --pack <name> --scope user .` invocation, the `installed: ... via kiro` confirmation line, upgrade/uninstall verbs.
+  - `docs/guides/how-to/install-user-scope-pack-into-codex.md` — Codex adopter's install path: prerequisites (Codex CLI with skills support, which requires RFC-0009's landing), the same invocation, the `installed: ... via codex` confirmation line, the `~/.agents/skills/` discovery model, the interaction with `~/.agents/plugins/marketplace.json` (skills and plugins share the `.agents/` parent dir but live in disjoint subtrees), upgrade/uninstall verbs.
+
+  Both cross-linked from the README install section.
+
+- **Author docs:** the `add-credentialed-skill` skill body and `docs/specs/skill-secrets/spec.md` each gain one paragraph: *"If your pack's content is portable across IDEs (skills-only, no IDE-specific agent shape), list every adapter in `allowed-adapters` that supports user scope. The two credentialed packs in this catalogue (`atlassian`, `figma`) list `claude-code`, `kiro`, and `codex` because their skills are pure text + Python and travel cleanly across all three adapters' user-scope skill directories."* No change to credential loading (skill-secrets AC3 untouched).
+
+- **Migration note for third-party pack authors:** `docs/guides/how-to/v05-to-v06-pack-upgrade.md` — covers the `[pack.adapter-contract] version` bump, the `allowed-adapters` field shape, the three currently-admitted adapter values (`claude-code`, `kiro`, `codex`), the schema's refuse-and-explain messages, and the legacy path for older packs.
+
+- **`docs/CONVENTIONS.md`** — no edit required. The pack source-of-truth section already covers the `[pack.install]` table at the right granularity; `allowed-adapters` slots in without a section addition.
+
+- **`docs/ROADMAP.md`** — entry added under "user-scope": *"`allowed-adapters` landed — Kiro and Codex user-scope installs now exercise the integrated path; next: codex-plugins install-route parity (sibling RFC, modeled on RFC-0008)."*
+
+- **Sibling RFC (not gated on this RFC's acceptance):** *codex-plugins-install-route-parity* — adds `codex-plugins` to `[adapter.codex.install-routes]`, lands per-pack `dist/codex-plugins/<pack>/.codex-plugin/plugin.json`, aggregates a marketplace at `dist/codex-plugins/marketplace.json`, wires the install→adapt chain via a per-pack `SessionStart`-equivalent writer. Modeled on [RFC-0008](0008-claude-plugins-install-route-parity.md) and [RFC-0010](0010-apm-install-route-parity.md); load-bearing decisions to make in that RFC's own research phase include Codex's `interface` field semantics on `plugin.json`, the marketplace-catalogue location split (`~/.agents/plugins/marketplace.json` vs `~/.codex/plugins/cache/`), and whether the existing `claude-plugins` SessionStart pattern transfers verbatim or needs a Codex-specific lifecycle hook.

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -14,8 +14,9 @@
 | [0006](0006-skill-secrets-storage.md) | Credential storage for credentialed skills — tiered env/keyring/dotfile + two-layer architecture | Accepted | 2026-05-24 | 2026-05-24 |
 | [0007](0007-user-scope-converter-pack.md) | First user-scope pack — `converters` (file-to-markdown, markdown-to-html, msg-to-markdown) | Accepted | 2026-05-24 | 2026-05-24 |
 | [0008](0008-claude-plugins-install-route-parity.md) | Claude-plugins install-route parity — per-pack SessionStart writer for the install→adapt chain | Accepted | 2026-05-24 | 2026-05-25 |
-| [0009](0009-codex-native-skills.md) | Migrate Codex adapter from managed-block AGENTS.md to native `.agents/skills/` | Draft | 2026-05-25 | |
+| [0009](0009-codex-native-skills.md) | Migrate Codex adapter from managed-block AGENTS.md to native `.agents/skills/` | Accepted | 2026-05-25 | 2026-05-25 |
 | [0010](0010-apm-install-route-parity.md) | APM install-route parity — per-pack SessionStart writer projected through APM's HookIntegrator | Accepted | 2026-05-25 | 2026-05-25 |
+| [0011](0011-pack-allowed-adapters.md) | Per-pack `allowed-adapters` declaration for user-scope adapter resolution | Open | 2026-05-25 | |
 
 ## Adding a new RFC
 

--- a/packages/agentbundle/tests/unit/test_flow_metrics_upstream_probe.py
+++ b/packages/agentbundle/tests/unit/test_flow_metrics_upstream_probe.py
@@ -1,0 +1,135 @@
+"""Regression test for the flow-metrics upstream-skill probe across the
+three user-scope-capable adapter directories.
+
+Pinned by RFC-0011 (Per-pack `allowed-adapters` declaration). Before this
+RFC's branch, `discover_skill_path` hardcoded `~/.claude/skills/` as the
+sole user-scope and project-scope candidate. The fix walks `.claude`,
+`.kiro`, and `.agents` for both user and project scope so the atlassian
+pack works under all three user-scope-capable adapters.
+
+This test pins:
+- claude / kiro / codex user-scope each resolve when the sibling-walk
+  (priority 2) misses;
+- project scope under any of the three adapters works the same way;
+- the priority-1 env-var override remains the runtime escape valve
+  documented in `discover_skill_path`'s docstring.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Locate the flow-metrics module under the catalogue's pack tree.
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_FLOW_METRICS_SCRIPTS = (
+    _REPO_ROOT
+    / "packs"
+    / "atlassian"
+    / ".apm"
+    / "skills"
+    / "flow-metrics"
+    / "scripts"
+)
+
+
+@pytest.fixture
+def upstream(monkeypatch):
+    """Import `flow_metrics.upstream` with its scripts dir on `sys.path`,
+    then repoint `_THIS_SKILL_DIR` at a scratch directory so the
+    priority-2 sibling walk reliably misses — isolating the
+    priority-3/-4 user/project candidates this test exercises."""
+    sys.path.insert(0, str(_FLOW_METRICS_SCRIPTS))
+    try:
+        import flow_metrics.upstream as up
+    finally:
+        sys.path.pop(0)
+
+    with tempfile.TemporaryDirectory() as scratch:
+        scratch_path = Path(scratch) / "flow-metrics-installed"
+        scratch_path.mkdir()
+        monkeypatch.setattr(up, "_THIS_SKILL_DIR", scratch_path)
+        yield up
+
+
+@pytest.mark.parametrize("adapter_dir", [".claude", ".kiro", ".agents"])
+def test_user_scope_probe_across_three_adapters(upstream, adapter_dir, monkeypatch):
+    """priority-3 user-scope walk resolves under each of the three
+    user-scope-capable adapter directories."""
+    with tempfile.TemporaryDirectory() as home:
+        home_path = Path(home)
+        script = home_path / adapter_dir / "skills" / "jira" / "scripts" / "jira.py"
+        script.parent.mkdir(parents=True)
+        script.write_text("# stub\n")
+
+        monkeypatch.setenv("HOME", str(home_path))
+        monkeypatch.delenv("FLOW_METRICS_JIRA_SCRIPT", raising=False)
+
+        found = upstream.discover_skill_path("jira", cwd=Path("/nonexistent-cwd"))
+        assert found == script, f"adapter={adapter_dir}: got {found}"
+
+
+@pytest.mark.parametrize("adapter_dir", [".claude", ".kiro", ".agents"])
+def test_project_scope_probe_across_three_adapters(upstream, adapter_dir, monkeypatch):
+    """priority-4 project-scope walk resolves under each of the three
+    adapter directories rooted at `cwd`."""
+    with tempfile.TemporaryDirectory() as proj, tempfile.TemporaryDirectory() as home:
+        proj_path = Path(proj)
+        script = proj_path / adapter_dir / "skills" / "jira" / "scripts" / "jira.py"
+        script.parent.mkdir(parents=True)
+        script.write_text("# stub\n")
+
+        # Empty HOME so user-scope candidates don't accidentally match.
+        monkeypatch.setenv("HOME", str(Path(home)))
+        monkeypatch.delenv("FLOW_METRICS_JIRA_SCRIPT", raising=False)
+
+        found = upstream.discover_skill_path("jira", cwd=proj_path)
+        assert found == script, f"adapter={adapter_dir}: got {found}"
+
+
+def test_env_override_wins_over_user_scope(upstream, monkeypatch):
+    """The priority-1 env override remains the documented runtime escape
+    valve for adopters who want a specific adapter root regardless of
+    probe order (mirrors the install-time `--adapter` flag admitted in
+    RFC-0011 as the user-scope adopter's escape valve)."""
+    with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as override:
+        home_path = Path(home)
+        # Place a sibling under ~/.claude/ that would win priority 3
+        # were the env override absent.
+        decoy = home_path / ".claude" / "skills" / "jira" / "scripts" / "jira.py"
+        decoy.parent.mkdir(parents=True)
+        decoy.write_text("# decoy\n")
+
+        # The override target.
+        override_path = Path(override) / "jira.py"
+        override_path.write_text("# override\n")
+
+        monkeypatch.setenv("HOME", str(home_path))
+        monkeypatch.setenv("FLOW_METRICS_JIRA_SCRIPT", str(override_path))
+
+        found = upstream.discover_skill_path("jira", cwd=Path("/nonexistent-cwd"))
+        assert found == override_path, f"override should win; got {found}"
+
+
+def test_all_candidates_miss_raises_with_seven_paths(upstream, monkeypatch):
+    """When no candidate resolves, the error names every probed path
+    (1 sibling + 3 user + 3 project = 7 paths when no env override is
+    set). Regression check on the candidate-list length so future
+    edits to `_USER_SCOPE_CAPABLE_ADAPTER_DIRS` are caught."""
+    with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as proj:
+        monkeypatch.setenv("HOME", str(Path(home)))
+        monkeypatch.delenv("FLOW_METRICS_JIRA_SCRIPT", raising=False)
+
+        with pytest.raises(upstream.UpstreamNotFoundError) as excinfo:
+            upstream.discover_skill_path("jira", cwd=Path(proj))
+
+        # The error message names every candidate path.
+        msg = str(excinfo.value)
+        # 3 user + 3 project = 6 adapter-rooted candidates plus 1 sibling.
+        for adapter_dir in (".claude", ".kiro", ".agents"):
+            assert f"{adapter_dir}/skills/jira" in msg, (
+                f"missing candidate for {adapter_dir} in error: {msg}"
+            )

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/config.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/config.py
@@ -42,7 +42,11 @@ def _find_skill_root(start: Optional[Path] = None) -> Path:
     both ``SKILL.md`` and ``references/`` is found.
 
     Layout-agnostic so the same resolver works for user-scope installs
-    (``~/.claude/skills/flow-metrics/``) and in-pack development trees
+    under any of the three user-scope-capable adapters
+    (``~/.claude/skills/flow-metrics/`` for claude-code,
+    ``~/.kiro/skills/flow-metrics/`` for kiro,
+    ``~/.agents/skills/flow-metrics/`` for codex per Codex's upstream
+    skills docs) and in-pack development trees
     (``<repo>/packs/atlassian/.apm/skills/flow-metrics/``). During
     development the
     ``SKILL.md`` file may not exist yet (T12 ships it); in that case we

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/upstream.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/upstream.py
@@ -117,18 +117,36 @@ def _module_name_for_script(name: str) -> str:
     return name.replace("-", "_")
 
 
+_USER_SCOPE_CAPABLE_ADAPTER_DIRS: Tuple[str, ...] = (".claude", ".kiro", ".agents")
+
+
 def discover_skill_path(name: str, *, env: Optional[Mapping[str, str]] = None, cwd: Optional[Path] = None) -> Path:
     """Locate the upstream skill's CLI entry script.
 
-    Probe order (per spec/plan):
+    Probe order:
 
     1. ``$FLOW_METRICS_<NAME>_SCRIPT`` env var (testing override).
-    2. ``<this-skill-dir>/../<name>/scripts/<name>.py`` (sibling layout).
-    3. ``~/.claude/skills/<name>/scripts/<name>.py`` (user scope).
-    4. ``<cwd>/.claude/skills/<name>/scripts/<name>.py`` (project scope).
+    2. ``<this-skill-dir>/../<name>/scripts/<name>.py`` (sibling layout —
+       covers same-adapter user-scope installs *and* in-pack development).
+    3. ``~/<adapter-dir>/skills/<name>/scripts/<name>.py`` (user scope),
+       walked across every user-scope-capable adapter directory:
+       ``.claude`` (claude-code), ``.kiro`` (kiro), ``.agents`` (codex —
+       per Codex's upstream skills documentation, skills land under the
+       shared ``$HOME/.agents/skills/`` not under ``~/.codex/``).
+    4. ``<cwd>/<adapter-dir>/skills/<name>/scripts/<name>.py`` (project
+       scope), same three adapter directories.
 
     First hit wins. None match → :class:`UpstreamNotFoundError` naming
     every candidate.
+
+    **Multi-root precedence.** When the same upstream skill is installed
+    under more than one adapter root (e.g. both ``~/.claude/skills/jira/``
+    and ``~/.kiro/skills/jira/``), priority 3's declared order is
+    ``claude → kiro → codex`` — claude wins by default. Adopters who
+    want a specific adapter set the priority-1 env override
+    ``FLOW_METRICS_<NAME>_SCRIPT`` to the exact script path; that's the
+    documented runtime escape valve. The install-time analogue lives in
+    ``agentbundle install --scope user --adapter <name>`` per RFC-0011.
     """
     e = env if env is not None else os.environ
     base_cwd = cwd if cwd is not None else Path.cwd()
@@ -136,22 +154,33 @@ def discover_skill_path(name: str, *, env: Optional[Mapping[str, str]] = None, c
 
     candidates: List[Tuple[str, Path]] = []
 
-    # 1. Env override. Honored even if the file doesn't exist *iff* the
-    #    user explicitly set it — but we still require the file to be a
-    #    real file before returning, so a typo'd override falls through
-    #    to the next candidate rather than silently failing later.
+    # 1. Env override appended as a candidate. The `is_file()` check
+    #    below means a typo'd override falls through to the next
+    #    candidate rather than silently failing later.
     env_value = e.get(_env_var_name(name))
     if env_value:
         candidates.append(("env:" + _env_var_name(name), Path(env_value)))
 
-    # 2. Sibling layout under this skill's parent dir.
+    # 2. Sibling layout under this skill's parent dir. This already
+    #    handles the common case where flow-metrics and its upstream
+    #    sibling skill are co-installed under the same adapter root
+    #    (the sibling walk lands one level above flow-metrics' own dir,
+    #    so it works for any adapter the install put us under).
     candidates.append(("sibling", _THIS_SKILL_DIR.parent / name / "scripts" / script))
 
-    # 3. User scope.
-    candidates.append(("user", Path.home() / ".claude" / "skills" / name / "scripts" / script))
+    # 3. User scope — walked across all three user-scope-capable adapter
+    #    directories. Order is claude/kiro/codex, matching the probe
+    #    order in `_resolve_user_scope_target_adapter`.
+    for adapter_dir in _USER_SCOPE_CAPABLE_ADAPTER_DIRS:
+        candidates.append(
+            ("user:" + adapter_dir, Path.home() / adapter_dir / "skills" / name / "scripts" / script)
+        )
 
-    # 4. Project scope.
-    candidates.append(("project", base_cwd / ".claude" / "skills" / name / "scripts" / script))
+    # 4. Project scope — same three adapter directories.
+    for adapter_dir in _USER_SCOPE_CAPABLE_ADAPTER_DIRS:
+        candidates.append(
+            ("project:" + adapter_dir, base_cwd / adapter_dir / "skills" / name / "scripts" / script)
+        )
 
     for _kind, path in candidates:
         if path.is_file():


### PR DESCRIPTION
## What does this change?

Opens RFC-0011 proposing a per-pack `[pack.install] allowed-adapters` field under adapter-contract v0.6, applied uniformly at both scopes. Co-lands the atlassian/flow-metrics three-adapter probe fix (with regression tests) that adversarial review surfaced as a load-bearing precondition for the RFC's portability claim. Flips RFC-0009 (codex native skills — code already shipped in #113) from Draft → Accepted in the same PR so its governance status matches reality.

## Why?

The user-scope dimension shipped (RFC-0004) and Kiro's `[scope]` table shipped (RFC-0005), but every user-scope-capable pack still resolves to Claude Code via the agents-presence heuristic at `install.py:1249` — the install-time TODO names this RFC as the intended fix. A Kiro or Codex adopter installing `agentbundle install --pack atlassian --scope user .` today silently writes to `~/.claude/skills/` for an IDE they don't run. RFC-0011 closes that gap and extends the same declarative constraint to repo-scope projection.

- Spec: [`docs/rfc/0011-pack-allowed-adapters.md`](docs/rfc/0011-pack-allowed-adapters.md)
- Builds on: [RFC-0004](docs/rfc/0004-install-scope-per-pack.md), [RFC-0005](docs/rfc/0005-user-scope-hook-support.md), [RFC-0009](docs/rfc/0009-codex-native-skills.md) (Accepted in this PR)

## How do I verify it?

- Read [`docs/rfc/0011-pack-allowed-adapters.md`](docs/rfc/0011-pack-allowed-adapters.md) end-to-end. Six rounds of adversarial review closed clean.
- `cd packages/agentbundle && python -m pytest tests/unit/test_flow_metrics_upstream_probe.py` — 8 parametrized tests pin the three-adapter probe across user/project scope, env-override precedence, and all-miss error.
- `python3 tools/hooks/pre-pr.py` — all enforcement-triplet gates pass.
- Confirm RFC-0009 status flip is consistent: [`docs/rfc/0009-codex-native-skills.md`](docs/rfc/0009-codex-native-skills.md) shows Accepted 2026-05-25; [`docs/rfc/README.md`](docs/rfc/README.md) index matches.

## What did you not change that you considered?

- **The legacy heuristic at `install.py:1249`** stays for `< 0.6` packs and v0.6 packs that omit `allowed-adapters`. Deleting it earns its own RFC once no live pack relies on it — see § *What this RFC does NOT do*.
- **Codex plugins install route** (`~/.codex/plugins/cache/...`, `.codex-plugin/plugin.json`, marketplace) — deferred to a sibling RFC modeled on RFC-0008's claude-plugins parity. Surfaced in chat; rationale recorded in § *What this RFC does NOT do* and § *Alternatives considered* item 9.
- **`default-adapter` scalar field** — `allowed-adapters[0]` plus the `DEFAULT_USER_SCOPE_ADAPTER` module constant cover the greenfield case without a parallel pack-level scalar.
- **Implementation** — no code changes to `install.py`, `cli.py`, `validate.py`, or `adapter.toml`. Those land in the follow-on spec PR after RFC-0011 reaches Accepted. The flow-metrics fix is in scope here only because adversarial review surfaced it as a load-bearing precondition for the RFC's claims, and a regression test ships alongside (per memory rule `feedback_rfc_code_precondition`).