### PR TITLE
docs(guides): add how-tos for core and governance-extras skills

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -170,7 +170,7 @@ are *forward-looking governance*; ADRs are *backward-looking record*.
 **Lifecycle:**
 
 ```
-Draft → Open for comment → Final comment period → Accepted | Rejected | Withdrawn
+Draft → Open → Final Comment Period → Accepted | Rejected | Withdrawn
 ```
 
 Once an RFC is **Accepted**, it produces follow-on artifacts:

--- a/docs/guides/explanation/core-pack.md
+++ b/docs/guides/explanation/core-pack.md
@@ -49,6 +49,12 @@ they all read:
   the editor lifecycle. `session-start.py` reads the install-marker
   and nudges into `adapt-to-project` on first session.
 
+Plus a sibling skill that runs alongside the six: **`bug-fix`** ships
+in `core` too and runs a parallel discipline (reproduce → red test →
+root vs. symptom → minimum fix → regression test stays) without
+entering the spec / loop pipeline. It composes with `work-loop` when
+the fix grows past one file. See [how to fix a bug](../how-to/bug-fix.md).
+
 ## How they tie together
 
 A feature lifecycle, end to end, with the parts named:

--- a/docs/guides/how-to/bug-fix.md
+++ b/docs/guides/how-to/bug-fix.md
@@ -1,0 +1,254 @@
+# How to fix a bug
+
+You have a defect — a deviation between what the code does and what
+it's supposed to do — and you want to drive it through the project's
+fix discipline rather than vibe-patching it. The `bug-fix` skill
+(shipped in `core`) is the entry point. This page walks the path from
+"I have a bug" through "the fix is in main and the regression test
+will catch this if it ever comes back."
+
+For the *why* behind the loop discipline the skill runs under the
+hood, read [the core pack as a system](../explanation/core-pack.md).
+This guide is task-oriented; it tells you what to type and what to
+expect back.
+
+## Prerequisites
+
+- The `core` pack installed in your target repo.
+- A working directory where you can edit, commit, and run gates
+  (lint / typecheck / test).
+- Either a reproducer in hand, or enough signal (stack trace, log line,
+  user report) to drive toward one. The skill won't let you skip the
+  reproducer step — see [Step 1](#step-1--reproduce-the-bug).
+
+## Is `bug-fix` the right entry point?
+
+| Situation | Skill to invoke |
+| --- | --- |
+| Code does the wrong thing and you want to fix it | `bug-fix` |
+| Code does what was specified but the spec is wrong | `new-spec` — this is a behavior change, not a fix |
+| Refactor that preserves behavior | Open a PR; skip both skills |
+| You don't know yet whether it's a bug or intended behavior | Investigate first; come back when the answer is "bug" |
+
+The line that matters: `bug-fix` is for **deviations from intended
+behavior in code that already exists.** If the conversation turns into
+"actually this should work differently," the skill stops and tells
+you to switch to `new-spec` — that boundary is in the skill
+description, not a mid-flow auto-routing.
+
+> **Invoke skills by name.** Claude Code's description-based
+> auto-discovery is best-effort — natural phrasings like "fix this
+> bug" usually fire the skill, but not always. **Naming the skill in
+> your request guarantees it fires.** Use the name-the-skill form
+> below whenever you want the discipline, including on edge cases
+> where description matching wouldn't pick it up.
+
+## Step 1 — Reproduce the bug
+
+This is the load-bearing step. No reproduction, no fix — the skill
+will refuse to draft code until you have one of: a failing test,
+documented manual steps that fail reliably, or a captured error /
+stack trace / log signature. The obvious fix is wrong about a third
+of the time, and you can't tell which third until the bug fails red
+in front of you.
+
+Name the skill in your invocation. Two worked invocations:
+
+```
+use the bug-fix skill to diagnose and fix the off-by-one in the
+pagination cursor on the orders list endpoint — repro: GET
+/orders?cursor=X returns 11 items instead of 10
+```
+(Reproducer is in hand — a curl that returns the wrong count. The
+skill goes straight to writing the failing test.)
+
+```
+use the bug-fix skill to investigate the intermittent 500 from the
+checkout webhook receiver — repro is flaky, only on production
+traffic shape
+```
+(Differs from above: the reproducer is flaky, not in-hand. The skill
+refuses to draft a fix without a deterministic reproduction — if you
+can't build one, it stops and asks rather than writing speculative
+code.)
+
+Natural phrasings (`fix this bug`, `this is broken`,
+`investigate this regression`) match the skill's description and often
+trigger it, but description matching isn't guaranteed. Lead with
+`use the bug-fix skill to …` whenever you want the discipline to fire
+reliably.
+
+## Step 2 — Write the failing test (red)
+
+Once the bug is reproducible, the skill writes a test that fails
+*because of the bug*. The test pins the **observable contract being
+violated**, not the current implementation — so it survives the fix
+and lives in the suite as the regression test.
+
+The skill pushes back on two common failure modes here:
+
+- **Mock-shape assertions.**
+  `expect(mock).toHaveBeenCalledWith(...)` when the observable
+  contract is actually a returned value or a state change. Test the
+  contract, not the implementation.
+- **Test passes for the wrong reason.** Before declaring the test
+  red, the skill runs it against the unfixed code and confirms it
+  fails *because of the bug*, not because the setup is broken.
+
+The failing test you write here is the regression test you ship. Don't
+plan to delete it after the fix lands.
+
+## Step 3 — Identify root cause before writing the fix
+
+Symptom-hunting is the most expensive failure mode in bug fixing.
+Before the diff opens, the skill writes down a one-line answer to
+each:
+
+1. **Where is the defect actually?** In the called function, the
+   caller, their shared assumption, or upstream of both? A null that
+   crashes in `parse()` may originate in the loader that should never
+   have produced null.
+2. **When did it start?** `git log` and `git blame` on the affected
+   code. For regressions, the breaking commit often tells you why;
+   even for non-regressions, the surrounding history surfaces original
+   intent.
+3. **Could the same class of bug exist elsewhere?** Grep for the same
+   pattern. If yes, decide whether the fix widens or whether you file
+   follow-ups and add an explicit non-goal ("fix here only").
+
+These three answers go in the commit body. The diff shows *what*; the
+commit body shows *why*.
+
+## Step 4 — Write the minimum fix
+
+The smallest change that turns the failing test green. The skill
+refuses to fix adjacent issues in the same PR — each cleanup is its
+own PR with its own justification. Bug-fix PRs are for fixing the
+named bug.
+
+The exception is the same-area, same-concern, mechanical ride-along
+carve-out described in the
+[`work-loop` skill](../../../packs/core/.apm/skills/work-loop/SKILL.md).
+A typo on the line above the fix is fine; a refactor of the
+surrounding module isn't. When in doubt, defer.
+
+## Step 5 — Verify root vs. symptom
+
+Look at the diff against the answers from step 3. Does this fix
+address the root cause, or does it mask the symptom? The skill
+refuses these symptom-only anti-patterns:
+
+- **Catch-all exception handlers** that swallow the bug instead of
+  making the failing call not throw.
+- **Defensive checks at every call site** when the invariant should
+  hold upstream. Twelve `if (x == null) return` callers of a function
+  that should never return null is masking, not fixing.
+- **Retries around flaky code** when the right fix is to make the
+  code deterministic.
+- **Feature flags that disable the broken path** instead of fixing
+  it. Flags are for staged rollout, not for hiding bugs.
+
+If the failing test from step 2 still passes under a symptom-only
+fix, the test is wrong — go back to step 2 and sharpen it.
+
+## Step 6 — Run gates and ship
+
+Run lint / typecheck / tests and open the PR. The commit follows
+Conventional Commits format (`fix(<scope>): <subject>`) with a body
+documenting the root cause from step 3.
+
+For multi-file fixes, treat the work as non-trivial and run it
+through `work-loop` for the gate / review / fix iteration: the same
+iteration cap, stasis detection, and adversarial-reviewer pass that
+any other multi-file change goes through. See
+[how to plan and execute non-trivial work](plan-and-execute-non-trivial-work.md)
+for the loop mechanics. The `bug-fix` skill itself doesn't dispatch
+the loop — that's your call based on the diff's shape.
+
+If there's a tracker ticket, the final step is commenting the PR URL
+on it and transitioning state. The mechanism is adopter-specific
+(`gh issue comment`, Jira MCP, Linear CLI, or whatever your team
+uses); the obligation — keeping the ticket synced — is universal.
+
+## Variations
+
+### Single-file fix vs. multi-file fix
+
+A one-file, one-function fix runs steps 1–6 inline; the work-loop
+overhead isn't worth it. If the fix touches multiple files or crosses
+a module boundary, treat it as non-trivial work and run the
+gate / review / fix iteration through `work-loop` at step 6. That's
+an operator-side call — the skill doesn't decide.
+
+### Production hotfix pressure
+
+The discipline still applies when production is on fire, but the
+order can flex on your call. Step 1 (reproduce) and step 4 (minimum
+fix) are non-negotiable. Step 2 (failing test) can ship as a
+follow-up PR if writing it would block the hotfix by more than
+minutes — file the follow-up explicitly so the regression test still
+lands. This is adopter pressure-handling, not skill behaviour; the
+skill itself runs regression-test-first.
+
+### Reproducer needs investigation
+
+If the bug is intermittent or production-only, the skill refuses to
+draft a fix without a deterministic reproduction. If you can't build
+one after investigation, the skill stops and asks rather than writing
+speculative code. "Couldn't reproduce on my machine" is a hypothesis
+worth testing, not a closing condition.
+
+## Pitfalls
+
+> **Fixing forward without a reproduction.** The obvious fix is
+> wrong about a third of the time, and the only way to tell is the
+> failing test. Don't skip step 1.
+
+> **Fixing the bug plus adjacent cleanup in one PR.** Each cleanup is
+> its own PR with its own justification. The same-area mechanical
+> ride-along carve-out is narrow — a typo, not a refactor.
+
+> **Adjusting the spec or the test to match the buggy behavior.** If
+> the spec and the fix disagree, one of them is wrong. Surface that
+> explicitly; don't paper over it.
+
+> **Closing as "not reproducible" without trying hard enough.**
+> Document what was tried, on what version, with what data, before
+> giving up. The cost of an extra hour of investigation is small
+> compared to a bug that resurfaces in three months.
+
+> **Deleting the failing test after the fix turns it green.** The
+> test is the regression test. It lives in the suite forever; that's
+> the point.
+
+## When not to use this workflow
+
+- **New features.** If "fixing" the bug means changing what the code
+  *should* do, that's a behavior change. Use `new-spec` instead — see
+  [how to plan and execute non-trivial work](plan-and-execute-non-trivial-work.md).
+- **Refactors that preserve behavior.** No bug, no fix — just a PR
+  with a clear rationale. See
+  [`docs/CONVENTIONS.md` § Pull requests](../../CONVENTIONS.md#pull-requests).
+- **Spikes and throwaway exploration.** If the output is going to be
+  thrown away, the skill's discipline adds friction for no gain.
+- **You don't know whether it's a bug.** Investigate first; come
+  back when you have an answer shaped like "the code does X, it
+  should do Y."
+
+## Related
+
+- [The core pack as a system](../explanation/core-pack.md) — why the
+  discipline exists and how the parts compose.
+- [`bug-fix` skill](../../../packs/core/.apm/skills/bug-fix/SKILL.md) —
+  authoritative procedure.
+- [How to plan and execute non-trivial work](plan-and-execute-non-trivial-work.md) —
+  the loop discipline that `bug-fix` hands off to for multi-file fixes.
+- [`docs/CONVENTIONS.md` § How we do non-trivial work](../../CONVENTIONS.md#how-we-do-non-trivial-work) —
+  the contributor-side rationale.
+- [`docs/CONVENTIONS.md` § Commits](../../CONVENTIONS.md#commits) —
+  Conventional Commits format and the body conventions the skill
+  follows.
+- [How to write a new RFC](new-rfc.md) — when a "bug" turns out to be
+  a cross-cutting design question.
+- [How to record a new ADR](new-adr.md) — when the root-cause analysis
+  surfaces a decision worth pinning.

--- a/docs/guides/how-to/new-adr.md
+++ b/docs/guides/how-to/new-adr.md
@@ -1,0 +1,284 @@
+# How to record a decision (ADR)
+
+You made an architectural call — a database choice, a process commitment,
+a structural rule the team will live with — and the next person to ask
+"why did we do it this way?" deserves an answer in writing. The `new-adr`
+skill drafts an Architecture Decision Record in `docs/adr/` from the
+bundled template, with the next sequential number, and pushes back on
+hand-wavy sections before you commit.
+
+This guide is task-oriented; for the *why* of ADRs (immutable history vs.
+living docs), read
+[`docs/CONVENTIONS.md` § ADR](../../CONVENTIONS.md#2-adr--architecture-decision-records--docsadr).
+For where ADRs sit in the wider doc system, see
+[the core pack as a system](../explanation/core-pack.md).
+
+## ADR or RFC?
+
+The two skills look adjacent and confuse readers regularly. The split is
+about *time*, not topic:
+
+| Property | ADR (`new-adr`) | RFC (`new-rfc`) |
+| --- | --- | --- |
+| Direction in time | Backward-looking record | Forward-looking proposal |
+| State of the decision | Made (or about to be made) | Under debate; may be rejected |
+| After acceptance | Body frozen at acceptance; `Status:` header still mutable | Body frozen at acceptance (status field mutable); spawns ADRs, specs, convention edits |
+| Change mechanism | New ADR that *supersedes* the old; status of the old flips, body stays | Normal revision until accepted, frozen thereafter |
+
+If the call is already made (or you're recording one made in a meeting
+yesterday), it's an ADR. If you want a debate, it's an RFC — and the
+*accepted* RFC then produces one or more ADRs as follow-on. See
+[how to propose a change (RFC)](new-rfc.md) for the inverse view.
+
+## Prerequisites
+
+> **Pack:** `governance-extras`. `new-adr` does not ship in `core`.
+> Verify with `ls .claude/skills/new-adr/` (or the equivalent skill
+> registry in your IDE — Claude Code's `/agents`, Cursor's Composer,
+> etc.). If the directory is missing, install or enable
+> `governance-extras` first.
+
+- A `docs/adr/` directory at the repo root. The skill creates it on
+  first use if absent; the repo's seed `docs/adr/README.md` is fine to
+  leave in place.
+- A decision that genuinely warrants an ADR — the entry-point prose
+  below covers the test.
+
+## When is `new-adr` the right call?
+
+Three conditions, all must hold:
+
+1. **The decision is about architecture or shared infrastructure**, not
+   one feature's internals. ("We use Postgres for the primary store"
+   is an ADR; "the saved-filters chip uses URL state, not local
+   storage" is a spec.)
+2. **The decision has been made** (or is being formally proposed for
+   acceptance). ADRs are not the venue for open-ended discussion — that
+   debate belongs in an RFC.
+3. **There is a concrete tradeoff.** At least one viable alternative
+   was considered. If only one option exists ("we use UTF-8"), you
+   don't need an ADR.
+
+If any of these fails, push back rather than writing an ADR that future
+readers will discount. The skill checks them at invocation time.
+
+> **Invoke skills by name.** Claude Code's description-based
+> auto-discovery is best-effort — natural phrasings like "let's ADR
+> this" usually fire the right skill, but not always. **Naming the
+> skill in your request guarantees it fires.** Use
+> `use the new-adr skill to …` whenever you want the discipline,
+> including on edges where description matching wouldn't pick it up.
+
+## Step 1 — Invoke the skill
+
+Two worked invocations that genuinely differ:
+
+```
+use the new-adr skill to record our choice of Postgres over DynamoDB
+for the user-activity store
+```
+(technology choice — the alternatives section will weigh DynamoDB,
+SQLite, and a managed warehouse against the team's Postgres
+familiarity.)
+
+```
+use the new-adr skill to record our decision to use trunk-based
+development with short-lived feature branches
+```
+(process choice — the alternatives section will weigh GitFlow and
+release-branch models against the team's deploy cadence.)
+
+Natural phrasings (`let's ADR this`, `write an ADR for X`,
+`record this decision`) match the skill's description and often
+trigger it, but description matching isn't guaranteed. Lead with
+`use the new-adr skill to …` whenever you want the discipline to fire
+reliably.
+
+## Step 2 — Confirm the three preconditions
+
+Before the skill scaffolds anything, it asks (explicitly or
+implicitly) about architecture-not-feature, decided-not-debated, and
+real-tradeoff. If you can't answer cleanly, the skill pushes back. Two
+common redirects:
+
+- **"This is still being debated."** → open an RFC instead. The
+  accepted RFC then produces the ADR as follow-on.
+- **"This is about a single feature's internals."** → write a spec
+  (`new-spec`), not an ADR.
+
+## Step 3 — Find the next ordinal and scaffold the file
+
+The skill runs its bundled `scripts/next-ordinal.py` helper (the path
+is skill-relative; the skill resolves it for you). It prints the next
+4-digit ordinal — `0001` if `docs/adr/` is empty, max-plus-one
+otherwise. Numbers are sequential and never reused. The helper parses
+the full digit prefix, so transitions like `0099` → `0100` work
+correctly without manual zero-padding.
+
+The skill then picks a short kebab-case title from your description
+(`0007-use-postgres-for-primary-store.md`, not
+`0007-decision-about-the-database.md`), copies its bundled
+`assets/adr.md` into `docs/adr/`, and renames.
+
+## Step 4 — Fill in frontmatter
+
+Status starts as `Proposed`. Today's date. Deciders are the GitHub
+handles of the people signing off. `Supersedes:` is `none` for a
+greenfield ADR; otherwise the ADR number being replaced (see
+Variations).
+
+## Step 5 — Draft the four body sections
+
+The skill walks you through Context, Decision, Consequences, and
+Alternatives. It pushes back on hand-wavy sections rather than
+accepting them:
+
+- **Context with no listed constraints** → the skill asks what's
+  actually constraining the choice. "We need a database" isn't
+  context; "~10M records, query by `user_id` and time range, team of
+  two who know Postgres" is.
+- **Decision without a single declarative sentence at the top** →
+  the skill asks you to write one. ("We will use Postgres as the
+  primary data store for user activity.")
+- **Consequences with only positives** → the skill asks what you're
+  giving up. Honest negatives are what save the next person from
+  re-litigating the choice.
+- **Alternatives without rejection reasons** → the skill asks why
+  each was rejected. One sentence each is enough; the point is to
+  show future readers you *considered* the option they're about to
+  suggest.
+
+## Step 6 — Update the ADR index
+
+The skill adds a row to `docs/adr/README.md` so the new ADR appears in
+the table.
+
+## Step 7 — Get sign-off, then mark Accepted
+
+The skill leaves status as `Proposed` and tells you to flip it to
+`Accepted` once the relevant reviewers have signed off — usually in
+the same PR, sometimes in a follow-up commit. Once Accepted, the body
+is frozen. See the immutability mechanic below.
+
+## The immutability principle
+
+ADRs differ from wiki-style docs in one load-bearing way: **once
+accepted, the body is never edited.** This is what makes ADRs a
+durable record rather than a moving target.
+
+The status field can move (`Accepted` → `Deprecated`, or
+`Accepted` → `Superseded by ADR-NNNN`). The body text stays put. If
+the decision is reversed or revised, you write a *new* ADR that
+supersedes the old one, with explicit cross-references in both
+directions, and update the old ADR's `Status:` header — *header only,
+body untouched*. The old text remains visible as historical record;
+the new ADR carries the current reasoning.
+
+This is the difference between an ADR and documentation. Documentation
+should match present truth; ADRs preserve why we *got here*.
+
+## Variations
+
+### Recording a decision made just now (the common case)
+
+You're capturing the call before the details fade. The decision is
+fresh in everyone's head; the skill's pushback on hand-wavy sections
+costs the least here. Invoke right after the meeting where the choice
+landed.
+
+### Recording a decision made months ago
+
+A maintainer joins, asks "why are we doing it this way?" and there's
+no good answer in writing. Open an ADR now anyway — backfilling is
+fine. Reconstruct Context from memory and Git history; mark Deciders
+as the people who actually decided (not you, unless you were in the
+room); note in `References` that the ADR is being backfilled. The
+content matters more than the freshness.
+
+### Superseding an existing ADR
+
+A previously-accepted ADR no longer reflects the team's call. You
+do *not* edit the old ADR's body. Instead:
+
+1. Run `new-adr` for the new decision. In Context, name the prior
+   ADR you're superseding and what changed since it was written.
+2. Set the new ADR's frontmatter `Supersedes:` to the old ADR's
+   number.
+3. After the new ADR is Accepted, update the old ADR's frontmatter
+   `Status:` from `Accepted` to `Superseded by ADR-<NNNN>` — with the
+   actual four-digit number of the new ADR substituted in (e.g.
+   `Superseded by ADR-0023`). Leave the old body alone — it's history.
+
+If the reversal is contested or non-obvious, the reversal should go
+through an RFC first; the accepted RFC then produces this superseding
+ADR as follow-on. See
+[`docs/CONVENTIONS.md` § RFC](../../CONVENTIONS.md#3-rfc--request-for-comments--docsrfc)
+for the trigger conditions.
+
+### Originating from an accepted RFC
+
+The RFC carried the debate; its accepted outcome lists "one or more
+ADRs to record the architectural decisions" as follow-on artifacts.
+Run `new-adr` per architectural decision named, cite the RFC in
+`Related:`, and let the RFC carry the prior-art and alternatives
+weight — the ADR's `Alternatives considered` can be terse when the RFC
+already exhausted them.
+
+## Pitfalls
+
+> **Treating an ADR as the place to debate.** ADRs are not the venue
+> for open discussion — that's an RFC. If you find yourself writing
+> "we should probably …" or "options to consider …", you wanted an
+> RFC. Stop, open one, let it carry the debate.
+
+> **Editing an accepted ADR's body.** The body is frozen at
+> acceptance. Status-only changes (`Accepted` → `Deprecated` |
+> `Superseded by ADR-NNNN`) are the only edits permitted. Anything
+> else is a *new* ADR that supersedes.
+
+> **Hand-wavy Alternatives.** "We considered other options but chose
+> this" tells future readers nothing. One sentence per alternative
+> with the actual rejection reason — that's the section that prevents
+> the same option being re-proposed in six months.
+
+> **Consequences with only positives.** Every decision has
+> tradeoffs; an ADR that lists only upside isn't honest, and the next
+> person will discount it. Push for at least one real negative or
+> "to revisit" item.
+
+> **An ADR for a single feature's internals.** That's a spec
+> (`docs/specs/<feature>/`), not an ADR. ADRs are for cross-cutting
+> architectural and infrastructural calls.
+
+## When not to use this workflow
+
+- **The decision is still being debated.** Use `new-rfc` — RFCs carry
+  the debate; ADRs record the outcome. The accepted RFC then produces
+  the ADR.
+- **The decision is about a single feature's internals.** Use
+  `new-spec` — feature-internal choices live in
+  `docs/specs/<feature>/spec.md` under Boundaries or Testing Strategy.
+- **The decision is trivial or has only one sensible option.**
+  ("We use UTF-8.") No ADR needed. Don't manufacture decisions to
+  document.
+- **Documenting how something works today.** That's
+  `docs/architecture/`, not `docs/adr/`. ADRs are *why* we made the
+  call; `architecture/` is *what* the code looks like now.
+
+## Related
+
+- [How to propose a change (RFC)](new-rfc.md) — the inverse: when the
+  decision isn't yet made, open an RFC.
+- [How to plan and execute non-trivial work](plan-and-execute-non-trivial-work.md) —
+  the spec/loop workflow for feature-shaped changes that aren't ADRs.
+- [The core pack as a system](../explanation/core-pack.md) — where
+  ADRs sit in the wider doc hierarchy.
+- [`new-adr` skill](../../../packs/governance-extras/.apm/skills/new-adr/SKILL.md) —
+  authoritative procedure (preconditions, template, pushback rules).
+- [`new-rfc` skill](../../../packs/governance-extras/.apm/skills/new-rfc/SKILL.md) —
+  authoritative procedure for the proposal skill.
+- [`docs/CONVENTIONS.md` § ADR](../../CONVENTIONS.md#2-adr--architecture-decision-records--docsadr) —
+  the immutability rule, status values, when-to-write tests.
+- [`docs/CONVENTIONS.md` § Document lifecycle](../../CONVENTIONS.md#document-lifecycle) —
+  living vs. frozen vs. governance; ADRs are why the living layer can
+  stay honest about the present.

--- a/docs/guides/how-to/new-rfc.md
+++ b/docs/guides/how-to/new-rfc.md
@@ -1,0 +1,258 @@
+# How to propose a cross-cutting change (RFC)
+
+You have a change in mind that touches more than one package, alters a
+convention, or reverses a previous decision — the kind of change where
+"open a PR and see what happens" is the wrong shape. This guide walks
+the path of drafting an RFC with the `new-rfc` skill: scaffolding the
+file, running the research phase before any body sentence gets written,
+and circulating the proposal for comment.
+
+For the surrounding system — where RFCs sit relative to ADRs, specs,
+and the loop that builds features once an RFC is accepted — read [the
+core pack as a system](../explanation/core-pack.md). This guide is
+task-oriented; it tells you what to type and what to expect back.
+
+## RFC vs. ADR — which one fits
+
+The two skills look adjacent but solve different problems. Get this
+right before you invoke either, or you'll write the wrong artifact
+twice.
+
+| Question | RFC | ADR |
+| --- | --- | --- |
+| Tense | Forward-looking ("should we change X?") | Backward-facing ("we chose X over Y") |
+| Lifecycle | `Draft` → `Open` → `Final Comment Period` → `Accepted` \| `Rejected` \| `Withdrawn` | `Proposed` → `Accepted` → (`Deprecated` \| `Superseded by ADR-NNNN`) |
+| Body after acceptance | Frozen at acceptance (status field can change later, body cannot); stays as historical record; produces follow-on ADRs, specs, or CONVENTIONS edits | Frozen at acceptance (status field can change later, body cannot) |
+| Reject path | `Rejected` is a normal terminal state — the discussion was the point | A pre-acceptance ADR that doesn't earn `Accepted` just isn't committed; there's no `Rejected` state |
+| Trigger | The decision is still being debated, or affects external users | The decision is made (or is being formally proposed) and has a concrete tradeoff |
+
+Quick rule: **RFCs propose; ADRs record.** If the discussion hasn't
+happened yet, you want an RFC. If the discussion is done and you're
+writing it down so the next maintainer can reconstruct it, you want an
+ADR. Both are covered by the lifecycle table in
+[`docs/CONVENTIONS.md` § Document lifecycle](../../CONVENTIONS.md#document-lifecycle).
+
+If you're recording a decision that's already settled, see
+[how to record a decision (ADR)](new-adr.md) instead.
+
+## Prerequisites
+
+> **Pack:** `governance-extras`. `new-rfc` does not ship in `core`.
+> Verify with `ls .claude/skills/new-rfc/` (or the equivalent skill
+> registry in your IDE — Claude Code's `/agents`, Cursor's Composer,
+> etc.). If the directory is missing, install or enable
+> `governance-extras` first.
+
+- A working `docs/rfc/` directory. The skill creates one if it's
+  missing, but the home for the file matters — the lifecycle rules in
+  `docs/CONVENTIONS.md` only apply to RFCs at this path.
+- Web search available in your agent harness (Claude Code's
+  `WebSearch`, or the equivalent elsewhere). The external prior-art
+  sweep degrades gracefully without it — the skill says so explicitly
+  rather than fabricating citations — but you lose half the research
+  phase's value.
+
+## When `new-rfc` is the right call
+
+Before invoking, check that the change clears at least one of these
+bars, lifted from [`docs/CONVENTIONS.md` § RFC](../../CONVENTIONS.md#3-rfc--request-for-comments--docsrfc):
+
+- It touches more than one package, or affects external users.
+- It reverses a previous ADR.
+- It adds, removes, or modifies a top-level directory or convention.
+- You expect any reasonable contributor to want a say.
+
+If none of these fire — the change fits in one package and preserves
+public interfaces — push back on yourself. A normal PR is enough.
+[`AGENTS.md`](../../../AGENTS.md) carries the same rule for
+*substantive* CHARTER edits: those go through RFC, but trivial ones
+(typos, broken links) ship as PRs.
+
+> **Invoke skills by name.** Claude Code's description-based
+> auto-discovery is best-effort — natural phrasings like "let's get
+> input on X" usually fire the right skill, but not always. **Naming
+> the skill in your request guarantees it fires.** Lead with
+> `use the new-rfc skill to …` whenever you want the discipline to
+> trigger reliably.
+
+## Step 1 — Invoke `new-rfc`
+
+Two worked invocations from genuinely different RFC shapes:
+
+```
+use the new-rfc skill to propose a new commit-message convention
+requiring spec citations in every feature PR
+```
+(a *new* convention — adds a rule that doesn't exist yet; the
+research phase will look hard for prior conventions the rule would
+clash with.)
+
+```
+use the new-rfc skill to amend the work-loop iteration cap from 5
+to 7 based on six months of stasis-detection data
+```
+(Differs from above: an *amendment* to an existing convention — the
+research phase already has the target sitting in `docs/CONVENTIONS.md`,
+so the proposal hinges on whether the precedent's reasoning still
+holds today, not on prior-art existence.)
+
+Natural phrasings (`propose a change to …`, `let's get input on …`,
+`draft an RFC for …`) match the skill's description and often
+trigger it. The explicit form is the reliable one.
+
+## Step 2 — Watch the research phase
+
+The skill scaffolds `docs/rfc/NNNN-<kebab-title>.md` from the bundled
+template and then **stops** before writing any body sentence. This is
+the load-bearing move: RFCs handed to reviewers with bare unresolved
+questions waste reviewer time on research the author should have done
+first.
+
+You'll see a `RESEARCH FINDINGS:` block in chat (not in the RFC file —
+the body is gated) with three sections:
+
+1. **Prior art (in repo).** Hits from grep across `docs/CHARTER.md`,
+   `docs/CONVENTIONS.md`, `docs/adr/`, `docs/rfc/`, `docs/specs/`,
+   and `docs/architecture/`. Each with a file path. Read these —
+   they often reveal that the proposal touches something you didn't
+   know was decided.
+2. **Prior art (external).** Web-search results on how comparable
+   projects, languages, or processes handled this shape of problem
+   (Rust RFCs, PEPs, IETF BCPs, internal RFCs from similar orgs).
+   Each as a markdown link. Empty here is a finding — say so — not
+   an omission.
+3. **Recommendations on unresolved questions.** Every question your
+   intent raised, paired with: what repo precedent suggests, what
+   external prior art suggests, and a recommended answer with
+   one-sentence reasoning.
+
+Read the recommendations carefully. For each:
+
+- **Accept** — the recommendation folds into the body when drafting
+  resumes.
+- **Reject without an alternative** — the question stays in the body's
+  `Unresolved questions` section, with your lean noted.
+- **Revise** — give the skill the alternative; it will re-thread that
+  one finding into the body.
+
+> **Do not approve the block in bulk.** A vague "looks good" doesn't
+> count as sign-off on the highest-stakes recommendation. Name the
+> recommendation you're accepting, especially when the skill flagged
+> one as load-bearing.
+
+## Step 3 — Drafting resumes against the research
+
+Once you sign off, the skill drafts the body sections of the RFC,
+threading the findings:
+
+- **Motivation.** Repo-precedent citations land here. The cost of
+  inaction lives here too — "we spend ~3 hours a week working
+  around X" beats "it would be nice to…".
+- **Proposal.** The concrete shape of the change. Specific enough
+  that a reviewer can disagree with the *substance*, not just the
+  framing.
+- **Alternatives considered.** Mandatory. Always includes "do
+  nothing." The skill pushes back if this section is empty.
+- **Prior art.** The external-sweep citations from the research
+  phase. Empty-with-explanation is a valid outcome; empty-with-no-
+  explanation is not.
+- **Drawbacks.** Mandatory. The skill pushes back on "none."
+- **Unresolved questions.** Carries your lean from research, even if
+  the lean is "punt to reviewers."
+
+The file lands at `docs/rfc/NNNN-<kebab-title>.md` with status `Draft`.
+
+## Step 4 — Move through the lifecycle
+
+The lifecycle is `Draft → Open → Final Comment Period →
+Accepted | Rejected | Withdrawn`. You move the status manually as
+the discussion progresses:
+
+- **`Draft`** — still working on it; not yet circulated.
+- **`Open`** — ready for reviewers. Update the frontmatter and push.
+- **`Final Comment Period`** — discussion is winding down; last call
+  for objections.
+- **`Accepted`** | **`Rejected`** | **`Withdrawn`** — terminal. Fill in
+  `Date closed:`. The RFC freezes here (see [`CONVENTIONS.md` § Document
+  lifecycle](../../CONVENTIONS.md#document-lifecycle)) — status field
+  can change later (e.g. a future RFC supersedes it), the body cannot.
+
+The skill also updates `docs/rfc/README.md` so the new file shows up
+in the index.
+
+## Step 5 — After acceptance
+
+An accepted RFC is rarely the last artifact. It points at concrete
+follow-on work, which lives in `docs/specs/<feature>/`, `docs/adr/`,
+or `docs/CONVENTIONS.md`:
+
+- **Architectural decisions → one or more ADRs.** See [how to record
+  a decision (ADR)](new-adr.md).
+- **Concrete features → specs.** See [how to plan and execute
+  non-trivial work](plan-and-execute-non-trivial-work.md).
+- **Convention changes → direct edits to `docs/CONVENTIONS.md`.** The
+  change itself, not a copy of the RFC text. Cite the RFC where the
+  reasoning belongs.
+
+The RFC's job is done once the follow-on artifacts exist. It stays as
+history.
+
+## Pitfalls
+
+> **Writing body content before the research phase clears.** The
+> skill refuses to do this; if you find yourself filling sections by
+> hand to "save time", you've skipped the part of the workflow that
+> makes the RFC worth reading. Let the research phase emit, sign off,
+> *then* let the body fill.
+
+> **Empty `Prior art` when web search was available.** "We didn't
+> look" isn't an answer — the external sweep is exactly what
+> distinguishes an RFC from a wishlist. If the sweep genuinely
+> returned nothing, say so explicitly under the heading and link the
+> queries you ran.
+
+> **Bare unresolved questions with no author lean.** Every entry in
+> `Unresolved questions` should carry your lean from the research
+> phase, even if it's "punt to reviewers." Reviewers reading bare
+> questions waste a round asking for context the author already had.
+
+> **Treating an RFC as a venue to relitigate an accepted ADR
+> without naming it.** If you're proposing a reversal, cite the ADR
+> in `Related:` and address its reasoning directly in `Motivation`.
+> The skill's repo-sweep will surface the ADR anyway; engaging with
+> it up-front saves a review round.
+
+> **Drifting a `Draft` RFC indefinitely.** A `Draft` that never moves
+> to `Open` is functionally a private note. If you're not ready to
+> circulate, ask whether the proposal is actually ready to exist as
+> an RFC, or whether a spike or investigation note belongs first.
+
+## When not to use this workflow
+
+- **A bug fix, performance improvement, or refactor that preserves
+  behavior.** Just open a PR. RFCs are for proposing change to
+  shared shape, not for fixing what's already agreed.
+- **A new feature that fits cleanly within one package and changes
+  no interface.** Write a spec, not an RFC — see [how to plan and
+  execute non-trivial work](plan-and-execute-non-trivial-work.md).
+- **A decision that's already settled.** That's an ADR — see [how to
+  record a decision (ADR)](new-adr.md). The `new-rfc` skill
+  explicitly refuses to scaffold an RFC for an already-decided thing.
+- **Single-feature internals.** The contract for one feature lives in
+  `docs/specs/<feature>/spec.md`, not in an RFC.
+
+## Related
+
+- [How to record a decision (ADR)](new-adr.md) — the inverse skill;
+  use it when the discussion is done.
+- [How to plan and execute non-trivial work](plan-and-execute-non-trivial-work.md) —
+  what an accepted RFC's feature follow-on looks like.
+- [The core pack as a system](../explanation/core-pack.md) — where
+  governance-extras fits relative to `core`.
+- [`new-rfc` skill](../../../packs/governance-extras/.apm/skills/new-rfc/SKILL.md) —
+  authoritative procedure, including the research-phase gating rules.
+- [`docs/CONVENTIONS.md` § RFC](../../CONVENTIONS.md#3-rfc--request-for-comments--docsrfc) —
+  the lifecycle, filename rule, and when-to / when-not-to.
+- [`docs/CONVENTIONS.md` § Document lifecycle](../../CONVENTIONS.md#document-lifecycle) —
+  living vs. frozen vs. governance, and why RFCs sit in their own
+  bucket.

--- a/docs/guides/how-to/plan-and-execute-non-trivial-work.md
+++ b/docs/guides/how-to/plan-and-execute-non-trivial-work.md
@@ -1,0 +1,278 @@
+# How to plan and execute non-trivial work
+
+You have a feature to build, a refactor to drive, a migration to run —
+anything past a one-line edit. This guide walks the path from "I'm
+about to start" through "the PR is green and the reviewer is clean",
+using the two skills that drive it: `new-spec` and `work-loop`.
+
+For the *why* behind this discipline, read [the core pack as a
+system](../explanation/core-pack.md). This guide is task-oriented; it
+tells you what to type and what to expect back.
+
+## Prerequisites
+
+- The `core` pack installed in your target repo.
+- A working directory where you can edit, commit, and run gates
+  (lint / typecheck / test).
+- Familiarity with the four mandatory spec sections (Objective,
+  Boundaries, Testing Strategy, Acceptance Criteria) — see
+  [`docs/CONVENTIONS.md`](../../CONVENTIONS.md).
+
+## Pick your entry point
+
+Two skills, one workflow:
+
+| Situation | Skill to invoke |
+| --- | --- |
+| New feature or significant change — no spec yet | `new-spec`, then `work-loop` |
+| Spec already exists in `docs/specs/<feature>/` | `work-loop` (it reads the spec) |
+| Multi-file bug fix | `bug-fix` — see [how to fix a bug](bug-fix.md) |
+| One-line edit, typo, single config tweak | Skip the loop — overhead isn't worth it |
+
+If you're unsure whether the change is trivial, default to the loop.
+The cost of running it on a small task is one extra minute; the cost
+of vibe-coding a non-trivial task is a re-do.
+
+> **Invoke skills by name.** Claude Code's description-based
+> auto-discovery is best-effort — natural phrasings like "let's spec
+> this out" usually fire the right skill, but not always. **Naming
+> the skill in your request guarantees it fires.** Use the
+> name-the-skill form below whenever you want the discipline,
+> including on edge cases where description matching wouldn't pick it
+> up.
+
+## Step 1 — Run `new-spec` (when no spec exists)
+
+The skill writes `docs/specs/<feature>/spec.md` and `plan.md`, and
+gates body content on assumption sign-off.
+
+Name the skill in your invocation. Two worked invocations — one
+backend, one frontend:
+
+```
+use the new-spec skill to design webhook retries with exponential
+backoff for the payment-events stream
+```
+(retry logic is a state machine — Testing Strategy will pick TDD for
+this one.)
+
+```
+use the new-spec skill to spec the saved-filters chip on the
+product-search results page
+```
+(the chip is a visible UI element — Testing Strategy will pair it
+with visual / manual QA, possibly automated.)
+
+Natural phrasings (`let's spec out X`, `new spec: Y`,
+`write a spec for Z`) match the skill's description and often
+trigger it, but description matching isn't guaranteed. Lead with
+`use the new-spec skill to …` whenever you want the discipline to
+fire reliably.
+
+### What to put in front of it
+
+`new-spec` ingests whatever input you give it and surfaces what's
+missing. Any of these shapes work:
+
+- A one-line idea ("add 2FA for admin login").
+- A requirements doc or PRD pasted into the message.
+- A linked ticket — Linear, Jira, GitHub issue. Reference the URL; the
+  skill reads what's there.
+- An upstream brief from a portfolio team (Feature Intent, Component
+  Brief, or whatever shape your org produces).
+- A bug report that's grown into a feature ("this thing should work
+  differently").
+
+The skill doesn't care which shape you brought. The assumption
+checkpoint is where missing information gets named, regardless of
+input shape — so an idea-shaped input surfaces more Unverified items,
+a brief-shaped input surfaces fewer. The output is the same: a spec
+and plan grounded in confirmed assumptions.
+
+### What to expect
+
+1. The skill scaffolds `docs/specs/<feature>/spec.md` and `plan.md`
+   from the bundled templates.
+2. It drafts assumption candidates across Technical / Product /
+   Process categories, runs **one targeted check per candidate** (a
+   repo read, a web lookup, or a read-only probe), then **stops** and
+   emits an `ASSUMPTIONS I'M MAKING:` block split into `Verified`
+   (each with a one-line citation of the check) and `Unverified`
+   (each needing your input). The check happens before the bullet
+   gets filed, not after.
+3. You read the Unverified list and confirm or revise. If the
+   Unverified list is empty, the skill surfaces the Verified list with
+   the highest-stakes item called out and asks you to confirm *that
+   one specifically* — a vague "looks good" doesn't count.
+4. Spec body fills in: Objective, Boundaries (including at least one
+   structural `Never do`), Testing Strategy with a verification mode
+   per outcome, Acceptance Criteria.
+5. Plan body fills in: tasks with `Tests:` before `Approach:`,
+   explicit `Depends on:`, verification mode per task.
+6. `adversarial-reviewer` reads the spec and plan cold. Iterate to
+   clean — usually one to two passes; if you can't reach clean in
+   three, the skill stops and asks for human direction (the spec
+   likely has a structural problem, not a wording one).
+7. The skill updates `docs/specs/README.md` and reminds you that spec
+   drift is a bug — update the spec in the same PR when implementation
+   diverges.
+
+If you want to stop here (pure planning, no build yet), this is the
+natural exit point. The spec and plan are durable; come back to
+`work-loop` whenever you're ready.
+
+## Step 2 — Run `work-loop`
+
+With a spec in place, invoke the loop by name. Same two domains
+carried through:
+
+```
+use the work-loop skill to implement docs/specs/webhook-retries
+```
+(TDD-mode tasks for retry logic; goal-based for wiring.)
+
+```
+use the work-loop skill to drive the saved-filters-chip spec
+```
+(visual / manual QA on the chip; goal-based on the URL-state plumbing.)
+
+Naming the skill is the reliable form. The `work-loop` description
+also matches phrasings like "implement the X spec" or "let's work on
+Y", but the explicit form fires the loop's full discipline — gates,
+adversarial review, stasis detection, the state machine — even on
+edges where description matching wouldn't pick it up automatically.
+
+### What it does
+
+The full procedure lives in
+[the `work-loop` SKILL.md](../../../packs/core/.apm/skills/work-loop/SKILL.md).
+The short version:
+
+- **PLAN** — reads `spec.md` and `plan.md`, picks verification modes if
+  not already set, designs construction tests up front, and asks you
+  to name the **declined-pattern register**: one to three things you
+  were tempted to add (a layer, a flag, a defensive wrapper) and
+  explicitly declined. The register pairs with the spec's Boundaries
+  section so REVIEW can catch drift toward declined temptations as
+  self-contradiction in the diff. Pre-EXECUTE adversarial review
+  fires automatically on spec amendments or on any of the four
+  structural triggers (new module, new dependency, new abstraction,
+  new top-level directory).
+- **EXECUTE** — implements task by task. TDD-mode tasks run
+  red-green-refactor; goal-based tasks run the `Done when:` one-liner;
+  manual-QA tasks record the visual check.
+- **GATES** — lint, typecheck, tests. Mechanical, ordered, no editing
+  the gate to make it pass.
+- **REVIEW** — `adversarial-reviewer` reads the diff cold against
+  `AGENTS.md` + `CONVENTIONS.md` + `spec.md`. Findings come back as
+  Blockers / Concerns / Nits with one-sentence fixes. The loop
+  records each pass's finding fingerprints to `state.json` via
+  `loop-cohort review record`, which is what enables stasis detection
+  in the next phase. Specialist reviewers (`security-reviewer`,
+  `quality-engineer`) run when the diff warrants.
+- **DECIDE** — each finding routes to `apply` (fix in this PR) or
+  `defer` (one-line entry under `Deferred:` in the PR body). Stasis
+  detection fires if the same findings come back two iterations in a
+  row — stop and surface to a human rather than spinning a third pass.
+
+For the end-to-end narrative with the parts in context, read
+[core-pack.md § How they tie together](../explanation/core-pack.md#how-they-tie-together).
+
+### Termination cues you'll see
+
+- **Gates green and review clean** → ship.
+- **`loop-cohort.py check` exits non-zero** → the script tells you
+  which cap fired (iteration cap, token budget, consecutive errors,
+  plan not approved, or fingerprint stasis). Read the message; don't
+  override.
+- **Diff is shrinking but findings aren't** → you're spot-fixing
+  without addressing root cause. Back to PLAN.
+
+If any of these fire and the work isn't done, the task is bigger than
+you thought. Re-plan rather than expanding scope silently.
+
+## Variations
+
+### Resume an in-flight spec
+
+`work-loop` reads `docs/specs/<feature>/` and picks up from
+`state.json`. Phrase as "resume the X work" or "continue on
+`docs/specs/X`". Pre-EXECUTE review won't re-fire unless you amended
+the spec or plan since the last pass — or the re-plan introduced one
+of the four structural triggers.
+
+`state.json` is gitignored session-scratch — on a fresh checkout
+(new machine, after `git clean`, a teammate's box), the loop
+re-initializes it via `loop-cohort.py init` and treats the spec /
+plan / diff as authoritative.
+
+### Spec amendment mid-flight
+
+If EXECUTE discovers a missing or wrong task, update `plan.md` first,
+then resume. The pre-EXECUTE adversarial review re-fires automatically
+if the re-plan introduces any structural trigger. This is by design —
+most over-engineering surfaces mid-flight, not during initial PLAN.
+
+### Parallel implementers (supervisor mode)
+
+If your plan has two or more tasks declaring `Depends on: none`,
+`work-loop` fans out into supervisor mode and dispatches one
+`implementer` subagent per independent task. The procedure lives in
+[`references/supervisor-mode.md`](../../../packs/core/.apm/skills/work-loop/references/supervisor-mode.md);
+the loop loads it on demand.
+
+## Pitfalls
+
+> **Skipping `new-spec` for "small" multi-file work.** If the change
+> touches more than one file, the spec is cheap insurance. A
+> three-paragraph spec is fine — the discipline is the point, not the
+> document length.
+
+> **Editing `state.json` by hand.** The file is owned by the
+> `loop-cohort` tool. Hand edits desync the loop's view of plan
+> approval and fingerprint state. Run the tool's verbs; don't reach
+> in.
+
+> **Treating gates as sufficient.** Gates are necessary. Review
+> catches what gates can't — missing edge cases, scope creep, spec
+> drift. Don't skip the reviewer pass because "it'll be fine".
+
+> **Skipping pre-EXECUTE review on a structural change.** The four
+> triggers (new module boundary, new dependency, new abstraction
+> layer, new top-level directory) are exactly the cases where
+> over-engineering is most expensive to undo. The cost of catching it
+> at PLAN is a sentence; at REVIEW it's a re-do.
+
+> **Letting the spec drift from the implementation.** When
+> implementation diverges from the spec, the spec is wrong. Update the
+> spec in the same PR — drift is a bug, not paperwork debt.
+
+## When not to use this workflow
+
+- **Genuine one-line edits** — typo, config tweak, copy-paste fix.
+  The loop's overhead exceeds the work.
+- **Spikes and throwaway exploration.** If the output is going to be
+  thrown away, the spec / plan / review machinery adds friction for no
+  gain. Mark the work explicitly as a spike and skip the loop.
+- **Investigation before implementation.** If you don't yet know what
+  to build, you're not ready for `new-spec`. Investigate first; come
+  back with a question shaped like a feature.
+
+For bug-shaped work that crosses multiple files, see
+[how to fix a bug](bug-fix.md) — the `bug-fix` skill is the right
+entry point.
+
+## Related
+
+- [The core pack as a system](../explanation/core-pack.md) — why the
+  loop exists and how the parts compose.
+- [`docs/CONVENTIONS.md` § How we do non-trivial work](../../CONVENTIONS.md#how-we-do-non-trivial-work) —
+  the contributor-side rationale.
+- [`new-spec` skill](../../../packs/core/.apm/skills/new-spec/SKILL.md) —
+  authoritative procedure for the planning skill.
+- [`work-loop` skill](../../../packs/core/.apm/skills/work-loop/SKILL.md) —
+  authoritative procedure for the loop itself.
+- [How to fix a bug](bug-fix.md) — `bug-fix` is the entry point for
+  bug-shaped work.
+- [How to adapt the pack to your project](adapt-to-project.md) —
+  post-install setup; do this before your first feature.

--- a/packs/core/seeds/docs/CONVENTIONS.md
+++ b/packs/core/seeds/docs/CONVENTIONS.md
@@ -170,7 +170,7 @@ are *forward-looking governance*; ADRs are *backward-looking record*.
 **Lifecycle:**
 
 ```
-Draft → Open for comment → Final comment period → Accepted | Rejected | Withdrawn
+Draft → Open → Final Comment Period → Accepted | Rejected | Withdrawn
 ```
 
 Once an RFC is **Accepted**, it produces follow-on artifacts:


### PR DESCRIPTION
## What does this change?

Adds four task-oriented how-to guides under `docs/guides/how-to/` covering invocation of `new-spec` + `work-loop`, `bug-fix`, `new-rfc`, and `new-adr`. Also aligns RFC lifecycle state names in `docs/CONVENTIONS.md` (and its seed) with the canonical `new-rfc` SKILL.md and bundled template, surfaced while drafting.

## Why?

`SKILL.md` files are agent-loaded — they tell the model what to do when invoked but aren't shaped for a human reader deciding *which* skill to invoke and what to put in front of it. The explanation-quadrant `core-pack.md` and the SKILL.md files (reference) didn't cover the how-to quadrant. No spec or RFC — this is a documentation addition that composes from existing primitives.

## How do I verify it?

- `make build-self FORCE=1` projects cleanly; `git status` shows seed and projection in sync.
- `grep -r 'Open for comment\|Final comment period' .` returns zero hits.
- Read each how-to against its `SKILL.md` — every behaviour claim should trace verbatim. Each new how-to passed two adversarial-reviewer passes (pass 1: 20 findings across the four files; pass 2: clean on all).

## What did you not change that you considered?

- **Component Brief / Feature Intent / Stories artifacts** — research showed no community standard for the per-component cross-team handover artifact; the patterns from the source doc compose silently via existing primitives (spec frontmatter, `new-spec` input absorption). Three-times rule not satisfied; revisit if more adopters ask.
- **Extending `user-guide-diataxis` with the how-tos** — small adopters skip that pack but still install `core`, so the how-tos belong in this catalog repo's own docs, not in a shipped pack.
- **Per-skill `HOWTO.md` siblings to each `SKILL.md`** — off-spec per agentskills.io; the `docs/guides/how-to/` home is correct.

---

## Checklist

- [x] Lint passes (`make lint-packs` runs as part of `build-self`)
- [x] Self-review via `adversarial-reviewer` — two passes per how-to; all clean
- [x] Spec and code agree — N/A (no spec for docs-only addition)
- [x] Living docs match reality:
  - [x] `docs/guides/` updated (the four new how-tos and the `core-pack.md` sibling-skill paragraph)
  - [x] `docs/architecture/` — no code structure change
  - [x] `docs/product/roadmap.md` — no roadmap item completed by this PR
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured: drafting patterns recorded to project memory (`feedback_skill_howto_drafting.md`) so the next how-to addition inherits them