### PR TITLE
feat(core): greenfield-inception front door — init-project skill, two front doors, adopter guides

### DIFF
--- a/.claude/skills/init-project/SKILL.md
+++ b/.claude/skills/init-project/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: init-project
+description: Use this skill to turn an idea into a structured new repo. It runs a trigger gate (throwaways and single scripts skip it), a value gate over fed-in discovery, records a foundation (an ADR plus a reference.md golden path), authors a walking-skeleton spec via new-spec and hands the build to work-loop, then hands off to the normal build loop. Triggers on "start a new project", "greenfield init", "idea to repo", "bootstrap a new codebase". Do NOT use inside an existing repo (use adapt-to-project) or to author one feature (use new-spec).
+---
+
+# Skill: init-project
+
+The greenfield front door. An idea arrives and there is no repo yet — no
+foundation recorded, no first slice built. The temptation is to *yolo* a
+throwaway prototype, get it sort-of working, then retrofit structure and lose
+the rationale. This skill gives that path a home: it turns an idea into a
+structured repo by **composing the skills the repo already owns**. It
+orchestrates; it does not reinvent, and it is **not** an autonomous code
+generator — the human stays in the loop and the existing skills do the work.
+
+It is the twin of `adapt-to-project` (the brownfield front door, for an
+*existing* repo). Both converge on the same downstream loop:
+`brief → reference.md → spec → low-level design → work-loop`.
+
+## When to invoke
+
+Invoke when the unit of work is a **brand-new repo from an idea** and there are
+real **stack / structure / tooling decisions** ahead — a service, a library, a
+multi-component app someone will maintain. The tells: "start a new project",
+"bootstrap this idea into a repo", "we're greenfielding X".
+
+Do **not** use it when:
+
+- You are inside an existing codebase → `adapt-to-project` is the brownfield
+  front door.
+- You want to author one feature from scratch → `new-spec`.
+- The thing ahead is a script, a spike, or a throwaway with no real structural
+  decisions → the **trigger gate** (stage 1) sends it straight to scaffolding;
+  don't force the flow onto it.
+
+## The flow — five phases, fluid not waterfall
+
+The five stages below are **fluid phases of attention, not a waterfall**. You
+revisit them as understanding firms up — authoring the walking skeleton
+routinely sends you back to amend the foundation, and that's the flow working,
+not failing. Each phase practises a **scoped handoff**: it passes the next phase
+only the artifacts that phase needs, nothing more.
+
+The skill **composes** existing skills and assets by *reference* — it names them
+and hands off to them; it never restates their procedures and never imports
+their code.
+
+### 1. Trigger gate — run this first
+
+Before any other work, decide whether the flow even applies:
+
+- **Real stack / structure / tooling decisions ahead?** (Which runtime? How is
+  it partitioned? What's the persistence and transport story?) → **continue** to
+  stage 2.
+- **A script, a spike, or a throwaway?** → **scaffold it directly and skip the
+  rest of this skill.** The flow's ceremony is wasted on code nobody will
+  maintain.
+
+Worked example. *"A 40-line script to rename files in a folder"* → no
+architecture decisions → skip the flow, just write the script. *"A webhook
+ingestion service with a queue, a worker, and a datastore"* → real decisions →
+continue.
+
+### 2. Value gate — over fed-in discovery
+
+Discovery is **fed in**, never performed here (see anti-patterns). Consume a
+discovery shape from one of three upstream sources:
+
+- the `research` skill's output (when the `research` pack is installed),
+- a provided PRD, or
+- a brief produced by `receive-brief`.
+
+From that input, derive the **business value** and the **MVP**: what outcome
+this serves and the smallest thing that delivers it. **Gate on it** — if you
+cannot state the business value plainly, *pause and send discovery back
+upstream* rather than guessing. Don't paper over a thin idea with a plausible
+mission.
+
+The phase's output is the first **brief** (`docs/product/briefs/<slug>.md`, the
+artifact `receive-brief` owns) — the *what / why* that the rest of the flow and
+the downstream loop read. Hand that brief forward; nothing else.
+
+### 3. Foundation — decide the stack, record the rationale
+
+Choose the stack and architecture, and **record the decision with its
+rationale** — a foundation you can hold later work to. Two artifacts:
+
+- **An ADR** capturing *what* you chose, *why*, the *alternatives* weighed, and
+  a *re-evaluation date*. A stack chosen with no recorded rationale is the thing
+  to stop and fix before going further.
+- **`docs/architecture/reference.md`** — the normative golden path (constraints,
+  solution strategy, building blocks, cross-cutting standards). Instantiate it
+  from the arc42 `reference.md` template the `adapt-to-project` skill bundles
+  (the same golden-path template its reference-architecture harvest fills) —
+  here you fill it forward from a decision rather than harvesting it from
+  existing code. The core methodology stays stack-neutral; the chosen stack is
+  *yours*, recorded in your ADR and your `reference.md`.
+
+Hand the foundation forward as the steering every later design conforms to.
+
+### 4. Walking skeleton — author the spec, hand the build to work-loop
+
+Author a **walking skeleton**: a thin, end-to-end slice that links the main
+architectural components — the smallest thing that exercises the real wiring
+(an inbound request reaching a real datastore through the real transport, say),
+not a sketch and not a throwaway. It is **kept and minimal**, held to a real
+feature contract.
+
+- Author it as a **single spec via `new-spec`** — one thin slice, with its own
+  acceptance criteria and `Shape:`.
+- **Hand the build to `work-loop`.** This skill orchestrates; `work-loop`
+  executes. Do not build the skeleton here — that would duplicate the loop the
+  repo already owns.
+
+If building the skeleton reveals the foundation was wrong, go back to stage 3
+and amend it — that's the fluid-phase posture, not a failure.
+
+### 5. Handoff — into the normal build loop
+
+From the skeleton onward, the project runs the ordinary loop:
+`brief → spec → low-level design → work-loop`, with `reference.md` in place for
+every feature's low-level design to conform to. The greenfield front door has
+done its job: a recorded foundation, a validated walking skeleton, and the
+normal loop running — instead of a throwaway someone has to clean up later.
+
+## Anti-patterns to refuse
+
+- **Performing discovery / research yourself.** Discovery is fed *in* (stage 2)
+  from the `research` pack, a PRD, or a `receive-brief` brief. This skill
+  consumes a discovery shape; it does not own the research phase.
+- **Building an autonomous multi-agent "software company" generator.** The human
+  stays in the loop and the existing skills do the work. The wins of a swarm of
+  agents auto-generating a codebase are survivorship-bias stories; the boring,
+  composed, human-in-the-loop path is the one that ships maintainable code.
+- **Forcing the flow onto throwaways.** The trigger gate exists to keep scripts
+  and spikes on the fast path. A flow that adds ceremony to a 40-line script is
+  friction, not discipline.
+- **Producing a throwaway prototype in place of the walking skeleton.** The
+  skeleton is kept and minimal, authored as a real spec and built through
+  `work-loop` — not a sketch you'll discard.
+- **Choosing a stack with no recorded rationale.** The foundation's ADR comes
+  before the skeleton is authored, so the *why* survives.
+- **Adding a new top-level directory, or importing another pack's code.** This
+  skill lives beside the other core skills and composes the rest **by reference,
+  not import** — it names `research`, `receive-brief`, the arc42 `reference.md`
+  template, `new-spec`, and `work-loop`, and hands off to them.
+- **Restating what a composed skill already documents.** Reference `new-spec`,
+  `work-loop`, and the brief; don't copy their procedures into this file.
+
+## When this skill is wrong
+
+If you're inside an existing repo, this is the wrong door — use
+`adapt-to-project`. If the idea is a one-off script, the trigger gate should
+already have sent you to scaffold it directly. And if the flow ever feels like
+ceremony getting in the way of a genuinely small thing, trust the trigger gate
+over the procedure.

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -629,6 +629,25 @@ doc, skill, or note has wasted what it learned. The next agent (or a
 human) will pay for it again. The work-loop skill enumerates where each
 kind of learning belongs.
 
+### Two front doors
+
+Work enters this loop through one of two front doors, depending on whether the
+repo already exists:
+
+- **Greenfield — a brand-new repo from an idea.** The `init-project` skill is
+  the front door. It runs a trigger gate (throwaways and one-off scripts skip
+  the flow), a value gate over fed-in discovery, records a foundation (an ADR
+  plus `docs/architecture/reference.md`), authors a walking-skeleton spec via
+  `new-spec`, and hands the build to `work-loop`.
+- **Brownfield — an existing repo.** The `adapt-to-project` skill is the front
+  door, run after installing a pack to fit the conventions to what's already
+  there — including harvesting a `reference.md` from the existing code.
+
+Both converge on the same downstream loop: `brief → reference.md → spec →
+low-level design → work-loop`. Neither is mandatory ceremony — the greenfield
+trigger gate sends a throwaway straight to scaffolding, and a small change in an
+existing repo just opens a PR.
+
 ### Work-loop state
 
 The work-loop's `state.json` schema, exit contract, lifecycle, and

--- a/docs/guides/explanation/foundation-vs-map.md
+++ b/docs/guides/explanation/foundation-vs-map.md
@@ -89,3 +89,4 @@ them. For how the design consumes it, see
 - [`reference.md` sections and the stack-pack contract](../reference/reference-architecture.md) — the authoritative section list and contract.
 - [Create and use your `reference.md`](../tutorials/create-your-reference-architecture.md) — the guided first walkthrough.
 - [Establish your repo's reference architecture](../how-to/establish-reference-architecture.md) — the task recipe, with variations.
+- [Decide and record your foundation during inception](../how-to/record-your-foundation-during-inception.md) — filling `reference.md` forward for a brand-new repo.

--- a/docs/guides/explanation/walking-skeleton-vs-throwaway.md
+++ b/docs/guides/explanation/walking-skeleton-vs-throwaway.md
@@ -1,0 +1,73 @@
+# About the walking skeleton
+
+> Why the greenfield front door builds a kept, minimal, end-to-end **walking
+> skeleton** instead of a throwaway prototype — and why that one choice changes
+> how a new project ages. This page is for readers who want to understand the
+> reasoning, not to run the flow. To run it, follow
+> [From idea to a walking skeleton](../tutorials/start-a-new-project.md).
+
+## The question this page answers
+
+When you start a new project from an idea, you face a fork: build a quick
+throwaway to feel the shape of the thing, or build a thin slice you intend to
+keep. Both put working software in front of you fast. So why does `init-project`
+insist on the second — a walking skeleton authored as a real spec and built
+through `work-loop` — and refuse to generate a throwaway? Because the two look
+similar on day one and diverge sharply by month three.
+
+## The shape of the answer
+
+A **walking skeleton** is the thinnest slice that wires the *real* components
+together end to end: a real request reaching a real datastore through the real
+transport. It does almost nothing — but what it does, it does through the
+architecture you actually chose. It is **kept**: held to a feature contract,
+covered by tests, the literal first commit of the system you're building.
+
+A **throwaway prototype** optimizes for a different thing — learning fast by
+cutting corners. Hardcoded values, no tests, the datastore faked, the transport
+stubbed. That's a legitimate tool for *answering a question* (a spike). The
+failure mode is what happens next: the prototype sort-of works, the pressure to
+ship is real, and nobody finds the moment to throw it away. It gets retrofitted
+into the foundation instead — and the rationale for every shortcut, never
+written down, is lost. You inherit the corners without the reasons.
+
+The walking skeleton dodges that trap by being kept *from the start*. There is
+no "throw it away" moment to miss, because it was never disposable. The first
+real feature extends it; it doesn't replace it.
+
+## Design choices and tradeoffs
+
+- **Orchestrate, don't generate.** `init-project` authors the skeleton as a spec
+  and hands the build to `work-loop` rather than generating the code itself. The
+  alternative — an autonomous multi-agent generator that emits a whole codebase
+  — trades the human-in-the-loop discipline (gates, adversarial review, scope
+  control) for speed, and the "it just built the whole app" stories are
+  survivorship bias. Composing the skills the repo already owns keeps every
+  guardrail the normal loop has.
+- **A foundation before the skeleton.** The stack is decided and recorded (an
+  ADR plus `reference.md`) *before* the skeleton is authored, so the skeleton
+  wires together components that were chosen on purpose. A skeleton built before
+  the foundation would bake in accidental choices — exactly the throwaway
+  failure mode, one level up.
+- **Fluid phases, not a waterfall.** Authoring the skeleton routinely surfaces a
+  wrong foundation decision; the flow expects you to go back and amend it. The
+  skeleton is kept, but the foundation stays revisable until the build confirms
+  it.
+
+## How this differs from a spike
+
+A **spike** is a throwaway by design — you build it to answer a question ("can
+this library do X?"), you read the answer, you delete the code. That's healthy,
+and the greenfield trigger gate explicitly sends spikes and one-off scripts
+*away* from this flow. The distinction is intent: a spike's value is the
+*knowledge* it produces and its code is disposable; a walking skeleton's value
+is the *code* it produces and it's the first brick of the building. Confusing
+the two — keeping a spike, or contract-testing a throwaway — is where the
+trouble starts.
+
+## See also
+
+- [From idea to a walking skeleton](../tutorials/start-a-new-project.md) — the guided first walkthrough.
+- [Decide and record your foundation during inception](../how-to/record-your-foundation-during-inception.md) — the foundation step the skeleton builds on.
+- [About foundation vs. map](../explanation/foundation-vs-map.md) — the normative golden path the skeleton conforms to.
+- [Why a brief layer](why-a-brief-layer.md) — the value-gate output that feeds inception.

--- a/docs/guides/how-to/establish-reference-architecture.md
+++ b/docs/guides/how-to/establish-reference-architecture.md
@@ -55,13 +55,20 @@ your repo. The delivery rules are specified in
 
 ## Route 3 — Greenfield, at project bootstrap
 
-A guided greenfield path — a bootstrap step that writes your first
-`reference.md` as you stand up a new project — is **planned but not yet
-available**. Until it ships, bootstrap a greenfield repo by copying the arc42
-template into `docs/architecture/reference.md` by hand (the template ships inside
-the `adapt-to-project` skill's `assets/` folder) and filling the sections you've
-decided on. Follow [Create and use your `reference.md`](../tutorials/create-your-reference-architecture.md)
-for the walkthrough.
+When you're standing up a brand-new repo from an idea, the `init-project` skill
+is the front door, and writing your first `reference.md` is its **foundation**
+step. It walks you through choosing the stack, recording the rationale as an
+ADR, and instantiating `reference.md` from the arc42 template — filled forward
+from your decision rather than harvested from existing code.
+
+1. Run the `init-project` skill in your new repo.
+2. At the foundation step, decide the load-bearing stack choices and let the
+   skill capture them as an ADR plus `docs/architecture/reference.md`. See
+   [Decide and record your foundation during inception](record-your-foundation-during-inception.md)
+   for that step on its own.
+
+For the whole greenfield flow end to end — idea through walking skeleton —
+follow [From idea to a walking skeleton](../tutorials/start-a-new-project.md).
 
 ## Verify
 

--- a/docs/guides/how-to/record-your-foundation-during-inception.md
+++ b/docs/guides/how-to/record-your-foundation-during-inception.md
@@ -1,0 +1,73 @@
+# Decide and record your foundation during inception
+
+This guide is for someone running the greenfield front door (`init-project`) who
+has reached the **foundation** step and needs to choose the stack and record it
+well. It assumes you've already passed the value gate — you can state the
+business value and the MVP — and you know what a `reference.md` is for. If you
+don't, read [About foundation vs. map](../explanation/foundation-vs-map.md)
+first.
+
+If you're starting from the very beginning, walk
+[From idea to a walking skeleton](../tutorials/start-a-new-project.md) instead —
+this guide zooms in on one step of that flow.
+
+## Before you start
+
+You need:
+
+- A stated business value and MVP (the value gate's output — the first brief).
+- The `init-project` skill running, at the foundation step.
+
+## Steps
+
+1. **Decide only the load-bearing choices.** Name the few decisions that shape
+   most of the codebase — the runtime and language, how the system is
+   partitioned, where state lives, the transport. Leave everything a future
+   feature can decide later *to* that feature.
+2. **Write the ADR.** Record *what* you chose, *why*, the *alternatives* you
+   weighed, and a *re-evaluation date*. The ADR is the thing that survives after
+   the reasoning leaves your head — a stack chosen with no recorded rationale is
+   the gap this step exists to close.
+3. **Instantiate `reference.md` from the arc42 template.** Fill
+   `docs/architecture/reference.md` forward from the decision you just made —
+   the **Solution strategy** section at minimum (your stack and the one-line
+   reason each choice won). The template is the same golden-path one the
+   `adapt-to-project` skill bundles; here you fill it from a decision rather than
+   harvesting it from existing code.
+4. **Hand the foundation forward.** The walking-skeleton spec, and every feature
+   after it, reads `reference.md` as steering. You don't need to fill every
+   section now — name what you've actually decided and leave the rest.
+
+## Variations
+
+Real inceptions branch. Cover the cases you're likely to hit:
+
+- **If the idea is still thin:** you may only be able to fill **Solution
+  strategy** and **Constraints**. That's fine — fill what you've decided and
+  leave the building-block and standards sections for when those decisions
+  become real. An under-filled `reference.md` beats an invented one.
+- **If a stack pack matches your choice:** install it and let it deliver a
+  pre-filled `reference.md` as a seed, then edit it to be *true* for your repo.
+  See [Establish your repo's reference architecture](establish-reference-architecture.md)
+  for the stack-pack route.
+- **If building the skeleton later proves the foundation wrong:** go back and
+  amend it. The inception phases are fluid, not a waterfall — record the change
+  (a superseding ADR) rather than quietly editing the decision away.
+
+## Common pitfalls
+
+- **Choosing a stack with no ADR.** The skill should stop you before the
+  skeleton is authored. If you skipped it, write the ADR now — the *why* is the
+  whole point, and it's cheapest to capture while it's fresh.
+- **Over-filling `reference.md` with invented constraints.** A foundation that
+  prescribes standards nobody agreed to manufactures drift. Record only
+  decisions you've actually made; the document's power comes from every line
+  being one a reviewer could hold a pull request to.
+- **Treating `reference.md` as the map.** It's the normative golden path, not a
+  description of what exists — that's `overview.md`'s job. Keep them separate.
+
+## See also
+
+- [`reference.md` sections and the stack-pack contract](../reference/reference-architecture.md) — the authoritative section list.
+- [About foundation vs. map](../explanation/foundation-vs-map.md) — why `reference.md` and `overview.md` stay separate.
+- [Why a walking skeleton beats a throwaway prototype](../explanation/walking-skeleton-vs-throwaway.md) — what the foundation steers next.

--- a/docs/guides/tutorials/start-a-new-project.md
+++ b/docs/guides/tutorials/start-a-new-project.md
@@ -1,0 +1,113 @@
+# From idea to a walking skeleton: start a new project
+
+> At the end of this tutorial you'll have a brand-new repo with a recorded
+> foundation — an ADR and a `docs/architecture/reference.md` — and a
+> walking-skeleton spec authored and ready to build. You'll learn the rhythm of
+> the greenfield front door by walking it once.
+
+This is a learning walkthrough, not a reference. For *why* the skeleton is built
+this way, read [Why a walking skeleton beats a throwaway prototype](../explanation/walking-skeleton-vs-throwaway.md)
+afterward; for the foundation step on its own, see
+[Decide and record your foundation during inception](../how-to/record-your-foundation-during-inception.md).
+
+We'll use one concrete idea throughout: **a URL-shortener service** — an API
+that takes a long URL and returns a short code, with a datastore behind it.
+It has real components, so it's a genuine project, not a throwaway.
+
+## Before you begin
+
+You need:
+
+- An empty (or nearly empty) repo you can commit to.
+- The `init-project` skill available in your repo.
+- A discovery shape to feed in — for this tutorial, a one-paragraph PRD is
+  enough: *"Users paste a long URL and get back a short link they can share;
+  links resolve fast and never expire. MVP: create a short link and resolve
+  it."* (In real use this comes from the `research` skill or a `receive-brief`
+  brief; a written PRD works the same way.)
+
+## Step 1 — Start the flow and pass the trigger gate
+
+Run the `init-project` skill and tell it your idea: *"Start a new project — a
+URL-shortener service."*
+
+The skill runs its **trigger gate** first. Because a shortener has real
+decisions ahead (an API, a datastore, a transport), the gate continues into the
+flow rather than sending you to scaffold a one-off script.
+
+You should see the skill confirm there are real structural decisions and move on
+to ask for your discovery input — not drop you straight into writing code.
+
+> If you don't see this: if the skill decides to just scaffold and stop, it
+> judged your idea a throwaway. For anything with a datastore and an API, say so
+> explicitly — "this is a maintained service, not a script" — and it will
+> continue.
+
+## Step 2 — Feed in discovery and pass the value gate
+
+Paste your one-paragraph PRD when the skill asks for the discovery input. The
+skill **consumes** it — it does not go research the idea itself.
+
+From the PRD it derives the **business value** ("sharable short links that
+resolve fast") and the **MVP** ("create a short link and resolve it"), and
+writes the first **brief**.
+
+You should see a new file at `docs/product/briefs/url-shortener.md` capturing the
+outcome and scope. Open it and confirm the value is stated plainly.
+
+> If you don't see this: if the skill pauses and asks you to sharpen the idea,
+> the value gate caught a gap — the PRD was too thin to state the value. Add the
+> missing piece (who it's for, what outcome it serves) and continue. That pause
+> is the gate working, not an error.
+
+## Step 3 — Record the foundation
+
+The skill now helps you choose the stack and **record the rationale**. Decide
+the few load-bearing things (say: a small HTTP service, a key-value store for
+the code-to-URL mapping) and let the skill capture them as two artifacts:
+
+- an **ADR** stating what you chose, why, the alternatives, and a re-evaluation
+  date;
+- a `docs/architecture/reference.md` — your golden path — instantiated from the
+  arc42 template and filled forward from the decision you just made.
+
+You should see both files written: an ADR under `docs/adr/` and
+`docs/architecture/reference.md` with at least the **Solution strategy** section
+naming your stack and the one-line reason it won.
+
+## Step 4 — Author the walking skeleton
+
+Now author the **walking skeleton**: the thinnest slice that wires the real
+components together end to end. For the shortener, that's *one request that
+creates a short code and stores it, and one that resolves a code back to the
+URL* — touching the real API and the real datastore, nothing mocked away.
+
+The skill authors this as a single spec via `new-spec` and hands the build to
+`work-loop`. It does not build the skeleton itself — orchestrating that build is
+`work-loop`'s job.
+
+You should see a new `docs/specs/walking-skeleton/` (or similarly named)
+spec with its own acceptance criteria, and the skill handing off to `work-loop`
+to build it.
+
+## What you built
+
+You now have a brand-new repo with a **recorded foundation** (an ADR plus
+`reference.md`) and a **walking-skeleton spec** authored and ready to build —
+not a throwaway you'll later have to clean up. Commit the foundation:
+
+```bash
+git add docs/adr docs/architecture/reference.md docs/product/briefs docs/specs
+git commit -m "chore: record foundation and author walking skeleton"
+```
+
+From here the project runs the ordinary loop.
+
+## Next steps
+
+- To build the skeleton and every feature after it: the
+  [`work-loop` plan-and-execute how-to](../how-to/plan-and-execute-non-trivial-work.md).
+- To go deeper on the foundation step alone:
+  [Decide and record your foundation during inception](../how-to/record-your-foundation-during-inception.md).
+- To understand *why* the skeleton is kept-and-minimal rather than a throwaway:
+  [Why a walking skeleton beats a throwaway prototype](../explanation/walking-skeleton-vs-throwaway.md).

--- a/docs/specs/greenfield-inception/plan.md
+++ b/docs/specs/greenfield-inception/plan.md
@@ -1,7 +1,7 @@
 # Plan: greenfield-inception
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Drafting <!-- Drafting | Executing | Done -->
+- **Status:** Done <!-- Drafting | Executing | Done -->
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
 > document is allowed to change as you learn. When it changes substantially

--- a/docs/specs/greenfield-inception/spec.md
+++ b/docs/specs/greenfield-inception/spec.md
@@ -1,6 +1,6 @@
 # Spec: greenfield-inception
 
-- **Status:** Draft <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** RFC-0021, ADR-0011
@@ -119,52 +119,52 @@ checks plus manual QA of the documented judgment.
 
 ## Acceptance Criteria
 
-- [ ] The **`init-project`** skill ships at
+- [x] The **`init-project`** skill ships at
   `packs/core/.apm/skills/init-project/SKILL.md` with valid frontmatter that
   passes `tools/lint-skill-spec.py`.
-- [ ] The skill documents the **trigger gate as its first step** — real
+- [x] The skill documents the **trigger gate as its first step** — real
   stack/structure/tooling decisions → continue; a script / spike / throwaway →
   scaffold directly and skip the flow (Decision 3).
-- [ ] The skill documents **consuming fed-in discovery** from any of the three
+- [x] The skill documents **consuming fed-in discovery** from any of the three
   sources (`research`-pack output, a provided PRD, a `receive-brief` brief) and
   states explicitly that it **does not perform discovery itself**.
-- [ ] The skill documents the **value gate**: derive business value + MVP from the
+- [x] The skill documents the **value gate**: derive business value + MVP from the
   discovery; pause and send discovery upstream if the value can't be stated
   plainly. Its output is the first **brief** (the RFC-0019 artifact).
-- [ ] The skill documents the **foundation step**: choose the stack/architecture
+- [x] The skill documents the **foundation step**: choose the stack/architecture
   with recorded rationale — an **ADR** (what / why / alternatives / re-evaluation
   date) **and `reference.md`**, authored from the arc42 template asset at
   `packs/core/.apm/skills/adapt-to-project/assets/reference.md` (the greenfield
   population path ADR-0010 names).
-- [ ] The skill documents the **walking-skeleton step**: author a single spec via
+- [x] The skill documents the **walking-skeleton step**: author a single spec via
   `new-spec` for a thin end-to-end slice that links the main architectural
   components, and **hand the build to `work-loop`** — kept and minimal, not a
   throwaway (resolves RFC-0021 Open Question 1: orchestrate, don't execute).
-- [ ] The skill documents the **handoff**: from the skeleton on, the normal
+- [x] The skill documents the **handoff**: from the skeleton on, the normal
   `brief → spec → LLD → work-loop` loop runs with `reference.md` in place for every
   LLD to conform to.
-- [ ] The skill documents the **fluid-not-waterfall** posture (revisitable phases)
+- [x] The skill documents the **fluid-not-waterfall** posture (revisitable phases)
   and **scoped handoffs** (each step receives only the artifacts the next needs).
-- [ ] The skill's **anti-patterns** explicitly **decline the autonomous
+- [x] The skill's **anti-patterns** explicitly **decline the autonomous
   multi-agent generator** and **forbid forcing ceremony on throwaways** (Decision
   4 + the trigger gate).
-- [ ] **No new top-level directory and no cross-pack import** are introduced — the
+- [x] **No new top-level directory and no cross-pack import** are introduced — the
   skill lives under `packs/core/.apm/skills/` and composes other skills by
   reference, not import.
-- [ ] The **`CONVENTIONS.md` seed amendment** documents the **two front-doors**
+- [x] The **`CONVENTIONS.md` seed amendment** documents the **two front-doors**
   (greenfield `init-project` / brownfield `adapt-to-project`) and where each enters
   the loop; it lands in this spec's implementing PR (it documents an entry point
   this spec creates, so it ships atomically with it).
-- [ ] **`make build-self`** projects the new core skill cleanly (no unexpected
+- [x] **`make build-self`** projects the new core skill cleanly (no unexpected
   reverts to projected paths) and **`make build-check`** is green.
-- [ ] Three adopter-facing **guide files exist** under `docs/guides/` at their
+- [x] Three adopter-facing **guide files exist** under `docs/guides/` at their
   Diátaxis paths — a **tutorial** ("From idea to a walking skeleton: start a new
   project"), a **how-to** ("Decide and record your foundation during inception"),
   and an **explanation** ("Why a walking skeleton beats a throwaway prototype").
   *(Authored in this catalogue repo via `new-guide`, which lives in the non-core
   `user-guide-diataxis` pack; guide authoring is not a capability `core` ships to
   adopters — per RFC-0021's "guides in this catalogue repo" scoping.)*
-- [ ] Each of the three guides **reads accurately** against the shipped skill
+- [x] Each of the three guides **reads accurately** against the shipped skill
   (manual-QA review recorded in the implementing PR).
 
 ## Assumptions

--- a/packs/core/.apm/skills/init-project/SKILL.md
+++ b/packs/core/.apm/skills/init-project/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: init-project
+description: Use this skill to turn an idea into a structured new repo. It runs a trigger gate (throwaways and single scripts skip it), a value gate over fed-in discovery, records a foundation (an ADR plus a reference.md golden path), authors a walking-skeleton spec via new-spec and hands the build to work-loop, then hands off to the normal build loop. Triggers on "start a new project", "greenfield init", "idea to repo", "bootstrap a new codebase". Do NOT use inside an existing repo (use adapt-to-project) or to author one feature (use new-spec).
+---
+
+# Skill: init-project
+
+The greenfield front door. An idea arrives and there is no repo yet — no
+foundation recorded, no first slice built. The temptation is to *yolo* a
+throwaway prototype, get it sort-of working, then retrofit structure and lose
+the rationale. This skill gives that path a home: it turns an idea into a
+structured repo by **composing the skills the repo already owns**. It
+orchestrates; it does not reinvent, and it is **not** an autonomous code
+generator — the human stays in the loop and the existing skills do the work.
+
+It is the twin of `adapt-to-project` (the brownfield front door, for an
+*existing* repo). Both converge on the same downstream loop:
+`brief → reference.md → spec → low-level design → work-loop`.
+
+## When to invoke
+
+Invoke when the unit of work is a **brand-new repo from an idea** and there are
+real **stack / structure / tooling decisions** ahead — a service, a library, a
+multi-component app someone will maintain. The tells: "start a new project",
+"bootstrap this idea into a repo", "we're greenfielding X".
+
+Do **not** use it when:
+
+- You are inside an existing codebase → `adapt-to-project` is the brownfield
+  front door.
+- You want to author one feature from scratch → `new-spec`.
+- The thing ahead is a script, a spike, or a throwaway with no real structural
+  decisions → the **trigger gate** (stage 1) sends it straight to scaffolding;
+  don't force the flow onto it.
+
+## The flow — five phases, fluid not waterfall
+
+The five stages below are **fluid phases of attention, not a waterfall**. You
+revisit them as understanding firms up — authoring the walking skeleton
+routinely sends you back to amend the foundation, and that's the flow working,
+not failing. Each phase practises a **scoped handoff**: it passes the next phase
+only the artifacts that phase needs, nothing more.
+
+The skill **composes** existing skills and assets by *reference* — it names them
+and hands off to them; it never restates their procedures and never imports
+their code.
+
+### 1. Trigger gate — run this first
+
+Before any other work, decide whether the flow even applies:
+
+- **Real stack / structure / tooling decisions ahead?** (Which runtime? How is
+  it partitioned? What's the persistence and transport story?) → **continue** to
+  stage 2.
+- **A script, a spike, or a throwaway?** → **scaffold it directly and skip the
+  rest of this skill.** The flow's ceremony is wasted on code nobody will
+  maintain.
+
+Worked example. *"A 40-line script to rename files in a folder"* → no
+architecture decisions → skip the flow, just write the script. *"A webhook
+ingestion service with a queue, a worker, and a datastore"* → real decisions →
+continue.
+
+### 2. Value gate — over fed-in discovery
+
+Discovery is **fed in**, never performed here (see anti-patterns). Consume a
+discovery shape from one of three upstream sources:
+
+- the `research` skill's output (when the `research` pack is installed),
+- a provided PRD, or
+- a brief produced by `receive-brief`.
+
+From that input, derive the **business value** and the **MVP**: what outcome
+this serves and the smallest thing that delivers it. **Gate on it** — if you
+cannot state the business value plainly, *pause and send discovery back
+upstream* rather than guessing. Don't paper over a thin idea with a plausible
+mission.
+
+The phase's output is the first **brief** (`docs/product/briefs/<slug>.md`, the
+artifact `receive-brief` owns) — the *what / why* that the rest of the flow and
+the downstream loop read. Hand that brief forward; nothing else.
+
+### 3. Foundation — decide the stack, record the rationale
+
+Choose the stack and architecture, and **record the decision with its
+rationale** — a foundation you can hold later work to. Two artifacts:
+
+- **An ADR** capturing *what* you chose, *why*, the *alternatives* weighed, and
+  a *re-evaluation date*. A stack chosen with no recorded rationale is the thing
+  to stop and fix before going further.
+- **`docs/architecture/reference.md`** — the normative golden path (constraints,
+  solution strategy, building blocks, cross-cutting standards). Instantiate it
+  from the arc42 `reference.md` template the `adapt-to-project` skill bundles
+  (the same golden-path template its reference-architecture harvest fills) —
+  here you fill it forward from a decision rather than harvesting it from
+  existing code. The core methodology stays stack-neutral; the chosen stack is
+  *yours*, recorded in your ADR and your `reference.md`.
+
+Hand the foundation forward as the steering every later design conforms to.
+
+### 4. Walking skeleton — author the spec, hand the build to work-loop
+
+Author a **walking skeleton**: a thin, end-to-end slice that links the main
+architectural components — the smallest thing that exercises the real wiring
+(an inbound request reaching a real datastore through the real transport, say),
+not a sketch and not a throwaway. It is **kept and minimal**, held to a real
+feature contract.
+
+- Author it as a **single spec via `new-spec`** — one thin slice, with its own
+  acceptance criteria and `Shape:`.
+- **Hand the build to `work-loop`.** This skill orchestrates; `work-loop`
+  executes. Do not build the skeleton here — that would duplicate the loop the
+  repo already owns.
+
+If building the skeleton reveals the foundation was wrong, go back to stage 3
+and amend it — that's the fluid-phase posture, not a failure.
+
+### 5. Handoff — into the normal build loop
+
+From the skeleton onward, the project runs the ordinary loop:
+`brief → spec → low-level design → work-loop`, with `reference.md` in place for
+every feature's low-level design to conform to. The greenfield front door has
+done its job: a recorded foundation, a validated walking skeleton, and the
+normal loop running — instead of a throwaway someone has to clean up later.
+
+## Anti-patterns to refuse
+
+- **Performing discovery / research yourself.** Discovery is fed *in* (stage 2)
+  from the `research` pack, a PRD, or a `receive-brief` brief. This skill
+  consumes a discovery shape; it does not own the research phase.
+- **Building an autonomous multi-agent "software company" generator.** The human
+  stays in the loop and the existing skills do the work. The wins of a swarm of
+  agents auto-generating a codebase are survivorship-bias stories; the boring,
+  composed, human-in-the-loop path is the one that ships maintainable code.
+- **Forcing the flow onto throwaways.** The trigger gate exists to keep scripts
+  and spikes on the fast path. A flow that adds ceremony to a 40-line script is
+  friction, not discipline.
+- **Producing a throwaway prototype in place of the walking skeleton.** The
+  skeleton is kept and minimal, authored as a real spec and built through
+  `work-loop` — not a sketch you'll discard.
+- **Choosing a stack with no recorded rationale.** The foundation's ADR comes
+  before the skeleton is authored, so the *why* survives.
+- **Adding a new top-level directory, or importing another pack's code.** This
+  skill lives beside the other core skills and composes the rest **by reference,
+  not import** — it names `research`, `receive-brief`, the arc42 `reference.md`
+  template, `new-spec`, and `work-loop`, and hands off to them.
+- **Restating what a composed skill already documents.** Reference `new-spec`,
+  `work-loop`, and the brief; don't copy their procedures into this file.
+
+## When this skill is wrong
+
+If you're inside an existing repo, this is the wrong door — use
+`adapt-to-project`. If the idea is a one-off script, the trigger gate should
+already have sent you to scaffold it directly. And if the flow ever feels like
+ceremony getting in the way of a genuinely small thing, trust the trigger gate
+over the procedure.

--- a/packs/core/seeds/docs/CONVENTIONS.md
+++ b/packs/core/seeds/docs/CONVENTIONS.md
@@ -629,6 +629,25 @@ doc, skill, or note has wasted what it learned. The next agent (or a
 human) will pay for it again. The work-loop skill enumerates where each
 kind of learning belongs.
 
+### Two front doors
+
+Work enters this loop through one of two front doors, depending on whether the
+repo already exists:
+
+- **Greenfield — a brand-new repo from an idea.** The `init-project` skill is
+  the front door. It runs a trigger gate (throwaways and one-off scripts skip
+  the flow), a value gate over fed-in discovery, records a foundation (an ADR
+  plus `docs/architecture/reference.md`), authors a walking-skeleton spec via
+  `new-spec`, and hands the build to `work-loop`.
+- **Brownfield — an existing repo.** The `adapt-to-project` skill is the front
+  door, run after installing a pack to fit the conventions to what's already
+  there — including harvesting a `reference.md` from the existing code.
+
+Both converge on the same downstream loop: `brief → reference.md → spec →
+low-level design → work-loop`. Neither is mandatory ceremony — the greenfield
+trigger gate sends a throwaway straight to scaffolding, and a small change in an
+existing repo just opens a PR.
+
 ### Work-loop state
 
 The work-loop's `state.json` schema, exit contract, lifecycle, and


### PR DESCRIPTION
## What does this change?

Implements the `greenfield-inception` spec: a greenfield front door for the methodology. Adds **`init-project`**, a new `core` skill that turns an idea into a structured repo by *composing the skills the repo already owns* — it orchestrates, it doesn't reinvent, and it's explicitly not an autonomous code generator.

The skill documents five fluid (not waterfall) phases with scoped handoffs:

1. **Trigger gate** (first) — a script/spike/throwaway scaffolds directly and skips the flow; real stack/structure/tooling decisions continue.
2. **Value gate over fed-in discovery** — consumes a discovery shape (`research` output, a PRD, or a `receive-brief` brief), never performs discovery itself; pauses if business value can't be stated; emits the first **brief**.
3. **Foundation** — records the stack decision as an **ADR** plus **`reference.md`**, instantiated from the arc42 template the `adapt-to-project` skill bundles.
4. **Walking skeleton** — a thin, kept, end-to-end slice authored as a single spec via `new-spec`, with the *build* handed to `work-loop`.
5. **Handoff** — into the normal `brief → spec → low-level design → work-loop` loop.

Also adds the **two front doors** note to the `CONVENTIONS.md` seed (greenfield `init-project` / brownfield `adapt-to-project`, both converging on the same loop) and three adopter guides: a tutorial, a how-to, and an explanation.

## Why?

Greenfield had no front door — adopters *yolo*'d a throwaway and retrofitted structure, losing the rationale and shipping no recorded foundation. This gives that path a home. Spec: `docs/specs/greenfield-inception/spec.md`.

## How do I verify it?

- `python3 tools/lint-skill-spec.py` — the new skill passes (valid frontmatter; name-only references, no install paths).
- `FORCE=1 make build-check` — green end to end (exit 0); `make build-self` projects the new core skill + the CONVENTIONS seed cleanly with no unexpected reverts.
- `python3 .claude/skills/work-loop/scripts/lint-spec-status.py` — spec metadata clean (Shipped, all 14 ACs checked).
- Three guide files exist under `docs/guides/{tutorials,how-to,explanation}/`.

**Adopter-clean:** the SKILL body, the CONVENTIONS seed block, and all three guides carry no internal-governance references (no RFC-NNNN / ADR-NNNN / "Open Question N" / "this spec"). Methodology concepts the adopter uses (write an ADR, author a spec, the brief) are present; numbered references to this catalogue's governance are not.

**Manual QA — `init-project` workflow behavior (trigger gate both ways, independent of the tutorial):**
- *Throwaway:* "a 40-line script to rename files in a folder" → trigger gate finds no real decisions → skips the flow, scaffolds directly. ✓
- *Real:* "a webhook ingestion service with a queue, a worker, and a datastore" → trigger gate continues → value gate emits the brief → foundation records ADR + `reference.md` → walking skeleton authored via `new-spec`, build handed to `work-loop` → handoff. ✓

**Manual QA — guides read accurately** against the shipped skill: tutorial (URL-shortener scenario) walks the five phases in order; how-to zooms into the foundation step (ADR + `reference.md`, with thin-idea / stack-pack / amend-later variations); explanation frames skeleton-vs-throwaway and orchestrate-not-generate. All internal links resolve. ✓

## What did you not change that you considered?

- **`core-pack.md`** — left untouched; it's curated meta-prose, not a skill inventory, so adding `init-project` there would be scope creep.
- **No new top-level directory, no cross-pack import** — the skill lives beside the other `core` skills and composes the rest by reference (Boundary honored).
- **No new code / no TDD surface** — `init-project` is an LLM workflow over already-tested pieces; verification is goal-based + manual QA per the spec's Testing Strategy.

## Bundled fixes

- `docs/guides/how-to/establish-reference-architecture.md` — Route 3 said the greenfield path was "planned but not yet available"; now that `init-project` ships, that's drift. Rewrote Route 3 to point at the skill and the new guides.
- `docs/guides/explanation/foundation-vs-map.md` — added the reverse cross-link to the new "Decide and record your foundation during inception" how-to (the `new-guide` maintenance-pact rule).