### PR TITLE
fix(architect): current adapter names in allowed-adapters + contract v0.10

### DIFF
--- a/packages/agentbundle/agentbundle/build/tests/test_shipped_packs_v08_declarations.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_shipped_packs_v08_declarations.py
@@ -14,14 +14,16 @@ declared v0.8 at birth. A future pack landing at v0.8 should add itself to
 
 Packs in-tree NOT at v0.8:
 
-  - ``architect``: still at v0.6 (older, pre-RFC-0013).
   - ``credential-brokers``: still at v0.7 (RFC-0013 shipped on v0.7 and
     a v0.7 pack continues to work under v0.8 — the legacy resolver path
     for codex drops agents/hooks per the v0.7 contract, fine for
     backward compat).
-  - ``core`` and ``research``: bumped to v0.10 by RFC-0024 /
-    docs/specs/copilot-full-parity (copilot now projects their agents +
-    hook-wiring), so they leave ``V08_PACKS``.
+  - ``core``, ``research``, and ``architect``: at v0.10. core/research
+    bumped by RFC-0024 / docs/specs/copilot-full-parity (copilot now
+    projects their agents + hook-wiring); architect followed when it
+    added copilot to ``allowed-adapters`` (copilot's skill primitive
+    gained its user-scope target at v0.10, and architect is
+    user-scope-default). All leave ``V08_PACKS``.
 """
 
 from __future__ import annotations

--- a/packs/architect/pack.toml
+++ b/packs/architect/pack.toml
@@ -3,12 +3,20 @@ name = "architect"
 version = "0.1.0"
 description = "Solution-architecture skills (architect-design, architect-diagram, architect-review). Workspace-agnostic, user-scope by default, no required configuration. Mermaid for diagrams; Google-style design docs; rubric-routed critique."
 
-# RFC-0011 contract level — pure-markdown skills, multi-adapter.
+# RFC-0024 contract level (v0.10) — pure-markdown skills, multi-adapter.
+# Bumped from v0.6 so listing `copilot` is honest: copilot's skill
+# primitive gained its user-scope target (`~/.copilot/instructions/`) at
+# v0.10, and architect is user-scope-default. Mirrors `research`/`core`.
 [pack.adapter-contract]
-version = "0.6"
+version = "0.10"
 
 [pack.install]
 default-scope = "user"
 allowed-scopes = ["user", "repo"]
-# Pure-markdown SKILL.md surface — no adapter-specific primitives.
-allowed-adapters = ["claude-code", "kiro", "codex"]
+# Pure-markdown SKILL.md surface — no adapter-specific primitives, so it
+# travels with every shipped adapter that projects the skill primitive.
+# Current adapter names: RFC-0022 split `kiro` into `kiro-ide`/`kiro-cli`
+# (the bare `kiro` alias is deprecated); RFC-0024 made `copilot`
+# user-scope-capable. `kiro-ide` precedes `kiro-cli` so a Kiro user's
+# `~/.kiro/` auto-probe resolves to the IDE.
+allowed-adapters = ["claude-code", "codex", "copilot", "kiro-ide", "kiro-cli"]


### PR DESCRIPTION
## Summary

Follow-up to PR #247's review, which flagged that `architect`'s `allowed-adapters = ["claude-code", "kiro", "codex"]` is stale. Two problems:
- `kiro` is the **deprecated alias** for `kiro-ide` (RFC-0022 split `kiro` → `kiro-ide` / `kiro-cli`).
- The list **omits `copilot`** (RFC-0024 made copilot user-scope-capable at contract v0.10).

**The live bug:** a Kiro user's `~/.kiro/` auto-probe resolves to `kiro-ide`, which the pack didn't list — so auto-detected `agentbundle install --pack architect` **refused**. Verified before/after.

## The fix

`architect` is a pure-markdown skill pack ("no adapter-specific primitives"), and every shipped adapter projects the `skill` primitive — so the honest list is every skill-capable adapter under current names:

```toml
allowed-adapters = ["claude-code", "codex", "copilot", "kiro-ide", "kiro-cli"]
```

`kiro-ide` precedes `kiro-cli` so a Kiro user's `~/.kiro/` auto-probe resolves to the IDE (the resolver returns the first declared adapter whose probe matches; both kiro probes hit `~/.kiro`).

**Contract bump 0.6 → 0.10:** copilot's `skill` primitive gained its user-scope target (`~/.copilot/instructions/`) at v0.10, and architect is `default-scope = "user"` — so listing copilot at a declared 0.6 was internally inconsistent (adversarial-review Blocker). Bumped to 0.10 to match the capability, mirroring `research`/`core`. **Pack version stays 0.1.0** — never registry-released (git-fetched catalogue), and marketplace.json carries no `allowed-adapters`, so no drift (`make build-check` clean).

## Verification

- `validate packs/architect` exit 0; `codex` / `copilot` / `kiro-ide` / `kiro-cli` all install cleanly at **both** repo and user scope (skills land in `.agents/skills/`, `.github/instructions/` + `~/.copilot/instructions/`, `.kiro/skills/`).
- Kiro auto-probe (no `--adapter`) now resolves to `kiro-ide` — the exact path that previously refused.
- 804 adapter/install/declarations tests pass; `make build-check` exit 0; no test pinned architect's old list. The v0.8-declarations test docstring updated to record architect at v0.10 (docstring-only — architect isn't in `V08_PACKS`).

## Acknowledged consequences / deferred (per adversarial review)

- **`--adapter kiro` against architect now refuses.** There's no `kiro`→`kiro-ide` normalization (separate literals), so explicitly passing the deprecated `kiro` now hits `_AdapterResolutionRefused`. Accepted: `kiro` is deprecated; the message names the supported set, and the auto-probe path resolves correctly. A one-line `kiro`→`kiro-ide` normalization could be a separate follow-up if back-compat for the alias matters.
- **`kiro-cli` was added beyond the originally-flagged kiro-ide+copilot** — under the "every skill-capable adapter" rule the new comment states (`kiro-cli` declares a skill projection in the contract). Not scope creep; a direct consequence of the stated rule.

## Systemic finding — recommend a single follow-up PR

This is **not architect-specific.** Six other user-scope packs carry the same deprecated `kiro`:
- `atlassian`, `contracts`, `converters`, `figma` — `["claude-code", "kiro", "codex"]`
- `credential-brokers` — `["claude-code", "kiro", "codex"]`, but its comment says it **commits to those three per RFC-0013**, so copilot-addition there is a governance decision, not mechanical.
- `research` — already has copilot but **still lists bare `kiro`** (not `kiro-ide`).

I scoped this PR to `architect` (the explicit ask). **Recommendation:** one follow-up PR that (a) does the mechanical `kiro` → `kiro-ide` de-stale across all seven packs, and (b) decides copilot-addition per-pack (respecting credential-brokers' RFC-0013 commitment). Flagging so the one-pack-fixed / six-pack-stale state is a tracked decision, not an accident — your call on whether to proceed.