### PR TITLE
docs(guides): add adapter support matrix reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Loop engineering relocates judgment rather than removing it. Plain-text primitiv
 | Topic | Link |
 | --- | --- |
 | All four install routes (CLI, APM, Claude plugins, local clone) | [install routes](docs/guides/how-to/install-agentbundle-from-clone.md) |
-| Pick a harness (Codex / Copilot / Kiro) and where primitives land | [`docs/contracts/`](docs/contracts/) |
+| What each agent tool supports — skill / subagent / command / hook — and where it degrades | [adapter support matrix](docs/guides/reference/adapter-support.md) |
 | Your edits are never silently overwritten — the file-safety contract | [file-safety contract](docs/guides/explanation/file-safety-contract.md) |
 | Tailor freshly-installed primitives to your repo | [`adapt-to-project`](docs/guides/how-to/adapt-to-project.md) |
 | Upgrading an installed pack | [upgrade packs](docs/guides/how-to/upgrade-packs.md) |

--- a/docs/guides/reference/README.md
+++ b/docs/guides/reference/README.md
@@ -8,6 +8,9 @@
 
 - [`agentbundle.md`](agentbundle.md) — install the CLI, install a pack,
   configure the default adapter.
+- [`adapter-support.md`](adapter-support.md) — the per-tool support matrix:
+  which primitives each agent tool receives (skill / subagent / command / hook)
+  and the runtime caveats, sourced from the adapter contract.
 - [`product-brief-fields.md`](product-brief-fields.md) — the product-brief
   field list and the linkage fields it stamps on derived specs.
 - [`research-pack.md`](research-pack.md) — every primitive in the

--- a/docs/guides/reference/adapter-support.md
+++ b/docs/guides/reference/adapter-support.md
@@ -1,0 +1,74 @@
+# Adapter support matrix
+
+Which agent tools the catalogue projects to, what each one receives, and where a
+tool's own limits mean you get less than the full loop. The README's "any agent
+that reads a skill file inherits it" is true for the **universal layer** (the
+`AGENTS.md` conventions every tool reads); this page is the honest detail
+underneath it — the tool-native primitives, and the caveats.
+
+**Source of truth.** The projection columns below are read from the adapter
+contract, `packages/agentbundle/agentbundle/_data/adapter.toml` (each adapter's
+`[[adapter.<name>.projection]]` rules). If this table and the contract ever
+disagree, the contract wins and the drift is a bug — file it. The *caveats* are
+the verified runtime findings recorded in the specs linked per row.
+
+## The matrix
+
+| Tool | Skill | Subagent | Slash command | Hook | Tier |
+| --- | --- | --- | --- | --- | --- |
+| **Claude Code** | ✅ native | ✅ native | ✅ native | ✅ native + `settings.json` merge | **Full** |
+| **Codex** | ✅ native | ✅ native (`.codex/agents/*.toml`) | ❌ tool-side | ✅ native + `.codex/hooks.json` merge | **Full**¹ |
+| **Copilot** | ✅ instruction file | ⚠️ native, no web tool | ❌ tool-side | ⚠️ user-scope fires; repo-scope regressed | **Partial** |
+| **Kiro CLI** | ✅ native | ✅ native | ❌ tool-side | ✅ body | **Near-full** |
+| **Kiro IDE** | ✅ native | ✅ native | ❌ tool-side | ⚠️ body only; wiring dropped | **Partial** |
+| **Any `AGENTS.md` reader** (Cursor, Gemini CLI, …) | ➖ via `AGENTS.md` | ❌ | ❌ | ❌ | **Universal layer** |
+
+**Legend.** ✅ native — projected to a tool-native file. ➖ — delivered through
+the shared `AGENTS.md` universal layer, not a per-tool file. ⚠️ — projected but
+with a runtime caveat (see the note). ❌ — not projected.
+
+¹ "Full" bar slash commands, which no listed tool below Claude Code supports — see
+the note on commands.
+
+## What "Universal layer" means
+
+Every tool in the matrix — and any future tool that reads `AGENTS.md` — inherits
+the **universal layer**: the `AGENTS.md` conventions, the source-of-truth map, and
+the work-loop discipline, inlined as text the agent reads on every session. That
+is the floor, and it is the same everywhere. The columns above are what each tool
+gets *on top of* that floor as tool-native primitives. A tool with no native
+primitives (Cursor, Gemini CLI) still runs the loop through `AGENTS.md`; it just
+doesn't get per-tool subagent/command/hook files.
+
+## Per-tool caveats
+
+- **Slash commands are dropped on every tool except Claude Code — and that's a
+  tool limit, not a catalogue gap.** Codex deprecated custom prompts, the Copilot
+  CLI doesn't yet load custom slash commands, and Kiro has no slash-command
+  surface. The contract marks `command` as `dropped` for each rather than
+  inventing one. When a tool ships the surface, the mapping is added and tested —
+  not projected speculatively.
+- **Copilot — subagents have no web tool.** Custom Copilot agents expose
+  read/grep/glob but no web fetch/search (verified against CLI 1.0.59), so the
+  `research` pack's retrieval subagents lose live web access on Copilot
+  (read-only degradation). See
+  [`copilot-full-parity`](../../specs/copilot-full-parity/spec.md).
+- **Copilot — repo-scope hooks regressed.** Repo-scope `.github/hooks/*.json`
+  wiring is byte-correct and correctly placed, but the CLI stopped executing it
+  between 1.0.59 and 1.0.60; the identical **user-scope** hook (`~/.copilot/hooks/`)
+  still fires. Version-sensitive; tracked in the `copilot-full-parity` follow-ons.
+- **Kiro IDE — hook-wiring is dropped.** Hook *bodies* project, but the IDE has no
+  settings surface the contract models for wiring, and standalone `.kiro.hook`
+  IDE-event files are not yet a contract primitive. The **Kiro CLI** split
+  (RFC-0022) is the fuller Kiro target. See
+  [`kiro-adapter-split`](../../rfc/0022-kiro-adapter-split.md).
+
+## Choosing a tool
+
+- Want the whole loop with every primitive? **Claude Code.**
+- Terminal-native with near-full parity? **Codex** or **Kiro CLI** (you lose only
+  slash commands, which those tools don't have).
+- On **Copilot**, expect skills + subagents + user-scope hooks to work, and plan
+  around the no-web-tool and repo-hook caveats above.
+- On any other `AGENTS.md`-aware tool, you still get the loop and the
+  conventions through the universal layer — just no tool-native extras.


### PR DESCRIPTION
## What does this change?

Adds a reference page — `docs/guides/reference/adapter-support.md` — that surfaces, in one place, which agent tools the catalogue projects to and what each one receives (skill / subagent / command / hook), plus the per-tool runtime caveats. Links it from the README's `Going deeper` section and registers it in the reference index.

## Why?

The README claims "any agent that reads a skill file inherits it" — true for the universal `AGENTS.md` layer, but it glosses the per-tool detail: `command` is dropped on Codex/Copilot/Kiro (those tools lack custom slash commands — not a catalogue gap), and Copilot/Kiro-IDE carry real degradations (Copilot's missing web tool + repo-scope hook regression; Kiro-IDE's dropped hook-wiring). Evaluators picking a harness need the honest version. Pure documentation — no spec/RFC (additive reference doc, no interface or behavior change; below the work-loop threshold).

## How do I verify it?

- `docs/guides/reference/adapter-support.md` renders; the matrix rows match `packages/agentbundle/agentbundle/_data/adapter.toml` (the page cites it as source of truth, so table-vs-contract drift is a bug).
- README `Going deeper` row points at the matrix; the top-of-README value prop is unchanged (`git diff origin/main -- README.md` is one line).
- Cross-links resolve: `copilot-full-parity` spec, RFC-0022, the contract.

## What did you not change that you considered?

- **No generated table + drift-lint.** Considered deriving the matrix from `adapter.toml` with a `build-check` gate; deferred until drift is actually observed (matches this repo's "escalate to a lint only if drift shows up" stance). The page cites the contract instead.
- **Did not put the link in the hero/install section** — adapter detail is "going deeper," not core value prop; keeping the lead shareable.
- **Did not add a normative `tier` field to the contract** — the tier labels are descriptive doc taxonomy, not a machine-enforced contract field. That would be a separate spec.