### PR TITLE
feat(packs): admit copilot + cursor for credentialed packs (RFC-0013 erratum)

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -522,16 +522,13 @@ distribution-only. Open follow-ons:
   helper + a regression test pinning `"0.11" >= "0.7"`. It was latent (both branches returned
   `DEFAULT_ADAPTER`); the v0.11 bump pushed it into live two-digit territory, so the inline
   comment's "two-digit minor bumps → move into a helper" was honored now.
-- **Pack opt-in for credentialed CLIs — RFC-0013-gated, catalogue-wide.** PR #273 added `cursor`
-  to no pack's `allowed-adapters`; a follow-on PR opted the two non-credentialed full-parity
-  packs (`research`, `architect`) in. The **5 credentialed packs** (atlassian, contracts,
-  converters, figma, credential-brokers) stay on `["claude-code", "kiro-ide", "codex"]`:
-  `credential-brokers` is frozen by RFC-0013 § 4 (§4d ties the `adapter-root-bins/` +
-  `~/.agentbundle/` broker projection to *exactly* the listed adapters), and the four consumer
-  packs functionally depend on the broker admitting `cursor` (a cursor-only user otherwise can
-  install the consumer pack but cannot install the broker → cannot authenticate). Follow-up: an
-  **RFC-0013 erratum** (Approver-signed) admitting `cursor` **and** `copilot` (catalogue-wide
-  uniformity) across all 5, gated on verifying the SSO broker installs/projects/runs on cursor +
-  copilot adapter roots, plus the implementation. Updates the two exact-list test pins —
-  `test_shipped_packs_v07_declarations.py::test_user_scope_packs_allowed_adapters` and
-  `test_credential_brokers_pack_install.py`.
+- **Pack opt-in for credentialed CLIs — RFC-0013-gated, catalogue-wide. Resolved 2026-06-12.**
+  PR #273 added `cursor` to no pack's `allowed-adapters`; #276 opted the two non-credentialed
+  full-parity packs (`research`, `architect`) in. The 5 credentialed packs (atlassian, contracts,
+  converters, figma, credential-brokers) now declare
+  `["claude-code", "kiro-ide", "codex", "copilot", "cursor"]` via **RFC-0013 § Errata
+  (2026-06-12)** — both full-parity adapters already declare `.agentbundle/` in
+  `allowed-prefixes.user` (the § 4d precondition), and the broker delivery rail is
+  adapter-agnostic; verified by real cursor/copilot installs of the broker + a consumer pack. No
+  contract change. Full record: RFC-0013 § Errata + `docs/specs/credential-broker-contract/spec.md`
+  § Changelog (2026-06-12).

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -24,9 +24,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--pack architect`) now projects their skills to `.cursor/skills/` — and, for `research`, the
   two retrieval subagents to `.cursor/agents/` with `readonly: true` — instead of refusing the
   install up front. The Cursor adapter shipped in the previous release, but no pack had opted
-  in. The credentialed packs (atlassian, contracts, converters, figma, credential-brokers) are
-  not yet Cursor-installable — that expansion is gated on an RFC-0013 erratum (the credential
-  broker's adapter set is frozen by RFC-0013).
+  in. (The credentialed packs are covered by the next entry.)
+- **Credentialed packs can now install via Cursor and Copilot** — `atlassian`, `contracts`,
+  `converters`, `figma`, and `credential-brokers` added `copilot` + `cursor` to their
+  `allowed-adapters`, so a Cursor- or Copilot-based adopter can install them (and the SSO/token
+  broker lands at `~/.agentbundle/bin/` as before — the broker delivery is adapter-independent).
+  Previously these packs admitted only `claude-code`, `kiro-ide`, and `codex`. Recorded as an
+  RFC-0013 § Errata decision; no contract change (both adapters already declare the
+  `.agentbundle/` install prefix the broker needs).
 - **`--dry-run` previews an install or upgrade without writing anything** —
   `agentbundle install --dry-run` and `agentbundle upgrade --dry-run` run the
   full read-only pre-flight, print a per-file plan to stdout (one

--- a/docs/rfc/0013-credential-broker-contract.md
+++ b/docs/rfc/0013-credential-broker-contract.md
@@ -1950,3 +1950,49 @@ record. Corrections are appended here, Approver-signed.
   `docs/specs/credential-broker-contract/spec.md` § Changelog (2026-05-31):
   AC27/AC28/AC34 superseded, AC30 takes the canonical-reference designation,
   consumer count six → five.
+
+- **2026-06-12 (Approver: eugenelim) — the five credentialed packs admit
+  `copilot` and `cursor`; § 4's three-harness `allowed-adapters` set widens
+  to five.** § 4 / § 4d scoped the broker pack's `allowed-adapters` to
+  `["claude-code", "kiro-ide", "codex"]` because the `adapter-root-bins/`
+  projection writes the SSO broker to `~/.agentbundle/bin/`, and at RFC time
+  only those three adapters declared `.agentbundle/` in
+  `allowed-prefixes.user` (the RFC itself amended claude-code and kiro to
+  add it). The set was a function of that precondition — not of any
+  credential-handling property of the adapters.
+
+  **Why the set widens now.** Two adapters shipped since have added
+  `.agentbundle/` to their own `allowed-prefixes.user` (for their install
+  state): `copilot` (`copilot-full-parity`, contract v0.10) and `cursor`
+  (`cursor-full-parity`, contract v0.11). The § 4d precondition therefore
+  now holds for both. The user-scope `.agentbundle/{lib,bin}/` delivery rail
+  (`install.py` `_deliver_user_scope_floor`) is **adapter-agnostic** — it
+  fires for any user-scope install and is fenced only by the target
+  adapter's `.agentbundle/` prefix, with no per-adapter allow-list. Verified
+  by a real user-scope install of `credential-brokers` via both `cursor` and
+  `copilot`: `~/.agentbundle/bin/sso-broker.py` and
+  `~/.agentbundle/lib/credbroker/` land, and the `credential-setup` skill
+  projects to `.cursor/skills/` / `~/.copilot/skills/`. The four consumer
+  packs (`atlassian`, `contracts`, `converters`, `figma`) ship skills only
+  (the `creds` shim is build-baked into their `scripts/`) and resolve the
+  broker from the canonical `~/.agentbundle/bin/`; they widen in lockstep so
+  a `cursor`/`copilot`-only adopter can install both the broker and its
+  consumers rather than a half-working consumer with no broker. All five now
+  declare `["claude-code", "kiro-ide", "codex", "copilot", "cursor"]`.
+
+  **No contract change.** The prefix precondition is already satisfied by the
+  shipped contract (v0.12) — no `allowed-prefixes` amendment, no version
+  bump. This erratum records a widening *permitted by* the current contract,
+  not a contract change.
+
+  **What is unchanged.** The four-broker contract, the two transports, the
+  in-process `creds` shim, the subprocess `sso-cookie` broker at the
+  canonical adapter-independent `~/.agentbundle/bin/`, the no-leak guarantees
+  (RFC-0006 § 1), and the brokers-not-skills architecture are untouched. Only
+  `allowed-adapters` membership widens.
+
+  **Where this is recorded.** Implementation (the five pack.toml edits + the
+  two exact-list test-pin updates) lands in
+  `docs/specs/credential-broker-contract/spec.md` § Changelog (2026-06-12);
+  the cursor opt-in follow-on in `docs/backlog.md` § `cursor-full-parity`
+  closes.

--- a/docs/specs/credential-broker-contract/spec.md
+++ b/docs/specs/credential-broker-contract/spec.md
@@ -230,6 +230,28 @@ The spec is closed when each of the following observable outcomes is verifiable 
 
 ## Changelog
 
+- 2026-06-12 (adapter set widened to five) — The `credential-brokers` pack
+  and its four consumer packs (`atlassian`, `contracts`, `converters`,
+  `figma`) now declare `allowed-adapters = ["claude-code", "kiro-ide",
+  "codex", "copilot", "cursor"]`, adding `copilot` + `cursor` to the RFC-0013
+  § 4 three-harness set. The widening is recorded as **RFC-0013 § Errata
+  (2026-06-12, Approver: eugenelim)**: § 4d scoped the set to three because
+  only those adapters declared `.agentbundle/` in `allowed-prefixes.user`
+  (the precondition for writing the broker to `~/.agentbundle/bin/`);
+  `copilot` (copilot-full-parity, v0.10) and `cursor` (cursor-full-parity,
+  v0.11) have since added that prefix, and the `.agentbundle/{lib,bin}/`
+  delivery rail (`install.py` `_deliver_user_scope_floor`) is
+  adapter-agnostic (fenced only by the prefix, no per-adapter allow-list).
+  **No contract change** — the precondition is satisfied by the shipped
+  contract (v0.12); no `allowed-prefixes` amendment, no version bump.
+  Verified by a real user-scope install of `credential-brokers` + `atlassian`
+  via both `cursor` and `copilot` (broker bin/lib land under
+  `~/.agentbundle/`; `credential-setup` + consumer skills project to the
+  adapter's skills dir). Test pins updated:
+  `test_shipped_packs_v07_declarations.py::test_user_scope_packs_allowed_adapters`
+  and `test_credential_brokers_pack_install.py::test_install_block_shape`.
+  The broker architecture, transports, shim, and no-leak guarantees are
+  unchanged.
 - 2026-05-31 — Status reconciled to Shipped (retroactive). The implementation is fully merged: the `credential-brokers` pack (`packs/credential-brokers/`), the `credentials_shim.py` projected into every consumer's `scripts/` + `.agentbundle/bin/`, the `sso-broker.py` adapter-root-bin, the `metadata.auth` broker-id frontmatter + lint, the six in-tree consumer migrations, and the `agentbundle.credentials`/`creds/` removal at 0.2.0. Per the 2026-05-29 erratum below, AC42's closure rule is reconciled to the open-items-only `backlog.md` convention (track-by-presence, no heading suffix). **Implementation-complete, acceptance-pending:** the manual-QA matrix transcripts (six broker × OS rows, gated on real corporate-SSO endpoint access) and the deferred security-hardening items (D3 AST dotfile-read walk; runtime shim-integrity guard; projection-path test coverage) remain open in `docs/backlog.md` § credential-broker-contract. This follows the same Shipped-with-deferred-manual-QA shape as `apm-install-route-parity` (AC17) and `adapt-to-project` (AC4b). This supersedes the 2026-05-27 "flipping to Shipped is gated on transcripts" note, which predated the open-items-only recuration.
 - 2026-05-31 (retire teaching skills) — The two RFC-0013 §9 *teaching*
   skills in `core` — `add-credentialed-skill` (author procedure) and

--- a/packages/agentbundle/agentbundle/build/tests/test_shipped_packs_v07_declarations.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_shipped_packs_v07_declarations.py
@@ -50,15 +50,19 @@ class TestUserScopePacksV07(unittest.TestCase):
                 )
 
     def test_user_scope_packs_allowed_adapters(self) -> None:
-        """allowed-adapters is the RFC-0011 three-harness set, de-staled
-        to current adapter names (RFC-0022 renamed bare `kiro` →
-        `kiro-ide`). The harness set is unchanged; only the spelling is."""
+        """allowed-adapters started as the RFC-0011 three-harness set,
+        de-staled to current adapter names (RFC-0022 renamed bare `kiro` →
+        `kiro-ide`), then widened to add `copilot` + `cursor` by RFC-0013
+        § Errata (2026-06-12): both full-parity adapters now declare
+        `.agentbundle/` in `allowed-prefixes.user` (the broker's § 4d
+        precondition), so these credentialed consumer packs admit them in
+        lockstep with `credential-brokers`. Order is append-only (RFC-0011)."""
         for name in USER_SCOPE_PACKS:
             with self.subTest(pack=name):
                 pack = _load_pack_toml(name)
                 self.assertEqual(
                     pack["pack"]["install"]["allowed-adapters"],
-                    ["claude-code", "kiro-ide", "codex"],
+                    ["claude-code", "kiro-ide", "codex", "copilot", "cursor"],
                     f"{name} declared adapter set wrong",
                 )
 

--- a/packages/agentbundle/tests/integration/test_credential_brokers_pack_install.py
+++ b/packages/agentbundle/tests/integration/test_credential_brokers_pack_install.py
@@ -76,9 +76,13 @@ class PackManifestShapeTests(unittest.TestCase):
         install_block = self.pack_toml["pack"]["install"]
         self.assertEqual(install_block["default-scope"], "user")
         self.assertEqual(install_block["allowed-scopes"], ["user", "repo"])
+        # RFC-0013 § 4 shipped the three-harness set; § Errata (2026-06-12)
+        # widened it to add `copilot` + `cursor` — both since declared
+        # `.agentbundle/` in `allowed-prefixes.user`, the § 4d precondition,
+        # so the adapter-agnostic broker delivery rail reaches them.
         self.assertEqual(
             install_block["allowed-adapters"],
-            ["claude-code", "kiro-ide", "codex"],
+            ["claude-code", "kiro-ide", "codex", "copilot", "cursor"],
         )
 
 

--- a/packages/agentbundle/tests/integration/test_install_user_scope_allowed_adapters.py
+++ b/packages/agentbundle/tests/integration/test_install_user_scope_allowed_adapters.py
@@ -8,10 +8,12 @@ and (b) `~/.agentbundle/state.toml` records the resolved adapter.
 
 Reference idiom mirrors `test_install_converters_user_scope.py`:
 in-process `install.run`, `$HOME` patched via `patch.dict`. The four
-catalogue user-scope packs ship `allowed-adapters = ["claude-code",
-"kiro-ide", "codex"]` (the bare `kiro` alias was de-staled to its
-current RFC-0022 name), so this test covers the resolver's three
-adapter-target paths without fabricating fixtures.
+credentialed user-scope packs ship `allowed-adapters = ["claude-code",
+"kiro-ide", "codex", "copilot", "cursor"]` — the bare `kiro` alias was
+de-staled to its current RFC-0022 name, and `copilot` + `cursor` were
+added by RFC-0013 § Errata (2026-06-12). This test covers the
+claude-code / kiro-ide / codex resolver paths without fabricating
+fixtures; it asserts install behaviour, not list equality.
 """
 
 from __future__ import annotations

--- a/packs/atlassian/pack.toml
+++ b/packs/atlassian/pack.toml
@@ -12,5 +12,9 @@ allowed-scopes = ["user", "repo"]
 # RFC-0011 / pack-allowed-adapters. Declared order also drives the
 # greenfield fallback (claude-code matches DEFAULT_USER_SCOPE_ADAPTER).
 # `kiro-ide` is the current name for the Kiro harness (RFC-0022 split;
-# bare `kiro` deprecated).
-allowed-adapters = ["claude-code", "kiro-ide", "codex"]
+# bare `kiro` deprecated). copilot + cursor added by RFC-0013 § Errata
+# (2026-06-12): the full-parity adapters are admitted for credentialed CLIs
+# now that both declare `.agentbundle/` in `allowed-prefixes.user` (the
+# § 4d precondition); the consumer skills resolve the broker from
+# `~/.agentbundle/bin/`. Append-only (RFC-0011 declared-order).
+allowed-adapters = ["claude-code", "kiro-ide", "codex", "copilot", "cursor"]

--- a/packs/contracts/pack.toml
+++ b/packs/contracts/pack.toml
@@ -10,5 +10,8 @@ version = "0.8"
 default-scope = "user"
 allowed-scopes = ["user", "repo"]
 # RFC-0011 / pack-allowed-adapters. `kiro-ide` is the current name for
-# the Kiro harness (RFC-0022 split; bare `kiro` deprecated).
-allowed-adapters = ["claude-code", "kiro-ide", "codex"]
+# the Kiro harness (RFC-0022 split; bare `kiro` deprecated). copilot +
+# cursor added by RFC-0013 § Errata (2026-06-12): the full-parity adapters
+# are admitted for credentialed CLIs now that both declare `.agentbundle/`
+# in `allowed-prefixes.user` (the § 4d precondition). Append-only.
+allowed-adapters = ["claude-code", "kiro-ide", "codex", "copilot", "cursor"]

--- a/packs/converters/pack.toml
+++ b/packs/converters/pack.toml
@@ -10,5 +10,8 @@ version = "0.8"
 default-scope = "user"
 allowed-scopes = ["user", "repo"]
 # RFC-0011 / pack-allowed-adapters. `kiro-ide` is the current name for
-# the Kiro harness (RFC-0022 split; bare `kiro` deprecated).
-allowed-adapters = ["claude-code", "kiro-ide", "codex"]
+# the Kiro harness (RFC-0022 split; bare `kiro` deprecated). copilot +
+# cursor added by RFC-0013 § Errata (2026-06-12): the full-parity adapters
+# are admitted for credentialed CLIs now that both declare `.agentbundle/`
+# in `allowed-prefixes.user` (the § 4d precondition). Append-only.
+allowed-adapters = ["claude-code", "kiro-ide", "codex", "copilot", "cursor"]

--- a/packs/credential-brokers/pack.toml
+++ b/packs/credential-brokers/pack.toml
@@ -9,8 +9,14 @@ version = "0.7"
 [pack.install]
 default-scope = "user"
 allowed-scopes = ["user", "repo"]
-# RFC-0011 / pack-allowed-adapters. RFC-0013 § 4 commits to these three
-# harnesses; `kiro-ide` is the current name for the Kiro harness
-# (RFC-0022 split; bare `kiro` deprecated). Stays three — adding copilot
-# would need an RFC-0013 erratum, out of scope for this rename.
-allowed-adapters = ["claude-code", "kiro-ide", "codex"]
+# RFC-0011 / pack-allowed-adapters. RFC-0013 § 4 originally committed to
+# three harnesses because only they declared `.agentbundle/` in
+# `allowed-prefixes.user` (the § 4d precondition for writing the broker to
+# `~/.agentbundle/bin/`). `copilot` (copilot-full-parity) and `cursor`
+# (cursor-full-parity) have since added `.agentbundle/` to their user
+# prefixes, so RFC-0013 § Errata (2026-06-12, Approver: eugenelim) admits
+# both — the broker delivery rail is adapter-agnostic, fenced only by that
+# prefix. `kiro-ide` is the current name for the Kiro harness (RFC-0022
+# split; bare `kiro` deprecated). Declared order is load-bearing
+# (RFC-0011): append-only.
+allowed-adapters = ["claude-code", "kiro-ide", "codex", "copilot", "cursor"]

--- a/packs/figma/pack.toml
+++ b/packs/figma/pack.toml
@@ -10,5 +10,8 @@ version = "0.8"
 default-scope = "user"
 allowed-scopes = ["user", "repo"]
 # RFC-0011 / pack-allowed-adapters. `kiro-ide` is the current name for
-# the Kiro harness (RFC-0022 split; bare `kiro` deprecated).
-allowed-adapters = ["claude-code", "kiro-ide", "codex"]
+# the Kiro harness (RFC-0022 split; bare `kiro` deprecated). copilot +
+# cursor added by RFC-0013 § Errata (2026-06-12): the full-parity adapters
+# are admitted for credentialed CLIs now that both declare `.agentbundle/`
+# in `allowed-prefixes.user` (the § 4d precondition). Append-only.
+allowed-adapters = ["claude-code", "kiro-ide", "codex", "copilot", "cursor"]


### PR DESCRIPTION
## What & why

Follow-on to #276. That PR opted the two **non-credentialed** full-parity packs (`research`, `architect`) into the Cursor adapter and deferred the 5 credentialed packs to an RFC-0013 erratum. This PR is that erratum + implementation.

Widens `allowed-adapters` for the five credentialed packs — **atlassian, contracts, converters, figma, credential-brokers** — from `["claude-code", "kiro-ide", "codex"]` to:

```
["claude-code", "kiro-ide", "codex", "copilot", "cursor"]
```

So a Cursor- or Copilot-based adopter can install the credentialed CLIs (and the credential broker they depend on). This makes the credentialed packs' adapter set identical to `research`'s — catalogue-wide uniformity across the full-parity adapters.

## The governance gate, and why it opens cleanly

RFC-0013 § 4 / §4d scoped `credential-brokers` to exactly three adapters because the `adapter-root-bins/` projection writes the SSO broker to `~/.agentbundle/bin/`, and **at RFC time only those three declared `.agentbundle/` in `allowed-prefixes.user`** (the RFC itself amended claude-code + kiro to add it). The limit was a function of that precondition, not of any credential property of the adapters.

Since then, **both** `copilot` (copilot-full-parity, contract v0.10) and `cursor` (cursor-full-parity, v0.11) added `.agentbundle/` to their own user prefixes for their install state. The `.agentbundle/{lib,bin}/` delivery rail (`install.py` `_deliver_user_scope_floor`) is **adapter-agnostic** — it fires for any user-scope install, fenced only by that prefix, with no per-adapter allow-list. So the precondition now holds for both, and **no contract change / no version bump** is needed.

Recorded as **RFC-0013 § Errata** (2026-06-12, Approver: eugenelim) — the append-only frozen-doc vehicle, matching the section's existing precedent entry — plus a `credential-broker-contract` spec Changelog entry.

## How it was verified

- **Real user-scope install** of `credential-brokers` + `atlassian` via **both cursor and copilot** into a temp `$HOME`: `~/.agentbundle/bin/sso-broker.py` and `~/.agentbundle/lib/credbroker/` land; `credential-setup` + the atlassian consumer skills project to the adapter's skills dir. The broker never lands inside the LLM-addressable skills tree.
- **Gates:** full pytest both roots EXIT=0 (incl. the 2 updated exact-list pins + credential-brokers + multi-pack + user-scope-adapters integration tests); `make build-check` EXIT=0; `build-self FORCE=1` zero projection drift; `lint-spec-status` clean.
- **Reviews:** `adversarial-reviewer` → Clean. `security-reviewer` → no Blockers/Concerns (threat model resolves cleanly: broker stays at `~/.agentbundle/{bin,lib}`, path-jail holds for both adapters, the one LLM-addressable `credential-setup` skill is unchanged); its 1 Nit (a stale reference docstring) is fixed in this PR.

## Security note

This crosses a credential boundary, so it got a dedicated security pass. No credential no-leak guarantee changes: the `creds` shim stays in-process, the `sso-cookie` broker stays a subprocess at the canonical adapter-independent `~/.agentbundle/bin/` (outside any adapter's skills dir), and consumer packs ship skills only (the shim is build-baked into their `scripts/`). The change is purely *which adapters may install these packs*.

## Bundled fixes

- Updated a stale reference docstring in `test_install_user_scope_allowed_adapters.py` (still claimed the three-adapter set for `converters`, which this change widens).

## Closes

- The catalogue-wide credentialed follow-on tracked in `docs/backlog.md § cursor-full-parity` (resolved-tombstone retained; full record in RFC-0013 § Errata + the credential spec Changelog).