### PR TITLE
docs(guides): skill-authoring standards guide + tier-policy remediation for converter skills

### DIFF
--- a/docs/guides/how-to/add-a-credentialed-skill.md
+++ b/docs/guides/how-to/add-a-credentialed-skill.md
@@ -271,3 +271,4 @@ Both lints exit 0 against the worked example; aim for the same.
 - ADR: [`docs/adr/0003-credential-broker-contract.md`](../../adr/0003-credential-broker-contract.md)
 - Reference consumer (runnable, shipped): [`packs/atlassian/.apm/skills/jira/`](../../../packs/atlassian/.apm/skills/jira/) — a live `auth: creds` credentialed CLI
 - Explanation: [`docs/guides/explanation/credentialed-skills.md`](../explanation/credentialed-skills.md)
+- Related how-to: [How to author a skill](author-a-skill.md) — the general skill-authoring standards (structure, cross-platform scripts, the three-tier dependency policy); the `auth: cli` broker is where credential and tool-presence concerns meet.

--- a/docs/guides/how-to/author-a-skill.md
+++ b/docs/guides/how-to/author-a-skill.md
@@ -1,0 +1,263 @@
+# How to author a skill
+
+This guide collects the standards every skill in this catalogue follows
+— the bundled packs and the skills you author in your own pack alike.
+Some standards are checked by lint (called out inline, with the linter
+as the authority); the rest are reviewer-enforced. It assumes you
+already know what a skill is and when to add one
+([`docs/CONVENTIONS.md`](../../CONVENTIONS.md) § Skills: you've done the
+same multi-step thing three times, and you're not adding one
+speculatively).
+
+For the credential dimension — a skill that calls an authenticated API
+or holds a token — read
+[How to add a credentialed skill](add-a-credentialed-skill.md)
+alongside this; that contract is separate and more specific.
+
+## Before you start
+
+You need a skill directory under `packs/<pack>/.apm/skills/<name>/` with
+a `SKILL.md`, and — if it does real work — a `scripts/` helper.
+
+## Frontmatter and description
+
+Keep frontmatter to the keys the [agentskills.io](https://agentskills.io)
+spec allows (`name`, `description`, `license`, `compatibility`,
+`metadata`, `allowed-tools`) and put any project-specific data under the
+`metadata:` escape hatch. The description is one sentence that names the
+*trigger* ("Use when …"), not the implementation.
+
+**The description must be a single-line scalar.** Folded/literal YAML
+blocks (`>`, `|`) and continuation lines (an indented next line) parse as
+valid YAML but break on some adapter targets — their downstream loaders
+fail on a multi-line description even when the YAML itself is clean. For
+the same reason, keep YAML structural characters out of an unquoted
+value: a bare `: ` mid-description, a leading `#`/`&`/`*`/`[`, or
+whitespace-then-`#` all change the parse. If you need any of those
+characters, wrap the whole value in double quotes. Keep it under 1024
+characters.
+
+Don't memorize the exact rules from this page — run the linter, which is
+the source of truth:
+
+```bash
+python3 tools/lint-skill-spec.py
+python3 tools/lint-agent-artifacts.py
+```
+
+They check the key whitelist, description syntax, `allowed-tools` shape,
+and `evals/`. (The CONVENTIONS rule applies: the linter does the style
+job better than prose can.)
+
+## Body structure
+
+Use the section order the shipped skills share, so a reader always knows
+where to look:
+
+- `# <Skill> title` + a 2–3 sentence intro stating what it does **and
+  what it doesn't**.
+- `## When to Use` — the trigger conditions.
+- `## Prerequisites` — tools, packages, sibling skills, credentials (see
+  the tier ladder below).
+- `## Instructions` / `## Procedure` — numbered steps with copy-paste
+  commands. The agent *invokes* the script; it is not the script.
+- `## Pitfalls` / `### Don't` — known failure modes and what not to do.
+- `## Verification` — how the agent confirms it worked.
+
+## Directory layout
+
+A skill is a directory with `SKILL.md` plus four optional subdirectories
+— and the linter (`tools/lint-skill-spec.py`) only blesses those four:
+
+- `scripts/` — helper code the skill invokes (`python scripts/foo.py`).
+  The skill body drives the script; it is not the script.
+- `references/` — detailed material the agent loads **on demand**, not
+  every time (schemas, per-branch strategies, long tables).
+- `assets/` — templates and fixtures the skill copies or fills in
+  (`assets/template.html`, `assets/state.json`).
+- `evals/` — evaluation fixtures in the canonical
+  `evals/evals.json` + `evals/files/<fixture>` layout.
+
+Two rules the linter enforces, worth getting right the first time:
+
+- **Keep files one level deep.** A reference to
+  `scripts/a/b/c.py` warns — flatten it. (`evals/` keeps its own
+  canonical nesting.)
+- **Reference your own files skill-relative, sibling skills by name.**
+  `scripts/foo.py` and `references/bar.md`, never
+  `.claude/skills/<name>/...` or `packs/<pack>/.apm/skills/<name>/...`
+  install-path prefixes; to point at another skill, name it
+  (`the jira skill`), don't path into it.
+
+Edit the **seed** under `packs/<pack>/.apm/skills/<name>/`, never the
+projected copy under `.claude/skills/`; after any edit run
+`make build-self` to regenerate the projection, then
+`python3 tools/lint-skill-spec.py`.
+
+## Progressive disclosure
+
+`SKILL.md` is the always-loaded entry point; everything in `references/`
+is pulled in only when the workflow reaches it. So keep `SKILL.md` lean
+— the spec recommends under 500 lines, the linter warns past 500 and
+errors past 1000 — and push depth into `references/` that the body links
+to at the moment of need. `file-to-markdown` is the model: its body
+routes to exactly one of five `references/strategy_*.md` files per run
+("Pick one strategy and load its reference file … Do not load any other
+strategy file unless you switch"), so the agent never carries four
+irrelevant strategies in context. Reach for a reference file whenever a
+section would otherwise bloat the body with detail only one branch
+needs.
+
+## Write scripts cross-platform
+
+Skills run under every adapter and on every OS, including Windows, where
+there's no guaranteed POSIX shell — PowerShell is the default and
+git-bash may not be present. So:
+
+- **New helper scripts are Python, not bash.** Invoke them as
+  `python scripts/<name>.py` from the skill body — portable everywhere.
+- **Detect tools with `shutil.which("<tool>")`, not `command -v`.**
+  `command -v` is a POSIX-shell builtin that doesn't exist in PowerShell
+  (`Get-Command` is the equivalent); a Python check resolves identically
+  on macOS, Linux, and Windows.
+- Prefer `pathlib`, `tempfile.gettempdir()`, and Python-level filtering
+  over `grep`/`sed`/`find` and hardcoded `/tmp`. Declare an OS
+  restriction only when the dependency is genuinely platform-bound.
+- **Always pass `encoding="utf-8"`** to `read_text`/`write_text`/`open`
+  for text. Windows defaults to CP1252 and silently corrupts non-ASCII
+  Markdown/JSON/TOML otherwise.
+- **`subprocess` uses list form, never `shell=True`,** and never shells
+  out to `which`/`grep`/`find`/`sed`/`awk`/`make`/`bash` — use the
+  Python equivalent.
+
+## Dependencies: the three-tier policy
+
+Any dependency outside the Python standard library — a CLI binary, a
+pip/npm package, or a sibling skill — falls under one of three tiers.
+**Tier 1 is mandatory and the default; Tier 2 is allowed but never the
+default; Tier 3 is banned.**
+
+**What counts as a dependency:** Python itself is the assumed runtime —
+skills invoke `python scripts/...`, so a stdlib-only script declares
+nothing. `pip`/`uv` ship with a Python install, so a pip-based Tier-2
+install is low-risk (the manager is almost always there). `npm`/Node is
+**not** a given — it's only present if the user installed Node — so an
+npm-based skill detects `npm` (and Node) before relying on it, and a
+Tier-2 npm install is gated on that detection. Prefer stdlib over a pip
+dependency, and a pip dependency over an npm one, when you have the
+choice.
+
+### Tier 1 — declare, detect, fail clean (mandatory, default)
+
+1. **Declare.** A `## Prerequisites` section names the tool, the minimum
+   version if one matters, and the exact install command or link.
+2. **Detect.** The first action of any workflow checks the dependency is
+   present, before any real work — a `--check` verb on your helper
+   script that uses `shutil.which("<tool>")` and exits `0` (present) /
+   `2` (absent). (`shutil.which` finds *binaries*; probe a library
+   package with an import / `require.resolve` instead — see the
+   variations below.) Where a version floor matters, also parse
+   `<tool> --version` and compare.
+3. **Fail clean.** On absence, stop and emit a precise remediation
+   string — the exact install command from `## Prerequisites`. Do not
+   improvise around the missing tool (no hand-rolled fallback, no
+   third-party web service).
+
+[`mermaid-renderer`](../../../packs/converters/.apm/skills/mermaid-renderer/)
+is the reference:
+
+````markdown
+## Prerequisites
+
+The renderer shells out to `@mermaid-js/mermaid-cli`. Install once:
+
+```bash
+npm install -g @mermaid-js/mermaid-cli
+```
+
+### Step 1 — Verify `mmdc` is available
+
+```bash
+python scripts/render_mermaid.py --check
+```
+
+- Exit code 0 → `mmdc` is on `PATH`, proceed.
+- Exit code 2 → not installed. Tell the user the install command above.
+  Don't try to install it for them.
+````
+
+### Tier 2 — opt-in, gated, idempotent install (allowed, not default)
+
+A skill may install a dependency for the user **only** when all of these
+hold:
+
+- the install is a **single, deterministic command**;
+- it needs **no sudo / root**;
+- it uses a package manager the user **demonstrably already has** —
+  `uv`, `npm`, `pipx`, or `brew` *if detected* (detect the manager
+  itself first; don't assume it).
+
+When you install, the pattern is always **detect → install →
+re-verify**, and you **pin the version** — never assume the install
+succeeded:
+
+```text
+1. detect:    shutil.which("foo")  → present? done, no-op.
+2. gate:      absent → ask the user; install only on explicit consent.
+3. install:   npm install -g foo@1.2.3      (pinned, no sudo)
+4. re-verify: shutil.which("foo")  → still absent? fail clean.
+```
+
+**Gated** means the user opts in: get explicit consent before installing
+into their environment; don't install as a silent side effect of the
+first run. **Idempotent** means re-running is safe — because you detect
+first, an already-present dependency is a no-op.
+
+### Tier 3 — banned
+
+Never:
+
+- **silently auto-install** anything (install without the user opting
+  in);
+- **assume sudo / root**, or run an install that needs it;
+- **`curl … | bash`** (or any pipe-to-shell installer) without explicit
+  consent;
+- **assume PATH within the same session** — re-verify after an install
+  rather than trusting that a just-installed binary is resolvable.
+
+### Variations on Tier 1 detection
+
+- **A pip/npm package, not a binary.** Probe presence with an import /
+  `require.resolve`, not `shutil.which` (which finds binaries, not
+  library packages); on absence, declare the install line and stop —
+  [`file-to-markdown`](../../../packs/converters/.apm/skills/file-to-markdown/)
+  is the detect-and-stop model. A skill that goes further and *installs*
+  on consent is Tier 2, not Tier 1
+  ([`markdown-to-html`](../../../packs/converters/.apm/skills/markdown-to-html/)).
+- **A sibling skill.** Detect by invoking that skill's own `check` verb
+  and reading its exit code; on failure, point the user at the sibling's
+  setup rather than reaching into its internals
+  ([`flow-metrics`](../../../packs/atlassian/.apm/skills/flow-metrics/),
+  in the atlassian pack → `jira: check`).
+- **A vendor CLI the user authenticated** (`gh`, `git`, `kubectl`).
+  Presence detection still applies; the credential dimension is the
+  `auth: cli` broker — see the credentialed-skill guide.
+
+## What's enforced vs. recommended
+
+Frontmatter and description rules are lint-enforced
+(`tools/lint-skill-spec.py`, `tools/lint-agent-artifacts.py`);
+credentialed-skill rules have their own lint. The body structure, the
+cross-platform rules, and the three-tier dependency policy are
+**reviewer-enforced conventions** — no gate checks them, so they live or
+die in review. Hold the line there.
+
+## See also
+
+- [How to add a credentialed skill](add-a-credentialed-skill.md) — the
+  separate contract for tokens, API auth, and the `auth: cli` broker.
+- [`mermaid-renderer`](../../../packs/converters/.apm/skills/mermaid-renderer/)
+  — the Tier-1 reference: `## Prerequisites` + a `shutil.which`
+  `--check` verb + an explicit "don't auto-install" rule.
+- [`docs/CONVENTIONS.md`](../../CONVENTIONS.md) § Skills — when to add a
+  skill at all (the three-times rule).

--- a/packs/converters/.apm/skills/file-to-markdown/SKILL.md
+++ b/packs/converters/.apm/skills/file-to-markdown/SKILL.md
@@ -14,9 +14,20 @@ A skill with two branches:
 
 ## Prerequisites
 
+The document branch needs Docling; both branches need Pillow:
+
 ```bash
 python -m pip install docling Pillow
 ```
+
+Before the document branch, confirm Docling is importable:
+
+```bash
+python -c "import docling"
+```
+
+Exit 0 → proceed. Non-zero → it's not installed; tell the user to run
+the `pip install` above and stop. Don't install it for them.
 
 First Docling run downloads ML models (~1–2 min). Subsequent runs are
 fast. Image-only flows need only Pillow.

--- a/packs/converters/.apm/skills/markdown-to-html/SKILL.md
+++ b/packs/converters/.apm/skills/markdown-to-html/SKILL.md
@@ -16,13 +16,26 @@ You are not the renderer. The script is. Invoke it and report the path.
 
 ### Step 1 — Verify dependencies
 
+The renderer needs Node.js and the `marked` + `highlight.js` packages
+(pinned in `package.json`). From the skill's own directory, check
+whether they're already installed:
+
 ```bash
-# From the skill's own directory — at the user-scope skills directory,
-# or the repo-scope skills directory.
-npm install   # installs marked + highlight.js per package.json
+node -e "require.resolve('marked'); require.resolve('highlight.js')"
 ```
 
-(One-time; subsequent runs are cached in `node_modules/`.)
+- Exit 0 → dependencies present; go to Step 2.
+- Non-zero → not installed yet. Confirm `npm` is available
+  (`npm --version`); if it isn't, tell the user to install Node.js and
+  stop. If it is, **ask the user before installing**, then run the
+  one-time install and re-verify — don't assume it succeeded:
+
+  ```bash
+  npm install   # installs the pinned marked + highlight.js
+  node -e "require.resolve('marked'); require.resolve('highlight.js')"
+  ```
+
+(The install is one-time; subsequent runs are cached in `node_modules/`.)
 
 > Note: if your installer drops this skill into a tracked directory, add the skill's `node_modules/` to your project's `.gitignore` to avoid committing the npm install artifacts.
 
@@ -82,7 +95,8 @@ relevant.
 ### Edge cases
 
 - **Missing dependencies**: `node scripts/render.js` exits 1 with an
-  install hint. Run `npm install` from the skill directory.
+  install hint. Follow Step 1 — install on consent, then re-verify;
+  don't install bare.
 - **No headings**: sidebar shows `(no sections)`. Output still works,
   the sidebar just stays empty.
 - **Custom theme requested by name not in the list**: the script exits

--- a/packs/converters/.apm/skills/markdown-to-html/package.json
+++ b/packs/converters/.apm/skills/markdown-to-html/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "highlight.js": "^11.11.1",
-    "marked": "^18.0.2"
+    "highlight.js": "11.11.1",
+    "marked": "18.0.2"
   }
 }

--- a/packs/converters/.apm/skills/msg-to-markdown/SKILL.md
+++ b/packs/converters/.apm/skills/msg-to-markdown/SKILL.md
@@ -7,23 +7,37 @@ description: Convert Outlook .msg email files to Markdown, preserving email head
 
 Convert Outlook `.msg` email files to clean, structured Markdown preserving headers, body, and attachment metadata.
 
+## Prerequisites
+
+The converter runs on Node.js and reads `.msg` files through an npm
+package — `@nicecode/msg-reader` (preferred) or `msgreader` as an
+alternative. `scripts/convert.js` uses whichever is installed. Install
+the preferred one once:
+
+```bash
+npm install @nicecode/msg-reader
+```
+
 ## Instructions
 
 You are a document conversion agent. When the user provides a `.msg` file path via `$ARGUMENTS`, convert it to Markdown that captures the full email structure.
 
 ### Step 1: Verify the environment
 
-Check if the required npm package is available. If not, install it:
+Confirm Node.js and a reader package are available. From the skill's own
+directory, check for either supported package (mirroring what
+`convert.js` resolves):
 
 ```bash
-npm list @nicecode/msg-reader || npm install @nicecode/msg-reader
+node -e "try{require.resolve('@nicecode/msg-reader')}catch{require.resolve('msgreader')}"
 ```
 
-If `@nicecode/msg-reader` fails to install, fall back to `msgreader`:
-
-```bash
-npm list msgreader || npm install msgreader
-```
+- Exit 0 → at least one reader is installed; proceed to Step 2.
+- Non-zero → neither is installed. Confirm `npm` is available
+  (`npm --version`); if npm is missing, tell the user to install
+  Node.js and stop. Otherwise tell the user to run the install command
+  from Prerequisites (or, **with their consent**, run it once and
+  re-verify). Don't install it silently.
 
 ### Step 2: Extract the email data
 


### PR DESCRIPTION
## What & why

Authors a **skill-authoring standards** guide and brings the catalogue's
non-compliant skills into line with it. The trigger was a recurring
question — "how should a skill handle a CLI/tool it assumes is installed
(e.g. playwright)?" — which had no documented answer. Rather than a
narrow prerequisites note, this collects the standards a skill author
needs in one place, mining what the linter / `CONVENTIONS.md` /
`AGENTS.local.md` already enforce plus a new dependency policy.

## What changed

**Guide** — new `docs/guides/how-to/author-a-skill.md`:
- frontmatter + the **single-line-description** portability rule (some
  adapter loaders fail on multi-line even when the YAML is valid)
- directory layout (`scripts` / `references` / `assets` / `evals`) and
  **progressive disclosure** (lean `SKILL.md`, on-demand `references/`)
- cross-platform scripting (`shutil.which` over `command -v`,
  Python-not-bash, explicit `encoding="utf-8"`, no `shell=True`)
- a normative **three-tier dependency policy**: Tier 1
  declare/detect/fail-clean (mandatory default), Tier 2 gated idempotent
  install (allowed, not default), Tier 3 banned (silent auto-install,
  assumed sudo, `curl|bash` without consent, in-session PATH assumptions)

It's **guidance, reviewer-enforced — not a lint gate** (the guide says
so). Repoints the reverse cross-link in `add-a-credentialed-skill.md`.

**Skill remediations** (the three install-performing converter skills):
- `msg-to-markdown` — was Tier 3 (silent `npm install` + auto-fallback);
  now declares the dependency and detects **either** supported reader
  package (mirroring `convert.js`'s runtime resolution), fails clean.
- `markdown-to-html` — was an ungated `npm install`; now Tier 2:
  detect → confirm npm → **ask consent** → install → re-verify.
- `file-to-markdown` — added a Docling import detection step.

## How verified

- `tools/lint-skill-spec.py`, `tools/lint-agent-artifacts.py`, and
  `make lint-packs` all pass (exit 0).
- `adversarial-reviewer` over two rounds: found a Blocker (msg-to-markdown
  prose forbade a fallback `convert.js` performs, and detected only the
  primary package) + 3 Concerns + 3 Nits — all fixed; reviewer verified
  the `node -e` detection exits correctly in all three install states.
- `security-reviewer` / `quality-engineer` not run — no new code, auth,
  secrets, or network surface (docs + skill prose); the Tier-3 rules are
  security-positive.

## Bundled fixes

- `markdown-to-html/package.json`: pin `marked` / `highlight.js` to exact
  `18.0.2` / `11.11.1` (the Tier-2 policy requires real pinning; caret
  ranges floated, so "pinned" was false).

## Follow-ups (not in this PR)

- If we later want these standards **enforced** rather than documented,
  the vehicle is an RFC → `CONVENTIONS.md` + a lint rule.
