### PR TITLE
fix(new-spec): make shipped plan template adopter-clean

### DIFF
--- a/.claude/skills/new-spec/assets/plan.md
+++ b/.claude/skills/new-spec/assets/plan.md
@@ -64,18 +64,18 @@ with separate commits when the change is non-trivial.
 or `none`. Don't omit the field; "obvious from order" is the failure mode
 that hides serial-by-default thinking. `none` is a valid and common answer.
 
-**`Depends on:` grammar** (so the supervisor-mode scheduler can read it —
-RFC-0015 / `loop-cohort schedule`). The field is a comma-separated list of:
+**`Depends on:` grammar** (so the supervisor-mode scheduler —
+`loop-cohort schedule` — can read it). The field is a comma-separated list of:
 local task IDs (`T1`, `T1a`), ranges (`T1-T6`), or a **cross-spec marker**
 `spec:<name>/TN` for a dependency on another spec's task (e.g.
-`spec:distribution-adapters/T7`). Parenthetical prose after the IDs is
+`spec:auth-tokens/T7`). Parenthetical prose after the IDs is
 ignored, so `T11 (lands after the shim)` is fine. Cross-spec deps are
 *spec-sequencing*, not intra-plan waves, and are excluded from this plan's
 DAG. The scheduler **fails on a dependency cycle** and **warns on a
 forward-reference** (a dep authored later — it still schedules correctly by
-running the dep first); `tools/lint-plan-deps.py` enforces this.
+running the dep first).
 
-**Optional `Touches:` grammar** (RFC-0015 follow-on 3 / `loop-cohort schedule`).
+**Optional `Touches:` grammar** (read by `loop-cohort schedule`).
 A task *may* add a `**Touches:**` line listing the file globs it expects to
 touch — a comma-separated list of paths/globs (`src/api/*.py, docs/api.md`),
 trailing prose ignored. `loop-cohort schedule` uses it to predict, per wave,

--- a/packs/core/.apm/skills/new-spec/assets/plan.md
+++ b/packs/core/.apm/skills/new-spec/assets/plan.md
@@ -64,18 +64,18 @@ with separate commits when the change is non-trivial.
 or `none`. Don't omit the field; "obvious from order" is the failure mode
 that hides serial-by-default thinking. `none` is a valid and common answer.
 
-**`Depends on:` grammar** (so the supervisor-mode scheduler can read it —
-RFC-0015 / `loop-cohort schedule`). The field is a comma-separated list of:
+**`Depends on:` grammar** (so the supervisor-mode scheduler —
+`loop-cohort schedule` — can read it). The field is a comma-separated list of:
 local task IDs (`T1`, `T1a`), ranges (`T1-T6`), or a **cross-spec marker**
 `spec:<name>/TN` for a dependency on another spec's task (e.g.
-`spec:distribution-adapters/T7`). Parenthetical prose after the IDs is
+`spec:auth-tokens/T7`). Parenthetical prose after the IDs is
 ignored, so `T11 (lands after the shim)` is fine. Cross-spec deps are
 *spec-sequencing*, not intra-plan waves, and are excluded from this plan's
 DAG. The scheduler **fails on a dependency cycle** and **warns on a
 forward-reference** (a dep authored later — it still schedules correctly by
-running the dep first); `tools/lint-plan-deps.py` enforces this.
+running the dep first).
 
-**Optional `Touches:` grammar** (RFC-0015 follow-on 3 / `loop-cohort schedule`).
+**Optional `Touches:` grammar** (read by `loop-cohort schedule`).
 A task *may* add a `**Touches:**` line listing the file globs it expects to
 touch — a comma-separated list of paths/globs (`src/api/*.py, docs/api.md`),
 trailing prose ignored. `loop-cohort schedule` uses it to predict, per wave,


### PR DESCRIPTION
## What

The `new-spec` `plan.md` template ships to adopters via the core pack (projected to `.claude/skills/new-spec/assets/plan.md`), but it referenced four catalogue-internal artifacts adopters never receive:

- **`RFC-0015`** and its **`follow-on 3`** provenance — internal RFCs; adopters have no `docs/rfc/0015-*`.
- **`tools/lint-plan-deps.py`** — a catalogue-internal tool that is not shipped in any pack, and which hardcodes a `packs/core/.apm/...` import path that cannot resolve in an adopter repo even if it were copied there.
- **`spec:distribution-adapters/T7`** — a grammar example naming one of *our own* specs (same defect class).

This is an adopter-clean violation: a shipped primitive pointing at tooling/docs that break on arrival.

## Change

Strip the internal references from the pack source and refresh the projection via `build-self`. Preserved:

- the `Depends on:` / `Touches:` **grammar prose** (the adopter-facing value);
- the **`loop-cohort schedule`** references — that script *does* ship to adopters.

Cycle/forward-ref enforcement was already attributed to "the scheduler" in the same sentence; that scheduler is the shipped `loop-cohort schedule`, which is the adopter-true enforcement surface, so dropping the internal-tool clause loses nothing for adopters.

### Why the lint stays repo-internal

The cycle/forward-ref **detection engine already ships** — `parse_plan` / `detect_cycles` / `detect_forward_refs` live in `loop-cohort.py`, projected as `.claude/skills/work-loop/scripts/loop-cohort.py`, and `loop-cohort schedule` fails on a cycle at dispatch. `lint-plan-deps.py` adds only a *batch sweep* over the whole `docs/specs/*/plan.md` corpus — a catalogue-governance shape, not an adopter-authoring one. So the capability isn't adopter-missing; only a redundant pre-flight wrapper is. It remains a repo-internal manual tool (still referenced legitimately by `docs/specs/supervisor-predict-disjointness/plan.md`).

## Gates

- `make build-self` — clean tree, exactly the source+projection pair updated
- `lint-packs` (source) — pass
- `tools/lint-agent-artifacts.py` (projection) — pass