### PR TITLE
feat(new-guide): implement skill from stub

### DIFF
--- a/.claude/skills/new-guide/SKILL.md
+++ b/.claude/skills/new-guide/SKILL.md
@@ -1,13 +1,231 @@
 ---
 name: new-guide
-description: Use this skill to draft a new user-facing guide under `docs/guides/<quadrant>/<slug>.md` following the Diátaxis framework. Triggers on "write a guide for X", "new tutorial", "new how-to". Picks the quadrant (tutorials/how-to/reference/explanation) and applies the per-quadrant template.
+description: Use this skill to draft a new user-facing guide under `docs/guides/<quadrant>/<slug>.md` following the Diátaxis framework. Triggers on "write a guide for X", "new tutorial", "new how-to", "new reference page", "new explanation". Settles the audience contract before any body is written, then scaffolds from the matching per-quadrant template. Do NOT use for feature contracts (use `new-spec`), cross-cutting proposals (use `new-rfc`), or recording decisions (use `new-adr`).
 ---
 
 # Skill: new-guide
 
-> **Status:** stub. The full body will land in a follow-on PR.
+Create a new user-facing guide under `docs/guides/<quadrant>/<slug>.md`,
+following the [Diátaxis framework](https://diataxis.fr/). The framework
+itself is documented in this repo's [`docs/guides/README.md`](../../../../docs/guides/README.md)
+and the per-quadrant README in each subdirectory — read those for the
+*what*; this skill is the *procedure* for landing a new piece on the
+right side of the line.
 
-This skill is referenced by the bundle's source-of-truth split (RFC-0002).
-The implementation is deferred to a follow-on PR. The pack-side directory
-is materialized so the projection map is complete and the build pipeline
-discovers the skill name; the body will be authored separately.
+The load-bearing rule is **link out, don't blend**. When mid-draft you
+find yourself wanting to add theory inside a tutorial, or steps inside an
+explanation, that's the cue to write the adjacent piece separately and
+link. Mixing quadrants is the most common reason user docs frustrate
+everyone.
+
+## When to invoke
+
+Before invoking, confirm:
+
+1. The topic is *user-facing* — the reader is someone using the product,
+   not a contributor reading the code. Contributor-facing material lives
+   in `docs/architecture/` (current state) or `docs/adr/` (decisions).
+   If it's spec-shaped, use `new-spec`.
+2. The behavior being documented *already ships* — guides are living
+   docs that must match current product behavior. If you're proposing a
+   change, you want an RFC or a spec, not a guide.
+3. You can name a real reader. "Someone might want to know X" isn't a
+   reader; "an adopter who has installed the credential-brokers pack and
+   needs to rotate their token" is.
+
+If any check fails, push back rather than proceeding.
+
+## Procedure
+
+1. **Settle the audience contract — gated checkpoint.** With nothing
+   scaffolded yet, stop and surface the contract *in chat*. This is the
+   skill's analogue to `new-spec`'s assumptions checkpoint: the body is
+   gated until the contract is signed off. A guide that doesn't name its
+   reader ends up serving none of them.
+
+   Emit the contract under exactly this shape:
+
+   ```markdown
+   AUDIENCE CONTRACT:
+
+   ## Reader profile
+   - **Right now they are:** <on rails, attentive | has a specific problem | scanning for an authoritative fact | reflecting, away from active use>
+   - **They leave with:** <a confident "I did it" + working artifact | their problem solved | the precise answer | a clearer mental model of why>
+
+   ## Quadrant pick
+   - **Quadrant:** <tutorials | how-to | reference | explanation>
+   - **Why this one (not the adjacent quadrants):** <one sentence>
+
+   ## Title (working)
+   - **Title:** <draft>
+   - **What the reader would have typed into search:** <phrase>
+   ```
+
+   Diátaxis distinguishes the four pieces by reader *posture*, not by
+   reader *skill*. The same person, expert at the product, can land in
+   any of the four quadrants on different days — what places them is
+   what they're doing right now. Use the posture-to-quadrant mapping:
+
+   | Reader's posture right now | Quadrant |
+   | --- | --- |
+   | On rails, attentive, wants a guaranteed working result | **Tutorials** |
+   | Has a named problem, wants the recipe | **How-to** |
+   | In a hurry, scanning for the authoritative answer | **Reference** |
+   | Away from the keyboard, wants to understand *why* | **Explanation** |
+
+   Then **wait for human confirmation or revision.** Don't write into
+   the body until the contract is signed off — even if the original
+   prompt sounded definitive. Two outcomes from confirmation:
+
+   - The contract is accepted → proceed to step 2.
+   - The contract splits into two readers or two postures → that's two
+     guides, not one. Surface this and ask the user to pick the
+     first; the second goes to follow-up.
+
+2. **Pick a kebab-case slug.** Keep it short and noun-y, matching what
+   the reader would have searched for: `rotate-credentialed-skill-token`,
+   not `how-to-rotate-your-token-step-by-step`. The quadrant subdir
+   carries the "how-to" / "tutorial" framing; don't repeat it in the
+   filename.
+
+3. **Scaffold from the matching template.** The quadrant token maps to
+   one asset filename and one destination directory — use the mapping
+   table below verbatim, don't interpolate by hand:
+
+   | Quadrant | Asset to copy | Destination |
+   | --- | --- | --- |
+   | `tutorials` | `assets/tutorials.md` | `docs/guides/tutorials/<slug>.md` |
+   | `how-to` | `assets/how-to.md` | `docs/guides/how-to/<slug>.md` |
+   | `reference` | `assets/reference.md` | `docs/guides/reference/<slug>.md` |
+   | `explanation` | `assets/explanation.md` | `docs/guides/explanation/<slug>.md` |
+
+   (Paths are skill-relative — the `assets/` folder lives next to this
+   `SKILL.md` wherever your IDE installed the skill.) The four
+   templates carry the minimal section structure for each quadrant; they
+   are starting scaffolds, not strict forms.
+
+4. **Draft, applying the per-quadrant rules.** The source of truth for
+   *what goes in* each quadrant is the seed README under
+   `docs/guides/<quadrant>/README.md`. Read the relevant one before
+   drafting. The condensed write-time rules, with the named anti-patterns
+   the canonical framework warns about:
+
+   - **Tutorials.** Concrete, complete, one path, no digression. Each
+     step says what to do, shows what to expect, reassures the reader
+     they're on track. Refuse the [*anti-pedagogical
+     temptations*](https://diataxis.fr/tutorials/) Procida names:
+     *abstraction, generalisation*, *explanation*, *choices*,
+     *information*. Tutorials must produce the result they promise —
+     broken reliability is the worst failure. Open with the guaranteed
+     outcome ("At the end you'll have a running X"), not "you will
+     learn".
+   - **How-to.** Solves one named problem for an already-competent
+     reader. Title is the problem. Skip backstory, skip "turn on the
+     power switch"–level steps, skip reteaching basics. Cover the
+     realistic variations and the common pitfalls — that's what makes a
+     how-to worth the click over the reference page.
+   - **Reference.** Authoritative, complete, consistently structured,
+     **neutral**. Procida: ["Neutral description is the key imperative
+     of technical reference"](https://diataxis.fr/reference/) — austere,
+     factual, no editorializing, no narrative. If the section is
+     auto-generated, mark it at the top so the next person doesn't
+     hand-edit it. Reference rots when the code drifts; "code change →
+     reference update in the same PR" is the discipline.
+   - **Explanation.** Discursive, illuminating, allowed to be opinionated
+     and to wander a little. Frame the scope with an *"About <topic>"*
+     question to keep it bounded — open-ended explanations sprawl. No
+     step-by-step instructions, no parameter lists. Make connections to
+     adjacent topics. ADRs vs. architecture docs vs. explanation: ADRs
+     are *frozen decisions for the team*, architecture is *how the code
+     is organized now for contributors*, explanation is *what the
+     concept means for someone using the product*.
+
+   On voice and tone — apply Google's developer-docs rule of thumb:
+   "Sound like a knowledgeable friend who understands what the developer
+   wants to do." Second person, active voice, present tense. Two
+   separate anti-patterns to avoid:
+
+   - **Don't gaslight stuck readers.** Drop *simply*, *just*, *easy*,
+     *quickly*, *obviously* — every one of those words makes a reader
+     who got stuck feel dumb.
+   - **Don't soften imperatives.** Drop *please* in instructions ("please
+     click", "please run") — it makes commands sound optional. Just
+     write the imperative.
+
+   Efficiency is a form of respect — the reader is in a hurry.
+
+5. **Apply the link-out rule as you draft.** When you find yourself
+   reaching for content from the adjacent quadrant, stop and write a
+   link instead:
+
+   - Tempted to explain *why* mid-tutorial → link to (or create) an
+     explanation page.
+   - Tempted to list every option mid-how-to → link to the reference.
+   - Tempted to walk a beginner through setup mid-explanation → link to
+     the tutorial.
+   - Tempted to recommend a best practice mid-reference → link to the
+     explanation.
+
+   The link can be a placeholder (`<!-- TODO: link to … -->`) if the
+   adjacent piece doesn't exist yet; surface those placeholders in the
+   final summary so the next guide gets written.
+
+6. **Self-check before announcing the draft.** Walk this list against
+   the chosen quadrant; every "yes" is a finding to fix:
+
+   - Tutorial: does any step lack a "you should see…" check? Did I
+     offer the reader a choice anywhere? Did I sneak in *why* instead of
+     linking out?
+   - How-to: does the title name the reader's problem in their words?
+     Did I reteach a basic the reader already knows? Did I cover only
+     the linear path and ignore realistic variations?
+   - Reference: did I editorialize anywhere ("this is the recommended
+     option…")? Is any entry of the same kind shaped differently from
+     its siblings? Did I skip an option?
+   - Explanation: is there a step-by-step block that belongs in a
+     how-to? Did I drift past the *"About <topic>"* scope? Did I avoid
+     opinion — explanation is *allowed* a voice?
+
+7. **Cross-link the siblings — only the ones that exist.** A new guide
+   rarely stands alone. From the new file, add a `See also` section.
+   For each candidate sibling — the tutorial that introduces the
+   concept, the how-to that uses what reference describes (and vice
+   versa), the explanation that says *why* — check whether the file
+   exists. If it does, link it. If it doesn't, surface the gap in the
+   final summary as a follow-up TODO; don't write a broken link, and
+   don't synthesize a plausible-sounding path. From each existing
+   sibling, add a reverse link to the new piece. Cross-links are a
+   maintenance pact: when one rots, the others surface the drift.
+
+   Don't touch `docs/guides/<quadrant>/README.md` — those seed READMEs
+   are the framework's per-quadrant explainer, not a piece index.
+   Adopters who want an index of pieces add one separately; the skill
+   doesn't invent one.
+
+## Anti-patterns to refuse
+
+- **Writing the body before the audience contract is confirmed.** The
+  body is gated. The contract is the cheapest place to catch a
+  mismatched quadrant; once draft prose is on the page, rework costs
+  compound.
+- **Picking the quadrant by *topic* instead of by *reader posture*.**
+  "Authentication" is a topic; *learning* authentication, *configuring*
+  it, *looking up its parameters*, and *understanding why it's
+  cookie-based* are four different pieces — possibly all four.
+- **Blending quadrants because "the reader will appreciate the
+  context".** They won't. The framework's whole thesis is that mixing
+  modes is what makes docs frustrating; the link-out rule is
+  non-negotiable.
+- **Drafting a tutorial without running the steps end-to-end.** A
+  tutorial that doesn't produce the promised result is worse than no
+  tutorial. If the steps can't be run, you're writing a how-to or an
+  explanation — re-open the audience contract.
+- **Writing reference in narrative voice.** "You'll want to set this
+  to…" is explanation leaking into reference. Reference says *what*;
+  recommendations live in explanation.
+- **Writing explanation without an *About <X>* frame.** Open-ended
+  explanation absorbs adjacent material and sprawls. Name the question
+  the page answers; if you can't, the page isn't ready.
+- **Editing an existing guide via this skill.** `new-guide` is for new
+  pieces. Edits are normal PRs against the existing file; the rules in
+  step 4 still apply, but the skill's checkpoint and scaffold don't.

--- a/.claude/skills/new-guide/SKILL.md
+++ b/.claude/skills/new-guide/SKILL.md
@@ -7,10 +7,10 @@ description: Use this skill to draft a new user-facing guide under `docs/guides/
 
 Create a new user-facing guide under `docs/guides/<quadrant>/<slug>.md`,
 following the [Diátaxis framework](https://diataxis.fr/). The framework
-itself is documented in this repo's [`docs/guides/README.md`](../../../../docs/guides/README.md)
-and the per-quadrant README in each subdirectory — read those for the
-*what*; this skill is the *procedure* for landing a new piece on the
-right side of the line.
+itself is documented in this repo at `docs/guides/README.md` and the
+per-quadrant README in each subdirectory — read those for the *what*;
+this skill is the *procedure* for landing a new piece on the right
+side of the line.
 
 The load-bearing rule is **link out, don't blend**. When mid-draft you
 find yourself wanting to add theory inside a tutorial, or steps inside an

--- a/.claude/skills/new-guide/assets/explanation.md
+++ b/.claude/skills/new-guide/assets/explanation.md
@@ -1,0 +1,51 @@
+# About <topic>
+
+> Why <thing> works the way it does. This page is for readers who want
+> to understand more deeply — not to learn a skill or solve a specific
+> problem. For tasks, see the [how-to index](../how-to/); for the
+> parameter list, see [<reference title>](../reference/<slug>.md).
+
+## The question this page answers
+
+<One paragraph framing the *About <X>* scope. What does a reader who
+lands here want to come away understanding? Naming this keeps the page
+bounded; without it, explanation absorbs adjacent material and
+sprawls.>
+
+## The shape of the answer
+
+<Walk the reader through the model. The key ideas, the connections to
+adjacent concepts, the bigger picture. Explanation is *allowed* to be
+opinionated and to wander a little — but it stays inside the *About <X>*
+frame above.>
+
+## Design choices and tradeoffs
+
+<The deliberate alternatives the design weighed; why this path was
+taken over the obvious other one. If a specific decision was recorded
+in an ADR, link it — but don't restate the ADR. ADRs are *for the
+team*; this page is *for users*.>
+
+## How this differs from <adjacent concept>
+
+<Comparisons that illuminate. "X vs. Y, when to use which" pieces live
+here, not in how-tos.>
+
+## See also
+
+- [<tutorial title>](../tutorials/<slug>.md) — to learn the skill.
+- [<how-to title>](../how-to/<slug>.md) — to apply it.
+- [<reference title>](../reference/<slug>.md) — for the precise
+  parameter list.
+- [ADR-NNNN](../../adr/NNNN-<slug>.md) — the team's record of *why we
+  chose* this approach.
+
+<!--
+Reminders from the skill — delete before committing:
+
+- Frame the scope as "About <X>". Without that, explanation sprawls.
+- No step-by-step instructions. No parameter tables. Link out.
+- Allowed to be opinionated and to wander — within the frame.
+- ADRs are *for the team*; this page is *for users*. Same topic,
+  different audience, different framing — don't merge them.
+-->

--- a/.claude/skills/new-guide/assets/how-to.md
+++ b/.claude/skills/new-guide/assets/how-to.md
@@ -1,0 +1,52 @@
+# How to <named problem in the reader's words>
+
+This guide is for <competent user> who needs to <accomplish the named
+goal>. It assumes you already <list the baseline competence — what the
+reader has, knows, or has set up>.
+
+If you're new to <product / feature>, start with
+[<tutorial title>](../tutorials/<slug>.md) instead — that one walks the
+basics.
+
+## Before you start
+
+You need:
+
+- <prerequisite — what the reader has / knows>
+- <prerequisite>
+
+## Steps
+
+1. <First action — terser than a tutorial; the reader knows their way around>.
+2. <Next action>.
+3. <Next action>.
+
+## Variations
+
+Real problems branch. Cover the cases the reader is likely to hit:
+
+- **If <condition>:** <alternate path>.
+- **If <condition>:** <alternate path>.
+
+## Common pitfalls
+
+- **<Symptom you'll see>** — <cause, and the one-line fix>.
+- **<Symptom>** — <cause, fix>.
+
+## See also
+
+- [<reference title>](../reference/<slug>.md) — for the full list of
+  <options / parameters / commands>.
+- [<explanation title>](../explanation/<slug>.md) — for *why* <design
+  choice> is the way it is.
+
+<!--
+Reminders from the skill — delete before committing:
+
+- Title names the reader's problem in their words. ("How to rotate a
+  credentialed-skill token", not "Credential rotation guide".)
+- Skip "turn on the power switch"-level steps. The reader is competent.
+- Cover the realistic variations and the common pitfalls — that's what
+  earns this page the click over reference.
+- No "why" deep dives. Link out to explanation.
+-->

--- a/.claude/skills/new-guide/assets/reference.md
+++ b/.claude/skills/new-guide/assets/reference.md
@@ -1,0 +1,87 @@
+# <Thing> reference
+
+> Authoritative description of <thing>. For tasks, see the
+> [how-to index](../how-to/). For why the design is shaped this way,
+> see [<explanation title>](../explanation/<slug>.md).
+
+<!--
+If this page is auto-generated from <source>, replace this comment with:
+
+> **Generated.** This file is generated from `<source>`. Do not edit by
+> hand — edit the source and re-run `<generator command>`.
+-->
+
+## <Section 1 — pick the shape that fits the item kind>
+
+Reference items come in many kinds. Pick *one* shape per kind and apply
+it uniformly across every entry of that kind — predictability is
+everything; readers scan. Three common shapes appear below as examples.
+If your reference items are a different kind (data schemas, env vars,
+event payloads, webhook bodies, etc.), design a shape that fits and
+apply it uniformly — don't force-fit one of the three.
+
+**Config option / parameter / flag — fixed metadata table:**
+
+### `<option name>`
+
+| | |
+| --- | --- |
+| Type | `<type>` |
+| Default | `<default>` |
+| Required | <yes / no> |
+| Since | `<version>` |
+
+<One-sentence neutral description. No recommendation. Just *what*.>
+
+```<lang>
+<minimal usage example>
+```
+
+**API endpoint / RPC — request / response shape:**
+
+### `<METHOD> <path>`
+
+<One-sentence neutral description.>
+
+| Parameter | In | Type | Required | Description |
+| --- | --- | --- | --- | --- |
+| `<name>` | path / query / body | `<type>` | <yes / no> | <description> |
+
+**Response:** `<status>` — `<shape>`.
+
+**CLI command / subcommand — usage + flags table:**
+
+### `<command>`
+
+```
+<command> [flags] <args>
+```
+
+| Flag | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--<name>` | `<type>` | `<default>` | <description> |
+
+## Errors
+
+<!-- Delete this section if your reference items don't have associated
+     error codes. -->
+
+| Code | Meaning | When you see it |
+| --- | --- | --- |
+| `<CODE>` | <neutral description> | <trigger condition> |
+| `<CODE>` | <neutral description> | <trigger condition> |
+
+## See also
+
+- [<how-to title>](../how-to/<slug>.md) — for tasks that use these.
+- [<explanation title>](../explanation/<slug>.md) — for the design
+  rationale.
+
+<!--
+Reminders from the skill — delete before committing:
+
+- Neutral, austere, factual. No editorializing, no "we recommend".
+- Every entry of the same kind has the same shape — readers scan.
+- Complete. Omitted options are the most common reference failure.
+- If auto-generated, mark it clearly at the top.
+-->

--- a/.claude/skills/new-guide/assets/tutorials.md
+++ b/.claude/skills/new-guide/assets/tutorials.md
@@ -1,0 +1,68 @@
+# <Verb-first title — "Build a working X", "Set up your first Y">
+
+> At the end of this tutorial you'll have <one concrete, working artifact
+> the reader can see, touch, or run>.
+
+This tutorial is for someone who has never used <product / feature>
+before. If you already have <prerequisite skill>, jump to
+[<how-to title>](../how-to/<slug>.md) instead.
+
+## Before you begin
+
+You need:
+
+- <prerequisite — installed binary, account, file>
+- <prerequisite>
+
+If installing any of these is non-trivial, follow
+[<install how-to>](../how-to/<slug>.md) first and come back here.
+
+## Step 1 — <concrete action in the imperative>
+
+<One short sentence on what this step does.>
+
+```bash
+<exact command>
+```
+
+You should see:
+
+```
+<exact expected output, or a screenshot description>
+```
+
+> If you don't see this: <the single most common pitfall and how to
+> recognize it>. Other variations belong in a separate how-to.
+
+## Step 2 — <next concrete action>
+
+<...>
+
+## Step 3 — <next concrete action>
+
+<...>
+
+## What you built
+
+You now have <name the artifact>. <One short sentence reassuring the
+reader that they accomplished the promised outcome.>
+
+## Next steps
+
+- For the natural next task: [<how-to title>](../how-to/<slug>.md).
+- To understand *why* <choice in the tutorial> works the way it does:
+  [<explanation title>](../explanation/<slug>.md).
+- For the full list of <options / commands / parameters>:
+  [<reference title>](../reference/<slug>.md).
+
+<!--
+Reminders from the skill — delete before committing:
+
+- One path only. No "you could also do…" branches.
+- Every step shows expected output / reassurance.
+- No theory inside the steps. Link out to explanation instead.
+- Step-level "If you don't see this" callouts cover the single most
+  common pitfall — extended troubleshooting goes in a how-to.
+- Test the tutorial end-to-end before merging. Broken tutorials are
+  the worst failure mode of the framework.
+-->

--- a/packs/user-guide-diataxis/.apm/skills/new-guide/SKILL.md
+++ b/packs/user-guide-diataxis/.apm/skills/new-guide/SKILL.md
@@ -1,13 +1,231 @@
 ---
 name: new-guide
-description: Use this skill to draft a new user-facing guide under `docs/guides/<quadrant>/<slug>.md` following the Diátaxis framework. Triggers on "write a guide for X", "new tutorial", "new how-to". Picks the quadrant (tutorials/how-to/reference/explanation) and applies the per-quadrant template.
+description: Use this skill to draft a new user-facing guide under `docs/guides/<quadrant>/<slug>.md` following the Diátaxis framework. Triggers on "write a guide for X", "new tutorial", "new how-to", "new reference page", "new explanation". Settles the audience contract before any body is written, then scaffolds from the matching per-quadrant template. Do NOT use for feature contracts (use `new-spec`), cross-cutting proposals (use `new-rfc`), or recording decisions (use `new-adr`).
 ---
 
 # Skill: new-guide
 
-> **Status:** stub. The full body will land in a follow-on PR.
+Create a new user-facing guide under `docs/guides/<quadrant>/<slug>.md`,
+following the [Diátaxis framework](https://diataxis.fr/). The framework
+itself is documented in this repo's [`docs/guides/README.md`](../../../../docs/guides/README.md)
+and the per-quadrant README in each subdirectory — read those for the
+*what*; this skill is the *procedure* for landing a new piece on the
+right side of the line.
 
-This skill is referenced by the bundle's source-of-truth split (RFC-0002).
-The implementation is deferred to a follow-on PR. The pack-side directory
-is materialized so the projection map is complete and the build pipeline
-discovers the skill name; the body will be authored separately.
+The load-bearing rule is **link out, don't blend**. When mid-draft you
+find yourself wanting to add theory inside a tutorial, or steps inside an
+explanation, that's the cue to write the adjacent piece separately and
+link. Mixing quadrants is the most common reason user docs frustrate
+everyone.
+
+## When to invoke
+
+Before invoking, confirm:
+
+1. The topic is *user-facing* — the reader is someone using the product,
+   not a contributor reading the code. Contributor-facing material lives
+   in `docs/architecture/` (current state) or `docs/adr/` (decisions).
+   If it's spec-shaped, use `new-spec`.
+2. The behavior being documented *already ships* — guides are living
+   docs that must match current product behavior. If you're proposing a
+   change, you want an RFC or a spec, not a guide.
+3. You can name a real reader. "Someone might want to know X" isn't a
+   reader; "an adopter who has installed the credential-brokers pack and
+   needs to rotate their token" is.
+
+If any check fails, push back rather than proceeding.
+
+## Procedure
+
+1. **Settle the audience contract — gated checkpoint.** With nothing
+   scaffolded yet, stop and surface the contract *in chat*. This is the
+   skill's analogue to `new-spec`'s assumptions checkpoint: the body is
+   gated until the contract is signed off. A guide that doesn't name its
+   reader ends up serving none of them.
+
+   Emit the contract under exactly this shape:
+
+   ```markdown
+   AUDIENCE CONTRACT:
+
+   ## Reader profile
+   - **Right now they are:** <on rails, attentive | has a specific problem | scanning for an authoritative fact | reflecting, away from active use>
+   - **They leave with:** <a confident "I did it" + working artifact | their problem solved | the precise answer | a clearer mental model of why>
+
+   ## Quadrant pick
+   - **Quadrant:** <tutorials | how-to | reference | explanation>
+   - **Why this one (not the adjacent quadrants):** <one sentence>
+
+   ## Title (working)
+   - **Title:** <draft>
+   - **What the reader would have typed into search:** <phrase>
+   ```
+
+   Diátaxis distinguishes the four pieces by reader *posture*, not by
+   reader *skill*. The same person, expert at the product, can land in
+   any of the four quadrants on different days — what places them is
+   what they're doing right now. Use the posture-to-quadrant mapping:
+
+   | Reader's posture right now | Quadrant |
+   | --- | --- |
+   | On rails, attentive, wants a guaranteed working result | **Tutorials** |
+   | Has a named problem, wants the recipe | **How-to** |
+   | In a hurry, scanning for the authoritative answer | **Reference** |
+   | Away from the keyboard, wants to understand *why* | **Explanation** |
+
+   Then **wait for human confirmation or revision.** Don't write into
+   the body until the contract is signed off — even if the original
+   prompt sounded definitive. Two outcomes from confirmation:
+
+   - The contract is accepted → proceed to step 2.
+   - The contract splits into two readers or two postures → that's two
+     guides, not one. Surface this and ask the user to pick the
+     first; the second goes to follow-up.
+
+2. **Pick a kebab-case slug.** Keep it short and noun-y, matching what
+   the reader would have searched for: `rotate-credentialed-skill-token`,
+   not `how-to-rotate-your-token-step-by-step`. The quadrant subdir
+   carries the "how-to" / "tutorial" framing; don't repeat it in the
+   filename.
+
+3. **Scaffold from the matching template.** The quadrant token maps to
+   one asset filename and one destination directory — use the mapping
+   table below verbatim, don't interpolate by hand:
+
+   | Quadrant | Asset to copy | Destination |
+   | --- | --- | --- |
+   | `tutorials` | `assets/tutorials.md` | `docs/guides/tutorials/<slug>.md` |
+   | `how-to` | `assets/how-to.md` | `docs/guides/how-to/<slug>.md` |
+   | `reference` | `assets/reference.md` | `docs/guides/reference/<slug>.md` |
+   | `explanation` | `assets/explanation.md` | `docs/guides/explanation/<slug>.md` |
+
+   (Paths are skill-relative — the `assets/` folder lives next to this
+   `SKILL.md` wherever your IDE installed the skill.) The four
+   templates carry the minimal section structure for each quadrant; they
+   are starting scaffolds, not strict forms.
+
+4. **Draft, applying the per-quadrant rules.** The source of truth for
+   *what goes in* each quadrant is the seed README under
+   `docs/guides/<quadrant>/README.md`. Read the relevant one before
+   drafting. The condensed write-time rules, with the named anti-patterns
+   the canonical framework warns about:
+
+   - **Tutorials.** Concrete, complete, one path, no digression. Each
+     step says what to do, shows what to expect, reassures the reader
+     they're on track. Refuse the [*anti-pedagogical
+     temptations*](https://diataxis.fr/tutorials/) Procida names:
+     *abstraction, generalisation*, *explanation*, *choices*,
+     *information*. Tutorials must produce the result they promise —
+     broken reliability is the worst failure. Open with the guaranteed
+     outcome ("At the end you'll have a running X"), not "you will
+     learn".
+   - **How-to.** Solves one named problem for an already-competent
+     reader. Title is the problem. Skip backstory, skip "turn on the
+     power switch"–level steps, skip reteaching basics. Cover the
+     realistic variations and the common pitfalls — that's what makes a
+     how-to worth the click over the reference page.
+   - **Reference.** Authoritative, complete, consistently structured,
+     **neutral**. Procida: ["Neutral description is the key imperative
+     of technical reference"](https://diataxis.fr/reference/) — austere,
+     factual, no editorializing, no narrative. If the section is
+     auto-generated, mark it at the top so the next person doesn't
+     hand-edit it. Reference rots when the code drifts; "code change →
+     reference update in the same PR" is the discipline.
+   - **Explanation.** Discursive, illuminating, allowed to be opinionated
+     and to wander a little. Frame the scope with an *"About <topic>"*
+     question to keep it bounded — open-ended explanations sprawl. No
+     step-by-step instructions, no parameter lists. Make connections to
+     adjacent topics. ADRs vs. architecture docs vs. explanation: ADRs
+     are *frozen decisions for the team*, architecture is *how the code
+     is organized now for contributors*, explanation is *what the
+     concept means for someone using the product*.
+
+   On voice and tone — apply Google's developer-docs rule of thumb:
+   "Sound like a knowledgeable friend who understands what the developer
+   wants to do." Second person, active voice, present tense. Two
+   separate anti-patterns to avoid:
+
+   - **Don't gaslight stuck readers.** Drop *simply*, *just*, *easy*,
+     *quickly*, *obviously* — every one of those words makes a reader
+     who got stuck feel dumb.
+   - **Don't soften imperatives.** Drop *please* in instructions ("please
+     click", "please run") — it makes commands sound optional. Just
+     write the imperative.
+
+   Efficiency is a form of respect — the reader is in a hurry.
+
+5. **Apply the link-out rule as you draft.** When you find yourself
+   reaching for content from the adjacent quadrant, stop and write a
+   link instead:
+
+   - Tempted to explain *why* mid-tutorial → link to (or create) an
+     explanation page.
+   - Tempted to list every option mid-how-to → link to the reference.
+   - Tempted to walk a beginner through setup mid-explanation → link to
+     the tutorial.
+   - Tempted to recommend a best practice mid-reference → link to the
+     explanation.
+
+   The link can be a placeholder (`<!-- TODO: link to … -->`) if the
+   adjacent piece doesn't exist yet; surface those placeholders in the
+   final summary so the next guide gets written.
+
+6. **Self-check before announcing the draft.** Walk this list against
+   the chosen quadrant; every "yes" is a finding to fix:
+
+   - Tutorial: does any step lack a "you should see…" check? Did I
+     offer the reader a choice anywhere? Did I sneak in *why* instead of
+     linking out?
+   - How-to: does the title name the reader's problem in their words?
+     Did I reteach a basic the reader already knows? Did I cover only
+     the linear path and ignore realistic variations?
+   - Reference: did I editorialize anywhere ("this is the recommended
+     option…")? Is any entry of the same kind shaped differently from
+     its siblings? Did I skip an option?
+   - Explanation: is there a step-by-step block that belongs in a
+     how-to? Did I drift past the *"About <topic>"* scope? Did I avoid
+     opinion — explanation is *allowed* a voice?
+
+7. **Cross-link the siblings — only the ones that exist.** A new guide
+   rarely stands alone. From the new file, add a `See also` section.
+   For each candidate sibling — the tutorial that introduces the
+   concept, the how-to that uses what reference describes (and vice
+   versa), the explanation that says *why* — check whether the file
+   exists. If it does, link it. If it doesn't, surface the gap in the
+   final summary as a follow-up TODO; don't write a broken link, and
+   don't synthesize a plausible-sounding path. From each existing
+   sibling, add a reverse link to the new piece. Cross-links are a
+   maintenance pact: when one rots, the others surface the drift.
+
+   Don't touch `docs/guides/<quadrant>/README.md` — those seed READMEs
+   are the framework's per-quadrant explainer, not a piece index.
+   Adopters who want an index of pieces add one separately; the skill
+   doesn't invent one.
+
+## Anti-patterns to refuse
+
+- **Writing the body before the audience contract is confirmed.** The
+  body is gated. The contract is the cheapest place to catch a
+  mismatched quadrant; once draft prose is on the page, rework costs
+  compound.
+- **Picking the quadrant by *topic* instead of by *reader posture*.**
+  "Authentication" is a topic; *learning* authentication, *configuring*
+  it, *looking up its parameters*, and *understanding why it's
+  cookie-based* are four different pieces — possibly all four.
+- **Blending quadrants because "the reader will appreciate the
+  context".** They won't. The framework's whole thesis is that mixing
+  modes is what makes docs frustrating; the link-out rule is
+  non-negotiable.
+- **Drafting a tutorial without running the steps end-to-end.** A
+  tutorial that doesn't produce the promised result is worse than no
+  tutorial. If the steps can't be run, you're writing a how-to or an
+  explanation — re-open the audience contract.
+- **Writing reference in narrative voice.** "You'll want to set this
+  to…" is explanation leaking into reference. Reference says *what*;
+  recommendations live in explanation.
+- **Writing explanation without an *About <X>* frame.** Open-ended
+  explanation absorbs adjacent material and sprawls. Name the question
+  the page answers; if you can't, the page isn't ready.
+- **Editing an existing guide via this skill.** `new-guide` is for new
+  pieces. Edits are normal PRs against the existing file; the rules in
+  step 4 still apply, but the skill's checkpoint and scaffold don't.

--- a/packs/user-guide-diataxis/.apm/skills/new-guide/SKILL.md
+++ b/packs/user-guide-diataxis/.apm/skills/new-guide/SKILL.md
@@ -7,10 +7,10 @@ description: Use this skill to draft a new user-facing guide under `docs/guides/
 
 Create a new user-facing guide under `docs/guides/<quadrant>/<slug>.md`,
 following the [Diátaxis framework](https://diataxis.fr/). The framework
-itself is documented in this repo's [`docs/guides/README.md`](../../../../docs/guides/README.md)
-and the per-quadrant README in each subdirectory — read those for the
-*what*; this skill is the *procedure* for landing a new piece on the
-right side of the line.
+itself is documented in this repo at `docs/guides/README.md` and the
+per-quadrant README in each subdirectory — read those for the *what*;
+this skill is the *procedure* for landing a new piece on the right
+side of the line.
 
 The load-bearing rule is **link out, don't blend**. When mid-draft you
 find yourself wanting to add theory inside a tutorial, or steps inside an

--- a/packs/user-guide-diataxis/.apm/skills/new-guide/assets/explanation.md
+++ b/packs/user-guide-diataxis/.apm/skills/new-guide/assets/explanation.md
@@ -1,0 +1,51 @@
+# About <topic>
+
+> Why <thing> works the way it does. This page is for readers who want
+> to understand more deeply — not to learn a skill or solve a specific
+> problem. For tasks, see the [how-to index](../how-to/); for the
+> parameter list, see [<reference title>](../reference/<slug>.md).
+
+## The question this page answers
+
+<One paragraph framing the *About <X>* scope. What does a reader who
+lands here want to come away understanding? Naming this keeps the page
+bounded; without it, explanation absorbs adjacent material and
+sprawls.>
+
+## The shape of the answer
+
+<Walk the reader through the model. The key ideas, the connections to
+adjacent concepts, the bigger picture. Explanation is *allowed* to be
+opinionated and to wander a little — but it stays inside the *About <X>*
+frame above.>
+
+## Design choices and tradeoffs
+
+<The deliberate alternatives the design weighed; why this path was
+taken over the obvious other one. If a specific decision was recorded
+in an ADR, link it — but don't restate the ADR. ADRs are *for the
+team*; this page is *for users*.>
+
+## How this differs from <adjacent concept>
+
+<Comparisons that illuminate. "X vs. Y, when to use which" pieces live
+here, not in how-tos.>
+
+## See also
+
+- [<tutorial title>](../tutorials/<slug>.md) — to learn the skill.
+- [<how-to title>](../how-to/<slug>.md) — to apply it.
+- [<reference title>](../reference/<slug>.md) — for the precise
+  parameter list.
+- [ADR-NNNN](../../adr/NNNN-<slug>.md) — the team's record of *why we
+  chose* this approach.
+
+<!--
+Reminders from the skill — delete before committing:
+
+- Frame the scope as "About <X>". Without that, explanation sprawls.
+- No step-by-step instructions. No parameter tables. Link out.
+- Allowed to be opinionated and to wander — within the frame.
+- ADRs are *for the team*; this page is *for users*. Same topic,
+  different audience, different framing — don't merge them.
+-->

--- a/packs/user-guide-diataxis/.apm/skills/new-guide/assets/how-to.md
+++ b/packs/user-guide-diataxis/.apm/skills/new-guide/assets/how-to.md
@@ -1,0 +1,52 @@
+# How to <named problem in the reader's words>
+
+This guide is for <competent user> who needs to <accomplish the named
+goal>. It assumes you already <list the baseline competence — what the
+reader has, knows, or has set up>.
+
+If you're new to <product / feature>, start with
+[<tutorial title>](../tutorials/<slug>.md) instead — that one walks the
+basics.
+
+## Before you start
+
+You need:
+
+- <prerequisite — what the reader has / knows>
+- <prerequisite>
+
+## Steps
+
+1. <First action — terser than a tutorial; the reader knows their way around>.
+2. <Next action>.
+3. <Next action>.
+
+## Variations
+
+Real problems branch. Cover the cases the reader is likely to hit:
+
+- **If <condition>:** <alternate path>.
+- **If <condition>:** <alternate path>.
+
+## Common pitfalls
+
+- **<Symptom you'll see>** — <cause, and the one-line fix>.
+- **<Symptom>** — <cause, fix>.
+
+## See also
+
+- [<reference title>](../reference/<slug>.md) — for the full list of
+  <options / parameters / commands>.
+- [<explanation title>](../explanation/<slug>.md) — for *why* <design
+  choice> is the way it is.
+
+<!--
+Reminders from the skill — delete before committing:
+
+- Title names the reader's problem in their words. ("How to rotate a
+  credentialed-skill token", not "Credential rotation guide".)
+- Skip "turn on the power switch"-level steps. The reader is competent.
+- Cover the realistic variations and the common pitfalls — that's what
+  earns this page the click over reference.
+- No "why" deep dives. Link out to explanation.
+-->

--- a/packs/user-guide-diataxis/.apm/skills/new-guide/assets/reference.md
+++ b/packs/user-guide-diataxis/.apm/skills/new-guide/assets/reference.md
@@ -1,0 +1,87 @@
+# <Thing> reference
+
+> Authoritative description of <thing>. For tasks, see the
+> [how-to index](../how-to/). For why the design is shaped this way,
+> see [<explanation title>](../explanation/<slug>.md).
+
+<!--
+If this page is auto-generated from <source>, replace this comment with:
+
+> **Generated.** This file is generated from `<source>`. Do not edit by
+> hand — edit the source and re-run `<generator command>`.
+-->
+
+## <Section 1 — pick the shape that fits the item kind>
+
+Reference items come in many kinds. Pick *one* shape per kind and apply
+it uniformly across every entry of that kind — predictability is
+everything; readers scan. Three common shapes appear below as examples.
+If your reference items are a different kind (data schemas, env vars,
+event payloads, webhook bodies, etc.), design a shape that fits and
+apply it uniformly — don't force-fit one of the three.
+
+**Config option / parameter / flag — fixed metadata table:**
+
+### `<option name>`
+
+| | |
+| --- | --- |
+| Type | `<type>` |
+| Default | `<default>` |
+| Required | <yes / no> |
+| Since | `<version>` |
+
+<One-sentence neutral description. No recommendation. Just *what*.>
+
+```<lang>
+<minimal usage example>
+```
+
+**API endpoint / RPC — request / response shape:**
+
+### `<METHOD> <path>`
+
+<One-sentence neutral description.>
+
+| Parameter | In | Type | Required | Description |
+| --- | --- | --- | --- | --- |
+| `<name>` | path / query / body | `<type>` | <yes / no> | <description> |
+
+**Response:** `<status>` — `<shape>`.
+
+**CLI command / subcommand — usage + flags table:**
+
+### `<command>`
+
+```
+<command> [flags] <args>
+```
+
+| Flag | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--<name>` | `<type>` | `<default>` | <description> |
+
+## Errors
+
+<!-- Delete this section if your reference items don't have associated
+     error codes. -->
+
+| Code | Meaning | When you see it |
+| --- | --- | --- |
+| `<CODE>` | <neutral description> | <trigger condition> |
+| `<CODE>` | <neutral description> | <trigger condition> |
+
+## See also
+
+- [<how-to title>](../how-to/<slug>.md) — for tasks that use these.
+- [<explanation title>](../explanation/<slug>.md) — for the design
+  rationale.
+
+<!--
+Reminders from the skill — delete before committing:
+
+- Neutral, austere, factual. No editorializing, no "we recommend".
+- Every entry of the same kind has the same shape — readers scan.
+- Complete. Omitted options are the most common reference failure.
+- If auto-generated, mark it clearly at the top.
+-->

--- a/packs/user-guide-diataxis/.apm/skills/new-guide/assets/tutorials.md
+++ b/packs/user-guide-diataxis/.apm/skills/new-guide/assets/tutorials.md
@@ -1,0 +1,68 @@
+# <Verb-first title — "Build a working X", "Set up your first Y">
+
+> At the end of this tutorial you'll have <one concrete, working artifact
+> the reader can see, touch, or run>.
+
+This tutorial is for someone who has never used <product / feature>
+before. If you already have <prerequisite skill>, jump to
+[<how-to title>](../how-to/<slug>.md) instead.
+
+## Before you begin
+
+You need:
+
+- <prerequisite — installed binary, account, file>
+- <prerequisite>
+
+If installing any of these is non-trivial, follow
+[<install how-to>](../how-to/<slug>.md) first and come back here.
+
+## Step 1 — <concrete action in the imperative>
+
+<One short sentence on what this step does.>
+
+```bash
+<exact command>
+```
+
+You should see:
+
+```
+<exact expected output, or a screenshot description>
+```
+
+> If you don't see this: <the single most common pitfall and how to
+> recognize it>. Other variations belong in a separate how-to.
+
+## Step 2 — <next concrete action>
+
+<...>
+
+## Step 3 — <next concrete action>
+
+<...>
+
+## What you built
+
+You now have <name the artifact>. <One short sentence reassuring the
+reader that they accomplished the promised outcome.>
+
+## Next steps
+
+- For the natural next task: [<how-to title>](../how-to/<slug>.md).
+- To understand *why* <choice in the tutorial> works the way it does:
+  [<explanation title>](../explanation/<slug>.md).
+- For the full list of <options / commands / parameters>:
+  [<reference title>](../reference/<slug>.md).
+
+<!--
+Reminders from the skill — delete before committing:
+
+- One path only. No "you could also do…" branches.
+- Every step shows expected output / reassurance.
+- No theory inside the steps. Link out to explanation instead.
+- Step-level "If you don't see this" callouts cover the single most
+  common pitfall — extended troubleshooting goes in a how-to.
+- Test the tutorial end-to-end before merging. Broken tutorials are
+  the worst failure mode of the framework.
+-->


### PR DESCRIPTION
## What does this change?

Replaces the `new-guide` skill's 10-line placeholder with a full implementation: a gated audience-contract checkpoint, an explicit quadrant→directory mapping, per-quadrant write-time rules with canonical Diátaxis citations, and four minimal scaffolds under `assets/`. The skill ships under the `user-guide-diataxis` pack with source at `packs/user-guide-diataxis/.apm/skills/new-guide/` and projected to `.claude/skills/new-guide/` via `make build-self`.

## Why?

Conversation thread asked whether the four reviewer agents (`adversarial-reviewer`, `security-reviewer`, `quality-engineer`, `implementer`) need a fifth "tech-writer" or "experience-focused" reviewer for user-facing and architecture docs. Audit found a literal gap (no reviewer covers writing quality, Diátaxis fit, or audience-fit) but the gap hasn't bit us three times — so adding a fifth specialist agent flunks the pressure-test bar. The cheaper move is to catch quadrant-fit at write time, in the existing `new-guide` skill (which was a stub). This PR fills it out.

## How do I verify it?

```
make build-check                          # lint + build + check; passes clean
git log -1 --stat                         # 10 files, 964 insertions
```

Adversarial review ran three passes (initial → fix → verify); final verdict `Clean — ready to commit.`

Trigger phrases that should now route to this skill: `"write a guide for X"`, `"new tutorial"`, `"new how-to"`, `"new reference page"`, `"new explanation"`. The frontmatter `Do NOT use for…` line disambiguates against `new-spec`, `new-rfc`, `new-adr`.

## What did you not change that you considered?

- A fifth `tech-writer` reviewer agent — declined; gap hasn't bit three times.
- A Diátaxis primer inside the SKILL.md — declined; the seed READMEs under `packs/user-guide-diataxis/seeds/docs/guides/<quadrant>/README.md` already are the user-facing primer; the skill links to them and to `diataxis.fr` rather than duplicating.
- A numbering script under `scripts/` — declined; guides are kebab-named under quadrant subdirs, not sequentially numbered.
- A prose-quality lint or voice/tone checker — declined; discipline, not scaffolding. The skill names Google's rules; mechanical enforcement is overreach.
- Extending `adversarial-reviewer` to read `docs/guides/` for docs↔code drift — deferred. That's a complementary move (catching drift at review time, not just fit at write time); worth doing if doc-quality bites us again.

---

## Checklist

- [x] Tests pass locally (no test surface — skill body + scaffolds only)
- [x] Lint and typecheck pass (`make build-check` → clean)
- [x] Self-review run via `adversarial-reviewer` — three passes; final `Clean — ready to commit.` `security-reviewer` and `quality-engineer` not warranted (no security boundary, no code paths).
- [x] Spec and code agree (no spec; the conversation thread is the contract)
- [x] Living docs match reality:
  - [x] `docs/product/changelog.md` — not user-visible; no entry needed
  - [x] `docs/guides/` — N/A, this PR doesn't add guides; it adds the skill that adds guides
  - [x] `docs/architecture/` — N/A, no code structure change
  - [x] `docs/product/roadmap.md` — N/A
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured — sibling-skill-shape mirroring (audience-contract checkpoint matches `new-spec`/`new-rfc` shape) is already established practice; no new memory needed.