### PR TITLE
docs(readme): one-line pip-install + per-adapter `config set adapter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,21 +32,32 @@ Pick `core` plus whichever add-ons fit your repo. The detailed breakdown of `cor
 
 The reference CLI `agentbundle` is the catalogue's foundation — install it once, then every pack install is one line at either scope.
 
-**One-time setup** (until [RFC-0003](docs/rfc/0003-spec-and-cli.md) § F-cli-dist ships a release artifact, install from a clone):
+**One-time setup** — install the CLI from PyPI:
 
 ```bash
-git clone https://github.com/eugenelim/agent-ready-repo
-pip install -e agent-ready-repo/packages/agentbundle/
+pip install agentbundle
 ```
+
+(For a pinned or offline checkout, `pip install -e` from a clone instead — see [route 4](#all-four-install-routes).)
+
+**Pick your harness** — optional; defaults to Claude Code. `config set adapter` persists the choice so every new install targets that harness's layout (upgrades keep the adapter the original install used):
+
+```bash
+agentbundle config set adapter codex      # Codex      → .agents/skills/
+agentbundle config set adapter copilot    # Copilot    → .github/instructions/
+agentbundle config set adapter kiro-ide   # Kiro (IDE) → .kiro/skills/
+```
+
+`agentbundle config get adapter` shows the current value and `config unset adapter` reverts to the `claude-code` default (`kiro-cli` targets Kiro's CLI binary). Prefer a single line? Chain the two: `pip install agentbundle && agentbundle config set adapter codex`. To override just one install without changing the saved default, pass `--adapter <name>` to `agentbundle install`. Not every pack travels with every harness — a pack installs only for the adapters it lists in `allowed-adapters` and refuses others with a clear message; `core` carries no such restriction and installs under any adapter.
 
 **Then one line per pack, either scope:**
 
 ```bash
-agentbundle install --pack core      git+https://github.com/eugenelim/agent-ready-repo   # repo-scope: into the current repo
-agentbundle install --pack architect git+https://github.com/eugenelim/agent-ready-repo   # user-scope: into ~/.claude/
+agentbundle install --pack core      git+https://github.com/eugenelim/agent-ready-repo   # repo scope: into the current repo
+agentbundle install --pack architect git+https://github.com/eugenelim/agent-ready-repo   # user scope: into your home dir, shared across projects
 ```
 
-`core` lands under the current repo's `.claude/`; `architect` lands under `~/.claude/` so it follows you across every project on the machine. Scope is read from each pack's `default-scope` — swap either pack name for any row in the [Packs](#packs) table.
+`core` lands in the current repo and `architect` in your home directory — under `.claude/` for the default Claude Code adapter, or the matching `.agents/` / `.kiro/` / `.github/` root for whichever harness you set — so `architect` follows you across every project. Scope is read from each pack's `default-scope` — swap either pack name for any row in the [Packs](#packs) table (each pack's supported adapters are its `allowed-adapters`).
 
 APM and Claude-plugin routes will land the same markdown content without the `pip install` step, but `adapt-to-project` substitution, credentialed skills (`jira`, `figma`, `confluence-publisher`, ...), and upgrade-time safety (`agentbundle init-state`) all require the `agentbundle` CLI on PATH — so the one-time pip step is effectively part of the setup either way.
 


### PR DESCRIPTION
## Summary

The install quick-start funneled everyone through the Claude-Code default and never surfaced `agentbundle config set adapter` — a shipped command (RFC-0012 / `agentbundle-config-subcommand`, Status: Shipped) that persists a default adapter so every fresh install targets your harness. This adds a **"Pick your harness"** block to the top install section.

Presented in the priority you asked for:
- **Persistent default (primary):** `agentbundle config set adapter <name>` with per-adapter examples + landing paths:
  ```bash
  agentbundle config set adapter codex      # Codex      → .agents/skills/
  agentbundle config set adapter copilot    # Copilot    → .github/instructions/
  agentbundle config set adapter kiro-ide   # Kiro (IDE) → .kiro/skills/
  ```
- **One-line form:** `pip install agentbundle && agentbundle config set adapter codex`.
- **Once-off (subordinate):** `--adapter <name>` on a single `agentbundle install`.

Plus `config get` / `config unset` and the `claude-code` default noted.

## Same-area drift fix (folded in)

The "One-time setup" block still said *"until RFC-0003 §F-cli-dist ships a release artifact, install from a clone"* and showed `git clone … && pip install -e`. The wheel shipped as `agentbundle 0.2.0`, so that's stale — it now reads `pip install agentbundle`, with a clone/editable-install pointer to route 4 preserved for pinned/offline checkouts.

## Adversarial review

Light-mode work-loop (single repo-owned doc). First pass found a **Blocker** + 2 Concerns, all fixed:
- **Blocker:** `architect`'s `allowed-adapters` omits `copilot`/`kiro-ide`, so a configured non-default would make the *next* `install --pack architect` example refuse. Fixed with a caveat — a pack installs only for the adapters in its `allowed-adapters` (refuses others with a clear message); `core` carries no restriction.
- **Concern:** the `.claude/` landing paths below the new block were only true for the default adapter — now qualified ("`.claude/` for Claude Code, or the matching `.agents/` / `.kiro/` / `.github/` root for whichever harness you set").
- **Concern:** "every later install" overstated — scoped to *fresh* installs (upgrades keep the adapter the original install used).

Second pass: `Clean — ready to commit.`

## Verification

- Adapter names + landing paths cross-checked against `docs/contracts/adapter.toml` and a **pip-installed 0.2.0 wheel** (`config set adapter` works from the wheel; accepts `claude-code/codex/copilot/kiro/kiro-cli/kiro-ide`; rejects unknowns).
- The config→fresh-install redirect verified **end-to-end**: `config set adapter codex` then `install --pack core` lands in `.agents/skills/` and reports "via codex".
- Gates: `make build-check` exit 0; `tools/lint-agents-md.py` passed.

## Follow-up observation (not fixed here)

`architect`'s `allowed-adapters = ["claude-code", "kiro", "codex"]` lists the **deprecated** `kiro` alias and omits `kiro-ide`/`copilot` (post-RFC-0022/0024). That's stale pack metadata, but `architect` isn't projected in this repo's self-host and fixing pack content is out of scope for a README change — flagging for a separate pack-metadata pass.