### PR TITLE
feat(new-rfc): support optional Experimental RFC status (RFC-0014 follow-on)

### DIFF
--- a/.claude/skills/new-rfc/SKILL.md
+++ b/.claude/skills/new-rfc/SKILL.md
@@ -134,8 +134,10 @@ push back: a normal PR (or a spec, if it's a feature) is enough.
      decide-by; aim for ≤3.
    - **Experiment / validation** (optional). Only if the proposal needs an
      experiment: hypothesis + what you measure + success/failure criteria.
-     Route *results* to a linked spike note, not the RFC body. Delete the
-     section otherwise.
+     Route *results* to a linked spike note, not the RFC body; once the RFC
+     is circulating and the trial is actually running, it moves to
+     `Experimental` while results are pending (a post-circulation state — see
+     `docs/CONVENTIONS.md` § RFC lifecycle). Delete the section otherwise.
 
 5. **Pre-handoff gate — mandatory, before status → Open.** Each item is
    *executed and its result recorded, never self-certified*:

--- a/.claude/skills/new-rfc/assets/rfc.md
+++ b/.claude/skills/new-rfc/assets/rfc.md
@@ -1,6 +1,6 @@
 # RFC-NNNN: <proposal title>
 
-- **Status:** Draft <!-- Draft | Open | Final Comment Period | Accepted | Rejected | Withdrawn -->
+- **Status:** Draft <!-- Draft | Open | Final Comment Period | Accepted | Rejected | Withdrawn | Experimental (optional: trial running, results pending — see the Experiment / validation section) -->
 - **Author:** <github-handle>
 - **Approver:** <github-handle who signs off — the one person whose yes starts implementation>
 - **Date opened:** YYYY-MM-DD
@@ -97,7 +97,9 @@ experiment. Frame the experiment here; do NOT paste raw results into the RFC
 - **Success / failure criteria.**
 
 Capture the results in a separate, linked spike note (or a follow-up RFC / a
-superseding ADR), and keep the RFC in Draft/Open while they're pending.
+superseding ADR), and mark the RFC `Experimental` while they're pending (see
+docs/CONVENTIONS.md § RFC lifecycle); move it to a terminal status once they
+land.
 -->
 
 ## Open questions

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -173,6 +173,15 @@ are *forward-looking governance*; ADRs are *backward-looking record*.
 Draft → Open → Final Comment Period → Accepted | Rejected | Withdrawn
 ```
 
+**Optional `Experimental` status.** An RFC that proposes running an
+experiment — using the optional `Experiment / validation` section of the
+`new-rfc` template — may sit in `Experimental` while the trial runs and
+results are pending, instead of being forced to a premature Accept or Reject.
+Results live in a linked spike note (or a follow-up RFC / superseding ADR),
+not the RFC body; when they land, the RFC moves to `Accepted | Rejected |
+Withdrawn`. An `Experimental` RFC is still in-flight (Governance class, not
+Frozen). Use it only when an experiment is genuinely running.
+
 Once an RFC is **Accepted**, it produces follow-on artifacts:
 
 - Architectural decisions → one or more ADRs

--- a/docs/guides/how-to/new-rfc.md
+++ b/docs/guides/how-to/new-rfc.md
@@ -22,7 +22,7 @@ twice.
 | Question | RFC | ADR |
 | --- | --- | --- |
 | Tense | Forward-looking ("should we change X?") | Backward-facing ("we chose X over Y") |
-| Lifecycle | `Draft` → `Open` → `Final Comment Period` → `Accepted` \| `Rejected` \| `Withdrawn` | `Proposed` → `Accepted` → (`Deprecated` \| `Superseded by ADR-NNNN`) |
+| Lifecycle | `Draft` → `Open` → `Final Comment Period` → `Accepted` \| `Rejected` \| `Withdrawn` (optional `Experimental` while a trial runs) | `Proposed` → `Accepted` → (`Deprecated` \| `Superseded by ADR-NNNN`) |
 | Body after acceptance | Frozen at acceptance (status field can change later, body cannot); stays as historical record; produces follow-on ADRs, specs, or CONVENTIONS edits | Frozen at acceptance (status field can change later, body cannot) |
 | Reject path | `Rejected` is a normal terminal state — the discussion was the point | A pre-acceptance ADR that doesn't earn `Accepted` just isn't committed; there's no `Rejected` state |
 | Trigger | The decision is still being debated, or affects external users | The decision is made (or is being formally proposed) and has a concrete tradeoff |
@@ -173,7 +173,8 @@ then cascading detail:
 - **Experiment / validation** (optional). Present only if the proposal
   needs an experiment — hypothesis, what's measured, success/failure
   criteria — with the *results* linked out to a spike note, not pasted
-  into the RFC.
+  into the RFC. Once circulating, while the trial runs the RFC sits in
+  `Experimental` (see Step 5).
 
 The file lands at `docs/rfc/NNNN-<kebab-title>.md` with status `Draft` and
 an `Approver` named in the frontmatter.
@@ -208,6 +209,11 @@ the discussion progresses:
 - **`Open`** — ready for reviewers. Update the frontmatter and push.
 - **`Final Comment Period`** — discussion is winding down; last call
   for objections.
+- **`Experimental`** (optional) — the proposal includes an
+  `Experiment / validation` section and the trial is running; the RFC
+  sits here, results pending in a linked spike note, until they land and
+  it moves to a terminal status. Use only when an experiment is genuinely
+  in flight.
 - **`Accepted`** | **`Rejected`** | **`Withdrawn`** — terminal. Fill in
   `Date closed:`. The RFC freezes here (see [`CONVENTIONS.md` § Document
   lifecycle](../../CONVENTIONS.md#document-lifecycle)) — status field

--- a/packs/core/seeds/docs/CONVENTIONS.md
+++ b/packs/core/seeds/docs/CONVENTIONS.md
@@ -173,6 +173,15 @@ are *forward-looking governance*; ADRs are *backward-looking record*.
 Draft → Open → Final Comment Period → Accepted | Rejected | Withdrawn
 ```
 
+**Optional `Experimental` status.** An RFC that proposes running an
+experiment — using the optional `Experiment / validation` section of the
+`new-rfc` template — may sit in `Experimental` while the trial runs and
+results are pending, instead of being forced to a premature Accept or Reject.
+Results live in a linked spike note (or a follow-up RFC / superseding ADR),
+not the RFC body; when they land, the RFC moves to `Accepted | Rejected |
+Withdrawn`. An `Experimental` RFC is still in-flight (Governance class, not
+Frozen). Use it only when an experiment is genuinely running.
+
 Once an RFC is **Accepted**, it produces follow-on artifacts:
 
 - Architectural decisions → one or more ADRs

--- a/packs/governance-extras/.apm/skills/new-rfc/SKILL.md
+++ b/packs/governance-extras/.apm/skills/new-rfc/SKILL.md
@@ -134,8 +134,10 @@ push back: a normal PR (or a spec, if it's a feature) is enough.
      decide-by; aim for ≤3.
    - **Experiment / validation** (optional). Only if the proposal needs an
      experiment: hypothesis + what you measure + success/failure criteria.
-     Route *results* to a linked spike note, not the RFC body. Delete the
-     section otherwise.
+     Route *results* to a linked spike note, not the RFC body; once the RFC
+     is circulating and the trial is actually running, it moves to
+     `Experimental` while results are pending (a post-circulation state — see
+     `docs/CONVENTIONS.md` § RFC lifecycle). Delete the section otherwise.
 
 5. **Pre-handoff gate — mandatory, before status → Open.** Each item is
    *executed and its result recorded, never self-certified*:

--- a/packs/governance-extras/.apm/skills/new-rfc/assets/rfc.md
+++ b/packs/governance-extras/.apm/skills/new-rfc/assets/rfc.md
@@ -1,6 +1,6 @@
 # RFC-NNNN: <proposal title>
 
-- **Status:** Draft <!-- Draft | Open | Final Comment Period | Accepted | Rejected | Withdrawn -->
+- **Status:** Draft <!-- Draft | Open | Final Comment Period | Accepted | Rejected | Withdrawn | Experimental (optional: trial running, results pending — see the Experiment / validation section) -->
 - **Author:** <github-handle>
 - **Approver:** <github-handle who signs off — the one person whose yes starts implementation>
 - **Date opened:** YYYY-MM-DD
@@ -97,7 +97,9 @@ experiment. Frame the experiment here; do NOT paste raw results into the RFC
 - **Success / failure criteria.**
 
 Capture the results in a separate, linked spike note (or a follow-up RFC / a
-superseding ADR), and keep the RFC in Draft/Open while they're pending.
+superseding ADR), and mark the RFC `Experimental` while they're pending (see
+docs/CONVENTIONS.md § RFC lifecycle); move it to a terminal status once they
+land.
 -->
 
 ## Open questions


### PR DESCRIPTION
## What

Implements the deferred half of [RFC-0014](../blob/main/docs/rfc/0014-answer-first-rfc-format-and-drafting-flow.md) decision 3: an optional **`Experimental`** RFC status, for proposals that run a trial before a terminal decision.

- **`docs/CONVENTIONS.md`** (via `packs/core` seed) — § RFC lifecycle gains an "Optional `Experimental` status" paragraph: an RFC with an `Experiment / validation` section may sit in `Experimental` while the trial runs and results are pending (results in a linked spike note, not the body), then moves to `Accepted | Rejected | Withdrawn`. It is in-flight (Governance class, not Frozen).
- **`new-rfc` template** — `Experimental` added to the Status enum; the Experiment section points at the lifecycle.
- **`new-rfc` SKILL.md** — the Experiment step moves the RFC to `Experimental` *post-circulation, while the trial runs* (not at draft time).
- **How-to guide** — lifecycle table + Step 5 + Step 3 updated, with consistent "while the trial runs" timing.
- Projected `.claude/*` and `docs/CONVENTIONS.md` via `make build-self`.

## Why

RFC-0014 decision 3 authorized both the Experiment *section* (shipped in #177) and the `Experimental` *status*. The status was deferred from #177 because it needs this CONVENTIONS lifecycle edit; landing it here keeps template/skill/guide and CONVENTIONS in sync (no drift). This is implementation of an accepted decision, not a new proposal.

## How verified

- Gates: `make lint-packs`, `tools/hooks/pre-pr.py` (incl. seeds lint + agent-artifact lint + projection-drift) all pass. The seeds lint correctly forced the CONVENTIONS seed to stay free of catalogue-RFC references.
- `.claude/*` byte-identical to pack source; `docs/CONVENTIONS.md` consistent with its seed.
- `adversarial-reviewer`: clean after fixing two timing-consistency concerns (the status now uniformly described as a post-circulation, trial-running state across CONVENTIONS, template, skill, and guide).
- `security-reviewer` / `quality-engineer`: not warranted (governance/skill prose).