### PR TITLE
feat(architect): well-architected cloud design + review, convergence loop (0.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
     {
       "description": "Solution-architecture skills (architect-design, architect-diagram, architect-review). Workspace-agnostic, user-scope by default, no required configuration.",
       "name": "architect",
-      "version": "0.1.0"
+      "version": "0.2.0"
     },
     {
       "description": "Atlassian primitives: jira / jira-align / confluence-crawler (credentialed CLI), plus the flow-metrics, ai-adoption-report, and jira-defect-flow workflows that compose them.",

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -19,6 +19,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The `architect` pack designs *and* reviews cloud architecture to the
+  well-architected standard, and the design skill now converges (architect pack
+  0.2.0).** `architect-design` shapes a one-page **concept first**, makes the
+  design **well-architected by construction** for the chosen provider — AWS /
+  Azure / GCP, **primitives providers like Hetzner** (it names the capability
+  gaps you must build yourself), or **local-first** (the local→production delta +
+  graduation path) — and then runs a **convergence loop**: it obtains a review
+  pass, **auto-resolves the mechanical findings** without asking, re-reviews, and
+  **surfaces only the judgment calls** (tradeoffs, risk acceptances,
+  low-confidence assumptions) to you as decisions. `architect-review` gains a
+  **well-architected / lens mode** (security · FinOps · SRE · DR · data ·
+  compliance · green concern-lenses, plus ML / **GenAI-agentic** / SaaS /
+  serverless workload-class lenses) that emits a risk register with every finding
+  tagged **mechanical / judgment** — the signal the design loop consumes. The
+  loop is an enhancement when both skills are present and degrades to an embedded
+  rubric self-check when it isn't; for genuinely novel domains the design takes a
+  **leading-edge path** that composes with the `research` skill when available and
+  degrades to flagged-novelty + lowered-confidence when absent. Pure-markdown, no
+  subagents, no new pack; the loop is an in-conversation procedure with no script
+  or state file. `architect-diagram` gains a `cloud-primitives` diagram vocab for
+  parity with its AWS/Azure/GCP references.
 - **The `security-reviewer` is stronger, current, and shifts left (core pack 0.4.0).**
   Security review is no longer only a late gate: on security-boundary work the
   `work-loop` now dispatches the reviewer in a **spec-stage secure-design mode**

--- a/docs/specs/well-architected-cloud/fixtures/brief-agentic-hetzner.md
+++ b/docs/specs/well-architected-cloud/fixtures/brief-agentic-hetzner.md
@@ -1,0 +1,63 @@
+# Dogfood brief — agentic platform on Hetzner
+
+> **Fixture for `well-architected-cloud` manual QA.** Feed this brief to
+> `architect-design` and `architect-review`. Referenced by path so the gesture
+> is replayable. The *Planted findings* block at the bottom records what this
+> fixture is engineered to exercise — it is QA scaffolding, not part of the
+> brief the skill reasons over.
+
+## The brief
+
+We're building **A2UI** — a multi-agent assistant that drives a web UI on the
+user's behalf. A planner agent decomposes a request; worker agents call tools
+(search, a code-runner, an email-sender) and can **take actions in the UI**
+(fill forms, click, submit). We want to ship on **Hetzner Cloud** to keep the
+bill flat and predictable.
+
+Current thinking:
+
+- A few `cx`-class cloud servers behind a Hetzner load balancer.
+- Conversation state and tool results in **self-managed Postgres** on a server
+  we run ourselves.
+- The agents call an **external hosted LLM API** for reasoning; user
+  conversation context (which can include uploaded internal documents) is sent
+  in the prompt.
+- We want it to be **highly available** — the assistant shouldn't go down.
+
+Constraints: small founding team, cost-sensitive, EU users (data should stay in
+the EU). No managed-cloud commitment yet — Hetzner is the call.
+
+Questions for the design: is Hetzner the right substrate? How do we make it
+production-grade? Should we keep using the external LLM API or self-host
+inference?
+
+---
+
+## Planted findings (QA scaffolding — not part of the brief)
+
+This fixture is engineered so the skills surface specific things:
+
+- **(a) Auto-resolved mechanical finding.** The internal-document →
+  external-LLM-API call crosses a **trust boundary the brief leaves unlabeled**.
+  The pillar spine determines it must be labeled; labeling it is determinate, so
+  the convergence loop should **auto-resolve** it (add the boundary + name the
+  egress) without asking.
+- **(b) Stasis-escape mechanical finding.** "Highly available" with
+  **self-managed Postgres but no stated RPO/restore target** and no constraint
+  that determines one. "State the recovery target" is spine-required (looks
+  mechanical), but the *value* is underivable from anything given — so the loop
+  cannot determinately fix it, it survives a pass, and the **stasis escape**
+  escalates it to the human rather than looping.
+- **Judgment finding (never auto-resolved).** **Self-host inference vs. external
+  LLM API** is a tradeoff (control + EU data-residency vs. operational burden +
+  capability lag). The loop must **surface** it as a decision, never pick a side.
+
+Expected `architect-design` concept observables: names the **primitives class** +
+at least the **data-tier** and **edge/CDN** capability gaps; prioritizes
+**Security (agentic)** + **Performance**; surfaces the self-host-vs-external call
+as a tradeoff / sensitivity point.
+
+Expected `architect-review` WA-mode observables (GenAI/agentic + security
+lenses): a risk register naming the **internal-data → external-LLM egress
+boundary** and the **A2UI surface-authority risk** (a worker agent that can act
+in the UI is a confused-deputy surface), each finding mechanical/judgment-tagged.

--- a/docs/specs/well-architected-cloud/fixtures/brief-enterprise-brain.md
+++ b/docs/specs/well-architected-cloud/fixtures/brief-enterprise-brain.md
@@ -1,0 +1,45 @@
+# Dogfood brief — enterprise brain (leading-edge domain)
+
+> **Fixture for `well-architected-cloud` manual QA.** A design brief in a domain
+> with **no shipped pillar/lens/provider reference** — it exists to exercise the
+> leading-edge path. Referenced by path so the gesture is replayable.
+
+## The brief
+
+We want to build an **"enterprise brain"** — a continuously-updated, queryable
+model of everything the company knows. It ingests documents, conversations,
+tickets, and code; maintains **living ontologies** that evolve as the business
+changes; tracks **provenance** (where each fact came from, how confident we are);
+and serves both humans and agents that reason over it.
+
+Open shape:
+
+- Should the knowledge model be **one centralized ontology** or **federated**
+  per-domain ontologies that reconcile at query time?
+- How do we represent **memory** — episodic (what happened) vs. semantic (what's
+  true) vs. procedural (how we do things)?
+- How do we **govern** a model that changes itself — provenance, access, the
+  right to be forgotten, drift?
+
+Constraints: this is genuinely novel territory; the patterns aren't settled
+practice yet. We need an architecture concept we can defend, with the
+uncertainty named honestly.
+
+---
+
+## Expected observables (QA scaffolding — not part of the brief)
+
+- `architect-design` recognizes **no shipped reference covers this domain** and
+  takes the **leading-edge path** (`leading-edge-domains.md`): **flags the
+  novelty** explicitly.
+- **Composes with the `research` skill** (`applied` / `deep`) when it is
+  installed to survey current grey literature; **degrades** to first-principles +
+  flagged-novelty + **lowered confidence** when `research` is absent — never
+  erroring or requiring it.
+- **Synthesizes an ad-hoc enterprise-brain lens** for this engagement (memory
+  types / knowledge stratums / provenance / governance) rather than forcing the
+  brief into a cloud pillar reference.
+- Surfaces the **centralized-vs-federated-ontology** decision as a **judgment
+  finding** carrying **source + confidence** — never auto-resolved.
+- Ships **no enterprise-brain content in the pack** — the lens is built per
+  engagement, not from a committed reference.

--- a/docs/specs/well-architected-cloud/fixtures/brief-hyperscaler.md
+++ b/docs/specs/well-architected-cloud/fixtures/brief-hyperscaler.md
@@ -1,0 +1,37 @@
+# Dogfood brief — hyperscaler (managed services)
+
+> **Fixture for `well-architected-cloud` manual QA.** Exercises the
+> managed-service (Class-1) by-construction path and confirms the primitives
+> "gaps" framing is **not** misapplied. Referenced by path so the gesture is
+> replayable.
+
+## The brief
+
+We're building a **B2B SaaS reporting product** on **AWS**. We're already
+committed to AWS and comfortable using managed services — we'd rather pay for
+managed than run our own. Expected shape:
+
+- API behind **API Gateway** + Lambda / Fargate.
+- **Aurora** (managed Postgres) for the relational store; **DynamoDB** for
+  high-volume event data.
+- **Cognito** for customer identity; **CloudFront** in front of the static app.
+- Multi-AZ from day one; we have an availability target of 99.9%.
+
+Constraints: enterprise customers, SOC 2 on the roadmap, a real on-call rotation.
+
+Question: is this well-architected? What are we missing per pillar?
+
+---
+
+## Expected observables (QA scaffolding — not part of the brief)
+
+- `architect-design` concept names **provider-managed-service pillar
+  achievement** — reliability via Multi-AZ Aurora, security via Cognito + IAM +
+  KMS, performance via managed autoscaling, etc. (the managed service that
+  carries each pillar).
+- It does **not** apply the primitives **"capability gaps you must build
+  yourself"** framing — that framing is for the primitives class, not a
+  hyperscaler with managed services. (Misapplying it here would be the failure
+  this fixture guards against.)
+- The 99.9% target becomes a **quality-attribute scenario** with a measure where
+  the design asserts availability.

--- a/docs/specs/well-architected-cloud/fixtures/brief-local-first.md
+++ b/docs/specs/well-architected-cloud/fixtures/brief-local-first.md
@@ -1,0 +1,36 @@
+# Dogfood brief — founder starting local-first
+
+> **Fixture for `well-architected-cloud` manual QA.** Exercises the local-first
+> provider-class on-ramp. Referenced by path so the gesture is replayable.
+
+## The brief
+
+I'm a solo founder building a **scheduling app**. Right now everything runs on my
+laptop: a single web process, a local Postgres, uploaded files saved to a folder,
+secrets in a `.env`, and I test against `http://localhost`. It works for me and
+two design-partner customers I onboarded manually.
+
+I want to **get it in front of real users** without over-building. What does my
+architecture need to look like to go from "runs on my laptop" to "real people can
+sign up", and how do I get there without boiling the ocean?
+
+Constraints: solo, limited time, limited money, don't want to prematurely adopt a
+big cloud platform.
+
+---
+
+## Expected observables (QA scaffolding — not part of the brief)
+
+- `architect-design` treats **local-first as a legitimate starting topology**,
+  not a mistake to scold.
+- Names the **local→production delta** (`local-dev.md`): what localhost fakes
+  that production must supply — **TLS + real domain**, **real secrets store**, a
+  **durable data tier** (backups + restore), **object storage** for uploads,
+  **observability**, and a **scaling/availability** story.
+- Names a **graduation path** to a chosen provider class (hyperscaler or
+  primitives) and **what becomes real first** (usually TLS + secrets + durable
+  data before CDN/multi-region).
+- Prescribes **no local toolchain** — no docker-compose recipe, no specific
+  images, no named dev dependency. Stays at architecture altitude.
+- The graduation *order* (how much availability before launch) is surfaced as a
+  **judgment** call, not baked into a number.

--- a/docs/specs/well-architected-cloud/fixtures/brief-non-cloud.md
+++ b/docs/specs/well-architected-cloud/fixtures/brief-non-cloud.md
@@ -1,0 +1,33 @@
+# Dogfood brief — non-cloud design question
+
+> **Fixture for `well-architected-cloud` manual QA.** Confirms the Stage-0
+> concept **degrades gracefully** when no provider is in play. Referenced by
+> path so the gesture is replayable.
+
+## The brief
+
+We maintain a **CLI tool** that parses large log files and emits a summary. Users
+run it on their own machines. It's getting slow on multi-GB files and the parser
+code has grown into one tangled module.
+
+We're deciding **how to restructure the parser**: a single streaming pass with a
+state machine, or a two-pass approach (index, then summarize). We want it to stay
+a dependency-light single binary.
+
+Constraints: must stay offline / local (no network calls), must not add heavy
+dependencies, must handle files larger than memory.
+
+Question: which parser shape should we choose, and why?
+
+---
+
+## Expected observables (QA scaffolding — not part of the brief)
+
+- `architect-design`'s **Stage-0 concept still runs**: it shapes **problem /
+  constraints / candidate shapes (streaming vs. two-pass) / quality attributes**
+  (here: performance on large-out-of-memory files, maintainability).
+- It does **not** force **provider selection** or **pillar-by-construction
+  scaffolding** — there is no cloud in play, and the concept doesn't manufacture
+  one.
+- The streaming-vs-two-pass choice is surfaced as the **key tradeoff** (memory
+  footprint vs. random-access flexibility).

--- a/docs/specs/well-architected-cloud/fixtures/qa-notes.md
+++ b/docs/specs/well-architected-cloud/fixtures/qa-notes.md
@@ -1,0 +1,127 @@
+# Dogfood QA notes — well-architected-cloud
+
+Manual QA for the pure-markdown skill + loop behavior, run by exercising the
+enhanced `architect-design` / `architect-review` against the committed brief
+fixtures in this directory. These skills have no runtime; the gesture is the
+agent applying the skill procedure to the brief. Recorded here so the result is
+inspectable and the gesture is replayable.
+
+> Run on 2026-06-12 against the implemented skills. The agentic-hetzner gesture
+> is traced in full because it exercises the concept stage, the convergence
+> loop (auto-resolve / stasis escape / surface-judgment), and WA-mode review;
+> the other four confirm their specific observable.
+
+---
+
+## 1. `brief-agentic-hetzner.md` — design concept + loop + review
+
+### Stage-0 concept (drafted from `assets/concept.md`)
+
+- **Problem & context:** A2UI multi-agent assistant that drives a web UI for the
+  user; planner + worker agents calling tools and acting in the UI.
+- **Constraints:** small team, cost-sensitive, EU data residency, Hetzner (no
+  managed-cloud commitment).
+- **Candidate shapes:** (A) agents on Hetzner cloud servers behind a Hetzner LB,
+  self-managed Postgres, external LLM API; (B) same but self-hosted inference.
+- **Provider / provider-class:** **primitives provider (Hetzner-class)** — by
+  construction, pillars are met by *building them yourself*. Routed to
+  `cloud-primitives.md`; capability gaps named: **managed data tier** (run
+  Postgres + replication + backups yourself), **edge/CDN** (no edge — front the
+  UI yourself), managed identity, serverless. ✅ *names primitives class + data-
+  tier + edge/CDN gaps.*
+- **Top prioritized quality attributes** (business-importance × risk):
+  1. **Security (agentic)** — agents act in the UI and send internal docs to an
+     external LLM; highest blast radius.
+  2. **Performance** — interactive assistant, latency-sensitive.
+  3. Reliability — stateful, but ranked behind the two above. ✅ *prioritizes
+     Security (agentic) + Performance.*
+- **Key tradeoff / open decision:** **self-host inference vs. external LLM API**
+  — control + EU residency vs. operational burden + capability lag. Surfaced as
+  a tradeoff / sensitivity point. ✅
+
+### Convergence loop (`convergence-loop.md`)
+
+Reviewer seeded with artifact + agreed concept + constraints (cold-read floor
+here, since same session; flagged as weaker isolation than a fresh context).
+
+- **Pass 1 findings:**
+  - **F1 🔧 mechanical** — internal-document → external-LLM-API call crosses an
+    **unlabeled trust boundary**. Fix fully determined by the spine → **auto-
+    resolved**: design labels the egress boundary, names what crosses (internal
+    docs in the prompt), flags residency. *(no human asked)* ✅
+  - **F2 🔧 mechanical (provisional)** — "highly available" + self-managed
+    Postgres but **no stated RPO/restore target**. Spine requires a recovery
+    target → attempt to auto-resolve, but **no constraint supplies the value**.
+  - **F3 🧭 judgment** — self-host inference vs. external LLM API (tradeoff).
+    **Not auto-resolved.**
+- **Pass 2 findings:** F1 resolved (boundary now labeled). **F2 reappears** — the
+  loop still can't determine an RPO from anything given. → **stasis escape**:
+  F2 escalated to the human as a judgment finding rather than looped. ✅
+- **Terminates** at pass 2 (no mechanical findings remain that can be resolved;
+  cap not even reached). ✅
+- **Surfaced to human as decisions:** F3 (self-host vs. external) and F2
+  (acceptable RPO / restore target for the data tier). Loop did **not** pick a
+  side on either. ✅ *(never auto-resolve a judgment finding)*
+
+### `architect-review` WA mode (GenAI/agentic + security lenses)
+
+Risk register (`assets/risk-register.md`) names, among others:
+
+- **🔧 mechanical 🟥** — internal-data → external-LLM **egress boundary** unlabeled
+  / un-minimized (determinate: label + minimize prompt payload).
+- **🧭 judgment 🟥** — **A2UI surface-authority risk**: a worker agent that can act
+  in the UI is a confused-deputy surface; how much autonomy/confirmation to
+  require is a risk-acceptance decision.
+- Each finding carries severity **and** a mechanical/judgment tag. ✅
+
+**Result: all agentic-hetzner observables met.**
+
+---
+
+## 2. `brief-enterprise-brain.md` — leading-edge path
+
+- `architect-design` finds **no shipped pillar/lens/provider reference** fits
+  "living ontologies / enterprise brain" → takes `leading-edge-domains.md`:
+  **flags novelty** explicitly. ✅
+- **Composes with `research`** (`applied`/`deep`) when installed for a grey-lit
+  survey; **degrades** to first-principles + flagged novelty + **lowered
+  confidence** when absent (does not error/require it). ✅
+- **Synthesizes an ad-hoc enterprise-brain lens** (memory types / knowledge
+  stratums / provenance / governance) for this engagement only. ✅
+- Surfaces **centralized-vs-federated-ontology** as a **judgment** finding
+  carrying **source + confidence**. ✅
+- Ships **no enterprise-brain content** in the pack (method only). ✅
+
+## 3. `brief-local-first.md` — local-first on-ramp
+
+- Concept treats local-first as a **legitimate starting topology**. ✅
+- Names the **local→production delta** (`local-dev.md`): TLS + domain, secrets
+  store, durable data tier (backups + restore), object storage for uploads,
+  observability, scaling/availability. ✅
+- Names a **graduation path** to a provider class + what becomes real first
+  (TLS + secrets + durable data before CDN/multi-region). ✅
+- Prescribes **no local toolchain** (no docker-compose, no images). ✅
+- Graduation order surfaced as a **judgment** call. ✅
+
+## 4. `brief-hyperscaler.md` — managed-service by-construction
+
+- Concept names **provider-managed-service pillar achievement** (Multi-AZ Aurora
+  → reliability, Cognito + IAM + KMS → security, managed autoscaling →
+  performance, CloudFront → edge). ✅
+- Does **not** apply the primitives **"gaps you must build"** framing — correct,
+  managed services carry the pillars here. ✅
+- 99.9% target framed as a quality-attribute scenario with a measure. ✅
+
+## 5. `brief-non-cloud.md` — graceful degradation
+
+- Stage-0 concept **still runs**: problem / constraints / candidate shapes
+  (streaming vs. two-pass) / quality attributes (large-file performance,
+  maintainability). ✅
+- Does **not** force provider selection or pillar-by-construction scaffolding —
+  no cloud is manufactured. ✅
+- Streaming-vs-two-pass surfaced as the key tradeoff (memory vs. random access).
+  ✅
+
+---
+
+**All seven gestures produce the named observables.**

--- a/docs/specs/well-architected-cloud/plan.md
+++ b/docs/specs/well-architected-cloud/plan.md
@@ -1,7 +1,7 @@
 # Plan: well-architected-cloud
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Drafting <!-- Drafting | Executing | Done -->
+- **Status:** Done <!-- Drafting | Executing | Done -->
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
 > document is allowed to change as you learn. When it changes substantially

--- a/docs/specs/well-architected-cloud/spec.md
+++ b/docs/specs/well-architected-cloud/spec.md
@@ -1,6 +1,6 @@
 # Spec: well-architected-cloud
 
-- **Status:** Draft <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** none
@@ -154,11 +154,11 @@ No compressible code invariant, so no TDD.
 
 **`architect-design` — concept-first, by-construction, convergence loop**
 
-- [ ] Invoking `architect-design` on a design brief produces a **Stage-0 concept** first
+- [x] Invoking `architect-design` on a design brief produces a **Stage-0 concept** first
   (≤ ~½ page: problem + constraints, 1–2 candidate shapes, provider / provider-class, top
   2–3 prioritized quality attributes) and expands to the full design doc only after the
   concept is acknowledged.
-- [ ] `architect-design` ships a **light concept template asset** (`assets/concept.md`),
+- [x] `architect-design` ships a **light concept template asset** (`assets/concept.md`),
   distinct from the existing heavy `assets/design-doc.md`, that the Stage-0 concept is drafted
   from. It is a **one-page** artifact in the spirit of the arc42 *Architecture Communication
   Canvas* ("elevator-pitch / zip-version", travel-light) — fields: **problem & context**,
@@ -167,45 +167,45 @@ No compressible code invariant, so no TDD.
   attributes** (the utility-tree-lite pass, with *why*), **key tradeoff / open decision(s)**,
   and optional **open questions**. It carries **none** of the design doc's heavy sections
   (no full proposal, alternatives-with-rejection, risks table, or rollout).
-- [ ] The concept stage does **not** trip the existing *"just write the proposal section"*
+- [x] The concept stage does **not** trip the existing *"just write the proposal section"*
   anti-pattern: the skill text distinguishes pre-full-doc *shaping* (carries context +
   constraints + the choice) from partial advocacy (a proposal stripped of those).
-- [ ] When a provider is named or inferred, the design names **how each relevant pillar**
+- [x] When a provider is named or inferred, the design names **how each relevant pillar**
   (Operational Excellence, Security, Reliability, Performance, Cost, + Sustainability) is
   *achieved on that provider*; for the **primitives class** it enumerates the
   **capability-gap categories the provider does not supply** (managed data tier, edge/CDN,
   managed identity, serverless, …) with **at least one concrete gap**, so the design names
   what it must build itself. (Specific named gaps are illustrative, not a pinned contract.)
-- [ ] The design surfaces at least one explicit **tradeoff point**, and a **sensitivity
+- [x] The design surfaces at least one explicit **tradeoff point**, and a **sensitivity
   point** where one exists — not only a flat per-pillar list.
-- [ ] The by-construction pass supports a **local-first** provider-class (the founder on-ramp)
+- [x] The by-construction pass supports a **local-first** provider-class (the founder on-ramp)
   alongside hyperscaler and primitives: it names the **local→production delta** (what local fakes
   that production must supply — TLS, real secrets, DB HA, object storage, CDN, observability) and
   the **graduation path** to a chosen provider class. It stays at architecture altitude and does
   **not** prescribe a local toolchain.
-- [ ] The concept stage **degrades gracefully for non-cloud design questions**: with no
+- [x] The concept stage **degrades gracefully for non-cloud design questions**: with no
   provider in play it still produces the Stage-0 concept (problem / constraints / shapes /
   quality attributes) without forcing provider selection or pillar-by-construction scaffolding.
-- [ ] The concept stage takes the **leading-edge path** (per `leading-edge-domains.md`) when no
+- [x] The concept stage takes the **leading-edge path** (per `leading-edge-domains.md`) when no
   shipped pillar/lens/provider reference covers the domain: it flags the novelty, composes with
   the `research` skill (`applied`/`deep`) when available to survey current grey literature and
   synthesize an ad-hoc domain lens, and **degrades** (first-principles + flagged novelty + lowered
   confidence) when `research` is absent — never erroring or requiring it.
-- [ ] Leading-edge claims in the concept/design carry **source + confidence**, and any assumption
+- [x] Leading-edge claims in the concept/design carry **source + confidence**, and any assumption
   resting on low-confidence / grey-lit evidence is classed as a **judgment** finding the loop
   surfaces, never auto-resolves.
-- [ ] After drafting the full doc, `architect-design` runs a **convergence loop**: it
+- [x] After drafting the full doc, `architect-design` runs a **convergence loop**: it
   obtains review findings (from `architect-review` when installed, else from its embedded
   rubric self-check), **auto-resolves the mechanical findings** by revising the doc
   *without asking*, re-reviews, and repeats until no mechanical findings remain or the
   bounded pass cap is reached.
-- [ ] The loop **never auto-resolves a judgment finding**; it surfaces the judgment
+- [x] The loop **never auto-resolves a judgment finding**; it surfaces the judgment
   findings (tradeoff / sensitivity / business calls) to the user as an explicit decision list.
-- [ ] The loop **terminates**: a fixed pass cap, and a stasis escape that escalates a
+- [x] The loop **terminates**: a fixed pass cap, and a stasis escape that escalates a
   mechanical finding which survives a pass to the human rather than looping forever.
-- [ ] With `architect-review` **not installed**, `architect-design` still loops using its
+- [x] With `architect-review` **not installed**, `architect-design` still loops using its
   embedded rubric self-check — it does not error or require the second skill.
-- [ ] The loop's **reviewer-independence** handling is *documented* in `convergence-loop.md`
+- [x] The loop's **reviewer-independence** handling is *documented* in `convergence-loop.md`
   (the checkable surface — the disposition itself is unobservable): it states the
   fresh-context-preferred → cold-re-read-floor ladder, the seed set (artifact + agreed concept +
   constraints, **not** the authoring narrative), and that the cold-read floor is **explicitly
@@ -213,99 +213,99 @@ No compressible code invariant, so no TDD.
 
 **`architect-review` — well-architected / lens mode, finding tags, review-only mode**
 
-- [ ] `architect-review` detects a well-architected / lens review intent **orthogonally
+- [x] `architect-review` detects a well-architected / lens review intent **orthogonally
   to** artifact-type routing and enters the WA mode.
-- [ ] The WA mode lets a **concern-lens** (security / FinOps / SRE / DR / data /
+- [x] The WA mode lets a **concern-lens** (security / FinOps / SRE / DR / data /
   compliance / green) and/or **workload-class lens** (incl. **GenAI/agentic**) be
   applied, inspecting against the pillar spine.
-- [ ] Every WA-mode finding carries a **mechanical** (determinate fix) vs **judgment**
+- [x] Every WA-mode finding carries a **mechanical** (determinate fix) vs **judgment**
   (human/business decision) tag, in addition to the existing severity tag — this is the
   signal `architect-design`'s loop consumes.
-- [ ] The mechanical-vs-judgment split is **operationally defined**, not just exemplified:
+- [x] The mechanical-vs-judgment split is **operationally defined**, not just exemplified:
   `rubric-well-architected.md` states a decidable test — a finding is **mechanical** when its
   fix is fully determined by the pillar spine or a stated constraint with **no** business-value
   or risk-acceptance choice; **judgment** when resolving it requires choosing between defensible
   options (a tradeoff, a risk acceptance, **or a low-confidence / leading-edge assumption**). A
   reviewer can apply the test to a *novel* finding, not only the planted examples.
-- [ ] WA-mode output is a **risk register** of severity-tagged findings + a **prioritized
+- [x] WA-mode output is a **risk register** of severity-tagged findings + a **prioritized
   improvement plan** + **documented risk-acceptance** + **documented non-risks**, reusing
   the skill's existing verdict + severity vocabulary.
-- [ ] Findings carry a **quality-attribute scenario** (source / stimulus / artifact /
+- [x] Findings carry a **quality-attribute scenario** (source / stimulus / artifact /
   environment / response / response-measure) wherever a measurable claim is in play.
-- [ ] The existing **review-only mode** (critiquing an artifact authored elsewhere) is
+- [x] The existing **review-only mode** (critiquing an artifact authored elsewhere) is
   preserved: it emits findings + verdict and **does not auto-fix** — it is a critique, not
   a loop.
 
 **Shared reference content (duplicated per skill, never shared)**
 
-- [ ] A generic **`cloud-primitives`** reference exists (Hetzner as named exemplar)
+- [x] A generic **`cloud-primitives`** reference exists (Hetzner as named exemplar)
   carrying the **"capability gaps you must fill"** checklist, duplicated into each
   consuming skill with a duplication note.
-- [ ] A **`local-dev`** reference exists (the local-first provider-class) carrying the
+- [x] A **`local-dev`** reference exists (the local-first provider-class) carrying the
   **local→production delta** + **graduation path**, architecture-altitude only (no toolchain
   prescription), duplicated into each consuming skill with a duplication note.
-- [ ] A **quality-attribute-scenario template**, a **tradeoff & sensitivity-point guide**, and
+- [x] A **quality-attribute-scenario template**, a **tradeoff & sensitivity-point guide**, and
   the **pillar spine + cloud-agnostic distillation** exist as references in each consuming skill.
-- [ ] A **cross-cutting question bank** reference exists (strategic alignment, build-vs-buy/reuse,
+- [x] A **cross-cutting question bank** reference exists (strategic alignment, build-vs-buy/reuse,
   lock-in/exit, supportability-in-2-years, data ownership & integration contract, and
   **third-party security attestation / restricted-scope-data assessability** — names CASA/ASVS as
   a *downstream verification gate*, referenced not reproduced, control-level verification routed to
   `security-reviewer`/`security-checklists`).
-- [ ] A **GenAI/agentic lens** reference exists (prompt-injection, tool-use authz,
+- [x] A **GenAI/agentic lens** reference exists (prompt-injection, tool-use authz,
   data-egress-to-LLM, evals/observability, token cost), **distinct** from the existing
   managed-platform agentic *diagram* references (Bedrock AgentCore / AI Foundry / Vertex), and
   applying even when the agent runtime is self-hosted on primitives.
-- [ ] A **`leading-edge-domains`** reference exists describing the **method** for designing in a
+- [x] A **`leading-edge-domains`** reference exists describing the **method** for designing in a
   domain with no established pillar/lens/provider reference: detect novelty → (optionally) compose
   with the `research` skill in `applied`/`deep` mode to survey current grey literature with GRADE
   confidence → synthesize an *ad-hoc domain lens for this engagement* → carry source + confidence
   into the concept/design → degrade (design from first principles, flag novelty, lower confidence)
   when `research` is absent. It ships the **method only**, never domain-specific content.
-- [ ] A **`convergence-loop`** reference exists under `architect-design` describing the
+- [x] A **`convergence-loop`** reference exists under `architect-design` describing the
   loop as a **pure-prose, in-conversation procedure (no script, no state file)**: review →
   auto-resolve mechanical → re-review → surface judgment, with the **reviewer-independence**
   handling (fresh-context-preferred / cold-re-read floor; reviewer seeded with
   artifact + concept + constraints), the pass cap, the stasis escape, and the
   no-`architect-review` degradation path.
-- [ ] `architect-diagram` gains a generic **cloud-primitives** diagram reference for
+- [x] `architect-diagram` gains a generic **cloud-primitives** diagram reference for
   parity with its existing `cloud-{aws,azure,gcp}.md` vocab.
 
 **Process / gates**
 
-- [ ] Every `architect-*` `SKILL.md` remains under the pack's <100-line principle.
-- [ ] No inter-skill reference *sharing* is introduced: no load-bearing cross-skill link
+- [x] Every `architect-*` `SKILL.md` remains under the pack's <100-line principle.
+- [x] No inter-skill reference *sharing* is introduced: no load-bearing cross-skill link
   (a load/include directive pointing into another skill's `references/`). The prose
   duplication note that names a sibling file is the sanctioned exception and does not count.
-- [ ] `pack.toml` + `.claude-plugin/plugin.json` are bumped to **0.2.0** and consistent;
+- [x] `pack.toml` + `.claude-plugin/plugin.json` are bumped to **0.2.0** and consistent;
   `.claude-plugin/marketplace.json` is regenerated; `lint-skill-spec` + `lint-packs` are
   green; a `docs/product/changelog.md` `[Unreleased]` entry is added.
 
 **Dogfood (manual QA — committed fixtures under `docs/specs/well-architected-cloud/fixtures/`)**
 
-- [ ] `fixtures/brief-agentic-hetzner.md`: enhanced `architect-design` yields a concept
+- [x] `fixtures/brief-agentic-hetzner.md`: enhanced `architect-design` yields a concept
   naming the primitives class + at least the data-tier and edge/CDN gaps, prioritizing
   Security (agentic) + Performance, and surfacing the self-host-inference-vs-external-LLM-API
   decision as a tradeoff / sensitivity point.
-- [ ] `fixtures/brief-agentic-hetzner.md` plants **two** findings that exercise the failure
+- [x] `fixtures/brief-agentic-hetzner.md` plants **two** findings that exercise the failure
   modes the Boundaries exist to prevent: (a) a cleanly-fixable mechanical finding (e.g. an
   unlabeled trust boundary) that the loop **auto-resolves** across iterations; (b) a mechanical
   finding the rubric **cannot determinately fix**, so the loop's **stasis escape** escalates it
   to the human rather than looping forever. The loop **surfaces** the self-host-vs-external
   decision as a judgment finding and does **not** auto-resolve it.
-- [ ] `fixtures/brief-agentic-hetzner.md`: `architect-review` WA mode under GenAI/agentic +
+- [x] `fixtures/brief-agentic-hetzner.md`: `architect-review` WA mode under GenAI/agentic +
   security lenses produces a risk register naming the internal-data→external-LLM egress
   boundary and the A2UI surface-authority risk, with each finding mechanical/judgment-tagged.
-- [ ] `fixtures/brief-enterprise-brain.md` (a leading-edge domain with no shipped reference):
+- [x] `fixtures/brief-enterprise-brain.md` (a leading-edge domain with no shipped reference):
   `architect-design` takes the leading-edge path — flags novelty, composes with `research`
   (`applied`/`deep`) when available (else degrades + flags), synthesizes an ad-hoc enterprise-brain
   lens (memory types / knowledge stratums / provenance / governance), and surfaces the
   centralized-vs-federated-ontology decision as a judgment finding carrying source + confidence.
-- [ ] `fixtures/brief-local-first.md`: `architect-design` concept treats local-first as a
+- [x] `fixtures/brief-local-first.md`: `architect-design` concept treats local-first as a
   legitimate starting topology, names the **local→production delta** (what local fakes) and a
   **graduation path** to a provider class, and prescribes **no** local toolchain.
-- [ ] `fixtures/brief-hyperscaler.md`: `architect-design` concept names provider-managed-service
+- [x] `fixtures/brief-hyperscaler.md`: `architect-design` concept names provider-managed-service
   pillar achievement and does **not** apply the primitives "gaps" framing.
-- [ ] `fixtures/brief-non-cloud.md`: `architect-design`'s Stage-0 concept degrades gracefully —
+- [x] `fixtures/brief-non-cloud.md`: `architect-design`'s Stage-0 concept degrades gracefully —
   it shapes problem / constraints / choice / quality-attributes without forcing provider or
   pillar-by-construction scaffolding.
 

--- a/packs/architect/.apm/skills/architect-design/SKILL.md
+++ b/packs/architect/.apm/skills/architect-design/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: architect-design
-description: Use when the user is framing a problem, weighing a technical choice, or designing a system or integration without a diagram as the headline ask. Triggers on "how should we", "we need to", "what's the right way to build X", tech-selection, integration design, NFR trade-offs. Produces a Google-style design doc (TL;DR, context, goals/non-goals, proposal, alternatives, risks, rollout, open questions), 2-5 pages, with Mermaid inline. Do NOT use when the ask is a diagram (use `architect-diagram`) or a critique (use `architect-review`).
+description: Use when the user is framing a problem, weighing a technical choice, or designing a system or integration without a diagram as the headline ask. Triggers on "how should we", "we need to", "what's the right way to build X", tech-selection, integration design, NFR trade-offs. Shapes a one-page concept first, then produces a Google-style design doc (TL;DR, context, goals/non-goals, proposal, alternatives, risks, rollout, open questions), 2-5 pages, with Mermaid inline, and converges it against review. Cloud well-architected by construction (AWS/Azure/GCP and primitives providers like Hetzner). Do NOT use when the ask is a diagram (use `architect-diagram`) or a critique (use `architect-review`).
 ---
 
 # Skill: architect-design
 
 Produce a Google-style design doc that names the problem, proposes a solution,
-considers alternatives honestly, and surfaces the risks the proposer is least
-keen to write down.
+considers alternatives honestly, and surfaces the risks the proposer least wants
+to write down — well-architected by construction, then converged against review.
 
 ## When to invoke
 
@@ -29,32 +29,52 @@ If any check fails, push back rather than proceeding.
 1. **Frame the problem.** Ask only what is *genuinely missing* — what we're
    building, who's affected, why now, what would count as success. Skip
    anything the user already said. Three to five questions max; if the
-   user can't answer one, write the doc with the gap flagged as an open
-   question rather than blocking on it.
+   user can't answer one, flag it as an open question rather than blocking.
 
-2. **Draft inline.** Use the skeleton in `assets/design-doc.md` (load it
+2. **Shape the concept first (Stage 0).** Before the full doc, draft a
+   ≤½-page concept from `assets/concept.md` — problem + constraints, 1–2
+   candidate shapes, provider / provider-class, top 2–3 prioritized quality
+   attributes (rank by business-importance × architectural-risk) — and
+   **wait for the user to agree the shape**. This is *shaping* (context +
+   constraints + the choice), not the refused "just write the proposal
+   section" advocacy (see Anti-patterns). Make it well-architected **by
+   construction**: a named provider → `references/well-architected-pillars.md`
+   (it routes a Hetzner-class **primitives** provider to
+   `references/cloud-primitives.md`'s capability gaps); a **local-first** start
+   → `references/local-dev.md`; in all cases name the tradeoff / sensitivity
+   points (`references/tradeoffs-and-sensitivity.md`). **No provider** → still
+   produce the concept, forcing no provider/pillar scaffolding. **No shipped
+   reference fits the domain** → the leading-edge method
+   (`references/leading-edge-domains.md`): flag novelty, compose with `research`
+   if present (degrade + lower confidence if absent), carry source + confidence.
+
+3. **Draft inline.** Use the skeleton in `assets/design-doc.md` (load it
    when you start the draft). Sections in order: TL;DR (≤3 sentences),
    Context, Goals and Non-goals, Proposal, Alternatives Considered, Risks,
    Rollout, Open Questions. Embed Mermaid diagrams where structural
    reasoning genuinely needs a picture — not as decoration.
 
-3. **Self-check against the rubric** in `references/design-doc-rubric.md`.
+4. **Self-check against the rubric** in `references/design-doc-rubric.md`.
    Walk it line by line; fix what fails before showing the draft.
    Common failures:
-   - Non-goals empty or unconvincing → load `references/alternatives.md`
-     for the *what's not in scope* pattern.
+   - Non-goals empty or unconvincing → load `references/alternatives.md`.
    - Alternatives are strawmen → load `references/alternatives.md` and
-     redraft until each alternative could have been chosen by a
-     reasonable engineer.
-   - No cross-cutting concerns named → load `references/nfr-checklist.md`
-     and add the ones that matter.
+     redraft until each could have been chosen by a reasonable engineer.
+   - No cross-cutting concerns named → load `references/nfr-checklist.md`.
 
-4. **Offer to save.** Scan the working directory for an obvious home —
+5. **Converge against review.** After the full draft, run
+   `references/convergence-loop.md`: obtain a review pass (from
+   `architect-review` if installed, else your embedded rubric self-check),
+   **auto-resolve mechanical findings without asking**, re-review, repeat to
+   the pass cap / stasis escape. **Never auto-resolve a judgment finding** —
+   surface the tradeoff / risk / low-confidence calls as explicit decisions.
+
+6. **Offer to save.** Scan the working directory for an obvious home —
    `docs/design/`, `design/`, `architecture/`, or `docs/`. Suggest a
    kebab-case filename based on the doc's title. If nothing fits, ask
    the user where it should go. Saving is an offer, never automatic.
 
-5. **Decision-moment prompt.** If the doc captures one or more discrete
+7. **Decision-moment prompt.** If the doc captures one or more discrete
    decisions (technology choice, structural commitment, interface
    contract), end with one sentence: *"<N> decision(s) here look
    ADR-worthy — capture them with your ADR skill?"* Don't couple to a
@@ -65,6 +85,9 @@ If any check fails, push back rather than proceeding.
 - **"Just write the proposal section."** A proposal without context,
   non-goals, or alternatives is advocacy, not a design doc. Either write
   the full doc or write a project brief — name which.
+- **Treating the Stage-0 concept as a stripped proposal.** The concept is
+  *shaping* — context + constraints + the choice, the opposite of a proposal
+  with those removed. Don't let it collapse into partial advocacy.
 - **Pre-selected alternative pretending to be a choice.** If the user has
   already decided and wants the doc to look like deliberation, that is an
   ADR with a Context section, not a design doc. Push back.

--- a/packs/architect/.apm/skills/architect-design/assets/concept.md
+++ b/packs/architect/.apm/skills/architect-design/assets/concept.md
@@ -1,0 +1,49 @@
+<!-- Stage-0 architecture concept — the ≤½-page shaping artifact drafted
+     BEFORE the full design doc. Spirit of arc42's Architecture Communication
+     Canvas: travel-light, elevator-pitch, "zip version" of the architecture.
+     This is NOT a second design doc — it carries NONE of design-doc.md's heavy
+     sections (no full proposal, no alternatives-with-rejection, no risks table,
+     no rollout). Depth belongs in design-doc.md after the concept is agreed. -->
+
+# Concept — <one-phrase name>
+
+## Problem & context
+
+<The user-visible problem and why now, in two or three sentences. What we're
+building and who's affected.>
+
+## Constraints
+
+<The hard edges: deadline, budget, team shape, regulatory, existing-system
+shape. At least one should be non-obvious.>
+
+## Candidate shapes (1–2)
+
+- **<Shape A — one line.>**
+- **<Shape B — one line, if there's a real second option.>**
+
+## Provider / provider-class
+
+<AWS / Azure / GCP, a primitives provider (Hetzner-class), local-first, or
+"none / not cloud". One **by-construction** line: which pillars are met by
+*managed services* vs. which you must *build yourself* (primitives), or the
+local→production delta (local-first).>
+
+## Top 2–3 prioritized quality attributes
+
+<Ranked by business-importance × architectural-risk — the utility-tree-lite
+pass. Each with a one-line *why it ranks here*.>
+
+1. **<Attribute>** — <why it's top.>
+2. **<Attribute>** — <why.>
+
+## Key tradeoff / open decision(s)
+
+<The one or two decisions that shape this design — each a tradeoff (two pillars
+pulling opposite ways) or an open call the human must make. This is what the
+full doc and the convergence loop will turn on.>
+
+## Open questions (optional)
+
+<Only real unknowns, each with who/what could answer it. Drop the section if
+there are none — don't pad.>

--- a/packs/architect/.apm/skills/architect-design/references/cloud-primitives.md
+++ b/packs/architect/.apm/skills/architect-design/references/cloud-primitives.md
@@ -1,0 +1,56 @@
+# Cloud primitives — the provider class with no managed services
+
+A primitives provider gives you compute, storage, and network *primitives* and
+little else: no managed database, no serverless, no managed identity, no managed
+multi-region failover, no well-architected framework of its own. Hetzner is the
+named exemplar; the class is the same shape as DigitalOcean, Linode/Akamai,
+Vultr, OVH. The reusable substance is the **class**, not Hetzner specifics.
+
+> Note: this reference is intentionally duplicated into `architect-review`'s
+> `references/cloud-primitives.md`. Skill autonomy beats DRY at this scale —
+> each skill stands alone. See the pack README.
+
+## Why this class earns its own reference
+
+On a hyperscaler you largely *achieve a pillar by selecting a managed service*.
+On a primitives provider the same pillar is met by **building it yourself**. A
+by-construction pillar pass therefore reads completely differently: Reliability
+shifts from "pick multi-AZ managed DB" to "you must design replication,
+backup/restore, and failover, because nothing does it for you." Naming that
+contrast is the teaching — it stops the "cheap VPS = done" trap by making the
+founder see what they now *own*.
+
+What the class typically *does* supply: cloud servers, L4/L7 load balancers
+(with TLS termination), S3-compatible object storage, block volumes, private
+networks, firewalls, snapshots/backups.
+
+## Capability gaps you must fill
+
+When the design targets a primitives provider, enumerate the **gap categories
+the provider does not supply** and name, for the ones that apply, *what the
+design builds itself*. The categories below are the spine; at least one concrete
+gap must be named for the workload (the examples are illustrative, not a pinned
+contract).
+
+| Gap category | What's missing | What the design now owns (concrete example) |
+|---|---|---|
+| **Managed data tier** | managed Postgres/MySQL, HA, automated backups, PITR | run Postgres yourself: streaming replication, a tested restore path, failover orchestration |
+| **Edge / CDN** | global CDN, edge caching, DDoS scrubbing at the edge | front static + cacheable content with your own caching tier / a third-party CDN; plan origin-shield |
+| **Managed identity** | managed user pools, OIDC/SAML IdP, managed secrets store | run your own IdP or wire a third-party one; stand up a secrets store and rotation |
+| **Serverless / event glue** | functions-as-a-service, managed queues, managed event bus | run a queue/broker and worker pool yourself; own scaling and dead-letter handling |
+| **Managed K8s / orchestration** | managed control plane, managed node lifecycle | run your own orchestrator or stay VM-native; own upgrades and node health |
+| **Managed multi-region failover** | cross-region replication + automated failover | design region placement, data replication, and a manual or scripted failover runbook |
+| **Observability** | managed metrics/logs/traces, managed alerting | stand up your own metrics/logs/traces stack and on-call alerting |
+
+## The lock-in credit
+
+A primitives provider also *lowers lock-in*: portable primitives, an
+S3-compatible API, plain VMs. The build-vs-buy / lock-in question
+(`cross-cutting-questions.md`) should credit that — the founder trades managed
+convenience for portability and a flatter, more predictable bill.
+
+## Use, don't recite
+
+Name the gaps this workload actually hits and what it builds for each. A design
+that lists all seven categories generically, without saying what *this* system
+owns, has missed the point of the class.

--- a/packs/architect/.apm/skills/architect-design/references/convergence-loop.md
+++ b/packs/architect/.apm/skills/architect-design/references/convergence-loop.md
@@ -1,0 +1,102 @@
+# Convergence loop — converge a design against review, in conversation
+
+After the full design doc is drafted, `architect-design` does not stop at a
+one-shot draft. It *converges* the doc: obtain a review pass, fix the mechanical
+findings itself, re-review, repeat — then surface only the real decisions to the
+human. This is a **pure-prose, in-conversation procedure**. There is **no
+script, no state file, no `loop-cohort`** — the loop is bounded by these
+instructions and stasis-checked by the agent re-reading its own prior findings.
+A script would forfeit the pack's pure-markdown, zero-config, portable property.
+
+## The cycle
+
+1. **Review.** Obtain review findings against the drafted doc (see *Where the
+   review comes from* and *Reviewer independence* below). Each finding is tagged
+   **mechanical** or **judgment** (the taxonomy lives in `architect-review`'s
+   `rubric-well-architected.md`; when reviewing against the embedded self-check,
+   apply the same test — see below).
+2. **Auto-resolve the mechanical findings.** A mechanical finding has a fix fully
+   determined by the pillar spine or a stated constraint, with no business-value
+   or risk-acceptance choice. Revise the doc to fix every mechanical finding
+   **without asking** — labelling an unlabeled trust boundary, adding a missing
+   response-measure that a stated SLO determines, naming an undocumented but
+   already-decided tradeoff.
+3. **Re-review.** Run the review pass again on the revised doc.
+4. **Repeat** until no mechanical findings remain *or* the pass cap is reached.
+5. **Surface the judgment findings** to the human as an explicit decision list —
+   never resolve them silently.
+
+## Never auto-resolve a judgment finding
+
+A **judgment** finding requires choosing between defensible options — a tradeoff,
+a risk acceptance, or an assumption resting on low-confidence / leading-edge
+evidence. The loop **never** auto-resolves one. It collects them and presents
+them to the human as a decision list ("here are the calls only you can make:
+self-host inference vs. external LLM API; how much availability before launch;
+…"). Auto-"fixing" a judgment finding by silently picking a side is the single
+worst failure this loop can have — it hides the real architecture in a diff.
+
+## Termination — the loop must stop
+
+Two independent guards, both required:
+
+- **Pass cap.** A fixed maximum of review passes (default **three**). When the
+  cap is hit, stop looping and surface whatever remains as decisions — do not
+  keep grinding.
+- **Stasis escape.** If a finding tagged *mechanical* **survives a pass** —
+  i.e. the same mechanical finding reappears after you tried to resolve it — the
+  rubric could not determinately fix it. Stop trying: **escalate it to the human
+  as a judgment finding** rather than looping on it indefinitely. A mechanical
+  finding that won't resolve is, in practice, a judgment call in disguise.
+
+To check stasis you re-read your own prior findings: compare this pass's findings
+to the last pass's. A finding present in both, after a fix attempt, trips the
+escape — **but first confirm the fix was actually applied to the doc**. A finding
+that re-surfaces only because the reviewer re-flagged something already resolved
+(not because its value is underivable) is dropped, not escalated; this matters
+most on the degraded path, where the same self-check both produces and re-checks.
+(This is the prose analogue of fingerprint stasis — done by reading, not by a
+state file.)
+
+## Reviewer independence
+
+A review of your own fresh draft, in the same context that authored it, marks its
+own homework — `architect-review`'s standing anti-pattern. Honor it with an
+isolation ladder, strongest first:
+
+1. **Fresh context (preferred).** A new session, or the harness's review
+   subagent where it has one. The reviewer has not seen the authoring.
+2. **Cold re-read (floor).** Where fresh context is unavailable, do a disciplined
+   cold re-read that **sets aside the authoring rationale** and reads the
+   artifact as if encountering it for the first time. This is **explicitly weaker
+   isolation** than a fresh context — name that it's the floor, not parity.
+
+In **every** case, seed the reviewer with the **artifact + the agreed concept +
+the constraints** — never the authoring chain-of-thought. Independence must not
+mean reviewing blind: the reviewer needs the concept and constraints to judge
+fit, but not the narrative of how the draft was reached (that narrative is what
+biases it toward agreeing).
+
+## Where the review comes from — degrade gracefully
+
+- **`architect-review` installed** → obtain the review from its well-architected
+  / lens mode (it returns severity- *and* mechanical/judgment-tagged findings —
+  the signal this loop consumes).
+- **`architect-review` not installed** → loop against `architect-design`'s own
+  **embedded rubric self-check**: walk `design-doc-rubric.md` and
+  `nfr-checklist.md`, plus the WA references (`well-architected-pillars.md`,
+  `tradeoffs-and-sensitivity.md`, `quality-attribute-scenarios.md`), and apply
+  the same mechanical-vs-judgment test to each gap you find. The loop is **never
+  a hard dependency** on the second skill — it does not error or require it, it
+  degrades.
+
+The mechanical-vs-judgment test, restated for the degraded path: a gap is
+**mechanical** when its fix is fully determined by the spine or a stated
+constraint with no business/risk choice; **judgment** when resolving it needs a
+choice between defensible options. Auto-resolve the former; surface the latter.
+
+## Use, don't recite
+
+Run the loop as far as it converges — often one or two passes is enough. Don't
+manufacture findings to justify a third pass, and don't skip surfacing the
+judgment decisions because the doc "looks done." The decisions are the point.

--- a/packs/architect/.apm/skills/architect-design/references/cross-cutting-questions.md
+++ b/packs/architect/.apm/skills/architect-design/references/cross-cutting-questions.md
@@ -1,0 +1,57 @@
+# Cross-cutting question bank — the ARB-grade questions, ceremony stripped
+
+These are architecture-quality questions that are *not* in the cloud pillar
+spine but catch the most expensive errors — strategic misfit, duplicated
+capability, lock-in, an unsupportable system in two years. Mined from
+enterprise architecture-review practice with the governance ceremony left
+behind: the questions come across, the board does not. Make the WA pass
+*actively ask* them, not just have them on a shelf.
+
+> Note: this reference is intentionally duplicated into `architect-review`'s
+> `references/cross-cutting-questions.md`. Skill autonomy beats DRY at this
+> scale — each skill stands alone. See the pack README.
+
+## The questions
+
+- **Strategic / business alignment** — does this design serve the stated goal?
+  The cheapest 100× error to catch is building the wrong thing well; ask it
+  first.
+- **Build-vs-buy / reuse** — does this duplicate an existing capability or
+  service? What does building it cost over buying or reusing?
+- **Lock-in / exit** — can we leave this provider/service, and what's the
+  switching cost? (Sharp across the provider set: a primitives provider lowers
+  lock-in; a deep managed-service bet raises it — credit or charge it honestly.)
+- **Supportability in 2 years** — who runs this, with what skills, and what's
+  the deprecation path? A design no one can operate is a liability dressed as an
+  asset.
+- **Data ownership & integration contract** — who owns the data; sync vs. async
+  boundaries; the API contract and its versioning story.
+- **Third-party security attestation / restricted-scope-data assessability** —
+  if the workload handles restricted-scope user data (e.g. Google-user data
+  under OAuth scopes) or integrates a third party that must attest its security,
+  is the system **assessable** against the relevant gate? Name **CASA** (Google's
+  Cloud Application Security Assessment, built on **OWASP ASVS**, tiered T1
+  self-scan → T3 lab-verified, triggered by restricted-scope OAuth access) as a
+  **downstream verification gate** the design must be *ready for* — minimize
+  OAuth scopes, keep trust boundaries assessable, design for least data.
+
+## CASA / ASVS is referenced, never reproduced
+
+This question stays at **design altitude**: it asks whether the design is shaped
+to *pass* a downstream security assessment, not whether each control is met.
+**Do not reproduce ASVS or CASA control checklists in this pack.** Route
+control-level verification to the repo's `security-reviewer` and
+`security-checklists` — that is where the controls live. Naming the gate and
+designing to be assessable is the architect's job; running the gate is not.
+
+## Several already live in the NFR checklist
+
+Supportability, data-handling, and compatibility overlap `nfr-checklist.md`. The
+move here is not to restate them but to make the WA pass *actively ask* the
+alignment + build-vs-buy + lock-in questions the NFR list doesn't, and to add the
+assessability pointer above.
+
+## Use, don't recite
+
+Ask the questions that bite for *this* design. A design that answers all six
+generically, with no teeth, has turned a thinking prompt into a section template.

--- a/packs/architect/.apm/skills/architect-design/references/leading-edge-domains.md
+++ b/packs/architect/.apm/skills/architect-design/references/leading-edge-domains.md
@@ -1,0 +1,58 @@
+# Leading-edge domains — the method for designing where no reference exists
+
+Some design briefs land in a domain no shipped pillar, lens, or provider
+reference covers — an enterprise brain over living ontologies, a novel agentic
+topology, a category that didn't exist last year. This reference ships the
+**method** for designing there. It deliberately ships **no domain-specific
+content**: living grey matter rots in a shipped file, and baking a domain lens
+in here would duplicate the `research` pack's job. The method travels; the
+content is produced per engagement.
+
+## Why no domain content lives here
+
+A concrete "enterprise-brain reference" (memory types, knowledge stratums,
+provenance schemes) would be stale within a release and would step on the
+`research` skill, whose job is exactly to survey current practice. So this file
+holds the *procedure* for synthesizing a domain lens on demand — never the lens
+itself.
+
+## The method
+
+1. **Detect novelty.** When the concept stage finds that **no shipped
+   pillar/lens/provider reference covers the domain**, take this path rather than
+   forcing the brief into a reference that doesn't fit. Flag the novelty
+   explicitly to the user — "this is a leading-edge domain; the pack ships no
+   reference for it."
+2. **Compose with `research` when available.** If the `research` skill is
+   installed (it is user-scope-default and co-resides with `architect`), invoke
+   it in **`applied`** mode (practitioner grey-literature survey, GRADE-style
+   confidence) or **`deep`** mode (adds an auto devil's-advocate pass) to survey
+   the current state of the art. Composition with `research` is **optional** —
+   the leading-edge path is the pack's first *cross-pack* reach, and like
+   intra-pack composition it is never required.
+3. **Synthesize an ad-hoc domain lens for this engagement.** From the survey (or
+   from first principles when degrading), assemble a *temporary* lens for this
+   design only — the handful of concerns that matter for this domain — and apply
+   it alongside the pillar spine. It is engagement-scoped, not shipped.
+4. **Carry source + confidence.** Every leading-edge claim in the concept/design
+   carries its **source** and a **confidence** level. An assumption resting on
+   low-confidence or grey-literature evidence is classed as a **judgment**
+   finding the loop **surfaces** (never auto-resolves) — see `convergence-loop.md`.
+5. **Degrade when `research` is absent.** With no `research` skill installed, do
+   **not** error or require it. Design **from first principles**, **flag the
+   novelty**, and **lower the confidence** on the resulting claims accordingly.
+   The path still produces a usable concept — just with the uncertainty named.
+
+## The degradation is the contract
+
+The leading-edge path must work three ways and say which one it took:
+`research`-composed (highest confidence, sourced), first-principles + flagged
+(degraded, lower confidence), and — always — novelty flagged so the human knows
+the ground is soft. Never present a leading-edge design as if a shipped reference
+backed it.
+
+## Use, don't recite
+
+Synthesize the lens the domain actually needs. The point is to design honestly in
+unfamiliar territory with the confidence named, not to produce a generic "novel
+domain" checklist.

--- a/packs/architect/.apm/skills/architect-design/references/lens-genai-agentic.md
+++ b/packs/architect/.apm/skills/architect-design/references/lens-genai-agentic.md
@@ -1,0 +1,59 @@
+# GenAI / agentic lens — the workload-class overlay for LLM-driven systems
+
+A workload-class lens for systems where an LLM or an agent is on the critical
+path: it reviews the *same* design through the concerns that flat pillars miss
+for generative/agentic workloads. AI/GenAI is the clear first-class workload
+class across all three cloud vendors (AWS GenAI + Responsible-AI lenses, Google
+AI/ML perspective, Azure AI-in-operations) — this is the cloud-agnostic
+distillation of that overlay.
+
+> Note: this reference is intentionally duplicated into `architect-review`'s
+> `references/lens-genai-agentic.md`. Skill autonomy beats DRY at this scale —
+> each skill stands alone. See the pack README.
+
+## Distinct from the managed-platform agentic *diagram* refs
+
+`architect-diagram` ships `agentic-bedrock-agentcore.md`, `agentic-ai-foundry.md`,
+and `agentic-vertex-agent-engine.md` — those are *diagram vocabularies* for three
+managed agent platforms. This lens is **not** that. It is a provider-agnostic
+*design-quality* overlay, and it applies **even when the agent runtime is
+self-hosted on primitives** (no managed agent platform in sight). Reasoning about
+quality is the job here; drawing a managed platform is not.
+
+## The concerns
+
+- **Prompt injection** — untrusted text (user input, retrieved documents, tool
+  output, web content) reaching the model can hijack its instructions. Where is
+  the trust boundary between *instructions* and *data*? What can a hijacked turn
+  actually cause? Treat model input as untrusted by default.
+- **Tool-use authorization** — an agent that can call tools acts with whatever
+  authority those tools carry. Are tool permissions scoped to least privilege?
+  Is a destructive or outbound-spending tool gated behind confirmation or a
+  policy check? An agent with an over-broad tool is a confused-deputy waiting to
+  happen.
+- **Data egress to the LLM** — what internal/sensitive data crosses the boundary
+  to an external model API? Is that egress intended, minimized, and contractually
+  allowed (training opt-out, residency)? The internal-data → external-LLM
+  boundary is a first-class trust boundary, not plumbing.
+- **Evals & observability** — how is output quality measured (an eval set, not
+  vibes)? Are prompts, tool calls, and responses traced enough to debug a bad
+  turn at 3am? Non-determinism makes observability harder, not optional.
+- **Token cost** — token spend is a unit-economics axis that scales with usage
+  and can dwarf compute. What's the cost per request at p50/p99, and what stops a
+  runaway loop or a prompt-injected spend?
+
+## Routes into the security boundary
+
+Prompt-injection, tool-use authz, and data-egress are security-boundary
+concerns. This lens names them at design altitude (trust boundaries, least
+privilege, egress minimization); control-level verification routes to the repo's
+`security-reviewer` / `security-checklists` (the `llm-agent` module), per
+`cross-cutting-questions.md`. Name frameworks never — the lens reasons about
+boundaries and authority, not whether to use a particular agent framework or
+vector store.
+
+## Use, don't recite
+
+Apply the concerns that bite for *this* agentic system. A self-hosted single-tool
+assistant and a multi-agent system with outbound spend authority have very
+different injection and tool-authz surfaces — name theirs, not a generic five.

--- a/packs/architect/.apm/skills/architect-design/references/local-dev.md
+++ b/packs/architect/.apm/skills/architect-design/references/local-dev.md
@@ -1,0 +1,55 @@
+# Local-first — the founder on-ramp as a legitimate starting topology
+
+A founder often starts on their own machine: everything on localhost, a single
+process, a local database, files on disk. That is a legitimate *starting
+topology*, not a mistake to correct — but it fakes things production must supply
+for real. The design's job at the concept stage is to treat local-first
+honestly: name the **local→production delta** and a **graduation path** to a
+chosen provider class.
+
+> Note: this reference is intentionally duplicated into `architect-review`'s
+> `references/local-dev.md`. Skill autonomy beats DRY at this scale — each skill
+> stands alone. See the pack README.
+
+## Stay at architecture altitude — no toolchain
+
+This reference reasons about *what local fakes and what production must supply*.
+It does **not** prescribe a local toolchain: no docker-compose recipes, no
+specific images, no named dev dependency. The graduation path names a provider
+*class* (hyperscaler / primitives) and the capability that has to become real —
+how you run it locally is out of scope.
+
+## The local→production delta
+
+What localhost fakes that production must make real:
+
+| Local fake | What production must supply |
+|---|---|
+| `http://localhost`, no certs | real **TLS** + a real domain + cert lifecycle |
+| secrets in `.env` / hardcoded | a real **secrets store** + rotation, no secrets in the image or repo |
+| single local DB, no backups | a **durable data tier**: backups, a tested restore, and HA if the SLO needs it |
+| files on local disk | **object storage** (durable, off-box), or a deliberate decision the data is ephemeral |
+| serve assets from the app | **CDN / edge** for static + cacheable content (when latency/scale need it) |
+| `print` / local logs | real **observability**: metrics, logs, traces, alerting someone is on call for |
+| one process, one machine | a **scaling + availability** story: more than one instance, a balancer, blast-radius thinking |
+
+## The graduation path
+
+A local-first concept names *where it graduates to* and *what becomes real
+first*. The shape:
+
+1. **Pick the target provider class** — hyperscaler (managed services carry the
+   delta) or primitives (you build the delta yourself; load `cloud-primitives.md`).
+2. **Order the delta by what blocks the first real users** — usually TLS + real
+   secrets + a durable data tier come before CDN and multi-region.
+3. **Name what stays faked deliberately** — not every local convenience must
+   graduate at once; say which are accepted-for-now and why.
+
+The graduation order is itself often a **judgment** call (how much availability
+is worth before launch); surface it as a decision, don't bake in a number.
+
+## Use, don't recite
+
+Name the deltas this system actually has and the first few that must become
+real. A generic "you'll need TLS and backups" with no graduation order doesn't
+help the founder decide what to do Monday.

--- a/packs/architect/.apm/skills/architect-design/references/quality-attribute-scenarios.md
+++ b/packs/architect/.apm/skills/architect-design/references/quality-attribute-scenarios.md
@@ -1,0 +1,52 @@
+# Quality-attribute scenarios — make a pillar claim testable
+
+A vague pillar question ("is it reliable?") is not a claim you can verify. The
+quality-attribute scenario (from ATAM / ISO 25010 practice) turns it into a
+*testable* assertion by naming six parts. Anchor every measurable pillar claim
+— a design assertion or a review finding — to one.
+
+> Note: this reference is intentionally duplicated into `architect-review`'s
+> `references/quality-attribute-scenarios.md`. Skill autonomy beats DRY at this
+> scale — each skill stands alone. See the pack README.
+
+## The six parts
+
+| Part | Question it answers |
+|---|---|
+| **Source** | Who or what generates the stimulus? (a user, a failing AZ, an attacker, a traffic spike) |
+| **Stimulus** | The condition that arrives. (zone failure, 10× load, a malformed request) |
+| **Artifact** | The part of the system stimulated. (the order service, the data tier, the LB) |
+| **Environment** | The state the system is in when it arrives. (peak load, degraded mode, normal) |
+| **Response** | What the system does. (fails over, sheds load, rejects and logs) |
+| **Response measure** | The measurable bar the response must clear. (within 60s, <0.1% dropped, p99 < 200ms) |
+
+## Worked example
+
+> When an availability zone fails **[stimulus]** during peak checkout load
+> **[environment]**, the order service **[artifact]** fails over **[response]**
+> within 60s with <0.1% dropped requests **[response measure]**.
+
+The measure is the load-bearing part. "Fails over gracefully" is a vibe; "within
+60s with <0.1% dropped" is a claim someone can test and a reviewer can falsify.
+
+## When to reach for one
+
+- **Design-time** — when you assert a pillar is achieved ("it's highly
+  available"), state it as a scenario with a measure instead. If you can't put a
+  number on the measure, that gap is itself worth surfacing.
+- **Review-time** — when a finding turns on a measurable claim, frame the finding
+  as the scenario the design fails to meet, so the fix target is unambiguous.
+
+## A scenario without a measure is an open decision
+
+If the source/stimulus/artifact are clear but the **measure** is unknown (no SLO,
+no agreed target), that is not a mechanical gap — it's a business call about how
+much reliability/latency/cost is worth. Surface it as a **judgment** item (see
+`tradeoffs-and-sensitivity.md`), not something the convergence loop fills in by
+guessing a number.
+
+## Use, don't recite
+
+Write scenarios for the two or three quality attributes the concept stage
+prioritized, not for every pillar. A design padded with six rote scenarios is
+worse than one with two sharp ones.

--- a/packs/architect/.apm/skills/architect-design/references/tradeoffs-and-sensitivity.md
+++ b/packs/architect/.apm/skills/architect-design/references/tradeoffs-and-sensitivity.md
@@ -1,0 +1,48 @@
+# Tradeoff & sensitivity points — name them, don't list pillars flat
+
+The clearest quality win over a flat per-pillar checklist is naming where the
+design's decisions *pull pillars against each other*. From ATAM (and echoed by
+Azure WAF's explicit "Tradeoffs"); the ceremony is dropped, the two concepts
+come across.
+
+> Note: this reference is intentionally duplicated into `architect-review`'s
+> `references/tradeoffs-and-sensitivity.md`. Skill autonomy beats DRY at this
+> scale — each skill stands alone. See the pack README.
+
+## The two concepts
+
+- **Sensitivity point** — a decision where a *small change swings one quality
+  attribute a lot*. (Cache TTL swings staleness; replica count swings recovery
+  time; thread-pool size swings tail latency.) It's a knob the design is
+  sensitive to — worth calling out so it isn't tuned blind.
+- **Tradeoff point** — a decision that is a sensitivity point for *two or more
+  pillars pulling opposite ways*. The decision can't optimize both; choosing is
+  the architecture.
+  - Cache TTL: performance ↑ / consistency ↓.
+  - Multi-AZ / multi-region: reliability ↑ / cost ↑.
+  - Synchronous replication: durability ↑ / write latency ↑.
+  - Self-host inference vs. external LLM API: control + data-residency ↑ /
+    operational burden + capability lag (cost, undifferentiated heavy lifting).
+
+## What each side of the loop does with them
+
+- **Design-time** — when you make a call at a tradeoff point, *name the tradeoff
+  and which way you resolved it, and why*. A design doc that silently picks one
+  side of a tradeoff hides the most important decision in it. Surface at least
+  one explicit tradeoff, and a sensitivity point where one exists.
+- **Review-time** — flag an **undocumented** tradeoff (the design picked a side
+  without saying it traded the other pillar away) and any sensitivity point left
+  un-named.
+
+## A tradeoff is a judgment call, never a mechanical fix
+
+Resolving a tradeoff point requires choosing between defensible options — that
+is the definition of a **judgment** finding. The convergence loop must
+**surface** a tradeoff to the human as a decision; it must never auto-resolve one
+by silently picking a side. A *missing label* on an already-decided tradeoff is
+mechanical (add the sentence naming it); *which way to decide* is judgment.
+
+## Use, don't recite
+
+Name the one or two tradeoffs that actually shape this design. A list of generic
+tradeoffs the design doesn't make is padding.

--- a/packs/architect/.apm/skills/architect-design/references/well-architected-pillars.md
+++ b/packs/architect/.apm/skills/architect-design/references/well-architected-pillars.md
@@ -1,0 +1,85 @@
+# Well-architected pillars — the spine + cloud-agnostic distillation
+
+The provider-independent quality spine an architect carries across clouds.
+AWS ships six pillars, Azure five, Google six — they differ in count, not in
+substance. Distil them to six dimensions and reason against those; map to a
+provider's own framework only when the user is committed to that provider.
+
+> Note: this reference is intentionally duplicated into `architect-review`'s
+> `references/well-architected-pillars.md`. Skill autonomy beats DRY at this
+> scale — each skill stands alone. See the pack README.
+
+## The six dimensions
+
+1. **Reliability / Resilience** — availability, fault tolerance, blast radius,
+   recovery (RTO/RPO), single-point-of-failure analysis, graceful degradation.
+2. **Security** (Google folds in *Privacy & Compliance*) — trust boundaries,
+   identity, least privilege, data classification, encryption, attack surface.
+3. **Cost Optimization** (FinOps) — unit economics, right-sizing, linear-vs-
+   sublinear scaling, commitment/spot, cost visibility.
+4. **Performance Efficiency** — workload-to-resource fit, scaling model,
+   latency budget (p50/p99), elasticity.
+5. **Operational Excellence** — observability (metrics/logs/traces), deployment
+   & rollback, runbooks, incident response, "debuggable at 3am."
+6. **Sustainability** — energy/carbon efficiency, resource utilization,
+   region/carbon-aware placement (top-level on AWS + Google; folded in on Azure).
+
+## By construction — name *how* each pillar is achieved on the provider
+
+The spine is provider-agnostic; *how each pillar is met* is provider-specific.
+When a provider is named or inferred, the design must say — per relevant pillar
+— **how it is achieved on that provider**, not merely that it matters. This is
+where the design is made well-architected *by construction* rather than caught
+in review.
+
+Two provider classes read very differently:
+
+- **Hyperscalers (AWS / Azure / GCP)** — you largely *achieve a pillar by
+  selecting the right managed service*: multi-AZ managed DB → reliability;
+  IAM + KMS → security; autoscaling → performance. Name the service that
+  carries each pillar.
+- **Primitives providers (Hetzner and its class)** — the *same* pillars are met
+  by **building them yourself**. The managed service does not exist, so the
+  design owns it. Load `cloud-primitives.md` for the capability-gap framing —
+  on a primitives provider the by-construction pass is mostly *naming what you
+  must build*.
+
+A per-pillar provider sketch (illustrative — confirm current specifics with the
+provider, never pin them here):
+
+| Pillar | Hyperscaler shape | Primitives shape (self-managed) |
+|---|---|---|
+| Reliability | multi-AZ managed DB, autoscaling, managed failover | multiple servers + LB + **your** replication / backups / failover |
+| Security | managed identity + KMS + managed firewall/threat-detection | firewall + private network; **you** run identity, secrets, patching |
+| Performance | autoscaling + managed cache | vertical / manual horizontal scaling, **your** cache tier |
+| Cost | commitments / spot / tagging | flat predictable price; few levers, low lock-in |
+| Operational excellence | managed metrics/logs/traces + managed IaC | **your** Prometheus/Grafana + IaC |
+| Sustainability | region carbon data, efficient instance families | green-energy DC region choice; fewer levers |
+
+## Security pillar — stay at design altitude
+
+The Security dimension here reasons about **trust boundaries, identity and IAM
+design, data egress, encryption-in-transit/at-rest decisions, OAuth scope
+minimization, and assessability** — design-altitude concerns. It does **not**
+reproduce a control checklist. Where a workload touches restricted-scope user
+data (e.g. Google-user data under OAuth) or needs third-party security
+attestation, name **CASA / ASVS as a downstream verification gate** and route
+control-level verification to the repo's `security-reviewer` /
+`security-checklists`. See `cross-cutting-questions.md` for the assessability
+question. Naming the gate is the design's job; running it is not.
+
+## Prioritize before grinding every pillar
+
+Don't walk all six flat. Rank the dimensions by **business-importance ×
+architectural-risk** and spend where it matters — a one-pass ranking (the
+"utility-tree-lite" move), not a workshop. The top two or three become the
+prioritized quality attributes the concept stage commits to. Load
+`quality-attribute-scenarios.md` to turn each into a testable claim and
+`tradeoffs-and-sensitivity.md` to name where pillars pull against each other.
+
+## Use, don't recite
+
+This is a prompt for honest per-pillar reasoning, not a section template. A
+design that names *how* reliability is achieved on the chosen provider — and
+what it must build when the provider supplies nothing — beats one that lists
+six headings and a sentence each.

--- a/packs/architect/.apm/skills/architect-diagram/SKILL.md
+++ b/packs/architect/.apm/skills/architect-diagram/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: architect-diagram
-description: Use when the user asks for a diagram of a system, integration, flow, state, data model, or deployment topology. Triggers on "show me", "draw", "diagram of", or artifact-shaped nouns like "sequence", "C4 Container view", "state machine". Produces Mermaid diagrams (flowchart, sequenceDiagram, C4, stateDiagram-v2, erDiagram) routed by intent. Cloud-aware (AWS, Azure, GCP) and agentic-platform-aware (Bedrock AgentCore, AI Foundry, Vertex Agent Engine). Do NOT use for full design-doc drafting (use `architect-design`), critique (use `architect-review`), or comparison tables (use plain Markdown).
+description: Use when the user asks for a diagram of a system, integration, flow, state, data model, or deployment topology. Triggers on "show me", "draw", "diagram of", or artifact-shaped nouns like "sequence", "C4 Container view", "state machine". Produces Mermaid diagrams (flowchart, sequenceDiagram, C4, stateDiagram-v2, erDiagram) routed by intent. Cloud-aware (AWS, Azure, GCP, and primitives providers like Hetzner) and agentic-platform-aware (Bedrock AgentCore, AI Foundry, Vertex Agent Engine). Do NOT use for full design-doc drafting (use `architect-design`), critique (use `architect-review`), or comparison tables (use plain Markdown).
 ---
 
 # Skill: architect-diagram
@@ -52,9 +52,9 @@ If two modes plausibly fit, ask once which the user wants.
    sync edges, trust-boundary labeling, storage shapes. Then layer
    the vendor-specific reference:
 
-   - **Any AWS / Azure / GCP service mentioned** (even if not in the
-     reference's short service table) → load
-     `references/cloud-<cloud>.md` for boundary vocabulary, subgraph
+   - **Any AWS / Azure / GCP service — or a primitives provider
+     (Hetzner and its class)** → load `references/cloud-<cloud>.md`
+     (incl. `cloud-primitives.md`) for boundary vocabulary, subgraph
      nesting, and gotchas. Multi-cloud → load multiple references.
    - **Agentic platform named** → load
      `references/agentic-<platform>.md` (`bedrock-agentcore`,

--- a/packs/architect/.apm/skills/architect-diagram/references/cloud-primitives.md
+++ b/packs/architect/.apm/skills/architect-diagram/references/cloud-primitives.md
@@ -1,0 +1,72 @@
+# Cloud primitives — boundary vocabulary, service shorthand, gotchas
+
+**Load this whenever a primitives / no-frills provider is named** — Hetzner is
+the exemplar; the same vocabulary fits DigitalOcean, Linode/Akamai, Vultr, OVH.
+These providers give you primitives, not managed services, so the diagram shows
+*what you run yourself* — there is no managed-DB or serverless box to draw.
+
+Common entry-point cues: Hetzner, hcloud, VPS, "bare VMs", Droplet, "cloud
+servers", "self-managed Postgres", "we run our own", DigitalOcean, Vultr, Linode,
+OVH — and any topology where the database and queue are processes *you* operate.
+
+## Boundary hierarchy → subgraph nesting
+
+```
+Project / Account
+└── Region / Location  (e.g. fsn1, nbg1)
+    └── Private Network  (10.0.0.0/16)
+        └── Subnet / zone  (app | data | edge)
+```
+
+Nest subgraphs in that order. The **private network is the trust boundary** —
+anything reaching in from the public internet crosses it through a load balancer
+or a firewall rule, and that crossing gets a dashed border and a labeled edge.
+
+## Subgraph conventions
+
+```
+subgraph project["project: prod"]
+    subgraph region["fsn1 (Falkenstein)"]
+        subgraph pubnet["🌐 public edge"]
+        end
+        subgraph privnet["🔒 private network (10.0.0.0/16)"]
+            subgraph apptier["app subnet"]
+            end
+            subgraph datatier["data subnet"]
+            end
+        end
+    end
+end
+```
+
+## Primitives that come up regularly
+
+| Primitive | Shorthand label | Shape |
+| --- | --- | --- |
+| Cloud server (VM) | `<name> [cx22 / VM]` | rectangle |
+| Load balancer (L4/L7, TLS term) | `LB [L7 + TLS]` | rectangle on the edge |
+| Object storage (S3-compatible) | `<bucket> [/S3-compat/]` | trapezoid |
+| Block volume | `<vol> [(volume)]` | cylinder attached to a server |
+| Self-managed Postgres | `<db> [(Postgres — self-managed)]` | cylinder, **mark "self-managed"** |
+| Self-managed queue/broker | `<q> [[Redis/RabbitMQ — self-run]]` | subroutine |
+| Private network | the `privnet` subgraph border, not a node | — |
+| Firewall | annotate on the boundary-crossing edge or as a note | — |
+| Floating / primary IP | `vip [floating IP]` | small rectangle on the edge |
+| Snapshot / backup | a note on the volume/DB, not a node | — |
+
+## Cloud-specific gotchas
+
+- **There is no managed-service box.** Don't draw a managed DB, a managed cache,
+  or a serverless function — they don't exist here. A database is a Postgres
+  *process on a server you patch*; render it that way and label it
+  "self-managed" so the diagram doesn't imply a managed tier.
+- **Mark what you own.** Replication, failover, and backups are *your*
+  components on a primitives provider — if reliability is load-bearing, draw the
+  replica server and the backup target, not an implied managed feature.
+- **Private network is the trust boundary, not the region.** Cross-network and
+  public-internet ingress are the boundaries that matter; make them visible with
+  a dashed border and a labeled edge (LB, firewall rule).
+- **TLS terminates at the load balancer** (or at your own reverse proxy) — show
+  where, because nothing terminates it for you by default.
+- **Object storage is S3-compatible but off-box.** Draw it outside the private
+  network as an external-ish dependency reached over its API endpoint.

--- a/packs/architect/.apm/skills/architect-review/SKILL.md
+++ b/packs/architect/.apm/skills/architect-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: architect-review
-description: Use when the user pastes an architecture artifact (design doc, diagram, RFC, ADR) and asks for critique. Triggers on "review this", "what's wrong with", "is this any good", or any artifact-shaped paste with a question attached. Produces a verdict (SHIP IT / SHIP WITH CHANGES / MAJOR REWRITE / WRONG ARTIFACT), executive summary, severity-tagged findings, and a closing "what's working" section. Inline only. Do NOT use to produce an artifact (use `architect-design` or `architect-diagram`).
+description: Use when the user pastes an architecture artifact (design doc, diagram, RFC, ADR) and asks for critique. Triggers on "review this", "what's wrong with", "is this any good", or any artifact-shaped paste with a question attached. Produces a verdict (SHIP IT / SHIP WITH CHANGES / MAJOR REWRITE / WRONG ARTIFACT), executive summary, severity-tagged findings, and a closing "what's working" section. Also runs a well-architected / lens review mode (concern + workload-class lenses incl. GenAI/agentic) emitting a risk register with mechanical/judgment-tagged findings. Inline only. Do NOT use to produce an artifact (use `architect-design` or `architect-diagram`).
 ---
 
 # Skill: architect-review
@@ -40,11 +40,18 @@ If any check fails, push back rather than reviewing.
    a design doc — flag it with the **WRONG ARTIFACT** verdict and
    route to the right skill.
 
-2. **Walk the rubric.** Read every check; note the failures. Do not
+2. **Or — well-architected lens mode** (orthogonal to artifact type): when the
+   ask is whether a *design* is well-architected (provider / pillar / a named
+   concern- or workload-class lens, incl. GenAI/agentic), walk
+   `references/rubric-well-architected.md` and write `assets/risk-register.md` —
+   it tags each finding **🔧 mechanical / 🧭 judgment** + scenario, reuses the
+   verdict/severity below, and does **not** auto-fix (a critique, not the loop).
+
+3. **Walk the rubric.** Read every check; note the failures. Do not
    start writing findings yet — finish the rubric pass first so the
    findings can be ordered by severity, not by discovery order.
 
-3. **Decide the verdict** before writing the findings:
+4. **Decide the verdict** before writing the findings:
    - **SHIP IT.** Zero blockers, ≤2 minors. Rare and worth saying so.
    - **SHIP WITH CHANGES.** Blockers absent or trivially fixable;
      majors exist but the artifact's shape is right.
@@ -53,7 +60,7 @@ If any check fails, push back rather than reviewing.
    - **WRONG ARTIFACT.** The artifact answers a question the user
      didn't ask. Name the right artifact and route.
 
-4. **Write the review** using the shape in `assets/critique.md`:
+5. **Write the review** using `assets/critique.md` (or `assets/risk-register.md` in WA mode):
    - Verdict (one line).
    - Executive summary (≤3 sentences).
    - Findings, ordered by severity, each with: **where** (5–10 words
@@ -63,7 +70,7 @@ If any check fails, push back rather than reviewing.
    - **What's working** (2–4 specific reusable strengths). Not
      flattery. Things the author should *keep* during a rewrite.
 
-5. **No file write.** Render inline. If the user explicitly asks to
+6. **No file write.** Render inline. If the user explicitly asks to
    save the review, write to a path they choose with a kebab-case
    slug — but the default is throwaway.
 

--- a/packs/architect/.apm/skills/architect-review/assets/risk-register.md
+++ b/packs/architect/.apm/skills/architect-review/assets/risk-register.md
@@ -1,0 +1,71 @@
+<!-- Inline output shape for `architect-review`'s well-architected (WA) mode.
+     Not written to disk by default — reviews are throwaway. Use this as the
+     order and section shape of the inline reply. Reuses the verdict + severity
+     vocabulary from `critique.md`; adds the mechanical/judgment tag and the
+     WAR-shaped risk register + improvement plan + risk-acceptance + non-risks. -->
+
+## Verdict
+
+<SHIP IT | SHIP WITH CHANGES | MAJOR REWRITE | WRONG ARTIFACT>
+
+## Summary
+
+<Three sentences or fewer. The workload + provider class, the lenses applied
+(e.g. security + GenAI/agentic), and the dominant risk.>
+
+> Lenses applied: <concern-lens(es)> · <workload-class lens(es)>. Pillar spine
+> per `rubric-well-architected.md`.
+
+## Risk register
+
+> Findings ordered by severity. Each finding carries a **severity** tag *and* a
+> **🔧 mechanical / 🧭 judgment** tag (the signal `architect-design`'s convergence
+> loop consumes). Mechanical = fix fully determined by the spine or a stated
+> constraint; judgment = a tradeoff / risk-acceptance / low-confidence call.
+
+### 🟥 Blockers
+
+**1. <Short title.>** `🔧 mechanical | 🧭 judgment`
+- *Pillar / lens:* <Reliability · Security · … / which lens surfaced it>
+- *Where:* "<quoted verbatim>" — or section + paragraph.
+- *What's wrong:* <One sentence naming the failed pillar check.>
+- *Scenario (if measurable):* <source/stimulus/artifact/environment/response/measure>
+- *Fix / decision:* <mechanical → the determinate fix; judgment → the decision
+  the human must make and the options.>
+
+### 🟧 Majors
+
+**2. <…>** `🔧 | 🧭`
+- *Pillar / lens:* …
+- *Where:* …
+- *What's wrong:* …
+- *Fix / decision:* …
+
+### 🟨 Minors / ⚪ Nits
+
+- <One-line finding + tag.>
+
+## Prioritized improvement plan
+
+> Remediation roadmap, ranked by business-importance × architectural-risk
+> (not finding order). Status vocabulary mirrors a real WAR.
+
+| # | Finding | Pillar / lens | Tag | Priority | Status |
+|---|---|---|---|---|---|
+| 1 | <title> | <pillar> | 🔧 / 🧭 | High / Med / Low | None / Not started / In progress / Complete / Risk acknowledged |
+
+## Documented risk-acceptance
+
+> Best practices the design **deliberately** does not adopt — recorded, not
+> hidden. Each is a 🧭 judgment call with a rationale and (where relevant) who
+> signed off.
+
+- **<Accepted risk>.** <Why it's accepted given the drivers; who owns the
+  acceptance.>
+
+## Documented non-risks
+
+> Decisions that are **sound given the drivers** — more rigorous than praise,
+> and the WA analogue of "what's working." Name *why* each is not a risk here.
+
+- **<Decision>.** <Why it's the right call for this workload / provider class.>

--- a/packs/architect/.apm/skills/architect-review/references/cloud-primitives.md
+++ b/packs/architect/.apm/skills/architect-review/references/cloud-primitives.md
@@ -1,0 +1,56 @@
+# Cloud primitives — the provider class with no managed services
+
+A primitives provider gives you compute, storage, and network *primitives* and
+little else: no managed database, no serverless, no managed identity, no managed
+multi-region failover, no well-architected framework of its own. Hetzner is the
+named exemplar; the class is the same shape as DigitalOcean, Linode/Akamai,
+Vultr, OVH. The reusable substance is the **class**, not Hetzner specifics.
+
+> Note: this reference is intentionally duplicated from `architect-design`'s
+> `references/cloud-primitives.md`. Skill autonomy beats DRY at this scale —
+> each skill stands alone. See the pack README.
+
+## Why this class earns its own reference
+
+On a hyperscaler you largely *achieve a pillar by selecting a managed service*.
+On a primitives provider the same pillar is met by **building it yourself**. A
+by-construction pillar pass therefore reads completely differently: Reliability
+shifts from "pick multi-AZ managed DB" to "you must design replication,
+backup/restore, and failover, because nothing does it for you." Naming that
+contrast is the teaching — it stops the "cheap VPS = done" trap by making the
+founder see what they now *own*.
+
+What the class typically *does* supply: cloud servers, L4/L7 load balancers
+(with TLS termination), S3-compatible object storage, block volumes, private
+networks, firewalls, snapshots/backups.
+
+## Capability gaps you must fill
+
+When the design targets a primitives provider, enumerate the **gap categories
+the provider does not supply** and name, for the ones that apply, *what the
+design builds itself*. The categories below are the spine; at least one concrete
+gap must be named for the workload (the examples are illustrative, not a pinned
+contract).
+
+| Gap category | What's missing | What the design now owns (concrete example) |
+|---|---|---|
+| **Managed data tier** | managed Postgres/MySQL, HA, automated backups, PITR | run Postgres yourself: streaming replication, a tested restore path, failover orchestration |
+| **Edge / CDN** | global CDN, edge caching, DDoS scrubbing at the edge | front static + cacheable content with your own caching tier / a third-party CDN; plan origin-shield |
+| **Managed identity** | managed user pools, OIDC/SAML IdP, managed secrets store | run your own IdP or wire a third-party one; stand up a secrets store and rotation |
+| **Serverless / event glue** | functions-as-a-service, managed queues, managed event bus | run a queue/broker and worker pool yourself; own scaling and dead-letter handling |
+| **Managed K8s / orchestration** | managed control plane, managed node lifecycle | run your own orchestrator or stay VM-native; own upgrades and node health |
+| **Managed multi-region failover** | cross-region replication + automated failover | design region placement, data replication, and a manual or scripted failover runbook |
+| **Observability** | managed metrics/logs/traces, managed alerting | stand up your own metrics/logs/traces stack and on-call alerting |
+
+## The lock-in credit
+
+A primitives provider also *lowers lock-in*: portable primitives, an
+S3-compatible API, plain VMs. The build-vs-buy / lock-in question
+(`cross-cutting-questions.md`) should credit that — the founder trades managed
+convenience for portability and a flatter, more predictable bill.
+
+## Use, don't recite
+
+Name the gaps this workload actually hits and what it builds for each. A design
+that lists all seven categories generically, without saying what *this* system
+owns, has missed the point of the class.

--- a/packs/architect/.apm/skills/architect-review/references/cross-cutting-questions.md
+++ b/packs/architect/.apm/skills/architect-review/references/cross-cutting-questions.md
@@ -1,0 +1,57 @@
+# Cross-cutting question bank — the ARB-grade questions, ceremony stripped
+
+These are architecture-quality questions that are *not* in the cloud pillar
+spine but catch the most expensive errors — strategic misfit, duplicated
+capability, lock-in, an unsupportable system in two years. Mined from
+enterprise architecture-review practice with the governance ceremony left
+behind: the questions come across, the board does not. Make the WA pass
+*actively ask* them, not just have them on a shelf.
+
+> Note: this reference is intentionally duplicated from `architect-design`'s
+> `references/cross-cutting-questions.md`. Skill autonomy beats DRY at this
+> scale — each skill stands alone. See the pack README.
+
+## The questions
+
+- **Strategic / business alignment** — does this design serve the stated goal?
+  The cheapest 100× error to catch is building the wrong thing well; ask it
+  first.
+- **Build-vs-buy / reuse** — does this duplicate an existing capability or
+  service? What does building it cost over buying or reusing?
+- **Lock-in / exit** — can we leave this provider/service, and what's the
+  switching cost? (Sharp across the provider set: a primitives provider lowers
+  lock-in; a deep managed-service bet raises it — credit or charge it honestly.)
+- **Supportability in 2 years** — who runs this, with what skills, and what's
+  the deprecation path? A design no one can operate is a liability dressed as an
+  asset.
+- **Data ownership & integration contract** — who owns the data; sync vs. async
+  boundaries; the API contract and its versioning story.
+- **Third-party security attestation / restricted-scope-data assessability** —
+  if the workload handles restricted-scope user data (e.g. Google-user data
+  under OAuth scopes) or integrates a third party that must attest its security,
+  is the system **assessable** against the relevant gate? Name **CASA** (Google's
+  Cloud Application Security Assessment, built on **OWASP ASVS**, tiered T1
+  self-scan → T3 lab-verified, triggered by restricted-scope OAuth access) as a
+  **downstream verification gate** the design must be *ready for* — minimize
+  OAuth scopes, keep trust boundaries assessable, design for least data.
+
+## CASA / ASVS is referenced, never reproduced
+
+This question stays at **design altitude**: it asks whether the design is shaped
+to *pass* a downstream security assessment, not whether each control is met.
+**Do not reproduce ASVS or CASA control checklists in this pack.** Route
+control-level verification to the repo's `security-reviewer` and
+`security-checklists` — that is where the controls live. Naming the gate and
+designing to be assessable is the architect's job; running the gate is not.
+
+## Several already live in the NFR checklist
+
+Supportability, data-handling, and compatibility overlap `nfr-checklist.md`. The
+move here is not to restate them but to make the WA pass *actively ask* the
+alignment + build-vs-buy + lock-in questions the NFR list doesn't, and to add the
+assessability pointer above.
+
+## Use, don't recite
+
+Ask the questions that bite for *this* design. A design that answers all six
+generically, with no teeth, has turned a thinking prompt into a section template.

--- a/packs/architect/.apm/skills/architect-review/references/lens-genai-agentic.md
+++ b/packs/architect/.apm/skills/architect-review/references/lens-genai-agentic.md
@@ -1,0 +1,59 @@
+# GenAI / agentic lens — the workload-class overlay for LLM-driven systems
+
+A workload-class lens for systems where an LLM or an agent is on the critical
+path: it reviews the *same* design through the concerns that flat pillars miss
+for generative/agentic workloads. AI/GenAI is the clear first-class workload
+class across all three cloud vendors (AWS GenAI + Responsible-AI lenses, Google
+AI/ML perspective, Azure AI-in-operations) — this is the cloud-agnostic
+distillation of that overlay.
+
+> Note: this reference is intentionally duplicated from `architect-design`'s
+> `references/lens-genai-agentic.md`. Skill autonomy beats DRY at this scale —
+> each skill stands alone. See the pack README.
+
+## Distinct from the managed-platform agentic *diagram* refs
+
+`architect-diagram` ships `agentic-bedrock-agentcore.md`, `agentic-ai-foundry.md`,
+and `agentic-vertex-agent-engine.md` — those are *diagram vocabularies* for three
+managed agent platforms. This lens is **not** that. It is a provider-agnostic
+*design-quality* overlay, and it applies **even when the agent runtime is
+self-hosted on primitives** (no managed agent platform in sight). Reasoning about
+quality is the job here; drawing a managed platform is not.
+
+## The concerns
+
+- **Prompt injection** — untrusted text (user input, retrieved documents, tool
+  output, web content) reaching the model can hijack its instructions. Where is
+  the trust boundary between *instructions* and *data*? What can a hijacked turn
+  actually cause? Treat model input as untrusted by default.
+- **Tool-use authorization** — an agent that can call tools acts with whatever
+  authority those tools carry. Are tool permissions scoped to least privilege?
+  Is a destructive or outbound-spending tool gated behind confirmation or a
+  policy check? An agent with an over-broad tool is a confused-deputy waiting to
+  happen.
+- **Data egress to the LLM** — what internal/sensitive data crosses the boundary
+  to an external model API? Is that egress intended, minimized, and contractually
+  allowed (training opt-out, residency)? The internal-data → external-LLM
+  boundary is a first-class trust boundary, not plumbing.
+- **Evals & observability** — how is output quality measured (an eval set, not
+  vibes)? Are prompts, tool calls, and responses traced enough to debug a bad
+  turn at 3am? Non-determinism makes observability harder, not optional.
+- **Token cost** — token spend is a unit-economics axis that scales with usage
+  and can dwarf compute. What's the cost per request at p50/p99, and what stops a
+  runaway loop or a prompt-injected spend?
+
+## Routes into the security boundary
+
+Prompt-injection, tool-use authz, and data-egress are security-boundary
+concerns. This lens names them at design altitude (trust boundaries, least
+privilege, egress minimization); control-level verification routes to the repo's
+`security-reviewer` / `security-checklists` (the `llm-agent` module), per
+`cross-cutting-questions.md`. Name frameworks never — the lens reasons about
+boundaries and authority, not whether to use a particular agent framework or
+vector store.
+
+## Use, don't recite
+
+Apply the concerns that bite for *this* agentic system. A self-hosted single-tool
+assistant and a multi-agent system with outbound spend authority have very
+different injection and tool-authz surfaces — name theirs, not a generic five.

--- a/packs/architect/.apm/skills/architect-review/references/local-dev.md
+++ b/packs/architect/.apm/skills/architect-review/references/local-dev.md
@@ -1,0 +1,55 @@
+# Local-first — the founder on-ramp as a legitimate starting topology
+
+A founder often starts on their own machine: everything on localhost, a single
+process, a local database, files on disk. That is a legitimate *starting
+topology*, not a mistake to correct — but it fakes things production must supply
+for real. The design's job at the concept stage is to treat local-first
+honestly: name the **local→production delta** and a **graduation path** to a
+chosen provider class.
+
+> Note: this reference is intentionally duplicated from `architect-design`'s
+> `references/local-dev.md`. Skill autonomy beats DRY at this scale — each skill
+> stands alone. See the pack README.
+
+## Stay at architecture altitude — no toolchain
+
+This reference reasons about *what local fakes and what production must supply*.
+It does **not** prescribe a local toolchain: no docker-compose recipes, no
+specific images, no named dev dependency. The graduation path names a provider
+*class* (hyperscaler / primitives) and the capability that has to become real —
+how you run it locally is out of scope.
+
+## The local→production delta
+
+What localhost fakes that production must make real:
+
+| Local fake | What production must supply |
+|---|---|
+| `http://localhost`, no certs | real **TLS** + a real domain + cert lifecycle |
+| secrets in `.env` / hardcoded | a real **secrets store** + rotation, no secrets in the image or repo |
+| single local DB, no backups | a **durable data tier**: backups, a tested restore, and HA if the SLO needs it |
+| files on local disk | **object storage** (durable, off-box), or a deliberate decision the data is ephemeral |
+| serve assets from the app | **CDN / edge** for static + cacheable content (when latency/scale need it) |
+| `print` / local logs | real **observability**: metrics, logs, traces, alerting someone is on call for |
+| one process, one machine | a **scaling + availability** story: more than one instance, a balancer, blast-radius thinking |
+
+## The graduation path
+
+A local-first concept names *where it graduates to* and *what becomes real
+first*. The shape:
+
+1. **Pick the target provider class** — hyperscaler (managed services carry the
+   delta) or primitives (you build the delta yourself; load `cloud-primitives.md`).
+2. **Order the delta by what blocks the first real users** — usually TLS + real
+   secrets + a durable data tier come before CDN and multi-region.
+3. **Name what stays faked deliberately** — not every local convenience must
+   graduate at once; say which are accepted-for-now and why.
+
+The graduation order is itself often a **judgment** call (how much availability
+is worth before launch); surface it as a decision, don't bake in a number.
+
+## Use, don't recite
+
+Name the deltas this system actually has and the first few that must become
+real. A generic "you'll need TLS and backups" with no graduation order doesn't
+help the founder decide what to do Monday.

--- a/packs/architect/.apm/skills/architect-review/references/quality-attribute-scenarios.md
+++ b/packs/architect/.apm/skills/architect-review/references/quality-attribute-scenarios.md
@@ -1,0 +1,52 @@
+# Quality-attribute scenarios — make a pillar claim testable
+
+A vague pillar question ("is it reliable?") is not a claim you can verify. The
+quality-attribute scenario (from ATAM / ISO 25010 practice) turns it into a
+*testable* assertion by naming six parts. Anchor every measurable pillar claim
+— a design assertion or a review finding — to one.
+
+> Note: this reference is intentionally duplicated from `architect-design`'s
+> `references/quality-attribute-scenarios.md`. Skill autonomy beats DRY at this
+> scale — each skill stands alone. See the pack README.
+
+## The six parts
+
+| Part | Question it answers |
+|---|---|
+| **Source** | Who or what generates the stimulus? (a user, a failing AZ, an attacker, a traffic spike) |
+| **Stimulus** | The condition that arrives. (zone failure, 10× load, a malformed request) |
+| **Artifact** | The part of the system stimulated. (the order service, the data tier, the LB) |
+| **Environment** | The state the system is in when it arrives. (peak load, degraded mode, normal) |
+| **Response** | What the system does. (fails over, sheds load, rejects and logs) |
+| **Response measure** | The measurable bar the response must clear. (within 60s, <0.1% dropped, p99 < 200ms) |
+
+## Worked example
+
+> When an availability zone fails **[stimulus]** during peak checkout load
+> **[environment]**, the order service **[artifact]** fails over **[response]**
+> within 60s with <0.1% dropped requests **[response measure]**.
+
+The measure is the load-bearing part. "Fails over gracefully" is a vibe; "within
+60s with <0.1% dropped" is a claim someone can test and a reviewer can falsify.
+
+## When to reach for one
+
+- **Design-time** — when you assert a pillar is achieved ("it's highly
+  available"), state it as a scenario with a measure instead. If you can't put a
+  number on the measure, that gap is itself worth surfacing.
+- **Review-time** — when a finding turns on a measurable claim, frame the finding
+  as the scenario the design fails to meet, so the fix target is unambiguous.
+
+## A scenario without a measure is an open decision
+
+If the source/stimulus/artifact are clear but the **measure** is unknown (no SLO,
+no agreed target), that is not a mechanical gap — it's a business call about how
+much reliability/latency/cost is worth. Surface it as a **judgment** item (see
+`tradeoffs-and-sensitivity.md`), not something the convergence loop fills in by
+guessing a number.
+
+## Use, don't recite
+
+Write scenarios for the two or three quality attributes the concept stage
+prioritized, not for every pillar. A design padded with six rote scenarios is
+worse than one with two sharp ones.

--- a/packs/architect/.apm/skills/architect-review/references/rubric-well-architected.md
+++ b/packs/architect/.apm/skills/architect-review/references/rubric-well-architected.md
@@ -1,0 +1,106 @@
+# Well-architected rubric — review a design through pillars + lenses
+
+The quality bar for `architect-review`'s **well-architected (WA) mode**. This
+rubric is *orthogonal to artifact type*: where the other rubrics route by *what
+the artifact is* (design doc, C4, sequence…), this one inspects a design for
+*how well-architected it is*, through the pillar spine and one or more selected
+lenses. Walk it, tag every finding, and emit the output shape in
+`assets/risk-register.md`.
+
+## Select the lenses first
+
+A WA review applies the pillar spine through whichever lenses the design and the
+user's intent call for. Two orthogonal axes:
+
+- **Concern-lens** — security · cost/FinOps · reliability/SRE · DR · data/privacy
+  · compliance · sustainability/green.
+- **Workload-class lens** — ML · **GenAI/agentic** · SaaS · serverless. For
+  GenAI/agentic, load `lens-genai-agentic.md`.
+
+A full review is the union of the relevant passes — usually one or two lenses,
+not all of them. Load `well-architected-pillars.md` for the spine,
+`quality-attribute-scenarios.md` to anchor measurable claims,
+`tradeoffs-and-sensitivity.md` for the tradeoff/sensitivity checks, and
+`cross-cutting-questions.md` for the alignment / lock-in / assessability bank.
+
+## The pillar checks (per selected lens)
+
+- [ ] **Reliability** — blast radius, SPOF, recovery (RTO/RPO), graceful
+      degradation named, with a measure where one is claimed.
+- [ ] **Security** — trust boundaries labeled, identity/least-privilege,
+      data classification + egress, attack surface. (Control-level verification
+      routes downstream to `security-reviewer` / `security-checklists` — this
+      rubric stays at design altitude.)
+- [ ] **Cost** — unit economics, scaling shape (linear vs sublinear), the levers
+      the provider class actually offers.
+- [ ] **Performance** — workload-to-resource fit, scaling model, latency budget
+      (p50/p99) as a scenario.
+- [ ] **Operational excellence** — observability (metrics/logs/traces),
+      deploy/rollback, "debuggable at 3am."
+- [ ] **Sustainability** — utilization, region/placement levers (when material).
+- [ ] **Provider fit** — for a primitives provider, are the **capability gaps**
+      (`cloud-primitives.md`) the design must build itself named? For a
+      hyperscaler, is each pillar tied to the managed service that carries it?
+- [ ] **Tradeoffs & sensitivity** — is at least one tradeoff point named, and any
+      sensitivity point? Flag *undocumented* tradeoffs.
+
+## Tag every finding — the decidable mechanical-vs-judgment test
+
+Every WA-mode finding carries the existing **severity** tag *and* a
+**mechanical / judgment** tag. This is the signal `architect-design`'s
+convergence loop consumes — so the test must be *decidable on a novel finding*,
+not just recognizable on the planted examples below.
+
+**The test.** Ask: *is the fix fully determined?*
+
+- **🔧 Mechanical** — the fix is **fully determined by the pillar spine or a
+  stated constraint**, with **no** business-value or risk-acceptance choice left
+  open. There is one correct resolution and applying it needs no human decision.
+- **🧭 Judgment** — resolving it **requires choosing between defensible options**:
+  a **tradeoff** (two pillars pull opposite ways), a **risk acceptance** (a best
+  practice deliberately not adopted, business sign-off), **or an assumption
+  resting on low-confidence / leading-edge evidence**. More than one answer is
+  defensible; a human must pick.
+
+Apply it to the finding in front of you, not a catalogue. If you can write the
+fix without making a business or risk call, it's mechanical; if writing the fix
+forces you to choose a side, it's judgment.
+
+**Worked discriminations:**
+
+| Finding | Tag | Why |
+|---|---|---|
+| An unlabeled trust boundary on a cross-tenant arrow | 🔧 mechanical | the spine determines it must be labeled; no choice |
+| A reliability claim with no response-measure, but a stated SLO exists | 🔧 mechanical | the constraint (the SLO) determines the measure |
+| A reliability claim with no SLO and no agreed target | 🧭 judgment | how much availability is worth is a business call |
+| Self-host inference vs. external LLM API | 🧭 judgment | a tradeoff (control/residency vs. burden/capability) |
+| A best practice the design skips for cost reasons | 🧭 judgment | a risk acceptance needing sign-off |
+| A design assumption resting on a grey-lit / leading-edge claim | 🧭 judgment | low-confidence evidence; a human must accept the risk |
+
+A mechanical finding that **cannot be determinately fixed** (the rubric can't
+resolve it) is judgment in disguise — tag it judgment and let the loop's stasis
+escape surface it.
+
+## Scenario-anchor measurable findings
+
+Where a finding turns on a measurable claim, frame it as the
+quality-attribute scenario the design fails to meet
+(source/stimulus/artifact/environment/response/response-measure) so the fix
+target is unambiguous. See `quality-attribute-scenarios.md`.
+
+## Reuse the existing verdict + severity vocabulary
+
+WA mode does not invent a new verdict scale. Reuse `architect-review`'s verdict
+(SHIP IT / SHIP WITH CHANGES / MAJOR REWRITE / WRONG ARTIFACT) and severity tags
+(🟥 blocker / 🟧 major / 🟨 minor / ⚪ nit). The mechanical/judgment tag is *added
+to* each finding, not a replacement.
+
+## Severity mapping (typical, WA mode)
+
+- 🟥 **Blocker** — an unmet pillar that makes the design unsafe to build as-is
+  (no recovery story for a stated availability goal; an unlabeled trust boundary
+  on sensitive egress).
+- 🟧 **Major** — a material pillar gap (no observability for an operability goal;
+  a primitives capability-gap the design never names).
+- 🟨 **Minor** — a partial pillar treatment; a sensitivity point left un-named.
+- ⚪ **Nit** — phrasing, ordering, a label that's present but imprecise.

--- a/packs/architect/.apm/skills/architect-review/references/tradeoffs-and-sensitivity.md
+++ b/packs/architect/.apm/skills/architect-review/references/tradeoffs-and-sensitivity.md
@@ -1,0 +1,48 @@
+# Tradeoff & sensitivity points — name them, don't list pillars flat
+
+The clearest quality win over a flat per-pillar checklist is naming where the
+design's decisions *pull pillars against each other*. From ATAM (and echoed by
+Azure WAF's explicit "Tradeoffs"); the ceremony is dropped, the two concepts
+come across.
+
+> Note: this reference is intentionally duplicated from `architect-design`'s
+> `references/tradeoffs-and-sensitivity.md`. Skill autonomy beats DRY at this
+> scale — each skill stands alone. See the pack README.
+
+## The two concepts
+
+- **Sensitivity point** — a decision where a *small change swings one quality
+  attribute a lot*. (Cache TTL swings staleness; replica count swings recovery
+  time; thread-pool size swings tail latency.) It's a knob the design is
+  sensitive to — worth calling out so it isn't tuned blind.
+- **Tradeoff point** — a decision that is a sensitivity point for *two or more
+  pillars pulling opposite ways*. The decision can't optimize both; choosing is
+  the architecture.
+  - Cache TTL: performance ↑ / consistency ↓.
+  - Multi-AZ / multi-region: reliability ↑ / cost ↑.
+  - Synchronous replication: durability ↑ / write latency ↑.
+  - Self-host inference vs. external LLM API: control + data-residency ↑ /
+    operational burden + capability lag (cost, undifferentiated heavy lifting).
+
+## What each side of the loop does with them
+
+- **Design-time** — when you make a call at a tradeoff point, *name the tradeoff
+  and which way you resolved it, and why*. A design doc that silently picks one
+  side of a tradeoff hides the most important decision in it. Surface at least
+  one explicit tradeoff, and a sensitivity point where one exists.
+- **Review-time** — flag an **undocumented** tradeoff (the design picked a side
+  without saying it traded the other pillar away) and any sensitivity point left
+  un-named.
+
+## A tradeoff is a judgment call, never a mechanical fix
+
+Resolving a tradeoff point requires choosing between defensible options — that
+is the definition of a **judgment** finding. The convergence loop must
+**surface** a tradeoff to the human as a decision; it must never auto-resolve one
+by silently picking a side. A *missing label* on an already-decided tradeoff is
+mechanical (add the sentence naming it); *which way to decide* is judgment.
+
+## Use, don't recite
+
+Name the one or two tradeoffs that actually shape this design. A list of generic
+tradeoffs the design doesn't make is padding.

--- a/packs/architect/.apm/skills/architect-review/references/well-architected-pillars.md
+++ b/packs/architect/.apm/skills/architect-review/references/well-architected-pillars.md
@@ -1,0 +1,85 @@
+# Well-architected pillars — the spine + cloud-agnostic distillation
+
+The provider-independent quality spine an architect carries across clouds.
+AWS ships six pillars, Azure five, Google six — they differ in count, not in
+substance. Distil them to six dimensions and reason against those; map to a
+provider's own framework only when the user is committed to that provider.
+
+> Note: this reference is intentionally duplicated from `architect-design`'s
+> `references/well-architected-pillars.md`. Skill autonomy beats DRY at this
+> scale — each skill stands alone. See the pack README.
+
+## The six dimensions
+
+1. **Reliability / Resilience** — availability, fault tolerance, blast radius,
+   recovery (RTO/RPO), single-point-of-failure analysis, graceful degradation.
+2. **Security** (Google folds in *Privacy & Compliance*) — trust boundaries,
+   identity, least privilege, data classification, encryption, attack surface.
+3. **Cost Optimization** (FinOps) — unit economics, right-sizing, linear-vs-
+   sublinear scaling, commitment/spot, cost visibility.
+4. **Performance Efficiency** — workload-to-resource fit, scaling model,
+   latency budget (p50/p99), elasticity.
+5. **Operational Excellence** — observability (metrics/logs/traces), deployment
+   & rollback, runbooks, incident response, "debuggable at 3am."
+6. **Sustainability** — energy/carbon efficiency, resource utilization,
+   region/carbon-aware placement (top-level on AWS + Google; folded in on Azure).
+
+## By construction — name *how* each pillar is achieved on the provider
+
+The spine is provider-agnostic; *how each pillar is met* is provider-specific.
+When a provider is named or inferred, the design must say — per relevant pillar
+— **how it is achieved on that provider**, not merely that it matters. This is
+where the design is made well-architected *by construction* rather than caught
+in review.
+
+Two provider classes read very differently:
+
+- **Hyperscalers (AWS / Azure / GCP)** — you largely *achieve a pillar by
+  selecting the right managed service*: multi-AZ managed DB → reliability;
+  IAM + KMS → security; autoscaling → performance. Name the service that
+  carries each pillar.
+- **Primitives providers (Hetzner and its class)** — the *same* pillars are met
+  by **building them yourself**. The managed service does not exist, so the
+  design owns it. Load `cloud-primitives.md` for the capability-gap framing —
+  on a primitives provider the by-construction pass is mostly *naming what you
+  must build*.
+
+A per-pillar provider sketch (illustrative — confirm current specifics with the
+provider, never pin them here):
+
+| Pillar | Hyperscaler shape | Primitives shape (self-managed) |
+|---|---|---|
+| Reliability | multi-AZ managed DB, autoscaling, managed failover | multiple servers + LB + **your** replication / backups / failover |
+| Security | managed identity + KMS + managed firewall/threat-detection | firewall + private network; **you** run identity, secrets, patching |
+| Performance | autoscaling + managed cache | vertical / manual horizontal scaling, **your** cache tier |
+| Cost | commitments / spot / tagging | flat predictable price; few levers, low lock-in |
+| Operational excellence | managed metrics/logs/traces + managed IaC | **your** Prometheus/Grafana + IaC |
+| Sustainability | region carbon data, efficient instance families | green-energy DC region choice; fewer levers |
+
+## Security pillar — stay at design altitude
+
+The Security dimension here reasons about **trust boundaries, identity and IAM
+design, data egress, encryption-in-transit/at-rest decisions, OAuth scope
+minimization, and assessability** — design-altitude concerns. It does **not**
+reproduce a control checklist. Where a workload touches restricted-scope user
+data (e.g. Google-user data under OAuth) or needs third-party security
+attestation, name **CASA / ASVS as a downstream verification gate** and route
+control-level verification to the repo's `security-reviewer` /
+`security-checklists`. See `cross-cutting-questions.md` for the assessability
+question. Naming the gate is the design's job; running it is not.
+
+## Prioritize before grinding every pillar
+
+Don't walk all six flat. Rank the dimensions by **business-importance ×
+architectural-risk** and spend where it matters — a one-pass ranking (the
+"utility-tree-lite" move), not a workshop. The top two or three become the
+prioritized quality attributes the concept stage commits to. Load
+`quality-attribute-scenarios.md` to turn each into a testable claim and
+`tradeoffs-and-sensitivity.md` to name where pillars pull against each other.
+
+## Use, don't recite
+
+This is a prompt for honest per-pillar reasoning, not a section template. A
+design that names *how* reliability is achieved on the chosen provider — and
+what it must build when the provider supplies nothing — beats one that lists
+six headings and a sentence each.

--- a/packs/architect/.claude-plugin/plugin.json
+++ b/packs/architect/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "architect",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Solution-architecture skills (architect-design, architect-diagram, architect-review). Workspace-agnostic, user-scope by default, no required configuration."
 }

--- a/packs/architect/README.md
+++ b/packs/architect/README.md
@@ -6,9 +6,9 @@ one repo.
 
 | Skill | What it does |
 | --- | --- |
-| `architect-design` | Drafts Google-style design docs (TL;DR → context → goals → proposal → alternatives → risks → rollout → open questions) with Mermaid diagrams inline where structure needs a picture. |
-| `architect-diagram` | Produces Mermaid diagrams routed by intent (C4, flowchart, sequence, state, ER). Cloud-aware (AWS / Azure / GCP) and agentic-platform-aware (Bedrock AgentCore, AI Foundry, Vertex Agent Engine). |
-| `architect-review` | Critiques an existing design doc or diagram with severity-tagged findings, genre-aware rubric routing, and a one-line verdict (SHIP IT / SHIP WITH CHANGES / MAJOR REWRITE / WRONG ARTIFACT). |
+| `architect-design` | Shapes a one-page concept first, then drafts a Google-style design doc (TL;DR → context → goals → proposal → alternatives → risks → rollout → open questions) with Mermaid inline — **well-architected by construction** for the chosen provider (AWS / Azure / GCP, primitives providers like Hetzner, or local-first) and **converged against review** (auto-resolve mechanical findings, surface the judgment calls). |
+| `architect-diagram` | Produces Mermaid diagrams routed by intent (C4, flowchart, sequence, state, ER). Cloud-aware (AWS / Azure / GCP, and primitives providers like Hetzner) and agentic-platform-aware (Bedrock AgentCore, AI Foundry, Vertex Agent Engine). |
+| `architect-review` | Critiques an existing design doc or diagram with severity-tagged findings, genre-aware rubric routing, and a one-line verdict (SHIP IT / SHIP WITH CHANGES / MAJOR REWRITE / WRONG ARTIFACT). Adds a **well-architected / lens mode** (concern + workload-class lenses, incl. GenAI/agentic) that emits a risk register with each finding tagged **mechanical / judgment**. |
 
 ## Install
 
@@ -100,9 +100,19 @@ packs/architect/
     │   ├── references/
     │   │   ├── design-doc-rubric.md
     │   │   ├── alternatives.md
-    │   │   └── nfr-checklist.md
+    │   │   ├── nfr-checklist.md
+    │   │   ├── well-architected-pillars.md
+    │   │   ├── quality-attribute-scenarios.md
+    │   │   ├── tradeoffs-and-sensitivity.md
+    │   │   ├── cloud-primitives.md
+    │   │   ├── local-dev.md
+    │   │   ├── cross-cutting-questions.md
+    │   │   ├── lens-genai-agentic.md
+    │   │   ├── convergence-loop.md          # design-only: the loop procedure
+    │   │   └── leading-edge-domains.md      # design-only: novel-domain method
     │   └── assets/
-    │       └── design-doc.md
+    │       ├── design-doc.md
+    │       └── concept.md                   # the one-page Stage-0 concept
     ├── architect-diagram/
     │   ├── SKILL.md
     │   ├── references/
@@ -110,24 +120,28 @@ packs/architect/
     │   │   ├── diagram-rubric.md
     │   │   ├── cloud-patterns.md
     │   │   ├── mermaid-{flowchart,sequence,c4,state,er,architecture-beta}.md
-    │   │   ├── cloud-{aws,azure,gcp}.md
+    │   │   ├── cloud-{aws,azure,gcp,primitives}.md
     │   │   └── agentic-{bedrock-agentcore,ai-foundry,vertex-agent-engine}.md
     │   └── assets/
     │       └── c4-container.mmd
     └── architect-review/
         ├── SKILL.md
         ├── references/
-        │   ├── rubric-design-doc.md
-        │   ├── rubric-c4-diagram.md
-        │   ├── rubric-sequence-diagram.md
-        │   ├── rubric-state-diagram.md
-        │   ├── rubric-er-diagram.md
-        │   └── rubric-generic.md
+        │   ├── rubric-{design-doc,c4-diagram,sequence-diagram,state-diagram,er-diagram,generic}.md
+        │   ├── rubric-well-architected.md   # WA-mode rubric + mechanical/judgment test
+        │   ├── well-architected-pillars.md  # ┐
+        │   ├── quality-attribute-scenarios.md #  │ duplicated from architect-design
+        │   ├── tradeoffs-and-sensitivity.md #  │ (skill autonomy beats DRY),
+        │   ├── cloud-primitives.md          #  │ each with a one-line note
+        │   ├── local-dev.md                 #  │
+        │   ├── cross-cutting-questions.md   #  │
+        │   └── lens-genai-agentic.md        # ┘
         └── assets/
-            └── critique.md
+            ├── critique.md
+            └── risk-register.md             # WA-mode output shape
 ```
 
-Rubrics are deliberately duplicated between `architect-design`'s
-self-check rubric and `architect-review`'s critique rubrics. Each
-duplicated rubric carries a one-line note. The duplication is the
-principle, not the bug.
+Rubrics and well-architected references are deliberately duplicated
+between `architect-design` and `architect-review` rather than shared via
+inter-skill references. Each duplicated file carries a one-line note. The
+duplication is the principle, not the bug — each skill stands alone.

--- a/packs/architect/pack.toml
+++ b/packs/architect/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "architect"
-version = "0.1.0"
+version = "0.2.0"
 description = "Solution-architecture skills (architect-design, architect-diagram, architect-review). Workspace-agnostic, user-scope by default, no required configuration. Mermaid for diagrams; Google-style design docs; rubric-routed critique."
 
 # RFC-0024 contract level (v0.10) — pure-markdown skills, multi-adapter.


### PR DESCRIPTION
Implements the [`well-architected-cloud`](docs/specs/well-architected-cloud/spec.md) spec for the `architect` pack. Pure-markdown skill content — no code, no subagents, no new pack. Pack 0.1.0 → **0.2.0**.

## What changed

**`architect-design` — concept-first, by-construction, convergence loop**
- Shapes a ≤½-page **Stage-0 concept** (`assets/concept.md`) before the full doc and waits for the user to agree the shape.
- Makes the design **well-architected by construction** for the chosen provider — AWS/Azure/GCP, **primitives providers (Hetzner-class)** with the capability gaps you must build yourself, or **local-first** (local→production delta + graduation path). Degrades gracefully when no provider/cloud is in play.
- Runs a **convergence loop** (pure prose, no script/state file): obtain a review pass → **auto-resolve mechanical findings without asking** → re-review → **surface only the judgment calls** as decisions. Bounded by a pass cap + stasis escape; degrades to an embedded rubric self-check when `architect-review` isn't installed.
- **Leading-edge path** for novel domains: flag novelty, compose with the `research` skill when present, degrade to first-principles + lowered confidence when absent (ships the method, never domain content).

**`architect-review` — well-architected / lens mode**
- New WA mode orthogonal to artifact-type routing; concern-lenses (security · FinOps · SRE · DR · data · compliance · green) + workload-class lenses (incl. **GenAI/agentic**).
- Every WA finding tagged **🔧 mechanical / 🧭 judgment** (a decidable test in `rubric-well-architected.md`) plus severity; emits a risk register (`assets/risk-register.md`). The existing **review-only mode is preserved** (critique, no auto-fix).

**`architect-diagram`** — `cloud-primitives.md` diagram vocab for parity with the AWS/Azure/GCP references.

**Pack principles honored:** every `SKILL.md` < 100 lines (99/96/99); shared references **duplicated per-skill, never shared** (each with a duplication note); CASA/ASVS named as a **downstream gate, not reproduced** (control verification routes to `security-reviewer`/`security-checklists`); no frameworks prescribed.

## Verification
- Goal-based structural invariants (line ceilings, no inter-skill links, version consistency) + **manual-QA dogfooding** against five committed fixtures, traced in [`fixtures/qa-notes.md`](docs/specs/well-architected-cloud/fixtures/qa-notes.md).
- Gates: `lint-packs`, `lint-skill-spec`, `lint-spec-status` all green; `marketplace.json` regenerated to 0.2.0.
- Reviews: adversarial-reviewer clean; quality-engineer whole-spec pass (1 Concern applied — stasis escape now confirms the fix was applied before escalating).

## Deferred (not defects)
- `architect-design`/`architect-review` SKILL.md sit at 99/100 — any future routing line must relocate to a reference first (noted, not backlogged as work).
- A minor step-4-vs-step-5 clarity nit in design SKILL.md — applying it risks breaching the line ceiling for marginal gain.

## Notes
- security-reviewer not run: the diff crosses no security boundary (prose *about* security design; the "route control-verification downstream" boundary is honored).