### PR TITLE
ci(codeql): exclude test trees from analysis (paths-ignore)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,6 +43,15 @@ jobs:
           # security-extended adds the taint queries (incl. py/path-injection)
           # beyond the default suite.
           queries: security-extended
+          # Exclude test trees from analysis — consistent with bandit.yaml's
+          # exclude_dirs and the packs/-scoped Semgrep taint rule. Test fixtures
+          # (permissive chmod, fixture URLs/credentials) are not shipped attack
+          # surface; this is the durable form of dismissing those alerts.
+          config: |
+            paths-ignore:
+              - '**/tests/**'
+              - '**/test_*.py'
+              - '**/test-*.py'
 
       # Python is interpreted — no build step; CodeQL extracts the source.
       - name: Perform CodeQL analysis


### PR DESCRIPTION
## What does this change?

Adds a `paths-ignore` policy to the CodeQL workflow so test trees are excluded from analysis. Follow-up to #281 / ADR-0017.

## Why?

Turning CodeQL on surfaced a 14-alert backlog, **12 of which were test fixtures** (permissive `chmod`, fixture URLs/credentials) — not shipped attack surface. Per-alert dismissal clears them once but they'd recur on every new test file. Excluding test trees is the **durable** form, and it makes all three SAST lenses agree: `bandit.yaml` already sets `exclude_dirs` for tests and the Semgrep taint rule is scoped to `packs/`.

The 2 production alerts were triaged separately (not in this PR, no code change):
- `safety.py` — dismissed as a **false positive** (generic atomic-write helper; mode is a caller-supplied parameter, callers pass restrictive modes).
- `adapter_root_bins.py` (`0o755`) — dismissed **won't-fix / by-design**: `0o755` is the contract-pinned executable mode (`credential-broker-contract` AC22, frozen by RFC-0013, with a pinning test). Tightening to `0o700` would need an Approver-signed contract erratum — out of scope for a CodeQL cleanup.

## How do I verify it?

The CodeQL check on this PR runs with the new config; test-tree files no longer produce alerts. `make build-check` is unaffected (workflow-only change).

## What did you not change that you considered?

- **Did not pursue the `0o700` hardening** — it's a frozen-contract change (credential-broker-contract AC22 / RFC-0013), tracked as a possible erratum, not bundled here.
- **Did not stop scanning production code** — only test trees are excluded, matching the other two scanners.

---

## Checklist

- [x] Lint/build pass (`make build-check` — workflow-only change, unaffected)
- [x] Spec and code agree (follow-up to ADR-0017; no spec contract changed)
- [x] No new top-level directories
- [x] Conventional commit format
