### PR TITLE
chore(packs): replace bare build-task labels with descriptive names (ai-adoption-report + flow-metrics)

### DIFF
--- a/.agentbundle/bin/credentials_shim.py
+++ b/.agentbundle/bin/credentials_shim.py
@@ -19,7 +19,7 @@ module-load time: ``_keychain_macos`` iff ``sys.platform ==
 "darwin"``, ``_credman_windows`` iff ``"win32"``, no Tier-2 backend on
 other platforms (resolver falls through directly to Tier 3).
 
-``.env`` parser (T2 surface, retained here):
+``.env`` parser (retained here):
 
 Supported:
     ``KEY=value``

--- a/packs/atlassian/.apm/skills/ai-adoption-report/manifest.json
+++ b/packs/atlassian/.apm/skills/ai-adoption-report/manifest.json
@@ -17,7 +17,7 @@
   "input": {
     "arguments": "Required: subcommand MODE (one of baseline / cohort / program) plus --output FILE. baseline mode also requires --baseline PATH --current PATH; cohort mode requires --input PATH; program mode requires --inputs DIR --window FROM..TO. Common optional flags: --format {markdown,json,both} (default both), --overwrite (replace existing output without prompting), --title TITLE, --verbose. Mode-specific optional flags: --include-cohort-breakdown (baseline + program).",
     "env": {
-      "AI_ADOPTION_REPORT_GENERATED_AT": "Optional. When set, the skill uses this ISO-8601 string verbatim for the report's meta.generated_at instead of reading the runtime clock. Intended for deterministic-build tests and golden-file diffs (T9 golden tests rely on this). Unset in normal operation."
+      "AI_ADOPTION_REPORT_GENERATED_AT": "Optional. When set, the skill uses this ISO-8601 string verbatim for the report's meta.generated_at instead of reading the runtime clock. Intended for deterministic-build tests and golden-file diffs (the golden tests rely on this). Unset in normal operation."
     },
     "_invocation_note": "CLI is invoked as `python -m ai_adoption_report MODE ...` (the package's __main__.py shims to ai_adoption_report.main). Resolving the package as importable Python is the user's responsibility (typically PYTHONPATH pointed at scripts/)."
   },

--- a/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/__init__.py
+++ b/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/__init__.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """ai-adoption-report CLI entry point.
 
-T1 scaffold: argparse subcommands (baseline / cohort / program), Python
+CLI scaffold: argparse subcommands (baseline / cohort / program), Python
 version guard, path-safety helper, --window FROM..TO parser, exit codes.
 Each subcommand body is a stub that prints "not yet implemented" and
-exits 0. Later tasks fill in the real work.
+exits 0. Later layers fill in the real work.
 
 Stdlib only. Python >= 3.10.
 """
@@ -276,19 +276,19 @@ def _path_roles_for_mode(args: argparse.Namespace) -> Iterator[Tuple[str, str]]:
 
 
 def validate_args(args: argparse.Namespace) -> None:
-    """Apply T1 flag-combo validation.
+    """Apply CLI flag-combo validation.
 
     Currently only path-safety: every path-bearing flag must resolve
-    inside ``Path.cwd()``. Later tasks layer on input-file validation
-    (T2) and mode-specific checks (T3, T4).
+    inside ``Path.cwd()``. Later layers add input-file validation
+    (the input loader) and mode-specific checks (modes, program discovery).
     """
     for role, value in _path_roles_for_mode(args):
         validate_local_path(value, role=role)
 
 
 # ---------------------------------------------------------------------------
-# Subcommand dispatch. baseline + cohort delegate to T3's modes module;
-# program is still stubbed for T4/T6.
+# Subcommand dispatch. baseline + cohort delegate to the modes module;
+# program is still stubbed for program discovery + aggregation.
 # ---------------------------------------------------------------------------
 def _default_title(mode: str) -> str:
     return "AI-adoption report — {}".format(mode)
@@ -299,12 +299,13 @@ def _resolve_generated_at() -> str:
 
     Honors the test-pinning env var :data:`write.GENERATED_AT_ENV_VAR`
     (``AI_ADOPTION_REPORT_GENERATED_AT``) for deterministic-build tests
-    (T9's golden-file diffs rely on this). When unset, returns the
+    (golden-file diffs rely on this). When unset, returns the
     current UTC clock in ISO-8601 seconds precision with the trailing
     ``Z`` form (``2026-05-19T14:30:00Z``).
 
-    T7 stays pure — never reads the clock or env. T8 owns the timestamp
-    and threads it through ``render_markdown`` / ``render_json``.
+    The renderer stays pure — never reads the clock or env. The write
+    path owns the timestamp and threads it through ``render_markdown`` /
+    ``render_json``.
     """
     from .write import GENERATED_AT_ENV_VAR
 

--- a/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/aggregation.py
+++ b/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/aggregation.py
@@ -1,4 +1,4 @@
-"""T6 program-mode aggregation engine.
+"""Program-mode aggregation engine.
 
 Turns a list of :class:`program_discovery.ProgramScope` into:
 
@@ -23,12 +23,12 @@ Aggregation rules for program mode:
   aggregated ``flow_distribution.denominator`` is the integer sum
   across contributing scopes.
 
-Insertion order matches :data:`delta.CANONICAL_METRIC_ORDER` so T7's
-``CanonicalEncoder`` reads insertion order for the aggregates / cohort
-subtrees the way it does for ``deltas``.
+Insertion order matches :data:`delta.CANONICAL_METRIC_ORDER` so the
+renderer's ``CanonicalEncoder`` reads insertion order for the
+aggregates / cohort subtrees the way it does for ``deltas``.
 
-Notes are returned in append order — T7 sorts and dedupes the merged
-list. T6 does NOT pre-sort.
+Notes are returned in append order — the renderer sorts and dedupes the
+merged list. The aggregation engine does NOT pre-sort.
 
 Stdlib only. Python >= 3.10.
 """
@@ -43,7 +43,7 @@ from .program_discovery import ProgramScope
 
 
 # Top-level keys in the order they appear in the aggregates / cohort
-# side dicts T6 produces. Follows the canonical metric row order,
+# side dicts the aggregation engine produces. Follows the canonical metric row order,
 # collapsed to one entry per top-level metric.
 _TOP_LEVEL_METRIC_ORDER: Tuple[str, ...] = (
     "throughput",
@@ -115,8 +115,8 @@ def aggregate_non_cohort(
     notes is ``"non-cohort"``.
 
     The returned dict matches the shape of flow-metrics's ``aggregates``
-    block: same keys, same nesting. T7 may layer on derived fields
-    (e.g. ``throughput_per_week``) at the renderer boundary.
+    block: same keys, same nesting. The renderer may layer on derived
+    fields (e.g. ``throughput_per_week``) at the renderer boundary.
     """
     blocks_with_basenames = [(s.aggregates, s.source_basename) for s in scopes]
     out, _missing_fd, notes = _aggregate_blocks(
@@ -141,7 +141,7 @@ def aggregate_cohort_side(
 
     - ``from_per_team=True`` scopes are excluded from BOTH cohort and
       control rollups (flow-metrics v1 doesn't split per_team rows by
-      cohort; T4 already emits the per_team-cohort-deferred note).
+      cohort; program discovery already emits the per_team-cohort-deferred note).
     - Scopes missing ``cohort_breakdown`` are excluded from both sides;
       a ``cohort-breakdown-missing`` note records the basenames.
     - Scopes whose ``cohort_breakdown.<side>.flow_distribution`` is
@@ -151,8 +151,8 @@ def aggregate_cohort_side(
       basenames.
 
     Returns ``(None, notes)`` when zero scopes contribute, and emits a
-    ``cohort-breakdown-section-empty`` note. T7 dedupes the duplicate
-    emission across the two side calls.
+    ``cohort-breakdown-section-empty`` note. The renderer dedupes the
+    duplicate emission across the two side calls.
     """
     notes: List[str] = []
 
@@ -160,7 +160,7 @@ def aggregate_cohort_side(
     total_m = len(eligible)
     if total_m == 0:
         # No eligible scopes at all (every input was per_team-flattened).
-        # The per_team-cohort-deferred note is T4's responsibility; we
+        # The per_team-cohort-deferred note is program discovery's responsibility; we
         # only need to record the section-empty literal.
         notes.append(Note.cohort_breakdown_section_empty())
         return None, notes
@@ -198,7 +198,7 @@ def aggregate_cohort_side(
     # aggregates are produced. aggregate_non_cohort is the canonical
     # emission point, but firing here too defends against the (contrived)
     # case where the non-cohort table has no distribution metrics yet a
-    # cohort side does. T7 dedupes by exact match, so the duplicate
+    # cohort side does. The renderer dedupes by exact match, so the duplicate
     # emission is free.
     if any(m in out for m in _DISTRIBUTION_METRICS):
         notes.append(Note.median_of_medians_approximation())
@@ -230,8 +230,8 @@ def _aggregate_blocks(
 
     Returns ``(aggregate_dict, missing_flow_dist_basenames, notes)``.
     The dict's keys are inserted in :data:`_TOP_LEVEL_METRIC_ORDER` —
-    T7's CanonicalEncoder relies on insertion order for the aggregates
-    subtree the same way it does for ``deltas``.
+    the renderer's CanonicalEncoder relies on insertion order for the
+    aggregates subtree the same way it does for ``deltas``.
 
     ``missing_flow_dist_basenames`` is the list of basenames whose
     block lacked a ``flow_distribution`` sub-block. The caller decides

--- a/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/delta.py
+++ b/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/delta.py
@@ -1,21 +1,23 @@
-"""T5 delta math engine.
+"""Delta math engine.
 
 :func:`compute_deltas` consumes two aggregate-shaped dicts (the same
 shape ``flow-metrics`` emits in ``aggregates`` or in
 ``cohort_breakdown.<side>``) and returns a :class:`DeltaResult` carrying
 per-metric rows and unsorted notes.
 
-T5 knows nothing about modes. Baseline mode passes two ``aggregates``
-blocks; cohort mode and the program cohort rollup pass two
-``cohort_breakdown.<side>`` blocks. ``side_labels`` lets the caller
+The delta engine knows nothing about modes. Baseline mode passes two
+``aggregates`` blocks; cohort mode and the program cohort rollup pass
+two ``cohort_breakdown.<side>`` blocks. ``side_labels`` lets the caller
 control the wording of any notes (``("baseline", "current")``,
 ``("control", "cohort")``, etc.).
 
-Notes are returned in append order — T7 sorts and dedupes the final
-merged list (see the notes-merge contract). Do NOT pre-sort.
+Notes are returned in append order — the renderer (render.py) sorts and
+dedupes the final merged list (see the notes-merge contract). Do NOT
+pre-sort.
 
 Percent deltas are decimal fractions, not formatted strings. Rounding
-to 4 decimal places is T7's job; T5 emits full precision.
+to 4 decimal places is the renderer's job; the delta engine emits full
+precision.
 
 Stdlib only. Python >= 3.10.
 """
@@ -103,7 +105,7 @@ class DeltaRow:
     null). ``abs_delta`` is ``b - a`` (``None`` when either side is
     ``None``). ``pct_delta`` is the decimal fraction ``(b - a) / a``
     (``math.inf`` / ``-math.inf`` for the zero-baseline case, ``None``
-    when undefined). T7 formats both for Markdown.
+    when undefined). The renderer formats both for Markdown.
     """
 
     metric_label: str
@@ -120,8 +122,9 @@ class DeltaResult:
     ``rows`` is in canonical metric row order; metrics absent on BOTH
     sides are omitted entirely.
 
-    ``notes`` is in append order (unsorted). T3 / T6 concatenate this
-    onto ``ReportData.notes``; T7 sorts and dedupes the final list.
+    ``notes`` is in append order (unsorted). The modes and aggregation
+    engine concatenate this onto ``ReportData.notes``; the renderer
+    sorts and dedupes the final list.
     """
 
     rows: List[DeltaRow] = field(default_factory=list)
@@ -134,7 +137,7 @@ class DeltaResult:
         Distribution metrics nest under ``p50`` / ``p75`` / ``p90``
         keys; ``flow_distribution`` nests under bucket keys. Insertion
         order follows :data:`CANONICAL_METRIC_ORDER` because :attr:`rows`
-        is already in that order — T7's canonical encoder preserves
+        is already in that order — the renderer's canonical encoder preserves
         insertion order for the ``deltas`` block (the one intentional
         exception to the global sort-keys rule).
         """
@@ -235,8 +238,8 @@ def _emit_absent_side(
     Emits placeholder rows (``a=None`` or ``b=None`` as appropriate,
     ``abs`` / ``pct`` both ``None``) plus ONE ``metric_absent`` note —
     not one per percentile or bucket. The note's ``<file>`` slot is
-    filled with the absent side's label since T5 has no access to
-    filenames.
+    filled with the absent side's label since the delta engine has no
+    access to filenames.
     """
     absent_label = a_label if metric not in a else b_label
     result.notes.append(Note.metric_absent(metric, absent_label))

--- a/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/inputs.py
+++ b/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/inputs.py
@@ -1,8 +1,8 @@
-"""T2 input file loader.
+"""Input file loader.
 
 Reads one flow-metrics JSON, validates the ``meta`` block, infers the
 scope ``kind`` from key presence, and returns an :class:`InputFile`
-dataclass that the three mode-runners (T3/T4) consume.
+dataclass that the three mode-runners (modes, program discovery) consume.
 
 Validation rules for input file validation are enforced here. Every
 error message names the file basename; the basename is the only
@@ -76,15 +76,17 @@ def infer_scope_kind(scope: dict, *, basename: str) -> str:
     Recognised kinds:
     ``portfolio`` / ``program`` / ``project`` / ``project+team``.
 
-    Synthesized-only kinds (introduced by T4's per_team flattening of a
-    program- or portfolio-scope input; flagged for spec amendment):
+    Synthesized-only kinds (introduced when program discovery
+    (program_discovery.py) flattens the per_team array of a program- or
+    portfolio-scope input; flagged for spec amendment):
     ``program+team`` / ``portfolio+team``. These are not produced by
-    `flow-metrics` directly — they only arise when T4 synthesises a
-    scope dict by carrying forward the source input's
+    `flow-metrics` directly — they only arise when program discovery
+    synthesises a scope dict by carrying forward the source input's
     ``program_id`` / ``portfolio_id`` and attaching a ``team`` value
     from a ``per_team`` entry. Accepting them here keeps inference in
-    one place; the alternative (a special-case path in T4) was rejected
-    so that T4 can re-infer the kind on the synthesised dict.
+    one place; the alternative (a special-case path in program
+    discovery) was rejected so that program discovery can re-infer the
+    kind on the synthesised dict.
 
     Anything outside the table raises :class:`ValidationError`.
 

--- a/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/modes.py
+++ b/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/modes.py
@@ -1,15 +1,17 @@
-"""T3 file-consumer modes: ``baseline`` and ``cohort``.
+"""File-consumer modes: ``baseline`` and ``cohort``.
 
-Both modes load one or two flow-metrics JSONs via T2's
-:func:`inputs.load_input`, run T5's :func:`delta.compute_deltas` on the
-relevant aggregate pair, and return a :class:`ReportData` for T7 to
-render. ``program`` mode (T4/T6) populates the same dataclass with
+Both modes load one or two flow-metrics JSONs via the input loader's
+:func:`inputs.load_input`, run the delta engine's
+:func:`delta.compute_deltas` on the relevant aggregate pair, and return
+a :class:`ReportData` for the renderer to render. ``program`` mode
+(program discovery + aggregation) populates the same dataclass with
 :attr:`ReportData.per_scope_rows`; the field is ``None`` for baseline
 and cohort.
 
-Notes-merge contract: T5 returns its notes
-unsorted; T3 concatenates them onto :attr:`ReportData.notes` in append
-order. T7 sorts and dedupes the final list — T3 does NOT pre-sort.
+Notes-merge contract: the delta engine returns its notes
+unsorted; the modes concatenate them onto :attr:`ReportData.notes` in
+append order. The renderer sorts and dedupes the final list — the modes
+do NOT pre-sort.
 
 All exit-2 conditions raise :class:`ValidationError`; the CLI entry
 point in :mod:`ai_adoption_report` catches and prints them.
@@ -36,9 +38,9 @@ from .program_discovery import discover_inputs
 # ---------------------------------------------------------------------------
 # Canonical scope representation
 # ---------------------------------------------------------------------------
-# Temporary home — T7 may relocate when it owns the renderer. Kept here
-# because both header-line assembly (T3) and per-scope-row labels (T6)
-# need the same string.
+# Temporary home — the renderer (render.py) may relocate this. Kept here
+# because both header-line assembly (the modes) and per-scope-row labels
+# (aggregation) need the same string.
 _SCOPE_FIELDS = ("project", "team", "program_id", "portfolio_id")
 
 
@@ -61,19 +63,21 @@ def canonical_scope_repr(scope: dict, kind: str) -> str:
 # ---------------------------------------------------------------------------
 @dataclass
 class ReportData:
-    """The mode-agnostic data bundle T7 renders.
+    """The mode-agnostic data bundle the renderer renders.
 
     ``deltas`` and ``cohort_deltas`` carry the
     :meth:`delta.DeltaResult.to_dict` shape (the canonical
-    insertion-order metric dict that the JSON sidecar emits). T3 calls
-    ``to_dict`` so T7 sees the same structure regardless of mode.
+    insertion-order metric dict that the JSON sidecar emits). The modes
+    call ``to_dict`` so the renderer sees the same structure regardless
+    of mode.
 
-    ``per_scope_rows`` stays ``None`` for baseline + cohort; T4/T6
-    populates it for program mode.
+    ``per_scope_rows`` stays ``None`` for baseline + cohort; program
+    discovery and aggregation populate it for program mode.
 
-    ``notes`` is the merged unsorted list (T2's mixed-major note +
-    T3's drift / per_team / cohort-jql notes + T5's compute_deltas
-    notes). T7 sorts and dedupes the final list.
+    ``notes`` is the merged unsorted list (the input loader's
+    mixed-major note + the modes' drift / per_team / cohort-jql notes +
+    the delta engine's compute_deltas notes). The renderer sorts and
+    dedupes the final list.
     """
 
     mode: Literal["baseline", "cohort", "program"]
@@ -86,7 +90,7 @@ class ReportData:
     notes: List[str] = field(default_factory=list)
     # Side labels for ``cohort_deltas`` cells. Carries the
     # ``(a_label, b_label)`` tuple that the originating ``compute_deltas``
-    # call used so T7 can label the Cohort breakdown table columns
+    # call used so the renderer can label the Cohort breakdown table columns
     # accurately (baseline+cohort uses ``("baseline-cohort",
     # "current-cohort")``; program mode uses ``("control", "cohort")``).
     # ``None`` whenever ``cohort_deltas`` is ``None``.
@@ -108,8 +112,8 @@ def run_baseline(args) -> ReportData:
     inputs = [baseline, current]
     notes: List[str] = []
 
-    # T2 cross-input note (mixed schema majors). Same call pattern T4
-    # will use in program mode, kept here for the baseline pair so the
+    # Cross-input note (mixed schema majors). Same call pattern program
+    # discovery uses in program mode, kept here for the baseline pair so the
     # warning surfaces in single-pair runs too.
     mixed_major = collect_mixed_major_note(inputs)
     if mixed_major is not None:
@@ -159,8 +163,8 @@ def run_baseline(args) -> ReportData:
         if inp.per_team:
             notes.append(Note.per_team_ignored_in_baseline(inp.basename))
 
-    # Primary deltas. T5 returns notes unsorted; T3 concatenates per
-    # the notes-merge contract.
+    # Primary deltas. The delta engine returns notes unsorted; the modes
+    # concatenate per the notes-merge contract.
     primary = compute_deltas(
         baseline.aggregates,
         current.aggregates,
@@ -235,11 +239,11 @@ def _baseline_cohort_section(
     # The spec is silent on which sub-side gets compared across windows
     # in baseline mode. The natural reading of "cohort-vs-control deltas
     # across the two windows" is: compare the cohort side at baseline
-    # vs the cohort side at current (and likewise for control). Our T5
-    # engine handles one pair at a time; the section here compares
+    # vs the cohort side at current (and likewise for control). Our
+    # delta engine handles one pair at a time; the section here compares
     # ``baseline.cohort`` vs ``current.cohort`` because that's the
     # quantity a baseline reader asks about ("did AI adoption move the
-    # cohort?"). T7 may add a second sub-table for control later;
+    # cohort?"). The renderer may add a second sub-table for control later;
     # extending requires only another compute_deltas call.
     result = compute_deltas(
         baseline.cohort_breakdown.get("cohort", {}),
@@ -296,7 +300,7 @@ def run_cohort(args) -> ReportData:
 
 
 # ---------------------------------------------------------------------------
-# Mode: program (T4 + T6)
+# Mode: program (program discovery + aggregation)
 # ---------------------------------------------------------------------------
 def run_program(args) -> ReportData:
     """Run program mode end-to-end and return :class:`ReportData`.
@@ -308,13 +312,13 @@ def run_program(args) -> ReportData:
 
     Pipeline:
 
-    1. T4: ``discover_inputs`` — glob, validate, dedupe, overlap-check,
-       per_team flatten.
-    2. T6: ``aggregate_non_cohort`` — program-wide aggregates.
-    3. T6: ``aggregate_cohort_side`` (twice) when
+    1. Program discovery: ``discover_inputs`` — glob, validate, dedupe,
+       overlap-check, per_team flatten.
+    2. Aggregation: ``aggregate_non_cohort`` — program-wide aggregates.
+    3. Aggregation: ``aggregate_cohort_side`` (twice) when
        ``--include-cohort-breakdown`` — cohort and control side
        rollups, computed independently.
-    4. T5: ``compute_deltas`` ONCE — only for the cohort-vs-control
+    4. Delta engine: ``compute_deltas`` ONCE — only for the cohort-vs-control
        rollup comparison. Program mode's main table is per-scope rows
        + aggregate row, NOT a two-side comparison, so the global
        ``deltas`` block stays empty.
@@ -341,7 +345,7 @@ def run_program(args) -> ReportData:
     # Throughput is reported as a raw count AND as a per-week rate.
     # The non-cohort aggregate is the only place this is computed;
     # cohort-side rollups don't carry a window-normalised variant
-    # (T7's renderer can compute one if it wants).
+    # (the renderer can compute one if it wants).
     if "throughput" in global_agg:
         try:
             d_from = date.fromisoformat(from_endpoint)

--- a/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/notes.py
+++ b/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/notes.py
@@ -1,4 +1,4 @@
-"""T2 notes-string formatter.
+"""Notes-string formatter.
 
 Every ``notes`` entry the report emits goes through one of :class:`Note`'s
 factory methods. Centralising the wording prevents drift across the
@@ -6,8 +6,9 @@ modes (baseline, cohort, program) and keeps the spec-literal strings in
 one auditable place.
 
 The factories are pure formatters — they return strings. Buffering and
-sorting live in a higher layer (T3/T4's report assembly), mirroring the
-``flow_metrics.notes`` collector-vs-formatter split.
+sorting live in a higher layer (the modes and program-discovery report
+assembly), mirroring the ``flow_metrics.notes`` collector-vs-formatter
+split.
 
 Note wording is pinned here as the single source of truth for each
 note string emitted by the report.
@@ -24,12 +25,12 @@ class Note:
 
     Each ``@classmethod`` renders one entry exactly as the spec pins it.
     Where the spec gives a verbatim example the wording is reproduced;
-    later tasks (T3/T4/T6) only fill in the stubbed methods, never
-    invent new wording outside this class.
+    later layers (modes, program discovery, aggregation) only fill in
+    the stubbed methods, never invent new wording outside this class.
     """
 
     # ------------------------------------------------------------------
-    # T2 — emitted during input loading
+    # Emitted during input loading
     # ------------------------------------------------------------------
     @classmethod
     def mixed_major_schema_versions(
@@ -66,7 +67,7 @@ class Note:
         return "mixed-major-schema-versions: " + ", ".join(parts)
 
     # ------------------------------------------------------------------
-    # T3 — baseline-mode + cohort-mode
+    # Emitted by the file-consumer modes (baseline + cohort)
     # ------------------------------------------------------------------
     @classmethod
     def config_sha_drift(cls, sha_name: str, a: str, b: str) -> str:
@@ -116,7 +117,7 @@ class Note:
         )
 
     # ------------------------------------------------------------------
-    # T4 — program-mode input discovery, dedupe, overlap, per_team
+    # Emitted by program-mode input discovery — dedupe, overlap, per_team
     # ------------------------------------------------------------------
     @classmethod
     def per_team_cohort_deferred(cls, n_rows: int) -> str:
@@ -124,7 +125,7 @@ class Note:
         ``"per_team-cohort-deferred: N flattened per-team rows have no
         cohort_breakdown; excluded from cohort rollup"``.
 
-        T4 emits this only when ``--include-cohort-breakdown`` is set
+        Program discovery emits this only when ``--include-cohort-breakdown`` is set
         and at least one per_team-flattened row exists (n_rows > 0).
         ``n_rows`` is the count of ``from_per_team=True`` rows in
         :class:`ProgramInputs.scopes`.
@@ -240,7 +241,7 @@ class Note:
         )
 
     # ------------------------------------------------------------------
-    # T6 — program-mode aggregation
+    # Emitted by program-mode aggregation
     # ------------------------------------------------------------------
     @classmethod
     def aggregation_zero_denominator(cls, metric: str, side: str) -> str:
@@ -250,8 +251,8 @@ class Note:
         undefined (total weight is zero on <side>)"``.
 
         ``side`` is one of ``"non-cohort"`` / ``"cohort"`` / ``"control"``
-        — the rollup side whose denominator collapsed to zero. T6 fills
-        in the side label at the call site.
+        — the rollup side whose denominator collapsed to zero. The
+        aggregation engine fills in the side label at the call site.
         """
         return (
             "aggregation-zero-denominator: {}; weighted-average undefined "
@@ -377,18 +378,19 @@ class Note:
         )
 
     # ------------------------------------------------------------------
-    # T5 — delta math (compute_deltas note factories)
+    # Emitted by the delta engine (compute_deltas note factories)
     # ------------------------------------------------------------------
     @classmethod
     def metric_absent(cls, metric: str, side_label: str) -> str:
         """Metric absent note: ``"<metric> absent in <file>; cell omitted"``.
 
-        T5 calls this when a metric key is present on one side of the
-        comparison but missing on the other. ``side_label`` is the
-        per-side label supplied to :func:`compute_deltas` (``"baseline"``
-        / ``"current"`` / ``"cohort"`` / ``"control"`` / a basename in
-        program-mode rollups) — T5 has no access to filenames, so the
-        caller pre-resolves ``<file>`` into the label.
+        The delta engine calls this when a metric key is present on one
+        side of the comparison but missing on the other. ``side_label``
+        is the per-side label supplied to :func:`compute_deltas`
+        (``"baseline"`` / ``"current"`` / ``"cohort"`` / ``"control"`` /
+        a basename in program-mode rollups) — the delta engine has no
+        access to filenames, so the caller pre-resolves ``<file>`` into
+        the label.
         """
         return "{} absent in {}; cell omitted".format(metric, side_label)
 
@@ -396,10 +398,10 @@ class Note:
     def metric_null_on_one_side(cls, metric: str, side_label: str) -> str:
         """Metric null on one side: ``"<metric> null in <which-side> for <scope>"``.
 
-        T5 does not know the scope (it operates on raw aggregate dicts),
-        so it emits the leading clause only. T3 / T6 may later wrap or
-        rewrite if they want to thread the scope through; the stable
-        wording lives here.
+        The delta engine does not know the scope (it operates on raw
+        aggregate dicts), so it emits the leading clause only. The modes
+        or aggregation engine may later wrap or rewrite if they want to
+        thread the scope through; the stable wording lives here.
         """
         return "{} null in {}".format(metric, side_label)
 

--- a/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/program_discovery.py
+++ b/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/program_discovery.py
@@ -1,4 +1,4 @@
-"""T4 program-mode input discovery.
+"""Program-mode input discovery.
 
 Globs ``<DIR>/*.json`` (non-recursive), filters by ``--window``, runs
 duplicate + cross-kind overlap detection, flattens ``per_team`` arrays
@@ -29,10 +29,11 @@ from .notes import Note
 class ProgramScope:
     """One row in the program-mode per-scope table.
 
-    Carries enough state for T6 to drive per-metric aggregation without
-    re-reading files. ``from_per_team=True`` rows are synthesised from
-    a parent input's ``per_team`` array and are excluded from cohort
-    rollups (flow-metrics v1 does not split per_team rows by cohort).
+    Carries enough state for the aggregation engine to drive per-metric
+    aggregation without re-reading files. ``from_per_team=True`` rows
+    are synthesised from a parent input's ``per_team`` array and are
+    excluded from cohort rollups (flow-metrics v1 does not split
+    per_team rows by cohort).
     """
 
     scope: dict
@@ -51,8 +52,9 @@ class ProgramInputs:
 
     ``scopes`` is the post-flattening, post-dedupe, post-overlap-check
     list. ``source_inputs`` is the original :class:`InputFile` set that
-    survived the window filter — T7 reads this for the Provenance
-    section. ``notes`` is unsorted; T7 sorts and dedupes.
+    survived the window filter — the renderer reads this for the
+    Provenance section. ``notes`` is unsorted; the renderer sorts and
+    dedupes.
     """
 
     scopes: List[ProgramScope]
@@ -89,7 +91,7 @@ def canonical_scope_repr(scope: dict, scope_kind: str) -> str:
     Used for:
 
     - duplicate-scope detection (group key in :func:`discover_inputs`),
-    - per-scope row ordering in T7's Markdown / JSON output,
+    - per-scope row ordering in the renderer's Markdown / JSON output,
     - the canonical sort key for ``meta.inputs`` per-scope rows.
 
     The kind is taken as an argument (rather than re-inferred) so this
@@ -118,7 +120,7 @@ def discover_inputs(
 
     1. ``directory.glob("*.json")`` — no recursion.
        Results sorted codepoint-ascending for deterministic errors.
-    2. ``load_input`` each (T2). Failures exit 2 naming the basename.
+    2. ``load_input`` each (input loader). Failures exit 2 naming the basename.
     3. Window filter: ``input.window_from == FROM and
        input.window_to == TO`` (string equality).
     4. Empty result → ValidationError.
@@ -129,10 +131,11 @@ def discover_inputs(
     9. Post-flatten duplicate-scope safeguard.
     10. Emit notes (per_team-double-counted, per_team-cohort-deferred).
 
-    ``window`` is the tuple returned by T1's ``parse_window_flag``.
+    ``window`` is the tuple returned by the CLI scaffold's ``parse_window_flag``.
 
     ``include_cohort_breakdown`` controls the
-    ``per_team-cohort-deferred`` note only; T4 has no other use for it.
+    ``per_team-cohort-deferred`` note only; program discovery has no
+    other use for it.
     """
     candidates = sorted(directory.glob("*.json"), key=lambda p: p.name)
 

--- a/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/render.py
+++ b/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/render.py
@@ -1,9 +1,9 @@
-"""T7 output rendering — Markdown + JSON sidecar.
+"""Output rendering — Markdown + JSON sidecar.
 
 Pure transformation layer. :func:`render_markdown` and :func:`render_json`
 take a :class:`modes.ReportData` plus a caller-supplied ``title`` and
-``generated_at`` (T8 supplies the latter; tests stub it) and return the
-final wire strings. No I/O, no clock reads.
+``generated_at`` (the write path supplies the latter; tests stub it) and
+return the final wire strings. No I/O, no clock reads.
 
 Markdown rules:
 
@@ -40,20 +40,21 @@ is then string-replaced with the separately-serialized canonical-order
 deltas blob (chosen over an encoder subclass unless a cleaner
 encoder pattern emerges).
 
-T7 invariants and decisions (flagged for spec amendment):
+Renderer invariants and decisions (flagged for spec amendment):
 
-1. Summary string is composed by T7 from :attr:`ReportData.deltas` (or
-   ``cohort_deltas`` in cohort mode, or scope-count + window in program
-   mode). An example exists but the producer isn't pinned;
-   T7 takes the role and emits a best-effort sentence.
+1. Summary string is composed by the renderer from
+   :attr:`ReportData.deltas` (or ``cohort_deltas`` in cohort mode, or
+   scope-count + window in program mode). An example exists but the
+   producer isn't pinned; the renderer takes the role and emits a
+   best-effort sentence.
 2. Per-scope table column set: every canonical-order scalar metric +
    every distribution metric's p50 only (p75/p90 elided; readers wanting
    full percentile detail look at the JSON sidecar). No example pins
    the full column set.
 3. Aggregate row: emitted as a final ``"Aggregate"``-labeled row in the
    per-scope table, sourced from :attr:`ReportData.program_aggregates`.
-   Spec doesn't require it explicitly; T6 computes the math so this
-   surfaces it.
+   Spec doesn't require it explicitly; the aggregation engine computes
+   the math so this surfaces it.
 4. ``cohort_breakdown`` JSON subtree keys are sorted codepoint-ascending
    (not canonical-metric-order) — only ``deltas`` gets the order
    exception (the one intentional exception to the global sort-keys
@@ -135,9 +136,10 @@ def render_markdown(
 ) -> str:
     """Render the full Markdown document for ``report``.
 
-    ``generated_at`` is a UTC ISO-8601 string; T8 passes it. T7 never
-    reads the clock. The function is pure — same inputs produce
-    byte-identical output (per the ``test_byte_identical_rerun`` test).
+    ``generated_at`` is a UTC ISO-8601 string; the write path passes it.
+    The renderer never reads the clock. The function is pure — same
+    inputs produce byte-identical output (per the
+    ``test_byte_identical_rerun`` test).
     """
     lines: List[str] = []
 
@@ -233,7 +235,7 @@ def render_json(
 ) -> str:
     """Render the JSON sidecar as a serialized string.
 
-    Pure — no I/O, no clock reads. T8 calls this and writes the bytes.
+    Pure — no I/O, no clock reads. The write path calls this and writes the bytes.
     """
     # Build meta block.
     meta = {
@@ -300,7 +302,8 @@ def render_json(
 # ---------------------------------------------------------------------------
 def _finalize_notes(notes: Iterable[str]) -> List[str]:
     """Dedupe + codepoint-sort. Used by both renderers so they emit the
-    same list. T3/T4/T5/T6 produced notes unsorted; T7 finalizes.
+    same list. The modes, program discovery, delta engine, and
+    aggregation engine produced notes unsorted; the renderer finalizes.
     """
     return sorted(set(notes))
 
@@ -311,7 +314,7 @@ def _finalize_notes(notes: Iterable[str]) -> List[str]:
 def _build_summary(report: ReportData) -> str:
     """Compose the one-line plain-English summary.
 
-    T7 invention (the spec shows an example but doesn't pin the
+    Renderer invention (the spec shows an example but doesn't pin the
     producer). Strategy: pick a few canonical-order key metrics from
     ``report.deltas`` (throughput, cycle_time_hours p50, rework_rate) and
     render their pct deltas in human-readable form. Falls back to a
@@ -501,7 +504,7 @@ def _render_per_scope_table(
 ) -> List[str]:
     """Render the per-scope table plus the final Aggregate row.
 
-    ``per_scope_rows`` arrives sorted by ``scope_repr`` (T6 sorts).
+    ``per_scope_rows`` arrives sorted by ``scope_repr`` (aggregation sorts).
     """
     header_cells = ["Scope"] + [label for label, _, _ in _PER_SCOPE_COLUMNS]
     out = [

--- a/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/write.py
+++ b/packs/atlassian/.apm/skills/ai-adoption-report/scripts/ai_adoption_report/write.py
@@ -1,6 +1,6 @@
-"""T8 output write path — atomic, collision-detecting, --overwrite-aware.
+"""Output write path — atomic, collision-detecting, --overwrite-aware.
 
-The only place the skill writes to disk. T7's :func:`render.render_markdown`
+The only place the skill writes to disk. The renderer's :func:`render.render_markdown`
 and :func:`render.render_json` produce the wire strings; this module takes
 ``(path, contents)`` pairs and lands them on disk atomically.
 
@@ -34,8 +34,8 @@ the Markdown and sidecar cannot collide on the same filename.
 
 Env var: :data:`GENERATED_AT_ENV_VAR` (``AI_ADOPTION_REPORT_GENERATED_AT``)
 is read by the CLI dispatch in :mod:`ai_adoption_report` to pin
-``generated_at`` for deterministic-build tests. T7 stays pure; T8 owns
-the clock.
+``generated_at`` for deterministic-build tests. The renderer stays
+pure; the write path owns the clock.
 
 Stdlib only. Python >= 3.10.
 """
@@ -49,7 +49,7 @@ from typing import List, Sequence, Tuple
 from . import ValidationError
 
 
-# Pinned for the CLI dispatch + T9's SKILL.md to reference.
+# Pinned for the CLI dispatch + the SKILL.md docs to reference.
 GENERATED_AT_ENV_VAR = "AI_ADOPTION_REPORT_GENERATED_AT"
 
 

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/credentials_shim.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/credentials_shim.py
@@ -19,7 +19,7 @@ module-load time: ``_keychain_macos`` iff ``sys.platform ==
 "darwin"``, ``_credman_windows`` iff ``"win32"``, no Tier-2 backend on
 other platforms (resolver falls through directly to Tier 3).
 
-``.env`` parser (T2 surface, retained here):
+``.env`` parser (retained here):
 
 Supported:
     ``KEY=value``

--- a/packs/atlassian/.apm/skills/confluence-publisher/scripts/credentials_shim.py
+++ b/packs/atlassian/.apm/skills/confluence-publisher/scripts/credentials_shim.py
@@ -19,7 +19,7 @@ module-load time: ``_keychain_macos`` iff ``sys.platform ==
 "darwin"``, ``_credman_windows`` iff ``"win32"``, no Tier-2 backend on
 other platforms (resolver falls through directly to Tier 3).
 
-``.env`` parser (T2 surface, retained here):
+``.env`` parser (retained here):
 
 Supported:
     ``KEY=value``

--- a/packs/atlassian/.apm/skills/flow-metrics/SKILL.md
+++ b/packs/atlassian/.apm/skills/flow-metrics/SKILL.md
@@ -347,7 +347,7 @@ Output is canonicalised at serialisation: codepoint-sorted object keys
 (except `flow_distribution` which uses a fixed bucket order), floats
 rounded to 4 decimal places, per_team sorted by team name codepoint.
 The schema does **not** re-validate canonicalisation rules — those are
-enforced by the renderer's contract tests in T10.
+enforced by the renderer's contract tests.
 
 ## Further reading
 

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/__init__.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/__init__.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """flow-metrics CLI entry point.
 
-T1 scaffold: argparse, version guard, window resolution, path safety,
+CLI scaffold: argparse, version guard, window resolution, path safety,
 flag-combo validation. Every command path is a stub that prints
-"not yet implemented" and exits 0. Later tasks fill in the actual work.
+"not yet implemented" and exits 0. Later layers fill in the actual work.
 
 Stdlib only. Python >= 3.10.
 """
@@ -38,7 +38,8 @@ def _check_python_version(version_info=None) -> None:
 
 
 # Run guard BEFORE internal imports so any 3.10+ syntax in sibling modules
-# (T2+: config.py, upstream.py, ...) only parses on a supported interpreter.
+# (config.py, upstream.py, and other stage modules) only parses on a
+# supported interpreter.
 # The stdlib imports above are 3.7-safe; siblings below need the guard
 # to print a friendly message instead of a SyntaxError on 3.9 and older.
 _check_python_version()
@@ -294,9 +295,9 @@ def validate_args(args: argparse.Namespace) -> None:
     if args.issuetype_config is not None:
         validate_path(args.issuetype_config, "issuetype-config")
 
-    # Metrics list (just shape-check here; no fail-on-unknown until T10
-    # owns the canonical list emission. But typo'd metric names should
-    # surface early).
+    # Metrics list (just shape-check here; no fail-on-unknown until the
+    # renderer owns the canonical list emission. But typo'd metric names
+    # should surface early).
     if args.metrics is not None:
         names = [m.strip() for m in args.metrics.split(",") if m.strip()]
         unknown = [n for n in names if n not in ALL_METRICS]
@@ -309,8 +310,9 @@ def validate_args(args: argparse.Namespace) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Overwrite-confirm helper (T1 ships the prompt + TTY-detection helper that
-# the test exercises via a stub; the actual write path is T10).
+# Overwrite-confirm helper (the CLI scaffold ships the prompt +
+# TTY-detection helper that the test exercises via a stub; the actual
+# write path is the renderer).
 # ---------------------------------------------------------------------------
 def confirm_overwrite(
     path: Path,
@@ -345,7 +347,7 @@ def confirm_overwrite(
 
 
 # ---------------------------------------------------------------------------
-# Pipeline wiring (T13 — orchestrates T2-T11 module APIs end-to-end)
+# Pipeline wiring — orchestrates the per-stage module APIs end-to-end
 # ---------------------------------------------------------------------------
 def _format_team_id_literal(team_id: str) -> str:
     """Render a Jira Align team id as a JQL literal for the IN clause.
@@ -419,14 +421,14 @@ def _resolve_metrics(args: argparse.Namespace):
 def _run_pipeline(args: argparse.Namespace, window: "Window") -> int:
     """Drive the full pipeline end-to-end. Returns a process exit code.
 
-    Orchestration only — every computation step lives in a T2-T11 module.
+    Orchestration only — every computation step lives in a per-stage module.
     Exceptions raised by modules (ValidationError, AllowlistError,
     UpstreamNotFoundError, JiraError, CallerResolutionError, ConfigError,
     AlignResponseError, ValueError from align_join_field / align_teams_path)
     bubble out to main()'s try/except, which maps to the right exit code.
     """
-    # Local imports — keep top-level import surface minimal so the T1
-    # stub-only paths (--help, validation errors) don't pay the full
+    # Local imports — keep top-level import surface minimal so the CLI
+    # scaffold's stub-only paths (--help, validation errors) don't pay the full
     # module-graph cost.
     from dataclasses import replace as _replace
     from .config import ConfigError, TeamField, load_issuetype_config, load_state_config
@@ -586,7 +588,7 @@ def _run_pipeline(args: argparse.Namespace, window: "Window") -> int:
     if should_per_team and rows:
         # Array-kind team_field: enumerate the full membership list per
         # row so an issue with N>1 teams lands in each team's bucket.
-        # The list is canonical on the row (T5 derive_row populates
+        # The list is canonical on the row (per-issue derivation's derive_row populates
         # ``teams`` deduped, in encounter order) — bucket_by_team
         # dedupes within the row again defensively. NO_TEAM rows have
         # an empty ``teams`` tuple; bucket_by_team's "no teams →
@@ -682,16 +684,17 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         print("error: {}".format(e), file=sys.stderr)
         return EXIT_VALIDATION
     except (AllowlistError, UpstreamNotFoundError) as e:
-        # T3 test seam — these exceptions are raised by the upstream
-        # wrapper layer, never by validate_args itself in production, but
-        # T3's test_main_catches_* contract tests monkeypatch validate_args
-        # to inject them and assert main()'s exit-code mapping.
+        # Upstream-wrapper test seam — these exceptions are raised by the
+        # upstream wrapper layer, never by validate_args itself in
+        # production, but the upstream wrapper's test_main_catches_*
+        # contract tests monkeypatch validate_args to inject them and
+        # assert main()'s exit-code mapping.
         print("error: {}".format(e), file=sys.stderr)
         return EXIT_VALIDATION
     except JiraError:
         return EXIT_UPSTREAM
 
-    # Overwrite confirmation gate (T1 contract — applies before the
+    # Overwrite confirmation gate (CLI scaffold contract — applies before the
     # pipeline so a missing TTY aborts before any subprocess fires).
     if args.output is not None:
         out_path = Path(args.output)

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/aggregate.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/aggregate.py
@@ -1,4 +1,4 @@
-"""T6 aggregation — percentiles, throughput, WIP, Flow Load, Flow
+"""Aggregation — percentiles, throughput, WIP, Flow Load, Flow
 Distribution, defect ratio, rework rate, flow efficiency.
 
 :func:`aggregate` consumes an :class:`Iterator[PerIssueRow]` exactly
@@ -10,10 +10,10 @@ drained, percentiles are computed via :func:`statistics.quantiles` (n=
 metric on the way out (the round-once contract, locked in by
 ``test_percentile_computed_at_full_precision``).
 
-T6 owns the zero-denominator / unmapped-issuetype / delivered-without-
-commitment counters that T11 turns into ``notes`` lines. Cohort split
-(T8), caching (T7), output filtering and rendering (T10), and notes
-wording (T11) are downstream.
+The aggregator owns the zero-denominator / unmapped-issuetype /
+delivered-without-commitment counters that the notes collector turns
+into ``notes`` lines. The cohort split, the cache, output filtering and
+rendering, and notes wording are downstream.
 
 Stdlib only. Python >= 3.10.
 """
@@ -57,7 +57,7 @@ class PercentileStat:
 class AggregateBlock:
     """Flat one-field-per-metric aggregate.
 
-    Carries every metric the spec defines; the T10 serializer filters to
+    Carries every metric the spec defines; the renderer's serializer filters to
     ``--metrics``. Notes-block counters live alongside the metrics so the
     aggregator's single pass is the only place that needs to touch the
     raw row stream.
@@ -74,7 +74,7 @@ class AggregateBlock:
     flow_distribution: Mapping[str, float]
     flow_distribution_denominator: int
     defect_ratio: float
-    # Notes-block counters (T11 wordsmiths them into notes lines).
+    # Notes-block counters (the notes collector wordsmiths them into notes lines).
     cancelled_in_window: int
     delivered_without_commitment: int
     flow_efficiency_zero_denominator: int
@@ -119,10 +119,10 @@ def aggregate(
     than ``O(rows)``.
 
     ``config`` is reserved for future metric-config hooks (e.g., a
-    rework-signal override at aggregate time). T6 does not read it
-    today — every populated PerIssueRow already carries the
+    rework-signal override at aggregate time). The aggregator does not
+    read it today — every populated PerIssueRow already carries the
     state-config-derived booleans — but threading it keeps the
-    signature stable for T7+.
+    signature stable for the cache and downstream stages.
     """
     del config  # reserved; rows are pre-derived against state config
 
@@ -149,8 +149,9 @@ def aggregate(
             # Custom user-configured buckets (anything outside the spec's
             # standard six) funnel to "other" for the AggregateBlock's
             # fixed-shape distribution. They are NOT counted as unmapped
-            # — only T5's None-mapped-to-"other" sink (raw issuetype not
-            # in any user bucket) signals "unmapped" for the notes line.
+            # — only per-issue derivation's None-mapped-to-"other" sink
+            # (raw issuetype not in any user bucket) signals "unmapped"
+            # for the notes line.
             bucket = raw_bucket if raw_bucket in buckets else OTHER_BUCKET
             buckets[bucket] += 1
             if raw_bucket == OTHER_BUCKET:
@@ -174,7 +175,7 @@ def aggregate(
                     else:
                         # Cycle-eligible but ``(active_t + wait_t) == 0``
                         # — excluded from the flow_efficiency percentile
-                        # array, surfaced in notes by T11.
+                        # array, surfaced in notes by the notes collector.
                         flow_efficiency_zero_denominator += 1
                 else:
                     delivered_without_commitment += 1

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/align.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/align.py
@@ -1,4 +1,4 @@
-"""T9 Jira Align integration.
+"""Jira Align integration.
 
 Resolves team membership for program-id / portfolio-id scope runs via
 the ``jira-align`` skill's nested-resource ``raw GET`` endpoints, then
@@ -94,8 +94,8 @@ def validate_align_teams_path(path: str) -> str:
 # Canonical scope_kind values, shared with :mod:`flow_metrics.cache` (which
 # pins the same vocabulary in the cache-key payload:
 # ``scope_kind: "project" | "program" | "portfolio"``). Using anything
-# else here would silently break cache-key derivation when T10 wires this
-# module into the main run.
+# else here would silently break cache-key derivation when the renderer
+# wires this module into the main run.
 PROJECT_KIND = "project"
 PROGRAM_KIND = "program"
 PORTFOLIO_KIND = "portfolio"
@@ -308,7 +308,7 @@ def require_align_join_field(
 
 
 # ---------------------------------------------------------------------------
-# meta.sources helper (T10 emits; T9 surfaces the value)
+# meta.sources helper (the renderer emits; the Align integration surfaces the value)
 # ---------------------------------------------------------------------------
 def compute_sources(scope_kind: Optional[str]) -> List[str]:
     """Return the sorted list of upstream skill names used for this run.
@@ -318,7 +318,7 @@ def compute_sources(scope_kind: Optional[str]) -> List[str]:
     vocabulary (also accepted in their CLI-flag spellings ``program-id``
     / ``portfolio-id`` so call sites can pass either without an explicit
     conversion). The contract test ``test_meta_sources_reflects_skills_
-    called`` pins both shapes. T10 merges this into the top-level
+    called`` pins both shapes. The renderer merges this into the top-level
     ``meta`` block.
     """
     sources = ["jira"]

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/cache.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/cache.py
@@ -168,7 +168,7 @@ def _tuple_field_names() -> frozenset:
     JSON has no tuple type, so ``asdict`` → ``json.dumps`` → ``json.loads``
     on a tuple-valued field returns a list. Without re-tupling on read,
     a cached round-trip would not compare equal to the source row, which
-    breaks both T7's roundtrip equality guarantee and any downstream
+    breaks both the cache's roundtrip equality guarantee and any downstream
     code that relies on tuple semantics (immutability, hashing).
     """
     global _TUPLE_FIELD_NAMES

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/changelog.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/changelog.py
@@ -1,6 +1,6 @@
 """Per-issue changelog pagination — Cloud-regression workaround.
 
-T4 substrate: the upstream ``jira: search ... --expand changelog`` call
+The upstream ``jira: search ... --expand changelog`` call
 inlines at most the first ~100 changelog entries per issue under
 ``issue.changelog``. Long-lived issues need a follow-up
 ``jira: raw GET issue/<KEY>/changelog`` to drain the rest, or every
@@ -16,7 +16,7 @@ This module exposes a single streaming entry point,
 - yields entries lazily so the iterator's peak memory is
   O(transitions per issue), not O(total transitions across the run);
 - filters to ``field in {"status", "issuetype"}`` (the only two fields
-  T5 consumes) at this layer to keep per-issue memory bounded.
+  per-issue derivation consumes) at this layer to keep per-issue memory bounded.
 
 Pagination is detected from three signals in priority order:
 
@@ -43,7 +43,7 @@ from typing import Any, Iterator, List, Mapping, Optional
 from .upstream import JiraClient
 
 
-# Fields T5 consumes. Other field changes (labels, assignee, custom
+# Fields per-issue derivation consumes. Other field changes (labels, assignee, custom
 # fields) are filtered out at this layer so per-issue memory stays
 # bounded at O(state + issuetype transitions) rather than O(every edit).
 _KEPT_FIELDS: frozenset = frozenset({"status", "issuetype"})
@@ -159,8 +159,8 @@ def _entries_from_history(history: Mapping[str, Any]) -> Iterator[ChangelogEntry
         ts = _parse_jira_timestamp(created)
     except ValueError:
         # An unparseable timestamp on a single history record should not
-        # corrupt the whole iterator — skip it and let T5 surface any
-        # downstream consequences via the per-issue derivation checks.
+        # corrupt the whole iterator — skip it and let per-issue
+        # derivation surface any downstream consequences via its checks.
         return
     author = _author_name(history.get("author"))
     items = history.get("items")
@@ -232,7 +232,7 @@ def iter_issue_changelog(
     without the metadata we can't tell whether to drain. A bare list is
     still tolerated and treated as a complete, unpaginated changelog.
 
-    The follow-up ``raw_get`` calls go through the T3 allowlist:
+    The follow-up ``raw_get`` calls go through the upstream wrapper's allowlist:
     ``issue/<KEY>/changelog`` is one of the three permitted patterns;
     nothing else is.
     """

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/cohort.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/cohort.py
@@ -1,4 +1,4 @@
-"""T8 cohort split — `--cohort-jql` resolution + `cohort_breakdown`.
+"""Cohort split — `--cohort-jql` resolution + `cohort_breakdown`.
 
 Cohort behaviour:
 
@@ -9,7 +9,7 @@ Cohort behaviour:
 - :func:`tag_cohort` stamps each :class:`PerIssueRow` with a
   ``cohort: bool`` derived from set membership in the resolved key set.
 - :func:`aggregate_cohort` filters tagged rows by the ``cohort`` flag
-  and runs T6's :func:`aggregate` on the subset. The cohort-restricted
+  and runs the aggregator's :func:`aggregate` on the subset. The cohort-restricted
   denominators (throughput, rework_rate, flow_distribution) follow
   automatically: the subset has its own throughput and its own backward-
   edge sum, so ``rework_rate = cohort_edges / cohort_throughput`` and
@@ -21,8 +21,8 @@ Cohort behaviour:
   ``{"cohort": AggregateBlock, "control": AggregateBlock}`` pair. When
   the resolved cohort set is disjoint from in-scope rows, the duck-
   typed ``notes`` collector is asked to record the empty-cohort note
-  (T11 owns the wording).
-- :func:`cohort_meta` is the meta-block helper T10 will call: returns a
+  (the notes collector owns the wording).
+- :func:`cohort_meta` is the meta-block helper the renderer will call: returns a
   one-key dict when ``--cohort-jql`` was set, empty dict otherwise.
   Locked in here because the spec contract-tests "meta.cohort_jql is
   omitted entirely when --cohort-jql is absent".
@@ -114,7 +114,7 @@ def aggregate_cohort(
 ) -> AggregateBlock:
     """Aggregate the subset of ``rows`` whose ``cohort`` flag matches.
 
-    Wraps T6's :func:`aggregate` against a generator that filters by
+    Wraps the aggregator's :func:`aggregate` against a generator that filters by
     ``row.cohort``. The subset carries its own throughput and backward-
     edge totals, so the spec's "denominator-restricted" cohort metrics
     fall out for free: ``rework_rate`` divides by the cohort throughput,
@@ -128,7 +128,7 @@ def aggregate_cohort(
     cohort/control split when cohort tagging was skipped by mistake.
     """
     subset = (r for r in rows if r.cohort is cohort)
-    # T6-API: aggregate(rows, window, config, *, include_subtasks=False).
+    # aggregator API: aggregate(rows, window, config, *, include_subtasks=False).
     return aggregate(subset, window, config, include_subtasks=include_subtasks)
 
 
@@ -145,12 +145,13 @@ def build_cohort_breakdown(
 
     Materialises the row stream once (two passes are required —
     cohort+control — and the source is single-pass). For very large
-    runs T10 may replace this with a T7 ``read_cache`` re-iteration to
-    avoid the materialisation; the interface is identical either way.
+    runs the renderer may replace this with a ``read_cache`` re-iteration
+    from the cache to avoid the materialisation; the interface is
+    identical either way.
 
     When the resolved cohort set is disjoint from the in-scope rows
     (i.e. zero tagged rows have ``cohort=True``), ``notes`` is asked to
-    record the empty-cohort note. ``notes`` is duck-typed — the T11
+    record the empty-cohort note. ``notes`` is duck-typed — the
     :class:`NotesCollector` will satisfy the interface, but tests pass
     a ``MagicMock()`` and assert the call.
     """
@@ -161,7 +162,7 @@ def build_cohort_breakdown(
     if not cohort_rows:
         notes.add_empty_cohort()
 
-    # T6-API: aggregate(rows, window, config, *, include_subtasks=False).
+    # aggregator API: aggregate(rows, window, config, *, include_subtasks=False).
     cohort_block = aggregate(
         iter(cohort_rows), window, config, include_subtasks=include_subtasks
     )
@@ -177,7 +178,7 @@ def cohort_meta(cohort_jql: Optional[str]) -> Dict[str, str]:
     Empty dict when ``--cohort-jql`` was not provided (None or empty
     string). The spec contract-test ``test_meta_cohort_jql_omitted_when
     _absent`` pins this: the key must be missing, not null, not empty.
-    T10 merges the returned dict into the top-level ``meta`` object.
+    The renderer merges the returned dict into the top-level ``meta`` object.
     """
     if cohort_jql is None or cohort_jql.strip() == "":
         return {}

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/config.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/config.py
@@ -1,7 +1,8 @@
 """State + issuetype config loading, integrity validation, sha derivation.
 
 Implements the 9 startup integrity rules for state configuration
-and ships the canonical-state lookup helper consumed at walk-time by T5.
+and ships the canonical-state lookup helper consumed at walk-time by
+per-issue derivation.
 
 Stdlib only. Python >= 3.10.
 """
@@ -49,7 +50,7 @@ def _find_skill_root(start: Optional[Path] = None) -> Path:
     skills docs) and in-pack development trees
     (``<repo>/packs/atlassian/.apm/skills/flow-metrics/``). During
     development the
-    ``SKILL.md`` file may not exist yet (T12 ships it); in that case we
+    ``SKILL.md`` file may not exist yet (the skill docs add it); in that case we
     fall back to a directory that contains ``references/`` and a sibling
     ``scripts/`` so tests run from a clone before packaging is complete.
     """
@@ -118,7 +119,7 @@ class StateConfig:
         """O(1) lookup from raw Jira status name to canonical state.
 
         Returns ``None`` if ``raw_status`` is not mapped under any
-        ``canonical_states`` entry. T5's per-issue derivation converts a
+        ``canonical_states`` entry. Per-issue derivation converts a
         ``None`` return into the data-dependent unmapped-status exit-2.
         """
         return self._raw_to_canonical.get(raw_status)
@@ -158,12 +159,13 @@ def validate_state_config(parsed: Any) -> None:
 
     Each violation raises ``ConfigError`` with a message naming the
     offending field. The data-dependent unmapped-status check (rule for
-    unmapped raw statuses) belongs to T5 — this routine does NOT consult
-    any changelog data. Rule 9 (``team_field.id`` validated against
-    Jira's field catalog) is a startup check that requires the T3
-    upstream wrapper; the *config-shape* portion (id is a string, kind
-    is one of the allowed values) is enforced here, but the field-catalog
-    lookup itself is left to the caller after T3 lands.
+    unmapped raw statuses) belongs to per-issue derivation — this
+    routine does NOT consult any changelog data. Rule 9 (``team_field.id``
+    validated against Jira's field catalog) is a startup check that
+    requires the upstream wrapper; the *config-shape* portion (id is a
+    string, kind is one of the allowed values) is enforced here, but the
+    field-catalog lookup itself is left to the caller after the upstream
+    wrapper lands.
     """
     if not isinstance(parsed, dict):
         raise ConfigError(
@@ -272,7 +274,7 @@ def validate_state_config(parsed: Any) -> None:
         _check_refs(tos, "rework_signals[{}].to".format(i))
 
     # team_field shape check. Rule 9's field-catalog lookup is deferred to
-    # the T3 upstream wrapper; here we enforce shape + the v2 deferral.
+    # the upstream wrapper; here we enforce shape + the v2 deferral.
     team_field = parsed.get("team_field")
     if team_field is not None:
         if not isinstance(team_field, dict):
@@ -461,12 +463,12 @@ def validate_team_field_against_catalog(
 ) -> None:
     """Spec rule 9: the configured ``team_field.id`` must exist in Jira's
     field catalog. Deferred from :func:`validate_state_config` because it
-    requires the T3 upstream wrapper.
+    requires the upstream wrapper.
 
     Resolution order: ``--team-field-override`` (if set) wins; else
     ``state_config.team_field.id``. If neither is set, this is a no-op
     (the field is optional unless team rollup is requested; that gate
-    lives in T9).
+    lives in the per-team rollup).
 
     Raises :class:`ConfigError` (exit 2) naming the offending id when
     the field is absent from ``jira: raw GET field``.

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/jql.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/jql.py
@@ -1,7 +1,7 @@
 """JQL composition helper — the canonical iteration-order anchor.
 
 Used identically for scope, ``--jql``, ``--cohort-jql``, ``--align-filter``,
-and (T9) the program-scope JQL. Parenthesization is contract-tested:
+and (in the per-team rollup) the program-scope JQL. Parenthesization is contract-tested:
 ``(scope) AND (user)`` whenever a user clause is present, regardless of
 its internal operator precedence. ``ORDER BY key ASC`` is appended for
 canonical iteration order.

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/meta.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/meta.py
@@ -1,6 +1,6 @@
-"""T11 ``meta`` block builder.
+"""``meta`` block builder.
 
-Composes the meta dict T10's renderer splices into the canonical
+Composes the meta dict the renderer splices into the canonical
 output. Owns one upstream call — ``jira: whoami`` for ``meta.caller``
 — and the spec-pinned omission rules (``cohort_jql`` absent when
 unset, ``sources`` lex-sorted, ``metrics_requested`` in canonical
@@ -22,7 +22,7 @@ from .output import CANONICAL_METRICS_ORDER
 
 
 # schema_version is pinned at "1.0" for the v1 wire format. Future major
-# versions bump this; T10's renderer does not interpret the value, so the
+# versions bump this; the renderer does not interpret the value, so the
 # bump is single-source-changeable here.
 SCHEMA_VERSION = "1.0"
 
@@ -81,7 +81,7 @@ def _format_scope(
     """Build the ``meta.scope`` dict matching the spec example shape.
 
     Exactly one of ``project`` / ``program_id`` / ``portfolio_id``
-    should be set; the CLI's flag-combo validation (T1) already enforces
+    should be set; the CLI's flag-combo validation (the CLI scaffold) already enforces
     that. ``team`` is only emitted on the project path and only when
     non-empty — an empty team is the same wire shape as no team for the
     test that pins meta.scope passthrough.
@@ -99,10 +99,10 @@ def _format_scope(
 
 
 def _format_window(window: Any) -> Dict[str, str]:
-    """Render ``window`` as the ``{from, to}`` shape T10 emits.
+    """Render ``window`` as the ``{from, to}`` shape the renderer emits.
 
     Accepts either a :class:`flow_metrics.Window` (the runtime type
-    from T1) or a dict with ``from`` / ``to`` keys (tests). Date values
+    from the CLI scaffold) or a dict with ``from`` / ``to`` keys (tests). Date values
     serialise as ISO ``YYYY-MM-DD``; datetime values strip to date.
     """
     if isinstance(window, Mapping):
@@ -174,20 +174,20 @@ def build_meta(
     - ``scope`` — passes through as a mapping. Callers compose via
       :func:`_format_scope` when they have raw ``--project`` / team
       / ``--program-id`` / ``--portfolio-id`` values; pre-shaped dicts
-      are also accepted so T1 can pass an existing ``args``-derived
+      are also accepted so the CLI scaffold can pass an existing ``args``-derived
       shape unmodified.
     - ``window`` — accepts a :class:`flow_metrics.Window` or a mapping
       with ``from`` / ``to`` keys; rendered as ``YYYY-MM-DD`` strings.
-    - ``sources`` — lex-sorted at build time. T10 also sorts
+    - ``sources`` — lex-sorted at build time. The renderer also sorts
       defensively, but pre-sorting keeps the on-wire shape obvious.
     - ``metrics_requested`` — canonical ``--metrics`` order, deduped,
       unknown names dropped (see :func:`_canonical_metrics`).
     - ``generated_at`` — ISO-8601 UTC string. Test fixtures
       historically use ``"2026-05-19T14:00:00Z"``; we render via
       ``isoformat`` and append ``Z`` for naive UTC.
-    - ``per_team_double_counted`` — set by T9; threaded through here.
+    - ``per_team_double_counted`` — set by the per-team rollup; threaded through here.
     - ``cohort_jql`` — **omitted** when ``None`` or empty. The key must
-      be absent, not null, not "". T10's renderer also drops null / empty
+      be absent, not null, not "". The renderer also drops null / empty
       values; this is the first line of defence.
     """
     meta: Dict[str, Any] = {

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/notes.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/notes.py
@@ -1,7 +1,8 @@
-"""T11 notes collector.
+"""Notes collector.
 
-Buffers note strings emitted opportunistically by T5/T6/T8/T9 during a
-run, then :meth:`finalize` returns the lex-sorted list T10's renderer
+Buffers note strings emitted opportunistically by per-issue derivation,
+the aggregator, the cohort split, and the per-team rollup during a
+run, then :meth:`finalize` returns the lex-sorted list the renderer
 splices into the canonical output.
 
 Wording rules for the ``notes`` output block. Where a verbatim example
@@ -74,7 +75,7 @@ class NotesCollector:
     Each ``add_*`` method renders one (or, for the defect-ratio
     disclaimer, two) string(s) and appends them iff not already present.
     :meth:`finalize` returns a freshly-sorted copy each call so the
-    collector remains non-destructive — T10's renderer also sorts
+    collector remains non-destructive — the renderer also sorts
     defensively; both layers must be idempotent under repeated calls.
     """
 
@@ -154,14 +155,14 @@ class NotesCollector:
     def add_empty_cohort(self) -> None:
         """``--cohort-jql`` matched zero in-scope issues.
         ``test_empty_cohort_does_not_exit_nonzero`` pins the behaviour
-        (no exit) but not the wording — this string is T11's call
-        (flagged in PR)."""
+        (no exit) but not the wording — this string is the notes
+        collector's call (flagged in PR)."""
         self._append(_EMPTY_COHORT_LINE)
 
     def add_per_team_double_counted(self, n: int) -> None:
         """K issues belong to more than one team (array team_field kind)
         and are counted in each team's per_team row. Wording matches the
-        test fixture in T9's
+        test fixture in the per-team rollup's
         ``test_per_team_array_kind_double_count_flagged``."""
         self._append(_PER_TEAM_DOUBLE_COUNTED_TEMPLATE.format(n=n))
 
@@ -173,7 +174,7 @@ class NotesCollector:
 
         Non-destructive: repeated calls return equivalent lists; the
         collector remains usable for further add_* calls (subsequent
-        finalize calls reflect them). T10's renderer also sorts
+        finalize calls reflect them). The renderer also sorts
         defensively at emit time; both passes must be idempotent.
         """
         return sorted(self._notes)

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/output.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/output.py
@@ -1,7 +1,7 @@
-"""T10 output rendering — JSON canonicalisation, CSV long-form, per-issue JSONL.
+"""Output rendering — JSON canonicalisation, CSV long-form, per-issue JSONL.
 
-The renderer is the seam between the pipeline (T6 aggregate, T8 cohort,
-T9 per_team, T11 notes + meta) and the wire format. It takes an already-
+The renderer is the seam between the pipeline (aggregate, cohort,
+per_team, notes + meta) and the wire format. It takes an already-
 built :class:`Report` and emits bytes in the spec-pinned shape, applying:
 
 * ``--metrics`` filtering — :class:`~flow_metrics.aggregate.AggregateBlock`
@@ -20,9 +20,9 @@ built :class:`Report` and emits bytes in the spec-pinned shape, applying:
 * Defensive sorting — ``notes`` is sorted at emit; ``meta.sources`` and
   ``meta.metrics_requested`` are re-sorted (lex / canonical respectively)
   so the test passes even when the caller hands an unsorted list. The
-  per_team list is *not* re-sorted here — T9's :func:`per_team_rollup`
-  already sorts by team name in codepoint order, and re-sorting would
-  silently mask a regression there.
+  per_team list is *not* re-sorted here — the per-team rollup's
+  :func:`per_team_rollup` already sorts by team name in codepoint
+  order, and re-sorting would silently mask a regression there.
 
 Stdlib only. Python >= 3.10.
 """
@@ -41,7 +41,7 @@ from .aggregate import (
 )
 from .per_issue import PerIssueRow
 
-# T9-API: imported lazily so a Report can carry rows of the spec'd shape
+# per-team rollup API: imported lazily so a Report can carry rows of the spec'd shape
 # even if a tester stubs PerTeamRow locally (the only attributes accessed
 # are ``.team`` and ``.aggregates``).
 
@@ -171,8 +171,8 @@ def _sort_metrics_requested(metrics: Iterable[str]) -> List[str]:
     the published meta block stays consistent with what ``aggregates``
     actually carries — ``_aggregates_to_dict`` does not emit unknown
     metrics, so listing them in ``meta.metrics_requested`` would lie to
-    downstream consumers. CLI flag validation (T1) catches unknown
-    names before they reach the renderer; this is the last-line
+    downstream consumers. CLI flag validation (the CLI scaffold) catches
+    unknown names before they reach the renderer; this is the last-line
     defence.
     """
     seen: set = set()
@@ -190,7 +190,7 @@ def _meta_to_dict(
     """Build the meta wire dict, applying the defensive resorts.
 
     The caller is supposed to pre-sort ``meta.sources`` lex and
-    ``meta.metrics_requested`` canonical, but T11 produces ``notes`` /
+    ``meta.metrics_requested`` canonical, but the meta builder produces ``notes`` /
     ``sources`` opportunistically and the contract tests want stable
     output regardless. Re-sort here so a missing or unsorted upstream
     list doesn't surface as test churn.
@@ -246,7 +246,7 @@ def _build_report_dict(report: Report) -> Dict[str, Any]:
         #
         # Spec lines 406-428: cohort_breakdown emits both `cohort` and
         # `control` sides together — the example always shows both, and
-        # T8's :func:`build_cohort_breakdown` always returns both. A
+        # the cohort split's :func:`build_cohort_breakdown` always returns both. A
         # partial breakdown (one side only) is upstream contract
         # violation; rather than silently produce spec-undefined output,
         # require both-or-neither and skip emission when one is missing.
@@ -419,7 +419,7 @@ def _per_issue_row_to_dict(row: PerIssueRow) -> Dict[str, Any]:
     ``None``.
 
     ``cohort`` is **only** emitted when set (``True`` / ``False``). When
-    ``--cohort-jql`` is not in play, T8's :func:`tag_cohort` doesn't run
+    ``--cohort-jql`` is not in play, the cohort split's :func:`tag_cohort` doesn't run
     and ``row.cohort`` stays ``None``; emitting ``"cohort": null`` would
     mislead consumers into thinking the row was tagged as not-in-cohort.
     Cohort-field presence is bound to cohort-jql mode; absence is the

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/per_issue.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/per_issue.py
@@ -1,8 +1,8 @@
 """Per-issue derivation — :class:`PerIssueRow` and :func:`derive_row`.
 
-T5 substrate: walks each issue's :class:`Timeline`, applies the four
+Walks each issue's :class:`Timeline`, applies the four
 population predicates, and emits a :class:`PerIssueRow` carrying every
-field a downstream aggregator (T6) or per-issue consumer
+field a downstream aggregator or per-issue consumer
 (``ai-adoption-cohort``) needs.
 
 Field-presence rules for per-issue mode:
@@ -14,15 +14,15 @@ Field-presence rules for per-issue mode:
 - Cancelled-in-window or WIP-only rows emit ``null`` for the
   delivery-based fields and ``0`` for ``rework_count``;
   ``cycle_eligible`` is ``false``.
-- ``cohort`` is left as ``None`` here; the cohort path (T8) stamps it.
+- ``cohort`` is left as ``None`` here; the cohort split stamps it.
 - ``wip_samples`` carries one bool per inclusive calendar day in the
-  window (anchor: ``(d + 1 day) 00:00 UTC − 1µs``). T6's Flow Load
+  window (anchor: ``(d + 1 day) 00:00 UTC − 1µs``). The aggregator's Flow Load
   computation is a streaming sum across rows of these per-day samples;
   the last sample is identically ``wip_at_to``.
 
 The streaming entry point :func:`iter_per_issue_rows` calls
 :meth:`JiraClient.search` once (with ``compose_jql(..., order_by_key=
-True)``) and walks each issue via T4's
+True)``) and walks each issue via the changelog pager's
 :func:`iter_issue_changelog`. Rows are yielded lazily so peak memory is
 O(transitions per issue), per the spec's bounded-memory contract.
 
@@ -79,7 +79,7 @@ class PerIssueRow:
     wip_samples: Tuple[bool, ...] = field(default_factory=tuple)
     # Full team list for array-kind team_field semantics — ``team`` keeps
     # the first non-empty entry for backward compat with single-value
-    # consumers; ``teams`` is the complete list T9's per_team rollup
+    # consumers; ``teams`` is the complete list the per-team rollup
     # needs to count one issue in every membership bucket. For
     # ``single_value`` kind, ``teams`` is a one-element tuple
     # ``(team,)`` (or ``(NO_TEAM,)`` when the field is missing).
@@ -111,17 +111,17 @@ def _resolve_teams(issue: Mapping, state_config: StateConfig) -> Tuple[str, Tupl
     """Return ``(primary_team, full_team_list)`` for the issue's row.
 
     ``primary_team`` is the first non-empty team name (matching the
-    pre-T13 ``_resolve_team`` contract pinned by T5's per-issue tests).
-    ``full_team_list`` is the deduplicated tuple of every team name on
-    the issue — used by T9's per_team rollup under ``array`` kind to
-    bucket one issue into every team's row.
+    pre-pipeline-wiring ``_resolve_team`` contract pinned by the
+    per-issue tests). ``full_team_list`` is the deduplicated tuple of
+    every team name on the issue — used by the per-team rollup under
+    ``array`` kind to bucket one issue into every team's row.
 
     Field-level permission undercount: if ``team_field.id`` is missing
     or the issue's value is null / empty / unrecognised, returns
     ``(NO_TEAM, ())``. Downstream callers translate the empty list into
     a single ``NO_TEAM`` bucket; the empty tuple is the signal "this
-    issue carried no readable team membership" so T9's K-count for
-    array kind doesn't include it.
+    issue carried no readable team membership" so the per-team rollup's
+    K-count for array kind doesn't include it.
 
     For ``single_value`` kind, ``full_team_list`` is always a
     one-element tuple ``(primary_team,)`` so the iteration shape is
@@ -166,7 +166,7 @@ def _resolve_teams(issue: Mapping, state_config: StateConfig) -> Tuple[str, Tupl
 def _resolve_team(issue: Mapping, state_config: StateConfig) -> str:
     """Backward-compat shim — returns just the primary team.
 
-    Kept so existing T5 contract tests
+    Kept so existing per-issue contract tests
     (``test_per_issue_team_resolves_*``) that imported the original
     helper symbol keep passing.
     """
@@ -228,8 +228,8 @@ def _wip_samples(
     ``True`` per day where its canonical state at the anchor is in
     ``active_states``. Samples taken before the issue's ``created`` are
     forced to ``False`` (an issue cannot be WIP before it exists).
-    T6's :func:`aggregate.aggregate` sums these column-wise across rows
-    to derive Flow Load.
+    The aggregator's :func:`aggregate.aggregate` sums these column-wise
+    across rows to derive Flow Load.
     """
     sample_count = (window.to_date - window.from_date).days + 1
     if delivered:

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/per_team.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/per_team.py
@@ -1,7 +1,7 @@
-"""T9 per-team rollup.
+"""Per-team rollup.
 
 Buckets :class:`~flow_metrics.per_issue.PerIssueRow` instances by team
-and runs T6's :func:`~flow_metrics.aggregate.aggregate` against each
+and runs the aggregator's :func:`~flow_metrics.aggregate.aggregate` against each
 bucket. For ``team_field.kind == "single_value"`` the buckets are
 disjoint and ``sum(per_team[*].throughput) == aggregates.throughput``.
 For ``team_field.kind == "array"`` the buckets overlap (an issue with
@@ -16,22 +16,24 @@ team names (``"Zebra"``, ``"Über-team"``, ``"alpha"``); plain
 :func:`sorted` on strings is what produces the documented order.
 
 Program-scope JQL composition lives here too: given the resolved team-id
-list (from T9's :mod:`flow_metrics.align`), build the Jira-side query
-that intersects the team field against those ids. v1 assumes one Jira ↔
-one Jira Align instance pair, so the JQL deliberately has no
-``project = ...`` clause — the team field id is the sole scope selector.
+list (from the Jira Align integration, :mod:`flow_metrics.align`), build
+the Jira-side query that intersects the team field against those ids. v1
+assumes one Jira ↔ one Jira Align instance pair, so the JQL deliberately
+has no ``project = ...`` clause — the team field id is the sole scope
+selector.
 
 Field-level permission undercount: when an in-scope issue has no
 readable ``team_field`` value (Jira's field-level security strips it),
 its :class:`PerIssueRow` carries ``team == "(no team)"``. Those rows go
 into a synthetic ``"(no team)"`` bucket so global aggregates still
 reconcile with the per-team sum (for the ``single_value`` kind). The
-count is surfaced through the duck-typed ``notes`` collector so T11 can
+count is surfaced through the duck-typed ``notes`` collector so it can
 emit the spec's ``"per_team: N issues had no readable team_field
 value; bucketed as '(no team)'"`` line.
 
 ``meta.per_team_double_counted`` is computed by :func:`per_team_double_counted`
-and threaded into the output by T10. T9 sets the bool; T10 emits it.
+and threaded into the output by the renderer. The per-team rollup sets
+the bool; the renderer emits it.
 
 Stdlib only. Python >= 3.10.
 """
@@ -52,7 +54,7 @@ class PerTeamRow:
 
     Shape matches the spec's JSON example: ``{ "team": <name>,
     "aggregates": <AggregateBlock> }``. The ``aggregates`` value is the
-    full T6 :class:`AggregateBlock` for the bucket — same shape as the
+    full :class:`AggregateBlock` for the bucket — same shape as the
     top-level ``aggregates``, so downstream serializers can reuse the
     canonicalisation path on both.
     """
@@ -93,7 +95,7 @@ def bucket_by_team(
 
     Array semantics (``team_field.kind == "array"``): each row may land
     in multiple buckets. Callers supply ``teams_for_row`` to enumerate
-    the row's team list (T5's per-issue derivation collapses array
+    the row's team list (per-issue derivation collapses array
     values to the first non-empty entry, so the full list lives on the
     caller side — usually a ``key -> [teams]`` lookup built while
     walking issues). If ``teams_for_row`` returns an empty sequence the
@@ -108,16 +110,16 @@ def bucket_by_team(
     :data:`NO_TEAM` bucket is counted, and ``notes`` is asked to record
     the total via ``notes.add_field_permission_undercount(field_id, n)``
     when ``notes`` is provided and ``n > 0``. ``notes`` is duck-typed —
-    the T11 NotesCollector satisfies the interface; tests pass a
+    the NotesCollector satisfies the interface; tests pass a
     ``MagicMock``.
     """
     # Array-kind footgun: PerIssueRow.team carries only the *first* team
-    # for array-valued team fields (T5's _resolve_team collapses on the
-    # way in). Without a teams_for_row callable to enumerate the full
-    # list, bucket_by_team would silently degrade array kind to single-
-    # value semantics — wrong throughput, missing overlap, no rationale
-    # in the output. Refuse upfront so the caller is forced to thread
-    # the team list through.
+    # for array-valued team fields (per-issue derivation's _resolve_team
+    # collapses on the way in). Without a teams_for_row callable to
+    # enumerate the full list, bucket_by_team would silently degrade
+    # array kind to single-value semantics — wrong throughput, missing
+    # overlap, no rationale in the output. Refuse upfront so the caller
+    # is forced to thread the team list through.
     if (
         teams_for_row is None
         and team_field is not None
@@ -169,7 +171,7 @@ def bucket_by_team(
 
     # Surface the per_team_double_counted note on array kind. We supply
     # the K count the spec asks for ("K issues belong to multiple teams
-    # and are counted in each"); T11's NotesCollector renders the line.
+    # and are counted in each"); the NotesCollector renders the line.
     if (
         notes is not None
         and team_field is not None
@@ -205,7 +207,7 @@ def per_team_rollup(
     """
     out: List[PerTeamRow] = []
     for team_name in sorted(buckets.keys()):
-        # T6-API: aggregate(rows, window, config, *, include_subtasks=False).
+        # aggregator API: aggregate(rows, window, config, *, include_subtasks=False).
         block = aggregate(
             iter(buckets[team_name]),
             window,
@@ -220,9 +222,9 @@ def per_team_double_counted(team_field: Optional[TeamField]) -> bool:
     """Compute ``meta.per_team_double_counted`` from the team_field config.
 
     ``True`` iff ``team_field.kind == "array"`` — the only kind where
-    per_team rows overlap. T10 reads this value into the meta block; T9
-    owns the definition so the trigger condition is documented in one
-    place.
+    per_team rows overlap. The renderer reads this value into the meta
+    block; the per-team rollup owns the definition so the trigger
+    condition is documented in one place.
     """
     return team_field is not None and team_field.kind == "array"
 
@@ -269,10 +271,10 @@ def compose_program_scope_jql(
 
     The ``--jql`` user clause (if any) is merged via :func:`compose_jql`
     so the parenthesization and ``ORDER BY`` suffix follow the canonical
-    rule shared with every other JQL the skill builds. (T8 owns the
-    canonical helper; we route through it rather than reimplementing.)
+    rule shared with every other JQL the skill builds. (The cohort split
+    owns the canonical helper; we route through it rather than reimplementing.)
     """
-    # T8-API: compose_jql(scope, user, *, order_by_key=True) — canonical
+    # cohort-split API: compose_jql(scope, user, *, order_by_key=True) — canonical
     # parenthesization helper. Imported above; called below.
     if not isinstance(team_field_id, str) or not team_field_id:
         raise ValueError("team_field_id must be a non-empty string")

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/predicates.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/predicates.py
@@ -24,7 +24,7 @@ def wip_instant(window: Any) -> datetime:
     """Spec-defined WIP-instant: the last representable instant of the
     inclusive window — ``(to + 1 day) 00:00 UTC − 1 microsecond``.
 
-    Both :func:`wip_at_to` and Flow Load (T6) sample at this anchor so
+    Both :func:`wip_at_to` and Flow Load (the aggregator) sample at this anchor so
     the last Flow Load sample is identical to the WIP count.
     """
     return window.to_exclusive_utc - timedelta(microseconds=1)

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/timeline.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/timeline.py
@@ -1,9 +1,9 @@
 """Per-issue Timeline — canonical-state walk over the changelog.
 
-T5 substrate: builds an in-memory ordered view of one issue's
+Builds an in-memory ordered view of one issue's
 status and issuetype transitions, derived from its baseline
 (``issue.fields.created`` + initial ``status`` + initial ``issuetype``)
-and a stream of :class:`ChangelogEntry` records produced by T4.
+and a stream of :class:`ChangelogEntry` records produced by the changelog pager.
 
 Every raw status the walker encounters — baseline AND every
 ``from_value`` / ``to_value`` on a status transition — is mapped through

--- a/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/upstream.py
+++ b/packs/atlassian/.apm/skills/flow-metrics/scripts/flow_metrics/upstream.py
@@ -1,6 +1,6 @@
 """Upstream skill wrappers — discovery, allowlist, subprocess.
 
-T3 substrate: every downstream task reads Jira / Jira Align data through
+Every downstream stage reads Jira / Jira Align data through
 this module. The wrapper enforces the read-only allowlist — verbs and
 ``raw GET`` paths are validated against exact regex patterns before any
 subprocess is spawned.

--- a/packs/atlassian/.apm/skills/jira-align/scripts/credentials_shim.py
+++ b/packs/atlassian/.apm/skills/jira-align/scripts/credentials_shim.py
@@ -19,7 +19,7 @@ module-load time: ``_keychain_macos`` iff ``sys.platform ==
 "darwin"``, ``_credman_windows`` iff ``"win32"``, no Tier-2 backend on
 other platforms (resolver falls through directly to Tier 3).
 
-``.env`` parser (T2 surface, retained here):
+``.env`` parser (retained here):
 
 Supported:
     ``KEY=value``

--- a/packs/atlassian/.apm/skills/jira/scripts/credentials_shim.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/credentials_shim.py
@@ -19,7 +19,7 @@ module-load time: ``_keychain_macos`` iff ``sys.platform ==
 "darwin"``, ``_credman_windows`` iff ``"win32"``, no Tier-2 backend on
 other platforms (resolver falls through directly to Tier 3).
 
-``.env`` parser (T2 surface, retained here):
+``.env`` parser (retained here):
 
 Supported:
     ``KEY=value``

--- a/packs/credential-brokers/.apm/shared-libs/credentials_shim.py
+++ b/packs/credential-brokers/.apm/shared-libs/credentials_shim.py
@@ -19,7 +19,7 @@ module-load time: ``_keychain_macos`` iff ``sys.platform ==
 "darwin"``, ``_credman_windows`` iff ``"win32"``, no Tier-2 backend on
 other platforms (resolver falls through directly to Tier 3).
 
-``.env`` parser (T2 surface, retained here):
+``.env`` parser (retained here):
 
 Supported:
     ``KEY=value``

--- a/packs/credential-brokers/.apm/skills/credential-setup/scripts/credentials_shim.py
+++ b/packs/credential-brokers/.apm/skills/credential-setup/scripts/credentials_shim.py
@@ -19,7 +19,7 @@ module-load time: ``_keychain_macos`` iff ``sys.platform ==
 "darwin"``, ``_credman_windows`` iff ``"win32"``, no Tier-2 backend on
 other platforms (resolver falls through directly to Tier 3).
 
-``.env`` parser (T2 surface, retained here):
+``.env`` parser (retained here):
 
 Supported:
     ``KEY=value``

--- a/packs/figma/.apm/skills/figma/scripts/credentials_shim.py
+++ b/packs/figma/.apm/skills/figma/scripts/credentials_shim.py
@@ -19,7 +19,7 @@ module-load time: ``_keychain_macos`` iff ``sys.platform ==
 "darwin"``, ``_credman_windows`` iff ``"win32"``, no Tier-2 backend on
 other platforms (resolver falls through directly to Tier 3).
 
-``.env`` parser (T2 surface, retained here):
+``.env`` parser (retained here):
 
 Supported:
     ``KEY=value``


### PR DESCRIPTION
## What

Replaces bare internal build-task labels (`T1`–`T13`) in adopter-facing
pack content with descriptive module/role names. Pack content under
`packs/*/.apm/` ships to adopters, but these skills' docstrings/comments
referred to modules by their implementation-plan task numbers ("T7
renders the Markdown", "T6 owns the counters", "T3 substrate", "T10's
renderer"). Adopters never receive the catalogue's plans, so the numbers
are opaque jargon on arrival. Completes the adopter-readiness line of
#204 and #206 (the `plan §T5 …` *citations* were removed in #206; this
catches the bare labels left behind as architectural shorthand).

Two commits, one skill each, for reviewability:

1. **ai-adoption-report** — 9 `.py` modules + `manifest.json` env-var description.
2. **flow-metrics** — 17 `.py` modules + `SKILL.md`; plus the shared
   `credentials_shim.py` ("T2 surface" → "(retained here)"), whose 7
   byte-identical projected copies (confluence-crawler/-publisher, jira,
   jira-align, figma, credential-setup, `.agentbundle/bin`) were
   regenerated by `make build-self`.

## Mapping

Every `T<n>` was rewritten to name the responsible module/role, verified
against each module's opening docstring. Behavioral statements are
preserved verbatim — only the label changed.

| | ai-adoption-report | flow-metrics |
| --- | --- | --- |
| T1 | CLI scaffold (`__init__.py`) | CLI scaffold (`__init__.py`) |
| T2 | input loader / notes (`inputs.py`,`notes.py`) | config loading (`config.py`) |
| T3 | modes (`modes.py`) | upstream wrapper (`upstream.py`) |
| T4 | program discovery (`program_discovery.py`) | changelog pager (`changelog.py`) |
| T5 | delta engine (`delta.py`) | per-issue derivation (`per_issue.py`,`timeline.py`) |
| T6 | aggregation (`aggregation.py`) | aggregator (`aggregate.py`) |
| T7 | renderer (`render.py`) | cache (`cache.py`) |
| T8 | write path (`write.py`) | cohort split (`cohort.py`) |
| T9 | golden tests / docs | per-team rollup (`per_team.py`) / Jira Align (`align.py`) |
| T10 | — | renderer (`output.py`) |
| T11 | — | notes collector (`notes.py`) / meta builder (`meta.py`) |
| T13 | — | pipeline wiring (`__init__.py`) |

## Scope

- **In:** docstrings + comments only, plus the one prose-only env-var
  description in `ai-adoption-report/manifest.json`.
- **Out:** no logic, no code identifiers, no returned/compared/emitted
  string literals. Verified by an AST-skeleton diff (code + every
  non-docstring string constant byte-identical to `main`) across all 24
  edited modules, plus a clean `grep -rnE '\bT[0-9]+\b'` over both skills.

## Verification

- `make build-check` — exit 0.
- `make build-self FORCE=1` — exit 0, reprojected the 8 shim copies, no other drift.
- adversarial-reviewer — Clean across both commits.

## Deferred (follow-ups)

- **`per_team.py` `ValueError` message contains `(per T5)`** — left
  intact deliberately: it's an *emitted string literal*, not a
  comment/docstring, so changing it is a behavior change outside this
  chore's scope (and would break the byte-identical AST proof). It is
  also the most adopter-facing surface of the lot (printed to the
  terminal on an array-kind `team_field` misconfig), so a follow-up
  should reword it to e.g. "(only the first team is retained at
  per-issue derivation)".
- **Two faithful renames surface pre-existing inaccuracies** (no drift
  introduced here): `align.py` "the renderer wires this module into the
  main run" (the wiring is really the pipeline stage), and `per_team.py`
  "the cohort split owns the canonical helper" (`compose_jql` lives in
  `jql.py`). Both are faithful `T10`/`T8` → role expansions of the
  original text; correcting the attribution is a separate, intent-level
  follow-up.

## Bundled fixes

- Reflowed a handful of comment/docstring lines widened by the longer
  role names (same blocks as the label edits).
