### PR TITLE
fix(upgrade,diff): mirror install's per-IDE projection at repo scope

### DIFF
--- a/packages/agentbundle/agentbundle/commands/diff.py
+++ b/packages/agentbundle/agentbundle/commands/diff.py
@@ -49,6 +49,8 @@ def run(args: argparse.Namespace) -> int:
     installed_at_repo = False
     installed_at_user = False
     user_root_resolved: Path | None = None
+    repo_state_for_check = None
+    user_state_for_check = None
     if pack_name:
         repo_state_for_check = load_state(root / ".agentbundle-state.toml")
         installed_at_repo = pack_name in repo_state_for_check.packs
@@ -80,6 +82,19 @@ def run(args: argparse.Namespace) -> int:
                 return 1
             root = user_root_resolved
 
+    # Resolve effective scope and the matching pack_state (if any) so
+    # the renderer below can mirror the shape install used.
+    effective_scope = "repo"
+    pack_state = None
+    if cli_scope == "user" or (
+        cli_scope is None and installed_at_user and not installed_at_repo
+    ):
+        effective_scope = "user"
+        if user_state_for_check is not None and pack_name:
+            pack_state = user_state_for_check.packs.get(pack_name)
+    elif repo_state_for_check is not None and pack_name:
+        pack_state = repo_state_for_check.packs.get(pack_name)
+
     if not (pack_path / "pack.toml").exists():
         print(
             f"error: no pack.toml found at {pack_path}",
@@ -95,8 +110,84 @@ def run(args: argparse.Namespace) -> int:
     if gate is not None:
         return gate
 
+    # Pick the projection shape to compare against. RFC-0012 changed
+    # install's default at repo scope from the dist-tree producer
+    # (`render_pack`) to a per-IDE projection (`.claude/...`,
+    # `.kiro/...`). Comparing on-disk per-IDE files against a dist-tree
+    # render flags every per-IDE path as missing — exactly what makes
+    # `agentbundle diff` useless after a v0.7+ install.
+    #
+    # Detection rule: if the pack is recorded in state, the install
+    # itself tells us which shape landed:
+    #   - state.files contains `apm/<pack>/...`, `claude-plugins/<pack>/...`,
+    #     or `marketplace.json` → install used `--emit-install-routes`
+    #     (legacy dist-tree); keep the dist-tree render.
+    #   - otherwise → install used the RFC-0012 per-IDE path; render
+    #     via `_render_for_repo_scope` / `_render_for_user_scope` with
+    #     the recorded `state.adapter` as the hint.
+    # When state has no row (a maintainer running diff against a fresh
+    # render directory, the test_diff_cmd.py shape), fall back to the
+    # dist-tree render — that's the catalogue-publishing surface.
+    _use_dist_tree = pack_state is None or any(
+        rp.startswith(("apm/", "claude-plugins/")) or rp == "marketplace.json"
+        for rp in pack_state.files
+    )
     try:
-        rendered: dict[str, bytes] = render.render_pack(pack_path)
+        if _use_dist_tree:
+            rendered: dict[str, bytes] = render.render_pack(pack_path)
+        else:
+            import tomllib as _tomllib
+
+            _pack_toml = _tomllib.loads(
+                (pack_path / "pack.toml").read_text(encoding="utf-8")
+            )
+            _install_table = _pack_toml.get("pack", {}).get("install")
+            _allowed_adapters = None
+            if isinstance(_install_table, dict):
+                _raw_aa = _install_table.get("allowed-adapters")
+                if isinstance(_raw_aa, list):
+                    _allowed_adapters = [s for s in _raw_aa if isinstance(s, str)]
+            _contract_version = (
+                _pack_toml.get("pack", {}).get("adapter-contract", {}).get("version")
+                if isinstance(_pack_toml.get("pack", {}).get("adapter-contract"), dict)
+                else None
+            )
+            if effective_scope == "user":
+                from agentbundle.commands.install import (
+                    _AdapterResolutionRefused,
+                    _render_for_user_scope,
+                )
+
+                try:
+                    rendered = _render_for_user_scope(
+                        pack_path,
+                        adapter=None,
+                        allowed_adapters=_allowed_adapters,
+                        contract_version=_contract_version,
+                        state_adapter=pack_state.adapter,
+                        command_name="diff",
+                    )
+                except _AdapterResolutionRefused as exc:
+                    print(str(exc), file=sys.stderr)
+                    return 1
+            else:
+                from agentbundle.commands.install import (
+                    _AdapterResolutionRefused,
+                    _render_for_repo_scope,
+                )
+
+                try:
+                    _adapter, rendered = _render_for_repo_scope(
+                        pack_path,
+                        adapter=None,
+                        allowed_adapters=_allowed_adapters,
+                        contract_version=_contract_version,
+                        state_adapter=pack_state.adapter,
+                        command_name="diff",
+                    )
+                except _AdapterResolutionRefused as exc:
+                    print(str(exc), file=sys.stderr)
+                    return 1
     except (FileNotFoundError, ValueError) as exc:
         print(f"error: render failed for pack at '{pack_path}': {exc}", file=sys.stderr)
         return 1

--- a/packages/agentbundle/agentbundle/commands/upgrade.py
+++ b/packages/agentbundle/agentbundle/commands/upgrade.py
@@ -112,7 +112,7 @@ def run(args: "argparse.Namespace") -> int:
     # the pack is installed at user only. At user scope, `root` is the
     # user's home and the state file is `<root>/.agentbundle/state.toml`.
     effective_scope = "repo"
-    user_prefixes: list[str] | None = None
+    allowed_prefixes: list[str] | None = None
     if cli_scope == "user" or (cli_scope is None and installed_at_user and not installed_at_repo):
         if user_state_path is None:
             print(
@@ -131,7 +131,7 @@ def run(args: "argparse.Namespace") -> int:
             if pack_name in user_state_for_check.packs
             else "claude-code"
         ) or "claude-code"
-        user_prefixes = _adapter_allowed_prefixes_user(recorded_adapter)
+        allowed_prefixes = _adapter_allowed_prefixes_user(recorded_adapter)
 
     # ── Detect per-primitive flag ─────────────────────────────────────────────
     prim_flag: str | None = None
@@ -272,7 +272,50 @@ def run(args: "argparse.Namespace") -> int:
                 target_adapter=_new_target_adapter,
             )
         else:
-            projection = render_pack(pack_dir)
+            # Repo-scope render. RFC-0012 lifted the install default at
+            # this scope from the dist-tree producer to a per-IDE
+            # projection (`.claude/...`, `.kiro/...`, ...). Upgrade
+            # must mirror that shape, else the rendered keys won't
+            # overlap the install-time state.files keys and a whole-
+            # pack upgrade silently accretes a parallel dist-tree
+            # subtree into state.files (and onto disk via
+            # safety.write_jailed below).
+            #
+            # Backward compat for the `--emit-install-routes` install
+            # path (RFC-0012 § *CLI surface*): if existing state.files
+            # already carries dist-tree-shaped paths, this was a
+            # catalogue-publishing install — keep rendering the legacy
+            # shape so we don't accrete a parallel per-IDE subtree on
+            # top.
+            _was_dist_tree_install = any(
+                rp.startswith(("apm/", "claude-plugins/"))
+                or rp == "marketplace.json"
+                for rp in pack_state.files
+            )
+            if _was_dist_tree_install:
+                projection = render_pack(pack_dir)
+            else:
+                from agentbundle.commands.install import (
+                    _AdapterResolutionRefused,
+                    _adapter_allowed_prefixes_repo,
+                    _render_for_repo_scope,
+                )
+
+                try:
+                    _resolved_adapter, projection = _render_for_repo_scope(
+                        pack_dir,
+                        adapter=None,
+                        allowed_adapters=_pack_allowed_adapters,
+                        contract_version=_pack_contract_version,
+                        state_adapter=pack_state.adapter,
+                        command_name="upgrade",
+                    )
+                except _AdapterResolutionRefused as exc:
+                    print(str(exc), file=sys.stderr)
+                    return 1
+                allowed_prefixes = _adapter_allowed_prefixes_repo(
+                    _resolved_adapter
+                )
     except (FileNotFoundError, ValueError) as exc:
         print(f"upgrade: render failed for pack {pack_name!r}: {exc}", file=sys.stderr)
         return 1
@@ -323,7 +366,7 @@ def run(args: "argparse.Namespace") -> int:
                 safety.write_jailed(
                     root, relpath, content,
                     scope=effective_scope,
-                    allowed_prefixes=user_prefixes,
+                    allowed_prefixes=allowed_prefixes,
                 )
             except safety.PathJailError as exc:
                 print(f"upgrade: {exc}", file=sys.stderr)
@@ -426,11 +469,18 @@ def run(args: "argparse.Namespace") -> int:
 
     state_toml_content = dump_state(state)
     state_relpath = state_path.relative_to(root).as_posix()
+    # Mirror install.py:858-861 — the repo-scope state file lives at
+    # `<root>/.agentbundle-state.toml`, a top-level path that won't
+    # match the per-IDE `allowed-prefixes.repo` list. Skip the prefix
+    # check for that one file so the state write isn't blocked.
+    state_prefixes = allowed_prefixes
+    if effective_scope == "repo" and state_relpath == ".agentbundle-state.toml":
+        state_prefixes = None
     try:
         safety.write_jailed(
             root, state_relpath, state_toml_content,
             scope=effective_scope,
-            allowed_prefixes=user_prefixes,
+            allowed_prefixes=state_prefixes,
         )
     except safety.PathJailError as exc:
         print(f"upgrade: {exc}", file=sys.stderr)

--- a/packages/agentbundle/tests/integration/test_install_repo_scope_per_adapter.py
+++ b/packages/agentbundle/tests/integration/test_install_repo_scope_per_adapter.py
@@ -240,26 +240,24 @@ def _plant_state_row(
 
 
 class RepoScopeUpgradeWithStateHintTests(unittest.TestCase):
-    """AC33 upgrade-with-state-hint case — **defensive regression pin**.
+    """AC33 upgrade-with-state-hint case — **AC10b parity at repo scope**.
 
-    The spec asks for "AC10b parity at repo scope". AC10b proper (the
-    state-hint short-circuit inside ``_resolve_target_adapter``) is
-    not exercised at repo-scope upgrade today because
-    ``upgrade.py:230+`` only invokes the resolver when
-    ``effective_scope == "user"`` — repo scope falls through to
-    ``render_pack`` (dist-tree shape). The cross-adapter refusal at
-    ``upgrade.py:371-379`` is structurally unreachable at repo scope
-    by the same gating.
+    Now that repo-scope upgrade routes through
+    ``_render_for_repo_scope`` (mirroring install), AC10b is real at
+    this scope: ``upgrade.run`` invokes ``_resolve_target_adapter``
+    with ``state_adapter=pack_state.adapter`` so a Kiro-installed
+    pack stays on Kiro even when the resolver's legacy heuristic
+    would otherwise pick Claude Code on observing a populated
+    ``<repo>/.claude/`` directory.
 
-    This test pins that structure: ``state.adapter`` stays ``"kiro"``
-    after a repo-scope upgrade, and the ``pack adapter changed``
-    refusal does not fire. A future refactor that extends the
-    cross-adapter refusal block to repo scope without also threading
-    the state-hint short-circuit would break this test — that's the
-    regression the pin catches. Lifting repo-scope upgrade onto the
-    per-IDE projection path is explicitly Ask-first in the spec; if
-    that lift lands, this test wants tightening (assert the resolver
-    *was* called with ``state_adapter=pack_state.adapter``)."""
+    Pin: install ``--adapter kiro``, plant a Claude Code marker
+    under ``.claude/skills/``, run an upgrade with no flags. Assert
+    (a) ``state.adapter`` stays ``"kiro"``, (b) the cross-adapter
+    ``pack adapter changed`` refusal does not fire, (c) the
+    post-upgrade projection lands at ``.kiro/`` — the load-bearing
+    evidence the resolver was called with the state-hint and routed
+    to Kiro (a regression to ``render_pack`` or to the unhinted
+    resolver would re-emit dist-tree or ``.claude/`` shape)."""
 
     def setUp(self) -> None:
         _clear_inband_detection_seen()
@@ -291,6 +289,10 @@ class RepoScopeUpgradeWithStateHintTests(unittest.TestCase):
                 state["pack"]["core"].get("adapter"), "kiro",
                 f"install did not record adapter=kiro: {state!r}",
             )
+            self.assertTrue(
+                (adopter / ".kiro").exists(),
+                f"install did not land .kiro/ projection under {adopter}",
+            )
 
             # Step 2: populate <repo>/.claude/ to simulate the
             # adopter having Claude Code state present alongside Kiro.
@@ -317,20 +319,23 @@ class RepoScopeUpgradeWithStateHintTests(unittest.TestCase):
             )
             err_buf = io.StringIO()
             with redirect_stderr(err_buf):
-                _rc = upgrade.run(upgrade_args)
+                rc_upgrade = upgrade.run(upgrade_args)
             stderr = err_buf.getvalue()
 
-            # The cross-adapter refusal text from upgrade.py:371-379
-            # must not fire at repo scope. Pinning the exact substring
-            # makes a future refactor that extends the refusal block
-            # to repo scope (without state-hint) trip this assertion.
+            self.assertEqual(
+                rc_upgrade, 0,
+                f"upgrade must succeed at repo scope with state-hint; "
+                f"stderr={stderr!r}",
+            )
+
+            # The cross-adapter refusal text from upgrade.py's
+            # cross-adapter block must not fire at repo scope. Pinning
+            # the exact substring makes a future refactor that extends
+            # the refusal block to repo scope (without state-hint)
+            # trip this assertion.
             self.assertNotIn("pack adapter changed", stderr)
 
-            # State row's adapter stays kiro regardless of the upgrade's
-            # outcome (the test pins state preservation, not upgrade
-            # success — repo-scope upgrade still goes through the
-            # dist-tree renderer today; per-IDE upgrade at repo scope
-            # is a future RFC's surface).
+            # State row's adapter stays kiro across the upgrade.
             state_after = _load_state(adopter)
             recorded_after = (
                 state_after.get("pack", {}).get("core", {}).get("adapter", "claude-code")
@@ -338,6 +343,31 @@ class RepoScopeUpgradeWithStateHintTests(unittest.TestCase):
             self.assertEqual(
                 recorded_after, "kiro",
                 f"state.adapter regressed post-upgrade: {state_after!r}",
+            )
+
+            # Load-bearing evidence the resolver was called with
+            # `state_adapter="kiro"` and that the per-IDE projection
+            # landed (not the dist-tree producer's output): post-upgrade,
+            # `.kiro/` is still on disk and no `apm/`, `claude-plugins/`,
+            # or `marketplace.json` leaked into the adopter root.
+            self.assertTrue(
+                (adopter / ".kiro").exists(),
+                f"upgrade dropped .kiro/ projection — resolver was not "
+                f"called with state_adapter=kiro, or the per-IDE branch "
+                f"was bypassed; tree: "
+                f"{sorted(p.relative_to(adopter).as_posix() for p in adopter.rglob('*'))[:20]}",
+            )
+            self.assertFalse(
+                (adopter / "apm").exists(),
+                f"upgrade leaked apm/ subtree under {adopter}",
+            )
+            self.assertFalse(
+                (adopter / "claude-plugins").exists(),
+                f"upgrade leaked claude-plugins/ subtree under {adopter}",
+            )
+            self.assertFalse(
+                (adopter / "marketplace.json").exists(),
+                f"upgrade leaked marketplace.json under {adopter}",
             )
 
 

--- a/packages/agentbundle/tests/integration/test_install_repo_scope_per_adapter.py
+++ b/packages/agentbundle/tests/integration/test_install_repo_scope_per_adapter.py
@@ -341,6 +341,184 @@ class RepoScopeUpgradeWithStateHintTests(unittest.TestCase):
             )
 
 
+class RepoScopeSameVersionUpgradeStateFilesTests(unittest.TestCase):
+    """Regression: same-version `upgrade` at repo scope must not
+    silently re-shape `state.files` into the dist-tree projection nor
+    drop `apm/<pack>/` and `claude-plugins/<pack>/` subtrees into the
+    adopter's repo.
+
+    The bug: pre-fix, `upgrade.run` at repo scope called
+    `render.render_pack(pack_dir)` (the dist-tree producer used by
+    `make build`), which emits `apm/<pack>/...` +
+    `claude-plugins/<pack>/...` + `marketplace.json` keys. RFC-0012's
+    install lift uses `_render_for_repo_scope` (per-IDE shape such as
+    `.claude/skills/<name>/SKILL.md`). Same-version upgrade therefore
+    (i) wrote the dist-tree subtree on top of the per-IDE install and
+    (ii) accreted those paths into `state.files` while the
+    install-time per-IDE entries lingered — net ~3× growth.
+
+    Pin: install via the RFC-0012 default path, snapshot
+    `state.files`, run `upgrade --to <same-version>`, then assert the
+    keyset is byte-identical (same paths, no dist-tree leak) and no
+    `apm/` or `claude-plugins/` directories appear under the adopter
+    root."""
+
+    def setUp(self) -> None:
+        _clear_inband_detection_seen()
+
+    def test_same_version_upgrade_does_not_corrupt_state_or_leak_dist_tree(self) -> None:
+        from agentbundle.cli import _build_parser
+        from agentbundle.commands import install, upgrade
+
+        with TemporaryDirectory() as raw:
+            adopter = Path(raw) / "adopter"
+            adopter.mkdir()
+            parser = _build_parser()
+
+            # Step 1: install at repo scope (RFC-0012 default — no
+            # `--emit-install-routes`, no `--adapter`).
+            install_args = parser.parse_args(
+                [
+                    "install",
+                    "--pack", "core",
+                    "--scope", "repo",
+                    "--output", str(adopter),
+                    str(REPO_ROOT),
+                ]
+            )
+            rc = install.run(install_args)
+            self.assertEqual(rc, 0, "install of core must succeed")
+
+            state_before = _load_state(adopter)
+            files_before = set(
+                state_before["pack"]["core"].get("files", {}).keys()
+            )
+            self.assertTrue(
+                files_before,
+                "install must record at least one entry in state.files",
+            )
+            # Per-IDE projection — no dist-tree-shaped paths recorded.
+            for relpath in files_before:
+                self.assertFalse(
+                    relpath.startswith("apm/")
+                    or relpath.startswith("claude-plugins/")
+                    or relpath == "marketplace.json",
+                    f"install recorded unexpected dist-tree path {relpath!r}; "
+                    f"all paths: {sorted(files_before)}",
+                )
+
+            # Step 2: upgrade to the same version. The pack's `version`
+            # in `packs/core/pack.toml` is the source of truth; pin via
+            # the state row so the test stays valid through bumps.
+            installed_version = state_before["pack"]["core"]["installed-version"]
+            upgrade_args = parser.parse_args(
+                [
+                    "upgrade",
+                    "--pack", "core",
+                    "--to", installed_version,
+                    str(REPO_ROOT),
+                    "--root", str(adopter),
+                    "--scope", "repo",
+                ]
+            )
+            rc = upgrade.run(upgrade_args)
+            self.assertEqual(
+                rc, 0, "same-version upgrade at repo scope must succeed"
+            )
+
+            # Step 3: `state.files` keyset must match the install
+            # snapshot — same paths, no dist-tree leak.
+            state_after = _load_state(adopter)
+            files_after = set(
+                state_after["pack"]["core"].get("files", {}).keys()
+            )
+            new_keys = files_after - files_before
+            self.assertFalse(
+                new_keys,
+                f"upgrade added new entries to state.files: "
+                f"{sorted(new_keys)}",
+            )
+            stale_keys = files_before - files_after
+            self.assertFalse(
+                stale_keys,
+                f"upgrade dropped install-time entries from state.files: "
+                f"{sorted(stale_keys)}",
+            )
+
+            # Step 4: the adopter tree must not have grown a
+            # `claude-plugins/` or `apm/` subtree under the repo root.
+            self.assertFalse(
+                (adopter / "claude-plugins").exists(),
+                f"upgrade leaked claude-plugins/ subtree under {adopter}; "
+                f"tree: {sorted(p.relative_to(adopter).as_posix() for p in adopter.rglob('*'))[:20]}",
+            )
+            self.assertFalse(
+                (adopter / "apm").exists(),
+                f"upgrade leaked apm/ subtree under {adopter}",
+            )
+            self.assertFalse(
+                (adopter / "marketplace.json").exists(),
+                f"upgrade leaked marketplace.json under {adopter}",
+            )
+
+
+class RepoScopeDiffAfterInstallTests(unittest.TestCase):
+    """Regression: `diff` against a freshly-installed pack at repo scope
+    must report no drift.
+
+    The bug: pre-fix, `diff.run` unconditionally rendered the dist-tree
+    shape via `render.render_pack`, but RFC-0012's install lift landed
+    files at `<repo>/.claude/...` (or `.kiro/...`, etc.). The two
+    shapes never overlap, so diff returned exit 1 with every per-IDE
+    file flagged as missing — and any in-place adopter edit slipped
+    past detection because diff was looking at the wrong tree."""
+
+    def setUp(self) -> None:
+        _clear_inband_detection_seen()
+
+    def test_diff_after_install_reports_no_drift(self) -> None:
+        from agentbundle.cli import _build_parser
+        from agentbundle.commands import diff, install
+
+        with TemporaryDirectory() as raw:
+            adopter = Path(raw) / "adopter"
+            adopter.mkdir()
+            parser = _build_parser()
+
+            install_args = parser.parse_args(
+                [
+                    "install",
+                    "--pack", "core",
+                    "--scope", "repo",
+                    "--output", str(adopter),
+                    str(REPO_ROOT),
+                ]
+            )
+            rc = install.run(install_args)
+            self.assertEqual(rc, 0, "install must succeed")
+
+            diff_args = parser.parse_args(
+                [
+                    "diff",
+                    str(REPO_ROOT / "packs" / "core"),
+                    "--root", str(adopter),
+                ]
+            )
+            out_buf, err_buf = io.StringIO(), io.StringIO()
+            with redirect_stdout(out_buf), redirect_stderr(err_buf):
+                rc = diff.run(diff_args)
+
+            self.assertEqual(
+                rc, 0,
+                f"diff must report exit 0 when nothing has drifted post-install; "
+                f"stdout={out_buf.getvalue()!r} stderr={err_buf.getvalue()!r}",
+            )
+            self.assertEqual(
+                out_buf.getvalue().strip(), "",
+                f"diff must produce no stdout when in sync; got: {out_buf.getvalue()!r}",
+            )
+
+
 class RepoScopeMigrationTriggerBTests(unittest.TestCase):
     """AC33 + AC24(b): a pre-RFC-0012 state file plus on-disk dist-tree
     files refuses the install with the pinned (b) message."""


### PR DESCRIPTION
## Summary

- `agentbundle upgrade` and `agentbundle diff` at repo scope rendered via the legacy dist-tree producer (`render.render_pack`), while RFC-0012's install lift at the same scope produces per-IDE projections (`.claude/...`, `.kiro/...`). Same-version upgrade therefore accreted ~65 dist-tree-shape entries into `state.files` on top of the install-time per-IDE entries (~3× growth) and silently dropped `apm/<pack>/...`, `claude-plugins/<pack>/...`, and `marketplace.json` into the adopter's repo via `safety.write_jailed` (the prefix probe was skipped because `allowed_prefixes` was `None`). `diff` carried the same bug — `render_pack` against a per-IDE on-disk tree flagged every per-IDE path as missing.
- Root cause: RFC-0012 (PR #140) lifted `install.run` from `render_pack` to `_render_for_repo_scope` but didn't update `upgrade.run` or `diff.run`. The repo-scope-per-adapter spec carved out the upgrade lift as "Ask first"; this PR is the lift.
- Both commands now switch to `_render_for_repo_scope` / `_render_for_user_scope` and thread `pack_state.adapter` as the state-hint per RFC-0011 AC10b. A state-shape probe over `pack_state.files` keeps the legacy dist-tree shape for `--emit-install-routes` adopters; diff also falls back to dist-tree when no state row is present so the maintainer "render to dir + diff against dir" workflow still works. The repo-scope state file `<root>/.agentbundle-state.toml` skips the per-IDE prefix check in upgrade the same way install does at `install.py:858-861`.

## Regression tests

- `RepoScopeSameVersionUpgradeStateFilesTests` — install + same-version upgrade leaves `state.files` keyset byte-identical; no `apm/`, `claude-plugins/`, or `marketplace.json` on disk.
- `RepoScopeDiffAfterInstallTests` — diff after install returns 0 with empty stdout.
- `RepoScopeUpgradeWithStateHintTests` — tightened in the follow-up commit to close its pre-existing "if the lift lands, tighten this" TODO: now asserts `upgrade.run` returns 0, `.kiro/` projection persists post-upgrade (load-bearing evidence the resolver routed through the state-hint), and no dist-tree leak.

Both new tests were confirmed **red against the unfixed code** before the fix landed.

## Out of scope (follow-ups)

- **Cross-version stale-entry growth:** if v2 drops a file that v1 projected, the v1 entry lingers in `state.files`. A naive `pack_state.files = {}` reset would break Tier-2 collision detection (the classifier reads recorded SHAs to decide adopter-edit collisions); the safe shape needs its own spec.
- **Spec wording update for `repo-scope-per-adapter-projection`:** the "Ask first" carve-out for the upgrade lift can be retired now that the lift shipped. Doc-only PR.

## Test plan

- [x] `python -m pytest tests/` (full suite excluding build-check tests that need `make build` first) — 1073 pass, 1 skipped.
- [x] `python -m pytest tests/integration/test_install_repo_scope_per_adapter.py` — 10/10 pass.
- [x] `python tools/hooks/pre-pr.py` — all lint checks pass.
- [x] Manually verified the new regression tests fail red on `main` and green on this branch.