### PR TITLE
feat(product-engineering): add voice-and-microcopy content skill (product-engineering 0.4.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -157,7 +157,7 @@
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",
       "category": "product-management",
-      "description": "Shape product intent into shippable specs. Habits \u2014 frame-intent, de-risk-intent, decompose-intent \u2014 over a recursive, level-tagged `intent` (a capability intent and a feature intent are the same artifact at different levels). Outcome+opportunity framing, a choosable prototype-approach to de-risk the riskiest assumption, and decomposition into the briefs/specs your delivery loop already builds \u2014 at app scale, or sliced per component across a business-unit value stream coordinated by `align-value-stream`. Pure-markdown, user-scope.",
+      "description": "Shape product intent into shippable specs \u2014 and into the words users read. Habits \u2014 frame-intent, de-risk-intent, decompose-intent \u2014 over a recursive, level-tagged `intent` (a capability intent and a feature intent are the same artifact at different levels): outcome+opportunity framing, a choosable prototype-approach to de-risk the riskiest assumption, and decomposition into the briefs/specs your delivery loop already builds \u2014 at app scale, or sliced per component across a business-unit value stream coordinated by `align-value-stream`. `voice-and-microcopy` adds the content layer: characterize a product's voice and write blame-free, actionable UI copy. Pure-markdown, user-scope.",
       "displayName": "Product Engineering",
       "homepage": "https://github.com/eugenelim/agent-ready-repo",
       "keywords": [
@@ -169,7 +169,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "product-engineering",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.3.1"
+      "version": "0.4.0"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/docs/guides/product-engineering/README.md
+++ b/docs/guides/product-engineering/README.md
@@ -1,6 +1,6 @@
 # `product-engineering` — guides
 
-Shape product intent into work your delivery loop can build. The pack turns an idea, a request, or a strategy into a level-tagged `intent` — an outcome with a parent and children — and walks it down the tree: `frame-intent` to shape it, `de-risk-intent` to test the bet, `decompose-intent` to break it into the next level or a shippable slice, and `align-value-stream` to coordinate the work across many component repos. At the leaf, an intent becomes a brief or a spec and rejoins the normal build loop.
+Shape product intent into work your delivery loop can build. The pack turns an idea, a request, or a strategy into a level-tagged `intent` — an outcome with a parent and children — and walks it down the tree: `frame-intent` to shape it, `de-risk-intent` to test the bet, `decompose-intent` to break it into the next level or a shippable slice, and `align-value-stream` to coordinate the work across many component repos. At the leaf, an intent becomes a brief or a spec and rejoins the normal build loop. Once the feature is being built, `voice-and-microcopy` shapes the actual words users read — the product's voice and its error, empty, button, and label copy.
 
 New here? Start with [the intent tree](explanation/the-intent-tree.md) for the model, then [shape a feature intent](how-to/shape-a-feature-intent.md) in your own repo.
 
@@ -8,6 +8,7 @@ New here? Start with [the intent tree](explanation/the-intent-tree.md) for the m
 
 - [Shape a feature intent in an app repo](how-to/shape-a-feature-intent.md) — frame, de-risk, and decompose a single piece of work down to a spec.
 - [Run a capability across a value stream](how-to/run-a-capability-across-a-value-stream.md) — coordinate one capability across several component repos from a meta-repo.
+- [Write a product's voice and microcopy](how-to/write-product-microcopy.md) — characterize the product's voice, then write the error, empty, button, and label copy from blame-free formulas.
 
 ## Reference
 

--- a/docs/guides/product-engineering/how-to/write-product-microcopy.md
+++ b/docs/guides/product-engineering/how-to/write-product-microcopy.md
@@ -1,0 +1,55 @@
+# How to write a product's voice and microcopy
+
+> **Diátaxis: how-to.** A goal-oriented walk through the `voice-and-microcopy`
+> skill — characterizing a product's voice, then writing the recurring UI-state
+> copy. For shaping the *intent* behind a feature, see the how-to
+> [*Shape a feature intent*](shape-a-feature-intent.md); for the field tables, the
+> reference [*Intent fields and modes*](../reference/intent-fields-and-modes.md).
+
+You've shaped a feature down to a spec, and now it needs the actual words a user
+reads — the error when something fails, the empty state before there's data, the
+button that commits the action. Install the `product-engineering` pack, then:
+
+## 1. Characterize the product's voice — once
+
+Invoke **`voice-and-microcopy`**. The first time, it characterizes your product's
+**voice** along a few axes — humor, formality, respect, enthusiasm — and records
+it in a **voice chart** (the skill ships the template at
+`voice-and-microcopy/assets/voice-chart-template.md`; copy it to
+`docs/product/voice/<slug>.md`). Place the product on each axis with a one-line
+rationale and a real sample string. Do this once and **reuse the chart** across
+every feature — don't re-derive it per screen.
+
+The key distinction: **voice is constant, tone flexes by context.** The same
+product is warm in a success message and calm, plain, and blame-free in an error.
+The higher the user's stress, the closer the tone moves to plain — even for a
+playful product.
+
+## 2. Write each UI state from its formula
+
+For the copy in front of you, the skill applies the formula for that UI state:
+
+- **Error** — *what happened, plainly* + *what to do next*, blame-free. "That code
+  has expired — request a new one", never "You entered an invalid code".
+- **Empty state** — *orient* (what belongs here) + *invite the first action*. Never
+  a blank panel or a lone illustration.
+- **Button / CTA** — *verb + object* that names the goal. "Send invite", not
+  "Submit".
+- **Label** — concise, keyword front-loaded, one term per concept.
+
+Each formula ships with a before → after in
+`voice-and-microcopy/references/microcopy-formulas.md`.
+
+## 3. Run the content checklist before it ships
+
+Before the copy lands, the skill runs the **content checklist**
+(`voice-and-microcopy/references/content-checklist.md`): voice-consistent,
+blame-free, actionable, concise, terminology-consistent, scannable, inclusive. Run
+it deliberately on the strings that carry weight — errors, empty states, primary
+buttons, destructive confirmations — and fix the misses.
+
+---
+
+**Not documentation prose.** This skill shapes the words *inside the product*. For
+writing the *docs* about your product, the clear-prose craft lives in the
+`user-guide-diataxis` pack's `new-guide` skill — a different artifact and audience.

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -49,6 +49,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   itself stays cross-linked to the existing quality-attribute-scenarios
   guidance rather than restated.
 
+- **The `product-engineering` pack gains a content layer — `voice-and-microcopy`
+  (product-engineering 0.4.0).** A fifth pure-markdown skill that turns shaped
+  product intent into the **words a user reads** in the UI — the angle the pack's
+  intent-shaping habits (`frame-intent`, `de-risk-intent`, `decompose-intent`)
+  deliberately left open. The adopter characterizes their product's **voice**
+  along a few axes (humor / formality / respect / enthusiasm) and records it in a
+  travelling voice-chart template, writes the recurring UI states — **error,
+  empty, button, label** — from blame-free, actionable formulas (each with a
+  before/after), and runs a **content checklist** before copy ships. Voice is
+  constant, tone flexes by context (calm in errors, warm in success). Fully
+  framework-agnostic and habits-shaped — no engine, no schema, `SKILL.md` under
+  100 lines with depth in `references/`. Distinct from the
+  `house-voice-writing-craft` clear-prose rules, which shape *documentation*
+  prose, not product UI copy.
 - **The `bug-fix` skill gains two debugging-discipline moves (core 0.4.6).**
   A new "list candidate causes, then falsify each" step sits between
   reproduction and the root-cause assertion — name 2-3 rival causes and rule

--- a/docs/specs/voice-and-microcopy/plan.md
+++ b/docs/specs/voice-and-microcopy/plan.md
@@ -1,0 +1,118 @@
+# Plan: voice-and-microcopy
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Done <!-- Drafting | Executing | Done -->
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn.
+
+## Approach
+
+Add a fifth pure-markdown skill to the `product-engineering` pack, mirroring the
+existing skills' shape exactly: a lean `SKILL.md` (under 100 lines) that holds the
+procedure and routes depth into `references/`, plus a travelling `assets/`
+template. Three references carry the three deliverables (voice axes, microcopy
+formulas, content checklist) so `SKILL.md` stays a thin orchestration layer. The
+riskiest part is *staying inside the four charter bars* — keeping the content
+framework-agnostic and habits-shaped, not drifting into a style-guide CMS or
+tech-specific advice — and *not duplicating* the documentation-prose checklist
+`house-voice-writing-craft` already shipped (different artifact: product UI copy
+vs. docs prose). After the files land, the mechanical work is the version bump
+(two files), the changelog entry, the README skill-table row, the Diátaxis guide
+how-to + index entry, and refreshing the catalogue — `make build` re-aggregates
+`dist/`, and `make build-self FORCE=1` refreshes the committed root
+`.claude-plugin/marketplace.json` (a self-host projection).
+
+## Constraints
+
+- RFC-0030 / ADR-0019: the pack is **pure markdown, habits-shaped, user-scope**;
+  no adapter-specific primitives, no seeds, templates travel in skill `assets/`.
+- The `product-engineering-pack` v1 spec caps `SKILL.md` at **under 100 lines**
+  and anchors names to recognized vocabulary.
+- Edit `.apm/` sources only. The pack's skills are not projected into this repo's
+  `.claude/`; `make build` refreshes `dist/`, while the committed root
+  `.claude-plugin/marketplace.json` (all-packs aggregation) is refreshed by
+  `make build-self FORCE=1` — its only drift here is the version line.
+
+## Construction tests
+
+This is a docs/markdown addition; verification is goal-based + manual QA.
+
+**Integration tests:** none beyond the catalogue gates (`lint-packs`, `build`,
+`validate`, `lint-agent-artifacts.py`).
+**Manual verification:** read the skill + references against the Acceptance
+Criteria; `wc -l SKILL.md` < 100; `marketplace.json` shows the bumped version.
+
+## Tasks
+
+### T1: Author the `voice-and-microcopy` skill (SKILL.md + references + asset)
+
+**Depends on:** none
+
+**Tests:**
+- `SKILL.md` has valid frontmatter (`name: voice-and-microcopy`, a `description`
+  with trigger phrases + `Do NOT` cross-refs) — verified by `lint-packs`.
+- `wc -l SKILL.md` reports < 100.
+- `references/voice-axes.md`, `references/microcopy-formulas.md`,
+  `references/content-checklist.md`, and `assets/voice-chart-template.md` all exist.
+- Each of error / empty / button / label has a formula and a paired before/after
+  in `microcopy-formulas.md` (manual read).
+
+**Approach:**
+- Create `packs/product-engineering/.apm/skills/voice-and-microcopy/SKILL.md`
+  with a When-to-invoke gate, a 3-step procedure (characterize voice → write
+  microcopy with the state formula → run the content checklist), and an
+  anti-patterns section, matching the sibling skills' voice.
+- Write the three references and the voice-chart template asset.
+
+**Done when:** the five files exist, `SKILL.md` < 100 lines, and `lint-packs`
+passes on the pack.
+
+### T2: Wire the pack metadata + catalogue (version, README, changelog, guides)
+
+**Depends on:** T1
+
+**Tests:**
+- `pack.toml` `[pack] version` and `.claude-plugin/plugin.json` `version` match
+  and are bumped from `0.3.1`.
+- `marketplace.json` shows the bumped product-engineering version after `make build`.
+- `docs/product/changelog.md` `[Unreleased] → Added` names the new skill.
+- The pack `README.md` skill table includes a `voice-and-microcopy` row, and
+  `docs/guides/product-engineering/README.md` links a new how-to that exists.
+
+**Approach:**
+- Bump pack version to `0.4.0` (additive new skill) in `pack.toml` +
+  `plugin.json`; **update the `description`** in both (it enumerates the habit
+  skills, so it goes stale) to name the new content layer.
+- Add the README skill-table row + the Layout touch-ups as needed. **Bundled
+  fix:** the README "Design principles" line says "Skills + `references/` +
+  seeds" but the pack ships no `seeds/` — change "seeds" to "assets" (same-file,
+  same-concern ride-along).
+- Add the changelog entry.
+- Add `docs/guides/product-engineering/how-to/write-product-microcopy.md` and an
+  index row in the guides README.
+- Run `make build`; confirm clean `git status`.
+
+**Done when:** `make lint-packs build validate` and `tools/lint-agent-artifacts.py`
+all pass and `git status` is clean.
+
+## Rollout
+
+Pure-markdown skill addition — no infra, no migration, no flag. Ships when the PR
+merges; reversible by reverting the PR. The pack is user-scope, so adopters pick
+it up on their next `agentbundle install` / `claude plugin install` / `apm install`.
+
+## Risks
+
+- **Charter-bar drift** — the content could slide into tech-specific or
+  CMS-shaped territory. Mitigated by the `Never do` boundaries and the
+  pre-EXECUTE adversarial pass.
+- **Overlap with `house-voice-writing-craft`** — mitigated by scoping strictly to
+  product UI copy and cross-referencing, not restating, the docs-prose checklist.
+
+## Changelog
+
+- 2026-06-14: initial plan.
+- 2026-06-14: T1 + T2 complete; the committed root `.claude-plugin/marketplace.json`
+  required `make build-self FORCE=1` (not `make build`, which only refreshes
+  `dist/`) — spec ACs/assumptions corrected to match. Status → Done.

--- a/docs/specs/voice-and-microcopy/spec.md
+++ b/docs/specs/voice-and-microcopy/spec.md
@@ -1,0 +1,149 @@
+# Spec: voice-and-microcopy (product-engineering content layer)
+
+- **Status:** Shipped (2026-06-14) <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** RFC-0030 (product-engineering pack), ADR-0019
+- **Brief:** none
+- **Contract:** none <!-- a pure-markdown skill; exposes no machine interface, so new-spec step 4b is skipped -->
+- **Shape:** mixed
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+A product person running the `product-engineering` pack has framed, de-risked,
+and decomposed an intent down to a shippable feature — but the pack stops at the
+*structure* of the work and says nothing about the **words a user actually
+reads** in the UI. Today there is no home in the catalogue for shaping product
+intent into copy: `frame-intent` is deliberately solution-independent,
+`decompose-intent` cuts structure not content, and the `house-voice-writing-craft`
+work is about *documentation prose*, a different audience. This spec adds a fifth
+pure-markdown skill, **`voice-and-microcopy`**, that closes that gap: the adopter
+characterizes their product's **voice** along a few axes, writes the recurring
+UI-state microcopy (**error, empty, button, label**) from blame-free, actionable
+formulas, and runs a **content checklist** before copy ships. It is a *method*,
+not reference data — fully framework-agnostic, habits-shaped, and consistent with
+the pack's "never mandate a schema / SKILL.md under 100 lines / depth in
+references" design. Success: the adopter can ask "what should this error say?"
+or "characterize our product voice" and get a repeatable discipline that lands
+consistent, kind, actionable copy.
+
+## Boundaries
+
+The three-tier guard that keeps an implementing agent inside the lines.
+
+### Always do
+
+- Keep `SKILL.md` **under 100 lines**; push depth (the voice axes, the per-state
+  microcopy formulas, the content checklist) into `references/`, loaded on demand.
+- Keep the skill **pure markdown** and **habits-shaped**: `SKILL.md` +
+  `references/` + an `assets/` template only. No engine, hook, validator,
+  subagent, or seed.
+- Ship the voice-chart template in the skill's **`assets/`** (it travels with the
+  skill, like `frame-intent`'s `intent-template.md`), copied at runtime to
+  `docs/product/voice/<slug>.md` — so the pack stays user-scope and ships no `seeds/`.
+- Edit pack content at its **`.apm/` source** under
+  `packs/product-engineering/.apm/skills/voice-and-microcopy/`, never a projected
+  copy. `make build` re-aggregates `dist/`; the committed root
+  `.claude-plugin/marketplace.json` is a self-host projection, refreshed with
+  `make build-self FORCE=1` (the pack's skills are not projected to `.claude/`, so
+  the only resulting drift is the marketplace version line).
+- Bump the pack version in **both** `pack.toml` `[pack] version` **and**
+  `.claude-plugin/plugin.json`, and add an `[Unreleased]` changelog entry.
+- Add per-pack **Diátaxis guide coverage** for the new skill (a how-to + an index
+  entry in the guides README) under `docs/guides/product-engineering/`.
+- Frame the voice as **constant**, the tone as **context-flexed** — error copy is
+  calm even in a playful product.
+- Make every error and empty-state formula **blame-free and actionable** — name
+  what happened and the next action; never blame the user.
+- Where a content-checklist item overlaps `new-guide`'s `clear-prose.md` (e.g.
+  "concise / omit needless words"), **cross-reference it, don't restate it** —
+  this skill owns product UI copy, that one owns documentation prose.
+
+### Ask first
+
+- Adding a **sixth skill** or splitting this one — the pack grows one skill at a
+  time, each clearing the four charter bars.
+- Introducing any **adapter-specific primitive** (agent, hook, command) to the
+  pack — it is pure-markdown by design (RFC-0030).
+- Changing the behavior of an **existing** product-engineering skill (this spec
+  is additive).
+
+### Never do
+
+- Mandate the voice chart as a **schema** or block on a half-filled one — a
+  partial chart is normal input (the pack's never-mandate-a-schema rule).
+- Add **tech-specific** guidance (a CSS framework, a component library, a
+  specific i18n tool) — the method is framework-agnostic.
+- Duplicate the `house-voice-writing-craft` **documentation-prose** checklist —
+  this skill is about *product UI copy*, a different artifact and audience.
+- Write microcopy **examples that blame the user** or dead-end without a next
+  action, even as "before" samples without a paired "after".
+
+## Testing Strategy
+
+This is a pure-markdown skill addition; there is no runtime logic to unit-test.
+Verification is **goal-based**, exercised by the catalogue's existing gates:
+
+- **Lint / structure:** `make lint-packs` and `tools/lint-agent-artifacts.py`
+  validate frontmatter, description cap, and skill structure — goal-based check.
+- **Build / aggregation:** `make build` regenerates `marketplace.json` with the
+  bumped version — goal-based check (clean `git status`, version present).
+- **SKILL.md line budget:** `wc -l` under 100 — goal-based check.
+- **Content correctness** (axes present, four UI states covered, checklist
+  blame-free + actionable): manual QA against the Acceptance Criteria, confirmed
+  by the `adversarial-reviewer` pass.
+
+## Acceptance Criteria
+
+- [x] A new skill exists at
+  `packs/product-engineering/.apm/skills/voice-and-microcopy/SKILL.md` with valid
+  frontmatter (`name`, `description` with trigger phrases and `Do NOT` cross-refs
+  to the sibling skills), under 100 lines.
+- [x] `SKILL.md` documents a procedure covering all three deliverables:
+  characterize **voice** along axes, write **microcopy** for the recurring UI
+  states, and run the **content checklist**.
+- [x] A `references/voice-axes.md` defines the voice axes (e.g. humor, formality,
+  respect, enthusiasm), how to place a product on them, and the
+  **voice-is-constant / tone-flexes-by-context** distinction.
+- [x] A `references/microcopy-formulas.md` gives a formula **and** a paired
+  before/after for each of the four recurring UI states: **error** (blame-free +
+  actionable), **empty state** (orient + invite the first action), **button/CTA**
+  (verb + object), **label** (concise, consistent, scannable).
+- [x] A `references/content-checklist.md` provides a pre-ship checklist whose
+  items include (at least) voice-consistent, blame-free, actionable, concise, and
+  terminology-consistent.
+- [x] An `assets/voice-chart-template.md` ships a copy-to-`docs/product/voice/<slug>.md`
+  template that is explicitly a prompt sheet, not a schema.
+- [x] The pack version is bumped in both `pack.toml` and the pack's
+  `.claude-plugin/plugin.json`; `dist/` reflects it after `make build` and the
+  committed root `.claude-plugin/marketplace.json` after `make build-self FORCE=1`.
+- [x] The pack `description` (in `pack.toml` and `plugin.json`) is updated so its
+  skill enumeration is no longer stale once the fifth skill lands.
+- [x] `docs/product/changelog.md` carries an `[Unreleased] → Added` entry for the
+  new skill (with the pack version).
+- [x] The pack `README.md` skill table lists `voice-and-microcopy`, and
+  `docs/guides/product-engineering/` gains a how-to plus a row under the
+  `## How-to` heading of `docs/guides/product-engineering/README.md`.
+- [x] `make lint-packs`, `make build`, `make validate`, and
+  `tools/lint-agent-artifacts.py` all pass; `git status` is clean.
+
+## Assumptions
+
+- Process: the pack is user-scope-default and **not projected** into this repo's
+  `.claude/skills/`. `make build` refreshes `dist/`; the committed root
+  `.claude-plugin/marketplace.json` is a self-host projection refreshed by
+  `make build-self FORCE=1`, whose only drift here is the version line (source:
+  memory `self_host_pack_scope` + `nonprojected_pack_bump_drifts_marketplace`,
+  probe of `.claude/skills/` + build-self dry-run).
+- Product: adding this fifth skill is authorized despite the v1 spec's "ask first
+  before a fourth skill" boundary — `align-value-stream` already cleared that gate
+  via `value-stream-meta-repo`; this is the sanctioned next step (source: user
+  prompt 2026-06-14).
+- Technical: `house-voice-writing-craft` covers **documentation prose**, a
+  distinct artifact and audience, so this skill does not duplicate it (source:
+  probe of `docs/specs/house-voice-writing-craft/spec.md`).
+- Technical: voice axes and UI-state formulas are framework-agnostic (no
+  tech-specific content to strip) (source: user prompt + design).

--- a/packs/product-engineering/.apm/skills/voice-and-microcopy/SKILL.md
+++ b/packs/product-engineering/.apm/skills/voice-and-microcopy/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: voice-and-microcopy
+description: Use when shaping the actual words a user reads in a product's UI — characterizing the product's voice, writing the recurring UI-state microcopy (error, empty, button, label), or reviewing copy before it ships. Triggers on "what should this error say", "write the empty-state copy", "name this button", "characterize our product voice", "make this microcopy blame-free", "review this copy". Characterizes voice along a few axes, writes each UI state from a blame-free + actionable formula, and runs a content checklist. Do NOT use to frame the intent behind the feature (use `frame-intent`), to make visual or layout design decisions (this is words only), or to write documentation prose (that is `new-guide`'s clear-prose craft).
+---
+
+# Skill: voice-and-microcopy
+
+Shape product intent into the **words a user reads** in the UI. The pack frames,
+de-risks, and decomposes intent into shippable features; this skill writes the
+copy those features render. The method is three moves: **characterize the voice**
+along a few axes, **write each UI state** from a blame-free, actionable formula,
+and **run a content checklist** before the copy ships. It is a method, not a word
+bank — framework-agnostic, and it never mandates a schema. The voice axes are in
+`references/voice-axes.md`, the per-state formulas in
+`references/microcopy-formulas.md`, the checklist in `references/content-checklist.md`.
+
+## When to invoke
+
+Before writing, confirm:
+
+1. The ask is about the **words users read**, not the *intent* behind the feature
+   (route to `frame-intent`) and not visual or layout design (out of scope — this
+   skill shapes text only).
+2. There is a real **UI surface with copy** to write or review — an error, an
+   empty state, a button, a label, or a screen full of them. If there's no
+   user-facing text yet, there's nothing to shape; say so.
+
+## Procedure
+
+1. **Characterize the voice — once per product, then reuse.** Place the product
+   on a few axes (humor, formality, respect, enthusiasm) and record it in a
+   **voice chart** — copy `assets/voice-chart-template.md` to
+   `docs/product/voice/<slug>.md`. If a chart already exists, **reuse it**; don't
+   re-derive. Voice is **constant**; **tone flexes by context** — the same
+   product is calm and plain in an error, warmer in a success. See
+   `references/voice-axes.md`. A half-filled chart is normal input — offer a
+   default, don't block.
+
+2. **Write each UI state from its formula.** Identify the state and apply its
+   shape (`references/microcopy-formulas.md`):
+   - **Error** — *what happened, plainly* + *what to do next*. **Blame-free**:
+     describe the situation, never fault the user ("That code has expired —
+     request a new one", not "You entered an invalid code").
+   - **Empty state** — *orient* (what belongs here) + *invite the first action*.
+     Never a decorative dead end.
+   - **Button / CTA** — *verb + object* matching the user's goal ("Send invite",
+     not "Submit" / "OK").
+   - **Label** — concise, scannable, front-loaded keyword; one term per concept.
+
+3. **Run the content checklist before it ships** (`references/content-checklist.md`):
+   voice-consistent, blame-free, actionable, concise, and
+   terminology-consistent. Run it on any string before it lands; fix the misses.
+
+## Anti-patterns to refuse
+
+- **Blaming the user.** "You entered the wrong password" faults the reader;
+  "That password didn't match — try again or reset it" states the situation and
+  the next step. Error copy is blame-free, full stop.
+- **Dead-end copy.** An error or empty state that names the problem but not the
+  next action strands the user. Every dead end gets a way forward.
+- **Cleverness over clarity.** A joke that costs a beat of comprehension fails —
+  voice serves the user, not the writer. Wit is welcome only when it doesn't slow
+  the read.
+- **Ignoring emotional context.** A playful product is still calm and plain when
+  a payment fails. Voice is constant; tone flexes — don't joke in a crisis.
+- **Writing copy with no voice characterized.** Without a chart, terminology and
+  formality drift string to string. Characterize first, or reuse the chart.
+- **Mandating the chart as a schema.** The voice chart is a prompt sheet; a
+  half-filled one is fine. Blocking on empty fields is the failure mode.
+- **Restating the docs-prose craft.** Clear-prose rules for *documentation* live
+  in `new-guide`'s `clear-prose.md`; cross-reference shared items, don't fork them.

--- a/packs/product-engineering/.apm/skills/voice-and-microcopy/assets/voice-chart-template.md
+++ b/packs/product-engineering/.apm/skills/voice-and-microcopy/assets/voice-chart-template.md
@@ -1,0 +1,56 @@
+# Voice chart: <product name>
+
+> **This is a template, not a schema.** It shows the *shape* of a product's voice
+> chart — where the product sits on a few voice axes, how its tone flexes by
+> context, and the words it prefers. Copy it to `docs/product/voice/<slug>.md` and
+> fill in what you have; an empty field is a prompt, not an error. Characterize the
+> voice once and **reuse this chart** across features — don't re-derive it per
+> screen. Keep only the rows that earn their place.
+
+- **Slug:** `<slug>` <!-- kebab-case; matches the filename -->
+- **Product:** `<what this voice belongs to>`
+
+## Voice axes
+
+<!-- Place the product on each axis — not always the middle. Justify in one line
+from who the user is and what they came to do, and write one real sample line in
+that voice. Add or drop an axis if the product needs it. See
+references/voice-axes.md. -->
+
+| Axis | Position (one end ↔ other) | Why | Sample line |
+| --- | --- | --- | --- |
+| Humor | `<serious ↔ playful>` | <one line> | <a real string> |
+| Formality | `<formal ↔ casual>` | <one line> | <a real string> |
+| Respect | `<deferential ↔ irreverent>` | <one line> | <a real string> |
+| Enthusiasm | `<calm ↔ enthusiastic>` | <one line> | <a real string> |
+
+## Tone flex by context
+
+<!-- Voice is constant; tone flexes for the user's emotional state. The higher the
+stress, the closer the tone moves to plain and calm — even for a playful product. -->
+
+| Context | Tone |
+| --- | --- |
+| Success / celebration | <warmest the voice allows> |
+| Routine action | <the default voice> |
+| Error / failure | <calm, plain, blame-free> |
+| Destructive / high-stakes confirm | <most serious; no wit> |
+| Waiting / loading | <brief, reassuring> |
+
+## Terminology
+
+<!-- One concept, one word, everywhere. Preferred term + what to avoid, so the same
+thing reads the same way on every screen. -->
+
+| Concept | Use | Avoid |
+| --- | --- | --- |
+| <e.g. the container a user works in> | `<workspace>` | `<project, board>` |
+| | | |
+
+## Do / don't (optional)
+
+<!-- A few sample strings that capture the voice in action — the fastest way for
+the next writer to match it. -->
+
+- ✅ <a line that nails the voice>
+- ❌ <a line that misses it, and why>

--- a/packs/product-engineering/.apm/skills/voice-and-microcopy/references/content-checklist.md
+++ b/packs/product-engineering/.apm/skills/voice-and-microcopy/references/content-checklist.md
@@ -1,0 +1,30 @@
+# Content checklist — run before copy ships
+
+Run this on any user-facing string before it lands. It's a fast pass, not a gate —
+catch the misses and fix them. Each item is one question; a "no" is a fix.
+
+- [ ] **Voice-consistent.** Does it sit where the voice chart places the product on
+      the axes (`references/voice-axes.md`)? Is the tone right for *this* moment —
+      calm in an error, warm in a success?
+- [ ] **Blame-free.** Does it describe the situation without faulting the user? No
+      "you entered…", "invalid", or "you failed to…".
+- [ ] **Actionable.** Does the user know what to do next? An error or empty state
+      with no way forward is a dead end.
+- [ ] **Concise.** Is every word pulling weight? Cut filler ("please note that",
+      "in order to", "simply"). *Concise here is the UI-copy cut — for the
+      documentation-prose version of this rule, see `new-guide`'s `clear-prose.md`;
+      this checklist doesn't restate it.*
+- [ ] **Terminology-consistent.** One concept, one word, matching the voice chart's
+      terminology list — the same thing reads the same way on every screen.
+- [ ] **Scannable.** For labels and buttons: keyword front-loaded, no
+      sentence-shaped labels, self-describing out of context.
+- [ ] **Inclusive and plain.** Plain language; no idioms that don't translate, no
+      jargon the user didn't bring, no assumptions about who the user is.
+
+## How to use it
+
+Don't treat the list as ceremony for every word. Run it deliberately on the
+strings that carry weight — errors, empty states, primary buttons, destructive
+confirmations — and let the rest ride on a voice that's already characterized. The
+first three items (voice-consistent, blame-free, actionable) are the ones that
+most change how the copy lands; never skip those.

--- a/packs/product-engineering/.apm/skills/voice-and-microcopy/references/microcopy-formulas.md
+++ b/packs/product-engineering/.apm/skills/voice-and-microcopy/references/microcopy-formulas.md
@@ -1,0 +1,62 @@
+# Microcopy formulas — the recurring UI states
+
+Four UI states recur in almost every product. Each has a **formula** that makes
+the copy do its job, and a **before → after** that shows the formula at work. The
+formulas are framework-agnostic — they shape words, not widgets. The same
+formula-thinking extends to confirmations, notifications, and tooltips; these four
+are the load-bearing core.
+
+Filter every string through the voice chart (`references/voice-axes.md`) for
+position, and the content checklist (`references/content-checklist.md`) before it
+ships.
+
+## Error
+
+**Formula:** *what happened, plainly* + *what to do next*. **Blame-free** — describe
+the situation, never fault the user. Drop the error code and the apology; lead with
+the recovery.
+
+- ❌ **Before:** "Error: invalid input. You entered an incorrect verification code."
+- ✅ **After:** "That code has expired. Request a new one and we'll send it right away."
+
+Why: the "before" blames the user and stops at the diagnosis. The "after" states
+the situation neutrally and hands the user the next action. An error the user
+can't act on is a dead end.
+
+## Empty state
+
+**Formula:** *orient* (what belongs here, in one line) + *invite the first action*.
+An empty state is the user's first impression of a feature — never a blank panel or
+a lone illustration.
+
+- ❌ **Before:** "No items." / a graphic with no words
+- ✅ **After:** "No invoices yet. Create your first one to start tracking what you're owed." + a **Create invoice** button
+
+Why: the "before" confirms emptiness and stops. The "after" tells the user what
+this space is for and gives them the one action that fills it.
+
+## Button / CTA
+
+**Formula:** *verb + object* that names the user's goal. Avoid generic
+**Submit / OK / Yes** — they make the user re-read the surrounding copy to know
+what they're agreeing to. The button should make sense read on its own.
+
+- ❌ **Before:** "Submit" / "OK"
+- ✅ **After:** "Send invite" / "Delete 3 files"
+
+Why: a specific verb-object button is self-describing and survives being read out
+of context (screen readers, confirmation dialogs). For a destructive action, name
+the object and the count so the consequence is unmistakable.
+
+## Label
+
+**Formula:** concise noun phrase, **keyword front-loaded**, scannable, **one term
+per concept** (consistent with the voice chart's terminology list). Labels are
+scanned, not read — the first word carries the meaning.
+
+- ❌ **Before:** "Please enter the email address you'd like to use" / "Date that the project was created on"
+- ✅ **After:** "Email" / "Created"
+
+Why: users scan labels; a sentence-shaped label slows that scan. Front-load the
+keyword and cut the framing words. Keep the term identical everywhere the concept
+appears — a field called "Email" here must not be "E-mail address" two screens on.

--- a/packs/product-engineering/.apm/skills/voice-and-microcopy/references/voice-axes.md
+++ b/packs/product-engineering/.apm/skills/voice-and-microcopy/references/voice-axes.md
@@ -1,0 +1,55 @@
+# Voice axes — characterize a product's voice
+
+**Voice** is the product's steady personality in words. **Tone** is how that voice
+flexes for the moment. You characterize voice once and reuse it; you choose tone
+per context. Mixing the two up is the most common voice mistake — a brand that's
+"playful" everywhere cracks jokes in a failed-payment error, and the playfulness
+reads as not caring.
+
+## The axes
+
+Place the product on a few axes. Four cover most products; add or drop one if the
+product needs it — the axes are a starting frame, not a fixed set.
+
+| Axis | One end | Other end |
+| --- | --- | --- |
+| **Humor** | serious, straight | playful, witty |
+| **Formality** | formal, precise | casual, conversational |
+| **Respect** | deferential, careful | irreverent, cheeky |
+| **Enthusiasm** | matter-of-fact, calm | enthusiastic, energetic |
+
+How to place the product:
+
+1. **Pick a position on each axis** — not always the middle. "Mostly serious,
+   occasionally warm" is a position; "balanced" usually means undecided.
+2. **Justify it in one line** from who the user is and what they came to do. A tax
+   tool earns *serious + formal + respectful + calm*; a habit-tracker can be
+   *playful + casual + enthusiastic*.
+3. **Write one sample line per axis** — a real string in that voice. Samples make
+   the chart usable; abstract adjectives don't. Record them in the voice chart
+   (`assets/voice-chart-template.md`).
+
+## Voice is constant; tone flexes by context
+
+The position on the axes holds across the product. **Tone** dials within it for
+the user's emotional state. A useful way to choose tone: read the moment, then
+flex toward calm-and-plain as the stakes rise.
+
+| Context | Tone flex |
+| --- | --- |
+| Success / celebration | warmest, most enthusiastic the voice allows |
+| Routine action | the product's default voice |
+| Error / failure | calm, plain, blame-free — humor recedes |
+| Destructive / high-stakes confirm | most serious and precise; no wit |
+| Waiting / loading | brief, reassuring, never cute-at-length |
+
+The rule: **the higher the user's stress, the closer the tone moves to plain and
+calm** — even for a playful product. Voice doesn't change; the dial does.
+
+## Terminology is part of voice
+
+One concept, one word — everywhere. If it's a "workspace" in the nav, it's not a
+"project" in the empty state. The voice chart carries a short terminology list
+(preferred term + what to avoid) so the same thing reads the same way across every
+screen. Inconsistent terms cost the user a re-read even when each string is fine
+on its own.

--- a/packs/product-engineering/.claude-plugin/plugin.json
+++ b/packs/product-engineering/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "product-engineering",
-  "version": "0.3.1",
-  "description": "Shape product intent into shippable specs. Habits — frame-intent, de-risk-intent, decompose-intent — over a recursive, level-tagged `intent` (a capability intent and a feature intent are the same artifact at different levels). Outcome+opportunity framing, a choosable prototype-approach to de-risk the riskiest assumption, and decomposition into the briefs/specs your delivery loop already builds — at app scale, or sliced per component across a business-unit value stream coordinated by `align-value-stream`. Pure-markdown, user-scope."
+  "version": "0.4.0",
+  "description": "Shape product intent into shippable specs — and into the words users read. Habits — frame-intent, de-risk-intent, decompose-intent — over a recursive, level-tagged `intent` (a capability intent and a feature intent are the same artifact at different levels): outcome+opportunity framing, a choosable prototype-approach to de-risk the riskiest assumption, and decomposition into the briefs/specs your delivery loop already builds — at app scale, or sliced per component across a business-unit value stream coordinated by `align-value-stream`. `voice-and-microcopy` adds the content layer: characterize a product's voice and write blame-free, actionable UI copy. Pure-markdown, user-scope."
 }

--- a/packs/product-engineering/README.md
+++ b/packs/product-engineering/README.md
@@ -16,6 +16,7 @@ Intents form a recursive tree whose leaf is a shippable spec.
 | `de-risk-intent` | Name the riskiest assumption, predeclare the **kill condition** in the test's own currency, and run it under a **choosable prototype-approach** — `validate-first` (predeclare, then test) or `prototype-led` (build to learn; the build *is* the test) — to a survive/kill verdict. |
 | `decompose-intent` | Break an intent into the next level down — child intents, or a spec/slice at the leaf — and project the tree **one-way** onto your tracker (`none` / Linear / Jira Align). At app scale the leaf *is* an ordinary `core` brief; at business-unit scale it **slices the feature intent per component** into one brief per repo (each carrying `parent-intent:` + a version-pinned contract reference). |
 | `align-value-stream` | Stand up and keep current a **value-stream meta-repo** — a coordinating repo with no app code that holds the cross-component artifacts a polyrepo has nowhere else to put: the Backstage **federated catalog**, the shared-contract authority (referenced by version, never forked), the C4/bounded-context architecture, and the **cross-component delivery rollup**. Business-unit scale only. |
+| `voice-and-microcopy` | Shape the **words a user reads** in the UI. Characterize the product's **voice** along a few axes (humor / formality / respect / enthusiasm), write the recurring UI states — **error, empty, button, label** — from blame-free, actionable formulas, and run a **content checklist** before copy ships. The content layer of the pack; a method, not a word bank. |
 
 ## Install
 
@@ -51,8 +52,8 @@ The detailed wire contract is pinned later, at the spec stage, via the existing
 
 ## Design principles
 
-- **Habits, not infrastructure.** Skills + `references/` + seeds. No engine, no
-  hooks, no validators, no subagents, no runtime hub.
+- **Habits, not infrastructure.** Skills + `references/` + `assets/` templates. No
+  engine, no hooks, no validators, no subagents, no runtime hub.
 - **One artifact, every level.** The recursive `intent` spans solo→business-unit;
   decomposition is recursive and assumptions are de-risked per intent at its level.
 - **Modes are lightweight.** One global axis — **Scale** — resolved at intake;
@@ -91,13 +92,14 @@ packs/product-engineering/
     ├── frame-intent/        (SKILL.md + references/ + examples/ + assets/intent-template.md)
     ├── de-risk-intent/      (SKILL.md + references/)
     ├── decompose-intent/    (SKILL.md + references/)
-    └── align-value-stream/  (SKILL.md + references/ + assets/rollup-template.md)  ← business-unit scale
+    ├── align-value-stream/  (SKILL.md + references/ + assets/rollup-template.md)  ← business-unit scale
+    └── voice-and-microcopy/ (SKILL.md + references/ + assets/voice-chart-template.md)  ← content layer
 ```
 
-The intent and rollup **templates travel with their skills** (in each skill's
-`assets/`), not as repo `seeds/` — so the pack ships no `seeds/` and stays
-user-scope. The skills copy their template into the project's
-`docs/product/{intents,rollups}/<slug>.md` at runtime.
+The intent, rollup, and voice-chart **templates travel with their skills** (in
+each skill's `assets/`), not as repo `seeds/` — so the pack ships no `seeds/` and
+stays user-scope. The skills copy their template into the project's
+`docs/product/{intents,rollups,voice}/<slug>.md` at runtime.
 
 ## Usage
 
@@ -107,6 +109,7 @@ Ask your agent, for example:
 - "De-risk the riskiest assumption in this intent with a prototype." (`de-risk-intent`)
 - "Decompose this intent into shippable specs." (`decompose-intent`)
 - "Stand up a value-stream meta-repo to coordinate these components." (`align-value-stream`)
+- "Characterize our product voice, then write the empty-state and error copy." (`voice-and-microcopy`)
 
 ---
 

--- a/packs/product-engineering/pack.toml
+++ b/packs/product-engineering/pack.toml
@@ -1,7 +1,7 @@
 [pack]
 name = "product-engineering"
-version = "0.3.1"
-description = "Shape product intent into shippable specs. Habits — frame-intent, de-risk-intent, decompose-intent — over a recursive, level-tagged `intent` (a capability intent and a feature intent are the same artifact at different levels). Outcome+opportunity framing, a choosable prototype-approach to de-risk the riskiest assumption, and decomposition into the briefs/specs your delivery loop already builds — at app scale, or sliced per component across a business-unit value stream coordinated by `align-value-stream`. Pure-markdown, user-scope."
+version = "0.4.0"
+description = "Shape product intent into shippable specs — and into the words users read. Habits — frame-intent, de-risk-intent, decompose-intent — over a recursive, level-tagged `intent` (a capability intent and a feature intent are the same artifact at different levels): outcome+opportunity framing, a choosable prototype-approach to de-risk the riskiest assumption, and decomposition into the briefs/specs your delivery loop already builds — at app scale, or sliced per component across a business-unit value stream coordinated by `align-value-stream`. `voice-and-microcopy` adds the content layer: characterize a product's voice and write blame-free, actionable UI copy. Pure-markdown, user-scope."
 readme = "README.md"
 display_name = "Product Engineering"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
## What does this change?

Adds a fifth pure-markdown skill, `voice-and-microcopy`, to the `product-engineering` pack — a UX-writing / voice-&-tone capability that turns shaped product intent into the actual **words a user reads** in the UI. The pack's intent-shaping habits (`frame-intent`, `de-risk-intent`, `decompose-intent`) stop at the *structure* of the work; this skill writes the copy those features render.

## Why?

The pack had no content/writing angle. None of the existing skills was a clean home — `frame-intent` is deliberately solution-independent, `decompose-intent` cuts structure not content, `de-risk-intent` tests bets — and the shipped `house-voice-writing-craft` covers *documentation* prose, a different artifact and audience. Pressure-tested against the four charter bars (universal across stacks, substantive/non-duplicative, habit-not-tool, used-often) — all four pass, so a dedicated skill earns its place. A new skill is structural, so this ran the work-loop in full mode with a spec.

The skill is a method, not reference data:
- characterize a product's **voice** along axes (humor / formality / respect / enthusiasm), recorded in a travelling voice-chart template;
- write the recurring UI states (**error, empty, button, label**) from blame-free, actionable formulas, each with a before/after;
- run a **content checklist** before copy ships.

Voice is constant; tone flexes by context (calm in errors, warm in success). Fully framework-agnostic, habits-shaped — no engine, no schema, `SKILL.md` under 100 lines with depth in `references/`.

- Implements: docs/specs/voice-and-microcopy/spec.md

## How do I verify it?

- `make lint-packs build validate` and `python3 tools/lint-agent-artifacts.py` — all green
- `make build-check` — green (exit 0)
- `python3 .claude/skills/work-loop/scripts/lint-spec-status.py --root .` — "spec metadata clean"
- `wc -l packs/product-engineering/.apm/skills/voice-and-microcopy/SKILL.md` — 71 (< 100)
- Pack bumped 0.3.1 → 0.4.0 in `pack.toml` + `.claude-plugin/plugin.json`; committed root `.claude-plugin/marketplace.json` re-projected via `make build-self FORCE=1`
- Read the skill + three references + voice-chart template; the Diátaxis how-to is at `docs/guides/product-engineering/how-to/write-product-microcopy.md`

## What did you not change that you considered?

- **No seam in an existing skill** — considered extending `decompose-intent`, but content design is a distinct discipline and bolting it on would muddy that skill's clean recursive-decomposition purpose.
- **No agent, hook, validator, or seed** — the pack is pure-markdown and habits-shaped by design (RFC-0030); the voice-chart template travels in the skill's `assets/`.
- **No tech-specific guidance** (CSS framework, component library, i18n tooling) — the method stays framework-agnostic.
- **No security/quality-engineer review pass** — no security boundary crossed and no code/test/observability surface (pure-markdown docs), so neither lens was warranted.

## Reviewer notes

- adversarial-reviewer run at spec stage and on the diff; iterated to clean. The post-EXECUTE pass surfaced an accuracy correction: the committed root `marketplace.json` is refreshed by `make build-self FORCE=1` (not `make build`, which only refreshes `dist/`) — spec/plan corrected to match.

## Bundled fixes

- `packs/product-engineering/README.md`: "seeds" → "assets" in Design principles (the pack ships no `seeds/`; templates travel in skill `assets/`).