### PR TITLE
chore(packs): scrub internal spec/AC/plan citations from adopter-facing content

### DIFF
--- a/.agentbundle/bin/_sso_credman_windows.py
+++ b/.agentbundle/bin/_sso_credman_windows.py
@@ -1,4 +1,4 @@
-"""Windows Credential Manager Tier-2 backend (spec § AC9-AC12).
+"""Windows Credential Manager Tier-2 backend.
 
 In-process ``ctypes`` against ``advapi32.dll``'s ``CredReadW`` /
 ``CredWriteW`` / ``CredDeleteW`` / ``CredFree`` — stdlib only, no
@@ -15,7 +15,7 @@ zero-initialised via ``ctypes.Structure`` defaults — required by
 NULL when ``AttributeCount`` is 0; ``LastWritten`` is set by the API
 and ignored on write).
 
-Per spec § AC4b the loader imports this module **only** when
+The loader imports this module **only** when
 ``sys.platform == "win32"``. The advapi32 binding is platform-guarded
 below so the module itself stays importable on every platform; tests
 that don't actually call the OS can construct ``CREDENTIAL`` instances
@@ -31,11 +31,11 @@ from ctypes import POINTER, Structure, byref
 
 from .credentials_shim import Tier2HardFailError
 
-# Constants from ``wincred.h`` (spec § AC9):
+# Constants from ``wincred.h``:
 CRED_TYPE_GENERIC = 1
 CRED_PERSIST_LOCAL_MACHINE = 2
 
-# Win32 error codes — sourced from ``winerror.h`` and AC11:
+# Win32 error codes — sourced from ``winerror.h``:
 ERROR_NOT_FOUND = 1168          # falls through to Tier 3
 ERROR_NO_SUCH_LOGON_SESSION = 1312
 ERROR_INVALID_FLAGS = 1004
@@ -44,7 +44,7 @@ ERROR_LOGON_FAILURE = 1326
 TARGET_PREFIX = "agentbundle"
 # Tests can monkeypatch this to a ``tmp_path``-derived value so test
 # target-names can't collide with the developer's real Credential
-# Manager entries (spec § AC35 / plan T5 § Test isolation).
+# Manager entries.
 SERVICE_PREFIX_OVERRIDE: str | None = None
 
 
@@ -53,7 +53,7 @@ class CREDENTIAL(Structure):
 
     Field order and types must match the Win32 ABI exactly — a wrong-
     sized field on Windows returns garbage rather than raising, which
-    is why AC10 mandates a byte-equality round-trip test on every field.
+    is why a byte-equality round-trip test covers every field.
     """
 
     _fields_ = [
@@ -104,18 +104,18 @@ else:
 
 
 def _target_name(namespace: str, key: str) -> str:
-    """Compose the Win32 ``TargetName`` per spec § AC9."""
+    """Compose the Win32 ``TargetName``."""
     prefix = SERVICE_PREFIX_OVERRIDE or TARGET_PREFIX
     return f"{prefix}:{namespace}:{key}"
 
 
 def _classify_last_error(rc: int, op: str) -> None:
-    """Map the Win32 last-error code to the AC11 dispatch matrix.
+    """Map the Win32 last-error code to the dispatch matrix.
 
     ``ERROR_NOT_FOUND`` is the caller's responsibility (it indicates a
     legitimate miss — caller returns ``None``). Every other code on
     this matrix raises ``Tier2HardFailError`` so the resolver does not
-    silently degrade to Tier 3 (spec § Never do).
+    silently degrade to Tier 3.
     """
     if rc == ERROR_NO_SUCH_LOGON_SESSION:
         raise Tier2HardFailError(
@@ -144,7 +144,7 @@ def read_credential(namespace: str, key: str) -> str | None:
 
     Returns ``None`` on ``ERROR_NOT_FOUND`` (resolver falls through to
     Tier 3); raises ``Tier2HardFailError`` on every other documented
-    failure (AC11).
+    failure.
     """
     target = _target_name(namespace, key)
     out_ptr = POINTER(CREDENTIAL)()
@@ -169,7 +169,7 @@ def read_credential(namespace: str, key: str) -> str | None:
 
 
 def write_credential(namespace: str, key: str, value: str) -> None:
-    """Write ``value`` to ``(namespace, key)`` (AC9, AC10).
+    """Write ``value`` to ``(namespace, key)``.
 
     The token is UTF-16-LE encoded and stored in a writable buffer
     pointed to by ``CredentialBlob``; ``CredentialBlobSize`` is the
@@ -183,7 +183,7 @@ def write_credential(namespace: str, key: str, value: str) -> None:
     # All other fields stay at ctypes.Structure's zero-init defaults
     # (Flags=0, Comment=None, LastWritten=FILETIME(0,0),
     # AttributeCount=0, Attributes=None, TargetAlias=None) — required
-    # by CRED_TYPE_GENERIC per spec § AC9.
+    # by CRED_TYPE_GENERIC.
     cred.Type = CRED_TYPE_GENERIC
     cred.TargetName = target
     cred.CredentialBlobSize = len(blob)

--- a/.agentbundle/bin/_sso_keychain_macos.py
+++ b/.agentbundle/bin/_sso_keychain_macos.py
@@ -1,8 +1,8 @@
-"""macOS Keychain Tier-2 backend (spec § AC6-AC8).
+"""macOS Keychain Tier-2 backend.
 
 Stdlib subprocess against ``/usr/bin/security`` — the system-shipped
-Keychain CLI. Guaranteed present on every macOS install per spec §
-Boundaries § Never do (no third-party ``keyring`` dependency).
+Keychain CLI. Guaranteed present on every macOS install (no third-party
+``keyring`` dependency).
 
 Token bytes never reach argv:
 
@@ -16,7 +16,7 @@ Token bytes never reach argv:
 - **Delete** uses ``delete-generic-password`` (idempotent on miss).
 
 The build-projected ``credentials_shim`` imports this module **only**
-when ``sys.platform == "darwin"`` per AC4b. Tests monkeypatch
+when ``sys.platform == "darwin"``. Tests monkeypatch
 ``SERVICE`` to a ``tmp_path``-derived prefix so test entries never
 collide with the developer's real ``agentbundle`` Keychain entries.
 """
@@ -34,9 +34,9 @@ SERVICE = "agentbundle"
 # developer's login Keychain. ``security``'s ``-w`` prompt mode requires
 # ``-w`` as the trailing argv element, which forecloses the trailing-
 # keychain-positional approach to test isolation; the service-prefix
-# approach lets the canonical AC6 argv shape stay untouched.
+# approach lets the canonical argv shape stay untouched.
 
-# macOS Security framework OSStatus codes (spec § AC22):
+# macOS Security framework OSStatus codes:
 #   44      errSecItemNotFound          — legitimate "no such credential",
 #                                         falls through to Tier 3.
 #   45      errSecDuplicateItem         — only relevant on add; the ``-U``
@@ -46,7 +46,7 @@ SERVICE = "agentbundle"
 #
 # Names taken from ``<Security/SecBase.h>``. The two "Keychain locked /
 # unavailable" codes (25308 / -25291) MUST raise ``Tier2HardFailError``
-# so ``run_setup`` can route the AC22 fallback gate — silently
+# so ``run_setup`` can route the fallback gate — silently
 # degrading to Tier 3 defeats the security posture the user chose.
 EXIT_NOT_FOUND = 44
 EXIT_DUPLICATE_ITEM = 45
@@ -62,8 +62,7 @@ def _classify_macos_exit_code(rc: int, op: str) -> str | None:
     embed it in a ``Tier2HardFailError`` message. Returns ``None`` for
     ``EXIT_NOT_FOUND`` (the caller treats that as a legitimate miss).
 
-    Parallel in shape to ``_credman_windows._classify_last_error``;
-    AC22 cites this matrix explicitly.
+    Parallel in shape to ``_credman_windows._classify_last_error``.
     """
     if rc == 0:
         return None
@@ -92,12 +91,12 @@ def _classify_macos_exit_code(rc: int, op: str) -> str | None:
 
 
 def _account(namespace: str, key: str) -> str:
-    """Compose the Keychain account label per spec § AC6."""
+    """Compose the Keychain account label."""
     return f"{namespace}:{key}"
 
 
 def read_credential(namespace: str, key: str) -> str | None:
-    """Read ``(namespace, key)`` from the Keychain (spec § AC6, AC7)."""
+    """Read ``(namespace, key)`` from the Keychain."""
     argv = [
         SECURITY_BIN, "find-generic-password",
         "-s", SERVICE,
@@ -121,7 +120,7 @@ def read_credential(namespace: str, key: str) -> str | None:
 
 def write_credential(namespace: str, key: str, value: str) -> None:
     """Write ``value`` to ``(namespace, key)``. Token enters via child stdin
-    only — never argv (spec § AC6, AC7).
+    only — never argv.
 
     Refuses values containing ``\\n`` or ``\\r`` up front. ``security -w``
     prompts twice and the stdin payload is ``token + b"\\n" + token + b"\\n"``;

--- a/.agentbundle/bin/credentials_shim.py
+++ b/.agentbundle/bin/credentials_shim.py
@@ -13,9 +13,9 @@ Public surface a credentialed-primitive author imports:
 - ``Credentials`` — immutable, attribute-access view of the resolved values.
 - ``EnvParseError`` — raised by ``parse_env_file`` on unsupported syntax.
 
-Stdlib-only per spec § Boundaries § Never do — no ``python-dotenv``, no
+Stdlib-only by design — no ``python-dotenv``, no
 ``keyring``, no third-party imports. The Tier-2 backend is dispatched at
-module-load time per AC4b: ``_keychain_macos`` iff ``sys.platform ==
+module-load time: ``_keychain_macos`` iff ``sys.platform ==
 "darwin"``, ``_credman_windows`` iff ``"win32"``, no Tier-2 backend on
 other platforms (resolver falls through directly to Tier 3).
 
@@ -36,8 +36,8 @@ Trailing ``\\r`` from CRLF line endings is stripped; ``\\r`` *inside* a
 quoted value is preserved (``KEY="a\\rb"`` → ``{"KEY": "a\\rb"}``).
 
 When loaded outside a consumer-skill ``scripts/`` directory — e.g. as
-a sibling under ``~/.agentbundle/bin/`` per the credential-broker-contract
-AC22b companion projection — the shim's own ``_tier2_backend`` resolves
+a sibling under ``~/.agentbundle/bin/`` per the shim companion
+projection — the shim's own ``_tier2_backend`` resolves
 to ``None``. Callers in that context must not rely on ``load_credentials``
 for Tier-2 resolution; that path is the consumer-skill ``scripts/``
 projection only.
@@ -94,7 +94,7 @@ class Tier2HardFailError(Exception):
 class PermissiveAclError(Exception):
     """Raised when the Windows DACL on the Tier-3 dotfile is too permissive.
 
-    Per spec § AC15: ``icacls`` is invoked after each write; non-default
+    ``icacls`` is invoked after each write; non-default
     ACEs (anything beyond the inherited user / ``NT AUTHORITY\\SYSTEM`` /
     ``BUILTIN\\Administrators``) cause the helper to refuse unless
     ``allow_permissive_acl=True`` was passed.
@@ -104,7 +104,7 @@ class PermissiveAclError(Exception):
 class SchemaError(Exception):
     """Raised when a ``creds-schema.toml`` file is malformed or missing.
 
-    Per spec § AC24 / AC24b — names the offending file path and the
+    Names the offending file path and the
     specific shape violation (missing ``[namespace]``, empty
     ``namespace.keys``, non-boolean ``secret``, or unresolvable
     canonical path).
@@ -186,11 +186,11 @@ def parse_env_file(path: pathlib.Path) -> dict[str, str]:
         result[key] = value
     return result
 
-# Tier-2 backend dispatch at module-load time (spec § AC4b). The backend
-# modules are added by T4 (macOS) and T5 (Windows); until they land, the
-# try/except yields ``None`` and the resolver skips Tier 2 on the matching
-# platform. On Linux (and any non-Darwin / non-Windows platform), no import
-# is attempted at all — Tier 2 is unavailable by absence.
+# Tier-2 backend dispatch at module-load time. If a platform's backend
+# module is absent, the try/except yields ``None`` and the resolver skips
+# Tier 2 on the matching platform. On Linux (and any non-Darwin /
+# non-Windows platform), no import is attempted at all — Tier 2 is
+# unavailable by absence.
 if sys.platform == "darwin":
     try:
         from . import _keychain_macos as _tier2_backend  # type: ignore[no-redef]
@@ -208,7 +208,7 @@ else:
 class Credentials:
     """Immutable, attribute-access view of a namespace's resolved credentials.
 
-    Constructed by ``load_credentials``. The contract (spec § AC3) is:
+    Constructed by ``load_credentials``. The contract is:
 
     - Attribute access returns the resolved value:
       ``creds.API_TOKEN`` returns the resolved ``API_TOKEN`` for the
@@ -276,7 +276,7 @@ class Credentials:
 
 
 def _tier1_env(namespace: str, key: str) -> str | None:
-    """Resolve ``<NAMESPACE>_<KEY>`` from ``os.environ`` (spec § AC5).
+    """Resolve ``<NAMESPACE>_<KEY>`` from ``os.environ``.
 
     Empty-string env vars count as unset and return ``None`` so the
     resolver falls through to lower tiers.
@@ -289,12 +289,12 @@ def _tier1_env(namespace: str, key: str) -> str | None:
 
 
 def _tier2(namespace: str, key: str) -> str | None:
-    """Resolve via the platform-specific keyring backend (spec § AC6, AC9).
+    """Resolve via the platform-specific keyring backend.
 
     Returns ``None`` when the backend is absent (non-Darwin / non-Windows
-    platforms, or backend modules not yet shipped) or reports a clean
+    platforms, or backend modules not shipped) or reports a clean
     miss. Hard-fail error codes from the underlying API propagate as
-    ``Tier2HardFailError`` per AC11.
+    ``Tier2HardFailError``.
     """
     if _tier2_backend is None:
         return None
@@ -302,7 +302,7 @@ def _tier2(namespace: str, key: str) -> str | None:
 
 
 def _tier3(namespace: str, key: str) -> str | None:
-    """Resolve from the Tier-3 dotfile (spec § AC13).
+    """Resolve from the Tier-3 dotfile.
 
     Reads ``~/.agentbundle/credentials.env`` via the stdlib parser and
     looks up ``<NAMESPACE>_<KEY>``. Returns ``None`` on miss; a malformed
@@ -317,7 +317,7 @@ def _tier3(namespace: str, key: str) -> str | None:
 
 
 def _dotfile_path() -> pathlib.Path:
-    """Canonical Tier-3 dotfile path per spec § AC13.
+    """Canonical Tier-3 dotfile path.
 
     Resolves to ``pathlib.Path.home() / ".agentbundle" / "credentials.env"``
     on every platform. Tests redirect ``HOME`` (and ``USERPROFILE`` on
@@ -399,7 +399,7 @@ def _verify_icacls(
     path: pathlib.Path, *, allow_permissive_acl: bool = False
 ) -> None:
     """Run ``icacls /findsid`` and refuse if any well-known "broad
-    access" SID is granted access on the path (spec § AC15). No-op on
+    access" SID is granted access on the path. No-op on
     POSIX.
 
     Default ACEs on a per-user file are the inheriting user,
@@ -437,7 +437,7 @@ def _verify_icacls(
 
 
 def _ensure_parent(parent: pathlib.Path) -> None:
-    """Create the dotfile parent at mode 0o700 if absent (spec § AC15).
+    """Create the dotfile parent at mode 0o700 if absent.
 
     If the parent already exists, do **not** rewrite its mode — the
     directory is shared with ``~/.agentbundle/state.toml``.
@@ -465,7 +465,7 @@ def _dotfile_write(
 ) -> None:
     """Write ``(namespace, key) → value`` to the Tier-3 dotfile atomically.
 
-    Atomic write contract per spec § AC14:
+    Atomic write contract:
     ``tempfile.mkstemp(dir=target_dir)`` → ``os.write`` →
     ``os.fchmod`` (POSIX) → ``os.close`` → ``os.replace``. A mid-write
     read sees either the prior contents or the new contents, never
@@ -556,7 +556,7 @@ def load_credentials(
 ) -> Credentials:
     """Resolve ``required_keys`` for ``namespace``, walking Tiers 1 → 2 → 3.
 
-    First-hit-wins per key (spec § AC4): a key resolved at Tier 1 is not
+    First-hit-wins per key: a key resolved at Tier 1 is not
     re-checked at lower tiers; mixing tiers across keys within one
     namespace is permitted.
 
@@ -593,8 +593,8 @@ def load_credentials(
         attempts.append(f"Tier 1: env {env_name!r} not set")
 
         # Tier 2 — OS keyring (when loaded). Tier2HardFailError
-        # propagates per AC11 (no silent fallback to Tier 3 on hard
-        # fail); only a clean miss falls through.
+        # propagates (no silent fallback to Tier 3 on hard fail);
+        # only a clean miss falls through.
         if _tier2_backend is None:
             attempts.append("Tier 2: not loaded (no keyring backend on this platform)")
         else:
@@ -621,8 +621,8 @@ def load_credentials(
         tiers_tried[key] = attempts
 
     if missing:
-        # One-line preamble preserves the AC3 contract (message names
-        # namespace and the missing-keys list); the per-key trailer
+        # One-line preamble names the namespace and the missing-keys
+        # list; the per-key trailer
         # block comes below for triage.
         lines = [
             f"namespace {namespace!r}: missing required credential(s): "
@@ -641,7 +641,7 @@ def load_credentials(
     return Credentials(namespace, resolved)
 
 
-# ── creds-schema.toml parser (spec § AC24, AC24b) ─────────────────────
+# ── creds-schema.toml parser ──────────────────────────────────────────
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -649,7 +649,7 @@ class KeyDef:
     """A single required key declared in ``creds-schema.toml``.
 
     ``secret=True`` keys are prompted via ``getpass.getpass`` (no echo);
-    ``secret=False`` keys are prompted via ``input()`` per spec § AC24.
+    ``secret=False`` keys are prompted via ``input()``.
     """
 
     name: str
@@ -668,7 +668,7 @@ class CredsSchema:
 def _parse_schema(path: pathlib.Path) -> CredsSchema:
     """Parse a ``creds-schema.toml`` file into a typed ``CredsSchema``.
 
-    Per spec § AC24, the expected shape is::
+    The expected shape is::
 
         [namespace]
         name = "<namespace>"
@@ -733,7 +733,7 @@ _SKILL_MD_RE = re.compile(r"^\.claude/skills/([^/]+)/SKILL\.md$")
 def _relative_schema_path(
     state: "object", pack: str, skill_name: str
 ) -> pathlib.Path:
-    """Resolve the *state-relative* ``creds-schema.toml`` path per spec § AC24b.
+    """Resolve the *state-relative* ``creds-schema.toml`` path.
 
     Walks ``state.packs[pack].files`` for a relpath matching
     ``^\\.claude/skills/<skill_name>/SKILL\\.md$``; returns the
@@ -745,7 +745,7 @@ def _relative_schema_path(
     underscore-prefixed name reflects that contract; CLI callers go
     through `commands/creds._resolve_schema_for_namespace` which joins
     against `SKILL.md.parent` directly instead of calling this helper.
-    Kept around because it pins the AC24b state-walk shape with its
+    Kept around because it pins the state-walk shape with its
     own tests.
 
     Raises ``SchemaError`` if no matching SKILL.md row is in

--- a/.agentbundle/bin/sso-broker.py
+++ b/.agentbundle/bin/sso-broker.py
@@ -1,4 +1,4 @@
-"""SSO-cookie broker — credential-broker-contract T5.
+"""SSO-cookie broker.
 
 Six verbs: register / get-cookies / test / refresh / list-profiles / rm.
 
@@ -13,8 +13,6 @@ and ``agentbundle:sso:<profile>:<n>`` for continuation slots.
 
 This script lives at ``~/.agentbundle/bin/sso-broker.py`` and is
 subprocess-invoked from `auth: sso-cookie` consumer skills.
-
-Refs: docs/specs/credential-broker-contract/spec.md (AC9-AC17).
 """
 
 from __future__ import annotations
@@ -36,7 +34,7 @@ import urllib.request
 # ``__spec__ is None`` so the block only fires for true file-path
 # invocation; an importlib-based test harness is responsible for its
 # own package context. The shim companion (``credentials_shim.py``)
-# is co-located by the AC22b projection rule, so the per-platform
+# is co-located by the shim-companion projection rule, so the per-platform
 # ``_sso_*`` modules' ``from .credentials_shim import Tier2HardFailError``
 # resolves under user-scope install.
 if __package__ in (None, "") and __spec__ is None:
@@ -45,13 +43,13 @@ if __package__ in (None, "") and __spec__ is None:
     __package__ = _here.name
 
 
-# Per AC12 — chosen explicitly to leave headroom under the Win32
+# Chosen explicitly to leave headroom under the Win32
 # CRED_MAX_CREDENTIAL_BLOB_SIZE lower-bound of 2560 bytes pre-Windows 7.
 # macOS Keychain and Linux dotfile have higher capacity but the same
 # threshold is applied uniformly for cross-platform determinism.
 CRED_MAX_CREDENTIAL_BLOB_SIZE_BYTES = 2048
 
-# Reserved keychain-target namespace for this broker (AC12).
+# Reserved keychain-target namespace for this broker.
 # Every write_credential / read_credential call site constructs target
 # names of shape agentbundle:sso:<profile> (or :<n> for continuation).
 _SSO_NAMESPACE = "agentbundle:sso"
@@ -374,7 +372,7 @@ def _do_register(profile: str, args: argparse.Namespace) -> int:
     success = False
     success_re = re.compile(success_pattern)
 
-    # Corporate-network env passthrough — explicit per AC14.
+    # Corporate-network env passthrough — explicit by design.
     env_for_browser = {**os.environ}
 
     with sync_playwright() as pw:
@@ -595,7 +593,7 @@ def _do_list_profiles() -> int:
 def _do_show_tier2_backend() -> int:
     """Print ``repr(_tier2_backend)`` and exit 0.
 
-    Test surface for the AC22b shim-companion projection regression
+    Test surface for the shim-companion projection regression
     (`packages/agentbundle/tests/integration/test_credential_user_scope_invocation.py`):
     invoking ``python bin/sso-broker.py show-tier2-backend`` under the
     documented user-scope layout asserts the Tier-2 backend module
@@ -667,7 +665,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     sub.add_parser(
         "show-tier2-backend",
-        help="Print repr(_tier2_backend) (AC22b shim-companion probe).",
+        help="Print repr(_tier2_backend) (shim-companion probe).",
     )
 
     return parser

--- a/.claude/commands/conventions-check.md
+++ b/.claude/commands/conventions-check.md
@@ -30,14 +30,13 @@ Run these repo linters and report findings.
 4. Skill dirs contain a `SKILL.md` (and no stray `.md` siblings).
 5. Internal markdown links inside each artifact resolve.
 
-**`bash tools/lint-credentialed-skills.sh`** — credentialed-skill rules
-(skill-secrets spec § AC26 — see `docs/specs/skill-secrets/spec.md`);
+**`bash tools/lint-credentialed-skills.sh`** — credentialed-skill rules,
 scoped to skills whose `SKILL.md` declares `metadata.credentialed: true`
 (per agentskills.io spec, project-specific fields live under
 `metadata:`):
 
 1. The body contains an `### Security rules (non-negotiable)` heading
-   and the three RFC-0006 § 4 substrings inside that section (the
+   and the three required security substrings inside that section (the
    verbatim "Don't" block).
 2. For `metadata.primitive-class: credentialed-cli`: no script under
    the skill's `scripts/` directory accepts an `argparse` flag whose

--- a/.claude/skills/adapt-to-project/SKILL.md
+++ b/.claude/skills/adapt-to-project/SKILL.md
@@ -207,7 +207,7 @@ fold into `~/.claude/agents/bot.md`. Per-finding accept / edit /
 decline; recordings land in the scope of the file the finding was
 observed in.
 
-**Cross-scope restructure (AC23, never executed as a single move).**
+**Cross-scope restructure (never executed as a single move).**
 When a class-3 finding's `source-path` and `destination-path` live
 at different scopes (e.g., source under `<repo>/`, destination under
 `~/.claude/`), this cross-scope restructure is never executed as a single move. The skill detects the scope crossing, names both

--- a/.claude/skills/work-loop/scripts/loop-cohort.py
+++ b/.claude/skills/work-loop/scripts/loop-cohort.py
@@ -368,14 +368,14 @@ def dispatch_decision(categories, *, merge_tree_clean):
 
 def _dispatch_rationale(categories, *, merge_tree_clean, decision, source=None) -> str:
     """Human-readable one-line rationale for a `dispatch-decision` outcome —
-    the cleared-gate surface (AC10). On ``parallel`` it names the wave as
+    the cleared-gate surface. On ``parallel`` it names the wave as
     parallel-eligible + the task count; on ``serial`` it names the
     disqualifying reason, **merge-tree conflict first** to match
     `dispatch_decision`'s short-circuit order (so a both-fail wave names the
     conflict, not the category). ``source`` (``"auto"`` | ``"human"`` | None)
     names whether categories were auto-derived from branch diffs or
-    human-supplied; **None preserves the original output verbatim** so the
-    parent spec's AC10 tests stay green (additive change)."""
+    human-supplied; **None preserves the original output verbatim** so
+    existing output-shape tests stay green (additive change)."""
     if decision == "parallel":
         msg = (
             f"wave is PARALLEL-ELIGIBLE — {len(categories)} task(s), all "
@@ -494,7 +494,7 @@ def added_paths_may_share_symbol(per_branch_added) -> bool:
 def wave_is_disjoint(branches) -> bool:
     """True iff the wave's branches merge without conflict, via read-only
     ``git merge-tree`` (no working-tree mutation). Pairwise over the wave;
-    called by the ``dispatch-decision`` verb (and the AC9 worktree dry-run)."""
+    called by the ``dispatch-decision`` verb (and the worktree dry-run)."""
     for i in range(len(branches)):
         for j in range(i + 1, len(branches)):
             proc = run_git(
@@ -610,7 +610,7 @@ def cmd_dispatch_decision(args: argparse.Namespace) -> int:
 
     decision = dispatch_decision(categories, merge_tree_clean=clean)
     print(decision)  # stdout: the machine-readable token (scripted reads)
-    # stderr: the human-facing cleared-gate surface (AC10) — so the agent has
+    # stderr: the human-facing cleared-gate surface — so the agent has
     # something to present to the human for opt-in, never fanning out silently.
     print(
         "dispatch-decision: " + _dispatch_rationale(

--- a/AGENTS.local.md
+++ b/AGENTS.local.md
@@ -63,6 +63,42 @@ all run it. If you're tempted to make a shipped hook/command/template reference
 stop: that's catalogue-internal — it breaks on arrival in an adopter's repo
 (this is the issue #190 / `adopter-clean-enforcement-gate` class of bug).
 
+### Shipped pack content carries no internal-governance citations
+
+When you author or edit anything under a pack's `.apm/**` (skills, agents,
+commands, hooks, their `scripts/`, `references/`, `shared-libs/`,
+`adapter-root-bins/`), **never cite this catalogue's own governance**. Adopters
+receive the artifact but none of the governance it was written under, so the
+citation is dangling noise on arrival. The four types to keep out:
+
+1. **RFC numbers** — `RFC-0001`…`RFC-00NN` (our zero-padded form).
+2. **ADR numbers** — `ADR-0001`…`ADR-00NN`.
+3. **Named-spec / acceptance-criterion / plan citations** — `spec § AC15`,
+   `skill-secrets spec § AC24`, `credential-broker-contract T7`,
+   `plan §T5 lines 357-362`, `docs/specs/flow-metrics.md § "Outputs"`.
+4. **Internal doc paths** — `docs/specs/<named-feature>.md`, `docs/adr/…`,
+   `docs/rfc/…`, `.github/workflows/…` (the adopter-clean rule above already
+   bars these from shipped *hooks/commands*; it holds for all `.apm/**`).
+
+Drop the citation, keep the rule: *"Markers are repo-only per RFC-0004"* →
+*"Markers are repo-only"*; *"Refuses the reserved `sso` namespace (spec § AC4b)"*
+→ *"Refuses the reserved `sso` namespace"*. Where the citation carried a "why",
+reword to self-contained prose ("by convention", "a known gap"), never a
+dangling back-reference or an orphaned connective.
+
+**What is NOT a citation — leave it:** the generic spec-driven *workflow
+vocabulary* that ships as the convention itself (`docs/specs/<feature>/spec.md`
+and `plan.md` placeholders, the words "spec" / "plan" / "acceptance criteria"),
+**real external standards** (IETF/W3C — `RFC 9457`, `RFC 8259` — distinguished
+by the space + large number), and **functional fixture/template content** (e.g.
+`- [ ] AC1` rows in the spec-status linter's test fixtures, where `AC1` is data
+the parser consumes, not a citation).
+
+Precedent: `lint-seeds` already enforces this for `seeds/**`. There is **no
+automated lint for `.apm/**` skills/agents yet** — a `lint-seeds`-analogue is a
+possible follow-on, but adding one is a new convention and therefore RFC-gated.
+Until then this is a hand-checked authoring rule.
+
 ## Agents PROJECT — they are not "Claude Code only" (stop getting this wrong)
 
 The `agent` primitive (e.g. `adversarial-reviewer`, `quality-engineer`)

--- a/packs/atlassian/.apm/skills/ai-adoption-report/SKILL.md
+++ b/packs/atlassian/.apm/skills/ai-adoption-report/SKILL.md
@@ -129,13 +129,12 @@ The skill writes a Markdown report and (by default) a JSON sidecar:
   touches `report.md`.
 
 For the full output schema (delta math, JSON canonicalisation, scope
-canonical representation, metric row order) see
-`docs/specs/ai-adoption-report.md` §"Output: Markdown" and §"Output:
-JSON sidecar".
+canonical representation, metric row order) see the Outputs section
+above and the JSON sidecar description.
 
 ## Examples
 
-The three literal commands from spec §"Users and use cases".
+The three main invocation patterns:
 
 ### Baseline: pre-AI vs current
 
@@ -201,9 +200,9 @@ for atomic replace). The contract is enforced by tests in
 `os.spawn*` / `os.system` surface and snapshot the working
 directory before and after a run.
 
-## Spec reference
+## Implementation notes
 
-See `docs/specs/ai-adoption-report.md` for:
+Key behavioural contracts:
 
 - the full Inputs table and validation rules,
 - delta math (zero baseline, null on either side, distribution
@@ -217,5 +216,4 @@ See `docs/specs/ai-adoption-report.md` for:
 - Markdown rendering rules (Unicode minus in numeric cells, em-dash
   for absent / undefined cells, scope/team name escaping),
 - JSON canonicalisation (codepoint-sorted keys, 4 dp floats,
-  `deltas` block in canonical metric order),
-- the complete contract-test inventory.
+  `deltas` block in canonical metric order).

--- a/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/__init__.py
+++ b/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/__init__.py
@@ -59,8 +59,7 @@ def parse_window_flag(s: str) -> Tuple[str, str]:
     """Parse `--window FROM..TO` into two YYYY-MM-DD strings.
 
     Returns the two strings verbatim — no normalization. String equality
-    is the spec's window-match rule for program mode (see spec §"Input
-    file validation").
+    is the window-match rule for program mode.
     """
     parts = s.split("..")
     if len(parts) != 2 or not parts[0] or not parts[1]:
@@ -326,8 +325,8 @@ def _render_and_write(args: argparse.Namespace, report) -> None:
 
     - ``markdown``: write only the Markdown file at ``--output``.
     - ``json``: write only the derived ``.json`` sidecar; the Markdown
-      renderer is **not** invoked at all (spec line 86, "json skips
-      Markdown rendering"). The ``--output`` flag is interpreted as the
+      renderer is **not** invoked at all. The ``--output`` flag is
+      interpreted as the
       Markdown-path-shaped value and the sidecar is derived from it —
       so ``--format=json --output report.md`` writes ``report.json``
       and never touches ``report.md``.
@@ -348,9 +347,9 @@ def _render_and_write(args: argparse.Namespace, report) -> None:
             overwrite=args.overwrite,
         )
     elif fmt == "json":
-        # Per spec line 86 + T8 brief option (a): the --output path is
-        # always Markdown-shaped; for --format=json we still derive the
-        # sidecar path from it but skip the Markdown renderer entirely.
+        # The --output path is always Markdown-shaped; for --format=json
+        # we still derive the sidecar path from it but skip the Markdown
+        # renderer entirely.
         json_path = derive_sidecar_path(markdown_path)
         json_text = render_json(report, title=title, generated_at=generated_at)
         write_outputs(

--- a/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/aggregation.py
+++ b/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/aggregation.py
@@ -8,8 +8,7 @@ Turns a list of :class:`program_discovery.ProgramScope` into:
   ``flow-metrics``'s ``cohort_breakdown.<side>`` shape), produced only
   when ``--include-cohort-breakdown`` is set.
 
-Aggregation rules (spec §"Aggregation math (program mode only)" lines
-366-384 and §"Mode: program" lines 252-311):
+Aggregation rules for program mode:
 
 - ``throughput`` / ``wip`` / ``flow_load`` — sum across scopes.
 - ``cycle_time_hours`` / ``lead_time_hours`` / ``flow_time_hours`` /
@@ -18,8 +17,8 @@ Aggregation rules (spec §"Aggregation math (program mode only)" lines
 - ``rework_rate`` — throughput-weighted average. Side's own throughput
   is the weight (cohort uses cohort throughput, control uses control
   throughput, non-cohort uses per-scope ``aggregates.throughput``).
-- ``defect_ratio`` — flow_distribution.denominator-weighted average
-  (spec lines 273-281 + line 378). NOT throughput-weighted.
+- ``defect_ratio`` — flow_distribution.denominator-weighted average.
+  NOT throughput-weighted.
 - ``flow_distribution.<bucket>`` — denominator-weighted average. The
   aggregated ``flow_distribution.denominator`` is the integer sum
   across contributing scopes.
@@ -44,8 +43,8 @@ from .program_discovery import ProgramScope
 
 
 # Top-level keys in the order they appear in the aggregates / cohort
-# side dicts T6 produces. Derived from spec §"Metric row order" (lines
-# 352-364) collapsed to one entry per top-level metric.
+# side dicts T6 produces. Follows the canonical metric row order,
+# collapsed to one entry per top-level metric.
 _TOP_LEVEL_METRIC_ORDER: Tuple[str, ...] = (
     "throughput",
     "wip",
@@ -112,8 +111,8 @@ def aggregate_non_cohort(
     """Return ``(aggregates_dict, notes)`` for the non-cohort rollup.
 
     Includes every scope (per_team-flattened rows participate in the
-    non-cohort aggregation per spec lines 232-244). Side label woven
-    into zero-denominator notes is ``"non-cohort"``.
+    non-cohort aggregation). Side label woven into zero-denominator
+    notes is ``"non-cohort"``.
 
     The returned dict matches the shape of flow-metrics's ``aggregates``
     block: same keys, same nesting. T7 may layer on derived fields
@@ -138,7 +137,7 @@ def aggregate_cohort_side(
 ) -> Tuple[Optional[dict], List[str]]:
     """Return ``(cohort_breakdown_side_dict | None, notes)`` for one side.
 
-    Exclusions per spec lines 252-311:
+    Exclusions for cohort-side rollup:
 
     - ``from_per_team=True`` scopes are excluded from BOTH cohort and
       control rollups (flow-metrics v1 doesn't split per_team rows by
@@ -195,12 +194,12 @@ def aggregate_cohort_side(
     )
     notes.extend(agg_notes)
 
-    # Spec lines 381-384: emit the median-of-medians approximation note
-    # whenever distribution aggregates are produced. aggregate_non_cohort
-    # is the canonical emission point, but firing here too defends
-    # against the (contrived) case where the non-cohort table has no
-    # distribution metrics yet a cohort side does. T7 dedupes by exact
-    # match, so the duplicate emission is free.
+    # Emit the median-of-medians approximation note whenever distribution
+    # aggregates are produced. aggregate_non_cohort is the canonical
+    # emission point, but firing here too defends against the (contrived)
+    # case where the non-cohort table has no distribution metrics yet a
+    # cohort side does. T7 dedupes by exact match, so the duplicate
+    # emission is free.
     if any(m in out for m in _DISTRIBUTION_METRICS):
         notes.append(Note.median_of_medians_approximation())
 

--- a/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/delta.py
+++ b/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/delta.py
@@ -12,7 +12,7 @@ control the wording of any notes (``("baseline", "current")``,
 ``("control", "cohort")``, etc.).
 
 Notes are returned in append order — T7 sorts and dedupes the final
-merged list (see plan §T5 "Notes merge contract"). Do NOT pre-sort.
+merged list (see the notes-merge contract). Do NOT pre-sort.
 
 Percent deltas are decimal fractions, not formatted strings. Rounding
 to 4 decimal places is T7's job; T5 emits full precision.

--- a/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/delta.py
+++ b/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/delta.py
@@ -30,7 +30,7 @@ from .notes import Note
 
 
 # ---------------------------------------------------------------------------
-# Canonical orderings (spec lines 354-364, 332-350)
+# Canonical orderings
 # ---------------------------------------------------------------------------
 CANONICAL_METRIC_ORDER: Tuple[str, ...] = (
     "throughput",
@@ -128,7 +128,7 @@ class DeltaResult:
     notes: List[str] = field(default_factory=list)
 
     def to_dict(self) -> dict:
-        """Render the ``deltas`` subtree per spec §"Output: JSON sidecar".
+        """Render the ``deltas`` subtree for the JSON sidecar.
 
         Scalar metrics map to a flat ``{a, b, abs, pct}`` dict.
         Distribution metrics nest under ``p50`` / ``p75`` / ``p90``
@@ -136,7 +136,7 @@ class DeltaResult:
         order follows :data:`CANONICAL_METRIC_ORDER` because :attr:`rows`
         is already in that order — T7's canonical encoder preserves
         insertion order for the ``deltas`` block (the one intentional
-        exception to the global sort-keys rule, spec lines 507-509).
+        exception to the global sort-keys rule).
         """
         out: dict = {}
         for row in self.rows:
@@ -412,7 +412,7 @@ def _delta_pair(
         return abs_delta, math.inf
     if a_val == 0 and b_val < 0:
         # Unreachable today (flow-metrics emits no negative metrics);
-        # coded for spec completeness, spec lines 326-327.
+        # coded defensively for completeness.
         return abs_delta, -math.inf
     return abs_delta, (b_val - a_val) / a_val
 
@@ -442,9 +442,8 @@ def _maybe_emit_n_note(
     a_label: str,
     b_label: str,
 ) -> None:
-    """Spec lines 338-345. Emits one ``n-differs`` note per metric when
-    the per-side sample counts diverge by more than 10% or are zero on
-    either side.
+    """Emits one ``n-differs`` note per metric when the per-side sample
+    counts diverge by more than 10% or are zero on either side.
 
     Skipped silently when either side lacks an ``n`` / ``denominator``
     field (e.g. a synthetic test fixture). flow-metrics always emits

--- a/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/inputs.py
+++ b/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/inputs.py
@@ -47,7 +47,7 @@ _SCHEMA_VERSION_RE = re.compile(r"\A(\d+)\.(\d+)\Z")
 class InputFile:
     """One validated flow-metrics JSON file.
 
-    Fields mirror the plan §T2 dataclass shape (lines 169-175). Raw
+    Fields mirror the validated-input dataclass shape. Raw
     blocks (``scope``, ``meta``, ``aggregates``) are kept intact for
     downstream consumers; ``scope_kind``, ``window_from``, ``window_to``
     and ``schema_version`` are the parsed/inferred conveniences.
@@ -193,8 +193,8 @@ def load_input(path: Path) -> InputFile:
 
     # flow-metrics emits ``notes`` at the top level (see
     # flow_metrics.notes.NotesCollector + the fixture in
-    # tests/fixtures/proj_alpha/golden.json). The plan §T2 description
-    # mentions ``meta.notes``; we read both for forward-compat with no
+    # tests/fixtures/proj_alpha/golden.json). An older layout used
+    # ``meta.notes``; we read both for forward-compat with no
     # source of truth conflict (only one is present in practice).
     upstream_notes = _coerce_notes_list(
         doc.get("notes", meta.get("notes", [])), basename=basename

--- a/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/inputs.py
+++ b/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/inputs.py
@@ -4,10 +4,10 @@ Reads one flow-metrics JSON, validates the ``meta`` block, infers the
 scope ``kind`` from key presence, and returns an :class:`InputFile`
 dataclass that the three mode-runners (T3/T4) consume.
 
-Validation rules come from ``docs/specs/ai-adoption-report.md`` §
-"Input file validation" (lines 100-146). Every error message names the
-file basename; the basename is the only locator the user reliably
-recognises across the program-mode glob and the single-file modes.
+Validation rules for input file validation are enforced here. Every
+error message names the file basename; the basename is the only
+locator the user reliably recognises across the program-mode glob and
+the single-file modes.
 
 Stdlib only. Read-only — no subprocess, no writes.
 """
@@ -22,9 +22,7 @@ from typing import Any, Iterable, List, Optional, Tuple
 
 from . import ValidationError
 
-# Required meta keys per spec lines 102-105. Order matches the spec
-# sentence so the test parameter set reads top-to-bottom against the
-# spec.
+# Required meta keys. Order matches the documented input contract.
 REQUIRED_META_KEYS: Tuple[str, ...] = (
     "scope",
     "window",
@@ -34,14 +32,14 @@ REQUIRED_META_KEYS: Tuple[str, ...] = (
     "generated_at",
 )
 
-# Spec lines 121-124: YYYY-MM-DD only — no time component, no timezone.
+# Window dates must be YYYY-MM-DD only — no time component, no timezone.
 # ``date.fromisoformat`` accepts ``2026-02-19T00:00:00`` on newer Pythons,
 # so the regex is the first gate; ``date.fromisoformat`` then validates
 # that the YYYY/MM/DD parts form a real calendar date.
 _ISO_DATE_RE = re.compile(r"\A\d{4}-\d{2}-\d{2}\Z")
 
-# Spec lines 114-119: schema_version is ``<int>.<int>``. Anything else
-# exits 2. Trailing ``.0`` is fine (still two parts); ``1.0.0`` is not.
+# schema_version must be ``<int>.<int>``. Anything else exits 2.
+# Trailing ``.0`` is fine (still two parts); ``1.0.0`` is not.
 _SCHEMA_VERSION_RE = re.compile(r"\A(\d+)\.(\d+)\Z")
 
 
@@ -70,12 +68,12 @@ class InputFile:
 
 
 # ---------------------------------------------------------------------------
-# Scope-kind inference (spec lines 130-146).
+# Scope-kind inference.
 # ---------------------------------------------------------------------------
 def infer_scope_kind(scope: dict, *, basename: str) -> str:
     """Return one of the six recognised scope kinds.
 
-    Spec-pinned kinds (spec lines 130-146):
+    Recognised kinds:
     ``portfolio`` / ``program`` / ``project`` / ``project+team``.
 
     Synthesized-only kinds (introduced by T4's per_team flattening of a
@@ -309,12 +307,12 @@ def _coerce_notes_list(value: Any, *, basename: str) -> List[str]:
 def collect_mixed_major_note(inputs: Iterable[InputFile]) -> Optional[str]:
     """Return the ``mixed-major-schema-versions`` note, or ``None``.
 
-    Spec lines 114-118: if input files in the same run disagree on the
-    major component of ``schema_version``, emit a note listing each
-    distinct major and the basenames carrying it. Mixed minors are
-    silently allowed. Lives in :mod:`inputs` (not :mod:`notes`) so the
-    rule itself is testable in isolation from the wording; the wording
-    is delegated to :class:`Note.mixed_major_schema_versions`.
+    If input files in the same run disagree on the major component of
+    ``schema_version``, emit a note listing each distinct major and the
+    basenames carrying it. Mixed minors are silently allowed. Lives in
+    :mod:`inputs` (not :mod:`notes`) so the rule itself is testable in
+    isolation from the wording; the wording is delegated to
+    :class:`Note.mixed_major_schema_versions`.
     """
     # Local import to avoid a module-level cycle if Note ever wants to
     # call back into this module (it doesn't today, but keeping the

--- a/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/inputs.py
+++ b/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/inputs.py
@@ -193,8 +193,8 @@ def load_input(path: Path) -> InputFile:
 
     # flow-metrics emits ``notes`` at the top level (see
     # flow_metrics.notes.NotesCollector + the fixture in
-    # tests/fixtures/proj_alpha/golden.json). An older layout used
-    # ``meta.notes``; we read both for forward-compat with no
+    # tests/fixtures/proj_alpha/golden.json). Some inputs may instead
+    # carry ``meta.notes``; we read both for forward-compat with no
     # source of truth conflict (only one is present in practice).
     upstream_notes = _coerce_notes_list(
         doc.get("notes", meta.get("notes", [])), basename=basename

--- a/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/modes.py
+++ b/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/modes.py
@@ -34,11 +34,11 @@ from .program_discovery import discover_inputs
 
 
 # ---------------------------------------------------------------------------
-# Canonical scope representation (spec lines 510-515)
+# Canonical scope representation
 # ---------------------------------------------------------------------------
 # Temporary home — T7 may relocate when it owns the renderer. Kept here
 # because both header-line assembly (T3) and per-scope-row labels (T6)
-# need the same string and the spec defines it once.
+# need the same string.
 _SCOPE_FIELDS = ("project", "team", "program_id", "portfolio_id")
 
 
@@ -73,7 +73,7 @@ class ReportData:
 
     ``notes`` is the merged unsorted list (T2's mixed-major note +
     T3's drift / per_team / cohort-jql notes + T5's compute_deltas
-    notes). T7 sorts and dedupes the final list per spec line 504.
+    notes). T7 sorts and dedupes the final list.
     """
 
     mode: Literal["baseline", "cohort", "program"]
@@ -115,16 +115,16 @@ def run_baseline(args) -> ReportData:
     if mixed_major is not None:
         notes.append(mixed_major)
 
-    # Spec lines 153-156: exact dict equality on meta.scope.
+    # Exact dict equality on meta.scope is required in baseline mode.
     if baseline.scope != current.scope:
         raise ValidationError(
             "baseline-mode scope mismatch: baseline scope {} vs current "
             "scope {}".format(baseline.scope, current.scope)
         )
 
-    # Spec lines 157-160: baseline.window.to <= current.window.from.
+    # baseline.window.to must be <= current.window.from.
     # ISO YYYY-MM-DD strings compare correctly under lex order
-    # (spec line 127 — string equality is the official match rule).
+    # (string equality is the official match rule).
     if baseline.window_to > current.window_from:
         raise ValidationError(
             "baseline-mode window overlap: baseline {}..{} overlaps "
@@ -134,7 +134,7 @@ def run_baseline(args) -> ReportData:
             )
         )
 
-    # Spec lines 161-165: drift emits a note; deltas still compute.
+    # Config-SHA drift emits a note; deltas still compute.
     if baseline.meta.get("state_config_sha") != current.meta.get("state_config_sha"):
         notes.append(
             Note.config_sha_drift(
@@ -152,15 +152,15 @@ def run_baseline(args) -> ReportData:
             )
         )
 
-    # Spec lines 177-183: per_team is ignored in baseline mode; note
-    # per input that carries one. ``per_team`` arrives as a list (or
-    # None); only non-empty lists trigger the note.
+    # per_team is ignored in baseline mode; note per input that carries
+    # one. ``per_team`` arrives as a list (or None); only non-empty
+    # lists trigger the note.
     for inp in inputs:
         if inp.per_team:
             notes.append(Note.per_team_ignored_in_baseline(inp.basename))
 
-    # Primary deltas (spec §"Delta math"). T5 returns notes unsorted;
-    # T3 concatenates per the notes-merge contract.
+    # Primary deltas. T5 returns notes unsorted; T3 concatenates per
+    # the notes-merge contract.
     primary = compute_deltas(
         baseline.aggregates,
         current.aggregates,
@@ -210,7 +210,7 @@ def _baseline_cohort_section(
 ) -> tuple[Optional[dict], List[str]]:
     """Return ``(cohort_deltas, notes)`` for the optional cohort section.
 
-    Three branches per spec lines 167-175:
+    Three branches:
     1. Either input lacks ``cohort_breakdown`` → no-op + note,
        ``cohort_deltas`` stays ``None``.
     2. Both present but ``meta.cohort_jql`` differs → section omitted,
@@ -256,13 +256,12 @@ def _baseline_cohort_section(
 def run_cohort(args) -> ReportData:
     """Run cohort mode end-to-end and return :class:`ReportData`.
 
-    Side A is ``control`` and side B is ``cohort`` per spec line 194
-    and plan §T3 line 230.
+    Side A is ``control`` and side B is ``cohort``.
     """
     inp = load_input(args.input)
 
     if inp.cohort_breakdown is None:
-        # Spec line 191: literal error string.
+        # Literal error string for missing cohort_breakdown.
         raise ValidationError(
             "--input was not produced with --cohort-jql; no "
             "cohort_breakdown block present"
@@ -314,7 +313,7 @@ def run_program(args) -> ReportData:
     2. T6: ``aggregate_non_cohort`` — program-wide aggregates.
     3. T6: ``aggregate_cohort_side`` (twice) when
        ``--include-cohort-breakdown`` — cohort and control side
-       rollups, computed independently per spec lines 252-311.
+       rollups, computed independently.
     4. T5: ``compute_deltas`` ONCE — only for the cohort-vs-control
        rollup comparison. Program mode's main table is per-scope rows
        + aggregate row, NOT a two-side comparison, so the global
@@ -322,11 +321,10 @@ def run_program(args) -> ReportData:
     5. Mixed-cohort-jql note: emitted when contributing cohort-rollup
        scopes carry distinct ``meta.cohort_jql`` values.
     6. Per-scope rows: every scope in :attr:`ProgramInputs.scopes`,
-       sorted by canonical scope-repr per spec lines 510-513.
-    7. Header line: spec line 439. Kind counting is family-collapsed —
-       ``project+team`` counts as ``project``, ``program+team`` as
-       ``program``, ``portfolio+team`` as ``portfolio``. The spec does
-       not pin this rule; flagged for amendment.
+       sorted by canonical scope-repr.
+    7. Header line. Kind counting is family-collapsed — ``project+team``
+       counts as ``project``, ``program+team`` as ``program``,
+       ``portfolio+team`` as ``portfolio``.
     """
     from_endpoint, to_endpoint = args.window
     program_inputs = discover_inputs(
@@ -340,10 +338,10 @@ def run_program(args) -> ReportData:
     global_agg, non_cohort_notes = aggregate_non_cohort(program_inputs.scopes)
     notes.extend(non_cohort_notes)
 
-    # Spec line 373: throughput is reported as a raw count AND as a
-    # per-week rate. The non-cohort aggregate is the only place this
-    # is computed; cohort-side rollups don't carry a window-normalised
-    # variant (T7's renderer can compute one if it wants).
+    # Throughput is reported as a raw count AND as a per-week rate.
+    # The non-cohort aggregate is the only place this is computed;
+    # cohort-side rollups don't carry a window-normalised variant
+    # (T7's renderer can compute one if it wants).
     if "throughput" in global_agg:
         try:
             d_from = date.fromisoformat(from_endpoint)
@@ -374,10 +372,9 @@ def run_program(args) -> ReportData:
         notes.extend(control_notes)
 
         if cohort_agg is not None and control_agg is not None:
-            # Spec lines 305-308: collect cohort_jql across the scopes
-            # that actually contribute (non-per_team, have
-            # cohort_breakdown). Emit the mixed-cohort-jql note when
-            # >1 distinct value.
+            # Collect cohort_jql across the scopes that actually
+            # contribute (non-per_team, have cohort_breakdown). Emit
+            # the mixed-cohort-jql note when >1 distinct value.
             jql_groups: dict = {}
             for s in program_inputs.scopes:
                 if s.from_per_team or s.cohort_breakdown is None:
@@ -397,7 +394,7 @@ def run_program(args) -> ReportData:
             cohort_deltas = delta_result.to_dict()
             cohort_side_labels = ("control", "cohort")
 
-    # Per-scope rows: canonical sort by scope-repr (spec lines 506-507).
+    # Per-scope rows: canonical sort by scope-repr.
     sorted_scopes = sorted(
         program_inputs.scopes,
         key=lambda s: _program_scope_repr(s.scope, s.scope_kind),
@@ -412,8 +409,8 @@ def run_program(args) -> ReportData:
         for s in sorted_scopes
     ]
 
-    # Header line (spec line 439). Kind counts collapse ``+team`` into
-    # the parent family — flagged in the task report.
+    # Header line. Kind counts collapse ``+team`` into the parent
+    # family.
     kind_counts = {"project": 0, "program": 0, "portfolio": 0}
     for s in program_inputs.scopes:
         family = s.scope_kind.split("+", 1)[0]

--- a/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/modes.py
+++ b/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/modes.py
@@ -7,7 +7,7 @@ render. ``program`` mode (T4/T6) populates the same dataclass with
 :attr:`ReportData.per_scope_rows`; the field is ``None`` for baseline
 and cohort.
 
-Notes-merge contract (plan §T5 lines 355-362): T5 returns its notes
+Notes-merge contract: T5 returns its notes
 unsorted; T3 concatenates them onto :attr:`ReportData.notes` in append
 order. T7 sorts and dedupes the final list — T3 does NOT pre-sort.
 

--- a/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/notes.py
+++ b/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/notes.py
@@ -175,7 +175,7 @@ class Note:
         ``sources`` is an iterable of ``(basename, from_per_team)``
         tuples. ``from_per_team=True`` basenames are annotated with
         ``" (per_team flattened)"`` to distinguish a post-flatten
-        collision (plan lines 287-301) from a pre-flatten duplicate of
+        collision from a pre-flatten duplicate of
         two explicit inputs. The annotation deliberately omits the
         source's parent kind (program/portfolio/project+team) because
         the per_team flattening path admits all three; the source's

--- a/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/notes.py
+++ b/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/notes.py
@@ -9,8 +9,8 @@ The factories are pure formatters — they return strings. Buffering and
 sorting live in a higher layer (T3/T4's report assembly), mirroring the
 ``flow_metrics.notes`` collector-vs-formatter split.
 
-Spec line references point at ``docs/specs/ai-adoption-report.md`` unless
-noted otherwise.
+Note wording is pinned here as the single source of truth for each
+note string emitted by the report.
 
 Stdlib only. Python >= 3.10.
 """
@@ -36,15 +36,14 @@ class Note:
         cls,
         versions_and_basenames: Iterable[Tuple[int, str]],
     ) -> str:
-        """Spec lines 116-118: ``"mixed-major-schema-versions: <list of
-        distinct majors and their input basenames>"``.
+        """Note for mixed major schema versions: ``"mixed-major-schema-versions:
+        <list of distinct majors and their input basenames>"``.
 
         Accepts an iterable of ``(major, basename)`` pairs. Groups by
         major (ascending), sorts basenames lex within each group, and
         renders ``"<major> (<basename>, <basename>)"`` segments joined
-        by ``", "``. The spec pins the prefix but not the precise
-        rendering of the list; this format keeps the output stable
-        across runs (deterministic sort) and human-readable.
+        by ``", "``. The prefix is fixed; this format keeps the output
+        stable across runs (deterministic sort) and human-readable.
 
         Raises ``ValueError`` on empty input or a single-major input.
         The spec only emits this note when majors disagree; calling
@@ -71,16 +70,15 @@ class Note:
     # ------------------------------------------------------------------
     @classmethod
     def config_sha_drift(cls, sha_name: str, a: str, b: str) -> str:
-        """Spec line 163: ``"config-sha-drift: <sha_name> <a> → <b>"``.
+        """Config-SHA drift note: ``"config-sha-drift: <sha_name> <a> → <b>"``.
 
-        ``sha_name`` is ``"state_config_sha"`` or ``"issuetype_config_sha"``;
-        the spec gives both variants under one rule.
+        ``sha_name`` is ``"state_config_sha"`` or ``"issuetype_config_sha"``.
         """
         return "config-sha-drift: {} {} → {}".format(sha_name, a, b)
 
     @classmethod
     def cohort_jql_mismatch(cls, a_jql: str, b_jql: str) -> str:
-        """Spec lines 173-175: ``"cohort-jql-mismatch: <baseline-jql>
+        """Cohort JQL mismatch note: ``"cohort-jql-mismatch: <baseline-jql>
         vs <current-jql>; cohort breakdown comparison omitted"``."""
         return (
             "cohort-jql-mismatch: {} vs {}; cohort breakdown comparison "
@@ -89,12 +87,10 @@ class Note:
 
     @classmethod
     def cohort_breakdown_absent_noop(cls, basenames: Iterable[str]) -> str:
-        """Spec lines 167-172. ``--include-cohort-breakdown`` set in
-        baseline mode but at least one input lacks ``cohort_breakdown``;
-        the flag no-ops.
+        """``--include-cohort-breakdown`` set in baseline mode but at least
+        one input lacks ``cohort_breakdown``; the flag no-ops.
 
-        Spec does not pin the wording verbatim. Literal form chosen by T3
-        (spec reviewers should bless or amend):
+        Literal form:
         ``"cohort-breakdown-absent: cohort_breakdown missing from
         <comma-sep basenames sorted codepoint-ascending>;
         --include-cohort-breakdown no-op"``.
@@ -111,7 +107,7 @@ class Note:
 
     @classmethod
     def per_team_ignored_in_baseline(cls, basename: str) -> str:
-        """Spec lines 180-182: ``"per_team data present in <file>;
+        """Per-team ignored note: ``"per_team data present in <file>;
         ignored in baseline mode (use program mode for multi-team
         rollup)"``."""
         return (
@@ -124,7 +120,7 @@ class Note:
     # ------------------------------------------------------------------
     @classmethod
     def per_team_cohort_deferred(cls, n_rows: int) -> str:
-        """Spec lines 241-244. Literal form:
+        """Per-team cohort deferred note. Literal form:
         ``"per_team-cohort-deferred: N flattened per-team rows have no
         cohort_breakdown; excluded from cohort rollup"``.
 
@@ -140,7 +136,7 @@ class Note:
 
     @classmethod
     def per_team_double_counted(cls, basenames: Iterable[str]) -> str:
-        """Spec lines 246-250. Literal form:
+        """Per-team double-counted note. Literal form:
         ``"per_team-double-counted: <comma-separated input basenames
         whose meta.per_team_double_counted is true, sorted
         codepoint-ascending>; flattened per-team rows may double-count
@@ -168,7 +164,7 @@ class Note:
         scope: dict,
         sources: Iterable[Tuple[str, bool]],
     ) -> str:
-        """Spec lines 222-225. Literal form:
+        """Duplicate scope error. Literal form:
         ``"duplicate scope in input set: <scope dict> in <basename-a>
         and <basename-b>"``.
 
@@ -215,10 +211,8 @@ class Note:
         cls,
         pairs: Iterable[Tuple[Tuple[dict, str], Tuple[dict, str]]],
     ) -> str:
-        """Spec lines 210-228. The spec pins the *behaviour* ("exit 2
-        listing the overlapping scopes") but not a verbatim wording. T4
-        introduces this literal form so the error is a single source of
-        truth across the overlap rules:
+        """Overlapping scopes error. Exit 2 listing the overlapping scopes.
+        Literal form:
 
         ``"overlapping scopes in input set: <a-basename> (<a-scope>) "
         "overlaps <b-basename> (<b-scope>); ..."``
@@ -250,12 +244,8 @@ class Note:
     # ------------------------------------------------------------------
     @classmethod
     def aggregation_zero_denominator(cls, metric: str, side: str) -> str:
-        """Spec lines 377-379. The spec pins the *behaviour* ("zero
-        denominator → cell rendered as em-dash + notes entry") but does
-        NOT pin the literal note wording. T6 introduces this literal
-        form; spec reviewers should bless or amend.
-
-        Literal form (T6-introduced, not spec-pinned):
+        """Aggregation zero denominator note. Zero denominator causes
+        the cell to render as em-dash. Literal form:
         ``"aggregation-zero-denominator: <metric>; weighted-average
         undefined (total weight is zero on <side>)"``.
 
@@ -270,13 +260,11 @@ class Note:
 
     @classmethod
     def median_of_medians_approximation(cls) -> str:
-        """Spec lines 381-384. The spec pins the *behaviour* ("a notes
-        entry on program-mode reports records this and points users to
-        per-scope rows for honest distribution inspection") but NOT a
-        verbatim wording. T6 introduces this literal form; spec
-        reviewers should bless or amend.
+        """Median-of-medians approximation note. Program-mode reports emit
+        this once to flag that distribution aggregates are approximations;
+        readers should inspect per-scope rows for honest distribution detail.
 
-        Literal form (T6-introduced, not spec-pinned):
+        Literal form:
         ``"median-of-medians-approximation: distribution aggregates
         (cycle_time/lead_time/flow_time/flow_efficiency) computed as
         median-of-medians across scopes; see per-scope rows for
@@ -295,7 +283,7 @@ class Note:
         missing_basenames: Iterable[str],
         total: int,
     ) -> str:
-        """Spec lines 302-304. Literal form:
+        """Cohort breakdown missing note. Literal form:
         ``"cohort-breakdown-missing: N of M scopes (basenames: a.json,
         b.json); cohort rollup computed over the remaining M-N"``.
 
@@ -321,7 +309,7 @@ class Note:
 
     @classmethod
     def cohort_breakdown_section_empty(cls) -> str:
-        """Spec line 310. Literal form: ``"cohort-breakdown-section-empty"``."""
+        """Cohort breakdown section empty note. Literal form: ``"cohort-breakdown-section-empty"``."""
         return "cohort-breakdown-section-empty"
 
     @classmethod
@@ -331,7 +319,7 @@ class Note:
         missing_basenames: Iterable[str],
         total: int,
     ) -> str:
-        """Spec lines 289-294. Literal form:
+        """Cohort flow_distribution missing note. Literal form:
         ``"cohort-flow_distribution-missing: side=<cohort|control>
         dropped N of M scopes (basenames: a.json, b.json); defect_ratio
         and flow_distribution rollups computed over the remaining M-N"``.
@@ -358,7 +346,7 @@ class Note:
         cls,
         jqls_and_basenames: Iterable[Tuple[str, Iterable[str]]],
     ) -> str:
-        """Spec lines 305-308. Literal form:
+        """Mixed cohort JQL note. Literal form:
         ``"mixed-cohort-jql: <list of distinct JQLs and their input
         basenames>; rollup proceeds but cohort definitions differ across
         scopes"``.
@@ -393,7 +381,7 @@ class Note:
     # ------------------------------------------------------------------
     @classmethod
     def metric_absent(cls, metric: str, side_label: str) -> str:
-        """Spec lines 110-112: ``"<metric> absent in <file>; cell omitted"``.
+        """Metric absent note: ``"<metric> absent in <file>; cell omitted"``.
 
         T5 calls this when a metric key is present on one side of the
         comparison but missing on the other. ``side_label`` is the
@@ -406,7 +394,7 @@ class Note:
 
     @classmethod
     def metric_null_on_one_side(cls, metric: str, side_label: str) -> str:
-        """Spec line 331: ``"<metric> null in <which-side> for <scope>"``.
+        """Metric null on one side: ``"<metric> null in <which-side> for <scope>"``.
 
         T5 does not know the scope (it operates on raw aggregate dicts),
         so it emits the leading clause only. T3 / T6 may later wrap or
@@ -417,7 +405,7 @@ class Note:
 
     @classmethod
     def metric_zero_both_sides(cls, metric: str) -> str:
-        """Spec lines 323-325: ``"<metric> zero on both sides; percent
+        """Metric zero on both sides: ``"<metric> zero on both sides; percent
         delta undefined"``."""
         return "{} zero on both sides; percent delta undefined".format(metric)
 
@@ -429,15 +417,11 @@ class Note:
         n_b: int,
         side_labels: Tuple[str, str],
     ) -> str:
-        """Spec lines 338-345 (per-side ``n`` differs by more than 10%,
+        """N-differs note (per-side ``n`` differs by more than 10%,
         or zero on either side).
 
-        The spec text describes the *behaviour* ("records the per-side
-        ``n`` values when they differ by more than 10%") but does NOT
-        pin a verbatim wording. T5 introduced the literal form below;
-        spec reviewers should bless or amend.
-
-        Literal form (T5-introduced, not spec-pinned):
+        Records the per-side ``n`` values when they differ by more than 10%.
+        Literal form:
         ``"n-differs: <metric> n=<n_a> in <a_label>, n=<n_b> in <b_label>
         (>10% delta)"``.
         """

--- a/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/program_discovery.py
+++ b/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/program_discovery.py
@@ -6,9 +6,8 @@ into per-scope rows, and emits the program-mode notes. Every error
 names the offending basename(s); every note goes through
 :class:`ai_adoption_report.notes.Note`.
 
-Spec references: ``docs/specs/ai-adoption-report.md`` §"Mode: program"
-(lines 196-250) and §"Scope shape and ``kind`` inference" (lines
-130-146). Plan references: §T4 (lines 239-308).
+Handles program-mode input discovery: glob, filter, dedupe, overlap
+check, per_team flatten, and notes.
 
 Stdlib only. Read-only — no subprocess, no writes.
 """
@@ -33,7 +32,7 @@ class ProgramScope:
     Carries enough state for T6 to drive per-metric aggregation without
     re-reading files. ``from_per_team=True`` rows are synthesised from
     a parent input's ``per_team`` array and are excluded from cohort
-    rollups (spec lines 232-244).
+    rollups (flow-metrics v1 does not split per_team rows by cohort).
     """
 
     scope: dict
@@ -62,7 +61,7 @@ class ProgramInputs:
 
 
 # ---------------------------------------------------------------------------
-# Canonical scope representation (spec lines 510-513).
+# Canonical scope representation.
 # ---------------------------------------------------------------------------
 _CANONICAL_FIELDS: Tuple[str, ...] = ("project", "team", "program_id", "portfolio_id")
 
@@ -86,8 +85,8 @@ def canonical_scope_repr(scope: dict, scope_kind: str) -> str:
     """Return the spec-pinned canonical scope string.
 
     Form: ``kind=<kind>;project=<v>;team=<v>;program_id=<v>;portfolio_id=<v>``
-    with absent fields rendered as the empty string after the ``=``
-    (spec lines 510-513). Used for:
+    with absent fields rendered as the empty string after the ``=``.
+    Used for:
 
     - duplicate-scope detection (group key in :func:`discover_inputs`),
     - per-scope row ordering in T7's Markdown / JSON output,
@@ -115,19 +114,19 @@ def discover_inputs(
 ) -> ProgramInputs:
     """Glob, load, validate, dedupe, overlap-check, and flatten per_team.
 
-    Pipeline (spec §"Mode: program"):
+    Pipeline:
 
-    1. ``directory.glob("*.json")`` — no recursion (spec line 200).
+    1. ``directory.glob("*.json")`` — no recursion.
        Results sorted codepoint-ascending for deterministic errors.
     2. ``load_input`` each (T2). Failures exit 2 naming the basename.
     3. Window filter: ``input.window_from == FROM and
-       input.window_to == TO`` (string equality; spec lines 204-208).
-    4. Empty result → ValidationError (spec line 207).
-    5. Pre-flatten duplicate-scope check (spec lines 222-225).
-    6. Pre-flatten cross-kind overlap check (spec lines 214-228).
+       input.window_to == TO`` (string equality).
+    4. Empty result → ValidationError.
+    5. Pre-flatten duplicate-scope check.
+    6. Pre-flatten cross-kind overlap check.
     7. Build one ProgramScope per surviving input.
-    8. Per-team flattening (spec lines 232-244).
-    9. Post-flatten duplicate-scope safeguard (plan lines 287-301).
+    8. Per-team flattening.
+    9. Post-flatten duplicate-scope safeguard.
     10. Emit notes (per_team-double-counted, per_team-cohort-deferred).
 
     ``window`` is the tuple returned by T1's ``parse_window_flag``.
@@ -177,11 +176,10 @@ def discover_inputs(
 
     notes: List[str] = []
 
-    # Spec lines 246-250: only inputs that actually flattened (per_team
-    # non-empty) AND carry per_team_double_counted=true contribute to
-    # the note. An input with the flag set but no per_team produced no
-    # flattened rows, so the "may double-count" warning would be
-    # misleading. Spec phrasing "in any flattened input" pins this.
+    # Only inputs that actually flattened (per_team non-empty) AND carry
+    # per_team_double_counted=true contribute to the note. An input with
+    # the flag set but no per_team produced no flattened rows, so the
+    # "may double-count" warning would be misleading.
     double_counted_basenames = [
         inp.basename for inp in matching if _double_counted(inp) and inp.per_team
     ]
@@ -200,10 +198,10 @@ def discover_inputs(
 # Duplicate detection
 # ---------------------------------------------------------------------------
 def _check_duplicates_preflatten(inputs: List[InputFile]) -> None:
-    """Spec lines 222-225: across the window-filtered set, two inputs
-    sharing the same ``(scope_kind, canonical_scope_repr)`` exit 2 with
-    both basenames named. If more than two duplicates, all basenames
-    are listed in codepoint-ascending order.
+    """Across the window-filtered set, two inputs sharing the same
+    ``(scope_kind, canonical_scope_repr)`` exit 2 with both basenames
+    named. If more than two duplicates, all basenames are listed in
+    codepoint-ascending order.
     """
     groups: Dict[str, List[Tuple[InputFile, bool]]] = {}
     for inp in inputs:
@@ -278,28 +276,24 @@ def _overlaps(
     scope_b: dict,
     kind_b: str,
 ) -> bool:
-    """Return True if two scopes overlap per spec lines 214-228.
+    """Return True if two scopes overlap.
 
     Order-insensitive. Same-kind pairs are handled by duplicate
-    detection upstream — this function returns ``False`` for them. The
-    spec-pinned rules:
+    detection upstream — this function returns ``False`` for them.
+    Overlap rules:
 
-    - ``portfolio`` family vs any other family → overlap (spec line 218).
-    - ``program`` family vs ``project`` family → overlap (spec line 219).
+    - ``portfolio`` family vs any other family → overlap.
+    - ``program`` family vs ``project`` family → overlap.
     - Within the same family, base vs ``+team`` overlaps iff the parent
-      identifier matches (spec lines 220-221 for ``project`` vs
-      ``project+team``; T4 extends the same rule to ``portfolio`` and
-      ``program`` so explicit ``+team`` inputs of any family Just Work).
+      identifier matches (``project`` vs ``project+team``; the same rule
+      extends to ``portfolio`` and ``program``).
     - Same-kind same-identifier is the duplicate path; same-kind
       different-identifier is no overlap.
 
-    The spec does NOT resolve Jira hierarchy beyond declared scope
-    fields (spec line 229). The synthesised ``portfolio+team`` /
-    ``program+team`` kinds inherit their parent's cross-family rules:
-    portfolio+team overlaps any non-portfolio kind (because the parent
-    portfolio would), program+team overlaps project family (because
-    program would). This is conservative — it never under-reports
-    overlaps.
+    Jira hierarchy beyond declared scope fields is not resolved. The
+    synthesised ``portfolio+team`` / ``program+team`` kinds inherit
+    their parent's cross-family rules (conservative — never
+    under-reports overlaps).
     """
     if kind_a == kind_b:
         return False
@@ -340,17 +334,16 @@ def _check_overlaps(inputs: List[InputFile]) -> None:
 
 
 # ---------------------------------------------------------------------------
-# per_team flattening (spec lines 232-244)
+# per_team flattening
 # ---------------------------------------------------------------------------
 def _flatten_per_team(inputs: List[InputFile]) -> List[ProgramScope]:
     """Synthesise per-team rows for every input carrying a non-empty
     ``per_team`` array.
 
     The source input remains in :class:`ProgramInputs.scopes`; it is
-    not replaced by its flattened children. Spec lines 232-238 read as
-    "both participate in the non-cohort aggregation table", and the
-    plan §T4 lists the original-plus-children pattern as the expected
-    behaviour. Flagged for spec amendment if reviewers disagree.
+    not replaced by its flattened children. Both the original scope and
+    each flattened child participate in the non-cohort aggregation
+    table.
 
     For each ``per_team`` entry:
 
@@ -364,8 +357,8 @@ def _flatten_per_team(inputs: List[InputFile]) -> List[ProgramScope]:
       for a program-scope source, ``portfolio+team`` for a portfolio
       source.
     - ``aggregates`` is the entry's own ``aggregates`` block.
-    - ``cohort_breakdown`` is ``None`` (spec lines 240-244 —
-      ``flow-metrics`` v1 doesn't split per_team rows by cohort).
+    - ``cohort_breakdown`` is ``None`` (``flow-metrics`` v1 doesn't
+      split per_team rows by cohort).
     - ``cohort_jql`` is ``None`` (same reason).
     - ``per_team_double_counted`` propagates from the source input's
       ``meta.per_team_double_counted``.

--- a/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/render.py
+++ b/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/render.py
@@ -586,7 +586,10 @@ def _fmt_cell(value: Any, *, kind: str) -> str:
     """Format one Markdown table cell value.
 
     ``kind`` is one of ``"int" | "float" | "hours" | "percent"``.
-    ``kind`` is one of ``"int" | "float" | "hours" | "percent"``.
+    ``None`` → ``—``; ``percent`` delegates to ``_fmt_percent``; ``int``
+    emits the bare signed integer (4dp shortest-repr if the value arrived
+    as a float); ``float``/``hours`` emit a 4dp trailing-zero-stripped
+    value; infinities render as ``∞``.
     """
     if value is None:
         return "—"

--- a/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/render.py
+++ b/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/render.py
@@ -5,7 +5,7 @@ take a :class:`modes.ReportData` plus a caller-supplied ``title`` and
 ``generated_at`` (T8 supplies the latter; tests stub it) and return the
 final wire strings. No I/O, no clock reads.
 
-Markdown rules (spec lines 388-453, plan lines 463-500):
+Markdown rules:
 
 - Section order fixed; empty sections omitted entirely (no header).
 - Numeric cells: integers bare; floats rounded to 4dp with trailing
@@ -21,7 +21,7 @@ Markdown rules (spec lines 388-453, plan lines 463-500):
   start, which never happens inside a table cell, and dates like
   ``2024-Q1`` and team names like ``Mobile-Web`` are common).
 
-JSON canonicalization (spec lines 495-516, plan lines 502-516):
+JSON canonicalization rules:
 
 - All object keys sorted codepoint-ascending EXCEPT the ``deltas``
   subtree, whose keys follow :data:`delta.CANONICAL_METRIC_ORDER`.
@@ -56,7 +56,8 @@ T7 invariants and decisions (flagged for spec amendment):
    surfaces it.
 4. ``cohort_breakdown`` JSON subtree keys are sorted codepoint-ascending
    (not canonical-metric-order) — only ``deltas`` gets the order
-   exception per spec line 508 ("the one intentional exception").
+   exception (the one intentional exception to the global sort-keys
+   rule).
 
 Stdlib only. Pure functions. Python >= 3.10.
 """
@@ -585,7 +586,7 @@ def _fmt_cell(value: Any, *, kind: str) -> str:
     """Format one Markdown table cell value.
 
     ``kind`` is one of ``"int" | "float" | "hours" | "percent"``.
-    See spec lines 441-453 + plan lines 472-482 for the rules.
+    ``kind`` is one of ``"int" | "float" | "hours" | "percent"``.
     """
     if value is None:
         return "—"
@@ -641,8 +642,8 @@ def _format_float_value(v: float) -> str:
 def _fmt_percent(value: Any) -> str:
     """Format the percent column.
 
-    Per spec lines 446-449: signed with one decimal; ``+0.0%`` for true
-    zero; ``−`` for negative; ``±∞%`` for infinite.
+    Signed with one decimal; ``+0.0%`` for true zero; ``−`` for
+    negative; ``±∞%`` for infinite.
     """
     if value is None:
         return "—"
@@ -675,8 +676,8 @@ def _md_escape(s: str) -> str:
 def _build_inputs_json(inputs: List[InputFile]) -> list[dict]:
     """Build the ``meta.inputs`` array.
 
-    Sorted by basename codepoint-ascending (spec line 502). Each entry
-    carries the per-file provenance fields the spec pins (lines 469-477).
+    Sorted by basename codepoint-ascending. Each entry carries the
+    per-file provenance fields.
     """
     out: list[dict] = []
     for inp in sorted(inputs, key=lambda i: i.basename):

--- a/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/render.py
+++ b/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/render.py
@@ -37,19 +37,19 @@ The deltas-key-order exception is implemented via a sentinel
 placeholder: the document is built with ``deltas`` replaced by a
 unique string, serialized with ``sort_keys=True``, and the placeholder
 is then string-replaced with the separately-serialized canonical-order
-deltas blob (plan line 514-516, "Recommend this over the encoder
-subclass unless you find a cleaner encoder pattern").
+deltas blob (chosen over an encoder subclass unless a cleaner
+encoder pattern emerges).
 
 T7 invariants and decisions (flagged for spec amendment):
 
 1. Summary string is composed by T7 from :attr:`ReportData.deltas` (or
    ``cohort_deltas`` in cohort mode, or scope-count + window in program
-   mode). The spec shows an example (lines 400-402) but doesn't pin the
-   producer; T7 takes the role and emits a best-effort sentence.
+   mode). An example exists but the producer isn't pinned;
+   T7 takes the role and emits a best-effort sentence.
 2. Per-scope table column set: every canonical-order scalar metric +
    every distribution metric's p50 only (p75/p90 elided; readers wanting
-   full percentile detail look at the JSON sidecar). The spec example
-   (line 413) doesn't pin the full column set.
+   full percentile detail look at the JSON sidecar). No example pins
+   the full column set.
 3. Aggregate row: emitted as a final ``"Aggregate"``-labeled row in the
    per-scope table, sourced from :attr:`ReportData.program_aggregates`.
    Spec doesn't require it explicitly; T6 computes the math so this
@@ -82,7 +82,7 @@ from .modes import ReportData
 SKILL_NAME = "ai-adoption-report"
 SKILL_VERSION = "1.0"
 
-# Markdown escape characters per plan §T7 lines 483-498. ASCII hyphen ``-``
+# Markdown escape characters. ASCII hyphen ``-``
 # is deliberately excluded: date strings like ``2024-Q1`` and team names
 # like ``Mobile-Web`` are common, and ``-`` only acquires list-item
 # meaning at line start (never inside a table cell).
@@ -296,7 +296,7 @@ def render_json(
 
 
 # ---------------------------------------------------------------------------
-# Notes merge + finalize (plan §T5 lines 357-362)
+# Notes merge + finalize
 # ---------------------------------------------------------------------------
 def _finalize_notes(notes: Iterable[str]) -> List[str]:
     """Dedupe + codepoint-sort. Used by both renderers so they emit the

--- a/packs/atlassian/.apm/skills/confluence-crawler/references/creds-schema.toml
+++ b/packs/atlassian/.apm/skills/confluence-crawler/references/creds-schema.toml
@@ -1,8 +1,8 @@
 # Credentials schema for the confluence-crawler credentialed primitive.
-# Format pinned by skill-secrets spec § AC24.
+# Format: a [namespace] table plus one [[namespace.keys]] entry per key.
 #
 # Resolution: load_credentials("confluence", required_keys=[...]) walks
-# Tier 1 (env) → Tier 2 (OS keyring) → Tier 3 dotfile per AC4. Env-var
+# Tier 1 (env) → Tier 2 (OS keyring) → Tier 3 dotfile. Env-var
 # shape is <NAMESPACE>_<KEY> — CONFLUENCE_BASE_URL, CONFLUENCE_EMAIL,
 # CONFLUENCE_API_TOKEN, CONFLUENCE_FLAVOR.
 #

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/_credman_windows.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/_credman_windows.py
@@ -1,4 +1,4 @@
-"""Windows Credential Manager Tier-2 backend (spec § AC9-AC12).
+"""Windows Credential Manager Tier-2 backend.
 
 In-process ``ctypes`` against ``advapi32.dll``'s ``CredReadW`` /
 ``CredWriteW`` / ``CredDeleteW`` / ``CredFree`` — stdlib only, no
@@ -15,7 +15,7 @@ zero-initialised via ``ctypes.Structure`` defaults — required by
 NULL when ``AttributeCount`` is 0; ``LastWritten`` is set by the API
 and ignored on write).
 
-Per spec § AC4b the loader imports this module **only** when
+The loader imports this module **only** when
 ``sys.platform == "win32"``. The advapi32 binding is platform-guarded
 below so the module itself stays importable on every platform; tests
 that don't actually call the OS can construct ``CREDENTIAL`` instances
@@ -31,11 +31,11 @@ from ctypes import POINTER, Structure, byref
 
 from .credentials_shim import Tier2HardFailError
 
-# Constants from ``wincred.h`` (spec § AC9):
+# Constants from ``wincred.h``:
 CRED_TYPE_GENERIC = 1
 CRED_PERSIST_LOCAL_MACHINE = 2
 
-# Win32 error codes — sourced from ``winerror.h`` and AC11:
+# Win32 error codes — sourced from ``winerror.h``:
 ERROR_NOT_FOUND = 1168          # falls through to Tier 3
 ERROR_NO_SUCH_LOGON_SESSION = 1312
 ERROR_INVALID_FLAGS = 1004
@@ -44,7 +44,7 @@ ERROR_LOGON_FAILURE = 1326
 TARGET_PREFIX = "agentbundle"
 # Tests can monkeypatch this to a ``tmp_path``-derived value so test
 # target-names can't collide with the developer's real Credential
-# Manager entries (spec § AC35 / plan T5 § Test isolation).
+# Manager entries.
 SERVICE_PREFIX_OVERRIDE: str | None = None
 
 
@@ -53,7 +53,7 @@ class CREDENTIAL(Structure):
 
     Field order and types must match the Win32 ABI exactly — a wrong-
     sized field on Windows returns garbage rather than raising, which
-    is why AC10 mandates a byte-equality round-trip test on every field.
+    is why a byte-equality round-trip test covers every field.
     """
 
     _fields_ = [
@@ -104,18 +104,18 @@ else:
 
 
 def _target_name(namespace: str, key: str) -> str:
-    """Compose the Win32 ``TargetName`` per spec § AC9."""
+    """Compose the Win32 ``TargetName``."""
     prefix = SERVICE_PREFIX_OVERRIDE or TARGET_PREFIX
     return f"{prefix}:{namespace}:{key}"
 
 
 def _classify_last_error(rc: int, op: str) -> None:
-    """Map the Win32 last-error code to the AC11 dispatch matrix.
+    """Map the Win32 last-error code to the dispatch matrix.
 
     ``ERROR_NOT_FOUND`` is the caller's responsibility (it indicates a
     legitimate miss — caller returns ``None``). Every other code on
     this matrix raises ``Tier2HardFailError`` so the resolver does not
-    silently degrade to Tier 3 (spec § Never do).
+    silently degrade to Tier 3.
     """
     if rc == ERROR_NO_SUCH_LOGON_SESSION:
         raise Tier2HardFailError(
@@ -144,7 +144,7 @@ def read_credential(namespace: str, key: str) -> str | None:
 
     Returns ``None`` on ``ERROR_NOT_FOUND`` (resolver falls through to
     Tier 3); raises ``Tier2HardFailError`` on every other documented
-    failure (AC11).
+    failure.
     """
     target = _target_name(namespace, key)
     out_ptr = POINTER(CREDENTIAL)()
@@ -169,7 +169,7 @@ def read_credential(namespace: str, key: str) -> str | None:
 
 
 def write_credential(namespace: str, key: str, value: str) -> None:
-    """Write ``value`` to ``(namespace, key)`` (AC9, AC10).
+    """Write ``value`` to ``(namespace, key)``.
 
     The token is UTF-16-LE encoded and stored in a writable buffer
     pointed to by ``CredentialBlob``; ``CredentialBlobSize`` is the
@@ -183,7 +183,7 @@ def write_credential(namespace: str, key: str, value: str) -> None:
     # All other fields stay at ctypes.Structure's zero-init defaults
     # (Flags=0, Comment=None, LastWritten=FILETIME(0,0),
     # AttributeCount=0, Attributes=None, TargetAlias=None) — required
-    # by CRED_TYPE_GENERIC per spec § AC9.
+    # by CRED_TYPE_GENERIC.
     cred.Type = CRED_TYPE_GENERIC
     cred.TargetName = target
     cred.CredentialBlobSize = len(blob)

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/_keychain_macos.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/_keychain_macos.py
@@ -1,8 +1,8 @@
-"""macOS Keychain Tier-2 backend (spec § AC6-AC8).
+"""macOS Keychain Tier-2 backend.
 
 Stdlib subprocess against ``/usr/bin/security`` — the system-shipped
-Keychain CLI. Guaranteed present on every macOS install per spec §
-Boundaries § Never do (no third-party ``keyring`` dependency).
+Keychain CLI. Guaranteed present on every macOS install (no third-party
+``keyring`` dependency).
 
 Token bytes never reach argv:
 
@@ -16,7 +16,7 @@ Token bytes never reach argv:
 - **Delete** uses ``delete-generic-password`` (idempotent on miss).
 
 The build-projected ``credentials_shim`` imports this module **only**
-when ``sys.platform == "darwin"`` per AC4b. Tests monkeypatch
+when ``sys.platform == "darwin"``. Tests monkeypatch
 ``SERVICE`` to a ``tmp_path``-derived prefix so test entries never
 collide with the developer's real ``agentbundle`` Keychain entries.
 """
@@ -34,9 +34,9 @@ SERVICE = "agentbundle"
 # developer's login Keychain. ``security``'s ``-w`` prompt mode requires
 # ``-w`` as the trailing argv element, which forecloses the trailing-
 # keychain-positional approach to test isolation; the service-prefix
-# approach lets the canonical AC6 argv shape stay untouched.
+# approach lets the canonical argv shape stay untouched.
 
-# macOS Security framework OSStatus codes (spec § AC22):
+# macOS Security framework OSStatus codes:
 #   44      errSecItemNotFound          — legitimate "no such credential",
 #                                         falls through to Tier 3.
 #   45      errSecDuplicateItem         — only relevant on add; the ``-U``
@@ -46,7 +46,7 @@ SERVICE = "agentbundle"
 #
 # Names taken from ``<Security/SecBase.h>``. The two "Keychain locked /
 # unavailable" codes (25308 / -25291) MUST raise ``Tier2HardFailError``
-# so ``run_setup`` can route the AC22 fallback gate — silently
+# so ``run_setup`` can route the fallback gate — silently
 # degrading to Tier 3 defeats the security posture the user chose.
 EXIT_NOT_FOUND = 44
 EXIT_DUPLICATE_ITEM = 45
@@ -62,8 +62,7 @@ def _classify_macos_exit_code(rc: int, op: str) -> str | None:
     embed it in a ``Tier2HardFailError`` message. Returns ``None`` for
     ``EXIT_NOT_FOUND`` (the caller treats that as a legitimate miss).
 
-    Parallel in shape to ``_credman_windows._classify_last_error``;
-    AC22 cites this matrix explicitly.
+    Parallel in shape to ``_credman_windows._classify_last_error``.
     """
     if rc == 0:
         return None
@@ -92,12 +91,12 @@ def _classify_macos_exit_code(rc: int, op: str) -> str | None:
 
 
 def _account(namespace: str, key: str) -> str:
-    """Compose the Keychain account label per spec § AC6."""
+    """Compose the Keychain account label."""
     return f"{namespace}:{key}"
 
 
 def read_credential(namespace: str, key: str) -> str | None:
-    """Read ``(namespace, key)`` from the Keychain (spec § AC6, AC7)."""
+    """Read ``(namespace, key)`` from the Keychain."""
     argv = [
         SECURITY_BIN, "find-generic-password",
         "-s", SERVICE,
@@ -121,7 +120,7 @@ def read_credential(namespace: str, key: str) -> str | None:
 
 def write_credential(namespace: str, key: str, value: str) -> None:
     """Write ``value`` to ``(namespace, key)``. Token enters via child stdin
-    only — never argv (spec § AC6, AC7).
+    only — never argv.
 
     Refuses values containing ``\\n`` or ``\\r`` up front. ``security -w``
     prompts twice and the stdin payload is ``token + b"\\n" + token + b"\\n"``;

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/credentials_shim.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/credentials_shim.py
@@ -13,9 +13,9 @@ Public surface a credentialed-primitive author imports:
 - ``Credentials`` — immutable, attribute-access view of the resolved values.
 - ``EnvParseError`` — raised by ``parse_env_file`` on unsupported syntax.
 
-Stdlib-only per spec § Boundaries § Never do — no ``python-dotenv``, no
+Stdlib-only by design — no ``python-dotenv``, no
 ``keyring``, no third-party imports. The Tier-2 backend is dispatched at
-module-load time per AC4b: ``_keychain_macos`` iff ``sys.platform ==
+module-load time: ``_keychain_macos`` iff ``sys.platform ==
 "darwin"``, ``_credman_windows`` iff ``"win32"``, no Tier-2 backend on
 other platforms (resolver falls through directly to Tier 3).
 
@@ -36,8 +36,8 @@ Trailing ``\\r`` from CRLF line endings is stripped; ``\\r`` *inside* a
 quoted value is preserved (``KEY="a\\rb"`` → ``{"KEY": "a\\rb"}``).
 
 When loaded outside a consumer-skill ``scripts/`` directory — e.g. as
-a sibling under ``~/.agentbundle/bin/`` per the credential-broker-contract
-AC22b companion projection — the shim's own ``_tier2_backend`` resolves
+a sibling under ``~/.agentbundle/bin/`` per the shim companion
+projection — the shim's own ``_tier2_backend`` resolves
 to ``None``. Callers in that context must not rely on ``load_credentials``
 for Tier-2 resolution; that path is the consumer-skill ``scripts/``
 projection only.
@@ -94,7 +94,7 @@ class Tier2HardFailError(Exception):
 class PermissiveAclError(Exception):
     """Raised when the Windows DACL on the Tier-3 dotfile is too permissive.
 
-    Per spec § AC15: ``icacls`` is invoked after each write; non-default
+    ``icacls`` is invoked after each write; non-default
     ACEs (anything beyond the inherited user / ``NT AUTHORITY\\SYSTEM`` /
     ``BUILTIN\\Administrators``) cause the helper to refuse unless
     ``allow_permissive_acl=True`` was passed.
@@ -104,7 +104,7 @@ class PermissiveAclError(Exception):
 class SchemaError(Exception):
     """Raised when a ``creds-schema.toml`` file is malformed or missing.
 
-    Per spec § AC24 / AC24b — names the offending file path and the
+    Names the offending file path and the
     specific shape violation (missing ``[namespace]``, empty
     ``namespace.keys``, non-boolean ``secret``, or unresolvable
     canonical path).
@@ -186,11 +186,11 @@ def parse_env_file(path: pathlib.Path) -> dict[str, str]:
         result[key] = value
     return result
 
-# Tier-2 backend dispatch at module-load time (spec § AC4b). The backend
-# modules are added by T4 (macOS) and T5 (Windows); until they land, the
-# try/except yields ``None`` and the resolver skips Tier 2 on the matching
-# platform. On Linux (and any non-Darwin / non-Windows platform), no import
-# is attempted at all — Tier 2 is unavailable by absence.
+# Tier-2 backend dispatch at module-load time. If a platform's backend
+# module is absent, the try/except yields ``None`` and the resolver skips
+# Tier 2 on the matching platform. On Linux (and any non-Darwin /
+# non-Windows platform), no import is attempted at all — Tier 2 is
+# unavailable by absence.
 if sys.platform == "darwin":
     try:
         from . import _keychain_macos as _tier2_backend  # type: ignore[no-redef]
@@ -208,7 +208,7 @@ else:
 class Credentials:
     """Immutable, attribute-access view of a namespace's resolved credentials.
 
-    Constructed by ``load_credentials``. The contract (spec § AC3) is:
+    Constructed by ``load_credentials``. The contract is:
 
     - Attribute access returns the resolved value:
       ``creds.API_TOKEN`` returns the resolved ``API_TOKEN`` for the
@@ -276,7 +276,7 @@ class Credentials:
 
 
 def _tier1_env(namespace: str, key: str) -> str | None:
-    """Resolve ``<NAMESPACE>_<KEY>`` from ``os.environ`` (spec § AC5).
+    """Resolve ``<NAMESPACE>_<KEY>`` from ``os.environ``.
 
     Empty-string env vars count as unset and return ``None`` so the
     resolver falls through to lower tiers.
@@ -289,12 +289,12 @@ def _tier1_env(namespace: str, key: str) -> str | None:
 
 
 def _tier2(namespace: str, key: str) -> str | None:
-    """Resolve via the platform-specific keyring backend (spec § AC6, AC9).
+    """Resolve via the platform-specific keyring backend.
 
     Returns ``None`` when the backend is absent (non-Darwin / non-Windows
-    platforms, or backend modules not yet shipped) or reports a clean
+    platforms, or backend modules not shipped) or reports a clean
     miss. Hard-fail error codes from the underlying API propagate as
-    ``Tier2HardFailError`` per AC11.
+    ``Tier2HardFailError``.
     """
     if _tier2_backend is None:
         return None
@@ -302,7 +302,7 @@ def _tier2(namespace: str, key: str) -> str | None:
 
 
 def _tier3(namespace: str, key: str) -> str | None:
-    """Resolve from the Tier-3 dotfile (spec § AC13).
+    """Resolve from the Tier-3 dotfile.
 
     Reads ``~/.agentbundle/credentials.env`` via the stdlib parser and
     looks up ``<NAMESPACE>_<KEY>``. Returns ``None`` on miss; a malformed
@@ -317,7 +317,7 @@ def _tier3(namespace: str, key: str) -> str | None:
 
 
 def _dotfile_path() -> pathlib.Path:
-    """Canonical Tier-3 dotfile path per spec § AC13.
+    """Canonical Tier-3 dotfile path.
 
     Resolves to ``pathlib.Path.home() / ".agentbundle" / "credentials.env"``
     on every platform. Tests redirect ``HOME`` (and ``USERPROFILE`` on
@@ -399,7 +399,7 @@ def _verify_icacls(
     path: pathlib.Path, *, allow_permissive_acl: bool = False
 ) -> None:
     """Run ``icacls /findsid`` and refuse if any well-known "broad
-    access" SID is granted access on the path (spec § AC15). No-op on
+    access" SID is granted access on the path. No-op on
     POSIX.
 
     Default ACEs on a per-user file are the inheriting user,
@@ -437,7 +437,7 @@ def _verify_icacls(
 
 
 def _ensure_parent(parent: pathlib.Path) -> None:
-    """Create the dotfile parent at mode 0o700 if absent (spec § AC15).
+    """Create the dotfile parent at mode 0o700 if absent.
 
     If the parent already exists, do **not** rewrite its mode — the
     directory is shared with ``~/.agentbundle/state.toml``.
@@ -465,7 +465,7 @@ def _dotfile_write(
 ) -> None:
     """Write ``(namespace, key) → value`` to the Tier-3 dotfile atomically.
 
-    Atomic write contract per spec § AC14:
+    Atomic write contract:
     ``tempfile.mkstemp(dir=target_dir)`` → ``os.write`` →
     ``os.fchmod`` (POSIX) → ``os.close`` → ``os.replace``. A mid-write
     read sees either the prior contents or the new contents, never
@@ -556,7 +556,7 @@ def load_credentials(
 ) -> Credentials:
     """Resolve ``required_keys`` for ``namespace``, walking Tiers 1 → 2 → 3.
 
-    First-hit-wins per key (spec § AC4): a key resolved at Tier 1 is not
+    First-hit-wins per key: a key resolved at Tier 1 is not
     re-checked at lower tiers; mixing tiers across keys within one
     namespace is permitted.
 
@@ -593,8 +593,8 @@ def load_credentials(
         attempts.append(f"Tier 1: env {env_name!r} not set")
 
         # Tier 2 — OS keyring (when loaded). Tier2HardFailError
-        # propagates per AC11 (no silent fallback to Tier 3 on hard
-        # fail); only a clean miss falls through.
+        # propagates (no silent fallback to Tier 3 on hard fail);
+        # only a clean miss falls through.
         if _tier2_backend is None:
             attempts.append("Tier 2: not loaded (no keyring backend on this platform)")
         else:
@@ -621,8 +621,8 @@ def load_credentials(
         tiers_tried[key] = attempts
 
     if missing:
-        # One-line preamble preserves the AC3 contract (message names
-        # namespace and the missing-keys list); the per-key trailer
+        # One-line preamble names the namespace and the missing-keys
+        # list; the per-key trailer
         # block comes below for triage.
         lines = [
             f"namespace {namespace!r}: missing required credential(s): "
@@ -641,7 +641,7 @@ def load_credentials(
     return Credentials(namespace, resolved)
 
 
-# ── creds-schema.toml parser (spec § AC24, AC24b) ─────────────────────
+# ── creds-schema.toml parser ──────────────────────────────────────────
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -649,7 +649,7 @@ class KeyDef:
     """A single required key declared in ``creds-schema.toml``.
 
     ``secret=True`` keys are prompted via ``getpass.getpass`` (no echo);
-    ``secret=False`` keys are prompted via ``input()`` per spec § AC24.
+    ``secret=False`` keys are prompted via ``input()``.
     """
 
     name: str
@@ -668,7 +668,7 @@ class CredsSchema:
 def _parse_schema(path: pathlib.Path) -> CredsSchema:
     """Parse a ``creds-schema.toml`` file into a typed ``CredsSchema``.
 
-    Per spec § AC24, the expected shape is::
+    The expected shape is::
 
         [namespace]
         name = "<namespace>"
@@ -733,7 +733,7 @@ _SKILL_MD_RE = re.compile(r"^\.claude/skills/([^/]+)/SKILL\.md$")
 def _relative_schema_path(
     state: "object", pack: str, skill_name: str
 ) -> pathlib.Path:
-    """Resolve the *state-relative* ``creds-schema.toml`` path per spec § AC24b.
+    """Resolve the *state-relative* ``creds-schema.toml`` path.
 
     Walks ``state.packs[pack].files`` for a relpath matching
     ``^\\.claude/skills/<skill_name>/SKILL\\.md$``; returns the
@@ -745,7 +745,7 @@ def _relative_schema_path(
     underscore-prefixed name reflects that contract; CLI callers go
     through `commands/creds._resolve_schema_for_namespace` which joins
     against `SKILL.md.parent` directly instead of calling this helper.
-    Kept around because it pins the AC24b state-walk shape with its
+    Kept around because it pins the state-walk shape with its
     own tests.
 
     Raises ``SchemaError`` if no matching SKILL.md row is in

--- a/packs/atlassian/.apm/skills/confluence-publisher/references/creds-schema.toml
+++ b/packs/atlassian/.apm/skills/confluence-publisher/references/creds-schema.toml
@@ -1,11 +1,11 @@
 # Credentials schema for the confluence-publisher credentialed primitive.
-# Format pinned by skill-secrets spec § AC24.
+# Format: a [namespace] table plus one [[namespace.keys]] entry per key.
 #
 # Shares the `confluence` namespace with confluence-crawler — running
 # `credential-setup` skill once configures both skills.
 #
 # Resolution: load_credentials("confluence", required_keys=[...]) walks
-# Tier 1 (env) → Tier 2 (OS keyring) → Tier 3 dotfile per AC4. Env-var
+# Tier 1 (env) → Tier 2 (OS keyring) → Tier 3 dotfile. Env-var
 # shape is <NAMESPACE>_<KEY> — CONFLUENCE_BASE_URL, CONFLUENCE_EMAIL,
 # CONFLUENCE_API_TOKEN, CONFLUENCE_FLAVOR.
 #

--- a/packs/atlassian/.apm/skills/confluence-publisher/scripts/_credman_windows.py
+++ b/packs/atlassian/.apm/skills/confluence-publisher/scripts/_credman_windows.py
@@ -1,4 +1,4 @@
-"""Windows Credential Manager Tier-2 backend (spec § AC9-AC12).
+"""Windows Credential Manager Tier-2 backend.
 
 In-process ``ctypes`` against ``advapi32.dll``'s ``CredReadW`` /
 ``CredWriteW`` / ``CredDeleteW`` / ``CredFree`` — stdlib only, no
@@ -15,7 +15,7 @@ zero-initialised via ``ctypes.Structure`` defaults — required by
 NULL when ``AttributeCount`` is 0; ``LastWritten`` is set by the API
 and ignored on write).
 
-Per spec § AC4b the loader imports this module **only** when
+The loader imports this module **only** when
 ``sys.platform == "win32"``. The advapi32 binding is platform-guarded
 below so the module itself stays importable on every platform; tests
 that don't actually call the OS can construct ``CREDENTIAL`` instances
@@ -31,11 +31,11 @@ from ctypes import POINTER, Structure, byref
 
 from .credentials_shim import Tier2HardFailError
 
-# Constants from ``wincred.h`` (spec § AC9):
+# Constants from ``wincred.h``:
 CRED_TYPE_GENERIC = 1
 CRED_PERSIST_LOCAL_MACHINE = 2
 
-# Win32 error codes — sourced from ``winerror.h`` and AC11:
+# Win32 error codes — sourced from ``winerror.h``:
 ERROR_NOT_FOUND = 1168          # falls through to Tier 3
 ERROR_NO_SUCH_LOGON_SESSION = 1312
 ERROR_INVALID_FLAGS = 1004
@@ -44,7 +44,7 @@ ERROR_LOGON_FAILURE = 1326
 TARGET_PREFIX = "agentbundle"
 # Tests can monkeypatch this to a ``tmp_path``-derived value so test
 # target-names can't collide with the developer's real Credential
-# Manager entries (spec § AC35 / plan T5 § Test isolation).
+# Manager entries.
 SERVICE_PREFIX_OVERRIDE: str | None = None
 
 
@@ -53,7 +53,7 @@ class CREDENTIAL(Structure):
 
     Field order and types must match the Win32 ABI exactly — a wrong-
     sized field on Windows returns garbage rather than raising, which
-    is why AC10 mandates a byte-equality round-trip test on every field.
+    is why a byte-equality round-trip test covers every field.
     """
 
     _fields_ = [
@@ -104,18 +104,18 @@ else:
 
 
 def _target_name(namespace: str, key: str) -> str:
-    """Compose the Win32 ``TargetName`` per spec § AC9."""
+    """Compose the Win32 ``TargetName``."""
     prefix = SERVICE_PREFIX_OVERRIDE or TARGET_PREFIX
     return f"{prefix}:{namespace}:{key}"
 
 
 def _classify_last_error(rc: int, op: str) -> None:
-    """Map the Win32 last-error code to the AC11 dispatch matrix.
+    """Map the Win32 last-error code to the dispatch matrix.
 
     ``ERROR_NOT_FOUND`` is the caller's responsibility (it indicates a
     legitimate miss — caller returns ``None``). Every other code on
     this matrix raises ``Tier2HardFailError`` so the resolver does not
-    silently degrade to Tier 3 (spec § Never do).
+    silently degrade to Tier 3.
     """
     if rc == ERROR_NO_SUCH_LOGON_SESSION:
         raise Tier2HardFailError(
@@ -144,7 +144,7 @@ def read_credential(namespace: str, key: str) -> str | None:
 
     Returns ``None`` on ``ERROR_NOT_FOUND`` (resolver falls through to
     Tier 3); raises ``Tier2HardFailError`` on every other documented
-    failure (AC11).
+    failure.
     """
     target = _target_name(namespace, key)
     out_ptr = POINTER(CREDENTIAL)()
@@ -169,7 +169,7 @@ def read_credential(namespace: str, key: str) -> str | None:
 
 
 def write_credential(namespace: str, key: str, value: str) -> None:
-    """Write ``value`` to ``(namespace, key)`` (AC9, AC10).
+    """Write ``value`` to ``(namespace, key)``.
 
     The token is UTF-16-LE encoded and stored in a writable buffer
     pointed to by ``CredentialBlob``; ``CredentialBlobSize`` is the
@@ -183,7 +183,7 @@ def write_credential(namespace: str, key: str, value: str) -> None:
     # All other fields stay at ctypes.Structure's zero-init defaults
     # (Flags=0, Comment=None, LastWritten=FILETIME(0,0),
     # AttributeCount=0, Attributes=None, TargetAlias=None) — required
-    # by CRED_TYPE_GENERIC per spec § AC9.
+    # by CRED_TYPE_GENERIC.
     cred.Type = CRED_TYPE_GENERIC
     cred.TargetName = target
     cred.CredentialBlobSize = len(blob)

--- a/packs/atlassian/.apm/skills/confluence-publisher/scripts/_keychain_macos.py
+++ b/packs/atlassian/.apm/skills/confluence-publisher/scripts/_keychain_macos.py
@@ -1,8 +1,8 @@
-"""macOS Keychain Tier-2 backend (spec § AC6-AC8).
+"""macOS Keychain Tier-2 backend.
 
 Stdlib subprocess against ``/usr/bin/security`` — the system-shipped
-Keychain CLI. Guaranteed present on every macOS install per spec §
-Boundaries § Never do (no third-party ``keyring`` dependency).
+Keychain CLI. Guaranteed present on every macOS install (no third-party
+``keyring`` dependency).
 
 Token bytes never reach argv:
 
@@ -16,7 +16,7 @@ Token bytes never reach argv:
 - **Delete** uses ``delete-generic-password`` (idempotent on miss).
 
 The build-projected ``credentials_shim`` imports this module **only**
-when ``sys.platform == "darwin"`` per AC4b. Tests monkeypatch
+when ``sys.platform == "darwin"``. Tests monkeypatch
 ``SERVICE`` to a ``tmp_path``-derived prefix so test entries never
 collide with the developer's real ``agentbundle`` Keychain entries.
 """
@@ -34,9 +34,9 @@ SERVICE = "agentbundle"
 # developer's login Keychain. ``security``'s ``-w`` prompt mode requires
 # ``-w`` as the trailing argv element, which forecloses the trailing-
 # keychain-positional approach to test isolation; the service-prefix
-# approach lets the canonical AC6 argv shape stay untouched.
+# approach lets the canonical argv shape stay untouched.
 
-# macOS Security framework OSStatus codes (spec § AC22):
+# macOS Security framework OSStatus codes:
 #   44      errSecItemNotFound          — legitimate "no such credential",
 #                                         falls through to Tier 3.
 #   45      errSecDuplicateItem         — only relevant on add; the ``-U``
@@ -46,7 +46,7 @@ SERVICE = "agentbundle"
 #
 # Names taken from ``<Security/SecBase.h>``. The two "Keychain locked /
 # unavailable" codes (25308 / -25291) MUST raise ``Tier2HardFailError``
-# so ``run_setup`` can route the AC22 fallback gate — silently
+# so ``run_setup`` can route the fallback gate — silently
 # degrading to Tier 3 defeats the security posture the user chose.
 EXIT_NOT_FOUND = 44
 EXIT_DUPLICATE_ITEM = 45
@@ -62,8 +62,7 @@ def _classify_macos_exit_code(rc: int, op: str) -> str | None:
     embed it in a ``Tier2HardFailError`` message. Returns ``None`` for
     ``EXIT_NOT_FOUND`` (the caller treats that as a legitimate miss).
 
-    Parallel in shape to ``_credman_windows._classify_last_error``;
-    AC22 cites this matrix explicitly.
+    Parallel in shape to ``_credman_windows._classify_last_error``.
     """
     if rc == 0:
         return None
@@ -92,12 +91,12 @@ def _classify_macos_exit_code(rc: int, op: str) -> str | None:
 
 
 def _account(namespace: str, key: str) -> str:
-    """Compose the Keychain account label per spec § AC6."""
+    """Compose the Keychain account label."""
     return f"{namespace}:{key}"
 
 
 def read_credential(namespace: str, key: str) -> str | None:
-    """Read ``(namespace, key)`` from the Keychain (spec § AC6, AC7)."""
+    """Read ``(namespace, key)`` from the Keychain."""
     argv = [
         SECURITY_BIN, "find-generic-password",
         "-s", SERVICE,
@@ -121,7 +120,7 @@ def read_credential(namespace: str, key: str) -> str | None:
 
 def write_credential(namespace: str, key: str, value: str) -> None:
     """Write ``value`` to ``(namespace, key)``. Token enters via child stdin
-    only — never argv (spec § AC6, AC7).
+    only — never argv.
 
     Refuses values containing ``\\n`` or ``\\r`` up front. ``security -w``
     prompts twice and the stdin payload is ``token + b"\\n" + token + b"\\n"``;

--- a/packs/atlassian/.apm/skills/confluence-publisher/scripts/credentials_shim.py
+++ b/packs/atlassian/.apm/skills/confluence-publisher/scripts/credentials_shim.py
@@ -13,9 +13,9 @@ Public surface a credentialed-primitive author imports:
 - ``Credentials`` — immutable, attribute-access view of the resolved values.
 - ``EnvParseError`` — raised by ``parse_env_file`` on unsupported syntax.
 
-Stdlib-only per spec § Boundaries § Never do — no ``python-dotenv``, no
+Stdlib-only by design — no ``python-dotenv``, no
 ``keyring``, no third-party imports. The Tier-2 backend is dispatched at
-module-load time per AC4b: ``_keychain_macos`` iff ``sys.platform ==
+module-load time: ``_keychain_macos`` iff ``sys.platform ==
 "darwin"``, ``_credman_windows`` iff ``"win32"``, no Tier-2 backend on
 other platforms (resolver falls through directly to Tier 3).
 
@@ -36,8 +36,8 @@ Trailing ``\\r`` from CRLF line endings is stripped; ``\\r`` *inside* a
 quoted value is preserved (``KEY="a\\rb"`` → ``{"KEY": "a\\rb"}``).
 
 When loaded outside a consumer-skill ``scripts/`` directory — e.g. as
-a sibling under ``~/.agentbundle/bin/`` per the credential-broker-contract
-AC22b companion projection — the shim's own ``_tier2_backend`` resolves
+a sibling under ``~/.agentbundle/bin/`` per the shim companion
+projection — the shim's own ``_tier2_backend`` resolves
 to ``None``. Callers in that context must not rely on ``load_credentials``
 for Tier-2 resolution; that path is the consumer-skill ``scripts/``
 projection only.
@@ -94,7 +94,7 @@ class Tier2HardFailError(Exception):
 class PermissiveAclError(Exception):
     """Raised when the Windows DACL on the Tier-3 dotfile is too permissive.
 
-    Per spec § AC15: ``icacls`` is invoked after each write; non-default
+    ``icacls`` is invoked after each write; non-default
     ACEs (anything beyond the inherited user / ``NT AUTHORITY\\SYSTEM`` /
     ``BUILTIN\\Administrators``) cause the helper to refuse unless
     ``allow_permissive_acl=True`` was passed.
@@ -104,7 +104,7 @@ class PermissiveAclError(Exception):
 class SchemaError(Exception):
     """Raised when a ``creds-schema.toml`` file is malformed or missing.
 
-    Per spec § AC24 / AC24b — names the offending file path and the
+    Names the offending file path and the
     specific shape violation (missing ``[namespace]``, empty
     ``namespace.keys``, non-boolean ``secret``, or unresolvable
     canonical path).
@@ -186,11 +186,11 @@ def parse_env_file(path: pathlib.Path) -> dict[str, str]:
         result[key] = value
     return result
 
-# Tier-2 backend dispatch at module-load time (spec § AC4b). The backend
-# modules are added by T4 (macOS) and T5 (Windows); until they land, the
-# try/except yields ``None`` and the resolver skips Tier 2 on the matching
-# platform. On Linux (and any non-Darwin / non-Windows platform), no import
-# is attempted at all — Tier 2 is unavailable by absence.
+# Tier-2 backend dispatch at module-load time. If a platform's backend
+# module is absent, the try/except yields ``None`` and the resolver skips
+# Tier 2 on the matching platform. On Linux (and any non-Darwin /
+# non-Windows platform), no import is attempted at all — Tier 2 is
+# unavailable by absence.
 if sys.platform == "darwin":
     try:
         from . import _keychain_macos as _tier2_backend  # type: ignore[no-redef]
@@ -208,7 +208,7 @@ else:
 class Credentials:
     """Immutable, attribute-access view of a namespace's resolved credentials.
 
-    Constructed by ``load_credentials``. The contract (spec § AC3) is:
+    Constructed by ``load_credentials``. The contract is:
 
     - Attribute access returns the resolved value:
       ``creds.API_TOKEN`` returns the resolved ``API_TOKEN`` for the
@@ -276,7 +276,7 @@ class Credentials:
 
 
 def _tier1_env(namespace: str, key: str) -> str | None:
-    """Resolve ``<NAMESPACE>_<KEY>`` from ``os.environ`` (spec § AC5).
+    """Resolve ``<NAMESPACE>_<KEY>`` from ``os.environ``.
 
     Empty-string env vars count as unset and return ``None`` so the
     resolver falls through to lower tiers.
@@ -289,12 +289,12 @@ def _tier1_env(namespace: str, key: str) -> str | None:
 
 
 def _tier2(namespace: str, key: str) -> str | None:
-    """Resolve via the platform-specific keyring backend (spec § AC6, AC9).
+    """Resolve via the platform-specific keyring backend.
 
     Returns ``None`` when the backend is absent (non-Darwin / non-Windows
-    platforms, or backend modules not yet shipped) or reports a clean
+    platforms, or backend modules not shipped) or reports a clean
     miss. Hard-fail error codes from the underlying API propagate as
-    ``Tier2HardFailError`` per AC11.
+    ``Tier2HardFailError``.
     """
     if _tier2_backend is None:
         return None
@@ -302,7 +302,7 @@ def _tier2(namespace: str, key: str) -> str | None:
 
 
 def _tier3(namespace: str, key: str) -> str | None:
-    """Resolve from the Tier-3 dotfile (spec § AC13).
+    """Resolve from the Tier-3 dotfile.
 
     Reads ``~/.agentbundle/credentials.env`` via the stdlib parser and
     looks up ``<NAMESPACE>_<KEY>``. Returns ``None`` on miss; a malformed
@@ -317,7 +317,7 @@ def _tier3(namespace: str, key: str) -> str | None:
 
 
 def _dotfile_path() -> pathlib.Path:
-    """Canonical Tier-3 dotfile path per spec § AC13.
+    """Canonical Tier-3 dotfile path.
 
     Resolves to ``pathlib.Path.home() / ".agentbundle" / "credentials.env"``
     on every platform. Tests redirect ``HOME`` (and ``USERPROFILE`` on
@@ -399,7 +399,7 @@ def _verify_icacls(
     path: pathlib.Path, *, allow_permissive_acl: bool = False
 ) -> None:
     """Run ``icacls /findsid`` and refuse if any well-known "broad
-    access" SID is granted access on the path (spec § AC15). No-op on
+    access" SID is granted access on the path. No-op on
     POSIX.
 
     Default ACEs on a per-user file are the inheriting user,
@@ -437,7 +437,7 @@ def _verify_icacls(
 
 
 def _ensure_parent(parent: pathlib.Path) -> None:
-    """Create the dotfile parent at mode 0o700 if absent (spec § AC15).
+    """Create the dotfile parent at mode 0o700 if absent.
 
     If the parent already exists, do **not** rewrite its mode — the
     directory is shared with ``~/.agentbundle/state.toml``.
@@ -465,7 +465,7 @@ def _dotfile_write(
 ) -> None:
     """Write ``(namespace, key) → value`` to the Tier-3 dotfile atomically.
 
-    Atomic write contract per spec § AC14:
+    Atomic write contract:
     ``tempfile.mkstemp(dir=target_dir)`` → ``os.write`` →
     ``os.fchmod`` (POSIX) → ``os.close`` → ``os.replace``. A mid-write
     read sees either the prior contents or the new contents, never
@@ -556,7 +556,7 @@ def load_credentials(
 ) -> Credentials:
     """Resolve ``required_keys`` for ``namespace``, walking Tiers 1 → 2 → 3.
 
-    First-hit-wins per key (spec § AC4): a key resolved at Tier 1 is not
+    First-hit-wins per key: a key resolved at Tier 1 is not
     re-checked at lower tiers; mixing tiers across keys within one
     namespace is permitted.
 
@@ -593,8 +593,8 @@ def load_credentials(
         attempts.append(f"Tier 1: env {env_name!r} not set")
 
         # Tier 2 — OS keyring (when loaded). Tier2HardFailError
-        # propagates per AC11 (no silent fallback to Tier 3 on hard
-        # fail); only a clean miss falls through.
+        # propagates (no silent fallback to Tier 3 on hard fail);
+        # only a clean miss falls through.
         if _tier2_backend is None:
             attempts.append("Tier 2: not loaded (no keyring backend on this platform)")
         else:
@@ -621,8 +621,8 @@ def load_credentials(
         tiers_tried[key] = attempts
 
     if missing:
-        # One-line preamble preserves the AC3 contract (message names
-        # namespace and the missing-keys list); the per-key trailer
+        # One-line preamble names the namespace and the missing-keys
+        # list; the per-key trailer
         # block comes below for triage.
         lines = [
             f"namespace {namespace!r}: missing required credential(s): "
@@ -641,7 +641,7 @@ def load_credentials(
     return Credentials(namespace, resolved)
 
 
-# ── creds-schema.toml parser (spec § AC24, AC24b) ─────────────────────
+# ── creds-schema.toml parser ──────────────────────────────────────────
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -649,7 +649,7 @@ class KeyDef:
     """A single required key declared in ``creds-schema.toml``.
 
     ``secret=True`` keys are prompted via ``getpass.getpass`` (no echo);
-    ``secret=False`` keys are prompted via ``input()`` per spec § AC24.
+    ``secret=False`` keys are prompted via ``input()``.
     """
 
     name: str
@@ -668,7 +668,7 @@ class CredsSchema:
 def _parse_schema(path: pathlib.Path) -> CredsSchema:
     """Parse a ``creds-schema.toml`` file into a typed ``CredsSchema``.
 
-    Per spec § AC24, the expected shape is::
+    The expected shape is::
 
         [namespace]
         name = "<namespace>"
@@ -733,7 +733,7 @@ _SKILL_MD_RE = re.compile(r"^\.claude/skills/([^/]+)/SKILL\.md$")
 def _relative_schema_path(
     state: "object", pack: str, skill_name: str
 ) -> pathlib.Path:
-    """Resolve the *state-relative* ``creds-schema.toml`` path per spec § AC24b.
+    """Resolve the *state-relative* ``creds-schema.toml`` path.
 
     Walks ``state.packs[pack].files`` for a relpath matching
     ``^\\.claude/skills/<skill_name>/SKILL\\.md$``; returns the
@@ -745,7 +745,7 @@ def _relative_schema_path(
     underscore-prefixed name reflects that contract; CLI callers go
     through `commands/creds._resolve_schema_for_namespace` which joins
     against `SKILL.md.parent` directly instead of calling this helper.
-    Kept around because it pins the AC24b state-walk shape with its
+    Kept around because it pins the state-walk shape with its
     own tests.
 
     Raises ``SchemaError`` if no matching SKILL.md row is in

--- a/packs/atlassian/.apm/skills/flow-metrics/SKILL.md
+++ b/packs/atlassian/.apm/skills/flow-metrics/SKILL.md
@@ -23,10 +23,9 @@ verbs or replicate them inline.
 
 The pipeline (config validation, scope JQL, changelog walk, per-issue
 derivation, aggregation, cohort split, per-team rollup, notes, meta,
-output rendering, caching) lives in `scripts/flow_metrics/` — the
-canonical reference is `docs/specs/flow-metrics.md`. This SKILL.md tells
-the agent how to **invoke** the CLI for common flows; for design
-questions, read the spec.
+output rendering, caching) lives in `scripts/flow_metrics/`. This SKILL.md
+tells the agent how to **invoke** the CLI for common flows; for design
+details, read the inline module docstrings.
 
 ## Cross-skill invocation — name, not path
 
@@ -84,7 +83,7 @@ flow_metrics` if you're invoking from a clone.
 
 ### CLI flags
 
-The full surface, lifted from `docs/specs/flow-metrics.md` §"Inputs":
+The full flag surface:
 
 - **`--project KEY`** — Jira project key. Mutually exclusive with
   `--program-id` / `--portfolio-id`.
@@ -227,10 +226,9 @@ JSONL on disk, one row per in-scope issue. Downstream consumers
 ## Don't
 
 - **Don't bypass the upstream-skill allowlist.** This skill invokes
-  only the verbs and `raw GET` paths spelled out in spec §"Read-only
-  contract — upstream-skill allowlist". Any other invocation is a
-  regression. If a verb is missing, extend the `jira` or `jira-align`
-  skill — don't shim around it here.
+  only the allowlisted verbs and `raw GET` paths. Any other invocation
+  is a regression. If a verb is missing, extend the `jira` or
+  `jira-align` skill — don't shim around it here.
 - **Don't read `credentials.env` from this skill.** Credentials live
   in the `jira` / `jira-align` skills and are isolated from this one.
   Authentication failures surface as upstream exit 3; the fix is to
@@ -254,20 +252,20 @@ JSONL on disk, one row per in-scope issue. Downstream consumers
   collapses whitespace; two semantically equivalent JQL expressions
   with different clause order produce different cache files. That's
   the documented v1 trade.
-- **Don't paraphrase the metric definitions.** They are spec-pinned
-  and tested. If a metric "feels wrong", read spec §"Metric
-  definitions" before changing anything.
+- **Don't paraphrase the metric definitions.** They are pinned
+  and tested. If a metric "feels wrong", read the module docstrings
+  before changing anything.
 
 ## Security rules
 
 This skill operates under a **read-only contract** with credential
 isolation:
 
-- **Read-only contract:** the upstream-skill allowlist (spec §"Read-
-  only contract") names every verb and `raw GET` path this skill is
-  permitted to invoke. Any other upstream invocation, including the
-  `raw POST` / `PUT` / `PATCH` / `DELETE` escape hatches, is forbidden
-  and enforced by a contract test that wraps the upstream skills.
+- **Read-only contract:** the upstream-skill allowlist names every
+  verb and `raw GET` path this skill is permitted to invoke. Any other
+  upstream invocation, including the `raw POST` / `PUT` / `PATCH` /
+  `DELETE` escape hatches, is forbidden and enforced by a contract test
+  that wraps the upstream skills.
 - **Credential isolation:** this skill **never reads
   `credentials.env`** or any other secret file directly. Credentials
   belong to the `jira` / `jira-align` skills; this skill invokes them
@@ -286,7 +284,7 @@ isolation:
 
 ## Edge cases
 
-A short pointer; the full enumeration lives in spec §"Edge cases".
+The key edge cases to know about:
 
 - **Cancelled issues.** An issue transitioning into a
   `terminal_non_delivery_states` canonical state (default: `cancelled`)
@@ -351,14 +349,13 @@ rounded to 4 decimal places, per_team sorted by team name codepoint.
 The schema does **not** re-validate canonicalisation rules — those are
 enforced by the renderer's contract tests in T10.
 
-## Spec reference
+## Further reading
 
-See `docs/specs/flow-metrics.md` for:
+The module docstrings in `scripts/flow_metrics/` cover:
 
-- the full Inputs table,
-- metric definitions and core population predicates,
-- the upstream-skill allowlist (verbs and `raw GET` paths),
-- state-config and issuetype-config schemas,
-- canonicalisation rules,
-- cache-key derivation,
-- the complete edge-case enumeration.
+- metric definitions and core population predicates (`predicates.py`, `aggregate.py`),
+- the upstream-skill allowlist and verbs (`upstream.py`),
+- state-config and issuetype-config schemas (`config.py`),
+- canonicalisation rules and output rendering (`output.py`),
+- cache-key derivation (`cache.py`),
+- edge-case handling (`per_issue.py`, `notes.py`).

--- a/packs/atlassian/.apm/skills/flow-metrics/references/output.schema.json
+++ b/packs/atlassian/.apm/skills/flow-metrics/references/output.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "urn:atlassian-pack:flow-metrics:output.schema.json",
   "title": "flow-metrics canonical output",
-  "description": "Wire shape for the aggregate-mode JSON output of the flow-metrics CLI. Matches docs/specs/flow-metrics.md §\"Outputs\". The schema does not re-validate canonicalisation rules (key sort order, float rounding); those live in T10's renderer contract tests. Per-issue mode (--per-issue) emits JSONL with a different shape and is not covered here.",
+  "description": "Wire shape for the aggregate-mode JSON output of the flow-metrics CLI. The schema does not re-validate canonicalisation rules (key sort order, float rounding); those are covered by the renderer contract tests. Per-issue mode (--per-issue) emits JSONL with a different shape and is not covered here.",
   "type": "object",
   "required": ["meta", "aggregates", "notes"],
   "additionalProperties": false,

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/__init__.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/__init__.py
@@ -719,8 +719,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         print("error: {}".format(e), file=sys.stderr)
         return EXIT_VALIDATION
     except _UnmappedStatusError as e:
-        # Spec § "Unmapped-status policy": data-dependent exit 2 naming
-        # the offending raw status. The exception message already does so.
+        # Unmapped-status policy: data-dependent exit 2 naming the
+        # offending raw status. The exception message already does so.
         print("error: {}".format(e), file=sys.stderr)
         return EXIT_VALIDATION
     except ValueError as e:

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/align.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/align.py
@@ -3,8 +3,8 @@
 Resolves team membership for program-id / portfolio-id scope runs via
 the ``jira-align`` skill's nested-resource ``raw GET`` endpoints, then
 hands the resulting team-id list to the Jira side for the actual issue
-query (per spec § "Data sources": Jira Align supplies team membership;
-Jira's changelog supplies the metrics).
+query (Jira Align supplies team membership; Jira's changelog supplies
+the metrics).
 
 Allowlist alignment: every endpoint touched here is also enumerated in
 :class:`flow_metrics.upstream.JiraAlignClient._ALLOWED_RAW_PATTERNS`, so
@@ -92,7 +92,7 @@ def validate_align_teams_path(path: str) -> str:
 # Scope + team types
 # ---------------------------------------------------------------------------
 # Canonical scope_kind values, shared with :mod:`flow_metrics.cache` (which
-# pins the same vocabulary in the cache-key payload — spec § Caching:
+# pins the same vocabulary in the cache-key payload:
 # ``scope_kind: "project" | "program" | "portfolio"``). Using anything
 # else here would silently break cache-key derivation when T10 wires this
 # module into the main run.
@@ -285,8 +285,7 @@ def require_align_join_field(
     state_config: StateConfig,
     cli_override: Optional[str],
 ) -> str:
-    """Resolve the Jira ↔ Jira Align join field name per spec § "Data
-    sources" — Joining Jira ↔ Jira Align.
+    """Resolve the Jira ↔ Jira Align join field name.
 
     Resolution order:
       1. ``--align-join-field NAME`` CLI override (if non-empty).

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/cache.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/cache.py
@@ -1,6 +1,6 @@
 """On-disk cache for per-issue derived rows.
 
-Implements docs/specs/flow-metrics.md § "Caching":
+Caching behaviour:
 
 - :func:`cache_key` derives the sha256 over a canonical-JSON dict whose
   fields are exactly those listed in the spec. Cohort JQL, ``--metrics``

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/changelog.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/changelog.py
@@ -18,8 +18,7 @@ This module exposes a single streaming entry point,
 - filters to ``field in {"status", "issuetype"}`` (the only two fields
   T5 consumes) at this layer to keep per-issue memory bounded.
 
-Pagination is detected from three signals in priority order, per
-docs/specs/flow-metrics.md § "Changelog pagination (Cloud regression)":
+Pagination is detected from three signals in priority order:
 
 1. ``histories.length < total`` (Server / DC) — drain with
    ``startAt=<N>`` until ``total`` is reached.
@@ -83,8 +82,7 @@ def _parse_jira_timestamp(s: str) -> datetime:
     - ``2026-01-15T14:30:00.000+0000`` (Cloud)
     - ``2026-01-15T14:30:00.000+05:30`` (already-normalized offset)
     - ``2026-01-15T14:30:00+0530`` (no milliseconds)
-    - ``2026-01-15T14:30:00`` (no offset — interpreted as UTC, per spec
-      § Decisions: "UTC throughout")
+    - ``2026-01-15T14:30:00`` (no offset — interpreted as UTC)
     - trailing ``Z``
     """
     text = s.strip()

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/cohort.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/cohort.py
@@ -1,11 +1,11 @@
 """T8 cohort split — `--cohort-jql` resolution + `cohort_breakdown`.
 
-Implements docs/specs/flow-metrics.md § "Cohort behaviour":
+Cohort behaviour:
 
 - :func:`resolve_cohort_keys` issues exactly one ``jira: search`` for
   ``(scope) AND (cohort_jql) ORDER BY key ASC`` and returns the matching
   issue-key set. No window clause is added — intersection against the
-  main fetch's in-scope rows happens at tagging time, per spec.
+  main fetch's in-scope rows happens at tagging time.
 - :func:`tag_cohort` stamps each :class:`PerIssueRow` with a
   ``cohort: bool`` derived from set membership in the resolved key set.
 - :func:`aggregate_cohort` filters tagged rows by the ``cohort`` flag

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/config.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/config.py
@@ -1,6 +1,6 @@
 """State + issuetype config loading, integrity validation, sha derivation.
 
-Implements the 9 startup integrity rules from spec § "State configuration"
+Implements the 9 startup integrity rules for state configuration
 and ships the canonical-state lookup helper consumed at walk-time by T5.
 
 Stdlib only. Python >= 3.10.
@@ -154,16 +154,16 @@ def _require_list_of_str(value: Any, label: str) -> List[str]:
 
 
 def validate_state_config(parsed: Any) -> None:
-    """Run the 9 startup integrity rules from spec § State configuration.
+    """Run the 9 startup integrity rules for state configuration.
 
-    Each violation raises ``ConfigError`` with a spec-pinned message
-    naming the offending field. The data-dependent unmapped-status
-    check (rule for unmapped raw statuses) belongs to T5 — this routine
-    does NOT consult any changelog data. Rule 9 (``team_field.id``
-    validated against Jira's field catalog) is a startup check that
-    requires the T3 upstream wrapper; the *config-shape* portion (id is
-    a string, kind is one of the allowed values) is enforced here, but
-    the field-catalog lookup itself is left to the caller after T3 lands.
+    Each violation raises ``ConfigError`` with a message naming the
+    offending field. The data-dependent unmapped-status check (rule for
+    unmapped raw statuses) belongs to T5 — this routine does NOT consult
+    any changelog data. Rule 9 (``team_field.id`` validated against
+    Jira's field catalog) is a startup check that requires the T3
+    upstream wrapper; the *config-shape* portion (id is a string, kind
+    is one of the allowed values) is enforced here, but the field-catalog
+    lookup itself is left to the caller after T3 lands.
     """
     if not isinstance(parsed, dict):
         raise ConfigError(
@@ -388,8 +388,7 @@ class IssuetypeConfig:
         """Return the bucket name for ``raw_issuetype``, or ``None`` if unmapped.
 
         Unmapped issuetypes are bucketed as ``"other"`` by the consumer
-        (Flow Distribution); they do NOT exit 2 (spec § Issuetype
-        configuration).
+        (Flow Distribution); they do NOT exit 2.
         """
         return self._raw_to_bucket.get(raw_issuetype)
 

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/jql.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/jql.py
@@ -4,7 +4,7 @@ Used identically for scope, ``--jql``, ``--cohort-jql``, ``--align-filter``,
 and (T9) the program-scope JQL. Parenthesization is contract-tested:
 ``(scope) AND (user)`` whenever a user clause is present, regardless of
 its internal operator precedence. ``ORDER BY key ASC`` is appended for
-canonical iteration order (spec § Output canonicalization).
+canonical iteration order.
 
 Stdlib only. Python >= 3.10.
 """
@@ -21,9 +21,8 @@ def compose_jql(
 ) -> str:
     """Compose a JQL query from a scope clause and an optional user clause.
 
-    Always wraps both clauses in parentheses before ``AND`` (spec § Inputs,
-    Decision #15). Appends ``ORDER BY key ASC`` for canonical iteration
-    order unless suppressed (spec § Output canonicalization).
+    Always wraps both clauses in parentheses before ``AND``. Appends
+    ``ORDER BY key ASC`` for canonical iteration order unless suppressed.
 
     Used identically for ``--jql`` (Jira) and ``--align-filter`` (Jira
     Align OData) at the string-shape level — both follow the same

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/meta.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/meta.py
@@ -6,11 +6,10 @@ output. Owns one upstream call — ``jira: whoami`` for ``meta.caller``
 unset, ``sources`` lex-sorted, ``metrics_requested`` in canonical
 ``--metrics`` order).
 
-Scope rendering matches the spec example (§ "Outputs" line 374):
-``{ "project": "PROJ", "team": "Foo" }`` for project scope (team
-omitted when ``--team`` was not provided); ``{ "program_id": "42" }``
-or ``{ "portfolio_id": "42" }`` for Jira Align scope. Mirrors the
-``_format_scope`` CSV helper in :mod:`flow_metrics.output`.
+Scope rendering: ``{ "project": "PROJ", "team": "Foo" }`` for project
+scope (team omitted when ``--team`` was not provided); ``{ "program_id":
+"42" }`` or ``{ "portfolio_id": "42" }`` for Jira Align scope. Mirrors
+the ``_format_scope`` CSV helper in :mod:`flow_metrics.output`.
 
 Stdlib only. Python >= 3.10.
 """
@@ -22,17 +21,16 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence
 from .output import CANONICAL_METRICS_ORDER
 
 
-# Per spec § "Outputs" line 382: schema_version is pinned at "1.0" for
-# the v1 wire format. Future major versions bump this; T10's renderer
-# does not interpret the value, so the bump is single-source-changeable
-# here.
+# schema_version is pinned at "1.0" for the v1 wire format. Future major
+# versions bump this; T10's renderer does not interpret the value, so the
+# bump is single-source-changeable here.
 SCHEMA_VERSION = "1.0"
 
 
 class CallerResolutionError(Exception):
     """``jira: whoami`` returned a payload with neither ``accountId``
-    nor ``name`` — spec § "Permission undercounting" line 637-638 maps
-    to exit 3 (``test_caller_unrecognized_whoami_exits_3``).
+    nor ``name`` — maps to exit 3
+    (``test_caller_unrecognized_whoami_exits_3``).
 
     Distinct from :class:`flow_metrics.upstream.JiraError`: the upstream
     subprocess exited zero but the payload shape is unusable. The CLI
@@ -47,7 +45,7 @@ def resolve_caller(whoami_payload: Any) -> str:
 
     Cloud responses carry ``accountId`` (24-char opaque); Server / Data
     Center responses carry ``name`` (username). If both are present,
-    prefer ``accountId`` (spec § "Permission undercounting" line 637).
+    prefer ``accountId``.
     If neither is present, raise :class:`CallerResolutionError` —
     the CLI maps to exit 3 with a message mentioning ``whoami`` so the
     user can tell which upstream call produced the bad shape.
@@ -185,13 +183,12 @@ def build_meta(
     - ``metrics_requested`` — canonical ``--metrics`` order, deduped,
       unknown names dropped (see :func:`_canonical_metrics`).
     - ``generated_at`` — ISO-8601 UTC string. Test fixtures
-      historically use ``"2026-05-19T14:00:00Z"`` (spec example line
-      380); we render via ``isoformat`` and append ``Z`` for naive UTC.
+      historically use ``"2026-05-19T14:00:00Z"``; we render via
+      ``isoformat`` and append ``Z`` for naive UTC.
     - ``per_team_double_counted`` — set by T9; threaded through here.
-    - ``cohort_jql`` — **omitted** when ``None`` or empty (spec § "Cohort
-      behaviour" line 1128-1131). The key must be absent, not null, not
-      "". T10's renderer also drops null / empty values; this is the
-      first line of defence.
+    - ``cohort_jql`` — **omitted** when ``None`` or empty. The key must
+      be absent, not null, not "". T10's renderer also drops null / empty
+      values; this is the first line of defence.
     """
     meta: Dict[str, Any] = {
         "caller": caller,
@@ -214,10 +211,10 @@ def _iso_generated_at(value: datetime) -> str:
     """Render ``generated_at`` as ISO-8601 with a ``Z`` suffix for UTC.
 
     Naive datetimes are treated as UTC (the rest of the skill normalises
-    to UTC at boundary; spec § Decisions line 1374: "Time zones: UTC
-    throughout"). Tz-aware datetimes serialise via ``isoformat`` and the
-    offset is normalised to ``Z`` when the offset is zero — matching the
-    spec example ``"2026-05-19T14:00:00Z"``.
+    to UTC at boundary; the convention is UTC throughout). Tz-aware
+    datetimes serialise via ``isoformat`` and the offset is normalised to
+    ``Z`` when the offset is zero — matching the expected format
+    ``"2026-05-19T14:00:00Z"``.
     """
     if not isinstance(value, datetime):
         return str(value)

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/notes.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/notes.py
@@ -4,12 +4,10 @@ Buffers note strings emitted opportunistically by T5/T6/T8/T9 during a
 run, then :meth:`finalize` returns the lex-sorted list T10's renderer
 splices into the canonical output.
 
-Wording rules pinned by docs/specs/flow-metrics.md § "Outputs" (the
-``notes`` array in the JSON example, lines 434-444) and the Decisions
-section. Where the spec gives a verbatim example string, it is
-reproduced exactly. Where the spec only describes the contract (e.g.
-empty-cohort) the wording is this module's call and the PR description
-flags it for review.
+Wording rules for the ``notes`` output block. Where a verbatim example
+string is tested by the contract tests, it is reproduced exactly. Where
+only the behaviour is pinned (e.g. empty-cohort) the wording is this
+module's call and the PR description flags it for review.
 
 Dedup is by **full final string**, not by counter-method-name: two calls
 to ``add_cancelled(5)`` produce one notes line. Two calls to
@@ -77,8 +75,7 @@ class NotesCollector:
     disclaimer, two) string(s) and appends them iff not already present.
     :meth:`finalize` returns a freshly-sorted copy each call so the
     collector remains non-destructive — T10's renderer also sorts
-    defensively (spec § "Output canonicalization"); both layers must be
-    idempotent under repeated calls.
+    defensively; both layers must be idempotent under repeated calls.
     """
 
     def __init__(self) -> None:
@@ -100,52 +97,49 @@ class NotesCollector:
     # ------------------------------------------------------------------
     def add_cancelled(self, n: int) -> None:
         """Single line listing all five metrics cancelled-in-window
-        issues are excluded from (spec § "Outputs" line 439)."""
+        issues are excluded from."""
         self._append(_CANCELLED_TEMPLATE.format(n=n))
 
     def add_skipped_commitment(self, n: int) -> None:
         """Delivered-in-window but no commitment_state entry — excluded
-        from cycle_time (spec § Metric correctness line 998-999)."""
+        from cycle_time."""
         self._append(_SKIPPED_COMMITMENT_TEMPLATE.format(n=n))
 
     def add_zero_denominator_flow_eff(self, n: int) -> None:
         """Cycle-eligible but ``active_t + wait_t == 0`` — excluded
-        from flow_efficiency (spec § "Outputs" line 437)."""
+        from flow_efficiency."""
         self._append(_ZERO_DENOMINATOR_TEMPLATE.format(n=n))
 
     def add_unmapped_issuetype(self, name: str, n: int) -> None:
-        """One line per distinct unmapped issuetype name (spec § "Outputs"
-        line 436). Callers tally per-name before calling — two calls
-        with the same name+n collapse via dedup; with same name+different
-        n produce TWO lines (caller bug)."""
+        """One line per distinct unmapped issuetype name. Callers tally
+        per-name before calling — two calls with the same name+n collapse
+        via dedup; with same name+different n produce TWO lines (caller
+        bug)."""
         self._append(_UNMAPPED_ISSUETYPE_TEMPLATE.format(n=n, name=name))
 
     def add_permission_undercount(self, n: int) -> None:
         """Project-scope permission undercount: ``jira: get-project``
-        reports a higher total than the in-scope JQL (spec § "Permission
-        undercounting" line 642-643)."""
+        reports a higher total than the in-scope JQL."""
         self._append(_PERMISSION_UNDERCOUNT_TEMPLATE.format(n=n))
 
     def add_field_permission_undercount(self, field: Optional[str], n: int) -> None:
-        """N in-scope issues had no readable team_field value (spec §
-        "Permission undercounting" line 647-656). ``field`` is the
-        team_field id for diagnostics; the spec wording does not embed
-        the field id, but we accept it so call sites stay informative
-        if the wording changes."""
+        """N in-scope issues had no readable team_field value. ``field``
+        is the team_field id for diagnostics; the note wording does not
+        embed the field id, but we accept it so call sites stay
+        informative if the wording changes."""
         del field  # spec wording does not embed the field id today
         self._append(_FIELD_PERMISSION_UNDERCOUNT_TEMPLATE.format(n=n))
 
     def add_window_edge_count(self, n: int) -> None:
-        """Issues that entered in-progress before window start (spec §
-        "Outputs" line 435)."""
+        """Issues that entered in-progress before window start."""
         self._append(_WINDOW_EDGE_TEMPLATE.format(n=n))
 
     def add_flow_load_sample_count(self, n: int, weekend_policy: str = "included") -> None:
-        """Sample count + weekend policy line (spec § "Outputs" line 442;
-        Metric correctness ``test_flow_load_weekend_inclusion_recorded``).
-        v1 always emits ``"weekends included"`` because business-day-only
-        Flow Load is deferred to v2 (spec § "Deferred to v2" line 1523);
-        the parameter is kept so the v2 wiring is a one-arg change."""
+        """Sample count + weekend policy line
+        (``test_flow_load_weekend_inclusion_recorded``). v1 always emits
+        ``"weekends included"`` because business-day-only Flow Load is
+        deferred to v2; the parameter is kept so the v2 wiring is a
+        one-arg change."""
         self._append(
             _FLOW_LOAD_SAMPLE_TEMPLATE.format(n=n, policy=weekend_policy)
         )
@@ -158,17 +152,16 @@ class NotesCollector:
             self._append(line)
 
     def add_empty_cohort(self) -> None:
-        """``--cohort-jql`` matched zero in-scope issues. Spec § "Cohort
-        behaviour" test ``test_empty_cohort_does_not_exit_nonzero`` pins
-        the behaviour (no exit) but not the wording — this string is
-        T11's call (flagged in PR)."""
+        """``--cohort-jql`` matched zero in-scope issues.
+        ``test_empty_cohort_does_not_exit_nonzero`` pins the behaviour
+        (no exit) but not the wording — this string is T11's call
+        (flagged in PR)."""
         self._append(_EMPTY_COHORT_LINE)
 
     def add_per_team_double_counted(self, n: int) -> None:
         """K issues belong to more than one team (array team_field kind)
-        and are counted in each team's per_team row. Spec § "Outputs"
-        line 230-233 mentions the note but doesn't quote it verbatim;
-        wording matches the test fixture in T9's
+        and are counted in each team's per_team row. Wording matches the
+        test fixture in T9's
         ``test_per_team_array_kind_double_count_flagged``."""
         self._append(_PER_TEAM_DOUBLE_COUNTED_TEMPLATE.format(n=n))
 

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/notes.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/notes.py
@@ -54,7 +54,7 @@ _WINDOW_EDGE_TEMPLATE = (
 )
 _FLOW_LOAD_SAMPLE_TEMPLATE = "flow_load: {n} samples, weekends {policy}."
 _DEFECT_RATIO_DISCLAIMER_LINES = (
-    "defect_ratio is not Change Failure Rate; see spec §Out of scope.",
+    "defect_ratio is not Change Failure Rate (intentionally out of scope).",
     "defect_ratio uses flow_distribution denominator; throughput "
     "excludes subtasks (override: --include-subtasks).",
 )

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/output.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/output.py
@@ -49,15 +49,15 @@ from .per_issue import PerIssueRow
 # ---------------------------------------------------------------------------
 # Canonical orders
 # ---------------------------------------------------------------------------
-# Spec § "Outputs" → bucket order locked here (not lex). The order matches
+# Bucket order locked here (not lex). The order matches
 # :data:`flow_metrics.aggregate.FLOW_DISTRIBUTION_BUCKETS` plus the trailing
 # ``denominator`` field that lives inside the same map.
 BUCKET_ORDER: tuple = FLOW_DISTRIBUTION_BUCKETS + ("denominator",)
 
-# Spec § "Outputs" → meta.metrics_requested canonical order. Matches the
-# ``--metrics`` enumeration in :data:`flow_metrics.ALL_METRICS`. Duplicated
-# here so the output module doesn't import the CLI module (which would
-# create a cycle: __init__.py imports several submodules at import time).
+# Canonical order for meta.metrics_requested. Matches the ``--metrics``
+# enumeration in :data:`flow_metrics.ALL_METRICS`. Duplicated here so the
+# output module doesn't import the CLI module (which would create a cycle:
+# __init__.py imports several submodules at import time).
 CANONICAL_METRICS_ORDER: tuple = (
     "cycle_time",
     "lead_time",
@@ -132,7 +132,7 @@ def _aggregates_to_dict(
     The mapping from ``--metrics`` name to wire key is spec-pinned:
     ``cycle_time / lead_time / flow_time`` get the ``_hours`` suffix in
     the wire output; everything else keeps its bare name. Unrequested
-    metrics are absent (not emitted as ``null`` — spec § "Outputs").
+    metrics are absent (not emitted as ``null``).
     """
     requested = set(metrics_requested)
     out: Dict[str, Any] = {}
@@ -209,10 +209,10 @@ def _meta_to_dict(
         if k == "metrics_requested":
             continue  # Report-level field wins
         if k == "cohort_jql" and (v is None or (isinstance(v, str) and v == "")):
-            # Spec § "Cohort behaviour": key is **absent** when --cohort-jql
-            # was not provided — not null, not "". A generic meta builder
-            # that always sets the field (with None when unused) would
-            # otherwise leak `"cohort_jql":null` past the contract test.
+            # cohort_jql is **absent** when --cohort-jql was not provided —
+            # not null, not "". A generic meta builder that always sets the
+            # field (with None when unused) would otherwise leak
+            # `"cohort_jql":null` past the contract test.
             continue
         if k == "sources" and isinstance(v, (list, tuple)):
             out[k] = sorted(v)
@@ -413,17 +413,17 @@ def _per_issue_row_to_dict(row: PerIssueRow) -> Dict[str, Any]:
     """Per-issue wire dict.
 
     ``wip_samples`` is omitted — it's an internal flow_load aggregation
-    detail, not part of the documented per-issue contract (spec § "Per-
-    issue mode" lists every emitted field; ``wip_samples`` is not among
-    them). Every other field is emitted; nullable fields emit JSON
-    ``null`` for ``None``.
+    detail, not part of the per-issue output contract (the per-issue mode
+    lists every emitted field; ``wip_samples`` is not among them). Every
+    other field is emitted; nullable fields emit JSON ``null`` for
+    ``None``.
 
     ``cohort`` is **only** emitted when set (``True`` / ``False``). When
     ``--cohort-jql`` is not in play, T8's :func:`tag_cohort` doesn't run
     and ``row.cohort`` stays ``None``; emitting ``"cohort": null`` would
     mislead consumers into thinking the row was tagged as not-in-cohort.
-    Spec § "Cohort behaviour" line 1124 binds cohort-field presence to
-    cohort-jql mode; absence is the documented signal for "no cohort".
+    Cohort-field presence is bound to cohort-jql mode; absence is the
+    documented signal for "no cohort".
     """
     out: Dict[str, Any] = {
         "key": row.key,
@@ -509,7 +509,7 @@ def _emit_aggregate_rows(
 
     Percentile metrics fill ``p50/p75/p90`` and ``count`` from the
     :class:`PercentileStat`. Scalar metrics put the value in ``p50`` and
-    leave ``p75 / p90 / count`` blank (spec § "Outputs"). flow_distribution
+    leave ``p75 / p90 / count`` blank. flow_distribution
     expands into one row per bucket with the ratio in ``p50`` and the
     distribution denominator in ``count`` — keeping the long-form contract
     intact for downstream CSV consumers that pivot by ``(metric, scope,

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/per_issue.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/per_issue.py
@@ -5,7 +5,7 @@ population predicates, and emits a :class:`PerIssueRow` carrying every
 field a downstream aggregator (T6) or per-issue consumer
 (``ai-adoption-cohort``) needs.
 
-Field-presence rules per docs/specs/flow-metrics.md § "Per-issue mode":
+Field-presence rules for per-issue mode:
 
 - Delivered-in-window rows carry ``cycle_time_hours``,
   ``lead_time_hours``, ``flow_efficiency``, ``first_commitment_at``,
@@ -364,10 +364,9 @@ def iter_per_issue_rows(
     ``user_clause``) over ``window``.
 
     Composes JQL via :func:`compose_jql` with ``order_by_key=True`` so
-    every ``jira: search`` invocation ends in ``ORDER BY key ASC``
-    (spec output-canonicalization rule 4). Per the bounded-memory
-    contract, both the search and the per-issue changelog drain are
-    streamed; rows are yielded one at a time.
+    every ``jira: search`` invocation ends in ``ORDER BY key ASC``.
+    Per the bounded-memory contract, both the search and the per-issue
+    changelog drain are streamed; rows are yielded one at a time.
 
     Only emits rows that are in scope per the spec's per-issue
     membership rule:

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/per_team.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/per_team.py
@@ -17,10 +17,9 @@ team names (``"Zebra"``, ``"Über-team"``, ``"alpha"``); plain
 
 Program-scope JQL composition lives here too: given the resolved team-id
 list (from T9's :mod:`flow_metrics.align`), build the Jira-side query
-that intersects the team field against those ids. Per spec § "Data
-sources" v1 assumes one Jira ↔ one Jira Align instance pair, so the JQL
-deliberately has no ``project = ...`` clause — the team field id is the
-sole scope selector.
+that intersects the team field against those ids. v1 assumes one Jira ↔
+one Jira Align instance pair, so the JQL deliberately has no
+``project = ...`` clause — the team field id is the sole scope selector.
 
 Field-level permission undercount: when an in-scope issue has no
 readable ``team_field`` value (Jira's field-level security strips it),

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/predicates.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/predicates.py
@@ -1,5 +1,4 @@
-"""Core population predicates from docs/specs/flow-metrics.md §
-"Metric definitions" → "Core population predicates".
+"""Core population predicates for flow-metrics metric definitions.
 
 Each predicate is a pure function of a :class:`Timeline` and a window.
 The four predicates are intentionally independent — an issue can satisfy

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/timeline.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/timeline.py
@@ -9,7 +9,7 @@ Every raw status the walker encounters — baseline AND every
 ``from_value`` / ``to_value`` on a status transition — is mapped through
 :meth:`StateConfig.canonical_for`. An unmapped raw status raises
 :class:`UnmappedStatusError`; main translates this to exit 2 naming the
-offending status (spec § "Unmapped-status policy", data-dependent path).
+offending status (data-dependent path).
 
 Stdlib only. Python >= 3.10.
 """
@@ -27,8 +27,8 @@ class UnmappedStatusError(Exception):
     """Walker hit a raw status not present in ``canonical_states``.
 
     Carries the offending raw status name so :func:`flow_metrics.main`
-    can name it in the exit-2 error string (spec § "Unmapped-status
-    policy" — refusal rather than silent canonicalisation).
+    can name it in the exit-2 error string (refusal rather than silent
+    canonicalisation).
     """
 
     def __init__(self, status: str) -> None:

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/upstream.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/upstream.py
@@ -1,10 +1,9 @@
 """Upstream skill wrappers — discovery, allowlist, subprocess.
 
 T3 substrate: every downstream task reads Jira / Jira Align data through
-this module. The wrapper enforces the read-only allowlist from
-docs/specs/flow-metrics.md § "Read-only contract — upstream-skill
-allowlist" — verbs and ``raw GET`` paths are validated against exact
-regex patterns before any subprocess is spawned.
+this module. The wrapper enforces the read-only allowlist — verbs and
+``raw GET`` paths are validated against exact regex patterns before any
+subprocess is spawned.
 
 Architectural invariants (load-bearing; do not relax):
 
@@ -101,10 +100,10 @@ _THIS_SKILL_DIR = Path(__file__).resolve().parent.parent.parent
 
 
 def _env_var_name(name: str) -> str:
-    """Per spec/plan: FLOW_METRICS_<NAME>_SCRIPT with hyphens stripped.
+    """Return the env-var name for the named upstream skill's script path.
 
-    Matches the literals in docs/specs/flow-metrics-plan.md
-    (``FLOW_METRICS_JIRA_SCRIPT`` / ``FLOW_METRICS_JIRAALIGN_SCRIPT``).
+    Produces ``FLOW_METRICS_<NAME>_SCRIPT`` with hyphens stripped
+    (e.g. ``FLOW_METRICS_JIRA_SCRIPT`` / ``FLOW_METRICS_JIRAALIGN_SCRIPT``).
     """
     return "FLOW_METRICS_{}_SCRIPT".format(name.upper().replace("-", ""))
 

--- a/packs/atlassian/.apm/skills/jira-align/references/creds-schema.toml
+++ b/packs/atlassian/.apm/skills/jira-align/references/creds-schema.toml
@@ -1,8 +1,8 @@
 # Credentials schema for the jira-align credentialed primitive.
-# Format pinned by skill-secrets spec § AC24.
+# Format: a [namespace] table plus one [[namespace.keys]] entry per key.
 #
 # Resolution: load_credentials("jiraalign", required_keys=[...]) walks
-# Tier 1 (env) → Tier 2 (OS keyring) → Tier 3 dotfile per AC4. Env-var
+# Tier 1 (env) → Tier 2 (OS keyring) → Tier 3 dotfile. Env-var
 # shape is <NAMESPACE>_<KEY> — JIRAALIGN_BASE_URL, JIRAALIGN_API_TOKEN,
 # JIRAALIGN_FLAVOR.
 #

--- a/packs/atlassian/.apm/skills/jira-align/scripts/_credman_windows.py
+++ b/packs/atlassian/.apm/skills/jira-align/scripts/_credman_windows.py
@@ -1,4 +1,4 @@
-"""Windows Credential Manager Tier-2 backend (spec § AC9-AC12).
+"""Windows Credential Manager Tier-2 backend.
 
 In-process ``ctypes`` against ``advapi32.dll``'s ``CredReadW`` /
 ``CredWriteW`` / ``CredDeleteW`` / ``CredFree`` — stdlib only, no
@@ -15,7 +15,7 @@ zero-initialised via ``ctypes.Structure`` defaults — required by
 NULL when ``AttributeCount`` is 0; ``LastWritten`` is set by the API
 and ignored on write).
 
-Per spec § AC4b the loader imports this module **only** when
+The loader imports this module **only** when
 ``sys.platform == "win32"``. The advapi32 binding is platform-guarded
 below so the module itself stays importable on every platform; tests
 that don't actually call the OS can construct ``CREDENTIAL`` instances
@@ -31,11 +31,11 @@ from ctypes import POINTER, Structure, byref
 
 from .credentials_shim import Tier2HardFailError
 
-# Constants from ``wincred.h`` (spec § AC9):
+# Constants from ``wincred.h``:
 CRED_TYPE_GENERIC = 1
 CRED_PERSIST_LOCAL_MACHINE = 2
 
-# Win32 error codes — sourced from ``winerror.h`` and AC11:
+# Win32 error codes — sourced from ``winerror.h``:
 ERROR_NOT_FOUND = 1168          # falls through to Tier 3
 ERROR_NO_SUCH_LOGON_SESSION = 1312
 ERROR_INVALID_FLAGS = 1004
@@ -44,7 +44,7 @@ ERROR_LOGON_FAILURE = 1326
 TARGET_PREFIX = "agentbundle"
 # Tests can monkeypatch this to a ``tmp_path``-derived value so test
 # target-names can't collide with the developer's real Credential
-# Manager entries (spec § AC35 / plan T5 § Test isolation).
+# Manager entries.
 SERVICE_PREFIX_OVERRIDE: str | None = None
 
 
@@ -53,7 +53,7 @@ class CREDENTIAL(Structure):
 
     Field order and types must match the Win32 ABI exactly — a wrong-
     sized field on Windows returns garbage rather than raising, which
-    is why AC10 mandates a byte-equality round-trip test on every field.
+    is why a byte-equality round-trip test covers every field.
     """
 
     _fields_ = [
@@ -104,18 +104,18 @@ else:
 
 
 def _target_name(namespace: str, key: str) -> str:
-    """Compose the Win32 ``TargetName`` per spec § AC9."""
+    """Compose the Win32 ``TargetName``."""
     prefix = SERVICE_PREFIX_OVERRIDE or TARGET_PREFIX
     return f"{prefix}:{namespace}:{key}"
 
 
 def _classify_last_error(rc: int, op: str) -> None:
-    """Map the Win32 last-error code to the AC11 dispatch matrix.
+    """Map the Win32 last-error code to the dispatch matrix.
 
     ``ERROR_NOT_FOUND`` is the caller's responsibility (it indicates a
     legitimate miss — caller returns ``None``). Every other code on
     this matrix raises ``Tier2HardFailError`` so the resolver does not
-    silently degrade to Tier 3 (spec § Never do).
+    silently degrade to Tier 3.
     """
     if rc == ERROR_NO_SUCH_LOGON_SESSION:
         raise Tier2HardFailError(
@@ -144,7 +144,7 @@ def read_credential(namespace: str, key: str) -> str | None:
 
     Returns ``None`` on ``ERROR_NOT_FOUND`` (resolver falls through to
     Tier 3); raises ``Tier2HardFailError`` on every other documented
-    failure (AC11).
+    failure.
     """
     target = _target_name(namespace, key)
     out_ptr = POINTER(CREDENTIAL)()
@@ -169,7 +169,7 @@ def read_credential(namespace: str, key: str) -> str | None:
 
 
 def write_credential(namespace: str, key: str, value: str) -> None:
-    """Write ``value`` to ``(namespace, key)`` (AC9, AC10).
+    """Write ``value`` to ``(namespace, key)``.
 
     The token is UTF-16-LE encoded and stored in a writable buffer
     pointed to by ``CredentialBlob``; ``CredentialBlobSize`` is the
@@ -183,7 +183,7 @@ def write_credential(namespace: str, key: str, value: str) -> None:
     # All other fields stay at ctypes.Structure's zero-init defaults
     # (Flags=0, Comment=None, LastWritten=FILETIME(0,0),
     # AttributeCount=0, Attributes=None, TargetAlias=None) — required
-    # by CRED_TYPE_GENERIC per spec § AC9.
+    # by CRED_TYPE_GENERIC.
     cred.Type = CRED_TYPE_GENERIC
     cred.TargetName = target
     cred.CredentialBlobSize = len(blob)

--- a/packs/atlassian/.apm/skills/jira-align/scripts/_keychain_macos.py
+++ b/packs/atlassian/.apm/skills/jira-align/scripts/_keychain_macos.py
@@ -1,8 +1,8 @@
-"""macOS Keychain Tier-2 backend (spec § AC6-AC8).
+"""macOS Keychain Tier-2 backend.
 
 Stdlib subprocess against ``/usr/bin/security`` — the system-shipped
-Keychain CLI. Guaranteed present on every macOS install per spec §
-Boundaries § Never do (no third-party ``keyring`` dependency).
+Keychain CLI. Guaranteed present on every macOS install (no third-party
+``keyring`` dependency).
 
 Token bytes never reach argv:
 
@@ -16,7 +16,7 @@ Token bytes never reach argv:
 - **Delete** uses ``delete-generic-password`` (idempotent on miss).
 
 The build-projected ``credentials_shim`` imports this module **only**
-when ``sys.platform == "darwin"`` per AC4b. Tests monkeypatch
+when ``sys.platform == "darwin"``. Tests monkeypatch
 ``SERVICE`` to a ``tmp_path``-derived prefix so test entries never
 collide with the developer's real ``agentbundle`` Keychain entries.
 """
@@ -34,9 +34,9 @@ SERVICE = "agentbundle"
 # developer's login Keychain. ``security``'s ``-w`` prompt mode requires
 # ``-w`` as the trailing argv element, which forecloses the trailing-
 # keychain-positional approach to test isolation; the service-prefix
-# approach lets the canonical AC6 argv shape stay untouched.
+# approach lets the canonical argv shape stay untouched.
 
-# macOS Security framework OSStatus codes (spec § AC22):
+# macOS Security framework OSStatus codes:
 #   44      errSecItemNotFound          — legitimate "no such credential",
 #                                         falls through to Tier 3.
 #   45      errSecDuplicateItem         — only relevant on add; the ``-U``
@@ -46,7 +46,7 @@ SERVICE = "agentbundle"
 #
 # Names taken from ``<Security/SecBase.h>``. The two "Keychain locked /
 # unavailable" codes (25308 / -25291) MUST raise ``Tier2HardFailError``
-# so ``run_setup`` can route the AC22 fallback gate — silently
+# so ``run_setup`` can route the fallback gate — silently
 # degrading to Tier 3 defeats the security posture the user chose.
 EXIT_NOT_FOUND = 44
 EXIT_DUPLICATE_ITEM = 45
@@ -62,8 +62,7 @@ def _classify_macos_exit_code(rc: int, op: str) -> str | None:
     embed it in a ``Tier2HardFailError`` message. Returns ``None`` for
     ``EXIT_NOT_FOUND`` (the caller treats that as a legitimate miss).
 
-    Parallel in shape to ``_credman_windows._classify_last_error``;
-    AC22 cites this matrix explicitly.
+    Parallel in shape to ``_credman_windows._classify_last_error``.
     """
     if rc == 0:
         return None
@@ -92,12 +91,12 @@ def _classify_macos_exit_code(rc: int, op: str) -> str | None:
 
 
 def _account(namespace: str, key: str) -> str:
-    """Compose the Keychain account label per spec § AC6."""
+    """Compose the Keychain account label."""
     return f"{namespace}:{key}"
 
 
 def read_credential(namespace: str, key: str) -> str | None:
-    """Read ``(namespace, key)`` from the Keychain (spec § AC6, AC7)."""
+    """Read ``(namespace, key)`` from the Keychain."""
     argv = [
         SECURITY_BIN, "find-generic-password",
         "-s", SERVICE,
@@ -121,7 +120,7 @@ def read_credential(namespace: str, key: str) -> str | None:
 
 def write_credential(namespace: str, key: str, value: str) -> None:
     """Write ``value`` to ``(namespace, key)``. Token enters via child stdin
-    only — never argv (spec § AC6, AC7).
+    only — never argv.
 
     Refuses values containing ``\\n`` or ``\\r`` up front. ``security -w``
     prompts twice and the stdin payload is ``token + b"\\n" + token + b"\\n"``;

--- a/packs/atlassian/.apm/skills/jira-align/scripts/credentials_shim.py
+++ b/packs/atlassian/.apm/skills/jira-align/scripts/credentials_shim.py
@@ -13,9 +13,9 @@ Public surface a credentialed-primitive author imports:
 - ``Credentials`` — immutable, attribute-access view of the resolved values.
 - ``EnvParseError`` — raised by ``parse_env_file`` on unsupported syntax.
 
-Stdlib-only per spec § Boundaries § Never do — no ``python-dotenv``, no
+Stdlib-only by design — no ``python-dotenv``, no
 ``keyring``, no third-party imports. The Tier-2 backend is dispatched at
-module-load time per AC4b: ``_keychain_macos`` iff ``sys.platform ==
+module-load time: ``_keychain_macos`` iff ``sys.platform ==
 "darwin"``, ``_credman_windows`` iff ``"win32"``, no Tier-2 backend on
 other platforms (resolver falls through directly to Tier 3).
 
@@ -36,8 +36,8 @@ Trailing ``\\r`` from CRLF line endings is stripped; ``\\r`` *inside* a
 quoted value is preserved (``KEY="a\\rb"`` → ``{"KEY": "a\\rb"}``).
 
 When loaded outside a consumer-skill ``scripts/`` directory — e.g. as
-a sibling under ``~/.agentbundle/bin/`` per the credential-broker-contract
-AC22b companion projection — the shim's own ``_tier2_backend`` resolves
+a sibling under ``~/.agentbundle/bin/`` per the shim companion
+projection — the shim's own ``_tier2_backend`` resolves
 to ``None``. Callers in that context must not rely on ``load_credentials``
 for Tier-2 resolution; that path is the consumer-skill ``scripts/``
 projection only.
@@ -94,7 +94,7 @@ class Tier2HardFailError(Exception):
 class PermissiveAclError(Exception):
     """Raised when the Windows DACL on the Tier-3 dotfile is too permissive.
 
-    Per spec § AC15: ``icacls`` is invoked after each write; non-default
+    ``icacls`` is invoked after each write; non-default
     ACEs (anything beyond the inherited user / ``NT AUTHORITY\\SYSTEM`` /
     ``BUILTIN\\Administrators``) cause the helper to refuse unless
     ``allow_permissive_acl=True`` was passed.
@@ -104,7 +104,7 @@ class PermissiveAclError(Exception):
 class SchemaError(Exception):
     """Raised when a ``creds-schema.toml`` file is malformed or missing.
 
-    Per spec § AC24 / AC24b — names the offending file path and the
+    Names the offending file path and the
     specific shape violation (missing ``[namespace]``, empty
     ``namespace.keys``, non-boolean ``secret``, or unresolvable
     canonical path).
@@ -186,11 +186,11 @@ def parse_env_file(path: pathlib.Path) -> dict[str, str]:
         result[key] = value
     return result
 
-# Tier-2 backend dispatch at module-load time (spec § AC4b). The backend
-# modules are added by T4 (macOS) and T5 (Windows); until they land, the
-# try/except yields ``None`` and the resolver skips Tier 2 on the matching
-# platform. On Linux (and any non-Darwin / non-Windows platform), no import
-# is attempted at all — Tier 2 is unavailable by absence.
+# Tier-2 backend dispatch at module-load time. If a platform's backend
+# module is absent, the try/except yields ``None`` and the resolver skips
+# Tier 2 on the matching platform. On Linux (and any non-Darwin /
+# non-Windows platform), no import is attempted at all — Tier 2 is
+# unavailable by absence.
 if sys.platform == "darwin":
     try:
         from . import _keychain_macos as _tier2_backend  # type: ignore[no-redef]
@@ -208,7 +208,7 @@ else:
 class Credentials:
     """Immutable, attribute-access view of a namespace's resolved credentials.
 
-    Constructed by ``load_credentials``. The contract (spec § AC3) is:
+    Constructed by ``load_credentials``. The contract is:
 
     - Attribute access returns the resolved value:
       ``creds.API_TOKEN`` returns the resolved ``API_TOKEN`` for the
@@ -276,7 +276,7 @@ class Credentials:
 
 
 def _tier1_env(namespace: str, key: str) -> str | None:
-    """Resolve ``<NAMESPACE>_<KEY>`` from ``os.environ`` (spec § AC5).
+    """Resolve ``<NAMESPACE>_<KEY>`` from ``os.environ``.
 
     Empty-string env vars count as unset and return ``None`` so the
     resolver falls through to lower tiers.
@@ -289,12 +289,12 @@ def _tier1_env(namespace: str, key: str) -> str | None:
 
 
 def _tier2(namespace: str, key: str) -> str | None:
-    """Resolve via the platform-specific keyring backend (spec § AC6, AC9).
+    """Resolve via the platform-specific keyring backend.
 
     Returns ``None`` when the backend is absent (non-Darwin / non-Windows
-    platforms, or backend modules not yet shipped) or reports a clean
+    platforms, or backend modules not shipped) or reports a clean
     miss. Hard-fail error codes from the underlying API propagate as
-    ``Tier2HardFailError`` per AC11.
+    ``Tier2HardFailError``.
     """
     if _tier2_backend is None:
         return None
@@ -302,7 +302,7 @@ def _tier2(namespace: str, key: str) -> str | None:
 
 
 def _tier3(namespace: str, key: str) -> str | None:
-    """Resolve from the Tier-3 dotfile (spec § AC13).
+    """Resolve from the Tier-3 dotfile.
 
     Reads ``~/.agentbundle/credentials.env`` via the stdlib parser and
     looks up ``<NAMESPACE>_<KEY>``. Returns ``None`` on miss; a malformed
@@ -317,7 +317,7 @@ def _tier3(namespace: str, key: str) -> str | None:
 
 
 def _dotfile_path() -> pathlib.Path:
-    """Canonical Tier-3 dotfile path per spec § AC13.
+    """Canonical Tier-3 dotfile path.
 
     Resolves to ``pathlib.Path.home() / ".agentbundle" / "credentials.env"``
     on every platform. Tests redirect ``HOME`` (and ``USERPROFILE`` on
@@ -399,7 +399,7 @@ def _verify_icacls(
     path: pathlib.Path, *, allow_permissive_acl: bool = False
 ) -> None:
     """Run ``icacls /findsid`` and refuse if any well-known "broad
-    access" SID is granted access on the path (spec § AC15). No-op on
+    access" SID is granted access on the path. No-op on
     POSIX.
 
     Default ACEs on a per-user file are the inheriting user,
@@ -437,7 +437,7 @@ def _verify_icacls(
 
 
 def _ensure_parent(parent: pathlib.Path) -> None:
-    """Create the dotfile parent at mode 0o700 if absent (spec § AC15).
+    """Create the dotfile parent at mode 0o700 if absent.
 
     If the parent already exists, do **not** rewrite its mode — the
     directory is shared with ``~/.agentbundle/state.toml``.
@@ -465,7 +465,7 @@ def _dotfile_write(
 ) -> None:
     """Write ``(namespace, key) → value`` to the Tier-3 dotfile atomically.
 
-    Atomic write contract per spec § AC14:
+    Atomic write contract:
     ``tempfile.mkstemp(dir=target_dir)`` → ``os.write`` →
     ``os.fchmod`` (POSIX) → ``os.close`` → ``os.replace``. A mid-write
     read sees either the prior contents or the new contents, never
@@ -556,7 +556,7 @@ def load_credentials(
 ) -> Credentials:
     """Resolve ``required_keys`` for ``namespace``, walking Tiers 1 → 2 → 3.
 
-    First-hit-wins per key (spec § AC4): a key resolved at Tier 1 is not
+    First-hit-wins per key: a key resolved at Tier 1 is not
     re-checked at lower tiers; mixing tiers across keys within one
     namespace is permitted.
 
@@ -593,8 +593,8 @@ def load_credentials(
         attempts.append(f"Tier 1: env {env_name!r} not set")
 
         # Tier 2 — OS keyring (when loaded). Tier2HardFailError
-        # propagates per AC11 (no silent fallback to Tier 3 on hard
-        # fail); only a clean miss falls through.
+        # propagates (no silent fallback to Tier 3 on hard fail);
+        # only a clean miss falls through.
         if _tier2_backend is None:
             attempts.append("Tier 2: not loaded (no keyring backend on this platform)")
         else:
@@ -621,8 +621,8 @@ def load_credentials(
         tiers_tried[key] = attempts
 
     if missing:
-        # One-line preamble preserves the AC3 contract (message names
-        # namespace and the missing-keys list); the per-key trailer
+        # One-line preamble names the namespace and the missing-keys
+        # list; the per-key trailer
         # block comes below for triage.
         lines = [
             f"namespace {namespace!r}: missing required credential(s): "
@@ -641,7 +641,7 @@ def load_credentials(
     return Credentials(namespace, resolved)
 
 
-# ── creds-schema.toml parser (spec § AC24, AC24b) ─────────────────────
+# ── creds-schema.toml parser ──────────────────────────────────────────
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -649,7 +649,7 @@ class KeyDef:
     """A single required key declared in ``creds-schema.toml``.
 
     ``secret=True`` keys are prompted via ``getpass.getpass`` (no echo);
-    ``secret=False`` keys are prompted via ``input()`` per spec § AC24.
+    ``secret=False`` keys are prompted via ``input()``.
     """
 
     name: str
@@ -668,7 +668,7 @@ class CredsSchema:
 def _parse_schema(path: pathlib.Path) -> CredsSchema:
     """Parse a ``creds-schema.toml`` file into a typed ``CredsSchema``.
 
-    Per spec § AC24, the expected shape is::
+    The expected shape is::
 
         [namespace]
         name = "<namespace>"
@@ -733,7 +733,7 @@ _SKILL_MD_RE = re.compile(r"^\.claude/skills/([^/]+)/SKILL\.md$")
 def _relative_schema_path(
     state: "object", pack: str, skill_name: str
 ) -> pathlib.Path:
-    """Resolve the *state-relative* ``creds-schema.toml`` path per spec § AC24b.
+    """Resolve the *state-relative* ``creds-schema.toml`` path.
 
     Walks ``state.packs[pack].files`` for a relpath matching
     ``^\\.claude/skills/<skill_name>/SKILL\\.md$``; returns the
@@ -745,7 +745,7 @@ def _relative_schema_path(
     underscore-prefixed name reflects that contract; CLI callers go
     through `commands/creds._resolve_schema_for_namespace` which joins
     against `SKILL.md.parent` directly instead of calling this helper.
-    Kept around because it pins the AC24b state-walk shape with its
+    Kept around because it pins the state-walk shape with its
     own tests.
 
     Raises ``SchemaError`` if no matching SKILL.md row is in

--- a/packs/atlassian/.apm/skills/jira/references/creds-schema.toml
+++ b/packs/atlassian/.apm/skills/jira/references/creds-schema.toml
@@ -1,9 +1,9 @@
 # Credentials schema for the jira credentialed primitive.
-# Format pinned by skill-secrets spec § AC24.
+# Format: a [namespace] table plus one [[namespace.keys]] entry per key.
 #
 # Resolution: load_credentials("jira", required_keys=[...]) walks
-# Tier 1 (env) → Tier 2 (OS keyring) → Tier 3 (~/.agentbundle/credentials.env)
-# per AC4. Env-var shape is <NAMESPACE>_<KEY> — JIRA_BASE_URL, JIRA_EMAIL,
+# Tier 1 (env) → Tier 2 (OS keyring) → Tier 3 (~/.agentbundle/credentials.env).
+# Env-var shape is <NAMESPACE>_<KEY> — JIRA_BASE_URL, JIRA_EMAIL,
 # JIRA_API_TOKEN, JIRA_FLAVOR.
 #
 # BASE_URL and API_TOKEN are required for any operation. EMAIL is

--- a/packs/atlassian/.apm/skills/jira/scripts/_credman_windows.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/_credman_windows.py
@@ -1,4 +1,4 @@
-"""Windows Credential Manager Tier-2 backend (spec § AC9-AC12).
+"""Windows Credential Manager Tier-2 backend.
 
 In-process ``ctypes`` against ``advapi32.dll``'s ``CredReadW`` /
 ``CredWriteW`` / ``CredDeleteW`` / ``CredFree`` — stdlib only, no
@@ -15,7 +15,7 @@ zero-initialised via ``ctypes.Structure`` defaults — required by
 NULL when ``AttributeCount`` is 0; ``LastWritten`` is set by the API
 and ignored on write).
 
-Per spec § AC4b the loader imports this module **only** when
+The loader imports this module **only** when
 ``sys.platform == "win32"``. The advapi32 binding is platform-guarded
 below so the module itself stays importable on every platform; tests
 that don't actually call the OS can construct ``CREDENTIAL`` instances
@@ -31,11 +31,11 @@ from ctypes import POINTER, Structure, byref
 
 from .credentials_shim import Tier2HardFailError
 
-# Constants from ``wincred.h`` (spec § AC9):
+# Constants from ``wincred.h``:
 CRED_TYPE_GENERIC = 1
 CRED_PERSIST_LOCAL_MACHINE = 2
 
-# Win32 error codes — sourced from ``winerror.h`` and AC11:
+# Win32 error codes — sourced from ``winerror.h``:
 ERROR_NOT_FOUND = 1168          # falls through to Tier 3
 ERROR_NO_SUCH_LOGON_SESSION = 1312
 ERROR_INVALID_FLAGS = 1004
@@ -44,7 +44,7 @@ ERROR_LOGON_FAILURE = 1326
 TARGET_PREFIX = "agentbundle"
 # Tests can monkeypatch this to a ``tmp_path``-derived value so test
 # target-names can't collide with the developer's real Credential
-# Manager entries (spec § AC35 / plan T5 § Test isolation).
+# Manager entries.
 SERVICE_PREFIX_OVERRIDE: str | None = None
 
 
@@ -53,7 +53,7 @@ class CREDENTIAL(Structure):
 
     Field order and types must match the Win32 ABI exactly — a wrong-
     sized field on Windows returns garbage rather than raising, which
-    is why AC10 mandates a byte-equality round-trip test on every field.
+    is why a byte-equality round-trip test covers every field.
     """
 
     _fields_ = [
@@ -104,18 +104,18 @@ else:
 
 
 def _target_name(namespace: str, key: str) -> str:
-    """Compose the Win32 ``TargetName`` per spec § AC9."""
+    """Compose the Win32 ``TargetName``."""
     prefix = SERVICE_PREFIX_OVERRIDE or TARGET_PREFIX
     return f"{prefix}:{namespace}:{key}"
 
 
 def _classify_last_error(rc: int, op: str) -> None:
-    """Map the Win32 last-error code to the AC11 dispatch matrix.
+    """Map the Win32 last-error code to the dispatch matrix.
 
     ``ERROR_NOT_FOUND`` is the caller's responsibility (it indicates a
     legitimate miss — caller returns ``None``). Every other code on
     this matrix raises ``Tier2HardFailError`` so the resolver does not
-    silently degrade to Tier 3 (spec § Never do).
+    silently degrade to Tier 3.
     """
     if rc == ERROR_NO_SUCH_LOGON_SESSION:
         raise Tier2HardFailError(
@@ -144,7 +144,7 @@ def read_credential(namespace: str, key: str) -> str | None:
 
     Returns ``None`` on ``ERROR_NOT_FOUND`` (resolver falls through to
     Tier 3); raises ``Tier2HardFailError`` on every other documented
-    failure (AC11).
+    failure.
     """
     target = _target_name(namespace, key)
     out_ptr = POINTER(CREDENTIAL)()
@@ -169,7 +169,7 @@ def read_credential(namespace: str, key: str) -> str | None:
 
 
 def write_credential(namespace: str, key: str, value: str) -> None:
-    """Write ``value`` to ``(namespace, key)`` (AC9, AC10).
+    """Write ``value`` to ``(namespace, key)``.
 
     The token is UTF-16-LE encoded and stored in a writable buffer
     pointed to by ``CredentialBlob``; ``CredentialBlobSize`` is the
@@ -183,7 +183,7 @@ def write_credential(namespace: str, key: str, value: str) -> None:
     # All other fields stay at ctypes.Structure's zero-init defaults
     # (Flags=0, Comment=None, LastWritten=FILETIME(0,0),
     # AttributeCount=0, Attributes=None, TargetAlias=None) — required
-    # by CRED_TYPE_GENERIC per spec § AC9.
+    # by CRED_TYPE_GENERIC.
     cred.Type = CRED_TYPE_GENERIC
     cred.TargetName = target
     cred.CredentialBlobSize = len(blob)

--- a/packs/atlassian/.apm/skills/jira/scripts/_keychain_macos.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/_keychain_macos.py
@@ -1,8 +1,8 @@
-"""macOS Keychain Tier-2 backend (spec § AC6-AC8).
+"""macOS Keychain Tier-2 backend.
 
 Stdlib subprocess against ``/usr/bin/security`` — the system-shipped
-Keychain CLI. Guaranteed present on every macOS install per spec §
-Boundaries § Never do (no third-party ``keyring`` dependency).
+Keychain CLI. Guaranteed present on every macOS install (no third-party
+``keyring`` dependency).
 
 Token bytes never reach argv:
 
@@ -16,7 +16,7 @@ Token bytes never reach argv:
 - **Delete** uses ``delete-generic-password`` (idempotent on miss).
 
 The build-projected ``credentials_shim`` imports this module **only**
-when ``sys.platform == "darwin"`` per AC4b. Tests monkeypatch
+when ``sys.platform == "darwin"``. Tests monkeypatch
 ``SERVICE`` to a ``tmp_path``-derived prefix so test entries never
 collide with the developer's real ``agentbundle`` Keychain entries.
 """
@@ -34,9 +34,9 @@ SERVICE = "agentbundle"
 # developer's login Keychain. ``security``'s ``-w`` prompt mode requires
 # ``-w`` as the trailing argv element, which forecloses the trailing-
 # keychain-positional approach to test isolation; the service-prefix
-# approach lets the canonical AC6 argv shape stay untouched.
+# approach lets the canonical argv shape stay untouched.
 
-# macOS Security framework OSStatus codes (spec § AC22):
+# macOS Security framework OSStatus codes:
 #   44      errSecItemNotFound          — legitimate "no such credential",
 #                                         falls through to Tier 3.
 #   45      errSecDuplicateItem         — only relevant on add; the ``-U``
@@ -46,7 +46,7 @@ SERVICE = "agentbundle"
 #
 # Names taken from ``<Security/SecBase.h>``. The two "Keychain locked /
 # unavailable" codes (25308 / -25291) MUST raise ``Tier2HardFailError``
-# so ``run_setup`` can route the AC22 fallback gate — silently
+# so ``run_setup`` can route the fallback gate — silently
 # degrading to Tier 3 defeats the security posture the user chose.
 EXIT_NOT_FOUND = 44
 EXIT_DUPLICATE_ITEM = 45
@@ -62,8 +62,7 @@ def _classify_macos_exit_code(rc: int, op: str) -> str | None:
     embed it in a ``Tier2HardFailError`` message. Returns ``None`` for
     ``EXIT_NOT_FOUND`` (the caller treats that as a legitimate miss).
 
-    Parallel in shape to ``_credman_windows._classify_last_error``;
-    AC22 cites this matrix explicitly.
+    Parallel in shape to ``_credman_windows._classify_last_error``.
     """
     if rc == 0:
         return None
@@ -92,12 +91,12 @@ def _classify_macos_exit_code(rc: int, op: str) -> str | None:
 
 
 def _account(namespace: str, key: str) -> str:
-    """Compose the Keychain account label per spec § AC6."""
+    """Compose the Keychain account label."""
     return f"{namespace}:{key}"
 
 
 def read_credential(namespace: str, key: str) -> str | None:
-    """Read ``(namespace, key)`` from the Keychain (spec § AC6, AC7)."""
+    """Read ``(namespace, key)`` from the Keychain."""
     argv = [
         SECURITY_BIN, "find-generic-password",
         "-s", SERVICE,
@@ -121,7 +120,7 @@ def read_credential(namespace: str, key: str) -> str | None:
 
 def write_credential(namespace: str, key: str, value: str) -> None:
     """Write ``value`` to ``(namespace, key)``. Token enters via child stdin
-    only — never argv (spec § AC6, AC7).
+    only — never argv.
 
     Refuses values containing ``\\n`` or ``\\r`` up front. ``security -w``
     prompts twice and the stdin payload is ``token + b"\\n" + token + b"\\n"``;

--- a/packs/atlassian/.apm/skills/jira/scripts/credentials_shim.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/credentials_shim.py
@@ -13,9 +13,9 @@ Public surface a credentialed-primitive author imports:
 - ``Credentials`` — immutable, attribute-access view of the resolved values.
 - ``EnvParseError`` — raised by ``parse_env_file`` on unsupported syntax.
 
-Stdlib-only per spec § Boundaries § Never do — no ``python-dotenv``, no
+Stdlib-only by design — no ``python-dotenv``, no
 ``keyring``, no third-party imports. The Tier-2 backend is dispatched at
-module-load time per AC4b: ``_keychain_macos`` iff ``sys.platform ==
+module-load time: ``_keychain_macos`` iff ``sys.platform ==
 "darwin"``, ``_credman_windows`` iff ``"win32"``, no Tier-2 backend on
 other platforms (resolver falls through directly to Tier 3).
 
@@ -36,8 +36,8 @@ Trailing ``\\r`` from CRLF line endings is stripped; ``\\r`` *inside* a
 quoted value is preserved (``KEY="a\\rb"`` → ``{"KEY": "a\\rb"}``).
 
 When loaded outside a consumer-skill ``scripts/`` directory — e.g. as
-a sibling under ``~/.agentbundle/bin/`` per the credential-broker-contract
-AC22b companion projection — the shim's own ``_tier2_backend`` resolves
+a sibling under ``~/.agentbundle/bin/`` per the shim companion
+projection — the shim's own ``_tier2_backend`` resolves
 to ``None``. Callers in that context must not rely on ``load_credentials``
 for Tier-2 resolution; that path is the consumer-skill ``scripts/``
 projection only.
@@ -94,7 +94,7 @@ class Tier2HardFailError(Exception):
 class PermissiveAclError(Exception):
     """Raised when the Windows DACL on the Tier-3 dotfile is too permissive.
 
-    Per spec § AC15: ``icacls`` is invoked after each write; non-default
+    ``icacls`` is invoked after each write; non-default
     ACEs (anything beyond the inherited user / ``NT AUTHORITY\\SYSTEM`` /
     ``BUILTIN\\Administrators``) cause the helper to refuse unless
     ``allow_permissive_acl=True`` was passed.
@@ -104,7 +104,7 @@ class PermissiveAclError(Exception):
 class SchemaError(Exception):
     """Raised when a ``creds-schema.toml`` file is malformed or missing.
 
-    Per spec § AC24 / AC24b — names the offending file path and the
+    Names the offending file path and the
     specific shape violation (missing ``[namespace]``, empty
     ``namespace.keys``, non-boolean ``secret``, or unresolvable
     canonical path).
@@ -186,11 +186,11 @@ def parse_env_file(path: pathlib.Path) -> dict[str, str]:
         result[key] = value
     return result
 
-# Tier-2 backend dispatch at module-load time (spec § AC4b). The backend
-# modules are added by T4 (macOS) and T5 (Windows); until they land, the
-# try/except yields ``None`` and the resolver skips Tier 2 on the matching
-# platform. On Linux (and any non-Darwin / non-Windows platform), no import
-# is attempted at all — Tier 2 is unavailable by absence.
+# Tier-2 backend dispatch at module-load time. If a platform's backend
+# module is absent, the try/except yields ``None`` and the resolver skips
+# Tier 2 on the matching platform. On Linux (and any non-Darwin /
+# non-Windows platform), no import is attempted at all — Tier 2 is
+# unavailable by absence.
 if sys.platform == "darwin":
     try:
         from . import _keychain_macos as _tier2_backend  # type: ignore[no-redef]
@@ -208,7 +208,7 @@ else:
 class Credentials:
     """Immutable, attribute-access view of a namespace's resolved credentials.
 
-    Constructed by ``load_credentials``. The contract (spec § AC3) is:
+    Constructed by ``load_credentials``. The contract is:
 
     - Attribute access returns the resolved value:
       ``creds.API_TOKEN`` returns the resolved ``API_TOKEN`` for the
@@ -276,7 +276,7 @@ class Credentials:
 
 
 def _tier1_env(namespace: str, key: str) -> str | None:
-    """Resolve ``<NAMESPACE>_<KEY>`` from ``os.environ`` (spec § AC5).
+    """Resolve ``<NAMESPACE>_<KEY>`` from ``os.environ``.
 
     Empty-string env vars count as unset and return ``None`` so the
     resolver falls through to lower tiers.
@@ -289,12 +289,12 @@ def _tier1_env(namespace: str, key: str) -> str | None:
 
 
 def _tier2(namespace: str, key: str) -> str | None:
-    """Resolve via the platform-specific keyring backend (spec § AC6, AC9).
+    """Resolve via the platform-specific keyring backend.
 
     Returns ``None`` when the backend is absent (non-Darwin / non-Windows
-    platforms, or backend modules not yet shipped) or reports a clean
+    platforms, or backend modules not shipped) or reports a clean
     miss. Hard-fail error codes from the underlying API propagate as
-    ``Tier2HardFailError`` per AC11.
+    ``Tier2HardFailError``.
     """
     if _tier2_backend is None:
         return None
@@ -302,7 +302,7 @@ def _tier2(namespace: str, key: str) -> str | None:
 
 
 def _tier3(namespace: str, key: str) -> str | None:
-    """Resolve from the Tier-3 dotfile (spec § AC13).
+    """Resolve from the Tier-3 dotfile.
 
     Reads ``~/.agentbundle/credentials.env`` via the stdlib parser and
     looks up ``<NAMESPACE>_<KEY>``. Returns ``None`` on miss; a malformed
@@ -317,7 +317,7 @@ def _tier3(namespace: str, key: str) -> str | None:
 
 
 def _dotfile_path() -> pathlib.Path:
-    """Canonical Tier-3 dotfile path per spec § AC13.
+    """Canonical Tier-3 dotfile path.
 
     Resolves to ``pathlib.Path.home() / ".agentbundle" / "credentials.env"``
     on every platform. Tests redirect ``HOME`` (and ``USERPROFILE`` on
@@ -399,7 +399,7 @@ def _verify_icacls(
     path: pathlib.Path, *, allow_permissive_acl: bool = False
 ) -> None:
     """Run ``icacls /findsid`` and refuse if any well-known "broad
-    access" SID is granted access on the path (spec § AC15). No-op on
+    access" SID is granted access on the path. No-op on
     POSIX.
 
     Default ACEs on a per-user file are the inheriting user,
@@ -437,7 +437,7 @@ def _verify_icacls(
 
 
 def _ensure_parent(parent: pathlib.Path) -> None:
-    """Create the dotfile parent at mode 0o700 if absent (spec § AC15).
+    """Create the dotfile parent at mode 0o700 if absent.
 
     If the parent already exists, do **not** rewrite its mode — the
     directory is shared with ``~/.agentbundle/state.toml``.
@@ -465,7 +465,7 @@ def _dotfile_write(
 ) -> None:
     """Write ``(namespace, key) → value`` to the Tier-3 dotfile atomically.
 
-    Atomic write contract per spec § AC14:
+    Atomic write contract:
     ``tempfile.mkstemp(dir=target_dir)`` → ``os.write`` →
     ``os.fchmod`` (POSIX) → ``os.close`` → ``os.replace``. A mid-write
     read sees either the prior contents or the new contents, never
@@ -556,7 +556,7 @@ def load_credentials(
 ) -> Credentials:
     """Resolve ``required_keys`` for ``namespace``, walking Tiers 1 → 2 → 3.
 
-    First-hit-wins per key (spec § AC4): a key resolved at Tier 1 is not
+    First-hit-wins per key: a key resolved at Tier 1 is not
     re-checked at lower tiers; mixing tiers across keys within one
     namespace is permitted.
 
@@ -593,8 +593,8 @@ def load_credentials(
         attempts.append(f"Tier 1: env {env_name!r} not set")
 
         # Tier 2 — OS keyring (when loaded). Tier2HardFailError
-        # propagates per AC11 (no silent fallback to Tier 3 on hard
-        # fail); only a clean miss falls through.
+        # propagates (no silent fallback to Tier 3 on hard fail);
+        # only a clean miss falls through.
         if _tier2_backend is None:
             attempts.append("Tier 2: not loaded (no keyring backend on this platform)")
         else:
@@ -621,8 +621,8 @@ def load_credentials(
         tiers_tried[key] = attempts
 
     if missing:
-        # One-line preamble preserves the AC3 contract (message names
-        # namespace and the missing-keys list); the per-key trailer
+        # One-line preamble names the namespace and the missing-keys
+        # list; the per-key trailer
         # block comes below for triage.
         lines = [
             f"namespace {namespace!r}: missing required credential(s): "
@@ -641,7 +641,7 @@ def load_credentials(
     return Credentials(namespace, resolved)
 
 
-# ── creds-schema.toml parser (spec § AC24, AC24b) ─────────────────────
+# ── creds-schema.toml parser ──────────────────────────────────────────
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -649,7 +649,7 @@ class KeyDef:
     """A single required key declared in ``creds-schema.toml``.
 
     ``secret=True`` keys are prompted via ``getpass.getpass`` (no echo);
-    ``secret=False`` keys are prompted via ``input()`` per spec § AC24.
+    ``secret=False`` keys are prompted via ``input()``.
     """
 
     name: str
@@ -668,7 +668,7 @@ class CredsSchema:
 def _parse_schema(path: pathlib.Path) -> CredsSchema:
     """Parse a ``creds-schema.toml`` file into a typed ``CredsSchema``.
 
-    Per spec § AC24, the expected shape is::
+    The expected shape is::
 
         [namespace]
         name = "<namespace>"
@@ -733,7 +733,7 @@ _SKILL_MD_RE = re.compile(r"^\.claude/skills/([^/]+)/SKILL\.md$")
 def _relative_schema_path(
     state: "object", pack: str, skill_name: str
 ) -> pathlib.Path:
-    """Resolve the *state-relative* ``creds-schema.toml`` path per spec § AC24b.
+    """Resolve the *state-relative* ``creds-schema.toml`` path.
 
     Walks ``state.packs[pack].files`` for a relpath matching
     ``^\\.claude/skills/<skill_name>/SKILL\\.md$``; returns the
@@ -745,7 +745,7 @@ def _relative_schema_path(
     underscore-prefixed name reflects that contract; CLI callers go
     through `commands/creds._resolve_schema_for_namespace` which joins
     against `SKILL.md.parent` directly instead of calling this helper.
-    Kept around because it pins the AC24b state-walk shape with its
+    Kept around because it pins the state-walk shape with its
     own tests.
 
     Raises ``SchemaError`` if no matching SKILL.md row is in

--- a/packs/core/.apm/commands/conventions-check.md
+++ b/packs/core/.apm/commands/conventions-check.md
@@ -30,14 +30,13 @@ Run these repo linters and report findings.
 4. Skill dirs contain a `SKILL.md` (and no stray `.md` siblings).
 5. Internal markdown links inside each artifact resolve.
 
-**`bash tools/lint-credentialed-skills.sh`** — credentialed-skill rules
-(skill-secrets spec § AC26 — see `docs/specs/skill-secrets/spec.md`);
+**`bash tools/lint-credentialed-skills.sh`** — credentialed-skill rules,
 scoped to skills whose `SKILL.md` declares `metadata.credentialed: true`
 (per agentskills.io spec, project-specific fields live under
 `metadata:`):
 
 1. The body contains an `### Security rules (non-negotiable)` heading
-   and the three RFC-0006 § 4 substrings inside that section (the
+   and the three required security substrings inside that section (the
    verbatim "Don't" block).
 2. For `metadata.primitive-class: credentialed-cli`: no script under
    the skill's `scripts/` directory accepts an `argparse` flag whose

--- a/packs/core/.apm/hook-wiring/session-start.toml
+++ b/packs/core/.apm/hook-wiring/session-start.toml
@@ -17,7 +17,7 @@
 # No `id` field: repo-scope merge-json does not consume it (the field
 # is a user-scope concern in _merge_user_scope_hook_wiring). No
 # `attach-to-agent`: that's a Kiro-only field, and Kiro is out of
-# scope (see docs/specs/wire-session-start-hook/spec.md § Non-goals).
+# scope here.
 [[hooks.SessionStart]]
 hooks = [
   { type = "command", command = "python tools/hooks/session-start.py" },

--- a/packs/core/.apm/skills/adapt-to-project/SKILL.md
+++ b/packs/core/.apm/skills/adapt-to-project/SKILL.md
@@ -207,7 +207,7 @@ fold into `~/.claude/agents/bot.md`. Per-finding accept / edit /
 decline; recordings land in the scope of the file the finding was
 observed in.
 
-**Cross-scope restructure (AC23, never executed as a single move).**
+**Cross-scope restructure (never executed as a single move).**
 When a class-3 finding's `source-path` and `destination-path` live
 at different scopes (e.g., source under `<repo>/`, destination under
 `~/.claude/`), this cross-scope restructure is never executed as a single move. The skill detects the scope crossing, names both

--- a/packs/core/.apm/skills/work-loop/scripts/loop-cohort.py
+++ b/packs/core/.apm/skills/work-loop/scripts/loop-cohort.py
@@ -368,14 +368,14 @@ def dispatch_decision(categories, *, merge_tree_clean):
 
 def _dispatch_rationale(categories, *, merge_tree_clean, decision, source=None) -> str:
     """Human-readable one-line rationale for a `dispatch-decision` outcome —
-    the cleared-gate surface (AC10). On ``parallel`` it names the wave as
+    the cleared-gate surface. On ``parallel`` it names the wave as
     parallel-eligible + the task count; on ``serial`` it names the
     disqualifying reason, **merge-tree conflict first** to match
     `dispatch_decision`'s short-circuit order (so a both-fail wave names the
     conflict, not the category). ``source`` (``"auto"`` | ``"human"`` | None)
     names whether categories were auto-derived from branch diffs or
-    human-supplied; **None preserves the original output verbatim** so the
-    parent spec's AC10 tests stay green (additive change)."""
+    human-supplied; **None preserves the original output verbatim** so
+    existing output-shape tests stay green (additive change)."""
     if decision == "parallel":
         msg = (
             f"wave is PARALLEL-ELIGIBLE — {len(categories)} task(s), all "
@@ -494,7 +494,7 @@ def added_paths_may_share_symbol(per_branch_added) -> bool:
 def wave_is_disjoint(branches) -> bool:
     """True iff the wave's branches merge without conflict, via read-only
     ``git merge-tree`` (no working-tree mutation). Pairwise over the wave;
-    called by the ``dispatch-decision`` verb (and the AC9 worktree dry-run)."""
+    called by the ``dispatch-decision`` verb (and the worktree dry-run)."""
     for i in range(len(branches)):
         for j in range(i + 1, len(branches)):
             proc = run_git(
@@ -610,7 +610,7 @@ def cmd_dispatch_decision(args: argparse.Namespace) -> int:
 
     decision = dispatch_decision(categories, merge_tree_clean=clean)
     print(decision)  # stdout: the machine-readable token (scripted reads)
-    # stderr: the human-facing cleared-gate surface (AC10) — so the agent has
+    # stderr: the human-facing cleared-gate surface — so the agent has
     # something to present to the human for opt-in, never fanning out silently.
     print(
         "dispatch-decision: " + _dispatch_rationale(

--- a/packs/credential-brokers/.apm/adapter-root-bins/_sso_credman_windows.py
+++ b/packs/credential-brokers/.apm/adapter-root-bins/_sso_credman_windows.py
@@ -1,4 +1,4 @@
-"""Windows Credential Manager Tier-2 backend (spec § AC9-AC12).
+"""Windows Credential Manager Tier-2 backend.
 
 In-process ``ctypes`` against ``advapi32.dll``'s ``CredReadW`` /
 ``CredWriteW`` / ``CredDeleteW`` / ``CredFree`` — stdlib only, no
@@ -15,7 +15,7 @@ zero-initialised via ``ctypes.Structure`` defaults — required by
 NULL when ``AttributeCount`` is 0; ``LastWritten`` is set by the API
 and ignored on write).
 
-Per spec § AC4b the loader imports this module **only** when
+The loader imports this module **only** when
 ``sys.platform == "win32"``. The advapi32 binding is platform-guarded
 below so the module itself stays importable on every platform; tests
 that don't actually call the OS can construct ``CREDENTIAL`` instances
@@ -31,11 +31,11 @@ from ctypes import POINTER, Structure, byref
 
 from .credentials_shim import Tier2HardFailError
 
-# Constants from ``wincred.h`` (spec § AC9):
+# Constants from ``wincred.h``:
 CRED_TYPE_GENERIC = 1
 CRED_PERSIST_LOCAL_MACHINE = 2
 
-# Win32 error codes — sourced from ``winerror.h`` and AC11:
+# Win32 error codes — sourced from ``winerror.h``:
 ERROR_NOT_FOUND = 1168          # falls through to Tier 3
 ERROR_NO_SUCH_LOGON_SESSION = 1312
 ERROR_INVALID_FLAGS = 1004
@@ -44,7 +44,7 @@ ERROR_LOGON_FAILURE = 1326
 TARGET_PREFIX = "agentbundle"
 # Tests can monkeypatch this to a ``tmp_path``-derived value so test
 # target-names can't collide with the developer's real Credential
-# Manager entries (spec § AC35 / plan T5 § Test isolation).
+# Manager entries.
 SERVICE_PREFIX_OVERRIDE: str | None = None
 
 
@@ -53,7 +53,7 @@ class CREDENTIAL(Structure):
 
     Field order and types must match the Win32 ABI exactly — a wrong-
     sized field on Windows returns garbage rather than raising, which
-    is why AC10 mandates a byte-equality round-trip test on every field.
+    is why a byte-equality round-trip test covers every field.
     """
 
     _fields_ = [
@@ -104,18 +104,18 @@ else:
 
 
 def _target_name(namespace: str, key: str) -> str:
-    """Compose the Win32 ``TargetName`` per spec § AC9."""
+    """Compose the Win32 ``TargetName``."""
     prefix = SERVICE_PREFIX_OVERRIDE or TARGET_PREFIX
     return f"{prefix}:{namespace}:{key}"
 
 
 def _classify_last_error(rc: int, op: str) -> None:
-    """Map the Win32 last-error code to the AC11 dispatch matrix.
+    """Map the Win32 last-error code to the dispatch matrix.
 
     ``ERROR_NOT_FOUND`` is the caller's responsibility (it indicates a
     legitimate miss — caller returns ``None``). Every other code on
     this matrix raises ``Tier2HardFailError`` so the resolver does not
-    silently degrade to Tier 3 (spec § Never do).
+    silently degrade to Tier 3.
     """
     if rc == ERROR_NO_SUCH_LOGON_SESSION:
         raise Tier2HardFailError(
@@ -144,7 +144,7 @@ def read_credential(namespace: str, key: str) -> str | None:
 
     Returns ``None`` on ``ERROR_NOT_FOUND`` (resolver falls through to
     Tier 3); raises ``Tier2HardFailError`` on every other documented
-    failure (AC11).
+    failure.
     """
     target = _target_name(namespace, key)
     out_ptr = POINTER(CREDENTIAL)()
@@ -169,7 +169,7 @@ def read_credential(namespace: str, key: str) -> str | None:
 
 
 def write_credential(namespace: str, key: str, value: str) -> None:
-    """Write ``value`` to ``(namespace, key)`` (AC9, AC10).
+    """Write ``value`` to ``(namespace, key)``.
 
     The token is UTF-16-LE encoded and stored in a writable buffer
     pointed to by ``CredentialBlob``; ``CredentialBlobSize`` is the
@@ -183,7 +183,7 @@ def write_credential(namespace: str, key: str, value: str) -> None:
     # All other fields stay at ctypes.Structure's zero-init defaults
     # (Flags=0, Comment=None, LastWritten=FILETIME(0,0),
     # AttributeCount=0, Attributes=None, TargetAlias=None) — required
-    # by CRED_TYPE_GENERIC per spec § AC9.
+    # by CRED_TYPE_GENERIC.
     cred.Type = CRED_TYPE_GENERIC
     cred.TargetName = target
     cred.CredentialBlobSize = len(blob)

--- a/packs/credential-brokers/.apm/adapter-root-bins/_sso_keychain_macos.py
+++ b/packs/credential-brokers/.apm/adapter-root-bins/_sso_keychain_macos.py
@@ -1,8 +1,8 @@
-"""macOS Keychain Tier-2 backend (spec § AC6-AC8).
+"""macOS Keychain Tier-2 backend.
 
 Stdlib subprocess against ``/usr/bin/security`` — the system-shipped
-Keychain CLI. Guaranteed present on every macOS install per spec §
-Boundaries § Never do (no third-party ``keyring`` dependency).
+Keychain CLI. Guaranteed present on every macOS install (no third-party
+``keyring`` dependency).
 
 Token bytes never reach argv:
 
@@ -16,7 +16,7 @@ Token bytes never reach argv:
 - **Delete** uses ``delete-generic-password`` (idempotent on miss).
 
 The build-projected ``credentials_shim`` imports this module **only**
-when ``sys.platform == "darwin"`` per AC4b. Tests monkeypatch
+when ``sys.platform == "darwin"``. Tests monkeypatch
 ``SERVICE`` to a ``tmp_path``-derived prefix so test entries never
 collide with the developer's real ``agentbundle`` Keychain entries.
 """
@@ -34,9 +34,9 @@ SERVICE = "agentbundle"
 # developer's login Keychain. ``security``'s ``-w`` prompt mode requires
 # ``-w`` as the trailing argv element, which forecloses the trailing-
 # keychain-positional approach to test isolation; the service-prefix
-# approach lets the canonical AC6 argv shape stay untouched.
+# approach lets the canonical argv shape stay untouched.
 
-# macOS Security framework OSStatus codes (spec § AC22):
+# macOS Security framework OSStatus codes:
 #   44      errSecItemNotFound          — legitimate "no such credential",
 #                                         falls through to Tier 3.
 #   45      errSecDuplicateItem         — only relevant on add; the ``-U``
@@ -46,7 +46,7 @@ SERVICE = "agentbundle"
 #
 # Names taken from ``<Security/SecBase.h>``. The two "Keychain locked /
 # unavailable" codes (25308 / -25291) MUST raise ``Tier2HardFailError``
-# so ``run_setup`` can route the AC22 fallback gate — silently
+# so ``run_setup`` can route the fallback gate — silently
 # degrading to Tier 3 defeats the security posture the user chose.
 EXIT_NOT_FOUND = 44
 EXIT_DUPLICATE_ITEM = 45
@@ -62,8 +62,7 @@ def _classify_macos_exit_code(rc: int, op: str) -> str | None:
     embed it in a ``Tier2HardFailError`` message. Returns ``None`` for
     ``EXIT_NOT_FOUND`` (the caller treats that as a legitimate miss).
 
-    Parallel in shape to ``_credman_windows._classify_last_error``;
-    AC22 cites this matrix explicitly.
+    Parallel in shape to ``_credman_windows._classify_last_error``.
     """
     if rc == 0:
         return None
@@ -92,12 +91,12 @@ def _classify_macos_exit_code(rc: int, op: str) -> str | None:
 
 
 def _account(namespace: str, key: str) -> str:
-    """Compose the Keychain account label per spec § AC6."""
+    """Compose the Keychain account label."""
     return f"{namespace}:{key}"
 
 
 def read_credential(namespace: str, key: str) -> str | None:
-    """Read ``(namespace, key)`` from the Keychain (spec § AC6, AC7)."""
+    """Read ``(namespace, key)`` from the Keychain."""
     argv = [
         SECURITY_BIN, "find-generic-password",
         "-s", SERVICE,
@@ -121,7 +120,7 @@ def read_credential(namespace: str, key: str) -> str | None:
 
 def write_credential(namespace: str, key: str, value: str) -> None:
     """Write ``value`` to ``(namespace, key)``. Token enters via child stdin
-    only — never argv (spec § AC6, AC7).
+    only — never argv.
 
     Refuses values containing ``\\n`` or ``\\r`` up front. ``security -w``
     prompts twice and the stdin payload is ``token + b"\\n" + token + b"\\n"``;

--- a/packs/credential-brokers/.apm/adapter-root-bins/sso-broker.py
+++ b/packs/credential-brokers/.apm/adapter-root-bins/sso-broker.py
@@ -1,4 +1,4 @@
-"""SSO-cookie broker — credential-broker-contract T5.
+"""SSO-cookie broker.
 
 Six verbs: register / get-cookies / test / refresh / list-profiles / rm.
 
@@ -13,8 +13,6 @@ and ``agentbundle:sso:<profile>:<n>`` for continuation slots.
 
 This script lives at ``~/.agentbundle/bin/sso-broker.py`` and is
 subprocess-invoked from `auth: sso-cookie` consumer skills.
-
-Refs: docs/specs/credential-broker-contract/spec.md (AC9-AC17).
 """
 
 from __future__ import annotations
@@ -36,7 +34,7 @@ import urllib.request
 # ``__spec__ is None`` so the block only fires for true file-path
 # invocation; an importlib-based test harness is responsible for its
 # own package context. The shim companion (``credentials_shim.py``)
-# is co-located by the AC22b projection rule, so the per-platform
+# is co-located by the shim-companion projection rule, so the per-platform
 # ``_sso_*`` modules' ``from .credentials_shim import Tier2HardFailError``
 # resolves under user-scope install.
 if __package__ in (None, "") and __spec__ is None:
@@ -45,13 +43,13 @@ if __package__ in (None, "") and __spec__ is None:
     __package__ = _here.name
 
 
-# Per AC12 — chosen explicitly to leave headroom under the Win32
+# Chosen explicitly to leave headroom under the Win32
 # CRED_MAX_CREDENTIAL_BLOB_SIZE lower-bound of 2560 bytes pre-Windows 7.
 # macOS Keychain and Linux dotfile have higher capacity but the same
 # threshold is applied uniformly for cross-platform determinism.
 CRED_MAX_CREDENTIAL_BLOB_SIZE_BYTES = 2048
 
-# Reserved keychain-target namespace for this broker (AC12).
+# Reserved keychain-target namespace for this broker.
 # Every write_credential / read_credential call site constructs target
 # names of shape agentbundle:sso:<profile> (or :<n> for continuation).
 _SSO_NAMESPACE = "agentbundle:sso"
@@ -374,7 +372,7 @@ def _do_register(profile: str, args: argparse.Namespace) -> int:
     success = False
     success_re = re.compile(success_pattern)
 
-    # Corporate-network env passthrough — explicit per AC14.
+    # Corporate-network env passthrough — explicit by design.
     env_for_browser = {**os.environ}
 
     with sync_playwright() as pw:
@@ -595,7 +593,7 @@ def _do_list_profiles() -> int:
 def _do_show_tier2_backend() -> int:
     """Print ``repr(_tier2_backend)`` and exit 0.
 
-    Test surface for the AC22b shim-companion projection regression
+    Test surface for the shim-companion projection regression
     (`packages/agentbundle/tests/integration/test_credential_user_scope_invocation.py`):
     invoking ``python bin/sso-broker.py show-tier2-backend`` under the
     documented user-scope layout asserts the Tier-2 backend module
@@ -667,7 +665,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     sub.add_parser(
         "show-tier2-backend",
-        help="Print repr(_tier2_backend) (AC22b shim-companion probe).",
+        help="Print repr(_tier2_backend) (shim-companion probe).",
     )
 
     return parser

--- a/packs/credential-brokers/.apm/shared-libs/_credman_windows.py
+++ b/packs/credential-brokers/.apm/shared-libs/_credman_windows.py
@@ -1,4 +1,4 @@
-"""Windows Credential Manager Tier-2 backend (spec § AC9-AC12).
+"""Windows Credential Manager Tier-2 backend.
 
 In-process ``ctypes`` against ``advapi32.dll``'s ``CredReadW`` /
 ``CredWriteW`` / ``CredDeleteW`` / ``CredFree`` — stdlib only, no
@@ -15,7 +15,7 @@ zero-initialised via ``ctypes.Structure`` defaults — required by
 NULL when ``AttributeCount`` is 0; ``LastWritten`` is set by the API
 and ignored on write).
 
-Per spec § AC4b the loader imports this module **only** when
+The loader imports this module **only** when
 ``sys.platform == "win32"``. The advapi32 binding is platform-guarded
 below so the module itself stays importable on every platform; tests
 that don't actually call the OS can construct ``CREDENTIAL`` instances
@@ -31,11 +31,11 @@ from ctypes import POINTER, Structure, byref
 
 from .credentials_shim import Tier2HardFailError
 
-# Constants from ``wincred.h`` (spec § AC9):
+# Constants from ``wincred.h``:
 CRED_TYPE_GENERIC = 1
 CRED_PERSIST_LOCAL_MACHINE = 2
 
-# Win32 error codes — sourced from ``winerror.h`` and AC11:
+# Win32 error codes — sourced from ``winerror.h``:
 ERROR_NOT_FOUND = 1168          # falls through to Tier 3
 ERROR_NO_SUCH_LOGON_SESSION = 1312
 ERROR_INVALID_FLAGS = 1004
@@ -44,7 +44,7 @@ ERROR_LOGON_FAILURE = 1326
 TARGET_PREFIX = "agentbundle"
 # Tests can monkeypatch this to a ``tmp_path``-derived value so test
 # target-names can't collide with the developer's real Credential
-# Manager entries (spec § AC35 / plan T5 § Test isolation).
+# Manager entries.
 SERVICE_PREFIX_OVERRIDE: str | None = None
 
 
@@ -53,7 +53,7 @@ class CREDENTIAL(Structure):
 
     Field order and types must match the Win32 ABI exactly — a wrong-
     sized field on Windows returns garbage rather than raising, which
-    is why AC10 mandates a byte-equality round-trip test on every field.
+    is why a byte-equality round-trip test covers every field.
     """
 
     _fields_ = [
@@ -104,18 +104,18 @@ else:
 
 
 def _target_name(namespace: str, key: str) -> str:
-    """Compose the Win32 ``TargetName`` per spec § AC9."""
+    """Compose the Win32 ``TargetName``."""
     prefix = SERVICE_PREFIX_OVERRIDE or TARGET_PREFIX
     return f"{prefix}:{namespace}:{key}"
 
 
 def _classify_last_error(rc: int, op: str) -> None:
-    """Map the Win32 last-error code to the AC11 dispatch matrix.
+    """Map the Win32 last-error code to the dispatch matrix.
 
     ``ERROR_NOT_FOUND`` is the caller's responsibility (it indicates a
     legitimate miss — caller returns ``None``). Every other code on
     this matrix raises ``Tier2HardFailError`` so the resolver does not
-    silently degrade to Tier 3 (spec § Never do).
+    silently degrade to Tier 3.
     """
     if rc == ERROR_NO_SUCH_LOGON_SESSION:
         raise Tier2HardFailError(
@@ -144,7 +144,7 @@ def read_credential(namespace: str, key: str) -> str | None:
 
     Returns ``None`` on ``ERROR_NOT_FOUND`` (resolver falls through to
     Tier 3); raises ``Tier2HardFailError`` on every other documented
-    failure (AC11).
+    failure.
     """
     target = _target_name(namespace, key)
     out_ptr = POINTER(CREDENTIAL)()
@@ -169,7 +169,7 @@ def read_credential(namespace: str, key: str) -> str | None:
 
 
 def write_credential(namespace: str, key: str, value: str) -> None:
-    """Write ``value`` to ``(namespace, key)`` (AC9, AC10).
+    """Write ``value`` to ``(namespace, key)``.
 
     The token is UTF-16-LE encoded and stored in a writable buffer
     pointed to by ``CredentialBlob``; ``CredentialBlobSize`` is the
@@ -183,7 +183,7 @@ def write_credential(namespace: str, key: str, value: str) -> None:
     # All other fields stay at ctypes.Structure's zero-init defaults
     # (Flags=0, Comment=None, LastWritten=FILETIME(0,0),
     # AttributeCount=0, Attributes=None, TargetAlias=None) — required
-    # by CRED_TYPE_GENERIC per spec § AC9.
+    # by CRED_TYPE_GENERIC.
     cred.Type = CRED_TYPE_GENERIC
     cred.TargetName = target
     cred.CredentialBlobSize = len(blob)

--- a/packs/credential-brokers/.apm/shared-libs/_keychain_macos.py
+++ b/packs/credential-brokers/.apm/shared-libs/_keychain_macos.py
@@ -1,8 +1,8 @@
-"""macOS Keychain Tier-2 backend (spec § AC6-AC8).
+"""macOS Keychain Tier-2 backend.
 
 Stdlib subprocess against ``/usr/bin/security`` — the system-shipped
-Keychain CLI. Guaranteed present on every macOS install per spec §
-Boundaries § Never do (no third-party ``keyring`` dependency).
+Keychain CLI. Guaranteed present on every macOS install (no third-party
+``keyring`` dependency).
 
 Token bytes never reach argv:
 
@@ -16,7 +16,7 @@ Token bytes never reach argv:
 - **Delete** uses ``delete-generic-password`` (idempotent on miss).
 
 The build-projected ``credentials_shim`` imports this module **only**
-when ``sys.platform == "darwin"`` per AC4b. Tests monkeypatch
+when ``sys.platform == "darwin"``. Tests monkeypatch
 ``SERVICE`` to a ``tmp_path``-derived prefix so test entries never
 collide with the developer's real ``agentbundle`` Keychain entries.
 """
@@ -34,9 +34,9 @@ SERVICE = "agentbundle"
 # developer's login Keychain. ``security``'s ``-w`` prompt mode requires
 # ``-w`` as the trailing argv element, which forecloses the trailing-
 # keychain-positional approach to test isolation; the service-prefix
-# approach lets the canonical AC6 argv shape stay untouched.
+# approach lets the canonical argv shape stay untouched.
 
-# macOS Security framework OSStatus codes (spec § AC22):
+# macOS Security framework OSStatus codes:
 #   44      errSecItemNotFound          — legitimate "no such credential",
 #                                         falls through to Tier 3.
 #   45      errSecDuplicateItem         — only relevant on add; the ``-U``
@@ -46,7 +46,7 @@ SERVICE = "agentbundle"
 #
 # Names taken from ``<Security/SecBase.h>``. The two "Keychain locked /
 # unavailable" codes (25308 / -25291) MUST raise ``Tier2HardFailError``
-# so ``run_setup`` can route the AC22 fallback gate — silently
+# so ``run_setup`` can route the fallback gate — silently
 # degrading to Tier 3 defeats the security posture the user chose.
 EXIT_NOT_FOUND = 44
 EXIT_DUPLICATE_ITEM = 45
@@ -62,8 +62,7 @@ def _classify_macos_exit_code(rc: int, op: str) -> str | None:
     embed it in a ``Tier2HardFailError`` message. Returns ``None`` for
     ``EXIT_NOT_FOUND`` (the caller treats that as a legitimate miss).
 
-    Parallel in shape to ``_credman_windows._classify_last_error``;
-    AC22 cites this matrix explicitly.
+    Parallel in shape to ``_credman_windows._classify_last_error``.
     """
     if rc == 0:
         return None
@@ -92,12 +91,12 @@ def _classify_macos_exit_code(rc: int, op: str) -> str | None:
 
 
 def _account(namespace: str, key: str) -> str:
-    """Compose the Keychain account label per spec § AC6."""
+    """Compose the Keychain account label."""
     return f"{namespace}:{key}"
 
 
 def read_credential(namespace: str, key: str) -> str | None:
-    """Read ``(namespace, key)`` from the Keychain (spec § AC6, AC7)."""
+    """Read ``(namespace, key)`` from the Keychain."""
     argv = [
         SECURITY_BIN, "find-generic-password",
         "-s", SERVICE,
@@ -121,7 +120,7 @@ def read_credential(namespace: str, key: str) -> str | None:
 
 def write_credential(namespace: str, key: str, value: str) -> None:
     """Write ``value`` to ``(namespace, key)``. Token enters via child stdin
-    only — never argv (spec § AC6, AC7).
+    only — never argv.
 
     Refuses values containing ``\\n`` or ``\\r`` up front. ``security -w``
     prompts twice and the stdin payload is ``token + b"\\n" + token + b"\\n"``;

--- a/packs/credential-brokers/.apm/shared-libs/credentials_shim.py
+++ b/packs/credential-brokers/.apm/shared-libs/credentials_shim.py
@@ -13,9 +13,9 @@ Public surface a credentialed-primitive author imports:
 - ``Credentials`` — immutable, attribute-access view of the resolved values.
 - ``EnvParseError`` — raised by ``parse_env_file`` on unsupported syntax.
 
-Stdlib-only per spec § Boundaries § Never do — no ``python-dotenv``, no
+Stdlib-only by design — no ``python-dotenv``, no
 ``keyring``, no third-party imports. The Tier-2 backend is dispatched at
-module-load time per AC4b: ``_keychain_macos`` iff ``sys.platform ==
+module-load time: ``_keychain_macos`` iff ``sys.platform ==
 "darwin"``, ``_credman_windows`` iff ``"win32"``, no Tier-2 backend on
 other platforms (resolver falls through directly to Tier 3).
 
@@ -36,8 +36,8 @@ Trailing ``\\r`` from CRLF line endings is stripped; ``\\r`` *inside* a
 quoted value is preserved (``KEY="a\\rb"`` → ``{"KEY": "a\\rb"}``).
 
 When loaded outside a consumer-skill ``scripts/`` directory — e.g. as
-a sibling under ``~/.agentbundle/bin/`` per the credential-broker-contract
-AC22b companion projection — the shim's own ``_tier2_backend`` resolves
+a sibling under ``~/.agentbundle/bin/`` per the shim companion
+projection — the shim's own ``_tier2_backend`` resolves
 to ``None``. Callers in that context must not rely on ``load_credentials``
 for Tier-2 resolution; that path is the consumer-skill ``scripts/``
 projection only.
@@ -94,7 +94,7 @@ class Tier2HardFailError(Exception):
 class PermissiveAclError(Exception):
     """Raised when the Windows DACL on the Tier-3 dotfile is too permissive.
 
-    Per spec § AC15: ``icacls`` is invoked after each write; non-default
+    ``icacls`` is invoked after each write; non-default
     ACEs (anything beyond the inherited user / ``NT AUTHORITY\\SYSTEM`` /
     ``BUILTIN\\Administrators``) cause the helper to refuse unless
     ``allow_permissive_acl=True`` was passed.
@@ -104,7 +104,7 @@ class PermissiveAclError(Exception):
 class SchemaError(Exception):
     """Raised when a ``creds-schema.toml`` file is malformed or missing.
 
-    Per spec § AC24 / AC24b — names the offending file path and the
+    Names the offending file path and the
     specific shape violation (missing ``[namespace]``, empty
     ``namespace.keys``, non-boolean ``secret``, or unresolvable
     canonical path).
@@ -186,11 +186,11 @@ def parse_env_file(path: pathlib.Path) -> dict[str, str]:
         result[key] = value
     return result
 
-# Tier-2 backend dispatch at module-load time (spec § AC4b). The backend
-# modules are added by T4 (macOS) and T5 (Windows); until they land, the
-# try/except yields ``None`` and the resolver skips Tier 2 on the matching
-# platform. On Linux (and any non-Darwin / non-Windows platform), no import
-# is attempted at all — Tier 2 is unavailable by absence.
+# Tier-2 backend dispatch at module-load time. If a platform's backend
+# module is absent, the try/except yields ``None`` and the resolver skips
+# Tier 2 on the matching platform. On Linux (and any non-Darwin /
+# non-Windows platform), no import is attempted at all — Tier 2 is
+# unavailable by absence.
 if sys.platform == "darwin":
     try:
         from . import _keychain_macos as _tier2_backend  # type: ignore[no-redef]
@@ -208,7 +208,7 @@ else:
 class Credentials:
     """Immutable, attribute-access view of a namespace's resolved credentials.
 
-    Constructed by ``load_credentials``. The contract (spec § AC3) is:
+    Constructed by ``load_credentials``. The contract is:
 
     - Attribute access returns the resolved value:
       ``creds.API_TOKEN`` returns the resolved ``API_TOKEN`` for the
@@ -276,7 +276,7 @@ class Credentials:
 
 
 def _tier1_env(namespace: str, key: str) -> str | None:
-    """Resolve ``<NAMESPACE>_<KEY>`` from ``os.environ`` (spec § AC5).
+    """Resolve ``<NAMESPACE>_<KEY>`` from ``os.environ``.
 
     Empty-string env vars count as unset and return ``None`` so the
     resolver falls through to lower tiers.
@@ -289,12 +289,12 @@ def _tier1_env(namespace: str, key: str) -> str | None:
 
 
 def _tier2(namespace: str, key: str) -> str | None:
-    """Resolve via the platform-specific keyring backend (spec § AC6, AC9).
+    """Resolve via the platform-specific keyring backend.
 
     Returns ``None`` when the backend is absent (non-Darwin / non-Windows
-    platforms, or backend modules not yet shipped) or reports a clean
+    platforms, or backend modules not shipped) or reports a clean
     miss. Hard-fail error codes from the underlying API propagate as
-    ``Tier2HardFailError`` per AC11.
+    ``Tier2HardFailError``.
     """
     if _tier2_backend is None:
         return None
@@ -302,7 +302,7 @@ def _tier2(namespace: str, key: str) -> str | None:
 
 
 def _tier3(namespace: str, key: str) -> str | None:
-    """Resolve from the Tier-3 dotfile (spec § AC13).
+    """Resolve from the Tier-3 dotfile.
 
     Reads ``~/.agentbundle/credentials.env`` via the stdlib parser and
     looks up ``<NAMESPACE>_<KEY>``. Returns ``None`` on miss; a malformed
@@ -317,7 +317,7 @@ def _tier3(namespace: str, key: str) -> str | None:
 
 
 def _dotfile_path() -> pathlib.Path:
-    """Canonical Tier-3 dotfile path per spec § AC13.
+    """Canonical Tier-3 dotfile path.
 
     Resolves to ``pathlib.Path.home() / ".agentbundle" / "credentials.env"``
     on every platform. Tests redirect ``HOME`` (and ``USERPROFILE`` on
@@ -399,7 +399,7 @@ def _verify_icacls(
     path: pathlib.Path, *, allow_permissive_acl: bool = False
 ) -> None:
     """Run ``icacls /findsid`` and refuse if any well-known "broad
-    access" SID is granted access on the path (spec § AC15). No-op on
+    access" SID is granted access on the path. No-op on
     POSIX.
 
     Default ACEs on a per-user file are the inheriting user,
@@ -437,7 +437,7 @@ def _verify_icacls(
 
 
 def _ensure_parent(parent: pathlib.Path) -> None:
-    """Create the dotfile parent at mode 0o700 if absent (spec § AC15).
+    """Create the dotfile parent at mode 0o700 if absent.
 
     If the parent already exists, do **not** rewrite its mode — the
     directory is shared with ``~/.agentbundle/state.toml``.
@@ -465,7 +465,7 @@ def _dotfile_write(
 ) -> None:
     """Write ``(namespace, key) → value`` to the Tier-3 dotfile atomically.
 
-    Atomic write contract per spec § AC14:
+    Atomic write contract:
     ``tempfile.mkstemp(dir=target_dir)`` → ``os.write`` →
     ``os.fchmod`` (POSIX) → ``os.close`` → ``os.replace``. A mid-write
     read sees either the prior contents or the new contents, never
@@ -556,7 +556,7 @@ def load_credentials(
 ) -> Credentials:
     """Resolve ``required_keys`` for ``namespace``, walking Tiers 1 → 2 → 3.
 
-    First-hit-wins per key (spec § AC4): a key resolved at Tier 1 is not
+    First-hit-wins per key: a key resolved at Tier 1 is not
     re-checked at lower tiers; mixing tiers across keys within one
     namespace is permitted.
 
@@ -593,8 +593,8 @@ def load_credentials(
         attempts.append(f"Tier 1: env {env_name!r} not set")
 
         # Tier 2 — OS keyring (when loaded). Tier2HardFailError
-        # propagates per AC11 (no silent fallback to Tier 3 on hard
-        # fail); only a clean miss falls through.
+        # propagates (no silent fallback to Tier 3 on hard fail);
+        # only a clean miss falls through.
         if _tier2_backend is None:
             attempts.append("Tier 2: not loaded (no keyring backend on this platform)")
         else:
@@ -621,8 +621,8 @@ def load_credentials(
         tiers_tried[key] = attempts
 
     if missing:
-        # One-line preamble preserves the AC3 contract (message names
-        # namespace and the missing-keys list); the per-key trailer
+        # One-line preamble names the namespace and the missing-keys
+        # list; the per-key trailer
         # block comes below for triage.
         lines = [
             f"namespace {namespace!r}: missing required credential(s): "
@@ -641,7 +641,7 @@ def load_credentials(
     return Credentials(namespace, resolved)
 
 
-# ── creds-schema.toml parser (spec § AC24, AC24b) ─────────────────────
+# ── creds-schema.toml parser ──────────────────────────────────────────
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -649,7 +649,7 @@ class KeyDef:
     """A single required key declared in ``creds-schema.toml``.
 
     ``secret=True`` keys are prompted via ``getpass.getpass`` (no echo);
-    ``secret=False`` keys are prompted via ``input()`` per spec § AC24.
+    ``secret=False`` keys are prompted via ``input()``.
     """
 
     name: str
@@ -668,7 +668,7 @@ class CredsSchema:
 def _parse_schema(path: pathlib.Path) -> CredsSchema:
     """Parse a ``creds-schema.toml`` file into a typed ``CredsSchema``.
 
-    Per spec § AC24, the expected shape is::
+    The expected shape is::
 
         [namespace]
         name = "<namespace>"
@@ -733,7 +733,7 @@ _SKILL_MD_RE = re.compile(r"^\.claude/skills/([^/]+)/SKILL\.md$")
 def _relative_schema_path(
     state: "object", pack: str, skill_name: str
 ) -> pathlib.Path:
-    """Resolve the *state-relative* ``creds-schema.toml`` path per spec § AC24b.
+    """Resolve the *state-relative* ``creds-schema.toml`` path.
 
     Walks ``state.packs[pack].files`` for a relpath matching
     ``^\\.claude/skills/<skill_name>/SKILL\\.md$``; returns the
@@ -745,7 +745,7 @@ def _relative_schema_path(
     underscore-prefixed name reflects that contract; CLI callers go
     through `commands/creds._resolve_schema_for_namespace` which joins
     against `SKILL.md.parent` directly instead of calling this helper.
-    Kept around because it pins the AC24b state-walk shape with its
+    Kept around because it pins the state-walk shape with its
     own tests.
 
     Raises ``SchemaError`` if no matching SKILL.md row is in

--- a/packs/credential-brokers/.apm/skills/credential-setup/scripts/_credman_windows.py
+++ b/packs/credential-brokers/.apm/skills/credential-setup/scripts/_credman_windows.py
@@ -1,4 +1,4 @@
-"""Windows Credential Manager Tier-2 backend (spec § AC9-AC12).
+"""Windows Credential Manager Tier-2 backend.
 
 In-process ``ctypes`` against ``advapi32.dll``'s ``CredReadW`` /
 ``CredWriteW`` / ``CredDeleteW`` / ``CredFree`` — stdlib only, no
@@ -15,7 +15,7 @@ zero-initialised via ``ctypes.Structure`` defaults — required by
 NULL when ``AttributeCount`` is 0; ``LastWritten`` is set by the API
 and ignored on write).
 
-Per spec § AC4b the loader imports this module **only** when
+The loader imports this module **only** when
 ``sys.platform == "win32"``. The advapi32 binding is platform-guarded
 below so the module itself stays importable on every platform; tests
 that don't actually call the OS can construct ``CREDENTIAL`` instances
@@ -31,11 +31,11 @@ from ctypes import POINTER, Structure, byref
 
 from .credentials_shim import Tier2HardFailError
 
-# Constants from ``wincred.h`` (spec § AC9):
+# Constants from ``wincred.h``:
 CRED_TYPE_GENERIC = 1
 CRED_PERSIST_LOCAL_MACHINE = 2
 
-# Win32 error codes — sourced from ``winerror.h`` and AC11:
+# Win32 error codes — sourced from ``winerror.h``:
 ERROR_NOT_FOUND = 1168          # falls through to Tier 3
 ERROR_NO_SUCH_LOGON_SESSION = 1312
 ERROR_INVALID_FLAGS = 1004
@@ -44,7 +44,7 @@ ERROR_LOGON_FAILURE = 1326
 TARGET_PREFIX = "agentbundle"
 # Tests can monkeypatch this to a ``tmp_path``-derived value so test
 # target-names can't collide with the developer's real Credential
-# Manager entries (spec § AC35 / plan T5 § Test isolation).
+# Manager entries.
 SERVICE_PREFIX_OVERRIDE: str | None = None
 
 
@@ -53,7 +53,7 @@ class CREDENTIAL(Structure):
 
     Field order and types must match the Win32 ABI exactly — a wrong-
     sized field on Windows returns garbage rather than raising, which
-    is why AC10 mandates a byte-equality round-trip test on every field.
+    is why a byte-equality round-trip test covers every field.
     """
 
     _fields_ = [
@@ -104,18 +104,18 @@ else:
 
 
 def _target_name(namespace: str, key: str) -> str:
-    """Compose the Win32 ``TargetName`` per spec § AC9."""
+    """Compose the Win32 ``TargetName``."""
     prefix = SERVICE_PREFIX_OVERRIDE or TARGET_PREFIX
     return f"{prefix}:{namespace}:{key}"
 
 
 def _classify_last_error(rc: int, op: str) -> None:
-    """Map the Win32 last-error code to the AC11 dispatch matrix.
+    """Map the Win32 last-error code to the dispatch matrix.
 
     ``ERROR_NOT_FOUND`` is the caller's responsibility (it indicates a
     legitimate miss — caller returns ``None``). Every other code on
     this matrix raises ``Tier2HardFailError`` so the resolver does not
-    silently degrade to Tier 3 (spec § Never do).
+    silently degrade to Tier 3.
     """
     if rc == ERROR_NO_SUCH_LOGON_SESSION:
         raise Tier2HardFailError(
@@ -144,7 +144,7 @@ def read_credential(namespace: str, key: str) -> str | None:
 
     Returns ``None`` on ``ERROR_NOT_FOUND`` (resolver falls through to
     Tier 3); raises ``Tier2HardFailError`` on every other documented
-    failure (AC11).
+    failure.
     """
     target = _target_name(namespace, key)
     out_ptr = POINTER(CREDENTIAL)()
@@ -169,7 +169,7 @@ def read_credential(namespace: str, key: str) -> str | None:
 
 
 def write_credential(namespace: str, key: str, value: str) -> None:
-    """Write ``value`` to ``(namespace, key)`` (AC9, AC10).
+    """Write ``value`` to ``(namespace, key)``.
 
     The token is UTF-16-LE encoded and stored in a writable buffer
     pointed to by ``CredentialBlob``; ``CredentialBlobSize`` is the
@@ -183,7 +183,7 @@ def write_credential(namespace: str, key: str, value: str) -> None:
     # All other fields stay at ctypes.Structure's zero-init defaults
     # (Flags=0, Comment=None, LastWritten=FILETIME(0,0),
     # AttributeCount=0, Attributes=None, TargetAlias=None) — required
-    # by CRED_TYPE_GENERIC per spec § AC9.
+    # by CRED_TYPE_GENERIC.
     cred.Type = CRED_TYPE_GENERIC
     cred.TargetName = target
     cred.CredentialBlobSize = len(blob)

--- a/packs/credential-brokers/.apm/skills/credential-setup/scripts/_keychain_macos.py
+++ b/packs/credential-brokers/.apm/skills/credential-setup/scripts/_keychain_macos.py
@@ -1,8 +1,8 @@
-"""macOS Keychain Tier-2 backend (spec § AC6-AC8).
+"""macOS Keychain Tier-2 backend.
 
 Stdlib subprocess against ``/usr/bin/security`` — the system-shipped
-Keychain CLI. Guaranteed present on every macOS install per spec §
-Boundaries § Never do (no third-party ``keyring`` dependency).
+Keychain CLI. Guaranteed present on every macOS install (no third-party
+``keyring`` dependency).
 
 Token bytes never reach argv:
 
@@ -16,7 +16,7 @@ Token bytes never reach argv:
 - **Delete** uses ``delete-generic-password`` (idempotent on miss).
 
 The build-projected ``credentials_shim`` imports this module **only**
-when ``sys.platform == "darwin"`` per AC4b. Tests monkeypatch
+when ``sys.platform == "darwin"``. Tests monkeypatch
 ``SERVICE`` to a ``tmp_path``-derived prefix so test entries never
 collide with the developer's real ``agentbundle`` Keychain entries.
 """
@@ -34,9 +34,9 @@ SERVICE = "agentbundle"
 # developer's login Keychain. ``security``'s ``-w`` prompt mode requires
 # ``-w`` as the trailing argv element, which forecloses the trailing-
 # keychain-positional approach to test isolation; the service-prefix
-# approach lets the canonical AC6 argv shape stay untouched.
+# approach lets the canonical argv shape stay untouched.
 
-# macOS Security framework OSStatus codes (spec § AC22):
+# macOS Security framework OSStatus codes:
 #   44      errSecItemNotFound          — legitimate "no such credential",
 #                                         falls through to Tier 3.
 #   45      errSecDuplicateItem         — only relevant on add; the ``-U``
@@ -46,7 +46,7 @@ SERVICE = "agentbundle"
 #
 # Names taken from ``<Security/SecBase.h>``. The two "Keychain locked /
 # unavailable" codes (25308 / -25291) MUST raise ``Tier2HardFailError``
-# so ``run_setup`` can route the AC22 fallback gate — silently
+# so ``run_setup`` can route the fallback gate — silently
 # degrading to Tier 3 defeats the security posture the user chose.
 EXIT_NOT_FOUND = 44
 EXIT_DUPLICATE_ITEM = 45
@@ -62,8 +62,7 @@ def _classify_macos_exit_code(rc: int, op: str) -> str | None:
     embed it in a ``Tier2HardFailError`` message. Returns ``None`` for
     ``EXIT_NOT_FOUND`` (the caller treats that as a legitimate miss).
 
-    Parallel in shape to ``_credman_windows._classify_last_error``;
-    AC22 cites this matrix explicitly.
+    Parallel in shape to ``_credman_windows._classify_last_error``.
     """
     if rc == 0:
         return None
@@ -92,12 +91,12 @@ def _classify_macos_exit_code(rc: int, op: str) -> str | None:
 
 
 def _account(namespace: str, key: str) -> str:
-    """Compose the Keychain account label per spec § AC6."""
+    """Compose the Keychain account label."""
     return f"{namespace}:{key}"
 
 
 def read_credential(namespace: str, key: str) -> str | None:
-    """Read ``(namespace, key)`` from the Keychain (spec § AC6, AC7)."""
+    """Read ``(namespace, key)`` from the Keychain."""
     argv = [
         SECURITY_BIN, "find-generic-password",
         "-s", SERVICE,
@@ -121,7 +120,7 @@ def read_credential(namespace: str, key: str) -> str | None:
 
 def write_credential(namespace: str, key: str, value: str) -> None:
     """Write ``value`` to ``(namespace, key)``. Token enters via child stdin
-    only — never argv (spec § AC6, AC7).
+    only — never argv.
 
     Refuses values containing ``\\n`` or ``\\r`` up front. ``security -w``
     prompts twice and the stdin payload is ``token + b"\\n" + token + b"\\n"``;

--- a/packs/credential-brokers/.apm/skills/credential-setup/scripts/credentials_shim.py
+++ b/packs/credential-brokers/.apm/skills/credential-setup/scripts/credentials_shim.py
@@ -13,9 +13,9 @@ Public surface a credentialed-primitive author imports:
 - ``Credentials`` — immutable, attribute-access view of the resolved values.
 - ``EnvParseError`` — raised by ``parse_env_file`` on unsupported syntax.
 
-Stdlib-only per spec § Boundaries § Never do — no ``python-dotenv``, no
+Stdlib-only by design — no ``python-dotenv``, no
 ``keyring``, no third-party imports. The Tier-2 backend is dispatched at
-module-load time per AC4b: ``_keychain_macos`` iff ``sys.platform ==
+module-load time: ``_keychain_macos`` iff ``sys.platform ==
 "darwin"``, ``_credman_windows`` iff ``"win32"``, no Tier-2 backend on
 other platforms (resolver falls through directly to Tier 3).
 
@@ -36,8 +36,8 @@ Trailing ``\\r`` from CRLF line endings is stripped; ``\\r`` *inside* a
 quoted value is preserved (``KEY="a\\rb"`` → ``{"KEY": "a\\rb"}``).
 
 When loaded outside a consumer-skill ``scripts/`` directory — e.g. as
-a sibling under ``~/.agentbundle/bin/`` per the credential-broker-contract
-AC22b companion projection — the shim's own ``_tier2_backend`` resolves
+a sibling under ``~/.agentbundle/bin/`` per the shim companion
+projection — the shim's own ``_tier2_backend`` resolves
 to ``None``. Callers in that context must not rely on ``load_credentials``
 for Tier-2 resolution; that path is the consumer-skill ``scripts/``
 projection only.
@@ -94,7 +94,7 @@ class Tier2HardFailError(Exception):
 class PermissiveAclError(Exception):
     """Raised when the Windows DACL on the Tier-3 dotfile is too permissive.
 
-    Per spec § AC15: ``icacls`` is invoked after each write; non-default
+    ``icacls`` is invoked after each write; non-default
     ACEs (anything beyond the inherited user / ``NT AUTHORITY\\SYSTEM`` /
     ``BUILTIN\\Administrators``) cause the helper to refuse unless
     ``allow_permissive_acl=True`` was passed.
@@ -104,7 +104,7 @@ class PermissiveAclError(Exception):
 class SchemaError(Exception):
     """Raised when a ``creds-schema.toml`` file is malformed or missing.
 
-    Per spec § AC24 / AC24b — names the offending file path and the
+    Names the offending file path and the
     specific shape violation (missing ``[namespace]``, empty
     ``namespace.keys``, non-boolean ``secret``, or unresolvable
     canonical path).
@@ -186,11 +186,11 @@ def parse_env_file(path: pathlib.Path) -> dict[str, str]:
         result[key] = value
     return result
 
-# Tier-2 backend dispatch at module-load time (spec § AC4b). The backend
-# modules are added by T4 (macOS) and T5 (Windows); until they land, the
-# try/except yields ``None`` and the resolver skips Tier 2 on the matching
-# platform. On Linux (and any non-Darwin / non-Windows platform), no import
-# is attempted at all — Tier 2 is unavailable by absence.
+# Tier-2 backend dispatch at module-load time. If a platform's backend
+# module is absent, the try/except yields ``None`` and the resolver skips
+# Tier 2 on the matching platform. On Linux (and any non-Darwin /
+# non-Windows platform), no import is attempted at all — Tier 2 is
+# unavailable by absence.
 if sys.platform == "darwin":
     try:
         from . import _keychain_macos as _tier2_backend  # type: ignore[no-redef]
@@ -208,7 +208,7 @@ else:
 class Credentials:
     """Immutable, attribute-access view of a namespace's resolved credentials.
 
-    Constructed by ``load_credentials``. The contract (spec § AC3) is:
+    Constructed by ``load_credentials``. The contract is:
 
     - Attribute access returns the resolved value:
       ``creds.API_TOKEN`` returns the resolved ``API_TOKEN`` for the
@@ -276,7 +276,7 @@ class Credentials:
 
 
 def _tier1_env(namespace: str, key: str) -> str | None:
-    """Resolve ``<NAMESPACE>_<KEY>`` from ``os.environ`` (spec § AC5).
+    """Resolve ``<NAMESPACE>_<KEY>`` from ``os.environ``.
 
     Empty-string env vars count as unset and return ``None`` so the
     resolver falls through to lower tiers.
@@ -289,12 +289,12 @@ def _tier1_env(namespace: str, key: str) -> str | None:
 
 
 def _tier2(namespace: str, key: str) -> str | None:
-    """Resolve via the platform-specific keyring backend (spec § AC6, AC9).
+    """Resolve via the platform-specific keyring backend.
 
     Returns ``None`` when the backend is absent (non-Darwin / non-Windows
-    platforms, or backend modules not yet shipped) or reports a clean
+    platforms, or backend modules not shipped) or reports a clean
     miss. Hard-fail error codes from the underlying API propagate as
-    ``Tier2HardFailError`` per AC11.
+    ``Tier2HardFailError``.
     """
     if _tier2_backend is None:
         return None
@@ -302,7 +302,7 @@ def _tier2(namespace: str, key: str) -> str | None:
 
 
 def _tier3(namespace: str, key: str) -> str | None:
-    """Resolve from the Tier-3 dotfile (spec § AC13).
+    """Resolve from the Tier-3 dotfile.
 
     Reads ``~/.agentbundle/credentials.env`` via the stdlib parser and
     looks up ``<NAMESPACE>_<KEY>``. Returns ``None`` on miss; a malformed
@@ -317,7 +317,7 @@ def _tier3(namespace: str, key: str) -> str | None:
 
 
 def _dotfile_path() -> pathlib.Path:
-    """Canonical Tier-3 dotfile path per spec § AC13.
+    """Canonical Tier-3 dotfile path.
 
     Resolves to ``pathlib.Path.home() / ".agentbundle" / "credentials.env"``
     on every platform. Tests redirect ``HOME`` (and ``USERPROFILE`` on
@@ -399,7 +399,7 @@ def _verify_icacls(
     path: pathlib.Path, *, allow_permissive_acl: bool = False
 ) -> None:
     """Run ``icacls /findsid`` and refuse if any well-known "broad
-    access" SID is granted access on the path (spec § AC15). No-op on
+    access" SID is granted access on the path. No-op on
     POSIX.
 
     Default ACEs on a per-user file are the inheriting user,
@@ -437,7 +437,7 @@ def _verify_icacls(
 
 
 def _ensure_parent(parent: pathlib.Path) -> None:
-    """Create the dotfile parent at mode 0o700 if absent (spec § AC15).
+    """Create the dotfile parent at mode 0o700 if absent.
 
     If the parent already exists, do **not** rewrite its mode — the
     directory is shared with ``~/.agentbundle/state.toml``.
@@ -465,7 +465,7 @@ def _dotfile_write(
 ) -> None:
     """Write ``(namespace, key) → value`` to the Tier-3 dotfile atomically.
 
-    Atomic write contract per spec § AC14:
+    Atomic write contract:
     ``tempfile.mkstemp(dir=target_dir)`` → ``os.write`` →
     ``os.fchmod`` (POSIX) → ``os.close`` → ``os.replace``. A mid-write
     read sees either the prior contents or the new contents, never
@@ -556,7 +556,7 @@ def load_credentials(
 ) -> Credentials:
     """Resolve ``required_keys`` for ``namespace``, walking Tiers 1 → 2 → 3.
 
-    First-hit-wins per key (spec § AC4): a key resolved at Tier 1 is not
+    First-hit-wins per key: a key resolved at Tier 1 is not
     re-checked at lower tiers; mixing tiers across keys within one
     namespace is permitted.
 
@@ -593,8 +593,8 @@ def load_credentials(
         attempts.append(f"Tier 1: env {env_name!r} not set")
 
         # Tier 2 — OS keyring (when loaded). Tier2HardFailError
-        # propagates per AC11 (no silent fallback to Tier 3 on hard
-        # fail); only a clean miss falls through.
+        # propagates (no silent fallback to Tier 3 on hard fail);
+        # only a clean miss falls through.
         if _tier2_backend is None:
             attempts.append("Tier 2: not loaded (no keyring backend on this platform)")
         else:
@@ -621,8 +621,8 @@ def load_credentials(
         tiers_tried[key] = attempts
 
     if missing:
-        # One-line preamble preserves the AC3 contract (message names
-        # namespace and the missing-keys list); the per-key trailer
+        # One-line preamble names the namespace and the missing-keys
+        # list; the per-key trailer
         # block comes below for triage.
         lines = [
             f"namespace {namespace!r}: missing required credential(s): "
@@ -641,7 +641,7 @@ def load_credentials(
     return Credentials(namespace, resolved)
 
 
-# ── creds-schema.toml parser (spec § AC24, AC24b) ─────────────────────
+# ── creds-schema.toml parser ──────────────────────────────────────────
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -649,7 +649,7 @@ class KeyDef:
     """A single required key declared in ``creds-schema.toml``.
 
     ``secret=True`` keys are prompted via ``getpass.getpass`` (no echo);
-    ``secret=False`` keys are prompted via ``input()`` per spec § AC24.
+    ``secret=False`` keys are prompted via ``input()``.
     """
 
     name: str
@@ -668,7 +668,7 @@ class CredsSchema:
 def _parse_schema(path: pathlib.Path) -> CredsSchema:
     """Parse a ``creds-schema.toml`` file into a typed ``CredsSchema``.
 
-    Per spec § AC24, the expected shape is::
+    The expected shape is::
 
         [namespace]
         name = "<namespace>"
@@ -733,7 +733,7 @@ _SKILL_MD_RE = re.compile(r"^\.claude/skills/([^/]+)/SKILL\.md$")
 def _relative_schema_path(
     state: "object", pack: str, skill_name: str
 ) -> pathlib.Path:
-    """Resolve the *state-relative* ``creds-schema.toml`` path per spec § AC24b.
+    """Resolve the *state-relative* ``creds-schema.toml`` path.
 
     Walks ``state.packs[pack].files`` for a relpath matching
     ``^\\.claude/skills/<skill_name>/SKILL\\.md$``; returns the
@@ -745,7 +745,7 @@ def _relative_schema_path(
     underscore-prefixed name reflects that contract; CLI callers go
     through `commands/creds._resolve_schema_for_namespace` which joins
     against `SKILL.md.parent` directly instead of calling this helper.
-    Kept around because it pins the AC24b state-walk shape with its
+    Kept around because it pins the state-walk shape with its
     own tests.
 
     Raises ``SchemaError`` if no matching SKILL.md row is in

--- a/packs/credential-brokers/.apm/skills/credential-setup/scripts/setup.py
+++ b/packs/credential-brokers/.apm/skills/credential-setup/scripts/setup.py
@@ -1,4 +1,4 @@
-"""Interactive credential setup — credential-broker-contract T7.
+"""Interactive credential setup.
 
 Walks the user through writing each required key in a skill's
 ``creds-schema.toml`` to the highest-available tier (OS keychain on

--- a/packs/figma/.apm/skills/figma/references/creds-schema.toml
+++ b/packs/figma/.apm/skills/figma/references/creds-schema.toml
@@ -1,9 +1,9 @@
 # Credentials schema for the figma credentialed primitive.
-# Format pinned by skill-secrets spec § AC24.
+# Format: a [namespace] table plus one [[namespace.keys]] entry per key.
 #
 # Resolution: load_credentials("figma", required_keys=[...]) walks
-# Tier 1 (env) → Tier 2 (OS keyring) → Tier 3 (~/.agentbundle/credentials.env)
-# per AC4. Env-var shape is <NAMESPACE>_<KEY> — FIGMA_API_TOKEN.
+# Tier 1 (env) → Tier 2 (OS keyring) → Tier 3 (~/.agentbundle/credentials.env).
+# Env-var shape is <NAMESPACE>_<KEY> — FIGMA_API_TOKEN.
 #
 # Figma is SaaS-only (api.figma.com); there is no on-prem / self-hosted
 # variant, so no BASE_URL key. The token is a Personal Access Token

--- a/packs/figma/.apm/skills/figma/scripts/_credman_windows.py
+++ b/packs/figma/.apm/skills/figma/scripts/_credman_windows.py
@@ -1,4 +1,4 @@
-"""Windows Credential Manager Tier-2 backend (spec § AC9-AC12).
+"""Windows Credential Manager Tier-2 backend.
 
 In-process ``ctypes`` against ``advapi32.dll``'s ``CredReadW`` /
 ``CredWriteW`` / ``CredDeleteW`` / ``CredFree`` — stdlib only, no
@@ -15,7 +15,7 @@ zero-initialised via ``ctypes.Structure`` defaults — required by
 NULL when ``AttributeCount`` is 0; ``LastWritten`` is set by the API
 and ignored on write).
 
-Per spec § AC4b the loader imports this module **only** when
+The loader imports this module **only** when
 ``sys.platform == "win32"``. The advapi32 binding is platform-guarded
 below so the module itself stays importable on every platform; tests
 that don't actually call the OS can construct ``CREDENTIAL`` instances
@@ -31,11 +31,11 @@ from ctypes import POINTER, Structure, byref
 
 from .credentials_shim import Tier2HardFailError
 
-# Constants from ``wincred.h`` (spec § AC9):
+# Constants from ``wincred.h``:
 CRED_TYPE_GENERIC = 1
 CRED_PERSIST_LOCAL_MACHINE = 2
 
-# Win32 error codes — sourced from ``winerror.h`` and AC11:
+# Win32 error codes — sourced from ``winerror.h``:
 ERROR_NOT_FOUND = 1168          # falls through to Tier 3
 ERROR_NO_SUCH_LOGON_SESSION = 1312
 ERROR_INVALID_FLAGS = 1004
@@ -44,7 +44,7 @@ ERROR_LOGON_FAILURE = 1326
 TARGET_PREFIX = "agentbundle"
 # Tests can monkeypatch this to a ``tmp_path``-derived value so test
 # target-names can't collide with the developer's real Credential
-# Manager entries (spec § AC35 / plan T5 § Test isolation).
+# Manager entries.
 SERVICE_PREFIX_OVERRIDE: str | None = None
 
 
@@ -53,7 +53,7 @@ class CREDENTIAL(Structure):
 
     Field order and types must match the Win32 ABI exactly — a wrong-
     sized field on Windows returns garbage rather than raising, which
-    is why AC10 mandates a byte-equality round-trip test on every field.
+    is why a byte-equality round-trip test covers every field.
     """
 
     _fields_ = [
@@ -104,18 +104,18 @@ else:
 
 
 def _target_name(namespace: str, key: str) -> str:
-    """Compose the Win32 ``TargetName`` per spec § AC9."""
+    """Compose the Win32 ``TargetName``."""
     prefix = SERVICE_PREFIX_OVERRIDE or TARGET_PREFIX
     return f"{prefix}:{namespace}:{key}"
 
 
 def _classify_last_error(rc: int, op: str) -> None:
-    """Map the Win32 last-error code to the AC11 dispatch matrix.
+    """Map the Win32 last-error code to the dispatch matrix.
 
     ``ERROR_NOT_FOUND`` is the caller's responsibility (it indicates a
     legitimate miss — caller returns ``None``). Every other code on
     this matrix raises ``Tier2HardFailError`` so the resolver does not
-    silently degrade to Tier 3 (spec § Never do).
+    silently degrade to Tier 3.
     """
     if rc == ERROR_NO_SUCH_LOGON_SESSION:
         raise Tier2HardFailError(
@@ -144,7 +144,7 @@ def read_credential(namespace: str, key: str) -> str | None:
 
     Returns ``None`` on ``ERROR_NOT_FOUND`` (resolver falls through to
     Tier 3); raises ``Tier2HardFailError`` on every other documented
-    failure (AC11).
+    failure.
     """
     target = _target_name(namespace, key)
     out_ptr = POINTER(CREDENTIAL)()
@@ -169,7 +169,7 @@ def read_credential(namespace: str, key: str) -> str | None:
 
 
 def write_credential(namespace: str, key: str, value: str) -> None:
-    """Write ``value`` to ``(namespace, key)`` (AC9, AC10).
+    """Write ``value`` to ``(namespace, key)``.
 
     The token is UTF-16-LE encoded and stored in a writable buffer
     pointed to by ``CredentialBlob``; ``CredentialBlobSize`` is the
@@ -183,7 +183,7 @@ def write_credential(namespace: str, key: str, value: str) -> None:
     # All other fields stay at ctypes.Structure's zero-init defaults
     # (Flags=0, Comment=None, LastWritten=FILETIME(0,0),
     # AttributeCount=0, Attributes=None, TargetAlias=None) — required
-    # by CRED_TYPE_GENERIC per spec § AC9.
+    # by CRED_TYPE_GENERIC.
     cred.Type = CRED_TYPE_GENERIC
     cred.TargetName = target
     cred.CredentialBlobSize = len(blob)

--- a/packs/figma/.apm/skills/figma/scripts/_keychain_macos.py
+++ b/packs/figma/.apm/skills/figma/scripts/_keychain_macos.py
@@ -1,8 +1,8 @@
-"""macOS Keychain Tier-2 backend (spec § AC6-AC8).
+"""macOS Keychain Tier-2 backend.
 
 Stdlib subprocess against ``/usr/bin/security`` — the system-shipped
-Keychain CLI. Guaranteed present on every macOS install per spec §
-Boundaries § Never do (no third-party ``keyring`` dependency).
+Keychain CLI. Guaranteed present on every macOS install (no third-party
+``keyring`` dependency).
 
 Token bytes never reach argv:
 
@@ -16,7 +16,7 @@ Token bytes never reach argv:
 - **Delete** uses ``delete-generic-password`` (idempotent on miss).
 
 The build-projected ``credentials_shim`` imports this module **only**
-when ``sys.platform == "darwin"`` per AC4b. Tests monkeypatch
+when ``sys.platform == "darwin"``. Tests monkeypatch
 ``SERVICE`` to a ``tmp_path``-derived prefix so test entries never
 collide with the developer's real ``agentbundle`` Keychain entries.
 """
@@ -34,9 +34,9 @@ SERVICE = "agentbundle"
 # developer's login Keychain. ``security``'s ``-w`` prompt mode requires
 # ``-w`` as the trailing argv element, which forecloses the trailing-
 # keychain-positional approach to test isolation; the service-prefix
-# approach lets the canonical AC6 argv shape stay untouched.
+# approach lets the canonical argv shape stay untouched.
 
-# macOS Security framework OSStatus codes (spec § AC22):
+# macOS Security framework OSStatus codes:
 #   44      errSecItemNotFound          — legitimate "no such credential",
 #                                         falls through to Tier 3.
 #   45      errSecDuplicateItem         — only relevant on add; the ``-U``
@@ -46,7 +46,7 @@ SERVICE = "agentbundle"
 #
 # Names taken from ``<Security/SecBase.h>``. The two "Keychain locked /
 # unavailable" codes (25308 / -25291) MUST raise ``Tier2HardFailError``
-# so ``run_setup`` can route the AC22 fallback gate — silently
+# so ``run_setup`` can route the fallback gate — silently
 # degrading to Tier 3 defeats the security posture the user chose.
 EXIT_NOT_FOUND = 44
 EXIT_DUPLICATE_ITEM = 45
@@ -62,8 +62,7 @@ def _classify_macos_exit_code(rc: int, op: str) -> str | None:
     embed it in a ``Tier2HardFailError`` message. Returns ``None`` for
     ``EXIT_NOT_FOUND`` (the caller treats that as a legitimate miss).
 
-    Parallel in shape to ``_credman_windows._classify_last_error``;
-    AC22 cites this matrix explicitly.
+    Parallel in shape to ``_credman_windows._classify_last_error``.
     """
     if rc == 0:
         return None
@@ -92,12 +91,12 @@ def _classify_macos_exit_code(rc: int, op: str) -> str | None:
 
 
 def _account(namespace: str, key: str) -> str:
-    """Compose the Keychain account label per spec § AC6."""
+    """Compose the Keychain account label."""
     return f"{namespace}:{key}"
 
 
 def read_credential(namespace: str, key: str) -> str | None:
-    """Read ``(namespace, key)`` from the Keychain (spec § AC6, AC7)."""
+    """Read ``(namespace, key)`` from the Keychain."""
     argv = [
         SECURITY_BIN, "find-generic-password",
         "-s", SERVICE,
@@ -121,7 +120,7 @@ def read_credential(namespace: str, key: str) -> str | None:
 
 def write_credential(namespace: str, key: str, value: str) -> None:
     """Write ``value`` to ``(namespace, key)``. Token enters via child stdin
-    only — never argv (spec § AC6, AC7).
+    only — never argv.
 
     Refuses values containing ``\\n`` or ``\\r`` up front. ``security -w``
     prompts twice and the stdin payload is ``token + b"\\n" + token + b"\\n"``;

--- a/packs/figma/.apm/skills/figma/scripts/credentials_shim.py
+++ b/packs/figma/.apm/skills/figma/scripts/credentials_shim.py
@@ -13,9 +13,9 @@ Public surface a credentialed-primitive author imports:
 - ``Credentials`` — immutable, attribute-access view of the resolved values.
 - ``EnvParseError`` — raised by ``parse_env_file`` on unsupported syntax.
 
-Stdlib-only per spec § Boundaries § Never do — no ``python-dotenv``, no
+Stdlib-only by design — no ``python-dotenv``, no
 ``keyring``, no third-party imports. The Tier-2 backend is dispatched at
-module-load time per AC4b: ``_keychain_macos`` iff ``sys.platform ==
+module-load time: ``_keychain_macos`` iff ``sys.platform ==
 "darwin"``, ``_credman_windows`` iff ``"win32"``, no Tier-2 backend on
 other platforms (resolver falls through directly to Tier 3).
 
@@ -36,8 +36,8 @@ Trailing ``\\r`` from CRLF line endings is stripped; ``\\r`` *inside* a
 quoted value is preserved (``KEY="a\\rb"`` → ``{"KEY": "a\\rb"}``).
 
 When loaded outside a consumer-skill ``scripts/`` directory — e.g. as
-a sibling under ``~/.agentbundle/bin/`` per the credential-broker-contract
-AC22b companion projection — the shim's own ``_tier2_backend`` resolves
+a sibling under ``~/.agentbundle/bin/`` per the shim companion
+projection — the shim's own ``_tier2_backend`` resolves
 to ``None``. Callers in that context must not rely on ``load_credentials``
 for Tier-2 resolution; that path is the consumer-skill ``scripts/``
 projection only.
@@ -94,7 +94,7 @@ class Tier2HardFailError(Exception):
 class PermissiveAclError(Exception):
     """Raised when the Windows DACL on the Tier-3 dotfile is too permissive.
 
-    Per spec § AC15: ``icacls`` is invoked after each write; non-default
+    ``icacls`` is invoked after each write; non-default
     ACEs (anything beyond the inherited user / ``NT AUTHORITY\\SYSTEM`` /
     ``BUILTIN\\Administrators``) cause the helper to refuse unless
     ``allow_permissive_acl=True`` was passed.
@@ -104,7 +104,7 @@ class PermissiveAclError(Exception):
 class SchemaError(Exception):
     """Raised when a ``creds-schema.toml`` file is malformed or missing.
 
-    Per spec § AC24 / AC24b — names the offending file path and the
+    Names the offending file path and the
     specific shape violation (missing ``[namespace]``, empty
     ``namespace.keys``, non-boolean ``secret``, or unresolvable
     canonical path).
@@ -186,11 +186,11 @@ def parse_env_file(path: pathlib.Path) -> dict[str, str]:
         result[key] = value
     return result
 
-# Tier-2 backend dispatch at module-load time (spec § AC4b). The backend
-# modules are added by T4 (macOS) and T5 (Windows); until they land, the
-# try/except yields ``None`` and the resolver skips Tier 2 on the matching
-# platform. On Linux (and any non-Darwin / non-Windows platform), no import
-# is attempted at all — Tier 2 is unavailable by absence.
+# Tier-2 backend dispatch at module-load time. If a platform's backend
+# module is absent, the try/except yields ``None`` and the resolver skips
+# Tier 2 on the matching platform. On Linux (and any non-Darwin /
+# non-Windows platform), no import is attempted at all — Tier 2 is
+# unavailable by absence.
 if sys.platform == "darwin":
     try:
         from . import _keychain_macos as _tier2_backend  # type: ignore[no-redef]
@@ -208,7 +208,7 @@ else:
 class Credentials:
     """Immutable, attribute-access view of a namespace's resolved credentials.
 
-    Constructed by ``load_credentials``. The contract (spec § AC3) is:
+    Constructed by ``load_credentials``. The contract is:
 
     - Attribute access returns the resolved value:
       ``creds.API_TOKEN`` returns the resolved ``API_TOKEN`` for the
@@ -276,7 +276,7 @@ class Credentials:
 
 
 def _tier1_env(namespace: str, key: str) -> str | None:
-    """Resolve ``<NAMESPACE>_<KEY>`` from ``os.environ`` (spec § AC5).
+    """Resolve ``<NAMESPACE>_<KEY>`` from ``os.environ``.
 
     Empty-string env vars count as unset and return ``None`` so the
     resolver falls through to lower tiers.
@@ -289,12 +289,12 @@ def _tier1_env(namespace: str, key: str) -> str | None:
 
 
 def _tier2(namespace: str, key: str) -> str | None:
-    """Resolve via the platform-specific keyring backend (spec § AC6, AC9).
+    """Resolve via the platform-specific keyring backend.
 
     Returns ``None`` when the backend is absent (non-Darwin / non-Windows
-    platforms, or backend modules not yet shipped) or reports a clean
+    platforms, or backend modules not shipped) or reports a clean
     miss. Hard-fail error codes from the underlying API propagate as
-    ``Tier2HardFailError`` per AC11.
+    ``Tier2HardFailError``.
     """
     if _tier2_backend is None:
         return None
@@ -302,7 +302,7 @@ def _tier2(namespace: str, key: str) -> str | None:
 
 
 def _tier3(namespace: str, key: str) -> str | None:
-    """Resolve from the Tier-3 dotfile (spec § AC13).
+    """Resolve from the Tier-3 dotfile.
 
     Reads ``~/.agentbundle/credentials.env`` via the stdlib parser and
     looks up ``<NAMESPACE>_<KEY>``. Returns ``None`` on miss; a malformed
@@ -317,7 +317,7 @@ def _tier3(namespace: str, key: str) -> str | None:
 
 
 def _dotfile_path() -> pathlib.Path:
-    """Canonical Tier-3 dotfile path per spec § AC13.
+    """Canonical Tier-3 dotfile path.
 
     Resolves to ``pathlib.Path.home() / ".agentbundle" / "credentials.env"``
     on every platform. Tests redirect ``HOME`` (and ``USERPROFILE`` on
@@ -399,7 +399,7 @@ def _verify_icacls(
     path: pathlib.Path, *, allow_permissive_acl: bool = False
 ) -> None:
     """Run ``icacls /findsid`` and refuse if any well-known "broad
-    access" SID is granted access on the path (spec § AC15). No-op on
+    access" SID is granted access on the path. No-op on
     POSIX.
 
     Default ACEs on a per-user file are the inheriting user,
@@ -437,7 +437,7 @@ def _verify_icacls(
 
 
 def _ensure_parent(parent: pathlib.Path) -> None:
-    """Create the dotfile parent at mode 0o700 if absent (spec § AC15).
+    """Create the dotfile parent at mode 0o700 if absent.
 
     If the parent already exists, do **not** rewrite its mode — the
     directory is shared with ``~/.agentbundle/state.toml``.
@@ -465,7 +465,7 @@ def _dotfile_write(
 ) -> None:
     """Write ``(namespace, key) → value`` to the Tier-3 dotfile atomically.
 
-    Atomic write contract per spec § AC14:
+    Atomic write contract:
     ``tempfile.mkstemp(dir=target_dir)`` → ``os.write`` →
     ``os.fchmod`` (POSIX) → ``os.close`` → ``os.replace``. A mid-write
     read sees either the prior contents or the new contents, never
@@ -556,7 +556,7 @@ def load_credentials(
 ) -> Credentials:
     """Resolve ``required_keys`` for ``namespace``, walking Tiers 1 → 2 → 3.
 
-    First-hit-wins per key (spec § AC4): a key resolved at Tier 1 is not
+    First-hit-wins per key: a key resolved at Tier 1 is not
     re-checked at lower tiers; mixing tiers across keys within one
     namespace is permitted.
 
@@ -593,8 +593,8 @@ def load_credentials(
         attempts.append(f"Tier 1: env {env_name!r} not set")
 
         # Tier 2 — OS keyring (when loaded). Tier2HardFailError
-        # propagates per AC11 (no silent fallback to Tier 3 on hard
-        # fail); only a clean miss falls through.
+        # propagates (no silent fallback to Tier 3 on hard fail);
+        # only a clean miss falls through.
         if _tier2_backend is None:
             attempts.append("Tier 2: not loaded (no keyring backend on this platform)")
         else:
@@ -621,8 +621,8 @@ def load_credentials(
         tiers_tried[key] = attempts
 
     if missing:
-        # One-line preamble preserves the AC3 contract (message names
-        # namespace and the missing-keys list); the per-key trailer
+        # One-line preamble names the namespace and the missing-keys
+        # list; the per-key trailer
         # block comes below for triage.
         lines = [
             f"namespace {namespace!r}: missing required credential(s): "
@@ -641,7 +641,7 @@ def load_credentials(
     return Credentials(namespace, resolved)
 
 
-# ── creds-schema.toml parser (spec § AC24, AC24b) ─────────────────────
+# ── creds-schema.toml parser ──────────────────────────────────────────
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -649,7 +649,7 @@ class KeyDef:
     """A single required key declared in ``creds-schema.toml``.
 
     ``secret=True`` keys are prompted via ``getpass.getpass`` (no echo);
-    ``secret=False`` keys are prompted via ``input()`` per spec § AC24.
+    ``secret=False`` keys are prompted via ``input()``.
     """
 
     name: str
@@ -668,7 +668,7 @@ class CredsSchema:
 def _parse_schema(path: pathlib.Path) -> CredsSchema:
     """Parse a ``creds-schema.toml`` file into a typed ``CredsSchema``.
 
-    Per spec § AC24, the expected shape is::
+    The expected shape is::
 
         [namespace]
         name = "<namespace>"
@@ -733,7 +733,7 @@ _SKILL_MD_RE = re.compile(r"^\.claude/skills/([^/]+)/SKILL\.md$")
 def _relative_schema_path(
     state: "object", pack: str, skill_name: str
 ) -> pathlib.Path:
-    """Resolve the *state-relative* ``creds-schema.toml`` path per spec § AC24b.
+    """Resolve the *state-relative* ``creds-schema.toml`` path.
 
     Walks ``state.packs[pack].files`` for a relpath matching
     ``^\\.claude/skills/<skill_name>/SKILL\\.md$``; returns the
@@ -745,7 +745,7 @@ def _relative_schema_path(
     underscore-prefixed name reflects that contract; CLI callers go
     through `commands/creds._resolve_schema_for_namespace` which joins
     against `SKILL.md.parent` directly instead of calling this helper.
-    Kept around because it pins the AC24b state-walk shape with its
+    Kept around because it pins the state-walk shape with its
     own tests.
 
     Raises ``SchemaError`` if no matching SKILL.md row is in

--- a/packs/figma/.apm/skills/figma/scripts/figma.py
+++ b/packs/figma/.apm/skills/figma/scripts/figma.py
@@ -726,7 +726,7 @@ async def _dispatch(args: argparse.Namespace) -> int:
                 # but the architecture rule that skills do not read the
                 # credential store applies transitively to --data-file
                 # input. Path components compared separately so the
-                # forbidden-substring lint (AC26c) does not trip on
+                # forbidden-substring lint does not trip on
                 # this guard line.
                 resolved = args.data_file.expanduser().resolve()
                 parts = set(resolved.parts)


### PR DESCRIPTION
## Why

Second adopter-readiness pass, after #204 (RFC/ADR scrub). Adopter installs receive pack content under `packs/*/.apm/` but **none of this catalogue's specs or plans** — so citations like `spec § AC15`, `skill-secrets spec § AC24`, `credential-broker-contract T7`, or `plan §T5 lines 357-362` are dangling noise on arrival. The named spec docs (`docs/specs/flow-metrics.md`, `docs/specs/ai-adoption-report.md`) don't even exist in this repo, let alone an adopter's.

Same adopter-readiness principle `lint-seeds` already enforces for `seeds/**`, extended to skills/agents/commands/hooks.

## What

Dropped internal **spec / acceptance-criterion / plan** citations while preserving every behavioral rule verbatim in meaning; reworded "why" citations to self-contained prose. Also closed a gap from #204: its grep scoped to `skills`/`agents` and missed `commands/` + `hook-wiring/`, leaving a stray `RFC-0006` reference and several spec/AC ones.

**Scope — 24 canonical sources + 25 regenerated projections:**
- **credential surface:** `shared-libs/{credentials_shim,_keychain_macos,_credman_windows}.py` (canonical → projected copies), `adapter-root-bins/{_sso_keychain_macos,_sso_credman_windows,sso-broker}.py`, `credential-setup/scripts/setup.py`, 5× `references/creds-schema.toml`
- **atlassian:** `flow-metrics` (16 files), `ai-adoption-report` (explicit `docs/specs/*.md` / `spec §` / `plan §` citations), `output.schema.json`
- **core:** `commands/conventions-check.md` (RFC-0006 + skill-secrets AC26), `skills/adapt-to-project/SKILL.md`, `work-loop/scripts/loop-cohort.py`, `hook-wiring/session-start.toml`
- **figma:** `figma.py`
- projections regenerated via `make build-self`

Three **emitted user-facing strings** were reworded (not just comments) — `sso-broker --help`, the flow-metrics `defect_ratio` disclaimer, and `output.schema.json` `description` — each verified untested by any golden/assert.

## AGENTS.local.md — new authoring rule

Adds *"Shipped pack content carries no internal-governance citations"*: the four types to keep out of `.apm/**` (RFC numbers, ADR numbers, named-spec/AC/plan citations, internal doc paths), with explicit **KEEP** carve-outs for generic workflow convention (`docs/specs/<feature>/` placeholders), real external standards (`RFC 9457`), and functional fixture data (`- [ ] AC1` in the linter's test fixtures). No automated lint added — that's a new convention and RFC-gated; noted as a possible follow-on.

## Decisions

- **Preserved:** real external standards (`RFC 9457`) and OS headers (`wincred.h`, `winerror.h`, `/usr/bin/security`).
- **Deferred:** bare `T1`–`T9` architectural-shorthand labels in `ai-adoption-report` (e.g. "T7 renders the Markdown") — internal jargon, not governance citations; pervasively rewriting them is a separate, larger, riskier change. Flag if you want a follow-on.

## Verification

- No script **logic** changed — docstrings/comments + the 3 noted strings only (all Python AST-parses; reviewer confirmed).
- `make build-check` exits 0; projected copies byte-identical to canonicals.
- 52 credential / sso / flow-metrics / contract-doc tests pass.
- `adversarial-reviewer`: `Clean — ready to commit.` — every rule preserved (incl. security-relevant credential logic), no dangling references, no over-scrub.