### PR TITLE
feat(credbroker): T2 — release-credbroker.yml builds+smokes the wheel (publish gated)

### DIFF
--- a/.github/workflows/release-credbroker.yml
+++ b/.github/workflows/release-credbroker.yml
@@ -1,0 +1,164 @@
+name: release-credbroker
+
+on:
+  push:
+    tags:
+      - 'credbroker-v*'
+  pull_request:
+    paths:
+      - 'packages/credbroker/**'
+      - '.github/workflows/release-credbroker.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-credbroker-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Assert tag matches pyproject version
+        if: github.ref_type == 'tag'
+        run: |
+          python3 - <<'PY'
+          import os, re, sys, tomllib
+          tag = os.environ["GITHUB_REF_NAME"]
+          m = re.fullmatch(r"credbroker-v(\d+\.\d+\.\d+)", tag)
+          if not m:
+              print(f"::error::tag {tag!r} does not match credbroker-vX.Y.Z (pre-release / build-metadata suffixes refused by this spec)", file=sys.stderr)
+              sys.exit(1)
+          tag_ver = m.group(1)
+          with open("packages/credbroker/pyproject.toml", "rb") as f:
+              pp_ver = tomllib.load(f)["project"]["version"]
+          if tag_ver != pp_ver:
+              print(f"::error::tag {tag} declares version {tag_ver} but pyproject.toml has {pp_ver}", file=sys.stderr)
+              sys.exit(1)
+          PY
+
+      - name: Assert tag is on main
+        if: github.ref_type == 'tag'
+        run: |
+          git fetch --quiet origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::tag ${GITHUB_REF_NAME} points to ${GITHUB_SHA} which is not an ancestor of origin/main; refusing to publish (publish only from main)" >&2
+            exit 1
+          fi
+
+      - name: Install build + twine
+        run: python3 -m pip install --upgrade build twine
+
+      - name: Build wheel + sdist
+        working-directory: packages/credbroker
+        run: python3 -m build
+
+      - name: twine check
+        run: python3 -m twine check packages/credbroker/dist/*
+
+      - name: Smoke — install base wheel into a fresh venv and import credbroker
+        run: |
+          python3 -m venv /tmp/smoke-base
+          /tmp/smoke-base/bin/pip install --quiet packages/credbroker/dist/*.whl
+          /tmp/smoke-base/bin/python - <<'PY'
+          import credbroker
+          from credbroker import crypto_available, load_credentials  # noqa: F401
+          assert credbroker.__version__, "credbroker.__version__ is missing"
+          assert crypto_available() is False, "base wheel must not pull the [crypto] extra"
+          print(f"base import OK: credbroker {credbroker.__version__}, crypto_available={crypto_available()}")
+          PY
+
+      - name: Smoke — add the [crypto] extra into a fresh venv and import credbroker
+        run: |
+          python3 -m venv /tmp/smoke-crypto
+          /tmp/smoke-crypto/bin/pip install --quiet packages/credbroker/dist/*.whl
+          # credbroker is already satisfied by the local wheel, so this reaches
+          # PyPI only for the extra's deps (cryptography, argon2-cffi), never for
+          # credbroker itself.
+          /tmp/smoke-crypto/bin/pip install --quiet "credbroker[crypto]"
+          /tmp/smoke-crypto/bin/python - <<'PY'
+          import credbroker
+          from credbroker import crypto_available
+          assert crypto_available() is True, "[crypto] extra must make cryptography + argon2 importable"
+          print(f"[crypto] import OK: credbroker {credbroker.__version__}, crypto_available={crypto_available()}")
+          PY
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: packages/credbroker/dist/
+          if-no-files-found: error
+
+  # Gated: runs only on a `credbroker-v*` tag push (a manual maintainer
+  # action), never on merge or pull_request. The first real publish + PyPI
+  # name claim is the maintainer's call (RFC-0023 name-registration decision).
+  publish-pypi:
+    needs: [build-and-smoke]
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+
+  # Gated identically to publish-pypi. Uploads the same artifact to a corporate
+  # internal index when ARTIFACTORY_* secrets are configured; skips cleanly
+  # (no failure) when they are absent, so forks and unconfigured repos are fine.
+  publish-artifactory:
+    needs: [build-and-smoke]
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    steps:
+      - id: guard
+        name: Check Artifactory secret presence
+        env:
+          ART_URL: ${{ secrets.ARTIFACTORY_URL }}
+          ART_USER: ${{ secrets.ARTIFACTORY_USER }}
+          ART_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
+        run: |
+          if [ -n "$ART_TOKEN" ] && [ -n "$ART_URL" ] && [ -n "$ART_USER" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          elif [ -n "$ART_TOKEN" ] || [ -n "$ART_URL" ] || [ -n "$ART_USER" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Artifactory secrets partially configured (one of ARTIFACTORY_URL/USER/TOKEN is empty); refusing to publish to avoid sending credentials to a default endpoint."
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Artifactory secrets not set; skipping Artifactory publish."
+          fi
+
+      - if: steps.guard.outputs.configured == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - if: steps.guard.outputs.configured == 'true'
+        name: Install twine
+        run: python3 -m pip install --upgrade twine
+
+      - if: steps.guard.outputs.configured == 'true'
+        name: Upload to Artifactory
+        env:
+          TWINE_REPOSITORY_URL: ${{ secrets.ARTIFACTORY_URL }}
+          TWINE_USERNAME: ${{ secrets.ARTIFACTORY_USER }}
+          TWINE_PASSWORD: ${{ secrets.ARTIFACTORY_TOKEN }}
+        run: python3 -m twine upload dist/*

--- a/docs/guides/how-to/add-a-credentialed-skill.md
+++ b/docs/guides/how-to/add-a-credentialed-skill.md
@@ -287,7 +287,29 @@ credbroker
 python -m pip install -r requirements.txt
 ```
 
-[RFC-0023](../../rfc/0023-credential-manager-broker.md) replaced the build-projected `credentials_shim` sibling with the pip-installable `credbroker` library, imported in-process — so there is no `make build-self` projection step for the resolver, and no `scripts/`-vendored shim to keep in sync. Without the dependency installed, `from credbroker import …` fails with `ModuleNotFoundError: credbroker`. (Phase 1 installs from the repo path, `pip install -e ./packages/credbroker`; a future Phase 2 publishes `credbroker` to PyPI.)
+[RFC-0023](../../rfc/0023-credential-manager-broker.md) replaced the build-projected `credentials_shim` sibling with the pip-installable `credbroker` library, imported in-process — so there is no `make build-self` projection step for the resolver, and no `scripts/`-vendored shim to keep in sync. Without the dependency installed, `from credbroker import …` fails with `ModuleNotFoundError: credbroker`. For local development, install from the repo path: `pip install -e ./packages/credbroker`. For locked-down sites, see *Installing without PyPI (corporate)* just below.
+
+### Installing without PyPI (corporate)
+
+`credbroker` does **not** require PyPI. The [`release-credbroker`](../../../.github/workflows/release-credbroker.yml) workflow builds a platform-independent wheel (`credbroker-<version>-py3-none-any.whl`) and an sdist on every change to the package and validates them with `twine check`, so a locked-down or air-gapped site can install from a wheel it hosts or copies in:
+
+- **From an internal package index** (Artifactory, Nexus, a private mirror):
+
+  ```bash
+  pip install credbroker --index-url https://pypi.example.corp/simple
+  pip install "credbroker[crypto]" --index-url https://pypi.example.corp/simple   # + encrypted-at-rest vault
+  ```
+
+- **From a local `.whl`**:
+
+  ```bash
+  pip install ./credbroker-<version>-py3-none-any.whl
+  pip install "./credbroker-<version>-py3-none-any.whl[crypto]"                    # + encrypted-at-rest vault
+  ```
+
+The base wheel has no third-party dependency, so its local-`.whl` install is the only truly network-free path. The `[crypto]` extra additionally needs `cryptography` and `argon2-cffi` to be resolvable — from the same internal index, or pre-staged alongside the wheel — so on a fully air-gapped host stage those two first.
+
+Either way pip lands the package in site-packages, so the resolver imports exactly as the worked example above — no code change. Publishing to public PyPI is wired into the same workflow behind a **gated, tag-triggered** job, so `pip install credbroker` from public PyPI is a maintainer action that has not happened yet; the internal-index and local-wheel paths above need no PyPI.
 
 ## Step 10 — Set up the credential
 


### PR DESCRIPTION
## What does this change?

Adds `.github/workflows/release-credbroker.yml` — a release workflow that builds, validates, and smoke-imports the `credbroker` wheel/sdist on every PR touching the package, with OIDC PyPI + Artifactory publish jobs gated to manual tag pushes. Documents the corporate no-PyPI install path (internal index / local `.whl`) in the credentialed-skill how-to guide.

## Why?

- Implements: `docs/specs/credbroker-user-scope/plan.md` § **T2** (the foundation that unlocks the layer-2 corporate-pip and layer-3 PyPI delivery — once a wheel exists, a corporate site can `pip install` it with no PyPI and no new install machinery).
- Satisfies the spec's layer-2 (corporate) and layer-3 (PyPI) acceptance criteria: a release workflow builds+validates the wheel and is wired for OIDC Trusted Publishing, **gated** so the first publish + name claim is a maintainer action, not automatic on merge; and the corporate no-PyPI install is documented in the guide.
- Mirrors the established `release-agentbundle.yml` (the spec's named model to follow), including the secret-guarded Artifactory job — the CI side of the internal-index corporate path.

## How do I verify it?

Locally (all green):
\`\`\`bash
actionlint .github/workflows/release-credbroker.yml
python3 -m build ./packages/credbroker            # -> credbroker-0.1.0-py3-none-any.whl + sdist
python3 -m twine check packages/credbroker/dist/*
# base smoke: install wheel in a fresh venv -> import credbroker; crypto_available() is False
# [crypto] smoke: pip install "credbroker[crypto]" -> crypto_available() is True
\`\`\`
In CI: the `build-and-smoke` job runs on this PR (the `pull_request` paths include the workflow file) and goes green; `publish-pypi` / `publish-artifactory` are skipped (`if: github.ref_type == 'tag'` is false on a PR), proving they do not run on merge.

## What did you not change that you considered?

- **Did not flip the spec to Shipped / check ACs** — `credbroker-user-scope` is a multi-task spec; close-out is T5 (as T1/#254 did). The spec stays `Draft`.
- **Did not document the vendored `~/.agentbundle/lib` floor** — that's layer-1 (T3/T4), not yet shipped; the guide edit is scoped to the no-PyPI corporate wheel install only, to avoid documenting an unshipped path.
- **Did not add `workflow_dispatch`** — a `credbroker-v*` tag push is the manual maintainer trigger, matching the `release-agentbundle.yml` posture exactly.

## Reviewers

- `adversarial-reviewer`: clean (after two wording fixes — `[crypto]` smoke comment + guide network-caveat accuracy).
- `security-reviewer`: **Clean** — least-privilege `contents: read`, `id-token: write` scoped to `publish-pypi` only, no pwn-request path (`pull_request`, not `pull_request_target`; publishes gated off PR), tag-gating sound (version + main-ancestry guards in the needed build job), no secret reaches logs.

## Deferred

- SHA-pinning third-party actions (`@v4`, `@release/v1`): a standing hardening item that spans this workflow **and** `release-agentbundle.yml` — fix both or neither, so out of this PR's scope.
- The `pypi` GitHub **Environment** protection rule (required reviewer) is repo settings, not in-tree — surfaced for the maintainer as the human checkpoint before any OIDC publish.

## Checklist

- [x] Lint passes locally (`actionlint`, `make lint-packs`)
- [x] Self-review run via `adversarial-reviewer` + `security-reviewer`; blockers addressed
- [x] Spec and code agree (spec close-out deferred to T5 per the multi-task plan)
- [x] Living docs match reality (the credentialed-skill how-to guide updated)
- [x] No new top-level directories
- [x] Conventional commit format