### PR TITLE
feat(core): kiro-adapter-split Wave 1+2 — kiro-cli, kiro alias, E3 vocab, doc corrections (RFC-0022)

### DIFF
--- a/docs/contracts/adapter.toml
+++ b/docs/contracts/adapter.toml
@@ -249,6 +249,10 @@ frontmatter-mapping = "kiro-cli-agent-frontmatter-v1.0"
 on-conflict = "prompt-then-preserve"
 
 [[adapter.kiro-cli.projection]]
+# Legacy repo-scope entry — the pipeline-of-record for repo-scope hook-body
+# projection (mirrors the `kiro` adapter's RFC-0005 hybrid). The table form
+# below is the scope-conditional declaration for the user-scope pipeline;
+# both coexist intentionally. `_iter_primitives` deduplicates via set union.
 primitive = "hook-body"
 mode = "direct-file"
 target-path = "tools/hooks/"

--- a/docs/contracts/adapter.toml
+++ b/docs/contracts/adapter.toml
@@ -19,9 +19,15 @@
 # frontmatter-v0.8` mapping. Dropped-primitives warning rail introduced
 # in `agentbundle install` for any (adapter, pack) pair where the
 # resolved adapter projects a primitive type the pack ships as `dropped`.
+# RFC-0022 / docs/specs/kiro-adapter-split (v0.9): kiro adapter split into
+# `kiro-ide` (IDE, .md agents, kiro-ide-hook active, flat path confirmed by
+# Q6 probe no×yes 2026-06-01) and `kiro-cli` (CLI binary, .json agents,
+# hook-wiring retained). `kiro` retained as deprecated alias for `kiro-ide`.
+# `kiro-ide-hook` primitive activated; `kiro-ide-agent-frontmatter-v0.9` renamed
+# to `kiro-ide-agent-frontmatter-v0.9`.
 
 [contract]
-version = "0.8"
+version = "0.9"
 
 # Sibling schemas this contract references — pack metadata and the
 # per-pack Claude-plugin manifest. Defined by spec AC #3 + #4.
@@ -47,6 +53,11 @@ source-path = ".apm/hook-wiring/"
 
 [primitive.command]
 source-path = ".apm/commands/"
+
+# RFC-0022 / kiro-ide-hook: standalone IDE event hook files (.kiro.hook JSON).
+# Activated at v0.9 for the kiro-ide adapter; dropped for kiro-cli and others.
+[primitive."kiro-ide-hook"]
+source-path = ".apm/kiro-ide-hooks/"
 
 # RFC-0013 § 4c — `shared-libs/` carries Python sibling files that the
 # build pipeline projects into every consumer skill declaring
@@ -175,7 +186,7 @@ on-conflict = "prompt-then-preserve"
 primitive = "agent"
 mode = "direct-file"
 target-path = ".kiro/agents/"
-frontmatter-mapping = "kiro-agent-frontmatter-v0.9"
+frontmatter-mapping = "kiro-ide-agent-frontmatter-v0.9"
 on-conflict = "prompt-then-preserve"
 
 [[adapter.kiro.projection]]
@@ -224,6 +235,79 @@ user = "~"
 # RFC-0012: Kiro projects skills/agents to `.kiro/`; hook bodies land in the
 # legacy `tools/hooks/` at repo scope (matching the contract's hook-body
 # array entry above).
+allowed-prefixes.repo = [".kiro/", ".agentbundle/", "tools/hooks/"]
+allowed-prefixes.user = [".kiro/", ".agentbundle/"]
+
+# ---------------------------------------------------------------------------
+# kiro-ide adapter — targets the Kiro VS Code-fork IDE (RFC-0022).
+#
+# Projects agents as `.md` (gray-matter YAML frontmatter + body); the IDE
+# reads `.kiro/agents/<name>.md` via its gray-matter loader. hook-wiring is
+# DROPPED — the IDE loader silently drops any agent carrying a `hooks` key
+# (RFC-0022 E2). kiro-ide-hook is ACTIVATED with the flat path confirmed by
+# Q6 probe (no-recursion, yes-extension-filter, 2026-06-01, Kiro 0.12.224):
+# `.kiro/hooks/<pack>--<name>.kiro.hook`. RFC-0022 assumed yes-recursion;
+# T1 carries the corrected no-recursion flat path (no T-E1b fires).
+# ---------------------------------------------------------------------------
+
+[[adapter.kiro-ide.projection]]
+primitive = "skill"
+mode = "direct-directory"
+target-path = ".kiro/skills/"
+on-conflict = "prompt-then-preserve"
+
+[[adapter.kiro-ide.projection]]
+primitive = "agent"
+mode = "direct-file"
+target-path = ".kiro/agents/"
+frontmatter-mapping = "kiro-ide-agent-frontmatter-v0.9"
+on-conflict = "prompt-then-preserve"
+
+[[adapter.kiro-ide.projection]]
+primitive = "hook-body"
+mode = "direct-file"
+target-path = "tools/hooks/"
+on-conflict = "prompt-then-preserve"
+
+[[adapter.kiro-ide.projection]]
+primitive = "hook-wiring"
+mode = "dropped"
+
+[[adapter.kiro-ide.projection]]
+primitive = "command"
+mode = "dropped"
+
+# hook-body — scope-conditional target (RFC-0005 § hook-body at user scope).
+[adapter.kiro-ide.projections.hook-body]
+mode = "direct-file"
+target.repo = "tools/hooks/<name>.{sh,py}"
+target.user = ".kiro/hooks/<name>.{sh,py}"
+on-conflict = "prompt-then-preserve"
+
+# kiro-ide-hook — activated for the IDE target (Q6 probe: no-recursion,
+# yes-extension-filter). Flat path uses `<pack>--<name>` prefix separator
+# so pack hooks coexist in the single flat `.kiro/hooks/` directory.
+[adapter.kiro-ide.projections.kiro-ide-hook]
+mode = "direct-file"
+target.repo = ".kiro/hooks/<pack>--<name>.kiro.hook"
+ide-event-vocabulary = [
+  "fileEdited",
+  "fileCreated",
+  "fileDeleted",
+  "userTriggered",
+  "promptSubmit",
+  "agentStop",
+  "preToolUse",
+  "postToolUse",
+  "preTaskExecution",
+  "postTaskExecution",
+  "sessionStart",
+]
+ide-action-vocabulary = ["askAgent", "runCommand"]
+
+[adapter.kiro-ide.scope]
+repo = "."
+user = "~"
 allowed-prefixes.repo = [".kiro/", ".agentbundle/", "tools/hooks/"]
 allowed-prefixes.user = [".kiro/", ".agentbundle/"]
 
@@ -388,12 +472,12 @@ allowed-prefixes.user = [".agents/skills/", ".codex/", ".agentbundle/"]
 
 # Kiro agent frontmatter v0.9: renames Claude Code agent fields to Kiro's schema.
 # Adapters consume this table generically; no field dictionary hardcoded in Python.
-[frontmatter-mapping."kiro-agent-frontmatter-v0.9"]
+[frontmatter-mapping."kiro-ide-agent-frontmatter-v0.9"]
 
-[frontmatter-mapping."kiro-agent-frontmatter-v0.9".description]
+[frontmatter-mapping."kiro-ide-agent-frontmatter-v0.9".description]
 rename = "description"
 
-[frontmatter-mapping."kiro-agent-frontmatter-v0.9".tools]
+[frontmatter-mapping."kiro-ide-agent-frontmatter-v0.9".tools]
 normalize = "to-list"
 # Translate Claude Code tool names to specific Kiro tool *ids*. Kiro matches
 # an agent's `tools` entries by id or tag (never by Claude Code names); we
@@ -406,7 +490,7 @@ normalize = "to-list"
 # the Kiro CLI's short names land in the kiro-cli adapter.
 values = { Read = "read_file", Grep = "grep_search", Glob = "file_search", Edit = "str_replace", Write = "fs_write", MultiEdit = "str_replace", Bash = "execute_bash", WebFetch = "web_fetch", WebSearch = "web" }
 
-[frontmatter-mapping."kiro-agent-frontmatter-v0.9".model]
+[frontmatter-mapping."kiro-ide-agent-frontmatter-v0.9".model]
 rename = "model"
 # Translate Claude Code's friendly aliases to Kiro's documented model IDs
 # (https://kiro.dev/docs/cli/custom-agents/configuration-reference/). A
@@ -418,7 +502,7 @@ values = { opus = "claude-opus-4.6", sonnet = "claude-sonnet-4.5", haiku = "clau
 # kiro-cli agent frontmatter v1.0 (RFC-0022): rewrite rules from Claude Code
 # agent markdown to Kiro CLI JSON. Tools map to CLI short-names (not IDE ids).
 # The `kiro` CLI matches agents' `tools` entries by short name; the IDE uses
-# ids — hence the separate table rather than reusing kiro-agent-frontmatter-v0.9.
+# ids — hence the separate table rather than reusing kiro-ide-agent-frontmatter-v0.9.
 [frontmatter-mapping."kiro-cli-agent-frontmatter-v1.0"]
 
 [frontmatter-mapping."kiro-cli-agent-frontmatter-v1.0".description]

--- a/docs/contracts/adapter.toml
+++ b/docs/contracts/adapter.toml
@@ -152,13 +152,17 @@ allowed-prefixes.repo = [".claude/", ".agentbundle/", "tools/hooks/"]
 allowed-prefixes.user = [".claude/", ".agentbundle/"]
 
 # ---------------------------------------------------------------------------
-# Kiro adapter
+# Kiro adapter — DEPRECATED ALIAS for kiro-ide (RFC-0022 D1).
 #
-# RFC-0005 promotes Kiro `hook-wiring` out of `degraded-info-log` to the new
-# `merge-into-agent-json` mode — the legacy degraded entry is removed (per
-# AC2). `hook-body` keeps its legacy `direct-file → tools/hooks/` array entry
-# and additionally declares a v0.3 scope-conditional table for the user-scope
-# pipeline T5/T7 will land. Skill, agent, command remain in the array.
+# `kiro` is retained as a working alias with no removal timeline so existing
+# packs declaring `allowed-adapters = ["kiro"]` keep working. The Python
+# registry maps "kiro" → kiro_ide.project and emits a build-time
+# DeprecationWarning on use. Update `allowed-adapters` to `["kiro-ide"]` or
+# `["kiro-cli"]` in pack.toml to silence the warning.
+#
+# The projection blocks below are preserved verbatim so `validate` keeps
+# accepting "kiro" and `_shipped_for_cli` (derived from the adapter key set)
+# continues to include it.
 # ---------------------------------------------------------------------------
 
 [[adapter.kiro.projection]]
@@ -220,6 +224,70 @@ user = "~"
 # RFC-0012: Kiro projects skills/agents to `.kiro/`; hook bodies land in the
 # legacy `tools/hooks/` at repo scope (matching the contract's hook-body
 # array entry above).
+allowed-prefixes.repo = [".kiro/", ".agentbundle/", "tools/hooks/"]
+allowed-prefixes.user = [".kiro/", ".agentbundle/"]
+
+# ---------------------------------------------------------------------------
+# kiro-cli adapter — targets the `kiro` terminal binary (RFC-0022).
+#
+# Projects agents as `.json` with CLI short-name tool tokens. Retains
+# `hook-wiring` via `merge-into-agent-json`. `kiro-ide-hook` is dropped —
+# the IDE-only event-hook primitive is not supported by the CLI target.
+# ---------------------------------------------------------------------------
+
+[[adapter.kiro-cli.projection]]
+primitive = "skill"
+mode = "direct-directory"
+target-path = ".kiro/skills/"
+on-conflict = "prompt-then-preserve"
+
+[[adapter.kiro-cli.projection]]
+primitive = "agent"
+mode = "direct-file"
+target-path = ".kiro/agents/"
+frontmatter-mapping = "kiro-cli-agent-frontmatter-v1.0"
+on-conflict = "prompt-then-preserve"
+
+[[adapter.kiro-cli.projection]]
+primitive = "hook-body"
+mode = "direct-file"
+target-path = "tools/hooks/"
+on-conflict = "prompt-then-preserve"
+
+[[adapter.kiro-cli.projection]]
+primitive = "command"
+mode = "dropped"
+
+# hook-body — scope-conditional target (RFC-0005 § hook-body at user scope).
+[adapter.kiro-cli.projections.hook-body]
+mode = "direct-file"
+target.repo = "tools/hooks/<name>.{sh,py}"
+target.user = ".kiro/hooks/<name>.{sh,py}"
+on-conflict = "prompt-then-preserve"
+
+# hook-wiring — merge into the pack-owned agent JSON (same as legacy kiro).
+[adapter.kiro-cli.projections.hook-wiring]
+mode = "merge-into-agent-json"
+target.repo = ".kiro/agents/<attach-to-agent>.json"
+target.user = ".kiro/agents/<attach-to-agent>.json"
+managed-key = "hooks"
+agent-event-vocabulary = [
+  "agentSpawn",
+  "userPromptSubmit",
+  "preToolUse",
+  "postToolUse",
+  "stop",
+]
+
+# kiro-ide-hook — dropped for the CLI target. The IDE-only event-hook
+# primitive is not supported by the kiro binary; packs shipping
+# .apm/kiro-ide-hooks/ content must use the kiro-ide adapter instead.
+[adapter.kiro-cli.projections.kiro-ide-hook]
+mode = "dropped"
+
+[adapter.kiro-cli.scope]
+repo = "."
+user = "~"
 allowed-prefixes.repo = [".kiro/", ".agentbundle/", "tools/hooks/"]
 allowed-prefixes.user = [".kiro/", ".agentbundle/"]
 
@@ -341,6 +409,26 @@ rename = "model"
 # source value not in the map is dropped from the JSON output, leaving
 # Kiro to fall back to its CLI default with a warning rather than
 # rejecting the agent for an unknown model.
+values = { opus = "claude-opus-4.6", sonnet = "claude-sonnet-4.5", haiku = "claude-haiku-4.5" }
+
+# kiro-cli agent frontmatter v1.0 (RFC-0022): rewrite rules from Claude Code
+# agent markdown to Kiro CLI JSON. Tools map to CLI short-names (not IDE ids).
+# The `kiro` CLI matches agents' `tools` entries by short name; the IDE uses
+# ids — hence the separate table rather than reusing kiro-agent-frontmatter-v0.9.
+[frontmatter-mapping."kiro-cli-agent-frontmatter-v1.0"]
+
+[frontmatter-mapping."kiro-cli-agent-frontmatter-v1.0".description]
+rename = "description"
+
+[frontmatter-mapping."kiro-cli-agent-frontmatter-v1.0".tools]
+normalize = "to-list"
+# Translate Claude Code tool names to Kiro CLI short-name tool tokens.
+# Applied per list element after `to-list`; duplicates collapse and an
+# unmapped token drops with a build-time warning.
+values = { Read = "read", Grep = "grep", Glob = "glob", Edit = "write", Write = "write", MultiEdit = "write", Bash = "shell", WebFetch = "web_fetch", WebSearch = "web_search" }
+
+[frontmatter-mapping."kiro-cli-agent-frontmatter-v1.0".model]
+rename = "model"
 values = { opus = "claude-opus-4.6", sonnet = "claude-sonnet-4.5", haiku = "claude-haiku-4.5" }
 
 # Codex agent frontmatter v0.8 (docs/specs/dropped-primitives-coverage):

--- a/docs/specs/agent-spec-cli/spec.md
+++ b/docs/specs/agent-spec-cli/spec.md
@@ -411,7 +411,8 @@ explicit recovery gesture.
 ## v0.4 kiro-ide-hook primitive (RFC-0005)
 
 The v0.4 contract bump (RFC-0005) extends the CLI surface with the
-new `kiro-ide-hook` primitive. The primitive carries Kiro's
+new `kiro-ide-hook` primitive. (Code shipped in PR #99; contract activation deferred to RFC-0022.)
+The primitive carries Kiro's
 standalone IDE-event hooks — `.kiro.hook` JSON files Kiro reads on
 file create / save / delete, prompt submit, agent stop, and tool /
 task events. The full design lives in

--- a/docs/specs/distribution-adapters/spec.md
+++ b/docs/specs/distribution-adapters/spec.md
@@ -204,19 +204,14 @@ declares it so explicitly — no implicit defaults.
 | Primitive | Source path (in `packs/<pack>/`) | Claude Code | Kiro | Copilot | Codex |
 | --- | --- | --- | --- | --- | --- |
 | `skill` | `.apm/skills/<name>/` | `direct-directory` → `.claude/skills/<name>/` | `direct-directory` → `.kiro/skills/<name>/` | `instruction-file` → `.github/instructions/<name>.instructions.md` | `direct-directory` → `.agents/skills/<name>/` |
-| `agent` | `.apm/agents/<name>.md` | `direct-file` → `.claude/agents/<name>.md` | `direct-file`\* (with `kiro-agent-frontmatter-v0.9` rewrite) → `.kiro/agents/<name>.json` | `dropped` | `dropped` |
+| `agent` | `.apm/agents/<name>.md` | `direct-file` → `.claude/agents/<name>.md` | `kiro-ide`: `direct-file` → `.kiro/agents/<name>.md` (gray-matter); `kiro-cli`: `direct-file` → `.kiro/agents/<name>.json` (CLI short-names)\* | `dropped` | `dropped` |
 | `hook-body` | `.apm/hooks/<name>.{sh,py}` | `direct-file` — repo: `tools/hooks/<name>.{sh,py}`; user: `.claude/hooks/<pack>/<name>.{sh,py}` | `direct-file` — repo: `tools/hooks/<name>.{sh,py}`; user: `.kiro/hooks/<pack>/<name>.{sh,py}` | `direct-file` → `tools/hooks/<name>.{sh,py}` | `direct-file` → `tools/hooks/<name>.{sh,py}` |
-| `hook-wiring` | `.apm/hook-wiring/<name>.toml` | repo: `merge-json` (under `hooks` key of `.claude/settings.local.json`); user: `user-merge-json` (under `hooks` key of `.claude/settings.json`) | `merge-into-agent-json` (RFC-0005 — under `hooks` key of `.kiro/agents/<attach-to-agent>.json`) | `dropped` | `dropped` |
+| `hook-wiring` | `.apm/hook-wiring/<name>.toml` | repo: `merge-json` (under `hooks` key of `.claude/settings.local.json`); user: `user-merge-json` (under `hooks` key of `.claude/settings.json`) | `kiro-ide`: `dropped` (uses `kiro-ide-hook` instead); `kiro-cli`: `merge-into-agent-json` (RFC-0005 — under `hooks` key of `.kiro/agents/<attach-to-agent>.json`) | `dropped` | `dropped` |
 | `command` | `.apm/commands/<name>.md` | `direct-file` → `.claude/commands/<name>.md` | `dropped` | `dropped` | `dropped` |
 
-\* The Kiro `agent` row's `mode = "direct-file"` is retained for v0.3
-contract continuity; the implementation is semantically a
-*markdown-frontmatter → JSON-field rewrite*, not a byte-for-byte copy.
-RFC-0005 / T7 introduced the JSON emission once Kiro published the
-[custom-agents configuration reference](https://kiro.dev/docs/cli/custom-agents/configuration-reference/)
-confirming agents are JSON. A future contract bump could rename the
-mode (e.g. `agent-md-to-json`); the rename is deferred behind landing
-the implementation.
+\* kiro-ide projects `.md`; kiro-cli projects `.json`; the IDE accepts both
+(verified in `extension.js` `p16` / `loadCustomAgentFile`, 2026-06-01). The
+deprecated `kiro` alias maps to `kiro-ide` — RFC-0022 / ADR-0012.
 
 **Hook extensions.** A hook is a script; the runtime is determined by the
 file extension. The build pipeline projects `hook-body` byte-for-byte —

--- a/docs/specs/kiro-adapter-split/spec.md
+++ b/docs/specs/kiro-adapter-split/spec.md
@@ -1,6 +1,6 @@
 # Spec: kiro-adapter-split
 
-- **Status:** Implementing
+- **Status:** Shipped
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:**
@@ -70,51 +70,51 @@ The contract bumps from v0.8 to v0.9. Errata E1–E3 are appended to RFC-0005 (T
 
 ### Prerequisite doc changes (T9, T10)
 
-- [ ] RFC-0005 `## Errata` table appended with E1, E2, E3, Approver-signed (eugenelim, date of merge) (T9)
-- [ ] `docs/specs/kiro-ide-hook/probes.md` Q11 Outcome updated: RFC-0022 closes Q11 via static analysis of `extension.js` `IDEListenableEvent` enum; no IDE-UI-authored fixture required; E3 vocabulary recorded (T10)
+- [x] RFC-0005 `## Errata` table appended with E1, E2, E3, Approver-signed (eugenelim, date of merge) (T9)
+- [x] `docs/specs/kiro-ide-hook/probes.md` Q11 Outcome updated: RFC-0022 closes Q11 via static analysis of `extension.js` `IDEListenableEvent` enum; no IDE-UI-authored fixture required; E3 vocabulary recorded (T10)
 
 ### Contract and `kiro-ide` adapter (T1) — depends on Q6 probe + T9
 
-- [ ] `[contract] version` is `"0.9"` in `adapter.toml` (T1)
-- [ ] `[adapter.kiro-ide]` block declared with `.md` projection, repo-scope `kiro-ide-hook` activation, no CLI-only fields (T1)
-- [ ] `kiro-ide-agent-frontmatter-v0.9` mapping table (renamed from `kiro-agent-frontmatter-v0.9`); all call sites in `kiro.py` updated to the new name (T1)
-- [ ] `ide-event-vocabulary` in `kiro-ide` block matches E3 list: `fileEdited`, `fileCreated`, `fileDeleted`, `userTriggered`, `promptSubmit`, `agentStop`, `preToolUse`, `postToolUse`, `preTaskExecution`, `postTaskExecution`, `sessionStart` (T1)
-- [ ] `ide-action-vocabulary` in `kiro-ide` block: `["askAgent", "runCommand"]` (T1)
-- [ ] Q6 probe outcome recorded in `probes.md` before T1 merges (T1 gate)
+- [x] `[contract] version` is `"0.9"` in `adapter.toml` (T1)
+- [x] `[adapter.kiro-ide]` block declared with `.md` projection, repo-scope `kiro-ide-hook` activation, no CLI-only fields (T1)
+- [x] `kiro-ide-agent-frontmatter-v0.9` mapping table (renamed from `kiro-agent-frontmatter-v0.9`); all call sites in `kiro.py` updated to the new name (T1)
+- [x] `ide-event-vocabulary` in `kiro-ide` block matches E3 list: `fileEdited`, `fileCreated`, `fileDeleted`, `userTriggered`, `promptSubmit`, `agentStop`, `preToolUse`, `postToolUse`, `preTaskExecution`, `postTaskExecution`, `sessionStart` (T1)
+- [x] `ide-action-vocabulary` in `kiro-ide` block: `["askAgent", "runCommand"]` (T1)
+- [x] Q6 probe outcome recorded in `probes.md` before T1 merges (T1 gate)
 
 ### Validate rail (T2) — depends on T9
 
-- [ ] `kiro_ide_hook.py` validate rail updated to E3 vocabulary (T2)
-- [ ] `scope_rails.py` `check_kiro_ide_hook` updated to E3 vocabulary (T2)
+- [x] `kiro_ide_hook.py` validate rail updated to E3 vocabulary (T2)
+- [x] `scope_rails.py` `check_kiro_ide_hook` updated to E3 vocabulary (T2)
 
 ### `kiro-cli` adapter (T3)
 
-- [ ] `[adapter.kiro-cli]` block declared with `.json` projection and `hook-wiring` retained (T3)
-- [ ] `kiro-cli-agent-frontmatter-v1.0` mapping table with CLI short-name `tools.values`: `Read→read`, `Grep→grep`, `Glob→glob`, `Edit→write`, `Write→write`, `MultiEdit→write`, `Bash→shell`, `WebFetch→web_fetch`, `WebSearch→web_search` (T3)
-- [ ] `kiro-ide-hook` is `mode = "dropped"` in `kiro-cli` block (T3)
+- [x] `[adapter.kiro-cli]` block declared with `.json` projection and `hook-wiring` retained (T3)
+- [x] `kiro-cli-agent-frontmatter-v1.0` mapping table with CLI short-name `tools.values`: `Read→read`, `Grep→grep`, `Glob→glob`, `Edit→write`, `Write→write`, `MultiEdit→write`, `Bash→shell`, `WebFetch→web_fetch`, `WebSearch→web_search` (T3)
+- [x] `kiro-ide-hook` is `mode = "dropped"` in `kiro-cli` block (T3)
 
 ### `kiro` deprecated alias (T4)
 
-- [ ] `[adapter.kiro]` stub block retained in `adapter.toml` with deprecation comment (T4)
-- [ ] Python adapter registry maps `"kiro"` → `kiro_ide.project` (T4)
-- [ ] Deprecation warning logged on alias resolution: `"kiro: deprecated alias for kiro-ide; update allowed-adapters in pack.toml"` (T4)
+- [x] `[adapter.kiro]` stub block retained in `adapter.toml` with deprecation comment (T4)
+- [x] Python adapter registry maps `"kiro"` → `kiro_ide.project` (T4)
+- [x] Deprecation warning logged on alias resolution: `"kiro: deprecated alias for kiro-ide; update allowed-adapters in pack.toml"` (T4)
 
 ### Spec corrections (T5, T6)
 
-- [ ] `distribution-adapters/spec.md` footnote (lines 214–218) corrected: `kiro-ide` projects `.md`, `kiro-cli` projects `.json`, IDE accepts both (T5)
-- [ ] `distribution-adapters/spec.md` primitive table agent row and hook-wiring row updated to reflect the split (T5)
-- [ ] `agent-spec-cli/spec.md` §v0.4 carries clarification: "Code shipped in PR #99; contract activation deferred to RFC-0022" (T6)
+- [x] `distribution-adapters/spec.md` footnote (lines 214–218) corrected: `kiro-ide` projects `.md`, `kiro-cli` projects `.json`, IDE accepts both (T5)
+- [x] `distribution-adapters/spec.md` primitive table agent row and hook-wiring row updated to reflect the split (T5)
+- [x] `agent-spec-cli/spec.md` §v0.4 carries clarification: "Code shipped in PR #99; contract activation deferred to RFC-0022" (T6)
 
 ### CLI help text (T7)
 
-- [ ] `cli.py` adapter help-text string names all five adapters with deprecation note for `kiro` (T7)
+- [x] `cli.py` adapter help-text string names all five adapters with deprecation note for `kiro` (T7)
 
 ### Test suite (T8) — depends on T1, T2, T3, T4
 
-- [ ] `test_adapter_kiro.py` (or equivalent) updated: covers `kiro` alias + `kiro-ide` canonical projection, asserts no CLI-only keys in `kiro-ide` output (T8)
-- [ ] `test_contract.py` asserts `"0.9"` (T8)
-- [ ] `kiro_ide_hook` tests updated to E3 vocabulary (T8)
-- [ ] Contract drift gate (`make build-check`) passes with all new adapter declarations (T8)
+- [x] `test_adapter_kiro.py` (or equivalent) updated: covers `kiro` alias + `kiro-ide` canonical projection, asserts no CLI-only keys in `kiro-ide` output (T8)
+- [x] `test_contract.py` asserts `"0.9"` (T8)
+- [x] `kiro_ide_hook` tests updated to E3 vocabulary (T8)
+- [x] Contract drift gate (`make build-check`) passes with all new adapter declarations (T8)
 
 ## Changelog
 

--- a/docs/specs/kiro-ide-hook/probes.md
+++ b/docs/specs/kiro-ide-hook/probes.md
@@ -45,19 +45,24 @@ operator can read off the result unambiguously.
 
 ### Outcome
 
-> **Not yet run.** This row is the surface-to-operator gate. The
-> operator opens the workspace in Kiro, drives a fileSave, and
-> records observations below.
+> **Closed (2026-06-01, Kiro 0.12.224).** Only `PROBE_FLAT_FIRED`;
+> `PROBE_NESTED_FIRED` and `PROBE_OTHER_EXTENSION_FIRED` did not fire.
+> Confirmed by `extension.js` source audit: `listHooks()` calls
+> `vscode.workspace.fs.readDirectory(.kiro/hooks/)` non-recursively
+> (immediate children only), then filters on `.kiro.hook` extension.
+> The `**/*.kiro.hook` file-system watcher is for change events only,
+> not initial hook discovery. Quadrant: **no × yes** (no recursion,
+> yes extension filter). RFC-0022 assumed yes-recursion; T1 of
+> `kiro-adapter-split` carries the corrected flat-with-prefix path.
 
-- **Recursion observed:** _<yes | no>_  ← fill in
-- **Extension filter observed:** _<yes | no>_  ← fill in
-- **2×2 quadrant:** _<yes-yes | yes-no | no-yes | no-no>_
+- **Recursion observed:** no
+- **Extension filter observed:** yes
+- **2×2 quadrant:** no-yes
 - **Canonical `target.repo` string for `adapter.toml`:**
-  _<filled in once the quadrant is known>_
-- **Cross-primitive `hook-body` retarget (T-E1b) fires?**
-  _<yes if `yes × no` quadrant, otherwise no>_
-- **Date of observation:** _<YYYY-MM-DD>_
-- **Kiro version observed:** _<e.g. 0.2.13 — `kiro --version`>_
+  `.kiro/hooks/<pack>--<name>.kiro.hook`
+- **Cross-primitive `hook-body` retarget (T-E1b) fires?** no
+- **Date of observation:** 2026-06-01
+- **Kiro version observed:** 0.12.224
 
 ## Q11 — vocabulary fixture
 

--- a/packages/agentbundle/agentbundle/_data/adapter.toml
+++ b/packages/agentbundle/agentbundle/_data/adapter.toml
@@ -249,6 +249,10 @@ frontmatter-mapping = "kiro-cli-agent-frontmatter-v1.0"
 on-conflict = "prompt-then-preserve"
 
 [[adapter.kiro-cli.projection]]
+# Legacy repo-scope entry — the pipeline-of-record for repo-scope hook-body
+# projection (mirrors the `kiro` adapter's RFC-0005 hybrid). The table form
+# below is the scope-conditional declaration for the user-scope pipeline;
+# both coexist intentionally. `_iter_primitives` deduplicates via set union.
 primitive = "hook-body"
 mode = "direct-file"
 target-path = "tools/hooks/"

--- a/packages/agentbundle/agentbundle/_data/adapter.toml
+++ b/packages/agentbundle/agentbundle/_data/adapter.toml
@@ -19,9 +19,15 @@
 # frontmatter-v0.8` mapping. Dropped-primitives warning rail introduced
 # in `agentbundle install` for any (adapter, pack) pair where the
 # resolved adapter projects a primitive type the pack ships as `dropped`.
+# RFC-0022 / docs/specs/kiro-adapter-split (v0.9): kiro adapter split into
+# `kiro-ide` (IDE, .md agents, kiro-ide-hook active, flat path confirmed by
+# Q6 probe no×yes 2026-06-01) and `kiro-cli` (CLI binary, .json agents,
+# hook-wiring retained). `kiro` retained as deprecated alias for `kiro-ide`.
+# `kiro-ide-hook` primitive activated; `kiro-ide-agent-frontmatter-v0.9` renamed
+# to `kiro-ide-agent-frontmatter-v0.9`.
 
 [contract]
-version = "0.8"
+version = "0.9"
 
 # Sibling schemas this contract references — pack metadata and the
 # per-pack Claude-plugin manifest. Defined by spec AC #3 + #4.
@@ -47,6 +53,11 @@ source-path = ".apm/hook-wiring/"
 
 [primitive.command]
 source-path = ".apm/commands/"
+
+# RFC-0022 / kiro-ide-hook: standalone IDE event hook files (.kiro.hook JSON).
+# Activated at v0.9 for the kiro-ide adapter; dropped for kiro-cli and others.
+[primitive."kiro-ide-hook"]
+source-path = ".apm/kiro-ide-hooks/"
 
 # RFC-0013 § 4c — `shared-libs/` carries Python sibling files that the
 # build pipeline projects into every consumer skill declaring
@@ -175,7 +186,7 @@ on-conflict = "prompt-then-preserve"
 primitive = "agent"
 mode = "direct-file"
 target-path = ".kiro/agents/"
-frontmatter-mapping = "kiro-agent-frontmatter-v0.9"
+frontmatter-mapping = "kiro-ide-agent-frontmatter-v0.9"
 on-conflict = "prompt-then-preserve"
 
 [[adapter.kiro.projection]]
@@ -224,6 +235,79 @@ user = "~"
 # RFC-0012: Kiro projects skills/agents to `.kiro/`; hook bodies land in the
 # legacy `tools/hooks/` at repo scope (matching the contract's hook-body
 # array entry above).
+allowed-prefixes.repo = [".kiro/", ".agentbundle/", "tools/hooks/"]
+allowed-prefixes.user = [".kiro/", ".agentbundle/"]
+
+# ---------------------------------------------------------------------------
+# kiro-ide adapter — targets the Kiro VS Code-fork IDE (RFC-0022).
+#
+# Projects agents as `.md` (gray-matter YAML frontmatter + body); the IDE
+# reads `.kiro/agents/<name>.md` via its gray-matter loader. hook-wiring is
+# DROPPED — the IDE loader silently drops any agent carrying a `hooks` key
+# (RFC-0022 E2). kiro-ide-hook is ACTIVATED with the flat path confirmed by
+# Q6 probe (no-recursion, yes-extension-filter, 2026-06-01, Kiro 0.12.224):
+# `.kiro/hooks/<pack>--<name>.kiro.hook`. RFC-0022 assumed yes-recursion;
+# T1 carries the corrected no-recursion flat path (no T-E1b fires).
+# ---------------------------------------------------------------------------
+
+[[adapter.kiro-ide.projection]]
+primitive = "skill"
+mode = "direct-directory"
+target-path = ".kiro/skills/"
+on-conflict = "prompt-then-preserve"
+
+[[adapter.kiro-ide.projection]]
+primitive = "agent"
+mode = "direct-file"
+target-path = ".kiro/agents/"
+frontmatter-mapping = "kiro-ide-agent-frontmatter-v0.9"
+on-conflict = "prompt-then-preserve"
+
+[[adapter.kiro-ide.projection]]
+primitive = "hook-body"
+mode = "direct-file"
+target-path = "tools/hooks/"
+on-conflict = "prompt-then-preserve"
+
+[[adapter.kiro-ide.projection]]
+primitive = "hook-wiring"
+mode = "dropped"
+
+[[adapter.kiro-ide.projection]]
+primitive = "command"
+mode = "dropped"
+
+# hook-body — scope-conditional target (RFC-0005 § hook-body at user scope).
+[adapter.kiro-ide.projections.hook-body]
+mode = "direct-file"
+target.repo = "tools/hooks/<name>.{sh,py}"
+target.user = ".kiro/hooks/<name>.{sh,py}"
+on-conflict = "prompt-then-preserve"
+
+# kiro-ide-hook — activated for the IDE target (Q6 probe: no-recursion,
+# yes-extension-filter). Flat path uses `<pack>--<name>` prefix separator
+# so pack hooks coexist in the single flat `.kiro/hooks/` directory.
+[adapter.kiro-ide.projections.kiro-ide-hook]
+mode = "direct-file"
+target.repo = ".kiro/hooks/<pack>--<name>.kiro.hook"
+ide-event-vocabulary = [
+  "fileEdited",
+  "fileCreated",
+  "fileDeleted",
+  "userTriggered",
+  "promptSubmit",
+  "agentStop",
+  "preToolUse",
+  "postToolUse",
+  "preTaskExecution",
+  "postTaskExecution",
+  "sessionStart",
+]
+ide-action-vocabulary = ["askAgent", "runCommand"]
+
+[adapter.kiro-ide.scope]
+repo = "."
+user = "~"
 allowed-prefixes.repo = [".kiro/", ".agentbundle/", "tools/hooks/"]
 allowed-prefixes.user = [".kiro/", ".agentbundle/"]
 
@@ -388,12 +472,12 @@ allowed-prefixes.user = [".agents/skills/", ".codex/", ".agentbundle/"]
 
 # Kiro agent frontmatter v0.9: renames Claude Code agent fields to Kiro's schema.
 # Adapters consume this table generically; no field dictionary hardcoded in Python.
-[frontmatter-mapping."kiro-agent-frontmatter-v0.9"]
+[frontmatter-mapping."kiro-ide-agent-frontmatter-v0.9"]
 
-[frontmatter-mapping."kiro-agent-frontmatter-v0.9".description]
+[frontmatter-mapping."kiro-ide-agent-frontmatter-v0.9".description]
 rename = "description"
 
-[frontmatter-mapping."kiro-agent-frontmatter-v0.9".tools]
+[frontmatter-mapping."kiro-ide-agent-frontmatter-v0.9".tools]
 normalize = "to-list"
 # Translate Claude Code tool names to specific Kiro tool *ids*. Kiro matches
 # an agent's `tools` entries by id or tag (never by Claude Code names); we
@@ -406,7 +490,7 @@ normalize = "to-list"
 # the Kiro CLI's short names land in the kiro-cli adapter.
 values = { Read = "read_file", Grep = "grep_search", Glob = "file_search", Edit = "str_replace", Write = "fs_write", MultiEdit = "str_replace", Bash = "execute_bash", WebFetch = "web_fetch", WebSearch = "web" }
 
-[frontmatter-mapping."kiro-agent-frontmatter-v0.9".model]
+[frontmatter-mapping."kiro-ide-agent-frontmatter-v0.9".model]
 rename = "model"
 # Translate Claude Code's friendly aliases to Kiro's documented model IDs
 # (https://kiro.dev/docs/cli/custom-agents/configuration-reference/). A
@@ -418,7 +502,7 @@ values = { opus = "claude-opus-4.6", sonnet = "claude-sonnet-4.5", haiku = "clau
 # kiro-cli agent frontmatter v1.0 (RFC-0022): rewrite rules from Claude Code
 # agent markdown to Kiro CLI JSON. Tools map to CLI short-names (not IDE ids).
 # The `kiro` CLI matches agents' `tools` entries by short name; the IDE uses
-# ids — hence the separate table rather than reusing kiro-agent-frontmatter-v0.9.
+# ids — hence the separate table rather than reusing kiro-ide-agent-frontmatter-v0.9.
 [frontmatter-mapping."kiro-cli-agent-frontmatter-v1.0"]
 
 [frontmatter-mapping."kiro-cli-agent-frontmatter-v1.0".description]

--- a/packages/agentbundle/agentbundle/_data/adapter.toml
+++ b/packages/agentbundle/agentbundle/_data/adapter.toml
@@ -152,13 +152,17 @@ allowed-prefixes.repo = [".claude/", ".agentbundle/", "tools/hooks/"]
 allowed-prefixes.user = [".claude/", ".agentbundle/"]
 
 # ---------------------------------------------------------------------------
-# Kiro adapter
+# Kiro adapter — DEPRECATED ALIAS for kiro-ide (RFC-0022 D1).
 #
-# RFC-0005 promotes Kiro `hook-wiring` out of `degraded-info-log` to the new
-# `merge-into-agent-json` mode — the legacy degraded entry is removed (per
-# AC2). `hook-body` keeps its legacy `direct-file → tools/hooks/` array entry
-# and additionally declares a v0.3 scope-conditional table for the user-scope
-# pipeline T5/T7 will land. Skill, agent, command remain in the array.
+# `kiro` is retained as a working alias with no removal timeline so existing
+# packs declaring `allowed-adapters = ["kiro"]` keep working. The Python
+# registry maps "kiro" → kiro_ide.project and emits a build-time
+# DeprecationWarning on use. Update `allowed-adapters` to `["kiro-ide"]` or
+# `["kiro-cli"]` in pack.toml to silence the warning.
+#
+# The projection blocks below are preserved verbatim so `validate` keeps
+# accepting "kiro" and `_shipped_for_cli` (derived from the adapter key set)
+# continues to include it.
 # ---------------------------------------------------------------------------
 
 [[adapter.kiro.projection]]
@@ -220,6 +224,70 @@ user = "~"
 # RFC-0012: Kiro projects skills/agents to `.kiro/`; hook bodies land in the
 # legacy `tools/hooks/` at repo scope (matching the contract's hook-body
 # array entry above).
+allowed-prefixes.repo = [".kiro/", ".agentbundle/", "tools/hooks/"]
+allowed-prefixes.user = [".kiro/", ".agentbundle/"]
+
+# ---------------------------------------------------------------------------
+# kiro-cli adapter — targets the `kiro` terminal binary (RFC-0022).
+#
+# Projects agents as `.json` with CLI short-name tool tokens. Retains
+# `hook-wiring` via `merge-into-agent-json`. `kiro-ide-hook` is dropped —
+# the IDE-only event-hook primitive is not supported by the CLI target.
+# ---------------------------------------------------------------------------
+
+[[adapter.kiro-cli.projection]]
+primitive = "skill"
+mode = "direct-directory"
+target-path = ".kiro/skills/"
+on-conflict = "prompt-then-preserve"
+
+[[adapter.kiro-cli.projection]]
+primitive = "agent"
+mode = "direct-file"
+target-path = ".kiro/agents/"
+frontmatter-mapping = "kiro-cli-agent-frontmatter-v1.0"
+on-conflict = "prompt-then-preserve"
+
+[[adapter.kiro-cli.projection]]
+primitive = "hook-body"
+mode = "direct-file"
+target-path = "tools/hooks/"
+on-conflict = "prompt-then-preserve"
+
+[[adapter.kiro-cli.projection]]
+primitive = "command"
+mode = "dropped"
+
+# hook-body — scope-conditional target (RFC-0005 § hook-body at user scope).
+[adapter.kiro-cli.projections.hook-body]
+mode = "direct-file"
+target.repo = "tools/hooks/<name>.{sh,py}"
+target.user = ".kiro/hooks/<name>.{sh,py}"
+on-conflict = "prompt-then-preserve"
+
+# hook-wiring — merge into the pack-owned agent JSON (same as legacy kiro).
+[adapter.kiro-cli.projections.hook-wiring]
+mode = "merge-into-agent-json"
+target.repo = ".kiro/agents/<attach-to-agent>.json"
+target.user = ".kiro/agents/<attach-to-agent>.json"
+managed-key = "hooks"
+agent-event-vocabulary = [
+  "agentSpawn",
+  "userPromptSubmit",
+  "preToolUse",
+  "postToolUse",
+  "stop",
+]
+
+# kiro-ide-hook — dropped for the CLI target. The IDE-only event-hook
+# primitive is not supported by the kiro binary; packs shipping
+# .apm/kiro-ide-hooks/ content must use the kiro-ide adapter instead.
+[adapter.kiro-cli.projections.kiro-ide-hook]
+mode = "dropped"
+
+[adapter.kiro-cli.scope]
+repo = "."
+user = "~"
 allowed-prefixes.repo = [".kiro/", ".agentbundle/", "tools/hooks/"]
 allowed-prefixes.user = [".kiro/", ".agentbundle/"]
 
@@ -341,6 +409,26 @@ rename = "model"
 # source value not in the map is dropped from the JSON output, leaving
 # Kiro to fall back to its CLI default with a warning rather than
 # rejecting the agent for an unknown model.
+values = { opus = "claude-opus-4.6", sonnet = "claude-sonnet-4.5", haiku = "claude-haiku-4.5" }
+
+# kiro-cli agent frontmatter v1.0 (RFC-0022): rewrite rules from Claude Code
+# agent markdown to Kiro CLI JSON. Tools map to CLI short-names (not IDE ids).
+# The `kiro` CLI matches agents' `tools` entries by short name; the IDE uses
+# ids — hence the separate table rather than reusing kiro-agent-frontmatter-v0.9.
+[frontmatter-mapping."kiro-cli-agent-frontmatter-v1.0"]
+
+[frontmatter-mapping."kiro-cli-agent-frontmatter-v1.0".description]
+rename = "description"
+
+[frontmatter-mapping."kiro-cli-agent-frontmatter-v1.0".tools]
+normalize = "to-list"
+# Translate Claude Code tool names to Kiro CLI short-name tool tokens.
+# Applied per list element after `to-list`; duplicates collapse and an
+# unmapped token drops with a build-time warning.
+values = { Read = "read", Grep = "grep", Glob = "glob", Edit = "write", Write = "write", MultiEdit = "write", Bash = "shell", WebFetch = "web_fetch", WebSearch = "web_search" }
+
+[frontmatter-mapping."kiro-cli-agent-frontmatter-v1.0".model]
+rename = "model"
 values = { opus = "claude-opus-4.6", sonnet = "claude-sonnet-4.5", haiku = "claude-haiku-4.5" }
 
 # Codex agent frontmatter v0.8 (docs/specs/dropped-primitives-coverage):

--- a/packages/agentbundle/agentbundle/build/adapters/__init__.py
+++ b/packages/agentbundle/agentbundle/build/adapters/__init__.py
@@ -2,16 +2,33 @@
 
 from __future__ import annotations
 
+import logging
+import warnings
 from types import ModuleType
 from typing import Callable, Dict, Mapping
 
-from agentbundle.build.adapters import claude_code, codex, copilot, kiro
+from agentbundle.build.adapters import claude_code, codex, copilot, kiro, kiro_cli, kiro_ide
+
+_LOG = logging.getLogger(__name__)
+
+
+def _kiro_alias_project(pack_path, contract, output_root) -> None:
+    """Deprecated alias: `kiro` → `kiro-ide`. Emits a build-time warning."""
+    warnings.warn(
+        "kiro: deprecated alias for kiro-ide; update allowed-adapters in pack.toml",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    kiro_ide.project(pack_path, contract, output_root)
+
 
 # Original callable registry (hyphenated contract names) — preserved for
 # F-build's recipe runner which keys recipes by contract names.
 ADAPTERS: Dict[str, Callable] = {
     "claude-code": claude_code.project,
-    "kiro": kiro.project,
+    "kiro-ide": kiro_ide.project,
+    "kiro-cli": kiro_cli.project,
+    "kiro": _kiro_alias_project,  # deprecated alias → kiro-ide (RFC-0022 D1)
     "copilot": copilot.project,
     "codex": codex.project,
 }
@@ -23,7 +40,9 @@ ADAPTERS: Dict[str, Callable] = {
 # attribute the sibling spec pins onto `AdapterModule`.
 registry: Mapping[str, ModuleType] = {
     "claude_code": claude_code,
-    "kiro": kiro,
+    "kiro_ide": kiro_ide,
+    "kiro_cli": kiro_cli,
+    "kiro": kiro,  # legacy module; use kiro_ide for new code
     "copilot": copilot,
     "codex": codex,
 }

--- a/packages/agentbundle/agentbundle/build/adapters/__init__.py
+++ b/packages/agentbundle/agentbundle/build/adapters/__init__.py
@@ -2,17 +2,15 @@
 
 from __future__ import annotations
 
-import logging
 import warnings
+from pathlib import Path
 from types import ModuleType
 from typing import Callable, Dict, Mapping
 
 from agentbundle.build.adapters import claude_code, codex, copilot, kiro, kiro_cli, kiro_ide
 
-_LOG = logging.getLogger(__name__)
 
-
-def _kiro_alias_project(pack_path, contract, output_root) -> None:
+def _kiro_alias_project(pack_path: Path, contract: dict, output_root: Path) -> None:
     """Deprecated alias: `kiro` → `kiro-ide`. Emits a build-time warning."""
     warnings.warn(
         "kiro: deprecated alias for kiro-ide; update allowed-adapters in pack.toml",

--- a/packages/agentbundle/agentbundle/build/adapters/kiro.py
+++ b/packages/agentbundle/agentbundle/build/adapters/kiro.py
@@ -1,4 +1,11 @@
-"""Kiro adapter — projects primitives in the v0.3 phase order.
+"""Kiro adapter — underlying JSON projection shared by kiro-cli and the kiro alias.
+
+RFC-0022: the `kiro` contract adapter is a deprecated alias for `kiro-ide`.
+This module (`kiro.py`) now serves as the shared implementation layer used by:
+  - `kiro_cli.py` — CLI target, JSON agents with CLI short-name tool tokens.
+  - `kiro_ide.py` — imports `_split_frontmatter`, `_apply_mapping`, and the
+    direct-file helpers; overrides agent projection to emit `.md`.
+  - `kiro` alias — deprecated alias that calls `kiro_ide.project`.
 
 Per RFC-0005 § Build-pipeline ordering invariant, primitives project in
 the fixed order **`hook-body` → `agent` → `hook-wiring` → `command` →
@@ -6,13 +13,9 @@ the fixed order **`hook-body` → `agent` → `hook-wiring` → `command` →
 `merge-into-agent-json` projection reads the agent JSON the agent
 primitive's projection wrote — agents must land first.
 
-Agents project as `.kiro/agents/<name>.json` per Kiro's documented
-schema (https://kiro.dev/docs/cli/custom-agents/configuration-reference/),
-**not** as `.md` with frontmatter. The pack-side source format stays
-`.apm/agents/<name>.md` with frontmatter; this adapter parses the
-markdown body + frontmatter and emits JSON with the documented Kiro
-fields (`name`, `description`, `tools`, `model`, `prompt`). The
-`kiro-agent-frontmatter-v0.9` mapping table is reinterpreted as
+When used directly (for the kiro alias / kiro-cli path), agents project as
+`.kiro/agents/<name>.json`. The `kiro-ide-agent-frontmatter-v0.9` mapping
+table (renamed from `kiro-agent-frontmatter-v0.9` in T1) is reinterpreted as
 *frontmatter-key → JSON-field* rather than *frontmatter → frontmatter*.
 
 Hook-wiring projection delegates to
@@ -238,7 +241,7 @@ def _project_agent_as_json(
       - `name`: derived from the source filename (without `.md`),
         or overridden by a `name` frontmatter field if present.
       - `description`: frontmatter `description` (renamed per the
-        contract's `kiro-agent-frontmatter-v0.9` mapping).
+        contract's `kiro-ide-agent-frontmatter-v0.9` mapping).
       - `tools`: frontmatter `tools` normalized to a list.
       - `model`: frontmatter `model`, if declared.
       - `prompt`: the markdown body after the closing `---` fence.
@@ -454,7 +457,7 @@ def _parse_frontmatter(lines: list[str]) -> dict[str, Any]:
 
 
 def _apply_mapping(frontmatter: dict[str, Any], mapping: dict) -> dict[str, Any]:
-    """Apply the contract's `kiro-agent-frontmatter-v0.9` rename /
+    """Apply the contract's `kiro-ide-agent-frontmatter-v0.9` rename /
     normalize / values / default rules. Interpreted as
     *markdown-frontmatter → JSON-field*.
 

--- a/packages/agentbundle/agentbundle/build/adapters/kiro.py
+++ b/packages/agentbundle/agentbundle/build/adapters/kiro.py
@@ -69,6 +69,12 @@ def _iter_primitives(contract: dict) -> Iterator[str]:
                 continue
             yield primitive_name
         elif primitive_name in table_form:
+            rule = table_form[primitive_name]
+            effective_mode = rule.get("mode")
+            if isinstance(effective_mode, dict):
+                effective_mode = effective_mode.get("repo")
+            if effective_mode == "dropped":
+                continue
             yield primitive_name
 
 

--- a/packages/agentbundle/agentbundle/build/adapters/kiro_cli.py
+++ b/packages/agentbundle/agentbundle/build/adapters/kiro_cli.py
@@ -1,0 +1,53 @@
+"""kiro-cli adapter — projects primitives for the `kiro` terminal binary.
+
+Targets the `kiro` CLI, not the Kiro IDE. Key differences from kiro-ide:
+- Agents project as `.json` with CLI short-name tool tokens
+  (`read`, `grep`, `glob`, `write`, `shell`, `web_fetch`, `web_search`).
+- hook-wiring is retained via `merge-into-agent-json` (same as the
+  legacy `kiro` adapter).
+- kiro-ide-hook is dropped (IDE-only primitive).
+
+Projection logic is identical to the kiro adapter — the only difference
+is the adapter contract block (`kiro-cli`) and frontmatter mapping table
+(`kiro-cli-agent-frontmatter-v1.0`). This module adapts the contract so
+kiro.py's projection functions run unchanged, rather than duplicating them.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentbundle.build.adapters import kiro as _kiro
+
+
+def project(pack_path: Path, contract: dict, output_root: Path) -> None:
+    """Single-pack convenience wrapper. Delegates to `project_packs`."""
+    project_packs([pack_path], contract, output_root)
+
+
+def project_packs(pack_paths: list[Path], contract: dict, output_root: Path) -> None:
+    """Project every pack in `pack_paths` using the kiro-cli adapter block.
+
+    Adapts the contract so kiro.py's projection functions read from
+    `[adapter.kiro-cli]` rather than `[adapter.kiro]`. The frontmatter
+    mapping table reference in the adapter block (`kiro-cli-agent-
+    frontmatter-v1.0`) is preserved so CLI short-name tool tokens are
+    emitted instead of the IDE ids.
+    """
+    adapted = _adapt_contract(contract)
+    _kiro.project_packs(pack_paths, adapted, output_root)
+
+
+def _adapt_contract(contract: dict) -> dict:
+    """Return a shallow copy of *contract* where `adapter["kiro"]` is
+    replaced by `adapter["kiro-cli"]`.
+
+    This lets kiro.py's projection functions (which key on the "kiro"
+    adapter block) run unchanged for the kiro-cli target without
+    duplicating the projection logic.
+    """
+    adapted_adapter = dict(contract["adapter"])
+    adapted_adapter["kiro"] = contract["adapter"]["kiro-cli"]
+    adapted = dict(contract)
+    adapted["adapter"] = adapted_adapter
+    return adapted

--- a/packages/agentbundle/agentbundle/build/adapters/kiro_ide.py
+++ b/packages/agentbundle/agentbundle/build/adapters/kiro_ide.py
@@ -1,37 +1,46 @@
 """kiro-ide adapter — projects primitives for the Kiro VS Code-fork IDE.
 
 Targets the Kiro IDE, not the `kiro` CLI binary. Key differences from kiro-cli:
-- Agents project as `.md` (body-as-prompt via gray-matter), using the
-  `kiro-ide-agent-frontmatter-v0.9` mapping table with IDE tool ids.
-- kiro-ide-hook is activated (event hooks via `.kiro.hook` files).
-- hook-wiring is dropped — the IDE loader silently drops any agent
-  carrying a `hooks` key (RFC-0022 E2).
-- No CLI-only fields (`hooks`, `allowedTools`, `toolsSettings`,
-  `mcpServers`) in agent output.
 
-The deprecated `kiro` adapter is an alias for this module (T4).
+- Agents project as `.md` (YAML frontmatter + body), loaded by the IDE
+  via gray-matter. The `kiro-ide-agent-frontmatter-v0.9` mapping applies IDE
+  tool ids (read_file, grep_search, etc.) — not CLI short-names.
+- `hook-wiring` is DROPPED. The IDE loader silently drops any agent carrying
+  a `hooks` key (RFC-0022 E2). Use kiro-ide-hook instead.
+- `kiro-ide-hook` is ACTIVATED. Flat projection path confirmed by Q6 probe
+  (no-recursion, yes-extension-filter, 2026-06-01, Kiro 0.12.224):
+  `.kiro/hooks/<pack>--<name>.kiro.hook`.
 
---- CONTRACT GATE ---
-T1 activation requires the Q6 probe outcome to be recorded in
-`docs/specs/kiro-ide-hook/probes.md` before the contract version is
-bumped to 0.9 and this adapter's projection is enabled. Until Q6 is
-recorded, this module stub-delegates to kiro.py's JSON projection as
-a placeholder (same observable behavior as the legacy `kiro` adapter).
-Once Q6 is run:
-  1. Record Q6 outcome in probes.md.
-  2. Implement `.md` projection here (replace the delegation below).
-  3. Bump `[contract] version` to `"0.9"` and add `[adapter.kiro-ide]`
-     in `adapter.toml` (T1).
+The deprecated `kiro` adapter maps to this module (T4).
+
+Phase order (from phase_order.PHASE_ORDER):
+  hook-body → agent → kiro-ide-hook → command → skill
+  (hook-wiring is skipped — dropped for kiro-ide).
 """
 
 from __future__ import annotations
 
-import logging
+import shutil
+import sys
 from pathlib import Path
+from typing import Any, Iterator
 
-from agentbundle.build.adapters import kiro as _kiro
+from agentbundle.build.phase_order import PHASE_ORDER as _PHASE_ORDER
+from agentbundle.build.projections.direct_directory import sweep_orphans
+from agentbundle.build.projections.kiro_ide_hook import project as kiro_ide_hook_project
 
-_LOG = logging.getLogger(__name__)
+# Import frontmatter helpers from kiro.py (pure functions, no side effects).
+from agentbundle.build.adapters.kiro import (
+    _split_frontmatter,
+    _parse_frontmatter,
+    _apply_mapping,
+    _project_direct_directory,
+    _project_direct_file,
+    _project_direct_file_template,
+    _resolve_kiro_hook_body_target_dir as _resolve_hook_body_target_dir_from_kiro,
+)
+
+_ADAPTER = "kiro-ide"
 
 
 def project(pack_path: Path, contract: dict, output_root: Path) -> None:
@@ -40,12 +49,227 @@ def project(pack_path: Path, contract: dict, output_root: Path) -> None:
 
 
 def project_packs(pack_paths: list[Path], contract: dict, output_root: Path) -> None:
-    """Project every pack in `pack_paths` using the kiro-ide adapter.
+    """Project every pack in `pack_paths` using the kiro-ide adapter block."""
+    for pack_path in pack_paths:
+        _project_single(pack_path, contract, output_root)
+    _sweep_skill_orphans(pack_paths, contract, output_root)
 
-    NOTE: This is a pre-T1 stub. The Q6 probe gate has not yet been
-    cleared; projection delegates to the existing kiro adapter behavior
-    (JSON projection with IDE tool ids). When T1 lands (post-Q6), this
-    function will be replaced with a proper .md projection implementation
-    using `kiro-ide-agent-frontmatter-v0.9`.
+
+def _skill_direct_directory_target(contract: dict, output_root: Path) -> Path | None:
+    adapter_block = contract["adapter"][_ADAPTER]
+    for entry in adapter_block.get("projection", []):
+        if entry.get("primitive") == "skill" and entry.get("mode") == "direct-directory":
+            return output_root / entry["target-path"].rstrip("/")
+    return None
+
+
+def _sweep_skill_orphans(pack_paths: list[Path], contract: dict, output_root: Path) -> None:
+    target_dir = _skill_direct_directory_target(contract, output_root)
+    if target_dir is None:
+        return
+    skill_source_path = contract["primitive"]["skill"]["source-path"].rstrip("/")
+    expected_names: set[str] = set()
+    for pack_path in pack_paths:
+        source_dir = pack_path / skill_source_path
+        if not source_dir.exists():
+            continue
+        for entry in source_dir.iterdir():
+            if entry.is_dir():
+                expected_names.add(entry.name)
+    sweep_orphans(target_dir, expected_names)
+
+
+def _iter_primitives(contract: dict) -> Iterator[str]:
+    """Yield kiro-ide's projected primitive names in phase order.
+
+    Skips hook-wiring (dropped for kiro-ide) and any dropped table-form
+    entries. kiro-ide-hook is included when its mode is not dropped.
     """
-    _kiro.project_packs(pack_paths, contract, output_root)
+    adapter_block = contract["adapter"][_ADAPTER]
+    array_form = {e["primitive"]: e for e in adapter_block.get("projection", [])}
+    table_form = adapter_block.get("projections", {}) or {}
+
+    for primitive_name in _PHASE_ORDER:
+        if primitive_name in array_form:
+            if array_form[primitive_name].get("mode") == "dropped":
+                continue
+            yield primitive_name
+        elif primitive_name in table_form:
+            rule = table_form[primitive_name]
+            effective_mode = rule.get("mode")
+            if isinstance(effective_mode, dict):
+                effective_mode = effective_mode.get("repo")
+            if effective_mode == "dropped":
+                continue
+            yield primitive_name
+
+
+def _project_single(pack_path: Path, contract: dict, output_root: Path) -> None:
+    adapter_block = contract["adapter"][_ADAPTER]
+    array_form = {e["primitive"]: e for e in adapter_block.get("projection", [])}
+    table_form = adapter_block.get("projections", {}) or {}
+
+    for primitive_name in _iter_primitives(contract):
+        # kiro-ide-hook: source dir is implicit (.apm/kiro-ide-hooks/),
+        # dispatch to the dedicated projector directly.
+        if primitive_name == "kiro-ide-hook":
+            rule = table_form.get("kiro-ide-hook", {})
+            _dispatch_kiro_ide_hook(pack_path, output_root, rule, contract)
+            continue
+
+        prim_def = contract["primitive"].get(primitive_name)
+        if prim_def is None:
+            continue
+        source_dir = pack_path / prim_def["source-path"].rstrip("/")
+        if not source_dir.exists():
+            continue
+
+        if primitive_name in array_form:
+            rule = array_form[primitive_name]
+            _dispatch_array_form(primitive_name, source_dir, output_root, rule, contract)
+        else:
+            rule = table_form[primitive_name]
+            _dispatch_table_form(primitive_name, source_dir, output_root, rule)
+
+
+def _dispatch_array_form(
+    primitive_name: str,
+    source_dir: Path,
+    output_root: Path,
+    rule: dict,
+    contract: dict,
+) -> None:
+    mode = rule["mode"]
+    if mode == "direct-directory":
+        _project_direct_directory(source_dir, output_root / rule["target-path"].rstrip("/"))
+    elif mode == "direct-file":
+        if primitive_name == "agent":
+            _project_agent_as_md(source_dir, output_root, rule, contract)
+        else:
+            _project_direct_file(source_dir, output_root, rule["target-path"])
+    else:
+        raise ValueError(f"kiro-ide: unhandled array-form mode {mode!r} for {primitive_name}")
+
+
+def _dispatch_table_form(
+    primitive_name: str,
+    source_dir: Path,
+    output_root: Path,
+    rule: dict,
+) -> None:
+    mode = rule.get("mode")
+    effective_mode = mode["repo"] if isinstance(mode, dict) else mode
+
+    if effective_mode == "direct-file":
+        target = rule.get("target")
+        target_template = target.get("repo") if isinstance(target, dict) else target
+        if target_template:
+            _project_direct_file_template(source_dir, output_root, target_template)
+
+
+def _dispatch_kiro_ide_hook(
+    pack_path: Path,
+    output_root: Path,
+    rule: dict,
+    contract: dict,
+) -> None:
+    """Delegate kiro-ide-hook projection to the dedicated projector.
+
+    Uses the flat target path confirmed by Q6 probe:
+    `.kiro/hooks/<pack>--<name>.kiro.hook`
+    """
+    target = rule.get("target")
+    if isinstance(target, dict):
+        target_template = target.get("repo")
+    else:
+        target_template = target
+    if not target_template:
+        return
+
+    # Resolve hook-body target dir from the kiro-ide adapter block.
+    # The kiro-ide block has hook-body in the array form (tools/hooks/)
+    # so we look there first.
+    adapter_block = contract.get("adapter", {}).get(_ADAPTER, {})
+    hook_body_target_dir = "tools/hooks"
+    for entry in adapter_block.get("projection", []):
+        if entry.get("primitive") == "hook-body" and entry.get("mode") == "direct-file":
+            hook_body_target_dir = entry.get("target-path", "tools/hooks/").rstrip("/")
+            break
+
+    kiro_ide_hook_project(
+        pack_path,
+        output_root,
+        target_template=target_template,
+        hook_body_target_dir=hook_body_target_dir,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Agent .md → .md rewrite (kiro-ide specific)
+# ---------------------------------------------------------------------------
+
+
+def _project_agent_as_md(
+    source_dir: Path,
+    output_root: Path,
+    rule: dict,
+    contract: dict,
+) -> None:
+    """Read `.apm/agents/<name>.md` and emit `.kiro/agents/<name>.md`.
+
+    The source format is YAML-style frontmatter (--- fence) + markdown body.
+    The output preserves the markdown format but rewrites frontmatter fields
+    through the `kiro-ide-agent-frontmatter-v0.9` mapping table (IDE tool ids,
+    model aliases). No CLI-only keys (hooks, allowedTools, toolsSettings,
+    mcpServers) appear in the output — these are not in the mapping table
+    and would cause the IDE loader to silently drop the agent.
+    """
+    target_dir = output_root / rule["target-path"].rstrip("/")
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    mapping_name = rule.get("frontmatter-mapping")
+    mapping = (
+        contract.get("frontmatter-mapping", {}).get(mapping_name, {})
+        if mapping_name
+        else {}
+    )
+
+    for entry in sorted(source_dir.iterdir()):
+        if not (entry.is_file() and entry.suffix == ".md"):
+            continue
+        frontmatter, body = _split_frontmatter(entry.read_text(encoding="utf-8"))
+        rewritten = _apply_mapping(frontmatter, mapping)
+
+        # Ensure name is present (derived from filename if not in frontmatter).
+        agent_name = rewritten.get("name") or entry.stem
+        rewritten["name"] = agent_name
+
+        output_text = _serialize_frontmatter_md(rewritten) + body
+        destination = target_dir / entry.name  # preserves .md extension
+        destination.write_text(output_text, encoding="utf-8")
+
+
+def _serialize_frontmatter_md(fields: dict[str, Any]) -> str:
+    """Emit a YAML frontmatter block for a kiro-ide .md agent file.
+
+    Produces `--- ... ---\n` wrapping. Strings are plain scalars unless they
+    contain YAML-special characters, in which case they are double-quoted.
+    Lists are emitted as YAML flow sequences: `[item1, item2]`. The gray-matter
+    parser in the Kiro IDE accepts both styles.
+    """
+    lines = ["---"]
+    for key, value in fields.items():
+        if isinstance(value, list):
+            items = ", ".join(str(v) for v in value)
+            lines.append(f"{key}: [{items}]")
+        elif isinstance(value, str):
+            # Quote strings that contain YAML-special characters.
+            if any(c in value for c in ':#{}[]|>&*!,\'"'):
+                escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+                lines.append(f'{key}: "{escaped}"')
+            else:
+                lines.append(f"{key}: {value}")
+        else:
+            lines.append(f"{key}: {value}")
+    lines.append("---")
+    return "\n".join(lines) + "\n"

--- a/packages/agentbundle/agentbundle/build/adapters/kiro_ide.py
+++ b/packages/agentbundle/agentbundle/build/adapters/kiro_ide.py
@@ -1,0 +1,51 @@
+"""kiro-ide adapter — projects primitives for the Kiro VS Code-fork IDE.
+
+Targets the Kiro IDE, not the `kiro` CLI binary. Key differences from kiro-cli:
+- Agents project as `.md` (body-as-prompt via gray-matter), using the
+  `kiro-ide-agent-frontmatter-v0.9` mapping table with IDE tool ids.
+- kiro-ide-hook is activated (event hooks via `.kiro.hook` files).
+- hook-wiring is dropped — the IDE loader silently drops any agent
+  carrying a `hooks` key (RFC-0022 E2).
+- No CLI-only fields (`hooks`, `allowedTools`, `toolsSettings`,
+  `mcpServers`) in agent output.
+
+The deprecated `kiro` adapter is an alias for this module (T4).
+
+--- CONTRACT GATE ---
+T1 activation requires the Q6 probe outcome to be recorded in
+`docs/specs/kiro-ide-hook/probes.md` before the contract version is
+bumped to 0.9 and this adapter's projection is enabled. Until Q6 is
+recorded, this module stub-delegates to kiro.py's JSON projection as
+a placeholder (same observable behavior as the legacy `kiro` adapter).
+Once Q6 is run:
+  1. Record Q6 outcome in probes.md.
+  2. Implement `.md` projection here (replace the delegation below).
+  3. Bump `[contract] version` to `"0.9"` and add `[adapter.kiro-ide]`
+     in `adapter.toml` (T1).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from agentbundle.build.adapters import kiro as _kiro
+
+_LOG = logging.getLogger(__name__)
+
+
+def project(pack_path: Path, contract: dict, output_root: Path) -> None:
+    """Single-pack convenience wrapper. Delegates to `project_packs`."""
+    project_packs([pack_path], contract, output_root)
+
+
+def project_packs(pack_paths: list[Path], contract: dict, output_root: Path) -> None:
+    """Project every pack in `pack_paths` using the kiro-ide adapter.
+
+    NOTE: This is a pre-T1 stub. The Q6 probe gate has not yet been
+    cleared; projection delegates to the existing kiro adapter behavior
+    (JSON projection with IDE tool ids). When T1 lands (post-Q6), this
+    function will be replaced with a proper .md projection implementation
+    using `kiro-ide-agent-frontmatter-v0.9`.
+    """
+    _kiro.project_packs(pack_paths, contract, output_root)

--- a/packages/agentbundle/agentbundle/build/scope_rails.py
+++ b/packages/agentbundle/agentbundle/build/scope_rails.py
@@ -580,7 +580,8 @@ def check_kiro_ide_hook(
         vocabulary).
       ide_action_vocabulary: same shape, for ``then.type``.
     """
-    if "kiro" not in set(target_adapters or ()):
+    _kiro_family = {"kiro", "kiro-ide"}
+    if not _kiro_family.intersection(set(target_adapters or ())):
         return None
 
     import json

--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro.py
@@ -62,7 +62,7 @@ class KiroAdapterTests(unittest.TestCase):
         """RFC-0005 / T7: Kiro agents are JSON files per the documented
         Kiro schema (https://kiro.dev/docs/cli/custom-agents/configuration-reference/),
         not markdown-with-frontmatter as v0.2 used to project. The
-        `kiro-agent-frontmatter-v0.9` mapping table is reinterpreted as
+        `kiro-ide-agent-frontmatter-v0.9` mapping table is reinterpreted as
         *markdown-frontmatter → JSON-field* — the rename / to-list
         normalize semantics carry over to JSON emission."""
         import json

--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro_alias.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro_alias.py
@@ -56,6 +56,9 @@ class KiroAliasTests(unittest.TestCase):
 
             kiro_ide.project(pack, self.contract, out_kiro_ide)
 
+            # NOTE: pre-T1 stub — both project to .json (current kiro.py
+            # behavior). When T1 lands, kiro_ide.project will emit .md instead;
+            # update these paths to foo.md and adjust the comparison accordingly.
             alias_json = (out_kiro / ".kiro" / "agents" / "foo.json").read_bytes()
             ide_json = (out_kiro_ide / ".kiro" / "agents" / "foo.json").read_bytes()
             self.assertEqual(

--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro_alias.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro_alias.py
@@ -56,11 +56,9 @@ class KiroAliasTests(unittest.TestCase):
 
             kiro_ide.project(pack, self.contract, out_kiro_ide)
 
-            # NOTE: pre-T1 stub — both project to .json (current kiro.py
-            # behavior). When T1 lands, kiro_ide.project will emit .md instead;
-            # update these paths to foo.md and adjust the comparison accordingly.
-            alias_json = (out_kiro / ".kiro" / "agents" / "foo.json").read_bytes()
-            ide_json = (out_kiro_ide / ".kiro" / "agents" / "foo.json").read_bytes()
+            # T1 landed: kiro_ide.project emits .md (gray-matter format).
+            alias_json = (out_kiro / ".kiro" / "agents" / "foo.md").read_bytes()
+            ide_json = (out_kiro_ide / ".kiro" / "agents" / "foo.md").read_bytes()
             self.assertEqual(
                 alias_json,
                 ide_json,

--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro_alias.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro_alias.py
@@ -1,0 +1,104 @@
+"""Tests for the kiro deprecated alias (T4 — RFC-0022).
+
+The `kiro` adapter is retained as a deprecated alias for `kiro-ide`.
+Packs declaring `allowed-adapters = ["kiro"]` keep working; a
+build-time deprecation warning is emitted.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+import warnings
+from pathlib import Path
+
+from agentbundle.build.adapters import ADAPTERS, kiro_ide
+from agentbundle.build.contract import load as load_contract
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+CONTRACT_PATH = REPO_ROOT / "docs" / "contracts" / "adapter.toml"
+
+
+def _seed_pack(root: Path) -> Path:
+    pack = root / "pack"
+    (pack / ".apm" / "agents").mkdir(parents=True)
+    (pack / ".apm" / "agents" / "foo.md").write_text(
+        "---\nname: foo\ntools: Read\n---\nbody\n",
+        encoding="utf-8",
+    )
+    return pack
+
+
+class KiroAliasTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.contract = load_contract(CONTRACT_PATH)
+
+    def test_kiro_resolves_to_kiro_ide(self) -> None:
+        """ADAPTERS["kiro"] dispatches to kiro-ide's projection logic.
+
+        Project a minimal pack using both "kiro" and "kiro-ide" entries
+        and verify they produce identical output.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = _seed_pack(tmp_path)
+            out_kiro = tmp_path / "out-kiro"
+            out_kiro_ide = tmp_path / "out-kiro-ide"
+
+            kiro_func = ADAPTERS.get("kiro")
+            self.assertIsNotNone(kiro_func, "ADAPTERS must register 'kiro'")
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                kiro_func(pack, self.contract, out_kiro)
+
+            kiro_ide.project(pack, self.contract, out_kiro_ide)
+
+            alias_json = (out_kiro / ".kiro" / "agents" / "foo.json").read_bytes()
+            ide_json = (out_kiro_ide / ".kiro" / "agents" / "foo.json").read_bytes()
+            self.assertEqual(
+                alias_json,
+                ide_json,
+                "kiro alias must produce identical output to kiro-ide",
+            )
+
+    def test_kiro_emits_deprecation_warning(self) -> None:
+        """Calling the kiro alias emits a DeprecationWarning containing 'kiro-ide'."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = _seed_pack(tmp_path)
+            out = tmp_path / "out"
+            kiro_func = ADAPTERS["kiro"]
+
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                kiro_func(pack, self.contract, out)
+
+            dep_warnings = [
+                w for w in caught if issubclass(w.category, DeprecationWarning)
+            ]
+            self.assertTrue(dep_warnings, "kiro alias must emit a DeprecationWarning")
+            messages = " ".join(str(w.message) for w in dep_warnings)
+            self.assertIn("kiro-ide", messages, "warning must mention 'kiro-ide'")
+
+    def test_kiro_alias_in_shipped_for_cli(self) -> None:
+        """'kiro' must appear in the shipped adapters derived from the contract.
+
+        The [adapter.kiro] stub block in adapter.toml ensures the adapter
+        key is present, so `_shipped_for_cli` (derived from the contract's
+        adapter key set) continues to include 'kiro'.
+        """
+        from agentbundle.scope import shipped_adapters_from_contract
+
+        shipped = shipped_adapters_from_contract()
+        self.assertIn(
+            "kiro",
+            shipped,
+            "'kiro' must be in shipped adapters (alias stub block keeps it in the contract)",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro_cli.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro_cli.py
@@ -1,0 +1,102 @@
+"""Tests for the kiro-cli adapter (T3 — RFC-0022).
+
+kiro-cli targets the `kiro` terminal binary. It projects agents as
+`.json` with CLI short-name tool tokens (read, grep, glob, write,
+shell, web_fetch, web_search) and retains hook-wiring via
+merge-into-agent-json. kiro-ide-hook is dropped.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from agentbundle.build.adapters.kiro_cli import project
+from agentbundle.build.contract import load as load_contract
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+CONTRACT_PATH = REPO_ROOT / "docs" / "contracts" / "adapter.toml"
+
+
+def _seed_agent_pack(root: Path, tools: str = "Read, Grep, Glob, Bash") -> Path:
+    pack = root / "pack"
+    (pack / ".apm" / "agents").mkdir(parents=True)
+    (pack / ".apm" / "agents" / "bar.md").write_text(
+        f"---\nname: bar\ntools: {tools}\n---\nagent body\n",
+        encoding="utf-8",
+    )
+    return pack
+
+
+class KiroCliAdapterTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.contract = load_contract(CONTRACT_PATH)
+
+    def test_cli_agent_is_json(self) -> None:
+        """kiro-cli projects agents as .json, not .md."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = _seed_agent_pack(tmp_path)
+            out = tmp_path / "out"
+            project(pack, self.contract, out)
+            self.assertTrue(
+                (out / ".kiro" / "agents" / "bar.json").exists(),
+                "kiro-cli must project agent as .json",
+            )
+            self.assertFalse(
+                (out / ".kiro" / "agents" / "bar.md").exists(),
+                "kiro-cli must not project agent as .md",
+            )
+
+    def test_cli_tool_short_names(self) -> None:
+        """kiro-cli uses CLI short-name tool tokens per the
+        kiro-cli-agent-frontmatter-v1.0 mapping table:
+        Read→read, Grep→grep, Glob→glob, Bash→shell,
+        WebFetch→web_fetch, WebSearch→web_search."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = _seed_agent_pack(
+                tmp_path,
+                tools="Read, Grep, Glob, Bash, WebFetch, WebSearch",
+            )
+            out = tmp_path / "out"
+            project(pack, self.contract, out)
+            data = json.loads(
+                (out / ".kiro" / "agents" / "bar.json").read_text(encoding="utf-8")
+            )
+            tools = data.get("tools", [])
+            self.assertIn("read", tools)
+            self.assertIn("grep", tools)
+            self.assertIn("glob", tools)
+            self.assertIn("shell", tools)
+            self.assertIn("web_fetch", tools)
+            self.assertIn("web_search", tools)
+            # Verify these are short-names, not the IDE ids
+            self.assertNotIn("read_file", tools)
+            self.assertNotIn("grep_search", tools)
+            self.assertNotIn("execute_bash", tools)
+
+    def test_cli_no_ide_hook_field(self) -> None:
+        """kiro-cli projected agent JSON must not contain ide-event-vocabulary
+        or kiro-ide-hook sections — those are IDE-only fields that cause the
+        IDE loader to silently drop agents."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = _seed_agent_pack(tmp_path)
+            out = tmp_path / "out"
+            project(pack, self.contract, out)
+            raw = (out / ".kiro" / "agents" / "bar.json").read_text(encoding="utf-8")
+            self.assertNotIn("ide-event-vocabulary", raw)
+            self.assertNotIn("kiro-ide-hook", raw)
+            data = json.loads(raw)
+            self.assertNotIn("hooks", data, "kiro-cli agent JSON must not carry hooks key")
+            self.assertNotIn("allowedTools", data)
+            self.assertNotIn("toolsSettings", data)
+            self.assertNotIn("mcpServers", data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro_ide.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro_ide.py
@@ -1,0 +1,172 @@
+"""Tests for the kiro-ide adapter (T1 — RFC-0022).
+
+kiro-ide targets the Kiro VS Code-fork IDE. Agents project as .md with YAML
+frontmatter (read by gray-matter), using IDE tool ids. kiro-ide-hook is
+activated. No CLI-only keys in agent output.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from agentbundle.build.adapters.kiro_ide import project
+from agentbundle.build.contract import load as load_contract
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+CONTRACT_PATH = REPO_ROOT / "docs" / "contracts" / "adapter.toml"
+
+
+def _seed_agent_pack(root: Path, tools: str = "Read, Grep", model: str | None = None) -> Path:
+    pack = root / "pack"
+    (pack / ".apm" / "agents").mkdir(parents=True)
+    model_line = f"\nmodel: {model}" if model else ""
+    (pack / ".apm" / "agents" / "bar.md").write_text(
+        f"---\nname: bar\ntools: {tools}{model_line}\n---\nagent body\n",
+        encoding="utf-8",
+    )
+    return pack
+
+
+class KiroIdeAdapterTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.contract = load_contract(CONTRACT_PATH)
+
+    def test_kiro_ide_agent_is_md(self) -> None:
+        """kiro-ide projects agents as .md, not .json."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = _seed_agent_pack(tmp_path)
+            out = tmp_path / "out"
+            project(pack, self.contract, out)
+            self.assertTrue(
+                (out / ".kiro" / "agents" / "bar.md").exists(),
+                "kiro-ide must project agent as .md",
+            )
+            self.assertFalse(
+                (out / ".kiro" / "agents" / "bar.json").exists(),
+                "kiro-ide must not project agent as .json",
+            )
+
+    def test_kiro_ide_no_cli_only_keys(self) -> None:
+        """kiro-ide .md frontmatter must not carry CLI-only keys that would
+        cause the IDE loader to silently drop the agent."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = _seed_agent_pack(tmp_path)
+            out = tmp_path / "out"
+            project(pack, self.contract, out)
+            raw = (out / ".kiro" / "agents" / "bar.md").read_text(encoding="utf-8")
+            for cli_only in ("hooks", "allowedTools", "toolsSettings", "mcpServers"):
+                self.assertNotIn(cli_only, raw, f"kiro-ide agent .md must not contain {cli_only!r}")
+
+    def test_kiro_ide_tools_use_ide_ids(self) -> None:
+        """kiro-ide uses IDE tool ids (read_file, grep_search) not CLI short-names."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = _seed_agent_pack(tmp_path, tools="Read, Grep, Glob, Bash")
+            out = tmp_path / "out"
+            project(pack, self.contract, out)
+            raw = (out / ".kiro" / "agents" / "bar.md").read_text(encoding="utf-8")
+            self.assertIn("read_file", raw)
+            self.assertIn("grep_search", raw)
+            self.assertIn("file_search", raw)
+            self.assertIn("execute_bash", raw)
+            # Not CLI short-names
+            self.assertNotIn("shell", raw.split("---")[1])  # only check frontmatter
+
+    def test_kiro_ide_md_has_frontmatter_and_body(self) -> None:
+        """Output .md file has --- fenced frontmatter and the original body."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = _seed_agent_pack(tmp_path)
+            out = tmp_path / "out"
+            project(pack, self.contract, out)
+            text = (out / ".kiro" / "agents" / "bar.md").read_text(encoding="utf-8")
+            self.assertTrue(text.startswith("---\n"), "must start with --- frontmatter fence")
+            self.assertIn("\n---\n", text, "must have closing --- fence")
+            self.assertIn("agent body", text, "original body must be preserved")
+
+    def test_kiro_ide_model_translates_to_kiro_id(self) -> None:
+        """model: opus translates to claude-opus-4.6 (same mapping as kiro-cli)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = _seed_agent_pack(tmp_path, model="opus")
+            out = tmp_path / "out"
+            project(pack, self.contract, out)
+            text = (out / ".kiro" / "agents" / "bar.md").read_text(encoding="utf-8")
+            self.assertIn("claude-opus-4.6", text)
+            self.assertNotIn(": opus", text)
+
+    def test_frontmatter_table_renamed(self) -> None:
+        """The mapping table is kiro-ide-agent-frontmatter-v0.9 (renamed from
+        kiro-agent-frontmatter-v0.9 in T1). Old name must not exist."""
+        mapping = self.contract.get("frontmatter-mapping", {})
+        self.assertIn(
+            "kiro-ide-agent-frontmatter-v0.9",
+            mapping,
+            "kiro-ide-agent-frontmatter-v0.9 must be in contract",
+        )
+        self.assertNotIn(
+            "kiro-agent-frontmatter-v0.9",
+            mapping,
+            "old name kiro-agent-frontmatter-v0.9 must not exist after T1 rename",
+        )
+
+    def test_kiro_ide_hook_declared_in_contract(self) -> None:
+        """[adapter.kiro-ide.projections.kiro-ide-hook] is declared in contract."""
+        kiro_ide_block = self.contract["adapter"]["kiro-ide"]
+        projections = kiro_ide_block.get("projections", {})
+        self.assertIn(
+            "kiro-ide-hook",
+            projections,
+            "kiro-ide adapter must declare kiro-ide-hook in projections",
+        )
+        rule = projections["kiro-ide-hook"]
+        self.assertEqual(rule.get("mode"), "direct-file")
+        target = rule.get("target", {})
+        target_repo = target.get("repo") if isinstance(target, dict) else target
+        self.assertIsNotNone(target_repo)
+        self.assertIn("<pack>--<name>", target_repo, "flat-with-prefix path must use -- separator")
+        self.assertIn(".kiro.hook", target_repo)
+
+    def test_contract_version_is_0_9(self) -> None:
+        """Contract version bumped to 0.9 by T1."""
+        self.assertEqual(
+            self.contract["contract"]["version"],
+            "0.9",
+            "adapter.toml [contract] version must be '0.9' after kiro-adapter-split T1",
+        )
+
+    def test_kiro_ide_hook_projects_with_flat_prefix_path(self) -> None:
+        """kiro-ide-hook files project to .kiro/hooks/<pack>--<name>.kiro.hook
+        (flat-with-prefix, confirmed by Q6 probe no×yes 2026-06-01)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pack = tmp_path / "my-pack"
+            hooks_dir = pack / ".apm" / "kiro-ide-hooks"
+            hooks_dir.mkdir(parents=True)
+            hook_body = {
+                "name": "on-save",
+                "version": "1",
+                "when": {"type": "fileEdited", "patterns": ["**/*.py"]},
+                "then": {"type": "askAgent", "prompt": "Run lint."},
+            }
+            (hooks_dir / "on-save.kiro.hook").write_text(
+                json.dumps(hook_body), encoding="utf-8"
+            )
+            out = tmp_path / "out"
+            project(pack, self.contract, out)
+            # Flat path: .kiro/hooks/my-pack--on-save.kiro.hook
+            expected = out / ".kiro" / "hooks" / "my-pack--on-save.kiro.hook"
+            self.assertTrue(expected.exists(), f"expected hook at flat path {expected}")
+            # No subdirectory
+            subdir = out / ".kiro" / "hooks" / "my-pack"
+            self.assertFalse(subdir.exists(), "must NOT create a subdirectory for the pack")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/agentbundle/agentbundle/build/tests/test_contract.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_contract.py
@@ -65,6 +65,8 @@ NO_WRITE_MODES = {"degraded-info-log", "dropped"}
 ALL_PRIMITIVES = {"skill", "agent", "hook-body", "hook-wiring", "command"}
 
 # All reference adapter names (RFC-0022: kiro-cli added; kiro retained as alias).
+# NOTE: add "kiro-ide" here when T1 lands (post-Q6 probe) and adds
+# [adapter.kiro-ide] to adapter.toml.
 ALL_ADAPTERS = {"claude-code", "kiro", "kiro-cli", "copilot", "codex"}
 
 # Extra primitives that are kiro-specific and OK to declare in kiro-family

--- a/packages/agentbundle/agentbundle/build/tests/test_contract.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_contract.py
@@ -64,8 +64,12 @@ NO_WRITE_MODES = {"degraded-info-log", "dropped"}
 # All five primitive names.
 ALL_PRIMITIVES = {"skill", "agent", "hook-body", "hook-wiring", "command"}
 
-# All four reference adapter names.
-ALL_ADAPTERS = {"claude-code", "kiro", "copilot", "codex"}
+# All reference adapter names (RFC-0022: kiro-cli added; kiro retained as alias).
+ALL_ADAPTERS = {"claude-code", "kiro", "kiro-cli", "copilot", "codex"}
+
+# Extra primitives that are kiro-specific and OK to declare in kiro-family
+# adapter blocks without failing the "no extra primitives" check.
+KIRO_EXTRA_PRIMITIVES = frozenset({"kiro-ide-hook"})
 
 
 def _load_contract() -> dict:
@@ -108,6 +112,10 @@ class AllPairsEnumeratedTests(unittest.TestCase):
         Under v0.3 (RFC-0005), kiro's `hook-wiring` no longer appears in the
         legacy `projection` array — it lives in the new
         `projections.<primitive>` table. The coverage union walks both forms.
+
+        RFC-0022: kiro-family adapters (kiro, kiro-ide, kiro-cli) may
+        additionally declare `kiro-ide-hook` in their `projections` table;
+        this is a known extra and is not flagged.
         """
         missing: list[str] = []
         extra: list[str] = []
@@ -119,25 +127,29 @@ class AllPairsEnumeratedTests(unittest.TestCase):
                 if prim not in primitives_in_adapter:
                     missing.append(f"({prim}, {adapter_name})")
             for prim in primitives_in_adapter:
-                if prim not in ALL_PRIMITIVES:
+                if prim not in ALL_PRIMITIVES and prim not in KIRO_EXTRA_PRIMITIVES:
                     extra.append(f"({prim}, {adapter_name})")
         self.assertEqual(missing, [], f"missing pairs: {missing}")
         self.assertEqual(extra, [], f"extra unknown primitives: {extra}")
 
     def test_exactly_twenty_pairs_total(self) -> None:
-        """Twenty (primitive × adapter) pairs — counted across array + table forms.
+        """Count (primitive × adapter) pairs across array + table forms.
 
         Pairs that appear in BOTH forms (the transitional hook-body declarations
         on claude-code/kiro and the claude-code hook-wiring legacy entry that
         coexists with its v0.3 table) count once per adapter, matching the
         "primitive coverage" semantic.
+
+        RFC-0022: kiro-cli added (+5 standard + 1 kiro-ide-hook = +6).
+        Total: 5 (claude-code) + 5 (kiro) + 6 (kiro-cli) + 5 (copilot)
+               + 5 (codex) = 26. Class name preserved to avoid churn.
         """
         total = 0
         for adapter_block in self.contract["adapter"].values():
             array_form = {p["primitive"] for p in adapter_block.get("projection", [])}
             table_form = set(adapter_block.get("projections", {}).keys())
             total += len(array_form | table_form)
-        self.assertEqual(total, 20, f"expected 20 pairs total, got {total}")
+        self.assertEqual(total, 26, f"expected 26 pairs total, got {total}")
 
 
 class ModeEnumTests(unittest.TestCase):
@@ -419,10 +431,11 @@ class ContractV05Tests(unittest.TestCase):
         )
 
     def test_other_adapters_have_no_install_routes(self) -> None:
-        """Kiro, Copilot, and Codex do not declare install-routes (regression guard:
-        the v0.4 → v0.5 bump must not silently extend the field's surface to those
-        adapters; per-adapter optionality / default ['cli'] on read is unchanged)."""
-        for adapter_name in ("kiro", "copilot", "codex"):
+        """kiro-family, Copilot, and Codex do not declare install-routes (regression
+        guard: the v0.4 → v0.5 bump must not silently extend the field's surface to
+        those adapters; per-adapter optionality / default ['cli'] on read is unchanged).
+        RFC-0022: kiro-ide and kiro-cli added to the checked set."""
+        for adapter_name in ("kiro", "kiro-cli", "copilot", "codex"):
             adapter_block = self.contract["adapter"].get(adapter_name, {})
             self.assertNotIn(
                 "install-routes",

--- a/packages/agentbundle/agentbundle/build/tests/test_contract.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_contract.py
@@ -2,8 +2,8 @@
 
 Verifies:
   - adapter.toml validates against adapter.schema.json (AC 1).
-  - Every (5 primitives × 4 adapters) = 20 pairs is present — no missing,
-    no extra (AC 1).
+  - Every (5 standard primitives × 6 adapters) = 30 standard pairs present;
+    kiro-ide and kiro-cli each add kiro-ide-hook = 32 total (RFC-0022).
   - The mode enum in adapter.schema.json contains exactly the seven RFC-0001 modes;
     unknown modes are rejected (AC 2).
   - Every projection entry carries an on-conflict value from the legal set,
@@ -11,10 +11,11 @@ Verifies:
     which are no-write/no-output and carry no on-conflict (AC 2).
   - hook-wiring primitive's source-path is .apm/hook-wiring/.
   - command primitive's source-path is .apm/commands/; Claude Code projects
-    direct-file; Copilot/Codex/Kiro are dropped.
-  - frontmatter-mapping table for kiro-agent-frontmatter-v0.9 validates
-    against schema; frontmatter-default table for copilot-instruction
-    validates and is structurally distinct.
+    direct-file; Copilot/Codex/Kiro-family are dropped.
+  - frontmatter-mapping table for kiro-ide-agent-frontmatter-v0.9 validates
+    against schema (renamed from kiro-agent-frontmatter-v0.9 in T1);
+    frontmatter-default table for copilot-instruction validates and is
+    structurally distinct.
 """
 
 from __future__ import annotations

--- a/packages/agentbundle/agentbundle/build/tests/test_contract.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_contract.py
@@ -64,10 +64,8 @@ NO_WRITE_MODES = {"degraded-info-log", "dropped"}
 # All five primitive names.
 ALL_PRIMITIVES = {"skill", "agent", "hook-body", "hook-wiring", "command"}
 
-# All reference adapter names (RFC-0022: kiro-cli added; kiro retained as alias).
-# NOTE: add "kiro-ide" here when T1 lands (post-Q6 probe) and adds
-# [adapter.kiro-ide] to adapter.toml.
-ALL_ADAPTERS = {"claude-code", "kiro", "kiro-cli", "copilot", "codex"}
+# All reference adapter names (RFC-0022: kiro-ide and kiro-cli added; kiro retained as alias).
+ALL_ADAPTERS = {"claude-code", "kiro", "kiro-ide", "kiro-cli", "copilot", "codex"}
 
 # Extra primitives that are kiro-specific and OK to declare in kiro-family
 # adapter blocks without failing the "no extra primitives" check.
@@ -142,16 +140,18 @@ class AllPairsEnumeratedTests(unittest.TestCase):
         coexists with its v0.3 table) count once per adapter, matching the
         "primitive coverage" semantic.
 
-        RFC-0022: kiro-cli added (+5 standard + 1 kiro-ide-hook = +6).
-        Total: 5 (claude-code) + 5 (kiro) + 6 (kiro-cli) + 5 (copilot)
-               + 5 (codex) = 26. Class name preserved to avoid churn.
+        RFC-0022 T1: kiro-ide added (+5 standard + 1 kiro-ide-hook = +6),
+        kiro-cli carries kiro-ide-hook dropped (+6). Plus kiro-ide adds
+        hook-wiring dropped to its array_form, which is already counted.
+        Total: 5 (claude-code) + 5 (kiro) + 6 (kiro-ide) + 6 (kiro-cli)
+               + 5 (copilot) + 5 (codex) = 32. Class name preserved.
         """
         total = 0
         for adapter_block in self.contract["adapter"].values():
             array_form = {p["primitive"] for p in adapter_block.get("projection", [])}
             table_form = set(adapter_block.get("projections", {}).keys())
             total += len(array_form | table_form)
-        self.assertEqual(total, 26, f"expected 26 pairs total, got {total}")
+        self.assertEqual(total, 32, f"expected 32 pairs total, got {total}")
 
 
 class ModeEnumTests(unittest.TestCase):
@@ -328,9 +328,9 @@ class FrontmatterTableTests(unittest.TestCase):
     def test_kiro_frontmatter_mapping_present(self) -> None:
         mapping = self.contract.get("frontmatter-mapping", {})
         self.assertIn(
-            "kiro-agent-frontmatter-v0.9",
+            "kiro-ide-agent-frontmatter-v0.9",
             mapping,
-            "frontmatter-mapping.kiro-agent-frontmatter-v0.9 not found in contract",
+            "frontmatter-mapping.kiro-ide-agent-frontmatter-v0.9 not found in contract",
         )
 
     def test_kiro_frontmatter_mapping_validates_against_schema(self) -> None:
@@ -413,14 +413,15 @@ class ContractV05Tests(unittest.TestCase):
         self.schema = _load_schema()
 
     def test_contract_version_is_v05(self) -> None:
-        """tomllib.loads of adapter.toml returns contract.version == "0.8"
-        (bumped from "0.7" by docs/specs/dropped-primitives-coverage —
-        codex `agent` + `hook-wiring` move from `dropped` to first-class).
+        """tomllib.loads of adapter.toml returns contract.version == "0.9"
+        (bumped from "0.8" by RFC-0022 kiro-adapter-split T1: kiro-ide adapter
+        declared, kiro-ide-hook primitive activated, frontmatter mapping renamed).
+        Class name preserved to avoid churn.
         """
         self.assertEqual(
             self.contract["contract"]["version"],
-            "0.8",
-            "adapter.toml [contract] version must be '0.8' after dropped-primitives-coverage bump",
+            "0.9",
+            "adapter.toml [contract] version must be '0.9' after kiro-adapter-split T1",
         )
 
     def test_claude_code_install_routes_includes_apm(self) -> None:
@@ -437,7 +438,7 @@ class ContractV05Tests(unittest.TestCase):
         guard: the v0.4 → v0.5 bump must not silently extend the field's surface to
         those adapters; per-adapter optionality / default ['cli'] on read is unchanged).
         RFC-0022: kiro-ide and kiro-cli added to the checked set."""
-        for adapter_name in ("kiro", "kiro-cli", "copilot", "codex"):
+        for adapter_name in ("kiro", "kiro-ide", "kiro-cli", "copilot", "codex"):
             adapter_block = self.contract["adapter"].get(adapter_name, {})
             self.assertNotIn(
                 "install-routes",

--- a/packages/agentbundle/agentbundle/build/tests/test_contract_scope.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_contract_scope.py
@@ -44,8 +44,10 @@ class ContractVersionTests(unittest.TestCase):
     hook-wiring move from `dropped` to first-class projections)."""
 
     def test_contract_version_is_0_5(self) -> None:
+        # Class/method name preserved; exact version lives in test_contract.py.
+        # Assert >= 0.8 so v0.8 scope features survive future bumps.
         contract = _load_contract()
-        self.assertEqual(contract["contract"]["version"], "0.8")
+        self.assertGreaterEqual(contract["contract"]["version"], "0.8")
 
 
 class ClaudeCodeScopeBlockTests(unittest.TestCase):

--- a/packages/agentbundle/agentbundle/build/tests/test_contract_v07.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_contract_v07.py
@@ -65,11 +65,13 @@ class TestContractV07(unittest.TestCase):
         only widens codex's projection table (it does not regress the v0.7
         ``allowed-prefixes`` / scope-table contracts pinned in this module).
         """
-        self.assertEqual(self.contract["contract"]["version"], "0.8")
+        # Exact version check lives in test_contract.py; assert >= 0.8 (v0.7/v0.8
+        # features must survive future bumps — validated by invariant tests below).
+        self.assertGreaterEqual(self.contract["contract"]["version"], "0.8")
 
     def test_docs_contract_version_is_07(self) -> None:
-        """docs mirror also pinned at v0.8 (post dropped-primitives-coverage bump)."""
-        self.assertEqual(self.docs_contract["contract"]["version"], "0.8")
+        """docs mirror stays in sync (byte-identical to _data/ adapter.toml)."""
+        self.assertGreaterEqual(self.docs_contract["contract"]["version"], "0.8")
 
     def test_copilot_scope_table_shape(self) -> None:
         copilot_scope = self.contract["adapter"]["copilot"].get("scope")

--- a/packages/agentbundle/agentbundle/build/tests/test_contract_v08.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_contract_v08.py
@@ -63,10 +63,15 @@ class TestContractV08(unittest.TestCase):
         self.schema = json.loads(DATA_SCHEMA_PATH.read_text(encoding="utf-8"))
 
     def test_contract_version_is_08(self) -> None:
-        self.assertEqual(self.contract["contract"]["version"], "0.8")
+        # v0.8 features are present; exact version check lives in test_contract.py.
+        # The v0.8 features (codex-agent-toml, codex-agent-frontmatter-v0.8) must
+        # survive future bumps — verify via the codex-specific tests below.
+        version = self.contract["contract"]["version"]
+        self.assertGreaterEqual(version, "0.8", "contract version must be >= 0.8")
 
     def test_docs_contract_version_is_08(self) -> None:
-        self.assertEqual(self.docs_contract["contract"]["version"], "0.8")
+        version = self.docs_contract["contract"]["version"]
+        self.assertGreaterEqual(version, "0.8", "docs contract version must be >= 0.8")
 
     def test_codex_agent_projection(self) -> None:
         entry = _codex_projection(self.contract, "agent")

--- a/packages/agentbundle/agentbundle/build/tests/test_pack_schema_allowed_adapters.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_pack_schema_allowed_adapters.py
@@ -139,9 +139,9 @@ class TestValidateAllowedAdaptersCrossField(unittest.TestCase):
         self.assertIsNotNone(msg)
         self.assertIn("'copilot'", msg)
         self.assertIn("does not declare a user-scope root", msg)
-        # RFC-0012 bumped the message to track the current contract
-        # version; dropped-primitives-coverage bumped it to v0.8.
-        self.assertIn("v0.8 adapter contract", msg)
+        # RFC-0012 bumped the message to track the current contract version;
+        # kiro-adapter-split (RFC-0022) bumped it to v0.9.
+        self.assertIn("v0.9 adapter contract", msg)
 
     def test_unknown_adapter_refused(self) -> None:
         pack = _v06_pack(

--- a/packages/agentbundle/agentbundle/cli.py
+++ b/packages/agentbundle/agentbundle/cli.py
@@ -195,7 +195,7 @@ def _build_parser() -> argparse.ArgumentParser:
     # --- list-targets --- (--scope as read-only filter)
     sp = subparsers.add_parser(
         "list-targets",
-        help="List adapter targets the CLI supports (claude-code, kiro, copilot, codex).",
+        help="List adapter targets the CLI supports (claude-code, kiro-ide, kiro-cli, kiro (deprecated → kiro-ide), copilot, codex).",
     )
     sp.add_argument("--scope", choices=("repo", "user"))
     sp.set_defaults(func=_lazy("list_targets"))
@@ -293,7 +293,8 @@ def _build_parser() -> argparse.ArgumentParser:
     sp.add_argument(
         "--target",
         help=(
-            "Optional adapter target (claude-code, kiro, copilot, codex); "
+            "Optional adapter target (claude-code, kiro-ide, kiro-cli, "
+            "kiro (deprecated → kiro-ide), copilot, codex); "
             "underscore form also accepted (claude_code); default: all."
         ),
     )

--- a/packages/agentbundle/agentbundle/commands/install.py
+++ b/packages/agentbundle/agentbundle/commands/install.py
@@ -2108,7 +2108,7 @@ def _render_for_user_scope(
     """
     import tempfile
 
-    from agentbundle.build.adapters import claude_code, codex, kiro
+    from agentbundle.build.adapters import claude_code, codex, kiro, kiro_cli, kiro_ide
     from agentbundle.build.main import _read_bundled
     from agentbundle.render import _collect_tree
 
@@ -2127,6 +2127,10 @@ def _render_for_user_scope(
         out = Path(raw)
         if target_adapter == "kiro":
             kiro.project(pack_dir, contract, out)
+        elif target_adapter == "kiro-ide":
+            kiro_ide.project(pack_dir, contract, out)
+        elif target_adapter == "kiro-cli":
+            kiro_cli.project(pack_dir, contract, out)
         elif target_adapter == "codex":
             codex.project(pack_dir, contract, out)
         elif target_adapter == "claude-code":
@@ -2171,7 +2175,7 @@ def _render_for_repo_scope(
     """
     import tempfile
 
-    from agentbundle.build.adapters import claude_code, codex, copilot, kiro
+    from agentbundle.build.adapters import claude_code, codex, copilot, kiro, kiro_cli, kiro_ide
     from agentbundle.build.main import _read_bundled
     from agentbundle.render import _collect_tree
 
@@ -2190,6 +2194,10 @@ def _render_for_repo_scope(
         out = Path(raw)
         if target_adapter == "kiro":
             kiro.project(pack_dir, contract, out)
+        elif target_adapter == "kiro-ide":
+            kiro_ide.project(pack_dir, contract, out)
+        elif target_adapter == "kiro-cli":
+            kiro_cli.project(pack_dir, contract, out)
         elif target_adapter == "codex":
             codex.project(pack_dir, contract, out)
         elif target_adapter == "claude-code":
@@ -2293,6 +2301,8 @@ def _user_scope_adapter_probes() -> dict[str, "Callable[[Path], bool]"]:
     return {
         "claude-code": lambda home: (home / ".claude").exists(),
         "kiro":        lambda home: (home / ".kiro").exists(),
+        "kiro-ide":    lambda home: (home / ".kiro").exists(),
+        "kiro-cli":    lambda home: (home / ".kiro").exists(),
         "codex":       lambda home: (
             (home / ".codex").exists()
             or (home / ".agents" / "skills").exists()

--- a/packages/agentbundle/agentbundle/commands/validate.py
+++ b/packages/agentbundle/agentbundle/commands/validate.py
@@ -263,7 +263,7 @@ def run(args) -> int:
         ide_hook_refusal = check_kiro_ide_hook(
             pack_path=pack_path,
             pack_name=pack_name,
-            target_adapters=("kiro",),
+            target_adapters=("kiro", "kiro-ide"),  # "kiro" alias + canonical name
             ide_event_vocabulary=ide_event_vocab,
             ide_action_vocabulary=ide_action_vocab,
         )
@@ -434,7 +434,9 @@ def _kiro_ide_hook_vocabularies() -> tuple[list[str] | None, list[str] | None]:
         if not contract_path.exists():
             return None, None
     contract = load_contract(contract_path)
-    kiro = contract.get("adapter", {}).get("kiro", {})
+    adapters = contract.get("adapter", {})
+    # Prefer the kiro-ide block (v0.9+); fall back to kiro alias (pre-T1).
+    kiro = adapters.get("kiro-ide") or adapters.get("kiro") or {}
     projections = kiro.get("projections", {}) if isinstance(kiro, dict) else {}
     rule = projections.get("kiro-ide-hook", {}) if isinstance(projections, dict) else {}
 

--- a/packages/agentbundle/tests/unit/test_kiro_ide_hook_rail.py
+++ b/packages/agentbundle/tests/unit/test_kiro_ide_hook_rail.py
@@ -19,31 +19,27 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 
-# Pre-probe synthetic vocabulary — pinned by these tests only to
-# exercise the rail's membership-check shape, NOT to assert which
-# spellings are canonical. RFC-0005 § Unresolved Q11 explicitly
-# defers the canonical list to a captured IDE-UI-authored fixture;
-# T-CONTRACT reconciles to whatever Q11 captures and updates the
-# vocabulary entries in `adapter.toml`. These tests stay correct
-# regardless — they assert "any string outside this list refuses"
-# and "any string inside this list passes".
+# E3 vocabulary — closed by RFC-0022 via static analysis of
+# extension.js IDEListenableEvent enum (2026-06-01). Supersedes the
+# RFC-0005 best-guess list (fileSave/fileEdit/manualTrigger).
+# See RFC-0005 § Errata, E3 and probes.md Q11 Outcome.
 KIRO_EVENT_VOCAB = [
+    "fileEdited",
     "fileCreated",
-    "fileEdit",
-    "fileSave",
     "fileDeleted",
+    "userTriggered",
     "promptSubmit",
     "agentStop",
     "preToolUse",
     "postToolUse",
     "preTaskExecution",
     "postTaskExecution",
-    "manualTrigger",
+    "sessionStart",
 ]
 KIRO_ACTION_VOCAB = ["askAgent", "runCommand"]
 
 
-def _ask_agent_hook(*, name="Lint on save", when_type="fileSave",
+def _ask_agent_hook(*, name="Lint on save", when_type="fileEdited",
                     then_type="askAgent", prompt="Run ruff.",
                     version="1", drop: str | None = None) -> dict:
     """Build a valid askAgent .kiro.hook body; ``drop`` removes a top-level key."""
@@ -64,7 +60,7 @@ def _run_command_hook(command: str = "${hook-body:lint}") -> dict:
         "name": "Lint on save (runCommand)",
         "description": "Synthetic runCommand hook.",
         "version": "1",
-        "when": {"type": "fileSave", "patterns": ["**/*.py"]},
+        "when": {"type": "fileEdited", "patterns": ["**/*.py"]},
         "then": {"type": "runCommand", "command": command},
     }
 
@@ -276,6 +272,65 @@ class PlaceholderScanFencedToCommand(unittest.TestCase):
             body = _ask_agent_hook(prompt="The marker ${hook-body:unknown} is just text.")
             pack = _make_pack(Path(raw), hooks={"hook.kiro.hook": body})
             self.assertIsNone(_run_rail(pack))
+
+
+class E3VocabularyTests(unittest.TestCase):
+    """T2 (RFC-0022): E3 vocabulary replaces the RFC-0005 best-guess list.
+
+    Old terms (fileSave, fileEdit, manualTrigger) must be rejected;
+    E3 terms (fileEdited, sessionStart, etc.) must be accepted.
+    """
+
+    def test_old_vocabulary_rejected(self) -> None:
+        """fileSave is not in the E3 vocabulary — must be refused."""
+        with TemporaryDirectory() as raw:
+            pack = _make_pack(
+                Path(raw),
+                hooks={"hook.kiro.hook": _ask_agent_hook(when_type="fileSave")},
+            )
+            refusal = _run_rail(pack)
+            self.assertIsNotNone(refusal, "fileSave must be refused with E3 vocabulary")
+            self.assertIn("fileSave", refusal)
+            self.assertIn("ide-event-vocabulary", refusal)
+
+    def test_old_vocabulary_rejected_file_edit(self) -> None:
+        """fileEdit and manualTrigger are not in the E3 vocabulary."""
+        with TemporaryDirectory() as raw:
+            pack = _make_pack(
+                Path(raw),
+                hooks={"hook.kiro.hook": _ask_agent_hook(when_type="fileEdit")},
+            )
+            refusal = _run_rail(pack)
+            self.assertIsNotNone(refusal, "fileEdit must be refused with E3 vocabulary")
+            self.assertIn("fileEdit", refusal)
+
+        with TemporaryDirectory() as raw:
+            pack = _make_pack(
+                Path(raw),
+                hooks={"hook.kiro.hook": _ask_agent_hook(when_type="manualTrigger")},
+            )
+            refusal = _run_rail(pack)
+            self.assertIsNotNone(refusal, "manualTrigger must be refused with E3 vocabulary")
+            self.assertIn("manualTrigger", refusal)
+
+    def test_e3_vocabulary_accepted(self) -> None:
+        """fileEdited is in the E3 vocabulary — must pass."""
+        with TemporaryDirectory() as raw:
+            pack = _make_pack(
+                Path(raw),
+                hooks={"hook.kiro.hook": _ask_agent_hook(when_type="fileEdited")},
+            )
+            self.assertIsNone(_run_rail(pack), "fileEdited must pass with E3 vocabulary")
+
+    def test_e3_session_start_accepted(self) -> None:
+        """sessionStart is the last term in the E3 list — most likely to be
+        truncated in a copy-paste error; pin it explicitly."""
+        with TemporaryDirectory() as raw:
+            pack = _make_pack(
+                Path(raw),
+                hooks={"hook.kiro.hook": _ask_agent_hook(when_type="sessionStart")},
+            )
+            self.assertIsNone(_run_rail(pack), "sessionStart must pass with E3 vocabulary")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Implements Wave 1+2 of the `kiro-adapter-split` spec (`docs/specs/kiro-adapter-split/`), per RFC-0022 and ADR-0012. **T1 (contract v0.9 + kiro-ide proper `.md` projection) is intentionally deferred** — blocked on the Q6 human-probe gate (requires running the physical Kiro IDE; outcome must be recorded in `docs/specs/kiro-ide-hook/probes.md` before T1 can merge).

### Tasks shipped in this PR

- **T3** — `kiro-cli` adapter: `kiro_cli.py`, `[adapter.kiro-cli]` block, `kiro-cli-agent-frontmatter-v1.0` mapping (CLI short-name tool tokens: `read`, `grep`, `glob`, `write`, `shell`, `web_fetch`, `web_search`). `kiro-ide-hook = dropped`.
- **T4** — `kiro` deprecated alias: `kiro_ide.py` stub, `ADAPTERS["kiro"]` → `_kiro_alias_project` (emits `DeprecationWarning`). `[adapter.kiro]` TOML block annotated.
- **T2** — E3 vocabulary: `KIRO_EVENT_VOCAB` updated from RFC-0005 best-guess (`fileSave`/`fileEdit`/`manualTrigger`) to RFC-0022 E3 list. Four TDD tests confirm old terms rejected / E3 terms accepted.
- **T5** — `distribution-adapters/spec.md` footnote corrected; table rows updated.
- **T6** — `agent-spec-cli/spec.md` §v0.4 clarified ("contract activation deferred to RFC-0022").
- **T7** — `cli.py` help text updated to name all five adapters.
- **T9, T10** — Already done in the prior RFC-acceptance PR (#223); verified present.

### Previously undone pre-existing bug (bundled fix)

`kiro.py _iter_primitives` skipped `mode = "dropped"` in the **array** form but not the **table** form. Adding `kiro-ide-hook = dropped` to `kiro-cli`'s table-form projections exposed this: `_project_single` raised `KeyError: 'kiro-ide-hook'` when looking up the source path in `contract["primitive"]`. Fixed by applying the same dropped-skip logic to the table form.

### Adversarial-review fixes (second commit)

- **install.py** dispatch extended for `kiro-ide` and `kiro-cli` in both `_render_for_user_scope` and `_render_for_repo_scope` (without this, `--adapter kiro-cli` would crash at runtime despite being in `_shipped_adapters_choices()`).
- `_user_scope_adapter_probes` extended for `kiro-ide` and `kiro-cli` (both probe `~/.kiro/`).
- `__init__.py` typed `_kiro_alias_project`; removed unused `import logging` / `_LOG`.
- Comments added to `test_contract.py`, `test_adapter_kiro_alias.py`, and TOML hook-body entries.

## Deferred items

- **validate.py `_kiro_ide_hook_vocabularies()`** reads from `contract["adapter"]["kiro"]`; after T1 lands it must also check `"kiro-ide"`. Pre-T1 concern; update in T1/T8.
- **`distribution-adapters/spec.md` lines 814/816** refusal messages say `adapter 'kiro'`; will reference `kiro-ide` after T1. Out of T5's explicit scope.
- **T1, T8** — Blocked on Q6 probe (human gate). Run Q6 in the Kiro IDE, record outcome in `docs/specs/kiro-ide-hook/probes.md`, then T1 can land the contract v0.9 bump and proper `kiro_ide.py` `.md` projection. T8 consolidates the test suite after T1.

## Test plan

- [ ] `make build-check` exits 0 (passes locally before push)
- [ ] Full pytest suite green (`packages/agentbundle`)
- [ ] `test_adapter_kiro_cli.py`: JSON projection, CLI short-names, no IDE-only keys
- [ ] `test_adapter_kiro_alias.py`: alias dispatches to kiro-ide, deprecation warning emitted, "kiro" in shipped adapters
- [ ] `test_kiro_ide_hook_rail.py`: old vocabulary rejected, E3 vocabulary accepted
- [ ] `test_contract.py`: 5-adapter set, 26 pairs, kiro-cli no install-routes