### PR TITLE
chore(packs): scrub internal catalogue RFC/ADR refs from adopter-facing content

### DIFF
--- a/.agentbundle/bin/credentials_shim.py
+++ b/.agentbundle/bin/credentials_shim.py
@@ -1,8 +1,7 @@
 """Loader API and stdlib ``.env`` parser for credentialed primitives.
 
 This module is the build-pipeline-projected shim that ships alongside
-each ``auth: creds`` consumer skill's ``scripts/`` (per RFC-0013 § 4 +
-credential-broker-contract spec § AC6). The consumer imports
+each ``auth: creds`` consumer skill's ``scripts/``. The consumer imports
 ``from .credentials_shim import …`` against this sibling — there is no
 runtime ``agentbundle`` dependency.
 
@@ -441,7 +440,7 @@ def _ensure_parent(parent: pathlib.Path) -> None:
     """Create the dotfile parent at mode 0o700 if absent (spec § AC15).
 
     If the parent already exists, do **not** rewrite its mode — the
-    directory is shared with ``~/.agentbundle/state.toml`` per RFC-0004.
+    directory is shared with ``~/.agentbundle/state.toml``.
     On POSIX warn on stderr if the existing mode is more permissive
     than 0o755.
     """

--- a/.agentbundle/bin/sso-broker.py
+++ b/.agentbundle/bin/sso-broker.py
@@ -14,8 +14,7 @@ and ``agentbundle:sso:<profile>:<n>`` for continuation slots.
 This script lives at ``~/.agentbundle/bin/sso-broker.py`` and is
 subprocess-invoked from `auth: sso-cookie` consumer skills.
 
-Refs: docs/specs/credential-broker-contract/spec.md (AC9-AC17);
-RFC-0013 § 4b.
+Refs: docs/specs/credential-broker-contract/spec.md (AC9-AC17).
 """
 
 from __future__ import annotations
@@ -52,7 +51,7 @@ if __package__ in (None, "") and __spec__ is None:
 # threshold is applied uniformly for cross-platform determinism.
 CRED_MAX_CREDENTIAL_BLOB_SIZE_BYTES = 2048
 
-# Reserved keychain-target namespace for this broker (AC12 / RFC-0013 § 4b).
+# Reserved keychain-target namespace for this broker (AC12).
 # Every write_credential / read_credential call site constructs target
 # names of shape agentbundle:sso:<profile> (or :<n> for continuation).
 _SSO_NAMESPACE = "agentbundle:sso"
@@ -83,7 +82,7 @@ elif sys.platform == "win32":
             _tier2_backend = None
 
 
-# Argv-borne credential flags refused per RFC-0006 § 4 / argv ban.
+# Argv-borne credential flags refused per the argv ban.
 _ARGV_BAN = frozenset({
     "--token",
     "--api-token",

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -273,7 +273,7 @@ order, single-agent, by default** — on every adapter. `schedule` fails
 loud on a dependency **cycle** and warns on a **forward-reference** (a dep
 authored later — it reorders so the dep runs first), so an ill-formed plan
 is caught here, not run out of order. This is the proven, zero-hazard path;
-its win is correct ordering, not speed. (RFC-0015 / ADR-0005.) If tasks
+its win is correct ordering, not speed. If tasks
 declare optional `Touches:` globs, `schedule` also prints
 `predicted-disjoint: yes|no|unknown` per wave — a **serialize-only screen**
 (a predicted overlap is a reason to keep the wave serial; it **never**
@@ -340,7 +340,7 @@ go to FIX. Don't move past a failing gate by editing the gate.
 > into `pre-pr.py` (a projected hook body that would mis-fire). The catalogue
 > additionally runs it as a fail-closed CI gate via `make build-check`. (Why a
 > skill script and not a `tools/` linter: skill `scripts/` project to every
-> adapter — RFC-0016 § Errata / ADR-0007 corrected the original "linters don't
+> adapter — a later correction to the original "linters don't
 > project" premise.)
 
 ### 4. REVIEW — adversarial self-review

--- a/.claude/skills/work-loop/references/supervisor-mode.md
+++ b/.claude/skills/work-loop/references/supervisor-mode.md
@@ -5,8 +5,7 @@
 **topological order, single-agent, on every adapter** — it does *not*
 auto-fan-out. `schedule` also fails loud on a dependency cycle or a
 forward-reference (a task whose declared dep is authored later), so an
-ill-formed plan is caught at PLAN, not run out of order. (RFC-0015 /
-ADR-0005.)
+ill-formed plan is caught at PLAN, not run out of order.
 
 This file owns the **opt-in parallel-write path** only. It is entered
 deliberately — never automatically — and only for a wave that clears the

--- a/.claude/skills/work-loop/scripts/loop-cohort.py
+++ b/.claude/skills/work-loop/scripts/loop-cohort.py
@@ -138,13 +138,13 @@ def run_git(args: list[str], cwd: Path | None = None) -> subprocess.CompletedPro
     )
 
 
-# ── scheduler (wave-scheduled supervisor mode; RFC-0015 / ADR-0005) ────────
+# ── scheduler (wave-scheduled supervisor mode) ─────────────────────────────
 #
 # Pure functions over a plan's `Depends on:` graph. The supervisor mode runs
-# tasks in topological order *sequentially by default* on every adapter
-# (RFC-0015 decision 1); parallel writes are opt-in and gated (decision 3,
-# `dispatch_decision`). `Depends on:` is made machine-parseable here
-# (decision 4) — prose, ranges, letter-suffixed IDs, and a cross-spec marker.
+# tasks in topological order *sequentially by default* on every adapter;
+# parallel writes are opt-in and gated (`dispatch_decision`). `Depends on:` is
+# made machine-parseable here — prose, ranges, letter-suffixed IDs, and a
+# cross-spec marker.
 
 TASK_HEADING_RE = re.compile(r"^###\s+(T\d+[a-z]?)\b", re.MULTILINE)
 DEPENDS_LINE_RE = re.compile(r"^\*\*Depends on:\*\*\s*(.+)$", re.MULTILINE)
@@ -208,8 +208,8 @@ def parse_plan(text: str):
 # touch. Parsed like `Depends on:` but kept in a SEPARATE accessor so
 # `parse_plan`'s (ordered, deps) signature — and its ~8 callers — stay
 # unchanged. The globs drive a *screen-only* pre-dispatch disjointness
-# prediction in `schedule`; they never greenlight parallel (RFC-0015 / ADR-0005;
-# the post-write `git merge-tree` stays authoritative).
+# prediction in `schedule`; they never greenlight parallel (the post-write
+# `git merge-tree` stays authoritative).
 
 
 def parse_touches(field: str):
@@ -347,7 +347,7 @@ def detect_forward_refs(ordered, deps):
 # post-merge compile) and so are eligible for opt-in parallel writes. Every
 # other category — dynamic-semantic interference, shared mutable state,
 # move/extract-vs-edit, migration ordering, shared fixtures — fails *silent*
-# and stays serial. (RFC-0015 §3 / ADR-0005.)
+# and stays serial.
 SAFE_CATEGORIES = frozenset({"cannot-collide", "typed-group-b", "textual-loud"})
 
 
@@ -356,7 +356,7 @@ def dispatch_decision(categories, *, merge_tree_clean):
 
     Parallel only when **every** task is in a safe category **and** the wave
     is file-disjoint (a clean ``git merge-tree``). Fail closed: any non-safe
-    category, or any merge-tree conflict, serializes. (RFC-0015 decision 3.)
+    category, or any merge-tree conflict, serializes.
     This gates *writes* only; reviewer (read) fan-out is unaffected.
     """
     if not merge_tree_clean:
@@ -398,13 +398,13 @@ def _dispatch_rationale(categories, *, merge_tree_clean, decision, source=None) 
     return msg
 
 
-# ── auto-classification (supervisor-auto-classify; RFC-0015 / ADR-0005) ──────
+# ── auto-classification (supervisor-auto-classify) ───────────────────────────
 # Auto-derive a task's conflict category from its committed branch diff so the
 # supervisor stops hand-feeding `--category`. FAIL-CLOSED: only an all-added,
 # no-danger-path diff is `cannot-collide` (the lone auto-safe label); every
 # other shape gets a named non-safe label that serializes. This establishes
 # file-additive ∧ (with the gate's merge-tree half) file-disjoint — NOT
-# ADR-0005's full disjoint-no-shared-symbol; the cross-branch guard below
+# a full disjoint-no-shared-symbol guarantee; the cross-branch guard below
 # shrinks that residual, and the irreducible string-key/cross-file-symbol case
 # is backstopped by the post-merge test gate, not claimed here.
 _DANGER_PATH_RE = re.compile(
@@ -573,8 +573,8 @@ def cmd_schedule(args: argparse.Namespace) -> int:
 
 
 def cmd_dispatch_decision(args: argparse.Namespace) -> int:
-    """Gate one write wave: print ``parallel`` or ``serial`` (RFC-0015
-    decision 3 / AC5). The wave's conflict categories are **auto-derived** from
+    """Gate one write wave: print ``parallel`` or ``serial``. The wave's
+    conflict categories are **auto-derived** from
     each ``--branch``'s committed diff when ``--category`` is omitted, else the
     explicit ``--category`` list is used verbatim (human override). Combined
     with a mechanical ``git merge-tree`` file-disjointness check; fail closed:

--- a/.claude/skills/work-loop/scripts/test-lint-spec-status.py
+++ b/.claude/skills/work-loop/scripts/test-lint-spec-status.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Self-test for the sibling lint-spec-status.py (RFC-0016 Tier-1 lint).
+"""Self-test for the sibling lint-spec-status.py (the Tier-1 spec-status lint).
 
 Builds fixture spec trees in a tempdir and runs the linter as a
 subprocess against the documented `python <skill>/scripts/lint-spec-status.py

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/credentials_shim.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/credentials_shim.py
@@ -1,8 +1,7 @@
 """Loader API and stdlib ``.env`` parser for credentialed primitives.
 
 This module is the build-pipeline-projected shim that ships alongside
-each ``auth: creds`` consumer skill's ``scripts/`` (per RFC-0013 § 4 +
-credential-broker-contract spec § AC6). The consumer imports
+each ``auth: creds`` consumer skill's ``scripts/``. The consumer imports
 ``from .credentials_shim import …`` against this sibling — there is no
 runtime ``agentbundle`` dependency.
 
@@ -441,7 +440,7 @@ def _ensure_parent(parent: pathlib.Path) -> None:
     """Create the dotfile parent at mode 0o700 if absent (spec § AC15).
 
     If the parent already exists, do **not** rewrite its mode — the
-    directory is shared with ``~/.agentbundle/state.toml`` per RFC-0004.
+    directory is shared with ``~/.agentbundle/state.toml``.
     On POSIX warn on stderr if the existing mode is more permissive
     than 0o755.
     """

--- a/packs/atlassian/.apm/skills/confluence-publisher/scripts/credentials_shim.py
+++ b/packs/atlassian/.apm/skills/confluence-publisher/scripts/credentials_shim.py
@@ -1,8 +1,7 @@
 """Loader API and stdlib ``.env`` parser for credentialed primitives.
 
 This module is the build-pipeline-projected shim that ships alongside
-each ``auth: creds`` consumer skill's ``scripts/`` (per RFC-0013 § 4 +
-credential-broker-contract spec § AC6). The consumer imports
+each ``auth: creds`` consumer skill's ``scripts/``. The consumer imports
 ``from .credentials_shim import …`` against this sibling — there is no
 runtime ``agentbundle`` dependency.
 
@@ -441,7 +440,7 @@ def _ensure_parent(parent: pathlib.Path) -> None:
     """Create the dotfile parent at mode 0o700 if absent (spec § AC15).
 
     If the parent already exists, do **not** rewrite its mode — the
-    directory is shared with ``~/.agentbundle/state.toml`` per RFC-0004.
+    directory is shared with ``~/.agentbundle/state.toml``.
     On POSIX warn on stderr if the existing mode is more permissive
     than 0o755.
     """

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/upstream.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/upstream.py
@@ -146,7 +146,7 @@ def discover_skill_path(name: str, *, env: Optional[Mapping[str, str]] = None, c
     want a specific adapter set the priority-1 env override
     ``FLOW_METRICS_<NAME>_SCRIPT`` to the exact script path; that's the
     documented runtime escape valve. The install-time analogue lives in
-    ``agentbundle install --scope user --adapter <name>`` per RFC-0011.
+    ``agentbundle install --scope user --adapter <name>``.
     """
     e = env if env is not None else os.environ
     base_cwd = cwd if cwd is not None else Path.cwd()

--- a/packs/atlassian/.apm/skills/jira-align/scripts/credentials_shim.py
+++ b/packs/atlassian/.apm/skills/jira-align/scripts/credentials_shim.py
@@ -1,8 +1,7 @@
 """Loader API and stdlib ``.env`` parser for credentialed primitives.
 
 This module is the build-pipeline-projected shim that ships alongside
-each ``auth: creds`` consumer skill's ``scripts/`` (per RFC-0013 § 4 +
-credential-broker-contract spec § AC6). The consumer imports
+each ``auth: creds`` consumer skill's ``scripts/``. The consumer imports
 ``from .credentials_shim import …`` against this sibling — there is no
 runtime ``agentbundle`` dependency.
 
@@ -441,7 +440,7 @@ def _ensure_parent(parent: pathlib.Path) -> None:
     """Create the dotfile parent at mode 0o700 if absent (spec § AC15).
 
     If the parent already exists, do **not** rewrite its mode — the
-    directory is shared with ``~/.agentbundle/state.toml`` per RFC-0004.
+    directory is shared with ``~/.agentbundle/state.toml``.
     On POSIX warn on stderr if the existing mode is more permissive
     than 0o755.
     """

--- a/packs/atlassian/.apm/skills/jira/scripts/credentials_shim.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/credentials_shim.py
@@ -1,8 +1,7 @@
 """Loader API and stdlib ``.env`` parser for credentialed primitives.
 
 This module is the build-pipeline-projected shim that ships alongside
-each ``auth: creds`` consumer skill's ``scripts/`` (per RFC-0013 § 4 +
-credential-broker-contract spec § AC6). The consumer imports
+each ``auth: creds`` consumer skill's ``scripts/``. The consumer imports
 ``from .credentials_shim import …`` against this sibling — there is no
 runtime ``agentbundle`` dependency.
 
@@ -441,7 +440,7 @@ def _ensure_parent(parent: pathlib.Path) -> None:
     """Create the dotfile parent at mode 0o700 if absent (spec § AC15).
 
     If the parent already exists, do **not** rewrite its mode — the
-    directory is shared with ``~/.agentbundle/state.toml`` per RFC-0004.
+    directory is shared with ``~/.agentbundle/state.toml``.
     On POSIX warn on stderr if the existing mode is more permissive
     than 0o755.
     """

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -273,7 +273,7 @@ order, single-agent, by default** — on every adapter. `schedule` fails
 loud on a dependency **cycle** and warns on a **forward-reference** (a dep
 authored later — it reorders so the dep runs first), so an ill-formed plan
 is caught here, not run out of order. This is the proven, zero-hazard path;
-its win is correct ordering, not speed. (RFC-0015 / ADR-0005.) If tasks
+its win is correct ordering, not speed. If tasks
 declare optional `Touches:` globs, `schedule` also prints
 `predicted-disjoint: yes|no|unknown` per wave — a **serialize-only screen**
 (a predicted overlap is a reason to keep the wave serial; it **never**
@@ -340,7 +340,7 @@ go to FIX. Don't move past a failing gate by editing the gate.
 > into `pre-pr.py` (a projected hook body that would mis-fire). The catalogue
 > additionally runs it as a fail-closed CI gate via `make build-check`. (Why a
 > skill script and not a `tools/` linter: skill `scripts/` project to every
-> adapter — RFC-0016 § Errata / ADR-0007 corrected the original "linters don't
+> adapter — a later correction to the original "linters don't
 > project" premise.)
 
 ### 4. REVIEW — adversarial self-review

--- a/packs/core/.apm/skills/work-loop/references/supervisor-mode.md
+++ b/packs/core/.apm/skills/work-loop/references/supervisor-mode.md
@@ -5,8 +5,7 @@
 **topological order, single-agent, on every adapter** — it does *not*
 auto-fan-out. `schedule` also fails loud on a dependency cycle or a
 forward-reference (a task whose declared dep is authored later), so an
-ill-formed plan is caught at PLAN, not run out of order. (RFC-0015 /
-ADR-0005.)
+ill-formed plan is caught at PLAN, not run out of order.
 
 This file owns the **opt-in parallel-write path** only. It is entered
 deliberately — never automatically — and only for a wave that clears the

--- a/packs/core/.apm/skills/work-loop/scripts/loop-cohort.py
+++ b/packs/core/.apm/skills/work-loop/scripts/loop-cohort.py
@@ -138,13 +138,13 @@ def run_git(args: list[str], cwd: Path | None = None) -> subprocess.CompletedPro
     )
 
 
-# ── scheduler (wave-scheduled supervisor mode; RFC-0015 / ADR-0005) ────────
+# ── scheduler (wave-scheduled supervisor mode) ─────────────────────────────
 #
 # Pure functions over a plan's `Depends on:` graph. The supervisor mode runs
-# tasks in topological order *sequentially by default* on every adapter
-# (RFC-0015 decision 1); parallel writes are opt-in and gated (decision 3,
-# `dispatch_decision`). `Depends on:` is made machine-parseable here
-# (decision 4) — prose, ranges, letter-suffixed IDs, and a cross-spec marker.
+# tasks in topological order *sequentially by default* on every adapter;
+# parallel writes are opt-in and gated (`dispatch_decision`). `Depends on:` is
+# made machine-parseable here — prose, ranges, letter-suffixed IDs, and a
+# cross-spec marker.
 
 TASK_HEADING_RE = re.compile(r"^###\s+(T\d+[a-z]?)\b", re.MULTILINE)
 DEPENDS_LINE_RE = re.compile(r"^\*\*Depends on:\*\*\s*(.+)$", re.MULTILINE)
@@ -208,8 +208,8 @@ def parse_plan(text: str):
 # touch. Parsed like `Depends on:` but kept in a SEPARATE accessor so
 # `parse_plan`'s (ordered, deps) signature — and its ~8 callers — stay
 # unchanged. The globs drive a *screen-only* pre-dispatch disjointness
-# prediction in `schedule`; they never greenlight parallel (RFC-0015 / ADR-0005;
-# the post-write `git merge-tree` stays authoritative).
+# prediction in `schedule`; they never greenlight parallel (the post-write
+# `git merge-tree` stays authoritative).
 
 
 def parse_touches(field: str):
@@ -347,7 +347,7 @@ def detect_forward_refs(ordered, deps):
 # post-merge compile) and so are eligible for opt-in parallel writes. Every
 # other category — dynamic-semantic interference, shared mutable state,
 # move/extract-vs-edit, migration ordering, shared fixtures — fails *silent*
-# and stays serial. (RFC-0015 §3 / ADR-0005.)
+# and stays serial.
 SAFE_CATEGORIES = frozenset({"cannot-collide", "typed-group-b", "textual-loud"})
 
 
@@ -356,7 +356,7 @@ def dispatch_decision(categories, *, merge_tree_clean):
 
     Parallel only when **every** task is in a safe category **and** the wave
     is file-disjoint (a clean ``git merge-tree``). Fail closed: any non-safe
-    category, or any merge-tree conflict, serializes. (RFC-0015 decision 3.)
+    category, or any merge-tree conflict, serializes.
     This gates *writes* only; reviewer (read) fan-out is unaffected.
     """
     if not merge_tree_clean:
@@ -398,13 +398,13 @@ def _dispatch_rationale(categories, *, merge_tree_clean, decision, source=None) 
     return msg
 
 
-# ── auto-classification (supervisor-auto-classify; RFC-0015 / ADR-0005) ──────
+# ── auto-classification (supervisor-auto-classify) ───────────────────────────
 # Auto-derive a task's conflict category from its committed branch diff so the
 # supervisor stops hand-feeding `--category`. FAIL-CLOSED: only an all-added,
 # no-danger-path diff is `cannot-collide` (the lone auto-safe label); every
 # other shape gets a named non-safe label that serializes. This establishes
 # file-additive ∧ (with the gate's merge-tree half) file-disjoint — NOT
-# ADR-0005's full disjoint-no-shared-symbol; the cross-branch guard below
+# a full disjoint-no-shared-symbol guarantee; the cross-branch guard below
 # shrinks that residual, and the irreducible string-key/cross-file-symbol case
 # is backstopped by the post-merge test gate, not claimed here.
 _DANGER_PATH_RE = re.compile(
@@ -573,8 +573,8 @@ def cmd_schedule(args: argparse.Namespace) -> int:
 
 
 def cmd_dispatch_decision(args: argparse.Namespace) -> int:
-    """Gate one write wave: print ``parallel`` or ``serial`` (RFC-0015
-    decision 3 / AC5). The wave's conflict categories are **auto-derived** from
+    """Gate one write wave: print ``parallel`` or ``serial``. The wave's
+    conflict categories are **auto-derived** from
     each ``--branch``'s committed diff when ``--category`` is omitted, else the
     explicit ``--category`` list is used verbatim (human override). Combined
     with a mechanical ``git merge-tree`` file-disjointness check; fail closed:

--- a/packs/core/.apm/skills/work-loop/scripts/test-lint-spec-status.py
+++ b/packs/core/.apm/skills/work-loop/scripts/test-lint-spec-status.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Self-test for the sibling lint-spec-status.py (RFC-0016 Tier-1 lint).
+"""Self-test for the sibling lint-spec-status.py (the Tier-1 spec-status lint).
 
 Builds fixture spec trees in a tempdir and runs the linter as a
 subprocess against the documented `python <skill>/scripts/lint-spec-status.py

--- a/packs/credential-brokers/.apm/adapter-root-bins/sso-broker.py
+++ b/packs/credential-brokers/.apm/adapter-root-bins/sso-broker.py
@@ -14,8 +14,7 @@ and ``agentbundle:sso:<profile>:<n>`` for continuation slots.
 This script lives at ``~/.agentbundle/bin/sso-broker.py`` and is
 subprocess-invoked from `auth: sso-cookie` consumer skills.
 
-Refs: docs/specs/credential-broker-contract/spec.md (AC9-AC17);
-RFC-0013 § 4b.
+Refs: docs/specs/credential-broker-contract/spec.md (AC9-AC17).
 """
 
 from __future__ import annotations
@@ -52,7 +51,7 @@ if __package__ in (None, "") and __spec__ is None:
 # threshold is applied uniformly for cross-platform determinism.
 CRED_MAX_CREDENTIAL_BLOB_SIZE_BYTES = 2048
 
-# Reserved keychain-target namespace for this broker (AC12 / RFC-0013 § 4b).
+# Reserved keychain-target namespace for this broker (AC12).
 # Every write_credential / read_credential call site constructs target
 # names of shape agentbundle:sso:<profile> (or :<n> for continuation).
 _SSO_NAMESPACE = "agentbundle:sso"
@@ -83,7 +82,7 @@ elif sys.platform == "win32":
             _tier2_backend = None
 
 
-# Argv-borne credential flags refused per RFC-0006 § 4 / argv ban.
+# Argv-borne credential flags refused per the argv ban.
 _ARGV_BAN = frozenset({
     "--token",
     "--api-token",

--- a/packs/credential-brokers/.apm/shared-libs/credentials_shim.py
+++ b/packs/credential-brokers/.apm/shared-libs/credentials_shim.py
@@ -1,8 +1,7 @@
 """Loader API and stdlib ``.env`` parser for credentialed primitives.
 
 This module is the build-pipeline-projected shim that ships alongside
-each ``auth: creds`` consumer skill's ``scripts/`` (per RFC-0013 § 4 +
-credential-broker-contract spec § AC6). The consumer imports
+each ``auth: creds`` consumer skill's ``scripts/``. The consumer imports
 ``from .credentials_shim import …`` against this sibling — there is no
 runtime ``agentbundle`` dependency.
 
@@ -441,7 +440,7 @@ def _ensure_parent(parent: pathlib.Path) -> None:
     """Create the dotfile parent at mode 0o700 if absent (spec § AC15).
 
     If the parent already exists, do **not** rewrite its mode — the
-    directory is shared with ``~/.agentbundle/state.toml`` per RFC-0004.
+    directory is shared with ``~/.agentbundle/state.toml``.
     On POSIX warn on stderr if the existing mode is more permissive
     than 0o755.
     """

--- a/packs/credential-brokers/.apm/skills/credential-setup/SKILL.md
+++ b/packs/credential-brokers/.apm/skills/credential-setup/SKILL.md
@@ -10,7 +10,7 @@ metadata:
 # Skill: credential-setup
 
 This skill is the **single LLM-cooperative exception** to the
-brokers-not-skills rule (per RFC-0013 § 4e). It lives at
+brokers-not-skills rule. It lives at
 `<skills-dir>/credential-setup/` rather than at adapter-root because
 its job is to *prompt the user for a token* — an LLM-discoverable
 operation by design. The skill's body says, explicitly: this is
@@ -50,7 +50,7 @@ python3 scripts/setup.py <namespace> --schema-path <path>
 
 The script:
 
-1. Refuses the reserved `sso` namespace (per RFC-0013 § 4b — the
+1. Refuses the reserved `sso` namespace (the
    `sso-cookie` broker owns the `agentbundle:sso:*` keychain
    target-name prefix and the `credential-brokers` pack reserves
    the `sso` namespace globally for that broker's use).
@@ -85,5 +85,5 @@ To verify resolution after setup, invoke the consumer skill's own
 CLI primitive). The consumer's `check` walks Tier 1 → Tier 2 → Tier 3
 through the build-projected `credentials_shim` and exits 0 when every
 declared key resolves. This skill writes; the consumer's `check`
-reads. Do not write a `get` verb in this skill — the RFC-0006 § 5
+reads. Do not write a `get` verb in this skill — the
 wrap-and-leak shape is explicitly refused.

--- a/packs/credential-brokers/.apm/skills/credential-setup/scripts/credentials_shim.py
+++ b/packs/credential-brokers/.apm/skills/credential-setup/scripts/credentials_shim.py
@@ -1,8 +1,7 @@
 """Loader API and stdlib ``.env`` parser for credentialed primitives.
 
 This module is the build-pipeline-projected shim that ships alongside
-each ``auth: creds`` consumer skill's ``scripts/`` (per RFC-0013 § 4 +
-credential-broker-contract spec § AC6). The consumer imports
+each ``auth: creds`` consumer skill's ``scripts/``. The consumer imports
 ``from .credentials_shim import …`` against this sibling — there is no
 runtime ``agentbundle`` dependency.
 
@@ -441,7 +440,7 @@ def _ensure_parent(parent: pathlib.Path) -> None:
     """Create the dotfile parent at mode 0o700 if absent (spec § AC15).
 
     If the parent already exists, do **not** rewrite its mode — the
-    directory is shared with ``~/.agentbundle/state.toml`` per RFC-0004.
+    directory is shared with ``~/.agentbundle/state.toml``.
     On POSIX warn on stderr if the existing mode is more permissive
     than 0o755.
     """

--- a/packs/credential-brokers/.apm/skills/credential-setup/scripts/setup.py
+++ b/packs/credential-brokers/.apm/skills/credential-setup/scripts/setup.py
@@ -5,8 +5,8 @@ Walks the user through writing each required key in a skill's
 Darwin/Windows; 0600 dotfile floor on Linux or with
 ``--allow-insecure-fallback``).
 
-Refuses the reserved ``sso`` namespace (RFC-0013 § 4b). Refuses
-argv-borne credential flags and non-tty stdin (RFC-0006 § 4).
+Refuses the reserved ``sso`` namespace. Refuses
+argv-borne credential flags and non-tty stdin.
 
 This script is interactive, user-invoked, do not auto-run.
 """
@@ -43,7 +43,7 @@ from .credentials_shim import (
 
 RESERVED_NAMESPACES = frozenset({"sso"})
 
-# Argv-borne credential flags refused per RFC-0006 § 4 / argv ban.
+# Argv-borne credential flags refused per the argv ban.
 _ARGV_BAN = frozenset({
     "--token",
     "--api-token",

--- a/packs/figma/.apm/skills/figma/scripts/credentials_shim.py
+++ b/packs/figma/.apm/skills/figma/scripts/credentials_shim.py
@@ -1,8 +1,7 @@
 """Loader API and stdlib ``.env`` parser for credentialed primitives.
 
 This module is the build-pipeline-projected shim that ships alongside
-each ``auth: creds`` consumer skill's ``scripts/`` (per RFC-0013 § 4 +
-credential-broker-contract spec § AC6). The consumer imports
+each ``auth: creds`` consumer skill's ``scripts/``. The consumer imports
 ``from .credentials_shim import …`` against this sibling — there is no
 runtime ``agentbundle`` dependency.
 
@@ -441,7 +440,7 @@ def _ensure_parent(parent: pathlib.Path) -> None:
     """Create the dotfile parent at mode 0o700 if absent (spec § AC15).
 
     If the parent already exists, do **not** rewrite its mode — the
-    directory is shared with ``~/.agentbundle/state.toml`` per RFC-0004.
+    directory is shared with ``~/.agentbundle/state.toml``.
     On POSIX warn on stderr if the existing mode is more permissive
     than 0o755.
     """


### PR DESCRIPTION
## Why

Adopter installs receive this catalogue's skills, agents, and their scripts under `packs/*/.apm/` as projected content. Citations like `per RFC-0004` or `RFC-0015 decision 1` reference **this** catalogue's internal governance, which adopters have no access to — meaningless noise on arrival. This extends the adopter-readiness principle already enforced for seeds (`lint-seeds`) to skills/agents as a **one-time scrub**.

## What

Dropped internal catalogue RFC/ADR *numbers* (`RFC-00NN` / `ADR-00NN`) from adopter-facing pack artifacts while preserving every behavioral rule verbatim in meaning. Where a citation carried a "why", it was reworded to self-contained prose so **no dangling back-reference** is left behind (e.g. `(RFC-0015 decision 1)` → removed; `ADR-0005's full disjoint-no-shared-symbol` → `a full disjoint-no-shared-symbol guarantee`).

**Scope:**
- `core/work-loop`: `SKILL.md`, `references/supervisor-mode.md`, `scripts/loop-cohort.py`, `scripts/test-lint-spec-status.py`
- `credential-brokers`: `shared-libs/credentials_shim.py` (canonical), `credential-setup` `SKILL.md` + `scripts/setup.py`, `adapter-root-bins/sso-broker.py` (same-pack ride-along)
- `atlassian`: `flow-metrics/.../upstream.py`
- Projected copies (`.claude/**`, `.agentbundle/bin/**`, the 6 skill `credentials_shim.py` copies) refreshed via `make build-self`.

## Decisions

- **Option (a) one-time scrub** chosen over (b) enforce-going-forward. Codifying a lint analogous to `lint-seeds` + a CONVENTIONS entry is a new convention and is RFC-gated — **deferred**, not included here.
- **Preserved:** real external standards — `RFC-9457` (IETF Problem Details) in `api-contract/.../problem-1.0.1.yaml` is untouched. Ours vs. external is decided by digit-range (`RFC-00\d\d`).
- **Deferred (out of scope):** internal *spec/AC* references (`spec § AC15`, `(AC12)`, `(AC9-AC17)`) — same noise-class but outside this scrub's RFC/ADR-number scope. Flag if a follow-on is wanted.

## Verification

- No script **logic** changed — docstrings/comments only (all Python AST-equal, string constants aside).
- `make build-check` exits 0.
- `adversarial-reviewer`: `Clean — ready to commit.` — every rule preserved, no dangling references, no over-scrub.