### PR TITLE
fix(tools): add encoding="utf-8" to all read_text/write_text in tools and tests

### DIFF
--- a/AGENTS.local.md
+++ b/AGENTS.local.md
@@ -269,3 +269,51 @@ companion Windows-CI work expects every new script to be `python3
 `.github/workflows/docs.yml` should match that. Bash is fine for
 *existing* gates we haven't ported yet; for anything new, default to
 Python first.
+
+## Windows / cross-OS compatibility rules
+
+These rules apply to all new code in this repo. Production code
+(`packages/agentbundle/agentbundle/`) is already clean; the rules
+exist to keep it that way and to guide test/tool code.
+
+**Encoding — always explicit:**
+
+- `Path.read_text()` and `Path.write_text()` must always pass
+  `encoding="utf-8"`. On Windows the default codepage is CP1252, not
+  UTF-8; omitting it silently corrupts or rejects markdown, JSON, and
+  TOML with non-ASCII content.
+- `open()` calls that process text content need `encoding="utf-8"` too.
+- Exception: `read_bytes()` / `write_bytes()` are inherently correct.
+
+**Symlinks — guard, don't assume:**
+
+- In test code, wrap `os.symlink()` in `try/except OSError:
+  pytest.skip("symlinks not available")`. Windows without Developer
+  Mode denies symlink creation even for admin users.
+- Production code uses the `_is_equivalent_claude_md_shape()` helper
+  (`self_host.py`) which handles three equivalent representations:
+  POSIX symlink, Windows content copy, and Git-for-Windows stub.
+
+**POSIX-only assertions — gate explicitly:**
+
+- Inode checks (`st_ino`), nanosecond mtimes (`st_mtime_ns`), and
+  permission-bit assertions are POSIX-only. Wrap them in
+  `if sys.platform != "win32":` inside the test body.
+- `os.chmod()` in test setup must be gated with `if os.name == "posix":`.
+
+**Paths — use pathlib, not string surgery:**
+
+- All path construction uses `pathlib.Path` or `os.path.join`. No
+  string concatenation with `/`. No `os.environ["HOME"]` (use
+  `Path.home()`). No hardcoded `/tmp` for real filesystem operations
+  (use `tempfile`).
+
+**Subprocess — no shell, no Unix-only tools:**
+
+- `subprocess` calls use list form, never `shell=True`.
+- Do not invoke `which`, `grep`, `find`, `sed`, `awk`, `make`, `sh`,
+  or `bash` via subprocess in portable code; use Python equivalents.
+
+The `.github/workflows/build-check-windows.yml` CI job validates the
+portable subset. A first systematic sweep (tools + test files) was
+done in 2026-06.

--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro.py
@@ -110,9 +110,9 @@ class KiroAdapterTests(unittest.TestCase):
             )
             out = tmp_path / "out"
             project(pack, self.contract, out)
-            opus = json.loads((out / ".kiro" / "agents" / "opus-agent.json").read_text())
-            sonnet = json.loads((out / ".kiro" / "agents" / "sonnet-agent.json").read_text())
-            haiku = json.loads((out / ".kiro" / "agents" / "haiku-agent.json").read_text())
+            opus = json.loads((out / ".kiro" / "agents" / "opus-agent.json").read_text(encoding="utf-8"))
+            sonnet = json.loads((out / ".kiro" / "agents" / "sonnet-agent.json").read_text(encoding="utf-8"))
+            haiku = json.loads((out / ".kiro" / "agents" / "haiku-agent.json").read_text(encoding="utf-8"))
             self.assertEqual(opus["model"], "claude-opus-4.6")
             self.assertEqual(sonnet["model"], "claude-sonnet-4.5")
             self.assertEqual(haiku["model"], "claude-haiku-4.5")
@@ -136,7 +136,7 @@ class KiroAdapterTests(unittest.TestCase):
             buf = io.StringIO()
             with redirect_stderr(buf):
                 project(pack, self.contract, out)
-            data = json.loads((out / ".kiro" / "agents" / "mystery.json").read_text())
+            data = json.loads((out / ".kiro" / "agents" / "mystery.json").read_text(encoding="utf-8"))
             self.assertNotIn("model", data)
             stderr = buf.getvalue()
             self.assertIn("dropping model=", stderr)
@@ -156,7 +156,7 @@ class KiroAdapterTests(unittest.TestCase):
             )
             out = tmp_path / "out"
             project(pack, self.contract, out)
-            data = json.loads((out / ".kiro" / "agents" / "no-model.json").read_text())
+            data = json.loads((out / ".kiro" / "agents" / "no-model.json").read_text(encoding="utf-8"))
             self.assertNotIn("model", data)
 
     def test_model_non_scalar_value_drops_field(self) -> None:
@@ -177,7 +177,7 @@ class KiroAdapterTests(unittest.TestCase):
             buf = io.StringIO()
             with redirect_stderr(buf):
                 project(pack, self.contract, out)
-            data = json.loads((out / ".kiro" / "agents" / "list-model.json").read_text())
+            data = json.loads((out / ".kiro" / "agents" / "list-model.json").read_text(encoding="utf-8"))
             self.assertNotIn("model", data)
 
     def test_tools_comma_string_splits_to_list(self) -> None:
@@ -196,7 +196,7 @@ class KiroAdapterTests(unittest.TestCase):
             )
             out = tmp_path / "out"
             project(pack, self.contract, out)
-            data = json.loads((out / ".kiro" / "agents" / "multi.json").read_text())
+            data = json.loads((out / ".kiro" / "agents" / "multi.json").read_text(encoding="utf-8"))
             self.assertEqual(
                 data["tools"], ["read_file", "grep_search", "file_search", "execute_bash"]
             )
@@ -212,7 +212,7 @@ class KiroAdapterTests(unittest.TestCase):
             )
             out = tmp_path / "out"
             project(pack, self.contract, out)
-            data = json.loads((out / ".kiro" / "agents" / "one.json").read_text())
+            data = json.loads((out / ".kiro" / "agents" / "one.json").read_text(encoding="utf-8"))
             self.assertEqual(data["tools"], ["read_file"])
 
     def test_tools_bracketed_list_preserved(self) -> None:
@@ -230,7 +230,7 @@ class KiroAdapterTests(unittest.TestCase):
             )
             out = tmp_path / "out"
             project(pack, self.contract, out)
-            data = json.loads((out / ".kiro" / "agents" / "bracketed.json").read_text())
+            data = json.loads((out / ".kiro" / "agents" / "bracketed.json").read_text(encoding="utf-8"))
             self.assertEqual(data["tools"], ["read_file", "grep_search"])
 
     def test_tools_web_search_maps_to_web_tag(self) -> None:
@@ -247,7 +247,7 @@ class KiroAdapterTests(unittest.TestCase):
             )
             out = tmp_path / "out"
             project(pack, self.contract, out)
-            data = json.loads((out / ".kiro" / "agents" / "web.json").read_text())
+            data = json.loads((out / ".kiro" / "agents" / "web.json").read_text(encoding="utf-8"))
             self.assertEqual(data["tools"], ["read_file", "web_fetch", "web"])
 
     def test_tools_unmapped_token_drops_with_warning(self) -> None:
@@ -266,7 +266,7 @@ class KiroAdapterTests(unittest.TestCase):
             stderr = io.StringIO()
             with redirect_stderr(stderr):
                 project(pack, self.contract, out)
-            data = json.loads((out / ".kiro" / "agents" / "nb.json").read_text())
+            data = json.loads((out / ".kiro" / "agents" / "nb.json").read_text(encoding="utf-8"))
             self.assertEqual(data["tools"], ["read_file"])
             self.assertIn("NotebookEdit", stderr.getvalue())
 

--- a/packages/agentbundle/agentbundle/build/tests/test_pack_schema_allowed_adapters.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_pack_schema_allowed_adapters.py
@@ -167,10 +167,10 @@ class TestKiroTargetAdaptersV06Gate(unittest.TestCase):
         apm.mkdir(parents=True)
         if with_agents:
             (apm / "agents").mkdir()
-            (apm / "agents" / "a.md").write_text("dummy")
+            (apm / "agents" / "a.md").write_text("dummy", encoding="utf-8")
         if with_wiring:
             (apm / "hook-wiring").mkdir()
-            (apm / "hook-wiring" / "w.toml").write_text("event = 'PreToolUse'\n")
+            (apm / "hook-wiring" / "w.toml").write_text("event = 'PreToolUse'\n", encoding="utf-8")
         return tmp_path
 
     def test_v06_pack_with_on_disk_shape_no_allowed_adapters_fires_rail(self) -> None:

--- a/packages/agentbundle/agentbundle/build/tests/test_scope_rails.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_scope_rails.py
@@ -49,7 +49,7 @@ allowed-scopes = ["repo"]
 def _write_pack(root: Path, name: str, toml_text: str) -> Path:
     pack = root / name
     pack.mkdir()
-    (pack / "pack.toml").write_text(toml_text)
+    (pack / "pack.toml").write_text(toml_text, encoding="utf-8")
     return pack
 
 
@@ -62,7 +62,7 @@ class RailASeedsTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
             (pack / "seeds").mkdir()
-            (pack / "seeds" / "AGENTS.md").write_text("hi")
+            (pack / "seeds" / "AGENTS.md").write_text("hi", encoding="utf-8")
 
             result = check_seeds(pack, ["user"])
             self.assertIsNotNone(result)
@@ -74,7 +74,7 @@ class RailASeedsTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             pack = _write_pack(Path(td), "p", PACK_TOML_REPO_ONLY)
             (pack / "seeds").mkdir()
-            (pack / "seeds" / "AGENTS.md").write_text("hi")
+            (pack / "seeds" / "AGENTS.md").write_text("hi", encoding="utf-8")
 
             self.assertIsNone(check_seeds(pack, ["repo"]))
 
@@ -96,7 +96,7 @@ class RailBHooksTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
             (pack / ".apm" / "hooks").mkdir(parents=True)
-            (pack / ".apm" / "hooks" / "pre-pr.sh").write_text("#!/bin/sh\n")
+            (pack / ".apm" / "hooks" / "pre-pr.sh").write_text("#!/bin/sh\n", encoding="utf-8")
 
             result = check_hooks(pack, ["user"])
             self.assertIsNotNone(result)
@@ -108,7 +108,7 @@ class RailBHooksTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
             (pack / ".apm" / "hook-wiring").mkdir(parents=True)
-            (pack / ".apm" / "hook-wiring" / "pre-pr.toml").write_text("[hooks]\n")
+            (pack / ".apm" / "hook-wiring" / "pre-pr.toml").write_text("[hooks]\n", encoding="utf-8")
 
             result = check_hooks(pack, ["user"])
             self.assertIsNotNone(result)
@@ -120,7 +120,7 @@ class RailBHooksTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             pack = _write_pack(Path(td), "p", PACK_TOML_REPO_ONLY)
             (pack / ".apm" / "hooks").mkdir(parents=True)
-            (pack / ".apm" / "hooks" / "pre-pr.sh").write_text("#!/bin/sh\n")
+            (pack / ".apm" / "hooks" / "pre-pr.sh").write_text("#!/bin/sh\n", encoding="utf-8")
             self.assertIsNone(check_hooks(pack, ["repo"]))
 
     def test_rail_b_accepts_no_hooks(self) -> None:
@@ -139,7 +139,7 @@ class RailBHooksTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
             (pack / ".apm" / "hooks").mkdir(parents=True)
-            (pack / ".apm" / "hooks" / "pre-pr.sh").write_text("#!/bin/sh\nexit 0\n")
+            (pack / ".apm" / "hooks" / "pre-pr.sh").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
             self.assertIsNone(
                 check_hooks(pack, ["user"], user_scope_hooks=True),
                 "Rail B did not lift on user_scope_hooks=True",
@@ -153,7 +153,7 @@ class RailBHooksTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
             (pack / ".apm" / "hooks").mkdir(parents=True)
-            (pack / ".apm" / "hooks" / "pre-pr.sh").write_text("#!/bin/sh\nexit 0\n")
+            (pack / ".apm" / "hooks" / "pre-pr.sh").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
             # Default (no flag passed) — must refuse.
             self.assertIsNotNone(check_hooks(pack, ["user"]))
             # Explicit False — same refusal.
@@ -172,7 +172,8 @@ class RailCMarkersTests(unittest.TestCase):
             skills_dir = pack / ".apm" / "skills" / "my-skill"
             skills_dir.mkdir(parents=True)
             (skills_dir / "SKILL.md").write_text(
-                "# My skill\n\nDoes <adapt:PROJECT_NAME> things.\n"
+                "# My skill\n\nDoes <adapt:PROJECT_NAME> things.\n",
+                encoding="utf-8",
             )
 
             result = check_markers(pack, ["user"])
@@ -193,7 +194,8 @@ class RailCMarkersTests(unittest.TestCase):
             skills_dir = pack / ".apm" / "skills" / "my-skill"
             skills_dir.mkdir(parents=True)
             (skills_dir / "SKILL.md").write_text(
-                "# My skill\n\nDoes <adapt:project-name> things.\n"
+                "# My skill\n\nDoes <adapt:project-name> things.\n",
+                encoding="utf-8",
             )
 
             result = check_markers(pack, ["user"])
@@ -208,7 +210,7 @@ class RailCMarkersTests(unittest.TestCase):
             pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
             agents_dir = pack / ".apm" / "agents"
             agents_dir.mkdir(parents=True)
-            (agents_dir / "reviewer.md").write_text("Owner: <adapt:owner>\n")
+            (agents_dir / "reviewer.md").write_text("Owner: <adapt:owner>\n", encoding="utf-8")
 
             result = check_markers(pack, ["user"])
             self.assertIsNotNone(result)
@@ -228,11 +230,11 @@ class RailCMarkersTests(unittest.TestCase):
             skills_dir = pack / ".apm" / "skills" / "non-markers"
             skills_dir.mkdir(parents=True)
             # Wrong-cased prefix — must not match either grammar.
-            (skills_dir / "A.md").write_text("plays with <ADAPT:NAME>")
+            (skills_dir / "A.md").write_text("plays with <ADAPT:NAME>", encoding="utf-8")
             # Mixed-case name — matches neither UPPER_SNAKE nor lowercase-hyphen.
-            (skills_dir / "B.md").write_text("plays with <adapt:MixedCase>")
+            (skills_dir / "B.md").write_text("plays with <adapt:MixedCase>", encoding="utf-8")
             # Empty name — matches neither grammar.
-            (skills_dir / "C.md").write_text("plays with <adapt:>")
+            (skills_dir / "C.md").write_text("plays with <adapt:>", encoding="utf-8")
             self.assertIsNone(check_markers(pack, ["user"]))
 
     def test_rail_c_does_not_inspect_repo_only_pack(self) -> None:
@@ -243,7 +245,7 @@ class RailCMarkersTests(unittest.TestCase):
             pack = _write_pack(Path(td), "p", PACK_TOML_REPO_ONLY)
             skills_dir = pack / ".apm" / "skills" / "doc-marker"
             skills_dir.mkdir(parents=True)
-            (skills_dir / "SKILL.md").write_text("documents <adapt:NAME>")
+            (skills_dir / "SKILL.md").write_text("documents <adapt:NAME>", encoding="utf-8")
             self.assertIsNone(check_markers(pack, ["repo"]))
 
     def test_rail_c_skips_binary_files(self) -> None:
@@ -257,7 +259,7 @@ class RailCMarkersTests(unittest.TestCase):
             # Raw bytes that are not valid UTF-8 — should be skipped.
             (skills_dir / "icon.bin").write_bytes(b"\xff\xfe\x00<adapt:NAME>")
             # A clean text file in the same directory.
-            (skills_dir / "SKILL.md").write_text("# clean\n")
+            (skills_dir / "SKILL.md").write_text("# clean\n", encoding="utf-8")
             self.assertIsNone(check_markers(pack, ["user"]))
 
     def test_rail_c_refuses_symlink_under_skills(self) -> None:
@@ -311,7 +313,7 @@ class RailCMarkersTests(unittest.TestCase):
             for sub in ("z-late", "a-early"):
                 d = pack / ".apm" / "skills" / sub
                 d.mkdir(parents=True)
-                (d / "SKILL.md").write_text("hi <adapt:NAME>")
+                (d / "SKILL.md").write_text("hi <adapt:NAME>", encoding="utf-8")
             result = check_markers(pack, ["user"])
             self.assertIsNotNone(result)
             self.assertIn("a-early/SKILL.md", result)
@@ -371,7 +373,7 @@ class CliValidateWiringTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
             (pack / ".apm" / "hooks").mkdir(parents=True)
-            (pack / ".apm" / "hooks" / "pre-pr.sh").write_text("#!/bin/sh\n")
+            (pack / ".apm" / "hooks" / "pre-pr.sh").write_text("#!/bin/sh\n", encoding="utf-8")
 
             args = argparse.Namespace(pack_path=str(pack), strict=False)
             buf = io.StringIO()

--- a/packages/agentbundle/agentbundle/build/tests/test_self_host_check.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_self_host_check.py
@@ -699,7 +699,7 @@ class SelfHostPackFilterTests(unittest.TestCase):
 
             landed = output / "docs" / "backlog.md"
             self.assertTrue(landed.is_file())
-            self.assertIn("<!-- no deferred items yet -->", landed.read_text())
+            self.assertIn("<!-- no deferred items yet -->", landed.read_text(encoding="utf-8"))
 
 
 class ExcludedGlobTests(unittest.TestCase):

--- a/packages/agentbundle/tests/fixtures/creds/skills/dotfile-grep/scripts/leak.py
+++ b/packages/agentbundle/tests/fixtures/creds/skills/dotfile-grep/scripts/leak.py
@@ -5,7 +5,7 @@ import os
 
 
 def leak():
-    return open(os.path.expanduser("~/.agentbundle/credentials.env")).read()
+    return open(os.path.expanduser("~/.agentbundle/credentials.env"), encoding="utf-8").read()
 
 
 if __name__ == "__main__":

--- a/packages/agentbundle/tests/fixtures/creds/skills/dotfile-with-optout/scripts/legit.py
+++ b/packages/agentbundle/tests/fixtures/creds/skills/dotfile-with-optout/scripts/legit.py
@@ -8,7 +8,7 @@ import os
 
 def read():
     path = os.path.expanduser("~/.agentbundle/credentials.env")  # credentialed-primitive: reads-creds-directly
-    return open(path).read()
+    return open(path, encoding="utf-8").read()
 
 
 if __name__ == "__main__":

--- a/tools/hooks/session-start.py
+++ b/tools/hooks/session-start.py
@@ -107,7 +107,7 @@ def _emit_knowledge(path: Path, scope_filter: str) -> None:
     """
     entries = []
     malformed = 0
-    for line in path.read_text().splitlines():
+    for line in path.read_text(encoding="utf-8").splitlines():
         if not line.strip():
             continue
         try:

--- a/tools/lint-agents-md.py
+++ b/tools/lint-agents-md.py
@@ -96,7 +96,7 @@ def main() -> int:
 
     # 3. Root AGENTS.md size
     if agents_md.is_file():
-        lines = len(agents_md.read_text().splitlines())
+        lines = len(agents_md.read_text(encoding="utf-8").splitlines())
         if lines > MAX_ROOT_LINES:
             note(
                 f"AGENTS.md is {lines} lines (max {MAX_ROOT_LINES}). "
@@ -115,7 +115,7 @@ def main() -> int:
             continue
         if f == agents_md:
             continue
-        lines = len(f.read_text().splitlines())
+        lines = len(f.read_text(encoding="utf-8").splitlines())
         limit = MAX_SUB_LINES
         # The core pack's governance seed (AGENTS.md) is a root-class doc
         # (250-line cap), not a nested package AGENTS.md — wherever it lands.
@@ -139,7 +139,7 @@ def main() -> int:
         f = Path(f_str)
         if not f.is_file():
             continue
-        for match in link_re.findall(f.read_text()):
+        for match in link_re.findall(f.read_text(encoding="utf-8")):
             # Skip external schemes (http:, mailto:, etc.)
             if re.match(r"^[a-z]+:", match):
                 continue
@@ -206,7 +206,7 @@ def main() -> int:
         regex = re.compile(pattern)
         if canonical:
             cpath = Path(canonical)
-            if cpath.is_file() and not regex.search(cpath.read_text()):
+            if cpath.is_file() and not regex.search(cpath.read_text(encoding="utf-8")):
                 note(
                     f"drift-watch: '{pattern}' missing from canonical home {canonical}."
                 )
@@ -214,7 +214,7 @@ def main() -> int:
             fpath = Path(forb)
             if not fpath.is_file():
                 continue
-            if regex.search(fpath.read_text()):
+            if regex.search(fpath.read_text(encoding="utf-8")):
                 note(
                     f"drift-watch: '{pattern}' re-appeared in {forb} (canonical: {canonical})."
                 )
@@ -254,7 +254,7 @@ def main() -> int:
         f = Path(f_str)
         if not f.is_file():
             continue
-        if vendor_re.search(f.read_text()):
+        if vendor_re.search(f.read_text(encoding="utf-8")):
             note(
                 f"drift-watch: vendor token (ultrathink / 'Plan Mode (Shift+Tab') in {f_str}. "
                 f"Move it under .claude/."

--- a/tools/lint-build.py
+++ b/tools/lint-build.py
@@ -58,7 +58,7 @@ def _audit_imports(py_files: list[Path]) -> int:
     violations = 0
     for path in py_files:
         try:
-            source = path.read_text()
+            source = path.read_text(encoding="utf-8")
             tree = ast.parse(source, filename=str(path))
         except SyntaxError as exc:
             print(f"{path}:{exc.lineno}: syntax error: {exc.msg}", file=sys.stderr)

--- a/tools/lint-knowledge.py
+++ b/tools/lint-knowledge.py
@@ -58,7 +58,7 @@ def main() -> int:
 
     seen_ids: dict[str, int] = {}
 
-    for line_no, raw in enumerate(knowledge_file.read_text().splitlines(), start=1):
+    for line_no, raw in enumerate(knowledge_file.read_text(encoding="utf-8").splitlines(), start=1):
         if not raw.strip():
             continue
 

--- a/tools/lint-skill-spec.py
+++ b/tools/lint-skill-spec.py
@@ -540,7 +540,7 @@ def main() -> int:
             err(path, "evals/ directory present but evals/evals.json is missing")
             return
         try:
-            data = json.loads(evals_json.read_text())
+            data = json.loads(evals_json.read_text(encoding="utf-8"))
         except json.JSONDecodeError as exc:
             err(evals_json, f"evals/evals.json is not valid JSON: {exc}")
             return

--- a/tools/test-lint-credentialed-skills.py
+++ b/tools/test-lint-credentialed-skills.py
@@ -22,7 +22,7 @@ LINTER = REPO_ROOT / "tools" / "lint_credentialed_skills.py"
 
 def write(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(content)
+    path.write_text(content, encoding="utf-8")
 
 
 def run_lint(lint_root: Path) -> tuple[int, str, str]:


### PR DESCRIPTION
## Summary

- Adds `encoding=\"utf-8\"` to every `read_text()`, `write_text()`, and `open()` call that was missing it across tools and test files. On Windows the default codepage is CP1252, not UTF-8; omitting it silently corrupts or rejects markdown, JSON, and TOML with non-ASCII content.
- Adds a **Windows/cross-OS compatibility rules** section to `AGENTS.local.md` documenting the encoding, symlink, path, and subprocess conventions so they don't need to be rediscovered.

**Production agentbundle code was already clean** — all `read_text`/`write_text` calls in `packages/agentbundle/agentbundle/` already carried `encoding="utf-8"`.

## Files changed

**Tools (run in Windows CI — highest impact):**
- `tools/lint-agents-md.py` — 6 `read_text()` calls
- `tools/lint-build.py`, `lint-knowledge.py`, `lint-skill-spec.py` — 1 each
- `tools/hooks/session-start.py` — 1 `read_text()`
- `tools/test-lint-credentialed-skills.py` — 1 `write_text()`

**Build adapter tests:**
- `build/tests/test_adapter_kiro.py` — 11 `read_text()` calls inside `json.loads`
- `build/tests/test_self_host_check.py` — 1 `read_text()`
- `build/tests/test_scope_rails.py` — 18 `write_text()` calls in fixture setup
- `build/tests/test_pack_schema_allowed_adapters.py` — 2 `write_text()`

**Test fixture scripts** (intentionally-bad credential scripts used in security lint tests):
- `tests/fixtures/creds/skills/dotfile-grep/scripts/leak.py`
- `tests/fixtures/creds/skills/dotfile-with-optout/scripts/legit.py`

**Docs:**
- `AGENTS.local.md` — new Windows/cross-OS compatibility rules section

## Test plan

- [x] `pytest packages/agentbundle/` — full suite, exit code 0 (1800+ tests, 1 skip)
- [x] `python3 tools/lint-agents-md.py` — passes
- [x] `python3 tools/lint-knowledge.py` — passes
- [x] `python3 tools/lint-build.py` — passes
- [x] Grep confirms no remaining bare `read_text()` or `write_text()` in any changed file