### PR TITLE
feat(work-loop): "Scale with a tool, not turns" technique for large repetitive tasks (core 0.4.5)

### DIFF
--- a/.agents/skills/work-loop/SKILL.md
+++ b/.agents/skills/work-loop/SKILL.md
@@ -361,6 +361,27 @@ hand on any agent; in Claude Code the native `/simplify` command
 performs it, an optional accelerant and never a dependency, so adapters
 without it lose only the shortcut, not the step.
 
+#### Scale with a tool, not turns
+
+When a task spans many similar items — apply one change across N files,
+extract or transform a large set, audit every module against a rule —
+grinding through them item-by-item across turns exhausts context and
+reliably stalls before the last item, leaving the work *looking* done
+while the tail was never touched. **Reach for this whenever the work is
+repetitive and larger than a single window holds.** The move: write a
+small script that enumerates the items, drive them through a resumable
+tracking file (per-item `pending`/`done`/`failed`), and iterate
+idempotently so a re-run skips what's already done — that resumability,
+not your stamina, is what guarantees 100% completion. Where a per-item
+step needs judgment the script can't make, the script can shell out to
+the agent once per item; the tracking file still governs completion. It
+converts *"too big for my context"* into *"mechanical and resumable."*
+Throwaway tools are fine; occasionally one earns a place in `tools/`.
+Full playbook — tracking-file schema, idempotency and resumability, when
+to shell to the agent, keep-vs-delete the tool — in
+[`references/scale-with-a-tool.md`](references/scale-with-a-tool.md)
+(load it on demand).
+
 #### Parallel dispatch discipline
 
 When this skill fans out — multiple implementers in supervisor mode, or

--- a/.agents/skills/work-loop/references/scale-with-a-tool.md
+++ b/.agents/skills/work-loop/references/scale-with-a-tool.md
@@ -1,0 +1,175 @@
+# Scale with a tool, not turns — the resumable-tracking playbook
+
+Loaded on demand from `work-loop` EXECUTE's *Scale with a tool, not turns*
+subsection. Read it when a single task spans many similar items and is larger
+than one context window comfortably holds: applying one change across N files,
+extracting or transforming a large set, auditing every module against a rule.
+
+The failure this prevents is concrete. Grinding through the items
+conversationally — read item, edit item, read next item — fills the window with
+the items themselves. Somewhere short of the last item the context turns over,
+you lose the thread of which items are done, and the task stalls *looking*
+finished while items 40–N were never touched. No amount of care in the per-item
+edit fixes this; the problem is the loop's shape, not the edits.
+
+The fix is to stop holding the work-list in your head and put it in a file. Three
+moves:
+
+1. **Enumerate.** Write a small script that lists the work items — `git ls-files
+   '*.py'`, a glob, a query, a directory walk — and emits them as the rows of a
+   tracking file. Enumeration is mechanical; do it once, in code, not by reading
+   directories turn after turn.
+2. **Track.** Each item gets a row with explicit per-item state — `pending`,
+   `done`, `failed` — in a resumable file (see schema below). The tracking file,
+   not the transcript, is the source of truth for what remains.
+3. **Iterate idempotently.** Process each `pending` item, then flip its row to
+   `done` (or `failed` with a reason). A re-run reads the file, skips everything
+   already `done`, and picks up where it left off. **This idempotency is what
+   guarantees 100% completion** — the loop can be interrupted, the context can
+   turn over, the session can restart, and the next pass resumes exactly where
+   the last stopped. Completion is "no `pending` rows left," a fact you read from
+   the file, not a feeling.
+
+The whole move converts *"this is too big for my context"* into *"this is
+mechanical and resumable."* Those are very different problems: the first has no
+good answer, the second is just a loop over a file.
+
+## The tracking file
+
+Two shapes work; pick by whether the per-item result carries data.
+
+**`progress.jsonl` — one JSON object per line.** Append-friendly, survives
+partial writes (a torn last line is one lost item, not a corrupt file), trivially
+greppable. The default for anything machine-driven:
+
+```jsonl
+{"item": "packages/api/handlers.py", "status": "done", "note": "3 callsites updated"}
+{"item": "packages/api/models.py", "status": "pending"}
+{"item": "packages/web/client.py", "status": "failed", "note": "ambiguous import — needs a human"}
+```
+
+Minimum viable schema: an **item key** (stable, unique — a path, an id) and a
+**status** in `{pending, done, failed}`. Add a `note` for the failed-item reason
+or a one-line result; add whatever per-item output the downstream step needs
+(a diff hash, an extracted value). Resist a wider schema than the task uses —
+the file is scaffolding, not a database.
+
+**A markdown checklist** — when a human will skim progress or the items are
+coarse:
+
+```markdown
+- [x] packages/api/handlers.py — 3 callsites updated
+- [ ] packages/api/models.py
+- [!] packages/web/client.py — ambiguous import, needs a human
+```
+
+`[x]` done, `[ ]` pending, `[!]` (or a `FAILED:` prefix) for an item that needs
+attention. Less robust to interruption than JSONL — a half-written line is
+ambiguous — so prefer it for smaller or human-facing runs.
+
+Either way: **the file lives on disk, not in the window**, and it is the thing
+you re-read to answer "what's left." Treat it as scratch (gitignore it) unless
+the audit result is itself a deliverable.
+
+## Idempotency and resumability — the load-bearing properties
+
+These are not optional polish; they are the reason the technique works.
+
+- **Read-skip-process.** Every pass starts by reading the tracking file and
+  skipping rows already `done`. A row flips to `done` *only after* its item's
+  work is verified complete (the edit landed, the test passed) — never
+  speculatively before. If the process dies between "did the work" and "wrote
+  `done`," the item is re-done on resume; that re-do must be safe, which is why
+  the per-item action should itself be idempotent (an edit that's a no-op when
+  already applied, an upsert rather than an append).
+- **Write after each item, not at the end.** Flush the status the moment an item
+  finishes. Batching writes to the end of the run throws away the resumability
+  the file exists to provide — a crash loses the whole batch.
+- **`failed` is a first-class terminal state, not a retry-forever.** An item that
+  can't be processed mechanically (genuine ambiguity, a judgment call, a
+  pre-existing breakage) gets marked `failed` with a reason and the loop moves
+  on. Completion is then "zero `pending`," with `failed` rows surfaced to a human
+  as the explicit residue — far better than a loop that wedges on item 12 and
+  never reaches 13–N. Don't auto-retry a `failed` item silently; that's how
+  unattended loops burn money.
+- **Completion is a file fact.** "Done" is `grep -c pending progress.jsonl`
+  returning 0, not your sense that you've been at it a while. Report the tally —
+  N done, M failed — from the file.
+
+## When the per-item step needs judgment — shell out to the agent
+
+If processing an item is purely mechanical (rename a symbol, rewrite an import),
+the script does it directly and you never see the items. But when each item needs
+a judgment call the script can't make — *does this docstring still describe what
+the function does?*, *is this the right boundary to extract?* — keep the
+enumeration-and-tracking skeleton and let the **script shell out to the agent
+once per item**, feeding it that item and recording the agent's verdict in the
+tracking file.
+
+This is the same separation the loop uses elsewhere: a mechanical harness governs
+*which* items run and *whether all of them did*; the agent supplies *judgment* on
+one item at a time, with a fresh, small context each time. The tracking file
+still owns completion — the per-item agent call is just how a `pending` row
+becomes `done`. Some agents expose a native per-item or fresh-session facility for
+exactly this; the [Unattended loops](../SKILL.md#unattended-afk-loops) section
+covers when a fully unattended variant is appropriate (mechanical completion
+criterion, reliable verification, a prior in-session pass). The technique here is
+the *in-session* form: you're driving, the tool just keeps the list straight.
+
+A worked shape — a script that walks files, calls the agent per file, records the
+verdict:
+
+```python
+import json, subprocess
+from pathlib import Path
+
+progress = Path("progress.jsonl")
+seen = set()                             # done + failed — both are terminal, don't redo
+if progress.exists():
+    for line in progress.read_text().splitlines():
+        try:                             # tolerate a torn last line from a crashed write
+            seen.add(json.loads(line)["item"])
+        except json.JSONDecodeError:
+            pass
+
+for path in sorted(p for p in Path("packages").rglob("*.py") if str(p) not in seen):
+    verdict = subprocess.run(            # one fresh per-item agent invocation
+        ["your-agent", "--prompt", f"Audit {path} for stale docstrings; reply done|failed: <note>"],
+        capture_output=True, text=True,
+    ).stdout.strip()
+    status, _, note = verdict.partition(":")
+    with progress.open("a") as f:        # append after each item — resumable
+        f.write(json.dumps({"item": str(path), "status": status.strip(), "note": note.strip()}) + "\n")
+```
+
+The exact invocation is your agent's; the shape — enumerate, skip-done, call,
+append — is the point.
+
+## Keep the tool, or delete it
+
+Most of these scripts are **throwaway**, and that's correct — they exist to get one
+large task across the line, and a deleted ten-line enumerator owes no maintenance.
+Don't gold-plate a script you'll run twice.
+
+Occasionally one earns a place in `tools/`: when the same enumeration recurs
+(every release, every new module), when the tracking file becomes a deliverable
+others read, or when the third time you write it (the same *three-times* bar that
+promotes a workflow to a skill) tells you it's infrastructure, not scaffolding.
+Promote it then, with a name and a docstring, through the normal change — not
+preemptively. The default is throwaway; `tools/` is the exception you justify.
+
+## Boundaries
+
+- **Not for small or one-shot work.** A handful of items that fit in one window
+  don't need a tracking file — just do them. The technique earns its overhead
+  only when the item count exceeds what a context window holds.
+- **The per-item action still runs the loop's discipline.** Each mechanical edit
+  is still scoped, still gated; a tracking file doesn't license skipping GATES on
+  the aggregate change. Run the gates on the whole diff before REVIEW as usual.
+- **Doesn't replace REVIEW.** The tracking file proves *coverage* (every item was
+  visited), not *correctness* (each edit was right). A clean tracking file and a
+  green gate run still go through adversarial review like any other diff.
+- **Distinct from Unattended loops.** That section is about *fresh-session-per-
+  iteration* mechanics for AFK runs; this is an *in-session* technique you reach
+  for while driving. They compose — an unattended loop often uses exactly this
+  tracking file — but you don't need the unattended machinery to use it.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -86,7 +86,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "core",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.4.4"
+      "version": "0.4.5"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -361,6 +361,27 @@ hand on any agent; in Claude Code the native `/simplify` command
 performs it, an optional accelerant and never a dependency, so adapters
 without it lose only the shortcut, not the step.
 
+#### Scale with a tool, not turns
+
+When a task spans many similar items — apply one change across N files,
+extract or transform a large set, audit every module against a rule —
+grinding through them item-by-item across turns exhausts context and
+reliably stalls before the last item, leaving the work *looking* done
+while the tail was never touched. **Reach for this whenever the work is
+repetitive and larger than a single window holds.** The move: write a
+small script that enumerates the items, drive them through a resumable
+tracking file (per-item `pending`/`done`/`failed`), and iterate
+idempotently so a re-run skips what's already done — that resumability,
+not your stamina, is what guarantees 100% completion. Where a per-item
+step needs judgment the script can't make, the script can shell out to
+the agent once per item; the tracking file still governs completion. It
+converts *"too big for my context"* into *"mechanical and resumable."*
+Throwaway tools are fine; occasionally one earns a place in `tools/`.
+Full playbook — tracking-file schema, idempotency and resumability, when
+to shell to the agent, keep-vs-delete the tool — in
+[`references/scale-with-a-tool.md`](references/scale-with-a-tool.md)
+(load it on demand).
+
 #### Parallel dispatch discipline
 
 When this skill fans out — multiple implementers in supervisor mode, or

--- a/.claude/skills/work-loop/references/scale-with-a-tool.md
+++ b/.claude/skills/work-loop/references/scale-with-a-tool.md
@@ -1,0 +1,175 @@
+# Scale with a tool, not turns — the resumable-tracking playbook
+
+Loaded on demand from `work-loop` EXECUTE's *Scale with a tool, not turns*
+subsection. Read it when a single task spans many similar items and is larger
+than one context window comfortably holds: applying one change across N files,
+extracting or transforming a large set, auditing every module against a rule.
+
+The failure this prevents is concrete. Grinding through the items
+conversationally — read item, edit item, read next item — fills the window with
+the items themselves. Somewhere short of the last item the context turns over,
+you lose the thread of which items are done, and the task stalls *looking*
+finished while items 40–N were never touched. No amount of care in the per-item
+edit fixes this; the problem is the loop's shape, not the edits.
+
+The fix is to stop holding the work-list in your head and put it in a file. Three
+moves:
+
+1. **Enumerate.** Write a small script that lists the work items — `git ls-files
+   '*.py'`, a glob, a query, a directory walk — and emits them as the rows of a
+   tracking file. Enumeration is mechanical; do it once, in code, not by reading
+   directories turn after turn.
+2. **Track.** Each item gets a row with explicit per-item state — `pending`,
+   `done`, `failed` — in a resumable file (see schema below). The tracking file,
+   not the transcript, is the source of truth for what remains.
+3. **Iterate idempotently.** Process each `pending` item, then flip its row to
+   `done` (or `failed` with a reason). A re-run reads the file, skips everything
+   already `done`, and picks up where it left off. **This idempotency is what
+   guarantees 100% completion** — the loop can be interrupted, the context can
+   turn over, the session can restart, and the next pass resumes exactly where
+   the last stopped. Completion is "no `pending` rows left," a fact you read from
+   the file, not a feeling.
+
+The whole move converts *"this is too big for my context"* into *"this is
+mechanical and resumable."* Those are very different problems: the first has no
+good answer, the second is just a loop over a file.
+
+## The tracking file
+
+Two shapes work; pick by whether the per-item result carries data.
+
+**`progress.jsonl` — one JSON object per line.** Append-friendly, survives
+partial writes (a torn last line is one lost item, not a corrupt file), trivially
+greppable. The default for anything machine-driven:
+
+```jsonl
+{"item": "packages/api/handlers.py", "status": "done", "note": "3 callsites updated"}
+{"item": "packages/api/models.py", "status": "pending"}
+{"item": "packages/web/client.py", "status": "failed", "note": "ambiguous import — needs a human"}
+```
+
+Minimum viable schema: an **item key** (stable, unique — a path, an id) and a
+**status** in `{pending, done, failed}`. Add a `note` for the failed-item reason
+or a one-line result; add whatever per-item output the downstream step needs
+(a diff hash, an extracted value). Resist a wider schema than the task uses —
+the file is scaffolding, not a database.
+
+**A markdown checklist** — when a human will skim progress or the items are
+coarse:
+
+```markdown
+- [x] packages/api/handlers.py — 3 callsites updated
+- [ ] packages/api/models.py
+- [!] packages/web/client.py — ambiguous import, needs a human
+```
+
+`[x]` done, `[ ]` pending, `[!]` (or a `FAILED:` prefix) for an item that needs
+attention. Less robust to interruption than JSONL — a half-written line is
+ambiguous — so prefer it for smaller or human-facing runs.
+
+Either way: **the file lives on disk, not in the window**, and it is the thing
+you re-read to answer "what's left." Treat it as scratch (gitignore it) unless
+the audit result is itself a deliverable.
+
+## Idempotency and resumability — the load-bearing properties
+
+These are not optional polish; they are the reason the technique works.
+
+- **Read-skip-process.** Every pass starts by reading the tracking file and
+  skipping rows already `done`. A row flips to `done` *only after* its item's
+  work is verified complete (the edit landed, the test passed) — never
+  speculatively before. If the process dies between "did the work" and "wrote
+  `done`," the item is re-done on resume; that re-do must be safe, which is why
+  the per-item action should itself be idempotent (an edit that's a no-op when
+  already applied, an upsert rather than an append).
+- **Write after each item, not at the end.** Flush the status the moment an item
+  finishes. Batching writes to the end of the run throws away the resumability
+  the file exists to provide — a crash loses the whole batch.
+- **`failed` is a first-class terminal state, not a retry-forever.** An item that
+  can't be processed mechanically (genuine ambiguity, a judgment call, a
+  pre-existing breakage) gets marked `failed` with a reason and the loop moves
+  on. Completion is then "zero `pending`," with `failed` rows surfaced to a human
+  as the explicit residue — far better than a loop that wedges on item 12 and
+  never reaches 13–N. Don't auto-retry a `failed` item silently; that's how
+  unattended loops burn money.
+- **Completion is a file fact.** "Done" is `grep -c pending progress.jsonl`
+  returning 0, not your sense that you've been at it a while. Report the tally —
+  N done, M failed — from the file.
+
+## When the per-item step needs judgment — shell out to the agent
+
+If processing an item is purely mechanical (rename a symbol, rewrite an import),
+the script does it directly and you never see the items. But when each item needs
+a judgment call the script can't make — *does this docstring still describe what
+the function does?*, *is this the right boundary to extract?* — keep the
+enumeration-and-tracking skeleton and let the **script shell out to the agent
+once per item**, feeding it that item and recording the agent's verdict in the
+tracking file.
+
+This is the same separation the loop uses elsewhere: a mechanical harness governs
+*which* items run and *whether all of them did*; the agent supplies *judgment* on
+one item at a time, with a fresh, small context each time. The tracking file
+still owns completion — the per-item agent call is just how a `pending` row
+becomes `done`. Some agents expose a native per-item or fresh-session facility for
+exactly this; the [Unattended loops](../SKILL.md#unattended-afk-loops) section
+covers when a fully unattended variant is appropriate (mechanical completion
+criterion, reliable verification, a prior in-session pass). The technique here is
+the *in-session* form: you're driving, the tool just keeps the list straight.
+
+A worked shape — a script that walks files, calls the agent per file, records the
+verdict:
+
+```python
+import json, subprocess
+from pathlib import Path
+
+progress = Path("progress.jsonl")
+seen = set()                             # done + failed — both are terminal, don't redo
+if progress.exists():
+    for line in progress.read_text().splitlines():
+        try:                             # tolerate a torn last line from a crashed write
+            seen.add(json.loads(line)["item"])
+        except json.JSONDecodeError:
+            pass
+
+for path in sorted(p for p in Path("packages").rglob("*.py") if str(p) not in seen):
+    verdict = subprocess.run(            # one fresh per-item agent invocation
+        ["your-agent", "--prompt", f"Audit {path} for stale docstrings; reply done|failed: <note>"],
+        capture_output=True, text=True,
+    ).stdout.strip()
+    status, _, note = verdict.partition(":")
+    with progress.open("a") as f:        # append after each item — resumable
+        f.write(json.dumps({"item": str(path), "status": status.strip(), "note": note.strip()}) + "\n")
+```
+
+The exact invocation is your agent's; the shape — enumerate, skip-done, call,
+append — is the point.
+
+## Keep the tool, or delete it
+
+Most of these scripts are **throwaway**, and that's correct — they exist to get one
+large task across the line, and a deleted ten-line enumerator owes no maintenance.
+Don't gold-plate a script you'll run twice.
+
+Occasionally one earns a place in `tools/`: when the same enumeration recurs
+(every release, every new module), when the tracking file becomes a deliverable
+others read, or when the third time you write it (the same *three-times* bar that
+promotes a workflow to a skill) tells you it's infrastructure, not scaffolding.
+Promote it then, with a name and a docstring, through the normal change — not
+preemptively. The default is throwaway; `tools/` is the exception you justify.
+
+## Boundaries
+
+- **Not for small or one-shot work.** A handful of items that fit in one window
+  don't need a tracking file — just do them. The technique earns its overhead
+  only when the item count exceeds what a context window holds.
+- **The per-item action still runs the loop's discipline.** Each mechanical edit
+  is still scoped, still gated; a tracking file doesn't license skipping GATES on
+  the aggregate change. Run the gates on the whole diff before REVIEW as usual.
+- **Doesn't replace REVIEW.** The tracking file proves *coverage* (every item was
+  visited), not *correctness* (each edit was right). A clean tracking file and a
+  green gate run still go through adversarial review like any other diff.
+- **Distinct from Unattended loops.** That section is about *fresh-session-per-
+  iteration* mechanics for AFK runs; this is an *in-session* technique you reach
+  for while driving. They compose — an unattended loop often uses exactly this
+  tracking file — but you don't need the unattended machinery to use it.

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -19,6 +19,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`work-loop` gains a "Scale with a tool, not turns" technique for large,
+  repetitive tasks (core 0.4.5).** When a task spans many similar items —
+  applying one change across N files, transforming a large set, auditing every
+  module — the skill now points you at writing a small enumeration script backed
+  by a resumable tracking file (`progress.jsonl` or a checklist with per-item
+  `pending`/`done`/`failed` state), so an idempotent re-run skips finished items
+  and the loop reliably reaches 100% completion instead of stalling when context
+  turns over. A short headline lands in the EXECUTE phase; the full playbook —
+  tracking-file schema, idempotency, when to shell out to the agent per item, and
+  keep-vs-delete the tool — is a new on-demand reference,
+  `references/scale-with-a-tool.md`.
+
 - **The rest of the catalogue-internal references are swept from shipped
   content (core 0.4.4, figma 0.1.3).** Following the first pass, the remaining
   `make build-*` build-target mentions, an internal RFC citation, and the "this

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -361,6 +361,27 @@ hand on any agent; in Claude Code the native `/simplify` command
 performs it, an optional accelerant and never a dependency, so adapters
 without it lose only the shortcut, not the step.
 
+#### Scale with a tool, not turns
+
+When a task spans many similar items — apply one change across N files,
+extract or transform a large set, audit every module against a rule —
+grinding through them item-by-item across turns exhausts context and
+reliably stalls before the last item, leaving the work *looking* done
+while the tail was never touched. **Reach for this whenever the work is
+repetitive and larger than a single window holds.** The move: write a
+small script that enumerates the items, drive them through a resumable
+tracking file (per-item `pending`/`done`/`failed`), and iterate
+idempotently so a re-run skips what's already done — that resumability,
+not your stamina, is what guarantees 100% completion. Where a per-item
+step needs judgment the script can't make, the script can shell out to
+the agent once per item; the tracking file still governs completion. It
+converts *"too big for my context"* into *"mechanical and resumable."*
+Throwaway tools are fine; occasionally one earns a place in `tools/`.
+Full playbook — tracking-file schema, idempotency and resumability, when
+to shell to the agent, keep-vs-delete the tool — in
+[`references/scale-with-a-tool.md`](references/scale-with-a-tool.md)
+(load it on demand).
+
 #### Parallel dispatch discipline
 
 When this skill fans out — multiple implementers in supervisor mode, or

--- a/packs/core/.apm/skills/work-loop/references/scale-with-a-tool.md
+++ b/packs/core/.apm/skills/work-loop/references/scale-with-a-tool.md
@@ -1,0 +1,175 @@
+# Scale with a tool, not turns — the resumable-tracking playbook
+
+Loaded on demand from `work-loop` EXECUTE's *Scale with a tool, not turns*
+subsection. Read it when a single task spans many similar items and is larger
+than one context window comfortably holds: applying one change across N files,
+extracting or transforming a large set, auditing every module against a rule.
+
+The failure this prevents is concrete. Grinding through the items
+conversationally — read item, edit item, read next item — fills the window with
+the items themselves. Somewhere short of the last item the context turns over,
+you lose the thread of which items are done, and the task stalls *looking*
+finished while items 40–N were never touched. No amount of care in the per-item
+edit fixes this; the problem is the loop's shape, not the edits.
+
+The fix is to stop holding the work-list in your head and put it in a file. Three
+moves:
+
+1. **Enumerate.** Write a small script that lists the work items — `git ls-files
+   '*.py'`, a glob, a query, a directory walk — and emits them as the rows of a
+   tracking file. Enumeration is mechanical; do it once, in code, not by reading
+   directories turn after turn.
+2. **Track.** Each item gets a row with explicit per-item state — `pending`,
+   `done`, `failed` — in a resumable file (see schema below). The tracking file,
+   not the transcript, is the source of truth for what remains.
+3. **Iterate idempotently.** Process each `pending` item, then flip its row to
+   `done` (or `failed` with a reason). A re-run reads the file, skips everything
+   already `done`, and picks up where it left off. **This idempotency is what
+   guarantees 100% completion** — the loop can be interrupted, the context can
+   turn over, the session can restart, and the next pass resumes exactly where
+   the last stopped. Completion is "no `pending` rows left," a fact you read from
+   the file, not a feeling.
+
+The whole move converts *"this is too big for my context"* into *"this is
+mechanical and resumable."* Those are very different problems: the first has no
+good answer, the second is just a loop over a file.
+
+## The tracking file
+
+Two shapes work; pick by whether the per-item result carries data.
+
+**`progress.jsonl` — one JSON object per line.** Append-friendly, survives
+partial writes (a torn last line is one lost item, not a corrupt file), trivially
+greppable. The default for anything machine-driven:
+
+```jsonl
+{"item": "packages/api/handlers.py", "status": "done", "note": "3 callsites updated"}
+{"item": "packages/api/models.py", "status": "pending"}
+{"item": "packages/web/client.py", "status": "failed", "note": "ambiguous import — needs a human"}
+```
+
+Minimum viable schema: an **item key** (stable, unique — a path, an id) and a
+**status** in `{pending, done, failed}`. Add a `note` for the failed-item reason
+or a one-line result; add whatever per-item output the downstream step needs
+(a diff hash, an extracted value). Resist a wider schema than the task uses —
+the file is scaffolding, not a database.
+
+**A markdown checklist** — when a human will skim progress or the items are
+coarse:
+
+```markdown
+- [x] packages/api/handlers.py — 3 callsites updated
+- [ ] packages/api/models.py
+- [!] packages/web/client.py — ambiguous import, needs a human
+```
+
+`[x]` done, `[ ]` pending, `[!]` (or a `FAILED:` prefix) for an item that needs
+attention. Less robust to interruption than JSONL — a half-written line is
+ambiguous — so prefer it for smaller or human-facing runs.
+
+Either way: **the file lives on disk, not in the window**, and it is the thing
+you re-read to answer "what's left." Treat it as scratch (gitignore it) unless
+the audit result is itself a deliverable.
+
+## Idempotency and resumability — the load-bearing properties
+
+These are not optional polish; they are the reason the technique works.
+
+- **Read-skip-process.** Every pass starts by reading the tracking file and
+  skipping rows already `done`. A row flips to `done` *only after* its item's
+  work is verified complete (the edit landed, the test passed) — never
+  speculatively before. If the process dies between "did the work" and "wrote
+  `done`," the item is re-done on resume; that re-do must be safe, which is why
+  the per-item action should itself be idempotent (an edit that's a no-op when
+  already applied, an upsert rather than an append).
+- **Write after each item, not at the end.** Flush the status the moment an item
+  finishes. Batching writes to the end of the run throws away the resumability
+  the file exists to provide — a crash loses the whole batch.
+- **`failed` is a first-class terminal state, not a retry-forever.** An item that
+  can't be processed mechanically (genuine ambiguity, a judgment call, a
+  pre-existing breakage) gets marked `failed` with a reason and the loop moves
+  on. Completion is then "zero `pending`," with `failed` rows surfaced to a human
+  as the explicit residue — far better than a loop that wedges on item 12 and
+  never reaches 13–N. Don't auto-retry a `failed` item silently; that's how
+  unattended loops burn money.
+- **Completion is a file fact.** "Done" is `grep -c pending progress.jsonl`
+  returning 0, not your sense that you've been at it a while. Report the tally —
+  N done, M failed — from the file.
+
+## When the per-item step needs judgment — shell out to the agent
+
+If processing an item is purely mechanical (rename a symbol, rewrite an import),
+the script does it directly and you never see the items. But when each item needs
+a judgment call the script can't make — *does this docstring still describe what
+the function does?*, *is this the right boundary to extract?* — keep the
+enumeration-and-tracking skeleton and let the **script shell out to the agent
+once per item**, feeding it that item and recording the agent's verdict in the
+tracking file.
+
+This is the same separation the loop uses elsewhere: a mechanical harness governs
+*which* items run and *whether all of them did*; the agent supplies *judgment* on
+one item at a time, with a fresh, small context each time. The tracking file
+still owns completion — the per-item agent call is just how a `pending` row
+becomes `done`. Some agents expose a native per-item or fresh-session facility for
+exactly this; the [Unattended loops](../SKILL.md#unattended-afk-loops) section
+covers when a fully unattended variant is appropriate (mechanical completion
+criterion, reliable verification, a prior in-session pass). The technique here is
+the *in-session* form: you're driving, the tool just keeps the list straight.
+
+A worked shape — a script that walks files, calls the agent per file, records the
+verdict:
+
+```python
+import json, subprocess
+from pathlib import Path
+
+progress = Path("progress.jsonl")
+seen = set()                             # done + failed — both are terminal, don't redo
+if progress.exists():
+    for line in progress.read_text().splitlines():
+        try:                             # tolerate a torn last line from a crashed write
+            seen.add(json.loads(line)["item"])
+        except json.JSONDecodeError:
+            pass
+
+for path in sorted(p for p in Path("packages").rglob("*.py") if str(p) not in seen):
+    verdict = subprocess.run(            # one fresh per-item agent invocation
+        ["your-agent", "--prompt", f"Audit {path} for stale docstrings; reply done|failed: <note>"],
+        capture_output=True, text=True,
+    ).stdout.strip()
+    status, _, note = verdict.partition(":")
+    with progress.open("a") as f:        # append after each item — resumable
+        f.write(json.dumps({"item": str(path), "status": status.strip(), "note": note.strip()}) + "\n")
+```
+
+The exact invocation is your agent's; the shape — enumerate, skip-done, call,
+append — is the point.
+
+## Keep the tool, or delete it
+
+Most of these scripts are **throwaway**, and that's correct — they exist to get one
+large task across the line, and a deleted ten-line enumerator owes no maintenance.
+Don't gold-plate a script you'll run twice.
+
+Occasionally one earns a place in `tools/`: when the same enumeration recurs
+(every release, every new module), when the tracking file becomes a deliverable
+others read, or when the third time you write it (the same *three-times* bar that
+promotes a workflow to a skill) tells you it's infrastructure, not scaffolding.
+Promote it then, with a name and a docstring, through the normal change — not
+preemptively. The default is throwaway; `tools/` is the exception you justify.
+
+## Boundaries
+
+- **Not for small or one-shot work.** A handful of items that fit in one window
+  don't need a tracking file — just do them. The technique earns its overhead
+  only when the item count exceeds what a context window holds.
+- **The per-item action still runs the loop's discipline.** Each mechanical edit
+  is still scoped, still gated; a tracking file doesn't license skipping GATES on
+  the aggregate change. Run the gates on the whole diff before REVIEW as usual.
+- **Doesn't replace REVIEW.** The tracking file proves *coverage* (every item was
+  visited), not *correctness* (each edit was right). A clean tracking file and a
+  green gate run still go through adversarial review like any other diff.
+- **Distinct from Unattended loops.** That section is about *fresh-session-per-
+  iteration* mechanics for AFK runs; this is an *in-session* technique you reach
+  for while driving. They compose — an unattended loop often uses exactly this
+  tracking file — but you don't need the unattended machinery to use it.

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr + session-start hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "0.4.4"
+version = "0.4.5"
 description = "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr + session-start hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 readme = "README.md"
 display_name = "Core"


### PR DESCRIPTION
## What

Adds a new metacognitive technique to the `work-loop` skill for **large, repetitive tasks** — applying one change across N files, transforming a large set, auditing every module against a rule.

The failure it prevents: grinding through the items conversationally fills the window with the items themselves, the context turns over, and the task stalls *looking* finished while the tail was never touched. The fix is to stop holding the work-list in your head:

1. **Enumerate** the items with a small script.
2. **Track** each item in a resumable file (`progress.jsonl` or a checklist) with per-item `pending`/`done`/`failed` state.
3. **Iterate idempotently** so a re-run skips finished items — this resumability, not stamina, is what guarantees 100% completion.
4. Where a per-item step needs judgment, the script **shells out to the agent per item**; the tracking file still governs completion.

It converts *"too big for my context"* into *"mechanical and resumable."*

## How

Progressive disclosure, matching the existing `tdd-stubs.md` / `supervisor-mode.md` pattern:

- A short headline + when-to-reach-for-it as a `####` subsection under **EXECUTE** in `SKILL.md`.
- The full playbook — tracking-file schema, idempotency/resumability, shell-to-agent worked example, keep-vs-delete the tool, Boundaries — in a new on-demand reference, `references/scale-with-a-tool.md`.

Source edited under `packs/core/.apm/...`; `.claude/` and `.agents/` projections + `marketplace.json` regenerated via `make build-self`. Bumps core 0.4.4 → 0.4.5; changelog `[Unreleased]` entry added.

## Verification

- `make build-self` clean; projections match source byte-for-byte.
- `lint-packs`, `validate`, `tools/lint-agent-artifacts.py` all green.
- **adversarial-reviewer** (light-mode single pass): confirmed brief fidelity and guardrails (version bump, changelog, source-not-projection, no external attribution). Raised one Concern + one Nit on the worked-example code; both applied — the resume loop now tolerates a torn last JSONL line (the resilience the schema prose claims) and the skip-set is named `seen` to reflect it includes terminal `failed` rows. Example re-checked with `py_compile`.

## Not changing / declined

- No canonical tracking-file script shipped in `tools/` — the doctrine itself says throwaway is the default and one only *occasionally* earns a home; shipping one would contradict it.
- Kept as an EXECUTE subsection (not a top-level section) and to a single cross-reference into Unattended loops — related but distinct (fresh-session-per-iteration vs. in-session enumeration).