### PR TITLE
feat(product-engineering): record the decomposition decision in decompose-intent (0.4.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -169,7 +169,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "product-engineering",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.4.0"
+      "version": "0.4.1"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -19,6 +19,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`decompose-intent` records the decomposition decision (product-engineering
+  0.4.1).** When a cut drops or replaces a branch — most often after an upward
+  `de-risk-intent` kill bubbles up — there was no instruction to record *why* on
+  the parent, so a parent intent read as if its tree were always this shape and a
+  later reader re-litigated branches already ruled out. A new procedure step (and
+  an optional "Decomposition decisions" log in the intent template) asks for the
+  grouping rationale plus any dropped/replaced branch, pointing to the killed
+  child's verdict. This mirrors the de-risk trail, which already records why a bet
+  was tested the way it was; a line or two per decision, omit if the cut was
+  obvious. No new fields are required and the artifact stays a template, not a
+  schema. (Pure-markdown; dependency-contract paths between siblings and
+  confidence in a bet were audited and already covered by the business-unit
+  provider/consumer projection and the survive/kill verdict respectively — no
+  change there.)
+
 - **`architect-diagram` learns deliberate visual encoding (architect 0.5.3).**
   A new `references/visual-encoding.md` turns scattered correctness rules into
   one design heuristic: when a diagram distinguishes more than one category of

--- a/packs/product-engineering/.apm/skills/decompose-intent/SKILL.md
+++ b/packs/product-engineering/.apm/skills/decompose-intent/SKILL.md
@@ -36,7 +36,17 @@ Before decomposing, confirm:
      shippable, agent-buildable unit (one coherent scope, vertical, ships and
      tests on its own). Cut by **shippability**, never by component or layer.
 
-2. **Project the leaf — by Scale.** A feature-level intent is the leaf; how it
+2. **Record the decomposition decision.** Note *why* the cut went the way it did
+   on the parent's `Decomposition` — the grouping rationale, and any branch you
+   considered and dropped or replaced (with a pointer to the killed child's
+   `de-risk-intent` verdict when an upward kill forced the re-cut). This mirrors
+   the de-risk trail, which already records why a bet was tested the way it was
+   (`de-risk-intent`'s `references/reversibility-triage.md`). Without it the
+   parent reads as if the tree were always this shape, and a later reader
+   re-litigates a branch you already ruled out. A line or two per decision — a
+   log, not a memo.
+
+3. **Project the leaf — by Scale.** A feature-level intent is the leaf; how it
    projects depends on Scale (`references/recursive-decomposition.md`):
    - **`app` Scale** — it *is* a single `core` brief (same outcome, success
      metrics from the input/lagging/guardrail, scope/non-goals, appetite). Write
@@ -54,12 +64,12 @@ Before decomposing, confirm:
      Coordinating across repos this way has hard limits (no atomic cross-repo
      commit, no shared release train) — `align-value-stream` states them honestly.
 
-3. **Keep the contract behavioral here.** Carry only the *interaction* shape (who
+4. **Keep the contract behavioral here.** Carry only the *interaction* shape (who
    talks to whom, the consumer's expectations) into the brief; the **detailed
    wire contract is pinned at the spec stage** via the existing `Contract:` seam,
    where the component's full context lives. Don't author OpenAPI/AsyncAPI here.
 
-4. **Project onto a tracker (optional, one-way).** If the team uses a tracker,
+5. **Project onto a tracker (optional, one-way).** If the team uses a tracker,
    render the tree onto it per `references/tracker-projection.md` — `none`
    (markdown only), Linear (lean; collapse), or Jira Align (deep; expand). The
    canonical tree is the source; the tracker is a render. **One-way only** —
@@ -74,6 +84,10 @@ Before decomposing, confirm:
   feature-level seams and the per-feature bets. Produce child intents first.
 - **Decomposing a killed bet.** If `de-risk-intent` killed the riskiest
   assumption, reshape the parent — don't fan out specs that inherit the dead bet.
+- **Silently re-shaping the tree.** Dropping or replacing a branch after a kill
+  without recording why leaves the parent reading as if it were always cut this
+  way — and invites a later reader to re-propose the dead branch. Log the
+  decision (step 2).
 - **Letting the tracker dictate the model.** Linear's flatness and Jira Align's
   depth are *projection targets*, not the product model. Model in intents; render
   to the tracker. Same canonical spec lands at an Issue (Linear) and a Story

--- a/packs/product-engineering/.apm/skills/decompose-intent/references/recursive-decomposition.md
+++ b/packs/product-engineering/.apm/skills/decompose-intent/references/recursive-decomposition.md
@@ -29,9 +29,11 @@ isn't a slice yet — keep decomposing or regroup.
 
 Decomposition and de-risking interleave. A child intent whose riskiest assumption
 is **killed** bubbles up: it forces the parent to re-decompose (drop or replace
-that branch) or, if it invalidates the parent's bet, to reframe. That upward edge
-is the coupling that keeps the tree honest — a parent is only as sound as its
-surviving children.
+that branch) or, if it invalidates the parent's bet, to reframe. Record that
+re-cut on the parent's `Decomposition` (the decomposition decision, `SKILL.md`
+step 2), with a pointer to the killed child's verdict — so the dropped branch
+leaves a trace and isn't re-proposed later. That upward edge is the coupling that
+keeps the tree honest — a parent is only as sound as its surviving children.
 
 ## The brief projection (`app` Scale)
 

--- a/packs/product-engineering/.apm/skills/frame-intent/assets/intent-template.md
+++ b/packs/product-engineering/.apm/skills/frame-intent/assets/intent-template.md
@@ -49,3 +49,13 @@ brief — `receive-brief` takes it from there. Leave empty until decompose-inten
 runs. -->
 
 -
+
+### Decomposition decisions
+
+<!-- Optional log: why the cut went this way, plus any branch you considered and
+dropped or replaced — with a pointer to the killed child's de-risk verdict when
+an upward kill forced the re-cut. A line or two per decision; omit if the cut was
+obvious. Keeps the parent from reading as if the tree were always this shape. See
+decompose-intent step 2. -->
+
+-

--- a/packs/product-engineering/.claude-plugin/plugin.json
+++ b/packs/product-engineering/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "product-engineering",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Shape product intent into shippable specs — and into the words users read. Habits — frame-intent, de-risk-intent, decompose-intent — over a recursive, level-tagged `intent` (a capability intent and a feature intent are the same artifact at different levels): outcome+opportunity framing, a choosable prototype-approach to de-risk the riskiest assumption, and decomposition into the briefs/specs your delivery loop already builds — at app scale, or sliced per component across a business-unit value stream coordinated by `align-value-stream`. `voice-and-microcopy` adds the content layer: characterize a product's voice and write blame-free, actionable UI copy. Pure-markdown, user-scope."
 }

--- a/packs/product-engineering/pack.toml
+++ b/packs/product-engineering/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "product-engineering"
-version = "0.4.0"
+version = "0.4.1"
 description = "Shape product intent into shippable specs — and into the words users read. Habits — frame-intent, de-risk-intent, decompose-intent — over a recursive, level-tagged `intent` (a capability intent and a feature intent are the same artifact at different levels): outcome+opportunity framing, a choosable prototype-approach to de-risk the riskiest assumption, and decomposition into the briefs/specs your delivery loop already builds — at app scale, or sliced per component across a business-unit value stream coordinated by `align-value-stream`. `voice-and-microcopy` adds the content layer: characterize a product's voice and write blame-free, actionable UI copy. Pure-markdown, user-scope."
 readme = "README.md"
 display_name = "Product Engineering"


### PR DESCRIPTION
## What

Audit of the intent-decomposition loop (`frame-intent`, `de-risk-intent`, `decompose-intent`) against three candidate "wrinkles", biasing hard toward *already covered*. Two were covered and got no change; one was a genuine bounded gap and is fixed here.

| Wrinkle | Verdict |
|---|---|
| **(a)** explicit dependency-contract paths between decomposed units | **Already covered** — `recursive-decomposition.md`'s `business-unit` projection stamps each slice with a provider/consumer role, the compatibility direction on each `providesApi`/`consumesApi` edge, and a `contract@version` reference; `app` scale defers the wire contract to the spec-stage `Contract:` seam by design. |
| **(b)** a decision-log captured during decomposition | **Genuine bounded gap — added.** |
| **(c)** a confidence score on a decomposed intent | **Already covered** — the survive/kill verdict is the per-intent confidence gate, the qualitative lowered-confidence marker handles grounding, and "a parent is only as sound as its surviving children" is the roll-up. A retrofitted number is the false-precision theatre `frame-intent` already refuses. |

## The (b) fix

The de-risk side already records *why a bet was tested the way it was* (`reversibility-triage.md`), but decomposition had no parallel. When an upward kill forced a parent to drop or replace a branch, nothing instructed recording *why* on the parent — so a parent read as a clean tree and a later reader re-litigated branches already ruled out.

- `decompose-intent/SKILL.md` — new **step 2 "Record the decomposition decision"** (steps renumbered), plus a **"Silently re-shaping the tree"** anti-pattern.
- `decompose-intent/references/recursive-decomposition.md` — one clause in the upward-feedback paragraph: record the re-cut on the parent with a pointer to the killed child's verdict.
- `frame-intent/assets/intent-template.md` — optional **"Decomposition decisions"** section (no new required fields; stays a template, not a schema).

Deliberately scoped to the one asymmetry — no sibling-edge machinery (a), no numeric score (c). It mirrors an existing pack discipline rather than introducing a new mechanism.

## Mechanics

Pure-markdown, user-scope-default pack. Version bump `0.4.0 → 0.4.1` (`pack.toml` + `plugin.json`), `marketplace.json` regenerated (version-only diff via `make build-self FORCE=1`), changelog `[Unreleased]` entry.

## Verification

- `make build-check` — pass
- `tools/lint-agent-artifacts.py` — pass
- adversarial-reviewer — clean