### PR TITLE
docs: adoption-focused READMEs + agentbundle 0.3.1 / credbroker 0.1.1 doc releases

### DIFF
--- a/.agentbundle/lib/credbroker/__init__.py
+++ b/.agentbundle/lib/credbroker/__init__.py
@@ -48,7 +48,7 @@ from ._core import (
 from ._core import _parse_schema as parse_schema
 from ._core import _tier2_backend_label as tier2_backend_label
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = [
     # Resolver + container.

--- a/README.md
+++ b/README.md
@@ -1,34 +1,37 @@
 # agent-ready-repo
 
 **A loop your coding agent can't cut corners in.**
-Loop engineering for any repo, any agent — a plan → execute → verify → review loop with gates it can't pass on red and a reviewer that reads every diff cold.
+
+Loop engineering for any repo, any agent. Plan, execute, verify, review. Gates it can't pass on red. A reviewer that reads every diff cold.
 
 [![PyPI](https://img.shields.io/pypi/v/agentbundle)](https://pypi.org/project/agentbundle/)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](#license)
 
 > "You shouldn't be prompting coding agents anymore. You should be designing loops that prompt your agents." — [Peter Steinberger](https://x.com/steipete/status/2063697162748260627)
 
-The leverage in agent coding has moved from the prompt to the **loop** — the system that plans, executes, verifies, and decides what's next without you babysitting each turn. The catch is the part everyone skips: *a loop running unattended is also a loop making mistakes unattended.* So the loop has to verify its own work harder than you would.
+The leverage in agent coding moved from the prompt to the **loop**. The loop plans, executes, verifies, and decides what comes next. You stop babysitting every turn.
 
-The `core` pack **is** that loop — built so the agent **cannot self-certify its way out of it**, and shipped as Markdown you can read, edit, and `git diff`. Not a framework, not a service. Files.
+Here's the part most people skip. A loop running unattended is also a loop making mistakes unattended. So it has to check its own work harder than you would.
+
+`core` is the flagship pack. It's loop engineering made concrete: the planning discipline, the hard gates, and the cold-eyed review, working as one loop. The agent can't self-certify its way out of it.
 
 ```bash
 pip install agentbundle
 agentbundle install --pack core git+https://github.com/eugenelim/agent-ready-repo
 ```
 
-One line lands the loop in your repo. Any agent that reads a skill file — Claude Code, Codex, Cursor, Copilot, Kiro — inherits it.
+One line lands the loop in your repo. Any agent that reads a skill file inherits it: Claude Code, Codex, Cursor, Copilot, Gemini, Kiro.
 
 ## The loop
 
-Most agent workflows are `prompt → code → ship`. `core` replaces that one-shot path with a loop that separates the *maker* from the *verifier* and refuses to skip a step:
+Most agent workflows are `prompt → code → ship`. `core` replaces that one-shot path. It splits the maker from the verifier, and it won't skip a step.
 
-1. **Plan with surfaced assumptions.** Before any code, the agent writes what it's building, what it's *not* touching, and the assumptions it's making. When an assumption breaks mid-flight, the loop tells it to **stop and surface** — not guess past it.
-2. **Mechanical gates between every "done" and the actual finish.** Lint, typecheck, and tests run as hard gates. There is no path through the loop that lets the agent declare success past a red gate.
-3. **Adversarial review in a fresh session.** Once gates pass, a specialist reviewer reads the diff *cold* — no investment in the design, no sunk cost in the code. The loop iterates (fix → re-review) until the reviewer reports `Clean — ready to commit.`
-4. **Capture-learnings, because the model forgets and the repo doesn't.** When a run trips over an undocumented convention, the gap lands as a candidate edit to `CONVENTIONS.md`. The agent's mistakes become the project's memory instead of evaporating at the end of the session.
+1. **Plan, and surface the assumptions.** Before any code, the agent writes down what it's building, what it won't touch, and what it's assuming. When an assumption breaks mid-run, the loop makes it stop and say so. No guessing past the problem.
+2. **Hard gates between "done" and done.** Lint, typecheck, and tests run as gates. No path through the loop lets the agent claim success on a red gate.
+3. **Adversarial review in a fresh session.** Once the gates pass, a specialist reviewer reads the diff cold. No attachment to the design. No sunk cost in the code. The loop fixes and re-reviews until the reviewer says `Clean — ready to commit.`
+4. **Capture what it learned.** The model forgets between sessions. The repo doesn't. When a run trips over an undocumented convention, the gap lands as a proposed edit to `CONVENTIONS.md`. Mistakes become the project's memory instead of evaporating when the session ends.
 
-The reviewer isn't one generic critic — three sharp lenses, dispatched by what the change actually touches:
+The reviewer isn't one generic critic. It's three sharp lenses, picked by what the change actually touches:
 
 | Reviewer | Lens | When it runs |
 | --- | --- | --- |
@@ -38,37 +41,51 @@ The reviewer isn't one generic critic — three sharp lenses, dispatched by what
 
 The security lens **shifts left**: on security-boundary work it runs at spec stage as design guidance — catching a missing control as a one-sentence acceptance criterion instead of a post-implementation round-trip — and pulls its depth from a progressive-disclosure checklist library scoped to the boundaries a change actually crosses, so the review stays current (OWASP 2025, ASVS, CWE Top 25) without bloating the prompt. The quality lens holds every diff to a default quality floor — the universal maintainability smells and the mutation-testing mindset a strict static-analysis gate would enforce — applied by doctrine, whether or not such a gate is wired in.
 
-A fourth subagent, `implementer`, is the loop's own executor for running independent tasks in parallel.
+A fourth subagent, `implementer`, is the loop's own executor. It runs independent tasks in parallel.
 
-→ The full walkthrough — how the parts compose, and how it compares to vibe-coding, GitHub's Spec Kit, and Kiro's spec mode — is in [The core pack as a system](docs/guides/explanation/core-pack.md).
+→ Want the whole picture? [The core pack as a system](docs/guides/explanation/core-pack.md) walks through how the parts compose, and how it compares to vibe-coding, GitHub's Spec Kit, and Kiro's spec mode.
 
 ## The catalogue
 
-`core` is the loop. Everything else is à la carte — install only what your repo needs, at repo or user scope, one line each.
+`core` is the flagship pack. It's the loop itself. Everything else is à la carte. Install only what your repo needs, at repo or user scope, one line each.
 
 | Pack | Scope | What it ships |
 | --- | --- | --- |
-| [`core`](packs/core/) | **repo** | The loop: `work-loop`, `new-spec`, `bug-fix`, `adapt-to-project` skills, the four reviewer/executor subagents, `pre-pr` + `session-start` hooks, and governance seeds. **Install this even if you install nothing else.** |
-| [`governance-extras`](packs/governance-extras/) | repo | RFC/ADR ceremony — `new-rfc`, `new-adr`, `update-conventions` plus the `docs/rfc/` and `docs/adr/` shapes. |
+| [`core`](packs/core/) | **repo** | **The flagship pack.** The loop: `work-loop`, `new-spec`, `bug-fix`, `adapt-to-project` skills, the four reviewer/executor subagents, `pre-pr` + `session-start` hooks, and governance seeds. **Install this even if you install nothing else.** |
+| [`governance-extras`](packs/governance-extras/) | repo | RFC/ADR ceremony for teams and long-lived repos that need a written trail for decisions — `new-rfc`, `new-adr`, `update-conventions` plus the `docs/rfc/` and `docs/adr/` shapes. |
 | [`user-guide-diataxis`](packs/user-guide-diataxis/) | repo | Diátaxis docs skeleton — `docs/guides/{tutorials,how-to,reference,explanation}` plus `new-guide`. |
 | [`monorepo-extras`](packs/monorepo-extras/) | repo | Monorepo scaffolding — `new-package` and a `packages/_example/` template. |
+| [`research`](packs/research/) | user / repo | Evidence-grounded research — `research`, `source-map`, `compare-hypotheses`, `devils-advocate`, and more, plus two retrieval subagents. |
 | [`contracts`](packs/contracts/) | user / repo | Contract authoring — `api-contract` for OpenAPI 3.1. |
 | [`converters`](packs/converters/) | user / repo | `file-to-markdown` (PDF/DOCX/PPTX/XLSX + images), `markdown-to-html`, `msg-to-markdown`, `mermaid-renderer`. |
 | [`atlassian`](packs/atlassian/) | user / repo | `jira`, `jira-align`, `confluence-crawler`, `confluence-publisher` (credentialed) plus `flow-metrics`, `ai-adoption-report`, `jira-defect-flow`. |
 | [`figma`](packs/figma/) | user / repo | Figma REST primitive (credentialed) — reads files/nodes/comments/variables, renders frames, FigJam → Mermaid. |
 | [`architect`](packs/architect/) | user / repo | Solution architecture — `architect-design`, `architect-diagram`, `architect-review`. |
 
-*Repo-scope* packs install into the current repo and build on `core`. *User-scope* packs install into `~/.claude/` (or your harness's home root) and follow you across every project. Swap `core` for any pack name in the install command above.
+Repo-scope packs install into the current repo and build on `core`. User-scope packs install into `~/.claude/` (or your harness's home root) and follow you across every project. Swap `core` for any pack name in the command above.
 
-## An ecosystem building block
+## Ecosystem building blocks
 
-The `work-loop` skill is a Markdown file. Each reviewer is a Markdown file. The bundler installs them as plain-text primitives — **no SDK, no runtime, no service to host, no proprietary harness to lock into.** That's what makes this a building block and not a walled garden:
+Nothing here is a black box. Every piece is something you can pick up and use on its own.
 
-- **Harness-agnostic.** One adapter pipeline projects the same primitives into Claude Code, Codex, Copilot, and Kiro layouts. Cursor reads `AGENTS.md` directly.
-- **Inspectable and forkable.** The mechanics are prose you can read and `git diff`. When you outgrow a default, you edit the file — you don't file a feature request.
-- **Composable.** Packs layer cleanly; your edits are never silently overwritten — colliding files land as `*.upstream` companions to merge, not clobber.
+Your skills, subagents, and hooks are files you own, with no SDK, runtime, or service to run, and nothing proprietary to lock into. You version and compose them like any other code in your repo.
 
-Loop engineering relocates judgment rather than removing it. Plain-text primitives keep that judgment where you can exercise it — *build the loop like someone who intends to stay the engineer, not just the person who presses go.*
+- **Harness-agnostic.** One adapter pipeline projects the same primitives into Claude Code, Codex, Copilot, Cursor, Gemini, and Kiro layouts.
+- **Inspectable and forkable.** The mechanics are prose you can read and `git diff`. When you outgrow a default, you edit the file instead of filing a feature request.
+- **Composable.** Packs layer cleanly. Your edits are never silently overwritten. Colliding files land as `*.upstream` companions for you to merge, not clobber.
+
+The two packages underneath are building blocks in their own right. Both are pip-installable, standalone, and useful well beyond this repo:
+
+- **[`agentbundle`](https://pypi.org/project/agentbundle/)** — the bundler. It installs and upgrades packs, projects each primitive into the layout every agent expects, and builds catalogues of your own. `pip install agentbundle`
+- **[`credbroker`](https://pypi.org/project/credbroker/)** — the credential resolver behind credentialed skills. It resolves secrets in-process through environment variable → OS keyring → dotfile, and never lets cleartext reach the model. Drop it into any Python project. `pip install credbroker`
+
+Loop engineering relocates judgment, it doesn't remove it. Keeping every piece inspectable and composable keeps that judgment where you can exercise it. You stay the engineer, not just the person who presses go.
+
+## A foundation to build on
+
+Adopt the catalogue as-is, or use it as the base for your own. The same bundler that installs these packs can publish yours: fork them, write your house conventions and review standards into `core`, add skills for your own stack, and ship one catalogue that every engineer installs in a single line. The loop, the reviewers, and the standards come out identical on every machine and in every agent.
+
+That makes this a foundation for an organization's AI dev kit, not just a set of defaults to consume.
 
 ## Going deeper
 
@@ -82,11 +99,11 @@ Loop engineering relocates judgment rather than removing it. Plain-text primitiv
 | Mission, scope, and the four principles | [`docs/CHARTER.md`](docs/CHARTER.md) |
 | The catalogue distribution model | [RFC-0001](docs/rfc/0001-bundle-distribution-by-adapter-spec.md) |
 
-Skills follow the [agentskills.io specification](https://agentskills.io/specification) — each is a self-contained folder with closed frontmatter and no hidden cross-skill dependencies, so they install, copy, and audit cleanly.
+Skills follow the [agentskills.io specification](https://agentskills.io/specification). Each is a self-contained folder with closed frontmatter and no hidden cross-skill dependencies. They install, copy, and audit cleanly.
 
 ## Contributing
 
-Adding a pack, skill, or subagent? See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the three contribution lanes, the pack source-of-truth split, and the gates your PR has to pass.
+Adding a pack, skill, or subagent? [`CONTRIBUTING.md`](CONTRIBUTING.md) has the three contribution lanes, the pack source-of-truth split, and the gates your PR has to pass.
 
 ## License
 

--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -6,6 +6,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 — a minor bump on a 0.x release MAY be breaking.
 
+## [0.3.1] — 2026-06-12
+
+### Changed
+
+- **README rewritten for adoption** — quick start, a common-commands
+  reference, and the "npm for your coding agent" framing; the PyPI summary
+  now matches.
+- **Static-analysis annotations** carried in from the repo's SAST gate
+  (ADR-0017): `# nosec B310` on the constant-base GitHub-archive fetch and
+  `usedforsecurity=False` on the non-security finding-ID digest. No runtime
+  behaviour change.
+
 ## [0.3.0] — 2026-06-12
 
 ### Added

--- a/packages/agentbundle/README.md
+++ b/packages/agentbundle/README.md
@@ -1,19 +1,63 @@
 # agentbundle
 
-Runtime library and reference CLI for the
-[agent-ready-repo](https://github.com/eugenelim/agent-ready-repo) adapter
-contract. Ships the `agentbundle` console script — install, validate,
-adapt, and inspect packs — plus the build pipeline (`agentbundle.build`)
-that projects pack sources into adapter-shaped trees.
+[![PyPI](https://img.shields.io/pypi/v/agentbundle)](https://pypi.org/project/agentbundle/)
+[![Python](https://img.shields.io/pypi/pyversions/agentbundle)](https://pypi.org/project/agentbundle/)
+[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](https://github.com/eugenelim/agent-ready-repo#license)
 
-As of 0.2.0 the `agentbundle.credentials` module that earlier releases
-(0.1.x) exposed has been removed — `agentbundle` no longer ships a
-credential-resolution module. Since RFC-0023, `auth: creds` consumers
-resolve credentials through the standalone, pip-installable `credbroker`
-library, imported in-process (`from credbroker import …`); it replaced the
-build-projected `credentials_shim` sibling, which now survives only as the
-`sso-broker` companion. See the `credbroker` package, RFC-0023, and this
-package's `CHANGELOG.md` for the migration history.
+**The installer for [agent-ready-repo](https://github.com/eugenelim/agent-ready-repo).** Think npm, but for the skills, subagents, and hooks your coding agent runs on.
 
-See the [top-level README](https://github.com/eugenelim/agent-ready-repo#readme)
-for install routes, the pack catalogue, and the adapter contract.
+`agentbundle` installs packs of agent primitives into your repo or your home directory. It projects each primitive into the layout every agent expects. One pack. One command. Every major agent.
+
+```bash
+pip install agentbundle
+agentbundle install --pack core git+https://github.com/eugenelim/agent-ready-repo
+```
+
+That lands `core`, the flagship pack and the loop itself, in your repo. Claude Code, Codex, Cursor, Copilot, Gemini, and Kiro all read it.
+
+## Common commands
+
+```bash
+# See what's in a catalogue
+agentbundle list-packs git+https://github.com/eugenelim/agent-ready-repo
+
+# Install the flagship loop into this repo
+agentbundle install --pack core git+https://github.com/eugenelim/agent-ready-repo
+
+# Install a pack at user scope, so it follows you across every project
+agentbundle install --pack research git+https://github.com/eugenelim/agent-ready-repo --scope user
+
+# Preview an install without writing a file
+agentbundle install --pack core git+https://github.com/eugenelim/agent-ready-repo --dry-run
+
+# Upgrade a pack; it reports the .upstream files you need to reconcile
+agentbundle upgrade --pack core --to 0.4.0 git+https://github.com/eugenelim/agent-ready-repo
+```
+
+A catalogue is a git URL or a local path. Installs auto-detect your agent; pass `--adapter` to override.
+
+## Build your own catalogue
+
+`agentbundle` isn't tied to the agent-ready-repo catalogue. Any repo that lays its packs out the same way can use it. A pack is a directory:
+
+```text
+my-pack/
+  pack.toml                  # name, version, adapter-contract, install scope
+  .apm/
+    skills/<name>/SKILL.md    # one folder per skill
+    agents/<name>.md          # subagents
+    hooks/<name>.py           # lifecycle hooks
+  seeds/                      # files scaffolded into the adopter repo
+```
+
+Point a catalogue URI (a git URL or a local path) at the repo that holds your packs. Then `validate` a pack against the adapter contract, `render` it to preview the projection, and `install` it into a target repo. `scaffold` drops a pack's seeds into a fresh directory to start from. The build pipeline (`agentbundle.build`) is the same engine `make build` runs.
+
+See the [pack layout reference](https://github.com/eugenelim/agent-ready-repo/blob/main/docs/architecture/pack-layout.md) and [authoring a skill](https://github.com/eugenelim/agent-ready-repo/blob/main/docs/guides/how-to/author-a-skill.md).
+
+## Credentials
+
+`agentbundle` doesn't resolve secrets. Credentialed skills use [`credbroker`](https://pypi.org/project/credbroker/), a standalone resolver that keeps cleartext out of the model's reach.
+
+## Learn more
+
+The full story — the loop, the reviewers, the pack catalogue — is in the [agent-ready-repo README](https://github.com/eugenelim/agent-ready-repo#readme).

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentbundle"
-version = "0.3.0"
-description = "Reference CLI and distribution pipeline for the agent-ready-repo adapter contract."
+version = "0.3.1"
+description = "npm for your coding agent. Install packs of skills, subagents, and hooks into any repo, for every major agent."
 requires-python = ">=3.11"
 dependencies = []
 authors = [{ name = "eugenelim", email = "eugenelim@users.noreply.github.com" }]

--- a/packages/credbroker/CHANGELOG.md
+++ b/packages/credbroker/CHANGELOG.md
@@ -1,0 +1,22 @@
+# credbroker changelog
+
+All notable changes to the `credbroker` Python package.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
+the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
+— a minor bump on a 0.x release MAY be breaking.
+
+## [0.1.1] — 2026-06-12
+
+### Changed
+
+- **README rewritten for adoption** — badges, a corrected attribute-access
+  usage example (`creds.API_TOKEN`), an explicit per-OS resolution model
+  (macOS Keychain / Windows Credential Manager / dotfile floor elsewhere),
+  and absolute documentation links that render on the PyPI project page.
+
+## [0.1.0] — 2026-06-10
+
+Initial public release (RFC-0023): in-process three-tier credential
+resolver (environment variable → OS keyring → `0600` dotfile floor), with
+an optional encrypted-at-rest vault under the `[crypto]` extra.

--- a/packages/credbroker/README.md
+++ b/packages/credbroker/README.md
@@ -1,41 +1,63 @@
 # credbroker
 
-A standalone, pip-installable credential resolver for credentialed agent
-skills. Resolves secrets **in-process** through three tiers —
-environment variable → OS keyring → a `0600` dotfile floor — and never lets a
-cleartext value cross a process boundary to the LLM.
+[![PyPI](https://img.shields.io/pypi/v/credbroker)](https://pypi.org/project/credbroker/)
+[![Python](https://img.shields.io/pypi/pyversions/credbroker)](https://pypi.org/project/credbroker/)
+[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](https://github.com/eugenelim/agent-ready-repo#license)
 
-> Status: **published on PyPI** — `credbroker 0.1.0` (2026-06-10, RFC-0023).
-> Install from PyPI (`pip install credbroker`, or `credbroker[crypto]` for the
-> encrypted vault), or from the repo path for local development
-> (`pip install -e ./packages/credbroker`).
+**Resolve secrets for agent skills without leaking them to the model.**
+
+`credbroker` is a standalone, pip-installable credential resolver. It reads a secret in-process, walks three tiers, and never lets a cleartext value cross a process boundary to the LLM. The core is stdlib-only, with no third-party dependency.
 
 ## Install
 
 ```bash
-pip install credbroker                          # stdlib-only core, from PyPI
-pip install 'credbroker[crypto]'                # + encrypted-at-rest vault
-
-# Or work against a repo clone — an editable install for local development
-# (no PyPI needed; same import, the repo copy wins on sys.path):
-pip install -e ./packages/credbroker
-pip install -e './packages/credbroker[crypto]'
+pip install credbroker              # stdlib-only core
+pip install 'credbroker[crypto]'    # + encrypted-at-rest vault
 ```
 
-The core has **no third-party dependency**. The `[crypto]` extra adds
-`cryptography` + `argon2-cffi` for an encrypted-at-rest vault at the floor tier;
-without it, resolution degrades to the keyring/plaintext-dotfile floor.
-
 ## Use
+
+`credbroker` is a plain Python library. It works in any program, agent, or skill — no framework and no agent-ready-repo install required.
+
+Resolve a namespace's credentials in one call:
 
 ```python
 from credbroker import load_credentials
 
-# Keys are used verbatim; only the namespace is upper-cased to compose the
-# env / dotfile name (here: JIRA_BASE_URL, JIRA_API_TOKEN). Use upper-case keys.
+# Keys are used verbatim. The namespace is upper-cased to compose the
+# env / dotfile name: here, JIRA_BASE_URL and JIRA_API_TOKEN.
 creds = load_credentials("jira", required_keys=["BASE_URL", "API_TOKEN"])
+
+connect(creds.BASE_URL, token=creds.API_TOKEN)   # attribute access returns the value
 ```
 
-See [`docs/specs/credbroker/spec.md`](../../docs/specs/credbroker/spec.md) for
-the full contract and [RFC-0023](../../docs/rfc/0023-credential-manager-broker.md)
-for the rationale.
+A typical agent skill resolves its namespace once, up front, and fails loud if a secret is missing — so the agent surfaces a setup prompt instead of firing a half-filled request:
+
+```python
+from credbroker import load_credentials, CredentialsMissingError
+
+def jira_session():
+    try:
+        creds = load_credentials("jira", required_keys=["BASE_URL", "API_TOKEN"])
+    except CredentialsMissingError as exc:
+        raise SystemExit(str(exc))   # clear setup guidance, no broken call
+    return Session(creds.BASE_URL, token=creds.API_TOKEN)
+```
+
+The returned object is immutable, and its `repr` lists key names only. A stray `print(creds)` can't echo token bytes.
+
+## How it resolves
+
+`credbroker` walks three tiers and returns the first hit:
+
+1. **Environment variable** — `JIRA_API_TOKEN`. Good for CI and ephemeral shells.
+2. **OS keyring** — the platform's native secret store. macOS uses the Keychain. Windows uses Credential Manager. The backend is chosen at import time from `sys.platform`.
+3. **Dotfile floor** — a `0600` dotfile, or an encrypted-at-rest vault with the `[crypto]` extra (Argon2id, then AES-256-GCM).
+
+Linux and other platforms have no keyring tier. Resolution skips straight from the environment variable to the dotfile floor. Without `[crypto]`, that floor is the plaintext `0600` dotfile.
+
+## Learn more
+
+For local development, install from a repo clone: `pip install -e ./packages/credbroker`.
+
+See the [full contract](https://github.com/eugenelim/agent-ready-repo/blob/main/docs/specs/credbroker/spec.md) and [RFC-0023](https://github.com/eugenelim/agent-ready-repo/blob/main/docs/rfc/0023-credential-manager-broker.md) for the rationale.

--- a/packages/credbroker/credbroker/__init__.py
+++ b/packages/credbroker/credbroker/__init__.py
@@ -48,7 +48,7 @@ from ._core import (
 from ._core import _parse_schema as parse_schema
 from ._core import _tier2_backend_label as tier2_backend_label
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = [
     # Resolver + container.

--- a/packages/credbroker/pyproject.toml
+++ b/packages/credbroker/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "credbroker"
-version = "0.1.0"
+version = "0.1.1"
 description = "Standalone, pip-installable credential resolver for credentialed agent skills (env -> OS keyring -> dotfile, with an optional encrypted-at-rest vault)."
 requires-python = ">=3.11"
 dependencies = []

--- a/packs/credential-brokers/.apm/user-libs/credbroker/__init__.py
+++ b/packs/credential-brokers/.apm/user-libs/credbroker/__init__.py
@@ -48,7 +48,7 @@ from ._core import (
 from ._core import _parse_schema as parse_schema
 from ._core import _tier2_backend_label as tier2_backend_label
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = [
     # Resolver + container.


### PR DESCRIPTION
## What

Adoption-focused rewrite of the root README plus two documentation releases of the shipped packages.

### Root README (`docs`)
- Rewritten for tight, human prose — short sentences, no staccato-emphasis tics (dropped `Not a framework. Not a service. Files.`, the four-fragment `No SDK…` run, the walled-garden contrast), modest framing per what resonates with the senior-engineer / HN audience.
- Flagship-pack wording; `core` positioned as "loop engineering made concrete."
- Drift fixes: Cursor and Gemini are now full adapters (0.3.0); added the missing `research` pack to the catalogue table; governance-extras row now states who it's for.
- New **Ecosystem building blocks** section ties the primitives and the two packages together; new **A foundation to build on** section for the org / dev-kit audience.

### `release(agentbundle): 0.3.1`
- README rewritten for adoption (value prop, badges, verified common-commands block, "build your own catalogue" guide for authors); PyPI summary updated.
- Records the post-0.3.0 SAST annotations (`# nosec B310`, `usedforsecurity=False`). No runtime behaviour change — **not** a security release (the session-start confinement fix already ships via the `core` pack).

### `release(credbroker): 0.1.1`
- README rewritten for adoption: badges, corrected attribute-access usage (`creds.API_TOKEN`), explicit per-OS resolution model (macOS Keychain / Windows Credential Manager / dotfile floor elsewhere — no Linux keyring tier), a standalone + agent-skill usage example, and absolute doc links (the old relative links broke on the PyPI page).
- Version bumped across pyproject + `__version__`; the two vendored mirrors (`packs/credential-brokers/.apm/user-libs/credbroker/`, `.agentbundle/lib/credbroker/`) regenerated via `build-self`. All three copies byte-identical; drift gate stays green.

## Releasing
Both releases are tag-driven and **not** triggered by this PR. After merge to `main`, push `agentbundle-v0.3.1` and `credbroker-v0.1.1` to fire the respective release workflows.

## Out of band
The GitHub repo description and 20 topics were updated directly via the API; they are not part of this diff.
