### PR TITLE
docs(backlog): record credbroker name-registration decision (claim at Phase-2 publish)

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -311,10 +311,18 @@ unblocks the **APM / Claude-plugin adopter who has no repo** — until it ships,
 that profile stays on env Tier-1 or the projected shim. Gated on the package
 stabilising (not a date), per RFC-0023 § Delivery. **Unblocks when:** the
 `credbroker` public surface is stable and a maintainer is ready to own a PyPI
-release cadence. Separately, **defensive PyPI name registration** (an empty
-placeholder so `credbroker` can't be squatted before Phase 2) is an out-of-band
-**user action** — RFC-0023 asks for it as soon as the name is fixed; it is not
-performed by spec automation.
+release cadence.
+
+**Name-registration decision (2026-06-07):** RFC-0023 recommended a *defensive*
+placeholder upload to reserve the `credbroker` name as soon as it was fixed. The
+maintainer **declined the interim placeholder** and will instead claim the name
+with the **real Phase-2 publish when the package is ready** — accepting a small
+interim squat risk on the name. (A PyPI *pending* Trusted Publisher does **not**
+reserve the name — per the PyPI docs, only an actual upload does — so reservation
+and the first real release are the same event here.) Publication is **token-free
+via Trusted Publishing (OIDC)**, modelled on `release-agentbundle.yml`; the
+`release-credbroker.yml` workflow + the PyPI pending-publisher config are Phase-2
+artifacts, created when the publish is ready, not now.
 
 ## `copilot-full-parity`
 


### PR DESCRIPTION
## What

One-paragraph governance record under `docs/backlog.md#credbroker-phase-2`: the maintainer **declined RFC-0023's defensive-placeholder upload**. The `credbroker` PyPI name will be claimed by the **real Phase-2 publish when the package is ready** (token-free, Trusted Publishing / OIDC, modelled on `release-agentbundle.yml`), accepting a small interim squat risk.

## Why this corrects the prior note

The backlog entry (from #232) said to do defensive placeholder registration "as soon as the name is fixed." That's now superseded by the decision. The note also records a load-bearing PyPI fact discovered while evaluating options: a **pending Trusted Publisher does *not* reserve the name** — per the [PyPI docs](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/), only an actual upload does — so reservation and the first real release are the same event. `release-credbroker.yml` + the pending-publisher config stay Phase-2 artifacts.

## Scope

Docs-only, single paragraph. Kept out of the Wave A PR (#233) to keep that diff to its T1–T3 code. Deferral anchor `### credbroker-phase-2` intact; `lint-spec-status` clean.