### PR TITLE
ci: skip CodeQL + SAST/SCA on PRs with nothing to scan

### DIFF
--- a/.github/workflows/build-check-windows.yml
+++ b/.github/workflows/build-check-windows.yml
@@ -19,15 +19,26 @@ name: build-check-windows
 # unfiltered and authoritative, so any projected-doc drift is still
 # caught there.
 
+# This job's sole purpose is Python-script / bundler portability on Windows,
+# so it skips surfaces that cannot affect that: docs, the Makefile (the job
+# invokes `python` directly, never `make`), and root-level markdown. Nested
+# pack content (e.g. packs/**/*.md) is deliberately NOT ignored — it feeds the
+# bundler the job exercises. `.github/**` is also NOT ignored, so an edit to a
+# workflow (including this one) still triggers the job that validates it. The
+# Linux required check stays unfiltered (windows-ci-bundler spec § Never do).
 on:
   pull_request:
     branches: [main]
     paths-ignore:
       - "docs/**"
+      - "Makefile"
+      - "*.md"
   push:
     branches: [main]
     paths-ignore:
       - "docs/**"
+      - "Makefile"
+      - "*.md"
 
 jobs:
   # Runs the Python-portable subset of the Linux job: the bundler build

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -20,6 +20,59 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so the SAST-relevance diff below can reach the PR's
+          # merge-base. (check-adr-immutability in docs.yml also uses
+          # fetch-depth: 0, though it diffs 2-dot rather than the 3-dot
+          # merge-base form used here.)
+          fetch-depth: 0
+
+      # SAST is relevant to a PR when it touches either the scanned dirs
+      # (SAST_DIRS) or the gate's own config/CI surface (SAST_CONFIG — e.g.
+      # bandit.yaml, this workflow). A PR that touches neither has nothing to
+      # scan, so skip that leg — the job still runs (it is the required check)
+      # and its drift + lint gates still execute. Push-to-main always runs SAST
+      # (this step is PR-only; github.event.pull_request.base.sha is absent on
+      # push), so post-merge keeps a full pass as belt-and-braces.
+      #
+      # Two safety properties:
+      #   - Single source of truth: both lists are read from the Makefile, so
+      #     the predicate can't drift from SAST_DIRS / SAST_CONFIG.
+      #   - Fail CLOSED: any error reading the scope or the changed-file set
+      #     routes to skip_sast=false, so uncertain detection runs SAST. And
+      #     because SAST_CONFIG includes this workflow + bandit.yaml, a PR that
+      #     loosens the gate is itself scanned by the gate it changes.
+      - name: Detect whether SAST-relevant files changed
+        id: changes
+        if: github.event_name == 'pull_request'
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          dirs=$(make -s print-sast-dirs) || {
+            echo "::warning::Could not read SAST_DIRS from Makefile — running SAST (fail-closed)."
+            echo "skip_sast=false" >> "$GITHUB_OUTPUT"; exit 0; }
+          cfg=$(make -s print-sast-config) || {
+            echo "::warning::Could not read SAST_CONFIG from Makefile — running SAST (fail-closed)."
+            echo "skip_sast=false" >> "$GITHUB_OUTPUT"; exit 0; }
+          changed=$(git diff --name-only "$base"..."$head") || {
+            echo "::warning::Could not compute changed files — running SAST (fail-closed)."
+            echo "skip_sast=false" >> "$GITHUB_OUTPUT"; exit 0; }
+          dir_pat="^($(echo "$dirs" | tr ' ' '|'))/"
+          run=false
+          # Any file under a scanned dir → SAST is relevant.
+          if printf '%s\n' "$changed" | grep -qE "$dir_pat"; then run=true; fi
+          # Any edit to the gate's config/CI surface → SAST must run so the
+          # change is validated by the gate it changes. Whole-line fixed-string
+          # match (paths contain regex metachars like '.').
+          for c in $cfg; do
+            if printf '%s\n' "$changed" | grep -qxF "$c"; then run=true; fi
+          done
+          if [ "$run" = true ]; then
+            echo "skip_sast=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip_sast=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::No SAST-relevant files changed (dirs: [$dirs]; config: [$cfg]) — skipping SAST/SCA gate."
+          fi
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -37,11 +90,18 @@ jobs:
         # `make build-check` chains `make sast` (ADR-0017), which needs Bandit,
         # pip-audit, and Semgrep on PATH. Install before invoking make so the
         # dogfooded SAST gate is reachable. The shipped packages stay
-        # dependency-free; these are CI-only dev tools.
+        # dependency-free; these are CI-only dev tools. Skipped when the diff
+        # touches no SAST-relevant file (see the detection step above) — the
+        # SKIP_SAST flag below bypasses the scan, so the tools needn't be
+        # installed.
+        if: steps.changes.outputs.skip_sast != 'true'
         run: pip install -r tools/requirements-sast.txt
 
       - name: Run make build-check
-        run: make build-check PACKS_DIR=packs
+        # Pass SKIP_SAST=1 only when the diff touches no SAST-relevant file; the
+        # Makefile then skips the SAST/SCA leg while still running every drift
+        # and lint gate. Empty string (the default / push-to-main) runs SAST.
+        run: make build-check PACKS_DIR=packs ${{ steps.changes.outputs.skip_sast == 'true' && 'SKIP_SAST=1' || '' }}
 
       - name: Install ripgrep
         run: sudo apt-get update && sudo apt-get install -y ripgrep

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,8 +13,17 @@ name: codeql
 on:
   pull_request:
     branches: [main]
+    # CodeQL analyzes Python source only (tests excluded, see config below).
+    # A docs-only change has no Python to analyze, so skip it. This is a
+    # non-required check (branch protection requires only "make build-check"),
+    # so a skipped run can't block a docs-only PR's merge. Mixed PRs (docs +
+    # code) still run — paths-ignore only skips when ALL changed files match.
+    paths-ignore:
+      - "docs/**"
   push:
     branches: [main]
+    paths-ignore:
+      - "docs/**"
   schedule:
     # Weekly re-scan catches newly-published queries against unchanged code.
     - cron: "27 4 * * 1"

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ RECIPE ?=
 
 export PYTHONPATH
 
-.PHONY: build build-self build-self-dry-run build-check build-scaffold lint-packs pre-pr sast validate clean zipapp release-preflight
+.PHONY: build build-self build-self-dry-run build-check build-scaffold lint-packs pre-pr sast print-sast-dirs print-sast-config validate clean zipapp release-preflight
 
 # Windows-portability gate. Refuses packs that ship symlinks or
 # Windows-poisonous names under seeds/ or .apm/. Runs before every
@@ -85,7 +85,18 @@ build-check: lint-packs build
 	$(PYTHON) .claude/skills/receive-brief/scripts/lint-brief-coverage.py
 	# SAST/SCA gate (ADR-0017) — runs last so the fast, offline drift/lint
 	# checks above fail quickly before the slower, network-bound scanners.
-	$(MAKE) sast
+	# SKIP_SAST short-circuits the SAST/SCA leg only (the drift + lint gates
+	# above always run). build-check.yml sets it for PRs that touch no
+	# SAST-relevant file (neither SAST_DIRS nor SAST_CONFIG) — the scanners
+	# have nothing to scan, so the ~76k-LOC pass is pure waste there. Intent of
+	# ADR-0017 is preserved: SAST stays chained into the required build-check
+	# job (not a separate skippable workflow) and runs on every PR that changes
+	# a SAST-relevant file.
+	@if [ -n "$(SKIP_SAST)" ]; then \
+		echo "build-check: SKIP_SAST set — skipping SAST/SCA gate (no SAST-relevant changes to scan)"; \
+	else \
+		$(MAKE) sast; \
+	fi
 
 # SAST/SCA gate (ADR-0017). Three OSS scanners, installed from
 # tools/requirements-sast.txt as CI-only dev tools — never shipped runtime
@@ -107,6 +118,25 @@ build-check: lint-packs build
 # Excluding the duplicates avoids a second inline pragma system in shipped pack
 # scripts.
 SAST_DIRS := tools packs packages
+
+# The SAST config / CI surface that *governs* the gate but lives outside
+# SAST_DIRS. A diff touching any of these must run SAST so a change that
+# loosens the gate (e.g. a wider bandit.yaml exclusion or SEMGREP_EXCLUDE) is
+# validated by the gate it changes — build-check.yml's detection treats these
+# as SAST-relevant. (tools/requirements-sast.txt and tools/semgrep/ are already
+# covered by SAST_DIRS, so they need not be repeated here.)
+SAST_CONFIG := bandit.yaml .snyk Makefile .github/workflows/build-check.yml .github/workflows/codeql.yml
+
+# Single source of truth for the SAST scan scope + config surface.
+# build-check.yml's SAST-relevance detection reads these (`make -s
+# print-sast-dirs` / `print-sast-config`) instead of hard-coding the lists, so
+# the workflow predicate can't drift from them and silently skip the scan on a
+# newly-added scannable dir or an edit to the gate's own config.
+print-sast-dirs:
+	@echo $(SAST_DIRS)
+
+print-sast-config:
+	@echo $(SAST_CONFIG)
 SEMGREP_EXCLUDE := \
 	--exclude-rule python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1 \
 	--exclude-rule python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected \

--- a/docs/specs/sast-sca-tooling/spec.md
+++ b/docs/specs/sast-sca-tooling/spec.md
@@ -72,9 +72,12 @@ before proceeding; *Never do* is a hard rule, even under time pressure.
   ships as a documented scaffold until real IDs are available.
 - Never add scanner config or CI surface beyond the sanctioned set —
   `bandit.yaml`, `.snyk`, `tools/requirements-sast.txt`, `tools/semgrep/`
-  (custom taint rules), and `.github/workflows/codeql.yml`, plus wiring edits to
-  `Makefile` (the `sast` target + the `build-check` chain) and
-  `.github/workflows/build-check.yml` (install the SAST tools) — without amending
+  (custom taint rules), and `.github/workflows/codeql.yml` (including its
+  `paths-ignore`), plus wiring edits to `Makefile` (the `sast` target; the
+  `build-check` chain, including its `SKIP_SAST` short-circuit; and the
+  `print-sast-dirs` / `print-sast-config` scope targets backed by `SAST_DIRS` /
+  `SAST_CONFIG`) and `.github/workflows/build-check.yml` (install the SAST tools;
+  the path-scoping detection step that sets `SKIP_SAST`) — without amending
   this spec. The finding-driven source fixes (`session-start.py` sanitizer,
   `sso-broker.py` scheme guard, the SHA-1 / arXiv / `# nosec` dispositions) are
   the only shipped-code edits.
@@ -109,9 +112,25 @@ before proceeding; *Never do* is a hard rule, even under time pressure.
   on a clean working tree it exits 0.
 - [x] **The SAST gate is dogfooded into this repo's own development per the
   repo's gate convention:** `make build-check` (the single native gate, run
-  locally per CONTRIBUTING and in the `build-check.yml` CI on every PR to `main`)
-  chains `make sast`, so a new medium+ finding fails this repo's own gate — it is
-  not a separate, skippable workflow. No standalone `sast.yml` is added.
+  locally per CONTRIBUTING and in the `build-check.yml` CI) chains `make sast`,
+  so a new medium+ finding fails this repo's own gate. SAST stays **inside** the
+  required `build-check` job — never a separate workflow, and no standalone
+  `sast.yml` is added. It runs on every push to `main` and on every PR that
+  changes a SAST-relevant file (see the path-scoping AC below); a PR that changes
+  no SAST-relevant file skips **only** the SAST leg — the required job still runs
+  and reports its drift + lint gates — so the gate as a whole is never skippable.
+- [x] **The SAST/SCA leg is path-scoped to avoid no-op runs, and fails
+  closed.** `build-check.yml`'s detection step skips `make sast` (via `make
+  build-check SKIP_SAST=1`) **only** when a PR's diff touches neither `SAST_DIRS`
+  (`make -s print-sast-dirs`) nor the gate's config/CI surface `SAST_CONFIG`
+  (`make -s print-sast-config`: `bandit.yaml`, `.snyk`, `Makefile`,
+  `build-check.yml`, `codeql.yml`) — so a PR that *loosens* the gate is scanned by
+  the gate it changes. Both lists are read from the `Makefile` (single source of
+  truth — no hard-coded list to drift), detection runs for `pull_request` only
+  (push-to-`main` always runs SAST), and any error reading the scope or the
+  changed-file set routes to running SAST (fail-closed). `codeql.yml` carries
+  `paths-ignore: docs/**`; it is a non-required check, so a skipped docs-only run
+  cannot block merge, and its weekly cron still rescans in full.
 - [x] A repo-root `bandit.yaml` configures Bandit to fail on **medium-or-higher
   severity at medium-or-higher confidence**, excludes test trees, and skips
   `B101`; every exclusion/skip carries a justifying comment.

--- a/docs/specs/windows-ci-bundler/spec.md
+++ b/docs/specs/windows-ci-bundler/spec.md
@@ -63,9 +63,13 @@ validation is the Windows CI run itself (authoring happened on macOS).
 - [x] AC3. The Windows coverage ships as a **separate workflow file**, not an OS
   matrix folded into `build-check.yml`, so the Linux `make build-check` job (the
   required status check on `main`) is untouched.
-- [x] AC4. `build-check-windows.yml` carries `paths-ignore: docs/**` so a
-  docs-only PR skips the Windows parity job, while the Linux required check still
-  runs on the same PR.
+- [x] AC4. `build-check-windows.yml` carries `paths-ignore` for surfaces that
+  cannot affect Python-script / bundler portability — `docs/**`, `Makefile` (the
+  job invokes `python` directly, never `make`), and root-level `*.md` — so a PR
+  touching only those skips the Windows parity job, while the Linux required
+  check still runs on the same PR. Nested pack content (`packs/**/*.md`) is **not**
+  ignored (it feeds the bundler), and `.github/**` is **not** ignored (so a
+  workflow edit still triggers the job that validates it).
 - [x] AC5. `.github/workflows/build-check.yml` (the Linux gate) remains present
   and is the required status check.
 


### PR DESCRIPTION
## What & why

CodeQL and the SAST/SCA leg of `make build-check` ran on **every** PR — including docs-only changes (`docs/rfc/**`, `docs/specs/**`, …) that have no Python to analyze, so the scanners had nothing to do. This scopes them to the PRs that actually have something to scan.

Net effect: a docs-only PR now skips CodeQL (~20 min) and the SAST leg (~10 min) **and** the Windows parity job, while `make build-check`'s fast drift/lint gates still run and report. Any code-touching or gate-config-touching PR runs everything, unchanged.

## Changes

- **`codeql.yml`** — `paths-ignore: docs/**`. Non-required check, so a skipped docs-only run can't block merge; the weekly cron still does a full rescan.
- **`build-check.yml`** — the **required** job keeps running and reporting (drift + lint gates always execute); only its SAST/SCA leg is skipped (`SKIP_SAST=1`) when a PR touches no SAST-relevant file. Detection is a native `git diff` step (no new Action), **fail-closed** (any git/make error runs SAST), PR-only (push-to-`main` always runs SAST), and **single-sourced from the Makefile** (`SAST_DIRS` / `SAST_CONFIG`) so the predicate can't drift.
- **`build-check-windows.yml`** — `paths-ignore` broadened to `Makefile` and root `*.md` (the job runs `python` directly, never `make`). `.github/**` and nested pack markdown stay un-ignored so workflow edits self-trigger and bundler-affecting content still runs.
- **`Makefile`** — `SKIP_SAST` short-circuit on the `build-check` chain + `print-sast-dirs` / `print-sast-config` targets.

### Hardening (from review)

A PR that **loosens the gate itself** (`bandit.yaml`, `Makefile`, the workflows — all outside `SAST_DIRS`) now forces SAST to run via `SAST_CONFIG`, so the gate scans the change that weakens it. Without this the predicate failed *open* on exactly those edits.

### Spec amendments (same PR, required by governance)

The Shipped `sast-sca-tooling` spec § Never do requires a spec amendment for wiring edits to the `Makefile`/`build-check.yml`/`codeql.yml` SAST surface; its dogfooding AC is reworded (SAST stays inside the required job, never a separate skippable workflow) and a path-scoping AC added. `windows-ci-bundler` AC4 (which pinned the old `docs/**` filter) is updated for the broadened set.

## Verification

- Only `make build-check` is branch-protection-required (confirmed via API); CodeQL + Windows are non-required, so `paths-ignore` on them is safe.
- `make build-check SKIP_SAST=1` exits 0 with `lint-spec-status: spec metadata clean`.
- All three workflows parse; predicate traces correct across docs-only/config/code cases; `make -s print-sast-dirs` / `print-sast-config` resolve.
- adversarial-reviewer: clean (two earlier Blockers — spec-amendment + fail-open — resolved).

## Test plan

- [ ] On this PR (touches `.github/**` + `Makefile`): build-check runs SAST (config surface changed), CodeQL runs (not docs-only), Windows runs (`.github/**` not ignored).
- [ ] A follow-up docs-only PR should show CodeQL + Windows skipped and build-check green without the SAST leg.