### PR TITLE
release(agentbundle): 0.4.0 — enriched pack.toml metadata + design category

### DIFF
--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -6,6 +6,37 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 — a minor bump on a 0.x release MAY be breaking.
 
+## [0.4.0] — 2026-06-14
+
+### Added
+
+- **`pack.toml` is the rich source of truth for pack metadata** (RFC-0031,
+  adapter contract v0.14). A pack may now declare `license`,
+  `[[pack.maintainers]]`, `[pack.links]`, `categories`, `keywords`, a `readme`
+  pointer, and a `[pack.metadata.<tool>]` escape hatch. The build projects the
+  cleanly-mappable subset — plus the pack's `README.md` — into each
+  distribution route's manifest (`plugin.json` / `marketplace.json` entry), so
+  a catalogue describes each pack richly instead of with one sentence. **All new
+  fields are optional**; packs pinned below contract v0.14 are unaffected.
+- **Soft `categories` vocabulary** — `agentbundle validate` recognizes a
+  default set of category slugs and emits a **warning (exit 0)**, never an
+  error, on an unknown slug. The vocabulary is extensible by design (RFC-0031
+  D8); `design` is included for the `design-craft` pack.
+- **`list-packs` surfaces the enriched metadata** so a catalogue is browsable
+  by more than name and a one-line description.
+
+### Changed
+
+- **Pack and plugin-manifest JSON schemas accept the optional enriched fields**
+  (the `additionalProperties: false` gate on both manifest schemas was relaxed
+  for the projectable metadata subset).
+
+### Fixed
+
+- **`build-self` no longer emits untracked per-quadrant guide READMEs.** The
+  self-host projection skips `docs/guides/**` (adopters still receive guide
+  scaffolds via seed delivery).
+
 ## [0.3.1] — 2026-06-12
 
 ### Changed

--- a/packages/agentbundle/README.md
+++ b/packages/agentbundle/README.md
@@ -45,12 +45,17 @@ my-pack/
   pack.toml                  # name, version, adapter-contract, install scope,
                              # plus rich metadata (license, maintainers, links,
                              # categories, keywords) and a README pointer
+  .claude-plugin/
+    plugin.json              # Claude Code plugin manifest (hand-authored)
   README.md                  # the pack's portable doc — projected with the pack
-  .apm/
-    skills/<name>/SKILL.md    # one folder per skill
-    agents/<name>.md          # subagents
-    hooks/<name>.py           # lifecycle hooks
-  seeds/                      # files scaffolded into the adopter repo
+  .apm/                      # primitives — projected by the build pipeline
+    skills/<name>/
+      SKILL.md               # the skill body; one folder per skill
+      references/            # progressive-disclosure docs, loaded on demand
+      assets/                # templates the skill copies into the repo
+    agents/<name>.md         # subagents
+    hooks/<name>.py          # lifecycle hooks
+  seeds/                     # files scaffolded into the adopter repo
 ```
 
 `pack.toml` is the **single source of truth** for a pack's metadata. Declare

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentbundle"
-version = "0.3.1"
+version = "0.4.0"
 description = "npm for your coding agent. Install packs of skills, subagents, and hooks into any repo, for every major agent."
 requires-python = ">=3.11"
 dependencies = []


### PR DESCRIPTION
## What & why

Cuts **agentbundle 0.4.0** (from 0.3.1), bundling every `packages/agentbundle` change since the `agentbundle-v0.3.1` tag. Backward-compatible **minor** bump — the contract went v0.13→v0.14 with all new fields optional, so packs pinned below v0.14 are unaffected.

## Changes in this release

- **`pack.toml` is the rich metadata source of truth** (RFC-0031, contract v0.14) — `license`, `[[maintainers]]`, `[pack.links]`, `categories`, `keywords`, `[pack.metadata.<tool>]` + README pointer, projected into `plugin.json`/`marketplace.json` entries.
- **Soft `categories` vocabulary** — `validate` warns (exit 0) on unknown slugs; `design` added for the design-craft pack (#326).
- **`list-packs` surfaces the enriched metadata**; manifest JSON schemas relaxed for the optional fields.
- **Fixed:** `build-self` no longer emits untracked per-quadrant guide READMEs.

## This PR

- `pyproject.toml` `0.3.1 → 0.4.0` (the version the release tag asserts against).
- `CHANGELOG.md` `[0.4.0]` section.
- `README.md` (the PyPI long description) — example pack layout updated to the **enriched** structure: `.claude-plugin/plugin.json` + the skill `references/` and `assets/` dirs.

## Verification

Local mirror of the release CI's build-and-smoke: `python -m build` → wheel + sdist at 0.4.0, `twine check` PASSED, fresh-venv install + `from agentbundle.cli import main` + `agentbundle --help` OK, reports 0.4.0. Release-relevant pytest subset (pack/plugin-manifest schema, projectable-subset, contract, categories, enriched-metadata, list-packs) green.

## Publish path (after merge)

Tag `agentbundle-v0.4.0` on the merge commit and push → `release-agentbundle.yml` asserts tag==pyproject version + tag-on-main, builds, smoke-tests, and publishes to PyPI via trusted publishing. **The tag push is the irreversible publish trigger — I'll confirm before pushing it.**

## Review questions

- **What?** Cut agentbundle 0.4.0 + refresh the PyPI README layout.
- **Why?** Ship the enriched-metadata + categories work (incl. `design`) accumulated since 0.3.1.
- **Tested?** Local build/twine/smoke + pytest subset; CI release-agentbundle PR leg also runs on this PR.
- **Risks?** Minor, non-breaking (optional contract fields). The publish itself is gated on a deliberate tag push.