### PR TITLE
fix(credentialed-cli): reconfigure stdout/stderr to UTF-8 so the CLIs survive a legacy Windows console

### DIFF
--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/crawl_space.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/crawl_space.py
@@ -32,6 +32,19 @@ from typing import Iterable
 # invocation; an importlib-based test harness is responsible for
 # its own package context.
 if __package__ in (None, "") and __spec__ is None:
+    # Windows console hardening: this CLI writes UTF-8 payloads to stdout,
+    # and sys.stdout defaults to errors="strict" — so on a legacy Windows
+    # console (cp1252) a non-ASCII write raises UnicodeEncodeError. Force
+    # UTF-8 on stdout here, before any write. stderr defaults to
+    # backslashreplace (it mojibakes rather than crashing), but reconfigure
+    # it too for clean bytes; doing both before the import guard means even
+    # its messages emit correctly. Guarded: a replaced stream (StringIO under
+    # a test harness) or pythonw's None has no reconfigure().
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")
+        except (AttributeError, ValueError):
+            pass
     _here = Path(__file__).resolve().parent
     sys.path.insert(0, str(_here.parent))
     __package__ = _here.name

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/test_exit_codes.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/test_exit_codes.py
@@ -42,6 +42,24 @@ def _run(*args: str) -> subprocess.CompletedProcess:
     )
 
 
+def test_stdio_utf8_hardening_present() -> None:
+    # Windows console hardening: stdout/stderr are reconfigured to UTF-8 at
+    # the top of file-path invocation, so non-ASCII output (UTF-8 Markdown /
+    # JSON payloads on stdout — which is errors="strict" by default and
+    # *does* crash on a cp1252 console — plus em-dash messages) is safe. Must
+    # sit before the import guard so the guard's own messages are covered
+    # too. Source-asserted: a real non-UTF-8 Windows console isn't
+    # reproducible in a portable test (proven by A/B in the PR: --help
+    # crashed on `→` without this).
+    assert 'reconfigure(encoding="utf-8")' in SRC, \
+        "stdout/stderr UTF-8 hardening missing"
+    assert SRC.index('if __package__ in (None, "") and __spec__ is None:') \
+        < SRC.index('reconfigure(encoding="utf-8")'), \
+        "UTF-8 hardening must sit inside the file-path-invocation gate"
+    assert SRC.index('reconfigure(encoding="utf-8")') < SRC.index("missing dependency"), \
+        "UTF-8 hardening must run before the import guard"
+
+
 def _deps_installed() -> bool:
     # `--help` exits 0 only when every import resolves; any non-zero means the
     # env can't run the CLI (a missing third-party dep), so skip behavioral.

--- a/packs/atlassian/.apm/skills/confluence-publisher/scripts/publish_page.py
+++ b/packs/atlassian/.apm/skills/confluence-publisher/scripts/publish_page.py
@@ -35,6 +35,19 @@ from urllib.parse import urljoin
 # invocation; an importlib-based test harness is responsible for
 # its own package context.
 if __package__ in (None, "") and __spec__ is None:
+    # Windows console hardening: this CLI writes UTF-8 payloads to stdout,
+    # and sys.stdout defaults to errors="strict" — so on a legacy Windows
+    # console (cp1252) a non-ASCII write raises UnicodeEncodeError. Force
+    # UTF-8 on stdout here, before any write. stderr defaults to
+    # backslashreplace (it mojibakes rather than crashing), but reconfigure
+    # it too for clean bytes; doing both before the import guard means even
+    # its messages emit correctly. Guarded: a replaced stream (StringIO under
+    # a test harness) or pythonw's None has no reconfigure().
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")
+        except (AttributeError, ValueError):
+            pass
     _here = Path(__file__).resolve().parent
     sys.path.insert(0, str(_here.parent))
     __package__ = _here.name

--- a/packs/atlassian/.apm/skills/confluence-publisher/scripts/test_exit_codes.py
+++ b/packs/atlassian/.apm/skills/confluence-publisher/scripts/test_exit_codes.py
@@ -42,6 +42,24 @@ def _run(*args: str) -> subprocess.CompletedProcess:
     )
 
 
+def test_stdio_utf8_hardening_present() -> None:
+    # Windows console hardening: stdout/stderr are reconfigured to UTF-8 at
+    # the top of file-path invocation, so non-ASCII output (UTF-8 Markdown /
+    # XHTML payloads on stdout — which is errors="strict" by default and
+    # *does* crash on a cp1252 console — plus em-dash messages) is safe. Must
+    # sit before the import guard so the guard's own messages are covered
+    # too. Source-asserted: a real non-UTF-8 Windows console isn't
+    # reproducible in a portable test (proven by A/B in the PR: --help
+    # crashed on `→` without this).
+    assert 'reconfigure(encoding="utf-8")' in SRC, \
+        "stdout/stderr UTF-8 hardening missing"
+    assert SRC.index('if __package__ in (None, "") and __spec__ is None:') \
+        < SRC.index('reconfigure(encoding="utf-8")'), \
+        "UTF-8 hardening must sit inside the file-path-invocation gate"
+    assert SRC.index('reconfigure(encoding="utf-8")') < SRC.index("missing dependency"), \
+        "UTF-8 hardening must run before the import guard"
+
+
 def _deps_installed() -> bool:
     proc = _run("--help")
     return not (proc.returncode == 2 and "missing dependency" in proc.stderr)

--- a/packs/atlassian/.apm/skills/jira-align/scripts/jira_align.py
+++ b/packs/atlassian/.apm/skills/jira-align/scripts/jira_align.py
@@ -35,6 +35,19 @@ from typing import Any
 # invocation; an importlib-based test harness is responsible for
 # its own package context.
 if __package__ in (None, "") and __spec__ is None:
+    # Windows console hardening: this CLI writes UTF-8 payloads to stdout,
+    # and sys.stdout defaults to errors="strict" — so on a legacy Windows
+    # console (cp1252) a non-ASCII write raises UnicodeEncodeError. Force
+    # UTF-8 on stdout here, before any write. stderr defaults to
+    # backslashreplace (it mojibakes rather than crashing), but reconfigure
+    # it too for clean bytes; doing both before the import guard means even
+    # its messages emit correctly. Guarded: a replaced stream (StringIO under
+    # a test harness) or pythonw's None has no reconfigure().
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")
+        except (AttributeError, ValueError):
+            pass
     _here = Path(__file__).resolve().parent
     sys.path.insert(0, str(_here.parent))
     __package__ = _here.name

--- a/packs/atlassian/.apm/skills/jira-align/scripts/test_exit_codes.py
+++ b/packs/atlassian/.apm/skills/jira-align/scripts/test_exit_codes.py
@@ -43,6 +43,24 @@ def _run(*args: str) -> subprocess.CompletedProcess:
     )
 
 
+def test_stdio_utf8_hardening_present() -> None:
+    # Windows console hardening: stdout/stderr are reconfigured to UTF-8 at
+    # the top of file-path invocation, so non-ASCII output (UTF-8 JSON / CSV
+    # payloads on stdout — which is errors="strict" by default and *does*
+    # crash on a cp1252 console — plus em-dash messages) is safe. Must sit
+    # before the import guard so the guard's own messages are covered too.
+    # Source-asserted: a real non-UTF-8 Windows console isn't reproducible in
+    # a portable test (proven by A/B in the PR: --help crashed on `→`
+    # without this).
+    assert 'reconfigure(encoding="utf-8")' in SRC, \
+        "stdout/stderr UTF-8 hardening missing"
+    assert SRC.index('if __package__ in (None, "") and __spec__ is None:') \
+        < SRC.index('reconfigure(encoding="utf-8")'), \
+        "UTF-8 hardening must sit inside the file-path-invocation gate"
+    assert SRC.index('reconfigure(encoding="utf-8")') < SRC.index("missing dependency"), \
+        "UTF-8 hardening must run before the import guard"
+
+
 def _deps_installed() -> bool:
     proc = _run("--help")
     return not (proc.returncode == 2 and "missing dependency" in proc.stderr)

--- a/packs/atlassian/.apm/skills/jira/scripts/jira.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/jira.py
@@ -53,6 +53,19 @@ from typing import Any
 # invocation; an importlib-based test harness is responsible for
 # its own package context.
 if __package__ in (None, "") and __spec__ is None:
+    # Windows console hardening: this CLI writes UTF-8 payloads to stdout,
+    # and sys.stdout defaults to errors="strict" — so on a legacy Windows
+    # console (cp1252) a non-ASCII write raises UnicodeEncodeError. Force
+    # UTF-8 on stdout here, before any write. stderr defaults to
+    # backslashreplace (it mojibakes rather than crashing), but reconfigure
+    # it too for clean bytes; doing both before the import guard means even
+    # its messages emit correctly. Guarded: a replaced stream (StringIO under
+    # a test harness) or pythonw's None has no reconfigure().
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")
+        except (AttributeError, ValueError):
+            pass
     _here = Path(__file__).resolve().parent
     sys.path.insert(0, str(_here.parent))
     __package__ = _here.name

--- a/packs/atlassian/.apm/skills/jira/scripts/test_exit_codes.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/test_exit_codes.py
@@ -48,6 +48,24 @@ def _run(*args: str) -> subprocess.CompletedProcess:
     )
 
 
+def test_stdio_utf8_hardening_present() -> None:
+    # Windows console hardening: stdout/stderr are reconfigured to UTF-8 at
+    # the top of file-path invocation, so non-ASCII output (UTF-8 JSON / CSV
+    # payloads on stdout — which is errors="strict" by default and *does*
+    # crash on a cp1252 console — plus em-dash messages) is safe. Must sit
+    # before the import guard so the guard's own messages are covered too.
+    # Source-asserted: a real non-UTF-8 Windows console isn't reproducible in
+    # a portable test (proven by A/B in the PR: --help crashed on `→`
+    # without this).
+    assert 'reconfigure(encoding="utf-8")' in SRC, \
+        "stdout/stderr UTF-8 hardening missing"
+    assert SRC.index('if __package__ in (None, "") and __spec__ is None:') \
+        < SRC.index('reconfigure(encoding="utf-8")'), \
+        "UTF-8 hardening must sit inside the file-path-invocation gate"
+    assert SRC.index('reconfigure(encoding="utf-8")') < SRC.index("missing dependency"), \
+        "UTF-8 hardening must run before the import guard"
+
+
 def _deps_installed() -> bool:
     """False when the import guard fires (deps/shim absent) → skip behavioral."""
     proc = _run("--help")

--- a/packs/figma/.apm/skills/figma/scripts/figma.py
+++ b/packs/figma/.apm/skills/figma/scripts/figma.py
@@ -52,6 +52,19 @@ from typing import Any
 # invocation; an importlib-based test harness is responsible for
 # its own package context.
 if __package__ in (None, "") and __spec__ is None:
+    # Windows console hardening: this CLI writes UTF-8 payloads to stdout,
+    # and sys.stdout defaults to errors="strict" — so on a legacy Windows
+    # console (cp1252) a non-ASCII write raises UnicodeEncodeError. Force
+    # UTF-8 on stdout here, before any write. stderr defaults to
+    # backslashreplace (it mojibakes rather than crashing), but reconfigure
+    # it too for clean bytes; doing both before the import guard means even
+    # its messages emit correctly. Guarded: a replaced stream (StringIO under
+    # a test harness) or pythonw's None has no reconfigure().
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")
+        except (AttributeError, ValueError):
+            pass
     _here = Path(__file__).resolve().parent
     sys.path.insert(0, str(_here.parent))
     __package__ = _here.name

--- a/packs/figma/.apm/skills/figma/scripts/test_exit_codes.py
+++ b/packs/figma/.apm/skills/figma/scripts/test_exit_codes.py
@@ -43,6 +43,24 @@ def _run(*args: str) -> subprocess.CompletedProcess:
     )
 
 
+def test_stdio_utf8_hardening_present() -> None:
+    # Windows console hardening: stdout/stderr are reconfigured to UTF-8 at
+    # the top of file-path invocation, so non-ASCII output (UTF-8 JSON
+    # payloads on stdout — which is errors="strict" by default and *does*
+    # crash on a cp1252 console — plus em-dash messages) is safe. Must sit
+    # before the import guard so the guard's own messages are covered too.
+    # Source-asserted: a real non-UTF-8 Windows console isn't reproducible in
+    # a portable test (proven by A/B in the PR: --help crashed on `→`
+    # without this).
+    assert 'reconfigure(encoding="utf-8")' in SRC, \
+        "stdout/stderr UTF-8 hardening missing"
+    assert SRC.index('if __package__ in (None, "") and __spec__ is None:') \
+        < SRC.index('reconfigure(encoding="utf-8")'), \
+        "UTF-8 hardening must sit inside the file-path-invocation gate"
+    assert SRC.index('reconfigure(encoding="utf-8")') < SRC.index("missing dependency"), \
+        "UTF-8 hardening must run before the import guard"
+
+
 def _deps_installed() -> bool:
     proc = _run("--help")
     return not (proc.returncode == 2 and "missing dependency" in proc.stderr)


### PR DESCRIPTION
## What does this change?

Reconfigures `sys.stdout`/`sys.stderr` to UTF-8 inside each of the five credentialed CLIs' file-path-invocation bootstrap block, so the CLIs themselves don't crash emitting non-ASCII on a legacy Windows console. This is the deferred CLI-level half of the Windows fix from #230 (which hardened only the test subprocess env).

## Why?

No spec — direct follow-up to a deferred item noted in #230. `sys.stdout` defaults to `errors="strict"`, so a UTF-8 payload write (figma/jira JSON via `ensure_ascii=False`, crawler/publisher Markdown/XHTML, and the `→`/`…` in `--help` docstrings argparse prints to stdout) raises `UnicodeEncodeError` on a cp1252 console. (`sys.stderr` defaults to `backslashreplace`, so messages there only mojibake — reconfiguring it too is defense-in-depth for clean bytes.)

**Proven by A/B** (deps installed, `PYTHONIOENCODING=ascii`):
- BEFORE: `crawl_space.py --help` → `UnicodeEncodeError: 'ascii' codec can't encode character '→'` → exit 1.
- AFTER: clean exit 0.

The reconfigure sits inside the existing `if __package__ in (None, "") and __spec__ is None:` gate (so it only affects true CLI invocation, never an in-process import) and runs before the import guard (so even guard messages emit cleanly). Guarded with `try/except (AttributeError, ValueError)` so a replaced stream (test `StringIO`) or `pythonw`'s `None` is a no-op.

## How do I verify it?

- `make lint-packs`, `python3 tools/lint_credentialed_skills.py .`, `ruff` — clean.
- Each skill: `python3 packs/<…>/scripts/test_exit_codes.py` — green (6 checks deps-less, 8 with deps). New `test_stdio_utf8_hardening_present` pins the reconfigure inside the invocation gate and before the import guard.
- A/B above reproduces the crash/no-crash on any machine via `PYTHONIOENCODING=ascii`.
- Reviewed by `adversarial-reviewer` (1 Concern + 1 Nit, both fixed: the gate-membership assertion and the stderr-rationale wording).

## What did you not change that you considered?

- A behavioral hostile-console test — discarded: in deps-less CI `--help` hits the import guard on stderr (backslashreplace, never crashes) so it wouldn't discriminate, and figma/jira `--help` is ASCII. The source assertion + the A/B proof are the honest coverage (same pattern as the existing source-asserted figma AccessError test).
- De-em-dashing the messages — wrong layer; fixing the stream is correct and keeps the messages readable on UTF-8 terminals.
- `security-reviewer` — not warranted: the diff changes only output stream *encoding*, no auth/secret/input-validation logic.

## Checklist

- [x] Tests pass locally (5 standalone `test_exit_codes.py`, deps-less and with deps)
- [x] Lint passes (`make lint-packs`, `lint_credentialed_skills.py` + self-test, `ruff`); no typecheck step in this repo
- [x] Self-review via `adversarial-reviewer`; Concern + Nit addressed
- [x] Code matches the shipped contracts (no spec change — pure hardening)
- [ ] Living docs — N/A: no user-visible behavior change beyond not-crashing on a hostile console
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured (stderr=backslashreplace vs stdout=strict; the real crash is stdout payloads)