### PR TITLE
docs(readme): call out the new design-craft pack in the catalogue table

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ A fourth subagent, `implementer`, is the loop's own executor. It runs independen
 | [`figma`](docs/guides/figma/) | user / repo | Figma REST primitive (credentialed) — reads files/nodes/comments/variables, renders frames, FigJam → Mermaid. |
 | [`architect`](docs/guides/architect/) | user / repo | Solution architecture — `architect-design`, `architect-diagram`, `architect-review`, plus a read-only, forked-context `design-reviewer` subagent for independent design critique. |
 | [`product-engineering`](docs/guides/product-engineering/) | user / repo | Shape product intent into shippable specs — `frame-intent`, `de-risk-intent`, `decompose-intent` over a recursive, level-tagged `intent`; `voice-and-microcopy` for UI copy (error/empty/button/label) against a voice chart; and `align-value-stream` for the business-unit cross-component value-stream layer. Feeds the briefs/specs your delivery loop already builds. |
+| [`design-craft`](docs/guides/design-craft/) | user / repo | Framework-agnostic design discipline — `aesthetic-direction`, `design-system-foundations`, `layout-and-information-architecture`, `design-critique`, plus a shared `quality-floor` checklist. Authors the upstream design intent the build consumes; points to WCAG / W3C Design Tokens, never a stack or a values table. |
 
 Repo-scope packs install into the current repo and build on `core`. User-scope packs install into `~/.claude/` (or your harness's home root) and follow you across every project. Swap `core` for any pack name in the command above.
 


### PR DESCRIPTION
## What & why

The `design-craft` pack shipped in #324 (RFC-0033) but wasn't listed in the root README's catalogue table. This adds a `user / repo` row for it, placed next to its design-side twin `product-engineering`.

## Scope

One table row in `README.md`. The pack itself, its guides, ADR-0024, and the changelog entry all landed in #324; this is the front-page surfacing only. Repo-owned README (not a build-self projection), edited directly per the #322 precedent.

## Review questions

- **What?** One catalogue-table row for `design-craft` in the root README.
- **Why?** Discoverability — the pack was live but invisible on the front page.
- **Tested?** Doc-only; CI drift/lint gates apply.
- **Risks?** None — additive doc change.