### PR TITLE
feat(credbroker): T4 — install-time user-scope delivery rail (lib floor + sso-broker bin)

### DIFF
--- a/.github/workflows/build-check-windows.yml
+++ b/.github/workflows/build-check-windows.yml
@@ -117,6 +117,15 @@ jobs:
         working-directory: packages/agentbundle
         run: python -m pytest agentbundle/build/tests/test_user_libs_projection.py
 
+      # credbroker-user-scope T4: prove the user-scope install delivers the
+      # floor + sso-broker rail and a real consumer resolves `import credbroker`
+      # from `~/.agentbundle/lib` on Windows too. The lib floor must be
+      # importable cross-platform (the layer-1 resolution AC asserts on Windows
+      # CI); the POSIX-only mode-bit + chmod-refusal tests self-skip here.
+      - name: pytest user-scope floor delivery (credbroker-user-scope T4)
+        working-directory: packages/agentbundle
+        run: python -m pytest tests/integration/test_credential_brokers_pack_install.py
+
       - name: pytest hook parity-net suite (windows-hooks-phase3)
         working-directory: packages/agentbundle
         run: python -m pytest tests/hooks/

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -363,6 +363,32 @@ via Trusted Publishing (OIDC)**, modelled on `release-agentbundle.yml`; the
 `release-credbroker.yml` workflow + the PyPI pending-publisher config are Phase-2
 artifacts, created when the publish is ready, not now.
 
+## `credbroker-user-scope`
+
+Open follow-ons surfaced during T4 (install-time user-scope delivery rail) review:
+
+### floor-delivery-graceful-skip-on-missing-prefix
+The T4 floor delivery writes under `.agentbundle/` via `safety.write_jailed`, which
+relies on the resolved user adapter's `allowed-prefixes.user` containing `.agentbundle/`.
+Every shipped adapter declares it, so this is unreachable today; but a future adapter
+added without `.agentbundle/` in its user prefixes would make the floor `write_jailed`
+raise `PathJailError` and **hard-abort the whole install** rather than skip the floor
+rail. Follow-on: have `_deliver_user_scope_floor` detect a prefix list lacking
+`.agentbundle/` and skip the rail with a stderr note (graceful degrade), or add
+`.agentbundle/` to `_adapter_allowed_prefixes_user`'s defensive fallback. Deferred:
+no second caller exists, and adding speculative degradation now is scaffolding for a
+hypothetical adapter.
+
+### floor-reference-counting-on-uninstall
+The vendored floor (`~/.agentbundle/lib/credbroker/`) and the `sso-broker` bin scripts
+are shared, idempotent infrastructure, so T4 deliberately does **not** record them in
+any pack's `state.files` — uninstalling one credentialed pack must not strip a
+co-installed pack's floor. The consequence: uninstalling the *last* credentialed pack
+leaves the executable `~/.agentbundle/bin/sso-broker.py` (0o755) and the importable
+floor behind indefinitely (owner-owned, mode-correct — no exploit on its own, but a
+latent stale broker). Follow-on: a reference-counted `uninstall` that removes the floor
+only when no credentialed pack remains. Deferred: out of T4's delivery scope.
+
 ## `copilot-full-parity`
 
 Shipped 2026-06-05 (RFC-0024 / ADR-0013 → [`docs/specs/copilot-full-parity/spec.md`](specs/copilot-full-parity/spec.md)):

--- a/docs/specs/credbroker-user-scope/plan.md
+++ b/docs/specs/credbroker-user-scope/plan.md
@@ -1,7 +1,7 @@
 # Plan: credbroker-user-scope
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Drafting <!-- Drafting | Executing | Done -->
+- **Status:** Executing <!-- Drafting | Executing | Done -->
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
 > document is allowed to change as you learn. When it changes substantially
@@ -228,4 +228,41 @@ The on-disk + import contract (spec's `Contract: none` — specified here):
 - 2026-06-09: initial plan. Layered delivery (foundation+wheel → vendored floor → PyPI) in cost/value order; install-time `.agentbundle/` delivery rail is the net-new machinery and also closes the latent `sso-broker` user-scope gap. Premise correction vs. the original framing: the `~/.agentbundle/bin/` user-scope rail does **not** exist today (probe-confirmed) — it is built here, not mirrored.
 - 2026-06-09: spec-mode adversarial review fixes. T1 split into two shapes (5 CLIs append in their bootstrap; `setup.py` has no bootstrap + a top-level `from credbroker import`, so the floor-append is prepended before it) + parametric precedence test + no-insert-0 guard. T3 made the contract-primitive registration explicit (the `[primitive."user-libs"]` declaration + `_PACK_PRIMITIVE_TYPES`/validator ripple + the contract-bump-trap full-pytest, anchored on the `adapter-root-bins`/`shared-libs` build-only precedent). T4 reuses `adapter_root_bins.compute_projections` so the AC22b companion shim rides the `bin/` delivery (a bare glob would miss it), `lib/` written default-mode vs `bin/` `0o755`, + Windows importability. Catalogue risk downgraded (`build/main.py` copytrees the whole `.apm/`). Recorded the floor as *additive* (ADR-0003 posture unchanged — no new ADR).
 - 2026-06-09: T1 implemented. The precedence construction test is split by import shape: a deps-free **source/AST guard parametric across all 6** scripts (append-not-insert-0 + placement — the precedence mechanism + no-insert-0 Never-do) plus a **behavioral `credbroker.__file__`** check on the one eager, deps-free importer (`setup.py`); the five API CLIs import `credbroker` lazily (inside an `httpx`-gated verb), so their end-to-end floor resolution through a real consumer is deferred to T4's integration test. Implemented with `Path(...).expanduser()` (no new `import os`; `Path`/`pathlib` already imported in every file). Test lives at `packages/agentbundle/tests/integration/test_credbroker_floor_precedence.py` and is wired into `build-check.yml` (the no-insert-0 guard is platform-agnostic, so the Linux job gates it).
+- 2026-06-09: T4 implemented. The install-time user-scope delivery rail lands in
+  `install.py` Step 9, gated `plan.scope == "user"`: it delivers the pack's
+  `.apm/user-libs/**` → `~/.agentbundle/lib/**` (default mode, no exec bit) and
+  the `.apm/adapter-root-bins/*.py` + AC22b companion `credentials_shim.py` →
+  `~/.agentbundle/bin/**` (`0o755` on POSIX, DACL-inherited on Windows), all via
+  `safety.write_jailed(scope="user", …)` under the existing `.agentbundle/`
+  prefix (no jail change). Per the pass-2 concern, the companion-aware
+  enumeration is a **new single-`pack_dir`-scoped helper**
+  `adapter_root_bins.collect_pack_root_bins(pack_dir)` (reuses the ship-both
+  opt-in against one resolved catalogue pack) rather than the multi-pack,
+  working-tree-folding `compute_projections`. The floor is **shared, idempotent
+  infrastructure** (one copy per consumer), so the delivered files are
+  deliberately **not** recorded in `state.files` — uninstalling one pack must not
+  strip a co-installed pack's floor. Security mitigation (carried from T1's
+  review): `_assert_user_floor_dirs_safe` refuses on entry if `~/.agentbundle`,
+  `…/lib`, or `…/bin` already exists group/world-writable (a writable floor is a
+  local code-exec vector), and `_harden_floor_dir_modes` strips group/world
+  write bits from the delivered dirs after write (defends a permissive umask);
+  both no-op on Windows. The load-bearing end-to-end CLI test (`jira.py check`
+  under `-S` + a stub `httpx`) proves a real API CLI resolves `import credbroker`
+  from the floor and reaches the env→keyring→dotfile ladder (exit 2,
+  `CredentialsMissingError`); `setup.py --help` under `-S` covers the eager
+  importer; both run in `build-check-windows.yml` for cross-platform
+  importability. No state-recording, no contract bump (delivery only).
+  Post-implementation review (adversarial + security) hardened three things:
+  the floor-safety refusal is gated to packs that actually ship floor content
+  (a floor-less user install is never refused) and walks the full existing
+  `.agentbundle` tree (catches a pre-existing loose *leaf*); and — since
+  `install` resolves `pack_dir` from an *untrusted* catalogue — both delivery
+  halves reject symlinked sources (per-file `is_symlink()` skip +
+  `os.walk(followlinks=False)`) **and** a symlinked primitive *directory*
+  itself, so a crafted pack can't read an out-of-tree file
+  (`/etc/passwd`, `~/.ssh/id_rsa`) into the floor (the build-pipeline twin
+  on the trusted in-repo `packs/` intentionally doesn't filter). Two
+  follow-ons deferred to `docs/backlog.md` § `credbroker-user-scope`:
+  graceful floor-skip if a future adapter omits `.agentbundle/` from its
+  user prefixes, and reference-counted floor removal on uninstall.
 - 2026-06-09: T3 implemented. `agentbundle/build/user_libs.py` projects `packages/credbroker/credbroker/` byte-faithfully to **two** committed targets from one source: the catalogue-visible pack copy (`packs/credential-brokers/.apm/user-libs/credbroker/`, which `build/main.py` copytrees into each dist pack for T4) and the self-host floor staging (`<repo>/.agentbundle/lib/credbroker/`, mirroring the committed `.agentbundle/bin/`). `lib/` is written default-mode (no exec bit, unlike `bin/`'s `0o755`); the orphan scan skips `__pycache__`/`tests` so importing the floor (the purity test) can't masquerade as drift. Wired into `self_host.py` apply + `run_build_check_drift_gates`. **Version decision: no bump.** The `adapter-root-bins`/`shared-libs` precedent (#139, `de790fe`) added build-pipeline-only primitives — no per-adapter projection rules — *within* v0.7, not as a dedicated bump; `user-libs` is the same shape, so `[contract] version` stays `0.10`, the `test_contract.py` pin and marketplace aggregation are untouched, and the (primitive × adapter) pair count stays 20 (locked by a new `test_user_libs_is_build_pipeline_only`). `[primitive."user-libs"]` declared in both byte-identical `adapter.toml` copies; `"user-libs"` added to `safety.py:_PACK_PRIMITIVE_TYPES`. **Source-location call:** `user_libs` derives its source from `packs_dir.parent` and **no-ops when the package source is absent** (non-monorepo / fixture-packs invocations), so the existing install-marker drift-gate tests stay green; real `make build-check` (where `packs_dir.parent` is the repo root) gates fully. Full `packages/agentbundle` pytest run by hand per the contract-bump trap — no version-pin or stale-assertion breakage.

--- a/docs/specs/credbroker-user-scope/spec.md
+++ b/docs/specs/credbroker-user-scope/spec.md
@@ -1,6 +1,6 @@
 # Spec: credbroker-user-scope
 
-- **Status:** Draft <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Status:** Implementing <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** [RFC-0023](../../rfc/0023-credential-manager-broker.md) — **amends** it (an Approver-signed amendment recorded in the RFC): RFC-0023 chose pip over the vendored shim and deferred no-repo adopters to Phase-2 PyPI; this spec adds a **layered delivery model** (vendored floor → offline/local pip → PyPI) so user-scope/air-gapped corporate installs resolve credentials without PyPI. Completes the user-scope half of [RFC-0013](../../rfc/0013-credential-broker-contract.md)'s `~/.agentbundle/bin/` delivery (the `sso-broker` companion), which only ever shipped its self-host half. Builds on [`credbroker`](../credbroker/spec.md) (Shipped) and the projection retirement (T9/T10).

--- a/packages/agentbundle/agentbundle/build/adapter_root_bins.py
+++ b/packages/agentbundle/agentbundle/build/adapter_root_bins.py
@@ -189,6 +189,60 @@ def collect_companion_shim(packs_dir: Path) -> dict[str, Path]:
     return {}
 
 
+def collect_pack_root_bins(pack_dir: Path) -> dict[str, Path]:
+    """Single-pack, companion-aware enumeration for install-time delivery.
+
+    Returns ``{basename → source_path}`` for one already-resolved
+    catalogue ``pack_dir``'s ``.apm/adapter-root-bins/*.py`` plus the AC22b
+    companion ``credentials_shim.py`` when the pack ships BOTH that
+    directory (at least one ``*.py``) AND
+    ``.apm/shared-libs/credentials_shim.py`` — the same ship-both opt-in as
+    :func:`collect_companion_shim`, scoped to one pack.
+
+    Why not :func:`compute_projections` / :func:`collect_sources`? Those
+    walk a multi-pack build-time ``packs/`` root and fold a ``working_tree``
+    target into each pair. ``agentbundle install`` operates on a single
+    resolved catalogue ``pack_dir`` and owns its own per-scope path-jail, so
+    it needs basenames + sources for one pack, not absolute targets under a
+    build tree (credbroker-user-scope plan T4 — the install-side seam). The
+    install caller composes ``.agentbundle/bin/<basename>`` relpaths from
+    :data:`TARGET_SUBDIR` and writes via ``safety.write_jailed`` with POSIX
+    :data:`EXECUTABLE_MODE`.
+
+    A bare ``adapter-root-bins/*.py`` glob would miss the companion and land
+    the per-platform Tier-2 backends (``_sso_keychain_macos.py`` etc.)
+    broken on macOS/Windows — they import ``Tier2HardFailError`` from the
+    shim. This helper carries it for exactly the ship-both case.
+
+    The ship-both opt-in here is the single-pack twin of
+    :func:`collect_companion_shim` (the multi-pack, ``packs/``-walking
+    enumeration). The two predicates are intentionally parallel — a change to
+    the opt-in rule must update both.
+    """
+    # Skip symlinks: install resolves ``pack_dir`` from an untrusted catalogue
+    # (a downloaded archive / git checkout), and these bytes land executable
+    # (``0o755``) under ``~/.agentbundle/bin/``. A symlinked ``*.py`` pointing
+    # out of tree (e.g. ``~/.ssh/id_rsa``) would otherwise read that content
+    # into the floor. The build-pipeline ``collect_sources`` twin operates on
+    # the trusted in-repo ``packs/`` and intentionally does not filter.
+    bins_dir = pack_dir / SOURCE_SUBDIR
+    # A symlinked primitive *directory* would let glob enumerate the link
+    # target's real (non-symlink) files, smuggling out-of-tree content in.
+    if not bins_dir.is_dir() or bins_dir.is_symlink():
+        return {}
+    sources: dict[str, Path] = {
+        src.name: src
+        for src in sorted(bins_dir.glob("*.py"))
+        if src.is_file() and not src.is_symlink()
+    }
+    if not sources:
+        return {}
+    shim_source = pack_dir / shared_libs.SOURCE_SUBDIR / SHIM_COMPANION_BASENAME
+    if shim_source.is_file() and not shim_source.is_symlink():
+        sources[SHIM_COMPANION_BASENAME] = shim_source
+    return sources
+
+
 def compute_projections(
     working_tree: Path, packs_dir: Path
 ) -> list[AdapterRootBinProjection]:

--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_root_bins_projection.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_root_bins_projection.py
@@ -425,5 +425,66 @@ class AdapterRootBinsShimCompanionTests(unittest.TestCase):
         self.assertEqual(target.read_bytes(), source.read_bytes())
 
 
+class CollectPackRootBinsTests(unittest.TestCase):
+    """credbroker-user-scope T4: the single-pack, companion-aware
+    enumeration `agentbundle install` uses (it owns its own scope jail and
+    can't call the multi-pack, working-tree-folding `compute_projections`)."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tmp_path = Path(self._tmp.name)
+
+    def test_empty_when_pack_ships_no_adapter_root_bins(self) -> None:
+        pack = _make_fixture_pack(self.tmp_path / "packs", "no-bins", bins={})
+        self.assertEqual(arb.collect_pack_root_bins(pack), {})
+
+    def test_bins_without_companion_when_no_shim_shipped(self) -> None:
+        pack = _make_fixture_pack(
+            self.tmp_path / "packs", "bins-only", bins={"sso-broker.py": b"x\n"}
+        )
+        got = arb.collect_pack_root_bins(pack)
+        self.assertEqual(set(got), {"sso-broker.py"})
+
+    def test_includes_companion_shim_on_ship_both(self) -> None:
+        # Ship both adapter-root-bins/ AND shared-libs/credentials_shim.py →
+        # the companion rides along (a bare glob would miss it, landing the
+        # _sso_* backends' `from .credentials_shim import` broken).
+        pack = _make_fixture_pack(
+            self.tmp_path / "packs",
+            "both",
+            bins={
+                "sso-broker.py": b"a\n",
+                "_sso_keychain_macos.py": b"from .credentials_shim import X\n",
+            },
+            shared_libs={"credentials_shim.py": b"shim\n"},
+        )
+        got = arb.collect_pack_root_bins(pack)
+        self.assertEqual(
+            set(got),
+            {"sso-broker.py", "_sso_keychain_macos.py", "credentials_shim.py"},
+        )
+        self.assertEqual(
+            got["credentials_shim.py"],
+            pack / ".apm" / "shared-libs" / "credentials_shim.py",
+        )
+
+    def test_skips_symlinked_bin_source(self) -> None:
+        # install resolves pack_dir from an untrusted catalogue and lands these
+        # bytes executable — a symlinked *.py pointing out of tree must not be
+        # read into the floor.
+        if os.name != "posix":
+            self.skipTest("symlink creation needs privilege on Windows")
+        secret = self.tmp_path / "secret.txt"
+        secret.write_bytes(b"SECRET\n")
+        pack = _make_fixture_pack(
+            self.tmp_path / "packs", "sneaky", bins={"sso-broker.py": b"ok\n"}
+        )
+        link = pack / ".apm" / "adapter-root-bins" / "evil.py"
+        link.symlink_to(secret)
+        got = arb.collect_pack_root_bins(pack)
+        self.assertEqual(set(got), {"sso-broker.py"}, "symlinked bin must be skipped")
+
+
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()

--- a/packages/agentbundle/agentbundle/commands/install.py
+++ b/packages/agentbundle/agentbundle/commands/install.py
@@ -28,6 +28,7 @@ both scope roots use :func:`_classify_for_install`. Writes go through
 from __future__ import annotations
 
 import functools
+import os
 import re
 import sys
 import tomllib
@@ -831,6 +832,33 @@ def run(args: "argparse.Namespace") -> int:
                 "from-pack-version": pack_version,
             }
 
+        # ── User-scope `.agentbundle/{lib,bin}/` delivery rail ────────────
+        # (credbroker-user-scope T4) The vendored `credbroker` floor
+        # (`.apm/user-libs/**` → `~/.agentbundle/lib/`) and the
+        # `adapter-root-bins/*.py` + AC22b companion shim
+        # (`~/.agentbundle/bin/`) are build-pipeline-only primitives with no
+        # per-adapter projection rule, so the Step-7 render never emits them;
+        # this is the install-time half of the same `.agentbundle/` rail the
+        # build pipeline projects at self-host scope. Fenced by the user
+        # adapter's `allowed-prefixes.user` (every one includes
+        # `.agentbundle/`), so `write_jailed` admits the writes without a jail
+        # change. Pure file projection — no pip, no credential value touched
+        # (RFC-0006 no-leak). Skipped at repo scope (the floor is a user-scope
+        # `sys.path` fallback; repo consumers run from the monorepo).
+        if plan.scope == "user":
+            try:
+                floor_refusal = _deliver_user_scope_floor(
+                    pack_dir=pack_dir,
+                    root=plan.root,
+                    allowed_prefixes=plan.allowed_prefixes,
+                )
+            except (OSError, safety.PathJailError) as exc:
+                print(f"install: {exc}", file=sys.stderr)
+                return 1
+            if floor_refusal is not None:
+                print(f"install: {floor_refusal}", file=sys.stderr)
+                return 1
+
         # Deliver the pack's seeds (governance docs: AGENTS.md, docs/CHARTER.md,
         # …) into the repo at repo scope. Seeds land at the repo root / docs/,
         # outside the adapter projection prefixes, so they never interact with
@@ -1086,6 +1114,181 @@ def run(args: "argparse.Namespace") -> int:
             print(f"installed: {pack_name} @ {plan.scope}")
 
     return 0
+
+
+# ---------------------------------------------------------------------------
+# User-scope `.agentbundle/{lib,bin}/` delivery rail (credbroker-user-scope T4)
+# ---------------------------------------------------------------------------
+
+# Subtrees never delivered into the floor: bytecode caches and any in-package
+# test tree. Mirrors ``build.user_libs.EXCLUDED_DIR_NAMES`` so importing the
+# pack copy (which writes ``__pycache__/``) can't smuggle stale bytecode into
+# ``~/.agentbundle/lib/``.
+_USER_LIBS_EXCLUDED_DIR_NAMES = frozenset({"__pycache__", "tests"})
+
+
+def _assert_user_floor_dirs_safe(root: Path) -> str | None:
+    """POSIX guard: refuse delivery into a group/world-writable floor.
+
+    The vendored floor under ``~/.agentbundle/lib`` is appended to
+    ``sys.path`` at lowest precedence by every credentialed consumer
+    bootstrap (credbroker-user-scope T1), and ``~/.agentbundle/bin`` carries
+    executable broker scripts. A group/other-writable artifact dir is
+    therefore a local code-execution vector — another account could drop a
+    malicious ``credbroker/__init__.py`` or ``sso-broker.py`` that a consumer
+    then imports/runs. Delivery owns the floor's integrity (T1's bootstrap
+    relies on it), so refuse *before* writing if any existing artifact dir —
+    ``.agentbundle`` itself, ``lib/``/``bin/``, **and every leaf already under
+    them** (e.g. a pre-existing ``lib/credbroker/``) — carries a loose mode.
+    Walking the whole tree, not three fixed dirs, closes the
+    loose-leaf-passes-the-check gap; :func:`_harden_floor_dir_modes` only
+    repairs modes *after* a successful write.
+
+    Returns a refusal string, or ``None`` when safe. No-op on Windows: the
+    POSIX mode bits don't model the DACL the floor inherits from
+    ``%USERPROFILE%`` there.
+
+    TOCTOU: this is a check-then-write guard, so it assumes a single-user
+    ``$HOME`` (the floor's trust boundary). A world-loose ``$HOME`` shared
+    with a hostile local account can still race the window between this check
+    and the write — out of scope for the file-projection threat model.
+    """
+    if os.name != "posix":
+        return None
+    base = root / ".agentbundle"
+    candidates: list[Path] = [base]
+    for sub in (base / "lib", base / "bin"):
+        if sub.is_dir():
+            for dirpath, _dirnames, _filenames in os.walk(sub):
+                candidates.append(Path(dirpath))
+    for d in candidates:
+        if d.is_dir():
+            mode = os.stat(d).st_mode & 0o777
+            if mode & 0o022:
+                return (
+                    f"refusing user-scope delivery: {d} is group/world-writable "
+                    f"(mode {mode:#o}); a writable floor is a local "
+                    f"code-execution vector — run 'chmod go-w' on it and retry"
+                )
+    return None
+
+
+def _harden_floor_dir_modes(root: Path) -> None:
+    """Strip group/world *write* bits from the delivered floor dirs (POSIX).
+
+    ``write_jailed`` creates parent directories under the process umask; a
+    permissive umask (``002``/``000``) would otherwise leave
+    ``~/.agentbundle/{lib,bin}`` and their subdirs group/world-writable —
+    re-opening the code-execution vector :func:`_assert_user_floor_dirs_safe`
+    refuses on entry. Delivered *files* are already restrictive (``mkstemp``
+    creates ``0o600``; ``bin/`` is explicitly ``0o755``), so only directory
+    modes need hardening. No-op on Windows (DACL model).
+    """
+    if os.name != "posix":
+        return
+    base = root / ".agentbundle"
+    for d in (base, base / "lib", base / "bin"):
+        if not d.is_dir():
+            continue
+        for dirpath, _dirnames, _filenames in os.walk(d):
+            cur = os.stat(dirpath).st_mode & 0o777
+            if cur & 0o022:
+                os.chmod(dirpath, cur & ~0o022)
+
+
+def _deliver_user_scope_floor(
+    *,
+    pack_dir: Path,
+    root: Path,
+    allowed_prefixes: list[str] | None,
+) -> str | None:
+    """Deliver the user-scope ``.agentbundle/{lib,bin}/`` rail for one pack.
+
+    Two halves, both written through ``safety.write_jailed`` under the
+    user-scope path-jail (the target stays under ``.agentbundle/``, which
+    every user-scope adapter's ``allowed-prefixes.user`` already permits):
+
+    - **lib/** — the pack's ``.apm/user-libs/**`` vendored floor (e.g.
+      ``credbroker/``) → ``~/.agentbundle/lib/**``. Importable Python, written
+      with **default** mode (no exec bit). The consumer bootstraps append
+      ``~/.agentbundle/lib`` to ``sys.path`` at lowest precedence (T1), so a
+      no-repo user-scope install regains Tier-2/3 credential resolution.
+    - **bin/** — the pack's ``.apm/adapter-root-bins/*.py`` plus the AC22b
+      companion ``credentials_shim.py`` (ship-both) → ``~/.agentbundle/bin/``
+      with POSIX ``0o755`` (Windows inherits the parent DACL). Closes the
+      long-missing user-scope half of the RFC-0013 ``sso-broker`` delivery.
+
+    These are *shared, idempotent* floor artifacts — one copy serving every
+    credentialed consumer — not pack-private projected files, so they are
+    delivered on every fresh user-scope install and deliberately **not**
+    recorded in the pack's ``state.files``: uninstalling one pack must not
+    strip a co-installed pack's floor.
+
+    Returns a refusal string when the floor-safety guard fails (the caller
+    aborts the install), or ``None`` on success / when the pack ships no
+    floor content (then this is a no-op — a pack that writes nothing to the
+    floor never triggers the group/world-writable refusal).
+    """
+    from agentbundle import safety
+    from agentbundle.build import adapter_root_bins
+
+    bin_sources = adapter_root_bins.collect_pack_root_bins(pack_dir)
+    lib_src_root = pack_dir / ".apm" / "user-libs"
+    # Reject a symlinked primitive dir itself (os.walk(top=symlink) enumerates
+    # the link target's real files, which the per-entry is_symlink() skip below
+    # would not catch) — see collect_pack_root_bins for the bin/ twin.
+    has_lib = lib_src_root.is_dir() and not lib_src_root.is_symlink()
+    if not bin_sources and not has_lib:
+        # No floor content in this pack — nothing to deliver, and no reason to
+        # gate the install on the floor dirs' modes.
+        return None
+
+    floor_refusal = _assert_user_floor_dirs_safe(root)
+    if floor_refusal is not None:
+        return floor_refusal
+
+    # bin/ half — companion-aware, single-pack enumeration. 0o755 on POSIX.
+    bin_mode = adapter_root_bins.EXECUTABLE_MODE if os.name == "posix" else None
+    for basename, src in sorted(bin_sources.items()):
+        relpath = (adapter_root_bins.TARGET_SUBDIR / basename).as_posix()
+        safety.write_jailed(
+            root,
+            relpath,
+            src.read_bytes(),
+            mode=bin_mode,
+            scope="user",
+            allowed_prefixes=allowed_prefixes,
+        )
+
+    # lib/ half — the vendored floor, written default-mode (importable Python,
+    # no exec bit). Walk the pack's whole .apm/user-libs/** tree with
+    # followlinks=False and skip file symlinks: a crafted pack must not read an
+    # out-of-tree file (e.g. /etc/passwd) into the floor via a symlink (the
+    # write target can't escape the jail, but the *content* would). Matches the
+    # repo's os.walk(followlinks=False) convention for pack-content walks.
+    if has_lib:
+        for dirpath, dirnames, filenames in os.walk(lib_src_root, followlinks=False):
+            # Prune excluded subtrees in place (don't recurse into caches) and
+            # keep the walk deterministic.
+            dirnames[:] = sorted(
+                d for d in dirnames if d not in _USER_LIBS_EXCLUDED_DIR_NAMES
+            )
+            for fname in sorted(filenames):
+                src = Path(dirpath) / fname
+                if src.is_symlink():
+                    continue
+                rel = src.relative_to(lib_src_root)
+                relpath = (Path(".agentbundle") / "lib" / rel).as_posix()
+                safety.write_jailed(
+                    root,
+                    relpath,
+                    src.read_bytes(),
+                    scope="user",
+                    allowed_prefixes=allowed_prefixes,
+                )
+
+    _harden_floor_dir_modes(root)
+    return None
 
 
 _INBAND_DETECTION_SEEN: set[tuple[str, str]] = set()

--- a/packages/agentbundle/tests/integration/test_credential_brokers_pack_install.py
+++ b/packages/agentbundle/tests/integration/test_credential_brokers_pack_install.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import importlib.util
 import io
 import os
 import re
@@ -369,11 +370,12 @@ class UserScopeFloorDeliveryTests(_BaseInstall):
         # End-to-end (the LOAD-BEARING CLI case, plan T4 coverage note): the
         # five API CLIs import credbroker lazily inside an httpx-gated verb, so
         # T1 could only prove their precedence structurally. Here a real
-        # `jira.py check` — under `-S` (no site-packages credbroker) with a stub
-        # httpx so its `_client` import succeeds — reaches load_credentials,
-        # which imports credbroker from the floor and runs Tier-1→2→3
-        # resolution. No creds anywhere → CredentialsMissingError → AuthError →
-        # EXIT_USER_ACTION (2). Reaching exit 2 *requires* the floor import.
+        # `jira.py check` — with a stub httpx so its `_client` import succeeds —
+        # reaches load_credentials, which imports credbroker from the floor and
+        # runs Tier-1→2→3 resolution. No creds anywhere → CredentialsMissingError
+        # → AuthError → EXIT_USER_ACTION (2). Reaching exit 2 *and* emitting the
+        # Tier ladder *requires* the floor import (a vacuous exit-2 from a
+        # missing dependency would carry neither).
         self._install()
         entry = JIRA_SCRIPTS / "jira.py"
         if not entry.is_file():
@@ -381,8 +383,27 @@ class UserScopeFloorDeliveryTests(_BaseInstall):
         stub = self.tmp / "httpxstub"
         stub.mkdir()
         (stub / "httpx.py").write_text("# stub: import-only\n", encoding="utf-8")
+
+        # Make the floor the *only* credbroker. `-S` (no site-packages) does
+        # that — but only apply it when a credbroker is actually installed in
+        # this interpreter's site-packages: on Windows `-S` also breaks
+        # asyncio's `_overlapped` C-extension load (jira.py imports asyncio at
+        # module top), so the CLI can't run under `-S` there. CI never hits the
+        # bad combination — Linux build-check pip-installs credbroker (needs
+        # `-S`; asyncio is fine under `-S` on POSIX); Windows build-check does
+        # not (the floor is already the only credbroker, so no `-S` needed).
+        credbroker_in_site = importlib.util.find_spec("credbroker") is not None
+        if credbroker_in_site and os.name == "nt":
+            self.skipTest(
+                "credbroker installed on Windows: cannot hide it without -S, "
+                "which breaks asyncio import on Windows"
+            )
+        argv = [sys.executable]
+        if credbroker_in_site:
+            argv.append("-S")
+        argv += ["scripts/jira.py", "check"]
         proc = subprocess.run(
-            [sys.executable, "-S", "scripts/jira.py", "check"],
+            argv,
             cwd=str(JIRA_SCRIPTS.parent),
             capture_output=True,
             text=True,

--- a/packages/agentbundle/tests/integration/test_credential_brokers_pack_install.py
+++ b/packages/agentbundle/tests/integration/test_credential_brokers_pack_install.py
@@ -15,6 +15,7 @@ import io
 import os
 import re
 import shutil
+import subprocess
 import sys
 import tempfile
 import tomllib
@@ -24,6 +25,11 @@ from unittest.mock import patch
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 PACK_SRC = REPO_ROOT / "packs" / "credential-brokers"
+# credbroker-user-scope T4: a real API CLI (eager importer is setup.py, below)
+# whose floor resolution closes the lazy-import gap T1 could only prove
+# structurally. The atlassian pack ships it; skip if the checkout lacks it.
+JIRA_SCRIPTS = REPO_ROOT / "packs" / "atlassian" / ".apm" / "skills" / "jira" / "scripts"
+SETUP_SCRIPTS = PACK_SRC / ".apm" / "skills" / "credential-setup" / "scripts"
 
 
 def _run_install(args: argparse.Namespace) -> tuple[int, str, str]:
@@ -211,6 +217,199 @@ class SeedsRefusalRailTests(_BaseInstall):
         self.assertIn("seeds/", stderr)
         self.assertIn("user", stderr)
         self.assertIn("allowed-scopes", stderr)
+
+
+class UserScopeFloorDeliveryTests(_BaseInstall):
+    """credbroker-user-scope T4: a ``$HOME``-redirected user-scope install
+    delivers the vendored ``credbroker`` floor (``lib/``) **and** the
+    ``sso-broker`` rail (``bin/`` + the AC22b companion shim), and a real
+    consumer entry script resolves ``import credbroker`` from the floor.
+    """
+
+    def _install(self) -> tuple[str, str]:
+        args = argparse.Namespace(
+            pack="credential-brokers",
+            catalogue=str(self.cat),
+            output=str(self.repo),
+            scope="user",
+            force=False,
+            force_merge=False,
+        )
+        rc, stdout, stderr = _run_install(args)
+        self.assertEqual(
+            rc, 0, f"install --scope user failed: stdout={stdout!r} stderr={stderr!r}"
+        )
+        return stdout, stderr
+
+    def _clean_env(self, **extra: str) -> dict[str, str]:
+        """A minimal subprocess env: drop site-packages-leaking vars and any
+        ambient JIRA_* so the floor is the only ``credbroker`` and credentials
+        genuinely miss. ``HOME``/``USERPROFILE`` point at the install."""
+        keep = {"PATH", "SystemRoot", "TMPDIR", "TEMP", "TMP"}
+        env = {k: v for k, v in os.environ.items() if k in keep}
+        env["HOME"] = str(self.home)
+        env["USERPROFILE"] = str(self.home)
+        env.update(extra)
+        return env
+
+    def test_floor_lib_bin_and_companion_land(self) -> None:
+        # AC: floor-delivery + sso-broker half.
+        self._install()
+        lib = self.home / ".agentbundle" / "lib" / "credbroker"
+        for name in ("__init__.py", "_core.py", "_vault.py"):
+            self.assertTrue(
+                (lib / name).is_file(),
+                f"~/.agentbundle/lib/credbroker/{name} absent after install",
+            )
+        binp = self.home / ".agentbundle" / "bin"
+        # sso-broker.py + the AC22b companion shim + both _sso_* backends.
+        for name in (
+            "sso-broker.py",
+            "credentials_shim.py",
+            "_sso_keychain_macos.py",
+            "_sso_credman_windows.py",
+        ):
+            self.assertTrue(
+                (binp / name).is_file(),
+                f"~/.agentbundle/bin/{name} absent after install",
+            )
+
+    def test_lib_no_exec_bit_and_bin_is_0755(self) -> None:
+        # File-mode contract: lib/ default-mode (no exec bit), bin/ 0o755.
+        if os.name != "posix":
+            self.skipTest("POSIX mode bits; Windows inherits the parent DACL")
+        self._install()
+        init = self.home / ".agentbundle" / "lib" / "credbroker" / "__init__.py"
+        self.assertFalse(
+            init.stat().st_mode & 0o111,
+            "lib/ floor must carry no exec bit (importable Python, not a script)",
+        )
+        sso = self.home / ".agentbundle" / "bin" / "sso-broker.py"
+        self.assertEqual(
+            sso.stat().st_mode & 0o777, 0o755, "bin/*.py must be 0o755 on POSIX"
+        )
+
+    def test_delivery_stays_under_agentbundle_jail(self) -> None:
+        # Jail + no-leak: the floor/bin artifacts land ONLY under
+        # ~/.agentbundle/ — never leaked into the adapter projection dir or
+        # anywhere else under $HOME. write_jailed enforces the prefix; this
+        # asserts the delivery composed paths under it.
+        self._install()
+        artifact_root = self.home / ".agentbundle"
+        for needle in ("credbroker", "sso-broker", "credentials_shim"):
+            for hit in self.home.rglob(f"*{needle}*"):
+                self.assertTrue(
+                    artifact_root in hit.parents or hit == artifact_root,
+                    f"delivery leaked outside the .agentbundle/ jail: {hit}",
+                )
+
+    def test_refuses_group_world_writable_floor(self) -> None:
+        # Security: a pre-existing world/group-writable floor is a local
+        # code-execution vector (the floor is appended to sys.path); refuse.
+        if os.name != "posix":
+            self.skipTest("POSIX mode bits; the DACL model differs on Windows")
+        floor = self.home / ".agentbundle" / "lib"
+        floor.mkdir(parents=True)
+        os.chmod(floor, 0o777)
+        args = argparse.Namespace(
+            pack="credential-brokers",
+            catalogue=str(self.cat),
+            output=str(self.repo),
+            scope="user",
+            force=False,
+            force_merge=False,
+        )
+        rc, _stdout, stderr = _run_install(args)
+        self.assertNotEqual(rc, 0, "install must refuse a group/world-writable floor")
+        self.assertIn("group/world-writable", stderr)
+
+    def test_symlinked_pack_content_is_not_delivered(self) -> None:
+        # Security: pack_dir comes from an untrusted catalogue. A symlinked
+        # source under adapter-root-bins/ (executable bin) or user-libs/
+        # (importable floor) pointing out of tree must not have its target's
+        # bytes read into ~/.agentbundle/.
+        if os.name != "posix":
+            self.skipTest("symlink creation needs privilege on Windows")
+        secret = self.tmp / "secret.txt"
+        secret.write_bytes(b"SECRET-OUT-OF-TREE\n")
+        cat_pack = self.cat / "packs" / "credential-brokers"
+        (cat_pack / ".apm" / "adapter-root-bins" / "evil.py").symlink_to(secret)
+        (cat_pack / ".apm" / "user-libs" / "credbroker" / "evil_lib.py").symlink_to(secret)
+        self._install()
+        evil_bin = self.home / ".agentbundle" / "bin" / "evil.py"
+        evil_lib = self.home / ".agentbundle" / "lib" / "credbroker" / "evil_lib.py"
+        self.assertFalse(evil_bin.exists(), "symlinked bin source was delivered")
+        self.assertFalse(evil_lib.exists(), "symlinked lib source was delivered")
+
+    def test_setup_py_resolves_credbroker_from_floor(self) -> None:
+        # End-to-end (eager importer): setup.py does `from credbroker import …`
+        # at module top. Under `-S` (no site-packages) the floor is the ONLY
+        # credbroker, so `--help` (exit 0, after the import) proves the floor
+        # resolved. Real subprocess invocation — no runpy/importlib synthesis.
+        self._install()
+        entry = SETUP_SCRIPTS / "setup.py"
+        if not entry.is_file():
+            self.skipTest(f"{entry} not present in this checkout")
+        proc = subprocess.run(
+            [sys.executable, "-S", "scripts/setup.py", "--help"],
+            cwd=str(SETUP_SCRIPTS.parent),
+            capture_output=True,
+            text=True,
+            env=self._clean_env(),
+            timeout=60,
+        )
+        self.assertEqual(
+            proc.returncode,
+            0,
+            "setup.py --help failed under -S — `from credbroker import` did not "
+            f"resolve from the floor; stderr:\n{proc.stderr}",
+        )
+
+    def test_api_cli_resolves_credbroker_from_floor(self) -> None:
+        # End-to-end (the LOAD-BEARING CLI case, plan T4 coverage note): the
+        # five API CLIs import credbroker lazily inside an httpx-gated verb, so
+        # T1 could only prove their precedence structurally. Here a real
+        # `jira.py check` — under `-S` (no site-packages credbroker) with a stub
+        # httpx so its `_client` import succeeds — reaches load_credentials,
+        # which imports credbroker from the floor and runs Tier-1→2→3
+        # resolution. No creds anywhere → CredentialsMissingError → AuthError →
+        # EXIT_USER_ACTION (2). Reaching exit 2 *requires* the floor import.
+        self._install()
+        entry = JIRA_SCRIPTS / "jira.py"
+        if not entry.is_file():
+            self.skipTest(f"{entry} not present in this checkout")
+        stub = self.tmp / "httpxstub"
+        stub.mkdir()
+        (stub / "httpx.py").write_text("# stub: import-only\n", encoding="utf-8")
+        proc = subprocess.run(
+            [sys.executable, "-S", "scripts/jira.py", "check"],
+            cwd=str(JIRA_SCRIPTS.parent),
+            capture_output=True,
+            text=True,
+            env=self._clean_env(PYTHONPATH=str(stub)),
+            timeout=60,
+        )
+        self.assertNotIn(
+            "No module named 'credbroker'",
+            proc.stderr,
+            "the floor failed to resolve `import credbroker` for the API CLI",
+        )
+        self.assertEqual(
+            proc.returncode,
+            2,
+            "jira.py check must exit EXIT_USER_ACTION(2) via credbroker's "
+            f"CredentialsMissingError resolved from the floor; stderr:\n{proc.stderr}",
+        )
+        # Positive proof it reached credbroker's env→keyring→dotfile ladder
+        # (platform-agnostic: the Tier labels are emitted on every OS; the
+        # Tier-2 backend *name* is not, so we don't pin it).
+        for tier in ("Tier 1", "Tier 2", "Tier 3"):
+            self.assertIn(
+                tier,
+                proc.stderr,
+                f"{tier} resolution not reached — credbroker did not run from "
+                f"the floor; stderr:\n{proc.stderr}",
+            )
 
 
 if __name__ == "__main__":

--- a/packages/agentbundle/tests/integration/test_credential_brokers_pack_install.py
+++ b/packages/agentbundle/tests/integration/test_credential_brokers_pack_install.py
@@ -243,11 +243,23 @@ class UserScopeFloorDeliveryTests(_BaseInstall):
         return stdout, stderr
 
     def _clean_env(self, **extra: str) -> dict[str, str]:
-        """A minimal subprocess env: drop site-packages-leaking vars and any
-        ambient JIRA_* so the floor is the only ``credbroker`` and credentials
-        genuinely miss. ``HOME``/``USERPROFILE`` point at the install."""
-        keep = {"PATH", "SystemRoot", "TMPDIR", "TEMP", "TMP"}
-        env = {k: v for k, v in os.environ.items() if k in keep}
+        """Subprocess env with ``HOME``/``USERPROFILE`` pointed at the install
+        and the isolation knobs cleared: drop ``PYTHONPATH``/``PYTHONHOME`` (so
+        the only library source is site-packages — itself hidden by ``-S`` when
+        a real ``credbroker`` is installed — plus any caller-supplied
+        ``PYTHONPATH``) and any ambient ``JIRA_*``/``FIGMA_*`` credential vars
+        so credentials genuinely miss.
+
+        Inherits the *rest* of ``os.environ`` rather than allow-listing a
+        handful — on Windows, asyncio's Winsock init (``import _overlapped``)
+        needs ``SystemRoot``/``SystemDrive``/``WINDIR`` etc., and a minimal env
+        raises ``OSError: [WinError 10106]`` before the CLI can run."""
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in {"PYTHONPATH", "PYTHONHOME", "PYTHONSTARTUP"}
+            and not k.startswith(("JIRA_", "FIGMA_"))
+        }
         env["HOME"] = str(self.home)
         env["USERPROFILE"] = str(self.home)
         env.update(extra)


### PR DESCRIPTION
## What & why

T4 of [`docs/specs/credbroker-user-scope`](docs/specs/credbroker-user-scope/spec.md) — the **net-new install-time machinery** of the layered delivery model. A no-repo **user-scope** install of a credentialed pack previously delivered no `credbroker` and ran no `pip`, so OS-keyring (Tier-2) and dotfile/vault (Tier-3) resolution silently fell away, and `sso-broker.py` never reached `~/.agentbundle/bin/`. This wires the install-time half of the `.agentbundle/` rail to close both gaps on one path.

`agentbundle install` gains a Step-9 delivery step (gated `plan.scope == "user"`) that lands two build-pipeline-only primitives the adapter render never emits:

- **`lib/`** — the pack's `.apm/user-libs/**` → `~/.agentbundle/lib/**` (default mode, no exec bit). The vendored `credbroker` floor the T1 bootstraps append to `sys.path` at **lowest** precedence (a pip-installed copy still wins).
- **`bin/`** — `.apm/adapter-root-bins/*.py` + the AC22b companion `credentials_shim.py` → `~/.agentbundle/bin/**` (`0o755` POSIX, DACL-inherited on Windows). Closes the long-missing user-scope half of RFC-0013's `sso-broker` delivery.

Both go through `safety.write_jailed(scope="user", …)` under the existing `.agentbundle/` prefix — **no jail change**. The companion-aware enumeration is a new single-`pack_dir`-scoped helper `adapter_root_bins.collect_pack_root_bins` (reuses the ship-both opt-in against one resolved catalogue pack), **not** the multi-pack `compute_projections`, per the plan's explicit instruction.

## How it was verified

- `$HOME`-redirected user-scope install lands `lib/credbroker/` + `bin/sso-broker.py` + companion `credentials_shim.py` + `_sso_*` backends; `lib/` carries no exec bit, `bin/*.py` is `0o755` (POSIX).
- **End-to-end floor resolution** (load-bearing, plan coverage note): `setup.py` (eager importer, `-S`) resolves `import credbroker` from the floor; `jira.py check` (a real API CLI — lazy import under `-S` + stub `httpx`) reaches credbroker's **env→keyring→dotfile** ladder and exits `2`. Wired into **both** Linux and Windows CI for cross-platform importability.
- Security: group/world-writable-floor refusal; symlinked-source / symlinked-primitive-dir rejection.
- Full `packages/agentbundle` pytest + `make build-check` green.

## Review notes

Both `adversarial-reviewer` and `security-reviewer` ran (security boundary: an importable, executable floor on `sys.path`). Findings converged over three rounds — gating the refusal to floor-shipping packs, walking the full `.agentbundle` tree for a loose leaf, and rejecting symlinked sources on **both** delivery halves (install reads `pack_dir` from an untrusted catalogue) **and** the primitive directory itself.

The floor is **shared, idempotent** infrastructure (one copy per consumer), so delivered files are deliberately **not** recorded in `state.files` — uninstalling one pack must not strip a co-installed pack's floor.

**Trust boundary:** the group/world-writable refusal is a check-then-write guard that assumes a single-user `$HOME` (documented in `_assert_user_floor_dirs_safe`).

Spec → **Implementing** (T5 owns the `Shipped` close-out + RFC-0023 amendment).

## Deferred
See `docs/backlog.md` § `credbroker-user-scope`:
- **floor-delivery-graceful-skip-on-missing-prefix** — graceful floor-skip if a future adapter omits `.agentbundle/` from its user prefixes (unreachable today; would hard-abort rather than skip).
- **floor-reference-counting-on-uninstall** — reference-counted floor removal so uninstalling the last credentialed pack doesn't leave a stale broker behind.

## Bundled fixes
None.