### PR TITLE
fix(credentialed-cli): close token-CLI leak + AccessError / import-guard / Windows gaps across the 5 credentialed skills

### DIFF
--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/crawl_space.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/crawl_space.py
@@ -24,9 +24,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable
 
-import yaml
-from slugify import slugify
-
 # Bootstrap when invoked as ``python scripts/crawl_space.py`` so the
 # relative imports of sibling modules — including ``_client``'s
 # ``from .credentials_shim import …`` — resolve against the
@@ -39,7 +36,15 @@ if __package__ in (None, "") and __spec__ is None:
     sys.path.insert(0, str(_here.parent))
     __package__ = _here.name
 
+# Every third-party and sibling import goes inside this guard so a missing
+# dependency yields the banded exit-2 "run pip install" message instead of
+# a raw traceback. ``yaml`` / ``slugify`` (direct) and ``lxml`` /
+# ``markdownify`` (transitively, via ._convert) must be in here too — when
+# they sat above the guard a missing one bypassed the contract entirely.
 try:
+    import yaml  # noqa: E402
+    from slugify import slugify  # noqa: E402
+
     from ._client import (  # noqa: E402
         AuthError,
         ConfluenceClient,
@@ -48,6 +53,8 @@ try:
         Page,
         load_credentials,
     )
+    from ._convert import to_markdown  # noqa: E402
+    from ._links import LinkTargets  # noqa: E402
 except ModuleNotFoundError as _import_exc:  # noqa: E402
     # 1 = functional/internal (shim not projected); 2 = user must act (deps).
     if _import_exc.name and "credentials_shim" in _import_exc.name:
@@ -61,8 +68,6 @@ except ModuleNotFoundError as _import_exc:  # noqa: E402
         "python -m pip install -r requirements.txt\n"
     )
     raise SystemExit(2)
-from ._convert import to_markdown  # noqa: E402
-from ._links import LinkTargets  # noqa: E402
 
 log = logging.getLogger("confluence_crawler")
 
@@ -78,6 +83,33 @@ EXIT_ERROR = 1
 EXIT_USER_ACTION = 2
 SLUG_MAX_LEN = 80
 UNLIMITED_DEPTH = 9999
+
+# Token-shaped CLI flags are rejected before argparse runs — argparse would
+# otherwise echo the offending ``--flag VALUE`` verbatim in its
+# "unrecognized arguments" error, leaking the secret to stderr / the agent
+# transcript. The Confluence PAT (or Cloud API token used as a Basic-auth
+# password) is resolved only via env / keyring / dotfile. Mirrors the
+# sibling jira / jira-align idiom (exact-set match).
+# Superset of the CONVENTIONS § "The argv ban" canonical six
+# (--token, --api-token, --api-key, --bearer, --pat, --password) plus the
+# short -t and a Confluence-specific alias.
+TOKEN_CLI_FLAGS = frozenset({
+    "--token", "--api-token", "--api-key", "--bearer", "-t",
+    "--confluence-token", "--pat", "--password",
+})
+
+
+def _reject_token_on_cli(argv: list[str]) -> None:
+    """Confluence tokens / PATs are secret; refuse to accept them as CLI args."""
+    for arg in argv:
+        head = arg.split("=", 1)[0]
+        if head in TOKEN_CLI_FLAGS:
+            sys.stderr.write(
+                "error: API tokens must not be passed on the command line. "
+                "Run `credential-setup` skill to store CONFLUENCE_API_TOKEN "
+                "via env / keyring / dotfile.\n"
+            )
+            sys.exit(EXIT_ERROR)
 
 
 @dataclass
@@ -379,6 +411,7 @@ async def main_async(args: argparse.Namespace) -> int:
 
 
 def main() -> int:
+    _reject_token_on_cli(sys.argv[1:])
     args = parse_args()
     _setup_logging(args.verbose)
     # Top-level catch-all: no exception escapes as a traceback. `except

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/test_exit_codes.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/test_exit_codes.py
@@ -23,11 +23,22 @@ SRC = CLI.read_text(encoding="utf-8")
 
 
 def _run(*args: str) -> subprocess.CompletedProcess:
+    # Force UTF-8 in the child and on decode: the CLI writes non-ASCII
+    # (em-dashes in its messages) to stderr, and on Windows the default
+    # console / pipe codec is cp1252 — without this the child raises
+    # UnicodeEncodeError emitting its own guard messages and the parent
+    # mis-decodes, defeating the exit-code assertions below.
     return subprocess.run(
         [sys.executable, "-B", str(CLI), *args],
         capture_output=True,
         text=True,
-        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        encoding="utf-8",
+        env={
+            **os.environ,
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "PYTHONIOENCODING": "utf-8",
+            "PYTHONUTF8": "1",
+        },
     )
 
 
@@ -35,6 +46,37 @@ def _deps_installed() -> bool:
     # `--help` exits 0 only when every import resolves; any non-zero means the
     # env can't run the CLI (a missing third-party dep), so skip behavioral.
     return _run("--help").returncode == 0
+
+
+# CONVENTIONS § "The argv ban" canonical six — every credentialed CLI must
+# refuse these before argparse can echo the value. The guard runs before
+# parse_args, so --check below is an incidental carrier (never consulted).
+CANONICAL_BANNED_FLAGS = (
+    "--token", "--api-token", "--api-key", "--bearer", "--pat", "--password",
+)
+
+
+def test_token_on_cli_rejected_exits_1_without_leak() -> None:
+    secret = "SECRET-tok-abc123"  # noqa: S105 — test literal, not a real cred
+    # Exercised per-flag so a deny-set regression on any canonical flag
+    # fails here, not just on --token.
+    for flag in CANONICAL_BANNED_FLAGS:
+        proc = _run("--check", flag, secret)
+        assert proc.returncode == 1, f"{flag}: expected 1, got {proc.returncode}: {proc.stderr}"
+        assert secret not in proc.stdout and secret not in proc.stderr, f"{flag}: token leaked"
+        assert "must not be passed on the command line" in proc.stderr, \
+            f"{flag}: exit 1 did not come from the token-reject guard"
+
+
+def test_token_reject_wired_source() -> None:
+    # Unconditional source check: the behavioral test above is in _BEHAVIORAL
+    # and self-skips when deps aren't installed (the import guard exits 2
+    # before main()'s reject runs) — which is exactly the deps-less CI lint
+    # env. Guards the reject wiring and the canonical-six deny-set against
+    # silent drift, where CI would otherwise see nothing.
+    assert SRC.count("_reject_token_on_cli") >= 2, "reject helper not defined+called"
+    for flag in CANONICAL_BANNED_FLAGS:
+        assert f'"{flag}"' in SRC, f"canonical banned flag {flag} missing from deny-set"
 
 
 def test_help_exits_0() -> None:
@@ -64,7 +106,7 @@ def test_import_guard_present() -> None:
     assert "missing dependency" in SRC, "missing dependency guard"
 
 
-_BEHAVIORAL = {"test_help_exits_0"}
+_BEHAVIORAL = {"test_help_exits_0", "test_token_on_cli_rejected_exits_1_without_leak"}
 
 
 def main() -> int:

--- a/packs/atlassian/.apm/skills/confluence-publisher/scripts/publish_page.py
+++ b/packs/atlassian/.apm/skills/confluence-publisher/scripts/publish_page.py
@@ -39,6 +39,11 @@ if __package__ in (None, "") and __spec__ is None:
     sys.path.insert(0, str(_here.parent))
     __package__ = _here.name
 
+# Every sibling import that transitively pulls a third-party dependency goes
+# inside this guard so a missing dep yields the banded exit-2 "run pip
+# install" message instead of a raw traceback: ._render pulls markdown_it,
+# ._target pulls yaml. When they sat below the guard a missing one bypassed
+# the contract entirely.
 try:
     from ._client import (  # noqa: E402
         AuthError,
@@ -47,6 +52,18 @@ try:
         ConfluenceError,
         PageRef,
         load_credentials,
+    )
+    from ._render import (  # noqa: E402
+        ALLOWED_INPUT_FORMATS,
+        INPUT_MARKDOWN,
+        as_storage_xhtml,
+        extract_title_from_markdown,
+    )
+    from ._target import (  # noqa: E402
+        ResolvedTarget,
+        TargetResolutionError,
+        read_input,
+        resolve_target,
     )
 except ModuleNotFoundError as _import_exc:  # noqa: E402
     # 1 = functional/internal (shim not projected); 2 = user must act (deps).
@@ -61,18 +78,6 @@ except ModuleNotFoundError as _import_exc:  # noqa: E402
         "python -m pip install -r requirements.txt\n"
     )
     raise SystemExit(2)
-from ._render import (  # noqa: E402
-    ALLOWED_INPUT_FORMATS,
-    INPUT_MARKDOWN,
-    as_storage_xhtml,
-    extract_title_from_markdown,
-)
-from ._target import (  # noqa: E402
-    ResolvedTarget,
-    TargetResolutionError,
-    read_input,
-    resolve_target,
-)
 
 log = logging.getLogger("confluence_publisher")
 
@@ -86,6 +91,33 @@ EXIT_USER_ACTION = 2
 EXIT_ERROR = 1
 
 DEFAULT_VERSION_COMMENT = "Published by confluence-publisher"
+
+# Token-shaped CLI flags are rejected before argparse runs — argparse would
+# otherwise echo the offending ``--flag VALUE`` verbatim in its
+# "unrecognized arguments" error, leaking the secret to stderr / the agent
+# transcript. The Confluence PAT (or Cloud API token used as a Basic-auth
+# password) is resolved only via env / keyring / dotfile. Mirrors the
+# sibling jira / jira-align idiom (exact-set match).
+# Superset of the CONVENTIONS § "The argv ban" canonical six
+# (--token, --api-token, --api-key, --bearer, --pat, --password) plus the
+# short -t and a Confluence-specific alias.
+TOKEN_CLI_FLAGS = frozenset({
+    "--token", "--api-token", "--api-key", "--bearer", "-t",
+    "--confluence-token", "--pat", "--password",
+})
+
+
+def _reject_token_on_cli(argv: list[str]) -> None:
+    """Confluence tokens / PATs are secret; refuse to accept them as CLI args."""
+    for arg in argv:
+        head = arg.split("=", 1)[0]
+        if head in TOKEN_CLI_FLAGS:
+            sys.stderr.write(
+                "error: API tokens must not be passed on the command line. "
+                "Run `credential-setup` skill to store CONFLUENCE_API_TOKEN "
+                "via env / keyring / dotfile.\n"
+            )
+            sys.exit(EXIT_ERROR)
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -442,6 +474,10 @@ def _run_publish(argv: list[str] | None = None) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
+    # Guard runs before _run_publish's own parse, against the same argv
+    # source the parser will see (explicit argv, else sys.argv[1:]), so the
+    # reject and the parse can never diverge on what they inspect.
+    _reject_token_on_cli(sys.argv[1:] if argv is None else argv)
     # Top-level catch-all: no exception escapes as a traceback. `except
     # Exception` deliberately does NOT catch SystemExit / KeyboardInterrupt.
     try:

--- a/packs/atlassian/.apm/skills/confluence-publisher/scripts/test_exit_codes.py
+++ b/packs/atlassian/.apm/skills/confluence-publisher/scripts/test_exit_codes.py
@@ -23,17 +23,59 @@ SRC = CLI.read_text(encoding="utf-8")
 
 
 def _run(*args: str) -> subprocess.CompletedProcess:
+    # Force UTF-8 in the child and on decode: the CLI writes non-ASCII
+    # (em-dashes in its messages) to stderr, and on Windows the default
+    # console / pipe codec is cp1252 — without this the child raises
+    # UnicodeEncodeError emitting its own guard messages and the parent
+    # mis-decodes, defeating the exit-code assertions below.
     return subprocess.run(
         [sys.executable, "-B", str(CLI), *args],
         capture_output=True,
         text=True,
-        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        encoding="utf-8",
+        env={
+            **os.environ,
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "PYTHONIOENCODING": "utf-8",
+            "PYTHONUTF8": "1",
+        },
     )
 
 
 def _deps_installed() -> bool:
     proc = _run("--help")
     return not (proc.returncode == 2 and "missing dependency" in proc.stderr)
+
+
+# CONVENTIONS § "The argv ban" canonical six — every credentialed CLI must
+# refuse these before argparse can echo the value. The guard runs before
+# parse_args, so --check below is an incidental carrier (never consulted).
+CANONICAL_BANNED_FLAGS = (
+    "--token", "--api-token", "--api-key", "--bearer", "--pat", "--password",
+)
+
+
+def test_token_on_cli_rejected_exits_1_without_leak() -> None:
+    secret = "SECRET-tok-abc123"  # noqa: S105 — test literal, not a real cred
+    # Exercised per-flag so a deny-set regression on any canonical flag
+    # fails here, not just on --token.
+    for flag in CANONICAL_BANNED_FLAGS:
+        proc = _run("--check", flag, secret)
+        assert proc.returncode == 1, f"{flag}: expected 1, got {proc.returncode}: {proc.stderr}"
+        assert secret not in proc.stdout and secret not in proc.stderr, f"{flag}: token leaked"
+        assert "must not be passed on the command line" in proc.stderr, \
+            f"{flag}: exit 1 did not come from the token-reject guard"
+
+
+def test_token_reject_wired_source() -> None:
+    # Unconditional source check: the behavioral test above is in _BEHAVIORAL
+    # and self-skips when deps aren't installed (the import guard exits 2
+    # before main()'s reject runs) — which is exactly the deps-less CI lint
+    # env. Guards the reject wiring and the canonical-six deny-set against
+    # silent drift, where CI would otherwise see nothing.
+    assert SRC.count("_reject_token_on_cli") >= 2, "reject helper not defined+called"
+    for flag in CANONICAL_BANNED_FLAGS:
+        assert f'"{flag}"' in SRC, f"canonical banned flag {flag} missing from deny-set"
 
 
 def test_help_exits_0() -> None:
@@ -61,7 +103,7 @@ def test_import_guard_present() -> None:
     assert "missing dependency" in SRC, "missing dependency guard"
 
 
-_BEHAVIORAL = {"test_help_exits_0"}
+_BEHAVIORAL = {"test_help_exits_0", "test_token_on_cli_rejected_exits_1_without_leak"}
 
 
 def main() -> int:

--- a/packs/atlassian/.apm/skills/jira-align/scripts/jira_align.py
+++ b/packs/atlassian/.apm/skills/jira-align/scripts/jira_align.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 import argparse
 import asyncio
 import csv
-import io
 import json
 import logging
 import sys
@@ -74,9 +73,12 @@ EXIT_OK = 0
 EXIT_ERROR = 1
 EXIT_USER_ACTION = 2
 
+# Superset of the CONVENTIONS § "The argv ban" canonical six
+# (--token, --api-token, --api-key, --bearer, --pat, --password) plus the
+# short -t and Jira-Align-specific aliases.
 TOKEN_CLI_FLAGS = frozenset({
-    "--token", "--api-token", "--bearer", "-t",
-    "--jira-align-token", "--jiraalign-token",
+    "--token", "--api-token", "--api-key", "--bearer", "-t",
+    "--jira-align-token", "--jiraalign-token", "--pat", "--password",
 })
 
 

--- a/packs/atlassian/.apm/skills/jira-align/scripts/test_exit_codes.py
+++ b/packs/atlassian/.apm/skills/jira-align/scripts/test_exit_codes.py
@@ -24,11 +24,22 @@ SRC = CLI.read_text(encoding="utf-8")
 
 
 def _run(*args: str) -> subprocess.CompletedProcess:
+    # Force UTF-8 in the child and on decode: the CLI writes non-ASCII
+    # (em-dashes in its messages) to stderr, and on Windows the default
+    # console / pipe codec is cp1252 — without this the child raises
+    # UnicodeEncodeError emitting its own guard messages and the parent
+    # mis-decodes, defeating the exit-code assertions below.
     return subprocess.run(
         [sys.executable, "-B", str(CLI), *args],
         capture_output=True,
         text=True,
-        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        encoding="utf-8",
+        env={
+            **os.environ,
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "PYTHONIOENCODING": "utf-8",
+            "PYTHONUTF8": "1",
+        },
     )
 
 
@@ -37,11 +48,33 @@ def _deps_installed() -> bool:
     return not (proc.returncode == 2 and "missing dependency" in proc.stderr)
 
 
+# CONVENTIONS § "The argv ban" canonical six — every credentialed CLI must
+# refuse these before argparse can echo the value.
+CANONICAL_BANNED_FLAGS = (
+    "--token", "--api-token", "--api-key", "--bearer", "--pat", "--password",
+)
+
+
 def test_token_on_cli_rejected_exits_1_without_leak() -> None:
     secret = "SECRET-tok-abc123"  # noqa: S105 — test literal, not a real cred
-    proc = _run("check", "--token", secret)
-    assert proc.returncode == 1, f"expected 1, got {proc.returncode}: {proc.stderr}"
-    assert secret not in proc.stdout and secret not in proc.stderr, "token leaked"
+    # Exercised per-flag so a deny-set regression on any canonical flag
+    # fails here, not just on --token.
+    for flag in CANONICAL_BANNED_FLAGS:
+        proc = _run("check", flag, secret)
+        assert proc.returncode == 1, f"{flag}: expected 1, got {proc.returncode}: {proc.stderr}"
+        assert secret not in proc.stdout and secret not in proc.stderr, f"{flag}: token leaked"
+        assert "must not be passed on the command line" in proc.stderr, \
+            f"{flag}: exit 1 did not come from the token-reject guard"
+
+
+def test_token_reject_wired_source() -> None:
+    # Unconditional source check: the behavioral test above is in _BEHAVIORAL
+    # and self-skips when deps aren't installed (the import guard exits before
+    # main()'s reject runs) — i.e. the deps-less CI lint env. Guards the reject
+    # wiring and the canonical-six deny-set against silent drift.
+    assert SRC.count("_reject_token_on_cli") >= 2, "reject helper not defined+called"
+    for flag in CANONICAL_BANNED_FLAGS:
+        assert f'"{flag}"' in SRC, f"canonical banned flag {flag} missing from deny-set"
 
 
 def test_help_exits_0() -> None:

--- a/packs/atlassian/.apm/skills/jira/scripts/jira.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/jira.py
@@ -92,9 +92,12 @@ EXIT_OK = 0
 EXIT_ERROR = 1
 EXIT_USER_ACTION = 2
 
+# Superset of the CONVENTIONS § "The argv ban" canonical six
+# (--token, --api-token, --api-key, --bearer, --pat, --password) plus the
+# short -t and a Jira-specific alias.
 TOKEN_CLI_FLAGS = frozenset({
-    "--token", "--api-token", "--bearer", "-t",
-    "--jira-token", "--pat",
+    "--token", "--api-token", "--api-key", "--bearer", "-t",
+    "--jira-token", "--pat", "--password",
 })
 
 

--- a/packs/atlassian/.apm/skills/jira/scripts/test_exit_codes.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/test_exit_codes.py
@@ -29,11 +29,22 @@ SRC = CLI.read_text(encoding="utf-8")
 
 
 def _run(*args: str) -> subprocess.CompletedProcess:
+    # Force UTF-8 in the child and on decode: the CLI writes non-ASCII
+    # (em-dashes in its messages) to stderr, and on Windows the default
+    # console / pipe codec is cp1252 — without this the child raises
+    # UnicodeEncodeError emitting its own guard messages and the parent
+    # mis-decodes, defeating the exit-code assertions below.
     return subprocess.run(
         [sys.executable, "-B", str(CLI), *args],
         capture_output=True,
         text=True,
-        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        encoding="utf-8",
+        env={
+            **os.environ,
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "PYTHONIOENCODING": "utf-8",
+            "PYTHONUTF8": "1",
+        },
     )
 
 
@@ -45,12 +56,33 @@ def _deps_installed() -> bool:
 
 # --- behavioral (real file-path invocation; need deps installed) -----------
 
+# CONVENTIONS § "The argv ban" canonical six — every credentialed CLI must
+# refuse these before argparse can echo the value.
+CANONICAL_BANNED_FLAGS = (
+    "--token", "--api-token", "--api-key", "--bearer", "--pat", "--password",
+)
+
+
 def test_token_on_cli_rejected_exits_1_without_leak() -> None:
     secret = "SECRET-tok-abc123"  # noqa: S105 — test literal, not a real cred
-    proc = _run("check", "--token", secret)
-    assert proc.returncode == 1, f"expected 1, got {proc.returncode}: {proc.stderr}"
-    assert secret not in proc.stdout and secret not in proc.stderr, "token leaked"
-    assert "command line" in proc.stderr, "expected the argv-ban message"
+    # Exercised per-flag so a deny-set regression on any canonical flag
+    # fails here, not just on --token.
+    for flag in CANONICAL_BANNED_FLAGS:
+        proc = _run("check", flag, secret)
+        assert proc.returncode == 1, f"{flag}: expected 1, got {proc.returncode}: {proc.stderr}"
+        assert secret not in proc.stdout and secret not in proc.stderr, f"{flag}: token leaked"
+        assert "must not be passed on the command line" in proc.stderr, \
+            f"{flag}: exit 1 did not come from the token-reject guard"
+
+
+def test_token_reject_wired_source() -> None:
+    # Unconditional source check: the behavioral test above is in _BEHAVIORAL
+    # and self-skips when deps aren't installed (the import guard exits before
+    # main()'s reject runs) — i.e. the deps-less CI lint env. Guards the reject
+    # wiring and the canonical-six deny-set against silent drift.
+    assert SRC.count("_reject_token_on_cli") >= 2, "reject helper not defined+called"
+    for flag in CANONICAL_BANNED_FLAGS:
+        assert f'"{flag}"' in SRC, f"canonical banned flag {flag} missing from deny-set"
 
 
 def test_help_exits_0() -> None:

--- a/packs/figma/.apm/skills/figma/scripts/figma.py
+++ b/packs/figma/.apm/skills/figma/scripts/figma.py
@@ -866,6 +866,20 @@ def main(argv: list[str] | None = None) -> int:
     except AuthError as exc:
         sys.stderr.write(f"{exc}\n")
         return EXIT_USER_ACTION
+    except AccessError as exc:
+        # Scope/plan access (403, or a 404 the token can't see). Per the
+        # banded taxonomy this is user-must-act (2), not a functional
+        # error (1). Without this clause it falls through to
+        # `except FigmaError` below and mis-reports as exit 1 for every
+        # command except get-variables / list-dev-resources (which catch
+        # AccessError inline with endpoint-specific hints and return first).
+        sys.stderr.write(f"{exc}\n")
+        sys.stderr.write(
+            "the token lacks scope for this endpoint, or the resource "
+            "requires Enterprise / Dev Mode. Regenerate the PAT with the "
+            "required scope, or run `credential-setup`.\n"
+        )
+        return EXIT_USER_ACTION
     except FigmaError as exc:
         sys.stderr.write(f"figma error: {exc}\n")
         return EXIT_ERROR

--- a/packs/figma/.apm/skills/figma/scripts/test_exit_codes.py
+++ b/packs/figma/.apm/skills/figma/scripts/test_exit_codes.py
@@ -24,11 +24,22 @@ SRC = CLI.read_text(encoding="utf-8")
 
 
 def _run(*args: str) -> subprocess.CompletedProcess:
+    # Force UTF-8 in the child and on decode: the CLI writes non-ASCII
+    # (em-dashes in its messages) to stderr, and on Windows the default
+    # console / pipe codec is cp1252 — without this the child raises
+    # UnicodeEncodeError emitting its own guard messages and the parent
+    # mis-decodes, defeating the exit-code assertions below.
     return subprocess.run(
         [sys.executable, "-B", str(CLI), *args],
         capture_output=True,
         text=True,
-        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        encoding="utf-8",
+        env={
+            **os.environ,
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "PYTHONIOENCODING": "utf-8",
+            "PYTHONUTF8": "1",
+        },
     )
 
 
@@ -67,6 +78,25 @@ def test_catch_all_is_except_exception_not_baseexception() -> None:
 def test_import_guard_present() -> None:
     assert "credentials_shim sibling not projected" in SRC, "missing shim guard"
     assert "missing dependency" in SRC, "missing dependency guard"
+
+
+def test_access_error_mapped_to_user_action() -> None:
+    # A 403/scope error (AccessError) must map to user-action (2) on every
+    # command, not just get-variables / list-dev-resources. Asserted by
+    # source: triggering a real 403 needs a live server.
+    #
+    # figma.py has two *inline* `except AccessError` handlers (get-variables,
+    # list-dev-resources) plus the top-level catch-all this test pins. A bare
+    # `SRC.index("except AccessError")` would match an inline handler —
+    # always before `except FigmaError` — and stay green even if the
+    # top-level clause were deleted. Anchor on the top-level handler's unique
+    # hint text instead; its presence proves the clause exists, and the
+    # ordering proves it precedes its parent `except FigmaError`.
+    hint = "the token lacks scope for this endpoint"
+    assert hint in SRC, "top-level except AccessError handler missing"
+    assert SRC.index(hint) < SRC.index("except FigmaError as exc:"), (
+        "top-level AccessError handler must precede its parent except FigmaError"
+    )
 
 
 _BEHAVIORAL = {"test_token_on_cli_rejected_exits_1_without_leak", "test_help_exits_0"}


### PR DESCRIPTION
## What does this change?

Hardens the five credentialed-skill CLIs: closes a token-on-CLI leak in the two Confluence skills, fixes figma's 403 exit-code mapping, completes the Confluence import guards, brings jira/jira-align deny-sets up to the canonical banned-flag set, and makes all five exit-code smoke tests deterministic on Windows.

## Why?

No spec — this is a bug-fix batch correcting deviations from **already-shipped contracts** (`docs/specs/credentialed-cli-exit-code-contract` and `CONVENTIONS.md` § "The argv ban"). Each fix restores conformance rather than changing a contract, so no RFC/spec is warranted. Originated from five review questions; verdicts below.

| # | Finding | Resolution |
|---|---------|-----------|
| 1 | client import direct-vs-relative | **Not a bug** — relative `from ._client` is load-bearing (the bootstrap makes file-path invocation resolve the shim) and consistent across all five. No change. |
| 2 | figma `AccessError` paths | Top-level `except AccessError → exit 2` added before `except FigmaError`. A 403/scope error on any command now maps to user-action (2), not 1. |
| 3 | confluence-crawler import guard | Moved `yaml`/`slugify` + dep-pulling sibling imports inside the guard — **and the publisher** (`_render`→`markdown_it`, `_target`→`yaml`), same defect. Missing dep → exit 2, no traceback. |
| 4 | Windows smoke-test encoding | All 5 `test_exit_codes.py` force UTF-8 (`encoding="utf-8"` + `PYTHONIOENCODING`/`PYTHONUTF8`) so the child doesn't crash emitting em-dash messages on cp1252. |
| 5 | Confluence `--token` rejection | Added `_reject_token_on_cli` + canonical-six deny-set to both Confluence CLIs; **folded in** jira/jira-align which were short of the canonical six (jira: +`--api-key`/`--password`; jira-align: +`--api-key`/`--pat`/`--password`). Behavioral + source test guards added across all four. |

## How do I verify it?

- `make lint-packs` and `python3 tools/lint_credentialed_skills.py .` (+ its self-test) — clean.
- Each skill: `python3 packs/<…>/scripts/test_exit_codes.py` — green (source checks always; behavioral when deps installed).
- With deps installed: every canonical token flag (`--token`, `--api-token`, `--api-key`, `--bearer`, `--pat`, `--password`) → exit 1, secret never echoed; missing dep → exit 2 with no traceback. The figma AccessError fix is mutation-proven (delete the handler → the test fails).
- Reviewed by `adversarial-reviewer` (Blocker found + fixed, final pass clean), `security-reviewer` (clean), `quality-engineer` (concerns resolved).

## What did you not change that you considered?

- **figma-style `SECRET_LIKE_FLAG_RE` / scrubbing-parser backstop** for token-shaped flags *outside* the canonical six (e.g. `--apikey`, `--credential`) — beyond the CONVENTIONS bar; deferred as pack-wide hardening.
- **CLI-level Windows console hardening** (`sys.stdout/stderr.reconfigure`) so the CLIs themselves don't crash emitting non-ASCII on a cp1252 console — this PR fixes the smoke-test subprocess only; deferred.
- The relative `from ._client import` pattern — verified correct, left as-is.

**Bundled fixes:** dropped an unused `import io` in `jira_align.py` (pre-existing dead import in a file this PR already edits).

## Checklist

- [x] Tests pass locally (5 standalone `test_exit_codes.py`, both deps-less and with deps)
- [x] Lint passes (`make lint-packs`, `lint_credentialed_skills.py` + self-test, `ruff`); no typecheck step in this repo
- [x] Self-review run via `adversarial-reviewer` + `security-reviewer` + `quality-engineer`; blockers addressed
- [x] Code matches the shipped contracts (no spec change needed — conformance fix)
- [ ] Living docs — N/A: corrects CLIs to match their already-documented behavior ("PAT never on the command line"); no doc/changelog drift introduced
- [x] No new top-level directories
- [x] Conventional commit format
- [ ] Learnings captured — see PR note (deny-set canonical-six is not mechanically enforced on the reject path)