### PR TITLE
fix(packs): de-stale `kiro` → `kiro-ide` across the user-scope packs

### DIFF
--- a/packages/agentbundle/agentbundle/build/tests/test_shipped_packs_v07_declarations.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_shipped_packs_v07_declarations.py
@@ -5,8 +5,9 @@ Two cohorts:
 
   - Four user-scope-capable packs (`atlassian`, `figma`, `converters`,
     `contracts`) bump `[pack.adapter-contract] version` from 0.6 to
-    0.7. `allowed-adapters` is unchanged from RFC-0011 (`["claude-code",
-    "kiro", "codex"]`).
+    0.7. `allowed-adapters` carries the RFC-0011 three-harness set,
+    de-staled to current adapter names (`["claude-code", "kiro-ide",
+    "codex"]`) — the bare `kiro` alias was renamed by RFC-0022.
   - Four repo-only packs (`core`, `governance-extras`,
     `user-guide-diataxis`, `monorepo-extras`) bump from 0.2 to 0.7 —
     load-bearing per Drawback #7: without this bump the legacy
@@ -48,14 +49,16 @@ class TestUserScopePacksV07(unittest.TestCase):
                     f"{name} must bump to v0.8",
                 )
 
-    def test_user_scope_packs_allowed_adapters_unchanged(self) -> None:
-        """allowed-adapters is unchanged from RFC-0011."""
+    def test_user_scope_packs_allowed_adapters(self) -> None:
+        """allowed-adapters is the RFC-0011 three-harness set, de-staled
+        to current adapter names (RFC-0022 renamed bare `kiro` →
+        `kiro-ide`). The harness set is unchanged; only the spelling is."""
         for name in USER_SCOPE_PACKS:
             with self.subTest(pack=name):
                 pack = _load_pack_toml(name)
                 self.assertEqual(
                     pack["pack"]["install"]["allowed-adapters"],
-                    ["claude-code", "kiro", "codex"],
+                    ["claude-code", "kiro-ide", "codex"],
                     f"{name} declared adapter set wrong",
                 )
 

--- a/packages/agentbundle/tests/integration/test_credential_brokers_pack_install.py
+++ b/packages/agentbundle/tests/integration/test_credential_brokers_pack_install.py
@@ -71,7 +71,7 @@ class PackManifestShapeTests(unittest.TestCase):
         self.assertEqual(install_block["allowed-scopes"], ["user", "repo"])
         self.assertEqual(
             install_block["allowed-adapters"],
-            ["claude-code", "kiro", "codex"],
+            ["claude-code", "kiro-ide", "codex"],
         )
 
 

--- a/packages/agentbundle/tests/integration/test_install_user_scope_allowed_adapters.py
+++ b/packages/agentbundle/tests/integration/test_install_user_scope_allowed_adapters.py
@@ -9,7 +9,8 @@ and (b) `~/.agentbundle/state.toml` records the resolved adapter.
 Reference idiom mirrors `test_install_converters_user_scope.py`:
 in-process `install.run`, `$HOME` patched via `patch.dict`. The four
 catalogue user-scope packs ship `allowed-adapters = ["claude-code",
-"kiro", "codex"]` post-T4, so this test covers the resolver's three
+"kiro-ide", "codex"]` (the bare `kiro` alias was de-staled to its
+current RFC-0022 name), so this test covers the resolver's three
 adapter-target paths without fabricating fixtures.
 """
 
@@ -54,10 +55,10 @@ def _install_args(*, catalogue: str, repo: str, scope: str, adapter: str | None 
 class AllowedAdaptersInstallTests(unittest.TestCase):
     """The four cases that exercise the resolver's distinct paths:
 
-      - kiro-only $HOME → install lands at ~/.kiro/skills/
+      - kiro-only $HOME → install lands at ~/.kiro/skills/ (via kiro-ide)
       - codex-only $HOME (via ~/.codex/) → install lands at ~/.agents/skills/
       - greenfield $HOME (no CLI home) → install lands at ~/.claude/skills/
-      - --adapter kiro override against claude-code-populated $HOME →
+      - --adapter kiro-ide override against claude-code-populated $HOME →
         install lands at ~/.kiro/skills/
     """
 
@@ -99,8 +100,8 @@ class AllowedAdaptersInstallTests(unittest.TestCase):
             _install_args(catalogue=str(self.cat), repo=str(self.repo), scope="user")
         )
         self.assertEqual(rc, 0, f"install failed: stdout={stdout!r} stderr={stderr!r}")
-        self._assert_pack_landed(".kiro/skills", "kiro")
-        self.assertIn("installed: converters @ user via kiro", stdout)
+        self._assert_pack_landed(".kiro/skills", "kiro-ide")
+        self.assertIn("installed: converters @ user via kiro-ide", stdout)
 
     def test_codex_only_home_lands_at_agents_skills(self) -> None:
         (self.home / ".codex").mkdir()
@@ -125,11 +126,11 @@ class AllowedAdaptersInstallTests(unittest.TestCase):
                 catalogue=str(self.cat),
                 repo=str(self.repo),
                 scope="user",
-                adapter="kiro",
+                adapter="kiro-ide",
             )
         )
         self.assertEqual(rc, 0, f"install failed: stdout={stdout!r} stderr={stderr!r}")
-        self._assert_pack_landed(".kiro/skills", "kiro")
+        self._assert_pack_landed(".kiro/skills", "kiro-ide")
 
     def test_upgrade_state_hint_preserves_adapter(self) -> None:
         """AC10b / AC25: install under claude-code; populate ~/.kiro/

--- a/packages/agentbundle/tests/unit/test_install_messages.py
+++ b/packages/agentbundle/tests/unit/test_install_messages.py
@@ -77,7 +77,7 @@ class InstallMessageRailTests(unittest.TestCase):
         (self.home / ".kiro").mkdir()
         rc, stdout, _ = self._install(scope="user")
         self.assertEqual(rc, 0)
-        self.assertIn("installed: converters @ user via kiro", stdout)
+        self.assertIn("installed: converters @ user via kiro-ide", stdout)
 
     def test_user_scope_install_no_suffix_when_single_home_populated(self) -> None:
         """AC14: no suffix when only one CLI home matches."""
@@ -94,10 +94,10 @@ class InstallMessageRailTests(unittest.TestCase):
         (self.home / ".kiro").mkdir()
         rc, stdout, _ = self._install(scope="user")
         self.assertEqual(rc, 0)
-        # claude-code wins (declared first); the suffix should list kiro.
+        # claude-code wins (declared first); the suffix should list kiro-ide.
         self.assertIn("installed: converters @ user via claude-code", stdout)
         self.assertIn(
-            "(other declared adapters: kiro; use --adapter to override)",
+            "(other declared adapters: kiro-ide; use --adapter to override)",
             stdout,
         )
 
@@ -106,9 +106,9 @@ class InstallMessageRailTests(unittest.TestCase):
         already chose)."""
         (self.home / ".claude").mkdir()
         (self.home / ".kiro").mkdir()
-        rc, stdout, _ = self._install(scope="user", adapter="kiro")
+        rc, stdout, _ = self._install(scope="user", adapter="kiro-ide")
         self.assertEqual(rc, 0)
-        self.assertIn("installed: converters @ user via kiro", stdout)
+        self.assertIn("installed: converters @ user via kiro-ide", stdout)
         self.assertNotIn("other declared adapters", stdout)
 
     def test_greenfield_user_scope_install_no_suffix(self) -> None:

--- a/packs/atlassian/pack.toml
+++ b/packs/atlassian/pack.toml
@@ -11,4 +11,6 @@ default-scope = "user"
 allowed-scopes = ["user", "repo"]
 # RFC-0011 / pack-allowed-adapters. Declared order also drives the
 # greenfield fallback (claude-code matches DEFAULT_USER_SCOPE_ADAPTER).
-allowed-adapters = ["claude-code", "kiro", "codex"]
+# `kiro-ide` is the current name for the Kiro harness (RFC-0022 split;
+# bare `kiro` deprecated).
+allowed-adapters = ["claude-code", "kiro-ide", "codex"]

--- a/packs/contracts/pack.toml
+++ b/packs/contracts/pack.toml
@@ -9,5 +9,6 @@ version = "0.8"
 [pack.install]
 default-scope = "user"
 allowed-scopes = ["user", "repo"]
-# RFC-0011 / pack-allowed-adapters.
-allowed-adapters = ["claude-code", "kiro", "codex"]
+# RFC-0011 / pack-allowed-adapters. `kiro-ide` is the current name for
+# the Kiro harness (RFC-0022 split; bare `kiro` deprecated).
+allowed-adapters = ["claude-code", "kiro-ide", "codex"]

--- a/packs/converters/pack.toml
+++ b/packs/converters/pack.toml
@@ -9,5 +9,6 @@ version = "0.8"
 [pack.install]
 default-scope = "user"
 allowed-scopes = ["user", "repo"]
-# RFC-0011 / pack-allowed-adapters.
-allowed-adapters = ["claude-code", "kiro", "codex"]
+# RFC-0011 / pack-allowed-adapters. `kiro-ide` is the current name for
+# the Kiro harness (RFC-0022 split; bare `kiro` deprecated).
+allowed-adapters = ["claude-code", "kiro-ide", "codex"]

--- a/packs/credential-brokers/pack.toml
+++ b/packs/credential-brokers/pack.toml
@@ -9,5 +9,8 @@ version = "0.7"
 [pack.install]
 default-scope = "user"
 allowed-scopes = ["user", "repo"]
-# RFC-0011 / pack-allowed-adapters. RFC-0013 § 4 commits to these three.
-allowed-adapters = ["claude-code", "kiro", "codex"]
+# RFC-0011 / pack-allowed-adapters. RFC-0013 § 4 commits to these three
+# harnesses; `kiro-ide` is the current name for the Kiro harness
+# (RFC-0022 split; bare `kiro` deprecated). Stays three — adding copilot
+# would need an RFC-0013 erratum, out of scope for this rename.
+allowed-adapters = ["claude-code", "kiro-ide", "codex"]

--- a/packs/figma/pack.toml
+++ b/packs/figma/pack.toml
@@ -9,5 +9,6 @@ version = "0.8"
 [pack.install]
 default-scope = "user"
 allowed-scopes = ["user", "repo"]
-# RFC-0011 / pack-allowed-adapters.
-allowed-adapters = ["claude-code", "kiro", "codex"]
+# RFC-0011 / pack-allowed-adapters. `kiro-ide` is the current name for
+# the Kiro harness (RFC-0022 split; bare `kiro` deprecated).
+allowed-adapters = ["claude-code", "kiro-ide", "codex"]

--- a/packs/research/pack.toml
+++ b/packs/research/pack.toml
@@ -13,7 +13,8 @@ version = "0.10"
 default-scope = "user"
 allowed-scopes = ["user", "repo"]
 # RFC-0011 / pack-allowed-adapters; copilot added by RFC-0024 / copilot-full-parity.
-allowed-adapters = ["claude-code", "kiro", "codex", "copilot"]
+# `kiro-ide` is the current name for the Kiro harness (RFC-0022 split; bare `kiro` deprecated).
+allowed-adapters = ["claude-code", "kiro-ide", "codex", "copilot"]
 
 # Copilot projection caveat (RFC-0024 / docs/specs/copilot-full-parity §
 # Success for the read-only subagents): the `evidence-retriever` and


### PR DESCRIPTION
## Summary

Follow-up sweep to #249 (which fixed `architect`). PR #249's review found this was **systemic**: six other user-scope packs carried the deprecated bare `kiro` alias in `allowed-adapters` (RFC-0022 renamed `kiro` → `kiro-ide` / `kiro-cli`). You approved the sweep across all 7.

**The live bug** (same as architect): a Kiro user's `~/.kiro/` auto-probe resolves to `kiro-ide`, which these packs didn't list — so auto-detected `agentbundle install` refused.

## Changes (6 packs)

| Pack | Before | After |
|---|---|---|
| atlassian, contracts, converters, figma | `["claude-code", "kiro", "codex"]` | `["claude-code", "kiro-ide", "codex"]` |
| credential-brokers | `["claude-code", "kiro", "codex"]` | `["claude-code", "kiro-ide", "codex"]` (stays three) |
| research | `["claude-code", "kiro", "codex", "copilot"]` | `["claude-code", "kiro-ide", "codex", "copilot"]` (keeps copilot) |

## Decisions (all cleared by adversarial review)

- **No contract-version bumps.** Unlike architect (which bumped 0.6→0.10 because it *added* copilot — a v0.10 user-scope-skill capability), this is a pure **rename**: `kiro-ide` is the current name for the same `.kiro/skills/` projection, not a new capability. The resolver/validator check adapters against the *bundled* contract, not the pack's declared version. Verified empirically: `kiro-ide` validates + installs on a contract-0.8 pack with no bump. Keeping versions unchanged also keeps the v0.7/v0.8-declarations tests green.
- **credential-brokers stays three** — RFC-0013 § 4 commits to three harnesses; `kiro-ide` is just the current spelling of the Kiro harness, so the de-stale doesn't touch the commitment. Adding copilot there would need an RFC-0013 erratum (out of scope).
- **`--adapter kiro` now refuses** for these packs (bare alias dropped, no normalization) — accepted, same as architect; the override test moved to `--adapter kiro-ide`.
- **copilot-addition deferred per-pack.** architect got copilot (verified, pure-reasoning skills). The credentialed/script packs (atlassian, figma, converters, contracts) shell out to CLIs whose copilot runtime is unverified, so claiming copilot there is a capability assertion I won't make mechanically — a separate verified follow-up if you want it. research keeps its existing (RFC-0024) copilot.

## Test updates

Updated only the 4 test files that assert against the **real modified packs** (they copy real pack.tomls as fixtures and asserted resolution to `"kiro"`). Synthetic-fixture tests that use `kiro` as a generic, still-valid adapter name are **untouched** — `kiro` remains a valid (deprecated) adapter in the contract. No assertion was gutted; each is a faithful rename.

## Verification

- `validate` exit 0 per pack; all six auto-resolve a `~/.kiro/` home to `kiro-ide`; no bare `kiro` left in any pack.
- Rebased onto current main (PR #248 / credbroker T7 landed during this work; no file overlap — clean rebase). **Gates re-run on the post-#248 tree:** `make build-check` exit 0, `tools/lint-agents-md.py` passed, **1783 package tests pass**.

Closes the systemic `kiro` de-stale across the catalogue's user-scope packs.