### PR TITLE
docs(contributing): add `Cutting an agentbundle release` runbook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,31 @@ Three gates, all of which run locally:
 
 Commit format is Conventional Commits — full rules in [`CONVENTIONS.md § Commits`](docs/CONVENTIONS.md#commits). If your commit implements a spec, RFC, or ADR, cite it in the footer (`Spec:`, `RFC:`, `ADR:`).
 
+## Cutting an `agentbundle` release
+
+Publishing a new `agentbundle` version to PyPI is a maintainer task, not a contributor lane. The release pipeline is `.github/workflows/release-agentbundle.yml` (jobs: `build-and-smoke` → `publish-pypi` via Trusted Publisher OIDC → `publish-artifactory`, the last green-skipped unless the corp Artifactory secrets are set). A tag push is the only trigger that *publishes* — PRs touching `packages/agentbundle/**` run `build-and-smoke` as a pre-merge gate, and there's no manual `twine upload`.
+
+Per release:
+
+1. **Bump the version** in [`packages/agentbundle/pyproject.toml`](packages/agentbundle/pyproject.toml) and add a matching entry to [`packages/agentbundle/CHANGELOG.md`](packages/agentbundle/CHANGELOG.md), in the same PR. Merge it to `main` through the normal gates.
+2. **Tag the tip of `main`** — never a feature branch:
+   ```bash
+   git checkout main && git pull origin main
+   git tag agentbundle-vX.Y.Z          # X.Y.Z must equal the pyproject version
+   git push origin agentbundle-vX.Y.Z
+   ```
+3. **Watch the run** (Actions → `release-agentbundle`). `build-and-smoke` and `publish-pypi` must go green; `publish-artifactory` shows green-skipped when the corp secrets are unset.
+4. **Verify** from a clean venv, ideally on another machine: `pip install agentbundle` resolves to the new version and `agentbundle --help` exits 0.
+
+Caveats the workflow enforces — know them before you tag:
+
+- **The tag format is exact: `agentbundle-vX.Y.Z`.** Pre-release / build-metadata suffixes (`-rc1`, `+build`) are refused by the version-assertion step.
+- **The tag's `X.Y.Z` must equal the pyproject `version`**, and the tagged commit **must be an ancestor of `origin/main`** — both are fail-closed assertions in `build-and-smoke`, so a wrong tag never publishes.
+- **A successful publish burns the version number permanently** — PyPI does not allow re-uploading the same version. A publish that *never reached PyPI* leaves the number claimable (delete the tag with `git push origin :refs/tags/agentbundle-vX.Y.Z`, fix, re-tag) — but a *partial* publish that did reach PyPI also burns it, so treat any run where `publish-pypi` started as a burn.
+- **`1.0.0` or higher is [§Ask first](docs/specs/agentbundle-wheel-release/spec.md#boundaries)** — the pre-1.0 stability contract changes at 1.0; record explicit sign-off in the release PR before pushing such a tag.
+
+The **one-time** PyPI account + Pending Publisher setup is not repeated per release; it lives in the plan's [Rollout § Phase B](docs/specs/agentbundle-wheel-release/plan.md#rollout).
+
 ## Where to find authoritative information
 
 | You want to know… | Look here |


### PR DESCRIPTION
## Summary

Adds a per-release maintainer runbook to `CONTRIBUTING.md`. The repo had no first-class, repeatable "how to cut a release" doc — the only steps lived in `docs/specs/agentbundle-wheel-release/plan.md` §Rollout, framed as **one-time** first-publish setup (Pending Publisher, first tag), not a recurring runbook.

## Why CONTRIBUTING.md (not `docs/guides/`)

`docs/guides/` is Diátaxis **adopter-facing** docs — adopters `pip install agentbundle`, they never cut a release of it. Cutting a release is a **maintainer** task, so it belongs in `CONTRIBUTING.md` (already the lane-structured maintainer/contributor-process doc). A new `docs/maintainers/` subdir was rejected — that's new docs structure and would warrant an RFC for a one-page checklist.

## What the section covers

- Per-release steps: bump `pyproject.toml` version + `CHANGELOG.md` entry → merge → tag the tip of `main` → watch the workflow → verify from a clean venv.
- A caveats list for the non-obvious fail-closed rules the workflow enforces: exact `agentbundle-vX.Y.Z` tag regex (no suffixes), tag-vs-pyproject version match, tag-must-be-ancestor-of-`main`, the version-burn rule (incl. partial publishes), and `1.0.0+` as §Ask-first.

## Scope boundaries (intentional)

- The **one-time** PyPI Pending Publisher setup stays linked in the plan's Rollout § Phase B — not duplicated.
- The corp Artifactory name-claim item is tracked separately by the maintainer — out of this doc.

## Verification

- Anchors resolve: `spec.md#boundaries`, `plan.md#rollout`; intra-doc file links (`pyproject.toml`, `CHANGELOG.md`) exist.
- Every workflow claim cross-checked against `.github/workflows/release-agentbundle.yml` ground truth.
- Gates: `make build-check` exit 0; `tools/lint-agents-md.py` passed.
- Light-mode work-loop (single repo-owned doc, no risk triggers). Adversarial pass found 3 factual findings (PR-trigger phrasing, plan-vs-spec attribution, partial-publish burn case) — all fixed.