### PR TITLE
fix(credentialed-cli): scrubbing-parser backstop for out-of-set token flags + lint enforcement

### DIFF
--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/crawl_space.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/crawl_space.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+import re
 import sys
 from collections import deque
 from dataclasses import dataclass, field
@@ -145,8 +146,52 @@ class CrawlPlan:
     to_fetch: set[str] = field(default_factory=set)
 
 
+class _ScrubbingArgumentParser(argparse.ArgumentParser):
+    """ArgumentParser that scrubs token-shaped values from error messages.
+
+    argparse's stock ``error()`` echoes the offending argv tokens verbatim —
+    including the value half of an unrecognised ``--flag VALUE``. A token
+    passed under a flag the deny-list doesn't enumerate (``--credential
+    SECRET``, ``--apikey SECRET``) would otherwise leak ``SECRET`` to stderr
+    / the agent transcript. This subclass redacts any argv token of length
+    >= 20 on a likely-credential character set before chaining to the stock
+    error handler.
+    """
+
+    # Credential-shaped token: >= 20 chars on a base64 / base64url / JWT /
+    # percent-encoded charset. `.` and `~` are included so dotted bearer /
+    # JWT tokens (header.payload.signature) match — without `.` the anchored
+    # regex fails on the separators and the value would leak. The >= 20 floor
+    # is deliberate (modern PATs/tokens exceed it); a shorter value under an
+    # out-of-set flag is not redacted.
+    _CREDENTIAL_LOOKING_RE = re.compile(r"^[A-Za-z0-9_/+=%.~-]{20,}$")
+    _STRIP_CHARS = "'\"`(),;:."
+
+    def error(self, message: str) -> None:  # type: ignore[override]
+        def _check(value: str) -> bool:
+            core = value.strip(self._STRIP_CHARS)
+            return bool(self._CREDENTIAL_LOOKING_RE.match(core))
+
+        def _scrub(match: re.Match[str]) -> str:
+            tok = match.group(0)
+            if tok.startswith("-"):
+                # Glued ``--flag=VALUE`` — check the RHS of the first ``=``
+                # for credential shape and replace only that half.
+                if "=" in tok:
+                    flag, _, value = tok.partition("=")
+                    if _check(value):
+                        return f"{flag}=<scrubbed>"
+                return tok
+            if _check(tok):
+                return "<scrubbed>"
+            return tok
+
+        scrubbed = re.sub(r"\S+", _scrub, message)
+        super().error(scrubbed)
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser = _ScrubbingArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--space", help="Confluence space key (e.g., ENG)")
     parser.add_argument("--root", help="Page ID to start from (default: space homepage)")
     parser.add_argument("--depth", type=int, default=UNLIMITED_DEPTH, help="Max hierarchy depth (default: unlimited)")

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/test_exit_codes.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/test_exit_codes.py
@@ -97,6 +97,18 @@ def test_token_reject_wired_source() -> None:
         assert f'"{flag}"' in SRC, f"canonical banned flag {flag} missing from deny-set"
 
 
+def test_outofset_token_flag_value_scrubbed() -> None:
+    # A token under a flag OUTSIDE the deny-set must not have its value
+    # echoed by argparse's error(); the scrubbing parser redacts it. The
+    # dotted JWT-shaped value also guards the regex charset (must include
+    # `.`), per the security review.
+    secret = "eyJhbGciOi." + "A" * 30 + ".Sig1234567890ABCDEF"  # noqa: S105 — JWT-shaped test literal
+    proc = _run("--bogus-flag", secret)
+    assert secret not in proc.stdout and secret not in proc.stderr, \
+        "out-of-set token value leaked"
+    assert "<scrubbed>" in proc.stderr, "value not scrubbed by the parser"
+
+
 def test_help_exits_0() -> None:
     proc = _run("--help")
     assert proc.returncode == 0, f"--help should exit 0, got {proc.returncode}"
@@ -124,7 +136,11 @@ def test_import_guard_present() -> None:
     assert "missing dependency" in SRC, "missing dependency guard"
 
 
-_BEHAVIORAL = {"test_help_exits_0", "test_token_on_cli_rejected_exits_1_without_leak"}
+_BEHAVIORAL = {
+    "test_help_exits_0",
+    "test_token_on_cli_rejected_exits_1_without_leak",
+    "test_outofset_token_flag_value_scrubbed",
+}
 
 
 def main() -> int:

--- a/packs/atlassian/.apm/skills/confluence-publisher/scripts/publish_page.py
+++ b/packs/atlassian/.apm/skills/confluence-publisher/scripts/publish_page.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import re
 import sys
 from pathlib import Path
 from urllib.parse import urljoin
@@ -133,8 +134,52 @@ def _reject_token_on_cli(argv: list[str]) -> None:
             sys.exit(EXIT_ERROR)
 
 
+class _ScrubbingArgumentParser(argparse.ArgumentParser):
+    """ArgumentParser that scrubs token-shaped values from error messages.
+
+    argparse's stock ``error()`` echoes the offending argv tokens verbatim —
+    including the value half of an unrecognised ``--flag VALUE``. A token
+    passed under a flag the deny-list doesn't enumerate (``--credential
+    SECRET``, ``--apikey SECRET``) would otherwise leak ``SECRET`` to stderr
+    / the agent transcript. This subclass redacts any argv token of length
+    >= 20 on a likely-credential character set before chaining to the stock
+    error handler.
+    """
+
+    # Credential-shaped token: >= 20 chars on a base64 / base64url / JWT /
+    # percent-encoded charset. `.` and `~` are included so dotted bearer /
+    # JWT tokens (header.payload.signature) match — without `.` the anchored
+    # regex fails on the separators and the value would leak. The >= 20 floor
+    # is deliberate (modern PATs/tokens exceed it); a shorter value under an
+    # out-of-set flag is not redacted.
+    _CREDENTIAL_LOOKING_RE = re.compile(r"^[A-Za-z0-9_/+=%.~-]{20,}$")
+    _STRIP_CHARS = "'\"`(),;:."
+
+    def error(self, message: str) -> None:  # type: ignore[override]
+        def _check(value: str) -> bool:
+            core = value.strip(self._STRIP_CHARS)
+            return bool(self._CREDENTIAL_LOOKING_RE.match(core))
+
+        def _scrub(match: re.Match[str]) -> str:
+            tok = match.group(0)
+            if tok.startswith("-"):
+                # Glued ``--flag=VALUE`` — check the RHS of the first ``=``
+                # for credential shape and replace only that half.
+                if "=" in tok:
+                    flag, _, value = tok.partition("=")
+                    if _check(value):
+                        return f"{flag}=<scrubbed>"
+                return tok
+            if _check(tok):
+                return "<scrubbed>"
+            return tok
+
+        scrubbed = re.sub(r"\S+", _scrub, message)
+        super().error(scrubbed)
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
+    parser = _ScrubbingArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/packs/atlassian/.apm/skills/confluence-publisher/scripts/test_exit_codes.py
+++ b/packs/atlassian/.apm/skills/confluence-publisher/scripts/test_exit_codes.py
@@ -96,6 +96,18 @@ def test_token_reject_wired_source() -> None:
         assert f'"{flag}"' in SRC, f"canonical banned flag {flag} missing from deny-set"
 
 
+def test_outofset_token_flag_value_scrubbed() -> None:
+    # A token under a flag OUTSIDE the deny-set must not have its value
+    # echoed by argparse's error(); the scrubbing parser redacts it. The
+    # dotted JWT-shaped value also guards the regex charset (must include
+    # `.`), per the security review.
+    secret = "eyJhbGciOi." + "A" * 30 + ".Sig1234567890ABCDEF"  # noqa: S105 — JWT-shaped test literal
+    proc = _run("--bogus-flag", secret)
+    assert secret not in proc.stdout and secret not in proc.stderr, \
+        "out-of-set token value leaked"
+    assert "<scrubbed>" in proc.stderr, "value not scrubbed by the parser"
+
+
 def test_help_exits_0() -> None:
     proc = _run("--help")
     assert proc.returncode == 0, f"--help should exit 0, got {proc.returncode}"
@@ -121,7 +133,11 @@ def test_import_guard_present() -> None:
     assert "missing dependency" in SRC, "missing dependency guard"
 
 
-_BEHAVIORAL = {"test_help_exits_0", "test_token_on_cli_rejected_exits_1_without_leak"}
+_BEHAVIORAL = {
+    "test_help_exits_0",
+    "test_token_on_cli_rejected_exits_1_without_leak",
+    "test_outofset_token_flag_value_scrubbed",
+}
 
 
 def main() -> int:

--- a/packs/atlassian/.apm/skills/jira-align/scripts/jira_align.py
+++ b/packs/atlassian/.apm/skills/jira-align/scripts/jira_align.py
@@ -23,6 +23,7 @@ import asyncio
 import csv
 import json
 import logging
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -108,8 +109,52 @@ def _reject_token_on_cli(argv: list[str]) -> None:
             sys.exit(EXIT_ERROR)
 
 
+class _ScrubbingArgumentParser(argparse.ArgumentParser):
+    """ArgumentParser that scrubs token-shaped values from error messages.
+
+    argparse's stock ``error()`` echoes the offending argv tokens verbatim —
+    including the value half of an unrecognised ``--flag VALUE``. A token
+    passed under a flag the deny-list doesn't enumerate (``--credential
+    SECRET``, ``--apikey SECRET``) would otherwise leak ``SECRET`` to stderr
+    / the agent transcript. This subclass redacts any argv token of length
+    >= 20 on a likely-credential character set before chaining to the stock
+    error handler.
+    """
+
+    # Credential-shaped token: >= 20 chars on a base64 / base64url / JWT /
+    # percent-encoded charset. `.` and `~` are included so dotted bearer /
+    # JWT tokens (header.payload.signature) match — without `.` the anchored
+    # regex fails on the separators and the value would leak. The >= 20 floor
+    # is deliberate (modern PATs/tokens exceed it); a shorter value under an
+    # out-of-set flag is not redacted.
+    _CREDENTIAL_LOOKING_RE = re.compile(r"^[A-Za-z0-9_/+=%.~-]{20,}$")
+    _STRIP_CHARS = "'\"`(),;:."
+
+    def error(self, message: str) -> None:  # type: ignore[override]
+        def _check(value: str) -> bool:
+            core = value.strip(self._STRIP_CHARS)
+            return bool(self._CREDENTIAL_LOOKING_RE.match(core))
+
+        def _scrub(match: re.Match[str]) -> str:
+            tok = match.group(0)
+            if tok.startswith("-"):
+                # Glued ``--flag=VALUE`` — check the RHS of the first ``=``
+                # for credential shape and replace only that half.
+                if "=" in tok:
+                    flag, _, value = tok.partition("=")
+                    if _check(value):
+                        return f"{flag}=<scrubbed>"
+                return tok
+            if _check(tok):
+                return "<scrubbed>"
+            return tok
+
+        scrubbed = re.sub(r"\S+", _scrub, message)
+        super().error(scrubbed)
+
+
 def _build_parser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser(
+    p = _ScrubbingArgumentParser(
         prog="jira_align.py",
         description="Query Jira Align REST API 2.0 (cloud or on-prem).",
     )
@@ -132,7 +177,9 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Write output to this file instead of stdout.",
     )
 
-    sub = p.add_subparsers(dest="command", required=True)
+    sub = p.add_subparsers(
+        dest="command", required=True, parser_class=_ScrubbingArgumentParser,
+    )
 
     sub.add_parser("check", help="Verify credentials and reachability.")
     sub.add_parser("whoami", help="Show the authenticated user record.")

--- a/packs/atlassian/.apm/skills/jira-align/scripts/test_exit_codes.py
+++ b/packs/atlassian/.apm/skills/jira-align/scripts/test_exit_codes.py
@@ -95,6 +95,18 @@ def test_token_reject_wired_source() -> None:
         assert f'"{flag}"' in SRC, f"canonical banned flag {flag} missing from deny-set"
 
 
+def test_outofset_token_flag_value_scrubbed() -> None:
+    # A token under a flag OUTSIDE the deny-set must not have its value
+    # echoed by argparse's error(); the scrubbing parser redacts it. The
+    # dotted JWT-shaped value also guards the regex charset (must include
+    # `.`), per the security review.
+    secret = "eyJhbGciOi." + "A" * 30 + ".Sig1234567890ABCDEF"  # noqa: S105 — JWT-shaped test literal
+    proc = _run("check", "--bogus-flag", secret)
+    assert secret not in proc.stdout and secret not in proc.stderr, \
+        "out-of-set token value leaked"
+    assert "<scrubbed>" in proc.stderr, "value not scrubbed by the parser"
+
+
 def test_help_exits_0() -> None:
     proc = _run("--help")
     assert proc.returncode == 0, f"--help should exit 0, got {proc.returncode}"
@@ -120,7 +132,11 @@ def test_import_guard_present() -> None:
     assert "missing dependency" in SRC, "missing dependency guard"
 
 
-_BEHAVIORAL = {"test_token_on_cli_rejected_exits_1_without_leak", "test_help_exits_0"}
+_BEHAVIORAL = {
+    "test_token_on_cli_rejected_exits_1_without_leak",
+    "test_outofset_token_flag_value_scrubbed",
+    "test_help_exits_0",
+}
 
 
 def main() -> int:

--- a/packs/atlassian/.apm/skills/jira/scripts/jira.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/jira.py
@@ -41,6 +41,7 @@ import asyncio
 import csv
 import json
 import logging
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -127,8 +128,52 @@ def _reject_token_on_cli(argv: list[str]) -> None:
             sys.exit(EXIT_ERROR)
 
 
+class _ScrubbingArgumentParser(argparse.ArgumentParser):
+    """ArgumentParser that scrubs token-shaped values from error messages.
+
+    argparse's stock ``error()`` echoes the offending argv tokens verbatim —
+    including the value half of an unrecognised ``--flag VALUE``. A token
+    passed under a flag the deny-list doesn't enumerate (``--credential
+    SECRET``, ``--apikey SECRET``) would otherwise leak ``SECRET`` to stderr
+    / the agent transcript. This subclass redacts any argv token of length
+    >= 20 on a likely-credential character set before chaining to the stock
+    error handler.
+    """
+
+    # Credential-shaped token: >= 20 chars on a base64 / base64url / JWT /
+    # percent-encoded charset. `.` and `~` are included so dotted bearer /
+    # JWT tokens (header.payload.signature) match — without `.` the anchored
+    # regex fails on the separators and the value would leak. The >= 20 floor
+    # is deliberate (modern PATs/tokens exceed it); a shorter value under an
+    # out-of-set flag is not redacted.
+    _CREDENTIAL_LOOKING_RE = re.compile(r"^[A-Za-z0-9_/+=%.~-]{20,}$")
+    _STRIP_CHARS = "'\"`(),;:."
+
+    def error(self, message: str) -> None:  # type: ignore[override]
+        def _check(value: str) -> bool:
+            core = value.strip(self._STRIP_CHARS)
+            return bool(self._CREDENTIAL_LOOKING_RE.match(core))
+
+        def _scrub(match: re.Match[str]) -> str:
+            tok = match.group(0)
+            if tok.startswith("-"):
+                # Glued ``--flag=VALUE`` — check the RHS of the first ``=``
+                # for credential shape and replace only that half.
+                if "=" in tok:
+                    flag, _, value = tok.partition("=")
+                    if _check(value):
+                        return f"{flag}=<scrubbed>"
+                return tok
+            if _check(tok):
+                return "<scrubbed>"
+            return tok
+
+        scrubbed = re.sub(r"\S+", _scrub, message)
+        super().error(scrubbed)
+
+
 def _build_parser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser(
+    p = _ScrubbingArgumentParser(
         prog="jira.py",
         description="Query the Jira REST API (Cloud v3 or Server/DC v2).",
     )
@@ -151,7 +196,9 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Write output to this file instead of stdout.",
     )
 
-    sub = p.add_subparsers(dest="command", required=True)
+    sub = p.add_subparsers(
+        dest="command", required=True, parser_class=_ScrubbingArgumentParser,
+    )
 
     sub.add_parser("check", help="Verify credentials and reachability.")
     sub.add_parser("whoami", help="Show the authenticated user record.")

--- a/packs/atlassian/.apm/skills/jira/scripts/test_exit_codes.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/test_exit_codes.py
@@ -103,6 +103,18 @@ def test_token_reject_wired_source() -> None:
         assert f'"{flag}"' in SRC, f"canonical banned flag {flag} missing from deny-set"
 
 
+def test_outofset_token_flag_value_scrubbed() -> None:
+    # A token under a flag OUTSIDE the deny-set must not have its value
+    # echoed by argparse's error(); the scrubbing parser redacts it. The
+    # dotted JWT-shaped value also guards the regex charset (must include
+    # `.`), per the security review.
+    secret = "eyJhbGciOi." + "A" * 30 + ".Sig1234567890ABCDEF"  # noqa: S105 — JWT-shaped test literal
+    proc = _run("check", "--bogus-flag", secret)
+    assert secret not in proc.stdout and secret not in proc.stderr, \
+        "out-of-set token value leaked"
+    assert "<scrubbed>" in proc.stderr, "value not scrubbed by the parser"
+
+
 def test_help_exits_0() -> None:
     proc = _run("--help")
     assert proc.returncode == 0, f"--help should exit 0, got {proc.returncode}"
@@ -130,7 +142,11 @@ def test_import_guard_present() -> None:
     assert "missing dependency" in SRC, "missing dependency guard"
 
 
-_BEHAVIORAL = {"test_token_on_cli_rejected_exits_1_without_leak", "test_help_exits_0"}
+_BEHAVIORAL = {
+    "test_token_on_cli_rejected_exits_1_without_leak",
+    "test_outofset_token_flag_value_scrubbed",
+    "test_help_exits_0",
+}
 
 
 def main() -> int:

--- a/packs/credential-brokers/.apm/skills/credential-setup/scripts/setup.py
+++ b/packs/credential-brokers/.apm/skills/credential-setup/scripts/setup.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import argparse
 import getpass
 import pathlib
+import re
 import sys
 
 # Bootstrap when invoked as ``python scripts/setup.py`` (Python sets
@@ -69,6 +70,50 @@ def _refuse_argv_ban(argv: list[str]) -> None:
         if head in _ARGV_BAN:
             sys.stderr.write(f"credential-setup: argv-refusal: {_ARGV_REFUSAL}\n")
             sys.exit(3)
+
+
+class _ScrubbingArgumentParser(argparse.ArgumentParser):
+    """ArgumentParser that scrubs token-shaped values from error messages.
+
+    ``_refuse_argv_ban`` above rejects the canonical banned flags before the
+    parse, but a token passed under a flag it doesn't enumerate
+    (``--credential SECRET``, ``--apikey SECRET``) would reach argparse,
+    whose stock ``error()`` echoes ``--credential SECRET`` verbatim to stderr
+    / the agent transcript. This subclass redacts any argv token of length
+    >= 20 on a likely-credential character set before chaining to the stock
+    error handler.
+    """
+
+    # Credential-shaped token: >= 20 chars on a base64 / base64url / JWT /
+    # percent-encoded charset. `.` and `~` are included so dotted bearer /
+    # JWT tokens (header.payload.signature) match — without `.` the anchored
+    # regex fails on the separators and the value would leak. The >= 20 floor
+    # is deliberate (modern PATs/tokens exceed it); a shorter value under an
+    # out-of-set flag is not redacted.
+    _CREDENTIAL_LOOKING_RE = re.compile(r"^[A-Za-z0-9_/+=%.~-]{20,}$")
+    _STRIP_CHARS = "'\"`(),;:."
+
+    def error(self, message: str) -> None:  # type: ignore[override]
+        def _check(value: str) -> bool:
+            core = value.strip(self._STRIP_CHARS)
+            return bool(self._CREDENTIAL_LOOKING_RE.match(core))
+
+        def _scrub(match: re.Match[str]) -> str:
+            tok = match.group(0)
+            if tok.startswith("-"):
+                # Glued ``--flag=VALUE`` — check the RHS of the first ``=``
+                # for credential shape and replace only that half.
+                if "=" in tok:
+                    flag, _, value = tok.partition("=")
+                    if _check(value):
+                        return f"{flag}=<scrubbed>"
+                return tok
+            if _check(tok):
+                return "<scrubbed>"
+            return tok
+
+        scrubbed = re.sub(r"\S+", _scrub, message)
+        super().error(scrubbed)
 
 
 def _find_schema(namespace: str) -> pathlib.Path | None:
@@ -132,7 +177,7 @@ def main(argv: list[str] | None = None) -> int:
     argv = list(sys.argv[1:]) if argv is None else list(argv)
     _refuse_argv_ban(argv)
 
-    parser = argparse.ArgumentParser(
+    parser = _ScrubbingArgumentParser(
         prog="credential-setup",
         description="Interactive credential setup. user-invoked.",
     )

--- a/packs/figma/.apm/skills/figma/scripts/figma.py
+++ b/packs/figma/.apm/skills/figma/scripts/figma.py
@@ -180,10 +180,13 @@ class _ScrubbingArgumentParser(argparse.ArgumentParser):
     to the stock error handler.
     """
 
-    # `%` included to catch percent-encoded values (a deliberately
-    # encoded secret would otherwise survive the scrub) even though
-    # the realistic threat model is bare token values.
-    _CREDENTIAL_LOOKING_RE = re.compile(r"^[A-Za-z0-9_/+=%-]{20,}$")
+    # Credential-shaped token: >= 20 chars on a base64 / base64url / JWT /
+    # percent-encoded charset. `.` and `~` are included so dotted bearer /
+    # JWT tokens (header.payload.signature) match — without `.` the anchored
+    # regex fails on the separators and the value would leak. The >= 20 floor
+    # is deliberate (modern PATs/tokens exceed it); a shorter value under an
+    # out-of-set flag is not redacted.
+    _CREDENTIAL_LOOKING_RE = re.compile(r"^[A-Za-z0-9_/+=%.~-]{20,}$")
     # Quoting / punctuation argparse and the shell may wrap a value in
     # before it lands in an error message.
     _STRIP_CHARS = "'\"`(),;:."

--- a/packs/figma/.apm/skills/figma/scripts/test_exit_codes.py
+++ b/packs/figma/.apm/skills/figma/scripts/test_exit_codes.py
@@ -73,6 +73,18 @@ def test_token_on_cli_rejected_exits_1_without_leak() -> None:
     assert secret not in proc.stdout and secret not in proc.stderr, "token leaked"
 
 
+def test_outofset_token_flag_value_scrubbed() -> None:
+    # A token under a flag OUTSIDE the deny-set must not have its value
+    # echoed by argparse's error(); the scrubbing parser redacts it. The
+    # dotted JWT-shaped value also guards the regex charset (must include
+    # `.`), per the security review.
+    secret = "eyJhbGciOi." + "A" * 30 + ".Sig1234567890ABCDEF"  # noqa: S105 — JWT-shaped test literal
+    proc = _run("whoami", "--bogus-flag", secret)
+    assert secret not in proc.stdout and secret not in proc.stderr, \
+        "out-of-set token value leaked"
+    assert "<scrubbed>" in proc.stderr, "value not scrubbed by the parser"
+
+
 def test_help_exits_0() -> None:
     proc = _run("--help")
     assert proc.returncode == 0, f"--help should exit 0, got {proc.returncode}"
@@ -117,7 +129,11 @@ def test_access_error_mapped_to_user_action() -> None:
     )
 
 
-_BEHAVIORAL = {"test_token_on_cli_rejected_exits_1_without_leak", "test_help_exits_0"}
+_BEHAVIORAL = {
+    "test_token_on_cli_rejected_exits_1_without_leak",
+    "test_outofset_token_flag_value_scrubbed",
+    "test_help_exits_0",
+}
 
 
 def main() -> int:

--- a/tools/lint_credentialed_skills.py
+++ b/tools/lint_credentialed_skills.py
@@ -669,6 +669,60 @@ def imports_playwright(py_path):
     return False
 
 
+def denyset_flag_groups(py_path):
+    """Yield, per set/list/tuple literal, the set of normalize_flag'd
+    flag-shaped string elements. A hand-maintained token deny-set
+    (``TOKEN_CLI_FLAGS = frozenset({...})`` / ``_ARGV_BAN = {...}`` / a list
+    or tuple) shows up as one such group, name-agnostically; the caller
+    identifies the deny-set as a group carrying >= 2 canonical banned flags
+    so an incidental set that merely mentions one token-shaped flag isn't
+    mistaken for one. ``ast.walk`` visits the inner ``Set``/``List`` of a
+    ``frozenset({...})`` / ``frozenset([...])`` directly, so no Call handling
+    is needed — which also avoids double-counting the same literal."""
+    tree = _ast_for(py_path)
+    if tree is None:
+        return
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Set, ast.List, ast.Tuple)):
+            continue
+        flags = set()
+        for el in node.elts:
+            s = _literal_string(el)
+            if s is not None and s.startswith("-"):
+                flags.add(normalize_flag(s))
+        if flags:
+            yield flags
+
+
+def has_scrubbing_parser(py_path):
+    """True iff the file defines an ``argparse.ArgumentParser`` subclass that
+    overrides ``error()`` — the value-scrubbing backstop that keeps a
+    token-shaped flag outside the deny-set from having its value echoed by
+    argparse's stock error message.
+
+    Structural check only: it confirms an ``error()`` override *exists*, not
+    that it actually scrubs. The scrubbing behavior itself is verified by the
+    CLIs' token smoke tests + manual A/B, not here; this is the source-level
+    drift sentinel that the backstop wasn't deleted."""
+    tree = _ast_for(py_path)
+    if tree is None:
+        return False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        base_is_argparse = any(
+            (isinstance(b, ast.Attribute) and b.attr == "ArgumentParser")
+            or (isinstance(b, ast.Name) and b.id == "ArgumentParser")
+            for b in node.bases
+        )
+        if base_is_argparse and any(
+            isinstance(m, ast.FunctionDef) and m.name == "error"
+            for m in node.body
+        ):
+            return True
+    return False
+
+
 # --- Main scan -------------------------------------------------------
 
 skill_md_files = []
@@ -746,6 +800,43 @@ for skill_md in skill_md_files:
                         f"{raw!r} accepted by argparse (normalised "
                         f"{norm!r} ∈ {sorted(BANNED_FLAGS)})",
                     )
+
+        # --- D2b: deny-set completeness + scrubbing backstop --------
+        # A token deny-set is a set/list/tuple literal carrying >= 2 of the
+        # canonical banned flags. The >= 2 floor keeps an incidental literal
+        # that merely mentions one token-shaped flag (e.g. an MCP header set)
+        # from being mistaken for a deny-set. Conditional on such a deny-set
+        # being present, so D2b never fires on minimal/unrelated scripts —
+        # which means a credentialed-cli that ships NO deny-set at all is not
+        # covered here (D2a's add_argument ban is the floor for that case).
+        # When a deny-set is present it must (a) carry ALL the canonical six
+        # — catching the drift where a consumer silently drops one — and
+        # (b) be backed by a value-scrubbing ArgumentParser, so a token-shaped
+        # flag OUTSIDE the deny-set doesn't have its value echoed by error().
+        token_denysets = [
+            g
+            for py in py_files
+            for g in denyset_flag_groups(py)
+            if len(g & BANNED_FLAGS) >= 2
+        ]
+        if token_denysets:
+            present = set().union(*token_denysets)
+            missing = sorted(BANNED_FLAGS - present)
+            if missing:
+                report(
+                    skill_md,
+                    f"token deny-set is incomplete — missing canonical "
+                    f"banned flag(s) {missing}; the argv ban requires all of "
+                    f"{sorted(BANNED_FLAGS)}",
+                )
+            if not any(has_scrubbing_parser(py) for py in py_files):
+                report(
+                    skill_md,
+                    "ships a token deny-set but no value-scrubbing "
+                    "ArgumentParser subclass (one overriding error()); a "
+                    "token-shaped flag outside the deny-set would have its "
+                    "value echoed verbatim by argparse's error message",
+                )
 
     # --- Broker-agnostic D3: dotfile read ----------------------
     for py in py_files:

--- a/tools/test-lint-credentialed-skills.py
+++ b/tools/test-lint-credentialed-skills.py
@@ -179,6 +179,96 @@ def _(root: Path) -> None:
     )
 
 
+# ── credentialed-cli D2b: token deny-set completeness + scrubbing backstop
+
+_SHIM = "from .credentials_shim import load_credentials\n"
+_DENYSET_COMPLETE = (
+    'TOKEN_CLI_FLAGS = frozenset({"--token", "--api-token", "--api-key", '
+    '"--bearer", "--pat", "--password"})\n'
+)
+_DENYSET_MISSING_APIKEY = (
+    'TOKEN_CLI_FLAGS = frozenset({"--token", "--api-token", '
+    '"--bearer", "--pat", "--password"})\n'
+)
+_SCRUBBER = (
+    "import argparse\n"
+    "class _Scrubber(argparse.ArgumentParser):\n"
+    "    def error(self, message):\n"
+    "        super().error(message)\n"
+)
+
+
+def _write_creds_cli(root: Path, script: str) -> None:
+    sk = root / "packs" / "p" / ".apm" / "skills" / "fixture-creds"
+    write(sk / "SKILL.md", make_skill_md("creds", namespace="foo", keys=["API_TOKEN"]))
+    write(sk / "scripts" / "cli.py", script)
+
+
+@case(
+    "denyset-incomplete-missing-flag",
+    expect_exit=1,
+    expect_substrings=["token deny-set is incomplete", "api_key"],
+)
+def _(root: Path) -> None:
+    # Deny-set drops --api-key; shim import + scrubber present so only the
+    # incompleteness finding fires.
+    _write_creds_cli(root, _SHIM + _DENYSET_MISSING_APIKEY + _SCRUBBER)
+
+
+@case(
+    "denyset-complete-no-scrubber",
+    expect_exit=1,
+    expect_substrings=["no value-scrubbing"],
+    refuse_substrings=["token deny-set is incomplete"],
+)
+def _(root: Path) -> None:
+    # Complete deny-set but no ArgumentParser.error override.
+    _write_creds_cli(root, _SHIM + _DENYSET_COMPLETE)
+
+
+@case(
+    "denyset-complete-with-scrubber",
+    expect_exit=0,
+)
+def _(root: Path) -> None:
+    _write_creds_cli(root, _SHIM + _DENYSET_COMPLETE + _SCRUBBER)
+
+
+@case(
+    "no-denyset-not-checked",
+    expect_exit=0,
+)
+def _(root: Path) -> None:
+    # No deny-set literal → D2b is silent (conditional, not a positive
+    # mandate) — minimal scripts that test other rules stay clean.
+    _write_creds_cli(root, _SHIM + "print(load_credentials)\n")
+
+
+@case(
+    "denyset-split-across-scripts-clean",
+    expect_exit=0,
+)
+def _(root: Path) -> None:
+    # Deny-set in one script, scrubbing parser in another: D2b unions the
+    # deny-set groups across scripts and checks the scrubber per-skill, so
+    # this is compliant. Pins the multi-script union / any-script paths.
+    sk = root / "packs" / "p" / ".apm" / "skills" / "fixture-creds"
+    write(sk / "SKILL.md", make_skill_md("creds", namespace="foo", keys=["API_TOKEN"]))
+    write(sk / "scripts" / "cli.py", _SHIM + _DENYSET_COMPLETE)
+    write(sk / "scripts" / "_parser.py", _SCRUBBER)
+
+
+@case(
+    "single-incidental-flag-not-a-denyset",
+    expect_exit=0,
+)
+def _(root: Path) -> None:
+    # A literal that merely mentions ONE token-shaped flag (< 2 canonical)
+    # is not a deny-set — D2b must not demand completeness or a scrubber of
+    # it. Pins the >= 2-canonical-flag threshold against false positives.
+    _write_creds_cli(root, _SHIM + 'HEADER_FLAGS = {"--bearer-header", "--token"}\n')
+
+
 # ── auth: env — exact-string-equal key match (no substring)
 
 @case(


### PR DESCRIPTION
## What does this change?

Closes the residual token-leak across the credentialed CLIs and makes it un-regressable. The CLIs reject tokens under the canonical-six argv-ban flags via an exact-match deny-set, but a token under a token-shaped flag *outside* that set (`--credential SECRET`, `--apikey SECRET`) fell through to argparse, whose `error()` echoes the value to stderr / the agent transcript. figma had a `_ScrubbingArgumentParser` backstop; the other five didn't. This ports the backstop to all five and adds a lint that requires it.

## Why?

The deferred "figma-style substring/scrubbing backstop, pack-wide" follow-up from the earlier deny-set PR. No spec — a hardening follow-up. The chosen layer is the **value-scrubber** (redacts credential-shaped values in argparse errors), not figma's flag-name substring regex, because the scrubber has no false-positive maintenance hazard (a future `--author`/`--path` flag won't be wrongly rejected).

**1 — port the scrubber (close the leak):** `_ScrubbingArgumentParser` added to `jira`, `jira-align`, `confluence-crawler`, `confluence-publisher`, and `credential-setup` (the broker had the same leak via `_ARGV_BAN` + `_refuse_argv_ban`). Wired into each parser, and pinned on the jira/jira-align subparsers. **Security-review caught a real gap:** the scrub regex excluded `.`, so dotted **JWT/OAuth bearer tokens leaked verbatim** — fixed in all six CLIs (incl. figma): `^[A-Za-z0-9_/+=%.~-]{20,}$`. A/B-proven: `--bogus-flag <dotted-JWT>` → `<scrubbed>`.

**3 — enforce mechanically:** `tools/lint_credentialed_skills.py` gains a conditional check — a script shipping a token deny-set (a set/list/tuple literal with **≥2** canonical banned flags) must carry **all six** canonical flags (catches the kind of deny-set drift fixed in the prior PR) **and** a value-scrubbing `ArgumentParser` subclass. Name-agnostic (`TOKEN_CLI_FLAGS` and `_ARGV_BAN`); conditional so it never fires on minimal/unrelated scripts.

## How do I verify it?

- `python3 tools/lint_credentialed_skills.py .` → 0 findings (6 credentialed-cli skills comply); self-test `tools/test-lint-credentialed-skills.py` → 26/26 (6 new D2b cases).
- Each skill: `python3 packs/<…>/scripts/test_exit_codes.py` → 6 checks deps-less, 9 with deps. New deps-gated `test_outofset_token_flag_value_scrubbed` (dotted-JWT value) proves redaction.
- A/B (deps + `PYTHONIOENCODING` irrelevant): `<cli> --bogus-flag eyJ…A×30….Sig…` → `error: unrecognized arguments: --bogus-flag <scrubbed>`, value absent.
- `make lint-packs` clean; reviewed by `adversarial-reviewer`, `security-reviewer`, `quality-engineer` — all clean after two rounds.

## What did you not change that you considered?

- figma's **flag-name substring regex** (`SECRET_LIKE_FLAG_RE`) — NOT ported; it carries a future-flag false-positive hazard (`--author` matches `auth`, `--path` matches `pat`). The value-scrubber covers the same threat without it.
- **Interior-colon / `#` values** (`user:pass`) still pass through — by design; not a credential shape these CLIs accept as a value, and adding `:` would false-positive on every `host:port` arg (security-review confirmed).
- **Short (<20 char) tokens** under a typo'd out-of-set flag aren't redacted — documented floor at each regex.
- `has_scrubbing_parser` is a **structural** lint (confirms an `error()` override exists, not that it scrubs) — behavior is covered by the smoke tests; documented as such.
- **CONVENTIONS § argv-ban** names the lint as `…-skills.sh`; the actual tool is `…_skills.py`. The `.sh` shim exists and delegates, so the reference isn't broken, and CONVENTIONS is RFC-gated — deferred, not touched here.

**Bundled fixes:** none.

## Checklist

- [x] Tests pass locally (6 standalone smoke tests deps-less + with deps; lint self-test 26/26)
- [x] Lint passes (`lint_credentialed_skills.py` + self-test, `make lint-packs`, `ruff` on new code); no typecheck step in this repo
- [x] Self-review via `adversarial-reviewer` + `security-reviewer` + `quality-engineer`; all clean
- [x] Matches the shipped contracts (CONVENTIONS § argv ban) — no spec change
- [ ] Living docs — N/A (no user-visible behavior change beyond not-leaking)
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured (the dotted-JWT charset gap; the scrubber-vs-substring trade-off)