### PR TITLE
fix(core): map Claude Code tool names to Kiro tool ids in kiro adapter

### DIFF
--- a/docs/contracts/adapter.toml
+++ b/docs/contracts/adapter.toml
@@ -323,6 +323,16 @@ rename = "description"
 
 [frontmatter-mapping."kiro-agent-frontmatter-v0.9".tools]
 normalize = "to-list"
+# Translate Claude Code tool names to specific Kiro tool *ids*. Kiro matches
+# an agent's `tools` entries by id or tag (never by Claude Code names); we
+# prefer ids for a faithful, least-privilege 1:1 mapping rather than the
+# broad category tags (the `read` tag also grants diagnostics + read_code;
+# `write` also grants delete_file). `WebSearch` is the exception — the IDE
+# exposes no granular web-search tool id, so it maps to the `web` tag.
+# Applied per list element after `to-list`; duplicates collapse and an
+# unmapped token drops with a build-time warning. These are Kiro IDE ids;
+# the Kiro CLI's short names land in the kiro-cli adapter.
+values = { Read = "read_file", Grep = "grep_search", Glob = "file_search", Edit = "str_replace", Write = "fs_write", MultiEdit = "str_replace", Bash = "execute_bash", WebFetch = "web_fetch", WebSearch = "web" }
 
 [frontmatter-mapping."kiro-agent-frontmatter-v0.9".model]
 rename = "model"

--- a/packages/agentbundle/agentbundle/_data/adapter.toml
+++ b/packages/agentbundle/agentbundle/_data/adapter.toml
@@ -323,6 +323,16 @@ rename = "description"
 
 [frontmatter-mapping."kiro-agent-frontmatter-v0.9".tools]
 normalize = "to-list"
+# Translate Claude Code tool names to specific Kiro tool *ids*. Kiro matches
+# an agent's `tools` entries by id or tag (never by Claude Code names); we
+# prefer ids for a faithful, least-privilege 1:1 mapping rather than the
+# broad category tags (the `read` tag also grants diagnostics + read_code;
+# `write` also grants delete_file). `WebSearch` is the exception — the IDE
+# exposes no granular web-search tool id, so it maps to the `web` tag.
+# Applied per list element after `to-list`; duplicates collapse and an
+# unmapped token drops with a build-time warning. These are Kiro IDE ids;
+# the Kiro CLI's short names land in the kiro-cli adapter.
+values = { Read = "read_file", Grep = "grep_search", Glob = "file_search", Edit = "str_replace", Write = "fs_write", MultiEdit = "str_replace", Bash = "execute_bash", WebFetch = "web_fetch", WebSearch = "web" }
 
 [frontmatter-mapping."kiro-agent-frontmatter-v0.9".model]
 rename = "model"

--- a/packages/agentbundle/agentbundle/build/adapters/kiro.py
+++ b/packages/agentbundle/agentbundle/build/adapters/kiro.py
@@ -464,11 +464,13 @@ def _apply_mapping(frontmatter: dict[str, Any], mapping: dict) -> dict[str, Any]
     build time so a pack-author typo (`opsus` for `opus`) doesn't
     silently ship a default-model agent.
 
-    `values` and `normalize = "to-list"` are not currently combined
-    on any rule and are not designed to compose — `to-list` runs
-    first and would convert a string scalar to a list, after which
-    the `values` lookup can only miss. Don't declare both on the
-    same field without revisiting the order."""
+    `values` composes with `normalize = "to-list"`: `to-list` runs
+    first, then `values` translates each element of the resulting list
+    (collapsing duplicates, preserving order, dropping unmapped tokens
+    with a warning). This is how the `tools` field maps Claude Code
+    tool names (`Read`, `Grep`, `Bash`, …) onto Kiro tool ids
+    (`read_file`, `grep_search`, `execute_bash`, …); the same `values`
+    map still applies to a scalar field like `model`."""
     rewritten: dict[str, Any] = {}
     for source_key, value in frontmatter.items():
         rule = mapping.get(source_key, {})
@@ -483,7 +485,31 @@ def _apply_mapping(frontmatter: dict[str, Any], mapping: dict) -> dict[str, Any]
                 value = [value]
         values_map = rule.get("values")
         if isinstance(values_map, dict):
-            if isinstance(value, str) and value in values_map:
+            if isinstance(value, list) and normalize == "to-list":
+                # Per-element translation for a declared list field (`tools`
+                # after `to-list`). Gated on `normalize == "to-list"` so a
+                # scalar field that merely *parsed* as a list (e.g. a
+                # malformed `model: [opus]`) still takes the scalar miss
+                # branch and drops. Each source token maps through the values
+                # map; an unmapped token drops with a stderr warning (it would
+                # match no Kiro tool id/tag downstream and silently yield an
+                # empty tool set). Order is preserved and duplicates collapse
+                # — e.g. `Read, Grep, Glob` all map to the `read` tag, so the
+                # output carries a single `read`.
+                mapped: list = []
+                for item in value:
+                    if item in values_map:
+                        translated = values_map[item]
+                        if translated not in mapped:
+                            mapped.append(translated)
+                    else:
+                        print(
+                            f"kiro: dropping {new_key} entry {item!r} — not in "
+                            f"contract values map for source key {source_key!r}",
+                            file=sys.stderr,
+                        )
+                value = mapped
+            elif isinstance(value, str) and value in values_map:
                 value = values_map[value]
             else:
                 print(

--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro.py
@@ -80,9 +80,9 @@ class KiroAdapterTests(unittest.TestCase):
                 "stale .md projection left behind",
             )
             data = json.loads(agent_json_path.read_text(encoding="utf-8"))
-            # `tools: Read` source normalises to a list per the mapping
-            # table's `normalize: to-list` rule.
-            self.assertEqual(data["tools"], ["Read"])
+            # `tools: Read` source normalises to a list (`to-list`) then
+            # maps onto the Kiro `read_file` tool id (`values`).
+            self.assertEqual(data["tools"], ["read_file"])
             # `name` from filename (or frontmatter); body becomes prompt.
             self.assertEqual(data["name"], "bar")
             self.assertEqual(data.get("prompt", "").strip(), "agent body")
@@ -183,10 +183,9 @@ class KiroAdapterTests(unittest.TestCase):
     def test_tools_comma_string_splits_to_list(self) -> None:
         """Pack authors write `tools: Read, Grep, Glob, Bash` —
         Claude Code's frontmatter convention, not YAML flow syntax —
-        and the kiro JSON projection must split on commas. Wrapping
-        the whole string in a single-element list (the prior bug)
-        produces `["Read, Grep, Glob, Bash"]`, which Kiro reads as
-        an unknown tool."""
+        and the kiro projection must split on commas, then map each
+        Claude Code name onto its Kiro tool id: Read→read_file,
+        Grep→grep_search, Glob→file_search, Bash→execute_bash."""
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             pack = tmp_path / "pack"
@@ -198,7 +197,9 @@ class KiroAdapterTests(unittest.TestCase):
             out = tmp_path / "out"
             project(pack, self.contract, out)
             data = json.loads((out / ".kiro" / "agents" / "multi.json").read_text())
-            self.assertEqual(data["tools"], ["Read", "Grep", "Glob", "Bash"])
+            self.assertEqual(
+                data["tools"], ["read_file", "grep_search", "file_search", "execute_bash"]
+            )
 
     def test_tools_single_token_one_element_list(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -212,12 +213,13 @@ class KiroAdapterTests(unittest.TestCase):
             out = tmp_path / "out"
             project(pack, self.contract, out)
             data = json.loads((out / ".kiro" / "agents" / "one.json").read_text())
-            self.assertEqual(data["tools"], ["Read"])
+            self.assertEqual(data["tools"], ["read_file"])
 
     def test_tools_bracketed_list_preserved(self) -> None:
         """A YAML flow-sequence `tools: [Read, Grep]` is parsed as a
         list by `_parse_frontmatter`; the to-list normalize must not
-        re-wrap or re-split it."""
+        re-wrap or re-split it, and each element still maps to its
+        Kiro tool id."""
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             pack = tmp_path / "pack"
@@ -229,7 +231,44 @@ class KiroAdapterTests(unittest.TestCase):
             out = tmp_path / "out"
             project(pack, self.contract, out)
             data = json.loads((out / ".kiro" / "agents" / "bracketed.json").read_text())
-            self.assertEqual(data["tools"], ["Read", "Grep"])
+            self.assertEqual(data["tools"], ["read_file", "grep_search"])
+
+    def test_tools_web_search_maps_to_web_tag(self) -> None:
+        """`WebSearch` has no granular Kiro tool id, so it maps to the
+        `web` tag; `WebFetch` maps to the granular `web_fetch` id. Order
+        is preserved."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = tmp_path / "pack"
+            (pack / ".apm" / "agents").mkdir(parents=True)
+            (pack / ".apm" / "agents" / "web.md").write_text(
+                "---\nname: web\ntools: Read, WebFetch, WebSearch\n---\nbody\n",
+                encoding="utf-8",
+            )
+            out = tmp_path / "out"
+            project(pack, self.contract, out)
+            data = json.loads((out / ".kiro" / "agents" / "web.json").read_text())
+            self.assertEqual(data["tools"], ["read_file", "web_fetch", "web"])
+
+    def test_tools_unmapped_token_drops_with_warning(self) -> None:
+        """A Claude Code tool name absent from the values map (e.g.
+        `NotebookEdit`) drops from the output with a stderr warning,
+        rather than emitting a token Kiro can't resolve."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = tmp_path / "pack"
+            (pack / ".apm" / "agents").mkdir(parents=True)
+            (pack / ".apm" / "agents" / "nb.md").write_text(
+                "---\nname: nb\ntools: Read, NotebookEdit\n---\nbody\n",
+                encoding="utf-8",
+            )
+            out = tmp_path / "out"
+            stderr = io.StringIO()
+            with redirect_stderr(stderr):
+                project(pack, self.contract, out)
+            data = json.loads((out / ".kiro" / "agents" / "nb.json").read_text())
+            self.assertEqual(data["tools"], ["read_file"])
+            self.assertIn("NotebookEdit", stderr.getvalue())
 
     def test_hook_wiring_array_entry_removed(self) -> None:
         """AC2: the legacy `degraded-info-log` kiro hook-wiring entry is gone."""

--- a/packages/agentbundle/tests/unit/test_pipeline_phase_order.py
+++ b/packages/agentbundle/tests/unit/test_pipeline_phase_order.py
@@ -175,7 +175,7 @@ class KiroHookWiringMergeDuringBuildTests(unittest.TestCase):
             # Body fields from agent .md frontmatter present.
             self.assertEqual(data["name"], "reviewer")
             self.assertEqual(data["description"], "Demo agent.")
-            self.assertEqual(data["tools"], ["Read"])
+            self.assertEqual(data["tools"], ["read_file"])
 
             # Wiring merged: hooks.agentSpawn with an id-tagged entry.
             self.assertIn("hooks", data, "wiring did not merge into agent JSON")


### PR DESCRIPTION
## What

The kiro adapter projected agent `tools:` frontmatter (`Read, Grep, Glob, Bash`, …) verbatim into `.kiro/agents/`. Kiro matches `tools` entries by tool **id** or **tag** — never by Claude Code names — so every shipped agent (the four core reviewers/implementer + the two research agents) landed with a tool set that resolves to **nothing**. They were effectively tool-less in Kiro.

## How

- Add a Claude→Kiro `values` map to the `kiro-agent-frontmatter-v0.9` **tools** rule in both `adapter.toml` copies (kept byte-identical for the drift gate).
- Extend `_apply_mapping` to apply a `values` map **per element** of a list-valued field, gated on `normalize = "to-list"` so a scalar field that merely parsed as a list (e.g. a malformed `model: [opus]`) still takes the scalar-miss branch and drops.
- Map to specific Kiro tool **ids**, not the broad category tags — a faithful, least-privilege 1:1 mapping. The `read` tag would also grant diagnostics + `read_code`; `write` would grant `delete_file`. `WebSearch` is the one exception (the IDE exposes no granular web-search id), mapping to the `web` tag.
- Unmapped tokens drop with a build-time warning; duplicates collapse (`Read, Grep, Glob` → one `read_file`/`grep_search`/`file_search`).

Resulting projection:

| agent | tools |
| --- | --- |
| adversarial / quality / security-reviewer | `read_file, grep_search, file_search, execute_bash` |
| implementer | `read_file, str_replace, fs_write, grep_search, file_search, execute_bash` |
| evidence-retriever / source-extractor | `read_file, grep_search, file_search, web_fetch, web` |

## Verification

`test_adapter_kiro` (incl. new dedup / `web`-tag / unmapped-warn cases), `test_contract`, `test_pipeline_phase_order`, the `_data`↔`docs/contracts` drift gate, the full build + unit suites, `ruff`, `lint-packs`, and `validate` all pass.

## Deferred (follow-up RFC)

The `kiro-ide` / `kiro-cli` adapter split, IDE event-hook (`.kiro/hooks/*.kiro.hook`) activation, and model-id verification (the `claude-opus-4.6`-style ids are CLI values, not confirmed for the IDE) are out of scope here and tracked for a follow-up RFC, which will also carry the RFC-0005 errata and the `distribution-adapters` "agents are JSON" correction.