### PR TITLE
RFC-0012 AC24 (a)/(b) in-band detection + AC33 follow-ons

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -185,7 +185,7 @@ classes 2–4 LLM-judgment writes under the per-scope path-jail).
   preparatory evidence, not closing per AC4a's *(c)* contract
   ("captured against a real adopter session").
 
-## `repo-scope-per-adapter-projection` — in flight (T1-T9 landed)
+## `repo-scope-per-adapter-projection` — in flight (T1-T9 landed; AC24 + AC33 follow-ons landed)
 
 Spec: [`specs/repo-scope-per-adapter-projection/spec.md`](specs/repo-scope-per-adapter-projection/spec.md).
 RFC: [`rfc/0012-repo-scope-per-adapter-projection.md`](rfc/0012-repo-scope-per-adapter-projection.md)
@@ -217,15 +217,27 @@ adapter-disagreement / orphan recovery) carries adopters across
 the v0.6 → v0.7 transition.
 
 - **Status as of 2026-05-26 (this session):** T1-T9 landed via a
-  single work-loop execution. ACs closed: AC1-AC23, AC25-AC33,
-  AC35-AC37 (subject to T11 final gate verification on the PR).
-  ACs partially closed / deferred to follow-up:
-  - **AC24** — in-band detection of pre-RFC-0012 state. The
-    orphan-recovery (c) trigger ships with T7; the (a)
-    adapter-disagreement and (b) shape-mismatch triggers are a
-    follow-up amendment.
-  - **AC34** — passing on the new tests + green elsewhere; will
-    re-verify on PR CI.
+  single work-loop execution. AC24 (a)/(b) + three AC33 integration
+  cases landed in PR #141 as a follow-on. ACs closed: AC1-AC37
+  (subject to T11 final gate verification on the PR).
+- **AC24 (a)/(b) follow-on landed in PR #141 (2026-05-26).** The
+  orphan-recovery (c) trigger shipped with T7 in PR #140; (a)
+  adapter-disagreement and (b) shape-mismatch shipped in PR #141
+  along with the three AC33 integration cases (upgrade-with-state-
+  hint defensive regression pin; migration-(b) e2e; migration-(a)
+  e2e). The implementer-chosen wording for (a) and (b) is named in
+  the PR body; a follow-on spec amendment can pin the strings
+  verbatim in AC24.
+- **Open follow-on items:**
+  - **Spec amendment** pinning the chosen (a)/(b) stderr wording
+    verbatim in AC24 — implementer's choice today; spec amendment
+    closes the loop.
+  - **Per-pack scoping of (c)'s artifact scan** — pre-existing AC22
+    limitation inherited verbatim. `safety.scan_for_pack_artifacts`
+    is adapter-prefix scoped; tightening to pack-name scoping is a
+    future surface (cross-pack false-positive only fires when an
+    orphan from a third pack sits under the same adapter prefix as
+    the pack being installed).
 - **Tasks landed (this session):**
   - **AC1, AC2, AC3, AC4** close with T1 (contract bump + scope
     tables + schema validator).

--- a/packages/agentbundle/agentbundle/commands/install.py
+++ b/packages/agentbundle/agentbundle/commands/install.py
@@ -290,9 +290,6 @@ def run(args: "argparse.Namespace") -> int:
         user_root = None
         user_state_path = None
 
-    installed_at_repo = pack_name in repo_state.packs
-    installed_at_user = user_state is not None and pack_name in user_state.packs
-
     # ── Step 3b: Dependency gate — [pack.dependencies.required] ──────────────
     # Resolves required deps against the union of repo + user state (AC17).
     # Gate runs before any write (and before the already-installed check, so
@@ -307,6 +304,63 @@ def run(args: "argparse.Namespace") -> int:
     except RuntimeError as exc:
         print(str(exc), file=sys.stderr)
         return 1
+
+    # ── Step 3c: RFC-0012 AC24 in-band detection (repo scope, per-IDE) ──
+    # Pre-RFC-0012 state must surface migration messaging *before* the
+    # already-installed branch fires its "use 'upgrade'" refusal —
+    # otherwise an adopter with stale state would receive misleading
+    # advice ("just upgrade") instead of the correct uninstall +
+    # reinstall path. Detection is gated to ``--scope repo`` without
+    # ``--emit-install-routes`` per spec AC24's narrowed-inference rule
+    # (the legacy dist-tree producer must not trigger (b) on its own
+    # output). The resolver is lifted here so the (a) trigger has a
+    # ``repo_target_adapter`` to compare against ``state.adapter``; the
+    # same values are reused downstream and the original computation
+    # block below is now a no-op for this code path.
+    _pack_allowed_adapters: list[str] | None = None
+    if isinstance(pack_install, dict):
+        _raw = pack_install.get("allowed-adapters")
+        if isinstance(_raw, list):
+            _pack_allowed_adapters = [s for s in _raw if isinstance(s, str)]
+    _pack_contract_version = pack_spec_version(pack_toml)
+    repo_target_adapter: str | None = None
+    allowed_prefixes_repo: list[str] | None = None
+    if requested_scope == "repo" and not emit_install_routes:
+        try:
+            repo_target_adapter = _resolve_target_adapter(
+                pack_dir,
+                scope="repo",
+                adapter=cli_adapter,
+                allowed_adapters=_pack_allowed_adapters,
+                contract_version=_pack_contract_version,
+                state_adapter=None,
+                command_name="install",
+            )
+        except _AdapterResolutionRefused as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+        allowed_prefixes_repo = _adapter_allowed_prefixes_repo(
+            repo_target_adapter
+        )
+        rc = _classify_pre_rfc0012_state(
+            output_root=output_root,
+            pack_name=pack_name,
+            repo_state=repo_state,
+            repo_target_adapter=repo_target_adapter,
+            allowed_prefixes_repo=allowed_prefixes_repo,
+            force=force,
+        )
+        if rc is not None:
+            return rc
+
+    # ``installed_at_*`` is computed AFTER Step 3c because (b)+--force
+    # drops the stale state row inside ``_classify_pre_rfc0012_state``
+    # so the subsequent install proceeds as a clean reinstall. Computing
+    # the flag before detection would cache pre-cleanup state and fire
+    # the misleading "use 'upgrade' to change version" refusal at
+    # Step 4 even after --force succeeded.
+    installed_at_repo = pack_name in repo_state.packs
+    installed_at_user = user_state is not None and pack_name in user_state.packs
 
     # ── Step 4: Branch on already-installed shape ─────────────────────────────
     # 4a. Already at requested scope → refuse (use 'upgrade'); --force does
@@ -349,12 +403,9 @@ def run(args: "argparse.Namespace") -> int:
     # one to Codex; RFC-0012 added one to Copilot. Resolve which
     # adapter the user-scope install targets via the six-step (0–5)
     # lookup and use that adapter's `allowed-prefixes.user`.
-    _pack_allowed_adapters = None
-    if isinstance(pack_install, dict):
-        _raw = pack_install.get("allowed-adapters")
-        if isinstance(_raw, list):
-            _pack_allowed_adapters = [s for s in _raw if isinstance(s, str)]
-    _pack_contract_version = pack_spec_version(pack_toml)
+    # ``_pack_allowed_adapters`` and ``_pack_contract_version`` were
+    # lifted to Step 3c above so the AC24 detection block can resolve
+    # the repo-target adapter early; reuse the same values here.
     # Only resolve the user-scope target adapter when user scope is in
     # this run's plan. Resolving unconditionally at scope="user" would
     # surface the user-scope-capability subcheck refusal (e.g.
@@ -378,61 +429,11 @@ def run(args: "argparse.Namespace") -> int:
             return 1
         allowed_prefixes_user = _adapter_allowed_prefixes_user(user_target_adapter)
 
-    # RFC-0012: at repo scope, when --emit-install-routes is NOT set,
-    # the install path is per-IDE projection (not dist-tree). Resolve
-    # the repo-target adapter via the six-step lookup at scope="repo"
-    # and capture the matching allowed-prefixes.repo for the path-jail.
-    # When --emit-install-routes IS set, we fall back to the legacy
-    # dist-tree behaviour and skip these (the dist-tree producer
-    # writes outside the per-IDE prefix set).
-    repo_target_adapter: str | None = None
-    allowed_prefixes_repo: list[str] | None = None
-    if requested_scope == "repo" and not emit_install_routes:
-        try:
-            repo_target_adapter = _resolve_target_adapter(
-                pack_dir,
-                scope="repo",
-                adapter=cli_adapter,
-                allowed_adapters=_pack_allowed_adapters,
-                contract_version=_pack_contract_version,
-                state_adapter=None,
-                command_name="install",
-            )
-        except _AdapterResolutionRefused as exc:
-            print(str(exc), file=sys.stderr)
-            return 1
-        allowed_prefixes_repo = _adapter_allowed_prefixes_repo(
-            repo_target_adapter
-        )
-
-        # RFC-0012 § *Reliability* (AC22): orphan-projection refusal.
-        # If state.toml has no row for the pack AND on-disk artifacts
-        # exist under the adapter's repo-scope prefix list, the prior
-        # install crashed mid-write. Without this check, Tier-2
-        # squatter logic would drop `.upstream.<ext>` companions next
-        # to every orphan. `--force` clears the orphans and proceeds.
-        if pack_name not in repo_state.packs:
-            orphans = safety.scan_for_pack_artifacts(
-                output_root, allowed_prefixes_repo
-            )
-            if orphans:
-                if force:
-                    for orphan in orphans:
-                        try:
-                            orphan.unlink()
-                        except OSError:
-                            pass
-                else:
-                    print(
-                        f"install: orphan projection files for pack "
-                        f"{pack_name} at "
-                        f"{_format_route_list([str(p) for p in orphans])} "
-                        f"— prior install interrupted; rerun with --force "
-                        f"to clean and reinstall, or delete the listed "
-                        f"paths and rerun",
-                        file=sys.stderr,
-                    )
-                    return 1
+    # RFC-0012 repo-scope per-IDE resolution: ``repo_target_adapter``
+    # and ``allowed_prefixes_repo`` were lifted to Step 3c above so the
+    # AC24 detection block (which covers the AC22 orphan-refusal path
+    # as trigger (c)) can run before the already-installed branch.
+    # No re-resolution here.
 
     # RFC-0005 AC25: refuse install --scope user against an adapter
     # that doesn't declare a working user-scope hook-wiring mode. The
@@ -945,6 +946,188 @@ def run(args: "argparse.Namespace") -> int:
             print(f"installed: {pack_name} @ {plan.scope}")
 
     return 0
+
+
+_INBAND_DETECTION_SEEN: set[tuple[str, str]] = set()
+"""RFC-0012 AC24 once-per-``(root, pack_name)`` short-circuit.
+
+Process-scoped mutable state. The detection block consults this set; an
+entry means "we already emitted a migration line for this (root, pack) in
+this process and any further ``install`` invocation should stay silent."
+Production ``agentbundle`` CLI invocations are short-lived processes so
+the set resets naturally; long-running embedders (an MCP shim that loops
+``install.run`` calls, a test harness) MUST reset via
+:func:`_clear_inband_detection_seen` between logical sessions or detection
+will silently skip on the second call."""
+
+
+def _clear_inband_detection_seen() -> None:
+    """Reset the once-per-session detection set.
+
+    Public-by-convention (single leading underscore) helper for callers
+    that need to bypass the once-per-process short-circuit — tests, and
+    any long-running embedder restarting an install loop. Prefer this
+    over reaching into :data:`_INBAND_DETECTION_SEEN` directly so the
+    storage shape can change without breaking callers.
+    """
+    _INBAND_DETECTION_SEEN.clear()
+
+
+def _scan_dist_tree_artifacts(root: Path, pack_name: str) -> list[Path]:
+    """Return pre-RFC-0012 dist-tree projection files for ``pack_name``.
+
+    Scans ``<root>/claude-plugins/<pack>/`` and ``<root>/apm/<pack>/`` —
+    the two per-pack subtrees the legacy ``per-pack-claude-plugin`` and
+    ``per-pack-apm-package`` recipes produce. Other top-level
+    directories (``.claude/`` etc.) belong to AC24 trigger (c)'s
+    ``safety.scan_for_pack_artifacts`` scan, not this one.
+    """
+    out: list[Path] = []
+    for top in ("claude-plugins", "apm"):
+        base = root / top / pack_name
+        if not base.exists():
+            continue
+        for entry in base.rglob("*"):
+            if entry.is_file():
+                out.append(entry)
+    return sorted(out)
+
+
+def _classify_pre_rfc0012_state(
+    *,
+    output_root: Path,
+    pack_name: str,
+    repo_state: "State",
+    repo_target_adapter: str,
+    allowed_prefixes_repo: list[str],
+    force: bool,
+) -> int | None:
+    """RFC-0012 AC24: in-band detection of pre-RFC-0012 state.
+
+    Triggers evaluated per-pack in precedence ``(b) → (a) → (c)``; only
+    the first match emits. Detection runs once per
+    ``(output_root, pack_name)`` per process; subsequent calls
+    short-circuit to silence.
+
+    Returns:
+      - ``None`` — no trigger fired, or ``--force`` cleared the
+        trigger's on-disk shape; caller proceeds with the install.
+      - ``1`` — refused with pinned stderr; caller returns 1.
+    """
+    from agentbundle import safety
+
+    key = (str(output_root), pack_name)
+    if key in _INBAND_DETECTION_SEEN:
+        return None
+
+    state_row = repo_state.packs.get(pack_name)
+
+    # (b) Shape-mismatch — state row exists AND dist-tree files exist.
+    # Pre-RFC-0012 signal per spec AC24: state.toml carries a row AND
+    # the on-disk shape is the legacy dist-tree (post-RFC-0012 the only
+    # code path producing those files is ``--emit-install-routes``,
+    # which short-circuits before this detection runs).
+    if state_row is not None:
+        dist_tree = _scan_dist_tree_artifacts(output_root, pack_name)
+        if dist_tree:
+            _INBAND_DETECTION_SEEN.add(key)
+            if force:
+                # AC25(vi): --force is the corrective action for (b)'s
+                # cross-invocation false positive — clean the dist-tree
+                # files AND drop the stale state row so the install
+                # proceeds as a clean reinstall. Without the row drop
+                # Step 4 would refuse with "use 'upgrade'", trapping the
+                # adopter in a loop (upgrade at repo scope re-emits the
+                # dist-tree shape today). The caller re-computes
+                # ``installed_at_repo`` after this helper returns; the
+                # on-disk state.toml is rewritten here too because the
+                # per-scope plan loop reloads state from disk at
+                # ``install.py:519`` (``load_state(for_write=True)``) and
+                # an in-memory-only pop would silently resurrect.
+                import shutil
+
+                from agentbundle.config import dump_state
+
+                for top in ("claude-plugins", "apm"):
+                    subtree = output_root / top / pack_name
+                    if subtree.exists():
+                        try:
+                            shutil.rmtree(subtree)
+                        except OSError:
+                            pass
+                repo_state.packs.pop(pack_name, None)
+                state_path = output_root / ".agentbundle-state.toml"
+                if state_path.exists():
+                    # Direct write (not ``safety.write_jailed``) because
+                    # the path *is* the jail anchor plus a fixed top-
+                    # level filename; the durability guarantee comes from
+                    # the post-install atomic rewrite at line ~809 a few
+                    # hundred milliseconds later. If detection is ever
+                    # lifted into a standalone verb, route through
+                    # ``safety.write_jailed`` for atomicity.
+                    state_path.write_text(
+                        dump_state(repo_state), encoding="utf-8"
+                    )
+                return None
+            print(
+                f"install: pre-RFC-0012 dist-tree files for pack "
+                f"{pack_name} at "
+                f"{_format_route_list([str(p) for p in dist_tree])} — "
+                f"state recorded but on-disk shape predates per-IDE "
+                f"projection; rerun with --force to clean and reinstall, "
+                f"or delete the listed paths and rerun",
+                file=sys.stderr,
+            )
+            return 1
+
+        # (a) Adapter disagreement — state row exists, no dist-tree
+        # files (so (b) didn't fire), AND resolver's pick disagrees
+        # with the recorded adapter. AC25(iii): the corrective action
+        # is uninstall + reinstall; ``--force`` does NOT clear this.
+        # ``state_row.adapter`` is always a non-empty string per
+        # ``load_state`` (defaults to "claude-code" at read time for
+        # absent / non-string values); no coercion needed.
+        recorded_adapter = state_row.adapter
+        if recorded_adapter != repo_target_adapter:
+            _INBAND_DETECTION_SEEN.add(key)
+            print(
+                f"install: state records adapter "
+                f"{recorded_adapter!r} for pack {pack_name}, but "
+                f"resolver picked {repo_target_adapter!r} — uninstall "
+                f"the pack at repo scope and reinstall to reconcile "
+                f"(cross-adapter install is not supported)",
+                file=sys.stderr,
+            )
+            return 1
+    else:
+        # (c) Orphan recovery — no state row AND per-IDE artifacts
+        # exist under the resolved adapter's allowed-prefixes.repo.
+        # The AC22 refusal text is preserved verbatim.
+        orphans = safety.scan_for_pack_artifacts(
+            output_root, allowed_prefixes_repo
+        )
+        if orphans:
+            _INBAND_DETECTION_SEEN.add(key)
+            if force:
+                for orphan in orphans:
+                    try:
+                        orphan.unlink()
+                    except OSError:
+                        pass
+                return None
+            print(
+                f"install: orphan projection files for pack "
+                f"{pack_name} at "
+                f"{_format_route_list([str(p) for p in orphans])} — "
+                f"prior install interrupted; rerun with --force to "
+                f"clean and reinstall, or delete the listed paths and "
+                f"rerun",
+                file=sys.stderr,
+            )
+            return 1
+
+    _INBAND_DETECTION_SEEN.add(key)
+    return None
 
 
 def _format_route_list(routes: list[str]) -> str:

--- a/packages/agentbundle/tests/integration/test_install_repo_scope_per_adapter.py
+++ b/packages/agentbundle/tests/integration/test_install_repo_scope_per_adapter.py
@@ -18,10 +18,14 @@ Coverage scope (vs. spec AC33's full matrix):
   - Per-adapter greenfield writes projection + state + stdout
     (claude-code default, kiro, codex, copilot).
   - `--emit-install-routes` dist-tree shape.
+  - Upgrade with state-hint at repo scope (AC10b parity).
+  - Migration trigger (b) shape-mismatch end-to-end.
+  - Migration trigger (a) adapter-disagreement end-to-end.
 
-Deferred to follow-up: cross-adapter upgrade with state-hint, the
-three migration triggers (b/a/c), and the (b)+(c) precedence test.
-The orphan-recovery case (c) ships in the unit tests already.
+The orphan-recovery case (c) ships in
+``tests/unit/test_install_inband_detection.py`` alongside the
+per-pack (b)+(c) precedence witness and the once-per-session
+short-circuit witness.
 """
 
 from __future__ import annotations
@@ -190,6 +194,222 @@ class RepoScopeEmitInstallRoutesTests(unittest.TestCase):
             self.assertIn("emitted install routes for core at", stdout)
             self.assertIn(" and ", stdout)  # the N=2 join rule
             self.assertIn("installed: core @ repo", stdout)
+
+
+def _clear_inband_detection_seen() -> None:
+    """Reset the once-per-session detection set between cases."""
+    from agentbundle.commands import install as _install_mod
+
+    _install_mod._clear_inband_detection_seen()
+
+
+def _plant_state_row(
+    adopter: Path,
+    *,
+    pack_name: str,
+    adapter: str = "claude-code",
+    installed_version: str = "0.1.0",
+) -> None:
+    """Write a minimal v0.3 state.toml with a single ``[pack.<name>]`` row.
+
+    Mirrors the fixture helper in
+    :mod:`tests.unit.test_install_inband_detection` — kept local rather
+    than imported to keep this module self-contained for the integration
+    suite.
+    """
+    import textwrap
+
+    adapter_line = ""
+    if adapter != "claude-code":
+        adapter_line = f'adapter = "{adapter}"\n'
+    state_path = adopter / ".agentbundle-state.toml"
+    state_path.write_text(
+        textwrap.dedent(
+            f"""\
+            schema-version = "0.3"
+
+            [pack.{pack_name}]
+            installed-version = "{installed_version}"
+            source = "agent-ready-repo"
+            install-route = "cli"
+            scope = "repo"
+            {adapter_line}"""
+        ),
+        encoding="utf-8",
+    )
+
+
+class RepoScopeUpgradeWithStateHintTests(unittest.TestCase):
+    """AC33 upgrade-with-state-hint case — **defensive regression pin**.
+
+    The spec asks for "AC10b parity at repo scope". AC10b proper (the
+    state-hint short-circuit inside ``_resolve_target_adapter``) is
+    not exercised at repo-scope upgrade today because
+    ``upgrade.py:230+`` only invokes the resolver when
+    ``effective_scope == "user"`` — repo scope falls through to
+    ``render_pack`` (dist-tree shape). The cross-adapter refusal at
+    ``upgrade.py:371-379`` is structurally unreachable at repo scope
+    by the same gating.
+
+    This test pins that structure: ``state.adapter`` stays ``"kiro"``
+    after a repo-scope upgrade, and the ``pack adapter changed``
+    refusal does not fire. A future refactor that extends the
+    cross-adapter refusal block to repo scope without also threading
+    the state-hint short-circuit would break this test — that's the
+    regression the pin catches. Lifting repo-scope upgrade onto the
+    per-IDE projection path is explicitly Ask-first in the spec; if
+    that lift lands, this test wants tightening (assert the resolver
+    *was* called with ``state_adapter=pack_state.adapter``)."""
+
+    def setUp(self) -> None:
+        _clear_inband_detection_seen()
+
+    def test_upgrade_state_hint_keeps_kiro_no_cross_adapter_refusal(self) -> None:
+        from agentbundle.cli import _build_parser
+        from agentbundle.commands import install, upgrade
+
+        with TemporaryDirectory() as raw:
+            adopter = Path(raw) / "adopter"
+            adopter.mkdir()
+            parser = _build_parser()
+
+            # Step 1: install --adapter kiro.
+            args = parser.parse_args(
+                [
+                    "install",
+                    "--pack", "core",
+                    "--scope", "repo",
+                    "--adapter", "kiro",
+                    "--output", str(adopter),
+                    str(REPO_ROOT),
+                ]
+            )
+            rc = install.run(args)
+            self.assertEqual(rc, 0)
+            state = _load_state(adopter)
+            self.assertEqual(
+                state["pack"]["core"].get("adapter"), "kiro",
+                f"install did not record adapter=kiro: {state!r}",
+            )
+
+            # Step 2: populate <repo>/.claude/ to simulate the
+            # adopter having Claude Code state present alongside Kiro.
+            # AC10b parity: the resolver's state-hint short-circuit
+            # must prefer state.adapter (kiro) over any heuristic that
+            # would route to claude-code on observing this directory.
+            claude_dir = adopter / ".claude" / "skills" / "marker"
+            claude_dir.mkdir(parents=True)
+            (claude_dir / "SKILL.md").write_text(
+                "---\nname: marker\ndescription: claude-state\n---\nBody.",
+                encoding="utf-8",
+            )
+
+            # Step 3: upgrade.
+            upgrade_args = parser.parse_args(
+                [
+                    "upgrade",
+                    "--pack", "core",
+                    "--to", "0.1.0",
+                    str(REPO_ROOT),
+                    "--root", str(adopter),
+                    "--scope", "repo",
+                ]
+            )
+            err_buf = io.StringIO()
+            with redirect_stderr(err_buf):
+                _rc = upgrade.run(upgrade_args)
+            stderr = err_buf.getvalue()
+
+            # The cross-adapter refusal text from upgrade.py:371-379
+            # must not fire at repo scope. Pinning the exact substring
+            # makes a future refactor that extends the refusal block
+            # to repo scope (without state-hint) trip this assertion.
+            self.assertNotIn("pack adapter changed", stderr)
+
+            # State row's adapter stays kiro regardless of the upgrade's
+            # outcome (the test pins state preservation, not upgrade
+            # success — repo-scope upgrade still goes through the
+            # dist-tree renderer today; per-IDE upgrade at repo scope
+            # is a future RFC's surface).
+            state_after = _load_state(adopter)
+            recorded_after = (
+                state_after.get("pack", {}).get("core", {}).get("adapter", "claude-code")
+            )
+            self.assertEqual(
+                recorded_after, "kiro",
+                f"state.adapter regressed post-upgrade: {state_after!r}",
+            )
+
+
+class RepoScopeMigrationTriggerBTests(unittest.TestCase):
+    """AC33 + AC24(b): a pre-RFC-0012 state file plus on-disk dist-tree
+    files refuses the install with the pinned (b) message."""
+
+    def setUp(self) -> None:
+        _clear_inband_detection_seen()
+
+    def test_b_shape_mismatch_e2e_real_pack(self) -> None:
+        with TemporaryDirectory() as raw:
+            adopter = Path(raw) / "adopter"
+            adopter.mkdir()
+            _plant_state_row(adopter, pack_name="core")
+            # Plant dist-tree files (legacy producer shape).
+            (adopter / "claude-plugins" / "core").mkdir(parents=True)
+            (adopter / "claude-plugins" / "core" / "plugin.json").write_text(
+                "{}", encoding="utf-8"
+            )
+            (adopter / "apm" / "core").mkdir(parents=True)
+            (adopter / "apm" / "core" / "pack.toml").write_text(
+                "", encoding="utf-8"
+            )
+
+            rc, stdout, stderr = _run_install(
+                [
+                    "--pack", "core",
+                    "--scope", "repo",
+                    "--output", str(adopter),
+                    str(REPO_ROOT),
+                ]
+            )
+            self.assertNotEqual(rc, 0)
+            self.assertIn("pre-RFC-0012 dist-tree files for pack core", stderr)
+            # Platform-portable: separate segments avoid the Windows
+            # path-separator (``\\``) breaking the joined substring.
+            self.assertIn("claude-plugins", stderr)
+            self.assertIn("apm", stderr)
+            self.assertIn("rerun with --force", stderr)
+
+
+class RepoScopeMigrationTriggerATests(unittest.TestCase):
+    """AC33 + AC24(a): a pre-RFC-0012 state file whose recorded adapter
+    disagrees with the resolver's pick (and no dist-tree files) refuses
+    the install with the pinned (a) message."""
+
+    def setUp(self) -> None:
+        _clear_inband_detection_seen()
+
+    def test_a_adapter_disagreement_e2e_real_pack(self) -> None:
+        with TemporaryDirectory() as raw:
+            adopter = Path(raw) / "adopter"
+            adopter.mkdir()
+            # State records claude-code; CLI passes --adapter kiro.
+            _plant_state_row(adopter, pack_name="core", adapter="claude-code")
+            # No dist-tree files → (b) does not fire; (a) does.
+
+            rc, stdout, stderr = _run_install(
+                [
+                    "--pack", "core",
+                    "--scope", "repo",
+                    "--adapter", "kiro",
+                    "--output", str(adopter),
+                    str(REPO_ROOT),
+                ]
+            )
+            self.assertNotEqual(rc, 0)
+            self.assertIn(
+                "state records adapter 'claude-code' for pack core", stderr
+            )
+            self.assertIn("resolver picked 'kiro'", stderr)
 
 
 if __name__ == "__main__":

--- a/packages/agentbundle/tests/unit/test_install_inband_detection.py
+++ b/packages/agentbundle/tests/unit/test_install_inband_detection.py
@@ -1,0 +1,424 @@
+"""RFC-0012 AC24: in-band detection of pre-RFC-0012 state at install start.
+
+Three triggers evaluated per-pack in precedence ``(b) → (a) → (c)``; only the
+first match emits. Detection runs once per ``(repo, pack)`` per session and
+short-circuits to silence on subsequent calls.
+
+  - **(b) Shape-mismatch.** ``state.toml`` has a row for the pack AND
+    dist-tree files exist at ``<repo>/claude-plugins/<pack>/`` or
+    ``<repo>/apm/<pack>/``. Pinned stderr names the dist-tree paths to
+    remove. ``--force`` cleans dist-tree and proceeds (AC25(vi)).
+
+  - **(a) Adapter disagreement.** ``state.toml`` has a row for the pack
+    with a recorded ``adapter`` AND resolver's pick disagrees AND no
+    dist-tree files. Pinned stderr names recorded vs. resolved adapter.
+    ``--force`` does NOT clear this trigger; uninstall + reinstall is
+    the corrective action.
+
+  - **(c) Orphan recovery.** No state row but per-IDE artifacts exist
+    under the resolved adapter's ``allowed-prefixes.repo``. The AC22
+    refusal path (already covered in :mod:`test_install_messages_repo_scope`)
+    extended here to pin precedence-chain semantics and once-per-session
+    short-circuit.
+
+Detection runs only on the per-IDE install code path —
+``--scope repo`` without ``--emit-install-routes`` (spec AC24
+narrowed-inference rule). ``--emit-install-routes`` short-circuits
+before detection.
+"""
+
+from __future__ import annotations
+
+import io
+import textwrap
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+def _make_pack(
+    packs_dir: Path,
+    *,
+    name: str = "demo",
+    allowed_adapters: list[str] | None = None,
+) -> Path:
+    """A minimal v0.7 repo-scope pack the resolver can dispatch."""
+    pack_dir = packs_dir / name
+    pack_dir.mkdir(parents=True)
+    aa_line = ""
+    if allowed_adapters is not None:
+        aa_line = f"allowed-adapters = {allowed_adapters!r}\n"
+    (pack_dir / "pack.toml").write_text(
+        textwrap.dedent(
+            f"""\
+            [pack]
+            name = "{name}"
+            version = "0.1.0"
+            spec-version = "0.6"
+
+            [pack.adapter-contract]
+            version = "0.7"
+
+            [pack.install]
+            default-scope = "repo"
+            allowed-scopes = ["repo"]
+            {aa_line}"""
+        ),
+        encoding="utf-8",
+    )
+    skill_dir = pack_dir / ".apm" / "skills" / f"{name}-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}-skill\ndescription: {name}\n---\nBody.",
+        encoding="utf-8",
+    )
+    return pack_dir
+
+
+def _plant_state(adopter: Path, *, pack_name: str, adapter: str = "claude-code") -> None:
+    """Write a minimal v0.3 state.toml carrying a single ``[pack.<name>]`` row.
+
+    The fixture mirrors a pre-RFC-0012 install — the row exists but no
+    repo-scope per-IDE files match it on disk (dist-tree or orphan
+    artifacts are planted by the caller).
+    """
+    adapter_line = ""
+    if adapter != "claude-code":
+        adapter_line = f'adapter = "{adapter}"\n'
+    state_path = adopter / ".agentbundle-state.toml"
+    state_path.write_text(
+        textwrap.dedent(
+            f"""\
+            schema-version = "0.3"
+
+            [pack.{pack_name}]
+            installed-version = "0.1.0"
+            source = "agent-ready-repo"
+            install-route = "cli"
+            scope = "repo"
+            {adapter_line}"""
+        ),
+        encoding="utf-8",
+    )
+
+
+def _run_install(argv: list[str]) -> tuple[int, str]:
+    """Invoke install via the argparse layer; return ``(rc, stderr)``."""
+    from agentbundle.cli import _build_parser
+    from agentbundle.commands import install
+
+    parser = _build_parser()
+    args = parser.parse_args(["install"] + argv)
+    buf = io.StringIO()
+    with redirect_stderr(buf):
+        rc = install.run(args)
+    return rc, buf.getvalue()
+
+
+def _clear_session_set() -> None:
+    """Reset the once-per-session detection set between tests."""
+    from agentbundle.commands import install
+
+    install._clear_inband_detection_seen()
+
+
+class TriggerBShapeMismatchTests(unittest.TestCase):
+    """(b) shape-mismatch: state row + dist-tree files on disk."""
+
+    def setUp(self) -> None:
+        _clear_session_set()
+
+    def test_b_fires_when_state_row_and_dist_tree_present(self) -> None:
+        with TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            packs_dir = tmp / "packs"
+            packs_dir.mkdir()
+            _make_pack(packs_dir, allowed_adapters=["claude-code", "kiro"])
+            adopter = tmp / "adopter"
+            adopter.mkdir()
+            _plant_state(adopter, pack_name="demo")
+            # Plant dist-tree files (pre-RFC-0012 shape).
+            (adopter / "claude-plugins" / "demo").mkdir(parents=True)
+            (adopter / "claude-plugins" / "demo" / "plugin.json").write_text(
+                "{}", encoding="utf-8"
+            )
+            (adopter / "apm" / "demo").mkdir(parents=True)
+            (adopter / "apm" / "demo" / "pack.toml").write_text(
+                "", encoding="utf-8"
+            )
+
+            rc, stderr = _run_install(
+                ["--pack", "demo", "--scope", "repo",
+                 "--output", str(adopter), str(packs_dir)]
+            )
+            self.assertNotEqual(rc, 0)
+            self.assertIn("pre-RFC-0012 dist-tree files for pack demo", stderr)
+            # Platform-portable: assert path segments separately so the
+            # Windows path-separator (``\\``) doesn't break substring
+            # matching on the joined ``claude-plugins/demo`` literal.
+            self.assertIn("claude-plugins", stderr)
+            self.assertIn("apm", stderr)
+            self.assertIn("demo", stderr)
+            self.assertIn("rerun with --force", stderr)
+
+    def test_b_force_cleans_dist_tree_and_proceeds(self) -> None:
+        """AC25(vi): ``--force`` is the corrective action for (b). It
+        must (1) delete the dist-tree subtrees, (2) drop the stale
+        state row so Step 4 doesn't re-refuse with "use 'upgrade'",
+        and (3) let the install complete cleanly with the per-IDE
+        projection landing in place of the dist-tree shape."""
+        with TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            packs_dir = tmp / "packs"
+            packs_dir.mkdir()
+            _make_pack(packs_dir, allowed_adapters=["claude-code", "kiro"])
+            adopter = tmp / "adopter"
+            adopter.mkdir()
+            _plant_state(adopter, pack_name="demo")
+            (adopter / "claude-plugins" / "demo").mkdir(parents=True)
+            (adopter / "claude-plugins" / "demo" / "plugin.json").write_text(
+                "{}", encoding="utf-8"
+            )
+
+            rc, stderr = _run_install(
+                ["--pack", "demo", "--scope", "repo", "--force",
+                 "--output", str(adopter), str(packs_dir)]
+            )
+            self.assertEqual(
+                rc, 0,
+                f"install did not complete after --force; stderr={stderr!r}",
+            )
+            self.assertNotIn("pre-RFC-0012 dist-tree files", stderr)
+            # Dist-tree subtree gone.
+            self.assertFalse(
+                (adopter / "claude-plugins" / "demo").exists(),
+                "expected claude-plugins/demo/ subtree to be removed by --force",
+            )
+            # Per-IDE projection landed in its place.
+            self.assertTrue(
+                (adopter / ".claude" / "skills").exists(),
+                "expected per-IDE projection at .claude/skills/ after reinstall",
+            )
+            # State.toml carries a fresh row pointing at the per-IDE
+            # paths (not the dist-tree paths). A regression that left
+            # the stale row's ``files`` map intact would surface here.
+            import tomllib
+
+            state = tomllib.loads(
+                (adopter / ".agentbundle-state.toml").read_text(encoding="utf-8")
+            )
+            pack_row = state.get("pack", {}).get("demo", {})
+            self.assertEqual(
+                pack_row.get("installed-version"), "0.1.0",
+                f"state row not refreshed after (b)+--force: {pack_row!r}",
+            )
+            files_recorded = list((pack_row.get("files") or {}).keys())
+            self.assertTrue(
+                any(p.startswith(".claude/") for p in files_recorded),
+                f"state.files missing per-IDE entries: {files_recorded!r}",
+            )
+            self.assertFalse(
+                any(
+                    p.startswith("claude-plugins/") or p.startswith("apm/")
+                    for p in files_recorded
+                ),
+                f"state.files still tracks dist-tree paths: {files_recorded!r}",
+            )
+
+
+class TriggerAAdapterDisagreementTests(unittest.TestCase):
+    """(a) adapter disagreement: state row + resolver disagreement +
+    no dist-tree files (precedence (b) → (a))."""
+
+    def setUp(self) -> None:
+        _clear_session_set()
+
+    def test_a_fires_when_recorded_adapter_disagrees_with_resolver(self) -> None:
+        with TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            packs_dir = tmp / "packs"
+            packs_dir.mkdir()
+            _make_pack(packs_dir, allowed_adapters=["claude-code", "kiro"])
+            adopter = tmp / "adopter"
+            adopter.mkdir()
+            # State records claude-code; resolver picks kiro via --adapter.
+            _plant_state(adopter, pack_name="demo", adapter="claude-code")
+            # NO dist-tree files — (b) must not fire.
+
+            rc, stderr = _run_install(
+                ["--pack", "demo", "--scope", "repo", "--adapter", "kiro",
+                 "--output", str(adopter), str(packs_dir)]
+            )
+            self.assertNotEqual(rc, 0)
+            self.assertIn(
+                "state records adapter 'claude-code' for pack demo", stderr
+            )
+            self.assertIn("resolver picked 'kiro'", stderr)
+            self.assertIn("uninstall", stderr)
+
+    def test_a_does_not_fire_when_dist_tree_present_b_takes_precedence(self) -> None:
+        with TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            packs_dir = tmp / "packs"
+            packs_dir.mkdir()
+            _make_pack(packs_dir, allowed_adapters=["claude-code", "kiro"])
+            adopter = tmp / "adopter"
+            adopter.mkdir()
+            _plant_state(adopter, pack_name="demo", adapter="claude-code")
+            # Plant dist-tree files: (b) fires before (a).
+            (adopter / "claude-plugins" / "demo").mkdir(parents=True)
+            (adopter / "claude-plugins" / "demo" / "plugin.json").write_text(
+                "{}", encoding="utf-8"
+            )
+
+            rc, stderr = _run_install(
+                ["--pack", "demo", "--scope", "repo", "--adapter", "kiro",
+                 "--output", str(adopter), str(packs_dir)]
+            )
+            self.assertNotEqual(rc, 0)
+            # (b) fired, not (a).
+            self.assertIn("pre-RFC-0012 dist-tree files", stderr)
+            self.assertNotIn("state records adapter", stderr)
+
+    def test_a_not_cleared_by_force(self) -> None:
+        """--force is NOT the corrective action for (a); uninstall + reinstall
+        is. The refusal text must still appear with --force passed."""
+        with TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            packs_dir = tmp / "packs"
+            packs_dir.mkdir()
+            _make_pack(packs_dir, allowed_adapters=["claude-code", "kiro"])
+            adopter = tmp / "adopter"
+            adopter.mkdir()
+            _plant_state(adopter, pack_name="demo", adapter="claude-code")
+
+            rc, stderr = _run_install(
+                ["--pack", "demo", "--scope", "repo", "--adapter", "kiro",
+                 "--force",
+                 "--output", str(adopter), str(packs_dir)]
+            )
+            self.assertNotEqual(rc, 0)
+            self.assertIn("state records adapter 'claude-code'", stderr)
+
+
+class PrecedenceAndSessionShortCircuitTests(unittest.TestCase):
+    """Per-pack precedence and the once-per-session short-circuit."""
+
+    def setUp(self) -> None:
+        _clear_session_set()
+
+    def test_per_pack_evaluation_b_for_a_then_c_for_b(self) -> None:
+        """Spec AC24 (b)+(c) overlap fixture. Two packs share the adopter:
+        pack A has a state row + dist-tree files (fires (b)); pack B has
+        orphan per-IDE files but no state row (fires (c)).
+
+        The detection key is ``(root, pack_name)``, so each pack lands
+        on its own trigger. Note that (c) re-uses
+        ``safety.scan_for_pack_artifacts`` which is **adapter-prefix
+        scoped, not pack-name scoped** (the AC22 baseline this PR
+        inherits) — so (c) would also fire if pack B were greenfield
+        and the orphan belonged to some third pack under the same
+        adapter prefix. Tightening (c) to pack-name scoping is a
+        follow-up surface (Concern 6 from the round-2 review)."""
+        with TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            packs_dir = tmp / "packs"
+            packs_dir.mkdir()
+            _make_pack(packs_dir, name="apack", allowed_adapters=["claude-code"])
+            _make_pack(packs_dir, name="bpack", allowed_adapters=["claude-code"])
+            adopter = tmp / "adopter"
+            adopter.mkdir()
+            # Pack A: state row + dist-tree files → (b) should fire.
+            _plant_state(adopter, pack_name="apack")
+            (adopter / "claude-plugins" / "apack").mkdir(parents=True)
+            (adopter / "claude-plugins" / "apack" / "plugin.json").write_text(
+                "{}", encoding="utf-8"
+            )
+            # Pack B: no state row but orphan per-IDE files → (c) should
+            # fire when installing B.
+            orphan = adopter / ".claude" / "skills" / "bpack-skill" / "SKILL.md"
+            orphan.parent.mkdir(parents=True)
+            orphan.write_text("stale", encoding="utf-8")
+
+            # Install pack A first — (b) fires.
+            rc_a, stderr_a = _run_install(
+                ["--pack", "apack", "--scope", "repo",
+                 "--output", str(adopter), str(packs_dir)]
+            )
+            self.assertNotEqual(rc_a, 0)
+            self.assertIn("pre-RFC-0012 dist-tree files for pack apack", stderr_a)
+
+            # Install pack B in the same session — (c) fires.
+            rc_b, stderr_b = _run_install(
+                ["--pack", "bpack", "--scope", "repo",
+                 "--output", str(adopter), str(packs_dir)]
+            )
+            self.assertNotEqual(rc_b, 0)
+            self.assertIn("orphan projection files for pack bpack", stderr_b)
+
+    def test_short_circuit_on_repeat_invocation_same_pack(self) -> None:
+        """Re-invoking install for the same ``(root, pack)`` within the
+        same Python process does NOT re-emit the detection line."""
+        with TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            packs_dir = tmp / "packs"
+            packs_dir.mkdir()
+            _make_pack(packs_dir, allowed_adapters=["claude-code", "kiro"])
+            adopter = tmp / "adopter"
+            adopter.mkdir()
+            _plant_state(adopter, pack_name="demo")
+            (adopter / "claude-plugins" / "demo").mkdir(parents=True)
+            (adopter / "claude-plugins" / "demo" / "plugin.json").write_text(
+                "{}", encoding="utf-8"
+            )
+
+            rc1, stderr1 = _run_install(
+                ["--pack", "demo", "--scope", "repo",
+                 "--output", str(adopter), str(packs_dir)]
+            )
+            self.assertIn("pre-RFC-0012 dist-tree files", stderr1)
+
+            # Second call within the same process — detection short-circuits.
+            rc2, stderr2 = _run_install(
+                ["--pack", "demo", "--scope", "repo",
+                 "--output", str(adopter), str(packs_dir)]
+            )
+            self.assertNotIn("pre-RFC-0012 dist-tree files", stderr2)
+
+
+class EmitInstallRoutesBypassesDetectionTests(unittest.TestCase):
+    """Spec AC24 narrowed-inference rule: detection runs only on the
+    per-IDE install code path (``--scope repo`` without
+    ``--emit-install-routes``). The dist-tree producer must NOT trigger
+    (b) on its own legitimate output."""
+
+    def setUp(self) -> None:
+        _clear_session_set()
+
+    def test_emit_install_routes_does_not_trigger_b(self) -> None:
+        with TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            packs_dir = tmp / "packs"
+            packs_dir.mkdir()
+            _make_pack(packs_dir, allowed_adapters=["claude-code", "kiro"])
+            adopter = tmp / "adopter"
+            adopter.mkdir()
+            _plant_state(adopter, pack_name="demo")
+            (adopter / "claude-plugins" / "demo").mkdir(parents=True)
+            (adopter / "claude-plugins" / "demo" / "plugin.json").write_text(
+                "{}", encoding="utf-8"
+            )
+
+            rc, stderr = _run_install(
+                ["--pack", "demo", "--scope", "repo",
+                 "--emit-install-routes",
+                 "--output", str(adopter), str(packs_dir)]
+            )
+            # The detection block is bypassed; the already-installed
+            # refusal at install.py:314 fires instead.
+            self.assertNotIn("pre-RFC-0012 dist-tree files", stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes the deferred items named in the RFC-0012 PR #140 commit body:
spec **AC24 triggers (a) adapter-disagreement and (b) shape-mismatch**
(only (c) orphan-recovery shipped in #140), plus the three **AC33
integration cases** that were stubbed in T8 (upgrade-with-state-hint,
migration-(b) e2e, migration-(a) e2e).

## What changed

- `packages/agentbundle/agentbundle/commands/install.py` — moves the
  existing AC22 orphan-refusal block into a new helper
  `_classify_pre_rfc0012_state` that evaluates (b)→(a)→(c) in
  precedence. The repo-scope resolver call is lifted to before the
  already-installed branch so detection's pinned migration messaging
  fires before the misleading "use 'upgrade'" refusal. A
  `(root, pack_name)` short-circuit set keeps the line from
  re-emitting on repeat invocations in the same process.
- `packages/agentbundle/tests/unit/test_install_inband_detection.py`
  (new) — unit coverage for (a), (b), per-pack precedence, once-per-
  session short-circuit, `--emit-install-routes` bypass.
- `packages/agentbundle/tests/integration/test_install_repo_scope_per_adapter.py`
  — three new test classes: upgrade-with-state-hint at repo scope
  (defensive regression pin, see below), migration-trigger-(b) e2e
  with real `core` pack, migration-trigger-(a) e2e with real `core`
  pack.

## --force semantics (per spec AC25)

- **(b)** shape-mismatch: clean dist-tree subtrees AND drop the stale
  state row (in-memory pop + on-disk rewrite) so the install proceeds
  as a clean reinstall. Without the row drop Step 4's "use 'upgrade'"
  would trap the adopter in a loop because repo-scope upgrade today
  re-emits the dist-tree shape.
- **(c)** orphan-recovery: clean orphan files and proceed (unchanged
  from AC22).
- **(a)** adapter-disagreement: NOT cleared by `--force`; corrective
  action is uninstall + reinstall per AC25(iii).

## Implementer-chosen wording (spec amendment follow-up)

Spec AC24 says "Each trigger emits its own pinned stderr line" without
pinning the exact strings for (a) and (b). The chosen wording:

- **(b)** `install: pre-RFC-0012 dist-tree files for pack <name> at
  <paths> — state recorded but on-disk shape predates per-IDE
  projection; rerun with --force to clean and reinstall, or delete
  the listed paths and rerun`
- **(a)** `install: state records adapter '<recorded>' for pack
  <name>, but resolver picked '<resolved>' — uninstall the pack at
  repo scope and reinstall to reconcile (cross-adapter install is
  not supported)`
- **(c)** orphan-recovery wording preserved verbatim from AC22.

A spec amendment can pin these in AC24 verbatim once shipped.

## AC33 upgrade test scope

The upgrade-with-state-hint test (`RepoScopeUpgradeWithStateHintTests`)
is a **defensive regression pin**, not a true AC10b exerciser.
`upgrade.py:230+` gates the resolver call on `effective_scope == "user"`
so the cross-adapter refusal at `upgrade.py:371-379` is structurally
unreachable at repo scope today. The test asserts current behaviour
(`state.adapter` stays kiro after a repo-scope upgrade; no `pack
adapter changed` stderr) so a future refactor that lifts the refusal
block to repo scope without also threading the state-hint
short-circuit would break it. Lifting repo-scope upgrade onto the
per-IDE projection path is explicitly Ask-first in the spec.

## Deferred to follow-up (not in this PR)

- **Per-pack scoping of (c)'s artifact scan.** Pre-existing AC22
  limitation — `safety.scan_for_pack_artifacts` is adapter-prefix
  scoped, not pack-name scoped. The `test_per_pack_evaluation_b_for_a_then_c_for_b`
  docstring names this honestly; tightening is a future surface.
- **Spec amendment** pinning (a) and (b) wording verbatim in AC24.

## Test plan

- [x] `pytest packages/agentbundle/tests/unit/test_install_inband_detection.py` — 8 green
- [x] `pytest packages/agentbundle/tests/integration/test_install_repo_scope_per_adapter.py` — 8 green
- [x] `pytest packages/agentbundle/tests/unit/test_install_messages_repo_scope.py` — 6 green (existing AC22 tests preserved)
- [x] Full agentbundle suite: 1411 passed, 10 skipped (the one pre-existing `test_make_build_check_passes_post_migration` failure on main is env-dependent and unrelated to this diff)
- [x] `python3 tools/hooks/pre-pr.py` — clean
- [x] `make build-self FORCE=1 && git status --short` — clean modulo the three intended files
- [x] Three adversarial review passes; final returned "Clean — ready to commit." with one non-blocking nit addressed in the same diff