### PR TITLE
chore(lint-build): authorise .agentbundle/ per RFC-0013

### DIFF
--- a/tools/lint-build.py
+++ b/tools/lint-build.py
@@ -32,6 +32,7 @@ from pathlib import Path
 # entries only when an Accepted RFC authorises the new directory.
 RFC_AUTHORISED_DIRS = (
     "packs",  # RFC-0002 — self-hosting source-of-truth split
+    ".agentbundle",  # RFC-0013 — adapter-root-bins/ self-hosted projection (sso-broker.py + helpers)
 )
 
 


### PR DESCRIPTION
## Summary

Adds `.agentbundle` to `RFC_AUTHORISED_DIRS` in `tools/lint-build.py`.

RFC-0013 (credential broker contract) shipped via PR #142 (commit df2407c)
landed the adapter-root-bins/ self-hosted projection at
`.agentbundle/bin/sso-broker.py` plus two OS helpers (RFC-0013 § 4d).
The lint allowlist wasn't updated in the same PR, so any branch whose
merge-base predates #142 — or any local checkout whose `main` ref is
stale, common in Conductor worktrees where main lives in a sibling
workspace — trips the "new top-level directories introduced (RFC
required)" refusal as a false positive.

PR #144 hit this and documented the workaround in its body. This PR
closes the drift at the source.

## Test plan

- [x] `python3 tools/hooks/pre-pr.py` — exit 0 locally (previously failed with `lint-build: new top-level directories introduced: .agentbundle`)
- [x] One-line addition; entry mirrors the format of the existing `"packs"` entry with an RFC reference in the trailing comment