### PR TITLE
feat(packs): opt research + architect into the cursor adapter (allowed-adapters)

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -522,3 +522,16 @@ distribution-only. Open follow-ons:
   helper + a regression test pinning `"0.11" >= "0.7"`. It was latent (both branches returned
   `DEFAULT_ADAPTER`); the v0.11 bump pushed it into live two-digit territory, so the inline
   comment's "two-digit minor bumps → move into a helper" was honored now.
+- **Pack opt-in for credentialed CLIs — RFC-0013-gated, catalogue-wide.** PR #273 added `cursor`
+  to no pack's `allowed-adapters`; a follow-on PR opted the two non-credentialed full-parity
+  packs (`research`, `architect`) in. The **5 credentialed packs** (atlassian, contracts,
+  converters, figma, credential-brokers) stay on `["claude-code", "kiro-ide", "codex"]`:
+  `credential-brokers` is frozen by RFC-0013 § 4 (§4d ties the `adapter-root-bins/` +
+  `~/.agentbundle/` broker projection to *exactly* the listed adapters), and the four consumer
+  packs functionally depend on the broker admitting `cursor` (a cursor-only user otherwise can
+  install the consumer pack but cannot install the broker → cannot authenticate). Follow-up: an
+  **RFC-0013 erratum** (Approver-signed) admitting `cursor` **and** `copilot` (catalogue-wide
+  uniformity) across all 5, gated on verifying the SSO broker installs/projects/runs on cursor +
+  copilot adapter roots, plus the implementation. Updates the two exact-list test pins —
+  `test_shipped_packs_v07_declarations.py::test_user_scope_packs_allowed_adapters` and
+  `test_credential_brokers_pack_install.py`.

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Cursor can now install the `research` and `architect` packs** — both packs added `cursor`
+  to their `allowed-adapters`, so `agentbundle install --pack research --adapter cursor` (and
+  `--pack architect`) now projects their skills to `.cursor/skills/` — and, for `research`, the
+  two retrieval subagents to `.cursor/agents/` with `readonly: true` — instead of refusing the
+  install up front. The Cursor adapter shipped in the previous release, but no pack had opted
+  in. The credentialed packs (atlassian, contracts, converters, figma, credential-brokers) are
+  not yet Cursor-installable — that expansion is gated on an RFC-0013 erratum (the credential
+  broker's adapter set is frozen by RFC-0013).
 - **`--dry-run` previews an install or upgrade without writing anything** —
   `agentbundle install --dry-run` and `agentbundle upgrade --dry-run` run the
   full read-only pre-flight, print a per-file plan to stdout (one

--- a/docs/specs/cursor-full-parity/plan.md
+++ b/docs/specs/cursor-full-parity/plan.md
@@ -321,4 +321,3 @@ Changelog.
 - 2026-06-11: initial plan. Tasks T1–T7, single PR. Both RFC open questions resolved in the spec
   spike (no-rewrite same-prefix scope; conservative readonly predicate); hook-event-map keyed on
   PascalCase source names (erratum vs RFC-0026, recorded in spec).
-</content>

--- a/docs/specs/cursor-full-parity/spec.md
+++ b/docs/specs/cursor-full-parity/spec.md
@@ -457,4 +457,26 @@ The spec is closed when each observable outcome is verifiable in the merged PR.
     command so the emitted `hooks.json` references the script where it lands — the same rewrite
     `copilot_hooks_json` does for `.github/hooks/`. AC10 updated to pin the rewritten command.
     Repo-scope only; no shipped pack ships a user-scope cursor hook (core is repo-only).
-</content>
+
+- **2026-06-11 — pack opt-in completed for the non-credentialed packs (follow-on PR).** The
+  implementing PR (#273) shipped the adapter but added `cursor` to **no** pack's
+  `allowed-adapters`, leaving it inert except where a line-less pack admits any shipped adapter
+  at repo scope — the opt-in mechanism RFC-0026 § Migration path and [`plan.md`](plan.md)'s Rollout
+  describe ("a new adapter is inert until a pack declares `allowed-adapters = [… "cursor"]`"),
+  never exercised on the explicit allow-list packs. This follow-on opts the two
+  **non-credentialed** full-parity packs in:
+  `research` (the catalogue's parity validation surface — it ships the 2 retrieval subagents +
+  skills the full-parity adapters are checked against; mirrors how `copilot-full-parity` added
+  `copilot` to `research`) and `architect` (workspace-agnostic, pure-markdown skills). **No
+  contract bump** — cursor reuses existing projection modes (no new mode), and both packs
+  already declare a contract version under which cursor's skill/agent projection is valid
+  (`research` v0.12, `architect` v0.10). Parity was verified by rendering `research` through the
+  cursor adapter: 7 skills → `.cursor/skills/<name>/`, both retrieval subagents →
+  `.cursor/agents/<name>.md` with `readonly: true` and `tools` dropped. The **5 credentialed
+  packs** (atlassian, contracts, converters, figma, credential-brokers) are deferred to a
+  follow-on **RFC-0013 erratum**: `credential-brokers`' 3-adapter set is frozen by RFC-0013 § 4
+  (§4d ties the `adapter-root-bins/` + `~/.agentbundle/` broker projection to *exactly* the
+  listed adapters), and the four consumer packs functionally depend on the broker admitting
+  cursor too (a cursor-only user otherwise cannot install the broker and cannot authenticate).
+  That erratum will also backfill `copilot` for catalogue-wide uniformity. See `docs/backlog.md`
+  § `cursor-full-parity`.

--- a/packs/architect/pack.toml
+++ b/packs/architect/pack.toml
@@ -17,6 +17,10 @@ allowed-scopes = ["user", "repo"]
 # travels with every shipped adapter that projects the skill primitive.
 # Current adapter names: RFC-0022 split `kiro` into `kiro-ide`/`kiro-cli`
 # (the bare `kiro` alias is deprecated); RFC-0024 made `copilot`
-# user-scope-capable. `kiro-ide` precedes `kiro-cli` so a Kiro user's
-# `~/.kiro/` auto-probe resolves to the IDE.
-allowed-adapters = ["claude-code", "codex", "copilot", "kiro-ide", "kiro-cli"]
+# user-scope-capable; RFC-0026 / cursor-full-parity added `cursor` (it
+# projects skills to `.cursor/skills/` via the existing direct-directory
+# mode — no new projection mode, so no `[pack.adapter-contract]` bump).
+# Declared order is load-bearing (RFC-0011): `kiro-ide` precedes `kiro-cli`
+# so a Kiro user's `~/.kiro/` auto-probe resolves to the IDE; `cursor`
+# appended last (append-only).
+allowed-adapters = ["claude-code", "codex", "copilot", "kiro-ide", "kiro-cli", "cursor"]

--- a/packs/research/pack.toml
+++ b/packs/research/pack.toml
@@ -14,9 +14,12 @@ version = "0.12"
 [pack.install]
 default-scope = "user"
 allowed-scopes = ["user", "repo"]
-# RFC-0011 / pack-allowed-adapters; copilot added by RFC-0024 / copilot-full-parity.
+# RFC-0011 / pack-allowed-adapters; copilot added by RFC-0024 / copilot-full-parity;
+# cursor added by RFC-0026 / cursor-full-parity (research is the catalogue's parity
+# validation surface — it ships the 2 retrieval subagents + skills the full-parity
+# adapters are checked against). Declared order is load-bearing (RFC-0011): append-only.
 # `kiro-ide` is the current name for the Kiro harness (RFC-0022 split; bare `kiro` deprecated).
-allowed-adapters = ["claude-code", "kiro-ide", "codex", "copilot"]
+allowed-adapters = ["claude-code", "kiro-ide", "codex", "copilot", "cursor"]
 
 # Copilot projection note (docs/specs/copilot-skills-and-web / RFC-0024 § Errata
 # E1): the `evidence-retriever` and `source-extractor` subagents declare


### PR DESCRIPTION
## What & why

The Cursor full-parity distribution adapter (RFC-0026 / ADR-0015, merged #273, contract **v0.12**) was shipped but never added to any pack's `[pack.install] allowed-adapters` — so it was inert on every explicit allow-list pack (it only worked on the four line-less packs that admit any shipped adapter at repo scope). When **copilot** went full-parity it was added to `research`'s allow-list specifically because `research` is the catalogue's parity *validation surface*; cursor's PR skipped that step.

This PR opts the two **non-credentialed** full-parity packs in:

- **`research`** — the catalogue's parity validation surface (ships the 2 retrieval subagents + the skills the full-parity adapters are checked against), mirroring how `copilot-full-parity` added `copilot` here.
- **`architect`** — workspace-agnostic, pure-markdown skills; already carries `copilot`.

This makes cursor's pack footprint identical to the only other shipped full-parity adapter (copilot): `research` + `architect`.

## How it was verified

- **No version bump** — cursor reuses existing projection modes (no new mode per the cursor spec), and both packs already declare a contract version under which cursor's skill/agent projection is valid (`research` v0.12, `architect` v0.10). Confirmed `cursor` is shipped at contract v0.12 in `docs/contracts/adapter.toml`; the `_validate_allowed_adapters` cross-field check passes (cursor is shipped + user-scope-capable).
- **Parity rendered through the cursor adapter:** `research` → 7 skills at `.cursor/skills/<name>/`; `evidence-retriever` + `source-extractor` → `.cursor/agents/<name>.md` with `readonly: true` and `tools` dropped.
- **Gates:** `make build-check` EXIT=0; `build/tests` root 100%; declaration/contract/schema + `credential-brokers`/`copilot` integration tests green; `make build-self FORCE=1` produced **zero** projection drift (no `marketplace.json` ripple); `lint-spec-status` clean. The 3 `credbroker` `test_credential_setup_skill.py` failures are pre-existing/environmental (stash-verified identical on origin/main; `credbroker` not pip-installed locally), not from this change.
- **Adversarial review:** one light-mode pass; 0 Blockers. Concern 1 (a dangling "Rollout note" reference in the spec Changelog) fixed → now points at RFC-0026 § Migration path + `plan.md`'s Rollout. Concern 2 (editing a Status: Shipped spec body) — conscious decision to keep the append, confined to the append-only Changelog section: the repo demonstrably practices post-ship Changelog/accuracy reconciliation on shipped specs (`copilot-full-parity` spec was edited post-ship in #271 and #272).

## What I did NOT change, and why

The **5 credentialed packs** (atlassian, contracts, converters, figma, credential-brokers) are **deliberately deferred**. `credential-brokers` is frozen by **RFC-0013 § 4** (§4d ties the `adapter-root-bins/` + `~/.agentbundle/` broker projection to *exactly* the listed adapters; the pack comment itself says expansion "would need an RFC-0013 erratum"). The four consumer packs functionally depend on the broker admitting cursor (a cursor-only user otherwise can install a consumer pack but cannot install the broker → cannot authenticate). So "Cursor as a supported target for credentialed CLIs" is one governed decision, not free metadata.

## Pushback / open question

This does **not** fully land "all 7 packs" — it lands the 2 that are ungated metadata. Per the agreed plan, the 5 credentialed packs (cursor **and** copilot, catalogue-wide) go through a follow-on **RFC-0013 erratum + implementation**, gated on verifying the SSO broker installs/projects/runs on cursor + copilot adapter roots.

## Bundled fixes

- Removed a stray pre-existing `</content>` authoring artifact from `docs/specs/cursor-full-parity/spec.md:460` and `plan.md:324` (same-directory, mechanical).

## Deferred

- **Pack opt-in for credentialed CLIs (RFC-0013-gated, catalogue-wide)** — see `docs/backlog.md` § `cursor-full-parity`. Follow-on RFC-0013 erratum admitting cursor + copilot across the 5 credentialed packs.