### PR TITLE
feat(core): make real-user verification first-class for non-UI tools (core 0.4.9)

### DIFF
--- a/.agents/skills/work-loop/SKILL.md
+++ b/.agents/skills/work-loop/SKILL.md
@@ -165,21 +165,32 @@ For anything beyond trivial, *think before you write code*. Concretely:
     contract; verify with a one-liner (build command, `grep`, typecheck)
     instead of a test file. Don't write a test that just asserts what
     the compiler already proves.
-  - **Visual / manual QA** — UI rendering, end-to-end UX flows. The task
-    records the manual check explicitly. For user-facing flows that are
-    part of the spec's contract, the verification artifact — automated or
-    manual — should simulate the user's gesture and assert *what the user
-    actually sees* (rendered text, visible elements, navigation), not
-    internal state (store contents, mock-call counts, context-provider
-    values). A test that passes when the on-screen result is wrong is
-    mode-mismatched, regardless of which framework wrote it. Add
-    automation when the regression cost (UI bugs ship invisibly) outweighs
-    the cost (flakiness, framework brittleness); the choice of tool is the
-    adopter's. A third flavor — *exploratory / visual fuzz* — drives the
-    UI with varied or random input and asserts **invariants** ("didn't
-    crash, didn't render garbage, layout holds, no overflow") rather than
-    specific outputs. Reach for it when the failure mode is open-ended and
-    you can't enumerate the gestures up front.
+  - **Visual / manual QA** — UI rendering and end-to-end UX flows, **and any
+    other artifact a user invokes directly**: a CLI, a library's public API, an
+    agent or skill, a service endpoint. The task records the manual check
+    explicitly. **When a change ships something a user invokes, verification
+    includes exercising the real built artifact end-to-end the way a user
+    would — through the documented happy path — and recording what you
+    observed**: the actual stdout and exit code, the returned value, the file
+    written, the on-screen result. Assert on that observed result, not on
+    internal state (store contents, mock-call counts, context-provider values),
+    and don't let a passing unit gate stand in for the real invocation. A test
+    or check that passes while the artifact, run as documented, produces the
+    wrong result is mode-mismatched, regardless of which framework wrote it.
+    For UI flows "what you observed" is *what the user actually sees* (rendered
+    text, visible elements, navigation); for a CLI it's the command's real
+    output and exit status; for a library it's the public call's result and
+    effects through its documented entry point, not a private internal. This is
+    **harness-agnostic doctrine** — exercise the artifact by hand on any agent;
+    in Claude Code the native `/verify` and `/run` commands perform it, an
+    optional accelerant and never a dependency, so adapters without them lose
+    only the shortcut, not the step. Add automation when the regression cost (a
+    broken invocation ships invisibly) outweighs the cost (flakiness,
+    brittleness); the choice of tool is the adopter's. A third flavor —
+    *exploratory / visual fuzz* — drives the UI with varied or random input and
+    asserts **invariants** ("didn't crash, didn't render garbage, layout holds,
+    no overflow") rather than specific outputs. Reach for it when the failure
+    mode is open-ended and you can't enumerate the gestures up front.
 
   Spikes and throwaway exploration are out of scope.
 - **Design tests up front, before any code.** The contract lives in
@@ -304,8 +315,9 @@ Match the discipline to the verification mode you picked during PLAN:
   3. Refactor with the test as your safety net. Commit.
 - **Goal-based check** — write the code, then run the one-liner from
   `Done when:`. No production test file.
-- **Visual / manual QA** — implement, then run the manual check recorded
-  in the task. Record the result.
+- **Visual / manual QA** — implement, then exercise the built artifact
+  end-to-end through the documented workflow recorded in the task, and
+  record what you observed (real output, not internal state).
 
 For each task, implement the smallest coherent unit of work toward the
 goal. Resist the urge to fix unrelated things you notice along the way;
@@ -630,6 +642,10 @@ mode below, then evaluate the terminal-state bullet last.
   `adversarial-reviewer` pass, with no `loop-cohort` involved. The doc-drift
   invariants and `lint-spec-status.py` still apply.)
   - GATES were clean (lint, typecheck, tests).
+  - **If the change ships something a user invokes** (a CLI, a library's
+    public API, an agent, a UI), the real built artifact was exercised
+    end-to-end through its documented happy path and the observed result
+    recorded — a passing unit gate alone does not satisfy this.
   - For each reviewer the diff warranted (`adversarial-reviewer`
     always; `security-reviewer` on security-boundary diffs;
     `quality-engineer` on every loop, plus a whole-spec pass on the

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -86,7 +86,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "core",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.4.8"
+      "version": "0.4.9"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -165,21 +165,32 @@ For anything beyond trivial, *think before you write code*. Concretely:
     contract; verify with a one-liner (build command, `grep`, typecheck)
     instead of a test file. Don't write a test that just asserts what
     the compiler already proves.
-  - **Visual / manual QA** — UI rendering, end-to-end UX flows. The task
-    records the manual check explicitly. For user-facing flows that are
-    part of the spec's contract, the verification artifact — automated or
-    manual — should simulate the user's gesture and assert *what the user
-    actually sees* (rendered text, visible elements, navigation), not
-    internal state (store contents, mock-call counts, context-provider
-    values). A test that passes when the on-screen result is wrong is
-    mode-mismatched, regardless of which framework wrote it. Add
-    automation when the regression cost (UI bugs ship invisibly) outweighs
-    the cost (flakiness, framework brittleness); the choice of tool is the
-    adopter's. A third flavor — *exploratory / visual fuzz* — drives the
-    UI with varied or random input and asserts **invariants** ("didn't
-    crash, didn't render garbage, layout holds, no overflow") rather than
-    specific outputs. Reach for it when the failure mode is open-ended and
-    you can't enumerate the gestures up front.
+  - **Visual / manual QA** — UI rendering and end-to-end UX flows, **and any
+    other artifact a user invokes directly**: a CLI, a library's public API, an
+    agent or skill, a service endpoint. The task records the manual check
+    explicitly. **When a change ships something a user invokes, verification
+    includes exercising the real built artifact end-to-end the way a user
+    would — through the documented happy path — and recording what you
+    observed**: the actual stdout and exit code, the returned value, the file
+    written, the on-screen result. Assert on that observed result, not on
+    internal state (store contents, mock-call counts, context-provider values),
+    and don't let a passing unit gate stand in for the real invocation. A test
+    or check that passes while the artifact, run as documented, produces the
+    wrong result is mode-mismatched, regardless of which framework wrote it.
+    For UI flows "what you observed" is *what the user actually sees* (rendered
+    text, visible elements, navigation); for a CLI it's the command's real
+    output and exit status; for a library it's the public call's result and
+    effects through its documented entry point, not a private internal. This is
+    **harness-agnostic doctrine** — exercise the artifact by hand on any agent;
+    in Claude Code the native `/verify` and `/run` commands perform it, an
+    optional accelerant and never a dependency, so adapters without them lose
+    only the shortcut, not the step. Add automation when the regression cost (a
+    broken invocation ships invisibly) outweighs the cost (flakiness,
+    brittleness); the choice of tool is the adopter's. A third flavor —
+    *exploratory / visual fuzz* — drives the UI with varied or random input and
+    asserts **invariants** ("didn't crash, didn't render garbage, layout holds,
+    no overflow") rather than specific outputs. Reach for it when the failure
+    mode is open-ended and you can't enumerate the gestures up front.
 
   Spikes and throwaway exploration are out of scope.
 - **Design tests up front, before any code.** The contract lives in
@@ -304,8 +315,9 @@ Match the discipline to the verification mode you picked during PLAN:
   3. Refactor with the test as your safety net. Commit.
 - **Goal-based check** — write the code, then run the one-liner from
   `Done when:`. No production test file.
-- **Visual / manual QA** — implement, then run the manual check recorded
-  in the task. Record the result.
+- **Visual / manual QA** — implement, then exercise the built artifact
+  end-to-end through the documented workflow recorded in the task, and
+  record what you observed (real output, not internal state).
 
 For each task, implement the smallest coherent unit of work toward the
 goal. Resist the urge to fix unrelated things you notice along the way;
@@ -630,6 +642,10 @@ mode below, then evaluate the terminal-state bullet last.
   `adversarial-reviewer` pass, with no `loop-cohort` involved. The doc-drift
   invariants and `lint-spec-status.py` still apply.)
   - GATES were clean (lint, typecheck, tests).
+  - **If the change ships something a user invokes** (a CLI, a library's
+    public API, an agent, a UI), the real built artifact was exercised
+    end-to-end through its documented happy path and the observed result
+    recorded — a passing unit gate alone does not satisfy this.
   - For each reviewer the diff warranted (`adversarial-reviewer`
     always; `security-reviewer` on security-boundary diffs;
     `quality-engineer` on every loop, plus a whole-spec pass on the

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -48,6 +48,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is the ceiling" scopes the core code-review lenses, not opt-in design-side
   review.
 
+- **`work-loop` makes "run it as a real user" first-class for non-UI tools (core 0.4.9).**
+  The manual-QA verification mode was framed almost entirely around UI rendering
+  and UX flows; it now explicitly covers any artifact a user invokes — a CLI, a
+  library's public API, an agent or skill, a service endpoint. The doctrine:
+  when a change ships something a user invokes, verification includes exercising
+  the real built artifact end-to-end through its documented happy path and
+  recording what you observed (real stdout/exit code, returned value, file
+  written, on-screen result), not internal state or a unit gate standing in for
+  the real invocation. Framed harness-agnostic like the EXECUTE simplify pass —
+  done by hand on any agent, with Claude Code's native `/verify` and `/run` as
+  an optional accelerant. The DECIDE end-of-session checklist gains a line that
+  refuses "done" until that end-to-end exercise has happened. Existing
+  UI-specific guidance is preserved as the UI instantiation of the general rule.
+
 - **`architect-diagram` learns deliberate visual encoding (architect 0.5.3).**
   A new `references/visual-encoding.md` turns scattered correctness rules into
   one design heuristic: when a diagram distinguishes more than one category of

--- a/docs/specs/work-loop-user-level-verification/plan.md
+++ b/docs/specs/work-loop-user-level-verification/plan.md
@@ -1,0 +1,63 @@
+# Plan: work-loop-user-level-verification
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Shipped
+
+## Approach
+
+One shipped skill, three localized edits, no new artifact. The audit
+(recorded in the spec's Objective) established the gap is the *framing* of the
+existing manual-QA mode, not a missing mode — so the plan broadens that mode
+and adds a DECIDE checklist line, then reprojects.
+
+Declined patterns:
+
+- *Tempted to add a fourth "tool/CLI verification" mode; declining* — the
+  reflex belongs inside manual QA, and a fourth mode would split one concept
+  ("exercise the real artifact as a user would") across two modes by surface
+  type. Surfaced as an Ask-first boundary.
+- *Tempted to reference the `/verify` skill as a primitive; declining* — it
+  isn't shipped by `core`; the only sanctioned reference is the harness-native
+  command, framed as the simplify pass frames `/simplify`.
+- *Tempted to write a unit test asserting the prose; declining* — goal-based
+  task; grep + review + the projection lint cover it without pinning wording.
+
+## Constraints
+
+- Self-hosting: edit `packs/core/.apm/...` source, never the projected
+  `.claude/...` copy; `make build-self` after.
+- Version-bump collision: this PR and the retcon-lint PR both bump `core`;
+  sequence the bumps (this one to the next patch, retcon-lint to the one after).
+
+## Tasks
+
+### Task 1 — broaden the manual-QA mode and add the DECIDE line
+
+- **Depends on:** none
+- **Verification mode:** goal-based
+- **Done when:** the PLAN verification-mode picker's third mode names CLI /
+  library API / agent as in-scope and states the exercise-and-observe doctrine
+  with harness-agnostic `/verify` framing (AC1–AC4); the DECIDE checklist
+  carries the refuse-until-exercised line (AC5); the EXECUTE per-mode bullet
+  reinforces "exercise the artifact, record what you observed".
+- **Tests:** `no stub (goal-based)`. Verify by `grep` + reading the edited
+  source in context.
+- **Approach:** edit `packs/core/.apm/skills/work-loop/SKILL.md` in place
+  (three spots: PLAN picker, EXECUTE per-mode discipline, DECIDE checklist).
+
+### Task 2 — reproject and bump
+
+- **Depends on:** Task 1
+- **Verification mode:** goal-based
+- **Done when:** `make build-self` regenerates the projected skill with no other
+  drift; `packs/core` version bumped in `pack.toml` + `plugin.json`; changelog
+  `[Unreleased]` entry added; `make build-check`, `tools/lint-agent-artifacts.py`
+  green; `git status` clean (AC6).
+- **Tests:** `no stub (goal-based)`. `make build-check` + projection lint are
+  the gate.
+
+## Changelog
+
+- Broadened `work-loop` manual-QA verification mode to cover any user-invoked
+  artifact and made "exercise the real artifact end-to-end and record what you
+  observed" a first-class expectation; added a DECIDE checklist line.

--- a/docs/specs/work-loop-user-level-verification/spec.md
+++ b/docs/specs/work-loop-user-level-verification/spec.md
@@ -1,0 +1,134 @@
+# Spec: work-loop-user-level-verification
+
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** RFC-0025 (work-loop light mode), ADR-0014
+- **Brief:** none
+- **Contract:** none
+- **Shape:** n/a — methodology/prose change (one shipped skill's doctrine); no application LLD
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+Agents running the `core` pack treat **"run it as a real user and report what
+you observed"** as a first-class verification expectation for any change that
+ships something a user invokes — not only for UIs.
+
+Today the `work-loop` skill defines three verification modes (TDD / goal-based /
+visual-manual-QA), but the manual-QA mode is framed almost entirely around UI
+rendering and UX flows: "what the user actually sees", "rendered text, visible
+elements, navigation", "UI bugs ship invisibly", "drives the UI". For
+user-facing artifacts that aren't UIs — a CLI, a library's public API, an agent
+or skill — the loop offers no default reflex to **actually invoke the built
+artifact end-to-end through its documented workflow and record the observed
+result**; it leans on unit gates, which can stay green while the real
+invocation is broken.
+
+Success is: the manual-QA mode's scope explicitly covers any user-invoked
+artifact (CLI, library API, agent, service, UI), states the
+exercise-the-real-artifact-and-record-what-you-observed doctrine, and the DECIDE
+end-of-session checklist carries a line that refuses "done" until that
+end-to-end exercise has happened when the change ships something a user invokes.
+The doctrine is **harness-agnostic** and framed like the EXECUTE simplify pass:
+done by hand on any agent, with an agent's own verify/run facility as an
+optional accelerant, never a dependency.
+
+The change edits the `core` pack source for the `work-loop` skill
+(`packs/core/.apm/skills/work-loop/SKILL.md`) and reprojects via
+`make build-self`. It adds **no executable code, no new skill, no new
+verification mode, and no new artifact type**.
+
+## Boundaries
+
+The three-tier guard that keeps an implementing agent inside the lines.
+*Always do* applies without asking; *Ask first* requires human sign-off
+before proceeding; *Never do* is a hard rule, even under time pressure.
+
+### Always do
+
+- Edit the **source** at `packs/core/.apm/skills/work-loop/SKILL.md`, then run
+  `make build-self` to regenerate the projected `.claude/skills/work-loop/SKILL.md`.
+- Keep the change **inside the existing manual-QA mode** — broaden its scope and
+  add a DECIDE checklist line; preserve the existing UI guidance (rendered text,
+  visible elements, navigation) and the exploratory-fuzz flavor as the UI
+  instantiation of the general doctrine.
+- Run all lint surfaces before declaring done: `make build-check` (includes
+  `lint-packs` and `validate`) and `python tools/lint-agent-artifacts.py`
+  (projection lint, not in build-check).
+- Bump `packs/core/pack.toml` and `packs/core/.claude-plugin/plugin.json` in
+  lockstep; add a `docs/product/changelog.md` `[Unreleased]` entry.
+
+### Ask first
+
+- Adding a **fourth verification mode** instead of broadening the third — out
+  of scope by decision; the audit found the gap is scope, not a missing mode.
+- Touching any skill other than `work-loop`.
+
+### Never do
+
+- Reference a "verify skill" or "run skill" as a `core`-pack primitive. Neither
+  is shipped by this repo; the only sanctioned references are to the Claude Code
+  **native** `/verify` and `/run` commands, framed as an optional accelerant
+  exactly as the simplify pass frames `/simplify`.
+- Make the end-to-end exercise contingent on a particular harness, command, or
+  automation tool. The doctrine must hold on an agent with no verify facility.
+
+## Acceptance Criteria
+
+- [x] **AC1 — manual-QA scope broadened.** The `work-loop` PLAN
+  verification-mode picker's third mode explicitly names artifacts a user
+  invokes beyond UIs (at minimum a CLI, a library's public API, and an
+  agent/skill) as in-scope for manual QA.
+- [x] **AC2 — exercise-and-observe doctrine stated.** The same mode states that
+  when a change ships something a user invokes, verification includes exercising
+  the real built artifact end-to-end through the documented happy path and
+  recording what was observed (real output: stdout/exit code, returned value,
+  file written, on-screen result) — explicitly *not* internal state
+  (mock-call counts, store contents) and *not* a unit gate standing in for the
+  real invocation.
+- [x] **AC3 — harness-agnostic framing.** The doctrine is labelled
+  harness-agnostic and framed as done by hand on any agent, naming the Claude
+  Code native `/verify` / `/run` commands as an optional accelerant and never a
+  dependency — mirroring the EXECUTE simplify pass. No "verify skill"
+  pack-primitive reference appears.
+- [x] **AC4 — UI guidance preserved.** The pre-existing UI-specific guidance
+  (assert what the user sees; rendered text / visible elements / navigation) and
+  the exploratory-fuzz flavor survive as the UI instantiation of the general
+  doctrine; nothing UI-only is lost.
+- [x] **AC5 — DECIDE checklist line.** The DECIDE end-of-session checklist
+  carries a line that refuses "done" until, when the change ships something a
+  user invokes, the real artifact was exercised end-to-end through its
+  documented happy path and the observed result recorded — a passing unit gate
+  alone does not satisfy it.
+- [x] **AC6 — projection regenerated, gates green.** `make build-self`
+  regenerates the projected skill; `git status` is clean; `lint-packs`,
+  `validate`, and `tools/lint-agent-artifacts.py` pass; `packs/core` version is
+  bumped in `pack.toml` + `plugin.json` and the changelog carries an
+  `[Unreleased]` entry.
+
+## Testing Strategy
+
+Goal-based verification (prose/doctrine change to one shipped skill; no
+executable code). "Done" is checked mechanically and by reading:
+
+- **AC1–AC5** — `grep` the edited source for the broadened scope, the
+  exercise-and-observe sentence, the `/verify` accelerant framing, the surviving
+  UI clauses, and the DECIDE checklist line; read each in context to confirm
+  intent (a grep hit is necessary, not sufficient).
+- **AC6** — `make build-self` then `git status --porcelain` is empty after
+  staging; `make build-check` green; `python tools/lint-agent-artifacts.py`
+  green; `grep` the bumped version in both manifests.
+
+No construction test file — this is a goal-based task; a unit test asserting on
+prose would pin wording the linter and review already cover.
+
+## Assumptions
+
+- The verification-mode picker stays a **three-mode** taxonomy; the gap is the
+  third mode's framing, confirmed by reading the source (manual-QA was UI-only).
+- `/verify` and `/run` are Claude Code **native** commands (an agent facility),
+  not `core`-pack primitives — so referencing them mirrors the sanctioned
+  `/simplify` precedent already in the skill's EXECUTE simplify pass.

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -165,21 +165,32 @@ For anything beyond trivial, *think before you write code*. Concretely:
     contract; verify with a one-liner (build command, `grep`, typecheck)
     instead of a test file. Don't write a test that just asserts what
     the compiler already proves.
-  - **Visual / manual QA** — UI rendering, end-to-end UX flows. The task
-    records the manual check explicitly. For user-facing flows that are
-    part of the spec's contract, the verification artifact — automated or
-    manual — should simulate the user's gesture and assert *what the user
-    actually sees* (rendered text, visible elements, navigation), not
-    internal state (store contents, mock-call counts, context-provider
-    values). A test that passes when the on-screen result is wrong is
-    mode-mismatched, regardless of which framework wrote it. Add
-    automation when the regression cost (UI bugs ship invisibly) outweighs
-    the cost (flakiness, framework brittleness); the choice of tool is the
-    adopter's. A third flavor — *exploratory / visual fuzz* — drives the
-    UI with varied or random input and asserts **invariants** ("didn't
-    crash, didn't render garbage, layout holds, no overflow") rather than
-    specific outputs. Reach for it when the failure mode is open-ended and
-    you can't enumerate the gestures up front.
+  - **Visual / manual QA** — UI rendering and end-to-end UX flows, **and any
+    other artifact a user invokes directly**: a CLI, a library's public API, an
+    agent or skill, a service endpoint. The task records the manual check
+    explicitly. **When a change ships something a user invokes, verification
+    includes exercising the real built artifact end-to-end the way a user
+    would — through the documented happy path — and recording what you
+    observed**: the actual stdout and exit code, the returned value, the file
+    written, the on-screen result. Assert on that observed result, not on
+    internal state (store contents, mock-call counts, context-provider values),
+    and don't let a passing unit gate stand in for the real invocation. A test
+    or check that passes while the artifact, run as documented, produces the
+    wrong result is mode-mismatched, regardless of which framework wrote it.
+    For UI flows "what you observed" is *what the user actually sees* (rendered
+    text, visible elements, navigation); for a CLI it's the command's real
+    output and exit status; for a library it's the public call's result and
+    effects through its documented entry point, not a private internal. This is
+    **harness-agnostic doctrine** — exercise the artifact by hand on any agent;
+    in Claude Code the native `/verify` and `/run` commands perform it, an
+    optional accelerant and never a dependency, so adapters without them lose
+    only the shortcut, not the step. Add automation when the regression cost (a
+    broken invocation ships invisibly) outweighs the cost (flakiness,
+    brittleness); the choice of tool is the adopter's. A third flavor —
+    *exploratory / visual fuzz* — drives the UI with varied or random input and
+    asserts **invariants** ("didn't crash, didn't render garbage, layout holds,
+    no overflow") rather than specific outputs. Reach for it when the failure
+    mode is open-ended and you can't enumerate the gestures up front.
 
   Spikes and throwaway exploration are out of scope.
 - **Design tests up front, before any code.** The contract lives in
@@ -304,8 +315,9 @@ Match the discipline to the verification mode you picked during PLAN:
   3. Refactor with the test as your safety net. Commit.
 - **Goal-based check** — write the code, then run the one-liner from
   `Done when:`. No production test file.
-- **Visual / manual QA** — implement, then run the manual check recorded
-  in the task. Record the result.
+- **Visual / manual QA** — implement, then exercise the built artifact
+  end-to-end through the documented workflow recorded in the task, and
+  record what you observed (real output, not internal state).
 
 For each task, implement the smallest coherent unit of work toward the
 goal. Resist the urge to fix unrelated things you notice along the way;
@@ -630,6 +642,10 @@ mode below, then evaluate the terminal-state bullet last.
   `adversarial-reviewer` pass, with no `loop-cohort` involved. The doc-drift
   invariants and `lint-spec-status.py` still apply.)
   - GATES were clean (lint, typecheck, tests).
+  - **If the change ships something a user invokes** (a CLI, a library's
+    public API, an agent, a UI), the real built artifact was exercised
+    end-to-end through its documented happy path and the observed result
+    recorded — a passing unit gate alone does not satisfy this.
   - For each reviewer the diff warranted (`adversarial-reviewer`
     always; `security-reviewer` on security-boundary diffs;
     `quality-engineer` on every loop, plus a whole-spec pass on the

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr + session-start hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "0.4.8"
+version = "0.4.9"
 description = "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr + session-start hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 readme = "README.md"
 display_name = "Core"


### PR DESCRIPTION
## What does this change?

Broadens `work-loop`'s third verification mode (Visual / manual QA) so that **"exercise the real built artifact end-to-end as a user would, through the documented happy path, and record what you observed"** is a first-class expectation for *any* user-invoked artifact — a CLI, a library's public API, an agent or skill, a service — not only UIs. Adds a DECIDE end-of-session checklist line that refuses "done" until that end-to-end exercise has happened.

## Why?

The manual-QA mode was framed almost entirely around UI rendering and UX flows ("rendered text, visible elements, navigation", "UI bugs ship invisibly"). For user-facing tools that aren't UIs, the loop had no default reflex to actually invoke the built artifact through a documented workflow — it leaned on unit gates, which can stay green while the real invocation is broken. The doctrine is framed harness-agnostic, exactly like the EXECUTE simplify pass: done by hand on any agent, with Claude Code's native `/verify` and `/run` as an optional accelerant, never a dependency.

- Implements: docs/specs/work-loop-user-level-verification/spec.md

## How do I verify it?

- Read `packs/core/.apm/skills/work-loop/SKILL.md` (the source); the `.claude/` and `.agents/` copies are generated projections and are byte-identical (`make build-self`).
- `make build-check` (lint-packs + validate) and `python tools/lint-agent-artifacts.py` both pass.
- Spec ACs AC1–AC6 each map to an artifact; adversarial-reviewer reached `Clean — ready to commit.`

## What did you not change that you considered?

- **No fourth verification mode.** The gap was the third mode's framing, not a missing mode; a fourth would split "exercise the real artifact as a user would" across two modes by surface type.
- **No "verify skill" pack-primitive reference.** `/verify` and `/run` are Claude Code native commands (an accelerant), not core-pack primitives — referenced exactly as `/simplify` already is.
- **Did not generalize the exploratory-fuzz flavor.** An earlier draft renamed "visual fuzz" → "fuzz", which desynced the term from three sibling agents and broke the repo's deliberate split (non-UI invariant fuzzing belongs in construction tests / TDD; the manual-QA fuzz flavor is the UI counterpart). Reverted — the broadening lives entirely in the main exercise-and-observe doctrine.
- **Did not touch sibling agent files.** Scoped to the `work-loop` skill per the spec.

## Checklist

- [x] Tests pass locally (`make build-check`)
- [x] Lint and typecheck pass (`lint-packs`, `validate`, `tools/lint-agent-artifacts.py`)
- [x] Self-review run via `adversarial-reviewer` — reached Clean; no security boundary crossed
- [x] Spec and code agree (spec landed in this PR, all ACs `[x]`)
- [x] Living docs match reality: `docs/product/changelog.md` updated; no guide/architecture/roadmap change needed (internal methodology prose)
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured (the rename-induced sibling desync is noted above and resolved)