### PR TITLE
fix(agentbundle): make `kiro` install behave exactly like `kiro-ide` (RFC-0022 alias parity)

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -669,3 +669,24 @@ the citations sit in library-provenance docstrings rather than agent-facing
 prose, so they were left for a separate, deliberate pass that respects the
 freeze. Fold this into the `apm-leak-lint-rfc` work, or do it as a focused
 comment-only PR against the frozen pack with explicit sign-off.
+
+### upgrade-orphan-removal-on-projection-shape-change
+
+**Spec:** [kiro-install-alias-parity](specs/kiro-install-alias-parity/spec.md)
+AC8 (upgrade path). `agentbundle upgrade` re-renders the new projection and
+writes it, but has **no orphan-removal step**: a file present in the old
+`state.files` but absent from the new projection is left on disk (and in
+state). This surfaces when an agent's projected file *shape* changes across an
+upgrade — e.g. a legacy `kiro` install recorded `.kiro/agents/<n>.json`, and
+after this migration the `kiro` alias (= kiro-ide) re-renders `.kiro/agents/<n>.md`,
+leaving the stale `.json` orphaned. For kiro-ide this is harmful: the IDE loads
+**both** `.md` and `.json` agents, so the adopter ends up with a duplicate
+(and the stale `.json` still carries a `hooks` key). This is a **pre-existing,
+general** upgrade limitation, not specific to the alias migration; it is
+exposed by it. **Clean path today:** `uninstall` + reinstall (the uninstall
+migration is clean — see `LegacyKiroJsonUninstallMigrationTests`). **Unblocks
+when:** `upgrade` grows a Tier-1 orphan-removal pass (old `state.files` ∖ new
+projection), ordered correctly against the hook-wiring unproject (the orphaned
+agent JSON is also the old merge target) and gated to whole-pack (not
+`--<primitive>`) upgrades. Pinned by an `@unittest.expectedFailure` in
+`test_upgrade_user_hooks.py::LegacyKiroJsonUpgradeMigrationTests`.

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -17,6 +17,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`agentbundle install --adapter kiro` now behaves exactly like `kiro-ide`.**
+  The deprecated `kiro` alias (RFC-0022) was honored by `make build` but not by
+  the install path, which still emitted `.json` agents and merged hook-wiring —
+  the legacy behavior. Installing, upgrading, or uninstalling via `kiro` now
+  projects `.md` agents and **drops** hook-wiring (the IDE shape), consistent
+  with the build registry. The legacy `.json`-agents + hook-wiring-merge
+  behavior is unchanged — it lives under the `kiro-cli` adapter. The dropped-
+  primitives warning for `kiro` now names what is actually dropped (hook-wiring
+  and commands). `state.adapter` still records the name you chose (`kiro` stays
+  `kiro`), so the alias remains a working, named adapter. The `attach-to-agent`
+  validation and path-confinement rails now also fire for `kiro-cli`, so a
+  malformed or path-traversing wiring declaration is refused for the adapter
+  that performs the merge.
+
 ### Added
 
 - **`design` joins the soft `categories` vocabulary.** `agentbundle validate`

--- a/docs/specs/kiro-install-alias-parity/plan.md
+++ b/docs/specs/kiro-install-alias-parity/plan.md
@@ -1,0 +1,92 @@
+# Plan: kiro-install-alias-parity
+
+- **Spec:** [`spec.md`](spec.md)
+- **Mode:** full
+
+## Trio
+
+- **Files I'll touch:** `packages/agentbundle/agentbundle/commands/install.py` (projection dispatch — done; explicit-allowlist hook-wiring merge gate; drop-warning enumerate-canonical/display-original; pre-flight `:639` → merging adapter; a single `_canonical_install_adapter` helper); `packages/agentbundle/agentbundle/build/scope_rails.py` (merge-family membership for the two attach-to-agent rails); `packages/agentbundle/agentbundle/commands/validate.py` (`_kiro_target_adapters` recognizes `kiro-cli`); the two fixtures' `pack.toml` (`allowed-adapters` → `kiro-cli`); the integration + unit tests listed below; `docs/product/changelog.md`.
+- **What proves done:** the full `agentbundle` pytest suite is green, including (a) a new regression test that a `kiro`-alias user-scope install of a hook-wiring pack drops the wiring without crashing; (b) the retargeted `kiro-cli` suites pinning the legacy JSON + merge behavior with the rails still firing; (c) a new rail-fires-for-kiro-cli unit case; (d) a legacy-JSON-upgrade migration test.
+- **What I'm NOT changing:** the `adapter.toml` contract (no block edits, no `SPEC_VERSION` bump); the recorded-adapter identity (state stays `kiro`/`kiro-cli`); the build adapters (`kiro_ide.py` / `kiro_cli.py` / `kiro.py`).
+
+**Declined patterns.** Tempted to normalize `state.adapter` from `kiro`→`kiro-ide` at the resolver (one clean chokepoint); declining — it rewrites the adopter's chosen adapter identity, which RFC-0022 keeps as a named alias. Tempted to add an install-time deprecation-warning line for the `kiro` alias (mirroring the build registry's `DeprecationWarning`); declining — out of scope for "behave like kiro-ide", and adds stderr noise the tests would need to absorb. Tempted to make `_merge_user_scope_hook_wiring` *raise* on an unrecognized adapter (strict fail-closed); declining — returning `[]` (no spurious `.kiro/agents/*.json` write) is the safe behavior and raising risks breaking a legitimate-but-unmodeled adapter that ships user-scope hooks; the no-fall-through-to-Kiro-merge property is what the security finding actually required.
+
+> **Review note:** the pre-EXECUTE adversarial + security pass corrected an earlier "leave the rails alone" decision — retargeting the merge behavior to `kiro-cli` while the rails keyed on literal `"kiro"` would have silently dropped the install-time symlink / malformed-TOML / missing-`attach-to-agent` / path-traversal refusals for the merging adapter. The rails now recognize the merge family; the diff grows by a membership-set change in three call sites (no new abstraction).
+
+## Tasks
+
+### T1 — Projection dispatch routes `kiro` → kiro-ide + `_canonical_install_adapter` helper
+
+**Depends on:** none.
+
+**Mode:** TDD. **Done when:** a module-level `_canonical_install_adapter(adapter) -> str` (maps `"kiro"`→`"kiro-ide"`, else identity; single source for the alias in install.py, mirroring the registry's `_kiro_alias_project`) exists, and both `_render_for_user_scope` and `_render_for_repo_scope` dispatch on it (the routing half landed in the pre-spec spike as inline `in ("kiro","kiro-ide")`; refactor onto the helper here); unused `kiro` import dropped.
+
+**Tests:** `test_kiro_alias_projects_md_agents_not_json` (added) — `.md` agents, no `.json`. (AC1) + `state.adapter == "kiro"` assertion added in T5.
+
+**Approach:** Add the helper near the other adapter constants; replace the two inline `in ("kiro","kiro-ide")` dispatch checks with `_canonical_install_adapter(target_adapter) == "kiro-ide"`.
+
+### T2 — Hook-wiring merge: explicit adapter allowlist; drop for the kiro alias
+
+**Depends on:** T1 (`_canonical_install_adapter`).
+
+**Mode:** TDD. **Done when:** `_merge_user_scope_hook_wiring` dispatches on an explicit allowlist — copilot → `[]`; claude-code → settings merge; `_canonical_install_adapter(target_adapter) == "kiro-ide"` (i.e. `kiro`/`kiro-ide`) → `[]` (early, before parse/write); `kiro-cli` → the agent-JSON merge; any other adapter → `[]` (no fall-through to Kiro merge).
+
+**Tests:**
+- New: user-scope install (`--adapter kiro`) of a hook-wiring-bearing pack → rc 0, `.kiro/agents/<name>.md` exists, no `.json`, `hook_wiring_owned == []`. (AC2)
+- Existing `kiro-cli` retargeted suites still merge (AC4) — guards against over-gating.
+
+**Approach:** Reshape the trailing branch: add `if _canonical_install_adapter(target_adapter) == "kiro-ide": return []` ahead of the merge, change the merge guard to `if target_adapter == "kiro-cli":`, and end with `return []` for the unmodeled-adapter case, with a comment naming kiro-cli as the only agent-JSON merger **and why the fall-through returns empty** (no merge owner; avoids a spurious `.kiro/agents/*.json` write — a future adapter that ships user-scope hooks must add its own branch rather than silently riding this one).
+
+### T3 — Drop-warning: enumerate canonical, display the adopter's name
+
+**Depends on:** T1 (`_canonical_install_adapter`).
+
+**Mode:** TDD. **Done when:** the warning for a `kiro` install enumerates kiro-ide's drops (hook-wiring + command for `core`) but its text names `kiro`, not `kiro-ide`.
+
+**Tests:** New/extended assertion: the `kiro` drop-warning clause contains `hook-wiring` AND the message text contains `kiro` and not `kiro-ide`. (AC3)
+
+**Approach:** Give `_maybe_emit_dropped_warning` separate enumeration-vs-display adapters: enumerate dropped/compatible sets with `_canonical_install_adapter(adapter)` (kiro-ide), but pass the original `adapter` (`kiro`) as the display name into `format_drop_message`. `kiro-cli`/others: canonical == original, no change.
+
+### T4 — Merge-path rails recognize the merge family `{"kiro","kiro-cli"}`
+
+**Depends on:** none (independent of T1's helper; uses a scope_rails constant).
+
+**Mode:** TDD. **Done when:**
+- `check_kiro_attach_to_agent` (scope_rails ~328) and `check_kiro_wiring` (~488) fire on intersection with a module constant `_MERGE_INTO_AGENT_JSON_ADAPTERS = {"kiro", "kiro-cli"}`;
+- `validate._kiro_target_adapters` returns the merge-family members present in `allowed-adapters`, **and** the validate caller gate at `validate.py:196` fires on `target_adapters & _MERGE_INTO_AGENT_JSON_ADAPTERS` (not literal `"kiro"`), passing the resolved member into `enumerate_event_dropped_wirings` / `format_drop_message` at `:239`/`:245`;
+- the install pre-flight at `install.py:639` fires for `user_target_adapter == "kiro-cli"` (passing `{"kiro-cli"}`), not for the `kiro` alias, and its comment block (`:633-639`) is updated to say "fires for the merging adapter, not the `kiro` alias".
+
+**Tests:**
+- New unit case in `test_validate_attach_to_agent.py`: the in-memory rail + filesystem wrapper fire (refuse) for `{"kiro-cli"}`; existing `{"claude-code"}` no-op cases unchanged. (AC7)
+- New **end-to-end** `validate`-command test: a malformed-wiring `kiro-cli` pack fails `validate` (rc 1) — pins the `:196` caller gate, not just `_kiro_target_adapters`'s return value. (AC7)
+- The retargeted `AttachToAgentPathTraversalRefusedTests` (T5) exercises the pre-flight firing for kiro-cli end-to-end. (AC5)
+
+**Approach:** Replace the two literal `"kiro" not in set(...)` guards in scope_rails with `not (set(target_adapters or ()) & _MERGE_INTO_AGENT_JSON_ADAPTERS)`; in `validate._kiro_target_adapters` return `{a for a in ("kiro","kiro-cli") if a in allowed_strs}` (heuristic fall-through stays `{"kiro"}`); widen the `validate.py:196` gate + thread the resolved member through `:239`/`:245`; change `install.py:639` to the merging-adapter trigger + update its comment.
+
+### T5 — Retarget fixtures + tests to `kiro-cli`
+
+**Depends on:** T2, T4 (retargeted tests assert the new merge gate + rails behavior).
+
+**Mode:** TDD (the tests are the contract). **Done when:** the two fixtures declare `allowed-adapters = ["kiro-cli"]` and every legacy-behavior test installs via `kiro-cli`, with `state.adapter` expectations updated to `kiro-cli`.
+
+**Tests (retargeted):** `KiroUserHooksInstallTests`, `AttachToAgentPathTraversalRefusedTests` (strengthen: assert refusal names `attach-to-agent` AND no `tmp/escape*` file created), `KiroUserHooksUninstallTests` (×2), `UpgradeThenUninstallTests::test_kiro_install_upgrade_uninstall_removes_agent_file`, `AttachToAgentRenameTests`, `KiroPerFileDropEndToEnd`, `KiroWarningEndToEnd::test_kiro_warning_names_command_only`. (AC4, AC5, AC6) Also add a `state.adapter == "kiro"` assertion to `test_kiro_alias_*`.
+
+**Approach:** Flip `allowed-adapters` in `tests/fixtures/packs/{kiro-user-hooks,kiro-repo-hooks}/pack.toml`; change each test's `--adapter kiro` / inline `allowed-adapters = ["kiro"]` to `kiro-cli`, and `assertEqual(ps.adapter, "kiro")` → `"kiro-cli"`. Verify the build-layer fixture tests stay green (call `project()` directly).
+
+### T6 — Legacy-JSON upgrade migration
+
+**Depends on:** T1, T2 (exercises the new projection + merge-drop on an upgrade).
+
+**Mode:** TDD. **Done when:** a synthesized pre-existing legacy `kiro` JSON install (`.kiro/agents/<name>.json` + `hook_wiring_owned` state rows recorded under adapter `kiro`) transitions cleanly when the new code runs upgrade/install: no crash, `.md` projected, stale `.json` + merge-owned rows reconciled (not orphaned, no adopter-edited false-refusal).
+
+**Tests:** New test under `test_upgrade_user_hooks.py` (or a new module) synthesizing the legacy state and asserting the clean transition. (AC8) If the upgrade machinery surfaces a real bug, fix it in `install.py`; if it cannot be fixed within scope, **Surface** rather than rabbit-hole.
+
+### T7 — Changelog
+
+**Depends on:** none.
+
+**Mode:** goal-based. **Done when:** `docs/product/changelog.md` `[Unreleased]` has a `Fixed` entry for the kiro install alias. (AC9) (No `docs/backlog.md` deferral — the validate-rail gap is closed by T4.)
+
+## Verification
+
+`cd packages/agentbundle && python -m pytest tests/ agentbundle/build/tests/ -q` green; targeted re-run of the seven retargeted classes + the two new tests; `make build-check` from repo root if any projected surface is implicated (it is not — this is package code only).

--- a/docs/specs/kiro-install-alias-parity/spec.md
+++ b/docs/specs/kiro-install-alias-parity/spec.md
@@ -1,0 +1,93 @@
+# Spec: kiro-install-alias-parity
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:**
+  - [RFC-0022](../../rfc/0022-kiro-adapter-split.md) — `kiro` is a deprecated alias for `kiro-ide`; this spec completes that decision in the install path.
+  - [ADR-0012](../../adr/0012-kiro-adapter-split.md) — the six split decisions.
+  - [RFC-0005](../../rfc/0005-user-scope-hook-support.md) — user-scope hook-wiring merge (`merge-into-agent-json`).
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+> **Mode: full** (risk triggers: structural / public-interface change — the
+> `agentbundle install` behavior for the `kiro` adapter changes; and it sits
+> adjacent to a security boundary — the user-scope hook-wiring merge and its
+> path-traversal rail).
+
+## Objective
+
+RFC-0022 made bare `kiro` a **deprecated alias for `kiro-ide`**. That alias was
+wired into the build registry (`ADAPTERS["kiro"]` → `_kiro_alias_project` →
+`kiro_ide.project`) but **never into the install path**: `agentbundle install`
+had its own dispatch that routed `kiro` → `kiro.project`, which reads the legacy
+`[adapter.kiro]` contract block and emits `.json` agents plus a hook-wiring
+merge. Result: `make build` treated `kiro` as kiro-ide while
+`install --adapter kiro` treated it as the legacy (≈ kiro-cli) adapter — a
+silent divergence, and the symptom the user reported (kiro installs subagents as
+JSON, not markdown).
+
+Make `agentbundle install`/`uninstall`/`upgrade` treat `kiro` **exactly like
+`kiro-ide`**: `.md` agents, hook-wiring **dropped** (no merge), kiro-ide drop
+semantics. The legacy JSON-agents + hook-wiring-merge behavior is retained — it
+lives under the `kiro-cli` adapter, which is where its test coverage moves.
+
+The recorded `state.adapter` (and the `installed: … via <adapter>` summary) keep
+showing the name the adopter chose — `kiro` — so the alias stays a working,
+named adapter (RFC-0022 keeps it with no removal timeline). Only **behavior**
+canonicalizes to kiro-ide; **identity** is preserved.
+
+## Boundaries
+
+**Always do:**
+- Route `kiro` (install/uninstall/upgrade projection) through `kiro_ide.project`, matching the build registry alias.
+- Drop hook-wiring for `kiro` at install time — via an explicit early return in `_merge_user_scope_hook_wiring` keyed on the canonical adapter, **before** any wiring-TOML parse or filesystem write: return no merge-owned rows, write no `.kiro/agents/<name>.json`, never crash on a hook-wiring-bearing pack.
+- Make `_merge_user_scope_hook_wiring` dispatch on an explicit adapter allowlist (copilot → none; claude-code → settings merge; kiro/kiro-ide → none/dropped; kiro-cli → agent-JSON merge) and return no rows for any other adapter — no silent fall-through to Kiro merge semantics.
+- Make the dropped-primitives install warning **enumerate** kiro-ide's drops (hook-wiring + command) for the `kiro` alias, while **displaying** the adopter's chosen adapter name (`kiro`) in the warning text.
+- Keep the legacy JSON + hook-wiring-merge behavior reachable and tested under `kiro-cli`; retarget the affected fixtures and tests from `kiro` to `kiro-cli`.
+- Fire the merge-path rails for the adapter that actually merges. The shared `scope_rails` rails (`check_kiro_attach_to_agent` / `check_kiro_wiring`), the install pre-flight (the Step-6 `check_kiro_wiring` call in `install.run`), and `validate`'s `_kiro_target_adapters` recognize the merge family `{"kiro", "kiro-cli"}`, so `kiro-cli` packs keep the symlink, malformed-TOML, missing/unknown-`attach-to-agent`, and path-traversal refusals that `kiro` packs had pre-split. The pre-flight fires for the merging adapter (`kiro-cli`), **not** for the `kiro` alias (which drops wiring, matching kiro-ide).
+- Record `state.adapter` as the adopter's chosen name (`kiro` stays `kiro`, `kiro-cli` stays `kiro-cli`).
+- Add a `docs/product/changelog.md` `[Unreleased]` entry (adopter-visible behavior change).
+
+**Ask first:**
+- Any change to the recorded-adapter identity (normalizing `state.adapter` from `kiro` to `kiro-ide`) — out of scope; the alias stays a named adapter.
+- Bumping the adapter contract version (`SPEC_VERSION`) — not required; no contract block changes.
+
+**Never do:**
+- Edit any `adapter.toml` block (RFC-0022 forbids removing the kiro block; no block needs changing).
+- Normalize the alias anywhere the adopter sees the adapter name (stdout summary, state file, **drop-warning text**).
+- Co-project `.md` and `.json` for the same agent: a single install resolves exactly one target adapter, so `kiro` (md) and `kiro-cli` (json) are never both projected in one run even for a pack that lists both in `allowed-adapters`.
+
+## Acceptance Criteria
+
+- [x] **AC1** — `install --adapter kiro` (repo and user scope) projects agents as `.kiro/agents/<name>.md`; no `.kiro/agents/*.json` is written.
+- [x] **AC2** — `kiro` makes the **same** decisions as `kiro-ide` for a hook-wiring-bearing pack: at **repo** scope it installs without crashing, dropping the wiring (no agent JSON, no merge); at **user** scope a `user-scope-hooks = true` pack is **refused** identically to `kiro-ide` (the IDE has no user-scope hook-wiring mode — RFC-0005 AC25), because the install gate canonicalizes the alias before deciding. The merge-side drop (`_merge_user_scope_hook_wiring` early-return keyed on the canonical adapter, before any parse/write) is the defense-in-depth backstop, exercised via the legacy-state upgrade path.
+- [x] **AC3** — The dropped-primitives install warning for `kiro` (repo scope) enumerates the primitives kiro-ide drops (for `core`: `hook-wiring` and `command`), while its text names the adopter's chosen adapter (`kiro`, not `kiro-ide`).
+- [x] **AC4** — `install --adapter kiro-cli` retains the legacy behavior: `.json` agents with CLI tool tokens and hook-wiring merged into `.kiro/agents/<attach-to-agent>.json`, with `hook_wiring_owned` rows carrying the `target-file` field. (Verified by the retargeted user-hooks/uninstall/upgrade suites.)
+- [x] **AC5** — A user-scope `kiro-cli` install of a pack whose `hook-wiring` declares a path-traversal `attach-to-agent` (`"../../../tmp/escape"`) is refused (`rc != 0`); the refusal text names `attach-to-agent`, and no file is created outside the user-scope root.
+- [x] **AC6** — `state.adapter` records the adopter's chosen adapter name verbatim — a `kiro`-alias install records `kiro` (asserted by `test_kiro_alias_*`), a `kiro-cli` install records `kiro-cli` (retargeted suites); the `installed: … via <adapter>` summary matches.
+- [x] **AC7** — The merge-path rails recognize the merge family `{"kiro", "kiro-cli"}`: `check_kiro_attach_to_agent` / `check_kiro_wiring` fire for `kiro-cli` (unit-tested), the install pre-flight rail (the `check_kiro_wiring` call in Step 6 of `install.run`) fires for `kiro-cli` and **not** for the `kiro` alias (which drops wiring), and `validate`'s `_kiro_target_adapters` + its caller gate run the rail for a `kiro-cli` pack. **Validate stays strict for the whole merge family by design** — it runs the `attach-to-agent` well-formedness rail for a `["kiro"]`-declared pack too (a pack-authoring check), intentionally stricter than install (where the `kiro` alias drops the wiring without validating it); this asymmetry is pinned by `test_kiro_legacy_alias_pack_validate_stays_strict`.
+- [ ] **AC8** — A legacy `kiro` JSON install (pre-existing `.kiro/agents/<name>.json` + `hook_wiring_owned` rows, `state.adapter == "kiro"`) migrates cleanly under the new code. **Uninstall** removes the agent JSON via the merge-family unproject (no orphan) — fully verified. **Upgrade** re-renders `.md`, records `kiro`, and clears the merge rows — verified — but **leaves the stale `.json` orphaned**, a pre-existing general `upgrade` limitation (no orphan-removal on projection-shape change) that is exposed, not caused, by this migration. Deferred `(deferred: upgrade-orphan-removal-on-projection-shape-change)`; workaround is uninstall + reinstall.
+- [x] **AC9** — `docs/product/changelog.md` `[Unreleased]` documents the install-behavior change for the `kiro` alias.
+
+## Testing Strategy
+
+| Criterion | Mode | Verification |
+|---|---|---|
+| AC1 | TDD | `test_install_repo_scope_per_adapter.py::test_kiro_alias_projects_md_agents_not_json` — `.md` present, no `.json`. |
+| AC2 | TDD | `KiroAliasRefusesUserScopeHooksLikeKiroIdeTests` — user-scope `kiro` and `kiro-ide` both refuse a `user-scope-hooks` pack with the same AC25 message; `test_kiro_alias_projects_md_agents_not_json` (repo) — installs `core` (ships hook-wiring) without crashing, no `.json`. |
+| AC3 | TDD | `test_kiro_alias_projects_md_agents_not_json` asserts the repo-scope drop-warning names `hook-wiring` AND the text reads `kiro` (not `kiro-ide`). |
+| AC4 | TDD | Retargeted `KiroUserHooksInstallTests`, `KiroUserHooksUninstallTests` (×2), `UpgradeThenUninstallTests`, `AttachToAgentRenameTests`, `KiroPerFileDropEndToEnd`, `KiroWarningEndToEnd` — now `kiro-cli`. |
+| AC5 | TDD | Retargeted `AttachToAgentPathTraversalRefusedTests` (now `kiro-cli`) — `rc != 0`; refusal text names `attach-to-agent`; assert no `tmp/escape*` file created. |
+| AC6 | goal-based | Retargeted tests assert `state.adapter == "kiro-cli"`; `test_kiro_alias_*` asserts `state.adapter == "kiro"` + the `via kiro` summary. |
+| AC7 | TDD | New `scope_rails` unit case: rail fires for `{"kiro-cli"}`; existing `{"claude-code"}` no-op cases stay green. **End-to-end `validate`**: a malformed-wiring `kiro-cli` pack fails `validate` (rc 1) — covers the `validate` caller gate, not just `_kiro_target_adapters`'s return value. |
+| AC8 | TDD | `LegacyKiroJsonUninstallMigrationTests` (uninstall — clean, verified); `LegacyKiroJsonUpgradeMigrationTests` (upgrade — `.md` projected + rows cleared verified; the orphaned-`.json` assertion is an `@unittest.expectedFailure` pinning the deferred limitation). |
+| AC9 | goal-based | `grep` the changelog `[Unreleased]` block. |
+
+## Assumptions
+
+- **Verified** — the install resolver returns the adopter's chosen adapter un-normalized (`--adapter kiro` reaches the `== "kiro"` dispatch); this is why the projection bug existed and why the retarget tests fail today.
+- **Verified** — the build-layer fixture tests (`test_kiro_user_hooks_fixture.py`, `test_kiro_repo_hooks_fixture.py`) call `merge_into_agent_json.project()` directly and do not read `allowed-adapters`, so the fixture retarget to `kiro-cli` does not affect them.
+- **Verified** — `InMemoryRailNonKiroTargetTests` uses `{"claude-code"}` as its non-kiro example, so broadening the rail membership to `{"kiro", "kiro-cli"}` leaves the existing no-op cases green.
+- **Verified** — the path-traversal refusal under `kiro-cli` is defended at two depths: the pre-flight rail (now firing for `kiro-cli`) refuses an `attach-to-agent` that names no shipped agent, and the in-merge grammar (`_AGENT_NAME_RE`) + path-jail (`safety.assert_under`) refuse before any write — confinement (CWE-73) holds regardless of which fires first.

--- a/packages/agentbundle/agentbundle/build/scope_rails.py
+++ b/packages/agentbundle/agentbundle/build/scope_rails.py
@@ -299,6 +299,16 @@ def run_all(
 # ---------------------------------------------------------------------------
 
 
+# Adapters whose hook-wiring projects via `merge-into-agent-json` (a
+# pack-owned `.kiro/agents/<attach-to-agent>.json`): the legacy `kiro`
+# block and the `kiro-cli` adapter. The `attach-to-agent` rails below
+# validate that merge target, so they fire for this family. `kiro-ide`
+# (and the `kiro` *install alias*, which routes to kiro-ide) DROPS
+# hook-wiring and is intentionally absent — there is no merge target to
+# validate. Mirrors install.py's merge dispatch.
+_MERGE_INTO_AGENT_JSON_ADAPTERS = frozenset({"kiro", "kiro-cli"})
+
+
 def check_kiro_attach_to_agent(
     pack_name: str,
     wiring_tomls: dict[str, dict],
@@ -325,7 +335,7 @@ def check_kiro_attach_to_agent(
       target_adapters: iterable of adapter names the pack is being
         validated against. No-op when ``kiro`` is absent.
     """
-    if "kiro" not in set(target_adapters or ()):
+    if not (set(target_adapters or ()) & _MERGE_INTO_AGENT_JSON_ADAPTERS):
         return None
     for wiring_name, body in wiring_tomls.items():
         attach = body.get("attach-to-agent") if isinstance(body, dict) else None
@@ -485,7 +495,7 @@ def check_kiro_wiring(
     would let a pack reach outside its source tree. A wiring TOML that
     fails to parse counts as a refusal on its own.
     """
-    if "kiro" not in set(target_adapters or ()):
+    if not (set(target_adapters or ()) & _MERGE_INTO_AGENT_JSON_ADAPTERS):
         return None
 
     loaded = _load_pack_hook_wiring_safely(pack_path, pack_name)

--- a/packages/agentbundle/agentbundle/commands/install.py
+++ b/packages/agentbundle/agentbundle/commands/install.py
@@ -507,7 +507,15 @@ def run(args: "argparse.Namespace") -> int:
     if (
         user_scope_hooks_opt_in
         and requested_scope == "user"
-        and not _adapter_supports_user_scope_hook_wiring(user_target_adapter)
+        # Canonicalize the deprecated `kiro` alias to `kiro-ide` so it makes
+        # the SAME refuse decision as its canonical target (RFC-0022): the
+        # IDE has no user-scope hook-wiring mode, so a `user-scope-hooks`
+        # pack is refused — not silently accepted-and-dropped. The legacy
+        # `[adapter.kiro]` block still declares `merge-into-agent-json`, so
+        # without canonicalizing here the alias would diverge from kiro-ide.
+        and not _adapter_supports_user_scope_hook_wiring(
+            _canonical_install_adapter(user_target_adapter)
+        )
     ):
         print(
             f"install: adapter {user_target_adapter!r} does not declare a "
@@ -630,14 +638,17 @@ def run(args: "argparse.Namespace") -> int:
         )
 
     # ── Step 6: Pre-flight — rails A/B/C for any user-scope write ────────────
-    # Also run the kiro attach-to-agent rail (T2's `check_kiro_wiring`)
-    # for user-scope kiro-targeted packs. Catches malformed wiring TOMLs
-    # (missing/typo'd `attach-to-agent`, path-traversal payloads) before
-    # any render — the build-pipeline error message ("internal: <path>
-    # missing") isn't actionable for adopters; this rail surfaces the
-    # actual contract violation.
-    if any(p.scope == "user" for p in plans) and user_target_adapter == "kiro":
-        target_adapters = {"kiro"}
+    # Also run the kiro attach-to-agent rail (`scope_rails.check_kiro_wiring`)
+    # for user-scope packs targeting the MERGING adapter (`kiro-cli`).
+    # Catches malformed wiring TOMLs (missing/typo'd `attach-to-agent`,
+    # path-traversal payloads) before any render — the build-pipeline error
+    # message ("internal: <path> missing") isn't actionable for adopters;
+    # this rail surfaces the actual contract violation. The `kiro` alias
+    # (= kiro-ide) DROPS hook-wiring, so it has no merge target to validate
+    # and is intentionally NOT gated here (matches kiro-ide: drop + warn,
+    # don't refuse) — RFC-0022.
+    if any(p.scope == "user" for p in plans) and user_target_adapter == "kiro-cli":
+        target_adapters = {"kiro-cli"}
         kiro_refusal = scope_rails.check_kiro_wiring(
             pack_dir, pack_name, target_adapters
         )
@@ -1593,8 +1604,14 @@ def _maybe_emit_dropped_warning(
     from agentbundle.build.main import _read_bundled
     contract = _tomllib.loads(_read_bundled("adapter.toml"))
 
-    dropped = _enumerate_dropped_primitives(pack_dir, adapter, contract)
-    event_drops = enumerate_event_dropped_wirings(pack_dir, adapter, contract)
+    # Enumerate against the *canonical* adapter so the deprecated `kiro`
+    # alias reports kiro-ide's drops (hook-wiring + command), matching what
+    # is actually projected — but keep the adopter's chosen name (`kiro`) in
+    # the warning *text*, since the recorded adapter identity is preserved
+    # (RFC-0022 keeps `kiro` a named alias).
+    canonical_adapter = _canonical_install_adapter(adapter)
+    dropped = _enumerate_dropped_primitives(pack_dir, canonical_adapter, contract)
+    event_drops = enumerate_event_dropped_wirings(pack_dir, canonical_adapter, contract)
 
     if not dropped and not event_drops:
         # Adapter has no dropped modes OR pack ships nothing droppable.
@@ -1603,7 +1620,7 @@ def _maybe_emit_dropped_warning(
         # a sudden warning mid-process.
         _DROPPED_WARNING_SEEN.add(key)
         return
-    compatible = _enumerate_compatible_primitives(pack_dir, adapter, contract)
+    compatible = _enumerate_compatible_primitives(pack_dir, canonical_adapter, contract)
     msg = format_drop_message(
         pack_name=pack_name,
         adapter=adapter,
@@ -2328,6 +2345,22 @@ def _emit_recommends_warning(
 # ---------------------------------------------------------------------------
 
 
+# Deprecated adapter aliases → their canonical adapter, for *behavior* only.
+# `kiro` is a deprecated alias for `kiro-ide` (RFC-0022 D1): same projection
+# (`.md` agents, hook-wiring dropped). This mirrors the build registry's
+# `_kiro_alias_project`. The adopter's *chosen* name is still recorded in
+# `state.adapter` and printed in the install summary — only projection,
+# the hook-wiring merge gate, and the dropped-primitives enumeration
+# canonicalize through here.
+_INSTALL_ADAPTER_ALIASES = {"kiro": "kiro-ide"}
+
+
+def _canonical_install_adapter(adapter: str) -> str:
+    """Resolve a deprecated adapter alias to its canonical adapter for
+    behavioral dispatch. Identity for every non-alias adapter."""
+    return _INSTALL_ADAPTER_ALIASES.get(adapter, adapter)
+
+
 def _render_for_user_scope(
     pack_dir: Path,
     *,
@@ -2378,7 +2411,6 @@ def _render_for_user_scope(
         copilot,
         cursor,
         gemini,
-        kiro,
         kiro_cli,
         kiro_ide,
     )
@@ -2398,9 +2430,13 @@ def _render_for_user_scope(
     )
     with tempfile.TemporaryDirectory() as raw:
         out = Path(raw)
-        if target_adapter == "kiro":
-            kiro.project(pack_dir, contract, out)
-        elif target_adapter == "kiro-ide":
+        if _canonical_install_adapter(target_adapter) == "kiro-ide":
+            # `kiro` is a deprecated alias for `kiro-ide` (RFC-0022 D1):
+            # it projects `.md` agents, identical to `kiro-ide`. Route it
+            # through `kiro_ide.project` so the alias and the registry
+            # (`ADAPTERS["kiro"]` → `_kiro_alias_project`) stay in lockstep;
+            # the legacy `kiro.project` emits `.json` agents (the kiro-cli
+            # shape) and must not be reached for the alias.
             kiro_ide.project(pack_dir, contract, out)
         elif target_adapter == "kiro-cli":
             kiro_cli.project(pack_dir, contract, out)
@@ -2474,7 +2510,6 @@ def _render_for_repo_scope(
         copilot,
         cursor,
         gemini,
-        kiro,
         kiro_cli,
         kiro_ide,
     )
@@ -2494,9 +2529,13 @@ def _render_for_repo_scope(
     )
     with tempfile.TemporaryDirectory() as raw:
         out = Path(raw)
-        if target_adapter == "kiro":
-            kiro.project(pack_dir, contract, out)
-        elif target_adapter == "kiro-ide":
+        if _canonical_install_adapter(target_adapter) == "kiro-ide":
+            # `kiro` is a deprecated alias for `kiro-ide` (RFC-0022 D1):
+            # it projects `.md` agents, identical to `kiro-ide`. Route it
+            # through `kiro_ide.project` so the alias and the registry
+            # (`ADAPTERS["kiro"]` → `_kiro_alias_project`) stay in lockstep;
+            # the legacy `kiro.project` emits `.json` agents (the kiro-cli
+            # shape) and must not be reached for the alias.
             kiro_ide.project(pack_dir, contract, out)
         elif target_adapter == "kiro-cli":
             kiro_cli.project(pack_dir, contract, out)
@@ -2923,10 +2962,13 @@ def _rewrite_user_scope_hook_paths(
             basename = Path(relpath).name
             rewritten[f"{hook_subdir}/{pack_name}/{basename}"] = content
         elif (
-            target_adapter == "kiro"
+            target_adapter == "kiro-cli"
             and relpath.startswith(".kiro/agents/")
             and relpath.endswith(".json")
         ):
+            # `kiro-cli` is the adapter that emits agent JSON with a build-
+            # merged `hooks` key (the `kiro` alias routes to kiro-ide and
+            # emits `.md`, so there is no JSON to strip).
             # Strip the `hooks` key — the install-time merge step
             # re-adds it. Single-writer discipline; double-merge
             # would be idempotent today but fragile under any
@@ -2991,7 +3033,8 @@ def _merge_user_scope_hook_wiring(
     ``target-file`` field is omitted for Claude Code rows (the
     adapter's user-scope default target — ``~/.claude/settings.json``
     — is the implicit target on read; RFC-0005 § State-file impact)
-    and explicit for Kiro rows.
+    and explicit for ``kiro-cli`` rows. The deprecated ``kiro`` alias and
+    ``kiro-ide`` drop hook-wiring (RFC-0022) and return no rows.
     """
     import tomllib
 
@@ -3021,7 +3064,25 @@ def _merge_user_scope_hook_wiring(
         owned = _project(target, pack_name, wiring_tomls, force_merge=force_merge)
         return [{"event": event, "id": entry_id} for event, entry_id in owned]
 
-    # Kiro: group wiring by attach-to-agent; one merge call per agent.
+    if _canonical_install_adapter(target_adapter) == "kiro-ide":
+        # `kiro` (deprecated alias) and `kiro-ide` both DROP hook-wiring
+        # (RFC-0022): the IDE silently drops any agent carrying a `hooks`
+        # key, and the agent is projected as `.md` (no agent JSON to merge
+        # into). Return before parsing any wiring TOML or touching the
+        # filesystem — the wiring is dropped, surfaced by the
+        # dropped-primitives warning rail, not merged.
+        return []
+
+    if target_adapter != "kiro-cli":
+        # Only `kiro-cli` merges hook-wiring into a pack-owned agent JSON.
+        # claude-code / copilot / kiro-ide are handled above; every other
+        # adapter has no agent-JSON merge owner, so return empty rather
+        # than fall through to the Kiro merge (which would write a spurious
+        # `.kiro/agents/*.json`). A future adapter that ships user-scope
+        # hooks must add its own branch here, not ride this fall-through.
+        return []
+
+    # Kiro CLI: group wiring by attach-to-agent; one merge call per agent.
     from agentbundle import safety
     from agentbundle.build.projections.merge_into_agent_json import project as _project
 

--- a/packages/agentbundle/agentbundle/commands/uninstall.py
+++ b/packages/agentbundle/agentbundle/commands/uninstall.py
@@ -210,7 +210,10 @@ def run(args: "argparse.Namespace") -> int:
 
         for target_file_rel, owned in owned_by_target.items():
             target_path = root / target_file_rel.lstrip("/")
-            if adapter == "kiro":
+            # The merge family (`kiro-cli`, plus the legacy `kiro` block that
+            # pre-migration state may still record) merges into a pack-owned
+            # agent JSON; claude-code merges into the shared settings file.
+            if adapter in ("kiro", "kiro-cli"):
                 from agentbundle.build.projections.merge_into_agent_json import (
                     unproject as _unproject,
                 )

--- a/packages/agentbundle/agentbundle/commands/upgrade.py
+++ b/packages/agentbundle/agentbundle/commands/upgrade.py
@@ -522,9 +522,13 @@ def run(args: "argparse.Namespace") -> int:
                 force_merge=False,
             )
             pack_state.hook_wiring_owned = new_rows
-            pack_state.adapter = (
-                new_target_adapter if new_target_adapter == "kiro" else "claude-code"
-            )
+            # Record the resolved adapter faithfully (mirrors install's
+            # `new_pack_state.adapter = user_target_adapter`). The old
+            # `kiro`-or-`claude-code` collapse mis-recorded `kiro-cli`
+            # (the merging adapter) as `claude-code`, which then routed
+            # uninstall's unproject to the wrong engine and orphaned the
+            # agent JSON.
+            pack_state.adapter = new_target_adapter
             # Blocker #1: refresh state.files SHA for the agent JSON the
             # merge phase rewrote. Without this, post-upgrade uninstall
             # would misclassify it as Tier-2 and refuse to remove it.
@@ -625,8 +629,15 @@ def _compute_new_wiring_rows(
     # against the old target file).
     _AGENT_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 
+    from agentbundle.commands.install import _canonical_install_adapter
+
     wiring_dir = pack_dir / ".apm" / "hook-wiring"
     if not wiring_dir.exists():
+        return []
+    if _canonical_install_adapter(target_adapter) == "kiro-ide":
+        # `kiro` (deprecated alias) and `kiro-ide` DROP hook-wiring
+        # (RFC-0022): the install-time merge returns no rows, so the
+        # symmetric-diff computation must agree and yield none.
         return []
     rows: list[dict[str, str]] = []
     for entry in sorted(wiring_dir.iterdir()):
@@ -649,7 +660,7 @@ def _compute_new_wiring_rows(
         attach = body.get("attach-to-agent") if isinstance(body, dict) else None
         # Grammar guard for Kiro: refuse anything that would corrupt
         # `target_file_rel` (path-traversal, special chars, …).
-        if target_adapter == "kiro" and isinstance(attach, str):
+        if target_adapter == "kiro-cli" and isinstance(attach, str):
             if not _AGENT_NAME_RE.fullmatch(attach):
                 raise RuntimeError(
                     f"upgrade: pack {pack_name}'s hook-wiring {entry.stem}.toml "
@@ -660,7 +671,7 @@ def _compute_new_wiring_rows(
             if not isinstance(incoming, list):
                 continue
             row: dict[str, str] = {"event": event, "id": entry_id}
-            if target_adapter == "kiro" and isinstance(attach, str):
+            if target_adapter == "kiro-cli" and isinstance(attach, str):
                 row["target-file"] = f".kiro/agents/{attach}.json"
             rows.append(row)
     return rows
@@ -702,7 +713,11 @@ def _unproject_removed_rows(
 
     for target_rel, pairs in removed_by_target.items():
         target_path = root / target_rel.lstrip("/")
-        if old_adapter == "kiro":
+        # The merge family (`kiro-cli`, plus the legacy `kiro` block that
+        # pre-migration state may still record) merges into a pack-owned
+        # agent JSON; everything else (claude-code) merges into a shared
+        # settings file.
+        if old_adapter in ("kiro", "kiro-cli"):
             from agentbundle.build.projections.merge_into_agent_json import unproject
         else:
             from agentbundle.build.projections.user_merge_json import unproject

--- a/packages/agentbundle/agentbundle/commands/validate.py
+++ b/packages/agentbundle/agentbundle/commands/validate.py
@@ -188,12 +188,20 @@ def run(args) -> int:
     # unknown-agent) violations.
     #
     # Spec: docs/specs/incompatible-hook-event-drop AC1–AC5, AC6b.
-    from agentbundle.build.scope_rails import _load_pack_hook_wiring_safely
+    from agentbundle.build.scope_rails import (
+        _MERGE_INTO_AGENT_JSON_ADAPTERS,
+        _load_pack_hook_wiring_safely,
+    )
 
     target_adapters = _kiro_target_adapters(pack_data, pack_path)
     pack_name = pack_data.get("pack", {}).get("name") or pack_path.name
 
-    if "kiro" in target_adapters:
+    # Representative merge-family adapter for the enumeration calls below
+    # (`kiro-cli` if declared, else the legacy `kiro`). The attach-to-agent
+    # rail fires for the whole family; `kiro-ide` is excluded (drops wiring).
+    merge_adapters = target_adapters & _MERGE_INTO_AGENT_JSON_ADAPTERS
+    enum_adapter = "kiro-cli" if "kiro-cli" in merge_adapters else "kiro"
+    if merge_adapters:
         # 1. Safe-load: security + correctness refusals (AC3, AC3b, AC4).
         loaded = _load_pack_hook_wiring_safely(pack_path, pack_name)
         if isinstance(loaded, str):
@@ -236,13 +244,13 @@ def run(args) -> int:
         #    of truth with the install side (AC6b).
         contract = _load_adapter_contract()
         info_drops = _drop_warning.enumerate_event_dropped_wirings(
-            pack_path, "kiro", contract,
+            pack_path, enum_adapter, contract,
         )
         if info_drops:
             info = _drop_warning.format_drop_message(
                 mode="validate_info",
                 pack_name=pack_name,
-                adapter="kiro",
+                adapter=enum_adapter,
                 dropped_counts={},
                 compatible_types=[],
                 event_drops=info_drops,
@@ -390,7 +398,10 @@ def _kiro_target_adapters(pack_data: dict, pack_path: Path) -> set[str]:
         allowed = install.get("allowed-adapters")
         if isinstance(allowed, list):
             allowed_strs = [s for s in allowed if isinstance(s, str)]
-            return {"kiro"} if "kiro" in allowed_strs else set()
+            # The merge-into-agent-json family (`kiro` legacy block + `kiro-cli`)
+            # both validate `attach-to-agent`. `kiro-ide` is absent — it drops
+            # hook-wiring (RFC-0022). Mirrors scope_rails._MERGE_INTO_AGENT_JSON_ADAPTERS.
+            return {a for a in ("kiro", "kiro-cli") if a in allowed_strs}
 
     # Heuristic: kiro projection requires a same-pack agent. A pack
     # with wiring but no agents has nothing to attach to.

--- a/packages/agentbundle/tests/fixtures/packs/kiro-repo-hooks/pack.toml
+++ b/packages/agentbundle/tests/fixtures/packs/kiro-repo-hooks/pack.toml
@@ -17,4 +17,4 @@ allowed-scopes = ["repo"]
 # Explicit kiro routing — previously inferred via the legacy
 # agents-presence heuristic at step 5, which now defers to
 # ``DEFAULT_ADAPTER`` (multi-IDE uniformity).
-allowed-adapters = ["kiro"]
+allowed-adapters = ["kiro-cli"]

--- a/packages/agentbundle/tests/fixtures/packs/kiro-user-hooks/pack.toml
+++ b/packages/agentbundle/tests/fixtures/packs/kiro-user-hooks/pack.toml
@@ -18,4 +18,4 @@ user-scope-hooks = true
 # Explicit kiro routing — previously inferred via the legacy
 # agents-presence heuristic at step 5, which now defers to
 # ``DEFAULT_ADAPTER`` (multi-IDE uniformity).
-allowed-adapters = ["kiro"]
+allowed-adapters = ["kiro-cli"]

--- a/packages/agentbundle/tests/integration/test_install_dropped_primitives_warning.py
+++ b/packages/agentbundle/tests/integration/test_install_dropped_primitives_warning.py
@@ -161,13 +161,15 @@ class CopilotWarningEndToEnd(unittest.TestCase):
 
 
 class KiroWarningEndToEnd(unittest.TestCase):
-    """Kiro drops only `command`."""
+    """kiro-cli drops only `command` (hook-wiring merges; the deprecated
+    `kiro` alias now routes to kiro-ide and drops both — covered by the
+    alias test in test_install_repo_scope_per_adapter.py)."""
 
     def test_kiro_warning_names_command_only(self) -> None:
         with TemporaryDirectory() as raw:
             adopter = Path(raw) / "adopter"
             adopter.mkdir()
-            rc, stdout, stderr = _install_core_via("kiro", adopter)
+            rc, stdout, stderr = _install_core_via("kiro-cli", adopter)
             self.assertEqual(
                 rc, 0,
                 f"install failed:\nstdout={stdout}\nstderr={stderr}",
@@ -175,8 +177,8 @@ class KiroWarningEndToEnd(unittest.TestCase):
 
             # Warning fires for command only.
             self.assertIn(
-                "kiro projects as 'dropped'", stderr,
-                f"expected kiro dropped-warning in stderr:\n{stderr}",
+                "kiro-cli projects as 'dropped'", stderr,
+                f"expected kiro-cli dropped-warning in stderr:\n{stderr}",
             )
             # Agent and hook-wiring NOT in the drop clause (kiro
             # projects both natively).
@@ -385,7 +387,7 @@ allowed-adapters = ["claude-code", "kiro", "codex"]
 class KiroPerFileDropEndToEnd(unittest.TestCase):
     """T6 of docs/specs/incompatible-hook-event-drop.
 
-    Installs core via kiro at repo scope and asserts:
+    Installs core via kiro-cli at repo scope and asserts:
       - rc 0
       - stderr contains the exact three-clause warning (built via
         _drop_warning.format_drop_message so the test stays in sync
@@ -421,17 +423,17 @@ class KiroPerFileDropEndToEnd(unittest.TestCase):
         # pin (spec AC10).
         expected_warning = format_drop_message(
             pack_name="core",
-            adapter="kiro",
-            dropped_counts=_enumerate_dropped_primitives(pack_dir, "kiro", contract),
-            compatible_types=_enumerate_compatible_primitives(pack_dir, "kiro", contract),
-            event_drops=enumerate_event_dropped_wirings(pack_dir, "kiro", contract),
+            adapter="kiro-cli",
+            dropped_counts=_enumerate_dropped_primitives(pack_dir, "kiro-cli", contract),
+            compatible_types=_enumerate_compatible_primitives(pack_dir, "kiro-cli", contract),
+            event_drops=enumerate_event_dropped_wirings(pack_dir, "kiro-cli", contract),
             mode="install_warning",
         )
 
         with TemporaryDirectory() as raw:
             adopter = Path(raw) / "adopter"
             adopter.mkdir()
-            rc, stdout, stderr = _install_core_via("kiro", adopter)
+            rc, stdout, stderr = _install_core_via("kiro-cli", adopter)
 
             self.assertEqual(
                 rc, 0, f"install returned non-zero:\nstdout={stdout}\nstderr={stderr}"

--- a/packages/agentbundle/tests/integration/test_install_repo_scope_per_adapter.py
+++ b/packages/agentbundle/tests/integration/test_install_repo_scope_per_adapter.py
@@ -134,6 +134,67 @@ class RepoScopePerAdapterGreenfieldTests(unittest.TestCase):
             expected_dir=".kiro",
         )
 
+    def test_kiro_alias_projects_md_agents_not_json(self) -> None:
+        """`kiro` is a deprecated alias for `kiro-ide` (RFC-0022 D1), so it
+        must project `.md` agents — never the `.json` shape the legacy
+        `kiro.project` (kiro-cli) emits."""
+        with TemporaryDirectory() as raw:
+            adopter = Path(raw) / "adopter"
+            adopter.mkdir()
+            rc, stdout, stderr = _run_install(
+                [
+                    "--pack",
+                    "core",
+                    "--adapter",
+                    "kiro",
+                    "--scope",
+                    "repo",
+                    "--output",
+                    str(adopter),
+                    str(REPO_ROOT),
+                ]
+            )
+            self.assertEqual(
+                rc, 0, f"install failed:\nstdout={stdout}\nstderr={stderr}"
+            )
+
+            agents_dir = adopter / ".kiro" / "agents"
+            self.assertTrue(
+                agents_dir.exists(),
+                f"expected projected agents at {agents_dir}",
+            )
+            md_agents = sorted(agents_dir.glob("*.md"))
+            json_agents = sorted(agents_dir.glob("*.json"))
+            self.assertTrue(
+                md_agents,
+                f"expected `.md` agents (kiro-ide shape); found "
+                f"{[p.name for p in sorted(agents_dir.iterdir())]}",
+            )
+            self.assertEqual(
+                json_agents,
+                [],
+                f"kiro alias must not emit `.json` agents; found "
+                f"{[p.name for p in json_agents]}",
+            )
+
+            # Identity preserved: the adopter chose `kiro`, so state and the
+            # summary record `kiro` (not the canonical `kiro-ide`).
+            self.assertIn("installed: core @ repo via kiro", stdout)
+            state = _load_state(adopter)
+            self.assertEqual(
+                state.get("pack", {}).get("core", {}).get("adapter"),
+                "kiro",
+                "kiro alias must record the chosen name in state.adapter",
+            )
+
+            # AC3: core ships hook-wiring + a command, both dropped by kiro-ide.
+            # The warning enumerates kiro-ide's drops (names hook-wiring) but
+            # displays the adopter's chosen name `kiro` — never `kiro-ide`.
+            self.assertIn("hook-wiring", stderr, f"drop warning missing: {stderr}")
+            self.assertIn("kiro", stderr)
+            self.assertNotIn("kiro-ide", stderr)
+            # No agent JSON / no merge crash on a hook-wiring-bearing pack (AC2).
+
     def test_codex_explicit_adapter(self) -> None:
         self._install_and_assert(
             adapter_flag="codex",

--- a/packages/agentbundle/tests/integration/test_install_user_hooks.py
+++ b/packages/agentbundle/tests/integration/test_install_user_hooks.py
@@ -152,7 +152,7 @@ class KiroUserHooksInstallTests(_UserScopeInstallBase):
 
         state = load_state(self.home / ".agentbundle" / "state.toml")
         ps = state.packs["kiro-user-hooks"]
-        self.assertEqual(ps.adapter, "kiro")
+        self.assertEqual(ps.adapter, "kiro-cli")
         self.assertEqual(len(ps.hook_wiring_owned), 1)
         self.assertEqual(ps.hook_wiring_owned[0]["event"], "agentSpawn")
         self.assertEqual(ps.hook_wiring_owned[0]["id"], "kiro-user-hooks:on-spawn")
@@ -247,9 +247,11 @@ class AttachToAgentPathTraversalRefusedTests(_UserScopeInstallBase):
     def test_dot_dot_in_attach_to_agent_refuses(self) -> None:
         pack = self.cat / "packs" / "evil-pack"
         (pack / ".apm" / "agents").mkdir(parents=True)
-        # Declare kiro explicitly — the legacy agents-presence
-        # heuristic that previously inferred this now defers to
-        # ``DEFAULT_ADAPTER``.
+        # Declare kiro-cli explicitly — the merging adapter (RFC-0022).
+        # `kiro` (the deprecated alias) routes to kiro-ide, which DROPS
+        # hook-wiring, so a path-traversal `attach-to-agent` never reaches
+        # a merge target there; the refusal lives on the merge path
+        # (kiro-cli), guarded by the pre-flight rail + in-merge grammar.
         (pack / ".apm" / "agents" / "evil.md").write_text(
             "---\nname: evil\n---\nbody\n", encoding="utf-8"
         )
@@ -269,7 +271,7 @@ class AttachToAgentPathTraversalRefusedTests(_UserScopeInstallBase):
             '[pack.adapter-contract]\nversion = "0.3"\n\n'
             '[pack.install]\ndefault-scope = "user"\n'
             'allowed-scopes = ["user"]\nuser-scope-hooks = true\n'
-            'allowed-adapters = ["kiro"]\n',
+            'allowed-adapters = ["kiro-cli"]\n',
             encoding="utf-8",
         )
         for entry in pack.rglob("*.sh"):
@@ -283,6 +285,78 @@ class AttachToAgentPathTraversalRefusedTests(_UserScopeInstallBase):
         rc, _stdout, stderr = _run_install(args)
         self.assertEqual(rc, 1, "evil pack was accepted")
         self.assertIn("attach-to-agent", stderr)
+        # Confinement (CWE-73): the path-traversal payload must never have
+        # produced a file — the refusal fires before any merge write, so no
+        # `escape` artifact lands anywhere under the sandbox (in particular
+        # outside the user-scope home jail).
+        self.assertEqual(
+            list(self.tmp.rglob("*escape*")), [],
+            "path-traversal attach-to-agent created a file outside the jail",
+        )
+
+
+class KiroAliasRefusesUserScopeHooksLikeKiroIdeTests(_UserScopeInstallBase):
+    """RFC-0022 / kiro-install-alias-parity AC2: the deprecated ``kiro`` alias
+    must make the SAME user-scope decision as ``kiro-ide``. kiro-ide has no
+    user-scope hook-wiring mode, so a ``user-scope-hooks = true`` pack is
+    REFUSED (RFC-0005 AC25) — not silently accepted-and-dropped. The legacy
+    ``[adapter.kiro]`` block still declares ``merge-into-agent-json``, so this
+    pins that the install gate canonicalizes the alias before deciding."""
+
+    def _make_hooks_pack(self, name: str, adapter: str) -> None:
+        pack = self.cat / "packs" / name
+        (pack / ".apm" / "agents").mkdir(parents=True)
+        (pack / ".apm" / "agents" / "reviewer.md").write_text(
+            "---\nname: reviewer\n---\nbody\n", encoding="utf-8"
+        )
+        (pack / ".apm" / "hooks").mkdir(parents=True)
+        (pack / ".apm" / "hooks" / "on-spawn.sh").write_text(
+            "#!/bin/sh\nexit 0\n", encoding="utf-8"
+        )
+        (pack / ".apm" / "hook-wiring").mkdir(parents=True)
+        (pack / ".apm" / "hook-wiring" / "on-spawn.toml").write_text(
+            'attach-to-agent = "reviewer"\n\n'
+            '[[hooks.agentSpawn]]\ncommand = "x"\n',
+            encoding="utf-8",
+        )
+        (pack / "pack.toml").write_text(
+            f'[pack]\nname = "{name}"\nversion = "0.1.0"\n\n'
+            '[pack.adapter-contract]\nversion = "0.3"\n\n'
+            '[pack.install]\ndefault-scope = "user"\n'
+            'allowed-scopes = ["user"]\nuser-scope-hooks = true\n'
+            f'allowed-adapters = ["{adapter}"]\n',
+            encoding="utf-8",
+        )
+        for entry in pack.rglob("*.sh"):
+            entry.chmod(0o755)
+
+    def test_kiro_alias_refuses_identically_to_kiro_ide(self) -> None:
+        self._make_hooks_pack("kiro-alias-hooks", "kiro")
+        self._make_hooks_pack("kiro-ide-hooks", "kiro-ide")
+
+        rc_alias, _out, err_alias = _run_install(_install_args(
+            pack="kiro-alias-hooks",
+            catalogue=str(self.cat),
+            output=str(self.repo),
+            scope="user",
+        ))
+        rc_ide, _out2, err_ide = _run_install(_install_args(
+            pack="kiro-ide-hooks",
+            catalogue=str(self.cat),
+            output=str(self.repo),
+            scope="user",
+        ))
+
+        # Both refuse — the alias is a true alias for kiro-ide.
+        self.assertEqual(rc_alias, 1, f"kiro alias should refuse like kiro-ide: {err_alias}")
+        self.assertEqual(rc_ide, 1, f"kiro-ide should refuse user-scope hooks: {err_ide}")
+        self.assertIn("does not declare a hook-wiring mode that supports user scope", err_alias)
+        self.assertIn("does not declare a hook-wiring mode that supports user scope", err_ide)
+        # The refusal is a pre-flight gate — it fires before any render, so
+        # neither the `.json` (kiro-cli shape) nor the `.md` (kiro-ide shape)
+        # agent is written for either arm.
+        self.assertFalse((self.home / ".kiro" / "agents" / "reviewer.json").exists())
+        self.assertFalse((self.home / ".kiro" / "agents" / "reviewer.md").exists())
 
 
 class RailBStillRefusesPacksWithoutOptInTests(_UserScopeInstallBase):

--- a/packages/agentbundle/tests/integration/test_uninstall_user_hooks.py
+++ b/packages/agentbundle/tests/integration/test_uninstall_user_hooks.py
@@ -264,5 +264,48 @@ class KiroUserHooksUninstallTests(_UninstallBase):
         self.assertEqual(after.get("notes"), "adopter-added")
 
 
+class LegacyKiroJsonUninstallMigrationTests(_UninstallBase):
+    """RFC-0022 / kiro-install-alias-parity AC8: an adopter who installed via
+    the legacy `kiro` JSON path (agent JSON on disk, `state.adapter == "kiro"`,
+    `hook_wiring_owned` rows pointing at the agent JSON) must uninstall cleanly
+    under the new code — the agent JSON is removed (not orphaned) and the
+    merge-family unproject routes to the agent-JSON engine, not Claude Code's
+    settings engine. Simulated by installing via `kiro-cli` (which produces the
+    JSON + merge), then doctoring `state.adapter` to the legacy `"kiro"`."""
+
+    def test_legacy_kiro_recorded_state_uninstalls_agent_json_cleanly(self) -> None:
+        from agentbundle.config import dump_state, load_state
+
+        _copy_fixture(FIXTURES / "kiro-user-hooks", self.cat / "packs" / "kiro-user-hooks")
+        rc = _run_install(_install_args(
+            pack="kiro-user-hooks",
+            catalogue=str(self.cat),
+            output=str(self.repo),
+            scope="user",
+        ))
+        self.assertEqual(rc, 0, "setup install failed")
+
+        agent_json = self.home / ".kiro" / "agents" / "reviewer.json"
+        self.assertTrue(agent_json.exists(), "setup: agent JSON should exist")
+
+        # Doctor state to the legacy recording: pre-split, the only kiro
+        # adapter was `kiro`, so an old install recorded `kiro` (not `kiro-cli`).
+        state_path = self.home / ".agentbundle" / "state.toml"
+        state = load_state(state_path)
+        state.packs["kiro-user-hooks"].adapter = "kiro"
+        state_path.write_text(dump_state(state), encoding="utf-8")
+
+        rc, err = _run_uninstall(_uninstall_args(
+            pack="kiro-user-hooks",
+            output=str(self.repo),
+            scope="user",
+        ))
+        self.assertEqual(rc, 0, f"uninstall of legacy kiro state failed: {err}")
+        self.assertFalse(
+            agent_json.exists(),
+            "legacy kiro agent JSON orphaned by uninstall (adapter mis-routed)",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/packages/agentbundle/tests/integration/test_upgrade_user_hooks.py
+++ b/packages/agentbundle/tests/integration/test_upgrade_user_hooks.py
@@ -209,5 +209,86 @@ class UpgradeRemovesHookEntryTests(_UpgradeBase):
         self.assertEqual(ids, {"cc-user-hooks:on-prompt"})
 
 
+class LegacyKiroJsonUpgradeMigrationTests(_UpgradeBase):
+    """RFC-0022 / kiro-install-alias-parity AC8: an adopter who installed via
+    the legacy `kiro` JSON path (agent `.json` on disk, `state.adapter ==
+    "kiro"`, `hook_wiring_owned` rows) must UPGRADE cleanly under the new
+    code — the `kiro` alias now resolves to kiro-ide, so the upgrade re-renders
+    `.md`, drops hook-wiring, reconciles the stale `.json` (no orphan), and
+    clears the merge-owned rows. Simulated by installing via `kiro-cli` (real
+    JSON + merge + correct SHA) and doctoring the recording to legacy `kiro`."""
+
+    def test_legacy_kiro_recorded_state_upgrades_to_md_cleanly(self):
+        from agentbundle.config import dump_state, load_state
+
+        pack_dst = self.cat / "packs" / "kiro-user-hooks"
+        _copy_fixture(FIXTURES / "kiro-user-hooks", pack_dst)
+        self.assertEqual(_run_install(_install_args(
+            "kiro-user-hooks", str(self.cat), str(self.repo))), 0)
+        agent_json = self.home / ".kiro" / "agents" / "reviewer.json"
+        self.assertTrue(agent_json.exists(), "setup: legacy JSON agent should exist")
+
+        # Doctor to the legacy recording: pre-split, the only kiro adapter was
+        # `kiro`. Flip the catalogue pack to `["kiro"]` so the upgrade resolves
+        # the alias (matching the recorded state hint).
+        state_path = self.home / ".agentbundle" / "state.toml"
+        state = load_state(state_path)
+        state.packs["kiro-user-hooks"].adapter = "kiro"
+        state_path.write_text(dump_state(state), encoding="utf-8")
+        pt = (pack_dst / "pack.toml").read_text(encoding="utf-8")
+        (pack_dst / "pack.toml").write_text(
+            pt.replace('["kiro-cli"]', '["kiro"]'), encoding="utf-8"
+        )
+
+        rc, err = _run_upgrade(_upgrade_args(
+            "kiro-user-hooks", str(self.cat), "0.2.0", str(self.repo)))
+        self.assertEqual(rc, 0, f"legacy kiro upgrade failed: {err}")
+
+        # The kiro alias re-renders the `.md` agent (kiro-ide shape) and the
+        # hook-wiring reconciliation clears the merge-owned rows.
+        self.assertTrue(
+            (self.home / ".kiro" / "agents" / "reviewer.md").exists(),
+            "upgrade should project the .md agent (kiro-ide shape)",
+        )
+        state2 = load_state(state_path)
+        ps = state2.packs["kiro-user-hooks"]
+        self.assertEqual(ps.adapter, "kiro")
+        self.assertEqual(ps.hook_wiring_owned, [])
+
+    @unittest.expectedFailure
+    def test_legacy_kiro_upgrade_orphans_stale_json_known_limitation(self):
+        """KNOWN LIMITATION (docs/backlog.md#upgrade-orphan-removal-on-projection-shape-change):
+        `upgrade` has no orphan-removal step, so when an agent's projected file
+        SHAPE changes across the upgrade (legacy kiro `.json` → kiro-ide `.md`),
+        the new file is written but the stale `.json` is left on disk. For
+        kiro-ide this is harmful — the IDE loads BOTH `.md` and `.json` agents.
+        This is a pre-existing general upgrade limitation (independent of the
+        alias migration); the clean path today is uninstall + reinstall (see
+        LegacyKiroJsonUninstallMigrationTests, which IS clean). Marked
+        expectedFailure until upgrade grows orphan-removal."""
+        from agentbundle.config import dump_state, load_state
+
+        pack_dst = self.cat / "packs" / "kiro-user-hooks"
+        _copy_fixture(FIXTURES / "kiro-user-hooks", pack_dst)
+        self.assertEqual(_run_install(_install_args(
+            "kiro-user-hooks", str(self.cat), str(self.repo))), 0)
+        agent_json = self.home / ".kiro" / "agents" / "reviewer.json"
+
+        state_path = self.home / ".agentbundle" / "state.toml"
+        state = load_state(state_path)
+        state.packs["kiro-user-hooks"].adapter = "kiro"
+        state_path.write_text(dump_state(state), encoding="utf-8")
+        pt = (pack_dst / "pack.toml").read_text(encoding="utf-8")
+        (pack_dst / "pack.toml").write_text(
+            pt.replace('["kiro-cli"]', '["kiro"]'), encoding="utf-8"
+        )
+
+        rc, err = _run_upgrade(_upgrade_args(
+            "kiro-user-hooks", str(self.cat), "0.2.0", str(self.repo)))
+        self.assertEqual(rc, 0, f"legacy kiro upgrade failed: {err}")
+        # This is the assertion that currently fails (orphan left behind):
+        self.assertFalse(agent_json.exists())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/packages/agentbundle/tests/unit/test_install_dropped_primitives_warning.py
+++ b/packages/agentbundle/tests/unit/test_install_dropped_primitives_warning.py
@@ -576,12 +576,14 @@ class TestMaybeEmitEventDrops(unittest.TestCase):
 
         # Pack with no command/agent/hook-wiring primitive drops BUT has
         # an out-of-vocab hook-wiring that enumerate_event_dropped_wirings
-        # will detect. Kiro drops only 'command'; pack ships no commands.
+        # will detect. kiro-cli (the merge adapter — the deprecated `kiro`
+        # alias now routes to kiro-ide, which drops hook-wiring wholesale)
+        # drops only 'command'; pack ships no commands.
         pack = self.tmp_path / "event-only-pack"
         pack.mkdir(parents=True)
         hw_dir = pack / ".apm" / "hook-wiring"
         hw_dir.mkdir(parents=True)
-        # SessionStart is NOT in kiro's event vocabulary.
+        # SessionStart is NOT in kiro-cli's event vocabulary.
         (hw_dir / "session-start.toml").write_text(
             '[[hooks.SessionStart]]\nhooks = [{type = "command", command = "x"}]\n',
             encoding="utf-8",
@@ -595,7 +597,7 @@ class TestMaybeEmitEventDrops(unittest.TestCase):
                 root=self.tmp_path,
                 pack_dir=pack,
                 pack_name="event-only-pack",
-                adapter="kiro",
+                adapter="kiro-cli",
                 scope="repo",
             )
             first_output = captured.getvalue()
@@ -607,7 +609,7 @@ class TestMaybeEmitEventDrops(unittest.TestCase):
                 root=self.tmp_path,
                 pack_dir=pack,
                 pack_name="event-only-pack",
-                adapter="kiro",
+                adapter="kiro-cli",
                 scope="repo",
             )
             second_output = captured.getvalue()
@@ -655,8 +657,11 @@ class TestMaybeEmitEventDrops(unittest.TestCase):
         self.assertIn(("no-drop-pack", "claude-code", "repo"), keys)
 
     def test_maybe_emit_full_three_clause_for_kiro_core(self) -> None:
-        """Fixture install of core via kiro: stderr contains the exact
+        """Fixture install of core via kiro-cli: stderr contains the exact
         AC10 three-clause warning text naming hook-wiring/session-start.toml.
+        (The deprecated `kiro` alias routes to kiro-ide, which drops
+        hook-wiring wholesale — the per-event three-clause warning is the
+        kiro-cli merge adapter's behavior.)
 
         Integration-shape but lives in the unit module per plan T5 for
         inputs-stable assertion.
@@ -675,23 +680,26 @@ class TestMaybeEmitEventDrops(unittest.TestCase):
 
         # Build the expected message via the formatter (single source of truth).
         contract = _tomllib.loads(_read_bundled("adapter.toml"))
-        dropped = _enumerate_dropped_primitives(pack_dir, "kiro", contract)
-        event_drops = enumerate_event_dropped_wirings(pack_dir, "kiro", contract)
-        compatible = _enumerate_compatible_primitives(pack_dir, "kiro", contract)
+        dropped = _enumerate_dropped_primitives(pack_dir, "kiro-cli", contract)
+        event_drops = enumerate_event_dropped_wirings(pack_dir, "kiro-cli", contract)
+        compatible = _enumerate_compatible_primitives(pack_dir, "kiro-cli", contract)
         expected = format_drop_message(
             pack_name="core",
-            adapter="kiro",
+            adapter="kiro-cli",
             dropped_counts=dropped,
             compatible_types=compatible,
             event_drops=event_drops,
             mode="install_warning",
         )
 
-        # Sanity: the expected string must mention the file and contain both
-        # reason categories.
+        # Sanity: the expected string must name the dropped command, the
+        # skipped wiring file, and the event-vocabulary reason. (kiro-cli
+        # keeps hook-wiring, so an out-of-vocab event is *skipped*; the
+        # `kiro` alias instead drops hook-wiring wholesale — covered by
+        # KiroAliasDropsHookWiringTests.)
+        self.assertIn("command that kiro-cli projects as 'dropped'", expected)
         self.assertIn("hook-wiring/session-start.toml", expected)
         self.assertIn("event not in adapter vocabulary", expected)
-        self.assertIn("kiro requires 'attach-to-agent'", expected)
         self.assertIn("Additionally,", expected)
 
         # Now exercise _maybe_emit_dropped_warning and assert the same text.
@@ -703,7 +711,7 @@ class TestMaybeEmitEventDrops(unittest.TestCase):
                 root=self.tmp_path,
                 pack_dir=pack_dir,
                 pack_name="core",
-                adapter="kiro",
+                adapter="kiro-cli",
                 scope="repo",
             )
         finally:

--- a/packages/agentbundle/tests/unit/test_validate_attach_to_agent.py
+++ b/packages/agentbundle/tests/unit/test_validate_attach_to_agent.py
@@ -93,6 +93,35 @@ class InMemoryRailKiroTargetedTests(unittest.TestCase):
         self.assertNotIn("c.toml", refusal)
 
 
+class InMemoryRailKiroCliTargetedTests(unittest.TestCase):
+    """The rail fires for the whole merge-into-agent-json family — `kiro-cli`
+    as well as the legacy `kiro` (RFC-0022 / kiro-install-alias-parity). The
+    `attach-to-agent` merge target exists for both, so both validate it."""
+
+    def test_fires_for_kiro_cli_unknown_agent(self) -> None:
+        from agentbundle.build.scope_rails import check_kiro_attach_to_agent
+
+        refusal = check_kiro_attach_to_agent(
+            pack_name="cli-pack",
+            wiring_tomls={"on-prompt": {"attach-to-agent": "non-existent"}},
+            agent_basenames={"reviewer"},
+            target_adapters={"kiro-cli"},
+        )
+        self.assertIsNotNone(refusal)
+        self.assertIn("or names an unknown agent", refusal)
+
+    def test_accepts_well_formed_kiro_cli(self) -> None:
+        from agentbundle.build.scope_rails import check_kiro_attach_to_agent
+
+        refusal = check_kiro_attach_to_agent(
+            pack_name="cli-pack",
+            wiring_tomls={"on-prompt": {"attach-to-agent": "reviewer"}},
+            agent_basenames={"reviewer"},
+            target_adapters={"kiro-cli"},
+        )
+        self.assertIsNone(refusal)
+
+
 class InMemoryRailNonKiroTargetTests(unittest.TestCase):
     """Rail is a no-op when kiro isn't in target_adapters — Claude-Code-only packs."""
 
@@ -205,6 +234,25 @@ class FilesystemWrapperTests(unittest.TestCase):
                 agents=["reviewer"],
             )
             self.assertIsNone(check_kiro_wiring(pack, "demo-pack", {"kiro"}))
+
+    def test_filesystem_wrapper_refuses_missing_attach_to_agent_for_kiro_cli(self) -> None:
+        """The wrapper fires for the merging adapter `kiro-cli` too — symlink /
+        parse / missing-attach refusals are preserved for the adapter that now
+        owns the legacy JSON+merge behavior (RFC-0022 / kiro-install-alias-parity)."""
+        import tempfile
+
+        from agentbundle.build.scope_rails import check_kiro_wiring
+
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            pack = self._make_pack(
+                tmp,
+                wiring={"on-prompt": '[[hooks.userPromptSubmit]]\ncommand = "x"\n'},
+                agents=["reviewer"],
+            )
+            refusal = check_kiro_wiring(pack, "demo-pack", {"kiro-cli"})
+            self.assertIsNotNone(refusal)
+            self.assertIn("does not declare 'attach-to-agent'", refusal)
 
     def test_filesystem_wrapper_skips_when_no_kiro_in_targets(self) -> None:
         import tempfile

--- a/packages/agentbundle/tests/unit/test_validate_cmd.py
+++ b/packages/agentbundle/tests/unit/test_validate_cmd.py
@@ -259,3 +259,68 @@ def test_allowed_scopes_v0_1_stays_repo_only():
         }
     }
     assert _allowed_scopes(pack_data) == ["repo"]
+
+
+# ---------------------------------------------------------------------------
+# kiro-cli attach-to-agent rail (RFC-0022 / kiro-install-alias-parity)
+# ---------------------------------------------------------------------------
+
+
+def test_kiro_cli_pack_with_unknown_attach_to_agent_exits_1(tmp_path):
+    """End-to-end: the validate command runs the attach-to-agent rail for a
+    `kiro-cli` pack — pins the caller gate at validate.py, not just
+    `_kiro_target_adapters`'s return value. A wiring TOML whose
+    `attach-to-agent` names no shipped agent is refused."""
+    pack = tmp_path / "cli-hooks"
+    (pack / ".apm" / "agents").mkdir(parents=True)
+    (pack / ".apm" / "agents" / "reviewer.md").write_text(
+        "---\nname: reviewer\n---\nbody\n", encoding="utf-8"
+    )
+    (pack / ".apm" / "hook-wiring").mkdir(parents=True)
+    (pack / ".apm" / "hook-wiring" / "on-spawn.toml").write_text(
+        'attach-to-agent = "no-such-agent"\n\n[[hooks.agentSpawn]]\ncommand = "x"\n',
+        encoding="utf-8",
+    )
+    (pack / "pack.toml").write_text(
+        '[pack]\nname = "cli-hooks"\nversion = "0.1.0"\n\n'
+        '[pack.adapter-contract]\nversion = "0.3"\n\n'
+        '[pack.install]\ndefault-scope = "user"\n'
+        'allowed-scopes = ["user"]\nuser-scope-hooks = true\n'
+        'allowed-adapters = ["kiro-cli"]\n',
+        encoding="utf-8",
+    )
+
+    rc, stderr = _run(pack)
+    assert rc == 1, f"expected validate to refuse, got rc={rc}; stderr={stderr!r}"
+    assert "attach-to-agent" in stderr, stderr
+
+
+def test_kiro_legacy_alias_pack_validate_stays_strict(tmp_path):
+    """`validate` runs the attach-to-agent well-formedness rail for the whole
+    merge family — including the legacy `kiro` block — by design. This is a
+    pack-authoring well-formedness check and is INTENTIONALLY stricter than the
+    install path, where the `kiro` alias (= kiro-ide) drops hook-wiring without
+    validating `attach-to-agent`. Pinning this asymmetry so a future change
+    doesn't silently flip it (RFC-0022 / kiro-install-alias-parity AC7)."""
+    pack = tmp_path / "legacy-kiro-hooks"
+    (pack / ".apm" / "agents").mkdir(parents=True)
+    (pack / ".apm" / "agents" / "reviewer.md").write_text(
+        "---\nname: reviewer\n---\nbody\n", encoding="utf-8"
+    )
+    (pack / ".apm" / "hook-wiring").mkdir(parents=True)
+    (pack / ".apm" / "hook-wiring" / "on-spawn.toml").write_text(
+        'attach-to-agent = "no-such-agent"\n\n[[hooks.agentSpawn]]\ncommand = "x"\n',
+        encoding="utf-8",
+    )
+    (pack / "pack.toml").write_text(
+        '[pack]\nname = "legacy-kiro-hooks"\nversion = "0.1.0"\n\n'
+        '[pack.adapter-contract]\nversion = "0.3"\n\n'
+        '[pack.install]\ndefault-scope = "user"\n'
+        'allowed-scopes = ["user"]\nuser-scope-hooks = true\n'
+        'allowed-adapters = ["kiro"]\n',
+        encoding="utf-8",
+    )
+
+    rc, stderr = _run(pack)
+    assert rc == 1, f"expected validate to stay strict for ['kiro'], got rc={rc}; {stderr!r}"
+    assert "attach-to-agent" in stderr, stderr


### PR DESCRIPTION
## What does this change?

`agentbundle install`/`uninstall`/`upgrade`/`validate` now treat the deprecated `kiro` adapter as a true alias for `kiro-ide` — `.md` agents, hook-wiring dropped — matching what the build registry already did. Installing via `kiro` previously emitted `.json` agents and merged hook-wiring (the legacy behavior, the reported bug).

## Why?

RFC-0022 made `kiro` a deprecated alias for `kiro-ide`, but only the build registry (`ADAPTERS["kiro"]`) honored it; the install path had its own `== "kiro"` branches reading the legacy `[adapter.kiro]` block, so `make build` and `install --adapter kiro` silently disagreed. The legacy JSON-agents + hook-wiring-merge behavior is unchanged — it lives under `kiro-cli`, where the affected fixtures and tests are retargeted.

- Implements: `docs/specs/kiro-install-alias-parity/spec.md` (Shipped)
- Follows from: RFC-0022, ADR-0012, RFC-0005

`state.adapter` still records the adopter's chosen name (`kiro` stays `kiro`), so the alias remains a working, named adapter. The `attach-to-agent` / path-traversal / symlink / malformed-TOML rails now recognize the merge family `{kiro, kiro-cli}`, so `kiro-cli` packs keep the refusals `kiro` packs had pre-split (validate + install pre-flight). The user-scope-hooks gate canonicalizes the alias so `kiro` *refuses* a `user-scope-hooks` pack identically to `kiro-ide` rather than silently accepting-and-dropping.

## How do I verify it?

```
# Real CLI — agents land as .md, summary says "via kiro", warning names hook-wiring as dropped:
agentbundle install --pack core --adapter kiro --scope repo --output /tmp/x .
ls /tmp/x/.kiro/agents/        # *.md, no *.json

# Tests:
cd packages/agentbundle && python -m pytest tests/ agentbundle/build/tests/ -q
```

All green except 3 pre-existing `tests/unit/test_credential_setup_skill.py` failures — an environmental `credbroker`-not-installed issue, unrelated to this diff (touches no credential files). Reviews: `adversarial-reviewer` (×3, clean of blockers) + `security-reviewer` (clean; drove the rail broadening and the gate canonicalization).

## What did you not change that you considered?

- **Did not normalize `state.adapter`** from `kiro` to `kiro-ide` — RFC-0022 keeps `kiro` a named alias; only behavior canonicalizes, identity is preserved.
- **Did not edit any `adapter.toml` block** or bump `SPEC_VERSION` — no contract change.
- **Did not add an install-time deprecation-warning line** for the alias — out of scope for "behave like kiro-ide".

## Deferred

- **`upgrade` orphan-removal on a projection-shape change** (`docs/backlog.md#upgrade-orphan-removal-on-projection-shape-change`). Testing the legacy-install migration surfaced a pre-existing, general `upgrade` limitation: it re-renders the new projection but never removes a file that vanished from it, so a legacy `kiro` `.json` is orphaned when upgrade re-renders `.md`. Uninstall-then-reinstall is clean (verified); the orphan case is pinned by an `@unittest.expectedFailure`. Deferred because the fix touches `upgrade`'s core file-reconciliation (all packs, not just kiro) and exceeds this migration's scope.