### PR TITLE
feat(agentbundle): projection dry-run (--dry-run for install/upgrade)

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -412,3 +412,37 @@ copilot became a full-parity, user-scope-capable adapter — `agent` →
   session CWD is arbitrary, so a relative command path won't resolve — an unsolved follow-on.
   Not exercised today: `core` (the only hook-body pack) is repo-only; no shipped pack ships a
   user-scope copilot hook. Needs a fresh probe of Copilot's user-scope hook CWD semantics.
+
+## `projection-dry-run`
+
+### install dry-run preview governance seeds
+
+- **`install --dry-run` previews the rendered adapter projection only.** The
+  preview walks the per-adapter projection (`.claude/…`, `tools/…`) and labels
+  each file via `_classify_for_install`. It does **not** enumerate the
+  governance **seeds** a real repo-scope install also delivers (`AGENTS.md`,
+  `docs/CHARTER.md`, `docs/CONVENTIONS.md`) — those go through
+  `_common.deliver_seeds`, a content-equality delivery path distinct from the
+  tier classifier. **Blocking:** previewing seeds without writing needs
+  `deliver_seeds` split into a read-only classify half + a write half (today
+  it writes as it walks); the spec forbids forking the classifier or writing
+  under `--dry-run`, so the no-cost path is a refactor, not a copy. **Unblock:**
+  extract `deliver_seeds`' classification into a pure function both the dry-run
+  preview and the real delivery call. Disclosed in the
+  [preview how-to](guides/how-to/preview-install-or-upgrade.md) so the
+  preview's silence on seeds is stated, not implied-complete.
+
+### unify the path-jail projection probe
+
+- **The prefix-jail rule has three near-verbatim copies.** install's standalone
+  Step 8 probe (`install.py`), the new `upgrade --dry-run` probe (`upgrade.py`),
+  and `safety.write_jailed`'s inline prefix block each re-implement "resolve the
+  target, assert it's under the root, assert it starts with an allowed prefix
+  (directory-boundary match)." A change to the matching semantics must touch all
+  three or they drift. **Blocking:** the clean fix extracts a read-only
+  `safety.assert_projection_jailed(root, relpaths, allowed_prefixes, *, command)`
+  and routes install Step 8, the upgrade dry-run probe, **and** the real upgrade
+  write loop through it — but rewiring the non-`--dry-run` write loop was out of
+  scope for the dry-run spec (*Never do: change non-`--dry-run` behavior*).
+  **Unblock:** a focused refactor PR that introduces the helper and migrates all
+  three call sites under its own regression coverage.

--- a/docs/guides/how-to/preview-install-or-upgrade.md
+++ b/docs/guides/how-to/preview-install-or-upgrade.md
@@ -1,0 +1,112 @@
+# How to preview an install or upgrade with `--dry-run`
+
+See exactly what `agentbundle install` or `agentbundle upgrade` *would* do
+to your working tree — which files it creates, which it overwrites, and
+which of your edits it would preserve as `.upstream.<ext>` companions —
+without writing a single byte.
+
+## When to reach for it
+
+- Before the **first install** of a pack into a repo that already has
+  hand-authored files at projection paths (`.claude/…`, `tools/…`), to see
+  which of yours would be kept as companions.
+- Before an **upgrade**, to see how many files moved and whether any of your
+  local edits collide with the new version.
+- In review or CI scripting, when you want the plan as plain text on stdout
+  without committing to the change.
+
+`--dry-run` is read-only: it runs the same pre-flight a real run does
+(resolve the catalogue, build the scope plan, render the projection, probe
+the path-jail), prints the plan, and stops **before** the first write. It
+writes no projected file, no companion, no `.agentbundle-state.toml`, and no
+install marker; it runs no chained `adapt` and prints no `installed:` /
+`upgraded:` recap.
+
+## Prerequisites
+
+- The `agentbundle` CLI on your PATH.
+- For `upgrade`: the pack already installed (and, for APM / Claude-plugin
+  installs, a one-time `agentbundle init-state` so the tier check has a
+  baseline — see [upgrade-packs](upgrade-packs.md)).
+
+## Preview an install
+
+```bash
+agentbundle install <catalogue-uri> --pack core --dry-run
+```
+
+A fresh install previews every file in the rendered adapter projection as a
+`create`:
+
+```
+create    tier-1 .claude/agents/adversarial-reviewer.md
+create    tier-1 .claude/skills/work-loop/SKILL.md
+create    tier-1 tools/hooks/pre-pr.py
+dry-run: 29 file(s) — 29 create. Nothing written.
+```
+
+## Preview an upgrade
+
+```bash
+agentbundle upgrade <catalogue-uri> --pack core --to 0.2.0 --dry-run
+```
+
+When you've edited a projected file since install, that file shows as a
+`companion` line naming the `.upstream.<ext>` the real run would drop
+alongside your edit (your file is never overwritten):
+
+```
+overwrite tier-1 .claude/agents/reviewer.md
+overwrite tier-1 .claude/commands/deploy.md
+companion tier-2 .claude/skills/work-loop/SKILL.md -> .claude/skills/work-loop/SKILL.upstream.md
+dry-run: 20 file(s) — 19 overwrite, 1 companion. Nothing written.
+```
+
+A per-primitive preview narrows the plan to one primitive:
+
+```bash
+agentbundle upgrade <catalogue-uri> --pack core --to 0.2.0 --skill work-loop --dry-run
+```
+
+## How to read the plan
+
+Each line is `<action> <tier> <target path>`:
+
+| Column   | Meaning                                                                 |
+| -------- | ----------------------------------------------------------------------- |
+| `action` | `create` (new file), `overwrite` (Tier-1 file the bundle owns), or `companion` (your edit is kept; the upstream version lands at `<path>.upstream.<ext>`). |
+| `tier`   | `tier-1` (bundle-owned, safe to write), `tier-2` (you edited it — preserved). See the [file-safety contract](../explanation/file-safety-contract.md) for the full tier model. |
+| target   | The path the file would land at, relative to the install root — the "where". For a `companion` line, ` -> ` names the companion path too. |
+
+The closing `dry-run: … Nothing written.` line counts the plan by action and
+restates the no-write guarantee.
+
+## What `--dry-run` does *not* do
+
+- It previews the **rendered adapter projection** (the `.claude/…`, `tools/…`
+  files). It does **not** yet enumerate the governance **seeds** an install
+  also delivers at repo scope (`AGENTS.md`, `docs/CHARTER.md`,
+  `docs/CONVENTIONS.md`) — those use a different, content-equality delivery
+  path. A real install still creates them; the preview just doesn't list them
+  (tracked in [the backlog](../../backlog.md#install-dry-run-preview-governance-seeds)).
+- It does **not** preview `--force`'s destructive cleanup. `agentbundle
+  install --dry-run --force` is refused up front, because `--force` removes
+  leftover files and rewrites state — operations a read-only preview must
+  not perform. Run `--dry-run` without `--force` to preview, or `--force`
+  without `--dry-run` to apply.
+- A present Tier-2 collision does **not** change the exit code — a successful
+  preview exits 0 even with companions in the plan. `--dry-run` is
+  informational; `agentbundle diff` is the verb that gates on drift.
+- If the read-only pre-flight itself would fail (catalogue unresolvable,
+  spec-version mismatch, adapter resolution refused, a path that escapes the
+  jail, pack not installed for `upgrade`, or a pre-RFC-0012 / orphan state
+  install would refuse), `--dry-run` reports it on stderr and exits non-zero
+  — exactly as the real run would at that stage, still writing nothing.
+
+## Related
+
+- [Upgrade an installed pack](upgrade-packs.md) — the real upgrade, once the
+  preview looks right.
+- [The file-safety contract](../explanation/file-safety-contract.md) — why
+  edited files become `.upstream.<ext>` companions.
+- [`agentbundle` reference](../reference/agentbundle.md) — the full flag set.

--- a/docs/guides/reference/agentbundle.md
+++ b/docs/guides/reference/agentbundle.md
@@ -35,8 +35,27 @@ Common flags:
 | `--scope {repo,user}`      | Target install scope; default `repo`.                                                   |
 | `--adapter <name>`         | Override the resolved adapter per-invocation (e.g. `claude-code`, `codex`, `kiro`).     |
 | `--output <dir>`           | Output root; default depends on scope.                                                  |
+| `--dry-run`                | Preview the per-file plan (action + tier + target path) to stdout and exit 0 without writing anything. Refused with `--force`. See [Preview before applying](#preview-before-applying). |
 
 Run `agentbundle install --help` for the complete set.
+
+## Preview before applying
+
+Both `agentbundle install` and `agentbundle upgrade` accept `--dry-run`: it
+runs the full read-only pre-flight, prints a per-file plan to stdout (one
+`<action> <tier> <target>` line each — `create` / `overwrite` / `companion`,
+with Tier-2 lines naming the `.upstream.<ext>` companion), and exits 0
+without writing anything. Diagnostics and pre-flight failures go to stderr.
+
+```bash
+agentbundle install <catalogue-uri> --pack core --dry-run
+agentbundle upgrade <catalogue-uri> --pack core --to 0.2.0 --dry-run
+```
+
+`install --dry-run --force` is refused — `--force`'s destructive cleanup is
+incompatible with a read-only preview. See the
+[preview how-to](../how-to/preview-install-or-upgrade.md) for how to read the
+plan.
 
 ## Configure the default adapter
 

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -19,7 +19,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- (nothing yet)
+- **`--dry-run` previews an install or upgrade without writing anything** —
+  `agentbundle install --dry-run` and `agentbundle upgrade --dry-run` run the
+  full read-only pre-flight, print a per-file plan to stdout (one
+  `<action> <tier> <target>` line each — `create` / `overwrite` /
+  `companion`, with Tier-2 lines naming the `.upstream.<ext>` companion the
+  real run would drop), and exit 0 without touching the tree, state, or
+  install marker. A present Tier-2 collision does not change the exit code;
+  the preview is informational. `install --dry-run --force` is refused
+  (`--force`'s destructive cleanup is incompatible with a read-only preview).
+  The install preview covers the rendered adapter projection; it does not yet
+  enumerate the governance seeds (`AGENTS.md`, `docs/CHARTER.md`,
+  `docs/CONVENTIONS.md`) a real install also delivers. See the
+  [preview how-to](../guides/how-to/preview-install-or-upgrade.md).
 
 ### Changed
 

--- a/docs/specs/projection-dry-run/plan.md
+++ b/docs/specs/projection-dry-run/plan.md
@@ -1,7 +1,7 @@
 # Plan: projection dry-run (`--dry-run` for `install` / `upgrade`)
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Drafting <!-- Drafting | Executing | Done -->
+- **Status:** Done <!-- Drafting | Executing | Done -->
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
 > document is allowed to change as you learn.

--- a/docs/specs/projection-dry-run/spec.md
+++ b/docs/specs/projection-dry-run/spec.md
@@ -1,6 +1,6 @@
 # Spec: projection dry-run (`--dry-run` for `install` / `upgrade`)
 
-- **Status:** Draft <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** none <!-- additive, read-only CLI flag; spec-level per CONVENTIONS §3 -->
@@ -95,38 +95,38 @@ before proceeding; *Never do* is a hard rule, even under time pressure.
 
 ## Acceptance Criteria
 
-- [ ] `agentbundle upgrade --dry-run <pack> --to <v> <catalogue>` prints a
+- [x] `agentbundle upgrade --dry-run <pack> --to <v> <catalogue>` prints a
   per-file plan to stdout — each line naming an action (`create` / `overwrite` /
   `companion`), the tier, and the target relpath; Tier-2 lines also show
   `<path> -> <path>.upstream.<ext>` — and exits 0. **Nothing is written:** no
   projected file, no companion, no state, no hook-wiring change. A per-primitive
   preview (`--dry-run --skill <name>`, etc.) previews only that primitive's files;
   a primitive-not-found still exits non-zero (the pre-render refusal passes through).
-- [ ] `agentbundle install --dry-run <pack> <catalogue>` prints the same shape of
+- [x] `agentbundle install --dry-run <pack> <catalogue>` prints the same shape of
   per-file plan to stdout and exits 0, **writing nothing** — no projected file,
   no companion, no `.agentbundle-state.toml`, no install marker — and running no
   chained `adapt` and emitting no `installed:` recap.
-- [ ] The per-file plan uses stable, greppable tier labels and shows the resolved
+- [x] The per-file plan uses stable, greppable tier labels and shows the resolved
   target path (the "where") for each file, for the scope/adapter the real run
   would target. (Dual-scope writes arise only under `--force`, which `--dry-run`
   refuses — see the `--dry-run --force` criterion below — so a preview targets a
   single scope.)
-- [ ] A present Tier-2 collision does **not** change the exit code (still 0); the
+- [x] A present Tier-2 collision does **not** change the exit code (still 0); the
   preview is informational. (`diff` remains the drift-gating verb.)
-- [ ] When the read-only pre-flight itself would fail — catalogue resolve,
+- [x] When the read-only pre-flight itself would fail — catalogue resolve,
   spec-version gate, adapter-resolution refusal, path-jail violation, pack not
   installed (`upgrade`), or the pre-RFC-0012 / orphan refusal that install's
   Step 3c raises *without* `--force` — `--dry-run` reports it on stderr and exits
   non-zero, matching the real run at that stage, and still writes nothing.
-- [ ] `agentbundle install --dry-run --force …` is refused up front with a
+- [x] `agentbundle install --dry-run --force …` is refused up front with a
   non-zero exit and a stderr message explaining that `--force`'s destructive
   cleanup is incompatible with a read-only preview; **nothing is written** (no
   `rmtree`, no orphan `unlink`, no state rewrite). Previewing *what `--force`
   would clean* is explicitly deferred to a future feature.
-- [ ] The no-write invariant is regression-guarded: an integration test asserts
+- [x] The no-write invariant is regression-guarded: an integration test asserts
   the target tree, state file, and install marker are byte-identical before and
   after a `--dry-run` of both `install` and `upgrade`.
-- [ ] A Diátaxis **how-to** under `docs/guides/how-to/` documents previewing an
+- [x] A Diátaxis **how-to** under `docs/guides/how-to/` documents previewing an
   install/upgrade with `--dry-run` (when to reach for it, how to read the plan
   output, the no-write guarantee), and the CLI **reference** page lists the
   `--dry-run` flag for both commands.

--- a/packages/agentbundle/agentbundle/cli.py
+++ b/packages/agentbundle/agentbundle/cli.py
@@ -272,6 +272,17 @@ def _build_parser() -> argparse.ArgumentParser:
             "mutually exclusive with `--adapter` at that scope."
         ),
     )
+    sp.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Preview the per-file plan (action + tier + target path) without "
+            "writing anything — no projected file, companion, state, or install "
+            "marker, and no chained adapt. Refused with --force (its destructive "
+            "cleanup is incompatible with a read-only preview). Exits 0 on a "
+            "successful preview, even with Tier-2 collisions present."
+        ),
+    )
     sp.set_defaults(func=_lazy("install"))
 
     # --- validate --- (no --scope; schema + rails A/B/C)
@@ -346,6 +357,15 @@ def _build_parser() -> argparse.ArgumentParser:
     sp.add_argument("catalogue", help="Catalogue URI to fetch the new version from.")
     sp.add_argument("--root", default=".")
     sp.add_argument("--scope", choices=("repo", "user"))
+    sp.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Preview the per-file plan (action + tier + target path) without "
+            "writing anything — no projected file, companion, or state change. "
+            "Exits 0 on a successful preview, even with Tier-2 collisions present."
+        ),
+    )
     sp.set_defaults(func=_lazy("upgrade"))
 
     # --- uninstall --- (--scope disambiguator)

--- a/packages/agentbundle/agentbundle/commands/_common.py
+++ b/packages/agentbundle/agentbundle/commands/_common.py
@@ -9,9 +9,12 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from agentbundle.version import SPEC_VERSION
+
+if TYPE_CHECKING:
+    from agentbundle.safety import Tier
 
 
 class SeedDelivery(NamedTuple):
@@ -172,3 +175,71 @@ def _major(version: str) -> str:
     """Return the major component of a version string like '0.1' or 'v2.0'."""
     v = version.lstrip("v")
     return v.split(".")[0]
+
+
+# ---------------------------------------------------------------------------
+# Dry-run plan formatting (shared by `install --dry-run` and `upgrade --dry-run`)
+# ---------------------------------------------------------------------------
+
+# The complete set of action verbs `plan_action` can emit, in display order.
+# `summarize_plan` counts against exactly this tuple, so the two must stay in
+# sync: a new verb returned by `plan_action` must be added here or the summary
+# would silently drop it from the per-action breakdown.
+_PLAN_ACTIONS: tuple[str, ...] = ("create", "overwrite", "companion")
+
+
+def plan_action(tier: "Tier", *, on_disk: bool) -> str:
+    """Map a classified ``Tier`` + on-disk presence to a dry-run plan verb.
+
+    The verb mirrors what a real run would do at that file:
+
+      - ``Tier.TIER_2`` → ``"companion"`` — the adopter edited the file, so a
+        real run drops a ``.upstream.<ext>`` companion and leaves the original.
+      - ``Tier.TIER_1`` already on disk → ``"overwrite"``.
+      - ``Tier.TIER_1`` absent → ``"create"``.
+
+    Shared so a file is labelled identically whether the real run would
+    ``install`` or ``upgrade`` it; the ``Tier`` itself comes from each command's
+    own classifier (`commands.install._classify_for_install` / `safety.classify`)
+    — this helper never reclassifies, it only names the action.
+    """
+    from agentbundle.safety import Tier
+
+    if tier is Tier.TIER_2:
+        return "companion"
+    return "overwrite" if on_disk else "create"
+
+
+def format_plan_line(
+    action: str, tier: str, target: str, companion: str | None = None
+) -> str:
+    """Render one ``--dry-run`` plan line: ``<action> <tier> <target>``.
+
+    For a Tier-2 ``companion`` action the line also names the companion the
+    real run would drop: ``<target> -> <companion>``. ``tier`` is the stable,
+    greppable tier label (``tier-1`` / ``tier-2`` / ``tier-3``). Columns are
+    left-aligned so a multi-line plan reads as a table.
+    """
+    line = f"{action:<9} {tier:<6} {target}"
+    if companion is not None:
+        line += f" -> {companion}"
+    return line
+
+
+def summarize_plan(actions: list[str]) -> str:
+    """One-line count summary closing a ``--dry-run`` plan.
+
+    Counts each action verb (in the fixed order create / overwrite / companion)
+    and restates the no-write guarantee, e.g.
+    ``dry-run: 5 file(s) — 3 create, 2 companion. Nothing written.``
+    """
+    from collections import Counter
+
+    counts = Counter(actions)
+    parts = [
+        f"{counts[verb]} {verb}"
+        for verb in _PLAN_ACTIONS
+        if counts.get(verb)
+    ]
+    body = ", ".join(parts) if parts else "no files"
+    return f"dry-run: {len(actions)} file(s) — {body}. Nothing written."

--- a/packages/agentbundle/agentbundle/commands/install.py
+++ b/packages/agentbundle/agentbundle/commands/install.py
@@ -79,7 +79,12 @@ def run(args: "argparse.Namespace") -> int:
     for the dual-scope contract.
     """
     from agentbundle.catalogue import CatalogueError, resolve_catalogue
-    from agentbundle.commands._common import check_spec_version_gate
+    from agentbundle.commands._common import (
+        check_spec_version_gate,
+        format_plan_line,
+        plan_action,
+        summarize_plan,
+    )
     from agentbundle.config import (
         ConfigError,
         PackState,
@@ -96,6 +101,7 @@ def run(args: "argparse.Namespace") -> int:
     cli_scope: str | None = getattr(args, "scope", None)
     force: bool = bool(getattr(args, "force", False))
     force_merge: bool = bool(getattr(args, "force_merge", False))
+    dry_run: bool = bool(getattr(args, "dry_run", False))
     cli_adapter: str | None = getattr(args, "adapter", None)
     # User-config attached by `cli.py:main()` via args._user_config.
     # Default to None for callers that construct an args namespace by
@@ -113,6 +119,21 @@ def run(args: "argparse.Namespace") -> int:
         print(
             "install: --force-merge is bound to user scope; pass --scope user "
             "or omit --force-merge",
+            file=sys.stderr,
+        )
+        return 1
+
+    # `--dry-run` is a read-only preview; `--force` performs destructive
+    # cleanup (Step 3c's rmtree / orphan unlink / state rewrite). The two are
+    # contradictory — refuse up front, before Step 3c can touch anything, so a
+    # preview never runs that cleanup. Previewing *what --force would clean* is
+    # a separate future feature.
+    if dry_run and force:
+        print(
+            "install: --dry-run is incompatible with --force: --force performs "
+            "destructive cleanup (removing leftover files, rewriting state) that "
+            "a read-only preview must not do. Run --dry-run without --force to "
+            "preview, or --force without --dry-run to apply.",
             file=sys.stderr,
         )
         return 1
@@ -777,6 +798,38 @@ def run(args: "argparse.Namespace") -> int:
                         file=sys.stderr,
                     )
                     return 1
+
+    # ── Dry-run: all read-only pre-flight passed — preview and stop ───────────
+    # At the top of Step 9 (after Step 8's path-jail probe) so every pre-flight
+    # refusal in Steps 1–8 has already returned the real run's exit code (AC5).
+    # Classify each plan's projection with the SAME `_classify_for_install` the
+    # write loop below uses, print the per-file plan to stdout, and return
+    # before any write — skipping the rest of Step 9 and Steps 10–13 (file
+    # writes, seed delivery, state, install marker, chained adapt, `installed:`
+    # recap). `--force` is refused up front, so there is exactly one writing
+    # plan here (dual-scope writes arise only under --force).
+    if dry_run:
+        actions: list[str] = []
+        for plan in plans:
+            if plan.already_installed:
+                continue
+            projection = repo_projection if plan.scope == "repo" else user_projection
+            if projection is None:
+                continue
+            for relpath, content in sorted(projection.items()):
+                tier = _classify_for_install(
+                    relpath, plan.root, content, plan.state, pack_name=pack_name,
+                )
+                action = plan_action(tier, on_disk=(plan.root / relpath).exists())
+                companion = (
+                    safety.companion_path(Path(relpath)).as_posix()
+                    if tier is safety.Tier.TIER_2
+                    else None
+                )
+                print(format_plan_line(action, tier.value, relpath, companion))
+                actions.append(action)
+        print(summarize_plan(actions))
+        return 0
 
     # ── Step 9: All pre-flight passed — perform writes ────────────────────────
     for plan in plans:

--- a/packages/agentbundle/agentbundle/commands/upgrade.py
+++ b/packages/agentbundle/agentbundle/commands/upgrade.py
@@ -68,7 +68,12 @@ def run(args: "argparse.Namespace") -> int:
     Returns 0 on success, non-zero on any failure.
     """
     from agentbundle.catalogue import CatalogueError, resolve_catalogue
-    from agentbundle.commands._common import check_spec_version_gate
+    from agentbundle.commands._common import (
+        check_spec_version_gate,
+        format_plan_line,
+        plan_action,
+        summarize_plan,
+    )
     from agentbundle.config import (
         ConfigError,
         dump_state,
@@ -351,6 +356,61 @@ def run(args: "argparse.Namespace") -> int:
         work_projection = filtered
     else:
         work_projection = projection
+
+    # ── Dry-run: preview the plan and stop before any write ───────────────────
+    # Inserted after `work_projection` is built so it covers both the whole-pack
+    # and the per-primitive (`--skill <name>`, …) shapes — and after every
+    # pre-flight refusal above (catalogue resolve, version gate, adapter
+    # resolution, render, pack-not-installed, primitive-not-found) has already
+    # passed through with the real run's exit code. Classify each file with the
+    # SAME `safety.classify` the write loop below uses — mirroring its
+    # Tier-3→Tier-1 coercion for new paths — print the per-file plan to stdout,
+    # and return before the walk: no companion, no state write, no hook-wiring
+    # reconciliation, no `upgraded:` recap.
+    if getattr(args, "dry_run", False):
+        # Path-jail pre-flight (AC5). Unlike install (which probes every file in
+        # its standalone Step 8 before any write), upgrade enforces the jail
+        # *inside* its write loop via `write_jailed`, so a real upgrade over a
+        # projection that escapes the root would fail non-zero there. Mirror
+        # install's Step 8 probe here — read-only — so the dry-run surfaces the
+        # same refusal before printing any plan, rather than reporting a clean
+        # preview the real run would reject. Deliberately a separate pass before
+        # the print loop (probe-all-then-print): a jail violation on a late file
+        # aborts with a clean stderr refusal instead of a partial plan already
+        # on stdout.
+        for relpath in sorted(work_projection):
+            target = root / relpath
+            try:
+                safety.assert_under(root, target)
+            except safety.PathJailError as exc:
+                print(f"upgrade: {exc}", file=sys.stderr)
+                return 1
+            if allowed_prefixes is not None:
+                target_relpath = (
+                    target.resolve().relative_to(root.resolve()).as_posix()
+                )
+                if not any(target_relpath.startswith(p) for p in allowed_prefixes):
+                    print(
+                        f"upgrade: refusing to write outside allowed prefixes "
+                        f"for scope {effective_scope!r}: {target.resolve()}",
+                        file=sys.stderr,
+                    )
+                    return 1
+        actions: list[str] = []
+        for relpath in sorted(work_projection):
+            tier = safety.classify(relpath, root, state)
+            if tier is safety.Tier.TIER_3:
+                tier = safety.Tier.TIER_1
+            action = plan_action(tier, on_disk=(root / relpath).exists())
+            companion = (
+                safety.companion_path(Path(relpath)).as_posix()
+                if tier is safety.Tier.TIER_2
+                else None
+            )
+            print(format_plan_line(action, tier.value, relpath, companion))
+            actions.append(action)
+        print(summarize_plan(actions))
+        return 0
 
     # ── Walk projection; apply Tier contract ──────────────────────────────────
     # Collect `.upstream.<ext>` companions dropped this run so we can surface

--- a/packages/agentbundle/tests/integration/test_install_cmd.py
+++ b/packages/agentbundle/tests/integration/test_install_cmd.py
@@ -19,6 +19,8 @@ Coverage:
 
 from __future__ import annotations
 
+import argparse
+import contextlib
 import io
 import os
 import tarfile
@@ -451,4 +453,162 @@ def test_install_warns_on_pack_collision(tmp_path, capsys):
     captured = capsys.readouterr()
     assert "also recorded under pack 'other'" in captured.err, (
         f"expected collision warning in stderr: {captured.err!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dry-run preview (projection-dry-run spec): read-only, writes nothing
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+WORK_LOOP_SKILL = ".claude/skills/work-loop/SKILL.md"
+
+
+def _args_core(target: Path, *, force: bool = False, dry_run: bool = False):
+    """Args for installing the real `core` pack at repo scope (per-IDE shape)."""
+    return argparse.Namespace(
+        pack="core",
+        catalogue=str(REPO_ROOT),
+        output=str(target),
+        scope="repo",
+        emit_install_routes=False,
+        force=force,
+        dry_run=dry_run,
+    )
+
+
+def _run_core(args) -> tuple[int, str, str]:
+    from agentbundle.commands.install import run as install_run
+
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        rc = install_run(args)
+    return rc, out.getvalue(), err.getvalue()
+
+
+def _reset_inband_cache() -> None:
+    from agentbundle.commands import install as install_mod
+
+    install_mod._clear_inband_detection_seen()
+
+
+def _snapshot_tree(root: Path) -> dict:
+    return {
+        p.relative_to(root).as_posix(): p.read_bytes()
+        for p in sorted(root.rglob("*"))
+        if p.is_file()
+    }
+
+
+def test_dry_run_install_fresh_previews_create_writes_nothing(tmp_path):
+    """AC2/AC6: a dry-run fresh install lists every projected file with
+    `create`/tier-1 + target path, exits 0, and writes nothing — no projected
+    file, no `.agentbundle-state.toml`, no install marker."""
+    target = tmp_path / "repo"
+    target.mkdir()
+    before = _snapshot_tree(target)
+
+    _reset_inband_cache()
+    rc, out, err = _run_core(_args_core(target, dry_run=True))
+    assert rc == 0, f"dry-run fresh install must exit 0: {err}"
+
+    assert "create" in out, f"fresh install must preview create lines; got:\n{out}"
+    assert "tier-1" in out, f"plan must use the greppable tier-1 label; got:\n{out}"
+    assert ".claude/" in out, f"plan must show the projected target paths; got:\n{out}"
+    assert "Nothing written." in out
+
+    # No-write invariant: tree byte-identical, no state, no marker.
+    assert _snapshot_tree(target) == before, "dry-run install must write nothing"
+    assert not (target / ".agentbundle-state.toml").exists(), "no state file"
+    assert not (target / ".adapt-install-marker.toml").exists(), "no install marker"
+    assert not (target / ".claude").exists(), "no projected files"
+
+
+def test_dry_run_install_over_edited_previews_companion(tmp_path):
+    """AC2/AC4: a dry-run install over an adopter-edited file at a projection
+    path previews the `companion`/tier-2 line, exits 0, writes no companion."""
+    from agentbundle import safety
+
+    target = tmp_path / "repo"
+    (target / ".claude" / "skills" / "work-loop").mkdir(parents=True)
+    edited = b"# my hand-authored work-loop, do not delete\n"
+    (target / WORK_LOOP_SKILL).write_bytes(edited)
+
+    before = _snapshot_tree(target)
+
+    _reset_inband_cache()
+    rc, out, err = _run_core(_args_core(target, dry_run=True))
+    assert rc == 0, f"dry-run install over an edited primitive must exit 0: {err}"
+
+    companion_rel = safety.companion_path(Path(WORK_LOOP_SKILL)).as_posix()
+    assert "companion" in out and "tier-2" in out, f"got:\n{out}"
+    assert f"{WORK_LOOP_SKILL} -> {companion_rel}" in out, (
+        f"Tier-2 line must show the companion target; got:\n{out}"
+    )
+
+    assert _snapshot_tree(target) == before, "dry-run install must write nothing"
+    assert not (target / companion_rel).exists(), "dry-run must not drop a companion"
+    assert (target / WORK_LOOP_SKILL).read_bytes() == edited, "edit left untouched"
+
+
+def test_dry_run_force_refused_leaves_orphan_intact(tmp_path):
+    """AC8/AC6: `--dry-run --force` is refused up front (non-zero + stderr), and
+    over a fixture where `--force` WOULD rmtree/unlink, the orphan crumb is left
+    intact — the destructive Step 3c cleanup never runs. (Its sibling
+    `test_dry_run_step3c_refusal_passthrough` confirms this crumb is a genuine
+    orphan — i.e. the cleanup this test bypasses would really have removed it.)"""
+    target = tmp_path / "repo"
+    (target / ".claude" / "skills" / "work-loop").mkdir(parents=True)
+    crumb = target / ".claude" / "skills" / "work-loop" / "STALE-EXTRA.md"
+    crumb.write_bytes(b"leftover\n")
+    before = _snapshot_tree(target)
+
+    _reset_inband_cache()
+    rc, out, err = _run_core(_args_core(target, force=True, dry_run=True))
+    assert rc != 0, "--dry-run --force must be refused"
+    assert "--force" in err and "--dry-run" in err, (
+        f"stderr must explain the contradiction; got:\n{err}"
+    )
+    assert out == "", "a refused preview prints no plan to stdout"
+
+    # The destructive cleanup that --force alone would do must NOT have run.
+    assert crumb.exists(), "--dry-run --force must not unlink the orphan crumb"
+    assert _snapshot_tree(target) == before, "nothing may change"
+
+
+def test_dry_run_step3c_refusal_passthrough(tmp_path):
+    """AC5: `--dry-run` (no --force) over a non-projection orphan crumb exits
+    non-zero with the same refusal a real run gives, writing nothing."""
+    target = tmp_path / "repo"
+    (target / ".claude" / "skills" / "work-loop").mkdir(parents=True)
+    crumb = target / ".claude" / "skills" / "work-loop" / "STALE-EXTRA.md"
+    crumb.write_bytes(b"leftover\n")
+    before = _snapshot_tree(target)
+
+    _reset_inband_cache()
+    rc, _out, err = _run_core(_args_core(target, dry_run=True))
+    assert rc != 0, "a non-projection crumb must still be refused under --dry-run"
+    assert "your own files" in err, f"the real-run refusal must pass through; got:\n{err}"
+    assert crumb.exists(), "refusal must not delete anything"
+    assert _snapshot_tree(target) == before, "nothing may change"
+
+
+def test_dry_run_preflight_path_jail_passthrough(tmp_path):
+    """AC5: a path-jail-violating projection under `--dry-run` is refused at the
+    Step 8 probe (non-zero), and nothing is written outside the root."""
+    from agentbundle.commands.install import run
+
+    malicious_relpath = "../../malicious_dry_run.txt"
+    fake_projection = {malicious_relpath: b"malicious content"}
+
+    args = types.SimpleNamespace(
+        pack="alpha", catalogue=str(FIXTURE_CATALOGUE), output=str(tmp_path),
+        emit_install_routes=True, dry_run=True,
+    )
+    with mock.patch("agentbundle.render.render_pack", return_value=fake_projection):
+        rc = run(args)
+
+    assert rc != 0, "dry-run must surface the path-jail pre-flight failure"
+    assert not (tmp_path / malicious_relpath).resolve().exists(), (
+        "malicious file must not be written even under dry-run"
     )

--- a/packages/agentbundle/tests/integration/test_upgrade_cmd.py
+++ b/packages/agentbundle/tests/integration/test_upgrade_cmd.py
@@ -40,6 +40,7 @@ def _args_upgrade(
     hook: str | None = None,
     seed: str | None = None,
     command: str | None = None,
+    dry_run: bool = False,
 ) -> types.SimpleNamespace:
     return types.SimpleNamespace(
         pack=pack,
@@ -51,6 +52,7 @@ def _args_upgrade(
         hook=hook,
         seed=seed,
         command=command,
+        dry_run=dry_run,
     )
 
 
@@ -599,3 +601,185 @@ def test_per_primitive_upgrade_surfaces_tier2_companion(tmp_path, capsys):
     assert companion_rel.as_posix() in err, f"must name the companion path; got: {err!r}"
     # Adopter edit preserved.
     assert (tmp_path / target_rel).read_bytes() == b"# adopter-edited skill body\n"
+
+
+# ---------------------------------------------------------------------------
+# Dry-run preview (projection-dry-run spec): read-only, writes nothing
+# ---------------------------------------------------------------------------
+
+
+def _snapshot_tree(root: Path) -> dict[str, bytes]:
+    """Map every file under ``root`` to its bytes, for byte-identical asserts."""
+    return {
+        p.relative_to(root).as_posix(): p.read_bytes()
+        for p in sorted(root.rglob("*"))
+        if p.is_file()
+    }
+
+
+def test_dry_run_upgrade_tier2_collision_previews_companion_writes_nothing(
+    tmp_path, capsys
+):
+    """AC1/AC4/AC6: a dry-run upgrade over an adopter-edited file previews the
+    `companion`/tier-2 line (with the `-> *.upstream` target), exits 0, and
+    leaves the tree + state byte-identical with no companion on disk."""
+    from agentbundle import safety
+    from agentbundle.commands.upgrade import _filter_for_primitive
+    from agentbundle.render import render_pack
+
+    rc = _install_v1(tmp_path)
+    assert rc == 0
+    capsys.readouterr()  # drain install output
+
+    skill_paths = [
+        rp
+        for rp in sorted(_filter_for_primitive(render_pack(PACK_V1), "work-loop", "skills"))
+        if (tmp_path / rp).exists()
+    ]
+    assert skill_paths, "work-loop skill must project at least one file on disk"
+    target_rel = skill_paths[0]
+    (tmp_path / target_rel).write_bytes(b"# adopter-edited skill body\n")
+
+    before = _snapshot_tree(tmp_path)
+
+    rc = _run_upgrade(
+        pack="core", catalogue=str(CAT_V2), to_version="0.2.0",
+        root=str(tmp_path), dry_run=True,
+    )
+    assert rc == 0, "dry-run upgrade must exit 0 even with a Tier-2 collision"
+
+    out = capsys.readouterr().out
+    companion_rel = safety.companion_path(Path(target_rel)).as_posix()
+    assert "tier-2" in out, f"plan must use the greppable tier-2 label; got:\n{out}"
+    assert "companion" in out, f"plan must name the companion action; got:\n{out}"
+    assert f"{target_rel} -> {companion_rel}" in out, (
+        f"Tier-2 line must show the companion target; got:\n{out}"
+    )
+    assert "Nothing written." in out, "summary must restate the no-write guarantee"
+
+    # No-write invariant: tree + state byte-identical, no companion on disk.
+    assert _snapshot_tree(tmp_path) == before, "dry-run upgrade must write nothing"
+    assert not (tmp_path / companion_rel).exists(), (
+        "dry-run must not drop the .upstream companion"
+    )
+
+
+def test_dry_run_upgrade_no_edits_previews_overwrite_writes_nothing(tmp_path, capsys):
+    """AC1/AC3: a dry-run upgrade with no adopter edits lists the projected files
+    with `overwrite`/tier-1 labels and target paths, exits 0, writes nothing."""
+    rc = _install_v1(tmp_path)
+    assert rc == 0
+    capsys.readouterr()
+
+    before = _snapshot_tree(tmp_path)
+
+    rc = _run_upgrade(
+        pack="core", catalogue=str(CAT_V2), to_version="0.2.0",
+        root=str(tmp_path), dry_run=True,
+    )
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    assert "overwrite" in out, f"unedited files must preview as overwrite; got:\n{out}"
+    assert "tier-1" in out, f"plan must use the greppable tier-1 label; got:\n{out}"
+    # A real projected path appears in the plan (the "where").
+    state = __import__("agentbundle.config", fromlist=["load_state"]).load_state(
+        tmp_path / ".agentbundle-state.toml"
+    )
+    a_path = sorted(state.packs["core"].files)[0]
+    assert a_path in out, f"plan must show the target path {a_path!r}; got:\n{out}"
+
+    assert _snapshot_tree(tmp_path) == before, "dry-run upgrade must write nothing"
+
+
+def test_dry_run_upgrade_per_primitive_scopes_to_that_primitive(tmp_path, capsys):
+    """AC1: `--dry-run --skill work-loop` previews only that skill's files;
+    `--dry-run --skill bogus` still exits non-zero (primitive-not-found)."""
+    from agentbundle.commands.upgrade import _filter_for_primitive
+    from agentbundle.render import render_pack
+
+    rc = _install_v1(tmp_path)
+    assert rc == 0
+    capsys.readouterr()
+
+    before = _snapshot_tree(tmp_path)
+
+    rc = _run_upgrade(
+        pack="core", catalogue=str(CAT_V2), to_version="0.2.0",
+        root=str(tmp_path), skill="work-loop", dry_run=True,
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+
+    skill_files = set(_filter_for_primitive(render_pack(PACK_V2), "work-loop", "skills"))
+    assert skill_files, "fixture must project a work-loop skill"
+    for rp in skill_files:
+        assert rp in out, f"per-primitive plan must list {rp!r}; got:\n{out}"
+    # A non-skill file (the reviewer agent) must NOT appear.
+    agent_files = set(_filter_for_primitive(render_pack(PACK_V2), "reviewer", "agents"))
+    for rp in agent_files:
+        assert rp not in out, f"per-primitive plan must exclude {rp!r}; got:\n{out}"
+
+    assert _snapshot_tree(tmp_path) == before, "dry-run must write nothing"
+
+    # Primitive-not-found passes through as a non-zero pre-render refusal.
+    rc = _run_upgrade(
+        pack="core", catalogue=str(CAT_V2), to_version="0.2.0",
+        root=str(tmp_path), skill="bogus", dry_run=True,
+    )
+    assert rc != 0, "a --dry-run for a missing primitive must still exit non-zero"
+    assert _snapshot_tree(tmp_path) == before
+
+
+def test_format_plan_line_shape():
+    """AC3: the shared formatter renders the documented action/tier/path shape,
+    and appends the `-> companion` suffix only for a Tier-2 line."""
+    from agentbundle.commands._common import (
+        format_plan_line,
+        plan_action,
+        summarize_plan,
+    )
+    from agentbundle.safety import Tier
+
+    create = format_plan_line("create", "tier-1", ".claude/agents/foo.md")
+    assert create.split() == ["create", "tier-1", ".claude/agents/foo.md"]
+    assert "->" not in create
+
+    comp = format_plan_line("companion", "tier-2", "AGENTS.md", "AGENTS.upstream.md")
+    assert comp.startswith("companion")
+    assert "tier-2" in comp
+    assert comp.endswith("AGENTS.md -> AGENTS.upstream.md")
+
+    # Action mapping is shared and mirrors a real run's write decision.
+    assert plan_action(Tier.TIER_2, on_disk=True) == "companion"
+    assert plan_action(Tier.TIER_1, on_disk=True) == "overwrite"
+    assert plan_action(Tier.TIER_1, on_disk=False) == "create"
+
+    summary = summarize_plan(["create", "create", "companion"])
+    assert "2 create" in summary and "1 companion" in summary
+    assert summary.endswith("Nothing written.")
+
+
+def test_dry_run_upgrade_preflight_path_jail_passthrough(tmp_path):
+    """AC5: a path-jail-violating projection under `upgrade --dry-run` is refused
+    (non-zero), matching the real run's `write_jailed` refusal, and nothing is
+    written outside the root."""
+    from unittest import mock
+
+    rc = _install_v1(tmp_path)
+    assert rc == 0
+
+    before = _snapshot_tree(tmp_path)
+    # The v1 install used the dist-tree shape, so upgrade renders via
+    # `render_pack`; patch it to return a projection that escapes the root.
+    malicious = {"../../evil_dry_run.txt": b"evil"}
+    with mock.patch("agentbundle.render.render_pack", return_value=malicious):
+        rc = _run_upgrade(
+            pack="core", catalogue=str(CAT_V2), to_version="0.2.0",
+            root=str(tmp_path), dry_run=True,
+        )
+    assert rc != 0, "dry-run must surface the path-jail pre-flight failure"
+    assert not (tmp_path / ".." / ".." / "evil_dry_run.txt").resolve().exists(), (
+        "the escaping file must not be written even under dry-run"
+    )
+    assert _snapshot_tree(tmp_path) == before, "nothing may change"


### PR DESCRIPTION
## What does this change?

Adds a read-only `--dry-run` flag to `agentbundle install` and `agentbundle upgrade`. It runs the full read-only pre-flight, prints a per-file plan to stdout (`<action> <tier> <target>`, with Tier-2 lines naming the `.upstream.<ext>` companion), and stops before the first write — touching nothing.

## Why?

Today the only way to learn what an install/upgrade will do to your tree is to run it. `--dry-run` lets an adopter preview exactly what would change and where, and trust the preview wrote nothing.

- Implements: `docs/specs/projection-dry-run/spec.md` (Shipped; 8/8 ACs)
- Plan: `docs/specs/projection-dry-run/plan.md` (Done)
- Spec + plan merged on main via #266

## How do I verify it?

```bash
pip install -e './packages/credbroker[crypto]'        # else 3 unrelated credbroker tests fail
cd packages/agentbundle && python -m pytest             # full package suite — green
make build-check                                        # exit 0 (lint-packs + build + pre-pr + lint-spec-status)
```

New integration tests cover: the no-write invariant (whole-tree + state + marker byte-identical snapshots before/after a dry-run of both commands), the Tier-2 companion preview line, per-primitive scoping (`--dry-run --skill`), the `--dry-run --force` refusal + no-write stress test over an orphan fixture, and pre-flight passthrough (Step-3c refusal + path-jail) for both commands. A formatter unit test pins the plan-line shape.

Try it live:

```bash
agentbundle install <catalogue> --pack core --dry-run
agentbundle upgrade <catalogue> --pack core --to 0.2.0 --dry-run
```

## What did you not change that you considered?

- **The existing classifiers.** The preview reuses `_classify_for_install` (install) and `safety.classify` (upgrade) verbatim — no fork, so the preview's tiers can't drift from a real run.
- **Non-`--dry-run` behavior of install/upgrade.** Untouched.
- **`--json` output / interactive "ask mode" / dry-run for other write verbs.** Out of v1 scope (spec Boundaries → Ask first).
- **Plan divergence:** the plan's T3 said the new how-to would be listed in `docs/guides/how-to/README.md`, but that README is meta-guidance and indexes no how-tos, so nothing was added there.

## Bundled fixes

- Hoisted `argparse` / `contextlib` to the top import block in `test_install_cmd.py` (dropped two mid-file `# noqa: E402` imports).
- Extracted the `_PLAN_ACTIONS` verb tuple in `_common.py` so `summarize_plan`'s buckets stay in sync with `plan_action`'s outputs.

## Deferred

Tracked in `docs/backlog.md` under `projection-dry-run`:

- **install dry-run does not yet enumerate governance seeds** (`AGENTS.md`, `docs/CHARTER.md`, `docs/CONVENTIONS.md`). Previewing them faithfully needs `deliver_seeds` split into a read-only classify half + a write half; forking the classifier or writing is forbidden by the spec. Disclosed in the how-to and changelog.
- **Unify the path-jail projection probe** across install Step 8, the new upgrade dry-run probe, and `safety.write_jailed`. The clean fix rewires the non-`--dry-run` write loop — out of scope for this spec.

## Reviews

`adversarial-reviewer` → `Clean — ready to commit.` (two Concerns raised and resolved: the upgrade path-jail gap was fixed in-PR; the seed-omission is disclosed). `quality-engineer` → `Clean — ready to commit.` (whole-spec coverage pass; Concerns deferred/applied as above). No security boundary crossed — the feature is read-only.