### PR TITLE
feat(research): preserve and characterize irreducible ambiguity (research 0.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -186,7 +186,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "research",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.1.2"
+      "version": "0.2.0"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/docs/guides/research/how-to/research-pipelines.md
+++ b/docs/guides/research/how-to/research-pipelines.md
@@ -51,7 +51,7 @@ This guide is task-shaped. It assumes you already know what the pack does — if
 1. `perspectives.md` — named camps with core claims and representative voices.
 2. `sources.md` — candidates grouped by primacy *and* by camp (camp- grouping is the decision-pipeline-specific shape).
 3. `hypotheses.md` — ACH-style matrix (hypotheses × evidence-for / against), with a ranking.
-4. `counterpoints.md` — `/devils-advocate` against `hypotheses.md`; proposed rating downgrades.
+4. `counterpoints.md` — `/devils-advocate` against `hypotheses.md`; a per-finding verdict (rating downgrade, or do-not-resolve for an irreducible tension).
 
 **Degraded-mode example:** if you skip `/source-map`, then `/compare-hypotheses` falls back to enumerating hypotheses with the sources it can find inline — it still produces `hypotheses.md`, but the matrix is thinner and `[high]` ratings will be rare because the triangulation discipline can't be satisfied. The downstream `/devils-advocate` pass then proposes more downgrades. The pipeline *degrades* gracefully — it doesn't break.
 

--- a/docs/guides/research/reference/research-pack.md
+++ b/docs/guides/research/reference/research-pack.md
@@ -10,7 +10,7 @@ Seven skills ship in the pack. The `name` and `description` below are reproduced
 
 **name:** `identify-perspectives`.
 
-**description:** Enumerate the named camps on a contested topic before research begins. Builds the perspective scaffold that `/source-map` and `/compare-hypotheses` consume downstream in the decision pipeline. Grounded in Wikipedia NPOV (neutral point of view — fairly represent significant views) and ACH (competing hypotheses — surface all explanations before evaluating). Produces `perspectives.md` listing each camp's name, its core claim, and representative voices. Depth cues — `quickly`, `top three`, `briefly` for the dominant few; `comprehensively`, `exhaustively`, `in depth`, `extensive` for fringe and dissenting positions too.
+**description:** Enumerate the named camps on a contested topic before research begins. Builds the perspective scaffold that `/source-map` and `/compare-hypotheses` consume downstream in the decision pipeline. Grounded in Wikipedia NPOV (neutral point of view — fairly represent significant views) and ACH (competing hypotheses — surface all explanations before evaluating). Produces `perspectives.md` listing each camp's name, its core claim, and representative voices, plus a tension map recording which disagreements are irreducible (both sides right under different conditions) and what a forced resolution would destroy. Depth cues — `quickly`, `top three`, `briefly` for the dominant few; `comprehensively`, `exhaustively`, `in depth`, `extensive` for fringe and dissenting positions too.
 
 ### build-outline
 
@@ -34,7 +34,7 @@ Seven skills ship in the pack. The `name` and `description` below are reproduced
 
 **name:** `devils-advocate`.
 
-**description:** Adversarially review a research artifact (`research.md`) or a user-supplied claim. Searches for counter- evidence, names the strongest objections, and proposes confidence- rating downgrades. Grounded in ACH (evidence-against column — the discipline that catches premature closure) and GIJN investigative- journalism practice ("what does the other side say"). Auto-invoked by `/research` deep mode against `research.md`; runs standalone against any user-supplied claim. Produces `counterpoints.md` linking back to the source artifact. Depth cues — `quickly`, `top three`, `briefly`, `summary only` for the strongest objections; `comprehensively`, `exhaustively`, `in depth`, `extensive` for the full set.
+**description:** Adversarially review a research artifact (`research.md`) or a user-supplied claim. Searches for counter-evidence, names the strongest objections, and routes each to a verdict — either a confidence-rating downgrade or a do-not-resolve verdict for an irreducible tension where both sides are well-evidenced under different conditions. Grounded in ACH (evidence-against column — the discipline that catches premature closure) and GIJN investigative-journalism practice ("what does the other side say"). Auto-invoked by `/research` deep mode against `research.md`; runs standalone against any user-supplied claim. Produces `counterpoints.md` linking back to the source artifact. Depth cues — `quickly`, `top three`, `briefly`, `summary only` for the strongest objections; `comprehensively`, `exhaustively`, `in depth`, `extensive` for the full set.
 
 ### compare-hypotheses
 
@@ -46,7 +46,7 @@ Seven skills ship in the pack. The `name` and `description` below are reproduced
 
 **name:** `decision-archaeology`.
 
-**description:** Reconstruct the rationale for a past decision by walking time-ordered artifacts (commits, PRs, design docs, chat logs, internal memos). Self-contained — does not invoke `/source-map` or other research-pack skills, because the source surface is time- ordered and internal, and authority is established by an artifact's place in the history rather than by external curation. Produces `archaeology.md` with chronology, the rationale chain, and the alternatives that were considered and rejected. Depth cues — `quickly`, `top three`, `briefly`, `summary only` for the main rationale chain; `comprehensively`, `exhaustively`, `in depth`, `extensive` for branch alternatives and dead ends.
+**description:** Reconstruct the rationale for a past decision by walking time-ordered artifacts (commits, PRs, design docs, chat logs, internal memos). Self-contained — does not invoke `/source-map` or other research-pack skills, because the source surface is time-ordered and internal, and authority is established by an artifact's place in the history rather than by external curation. Produces `archaeology.md` with chronology, the rationale chain, the alternatives that were considered and rejected, and a revival check flagging rejected alternatives whose original rejection rationale no longer holds. Depth cues — `quickly`, `top three`, `briefly`, `summary only` for the main rationale chain; `comprehensively`, `exhaustively`, `in depth`, `extensive` for branch alternatives and dead ends.
 
 ## Retrieval subagents
 

--- a/docs/guides/research/tutorials/research-first-session.md
+++ b/docs/guides/research/tutorials/research-first-session.md
@@ -144,7 +144,7 @@ research.md
 counterpoints.md
 ```
 
-`counterpoints.md` walks each finding in `research.md`, names the strongest counter-position, cites counter-evidence, and proposes confidence-rating downgrades. Open it:
+`counterpoints.md` walks each finding in `research.md`, names the strongest counter-position, cites counter-evidence, and routes each to a verdict — either a confidence-rating downgrade, or a *do-not-resolve* verdict when both sides are well-evidenced under different conditions and more evidence would not collapse the disagreement to one answer. Open it:
 
 ```markdown
 # Counterpoints — research.md
@@ -156,8 +156,18 @@ similarity search at scale.
   cited workload class; "at scale" is contested.
 - **Counter-evidence:** [peer-reviewed benchmark paper], [SIGMOD
   discussion].
-- **Proposed rating change:** `[high]` → `[moderate]`. Reason:
+- **Verdict:** rating downgrade — `[high]` → `[moderate]`. Reason:
   `contested-in-field`.
+
+## Finding: a monorepo is the right default for multi-team codebases.
+
+- **Counter-position:** polyrepo wins for independently-deployed teams
+  with strong service boundaries; both are well-evidenced.
+- **Counter-evidence:** [large-scale monorepo case study], [polyrepo
+  migration retrospective].
+- **Verdict:** do-not-resolve. Monorepo holds when tooling and release
+  cadence are shared; polyrepo holds when teams deploy independently.
+  More evidence would not collapse this to one answer.
 ```
 
 That's the deep-mode signature: two artifacts, the second arguing against the first.

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -42,6 +42,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   keep-vs-delete the tool — is a new on-demand reference,
   `references/scale-with-a-tool.md`.
 
+- **The research pack learns to preserve irreducible ambiguity instead of
+  always collapsing to one rated answer (research 0.2.0).** Four skills gain a
+  first-class way to hold a question open when the honest output is not a single
+  verdict: `/identify-perspectives` adds a **tension map** recording, per
+  irreducible disagreement, the conditions under which each camp holds and what
+  a forced resolution would destroy; `/devils-advocate` adds a **do-not-resolve
+  verdict** for productive tensions where both sides are well-evidenced under
+  different conditions, distinct from its confidence-downgrade; `/research` adds
+  a first-class **known-unknowns / unknowables** gap section, distinct from
+  rating a weak finding `[uncertain]`; and `/decision-archaeology` adds a
+  **revival check** that flags a rejected alternative whose original rejection
+  rationale no longer holds because a constraint changed. Each is additive — no
+  existing schema field or downstream contract changes.
+
 - **The rest of the catalogue-internal references are swept from shipped
   content (core 0.4.4, figma 0.1.3).** Following the first pass, the remaining
   `make build-*` build-target mentions, an internal RFC citation, and the "this

--- a/docs/specs/research-ambiguity-preservation/spec.md
+++ b/docs/specs/research-ambiguity-preservation/spec.md
@@ -1,0 +1,112 @@
+# Spec: research-ambiguity-preservation
+
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Plan:** none (lean light-mode spec; task list below)
+- **Constrained by:** none
+- **Brief:** none
+- **Contract:** none
+- **Shape:** docs/prose (skill content)
+
+> Mode: light (no risk trigger fired) — prose-only, additive edits to four
+> existing research-pack skills; no new module, layer, dependency, or breaking
+> interface change. The four output schemas gain *additive* sections; no
+> existing schema field or downstream contract changes.
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+The research pack's standing bias is to **collapse every contested or
+under-determined question to one rated answer**: `/research` tags each finding
+with a single confidence level, `/devils-advocate`'s only verdict is a
+confidence *downgrade*, `/identify-perspectives` enumerates camps then hands
+them to `/compare-hypotheses` to pick a winner, and `/decision-archaeology`
+records a rejection as a settled verdict. None of these has a first-class way
+to **preserve and characterize irreducible ambiguity** — the cases where the
+honest output is "both positions hold, under different conditions," "this is a
+gap we cannot fill, not a weak finding," or "this rejection was conditional and
+the condition has changed."
+
+This spec adds that missing axis to four skills, each addition distinct from
+what the pack already encodes (triangulation, GRADE confidence, ACH, NPOV
+camps, chronology + rationale chains):
+
+1. **identify-perspectives — tension map.** For each *preserved* disagreement
+   (one that does not resolve to a single right camp), record the conditions
+   under which each position holds and what a forced resolution would destroy.
+   Distinct from the camp enumeration (per-camp claims/voices): the tension map
+   is a *relational* layer that marks which disagreements are irreducible and
+   why, so a reader — or a future `/compare-hypotheses` pass — can refuse to
+   flatten them. (Wiring `/compare-hypotheses` to honor the marking is a
+   deliberate follow-on, out of this PR's four-skill scope; today the marking
+   is the record, not yet an enforced gate.)
+
+2. **devils-advocate — do-not-resolve verdict.** A verdict, distinct from the
+   existing confidence-downgrade, for productive/irreducible tensions: both
+   sides are well-evidenced and the disagreement is in the world, not in our
+   knowledge, so lowering confidence would falsely imply more evidence resolves
+   it. The skill routes substantive evidence-against to *either* a downgrade
+   *or* do-not-resolve.
+
+3. **research — known-unknowns / unknowables gap section.** A first-class
+   artifact section cataloguing questions a complete answer requires but the
+   evidence cannot supply, split into *known-unknowns* (answerable in
+   principle, evidence not yet available) and *unknowables* (not answerable
+   from available evidence even in principle). Distinct from rating a weak
+   *finding* `[uncertain]`: a known-unknown is a *non-finding* — rating it
+   would dress "we don't know" up as a weak claim.
+
+4. **decision-archaeology — revival check.** For each rejected alternative,
+   evaluate whether its *original rejection rationale still holds today*; when
+   the constraint that killed it has changed, flag it as a revival candidate.
+   Distinct from the alternatives-considered record (the historical what/why):
+   the revival check is a forward-looking audit of that record against present
+   constraints.
+
+## Acceptance Criteria
+
+- [x] **AC1** `identify-perspectives/SKILL.md` adds a tension-map procedure
+  step and a `## Tension map` section in the `perspectives.md` output schema,
+  recording per preserved disagreement: the conditions under which each
+  position holds, and what forced resolution would destroy. Prose states it is
+  distinct from (not a relabel of) the camp enumeration.
+- [x] **AC2** `devils-advocate/SKILL.md` adds a do-not-resolve verdict as a
+  third routing outcome (alongside the existing rating-downgrade), with prose
+  that distinguishes irreducible/productive tension from evidential weakness,
+  and a corresponding entry in the `counterpoints.md` schema.
+- [x] **AC3** `research/SKILL.md` adds a known-unknowns / unknowables gap
+  section as a pipeline step and a `## Known unknowns` artifact section, with
+  prose that distinguishes a gap (non-finding) from an `[uncertain]`-rated
+  finding, and the known-unknown vs. unknowable split.
+- [x] **AC4** `decision-archaeology/SKILL.md` adds a revival-check procedure
+  step and a `## Revival candidates` schema section flagging rejected
+  alternatives whose original rejection rationale no longer holds, distinct
+  from the alternatives-considered record.
+- [x] **AC5** The optional build-outline "era axis" is evaluated and
+  **declined** (recorded in the PR's declined-pattern register): era-dependence
+  is already covered by research's recency rule + `stale prior art` factor and
+  by AC1's tension-map conditions field; it fails the non-duplication bar.
+- [x] **AC6** Each addition is universal (no domain coupling), additive (no
+  existing schema field or downstream contract removed/changed), and framed as
+  a standing habit (a procedure step, not an aside).
+- [x] **AC8** The pack's in-repo guides are kept in sync with the changed
+  frontmatter and `counterpoints.md` verdict shape: `docs/guides/research/`
+  reference (the three changed verbatim frontmatter descriptions), the
+  tutorial (`counterpoints.md` walkthrough + example), and the how-to
+  (pipeline artifact list) no longer describe `/devils-advocate` as
+  downgrade-only or omit the new sections. (Doc-drift invariant; surfaced by
+  adversarial review.)
+- [x] **AC7** `packs/research/pack.toml` + `plugin.json` version bumped;
+  `make build` run so `marketplace.json` reflects the bump; changelog
+  `[Unreleased]` entry added; `git status` clean; `tools/lint-agent-artifacts.py`
+  green; adversarial-reviewer clean.
+
+## Tasks
+
+1. identify-perspectives: tension-map step + schema section (AC1).
+2. devils-advocate: do-not-resolve verdict + schema entry (AC2).
+3. research: known-unknowns/unknowables gap step + artifact section (AC3).
+4. decision-archaeology: revival check step + schema section (AC4).
+5. Version bump (pack.toml + plugin.json), `make build`, changelog entry (AC7).

--- a/packs/research/.apm/skills/decision-archaeology/SKILL.md
+++ b/packs/research/.apm/skills/decision-archaeology/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: decision-archaeology
-description: Reconstruct the rationale for a past decision by walking time-ordered artifacts (commits, PRs, design docs, chat logs, internal memos). Self-contained — does not invoke `/source-map` or other research-pack skills, because the source surface is time-ordered and internal, and authority is established by an artifact's place in the history rather than by external curation. Produces `archaeology.md` with chronology, the rationale chain, and the alternatives that were considered and rejected. Depth cues — `quickly`, `top three`, `briefly`, `summary only` for the main rationale chain; `comprehensively`, `exhaustively`, `in depth`, `extensive` for branch alternatives and dead ends.
+description: Reconstruct the rationale for a past decision by walking time-ordered artifacts (commits, PRs, design docs, chat logs, internal memos). Self-contained — does not invoke `/source-map` or other research-pack skills, because the source surface is time-ordered and internal, and authority is established by an artifact's place in the history rather than by external curation. Produces `archaeology.md` with chronology, the rationale chain, the alternatives that were considered and rejected, and a revival check flagging rejected alternatives whose original rejection rationale no longer holds. Depth cues — `quickly`, `top three`, `briefly`, `summary only` for the main rationale chain; `comprehensively`, `exhaustively`, `in depth`, `extensive` for branch alternatives and dead ends.
 ---
 
 # /decision-archaeology
@@ -62,7 +62,17 @@ Rationale reconstruction has three converging disciplines:
    rejected, who signed.
 5. **Surface alternatives-considered** — the rejected branches deserve
    their own section.
-6. **Write `archaeology.md`**. No `sources.md` is produced.
+6. **Run the revival check** — for each rejected alternative, ask
+   whether *the rationale that rejected it still holds today*. A
+   rejection is never an unconditional verdict: it was conditional on
+   the constraints at decision time (the library didn't exist, the team
+   was too small, the latency budget was tighter, the cost was
+   prohibitive). When a constraint that drove the rejection has since
+   changed, the rejection is **stale** and the alternative is a
+   **revival candidate**. See *The revival check* below. This is the
+   payoff of recording *why* each alternative was rejected: a rationale
+   you can name is a rationale you can later audit against the present.
+7. **Write `archaeology.md`**. No `sources.md` is produced.
 
 ## `archaeology.md` output schema
 
@@ -91,10 +101,27 @@ Rationale reconstruction has three converging disciplines:
 - **<alternative name>** — rejected at step <N>. Reason: <citation>.
 - **<alternative name>** — rejected at step <N>. Reason: <citation>.
 
+## Revival candidates
+
+- **<alternative name>** — rejected because <original rationale>. That
+  constraint has changed: <what changed, with a citation or dated
+  signal>. The original reason no longer holds, so this is a candidate
+  to reconsider. (Not a recommendation to adopt it — only a flag that
+  its rejection is stale.)
+
 ## Open questions
 
 - <a rationale link the artifact trail does not actually establish>.
 ```
+
+The revival check is **distinct from** the alternatives-considered
+record above it. Alternatives-considered is the *historical* record —
+what was rejected and why, as of the decision. The revival check is a
+*forward-looking* audit of that record against today's constraints: it
+reads each historical rejection rationale and asks whether it survived.
+An alternative that was rejected for a reason still true today does
+*not* become a revival candidate; only one whose rejection rationale has
+been overtaken by a changed constraint does.
 
 ## Citation discipline
 
@@ -106,7 +133,9 @@ syntheses are marked `[synthesis]`.
 ## Depth cues
 
 - `quickly`, `top three`, `briefly`, `summary only` — return the main
-  rationale chain only; skip alternatives-considered.
+  rationale chain only; skip alternatives-considered and the revival
+  check.
 - `comprehensively`, `exhaustively`, `in depth`, `extensive` — walk
   branch alternatives and dead ends; surface artifacts that
-  influenced the decision indirectly; include rejected drafts.
+  influenced the decision indirectly; include rejected drafts; run the
+  revival check over every rejected alternative.

--- a/packs/research/.apm/skills/devils-advocate/SKILL.md
+++ b/packs/research/.apm/skills/devils-advocate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: devils-advocate
-description: Adversarially review a research artifact (`research.md`) or a user-supplied claim. Searches for counter-evidence, names the strongest objections, and proposes confidence-rating downgrades. Grounded in ACH (evidence-against column — the discipline that catches premature closure) and GIJN investigative-journalism practice ("what does the other side say"). Auto-invoked by `/research` deep mode against `research.md`; runs standalone against any user-supplied claim. Produces `counterpoints.md` linking back to the source artifact. Depth cues — `quickly`, `top three`, `briefly`, `summary only` for the strongest objections; `comprehensively`, `exhaustively`, `in depth`, `extensive` for the full set.
+description: Adversarially review a research artifact (`research.md`) or a user-supplied claim. Searches for counter-evidence, names the strongest objections, and routes each to a verdict — either a confidence-rating downgrade or a do-not-resolve verdict for an irreducible tension where both sides are well-evidenced under different conditions. Grounded in ACH (evidence-against column — the discipline that catches premature closure) and GIJN investigative-journalism practice ("what does the other side say"). Auto-invoked by `/research` deep mode against `research.md`; runs standalone against any user-supplied claim. Produces `counterpoints.md` linking back to the source artifact. Depth cues — `quickly`, `top three`, `briefly`, `summary only` for the strongest objections; `comprehensively`, `exhaustively`, `in depth`, `extensive` for the full set.
 ---
 
 # /devils-advocate
@@ -51,14 +51,55 @@ Two convergent disciplines:
 3. **Retrieve counter-evidence** — dispatch `evidence-retriever`
    subagent against each counter-position. The main session does the
    reasoning; the subagent supplies the material.
-4. **Propose rating downgrades** — for each finding whose evidence-
-   against is substantive, propose the new confidence rating
-   (`[high]` → `[moderate]`, or `[moderate]` → `[low]`, etc., per
-   `references/confidence-schema.md`). Name the downgrade factor.
+4. **Route each substantive evidence-against to a verdict** — for each
+   finding whose evidence-against is substantive, pick one of two
+   verdicts:
+   - **Rating downgrade** — the evidence-against weakens the finding:
+     propose the new confidence rating (`[high]` → `[moderate]`, or
+     `[moderate]` → `[low]`, etc., per `references/confidence-schema.md`)
+     and name the downgrade factor. This is the default verdict.
+   - **Do-not-resolve** — the evidence-against does *not* weaken the
+     finding; it establishes a credible *opposing* position that is
+     itself well-evidenced, so the finding and its counter are both
+     right under different conditions. See *The do-not-resolve verdict*
+     below. Reach for this only when a downgrade would misrepresent the
+     situation.
 5. **Moderator pass** — before declaring done, scan retrieved-but-
    uncited counter-material and consider one more query from the
    highest-signal unused snippet (Co-STORM contribution).
 6. **Write `counterpoints.md`**, linking back to the source artifact.
+
+## The do-not-resolve verdict
+
+A rating downgrade says *"trust this finding less — the evidence is
+weaker than it was rated."* It is the right verdict when the
+counter-evidence undercuts the finding: a single source where three
+were claimed, an unaccounted contested-in-field factor, a benchmark
+that doesn't replicate.
+
+But sometimes the counter-evidence is not a weakness in the finding —
+it is a credible, well-evidenced position that *opposes* it, and both
+survive scrutiny because they are right under **different conditions**.
+The disagreement is in the world, not in a gap in the evidence.
+Downgrading the finding here is wrong twice over: it implies the
+finding is shaky (it isn't), and it implies that more evidence would
+settle the question (it won't). The honest verdict is **do-not-resolve**:
+name the productive tension, state the conditions under which each side
+holds, and leave both standing.
+
+Use the test: *would more or better evidence collapse this to one
+answer?* If yes, it is a confidence question — downgrade. If no — if
+the two positions are answers to subtly different questions, or hold in
+different regimes — it is an irreducible tension, and you record it
+rather than adjudicate it. Do-not-resolve is the `/devils-advocate`
+counterpart to the tension map `/identify-perspectives` builds upstream:
+the same irreducibility, surfaced adversarially against a finding rather
+than enumerated across camps.
+
+Do-not-resolve is **not** an escape hatch for "the evidence is thin so I
+won't commit." Thin evidence is `[uncertain]` (a `/research` rating) or
+a known-unknown (a `/research` gap entry) — not a tension. A
+do-not-resolve verdict requires *substantive evidence on both sides*.
 
 ## `counterpoints.md` output schema
 
@@ -69,13 +110,20 @@ Two convergent disciplines:
 
 - **Counter-position:** <strongest objection, one paragraph>.
 - **Counter-evidence:** <citations>.
-- **Proposed rating change:** `[high]` → `[moderate]`. Reason:
+- **Verdict:** rating downgrade — `[high]` → `[moderate]`. Reason:
   contested-in-field.
 
 ## Finding: <next>
 
-(same shape)
+- **Counter-position:** <a credible, well-evidenced opposing position>.
+- **Counter-evidence:** <citations — substantive, on both sides>.
+- **Verdict:** do-not-resolve. Both hold under different conditions:
+  <finding> holds when <conditions>; <counter-position> holds when
+  <conditions>. More evidence would not collapse this to one answer.
 ```
+
+The `Verdict` line carries exactly one of the two outcomes from step 4 —
+a rating downgrade *or* do-not-resolve, never both for the same finding.
 
 ## Citation discipline
 

--- a/packs/research/.apm/skills/identify-perspectives/SKILL.md
+++ b/packs/research/.apm/skills/identify-perspectives/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: identify-perspectives
-description: Enumerate the named camps on a contested topic before research begins. Builds the perspective scaffold that `/source-map` and `/compare-hypotheses` consume downstream in the decision pipeline. Grounded in Wikipedia NPOV (neutral point of view — fairly represent significant views) and ACH (competing hypotheses — surface all explanations before evaluating). Produces `perspectives.md` listing each camp's name, its core claim, and representative voices. Depth cues — `quickly`, `top three`, `briefly` for the dominant few; `comprehensively`, `exhaustively`, `in depth`, `extensive` for fringe and dissenting positions too.
+description: Enumerate the named camps on a contested topic before research begins. Builds the perspective scaffold that `/source-map` and `/compare-hypotheses` consume downstream in the decision pipeline. Grounded in Wikipedia NPOV (neutral point of view — fairly represent significant views) and ACH (competing hypotheses — surface all explanations before evaluating). Produces `perspectives.md` listing each camp's name, its core claim, and representative voices, plus a tension map recording which disagreements are irreducible (both sides right under different conditions) and what a forced resolution would destroy. Depth cues — `quickly`, `top three`, `briefly` for the dominant few; `comprehensively`, `exhaustively`, `in depth`, `extensive` for fringe and dissenting positions too.
 ---
 
 # /identify-perspectives
@@ -50,7 +50,19 @@ Evaluation is `/compare-hypotheses`'s job downstream.
 4. **Look for missing camps** — quiet positions, dissenting minorities,
    contrarian-but-credentialed. The biggest NPOV failure is
    *omission*, not bias.
-5. **Write `perspectives.md`**.
+5. **Map the tensions** — for each pair of camps that genuinely
+   disagree, decide whether the disagreement *resolves* (one camp is
+   right, the other is wrong, and evidence settles it) or is
+   **irreducible** (both camps are right under different conditions, and
+   the disagreement is in the world, not in a gap in the evidence). For
+   every irreducible disagreement, record the conditions under which
+   each side holds, and what a forced resolution would destroy. This is
+   the step that *marks* an irreducible tension so it is not silently
+   flattened downstream — `/compare-hypotheses` is built to pick a
+   winner, so a disagreement that *shouldn't* have a winner needs to
+   carry that marking before it reaches that skill, so a reader (or a
+   future `/compare-hypotheses` pass) can refuse to collapse it.
+6. **Write `perspectives.md`**.
 
 ## `perspectives.md` output schema
 
@@ -70,7 +82,31 @@ Evaluation is `/compare-hypotheses`'s job downstream.
 ## Possibly-missing camps
 
 - <one-line description of a position that might be under-represented>.
+
+## Tension map
+
+- **<camp A> vs. <camp B>** — irreducible.
+  - **<camp A> holds when:** <the conditions / regime / scope under which A is right>.
+  - **<camp B> holds when:** <the conditions under which B is right>.
+  - **Forced resolution would destroy:** <what picking one side erases — a
+    real distinction, a context where the loser is correct, a constraint
+    that only the loser respects>.
+- **<camp C> vs. <camp D>** — resolves (defer to `/compare-hypotheses`).
 ```
+
+The tension map is **not** a relabelling of the camp list above it. The
+camp list answers *"what are the positions?"*; the tension map answers
+*"which disagreements between them have no single right answer, and
+why?"* A camp can appear in the list and never reach the tension map
+(it doesn't conflict with another camp); a disagreement reaches the
+tension map only when it is **irreducible** — both sides survive
+because they are right under different conditions, not because the
+evidence is too thin to choose (that latter case is a confidence
+question for `/research`, not a tension). Marking the irreducible ones
+here is what lets a reader — or a future `/compare-hypotheses` pass —
+refuse to collapse them to a verdict; today `/compare-hypotheses` ranks
+unconditionally, so the marking is the record that a ranking would be
+the wrong move, not yet a mechanism that prevents one.
 
 ## Citation discipline
 
@@ -82,8 +118,8 @@ the model has seen across cited material).
 ## Depth cues
 
 - `quickly`, `top three`, `briefly` — return the dominant two or three
-  camps only; skip the missing-camps survey.
+  camps only; skip the missing-camps survey and the tension map.
 - `summary only` — same; one-line per camp.
 - `comprehensively`, `exhaustively`, `in depth`, `extensive` —
   enumerate every named camp, including fringe and dissenting ones;
-  spend real effort on the missing-camps survey.
+  spend real effort on the missing-camps survey and the tension map.

--- a/packs/research/.apm/skills/research/SKILL.md
+++ b/packs/research/.apm/skills/research/SKILL.md
@@ -126,8 +126,10 @@ art` to the closed downgrade-factor set.
 Fires on `go deep`, `exhaustively`, `extensive research` (when no
 applied cue is also present — see Cue precedence above). Same artifact
 shape as standard, plus auto-invocation of `/devils-advocate` on the
-produced `research.md`, producing `counterpoints.md` with proposed
-rating downgrades.
+produced `research.md`, producing `counterpoints.md` with a per-finding
+verdict — a confidence downgrade, or a do-not-resolve verdict for an
+irreducible tension where both sides are well-evidenced under different
+conditions.
 
 Note: applied mode can be chained with `/devils-advocate` as a
 follow-up invocation when the user wants adversarial review of a
@@ -151,10 +153,15 @@ to chain.
    `[inference]` per Wikipedia V/RS and GRADE convergence.
 5. **Rate** — apply the confidence schema in
    `references/confidence-schema.md` to every finding.
-6. **Moderator pass** — before declaring done, scan retrieved-but-
+6. **Name the gaps** — before the moderator pass, write the
+   known-unknowns / unknowables section (see *Known unknowns and
+   unknowables* below). Skip in quick mode. This is a standing step, not
+   an optional flourish: a synthesis with no gap section is asserting it
+   answered everything the question raised, which is almost never true.
+7. **Moderator pass** — before declaring done, scan retrieved-but-
    uncited material and consider one more query from the highest-signal
    unused snippet (Co-STORM contribution). Skip in quick mode.
-7. **Adversarial review (deep mode only)** — auto-invoke
+8. **Adversarial review (deep mode only)** — auto-invoke
    `/devils-advocate` on `research.md`; emit `counterpoints.md`.
 
 ## Retrievers
@@ -213,6 +220,58 @@ Every factual claim in `research.md` carries a citation, or is marked
 defensible deduction that no single source states). Confidence per
 finding follows the four-level schema in
 `references/confidence-schema.md`; downgrade factors are named explicitly.
+
+## Known unknowns and unknowables (standard / applied / deep)
+
+A confidence rating answers *"how much should you trust this finding?"*
+It is a tag on a claim the research **did** make. It says nothing about
+the questions the research **could not answer at all** — and quietly
+omitting those, or dressing one up as a thin `[uncertain]` finding, is
+the most common way a synthesis overstates how complete it is.
+
+So every non-quick artifact carries a first-class gap section. It is
+**not** a rating — there is no finding to rate, because the evidence to
+support one does not exist. Rating a non-finding `[uncertain]` is a
+category error: `[uncertain]` means *"we have a claim, but weak grounds
+for it"*; a gap means *"we have no claim, because the evidence isn't
+there."* Keep the two apart — a weak finding stays in **Findings** with
+an `[uncertain]` tag; a gap goes here.
+
+Split each gap into one of two kinds:
+
+- **Known-unknown** — answerable *in principle*; the evidence exists or
+  could be produced, you just don't have it in hand. (The benchmark
+  hasn't been run on this workload; the vendor hasn't published the
+  number; the primary source is paywalled.) A known-unknown names what
+  evidence *would* close it — it is a research lead, not a dead end.
+- **Unknowable** — not answerable from available evidence *even in
+  principle*, at least as the question is posed. The data was never
+  recorded; the counterfactual can't be run; the outcome is in the
+  future; the question is contested in a way no evidence settles (in
+  which case it belongs in a tension, not a finding — see
+  `/identify-perspectives` and `/devils-advocate`'s do-not-resolve
+  verdict). An unknowable names *why* the evidence can't exist, so a
+  reader stops hunting for it.
+
+The discipline is the same one GRADE encodes for ratings: make the
+limit explicit and named, rather than letting silence imply completeness.
+
+### `## Known unknowns` artifact section
+
+```markdown
+## Known unknowns
+
+- **Known-unknown:** <question a complete answer needs>. Would be closed
+  by: <the evidence that would answer it — a benchmark, a primary
+  source, a disclosure>.
+- **Unknowable:** <question that can't be answered from available
+  evidence>. Why not: <the data was never recorded / the outcome hasn't
+  happened / no evidence settles it>.
+```
+
+Depth cues scale this section the same way they scale findings: a
+`briefly` artifact names only the load-bearing gaps; a `comprehensively`
+one chases the second-order ones too.
 
 ## Moderator pass (standard / deep)
 

--- a/packs/research/.claude-plugin/plugin.json
+++ b/packs/research/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "research",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Evidence-grounded research portable across every repo. Seven skills (scoping, source curation, synthesis, adversarial review, decision support, rationale reconstruction) plus two retrieval subagents; methodology grounded in seven convergent disciplines (STORM, PRISMA, ACH, Wikipedia V/RS/NPOV, OSINT, GIJN, GRADE)."
 }

--- a/packs/research/pack.toml
+++ b/packs/research/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "research"
-version = "0.1.2"
+version = "0.2.0"
 description = "Evidence-grounded research portable across every repo. Seven skills (scoping, source curation, synthesis, adversarial review, decision support, rationale reconstruction) plus two retrieval subagents; methodology grounded in seven convergent disciplines (STORM, PRISMA, ACH, Wikipedia V/RS/NPOV, OSINT, GIJN, GRADE)."
 readme = "README.md"
 display_name = "Research"


### PR DESCRIPTION
## What & why

The research pack's standing bias was to **collapse every contested or under-determined question to one rated answer** — `/research` tags each finding with a single confidence level, `/devils-advocate`'s only verdict was a confidence downgrade, `/identify-perspectives` enumerated camps then handed them to `/compare-hypotheses` to pick a winner, and `/decision-archaeology` recorded a rejection as a settled verdict. None had a first-class way to **preserve and characterize irreducible ambiguity**.

This adds that missing axis to four source skills (`packs/research/.apm/skills/`), each distinct from what the pack already encodes (triangulation, GRADE, ACH, NPOV camps, chronology + rationale chains):

| Skill | Addition | Distinct from |
|---|---|---|
| identify-perspectives | **tension map** — per irreducible disagreement, the conditions each camp holds under + what forced resolution destroys | the camp enumeration (per-camp claims/voices) |
| devils-advocate | **do-not-resolve verdict** — for productive tensions where both sides are well-evidenced under different conditions | the confidence-downgrade (evidential weakness) |
| research | **known-unknowns / unknowables** gap section — non-findings the evidence can't supply | rating a weak *finding* `[uncertain]` |
| decision-archaeology | **revival check** — flags a rejected alternative whose original rejection rationale no longer holds | the alternatives-considered historical record |

**Declined:** the optional build-outline "era axis". Era-dependence is already covered by research's recency rule + `stale prior art` factor *and* by the new tension-map conditions field — it failed the non-duplication bar.

## How it was verified

- `make lint-packs`, `python3 tools/lint-agent-artifacts.py`, research-retriever conformance + self-host/plugin-manifest pytest, `lint-spec-status.py` (my spec clean) — all green.
- `make build-self FORCE=1` to refresh `.claude-plugin/marketplace.json` (research 0.1.2 → 0.2.0); dry-run confirms no other drift (research is user-scope-default, not projected into this tree).
- `adversarial-reviewer` iterated to `Clean — ready to commit.` It caught a doc-drift Blocker (the hand-maintained `docs/guides/research/reference/` mirrors skill frontmatter verbatim and went stale) and a Concern (tutorial/how-to described `counterpoints.md` as downgrade-only) — both fixed in this PR.

## What I'm unsure about / follow-ons

- **`/compare-hypotheses` does not yet honor the tension map.** It still ranks unconditionally, so an irreducible disagreement marked upstream is recorded but not *enforced* against collapse. Wiring it is a deliberate follow-on, kept out of this PR's four-skill scope; the prose and spec say so honestly rather than overclaiming present protection.

## Anything reviewers should focus on

The **distinctness** of each addition from the mechanism it sits beside (tension map ≠ camp list; do-not-resolve ≠ downgrade; known-unknown ≠ `[uncertain]`; revival check ≠ alternatives-considered). Each is additive — no existing schema field or downstream contract changed.

## Deferred

- Wire `/compare-hypotheses` to honor the tension-map markings (see follow-on above).