### PR TITLE
feat(architect): add deliberate visual-encoding heuristics to architect-diagram (architect 0.5.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "architect",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.5.2"
+      "version": "0.5.3"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -19,6 +19,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`architect-diagram` learns deliberate visual encoding (architect 0.5.3).**
+  A new `references/visual-encoding.md` turns scattered correctness rules into
+  one design heuristic: when a diagram distinguishes more than one category of
+  thing or relationship, map each visual channel (shape, grouping, position,
+  edge style, marker) to meaning *by the data type it carries*, rather than
+  decorating arbitrarily. It names which channels are robust across enterprise
+  wiki renderers versus fragile (colour, opacity) — colour is reinforcement,
+  never the sole carrier — and notes honestly that Mermaid can't size nodes, so
+  magnitude goes in a label. Mermaid-only; no rendering-library code. The draft
+  step in the skill now loads it when a diagram carries more than one
+  dimension.
+
 - **`quality-engineer` catches two more test/edge-case shapes (core 0.4.8).**
   The tautological-tests finding now also flags a test that asserts on the
   mock's own configured return value (it can never fail, so it pins nothing),

--- a/packs/architect/.apm/skills/architect-diagram/SKILL.md
+++ b/packs/architect/.apm/skills/architect-diagram/SKILL.md
@@ -84,7 +84,11 @@ If two modes plausibly fit, ask once which the user wants.
    newer `architecture-beta` syntax as an alternative — load
    `references/mermaid-architecture-beta.md` for the trade-offs and
    skeleton before offering. Do not default to it; rendering is
-   inconsistent across enterprise wikis.
+   inconsistent across enterprise wikis. **When the diagram
+   distinguishes more than one category of thing or relationship, load
+   `references/visual-encoding.md`** — map each visual channel (shape,
+   grouping, position, edge style, marker) to meaning by data type, and
+   keep colour as reinforcement only, never the sole carrier.
 
 7. **Self-check against `references/diagram-rubric.md`.** Fix
    violations before showing the user. The non-negotiables: every

--- a/packs/architect/.apm/skills/architect-diagram/references/visual-encoding.md
+++ b/packs/architect/.apm/skills/architect-diagram/references/visual-encoding.md
@@ -1,0 +1,70 @@
+# Visual encoding — map channels to meaning, don't decorate
+
+When a diagram distinguishes *kinds* of things or *kinds* of
+relationships, every visual difference the reader sees is a claim. Pick
+each channel deliberately — by what the data **is** — so the picture
+reads at a glance. The opposite failure is decoration: colour and shape
+that vary for no reason, which the reader still tries to decode and
+can't.
+
+This is the *encoding* lens. It rides on top of the shape and edge
+tables in `references/mermaid-flowchart.md` and the consistency checks
+in `references/diagram-rubric.md` — it doesn't restate them. Use it
+whenever a diagram carries more than one category or dimension.
+
+## The channels Mermaid actually gives you
+
+Author-controllable and **robust** across enterprise wiki renderers
+(GitHub, Confluence, Azure DevOps Wiki, GitLab):
+
+| Channel | How | Best for |
+| --- | --- | --- |
+| **Position / direction** | `TB` vs `LR`, ordering | flow, layering, before/after |
+| **Containment / grouping** | nested `subgraph` | boundaries, ownership, zones |
+| **Shape** | node-shape table | the *category* of a thing |
+| **Edge style** | `-->`, `-.->`, `--o`, `--x`, `===` | the *kind* of relationship |
+| **Text marker / label** | emoji or word on the label | a flag (public/private), a value |
+
+Author-controllable but **fragile** — renders inconsistently, so never
+the *sole* carrier of meaning:
+
+| Channel | Why fragile |
+| --- | --- |
+| **Colour** (`classDef` fill/stroke) | theming varies per renderer and breaks in grayscale / for colour-blind readers |
+| **Opacity** | poorly or not supported across wiki Mermaid |
+
+Not author-controllable in Mermaid: **size**. Node size is derived from
+label length, not set by you — so "bigger = more important" isn't an
+encoding you can make. Put the magnitude in the **label** ("12 nodes",
+"P0") instead.
+
+## Choose the channel by data type
+
+| The data is… | Encode with | Not with |
+| --- | --- | --- |
+| **Categorical** — kind of component (service / queue / store / external) | shape, and/or grouping | colour alone |
+| **Hierarchical / containment** — zones, accounts, layers | nested subgraphs, position | colour alone |
+| **Ordinal / sequential** — request order, lifecycle stage | position / direction | shape |
+| **Relationship type** — sync / async / read-only / failure | edge style | colour alone |
+| **Boolean flag** — public/private, internal/external | text or emoji marker | colour alone |
+| **Quantitative** — load, criticality, count | a **label** (Mermaid can't size nodes) | size, opacity |
+
+## Rules
+
+- **One channel, one meaning.** Don't make colour mean both "team that
+  owns it" and "how critical it is." If you have two dimensions, spend
+  two channels.
+- **Reserve a channel; don't spend it on nothing.** A channel that
+  carries no meaning stays at default. Varied-for-variety's-sake shape
+  or colour is noise the reader still has to rule out. (This is the
+  *why* behind the rubric's "pick one shape per category" check.)
+- **Colour is reinforcement, never the carrier.** Encode the meaning in
+  a robust channel first (shape, marker, grouping); add colour only to
+  *restate* it. The diagram must read correctly in grayscale.
+- **Name the encoding.** If a reader can't infer what a shape, marker,
+  or colour means from context, add a one-line legend (a `%% comment`
+  or a note line). An unlabelled encoding is a puzzle.
+
+These extend, not replace, the "Styling — use sparingly" guidance in
+`references/mermaid-flowchart.md`: encode meaning deliberately, and keep
+everything that *isn't* meaning at the default.

--- a/packs/architect/.claude-plugin/plugin.json
+++ b/packs/architect/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "architect",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Solution-architecture skills (architect-design, architect-diagram, architect-review). Workspace-agnostic, user-scope by default, no required configuration."
 }

--- a/packs/architect/pack.toml
+++ b/packs/architect/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "architect"
-version = "0.5.2"
+version = "0.5.3"
 description = "Solution-architecture skills (architect-design, architect-diagram, architect-review). Workspace-agnostic, user-scope by default, no required configuration. Mermaid for diagrams; Google-style design docs; rubric-routed critique."
 readme = "README.md"
 display_name = "Architect"


### PR DESCRIPTION
## What

Adds deliberate **visual-encoding** guidance to the `architect-diagram` skill: when a diagram encodes data or relationships, map each visual channel to semantic meaning chosen *by data type* rather than decorating arbitrarily.

- **New `references/visual-encoding.md`** — a channel→meaning heuristic. Inventories which channels are **robust** across enterprise wiki renderers (shape, grouping, position, edge style, marker) versus **fragile** (colour, opacity), with the load-bearing rule that *colour is reinforcement, never the sole carrier* (grayscale / colour-blind). Notes honestly that Mermaid can't size nodes, so magnitude goes in a label. A data-type → channel table picks the encoding deliberately (categorical → shape/grouping, ordinal → position, relationship type → edge style, etc.).
- **SKILL.md** draft step now loads it when a diagram carries more than one dimension.
- Cross-links the existing shape/edge tables and rubric rather than restating them; reinforces (does not contradict) the existing "Styling — use sparingly" stance.

## Why

Audit first: `architect-diagram` already has notation-routing, a diagram-rubric, and knowledge-surfaces. Those cover *which notation* and *correctness of distinctions* — but there was no deliberate "map visual channel → meaning, choose by data type" heuristic. Genuine, narrow gap; passes all four charter bars (universal data-viz principle, substantive vs. the scattered correctness rules, a habit not a tool, reached for on any multi-dimensional diagram). Resolution is a small reference addition, not a new skill or agent.

## Scope guardrails

- **Mermaid-only** — no D3/pyvis/sigma or rendering-library code (would be framework lock-in and fail the universality bar).
- No rubric edit: `diagram-rubric.md` is deliberately duplicated into `architect-review`, so a rubric bullet would incur a cross-pack sync burden. The Procedure load-step gives sufficient discoverability.

## Verification

- `make build-check` (drift + lint gates) — green. SAST is markdown-only/irrelevant here; CI runs it anyway.
- `tools/lint-agent-artifacts.py` — passed.
- adversarial-reviewer — content clean (no duplication, no contradiction, Mermaid facts accurate, no lock-in).
- Rebased onto `main` after #314 merged; bumped architect **0.5.2 → 0.5.3** to clear the co-bump collision (#314 took 0.5.2 for the architect-design performance-budget work). marketplace.json regenerated via `make build-self`.