### PR TITLE
docs(agentbundle): README — credbroker library, not the retired projected shim

### DIFF
--- a/packages/agentbundle/README.md
+++ b/packages/agentbundle/README.md
@@ -6,14 +6,14 @@ contract. Ships the `agentbundle` console script — install, validate,
 adapt, and inspect packs — plus the build pipeline (`agentbundle.build`)
 that projects pack sources into adapter-shaped trees.
 
-As of 0.2.0, credential resolution lives in the build-projected
-`credentials_shim` sibling that the `credential-brokers` pack drops
-alongside each `auth: creds` consumer skill's `scripts/`. The
-`agentbundle.credentials` module that previous releases (0.1.x)
-exposed has been removed; consumers import `from .credentials_shim
-import …` against the projected sibling instead. See the
-`credential-broker-contract` spec and this package's `CHANGELOG.md`
-for the migration recipe.
+As of 0.2.0 the `agentbundle.credentials` module that earlier releases
+(0.1.x) exposed has been removed — `agentbundle` no longer ships a
+credential-resolution module. Since RFC-0023, `auth: creds` consumers
+resolve credentials through the standalone, pip-installable `credbroker`
+library, imported in-process (`from credbroker import …`); it replaced the
+build-projected `credentials_shim` sibling, which now survives only as the
+`sso-broker` companion. See the `credbroker` package, RFC-0023, and this
+package's `CHANGELOG.md` for the migration history.
 
 See the [top-level README](https://github.com/eugenelim/agent-ready-repo#readme)
 for install routes, the pack catalogue, and the adapter contract.


### PR DESCRIPTION
## What

`packages/agentbundle/README.md` still described `auth: creds` credential resolution as living in the **build-projected `credentials_shim`** that consumers import via `from .credentials_shim import …`. Since RFC-0023 the resolver is the standalone, pip-installable **`credbroker`** library (imported in-process); the shim survives only as the `sso-broker` companion.

This is the same stale-shim drift class the docs pass (#259) and the credbroker README (#260) corrected — this closes the last package README still carrying it.

## How tested

- `make build-check` — exit 0.
- Grep confirms the only remaining `credentials_shim` mention is the correct "it *replaced* the … shim, which now survives only as the `sso-broker` companion" framing.
- Kept the 0.2.0 `agentbundle.credentials`-removal fact and the by-name references (no fragile relative links, since this README ships to PyPI).

One paragraph, factually identical in shape to prose already reviewed clean in #259/#260 — self-reviewed rather than re-dispatching a subagent (work-loop triviality test).

## Risks

None — a single documentation paragraph; no code, no behavior change.