### PR TITLE
feat(user-guide-diataxis): clear-prose guidance + leak fixes in new-guide (0.1.3)

### DIFF
--- a/.agents/skills/new-guide/SKILL.md
+++ b/.agents/skills/new-guide/SKILL.md
@@ -30,8 +30,8 @@ Before invoking, confirm:
    docs that must match current product behavior. If you're proposing a
    change, you want an RFC or a spec, not a guide.
 3. You can name a real reader. "Someone might want to know X" isn't a
-   reader; "an adopter who has installed the credential-brokers pack and
-   needs to rotate their token" is.
+   reader; "an operator whose API token expires tomorrow and needs to
+   rotate it before the next deploy" is.
 
 If any check fails, push back rather than proceeding.
 
@@ -161,6 +161,16 @@ If any check fails, push back rather than proceeding.
 
    Efficiency is a form of respect — the reader is in a hurry.
 
+   Beyond word choice, the draft should read like a person wrote it, not a
+   machine. Cut the tells that make prose feel generated: hedges ("it's
+   worth noting"), uniform sentence rhythm, em-dash overuse, throat-clearing
+   openers ("In this guide we will explore…"), inflated verbs ("leverage",
+   "utilize", "delve"), and sentences that restate the heading. Vary sentence
+   length, keep one claim per sentence, and prefer a concrete number or
+   example over an adjective. Read the full checklist in
+   [`references/clear-prose.md`](references/clear-prose.md) while you draft and
+   edit, not before.
+
 5. **Apply the link-out rule as you draft.** When you find yourself
    reaching for content from the adjacent quadrant, stop and write a
    link instead:
@@ -192,6 +202,14 @@ If any check fails, push back rather than proceeding.
    - Explanation: is there a step-by-step block that belongs in a
      how-to? Did I drift past the *"About <topic>"* scope? Did I avoid
      opinion — explanation is *allowed* a voice?
+
+   Then run a prose pass against
+   [`references/clear-prose.md`](references/clear-prose.md). When your
+   environment provides subagents, hand the draft plus that checklist to a
+   read-only subagent and ask it to flag machine-shaped prose; that keeps the
+   style read off your main context. Without subagents, read the draft cold
+   yourself against the checklist. The quadrant self-check above is the floor;
+   the prose pass is the polish.
 
 7. **Cross-link the siblings — only the ones that exist.** A new guide
    rarely stands alone. From the new file, add a `See also` section.

--- a/.agents/skills/new-guide/assets/explanation.md
+++ b/.agents/skills/new-guide/assets/explanation.md
@@ -37,8 +37,8 @@ here, not in how-tos.>
 - [<how-to title>](../how-to/<slug>.md) — to apply it.
 - [<reference title>](../reference/<slug>.md) — for the precise
   parameter list.
-- [ADR-NNNN](../../adr/NNNN-<slug>.md) — the team's record of *why we
-  chose* this approach.
+- [the relevant decision record](../../adr/<slug>.md) — the team's record
+  of *why we chose* this approach.
 
 <!--
 Reminders from the skill — delete before committing:

--- a/.agents/skills/new-guide/references/clear-prose.md
+++ b/.agents/skills/new-guide/references/clear-prose.md
@@ -1,0 +1,64 @@
+# Clear-prose checklist
+
+Good docs read like one person wrote them for another. Prose that reads
+machine-made — even when every fact is right — makes a reader trust the page
+less. Run a draft past this list before you ship it. Read it when you're
+drafting or editing, not as theory up front.
+
+## Tells to cut
+
+These are the habits that make writing feel generated. Each one is easy to
+search for once you know its shape.
+
+- **Hedges.** "It's worth noting that", "it's important to understand",
+  "generally speaking", "in most cases". They pad the line and duck the claim.
+  Delete the throat-clearing and state the thing.
+- **Uniform rhythm.** When every sentence runs the same length, the reader
+  glazes over. Vary it. A longer sentence that carries a real idea, then a
+  short one that lands.
+- **The rule of three, on a loop.** "Fast, reliable, and scalable."
+  "Configure, deploy, and monitor." One triad is fine. A page of them reads
+  like filler poured in to reach a word count.
+- **Em-dash overuse.** One or two per page punctuate well. Ten make every
+  sentence sound the same. Reach for a period or a comma first; keep the dash
+  for the break that earns it.
+- **Throat-clearing openers and closers.** "In this guide, we will explore…",
+  "In conclusion…", "Overall, it is clear that…". Cut them. Start with the
+  first sentence that does work.
+- **Inflated verbs and adjectives.** "Leverage", "utilize", "delve into",
+  "robust", "seamless", "powerful". Write "use". Replace the adjective with a
+  fact: not "blazingly fast" but "renders in under 50 ms".
+- **Restating the heading.** A section called "Rotate a token" that opens
+  "This section explains how to rotate a token." The reader already read the
+  heading. Start rotating the token.
+
+## Habits to keep
+
+- **One claim per sentence.** If a sentence has two "and"s and a "which", it's
+  two or three sentences wearing a trench coat. Split it.
+- **Concrete over abstract.** A number, a command, or an example beats an
+  adjective every time. Show the thing instead of praising it.
+- **Strong verbs, not noun phrases.** "Decide" beats "make a decision";
+  "configure" beats "perform the configuration".
+- **Omit needless words.** Read each sentence and cut what carries no meaning.
+  "In order to" → "to". "At this point in time" → "now". "Due to the fact
+  that" → "because".
+- **Second person, active voice, present tense.** "Run the command and you'll
+  see the build pass", not "the command should be run, after which it will be
+  observed that the build passes".
+- **Don't explain your own reasoning mid-sentence.** "We organize it this way
+  because…" is your thinking leaking onto the page. State what is. If the *why*
+  earns space, give it its own sentence or link to an explanation page.
+- **Don't narrate your intent.** "Here we want to show you…", "the goal of this
+  section is…". Drop the meta-commentary and show the reader directly.
+
+## A fast self-check
+
+Read the draft cold, ideally out loud. The sentences you stumble over are the
+ones to cut or split. If a paragraph could be three bullets, make it three
+bullets. If a sentence survives only because it sounds finished, it's filler —
+cut it.
+
+When your environment has subagents, the skill's optional copyedit pass hands
+the draft and this checklist to a fresh reader so the style read stays off your
+main context. The cold self-read is the floor either way.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "atlassian",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.1.2"
+      "version": "0.1.3"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",
@@ -86,7 +86,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "core",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.4.2"
+      "version": "0.4.3"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -203,7 +203,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "user-guide-diataxis",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.1.2"
+      "version": "0.1.3"
     }
   ]
 }

--- a/.claude/commands/conventions-check.md
+++ b/.claude/commands/conventions-check.md
@@ -1,53 +1,48 @@
 ---
-description: Lint AGENTS.md, CLAUDE.md, and projected agent artifacts against the conventions in this repo
+description: Check AGENTS.md, CLAUDE.md, and the projected agent artifacts (skills, subagents, commands) against the repo's conventions
 ---
 
-Run these repo linters and report findings.
+Verify the conventions below and report findings. If your project ships
+linters that cover any of these, run them; otherwise inspect the files
+directly and report each check by hand. Don't auto-fix — report findings and
+let the user decide.
 
-> These linters are *this catalogue's own* (they enforce its conventions on its
-> `.apm/` and seed artifacts) and aren't shipped into an adopter tree — if
-> they're absent, substitute your project's equivalent checks, or fall back to
-> inspecting the files directly (see the closing note).
-
-**`python tools/lint-agents-md.py`** — AGENTS.md hygiene:
+## AGENTS.md hygiene
 
 1. Root `AGENTS.md` is under 250 lines.
-2. `CLAUDE.md` is either a symlink to `AGENTS.md` or a byte-identical
-   copy of it. (Native Windows checkouts can't materialise symlinks
-   without elevation, so an identical regular file is accepted; a
-   diverged regular file is not.)
+2. `CLAUDE.md` is a symlink to `AGENTS.md`, or a byte-identical copy of it.
+   (Native Windows checkouts can't materialise symlinks without elevation, so
+   an identical regular file is accepted; a diverged regular file is not.)
 3. No subdirectory `AGENTS.md` exceeds 150 lines.
 4. Internal links resolve.
-5. `docs/CHARTER.md` and the Diátaxis subdirectories exist.
+5. `docs/CHARTER.md` and the Diátaxis guide subdirectories exist.
 
-**`python tools/lint-agent-artifacts.py`** — projected agent-artifact hygiene:
+## Agent-artifact hygiene (skills, subagents, commands)
 
-1. Every skill / subagent / command has well-formed YAML frontmatter with
+1. Every skill, subagent, and command has well-formed YAML frontmatter with
    the required keys (`name`, `description`).
-2. Skill directory names match the frontmatter `name`; subagent filenames
-   match the frontmatter `name`; kebab-case enforced.
-3. Frontmatter has no unknown keys.
-4. Skill dirs contain a `SKILL.md` (and no stray `.md` siblings).
+2. Skill directory names match the frontmatter `name`; subagent and command
+   filenames match their `name`; all kebab-case.
+3. Frontmatter carries no unknown keys.
+4. Each skill dir contains a `SKILL.md` and no stray `.md` siblings.
 5. Internal markdown links inside each artifact resolve.
 
-**`bash tools/lint-credentialed-skills.sh`** — credentialed-skill rules,
-scoped to skills whose `SKILL.md` declares `metadata.credentialed: true`
-(per agentskills.io spec, project-specific fields live under
-`metadata:`):
+## Credentialed-skill rules
 
-1. The body contains an `### Security rules (non-negotiable)` heading
-   and the three required security substrings inside that section (the
-   verbatim "Don't" block).
-2. For `metadata.primitive-class: credentialed-cli`: no script under
-   the skill's `scripts/` directory accepts an `argparse` flag whose
-   normalised name (strip leading `-`, casefold, `-` → `_`) is one of
-   `{token, api_token, api_key, bearer, pat, password}`. Detection
-   handles literal strings AND `"--" + "name"`-style concatenation.
-3. No script under a credentialed skill's `scripts/` directory contains
-   the substring `.agentbundle/credentials.env` unless the opt-out
-   comment `# credentialed-primitive: reads-creds-directly` appears
-   on the same line.
+Scoped to skills whose `SKILL.md` declares `metadata.credentialed: true`
+(project-specific fields live under `metadata:` per the agentskills.io spec):
 
-If any linter is missing or fails to run, fall back to inspecting the
-files directly and report the same checks manually. Don't auto-fix
-anything — report findings and let the user decide what to do.
+1. The body contains a `### Security rules (non-negotiable)` heading and the
+   three required security substrings inside that section (the verbatim
+   "Don't" block).
+2. For `metadata.primitive-class: credentialed-cli`: no script under the
+   skill's `scripts/` directory accepts an `argparse` flag whose normalised
+   name (strip leading `-`, casefold, `-` → `_`) is one of `{token, api_token,
+   api_key, bearer, pat, password}`. This covers literal strings and
+   `"--" + "name"`-style concatenation.
+3. No script under a credentialed skill's `scripts/` directory contains the
+   substring `.agentbundle/credentials.env` unless the opt-out comment
+   `# credentialed-primitive: reads-creds-directly` appears on the same line.
+
+If you inspect by hand because no linter covers a check, report the same
+findings manually. Don't auto-fix anything — report and let the user decide.

--- a/.claude/skills/new-guide/SKILL.md
+++ b/.claude/skills/new-guide/SKILL.md
@@ -30,8 +30,8 @@ Before invoking, confirm:
    docs that must match current product behavior. If you're proposing a
    change, you want an RFC or a spec, not a guide.
 3. You can name a real reader. "Someone might want to know X" isn't a
-   reader; "an adopter who has installed the credential-brokers pack and
-   needs to rotate their token" is.
+   reader; "an operator whose API token expires tomorrow and needs to
+   rotate it before the next deploy" is.
 
 If any check fails, push back rather than proceeding.
 
@@ -161,6 +161,16 @@ If any check fails, push back rather than proceeding.
 
    Efficiency is a form of respect — the reader is in a hurry.
 
+   Beyond word choice, the draft should read like a person wrote it, not a
+   machine. Cut the tells that make prose feel generated: hedges ("it's
+   worth noting"), uniform sentence rhythm, em-dash overuse, throat-clearing
+   openers ("In this guide we will explore…"), inflated verbs ("leverage",
+   "utilize", "delve"), and sentences that restate the heading. Vary sentence
+   length, keep one claim per sentence, and prefer a concrete number or
+   example over an adjective. Read the full checklist in
+   [`references/clear-prose.md`](references/clear-prose.md) while you draft and
+   edit, not before.
+
 5. **Apply the link-out rule as you draft.** When you find yourself
    reaching for content from the adjacent quadrant, stop and write a
    link instead:
@@ -192,6 +202,14 @@ If any check fails, push back rather than proceeding.
    - Explanation: is there a step-by-step block that belongs in a
      how-to? Did I drift past the *"About <topic>"* scope? Did I avoid
      opinion — explanation is *allowed* a voice?
+
+   Then run a prose pass against
+   [`references/clear-prose.md`](references/clear-prose.md). When your
+   environment provides subagents, hand the draft plus that checklist to a
+   read-only subagent and ask it to flag machine-shaped prose; that keeps the
+   style read off your main context. Without subagents, read the draft cold
+   yourself against the checklist. The quadrant self-check above is the floor;
+   the prose pass is the polish.
 
 7. **Cross-link the siblings — only the ones that exist.** A new guide
    rarely stands alone. From the new file, add a `See also` section.

--- a/.claude/skills/new-guide/assets/explanation.md
+++ b/.claude/skills/new-guide/assets/explanation.md
@@ -37,8 +37,8 @@ here, not in how-tos.>
 - [<how-to title>](../how-to/<slug>.md) — to apply it.
 - [<reference title>](../reference/<slug>.md) — for the precise
   parameter list.
-- [ADR-NNNN](../../adr/NNNN-<slug>.md) — the team's record of *why we
-  chose* this approach.
+- [the relevant decision record](../../adr/<slug>.md) — the team's record
+  of *why we chose* this approach.
 
 <!--
 Reminders from the skill — delete before committing:

--- a/.claude/skills/new-guide/references/clear-prose.md
+++ b/.claude/skills/new-guide/references/clear-prose.md
@@ -1,0 +1,64 @@
+# Clear-prose checklist
+
+Good docs read like one person wrote them for another. Prose that reads
+machine-made — even when every fact is right — makes a reader trust the page
+less. Run a draft past this list before you ship it. Read it when you're
+drafting or editing, not as theory up front.
+
+## Tells to cut
+
+These are the habits that make writing feel generated. Each one is easy to
+search for once you know its shape.
+
+- **Hedges.** "It's worth noting that", "it's important to understand",
+  "generally speaking", "in most cases". They pad the line and duck the claim.
+  Delete the throat-clearing and state the thing.
+- **Uniform rhythm.** When every sentence runs the same length, the reader
+  glazes over. Vary it. A longer sentence that carries a real idea, then a
+  short one that lands.
+- **The rule of three, on a loop.** "Fast, reliable, and scalable."
+  "Configure, deploy, and monitor." One triad is fine. A page of them reads
+  like filler poured in to reach a word count.
+- **Em-dash overuse.** One or two per page punctuate well. Ten make every
+  sentence sound the same. Reach for a period or a comma first; keep the dash
+  for the break that earns it.
+- **Throat-clearing openers and closers.** "In this guide, we will explore…",
+  "In conclusion…", "Overall, it is clear that…". Cut them. Start with the
+  first sentence that does work.
+- **Inflated verbs and adjectives.** "Leverage", "utilize", "delve into",
+  "robust", "seamless", "powerful". Write "use". Replace the adjective with a
+  fact: not "blazingly fast" but "renders in under 50 ms".
+- **Restating the heading.** A section called "Rotate a token" that opens
+  "This section explains how to rotate a token." The reader already read the
+  heading. Start rotating the token.
+
+## Habits to keep
+
+- **One claim per sentence.** If a sentence has two "and"s and a "which", it's
+  two or three sentences wearing a trench coat. Split it.
+- **Concrete over abstract.** A number, a command, or an example beats an
+  adjective every time. Show the thing instead of praising it.
+- **Strong verbs, not noun phrases.** "Decide" beats "make a decision";
+  "configure" beats "perform the configuration".
+- **Omit needless words.** Read each sentence and cut what carries no meaning.
+  "In order to" → "to". "At this point in time" → "now". "Due to the fact
+  that" → "because".
+- **Second person, active voice, present tense.** "Run the command and you'll
+  see the build pass", not "the command should be run, after which it will be
+  observed that the build passes".
+- **Don't explain your own reasoning mid-sentence.** "We organize it this way
+  because…" is your thinking leaking onto the page. State what is. If the *why*
+  earns space, give it its own sentence or link to an explanation page.
+- **Don't narrate your intent.** "Here we want to show you…", "the goal of this
+  section is…". Drop the meta-commentary and show the reader directly.
+
+## A fast self-check
+
+Read the draft cold, ideally out loud. The sentences you stumble over are the
+ones to cut or split. If a paragraph could be three bullets, make it three
+bullets. If a sentence survives only because it sounds finished, it's filler —
+cut it.
+
+When your environment has subagents, the skill's optional copyedit pass hands
+the draft and this checklist to a fresh reader so the style read stays off your
+main context. The cold self-read is the floor either way.

--- a/AGENTS.local.md
+++ b/AGENTS.local.md
@@ -96,8 +96,34 @@ the parser consumes, not a citation).
 
 Precedent: `lint-seeds` already enforces this for `seeds/**`. There is **no
 automated lint for `.apm/**` skills/agents yet** — a `lint-seeds`-analogue is a
-possible follow-on, but adding one is a new convention and therefore RFC-gated.
-Until then this is a hand-checked authoring rule.
+possible follow-on, but adding one is a new convention and therefore RFC-gated
+(tracked at `docs/backlog.md` § `apm-leak-lint-rfc`). Until then this is a
+hand-checked authoring rule.
+
+## House style for our own internal docs
+
+This covers prose that stays in this repo and never ships to adopters: this
+file, `docs/architecture/`, `docs/specs/`, RFCs and ADRs, internal READMEs.
+The adopter-facing version of this craft ships in the `user-guide-diataxis`
+pack's `new-guide` skill (`references/clear-prose.md`); keep each in its own
+home rather than duplicating.
+
+- **Write prose that reads like a person wrote it.** Cut the tells that make
+  text feel machine-made: hedges ("it's worth noting"), uniform sentence
+  rhythm, em-dash overuse, the rule of three on a loop, throat-clearing
+  openers, inflated verbs ("leverage", "utilize", "delve"). Vary sentence
+  length, keep one claim per sentence, and prefer a concrete number or example
+  over an adjective.
+- **State what is — don't leak rationale or identity.** An aside that
+  justifies a choice mid-sentence ("organized this way because…") reads as
+  internal thinking spilling onto the page; cut it, or give the *why* its own
+  sentence. Drop self-narration too ("internally we…", "our goal here is…").
+- **Soft-wrap guides — one logical line per paragraph.** Under `docs/guides/`,
+  don't hard-wrap mid-paragraph: one line per paragraph, a blank line between
+  paragraphs, list items one line each. It renders identically on GitHub (a
+  wrapped newline reads as a space) and stays clean in preview panes that treat
+  a single newline as a break. The older docs (README, CONVENTIONS) are still
+  hard-wrapped near 72 columns; match the file you're editing.
 
 ## Agents PROJECT — they are not "Claude Code only" (stop getting this wrong)
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -630,3 +630,15 @@ then escapes the backslash, so a frontmatter `description` carrying escaped quot
 double-escaped (`\\\"…\\\"`). This is **byte-identical to the merged `cursor.py`** (an inherited
 cross-adapter behavior, not a gemini regression). Fix both adapters together: unescape `\"`→`"`
 in the quote-stripping branch.
+
+## `house-voice-writing-craft`
+
+### apm-leak-lint-rfc
+
+A `lint-seeds`-analogue for `packs/*/.apm/**` that mechanically catches
+internal-governance citations (RFC/ADR numbers, `docs/specs|rfc|adr` paths,
+`make`/`tools/lint` references, "this catalogue" identity asides) in shipped
+skills, agents, commands, and hooks. Today the rule is hand-checked
+(`AGENTS.local.md` § "Shipped pack content carries no internal-governance
+citations"). Adding the lint is a new convention and therefore RFC-gated;
+open an RFC before building it.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -642,3 +642,16 @@ skills, agents, commands, and hooks. Today the rule is hand-checked
 (`AGENTS.local.md` § "Shipped pack content carries no internal-governance
 citations"). Adding the lint is a new convention and therefore RFC-gated;
 open an RFC before building it.
+
+A 2026-06-13 sweep found the `core` pack still carries ~10 such references in
+shipped `.apm/**` that a hand-pass left in place — `work-loop/SKILL.md` (an
+`RFC-0025` reference; a `make build-check` mention), `hooks/pre-pr.py` ("this
+catalogue's own"), the work-loop and receive-brief `scripts/` (`make
+build-check` in comments), `hook-wiring/session-start.toml` (`make
+build-self`), and `adapt-to-project/assets/reference.md` ("this catalogue").
+These were left untouched deliberately: sweeping the most sensitive pack
+(work-loop's `SKILL.md` carries a byte-identical risk-trigger block mirrored
+across four files) is exactly the systematic job the lint should drive, not a
+hand-sweep. Land the lint under the RFC, then do the sweep under it.
+(`RFC-1918` in `security-checklists/references/outbound-ssrf.md` is a real IETF
+standard, not an internal citation — leave it.)

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`new-guide` now coaches prose, not just structure (user-guide-diataxis
+  0.1.3).** The skill ships a `clear-prose` checklist. It names the tells that
+  make docs read machine-made (hedges, uniform sentence rhythm, em-dash
+  overuse, throat-clearing openers, inflated verbs) and the habits that keep
+  them human (one claim per sentence, concrete over abstract, strong verbs,
+  omit needless words). The voice section points to it. An optional copyedit
+  pass hands the draft to a read-only subagent when one is available.
+
 - **A guide home for every pack, and real guides for the packs that lacked
   them (ADR-0020).** `docs/guides/` is reorganized from flat Diátaxis quadrants
   to a per-pack hierarchy — `docs/guides/<pack>/{tutorials,how-to,reference,explanation}/`

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -19,6 +19,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Shipped pack content sheds catalogue-internal references (core 0.4.3,
+  atlassian 0.1.3).** The `conventions-check` command no longer instructs
+  running this repo's own `tools/lint-*` scripts — which never install into an
+  adopter tree — and is reframed as checks you (or your own linters) perform
+  directly. The `jira` skill's error-handling guidance drops a `make
+  build-self` remediation hint in favour of "reinstall the pack", and four
+  shipped atlassian test scripts drop dangling internal-RFC comment citations.
+
+- **`make build-self` no longer litters the tree with by-quadrant guide
+  scaffolds.** Self-host projection skips `docs/guides/**`: guides are
+  repo-owned and reach adopters through install-time seed delivery, so a repo
+  that organizes its guides by pack no longer gets untracked
+  `docs/guides/{tutorials,how-to,reference,explanation}/README.md` re-created
+  on every build.
+
 - **`new-guide` now coaches prose, not just structure (user-guide-diataxis
   0.1.3).** The skill ships a `clear-prose` checklist. It names the tells that
   make docs read machine-made (hedges, uniform sentence rhythm, em-dash

--- a/docs/specs/house-voice-writing-craft/plan.md
+++ b/docs/specs/house-voice-writing-craft/plan.md
@@ -1,0 +1,72 @@
+# Plan: house-voice writing craft
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Done <!-- Drafting | Executing | Done -->
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn.
+
+## Approach
+
+Two slices, shipped as two PRs. The first is the adopter-facing change in the
+`user-guide-diataxis` pack: a new on-demand reference, an expanded voice
+section in `new-guide`, an optional copyedit pass, two leak fixes, a version
+bump, build-self, and a changelog entry. The second is a repo-internal change:
+a house-style section in `AGENTS.local.md`. The riskiest part is prose quality
+and keeping external attribution and strategic intent out of tracked files —
+both verified by grep and one adversarial pass. No runtime code changes, so
+verification is goal-based plus review.
+
+**Declined-pattern register.** Tempted to vendor the full Strunk text as a
+12k-token reference (as the upstream skill does); declining — a tight original
+checklist matches the repo's lean bias and avoids attribution. Tempted to add a
+`references/clear-prose.md` reminder to all four asset templates; declining —
+the SKILL voice section plus one reference is the single lever, asset edits are
+scope creep. Tempted to fix the atlassian / research / conventions-check leaks
+in the same PR; declining — out of this pack, surfaced as follow-ups. Tempted
+to build the `.apm/**` leak lint; declining — RFC-gated new convention.
+
+## Tasks
+
+### T1: Adopter-facing clear-prose guidance in `user-guide-diataxis`
+
+**Depends on:** none
+
+**Tests:** (goal-based)
+- `python3 tools/lint-skill-spec.py` passes (skill-relative path to the new `references/clear-prose.md`).
+- `grep -rEi 'obra|strunk|elements of style' packs/user-guide-diataxis` returns nothing.
+- `grep -rE 'RFC-[0-9]|ADR-[0-9]|make build|tools/lint' packs/user-guide-diataxis/.apm` returns nothing.
+- `grep -ri 'credential-brokers' packs/user-guide-diataxis/.apm/skills/new-guide/SKILL.md` returns nothing.
+- `make build-self && make build-check` → zero drift; `make lint-packs` passes.
+
+**Approach:**
+- Write `references/clear-prose.md`: tells-to-cut + habits-to-keep + a fast self-check. Original, attribution-free, adopter-generic.
+- Extend the SKILL voice paragraph: keep existing rules, add the natural-prose rule set + a skill-relative pointer to the reference (read when drafting).
+- Add an optional copyedit-subagent pass to the step-6 self-check, degrading to a cold self-read.
+- Genericize the credential-brokers example reader; soften the `ADR-NNNN` See-also in `explanation.md`.
+- Bump `pack.toml` and `plugin.json` 0.1.2 → 0.1.3; `make build-self`.
+- Add a `[Unreleased]` changelog entry.
+
+**Done when:** all T1 tests green and `make build-check` reports zero drift.
+
+### T2: Internal-doc house style in `AGENTS.local.md`
+
+**Depends on:** none
+
+**Tests:** (goal-based)
+- `grep -riE 'viral|virality|adoption|hacker.?news|evangelist|founder|go.viral' AGENTS.local.md` returns nothing.
+- New section names natural prose, no rationale/identity leak, and soft-wrap for `docs/guides/`.
+
+**Approach:**
+- Add a "house style for our own internal docs" section: natural prose (the tells), no rationale/identity leak, soft-wrap guides. Cross-reference the pack as the adopter-facing home so the two don't duplicate. No strategic *why*.
+
+**Done when:** section present, grep clean, file still parses (it is not a projected path, so no build-self).
+
+## Risks
+
+- Prose that itself reads like AI-slop would be self-refuting. Mitigation: the adversarial pass reads the new prose against its own checklist.
+- Accidentally reintroducing a leak while editing the leak fixes. Mitigation: the grep tests in T1 gate it.
+
+## Changelog
+
+- 2026-06-13: initial plan.

--- a/docs/specs/house-voice-writing-craft/plan.md
+++ b/docs/specs/house-voice-writing-craft/plan.md
@@ -70,3 +70,10 @@ to build the `.apm/**` leak lint; declining — RFC-gated new convention.
 ## Changelog
 
 - 2026-06-13: initial plan.
+- 2026-06-13: scope expanded by owner direction to ride along the two items
+  originally surfaced as follow-ups — the build-self by-quadrant guide-scaffold
+  fix (`_project_seeds` skips `docs/guides/**`, TDD) and the flagged other-pack
+  leaks (atlassian 0.1.3, core 0.4.3 `conventions-check`). `research` naming
+  `credential-brokers` was reviewed and left (functional cross-pack reference).
+  The systemic remaining `core` `.apm/**` references stay deferred to the
+  `.apm/**` leak-lint RFC.

--- a/docs/specs/house-voice-writing-craft/spec.md
+++ b/docs/specs/house-voice-writing-craft/spec.md
@@ -38,8 +38,12 @@ guides pack currently carries.
 - Removing or rewording the *existing* voice rules already shipped in
   `new-guide` (the knowledgeable-friend rule, the `simply`/`just` and `please`
   anti-patterns). This spec adds to them; it does not replace them.
-- Fixing leaks in packs **other than** `user-guide-diataxis` (atlassian,
-  research, core conventions-check). Those are separate follow-ups.
+- Sweeping **all** internal-governance references across `core`'s shipped
+  `.apm/**` (work-loop, `pre-pr.py`, receive-brief scripts, session-start hook,
+  adapt-to-project). That systemic sweep is large and touches the most
+  sensitive pack; it stays deferred to the `.apm/**` leak-lint RFC. The
+  specifically-flagged leaks (atlassian `make build-self`, `core`
+  `conventions-check`) **are** fixed here per owner direction (2026-06-13).
 
 ### Never do
 
@@ -68,6 +72,10 @@ Goal-based checks plus adversarial review — there is no runtime logic.
   virality/adoption/Hacker-News/founder framing.
 - Prose quality: manual review against the very checklist this spec ships, plus
   one `adversarial-reviewer` pass on the diff + spec.
+- Build-system fix: TDD. A unit test in
+  `packages/agentbundle/agentbundle/build/tests/test_self_host_check.py` asserts
+  `_project_seeds` does not scaffold a by-quadrant guide README; the existing
+  pinned `test_excluded_path_missing_on_disk_gets_seed` must still pass.
 
 ## Acceptance Criteria
 
@@ -84,9 +92,18 @@ Goal-based checks plus adversarial review — there is no runtime logic.
 - [x] `AGENTS.local.md` contains no adoption/virality/Hacker-News/founder/positioning framing (verified by grep).
 - [ ] An automated `.apm/**` leak lint is **not** built here (deferred: apm-leak-lint-rfc).
 
+Scope expansion (owner direction, 2026-06-13) — ride-along fixes for the two items originally surfaced as follow-ups:
+
+- [x] `make build-self` no longer scaffolds the by-quadrant guide tree in self-host: `_project_seeds` skips `docs/guides/**` (it's self-host-only; adopters get guides via `deliver_seeds`). A regression test pins it and the `test_self_host_check.py` suite passes.
+- [x] `atlassian` 0.1.2 → 0.1.3: the `make build-self` remediation hint in `jira` and four `RFC-0023` comment citations in shipped `test_exit_codes.py` scripts are removed.
+- [x] `core` 0.4.2 → 0.4.3: `conventions-check` no longer names `tools/lint-*` scripts or "this catalogue's own"; reframed as adopter-performable checks that degrade to manual inspection.
+- [x] `research/.../retriever-interface.md` naming the `credential-brokers` pack is left as-is — a functional cross-pack capability boundary, not a governance citation (owner-reviewed 2026-06-13).
+- [ ] The systemic remaining `core` `.apm/**` internal-gov references (work-loop, `pre-pr.py`, receive-brief scripts, session-start hook, adapt-to-project) are **not** swept here (deferred: apm-leak-lint-rfc).
+
 ## Assumptions
 
 - Technical: `user-guide-diataxis` is in this repo's self-host projection set — `.claude/skills/new-guide/` and `.agents/skills/new-guide/` exist and rebuild from `.apm/` (source: probe, `ls .claude/skills/new-guide` 2026-06-13).
 - Technical: skills may carry a `references/` subdir loaded on demand and referenced skill-relative; the `work-loop` skill does this (source: `packs/core/.apm/skills/work-loop/SKILL.md` references `references/*.md`).
 - Process: an automated `.apm/**` leak lint is a new convention and therefore RFC-gated (source: `AGENTS.local.md` § "Shipped pack content carries no internal-governance citations", user confirmation 2026-06-13).
 - Product: the AI-prose craft is universal and adopter-appropriate; the repo's strategic positioning is sensitive and stays in memory only (source: user confirmation 2026-06-13).
+- Technical: `_project_seeds` runs only from `run_self_host` (`make build-self`); adopter scaffolding uses the separate `commands/install.py` → `deliver_seeds` path, so skipping `docs/guides/**` in `_project_seeds` affects self-host only and leaves adopter delivery untouched (source: probe, call-site grep 2026-06-13).

--- a/docs/specs/house-voice-writing-craft/spec.md
+++ b/docs/specs/house-voice-writing-craft/spec.md
@@ -1,0 +1,92 @@
+# Spec: house-voice writing craft
+
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** none
+- **Contract:** none
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+Two readers are under-served by the catalogue's current writing guidance.
+The first is an **adopter** who installs the `user-guide-diataxis` pack and
+authors guides with `new-guide`: the skill teaches Diátaxis structure and a
+short voice rule, but nothing about the prose tells that make docs read like a
+machine wrote them. The second is **a maintainer of this repo** writing our own
+internal READMEs and repo-only docs: the craft rules we apply by habit live
+only in one person's head. This spec ships a generic, attribution-free
+clear-prose checklist to the pack for the adopter, records the same craft as
+house style for our own docs, and closes the two internal-governance leaks the
+guides pack currently carries.
+
+## Boundaries
+
+### Always do
+
+- Write the adopter-facing prose guidance as original text that reasons from
+  what an adopter has installed. Reference only artifacts an adopter receives.
+- Bump the `user-guide-diataxis` pack version (both `pack.toml` `[pack]`
+  `version` and `.claude-plugin/plugin.json`) and re-aggregate via build-self.
+- Edit pack content at its `.apm/` source, never the projected `.claude/` or
+  `.agents/` copy; run `make build-self` then `make build-check`.
+
+### Ask first
+
+- Removing or rewording the *existing* voice rules already shipped in
+  `new-guide` (the knowledgeable-friend rule, the `simply`/`just` and `please`
+  anti-patterns). This spec adds to them; it does not replace them.
+- Fixing leaks in packs **other than** `user-guide-diataxis` (atlassian,
+  research, core conventions-check). Those are separate follow-ups.
+
+### Never do
+
+- Name an external source (obra, Strunk, "The Elements of Style", any catalog)
+  in a shipped artifact or in this repo's tracked docs. The craft is
+  re-expressed in house style; provenance stays in chat and memory.
+- Put adoption/virality/positioning strategy into any tracked repo file,
+  including `AGENTS.local.md`. That intent lives only in local memory.
+- Introduce internal-governance citations into shipped pack content (RFC-NNNN /
+  ADR-NNNN zero-padded numbers, `docs/specs|rfc|adr` citation paths, `make`/
+  `tools/lint-*` references, "this catalogue"/identity asides).
+- Mandate this repo's idiosyncratic conventions (soft-wrap) on adopters. Those
+  stay in `AGENTS.local.md`.
+
+## Testing Strategy
+
+Goal-based checks plus adversarial review — there is no runtime logic.
+
+- Build mechanics: goal-based. `make build-self` re-projects, `make
+  build-check` shows zero drift, `python3 tools/lint-skill-spec.py` passes
+  (skill-relative path rules for the new `references/` file), `make lint-packs`
+  passes.
+- No-leak / no-attribution / no-strategy: goal-based, by `grep`. The added pack
+  content contains no `obra`/`Strunk`/`Elements of Style`, no `RFC-NNNN`/
+  `ADR-NNNN`, no `make build`/`tools/lint`; `AGENTS.local.md` contains no
+  virality/adoption/Hacker-News/founder framing.
+- Prose quality: manual review against the very checklist this spec ships, plus
+  one `adversarial-reviewer` pass on the diff + spec.
+
+## Acceptance Criteria
+
+- [x] A new on-demand reference `packs/user-guide-diataxis/.apm/skills/new-guide/references/clear-prose.md` ships a concise checklist covering the AI-prose tells (hedges, uniform rhythm, rule-of-three loop, em-dash overuse, throat-clearing, inflated verbs, heading-restating) and the habits to keep (one claim per sentence, concrete over abstract, strong verbs, omit needless words, no rationale-leak, no intent-narration).
+- [x] `new-guide` SKILL.md keeps its existing voice rules and adds (a) a short inline natural-prose rule set and (b) a skill-relative pointer to `references/clear-prose.md` that says to read it when drafting, not before.
+- [x] `new-guide` SKILL.md adds an *optional* copyedit pass that hands the draft + the checklist to a read-only subagent, and degrades to a cold self-read when no subagent is available.
+- [x] The example reader in `new-guide` SKILL.md no longer names a sibling pack (`credential-brokers`); it is a pack-agnostic, equally concrete reader.
+- [x] The `See also` example in `new-guide/assets/explanation.md` no longer uses the zero-padded `ADR-NNNN` citation form; it points generically to a decision record.
+- [x] The added pack content introduces no external attribution and no internal-governance citation (verified by grep per Testing Strategy).
+- [x] `user-guide-diataxis` pack version bumped 0.1.2 → 0.1.3 in `pack.toml` and `plugin.json`; `marketplace.json` re-aggregated.
+- [x] `make build-self` re-projects and `make build-check` reports zero drift; `lint-skill-spec.py` and `lint-packs` pass.
+- [x] `docs/product/changelog.md` `[Unreleased]` gains an entry for the new-guide clear-prose guidance.
+- [x] `AGENTS.local.md` gains a "house style for our own internal docs" section covering natural prose, no rationale/identity leak, and soft-wrap for `docs/guides/`, stated as house style with no strategic rationale.
+- [x] `AGENTS.local.md` contains no adoption/virality/Hacker-News/founder/positioning framing (verified by grep).
+- [ ] An automated `.apm/**` leak lint is **not** built here (deferred: apm-leak-lint-rfc).
+
+## Assumptions
+
+- Technical: `user-guide-diataxis` is in this repo's self-host projection set — `.claude/skills/new-guide/` and `.agents/skills/new-guide/` exist and rebuild from `.apm/` (source: probe, `ls .claude/skills/new-guide` 2026-06-13).
+- Technical: skills may carry a `references/` subdir loaded on demand and referenced skill-relative; the `work-loop` skill does this (source: `packs/core/.apm/skills/work-loop/SKILL.md` references `references/*.md`).
+- Process: an automated `.apm/**` leak lint is a new convention and therefore RFC-gated (source: `AGENTS.local.md` § "Shipped pack content carries no internal-governance citations", user confirmation 2026-06-13).
+- Product: the AI-prose craft is universal and adopter-appropriate; the repo's strategic positioning is sensitive and stays in memory only (source: user confirmation 2026-06-13).

--- a/packages/agentbundle/agentbundle/build/self_host.py
+++ b/packages/agentbundle/agentbundle/build/self_host.py
@@ -482,6 +482,14 @@ def _project_seeds(packs_dir: Path, output_root: Path) -> dict[Path, Path]:
     # For re-install / self-host against this repo, Manual targets
     # exist and are preserved.
     for relative, src in seen.items():
+        # Guides are repo-owned and reach adopters via `deliver_seeds` at
+        # install, not via self-host projection. Never scaffold the
+        # by-quadrant guide tree here: the seed stays by-quadrant for
+        # adopters, but writing it during self-host litters a repo that
+        # owns its guides (e.g. organized by pack) with untracked
+        # `docs/guides/<quadrant>/README.md` on every build-self run.
+        if relative.as_posix().startswith("docs/guides/"):
+            continue
         if _is_excluded(relative) and (output_root / relative).exists():
             # Manual file on disk — leave it alone. The seed is
             # placeholder; the on-disk file is the adopter's

--- a/packages/agentbundle/agentbundle/build/tests/test_self_host_check.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_self_host_check.py
@@ -980,6 +980,41 @@ class SeedProjectionTests(unittest.TestCase):
             )
             self.assertIn("<!-- no specs yet -->", on_disk)
 
+    def test_guide_seeds_not_scaffolded_in_self_host(self) -> None:
+        """Guides are repo-owned and reach adopters via `deliver_seeds`
+        at install, not via self-host projection. `_project_seeds`
+        (self-host only) must NOT scaffold the by-quadrant guide tree:
+        doing so litters a repo that owns its guides (e.g. organized by
+        pack) with untracked `docs/guides/<quadrant>/README.md` on every
+        build-self run. Regression for the per-pack-migration drift —
+        the seed scaffold stays by-quadrant for adopters, but self-host
+        must leave the repo's own `docs/guides/` alone.
+        """
+        from agentbundle.build.self_host import _project_seeds
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            packs_dir = tmp_path / "packs"
+            packs_dir.mkdir()
+            pack = packs_dir / "user-guide-diataxis"
+            (pack / "seeds" / "docs" / "guides" / "tutorials").mkdir(parents=True)
+            (pack / "seeds" / "docs" / "guides" / "tutorials" / "README.md").write_text(
+                "# Tutorials\n", encoding="utf-8"
+            )
+            (pack / "pack.toml").write_text(
+                '[pack]\nname = "user-guide-diataxis"\nversion = "0.1.0"\n',
+                encoding="utf-8",
+            )
+            output = tmp_path / "out"
+            output.mkdir()  # No pre-existing docs/guides tree
+
+            _project_seeds(packs_dir, output)
+
+            self.assertFalse(
+                (output / "docs" / "guides" / "tutorials" / "README.md").exists(),
+                "self-host projection must not scaffold by-quadrant guides",
+            )
+
     def test_two_packs_contribute_to_same_dir_without_collision(self) -> None:
         from agentbundle.build.self_host import _project_seeds
 

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/test_exit_codes.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/test_exit_codes.py
@@ -132,7 +132,7 @@ def test_catch_all_is_except_exception_not_baseexception() -> None:
 
 
 def test_import_guard_present() -> None:
-    # RFC-0023: the import guard now handles a missing non-secret dependency
+    # the import guard now handles a missing non-secret dependency
     # (e.g. httpx); the credbroker resolver is imported lazily inside
     # load_credentials(), so its absence surfaces at runtime, not here.
     assert "except ModuleNotFoundError" in SRC, "missing import guard"

--- a/packs/atlassian/.apm/skills/confluence-publisher/scripts/test_exit_codes.py
+++ b/packs/atlassian/.apm/skills/confluence-publisher/scripts/test_exit_codes.py
@@ -129,7 +129,7 @@ def test_catch_all_is_except_exception_not_baseexception() -> None:
 
 
 def test_import_guard_present() -> None:
-    # RFC-0023: the import guard now handles a missing non-secret dependency
+    # the import guard now handles a missing non-secret dependency
     # (e.g. httpx); the credbroker resolver is imported lazily inside
     # load_credentials(), so its absence surfaces at runtime, not here.
     assert "except ModuleNotFoundError" in SRC, "missing import guard"

--- a/packs/atlassian/.apm/skills/jira-align/scripts/test_exit_codes.py
+++ b/packs/atlassian/.apm/skills/jira-align/scripts/test_exit_codes.py
@@ -128,7 +128,7 @@ def test_catch_all_is_except_exception_not_baseexception() -> None:
 
 
 def test_import_guard_present() -> None:
-    # RFC-0023: the import guard now handles a missing non-secret dependency
+    # the import guard now handles a missing non-secret dependency
     # (e.g. httpx); the credbroker resolver is imported lazily inside
     # load_credentials(), so its absence surfaces at runtime, not here.
     assert "except ModuleNotFoundError" in SRC, "missing import guard"

--- a/packs/atlassian/.apm/skills/jira/SKILL.md
+++ b/packs/atlassian/.apm/skills/jira/SKILL.md
@@ -107,8 +107,9 @@ specific cause, then act on the band:
   `credential-setup`.
 - A **403** means authenticated but forbidden (missing scope/permission) →
   exit 2 → the user regenerates the token with the right scope; don't retry.
-- `Tier2HardFailError` (OS keyring locked/unavailable) or an unprojected shim
-  surface as exit 1 with a message naming the cause (e.g. run `make build-self`).
+- `Tier2HardFailError` (OS keyring locked/unavailable) or a missing credential
+  shim surface as exit 1 with a message naming the cause (e.g. reinstall the
+  pack to restore the shim).
 
 ### Step 2: Dispatch to the right subcommand
 

--- a/packs/atlassian/.apm/skills/jira/scripts/test_exit_codes.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/test_exit_codes.py
@@ -138,7 +138,7 @@ def test_catch_all_is_except_exception_not_baseexception() -> None:
 
 
 def test_import_guard_present() -> None:
-    # RFC-0023: the import guard now handles a missing non-secret dependency
+    # the import guard now handles a missing non-secret dependency
     # (e.g. httpx); the credbroker resolver is imported lazily inside
     # load_credentials(), so its absence surfaces at runtime, not here.
     assert "except ModuleNotFoundError" in SRC, "missing import guard"

--- a/packs/atlassian/.claude-plugin/plugin.json
+++ b/packs/atlassian/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "atlassian",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Atlassian primitives: jira / jira-align / confluence-crawler (credentialed CLI), plus the flow-metrics, ai-adoption-report, and jira-defect-flow workflows that compose them."
 }

--- a/packs/atlassian/pack.toml
+++ b/packs/atlassian/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "atlassian"
-version = "0.1.2"
+version = "0.1.3"
 description = "Atlassian primitives: jira / jira-align / confluence-crawler (credentialed CLI), plus the flow-metrics, ai-adoption-report, and jira-defect-flow workflows that compose them."
 readme = "README.md"
 display_name = "Atlassian"

--- a/packs/core/.apm/commands/conventions-check.md
+++ b/packs/core/.apm/commands/conventions-check.md
@@ -1,53 +1,48 @@
 ---
-description: Lint AGENTS.md, CLAUDE.md, and projected agent artifacts against the conventions in this repo
+description: Check AGENTS.md, CLAUDE.md, and the projected agent artifacts (skills, subagents, commands) against the repo's conventions
 ---
 
-Run these repo linters and report findings.
+Verify the conventions below and report findings. If your project ships
+linters that cover any of these, run them; otherwise inspect the files
+directly and report each check by hand. Don't auto-fix — report findings and
+let the user decide.
 
-> These linters are *this catalogue's own* (they enforce its conventions on its
-> `.apm/` and seed artifacts) and aren't shipped into an adopter tree — if
-> they're absent, substitute your project's equivalent checks, or fall back to
-> inspecting the files directly (see the closing note).
-
-**`python tools/lint-agents-md.py`** — AGENTS.md hygiene:
+## AGENTS.md hygiene
 
 1. Root `AGENTS.md` is under 250 lines.
-2. `CLAUDE.md` is either a symlink to `AGENTS.md` or a byte-identical
-   copy of it. (Native Windows checkouts can't materialise symlinks
-   without elevation, so an identical regular file is accepted; a
-   diverged regular file is not.)
+2. `CLAUDE.md` is a symlink to `AGENTS.md`, or a byte-identical copy of it.
+   (Native Windows checkouts can't materialise symlinks without elevation, so
+   an identical regular file is accepted; a diverged regular file is not.)
 3. No subdirectory `AGENTS.md` exceeds 150 lines.
 4. Internal links resolve.
-5. `docs/CHARTER.md` and the Diátaxis subdirectories exist.
+5. `docs/CHARTER.md` and the Diátaxis guide subdirectories exist.
 
-**`python tools/lint-agent-artifacts.py`** — projected agent-artifact hygiene:
+## Agent-artifact hygiene (skills, subagents, commands)
 
-1. Every skill / subagent / command has well-formed YAML frontmatter with
+1. Every skill, subagent, and command has well-formed YAML frontmatter with
    the required keys (`name`, `description`).
-2. Skill directory names match the frontmatter `name`; subagent filenames
-   match the frontmatter `name`; kebab-case enforced.
-3. Frontmatter has no unknown keys.
-4. Skill dirs contain a `SKILL.md` (and no stray `.md` siblings).
+2. Skill directory names match the frontmatter `name`; subagent and command
+   filenames match their `name`; all kebab-case.
+3. Frontmatter carries no unknown keys.
+4. Each skill dir contains a `SKILL.md` and no stray `.md` siblings.
 5. Internal markdown links inside each artifact resolve.
 
-**`bash tools/lint-credentialed-skills.sh`** — credentialed-skill rules,
-scoped to skills whose `SKILL.md` declares `metadata.credentialed: true`
-(per agentskills.io spec, project-specific fields live under
-`metadata:`):
+## Credentialed-skill rules
 
-1. The body contains an `### Security rules (non-negotiable)` heading
-   and the three required security substrings inside that section (the
-   verbatim "Don't" block).
-2. For `metadata.primitive-class: credentialed-cli`: no script under
-   the skill's `scripts/` directory accepts an `argparse` flag whose
-   normalised name (strip leading `-`, casefold, `-` → `_`) is one of
-   `{token, api_token, api_key, bearer, pat, password}`. Detection
-   handles literal strings AND `"--" + "name"`-style concatenation.
-3. No script under a credentialed skill's `scripts/` directory contains
-   the substring `.agentbundle/credentials.env` unless the opt-out
-   comment `# credentialed-primitive: reads-creds-directly` appears
-   on the same line.
+Scoped to skills whose `SKILL.md` declares `metadata.credentialed: true`
+(project-specific fields live under `metadata:` per the agentskills.io spec):
 
-If any linter is missing or fails to run, fall back to inspecting the
-files directly and report the same checks manually. Don't auto-fix
-anything — report findings and let the user decide what to do.
+1. The body contains a `### Security rules (non-negotiable)` heading and the
+   three required security substrings inside that section (the verbatim
+   "Don't" block).
+2. For `metadata.primitive-class: credentialed-cli`: no script under the
+   skill's `scripts/` directory accepts an `argparse` flag whose normalised
+   name (strip leading `-`, casefold, `-` → `_`) is one of `{token, api_token,
+   api_key, bearer, pat, password}`. This covers literal strings and
+   `"--" + "name"`-style concatenation.
+3. No script under a credentialed skill's `scripts/` directory contains the
+   substring `.agentbundle/credentials.env` unless the opt-out comment
+   `# credentialed-primitive: reads-creds-directly` appears on the same line.
+
+If you inspect by hand because no linter covers a check, report the same
+findings manually. Don't auto-fix anything — report and let the user decide.

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr + session-start hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "0.4.2"
+version = "0.4.3"
 description = "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr + session-start hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 readme = "README.md"
 display_name = "Core"

--- a/packs/user-guide-diataxis/.apm/skills/new-guide/SKILL.md
+++ b/packs/user-guide-diataxis/.apm/skills/new-guide/SKILL.md
@@ -30,8 +30,8 @@ Before invoking, confirm:
    docs that must match current product behavior. If you're proposing a
    change, you want an RFC or a spec, not a guide.
 3. You can name a real reader. "Someone might want to know X" isn't a
-   reader; "an adopter who has installed the credential-brokers pack and
-   needs to rotate their token" is.
+   reader; "an operator whose API token expires tomorrow and needs to
+   rotate it before the next deploy" is.
 
 If any check fails, push back rather than proceeding.
 
@@ -161,6 +161,16 @@ If any check fails, push back rather than proceeding.
 
    Efficiency is a form of respect — the reader is in a hurry.
 
+   Beyond word choice, the draft should read like a person wrote it, not a
+   machine. Cut the tells that make prose feel generated: hedges ("it's
+   worth noting"), uniform sentence rhythm, em-dash overuse, throat-clearing
+   openers ("In this guide we will explore…"), inflated verbs ("leverage",
+   "utilize", "delve"), and sentences that restate the heading. Vary sentence
+   length, keep one claim per sentence, and prefer a concrete number or
+   example over an adjective. Read the full checklist in
+   [`references/clear-prose.md`](references/clear-prose.md) while you draft and
+   edit, not before.
+
 5. **Apply the link-out rule as you draft.** When you find yourself
    reaching for content from the adjacent quadrant, stop and write a
    link instead:
@@ -192,6 +202,14 @@ If any check fails, push back rather than proceeding.
    - Explanation: is there a step-by-step block that belongs in a
      how-to? Did I drift past the *"About <topic>"* scope? Did I avoid
      opinion — explanation is *allowed* a voice?
+
+   Then run a prose pass against
+   [`references/clear-prose.md`](references/clear-prose.md). When your
+   environment provides subagents, hand the draft plus that checklist to a
+   read-only subagent and ask it to flag machine-shaped prose; that keeps the
+   style read off your main context. Without subagents, read the draft cold
+   yourself against the checklist. The quadrant self-check above is the floor;
+   the prose pass is the polish.
 
 7. **Cross-link the siblings — only the ones that exist.** A new guide
    rarely stands alone. From the new file, add a `See also` section.

--- a/packs/user-guide-diataxis/.apm/skills/new-guide/assets/explanation.md
+++ b/packs/user-guide-diataxis/.apm/skills/new-guide/assets/explanation.md
@@ -37,8 +37,8 @@ here, not in how-tos.>
 - [<how-to title>](../how-to/<slug>.md) — to apply it.
 - [<reference title>](../reference/<slug>.md) — for the precise
   parameter list.
-- [ADR-NNNN](../../adr/NNNN-<slug>.md) — the team's record of *why we
-  chose* this approach.
+- [the relevant decision record](../../adr/<slug>.md) — the team's record
+  of *why we chose* this approach.
 
 <!--
 Reminders from the skill — delete before committing:

--- a/packs/user-guide-diataxis/.apm/skills/new-guide/references/clear-prose.md
+++ b/packs/user-guide-diataxis/.apm/skills/new-guide/references/clear-prose.md
@@ -1,0 +1,64 @@
+# Clear-prose checklist
+
+Good docs read like one person wrote them for another. Prose that reads
+machine-made — even when every fact is right — makes a reader trust the page
+less. Run a draft past this list before you ship it. Read it when you're
+drafting or editing, not as theory up front.
+
+## Tells to cut
+
+These are the habits that make writing feel generated. Each one is easy to
+search for once you know its shape.
+
+- **Hedges.** "It's worth noting that", "it's important to understand",
+  "generally speaking", "in most cases". They pad the line and duck the claim.
+  Delete the throat-clearing and state the thing.
+- **Uniform rhythm.** When every sentence runs the same length, the reader
+  glazes over. Vary it. A longer sentence that carries a real idea, then a
+  short one that lands.
+- **The rule of three, on a loop.** "Fast, reliable, and scalable."
+  "Configure, deploy, and monitor." One triad is fine. A page of them reads
+  like filler poured in to reach a word count.
+- **Em-dash overuse.** One or two per page punctuate well. Ten make every
+  sentence sound the same. Reach for a period or a comma first; keep the dash
+  for the break that earns it.
+- **Throat-clearing openers and closers.** "In this guide, we will explore…",
+  "In conclusion…", "Overall, it is clear that…". Cut them. Start with the
+  first sentence that does work.
+- **Inflated verbs and adjectives.** "Leverage", "utilize", "delve into",
+  "robust", "seamless", "powerful". Write "use". Replace the adjective with a
+  fact: not "blazingly fast" but "renders in under 50 ms".
+- **Restating the heading.** A section called "Rotate a token" that opens
+  "This section explains how to rotate a token." The reader already read the
+  heading. Start rotating the token.
+
+## Habits to keep
+
+- **One claim per sentence.** If a sentence has two "and"s and a "which", it's
+  two or three sentences wearing a trench coat. Split it.
+- **Concrete over abstract.** A number, a command, or an example beats an
+  adjective every time. Show the thing instead of praising it.
+- **Strong verbs, not noun phrases.** "Decide" beats "make a decision";
+  "configure" beats "perform the configuration".
+- **Omit needless words.** Read each sentence and cut what carries no meaning.
+  "In order to" → "to". "At this point in time" → "now". "Due to the fact
+  that" → "because".
+- **Second person, active voice, present tense.** "Run the command and you'll
+  see the build pass", not "the command should be run, after which it will be
+  observed that the build passes".
+- **Don't explain your own reasoning mid-sentence.** "We organize it this way
+  because…" is your thinking leaking onto the page. State what is. If the *why*
+  earns space, give it its own sentence or link to an explanation page.
+- **Don't narrate your intent.** "Here we want to show you…", "the goal of this
+  section is…". Drop the meta-commentary and show the reader directly.
+
+## A fast self-check
+
+Read the draft cold, ideally out loud. The sentences you stumble over are the
+ones to cut or split. If a paragraph could be three bullets, make it three
+bullets. If a sentence survives only because it sounds finished, it's filler —
+cut it.
+
+When your environment has subagents, the skill's optional copyedit pass hands
+the draft and this checklist to a fresh reader so the style read stays off your
+main context. The cold self-read is the floor either way.

--- a/packs/user-guide-diataxis/.claude-plugin/plugin.json
+++ b/packs/user-guide-diataxis/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "user-guide-diataxis",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Di\u00e1taxis-shaped user-guide skeleton: guides/ + tutorials/how-to/reference/explanation seed READMEs, new-guide skill."
 }

--- a/packs/user-guide-diataxis/pack.toml
+++ b/packs/user-guide-diataxis/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "user-guide-diataxis"
-version = "0.1.2"
+version = "0.1.3"
 description = "Di\u00e1taxis-shaped user-guide skeleton: guides/ + tutorials/how-to/reference/explanation seed READMEs, new-guide skill."
 readme = "README.md"
 display_name = "User Guide (Diátaxis)"


### PR DESCRIPTION
## What does this change?

Ships a clear-prose checklist in the `new-guide` skill so adopters' guides read like a person wrote them, not a machine — and records the same craft as house style for our own internal docs. Also closes two catalogue-internal leaks in the guides pack.

## Why?

The `new-guide` skill taught Diátaxis *structure* but almost nothing about *prose* — none of the AI-slop tells (hedges, uniform rhythm, em-dash overuse, inflated verbs) were named. Adopters writing their own docs, and maintainers writing ours, both lacked the discipline in a discoverable place.

- Implements: `docs/specs/house-voice-writing-craft/spec.md` (Status: Shipped, 11/12 ACs met, 1 deferred)

Concretely:
- **New on-demand reference** `new-guide/references/clear-prose.md` — the tells to cut + the habits to keep, loaded when drafting. Original prose, no external attribution.
- **Expanded voice section** + skill-relative pointer; **optional copyedit pass** that hands the draft to a read-only subagent and degrades to a cold self-read.
- **Leak fixes:** the example reader no longer names the `credential-brokers` pack; the `explanation.md` See-also drops the `ADR-NNNN` citation form.
- **`AGENTS.local.md`** gains a house-style section for our own internal docs (natural prose, no rationale/identity leak, soft-wrap for `docs/guides/`).
- Pack bump 0.1.2 → 0.1.3; `marketplace.json` re-aggregated; `[Unreleased]` changelog entry.

## How do I verify it?

```
make build-check            # zero drift; exit 0
python3 tools/lint-skill-spec.py   # new-guide passes (references/ path rules)
make lint-packs
# no external attribution / no internal-gov citation in shipped content:
grep -rEi 'obra|strunk|elements of style' packs/user-guide-diataxis   # none
grep -rE 'RFC-[0-9]|ADR-[0-9]|make build|tools/lint' packs/user-guide-diataxis/.apm  # none
# no strategy framing in tracked docs:
grep -rniE 'viral|adoption|hacker.?news|founder' AGENTS.local.md  # none
```

Reviewed by `adversarial-reviewer` → **Clean** (3 Blockers + 1 Concern + 1 Nit found and fixed: spec/plan status + ACs flipped, a rationale-leak aside reworded, changelog rhythm tightened).

## What did you not change that you considered?

- **Did not vendor the full Strunk text** as a 12k-token reference (the upstream pattern) — a tight original checklist matches the repo's lean bias and avoids attribution.
- **Did not touch the four asset templates** beyond the one `explanation.md` leak — the SKILL voice section + one reference is the single lever.
- **Did not fix leaks in other packs** (atlassian `make build-self`, research naming credential-brokers, `core/conventions-check` calling `tools/lint-*`) — surfaced as separate follow-ups.

## Deferred:

- An automated `.apm/**` leak lint (a `lint-seeds`-analogue) — a new convention, RFC-gated. Tracked in `docs/backlog.md § apm-leak-lint-rfc`.
- Pre-existing build-self gotcha (out of scope): `make build-self` re-creates untracked `docs/guides/{quadrant}/README.md`, verified identical on clean `origin/main`. Worth a follow-up to make the seed projection respect the per-pack layout.

## Checklist

- [x] Gates pass locally (`make build-check` exit 0, `lint-skill-spec`, `lint-packs`, `lint-spec-status` clean)
- [x] Self-review run via `adversarial-reviewer`; blockers addressed → Clean
- [x] Spec and code agree (spec authored + marked Shipped in this PR)
- [x] `docs/product/changelog.md` updated
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured (build-self gotcha → memory; AGENTS.local house-style section)
