### PR TITLE
feat(agentbundle): surface upgrade Tier-2 companion-drops + reconcile RFC-0001

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -45,14 +45,6 @@ marker — see RFC-0016).
   (`git+ssh://…` exits non-zero with a "deferred to v1.1" message);
   full `--strict` `validate` against the v0.1 conformance fixtures
   (owned by RFC-0003's deferred F-conformance task).
-- **Tier-2 upgrade prompt — v0.1 ships companion-drop only.** RFC-0001
-  specifies a three-option in-CLI prompt on `agentbundle upgrade` Tier-2
-  collisions (keep / overwrite with `.pre-update.bak` / invoke
-  `adapt-to-project`). The shipped `upgrade.py` is non-interactive
-  (writes a `*.upstream.<ext>` companion and continues); the
-  `.pre-update.bak` overwrite path is unimplemented. **Unblocks when:**
-  the interactive prompt + backup path are implemented, or RFC-0001's
-  Tier-2 contract is amended to match the companion-drop-only shape.
 
 ## `adapt-to-project`
 

--- a/docs/guides/explanation/file-safety-contract.md
+++ b/docs/guides/explanation/file-safety-contract.md
@@ -48,11 +48,15 @@ The CLI records a SHA-256 of every projected file in
 `agentbundle upgrade --pack <name> --to <version> <catalogue>`, any
 file whose content diverged since install (Tier-2) gets a
 `*.upstream.<ext>` companion dropped next to it; your edited file is
-left alone and the CLI continues without prompting. The merge UI lives
-in the `adapt-to-project` skill, which you re-invoke after the upgrade
-to walk the new companions one at a time. RFC-0001 specifies a richer
-in-CLI prompt with a `<path>.pre-update.bak` overwrite path; v0.1
-ships the companion-drop only.
+left alone and the CLI continues without prompting. The upgrade then
+reports on stderr how many files were kept and the companion path of
+each, so you can find them. The merge UI lives in the `adapt-to-project`
+skill, which you re-invoke after the upgrade to walk the new companions
+one at a time. RFC-0001's original draft specified a richer in-CLI
+prompt with a `<path>.pre-update.bak` overwrite path; that prompt was
+superseded by this deterministic companion-drop design (RFC-0001
+§ Errata, 2026-06-11) — the CLI never clobbers or prompts, and the
+keep/merge/overwrite choice lives in `adapt-to-project`.
 
 ### Tier-3 (everything else)
 

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -23,6 +23,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`agentbundle upgrade` tells you when it keeps your edits** — when a
+  projected file you edited since install collides with the new version
+  (Tier-2), the upgrade preserves your file and drops the upstream version
+  as a `<path>.upstream.<ext>` companion, exactly as before. It now also
+  prints, on stderr after the upgrade commits, how many files were kept
+  and the companion path of each — so you can find them and run
+  `adapt-to-project` to merge. Parity with what `install` already reports;
+  no change to the file-safety contract (the CLI still never clobbers or
+  prompts). Per
+  [RFC-0001 § Errata (2026-06-11)](../rfc/0001-bundle-distribution-by-adapter-spec.md#errata),
+  which reconciles the original draft's unbuilt in-CLI Tier-2 prompt with
+  this deterministic companion-drop design.
+
 - **Codex receives full skill bodies** — the `skill` projection for the
   Codex adapter flips from `managed-block-inline` (one-line teasers
   in `AGENTS.md` between `<!-- agent-skills:start -->` /

--- a/docs/rfc/0001-bundle-distribution-by-adapter-spec.md
+++ b/docs/rfc/0001-bundle-distribution-by-adapter-spec.md
@@ -1511,3 +1511,43 @@ absorbed into the build pipeline.
   disposition, not the architecture. The frozen body above is unchanged; this
   annotation is the correction of record. See
   `docs/specs/core-install-seed-delivery/` for the implementing spec.
+
+- **2026-06-11 — Tier-2 conflict resolution is deterministic companion-drop; the
+  in-CLI prompt is superseded.** Short version: **the CLI never prompts and never
+  clobbers on a Tier-2 collision — it drops a `.upstream.<ext>` companion and now
+  tells you it did; the keep/merge/overwrite choice lives in `adapt-to-project`,
+  not the CLI.** The § *Adopter file safety contract* clause **"Tier-2 behaviour
+  on detection"** (which offered "three options: keep … overwrite … (preserving a
+  backup at `<path>.pre-update.bak`) … or invoke the `adapt-to-project` skill")
+  described an in-CLI interactive prompt that was never built and is superseded by
+  the as-shipped design:
+
+  1. **The CLI is deterministic, not interactive.** On every write-capable verb
+     (`install`, `upgrade`, `adapt`, `init-state`, …), a Tier-2 path is preserved
+     byte-for-byte and the upstream version is dropped at `<path>.upstream.<ext>`.
+     The CLI does **not** prompt, read stdin, overwrite, or write a
+     `.pre-update.bak`. This is the contract the `agent-spec-cli` and
+     `distribution-adapters` specs (both Shipped) codified — *"never clobber a
+     Tier-2 file; always emit a `.upstream.<ext>` companion"* — and that
+     `tests/integration/test_tier_invariants.py` pins across all write verbs.
+
+  2. **Interactivity moved to `adapt-to-project`.** The keep / merge / overwrite
+     negotiation the RFC body located in the CLI prompt is owned by the
+     `adapt-to-project` skill, which picks up the `.upstream.<ext>` companions and
+     resolves them with adopter approval (per § *Post-install adaptation* and the
+     `distribution-adapters` spec's companion semantics). A deterministic CLI plus
+     an LLM-driven merge skill is a cleaner split than an in-CLI prompt.
+
+  3. **The CLI surfaces the companion-drop.** Closing the diagnosability gap that
+     made (1) safe to live with: `install` surfaces Tier-2 companions today (its
+     seed-delivery rail prints a stderr notice; its projection-walk companions are
+     recorded in the install-state marker), whereas `upgrade` surfaced nothing.
+     `upgrade` now emits a stderr notice naming the count and the companion
+     path(s), so an adopter can find and merge what was kept. See
+     `docs/specs/upgrade-companion-visibility/` for the implementing spec.
+
+  Approver-signed (@eugenelim, 2026-06-11) as an erratum rather than a superseding
+  RFC: it records an as-built divergence in one clause's *mechanism* (deterministic
+  companion-drop in place of an unbuilt in-CLI prompt), not a change to the Tier-2
+  trust model or the architecture. The frozen body above is unchanged; this
+  annotation is the correction of record.

--- a/docs/specs/upgrade-companion-visibility/plan.md
+++ b/docs/specs/upgrade-companion-visibility/plan.md
@@ -1,0 +1,136 @@
+# Plan: upgrade companion-drop visibility
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Done <!-- Drafting | Executing | Done -->
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn.
+
+## Approach
+
+Two complementary changes in one PR:
+
+1. **Code (bug-fix shape).** In `upgrade.py`'s projection walk, the Tier-2 branch
+   (`upgrade.py:365-374`) writes the `.upstream.<ext>` companion silently. Collect
+   each companion relpath into a per-run list as it is written, then after the
+   walk emit a single stderr summary naming the count and the companion paths.
+   This follows `install.py:891-904`'s seed-companion notice (same "kept as
+   `*.upstream.<ext>` companions" vocabulary, same stderr-not-stdout rationale) and
+   **extends** it by naming the path(s) — `upgrade` has no install-state marker to
+   record them in, unlike `install`'s projection-walk rail (`install.py:809-817`).
+   The Tier-2 write itself and the state update are unchanged; this is purely
+   additive observability. The per-primitive upgrade path (`upgrade.py:335-353`)
+   walks the same Tier-2 branch, so it is covered by the same change.
+
+2. **Governance (erratum).** Add an Approver-signed entry to RFC-0001 § Errata
+   reconciling the frozen body's Tier-2 in-CLI three-option prompt with the shipped
+   companion-drop + surfacing + `adapt-to-project`-owned-interactivity design,
+   matching the existing 2026-05-30 erratum's format. The frozen body is unchanged;
+   the erratum is the correction of record. Resolve the `docs/backlog.md` item.
+
+**Riskiest part:** none in the code (additive stderr). The judgement risk is the
+erratum wording — it must reconcile, not silently rewrite, a frozen Accepted RFC.
+That is why the pre-EXECUTE adversarial review runs on the spec + plan + erratum
+draft before any code.
+
+### The trio
+
+- **Files touched:** `packages/agentbundle/agentbundle/commands/upgrade.py`
+  (companion collection + stderr summary); `packages/agentbundle/tests/integration/test_upgrade_cmd.py`
+  (regression test); `docs/rfc/0001-bundle-distribution-by-adapter-spec.md`
+  (§ Errata entry); `docs/backlog.md` (resolve item); this spec dir.
+- **Tests that show "done":** a new integration test that edits a projected file
+  post-install to force Tier-2, runs `upgrade`, and asserts the companion exists
+  with upstream content, the adopter edit is preserved, and stderr names the
+  companion path; the existing `test_tier_invariants.py` harness stays green.
+- **Not changing:** the Tier-2 file-safety contract (still companion-drop, never
+  clobber); `install.py`; the stdout `upgraded:` recap; non-TTY behavior (identical
+  but for the added stderr line). No `--dry-run`/plan (separate spec).
+
+### Declined patterns
+
+- Tempted to implement RFC-0001's three-option in-CLI prompt (keep / overwrite-with-`.pre-update.bak` / adapt) — **declining**; it clobbers Tier-2, contradicting two Shipped specs + the conformance harness. Reconciled via erratum instead.
+- Tempted to add a `--dry-run` / projection-plan flag now — **declining**; it is a real feature deferred to its own spec, gated on user go/no-go.
+- Tempted to extract `install`'s companion-summary into a shared helper for `upgrade` to reuse — **declining**; two call sites with different surrounding context (install records paths in the install-marker; upgrade in a stderr recap). Inline until a third caller appears (CONVENTIONS: inline a single-use operation).
+- Tempted to surface a full per-file projection manifest (Tier-1 writes too) on every upgrade — **declining**; scope is the silent-companion gap, not a general install log. That is `--dry-run` territory.
+
+## Constraints
+
+- RFC-0001 is **Accepted/frozen**: bodies are immutable; corrections land in
+  § Errata, Approver-signed (CONVENTIONS § 4; the existing 2026-05-30 erratum is
+  the pattern).
+- `agent-spec-cli` and `distribution-adapters` specs are **Shipped/frozen** — no
+  body edits; their Boundaries ("never clobber Tier-2; always emit a companion")
+  are the contract this change must not violate.
+- `test_tier_invariants.py` pins the Tier-2 invariant across `upgrade`; it must
+  stay green unmodified.
+
+## Construction tests
+
+**Integration tests:** see T1 `Tests:`.
+**Manual verification:** none (no TTY-only path; the notice fires in non-TTY too).
+
+## Tasks
+
+### T1: `upgrade` surfaces Tier-2 companion-drops (parity with `install`)
+
+**Depends on:** none
+
+**Touches:** packages/agentbundle/agentbundle/commands/upgrade.py, packages/agentbundle/tests/integration/test_upgrade_cmd.py
+
+**Tests:** (write first, red → green)
+- Install v1 into `tmp_path`; overwrite one projected file with adopter bytes
+  (forces Tier-2 on next upgrade); upgrade to v2 and assert:
+  - the adopter bytes are still on disk at the original path (never clobbered);
+  - the `.upstream.<ext>` companion exists with the v2 content;
+  - **stderr names the companion path** and a count (the new visibility). [AC2]
+- Negative: a clean install→upgrade (no edit) emits **no** companion notice on
+  stderr. [AC3]
+- Regression: `test_tier_invariants.py` (already covers `upgrade`) stays green
+  unmodified. [AC1, AC4]
+
+**Approach:**
+- Initialise an empty `companions: list[str]` before the projection walk.
+- In the Tier-2 branch, after `safety.write_companion(...)`, append
+  `safety.companion_path(Path(relpath)).as_posix()` to `companions`. Leave the
+  existing `pack_state.files[relpath] = {...}` update untouched.
+- After the walk, if `companions`, print a single stderr summary: the count, that
+  the files were modified since install and kept as `*.upstream.<ext>` companions
+  (edits preserved), and the companion path(s). Vocabulary follows
+  `install.py:895-903`, extended to list the path(s).
+
+**Done when:** the new integration tests pass, `test_tier_invariants.py` stays
+green, and `agentbundle upgrade` over a Tier-2 collision prints the companion path
+to stderr while leaving the adopter file untouched.
+
+### T2: RFC-0001 § Errata reconciliation + backlog resolution
+
+**Depends on:** none
+
+**Touches:** docs/rfc/0001-bundle-distribution-by-adapter-spec.md, docs/backlog.md
+
+**Tests:** goal-based —
+- RFC-0001 § Errata gains a dated, Approver-signed (@eugenelim) entry stating the
+  Tier-2 in-CLI prompt is superseded by deterministic companion-drop + surfacing
+  + `adapt-to-project`-owned interactivity; frozen body unchanged. [AC5]
+- `docs/backlog.md`'s `agent-spec-cli` "Tier-2 upgrade prompt" item is removed/
+  resolved (no dangling inbound `#anchor` — it is a plain bullet). [AC5]
+- `python .claude/skills/work-loop/scripts/lint-spec-status.py` passes.
+
+**Approach:**
+- Append an Errata entry below the 2026-05-30 one, same shape (short version,
+  numbered correction, Approver-signed sign-off, pointer to this spec).
+- Delete the resolved backlog bullet (grep first to confirm nothing links it).
+
+**Done when:** the erratum reads as a reconciliation (not a body rewrite), the
+backlog item is gone, and `lint-spec-status.py` is clean.
+
+## Risks
+
+- Erratum wording could read as rewriting the frozen decision rather than
+  recording the as-built divergence. Mitigation: pre-EXECUTE adversarial review;
+  use "superseded by the shipped design" framing, not silent edits to the body.
+
+## Changelog
+
+- 2026-06-11: initial plan.

--- a/docs/specs/upgrade-companion-visibility/spec.md
+++ b/docs/specs/upgrade-companion-visibility/spec.md
@@ -1,0 +1,113 @@
+# Spec: upgrade companion-drop visibility
+
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** RFC-0001 (Tier-2 file-safety contract + this spec's reconciling erratum); `agent-spec-cli` and `distribution-adapters` specs (Shipped) own the contract this consumes.
+- **Contract:** none (no new API surface; consumes the existing Tier-2 / `.upstream.<ext>` contract verbatim)
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+> **Mode: full** — risk trigger: *Compliance/governance surface* (amends a frozen
+> Accepted RFC via an Approver-signed erratum) and a *public-interface change*
+> (new CLI stderr output on `agentbundle upgrade`).
+
+## Objective
+
+When an adopter runs `agentbundle upgrade` and a projected file they have edited
+since install is detected as Tier-2, the CLI preserves their edits and drops the
+upstream version as a `.upstream.<ext>` companion — but today it does so
+**silently**, so the adopter never learns the upgrade skipped their file or where
+the companion landed. `install` surfaces this case (a stderr notice on its
+seed-delivery rail; the install-state marker for its projection-walk companions);
+`upgrade` surfaces nothing. This spec closes that gap: a Tier-2 companion-drop on
+upgrade is announced to the operator (count + the companion path(s)), so they can
+find and merge it. It also
+records, via an RFC-0001 erratum, that the deterministic companion-drop — not the
+RFC's original in-CLI three-option prompt — is the shipped Tier-2 contract, with
+the keep/merge/overwrite interactivity owned by the `adapt-to-project` skill.
+
+## Boundaries
+
+The three-tier guard that keeps an implementing agent inside the lines.
+
+### Always do
+
+- Preserve the Tier-2 file-safety contract verbatim: a Tier-2 path's adopter
+  content is left byte-for-byte unchanged, and the upstream content is written to
+  the `.upstream.<ext>` companion. This contract is owned by the
+  `distribution-adapters` spec; this change consumes it.
+- Emit the new companion-drop notice to **stderr**, so the stdout `upgraded:`
+  recap stays parseable (same rationale as `install.py`'s seed-companion notice).
+- Follow `install`'s companion-notice vocabulary ("kept as `*.upstream.<ext>`
+  companions"), **extended** to also name the companion path(s) — `upgrade` has no
+  install-state marker to record them in, so the path belongs in the notice.
+
+### Ask first
+
+- Any change to the Tier-2 file-safety contract itself (clobber semantics, a
+  backup path, an interactive prompt). That is governance-gated and out of scope.
+
+### Never do
+
+- Reintroduce an in-CLI overwrite or `.pre-update.bak` path, or any keep /
+  overwrite / adapt prompt. Interactivity lives in `adapt-to-project`, by design.
+- Clobber a Tier-2 file, or block the CLI on stdin / make `upgrade` interactive.
+- Break the `test_tier_invariants.py` conformance harness.
+
+## Testing Strategy
+
+- **Companion-drop visibility (AC1–AC4): TDD**, exercised by an **integration**
+  test against the real `upgrade` command — install v1, edit a projected file to
+  force Tier-2, upgrade, and assert on the on-disk effect (original preserved,
+  companion written) and the stderr notice. The behavior only proves out across
+  the install→edit→upgrade boundary, so it lives at the integration surface, not
+  a unit test.
+- **Regression (AC1, AC4): the existing `test_tier_invariants.py` harness stays
+  green** — it already pins "never clobber + companion exists" across `upgrade`.
+  AC4's TTY/non-TTY parity is satisfied **structurally**, not by a dedicated test:
+  the Tier-2 branch reads no stdin and has no `isatty` check, so there is no
+  TTY-dependent code path to diverge (asserting otherwise would only re-prove the
+  compiler).
+- **Erratum + backlog reconciliation (AC5): goal-based** — the RFC-0001 erratum
+  exists and is Approver-signed; the backlog item is resolved; `lint-spec-status.py`
+  passes.
+
+## Acceptance Criteria
+
+- [x] On `agentbundle upgrade`, a Tier-2 path's adopter content is preserved
+  byte-for-byte and the upstream content is written to its `.upstream.<ext>`
+  companion (existing safety invariant; regression-guarded by
+  `test_tier_invariants.py` staying green).
+- [x] When one or more Tier-2 companion-drops occur during an upgrade, the CLI
+  emits a one-per-run summary to **stderr** naming the count and the companion
+  path(s) written; the stdout `upgraded:` recap is unchanged and still parseable.
+- [x] When no Tier-2 collision occurs, `upgrade` emits no companion notice (the
+  summary is conditional).
+- [x] The change adds no in-CLI overwrite/prompt path: no `.pre-update.bak`, no
+  interactive prompt, no stdin read; TTY and non-TTY upgrades behave identically
+  apart from the added stderr notice.
+- [x] RFC-0001 § Errata records the reconciliation (Approver-signed,
+  @eugenelim): the frozen body's Tier-2 in-CLI three-option prompt is superseded
+  by the shipped companion-drop + surfacing + `adapt-to-project`-owned
+  interactivity; the `docs/backlog.md` "Tier-2 upgrade prompt" item is resolved.
+
+## Assumptions
+
+- Technical: `upgrade.py`'s Tier-2 branch calls `safety.write_companion` with no
+  operator notice and no recap tracking (source: `upgrade.py:365-374`, read 2026-06-11).
+- Technical: `install.py` surfaces Tier-2 companions on its **seed-delivery** rail
+  via a stderr count + "kept as *.upstream.<ext> companions" message
+  (`install.py:891-904`); its **projection-walk** companions are recorded in the
+  install-state marker (`new_companions`, `install.py:809-817, 2074, 2113`), not
+  stderr. `upgrade` surfaces neither — this fix adds the stderr notice (read 2026-06-11).
+- Technical: the deterministic Tier-2 companion-drop — not RFC-0001's in-CLI
+  three-option prompt — is the shipped contract, pinned by two Shipped specs and
+  the conformance harness (source: `agent-spec-cli/spec.md` Boundaries,
+  `distribution-adapters/spec.md` §134-154, `test_tier_invariants.py` — read 2026-06-11).
+- Process: the in-CLI three-option prompt is reconciled away via an RFC-0001
+  erratum rather than implemented (source: user confirmation 2026-06-11).
+- Product: a separate `--dry-run` / projection-plan feature (show what/where
+  before writing) is deferred to its own spec, pending go/no-go (source: user
+  confirmation 2026-06-11).

--- a/packages/agentbundle/agentbundle/commands/upgrade.py
+++ b/packages/agentbundle/agentbundle/commands/upgrade.py
@@ -353,6 +353,13 @@ def run(args: "argparse.Namespace") -> int:
         work_projection = projection
 
     # ── Walk projection; apply Tier contract ──────────────────────────────────
+    # Collect `.upstream.<ext>` companions dropped this run so we can surface
+    # them after the walk. Without this notice the upgrade is silent on a
+    # Tier-2 collision — the adopter never learns their edit was kept (and the
+    # upstream parked in a companion) or where to find it. Parity with
+    # install's seed-companion notice (install.py:891-904), extended to name
+    # the path since upgrade has no install-state marker to record it in.
+    companions: list[str] = []
     for relpath, content in sorted(work_projection.items()):
         tier = safety.classify(relpath, root, state)
 
@@ -368,6 +375,7 @@ def run(args: "argparse.Namespace") -> int:
             except safety.PathJailError as exc:
                 print(f"upgrade: {exc}", file=sys.stderr)
                 return 1
+            companions.append(safety.companion_path(Path(relpath)).as_posix())
             pack_state.files[relpath] = {
                 "sha": safety.sha256_bytes(content),
                 "from-pack-version": to_version,
@@ -497,6 +505,21 @@ def run(args: "argparse.Namespace") -> int:
     except safety.PathJailError as exc:
         print(f"upgrade: {exc}", file=sys.stderr)
         return 1
+
+    # ── Surface Tier-2 companion-drops ────────────────────────────────────────
+    # Printed here, after every `return 1` gate above (companion writes, hook-
+    # wiring reconciliation, state write) has passed, so an announced companion
+    # always implies a committed upgrade — never "kept your edits" followed by an
+    # abort. The companion itself was written eagerly during the walk; this only
+    # reports it. stderr (not stdout) so the `upgraded:` recap rail stays parseable.
+    if companions:
+        print(
+            f"upgrade: {len(companions)} file(s) were modified since install and "
+            f"kept as *.upstream.<ext> companions (your edits preserved):",
+            file=sys.stderr,
+        )
+        for comp in companions:
+            print(f"  {comp}", file=sys.stderr)
 
     if is_per_primitive:
         ptype, _src_dir = _PRIMITIVE_FLAG_MAP[prim_flag]

--- a/packages/agentbundle/tests/integration/test_upgrade_cmd.py
+++ b/packages/agentbundle/tests/integration/test_upgrade_cmd.py
@@ -443,3 +443,159 @@ def test_filter_for_primitive_refuses_ambiguous_name():
     import pytest
     with pytest.raises(ValueError, match="ambiguous"):
         _filter_for_primitive(projection, "foo", "skills")
+
+
+# ---------------------------------------------------------------------------
+# 8. Tier-2 companion-drop visibility (upgrade-companion-visibility spec)
+#    A file edited since install is detected Tier-2 on upgrade: the adopter's
+#    edit is preserved, the upstream goes to a `.upstream.<ext>` companion, and
+#    the operator is TOLD (count + companion path) on stderr — closing the
+#    silent-companion diagnosability gap. Regression-paired with the
+#    test_tier_invariants.py harness (never-clobber + companion-exists).
+# ---------------------------------------------------------------------------
+
+# Anchor on the production-unique header phrase so the positive and negative
+# tests bind to the same load-bearing string (they drift together if reworded).
+_COMPANION_NOTICE = "were modified since install and kept as *.upstream.<ext> companions"
+
+
+def _first_projected_on_disk(root: Path, pack_dir: Path) -> str:
+    """Pick a relpath the pack projects that exists on disk after install."""
+    from agentbundle.render import render_pack
+
+    for relpath in sorted(render_pack(pack_dir)):
+        if (root / relpath).exists():
+            return relpath
+    raise AssertionError("no projected file found on disk after install")
+
+
+def test_upgrade_tier2_collision_surfaces_companion_path(tmp_path, capsys):
+    """A file edited since install must, on upgrade: stay byte-for-byte the
+    adopter's (never clobbered), gain a `.upstream.<ext>` companion holding the
+    upstream content, AND have its companion path named on stderr with the
+    'kept as *.upstream.<ext> companions' notice. [AC1, AC2]"""
+    from agentbundle import safety
+    from agentbundle.render import render_pack
+
+    rc = _install_v1(tmp_path)
+    assert rc == 0
+    capsys.readouterr()  # drop install output
+
+    target_rel = _first_projected_on_disk(tmp_path, PACK_V2)
+    adopter_bytes = b"# adopter edits -- do not clobber\n"
+    (tmp_path / target_rel).write_bytes(adopter_bytes)  # forces Tier-2
+
+    rc = _run_upgrade(
+        pack="core", catalogue=str(CAT_V2), to_version="0.2.0", root=str(tmp_path)
+    )
+    assert rc == 0, "upgrade over a Tier-2 collision must still succeed"
+
+    # Never clobbered: the adopter's edit survives at the original path.
+    assert (tmp_path / target_rel).read_bytes() == adopter_bytes, (
+        "Tier-2 file must not be clobbered on upgrade"
+    )
+
+    # Upstream content went to the `.upstream.<ext>` companion.
+    companion_rel = safety.companion_path(Path(target_rel))
+    companion_on_disk = tmp_path / companion_rel
+    assert companion_on_disk.exists(), f"expected companion {companion_rel}"
+    assert companion_on_disk.read_bytes() == render_pack(PACK_V2)[target_rel], (
+        "companion must hold the upstream (v2) content"
+    )
+
+    # The operator is TOLD: notice + count + the companion path on stderr.
+    err = capsys.readouterr().err
+    assert _COMPANION_NOTICE in err, (
+        f"upgrade must announce the companion-drop on stderr; got: {err!r}"
+    )
+    assert "1 file(s)" in err, f"notice must name the count; got: {err!r}"
+    assert companion_rel.as_posix() in err, (
+        f"upgrade must name the companion path on stderr; got: {err!r}"
+    )
+
+
+def test_upgrade_without_collision_emits_no_companion_notice(tmp_path, capsys):
+    """A clean install→upgrade (no adopter edits) is all Tier-1: no companion
+    is dropped and no companion notice is printed. [AC3]"""
+    rc = _install_v1(tmp_path)
+    assert rc == 0
+    capsys.readouterr()  # drop install output
+
+    rc = _run_upgrade(
+        pack="core", catalogue=str(CAT_V2), to_version="0.2.0", root=str(tmp_path)
+    )
+    assert rc == 0
+
+    err = capsys.readouterr().err
+    assert _COMPANION_NOTICE not in err, (
+        f"a collision-free upgrade must not print a companion notice; got: {err!r}"
+    )
+
+
+def test_upgrade_multiple_tier2_collisions_counts_and_lists_all(tmp_path, capsys):
+    """Two files edited since install must both be preserved + companioned, and
+    the notice must report the count (`2 file(s)`) and enumerate both companion
+    paths — pins the count rendering and the plural-path branch. [AC2]"""
+    from agentbundle import safety
+    from agentbundle.render import render_pack
+
+    rc = _install_v1(tmp_path)
+    assert rc == 0
+    capsys.readouterr()
+
+    on_disk = [rp for rp in sorted(render_pack(PACK_V2)) if (tmp_path / rp).exists()]
+    assert len(on_disk) >= 2, "fixture must project at least two files"
+    targets = on_disk[:2]
+    for rp in targets:
+        (tmp_path / rp).write_bytes(f"# adopter edit of {rp}\n".encode())
+
+    rc = _run_upgrade(
+        pack="core", catalogue=str(CAT_V2), to_version="0.2.0", root=str(tmp_path)
+    )
+    assert rc == 0
+
+    err = capsys.readouterr().err
+    assert "2 file(s)" in err, f"notice must report count 2; got: {err!r}"
+    for rp in targets:
+        companion_rel = safety.companion_path(Path(rp)).as_posix()
+        assert companion_rel in err, (
+            f"notice must list every companion path; missing {companion_rel}\n{err!r}"
+        )
+        # And every original is preserved (never clobbered).
+        assert (tmp_path / rp).read_bytes() == f"# adopter edit of {rp}\n".encode()
+
+
+def test_per_primitive_upgrade_surfaces_tier2_companion(tmp_path, capsys):
+    """The companion notice also fires on a per-primitive (`--skill`) upgrade —
+    the same shared walk handles both shapes. Edit a projected work-loop skill
+    file, upgrade just that skill, and assert the companion + notice. [AC2]"""
+    from agentbundle.commands.upgrade import _filter_for_primitive
+    from agentbundle import safety
+    from agentbundle.render import render_pack
+
+    rc = _install_v1(tmp_path)
+    assert rc == 0
+    capsys.readouterr()
+
+    skill_paths = [
+        rp
+        for rp in sorted(_filter_for_primitive(render_pack(PACK_V2), "work-loop", "skills"))
+        if (tmp_path / rp).exists()
+    ]
+    assert skill_paths, "work-loop skill must project at least one file on disk"
+    target_rel = skill_paths[0]
+    (tmp_path / target_rel).write_bytes(b"# adopter-edited skill body\n")
+
+    rc = _run_upgrade(
+        pack="core", catalogue=str(CAT_V2), to_version="0.2.0",
+        root=str(tmp_path), skill="work-loop",
+    )
+    assert rc == 0
+
+    companion_rel = safety.companion_path(Path(target_rel))
+    assert (tmp_path / companion_rel).exists(), "per-primitive upgrade must drop a companion"
+    err = capsys.readouterr().err
+    assert _COMPANION_NOTICE in err, f"per-primitive upgrade must announce it; got: {err!r}"
+    assert companion_rel.as_posix() in err, f"must name the companion path; got: {err!r}"
+    # Adopter edit preserved.
+    assert (tmp_path / target_rel).read_bytes() == b"# adopter-edited skill body\n"


### PR DESCRIPTION
## What does this change?

`agentbundle upgrade` now reports the Tier-2 `.upstream.<ext>` companions it drops — count + each companion path, on stderr after the upgrade commits — closing the silent-companion diagnosability gap at parity with `install`. An Approver-signed RFC-0001 erratum reconciles the frozen body's *unbuilt* in-CLI three-option Tier-2 prompt with the as-shipped deterministic companion-drop design.

## Why?

- **Implements:** `docs/specs/upgrade-companion-visibility/spec.md` (Shipped)
- **Reconciles:** `RFC-0001 § Errata` (2026-06-11). The original draft's in-CLI keep/overwrite-with-`.pre-update.bak`/adapt prompt was never built; the CLI is deterministic companion-drop and the keep/merge/overwrite interactivity is owned by the `adapt-to-project` skill — matching the Shipped `agent-spec-cli` + `distribution-adapters` specs and the `test_tier_invariants.py` conformance harness.
- **Resolves:** the `docs/backlog.md` "Tier-2 upgrade prompt" item.

The original ask was "implement RFC-0001's three-option in-CLI prompt." Pushed back: that prompt's overwrite path **clobbers** a Tier-2 file, which two Shipped specs + the conformance harness forbid. We took the backlog item's named alternative (reconcile the RFC) plus the genuinely-useful, in-charter half — surfacing the companion-drop. The `--dry-run`/projection-plan idea ("show what/where before writing") is parked as its own spec pending go/no-go.

## How do I verify it?

- `cd packages/agentbundle && python -m pytest tests/integration/test_upgrade_cmd.py tests/integration/test_tier_invariants.py` → green. New tests: single-collision (count + path), multi-collision (`2 file(s)` + both paths + both originals preserved), per-primitive `--skill` Tier-2, and a no-notice negative. Regression: the tier-invariants harness still pins "never clobber + companion exists" across `upgrade`.
- Full package suite green (requires `pip install -e ./packages/credbroker[crypto]`, exactly as CI does — `build-check.yml`).
- `make build-check` → exit 0; `lint-spec-status.py` clean.
- Manual: install a pack, edit a projected file, `agentbundle upgrade …` → stderr names the companion path(s); your edit is preserved byte-for-byte.

## What did you not change that you considered?

- **No in-CLI prompt / `.pre-update.bak` / overwrite path** — clobbers Tier-2 (forbidden by two Shipped specs + the harness). Reconciled via the erratum instead.
- **No `--dry-run` / projection-plan** — separate spec, pending go/no-go.
- **Did not extract a shared install/upgrade companion-notice helper** — two call sites, different surrounding context (install records to its state marker; upgrade has none). Inline until a third caller appears.
- **Did not edit any frozen body** (RFC-0001, `agent-spec-cli`, `distribution-adapters`) — corrections recorded in the RFC-0001 erratum only.

**Bundled fixes:** `docs/product/changelog.md` entry; `docs/guides/explanation/file-safety-contract.md` updated (mentions the notice; reframes the superseded prompt).

---

## Checklist

- [x] Tests pass locally (`python -m pytest` in `packages/agentbundle` — green after `pip install -e ./packages/credbroker[crypto]`)
- [x] Lint passes (`make build-check` exit 0; `lint-spec-status.py` clean). No typecheck configured (lint is pack-content).
- [x] Self-review run: `adversarial-reviewer` (pre-EXECUTE on spec/plan/erratum + post-EXECUTE → `Clean — ready to commit.`) and `quality-engineer` (findings applied: notice moved after commit gates; count + per-primitive tests added). No new security boundary, so `security-reviewer` not run.
- [x] Spec and code agree (spec Shipped, all 5 ACs checked, plan Done)
- [x] Living docs match reality: `docs/product/changelog.md` updated; `docs/guides/explanation/file-safety-contract.md` updated. No architecture/roadmap change.
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured (spec Assumptions record the governance-conflict resolution; the RFC-0001 erratum is the durable record)