### PR TITLE
feat(new-rfc): implement RFC-0014 — answer-first template + research-and-de-risk flow

### DIFF
--- a/.claude/skills/new-rfc/SKILL.md
+++ b/.claude/skills/new-rfc/SKILL.md
@@ -5,11 +5,13 @@ description: Use this skill when the user asks to propose, draft, or open an RFC
 
 # Skill: new-rfc
 
-Open a new RFC in `docs/rfc/` from the template — with a research phase
-before drafting, so reviewers don't get handed bare unresolved questions
-the author hadn't yet looked into. Modeled on `new-spec`'s assumption
-checkpoint, plus a per-question recommendation pass that RFCs need and
-specs don't.
+Open a new RFC in `docs/rfc/` from the template — **answer-first** (lead with
+"The ask"), with a per-subpoint research-and-de-risk phase before drafting and
+a mandatory self-review gate before handoff. The point: a reviewer gets a
+steerable proposal with the decision on top and its options modelled out and
+backed by research — not a pile of un-researched questions to rescue. Modeled
+on `new-spec`'s assumption checkpoint, plus the per-decision recommendation
+pass RFCs need and specs don't.
 
 ## When to invoke
 
@@ -43,36 +45,58 @@ push back: a normal PR (or a spec, if it's a feature) is enough.
    `assets/` folder lives next to this `SKILL.md` wherever your IDE
    installed the skill.)
 
-3. **Research phase — gated checkpoint.** With the file scaffolded, stop.
-   Don't write a single body sentence yet. The point of an RFC is to weigh
-   a proposal against what's already been tried; bare unresolved questions
-   handed to reviewers are research the author should have done first.
+3. **Research + de-risk checkpoint — gated.** With the file scaffolded, stop.
+   Don't write a single body sentence yet. A complex RFC is a tree, not one
+   blob: research the *subpoints*, model the options out, and de-risk your own
+   riskiest assumption before handing anything to a reviewer. A single shallow
+   up-front sweep is the failure this replaces.
 
-   Emit the findings *in chat* (not into the RFC file — the body is gated
-   below) under the structure shown. Two sweeps and a synthesis pass:
+   Work the proposal as decisions/subpoints, emitting findings *in chat* (not
+   into the gated body):
 
-   - **Repo sweep.** Grep `docs/CHARTER.md`, `docs/CONVENTIONS.md`,
-     `docs/adr/`, `docs/rfc/`, `docs/specs/`, and `docs/architecture/`
-     for precedent and conflicts — prior decisions the proposal touches,
-     related specs, conventions the proposal would alter. Cite each hit
-     with file path.
-   - **External sweep.** If web search is available (`WebSearch` in
-     Claude Code; the equivalent in other harnesses), look up how
-     comparable projects, languages, or processes have handled this shape
-     of problem (Rust RFCs, PEPs, IETF BCPs, internal RFCs from similar
-     orgs — whatever maps). Cite each source as a markdown link. If web
-     search isn't available, skip this sweep and say so explicitly under
-     the heading rather than producing fabricated citations.
-   - **Recommendations on unresolved questions.** For every question the
-     user's intent raises (from the conversation that triggered this
-     skill — the RFC body is still empty at this stage), surface: the
-     question, what repo precedent suggests, what external prior art
-     suggests, and a recommended answer with one-sentence reasoning.
+   - **Decompose first.** Break the proposal into its decisions/subpoints. The
+     research unit is the subpoint, not the whole RFC.
+   - **Research each subpoint independently:**
+     - *Repo sweep.* Grep `docs/CHARTER.md`, `docs/CONVENTIONS.md`,
+       `docs/adr/`, `docs/rfc/`, `docs/specs/`, and `docs/architecture/` for
+       precedent and conflicts the subpoint touches. Cite each hit with file
+       path.
+     - *External sweep.* If web search is available (`WebSearch` in Claude
+       Code; the equivalent elsewhere), look up how comparable projects,
+       languages, or processes handled this shape of problem (Rust RFCs, PEPs,
+       IETF BCPs, internal RFCs from similar orgs). Cite each as a markdown
+       link. If web search isn't available, say so explicitly rather than
+       fabricating citations.
+   - **Enumerate each option/scenario space to be collectively exhaustive
+     (MECE) along a stated axis**, and **ground every option in prior art**
+     (how have others taxonomised this?) rather than inventing categories. A
+     small round count (e.g. exactly 3) with no exhaustiveness argument or
+     sources is a smell to challenge, not a finish line. Always include
+     do-nothing.
+   - **Self-Ask.** Resolve research-answerable questions yourself and fold the
+     answers into the findings — they should not reach the human as open
+     questions.
+   - **Spike the riskiest assumption.** Identify the one assumption that, if
+     false, sinks the proposal; run a small/timeboxed check and report the
+     result — or state explicitly why no spike is needed. Do your own
+     experimentation; don't hand the reviewer an untested guess.
+   - **Cite as you go.** When a sweep (or a research subagent) surfaces a
+     source, fetch it and confirm it resolves *and* contains the borrowed
+     claim before that claim enters the findings. Never pass an unverified
+     citation through.
+   - **Recommend per decision.** For each decision/subpoint: the question,
+     what repo precedent suggests, what external prior art suggests, and a
+     recommended answer with one-sentence reasoning + owner + decide-by. Cap
+     genuinely-open questions at ~3.
 
-   Emit the findings under exactly these three headings:
+   Emit the findings under exactly these headings:
 
    ```
    RESEARCH FINDINGS:
+
+   ## Decisions / subpoints
+   1. **<subpoint>** — options (MECE along <axis>, prior-art-grounded): …
+      · recommendation: … · owner: … · decide-by: …
 
    ## Prior art (in repo)
    - …
@@ -80,41 +104,66 @@ push back: a normal PR (or a spec, if it's a feature) is enough.
    ## Prior art (external)
    - …
 
-   ## Recommendations on unresolved questions
-   1. **Question.** …
-      - Repo precedent: …
-      - External prior art: …
-      - Recommendation: …
+   ## De-risk
+   - Riskiest assumption: … · spike result (or why none needed): …
    ```
 
    Then **wait for human confirmation, rejection, or revision per
-   recommendation.** Do not write into *any* body section until the user
-   has signed off. The scaffolded headers can stay; the bodies are gated.
-   Recommendations the user accepts fold into the body; ones the user
-   rejects without an alternative, or genuinely defers, stay in
-   `Unresolved questions` — with the author's lean noted. Treat
-   unanswered recommendations as deferred (same destination, lean kept).
+   recommendation.** Do not write into *any* body section until the user has
+   signed off. Accepted recommendations fold into the body; ones rejected
+   without an alternative, or genuinely deferred, stay in `Open questions` —
+   with a recommended default + owner + decide-by, never bare.
 
-4. Draft the body, now informed by the research. Route the findings:
-   repo precedent lands as citations in `Motivation`; external precedent
-   lands in `Prior art`. (The chat block split the two for legibility;
-   the body has a single `Prior art` section.) Sections to push hardest
-   on:
-   - **Motivation.** Cite repo precedent where it argues for or against
-     the proposal.
-   - **Alternatives considered.** Including "do nothing." If the user
-     can't articulate any, the proposal isn't yet honest.
-   - **Prior art.** Land the external-sweep citations here. Empty prior
-     art is a finding (no one has done anything like this) — surface
-     that explicitly rather than leaving the section blank.
-   - **Drawbacks.** If they say "none", push back. There are always
-     drawbacks.
-   - **Unresolved questions.** Each carries the author's lean from the
-     research phase, even if the lean is "punt to reviewers."
+4. **Draft the body, answer-first.** Lead with **The ask**; then route the
+   findings: repo precedent → `Problem & goals` / `Evidence & prior art`;
+   external precedent and the spike result → `Evidence & prior art`. Sections
+   to push hardest on:
+   - **The ask.** The decision a reviewer must make, in plain language, on
+     top — Recommendation (BLUF) + SCQA framing + numbered decisions, each
+     with a recommended option + decide-by.
+   - **Problem & goals.** Diagnosis before solution; real **Non-goals**
+     (could-have-been-goals deliberately dropped), not negated goals.
+   - **Options considered.** MECE along a stated axis, each grounded in prior
+     art, including do-nothing. If you can't articulate ≥2 genuinely distinct
+     options, the proposal isn't honest yet.
+   - **Risks & what would make this wrong.** Pre-mortem + falsifiable
+     assumptions + drawbacks. If they say "no drawbacks", push back.
+   - **Evidence & prior art.** Empty prior art is a finding (no one has done
+     this) — surface it; never leave it blank or fabricated.
+   - **Open questions.** Each carries a recommended default + owner +
+     decide-by; aim for ≤3.
+   - **Experiment / validation** (optional). Only if the proposal needs an
+     experiment: hypothesis + what you measure + success/failure criteria.
+     Route *results* to a linked spike note, not the RFC body. Delete the
+     section otherwise.
 
-5. Set status to `Draft` until the user is ready to circulate, then `Open`.
+5. **Pre-handoff gate — mandatory, before status → Open.** Each item is
+   *executed and its result recorded, never self-certified*:
+   - **Citation-integrity protocol.** Every reference is fetched; it must both
+     resolve and actually contain the claim or statistic it is cited for (a
+     link that merely loads is not enough). Citations surfaced by a research
+     subagent get the same treatment. If a claim can't be confirmed, downgrade
+     or drop it. The rule is symmetric: *challenge* a citation by fetching it
+     too — never by judging whether an identifier "looks real".
+   - **Verify-before-you-assert.** Every checkable claim the RFC makes about
+     *itself* (section/field counts, "lighter", "readable") is checked against
+     the artifact, not asserted.
+   - **Per-subpoint backing.** Each decision/subpoint is independently backed
+     by research; each enumeration is MECE along a stated axis and prior-art-
+     grounded, not invented.
+   - **Completeness checklist (YES/NO).** Approver named? every decision
+     carries a recommendation? do-nothing present? ≤3 owned open questions? no
+     item is simultaneously a decided default *and* an open question? all
+     internal cross-references resolve?
+   - **Different-lens review.** Dispatch a subagent matching
+     `adversarial-reviewer` (fresh context) — **mandatory**, re-run until it
+     reports clean; add `security-reviewer` if the RFC touches a security
+     boundary. If no such subagent is installed, note it in the summary
+     rather than skipping silently.
 
-6. Update `docs/rfc/README.md` table (create the file with the standard
+6. Set status to `Draft` until the user is ready to circulate, then `Open`.
+
+7. Update `docs/rfc/README.md` table (create the file with the standard
    header row if absent).
 
 ## After acceptance
@@ -131,11 +180,22 @@ The RFC itself is then "done" and stays as historical record.
 ## Anti-patterns to refuse
 
 - Writing into the RFC body before the checkpoint clears → see step 3.
-- Bare unresolved questions with no author lean → if the question
-  hasn't been searched against repo + external prior art, the research
-  phase wasn't done. Send it back.
-- Empty `Prior art` while web search was available and comparable
-  processes plainly exist → the external sweep produces this section;
-  "we didn't look" isn't an answer. When web search *wasn't*
-  available, the section can be empty — but say so explicitly under
-  the heading and never fabricate citations to fill it.
+- A single shallow up-front sweep standing in for per-subpoint research on a
+  multi-decision RFC → decompose and back each subpoint.
+- Enumerating an option/scenario space by inventing a small round number of
+  categories (e.g. exactly 3) with no exhaustiveness argument or prior-art
+  grounding → make it MECE along a stated axis, and source it.
+- Bare open questions with no recommended default + owner → if the question
+  hasn't been searched against repo + external prior art, the research phase
+  wasn't done. Send it back.
+- Passing any citation — especially one surfaced by a subagent — into the
+  draft without fetching the source and confirming the borrowed claim is in
+  it (a link that resolves is not enough; this is the single most-documented
+  LLM-drafting failure). Challenge a citation the same way — by fetching —
+  never by judging whether an identifier "looks real".
+- Asserting any self-claim or a "gate passed" status without having run the
+  check.
+- Empty `Evidence & prior art` while web search was available and comparable
+  processes plainly exist → "we didn't look" isn't an answer. When web search
+  *wasn't* available, say so explicitly under the heading and never fabricate
+  citations to fill it.

--- a/.claude/skills/new-rfc/assets/rfc.md
+++ b/.claude/skills/new-rfc/assets/rfc.md
@@ -2,87 +2,117 @@
 
 - **Status:** Draft <!-- Draft | Open | Final Comment Period | Accepted | Rejected | Withdrawn -->
 - **Author:** <github-handle>
+- **Approver:** <github-handle who signs off — the one person whose yes starts implementation>
 - **Date opened:** YYYY-MM-DD
 - **Date closed:** <!-- filled in when status reaches a terminal state -->
 - **Related:** <!-- ADRs, specs, prior RFCs -->
 
-## Summary
+## The ask
 
 <!--
-One paragraph. What are you proposing? After reading this section a reviewer
-should know whether they care.
+Answer-first. After this section a reviewer should know exactly what they are
+being asked to approve, in plain language, without hunting through the design.
+
+- **Recommendation (BLUF):** one or two sentences — what to approve.
+- **Why now (SCQA):** Situation (agreed context) → Complication (what changed /
+  the problem) → the Question it raises. Three or four lines.
+- **Decisions requested:** numbered. Each = the question · the recommended
+  option · a one-line why · decide-by (and the default if no objection).
+
+Right-size to the stakes: a small, reversible change keeps this short and
+collapses the sections below to one-liners.
 -->
 
-## Motivation
+## Problem & goals
 
 <!--
-Why are we doing this? What's broken, missing, or about to become a problem?
+Diagnosis before any solution — name the problem first; if you can't, you have
+a wishlist, not a proposal. Then:
 
-Show the cost of inaction. "It would be nice to..." is not a motivation; "we
-spend ~3 hours a week working around X" is.
+- **Goals.**
+- **Non-goals** — things that could reasonably have been goals but you are
+  deliberately choosing not to pursue. Negated goals ("won't crash") don't
+  count; this section is where scoping work shows.
 -->
 
 ## Proposal
 
 <!--
-What specifically are you proposing? Be concrete enough that a reviewer can
-disagree with the substance, not just the framing.
-
-This section is where the design lives. Include:
-- The new shape of things (interfaces, file layout, processes — whatever
-  applies).
-- Migration path, if there's existing state to convert.
-- How users / contributors will interact with the change.
+The design. Concrete enough that a reviewer can disagree with the substance,
+not just the framing. Cascade the detail under each requested decision.
+Include the migration path if there's existing state to convert.
 -->
 
-## Alternatives considered
+## Options considered
 
 <!--
-What else did you look at? This section is mandatory — proposals without
-alternatives signal that the author hasn't yet thought hard enough.
+This section is mandatory and load-bearing.
 
-Include the "do nothing" option. Sometimes it wins.
+- Enumerate the option/scenario space to be **collectively exhaustive (MECE)
+  along a stated axis** — say what the axis is and why these options exhaust
+  it. A small round count (e.g. exactly 3) with no exhaustiveness argument is
+  a smell, not a finish line.
+- **Ground each option in prior art** (how have others solved this shape of
+  problem?) rather than inventing categories.
+- Include the **do-nothing** option and its cost of delay. Sometimes it wins.
+- State each option's trade-offs up front, against the goals — not retrofitted
+  after the choice. A starred/recommended-option table is encouraged.
 -->
 
-## Drawbacks
+## Risks & what would make this wrong
 
 <!--
-What's the cost of accepting this proposal? What might go wrong? What are we
-giving up?
-
-If you can't think of any drawbacks, the proposal isn't yet honest.
+- **Pre-mortem:** assume this shipped and failed — list the top failure modes
+  and their mitigations.
+- **Key assumptions (falsifiable):** phrase each so a reviewer can point at one
+  and say "that's wrong, because…".
+- **Drawbacks:** what it costs, what you're giving up. "None" is not an
+  answer — push back on yourself.
 -->
 
-## Prior art
+## Evidence & prior art
 
 <!--
-What other projects, languages, or processes have tackled the same shape of
-problem? What worked, what didn't, what should we learn?
-
-Land prior-art citations here — both from this repo (related ADRs, RFCs,
-specs) and from external precedent. "We considered X and it's a poor fit
-because Y" beats unsourced assertion.
-
-Empty prior art is itself a signal — no one has tried this — but call it
-out rather than leaving the section blank.
+- **Spike / de-risk result.** Identify the assumption that, if false, sinks the
+  proposal; run a small/timeboxed check and report the result here — or state
+  why no spike was needed. Do your own experimentation; don't hand the reviewer
+  an untested guess.
+- **Repo precedent.** Related ADRs, RFCs, specs the proposal touches.
+- **External prior art.** What other projects/processes did with this shape of
+  problem. Every citation must be fetched and confirmed to contain the claim it
+  supports — a link that merely loads is not enough. Empty prior art is itself
+  a finding (no one has tried this) — say so rather than leaving it blank, and
+  never fabricate.
 -->
 
-## Unresolved questions
+## Experiment / validation
 
 <!--
-What did you punt on? What are you hoping reviewers will weigh in on? Listing
-these explicitly focuses the discussion.
+OPTIONAL — delete this section unless the proposal genuinely needs an
+experiment. Frame the experiment here; do NOT paste raw results into the RFC
+(that bloats the proposal into a lab notebook).
 
-Each question should carry the author's lean — even if the lean is "punt to
-reviewers." A bare question with no author position means the homework
-wasn't done.
+- **Hypothesis.**
+- **What we measure.**
+- **Success / failure criteria.**
+
+Capture the results in a separate, linked spike note (or a follow-up RFC / a
+superseding ADR), and keep the RFC in Draft/Open while they're pending.
+-->
+
+## Open questions
+
+<!--
+Aim for ≤3. Each carries a **recommended default + owner + decide-by** — never
+a bare question. Anything you could resolve by research must already be
+answered in the body, not parked here; a bare question means the research
+phase wasn't done.
 -->
 
 ## Follow-on artifacts
 
 <!--
-Filled in when the RFC is accepted. What ADRs, specs, or convention changes
-will this produce? This is the bridge from "we agreed" to "we did it".
+Filled in when the RFC is accepted. The bridge from "we agreed" to "we did it".
 
 - ADR-NNNN: <title>
 - Spec: docs/specs/<feature>/

--- a/docs/guides/how-to/new-rfc.md
+++ b/docs/guides/how-to/new-rfc.md
@@ -4,8 +4,9 @@ You have a change in mind that touches more than one package, alters a
 convention, or reverses a previous decision — the kind of change where
 "open a PR and see what happens" is the wrong shape. This guide walks
 the path of drafting an RFC with the `new-rfc` skill: scaffolding the
-file, running the research phase before any body sentence gets written,
-and circulating the proposal for comment.
+file, running the per-subpoint research-and-de-risk phase before any body
+sentence gets written, drafting answer-first, and circulating the proposal
+after a self-review gate.
 
 For the surrounding system — where RFCs sit relative to ADRs, specs,
 and the loop that builds features once an RFC is accepted — read [the
@@ -100,38 +101,42 @@ Natural phrasings (`propose a change to …`, `let's get input on …`,
 `draft an RFC for …`) match the skill's description and often
 trigger it. The explicit form is the reliable one.
 
-## Step 2 — Watch the research phase
+## Step 2 — Watch the research + de-risk phase
 
 The skill scaffolds `docs/rfc/NNNN-<kebab-title>.md` from the bundled
 template and then **stops** before writing any body sentence. This is
-the load-bearing move: RFCs handed to reviewers with bare unresolved
-questions waste reviewer time on research the author should have done
-first.
+the load-bearing move: a complex RFC is a tree, not one blob, so the
+skill researches each *subpoint*, models its options out, and de-risks
+its own riskiest assumption — rather than handing you a pile of
+un-researched questions to rescue.
 
 You'll see a `RESEARCH FINDINGS:` block in chat (not in the RFC file —
-the body is gated) with three sections:
+the body is gated) with these sections:
 
-1. **Prior art (in repo).** Hits from grep across `docs/CHARTER.md`,
-   `docs/CONVENTIONS.md`, `docs/adr/`, `docs/rfc/`, `docs/specs/`,
-   and `docs/architecture/`. Each with a file path. Read these —
-   they often reveal that the proposal touches something you didn't
-   know was decided.
-2. **Prior art (external).** Web-search results on how comparable
-   projects, languages, or processes handled this shape of problem
-   (Rust RFCs, PEPs, IETF BCPs, internal RFCs from similar orgs).
-   Each as a markdown link. Empty here is a finding — say so — not
-   an omission.
-3. **Recommendations on unresolved questions.** Every question your
-   intent raised, paired with: what repo precedent suggests, what
-   external prior art suggests, and a recommended answer with
-   one-sentence reasoning.
+1. **Decisions / subpoints.** The proposal broken into the decisions it
+   asks for. Each lists its options — *collectively exhaustive (MECE)
+   along a stated axis and grounded in prior art, not a round number
+   someone invented* — plus a recommendation, an owner, and a decide-by.
+   This is where to push: if a subpoint shows "3 options" with no axis
+   or sources, the space wasn't modelled.
+2. **Prior art (in repo).** Grep hits across `docs/CHARTER.md`,
+   `docs/CONVENTIONS.md`, `docs/adr/`, `docs/rfc/`, `docs/specs/`, and
+   `docs/architecture/`, each with a file path. They often reveal the
+   proposal touches something you didn't know was decided.
+3. **Prior art (external).** Web-search results on how comparable
+   projects or processes handled this shape of problem (Rust RFCs, PEPs,
+   IETF BCPs). Each a markdown link. Empty here is a finding — say so —
+   not an omission.
+4. **De-risk.** The one assumption that, if false, sinks the proposal,
+   and the result of a small spike against it (or why none was needed).
 
 Read the recommendations carefully. For each:
 
 - **Accept** — the recommendation folds into the body when drafting
   resumes.
 - **Reject without an alternative** — the question stays in the body's
-  `Unresolved questions` section, with your lean noted.
+  `Open questions` section, with a recommended default + owner +
+  decide-by.
 - **Revise** — give the skill the alternative; it will re-thread that
   one finding into the body.
 
@@ -140,29 +145,60 @@ Read the recommendations carefully. For each:
 > recommendation you're accepting, especially when the skill flagged
 > one as load-bearing.
 
-## Step 3 — Drafting resumes against the research
+## Step 3 — Drafting resumes, answer-first
 
-Once you sign off, the skill drafts the body sections of the RFC,
-threading the findings:
+Once you sign off, the skill drafts the body — leading with the decision,
+then cascading detail:
 
-- **Motivation.** Repo-precedent citations land here. The cost of
-  inaction lives here too — "we spend ~3 hours a week working
-  around X" beats "it would be nice to…".
-- **Proposal.** The concrete shape of the change. Specific enough
-  that a reviewer can disagree with the *substance*, not just the
-  framing.
-- **Alternatives considered.** Mandatory. Always includes "do
-  nothing." The skill pushes back if this section is empty.
-- **Prior art.** The external-sweep citations from the research
-  phase. Empty-with-explanation is a valid outcome; empty-with-no-
-  explanation is not.
-- **Drawbacks.** Mandatory. The skill pushes back on "none."
-- **Unresolved questions.** Carries your lean from research, even if
-  the lean is "punt to reviewers."
+- **The ask.** Answer-first: the recommendation (BLUF) + an SCQA framing
+  (Situation → Complication → Question) + the numbered decisions you're
+  being asked to make, each with a recommended option and a decide-by. A
+  reviewer should know what they're approving from the first screen.
+- **Problem & goals.** Diagnosis before solution, plus **Non-goals** —
+  the could-have-been-goals deliberately dropped (not "won't crash").
+- **Proposal.** The concrete shape of the change, detailed under each
+  decision.
+- **Options considered.** Mandatory and MECE along a stated axis, each
+  option grounded in prior art and including "do nothing." The skill
+  pushes back if the enumeration is a round number with no exhaustiveness
+  argument.
+- **Risks & what would make this wrong.** A pre-mortem (assume it shipped
+  and failed), falsifiable key assumptions, and drawbacks. The skill
+  pushes back on "no drawbacks."
+- **Evidence & prior art.** The spike result and the prior-art citations
+  from the research phase. Empty-with-explanation is valid; empty-with-no-
+  explanation is not, and every citation is fetched and confirmed.
+- **Open questions.** Each carries a recommended default + owner +
+  decide-by.
+- **Experiment / validation** (optional). Present only if the proposal
+  needs an experiment — hypothesis, what's measured, success/failure
+  criteria — with the *results* linked out to a spike note, not pasted
+  into the RFC.
 
-The file lands at `docs/rfc/NNNN-<kebab-title>.md` with status `Draft`.
+The file lands at `docs/rfc/NNNN-<kebab-title>.md` with status `Draft` and
+an `Approver` named in the frontmatter.
 
-## Step 4 — Move through the lifecycle
+## Step 4 — The pre-handoff gate
+
+Before the RFC moves to `Open`, the skill runs a mandatory self-review gate
+so you aren't the one catching obvious misses. Each check is *run, not
+asserted*:
+
+- **Citation-integrity.** Every reference is fetched and confirmed to
+  actually contain the claim it's cited for — a link that merely loads
+  isn't enough. Citations are challenged the same way (by fetching), never
+  by eyeballing whether an identifier "looks real."
+- **Verify-before-you-assert.** Self-claims the RFC makes about itself
+  (counts, "lighter", "readable") are checked against the artifact.
+- **Per-subpoint backing + completeness.** Each decision is backed; the
+  `Approver` is named; every decision has a recommendation; do-nothing is
+  present; open questions are ≤3 and owned.
+- **A different-lens review.** A fresh-context `adversarial-reviewer` pass
+  (and `security-reviewer` if the RFC touches a security boundary), re-run
+  until clean — because a same-session self-check rationalises its own
+  draft.
+
+## Step 5 — Move through the lifecycle
 
 The lifecycle is `Draft → Open → Final Comment Period →
 Accepted | Rejected | Withdrawn`. You move the status manually as
@@ -180,7 +216,7 @@ the discussion progresses:
 The skill also updates `docs/rfc/README.md` so the new file shows up
 in the index.
 
-## Step 5 — After acceptance
+## Step 6 — After acceptance
 
 An accepted RFC is rarely the last artifact. It points at concrete
 follow-on work, which lives in `docs/specs/<feature>/`, `docs/adr/`,
@@ -205,20 +241,33 @@ history.
 > makes the RFC worth reading. Let the research phase emit, sign off,
 > *then* let the body fill.
 
-> **Empty `Prior art` when web search was available.** "We didn't
-> look" isn't an answer — the external sweep is exactly what
+> **Empty `Evidence & prior art` when web search was available.** "We
+> didn't look" isn't an answer — the external sweep is exactly what
 > distinguishes an RFC from a wishlist. If the sweep genuinely
 > returned nothing, say so explicitly under the heading and link the
 > queries you ran.
 
-> **Bare unresolved questions with no author lean.** Every entry in
-> `Unresolved questions` should carry your lean from the research
-> phase, even if it's "punt to reviewers." Reviewers reading bare
-> questions waste a round asking for context the author already had.
+> **An invented, round-number option list.** "Three categories" with no
+> stated axis and no sources means the space wasn't modelled — exactly
+> the failure the per-subpoint research phase exists to prevent. Push
+> the skill to make each `Options considered` enumeration MECE along a
+> stated axis and grounded in prior art.
+
+> **An unverified citation.** A link that loads is not proof — the
+> claim has to actually be in the source. The skill's gate fetches and
+> confirms every reference (and challenges a doubtful one by fetching,
+> not by judging whether the identifier "looks real"); don't wave a
+> citation through on plausibility.
+
+> **Bare open questions with no recommended default.** Every entry in
+> `Open questions` should carry a recommended default + owner +
+> decide-by, even if the default is "punt to reviewers." Reviewers
+> reading bare questions waste a round asking for context the author
+> already had.
 
 > **Treating an RFC as a venue to relitigate an accepted ADR
 > without naming it.** If you're proposing a reversal, cite the ADR
-> in `Related:` and address its reasoning directly in `Motivation`.
+> in `Related:` and address its reasoning directly in `Problem & goals`.
 > The skill's repo-sweep will surface the ADR anyway; engaging with
 > it up-front saves a review round.
 

--- a/packs/governance-extras/.apm/skills/new-rfc/SKILL.md
+++ b/packs/governance-extras/.apm/skills/new-rfc/SKILL.md
@@ -5,11 +5,13 @@ description: Use this skill when the user asks to propose, draft, or open an RFC
 
 # Skill: new-rfc
 
-Open a new RFC in `docs/rfc/` from the template — with a research phase
-before drafting, so reviewers don't get handed bare unresolved questions
-the author hadn't yet looked into. Modeled on `new-spec`'s assumption
-checkpoint, plus a per-question recommendation pass that RFCs need and
-specs don't.
+Open a new RFC in `docs/rfc/` from the template — **answer-first** (lead with
+"The ask"), with a per-subpoint research-and-de-risk phase before drafting and
+a mandatory self-review gate before handoff. The point: a reviewer gets a
+steerable proposal with the decision on top and its options modelled out and
+backed by research — not a pile of un-researched questions to rescue. Modeled
+on `new-spec`'s assumption checkpoint, plus the per-decision recommendation
+pass RFCs need and specs don't.
 
 ## When to invoke
 
@@ -43,36 +45,58 @@ push back: a normal PR (or a spec, if it's a feature) is enough.
    `assets/` folder lives next to this `SKILL.md` wherever your IDE
    installed the skill.)
 
-3. **Research phase — gated checkpoint.** With the file scaffolded, stop.
-   Don't write a single body sentence yet. The point of an RFC is to weigh
-   a proposal against what's already been tried; bare unresolved questions
-   handed to reviewers are research the author should have done first.
+3. **Research + de-risk checkpoint — gated.** With the file scaffolded, stop.
+   Don't write a single body sentence yet. A complex RFC is a tree, not one
+   blob: research the *subpoints*, model the options out, and de-risk your own
+   riskiest assumption before handing anything to a reviewer. A single shallow
+   up-front sweep is the failure this replaces.
 
-   Emit the findings *in chat* (not into the RFC file — the body is gated
-   below) under the structure shown. Two sweeps and a synthesis pass:
+   Work the proposal as decisions/subpoints, emitting findings *in chat* (not
+   into the gated body):
 
-   - **Repo sweep.** Grep `docs/CHARTER.md`, `docs/CONVENTIONS.md`,
-     `docs/adr/`, `docs/rfc/`, `docs/specs/`, and `docs/architecture/`
-     for precedent and conflicts — prior decisions the proposal touches,
-     related specs, conventions the proposal would alter. Cite each hit
-     with file path.
-   - **External sweep.** If web search is available (`WebSearch` in
-     Claude Code; the equivalent in other harnesses), look up how
-     comparable projects, languages, or processes have handled this shape
-     of problem (Rust RFCs, PEPs, IETF BCPs, internal RFCs from similar
-     orgs — whatever maps). Cite each source as a markdown link. If web
-     search isn't available, skip this sweep and say so explicitly under
-     the heading rather than producing fabricated citations.
-   - **Recommendations on unresolved questions.** For every question the
-     user's intent raises (from the conversation that triggered this
-     skill — the RFC body is still empty at this stage), surface: the
-     question, what repo precedent suggests, what external prior art
-     suggests, and a recommended answer with one-sentence reasoning.
+   - **Decompose first.** Break the proposal into its decisions/subpoints. The
+     research unit is the subpoint, not the whole RFC.
+   - **Research each subpoint independently:**
+     - *Repo sweep.* Grep `docs/CHARTER.md`, `docs/CONVENTIONS.md`,
+       `docs/adr/`, `docs/rfc/`, `docs/specs/`, and `docs/architecture/` for
+       precedent and conflicts the subpoint touches. Cite each hit with file
+       path.
+     - *External sweep.* If web search is available (`WebSearch` in Claude
+       Code; the equivalent elsewhere), look up how comparable projects,
+       languages, or processes handled this shape of problem (Rust RFCs, PEPs,
+       IETF BCPs, internal RFCs from similar orgs). Cite each as a markdown
+       link. If web search isn't available, say so explicitly rather than
+       fabricating citations.
+   - **Enumerate each option/scenario space to be collectively exhaustive
+     (MECE) along a stated axis**, and **ground every option in prior art**
+     (how have others taxonomised this?) rather than inventing categories. A
+     small round count (e.g. exactly 3) with no exhaustiveness argument or
+     sources is a smell to challenge, not a finish line. Always include
+     do-nothing.
+   - **Self-Ask.** Resolve research-answerable questions yourself and fold the
+     answers into the findings — they should not reach the human as open
+     questions.
+   - **Spike the riskiest assumption.** Identify the one assumption that, if
+     false, sinks the proposal; run a small/timeboxed check and report the
+     result — or state explicitly why no spike is needed. Do your own
+     experimentation; don't hand the reviewer an untested guess.
+   - **Cite as you go.** When a sweep (or a research subagent) surfaces a
+     source, fetch it and confirm it resolves *and* contains the borrowed
+     claim before that claim enters the findings. Never pass an unverified
+     citation through.
+   - **Recommend per decision.** For each decision/subpoint: the question,
+     what repo precedent suggests, what external prior art suggests, and a
+     recommended answer with one-sentence reasoning + owner + decide-by. Cap
+     genuinely-open questions at ~3.
 
-   Emit the findings under exactly these three headings:
+   Emit the findings under exactly these headings:
 
    ```
    RESEARCH FINDINGS:
+
+   ## Decisions / subpoints
+   1. **<subpoint>** — options (MECE along <axis>, prior-art-grounded): …
+      · recommendation: … · owner: … · decide-by: …
 
    ## Prior art (in repo)
    - …
@@ -80,41 +104,66 @@ push back: a normal PR (or a spec, if it's a feature) is enough.
    ## Prior art (external)
    - …
 
-   ## Recommendations on unresolved questions
-   1. **Question.** …
-      - Repo precedent: …
-      - External prior art: …
-      - Recommendation: …
+   ## De-risk
+   - Riskiest assumption: … · spike result (or why none needed): …
    ```
 
    Then **wait for human confirmation, rejection, or revision per
-   recommendation.** Do not write into *any* body section until the user
-   has signed off. The scaffolded headers can stay; the bodies are gated.
-   Recommendations the user accepts fold into the body; ones the user
-   rejects without an alternative, or genuinely defers, stay in
-   `Unresolved questions` — with the author's lean noted. Treat
-   unanswered recommendations as deferred (same destination, lean kept).
+   recommendation.** Do not write into *any* body section until the user has
+   signed off. Accepted recommendations fold into the body; ones rejected
+   without an alternative, or genuinely deferred, stay in `Open questions` —
+   with a recommended default + owner + decide-by, never bare.
 
-4. Draft the body, now informed by the research. Route the findings:
-   repo precedent lands as citations in `Motivation`; external precedent
-   lands in `Prior art`. (The chat block split the two for legibility;
-   the body has a single `Prior art` section.) Sections to push hardest
-   on:
-   - **Motivation.** Cite repo precedent where it argues for or against
-     the proposal.
-   - **Alternatives considered.** Including "do nothing." If the user
-     can't articulate any, the proposal isn't yet honest.
-   - **Prior art.** Land the external-sweep citations here. Empty prior
-     art is a finding (no one has done anything like this) — surface
-     that explicitly rather than leaving the section blank.
-   - **Drawbacks.** If they say "none", push back. There are always
-     drawbacks.
-   - **Unresolved questions.** Each carries the author's lean from the
-     research phase, even if the lean is "punt to reviewers."
+4. **Draft the body, answer-first.** Lead with **The ask**; then route the
+   findings: repo precedent → `Problem & goals` / `Evidence & prior art`;
+   external precedent and the spike result → `Evidence & prior art`. Sections
+   to push hardest on:
+   - **The ask.** The decision a reviewer must make, in plain language, on
+     top — Recommendation (BLUF) + SCQA framing + numbered decisions, each
+     with a recommended option + decide-by.
+   - **Problem & goals.** Diagnosis before solution; real **Non-goals**
+     (could-have-been-goals deliberately dropped), not negated goals.
+   - **Options considered.** MECE along a stated axis, each grounded in prior
+     art, including do-nothing. If you can't articulate ≥2 genuinely distinct
+     options, the proposal isn't honest yet.
+   - **Risks & what would make this wrong.** Pre-mortem + falsifiable
+     assumptions + drawbacks. If they say "no drawbacks", push back.
+   - **Evidence & prior art.** Empty prior art is a finding (no one has done
+     this) — surface it; never leave it blank or fabricated.
+   - **Open questions.** Each carries a recommended default + owner +
+     decide-by; aim for ≤3.
+   - **Experiment / validation** (optional). Only if the proposal needs an
+     experiment: hypothesis + what you measure + success/failure criteria.
+     Route *results* to a linked spike note, not the RFC body. Delete the
+     section otherwise.
 
-5. Set status to `Draft` until the user is ready to circulate, then `Open`.
+5. **Pre-handoff gate — mandatory, before status → Open.** Each item is
+   *executed and its result recorded, never self-certified*:
+   - **Citation-integrity protocol.** Every reference is fetched; it must both
+     resolve and actually contain the claim or statistic it is cited for (a
+     link that merely loads is not enough). Citations surfaced by a research
+     subagent get the same treatment. If a claim can't be confirmed, downgrade
+     or drop it. The rule is symmetric: *challenge* a citation by fetching it
+     too — never by judging whether an identifier "looks real".
+   - **Verify-before-you-assert.** Every checkable claim the RFC makes about
+     *itself* (section/field counts, "lighter", "readable") is checked against
+     the artifact, not asserted.
+   - **Per-subpoint backing.** Each decision/subpoint is independently backed
+     by research; each enumeration is MECE along a stated axis and prior-art-
+     grounded, not invented.
+   - **Completeness checklist (YES/NO).** Approver named? every decision
+     carries a recommendation? do-nothing present? ≤3 owned open questions? no
+     item is simultaneously a decided default *and* an open question? all
+     internal cross-references resolve?
+   - **Different-lens review.** Dispatch a subagent matching
+     `adversarial-reviewer` (fresh context) — **mandatory**, re-run until it
+     reports clean; add `security-reviewer` if the RFC touches a security
+     boundary. If no such subagent is installed, note it in the summary
+     rather than skipping silently.
 
-6. Update `docs/rfc/README.md` table (create the file with the standard
+6. Set status to `Draft` until the user is ready to circulate, then `Open`.
+
+7. Update `docs/rfc/README.md` table (create the file with the standard
    header row if absent).
 
 ## After acceptance
@@ -131,11 +180,22 @@ The RFC itself is then "done" and stays as historical record.
 ## Anti-patterns to refuse
 
 - Writing into the RFC body before the checkpoint clears → see step 3.
-- Bare unresolved questions with no author lean → if the question
-  hasn't been searched against repo + external prior art, the research
-  phase wasn't done. Send it back.
-- Empty `Prior art` while web search was available and comparable
-  processes plainly exist → the external sweep produces this section;
-  "we didn't look" isn't an answer. When web search *wasn't*
-  available, the section can be empty — but say so explicitly under
-  the heading and never fabricate citations to fill it.
+- A single shallow up-front sweep standing in for per-subpoint research on a
+  multi-decision RFC → decompose and back each subpoint.
+- Enumerating an option/scenario space by inventing a small round number of
+  categories (e.g. exactly 3) with no exhaustiveness argument or prior-art
+  grounding → make it MECE along a stated axis, and source it.
+- Bare open questions with no recommended default + owner → if the question
+  hasn't been searched against repo + external prior art, the research phase
+  wasn't done. Send it back.
+- Passing any citation — especially one surfaced by a subagent — into the
+  draft without fetching the source and confirming the borrowed claim is in
+  it (a link that resolves is not enough; this is the single most-documented
+  LLM-drafting failure). Challenge a citation the same way — by fetching —
+  never by judging whether an identifier "looks real".
+- Asserting any self-claim or a "gate passed" status without having run the
+  check.
+- Empty `Evidence & prior art` while web search was available and comparable
+  processes plainly exist → "we didn't look" isn't an answer. When web search
+  *wasn't* available, say so explicitly under the heading and never fabricate
+  citations to fill it.

--- a/packs/governance-extras/.apm/skills/new-rfc/assets/rfc.md
+++ b/packs/governance-extras/.apm/skills/new-rfc/assets/rfc.md
@@ -2,87 +2,117 @@
 
 - **Status:** Draft <!-- Draft | Open | Final Comment Period | Accepted | Rejected | Withdrawn -->
 - **Author:** <github-handle>
+- **Approver:** <github-handle who signs off — the one person whose yes starts implementation>
 - **Date opened:** YYYY-MM-DD
 - **Date closed:** <!-- filled in when status reaches a terminal state -->
 - **Related:** <!-- ADRs, specs, prior RFCs -->
 
-## Summary
+## The ask
 
 <!--
-One paragraph. What are you proposing? After reading this section a reviewer
-should know whether they care.
+Answer-first. After this section a reviewer should know exactly what they are
+being asked to approve, in plain language, without hunting through the design.
+
+- **Recommendation (BLUF):** one or two sentences — what to approve.
+- **Why now (SCQA):** Situation (agreed context) → Complication (what changed /
+  the problem) → the Question it raises. Three or four lines.
+- **Decisions requested:** numbered. Each = the question · the recommended
+  option · a one-line why · decide-by (and the default if no objection).
+
+Right-size to the stakes: a small, reversible change keeps this short and
+collapses the sections below to one-liners.
 -->
 
-## Motivation
+## Problem & goals
 
 <!--
-Why are we doing this? What's broken, missing, or about to become a problem?
+Diagnosis before any solution — name the problem first; if you can't, you have
+a wishlist, not a proposal. Then:
 
-Show the cost of inaction. "It would be nice to..." is not a motivation; "we
-spend ~3 hours a week working around X" is.
+- **Goals.**
+- **Non-goals** — things that could reasonably have been goals but you are
+  deliberately choosing not to pursue. Negated goals ("won't crash") don't
+  count; this section is where scoping work shows.
 -->
 
 ## Proposal
 
 <!--
-What specifically are you proposing? Be concrete enough that a reviewer can
-disagree with the substance, not just the framing.
-
-This section is where the design lives. Include:
-- The new shape of things (interfaces, file layout, processes — whatever
-  applies).
-- Migration path, if there's existing state to convert.
-- How users / contributors will interact with the change.
+The design. Concrete enough that a reviewer can disagree with the substance,
+not just the framing. Cascade the detail under each requested decision.
+Include the migration path if there's existing state to convert.
 -->
 
-## Alternatives considered
+## Options considered
 
 <!--
-What else did you look at? This section is mandatory — proposals without
-alternatives signal that the author hasn't yet thought hard enough.
+This section is mandatory and load-bearing.
 
-Include the "do nothing" option. Sometimes it wins.
+- Enumerate the option/scenario space to be **collectively exhaustive (MECE)
+  along a stated axis** — say what the axis is and why these options exhaust
+  it. A small round count (e.g. exactly 3) with no exhaustiveness argument is
+  a smell, not a finish line.
+- **Ground each option in prior art** (how have others solved this shape of
+  problem?) rather than inventing categories.
+- Include the **do-nothing** option and its cost of delay. Sometimes it wins.
+- State each option's trade-offs up front, against the goals — not retrofitted
+  after the choice. A starred/recommended-option table is encouraged.
 -->
 
-## Drawbacks
+## Risks & what would make this wrong
 
 <!--
-What's the cost of accepting this proposal? What might go wrong? What are we
-giving up?
-
-If you can't think of any drawbacks, the proposal isn't yet honest.
+- **Pre-mortem:** assume this shipped and failed — list the top failure modes
+  and their mitigations.
+- **Key assumptions (falsifiable):** phrase each so a reviewer can point at one
+  and say "that's wrong, because…".
+- **Drawbacks:** what it costs, what you're giving up. "None" is not an
+  answer — push back on yourself.
 -->
 
-## Prior art
+## Evidence & prior art
 
 <!--
-What other projects, languages, or processes have tackled the same shape of
-problem? What worked, what didn't, what should we learn?
-
-Land prior-art citations here — both from this repo (related ADRs, RFCs,
-specs) and from external precedent. "We considered X and it's a poor fit
-because Y" beats unsourced assertion.
-
-Empty prior art is itself a signal — no one has tried this — but call it
-out rather than leaving the section blank.
+- **Spike / de-risk result.** Identify the assumption that, if false, sinks the
+  proposal; run a small/timeboxed check and report the result here — or state
+  why no spike was needed. Do your own experimentation; don't hand the reviewer
+  an untested guess.
+- **Repo precedent.** Related ADRs, RFCs, specs the proposal touches.
+- **External prior art.** What other projects/processes did with this shape of
+  problem. Every citation must be fetched and confirmed to contain the claim it
+  supports — a link that merely loads is not enough. Empty prior art is itself
+  a finding (no one has tried this) — say so rather than leaving it blank, and
+  never fabricate.
 -->
 
-## Unresolved questions
+## Experiment / validation
 
 <!--
-What did you punt on? What are you hoping reviewers will weigh in on? Listing
-these explicitly focuses the discussion.
+OPTIONAL — delete this section unless the proposal genuinely needs an
+experiment. Frame the experiment here; do NOT paste raw results into the RFC
+(that bloats the proposal into a lab notebook).
 
-Each question should carry the author's lean — even if the lean is "punt to
-reviewers." A bare question with no author position means the homework
-wasn't done.
+- **Hypothesis.**
+- **What we measure.**
+- **Success / failure criteria.**
+
+Capture the results in a separate, linked spike note (or a follow-up RFC / a
+superseding ADR), and keep the RFC in Draft/Open while they're pending.
+-->
+
+## Open questions
+
+<!--
+Aim for ≤3. Each carries a **recommended default + owner + decide-by** — never
+a bare question. Anything you could resolve by research must already be
+answered in the body, not parked here; a bare question means the research
+phase wasn't done.
 -->
 
 ## Follow-on artifacts
 
 <!--
-Filled in when the RFC is accepted. What ADRs, specs, or convention changes
-will this produce? This is the bridge from "we agreed" to "we did it".
+Filled in when the RFC is accepted. The bridge from "we agreed" to "we did it".
 
 - ADR-NNNN: <title>
 - Spec: docs/specs/<feature>/


### PR DESCRIPTION
## What

Implements the accepted [RFC-0014](../blob/main/docs/rfc/0014-answer-first-rfc-format-and-drafting-flow.md) follow-on in the `new-rfc` skill (governance-extras pack).

- **Template** (`assets/rfc.md`): answer-first spine — "The ask" (BLUF + SCQA + numbered decisions, each with a recommended option + decide-by) on top, an `Approver` header field, explicit **Non-goals**, `Options considered` (MECE along a stated axis, prior-art-grounded, do-nothing + cost of delay), `Risks & what would make this wrong` (pre-mortem + falsifiable assumptions), `Evidence & prior art`, an *optional* `Experiment / validation` section, and capped/owned `Open questions`.
- **Flow** (`SKILL.md`): decompose into subpoints → research each independently → enumerate options MECE/prior-art-grounded → Self-Ask → spike the riskiest assumption → cite-as-you-go (fetch + confirm the claim is in the source) → recommend; plus a **mandatory** pre-handoff gate (citation-integrity, verify-before-you-assert, per-subpoint backing, completeness checklist, mandatory `adversarial-reviewer`). Anti-patterns updated.
- **How-to guide** (`docs/guides/how-to/new-rfc.md`): rewritten against the new spine + flow (Steps 2–4 + Pitfalls). Manual/instance content, excluded from projection.
- Projected `.claude/skills/new-rfc/*` via `make build-self`.

## Why

RFC-0014 was accepted (PR #176) as the decision record; this wires its template + flow into the running skill so future RFCs are drafted answer-first, research their subpoints, and self-review before reaching a human.

## How verified

- Gates: `make lint-packs`, `tools/lint-agent-artifacts.py`, and `tools/hooks/pre-pr.py` all pass.
- `.claude/skills/new-rfc/*` confirmed byte-identical to the pack source (projection parity).
- `adversarial-reviewer`: clean (contract fidelity, parity, no guide drift, no scope creep).
- `security-reviewer` / `quality-engineer`: not warranted — documentation/skill prose, no code/test/observability or security-boundary surface.

## Deferred

- Optional `Experimental` RFC status (RFC-0014 decision 3) — adding it requires a `docs/CONVENTIONS.md` lifecycle edit outside this follow-on's file list; landing it there avoids template-vs-CONVENTIONS drift. The optional Experiment *section* ships in this PR.