### PR TITLE
feat(skills): retcon writing + context-poisoning doc disciplines (core 0.4.6, user-guide-diataxis 0.1.4)

### DIFF
--- a/.agents/skills/new-guide/SKILL.md
+++ b/.agents/skills/new-guide/SKILL.md
@@ -158,6 +158,13 @@ If any check fails, push back rather than proceeding.
    - **Don't soften imperatives.** Drop *please* in instructions ("please
      click", "please run") — it makes commands sound optional. Just
      write the imperative.
+   - **Don't narrate the product's history.** Write as if the product
+     always worked this way — the *retcon* discipline. Drop "will be
+     added", "previously X, now Y", "deprecated in 2.0", and
+     version-stamped history from the guide body. A guide is a living doc
+     describing current behavior; the reader wants what is true now, not a
+     changelog. Evolution belongs in release notes, the changelog, or an
+     ADR — link to it instead of narrating it inline.
 
    Efficiency is a form of respect — the reader is in a hurry.
 

--- a/.agents/skills/new-guide/references/clear-prose.md
+++ b/.agents/skills/new-guide/references/clear-prose.md
@@ -51,6 +51,11 @@ search for once you know its shape.
   earns space, give it its own sentence or link to an explanation page.
 - **Don't narrate your intent.** "Here we want to show you…", "the goal of this
   section is…". Drop the meta-commentary and show the reader directly.
+- **Don't narrate the product's history.** Describe how it works now, not how it
+  used to — the *retcon* discipline. "Previously X, now Y", "will be added next
+  release", "deprecated in 2.0" belong in release notes or the changelog, not the
+  body. The reader wants what's true today; mixed tenses make them guess which
+  part still holds.
 
 ## A fast self-check
 

--- a/.agents/skills/new-spec/SKILL.md
+++ b/.agents/skills/new-spec/SKILL.md
@@ -141,6 +141,16 @@ look like?" before any code.
      dependency, no new module boundary) so the diff can't sprawl into
      hypothetical futures.
    - **No Acceptance Criteria.** Without a checklist, "done" is opinion.
+   - **Body narrates history or the future.** Write the spec in the
+     present tense, as if the feature already exists and always worked
+     this way — the *retcon* discipline. No "will be implemented", no
+     "previously X, now Y", no deprecation timelines, no version-stamped
+     history in the body. Mixed tenses make an agent reading the spec
+     guess wrong about what is current; a present-tense body reads as a
+     clean description of the contract as it stands. Decision history
+     lives in ADRs and the changelog, not the spec body — the plan
+     (`plan.md`) is the one exception, since it carries its own changelog
+     of how the approach evolved.
 
    While writing Testing Strategy, sanity-check that each TDD-mode AC is
    concrete enough to *stub* — see `work-loop`'s
@@ -256,8 +266,17 @@ look like?" before any code.
 
 7. Update `docs/specs/README.md` to add the feature to the active list.
 
-8. Remind the user: when implementation diverges from the spec, the spec is
-   wrong. Update the spec in the same PR.
+8. **Keep the spec the single source of truth — drift is a bug.** When
+   implementation diverges from the spec, the spec is wrong: update it in
+   the same PR. The failure mode this discipline prevents has a name —
+   **context poisoning**: an agent loads a stale, duplicated, or
+   self-contradicting doc and makes a confident, wrong decision from it,
+   because nothing in the document tells it which part is current. Two
+   habits are the defense, one for each way a doc poisons: **one canonical
+   home per fact** (the *Source of truth* map in `AGENTS.md`) stops a fact
+   from living in two places that can drift apart, and the **present-tense
+   retcon body** (the failure mode in step 4) stops a single document from
+   contradicting itself across tenses. Remind the user of both.
 
 ## Anti-patterns to refuse
 

--- a/.agents/skills/new-spec/assets/spec.md
+++ b/.agents/skills/new-spec/assets/spec.md
@@ -18,6 +18,13 @@ skill's light mode, only Objective + Acceptance Criteria + a short task list
 risk trigger (see the `work-loop` skill) escalates to full mode, where every
 section is filled. -->
 
+<!-- **Present tense, as-built.** Write every body section below as if the
+feature already exists and always worked this way — no "will be", no
+"previously X, now Y", no deprecation timelines, no version-stamped history.
+The body describes the current contract; decision history lives in ADRs and the
+changelog. This applies to the spec body only — `plan.md` keeps its own
+changelog of how the approach evolved. -->
+
 ## Objective
 
 <!--

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -86,7 +86,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "core",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.4.6"
+      "version": "0.4.7"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",
@@ -203,7 +203,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "user-guide-diataxis",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.1.3"
+      "version": "0.1.4"
     }
   ]
 }

--- a/.claude/skills/new-guide/SKILL.md
+++ b/.claude/skills/new-guide/SKILL.md
@@ -158,6 +158,13 @@ If any check fails, push back rather than proceeding.
    - **Don't soften imperatives.** Drop *please* in instructions ("please
      click", "please run") — it makes commands sound optional. Just
      write the imperative.
+   - **Don't narrate the product's history.** Write as if the product
+     always worked this way — the *retcon* discipline. Drop "will be
+     added", "previously X, now Y", "deprecated in 2.0", and
+     version-stamped history from the guide body. A guide is a living doc
+     describing current behavior; the reader wants what is true now, not a
+     changelog. Evolution belongs in release notes, the changelog, or an
+     ADR — link to it instead of narrating it inline.
 
    Efficiency is a form of respect — the reader is in a hurry.
 

--- a/.claude/skills/new-guide/references/clear-prose.md
+++ b/.claude/skills/new-guide/references/clear-prose.md
@@ -51,6 +51,11 @@ search for once you know its shape.
   earns space, give it its own sentence or link to an explanation page.
 - **Don't narrate your intent.** "Here we want to show you…", "the goal of this
   section is…". Drop the meta-commentary and show the reader directly.
+- **Don't narrate the product's history.** Describe how it works now, not how it
+  used to — the *retcon* discipline. "Previously X, now Y", "will be added next
+  release", "deprecated in 2.0" belong in release notes or the changelog, not the
+  body. The reader wants what's true today; mixed tenses make them guess which
+  part still holds.
 
 ## A fast self-check
 

--- a/.claude/skills/new-spec/SKILL.md
+++ b/.claude/skills/new-spec/SKILL.md
@@ -141,6 +141,16 @@ look like?" before any code.
      dependency, no new module boundary) so the diff can't sprawl into
      hypothetical futures.
    - **No Acceptance Criteria.** Without a checklist, "done" is opinion.
+   - **Body narrates history or the future.** Write the spec in the
+     present tense, as if the feature already exists and always worked
+     this way — the *retcon* discipline. No "will be implemented", no
+     "previously X, now Y", no deprecation timelines, no version-stamped
+     history in the body. Mixed tenses make an agent reading the spec
+     guess wrong about what is current; a present-tense body reads as a
+     clean description of the contract as it stands. Decision history
+     lives in ADRs and the changelog, not the spec body — the plan
+     (`plan.md`) is the one exception, since it carries its own changelog
+     of how the approach evolved.
 
    While writing Testing Strategy, sanity-check that each TDD-mode AC is
    concrete enough to *stub* — see `work-loop`'s
@@ -256,8 +266,17 @@ look like?" before any code.
 
 7. Update `docs/specs/README.md` to add the feature to the active list.
 
-8. Remind the user: when implementation diverges from the spec, the spec is
-   wrong. Update the spec in the same PR.
+8. **Keep the spec the single source of truth — drift is a bug.** When
+   implementation diverges from the spec, the spec is wrong: update it in
+   the same PR. The failure mode this discipline prevents has a name —
+   **context poisoning**: an agent loads a stale, duplicated, or
+   self-contradicting doc and makes a confident, wrong decision from it,
+   because nothing in the document tells it which part is current. Two
+   habits are the defense, one for each way a doc poisons: **one canonical
+   home per fact** (the *Source of truth* map in `AGENTS.md`) stops a fact
+   from living in two places that can drift apart, and the **present-tense
+   retcon body** (the failure mode in step 4) stops a single document from
+   contradicting itself across tenses. Remind the user of both.
 
 ## Anti-patterns to refuse
 

--- a/.claude/skills/new-spec/assets/spec.md
+++ b/.claude/skills/new-spec/assets/spec.md
@@ -18,6 +18,13 @@ skill's light mode, only Objective + Acceptance Criteria + a short task list
 risk trigger (see the `work-loop` skill) escalates to full mode, where every
 section is filled. -->
 
+<!-- **Present tense, as-built.** Write every body section below as if the
+feature already exists and always worked this way — no "will be", no
+"previously X, now Y", no deprecation timelines, no version-stamped history.
+The body describes the current contract; decision history lives in ADRs and the
+changelog. This applies to the spec body only — `plan.md` keeps its own
+changelog of how the approach evolved. -->
+
 ## Objective
 
 <!--

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -30,6 +30,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   step from 8 to 9; the atlassian `jira-defect-flow` skill's references to it
   are updated to match (atlassian 0.1.4).
 
+- **Spec and guide authoring skills teach two doc-writing disciplines: retcon
+  writing and context poisoning (core 0.4.7, user-guide-diataxis 0.1.4).**
+  *Retcon writing* — `new-spec` and `new-guide` now instruct authors to write
+  spec/guide bodies in the present tense, as if the feature already exists and
+  always worked this way: no "will be implemented", no "previously X, now Y", no
+  deprecation timelines, no version-stamped history in the body (decision history
+  stays in ADRs and the changelog). The rule lands as a failure-mode bullet in
+  `new-spec` step 4, a guide-voice anti-pattern in `new-guide` step 4, a reminder
+  in the `new-spec` `spec.md` template, and a `clear-prose.md` checklist item;
+  `plan.md` is exempt, since it keeps its own changelog. *Context poisoning* —
+  `new-spec` now names the failure mode its single-source-of-truth / drift-is-a-bug
+  discipline prevents (an agent loading a stale, duplicated, or self-contradicting
+  doc and deciding wrong from it) in one canonical place, tying the
+  one-canonical-home rule and the retcon body together as the two halves of the
+  defense.
+
 - **`work-loop` gains a "Scale with a tool, not turns" technique for large,
   repetitive tasks (core 0.4.5).** When a task spans many similar items —
   applying one change across N files, transforming a large set, auditing every

--- a/docs/specs/retcon-doc-discipline/spec.md
+++ b/docs/specs/retcon-doc-discipline/spec.md
@@ -1,0 +1,76 @@
+# Spec: retcon + context-poisoning doc-writing disciplines
+
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Plan:** inline (light mode — no separate plan.md)
+
+Mode: light (no risk trigger fired — additive drafting guidance to two skills'
+prose; no structural, interface-contract, security, or dependency change).
+
+## Objective
+
+Two related doc-writing disciplines are taught by our spec/guide authoring
+skills so that an agent reading a spec or guide can trust the document as a
+description of what is true *now*:
+
+- **(a) Retcon writing.** `new-spec` and `new-guide` instruct authors to write
+  spec/guide bodies in the present tense, as if the feature already exists and
+  always worked this way — no future-tense ("will be implemented"), no
+  "previously X, now Y" history, no deprecation timelines, no version-stamped
+  history in the body. Decision history still lives in ADRs and the changelog;
+  this is about the body being a clean present-tense description. The plan
+  (`plan.md`) is exempt — it is an explicitly living strategy doc with its own
+  changelog.
+- **(b) Context poisoning.** `new-spec` names the failure mode that the
+  single-source-of-truth / drift-is-a-bug discipline prevents: an agent that
+  loads a stale, duplicated, or self-contradicting doc makes a confident, wrong
+  decision from it. The concept is defined in exactly one canonical place.
+
+## Acceptance Criteria
+
+- [x] `new-spec` SKILL.md teaches retcon writing as drafting guidance: present
+      tense, as-built, with the four named bans (future tense, previously-X-now-Y,
+      deprecation timelines, version-stamped history) and the rationale (mixed
+      tenses make a reading agent guess wrong about what's current; history lives
+      in ADRs/changelog).
+- [x] `new-spec`'s bundled `assets/spec.md` template carries a concise
+      present-tense reminder scoped to the spec body; `plan.md` is left unchanged
+      (it keeps its changelog and is exempt).
+- [x] `new-guide` SKILL.md teaches the same retcon discipline in guide-flavored
+      terms, and the shared `references/clear-prose.md` checklist gains a
+      matching "don't narrate product history" item.
+- [x] `new-spec` names **context poisoning** as a short named concept in exactly
+      one canonical place — its drift-is-a-bug / one-canonical-home rationale —
+      and links the two halves of the defense (one-canonical-home + retcon)
+      rather than restating either.
+- [x] No new glossary file is created; the concept is not restated in three
+      places.
+- [x] `packs/core` bumped to 0.4.7 (pack.toml + plugin.json);
+      `packs/user-guide-diataxis` bumped 0.1.3 → 0.1.4 (pack.toml + plugin.json);
+      changelog `[Unreleased]` gains an entry.
+- [x] `make build-self` + `make build` run clean; `git status` clean; gates +
+      `tools/lint-agent-artifacts.py` pass; adversarial-reviewer returns clean.
+
+## Tasks
+
+1. Edit `new-spec` SKILL.md — add retcon failure-mode bullet (step 4) + expand
+   step 8 with the context-poisoning named concept tying to retcon + the
+   AGENTS.md source-of-truth map.
+2. Edit `new-spec` `assets/spec.md` template — add present-tense body reminder.
+3. Edit `new-guide` SKILL.md (step 4 voice anti-patterns) + `clear-prose.md`.
+4. Bump versions (both packs) + changelog entry.
+5. Build (`build-self` + `build`), verify gates + lint-agent-artifacts + clean
+   tree, adversarial pass.
+
+## Declined-pattern register
+
+- Tempted to create a new `docs/guides/reference/glossary.md` for context
+  poisoning; declining — no glossary exists, guides are by-pack, core ships
+  self-contained, and a core→glossary link would dangle for core-only adopters.
+  The canonical home is `new-spec`'s rationale inline.
+- Tempted to add the retcon reminder to all four guide templates; declining —
+  it is a cross-quadrant prose rule, so it lives once in `clear-prose.md`
+  (the shared prose reference every quadrant reads) + the `new-guide` SKILL,
+  not duplicated four times.
+- Tempted to add retcon to `plan.md`; declining — the plan is a living doc with
+  its own changelog, so present-tense-as-built does not apply to it.

--- a/packs/core/.apm/skills/new-spec/SKILL.md
+++ b/packs/core/.apm/skills/new-spec/SKILL.md
@@ -141,6 +141,16 @@ look like?" before any code.
      dependency, no new module boundary) so the diff can't sprawl into
      hypothetical futures.
    - **No Acceptance Criteria.** Without a checklist, "done" is opinion.
+   - **Body narrates history or the future.** Write the spec in the
+     present tense, as if the feature already exists and always worked
+     this way — the *retcon* discipline. No "will be implemented", no
+     "previously X, now Y", no deprecation timelines, no version-stamped
+     history in the body. Mixed tenses make an agent reading the spec
+     guess wrong about what is current; a present-tense body reads as a
+     clean description of the contract as it stands. Decision history
+     lives in ADRs and the changelog, not the spec body — the plan
+     (`plan.md`) is the one exception, since it carries its own changelog
+     of how the approach evolved.
 
    While writing Testing Strategy, sanity-check that each TDD-mode AC is
    concrete enough to *stub* — see `work-loop`'s
@@ -256,8 +266,17 @@ look like?" before any code.
 
 7. Update `docs/specs/README.md` to add the feature to the active list.
 
-8. Remind the user: when implementation diverges from the spec, the spec is
-   wrong. Update the spec in the same PR.
+8. **Keep the spec the single source of truth — drift is a bug.** When
+   implementation diverges from the spec, the spec is wrong: update it in
+   the same PR. The failure mode this discipline prevents has a name —
+   **context poisoning**: an agent loads a stale, duplicated, or
+   self-contradicting doc and makes a confident, wrong decision from it,
+   because nothing in the document tells it which part is current. Two
+   habits are the defense, one for each way a doc poisons: **one canonical
+   home per fact** (the *Source of truth* map in `AGENTS.md`) stops a fact
+   from living in two places that can drift apart, and the **present-tense
+   retcon body** (the failure mode in step 4) stops a single document from
+   contradicting itself across tenses. Remind the user of both.
 
 ## Anti-patterns to refuse
 

--- a/packs/core/.apm/skills/new-spec/assets/spec.md
+++ b/packs/core/.apm/skills/new-spec/assets/spec.md
@@ -18,6 +18,13 @@ skill's light mode, only Objective + Acceptance Criteria + a short task list
 risk trigger (see the `work-loop` skill) escalates to full mode, where every
 section is filled. -->
 
+<!-- **Present tense, as-built.** Write every body section below as if the
+feature already exists and always worked this way — no "will be", no
+"previously X, now Y", no deprecation timelines, no version-stamped history.
+The body describes the current contract; decision history lives in ADRs and the
+changelog. This applies to the spec body only — `plan.md` keeps its own
+changelog of how the approach evolved. -->
+
 ## Objective
 
 <!--

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr + session-start hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "0.4.6"
+version = "0.4.7"
 description = "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr + session-start hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 readme = "README.md"
 display_name = "Core"

--- a/packs/user-guide-diataxis/.apm/skills/new-guide/SKILL.md
+++ b/packs/user-guide-diataxis/.apm/skills/new-guide/SKILL.md
@@ -158,6 +158,13 @@ If any check fails, push back rather than proceeding.
    - **Don't soften imperatives.** Drop *please* in instructions ("please
      click", "please run") — it makes commands sound optional. Just
      write the imperative.
+   - **Don't narrate the product's history.** Write as if the product
+     always worked this way — the *retcon* discipline. Drop "will be
+     added", "previously X, now Y", "deprecated in 2.0", and
+     version-stamped history from the guide body. A guide is a living doc
+     describing current behavior; the reader wants what is true now, not a
+     changelog. Evolution belongs in release notes, the changelog, or an
+     ADR — link to it instead of narrating it inline.
 
    Efficiency is a form of respect — the reader is in a hurry.
 

--- a/packs/user-guide-diataxis/.apm/skills/new-guide/references/clear-prose.md
+++ b/packs/user-guide-diataxis/.apm/skills/new-guide/references/clear-prose.md
@@ -51,6 +51,11 @@ search for once you know its shape.
   earns space, give it its own sentence or link to an explanation page.
 - **Don't narrate your intent.** "Here we want to show you…", "the goal of this
   section is…". Drop the meta-commentary and show the reader directly.
+- **Don't narrate the product's history.** Describe how it works now, not how it
+  used to — the *retcon* discipline. "Previously X, now Y", "will be added next
+  release", "deprecated in 2.0" belong in release notes or the changelog, not the
+  body. The reader wants what's true today; mixed tenses make them guess which
+  part still holds.
 
 ## A fast self-check
 

--- a/packs/user-guide-diataxis/.claude-plugin/plugin.json
+++ b/packs/user-guide-diataxis/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "user-guide-diataxis",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Di\u00e1taxis-shaped user-guide skeleton: guides/ + tutorials/how-to/reference/explanation seed READMEs, new-guide skill."
 }

--- a/packs/user-guide-diataxis/pack.toml
+++ b/packs/user-guide-diataxis/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "user-guide-diataxis"
-version = "0.1.3"
+version = "0.1.4"
 description = "Di\u00e1taxis-shaped user-guide skeleton: guides/ + tutorials/how-to/reference/explanation seed READMEs, new-guide skill."
 readme = "README.md"
 display_name = "User Guide (Diátaxis)"


### PR DESCRIPTION
## What

Teaches two related doc-writing disciplines in the spec/guide authoring skills, so an agent reading a spec or guide can trust it as a description of what is true *now*.

**(a) Retcon writing.** `new-spec` and `new-guide` instruct authors to write spec/guide bodies in the present tense, as if the feature already exists and always worked this way — no "will be implemented", no "previously X, now Y", no deprecation timelines, no version-stamped history in the body. Decision history stays in ADRs and the changelog.
- `new-spec` SKILL.md — failure-mode bullet in step 4 (four bans + rationale; `plan.md`-is-exempt carve-out).
- `new-spec` `assets/spec.md` — present-tense reminder scoped to the spec body.
- `new-guide` SKILL.md — third voice anti-pattern in step 4.
- `new-guide` `references/clear-prose.md` — matching checklist item (the shared cross-quadrant prose home).

**(b) Context poisoning.** `new-spec` step 8 names the failure mode its single-source-of-truth / drift-is-a-bug discipline prevents — an agent loading a stale, duplicated, or self-contradicting doc and deciding wrong from it — in **one canonical place**, tying the one-canonical-home rule (the AGENTS.md *Source of truth* map, which ships in core's seed) and the present-tense retcon body together as the two halves of the defense.

## Decisions (declined paths)

- **No new `docs/guides/reference/glossary.md`** — none exists, guides here are by-pack, core ships self-contained, and a core→glossary link would dangle for core-only adopters. The canonical home is `new-spec`'s rationale inline.
- **Retcon lives once in `clear-prose.md` + each SKILL**, not duplicated across the four guide templates.
- **`plan.md` left untouched** — it is a living strategy doc with its own changelog, so present-tense-as-built doesn't apply to it.

## Versions + changelog

core `0.4.5 → 0.4.6`, user-guide-diataxis `0.1.3 → 0.1.4` (pack.toml + plugin.json + marketplace.json); `[Unreleased]` changelog entry added.

## Verification

- `make build-self` + `make build` clean; `make build-check` green (lint-packs, build, pre-pr, pip-audit, semgrep).
- `tools/lint-agent-artifacts.py` passed; `lint-spec-status.py` clean.
- Adversarial-reviewer pass clean; spec marked Shipped with ACs checked in this PR.

Spec: `docs/specs/retcon-doc-discipline/spec.md`