### PR TITLE
feat(work-loop): bundled-fixes carve-out, named resolution modes, reviewer suppressions

### DIFF
--- a/.claude/agents/adversarial-reviewer.md
+++ b/.claude/agents/adversarial-reviewer.md
@@ -116,8 +116,27 @@ checklists; verification-mode awareness applies to every review.
    specific cases it might not.
 3. **Errors.** What does the caller see when things go wrong? "Returns an
    error" is not enough — what error, with what payload?
+<!-- Bundled-fixes carve-out mirrors work-loop/SKILL.md § EXECUTE.
+     Keep all three sites (this file, work-loop/SKILL.md,
+     implementer.md operating envelope) in sync when changing the
+     gates. -->
 4. **Scope.** Does the diff contain changes outside the plan? Each
-   out-of-scope change is a Blocker until justified or extracted.
+   out-of-scope change is a Blocker until justified, extracted, or
+   listed in the PR description's `Bundled fixes:` section. Authorized
+   bundled fixes are same-area, same-concern, mechanical ride-alongs
+   (dead import the change orphaned, stale comment that now
+   contradicts the new code, unused local the change orphaned,
+   sibling-file typo). The causal qualifier matters — a pre-existing
+   dead import or unused local that *this change didn't orphan* is
+   not a ride-along; it's an out-of-scope cleanup attempt.
+   *Same area* = a file in a directory that already contains a file
+   the change is editing — at review time the merged PR diff defines
+   the change. If a `Bundled fixes:` line claims something outside a
+   touched directory, requires a design call, or changes user-visible
+   behavior, that's still a Blocker — the carve-out fails closed.
+   Flag the bundle as Blocker-grade sprawl if it isn't visibly
+   smaller than the primary change — i.e. if a reader couldn't
+   immediately tell which part is primary and which are ride-alongs.
 5. **Spec drift.** If the implementation differs from the spec, the spec
    must be updated in the same PR. Otherwise it's drift, not done.
 6. **Security and privacy.** What data does this touch? Is access
@@ -194,6 +213,54 @@ asks for that scheme.
 
 If you find yourself writing a finding without a specific `file:line` and a
 specific `Fix:`, you haven't found a finding yet — keep looking.
+
+## What not to flag
+
+**Read the full diff before flagging anything.** A finding that's
+already addressed elsewhere in the same diff is noise. **When in
+doubt, flag.** The list below is the complete enumeration of
+suppressible categories; anything not on this list is not
+suppressible. **If a candidate suppression is actually a decision
+(behavioral, structural, user-visible), don't suppress — surface it
+as a Concern.** Suppression silences noise; it does not silence
+questions the operator should answer.
+
+- **Harmless redundancy that aids readability** (e.g., `present?`
+  alongside `length > 20`). Skip when the redundancy is *harmless* and
+  *aids* clarity. If the redundancy hides a bug or contradicts intent,
+  it's still a finding.
+- **"Add a comment explaining a self-evident tunable threshold"** —
+  e.g., a `MAX_RETRIES = 3` whose value is the comment's content.
+  Thresholds derived from a spec AC, regulatory limit, calibrated /
+  measured value, or otherwise non-obvious origin still warrant a
+  one-line *why* comment — those are "non-obvious invariants" in the
+  sense `quality-engineer.md` § Maintainability uses the phrase.
+  Suppress the request only when the comment would restate the
+  literal.
+- **"This assertion could be tighter"** when the assertion already
+  covers the behavior under test. Tighter ≠ better when the looser
+  form is correct.
+- **Consistency-only changes** — don't ask for one call site to match
+  the shape of another when both forms are correct. Premature
+  uniformity is its own cost.
+- **"Regex doesn't handle edge case X"** when the input is constrained
+  at a *verified boundary*. A verified boundary is one of: (a) type
+  narrowing visible in the same function, (b) an assertion or
+  validation call in the PR's call graph that rejects the edge case,
+  or (c) a documented invariant in the spec. "X never occurs in
+  practice" without one of these citations is not a suppression — that's
+  the famous-last-words category, and the finding stands.
+- **"Test exercises multiple guards simultaneously."** Tests aren't
+  required to isolate every guard; a single test covering several is
+  fine when the contract is the composite behavior.
+- **Linter-enforced style preferences** (quote style, import order,
+  whitespace). The linter is the source of truth; reviewer prose on
+  the same point is noise.
+- **Speculative future-proofing.** "What if we want to support X
+  later?" is out — the project explicitly refuses designing for
+  hypothetical future requirements.
+- **Backwards-compat shims for in-repo callers.** When the project can
+  just change the code, asking for a shim is noise.
 
 ## What you do not do
 

--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -37,9 +37,28 @@ If the supervisor's brief omits the spec/plan paths, ask — don't guess.
   checked out branch `<base>-<task-id>` there. All your edits happen
   inside that directory. Use `cd` or absolute paths; do not edit files
   in the primary worktree.
+<!-- Bundled-fixes carve-out mirrors work-loop/SKILL.md § EXECUTE.
+     Keep all three sites (this file, work-loop/SKILL.md,
+     adversarial-reviewer.md scope check #4) in sync when changing
+     the gates. -->
 - **One task:** implement only the task you were assigned. If you
-  notice an unrelated issue, note it in your report under "Out of
-  scope observed" — do not fix it.
+  notice an unrelated issue, default to noting it under "Out of scope
+  observed" and do not fix it. **Exception — bundled-fixes carve-out.**
+  If the supervisor's brief explicitly authorizes bundled fixes, you
+  may land same-area, same-concern, mechanical ride-alongs (dead
+  import, stale comment that now contradicts the new code, unused
+  local the change orphaned, typo in a sibling file). *Same area*
+  means a file in a directory that already contains a file this task
+  is editing — siblings in the touched directory, not a walk-up to
+  the parent and not a sideways jump to a directory this task isn't
+  editing. Report ride-alongs under `Bundled fixes:`. The carve-out
+  fails closed on any of: a file outside a touched directory, a
+  design call, a behavior change — those stay under "Out of scope
+  observed". Keep ride-alongs individually small (a line or two
+  each). The bundle should be visibly smaller than the primary
+  change — if a reader couldn't immediately tell which part is
+  primary and which are ride-alongs, you've sprawled; drop the
+  surplus to "Out of scope observed" for the supervisor to triage.
 - **Gates:** run the project's lint, typecheck, and test commands as
   documented in `AGENTS.md` and the project's root README. Capture
   pass/fail and any failing output. Your gate results are **advisory**
@@ -87,6 +106,12 @@ terse — the supervisor reads N reports in one context.
 
 **Deviations from the task body**
 <bullet list, or "none">
+
+**Bundled fixes:**
+<bullet list of same-area mechanical ride-alongs landed under the
+carve-out, or "none". Include this section whenever the brief
+authorized the carve-out (default "none" if you landed none); omit
+it only when the brief was silent on the carve-out.>
 
 **Out of scope observed**
 <bullet list of issues you noticed but did not fix, or "none">

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -208,6 +208,41 @@ goal. Resist the urge to fix unrelated things you notice along the way;
 note them in `notes/` for later. Scope creep is the single biggest source
 of plan-vs-implementation drift.
 
+<!-- Bundled-fixes carve-out — canonical site. Mirrored by
+     implementer.md (operating envelope) and adversarial-reviewer.md
+     (scope check #4). Keep all three in sync. -->
+**Bundled-fixes carve-out.** Same-area, same-concern, mechanical
+ride-alongs land in the change — dead import, stale comment that now
+contradicts the new code, unused local the change orphaned, typo in a
+sibling file. *Same area* means a file in a directory that already
+contains a file the change is editing — siblings in the touched
+directory, not a walk-up to the parent and not a sideways jump to a
+directory the change isn't editing. "The change" = the current plan
+task for the executor; the merged PR diff for the reviewer. The
+reviewer is loading that directory's context for the primary change;
+tagging along is cheap. List ride-alongs in the PR description under
+`Bundled fixes:`, one line each, so the reviewer can scan them at a
+glance. The carve-out fails closed on any of: a file outside a
+touched directory, a design call, a behavior change. Those still go
+to `notes/` (EXECUTE-phase surplus, picked up by a future plan task);
+contrast with the DECIDE-phase `Deferred:` bucket below, which holds
+reviewer findings the loop chose not to fix — different lifecycle,
+different reader. **Volume guard** — bundled fixes are individually small
+(a line or two each). The bundle should also be visibly smaller than
+the primary change: if a reviewer reading the PR couldn't immediately
+tell which part is the primary change and which are ride-alongs, you
+sprawled — move the surplus to `notes/`. In supervisor mode, the
+dispatch brief explicitly authorizes the carve-out and restates the
+gates so the implementer applies them per its own task; without that
+authorization line the implementer defaults to no-carve-out.
+
+**`Bundled fixes:` in the PR description.** The work-loop emits a
+named `Bundled fixes:` section in the PR description that doesn't
+appear in the project's PR template — one line per ride-along landed
+under the carve-out above. Append it as a standalone section below
+the standard template content; do not modify the template itself.
+(See step 5 for the companion `Deferred:` section.)
+
 #### Parallel dispatch discipline
 
 When this skill fans out — multiple implementers in supervisor mode, or
@@ -328,9 +363,29 @@ checklist instead:
 
 ### 5. DECIDE — fix or finish
 
-- **Blockers from review** → go to FIX, then re-run GATES and REVIEW.
-- **Concerns from review** → fix the ones you can in this PR; capture the
-  rest as follow-up issues. Don't let "concerns" rot in chat.
+Route each reviewer finding into one of two resolution modes — `apply`
+(fix in this PR) or `defer` (capture as a follow-up). This is the
+work-loop's interpretation of reviewer output; the reviewer keeps its
+narrow Blockers / Concerns / Nits contract. Once routed, act on each
+mode below, then evaluate the terminal-state bullet last.
+
+- **Blockers** → `apply`. Re-run GATES and REVIEW after each fix.
+- **Concerns** → `apply` if mechanical and in scope (default for any
+  Concern whose fix meets the bundled-fixes gates above). `defer` if
+  the fix would cross files outside the plan, require a design call,
+  or change user-visible behavior the spec didn't authorize. Don't let
+  Concerns rot in chat — every Concern resolves into one of the two.
+- **Nits** → same two modes as Concerns. `apply` if they meet the
+  bundled-fixes gates above (ride along in `Bundled fixes:`).
+  Otherwise `defer` — one line in `Deferred:`. Every Nit resolves
+  into one of the two; the `Deferred:` line *is* the acknowledgement
+  that the loop saw the Nit and chose not to fix.
+- **Deferred items** → one-line follow-up note in the PR description
+  under `Deferred:` so they don't rot. Append it as a standalone
+  section below the standard template content alongside the
+  `Bundled fixes:` section from EXECUTE; do not modify the template
+  itself. Don't open separate issues by default — the PR is the
+  durable record.
 - **Gates green and review clean** → ready to ship. Walk this end-of-session
   checklist; refuse to declare done until every line is true:
   - GATES were clean (lint, typecheck, tests).

--- a/.claude/skills/work-loop/references/supervisor-mode.md
+++ b/.claude/skills/work-loop/references/supervisor-mode.md
@@ -49,8 +49,15 @@ not edit `state.json` or invoke `git worktree` directly.
 
 2. **Dispatch implementers in parallel** per the parallel-dispatch
    discipline (see parent SKILL body). Each brief includes: the task
-   ID, the plan-task body, the worktree path, and paths to the spec +
-   plan.
+   ID, the plan-task body, the worktree path, paths to the spec +
+   plan, and an explicit **bundled-fixes authorization line** —
+   "Bundled fixes authorized per the carve-out in `work-loop/SKILL.md`
+   (EXECUTE phase); apply same-area, same-concern, mechanical
+   ride-alongs only and report under `Bundled fixes:` in your output."
+   If a particular task should run without the carve-out (e.g. a
+   high-blast-radius migration), omit the authorization line; the
+   implementer defaults to no-carve-out and routes everything to
+   "Out of scope observed".
 
 3. **Persist each report and update state.** For each returning
    subagent, write its markdown report to disk, then run
@@ -101,6 +108,15 @@ not edit `state.json` or invoke `git worktree` directly.
    weren't actually independent — the tool runs `git merge --abort`,
    exits non-zero, and names the offending task ID. Return to PLAN and
    fix the `Depends on:` declarations.
+
+   **Lift `Bundled fixes:` into the PR body.** Each implementer report
+   may carry a `Bundled fixes:` section listing ride-alongs landed
+   under the carve-out. After merge succeeds, collect those lines
+   from every ready report, dedupe by exact-string match (falling
+   back to operator judgment when two lines describe the same change
+   in different words), and emit a single `Bundled fixes:` section
+   in the PR description below the standard template. If no
+   implementer landed ride-alongs, omit the section.
 
 6. **Clean up worktrees.** After all merges succeed, run
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,10 @@ Scope each change precisely to the request.
 - **Add a flag or option only when a second caller actually needs to
   differ.** Today's one caller is enough to define the shape.
 - **Add docstrings and types to code the change actually touches.**
-  Leave nearby untouched code as it is.
+  Leave nearby untouched code as it is — except under the
+  bundled-fixes carve-out defined in the `work-loop` skill (same-area,
+  same-concern, mechanical ride-alongs only; surplus still goes to
+  follow-up).
 - **Validate at boundaries the request crosses** (user input, external
   APIs). Trust internal callers and framework guarantees.
 - **Inline a single-use operation.** Extract a helper once a second

--- a/packs/core/.apm/agents/adversarial-reviewer.md
+++ b/packs/core/.apm/agents/adversarial-reviewer.md
@@ -116,8 +116,27 @@ checklists; verification-mode awareness applies to every review.
    specific cases it might not.
 3. **Errors.** What does the caller see when things go wrong? "Returns an
    error" is not enough — what error, with what payload?
+<!-- Bundled-fixes carve-out mirrors work-loop/SKILL.md § EXECUTE.
+     Keep all three sites (this file, work-loop/SKILL.md,
+     implementer.md operating envelope) in sync when changing the
+     gates. -->
 4. **Scope.** Does the diff contain changes outside the plan? Each
-   out-of-scope change is a Blocker until justified or extracted.
+   out-of-scope change is a Blocker until justified, extracted, or
+   listed in the PR description's `Bundled fixes:` section. Authorized
+   bundled fixes are same-area, same-concern, mechanical ride-alongs
+   (dead import the change orphaned, stale comment that now
+   contradicts the new code, unused local the change orphaned,
+   sibling-file typo). The causal qualifier matters — a pre-existing
+   dead import or unused local that *this change didn't orphan* is
+   not a ride-along; it's an out-of-scope cleanup attempt.
+   *Same area* = a file in a directory that already contains a file
+   the change is editing — at review time the merged PR diff defines
+   the change. If a `Bundled fixes:` line claims something outside a
+   touched directory, requires a design call, or changes user-visible
+   behavior, that's still a Blocker — the carve-out fails closed.
+   Flag the bundle as Blocker-grade sprawl if it isn't visibly
+   smaller than the primary change — i.e. if a reader couldn't
+   immediately tell which part is primary and which are ride-alongs.
 5. **Spec drift.** If the implementation differs from the spec, the spec
    must be updated in the same PR. Otherwise it's drift, not done.
 6. **Security and privacy.** What data does this touch? Is access
@@ -194,6 +213,54 @@ asks for that scheme.
 
 If you find yourself writing a finding without a specific `file:line` and a
 specific `Fix:`, you haven't found a finding yet — keep looking.
+
+## What not to flag
+
+**Read the full diff before flagging anything.** A finding that's
+already addressed elsewhere in the same diff is noise. **When in
+doubt, flag.** The list below is the complete enumeration of
+suppressible categories; anything not on this list is not
+suppressible. **If a candidate suppression is actually a decision
+(behavioral, structural, user-visible), don't suppress — surface it
+as a Concern.** Suppression silences noise; it does not silence
+questions the operator should answer.
+
+- **Harmless redundancy that aids readability** (e.g., `present?`
+  alongside `length > 20`). Skip when the redundancy is *harmless* and
+  *aids* clarity. If the redundancy hides a bug or contradicts intent,
+  it's still a finding.
+- **"Add a comment explaining a self-evident tunable threshold"** —
+  e.g., a `MAX_RETRIES = 3` whose value is the comment's content.
+  Thresholds derived from a spec AC, regulatory limit, calibrated /
+  measured value, or otherwise non-obvious origin still warrant a
+  one-line *why* comment — those are "non-obvious invariants" in the
+  sense `quality-engineer.md` § Maintainability uses the phrase.
+  Suppress the request only when the comment would restate the
+  literal.
+- **"This assertion could be tighter"** when the assertion already
+  covers the behavior under test. Tighter ≠ better when the looser
+  form is correct.
+- **Consistency-only changes** — don't ask for one call site to match
+  the shape of another when both forms are correct. Premature
+  uniformity is its own cost.
+- **"Regex doesn't handle edge case X"** when the input is constrained
+  at a *verified boundary*. A verified boundary is one of: (a) type
+  narrowing visible in the same function, (b) an assertion or
+  validation call in the PR's call graph that rejects the edge case,
+  or (c) a documented invariant in the spec. "X never occurs in
+  practice" without one of these citations is not a suppression — that's
+  the famous-last-words category, and the finding stands.
+- **"Test exercises multiple guards simultaneously."** Tests aren't
+  required to isolate every guard; a single test covering several is
+  fine when the contract is the composite behavior.
+- **Linter-enforced style preferences** (quote style, import order,
+  whitespace). The linter is the source of truth; reviewer prose on
+  the same point is noise.
+- **Speculative future-proofing.** "What if we want to support X
+  later?" is out — the project explicitly refuses designing for
+  hypothetical future requirements.
+- **Backwards-compat shims for in-repo callers.** When the project can
+  just change the code, asking for a shim is noise.
 
 ## What you do not do
 

--- a/packs/core/.apm/agents/implementer.md
+++ b/packs/core/.apm/agents/implementer.md
@@ -37,9 +37,28 @@ If the supervisor's brief omits the spec/plan paths, ask — don't guess.
   checked out branch `<base>-<task-id>` there. All your edits happen
   inside that directory. Use `cd` or absolute paths; do not edit files
   in the primary worktree.
+<!-- Bundled-fixes carve-out mirrors work-loop/SKILL.md § EXECUTE.
+     Keep all three sites (this file, work-loop/SKILL.md,
+     adversarial-reviewer.md scope check #4) in sync when changing
+     the gates. -->
 - **One task:** implement only the task you were assigned. If you
-  notice an unrelated issue, note it in your report under "Out of
-  scope observed" — do not fix it.
+  notice an unrelated issue, default to noting it under "Out of scope
+  observed" and do not fix it. **Exception — bundled-fixes carve-out.**
+  If the supervisor's brief explicitly authorizes bundled fixes, you
+  may land same-area, same-concern, mechanical ride-alongs (dead
+  import, stale comment that now contradicts the new code, unused
+  local the change orphaned, typo in a sibling file). *Same area*
+  means a file in a directory that already contains a file this task
+  is editing — siblings in the touched directory, not a walk-up to
+  the parent and not a sideways jump to a directory this task isn't
+  editing. Report ride-alongs under `Bundled fixes:`. The carve-out
+  fails closed on any of: a file outside a touched directory, a
+  design call, a behavior change — those stay under "Out of scope
+  observed". Keep ride-alongs individually small (a line or two
+  each). The bundle should be visibly smaller than the primary
+  change — if a reader couldn't immediately tell which part is
+  primary and which are ride-alongs, you've sprawled; drop the
+  surplus to "Out of scope observed" for the supervisor to triage.
 - **Gates:** run the project's lint, typecheck, and test commands as
   documented in `AGENTS.md` and the project's root README. Capture
   pass/fail and any failing output. Your gate results are **advisory**
@@ -87,6 +106,12 @@ terse — the supervisor reads N reports in one context.
 
 **Deviations from the task body**
 <bullet list, or "none">
+
+**Bundled fixes:**
+<bullet list of same-area mechanical ride-alongs landed under the
+carve-out, or "none". Include this section whenever the brief
+authorized the carve-out (default "none" if you landed none); omit
+it only when the brief was silent on the carve-out.>
 
 **Out of scope observed**
 <bullet list of issues you noticed but did not fix, or "none">

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -208,6 +208,41 @@ goal. Resist the urge to fix unrelated things you notice along the way;
 note them in `notes/` for later. Scope creep is the single biggest source
 of plan-vs-implementation drift.
 
+<!-- Bundled-fixes carve-out — canonical site. Mirrored by
+     implementer.md (operating envelope) and adversarial-reviewer.md
+     (scope check #4). Keep all three in sync. -->
+**Bundled-fixes carve-out.** Same-area, same-concern, mechanical
+ride-alongs land in the change — dead import, stale comment that now
+contradicts the new code, unused local the change orphaned, typo in a
+sibling file. *Same area* means a file in a directory that already
+contains a file the change is editing — siblings in the touched
+directory, not a walk-up to the parent and not a sideways jump to a
+directory the change isn't editing. "The change" = the current plan
+task for the executor; the merged PR diff for the reviewer. The
+reviewer is loading that directory's context for the primary change;
+tagging along is cheap. List ride-alongs in the PR description under
+`Bundled fixes:`, one line each, so the reviewer can scan them at a
+glance. The carve-out fails closed on any of: a file outside a
+touched directory, a design call, a behavior change. Those still go
+to `notes/` (EXECUTE-phase surplus, picked up by a future plan task);
+contrast with the DECIDE-phase `Deferred:` bucket below, which holds
+reviewer findings the loop chose not to fix — different lifecycle,
+different reader. **Volume guard** — bundled fixes are individually small
+(a line or two each). The bundle should also be visibly smaller than
+the primary change: if a reviewer reading the PR couldn't immediately
+tell which part is the primary change and which are ride-alongs, you
+sprawled — move the surplus to `notes/`. In supervisor mode, the
+dispatch brief explicitly authorizes the carve-out and restates the
+gates so the implementer applies them per its own task; without that
+authorization line the implementer defaults to no-carve-out.
+
+**`Bundled fixes:` in the PR description.** The work-loop emits a
+named `Bundled fixes:` section in the PR description that doesn't
+appear in the project's PR template — one line per ride-along landed
+under the carve-out above. Append it as a standalone section below
+the standard template content; do not modify the template itself.
+(See step 5 for the companion `Deferred:` section.)
+
 #### Parallel dispatch discipline
 
 When this skill fans out — multiple implementers in supervisor mode, or
@@ -328,9 +363,29 @@ checklist instead:
 
 ### 5. DECIDE — fix or finish
 
-- **Blockers from review** → go to FIX, then re-run GATES and REVIEW.
-- **Concerns from review** → fix the ones you can in this PR; capture the
-  rest as follow-up issues. Don't let "concerns" rot in chat.
+Route each reviewer finding into one of two resolution modes — `apply`
+(fix in this PR) or `defer` (capture as a follow-up). This is the
+work-loop's interpretation of reviewer output; the reviewer keeps its
+narrow Blockers / Concerns / Nits contract. Once routed, act on each
+mode below, then evaluate the terminal-state bullet last.
+
+- **Blockers** → `apply`. Re-run GATES and REVIEW after each fix.
+- **Concerns** → `apply` if mechanical and in scope (default for any
+  Concern whose fix meets the bundled-fixes gates above). `defer` if
+  the fix would cross files outside the plan, require a design call,
+  or change user-visible behavior the spec didn't authorize. Don't let
+  Concerns rot in chat — every Concern resolves into one of the two.
+- **Nits** → same two modes as Concerns. `apply` if they meet the
+  bundled-fixes gates above (ride along in `Bundled fixes:`).
+  Otherwise `defer` — one line in `Deferred:`. Every Nit resolves
+  into one of the two; the `Deferred:` line *is* the acknowledgement
+  that the loop saw the Nit and chose not to fix.
+- **Deferred items** → one-line follow-up note in the PR description
+  under `Deferred:` so they don't rot. Append it as a standalone
+  section below the standard template content alongside the
+  `Bundled fixes:` section from EXECUTE; do not modify the template
+  itself. Don't open separate issues by default — the PR is the
+  durable record.
 - **Gates green and review clean** → ready to ship. Walk this end-of-session
   checklist; refuse to declare done until every line is true:
   - GATES were clean (lint, typecheck, tests).

--- a/packs/core/.apm/skills/work-loop/references/supervisor-mode.md
+++ b/packs/core/.apm/skills/work-loop/references/supervisor-mode.md
@@ -49,8 +49,15 @@ not edit `state.json` or invoke `git worktree` directly.
 
 2. **Dispatch implementers in parallel** per the parallel-dispatch
    discipline (see parent SKILL body). Each brief includes: the task
-   ID, the plan-task body, the worktree path, and paths to the spec +
-   plan.
+   ID, the plan-task body, the worktree path, paths to the spec +
+   plan, and an explicit **bundled-fixes authorization line** —
+   "Bundled fixes authorized per the carve-out in `work-loop/SKILL.md`
+   (EXECUTE phase); apply same-area, same-concern, mechanical
+   ride-alongs only and report under `Bundled fixes:` in your output."
+   If a particular task should run without the carve-out (e.g. a
+   high-blast-radius migration), omit the authorization line; the
+   implementer defaults to no-carve-out and routes everything to
+   "Out of scope observed".
 
 3. **Persist each report and update state.** For each returning
    subagent, write its markdown report to disk, then run
@@ -101,6 +108,15 @@ not edit `state.json` or invoke `git worktree` directly.
    weren't actually independent — the tool runs `git merge --abort`,
    exits non-zero, and names the offending task ID. Return to PLAN and
    fix the `Depends on:` declarations.
+
+   **Lift `Bundled fixes:` into the PR body.** Each implementer report
+   may carry a `Bundled fixes:` section listing ride-alongs landed
+   under the carve-out. After merge succeeds, collect those lines
+   from every ready report, dedupe by exact-string match (falling
+   back to operator judgment when two lines describe the same change
+   in different words), and emit a single `Bundled fixes:` section
+   in the PR description below the standard template. If no
+   implementer landed ride-alongs, omit the section.
 
 6. **Clean up worktrees.** After all merges succeed, run
 

--- a/packs/core/seeds/AGENTS.md
+++ b/packs/core/seeds/AGENTS.md
@@ -41,7 +41,10 @@ Scope each change precisely to the request.
 - **Add a flag or option only when a second caller actually needs to
   differ.** Today's one caller is enough to define the shape.
 - **Add docstrings and types to code the change actually touches.**
-  Leave nearby untouched code as it is.
+  Leave nearby untouched code as it is — except under the
+  bundled-fixes carve-out defined in the `work-loop` skill (same-area,
+  same-concern, mechanical ride-alongs only; surplus still goes to
+  follow-up).
 - **Validate at boundaries the request crosses** (user input, external
   APIs). Trust internal callers and framework guarantees.
 - **Inline a single-use operation.** Extract a helper once a second


### PR DESCRIPTION
## What does this change?

Calibrates the work-loop, implementer, and adversarial-reviewer with a same-area bundled-fixes carve-out, names two explicit resolution modes (`apply` / `defer`) in DECIDE, and adds a `What not to flag` suppressions section to the reviewer. Goal: cut defer-volume from same-area mechanical ride-alongs without inviting "while I was in there" sprawl.

## Why?

Spec-less convention edit; RFC not warranted per offline decision. The work-loop's `notes/` defer bucket was filling with same-area mechanical work the reviewer was already loading context for, and the reviewer had no documented suppressions so it over-flagged. The carve-out is the narrow exception to AGENTS.md `Touch only what you're asked to touch`; pointer added there so the two don't contradict.

## How do I verify it?

`make lint-packs`, `make build-check`, `make validate` clean. Both reviewers cleared the diff: `adversarial-reviewer` over 4 passes (12 → 3 → 1 → 0 findings), `quality-engineer` over 3 passes (7 → 3 → 0 findings). `security-reviewer` not warranted — no security boundary crossed.

## What did you not change that you considered?

Did not edit `.github/pull_request_template.md` (out of touched-dir scope; addressed via work-loop SKILL.md note that `Bundled fixes:` / `Deferred:` are agent-appended standalone sections). Did not introduce a third `surface` resolution mode (operator-pause flow gate) — explicitly out of scope per user direction to avoid loop friction; revisit only if defer/apply turns out insufficient. Did not soften `docs/CONVENTIONS.md:777` "I can fix this while I'm here" rebuttal — deferred as the lower-priority half of the AGENTS.md coherence fix.

## Bundled fixes

- `AGENTS.md` carve-out pointer — justified scope expansion per AGENTS.md's own "would ship broken without it" rule.

## Deferred

- (none — all review findings applied this PR)