### PR TITLE
feat(tooling): SAST/SCA gate (Bandit + pip-audit + Semgrep + CodeQL) with taint coverage (ADR-0017)

### DIFF
--- a/.agentbundle/bin/sso-broker.py
+++ b/.agentbundle/bin/sso-broker.py
@@ -26,6 +26,7 @@ import sys
 import time
 import tomllib
 import urllib.error
+import urllib.parse
 import urllib.request
 
 # Bootstrap when invoked as ``python ~/.agentbundle/bin/sso-broker.py``
@@ -503,12 +504,21 @@ def _do_test(profile: str) -> int:
     cookie_header = "; ".join(f"{c['name']}={c['value']}" for c in cookies)
 
     url = base.rstrip("/") + endpoint
+    # Reject non-web schemes before the request. B310's real danger is urllib
+    # honouring file:// / ftp:// / gopher:// — a corrupt or hand-edited profile
+    # whose login-url points elsewhere is treated as corrupt config (exit 3).
+    # http and https both stay valid, so this breaks no legitimate endpoint.
+    if urllib.parse.urlparse(url).scheme not in ("https", "http"):
+        sys.stderr.write(f"sso-broker test: refusing non-http(s) URL scheme for {profile!r}\n")
+        return 3
     req = urllib.request.Request(url, headers={"Cookie": cookie_header})
     try:
         # Corporate-network env passthrough is the parent's responsibility;
         # urllib honours HTTPS_PROXY / NO_PROXY / SSL_CERT_FILE / SSL_CERT_DIR
         # from the environment automatically.
-        with urllib.request.urlopen(req, timeout=15) as resp:
+        # B310: scheme asserted http(s) above; base is the operator-configured
+        # SSO endpoint (not attacker input).
+        with urllib.request.urlopen(req, timeout=15) as resp:  # nosec B310
             status = resp.status
     except urllib.error.HTTPError as exc:
         status = exc.code

--- a/.agents/skills/work-loop/scripts/loop-cohort.py
+++ b/.agents/skills/work-loop/scripts/loop-cohort.py
@@ -745,7 +745,7 @@ def parse_findings(report_text: str) -> list[str]:
             continue
         line_num = line_match.group(0)
         key = f"{file_part}|{line_num}|{title}"
-        fingerprints.append(hashlib.sha1(key.encode("utf-8")).hexdigest())
+        fingerprints.append(hashlib.sha1(key.encode("utf-8"), usedforsecurity=False).hexdigest())
     return fingerprints
 
 

--- a/.claude/skills/work-loop/scripts/loop-cohort.py
+++ b/.claude/skills/work-loop/scripts/loop-cohort.py
@@ -745,7 +745,7 @@ def parse_findings(report_text: str) -> list[str]:
             continue
         line_num = line_match.group(0)
         key = f"{file_part}|{line_num}|{title}"
-        fingerprints.append(hashlib.sha1(key.encode("utf-8")).hexdigest())
+        fingerprints.append(hashlib.sha1(key.encode("utf-8"), usedforsecurity=False).hexdigest())
     return fingerprints
 
 

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -15,7 +15,9 @@ jobs:
   build-check:
     name: make build-check
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # Bumped 5 → 15 (ADR-0017): `make build-check` now chains `make sast`, whose
+    # Semgrep leg fetches registry rulesets and scans ~76k LOC.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -30,6 +32,13 @@ jobs:
         # PyYAML from tools/requirements.txt. Install before invoking make
         # so the projected-artifact lint surface is reachable in CI.
         run: pip install -r tools/requirements.txt
+
+      - name: Install SAST/SCA tools
+        # `make build-check` chains `make sast` (ADR-0017), which needs Bandit,
+        # pip-audit, and Semgrep on PATH. Install before invoking make so the
+        # dogfooded SAST gate is reachable. The shipped packages stay
+        # dependency-free; these are CI-only dev tools.
+        run: pip install -r tools/requirements-sast.txt
 
       - name: Run make build-check
         run: make build-check PACKS_DIR=packs

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,51 @@
+name: codeql
+
+# Deep dataflow/taint SAST (ADR-0017). CodeQL is the open-source analogue of
+# Snyk Code's interprocedural taint engine — the lens Bandit structurally
+# cannot provide (no dataflow) and that OSS Semgrep covers only
+# intraprocedurally. The `security-extended` suite includes `py/path-injection`
+# (CWE-22/73), the query class that flagged the session-start env→Path flow.
+#
+# Free for this public repository. Alerts surface in the repo's Security tab
+# and as PR annotations; making them block merges is a branch-protection
+# setting ("require CodeQL"), not a workflow change.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    # Weekly re-scan catches newly-published queries against unchanged code.
+    - cron: "27 4 * * 1"
+
+# A newer push to the same ref supersedes an in-flight scan.
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: CodeQL analyze (python)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+          # security-extended adds the taint queries (incl. py/path-injection)
+          # beyond the default suite.
+          queries: security-extended
+
+      # Python is interpreted — no build step; CodeQL extracts the source.
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:python"

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,44 @@
+# Snyk policy file — the Snyk-native suppression vehicle (ADR-0017).
+#
+# Our own gate (Bandit + pip-audit + Semgrep, via `make sast`) is the primary
+# pre-merge SAST/SCA check. This file exists for the *organisational* Snyk scan,
+# which our gate cannot configure and whose output we cannot see directly.
+#
+# Suppression policy (ADR-0017), in order of preference:
+#   1. Fix the code. A real fix satisfies Bandit, Semgrep, AND Snyk — a comment
+#      does not. Prefer this for every genuine finding.
+#   2. `# nosec <ID>` for Bandit-only false positives; Semgrep rule exclusions in
+#      `make sast` for its duplicates. Neither reaches Snyk.
+#   3. This file — the only suppression that reaches Snyk. Use it to *accept* a
+#      finding Snyk reports that we have judged acceptable.
+#
+# Snyk Open Source (SCA): `ignore` blocks below are honoured directly.
+# Snyk Code (SAST): `ignore` blocks here apply only when the org has enabled
+#   "Consistent Ignores"; otherwise Code ignores are managed in the Snyk
+#   platform/API. Either path needs the issue ID from an actual Snyk run.
+#
+# DO NOT invent issue IDs. Populate `ignore` only with IDs copied from a real
+# Snyk scan, each carrying a `reason` and an `expires`. Add entries with:
+#   snyk ignore --id=<ISSUE_ID> --reason="<why>" --expiry=<YYYY-MM-DD>
+#
+# Likely first candidates (ADR-0017): Snyk Code keys its weak-hash rule on the
+# `hashlib.sha1(...)` call, not on the `usedforsecurity=False` kwarg, so it may
+# still flag the two NON-security SHA-1 digests our gate already cleared:
+#   - packages/agentbundle/agentbundle/config.py  (8-char derivation cache key)
+#   - packs/core/.apm/skills/work-loop/scripts/loop-cohort.py  (review fingerprint)
+# Both are documented non-security digests (see their docstrings); changing the
+# algorithm would diverge from documented spec/skill contracts. If the org scan
+# flags them, accept here with the Snyk-assigned ID — do not change the code.
+#
+# Worked example (commented — not active; replace with a real ID before use):
+#
+# ignore:
+#   SNYK-PYTHON-EXAMPLE-1234567:
+#     - '*':
+#         reason: >-
+#           Accepted: <one-line justification>. Tracked in <link/ticket>.
+#         expires: 2026-12-31T00:00:00.000Z
+
+version: v1.25.0
+ignore: {}
+patch: {}

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ RECIPE ?=
 
 export PYTHONPATH
 
-.PHONY: build build-self build-self-dry-run build-check build-scaffold lint-packs pre-pr validate clean zipapp release-preflight
+.PHONY: build build-self build-self-dry-run build-check build-scaffold lint-packs pre-pr sast validate clean zipapp release-preflight
 
 # Windows-portability gate. Refuses packs that ship symlinks or
 # Windows-poisonous names under seeds/ or .apm/. Runs before every
@@ -83,6 +83,50 @@ build-check: lint-packs build
 	# No-ops on this repo (it ships no brief); fail-closed on a stale Spec map.
 	$(PYTHON) .claude/skills/receive-brief/scripts/test-lint-brief-coverage.py
 	$(PYTHON) .claude/skills/receive-brief/scripts/lint-brief-coverage.py
+	# SAST/SCA gate (ADR-0017) — runs last so the fast, offline drift/lint
+	# checks above fail quickly before the slower, network-bound scanners.
+	$(MAKE) sast
+
+# SAST/SCA gate (ADR-0017). Three OSS scanners, installed from
+# tools/requirements-sast.txt as CI-only dev tools — never shipped runtime
+# deps. Chained into build-check above so the repo's single native gate runs it
+# locally and in build-check.yml CI. Not added to tools/hooks/pre-pr.py or
+# tools/pre-pr-catalogue.py (the Windows CI path runs the former; Semgrep has no
+# Windows support). Linux/macOS only (Semgrep).
+#
+# These four Semgrep rules are excluded as duplicates of findings already
+# dispositioned for Bandit, with no coverage loss (Bandit still flags new
+# instances of each class):
+#   - sha1   → the two sites are documented non-security digests annotated
+#              `usedforsecurity=False`; Bandit B324 is satisfied, Semgrep's rule
+#              can't read the kwarg. Bandit B324 still flags any new sha1.
+#   - urllib → constant/operator-configured bases, line-precise `# nosec B310`.
+#   - xml    → stdlib ElementTree (no external entities/DTDs), `# nosec B314`.
+#   - chmod  → the one hit is a restrictive 0o700 (secure); Bandit B103 is
+#              correctly silent on it and still flags genuinely-permissive modes.
+# Excluding the duplicates avoids a second inline pragma system in shipped pack
+# scripts.
+SAST_DIRS := tools packs packages
+SEMGREP_EXCLUDE := \
+	--exclude-rule python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1 \
+	--exclude-rule python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected \
+	--exclude-rule python.lang.security.use-defused-xml.use-defused-xml \
+	--exclude-rule python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
+
+sast:
+	@command -v bandit   >/dev/null 2>&1 || { echo "make sast: bandit not found — run: pip install -r tools/requirements-sast.txt" >&2; exit 1; }
+	@command -v pip-audit >/dev/null 2>&1 || { echo "make sast: pip-audit not found — run: pip install -r tools/requirements-sast.txt" >&2; exit 1; }
+	@command -v semgrep   >/dev/null 2>&1 || { echo "make sast: semgrep not found — run: pip install -r tools/requirements-sast.txt" >&2; exit 1; }
+	bandit -r $(SAST_DIRS) -c bandit.yaml --severity-level medium --confidence-level medium -q
+	@for f in tools/requirements.txt tools/requirements-sast.txt $$(find packs -name requirements.txt | sort); do \
+		echo "pip-audit -r $$f"; \
+		pip-audit -r "$$f" || exit 1; \
+	done
+	# Both shipped packages declare dependencies=[]; credbroker's optional
+	# [crypto] extra is the only third-party code either can pull, so audit it
+	# explicitly. Mirror packages/credbroker/pyproject.toml [crypto].
+	@printf 'cryptography>=42\nargon2-cffi>=23\n' | pip-audit -r /dev/stdin
+	semgrep --config p/python --config p/security-audit --config tools/semgrep/ --error --quiet --metrics off $(SEMGREP_EXCLUDE) $(SAST_DIRS)
 
 build-scaffold:
 	@test -n "$(OUTPUT)" || (echo "make build-scaffold OUTPUT=<dir> required" >&2; exit 1)

--- a/bandit.yaml
+++ b/bandit.yaml
@@ -1,0 +1,23 @@
+# Bandit configuration — the repo's Python SAST gate (ADR-0017).
+#
+# Invoked by `make sast` as:
+#   bandit -r tools packs packages -c bandit.yaml \
+#          --severity-level medium --confidence-level medium
+#
+# The medium+ severity / medium+ confidence floor is set on the CLI (above),
+# not here: it filters out the large low-severity tail (subprocess imports,
+# partial-path process starts) that is noise for an attack-surface gate while
+# keeping the findings an org-grade scan would block on.
+
+skips:
+  # B101 assert_used — test suites (pytest and the standalone tools/test-*.py
+  # harnesses) rely on `assert`; it is not an attack-surface signal. Skipped
+  # globally so test asserts never reach the gate regardless of file location.
+  - B101
+
+exclude_dirs:
+  # Test trees only. Test code legitimately uses permissive chmod (B103) and
+  # hardcoded /tmp fixtures (B108); those are not shipped attack surface.
+  # Globs are matched against each scanned file's path.
+  - '*/tests/*'        # packages/*/tests/, integration + unit suites
+  - '*/build/tests/*'  # packages/agentbundle/agentbundle/build/tests/ (adapter/contract)

--- a/docs/adr/0017-adopt-bandit-pip-audit-semgrep-sast-gate.md
+++ b/docs/adr/0017-adopt-bandit-pip-audit-semgrep-sast-gate.md
@@ -1,0 +1,211 @@
+# ADR-0017: Adopt Bandit + pip-audit + Semgrep as the repo's SAST/SCA gate
+
+- **Status:** Accepted <!-- Proposed | Accepted | Deprecated | Superseded by ADR-NNNN -->
+- **Date:** 2026-06-12
+- **Deciders:** eugenelim
+- **Supersedes:** none
+- **Related:** the implementing spec `docs/specs/sast-sca-tooling/`; ADR-0003 (credential-broker contract — `sso-broker.py` is one of the scanned scripts)
+
+## Context
+
+The repo ships agent skills, tool scripts, and two Python packages, but had **no
+static-analysis tooling of any kind** — no SAST, no dependency (SCA) scan, no
+config, no CI job. CI (`build-check.yml`) is entirely self-hosting drift gates
+plus targeted `pytest`; nothing inspects the ~76k lines of Python for the
+security-relevant patterns a scanner catches.
+
+The trigger was concrete: an **internal organisational Snyk scan** is flagging
+some of the skill/tool scripts, and the maintainer has **no access to that
+scan's output**. Without a local equivalent there is no way to see what Snyk
+sees, reproduce it, or gate it before it reaches the org scan.
+
+Running **Bandit** (the reference Python SAST tool, and the closest open-source
+analog to Snyk Code's Python ruleset) across `tools/`, `packs/`, and
+`packages/` reproduced a small, tractable set of medium/high findings in shipped
+code — weak SHA-1 digests, an unsafe XML parse of network data, and a handful of
+pattern false positives (a `yaml.load` against a `SafeLoader` **subclass**;
+`urllib.request.urlopen` against constant `https://` bases) — under a large
+low-severity tail dominated by `assert` use in test files.
+
+Two constraints shape the decision:
+
+- **The packages are deliberately stdlib-pure.** Both `agentbundle` and
+  `credbroker` declare `dependencies = []`; `credbroker`'s only third-party code
+  sits behind an optional `[crypto]` extra. This zero-runtime-dependency posture
+  is a load-bearing property, not an accident — see `credbroker`'s purity gate in
+  CI. Any scanner we adopt must be a **dev/CI-only** tool and must never become a
+  runtime dependency of a shipped package.
+- **We cannot see the Snyk findings, and `# nosec` does not reach Snyk.** Bandit
+  honours `# nosec`; Snyk does not. So suppression and the real remediation are
+  different levers, and the choice between them must be explicit per finding.
+- **Bandit has no taint/dataflow engine.** It is an AST pattern-matcher: it
+  cannot see that an *untrusted value flows into* a sink. A reported Snyk Code
+  finding on the `session-start` hook — environment-variable input flowing into
+  `pathlib.Path` (CWE-22/73 path injection) — is invisible to Bandit at any
+  severity, and the registry Semgrep packs did not carry that source→sink rule.
+  Closing the gate's gap therefore needs a *taint-capable* lens, not more Bandit
+  tuning.
+
+## Decision
+
+**We adopt four open-source scanners as the repo's CI-only SAST/SCA gate:
+Bandit (Python pattern SAST), pip-audit (Python dependency / SCA), Semgrep
+(cross-cutting SAST, including custom `mode: taint` rules), and CodeQL (deep
+interprocedural dataflow/taint — the open-source analogue of Snyk Code's
+engine).** They run behind a `make sast` target that is **chained
+into `make build-check`** — the repo's single native gate, run locally
+(CONTRIBUTING lists it among the gates that run locally) and in the existing
+`build-check.yml` CI on every PR — so the gate is dogfooded into this repo's own
+development rather than living in a separate, skippable workflow. None of the
+three is ever added to a shipped package's runtime dependencies.
+
+Boundaries on the decision:
+
+- **Bandit is the primary Python SAST gate.** It is configured (repo-root
+  `bandit.yaml`) to **fail on medium-or-higher severity at medium-or-higher
+  confidence**, excluding test trees and skipping `B101` (`assert` use) — the
+  large low-severity tail is noise for an attack-surface gate, not signal. This
+  keeps the gate achievable and focused on what an org scan would block on.
+- **pip-audit is the SCA gate.** It audits the dependency manifests the repo
+  actually owns — `tools/requirements.txt`, the two packages, and the shipped
+  per-skill `requirements.txt` files (which are what adopters install) — for
+  known-vulnerable versions.
+- **Semgrep is the cross-cutting SAST gate**, run against curated registry
+  rulesets (`p/python`, `p/security-audit`). It catches dataflow-shaped issues
+  Bandit's pattern rules miss and is the lens that extends to non-Python files
+  if the repo ever grows them. Because Semgrep has no Windows support, the gate
+  is reached **only** through `make build-check` (which the Windows CI job does
+  not invoke — `build-check-windows.yml` runs `agentbundle.build check` +
+  `tools/hooks/pre-pr.py` directly); the scanners live in `make sast` alone and
+  are added to neither `tools/hooks/pre-pr.py` (the shipped hook, on the Windows
+  path) nor `tools/pre-pr-catalogue.py` (the Linux `make build-check`
+  aggregator).
+- **Custom Semgrep `mode: taint` rules live in `tools/semgrep/`** and run in
+  `make sast` (`--config tools/semgrep/`). They close the dataflow gap Bandit
+  cannot — the first is `env-var-into-pathlib-path` (env → `pathlib.Path`,
+  CWE-22/73), the class Snyk Code flagged. OSS Semgrep taint is
+  *intraprocedural*; that is sufficient for same-function flows.
+- **CodeQL runs as a code-scanning workflow** (`.github/workflows/codeql.yml`,
+  `security-extended`, free for this public repo) for the *interprocedural*
+  taint Semgrep OSS can't do — the closest open-source match to Snyk Code.
+  Alerts surface in the Security tab / PR annotations; promoting them to a merge
+  blocker is a branch-protection setting, not a code change.
+- **Genuine taint findings are fixed in the shipped source, not suppressed.**
+  The `session-start` env → `Path` flow is sanitized once in the hook
+  (`_safe_override_path` rejects traversal before the path is used), so every
+  adopter inherits the fix rather than each carrying a suppression.
+- **Semgrep excludes four rules that duplicate Bandit's coverage**
+  (`insecure-hash-algorithm-sha1`, `dynamic-urllib-use-detected`,
+  `use-defused-xml`, `insecure-file-permissions`). Each maps to a class Bandit
+  owns line-precisely (sha1 → B324 + `usedforsecurity=False`; urllib → B310;
+  xml → B314; permissive-chmod → B103), so excluding the Semgrep duplicates
+  avoids a second inline-pragma system in shipped pack scripts with no loss of
+  coverage. The exclusion list lives in the `make sast` recipe.
+- **Suppression policy — three-way, real-fix-first:**
+  1. **Genuine findings get a real code fix**, never a suppression — a real fix
+     satisfies Bandit *and* the internal Snyk scan, which a comment cannot.
+  2. **Tool-specific false positives get `# nosec <ID> — <reason>`**, scoped to
+     Bandit. These are patterns Snyk's dataflow analysis already clears (a
+     `SafeLoader` subclass; a constant-scheme URL), so they need no Snyk ignore.
+  3. **A committed `.snyk` policy file is the Snyk-native suppression vehicle**
+     for findings that must be *accepted* in Snyk itself — primarily Snyk Open
+     Source (SCA) issues, ignored by issue ID with a `reason` and an `expires`.
+     Snyk **Code** (SAST) findings are suppressible through the same file only
+     where the org enables "Consistent Ignores"; otherwise they are managed in
+     the Snyk platform. Either path needs the issue ID from an actual Snyk run,
+     so the `.snyk` file ships as a documented scaffold, populated when those
+     IDs are available — not authored blind.
+
+## Consequences
+
+**Positive:**
+- A local + CI gate now mirrors the class of issue the org's Snyk scan catches,
+  so findings fail *our* build first instead of surfacing in a scan we can't see.
+- `make sast` gives any contributor the same reproduction locally — no Snyk
+  account or token required.
+- Real fixes for the genuine findings (weak hash, unsafe XML parse) harden code
+  that ships to adopters, not just our own tree.
+- The three tools are complementary lenses (pattern SAST / dependency CVEs /
+  dataflow SAST) and all are OSS, so the gate carries no licensing or
+  per-seat cost.
+
+**Negative:**
+- Three dev tools are real maintenance surface — versions to pin and bump, rule
+  updates to absorb.
+- **Chaining `make sast` into `make build-check` slows the repo's own gate** —
+  Semgrep fetches rules from the network and scans ~76k LOC, so a `build-check`
+  that was seconds now takes longer and needs connectivity. We accept this so the
+  gate is actually dogfooded (the maintainer's explicit priority over inner-loop
+  speed); the mitigations are running narrower targets during the inner loop and
+  bumping `build-check.yml`'s `timeout-minutes`.
+- **Semgrep pulls its rulesets from the registry at scan time** (network
+  dependency); upstream rule changes can shift findings between runs. We accept
+  this for the broader coverage; the mitigation if it becomes flaky is to pin or
+  vendor a ruleset (noted as a revisit, not built now).
+- The gate is tuned (medium+ severity, test trees excluded). A real low-severity
+  issue in non-test code could pass; the bet is that the org scan's blocking bar
+  is also medium+ and that the excluded surface is genuinely low-risk.
+- We cannot prove the gate matches the org Snyk scan exactly without access to
+  it — Bandit/Semgrep are a high-fidelity proxy, not the same engine.
+
+**Neutral / to revisit:**
+- Whether Semgrep should be blocking or advisory, and whether to pin/vendor its
+  rules, is revisited if registry drift causes CI flakiness.
+- If the slower `build-check` proves painful in the inner loop, a fast/slow split
+  (Bandit in `build-check`, the network-bound legs in a separate cadence) can be
+  revisited — but the default is the single dogfooded gate.
+- The `.snyk` file's Code-ignore entries stay empty until the org scan's issue
+  IDs are obtainable.
+- **The taint coverage is layered, and only `packs/` env→path is *blocking*.**
+  The Semgrep taint rule is scoped to `packs/**` (auto-running agent primitives);
+  the ~13 other env→path flows in `tools/` dev-CLIs (a maintainer's own arg) and
+  install-time `install-marker.py` (installer-set `HOME`/plugin paths) are
+  trusted-context and covered only by CodeQL, which is **advisory** until branch
+  protection requires it. A future `tools/` script that reads genuinely
+  untrusted env would inherit only advisory coverage — revisit the scope if that
+  happens. Promoting CodeQL to a merge blocker is a one-time branch-protection
+  setting, not a code change.
+
+## Alternatives considered
+
+- **Snyk CLI in CI** (`snyk code test` / `snyk test`) — the closest match to the
+  org scan. Rejected as the *primary* gate: it needs an authenticated Snyk
+  account/token in CI and (for the Code product) a paid entitlement, which the
+  OSS-published catalogue should not require of contributors. The `.snyk`
+  suppression file is adopted regardless, so a future Snyk-CLI step can layer on
+  top. **CodeQL is adopted instead** as the OSS deep-taint stand-in (free here).
+- **CodeQL** — initially weighed only as a Snyk-CLI alternative; **adopted**
+  once the taint gap surfaced. It is the only OSS option that does Snyk-Code-class
+  interprocedural dataflow, and it is free for this public repo (private repos
+  would need GitHub Advanced Security — an adopter caveat to document, not a
+  blocker here).
+- **Pysa (Meta/Pyre taint analyzer)** — also real interprocedural taint.
+  Rejected: heavier setup (hand-written taint models) for no gain over CodeQL on
+  a repo this size.
+- **Lowering Bandit's severity floor to catch the subprocess/partial-path tail** —
+  Rejected: it floods the gate with ~190 low-severity false positives (constant
+  `subprocess` calls) and still would not find the taint flows, which Bandit
+  cannot represent at any severity.
+- **Ruff's `S` ruleset (flake8-bandit) instead of Bandit** — much faster and
+  would honour the `# noqa: S###` comments already present in `catalogue.py`.
+  Rejected as the primary SAST: it reimplements a *subset* of Bandit's rules, and
+  the maintainer asked specifically for Bandit (the reference implementation with
+  full coverage). The stray `# noqa: S###` comments are realigned to Bandit's
+  `# nosec` form as part of the implementing spec.
+- **Bandit only** (skip pip-audit + Semgrep) — Rejected: Bandit covers neither
+  vulnerable-dependency detection (the packages are stdlib-pure but the shipped
+  skills pull `httpx`, `lxml`, `markdownify`, …) nor dataflow-shaped or
+  non-Python findings. The maintainer asked for all three.
+- **Do nothing** — Rejected: leaves the org scan as the only gate, with no local
+  reproduction and no pre-merge signal.
+
+## References
+
+- Implementing spec: `docs/specs/sast-sca-tooling/spec.md`.
+- Bandit: <https://bandit.readthedocs.io/> — `# nosec` is the only inline
+  suppression it honours.
+- pip-audit: <https://pypi.org/project/pip-audit/>.
+- Semgrep registry rulesets: <https://semgrep.dev/r> (`p/python`,
+  `p/security-audit`).
+- Snyk `.snyk` policy file + Consistent Ignores for Code:
+  <https://docs.snyk.io/manage-risk/policies/the-.snyk-file>.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,6 +22,7 @@
 | 0014 | [Rigor scales with risk — `work-loop` light/full modes](0014-rigor-scales-with-risk-work-loop-modes.md) | Accepted |
 | 0015 | [Cursor is a full-parity distribution adapter](0015-cursor-full-parity-distribution-adapter.md) | Accepted |
 | 0016 | [Gemini CLI is a full-parity distribution adapter](0016-gemini-cli-full-parity-adapter.md) | Accepted |
+| 0017 | [Adopt Bandit + pip-audit + Semgrep as the repo's SAST/SCA gate](0017-adopt-bandit-pip-audit-semgrep-sast-gate.md) | Accepted |
 
 ## Adding a new ADR
 

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -19,6 +19,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The repo now has a SAST/SCA gate** — `make sast` runs **Bandit** (Python pattern SAST),
+  **pip-audit** (dependency/SCA), **Semgrep** (cross-cutting SAST, including custom `mode: taint`
+  rules under `tools/semgrep/`), and a **CodeQL** code-scanning workflow (deep interprocedural
+  taint — the open-source analogue of Snyk Code). The first three are chained into
+  `make build-check` so every PR is scanned by the repo's own single native gate (locally and in
+  `build-check.yml` CI); CodeQL runs as its own workflow. Bandit fails on medium-or-higher findings
+  (tuning in `bandit.yaml`). The genuine findings surfaced were fixed in the same change: weak SHA-1
+  digests marked `usedforsecurity=False`; the arXiv retriever upgraded to HTTPS; the `session-start`
+  hook's env-var path overrides sanitized against directory traversal (a fix every adopter inherits);
+  and the SSO broker's `test` verb now rejects non-`http(s)` URL schemes. A committed `.snyk` policy
+  file is the Snyk-native suppression vehicle for the organisational scan. All four scanners are
+  CI-only dev tools (`tools/requirements-sast.txt`) and are **never** added to a shipped package's
+  runtime dependencies. See ADR-0017.
+
 - **Gemini CLI is now a full-parity adapter** — `agentbundle install --adapter gemini` (repo or
   user scope) projects every catalogue primitive to Gemini CLI's native `.gemini/*` layout:
   skills → `.gemini/skills/`, subagents → `.gemini/agents/<name>.md` (the `tools:` allowlist is

--- a/docs/specs/sast-sca-tooling/plan.md
+++ b/docs/specs/sast-sca-tooling/plan.md
@@ -1,0 +1,328 @@
+# Plan: SAST/SCA tooling (Bandit + pip-audit + Semgrep)
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Done <!-- Drafting | Executing | Done -->
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn. When it changes substantially
+> (a different approach, not just a re-ordering), note why in the changelog
+> at the bottom.
+
+## Approach
+
+Two interleaved strands: **stand up the gate** (config + Makefile target + CI
+workflow for three scanners) and **clear the gate** (fix the genuine findings,
+suppress the tool-specific false positives) so the gate lands green in the same
+PR. The riskiest part is the tuning: Bandit must fail on the real medium+ issues
+without drowning in the 1,951-entry `assert`-in-tests low tail, so the
+`bandit.yaml` floor (severity≥medium, confidence≥medium, exclude tests, skip
+B101) is load-bearing and verified empirically. The `loop-cohort.py` SHA-1 fix
+touches a **projected** skill script, so its source edit lands under `packs/` and
+is reprojected with `make build-self`. Order: build the Bandit config and prove
+the baseline first, then fix/suppress findings until Bandit is clean, then layer
+pip-audit and Semgrep, then CI + the `.snyk` scaffold + docs.
+
+## Constraints
+
+- **ADR-0017** — the three tools are CI-only dev dependencies, never runtime
+  deps; suppression is real-fix-first, then `# nosec` (Bandit), then `.snyk`
+  (Snyk-native).
+- **Self-hosting projection** (memory `feedback_self_host_projection`) —
+  `loop-cohort.py` source is `packs/core/.apm/skills/work-loop/scripts/`; edit
+  there + `make build-self`, never the `.claude/` copy.
+- **Stdlib purity** — `agentbundle`/`credbroker` are `dependencies = []`; the
+  research skill's `arxiv-retriever.py` declares "Python 3 stdlib only" in its
+  docstring. No fix may add a runtime dependency to these.
+- **Windows-portable tooling** (memory `feedback_new_tools_python_not_bash`) —
+  no new bash tool scripts; the gate is a Makefile target chained into the
+  existing `make build-check` / `build-check.yml`.
+
+## Construction tests
+
+Per-task `Tests:` below. No cross-cutting integration test — every gate is a
+goal-based one-liner (run the scanner, assert exit 0) per the spec's Testing
+Strategy.
+
+**Integration tests:** none beyond per-task goal-based checks.
+**Manual verification:** `make sast` on a clean tree exits 0; `make build-check`
+stays green; `make build-self` leaves the tree drift-clean.
+
+## Design (LLD)
+
+### Dependencies & integration
+
+Three OSS scanners, pinned in a new `tools/requirements-sast.txt` (CI installs
+it; contributors `pip install -r` it once). `make sast` **detects** the three
+binaries and **fails clean** with an install hint if absent (Tier-1
+declare/detect/fail-clean per memory `project_skill_prereq_pattern`) — it does
+not auto-install. CI installs explicitly, then runs the same commands. Traces to:
+AC "make sast exists", AC "dogfooded into make build-check".
+
+### Interfaces & contracts
+
+- `make sast` — the entry point; runs `bandit` → `pip-audit` → `semgrep`,
+  stopping at the first failure. **Chained into `make build-check`** so the
+  repo's single native gate runs it locally and in `build-check.yml` CI.
+- `bandit.yaml` (repo root) — `exclude_dirs` for test trees, `skips: [B101]`,
+  invoked with `--severity-level medium --confidence-level medium`.
+- `.snyk` — Snyk-native suppression policy (documented scaffold).
+No standalone `sast.yml`; the existing `build-check.yml` covers CI enforcement.
+Traces to: every AC.
+
+### Failure, edge cases & resilience
+
+- **pip-audit + first-party packages:** `credbroker` appears in skill
+  `requirements.txt` files. pip-audit audits the active env (after editable
+  installs of the two packages) plus the third-party deps; first-party lines that
+  don't resolve from an index are excluded from `-r` audits, audited via the
+  installed-package path instead.
+- **Semgrep registry drift:** rulesets pull from the network at scan time;
+  documented as an accepted risk in ADR-0017, mitigation (pin/vendor) deferred.
+Traces to: AC pip-audit, AC Semgrep.
+
+### Quality attributes (NFRs)
+
+Security-posture gate: "zero medium+ Bandit findings, zero Semgrep findings,
+zero known-vulnerable deps" is the pass/fail bar (spec ACs). Traces to: all gate
+ACs.
+
+## Tasks
+
+### T1: Bandit config + `make sast` (bandit leg) proves the baseline
+
+**Depends on:** none
+
+**Tests:**
+- Goal-based: `bandit -r tools packs packages -c bandit.yaml --severity-level
+  medium --confidence-level medium` at the configured floor **surfaces** the
+  SHA-1 and XML findings and **does not surface** the `assert`/test-only tail
+  (B101, test-tree B103/B108) — presence-of-signal + tail-suppression, not an
+  exact-count match (the count drifts the moment anyone adds a `urlopen`/`sha1`).
+
+**Approach:**
+- Add `tools/requirements-sast.txt` pinning `bandit`, `pip-audit`, `semgrep`.
+- Write repo-root `bandit.yaml`: `exclude_dirs` for `**/tests/**` /
+  `**/build/tests/**` (test code uses `assert`, chmod, `/tmp` legitimately),
+  `skips: [B101]`, each with a justifying comment.
+- Add `.PHONY: sast` + a `sast:` target to the Makefile; first leg runs Bandit
+  with the floor above. Detect the three binaries up front; fail clean with an
+  install hint if missing.
+
+**Done when:** `make sast` reaches the Bandit step and Bandit reports the known
+medium+ findings (not the low tail).
+
+### T2: Fix the two weak-SHA-1 findings (digest-preserving)
+
+**Depends on:** T1
+
+**Touches:** packages/agentbundle/agentbundle/config.py, packs/core/.apm/skills/work-loop/scripts/loop-cohort.py, .claude/skills/work-loop/scripts/loop-cohort.py (regenerated by build-self, not hand-edited)
+
+**Tests:**
+- Goal-based: Bandit no longer reports B324 at those two sites.
+- Existing package/skill tests stay green (digests are byte-identical:
+  `usedforsecurity=False` does not change SHA-1 output).
+
+**Approach:**
+- `config.py:482` and `loop-cohort.py:748` (pack source): add
+  `usedforsecurity=False` to the `hashlib.sha1(...)` call.
+- `make build-self` to reproject `loop-cohort.py` into `.claude/`.
+
+**Done when:** both B324 findings gone; `make build-self` drift-clean; package
+tests green.
+
+### T3: Disposition the false positives + harden the arXiv parse
+
+**Depends on:** T1
+
+**Touches:** tools/lint-agent-artifacts.py, tools/lint-skill-spec.py, packages/agentbundle/agentbundle/catalogue.py, packs/research/.apm/skills/research/scripts/arxiv-retriever.py, packs/research/.apm/skills/research/scripts/perplexity-retriever.py, packs/credential-brokers/.apm/adapter-root-bins/sso-broker.py
+
+**Tests:**
+- Goal-based: post-change Bandit medium+ run reports **zero** issues.
+- `arxiv-retriever.py` still parses a real arXiv Atom response (manual: run it
+  against a query, JSON on stdout).
+
+**Approach:**
+- `yaml.load` ×2 (`lint-agent-artifacts.py:189`, `lint-skill-spec.py:360`): add
+  `# nosec B506 — Loader is a yaml.SafeLoader subclass (class def above)`.
+- `catalogue.py` (B202 tarfile + B310 urlopen): this line **already carries its
+  real fix** — `extractall(filter="data")` rejects unsafe members. Drop the
+  stray `# noqa: S202` / `# noqa: S310` comments (nothing reads `# noqa: S`).
+  Run Bandit on the file: if B202 still fires (Bandit can't see the `filter=`
+  kwarg), add `# nosec B202 — real fix in place: extractall(filter="data")
+  rejects unsafe members; Bandit cannot see the kwarg` — **not** re-filed as a
+  pattern FP. The `urlopen` is a constant assembled-base GitHub archive URL:
+  `# nosec B310 — constant github.com archive base assembled from parsed
+  owner/repo/ref`.
+- `arxiv-retriever.py`: (a) **real fix** — upgrade `ARXIV_API` from `http://` to
+  `https://` (arXiv supports TLS; base stays constant), addressing B310 honestly;
+  (b) B314 is a **stdlib pattern FP** (ElementTree resolves no external
+  entities/DTDs on 3.11+) — `# nosec B314 — stdlib ElementTree resolves no
+  external entities/DTDs (3.11+); arXiv is a constant first-party endpoint over
+  TLS`; (c) `# nosec B310 — constant https arXiv API base`. **No** content-
+  scanning guard (fragile, evasion-prone) and no runtime dependency — keeps the
+  script stdlib-only per its docstring.
+- `perplexity-retriever.py:70`: `# nosec B310 — constant https Perplexity API
+  base`.
+- `sso-broker.py:511`: `# nosec B310` with an honest reason **plus** a scheme
+  guard (round-2 security review, C5): reject any resolved URL whose scheme is
+  not `http`/`https` (exit 3) before `urlopen`. This is boundary input-validation
+  returning the existing error code — `http` and `https` both still work, so it
+  is not a contract change (ADR-0003 unaffected). Tested in T9. (Round-1 had
+  deferred this as a behavior change; round-2 security review adopted the safe
+  allowlist form — see plan changelog.)
+
+**Done when:** post-change Bandit medium+ run is clean; arXiv parse still works.
+
+### T4: pip-audit leg of `make sast`
+
+**Depends on:** T1
+
+**Tests:**
+- Goal-based: `make sast`'s pip-audit step runs and reports no known-vulnerable
+  pinned versions across `tools/requirements.txt`, the two packages, and the
+  shipped per-skill `requirements.txt` files (or records any acceptance).
+
+**Approach:**
+- Add the pip-audit invocation to `make sast`: audit `tools/requirements.txt`
+  and each skill `requirements.txt` (third-party lines), plus the installed
+  editable packages. Handle first-party `credbroker` per the resilience note.
+
+**Done when:** pip-audit runs clean (or documented acceptance) in `make sast`.
+
+### T5: Semgrep leg of `make sast`
+
+**Depends on:** T1, T3
+
+**Tests:**
+- Goal-based: `semgrep --config p/python --config p/security-audit --error`
+  reports no findings on the post-fix tree.
+
+**Approach:**
+- Add the Semgrep invocation to `make sast` after the fixes land. Triage any
+  additional findings Semgrep raises (fix or justify) so the leg is clean.
+
+**Done when:** Semgrep leg of `make sast` exits 0.
+
+### T6: Dogfood the gate — chain `make sast` into `make build-check`
+
+**Depends on:** T1, T4, T5
+
+**Touches:** Makefile, .github/workflows/build-check.yml
+
+**Tests:**
+- Goal-based: `make build-check` invokes the SAST gate (grep the recipe; run it
+  and observe Bandit/pip-audit/Semgrep execute) and stays green on the post-fix
+  tree.
+- Goal-based: `build-check.yml` installs `tools/requirements-sast.txt` (+ the
+  editable packages pip-audit needs) **before** `make build-check`.
+- Goal-based: the Windows job (`build-check-windows.yml`) is untouched and does
+  not invoke Semgrep (it runs `python -m agentbundle.build check` +
+  `python tools/hooks/pre-pr.py`, never `make`).
+
+**Approach:**
+- Add `sast` to the Makefile `.PHONY` list and chain it into the `build-check`
+  recipe (so the repo's single native gate runs SAST locally and in CI). Keep
+  `make sast` callable standalone.
+- Edit `.github/workflows/build-check.yml`: add a `pip install -r
+  tools/requirements-sast.txt` step (and ensure the editable packages are
+  installed) **before** the `make build-check` step; **bump `timeout-minutes`**
+  (ADR-0017 already commits to Semgrep's rule-fetch + ~76k-LOC scan slowdown, so
+  raise it now — e.g. 5 → 15 — rather than discover it via a red first run).
+- Do **not** touch `tools/hooks/pre-pr.py`, `tools/pre-pr-catalogue.py`, or
+  `build-check-windows.yml`.
+
+**Done when:** `make build-check` runs the SAST gate green; Windows job
+unchanged.
+
+### T7: `.snyk` suppression scaffold
+
+**Depends on:** none
+
+**Tests:**
+- Goal-based: `.snyk` is valid YAML with a documented `ignore:` example and no
+  invented issue IDs.
+
+**Approach:**
+- Commit a `.snyk` policy file: header comment explaining it is the Snyk-native
+  suppression vehicle (SCA ignore-by-ID with `reason`+`expires`; Code via
+  Consistent Ignores), a commented worked example, and a `version` key.
+
+**Done when:** `.snyk` present, valid, documented, no fabricated IDs.
+
+### T8: Docs — changelog + dependency record
+
+**Depends on:** T1-T7
+
+**Tests:**
+- Goal-based: `make build-check` green; changelog `[Unreleased]` entry present;
+  dependency record names the three tools.
+
+**Approach:**
+- `docs/product/changelog.md` `[Unreleased]` → Added: the SAST/SCA gate.
+- The dependency record is **ADR-0017** itself (the rule's "or an ADR" branch;
+  these are dev/CI-only tools, not a package runtime dep). No `AGENTS.md` /
+  `AGENTS.local.md` dep edit is required by the rule — add a one-line pointer to
+  `AGENTS.local.md` only if it helps discoverability.
+- Flag in the PR description: the `http://`→`https://` arXiv endpoint change as a
+  deliberate finding-driven real fix (B310).
+
+**Done when:** `make build-check` green; docs updated.
+
+### T9: Taint coverage + session-start sanitization + sso-broker guard (round-2)
+
+**Depends on:** T1-T8
+
+**Touches:** tools/semgrep/env-path-taint.yml, Makefile, packs/core/.apm/hooks/session-start.py, packs/credential-brokers/.apm/adapter-root-bins/sso-broker.py, packages/agentbundle/tests/unit/test_sso_broker_verbs.py, .github/workflows/codeql.yml
+
+**Tests:**
+- Goal-based: the custom Semgrep taint rule reports 0 on the sanitized hook and
+  1 on a direct `Path(os.environ.get(...))` canary.
+- Existing session-start hook tests (17 py + shell) stay green; a `..` override
+  is refused.
+- New sso-broker tests: `file://` → exit 3; `https` (stubbed 2xx) → exit 0.
+
+**Approach:**
+- **Taint gap (Bandit can't do dataflow):** add `tools/semgrep/env-path-taint.yml`
+  (`mode: taint`, env → `pathlib.Path`), wire `--config tools/semgrep/` into
+  `make sast`; add the CodeQL workflow for interprocedural taint.
+- **Sanitize (ship the fix to adopters):** add `_safe_override_path` to
+  `session-start.py` (reject `..` before constructing the path), route the three
+  env overrides through it, reproject.
+- **sso-broker guard:** `{http,https}` scheme allowlist before `urlopen`.
+
+**Done when:** `make sast` (incl. taint rule) green; CodeQL workflow valid;
+session-start + sso-broker tests green.
+
+## Rollout
+
+- **Delivery:** big-bang, fully reversible (revert the PR). No data migration, no
+  published event. The gate runs from this PR onward — `make build-check` chains
+  `make sast` locally and in the existing `build-check.yml` CI; no new workflow.
+- **Infrastructure:** none beyond GitHub Actions (already in use).
+- **External-system integration:** Semgrep fetches registry rulesets at scan
+  time (network); pip-audit queries the PyPI advisory DB.
+- **Deployment sequencing:** fixes + config land together so the gate is green
+  on first CI run; `make build-self` reprojection committed alongside the
+  `loop-cohort.py` source edit.
+
+## Risks
+
+- **Semgrep raises findings beyond the known Bandit set** (different engine,
+  broader rules). Mitigation: T5 triages them; if a large unfixable set appears,
+  surface and consider scoping Semgrep's rulesets or making it advisory (ADR-0017
+  pre-authorizes that revisit).
+- **pip-audit can't resolve `credbroker`** from an index. Mitigation: audit it
+  via the installed-package path, exclude the first-party line from `-r` audits.
+- **Bandit version drift** changes rule IDs/behavior. Mitigation: pin in
+  `tools/requirements-sast.txt`.
+
+## Changelog
+
+- 2026-06-12: initial plan.
+- 2026-06-12: round-2 review + scope expansion (T9). Adopted the sso-broker
+  `{http,https}` scheme guard (security review C5 — round-1 had deferred it;
+  round-2 took the safe allowlist form that breaks no existing scheme).
+  Added taint coverage after an org Snyk finding (env→`Path` on the
+  session-start hook) exposed that Bandit has no dataflow engine: a custom
+  Semgrep `mode: taint` rule + a CodeQL workflow, and a source-level sanitizer
+  in the shipped hook so adopters inherit the fix rather than each suppressing.

--- a/docs/specs/sast-sca-tooling/spec.md
+++ b/docs/specs/sast-sca-tooling/spec.md
@@ -1,0 +1,209 @@
+# Spec: SAST/SCA tooling (Bandit + pip-audit + Semgrep)
+
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** ADR-0017
+- **Contract:** none
+- **Shape:** integration
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+The repo has no static-analysis tooling, and an internal organisational Snyk
+scan is flagging some skill/tool scripts with no output the maintainer can see.
+This feature gives the repo its own SAST/SCA gate — Bandit, pip-audit, and
+Semgrep — runnable locally as `make sast` and enforced in a dedicated CI
+workflow, so the class of issue the org scan catches fails *our* build first.
+The genuine findings the gate surfaces in shipped code are fixed in the same
+change; tool-specific false positives are suppressed at the narrowest scope that
+keeps the gate honest. Because Bandit has no dataflow engine, the gate also
+covers **taint** (untrusted input → sink) via custom Semgrep `mode: taint` rules
+and a CodeQL code-scanning workflow — the lens that caught the org scan's
+`session-start` env-var → `pathlib.Path` finding, which is fixed at the source so
+every adopter inherits it. Success: a contributor runs `make sast` on a clean
+tree and it passes; introducing a real security regression (including a new
+unsanitised env→path flow) makes it fail.
+
+## Boundaries
+
+The three-tier guard that keeps an implementing agent inside the lines.
+*Always do* applies without asking; *Ask first* requires human sign-off
+before proceeding; *Never do* is a hard rule, even under time pressure.
+
+### Always do
+
+- Keep the three scanners **dev/CI-only**. They are invoked from the Makefile
+  and the CI workflow; they are installed in CI, not pinned into any shipped
+  package.
+- Prefer a **real code fix** over any suppression for a genuine finding — a real
+  fix satisfies Bandit *and* the internal Snyk scan.
+- When a finding is a tool-specific false positive, suppress with
+  `# nosec <ID> — <reason>` carrying a one-line justification on the same line.
+- Validate untrusted input at the boundary it crosses — sanitize env-var path
+  overrides and assert URL schemes in the shipped source, so the fix ships to
+  every adopter rather than each suppressing the finding.
+- Edit pack **source** under `packs/<pack>/.apm/...`, then run `make build-self`
+  to reproject; never edit a projected `.claude/...` copy directly.
+- Keep `bandit.yaml`'s exclusions and skips minimal and justified by a comment.
+
+### Ask first
+
+- Adding a **runtime** dependency to any shipped package or skill to fix a
+  finding (e.g. `defusedxml`) — surface the stdlib-vs-dependency tradeoff before
+  taking it. (The XML finding is fixed without a new runtime dependency; see the
+  plan.)
+- Making the Semgrep job blocking-vs-advisory differently from the plan, or
+  changing which registry rulesets it runs.
+- Widening Bandit's severity/confidence floor below `medium`.
+
+### Never do
+
+- Never add Bandit, pip-audit, or Semgrep to a shipped package's
+  `dependencies`, optional-extras, or a skill `requirements.txt`. They are not
+  runtime code.
+- Never silence a genuine finding with `# nosec` to make the gate green.
+- Never wire the scanners into the projected `pre-pr.py` hook body (it projects
+  to adopters and would misfire); SAST is a repo-owned CI workflow + `make`
+  target, mirroring `build-check`.
+- Never author `.snyk` Code-ignore entries with invented issue IDs; the file
+  ships as a documented scaffold until real IDs are available.
+- Never add scanner config or CI surface beyond the sanctioned set —
+  `bandit.yaml`, `.snyk`, `tools/requirements-sast.txt`, `tools/semgrep/`
+  (custom taint rules), and `.github/workflows/codeql.yml`, plus wiring edits to
+  `Makefile` (the `sast` target + the `build-check` chain) and
+  `.github/workflows/build-check.yml` (install the SAST tools) — without amending
+  this spec. The finding-driven source fixes (`session-start.py` sanitizer,
+  `sso-broker.py` scheme guard, the SHA-1 / arXiv / `# nosec` dispositions) are
+  the only shipped-code edits.
+- Never add the SAST scanners to `tools/hooks/pre-pr.py` (the shipped adopter
+  hook — it runs on the Windows CI path at `build-check-windows.yml`, where
+  Semgrep is unsupported, and it projects to adopters) **or** to
+  `tools/pre-pr-catalogue.py` (the Linux `make build-check` aggregator — adding
+  them there would double-run, since `make build-check` already chains
+  `make sast`). The scanners live in `make sast` alone. The Windows job invokes
+  neither `make` nor `make sast`, so the dogfooded gate never reaches it.
+
+## Testing Strategy
+
+- **Bandit / pip-audit / Semgrep gates: goal-based check.** Each is verified by
+  running the tool and asserting a clean (exit 0) result on the current tree —
+  the `make sast` one-liner is the contract. No test file asserts what the
+  scanner already proves.
+- **Code fixes (SHA-1 `usedforsecurity=False`, XML hardening): goal-based
+  check**, verified by Bandit no longer reporting the finding at medium+
+  severity, plus the package/skill's existing tests staying green (the digests
+  and the arXiv parse remain functionally identical).
+- **CI wiring: goal-based check** — `make build-check` chains `make sast`, and
+  `build-check.yml` installs the SAST tools before invoking it; verified by
+  running `make build-check` and observing the scanners execute.
+- **Drift: goal-based check** — `make build-self` leaves the tree clean after
+  the `loop-cohort.py` edit is reprojected (`git status` shows no unstaged
+  projected drift).
+
+## Acceptance Criteria
+
+- [x] `make sast` exists and runs Bandit, pip-audit, and Semgrep in sequence;
+  on a clean working tree it exits 0.
+- [x] **The SAST gate is dogfooded into this repo's own development per the
+  repo's gate convention:** `make build-check` (the single native gate, run
+  locally per CONTRIBUTING and in the `build-check.yml` CI on every PR to `main`)
+  chains `make sast`, so a new medium+ finding fails this repo's own gate — it is
+  not a separate, skippable workflow. No standalone `sast.yml` is added.
+- [x] A repo-root `bandit.yaml` configures Bandit to fail on **medium-or-higher
+  severity at medium-or-higher confidence**, excludes test trees, and skips
+  `B101`; every exclusion/skip carries a justifying comment.
+- [x] `bandit -r tools packs packages -c bandit.yaml --severity-level medium
+  --confidence-level medium` reports **zero** issues on the post-change tree.
+- [x] The two weak-SHA-1 findings (`packages/agentbundle/agentbundle/config.py`,
+  `packs/core/.apm/skills/work-loop/scripts/loop-cohort.py`) are fixed with
+  `hashlib.sha1(..., usedforsecurity=False)`; the produced digests are
+  byte-identical to before (existing tests stay green).
+- [x] The `arxiv-retriever.py` endpoint is upgraded from `http://` to
+  `https://` (a real fix for the constant-base `urlopen` / B310), and the script
+  still parses a real arXiv Atom response.
+- [x] The `ET.fromstring` B314 finding is dispositioned as a **stdlib pattern
+  false positive** with a precise `# nosec B314 — <reason>` justification
+  (stdlib ElementTree resolves no external entities or DTDs on 3.11+; arXiv is a
+  constant first-party endpoint), keeping the script stdlib-only per its
+  docstring. No fragile content-scanning guard and no runtime dependency.
+- [x] The `yaml.load`-against-`SafeLoader`-subclass false positives
+  (`tools/lint-agent-artifacts.py`, `tools/lint-skill-spec.py`) and the
+  constant/operator-configured-base `urlopen` false positives carry
+  `# nosec <ID> — <reason>` annotations. The `catalogue.py` tarfile extraction
+  already carries its **real fix** (`extractall(filter="data")`); its stray
+  `# noqa: S###` comments are dropped, and a `# nosec B202` is added *only if*
+  Bandit still flags it despite the kwarg, with a reason naming the real fix in
+  place — it is not re-filed as a pattern FP.
+- [x] pip-audit audits `tools/requirements.txt`, `tools/requirements-sast.txt`,
+  every shipped per-skill `requirements.txt`, and the `credbroker[crypto]` extra
+  (`cryptography`, `argon2-cffi`) — the only third-party code either shipped
+  package can pull, since both declare `dependencies = []`. It reports **zero**
+  known-vulnerable versions; any accepted exception has a `.snyk` entry carrying
+  a `reason` and an `expires`.
+- [x] Semgrep runs against `p/python` + `p/security-audit` and reports no
+  findings on the post-change tree. Four rules are excluded as duplicates of
+  classes Bandit owns (sha1 → `usedforsecurity=False` + B324; urllib → B310;
+  xml → B314; permissive-chmod → B103), with no coverage loss; the exclusion
+  list and rationale live in the `make sast` recipe and ADR-0017 (this is the
+  spec amendment the structural Boundary requires).
+- [x] The Windows gate path is unaffected: `build-check-windows.yml` (which runs
+  `python -m agentbundle.build check` + `python tools/hooks/pre-pr.py`, **not**
+  `make build-check`) stays green, and Semgrep is never invoked on Windows.
+- [x] A committed `.snyk` policy file documents the Snyk-native suppression
+  vehicle (SCA ignore-by-ID; Code via Consistent Ignores) with a worked example
+  and no invented IDs.
+- [x] `make build-self` reprojects the `loop-cohort.py` source edit and leaves
+  the tree drift-clean; `make build-check` stays green.
+- [x] A custom Semgrep `mode: taint` rule (`tools/semgrep/env-path-taint.yml`,
+  env-var → `pathlib.Path`, CWE-22/73) is loaded by `make sast` via
+  `--config tools/semgrep/`; it reports zero findings on the post-change tree
+  and still fires on a direct `Path(os.environ.get(...))` (verified by canary).
+- [x] The `session-start` hook's three env→`Path` flows (`KNOWLEDGE_FILE`,
+  `ADAPT_REPO_MARKER`, `ADAPT_USER_MARKER`) are routed through a **confining**
+  sanitizer (`_safe_override_path`) in the **shipped** pack source: it
+  `expanduser().resolve()`-normalizes then requires the result to stay within an
+  allowed base (repo root for the first two, `~` for the user marker) — closing
+  not just `..` traversal (CWE-22) but absolute-path and symlink escape
+  (CWE-73). An out-of-bounds override is refused (warns + falls back to the
+  default); a regression test asserts both an absolute out-of-bounds path and a
+  `..` traversal are refused and their contents never emitted; existing
+  session-start tests (Python + both shell) stay green.
+- [x] `sso-broker.py`'s `test` verb rejects any resolved URL whose scheme is not
+  `http`/`https` (exit 3) before `urlopen`, with a regression test; `http`/`https`
+  endpoints still work. (Boundary input-validation, returns the existing error
+  code — not a contract change.)
+- [x] A CodeQL code-scanning workflow (`.github/workflows/codeql.yml`, Python,
+  `security-extended`) runs on PRs + push to `main`; it provides the
+  interprocedural-taint lens (`py/path-injection`) Bandit and OSS Semgrep cannot.
+- [x] The four dev tools (Bandit, pip-audit, Semgrep, CodeQL) are recorded in
+  **ADR-0017** (satisfying the "or an ADR" branch of the dependency-recording
+  rule — they are dev/CI-only, not a package runtime dependency), and a
+  `docs/product/changelog.md` `[Unreleased]` entry names them.
+
+## Assumptions
+
+- Technical: Both shipped packages declare `dependencies = []`; the SAST tools
+  must stay dev/CI-only (source: `packages/*/pyproject.toml`, ADR-0017).
+- Technical: The two `yaml.load` *call sites* (`lint-agent-artifacts.py:189`,
+  `lint-skill-spec.py:360`) pass a `yaml.SafeLoader` **subclass** (class defs at
+  `lint-agent-artifacts.py:91`, `lint-skill-spec.py:141`), so B506 is a false
+  positive (source: probe 2026-06-12).
+- Technical: stdlib `xml.etree.ElementTree` resolves no external entities or
+  DTDs on Python 3.11+, so the `arxiv-retriever.py` B314 is a pattern false
+  positive, not a genuine XXE/entity-expansion exposure; the real fix on that
+  line is the `http://`→`https://` endpoint upgrade for B310 (source: probe
+  2026-06-12, Python docs).
+- Technical: The SHA-1 sites are non-security digests (cache-key / review
+  fingerprint), so `usedforsecurity=False` is semantically correct and digest-
+  preserving (source: probe — `config.py:482`, `loop-cohort.py:748`).
+- Technical: `loop-cohort.py` is a projected skill script; the source of record
+  is `packs/core/.apm/skills/work-loop/scripts/` (source: memory
+  `feedback_self_host_projection`).
+- Process: SAST is chained into `make build-check` (the repo's single native
+  gate) so it is dogfooded into this repo's own development, accepting a slower
+  gate; no standalone `sast.yml` (source: user direction 2026-06-12, ADR-0017).
+- Product: Maintainer asked for all three tools and for Snyk-native suppression
+  where relevant (source: user confirmation 2026-06-12).

--- a/packages/agentbundle/agentbundle/catalogue.py
+++ b/packages/agentbundle/agentbundle/catalogue.py
@@ -134,13 +134,14 @@ def _github_archive_url(owner: str, repo: str, ref: str) -> str:
 
 def _fetch_and_extract(url: str, dest: Path) -> None:
     try:
-        with urllib.request.urlopen(url) as resp:  # noqa: S310 — url is assembled from parsed owner/repo/ref
+        # B310: constant github.com archive base assembled from parsed owner/repo/ref.
+        with urllib.request.urlopen(url) as resp:  # nosec B310
             with tarfile.open(fileobj=resp, mode="r|gz") as tf:
                 # filter="data" rejects unsafe members (absolute paths, ..
                 # links, devices, setuid bits) — Python 3.12+ default but
                 # explicit for 3.11 compatibility and to silence the 3.14
                 # DeprecationWarning. Path-jail is belt; this is braces.
-                tf.extractall(path=dest, filter="data")  # noqa: S202
+                tf.extractall(path=dest, filter="data")
     except urllib.error.URLError as exc:
         raise CatalogueError(
             f"Failed to fetch catalogue archive: {url} — {exc.reason}"

--- a/packages/agentbundle/agentbundle/config.py
+++ b/packages/agentbundle/agentbundle/config.py
@@ -479,7 +479,7 @@ def finding_id_for(
     contain ``/``.
     """
     raw = f"{pack}:{kind}:{':'.join(sorted(source_paths))}:{':'.join(sorted(dest_paths))}"
-    digest = hashlib.sha1(raw.encode("utf-8")).hexdigest()[:8]
+    digest = hashlib.sha1(raw.encode("utf-8"), usedforsecurity=False).hexdigest()[:8]
     return f"{pack}/{kind}:{digest}"
 
 

--- a/packages/agentbundle/tests/hooks/test_session_start.sh
+++ b/packages/agentbundle/tests/hooks/test_session_start.sh
@@ -38,6 +38,13 @@ cat > "$PATTERNS" <<'EOF'
 {"id":"k1","kind":"pattern","scope":"*","title":"test entry","body":"x","source":"-"}
 EOF
 
+# The hook confines KNOWLEDGE_FILE / ADAPT_REPO_MARKER to the repo root
+# (resolved from cwd when cwd is not a git repo) and ADAPT_USER_MARKER to HOME.
+# Run every invocation from inside the sandbox so the $TMP fixtures resolve
+# within the allowed base (CWE-22/73 confinement, see session-start.py).
+export HOME="$TMP"
+cd "$TMP"
+
 PASS=0
 FAIL=0
 

--- a/packages/agentbundle/tests/hooks/test_session_start_py.py
+++ b/packages/agentbundle/tests/hooks/test_session_start_py.py
@@ -34,22 +34,34 @@ def _load_hook_module():
     return mod
 
 
-def _run(env_overrides: dict, *args: str) -> subprocess.CompletedProcess:
+def _run(
+    env_overrides: dict, *args: str, cwd: Path | None = None
+) -> subprocess.CompletedProcess:
     env = {**os.environ, **env_overrides}
+    if cwd is not None:
+        # The hook confines KNOWLEDGE_FILE / ADAPT_REPO_MARKER to the repo root
+        # (resolved from cwd when cwd is not a git repo) and ADAPT_USER_MARKER
+        # to HOME. Point both at the per-test sandbox so legitimate tmp-path
+        # overrides resolve inside the allowed base.
+        env["HOME"] = str(cwd)
+        env["USERPROFILE"] = str(cwd)
     return subprocess.run(
         [sys.executable, str(HOOK), *args],
-        env=env, capture_output=True, text=True,
+        env=env, cwd=str(cwd) if cwd is not None else None,
+        capture_output=True, text=True,
     )
 
 
 def _isolated_env(**overrides: str) -> dict:
-    """Build an env dict that points the hook at empty/missing markers
-    so the adapt-nudge block stays silent for tests that only care
-    about the knowledge block (or vice versa)."""
+    """Build an env dict that leaves the markers/knowledge unset (empty
+    string → the hook falls back to its trusted default, which under a
+    sandbox cwd does not exist) so unrelated blocks stay silent. Empty
+    values are skipped by the hook's `_safe_override_path` without a
+    warning — distinct from an out-of-bounds path, which warns."""
     base = {
-        "KNOWLEDGE_FILE": "/dev/null",
-        "ADAPT_REPO_MARKER": "/dev/null",
-        "ADAPT_USER_MARKER": "/dev/null",
+        "KNOWLEDGE_FILE": "",
+        "ADAPT_REPO_MARKER": "",
+        "ADAPT_USER_MARKER": "",
     }
     base.update(overrides)
     return base
@@ -61,7 +73,7 @@ def test_session_start_emits_knowledge_block(tmp_path: Path) -> None:
         '{"id":"K-0001","kind":"pattern","scope":"*","title":"T","body":"B","source":"S"}\n',
         encoding="utf-8",
     )
-    result = _run(_isolated_env(KNOWLEDGE_FILE=str(kb)))
+    result = _run(_isolated_env(KNOWLEDGE_FILE=str(kb)), cwd=tmp_path)
     assert result.returncode == 0, result.stderr
     assert "=== knowledge ===" in result.stdout
     assert "[K-0001]" in result.stdout
@@ -72,7 +84,7 @@ def test_session_start_emits_knowledge_block(tmp_path: Path) -> None:
 def test_session_start_malformed_warns_to_stderr(tmp_path: Path) -> None:
     kb = tmp_path / "knowledge.jsonl"
     kb.write_text("{not json\n", encoding="utf-8")
-    result = _run(_isolated_env(KNOWLEDGE_FILE=str(kb)))
+    result = _run(_isolated_env(KNOWLEDGE_FILE=str(kb)), cwd=tmp_path)
     assert result.returncode == 0
     assert "skipped 1 malformed line(s)" in result.stderr
     # Adopter-clean: the hint must not point at a repo-native catalogue linter.
@@ -87,7 +99,7 @@ def test_session_start_mixed_valid_and_malformed(tmp_path: Path) -> None:
         '{"id":"K-0001","kind":"pattern","scope":"*","title":"T","body":"B","source":"S"}\n',
         encoding="utf-8",
     )
-    result = _run(_isolated_env(KNOWLEDGE_FILE=str(kb)))
+    result = _run(_isolated_env(KNOWLEDGE_FILE=str(kb)), cwd=tmp_path)
     assert result.returncode == 0
     assert "[K-0001]" in result.stdout
     assert "skipped 1 malformed" in result.stderr
@@ -96,23 +108,52 @@ def test_session_start_mixed_valid_and_malformed(tmp_path: Path) -> None:
 def test_session_start_empty_file_silent(tmp_path: Path) -> None:
     kb = tmp_path / "knowledge.jsonl"
     kb.write_text("", encoding="utf-8")
-    result = _run(_isolated_env(KNOWLEDGE_FILE=str(kb)))
+    result = _run(_isolated_env(KNOWLEDGE_FILE=str(kb)), cwd=tmp_path)
     assert result.returncode == 0
     assert result.stdout == ""
     assert result.stderr == ""
 
 
 def test_session_start_missing_file_silent(tmp_path: Path) -> None:
-    result = _run(_isolated_env(KNOWLEDGE_FILE=str(tmp_path / "absent.jsonl")))
+    result = _run(_isolated_env(KNOWLEDGE_FILE=str(tmp_path / "absent.jsonl")), cwd=tmp_path)
     assert result.returncode == 0
     assert result.stdout == ""
     assert result.stderr == ""
 
 
+def test_session_start_refuses_out_of_bounds_override(tmp_path: Path) -> None:
+    """CWE-73 / CWE-22: a KNOWLEDGE_FILE override resolving outside the
+    confinement base (repo root) is refused — warned + fallback — so the hook
+    never reads an arbitrary file. Covers both an *absolute* out-of-bounds path
+    (no `..`, the external-control case) and a `..` traversal."""
+    # A knowledge-shaped "secret" OUTSIDE the sandbox repo root (cwd=tmp_path).
+    outside = tmp_path.parent / "outside-secret.jsonl"
+    outside.write_text(
+        '{"id":"SECRET","kind":"pattern","scope":"*","title":"S","body":"B","source":"X"}\n',
+        encoding="utf-8",
+    )
+    try:
+        # Absolute out-of-bounds path — no "..", the CWE-73 case.
+        result = _run(_isolated_env(KNOWLEDGE_FILE=str(outside)), cwd=tmp_path)
+        assert result.returncode == 0
+        assert "SECRET" not in result.stdout, "out-of-bounds file was read"
+        assert "out-of-bounds path override" in result.stderr
+
+        # Traversal variant (CWE-22) resolving to the same outside file.
+        result2 = _run(
+            _isolated_env(KNOWLEDGE_FILE="../outside-secret.jsonl"), cwd=tmp_path
+        )
+        assert result2.returncode == 0
+        assert "SECRET" not in result2.stdout
+        assert "out-of-bounds path override" in result2.stderr
+    finally:
+        outside.unlink(missing_ok=True)
+
+
 def test_session_start_adapt_nudge_repo_marker(tmp_path: Path) -> None:
     marker = tmp_path / "repo-marker.toml"
     marker.write_text('[[packs-installed]]\nname = "core"\n', encoding="utf-8")
-    result = _run(_isolated_env(ADAPT_REPO_MARKER=str(marker)))
+    result = _run(_isolated_env(ADAPT_REPO_MARKER=str(marker)), cwd=tmp_path)
     assert result.returncode == 0
     assert "=== adapt-to-project:" in result.stdout
     assert "core" in result.stdout
@@ -132,7 +173,7 @@ def test_session_start_adapt_nudge_both_scopes(tmp_path: Path) -> None:
     result = _run(_isolated_env(
         ADAPT_REPO_MARKER=str(repo_marker),
         ADAPT_USER_MARKER=str(user_marker),
-    ))
+    ), cwd=tmp_path)
     assert result.returncode == 0
     assert "2 pack(s) pending" in result.stdout
     assert "2 scope(s)" in result.stdout
@@ -162,6 +203,7 @@ def test_session_start_scope_coverage_glob(tmp_path: Path) -> None:
     result = _run(
         _isolated_env(KNOWLEDGE_FILE=str(kb)),
         "--scope", "packages/auth/server.ts",
+        cwd=tmp_path,
     )
     assert result.returncode == 0
     assert "K-0001" in result.stdout
@@ -252,8 +294,8 @@ def test_session_start_nudge_byte_identical_v03_vs_v04(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    result_v03 = _run(_isolated_env(ADAPT_REPO_MARKER=str(v03_marker)))
-    result_v04 = _run(_isolated_env(ADAPT_REPO_MARKER=str(v04_marker)))
+    result_v03 = _run(_isolated_env(ADAPT_REPO_MARKER=str(v03_marker)), cwd=tmp_path)
+    result_v04 = _run(_isolated_env(ADAPT_REPO_MARKER=str(v04_marker)), cwd=tmp_path)
 
     assert result_v03.returncode == 0, result_v03.stderr
     assert result_v04.returncode == 0, result_v04.stderr

--- a/packages/agentbundle/tests/unit/test_sso_broker_verbs.py
+++ b/packages/agentbundle/tests/unit/test_sso_broker_verbs.py
@@ -462,3 +462,58 @@ def test_ac17_broker_lives_at_canonical_path():
     assert BROKER_PY.is_file()
     assert BROKER_PY.name == "sso-broker.py"
     assert BROKER_PY.parent.name == "adapter-root-bins"
+
+
+# ----------------------------------------------------------------------
+# URL scheme allowlist on `test` (B310 / SSRF-adjacent hardening).
+# ----------------------------------------------------------------------
+
+
+def test_do_test_rejects_non_http_url_scheme(broker):
+    """`_do_test` refuses a profile whose resolved URL scheme is not
+    http(s): a file:// login_url (e.g. a corrupt or hand-edited profile)
+    returns exit 3 *before* urllib.urlopen, closing the file:// local-read
+    vector rather than suppressing the Bandit B310 finding blindly."""
+    mod, _ = broker
+    mod._SSO_PROFILE_DIR.mkdir(parents=True, exist_ok=True)
+    mod._profile_path("evil").write_text(
+        '[profile]\nlogin_url = "file:///etc/passwd"\nvalidation_endpoint = "/x"\n',
+        encoding="utf-8",
+    )
+    # A cookie jar must exist so _do_test reaches the scheme check.
+    mod._store_cookie_jar("evil", b'[{"name":"sid","value":"v"}]')
+    assert mod._do_test("evil") == 3
+
+
+def test_do_test_accepts_https_url_scheme(broker, monkeypatch):
+    """The guard does not reject legitimate https endpoints: with the
+    network call stubbed to a 2xx, a normal https profile returns 0."""
+    mod, _ = broker
+    mod._SSO_PROFILE_DIR.mkdir(parents=True, exist_ok=True)
+    mod._profile_path("acme").write_text(
+        '[profile]\nlogin_url = "https://acme.example.com"\nvalidation_endpoint = "/whoami"\n',
+        encoding="utf-8",
+    )
+    mod._store_cookie_jar("acme", b'[{"name":"sid","value":"v"}]')
+
+    class _Resp:
+        status = 200
+        def __enter__(self): return self
+        def __exit__(self, *a): pass
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", lambda *a, **k: _Resp())
+    assert mod._do_test("acme") == 0
+
+
+def test_do_test_rejects_schemeless_url(broker):
+    """A schemeless login_url (degenerate / hand-edited profile) resolves to an
+    empty url scheme, which the allowlist also rejects (exit 3) — the guard
+    fails closed rather than letting a protocol-relative value through."""
+    mod, _ = broker
+    mod._SSO_PROFILE_DIR.mkdir(parents=True, exist_ok=True)
+    mod._profile_path("bare").write_text(
+        '[profile]\nlogin_url = "acme.example.com"\nvalidation_endpoint = "//evil.example/x"\n',
+        encoding="utf-8",
+    )
+    mod._store_cookie_jar("bare", b'[{"name":"sid","value":"v"}]')
+    assert mod._do_test("bare") == 3

--- a/packs/core/.apm/hooks/session-start.py
+++ b/packs/core/.apm/hooks/session-start.py
@@ -72,6 +72,40 @@ def _repo_root() -> Path:
     return Path.cwd()
 
 
+def _safe_override_path(raw: str, base: Path) -> Path | None:
+    """Resolve an operator-supplied path override and confine it to ``base``.
+
+    Returns the resolved ``Path`` when it stays inside ``base`` — the natural
+    scope for that override (the repo root for repo-scoped files, the home
+    directory for the user-scoped marker) — and ``None`` otherwise, so the
+    caller falls back to its trusted default.
+
+    Env vars are operator config, but an auto-running session hook must not let
+    a stray or hostile value steer it at an arbitrary file: not just directory
+    traversal (``../../etc/passwd``, CWE-22) but any *absolute* path to a
+    secret (``/etc/passwd``, ``~/.ssh/id_rsa``) or a symlink that escapes after
+    resolution — all of which are CWE-73 "external control of file name". The
+    containment check runs *after* ``resolve()``, so symlink targets are
+    validated at their real location, not their lexical form. Shipping the
+    barrier here means no adopter repo inherits the unsanitised env → path flow.
+    """
+    raw = raw.strip()
+    if not raw:
+        return None
+    try:
+        resolved = Path(raw).expanduser().resolve()
+        base_resolved = base.resolve()
+    except (OSError, RuntimeError, ValueError):
+        return None
+    if not resolved.is_relative_to(base_resolved):
+        sys.stderr.write(
+            f"session-start: ignoring out-of-bounds path override {raw!r} "
+            f"(must resolve within {base_resolved})\n"
+        )
+        return None
+    return resolved
+
+
 def _parse_args(argv: list[str]) -> str:
     """Return the scope filter (empty string if absent). Mirrors the
     bash arg loop: --scope requires a value, --help/-h prints USAGE
@@ -198,27 +232,19 @@ def main(argv: list[str]) -> int:
     scope_filter = _parse_args(argv[1:])
     repo_root = _repo_root()
 
-    knowledge_file = Path(
-        os.environ.get(
-            "KNOWLEDGE_FILE",
-            str(repo_root / "docs" / "knowledge" / "patterns.jsonl"),
-        )
-    )
+    home = Path.home()
+    knowledge_file = _safe_override_path(
+        os.environ.get("KNOWLEDGE_FILE", ""), repo_root
+    ) or (repo_root / "docs" / "knowledge" / "patterns.jsonl")
     if knowledge_file.is_file() and knowledge_file.stat().st_size > 0:
         _emit_knowledge(knowledge_file, scope_filter)
 
-    repo_marker = Path(
-        os.environ.get(
-            "ADAPT_REPO_MARKER",
-            str(repo_root / ".adapt-install-marker.toml"),
-        )
-    )
-    user_marker = Path(
-        os.environ.get(
-            "ADAPT_USER_MARKER",
-            str(Path.home() / ".agentbundle" / ".adapt-install-marker.toml"),
-        )
-    )
+    repo_marker = _safe_override_path(
+        os.environ.get("ADAPT_REPO_MARKER", ""), repo_root
+    ) or (repo_root / ".adapt-install-marker.toml")
+    user_marker = _safe_override_path(
+        os.environ.get("ADAPT_USER_MARKER", ""), home
+    ) or (home / ".agentbundle" / ".adapt-install-marker.toml")
     _emit_adapt_nudge(repo_marker, user_marker)
     return 0
 

--- a/packs/core/.apm/skills/work-loop/scripts/loop-cohort.py
+++ b/packs/core/.apm/skills/work-loop/scripts/loop-cohort.py
@@ -745,7 +745,7 @@ def parse_findings(report_text: str) -> list[str]:
             continue
         line_num = line_match.group(0)
         key = f"{file_part}|{line_num}|{title}"
-        fingerprints.append(hashlib.sha1(key.encode("utf-8")).hexdigest())
+        fingerprints.append(hashlib.sha1(key.encode("utf-8"), usedforsecurity=False).hexdigest())
     return fingerprints
 
 

--- a/packs/credential-brokers/.apm/adapter-root-bins/sso-broker.py
+++ b/packs/credential-brokers/.apm/adapter-root-bins/sso-broker.py
@@ -26,6 +26,7 @@ import sys
 import time
 import tomllib
 import urllib.error
+import urllib.parse
 import urllib.request
 
 # Bootstrap when invoked as ``python ~/.agentbundle/bin/sso-broker.py``
@@ -503,12 +504,21 @@ def _do_test(profile: str) -> int:
     cookie_header = "; ".join(f"{c['name']}={c['value']}" for c in cookies)
 
     url = base.rstrip("/") + endpoint
+    # Reject non-web schemes before the request. B310's real danger is urllib
+    # honouring file:// / ftp:// / gopher:// — a corrupt or hand-edited profile
+    # whose login-url points elsewhere is treated as corrupt config (exit 3).
+    # http and https both stay valid, so this breaks no legitimate endpoint.
+    if urllib.parse.urlparse(url).scheme not in ("https", "http"):
+        sys.stderr.write(f"sso-broker test: refusing non-http(s) URL scheme for {profile!r}\n")
+        return 3
     req = urllib.request.Request(url, headers={"Cookie": cookie_header})
     try:
         # Corporate-network env passthrough is the parent's responsibility;
         # urllib honours HTTPS_PROXY / NO_PROXY / SSL_CERT_FILE / SSL_CERT_DIR
         # from the environment automatically.
-        with urllib.request.urlopen(req, timeout=15) as resp:
+        # B310: scheme asserted http(s) above; base is the operator-configured
+        # SSO endpoint (not attacker input).
+        with urllib.request.urlopen(req, timeout=15) as resp:  # nosec B310
             status = resp.status
     except urllib.error.HTTPError as exc:
         status = exc.code

--- a/packs/research/.apm/skills/research/scripts/arxiv-retriever.py
+++ b/packs/research/.apm/skills/research/scripts/arxiv-retriever.py
@@ -26,7 +26,7 @@ import urllib.parse
 import urllib.request
 import xml.etree.ElementTree as ET
 
-ARXIV_API = "http://export.arxiv.org/api/query"
+ARXIV_API = "https://export.arxiv.org/api/query"
 ATOM_NS = "{http://www.w3.org/2005/Atom}"
 
 
@@ -40,10 +40,13 @@ def retrieve(query: str) -> dict:
         "sortOrder": "descending",
     }
     url = f"{ARXIV_API}?{urllib.parse.urlencode(params)}"
-    with urllib.request.urlopen(url, timeout=30) as resp:
+    # B310: constant https arXiv API base.
+    with urllib.request.urlopen(url, timeout=30) as resp:  # nosec B310
         body = resp.read().decode("utf-8")
 
-    root = ET.fromstring(body)
+    # B314: stdlib ElementTree resolves no external entities/DTDs (3.11+);
+    # arXiv is a constant first-party endpoint over TLS.
+    root = ET.fromstring(body)  # nosec B314
     entries = []
     for entry in root.findall(f"{ATOM_NS}entry"):
         title = (entry.findtext(f"{ATOM_NS}title") or "").strip()

--- a/packs/research/.apm/skills/research/scripts/perplexity-retriever.py
+++ b/packs/research/.apm/skills/research/scripts/perplexity-retriever.py
@@ -67,7 +67,8 @@ def retrieve(query: str) -> dict:
         },
         method="POST",
     )
-    with urllib.request.urlopen(req, timeout=60) as resp:
+    # B310: constant https Perplexity API base.
+    with urllib.request.urlopen(req, timeout=60) as resp:  # nosec B310
         body = json.loads(resp.read().decode("utf-8"))
 
     choice = (body.get("choices") or [{}])[0]

--- a/tools/hooks/session-start.py
+++ b/tools/hooks/session-start.py
@@ -72,6 +72,40 @@ def _repo_root() -> Path:
     return Path.cwd()
 
 
+def _safe_override_path(raw: str, base: Path) -> Path | None:
+    """Resolve an operator-supplied path override and confine it to ``base``.
+
+    Returns the resolved ``Path`` when it stays inside ``base`` — the natural
+    scope for that override (the repo root for repo-scoped files, the home
+    directory for the user-scoped marker) — and ``None`` otherwise, so the
+    caller falls back to its trusted default.
+
+    Env vars are operator config, but an auto-running session hook must not let
+    a stray or hostile value steer it at an arbitrary file: not just directory
+    traversal (``../../etc/passwd``, CWE-22) but any *absolute* path to a
+    secret (``/etc/passwd``, ``~/.ssh/id_rsa``) or a symlink that escapes after
+    resolution — all of which are CWE-73 "external control of file name". The
+    containment check runs *after* ``resolve()``, so symlink targets are
+    validated at their real location, not their lexical form. Shipping the
+    barrier here means no adopter repo inherits the unsanitised env → path flow.
+    """
+    raw = raw.strip()
+    if not raw:
+        return None
+    try:
+        resolved = Path(raw).expanduser().resolve()
+        base_resolved = base.resolve()
+    except (OSError, RuntimeError, ValueError):
+        return None
+    if not resolved.is_relative_to(base_resolved):
+        sys.stderr.write(
+            f"session-start: ignoring out-of-bounds path override {raw!r} "
+            f"(must resolve within {base_resolved})\n"
+        )
+        return None
+    return resolved
+
+
 def _parse_args(argv: list[str]) -> str:
     """Return the scope filter (empty string if absent). Mirrors the
     bash arg loop: --scope requires a value, --help/-h prints USAGE
@@ -198,27 +232,19 @@ def main(argv: list[str]) -> int:
     scope_filter = _parse_args(argv[1:])
     repo_root = _repo_root()
 
-    knowledge_file = Path(
-        os.environ.get(
-            "KNOWLEDGE_FILE",
-            str(repo_root / "docs" / "knowledge" / "patterns.jsonl"),
-        )
-    )
+    home = Path.home()
+    knowledge_file = _safe_override_path(
+        os.environ.get("KNOWLEDGE_FILE", ""), repo_root
+    ) or (repo_root / "docs" / "knowledge" / "patterns.jsonl")
     if knowledge_file.is_file() and knowledge_file.stat().st_size > 0:
         _emit_knowledge(knowledge_file, scope_filter)
 
-    repo_marker = Path(
-        os.environ.get(
-            "ADAPT_REPO_MARKER",
-            str(repo_root / ".adapt-install-marker.toml"),
-        )
-    )
-    user_marker = Path(
-        os.environ.get(
-            "ADAPT_USER_MARKER",
-            str(Path.home() / ".agentbundle" / ".adapt-install-marker.toml"),
-        )
-    )
+    repo_marker = _safe_override_path(
+        os.environ.get("ADAPT_REPO_MARKER", ""), repo_root
+    ) or (repo_root / ".adapt-install-marker.toml")
+    user_marker = _safe_override_path(
+        os.environ.get("ADAPT_USER_MARKER", ""), home
+    ) or (home / ".agentbundle" / ".adapt-install-marker.toml")
     _emit_adapt_nudge(repo_marker, user_marker)
     return 0
 

--- a/tools/lint-agent-artifacts.py
+++ b/tools/lint-agent-artifacts.py
@@ -186,7 +186,8 @@ def main() -> int:
         body_start_line = end + 2
         body = "\n".join(lines[end + 1:])
         try:
-            fields = yaml.load(fm_text, Loader=_FrontmatterLoader)
+            # B506: Loader is a yaml.SafeLoader subclass (class def above).
+            fields = yaml.load(fm_text, Loader=_FrontmatterLoader)  # nosec B506
         except _DuplicateKeyError as exc:
             # exc.line is 0-indexed within fm_text (mark.line + 1); the
             # frontmatter starts at file line 2 (line 1 is the opening

--- a/tools/lint-skill-spec.py
+++ b/tools/lint-skill-spec.py
@@ -357,7 +357,8 @@ def main() -> int:
             file_line = fm_line_idx + 2
             return None, 0, text, f"line {file_line}: {desc_msg}", fm_text
         try:
-            fields = yaml.load(fm_text, Loader=_FrontmatterLoader)
+            # B506: Loader is a yaml.SafeLoader subclass (class def above).
+            fields = yaml.load(fm_text, Loader=_FrontmatterLoader)  # nosec B506
         except _DuplicateKeyError as exc:
             return None, 0, text, (
                 f"duplicate frontmatter key {exc.key!r} (line {exc.line + 1})"

--- a/tools/requirements-sast.txt
+++ b/tools/requirements-sast.txt
@@ -1,0 +1,12 @@
+# SAST/SCA gate tooling (ADR-0017).
+#
+# CI-only dev dependencies — NEVER runtime dependencies of a shipped package.
+# `agentbundle` and `credbroker` stay `dependencies = []`; these tools are
+# installed only to run the gate (`make sast`, chained into `make build-check`
+# and the build-check.yml CI job).
+#
+# Contributors: `pip install -r tools/requirements-sast.txt` once, then
+# `make sast`.
+bandit>=1.9,<2
+pip-audit>=2.10,<3
+semgrep>=1.166,<2

--- a/tools/semgrep/env-path-taint.yml
+++ b/tools/semgrep/env-path-taint.yml
@@ -1,0 +1,54 @@
+# Custom Semgrep taint rules for the SAST gate (ADR-0017).
+#
+# These close the gap Bandit cannot cover: Bandit is an AST pattern-matcher
+# with no dataflow/taint engine, so it never sees that an environment-variable
+# value *flows into* a filesystem path. Snyk Code (taint-based) does, and
+# flagged exactly this on the session-start hook. Semgrep's `mode: taint`
+# (intraprocedural, OSS) reproduces it; CodeQL (.github/workflows/codeql.yml)
+# adds the deep interprocedural lens. Loaded by `make sast` via
+# `--config tools/semgrep/`.
+
+rules:
+  - id: env-var-into-pathlib-path
+    mode: taint
+    languages: [python]
+    severity: WARNING
+    message: >-
+      Environment-variable input flows into pathlib.Path without validation
+      (CWE-22 path traversal / CWE-73 external control of file name). Route the
+      value through a validator that rejects traversal (see session-start.py's
+      _safe_override_path) before using it as a filesystem target.
+    metadata:
+      cwe:
+        - "CWE-22: Improper Limitation of a Pathname to a Restricted Directory"
+        - "CWE-73: External Control of File Name or Path"
+      category: security
+      confidence: MEDIUM
+      references:
+        - https://docs.snyk.io/scan-with-snyk/snyk-code
+    # Scoped to packs/ — the shipped agent primitives (hooks, skills,
+    # adapter-root-bins) that run *automatically* inside an agent session or
+    # adapter, where the inherited environment is the genuine injection
+    # surface. Dev-only CLIs under tools/ (a maintainer's own path arg) and
+    # install-time code (installer-set HOME/plugin paths in install-marker)
+    # read operator/CI-controlled env by design; CodeQL (which scans the whole
+    # repo, advisory) is the broad net for those. This keeps the *blocking*
+    # rule on the surface where the threat is real, not on trusted-context
+    # flows it would only have to suppress.
+    paths:
+      include:
+        - "packs/**"
+    pattern-sources:
+      - pattern-either:
+          - pattern: os.environ.get(...)
+          - pattern: os.environ[...]
+          - pattern: os.getenv(...)
+    pattern-sinks:
+      - pattern-either:
+          - pattern: pathlib.Path(...)
+          - pattern: Path(...)
+    # A value confined by the hook's validator is no longer tainted — so a
+    # future `Path(_safe_override_path(os.environ[...], base))` is recognised as
+    # clean, while a raw `Path(os.environ[...])` still fires.
+    pattern-sanitizers:
+      - pattern: _safe_override_path(...)

--- a/tools/test-session-start.sh
+++ b/tools/test-session-start.sh
@@ -14,6 +14,12 @@ trap 'rm -rf "$TMP"' EXIT
 
 HOOK="$REPO_ROOT/tools/hooks/session-start.py"
 
+# The hook confines KNOWLEDGE_FILE to the repo root (resolved from cwd when cwd
+# is not a git repo). Run from inside the sandbox so the $TMP fixtures resolve
+# within the allowed base (CWE-22/73 confinement, see session-start.py).
+export HOME="$TMP"
+cd "$TMP"
+
 failures=0
 ran=0
 


### PR DESCRIPTION
## What does this change?

Adds the repo's first SAST/SCA gate — **Bandit + pip-audit + Semgrep** behind `make sast` (chained into `make build-check`, so it runs locally and in CI) plus a **CodeQL** code-scanning workflow — and fixes the findings it surfaced at the source. The motivating case: an internal org Snyk scan was flagging skill/tool scripts with no local tooling to reproduce or pre-empt it.

## Why?

- Implements: `docs/specs/sast-sca-tooling/spec.md`
- Follows from: `ADR-0017`

Bandit alone is not enough: it's an AST pattern-matcher with **no taint engine**, so it cannot see the env-var → `pathlib.Path` flow (CWE-22/73) Snyk Code flagged on the session-start hook. That gap is why this PR also adds a custom Semgrep `mode: taint` rule (`tools/semgrep/`, scoped to `packs/**`) and CodeQL for deep interprocedural taint. `# nosec` suppresses Bandit but not Snyk, so genuine findings get **real fixes**; only tool-specific false positives are suppressed.

Findings fixed at source (so adopters inherit them, no per-repo suppression):
- weak **SHA-1** → `usedforsecurity=False` (documented non-security digests)
- arXiv retriever **`http://` → `https://`**
- **session-start** env→path overrides **confined** via `_safe_override_path` (resolve + `is_relative_to(base)` — closes traversal *and* absolute/symlink escape)
- **sso-broker** `test` verb rejects non-`http(s)` URL schemes
- `SafeLoader` `yaml.load` + constant-URL `urlopen` false positives → justified `# nosec`; 4 duplicate Semgrep registry rules excluded with rationale; `.snyk` scaffold for Snyk-native accepts

All four scanners are CI-only dev tools (`tools/requirements-sast.txt`); both packages stay `dependencies = []`.

## How do I verify it?

```bash
pip install -r tools/requirements-sast.txt
make sast                 # Bandit + pip-audit + Semgrep, all green
make build-check          # the full gate, now chaining make sast
# Tests covering the source fixes:
PYTHONPATH=packages/agentbundle python -m pytest \
  packages/agentbundle/tests/unit/test_sso_broker_verbs.py \
  packages/agentbundle/tests/hooks/test_session_start_py.py
bash packages/agentbundle/tests/hooks/test_session_start.sh
```
CodeQL runs as its own workflow on the PR (alerts surface in the Security tab).

## What did you not change that you considered?

- **Did not lower Bandit's severity floor** to catch the `subprocess`/partial-path tail — ~190 low-severity false positives, and it still wouldn't find the taint flows. Left to the taint lenses.
- **Did not switch the SHA-1 digests to sha256** — both are documented non-security digests (one is the work-loop's canonical fingerprint algorithm); changing them would diverge from documented contracts. `usedforsecurity=False` + `.snyk` accept if Snyk insists.
- **Scoped the blocking Semgrep taint rule to `packs/**`** (auto-running agent primitives) rather than the whole repo — the ~13 env→path flows in `tools/` dev-CLIs and install-time `install-marker.py` are trusted-context and covered advisorily by CodeQL, not suppressed 13 times.
- **CodeQL is advisory** until branch protection requires it (a repo-settings toggle, not code).
- **Cannot verify against the actual org Snyk scan** (no access) — the four OSS scanners are a high-fidelity proxy.

---

## Checklist

- [x] Tests pass locally (`make build-check` green; broker + hook suites green)
- [x] Lint and typecheck pass (`make build-check`)
- [x] Self-review run via the relevant reviewer subagent (`adversarial-reviewer` + `security-reviewer`, security boundary crossed; iterated to clean; blockers addressed)
- [x] Spec and code agree (spec Shipped, all ACs checked, in this PR)
- [x] Living docs match reality:
  - [x] `docs/product/changelog.md` updated
  - [ ] `docs/guides/` — n/a (no user-facing interface change; repo-internal gate)
  - [ ] `docs/architecture/` — n/a
  - [ ] `docs/product/roadmap.md` — n/a
- [x] No new top-level directories (`tools/semgrep/` under `tools/`; `.snyk`/`bandit.yaml` are root config files)
- [x] Conventional commit format
- [x] Learnings captured (ADR-0017 records the Bandit-no-taint rationale)
