### PR TITLE
feat(bug-fix): hypothesis-first debugging + testing-gap question (core 0.4.6)

### DIFF
--- a/.agents/skills/bug-fix/SKILL.md
+++ b/.agents/skills/bug-fix/SKILL.md
@@ -7,7 +7,9 @@ description: Use this skill when the user wants to fix a bug -- a deviation betw
 
 Fix a defect in the smallest, most root-causing way. The discipline is
 universal: reproduce before fixing, write the failing test first,
-identify root vs symptom, minimum diff, commit body documents why.
+falsify rival hypotheses before asserting a cause, identify root vs
+symptom, close the coverage gap that let it through, minimum diff,
+commit body documents why.
 
 ## When to invoke
 
@@ -37,7 +39,25 @@ restructuring.
      unfixed code; confirm it fails *because of* the bug, not
      because the setup is wrong.
 
-3. **Identify root cause before writing the fix.** Write down a
+3. **List candidate causes, then falsify each.** Before asserting a
+   root cause, name 2-3 plausible causes — not just the first one
+   that comes to mind. For each, write Expected / Actual / Verdict:
+   what you'd observe *if* that cause were true, what a probe (a log,
+   a breakpoint, a one-off experiment) actually shows, and whether
+   that rules the cause in or out. For example:
+   - *Cause A: input arrives unsorted.* Expected: log shows
+     out-of-order keys. Actual: keys are sorted. **Verdict: ruled
+     out.**
+   - *Cause B: cache returns a stale entry.* Expected: second call
+     skips the loader. Actual: loader never runs on the repro.
+     **Verdict: ruled in.**
+
+   Fixating on the first plausible cause is how you fix the wrong
+   thing; making yourself name rivals and kill them with evidence
+   keeps you honest. One survivor that the evidence supports becomes
+   the root cause you assert in step 4.
+
+4. **Identify root cause before writing the fix.** Write down a
    one-line answer to each:
    - **Where is the defect actually?** In the called function, the
      caller, their shared assumption, or upstream of both? A null
@@ -53,14 +73,19 @@ restructuring.
      assumption made elsewhere. If yes, decide whether the fix's
      scope widens or whether you file follow-up tickets and add an
      explicit non-goal ("fix here only").
+   - **Why wasn't it caught?** Which test, assertion, or guard
+     should have caught this and didn't — or never existed? Name the
+     specific coverage gap (an untested branch, a contract no test
+     pinned, an input class no fixture covered). The regression test
+     in step 7 closes *that* gap, not just the one input you observed.
 
-4. **Minimum fix.** Write the smallest change that turns the failing
+5. **Minimum fix.** Write the smallest change that turns the failing
    test green. Refuse to fix adjacent issues in the same PR; note
    them for follow-up. (Echoes `adversarial-reviewer`'s scope check
    — out-of-scope changes are a Blocker until justified or extracted.)
 
-5. **Verify root vs symptom.** Look at the diff and ask: does this
-   address what step 3 identified, or does it mask the symptom?
+6. **Verify root vs symptom.** Look at the diff and ask: does this
+   address what step 4 identified, or does it mask the symptom?
    Common symptom-only anti-patterns to refuse:
    - **Catch-all exception handlers** that swallow the bug instead
      of making the failing call not throw.
@@ -76,19 +101,21 @@ restructuring.
    If the failing test from step 2 still passes under a symptom-only
    fix, you wrote the wrong test — go back to step 2 and sharpen it.
 
-6. **Regression test stays.** The failing test from step 2 is the
+7. **Regression test stays.** The failing test from step 2 is the
    regression test. It lives in the suite; it must pin the real
-   invariant so it catches this bug if it recurs. Don't delete it
-   after the fix lands.
+   invariant so it catches this bug if it recurs — and it should
+   close the coverage gap named in step 4, pinning the invariant
+   that was missing rather than only the one input you observed.
+   Don't delete it after the fix lands.
 
-7. **Commit body documents the root cause.** Conventional commit
+8. **Commit body documents the root cause.** Conventional commit
    subject (`fix(<scope>): <subject>`) plus a body explaining what
    was wrong (the observable bug), why it was wrong (the root cause
-   from step 3), and why the fix takes the shape it does. The diff
+   from step 4), and why the fix takes the shape it does. The diff
    shows *what*; the commit body shows *why*. Future readers care
    more about the latter.
 
-8. **Loop back to the tracker (if any).** Comment the PR URL on the
+9. **Loop back to the tracker (if any).** Comment the PR URL on the
    ticket and apply the next transition. The mechanism is
    adopter-specific (Jira MCP, Linear CLI, `gh issue comment`, etc.);
    the obligation — keeping the ticket synced — is universal.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "atlassian",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.1.3"
+      "version": "0.1.4"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",
@@ -86,7 +86,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "core",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.4.5"
+      "version": "0.4.6"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/.claude/skills/bug-fix/SKILL.md
+++ b/.claude/skills/bug-fix/SKILL.md
@@ -7,7 +7,9 @@ description: Use this skill when the user wants to fix a bug -- a deviation betw
 
 Fix a defect in the smallest, most root-causing way. The discipline is
 universal: reproduce before fixing, write the failing test first,
-identify root vs symptom, minimum diff, commit body documents why.
+falsify rival hypotheses before asserting a cause, identify root vs
+symptom, close the coverage gap that let it through, minimum diff,
+commit body documents why.
 
 ## When to invoke
 
@@ -37,7 +39,25 @@ restructuring.
      unfixed code; confirm it fails *because of* the bug, not
      because the setup is wrong.
 
-3. **Identify root cause before writing the fix.** Write down a
+3. **List candidate causes, then falsify each.** Before asserting a
+   root cause, name 2-3 plausible causes — not just the first one
+   that comes to mind. For each, write Expected / Actual / Verdict:
+   what you'd observe *if* that cause were true, what a probe (a log,
+   a breakpoint, a one-off experiment) actually shows, and whether
+   that rules the cause in or out. For example:
+   - *Cause A: input arrives unsorted.* Expected: log shows
+     out-of-order keys. Actual: keys are sorted. **Verdict: ruled
+     out.**
+   - *Cause B: cache returns a stale entry.* Expected: second call
+     skips the loader. Actual: loader never runs on the repro.
+     **Verdict: ruled in.**
+
+   Fixating on the first plausible cause is how you fix the wrong
+   thing; making yourself name rivals and kill them with evidence
+   keeps you honest. One survivor that the evidence supports becomes
+   the root cause you assert in step 4.
+
+4. **Identify root cause before writing the fix.** Write down a
    one-line answer to each:
    - **Where is the defect actually?** In the called function, the
      caller, their shared assumption, or upstream of both? A null
@@ -53,14 +73,19 @@ restructuring.
      assumption made elsewhere. If yes, decide whether the fix's
      scope widens or whether you file follow-up tickets and add an
      explicit non-goal ("fix here only").
+   - **Why wasn't it caught?** Which test, assertion, or guard
+     should have caught this and didn't — or never existed? Name the
+     specific coverage gap (an untested branch, a contract no test
+     pinned, an input class no fixture covered). The regression test
+     in step 7 closes *that* gap, not just the one input you observed.
 
-4. **Minimum fix.** Write the smallest change that turns the failing
+5. **Minimum fix.** Write the smallest change that turns the failing
    test green. Refuse to fix adjacent issues in the same PR; note
    them for follow-up. (Echoes `adversarial-reviewer`'s scope check
    — out-of-scope changes are a Blocker until justified or extracted.)
 
-5. **Verify root vs symptom.** Look at the diff and ask: does this
-   address what step 3 identified, or does it mask the symptom?
+6. **Verify root vs symptom.** Look at the diff and ask: does this
+   address what step 4 identified, or does it mask the symptom?
    Common symptom-only anti-patterns to refuse:
    - **Catch-all exception handlers** that swallow the bug instead
      of making the failing call not throw.
@@ -76,19 +101,21 @@ restructuring.
    If the failing test from step 2 still passes under a symptom-only
    fix, you wrote the wrong test — go back to step 2 and sharpen it.
 
-6. **Regression test stays.** The failing test from step 2 is the
+7. **Regression test stays.** The failing test from step 2 is the
    regression test. It lives in the suite; it must pin the real
-   invariant so it catches this bug if it recurs. Don't delete it
-   after the fix lands.
+   invariant so it catches this bug if it recurs — and it should
+   close the coverage gap named in step 4, pinning the invariant
+   that was missing rather than only the one input you observed.
+   Don't delete it after the fix lands.
 
-7. **Commit body documents the root cause.** Conventional commit
+8. **Commit body documents the root cause.** Conventional commit
    subject (`fix(<scope>): <subject>`) plus a body explaining what
    was wrong (the observable bug), why it was wrong (the root cause
-   from step 3), and why the fix takes the shape it does. The diff
+   from step 4), and why the fix takes the shape it does. The diff
    shows *what*; the commit body shows *why*. Future readers care
    more about the latter.
 
-8. **Loop back to the tracker (if any).** Comment the PR URL on the
+9. **Loop back to the tracker (if any).** Comment the PR URL on the
    ticket and apply the next transition. The mechanism is
    adopter-specific (Jira MCP, Linear CLI, `gh issue comment`, etc.);
    the obligation — keeping the ticket synced — is universal.

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -19,6 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The `bug-fix` skill gains two debugging-discipline moves (core 0.4.6).**
+  A new "list candidate causes, then falsify each" step sits between
+  reproduction and the root-cause assertion — name 2-3 rival causes and rule
+  each in or out with Expected / Actual / Verdict, so you don't fixate on the
+  first plausible cause. And a "Why wasn't it caught?" question joins the
+  root-cause set, so the regression test closes a *named* coverage gap rather
+  than only pinning the observed input. Both are language- and
+  framework-agnostic. The renumbering shifts `bug-fix`'s tracker-loopback
+  step from 8 to 9; the atlassian `jira-defect-flow` skill's references to it
+  are updated to match (atlassian 0.1.4).
+
 - **`work-loop` gains a "Scale with a tool, not turns" technique for large,
   repetitive tasks (core 0.4.5).** When a task spans many similar items —
   applying one change across N files, transforming a large set, auditing every

--- a/packs/atlassian/.apm/skills/jira-defect-flow/SKILL.md
+++ b/packs/atlassian/.apm/skills/jira-defect-flow/SKILL.md
@@ -18,7 +18,7 @@ exist:
   regression test, commit-body-explains-why, and tracker loopback. This
   skill does **not** re-explain that discipline; invoke `bug-fix` and
   follow it. **Stages 6–7 below are the Jira-specific mechanism for
-  `bug-fix` step 8** ("loop back to the tracker") — not a separate
+  `bug-fix` step 9** ("loop back to the tracker") — not a separate
   obligation.
 - **Reviewer subagents** (`adversarial-reviewer`, plus `security-reviewer`
   / `quality-engineer` when the diff warrants) — already wired into the
@@ -130,7 +130,7 @@ context. Everything from here through "regression test stays" is owned by
 - Verify the fix addresses the root, not the symptom.
 - Regression test stays in the suite.
 - Commit body explains *what was wrong, why, and why this shape of fix*.
-- Loop back to the tracker (PR URL + next transition) — `bug-fix` step 8.
+- Loop back to the tracker (PR URL + next transition) — `bug-fix` step 9.
   Stages 6–7 below are the Jira-specific mechanism for this; do not
   treat it as separate work.
 
@@ -161,7 +161,7 @@ surface or new logic. Iterate until each returns `Clean — ready to commit.`
 This step is not optional and not in this skill — it's in the consumer
 repo's `work-loop`. Defer to it.
 
-### Stage 6 — PR (bug-fix step 8, part 1)
+### Stage 6 — PR (bug-fix step 9, part 1)
 
 Open the PR with `gh`. The PR body uses the consumer repo's template
 (four questions: *what / why / how to verify / what you did not change*).
@@ -180,9 +180,9 @@ Generate `$KEY-pr-body.md` from the template — do not paste a freeform
 description. The "What did you not change" section is the most useful
 field; fill it honestly.
 
-### Stage 7 — Jira loopback (bug-fix step 8, part 2)
+### Stage 7 — Jira loopback (bug-fix step 9, part 2)
 
-`bug-fix` step 8 mandates that the tracker gets the PR URL and the
+`bug-fix` step 9 mandates that the tracker gets the PR URL and the
 next transition. This is the Jira-specific implementation. Via the
 `jira` skill, discover the next transition the same way as stage 2:
 
@@ -200,7 +200,7 @@ the verbs are equivalent — name that skill and use the same contract.
 
 ### Stage 8 — Deploy to dev (optional, consumer-repo specific)
 
-This stage is *beyond* `bug-fix` step 8 — the upstream skill stops at
+This stage is *beyond* `bug-fix` step 9 — the upstream skill stops at
 "PR + transition". Dev-deploy is environment-specific and only runs
 when the consumer repo provides a hook.
 

--- a/packs/atlassian/.apm/skills/jira-defect-flow/manifest.json
+++ b/packs/atlassian/.apm/skills/jira-defect-flow/manifest.json
@@ -17,7 +17,7 @@
       {
         "name": "bug-fix",
         "source": "host repo — .claude/skills/bug-fix/",
-        "purpose": "Reproduction-first, failing test, root vs symptom, minimum diff, regression test, commit-body explains why, tracker loopback (step 8). Defect-flow stages 6–7 are the Jira-specific implementation of step 8."
+        "purpose": "Reproduction-first, failing test, root vs symptom, minimum diff, regression test, commit-body explains why, tracker loopback (step 9). Defect-flow stages 6–7 are the Jira-specific implementation of step 9."
       }
     ],
     "agents": [

--- a/packs/atlassian/.apm/skills/jira-defect-flow/references/examples.md
+++ b/packs/atlassian/.apm/skills/jira-defect-flow/references/examples.md
@@ -59,7 +59,7 @@ gh pr create --base main \
   --body-file .context/defects/PROJ-123-pr-body.md
 # PR body's Why? section contains: Closes: PROJ-123
 
-# Stage 7 — Jira loopback (bug-fix step 8 mechanism)
+# Stage 7 — Jira loopback (bug-fix step 9 mechanism)
 jira: comment PROJ-123 --body "PR: https://github.com/acme/web/pull/4321. Repro test: tests/checkout/coupon_expiry_test.py::test_expired_coupon_does_not_crash"
 jira: transition PROJ-123 --to "In Review"
 

--- a/packs/atlassian/.claude-plugin/plugin.json
+++ b/packs/atlassian/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "atlassian",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Atlassian primitives: jira / jira-align / confluence-crawler (credentialed CLI), plus the flow-metrics, ai-adoption-report, and jira-defect-flow workflows that compose them."
 }

--- a/packs/atlassian/pack.toml
+++ b/packs/atlassian/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "atlassian"
-version = "0.1.3"
+version = "0.1.4"
 description = "Atlassian primitives: jira / jira-align / confluence-crawler (credentialed CLI), plus the flow-metrics, ai-adoption-report, and jira-defect-flow workflows that compose them."
 readme = "README.md"
 display_name = "Atlassian"

--- a/packs/core/.apm/skills/bug-fix/SKILL.md
+++ b/packs/core/.apm/skills/bug-fix/SKILL.md
@@ -7,7 +7,9 @@ description: Use this skill when the user wants to fix a bug -- a deviation betw
 
 Fix a defect in the smallest, most root-causing way. The discipline is
 universal: reproduce before fixing, write the failing test first,
-identify root vs symptom, minimum diff, commit body documents why.
+falsify rival hypotheses before asserting a cause, identify root vs
+symptom, close the coverage gap that let it through, minimum diff,
+commit body documents why.
 
 ## When to invoke
 
@@ -37,7 +39,25 @@ restructuring.
      unfixed code; confirm it fails *because of* the bug, not
      because the setup is wrong.
 
-3. **Identify root cause before writing the fix.** Write down a
+3. **List candidate causes, then falsify each.** Before asserting a
+   root cause, name 2-3 plausible causes — not just the first one
+   that comes to mind. For each, write Expected / Actual / Verdict:
+   what you'd observe *if* that cause were true, what a probe (a log,
+   a breakpoint, a one-off experiment) actually shows, and whether
+   that rules the cause in or out. For example:
+   - *Cause A: input arrives unsorted.* Expected: log shows
+     out-of-order keys. Actual: keys are sorted. **Verdict: ruled
+     out.**
+   - *Cause B: cache returns a stale entry.* Expected: second call
+     skips the loader. Actual: loader never runs on the repro.
+     **Verdict: ruled in.**
+
+   Fixating on the first plausible cause is how you fix the wrong
+   thing; making yourself name rivals and kill them with evidence
+   keeps you honest. One survivor that the evidence supports becomes
+   the root cause you assert in step 4.
+
+4. **Identify root cause before writing the fix.** Write down a
    one-line answer to each:
    - **Where is the defect actually?** In the called function, the
      caller, their shared assumption, or upstream of both? A null
@@ -53,14 +73,19 @@ restructuring.
      assumption made elsewhere. If yes, decide whether the fix's
      scope widens or whether you file follow-up tickets and add an
      explicit non-goal ("fix here only").
+   - **Why wasn't it caught?** Which test, assertion, or guard
+     should have caught this and didn't — or never existed? Name the
+     specific coverage gap (an untested branch, a contract no test
+     pinned, an input class no fixture covered). The regression test
+     in step 7 closes *that* gap, not just the one input you observed.
 
-4. **Minimum fix.** Write the smallest change that turns the failing
+5. **Minimum fix.** Write the smallest change that turns the failing
    test green. Refuse to fix adjacent issues in the same PR; note
    them for follow-up. (Echoes `adversarial-reviewer`'s scope check
    — out-of-scope changes are a Blocker until justified or extracted.)
 
-5. **Verify root vs symptom.** Look at the diff and ask: does this
-   address what step 3 identified, or does it mask the symptom?
+6. **Verify root vs symptom.** Look at the diff and ask: does this
+   address what step 4 identified, or does it mask the symptom?
    Common symptom-only anti-patterns to refuse:
    - **Catch-all exception handlers** that swallow the bug instead
      of making the failing call not throw.
@@ -76,19 +101,21 @@ restructuring.
    If the failing test from step 2 still passes under a symptom-only
    fix, you wrote the wrong test — go back to step 2 and sharpen it.
 
-6. **Regression test stays.** The failing test from step 2 is the
+7. **Regression test stays.** The failing test from step 2 is the
    regression test. It lives in the suite; it must pin the real
-   invariant so it catches this bug if it recurs. Don't delete it
-   after the fix lands.
+   invariant so it catches this bug if it recurs — and it should
+   close the coverage gap named in step 4, pinning the invariant
+   that was missing rather than only the one input you observed.
+   Don't delete it after the fix lands.
 
-7. **Commit body documents the root cause.** Conventional commit
+8. **Commit body documents the root cause.** Conventional commit
    subject (`fix(<scope>): <subject>`) plus a body explaining what
    was wrong (the observable bug), why it was wrong (the root cause
-   from step 3), and why the fix takes the shape it does. The diff
+   from step 4), and why the fix takes the shape it does. The diff
    shows *what*; the commit body shows *why*. Future readers care
    more about the latter.
 
-8. **Loop back to the tracker (if any).** Comment the PR URL on the
+9. **Loop back to the tracker (if any).** Comment the PR URL on the
    ticket and apply the next transition. The mechanism is
    adopter-specific (Jira MCP, Linear CLI, `gh issue comment`, etc.);
    the obligation — keeping the ticket synced — is universal.

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr + session-start hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "0.4.5"
+version = "0.4.6"
 description = "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr + session-start hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 readme = "README.md"
 display_name = "Core"


### PR DESCRIPTION
## What

Sharpens the `bug-fix` skill with two lightweight, language- and framework-agnostic debugging-discipline moves:

1. **Hypothesis-first debugging** — a new step ("List candidate causes, then falsify each") sits between reproduction and the root-cause assertion. It makes you name 2-3 rival causes and rule each in or out with an **Expected / Actual / Verdict** line, so you don't fixate on the first plausible cause. The surviving cause is what you assert as root cause.
2. **"Why wasn't it caught?"** — a fourth question in the root-cause set names the specific coverage gap (untested branch, unpinned contract, uncovered input class). The regression test now explicitly closes *that named gap* rather than only pinning the observed input.

Source edited at `packs/core/.apm/skills/bug-fix/SKILL.md` (self-hosting repo); `.claude/` + `.agents/` projections and `marketplace.json` regenerated via `make build` / `make build-self`. Core bumped **0.4.5 → 0.4.6**.

## Cross-pack ride-along

The new step renumbers the procedure — the tracker-loopback step moves from **8 → 9**. The atlassian `jira-defect-flow` skill cites that step by number in **8 places** (SKILL.md ×6, manifest.json, examples.md), so those references are updated to match. Atlassian bumped **0.1.3 → 0.1.4**.

## Verification

- `make build-check` — passed
- `tools/lint-agent-artifacts.py` — passed
- adversarial-reviewer — Clean (caught the cross-pack ref drift and a stale-base version collision, both resolved in-PR: rebased onto #308, re-attributed bug-fix bump to 0.4.6, changelog appends both entries)
- Clean git status; `.claude/`/`.agents/` projections byte-match source