### PR TITLE
docs(credbroker): release runbook in CONTRIBUTING + PyPI-first README install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,30 @@ Caveats the workflow enforces — know them before you tag:
 
 The **one-time** PyPI account + Pending Publisher setup is not repeated per release; it lives in the plan's [Rollout § Phase B](docs/specs/agentbundle-wheel-release/plan.md#rollout).
 
+## Cutting a `credbroker` release
+
+Publishing a new [`credbroker`](packages/credbroker/) version to PyPI mirrors the `agentbundle` flow above — same shape, separate package. The pipeline is `.github/workflows/release-credbroker.yml` (jobs: `build-and-smoke` → `publish-pypi` via Trusted Publisher OIDC → `publish-artifactory`, the last green-skipped unless the corp Artifactory secrets are set). A tag push is the only trigger that *publishes*; PRs touching `packages/credbroker/**` run `build-and-smoke` as a pre-merge gate, and there's no manual `twine upload`.
+
+Per release:
+
+1. **Bump the version in *both* places, in the same PR.** `credbroker` carries the version twice: [`packages/credbroker/pyproject.toml`](packages/credbroker/pyproject.toml) (`version`) **and** [`packages/credbroker/credbroker/__init__.py`](packages/credbroker/credbroker/__init__.py) (`__version__`, which the wheel-smoke step reads). Keep them equal — a mismatch ships a wheel whose `credbroker.__version__` disagrees with its distribution version. (credbroker has no `CHANGELOG.md` today; add one if the cadence warrants it.) Merge to `main` through the normal gates.
+2. **Tag the tip of `main`** — never a feature branch:
+   ```bash
+   git checkout main && git pull origin main
+   git tag credbroker-vX.Y.Z          # X.Y.Z must equal the pyproject version
+   git push origin credbroker-vX.Y.Z
+   ```
+3. **Watch the run** (Actions → `release-credbroker`). `build-and-smoke` and `publish-pypi` must go green; `publish-artifactory` shows green-skipped when the corp secrets are unset.
+4. **Verify** from a clean venv, ideally on another machine: `pip install credbroker` resolves to the new version and `python -c "import credbroker; print(credbroker.__version__)"` prints it.
+
+Caveats the workflow enforces — the same fail-closed assertions as `agentbundle`:
+
+- **The tag format is exact: `credbroker-vX.Y.Z`.** Pre-release / build-metadata suffixes (`-rc1`, `+build`) are refused by the version-assertion step.
+- **The tag's `X.Y.Z` must equal the pyproject `version`**, and the tagged commit **must be an ancestor of `origin/main`** — both fail-closed in `build-and-smoke`, so a wrong tag never publishes.
+- **A successful publish burns the version number permanently** — PyPI does not allow re-uploading the same version. A tag whose run *never reached* `publish-pypi` leaves the number claimable (delete the tag with `git push origin :refs/tags/credbroker-vX.Y.Z`, fix, re-tag); treat any run where `publish-pypi` *started* as a burn — even a partial upload that reached PyPI claims the version.
+
+The **one-time** PyPI Trusted Publisher — a Pending Publisher matching `release-credbroker.yml`'s `publish-pypi` job (project `credbroker`, owner `eugenelim`, repo `agent-ready-repo`, workflow `release-credbroker.yml`, environment `pypi`) — was configured at the `0.1.0` publish and is not repeated per release. The *name-registration decision* it implements (claim the name on the first real publish, no interim placeholder) is recorded in [`docs/backlog.md`](docs/backlog.md#credbroker-phase-2).
+
 ## Where to find authoritative information
 
 | You want to know… | Look here |

--- a/packages/credbroker/README.md
+++ b/packages/credbroker/README.md
@@ -13,8 +13,13 @@ cleartext value cross a process boundary to the LLM.
 ## Install
 
 ```bash
-pip install -e ./packages/credbroker            # stdlib-only core
-pip install -e './packages/credbroker[crypto]'  # + encrypted-at-rest vault
+pip install credbroker                          # stdlib-only core, from PyPI
+pip install 'credbroker[crypto]'                # + encrypted-at-rest vault
+
+# Or work against a repo clone — an editable install for local development
+# (no PyPI needed; same import, the repo copy wins on sys.path):
+pip install -e ./packages/credbroker
+pip install -e './packages/credbroker[crypto]'
 ```
 
 The core has **no third-party dependency**. The `[crypto]` extra adds


### PR DESCRIPTION
## What

Two docs follow-ups now that `credbroker 0.1.0` is on PyPI:

1. **`CONTRIBUTING.md` — a "Cutting a `credbroker` release" section**, mirroring the existing "Cutting an `agentbundle` release" runbook directly above it. Bump version → tag → watch → verify, plus the workflow-enforced caveats.
2. **`packages/credbroker/README.md` — PyPI-first Install block.** It led with the repo-editable install and never showed `pip install credbroker`; now it leads with PyPI and keeps the editable path as the local-dev option.

## Notable credbroker-specific differences from the agentbundle runbook

- **Version lives in two files** — `pyproject.toml` (`version`) *and* `credbroker/__init__.py` (`__version__`, which the wheel-smoke reads). The runbook says bump **both** and keep them equal (nothing auto-derives one from the other; the workflow asserts only tag==pyproject, so a stale `__version__` would ship silently).
- **No `CHANGELOG.md`** (agentbundle has one) — the runbook says so rather than referencing a file that doesn't exist.
- **Pending Publisher already configured** at the 0.1.0 publish — the runbook records the tuple (project `credbroker`, env `pypi`, workflow `release-credbroker.yml`) and points the *name-registration decision* at `docs/backlog.md#credbroker-phase-2`.
- **Omitted** agentbundle's "`1.0.0` is §Ask-first" caveat — credbroker has no wheel-release stability-contract spec to cite; inventing one would be the error.

## Can you install credbroker from the repo instead of a PyPI wheel?

**Yes — three non-PyPI paths, all already documented** (this PR also surfaces #1 in the README Install block):

1. **Editable repo install** — `pip install -e ./packages/credbroker` (local dev / a clone). Now shown in the README Install block, the how-to Step 9, and `install-agentbundle-from-clone.md`.
2. **The vendored floor (zero-pip)** — a user-scope `credential-brokers` install delivers `~/.agentbundle/lib/credbroker/`, appended to `sys.path` at lowest precedence, so `import credbroker` resolves with no pip at all. Documented in the how-to's layered-model subsection.
3. **Local wheel / internal index (corporate)** — `pip install ./credbroker-<v>-py3-none-any.whl` or `--index-url <internal>`. Documented in the how-to's "Installing without PyPI (corporate)" section.

A pip-installed copy (any of PyPI / wheel / editable) always wins over the floor on `sys.path`, so a repo/editable install transparently shadows the vendored copy.

## How tested

- `make build-check` — **exit 0**.
- Every runbook claim cross-checked against `.github/workflows/release-credbroker.yml` (trigger, PR gate on `packages/credbroker/**`, the three jobs, the tag/version/ancestor assertions, OIDC publish, Artifactory green-skip, the `__version__` smoke read) and against both version files.
- `adversarial-reviewer`: 1 Concern + 1 Nit, both applied (attributed the Pending-Publisher tuple to the workflow rather than the backlog link; restored the partial-publish "burn" rationale for parity). Parity, factual accuracy, and scope verified clean.

## Risks

None — docs only (CONTRIBUTING + a package README); no code, no behavior change.