### PR TITLE
feat(core): shift security review left + progressive-disclosure checklists (RFC-0029)

### DIFF
--- a/.agents/skills/security-checklists/SKILL.md
+++ b/.agents/skills/security-checklists/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: security-checklists
+description: Progressive-disclosure security-depth modules for the security-reviewer. Holds ten boundary-keyed checklists (access-control, authn-session, injection, path-and-file, secrets-and-crypto, outbound-ssrf, supply-chain, config-misconfig, exceptional-conditions, llm-agent) as references/, each anchored on a current standard (OWASP Top 10:2025, ASVS 5.0, API Security Top 10:2023, Proactive Controls 2024, CWE Top 25, OWASP LLM Top 10:2025). The work-loop's orchestrator loads only the boundary-matching modules and inlines them into the security-reviewer's brief; the subagent never self-discovers this skill. Not a reviewer prompt itself — it is the depth library the reviewer reasons from.
+---
+
+# Skill: security-checklists
+
+This skill is the **depth library** behind the `security-reviewer` agent. The
+reviewer's body carries the *universal method* (the three-bucket delegation
+rule, load-context-first, the always-on STRIDE + LINDDUN open pass, the
+established-helper-bypass meta-check, the severity rubric, the honest-limits
+footer, the output format). The *shape-specific depth* — what to actually
+check at each trust boundary — lives here, in ten `references/<module>.md`
+modules, so the agent prompt stays lean and the depth scales without bloat.
+
+## How it loads (orchestrator-driven, not self-discovered)
+
+**The orchestrator drives loading; the subagent does not.** There is no
+mechanism to force a subagent to invoke a skill, skill discovery is
+model-invoked and adapter-variable, and the `security-reviewer`'s `tools:`
+list does not even include a Skill tool. So depth must not depend on the
+reviewer finding this library itself.
+
+Concretely, at the work-loop's security-review step (and at the pre-EXECUTE
+spec-stage pass), the orchestrator:
+
+1. Detects which **trust boundaries** the diff or spec crosses.
+2. Loads **only the matching modules** via the deterministic
+   boundary→module routing table in `work-loop/SKILL.md`.
+3. **Inlines the selected modules' content** into the `security-reviewer`
+   subagent's brief — so the reviewer receives a focused ~30-item checklist
+   as prompt text, never a path to resolve.
+
+Where an adapter *does* support subagent skill auto-discovery, that is a
+redundant convenience layered on top — never the load-bearing mechanism.
+
+## The three-bucket delegation legend
+
+Every check in every module is tagged so the reviewer knows who owns it:
+
+- **`tool`** — scanner-owned. Confirm the scanner is *wired*; don't re-check
+  by hand. Detect the ecosystem's scanner rather than assuming one:
+  `npm audit` / `pip-audit` / `govulncheck` / `cargo audit` / `bundler-audit`,
+  or Snyk / Semgrep / CodeQL. If the delegated scanner is **absent**, do not
+  silently skip (Tier-1 declare/detect/fail-clean): either reason the class
+  best-effort and flag it `degraded: no scanner`, or state the gap explicitly
+  ("class X is normally scanner-owned; none detected → wire one or accept the
+  gap"). A silent skip is the worst outcome — it looks like coverage.
+- **`hybrid`** — the scanner finds the flow; *you* judge the fix. Taint
+  analysis can point at a sink, but whether the escaping, the confinement,
+  or the safe-loader choice is correct is reasoning work.
+- **`reason`** — reviewer-only. Logic-flaw access control, fail-open vs
+  fail-closed, confused-deputy, privacy exposure — the classes scanners
+  structurally cannot see. The highest-value findings live here.
+
+## Established-helper bypass (the repo-aware meta-check)
+
+For each boundary the change crosses, the most actionable real-world finding
+is **"this code rolled its own instead of the repo's blessed helper."** Each
+module names, in generic terms, the *kind* of helper that boundary usually
+has. To resolve the repo's actual helper, the reviewer consults, in
+precedence: the **`AGENTS.md`** "blessed security tools/helpers" list →
+`CONVENTIONS.md` and any context other packs install (steering files, etc.)
+→ **inference fallback** (grep the codebase for the de-facto helper). Flag
+code that re-implements a boundary the repo already has a sanctioned helper
+for. This skill carries the *mechanism* only — never any one repo's specific
+helper names.
+
+## Module index
+
+| Module | Boundary | Primary anchor |
+|---|---|---|
+| [`access-control`](references/access-control.md) | authz / object- & function-level access | OWASP A01:2025 + API Security Top 10:2023 (BOLA/BFLA) |
+| [`authn-session`](references/authn-session.md) | authentication, session, tokens | OWASP A07:2025 + ASVS 5.0 V6/V7 |
+| [`injection`](references/injection.md) | untrusted input → interpreter / deserializer | OWASP A05:2025 (+ A08 deserialization) |
+| [`path-and-file`](references/path-and-file.md) | filesystem paths, uploads, archive extraction | CWE-22 / CWE-73 + ASVS 5.0 V12 |
+| [`secrets-and-crypto`](references/secrets-and-crypto.md) | secrets, keys, hashing, signing, randomness | OWASP A04:2025 + ASVS 5.0 V11 |
+| [`outbound-ssrf`](references/outbound-ssrf.md) | outbound HTTP/DNS, URL fetch, webhooks | OWASP A01:2025 (SSRF) + ASVS 5.0 V13 |
+| [`supply-chain`](references/supply-chain.md) | dependencies, lockfiles, build trust | **OWASP A03:2025 (new)** |
+| [`config-misconfig`](references/config-misconfig.md) | CORS, IAM, IaC, server config | OWASP A02:2025 |
+| [`exceptional-conditions`](references/exceptional-conditions.md) | error paths, retries, fail-open | **OWASP A10:2025 (new)** (+ A09 logging) |
+| [`llm-agent`](references/llm-agent.md) | prompts, tool exposure, MCP, model output | OWASP LLM Top 10:2025 |
+
+Threat modeling (STRIDE + LINDDUN for privacy) and design-time Insecure
+Design (A06 / Proactive Controls 2024) are **not** runtime modules: STRIDE +
+LINDDUN ride the always-on open pass in the agent body, and Insecure Design
+is realized by the spec-stage secure-design mode. Each module below carries a
+**Spec-stage** section so the same depth backs the design-time pass in its
+proactive-control framing.

--- a/.agents/skills/security-checklists/references/access-control.md
+++ b/.agents/skills/security-checklists/references/access-control.md
@@ -1,0 +1,47 @@
+# access-control — authorization, object- & function-level
+
+> **Loaded when:** the change adds or alters an endpoint, handler, RPC, or any
+> code path that reads or mutates a resource on behalf of a caller.
+> **Standards:** OWASP Top 10:2025 A01 (Broken Access Control) · OWASP API
+> Security Top 10:2023 (API1 BOLA, API3 BOPLA, API5 BFLA) · ASVS 5.0 V4
+> (Access Control) · Proactive Controls 2024 C1 (Enforce Access Controls).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, ask whether the spec names the access rule **as an acceptance
+criterion** at the right depth: not "users can only see their own orders" in
+prose, but a criterion stating *which* identity is checked, *where* the check
+sits relative to the side effect, and what an out-of-scope caller receives
+(404 vs 403). A boundary with no AC for authz is the highest-leverage
+spec-stage finding (Proactive Controls 2024 C1; ASVS 5.0 V4.1).
+
+## Implementation checks
+
+- `reason` **Who is allowed to call this?** For every new/changed
+  endpoint/handler/RPC, name the identity and the guard. A mutating operation
+  with no `requireAuth`-equivalent before the side effect is a Blocker.
+- `reason` **Object-level (BOLA / IDOR).** A caller passing `id=B` while
+  authenticated as A must be rejected — the row is fetched *scoped to the
+  caller*, not fetched-then-checked-then-maybe-leaked.
+- `reason` **Function-level (BFLA).** Admin/privileged routes must verify the
+  *role*, not merely authentication. A regular user reaching an admin verb by
+  guessing the path is the classic miss.
+- `reason` **Check-before-effect ordering.** The authorization decision must
+  precede the mutation/read it guards; a check after the side effect is
+  decorative.
+- `reason` **Mass assignment / property-level (BOPLA).** Binding a request
+  body straight onto a model lets a caller set fields they shouldn't
+  (`isAdmin`, `ownerId`). Confirm an allowlist of writable fields.
+- `hybrid` **Missing-guard coverage.** A linter/SAST route-auth rule can list
+  unguarded routes; you judge whether each *should* be public.
+
+## Established-helper bypass
+
+Most repos centralize authz in one place — a policy/guard middleware, a
+`can(actor, action, resource)` helper, a decorator. Resolve the repo's
+sanctioned authorization helper (AGENTS.md blessed list → CONVENTIONS /
+installed context → grep for the de-facto guard) and flag any handler that
+hand-rolls an inline `if user.id == ...` check instead of calling it —
+ad-hoc checks drift out of sync with the policy the helper centralizes.

--- a/.agents/skills/security-checklists/references/authn-session.md
+++ b/.agents/skills/security-checklists/references/authn-session.md
@@ -1,0 +1,47 @@
+# authn-session — authentication, session, tokens
+
+> **Loaded when:** the change touches login, logout, password handling, MFA,
+> session creation/expiry, or token issuance/verification (JWT, opaque, API
+> keys).
+> **Standards:** OWASP Top 10:2025 A07 (Authentication Failures) · ASVS 5.0 V6
+> (Authentication) + V7 (Session Management) · OWASP API Security Top 10:2023
+> (API2 Broken Authentication) · Proactive Controls 2024 C6 (Digital Identity).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, confirm the spec specifies session **lifecycle** as criteria,
+not just "log the user in": rotation-on-privilege-change, idle and absolute
+timeouts, and what invalidates a session. Authentication strength
+(MFA paths, lockout/throttling) should be an AC where the asset warrants it
+(ASVS 5.0 V6.2; Proactive Controls 2024 C6).
+
+## Implementation checks
+
+- `reason` **Session fixation / rotation.** The session identifier must rotate
+  on login and on privilege elevation; reusing a pre-auth session id lets an
+  attacker fixate it.
+- `reason` **JWT verification.** Reject `alg: none`; pin the expected
+  algorithm; verify the signature against the *expected* key, not the key the
+  token names (`jku`/`kid` confusion). An unverified or `alg`-confused JWT is
+  a Blocker.
+- `reason` **Token entropy & storage.** Session tokens and reset tokens must be
+  CSPRNG-derived and stored hashed; predictable or plaintext-stored tokens are
+  forgeable.
+- `reason` **Lockout / throttling.** Sensitive auth endpoints (login, OTP,
+  reset) need rate-limiting or progressive backoff; their absence is a
+  credential-stuffing invitation.
+- `reason` **Logout & expiry actually invalidate.** A logout that only clears
+  a client cookie while the server token stays valid is a false control.
+- `hybrid` **Hardcoded / weak credentials in the diff.** A secret scanner
+  flags committed credentials; you judge whether a "test" default is reachable
+  in production config.
+
+## Established-helper bypass
+
+Authentication is almost never something to hand-roll. Resolve the repo's
+sanctioned auth/session library or middleware and flag a change that
+introduces its own password hashing, its own JWT parsing, or its own session
+store instead of the blessed path — rolled-its-own auth is where `alg: none`
+and unsalted hashes slip in.

--- a/.agents/skills/security-checklists/references/config-misconfig.md
+++ b/.agents/skills/security-checklists/references/config-misconfig.md
@@ -1,0 +1,45 @@
+# config-misconfig — CORS, IAM, IaC, server configuration
+
+> **Loaded when:** the change edits server/framework config, CORS, IAM/role
+> grants, infrastructure-as-code, container or deployment settings.
+> **Standards:** OWASP Top 10:2025 A02 (Security Misconfiguration) · ASVS 5.0
+> V14 (Configuration) · Proactive Controls 2024 C5 (Secure by Default
+> Configurations).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, the control is **secure-by-default** — the spec should name
+the least-privilege posture (which origins, which principals, which ports)
+rather than leaving defaults to be hardened later. A config AC reads "CORS
+allows exactly origin X with credentials off," not "configure CORS" (ASVS 5.0
+V14; Proactive Controls 2024 C5).
+
+## Implementation checks
+
+- `tool` **IaC misconfiguration.** Public buckets, open security groups,
+  over-broad IAM — IaC scanners (Checkov/tfsec/KICS, or Semgrep/CodeQL rules)
+  own the common patterns; confirm one is wired. If none is detected, flag
+  `degraded: no scanner` and reason the diff by hand rather than passing it
+  silently.
+- `reason` **CORS.** `Access-Control-Allow-Origin: *` together with
+  `Allow-Credentials: true` is a credential-leak misconfiguration; reflecting
+  the `Origin` header without an allowlist is the same bug in disguise.
+- `reason` **IAM / role grants.** Wildcards in actions or resources
+  (`"*"`), `PassRole` over-grants, and trust policies that admit too broad a
+  principal are least-privilege violations a reviewer judges in context.
+- `reason` **Default credentials & exposed surfaces.** Default admin
+  passwords, debug/management endpoints enabled, directory listing, verbose
+  error pages exposing stack traces or versions.
+- `reason` **Security headers / TLS posture.** Missing HSTS, permissive
+  `Content-Security-Policy`, TLS verification disabled, or downgraded
+  protocol/cipher settings.
+
+## Established-helper bypass
+
+Resolve the repo's sanctioned config/module (the hardened web-server base, the
+shared IAM module, the CORS middleware with the allowlist) and flag a change
+that defines a one-off permissive config inline instead of extending the
+blessed default — the shared module is where secure-by-default was already
+decided.

--- a/.agents/skills/security-checklists/references/exceptional-conditions.md
+++ b/.agents/skills/security-checklists/references/exceptional-conditions.md
@@ -1,0 +1,47 @@
+# exceptional-conditions — error paths, retries, fail-open
+
+> **Loaded when:** the change adds error handling, retry/timeout logic,
+> fallbacks, circuit breakers, or alters what happens when a dependency fails.
+> **Standards:** **OWASP Top 10:2025 A10 (Mishandling of Exceptional
+> Conditions — new in 2025)** (+ A09 Security Logging & Monitoring Failures) ·
+> ASVS 5.0 V16 (Security Logging & Error Handling) · Proactive Controls 2024
+> C10 (Handle all Errors and Exceptions).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, the control is **decide fail-open vs fail-closed explicitly**
+— for each control the feature relies on (authz check, token verification,
+rate limiter), the spec should state what happens when its dependency is
+unavailable. A security control that defaults to "allow" on error is the
+classic exceptional-condition bug (Proactive Controls 2024 C10; ASVS 5.0 V16).
+
+## Implementation checks
+
+- `reason` **Fail-open vs fail-closed.** When an authz/verification/rate-limit
+  dependency errors or times out, does the code *deny* or *allow*? A security
+  decision that falls through to allow on exception is a Blocker.
+- `reason` **Error-path information leak (A09).** Exceptions returned to the
+  caller must not carry stack traces, SQL, internal paths, or secrets;
+  trace what the catch block actually emits.
+- `reason` **Unbounded retry / amplification (DoS).** Retries without a cap or
+  backoff, recursion without a depth bound, or an unbounded allocation driven
+  by input is a denial-of-service vector.
+- `reason` **Swallowed exceptions.** A bare `except: pass` over a security
+  operation hides a failure that should deny or alert — flag the silent
+  swallow, not just the missing log.
+- `reason` **Critical-event logging gap (A09).** Auth failures, access-control
+  denials, and integrity violations should be logged with enough context
+  (correlation id, actor) to investigate — without logging the sensitive
+  payload itself.
+- `tool` **Empty-catch / swallowed-error lint.** Some linters flag empty catch
+  blocks; confirm the rule is on, but the *security* judgment (deny vs allow)
+  stays reviewer-owned.
+
+## Established-helper bypass
+
+Resolve the repo's sanctioned error-handling / result wrapper and structured
+logger, and flag a change that invents its own fail-through behavior or logs
+ad hoc (and possibly leaks) instead of using the blessed path — the shared
+error wrapper is where fail-closed and redaction were already settled.

--- a/.agents/skills/security-checklists/references/injection.md
+++ b/.agents/skills/security-checklists/references/injection.md
@@ -1,0 +1,48 @@
+# injection — untrusted input into an interpreter or deserializer
+
+> **Loaded when:** the change builds SQL, shell/OS commands, LDAP filters,
+> template strings, HTML, or NoSQL queries from input, **or** deserializes
+> untrusted data.
+> **Standards:** OWASP Top 10:2025 A05 (Injection) + A08 (Software & Data
+> Integrity — unsafe deserialization) · ASVS 5.0 V5 (Validation, Sanitization
+> & Encoding) · CWE Top 25 (CWE-89 SQLi, CWE-78 OS command, CWE-79 XSS,
+> CWE-502 deserialization).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, the control is "parameterize at the boundary, encode at the
+sink" — the spec should commit to parameterized queries / safe loaders rather
+than leaving sanitization to be retrofitted. Where a feature accepts a
+structured payload, name the expected schema as a criterion (ASVS 5.0 V5;
+Proactive Controls 2024 C3 Validate-all-Inputs / C4 Encode-and-Escape).
+
+## Implementation checks
+
+- `hybrid` **SQL / NoSQL.** Taint analysis finds input reaching a query; you
+  judge whether it is *parameterized* (`$1`, bound params) versus
+  string-concatenated. Flag any `fmt.Sprintf`/f-string/`+` building a query
+  with input.
+- `hybrid` **OS command / shell.** Prefer argument-vector exec over a shell
+  string; flag `shell=True`-equivalent with interpolated input. Scanner finds
+  the call; you judge whether the input is constrained.
+- `hybrid` **Template / SSTI & HTML / XSS.** Output into HTML or a template
+  engine must be contextually escaped; flag autoescape disabled or `raw`/
+  `dangerouslySetInnerHTML` over untrusted content.
+- `reason` **Unsafe deserialization (A08).** `pickle`, Java native
+  serialization, `yaml.load` (vs `safe_load`), PHP `unserialize` on untrusted
+  bytes is remote code execution. Confirm a safe loader or a signed/typed
+  format. This is reviewer-only judgment — a scanner may not know the source
+  is untrusted.
+- `tool` **Known-vulnerable parser/driver.** If the injection risk is a
+  CVE in the query driver or parser, that is SCA's job — confirm `pip-audit` /
+  `npm audit` / `govulncheck` is wired; if no scanner is detected, flag
+  `degraded: no scanner` rather than asserting the dependency is clean.
+
+## Established-helper bypass
+
+Resolve the repo's sanctioned query builder / ORM, its output-encoding helper,
+and its safe-deserialization wrapper. Flag code that drops to raw string
+concatenation or a raw `eval`/`load` when the blessed parameterizing or
+safe-loading path exists.

--- a/.agents/skills/security-checklists/references/llm-agent.md
+++ b/.agents/skills/security-checklists/references/llm-agent.md
@@ -1,0 +1,52 @@
+# llm-agent — prompts, tool exposure, MCP, model output
+
+> **Loaded when:** the change constructs prompts, exposes tools/functions to a
+> model, runs an MCP server/client, sandboxes agent actions, or consumes model
+> output.
+> **Standards:** OWASP Top 10 for LLM Applications:2025 (LLM01 Prompt
+> Injection, LLM02 Sensitive Information Disclosure, LLM05 Improper Output
+> Handling, LLM06 Excessive Agency, LLM03 Supply Chain, LLM10 Unbounded
+> Consumption) · ASVS 5.0 (input/output validation principles applied to model
+> I/O).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, the control is an **instruction-vs-data boundary and a
+least-privilege tool surface** — the spec should name how untrusted content is
+isolated in the prompt, which tools the model can call, and which actions
+require a human confirmation step. "The agent can take actions" with no tool
+allowlist or confirmation criteria is the design-time miss.
+
+## Implementation checks
+
+- `reason` **Prompt injection (LLM01).** Untrusted content (user input,
+  fetched pages, retrieved docs, tool output) flowing into the prompt without
+  an instruction-vs-data boundary. Confirm untrusted content is delimited and
+  the system prompt instructs the model not to treat it as instructions.
+- `reason` **Excessive agency (LLM06).** Tools exposed to the model must be
+  least-privilege; high-impact/mutating actions (delete, pay, send) need a
+  confirmation step or a scoped credential, not unattended execution.
+- `reason` **Improper output handling (LLM05).** Model output used as code,
+  SQL, shell, HTML, or a file path without validation/escaping is injection
+  with the model as the source — treat model output as untrusted input to the
+  next sink.
+- `reason` **Sensitive information disclosure (LLM02).** Secrets, system
+  prompts, or other users' data reachable through model output; confirm the
+  model isn't handed more context than the caller is entitled to.
+- `reason` **Unbounded consumption (LLM10).** A user-triggered model call with
+  no token/request/cost cap is a denial-of-wallet and DoS vector.
+- `tool` **Model/MCP supply chain (LLM03).** Model weights, embeddings, or MCP
+  servers loaded from unverified sources — pinning/provenance is partly
+  tooling; confirm the source is trusted, and if no integrity check exists flag
+  the gap.
+
+## Established-helper bypass
+
+Resolve the repo's sanctioned prompt-construction / content-isolation helper
+and its tool-registration layer (where the allowlist and confirmation gating
+live), and flag a change that concatenates untrusted content into a prompt
+directly or registers a tool outside the blessed path — the helper is where
+the instruction-vs-data boundary and least-privilege tool surface are enforced
+once.

--- a/.agents/skills/security-checklists/references/outbound-ssrf.md
+++ b/.agents/skills/security-checklists/references/outbound-ssrf.md
@@ -1,0 +1,43 @@
+# outbound-ssrf — outbound HTTP/DNS, URL fetch, webhooks
+
+> **Loaded when:** the change makes an outbound request (HTTP, DNS, webhook,
+> file fetch) where the URL, host, or scheme is influenced by input.
+> **Standards:** OWASP Top 10:2025 A01 (Broken Access Control — SSRF is
+> absorbed here) · ASVS 5.0 V13 (API & Web Service / outbound communication) ·
+> CWE Top 25 (CWE-918 SSRF) · Proactive Controls 2024 C3 (Validate all
+> Inputs).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, the control is a **scheme + host allowlist, not "validate the
+URL"** — the spec should name which destinations are permitted (scheme set,
+host/domain allowlist, whether private/link-local ranges are blocked) as
+acceptance criteria. "Validate the URL" with no allowlist named is the
+shallow framing that ships SSRF (ASVS 5.0 V13).
+
+## Implementation checks
+
+- `hybrid` **User-influenced destination.** Taint analysis finds input
+  reaching the request URL; you judge whether an allowlist gates it. Any
+  outbound call whose host comes from input without an allowlist is a finding.
+- `reason` **Scheme allowlist.** Restrict to `https` (and `http` only if
+  required); reject `file:`, `gopher:`, `ftp:`, `dict:` and other smuggling
+  schemes that turn a fetcher into a file reader or port scanner.
+- `reason` **Private / metadata range block.** Block requests to loopback,
+  RFC-1918, link-local, and cloud metadata endpoints (`169.254.169.254`,
+  `metadata.google.internal`) — the SSRF→credential-theft pivot.
+- `reason` **Redirect following.** A permitted host can `302` to an internal
+  one; re-validate the destination on each redirect, or disable
+  redirect-following for untrusted targets.
+- `reason` **DNS rebinding / TOCTOU.** Resolve-then-connect to the *same*
+  address you validated, or validate the connected IP — validating the
+  hostname and then re-resolving lets the answer change underneath you.
+
+## Established-helper bypass
+
+Resolve the repo's sanctioned outbound-HTTP client (the one with the SSRF
+guard, allowlist, and redirect policy baked in) and flag a change that reaches
+for a raw HTTP library directly for a user-influenced fetch — the guarded
+client is precisely where the allowlist and metadata-block live.

--- a/.agents/skills/security-checklists/references/path-and-file.md
+++ b/.agents/skills/security-checklists/references/path-and-file.md
@@ -1,0 +1,46 @@
+# path-and-file — filesystem paths, uploads, archive extraction
+
+> **Loaded when:** the change builds a filesystem path from input, accepts file
+> uploads, extracts archives, or serves files.
+> **Standards:** CWE Top 25 (CWE-22 Path Traversal, CWE-73 External Control of
+> File Name or Path) · OWASP Top 10:2025 A01 (Broken Access Control, of which
+> path traversal is a member) · ASVS 5.0 V12 (File Handling) · Proactive
+> Controls 2024 C3 (Validate all Inputs).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, the control is **confinement, not just traversal-blocking** —
+the spec should require that resolved paths stay within a designated root
+(canonicalize-then-verify-prefix), which is the CWE-73 depth, rather than the
+shallower "reject `..`" (CWE-22). Name the allowed root and the rejection
+behavior as criteria (ASVS 5.0 V12.1).
+
+## Implementation checks
+
+- `hybrid` **Path traversal (CWE-22).** Input containing `..`, absolute paths,
+  or encoded separators reaching a file operation. A SAST taint rule finds the
+  sink; you judge whether the fix actually confines.
+- `reason` **Confinement (CWE-73) — the deeper miss.** Even with `..`
+  stripped, the resolved real path must be verified to live under the intended
+  root *after* canonicalization (resolve symlinks first, then check the
+  prefix). Stripping `..` without a post-resolution prefix check is the gap
+  that scanners and shallow fixes both miss.
+- `reason` **Symlink escape.** A path that resolves through an attacker-placed
+  symlink can leave the root; resolve links before the boundary check, and
+  refuse to follow links into untrusted trees.
+- `reason` **Zip-slip / archive extraction.** Each entry's destination must be
+  validated to stay under the extraction root; an entry named `../../etc/...`
+  writes outside it. Reject absolute and traversing entry names.
+- `reason` **Upload handling.** Don't trust the client-supplied filename or
+  content-type for storage path or execution decisions; generate the stored
+  name, and store outside any executable/served root unless intended.
+
+## Established-helper bypass
+
+Path confinement is the canonical "rolled its own" trap. Resolve the repo's
+sanctioned path-confinement / safe-join helper and flag any change that builds
+a path with raw string joins or a bare `..`-strip instead of calling it — the
+blessed helper is where canonicalize-then-verify-prefix is done correctly,
+once.

--- a/.agents/skills/security-checklists/references/secrets-and-crypto.md
+++ b/.agents/skills/security-checklists/references/secrets-and-crypto.md
@@ -1,0 +1,46 @@
+# secrets-and-crypto — secrets, keys, hashing, signing, randomness
+
+> **Loaded when:** the change handles secrets/keys/tokens, hashes or signs
+> data, encrypts/decrypts, or generates security-relevant random values.
+> **Standards:** OWASP Top 10:2025 A04 (Cryptographic Failures) · ASVS 5.0 V11
+> (Cryptography) · CWE Top 25 (CWE-798 Hardcoded Credentials) · Proactive
+> Controls 2024 C8 (Protect Data Everywhere).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, the control is **broker-mediated secrets, not ad-hoc reads** —
+the spec should name where a secret comes from (a secrets manager / broker /
+mounted secret) rather than implying an inline read of an env var or file at
+the call site. For data at rest, name the algorithm class and key source as
+criteria, not "encrypt it" (ASVS 5.0 V11; Proactive Controls 2024 C8).
+
+## Implementation checks
+
+- `tool` **Hardcoded secrets (CWE-798).** Committed keys/passwords/tokens are
+  secret-scanner territory — confirm a secret scanner runs in CI; if none is
+  detected, flag `degraded: no scanner` and eyeball the diff rather than
+  asserting it's clean.
+- `tool` **Weak/broken primitives.** `MD5`/`SHA-1` for security, DES, ECB
+  mode, hardcoded IVs — SAST rules catch the common shapes; confirm the rule
+  is wired, and reason about any primitive the rule wouldn't recognize.
+- `reason` **Password storage.** Passwords must use a memory-hard KDF
+  (argon2/bcrypt/scrypt) with a per-password salt — not a fast hash. This is a
+  design judgment a generic scanner won't make.
+- `reason` **Randomness source.** Security-relevant values (tokens, nonces,
+  reset codes) must come from a CSPRNG (`secrets`, `crypto.randomBytes`), never
+  a non-crypto `random()`.
+- `reason` **Secrets in logs / errors.** Trace the secret forward — is it
+  logged, echoed in an error, or serialized into a response? Disclosure
+  through the error path is the common leak.
+- `reason` **Key lifecycle.** Hardcoded keys, no rotation path, or a key
+  checked into config are design gaps even when the primitive is strong.
+
+## Established-helper bypass
+
+Resolve the repo's sanctioned secrets broker / config-secret accessor and its
+crypto helper. Flag code that reads a secret directly from the environment or
+a file at the call site, or hand-rolls encryption, when the blessed broker /
+crypto helper exists — the broker is where access is mediated, audited, and
+rotated.

--- a/.agents/skills/security-checklists/references/supply-chain.md
+++ b/.agents/skills/security-checklists/references/supply-chain.md
@@ -1,0 +1,46 @@
+# supply-chain — dependencies, lockfiles, build trust
+
+> **Loaded when:** the change adds, removes, or repins a dependency; edits a
+> lockfile or package manifest; or changes how build artifacts are fetched.
+> **Standards:** **OWASP Top 10:2025 A03 (Software Supply Chain Failures — new
+> in 2025)** · ASVS 5.0 V10 (Coding & Build / dependency management) ·
+> Proactive Controls 2024 C2 (Use Secure Components / leverage frameworks).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, a new dependency is a forever-decision — the spec/plan should
+justify it (a second caller actually needs it) and prefer a maintained,
+widely-used component over a thin or abandoned one. Where the change adds a
+dependency, that addition should be a recorded decision, not an incidental
+import (ASVS 5.0 V10; Proactive Controls 2024 C2).
+
+## Implementation checks
+
+- `tool` **Known CVEs.** Vulnerable-version detection is SCA's job, not the
+  reviewer's — confirm `pip-audit` / `npm audit` / `govulncheck` /
+  `cargo audit` / `bundler-audit` (or Snyk) is wired against the lockfile. If
+  no scanner is detected, flag `degraded: no scanner` and state that CVE
+  coverage is unverified — never assert the dependency tree is clean by eye.
+- `reason` **Typosquat / dependency confusion.** A new package name one
+  character off a popular one, or an internal name resolvable from a public
+  index, is a reasoning finding a CVE scanner won't raise — verify the package
+  is the intended one and the registry/scope is correct.
+- `reason` **Pinning & integrity.** Dependencies should be pinned with a
+  lockfile and integrity hashes; an unpinned or hash-less add lets the
+  resolved artifact change silently.
+- `reason` **Maintenance & provenance.** Flag an unmaintained or
+  single-maintainer dependency added to a security-relevant path, and build
+  steps that fetch from a non-pinned or unverified source (`curl | sh`).
+- `reason` **Transitive surface.** A small direct add can pull a large
+  transitive tree; note when the dependency footprint is disproportionate to
+  the need.
+
+## Established-helper bypass
+
+Resolve the repo's sanctioned way to add a dependency (a workspace catalog, a
+vetted-internal mirror, a recorded-in-ADR process). Flag a change that adds a
+raw third-party dependency outside that path when the blessed mechanism or an
+already-present equivalent exists — re-implementing or re-importing duplicates
+the maintenance and audit surface the sanctioned path centralizes.

--- a/.agents/skills/work-loop/SKILL.md
+++ b/.agents/skills/work-loop/SKILL.md
@@ -255,6 +255,24 @@ For anything beyond trivial, *think before you write code*. Concretely:
   clean; `loop-cohort check <spec-dir> --phase plan` unlocks EXECUTE.
   No new state fields. **Both triggers respect the Profile-A opt-out:**
   skip if the project doesn't use the reviewer at all.
+- **Pre-EXECUTE secure-design review (net-new — security-boundary trigger).**
+  **Doctrine: security review shifts left — it runs at spec stage on
+  security-boundary work, not only as a late gate.** When the
+  **security-boundary risk trigger** is present (the change touches auth,
+  secrets, user input, deserialization, or file/network I/O), additionally
+  select a subagent matching `security-reviewer` and dispatch it in
+  **spec-stage secure-design mode** against the spec — asking, per trust
+  boundary the feature crosses, whether the control is specified as an
+  acceptance criterion at the right depth (confinement, not just traversal;
+  scheme allowlist, not "validate the URL"; broker-mediated secrets, not
+  ad-hoc reads). Inline the boundary-matching `security-checklists` modules
+  into its brief in their proactive-control framing, per the
+  [boundary→module routing table](#boundarymodule-routing-table) below. This
+  is **net-new wiring** — distinct from the adversarial-only firing above and
+  from RFC-0025's separate light→full escalation use of the same trigger; it
+  is not a re-use of either. Same Profile-A opt-out and the same
+  `approve-plan` gate apply. Fallback if no `security-reviewer` subagent is
+  installed: proceed and note the missing review in the final summary.
 - **Initialize the loop's state file.** Run this skill's bundled
   `scripts/loop-cohort.py init docs/specs/<feature>`; the tool copies
   the bundled `assets/state.json` template into place, sets `feature`
@@ -497,12 +515,40 @@ note in the summary, not a blocker.
 
 - Match `security-reviewer` — for diffs that cross a security boundary
   (auth, secrets, user input, deserialization, file/network I/O,
-  dependencies, LLM/agent code). OWASP + STRIDE lens. Complements
-  SAST/SCA scanners; does not replace them.
-- Match `quality-engineer` — testability, observability, reliability,
-  and maintainability lens. Also drafts contract or construction tests
-  on request. Different lens from adversarial-reviewer — don't skip it
-  because the spec already shipped.
+  dependencies, LLM/agent code). Current multi-framework lens (OWASP Top
+  10:2025, ASVS 5.0, API Security Top 10:2023, LLM Top 10:2025, CWE Top 25)
+  plus a STRIDE + LINDDUN open pass. Complements SAST/SCA scanners; does not
+  replace them. **Inline its depth, don't make it self-discover:** detect
+  which trust boundaries the diff crosses, load **only** the matching
+  `security-checklists` modules, and inline their content into the
+  subagent's brief (reusing the on-demand `references/*.md` loading the loop
+  already does) — the subagent's `tools:` has no Skill tool, so loading is
+  orchestrator-driven, not model-relevance-judged. Route deterministically:
+
+  <a id="boundarymodule-routing-table"></a>
+
+  | Trust boundary the change crosses | Inline module(s) |
+  | --- | --- |
+  | Authz / access-control; a new or changed endpoint, handler, RPC | `access-control` |
+  | Authentication, session, login, password, MFA, tokens (JWT/API key) | `authn-session` |
+  | Untrusted input → SQL / shell / template / LDAP / HTML; deserialization | `injection` |
+  | Filesystem path from input, file upload, archive extraction | `path-and-file` |
+  | Secrets, keys, hashing, signing, crypto, randomness | `secrets-and-crypto` |
+  | Outbound HTTP / DNS / URL fetch, webhooks | `outbound-ssrf` |
+  | Dependency / lockfile / manifest change, build-artifact fetch | `supply-chain` |
+  | CORS, IAM, IaC, server / framework / deploy config | `config-misconfig` |
+  | Error handling, retries, fallbacks, fail-open paths | `exceptional-conditions` |
+  | Prompts, model / tool exposure, MCP, model-output handling | `llm-agent` |
+
+  Load 1–3 modules for a typical change, never a flat march of all ten; an
+  auth-touching endpoint pulls `access-control` and often `authn-session`.
+  This same table backs the pre-EXECUTE spec-stage dispatch above.
+- Match `quality-engineer` — testability, observability, reliability, and
+  maintainability lens, applying a raised default quality floor (universal
+  maintainability smells + a mutation-testing mindset) even where no static
+  gate is wired. Also drafts contract or construction tests on request.
+  Different lens from adversarial-reviewer — don't skip it because the spec
+  already shipped.
 
 **Dispatch reviewers in parallel when you invoke more than one** per
 the [Parallel dispatch discipline](#parallel-dispatch-discipline)

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
     {
       "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr + session-start hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds.",
       "name": "core",
-      "version": "0.3.0"
+      "version": "0.4.0"
     },
     {
       "description": "User-scope credential brokering: credentials_shim (build-projected Python module for auth: creds skills), sso-broker (subprocess at ~/.agentbundle/bin/ for auth: sso-cookie skills), plus one LLM-cooperative credential-setup skill.",

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: security-reviewer
-description: Threat-model and OWASP-lens reviewer for diffs that change auth, data handling, dependencies, deserialization, file/network I/O, secrets, or LLM/agent code. Reads AGENTS.md, CONVENTIONS.md, any docs/architecture/security.md, the diff, and the spec if one exists; attacks along OWASP Top 10 (web + LLM Apps 2025) and a STRIDE prompt; returns severity-labeled findings. Complements -- does not replace -- SAST/SCA scanners and adversarial-reviewer. Use after adversarial-reviewer is clean, before merging anything that touches a security boundary. Re-run iteratively until the agent reports `Clean — ready to commit.`
+description: Threat-model and secure-design reviewer for changes that cross a security boundary — auth, data handling, dependencies, deserialization, file/network I/O, secrets, or LLM/agent code. Runs in two modes — a spec-stage secure-design pass (is the control specified as an acceptance criterion at the right depth?) and an implementation pass on the diff. Reads AGENTS.md, CONVENTIONS.md, any docs/architecture/security.md, the diff, and the spec if one exists; reasons along a current multi-framework stack (OWASP Top 10:2025, ASVS 5.0, API Security Top 10:2023, LLM Top 10:2025, CWE Top 25) plus a STRIDE + LINDDUN open pass, with boundary-scoped depth inlined into its brief by the orchestrator from the security-checklists skill. Tags every check tool / hybrid / reason. Complements -- does not replace -- SAST/SCA scanners and adversarial-reviewer. Use at spec stage on security-boundary work, and after adversarial-reviewer is clean before merging. Re-run iteratively until the agent reports `Clean — ready to commit.`
 tools: Read, Grep, Glob, Bash
 model: opus
 ---
@@ -17,6 +17,24 @@ aren't.**
 
 If a finding could have been caught by a scanner, say so and recommend
 configuring the scanner rather than relying on review.
+
+## Two modes
+
+You run in one of two modes; the orchestrator's brief names it, and you
+infer from what you were handed (a spec vs. a diff) if it doesn't.
+
+- **Spec-stage secure-design mode** — *before* code, on security-boundary
+  work. You read the **spec**, not a diff, and ask whether each control the
+  feature needs is *specified as an acceptance criterion at the right
+  depth*. This is the shift-left pass: catching a missing control as design
+  guidance costs a sentence; catching it post-implementation costs
+  round-trips. See [Spec-stage secure-design mode](#spec-stage-secure-design-mode).
+- **Implementation mode** (default) — after gates pass, on the diff. The
+  reasoning-level pass scanners can't do, scoped to the trust boundaries the
+  diff actually crosses.
+
+Both modes share the **universal method** below and are backed by the same
+boundary-scoped depth, which the orchestrator inlines into your brief.
 
 ## When you are the right reviewer
 
@@ -38,84 +56,85 @@ spin up this reviewer for spelling fixes.
 ## Load context first
 
 1. `AGENTS.md` and `docs/CONVENTIONS.md` — project conventions and any
-   security-relevant anti-patterns. First-class checks.
+   security-relevant anti-patterns. First-class checks. In particular, read
+   the **"blessed security tools/helpers"** list if `AGENTS.md` carries one —
+   it is the convention source for the established-helper-bypass meta-check
+   below.
 2. `docs/architecture/security.md` or `docs/guides/reference/security.md`
    if either exists. If not, that absence is itself a finding for any
    non-trivial diff in this space.
 3. The targeted `spec.md` if one exists, particularly its **Boundaries**
    (especially `Never do` and `Ask first`) and any claims under
    `Acceptance Criteria` about data handling, retention, or trust
-   boundaries.
+   boundaries. In spec-stage mode this *is* your primary input.
 4. The diff (`git diff <base>..HEAD` if not enumerated). Identify the
-   *trust boundaries* the diff crosses; that's the actual scope.
+   *trust boundaries* the change crosses; that's the actual scope.
+5. **The boundary-scoped checklist modules the orchestrator inlined into
+   your brief.** The work-loop detects which trust boundaries the change
+   crosses and inlines only the matching `security-checklists` modules as
+   prompt text — that is your depth reference for this change. You do not
+   load the skill yourself; if no modules were inlined, fall back to the
+   universal method and say so in the footer.
 
 If you skip step 1 you cannot do your job — repo-specific conventions
 (e.g. which library handles secrets, which logger to use) don't show up
 in the diff.
 
-## Attack along the relevant checklist
+## The universal method
 
-Run **only** the categories that match the diff's trust boundaries. A
-diff that doesn't touch SQL doesn't need an injection pass. Forced
-breadth dilutes findings.
+This is the method you apply on **every** review, in both modes. The
+*shape-specific depth* — the deep per-domain checklists for access control,
+injection, path confinement, SSRF, and the rest — is no longer carried in
+this prompt: it lives in the `security-checklists` skill's boundary modules,
+and the orchestrator inlines only the ones this change crosses into your
+brief (step 5 above). That keeps this lens lean and your findings focused —
+**forced breadth dilutes findings; two real Blockers beat ten recycled
+checklist items.** Run **only** the boundaries the change actually crosses.
 
-### Web / service code — OWASP Top 10:2021 lens
+Your awareness anchor is the **current** stack — OWASP Top 10:**2025** (web),
+OWASP API Security Top 10:2023, OWASP LLM Top 10:2025, with ASVS 5.0 and CWE
+Top 25 as the verification depth the inlined modules cite. (The 2025 web list
+added Software Supply Chain Failures and Mishandling of Exceptional
+Conditions — categories the older list missed.)
 
-1. **Broken access control.** For every new or changed endpoint /
-   handler / RPC: who is allowed to call it? Where is that enforced? Is
-   the check before the side-effect or after? Look for missing
-   `requireAuth`-equivalent guards on mutating operations and for
-   horizontal-privilege bugs (user A reaching user B's data).
-2. **Injection.** Untrusted input flowing into SQL, shell, OS command,
-   LDAP, eval, template strings, HTML, or query builders without
-   parameterisation. Flag string concatenation in any of those.
-3. **Cryptographic failures.** Custom crypto. `MD5`/`SHA-1` for
-   security. `random` instead of `secrets`/`crypto.randomBytes`.
-   Hardcoded keys/IVs. Missing TLS. Predictable tokens.
-4. **Insecure design.** Missing rate-limiting on sensitive endpoints.
-   No idempotency keys where retries are likely. No CSRF on
-   state-changing form posts. Confused-deputy designs.
-5. **Security misconfiguration.** Default credentials. CORS `*` on
-   credentialed endpoints. Verbose error pages exposing internals.
-   Permissive S3/IAM/role grants in IaC.
-6. **Vulnerable & outdated components.** New or pinned-down
-   dependencies with known CVEs or unmaintained upstreams. Recommend
-   `npm audit`/`pip-audit`/equivalent if it isn't already gated in CI.
-7. **Identification & authentication failures.** Weak password rules,
-   missing MFA paths, sessions that don't rotate after privilege
-   changes, JWTs accepted with `alg: none` or unverified signatures.
-8. **Software & data integrity failures.** Deserialising untrusted
-   data into objects (`pickle`, Java serializer, `unserialize`,
-   `yaml.load`). Unsigned update channels. CI that fetches from
-   non-pinned sources.
-9. **Logging & monitoring failures.** Sensitive data in logs (PII,
-   tokens, passwords). Conversely: critical security events not
-   logged. Logs without correlation IDs.
-10. **Server-side request forgery (SSRF).** Outbound HTTP/DNS where
-    the URL or host is influenced by user input, without an allowlist.
+### Three-bucket delegation — know who owns each check
 
-### LLM / agent code — OWASP Top 10 for LLM Apps 2025 lens
+Every check you run carries one of three tags; respect the ownership:
 
-Only if the diff touches model calls, prompts, or agent tool exposure:
+- **`tool`** — scanner-owned. **Confirm the scanner is wired; don't re-check
+  by hand.** Detect *the ecosystem's* scanner rather than assuming Python:
+  `npm audit` (Node), `pip-audit` (Python), `govulncheck` (Go),
+  `cargo audit` (Rust), `bundler-audit` (Ruby), or a cross-cutting
+  Snyk / Semgrep / CodeQL. **When the delegated scanner is absent, do not
+  silently skip** — reason the class best-effort and flag it
+  `degraded: no scanner`, or state the gap explicitly ("class X is normally
+  scanner-owned; none detected → wire one or accept the gap"). A silent skip
+  looks like coverage and is the worst outcome.
+- **`hybrid`** — the scanner finds the flow; *you* judge the fix. Taint
+  analysis points at a sink, but whether the parameterization, confinement,
+  or safe-loader choice is correct is reasoning work.
+- **`reason`** — reviewer-only. Logic-flaw access control, fail-open
+  defaults, confused-deputy, privacy exposure — the classes scanners
+  structurally can't see. Your highest-value findings live here.
 
-- **Prompt injection.** Untrusted content (user input, fetched pages,
-  comments, retrieved docs) flowing into the prompt without isolation
-  or instruction-vs-data boundaries.
-- **Improper output handling.** Model output used as code, SQL, shell,
-  or HTML without escaping/validation.
-- **Excessive agency.** Tools exposed to the model that exceed the
-  least privilege needed; tools that mutate without a confirmation step
-  for high-impact actions.
-- **Sensitive information disclosure.** Secrets, system prompts, or
-  other users' data reachable through model output.
-- **Supply chain.** Model weights, embeddings, or MCP servers loaded
-  from unverified sources.
-- **Unbounded consumption.** No token, request, or cost cap on
-  user-triggered model calls.
+### Established-helper bypass — the repo-aware meta-check
 
-### STRIDE — open-ended threat prompt
+For each boundary the change crosses, find the repo's **blessed helper** for
+that boundary and flag code that *rolled its own instead of calling it* —
+the single most actionable real-world finding. Resolve the helper in
+precedence: the `AGENTS.md` "blessed security tools/helpers" list →
+`docs/CONVENTIONS.md` and any context other packs install → **inference
+fallback** (grep the codebase for the de-facto helper). An inline path-strip
+where a confinement helper exists, a raw HTTP call where an SSRF-guarded
+client exists, an ad-hoc env read where a secrets broker exists — each is a
+finding even when the hand-rolled version looks correct today, because it
+drifts out of sync with the helper that centralizes the control.
 
-After the checklists, spend one explicit pass asking, for the change:
+### STRIDE + LINDDUN — the always-on open pass
+
+After the boundary checks, spend one explicit pass on the open-ended threat
+prompt — it catches novel issues the categories don't pre-name, and it is
+the highest-value part of the review.
 
 - **S**poofing — can an attacker pretend to be someone they aren't?
 - **T**ampering — can data, code, or config be modified out of band?
@@ -126,8 +145,37 @@ After the checklists, spend one explicit pass asking, for the change:
 - **E**levation of privilege — can a low-privilege actor reach
   high-privilege state through this change?
 
-Findings here are the highest-value: they catch novel issues the
-checklist categories don't pre-name.
+Then the **LINDDUN** privacy lens STRIDE blind-spots — most sharply
+**L**inkability, **I**dentifiability, and **N**on-repudiation of a data
+subject: does the change link or re-identify a person, or retain more
+personal data than the purpose needs?
+
+## Spec-stage secure-design mode
+
+When the orchestrator hands you a **spec** before code (the shift-left
+pass), you are not hunting bugs — there is no diff yet. You read the spec and
+ask, **for each trust boundary the feature crosses, whether the control is
+specified as an acceptance criterion at the right depth.** The depth is the
+point: a shallow control named in prose ships the gap anyway. Use the same
+inlined modules in their *proactive-control* framing.
+
+- **Confinement, not just traversal.** A file-path feature needs an AC for
+  *confinement* (resolved path stays under the root — CWE-73), not merely
+  "rejects `..`" (CWE-22).
+- **Scheme/host allowlist, not "validate the URL".** An outbound-fetch
+  feature needs an AC naming the permitted schemes and host allowlist and the
+  metadata-range block — not a vague "validate the URL".
+- **Broker-mediated secrets, not ad-hoc reads.** A feature handling secrets
+  needs an AC that the secret comes from the sanctioned broker, not an inline
+  env/file read at the call site.
+- **Authz as a criterion.** A new boundary needs an AC naming *which*
+  identity is checked and *where* relative to the side effect — not "users
+  see only their own data" in prose.
+
+Your finding in this mode is "the spec is missing an acceptance criterion
+for control X at depth Y" — phrased as design guidance, with the AC you'd
+add. A boundary the feature crosses with no control AC is the
+highest-leverage spec-stage finding.
 
 ## Report numbered findings
 

--- a/.claude/skills/security-checklists/SKILL.md
+++ b/.claude/skills/security-checklists/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: security-checklists
+description: Progressive-disclosure security-depth modules for the security-reviewer. Holds ten boundary-keyed checklists (access-control, authn-session, injection, path-and-file, secrets-and-crypto, outbound-ssrf, supply-chain, config-misconfig, exceptional-conditions, llm-agent) as references/, each anchored on a current standard (OWASP Top 10:2025, ASVS 5.0, API Security Top 10:2023, Proactive Controls 2024, CWE Top 25, OWASP LLM Top 10:2025). The work-loop's orchestrator loads only the boundary-matching modules and inlines them into the security-reviewer's brief; the subagent never self-discovers this skill. Not a reviewer prompt itself — it is the depth library the reviewer reasons from.
+---
+
+# Skill: security-checklists
+
+This skill is the **depth library** behind the `security-reviewer` agent. The
+reviewer's body carries the *universal method* (the three-bucket delegation
+rule, load-context-first, the always-on STRIDE + LINDDUN open pass, the
+established-helper-bypass meta-check, the severity rubric, the honest-limits
+footer, the output format). The *shape-specific depth* — what to actually
+check at each trust boundary — lives here, in ten `references/<module>.md`
+modules, so the agent prompt stays lean and the depth scales without bloat.
+
+## How it loads (orchestrator-driven, not self-discovered)
+
+**The orchestrator drives loading; the subagent does not.** There is no
+mechanism to force a subagent to invoke a skill, skill discovery is
+model-invoked and adapter-variable, and the `security-reviewer`'s `tools:`
+list does not even include a Skill tool. So depth must not depend on the
+reviewer finding this library itself.
+
+Concretely, at the work-loop's security-review step (and at the pre-EXECUTE
+spec-stage pass), the orchestrator:
+
+1. Detects which **trust boundaries** the diff or spec crosses.
+2. Loads **only the matching modules** via the deterministic
+   boundary→module routing table in `work-loop/SKILL.md`.
+3. **Inlines the selected modules' content** into the `security-reviewer`
+   subagent's brief — so the reviewer receives a focused ~30-item checklist
+   as prompt text, never a path to resolve.
+
+Where an adapter *does* support subagent skill auto-discovery, that is a
+redundant convenience layered on top — never the load-bearing mechanism.
+
+## The three-bucket delegation legend
+
+Every check in every module is tagged so the reviewer knows who owns it:
+
+- **`tool`** — scanner-owned. Confirm the scanner is *wired*; don't re-check
+  by hand. Detect the ecosystem's scanner rather than assuming one:
+  `npm audit` / `pip-audit` / `govulncheck` / `cargo audit` / `bundler-audit`,
+  or Snyk / Semgrep / CodeQL. If the delegated scanner is **absent**, do not
+  silently skip (Tier-1 declare/detect/fail-clean): either reason the class
+  best-effort and flag it `degraded: no scanner`, or state the gap explicitly
+  ("class X is normally scanner-owned; none detected → wire one or accept the
+  gap"). A silent skip is the worst outcome — it looks like coverage.
+- **`hybrid`** — the scanner finds the flow; *you* judge the fix. Taint
+  analysis can point at a sink, but whether the escaping, the confinement,
+  or the safe-loader choice is correct is reasoning work.
+- **`reason`** — reviewer-only. Logic-flaw access control, fail-open vs
+  fail-closed, confused-deputy, privacy exposure — the classes scanners
+  structurally cannot see. The highest-value findings live here.
+
+## Established-helper bypass (the repo-aware meta-check)
+
+For each boundary the change crosses, the most actionable real-world finding
+is **"this code rolled its own instead of the repo's blessed helper."** Each
+module names, in generic terms, the *kind* of helper that boundary usually
+has. To resolve the repo's actual helper, the reviewer consults, in
+precedence: the **`AGENTS.md`** "blessed security tools/helpers" list →
+`CONVENTIONS.md` and any context other packs install (steering files, etc.)
+→ **inference fallback** (grep the codebase for the de-facto helper). Flag
+code that re-implements a boundary the repo already has a sanctioned helper
+for. This skill carries the *mechanism* only — never any one repo's specific
+helper names.
+
+## Module index
+
+| Module | Boundary | Primary anchor |
+|---|---|---|
+| [`access-control`](references/access-control.md) | authz / object- & function-level access | OWASP A01:2025 + API Security Top 10:2023 (BOLA/BFLA) |
+| [`authn-session`](references/authn-session.md) | authentication, session, tokens | OWASP A07:2025 + ASVS 5.0 V6/V7 |
+| [`injection`](references/injection.md) | untrusted input → interpreter / deserializer | OWASP A05:2025 (+ A08 deserialization) |
+| [`path-and-file`](references/path-and-file.md) | filesystem paths, uploads, archive extraction | CWE-22 / CWE-73 + ASVS 5.0 V12 |
+| [`secrets-and-crypto`](references/secrets-and-crypto.md) | secrets, keys, hashing, signing, randomness | OWASP A04:2025 + ASVS 5.0 V11 |
+| [`outbound-ssrf`](references/outbound-ssrf.md) | outbound HTTP/DNS, URL fetch, webhooks | OWASP A01:2025 (SSRF) + ASVS 5.0 V13 |
+| [`supply-chain`](references/supply-chain.md) | dependencies, lockfiles, build trust | **OWASP A03:2025 (new)** |
+| [`config-misconfig`](references/config-misconfig.md) | CORS, IAM, IaC, server config | OWASP A02:2025 |
+| [`exceptional-conditions`](references/exceptional-conditions.md) | error paths, retries, fail-open | **OWASP A10:2025 (new)** (+ A09 logging) |
+| [`llm-agent`](references/llm-agent.md) | prompts, tool exposure, MCP, model output | OWASP LLM Top 10:2025 |
+
+Threat modeling (STRIDE + LINDDUN for privacy) and design-time Insecure
+Design (A06 / Proactive Controls 2024) are **not** runtime modules: STRIDE +
+LINDDUN ride the always-on open pass in the agent body, and Insecure Design
+is realized by the spec-stage secure-design mode. Each module below carries a
+**Spec-stage** section so the same depth backs the design-time pass in its
+proactive-control framing.

--- a/.claude/skills/security-checklists/references/access-control.md
+++ b/.claude/skills/security-checklists/references/access-control.md
@@ -1,0 +1,47 @@
+# access-control — authorization, object- & function-level
+
+> **Loaded when:** the change adds or alters an endpoint, handler, RPC, or any
+> code path that reads or mutates a resource on behalf of a caller.
+> **Standards:** OWASP Top 10:2025 A01 (Broken Access Control) · OWASP API
+> Security Top 10:2023 (API1 BOLA, API3 BOPLA, API5 BFLA) · ASVS 5.0 V4
+> (Access Control) · Proactive Controls 2024 C1 (Enforce Access Controls).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, ask whether the spec names the access rule **as an acceptance
+criterion** at the right depth: not "users can only see their own orders" in
+prose, but a criterion stating *which* identity is checked, *where* the check
+sits relative to the side effect, and what an out-of-scope caller receives
+(404 vs 403). A boundary with no AC for authz is the highest-leverage
+spec-stage finding (Proactive Controls 2024 C1; ASVS 5.0 V4.1).
+
+## Implementation checks
+
+- `reason` **Who is allowed to call this?** For every new/changed
+  endpoint/handler/RPC, name the identity and the guard. A mutating operation
+  with no `requireAuth`-equivalent before the side effect is a Blocker.
+- `reason` **Object-level (BOLA / IDOR).** A caller passing `id=B` while
+  authenticated as A must be rejected — the row is fetched *scoped to the
+  caller*, not fetched-then-checked-then-maybe-leaked.
+- `reason` **Function-level (BFLA).** Admin/privileged routes must verify the
+  *role*, not merely authentication. A regular user reaching an admin verb by
+  guessing the path is the classic miss.
+- `reason` **Check-before-effect ordering.** The authorization decision must
+  precede the mutation/read it guards; a check after the side effect is
+  decorative.
+- `reason` **Mass assignment / property-level (BOPLA).** Binding a request
+  body straight onto a model lets a caller set fields they shouldn't
+  (`isAdmin`, `ownerId`). Confirm an allowlist of writable fields.
+- `hybrid` **Missing-guard coverage.** A linter/SAST route-auth rule can list
+  unguarded routes; you judge whether each *should* be public.
+
+## Established-helper bypass
+
+Most repos centralize authz in one place — a policy/guard middleware, a
+`can(actor, action, resource)` helper, a decorator. Resolve the repo's
+sanctioned authorization helper (AGENTS.md blessed list → CONVENTIONS /
+installed context → grep for the de-facto guard) and flag any handler that
+hand-rolls an inline `if user.id == ...` check instead of calling it —
+ad-hoc checks drift out of sync with the policy the helper centralizes.

--- a/.claude/skills/security-checklists/references/authn-session.md
+++ b/.claude/skills/security-checklists/references/authn-session.md
@@ -1,0 +1,47 @@
+# authn-session — authentication, session, tokens
+
+> **Loaded when:** the change touches login, logout, password handling, MFA,
+> session creation/expiry, or token issuance/verification (JWT, opaque, API
+> keys).
+> **Standards:** OWASP Top 10:2025 A07 (Authentication Failures) · ASVS 5.0 V6
+> (Authentication) + V7 (Session Management) · OWASP API Security Top 10:2023
+> (API2 Broken Authentication) · Proactive Controls 2024 C6 (Digital Identity).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, confirm the spec specifies session **lifecycle** as criteria,
+not just "log the user in": rotation-on-privilege-change, idle and absolute
+timeouts, and what invalidates a session. Authentication strength
+(MFA paths, lockout/throttling) should be an AC where the asset warrants it
+(ASVS 5.0 V6.2; Proactive Controls 2024 C6).
+
+## Implementation checks
+
+- `reason` **Session fixation / rotation.** The session identifier must rotate
+  on login and on privilege elevation; reusing a pre-auth session id lets an
+  attacker fixate it.
+- `reason` **JWT verification.** Reject `alg: none`; pin the expected
+  algorithm; verify the signature against the *expected* key, not the key the
+  token names (`jku`/`kid` confusion). An unverified or `alg`-confused JWT is
+  a Blocker.
+- `reason` **Token entropy & storage.** Session tokens and reset tokens must be
+  CSPRNG-derived and stored hashed; predictable or plaintext-stored tokens are
+  forgeable.
+- `reason` **Lockout / throttling.** Sensitive auth endpoints (login, OTP,
+  reset) need rate-limiting or progressive backoff; their absence is a
+  credential-stuffing invitation.
+- `reason` **Logout & expiry actually invalidate.** A logout that only clears
+  a client cookie while the server token stays valid is a false control.
+- `hybrid` **Hardcoded / weak credentials in the diff.** A secret scanner
+  flags committed credentials; you judge whether a "test" default is reachable
+  in production config.
+
+## Established-helper bypass
+
+Authentication is almost never something to hand-roll. Resolve the repo's
+sanctioned auth/session library or middleware and flag a change that
+introduces its own password hashing, its own JWT parsing, or its own session
+store instead of the blessed path — rolled-its-own auth is where `alg: none`
+and unsalted hashes slip in.

--- a/.claude/skills/security-checklists/references/config-misconfig.md
+++ b/.claude/skills/security-checklists/references/config-misconfig.md
@@ -1,0 +1,45 @@
+# config-misconfig — CORS, IAM, IaC, server configuration
+
+> **Loaded when:** the change edits server/framework config, CORS, IAM/role
+> grants, infrastructure-as-code, container or deployment settings.
+> **Standards:** OWASP Top 10:2025 A02 (Security Misconfiguration) · ASVS 5.0
+> V14 (Configuration) · Proactive Controls 2024 C5 (Secure by Default
+> Configurations).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, the control is **secure-by-default** — the spec should name
+the least-privilege posture (which origins, which principals, which ports)
+rather than leaving defaults to be hardened later. A config AC reads "CORS
+allows exactly origin X with credentials off," not "configure CORS" (ASVS 5.0
+V14; Proactive Controls 2024 C5).
+
+## Implementation checks
+
+- `tool` **IaC misconfiguration.** Public buckets, open security groups,
+  over-broad IAM — IaC scanners (Checkov/tfsec/KICS, or Semgrep/CodeQL rules)
+  own the common patterns; confirm one is wired. If none is detected, flag
+  `degraded: no scanner` and reason the diff by hand rather than passing it
+  silently.
+- `reason` **CORS.** `Access-Control-Allow-Origin: *` together with
+  `Allow-Credentials: true` is a credential-leak misconfiguration; reflecting
+  the `Origin` header without an allowlist is the same bug in disguise.
+- `reason` **IAM / role grants.** Wildcards in actions or resources
+  (`"*"`), `PassRole` over-grants, and trust policies that admit too broad a
+  principal are least-privilege violations a reviewer judges in context.
+- `reason` **Default credentials & exposed surfaces.** Default admin
+  passwords, debug/management endpoints enabled, directory listing, verbose
+  error pages exposing stack traces or versions.
+- `reason` **Security headers / TLS posture.** Missing HSTS, permissive
+  `Content-Security-Policy`, TLS verification disabled, or downgraded
+  protocol/cipher settings.
+
+## Established-helper bypass
+
+Resolve the repo's sanctioned config/module (the hardened web-server base, the
+shared IAM module, the CORS middleware with the allowlist) and flag a change
+that defines a one-off permissive config inline instead of extending the
+blessed default — the shared module is where secure-by-default was already
+decided.

--- a/.claude/skills/security-checklists/references/exceptional-conditions.md
+++ b/.claude/skills/security-checklists/references/exceptional-conditions.md
@@ -1,0 +1,47 @@
+# exceptional-conditions — error paths, retries, fail-open
+
+> **Loaded when:** the change adds error handling, retry/timeout logic,
+> fallbacks, circuit breakers, or alters what happens when a dependency fails.
+> **Standards:** **OWASP Top 10:2025 A10 (Mishandling of Exceptional
+> Conditions — new in 2025)** (+ A09 Security Logging & Monitoring Failures) ·
+> ASVS 5.0 V16 (Security Logging & Error Handling) · Proactive Controls 2024
+> C10 (Handle all Errors and Exceptions).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, the control is **decide fail-open vs fail-closed explicitly**
+— for each control the feature relies on (authz check, token verification,
+rate limiter), the spec should state what happens when its dependency is
+unavailable. A security control that defaults to "allow" on error is the
+classic exceptional-condition bug (Proactive Controls 2024 C10; ASVS 5.0 V16).
+
+## Implementation checks
+
+- `reason` **Fail-open vs fail-closed.** When an authz/verification/rate-limit
+  dependency errors or times out, does the code *deny* or *allow*? A security
+  decision that falls through to allow on exception is a Blocker.
+- `reason` **Error-path information leak (A09).** Exceptions returned to the
+  caller must not carry stack traces, SQL, internal paths, or secrets;
+  trace what the catch block actually emits.
+- `reason` **Unbounded retry / amplification (DoS).** Retries without a cap or
+  backoff, recursion without a depth bound, or an unbounded allocation driven
+  by input is a denial-of-service vector.
+- `reason` **Swallowed exceptions.** A bare `except: pass` over a security
+  operation hides a failure that should deny or alert — flag the silent
+  swallow, not just the missing log.
+- `reason` **Critical-event logging gap (A09).** Auth failures, access-control
+  denials, and integrity violations should be logged with enough context
+  (correlation id, actor) to investigate — without logging the sensitive
+  payload itself.
+- `tool` **Empty-catch / swallowed-error lint.** Some linters flag empty catch
+  blocks; confirm the rule is on, but the *security* judgment (deny vs allow)
+  stays reviewer-owned.
+
+## Established-helper bypass
+
+Resolve the repo's sanctioned error-handling / result wrapper and structured
+logger, and flag a change that invents its own fail-through behavior or logs
+ad hoc (and possibly leaks) instead of using the blessed path — the shared
+error wrapper is where fail-closed and redaction were already settled.

--- a/.claude/skills/security-checklists/references/injection.md
+++ b/.claude/skills/security-checklists/references/injection.md
@@ -1,0 +1,48 @@
+# injection — untrusted input into an interpreter or deserializer
+
+> **Loaded when:** the change builds SQL, shell/OS commands, LDAP filters,
+> template strings, HTML, or NoSQL queries from input, **or** deserializes
+> untrusted data.
+> **Standards:** OWASP Top 10:2025 A05 (Injection) + A08 (Software & Data
+> Integrity — unsafe deserialization) · ASVS 5.0 V5 (Validation, Sanitization
+> & Encoding) · CWE Top 25 (CWE-89 SQLi, CWE-78 OS command, CWE-79 XSS,
+> CWE-502 deserialization).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, the control is "parameterize at the boundary, encode at the
+sink" — the spec should commit to parameterized queries / safe loaders rather
+than leaving sanitization to be retrofitted. Where a feature accepts a
+structured payload, name the expected schema as a criterion (ASVS 5.0 V5;
+Proactive Controls 2024 C3 Validate-all-Inputs / C4 Encode-and-Escape).
+
+## Implementation checks
+
+- `hybrid` **SQL / NoSQL.** Taint analysis finds input reaching a query; you
+  judge whether it is *parameterized* (`$1`, bound params) versus
+  string-concatenated. Flag any `fmt.Sprintf`/f-string/`+` building a query
+  with input.
+- `hybrid` **OS command / shell.** Prefer argument-vector exec over a shell
+  string; flag `shell=True`-equivalent with interpolated input. Scanner finds
+  the call; you judge whether the input is constrained.
+- `hybrid` **Template / SSTI & HTML / XSS.** Output into HTML or a template
+  engine must be contextually escaped; flag autoescape disabled or `raw`/
+  `dangerouslySetInnerHTML` over untrusted content.
+- `reason` **Unsafe deserialization (A08).** `pickle`, Java native
+  serialization, `yaml.load` (vs `safe_load`), PHP `unserialize` on untrusted
+  bytes is remote code execution. Confirm a safe loader or a signed/typed
+  format. This is reviewer-only judgment — a scanner may not know the source
+  is untrusted.
+- `tool` **Known-vulnerable parser/driver.** If the injection risk is a
+  CVE in the query driver or parser, that is SCA's job — confirm `pip-audit` /
+  `npm audit` / `govulncheck` is wired; if no scanner is detected, flag
+  `degraded: no scanner` rather than asserting the dependency is clean.
+
+## Established-helper bypass
+
+Resolve the repo's sanctioned query builder / ORM, its output-encoding helper,
+and its safe-deserialization wrapper. Flag code that drops to raw string
+concatenation or a raw `eval`/`load` when the blessed parameterizing or
+safe-loading path exists.

--- a/.claude/skills/security-checklists/references/llm-agent.md
+++ b/.claude/skills/security-checklists/references/llm-agent.md
@@ -1,0 +1,52 @@
+# llm-agent — prompts, tool exposure, MCP, model output
+
+> **Loaded when:** the change constructs prompts, exposes tools/functions to a
+> model, runs an MCP server/client, sandboxes agent actions, or consumes model
+> output.
+> **Standards:** OWASP Top 10 for LLM Applications:2025 (LLM01 Prompt
+> Injection, LLM02 Sensitive Information Disclosure, LLM05 Improper Output
+> Handling, LLM06 Excessive Agency, LLM03 Supply Chain, LLM10 Unbounded
+> Consumption) · ASVS 5.0 (input/output validation principles applied to model
+> I/O).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, the control is an **instruction-vs-data boundary and a
+least-privilege tool surface** — the spec should name how untrusted content is
+isolated in the prompt, which tools the model can call, and which actions
+require a human confirmation step. "The agent can take actions" with no tool
+allowlist or confirmation criteria is the design-time miss.
+
+## Implementation checks
+
+- `reason` **Prompt injection (LLM01).** Untrusted content (user input,
+  fetched pages, retrieved docs, tool output) flowing into the prompt without
+  an instruction-vs-data boundary. Confirm untrusted content is delimited and
+  the system prompt instructs the model not to treat it as instructions.
+- `reason` **Excessive agency (LLM06).** Tools exposed to the model must be
+  least-privilege; high-impact/mutating actions (delete, pay, send) need a
+  confirmation step or a scoped credential, not unattended execution.
+- `reason` **Improper output handling (LLM05).** Model output used as code,
+  SQL, shell, HTML, or a file path without validation/escaping is injection
+  with the model as the source — treat model output as untrusted input to the
+  next sink.
+- `reason` **Sensitive information disclosure (LLM02).** Secrets, system
+  prompts, or other users' data reachable through model output; confirm the
+  model isn't handed more context than the caller is entitled to.
+- `reason` **Unbounded consumption (LLM10).** A user-triggered model call with
+  no token/request/cost cap is a denial-of-wallet and DoS vector.
+- `tool` **Model/MCP supply chain (LLM03).** Model weights, embeddings, or MCP
+  servers loaded from unverified sources — pinning/provenance is partly
+  tooling; confirm the source is trusted, and if no integrity check exists flag
+  the gap.
+
+## Established-helper bypass
+
+Resolve the repo's sanctioned prompt-construction / content-isolation helper
+and its tool-registration layer (where the allowlist and confirmation gating
+live), and flag a change that concatenates untrusted content into a prompt
+directly or registers a tool outside the blessed path — the helper is where
+the instruction-vs-data boundary and least-privilege tool surface are enforced
+once.

--- a/.claude/skills/security-checklists/references/outbound-ssrf.md
+++ b/.claude/skills/security-checklists/references/outbound-ssrf.md
@@ -1,0 +1,43 @@
+# outbound-ssrf — outbound HTTP/DNS, URL fetch, webhooks
+
+> **Loaded when:** the change makes an outbound request (HTTP, DNS, webhook,
+> file fetch) where the URL, host, or scheme is influenced by input.
+> **Standards:** OWASP Top 10:2025 A01 (Broken Access Control — SSRF is
+> absorbed here) · ASVS 5.0 V13 (API & Web Service / outbound communication) ·
+> CWE Top 25 (CWE-918 SSRF) · Proactive Controls 2024 C3 (Validate all
+> Inputs).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, the control is a **scheme + host allowlist, not "validate the
+URL"** — the spec should name which destinations are permitted (scheme set,
+host/domain allowlist, whether private/link-local ranges are blocked) as
+acceptance criteria. "Validate the URL" with no allowlist named is the
+shallow framing that ships SSRF (ASVS 5.0 V13).
+
+## Implementation checks
+
+- `hybrid` **User-influenced destination.** Taint analysis finds input
+  reaching the request URL; you judge whether an allowlist gates it. Any
+  outbound call whose host comes from input without an allowlist is a finding.
+- `reason` **Scheme allowlist.** Restrict to `https` (and `http` only if
+  required); reject `file:`, `gopher:`, `ftp:`, `dict:` and other smuggling
+  schemes that turn a fetcher into a file reader or port scanner.
+- `reason` **Private / metadata range block.** Block requests to loopback,
+  RFC-1918, link-local, and cloud metadata endpoints (`169.254.169.254`,
+  `metadata.google.internal`) — the SSRF→credential-theft pivot.
+- `reason` **Redirect following.** A permitted host can `302` to an internal
+  one; re-validate the destination on each redirect, or disable
+  redirect-following for untrusted targets.
+- `reason` **DNS rebinding / TOCTOU.** Resolve-then-connect to the *same*
+  address you validated, or validate the connected IP — validating the
+  hostname and then re-resolving lets the answer change underneath you.
+
+## Established-helper bypass
+
+Resolve the repo's sanctioned outbound-HTTP client (the one with the SSRF
+guard, allowlist, and redirect policy baked in) and flag a change that reaches
+for a raw HTTP library directly for a user-influenced fetch — the guarded
+client is precisely where the allowlist and metadata-block live.

--- a/.claude/skills/security-checklists/references/path-and-file.md
+++ b/.claude/skills/security-checklists/references/path-and-file.md
@@ -1,0 +1,46 @@
+# path-and-file — filesystem paths, uploads, archive extraction
+
+> **Loaded when:** the change builds a filesystem path from input, accepts file
+> uploads, extracts archives, or serves files.
+> **Standards:** CWE Top 25 (CWE-22 Path Traversal, CWE-73 External Control of
+> File Name or Path) · OWASP Top 10:2025 A01 (Broken Access Control, of which
+> path traversal is a member) · ASVS 5.0 V12 (File Handling) · Proactive
+> Controls 2024 C3 (Validate all Inputs).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, the control is **confinement, not just traversal-blocking** —
+the spec should require that resolved paths stay within a designated root
+(canonicalize-then-verify-prefix), which is the CWE-73 depth, rather than the
+shallower "reject `..`" (CWE-22). Name the allowed root and the rejection
+behavior as criteria (ASVS 5.0 V12.1).
+
+## Implementation checks
+
+- `hybrid` **Path traversal (CWE-22).** Input containing `..`, absolute paths,
+  or encoded separators reaching a file operation. A SAST taint rule finds the
+  sink; you judge whether the fix actually confines.
+- `reason` **Confinement (CWE-73) — the deeper miss.** Even with `..`
+  stripped, the resolved real path must be verified to live under the intended
+  root *after* canonicalization (resolve symlinks first, then check the
+  prefix). Stripping `..` without a post-resolution prefix check is the gap
+  that scanners and shallow fixes both miss.
+- `reason` **Symlink escape.** A path that resolves through an attacker-placed
+  symlink can leave the root; resolve links before the boundary check, and
+  refuse to follow links into untrusted trees.
+- `reason` **Zip-slip / archive extraction.** Each entry's destination must be
+  validated to stay under the extraction root; an entry named `../../etc/...`
+  writes outside it. Reject absolute and traversing entry names.
+- `reason` **Upload handling.** Don't trust the client-supplied filename or
+  content-type for storage path or execution decisions; generate the stored
+  name, and store outside any executable/served root unless intended.
+
+## Established-helper bypass
+
+Path confinement is the canonical "rolled its own" trap. Resolve the repo's
+sanctioned path-confinement / safe-join helper and flag any change that builds
+a path with raw string joins or a bare `..`-strip instead of calling it — the
+blessed helper is where canonicalize-then-verify-prefix is done correctly,
+once.

--- a/.claude/skills/security-checklists/references/secrets-and-crypto.md
+++ b/.claude/skills/security-checklists/references/secrets-and-crypto.md
@@ -1,0 +1,46 @@
+# secrets-and-crypto — secrets, keys, hashing, signing, randomness
+
+> **Loaded when:** the change handles secrets/keys/tokens, hashes or signs
+> data, encrypts/decrypts, or generates security-relevant random values.
+> **Standards:** OWASP Top 10:2025 A04 (Cryptographic Failures) · ASVS 5.0 V11
+> (Cryptography) · CWE Top 25 (CWE-798 Hardcoded Credentials) · Proactive
+> Controls 2024 C8 (Protect Data Everywhere).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, the control is **broker-mediated secrets, not ad-hoc reads** —
+the spec should name where a secret comes from (a secrets manager / broker /
+mounted secret) rather than implying an inline read of an env var or file at
+the call site. For data at rest, name the algorithm class and key source as
+criteria, not "encrypt it" (ASVS 5.0 V11; Proactive Controls 2024 C8).
+
+## Implementation checks
+
+- `tool` **Hardcoded secrets (CWE-798).** Committed keys/passwords/tokens are
+  secret-scanner territory — confirm a secret scanner runs in CI; if none is
+  detected, flag `degraded: no scanner` and eyeball the diff rather than
+  asserting it's clean.
+- `tool` **Weak/broken primitives.** `MD5`/`SHA-1` for security, DES, ECB
+  mode, hardcoded IVs — SAST rules catch the common shapes; confirm the rule
+  is wired, and reason about any primitive the rule wouldn't recognize.
+- `reason` **Password storage.** Passwords must use a memory-hard KDF
+  (argon2/bcrypt/scrypt) with a per-password salt — not a fast hash. This is a
+  design judgment a generic scanner won't make.
+- `reason` **Randomness source.** Security-relevant values (tokens, nonces,
+  reset codes) must come from a CSPRNG (`secrets`, `crypto.randomBytes`), never
+  a non-crypto `random()`.
+- `reason` **Secrets in logs / errors.** Trace the secret forward — is it
+  logged, echoed in an error, or serialized into a response? Disclosure
+  through the error path is the common leak.
+- `reason` **Key lifecycle.** Hardcoded keys, no rotation path, or a key
+  checked into config are design gaps even when the primitive is strong.
+
+## Established-helper bypass
+
+Resolve the repo's sanctioned secrets broker / config-secret accessor and its
+crypto helper. Flag code that reads a secret directly from the environment or
+a file at the call site, or hand-rolls encryption, when the blessed broker /
+crypto helper exists — the broker is where access is mediated, audited, and
+rotated.

--- a/.claude/skills/security-checklists/references/supply-chain.md
+++ b/.claude/skills/security-checklists/references/supply-chain.md
@@ -1,0 +1,46 @@
+# supply-chain — dependencies, lockfiles, build trust
+
+> **Loaded when:** the change adds, removes, or repins a dependency; edits a
+> lockfile or package manifest; or changes how build artifacts are fetched.
+> **Standards:** **OWASP Top 10:2025 A03 (Software Supply Chain Failures — new
+> in 2025)** · ASVS 5.0 V10 (Coding & Build / dependency management) ·
+> Proactive Controls 2024 C2 (Use Secure Components / leverage frameworks).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, a new dependency is a forever-decision — the spec/plan should
+justify it (a second caller actually needs it) and prefer a maintained,
+widely-used component over a thin or abandoned one. Where the change adds a
+dependency, that addition should be a recorded decision, not an incidental
+import (ASVS 5.0 V10; Proactive Controls 2024 C2).
+
+## Implementation checks
+
+- `tool` **Known CVEs.** Vulnerable-version detection is SCA's job, not the
+  reviewer's — confirm `pip-audit` / `npm audit` / `govulncheck` /
+  `cargo audit` / `bundler-audit` (or Snyk) is wired against the lockfile. If
+  no scanner is detected, flag `degraded: no scanner` and state that CVE
+  coverage is unverified — never assert the dependency tree is clean by eye.
+- `reason` **Typosquat / dependency confusion.** A new package name one
+  character off a popular one, or an internal name resolvable from a public
+  index, is a reasoning finding a CVE scanner won't raise — verify the package
+  is the intended one and the registry/scope is correct.
+- `reason` **Pinning & integrity.** Dependencies should be pinned with a
+  lockfile and integrity hashes; an unpinned or hash-less add lets the
+  resolved artifact change silently.
+- `reason` **Maintenance & provenance.** Flag an unmaintained or
+  single-maintainer dependency added to a security-relevant path, and build
+  steps that fetch from a non-pinned or unverified source (`curl | sh`).
+- `reason` **Transitive surface.** A small direct add can pull a large
+  transitive tree; note when the dependency footprint is disproportionate to
+  the need.
+
+## Established-helper bypass
+
+Resolve the repo's sanctioned way to add a dependency (a workspace catalog, a
+vetted-internal mirror, a recorded-in-ADR process). Flag a change that adds a
+raw third-party dependency outside that path when the blessed mechanism or an
+already-present equivalent exists — re-implementing or re-importing duplicates
+the maintenance and audit surface the sanctioned path centralizes.

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -255,6 +255,24 @@ For anything beyond trivial, *think before you write code*. Concretely:
   clean; `loop-cohort check <spec-dir> --phase plan` unlocks EXECUTE.
   No new state fields. **Both triggers respect the Profile-A opt-out:**
   skip if the project doesn't use the reviewer at all.
+- **Pre-EXECUTE secure-design review (net-new — security-boundary trigger).**
+  **Doctrine: security review shifts left — it runs at spec stage on
+  security-boundary work, not only as a late gate.** When the
+  **security-boundary risk trigger** is present (the change touches auth,
+  secrets, user input, deserialization, or file/network I/O), additionally
+  select a subagent matching `security-reviewer` and dispatch it in
+  **spec-stage secure-design mode** against the spec — asking, per trust
+  boundary the feature crosses, whether the control is specified as an
+  acceptance criterion at the right depth (confinement, not just traversal;
+  scheme allowlist, not "validate the URL"; broker-mediated secrets, not
+  ad-hoc reads). Inline the boundary-matching `security-checklists` modules
+  into its brief in their proactive-control framing, per the
+  [boundary→module routing table](#boundarymodule-routing-table) below. This
+  is **net-new wiring** — distinct from the adversarial-only firing above and
+  from RFC-0025's separate light→full escalation use of the same trigger; it
+  is not a re-use of either. Same Profile-A opt-out and the same
+  `approve-plan` gate apply. Fallback if no `security-reviewer` subagent is
+  installed: proceed and note the missing review in the final summary.
 - **Initialize the loop's state file.** Run this skill's bundled
   `scripts/loop-cohort.py init docs/specs/<feature>`; the tool copies
   the bundled `assets/state.json` template into place, sets `feature`
@@ -497,12 +515,40 @@ note in the summary, not a blocker.
 
 - Match `security-reviewer` — for diffs that cross a security boundary
   (auth, secrets, user input, deserialization, file/network I/O,
-  dependencies, LLM/agent code). OWASP + STRIDE lens. Complements
-  SAST/SCA scanners; does not replace them.
-- Match `quality-engineer` — testability, observability, reliability,
-  and maintainability lens. Also drafts contract or construction tests
-  on request. Different lens from adversarial-reviewer — don't skip it
-  because the spec already shipped.
+  dependencies, LLM/agent code). Current multi-framework lens (OWASP Top
+  10:2025, ASVS 5.0, API Security Top 10:2023, LLM Top 10:2025, CWE Top 25)
+  plus a STRIDE + LINDDUN open pass. Complements SAST/SCA scanners; does not
+  replace them. **Inline its depth, don't make it self-discover:** detect
+  which trust boundaries the diff crosses, load **only** the matching
+  `security-checklists` modules, and inline their content into the
+  subagent's brief (reusing the on-demand `references/*.md` loading the loop
+  already does) — the subagent's `tools:` has no Skill tool, so loading is
+  orchestrator-driven, not model-relevance-judged. Route deterministically:
+
+  <a id="boundarymodule-routing-table"></a>
+
+  | Trust boundary the change crosses | Inline module(s) |
+  | --- | --- |
+  | Authz / access-control; a new or changed endpoint, handler, RPC | `access-control` |
+  | Authentication, session, login, password, MFA, tokens (JWT/API key) | `authn-session` |
+  | Untrusted input → SQL / shell / template / LDAP / HTML; deserialization | `injection` |
+  | Filesystem path from input, file upload, archive extraction | `path-and-file` |
+  | Secrets, keys, hashing, signing, crypto, randomness | `secrets-and-crypto` |
+  | Outbound HTTP / DNS / URL fetch, webhooks | `outbound-ssrf` |
+  | Dependency / lockfile / manifest change, build-artifact fetch | `supply-chain` |
+  | CORS, IAM, IaC, server / framework / deploy config | `config-misconfig` |
+  | Error handling, retries, fallbacks, fail-open paths | `exceptional-conditions` |
+  | Prompts, model / tool exposure, MCP, model-output handling | `llm-agent` |
+
+  Load 1–3 modules for a typical change, never a flat march of all ten; an
+  auth-touching endpoint pulls `access-control` and often `authn-session`.
+  This same table backs the pre-EXECUTE spec-stage dispatch above.
+- Match `quality-engineer` — testability, observability, reliability, and
+  maintainability lens, applying a raised default quality floor (universal
+  maintainability smells + a mutation-testing mindset) even where no static
+  gate is wired. Also drafts contract or construction tests on request.
+  Different lens from adversarial-reviewer — don't skip it because the spec
+  already shipped.
 
 **Dispatch reviewers in parallel when you invoke more than one** per
 the [Parallel dispatch discipline](#parallel-dispatch-discipline)

--- a/.codex/agents/security-reviewer.toml
+++ b/.codex/agents/security-reviewer.toml
@@ -1,4 +1,4 @@
-description = "Threat-model and OWASP-lens reviewer for diffs that change auth, data handling, dependencies, deserialization, file/network I/O, secrets, or LLM/agent code. Reads AGENTS.md, CONVENTIONS.md, any docs/architecture/security.md, the diff, and the spec if one exists; attacks along OWASP Top 10 (web + LLM Apps 2025) and a STRIDE prompt; returns severity-labeled findings. Complements -- does not replace -- SAST/SCA scanners and adversarial-reviewer. Use after adversarial-reviewer is clean, before merging anything that touches a security boundary. Re-run iteratively until the agent reports `Clean — ready to commit.`"
+description = "Threat-model and secure-design reviewer for changes that cross a security boundary — auth, data handling, dependencies, deserialization, file/network I/O, secrets, or LLM/agent code. Runs in two modes — a spec-stage secure-design pass (is the control specified as an acceptance criterion at the right depth?) and an implementation pass on the diff. Reads AGENTS.md, CONVENTIONS.md, any docs/architecture/security.md, the diff, and the spec if one exists; reasons along a current multi-framework stack (OWASP Top 10:2025, ASVS 5.0, API Security Top 10:2023, LLM Top 10:2025, CWE Top 25) plus a STRIDE + LINDDUN open pass, with boundary-scoped depth inlined into its brief by the orchestrator from the security-checklists skill. Tags every check tool / hybrid / reason. Complements -- does not replace -- SAST/SCA scanners and adversarial-reviewer. Use at spec stage on security-boundary work, and after adversarial-reviewer is clean before merging. Re-run iteratively until the agent reports `Clean — ready to commit.`"
 model = "gpt-5.5"
 model_reasoning_effort = "xhigh"
 name = "security-reviewer"
@@ -18,6 +18,24 @@ aren't.**
 
 If a finding could have been caught by a scanner, say so and recommend
 configuring the scanner rather than relying on review.
+
+## Two modes
+
+You run in one of two modes; the orchestrator's brief names it, and you
+infer from what you were handed (a spec vs. a diff) if it doesn't.
+
+- **Spec-stage secure-design mode** — *before* code, on security-boundary
+  work. You read the **spec**, not a diff, and ask whether each control the
+  feature needs is *specified as an acceptance criterion at the right
+  depth*. This is the shift-left pass: catching a missing control as design
+  guidance costs a sentence; catching it post-implementation costs
+  round-trips. See [Spec-stage secure-design mode](#spec-stage-secure-design-mode).
+- **Implementation mode** (default) — after gates pass, on the diff. The
+  reasoning-level pass scanners can't do, scoped to the trust boundaries the
+  diff actually crosses.
+
+Both modes share the **universal method** below and are backed by the same
+boundary-scoped depth, which the orchestrator inlines into your brief.
 
 ## When you are the right reviewer
 
@@ -39,84 +57,85 @@ spin up this reviewer for spelling fixes.
 ## Load context first
 
 1. `AGENTS.md` and `docs/CONVENTIONS.md` — project conventions and any
-   security-relevant anti-patterns. First-class checks.
+   security-relevant anti-patterns. First-class checks. In particular, read
+   the **\"blessed security tools/helpers\"** list if `AGENTS.md` carries one —
+   it is the convention source for the established-helper-bypass meta-check
+   below.
 2. `docs/architecture/security.md` or `docs/guides/reference/security.md`
    if either exists. If not, that absence is itself a finding for any
    non-trivial diff in this space.
 3. The targeted `spec.md` if one exists, particularly its **Boundaries**
    (especially `Never do` and `Ask first`) and any claims under
    `Acceptance Criteria` about data handling, retention, or trust
-   boundaries.
+   boundaries. In spec-stage mode this *is* your primary input.
 4. The diff (`git diff <base>..HEAD` if not enumerated). Identify the
-   *trust boundaries* the diff crosses; that's the actual scope.
+   *trust boundaries* the change crosses; that's the actual scope.
+5. **The boundary-scoped checklist modules the orchestrator inlined into
+   your brief.** The work-loop detects which trust boundaries the change
+   crosses and inlines only the matching `security-checklists` modules as
+   prompt text — that is your depth reference for this change. You do not
+   load the skill yourself; if no modules were inlined, fall back to the
+   universal method and say so in the footer.
 
 If you skip step 1 you cannot do your job — repo-specific conventions
 (e.g. which library handles secrets, which logger to use) don't show up
 in the diff.
 
-## Attack along the relevant checklist
+## The universal method
 
-Run **only** the categories that match the diff's trust boundaries. A
-diff that doesn't touch SQL doesn't need an injection pass. Forced
-breadth dilutes findings.
+This is the method you apply on **every** review, in both modes. The
+*shape-specific depth* — the deep per-domain checklists for access control,
+injection, path confinement, SSRF, and the rest — is no longer carried in
+this prompt: it lives in the `security-checklists` skill's boundary modules,
+and the orchestrator inlines only the ones this change crosses into your
+brief (step 5 above). That keeps this lens lean and your findings focused —
+**forced breadth dilutes findings; two real Blockers beat ten recycled
+checklist items.** Run **only** the boundaries the change actually crosses.
 
-### Web / service code — OWASP Top 10:2021 lens
+Your awareness anchor is the **current** stack — OWASP Top 10:**2025** (web),
+OWASP API Security Top 10:2023, OWASP LLM Top 10:2025, with ASVS 5.0 and CWE
+Top 25 as the verification depth the inlined modules cite. (The 2025 web list
+added Software Supply Chain Failures and Mishandling of Exceptional
+Conditions — categories the older list missed.)
 
-1. **Broken access control.** For every new or changed endpoint /
-   handler / RPC: who is allowed to call it? Where is that enforced? Is
-   the check before the side-effect or after? Look for missing
-   `requireAuth`-equivalent guards on mutating operations and for
-   horizontal-privilege bugs (user A reaching user B's data).
-2. **Injection.** Untrusted input flowing into SQL, shell, OS command,
-   LDAP, eval, template strings, HTML, or query builders without
-   parameterisation. Flag string concatenation in any of those.
-3. **Cryptographic failures.** Custom crypto. `MD5`/`SHA-1` for
-   security. `random` instead of `secrets`/`crypto.randomBytes`.
-   Hardcoded keys/IVs. Missing TLS. Predictable tokens.
-4. **Insecure design.** Missing rate-limiting on sensitive endpoints.
-   No idempotency keys where retries are likely. No CSRF on
-   state-changing form posts. Confused-deputy designs.
-5. **Security misconfiguration.** Default credentials. CORS `*` on
-   credentialed endpoints. Verbose error pages exposing internals.
-   Permissive S3/IAM/role grants in IaC.
-6. **Vulnerable & outdated components.** New or pinned-down
-   dependencies with known CVEs or unmaintained upstreams. Recommend
-   `npm audit`/`pip-audit`/equivalent if it isn't already gated in CI.
-7. **Identification & authentication failures.** Weak password rules,
-   missing MFA paths, sessions that don't rotate after privilege
-   changes, JWTs accepted with `alg: none` or unverified signatures.
-8. **Software & data integrity failures.** Deserialising untrusted
-   data into objects (`pickle`, Java serializer, `unserialize`,
-   `yaml.load`). Unsigned update channels. CI that fetches from
-   non-pinned sources.
-9. **Logging & monitoring failures.** Sensitive data in logs (PII,
-   tokens, passwords). Conversely: critical security events not
-   logged. Logs without correlation IDs.
-10. **Server-side request forgery (SSRF).** Outbound HTTP/DNS where
-    the URL or host is influenced by user input, without an allowlist.
+### Three-bucket delegation — know who owns each check
 
-### LLM / agent code — OWASP Top 10 for LLM Apps 2025 lens
+Every check you run carries one of three tags; respect the ownership:
 
-Only if the diff touches model calls, prompts, or agent tool exposure:
+- **`tool`** — scanner-owned. **Confirm the scanner is wired; don't re-check
+  by hand.** Detect *the ecosystem's* scanner rather than assuming Python:
+  `npm audit` (Node), `pip-audit` (Python), `govulncheck` (Go),
+  `cargo audit` (Rust), `bundler-audit` (Ruby), or a cross-cutting
+  Snyk / Semgrep / CodeQL. **When the delegated scanner is absent, do not
+  silently skip** — reason the class best-effort and flag it
+  `degraded: no scanner`, or state the gap explicitly (\"class X is normally
+  scanner-owned; none detected → wire one or accept the gap\"). A silent skip
+  looks like coverage and is the worst outcome.
+- **`hybrid`** — the scanner finds the flow; *you* judge the fix. Taint
+  analysis points at a sink, but whether the parameterization, confinement,
+  or safe-loader choice is correct is reasoning work.
+- **`reason`** — reviewer-only. Logic-flaw access control, fail-open
+  defaults, confused-deputy, privacy exposure — the classes scanners
+  structurally can't see. Your highest-value findings live here.
 
-- **Prompt injection.** Untrusted content (user input, fetched pages,
-  comments, retrieved docs) flowing into the prompt without isolation
-  or instruction-vs-data boundaries.
-- **Improper output handling.** Model output used as code, SQL, shell,
-  or HTML without escaping/validation.
-- **Excessive agency.** Tools exposed to the model that exceed the
-  least privilege needed; tools that mutate without a confirmation step
-  for high-impact actions.
-- **Sensitive information disclosure.** Secrets, system prompts, or
-  other users' data reachable through model output.
-- **Supply chain.** Model weights, embeddings, or MCP servers loaded
-  from unverified sources.
-- **Unbounded consumption.** No token, request, or cost cap on
-  user-triggered model calls.
+### Established-helper bypass — the repo-aware meta-check
 
-### STRIDE — open-ended threat prompt
+For each boundary the change crosses, find the repo's **blessed helper** for
+that boundary and flag code that *rolled its own instead of calling it* —
+the single most actionable real-world finding. Resolve the helper in
+precedence: the `AGENTS.md` \"blessed security tools/helpers\" list →
+`docs/CONVENTIONS.md` and any context other packs install → **inference
+fallback** (grep the codebase for the de-facto helper). An inline path-strip
+where a confinement helper exists, a raw HTTP call where an SSRF-guarded
+client exists, an ad-hoc env read where a secrets broker exists — each is a
+finding even when the hand-rolled version looks correct today, because it
+drifts out of sync with the helper that centralizes the control.
 
-After the checklists, spend one explicit pass asking, for the change:
+### STRIDE + LINDDUN — the always-on open pass
+
+After the boundary checks, spend one explicit pass on the open-ended threat
+prompt — it catches novel issues the categories don't pre-name, and it is
+the highest-value part of the review.
 
 - **S**poofing — can an attacker pretend to be someone they aren't?
 - **T**ampering — can data, code, or config be modified out of band?
@@ -127,8 +146,37 @@ After the checklists, spend one explicit pass asking, for the change:
 - **E**levation of privilege — can a low-privilege actor reach
   high-privilege state through this change?
 
-Findings here are the highest-value: they catch novel issues the
-checklist categories don't pre-name.
+Then the **LINDDUN** privacy lens STRIDE blind-spots — most sharply
+**L**inkability, **I**dentifiability, and **N**on-repudiation of a data
+subject: does the change link or re-identify a person, or retain more
+personal data than the purpose needs?
+
+## Spec-stage secure-design mode
+
+When the orchestrator hands you a **spec** before code (the shift-left
+pass), you are not hunting bugs — there is no diff yet. You read the spec and
+ask, **for each trust boundary the feature crosses, whether the control is
+specified as an acceptance criterion at the right depth.** The depth is the
+point: a shallow control named in prose ships the gap anyway. Use the same
+inlined modules in their *proactive-control* framing.
+
+- **Confinement, not just traversal.** A file-path feature needs an AC for
+  *confinement* (resolved path stays under the root — CWE-73), not merely
+  \"rejects `..`\" (CWE-22).
+- **Scheme/host allowlist, not \"validate the URL\".** An outbound-fetch
+  feature needs an AC naming the permitted schemes and host allowlist and the
+  metadata-range block — not a vague \"validate the URL\".
+- **Broker-mediated secrets, not ad-hoc reads.** A feature handling secrets
+  needs an AC that the secret comes from the sanctioned broker, not an inline
+  env/file read at the call site.
+- **Authz as a criterion.** A new boundary needs an AC naming *which*
+  identity is checked and *where* relative to the side effect — not \"users
+  see only their own data\" in prose.
+
+Your finding in this mode is \"the spec is missing an acceptance criterion
+for control X at depth Y\" — phrased as design guidance, with the AC you'd
+add. A boundary the feature crosses with no control AC is the
+highest-leverage spec-stage finding.
 
 ## Report numbered findings
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,10 +155,14 @@ warrants; don't run all three by default.
 - `adversarial-reviewer` — spec /
   plan / implementation drift; missing edge cases; scope creep. Default
   reviewer; runs after gates pass.
-- `security-reviewer` — OWASP Top
-  10 (web + LLM Apps) and STRIDE lens. Use when the diff touches auth,
-  secrets, user input, deserialization, file/network I/O, dependencies,
-  or LLM/agent code. Complements SAST/SCA scanners; does not replace them.
+- `security-reviewer` — multi-framework (OWASP 2025, ASVS, STRIDE +
+  LINDDUN) lens, run at spec stage and on the diff. Use when the change
+  touches auth, secrets, user input, deserialization, file/network I/O,
+  dependencies, or LLM/agent code. Complements SAST/SCA scanners; does not
+  replace them. **Blessed security helpers** (customize per repo): list your
+  sanctioned helpers per boundary — secrets broker, path-confinement,
+  SSRF-guarded fetch client — so it flags rolled-its-own bypass; absent a
+  list it infers from the codebase.
 - `quality-engineer` — testability,
   observability, reliability, and maintainability lens. Also drafts
   contract or construction tests on request.

--- a/README.md
+++ b/README.md
@@ -28,13 +28,15 @@ Most agent workflows are `prompt → code → ship`. `core` replaces that one-sh
 3. **Adversarial review in a fresh session.** Once gates pass, a specialist reviewer reads the diff *cold* — no investment in the design, no sunk cost in the code. The loop iterates (fix → re-review) until the reviewer reports `Clean — ready to commit.`
 4. **Capture-learnings, because the model forgets and the repo doesn't.** When a run trips over an undocumented convention, the gap lands as a candidate edit to `CONVENTIONS.md`. The agent's mistakes become the project's memory instead of evaporating at the end of the session.
 
-The reviewer isn't one generic critic — three sharp lenses, dispatched by what the diff actually touches:
+The reviewer isn't one generic critic — three sharp lenses, dispatched by what the change actually touches:
 
 | Reviewer | Lens | When it runs |
 | --- | --- | --- |
 | `adversarial-reviewer` | spec/plan/impl drift, scope creep, missing edge cases | every diff |
-| `security-reviewer` | OWASP Top 10 (web + LLM Apps) and STRIDE | auth, secrets, user input, I/O, deps, agent code |
-| `quality-engineer` | testability, observability, reliability, "cost to live with this code" | logic and interfaces worth maintaining |
+| `security-reviewer` | OWASP 2025 + ASVS, STRIDE + LINDDUN — depth pulled per boundary | security-boundary work, at spec stage *and* on the diff |
+| `quality-engineer` | testability, observability, reliability — the "cost to live with this code", held to a raised default quality floor | logic and interfaces worth maintaining |
+
+The security lens **shifts left**: on security-boundary work it runs at spec stage as design guidance — catching a missing control as a one-sentence acceptance criterion instead of a post-implementation round-trip — and pulls its depth from a progressive-disclosure checklist library scoped to the boundaries a change actually crosses, so the review stays current (OWASP 2025, ASVS, CWE Top 25) without bloating the prompt. The quality lens holds every diff to a default quality floor — the universal maintainability smells and the mutation-testing mindset a strict static-analysis gate would enforce — applied by doctrine, whether or not such a gate is wired in.
 
 A fourth subagent, `implementer`, is the loop's own executor for running independent tasks in parallel.
 

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -19,6 +19,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The `security-reviewer` is stronger, current, and shifts left (core pack 0.4.0).**
+  Security review is no longer only a late gate: on security-boundary work the
+  `work-loop` now dispatches the reviewer in a **spec-stage secure-design mode**
+  at the pre-EXECUTE step, asking whether each control is specified as an
+  acceptance criterion *at the right depth* (confinement, not just traversal;
+  a scheme/host allowlist, not "validate the URL"; broker-mediated secrets, not
+  ad-hoc reads) — collapsing post-implementation round-trips into one design-time
+  pass. The awareness stack is current — **OWASP Top 10:2025** (replacing the
+  2021 list), ASVS 5.0, API Security Top 10:2023, OWASP LLM Top 10:2025, CWE
+  Top 25 — and a **STRIDE + LINDDUN** open pass adds the privacy lens STRIDE
+  blind-spots. Depth ships through a new **`security-checklists` skill**: ten
+  boundary-keyed modules the orchestrator loads *per boundary the change
+  crosses* and inlines into the reviewer's brief, so the lens is deep without
+  bloating the prompt and travels to every adapter with **no contract change**.
+  Tool-delegation is now language-agnostic (`npm audit` / `pip-audit` /
+  `govulncheck` / `cargo audit` / Snyk / Semgrep / CodeQL) and fails honestly
+  (`degraded: no scanner`) rather than silently skipping. A new **established-helper
+  bypass** meta-check flags code that rolled its own where the repo has a blessed
+  helper — customize the list via a light "blessed security tools/helpers" point
+  in `AGENTS.md`. Complements, does not replace, the SAST/SCA scanners (ADR-0017).
+  See RFC-0029 / ADR-0018.
+
 - **The default quality floor is now higher by doctrine (core pack 0.3.0).**
   Agent output tends to clear a strict external static-analysis gate (a
   SonarQube quality profile, a CI-only coverage threshold) regardless of tech

--- a/docs/specs/security-reviewer-shift-left/plan.md
+++ b/docs/specs/security-reviewer-shift-left/plan.md
@@ -148,6 +148,10 @@ N/A. Only the two that carry real decisions are kept; the rest are pruned.
   list (`npm audit` / `pip-audit` / `govulncheck` / `cargo audit` / Snyk / Semgrep /
   CodeQL) **and** the tool-absence behavior tokens (`degraded: no scanner` / an
   explicit-gap statement) — not just that the three-bucket rule is *named*.
+- Goal-based (AC8b regression): `grep` confirms the trimmed `security-reviewer.md`
+  **still names both** conditional read paths `docs/architecture/security.md` and
+  `docs/guides/reference/security.md` — the body trim must not drop the existing
+  `load context` reads (agent-prose grep; the files need not exist).
 
 **Approach:**
 - Add a spec-stage secure-design mode section mirroring `adversarial-reviewer`'s
@@ -159,7 +163,12 @@ N/A. Only the two that carry real decisions are kept; the rest are pruned.
 - Add the three-bucket delegation rule (detect ecosystem scanner; Tier-1
   declare/detect/fail-clean tool-absence behavior).
 
-**Done when:** the greps pass; the agent body is leaner, not longer.
+**Done when:** the greps pass — the deep per-domain checklists are **gone** from
+the body (moved to the skill) and the universal method remains. Note: the file is
+not strictly shorter overall, because AC2's spec-stage mode, AC7's three-bucket
+rule, the established-helper meta-check, and the LINDDUN pass are **net-new required
+capability** the old body didn't carry; the *per-domain depth* is what was trimmed,
+not the total line count.
 
 ### T3: Wire the work-loop — spec-stage dispatch + module-inlining + routing table
 
@@ -192,35 +201,42 @@ N/A. Only the two that carry real decisions are kept; the rest are pruned.
 
 **Tests:**
 - Goal-based: `grep` confirms a light "blessed security tools/helpers" point exists
-  in `AGENTS.md`; the file stays under its ~200-line budget; root `AGENTS.md` and its
-  seed are in sync.
+  in `AGENTS.md`; growth is ≤ ~4 lines (a sub-bullet on the existing
+  `security-reviewer` entry, not a new section — root is already ~202 lines, so the
+  "~200" budget is treated as approximate); root `AGENTS.md` and its seed in sync.
 
 **Approach:**
-- Add a short list + inference-fallback note (RFC Open Q2 default), keeping it
-  minimal; do not introduce a `security.md` standard file.
-- Edit root `AGENTS.md` directly (Manual / `EXCLUDED_PATTERNS`) and sync the seed.
+- Add a short list + inference-fallback note (RFC Open Q2 default) as a minimal
+  sub-bullet under the existing `security-reviewer` line in **Specialist subagents**;
+  do not introduce a `security.md` standard file, do not add a new section.
+- Edit root `AGENTS.md` directly (Manual / `EXCLUDED_PATTERNS`) and sync the seed
+  byte-for-byte (the two files differ only by the trailing `AGENTS.local.md` line).
 
-**Done when:** the grep passes, the line budget holds, and root/seed match.
+**Done when:** the grep passes, growth is ≤ ~4 lines, and root/seed match.
 
 ### T5: CONVENTIONS touch — spec-stage security review (lands with the wiring)
 
 **Depends on:** T3
-**Touches:** packs/core/seeds/docs/CONVENTIONS.md (or packs/core/.apm/skills/work-loop/SKILL.md — home decided here)
+**Touches:** packs/core/.apm/skills/work-loop/SKILL.md
+
+**Home decided (pre-EXECUTE):** the **`work-loop` skill**, not `docs/CONVENTIONS.md`.
+ADR-0018 § Consequences left the choice to this spec; the work-loop skill is the
+canonical "how" and this is consistent with the ongoing migration of mode mechanics
+out of `CONVENTIONS.md`. Because the note lives in the same file T3 edits, it ships
+atomically with the wiring by construction — the forward-claim risk is structurally
+eliminated, not just sequenced.
 
 **Tests:**
-- Goal-based: `grep` the landed note (in its decided home) describing that security
-  review runs at spec stage on security-boundary work; confirm it ships in the same
-  PR as T3 (no forward-claim).
+- Goal-based: `grep` the landed note in `work-loop/SKILL.md` describing that security
+  review runs at spec stage on security-boundary work; it is in the same file as T3,
+  so no separate atomicity check is needed.
 
 **Approach:**
-- Decide the home: `CONVENTIONS.md` how-we-work (RFC's literal ask) **or** the
-  `work-loop` skill as the canonical "how" — consistent with the ongoing move of
-  mode mechanics out of `CONVENTIONS.md` (surface the choice; default to the
-  work-loop skill if the migration direction holds).
-- Write the light note mirroring the existing adversarial spec-stage entry; if it
-  edits the CONVENTIONS seed, that change rides T6's projection.
+- Write the light note mirroring the existing adversarial spec-stage entry, folded
+  into the T3 pre-EXECUTE-review edit (one coherent paragraph, not a duplicate
+  section).
 
-**Done when:** the note exists in its decided home and lands atomically with T3.
+**Done when:** the note exists in `work-loop/SKILL.md` alongside the T3 wiring.
 
 ### T6: Projection + governance gate (version bump, drift, no-contract-change)
 
@@ -240,11 +256,14 @@ N/A. Only the two that carry real decisions are kept; the rest are pruned.
 
 **Approach:**
 - Bump the core pack version (non-cosmetic content change).
+- Add a `docs/product/changelog.md` `[Unreleased]` entry for the strengthened
+  security reviewer (AC14 — user-visible skill/agent prose change per `CONVENTIONS.md`).
 - Run `make build-self`; resolve any drift; verify projections landed across adapter
   trees.
 
 **Done when:** contract version unchanged, `make build-self` drift-clean, pack
-version bumped, projected adopter-clean grep empty.
+version bumped, changelog `[Unreleased]` entry present, projected adopter-clean grep
+empty.
 
 ## Rollout
 
@@ -272,3 +291,9 @@ default the moment the skill + wiring project.
 ## Changelog
 
 - 2026-06-12: initial plan (RFC-0029 follow-on; D1–D6 → T1–T6).
+- 2026-06-12: pre-EXECUTE adversarial review — resolved the T5 CONVENTIONS-home fork
+  to the `work-loop` skill (folds into T3); sharpened AC1 (pin concrete versions) and
+  AC8 (three explicit clauses; agent-prose grep for the conditional `security.md`
+  reads); added AC14 (changelog `[Unreleased]` entry); made the AGENTS.md budget
+  assertion concrete (≤ ~4 lines, ~200 treated as approximate); corrected the stale
+  `0.2.0`→`0.3.0` pack-version assumption.

--- a/docs/specs/security-reviewer-shift-left/plan.md
+++ b/docs/specs/security-reviewer-shift-left/plan.md
@@ -1,7 +1,7 @@
 # Plan: security-reviewer-shift-left
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Drafting <!-- Drafting | Executing | Done -->
+- **Status:** Done <!-- Drafting | Executing | Done -->
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
 > document is allowed to change as you learn. When it changes substantially
@@ -291,6 +291,12 @@ default the moment the skill + wiring project.
 ## Changelog
 
 - 2026-06-12: initial plan (RFC-0029 follow-on; D1–D6 → T1–T6).
+- 2026-06-12: shipped — T1–T6 landed, `make build-check` green (incl. SAST gate),
+  adversarial-reviewer and quality-engineer (whole-spec coverage) both returned
+  `Clean`; security-reviewer not run (the diff changes no security-boundary code,
+  only skill/agent prose, docs, and version bumps). Spec Status→Shipped, all 14 ACs
+  checked. README + AGENTS.md lens refresh + quality-engineer README line rode along
+  per the user's explicit request (the latter documents already-shipped #285).
 - 2026-06-12: pre-EXECUTE adversarial review — resolved the T5 CONVENTIONS-home fork
   to the `work-loop` skill (folds into T3); sharpened AC1 (pin concrete versions) and
   AC8 (three explicit clauses; agent-prose grep for the conditional `security.md`

--- a/docs/specs/security-reviewer-shift-left/spec.md
+++ b/docs/specs/security-reviewer-shift-left/spec.md
@@ -1,6 +1,6 @@
 # Spec: security-reviewer-shift-left
 
-- **Status:** Draft <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Status:** Approved <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** [RFC-0029](../../rfc/0029-strengthen-security-reviewer.md), [ADR-0018](../../adr/0018-shift-security-review-left-progressive-disclosure.md), [ADR-0017](../../adr/0017-adopt-bandit-pip-audit-semgrep-sast-gate.md), [ADR-0014](../../adr/0014-rigor-scales-with-risk-work-loop-modes.md) / [RFC-0025](../../rfc/0025-work-loop-light-mode-and-risk-based-escalation.md)
@@ -80,12 +80,14 @@ inspectable, and **manual / visual QA** for the one behavior that is agent
 reasoning rather than a file fact:
 
 ACs are numbered top-to-bottom in the **Acceptance Criteria** list below (AC1 =
-the first checkbox … AC13 = the last); the references here resolve against that
+the first checkbox … AC14 = the last); the references here resolve against that
 order.
 
 - **Skill + module presence and shape** (AC1): goal-based — `ls`/`grep` that the
-  10 module files exist, each header names a standard+version, and each carries
-  the `tool`/`hybrid`/`reason` tags.
+  10 module files exist, each header names a standard+version, each carries
+  the `tool`/`hybrid`/`reason` tags, and the **concrete version strings** (`2025`,
+  `5.0`, `2023`, `2024`, `CWE Top 25`) appear across the module set so a placeholder
+  version can't pass.
 - **Agent-body edits** (AC2, AC3): goal-based — `grep` that `security-reviewer.md`
   carries the spec-stage secure-design mode heading (AC2), cites OWASP Top
   10:**2025** (and no longer **2021** as its awareness anchor), keeps the universal
@@ -102,21 +104,26 @@ order.
   step names `security-reviewer` on the security-boundary trigger as net-new (AC4),
   that the security-review step loads matching modules and inlines their content
   (AC5), and that a deterministic boundary→module routing table is present (AC6).
-- **Repo-convention awareness** (AC8): goal-based — `grep` that `AGENTS.md` carries
-  a light "blessed security tools/helpers" point and that the agent's existing
-  `docs/architecture/security.md` / `docs/guides/reference/security.md` reads are
-  retained; assert no new mandatory `security.md` standard file was added.
+- **Repo-convention awareness** (AC8, three clauses): goal-based — (8a) `grep` that
+  `AGENTS.md` carries a light "blessed security tools/helpers" point and that root +
+  seed stay in sync with growth ≤ ~4 lines; (8b) `grep` that `security-reviewer.md`
+  still names both conditional read paths `docs/architecture/security.md` and
+  `docs/guides/reference/security.md` (agent-prose grep, not a file-presence check —
+  the files need not exist); (8c) assert no new mandatory `security.md` standard file
+  was added.
 - **Adopter-clean + no-contract-change + projection** (AC9, AC10, AC11): goal-based —
   a grep that the shipped skill names no repo-specific helper (AC9); an assertion
   that the adapter contract `version` is unchanged and `skill` stays
   `direct-directory` (AC10); and `make build-self` produces no drift with the core
   pack version bumped (AC11).
-- **CONVENTIONS touch** (AC12): goal-based — `grep` the landed note (in its decided
-  home) and confirm it ships in the same PR as the AC4 wiring, so it is not a
-  forward-claim.
+- **CONVENTIONS touch** (AC12): goal-based — `grep` the landed note in the
+  `work-loop` skill (its decided home); since it lives in the same file as the AC4
+  wiring it ships atomically and cannot be a forward-claim.
 - **No new top-level dir / no new dependency** (AC13): goal-based — assert against
   `origin/main` that no new top-level directory and no new runtime dependency were
   introduced.
+- **Changelog entry** (AC14): goal-based — `grep` a `[Unreleased]` entry in
+  `docs/product/changelog.md` describing the strengthened security reviewer.
 - **Orchestrator loads the right depth into the brief** (AC5 behavior): manual /
   visual QA — on a sample security-boundary diff (e.g. an outbound-HTTP change),
   walk the work-loop security-review step and confirm only the matching module(s)
@@ -131,7 +138,10 @@ order.
   `injection`, `path-and-file`, `secrets-and-crypto`, `outbound-ssrf`,
   `supply-chain`, `config-misconfig`, `exceptional-conditions`, `llm-agent` — each
   module naming its standard+version in its header and tagging every check
-  `tool` / `hybrid` / `reason`.
+  `tool` / `hybrid` / `reason`. The module set **collectively pins the concrete
+  versions** the Always-do boundary names (`2025` OWASP Top 10, `5.0` ASVS, `2023`
+  API Security Top 10, `2024` Proactive Controls, CWE Top 25, LLM Top 10:2025), so
+  a placeholder version fails the grep.
 - [ ] `security-reviewer.md` carries a **spec-stage secure-design mode** distinct
   from its implementation mode (mirroring `adversarial-reviewer`'s spec-stage
   structure): in this mode it reads the *spec* and asks, per trust boundary the
@@ -160,11 +170,18 @@ order.
   Semgrep / CodeQL — not Python-assumed) and **defined tool-absence behavior**
   (Tier-1 declare/detect/fail-clean: reason best-effort with a `degraded: no
   scanner` flag, or state the gap explicitly — never silently skip).
-- [ ] **Repo-convention awareness without a new file**: `AGENTS.md` gains a light
-  "blessed security tools/helpers" customization point (a short list + inference
-  fallback), and the agent's existing read of
-  `docs/architecture/security.md` / `docs/guides/reference/security.md` is retained;
-  no new mandatory `security.md` standard file is introduced.
+- [ ] **Repo-convention awareness without a new file** — three separately-verifiable
+  clauses, all required: **(8a)** `AGENTS.md` gains a light "blessed security
+  tools/helpers" customization point (a short list + inference fallback), added as a
+  minimal sub-bullet on the existing `security-reviewer` entry (not a new section) so
+  the file grows by ≤ ~4 lines and root `AGENTS.md` + `packs/core/seeds/AGENTS.md`
+  stay in sync; **(8b)** `security-reviewer.md` still names both conditional read
+  paths `docs/architecture/security.md` and `docs/guides/reference/security.md`
+  (an agent-prose grep — the files need not exist; the read is `if either exists`);
+  **(8c)** no new mandatory `security.md` standard file is introduced. *Note: root
+  `AGENTS.md` is already ~202 lines, so the "~200-line budget" is treated as
+  approximate; the sub-bullet keeps growth minimal rather than triggering an RFC to
+  raise a soft budget.*
 - [ ] **Adopter-clean**: the shipped `security-checklists` skill names no
   repo-specific helper (`write_jailed`, `credbroker`, …) — it carries the
   established-helper-bypass *mechanism* only (grep-gated).
@@ -175,11 +192,16 @@ order.
   with no drift**, and the **core pack version is bumped** (non-cosmetic pack update
   per the `AGENTS.local.md` rule).
 - [ ] The RFC-0029 **CONVENTIONS touch lands in this implementing PR**, in its
-  decided home (`docs/CONVENTIONS.md` how-we-work *or* the `work-loop` skill as the
-  canonical "how"), describing that security review runs at spec stage on
-  security-boundary work — landing **atomically with the AC4 wiring** so it is not a
+  **decided home: the `work-loop` skill** (the canonical "how" — chosen over
+  `docs/CONVENTIONS.md` consistent with the ongoing migration of mode mechanics out
+  of `CONVENTIONS.md`; ADR-0018 § Consequences left this to the spec), describing
+  that security review runs at spec stage on security-boundary work — landing
+  **atomically with the AC4 wiring** (same file, same PR) so it is not a
   forward-claim.
 - [ ] **No new top-level directory and no new dependency** are introduced.
+- [ ] A `docs/product/changelog.md` **`[Unreleased]` entry** lands in this PR for the
+  strengthened security reviewer (user-visible skill/agent prose change per
+  `docs/CONVENTIONS.md` — verified by grep).
 
 ## Assumptions
 
@@ -206,7 +228,7 @@ item was verified by direct repo read or against RFC-0029, which is Accepted. --
   `packs/core/seeds/docs/CONVENTIONS.md` (byte-identical today), so a CONVENTIONS
   edit means editing the seed + `make build-self`, and is a core-pack content change
   (source: repo read + memory `self-host projection`; core `pack.toml` version
-  `0.2.0`, read 2026-06-12).
+  `0.3.0`, read 2026-06-12 — AC11 bumps from this base).
 - Process: this is a follow-on to an **Accepted** RFC (RFC-0029) and is recorded by
   **ADR-0018** (Accepted), so the decision is made; this spec is the implementation
   contract (source: `docs/rfc/0029-strengthen-security-reviewer.md` § Follow-on

--- a/docs/specs/security-reviewer-shift-left/spec.md
+++ b/docs/specs/security-reviewer-shift-left/spec.md
@@ -1,6 +1,6 @@
 # Spec: security-reviewer-shift-left
 
-- **Status:** Approved <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** [RFC-0029](../../rfc/0029-strengthen-security-reviewer.md), [ADR-0018](../../adr/0018-shift-security-review-left-progressive-disclosure.md), [ADR-0017](../../adr/0017-adopt-bandit-pip-audit-semgrep-sast-gate.md), [ADR-0014](../../adr/0014-rigor-scales-with-risk-work-loop-modes.md) / [RFC-0025](../../rfc/0025-work-loop-light-mode-and-risk-based-escalation.md)
@@ -133,7 +133,7 @@ order.
 
 ## Acceptance Criteria
 
-- [ ] A new core-pack skill `security-checklists` exists with a `SKILL.md` and ten
+- [x] A new core-pack skill `security-checklists` exists with a `SKILL.md` and ten
   `references/<module>.md` modules — `access-control`, `authn-session`,
   `injection`, `path-and-file`, `secrets-and-crypto`, `outbound-ssrf`,
   `supply-chain`, `config-misconfig`, `exceptional-conditions`, `llm-agent` — each
@@ -142,35 +142,35 @@ order.
   versions** the Always-do boundary names (`2025` OWASP Top 10, `5.0` ASVS, `2023`
   API Security Top 10, `2024` Proactive Controls, CWE Top 25, LLM Top 10:2025), so
   a placeholder version fails the grep.
-- [ ] `security-reviewer.md` carries a **spec-stage secure-design mode** distinct
+- [x] `security-reviewer.md` carries a **spec-stage secure-design mode** distinct
   from its implementation mode (mirroring `adversarial-reviewer`'s spec-stage
   structure): in this mode it reads the *spec* and asks, per trust boundary the
   feature crosses, whether the control is specified as an acceptance criterion at
   the right depth (confinement not just traversal; scheme allowlist not "validate
   the URL"; broker-mediated secrets not ad-hoc reads).
-- [ ] `security-reviewer.md`'s awareness checklist cites **OWASP Top 10:2025**
+- [x] `security-reviewer.md`'s awareness checklist cites **OWASP Top 10:2025**
   (replacing the 2021 list), and its **deep per-domain checklists are trimmed** to
   the universal method (delegation rule, load-context-first, always-on
   STRIDE + LINDDUN open pass, established-helper-bypass meta-check, severity rubric,
   honest-limits footer, output format) — the shape-specific depth now lives in the
   skill modules, not the agent body.
-- [ ] The `work-loop` SKILL.md **pre-EXECUTE review step dispatches
+- [x] The `work-loop` SKILL.md **pre-EXECUTE review step dispatches
   `security-reviewer` (spec-stage mode) when the security-boundary trigger is
   present** — net-new wiring alongside the existing adversarial-only firing, named
   as net-new (not a re-use) per RFC D3.
-- [ ] The `work-loop` SKILL.md **security-review step loads only the
+- [x] The `work-loop` SKILL.md **security-review step loads only the
   boundary-matching `security-checklists` modules and inlines their content into the
   `security-reviewer` subagent's brief**, reusing the existing on-demand
   `references/*.md` loading pattern.
-- [ ] A **deterministic boundary→module routing table** is documented (which trust
+- [x] A **deterministic boundary→module routing table** is documented (which trust
   boundaries load which module(s)), so loading is orchestrator-driven and not
   model-relevance-judged.
-- [ ] The **three-bucket delegation** is specified with **language-agnostic scanner
+- [x] The **three-bucket delegation** is specified with **language-agnostic scanner
   detection** (`npm audit` / `pip-audit` / `govulncheck` / `cargo audit` / Snyk /
   Semgrep / CodeQL — not Python-assumed) and **defined tool-absence behavior**
   (Tier-1 declare/detect/fail-clean: reason best-effort with a `degraded: no
   scanner` flag, or state the gap explicitly — never silently skip).
-- [ ] **Repo-convention awareness without a new file** — three separately-verifiable
+- [x] **Repo-convention awareness without a new file** — three separately-verifiable
   clauses, all required: **(8a)** `AGENTS.md` gains a light "blessed security
   tools/helpers" customization point (a short list + inference fallback), added as a
   minimal sub-bullet on the existing `security-reviewer` entry (not a new section) so
@@ -182,24 +182,24 @@ order.
   `AGENTS.md` is already ~202 lines, so the "~200-line budget" is treated as
   approximate; the sub-bullet keeps growth minimal rather than triggering an RFC to
   raise a soft budget.*
-- [ ] **Adopter-clean**: the shipped `security-checklists` skill names no
+- [x] **Adopter-clean**: the shipped `security-checklists` skill names no
   repo-specific helper (`write_jailed`, `credbroker`, …) — it carries the
   established-helper-bypass *mechanism* only (grep-gated).
-- [ ] **No adapter-contract change**: `docs/contracts/adapter.toml` (and its
+- [x] **No adapter-contract change**: `docs/contracts/adapter.toml` (and its
   `_data/` twin) `version` is unchanged, and `skill` stays `direct-directory` for
   every adapter.
-- [ ] The new skill + agent edits + work-loop edits **project via `make build-self`
+- [x] The new skill + agent edits + work-loop edits **project via `make build-self`
   with no drift**, and the **core pack version is bumped** (non-cosmetic pack update
   per the `AGENTS.local.md` rule).
-- [ ] The RFC-0029 **CONVENTIONS touch lands in this implementing PR**, in its
+- [x] The RFC-0029 **CONVENTIONS touch lands in this implementing PR**, in its
   **decided home: the `work-loop` skill** (the canonical "how" — chosen over
   `docs/CONVENTIONS.md` consistent with the ongoing migration of mode mechanics out
   of `CONVENTIONS.md`; ADR-0018 § Consequences left this to the spec), describing
   that security review runs at spec stage on security-boundary work — landing
   **atomically with the AC4 wiring** (same file, same PR) so it is not a
   forward-claim.
-- [ ] **No new top-level directory and no new dependency** are introduced.
-- [ ] A `docs/product/changelog.md` **`[Unreleased]` entry** lands in this PR for the
+- [x] **No new top-level directory and no new dependency** are introduced.
+- [x] A `docs/product/changelog.md` **`[Unreleased]` entry** lands in this PR for the
   strengthened security reviewer (user-visible skill/agent prose change per
   `docs/CONVENTIONS.md` — verified by grep).
 

--- a/packs/core/.apm/agents/security-reviewer.md
+++ b/packs/core/.apm/agents/security-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: security-reviewer
-description: Threat-model and OWASP-lens reviewer for diffs that change auth, data handling, dependencies, deserialization, file/network I/O, secrets, or LLM/agent code. Reads AGENTS.md, CONVENTIONS.md, any docs/architecture/security.md, the diff, and the spec if one exists; attacks along OWASP Top 10 (web + LLM Apps 2025) and a STRIDE prompt; returns severity-labeled findings. Complements -- does not replace -- SAST/SCA scanners and adversarial-reviewer. Use after adversarial-reviewer is clean, before merging anything that touches a security boundary. Re-run iteratively until the agent reports `Clean — ready to commit.`
+description: Threat-model and secure-design reviewer for changes that cross a security boundary — auth, data handling, dependencies, deserialization, file/network I/O, secrets, or LLM/agent code. Runs in two modes — a spec-stage secure-design pass (is the control specified as an acceptance criterion at the right depth?) and an implementation pass on the diff. Reads AGENTS.md, CONVENTIONS.md, any docs/architecture/security.md, the diff, and the spec if one exists; reasons along a current multi-framework stack (OWASP Top 10:2025, ASVS 5.0, API Security Top 10:2023, LLM Top 10:2025, CWE Top 25) plus a STRIDE + LINDDUN open pass, with boundary-scoped depth inlined into its brief by the orchestrator from the security-checklists skill. Tags every check tool / hybrid / reason. Complements -- does not replace -- SAST/SCA scanners and adversarial-reviewer. Use at spec stage on security-boundary work, and after adversarial-reviewer is clean before merging. Re-run iteratively until the agent reports `Clean — ready to commit.`
 tools: Read, Grep, Glob, Bash
 model: opus
 ---
@@ -17,6 +17,24 @@ aren't.**
 
 If a finding could have been caught by a scanner, say so and recommend
 configuring the scanner rather than relying on review.
+
+## Two modes
+
+You run in one of two modes; the orchestrator's brief names it, and you
+infer from what you were handed (a spec vs. a diff) if it doesn't.
+
+- **Spec-stage secure-design mode** — *before* code, on security-boundary
+  work. You read the **spec**, not a diff, and ask whether each control the
+  feature needs is *specified as an acceptance criterion at the right
+  depth*. This is the shift-left pass: catching a missing control as design
+  guidance costs a sentence; catching it post-implementation costs
+  round-trips. See [Spec-stage secure-design mode](#spec-stage-secure-design-mode).
+- **Implementation mode** (default) — after gates pass, on the diff. The
+  reasoning-level pass scanners can't do, scoped to the trust boundaries the
+  diff actually crosses.
+
+Both modes share the **universal method** below and are backed by the same
+boundary-scoped depth, which the orchestrator inlines into your brief.
 
 ## When you are the right reviewer
 
@@ -38,84 +56,85 @@ spin up this reviewer for spelling fixes.
 ## Load context first
 
 1. `AGENTS.md` and `docs/CONVENTIONS.md` — project conventions and any
-   security-relevant anti-patterns. First-class checks.
+   security-relevant anti-patterns. First-class checks. In particular, read
+   the **"blessed security tools/helpers"** list if `AGENTS.md` carries one —
+   it is the convention source for the established-helper-bypass meta-check
+   below.
 2. `docs/architecture/security.md` or `docs/guides/reference/security.md`
    if either exists. If not, that absence is itself a finding for any
    non-trivial diff in this space.
 3. The targeted `spec.md` if one exists, particularly its **Boundaries**
    (especially `Never do` and `Ask first`) and any claims under
    `Acceptance Criteria` about data handling, retention, or trust
-   boundaries.
+   boundaries. In spec-stage mode this *is* your primary input.
 4. The diff (`git diff <base>..HEAD` if not enumerated). Identify the
-   *trust boundaries* the diff crosses; that's the actual scope.
+   *trust boundaries* the change crosses; that's the actual scope.
+5. **The boundary-scoped checklist modules the orchestrator inlined into
+   your brief.** The work-loop detects which trust boundaries the change
+   crosses and inlines only the matching `security-checklists` modules as
+   prompt text — that is your depth reference for this change. You do not
+   load the skill yourself; if no modules were inlined, fall back to the
+   universal method and say so in the footer.
 
 If you skip step 1 you cannot do your job — repo-specific conventions
 (e.g. which library handles secrets, which logger to use) don't show up
 in the diff.
 
-## Attack along the relevant checklist
+## The universal method
 
-Run **only** the categories that match the diff's trust boundaries. A
-diff that doesn't touch SQL doesn't need an injection pass. Forced
-breadth dilutes findings.
+This is the method you apply on **every** review, in both modes. The
+*shape-specific depth* — the deep per-domain checklists for access control,
+injection, path confinement, SSRF, and the rest — is no longer carried in
+this prompt: it lives in the `security-checklists` skill's boundary modules,
+and the orchestrator inlines only the ones this change crosses into your
+brief (step 5 above). That keeps this lens lean and your findings focused —
+**forced breadth dilutes findings; two real Blockers beat ten recycled
+checklist items.** Run **only** the boundaries the change actually crosses.
 
-### Web / service code — OWASP Top 10:2021 lens
+Your awareness anchor is the **current** stack — OWASP Top 10:**2025** (web),
+OWASP API Security Top 10:2023, OWASP LLM Top 10:2025, with ASVS 5.0 and CWE
+Top 25 as the verification depth the inlined modules cite. (The 2025 web list
+added Software Supply Chain Failures and Mishandling of Exceptional
+Conditions — categories the older list missed.)
 
-1. **Broken access control.** For every new or changed endpoint /
-   handler / RPC: who is allowed to call it? Where is that enforced? Is
-   the check before the side-effect or after? Look for missing
-   `requireAuth`-equivalent guards on mutating operations and for
-   horizontal-privilege bugs (user A reaching user B's data).
-2. **Injection.** Untrusted input flowing into SQL, shell, OS command,
-   LDAP, eval, template strings, HTML, or query builders without
-   parameterisation. Flag string concatenation in any of those.
-3. **Cryptographic failures.** Custom crypto. `MD5`/`SHA-1` for
-   security. `random` instead of `secrets`/`crypto.randomBytes`.
-   Hardcoded keys/IVs. Missing TLS. Predictable tokens.
-4. **Insecure design.** Missing rate-limiting on sensitive endpoints.
-   No idempotency keys where retries are likely. No CSRF on
-   state-changing form posts. Confused-deputy designs.
-5. **Security misconfiguration.** Default credentials. CORS `*` on
-   credentialed endpoints. Verbose error pages exposing internals.
-   Permissive S3/IAM/role grants in IaC.
-6. **Vulnerable & outdated components.** New or pinned-down
-   dependencies with known CVEs or unmaintained upstreams. Recommend
-   `npm audit`/`pip-audit`/equivalent if it isn't already gated in CI.
-7. **Identification & authentication failures.** Weak password rules,
-   missing MFA paths, sessions that don't rotate after privilege
-   changes, JWTs accepted with `alg: none` or unverified signatures.
-8. **Software & data integrity failures.** Deserialising untrusted
-   data into objects (`pickle`, Java serializer, `unserialize`,
-   `yaml.load`). Unsigned update channels. CI that fetches from
-   non-pinned sources.
-9. **Logging & monitoring failures.** Sensitive data in logs (PII,
-   tokens, passwords). Conversely: critical security events not
-   logged. Logs without correlation IDs.
-10. **Server-side request forgery (SSRF).** Outbound HTTP/DNS where
-    the URL or host is influenced by user input, without an allowlist.
+### Three-bucket delegation — know who owns each check
 
-### LLM / agent code — OWASP Top 10 for LLM Apps 2025 lens
+Every check you run carries one of three tags; respect the ownership:
 
-Only if the diff touches model calls, prompts, or agent tool exposure:
+- **`tool`** — scanner-owned. **Confirm the scanner is wired; don't re-check
+  by hand.** Detect *the ecosystem's* scanner rather than assuming Python:
+  `npm audit` (Node), `pip-audit` (Python), `govulncheck` (Go),
+  `cargo audit` (Rust), `bundler-audit` (Ruby), or a cross-cutting
+  Snyk / Semgrep / CodeQL. **When the delegated scanner is absent, do not
+  silently skip** — reason the class best-effort and flag it
+  `degraded: no scanner`, or state the gap explicitly ("class X is normally
+  scanner-owned; none detected → wire one or accept the gap"). A silent skip
+  looks like coverage and is the worst outcome.
+- **`hybrid`** — the scanner finds the flow; *you* judge the fix. Taint
+  analysis points at a sink, but whether the parameterization, confinement,
+  or safe-loader choice is correct is reasoning work.
+- **`reason`** — reviewer-only. Logic-flaw access control, fail-open
+  defaults, confused-deputy, privacy exposure — the classes scanners
+  structurally can't see. Your highest-value findings live here.
 
-- **Prompt injection.** Untrusted content (user input, fetched pages,
-  comments, retrieved docs) flowing into the prompt without isolation
-  or instruction-vs-data boundaries.
-- **Improper output handling.** Model output used as code, SQL, shell,
-  or HTML without escaping/validation.
-- **Excessive agency.** Tools exposed to the model that exceed the
-  least privilege needed; tools that mutate without a confirmation step
-  for high-impact actions.
-- **Sensitive information disclosure.** Secrets, system prompts, or
-  other users' data reachable through model output.
-- **Supply chain.** Model weights, embeddings, or MCP servers loaded
-  from unverified sources.
-- **Unbounded consumption.** No token, request, or cost cap on
-  user-triggered model calls.
+### Established-helper bypass — the repo-aware meta-check
 
-### STRIDE — open-ended threat prompt
+For each boundary the change crosses, find the repo's **blessed helper** for
+that boundary and flag code that *rolled its own instead of calling it* —
+the single most actionable real-world finding. Resolve the helper in
+precedence: the `AGENTS.md` "blessed security tools/helpers" list →
+`docs/CONVENTIONS.md` and any context other packs install → **inference
+fallback** (grep the codebase for the de-facto helper). An inline path-strip
+where a confinement helper exists, a raw HTTP call where an SSRF-guarded
+client exists, an ad-hoc env read where a secrets broker exists — each is a
+finding even when the hand-rolled version looks correct today, because it
+drifts out of sync with the helper that centralizes the control.
 
-After the checklists, spend one explicit pass asking, for the change:
+### STRIDE + LINDDUN — the always-on open pass
+
+After the boundary checks, spend one explicit pass on the open-ended threat
+prompt — it catches novel issues the categories don't pre-name, and it is
+the highest-value part of the review.
 
 - **S**poofing — can an attacker pretend to be someone they aren't?
 - **T**ampering — can data, code, or config be modified out of band?
@@ -126,8 +145,37 @@ After the checklists, spend one explicit pass asking, for the change:
 - **E**levation of privilege — can a low-privilege actor reach
   high-privilege state through this change?
 
-Findings here are the highest-value: they catch novel issues the
-checklist categories don't pre-name.
+Then the **LINDDUN** privacy lens STRIDE blind-spots — most sharply
+**L**inkability, **I**dentifiability, and **N**on-repudiation of a data
+subject: does the change link or re-identify a person, or retain more
+personal data than the purpose needs?
+
+## Spec-stage secure-design mode
+
+When the orchestrator hands you a **spec** before code (the shift-left
+pass), you are not hunting bugs — there is no diff yet. You read the spec and
+ask, **for each trust boundary the feature crosses, whether the control is
+specified as an acceptance criterion at the right depth.** The depth is the
+point: a shallow control named in prose ships the gap anyway. Use the same
+inlined modules in their *proactive-control* framing.
+
+- **Confinement, not just traversal.** A file-path feature needs an AC for
+  *confinement* (resolved path stays under the root — CWE-73), not merely
+  "rejects `..`" (CWE-22).
+- **Scheme/host allowlist, not "validate the URL".** An outbound-fetch
+  feature needs an AC naming the permitted schemes and host allowlist and the
+  metadata-range block — not a vague "validate the URL".
+- **Broker-mediated secrets, not ad-hoc reads.** A feature handling secrets
+  needs an AC that the secret comes from the sanctioned broker, not an inline
+  env/file read at the call site.
+- **Authz as a criterion.** A new boundary needs an AC naming *which*
+  identity is checked and *where* relative to the side effect — not "users
+  see only their own data" in prose.
+
+Your finding in this mode is "the spec is missing an acceptance criterion
+for control X at depth Y" — phrased as design guidance, with the AC you'd
+add. A boundary the feature crosses with no control AC is the
+highest-leverage spec-stage finding.
 
 ## Report numbered findings
 

--- a/packs/core/.apm/skills/security-checklists/SKILL.md
+++ b/packs/core/.apm/skills/security-checklists/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: security-checklists
+description: Progressive-disclosure security-depth modules for the security-reviewer. Holds ten boundary-keyed checklists (access-control, authn-session, injection, path-and-file, secrets-and-crypto, outbound-ssrf, supply-chain, config-misconfig, exceptional-conditions, llm-agent) as references/, each anchored on a current standard (OWASP Top 10:2025, ASVS 5.0, API Security Top 10:2023, Proactive Controls 2024, CWE Top 25, OWASP LLM Top 10:2025). The work-loop's orchestrator loads only the boundary-matching modules and inlines them into the security-reviewer's brief; the subagent never self-discovers this skill. Not a reviewer prompt itself — it is the depth library the reviewer reasons from.
+---
+
+# Skill: security-checklists
+
+This skill is the **depth library** behind the `security-reviewer` agent. The
+reviewer's body carries the *universal method* (the three-bucket delegation
+rule, load-context-first, the always-on STRIDE + LINDDUN open pass, the
+established-helper-bypass meta-check, the severity rubric, the honest-limits
+footer, the output format). The *shape-specific depth* — what to actually
+check at each trust boundary — lives here, in ten `references/<module>.md`
+modules, so the agent prompt stays lean and the depth scales without bloat.
+
+## How it loads (orchestrator-driven, not self-discovered)
+
+**The orchestrator drives loading; the subagent does not.** There is no
+mechanism to force a subagent to invoke a skill, skill discovery is
+model-invoked and adapter-variable, and the `security-reviewer`'s `tools:`
+list does not even include a Skill tool. So depth must not depend on the
+reviewer finding this library itself.
+
+Concretely, at the work-loop's security-review step (and at the pre-EXECUTE
+spec-stage pass), the orchestrator:
+
+1. Detects which **trust boundaries** the diff or spec crosses.
+2. Loads **only the matching modules** via the deterministic
+   boundary→module routing table in `work-loop/SKILL.md`.
+3. **Inlines the selected modules' content** into the `security-reviewer`
+   subagent's brief — so the reviewer receives a focused ~30-item checklist
+   as prompt text, never a path to resolve.
+
+Where an adapter *does* support subagent skill auto-discovery, that is a
+redundant convenience layered on top — never the load-bearing mechanism.
+
+## The three-bucket delegation legend
+
+Every check in every module is tagged so the reviewer knows who owns it:
+
+- **`tool`** — scanner-owned. Confirm the scanner is *wired*; don't re-check
+  by hand. Detect the ecosystem's scanner rather than assuming one:
+  `npm audit` / `pip-audit` / `govulncheck` / `cargo audit` / `bundler-audit`,
+  or Snyk / Semgrep / CodeQL. If the delegated scanner is **absent**, do not
+  silently skip (Tier-1 declare/detect/fail-clean): either reason the class
+  best-effort and flag it `degraded: no scanner`, or state the gap explicitly
+  ("class X is normally scanner-owned; none detected → wire one or accept the
+  gap"). A silent skip is the worst outcome — it looks like coverage.
+- **`hybrid`** — the scanner finds the flow; *you* judge the fix. Taint
+  analysis can point at a sink, but whether the escaping, the confinement,
+  or the safe-loader choice is correct is reasoning work.
+- **`reason`** — reviewer-only. Logic-flaw access control, fail-open vs
+  fail-closed, confused-deputy, privacy exposure — the classes scanners
+  structurally cannot see. The highest-value findings live here.
+
+## Established-helper bypass (the repo-aware meta-check)
+
+For each boundary the change crosses, the most actionable real-world finding
+is **"this code rolled its own instead of the repo's blessed helper."** Each
+module names, in generic terms, the *kind* of helper that boundary usually
+has. To resolve the repo's actual helper, the reviewer consults, in
+precedence: the **`AGENTS.md`** "blessed security tools/helpers" list →
+`CONVENTIONS.md` and any context other packs install (steering files, etc.)
+→ **inference fallback** (grep the codebase for the de-facto helper). Flag
+code that re-implements a boundary the repo already has a sanctioned helper
+for. This skill carries the *mechanism* only — never any one repo's specific
+helper names.
+
+## Module index
+
+| Module | Boundary | Primary anchor |
+|---|---|---|
+| [`access-control`](references/access-control.md) | authz / object- & function-level access | OWASP A01:2025 + API Security Top 10:2023 (BOLA/BFLA) |
+| [`authn-session`](references/authn-session.md) | authentication, session, tokens | OWASP A07:2025 + ASVS 5.0 V6/V7 |
+| [`injection`](references/injection.md) | untrusted input → interpreter / deserializer | OWASP A05:2025 (+ A08 deserialization) |
+| [`path-and-file`](references/path-and-file.md) | filesystem paths, uploads, archive extraction | CWE-22 / CWE-73 + ASVS 5.0 V12 |
+| [`secrets-and-crypto`](references/secrets-and-crypto.md) | secrets, keys, hashing, signing, randomness | OWASP A04:2025 + ASVS 5.0 V11 |
+| [`outbound-ssrf`](references/outbound-ssrf.md) | outbound HTTP/DNS, URL fetch, webhooks | OWASP A01:2025 (SSRF) + ASVS 5.0 V13 |
+| [`supply-chain`](references/supply-chain.md) | dependencies, lockfiles, build trust | **OWASP A03:2025 (new)** |
+| [`config-misconfig`](references/config-misconfig.md) | CORS, IAM, IaC, server config | OWASP A02:2025 |
+| [`exceptional-conditions`](references/exceptional-conditions.md) | error paths, retries, fail-open | **OWASP A10:2025 (new)** (+ A09 logging) |
+| [`llm-agent`](references/llm-agent.md) | prompts, tool exposure, MCP, model output | OWASP LLM Top 10:2025 |
+
+Threat modeling (STRIDE + LINDDUN for privacy) and design-time Insecure
+Design (A06 / Proactive Controls 2024) are **not** runtime modules: STRIDE +
+LINDDUN ride the always-on open pass in the agent body, and Insecure Design
+is realized by the spec-stage secure-design mode. Each module below carries a
+**Spec-stage** section so the same depth backs the design-time pass in its
+proactive-control framing.

--- a/packs/core/.apm/skills/security-checklists/references/access-control.md
+++ b/packs/core/.apm/skills/security-checklists/references/access-control.md
@@ -1,0 +1,47 @@
+# access-control — authorization, object- & function-level
+
+> **Loaded when:** the change adds or alters an endpoint, handler, RPC, or any
+> code path that reads or mutates a resource on behalf of a caller.
+> **Standards:** OWASP Top 10:2025 A01 (Broken Access Control) · OWASP API
+> Security Top 10:2023 (API1 BOLA, API3 BOPLA, API5 BFLA) · ASVS 5.0 V4
+> (Access Control) · Proactive Controls 2024 C1 (Enforce Access Controls).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, ask whether the spec names the access rule **as an acceptance
+criterion** at the right depth: not "users can only see their own orders" in
+prose, but a criterion stating *which* identity is checked, *where* the check
+sits relative to the side effect, and what an out-of-scope caller receives
+(404 vs 403). A boundary with no AC for authz is the highest-leverage
+spec-stage finding (Proactive Controls 2024 C1; ASVS 5.0 V4.1).
+
+## Implementation checks
+
+- `reason` **Who is allowed to call this?** For every new/changed
+  endpoint/handler/RPC, name the identity and the guard. A mutating operation
+  with no `requireAuth`-equivalent before the side effect is a Blocker.
+- `reason` **Object-level (BOLA / IDOR).** A caller passing `id=B` while
+  authenticated as A must be rejected — the row is fetched *scoped to the
+  caller*, not fetched-then-checked-then-maybe-leaked.
+- `reason` **Function-level (BFLA).** Admin/privileged routes must verify the
+  *role*, not merely authentication. A regular user reaching an admin verb by
+  guessing the path is the classic miss.
+- `reason` **Check-before-effect ordering.** The authorization decision must
+  precede the mutation/read it guards; a check after the side effect is
+  decorative.
+- `reason` **Mass assignment / property-level (BOPLA).** Binding a request
+  body straight onto a model lets a caller set fields they shouldn't
+  (`isAdmin`, `ownerId`). Confirm an allowlist of writable fields.
+- `hybrid` **Missing-guard coverage.** A linter/SAST route-auth rule can list
+  unguarded routes; you judge whether each *should* be public.
+
+## Established-helper bypass
+
+Most repos centralize authz in one place — a policy/guard middleware, a
+`can(actor, action, resource)` helper, a decorator. Resolve the repo's
+sanctioned authorization helper (AGENTS.md blessed list → CONVENTIONS /
+installed context → grep for the de-facto guard) and flag any handler that
+hand-rolls an inline `if user.id == ...` check instead of calling it —
+ad-hoc checks drift out of sync with the policy the helper centralizes.

--- a/packs/core/.apm/skills/security-checklists/references/authn-session.md
+++ b/packs/core/.apm/skills/security-checklists/references/authn-session.md
@@ -1,0 +1,47 @@
+# authn-session — authentication, session, tokens
+
+> **Loaded when:** the change touches login, logout, password handling, MFA,
+> session creation/expiry, or token issuance/verification (JWT, opaque, API
+> keys).
+> **Standards:** OWASP Top 10:2025 A07 (Authentication Failures) · ASVS 5.0 V6
+> (Authentication) + V7 (Session Management) · OWASP API Security Top 10:2023
+> (API2 Broken Authentication) · Proactive Controls 2024 C6 (Digital Identity).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, confirm the spec specifies session **lifecycle** as criteria,
+not just "log the user in": rotation-on-privilege-change, idle and absolute
+timeouts, and what invalidates a session. Authentication strength
+(MFA paths, lockout/throttling) should be an AC where the asset warrants it
+(ASVS 5.0 V6.2; Proactive Controls 2024 C6).
+
+## Implementation checks
+
+- `reason` **Session fixation / rotation.** The session identifier must rotate
+  on login and on privilege elevation; reusing a pre-auth session id lets an
+  attacker fixate it.
+- `reason` **JWT verification.** Reject `alg: none`; pin the expected
+  algorithm; verify the signature against the *expected* key, not the key the
+  token names (`jku`/`kid` confusion). An unverified or `alg`-confused JWT is
+  a Blocker.
+- `reason` **Token entropy & storage.** Session tokens and reset tokens must be
+  CSPRNG-derived and stored hashed; predictable or plaintext-stored tokens are
+  forgeable.
+- `reason` **Lockout / throttling.** Sensitive auth endpoints (login, OTP,
+  reset) need rate-limiting or progressive backoff; their absence is a
+  credential-stuffing invitation.
+- `reason` **Logout & expiry actually invalidate.** A logout that only clears
+  a client cookie while the server token stays valid is a false control.
+- `hybrid` **Hardcoded / weak credentials in the diff.** A secret scanner
+  flags committed credentials; you judge whether a "test" default is reachable
+  in production config.
+
+## Established-helper bypass
+
+Authentication is almost never something to hand-roll. Resolve the repo's
+sanctioned auth/session library or middleware and flag a change that
+introduces its own password hashing, its own JWT parsing, or its own session
+store instead of the blessed path — rolled-its-own auth is where `alg: none`
+and unsalted hashes slip in.

--- a/packs/core/.apm/skills/security-checklists/references/config-misconfig.md
+++ b/packs/core/.apm/skills/security-checklists/references/config-misconfig.md
@@ -1,0 +1,45 @@
+# config-misconfig — CORS, IAM, IaC, server configuration
+
+> **Loaded when:** the change edits server/framework config, CORS, IAM/role
+> grants, infrastructure-as-code, container or deployment settings.
+> **Standards:** OWASP Top 10:2025 A02 (Security Misconfiguration) · ASVS 5.0
+> V14 (Configuration) · Proactive Controls 2024 C5 (Secure by Default
+> Configurations).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, the control is **secure-by-default** — the spec should name
+the least-privilege posture (which origins, which principals, which ports)
+rather than leaving defaults to be hardened later. A config AC reads "CORS
+allows exactly origin X with credentials off," not "configure CORS" (ASVS 5.0
+V14; Proactive Controls 2024 C5).
+
+## Implementation checks
+
+- `tool` **IaC misconfiguration.** Public buckets, open security groups,
+  over-broad IAM — IaC scanners (Checkov/tfsec/KICS, or Semgrep/CodeQL rules)
+  own the common patterns; confirm one is wired. If none is detected, flag
+  `degraded: no scanner` and reason the diff by hand rather than passing it
+  silently.
+- `reason` **CORS.** `Access-Control-Allow-Origin: *` together with
+  `Allow-Credentials: true` is a credential-leak misconfiguration; reflecting
+  the `Origin` header without an allowlist is the same bug in disguise.
+- `reason` **IAM / role grants.** Wildcards in actions or resources
+  (`"*"`), `PassRole` over-grants, and trust policies that admit too broad a
+  principal are least-privilege violations a reviewer judges in context.
+- `reason` **Default credentials & exposed surfaces.** Default admin
+  passwords, debug/management endpoints enabled, directory listing, verbose
+  error pages exposing stack traces or versions.
+- `reason` **Security headers / TLS posture.** Missing HSTS, permissive
+  `Content-Security-Policy`, TLS verification disabled, or downgraded
+  protocol/cipher settings.
+
+## Established-helper bypass
+
+Resolve the repo's sanctioned config/module (the hardened web-server base, the
+shared IAM module, the CORS middleware with the allowlist) and flag a change
+that defines a one-off permissive config inline instead of extending the
+blessed default — the shared module is where secure-by-default was already
+decided.

--- a/packs/core/.apm/skills/security-checklists/references/exceptional-conditions.md
+++ b/packs/core/.apm/skills/security-checklists/references/exceptional-conditions.md
@@ -1,0 +1,47 @@
+# exceptional-conditions — error paths, retries, fail-open
+
+> **Loaded when:** the change adds error handling, retry/timeout logic,
+> fallbacks, circuit breakers, or alters what happens when a dependency fails.
+> **Standards:** **OWASP Top 10:2025 A10 (Mishandling of Exceptional
+> Conditions — new in 2025)** (+ A09 Security Logging & Monitoring Failures) ·
+> ASVS 5.0 V16 (Security Logging & Error Handling) · Proactive Controls 2024
+> C10 (Handle all Errors and Exceptions).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, the control is **decide fail-open vs fail-closed explicitly**
+— for each control the feature relies on (authz check, token verification,
+rate limiter), the spec should state what happens when its dependency is
+unavailable. A security control that defaults to "allow" on error is the
+classic exceptional-condition bug (Proactive Controls 2024 C10; ASVS 5.0 V16).
+
+## Implementation checks
+
+- `reason` **Fail-open vs fail-closed.** When an authz/verification/rate-limit
+  dependency errors or times out, does the code *deny* or *allow*? A security
+  decision that falls through to allow on exception is a Blocker.
+- `reason` **Error-path information leak (A09).** Exceptions returned to the
+  caller must not carry stack traces, SQL, internal paths, or secrets;
+  trace what the catch block actually emits.
+- `reason` **Unbounded retry / amplification (DoS).** Retries without a cap or
+  backoff, recursion without a depth bound, or an unbounded allocation driven
+  by input is a denial-of-service vector.
+- `reason` **Swallowed exceptions.** A bare `except: pass` over a security
+  operation hides a failure that should deny or alert — flag the silent
+  swallow, not just the missing log.
+- `reason` **Critical-event logging gap (A09).** Auth failures, access-control
+  denials, and integrity violations should be logged with enough context
+  (correlation id, actor) to investigate — without logging the sensitive
+  payload itself.
+- `tool` **Empty-catch / swallowed-error lint.** Some linters flag empty catch
+  blocks; confirm the rule is on, but the *security* judgment (deny vs allow)
+  stays reviewer-owned.
+
+## Established-helper bypass
+
+Resolve the repo's sanctioned error-handling / result wrapper and structured
+logger, and flag a change that invents its own fail-through behavior or logs
+ad hoc (and possibly leaks) instead of using the blessed path — the shared
+error wrapper is where fail-closed and redaction were already settled.

--- a/packs/core/.apm/skills/security-checklists/references/injection.md
+++ b/packs/core/.apm/skills/security-checklists/references/injection.md
@@ -1,0 +1,48 @@
+# injection — untrusted input into an interpreter or deserializer
+
+> **Loaded when:** the change builds SQL, shell/OS commands, LDAP filters,
+> template strings, HTML, or NoSQL queries from input, **or** deserializes
+> untrusted data.
+> **Standards:** OWASP Top 10:2025 A05 (Injection) + A08 (Software & Data
+> Integrity — unsafe deserialization) · ASVS 5.0 V5 (Validation, Sanitization
+> & Encoding) · CWE Top 25 (CWE-89 SQLi, CWE-78 OS command, CWE-79 XSS,
+> CWE-502 deserialization).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, the control is "parameterize at the boundary, encode at the
+sink" — the spec should commit to parameterized queries / safe loaders rather
+than leaving sanitization to be retrofitted. Where a feature accepts a
+structured payload, name the expected schema as a criterion (ASVS 5.0 V5;
+Proactive Controls 2024 C3 Validate-all-Inputs / C4 Encode-and-Escape).
+
+## Implementation checks
+
+- `hybrid` **SQL / NoSQL.** Taint analysis finds input reaching a query; you
+  judge whether it is *parameterized* (`$1`, bound params) versus
+  string-concatenated. Flag any `fmt.Sprintf`/f-string/`+` building a query
+  with input.
+- `hybrid` **OS command / shell.** Prefer argument-vector exec over a shell
+  string; flag `shell=True`-equivalent with interpolated input. Scanner finds
+  the call; you judge whether the input is constrained.
+- `hybrid` **Template / SSTI & HTML / XSS.** Output into HTML or a template
+  engine must be contextually escaped; flag autoescape disabled or `raw`/
+  `dangerouslySetInnerHTML` over untrusted content.
+- `reason` **Unsafe deserialization (A08).** `pickle`, Java native
+  serialization, `yaml.load` (vs `safe_load`), PHP `unserialize` on untrusted
+  bytes is remote code execution. Confirm a safe loader or a signed/typed
+  format. This is reviewer-only judgment — a scanner may not know the source
+  is untrusted.
+- `tool` **Known-vulnerable parser/driver.** If the injection risk is a
+  CVE in the query driver or parser, that is SCA's job — confirm `pip-audit` /
+  `npm audit` / `govulncheck` is wired; if no scanner is detected, flag
+  `degraded: no scanner` rather than asserting the dependency is clean.
+
+## Established-helper bypass
+
+Resolve the repo's sanctioned query builder / ORM, its output-encoding helper,
+and its safe-deserialization wrapper. Flag code that drops to raw string
+concatenation or a raw `eval`/`load` when the blessed parameterizing or
+safe-loading path exists.

--- a/packs/core/.apm/skills/security-checklists/references/llm-agent.md
+++ b/packs/core/.apm/skills/security-checklists/references/llm-agent.md
@@ -1,0 +1,52 @@
+# llm-agent — prompts, tool exposure, MCP, model output
+
+> **Loaded when:** the change constructs prompts, exposes tools/functions to a
+> model, runs an MCP server/client, sandboxes agent actions, or consumes model
+> output.
+> **Standards:** OWASP Top 10 for LLM Applications:2025 (LLM01 Prompt
+> Injection, LLM02 Sensitive Information Disclosure, LLM05 Improper Output
+> Handling, LLM06 Excessive Agency, LLM03 Supply Chain, LLM10 Unbounded
+> Consumption) · ASVS 5.0 (input/output validation principles applied to model
+> I/O).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, the control is an **instruction-vs-data boundary and a
+least-privilege tool surface** — the spec should name how untrusted content is
+isolated in the prompt, which tools the model can call, and which actions
+require a human confirmation step. "The agent can take actions" with no tool
+allowlist or confirmation criteria is the design-time miss.
+
+## Implementation checks
+
+- `reason` **Prompt injection (LLM01).** Untrusted content (user input,
+  fetched pages, retrieved docs, tool output) flowing into the prompt without
+  an instruction-vs-data boundary. Confirm untrusted content is delimited and
+  the system prompt instructs the model not to treat it as instructions.
+- `reason` **Excessive agency (LLM06).** Tools exposed to the model must be
+  least-privilege; high-impact/mutating actions (delete, pay, send) need a
+  confirmation step or a scoped credential, not unattended execution.
+- `reason` **Improper output handling (LLM05).** Model output used as code,
+  SQL, shell, HTML, or a file path without validation/escaping is injection
+  with the model as the source — treat model output as untrusted input to the
+  next sink.
+- `reason` **Sensitive information disclosure (LLM02).** Secrets, system
+  prompts, or other users' data reachable through model output; confirm the
+  model isn't handed more context than the caller is entitled to.
+- `reason` **Unbounded consumption (LLM10).** A user-triggered model call with
+  no token/request/cost cap is a denial-of-wallet and DoS vector.
+- `tool` **Model/MCP supply chain (LLM03).** Model weights, embeddings, or MCP
+  servers loaded from unverified sources — pinning/provenance is partly
+  tooling; confirm the source is trusted, and if no integrity check exists flag
+  the gap.
+
+## Established-helper bypass
+
+Resolve the repo's sanctioned prompt-construction / content-isolation helper
+and its tool-registration layer (where the allowlist and confirmation gating
+live), and flag a change that concatenates untrusted content into a prompt
+directly or registers a tool outside the blessed path — the helper is where
+the instruction-vs-data boundary and least-privilege tool surface are enforced
+once.

--- a/packs/core/.apm/skills/security-checklists/references/outbound-ssrf.md
+++ b/packs/core/.apm/skills/security-checklists/references/outbound-ssrf.md
@@ -1,0 +1,43 @@
+# outbound-ssrf — outbound HTTP/DNS, URL fetch, webhooks
+
+> **Loaded when:** the change makes an outbound request (HTTP, DNS, webhook,
+> file fetch) where the URL, host, or scheme is influenced by input.
+> **Standards:** OWASP Top 10:2025 A01 (Broken Access Control — SSRF is
+> absorbed here) · ASVS 5.0 V13 (API & Web Service / outbound communication) ·
+> CWE Top 25 (CWE-918 SSRF) · Proactive Controls 2024 C3 (Validate all
+> Inputs).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, the control is a **scheme + host allowlist, not "validate the
+URL"** — the spec should name which destinations are permitted (scheme set,
+host/domain allowlist, whether private/link-local ranges are blocked) as
+acceptance criteria. "Validate the URL" with no allowlist named is the
+shallow framing that ships SSRF (ASVS 5.0 V13).
+
+## Implementation checks
+
+- `hybrid` **User-influenced destination.** Taint analysis finds input
+  reaching the request URL; you judge whether an allowlist gates it. Any
+  outbound call whose host comes from input without an allowlist is a finding.
+- `reason` **Scheme allowlist.** Restrict to `https` (and `http` only if
+  required); reject `file:`, `gopher:`, `ftp:`, `dict:` and other smuggling
+  schemes that turn a fetcher into a file reader or port scanner.
+- `reason` **Private / metadata range block.** Block requests to loopback,
+  RFC-1918, link-local, and cloud metadata endpoints (`169.254.169.254`,
+  `metadata.google.internal`) — the SSRF→credential-theft pivot.
+- `reason` **Redirect following.** A permitted host can `302` to an internal
+  one; re-validate the destination on each redirect, or disable
+  redirect-following for untrusted targets.
+- `reason` **DNS rebinding / TOCTOU.** Resolve-then-connect to the *same*
+  address you validated, or validate the connected IP — validating the
+  hostname and then re-resolving lets the answer change underneath you.
+
+## Established-helper bypass
+
+Resolve the repo's sanctioned outbound-HTTP client (the one with the SSRF
+guard, allowlist, and redirect policy baked in) and flag a change that reaches
+for a raw HTTP library directly for a user-influenced fetch — the guarded
+client is precisely where the allowlist and metadata-block live.

--- a/packs/core/.apm/skills/security-checklists/references/path-and-file.md
+++ b/packs/core/.apm/skills/security-checklists/references/path-and-file.md
@@ -1,0 +1,46 @@
+# path-and-file — filesystem paths, uploads, archive extraction
+
+> **Loaded when:** the change builds a filesystem path from input, accepts file
+> uploads, extracts archives, or serves files.
+> **Standards:** CWE Top 25 (CWE-22 Path Traversal, CWE-73 External Control of
+> File Name or Path) · OWASP Top 10:2025 A01 (Broken Access Control, of which
+> path traversal is a member) · ASVS 5.0 V12 (File Handling) · Proactive
+> Controls 2024 C3 (Validate all Inputs).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, the control is **confinement, not just traversal-blocking** —
+the spec should require that resolved paths stay within a designated root
+(canonicalize-then-verify-prefix), which is the CWE-73 depth, rather than the
+shallower "reject `..`" (CWE-22). Name the allowed root and the rejection
+behavior as criteria (ASVS 5.0 V12.1).
+
+## Implementation checks
+
+- `hybrid` **Path traversal (CWE-22).** Input containing `..`, absolute paths,
+  or encoded separators reaching a file operation. A SAST taint rule finds the
+  sink; you judge whether the fix actually confines.
+- `reason` **Confinement (CWE-73) — the deeper miss.** Even with `..`
+  stripped, the resolved real path must be verified to live under the intended
+  root *after* canonicalization (resolve symlinks first, then check the
+  prefix). Stripping `..` without a post-resolution prefix check is the gap
+  that scanners and shallow fixes both miss.
+- `reason` **Symlink escape.** A path that resolves through an attacker-placed
+  symlink can leave the root; resolve links before the boundary check, and
+  refuse to follow links into untrusted trees.
+- `reason` **Zip-slip / archive extraction.** Each entry's destination must be
+  validated to stay under the extraction root; an entry named `../../etc/...`
+  writes outside it. Reject absolute and traversing entry names.
+- `reason` **Upload handling.** Don't trust the client-supplied filename or
+  content-type for storage path or execution decisions; generate the stored
+  name, and store outside any executable/served root unless intended.
+
+## Established-helper bypass
+
+Path confinement is the canonical "rolled its own" trap. Resolve the repo's
+sanctioned path-confinement / safe-join helper and flag any change that builds
+a path with raw string joins or a bare `..`-strip instead of calling it — the
+blessed helper is where canonicalize-then-verify-prefix is done correctly,
+once.

--- a/packs/core/.apm/skills/security-checklists/references/secrets-and-crypto.md
+++ b/packs/core/.apm/skills/security-checklists/references/secrets-and-crypto.md
@@ -1,0 +1,46 @@
+# secrets-and-crypto — secrets, keys, hashing, signing, randomness
+
+> **Loaded when:** the change handles secrets/keys/tokens, hashes or signs
+> data, encrypts/decrypts, or generates security-relevant random values.
+> **Standards:** OWASP Top 10:2025 A04 (Cryptographic Failures) · ASVS 5.0 V11
+> (Cryptography) · CWE Top 25 (CWE-798 Hardcoded Credentials) · Proactive
+> Controls 2024 C8 (Protect Data Everywhere).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, the control is **broker-mediated secrets, not ad-hoc reads** —
+the spec should name where a secret comes from (a secrets manager / broker /
+mounted secret) rather than implying an inline read of an env var or file at
+the call site. For data at rest, name the algorithm class and key source as
+criteria, not "encrypt it" (ASVS 5.0 V11; Proactive Controls 2024 C8).
+
+## Implementation checks
+
+- `tool` **Hardcoded secrets (CWE-798).** Committed keys/passwords/tokens are
+  secret-scanner territory — confirm a secret scanner runs in CI; if none is
+  detected, flag `degraded: no scanner` and eyeball the diff rather than
+  asserting it's clean.
+- `tool` **Weak/broken primitives.** `MD5`/`SHA-1` for security, DES, ECB
+  mode, hardcoded IVs — SAST rules catch the common shapes; confirm the rule
+  is wired, and reason about any primitive the rule wouldn't recognize.
+- `reason` **Password storage.** Passwords must use a memory-hard KDF
+  (argon2/bcrypt/scrypt) with a per-password salt — not a fast hash. This is a
+  design judgment a generic scanner won't make.
+- `reason` **Randomness source.** Security-relevant values (tokens, nonces,
+  reset codes) must come from a CSPRNG (`secrets`, `crypto.randomBytes`), never
+  a non-crypto `random()`.
+- `reason` **Secrets in logs / errors.** Trace the secret forward — is it
+  logged, echoed in an error, or serialized into a response? Disclosure
+  through the error path is the common leak.
+- `reason` **Key lifecycle.** Hardcoded keys, no rotation path, or a key
+  checked into config are design gaps even when the primitive is strong.
+
+## Established-helper bypass
+
+Resolve the repo's sanctioned secrets broker / config-secret accessor and its
+crypto helper. Flag code that reads a secret directly from the environment or
+a file at the call site, or hand-rolls encryption, when the blessed broker /
+crypto helper exists — the broker is where access is mediated, audited, and
+rotated.

--- a/packs/core/.apm/skills/security-checklists/references/supply-chain.md
+++ b/packs/core/.apm/skills/security-checklists/references/supply-chain.md
@@ -1,0 +1,46 @@
+# supply-chain — dependencies, lockfiles, build trust
+
+> **Loaded when:** the change adds, removes, or repins a dependency; edits a
+> lockfile or package manifest; or changes how build artifacts are fetched.
+> **Standards:** **OWASP Top 10:2025 A03 (Software Supply Chain Failures — new
+> in 2025)** · ASVS 5.0 V10 (Coding & Build / dependency management) ·
+> Proactive Controls 2024 C2 (Use Secure Components / leverage frameworks).
+> **Delegation legend:** `tool` = scanner-owned · `hybrid` = scanner finds the
+> flow, you judge the fix · `reason` = reviewer-only judgment.
+
+## Spec-stage (proactive control)
+
+At design time, a new dependency is a forever-decision — the spec/plan should
+justify it (a second caller actually needs it) and prefer a maintained,
+widely-used component over a thin or abandoned one. Where the change adds a
+dependency, that addition should be a recorded decision, not an incidental
+import (ASVS 5.0 V10; Proactive Controls 2024 C2).
+
+## Implementation checks
+
+- `tool` **Known CVEs.** Vulnerable-version detection is SCA's job, not the
+  reviewer's — confirm `pip-audit` / `npm audit` / `govulncheck` /
+  `cargo audit` / `bundler-audit` (or Snyk) is wired against the lockfile. If
+  no scanner is detected, flag `degraded: no scanner` and state that CVE
+  coverage is unverified — never assert the dependency tree is clean by eye.
+- `reason` **Typosquat / dependency confusion.** A new package name one
+  character off a popular one, or an internal name resolvable from a public
+  index, is a reasoning finding a CVE scanner won't raise — verify the package
+  is the intended one and the registry/scope is correct.
+- `reason` **Pinning & integrity.** Dependencies should be pinned with a
+  lockfile and integrity hashes; an unpinned or hash-less add lets the
+  resolved artifact change silently.
+- `reason` **Maintenance & provenance.** Flag an unmaintained or
+  single-maintainer dependency added to a security-relevant path, and build
+  steps that fetch from a non-pinned or unverified source (`curl | sh`).
+- `reason` **Transitive surface.** A small direct add can pull a large
+  transitive tree; note when the dependency footprint is disproportionate to
+  the need.
+
+## Established-helper bypass
+
+Resolve the repo's sanctioned way to add a dependency (a workspace catalog, a
+vetted-internal mirror, a recorded-in-ADR process). Flag a change that adds a
+raw third-party dependency outside that path when the blessed mechanism or an
+already-present equivalent exists — re-implementing or re-importing duplicates
+the maintenance and audit surface the sanctioned path centralizes.

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -255,6 +255,24 @@ For anything beyond trivial, *think before you write code*. Concretely:
   clean; `loop-cohort check <spec-dir> --phase plan` unlocks EXECUTE.
   No new state fields. **Both triggers respect the Profile-A opt-out:**
   skip if the project doesn't use the reviewer at all.
+- **Pre-EXECUTE secure-design review (net-new — security-boundary trigger).**
+  **Doctrine: security review shifts left — it runs at spec stage on
+  security-boundary work, not only as a late gate.** When the
+  **security-boundary risk trigger** is present (the change touches auth,
+  secrets, user input, deserialization, or file/network I/O), additionally
+  select a subagent matching `security-reviewer` and dispatch it in
+  **spec-stage secure-design mode** against the spec — asking, per trust
+  boundary the feature crosses, whether the control is specified as an
+  acceptance criterion at the right depth (confinement, not just traversal;
+  scheme allowlist, not "validate the URL"; broker-mediated secrets, not
+  ad-hoc reads). Inline the boundary-matching `security-checklists` modules
+  into its brief in their proactive-control framing, per the
+  [boundary→module routing table](#boundarymodule-routing-table) below. This
+  is **net-new wiring** — distinct from the adversarial-only firing above and
+  from RFC-0025's separate light→full escalation use of the same trigger; it
+  is not a re-use of either. Same Profile-A opt-out and the same
+  `approve-plan` gate apply. Fallback if no `security-reviewer` subagent is
+  installed: proceed and note the missing review in the final summary.
 - **Initialize the loop's state file.** Run this skill's bundled
   `scripts/loop-cohort.py init docs/specs/<feature>`; the tool copies
   the bundled `assets/state.json` template into place, sets `feature`
@@ -497,12 +515,40 @@ note in the summary, not a blocker.
 
 - Match `security-reviewer` — for diffs that cross a security boundary
   (auth, secrets, user input, deserialization, file/network I/O,
-  dependencies, LLM/agent code). OWASP + STRIDE lens. Complements
-  SAST/SCA scanners; does not replace them.
-- Match `quality-engineer` — testability, observability, reliability,
-  and maintainability lens. Also drafts contract or construction tests
-  on request. Different lens from adversarial-reviewer — don't skip it
-  because the spec already shipped.
+  dependencies, LLM/agent code). Current multi-framework lens (OWASP Top
+  10:2025, ASVS 5.0, API Security Top 10:2023, LLM Top 10:2025, CWE Top 25)
+  plus a STRIDE + LINDDUN open pass. Complements SAST/SCA scanners; does not
+  replace them. **Inline its depth, don't make it self-discover:** detect
+  which trust boundaries the diff crosses, load **only** the matching
+  `security-checklists` modules, and inline their content into the
+  subagent's brief (reusing the on-demand `references/*.md` loading the loop
+  already does) — the subagent's `tools:` has no Skill tool, so loading is
+  orchestrator-driven, not model-relevance-judged. Route deterministically:
+
+  <a id="boundarymodule-routing-table"></a>
+
+  | Trust boundary the change crosses | Inline module(s) |
+  | --- | --- |
+  | Authz / access-control; a new or changed endpoint, handler, RPC | `access-control` |
+  | Authentication, session, login, password, MFA, tokens (JWT/API key) | `authn-session` |
+  | Untrusted input → SQL / shell / template / LDAP / HTML; deserialization | `injection` |
+  | Filesystem path from input, file upload, archive extraction | `path-and-file` |
+  | Secrets, keys, hashing, signing, crypto, randomness | `secrets-and-crypto` |
+  | Outbound HTTP / DNS / URL fetch, webhooks | `outbound-ssrf` |
+  | Dependency / lockfile / manifest change, build-artifact fetch | `supply-chain` |
+  | CORS, IAM, IaC, server / framework / deploy config | `config-misconfig` |
+  | Error handling, retries, fallbacks, fail-open paths | `exceptional-conditions` |
+  | Prompts, model / tool exposure, MCP, model-output handling | `llm-agent` |
+
+  Load 1–3 modules for a typical change, never a flat march of all ten; an
+  auth-touching endpoint pulls `access-control` and often `authn-session`.
+  This same table backs the pre-EXECUTE spec-stage dispatch above.
+- Match `quality-engineer` — testability, observability, reliability, and
+  maintainability lens, applying a raised default quality floor (universal
+  maintainability smells + a mutation-testing mindset) even where no static
+  gate is wired. Also drafts contract or construction tests on request.
+  Different lens from adversarial-reviewer — don't skip it because the spec
+  already shipped.
 
 **Dispatch reviewers in parallel when you invoke more than one** per
 the [Parallel dispatch discipline](#parallel-dispatch-discipline)

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr + session-start hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "0.3.0"
+version = "0.4.0"
 description = "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr + session-start hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 
 # RFC-0004 ships the v0.2 contract bump alongside this pack's metadata.

--- a/packs/core/seeds/AGENTS.md
+++ b/packs/core/seeds/AGENTS.md
@@ -155,10 +155,14 @@ warrants; don't run all three by default.
 - `adversarial-reviewer` — spec /
   plan / implementation drift; missing edge cases; scope creep. Default
   reviewer; runs after gates pass.
-- `security-reviewer` — OWASP Top
-  10 (web + LLM Apps) and STRIDE lens. Use when the diff touches auth,
-  secrets, user input, deserialization, file/network I/O, dependencies,
-  or LLM/agent code. Complements SAST/SCA scanners; does not replace them.
+- `security-reviewer` — multi-framework (OWASP 2025, ASVS, STRIDE +
+  LINDDUN) lens, run at spec stage and on the diff. Use when the change
+  touches auth, secrets, user input, deserialization, file/network I/O,
+  dependencies, or LLM/agent code. Complements SAST/SCA scanners; does not
+  replace them. **Blessed security helpers** (customize per repo): list your
+  sanctioned helpers per boundary — secrets broker, path-confinement,
+  SSRF-guarded fetch client — so it flags rolled-its-own bypass; absent a
+  list it infers from the codebase.
 - `quality-engineer` — testability,
   observability, reliability, and maintainability lens. Also drafts
   contract or construction tests on request.


### PR DESCRIPTION
## What does this change?

Strengthens the `security-reviewer` along three axes (RFC-0029 / ADR-0018): it now runs a **spec-stage secure-design mode** at the work-loop's pre-EXECUTE step on the security-boundary trigger (shift-left), reasons along a **current multi-framework stack** (OWASP Top 10:2025, ASVS 5.0, API Security Top 10:2023, LLM Top 10:2025, CWE Top 25, STRIDE + LINDDUN), and pulls its depth from a new **orchestrator-loaded `security-checklists` skill** of ten boundary-keyed modules — so the lens is deep without bloating the prompt and ships to every adapter with **no contract change**.

## Why?

- Implements: `docs/specs/security-reviewer-shift-left/spec.md` (14/14 ACs)
- Follows from: RFC-0029 (Accepted), ADR-0018 (Accepted); complements ADR-0017's SAST/SCA gate (reasoning lens above the scanners, not a replacement)

## How do I verify it?

- `make build-check` — green, including the full SAST gate (Bandit / pip-audit / Semgrep).
- Spec ACs are goal-based; spot-check:
  - `ls packs/core/.apm/skills/security-checklists/references/` → 10 modules, each tagging `tool`/`hybrid`/`reason` and naming a standard+version.
  - `grep -c 2021 packs/core/.apm/agents/security-reviewer.md` → 0 (now cites OWASP 2025); `## Spec-stage secure-design mode` present.
  - Risk-trigger block in `work-loop/SKILL.md` is byte-identical to `origin/main` (regression-checked).
  - Adopter-clean: `grep -ri 'write_jailed\|credbroker\|sso-broker'` over the shipped skill (source + projections) → empty.
- **AC5 manual QA (routing determinism):** an SSRF-shaped diff (input-influenced outbound URL) matches exactly one routing-table row → loads `outbound-ssrf` only, not all ten modules. Selection traces to a named table row, not a relevance score.

## What did you not change that you considered?

- **No adapter-contract change** — the `skill` primitive already projects `direct-directory` everywhere; bumping the agent primitive's contract was rejected (RFC-0029 option 5).
- **No new mandatory `security.md` file** — convention awareness rides existing surfaces (`AGENTS.md` blessed-helpers point + retained conditional `security.md` reads + inference fallback).
- **Did not run `security-reviewer` on this PR** — the diff changes no security-boundary *code* (skill/agent prose, docs, version bumps only); the code-threat lens has no surface here. adversarial-reviewer and quality-engineer (whole-spec coverage) both returned `Clean`.
- **Did not collapse the 10 modules** (RFC Open Q1) — ship 10, collapse only on observed co-firing redundancy.

**Bundled fixes / ride-alongs (user-requested):** `README.md` reviewer-table refresh for the security lens, and a one-line refresh of the `quality-engineer` lens documenting the already-shipped universal-quality-floor work (#285); the `AGENTS.md` security-reviewer lens text was refreshed alongside the new blessed-helpers point.

**Maintainability note (quality-engineer, non-blocking):** the boundary→module routing table and the modules' hard-coded OWASP `A0x:2025` category numbers have no automated guard — a future module rename must be propagated by hand across the routing table, the skill index, and the agent body. Acceptable for a prose deliverable shipping as one unit.

## Checklist

- [x] Tests pass locally (`make build-check`, incl. SAST)
- [x] Lint and typecheck pass (`make lint-packs`, `lint-spec-status`)
- [x] Self-review: `adversarial-reviewer` + `quality-engineer` both `Clean`; `security-reviewer` n/a (no security-boundary code)
- [x] Spec and code agree (spec marked Shipped, 14/14 ACs checked in this PR)
- [x] `docs/product/changelog.md` `[Unreleased]` entry added
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured (existing conventions covered this loop; no new doc/skill needed)