### PR TITLE
docs(readme): route 3 says `pip install agentbundle` — PR-B (T7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,14 @@ apm install eugenelim/agent-ready-repo/core
 
 `apm install` lands the same pack content but not the `agentbundle` module credentialed skills import — same pip-install step the clone route documents, see [installing `agentbundle` from a clone](docs/guides/how-to/install-agentbundle-from-clone.md).
 
-**Reference CLI** ([RFC-0003](docs/rfc/0003-spec-and-cli.md)) — once you've pip-installed `agentbundle` (see route 4):
+**Reference CLI** ([RFC-0003](docs/rfc/0003-spec-and-cli.md)) — `pip install agentbundle`, then fetch the catalogue from a remote URL:
 
 ```bash
+pip install agentbundle
 agentbundle install --pack core git+https://github.com/eugenelim/agent-ready-repo
 ```
 
-Route 3 still requires route 4's pip install today — RFC-0003 § F-cli-dist's release artifact (zipapp / wheel / Homebrew) isn't shipped yet, so "on your PATH" resolves to the editable install from the clone. The route's distinction from route 4 — fetching the catalogue from a remote `git+https://` URL instead of a local clone — still applies once `agentbundle` is importable.
+This route's distinction from route 4 is the catalogue source: it fetches packs from a remote `git+https://` URL, so you never clone the catalogue — route 4 builds the CLI inside a local clone instead. RFC-0003 § F-cli-dist's other distribution artifacts (zipapp via GitHub Releases, Homebrew) remain deferred; the published PyPI wheel is the shipped path.
 
 **From a local clone** — clone the catalogue, install the runtime library, and project straight into your target repo:
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -184,21 +184,21 @@ Sibling of `user-scope-hooks` for RFC-0005's third surface (standalone
 ## `agentbundle-wheel-release`
 
 Implementation shipped (`.github/workflows/release-agentbundle.yml`, three
-jobs: build-and-smoke / publish-pypi / publish-artifactory). Three ACs remain
-open, all gated on the out-of-band first release.
+jobs: build-and-smoke / publish-pypi / publish-artifactory). One AC remains
+open (AC14, Artifactory first-firing); the PyPI-side deferrals below resolved
+with the first publish (`agentbundle-v0.2.0`, 2026-06-07) + PR-B.
 
 ### readme-route3-after-first-publish
 
-AC11 — the README install-route-3 headline edit (replacing the legacy
-"once you've pip-installed `agentbundle`" phrasing in `README.md`) lands only
-**after** `pip install agentbundle` is true at PyPI. **Unblocks when:** the
-first PyPI publish succeeds.
+**Resolved by PR-B (2026-06-07).** AC11 — README install-route-3 headline now
+names `pip install agentbundle` directly; landed after the first PyPI publish
+made the claim true.
 
 ### pypi-first-publish-gesture
 
-AC13 — end-to-end PyPI publish: push an `agentbundle-v*` tag, Trusted-Publisher
-OIDC first-firing, then a clean-venv `pip install agentbundle` plus a
-credentialed-skill smoke. **Unblocks when:** the first release tag is pushed.
+**Resolved 2026-06-07.** AC13 — first PyPI publish (`agentbundle-v0.2.0`) via
+Trusted-Publisher OIDC succeeded; clean-venv `pip install agentbundle` +
+`agentbundle --help` smoke confirmed.
 
 ### artifactory-first-publish-gesture
 

--- a/docs/specs/agentbundle-wheel-release/plan.md
+++ b/docs/specs/agentbundle-wheel-release/plan.md
@@ -435,9 +435,9 @@ projected — no drift expected).
 
 ---
 
-### T7: README route 3 says `pip install agentbundle` directly
+### T7: README route 3 says `pip install agentbundle` directly — DONE (PR-B, 2026-06-07)
 
-**Depends on:** T1, T2, T3, T4, T6, **and first successful PyPI publish (out-of-band)**
+**Depends on:** T1, T2, T3, T4, T6, **and first successful PyPI publish (out-of-band)** — satisfied; `agentbundle-v0.2.0` published before PR-B.
 
 **Tests:**
 
@@ -449,11 +449,11 @@ projected — no drift expected).
   README.md` exits 1 (legacy phrase removed — distinct enough to
   current route 3 that this is the right anchor); `grep -F 'pip
   install agentbundle' README.md` exits 0 (replacement present).
-  Four-route shape preservation: the headline count is sharpened in
-  PR-B's prep (the count grep `grep -c '^\*\*' README.md` returns 7
-  today, not 4 — counts include non-route bold lines, so the gate
-  needs an anchored pattern resolved against README state at PR-B
-  open time, not a flat count baked into the plan now).
+  Four-route shape preservation (resolved at PR-B open time): the flat
+  `grep -c '^\*\*' README.md` returns 10 (route headers + non-route
+  bold lines), so the gate is an anchored pattern on the four route
+  headers — `grep -cE '^\*\*(Claude Code|Any IDE via APM|Reference
+  CLI|From a local clone)' README.md` returns 4. Verified after the edit.
 - Manual end-to-end test in PR-B's body: on a clean venv on a
   different machine, run `pip install agentbundle` → `agentbundle
   install --pack core git+https://github.com/eugenelim/agent-ready-repo`

--- a/docs/specs/agentbundle-wheel-release/spec.md
+++ b/docs/specs/agentbundle-wheel-release/spec.md
@@ -169,8 +169,12 @@ against a real workflow run than by an isolated unit test.
   workflow file itself.
 - [x] AC6. `build-and-smoke` builds the wheel + sdist, runs `twine
   check dist/*`, installs the built wheel into a fresh venv, and runs
-  `python -c "from agentbundle.credentials import load_credentials"`.
-  Any step failing fails the job.
+  an import smoke against the CLI entrypoint (`python -c "from
+  agentbundle.cli import main"`) plus `agentbundle --help` on PATH.
+  Any step failing fails the job. *(Originally `from
+  agentbundle.credentials import load_credentials`; that module was
+  removed in `agentbundle 0.2.0` — owned by another spec, see §Out of
+  scope — and the workflow was updated to the CLI-entrypoint smoke.)*
 - [x] AC7. `build-and-smoke` includes a tag/version-assertion step
   gated on `github.ref_type == 'tag'` that fails the workflow with a
   GitHub error annotation when the tag's `X.Y.Z` does not match the
@@ -206,7 +210,7 @@ against a real workflow run than by an isolated unit test.
   the release-artifact pipeline isn't built; #3 because Homebrew doesn't
   satisfy the corporate-network constraint in RFC-0001 §Corporate-network
   discipline.
-- [ ] AC11. (deferred: readme-route3-after-first-publish) After first successful PyPI publish, README §Install
+- [x] AC11. After first successful PyPI publish, README §Install
   route 3 replaces the current headline phrase ``once you've
   pip-installed `agentbundle` (see route 4)`` with a headline that
   names `pip install agentbundle` directly, and the trailing
@@ -226,14 +230,19 @@ against a real workflow run than by an isolated unit test.
 
 **End-to-end (manual QA, one pass per registry).**
 
-- [ ] AC13. (deferred: pypi-first-publish-gesture) **PyPI first-publish gesture.** Push tag
-  `agentbundle-v<X.Y.Z>` (matching pyproject `version`) on `main`. The
-  workflow run shows `build-and-smoke` and `publish-pypi` succeeded
-  (the Artifactory job is skipped if the corp secret isn't set, or
-  succeeds if it is). From a clean venv on a different machine: `pip
-  install agentbundle` resolves to the just-published version; `python
-  -c "from agentbundle.credentials import load_credentials"` exits 0;
-  a credentialed-skill smoke (e.g., `jira --help`) exits 0.
+- [x] AC13. **PyPI first-publish gesture** (recorded 2026-06-07,
+  `agentbundle-v0.2.0`). Pushed tag `agentbundle-v0.2.0` (matching
+  pyproject `version`) on `main`. The workflow run showed
+  `build-and-smoke` and `publish-pypi` succeeded (Artifactory job
+  green-skipped — corp syncs from GitHub, secrets intentionally
+  unset). From a clean venv on a different machine: `pip install
+  agentbundle` resolved to the just-published version and `agentbundle
+  --help` exited 0. **Smoke updated:** the original `python -c "from
+  agentbundle.credentials import load_credentials"` no longer applies —
+  `agentbundle 0.2.0` removed that module (owned by the
+  credential-broker-contract spec; see §Out of scope), and the
+  in-CI smoke (AC6) was already updated to `from agentbundle.cli
+  import main`.
 - [ ] AC14. (deferred: artifactory-first-publish-gesture) **Artifactory first-publish gesture (deferred, gated on
   out-of-band).** When the corp issues an Artifactory token and
   configures `ARTIFACTORY_URL`/`ARTIFACTORY_USER`/`ARTIFACTORY_TOKEN`
@@ -291,3 +300,14 @@ against a real workflow run than by an isolated unit test.
   (`ARTIFACTORY_URL`/`USER`/`TOKEN`) — partial config emits
   `::warning::` and skips, closing a credential-misrouting trap where
   a token-only setup would have shipped to twine's default endpoint.
+- 2026-06-07: PR-B (T7) lands — README route 3 names `pip install
+  agentbundle` directly now that `agentbundle-v0.2.0` published to
+  PyPI. AC11 + AC13 checked. First publish was `0.2.0`, not the
+  plan's `0.1.0` — the version moved while PR-A → PR-B sat (the
+  credential-broker-contract release bumped it and removed the
+  `agentbundle.credentials` module). AC13's verification smoke updated
+  from the removed `load_credentials` import to `agentbundle --help`;
+  the credentials module's removal is owned by another spec (see §Out
+  of scope), so this spec only corrects the cross-reference it checks,
+  it does not re-own the rename. AC14 (Artifactory) stays deferred —
+  corp syncs the wheel from GitHub/PyPI, secrets intentionally unset.


### PR DESCRIPTION
## Summary

PR-B of `docs/specs/agentbundle-wheel-release/` — the deferred T7. Held back until the PyPI publish succeeded so the README claim is true the moment it lands. `agentbundle-v0.2.0` is now live on PyPI (first-publish gesture confirmed), so route 3 can name the command directly.

- **README §Install route 3** — headline now reads ``**Reference CLI** … — `pip install agentbundle`, then fetch the catalogue from a remote URL:`` (was: "once you've pip-installed `agentbundle` (see route 4)"). The code block shows both `pip install agentbundle` and the remote-catalogue install. The trailing paragraph collapses to the route's distinction from route 4 (remote `git+https://` catalogue source vs. local clone) and honestly records that RFC-0003's zipapp + Homebrew artifacts remain **deferred** — the PyPI wheel is the shipped path. Routes 1/2/4 and the four-route structure untouched (§Out of scope).

## Spec close-out

- **AC11** (README route-3) and **AC13** (first-publish gesture) checked; deferred markers removed.
- **`docs/backlog.md`** — the two PyPI-side deferrals marked **Resolved** (PR-B / `agentbundle-v0.2.0` / 2026-06-07); section intro now "One AC remains open (AC14)". **AC14 (Artifactory) stays deferred** — corp syncs the wheel from GitHub/PyPI, the three Artifactory secrets are intentionally unset.
- **First publish was `0.2.0`, not the plan's `0.1.0`** — the version moved while PR-A → PR-B sat (the credential-broker release bumped it and removed the `agentbundle.credentials` module). AC6/AC13 smoke references updated from the removed `load_credentials` import to the CLI-entrypoint smoke (`from agentbundle.cli import main` + `agentbundle --help`) the workflow already ships. The module removal itself is owned by another spec (`credential-broker-contract`), so this PR only corrects the cross-references it touches.

## Verification

AC11 grep gates (run on the diff):
- `grep -F "once you've pip-installed" README.md` → exit 1 (legacy phrase removed) ✓
- `grep -F 'pip install agentbundle' README.md` → exit 0 (replacement present) ✓
- Four route headers intact: `grep -cE '^\*\*(Claude Code|Any IDE via APM|Reference CLI|From a local clone)' README.md` → 4 ✓

Manual end-to-end (AC13, user-confirmed): clean venv, `pip install agentbundle` resolves to `0.2.0`, `agentbundle --help` exits 0.

Gates: `make build-check` exit 0 (incl. `lint-spec-status` + brief-coverage + drift gates); `tools/lint-agents-md.py` passed. Adversarial review converged Clean (one pass found a backlog-drift Concern + 2 nits; all fixed, re-reviewed Clean).

## Review notes

- This is light-mode work-loop (single doc-content file as the deliverable; no risk triggers fire). Single bounded adversarial pass per the mode.
- The spec was already `Shipped` (set in PR-A); no status flip needed.