### PR TITLE
feat(agentbundle): add `design` to the soft categories vocabulary (RFC-0031 D8)

### DIFF
--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`design` joins the soft `categories` vocabulary.** `agentbundle validate`
+  now recognizes `design` as a known pack category, so the `design-craft` pack
+  (and any future design pack) declares it without a soft warning. The
+  vocabulary is extensible by design (RFC-0031 D8) — this grows it by one slug,
+  no RFC required, no behavior change for any other pack.
+
 - **New `design-craft` pack for interaction/visual designers (design-craft
   0.1.0).** An opt-in, user-scope pack of four pure-markdown skills —
   `aesthetic-direction` (turn a vague vibe into named, ranked goals),

--- a/packages/agentbundle/agentbundle/categories.py
+++ b/packages/agentbundle/agentbundle/categories.py
@@ -13,13 +13,16 @@ single source of truth the validate command reads.
 
 from __future__ import annotations
 
-# The ~16 default slugs (RFC-0031 D3). Soft: unknown slugs warn, never fail.
+# The default slugs: the RFC-0031 D3 baseline (~16) plus `design` (added for
+# the design-craft pack). Soft and extensible by design (RFC-0031 D8) — unknown
+# slugs warn, never fail — so the list grows without an RFC.
 DEFAULT_CATEGORIES: frozenset[str] = frozenset(
     {
         "code-review",
         "testing",
         "documentation",
         "architecture",
+        "design",
         "security",
         "research",
         "product-management",

--- a/packages/agentbundle/tests/unit/test_validate_categories.py
+++ b/packages/agentbundle/tests/unit/test_validate_categories.py
@@ -64,8 +64,10 @@ def test_no_categories_is_silent_exit_0(tmp_path):
     assert "warning" not in stderr.lower()
 
 
-def test_default_vocabulary_has_the_sixteen_rfc_0031_slugs():
-    expected = {
+def test_default_vocabulary_is_the_rfc_0031_baseline_plus_design():
+    # The RFC-0031 D3 baseline. The vocabulary is soft and extensible (D8),
+    # so it grows without an RFC — `design` was added for the design-craft pack.
+    rfc_0031_baseline = {
         "code-review",
         "testing",
         "documentation",
@@ -83,5 +85,7 @@ def test_default_vocabulary_has_the_sixteen_rfc_0031_slugs():
         "data",
         "ai-agent",
     }
-    assert set(DEFAULT_CATEGORIES) == expected
-    assert len(DEFAULT_CATEGORIES) == 16
+    assert rfc_0031_baseline <= set(DEFAULT_CATEGORIES)
+    assert "design" in DEFAULT_CATEGORIES
+    assert set(DEFAULT_CATEGORIES) == rfc_0031_baseline | {"design"}
+    assert len(DEFAULT_CATEGORIES) == 17


### PR DESCRIPTION
## What & why

The `design-craft` pack (#324) declares `categories = ["design", "documentation"]`. `design` wasn't in the soft default vocabulary, so `agentbundle validate` emitted an unknown-slug **warning** (exit 0 — non-gating, but noise). RFC-0031 D8 designed this vocabulary to be **extensible without an RFC** ("the list can grow… we do not control it as a hard registry"), so this adds `design` as a first-class slug.

## Changes

- `agentbundle/categories.py` — add `design` to `DEFAULT_CATEGORIES`.
- `tests/unit/test_validate_categories.py` — update the exact-set contract test (RFC-0031 baseline + `design` = 17; asserts the baseline as a subset so the provenance stays legible).
- `docs/product/changelog.md` — `[Unreleased]` entry.

## Review questions

- **What?** One new slug in the soft category vocabulary.
- **Why?** `design-craft` declares it; D8 sanctions growth without an RFC.
- **Tested?** Updated unit test passes; no behavior change for any other pack (a previously-unknown slug becoming known only removes a warning).
- **Risks?** None — additive, soft vocabulary, fully reversible.