### PR TITLE
docs(rfc): RFC-0019/0020/0021 — product-brief intake, reference-architecture foundation, greenfield init-project

### DIFF
--- a/docs/rfc/0019-product-brief-intake.md
+++ b/docs/rfc/0019-product-brief-intake.md
@@ -1,0 +1,252 @@
+# RFC-0019: Product-brief intake + LLD-aware spec/plan — receiving a multi-spec brief into a design-bearing spec-driven loop
+
+- **Status:** Accepted <!-- Draft | Open | Final Comment Period | Accepted | Rejected | Withdrawn | Experimental -->
+- **Author:** eugenelim
+- **Approver:** eugenelim
+- **Date opened:** 2026-06-01
+- **Date closed:** 2026-06-01
+- **Related:** RFC-0017 (pluggable API contract standards — many specs reference one contract by reference; the linkage precedent); RFC-0020 (reference-architecture foundation — the LLD reads `reference.md` when present, Decision 9); RFC-0021 (greenfield inception — produces the first brief and feeds this loop); `docs/CONVENTIONS.md` §"document hierarchy" (the doc-altitude diagram this RFC amends) and §4 (Specs and Plans); `docs/CHARTER.md` §Principles (the four bars a core addition must clear); the `new-spec` and `work-loop` skills (core pack).
+
+## The ask
+
+- **Recommendation (BLUF):** Add a product **brief** artifact to the core pack at `docs/product/briefs/<slug>.md`, plus a `receive-brief` skill that ingests a product brief (PRD-style) — **eliciting missing inputs rather than mandating a schema** — decomposes it into engineering specs, and **executes each slice through the existing `new-spec` → `work-loop` pipeline**. The brief carries the *what/why* and a coverage map whose status is **auto-derived from its child specs**. In the same change, enrich the **spec/plan templates** to carry a **low-level design (LLD)** — a `## Design (LLD)` section in `plan.md` built from **stack-neutral** categories, **shape-selected** per spec, and filled with stack-specific content the agent **derives** from the brief-intake or the established repo (never baked into the template). The spec stays the contract; the design lives in the plan.
+
+- **Why now (SCQA):**
+  - *Situation.* Core gives adopters spec-driven delivery: `new-spec` writes one feature contract, `work-loop` builds it. One spec = one feature, "sized to be built in days or weeks" (`CONVENTIONS.md:215`).
+  - *Complication.* Enterprise adopters don't author all their own work — they **receive** an externally-authored product brief (a PRD, a solution handoff) that spans several features. Core's only work-intake is single-feature `new-spec`, and it lacks the RFC skill (which lives in governance-extras) — so the product→engineering handoff has no home. The adopter either crams a multi-feature brief into one oversized spec (breaking the sizing rule and the per-spec `work-loop`) or fires `new-spec` N times by hand with nothing recording the why, the decomposition, or coverage.
+  - *Question.* How does a single-repo, spec-driven toolchain **receive** a multi-feature brief and route it into delivery without losing the why, the decomposition, or the coverage the handoff demands — and carry the **low-level design** an enterprise build needs, without baking any one tech stack into a universal template?
+
+- **Decisions requested:**
+  1. **Scope** — own-the-repo-slice only (no cross-repo coordination hub); the brief may carry an optional `Epic:` pointer to an external coordinator. *Recommended; default if no objection.* Decide-by 2026-06-11.
+  2. **Carrier** — a new `brief` artifact (not an extension of roadmap/backlog or the spec). *Recommended.* Decide-by 2026-06-11.
+  3. **Pack** — ship in **core** (not governance-extras, not a new product pack). *Recommended; most contested — see Options.* Decide-by 2026-06-11.
+  4. **Input posture** — elicit missing inputs against a recommended shape + ship an example references file; do not mandate a schema. *Recommended.* Decide-by 2026-06-11.
+  5. **User stories** — optional; when present, traced to acceptance criteria via a `Satisfies: US-n` marker. *Recommended.* Decide-by 2026-06-11.
+  6. **Linkage** — specs reference their brief via a new `Brief:` field (no nesting); this decision covers the `Brief:` / `Satisfies:` / `Epic:` field set. *Recommended.* Decide-by 2026-06-11.
+  7. **Coverage tracking** — the brief's status is **auto-rolled-up** from child specs by a lint, not hand-maintained. *Recommended.* Decide-by 2026-06-11.
+  8. **LLD locus** — enrich `plan.md` with a stack-neutral `## Design (LLD)` section (and light `spec.md` touches: a `Shape:` field + AC phrasing for states/NFRs); reuse the existing `Rollout`/`Risks`/`Depends on:` rather than adding tiers. *Recommended.* Decide-by 2026-06-11.
+  9. **Stack source** — the LLD's stack-specific content is **derived**: read `docs/architecture/reference.md` (RFC-0020) and conform to it **when present**; otherwise derive from brief-intake context and/or established-repo detection, eliciting gaps. The template ships only universal categories. *Recommended.* Decide-by 2026-06-11.
+
+## Problem & goals
+
+A product brief and an engineering spec are different artifacts owned by different roles. The prior art is explicit: *"the product manager owns the PRD,"* which covers *"what to build"* and *"user experience"*, while *"the engineering lead or tech lead"* writes the spec, which covers *"how the team will implement the requirements"* — architecture, data models, API contracts ([PRD vs Product Brief vs Spec](https://www.ideaplan.io/compare/prd-vs-product-brief-vs-product-spec)). **Core jumps straight to the engineering spec.** There is no inbox for the thing product hands engineering.
+
+This is not cosmetic. `CONVENTIONS.md:215` sizes a spec at *one feature, days-to-weeks*, and `work-loop` runs *per spec*. A multi-feature brief is months of work across features — it provably **cannot** be one spec without breaking both. So any multi-feature input structurally forces a layer *above* the spec, and core ships none. The gap shows up precisely where an organization separates the product and engineering functions — i.e. in the enterprise.
+
+### Goals
+
+- Receive a product brief that spans multiple specs, and record its *what/why* (problem, outcome, success metrics, scope) as a durable handoff artifact.
+- **Elicit** the brief's missing inputs conversationally rather than rejecting input that doesn't match a fixed schema.
+- **Decompose** the brief into independently-shippable, feature-sized specs and **execute** each through the existing `new-spec` → `work-loop` pipeline.
+- Maintain a **coverage map** (brief → spec → status) so "is this brief delivered?" is answerable — and keep it current **automatically**, derived from child-spec status.
+- Support **optional** user-story traceability (brief story → spec acceptance criteria) without forcing it.
+- Own only **this repo's slice**; point upward to an external coordinator when the brief is part of a cross-repo epic.
+- Give the engineering build a **low-level design** home in the plan, built from stack-neutral categories and filled with stack-specific content the agent **derives** — so an enterprise LLD fits without baking a stack into a universal template.
+
+### Non-goals
+
+- **A cross-repo coordination hub.** Coordinating an epic across repos is a tracker's job (Jira, GitHub Projects, an integration repo). We integrate with it via an optional pointer; we do not become it.
+- **A new "user story" artifact tier.** Acceptance criteria already are the testable user-story unit; we add a trace marker, not a directory or object.
+- **A portfolio/initiative layer above the brief.** One received brief is the ceiling of this RFC; multi-brief portfolio rollup is out of scope.
+- **Mandating a brief schema.** The shape is a guide, not a gate (see Decision 4).
+- **Replacing roadmap or backlog.** The brief slots between them; both keep their jobs.
+- **Baking any tech stack into the templates.** The `## Design (LLD)` categories are stack-neutral; React/TanStack/Kafka/Spring etc. appear only in the *derived, filled instance*, never in the shipped template (Principle 1).
+- **Moving design above the spec.** The brief carries *what/why*; the per-spec LLD stays in `plan.md`. The spec gains only a light shape-selector and AC guidance — **no LLD body** migrates into it; it remains the contract.
+- **A separate `design.md` tier.** The plan is the design home; we add a section, not an artifact.
+- **Reshaping the spec lifecycle into delta-expressed / always-living specs.** OpenSpec's delta specs (ADDED/MODIFIED/REMOVED merged into a source-of-truth) and Intent's living-specs were considered and **deferred**: they would change `spec.md`'s shape for every adopter, partly duplicate the existing "living-during-build / drift-is-a-bug" model, and "always living" conflicts with the deliberate "frozen after ship" stance. Delta-expression, if pursued, is its own future RFC — not a rider here.
+
+## Proposal
+
+### The brief artifact (Decisions 2, 3)
+
+A brief lives at `docs/product/briefs/<slug>.md` — inside core's existing product surface (`packs/core/seeds/docs/product/` already ships `roadmap.md` and `changelog.md`). It carries:
+
+- **Outcome** — the problem and the user-facing outcome (the load-bearing field).
+- **Success metrics**, **scope / non-goals**, **appetite** (a constraint, not an estimate — *"we want to … do it in six weeks, not three months"* ([Shape Up](https://basecamp.com/shapeup/1.5-chapter-06))).
+- **User stories** — *optional* (Decision 5).
+- **`Epic:`** — *optional* pointer to an external coordinator's id, carried in from the brief when this repo's work is one slice of a cross-repo epic (Decision 1).
+- **Spec map** — the coverage table (`spec → status`, plus a `story` column in the story-list shape), **auto-derived** (Decision 7).
+
+The brief sits between two artifacts core already has. The repo's canonical document hierarchy (`CONVENTIONS.md:~24–65`) already places `product/` (roadmap + changelog) as the "external current state" bucket; this RFC adds `briefs/` under that bucket and amends the diagram accordingly. The altitude mirrors the product hierarchy where an *Initiative* is a *"measurable outcome … [that] appears on roadmap"* and the bodies of work that serve it *"appear in backlog"* ([Initiative vs Epic vs Story](https://roadmap.one/blog/posts/blog26-initiative-epic-story/)):
+
+```
+roadmap          forward-looking themes        ──references──►  briefs
+  └─ BRIEF        received outcome + spec map   ◄── NEW; backlog rolls up to it
+       └─ spec    engineering contract (how)    (role unchanged; +Shape: field, see LLD)
+            └─ AC  the testable user-story unit
+```
+
+### Two shapes, one toggle (Decision 5)
+
+The user-story section is the only toggle; it changes traceability granularity, not the pipeline.
+
+- **Shape A — no stories.** The agent derives spec boundaries from outcome + scope and surfaces the cut for confirmation. Coverage is **spec-granular**. Stories still exist — they're written as the spec's ACs at authoring time.
+- **Shape B — story list.** Stories carry ids (`US-n`); decomposition is *grouping stories into specs*; each satisfying AC carries `Satisfies: US-n`. Coverage is **story-granular**: "US-2 → `password-reset` AC3 → shipped." A story too big to fit one spec is an epic — split it.
+
+### Linkage (Decision 6)
+
+A derived spec references its brief through a new `Brief:` field in the spec front-matter (sibling to the existing `Constrained by:` and `Contract:` fields in `new-spec`'s `spec.md`). Reference, not nesting: specs stay flat under `docs/specs/<feature>/`, a spec can predate its brief, and this mirrors how RFC-0017 already lets many specs reference one contract over time. `Constrained by:` is reserved for governance constraints (ADR/RFC); `Brief:` records product provenance — distinct semantics, distinct field. The same decision settles the two companion markers: `Satisfies: US-n` on ACs (Decision 5) and the optional `Epic:` field on the brief (Decision 1).
+
+### The skill and the execution spine
+
+`receive-brief` (core skill):
+
+1. **Elicit.** Ingest whatever the adopter has (a pasted PRD, a doc, a link, or nothing). Elicit the load-bearing fields (outcome, scope) conversationally; offer the rest. Never reject for non-conformance (Decision 4).
+2. **Decompose.** Cut the brief into independently-shippable, independently-testable feature slices (the shippability test, not a component/layer split). In Shape B, this is grouping stories; flag any uncovered outcome as a gap and any epic-sized story for splitting.
+3. **Execute.** For each slice, chain `new-spec` to scaffold `spec.md` + `plan.md`, stamp the `Brief:` back-link (and `Satisfies:` on ACs in Shape B), then hand off to `work-loop`. The brief is thus **executable**: `brief → (spec, plan) × N → work-loop`.
+
+### Auto-rolled-up coverage (Decision 7)
+
+A lint reads every `docs/specs/*/spec.md` `Status:` field, follows the `Brief:` back-links, and rolls each brief's spec-map status up from its children — so the brief stays a live tracker with no hand-maintenance, and a brief whose every spec is Shipped reports *delivered* on its own. This is the "operating document tied to execution" that modern PRDs aim for, made mechanical. Placement of the lint (build-check vs CI-only/advisory) is Open question 1.
+
+### Example references file (Decision 4)
+
+The skill ships `examples/` with a worked brief in **both** shapes (a no-stories outcome brief and a story-list brief), showing the expected fields and a populated spec map. It is a guide that demonstrates the shape — never a schema the skill enforces.
+
+### LLD enrichment of spec/plan (Decisions 8, 9)
+
+An enterprise build needs a low-level design — for UI: screen states, component decomposition, state management, navigation, accessibility; for backend: data model, sequence, resilience, security, deployment sequencing. These abstract to **ten stack-neutral categories**: design decisions; data & schema; interfaces & contracts; component/module decomposition; state & control flow; behavior & rules; failure, edge cases & resilience; quality attributes (NFRs); dependencies & integration; rollout & deployment. The category *names* are universal; *which* are heavy and *how* they are filled is stack-specific.
+
+The enrichment keeps the spec as the contract and puts the design in the plan:
+
+- **`spec.md` (light).** Add a stack-neutral **`Shape:`** field (`ui | service | data | integration | mixed`) that selects which plan sub-sections scaffold; extend AC guidance so a UI **state/trigger/outcome** lands as an acceptance criterion and an NFR with a pass/fail bar (e.g. WCAG-AA, p99) is an AC; minor `Contract:` / `Testing Strategy` wording so events/BFF and integration/E2E are first-class. The spec grows no LLD body.
+- **`plan.md` (the LLD home).** Add a **`## Design (LLD)`** section before `## Tasks`, built from the ten categories as **optional, shape-selected** sub-headings, each tracing to the AC(s) it satisfies and the `contracts/` it implements. **Expand the existing `## Rollout`** to cover infra, external-system integration, and deployment sequencing (the one dimension with no home today). Dependencies reuse `Depends on:` / `Touches:`; testing reuses `Construction tests` + the spec's `Testing Strategy`. Net new surface: one section added, one expanded.
+
+**Stack derivation.** `new-spec` (and `receive-brief` when it scaffolds specs) derives the **shape** (from the brief or by asking) and the **stack**. For the stack it **first reads `docs/architecture/reference.md` (RFC-0020) when present** and conforms the LLD to that foundation (referencing its components/stereotypes/standards by name); when absent it **degrades** — detecting the established repo's lockfiles/build files/imports and/or the brief-intake context, eliciting gaps (a one-line nudge may suggest establishing a foundation). The check is the seam that lets RFC-0019 and RFC-0020 land in either order: 0019 ships standalone via the degrade path, and the day a `reference.md` exists the LLD conforms to it automatically. The template ships only the categories; the stack lives in the filled instance.
+
+**Minimal by default.** The Design section is optional and shape-pruned; a one-file change keeps a thin plan. The enrichment is **additive** — no existing spec/plan section is removed or renamed — so specs and plans authored before this change stay valid.
+
+## Options considered
+
+Each requested decision's option space is modelled below, MECE along a stated axis. A do-nothing-equivalent row appears where the axis admits it (Decisions 1, 4, 7, 8); the global do-nothing is at the end of this section (Decisions 2, 3, 6, 9 presuppose the brief/LLD exists, so their axes don't carry a separate do-nothing).
+
+### Decision 1 — Scope — *axis: how much cross-repo coordination the toolchain owns*
+
+| Option | What | Trade-off |
+| --- | --- | --- |
+| **Own-the-repo-slice** ★ | Ingest this repo's portion; point upward via optional `Epic:` | Honest about the single-repo install boundary; relies on an external hub the adopter already has |
+| Build-a-hub | Ship cross-repo coordination ourselves | Duplicates Jira / GitHub Projects; breaks the single-repo model; near-certain charter violation |
+| Do-nothing | Adopter coordinates by hand | Zero build cost; the gap persists |
+
+Every cross-repo system places the coordinator *above* the repos and threads a shared id into per-repo work — Gerrit *topics* ([Gerrit](https://gerrit-review.googlesource.com/Documentation/cross-repository-changes.html)) and GitHub change-set ids ([GitHub polyrepo](https://wellarchitected.github.com/library/architecture/recommendations/implementing-polyrepo-engineering/)). Own-the-slice is that pattern's repo end.
+
+### Decision 2 — Carrier — *axis: which artifact holds the received brief*
+
+| Option | Trade-off |
+| --- | --- |
+| **New `brief` artifact** ★ | One small artifact; holds PRD prose + coverage map + delivered lifecycle that nothing else can |
+| Extend `roadmap.md` / `backlog.md` | Reuses a file, but roadmap is a flat forward list ("Not commitments") and backlog is open-items-only by spec — neither holds the why or a closed→delivered map |
+| Absorb into the spec | No new artifact, but a spec is single-feature (`CONVENTIONS.md:215`) — it cannot carry a multi-feature brief |
+
+### Decision 3 — Pack — *axis: which pack ships it* (most contested)
+
+| Option | Trade-off |
+| --- | --- |
+| **core** ★ | The handoff is stack-agnostic (Principle 1); reuses core's existing product surface; cost = core grows past "just specs" |
+| governance-extras | Natural neighbour to RFC/ADR — **but adopters install core *without* it, which recreates the exact gap this RFC closes**; and a brief is *work-intake* (like `new-spec`), not rule-change governance |
+| new `product` pack | Clean separation — but a whole pack for one artifact + one skill is heavier than core-growth, and it fragments the product surface core already ships |
+
+The `jira-defect-flow` intake precedent lives in the *non-core* `atlassian` pack, which might look like an argument against core. It isn't: that skill is Jira-specific and so fails Principle 1 (Universal) for core. Brief-intake is stack-agnostic, so the constraint that pushed `jira-defect-flow` out of core does not apply here.
+
+### Decision 4 — Input posture — *axis: input rigidity*
+
+| Option | Trade-off |
+| --- | --- |
+| Mandate a fixed schema | Consistent input, but rejects real-world briefs that arrive half-formed; contradicts the "elicit" intent |
+| **Elicit + example refs** ★ | Meets adopters where they are; the example shows the shape. Shape Up warns against over-specifying ([Shape Up](https://basecamp.com/shapeup/1.5-chapter-06)); PRD practice treats templates as guides |
+| Freeform, no shape | Lowest friction, but no shared shape for the agent to decompose against |
+
+### Decision 5 — User stories — *axis: story requirement*
+
+| Option | Trade-off |
+| --- | --- |
+| Require stories | Forces a `## User stories` section; contradicts Shape Up's caution against over-specifying |
+| **Optional + `Satisfies:` trace** ★ | Both shapes work from one toggle; story-granular coverage when product provides stories, spec-granular when it doesn't |
+| Ban stories | Loses the finest-grain traceability the enterprise handoff asks for |
+
+### Decision 6 — Linkage — *axis: coupling between brief and spec*
+
+| Option | Trade-off |
+| --- | --- |
+| **Reference via `Brief:` field** ★ | Specs stay flat; a spec can predate its brief; mirrors RFC-0017's many-specs-one-contract reference |
+| Nest specs under the brief dir | Changes `new-spec`'s flat `docs/specs/<feature>/` path; couples a spec to exactly one brief |
+
+### Decision 7 — Coverage tracking — *axis: how brief status is kept current*
+
+| Option | Trade-off |
+| --- | --- |
+| Hand-maintained spec map | No new tooling, but drifts the moment a spec ships and nobody edits the brief |
+| **Auto-rollup lint** ★ | Live tracker, zero hand-maintenance, reads only existing `Status:` fields; cost = one new lint to maintain |
+| No tracking | Cheapest, but "is this brief delivered?" becomes unanswerable — defeats the handoff |
+
+### Decision 8 — LLD locus — *axis: where the design lives*
+
+| Option | Trade-off |
+| --- | --- |
+| **Enrich `plan.md` (+ light spec)** ★ | Plan is already the design step (Kiro's "Design", spec-kit's "Plan"); additive section, no new tier; reuses Rollout/Depends-on |
+| Separate `design.md` in the spec dir | Cleaner for heavyweight, separately-reviewed LLD — but a new per-spec artifact and review gate for every adopter |
+| Put LLD in the spec | Single doc, but conflates contract with design and bloats the spec a single-feature contract is meant to stay |
+| Do-nothing (no LLD) | Plan stays thin — but the enterprise design has nowhere to live; deployment sequencing remains homeless |
+
+### Decision 9 — Stack source — *axis: how stack-specific content enters the LLD*
+
+| Option | Trade-off |
+| --- | --- |
+| **Derive (brief-intake + repo detection), elicit as fallback** ★ | Template stays universal (Principle 1); content matches the real codebase; degrades to a question when detection is ambiguous |
+| Adopter hard-codes a stack template | Precise for one org, but every adopter must author a template, and core can't ship a universal default |
+| Bake a stack into the shipped template | Zero setup for that stack — but violates universality and rots for everyone else |
+
+**Do-nothing** (across all axes) keeps core lean but leaves the structural gap: the most common enterprise scenario — "an architect handed us a design, now build it" — has no supported path, and the build that follows has no place to record its design.
+
+## Risks & what would make this wrong
+
+- **Pre-mortem.**
+  - *The brief becomes ceremony adopters skip.* Mitigation: the skill earns its place by *executing* (brief → specs → work-loop) and *auto-tracking* coverage — value beyond the document.
+  - *Elicit-not-mandate yields briefs too thin to decompose.* Mitigation: the skill insists only on the load-bearing fields (outcome, scope) and surfaces gaps; everything else is offered, not required.
+  - *The auto-rollup lint is noisy or brittle.* Mitigation: it reads only existing `Status:` fields via `Brief:` back-links — no new state; if a back-link is missing the brief simply shows that spec as untracked.
+  - *The layer duplicates roadmap.* Mitigation: roadmap *references* briefs and backlog *rolls up to* them; the brief is the only artifact holding the why + coverage.
+  - *The `## Design (LLD)` section bloats every plan, including trivial ones.* Mitigation: the section is optional and shape-pruned; the small-change path keeps a thin plan, per the existing right-size-to-stakes ethos.
+  - *Stack derivation guesses wrong (ambiguous or greenfield repo).* Mitigation: detection degrades to elicitation — the agent asks rather than inventing a stack; the brief-intake context is a second signal.
+  - *Touching `spec.md`/`plan.md` breaks existing specs/plans.* Mitigation: every change is **additive** — a new optional field/section, nothing removed or renamed — so prior specs/plans stay valid and the self-host projection re-renders cleanly.
+
+- **Two claims that must stay separate.** The de-risk spike establishes only that *a layer above the spec is structurally forced **if** a multi-feature brief arrives* (a multi-feature brief cannot be one spec). It does **not** establish that such briefs arrive **often enough** to earn a core primitive. The first is settled; the second is the open product call below. Conflating them would let the "structurally forced" framing smuggle in a frequency claim it cannot support.
+
+- **Decision 3 against the four charter principles (`CHARTER.md:58`), by name.**
+  1. *Universal across tech stacks* — **clears.** The product→engineering handoff is stack-agnostic.
+  2. *Substantive, not duplicative* — **clears.** No existing artifact carries a received brief + coverage map; `new-spec` is single-feature by contract.
+  3. *A habit, not a tool* — **mostly clears.** The receive → decompose → execute workflow is a way of working; the auto-rollup lint is the one component that leans "tool," justified only as mechanical support for the habit (and demotable to advisory — Open question 1).
+  4. *Used often enough to stick* — **the open one.** This is Assumption 1 below; the principle it must clear is frequency, not structure.
+
+- **Key assumptions (falsifiable).**
+  1. **Enough adopters receive externally-authored, multi-feature briefs to earn a *core* primitive (Principle 4).** If most adopters author their own single features, `new-spec` alone suffices and this is over-build. *Cannot be settled by a spike.* What would move the Approver: anecdotal frequency evidence — how many times has this repo (or a known adopter) actually received such a brief? If the honest answer is "rarely," ship it in a non-core pack or defer.
+  2. Decomposing a brief into shippable specs is judgment the agent can do well enough to be useful, not just mechanically.
+  3. Auto-rolling status up from child-spec `Status:` fields is reliable enough to trust as a coverage answer.
+  4. The ten LLD categories are genuinely stack-neutral — they hold a UI feature, a backend service, a data pipeline, and an integration without privileging any stack. If a real LLD has a dimension none of the ten captures, the abstraction is wrong.
+  5. The agent can derive shape and stack reliably enough that the filled LLD is useful more often than it misleads.
+- **Drawbacks.** One more artifact and one more skill to maintain; a new lint in the gate set; core grows past "just specs." **Changing `spec.md`/`plan.md` is the widest blast radius here** — those templates are the contract for *every* adopter and the self-host projection, so even an additive change touches everyone; the mitigation (additive-only) bounds but does not erase that. The bet is that the handoff and the LLD are common enough that the cost is repaid.
+
+## Evidence & prior art
+
+- **Spike / de-risk result (brief layer).** *Riskiest assumption:* that the brief layer is needed at all and isn't just a spec with more ACs. *Check (against the convention):* `CONVENTIONS.md:215` sizes a spec at days-to-weeks/one feature and `work-loop` runs per spec; a multi-feature brief is months across features, so it cannot be one spec without breaking both — **the layer is structurally forced (conditional on such a brief arriving), independent of frequency.** Holds, with the frequency caveat kept separate (Risks).
+- **Spike / de-risk result (LLD categories — Assumption 4).** *Check:* the ten stack-neutral categories were validated against two real enterprise LLDs supplied during drafting — a UI per-screen LLD (design decisions, screen states, component hierarchy, server/local/form state, client validation, BFF contract, routing, accessibility, responsive, error/edge, observability, testing, MFE deps, deployment impact) and a backend LLD (component stereotype, business workflow + rules, internal framework, data model, API contracts, Kafka events, sequence, resilience, security, observability, testing, external deps, infra + deployment sequencing). **Every item mapped to one of the ten categories; the only dimension with no prior home was deployment sequencing, now covered by the expanded `## Rollout`.** Holds. The remaining risk is derivation reliability (Assumption 5), accepted on judgment.
+- **Repo precedent.** `CONVENTIONS.md:215` (spec = single feature); the document-hierarchy diagram at `CONVENTIONS.md:~24–65` (assigns every doc to one bucket and already shows `product/` holding roadmap + changelog — the bucket `briefs/` joins, and the diagram this RFC amends); `new-spec`'s `spec.md` (`Constrained by:` / `Contract:` fields — the back-link pattern `Brief:` extends); `packs/core/seeds/docs/product/roadmap.md` (items "link to a spec"; substantive additions go through RFC); `docs/backlog.md` ("open items by spec"); RFC-0017 (many specs reference one contract by reference — the linkage precedent the brief lifts into an adopter-facing artifact); `packs/atlassian/.apm/skills/jira-defect-flow` ("Stage 1 — Intake" precedent, in a non-core pack — see Decision 3). No existing brief/intake/PRD skill in any pack.
+- **External prior art.** Product/engineering ownership split — [PRD vs Product Brief vs Spec](https://www.ideaplan.io/compare/prd-vs-product-brief-vs-product-spec); appetite-as-constraint and don't-over-specify — [Shape Up ch.6](https://basecamp.com/shapeup/1.5-chapter-06); the outcome-that-appears-on-roadmap / body-of-work-in-backlog hierarchy — [Initiative vs Epic vs Story](https://roadmap.one/blog/posts/blog26-initiative-epic-story/); cross-repo coordination via a hub-above-repos + shared id — [Gerrit topics](https://gerrit-review.googlesource.com/Documentation/cross-repository-changes.html), [GitHub polyrepo](https://wellarchitected.github.com/library/architecture/recommendations/implementing-polyrepo-engineering/). Spec-driven corroboration of the brief/spec/coverage shape — [OpenSpec](https://github.com/Fission-AI/OpenSpec) (proposal-first + *delta specs* marking ADDED/MODIFIED/REMOVED, confirmed against its concepts doc) and Intent (Augment Code) *living specs* (the spec reflects what was actually built — the auto-rollup posture of Decision 7).
+
+## Open questions
+
+1. **Auto-rollup lint placement** — in `make build-check` (fails fast, local) vs CI-only/advisory (lighter local gate). *Recommended default:* CI-only/advisory, not in the local gate, to keep `build-check` fast; promote to build-check only if coverage drift proves common. (No backlog-style precedent is claimed — the repo has no purpose-built coverage lint today.) Owner: eugenelim · decide-by 2026-06-18.
+2. **Skill name** — `receive-brief` vs `new-brief`. *Recommended default:* `receive-brief` (the verb is *receive/decompose*, distinct from `new-spec`'s *author*). Owner: eugenelim · decide-by 2026-06-18.
+3. **Whether `examples/` ships one shape or both** — *Recommended default:* both (a no-stories brief and a story-list brief), since the two-shape behavior is the load-bearing nuance. Owner: eugenelim · decide-by 2026-06-18.
+
+## Follow-on artifacts
+
+Filled in on acceptance:
+
+- ADR-NNNN: record the brief-layer decision (new artifact altitude between roadmap and spec; own-the-slice boundary) and the LLD-locus decision (design lives in the plan; stack is derived, not baked).
+- Spec: `docs/specs/product-brief-intake/` — the `brief` template, the `receive-brief` skill, the `Brief:` / `Satisfies:` / `Epic:` fields, the example references file, and the auto-rollup lint.
+- Spec: `docs/specs/lld-aware-spec-plan/` — the `spec.md` `Shape:` field + AC guidance, the `plan.md` `## Design (LLD)` section + expanded `## Rollout`, and the shape/stack-derivation step in `new-spec` and `receive-brief`. (Touches the core templates — additive only.)
+- Convention change: `docs/CONVENTIONS.md` — amend the document-hierarchy diagram to add `briefs/` under `product/`; document the `roadmap → brief → spec → AC` altitude and the `Brief:` field on specs; document the spec/plan LLD enrichment (the `Shape:` field, the `## Design (LLD)` categories, stack-derivation) in §4 (Specs and Plans).
+- **User guides (in *this* catalogue repo, `docs/guides/`, authored via `new-guide`)** — the implementing spec/plan plans and writes them as part of "done", so the new capabilities ship documented for adopters:
+  - *How-to* — "Receive a product brief and decompose it into specs" (the `receive-brief` flow, end to end).
+  - *Reference* — the `brief` artifact fields (incl. `Epic:`, the spec map) and the spec/plan additions (`Brief:`, `Shape:`, the `## Design (LLD)` categories).
+  - *Explanation* — "Why a brief layer": the `roadmap → brief → spec → AC` altitude and the product→engineering handoff this closes.

--- a/docs/rfc/0020-reference-architecture-foundation.md
+++ b/docs/rfc/0020-reference-architecture-foundation.md
@@ -1,0 +1,169 @@
+# RFC-0020: Reference-architecture foundation — the repo's golden-path anchor that LLDs conform to
+
+- **Status:** Accepted <!-- Draft | Open | Final Comment Period | Accepted | Rejected | Withdrawn | Experimental -->
+- **Author:** eugenelim
+- **Approver:** eugenelim
+- **Date opened:** 2026-06-01
+- **Date closed:** 2026-06-01
+- **Related:** RFC-0019 (the LLD reads `reference.md` when present — Decision 9, the consumer); RFC-0021 (greenfield inception — its foundation step authors `reference.md`); RFCs 0001–0003 (the pack-catalogue model that opt-in stack packs extend); `docs/CONVENTIONS.md` §"document hierarchy"; the `adapt-to-project` skill (Class-3 discovery, extended here for harvest); `docs/CHARTER.md` §Principles.
+
+## The ask
+
+- **Recommendation (BLUF):** Add a **normative** reference-architecture document — named **`reference.md`** — at `docs/architecture/reference.md`: the repo's *golden path* (stack, internal frameworks, component catalogue, stereotypes, cross-cutting standards) that the agent treats as **steering** — persistent, always-applied context every design conforms to, the architecture-altitude companion to `AGENTS.md`'s conventions-steering — kept distinct from the **descriptive** `overview.md` (the code map). **Instantiate it on demand from a template** (the `new-spec`→`spec.md`/`plan.md` pattern — a template in a skill asset), **not** as a pre-placed core seed, so there's no shipped file for an add-on pack to collide with. Populate it by **repo context** — greenfield authoring (RFC-0021), brownfield **harvest** (extend `adapt-to-project` Class-3, fed by repo detection), or an opt-in **stack pack** (pre-bake). Use arc42 vocabulary for its sections.
+
+- **Why now (SCQA):**
+  - *Situation.* RFC-0019 gives every feature a low-level design that should conform to a *shared* architecture; its Decision 9 has the LLD read `reference.md` when present.
+  - *Complication.* We ship a **descriptive** code map (`overview.md`, in the spirit of matklad's `ARCHITECTURE.md`) but **no normative foundation** for the LLD to read — so the LLD falls back to re-deriving the stack every time, and there is no home for the org's golden path.
+  - *Question.* Where does the golden path live, how is it distributed, and how is it populated across greenfield/brownfield/enterprise — without baking any one tech stack into universal core?
+
+- **Decisions requested:**
+  1. **Artifact + name** — add a normative doc distinct from `overview.md`, named **`reference.md`** (`foundation.md` considered and rejected as less industry-recognizable). *Recommended.* Decide-by 2026-06-13.
+  2. **Sections** — use **arc42** vocabulary (Constraints · Solution strategy · Building-block view/component catalogue · Crosscutting concepts/standards), not invented headings. *Recommended; see Options.* Decide-by 2026-06-13.
+  3. **Distribution** — `reference.md` is **generated on demand from a template asset** (like `spec.md`/`plan.md`), **not** a pre-placed core seed — this avoids a *guaranteed* core-vs-stack-pack seed collision. (`overview.md` stays a core seed: it has no competing producer.) *Recommended.* Decide-by 2026-06-13.
+  4. **Population** — by repo context: greenfield authoring (RFC-0021) · brownfield harvest (`adapt-to-project`, fed by detection) · stack-pack pre-bake. *Recommended.* Decide-by 2026-06-13.
+  5. **Harvest** — extend `adapt-to-project` Class-3 discovery to propose a draft `reference.md` from existing code, rather than a new harvester skill. *Recommended.* Decide-by 2026-06-13.
+  6. **Stack specifics** — pre-baked by **opt-in stack packs** (each a follow-on), never baked into core. *Recommended.* Decide-by 2026-06-13.
+
+## Problem & goals
+
+`docs/architecture/overview.md` answers *"where is the thing that does X"* — matklad's rule for `ARCHITECTURE.md` is to *"only specify things that are unlikely to frequently change"* ([matklad](https://matklad.github.io/2021/02/06/ARCHITECTURE.md.html)). That is **descriptive**. What's missing is the **normative** counterpart: the golden path a design must *conform to* — the stack, the internal framework building blocks, the component stereotypes, the cross-cutting standards (security, observability, resilience defaults). This is the altitude enterprise architecture draws between the framework and its application: *"Enterprise Architecture establishes the overarching strategic framework and guidelines, while Solution Architecture interprets and applies these directives"* ([Ardoq](https://www.ardoq.com/knowledge-hub/enterprise-architecture-vs-solution-architecture)). Without a normative anchor, RFC-0019's LLD has nothing org-specific to conform to and re-derives the stack each time.
+
+### Goals
+
+- A single **normative** anchor (`reference.md`) the LLD conforms to and references by name, **instantiated on demand from a template** (the `spec.md`/`plan.md` pattern), so every adopter can generate the skeleton with no pre-placed seed to collide against.
+- **Greenfield, brownfield, and enterprise** each reach a populated foundation — authored (0021), harvested (adapt-to-project), or pre-baked (stack pack).
+- Keep **core stack-neutral**; let opt-in **stack packs** carry the stack specifics.
+- Reuse existing machinery — the template-asset instantiation pattern (the `spec.md`/`plan.md` precedent), `adapt-to-project` discovery, the pack catalogue — rather than building new mechanisms.
+
+### Non-goals
+
+- **A vendor/cloud "reference architecture" blueprint.** This is the *repo's own* golden path, not an AWS-style solution template.
+- **Replacing `overview.md` or the ADR log.** `overview.md` stays the descriptive map; ADRs stay the decision audit trail; `reference.md` is the normative foundation between them.
+- **Baking a stack into core.** Stack specifics live only in opt-in packs or the populated instance.
+- **Authoring specific stack packs here.** This RFC defines the *contract* a stack pack fills; individual packs (React, Spring, …) are follow-on specs.
+- **Changing the spec/plan templates.** Reading `reference.md` is RFC-0019's Decision 9; this RFC ships the doc + how it's populated, not a spec/plan change.
+- **A runtime service registry / infra inventory.** The foundation documents the design golden path, not live infrastructure state.
+
+## Proposal
+
+### The artifact, named and distributed (Decisions 1, 2, 3)
+
+`docs/architecture/reference.md` — normative, durable, low-churn. **Generated on demand from a template, not pre-seeded.** The arc42-section skeleton lives as a **skill asset** (the `new-spec`→`spec.md`/`plan.md` pattern: a template instantiated per use, never shipped as a pre-placed doc); whichever population path runs instantiates it into `docs/architecture/reference.md`. This is the deliberate fix for a **guaranteed-collision** problem: if core *seeded* `reference.md`, every stack pack that ships its own would collide — the bundler errors on differing-content seed collision at self-host and forces a `.upstream` dance at install. Because nothing is pre-placed, the population path that runs is the **sole producer** and there is nothing to collide against. The *template* (not a seeded file) is the shared contract a stack pack pre-bakes and a harvest writes into. `overview.md` is different — it stays a core seed because it has exactly one producer ever (the adopter mapping their own code) and no pack competes to provide it.
+
+Sections use **arc42** vocabulary — four of arc42's twelve sections — so the structure is recognizable rather than bespoke:
+
+- **Constraints** (arc42 §2) — fixed technical/organizational constraints every design honors.
+- **Solution strategy** (arc42 §4) — the stack and fundamental technology choices.
+- **Building-block view / component catalogue** (arc42 §5) — the reusable internal components and framework building blocks an LLD composes from, named so an LLD can reference them.
+- **Crosscutting concepts / standards** (arc42 §8) — the org's defaults for security, observability, resilience, error handling, accessibility.
+
+`overview.md` (descriptive map) and `reference.md` (normative golden path) are siblings under `docs/architecture/`; RFC-0019's LLD reads `reference.md` when present and degrades to detection + elicitation when absent.
+
+**`reference.md` is steering, not just a doc (learned from cc-sdd/Kiro and OpenSpec).** Kiro/cc-sdd carry a *steering* concept — persistent project context the agent applies on every task — and OpenSpec keeps source-of-truth specs every change reconciles against. `reference.md` is that, at the architecture altitude: not a reference an LLD optionally consults, but the **always-applied golden path** a design *conforms to* (and a reviewer checks conformance against). This sharpens the consumer relationship in RFC-0019 Decision 9 from "reads if present" to "conforms to the steering when present" — the same posture `AGENTS.md` already holds for conventions. It also bounds scope: steering is *durable golden-path*, not per-feature design (that stays in the plan) and not live infra state.
+
+### Populating it, by repo context (Decisions 4, 5, 6)
+
+Three population paths, one per repo context; **detection feeds the harvest** (it is not a standalone path):
+
+1. **Greenfield → authoring (RFC-0021).** The inception flow's foundation step authors `reference.md` (stack chosen with recorded rationale) — spec-kit's "constitution first" ([spec-kit](https://github.com/github/spec-kit)).
+2. **Brownfield → harvest (extend `adapt-to-project` Class-3).** Detect the stack + reusable components + recurring patterns from existing code and **propose a draft** `reference.md` the adopter confirms/edits — a discovery output written under the existing path-jail (the Class-3 "Contract relocation" propose-and-confirm shape), not a new skill.
+3. **Enterprise → stack pack (opt-in pre-bake).** A stack pack ships pre-baked `reference.md` content — its component catalogue, stereotypes, standards — plus optional stack-specific LLD guidance. This keeps core stack-neutral, exactly as `atlassian` (Jira-specific) and `converters` (format-specific) already do.
+
+   **Delivery (grounded in the bundler's actual behavior).** Because core does **not** pre-place `reference.md`, the population path that runs is the **sole producer** — a stack pack ships its filled `reference.md` as an ordinary seed with **nothing to collide against**. The only collision case is *two* producers for one repo (two stack packs, or a stack pack atop an adopter's existing `reference.md`): the bundler has **no pack-override field** and errors on differing-content seed collision at self-host (`self_host.py` `_project_seeds`) / writes a `.upstream` companion at install (`commands/_common.py`), so that narrower case routes through the **`.upstream` + `adapt-to-project` merge** (the path adopter customization and copier-style updates already use). A stack pack **never** ships `overview.md`. The stack-pack-contract spec (follow-on) defines this; no new override field is introduced.
+
+The pattern is **detect → curate → LLD-reads** (brownfield) and **author → LLD-reads** (greenfield): the foundation is curated once and read thereafter, not re-derived per spec.
+
+## Options considered
+
+Each requested decision's option space, MECE along a stated axis. A literal do-nothing row appears for Decisions 1, 3, and 4 (the axes that admit it); Decisions 2, 5, 6 carry a weakest-leverage option instead of a literal do-nothing, since their axes presuppose the artifact and a population path exist. The global do-nothing (no foundation at all) is Decision 1's last row.
+
+### Decision 1 — Artifact locus + name — *axis: where the normative golden path lives*
+
+| Option | Trade-off |
+| --- | --- |
+| **New `reference.md`** ★ | Clean descriptive/normative split; one durable doc; industry-recognizable name |
+| `foundation.md` (same doc, different name) | Avoids the vendor-blueprint reading of "reference architecture" — but less recognizable; kept as the fallback if that reading proves common |
+| Fold into `overview.md` | One file — but conflates "where things are" with "what to conform to"; violates matklad's descriptive-only rule |
+| Put it in `CHARTER.md` / `CONVENTIONS.md` | Reuses a doc — but CHARTER is product mission, CONVENTIONS is process; neither is the technical golden path |
+| Do-nothing | No new doc — but the LLD has no anchor and re-derives the stack each time |
+
+### Decision 2 — Section vocabulary — *axis: how the doc is structured*
+
+| Option | Trade-off |
+| --- | --- |
+| **arc42 (4 of 12 sections)** ★ | Recognized template; the four normative sections (§2/§4/§5/§8) map exactly to constraints/stack/components/standards | 
+| C4 model | Strong for diagrams/views, but it's a visualization model, not a normative-standards vocabulary |
+| Invented headings | Tailored — but bespoke, unrecognizable, and re-litigated per repo |
+| Reuse `overview.md`'s headings | Consistent with the map — but those are descriptive-codemap headings, wrong for normative standards |
+
+### Decision 3 — Distribution — *axis: how the skeleton reaches the adopter*
+
+| Option | Trade-off |
+| --- | --- |
+| **Template instantiated on demand** ★ (skill asset, the `spec.md`/`plan.md` pattern) | One sole producer per repo; **nothing pre-placed to collide with**; the template is still the shared contract |
+| Core pack document seed (parallel to `overview.md`) | Discoverable — but **guarantees a collision** with every stack pack that ships its own `reference.md` (build errors / install companions). Rejected for that reason — this is the flaw the user flagged |
+| Non-core pack | Keeps core lean — but a core-only adopter wouldn't get the template, and the foundation is baseline |
+| Adopter authors from scratch (do-nothing) | Zero shipped surface — but every adopter reinvents the arc42 structure |
+
+### Decision 4 — Population — *axis: how the foundation gets filled, by repo context*
+
+| Option | Trade-off |
+| --- | --- |
+| **By repo context (author / harvest / pre-bake)** ★ | Covers greenfield + brownfield + enterprise; detection feeds harvest | 
+| Harvest only | Fails greenfield (nothing to harvest) |
+| Authoring only | Ignores existing code; high manual cost on brownfield |
+| Do-nothing | Foundation is never populated; the template is never instantiated |
+
+### Decision 5 — Harvest mechanism — *axis: what writes the brownfield draft*
+
+| Option | Trade-off |
+| --- | --- |
+| **Extend `adapt-to-project` Class-3** ★ | Reuses the discovery engine + path-jail + propose-and-confirm; harvest *is* discovery | 
+| New harvester skill | Duplicates discovery; another skill to maintain |
+| Manual only | No leverage; defeats the brownfield goal |
+
+### Decision 6 — Stack specifics — *axis: who carries the stack*
+
+| Option | Trade-off |
+| --- | --- |
+| **Opt-in stack packs** ★ | Core stays universal (Principle 1); precedented by `atlassian`/`converters` | 
+| Bake into core | Violates universality; rots for non-matching adopters |
+| Adopter-authored only | Works, but every org re-authors the same React/Spring golden path from scratch |
+
+## Risks & what would make this wrong
+
+- **Pre-mortem.**
+  - *The foundation rots — written once, never maintained, and the LLD conforms to a lie.* Mitigation: it's normative and low-churn by design; give it a named owner and a verification cadence matched to its volatility (general documentation practice).
+  - *Harvest mis-infers the architecture.* Mitigation: harvest only *proposes a draft*; the adopter curates before it's authoritative — the confirm gate `adapt-to-project` already uses.
+  - *An instantiated-but-unfilled `reference.md` invites cargo-cult half-filling.* Mitigation: the template carries guidance that it's filled when there are real architecture decisions (the throwaway gate of RFC-0021); a thin repo simply never instantiates it.
+  - *"Reference architecture" is read as a vendor blueprint.* Mitigation: the Non-goal states it's the repo's own golden path; `foundation.md` is the Decision-1 fallback name.
+  - *Two producers target `reference.md` (e.g. two stack packs).* Mitigation: core pre-places nothing, so the common case has a sole producer and no collision; the two-producer case routes through the `.upstream` companion + `adapt-to-project` merge (the bundler has no override field and errors on raw seed collision). This is exactly why Decision 3 rejects a core seed — pre-seeding would make the collision *universal* rather than this narrow two-producer case. Stack packs never ship `overview.md`.
+- **Key assumptions (falsifiable).**
+  1. A *normative* foundation (distinct from the descriptive map) is reached often enough to earn a first-class template-instantiated doc (Principle 4) — rather than teams being served by `overview.md` + ADRs alone.
+  2. arc42's four chosen sections are universal enough to hold any adopter's golden path without privileging a stack or domain.
+- **Drawbacks.** A new template asset to own; an `adapt-to-project` extension to build and test; a stack-pack contract to specify; one CONVENTIONS hierarchy-diagram edit. **Blast radius is bounded to the architecture-doc surface** — it adds a template asset + extends one skill + one convention line; it does **not** touch the core `spec.md`/`plan.md` templates (that's RFC-0019). The foundation is **consumed** by RFC-0019's LLD (Decision 9), so it is not inert.
+
+## Evidence & prior art
+
+- **Spike / de-risk result.** *Riskiest assumption:* that the descriptive/normative split is real and not redundant with `overview.md`. *Check:* matklad's `ARCHITECTURE.md` is explicitly descriptive (codemap; "only specify things unlikely to change"); arc42 carries normative content in *separate* sections (§2/§4/§5/§8); spec-kit's **constitution** is a normative anchor authored before code. Three independent traditions draw the same line — **the split is real**, `overview.md` ≠ `reference.md`. Holds. The *frequency* question (Assumption 1) is the Approver's product call, mitigated by reusing the seed + discovery machinery so cost-if-rare is low.
+- **Repo precedent.** `new-spec`'s `spec.md`/`plan.md` (templates in a skill asset, instantiated on demand — the distribution precedent `reference.md` follows, **not** pre-seeded); `docs/architecture/overview.md` (descriptive map, a core seed — but it has no competing producer, hence safe to seed, *unlike* `reference.md`); `docs/adr/` (decision log); `adapt-to-project` Class-3 discovery + path-jail + propose-and-confirm (the harvest host); RFCs 0001–0003 (the pack-catalogue model stack packs extend); `packs/atlassian` and `packs/converters` (opt-in, deliberately non-universal packs — the stack-pack precedent). RFC-0019 Decision 9 is the consumer that reads this foundation.
+- **External prior art.** [arc42 template](https://arc42.org/overview) — the four normative sections this adopts; [matklad — ARCHITECTURE.md](https://matklad.github.io/2021/02/06/ARCHITECTURE.md.html) — descriptive codemap (Redis/rust-analyzer/Tauri); [GitHub spec-kit](https://github.com/github/spec-kit) — the constitution as a normative anchor; [Ardoq — EA vs SA](https://www.ardoq.com/knowledge-hub/enterprise-architecture-vs-solution-architecture) — the framework-vs-application *altitude* (cited only for that distinction; the page does not define "reference architecture"). The "named owner + verification cadence" is general documentation practice `[synthesis]`, not a single-source claim.
+
+## Open questions
+
+1. **Harvest trigger** — run at install vs on-demand via `adapt-to-project`. *Recommended default:* on-demand (the adapt flow already gates dirty-state and confirmation). Owner: eugenelim · decide-by 2026-06-20.
+2. **Stack-pack naming convention** — how stack packs are named/namespaced in the catalogue. *Recommended default:* defer to the first stack-pack spec; not load-bearing here. Owner: eugenelim · decide-by 2026-06-20.
+
+## Follow-on artifacts
+
+Filled in on acceptance:
+
+- ADR-NNNN: record the reference-architecture-foundation decision (normative `reference.md` distinct from descriptive `overview.md`; template-instantiated-on-demand distribution, **not** a pre-placed seed; population by repo context; `adapt-to-project` harvest).
+- Spec: `docs/specs/reference-architecture/` — the `reference.md` **template asset** (arc42 sections, instantiated on demand like `spec.md`/`plan.md` — **not** a pre-placed seed), the `adapt-to-project` Class-3 harvest extension, and the stack-pack contract (what a pack pre-bakes and how it delivers).
+- Spec(s): the first **stack pack(s)** (e.g. a frontend and a backend pack) — downstream, each clearing the charter bars on its own.
+- Convention change: `docs/CONVENTIONS.md` — amend the document-hierarchy diagram to add `reference.md` under `architecture/`, distinguished from `overview.md`.
+- **User guides (in *this* catalogue repo, `docs/guides/`, via `new-guide`)** — authored as part of "done"; this repo ships a guide on **`reference.md` and how to use it**:
+  - *Tutorial* — **"Create and use your `reference.md`"**: establish it (greenfield via `init-project` / brownfield via harvest / stack-pack pre-bake), then *use* it — how a design conforms to it, how to reference its components and stereotypes by name, and how the LLD (RFC-0019, Decision 9) reads it as steering.
+  - *How-to* — "Establish your repo's reference architecture" (greenfield author / brownfield harvest / stack-pack pre-bake).
+  - *Explanation* — "Foundation vs. map": why `reference.md` (normative steering) and `overview.md` (descriptive) are separate, and why `reference.md` is template-instantiated rather than seeded.
+  - *Reference* — the `reference.md` arc42 sections and the stack-pack contract.

--- a/docs/rfc/0021-greenfield-inception-research.md
+++ b/docs/rfc/0021-greenfield-inception-research.md
@@ -1,0 +1,116 @@
+# Research: greenfield idea→repo bootstrapping (for RFC-0021)
+
+> Discipline: applied (practitioner-pattern survey)
+
+Prior-art + best-practice + anti-pattern survey for the greenfield front-door.
+Confidence per finding: `[high]`/`[moderate]`/`[low]`/`[uncertain]`.
+Independence calibrated per practitioner taxonomy (same vendor/employer = one).
+Recency flag: LLM-agent systems are <2yr in a fast-moving domain — cited as
+current-generation; walking-skeleton/inception are slow-moving (no penalty).
+
+## Findings
+
+**F1 — Two paradigms exist for idea→repo. `[high]`** Scaffold-from-template
+(cookiecutter / copier / Yeoman / `create-*`) vs multi-agent generation
+(MetaGPT / ChatDev / AutoDev). Independent sources across both families.
+
+**F2 — spec-kit is greenfield-first; we are the inverse. `[high]`**
+`specify init` + a constitution bootstraps a new project; brownfield is still
+only an open extension proposal (spec-kit #1436). Our repo has `adapt-to-project`
+(brownfield) and lacks the greenfield front-door — confirming the gap is real.
+Sources: spec-kit repo (primary), MS Learn lab, Scott Logic review — independent.
+
+**F3 — Walking skeleton / tracer bullet / steel thread is THE principled
+anti-yolo. `[high]`** A thin end-to-end slice that links the main architectural
+components to validate the architecture early; "small integration pain all
+along the way" beats a big cleanup. Cockburn (origin), Pragmatic Programmer
+(tracer bullet), Rubick (steel threads), Code Climate, Equal Experts — independent,
+slow-moving domain.
+
+**F4 — Structured inception precedes code. `[high]`** Lean Inception (Fowler):
+a focused kickoff that sets direction, MVP, and explicitly "NFRs, technical
+architecture, tech stack, path to production," plus "a short architecture
+decision log for each major choice — what you picked, why, alternatives
+rejected, re-evaluation date." Value gate: "if you cannot explain the business
+value in plain language, pause; code should not start yet." Fowler (primary) +
+discovery-phase practitioner sources.
+
+**F5 — The current spec-driven / agentic-SDD landscape to situate against
+(replaces the abandoned Microsoft/AutoDev thread).**
+- **BMAD-METHOD** `[high]` on framing, `[moderate]` on exact chain. Agent-
+  orchestrated SDLC; the homepage confirms an "Analysis Phase: From Idea to
+  Foundation," "Named Agents," and ideation→planning→agentic-implementation
+  producing explicit version-controlled artifacts (docs.bmad-method.org,
+  fetched). Secondary sources (GitHub, Medium guides) report the greenfield
+  chain **analyst → project-brief → PM → PRD → architect → stories → code** —
+  independently the *same* brief→foundation chain as our trilogy. The closest
+  cousin to RFC-0021. Chain confirmed only via secondary → `[moderate]`.
+- **OpenSpec** (Fission-AI) `[high]` (concepts.md fetched). Lightweight,
+  **proposal-first**: `proposal → specs → design → tasks → implement`, with
+  **delta specs** (ADDED/MODIFIED/REMOVED) merged into source-of-truth specs on
+  archive; 20+ agents, no lock-in, lighter than spec-kit. Corroborates
+  RFC-0019's brief/spec + contract-delta shape.
+- **cc-sdd** (gotalab) `[moderate]`. npm SDD harness bringing Kiro-style
+  `discovery → spec-init → requirements → design → tasks → impl` (EARS) to
+  Claude Code/Codex/Cursor/etc.; "turn approved specs into long-running
+  autonomous implementation." Its `discovery` front maps to our inception.
+- **Intent** (Augment Code) `[moderate]`. Platform with **living specs** (the
+  spec updates as the implementation changes; agents implement from current
+  state) + coordinated multi-agent execution + enterprise compliance.
+  Corroborates RFC-0019's auto-rollup coverage and spec-as-validation-gate.
+
+(AutoDev ruled out by user; Copilot Workspace dropped — these four are the
+grounded reference set the user named.)
+
+**F6 — Multi-agent "AI software company" generates idea→repo. `[high]`**
+MetaGPT: "Code = SOP(Team)"; one-line requirement → PRD / design / tasks / code
+via PM/architect/engineer roles communicating through structured documents.
+ChatDev: dialogue-based variant. Sources: arXiv 2308.00352 (primary) + IBM +
+GitHub — independent.
+
+**F7 — Template UPDATE support (copier) maps to our `.upstream` merge. `[moderate]`**
+Copier is unique among scaffolders in syncing template evolution into already-
+generated projects ("code lifecycle management"); cookiecutter/Yeoman can't.
+This validates `adapt-to-project` + `.upstream` as the re-sync mechanism.
+Sources: copier docs (primary) + cookiecutter.io comparison (vendor — counts as
+one) + recallstack. Independence partial → `[moderate]`.
+
+**F8 — Enterprise golden-path scaffolding = Backstage software templates.
+`[moderate]`** `template.yaml` the scaffolder reads; encodes org tech stacks,
+standards, CI/CD, security/compliance; ING's "Golden Path plugin" is a
+meta-template stitching several team-owned templates. Maps to our stack packs
+(RFC-0020). Sources: Backstage docs (primary, Spotify) + Red Hat + Roadie.
+
+**F9 — The throwaway-vs-structured gate. `[moderate]`** Practitioner guidance:
+"if the project is a single script or throwaway prototype, scaffold it directly;
+for projects with real tech-stack/structure/tooling decisions, use the project
+initialization workflow." Fewer independent sources (agent-skill catalogues,
+practitioner blogs) → `[moderate]`; but it converges with the Lean-Inception
+value gate (F4).
+
+## Anti-patterns
+
+**AP1 — yolo-prototype-then-cleanup. `[moderate]`** Building a throwaway to
+"figure it out," then retrofitting structure — loses the research rationale and
+the foundation. The walking skeleton (F3) is the deliberate replacement.
+
+**AP2 — autonomous multi-agent over-generation. `[low]` (survivorship-bias
+flagged)** Full "AI software company" generation (MetaGPT / ChatDev, and the
+autonomous end of BMAD) produces impressive demos, but reported production
+maintainability/quality is uneven; the blogs that survive are the successes.
+Treat the agent-orchestrated SOP as a paradigm to *borrow the structure from*,
+not adopt as an autonomous engine wholesale.
+
+## Implication for RFC-0021
+
+**BMAD independently validates the chain** (analyst→brief→PM→PRD→architect ≈
+our 0021→0019→0020), so the *structure* is proven. Decline the autonomous
+multi-agent *engine* (MetaGPT/ChatDev, BMAD's autonomous end). Instead
+**compose our existing single-purpose skills** (brief → foundation → spec →
+work-loop) and add the two genuinely-missing pieces the prior art validates: a
+**structured inception gate** (F4 + F9) and a **walking skeleton** (F3), with
+copier-style **re-sync** (F7) via existing machinery. Boring, maintainable,
+charter-aligned (habit not infra) — borrowing the *agent-orchestrated
+structured-document handoff* (BMAD, MetaGPT) without the agent-company.
+OpenSpec's delta-specs and Intent's living-specs separately corroborate
+RFC-0019's contract-delta + auto-rollup coverage.

--- a/docs/rfc/0021-greenfield-inception.md
+++ b/docs/rfc/0021-greenfield-inception.md
@@ -1,0 +1,146 @@
+# RFC-0021: Greenfield inception — the idea→repo front-door (research → foundation → walking skeleton)
+
+- **Status:** Accepted <!-- Draft | Open | Final Comment Period | Accepted | Rejected | Withdrawn | Experimental -->
+- **Author:** eugenelim
+- **Approver:** eugenelim
+- **Date opened:** 2026-06-01
+- **Date closed:** 2026-06-01
+- **Related:** RFC-0019 (brief intake + LLD — 0021 produces the first brief and feeds the build loop); RFC-0020 (reference-architecture foundation — 0021's foundation step authors it); the `adapt-to-project` skill (the *brownfield* counterpart front-door); applied-mode prior-art survey at `0021-greenfield-inception-research.md`.
+
+## The ask
+
+- **Recommendation (BLUF):** Add the **greenfield front-door** the methodology lacks: the **`init-project`** inception flow that turns an *idea* into a structured repo — apply a **value gate** over a **fed-in discovery shape** (the `research` pack's output, a provided PRD, or `receive-brief` — `init-project` *consumes* discovery, it does not perform it), make the **foundation** decision (an ADR + `reference.md` per RFC-0020), and produce a **walking skeleton** (a thin, kept, end-to-end slice that validates the foundation) — then hand off to the `brief → spec → work-loop` build. It is gated: throwaway/single-file repos skip it (yolo stays fine); it fires only when there are **real stack/structure decisions**. It composes existing skills (brief, foundation, ADR, spec) rather than reinventing an autonomous generator.
+
+- **Why now (SCQA):**
+  - *Situation.* The methodology has a brownfield front-door (`adapt-to-project`), a downstream loop (brief → foundation → spec → LLD → build), and the foundation (RFC-0020).
+  - *Complication.* A **brand-new repo has no front-door**. Adopters research an idea, then *yolo* a throwaway prototype and retrofit structure — losing the research rationale and shipping no foundation. spec-kit proves the opposite emphasis (`specify init` is greenfield-first; brownfield is its open gap); we are the mirror, and greenfield is *ours*.
+  - *Question.* How does an idea become a structured repo with a justified foundation and a validated skeleton — without forcing inception ceremony onto throwaways, and without building an autonomous code generator?
+
+- **Decisions requested:**
+  1. **Front-door locus** — a **new greenfield inception flow** (the **`init-project`** skill), not an extension of `adapt-to-project` (which is brownfield by definition). *Recommended.* Decide-by 2026-06-13.
+  2. **Flow shape** — value gate over **fed-in discovery** → foundation (ADR + `reference.md`) → walking skeleton → hand off to `brief → spec → work-loop`. *Recommended.* Decide-by 2026-06-13.
+  3. **Trigger gate** — throwaway/single-script repos skip it; it fires only for repos with real tech-stack/structure/tooling decisions. *Recommended.* Decide-by 2026-06-13.
+  4. **Generation engine** — **compose existing single-purpose skills** + a walking skeleton; *decline* the autonomous multi-agent "software company" paradigm (BMAD/MetaGPT/ChatDev-style) as the engine, while borrowing its structured-document handoff. *Recommended.* Decide-by 2026-06-13.
+
+## Problem & goals
+
+The current greenfield path is the **yolo-prototype-then-cleanup** anti-pattern: build a throwaway to "figure it out," then retrofit structure once it sort-of works. The prior art's principled replacement is the **walking skeleton / tracer bullet / steel thread** — *"a tiny implementation that performs a small end-to-end function… links the main architectural components"* to validate the architecture early ([Henrico Dolfing](https://www.henricodolfing.com/2018/04/start-your-project-with-walking-skeleton.html), [Rubick — steel threads](https://www.rubick.com/steel-threads/)) — wrapped in a structured **inception** that decides direction, stack, and the value proposition before code ([Lean Inception, Fowler](https://martinfowler.com/articles/lean-inception/)).
+
+### Goals
+
+- Give a brand-new repo a front-door: **idea → structured repo** with a justified foundation, replacing yolo-then-cleanup.
+- Apply a **value gate** over **fed-in discovery** (*"if you can't explain the business value, pause"*) so the stack decision is reasoned and recorded (ADR), not improvised — discovery itself is produced upstream (the `research` pack), not by `init-project`.
+- Produce a **walking skeleton** — thin, kept, end-to-end — instead of a throwaway prototype.
+- **Compose** the existing artifacts (brief, foundation, spec) — the inception flow orchestrates, it doesn't reinvent.
+- Stay out of the way for throwaways (the trigger gate).
+
+### Non-goals
+
+- **An autonomous code generator.** We decline the multi-agent "AI software company" engine (Decision 4); the human stays in the loop and the existing skills do the work.
+- **A repo/code scaffolder like `create-next-app`.** The flow produces the *foundation + a thin skeleton*, not a fully-generated app from a stack template.
+- **Replacing `adapt-to-project`.** That remains the brownfield front-door; this is its greenfield twin, not a merge.
+- **Forcing ceremony on throwaways.** The trigger gate keeps single-scripts on the yolo path.
+- **Performing discovery/research itself.** Discovery (market/technical research, prior art, competitive landscape) is **fed in as a shape** — from the `research` pack (applied mode), a provided PRD, or `receive-brief` — and `init-project` consumes it. Owning the research phase is out of scope; that's the research pack's job (scoped-handoff principle).
+
+## Proposal
+
+`init-project`, a guided greenfield flow:
+
+1. **Trigger gate (Decision 3).** Real stack/structure/tooling decisions ahead? If no (a script, a spike, a throwaway) → scaffold directly, skip the flow. If yes → continue.
+2. **Frame + value gate.** Take the **fed-in discovery shape** — `research`-pack output (applied mode), a provided PRD, or `receive-brief`'s brief — and from it articulate business value + MVP. Gate: if the value can't be stated plainly, pause and send discovery back upstream. **Output: the first `brief`** (RFC-0019 artifact, greenfield variant). `init-project` *consumes* discovery; it does not run it.
+3. **Foundation decision.** Choose the stack/architecture with recorded rationale — **an ADR** (what/why/alternatives/re-evaluation date) **and `reference.md`** (RFC-0020, greenfield-authoring path). This is the greenfield population source RFC-0020 names.
+4. **Walking skeleton.** Author a single spec for a thin end-to-end slice that links the main architectural components, and build it through `work-loop`. It is *kept and minimal*, not thrown away — validating the foundation with "small integration pain all along the way."
+5. **Hand off.** From here the normal `brief → spec → LLD → work-loop` loop runs, with `reference.md` in place for every LLD to conform to.
+
+**Fluid, not waterfall (learned from OpenSpec).** These are *phases of attention*, not gates — any artifact is revisitable as understanding firms up (the walking skeleton routinely sends you back to amend the foundation). The order is the default path, not a one-way ratchet. **Scoped handoffs (learned from BMAD):** each step passes the *next* step only the artifacts it needs — inception → the brief; foundation → the brief + ADRs; skeleton → the brief slice + `reference.md` — not the whole accreted history.
+
+## How the three RFCs hold together
+
+Two front-doors feed one shared downstream; the foundation is the spine:
+
+```
+GREENFIELD front-door ── RFC-0021 ──┐   (idea → inception → foundation → walking skeleton)
+                                     ├──►  brief ──►  reference.md ──►  spec ──►  LLD ──►  work-loop build
+BROWNFIELD front-door ── adapt-to-project ┘  (RFC-0019)   (RFC-0020)   (0019)  (0019, conforms
+                          + RFC-0020 harvest                                     to reference.md)
+```
+
+The **seams** that let the three land independently and in any order:
+
+- **0021 produces 0019's and 0020's artifacts.** Inception emits the first **brief** (0019); the foundation step authors **`reference.md`** (0020). 0021 is an *orchestrator* of the other two plus the walking skeleton — it adds no artifact type of its own.
+- **0019 ↔ 0020 by presence-check.** RFC-0019's LLD (Decision 9) **reads `reference.md` when present, else derives + elicits** — so 0019 ships standalone, and the day a `reference.md` exists (via 0021 greenfield, 0020 harvest, or a stack pack) the LLD conforms to it automatically.
+- **0020's population maps to repo context.** Greenfield → **0021's** foundation step; brownfield → **`adapt-to-project` harvest** (repo **detection** feeds it); enterprise → **stack packs**. No vague "authoring".
+- **Each is independently valuable.** 0019 alone gives brief-intake + LLD. 0020 alone gives a foundation `adapt-to-project` can harvest. 0021 needs 0019+0020 to land first (it composes them) — the only ordering constraint, and a soft one.
+
+## Options considered
+
+Each decision's option space, MECE along a stated axis, do-nothing included where the axis admits it.
+
+### Decision 1 — Front-door locus — *axis: where greenfield init lives*
+
+| Option | Trade-off |
+| --- | --- |
+| **New greenfield inception flow** ★ | The clean greenfield twin of `adapt-to-project`; symmetric and discoverable |
+| Extend `adapt-to-project` | Wrong by definition — that skill adapts *existing* content; greenfield has none |
+| Template-repo only (`Use this template`) | Zero logic, but no research/value gate, no foundation, no skeleton |
+| Do-nothing (yolo) | No build cost; the yolo-then-cleanup anti-pattern persists |
+
+### Decision 2 — Flow shape — *axis: how idea becomes structured repo*
+
+| Option | Trade-off |
+| --- | --- |
+| **Inception → foundation → walking skeleton → handoff** ★ | Grounded in Lean Inception + walking skeleton + constitution-first; each step has a home artifact |
+| Foundation-first, no inception | Skips the value gate — stack chosen before the problem is understood |
+| Skeleton-first, no foundation | Validates integration but bakes in unrecorded stack decisions |
+
+### Decision 3 — Trigger gate — *axis: when the flow fires*
+
+| Option | Trade-off |
+| --- | --- |
+| **Gate on "real decisions"** ★ | Throwaways stay yolo; ceremony only where it pays — matches "right-size to stakes" |
+| Always run | Inception on a weekend script is friction that drives people off the path |
+| Never (manual) | No guidance; back to yolo-then-cleanup |
+
+### Decision 4 — Generation engine — *axis: how much the system auto-generates*
+
+| Option | Trade-off | Prior art |
+| --- | --- | --- |
+| **Compose existing skills + walking skeleton** ★ | Boring, maintainable, human-in-loop; no new agent framework | our skills + walking skeleton |
+| Autonomous multi-agent "software company" | Impressive idea→repo demos — but uneven production quality, heavy framework, survivorship-biased | BMAD, MetaGPT, ChatDev |
+| Pure stack scaffolder | Fast code, but no reasoned foundation or value gate | cookiecutter / `create-*` |
+| Do-nothing | — | — |
+
+**BMAD corroborates this chain** — its greenfield flow *reportedly* runs analyst → project-brief → PM → PRD → architect (per secondary sources; the homepage confirms only "Idea→Foundation" + named agents), the same brief→foundation→spec progression as our trilogy — so the *structure* is independently corroborated. We **borrow** two concrete things from it: the agent-orchestrated **structured-document handoff**, and BMAD's **scoped-context** discipline — *each step receives only the artifacts it needs* (the spec author gets the brief slice + `reference.md`, not the whole history). We **decline** the autonomous-agent-company *engine* (AP2: survivorship-bias-flagged). OpenSpec's delta-specs and Intent's living-specs separately corroborate RFC-0019's proposal-first decomposition and auto-rollup coverage.
+
+## Risks & what would make this wrong
+
+- **Pre-mortem.**
+  - *Inception becomes ceremony people skip.* Mitigation: the trigger gate (Decision 3) — it fires only for real decisions; throwaways stay on yolo.
+  - *The "walking skeleton" becomes the throwaway it was meant to replace.* Mitigation: it's authored as a real spec through `work-loop`, kept and minimal — held to the same contract as any feature, not a sketch.
+  - *Multi-agent envy* — pressure to make it an autonomous generator. Mitigation: Decision 4 declines it explicitly, with the survivorship-bias evidence.
+- **Key assumptions (falsifiable).**
+  1. Greenfield-with-real-decisions happens often enough among adopters to earn a front-door (Principle 4); if most new repos are throwaways, the gate sends them to yolo and this rarely fires.
+  2. Composing existing skills + a walking skeleton genuinely beats yolo-then-cleanup in practice — the steel-thread claim holds for agent-built repos, not just human teams.
+- **Drawbacks.** A new orchestrating skill to maintain; a soft ordering dependency on RFC-0019 + RFC-0020 landing first. Lower blast radius than 0019 (no core-template change) — it adds a skill and composes existing artifacts.
+
+## Evidence & prior art
+
+- **Spike / de-risk result.** *Riskiest assumption:* that a structured greenfield flow beats yolo. *Check (prior art, applied survey):* the walking skeleton / tracer bullet / steel thread is the cross-industry, decades-stable answer to exactly this — validate the architecture with a thin end-to-end slice rather than a throwaway — and Lean Inception is the established value-gated kickoff. Both are slow-moving (no recency penalty). The *agent-built-repo* generalization (Assumption 2) is the part not yet proven and is the Approver's call. See `0021-greenfield-inception-research.md`.
+- **Repo precedent.** `adapt-to-project` (the brownfield twin this mirrors); RFC-0019 (brief, the inception output) and RFC-0020 (foundation, the foundation step); the `research` pack (applied mode, used in inception); `docs/adr/` (the foundation-decision log).
+- **External prior art** (applied-mode survey, confidence-rated in `0021-greenfield-inception-research.md`): walking skeleton / steel thread ([Dolfing](https://www.henricodolfing.com/2018/04/start-your-project-with-walking-skeleton.html), [Rubick](https://www.rubick.com/steel-threads/)); [Lean Inception (Fowler)](https://martinfowler.com/articles/lean-inception/); spec-kit greenfield-first vs our brownfield-first ([spec-kit](https://github.com/github/spec-kit)). The spec-driven / agentic landscape we situate against: **[BMAD-METHOD](https://docs.bmad-method.org/)** — agent-orchestrated idea→foundation (analyst→brief→PM→PRD→architect per secondary sources); the closest cousin, whose *structure* we borrow and whose autonomous *engine* we decline alongside [MetaGPT (arXiv 2308.00352)](https://arxiv.org/abs/2308.00352) and ChatDev. **[OpenSpec](https://github.com/Fission-AI/OpenSpec)** — proposal-first + delta specs (corroborates RFC-0019). **[cc-sdd](https://github.com/gotalab/cc-sdd)** — Kiro-style discovery→spec→design→tasks→impl harness on Claude Code; its *discovery* is a **distinct upstream phase**, reinforcing our boundary that discovery is fed *in*, not owned by `init-project`. **Intent** (Augment Code) — living specs (corroborates 0019's auto-rollup). The throwaway-vs-structured gate is practitioner guidance, `[moderate]`.
+
+## Open questions
+
+1. **Walking skeleton in-scope vs handoff** — does `init-project` author+build the skeleton, or stop at the foundation and hand the skeleton to the normal loop? *Recommended default:* author the spec, hand the *build* to `work-loop` (`init-project` orchestrates, work-loop executes). Owner: eugenelim · decide-by 2026-06-20.
+
+## Follow-on artifacts
+
+Filled in on acceptance:
+
+- ADR-NNNN: record the greenfield-front-door decision (new flow, not `adapt-to-project`; compose-not-autogenerate).
+- Spec: `docs/specs/greenfield-inception/` — the `init-project` skill (trigger gate → inception → foundation → walking skeleton → handoff), composing `research` / brief / `reference.md` / spec / `work-loop`.
+- Convention change: `docs/CONVENTIONS.md` — document the two front-doors (greenfield inception / brownfield adapt) and where each enters the loop.
+- **User guides (in *this* catalogue repo, `docs/guides/`, via `new-guide`)** — authored as part of "done":
+  - *Tutorial* — "From idea to a walking skeleton: start a new project."
+  - *How-to* — "Decide and record your foundation during inception."
+  - *Explanation* — "Why a walking skeleton beats a throwaway prototype."

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -24,6 +24,9 @@
 | [0016](0016-doc-drift-mechanical-gate.md) | Doc-drift prevention — construction + judgment (template / reviewer / DECIDE / CONVENTIONS / in-repo backlog), with a catalogue-governance linter | Draft | 2026-05-29 | |
 | [0017](0017-pluggable-api-contract-standards.md) | Pluggable API-contract standards (base+delta, Zalando as starter) + a contract-type-agnostic `new-spec` seam | Accepted | 2026-05-30 | 2026-05-30 |
 | [0018](0018-event-asyncapi-authoring-engine.md) | Event/AsyncAPI authoring engine for `contracts` — `event-contract` skill (AsyncAPI 3.1.0 + CloudEvents 1.0.2 envelope, Zalando event rules as starter) | Accepted | 2026-05-31 | 2026-05-31 |
+| [0019](0019-product-brief-intake.md) | Product-brief intake + LLD-aware spec/plan — `brief` artifact + `receive-brief` skill (own-the-repo-slice) and a stack-neutral, stack-derived `## Design (LLD)` in spec/plan | Accepted | 2026-06-01 | 2026-06-01 |
+| [0020](0020-reference-architecture-foundation.md) | Reference-architecture foundation — normative `docs/architecture/reference.md` golden path (arc42), **template-instantiated on demand** (not core-seeded — avoids guaranteed stack-pack collisions); populated by stack pack / brownfield harvest / greenfield `init-project`; the LLD's steering | Accepted | 2026-06-01 | 2026-06-01 |
+| [0021](0021-greenfield-inception.md) | Greenfield inception — the idea→repo front-door (research + value gate → foundation → walking skeleton), the greenfield twin of `adapt-to-project`; composes brief/foundation/spec, declines autonomous generation | Accepted | 2026-06-01 | 2026-06-01 |
 
 ## Adding a new RFC
 


### PR DESCRIPTION
## What

Three coherent, cross-referenced RFCs (all **Accepted**) that close the product→engineering intake gap end-to-end and add the missing greenfield front-door.

- **RFC-0019 — Product-brief intake + LLD-aware spec/plan.** Receive an externally-authored product brief (own-the-repo-slice), decompose into specs, execute via `new-spec → work-loop`; the plan gains a stack-neutral `## Design (LLD)` whose stack is *derived* — it reads `reference.md` when present, else detects/elicits.
- **RFC-0020 — Reference-architecture foundation.** `docs/architecture/reference.md` as the **steering** golden path (arc42 vocabulary), **template-instantiated on demand** (the `spec.md`/`plan.md` pattern — *not* core-seeded, which would guarantee stack-pack collisions); populated greenfield (`init-project`) / brownfield (`adapt-to-project` Class-3 harvest) / enterprise (opt-in stack pack).
- **RFC-0021 — Greenfield inception (`init-project`).** The idea→repo front-door: value gate over *fed-in* discovery → foundation (ADR + `reference.md`) → walking skeleton → handoff. Composes existing skills; declines the autonomous multi-agent generation paradigm.

## How they hold together

Two front-doors (greenfield `init-project` / brownfield `adapt-to-project`) → **brief** (0019) → **`reference.md`** steering (0020) → spec → **LLD conforms if present** (0019 Decision 9) → `work-loop`. Each RFC lands independently via presence-checks; 0021 composes 0019 + 0020.

## Notes

- Prior art grounded in an applied-mode survey committed alongside RFC-0021 (`docs/rfc/0021-greenfield-inception-research.md`); citations verified by fetch (two earlier misattributions corrected mid-review).
- These are governance docs — follow-on ADRs, specs, and user guides are enumerated in each RFC's "Follow-on artifacts".
- Reviewed iteratively with the adversarial-reviewer; the trilogy was reported clean before acceptance.