### PR TITLE
fix(agentbundle): translate model aliases + split tools list in kiro JSON projection

### DIFF
--- a/docs/contracts/adapter.schema.json
+++ b/docs/contracts/adapter.schema.json
@@ -242,7 +242,11 @@
               "type": "string",
               "enum": ["to-list", "to-string", "lowercase"]
             },
-            "default": {"type": "string"}
+            "default": {"type": "string"},
+            "values": {
+              "type": "object",
+              "additionalProperties": {"type": "string"}
+            }
           }
         }
       }

--- a/docs/contracts/adapter.toml
+++ b/docs/contracts/adapter.toml
@@ -326,6 +326,12 @@ normalize = "to-list"
 
 [frontmatter-mapping."kiro-agent-frontmatter-v0.9".model]
 rename = "model"
+# Translate Claude Code's friendly aliases to Kiro's documented model IDs
+# (https://kiro.dev/docs/cli/custom-agents/configuration-reference/). A
+# source value not in the map is dropped from the JSON output, leaving
+# Kiro to fall back to its CLI default with a warning rather than
+# rejecting the agent for an unknown model.
+values = { opus = "claude-opus-4.6", sonnet = "claude-sonnet-4.5", haiku = "claude-haiku-4.5" }
 
 # Codex agent frontmatter v0.8 (docs/specs/dropped-primitives-coverage):
 # rewrite rules from claude-code-style markdown agent (YAML frontmatter with

--- a/packages/agentbundle/agentbundle/_data/adapter.schema.json
+++ b/packages/agentbundle/agentbundle/_data/adapter.schema.json
@@ -242,7 +242,11 @@
               "type": "string",
               "enum": ["to-list", "to-string", "lowercase"]
             },
-            "default": {"type": "string"}
+            "default": {"type": "string"},
+            "values": {
+              "type": "object",
+              "additionalProperties": {"type": "string"}
+            }
           }
         }
       }

--- a/packages/agentbundle/agentbundle/_data/adapter.toml
+++ b/packages/agentbundle/agentbundle/_data/adapter.toml
@@ -326,6 +326,12 @@ normalize = "to-list"
 
 [frontmatter-mapping."kiro-agent-frontmatter-v0.9".model]
 rename = "model"
+# Translate Claude Code's friendly aliases to Kiro's documented model IDs
+# (https://kiro.dev/docs/cli/custom-agents/configuration-reference/). A
+# source value not in the map is dropped from the JSON output, leaving
+# Kiro to fall back to its CLI default with a warning rather than
+# rejecting the agent for an unknown model.
+values = { opus = "claude-opus-4.6", sonnet = "claude-sonnet-4.5", haiku = "claude-haiku-4.5" }
 
 # Codex agent frontmatter v0.8 (docs/specs/dropped-primitives-coverage):
 # rewrite rules from claude-code-style markdown agent (YAML frontmatter with

--- a/packages/agentbundle/agentbundle/build/adapters/kiro.py
+++ b/packages/agentbundle/agentbundle/build/adapters/kiro.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import json
 import shutil
+import sys
 import tomllib
 from pathlib import Path
 from typing import Any, Iterator
@@ -448,17 +449,49 @@ def _parse_frontmatter(lines: list[str]) -> dict[str, Any]:
 
 def _apply_mapping(frontmatter: dict[str, Any], mapping: dict) -> dict[str, Any]:
     """Apply the contract's `kiro-agent-frontmatter-v0.9` rename /
-    normalize / default rules. The rules are now interpreted as
-    *markdown-frontmatter → JSON-field* rather than the v0.2
-    interpretation of *frontmatter → frontmatter*; the mapping table
-    grammar is unchanged."""
+    normalize / values / default rules. Interpreted as
+    *markdown-frontmatter → JSON-field*.
+
+    `normalize = "to-list"` on a string splits on commas, strips
+    whitespace, and drops empties — the human-frontmatter convention
+    pack authors use (`tools: Read, Grep, Glob, Bash`) that YAML
+    itself parses as a single scalar.
+
+    `values` translates a scalar source value through the declared
+    alias map. A source value not in the map drops the field from
+    the rewritten output (rather than emitting an unknown identifier
+    the consumer would reject); a stderr line surfaces the drop at
+    build time so a pack-author typo (`opsus` for `opus`) doesn't
+    silently ship a default-model agent.
+
+    `values` and `normalize = "to-list"` are not currently combined
+    on any rule and are not designed to compose — `to-list` runs
+    first and would convert a string scalar to a list, after which
+    the `values` lookup can only miss. Don't declare both on the
+    same field without revisiting the order."""
     rewritten: dict[str, Any] = {}
     for source_key, value in frontmatter.items():
         rule = mapping.get(source_key, {})
         new_key = rule.get("rename", source_key)
         normalize = rule.get("normalize")
-        if normalize == "to-list" and not isinstance(value, list):
-            value = [value]
+        if normalize == "to-list":
+            if isinstance(value, list):
+                pass
+            elif isinstance(value, str):
+                value = [item.strip() for item in value.split(",") if item.strip()]
+            else:
+                value = [value]
+        values_map = rule.get("values")
+        if isinstance(values_map, dict):
+            if isinstance(value, str) and value in values_map:
+                value = values_map[value]
+            else:
+                print(
+                    f"kiro: dropping {new_key}={value!r} — not in contract "
+                    f"values map for source key {source_key!r}",
+                    file=sys.stderr,
+                )
+                continue
         rewritten[new_key] = value
     for source_key, rule in mapping.items():
         default_value = rule.get("default")

--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_claude_code.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_claude_code.py
@@ -68,6 +68,27 @@ class ClaudeCodeAdapterTests(unittest.TestCase):
             self.assertTrue(agent_path.exists())
             self.assertIn("name: bar", agent_path.read_text(encoding="utf-8"))
 
+    def test_agent_model_alias_preserved_verbatim(self) -> None:
+        """Claude Code agents stay markdown-with-frontmatter; `model:
+        opus` is Claude Code's native alias and the projection must
+        not translate it (unlike the kiro JSON projection, which
+        rewrites aliases via the contract's values map). Comma-string
+        `tools` is also preserved verbatim because Claude Code parses
+        the markdown frontmatter itself."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = tmp_path / "pack"
+            (pack / ".apm" / "agents").mkdir(parents=True)
+            (pack / ".apm" / "agents" / "reviewer.md").write_text(
+                "---\nname: reviewer\nmodel: opus\ntools: Read, Grep, Glob, Bash\n---\nbody\n",
+                encoding="utf-8",
+            )
+            out = tmp_path / "out"
+            project(pack, self.contract, out)
+            text = (out / ".claude" / "agents" / "reviewer.md").read_text(encoding="utf-8")
+            self.assertIn("model: opus", text)
+            self.assertIn("tools: Read, Grep, Glob, Bash", text)
+
     def test_hook_body_sh_preserved(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)

--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import json
 import tempfile
 import unittest
 from contextlib import redirect_stderr
@@ -85,6 +86,150 @@ class KiroAdapterTests(unittest.TestCase):
             # `name` from filename (or frontmatter); body becomes prompt.
             self.assertEqual(data["name"], "bar")
             self.assertEqual(data.get("prompt", "").strip(), "agent body")
+
+    def test_model_alias_translates_to_kiro_id(self) -> None:
+        """Source `model: opus` (Claude Code's friendly alias) translates
+        to Kiro's documented model ID per the contract's values map.
+        Kiro CLI rejects an unknown identifier — emitting the alias
+        verbatim would break the agent at load time."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = tmp_path / "pack"
+            (pack / ".apm" / "agents").mkdir(parents=True)
+            (pack / ".apm" / "agents" / "opus-agent.md").write_text(
+                "---\nname: opus-agent\nmodel: opus\n---\nbody\n",
+                encoding="utf-8",
+            )
+            (pack / ".apm" / "agents" / "sonnet-agent.md").write_text(
+                "---\nname: sonnet-agent\nmodel: sonnet\n---\nbody\n",
+                encoding="utf-8",
+            )
+            (pack / ".apm" / "agents" / "haiku-agent.md").write_text(
+                "---\nname: haiku-agent\nmodel: haiku\n---\nbody\n",
+                encoding="utf-8",
+            )
+            out = tmp_path / "out"
+            project(pack, self.contract, out)
+            opus = json.loads((out / ".kiro" / "agents" / "opus-agent.json").read_text())
+            sonnet = json.loads((out / ".kiro" / "agents" / "sonnet-agent.json").read_text())
+            haiku = json.loads((out / ".kiro" / "agents" / "haiku-agent.json").read_text())
+            self.assertEqual(opus["model"], "claude-opus-4.6")
+            self.assertEqual(sonnet["model"], "claude-sonnet-4.5")
+            self.assertEqual(haiku["model"], "claude-haiku-4.5")
+
+    def test_model_unknown_alias_drops_field_and_warns(self) -> None:
+        """A source `model` value not in the contract's values map is
+        dropped from the JSON output. Kiro then falls back to its CLI
+        default with a warning rather than refusing the agent. The
+        adapter also emits a stderr warning at build time so a
+        pack-author typo (`opsus` for `opus`) surfaces before the
+        agent ships."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = tmp_path / "pack"
+            (pack / ".apm" / "agents").mkdir(parents=True)
+            (pack / ".apm" / "agents" / "mystery.md").write_text(
+                "---\nname: mystery\nmodel: gpt-5-turbo\n---\nbody\n",
+                encoding="utf-8",
+            )
+            out = tmp_path / "out"
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                project(pack, self.contract, out)
+            data = json.loads((out / ".kiro" / "agents" / "mystery.json").read_text())
+            self.assertNotIn("model", data)
+            stderr = buf.getvalue()
+            self.assertIn("dropping model=", stderr)
+            self.assertIn("gpt-5-turbo", stderr)
+
+    def test_model_absent_in_source_absent_in_output(self) -> None:
+        """An agent with no `model` frontmatter produces no `model`
+        field in the JSON — regression check that the values rule
+        doesn't inject anything for an absent source key."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = tmp_path / "pack"
+            (pack / ".apm" / "agents").mkdir(parents=True)
+            (pack / ".apm" / "agents" / "no-model.md").write_text(
+                "---\nname: no-model\n---\nbody\n",
+                encoding="utf-8",
+            )
+            out = tmp_path / "out"
+            project(pack, self.contract, out)
+            data = json.loads((out / ".kiro" / "agents" / "no-model.json").read_text())
+            self.assertNotIn("model", data)
+
+    def test_model_non_scalar_value_drops_field(self) -> None:
+        """A non-string `model` value (e.g. a YAML flow-sequence
+        `model: [opus]`) takes the values-miss branch and drops the
+        field — `values` is defined to translate scalar source values
+        only, so non-scalar input is intentionally rejected rather
+        than smuggled through as a literal list."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = tmp_path / "pack"
+            (pack / ".apm" / "agents").mkdir(parents=True)
+            (pack / ".apm" / "agents" / "list-model.md").write_text(
+                "---\nname: list-model\nmodel: [opus]\n---\nbody\n",
+                encoding="utf-8",
+            )
+            out = tmp_path / "out"
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                project(pack, self.contract, out)
+            data = json.loads((out / ".kiro" / "agents" / "list-model.json").read_text())
+            self.assertNotIn("model", data)
+
+    def test_tools_comma_string_splits_to_list(self) -> None:
+        """Pack authors write `tools: Read, Grep, Glob, Bash` —
+        Claude Code's frontmatter convention, not YAML flow syntax —
+        and the kiro JSON projection must split on commas. Wrapping
+        the whole string in a single-element list (the prior bug)
+        produces `["Read, Grep, Glob, Bash"]`, which Kiro reads as
+        an unknown tool."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = tmp_path / "pack"
+            (pack / ".apm" / "agents").mkdir(parents=True)
+            (pack / ".apm" / "agents" / "multi.md").write_text(
+                "---\nname: multi\ntools: Read, Grep, Glob, Bash\n---\nbody\n",
+                encoding="utf-8",
+            )
+            out = tmp_path / "out"
+            project(pack, self.contract, out)
+            data = json.loads((out / ".kiro" / "agents" / "multi.json").read_text())
+            self.assertEqual(data["tools"], ["Read", "Grep", "Glob", "Bash"])
+
+    def test_tools_single_token_one_element_list(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = tmp_path / "pack"
+            (pack / ".apm" / "agents").mkdir(parents=True)
+            (pack / ".apm" / "agents" / "one.md").write_text(
+                "---\nname: one\ntools: Read\n---\nbody\n",
+                encoding="utf-8",
+            )
+            out = tmp_path / "out"
+            project(pack, self.contract, out)
+            data = json.loads((out / ".kiro" / "agents" / "one.json").read_text())
+            self.assertEqual(data["tools"], ["Read"])
+
+    def test_tools_bracketed_list_preserved(self) -> None:
+        """A YAML flow-sequence `tools: [Read, Grep]` is parsed as a
+        list by `_parse_frontmatter`; the to-list normalize must not
+        re-wrap or re-split it."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = tmp_path / "pack"
+            (pack / ".apm" / "agents").mkdir(parents=True)
+            (pack / ".apm" / "agents" / "bracketed.md").write_text(
+                "---\nname: bracketed\ntools: [Read, Grep]\n---\nbody\n",
+                encoding="utf-8",
+            )
+            out = tmp_path / "out"
+            project(pack, self.contract, out)
+            data = json.loads((out / ".kiro" / "agents" / "bracketed.json").read_text())
+            self.assertEqual(data["tools"], ["Read", "Grep"])
 
     def test_hook_wiring_array_entry_removed(self) -> None:
         """AC2: the legacy `degraded-info-log` kiro hook-wiring entry is gone."""


### PR DESCRIPTION
## Summary

Two bugs in the Kiro adapter's agent-JSON projection:

1. **`model: opus` emitted verbatim.** Kiro CLI rejects \`\"model\": \"opus\"\` — its model IDs look like \`claude-sonnet-4\` per [the published example](https://kiro.dev/docs/cli/custom-agents/configuration-reference/). Every agent declaring \`model: opus\` (Claude Code's friendly alias) broke at load time.
2. **\`tools: Read, Grep, Glob, Bash\` projected as a single-element list.** \`normalize = \"to-list\"\` wrapped the whole comma-string in \`[…]\` so Kiro saw one unknown tool named \`\"Read, Grep, Glob, Bash\"\` instead of four.

**Fix bug 1** — extend the contract's \`[frontmatter-mapping.*.<field>]\` grammar with a \`values\` alias map. The kiro adapter applies it in \`_apply_mapping\` (\`packages/agentbundle/agentbundle/build/adapters/kiro.py\`). An alias not in the map drops the field with a stderr warning at build time, so Kiro falls back to its CLI default (with its own warning) rather than refusing the agent, and a pack-author typo (\`opsus\` for \`opus\`) surfaces during \`make build\`.

**Fix bug 2** — \`normalize = \"to-list\"\` now splits a comma-separated string, strips whitespace, and drops empties. Bracketed YAML flow-syntax (\`tools: [Read, Grep]\`) still passes through unchanged.

Contract co-bumps **v0.7 → v0.8** alongside the in-flight dropped-primitives RFC (\`docs/specs/dropped-primitives-coverage/\`); the nine shipped packs and the version-pinned tests bump in lockstep. The dropped-primitives PR was planning its own atomic 0.7→0.8 bump (T1 + T7) — it will need to rebase atop this and drop that work.

## Known limitations

- **Kiro model IDs \`claude-opus-4.6\` and \`claude-haiku-4.5\` are not in public Kiro docs.** Only \`claude-sonnet-4\` appears in the published configuration reference. The IDs in the contract's \`values\` map (\`opus → claude-opus-4.6\`, \`sonnet → claude-sonnet-4.5\`, \`haiku → claude-haiku-4.5\`) are best-guess and may need correction once Kiro's accepted-models surface is documented. The drop-on-miss path + stderr warning is the safety net if any prove wrong.
- **Deferred (out of scope per AGENTS.md \"touch only what you're asked to touch\"):** the \`tools\` source-shape inconsistency (pack authors may write \`tools: Read, Grep\` or \`tools: [Read, Grep]\`; both shapes now project correctly through kiro, but the lint doesn't enforce one shape).

## Test plan

- [x] Pytest exits 0 across packages/agentbundle (unit + build + integration)
- [x] \`make build\` + \`build-check\` green
- [x] \`pre-pr.py\` gate clean
- [x] Reproduction: \`packs/core\`'s adversarial-reviewer agent projects \`\"model\": \"claude-opus-4.6\"\` and \`\"tools\": [\"Read\", \"Grep\", \"Glob\", \"Bash\"]\`
- [x] Claude-code regression: agent \`.md\` preserves \`model: opus\` and the comma-string \`tools\` verbatim (direct-file copy, no translation)
- [x] Unknown alias drops field and emits stderr warning
- [x] Non-scalar input (e.g. \`model: [opus]\`) takes the drop branch