### PR TITLE
feat(research): preserve irreducible ambiguity across four skills (0.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -186,7 +186,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "research",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.1.2"
+      "version": "0.2.0"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -31,6 +31,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   keep-vs-delete the tool — is a new on-demand reference,
   `references/scale-with-a-tool.md`.
 
+- **The research pack learns to preserve irreducible ambiguity instead of
+  always collapsing to one rated answer (research 0.2.0).** Four skills gain a
+  habit each, under a single theme: `/identify-perspectives` now builds a
+  **tension map** recording, per preserved disagreement, the conditions under
+  which each camp holds and what forced resolution would destroy;
+  `/devils-advocate` gains a **do-not-resolve** verdict for productive,
+  irreducible tensions, distinct from its confidence-downgrade; `/research`
+  standard/applied/deep artifacts close with a first-class **gaps** section
+  naming known-unknowns and unknowables, distinct from rating a weak finding
+  `[uncertain]`; and `/decision-archaeology` runs a **revival check** that flags
+  a rejected alternative whose original rejection rationale no longer holds
+  (the constraint changed) as a revival candidate. Skill prose only.
+
 - **The rest of the catalogue-internal references are swept from shipped
   content (core 0.4.4, figma 0.1.3).** Following the first pass, the remaining
   `make build-*` build-target mentions, an internal RFC citation, and the "this

--- a/packs/research/.apm/skills/decision-archaeology/SKILL.md
+++ b/packs/research/.apm/skills/decision-archaeology/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: decision-archaeology
-description: Reconstruct the rationale for a past decision by walking time-ordered artifacts (commits, PRs, design docs, chat logs, internal memos). Self-contained — does not invoke `/source-map` or other research-pack skills, because the source surface is time-ordered and internal, and authority is established by an artifact's place in the history rather than by external curation. Produces `archaeology.md` with chronology, the rationale chain, and the alternatives that were considered and rejected. Depth cues — `quickly`, `top three`, `briefly`, `summary only` for the main rationale chain; `comprehensively`, `exhaustively`, `in depth`, `extensive` for branch alternatives and dead ends.
+description: Reconstruct the rationale for a past decision by walking time-ordered artifacts (commits, PRs, design docs, chat logs, internal memos). Self-contained — does not invoke `/source-map` or other research-pack skills, because the source surface is time-ordered and internal, and authority is established by an artifact's place in the history rather than by external curation. Produces `archaeology.md` with chronology, the rationale chain, the alternatives that were considered and rejected, and a revival check flagging any rejected alternative whose original rejection rationale no longer holds. Depth cues — `quickly`, `top three`, `briefly`, `summary only` for the main rationale chain; `comprehensively`, `exhaustively`, `in depth`, `extensive` for branch alternatives and dead ends.
 ---
 
 # /decision-archaeology
@@ -62,7 +62,11 @@ Rationale reconstruction has three converging disciplines:
    rejected, who signed.
 5. **Surface alternatives-considered** — the rejected branches deserve
    their own section.
-6. **Write `archaeology.md`**. No `sources.md` is produced.
+6. **Run the revival check** — for each rejected alternative, test
+   whether its original rejection rationale still holds today. Where the
+   constraint that forced rejection has changed, flag the alternative as
+   a **revival candidate**. See *Revival check* below.
+7. **Write `archaeology.md`**. No `sources.md` is produced.
 
 ## `archaeology.md` output schema
 
@@ -91,10 +95,40 @@ Rationale reconstruction has three converging disciplines:
 - **<alternative name>** — rejected at step <N>. Reason: <citation>.
 - **<alternative name>** — rejected at step <N>. Reason: <citation>.
 
+## Revival candidates
+
+- **<alternative name>** — rejected at step <N> because <original
+  rationale, cited>. That constraint has since changed: <what changed,
+  cited>. Revival candidate.
+
 ## Open questions
 
 - <a rationale link the artifact trail does not actually establish>.
 ```
+
+## Revival check
+
+`Alternatives considered` records what was rejected and why. The revival
+check asks the next question: *does the rejection still hold?* A rejection
+rationale that pointed at an external constraint — cost, a missing
+dependency, immature tooling, team size, scale not yet reached — is only
+as live as that constraint. An archaeology that stops at "X was rejected
+because Y" leaves a live opportunity buried once Y stops being true.
+
+For each rejected alternative, classify its rejection rationale:
+
+- **Still binding** — the constraint that forced rejection holds today.
+  Leave it rejected; say so, so the next reader doesn't re-litigate it.
+- **Lapsed** — the constraint has since changed (the dependency now
+  exists, the cost dropped, the scale arrived, the tooling matured).
+  Flag the alternative as a **revival candidate**, citing both the
+  original rationale and the changed constraint.
+
+A revival candidate is a *finding*, not a recommendation: it says "this
+deserves reconsideration" and hands the actual forward decision to
+`/compare-hypotheses`. Rationales that rest on a value choice rather than
+a changed constraint are not revival candidates — they did not lapse,
+the priorities shifted, which is a different conversation.
 
 ## Citation discipline
 

--- a/packs/research/.apm/skills/devils-advocate/SKILL.md
+++ b/packs/research/.apm/skills/devils-advocate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: devils-advocate
-description: Adversarially review a research artifact (`research.md`) or a user-supplied claim. Searches for counter-evidence, names the strongest objections, and proposes confidence-rating downgrades. Grounded in ACH (evidence-against column — the discipline that catches premature closure) and GIJN investigative-journalism practice ("what does the other side say"). Auto-invoked by `/research` deep mode against `research.md`; runs standalone against any user-supplied claim. Produces `counterpoints.md` linking back to the source artifact. Depth cues — `quickly`, `top three`, `briefly`, `summary only` for the strongest objections; `comprehensively`, `exhaustively`, `in depth`, `extensive` for the full set.
+description: Adversarially review a research artifact (`research.md`) or a user-supplied claim. Searches for counter-evidence, names the strongest objections, and proposes confidence-rating downgrades — or, for a productive/irreducible tension, a do-not-resolve verdict that preserves the disagreement instead of collapsing it. Grounded in ACH (evidence-against column — the discipline that catches premature closure) and GIJN investigative-journalism practice ("what does the other side say"). Auto-invoked by `/research` deep mode against `research.md`; runs standalone against any user-supplied claim. Produces `counterpoints.md` linking back to the source artifact. Depth cues — `quickly`, `top three`, `briefly`, `summary only` for the strongest objections; `comprehensively`, `exhaustively`, `in depth`, `extensive` for the full set.
 ---
 
 # /devils-advocate
@@ -51,14 +51,43 @@ Two convergent disciplines:
 3. **Retrieve counter-evidence** — dispatch `evidence-retriever`
    subagent against each counter-position. The main session does the
    reasoning; the subagent supplies the material.
-4. **Propose rating downgrades** — for each finding whose evidence-
-   against is substantive, propose the new confidence rating
-   (`[high]` → `[moderate]`, or `[moderate]` → `[low]`, etc., per
-   `references/confidence-schema.md`). Name the downgrade factor.
+4. **Fork the verdict** — for each finding whose evidence-against is
+   substantive, decide between two outcomes (see *Two verdicts* below):
+   - **Downgrade** — propose the new confidence rating (`[high]` →
+     `[moderate]`, or `[moderate]` → `[low]`, etc., per
+     `references/confidence-schema.md`) and name the downgrade factor.
+   - **Do-not-resolve** — when the finding and its counter-position are
+     *both* well-supported and hold under different conditions, return a
+     do-not-resolve verdict instead of a downgrade. Name the regime
+     split; do not pick a winner.
 5. **Moderator pass** — before declaring done, scan retrieved-but-
    uncited counter-material and consider one more query from the
    highest-signal unused snippet (Co-STORM contribution).
 6. **Write `counterpoints.md`**, linking back to the source artifact.
+
+## Two verdicts: downgrade vs do-not-resolve
+
+A confidence downgrade and a do-not-resolve verdict are different
+outcomes, and conflating them is the failure this section exists to
+prevent.
+
+- **Downgrade** says the finding is *weaker* than rated — the
+  counter-evidence erodes it, one answer still stands, just less
+  confidently. The artifact still collapses to a single rated answer.
+- **Do-not-resolve** says the finding and its counter-position are
+  *both* well-supported and each holds under different conditions. The
+  tension is productive: collapsing it to one rated answer would be
+  false precision, not added confidence, and forcing a winner would
+  destroy real information about *when* each holds.
+
+Reach for do-not-resolve when the evidence-against is roughly as strong
+as the evidence-for **and** the two hold in different regimes (different
+scale, context, time horizon, or value frame). This is ACH's discipline
+taken to its conclusion: ACH refuses *premature* closure, and the
+do-not-resolve verdict refuses closure where closure itself is the
+error. Where `/identify-perspectives` produced a tension map, a
+do-not-resolve verdict is its downstream echo — cite the matching
+tension if one exists.
 
 ## `counterpoints.md` output schema
 
@@ -75,6 +104,14 @@ Two convergent disciplines:
 ## Finding: <next>
 
 (same shape)
+
+## Finding: <quoted from target> — do-not-resolve
+
+- **Verdict:** do-not-resolve (productive tension).
+- **Counter-position:** <the equally-supported opposing finding>.
+- **Holds when:** original finding under <regime A>; counter-position
+  under <regime B>.
+- **Why not collapse:** <what a forced single answer would destroy>.
 ```
 
 ## Citation discipline

--- a/packs/research/.apm/skills/identify-perspectives/SKILL.md
+++ b/packs/research/.apm/skills/identify-perspectives/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: identify-perspectives
-description: Enumerate the named camps on a contested topic before research begins. Builds the perspective scaffold that `/source-map` and `/compare-hypotheses` consume downstream in the decision pipeline. Grounded in Wikipedia NPOV (neutral point of view — fairly represent significant views) and ACH (competing hypotheses — surface all explanations before evaluating). Produces `perspectives.md` listing each camp's name, its core claim, and representative voices. Depth cues — `quickly`, `top three`, `briefly` for the dominant few; `comprehensively`, `exhaustively`, `in depth`, `extensive` for fringe and dissenting positions too.
+description: Enumerate the named camps on a contested topic before research begins. Builds the perspective scaffold that `/source-map` and `/compare-hypotheses` consume downstream in the decision pipeline. Grounded in Wikipedia NPOV (neutral point of view — fairly represent significant views) and ACH (competing hypotheses — surface all explanations before evaluating). Produces `perspectives.md` listing each camp's name, its core claim, and representative voices, plus a tension map of the irreducible disagreements — the conditions under which each position holds and what forced resolution would destroy. Depth cues — `quickly`, `top three`, `briefly` for the dominant few; `comprehensively`, `exhaustively`, `in depth`, `extensive` for fringe and dissenting positions too.
 ---
 
 # /identify-perspectives
@@ -50,7 +50,32 @@ Evaluation is `/compare-hypotheses`'s job downstream.
 4. **Look for missing camps** — quiet positions, dissenting minorities,
    contrarian-but-credentialed. The biggest NPOV failure is
    *omission*, not bias.
-5. **Write `perspectives.md`**.
+5. **Map the irreducible tensions.** Camps that genuinely conflict are
+   the point of the artifact, not a defect to adjudicate here. For each
+   *preserved* disagreement — one where both camps hold real ground —
+   record the **conditions under which each position holds** (the
+   boundary that makes each camp right *somewhere*) and **what forced
+   resolution would destroy** (the distinction that collapsing to one
+   camp would erase). A disagreement that dissolves once its conditions
+   are named was never a real tension — fold it back into the camps. One
+   that *sharpens* under that test is irreducible — preserve it. See
+   *Tension map* below.
+6. **Write `perspectives.md`**.
+
+## Tension map
+
+Naming the camps says *what* the positions are; the tension map says
+*why the disagreement persists*. It is the difference between a list and
+an explanation, and it is the habit that keeps this skill from quietly
+collapsing a live controversy into the camp the model finds most
+credible.
+
+A tension belongs on the map when both positions are defensible and each
+is right under different conditions — not when one is simply better
+supported (that is `/compare-hypotheses`'s call, downstream). The map
+extends NPOV's *representation* discipline one step: from "every
+significant camp gets named" to "the boundary between camps gets named,
+so the disagreement survives the trip downstream intact."
 
 ## `perspectives.md` output schema
 
@@ -70,6 +95,15 @@ Evaluation is `/compare-hypotheses`'s job downstream.
 ## Possibly-missing camps
 
 - <one-line description of a position that might be under-represented>.
+
+## Tension map
+
+### Tension: <camp A> vs <camp B>
+
+- **Holds for A when:** <the regime / conditions under which A is right>.
+- **Holds for B when:** <the regime / conditions under which B is right>.
+- **Forced resolution would destroy:** <the distinction lost if the
+  pipeline collapsed this to one answer>.
 ```
 
 ## Citation discipline

--- a/packs/research/.apm/skills/research/SKILL.md
+++ b/packs/research/.apm/skills/research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research
-description: "Evidence-grounded research with selectable depth and discipline. Use for any look-up, find-out, fact-check, or comprehensive investigation, including prior art and best practice surveys. Carries a mode parameter (quick / standard / applied / deep) with `quick` as default — casual phrasings (`look up`, `find out`, `quick check`) stay quick; academic phrasings (`research with citations`, `evidence-grounded`, `go deep`, `comprehensively`) bias standard or deep; practitioner phrasings (`applied patterns for`, `best practice for`, `prior art on`, `grey literature`) bias applied. Quick mode is inline, ≤5 fetches, no artifact. Standard mode produces `research.md` with GRADE-style confidence per finding from peer-reviewed and primary sources. Applied mode produces `research.md` calibrated for practitioner grey literature with a discipline-aware confidence overlay. Deep mode additionally auto-runs `/devils-advocate`, producing `counterpoints.md`."
+description: "Evidence-grounded research with selectable depth and discipline. Use for any look-up, find-out, fact-check, or comprehensive investigation, including prior art and best practice surveys. Carries a mode parameter (quick / standard / applied / deep) with `quick` as default — casual phrasings (`look up`, `find out`, `quick check`) stay quick; academic phrasings (`research with citations`, `evidence-grounded`, `go deep`, `comprehensively`) bias standard or deep; practitioner phrasings (`applied patterns for`, `best practice for`, `prior art on`, `grey literature`) bias applied. Quick mode is inline, ≤5 fetches, no artifact. Standard mode produces `research.md` with GRADE-style confidence per finding from peer-reviewed and primary sources. Applied mode produces `research.md` calibrated for practitioner grey literature with a discipline-aware confidence overlay. Deep mode additionally auto-runs `/devils-advocate`, producing `counterpoints.md`. Plus a known-unknowns/unknowables gap section."
 ---
 
 # /research
@@ -151,10 +151,13 @@ to chain.
    `[inference]` per Wikipedia V/RS and GRADE convergence.
 5. **Rate** — apply the confidence schema in
    `references/confidence-schema.md` to every finding.
-6. **Moderator pass** — before declaring done, scan retrieved-but-
+6. **Name the gaps** — record what the research could *not* establish
+   as a first-class section, not as low-rated findings. See *Gaps*
+   below. Skip in quick mode (no artifact).
+7. **Moderator pass** — before declaring done, scan retrieved-but-
    uncited material and consider one more query from the highest-signal
    unused snippet (Co-STORM contribution). Skip in quick mode.
-7. **Adversarial review (deep mode only)** — auto-invoke
+8. **Adversarial review (deep mode only)** — auto-invoke
    `/devils-advocate` on `research.md`; emit `counterpoints.md`.
 
 ## Retrievers
@@ -220,6 +223,39 @@ Before declaring the artifact done, scan retrieved-but-uncited
 material. If the highest-signal unused snippet would change a rating
 or fill a gap, issue one more targeted query. This is the Co-STORM
 contribution — it catches the trail you almost left on the table.
+
+## Gaps — known-unknowns and unknowables
+
+A confidence tag rates a finding that *exists*. It has no slot for a
+question the research raised but could not answer, and that absence
+silently disappears unless the artifact names it. Standard, applied, and
+deep mode therefore close with a first-class gap section — distinct from
+any `[low]` or `[uncertain]` finding, which still asserts *something*:
+
+- **Known-unknowns** — questions the research surfaced and could not
+  answer within its bounds: no source exists yet, the source exists but
+  was out of reach, or the search was scoped out. These are *answerable
+  in principle* — they mark where more research would pay off.
+- **Unknowables** — questions research cannot settle at all: genuinely
+  open at the frontier, contested by definition, dependent on a future
+  that hasn't happened, or resting on a value choice rather than a fact.
+  Tagging these `[uncertain]` would misrepresent them as weak findings
+  rather than as questions outside evidence's reach.
+
+A gap is not a failure of the research; an *unnamed* gap is. The section
+lives in `research.md`:
+
+```markdown
+## Gaps
+
+### Known-unknowns
+
+- <question raised but unanswerable within bounds; what would resolve it>.
+
+### Unknowables
+
+- <question outside evidence's reach; why it is unknowable, not just weak>.
+```
 
 ## What this skill is not
 

--- a/packs/research/.claude-plugin/plugin.json
+++ b/packs/research/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "research",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Evidence-grounded research portable across every repo. Seven skills (scoping, source curation, synthesis, adversarial review, decision support, rationale reconstruction) plus two retrieval subagents; methodology grounded in seven convergent disciplines (STORM, PRISMA, ACH, Wikipedia V/RS/NPOV, OSINT, GIJN, GRADE)."
 }

--- a/packs/research/pack.toml
+++ b/packs/research/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "research"
-version = "0.1.2"
+version = "0.2.0"
 description = "Evidence-grounded research portable across every repo. Seven skills (scoping, source curation, synthesis, adversarial review, decision support, rationale reconstruction) plus two retrieval subagents; methodology grounded in seven convergent disciplines (STORM, PRISMA, ACH, Wikipedia V/RS/NPOV, OSINT, GIJN, GRADE)."
 readme = "README.md"
 display_name = "Research"


### PR DESCRIPTION
## What & why

The research pack was thoroughly built for **collapsing** ambiguity — triangulation, GRADE confidence ratings, ACH evidence matrices that rank a most-supported hypothesis, NPOV camp enumeration that feeds a downstream verdict. It under-served the inverse, equally-important move: **preserving and characterizing irreducible ambiguity** when the honest answer is "it depends, and here's on what" rather than a single rated finding.

This PR adds one habit per skill under that single theme. Each is wired into the skill's procedure (a habit, not an opt-in), is universal, and is verified distinct from what the pack already encodes.

| Skill | Addition | Distinct from |
|---|---|---|
| `identify-perspectives` | **Tension map** — per preserved disagreement, the conditions under which each camp holds and what forced resolution would destroy | NPOV camp enumeration (names *what* the positions are; the map says *why the disagreement persists*) |
| `devils-advocate` | **Do-not-resolve verdict** — for tensions where finding and counter-position are both well-supported under different regimes | the existing confidence-downgrade (which still collapses to one, weaker answer) |
| `research` | **Known-unknowns / unknowables gap section** — first-class, in `research.md` | a `[low]`/`[uncertain]` tag (which rates a finding that *exists*; the gap section names what doesn't) |
| `decision-archaeology` | **Revival check** — flag a rejected alternative whose original rejection rationale no longer holds | alternatives-considered (records *that* it was rejected; the check tests whether the rejection *still holds*) |

## Declined: the optional 5th (build-outline "era axis")

Deliberately left out. `build-outline` already decomposes along generalized PICO axes, so a temporal/era axis is both niche (fast-moving fields only) and largely duplicative; it also fits staleness/recency (already handled by applied mode's recency rule) more than the ambiguity-preservation theme. It did not clear the universal + non-duplicative bar.

## Mechanics

- Version bumped `research` 0.1.2 → 0.2.0 (`pack.toml` + `plugin.json`); `marketplace.json` regenerated via `build-self` (research is user-scope-default — not projected into this repo's `.claude/` tree, so only `marketplace.json` changes).
- `[Unreleased]` changelog entry added.
- Skill **prose only** — no code, no new dependency, no schema/contract change. Grounding stays in disciplines the pack already cites (NPOV / ACH / GRADE / GIJN); no external-catalogue attribution.

## Verification

- `make build-check` — green (lint-packs, build, self-host drift, doc-drift gates).
- `tools/lint-agent-artifacts.py` — passed.
- `test_research_retrievers_conformance.py` — passed (description cue-tokens + explicit-default wording preserved; the research description was trimmed to stay under the 1024 cap while keeping all load-bearing tokens).
- adversarial-reviewer — `Clean — ready to commit.`