### PR TITLE
build(makefile): chain pre-pr aggregator into build-check

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -24,6 +24,13 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install tools dependencies
+        # `make build-check` chains `tools/hooks/pre-pr.py`, which calls
+        # `tools/lint-agent-artifacts.py` (and siblings) — those import
+        # PyYAML from tools/requirements.txt. Install before invoking make
+        # so the projected-artifact lint surface is reachable in CI.
+        run: pip install -r tools/requirements.txt
+
       - name: Run make build-check
         run: make build-check PACKS_DIR=packs
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ RECIPE ?=
 
 export PYTHONPATH
 
-.PHONY: build build-self build-self-dry-run build-check build-scaffold lint-packs validate clean zipapp release-preflight
+.PHONY: build build-self build-self-dry-run build-check build-scaffold lint-packs pre-pr validate clean zipapp release-preflight
 
 # Windows-portability gate. Refuses packs that ship symlinks or
 # Windows-poisonous names under seeds/ or .apm/. Runs before every
@@ -60,8 +60,18 @@ endif
 build-self-dry-run: lint-packs
 	$(PYTHON) -m agentbundle.build self --dry-run --packs-dir $(PACKS_DIR)
 
+# Projected-artifact + spec-state aggregator. Mirrors what
+# docs.yml's per-layer jobs and the `Lifecycle hooks` job run in CI;
+# chained into build-check below so `make build-check` is the single
+# local gate that covers both lint surfaces (packs source via
+# lint-packs, projected .claude/* artifacts via pre-pr). Safe to call
+# directly when you want only the artifact checks without rebuilding.
+pre-pr:
+	$(PYTHON) tools/hooks/pre-pr.py
+
 build-check: lint-packs build
 	$(PYTHON) -m agentbundle.build check --packs-dir $(PACKS_DIR)
+	$(PYTHON) tools/hooks/pre-pr.py
 
 build-scaffold:
 	@test -n "$(OUTPUT)" || (echo "make build-scaffold OUTPUT=<dir> required" >&2; exit 1)


### PR DESCRIPTION
## What does this change?

Wires `python tools/hooks/pre-pr.py` (the seven-linter aggregator) into `make build-check`, and adds a standalone `pre-pr` phony target so the aggregator can also be invoked directly. The local gate now covers both lint surfaces that this repo carries: packs source (via `lint-packs`) and projected `.claude/*` artifacts (via `pre-pr.py`).

## Why?

PR #169 (`new-guide` skill) shipped a CI failure that the work-loop's GATES discipline should have caught locally. The bug was a relative link with four `..` segments — valid neither from the source location (5 directories deep under `packs/...`) nor from the projection (3 directories deep under `.claude/...`). The relevant lint (`tools/lint-agent-artifacts.py`) runs against the projection, not against the source, so the source-side `lint-packs` couldn't see it. Local `make build-check` came back green; the `Agent-artifact hygiene` and `Lifecycle hooks` jobs in CI failed.

The root cause is structural: `make build-check` was wired against only one of the two lint surfaces. This PR closes the gap by chaining the canonical aggregator (`pre-pr.py`, already used by `docs.yml`'s `hooks` job) into `make build-check`.

## How do I verify it?

```bash
make pre-pr           # standalone — runs all seven artifact linters
make build-check      # also runs them, after lint-packs + build + drift check
```

Regression test (run locally, reverted):

1. Reintroduce a four-dot relative link in `packs/user-guide-diataxis/.apm/skills/new-guide/SKILL.md`.
2. `make build-self --force` to project.
3. `make build-check` — fails on `pre-pr: ✖ agent-artifact lint failed`. ✓

The seven linters chained: `lint-agents-md`, `lint-agent-artifacts`, `lint-skill-spec`, `lint-knowledge`, `lint-build`, `lint-seeds`, `lint-credentialed-skills` (+ its self-test), plus per-spec `loop-cohort check` against any `docs/specs/*/state.json` that's present.

## What did you not change that you considered?

- **Consolidating `docs.yml`'s per-layer CI jobs into `make build-check`.** Declined — the in-file comment on the `hooks` job documents the duplication as intentional for PR-UI granularity (each layer surfaces as its own check). Removing them would reduce review signal.
- **Chaining only `tools/lint-agent-artifacts.py` into `build-check`** rather than the full aggregator. Declined — the same gap covers six sibling linters; plugging one is whack-a-mole. The aggregator already exists and is the canonical pre-PR surface.
- **Updating `AGENTS.md` or `CONVENTIONS.md`.** Not needed — they refer to `make build-check` as the gate, and that statement is now *more* truthful than before, not less. `docs/CONVENTIONS.md:360` says "Projected paths under `make build-check`'s gate" — still accurate, broader scope.
- **Renaming `pre-pr` to `lint-artifacts` or similar.** Declined — `pre-pr` is the established name in the codebase (script, bash sibling, hooks-doc references). Adding a different name for the same thing is gratuitous churn.
- **Updating the `work-loop` skill's GATES section.** Not needed — that section uses `<lint command>` abstractly; this PR is a recipe-level binding for this repo.

---

## Checklist

- [x] Tests pass locally (`make build-check` clean; the existing `test_build_check_drift_gates.py` calls `run_build_check_drift_gates` in-process per its own comment, not via subprocess to make, so unaffected)
- [x] Lint and typecheck pass (`make build-check` runs both surfaces clean)
- [x] Self-review run — change is a 13-line Makefile addition with mechanical regression verification; adversarial-reviewer not warranted for this scope.
- [x] Spec and code agree (no spec; conversation thread + memory entry `feedback_two_lint_surfaces.md` carry the contract)
- [x] Living docs match reality:
  - [x] `docs/product/changelog.md` — N/A (developer workflow, not user-visible)
  - [x] `docs/guides/` — N/A
  - [x] `docs/architecture/` — N/A
  - [x] `docs/product/roadmap.md` — N/A
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured — memory entry `feedback_two_lint_surfaces.md` records the trap; will update post-merge to reflect the new wiring.