### PR TITLE
fix(install): orphan-cleanup must consult state for foreign-pack ownership

### DIFF
--- a/packages/agentbundle/agentbundle/commands/install.py
+++ b/packages/agentbundle/agentbundle/commands/install.py
@@ -1413,6 +1413,42 @@ def _classify_pre_rfc0012_state(
             output_root, allowed_prefixes_repo,
             pack_dir=pack_dir, pack_name=pack_name,
         )
+        # The scanner's primitive-name heuristic is best-effort scoping,
+        # not authoritative ownership. When two packs ship primitives
+        # whose names collide (segment-match or stem-match), the
+        # scanner mis-attributes the foreign pack's file as an orphan
+        # of the installing pack — and the --force branch below would
+        # unlink another state-tracked pack's file. ``state.toml`` IS
+        # authoritative: filter out paths claimed by any other pack's
+        # state row before treating the scanner's result as orphans.
+        #
+        # Compare with NFC + ``os.path.normcase`` on both sides so a
+        # case-insensitive filesystem (Windows NTFS, HFS+) or a
+        # filesystem that returned the path in a different Unicode
+        # normalisation form (macOS NFD ↔ NFC) doesn't fail-open and
+        # let a foreign-owned path slip through into the unlink set.
+        if orphans:
+            import os as _os
+            import unicodedata as _unicodedata
+
+            def _canon_relpath(rel: str) -> str:
+                return _unicodedata.normalize(
+                    "NFC", _os.path.normcase(rel)
+                )
+
+            foreign_owned: set[str] = set()
+            for other_name, other_state in repo_state.packs.items():
+                if other_name == pack_name:
+                    continue
+                foreign_owned.update(
+                    _canon_relpath(rel) for rel in other_state.files.keys()
+                )
+            if foreign_owned:
+                orphans = [
+                    p for p in orphans
+                    if _canon_relpath(p.relative_to(output_root).as_posix())
+                    not in foreign_owned
+                ]
         if orphans:
             _INBAND_DETECTION_SEEN.add(key)
             if force:

--- a/packages/agentbundle/tests/integration/test_orphan_cleanup_respects_foreign_state.py
+++ b/packages/agentbundle/tests/integration/test_orphan_cleanup_respects_foreign_state.py
@@ -1,0 +1,265 @@
+"""Regression: orphan-cleanup must not unlink files claimed by other
+state-tracked packs.
+
+Reported by an adopter: when installing pack B with ``--force`` into a
+directory where pack A is already installed, the installer's orphan
+detection treats pack A's projected files as "orphan projection files"
+and deletes them. The state file retains pack A's row with its
+recorded SHA, but the on-disk file is gone (or, worse, silently
+overwritten with pack B's content of the same name). State is now
+lying about disk.
+
+Root cause: ``safety.scan_for_pack_artifacts`` uses a primitive-name
+heuristic to attribute on-disk files to the installing pack. The
+heuristic is best-effort scoping — it does not consult the state file
+to exclude paths claimed by *other* state-tracked packs. When two
+packs ship primitives with overlapping names, the heuristic
+mis-attributes the foreign pack's file as an orphan of the installing
+pack; ``_classify_pre_rfc0012_state``'s branch (c) ``--force`` clause
+then unlinks them.
+
+Catalogue today has no primitive-name overlaps across shipped packs
+(verified at the time of writing), so the bug is dormant against
+default catalogue use — but adopters with custom packs, or any future
+catalogue change that introduces an overlap, trigger it. The fix
+makes the orphan filter authoritative: paths claimed by another
+state-tracked pack are excluded from the orphan list.
+
+Tests in this module use synthetic packs because the bug requires a
+primitive-name collision that the shipped catalogue does not exhibit.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import io
+import textwrap
+import tomllib
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Test hygiene
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home_and_caches(tmp_path, monkeypatch):
+    """Same isolation pattern as test_multi_pack_install.py — see that
+    file's fixture docstring for the rationale (HOME isolation +
+    once-per-process cache reset)."""
+    from agentbundle.commands import install
+
+    home = tmp_path / "iso_home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    install._clear_inband_detection_seen()
+    install._clear_dropped_warning_seen()
+    yield
+    install._clear_inband_detection_seen()
+    install._clear_dropped_warning_seen()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _stage_pack(
+    cat_root: Path, name: str, *, skills: list[str],
+) -> Path:
+    """Materialise a synthetic pack at ``cat_root/packs/<name>/`` with the
+    given skill names. Each skill is a directory under ``.apm/skills/``
+    containing a ``SKILL.md`` whose body identifies the pack of origin
+    so post-install content can be attributed.
+    """
+    pack_dir = cat_root / "packs" / name
+    pack_dir.mkdir(parents=True)
+    (pack_dir / "pack.toml").write_text(
+        textwrap.dedent(
+            f"""\
+            [pack]
+            name = "{name}"
+            version = "0.1.0"
+
+            [pack.adapter-contract]
+            version = "0.8"
+
+            [pack.install]
+            default-scope = "repo"
+            allowed-scopes = ["repo"]
+            """
+        ),
+        encoding="utf-8",
+    )
+    apm = pack_dir / ".apm"
+    apm.mkdir()
+    for skill in skills:
+        sd = apm / "skills" / skill
+        sd.mkdir(parents=True)
+        (sd / "SKILL.md").write_text(
+            f"---\nname: {skill}\ndescription: from-{name}\n---\nBody from {name}.",
+            encoding="utf-8",
+        )
+    return pack_dir
+
+
+def _install_argv(argv: list[str]) -> tuple[int, str, str]:
+    """Run install via the argparse parser; return (rc, stdout, stderr)."""
+    from agentbundle.cli import _build_parser
+    from agentbundle.commands import install
+
+    parser = _build_parser()
+    args = parser.parse_args(["install"] + argv)
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        rc = install.run(args)
+    return rc, out.getvalue(), err.getvalue()
+
+
+def _state(adopter: Path) -> dict:
+    return tomllib.loads(
+        (adopter / ".agentbundle-state.toml").read_text(encoding="utf-8")
+    )
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_force_install_does_not_unlink_foreign_packs_file(tmp_path):
+    """Pack A ships ``shared-tool`` skill, then pack B (which also
+    ships ``shared-tool``) is installed with ``--force``. The orphan-
+    cleanup branch MUST NOT unlink pack-a's file, and pack-a's state
+    row MUST remain intact.
+
+    With the bug: pack-b's orphan scan returns pack-a's file (segment
+    match on the shared primitive name); the ``--force`` branch
+    unlinks it via ``orphan.unlink()``. Between the unlink and pack-b's
+    subsequent write, pack-a's file is genuinely missing — and if
+    pack-b's render fails mid-flight, pack-a's file is permanently
+    lost while pack-a's state row keeps claiming it.
+
+    With the fix: scanner result is filtered to exclude paths claimed
+    by other state-tracked packs (state.toml is authoritative; the
+    primitive-name heuristic is best-effort scoping). The orphans
+    list is filtered down — pack-a's file is excluded — so no foreign
+    file is unlinked in the ``--force`` branch.
+
+    SCOPE NOTE: when two packs intentionally project to the same
+    on-disk path, ``_classify_for_install`` already warns + allows the
+    write-step overwrite — that is the catalogue-level path-collision
+    contract today. This test does NOT pin write-step content (which
+    the existing contract allows to be pack-b's) — it pins only that
+    the **orphan-cleanup unlink does not fire** for a foreign-owned
+    path, which closes the user's specific report ("the actual files
+    are gone from disk").
+    """
+    cat = tmp_path / "cat"
+    _stage_pack(cat, "pack-a", skills=["shared-tool"])
+    _stage_pack(cat, "pack-b", skills=["shared-tool", "b-only"])
+
+    adopter = tmp_path / "adopter"
+    adopter.mkdir()
+
+    # Install pack-a.
+    rc, _, err = _install_argv(
+        ["--pack", "pack-a", "--output", str(adopter), str(cat)]
+    )
+    assert rc == 0, f"pack-a install failed: {err}"
+
+    shared_path = adopter / ".claude/skills/shared-tool/SKILL.md"
+    assert shared_path.exists()
+
+    # Spy on Path.unlink to record every unlink the install handler
+    # performs. The orphan-cleanup branch unlinks via ``orphan.unlink()``;
+    # if the bug is live, that call lands for shared_path. The spy
+    # records the absolute path so we can assert pack-a's file was NOT
+    # in the unlink set.
+    unlinked: list[Path] = []
+    from pathlib import Path as _Path
+    original_unlink = _Path.unlink
+
+    def _spy_unlink(self, *args, **kwargs):
+        unlinked.append(self)
+        return original_unlink(self, *args, **kwargs)
+
+    import unittest.mock
+    with unittest.mock.patch.object(_Path, "unlink", _spy_unlink):
+        rc, _, err = _install_argv(
+            ["--pack", "pack-b", "--force",
+             "--output", str(adopter), str(cat)]
+        )
+
+    assert rc == 0, f"pack-b --force install failed: {err}"
+
+    # Load-bearing post-conditions: pack-a's state row preserved and
+    # NO call to unlink targeted pack-a's file.
+    state = _state(adopter)
+    assert "pack-a" in state.get("pack", {}), (
+        "pack-a's state row was dropped by pack-b install"
+    )
+    pack_a_unlinks = [u for u in unlinked if u.resolve() == shared_path.resolve()]
+    assert not pack_a_unlinks, (
+        f"--force install of pack-b unlinked pack-a's state-tracked file "
+        f"{shared_path}; the orphan-cleanup branch mis-attributed it. "
+        f"All unlinks during install: {unlinked!r}"
+    )
+
+
+def test_orphan_refusal_does_not_cite_foreign_owned_paths(tmp_path):
+    """The orphan-refusal stderr message MUST NOT cite paths owned by
+    another state-tracked pack as "orphans" — that's a lie about
+    ownership and misleads adopters into running ``--force`` (which
+    would clobber the foreign pack).
+
+    With the bug: pack-b install (no --force) emits
+    ``install: orphan projection files for pack pack-b at <pack-a's
+    file>``, naming pack-a's state-tracked file as a pack-b orphan.
+    With the fix: the orphan list is filtered to exclude foreign-owned
+    paths; if every "orphan" found by the scanner is in fact
+    foreign-owned, the refusal does not fire and install proceeds
+    (rc=0). The assertion is unconditional — checking ``pack_a_file
+    not in err`` regardless of whether the refusal message fires, so a
+    future stderr rewording can't make this test silently vacuous.
+    """
+    cat = tmp_path / "cat"
+    _stage_pack(cat, "pack-a", skills=["shared-tool"])
+    _stage_pack(cat, "pack-b", skills=["shared-tool"])
+
+    adopter = tmp_path / "adopter"
+    adopter.mkdir()
+
+    rc, _, err = _install_argv(
+        ["--pack", "pack-a", "--output", str(adopter), str(cat)]
+    )
+    assert rc == 0, f"pack-a install failed: {err}"
+
+    rc, _, err = _install_argv(
+        ["--pack", "pack-b", "--output", str(adopter), str(cat)]
+    )
+    # Load-bearing: with the fix, the orphan-refusal branch must not
+    # fire for pack-b — every "orphan" the scanner returned was in
+    # fact pack-a's foreign-owned file, filtered out by the foreign-
+    # state-consultation pass. The install proceeds (rc=0).
+    assert rc == 0, (
+        f"pack-b install must proceed cleanly after the fix; the "
+        f"orphan-refusal branch fired against a foreign-owned path. "
+        f"rc={rc}, stderr: {err!r}"
+    )
+    # And the specific orphan-refusal phrasing must NOT have been
+    # emitted (positive signal that the filter ran, not that the
+    # branch was bypassed for some other reason).
+    assert "orphan projection files for pack pack-b" not in err, (
+        f"orphan refusal still fired against a foreign-owned path; "
+        f"stderr: {err!r}"
+    )


### PR DESCRIPTION
## Summary

Closes a real cross-pack file-clobber bug in `agentbundle install`: the orphan-recovery branch in `_classify_pre_rfc0012_state` was returning a state-tracked foreign pack's files as "orphans" of the installing pack, and `--force` unlinked them. After fix: `state.toml` is consulted as authoritative ownership, the foreign-owned paths are filtered out of the orphan list, and the unlink no longer fires for them.

Reported by adopter as:
> When installing pack B with `--force` into a directory where pack A is already installed, the installer's orphan detection treats pack A's projected files as "orphan projection files" and deletes them. The state file retains the entries (with SHAs), but the actual files are gone from disk.

## Root cause

`safety.scan_for_pack_artifacts` uses a primitive-name heuristic (segment-or-stem match against the installing pack's `.apm/` tree). It's best-effort scoping, not authoritative ownership. If two state-tracked packs ship primitives with overlapping names, the foreign pack's files match the installing pack's heuristic. The orphan-recovery branch at `_classify_pre_rfc0012_state` then unlinks them under `--force`.

The shipped catalogue has no primitive-name overlaps across packs (verified at the time of writing) so the bug is dormant in default use — but any adopter custom pack collision triggers it.

## Fix

After the scanner returns its candidate orphan list, exclude every path that appears in another pack's `[pack.<x>.files]` table in `repo_state`. The compare uses NFC + `os.path.normcase` on both sides so a case-insensitive filesystem (Windows NTFS, HFS+) or a filesystem returning the path in a different Unicode normalisation form (macOS NFD ↔ NFC) doesn't fail-open. 36 lines added in `install.py`.

## Scope (explicit per bug-fix discipline)

- **In scope:** orphan-cleanup mis-attribution under `--force`. The user's specific report ("files gone from disk").
- **Out of scope, by design:** when two packs intentionally project to the same on-disk path, `_classify_for_install` already warns + allows the write-step overwrite. This PR does not change that contract.
- **Pre-existing concerns deferred (security reviewer raised, not introduced by this diff):**
  - Symlink in orphan set — `Path.unlink` removes the link only, not the target; the residual is bounded. A future change to `safety.scan_for_pack_artifacts` (defence in depth) could skip symlinks at scan time.
  - Concurrent installs against the same adopter root — entire install command lacks an advisory lock; this affects every state-consulting decision, not just this one.

## Test coverage

New file: `packages/agentbundle/tests/integration/test_orphan_cleanup_respects_foreign_state.py` (2 tests). Uses synthetic name-colliding packs because the shipped catalogue has none.

- `test_force_install_does_not_unlink_foreign_packs_file` — spy on `Path.unlink` asserts the orphan-cleanup branch does NOT target the foreign pack's file under `--force`.
- `test_orphan_refusal_does_not_cite_foreign_owned_paths` — install proceeds (rc=0) and the orphan-refusal phrasing does NOT fire against a foreign-owned path under no-force.

Both fail red against unfixed code, pass green after the fix (verified by stashing the production change and re-running).

## Process

- Followed `bug-fix` skill: reproduce → failing test (red) → root cause → minimum fix → verify root vs symptom.
- Followed `work-loop` skill: PLAN with verification mode + declined-pattern register; EXECUTE; GATES (pre-pr, full suite); REVIEW (adversarial + security in parallel; 2 iterations until clean).

## Gates

- `tools/hooks/pre-pr.py`: all 8 lints green.
- Full `agentbundle` suite: 1147 passed, 1 skipped, 1 pre-existing failure (`test_make_build_check_passes_post_migration` — requires `make build` artifacts in `dist/`; not introduced by this PR).
- Adversarial + security reviewer iterations: both return `Clean — ready to commit.`

## Test plan
- [ ] CI: pre-pr green.
- [ ] CI: full `agentbundle` suite green except the same pre-existing `test_make_build_check_passes_post_migration` failure (not introduced by this PR).
- [ ] Reviewer: confirm scope decision (write-step overwrite left to existing warn-and-allow contract).