### PR TITLE
feat(core): product-brief intake — receive-brief skill, brief layer, coverage rollup

### DIFF
--- a/.claude/skills/new-spec/SKILL.md
+++ b/.claude/skills/new-spec/SKILL.md
@@ -116,6 +116,13 @@ look like?" before any code.
      items that name an ADR or RFC the feature must cite. The header
      lands before any body section; Verified items don't gate the
      Unverified loop but they do gate `Constrained by:`.
+   - Stamp the optional `Brief:` header **only** when this spec is
+     derived from a product brief — i.e. you arrived here from
+     `receive-brief`, which decomposes a received brief into specs. Set
+     it to the brief's slug (`docs/product/briefs/<slug>.md`); leave it
+     blank or `none` for a spec authored directly. It records *product
+     provenance* and is distinct from `Constrained by:` (governance).
+     A spec without it stays valid — the field is additive.
 
 4. Fill in the spec — including the **Testing Strategy** section. Push
    back hard on these failure modes:

--- a/.claude/skills/new-spec/assets/spec.md
+++ b/.claude/skills/new-spec/assets/spec.md
@@ -4,6 +4,7 @@
 - **Owner:** <github-handle>
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** <!-- ADR-NNNN, RFC-NNNN, or "none" -->
+- **Brief:** <!-- optional: the product brief this spec was derived from (`docs/product/briefs/<slug>.md`); stamped by receive-brief. Omit, or "none", for a spec authored directly. Distinct from Constrained by: this is product provenance, not a governance constraint. -->
 - **Contract:** <!-- contracts/<type>/<name> this spec defines or touches (see new-spec step 4b / CONVENTIONS § 4 Contracts), or "none" for a non-API feature -->
 
 > **Spec contract:** this document defines what "done" means. The implementing
@@ -85,6 +86,16 @@ mark it deferred with an inline anchor into the backlog register:
 - [ ] <observable outcome> (deferred: <backlog-anchor>)
 
 where <backlog-anchor> resolves to a heading in `docs/backlog.md`.
+
+Optional story trace: when this spec was derived from a product brief that
+carries user stories (Shape B; see receive-brief), append `Satisfies: US-n`
+to each acceptance criterion that satisfies that story, so coverage is
+story-granular:
+
+- [x] <observable outcome>. Satisfies: US-2
+
+The marker is optional — omit it for a no-stories brief (Shape A) or a spec
+authored directly.
 -->
 
 ## Assumptions

--- a/.claude/skills/receive-brief/SKILL.md
+++ b/.claude/skills/receive-brief/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: receive-brief
+description: Use this skill when the user receives an externally-authored, multi-feature product brief -- a PRD, a solution handoff, a requirements packet -- and needs to turn it into shippable specs. Triggers on "receive a brief", "decompose this PRD", "we got a product brief", "break this handoff into specs". Elicits the load-bearing fields without mandating a schema, decomposes by shippability, and executes each slice through new-spec then work-loop. Do NOT use to author a single feature from scratch (use new-spec) or to record a decision (use new-adr).
+---
+
+# Skill: receive-brief
+
+Receive a product brief — a PRD, a solution handoff, a packet of work product
+handed from someone else — and route it into delivery. A brief spans several
+features and carries the *what/why*; a spec is one feature and carries the
+*how*. `new-spec` authors one feature; this skill is the inbox a level above
+it: **elicit** what the brief is missing, **decompose** it into
+independently-shippable slices, and **execute** each slice through the normal
+`new-spec` → `work-loop` pipeline. The brief becomes a live tracker whose
+coverage rolls up from the specs it spawned.
+
+## When to invoke
+
+Invoke when the unit of work that arrives is **bigger than one feature** and
+authored by someone other than the implementer — product hands engineering a
+brief. If the user is authoring a single feature themselves, that's `new-spec`,
+not this skill. If they want to record a decision already made, that's
+`new-adr`. The tell is multiplicity: one outcome, several features, no home.
+
+A brief lives at `docs/product/briefs/<slug>.md`. Copy the bundled template
+(your installer places a `_template.md` in that directory) and fill what you
+have. The shape is a guide, not a gate — see the Elicit stage.
+
+## Two shapes, one toggle
+
+The only structural choice is whether the brief carries **user stories**:
+
+- **Shape A — no stories.** You derive spec boundaries from the Outcome and
+  Scope, and surface the cut for confirmation. Coverage is **spec-granular**
+  ("is `password-reset` shipped?"). Stories still exist — they're written as
+  each spec's acceptance criteria when the spec is authored.
+- **Shape B — story list.** The brief lists stories with ids (`US-1`, `US-2`,
+  …). Decomposition is *grouping stories into specs*. Each satisfying
+  acceptance criterion carries a `Satisfies: US-n` marker, so coverage is
+  **story-granular** ("US-2 → `password-reset` AC3 → shipped"). A story too
+  big to fit one feature-sized spec is an epic — flag it for splitting.
+
+Both shapes run the same three stages below. The toggle changes traceability
+granularity, not the pipeline.
+
+## Procedure
+
+### 1. Elicit — meet the brief where it is
+
+Ingest whatever the user has: a pasted document, a file, a link, or a verbal
+sketch. Then fill the brief template by **conversation**, not by rejection.
+
+- **Insist on only the load-bearing fields: Outcome and Scope.** Without the
+  outcome you can't tell whether a slice serves the brief; without scope (and
+  non-goals) the decomposition sprawls. Ask for these until you have them.
+- **Offer the rest; never require it.** Success metrics, appetite, and stories
+  improve the cut but are not gates. Suggest a default ("no metrics given — I'll
+  propose p95 latency and ticket volume; correct me") rather than blocking.
+- **Surface gaps; never invent.** If the brief is silent on something
+  load-bearing, say so and ask. Do not fabricate an outcome or quietly drop a
+  requirement to make the brief parse.
+- **Never mandate a schema.** A half-formed brief is normal input. The template
+  is a prompt sheet, not a form to be rejected for missing sections.
+
+Record the result in `docs/product/briefs/<slug>.md`. Carry the optional
+`Epic:` pointer if this repo's work is one slice of a larger cross-repo effort
+— that pointer is the *only* nod to the wider epic; you own this repo's slice
+and nothing above it.
+
+### 2. Decompose — cut by shippability, then surface the cut
+
+Cut the brief into slices, each of which is **independently shippable and
+independently testable** — a feature `work-loop` can carry end to end. This is
+the shippability test, **not** a component or layer split: "auth service" and
+"auth UI" are not two slices unless each ships and tests on its own.
+
+- In **Shape A**, derive slice boundaries from Outcome + Scope.
+- In **Shape B**, group the stories into slices; each slice becomes one spec.
+- **Flag any epic-sized story** — one that can't fit a single feature-sized
+  spec — for splitting before you scaffold. Ask before treating it as one spec.
+- **Flag any outcome no slice covers** as a gap, and surface it. Don't silently
+  drop an outcome to make the decomposition tidy.
+
+**Surface the proposed cut and wait for confirmation before scaffolding any
+spec.** Present the slices, what each delivers, and (Shape B) which stories
+each carries. The decomposition is judgment; the human signs off on it.
+
+### 3. Execute — scaffold, back-link, hand off
+
+For each confirmed slice, in dependency order:
+
+1. **Chain `new-spec`** to scaffold the slice's `spec.md` + `plan.md`. Pass the
+   slice's outcome and scope so `new-spec`'s assumption-surfacing starts from
+   the brief, not a blank page.
+2. **Stamp the `Brief:` back-link** on the derived spec — set it to this
+   brief's slug. In **Shape B**, also stamp `Satisfies: US-n` on each
+   acceptance criterion that satisfies a story, so the trace is bidirectional.
+3. **Add a row to the brief's Spec map** for the new slice (the Status column
+   is auto-derived — leave it to the lint; do not hand-write it).
+4. **Hand off to `work-loop`** to build the slice. The brief is thus
+   *executable*: brief → (spec, plan) × N → work-loop.
+
+You don't have to scaffold every slice at once — a brief can grow its Spec map
+over time as slices are picked up. A spec may even predate its brief; the
+`Brief:` back-link is what ties them together, not directory nesting.
+
+## Coverage — auto-rolled-up, never hand-maintained
+
+The brief's **Spec map** answers "is this brief delivered?" and stays current
+on its own. The bundled coverage lint at `scripts/lint-brief-coverage.py`
+reads every spec's `Status:` field, follows the `Brief:` back-links, and rolls
+each brief's map up from its children:
+
+- A brief whose every mapped spec is `Shipped` reports **delivered**.
+- A brief whose map has no mapped specs reports **not delivered** — an empty
+  map is never vacuously delivered.
+- A spec that back-links a brief but isn't in that brief's map is reported
+  **untracked** (informational) — add the row; it's not an error.
+
+Run it after a slice's status changes; wire it into your gate if you want it
+enforced. **Never hand-edit the Status column** — a status written by hand
+drifts the moment a spec ships, which is the exact failure this rollup avoids.
+
+See `examples/` for two worked briefs — a no-stories outcome brief (Shape A)
+and a story-list brief (Shape B), each with a populated Spec map.
+
+## Anti-patterns to refuse
+
+- **Mandating a schema / rejecting a half-formed brief.** The shape is a guide.
+  Elicit the load-bearing fields; offer the rest. A brief that arrives missing
+  metrics is normal, not invalid.
+- **Decomposing by component or layer instead of shippability.** "Backend,
+  then frontend" is not two slices; "the slice that lets a user reset their
+  password, end to end" is. If a slice can't ship and test on its own, it's not
+  a slice yet.
+- **Scaffolding before the cut is confirmed.** The decomposition is the
+  judgment call the human most needs to see. Surface it; don't present N specs
+  as a fait accompli.
+- **Building a cross-repo coordination hub.** You own this repo's slice. Point
+  upward with the optional `Epic:` pointer; do not reimplement a tracker.
+- **Hand-maintaining the coverage map.** The Status column is derived. Editing
+  it by hand reintroduces the drift the lint exists to prevent.
+- **Cramming a multi-feature brief into one oversized spec.** That breaks the
+  one-feature sizing rule and the per-spec `work-loop`. If it's several
+  features, it's several specs.

--- a/.claude/skills/receive-brief/examples/shape-a-outcome-brief.md
+++ b/.claude/skills/receive-brief/examples/shape-a-outcome-brief.md
@@ -1,0 +1,59 @@
+# Brief: Self-service password reset
+
+> **This is an example, not a schema.** It demonstrates **Shape A** — a
+> no-stories *outcome* brief, where spec boundaries are derived from the
+> Outcome and Scope and coverage is spec-granular. The fields and the Spec map
+> show the expected shape; copy the structure, not the content. Your real brief
+> may have fewer or more sections — the `receive-brief` skill elicits what's
+> missing rather than rejecting a brief for not matching this exactly.
+
+- **Slug:** `self-service-password-reset`
+- **Received:** 2026-05-18
+- **Owner:** platform team
+- **Epic:** ACME-2231 <!-- this slice is part of a larger "reduce support load" epic tracked in the company tracker; we own only the password-reset portion -->
+
+## Outcome
+
+Users who forget their password can't get back in without filing a support
+ticket, and password-reset tickets are the single largest category in the
+support queue. We want a user to reset their own password end to end — request
+a reset, verify by email, set a new password — without any human in the loop.
+
+## Success metrics
+
+- Password-reset support tickets down 60% within one quarter of launch.
+- 90% of reset attempts complete without contacting support.
+- Median time from "forgot password" to "logged in again" under 5 minutes.
+
+## Scope / Non-goals
+
+**In scope:**
+
+- Email-based reset request and verification.
+- Setting a new password that meets the existing password policy.
+- Rate-limiting and basic abuse protection on the reset endpoint.
+
+**Non-goals:**
+
+- SMS or authenticator-app recovery (a later brief may add these).
+- Changing the password policy itself.
+- Admin-initiated resets (already covered by the admin console).
+
+## Appetite
+
+A few weeks, not a quarter. If the verification flow turns out to need a new
+identity provider integration, that's a separate brief — flag it, don't absorb
+it here.
+
+## Spec map
+
+<!-- No stories (Shape A): one row per derived spec, coverage is spec-granular.
+The Status column is auto-derived by the coverage lint from each spec's own
+Status field — shown here filled in so you can see the rolled-up shape. This
+brief is NOT yet delivered: account-lockout-recovery is still Implementing. -->
+
+| Spec | Status |
+| --- | --- |
+| `password-reset-request` | Shipped |
+| `password-reset-verification` | Shipped |
+| `account-lockout-recovery` | Implementing |

--- a/.claude/skills/receive-brief/examples/shape-b-story-list-brief.md
+++ b/.claude/skills/receive-brief/examples/shape-b-story-list-brief.md
@@ -1,0 +1,71 @@
+# Brief: Team billing portal
+
+> **This is an example, not a schema.** It demonstrates **Shape B** — a
+> *story-list* brief, where the brief carries user stories with ids and
+> decomposition is *grouping stories into specs*. Coverage is story-granular:
+> each satisfying acceptance criterion in a derived spec carries a
+> `Satisfies: US-n` marker, and the Spec map gains a `Story` column. The fields
+> and the Spec map show the expected shape; copy the structure, not the
+> content. `receive-brief` elicits what's missing rather than rejecting a brief
+> that doesn't match this exactly.
+
+- **Slug:** `team-billing-portal`
+- **Received:** 2026-05-20
+- **Owner:** billing team
+- **Epic:** <!-- none; this brief is self-contained, so the pointer is omitted -->
+
+## Outcome
+
+Team admins have no way to manage their own billing — they email us to change
+plans, update payment methods, or download invoices, and every change is a
+manual back-office task. We want admins to manage their team's billing
+themselves from a portal, so billing changes stop being a support workflow.
+
+## Success metrics
+
+- 80% of plan changes and payment-method updates happen self-serve.
+- Back-office billing tasks down 70% within two quarters.
+- Invoice-download requests to support drop to near zero.
+
+## Scope / Non-goals
+
+**In scope:**
+
+- View and change the team's plan.
+- Add, update, and remove payment methods.
+- Download past invoices as PDF.
+
+**Non-goals:**
+
+- Usage-based / metered billing (the current model is seat-based).
+- Multi-currency support.
+- Reselling or partner billing hierarchies.
+
+## Appetite
+
+About six weeks. The invoice PDF rendering is the riskiest piece — if it needs
+a new rendering service, that's its own slice, surfaced for sign-off, not
+silently folded in.
+
+## User stories
+
+- **US-1.** As a team admin, I want to see my current plan and change it, so
+  that I can upgrade or downgrade without emailing support.
+- **US-2.** As a team admin, I want to add and remove payment methods, so that
+  billing keeps working when a card expires.
+- **US-3.** As a team admin, I want to download past invoices as PDFs, so that
+  I can submit them for expense reporting.
+
+## Spec map
+
+<!-- Story-list (Shape B): stories are grouped into specs; the `Story` column
+links each row to the US-n it satisfies (the satisfying ACs inside each spec
+carry a `Satisfies: US-n` marker). The Status column is auto-derived by the
+coverage lint. This brief is NOT yet delivered: invoice-pdf-export is still
+in Draft. -->
+
+| Spec | Story | Status |
+| --- | --- | --- |
+| `billing-plan-management` | US-1 | Shipped |
+| `payment-method-management` | US-2 | Implementing |
+| `invoice-pdf-export` | US-3 | Draft |

--- a/.claude/skills/receive-brief/scripts/lint-brief-coverage.py
+++ b/.claude/skills/receive-brief/scripts/lint-brief-coverage.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Brief-coverage auto-rollup lint.
+
+This is a `receive-brief` **skill script**: it lives at
+`packs/core/.apm/skills/receive-brief/scripts/lint-brief-coverage.py` and
+projects to every adapter's `.../skills/receive-brief/scripts/`, the same way
+the work-loop's `lint-spec-status.py` does. The agent runs it after a slice's
+status changes; the catalogue additionally runs it as a **fail-closed CI gate**
+via `make build-check`. It no-ops gracefully where Python is absent.
+
+What it does: reads every `docs/specs/*/spec.md` `Status:` field, follows the
+`Brief:` back-links, and rolls each brief's Spec map up from its child specs —
+so "is this brief delivered?" stays answerable with no hand-maintenance. It
+reads only existing `Status:` fields and the brief's Spec map; it introduces no
+new state.
+
+Rollup rules:
+  - A brief is *delivered* only when its Spec map is non-empty AND every mapped
+    spec is `Shipped`. An empty map is never vacuously delivered.
+  - A spec that back-links a brief (`Brief: <slug>`) but is absent from that
+    brief's Spec map is reported **untracked** — informational, never an error.
+  - A `docs/product/briefs/_template.md` (or any `_`-prefixed file) is the
+    shipped template, not a brief; it is skipped.
+
+Exit codes:
+  0 = clean (coverage reported; warnings/untracked allowed).
+  1 = drift: a brief's Spec map records a status that contradicts the spec's
+      actual `Status:` (a hand-edited, now-stale cell). The Status column is
+      auto-derived and must not be hand-maintained — drift is the failure this
+      lint exists to catch. An unset cell (`<auto>`, `—`, `-`, or empty) means
+      "not yet derived" and is reported, not failed.
+
+No briefs found → exit 0 with no diagnostic output (the common case in a repo
+that ships no brief). Usage: lint-brief-coverage.py [--root DIR]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Header status / brief / slug lines, e.g. `- **Status:** Shipped (2026-05-26)`.
+_STATUS_RE = re.compile(r"\*\*Status:\*\*\s*(.+?)\s*$")
+_BRIEF_RE = re.compile(r"\*\*Brief:\*\*\s*(.+?)\s*$")
+_SLUG_RE = re.compile(r"\*\*Slug:\*\*\s*(.+?)\s*$")
+# Recorded-status cells that mean "not yet derived" — reported, never drift.
+_UNSET_CELLS = frozenset({"", "<auto>", "—", "-", "tbd", "todo"})
+
+
+def _is_placeholder(value: str) -> bool:
+    """True for an unset/template value: empty, `none`, an HTML comment, or a
+    bare angle-bracket placeholder (`<slug>`)."""
+    v = value.strip()
+    return (
+        not v
+        or v.lower() == "none"
+        or v.startswith("<!--")
+        or (v.startswith("<") and v.endswith(">"))
+    )
+
+
+def extract_token(raw: str) -> str:
+    """Leading token from a header value, truncating at ` (`, ` →`, or `<!--`.
+
+    Intentionally mirrors lint-spec-status.py's `extract_status_token` (same
+    delimiters) — cross-skill import is banned by this spec's Boundaries, so
+    the two must be kept in lockstep by hand. Reduces annotated statuses
+    (`Shipped (2026-05-26)`, `Approved → Shipped (…)`, `Draft <!-- ... -->`) to
+    their leading word.
+    """
+    text = raw
+    for delim in (" (", " →", "<!--"):
+        idx = text.find(delim)
+        if idx != -1:
+            text = text[:idx]
+    parts = text.strip().split()
+    return parts[0] if parts else ""
+
+
+def parse_spec(spec_text: str) -> tuple[str | None, str | None]:
+    """Return (status-token, brief-back-link-slug) from a spec's header.
+
+    A `Brief:` value that is empty, `none`, or the template HTML-comment
+    placeholder counts as no back-link (None).
+    """
+    status: str | None = None
+    brief: str | None = None
+    for line in spec_text.splitlines():
+        if status is None:
+            m = _STATUS_RE.search(line)
+            if m:
+                status = extract_token(m.group(1))
+        if brief is None:
+            m = _BRIEF_RE.search(line)
+            if m:
+                value = m.group(1).strip()
+                if not _is_placeholder(value):
+                    brief = extract_token(value).strip("`")
+    return status, brief
+
+
+def parse_brief_slug(brief_text: str, fallback: str) -> str:
+    """Return the brief's canonical slug from its `- **Slug:**` field.
+
+    A derived spec's `Brief:` back-link names this slug, which need not equal
+    the brief's filename stem — so the slug, not the stem, is the join key for
+    coverage and untracked detection. Falls back to `fallback` (the filename
+    stem) only when no usable `Slug:` field is present.
+    """
+    for line in brief_text.splitlines():
+        m = _SLUG_RE.search(line)
+        if m:
+            value = m.group(1).strip().strip("`")
+            if not _is_placeholder(value):
+                return extract_token(value).strip("`")
+    return fallback
+
+
+def parse_spec_map(brief_text: str) -> list[tuple[int, str, str]]:
+    """Return (lineno, spec-slug, recorded-status) for each Spec map row.
+
+    Parses the markdown table under the `## Spec map` heading. The first
+    table column is the spec slug; the LAST column is the recorded status
+    (so a Shape-B map with a middle `Story` column parses the same way).
+    The header row and the `| --- |` separator row are skipped.
+    """
+    rows: list[tuple[int, str, str]] = []
+    in_section = False
+    for lineno, line in enumerate(brief_text.splitlines(), start=1):
+        if re.match(r"^##\s+Spec map\b", line, re.IGNORECASE):
+            in_section = True
+            continue
+        if in_section and re.match(r"^##\s+", line):
+            break
+        # Only a markdown table row counts — it must start with `|`. This
+        # ignores explanatory prose under the heading that happens to contain a
+        # pipe (which would otherwise parse as a phantom row and trip drift).
+        if not in_section or not line.lstrip().startswith("|"):
+            continue
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if len(cells) < 2:
+            continue
+        first = cells[0].strip("` ")
+        last = cells[-1].strip("` ")
+        # Skip the header row and the `| --- | --- |` separator row.
+        if first.lower() == "spec" or set(first) <= set("-: "):
+            continue
+        rows.append((lineno, first, last))
+    return rows
+
+
+def check(root: Path) -> tuple[list[str], list[str]]:
+    """Return (lines_to_print, hard_violations)."""
+    briefs_dir = root / "docs" / "product" / "briefs"
+    if not briefs_dir.is_dir():
+        return [], []
+
+    brief_files = [
+        p for p in sorted(briefs_dir.glob("*.md")) if not p.name.startswith("_")
+    ]
+    if not brief_files:
+        return [], []
+
+    # Index specs by slug → (status, brief-back-link).
+    specs: dict[str, tuple[str | None, str | None]] = {}
+    specs_dir = root / "docs" / "specs"
+    for spec_path in sorted(specs_dir.glob("*/spec.md")):
+        slug = spec_path.parent.name
+        specs[slug] = parse_spec(
+            spec_path.read_text(encoding="utf-8", errors="replace")
+        )
+
+    out: list[str] = []
+    hard: list[str] = []
+
+    for brief_path in brief_files:
+        text = brief_path.read_text(encoding="utf-8", errors="replace")
+        # The slug (from the `Slug:` field), not the filename stem, is the
+        # identity a spec's `Brief:` back-link names — see parse_brief_slug.
+        brief_slug = parse_brief_slug(text, brief_path.stem)
+        rel = brief_path.relative_to(root).as_posix()
+        rows = parse_spec_map(text)
+
+        mapped = {slug for _, slug, _ in rows if slug}
+        derived: list[str] = []
+        for lineno, spec_slug, recorded in rows:
+            if not spec_slug:
+                continue
+            status = specs.get(spec_slug, (None, None))[0]
+            actual = status if status else "missing"
+            derived.append(actual)
+            # Normalise the recorded cell the same way as the actual status
+            # (leading token) so an annotated cell like `Shipped (2026-06-01)`
+            # isn't misreported as drift against a derived `Shipped`.
+            recorded_norm = extract_token(recorded).strip("`").lower()
+            if recorded_norm not in _UNSET_CELLS and recorded_norm != actual.lower():
+                hard.append(
+                    f"{rel}:{lineno}: spec '{spec_slug}' recorded '{recorded}' "
+                    f"but its Status is '{actual}' — the Spec map is stale "
+                    f"(auto-derived; do not hand-edit the Status column)"
+                )
+
+        # Case-insensitive so a lowercase `shipped` token agrees with the drift
+        # check (which is also case-insensitive) on the delivered verdict.
+        delivered = bool(mapped) and all(s.lower() == "shipped" for s in derived)
+        out.append(
+            f"lint-brief-coverage: brief '{brief_slug}': "
+            f"{'delivered' if delivered else 'not delivered'}"
+        )
+        for _, spec_slug, _ in rows:
+            if spec_slug:
+                status = specs.get(spec_slug, (None, None))[0]
+                out.append(f"  - {spec_slug}: {status if status else 'missing'}")
+
+        # Untracked: specs that back-link this brief but aren't in its map.
+        untracked = sorted(
+            slug for slug, (_, back) in specs.items()
+            if back == brief_slug and slug not in mapped
+        )
+        for slug in untracked:
+            out.append(
+                f"  - {slug}: untracked (back-links this brief, not in Spec map)"
+            )
+
+    out.append(f"lint-brief-coverage: {len(brief_files)} brief(s) checked.")
+    return out, hard
+
+
+def _repo_root() -> Path:
+    # Best-effort discovery for a bare manual run. The gate (`make build-check`)
+    # and every self-test pass `--root` explicitly, so this only fires for a
+    # hand-run with no `--root`; prefer git's toplevel when available.
+    try:
+        r = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=False,
+        )
+        if r.returncode == 0 and r.stdout.strip():
+            return Path(r.stdout.strip())
+    except FileNotFoundError:
+        pass
+    return Path(__file__).resolve().parent.parent
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=None)
+    args = parser.parse_args(argv)
+    root = args.root.resolve() if args.root else _repo_root()
+
+    out, hard = check(root)
+
+    for line in out:
+        print(line)
+    if hard:
+        for v in hard:
+            print(f"lint-brief-coverage: {v}", file=sys.stderr)
+        print(
+            f"lint-brief-coverage: {len(hard)} stale Spec-map cell(s).",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/receive-brief/scripts/test-lint-brief-coverage.py
+++ b/.claude/skills/receive-brief/scripts/test-lint-brief-coverage.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Self-test for the sibling lint-brief-coverage.py (the brief-coverage rollup).
+
+Builds fixture brief + spec trees in a tempdir and runs the linter as a
+subprocess against the documented `python <skill>/scripts/lint-brief-coverage.py
+--root <dir>` invocation — the same shape `make build-check` uses (not a
+synthesised import, so the real `from .X import Y`-free entry point is
+exercised). Covers each acceptance case red-and-green: rollup of a mixed map,
+all-Shipped → delivered, empty map → not delivered, no-brief no-op, untracked
+back-link as informational, and a hand-edited stale cell as the fail-closed
+drift case.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+LINTER = Path(__file__).resolve().parent / "lint-brief-coverage.py"
+
+FAILURES: list[str] = []
+
+
+def expect(cond: bool, msg: str) -> None:
+    if not cond:
+        FAILURES.append(msg)
+
+
+def write_spec(root: Path, slug: str, status: str, brief: str | None = None) -> None:
+    p = root / "docs" / "specs" / slug / "spec.md"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    header = f"# Spec: {slug}\n\n- **Status:** {status}\n"
+    if brief is not None:
+        header += f"- **Brief:** {brief}\n"
+    header += "\n## Acceptance Criteria\n\n- [ ] AC1\n"
+    p.write_text(header, encoding="utf-8")
+
+
+def write_brief(root: Path, slug: str, rows: list[tuple[str, str]], stem: str | None = None) -> None:
+    """Write a brief with a two-column Spec map. `rows` is (spec-slug, recorded-status)."""
+    name = stem if stem is not None else slug
+    p = root / "docs" / "product" / "briefs" / f"{name}.md"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    body = f"# Brief: {slug}\n\n- **Slug:** `{slug}`\n\n## Spec map\n\n"
+    body += "| Spec | Status |\n| --- | --- |\n"
+    for spec_slug, recorded in rows:
+        body += f"| `{spec_slug}` | {recorded} |\n"
+    p.write_text(body, encoding="utf-8")
+
+
+def run_lint(root: Path) -> tuple[int, str, str]:
+    proc = subprocess.run(
+        [sys.executable, str(LINTER), "--root", str(root)],
+        capture_output=True, text=True,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def case_mixed_map_not_delivered() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_spec(root, "alpha", "Shipped", brief="myb")
+        write_spec(root, "beta", "Implementing", brief="myb")
+        write_brief(root, "myb", [("alpha", "Shipped"), ("beta", "Implementing")])
+        rc, out, err = run_lint(root)
+        expect(rc == 0, f"mixed map should exit 0, got {rc}: {err}")
+        expect("shipped" in out.lower(), f"alpha should roll up shipped: {out}")
+        expect("implementing" in out.lower(), f"beta should roll up implementing: {out}")
+        expect("not delivered" in out.lower(), f"mixed map → not delivered: {out}")
+
+
+def case_all_shipped_delivered() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_spec(root, "alpha", "Shipped", brief="myb")
+        write_spec(root, "beta", "Shipped", brief="myb")
+        write_brief(root, "myb", [("alpha", "Shipped"), ("beta", "Shipped")])
+        rc, out, err = run_lint(root)
+        expect(rc == 0, f"all-shipped should exit 0, got {rc}: {err}")
+        # "': delivered" disambiguates from "': not delivered".
+        expect("': delivered" in out, f"all-shipped brief → delivered: {out}")
+
+
+def case_empty_map_not_delivered() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_brief(root, "emptyb", [])
+        rc, out, err = run_lint(root)
+        expect(rc == 0, f"empty map should exit 0, got {rc}: {err}")
+        expect("not delivered" in out.lower(),
+               f"empty map is never vacuously delivered: {out}")
+        expect("': delivered" not in out,
+               f"empty map must NOT report delivered: {out}")
+
+
+def case_no_brief_noop() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_spec(root, "alpha", "Shipped")  # spec but no brief
+        rc, out, err = run_lint(root)
+        expect(rc == 0, f"no brief should exit 0, got {rc}: {err}")
+        expect(err.strip() == "", f"no brief → no diagnostic on stderr: {err!r}")
+        expect(out.strip() == "", f"no brief → no diagnostic on stdout: {out!r}")
+
+
+def case_template_skipped() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        # A `_template.md` placeholder in the briefs dir must NOT be treated
+        # as a real brief (it ships with the pack and projects into repos).
+        write_brief(root, "<one-line outcome>", [("<feature-slug>", "<auto>")],
+                    stem="_template")
+        rc, out, err = run_lint(root)
+        expect(rc == 0, f"template-only briefs dir should exit 0, got {rc}: {err}")
+        expect(out.strip() == "" and err.strip() == "",
+               f"_template.md must be skipped (no diagnostic): out={out!r} err={err!r}")
+
+
+def case_untracked_backlink_informational() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        # gamma back-links myb but is NOT in myb's Spec map → untracked.
+        write_spec(root, "alpha", "Shipped", brief="myb")
+        write_spec(root, "gamma", "Draft", brief="myb")
+        write_brief(root, "myb", [("alpha", "Shipped")])
+        rc, out, err = run_lint(root)
+        combined = (out + err).lower()
+        expect(rc == 0, f"untracked back-link must NOT be an error, got {rc}: {err}")
+        expect("untracked" in combined, f"gamma should be reported untracked: {out}{err}")
+        expect("gamma" in combined, f"untracked spec named: {out}{err}")
+
+
+def case_stale_cell_drifts_fail_closed() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        # beta is actually Shipped, but the brief's Spec map still records
+        # Implementing — a hand-edited stale cell. Fail closed.
+        write_spec(root, "alpha", "Shipped", brief="myb")
+        write_spec(root, "beta", "Shipped", brief="myb")
+        write_brief(root, "myb", [("alpha", "Shipped"), ("beta", "Implementing")])
+        rc, out, err = run_lint(root)
+        expect(rc == 1, f"stale recorded cell should exit 1, got {rc}: {out}")
+        expect("stale" in err.lower(), f"drift message should name staleness: {err}")
+        expect("beta" in err, f"drift message should name the spec: {err}")
+
+
+def case_unset_cell_is_not_drift() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        # An `<auto>` / unset cell means "not yet derived" — report, don't fail.
+        write_spec(root, "alpha", "Implementing", brief="myb")
+        write_brief(root, "myb", [("alpha", "<auto>")])
+        rc, out, err = run_lint(root)
+        expect(rc == 0, f"unset <auto> cell must not be drift, got {rc}: {err}")
+        expect("implementing" in out.lower(), f"derived status still reported: {out}")
+
+
+def case_slug_differs_from_filename() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        # The brief's Slug field (real-slug) differs from its filename stem
+        # (shape-a) — the shipped examples do exactly this. A spec back-links
+        # the SLUG; untracked detection must join on the slug, not the stem.
+        write_spec(root, "gamma", "Draft", brief="real-slug")
+        write_brief(root, "real-slug", [("alpha", "<auto>")], stem="shape-a")
+        rc, out, err = run_lint(root)
+        combined = (out + err).lower()
+        expect(rc == 0, f"untracked is informational, got {rc}: {err}")
+        expect("gamma" in combined and "untracked" in combined,
+               f"gamma back-links by slug, must be untracked: {out}{err}")
+
+
+def case_prose_pipe_after_table_is_not_a_row() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_spec(root, "alpha", "Shipped", brief="myb")
+        p = root / "docs" / "product" / "briefs" / "myb.md"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(
+            "# Brief: myb\n\n- **Slug:** `myb`\n\n## Spec map\n\n"
+            "| Spec | Status |\n| --- | --- |\n| `alpha` | Shipped |\n\n"
+            "Note: rows are added as slices ship | one per spec.\n",
+            encoding="utf-8",
+        )
+        rc, out, err = run_lint(root)
+        expect(rc == 0, f"prose pipe must not trip drift exit 1, got {rc}: {err}")
+        expect("stale" not in err.lower(), f"no phantom drift row: {err}")
+
+
+def case_lowercase_status_token_still_delivers() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_spec(root, "alpha", "shipped", brief="myb")  # lowercase token
+        write_brief(root, "myb", [("alpha", "Shipped")])
+        rc, out, err = run_lint(root)
+        expect(rc == 0, f"no drift expected, got {rc}: {err}")
+        expect("': delivered" in out,
+               f"lowercase 'shipped' must still count as delivered: {out}")
+
+
+def case_placeholder_brief_value_ignored() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_spec(root, "alpha", "Draft", brief="<slug>")  # template placeholder
+        write_brief(root, "myb", [("beta", "<auto>")])
+        rc, out, err = run_lint(root)
+        combined = out + err
+        expect(rc == 0, f"placeholder back-link must not error, got {rc}: {err}")
+        expect("<slug>" not in combined,
+               f"placeholder must not surface as a tracked/untracked slug: {combined}")
+
+
+def case_annotated_recorded_cell_not_drift() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        # A recorded cell annotated the same way a spec's own Status field may
+        # be (`Shipped (2026-06-01)`) must not misreport as drift against a
+        # derived `Shipped` — the recorded side is normalized symmetrically.
+        write_spec(root, "alpha", "Shipped", brief="myb")
+        write_brief(root, "myb", [("alpha", "Shipped (2026-06-01)")])
+        rc, out, err = run_lint(root)
+        expect(rc == 0, f"annotated recorded cell must not drift, got {rc}: {err}")
+        expect("stale" not in err.lower(), f"no false drift on annotated cell: {err}")
+        expect("': delivered" in out, f"annotated-cell brief still delivered: {out}")
+
+
+def main() -> int:
+    for case in (
+        case_mixed_map_not_delivered,
+        case_annotated_recorded_cell_not_drift,
+        case_all_shipped_delivered,
+        case_empty_map_not_delivered,
+        case_no_brief_noop,
+        case_template_skipped,
+        case_untracked_backlink_informational,
+        case_stale_cell_drifts_fail_closed,
+        case_unset_cell_is_not_drift,
+        case_slug_differs_from_filename,
+        case_prose_pipe_after_table_is_not_a_row,
+        case_lowercase_status_token_still_delivers,
+        case_placeholder_brief_value_ignored,
+    ):
+        case()
+    if FAILURES:
+        for f in FAILURES:
+            print(f"FAIL: {f}", file=sys.stderr)
+        print(f"test-lint-brief-coverage: {len(FAILURES)} failure(s).", file=sys.stderr)
+        return 1
+    print("test-lint-brief-coverage: all cases pass.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,11 @@ build-check: lint-packs build
 	# the projected loop-cohort.py). NOT wired into the projected pre-pr.py hook.
 	$(PYTHON) .claude/skills/work-loop/scripts/test-lint-spec-status.py
 	$(PYTHON) .claude/skills/work-loop/scripts/lint-spec-status.py
+	# Brief-coverage auto-rollup gate (receive-brief skill script). Same shape
+	# as the spec-status pair above: run the PROJECTED self-test then the lint.
+	# No-ops on this repo (it ships no brief); fail-closed on a stale Spec map.
+	$(PYTHON) .claude/skills/receive-brief/scripts/test-lint-brief-coverage.py
+	$(PYTHON) .claude/skills/receive-brief/scripts/lint-brief-coverage.py
 
 build-scaffold:
 	@test -n "$(OUTPUT)" || (echo "make build-scaffold OUTPUT=<dir> required" >&2; exit 1)

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -50,6 +50,7 @@ below assigns every kind of doc to exactly one bucket.
    │  organized today.        │      │  doing today.              │
    │  Living. For contributors│      │  Living. For maintainers.  │
    │                          │      │  - roadmap.md              │
+   │                          │      │  - briefs/<slug>.md        │
    │                          │      │  - changelog.md            │
    │                          │      │  - personas.md (optional)  │
    └──────────────────────────┘      └────────────────────────────┘
@@ -66,6 +67,19 @@ below assigns every kind of doc to exactly one bucket.
 
 The bottom layers cite the upper layers; upper layers do not know about
 lower layers. That's the whole point of the hierarchy.
+
+**The brief altitude.** A *brief* (`product/briefs/<slug>.md`) sits between
+the roadmap and the specs — it is where an externally-authored, multi-feature
+product handoff (a PRD, a solution packet) lands when it's too big to be one
+spec. The altitude reads `roadmap → brief → spec → AC`: the roadmap names
+themes, a brief records one received outcome and the specs that deliver it, a
+spec is the engineering contract for one feature, and an acceptance criterion
+is the testable unit. A brief owns only **this repo's slice**; an optional
+`Epic:` field points up to an external coordinator when the work spans repos.
+A derived spec links back to its brief with a `Brief:` field (see § 4), and
+the brief's coverage map rolls up automatically from those specs' `Status:`
+fields. Use the `receive-brief` skill to receive, decompose, and execute a
+brief; it never mandates a schema.
 
 ---
 
@@ -270,6 +284,17 @@ mechanical rule.
   open work. Form: `- [ ] <outcome> (deferred: <backlog-anchor>)`. A deferral
   recorded only in a PR comment rots; the register is version-controlled and
   greppable.
+- **Brief back-link (optional).** A spec derived from a product brief carries a
+  `- **Brief:**` header naming that brief (`product/briefs/<slug>.md`). It
+  records *product provenance* and is distinct from `Constrained by:` (which
+  cites the ADRs/RFCs that govern the spec). The field is additive and optional
+  — a spec authored directly omits it and stays valid. The brief's coverage map
+  rolls up from these back-links automatically; never hand-write a spec's status
+  into the brief.
+- **Story trace (optional).** When the brief carries user stories (Shape B), an
+  acceptance criterion that satisfies a story appends a `Satisfies: US-n` marker
+  so coverage is story-granular. Optional — omit it for a no-stories brief or a
+  directly-authored spec.
 
 ### Contract vs. construction tests
 
@@ -387,6 +412,10 @@ right now?"
 - `changelog.md` — user-visible changes by release, in
   [Keep a Changelog](https://keepachangelog.com/) format. Updated in the
   same PR as any user-visible behavior change.
+- `briefs/<slug>.md` (optional) — a received, externally-authored
+  multi-feature product brief and its auto-rolled-up coverage map. Created by
+  the `receive-brief` skill; one file per brief. See the brief altitude under
+  *Document hierarchy*.
 - `personas.md` (optional) — who we're building for. Add only if it's
   actively used to make decisions; speculative personas rot.
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -282,3 +282,17 @@ of their own yet.
   adopter-shipping — demote to catalogue-local / retire in favour of the how-to —
   against `credential-broker-contract` AC27/AC43 and RFC-0013 §7. Not touched by
   `adopter-clean-enforcement-gate` (that spec owns these primitives).
+
+---
+
+## `product-brief-intake`
+
+- **Follow-up (reviewer-flagged, not an unmet AC):** the adopter-facing
+  leak guard (no `agent-ready-repo` / `RFC-NNNN` / catalogue-spec-name) is
+  enforced by `tools/lint-seeds.py` for **seed** files only. The shipped
+  `receive-brief/SKILL.md` and `receive-brief/examples/*.md` live under
+  `packs/core/.apm/skills/` and are outside that lint's scope — clean today by
+  inspection, but unguarded against regression. Extend the seed-content
+  blocklist (or `tools/lint-agent-artifacts.py`) to cover shipped-skill bodies
+  and `examples/`. Pre-existing catalogue gap surfaced by this spec, not
+  introduced by it.

--- a/docs/guides/explanation/why-a-brief-layer.md
+++ b/docs/guides/explanation/why-a-brief-layer.md
@@ -1,0 +1,95 @@
+# Why a brief layer
+
+Spec-driven delivery gives you a clean path from "we should build X" to "X is
+shipped": `new-spec` writes one feature's contract, `work-loop` builds it. A
+spec is sized to one feature, built in days or weeks. That shape is deliberate
+— and it has an edge.
+
+This page explains the edge, why a **brief** sits above the spec to cover it,
+and why the brief looks the way it does. For how to use the brief, see
+[Receive a product brief and decompose it into specs](../how-to/receive-a-product-brief-and-decompose-it-into-specs.md);
+for the field list, see
+[Product brief fields](../reference/product-brief-fields.md).
+
+## The gap: there's no inbox for a handoff
+
+Not every team authors all its own work. Where the product and engineering
+functions are separate — most enterprises — engineering *receives* work:
+someone hands over a product brief, a PRD, a solution document that spans
+several features and months of effort.
+
+A spec can't hold that. A spec is one feature, days to weeks, and `work-loop`
+runs per spec. A multi-feature brief provably cannot be a single spec without
+breaking both the sizing rule and the build loop. So a multi-feature handoff
+*structurally forces* a layer above the spec — and without one, you're left
+with two bad options:
+
+- **Cram it into one oversized spec.** It breaks the sizing rule, and the build
+  loop has nothing coherent to chew on.
+- **Fire `new-spec` N times by hand.** Nothing records *why* the work exists,
+  *how* it was decomposed, or *whether the whole thing is delivered*.
+
+The brief is the missing inbox.
+
+## The altitude: roadmap → brief → spec → AC
+
+The brief slots into the document hierarchy between the roadmap and the specs:
+
+```
+roadmap   forward-looking themes        →  references briefs
+  brief    one received outcome + the specs that deliver it
+    spec   the engineering contract for one feature
+      AC   the testable unit
+```
+
+The roadmap names themes. A brief records *one received outcome* and the specs
+that deliver it. A spec is the contract for one feature. An acceptance
+criterion is the testable unit. Each layer cites the one above it; none knows
+about the layer below. The brief carries the *what/why* of the handoff; the
+spec stays the *how*.
+
+## Why these design choices
+
+- **It executes — it isn't just a document.** The brief earns its place by
+  *doing* something: `receive-brief` decomposes it into specs and hands each to
+  `work-loop`. A brief that only described work would rot. One that spawns and
+  tracks work stays alive.
+
+- **Coverage is auto-derived, never hand-maintained.** The brief's Spec map
+  rolls up from each spec's own `Status:` field via the `Brief:` back-links. A
+  hand-written status drifts the moment a spec ships — so the coverage lint
+  derives the truth and fails closed on a stale cell. "Is this brief
+  delivered?" stays answerable for free.
+
+- **It elicits; it doesn't mandate a schema.** Real briefs arrive half-formed.
+  Rejecting them for missing a section would just push the friction back onto
+  the person handing over the work. The skill insists only on the load-bearing
+  fields (outcome, scope), offers the rest, and surfaces gaps.
+
+- **It owns one repo's slice, not a coordination hub.** Coordinating an epic
+  across repos is a tracker's job (a project board, an integration repo). The
+  brief integrates with that via an optional `Epic:` pointer and stops there —
+  building a hub would duplicate tools you already have and break the
+  single-repo model.
+
+- **Linkage is by reference, not nesting.** A spec names its brief with a
+  `Brief:` field rather than living inside a brief directory. Specs stay flat,
+  a spec can predate its brief, and one brief can gather specs authored over
+  time — the same way many specs can reference one shared contract.
+
+## What it deliberately is not
+
+- **Not a portfolio layer.** One received brief is the ceiling. Rolling many
+  briefs up into an initiative is a tracker's job, not this layer's.
+- **Not a replacement for the roadmap or backlog.** The brief slots between
+  them; both keep their jobs. The roadmap references briefs; backlog items roll
+  up to them.
+- **Not a new design tier.** The brief is *what/why*. The engineering *how* —
+  including any low-level design — stays in the spec and its plan.
+
+## See also
+
+- [Receive a product brief and decompose it into specs](../how-to/receive-a-product-brief-and-decompose-it-into-specs.md)
+- [Product brief fields](../reference/product-brief-fields.md)
+- [The core pack as a system](core-pack.md) — where `receive-brief` sits among
+  the other core skills.

--- a/docs/guides/how-to/receive-a-product-brief-and-decompose-it-into-specs.md
+++ b/docs/guides/how-to/receive-a-product-brief-and-decompose-it-into-specs.md
@@ -1,0 +1,115 @@
+# How to receive a product brief and decompose it into specs
+
+Someone handed you a product brief — a PRD, a solution document, a packet of
+requirements that spans several features — and you need to turn it into work
+your team can actually ship. The `receive-brief` skill (shipped in `core`) is
+the entry point. This guide walks the path from "here's a brief" through
+"feature-sized specs are in the normal build loop and a coverage map tracks
+them automatically."
+
+For the *why* behind a brief sitting between the roadmap and the specs, read
+[Why a brief layer](../explanation/why-a-brief-layer.md). For the exact fields
+a brief and a derived spec carry, see
+[Product brief fields](../reference/product-brief-fields.md). This page is
+task-oriented: what to type and what to expect back.
+
+## Before you start
+
+You need:
+
+- The `core` pack installed in your target repo.
+- A brief in some form — a pasted document, a file, a link, or even a verbal
+  sketch. It does not have to be complete or well-formatted; the skill elicits
+  what's missing.
+- A sense of who owns delivering this repo's slice of the work.
+
+## Is `receive-brief` the right entry point?
+
+| Situation | Skill to invoke |
+| --- | --- |
+| You received a multi-feature brief and need to route it into delivery | `receive-brief` |
+| You're authoring one feature yourself, from scratch | `new-spec` |
+| You're recording a decision already made | `new-adr` |
+
+The tell for `receive-brief` is **multiplicity authored by someone else**: one
+outcome, several features, handed to you. A single feature you're writing
+yourself is `new-spec` directly.
+
+## Steps
+
+1. **Invoke the skill with whatever you have.** "We got a product brief for a
+   billing portal — here it is: …" The skill ingests the document and starts a
+   short conversation; it won't reject a half-formed brief.
+
+2. **Answer the elicitation for the load-bearing fields.** The skill insists on
+   only two things: the **Outcome** (the problem and the user-facing result)
+   and the **Scope / Non-goals** (where this repo's slice begins and ends).
+   Everything else — success metrics, appetite, user stories — it *offers* and
+   you can supply or skip. It surfaces gaps rather than inventing answers.
+
+3. **Confirm the proposed decomposition.** The skill cuts the brief into
+   slices, each one independently shippable and testable, and **shows you the
+   cut before scaffolding anything**. Read it: does each slice ship on its own?
+   Is anything in the brief left uncovered? Is any slice too big for one
+   feature-sized spec? Approve, or push back and have it re-cut.
+
+4. **Let it scaffold and back-link the specs.** For each confirmed slice the
+   skill chains `new-spec` to create `spec.md` + `plan.md`, stamps a `Brief:`
+   back-link on the spec, and adds a row to the brief's Spec map. The brief
+   lands at `docs/product/briefs/<slug>.md`.
+
+5. **Build each slice with `work-loop`, as usual.** The derived specs are
+   ordinary specs — nothing about the brief changes how you build them. As each
+   ships, the brief's coverage map rolls up automatically (next step).
+
+6. **Check coverage any time.** Run the bundled coverage lint to see whether
+   the brief is delivered:
+
+   ```bash
+   python .claude/skills/receive-brief/scripts/lint-brief-coverage.py
+   ```
+
+   It reads each spec's `Status:` field, follows the `Brief:` back-links, and
+   reports each brief as *delivered* (every mapped spec Shipped) or *not
+   delivered*. Wire it into your gate if you want coverage enforced.
+
+## Variations
+
+- **If the brief carries user stories** (Shape B): give each story an id
+  (`US-1`, `US-2`, …). Decomposition becomes *grouping stories into specs*, and
+  each satisfying acceptance criterion gets a `Satisfies: US-n` marker — so
+  coverage is story-granular ("US-2 → `password-reset` AC3 → shipped"). A story
+  too big for one spec is an epic; the skill flags it for splitting.
+
+- **If the brief has no stories** (Shape A): the skill derives spec boundaries
+  from Outcome + Scope and coverage is spec-granular. This is the common case.
+
+- **If the brief is one slice of a cross-repo effort:** record the external
+  coordinator's id in the brief's optional `Epic:` field. You own this repo's
+  slice only — the pointer is the nod to the wider effort, not a hub you build.
+
+- **If you only want to scaffold some slices now:** that's fine. A brief can
+  grow its Spec map over time as slices get picked up; a spec can even predate
+  its brief. The `Brief:` back-link is what ties them together.
+
+## Common pitfalls
+
+- **A brief arrives missing metrics or appetite** — that's normal input, not an
+  error. Supply your best guess or skip; the skill won't block on it.
+- **The cut splits by component, not by shippability** — "backend, then
+  frontend" is not two slices. Push back: each slice should ship and test on
+  its own. The skill aims for this, but you're the check.
+- **Hand-editing the Status column in the brief** — don't. It's auto-derived;
+  a hand-written status drifts the moment a spec ships, which is the exact
+  failure the coverage lint exists to catch.
+- **Cramming the whole brief into one spec** — that breaks the one-feature
+  sizing rule and the per-spec build loop. Several features means several specs.
+
+## See also
+
+- [Product brief fields](../reference/product-brief-fields.md) — the full field
+  list for briefs and derived specs.
+- [Why a brief layer](../explanation/why-a-brief-layer.md) — the altitude and
+  the handoff this closes.
+- [Plan and execute non-trivial work](plan-and-execute-non-trivial-work.md) —
+  the `work-loop` each derived slice runs through.

--- a/docs/guides/reference/product-brief-fields.md
+++ b/docs/guides/reference/product-brief-fields.md
@@ -1,0 +1,81 @@
+# Product brief fields
+
+Authoritative field list for a **product brief** and the linkage fields it
+stamps on derived specs. A brief lives at `docs/product/briefs/<slug>.md` and
+is created by the `receive-brief` skill. For how to use it, see
+[Receive a product brief and decompose it into specs](../how-to/receive-a-product-brief-and-decompose-it-into-specs.md);
+for why the layer exists, see
+[Why a brief layer](../explanation/why-a-brief-layer.md).
+
+> The brief template is a **guide, not a schema**. Every field below except
+> Outcome and Scope is optional. `receive-brief` elicits what's missing; it
+> never rejects a brief for not matching this list.
+
+## Brief header fields
+
+| Field | Required? | Meaning |
+| --- | --- | --- |
+| `Slug` | yes | Kebab-case identifier; matches the filename and the `Brief:` back-link on derived specs. |
+| `Received` | recommended | The date the brief was handed over (`YYYY-MM-DD`). |
+| `Owner` | recommended | Who owns delivering this repo's slice. |
+| `Epic` | optional | Id or link of an external coordinator (a tracker epic, an integration repo) when this repo's work is one slice of a cross-repo effort. Omit when there is none. This is the only pointer to the wider effort — the repo owns its slice, not a coordination hub. |
+
+## Brief body sections
+
+| Section | Required? | Meaning |
+| --- | --- | --- |
+| `Outcome` | **yes (load-bearing)** | The problem and the user-facing outcome, in the user's terms. The one field a brief cannot do without — it's what every slice is measured against. |
+| `Success metrics` | optional | Observable signals that the outcome landed (not activities). E.g. "p95 checkout under 400ms", "reset tickets down 60%". |
+| `Scope / Non-goals` | **yes** | The boundary of this repo's slice. Non-goals are as load-bearing as scope — they stop the decomposition from sprawling. |
+| `Appetite` | optional | A *constraint*, not an estimate: how much time/effort the outcome is worth ("a few weeks, not a quarter"). Bounds the decomposition. |
+| `User stories` | optional (Shape B) | Stories with ids (`US-1`, `US-2`, …). Present → decomposition groups stories into specs and coverage is story-granular. Absent → Shape A, spec-granular coverage. |
+| `Spec map` | yes | The coverage table. One row per derived spec; the Status column is **auto-derived** by the coverage lint (never hand-edited). Shape B adds a `Story` column. |
+
+## The Spec map
+
+A markdown table whose rows the coverage lint reconciles against the specs:
+
+```
+| Spec | Status |          ← Shape A (no stories)
+| --- | --- |
+| `password-reset-request` | Shipped |
+
+| Spec | Story | Status |  ← Shape B (story list)
+| --- | --- | --- |
+| `billing-plan-management` | US-1 | Shipped |
+```
+
+- The **first** column is the spec slug (`docs/specs/<slug>/`).
+- The **last** column is the auto-derived status — leave it to the lint.
+- A brief is **delivered** only when its map is non-empty *and* every mapped
+  spec is `Shipped`. An empty map is never vacuously delivered.
+
+## Linkage fields on derived specs
+
+`receive-brief` stamps these on the specs it scaffolds (both are additive and
+optional — a directly-authored spec omits them and stays valid):
+
+| Field / marker | Where | Meaning |
+| --- | --- | --- |
+| `Brief: <slug>` | spec header (sibling to `Constrained by:` / `Contract:`) | Product provenance — the brief this spec was derived from. Distinct from `Constrained by:`, which cites the ADRs/RFCs that *govern* the spec. The coverage map rolls up from these back-links. |
+| `Satisfies: US-n` | appended to an acceptance criterion | Story trace (Shape B only). Marks the AC that satisfies story `US-n`, giving story-granular coverage. Omitted in Shape A. |
+
+## The coverage lint
+
+`scripts/lint-brief-coverage.py` (bundled with the `receive-brief` skill) reads
+every spec's `Status:` field, follows the `Brief:` back-links, and rolls each
+brief's Spec map up from its children. Behavior:
+
+- Reports each brief as **delivered** or **not delivered**.
+- A spec that back-links a brief but isn't in that brief's map is reported
+  **untracked** (informational) — add the row; it's not an error.
+- A brief's Spec-map Status cell that *contradicts* the spec's real status (a
+  hand-edited, stale cell) is a **failure** (exit 1) — the column is
+  auto-derived and must not be hand-maintained.
+- It **no-ops** (exit 0, silent) when no brief exists.
+- The shipped `_template.md` is skipped — it's the template, not a brief.
+
+## See also
+
+- [Receive a product brief and decompose it into specs](../how-to/receive-a-product-brief-and-decompose-it-into-specs.md)
+- [Why a brief layer](../explanation/why-a-brief-layer.md)

--- a/docs/specs/product-brief-intake/plan.md
+++ b/docs/specs/product-brief-intake/plan.md
@@ -1,7 +1,7 @@
 # Plan: product-brief-intake
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Drafting <!-- Drafting | Executing | Done -->
+- **Status:** Done <!-- Drafting | Executing | Done -->
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
 > document is allowed to change as you learn. When it changes substantially
@@ -307,3 +307,15 @@ no-ops where no brief exists, so it cannot break a brief-free adopter's gate.
 ## Changelog
 
 - 2026-06-01: initial plan (drafted from RFC-0019 + ADR-0009).
+- 2026-06-01: T6 refined during EXECUTE — the lint's fail-closed condition is a
+  brief's Spec-map Status cell that *contradicts* the spec's actual `Status:`
+  (a hand-edited, now-stale cell); an unset cell (`<auto>`/`—`/empty) is
+  reported, not failed, and the `_template.md` placeholder is skipped. Added two
+  self-test cases (stale-cell drift → exit 1; unset cell → not drift) beyond the
+  six in the task. This is what gives "fail-closed in build-check" non-vacuous
+  meaning while keeping the no-brief / untracked / empty-map ACs intact.
+- 2026-06-01: shipped. All tasks T1–T10 complete; `make build-check` green;
+  spec marked Shipped with all ACs checked (spec + code land atomically).
+  Self-host projection: build-self does not project `docs/product/briefs/` into
+  this repo (consistent with `docs/product/` being adopter-owned), so this repo
+  ships no brief and the coverage lint no-ops — no `self_host.py` change needed.

--- a/docs/specs/product-brief-intake/spec.md
+++ b/docs/specs/product-brief-intake/spec.md
@@ -1,6 +1,6 @@
 # Spec: product-brief-intake
 
-- **Status:** Draft <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Status:** Shipped (2026-06-01) <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** RFC-0019, ADR-0009
@@ -96,58 +96,58 @@ before proceeding; *Never do* is a hard rule, even under time pressure.
 
 ## Acceptance Criteria
 
-- [ ] A **brief template** ships as a `core` seed at
+- [x] A **brief template** ships as a `core` seed at
   `packs/core/seeds/docs/product/briefs/` carrying the documented fields:
   Outcome, Success metrics, Scope / Non-goals, Appetite, optional User stories,
   optional `Epic:`, and the Spec map (coverage table).
-- [ ] The **`receive-brief`** skill ships at
+- [x] The **`receive-brief`** skill ships at
   `packs/core/.apm/skills/receive-brief/SKILL.md` with valid frontmatter that
   passes `tools/lint-skill-spec.py`.
-- [ ] `receive-brief`'s documented procedure includes an explicit
+- [x] `receive-brief`'s documented procedure includes an explicit
   **never-reject / elicit-load-bearing-fields-only** step (insist on outcome +
   scope; offer the rest; surface gaps), verified by a manual-QA walk-through of
   the two examples.
-- [ ] `receive-brief` documents **decomposition by the shippability test** and
+- [x] `receive-brief` documents **decomposition by the shippability test** and
   **surfaces the proposed cut** for confirmation; in Shape B it groups stories
   into specs and flags any epic-sized story for splitting.
-- [ ] `receive-brief` documents the **execute** spine: chain `new-spec` per
+- [x] `receive-brief` documents the **execute** spine: chain `new-spec` per
   slice, stamp the `Brief:` back-link (and `Satisfies: US-n` on ACs in Shape B),
   hand off to `work-loop`.
-- [ ] The **`spec.md` template and `new-spec`** gain an optional `Brief:`
+- [x] The **`spec.md` template and `new-spec`** gain an optional `Brief:`
   front-matter field (sibling to `Constrained by:` / `Contract:`); the change is
   additive and specs authored before it stay valid.
-- [ ] The optional **`Satisfies: US-n`** acceptance-criterion marker and the
+- [x] The optional **`Satisfies: US-n`** acceptance-criterion marker and the
   optional **`Epic:`** brief field are documented in their conventional places.
-- [ ] **`examples/`** ships **two** worked briefs — a no-stories outcome brief
+- [x] **`examples/`** ships **two** worked briefs — a no-stories outcome brief
   (Shape A) and a story-list brief (Shape B) — each carrying a header that
   clearly labels it an **example demonstrating the shape, not a schema**.
-- [ ] An **auto-rollup lint** reads every `docs/specs/*/spec.md` `Status:` field,
+- [x] An **auto-rollup lint** reads every `docs/specs/*/spec.md` `Status:` field,
   follows `Brief:` back-links, and rolls each brief's Spec map up from its
   children; a brief whose every child spec is `Shipped` reports *delivered*.
-- [ ] A brief whose Spec map has **no mapped child specs** reports **not
+- [x] A brief whose Spec map has **no mapped child specs** reports **not
   delivered** (not vacuously delivered) — an empty rollup is never *delivered*.
-- [ ] The lint **no-ops cleanly when no brief exists** — exit 0, no diagnostic —
+- [x] The lint **no-ops cleanly when no brief exists** — exit 0, no diagnostic —
   verified against this repo (which ships no brief).
-- [ ] A spec whose `Brief:` back-link is **missing** shows as **untracked** in
+- [x] A spec whose `Brief:` back-link is **missing** shows as **untracked** in
   the brief's map, not as a lint error.
-- [ ] The lint is wired into **`make build-check`** (fail-closed) and passes on
+- [x] The lint is wired into **`make build-check`** (fail-closed) and passes on
   this repo.
-- [ ] The **`CONVENTIONS.md` seed amendment** — `briefs/` added to the
+- [x] The **`CONVENTIONS.md` seed amendment** — `briefs/` added to the
   document-hierarchy diagram under `product/`, the `Brief:` field on specs, and
   the `roadmap → brief → spec → AC` altitude — lands in this spec's implementing
   PR (it documents artifacts this spec creates, so it ships atomically with them).
-- [ ] **No new top-level directory and no cross-pack import** are introduced; the
+- [x] **No new top-level directory and no cross-pack import** are introduced; the
   brief lives under `docs/product/`, the skill under `packs/core/.apm/skills/`.
-- [ ] **`make build-self`** projects the new core primitives (skill + seed)
+- [x] **`make build-self`** projects the new core primitives (skill + seed)
   cleanly and `make build-check` is green.
-- [ ] Three adopter-facing **guide files exist** under `docs/guides/` at their
+- [x] Three adopter-facing **guide files exist** under `docs/guides/` at their
   Diátaxis paths — a how-to ("Receive a product brief and decompose it into
   specs"), a reference (brief fields incl. `Epic:` + the spec map; the `Brief:` /
   `Satisfies:` fields), and an explanation ("Why a brief layer"). *(Authored in
   this catalogue repo via `new-guide`, which lives in the non-core
   `user-guide-diataxis` pack; guide authoring is not a capability `core` ships to
   adopters — per RFC-0019's "guides in this catalogue repo" scoping.)*
-- [ ] Each of the three guides **reads accurately** against the shipped skill +
+- [x] Each of the three guides **reads accurately** against the shipped skill +
   template (manual-QA review recorded in the implementing PR).
 
 ## Assumptions

--- a/packs/core/.apm/skills/new-spec/SKILL.md
+++ b/packs/core/.apm/skills/new-spec/SKILL.md
@@ -116,6 +116,13 @@ look like?" before any code.
      items that name an ADR or RFC the feature must cite. The header
      lands before any body section; Verified items don't gate the
      Unverified loop but they do gate `Constrained by:`.
+   - Stamp the optional `Brief:` header **only** when this spec is
+     derived from a product brief — i.e. you arrived here from
+     `receive-brief`, which decomposes a received brief into specs. Set
+     it to the brief's slug (`docs/product/briefs/<slug>.md`); leave it
+     blank or `none` for a spec authored directly. It records *product
+     provenance* and is distinct from `Constrained by:` (governance).
+     A spec without it stays valid — the field is additive.
 
 4. Fill in the spec — including the **Testing Strategy** section. Push
    back hard on these failure modes:

--- a/packs/core/.apm/skills/new-spec/assets/spec.md
+++ b/packs/core/.apm/skills/new-spec/assets/spec.md
@@ -4,6 +4,7 @@
 - **Owner:** <github-handle>
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** <!-- ADR-NNNN, RFC-NNNN, or "none" -->
+- **Brief:** <!-- optional: the product brief this spec was derived from (`docs/product/briefs/<slug>.md`); stamped by receive-brief. Omit, or "none", for a spec authored directly. Distinct from Constrained by: this is product provenance, not a governance constraint. -->
 - **Contract:** <!-- contracts/<type>/<name> this spec defines or touches (see new-spec step 4b / CONVENTIONS § 4 Contracts), or "none" for a non-API feature -->
 
 > **Spec contract:** this document defines what "done" means. The implementing
@@ -85,6 +86,16 @@ mark it deferred with an inline anchor into the backlog register:
 - [ ] <observable outcome> (deferred: <backlog-anchor>)
 
 where <backlog-anchor> resolves to a heading in `docs/backlog.md`.
+
+Optional story trace: when this spec was derived from a product brief that
+carries user stories (Shape B; see receive-brief), append `Satisfies: US-n`
+to each acceptance criterion that satisfies that story, so coverage is
+story-granular:
+
+- [x] <observable outcome>. Satisfies: US-2
+
+The marker is optional — omit it for a no-stories brief (Shape A) or a spec
+authored directly.
 -->
 
 ## Assumptions

--- a/packs/core/.apm/skills/receive-brief/SKILL.md
+++ b/packs/core/.apm/skills/receive-brief/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: receive-brief
+description: Use this skill when the user receives an externally-authored, multi-feature product brief -- a PRD, a solution handoff, a requirements packet -- and needs to turn it into shippable specs. Triggers on "receive a brief", "decompose this PRD", "we got a product brief", "break this handoff into specs". Elicits the load-bearing fields without mandating a schema, decomposes by shippability, and executes each slice through new-spec then work-loop. Do NOT use to author a single feature from scratch (use new-spec) or to record a decision (use new-adr).
+---
+
+# Skill: receive-brief
+
+Receive a product brief — a PRD, a solution handoff, a packet of work product
+handed from someone else — and route it into delivery. A brief spans several
+features and carries the *what/why*; a spec is one feature and carries the
+*how*. `new-spec` authors one feature; this skill is the inbox a level above
+it: **elicit** what the brief is missing, **decompose** it into
+independently-shippable slices, and **execute** each slice through the normal
+`new-spec` → `work-loop` pipeline. The brief becomes a live tracker whose
+coverage rolls up from the specs it spawned.
+
+## When to invoke
+
+Invoke when the unit of work that arrives is **bigger than one feature** and
+authored by someone other than the implementer — product hands engineering a
+brief. If the user is authoring a single feature themselves, that's `new-spec`,
+not this skill. If they want to record a decision already made, that's
+`new-adr`. The tell is multiplicity: one outcome, several features, no home.
+
+A brief lives at `docs/product/briefs/<slug>.md`. Copy the bundled template
+(your installer places a `_template.md` in that directory) and fill what you
+have. The shape is a guide, not a gate — see the Elicit stage.
+
+## Two shapes, one toggle
+
+The only structural choice is whether the brief carries **user stories**:
+
+- **Shape A — no stories.** You derive spec boundaries from the Outcome and
+  Scope, and surface the cut for confirmation. Coverage is **spec-granular**
+  ("is `password-reset` shipped?"). Stories still exist — they're written as
+  each spec's acceptance criteria when the spec is authored.
+- **Shape B — story list.** The brief lists stories with ids (`US-1`, `US-2`,
+  …). Decomposition is *grouping stories into specs*. Each satisfying
+  acceptance criterion carries a `Satisfies: US-n` marker, so coverage is
+  **story-granular** ("US-2 → `password-reset` AC3 → shipped"). A story too
+  big to fit one feature-sized spec is an epic — flag it for splitting.
+
+Both shapes run the same three stages below. The toggle changes traceability
+granularity, not the pipeline.
+
+## Procedure
+
+### 1. Elicit — meet the brief where it is
+
+Ingest whatever the user has: a pasted document, a file, a link, or a verbal
+sketch. Then fill the brief template by **conversation**, not by rejection.
+
+- **Insist on only the load-bearing fields: Outcome and Scope.** Without the
+  outcome you can't tell whether a slice serves the brief; without scope (and
+  non-goals) the decomposition sprawls. Ask for these until you have them.
+- **Offer the rest; never require it.** Success metrics, appetite, and stories
+  improve the cut but are not gates. Suggest a default ("no metrics given — I'll
+  propose p95 latency and ticket volume; correct me") rather than blocking.
+- **Surface gaps; never invent.** If the brief is silent on something
+  load-bearing, say so and ask. Do not fabricate an outcome or quietly drop a
+  requirement to make the brief parse.
+- **Never mandate a schema.** A half-formed brief is normal input. The template
+  is a prompt sheet, not a form to be rejected for missing sections.
+
+Record the result in `docs/product/briefs/<slug>.md`. Carry the optional
+`Epic:` pointer if this repo's work is one slice of a larger cross-repo effort
+— that pointer is the *only* nod to the wider epic; you own this repo's slice
+and nothing above it.
+
+### 2. Decompose — cut by shippability, then surface the cut
+
+Cut the brief into slices, each of which is **independently shippable and
+independently testable** — a feature `work-loop` can carry end to end. This is
+the shippability test, **not** a component or layer split: "auth service" and
+"auth UI" are not two slices unless each ships and tests on its own.
+
+- In **Shape A**, derive slice boundaries from Outcome + Scope.
+- In **Shape B**, group the stories into slices; each slice becomes one spec.
+- **Flag any epic-sized story** — one that can't fit a single feature-sized
+  spec — for splitting before you scaffold. Ask before treating it as one spec.
+- **Flag any outcome no slice covers** as a gap, and surface it. Don't silently
+  drop an outcome to make the decomposition tidy.
+
+**Surface the proposed cut and wait for confirmation before scaffolding any
+spec.** Present the slices, what each delivers, and (Shape B) which stories
+each carries. The decomposition is judgment; the human signs off on it.
+
+### 3. Execute — scaffold, back-link, hand off
+
+For each confirmed slice, in dependency order:
+
+1. **Chain `new-spec`** to scaffold the slice's `spec.md` + `plan.md`. Pass the
+   slice's outcome and scope so `new-spec`'s assumption-surfacing starts from
+   the brief, not a blank page.
+2. **Stamp the `Brief:` back-link** on the derived spec — set it to this
+   brief's slug. In **Shape B**, also stamp `Satisfies: US-n` on each
+   acceptance criterion that satisfies a story, so the trace is bidirectional.
+3. **Add a row to the brief's Spec map** for the new slice (the Status column
+   is auto-derived — leave it to the lint; do not hand-write it).
+4. **Hand off to `work-loop`** to build the slice. The brief is thus
+   *executable*: brief → (spec, plan) × N → work-loop.
+
+You don't have to scaffold every slice at once — a brief can grow its Spec map
+over time as slices are picked up. A spec may even predate its brief; the
+`Brief:` back-link is what ties them together, not directory nesting.
+
+## Coverage — auto-rolled-up, never hand-maintained
+
+The brief's **Spec map** answers "is this brief delivered?" and stays current
+on its own. The bundled coverage lint at `scripts/lint-brief-coverage.py`
+reads every spec's `Status:` field, follows the `Brief:` back-links, and rolls
+each brief's map up from its children:
+
+- A brief whose every mapped spec is `Shipped` reports **delivered**.
+- A brief whose map has no mapped specs reports **not delivered** — an empty
+  map is never vacuously delivered.
+- A spec that back-links a brief but isn't in that brief's map is reported
+  **untracked** (informational) — add the row; it's not an error.
+
+Run it after a slice's status changes; wire it into your gate if you want it
+enforced. **Never hand-edit the Status column** — a status written by hand
+drifts the moment a spec ships, which is the exact failure this rollup avoids.
+
+See `examples/` for two worked briefs — a no-stories outcome brief (Shape A)
+and a story-list brief (Shape B), each with a populated Spec map.
+
+## Anti-patterns to refuse
+
+- **Mandating a schema / rejecting a half-formed brief.** The shape is a guide.
+  Elicit the load-bearing fields; offer the rest. A brief that arrives missing
+  metrics is normal, not invalid.
+- **Decomposing by component or layer instead of shippability.** "Backend,
+  then frontend" is not two slices; "the slice that lets a user reset their
+  password, end to end" is. If a slice can't ship and test on its own, it's not
+  a slice yet.
+- **Scaffolding before the cut is confirmed.** The decomposition is the
+  judgment call the human most needs to see. Surface it; don't present N specs
+  as a fait accompli.
+- **Building a cross-repo coordination hub.** You own this repo's slice. Point
+  upward with the optional `Epic:` pointer; do not reimplement a tracker.
+- **Hand-maintaining the coverage map.** The Status column is derived. Editing
+  it by hand reintroduces the drift the lint exists to prevent.
+- **Cramming a multi-feature brief into one oversized spec.** That breaks the
+  one-feature sizing rule and the per-spec `work-loop`. If it's several
+  features, it's several specs.

--- a/packs/core/.apm/skills/receive-brief/examples/shape-a-outcome-brief.md
+++ b/packs/core/.apm/skills/receive-brief/examples/shape-a-outcome-brief.md
@@ -1,0 +1,59 @@
+# Brief: Self-service password reset
+
+> **This is an example, not a schema.** It demonstrates **Shape A** — a
+> no-stories *outcome* brief, where spec boundaries are derived from the
+> Outcome and Scope and coverage is spec-granular. The fields and the Spec map
+> show the expected shape; copy the structure, not the content. Your real brief
+> may have fewer or more sections — the `receive-brief` skill elicits what's
+> missing rather than rejecting a brief for not matching this exactly.
+
+- **Slug:** `self-service-password-reset`
+- **Received:** 2026-05-18
+- **Owner:** platform team
+- **Epic:** ACME-2231 <!-- this slice is part of a larger "reduce support load" epic tracked in the company tracker; we own only the password-reset portion -->
+
+## Outcome
+
+Users who forget their password can't get back in without filing a support
+ticket, and password-reset tickets are the single largest category in the
+support queue. We want a user to reset their own password end to end — request
+a reset, verify by email, set a new password — without any human in the loop.
+
+## Success metrics
+
+- Password-reset support tickets down 60% within one quarter of launch.
+- 90% of reset attempts complete without contacting support.
+- Median time from "forgot password" to "logged in again" under 5 minutes.
+
+## Scope / Non-goals
+
+**In scope:**
+
+- Email-based reset request and verification.
+- Setting a new password that meets the existing password policy.
+- Rate-limiting and basic abuse protection on the reset endpoint.
+
+**Non-goals:**
+
+- SMS or authenticator-app recovery (a later brief may add these).
+- Changing the password policy itself.
+- Admin-initiated resets (already covered by the admin console).
+
+## Appetite
+
+A few weeks, not a quarter. If the verification flow turns out to need a new
+identity provider integration, that's a separate brief — flag it, don't absorb
+it here.
+
+## Spec map
+
+<!-- No stories (Shape A): one row per derived spec, coverage is spec-granular.
+The Status column is auto-derived by the coverage lint from each spec's own
+Status field — shown here filled in so you can see the rolled-up shape. This
+brief is NOT yet delivered: account-lockout-recovery is still Implementing. -->
+
+| Spec | Status |
+| --- | --- |
+| `password-reset-request` | Shipped |
+| `password-reset-verification` | Shipped |
+| `account-lockout-recovery` | Implementing |

--- a/packs/core/.apm/skills/receive-brief/examples/shape-b-story-list-brief.md
+++ b/packs/core/.apm/skills/receive-brief/examples/shape-b-story-list-brief.md
@@ -1,0 +1,71 @@
+# Brief: Team billing portal
+
+> **This is an example, not a schema.** It demonstrates **Shape B** — a
+> *story-list* brief, where the brief carries user stories with ids and
+> decomposition is *grouping stories into specs*. Coverage is story-granular:
+> each satisfying acceptance criterion in a derived spec carries a
+> `Satisfies: US-n` marker, and the Spec map gains a `Story` column. The fields
+> and the Spec map show the expected shape; copy the structure, not the
+> content. `receive-brief` elicits what's missing rather than rejecting a brief
+> that doesn't match this exactly.
+
+- **Slug:** `team-billing-portal`
+- **Received:** 2026-05-20
+- **Owner:** billing team
+- **Epic:** <!-- none; this brief is self-contained, so the pointer is omitted -->
+
+## Outcome
+
+Team admins have no way to manage their own billing — they email us to change
+plans, update payment methods, or download invoices, and every change is a
+manual back-office task. We want admins to manage their team's billing
+themselves from a portal, so billing changes stop being a support workflow.
+
+## Success metrics
+
+- 80% of plan changes and payment-method updates happen self-serve.
+- Back-office billing tasks down 70% within two quarters.
+- Invoice-download requests to support drop to near zero.
+
+## Scope / Non-goals
+
+**In scope:**
+
+- View and change the team's plan.
+- Add, update, and remove payment methods.
+- Download past invoices as PDF.
+
+**Non-goals:**
+
+- Usage-based / metered billing (the current model is seat-based).
+- Multi-currency support.
+- Reselling or partner billing hierarchies.
+
+## Appetite
+
+About six weeks. The invoice PDF rendering is the riskiest piece — if it needs
+a new rendering service, that's its own slice, surfaced for sign-off, not
+silently folded in.
+
+## User stories
+
+- **US-1.** As a team admin, I want to see my current plan and change it, so
+  that I can upgrade or downgrade without emailing support.
+- **US-2.** As a team admin, I want to add and remove payment methods, so that
+  billing keeps working when a card expires.
+- **US-3.** As a team admin, I want to download past invoices as PDFs, so that
+  I can submit them for expense reporting.
+
+## Spec map
+
+<!-- Story-list (Shape B): stories are grouped into specs; the `Story` column
+links each row to the US-n it satisfies (the satisfying ACs inside each spec
+carry a `Satisfies: US-n` marker). The Status column is auto-derived by the
+coverage lint. This brief is NOT yet delivered: invoice-pdf-export is still
+in Draft. -->
+
+| Spec | Story | Status |
+| --- | --- | --- |
+| `billing-plan-management` | US-1 | Shipped |
+| `payment-method-management` | US-2 | Implementing |
+| `invoice-pdf-export` | US-3 | Draft |

--- a/packs/core/.apm/skills/receive-brief/scripts/lint-brief-coverage.py
+++ b/packs/core/.apm/skills/receive-brief/scripts/lint-brief-coverage.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Brief-coverage auto-rollup lint.
+
+This is a `receive-brief` **skill script**: it lives at
+`packs/core/.apm/skills/receive-brief/scripts/lint-brief-coverage.py` and
+projects to every adapter's `.../skills/receive-brief/scripts/`, the same way
+the work-loop's `lint-spec-status.py` does. The agent runs it after a slice's
+status changes; the catalogue additionally runs it as a **fail-closed CI gate**
+via `make build-check`. It no-ops gracefully where Python is absent.
+
+What it does: reads every `docs/specs/*/spec.md` `Status:` field, follows the
+`Brief:` back-links, and rolls each brief's Spec map up from its child specs —
+so "is this brief delivered?" stays answerable with no hand-maintenance. It
+reads only existing `Status:` fields and the brief's Spec map; it introduces no
+new state.
+
+Rollup rules:
+  - A brief is *delivered* only when its Spec map is non-empty AND every mapped
+    spec is `Shipped`. An empty map is never vacuously delivered.
+  - A spec that back-links a brief (`Brief: <slug>`) but is absent from that
+    brief's Spec map is reported **untracked** — informational, never an error.
+  - A `docs/product/briefs/_template.md` (or any `_`-prefixed file) is the
+    shipped template, not a brief; it is skipped.
+
+Exit codes:
+  0 = clean (coverage reported; warnings/untracked allowed).
+  1 = drift: a brief's Spec map records a status that contradicts the spec's
+      actual `Status:` (a hand-edited, now-stale cell). The Status column is
+      auto-derived and must not be hand-maintained — drift is the failure this
+      lint exists to catch. An unset cell (`<auto>`, `—`, `-`, or empty) means
+      "not yet derived" and is reported, not failed.
+
+No briefs found → exit 0 with no diagnostic output (the common case in a repo
+that ships no brief). Usage: lint-brief-coverage.py [--root DIR]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Header status / brief / slug lines, e.g. `- **Status:** Shipped (2026-05-26)`.
+_STATUS_RE = re.compile(r"\*\*Status:\*\*\s*(.+?)\s*$")
+_BRIEF_RE = re.compile(r"\*\*Brief:\*\*\s*(.+?)\s*$")
+_SLUG_RE = re.compile(r"\*\*Slug:\*\*\s*(.+?)\s*$")
+# Recorded-status cells that mean "not yet derived" — reported, never drift.
+_UNSET_CELLS = frozenset({"", "<auto>", "—", "-", "tbd", "todo"})
+
+
+def _is_placeholder(value: str) -> bool:
+    """True for an unset/template value: empty, `none`, an HTML comment, or a
+    bare angle-bracket placeholder (`<slug>`)."""
+    v = value.strip()
+    return (
+        not v
+        or v.lower() == "none"
+        or v.startswith("<!--")
+        or (v.startswith("<") and v.endswith(">"))
+    )
+
+
+def extract_token(raw: str) -> str:
+    """Leading token from a header value, truncating at ` (`, ` →`, or `<!--`.
+
+    Intentionally mirrors lint-spec-status.py's `extract_status_token` (same
+    delimiters) — cross-skill import is banned by this spec's Boundaries, so
+    the two must be kept in lockstep by hand. Reduces annotated statuses
+    (`Shipped (2026-05-26)`, `Approved → Shipped (…)`, `Draft <!-- ... -->`) to
+    their leading word.
+    """
+    text = raw
+    for delim in (" (", " →", "<!--"):
+        idx = text.find(delim)
+        if idx != -1:
+            text = text[:idx]
+    parts = text.strip().split()
+    return parts[0] if parts else ""
+
+
+def parse_spec(spec_text: str) -> tuple[str | None, str | None]:
+    """Return (status-token, brief-back-link-slug) from a spec's header.
+
+    A `Brief:` value that is empty, `none`, or the template HTML-comment
+    placeholder counts as no back-link (None).
+    """
+    status: str | None = None
+    brief: str | None = None
+    for line in spec_text.splitlines():
+        if status is None:
+            m = _STATUS_RE.search(line)
+            if m:
+                status = extract_token(m.group(1))
+        if brief is None:
+            m = _BRIEF_RE.search(line)
+            if m:
+                value = m.group(1).strip()
+                if not _is_placeholder(value):
+                    brief = extract_token(value).strip("`")
+    return status, brief
+
+
+def parse_brief_slug(brief_text: str, fallback: str) -> str:
+    """Return the brief's canonical slug from its `- **Slug:**` field.
+
+    A derived spec's `Brief:` back-link names this slug, which need not equal
+    the brief's filename stem — so the slug, not the stem, is the join key for
+    coverage and untracked detection. Falls back to `fallback` (the filename
+    stem) only when no usable `Slug:` field is present.
+    """
+    for line in brief_text.splitlines():
+        m = _SLUG_RE.search(line)
+        if m:
+            value = m.group(1).strip().strip("`")
+            if not _is_placeholder(value):
+                return extract_token(value).strip("`")
+    return fallback
+
+
+def parse_spec_map(brief_text: str) -> list[tuple[int, str, str]]:
+    """Return (lineno, spec-slug, recorded-status) for each Spec map row.
+
+    Parses the markdown table under the `## Spec map` heading. The first
+    table column is the spec slug; the LAST column is the recorded status
+    (so a Shape-B map with a middle `Story` column parses the same way).
+    The header row and the `| --- |` separator row are skipped.
+    """
+    rows: list[tuple[int, str, str]] = []
+    in_section = False
+    for lineno, line in enumerate(brief_text.splitlines(), start=1):
+        if re.match(r"^##\s+Spec map\b", line, re.IGNORECASE):
+            in_section = True
+            continue
+        if in_section and re.match(r"^##\s+", line):
+            break
+        # Only a markdown table row counts — it must start with `|`. This
+        # ignores explanatory prose under the heading that happens to contain a
+        # pipe (which would otherwise parse as a phantom row and trip drift).
+        if not in_section or not line.lstrip().startswith("|"):
+            continue
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if len(cells) < 2:
+            continue
+        first = cells[0].strip("` ")
+        last = cells[-1].strip("` ")
+        # Skip the header row and the `| --- | --- |` separator row.
+        if first.lower() == "spec" or set(first) <= set("-: "):
+            continue
+        rows.append((lineno, first, last))
+    return rows
+
+
+def check(root: Path) -> tuple[list[str], list[str]]:
+    """Return (lines_to_print, hard_violations)."""
+    briefs_dir = root / "docs" / "product" / "briefs"
+    if not briefs_dir.is_dir():
+        return [], []
+
+    brief_files = [
+        p for p in sorted(briefs_dir.glob("*.md")) if not p.name.startswith("_")
+    ]
+    if not brief_files:
+        return [], []
+
+    # Index specs by slug → (status, brief-back-link).
+    specs: dict[str, tuple[str | None, str | None]] = {}
+    specs_dir = root / "docs" / "specs"
+    for spec_path in sorted(specs_dir.glob("*/spec.md")):
+        slug = spec_path.parent.name
+        specs[slug] = parse_spec(
+            spec_path.read_text(encoding="utf-8", errors="replace")
+        )
+
+    out: list[str] = []
+    hard: list[str] = []
+
+    for brief_path in brief_files:
+        text = brief_path.read_text(encoding="utf-8", errors="replace")
+        # The slug (from the `Slug:` field), not the filename stem, is the
+        # identity a spec's `Brief:` back-link names — see parse_brief_slug.
+        brief_slug = parse_brief_slug(text, brief_path.stem)
+        rel = brief_path.relative_to(root).as_posix()
+        rows = parse_spec_map(text)
+
+        mapped = {slug for _, slug, _ in rows if slug}
+        derived: list[str] = []
+        for lineno, spec_slug, recorded in rows:
+            if not spec_slug:
+                continue
+            status = specs.get(spec_slug, (None, None))[0]
+            actual = status if status else "missing"
+            derived.append(actual)
+            # Normalise the recorded cell the same way as the actual status
+            # (leading token) so an annotated cell like `Shipped (2026-06-01)`
+            # isn't misreported as drift against a derived `Shipped`.
+            recorded_norm = extract_token(recorded).strip("`").lower()
+            if recorded_norm not in _UNSET_CELLS and recorded_norm != actual.lower():
+                hard.append(
+                    f"{rel}:{lineno}: spec '{spec_slug}' recorded '{recorded}' "
+                    f"but its Status is '{actual}' — the Spec map is stale "
+                    f"(auto-derived; do not hand-edit the Status column)"
+                )
+
+        # Case-insensitive so a lowercase `shipped` token agrees with the drift
+        # check (which is also case-insensitive) on the delivered verdict.
+        delivered = bool(mapped) and all(s.lower() == "shipped" for s in derived)
+        out.append(
+            f"lint-brief-coverage: brief '{brief_slug}': "
+            f"{'delivered' if delivered else 'not delivered'}"
+        )
+        for _, spec_slug, _ in rows:
+            if spec_slug:
+                status = specs.get(spec_slug, (None, None))[0]
+                out.append(f"  - {spec_slug}: {status if status else 'missing'}")
+
+        # Untracked: specs that back-link this brief but aren't in its map.
+        untracked = sorted(
+            slug for slug, (_, back) in specs.items()
+            if back == brief_slug and slug not in mapped
+        )
+        for slug in untracked:
+            out.append(
+                f"  - {slug}: untracked (back-links this brief, not in Spec map)"
+            )
+
+    out.append(f"lint-brief-coverage: {len(brief_files)} brief(s) checked.")
+    return out, hard
+
+
+def _repo_root() -> Path:
+    # Best-effort discovery for a bare manual run. The gate (`make build-check`)
+    # and every self-test pass `--root` explicitly, so this only fires for a
+    # hand-run with no `--root`; prefer git's toplevel when available.
+    try:
+        r = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=False,
+        )
+        if r.returncode == 0 and r.stdout.strip():
+            return Path(r.stdout.strip())
+    except FileNotFoundError:
+        pass
+    return Path(__file__).resolve().parent.parent
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=None)
+    args = parser.parse_args(argv)
+    root = args.root.resolve() if args.root else _repo_root()
+
+    out, hard = check(root)
+
+    for line in out:
+        print(line)
+    if hard:
+        for v in hard:
+            print(f"lint-brief-coverage: {v}", file=sys.stderr)
+        print(
+            f"lint-brief-coverage: {len(hard)} stale Spec-map cell(s).",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packs/core/.apm/skills/receive-brief/scripts/test-lint-brief-coverage.py
+++ b/packs/core/.apm/skills/receive-brief/scripts/test-lint-brief-coverage.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Self-test for the sibling lint-brief-coverage.py (the brief-coverage rollup).
+
+Builds fixture brief + spec trees in a tempdir and runs the linter as a
+subprocess against the documented `python <skill>/scripts/lint-brief-coverage.py
+--root <dir>` invocation — the same shape `make build-check` uses (not a
+synthesised import, so the real `from .X import Y`-free entry point is
+exercised). Covers each acceptance case red-and-green: rollup of a mixed map,
+all-Shipped → delivered, empty map → not delivered, no-brief no-op, untracked
+back-link as informational, and a hand-edited stale cell as the fail-closed
+drift case.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+LINTER = Path(__file__).resolve().parent / "lint-brief-coverage.py"
+
+FAILURES: list[str] = []
+
+
+def expect(cond: bool, msg: str) -> None:
+    if not cond:
+        FAILURES.append(msg)
+
+
+def write_spec(root: Path, slug: str, status: str, brief: str | None = None) -> None:
+    p = root / "docs" / "specs" / slug / "spec.md"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    header = f"# Spec: {slug}\n\n- **Status:** {status}\n"
+    if brief is not None:
+        header += f"- **Brief:** {brief}\n"
+    header += "\n## Acceptance Criteria\n\n- [ ] AC1\n"
+    p.write_text(header, encoding="utf-8")
+
+
+def write_brief(root: Path, slug: str, rows: list[tuple[str, str]], stem: str | None = None) -> None:
+    """Write a brief with a two-column Spec map. `rows` is (spec-slug, recorded-status)."""
+    name = stem if stem is not None else slug
+    p = root / "docs" / "product" / "briefs" / f"{name}.md"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    body = f"# Brief: {slug}\n\n- **Slug:** `{slug}`\n\n## Spec map\n\n"
+    body += "| Spec | Status |\n| --- | --- |\n"
+    for spec_slug, recorded in rows:
+        body += f"| `{spec_slug}` | {recorded} |\n"
+    p.write_text(body, encoding="utf-8")
+
+
+def run_lint(root: Path) -> tuple[int, str, str]:
+    proc = subprocess.run(
+        [sys.executable, str(LINTER), "--root", str(root)],
+        capture_output=True, text=True,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def case_mixed_map_not_delivered() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_spec(root, "alpha", "Shipped", brief="myb")
+        write_spec(root, "beta", "Implementing", brief="myb")
+        write_brief(root, "myb", [("alpha", "Shipped"), ("beta", "Implementing")])
+        rc, out, err = run_lint(root)
+        expect(rc == 0, f"mixed map should exit 0, got {rc}: {err}")
+        expect("shipped" in out.lower(), f"alpha should roll up shipped: {out}")
+        expect("implementing" in out.lower(), f"beta should roll up implementing: {out}")
+        expect("not delivered" in out.lower(), f"mixed map → not delivered: {out}")
+
+
+def case_all_shipped_delivered() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_spec(root, "alpha", "Shipped", brief="myb")
+        write_spec(root, "beta", "Shipped", brief="myb")
+        write_brief(root, "myb", [("alpha", "Shipped"), ("beta", "Shipped")])
+        rc, out, err = run_lint(root)
+        expect(rc == 0, f"all-shipped should exit 0, got {rc}: {err}")
+        # "': delivered" disambiguates from "': not delivered".
+        expect("': delivered" in out, f"all-shipped brief → delivered: {out}")
+
+
+def case_empty_map_not_delivered() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_brief(root, "emptyb", [])
+        rc, out, err = run_lint(root)
+        expect(rc == 0, f"empty map should exit 0, got {rc}: {err}")
+        expect("not delivered" in out.lower(),
+               f"empty map is never vacuously delivered: {out}")
+        expect("': delivered" not in out,
+               f"empty map must NOT report delivered: {out}")
+
+
+def case_no_brief_noop() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_spec(root, "alpha", "Shipped")  # spec but no brief
+        rc, out, err = run_lint(root)
+        expect(rc == 0, f"no brief should exit 0, got {rc}: {err}")
+        expect(err.strip() == "", f"no brief → no diagnostic on stderr: {err!r}")
+        expect(out.strip() == "", f"no brief → no diagnostic on stdout: {out!r}")
+
+
+def case_template_skipped() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        # A `_template.md` placeholder in the briefs dir must NOT be treated
+        # as a real brief (it ships with the pack and projects into repos).
+        write_brief(root, "<one-line outcome>", [("<feature-slug>", "<auto>")],
+                    stem="_template")
+        rc, out, err = run_lint(root)
+        expect(rc == 0, f"template-only briefs dir should exit 0, got {rc}: {err}")
+        expect(out.strip() == "" and err.strip() == "",
+               f"_template.md must be skipped (no diagnostic): out={out!r} err={err!r}")
+
+
+def case_untracked_backlink_informational() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        # gamma back-links myb but is NOT in myb's Spec map → untracked.
+        write_spec(root, "alpha", "Shipped", brief="myb")
+        write_spec(root, "gamma", "Draft", brief="myb")
+        write_brief(root, "myb", [("alpha", "Shipped")])
+        rc, out, err = run_lint(root)
+        combined = (out + err).lower()
+        expect(rc == 0, f"untracked back-link must NOT be an error, got {rc}: {err}")
+        expect("untracked" in combined, f"gamma should be reported untracked: {out}{err}")
+        expect("gamma" in combined, f"untracked spec named: {out}{err}")
+
+
+def case_stale_cell_drifts_fail_closed() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        # beta is actually Shipped, but the brief's Spec map still records
+        # Implementing — a hand-edited stale cell. Fail closed.
+        write_spec(root, "alpha", "Shipped", brief="myb")
+        write_spec(root, "beta", "Shipped", brief="myb")
+        write_brief(root, "myb", [("alpha", "Shipped"), ("beta", "Implementing")])
+        rc, out, err = run_lint(root)
+        expect(rc == 1, f"stale recorded cell should exit 1, got {rc}: {out}")
+        expect("stale" in err.lower(), f"drift message should name staleness: {err}")
+        expect("beta" in err, f"drift message should name the spec: {err}")
+
+
+def case_unset_cell_is_not_drift() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        # An `<auto>` / unset cell means "not yet derived" — report, don't fail.
+        write_spec(root, "alpha", "Implementing", brief="myb")
+        write_brief(root, "myb", [("alpha", "<auto>")])
+        rc, out, err = run_lint(root)
+        expect(rc == 0, f"unset <auto> cell must not be drift, got {rc}: {err}")
+        expect("implementing" in out.lower(), f"derived status still reported: {out}")
+
+
+def case_slug_differs_from_filename() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        # The brief's Slug field (real-slug) differs from its filename stem
+        # (shape-a) — the shipped examples do exactly this. A spec back-links
+        # the SLUG; untracked detection must join on the slug, not the stem.
+        write_spec(root, "gamma", "Draft", brief="real-slug")
+        write_brief(root, "real-slug", [("alpha", "<auto>")], stem="shape-a")
+        rc, out, err = run_lint(root)
+        combined = (out + err).lower()
+        expect(rc == 0, f"untracked is informational, got {rc}: {err}")
+        expect("gamma" in combined and "untracked" in combined,
+               f"gamma back-links by slug, must be untracked: {out}{err}")
+
+
+def case_prose_pipe_after_table_is_not_a_row() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_spec(root, "alpha", "Shipped", brief="myb")
+        p = root / "docs" / "product" / "briefs" / "myb.md"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(
+            "# Brief: myb\n\n- **Slug:** `myb`\n\n## Spec map\n\n"
+            "| Spec | Status |\n| --- | --- |\n| `alpha` | Shipped |\n\n"
+            "Note: rows are added as slices ship | one per spec.\n",
+            encoding="utf-8",
+        )
+        rc, out, err = run_lint(root)
+        expect(rc == 0, f"prose pipe must not trip drift exit 1, got {rc}: {err}")
+        expect("stale" not in err.lower(), f"no phantom drift row: {err}")
+
+
+def case_lowercase_status_token_still_delivers() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_spec(root, "alpha", "shipped", brief="myb")  # lowercase token
+        write_brief(root, "myb", [("alpha", "Shipped")])
+        rc, out, err = run_lint(root)
+        expect(rc == 0, f"no drift expected, got {rc}: {err}")
+        expect("': delivered" in out,
+               f"lowercase 'shipped' must still count as delivered: {out}")
+
+
+def case_placeholder_brief_value_ignored() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_spec(root, "alpha", "Draft", brief="<slug>")  # template placeholder
+        write_brief(root, "myb", [("beta", "<auto>")])
+        rc, out, err = run_lint(root)
+        combined = out + err
+        expect(rc == 0, f"placeholder back-link must not error, got {rc}: {err}")
+        expect("<slug>" not in combined,
+               f"placeholder must not surface as a tracked/untracked slug: {combined}")
+
+
+def case_annotated_recorded_cell_not_drift() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        # A recorded cell annotated the same way a spec's own Status field may
+        # be (`Shipped (2026-06-01)`) must not misreport as drift against a
+        # derived `Shipped` — the recorded side is normalized symmetrically.
+        write_spec(root, "alpha", "Shipped", brief="myb")
+        write_brief(root, "myb", [("alpha", "Shipped (2026-06-01)")])
+        rc, out, err = run_lint(root)
+        expect(rc == 0, f"annotated recorded cell must not drift, got {rc}: {err}")
+        expect("stale" not in err.lower(), f"no false drift on annotated cell: {err}")
+        expect("': delivered" in out, f"annotated-cell brief still delivered: {out}")
+
+
+def main() -> int:
+    for case in (
+        case_mixed_map_not_delivered,
+        case_annotated_recorded_cell_not_drift,
+        case_all_shipped_delivered,
+        case_empty_map_not_delivered,
+        case_no_brief_noop,
+        case_template_skipped,
+        case_untracked_backlink_informational,
+        case_stale_cell_drifts_fail_closed,
+        case_unset_cell_is_not_drift,
+        case_slug_differs_from_filename,
+        case_prose_pipe_after_table_is_not_a_row,
+        case_lowercase_status_token_still_delivers,
+        case_placeholder_brief_value_ignored,
+    ):
+        case()
+    if FAILURES:
+        for f in FAILURES:
+            print(f"FAIL: {f}", file=sys.stderr)
+        print(f"test-lint-brief-coverage: {len(FAILURES)} failure(s).", file=sys.stderr)
+        return 1
+    print("test-lint-brief-coverage: all cases pass.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packs/core/seeds/docs/CONVENTIONS.md
+++ b/packs/core/seeds/docs/CONVENTIONS.md
@@ -50,6 +50,7 @@ below assigns every kind of doc to exactly one bucket.
    │  organized today.        │      │  doing today.              │
    │  Living. For contributors│      │  Living. For maintainers.  │
    │                          │      │  - roadmap.md              │
+   │                          │      │  - briefs/<slug>.md        │
    │                          │      │  - changelog.md            │
    │                          │      │  - personas.md (optional)  │
    └──────────────────────────┘      └────────────────────────────┘
@@ -66,6 +67,19 @@ below assigns every kind of doc to exactly one bucket.
 
 The bottom layers cite the upper layers; upper layers do not know about
 lower layers. That's the whole point of the hierarchy.
+
+**The brief altitude.** A *brief* (`product/briefs/<slug>.md`) sits between
+the roadmap and the specs — it is where an externally-authored, multi-feature
+product handoff (a PRD, a solution packet) lands when it's too big to be one
+spec. The altitude reads `roadmap → brief → spec → AC`: the roadmap names
+themes, a brief records one received outcome and the specs that deliver it, a
+spec is the engineering contract for one feature, and an acceptance criterion
+is the testable unit. A brief owns only **this repo's slice**; an optional
+`Epic:` field points up to an external coordinator when the work spans repos.
+A derived spec links back to its brief with a `Brief:` field (see § 4), and
+the brief's coverage map rolls up automatically from those specs' `Status:`
+fields. Use the `receive-brief` skill to receive, decompose, and execute a
+brief; it never mandates a schema.
 
 ---
 
@@ -270,6 +284,17 @@ mechanical rule.
   open work. Form: `- [ ] <outcome> (deferred: <backlog-anchor>)`. A deferral
   recorded only in a PR comment rots; the register is version-controlled and
   greppable.
+- **Brief back-link (optional).** A spec derived from a product brief carries a
+  `- **Brief:**` header naming that brief (`product/briefs/<slug>.md`). It
+  records *product provenance* and is distinct from `Constrained by:` (which
+  cites the ADRs/RFCs that govern the spec). The field is additive and optional
+  — a spec authored directly omits it and stays valid. The brief's coverage map
+  rolls up from these back-links automatically; never hand-write a spec's status
+  into the brief.
+- **Story trace (optional).** When the brief carries user stories (Shape B), an
+  acceptance criterion that satisfies a story appends a `Satisfies: US-n` marker
+  so coverage is story-granular. Optional — omit it for a no-stories brief or a
+  directly-authored spec.
 
 ### Contract vs. construction tests
 
@@ -387,6 +412,10 @@ right now?"
 - `changelog.md` — user-visible changes by release, in
   [Keep a Changelog](https://keepachangelog.com/) format. Updated in the
   same PR as any user-visible behavior change.
+- `briefs/<slug>.md` (optional) — a received, externally-authored
+  multi-feature product brief and its auto-rolled-up coverage map. Created by
+  the `receive-brief` skill; one file per brief. See the brief altitude under
+  *Document hierarchy*.
 - `personas.md` (optional) — who we're building for. Add only if it's
   actively used to make decisions; speculative personas rot.
 

--- a/packs/core/seeds/docs/product/briefs/_template.md
+++ b/packs/core/seeds/docs/product/briefs/_template.md
@@ -1,0 +1,76 @@
+# Brief: <one-line outcome>
+
+> **This is a template, not a schema.** It shows the *shape* of a received
+> product brief — a PRD, a solution handoff, an externally-authored packet of
+> work. Copy it to `docs/product/briefs/<slug>.md` and fill in what you have.
+> The `receive-brief` skill elicits the load-bearing fields conversationally
+> and never rejects a half-formed brief for non-conformance, so an empty
+> heading is a prompt, not an error. Keep only the sections that earn their
+> place.
+
+- **Slug:** `<slug>` <!-- kebab-case; matches the filename and the `Brief:` back-link on derived specs -->
+- **Received:** YYYY-MM-DD
+- **Owner:** <who owns delivering this repo's slice>
+- **Epic:** <!-- optional: id/link of an external coordinator (a tracker epic, an integration repo) when this repo's work is one slice of a cross-repo effort. Omit when there is none. -->
+
+## Outcome
+
+<!-- LOAD-BEARING. The problem and the user-facing outcome, in the user's
+terms. What changes for them when this is delivered? This is the one field
+the brief cannot do without. -->
+
+<one paragraph: the problem and the outcome>
+
+## Success metrics
+
+<!-- How will we know the outcome landed? Name observable signals, not
+activities. "p95 checkout under 400ms"; "support tickets for password reset
+down 50%". Offer your best guess if the brief arrived without them. -->
+
+-
+-
+
+## Scope / Non-goals
+
+<!-- The boundary of this repo's slice. Non-goals are as load-bearing as
+scope — they stop the decomposition from sprawling. -->
+
+**In scope:**
+
+-
+
+**Non-goals:**
+
+-
+
+## Appetite
+
+<!-- A *constraint*, not an estimate: how much time/effort this outcome is
+worth ("a few weeks, not a quarter"). It bounds the decomposition — slices
+that don't fit the appetite get cut or flagged, not silently absorbed. -->
+
+<the appetite>
+
+## User stories
+
+<!-- OPTIONAL (Shape B). When product supplies stories, give each an id
+(`US-1`, `US-2`, …) and trace it to the satisfying spec's acceptance criteria
+with a `Satisfies: US-n` marker on those ACs. Omit this whole section for a
+no-stories outcome brief (Shape A); the spec boundaries are then derived from
+Outcome + Scope and coverage is spec-granular. -->
+
+- **US-1.** As a <role>, I want <capability>, so that <benefit>.
+- **US-2.** …
+
+## Spec map
+
+<!-- Coverage table. The Status column is AUTO-DERIVED from each spec's own
+`Status:` field by the coverage lint — do not hand-edit it. Add one row per
+derived spec as `receive-brief` scaffolds it; each derived spec carries a
+`Brief: <slug>` back-link. A brief is *delivered* only when every mapped spec
+is Shipped; an empty map is never delivered. (Shape B adds a `Story` column
+linking each row to the `US-n` it satisfies.) -->
+
+| Spec | Status |
+| --- | --- |
+| `<feature-slug>` | <auto> |

--- a/tools/lint-seeds.py
+++ b/tools/lint-seeds.py
@@ -101,6 +101,7 @@ REQUIRED_PLACEHOLDERS: dict[str, tuple[str, ...]] = {
     "docs/product/README.md": (),
     "docs/product/roadmap.md": ("YYYY-MM-DD",),
     "docs/product/changelog.md": ("Unreleased",),
+    "docs/product/briefs/_template.md": ("<slug>", "<one-line outcome>"),
     "docs/CONVENTIONS.md": (),
     "AGENTS.md": ("<project-name>",),
     "docs/guides/README.md": (),


### PR DESCRIPTION
Implements `docs/specs/product-brief-intake/` (Constrained by RFC-0019, ADR-0009). Adopters who *receive* an externally-authored, multi-feature product brief (a PRD, a solution handoff) had no home for it — `core` jumped straight to single-feature `new-spec`. This adds the missing layer between roadmap and spec.

## What ships (all in `core`, additive)

- **Brief template seed** — `packs/core/seeds/docs/product/briefs/_template.md`, placeholder-shaped (registered in `tools/lint-seeds.py`).
- **`receive-brief` skill** — elicit load-bearing fields (never reject a half-formed brief) → decompose by shippability + surface the cut → execute each slice through `new-spec` → `work-loop`. Ships two labelled worked examples (Shape A no-stories, Shape B story-list).
- **Auto-rollup coverage lint** — `scripts/lint-brief-coverage.py` + self-test (13 cases). Reads each spec's `Status:` via `Brief:` back-links, reports delivered/not-delivered, untracked back-links informational, no-ops with no brief, **fail-closed on a hand-edited stale Spec-map cell**. Wired into `make build-check`.
- **Optional linkage fields** — `Brief:` on the spec template + `new-spec`; `Satisfies: US-n` AC marker; `Epic:` brief field. All additive — specs authored before this stay valid.
- **`CONVENTIONS.md`** — `briefs/` in the document hierarchy, the `roadmap → brief → spec → AC` altitude, the `Brief:`/`Satisfies:` fields.
- **Three adopter guides** — how-to, reference, explanation.

The four catalogue-internal RFC/spec references are confined to governance docs (spec/plan/CONVENTIONS amendment provenance); the adopter-facing skill, examples, and seed name no repo, RFC, or internal spec.

## Verification

- `make build-check` green end-to-end; the coverage lint **no-ops on this repo** (it ships no brief — `build-self` does not project `docs/product/briefs/` here, consistent with `docs/product/` being adopter-owned).
- Coverage lint TDD: 13 self-test cases (red→green), run via the documented file-path subprocess form.
- Spec marked **Shipped** with all 18 ACs `[x]` (spec + code land atomically); plan **Done**.

## Manual QA (AC: skill behavior + guide accuracy)

- Walked both shipped examples through the documented flow: `shape-a` (password-reset) — outcome+scope present, three independently-shippable slices, spec-granular map; `shape-b` (billing portal) — three stories grouped into three specs with a `Story` column + `Satisfies: US-n` traces. Both Spec maps are internally consistent with what the rollup lint produces.
- Read each guide against the shipped skill + template: how-to steps match the skill's three stages and the lint invocation; reference field list matches the template + linkage fields; explanation altitude matches the CONVENTIONS amendment.

## Review

`adversarial-reviewer` and `quality-engineer` both returned `Clean`. The quality pass caught a real **Blocker** — the coverage lint joined the `Brief:` back-link on the brief's *filename stem* rather than its `Slug:` field (the shipped examples have stem ≠ slug), which would have silently broken untracked detection — now fixed with `parse_brief_slug()` and a regression test. Also fixed: asymmetric drift-message normalization, prose-pipe phantom rows, case-insensitive delivered verdict, angle-bracket placeholder back-links. `security-reviewer` not run (no security boundary — a stdlib markdown-reading lint).

## Out of scope (sibling spec)

`Shape:` field and `## Design (LLD)` are owned by `lld-aware-spec-plan`, deliberately absent here.

## Deferred
- Leak-guard coverage for adopter-facing skill bodies/`examples/` (today only seeds are linted for internal-name leakage) — recorded in `docs/backlog.md`. Pre-existing catalogue gap surfaced by this PR, not introduced by it.

## Bundled fixes
- `tools/lint-seeds.py`: registered the new `_template.md` seed's placeholder shape (required for the existing seed lint to accept it — same-area, same-concern consequence of shipping the seed).