### PR TITLE
test(architect): design-reviewer rubric-parity + cursor-readonly guards; refresh root README (architect + product-engineering)

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -176,14 +176,19 @@ jobs:
         working-directory: packages/agentbundle
         run: python -m pytest agentbundle/build/tests/test_adapter_gemini.py
 
-      # architect-design-reviewer (RFC-0032): the durable cross-adapter
-      # projection check for the design-reviewer subagent lives in the
-      # build/tests root, which `make build-check` does not run. Wire it in
-      # explicitly or it never gates (CI does not auto-discover package pytest)
-      # — AC10's "fails if a future adapter change drops it" depends on this.
-      - name: pytest architect design-reviewer projection (RFC-0032)
+      # architect-design-reviewer (RFC-0032): the design-reviewer subagent's
+      # cross-adapter projection check (AC10's "fails if a future adapter change
+      # drops it") and its rubric-parity guard (the verdict / severity /
+      # mechanical-judgment vocabulary must stay identical across the agent and
+      # architect-review) live in the build/tests root, which `make build-check`
+      # does not run. Wire them in explicitly or they never gate (CI does not
+      # auto-discover package pytest).
+      - name: pytest architect design-reviewer guards (RFC-0032)
         working-directory: packages/agentbundle
-        run: python -m pytest agentbundle/build/tests/test_architect_design_reviewer_projection.py
+        run: >-
+          python -m pytest
+          agentbundle/build/tests/test_architect_design_reviewer_projection.py
+          agentbundle/build/tests/test_architect_design_reviewer_rubric_parity.py
 
       # enriched-pack-manifest (RFC-0031): the manifest layer's contract +
       # construction tests live in the build/tests + tests/{unit,integration}

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ A fourth subagent, `implementer`, is the loop's own executor. It runs independen
 | [`converters`](docs/guides/converters/) | user / repo | `file-to-markdown` (PDF/DOCX/PPTX/XLSX + images), `markdown-to-html`, `msg-to-markdown`, `mermaid-renderer`. |
 | [`atlassian`](docs/guides/atlassian/) | user / repo | `jira`, `jira-align`, `confluence-crawler`, `confluence-publisher` (credentialed) plus `flow-metrics`, `ai-adoption-report`, `jira-defect-flow`. |
 | [`figma`](docs/guides/figma/) | user / repo | Figma REST primitive (credentialed) — reads files/nodes/comments/variables, renders frames, FigJam → Mermaid. |
-| [`architect`](docs/guides/architect/) | user / repo | Solution architecture — `architect-design`, `architect-diagram`, `architect-review`. |
-| [`product-engineering`](docs/guides/product-engineering/) | user / repo | Shape product intent into shippable specs — `frame-intent`, `de-risk-intent`, `decompose-intent` over a recursive, level-tagged `intent`, feeding the briefs/specs your delivery loop already builds. |
+| [`architect`](docs/guides/architect/) | user / repo | Solution architecture — `architect-design`, `architect-diagram`, `architect-review`, plus a read-only, forked-context `design-reviewer` subagent for independent design critique. |
+| [`product-engineering`](docs/guides/product-engineering/) | user / repo | Shape product intent into shippable specs — `frame-intent`, `de-risk-intent`, `decompose-intent` over a recursive, level-tagged `intent`; `voice-and-microcopy` for UI copy (error/empty/button/label) against a voice chart; and `align-value-stream` for the business-unit cross-component value-stream layer. Feeds the briefs/specs your delivery loop already builds. |
 
 Repo-scope packs install into the current repo and build on `core`. User-scope packs install into `~/.claude/` (or your harness's home root) and follow you across every project. Swap `core` for any pack name in the command above.
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -669,37 +669,3 @@ the citations sit in library-provenance docstrings rather than agent-facing
 prose, so they were left for a separate, deliberate pass that respects the
 freeze. Fold this into the `apm-leak-lint-rfc` work, or do it as a focused
 comment-only PR against the frozen pack with explicit sign-off.
-
-## architect-rubric-parity-guard
-
-### design-reviewer-rubric-drift
-
-`packs/architect/.apm/agents/design-reviewer.md` (RFC-0032) inlines a condensed
-copy of `architect-review`'s verdict scheme, severity glossary, and 🔧/🧭
-mechanical-judgment taxonomy — guarded only by a one-time authoring
-byte-faithfulness diff plus a prose note, per the pack's standing
-duplication-over-DRY convention. There is no mechanical guard forcing the agent
-copy to reconcile when `architect-review/SKILL.md` or `rubric-well-architected.md`
-next changes those labels/definitions. Note this is **not** a new gap unique to
-the agent: the same verdict/severity rubric is already duplicated
-`architect-design`↔`architect-review` without a parity guard (the existing
-`tools/lint-knowledge-surface-parity.py` covers only the *knowledge-surface*
-taxonomy, not these rubrics). A guard here would therefore also imply guarding
-that pre-existing duplication — a deliberate design call beyond RFC-0032's scope.
-
-Deferred from the `architect-design-reviewer` quality-engineer pass (Concern 1).
-If pursued: extend `lint-knowledge-surface-parity.py` (or add a sibling lint) to
-assert the verdict labels / severity glyphs / mechanical-judgment definitions are
-byte-identical across `architect-design`, `architect-review`, and the
-`design-reviewer` agent, wired into CI alongside that lint. Weigh against the
-pack's duplication-over-DRY principle first — it may be a deliberate non-goal.
-
-### design-reviewer-cursor-readonly-projection-assertion
-
-The `architect-design-reviewer` projection test asserts the agent lands under
-each adapter's `agents/` route but not that the `cursor` adapter emits
-`readonly: true` for it (cursor's documented degradation that makes "flag, never
-rewrite" hold for that target). The generic readonly-derivation mechanism is
-already covered by `test_adapter_cursor.py`, so this is a coverage-tightening
-nit, not a gap. Deferred from the quality-engineer pass (Nit 2); if pursued, add
-a one-line `assertIn("readonly", …)` to the cursor subTest.

--- a/packages/agentbundle/agentbundle/build/tests/test_architect_design_reviewer_projection.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_architect_design_reviewer_projection.py
@@ -69,6 +69,19 @@ class ArchitectDesignReviewerProjectionTests(unittest.TestCase):
                         any("agents" in h.parts for h in hits),
                         f"{adapter}: design-reviewer projected but not under an agents/ route: {hits}",
                     )
+                    if adapter == "cursor":
+                        # cursor encodes the read-only contract as a `readonly`
+                        # frontmatter flag (it drops the source `tools:` allowlist
+                        # and derives the flag for a non-mutating agent). Assert it
+                        # survives projection so AC5's read-only guarantee holds at
+                        # the one target that represents it as a flag rather than a
+                        # tools list — the design-reviewer flags, never rewrites.
+                        agent_hit = next(h for h in hits if "agents" in h.parts)
+                        self.assertIn(
+                            "readonly",
+                            agent_hit.read_text(encoding="utf-8"),
+                            "cursor: design-reviewer must project with the readonly flag",
+                        )
 
 
 if __name__ == "__main__":

--- a/packages/agentbundle/agentbundle/build/tests/test_architect_design_reviewer_rubric_parity.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_architect_design_reviewer_rubric_parity.py
@@ -1,0 +1,74 @@
+"""Rubric-parity guard for architect's `design-reviewer` subagent (RFC-0032).
+
+The `design-reviewer` agent inlines a condensed copy of `architect-review`'s
+verdict scheme, severity glossary, and 🔧/🧭 mechanical-judgment taxonomy
+(agents bundle no `references/`, so the rubric is inlined — the pack's
+duplication-over-DRY stance). The *prose* is free to be condensed, but three
+token sets are a **cross-skill interop contract**: `architect-design`'s
+convergence loop consumes mechanical/judgment-tagged findings and routes on the
+verdict + severity vocabulary, so those tokens must stay identical wherever they
+appear. This is the same reason `tools/lint-knowledge-surface-parity.py` guards
+the knowledge-surface taxonomy despite the duplication principle.
+
+This test is the guard the `design-reviewer-rubric-drift` backlog item asked
+for. The canonical constants below are an **explicit allowlist** of the
+interop tokens: a clean *rename or drop* in any carrier (e.g. retitling
+`SHIP IT` in `architect-review/SKILL.md`) removes the token from that file,
+fails the per-file assertion, and forces the rename to be reconciled across the
+constant *and* every carrier in one change — that clean-rename drift is the
+realistic case and what this catches. Two limits, by design: a reword that
+keeps the token as a substring (`MAJOR REWRITE` → `MAJOR REWRITE REQUIRED`) is
+not caught (AC2's one-time byte-faithful diff covers strict wording), and a
+*newly added* verdict/glyph must be added to the constants here by hand — the
+allowlist does not auto-discover vocabulary growth.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+ARCHITECT = REPO_ROOT / "packs" / "architect"
+
+# The interop vocabulary, canonical. (Prose around these may be condensed in a
+# copy; the tokens themselves may not drift.)
+VERDICTS = ("SHIP IT", "SHIP WITH CHANGES", "MAJOR REWRITE", "WRONG ARTIFACT")
+SEVERITY_GLYPHS = ("🟥", "🟧", "🟨", "⚪")
+TAXONOMY_GLYPHS = ("🔧", "🧭")
+ALL_TOKENS = VERDICTS + SEVERITY_GLYPHS + TAXONOMY_GLYPHS
+
+# Every carrier of the rubric vocabulary. architect-review is canonical (its
+# SKILL.md + rubric-well-architected.md own the verdict / severity / taxonomy);
+# the design-reviewer agent is the inlined copy. All must carry every token.
+CARRIERS = (
+    ARCHITECT / ".apm" / "skills" / "architect-review" / "SKILL.md",
+    ARCHITECT / ".apm" / "skills" / "architect-review" / "references" / "rubric-well-architected.md",
+    ARCHITECT / ".apm" / "agents" / "design-reviewer.md",
+)
+
+
+class ArchitectRubricParityTests(unittest.TestCase):
+    def test_every_carrier_exists(self) -> None:
+        for path in CARRIERS:
+            with self.subTest(path=str(path)):
+                self.assertTrue(path.exists(), f"rubric carrier missing: {path}")
+
+    def test_interop_tokens_consistent_across_carriers(self) -> None:
+        for path in CARRIERS:
+            text = path.read_text(encoding="utf-8")
+            for token in ALL_TOKENS:
+                with self.subTest(carrier=path.name, token=token):
+                    self.assertIn(
+                        token,
+                        text,
+                        f"{path.name} is missing interop token {token!r} — the "
+                        f"design-reviewer agent and architect-review must share "
+                        f"one verdict / severity / mechanical-judgment vocabulary; "
+                        f"reconcile the rename across all carriers and the "
+                        f"canonical constants in this test.",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this change?

Closes the two deferred `quality-engineer` follow-ons from the `architect-design-reviewer` feature (RFC-0032), and refreshes the two now-stale root-README pack rows. Test/CI + docs only — no runtime or pack-content change.

## Why?

The two findings were recorded in `docs/backlog.md` as deliberate deferrals when RFC-0032 shipped; this lands them. The README rows hadn't kept up with what the packs actually ship.

## How do I verify it?

**Follow-ons** (`packages/agentbundle/agentbundle/build/tests/`):
- `test_architect_design_reviewer_rubric_parity.py` (new) — pins the verdict / severity / 🔧🧭 mechanical-judgment vocabulary across the `design-reviewer` agent and `architect-review`'s canonical `SKILL.md` + `rubric-well-architected.md`. The interop tokens are what `architect-design`'s convergence loop routes on; the test's canonical constants force a clean rename to reconcile across every carrier at once. Mutation-checked: a drifted token fails 3/3 carriers.
- `test_architect_design_reviewer_projection.py` — adds a cursor-only `assertIn("readonly", …)`, tying AC5's read-only contract to its projected enforcement (cursor encodes read-only as a frontmatter flag).
- Both wired into `build-check.yml` (the `build/tests` root isn't auto-discovered). Run: `python -m pytest agentbundle/build/tests/test_architect_design_reviewer_{projection,rubric_parity}.py` → 5 passed.

**README** (`README.md`): architect row now names the `design-reviewer` subagent; product-engineering row adds `voice-and-microcopy` and `align-value-stream` (it had only the three intent-shaping skills).

## What did you not change that you considered?

- **Not a new `tools/` lint** for rubric parity — a test in the already-CI-wired `build/tests` root is the proportionate guard for a small fixed token set (the `knowledge-surface` parity *lint* guards a complex 8-row table across 4 copies; different complexity, different tool).
- **No changelog entry** — these are test/CI guards + a doc refresh, no user-visible behavior change.
- **Substring vs. word-boundary matching** — the parity guard catches a clean rename/drop (the realistic drift); the docstring states the two by-design limits (reword-into-superstring, allowlist growth) rather than overclaiming.

---

## Checklist

- [x] Tests pass locally — 5 guard tests green; `lint-packs`, `lint-spec-status` clean
- [x] Lint and typecheck pass
- [x] Self-review run — `adversarial-reviewer` → 2 docstring-accuracy findings, applied; no blockers
- [x] Spec and code agree — closes backlog items recorded under the Shipped `architect-design-reviewer` spec
- [x] Living docs match reality — root README refreshed; backlog entries removed
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured — n/a (covered by existing memory)