### PR TITLE
feat(architect): add measure-before-optimize discipline to NFR lens (architect 0.5.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "architect",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.5.1"
+      "version": "0.5.2"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -25,6 +25,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and the edge-case enumeration adds `permission-denied` and
   `resource-exhausted` to the cases the reviewer checks for.
 
+- **The `architect-design` NFR lens gains a performance-budget optimization
+  discipline (architect 0.5.2).** The "Performance and scale" checklist now
+  asks for a performance budget committed up front (a latency, throughput, or
+  resource target stated as a testable claim), and adds an "earn each
+  optimization against the budget" prompt: measure before optimizing (no
+  optimizing an unmeasured hotspot), spend effort on the hotspot where most of
+  the cost sits, and weigh each optimization's ongoing complexity cost against
+  the gain it actually buys. Framework- and stack-agnostic — no profiler or
+  tool names. The optimization discipline was previously absent; budget-setting
+  itself stays cross-linked to the existing quality-attribute-scenarios
+  guidance rather than restated.
+
 - **The `bug-fix` skill gains two debugging-discipline moves (core 0.4.6).**
   A new "list candidate causes, then falsify each" step sits between
   reproduction and the root-cause assertion — name 2-3 rival causes and rule

--- a/packs/architect/.apm/skills/architect-design/references/nfr-checklist.md
+++ b/packs/architect/.apm/skills/architect-design/references/nfr-checklist.md
@@ -15,6 +15,26 @@ not.
 - What's the failure-budget shape? (SLO if one exists; otherwise
   what counts as "down" to a user.)
 - What changes at 10× volume? At 100×?
+- Is there a performance budget committed up front — a latency,
+  throughput, or resource target the design must meet? "Fast enough"
+  left undefined can be neither met nor missed. State it as a testable
+  claim (`quality-attribute-scenarios.md`).
+
+### Optimizing — earn each optimization against the budget
+
+When the proposal trades simplicity for speed, the reasoning is owed,
+not just the mechanism:
+
+- **Measure before optimizing.** Name the evidence the bottleneck is
+  real and where it sits — not a guess. Optimizing an unmeasured hotspot
+  ships complexity for no proven gain.
+- **Spend on the hotspot.** Most of the cost usually sits in a small
+  fraction of the system. Optimize that fraction; leave the rest simple.
+  Effort off the bottleneck buys nothing.
+- **Weigh complexity against gain.** Every optimization carries an
+  ongoing cost — harder to read, change, and operate. Name the gain, and
+  whether it clears that cost against the budget. One that doesn't move
+  the budget isn't worth its complexity.
 
 ## Availability and reliability
 

--- a/packs/architect/.claude-plugin/plugin.json
+++ b/packs/architect/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "architect",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Solution-architecture skills (architect-design, architect-diagram, architect-review). Workspace-agnostic, user-scope by default, no required configuration."
 }

--- a/packs/architect/pack.toml
+++ b/packs/architect/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "architect"
-version = "0.5.1"
+version = "0.5.2"
 description = "Solution-architecture skills (architect-design, architect-diagram, architect-review). Workspace-agnostic, user-scope by default, no required configuration. Mermaid for diagrams; Google-style design docs; rubric-routed critique."
 readme = "README.md"
 display_name = "Architect"


### PR DESCRIPTION
## What

Adds the missing **optimization discipline** to the `architect-design` NFR lens (`nfr-checklist.md`, "Performance and scale" section):

- **Commit a performance budget up front** — a latency, throughput, or resource target stated as a testable claim (cross-links `quality-attribute-scenarios.md` for the testable-claim mechanics rather than restating it).
- **Measure before optimizing** — name the evidence the bottleneck is real; don't optimize an unmeasured hotspot.
- **Spend on the hotspot** — most cost sits in a small fraction; optimize that, leave the rest simple.
- **Weigh complexity against gain** — every optimization carries an ongoing carrying cost; an optimization that doesn't move the budget isn't worth it.

Framework- and stack-agnostic — **no profiler or tool names** (cProfile, py-spy, EXPLAIN, etc. are stack picks and fail the universality bar).

## Audit first (why this, scoped this way)

The brief was to audit before adding. Budget-*setting* was already partially present — `nfr-checklist` (tail-latency tolerance, failure-budget shape), `well-architected-pillars` (latency budget p50/p99), and `quality-attribute-scenarios` (response-measure as a number). What was **genuinely absent** was the optimization *discipline*: measure-before-optimize, hotspot/80-20, and complexity-vs-gain of an individual optimization (the tradeoffs reference covers only *pillar-vs-pillar* tradeoffs). So the addition is scoped to the missing half and cross-links the existing budget material to stay non-duplicative.

Pressure-tested against the four charter bars: **universal** ✓ · **non-duplicative** ✓ · **habit-not-infra** ✓ · **used-often** ✓. Reference edit only — **skill, not agent**; no new skill file.

## Scope note (deliberate)

Kept design-side only. `architect-review` already carries the WA "Performance" pillar check; I did not add a symmetric "did the design measure before proposing an optimization?" reviewer check, to keep the diff minimal and non-duplicative. Easy follow-on if wanted.

## Mechanics

- Bumped `packs/architect/pack.toml` + `.claude-plugin/plugin.json` to **0.5.2**; `make build-self` refreshed the top-level `.claude-plugin/marketplace.json` (architect is user-scope-default — not projected in the working tree, but its version aggregates into marketplace.json).
- `docs/product/changelog.md` `[Unreleased]` entry added.
- Gates green: `lint-packs`, `validate`, `tools/lint-agent-artifacts.py`, zero self-host drift.
- adversarial-reviewer pass: **Clean — ready to commit.**