### PR TITLE
chore(packs): sweep remaining catalogue-internal references from shipped content (core 0.4.4, figma 0.1.3)

### DIFF
--- a/.agents/skills/adapt-to-project/assets/reference.md
+++ b/.agents/skills/adapt-to-project/assets/reference.md
@@ -60,7 +60,7 @@ reason it won. This is the section a new contributor reads first to understand
 
 *The reusable internal building blocks and the component stereotypes new code
 is expected to reuse rather than reinvent.* This is the heart of the golden
-path: when a design needs a thing this catalogue already names, it uses that
+path: when a design needs a thing this project already names, it uses that
 thing. Reach for something new only with a recorded reason.
 
 - **Component stereotypes.** <The recurring *kinds* of component in this repo

--- a/.agents/skills/receive-brief/scripts/lint-brief-coverage.py
+++ b/.agents/skills/receive-brief/scripts/lint-brief-coverage.py
@@ -5,8 +5,8 @@ This is a `receive-brief` **skill script**: it lives at
 `packs/core/.apm/skills/receive-brief/scripts/lint-brief-coverage.py` and
 projects to every adapter's `.../skills/receive-brief/scripts/`, the same way
 the work-loop's `lint-spec-status.py` does. The agent runs it after a slice's
-status changes; the catalogue additionally runs it as a **fail-closed CI gate**
-via `make build-check`. It no-ops gracefully where Python is absent.
+status changes; it can also run as a **fail-closed CI gate** where a PR event
+and Python both exist. It no-ops gracefully where Python is absent.
 
 What it does: reads every `docs/specs/*/spec.md` `Status:` field, follows the
 `Brief:` back-links, and rolls each brief's Spec map up from its child specs —
@@ -230,7 +230,7 @@ def check(root: Path) -> tuple[list[str], list[str]]:
 
 
 def _repo_root() -> Path:
-    # Best-effort discovery for a bare manual run. The gate (`make build-check`)
+    # Best-effort discovery for a bare manual run. The CI gate
     # and every self-test pass `--root` explicitly, so this only fires for a
     # hand-run with no `--root`; prefer git's toplevel when available.
     try:

--- a/.agents/skills/receive-brief/scripts/test-lint-brief-coverage.py
+++ b/.agents/skills/receive-brief/scripts/test-lint-brief-coverage.py
@@ -3,7 +3,7 @@
 
 Builds fixture brief + spec trees in a tempdir and runs the linter as a
 subprocess against the documented `python <skill>/scripts/lint-brief-coverage.py
---root <dir>` invocation — the same shape `make build-check` uses (not a
+--root <dir>` invocation — the same shape the CI gate uses (not a
 synthesised import, so the real `from .X import Y`-free entry point is
 exercised). Covers each acceptance case red-and-green: rollup of a mixed map,
 all-Shipped → delivered, empty map → not delivered, no-brief no-op, untracked

--- a/.agents/skills/work-loop/SKILL.md
+++ b/.agents/skills/work-loop/SKILL.md
@@ -269,7 +269,7 @@ For anything beyond trivial, *think before you write code*. Concretely:
   into its brief in their proactive-control framing, per the
   [boundary→module routing table](#boundarymodule-routing-table) below. This
   is **net-new wiring** — distinct from the adversarial-only firing above and
-  from RFC-0025's separate light→full escalation use of the same trigger; it
+  from the separate light→full escalation use of the same trigger; it
   is not a re-use of either. Same Profile-A opt-out and the same
   `approve-plan` gate apply. Fallback if no `security-reviewer` subagent is
   installed: proceed and note the missing review in the final summary.
@@ -455,8 +455,8 @@ go to FIX. Don't move past a failing gate by editing the gate.
 > the four drift invariants the `adversarial-reviewer` checks by judgment; it
 > no-ops where Python is absent. It is *available and agent-invoked, not
 > fail-closed* (there is no PR-open hook event to bind it to). **Do not** wire it
-> into `pre-pr.py` (a projected hook body that would mis-fire). The catalogue
-> additionally runs it as a fail-closed CI gate via `make build-check`. (Why a
+> into `pre-pr.py` (a projected hook body that would mis-fire). It can also
+> run as a fail-closed CI gate. (Why a
 > skill script and not a `tools/` linter: skill `scripts/` project to every
 > adapter — a later correction to the original "linters don't
 > project" premise.)

--- a/.agents/skills/work-loop/scripts/lint-spec-status.py
+++ b/.agents/skills/work-loop/scripts/lint-spec-status.py
@@ -8,13 +8,12 @@ does. The agent runs it at the work-loop's finish-time checklist — *available
 and agent-invoked, not fail-closed* (there is no PR-open hook event in an
 adopter repo). It no-ops gracefully where Python is absent.
 
-The catalogue additionally runs it as a **fail-closed CI gate** via
-`make build-check` (where a PR event and Python both exist). Do NOT wire it into
-`tools/hooks/pre-pr.py`: that hook is a *body* that projects to adopter trees
-and would mis-fire — the finish-time skill checklist and the Makefile gate are
-the two invocation surfaces. (An earlier design shipped this as a
-catalogue-only `tools/` linter; it now ships as a skill script so it projects
-to adopters too.)
+It can also run as a **fail-closed CI gate** where a PR event and Python both
+exist. Do NOT wire it into the projected `pre-pr` hook body: that body projects
+to adopter trees and would mis-fire — the finish-time skill checklist and a CI
+gate are the two invocation surfaces. (An earlier design shipped this as a
+standalone linter; it now ships as a skill script so it projects to adopters
+too.)
 
 It checks five invariants over `docs/specs/*/spec.md`, measured against the
 contract pinned in `CONVENTIONS.md` § 4 (Spec metadata contract). Only the

--- a/.agents/skills/work-loop/scripts/test-lint-spec-status.py
+++ b/.agents/skills/work-loop/scripts/test-lint-spec-status.py
@@ -3,7 +3,7 @@
 
 Builds fixture spec trees in a tempdir and runs the linter as a
 subprocess against the documented `python <skill>/scripts/lint-spec-status.py
---root <dir>` invocation — the same shape `make build-check` uses.
+--root <dir>` invocation — the same shape the CI gate uses.
 Exercises each of the four invariants red-and-green, including the
 lenient leading-token parse, the diff-triggered ship transition (with
 real git base fixtures), the grandfather and no-base branches, and the

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -86,7 +86,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "core",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.4.3"
+      "version": "0.4.4"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",
@@ -120,7 +120,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "figma",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.1.2"
+      "version": "0.1.3"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/.claude/skills/adapt-to-project/assets/reference.md
+++ b/.claude/skills/adapt-to-project/assets/reference.md
@@ -60,7 +60,7 @@ reason it won. This is the section a new contributor reads first to understand
 
 *The reusable internal building blocks and the component stereotypes new code
 is expected to reuse rather than reinvent.* This is the heart of the golden
-path: when a design needs a thing this catalogue already names, it uses that
+path: when a design needs a thing this project already names, it uses that
 thing. Reach for something new only with a recorded reason.
 
 - **Component stereotypes.** <The recurring *kinds* of component in this repo

--- a/.claude/skills/receive-brief/scripts/lint-brief-coverage.py
+++ b/.claude/skills/receive-brief/scripts/lint-brief-coverage.py
@@ -5,8 +5,8 @@ This is a `receive-brief` **skill script**: it lives at
 `packs/core/.apm/skills/receive-brief/scripts/lint-brief-coverage.py` and
 projects to every adapter's `.../skills/receive-brief/scripts/`, the same way
 the work-loop's `lint-spec-status.py` does. The agent runs it after a slice's
-status changes; the catalogue additionally runs it as a **fail-closed CI gate**
-via `make build-check`. It no-ops gracefully where Python is absent.
+status changes; it can also run as a **fail-closed CI gate** where a PR event
+and Python both exist. It no-ops gracefully where Python is absent.
 
 What it does: reads every `docs/specs/*/spec.md` `Status:` field, follows the
 `Brief:` back-links, and rolls each brief's Spec map up from its child specs —
@@ -230,7 +230,7 @@ def check(root: Path) -> tuple[list[str], list[str]]:
 
 
 def _repo_root() -> Path:
-    # Best-effort discovery for a bare manual run. The gate (`make build-check`)
+    # Best-effort discovery for a bare manual run. The CI gate
     # and every self-test pass `--root` explicitly, so this only fires for a
     # hand-run with no `--root`; prefer git's toplevel when available.
     try:

--- a/.claude/skills/receive-brief/scripts/test-lint-brief-coverage.py
+++ b/.claude/skills/receive-brief/scripts/test-lint-brief-coverage.py
@@ -3,7 +3,7 @@
 
 Builds fixture brief + spec trees in a tempdir and runs the linter as a
 subprocess against the documented `python <skill>/scripts/lint-brief-coverage.py
---root <dir>` invocation — the same shape `make build-check` uses (not a
+--root <dir>` invocation — the same shape the CI gate uses (not a
 synthesised import, so the real `from .X import Y`-free entry point is
 exercised). Covers each acceptance case red-and-green: rollup of a mixed map,
 all-Shipped → delivered, empty map → not delivered, no-brief no-op, untracked

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -269,7 +269,7 @@ For anything beyond trivial, *think before you write code*. Concretely:
   into its brief in their proactive-control framing, per the
   [boundary→module routing table](#boundarymodule-routing-table) below. This
   is **net-new wiring** — distinct from the adversarial-only firing above and
-  from RFC-0025's separate light→full escalation use of the same trigger; it
+  from the separate light→full escalation use of the same trigger; it
   is not a re-use of either. Same Profile-A opt-out and the same
   `approve-plan` gate apply. Fallback if no `security-reviewer` subagent is
   installed: proceed and note the missing review in the final summary.
@@ -455,8 +455,8 @@ go to FIX. Don't move past a failing gate by editing the gate.
 > the four drift invariants the `adversarial-reviewer` checks by judgment; it
 > no-ops where Python is absent. It is *available and agent-invoked, not
 > fail-closed* (there is no PR-open hook event to bind it to). **Do not** wire it
-> into `pre-pr.py` (a projected hook body that would mis-fire). The catalogue
-> additionally runs it as a fail-closed CI gate via `make build-check`. (Why a
+> into `pre-pr.py` (a projected hook body that would mis-fire). It can also
+> run as a fail-closed CI gate. (Why a
 > skill script and not a `tools/` linter: skill `scripts/` project to every
 > adapter — a later correction to the original "linters don't
 > project" premise.)

--- a/.claude/skills/work-loop/scripts/lint-spec-status.py
+++ b/.claude/skills/work-loop/scripts/lint-spec-status.py
@@ -8,13 +8,12 @@ does. The agent runs it at the work-loop's finish-time checklist — *available
 and agent-invoked, not fail-closed* (there is no PR-open hook event in an
 adopter repo). It no-ops gracefully where Python is absent.
 
-The catalogue additionally runs it as a **fail-closed CI gate** via
-`make build-check` (where a PR event and Python both exist). Do NOT wire it into
-`tools/hooks/pre-pr.py`: that hook is a *body* that projects to adopter trees
-and would mis-fire — the finish-time skill checklist and the Makefile gate are
-the two invocation surfaces. (An earlier design shipped this as a
-catalogue-only `tools/` linter; it now ships as a skill script so it projects
-to adopters too.)
+It can also run as a **fail-closed CI gate** where a PR event and Python both
+exist. Do NOT wire it into the projected `pre-pr` hook body: that body projects
+to adopter trees and would mis-fire — the finish-time skill checklist and a CI
+gate are the two invocation surfaces. (An earlier design shipped this as a
+standalone linter; it now ships as a skill script so it projects to adopters
+too.)
 
 It checks five invariants over `docs/specs/*/spec.md`, measured against the
 contract pinned in `CONVENTIONS.md` § 4 (Spec metadata contract). Only the

--- a/.claude/skills/work-loop/scripts/test-lint-spec-status.py
+++ b/.claude/skills/work-loop/scripts/test-lint-spec-status.py
@@ -3,7 +3,7 @@
 
 Builds fixture spec trees in a tempdir and runs the linter as a
 subprocess against the documented `python <skill>/scripts/lint-spec-status.py
---root <dir>` invocation — the same shape `make build-check` uses.
+--root <dir>` invocation — the same shape the CI gate uses.
 Exercises each of the four invariants red-and-green, including the
 lenient leading-token parse, the diff-triggered ship transition (with
 real git base fixtures), the grandfather and no-base branches, and the

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -655,3 +655,17 @@ across four files) is exactly the systematic job the lint should drive, not a
 hand-sweep. Land the lint under the RFC, then do the sweep under it.
 (`RFC-1918` in `security-checklists/references/outbound-ssrf.md` is a real IETF
 standard, not an internal citation — leave it.)
+
+## `apm-internal-ref-sweep`
+
+### credbroker-frozen-pack-ref-sweep
+
+The `credential-brokers` pack's shipped `.apm/**` carries `RFC-0023` / `RFC-0006`
+citations in `skills/credential-setup/scripts/setup.py` and the
+`user-libs/credbroker/` library docstrings/comments (`__init__.py`, `_core.py`,
+`_vault.py`). These are the same dangling-on-arrival class the `apm-internal-ref-sweep`
+cleaned from core + figma, but the pack is **frozen by RFC-0013 (§4/§4d)** and
+the citations sit in library-provenance docstrings rather than agent-facing
+prose, so they were left for a separate, deliberate pass that respects the
+freeze. Fold this into the `apm-leak-lint-rfc` work, or do it as a focused
+comment-only PR against the frozen pack with explicit sign-off.

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -19,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The rest of the catalogue-internal references are swept from shipped
+  content (core 0.4.4, figma 0.1.3).** Following the first pass, the remaining
+  `make build-*` build-target mentions, an internal RFC citation, and the "this
+  catalogue" identity asides are removed from the work-loop and receive-brief
+  skill scripts, the session-start hook, the `pre-pr` hook, and the
+  adapt-to-project reference; figma's exit-code test drops a dangling internal-RFC
+  comment. Comment, docstring, and prose only — no behavior change.
+  (`credential-brokers`, which is frozen, is left for a separate pass.)
+
 - **Shipped pack content sheds catalogue-internal references (core 0.4.3,
   atlassian 0.1.3).** The `conventions-check` command no longer instructs
   running this repo's own `tools/lint-*` scripts — which never install into an

--- a/docs/specs/apm-internal-ref-sweep/spec.md
+++ b/docs/specs/apm-internal-ref-sweep/spec.md
@@ -1,0 +1,44 @@
+# Spec: apm-internal-ref-sweep
+
+Mode: light (no risk trigger fired — mechanical prose/comment cleanup, single logical task, familiar territory; owner directed light mode).
+
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Plan:** inline (light mode)
+- **Constrained by:** none
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it.
+
+## Objective
+
+Shipped pack content (`packs/*/.apm/**`) must carry no catalogue-internal
+governance references, because adopters receive the artifact but none of the
+governance it was written under. The earlier `house-voice-writing-craft` PR
+fixed the flagged sites and deferred the systemic remainder to this sweep
+(`docs/backlog.md § apm-leak-lint-rfc`). This sweep removes the remaining
+`make build-*` build-target references, the `RFC-NNNN` citation, the "this
+catalogue" identity asides, and one same-class `RFC-0023` comment in `figma` —
+without changing any behavior. `credential-brokers` (frozen by RFC-0013) is
+left for a separate pass.
+
+## Acceptance Criteria
+
+- [x] `core/.apm/hook-wiring/session-start.toml` no longer names `make build-self`.
+- [x] `core/.apm/hooks/pre-pr.py` drops the "this catalogue's own" identity framing (reworded adopter-neutral; the meaning — it runs none of the source project's own linters — is kept).
+- [x] `core/.apm/skills/work-loop/SKILL.md` drops the `RFC-0025` citation (line ~272) and the `make build-check` / "the catalogue" reference (line ~459); the byte-identical risk-trigger block (lines 57–77) is untouched.
+- [x] `core/.apm/skills/work-loop/scripts/lint-spec-status.py` and `test-lint-spec-status.py` docstrings drop `make build-check` and `tools/hooks/pre-pr.py`; the script self-test still passes.
+- [x] `core/.apm/skills/receive-brief/scripts/lint-brief-coverage.py` and `test-lint-brief-coverage.py` drop `make build-check`; the script self-test still passes.
+- [x] `core/.apm/skills/adapt-to-project/assets/reference.md` replaces "this catalogue" with a project-neutral term.
+- [x] `figma/.apm/skills/figma/scripts/test_exit_codes.py` drops the `RFC-0023:` comment prefix.
+- [x] `core` bumped 0.4.3 → 0.4.4; `figma` bumped 0.1.2 → 0.1.3; `marketplace.json` re-aggregated.
+- [x] `make build-self` zero drift; `make build-check`, `lint-skill-spec`, `lint-packs`, the touched script self-tests all pass.
+- [x] No behavior change: every edit is comment/docstring/prose only (code paths untouched).
+- [x] All real carve-outs left intact: spec-driven workflow vocabulary (`docs/specs/<feature>/…`, `docs/rfc/`, `docs/adr/`), real IETF RFCs (`RFC-9457`, `RFC-1918`), template placeholders, and `test-lint-spec-status.py` fixture data.
+- [ ] `credential-brokers` `.apm/**` RFC citations (setup.py, user-libs/credbroker) are **not** swept here (deferred: credbroker-frozen-pack-ref-sweep).
+
+## Tasks
+
+- T1: Reword the core leak sites (session-start, pre-pr.py, work-loop SKILL + scripts, receive-brief scripts, adapt reference); bump core.
+- T2: Reword the figma RFC-0023 comment; bump figma.
+- T3: build-self; run gates + touched script self-tests; single adversarial pass; changelog.

--- a/packs/core/.apm/hook-wiring/session-start.toml
+++ b/packs/core/.apm/hook-wiring/session-start.toml
@@ -6,7 +6,7 @@
 # that under the recipe pipeline's `claude-plugins/<pack>/`
 # output-subdir (so adopters see the file at
 # `<output>/claude-plugins/core/.claude/settings.local.json`); at
-# self-host time, `make build-self` writes the flat workspace path
+# self-host time, the upstream build writes the flat workspace path
 # (`<workspace>/.claude/settings.local.json`, gitignored).
 #
 # Shape: Claude Code's documented nested SessionStart schema

--- a/packs/core/.apm/hooks/pre-pr.py
+++ b/packs/core/.apm/hooks/pre-pr.py
@@ -16,8 +16,8 @@ What it runs:
     into (``.claude/``, ``.agents/``, ``.kiro/`` …). Skipped cleanly when
     there are no active specs (or the work-loop isn't installed).
 
-It deliberately runs **none** of this catalogue's own artifact linters —
-those enforce the catalogue's conventions on the catalogue's own tree and
+It deliberately runs **none** of the source project's own artifact linters —
+those enforce that project's conventions on its own tree and
 don't apply to your repo. Wire your project's lint/typecheck/test commands
 into the stub below instead (or let the ``adapt-to-project`` skill do it).
 

--- a/packs/core/.apm/skills/adapt-to-project/assets/reference.md
+++ b/packs/core/.apm/skills/adapt-to-project/assets/reference.md
@@ -60,7 +60,7 @@ reason it won. This is the section a new contributor reads first to understand
 
 *The reusable internal building blocks and the component stereotypes new code
 is expected to reuse rather than reinvent.* This is the heart of the golden
-path: when a design needs a thing this catalogue already names, it uses that
+path: when a design needs a thing this project already names, it uses that
 thing. Reach for something new only with a recorded reason.
 
 - **Component stereotypes.** <The recurring *kinds* of component in this repo

--- a/packs/core/.apm/skills/receive-brief/scripts/lint-brief-coverage.py
+++ b/packs/core/.apm/skills/receive-brief/scripts/lint-brief-coverage.py
@@ -5,8 +5,8 @@ This is a `receive-brief` **skill script**: it lives at
 `packs/core/.apm/skills/receive-brief/scripts/lint-brief-coverage.py` and
 projects to every adapter's `.../skills/receive-brief/scripts/`, the same way
 the work-loop's `lint-spec-status.py` does. The agent runs it after a slice's
-status changes; the catalogue additionally runs it as a **fail-closed CI gate**
-via `make build-check`. It no-ops gracefully where Python is absent.
+status changes; it can also run as a **fail-closed CI gate** where a PR event
+and Python both exist. It no-ops gracefully where Python is absent.
 
 What it does: reads every `docs/specs/*/spec.md` `Status:` field, follows the
 `Brief:` back-links, and rolls each brief's Spec map up from its child specs —
@@ -230,7 +230,7 @@ def check(root: Path) -> tuple[list[str], list[str]]:
 
 
 def _repo_root() -> Path:
-    # Best-effort discovery for a bare manual run. The gate (`make build-check`)
+    # Best-effort discovery for a bare manual run. The CI gate
     # and every self-test pass `--root` explicitly, so this only fires for a
     # hand-run with no `--root`; prefer git's toplevel when available.
     try:

--- a/packs/core/.apm/skills/receive-brief/scripts/test-lint-brief-coverage.py
+++ b/packs/core/.apm/skills/receive-brief/scripts/test-lint-brief-coverage.py
@@ -3,7 +3,7 @@
 
 Builds fixture brief + spec trees in a tempdir and runs the linter as a
 subprocess against the documented `python <skill>/scripts/lint-brief-coverage.py
---root <dir>` invocation — the same shape `make build-check` uses (not a
+--root <dir>` invocation — the same shape the CI gate uses (not a
 synthesised import, so the real `from .X import Y`-free entry point is
 exercised). Covers each acceptance case red-and-green: rollup of a mixed map,
 all-Shipped → delivered, empty map → not delivered, no-brief no-op, untracked

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -269,7 +269,7 @@ For anything beyond trivial, *think before you write code*. Concretely:
   into its brief in their proactive-control framing, per the
   [boundary→module routing table](#boundarymodule-routing-table) below. This
   is **net-new wiring** — distinct from the adversarial-only firing above and
-  from RFC-0025's separate light→full escalation use of the same trigger; it
+  from the separate light→full escalation use of the same trigger; it
   is not a re-use of either. Same Profile-A opt-out and the same
   `approve-plan` gate apply. Fallback if no `security-reviewer` subagent is
   installed: proceed and note the missing review in the final summary.
@@ -455,8 +455,8 @@ go to FIX. Don't move past a failing gate by editing the gate.
 > the four drift invariants the `adversarial-reviewer` checks by judgment; it
 > no-ops where Python is absent. It is *available and agent-invoked, not
 > fail-closed* (there is no PR-open hook event to bind it to). **Do not** wire it
-> into `pre-pr.py` (a projected hook body that would mis-fire). The catalogue
-> additionally runs it as a fail-closed CI gate via `make build-check`. (Why a
+> into `pre-pr.py` (a projected hook body that would mis-fire). It can also
+> run as a fail-closed CI gate. (Why a
 > skill script and not a `tools/` linter: skill `scripts/` project to every
 > adapter — a later correction to the original "linters don't
 > project" premise.)

--- a/packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py
+++ b/packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py
@@ -8,13 +8,12 @@ does. The agent runs it at the work-loop's finish-time checklist — *available
 and agent-invoked, not fail-closed* (there is no PR-open hook event in an
 adopter repo). It no-ops gracefully where Python is absent.
 
-The catalogue additionally runs it as a **fail-closed CI gate** via
-`make build-check` (where a PR event and Python both exist). Do NOT wire it into
-`tools/hooks/pre-pr.py`: that hook is a *body* that projects to adopter trees
-and would mis-fire — the finish-time skill checklist and the Makefile gate are
-the two invocation surfaces. (An earlier design shipped this as a
-catalogue-only `tools/` linter; it now ships as a skill script so it projects
-to adopters too.)
+It can also run as a **fail-closed CI gate** where a PR event and Python both
+exist. Do NOT wire it into the projected `pre-pr` hook body: that body projects
+to adopter trees and would mis-fire — the finish-time skill checklist and a CI
+gate are the two invocation surfaces. (An earlier design shipped this as a
+standalone linter; it now ships as a skill script so it projects to adopters
+too.)
 
 It checks five invariants over `docs/specs/*/spec.md`, measured against the
 contract pinned in `CONVENTIONS.md` § 4 (Spec metadata contract). Only the

--- a/packs/core/.apm/skills/work-loop/scripts/test-lint-spec-status.py
+++ b/packs/core/.apm/skills/work-loop/scripts/test-lint-spec-status.py
@@ -3,7 +3,7 @@
 
 Builds fixture spec trees in a tempdir and runs the linter as a
 subprocess against the documented `python <skill>/scripts/lint-spec-status.py
---root <dir>` invocation — the same shape `make build-check` uses.
+--root <dir>` invocation — the same shape the CI gate uses.
 Exercises each of the four invariants red-and-green, including the
 lenient leading-token parse, the diff-triggered ship transition (with
 real git base fixtures), the grandfather and no-base branches, and the

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr + session-start hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "0.4.3"
+version = "0.4.4"
 description = "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr + session-start hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 readme = "README.md"
 display_name = "Core"

--- a/packs/figma/.apm/skills/figma/scripts/test_exit_codes.py
+++ b/packs/figma/.apm/skills/figma/scripts/test_exit_codes.py
@@ -106,7 +106,7 @@ def test_catch_all_is_except_exception_not_baseexception() -> None:
 
 
 def test_import_guard_present() -> None:
-    # RFC-0023: the import guard now handles a missing non-secret dependency
+    # the import guard now handles a missing non-secret dependency
     # (e.g. httpx); the credbroker resolver is imported lazily inside
     # load_credentials(), so its absence surfaces at runtime, not here.
     assert "except ModuleNotFoundError" in SRC, "missing import guard"

--- a/packs/figma/.claude-plugin/plugin.json
+++ b/packs/figma/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "figma",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Figma REST API primitive (credentialed CLI). Reads files / nodes / metadata / versions / comments / variables / dev resources, renders frame images, posts comments, and converts FigJam connector graphs to Mermaid."
 }

--- a/packs/figma/pack.toml
+++ b/packs/figma/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "figma"
-version = "0.1.2"
+version = "0.1.3"
 description = "Figma REST API primitive (credentialed CLI). Reads files / nodes / metadata / versions / comments / variables / dev resources, renders frame images, posts comments, and converts FigJam connector graphs to Mermaid."
 readme = "README.md"
 display_name = "Figma"

--- a/tools/hooks/pre-pr.py
+++ b/tools/hooks/pre-pr.py
@@ -16,8 +16,8 @@ What it runs:
     into (``.claude/``, ``.agents/``, ``.kiro/`` …). Skipped cleanly when
     there are no active specs (or the work-loop isn't installed).
 
-It deliberately runs **none** of this catalogue's own artifact linters —
-those enforce the catalogue's conventions on the catalogue's own tree and
+It deliberately runs **none** of the source project's own artifact linters —
+those enforce that project's conventions on its own tree and
 don't apply to your repo. Wire your project's lint/typecheck/test commands
 into the stub below instead (or let the ``adapt-to-project`` skill do it).
 


### PR DESCRIPTION
## What does this change?

Completes the sweep that #306 deferred: removes the remaining catalogue-internal governance references from shipped pack content (`packs/*/.apm/**`), so adopters receive artifacts with no dangling references to governance they never installed.

## Why?

Shipped pack content must reference only things an adopter has. A 2026-06-13 sweep found `core` still carried ~10 such references that a hand-pass missed. This clears them (light mode — mechanical, comment/docstring/prose only, no behavior change).

- Implements: `docs/specs/apm-internal-ref-sweep/spec.md` (light mode; Status: Shipped)
- Follows from: `docs/backlog.md § apm-leak-lint-rfc`

What changed (all comment/docstring/prose):
- **core 0.4.4** — dropped `make build-self`/`make build-check` mentions from the session-start hook, the `pre-pr` hook, the work-loop `SKILL.md` + its `lint-spec-status` scripts, and the receive-brief `lint-brief-coverage` scripts; dropped an `RFC-0025` citation and the "this catalogue" identity asides (work-loop, adapt-to-project).
- **figma 0.1.3** — the exit-code test drops a dangling `RFC-0023` comment.

## How do I verify it?

```
make build-check            # exit 0, zero drift
# touched script self-tests still pass:
python3 packs/core/.apm/skills/work-loop/scripts/test-lint-spec-status.py
python3 packs/core/.apm/skills/receive-brief/scripts/test-lint-brief-coverage.py
python3 -m pytest packs/figma/.apm/skills/figma/scripts/test_exit_codes.py -q
# residual targeted leaks (only RFC-1918, a real IETF standard, remains):
grep -rnE 'make build-self|make build-check|this catalogue|RFC-[0-9]{4}' packs/core/.apm packs/figma/.apm
```

Reviewed by `adversarial-reviewer` → **Clean** (AST skeletons identical across all six touched `.py` files; risk-trigger block untouched; projections match sources).

## What did you not change that you considered?

- **`credential-brokers` `.apm/**`** (RFC-0023/RFC-0006 citations in `setup.py` + `user-libs/credbroker/`) — the pack is **frozen by RFC-0013**, and the citations sit in library-provenance docstrings rather than agent-facing prose. Deferred to a separate, sign-off-gated pass (`docs/backlog.md § credbroker-frozen-pack-ref-sweep`).
- **Carve-outs left intact** — `RFC-1918` (real IETF standard) in the SSRF checklist; the `tools/lint-missing.py` fixture strings the spec-status linter test consumes; the `docs/specs/<feature>/…` / `docs/rfc/` / `docs/adr/` spec-driven workflow vocabulary.
- **The systematic `.apm/**` leak lint** itself stays deferred to its RFC (`apm-leak-lint-rfc`) — this PR is the hand-sweep, not the enforcement.

## Deferred:

- `credbroker-frozen-pack-ref-sweep` and `apm-leak-lint-rfc` — both in `docs/backlog.md`.

## Checklist

- [x] Gates pass locally (`make build-check` exit 0; touched script self-tests; `lint-skill-spec`; `lint-packs`; `lint-spec-status` clean)
- [x] Self-review via `adversarial-reviewer` → Clean
- [x] Spec and code agree (lean light-mode spec authored + marked Shipped)
- [x] `docs/product/changelog.md` updated
- [x] No new top-level directories
- [x] Conventional commit format
