### PR TITLE
feat(quality-engineer): mock-return tautology + permission/resource edge cases (core 0.4.8)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -86,7 +86,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "core",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.4.7"
+      "version": "0.4.8"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/.claude/agents/quality-engineer.md
+++ b/.claude/agents/quality-engineer.md
@@ -108,8 +108,14 @@ holds).
    change in lockstep with production code; they are mirrors, not
    contracts. Replace with assertions on observable post-conditions.
 3. **Tautological tests.** Where the test math equals the production
-   math (`expect(add(2,3)).toBe(2+3)`). Flag and propose a fixture
-   table instead.
+   math (`expect(add(2,3)).toBe(2+3)`), or where the code under test
+   returns a collaborator's value unchanged and the test asserts on the
+   mock's own configured return value (`mock.fetch.return_value = X` then
+   `assert result == X`) — the assertion mirrors the mock setup and can
+   never fail, so it pins nothing. (A test asserting on a *transform* of
+   the mocked value is not this — there the assertion can still fail.)
+   Flag and propose a fixture table, or an assertion on a real
+   post-condition, instead.
 4. **DAMP over DRY in tests.** Tests should read like a specification,
    even at the cost of some duplication — a clever helper that hides
    setup is the wrong kind of reuse when it obscures what the test is
@@ -128,7 +134,8 @@ holds).
    Recommend deleting and pointing at the one-liner instead.
 7. **Edge-case coverage.** Empty input, max input, malformed input,
    zero / negative / NaN where numeric, concurrent access, partial
-   failure. Cite the specific cases tested and the specific cases
+   failure, permission-denied, resource-exhausted. Cite the specific cases
+   tested and the specific cases
    that aren't. When the surface is invariant-shaped — parser,
    deserializer, schema/protocol boundary, prompt template, or
    tool-input handler with a "parses-or-rejects, no crash, no

--- a/.codex/agents/quality-engineer.toml
+++ b/.codex/agents/quality-engineer.toml
@@ -109,8 +109,14 @@ holds).
    change in lockstep with production code; they are mirrors, not
    contracts. Replace with assertions on observable post-conditions.
 3. **Tautological tests.** Where the test math equals the production
-   math (`expect(add(2,3)).toBe(2+3)`). Flag and propose a fixture
-   table instead.
+   math (`expect(add(2,3)).toBe(2+3)`), or where the code under test
+   returns a collaborator's value unchanged and the test asserts on the
+   mock's own configured return value (`mock.fetch.return_value = X` then
+   `assert result == X`) — the assertion mirrors the mock setup and can
+   never fail, so it pins nothing. (A test asserting on a *transform* of
+   the mocked value is not this — there the assertion can still fail.)
+   Flag and propose a fixture table, or an assertion on a real
+   post-condition, instead.
 4. **DAMP over DRY in tests.** Tests should read like a specification,
    even at the cost of some duplication — a clever helper that hides
    setup is the wrong kind of reuse when it obscures what the test is
@@ -129,7 +135,8 @@ holds).
    Recommend deleting and pointing at the one-liner instead.
 7. **Edge-case coverage.** Empty input, max input, malformed input,
    zero / negative / NaN where numeric, concurrent access, partial
-   failure. Cite the specific cases tested and the specific cases
+   failure, permission-denied, resource-exhausted. Cite the specific cases
+   tested and the specific cases
    that aren't. When the surface is invariant-shaped — parser,
    deserializer, schema/protocol boundary, prompt template, or
    tool-input handler with a \"parses-or-rejects, no crash, no

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`quality-engineer` catches two more test/edge-case shapes (core 0.4.8).**
+  The tautological-tests finding now also flags a test that asserts on the
+  mock's own configured return value (it can never fail, so it pins nothing),
+  and the edge-case enumeration adds `permission-denied` and
+  `resource-exhausted` to the cases the reviewer checks for.
+
 - **The `bug-fix` skill gains two debugging-discipline moves (core 0.4.6).**
   A new "list candidate causes, then falsify each" step sits between
   reproduction and the root-cause assertion — name 2-3 rival causes and rule

--- a/packs/core/.apm/agents/quality-engineer.md
+++ b/packs/core/.apm/agents/quality-engineer.md
@@ -108,8 +108,14 @@ holds).
    change in lockstep with production code; they are mirrors, not
    contracts. Replace with assertions on observable post-conditions.
 3. **Tautological tests.** Where the test math equals the production
-   math (`expect(add(2,3)).toBe(2+3)`). Flag and propose a fixture
-   table instead.
+   math (`expect(add(2,3)).toBe(2+3)`), or where the code under test
+   returns a collaborator's value unchanged and the test asserts on the
+   mock's own configured return value (`mock.fetch.return_value = X` then
+   `assert result == X`) — the assertion mirrors the mock setup and can
+   never fail, so it pins nothing. (A test asserting on a *transform* of
+   the mocked value is not this — there the assertion can still fail.)
+   Flag and propose a fixture table, or an assertion on a real
+   post-condition, instead.
 4. **DAMP over DRY in tests.** Tests should read like a specification,
    even at the cost of some duplication — a clever helper that hides
    setup is the wrong kind of reuse when it obscures what the test is
@@ -128,7 +134,8 @@ holds).
    Recommend deleting and pointing at the one-liner instead.
 7. **Edge-case coverage.** Empty input, max input, malformed input,
    zero / negative / NaN where numeric, concurrent access, partial
-   failure. Cite the specific cases tested and the specific cases
+   failure, permission-denied, resource-exhausted. Cite the specific cases
+   tested and the specific cases
    that aren't. When the surface is invariant-shaped — parser,
    deserializer, schema/protocol boundary, prompt template, or
    tool-input handler with a "parses-or-rejects, no crash, no

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr + session-start hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "0.4.7"
+version = "0.4.8"
 description = "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr + session-start hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 readme = "README.md"
 display_name = "Core"


### PR DESCRIPTION
## What

Two surgical additions to the `quality-engineer` reviewer agent, integrated into existing findings rather than new sections.

1. **Mock-return tautology** — folded into the existing tautological-tests finding (#3). A test that asserts on the mock's own configured return value, where the code under test returns that value unchanged, mirrors the mock setup and can never fail. A pass-through condition and an explicit carve-out are spelled out so a transform-asserting test (which *can* fail) is not flagged.

2. **Edge-case categories** — `permission-denied` and `resource-exhausted` added to the existing edge-case enumeration (#7).

## Why

These are two recurring quality-review blind spots the agent didn't name. Both are integrated surgically — no new sections, no coverage-% targets or testing-pyramid ratios (those conflict with the repo's mutation-mindset doctrine).

## Not duplicative

- The mock-return clause is distinct from finding #2 (mock *call*-shape — `toHaveBeenCalledWith`/call counts).
- The new edge cases don't overlap the reliability section (#15/#19, about what the caller sees and how the SUT degrades, not which test inputs to enumerate).

## Mechanics

- Edited the source `packs/core/.apm/agents/quality-engineer.md`; projections regenerated via `make build-self`.
- Bumps `core` 0.4.7 → 0.4.8 (`pack.toml` + `plugin.json`; `marketplace.json` follows). Rebased onto main, resolving a co-bump version collision (main had advanced core to 0.4.7).
- Changelog `[Unreleased]` entry added.

## Verification

- `make build-check` — green (exit 0).
- `tools/lint-agent-artifacts.py` — green.
- Clean git status after build-self; projections (`.claude/agents/`, `.codex/agents/`) in sync.
- adversarial-reviewer: **Clean — ready to commit** (one Concern on overstated "can never fail" wording addressed before commit).