### PR TITLE
docs(credbroker): reconcile architecture + guide docs to the credbroker delivery

### DIFF
--- a/.agentbundle/lib/credbroker/_vault.py
+++ b/.agentbundle/lib/credbroker/_vault.py
@@ -1,11 +1,12 @@
 """Encrypted-at-rest credential vault for the `credbroker[crypto]` extra.
 
 RFC-0023's Tier-3 floor upgrade: instead of a plaintext `0600` dotfile, the
-optional `[crypto]` extra stores values in an AEAD-encrypted file. This module
-imports `cryptography` and `argon2` at top level, so it is imported **lazily**
-(never from `credbroker/__init__.py` or `credbroker/_core.py`) — the base import
-graph stays third-party-free (spec AC4). A consumer reaches it only through the
-Tier-3 dispatch path (T5) or the credential-setup write path (T8).
+optional `[crypto]` extra stores values in an AEAD-encrypted file. This module's
+own top level pulls in `cryptography` and `argon2`, so the resolution core imports
+the vault **module lazily** — only inside the functions that need it, never at the
+top level of `credbroker/__init__.py` or `credbroker/_core.py`. The base import
+graph therefore stays third-party-free (spec AC4). A consumer reaches the vault
+only through the Tier-3 dispatch path (T5) or the credential-setup write path (T8).
 
 Key hierarchy (authsome's scheme):
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -13,7 +13,8 @@ How the code is *currently* organized. Not why (that's in
   CLI verbs, bundler internals (recipes → adapters → projections), the
   adapter contract, and the install→adapt chain.
 - [`credentials.md`](credentials.md) — the credential-loading subsystem:
-  three-tier storage, the build-projected `credentials_shim` (RFC-0013),
+  three-tier storage, the `credbroker` library resolver (RFC-0023, which
+  replaced the build-projected `credentials_shim` of RFC-0013),
   the four-broker contract (`creds` / `env` / `cli` / `sso-cookie`),
   the credentialed-primitive model, and the substring trap.
 

--- a/docs/architecture/agentbundle.md
+++ b/docs/architecture/agentbundle.md
@@ -5,8 +5,8 @@ The reference CLI and build pipeline at
 zipapp-distributable. One surface in one install: a CLI on PATH
 (`agentbundle <verb>`) that drives pack install, validation, adapt,
 and build. As of 0.2.0 the package no longer exposes a credential-
-resolution module — credentialed primitives import a build-projected
-`credentials_shim` sibling shipped by the `credential-brokers` pack
+resolution module — credentialed primitives resolve credentials through
+the pip-installable `credbroker` library (RFC-0023)
 (see [`credentials.md`](credentials.md)). This page describes the
 package as code; the spec lives in
 [`docs/specs/agent-spec-cli/spec.md`](../specs/agent-spec-cli/spec.md),
@@ -30,10 +30,11 @@ packages/agentbundle/agentbundle/
 ├── _data/                # bundled schemas + install-marker copy
 └── templates/            # canonical install-marker.py (sync source)
 
-(Credential resolution moved to the build-projected `credentials_shim`
-sibling per RFC-0013; see [`credentials.md`](credentials.md). The
-`credentials.py`, `creds/`, and `commands/creds.py` surfaces shipped
-in 0.1.x were removed in 0.2.0.)
+(Credential resolution moved out of the wheel: first to the
+build-projected `credentials_shim` per RFC-0013, then to the
+pip-installable `credbroker` library per RFC-0023; see
+[`credentials.md`](credentials.md). The `credentials.py`, `creds/`, and
+`commands/creds.py` surfaces shipped in 0.1.x were removed in 0.2.0.)
 ```
 
 ## The CLI surface

--- a/docs/architecture/credentials.md
+++ b/docs/architecture/credentials.md
@@ -1,11 +1,12 @@
 # Credentials
 
-> **Partially superseded (RFC-0023, 2026-06-09).** For `auth: creds`, the
-> resolver is now the pip-installable [`credbroker`](../rfc/0023-credential-manager-broker.md)
-> library imported in-process — the build-projected `credentials_shim`
-> described below was retired for consumer skills (it survives only as the
-> `adapter-root-bins` companion shim for `sso-broker`). A full rewrite of
-> this page is tracked in [`docs/backlog.md`](../backlog.md#credbroker).
+> **Updated for [RFC-0023](../rfc/0023-credential-manager-broker.md) (2026-06-09).**
+> For `auth: creds`, the resolver is the standalone, pip-installable
+> [`credbroker`](../rfc/0023-credential-manager-broker.md) library imported
+> in-process. It replaced the build-projected `credentials_shim`, which now
+> survives only as the `adapter-root-bins` companion shim for `sso-broker`.
+> This page describes the current (credbroker) model; the three-tier storage
+> contract below is unchanged from the shim.
 
 The secret-handling subsystem for credentialed primitives in this
 catalogue. Defines how a credentialed primitive — a `jira`, `figma`,
@@ -53,20 +54,24 @@ SSO flows respectively. See the spec for the per-broker contracts.
 
 `tools/lint-credentialed-skills.sh` enforces every rule: argv-ban,
 Don't-block presence, dotfile-read refusal, and per-broker AST walks
-(e.g. `auth: creds` requires `from .credentials_shim import …`).
+(e.g. `auth: creds` requires a `credbroker` resolver import —
+`from credbroker import …`; the legacy `from .credentials_shim import …`
+is still recognized).
 
 ## The `creds` broker
 
 The `creds` broker resolves credentials through the three-tier model
-below. The implementation is the build-projected `credentials_shim`
-module — the `credential-brokers` pack drops
-`credentials_shim.py` + per-platform Tier-2 backends
-(`_keychain_macos.py`, `_credman_windows.py`) into every `auth: creds`
-consumer skill's `scripts/` directory at install / `make build-self`
-time. Consumers import via the sibling relative form:
+below. Since [RFC-0023](../rfc/0023-credential-manager-broker.md) the
+implementation is the standalone, pip-installable **`credbroker`**
+library ([`packages/credbroker/`](../../packages/credbroker/)), imported
+**in-process** — it replaced the build-projected `credentials_shim` that
+earlier dropped a byte-identical copy (plus the Tier-2 backends
+`_keychain_macos.py` / `_credman_windows.py`, now `credbroker`'s own
+modules) into every consumer's `scripts/`. Consumers import the absolute
+package form:
 
 ```python
-from .credentials_shim import (
+from credbroker import (
     CredentialsMissingError,
     Tier2HardFailError,
     load_credentials,
@@ -86,10 +91,28 @@ job, not the loader's. The loader walks **first-hit-wins per key**
 (a key resolved at Tier 1 is not re-checked at lower tiers; mixing
 tiers across keys within one namespace is permitted).
 
-The canonical source for the shim lives under
-[`packs/credential-brokers/.apm/shared-libs/credentials_shim.py`](../../packs/credential-brokers/.apm/shared-libs/credentials_shim.py);
-build-self projects byte-identical copies into each consumer's
-`scripts/`.
+### How `credbroker` reaches the interpreter — the layered delivery
+
+`import credbroker` resolves through a `sys.path` precedence stack fed by
+two delivery layers (full author-facing detail in the
+[how-to](../guides/how-to/add-a-credentialed-skill.md#how-credbroker-reaches-syspath--the-layered-model)):
+
+- **Vendored floor (zero-pip, user scope).** A user-scope install of the
+  `credential-brokers` pack delivers a byte-faithful, stdlib-base copy of
+  the package source to `~/.agentbundle/lib/credbroker/`, which every
+  credentialed skill appends to `sys.path` at **lowest** precedence — so a
+  no-repo install resolves Tier-1/2/3 with no pip. The floor is drift-gated
+  byte-for-byte against `packages/credbroker/credbroker/` — **one shared
+  copy**, not the N-per-skill projection the shim used.
+- **pip (corporate / PyPI).** A `pip install credbroker` (internal index,
+  local wheel, or PyPI) lands in site-packages, which precedes the floor on
+  `sys.path` — so it wins and unlocks the encrypted `[crypto]` vault.
+
+The `credentials_shim` source is **kept** at
+[`packs/credential-brokers/.apm/shared-libs/credentials_shim.py`](../../packs/credential-brokers/.apm/shared-libs/credentials_shim.py),
+but only as the companion shim that rides the `adapter-root-bins` →
+`~/.agentbundle/bin/` projection for `sso-broker.py`; no consumer skill
+imports it for `creds` resolution any more.
 
 ## The three tiers
 
@@ -104,11 +127,11 @@ Tier 3 on Linux today.
 
 ### Tier 2 backends — stdlib only
 
-- **macOS** (the shim's `_keychain_macos.py` sibling) —
+- **macOS** (`credbroker`'s `_keychain_macos.py`) —
   `subprocess.run(["/usr/bin/security", ...])`. The write path passes
   the token via **child stdin**, never argv. Service =
   `"agentbundle"`, account = `"<namespace>:<key>"`.
-- **Windows** (the shim's `_credman_windows.py` sibling) —
+- **Windows** (`credbroker`'s `_credman_windows.py`) —
   `ctypes` against `advapi32.{CredReadW, CredWriteW, CredDeleteW,
   CredFree}`. In-process, no subprocess. `CRED_TYPE_GENERIC`,
   `CRED_PERSIST_LOCAL_MACHINE`, target-name
@@ -121,12 +144,18 @@ security smell, not the dotfile.
 
 ### Tier 3 — the dotfile
 
-A stdlib `.env` parser (`parse_env_file` in `credentials_shim.py`)
+A stdlib `.env` parser (`parse_env_file` in `credbroker`'s `_core`)
 handles `KEY=value`, quoted values, and `#` comments. It rejects
 `export ` prefix, variable expansion, and multi-line values — `.env`
 is not bash. POSIX: enforces mode `0600` on the file and `0700` on
 `~/.agentbundle/`. Windows: DACL-verified via `icacls`.
 `PermissiveAclError` on either failure.
+
+Where `credbroker[crypto]` is installed (a pip layer, never the stdlib
+floor), Tier 3 upgrades from the plaintext dotfile to an AEAD-encrypted
+**vault** (Argon2id → KEK → AES-256-GCM, `credbroker`'s `_vault`); the
+vendored floor stays stdlib-only and plaintext. See
+[RFC-0023](../rfc/0023-credential-manager-broker.md).
 
 ## Setting up credentials
 
@@ -199,15 +228,20 @@ if str(suspect) == ".agentbundle/credentials.env":
     refuse(...)
 ```
 
-This rule applies to `credentials_shim.py` itself and to any
-primitive script that mentions the dotfile defensively.
+This rule applies to any primitive script (`cli.py`) that mentions the
+dotfile defensively.
 
 ## Where to read next
 
 - [`docs/specs/credential-broker-contract/spec.md`](../specs/credential-broker-contract/spec.md) —
-  the current authoritative spec (four brokers; the shim model).
+  the four-broker contract.
+- [`docs/rfc/0023-credential-manager-broker.md`](../rfc/0023-credential-manager-broker.md) —
+  the `credbroker` library that replaced the projected shim for `auth: creds`
+  (and its layered-delivery amendment); [`docs/specs/credbroker/spec.md`](../specs/credbroker/spec.md)
+  + [`docs/specs/credbroker-user-scope/spec.md`](../specs/credbroker-user-scope/spec.md)
+  are the implementing specs.
 - [`docs/rfc/0013-credential-broker-contract.md`](../rfc/0013-credential-broker-contract.md) —
-  the current design rationale.
+  the four-broker design rationale (the predecessor shim model).
 - [`docs/specs/skill-secrets/spec.md`](../specs/skill-secrets/spec.md) —
   the predecessor spec (kept for historical context).
 - [`docs/guides/explanation/credentialed-skills.md`](../guides/explanation/credentialed-skills.md) —

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -96,8 +96,8 @@ One file per non-trivial subsystem:
   CLI and build pipeline. Stdlib-only, distributed as a zipapp and as
   an editable pip install. As of 0.2.0 it no longer ships a credential-
   resolution module; credentialed primitives in the `atlassian` and
-  `figma` packs import a build-projected `credentials_shim` sibling
-  shipped by the `credential-brokers` pack. See
+  `figma` packs resolve credentials through the pip-installable
+  `credbroker` library (RFC-0023), not the agentbundle wheel. See
   [`agentbundle.md`](agentbundle.md) and [`credentials.md`](credentials.md).
 - [`packages/_example/`](../../packages/_example/) — a minimal package
   template the `new-package` skill (in `monorepo-extras`) copies when an

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -302,28 +302,6 @@ of their own yet.
 RFC-0023 follow-on, **Phase 1 shipped 2026-06-09** (`docs/specs/credbroker/`,
 Status: Shipped). The items below are deferred out of Phase 1 by spec decision.
 
-**Doc follow-ups (deferred from T10 — stale shim/projection prose outside T10's named scope):**
-- `docs/architecture/credentials.md` still documents the build-projected
-  `credentials_shim` model as the `creds` delivery; after RFC-0023 the
-  `creds` resolver is the `credbroker` library (the projected shim survives
-  only as the adapter-root-bins companion for `sso-broker`). Rewrite the
-  architecture map for the credbroker delivery. The `docs/architecture/overview.md`
-  one-liner pointing at `credentials.md` moves with it.
-- `docs/guides/how-to/install-agentbundle-from-clone.md` references the
-  projected shim; reconcile with the `pip install credbroker` model.
-  **Unblocks when:** picked up as a docs pass (no code dependency).
-
-**credbroker-user-scope T3 review follow-ups (non-blocking):**
-- **`_vault.py` module-docstring imprecision.** `packages/credbroker/credbroker/_vault.py:5`
-  reads as if `_vault` itself defers the crypto import, but the lazy boundary is at the
-  *package* level — `_core`/`__init__` import `_vault` lazily, so the base graph stays
-  third-party-free even though `_vault`'s own top level pulls `cryptography`/`argon2`.
-  Reword to "the vault *module* is imported lazily by the resolution core." Must fix the
-  **source** package, not the vendored floor copies (`.agentbundle/lib/credbroker/_vault.py`
-  + `packs/credential-brokers/.apm/user-libs/credbroker/_vault.py`), which are byte-faithful
-  projections — re-run `make build-self` after to re-sync them. **Unblocks when:** picked up
-  as a `packages/credbroker` docs pass (no code dependency).
-
 **T5 review follow-ups (non-blocking, surfaced by the T5 review):**
 - **Per-key vault KDF re-derivation.** `load_credentials` resolves `required_keys`
   one at a time; for a vault-backed namespace each key that reaches Tier 3 opens

--- a/docs/guides/explanation/credentialed-skills.md
+++ b/docs/guides/explanation/credentialed-skills.md
@@ -104,7 +104,7 @@ The first time you install `atlassian` or `figma`, the
 prompts you to invoke the `credential-setup` skill. After that,
 nothing changes: you ask the agent to fetch a Jira issue, the agent
 calls the skill, the skill shells out to the primitive, the primitive
-loads the token via the build-projected `credentials_shim` and makes
+loads the token via the `credbroker` library and makes
 the call. You never see the token; the agent never sees the token; it
 lives in your keyring until you remove it (open Keychain Access /
 Credential Manager — there is no CLI verb).

--- a/docs/guides/how-to/install-agentbundle-from-clone.md
+++ b/docs/guides/how-to/install-agentbundle-from-clone.md
@@ -6,15 +6,20 @@ validation, adapt, and build. All four
 — skills, agents, hooks — but not the CLI, so every route converges
 here for the pip install.
 
-> **As of 0.2.0 (per RFC-0013), credentialed skills no longer import
-> from `agentbundle.credentials`.** The shim model projects
-> `credentials_shim.py` (and per-platform Tier-2 backends) into each
-> `auth: creds` consumer's `scripts/` directory at build time; the
-> consumer imports `from .credentials_shim import …` against the
-> projected sibling, with no runtime `agentbundle` dependency. The
-> CLI itself remains pip-installed from this clone; what changed is
-> that the *Python skill bodies* no longer reach back into the
-> agentbundle wheel for credential resolution.
+> **Credentialed skills don't resolve credentials through the
+> `agentbundle` wheel.** Since 0.2.0 (RFC-0013) they no longer import
+> from `agentbundle.credentials`, and since
+> [RFC-0023](../../rfc/0023-credential-manager-broker.md) the `auth: creds`
+> resolver is the standalone, pip-installable
+> [`credbroker`](../../../packages/credbroker/) library, imported
+> in-process (`from credbroker import …`) — it replaced the
+> build-projected `credentials_shim` sibling. From a clone, install it
+> alongside the CLI: `pip install -e ./packages/credbroker`. (The
+> no-PyPI corporate and zero-pip user-scope-floor paths are in Step 9 of
+> the [credentialed-skill how-to](add-a-credentialed-skill.md).) The CLI
+> itself remains pip-installed from this clone; what changed is that the
+> *Python skill bodies* resolve credentials through `credbroker`, not the
+> agentbundle wheel.
 
 Smoke test for the install:
 

--- a/packages/credbroker/credbroker/_vault.py
+++ b/packages/credbroker/credbroker/_vault.py
@@ -1,11 +1,12 @@
 """Encrypted-at-rest credential vault for the `credbroker[crypto]` extra.
 
 RFC-0023's Tier-3 floor upgrade: instead of a plaintext `0600` dotfile, the
-optional `[crypto]` extra stores values in an AEAD-encrypted file. This module
-imports `cryptography` and `argon2` at top level, so it is imported **lazily**
-(never from `credbroker/__init__.py` or `credbroker/_core.py`) — the base import
-graph stays third-party-free (spec AC4). A consumer reaches it only through the
-Tier-3 dispatch path (T5) or the credential-setup write path (T8).
+optional `[crypto]` extra stores values in an AEAD-encrypted file. This module's
+own top level pulls in `cryptography` and `argon2`, so the resolution core imports
+the vault **module lazily** — only inside the functions that need it, never at the
+top level of `credbroker/__init__.py` or `credbroker/_core.py`. The base import
+graph therefore stays third-party-free (spec AC4). A consumer reaches the vault
+only through the Tier-3 dispatch path (T5) or the credential-setup write path (T8).
 
 Key hierarchy (authsome's scheme):
 

--- a/packs/credential-brokers/.apm/user-libs/credbroker/_vault.py
+++ b/packs/credential-brokers/.apm/user-libs/credbroker/_vault.py
@@ -1,11 +1,12 @@
 """Encrypted-at-rest credential vault for the `credbroker[crypto]` extra.
 
 RFC-0023's Tier-3 floor upgrade: instead of a plaintext `0600` dotfile, the
-optional `[crypto]` extra stores values in an AEAD-encrypted file. This module
-imports `cryptography` and `argon2` at top level, so it is imported **lazily**
-(never from `credbroker/__init__.py` or `credbroker/_core.py`) — the base import
-graph stays third-party-free (spec AC4). A consumer reaches it only through the
-Tier-3 dispatch path (T5) or the credential-setup write path (T8).
+optional `[crypto]` extra stores values in an AEAD-encrypted file. This module's
+own top level pulls in `cryptography` and `argon2`, so the resolution core imports
+the vault **module lazily** — only inside the functions that need it, never at the
+top level of `credbroker/__init__.py` or `credbroker/_core.py`. The base import
+graph therefore stays third-party-free (spec AC4). A consumer reaches the vault
+only through the Tier-3 dispatch path (T5) or the credential-setup write path (T8).
 
 Key hierarchy (authsome's scheme):
 


### PR DESCRIPTION
## What

The "easy follow-on" docs pass — closes the deferred `credbroker` doc follow-ups (and one bonus) from `docs/backlog.md`. Several docs still described the retired build-projected `credentials_shim` as the live `auth: creds` delivery; after RFC-0023 the resolver is the pip-installable **`credbroker`** library (imported in-process), with a vendored zero-pip floor at `~/.agentbundle/lib/credbroker/` at user scope. The shim survives only as the `sso-broker` `adapter-root-bins` companion.

- **`docs/architecture/credentials.md`** — rewrote the `creds`-delivery prose for the credbroker library + the layered delivery (floor / pip); fixed the lint-rule line, Tier-2/Tier-3 module locations, a `[crypto]`-vault note, the substring-trap line, and "Where to read next".
- **`docs/architecture/{overview,agentbundle,README}.md`** — primitives resolve via the `credbroker` library, not the projected shim (package map + index summary). *(README + agentbundle were caught by review as the same drift class in the same directory — folded in.)*
- **`docs/guides/how-to/install-agentbundle-from-clone.md`** — blockquote reconciled with `pip install -e ./packages/credbroker`.
- **`docs/guides/explanation/credentialed-skills.md`** — the bonus: day-to-day line now says the token is loaded via the `credbroker` library.
- **`packages/credbroker/credbroker/_vault.py`** — module-docstring reword (lazy-import-boundary precision); the vault *module* is imported lazily by the resolution core. AST-verified **docstring-only**; `make build-self` re-synced the two byte-faithful floor copies.
- **`docs/backlog.md`** — removed the three now-closed items per the register's own maintenance rule (closed work lives in changelogs, not the backlog).

## Why

Living-doc ↔ shipped-reality drift is the biggest cause of agent quality decay. These were tracked backlog items under the shipped `credbroker` spec, all flagged "no code dependency — pick up as a docs pass."

## How tested

- `make build-check` — **exit 0**, including the floor drift gate (the two `_vault.py` floor copies are byte-identical to the source after `build-self`).
- AST skeleton diff on `_vault.py` proves the change is docstring-only (no code/identifier change).
- `lint-spec-status.py` — clean (no spec touched).
- Verified every rewritten claim against the actual `credbroker` package / lint (`parse_env_file`/backends in `_core`; `from credbroker import …` form; `has_credbroker_import` with legacy shim still recognized); all added cross-ref links + the how-to anchor resolve; swept `docs/architecture` + `docs/guides` to confirm no `credentials_shim` mention still presents the shim as the live resolver (all remaining mentions are correct historical / legacy / sso-companion framing).
- `adversarial-reviewer`: 2 Concerns (the `agentbundle.md` + architecture-`README.md` siblings), both applied; factual accuracy, link integrity, backlog hygiene, and scope all verified clean. No Blockers.

## Risks

Low — documentation + one docstring; no behavior change. The `_vault.py` edit is provably docstring-only and the floor copies stay byte-faithful (drift gate enforces it).