### PR TITLE
release(agentbundle): 0.3.0

### DIFF
--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -6,6 +6,42 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 — a minor bump on a 0.x release MAY be breaking.
 
+## [0.3.0] — 2026-06-12
+
+### Added
+
+- **Cursor full-parity distribution adapter** (RFC-0026) — projects all
+  primitives for both install scopes via the single-writer
+  `.cursor/` model.
+- **Gemini CLI full-parity distribution adapter** (RFC-0027) — keeps and
+  maps tools, projects a tier model map, supports the
+  `gemini-command-toml` mode, and bridges `AGENTS.md` through the
+  single-writer `.gemini/settings.json`.
+- **`--dry-run` for `install` and `upgrade`** — preview the projection
+  without writing any files.
+- **Upgrade surfaces Tier-2 companion-drops** — `upgrade` now reports the
+  `.upstream` companion files that an adopter must reconcile by hand.
+- **credbroker install-time user-scope delivery rail** — the build
+  pipeline vendors `credbroker` to `.agentbundle/lib` (drift-gated) and
+  consumer bootstraps append the `~/.agentbundle/lib` floor at lowest
+  precedence (new `user_libs` module).
+
+### Changed
+
+- **Copilot adapter projects skills as first-class `SKILL.md`** and
+  corrects the web-tool documentation (adapter contract v0.12).
+- **Codex adapter projects agent model and tool config** into the
+  generated agent TOML.
+- **Pack admittance** — credentialed packs admit the `copilot` and
+  `cursor` adapters (RFC-0013 erratum); `research` and `architect` opt
+  into the `cursor` adapter.
+
+### Removed
+
+- **Retired the shared-libs shim projection.** Credentialed skills now
+  `import credbroker` from the user-scope lib floor instead of a
+  build-projected shim.
+
 ## [0.2.0] — 2026-05-26
 
 ### Removed (breaking)

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentbundle"
-version = "0.2.0"
+version = "0.3.0"
 description = "Reference CLI and distribution pipeline for the agent-ready-repo adapter contract."
 requires-python = ">=3.11"
 dependencies = []


### PR DESCRIPTION
## What

Cuts the **agentbundle 0.3.0** PyPI release: bumps `pyproject.toml`
`0.2.0 → 0.3.0` and records the `0.3.0` CHANGELOG entry.

0.2.0 is already published to PyPI, so a new release needs a version
bump first (auto-bump is out of scope per `docs/specs/agentbundle-wheel-release/spec.md`
§Out of scope — manual edits in release PRs, asserted against the tag).

## Why 0.3.0 (minor)

16 commits have landed in `packages/agentbundle/` since `agentbundle-v0.2.0`,
including new adapters and command behavior. Pre-1.0 semver (a minor bump
MAY be breaking) and the shared-libs shim retirement make this a minor
release.

### Added
- Cursor full-parity adapter (RFC-0026)
- Gemini CLI full-parity adapter (RFC-0027)
- `--dry-run` for `install` / `upgrade`
- `upgrade` surfaces Tier-2 `.upstream` companion-drops
- credbroker user-scope lib floor (`user_libs` module)

### Changed
- Copilot adapter: skills as first-class `SKILL.md`; contract v0.12
- Codex adapter: project agent model + tool config
- Pack admittance: copilot+cursor for credentialed packs; research+architect into cursor

### Removed
- Retired the shared-libs shim projection (skills now `import credbroker`)

## Release mechanics

After merge to `main`, the release is cut by pushing tag
`agentbundle-v0.3.0`. The `release-agentbundle` workflow asserts
tag-version == pyproject-version and tag-on-main, builds wheel + sdist,
runs the in-CI smoke, and publishes via Trusted Publisher OIDC.

### Local gates (already run)
- `python -m build` → wheel + sdist ✓
- `twine check dist/*` → PASSED, 0 warnings ✓
- fresh-venv install → `from agentbundle.cli import main` + `agentbundle --help` exit 0; reports `0.3.0` ✓

## Not released here
**credbroker** — only 2 docs-only commits since `credbroker-v0.1.0`
(README install runbook); no package code/behavior change, so no PyPI
bump warranted.