### PR TITLE
feat(agentbundle): pack profiles — one-command curated pack install (RFC-0034)

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -113,6 +113,19 @@ jobs:
         working-directory: packages/agentbundle
         run: python -m pytest tests/integration/test_install_converters_user_scope.py
 
+      # pack-profiles (RFC-0034): the profile reader/schema, batch-aware dep
+      # gate, CLI surface (mutex + list-profiles), and the install orchestrator.
+      # make build-check runs no pytest, so wire these paths explicitly.
+      - name: pytest pack-profiles (RFC-0034)
+        working-directory: packages/agentbundle
+        run: >-
+          python -m pytest
+          tests/unit/test_profile_reader.py
+          tests/unit/test_dependencies_batch.py
+          tests/unit/test_cli_profile_surface.py
+          tests/integration/test_install_profile.py
+          tests/integration/test_install_profile_live.py
+
       # credbroker-user-scope T1: consumer bootstraps append the vendored
       # ~/.agentbundle/lib floor at LOWEST sys.path precedence. The
       # no-insert-0 source guard enforces the spec's "never prepend"
@@ -264,6 +277,16 @@ jobs:
             echo "::error::AC4: msg-to-markdown/evals/ exists; spec forbids synthesised evals for this skill"
             exit 1
           fi
+
+      - name: profiles lint + self-test (pack-profiles AC9)
+        # RFC-0034: profiles must be scope-homogeneous, dependency-complete
+        # (incl. version), and deps-first ordered. The self-test proves the
+        # linter catches each crafted bad fixture; the lint then scans the
+        # shipped profiles/ and fails the build on any real violation. Python,
+        # invoked directly (not via bash), so the same step works on Windows.
+        run: |
+          python3 tools/test-lint-profiles.py
+          python3 tools/lint-profiles.py --root .
 
       - name: design-craft framework-agnosticism lint + self-test (design-craft-pack AC8)
         # RFC-0033: the design-craft pack ships portable design method, never a

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,9 @@ on:
       - 'tools/lint-knowledge.py'
       - 'tools/test-lint-knowledge.sh'
       - 'tools/lint-seeds.py'
+      - 'profiles/**'
+      - 'tools/lint-profiles.py'
+      - 'tools/test-lint-profiles.py'
       - 'packs/**'
       - '.claude/skills/work-loop/scripts/loop-cohort.py'
       - 'packs/core/.apm/skills/work-loop/scripts/loop-cohort.py'
@@ -83,6 +86,16 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run seed-content linter (RFC-0002 scaffold contract)
         run: python tools/lint-seeds.py
+
+  lint-profiles:
+    name: Install profiles
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Self-test the linter (every failure mode + happy path)
+        run: python tools/test-lint-profiles.py
+      - name: Run profiles linter (scope/dep/order against the live packs/)
+        run: python tools/lint-profiles.py --root .
 
   loop-cohort:
     name: Caps enforcer self-test

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -35,6 +35,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Pack profiles — install a curated set of packs in one command (RFC-0034).**
+  `agentbundle install --profile <name> <catalogue>` reads a first-party
+  `profiles/<name>.toml` from the catalogue and installs its packs at the
+  profile's single declared scope, in deps-first order, on one pinned adapter,
+  with all preconditions checked before any write. `agentbundle list-profiles
+  <catalogue>` lists the available profiles (id, scope, description). Two
+  profiles ship: `solution-architect` (user scope → `architect` + `research` +
+  `contracts`) and `full-ceremony` (repo scope → `core` + `governance-extras`
+  + `user-guide-diataxis` + `monorepo-extras`). `--profile` is mutually
+  exclusive with `--pack`, and `--scope` is rejected with it (a profile
+  declares its own scope). Already-installed packs are skipped, not reinstalled;
+  per-pack state rows record `install_route = "profile"`. No new state schema,
+  no adapter-contract bump, no new install route — distribution hygiene over
+  the existing single-pack install path.
+
 - **`design` joins the soft `categories` vocabulary.** `agentbundle validate`
   now recognizes `design` as a known pack category, so the `design-craft` pack
   (and any future design pack) declares it without a soft warning. The

--- a/docs/specs/pack-profiles/plan.md
+++ b/docs/specs/pack-profiles/plan.md
@@ -1,7 +1,7 @@
 # Plan: pack-profiles
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Drafting <!-- Drafting | Executing | Done -->
+- **Status:** Done <!-- Drafting | Executing | Done -->
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
 > document is allowed to change as you learn. When it changes substantially
@@ -34,6 +34,8 @@ Stack: the `agentbundle` reference CLI (Python, argparse in `cli.py`, command ha
 - **Orchestrator calls existing per-pack paths, never reimplements them** — keeps single-pack `install` the one source of truth for resolve→check→write; the profile layer only sequences and gates. Traces to: AC3, AC4 · rejected: a parallel install routine (would drift from `install.run`).
 - **Manifest is TOML with a closed schema** (`scope`, `description`, `packs`) validated by `_data/profile.schema.json`, mirroring `pack.schema.json`. Traces to: AC1, AC2 · rejected: per-entry scope pins (unneeded — single-scope) and a free-form schema.
 - **Order is authored, lint-enforced, not computed** — no runtime topological sort. Traces to: AC9 · rejected: orchestrator topo-sort (RFC-0034 Axis C2).
+- **Batch pre-flight reuses single-pack `install.run` dry-run — path-jail included, nothing reimplemented** — single-pack `install.run` already runs a *read-only* path-jail probe (Step 8, `install.py:789`) **before** both its write loop (Step 9) and its dry-run return (`install.py:852`). So `install.run(dry_run=True)` exercises the full Steps 1–8 pre-flight — scope, batch dep gate, adapter membership, render, and the path-jail probe — and returns non-zero without writing a byte. The orchestrator dry-runs **every** pack (deps-first, with `_batch_packs` so the dep gate treats in-batch deps as present, and the pinned adapter) before writing **any** pack; a non-zero dry-run aborts the whole profile naming the pack. This extends single-pack's all-checks-before-any-write guarantee to the batch (RFC-0034 D5) without re-deriving `write_jailed`'s internals (Boundary: never reimplement install.run's write logic). Traces to: AC4 · grounded in RFC-0034 D5 (step 4's residual is genuine I/O only — disk full) · rejected: a hand-rolled helper-based pre-flight (would skip the path-jail probe) and a render-and-replicate-the-jail-check (would duplicate Step 8).
+- **Batch adapter is resolved once and asserted per-pack — not from the intersection, and not lint-guarded** — explicit `--adapter` else the scope's normal resolution run once (RFC-0034 D5 step 2); each pack asserts membership; a mismatch refuses before any write, naming the pack and suggesting a compatible adapter computed from the batch's `allowed-adapters` intersection. Traces to: AC5 · rejected: an adapter-homogeneity lint invariant (exceeds RFC-0034's fixed scope/dep/order lint triad — the RFC designs the runtime refuse-and-suggest instead) and intersection-based *resolution* (diverges from D5 step 2's "normal resolution run once").
 
 ### Interfaces & contracts
 
@@ -48,7 +50,7 @@ Stack: the `agentbundle` reference CLI (Python, argparse in `cli.py`, command ha
 
 - **All-pre-flight-before-any-write across the batch:** resolve every pack's scope, adapter, dep gate, and path-jail before the first write; any failure aborts the whole profile, naming the pack, exit non-zero (AC4).
 - **Partial write failure:** not transactional (matches single-pack install); deps-first write order guarantees a consistent prefix; emit a per-pack success/fail summary (AC8).
-- **Already-installed packs:** filtered out before invoking per-pack install, so refuse-on-reinstall (`install.py:426-432`) is never hit (AC6).
+- **Already-installed packs:** filtered out before invoking per-pack install, so refuse-on-reinstall (`install.py:446-454`) is never hit (AC6).
 - **Adapter split:** resolve one adapter once for the batch, assert membership per pack, refuse on mismatch before any write (AC5).
 
 ## Tasks
@@ -73,12 +75,13 @@ Stack: the `agentbundle` reference CLI (Python, argparse in `cli.py`, command ha
 
 **Tests:** (TDD)
 - Pass: `solution-architect` (all user-scope, no deps) and `full-ceremony` (all repo-scope, `core` first).
-- Fail: a user profile naming `core` (scope mismatch); `full-ceremony` with `core` removed (dep-incomplete); `governance-extras` before `core` (mis-ordered). (AC9)
+- Fail: a user profile naming `core` (scope mismatch); `full-ceremony` with `core` removed (dep-incomplete); a profile whose in-batch dep is present but at a version that does not satisfy the required range (dep version-incomplete); `governance-extras` before `core` (mis-ordered). (AC9)
 
 **Approach:**
-- Add `tools/lint-profiles.py` reading every `profiles/*.toml` and each named pack's `pack.toml` (`allowed-scopes`, `[pack.dependencies.required]`, incl. the catalogue-qualified match).
+- Add `tools/lint-profiles.py` reading every `profiles/*.toml` and each named pack's `pack.toml` (`allowed-scopes`, `[pack.dependencies.required]`, version, incl. the catalogue-qualified match).
 - Scope-homogeneity is checked against `allowed-scopes` **membership** of the profile's declared scope — *not* `default-scope` (the `solution-architect` packs are dual-scope, `allowed-scopes = ["user","repo"]`).
-- Assert the three invariants; exit non-zero with the offending profile + reason.
+- Dep-completeness checks both presence *and* version satisfiability: a required dep must be present earlier in the profile's pack list (or already catalogue-resolvable) at a version satisfying the `^X.Y` range — reuse the caret-minor grammar from `validate_dependencies_required` so the lint and the runtime gate agree.
+- Assert the three invariants (scope-homogeneity, dep-completeness, order-validity); exit non-zero with the offending profile + reason. **Adapter-homogeneity is deliberately *not* a lint invariant** (RFC-0034 fixes the lint triad; adapter mismatch is an install-time refuse-and-suggest per AC5).
 
 **Done when:** lint passes on the two shipped profiles and fails each crafted bad fixture.
 
@@ -88,9 +91,12 @@ Stack: the `agentbundle` reference CLI (Python, argparse in `cli.py`, command ha
 
 **Tests:** (TDD)
 - `validate_dependencies_required` with a batch set including `core` accepts `governance-extras`; without it, fails with "install core first". (AC7)
+- A dep *not* in the batch set still fails (the parameter widens, never bypasses, the gate).
+- Default call (no `also_installing`) is byte-for-byte the existing behavior — existing dep-gate tests stay green.
 
 **Approach:**
-- Add an optional `also_installing: set[str]` (or `batch_packs`) parameter to `validate_dependencies_required` (`install.py:3203`); treat those names as present-after when resolving required deps. Default empty → existing single-pack behavior unchanged.
+- Add an optional `also_installing: set[str] | None = None` parameter to `validate_dependencies_required` (`install.py:3203`); a required dep whose **name** is in `also_installing` is treated as satisfied. Default `None` → existing single-pack behavior unchanged.
+- Name-only satisfaction is intentional at pre-flight (nothing is written yet, so no version is on disk): the orchestrator passes the profile's full pack-name set. The **version** range is enforced for real at write time — deps-first order installs `core` first, so each dependent's per-pack gate runs against real state with `core`'s real version — and the T2 lint independently guarantees in-batch version satisfiability at author-time. This split (name at pre-flight, version at write-time + lint) is the load-bearing reason the parameter is a name-set, not a name→version map.
 
 **Done when:** new gate tests green; existing dep-gate tests still green.
 
@@ -113,13 +119,26 @@ Stack: the `agentbundle` reference CLI (Python, argparse in `cli.py`, command ha
 **Depends on:** T1, T3, T4
 
 **Tests:** (goal-based, integration — see Construction tests)
-- One command installs the set, in order, at the declared scope, on one pinned adapter; already-installed skipped; per-pack rows carry `install_route="profile"`; pre-flight failure aborts before any write. (AC3–AC8, AC12, AC13)
+- One command installs the set, in order, at the declared scope, on one pinned adapter; already-installed skipped (reported `already present, skipped`, never tripping the single-pack refuse-on-reinstall); per-pack rows carry `install_route="profile"`; pre-flight failure aborts before any write. (AC3–AC8, AC12, AC13)
+- **Adapter-disallowed refusal:** pin an adapter one pack excludes → refuse before any write (no state row, no file on disk for any pack), naming the offending pack and suggesting a compatible adapter. (AC5)
+- **Path-jail refusal across the batch:** a fixture pack *later* in the batch whose projection escapes its scope's allowed prefixes → the batch dry-run pre-flight refuses with **zero files written for any pack** (incl. the earlier well-formed packs), naming the offending pack. (AC4)
+- **Partial-failure (AC8):** monkeypatch `safety.write_jailed` to raise `safety.WriteError` (the genuine-I/O residual — **not** `PathJailError`, which would collide with the path-jail pre-flight test above) on the **second** pack's write; assert the first pack's files + state row persist (no rollback), the second-and-later packs have no files/rows, and the per-pack summary reports the first as success and the second as failure. This verifies the orchestrator's `except (safety.WriteError, OSError)` write-phase catch (step 6), since single-pack `run()` does not itself return non-zero on `WriteError`.
+- **`install_route` default unchanged (AC13 / Boundary "Ask first"):** a normal single-pack `install --pack` row still records `install_route="cli"` — the `_install_route` seam must not flip the default.
 
 **Approach:**
-- Add the `--profile` branch in `commands/install.py run()`: read manifest (T1) → resolve scope (declared) → resolve one adapter once + assert per pack → filter already-installed → run the batch dep gate (T3) and per-pack pre-flight (scope, path-jail) for all packs → write in listed order, per-pack, recording `install_route="profile"` → emit per-pack summary.
-- Reuse existing per-pack helpers; do not duplicate `install.run`'s write logic.
+- At the **top** of `commands/install.py run()` (before `pack_name = args.pack`), dispatch: `if getattr(args, "profile", None): return _run_profile(args)`. `_run_profile` lives in `install.py` so it can call `run()` per pack without a circular import.
+- `_run_profile`:
+  1. Read manifest (T1); resolve the declared scope.
+  2. Resolve **one** adapter for the batch — explicit `--adapter`, else the scope's normal resolution run once.
+  3. For each pack, assert the pinned adapter ∈ its `allowed-adapters` (legacy/None = all allowed); on mismatch **refuse-and-suggest** before anything else, naming the pack and listing the batch's `allowed-adapters` intersection (AC5). This explicit check owns the precise suggestion wording; the dry-run in step 5 re-checks adapter membership too, harmlessly.
+  4. Load state; filter out packs already installed at the declared scope (reported `already present, skipped`, AC6) — so the dry-run/write calls never trip single-pack refuse-on-reinstall.
+  5. **Pre-flight:** for each remaining pack in deps-first order, call `install.run(dry_run=True, …)` with a constructed args namespace pinning `pack`/`scope`/`adapter`, `_install_route="profile"`, and `_batch_packs` = the profile's pack-name set, **stdout suppressed** (the profile emits its own summary, not N per-file dry-run plans). Any non-zero return aborts the whole profile, naming the pack; **no byte has been written** (AC4 — this is where scope, batch-deps, adapter, render, and the Step-8 path-jail probe all fire for the whole batch).
+  6. **Write:** for each remaining pack in deps-first order, call `install.run(dry_run=False, …same args…)` wrapped in `except (safety.WriteError, OSError)`. This catch is **load-bearing**: single-pack `run()`'s projection write loop catches only `safety.PathJailError` (`install.py:880`), so a genuine mid-batch I/O failure (disk full) raised as `safety.WriteError` (subclass of `OSError`, `safety.py:43`) propagates *through* `install.run` rather than returning non-zero — the orchestrator converts it into the pack's `failed` summary line. Stop on the first write failure (no rollback, AC8).
+  7. Emit the per-pack summary (`installed` / `already present, skipped` / `failed`).
+- Two seams in single-pack `run()`, both backward-compatible via `getattr` defaults: `install_route=getattr(args, "_install_route", "cli")` at the PackState construction site (line ~851), and `also_installing=getattr(args, "_batch_packs", None)` threaded into the Step 3b `validate_dependencies_required` call.
+- Reuse `install.run` verbatim for both pre-flight (dry-run) and write; reuse `_locate_pack`/`validate_dependencies_required` for the manifest-side checks. **Do not duplicate `install.run`'s write logic.** Path-jail rides along for free in the dry-run pre-flight (Step 8 runs before the dry-run return — see Design decisions).
 
-**Done when:** integration test green; single-pack install tests unchanged.
+**Done when:** integration tests green (incl. adapter-disallowed, partial-failure, install_route-default); single-pack install tests unchanged; the full `packages/agentbundle` pytest passes (dep-gate signature change touches a load-bearing function — `feedback_contract_bump_test_traps`).
 
 ### T6: Ship two first-party profiles + CI wiring
 
@@ -128,7 +147,7 @@ Stack: the `agentbundle` reference CLI (Python, argparse in `cli.py`, command ha
 **Tests:** (goal-based)
 - `profiles/solution-architect.toml` (user) and `profiles/full-ceremony.toml` (repo) install cleanly against the live catalogue into temp roots. (AC14)
 - `lint-profiles` and the new `packages/agentbundle` test paths run in CI. (AC9; CI-wiring convention)
-- The full diff for this feature touches no `.claude-plugin/marketplace.json`, no `agentbundle/build/` recipe, and no self-host path — asserted by a `git diff --name-only origin/main` check in the PR (and guarded going forward by the existing build-check drift gate). (AC15)
+- The full diff for this feature touches no `.claude-plugin/marketplace.json`, no `agentbundle/build/` recipe, and no self-host path — verified by a name-only `git diff --name-only origin/main` over the feature's diff. This is the AC15 artifact (sufficient for an additive, CLI-route-only PR; `profiles/` is a new top-level dir outside `packs/`, so `build-self` never aggregates it into `marketplace.json`). Note: `run_build_check_drift_gates` does **not** assert this invariant — its three gates cover install-marker byte-identity, source-shape plugin.json, and `_emit_basic_string` parity, none of which would fail on a profile-induced marketplace/self-host change — so it is not cited as the enforcement here. (AC15)
 
 **Approach:**
 - Add `profiles/solution-architect.toml` and `profiles/full-ceremony.toml` (deps-first; `core` first in full-ceremony).
@@ -152,3 +171,6 @@ Stack: the `agentbundle` reference CLI (Python, argparse in `cli.py`, command ha
 ## Changelog
 
 - 2026-06-14: initial plan, following accepted RFC-0034 + ADR-0025.
+- 2026-06-14: pre-EXECUTE adversarial review (round 1) amendments — (Blocker 2, partially declined) kept RFC D5 step 2 resolve-once + assert-per-pack, added refuse-and-suggest message + test, declined an adapter-homogeneity lint invariant as exceeding the RFC's fixed lint triad (AC5/AC9/Assumptions); (Concern 3) batch dep gate satisfies by name at pre-flight, version enforced at write-time + by the lint (AC7, T3); (Concern 4) named the partial-failure fault-injection mechanism (T5); (Concern 5) added install_route="cli" single-pack regression test (T5).
+- 2026-06-14: pre-EXECUTE adversarial review (round 2) corrections — (Blocker 1, corrected) single-pack `install.run` runs a *read-only* path-jail probe at Step 8 (`install.py:789`) **before** both its write loop and its dry-run return (`install.py:852`); my round-1 "path-jail is write-time only" framing misread the code. Corrected design: the orchestrator dry-run-pre-flights every pack (Steps 1–8 incl. path-jail) before writing any pack, faithfully extending single-pack's all-checks-before-any-write to the batch (RFC-0034 D5). Spec AC4 + "Always do" + AC8 reworded; design decision rewritten; added a path-jail-across-the-batch refusal test (T5). (Blocker 3) AC15's "durable drift-gate" claim was false — `run_build_check_drift_gates` doesn't cover marketplace/build/self-host membership; the name-only `git diff` is the actual artifact (sufficient for this additive PR).
+- 2026-06-14: pre-EXECUTE adversarial review (round 3) — (Concern 1) the write-phase `install.run` calls must be wrapped in `except (safety.WriteError, OSError)` because single-pack `run()`'s projection write loop catches only `PathJailError`, so a genuine I/O failure propagates rather than returning non-zero (T5 step 6); (Concern 2) the partial-failure test raises `safety.WriteError` specifically, distinct from the path-jail test's `PathJailError` (T5); (Nit 3) added an AC15 line to the spec's Testing Strategy.

--- a/docs/specs/pack-profiles/spec.md
+++ b/docs/specs/pack-profiles/spec.md
@@ -1,6 +1,6 @@
 # Spec: pack-profiles
 
-- **Status:** Draft <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** [RFC-0034](../../rfc/0034-pack-profiles.md), [ADR-0025](../../adr/0025-pack-profiles-single-scope-cli-manifest.md)
@@ -23,7 +23,7 @@ before proceeding; *Never do* is a hard rule, even under time pressure.
 
 ### Always do
 
-- Run all preconditions for every pack in the batch (scope, dep gate, adapter, path-jail) **before any write** — extend install's existing resolve→check→write contract from one pack to the whole batch.
+- Run all preconditions for every pack in the batch (scope, dep gate, adapter, path-jail) **before any write** — extend install's existing resolve→check→write contract from one pack to the whole batch. Single-pack `install.run` already runs a *read-only* path-jail probe (Steps 1–8, `install.py:789`) before its write loop; the orchestrator extends that to the batch by dry-run-pre-flighting **every** pack (Steps 1–8 incl. the path-jail probe) before writing **any** pack. The residual write-time window is genuine I/O error only (disk full) — the same residual single-pack install already accepts (RFC-0034 D5 step 4) — and deps-first write order keeps any aborted prefix internally consistent.
 - Install packs in the profile's authored (deps-first) order, and skip packs already installed at the declared scope, reporting them as `already present, skipped`.
 - Pin exactly one adapter for the whole batch (explicit `--adapter`, else the scope's normal resolution run once) and refuse before any write if any pack disallows it.
 - Keep each profile single-scope: read the `scope` field and install every pack at that scope.
@@ -47,28 +47,32 @@ before proceeding; *Never do* is a hard rule, even under time pressure.
 - **Manifest schema + parse (id from filename stem, required `scope`, ordered `packs`):** TDD — a compressible invariant (valid/invalid manifests in, accept/reject out).
 - **The lint (scope-homogeneity, dep-completeness, order-validity) against the live `packs/` tree:** TDD — each invariant has a clean pass case and a failing case (a user profile naming `core`; a repo profile missing `core`; `governance-extras` listed before `core`).
 - **Batch-aware dep gate (`validate_dependencies_required` treats the profile set as present):** TDD — `full-ceremony` passes because `core` is in the batch; the same set with `core` removed fails.
-- **`install --profile` end-to-end (one command installs the set, ordered, one scope, one adapter, skip-already-installed, partial-failure summary):** goal-based, exercised by an **integration** test against a fixture catalogue + temp scope roots — assert the resulting state rows and on-disk files.
+- **`install --profile` end-to-end (one command installs the set, ordered, one scope, one adapter, skip-already-installed, partial-failure summary):** goal-based, exercised by an **integration** test against a fixture catalogue + temp scope roots — assert the resulting state rows and on-disk files. The partial-failure case injects the fault deterministically (monkeypatch `safety.write_jailed` to raise on the second pack), then asserts the first pack's files + state row persist (no rollback), the failed/unwritten packs are absent, and the per-pack summary names success vs. failure.
+- **Pinned adapter disallowed by a batch pack:** goal-based — pin (or resolve) an adapter one pack's `allowed-adapters` excludes; assert the command refuses **before any write** (no state row, no file), names the offending pack, and suggests a compatible adapter.
+- **`install_route` regression:** goal-based — a normal single-pack `install --pack` still records `install_route="cli"` (the `_install_route` seam must not flip the single-pack default), and a profile-installed pack records `"profile"`.
+- **Batch dep version enforced at write time:** goal-based — a batch whose in-batch dep is present by name but at an unsatisfying version still refuses (caught by the lint at author-time; and by the real write-time gate were it to slip through).
 - **`list-profiles` output (id + scope + description):** goal-based — run the command against the fixture catalogue and assert the listing.
 - **`--scope` rejected with `--profile`; `--profile` mutually exclusive with `--pack`:** goal-based — assert non-zero exit + message.
 - **Both shipped profiles install cleanly against the real catalogue:** goal-based — `solution-architect` (user) and `full-ceremony` (repo) each install in a temp scope root.
+- **No marketplace/build/self-host change (AC15):** goal-based — a name-only `git diff --name-only origin/main` over the feature's diff touches none of `.claude-plugin/marketplace.json`, `packages/agentbundle/agentbundle/build/`, or self-host paths.
 
 ## Acceptance Criteria
 
-- [ ] `profiles/<name>.toml` is read from the catalogue root; the profile id is the filename stem and must match `^[a-z0-9][a-z0-9-]*$`.
-- [ ] A profile manifest declares a required `scope` (`"user"` | `"repo"`), a `description`, and an ordered `packs` list (each entry a pack name); an unknown field or missing `scope` is rejected.
-- [ ] `agentbundle install --profile <name> <catalogue>` installs every pack in the manifest, in listed order, at the profile's declared scope.
-- [ ] All preconditions for every pack run before any write; if any pack's precondition fails (scope, missing dep not in the batch, disallowed adapter, path-jail), the command refuses **before writing any pack**, naming the offending pack, and exits non-zero.
-- [ ] Exactly one adapter is resolved for the whole batch (explicit `--adapter`, else the scope's normal resolution run once) and applied to every pack; if any pack disallows it, the command refuses before any write.
-- [ ] Packs already installed at the declared scope are skipped and reported as `already present, skipped`; the single-pack refuse-on-reinstall path (`install.py:426-432`) is not triggered.
-- [ ] `validate_dependencies_required` accepts a "also-installing-in-this-batch" set, so `full-ceremony` installs (the three non-core packs' required `core ^0.1` is satisfied by `core` earlier in the batch); removing `core` from that profile fails the dep gate.
-- [ ] On a write-phase I/O failure, packs already written stay (no rollback); the command reports a per-pack success/fail summary and the deps-first order guarantees any installed prefix is dependency-consistent.
-- [ ] A lint fails the build when a profile is not scope-homogeneous (a pack does not allow the declared `scope`), is not dependency-complete (a required dep is neither in the set nor satisfiable), or is mis-ordered (a pack's required dep appears later than it).
-- [ ] `agentbundle list-profiles <catalogue>` lists each profile's id, scope, and description.
-- [ ] `--profile` and `--pack` are mutually exclusive (a required mutex group); `--scope` is rejected when combined with `--profile`.
-- [ ] No profile is recorded in state; per-pack rows are written at the profile's scope exactly as a manual per-pack install would; `STATE_SCHEMA_VERSION` is unchanged.
-- [ ] `install_route` on each profile-installed pack's state row reads `"profile"` (RFC-0034 OQ3, accepted); the adapter contract version is unchanged.
-- [ ] Two first-party profiles ship: `profiles/solution-architect.toml` (`scope = "user"`) and `profiles/full-ceremony.toml` (`scope = "repo"`), each installing cleanly against the live catalogue.
-- [ ] No change to `.claude-plugin/marketplace.json`, the build pipeline, or self-host.
+- [x] `profiles/<name>.toml` is read from the catalogue root; the profile id is the filename stem and must match `^[a-z0-9][a-z0-9-]*$`.
+- [x] A profile manifest declares a required `scope` (`"user"` | `"repo"`), a `description`, and an ordered `packs` list (each entry a pack name); an unknown field or missing `scope` is rejected.
+- [x] `agentbundle install --profile <name> <catalogue>` installs every pack in the manifest, in listed order, at the profile's declared scope.
+- [x] All preconditions for every pack run before any write; if any pack's precondition fails (scope, missing dep not in the batch, disallowed adapter, path-jail), the command refuses **before writing any pack**, naming the offending pack, and exits non-zero. The orchestrator achieves this by running each pack's read-only pre-flight — single-pack `install.run` in dry-run mode, Steps 1–8 including the path-jail probe at `install.py:789` — for the whole batch before any pack's write loop runs.
+- [x] Exactly one adapter is resolved for the whole batch (explicit `--adapter`, else the scope's normal resolution run once) and applied to every pack; if any pack disallows the pinned adapter, the command refuses before any write, naming the offending pack and suggesting a compatible adapter (drawn from the intersection of the batch's `allowed-adapters`).
+- [x] Packs already installed at the declared scope are skipped and reported as `already present, skipped`; the single-pack refuse-on-reinstall path (`install.py:446-454`) is not triggered.
+- [x] `validate_dependencies_required` accepts a "also-installing-in-this-batch" set, so `full-ceremony` installs (the three non-core packs' required `core ^0.1` is satisfied by `core` earlier in the batch); removing `core` from that profile fails the dep gate. The batch set satisfies the gate by pack *name* at pre-flight; the version range is enforced for real at write time by each pack's gate against actual state (deps-first order installs the dep first), and the lint (AC9) independently checks in-batch version satisfiability.
+- [x] On a write-phase **genuine I/O failure** (disk full and the like — *not* a precondition miss, which the batch dry-run pre-flight already caught before any write), packs already written stay (no rollback); the command reports a per-pack success/fail summary and the deps-first order guarantees any installed prefix is dependency-consistent.
+- [x] A lint fails the build when a profile is not scope-homogeneous (a pack does not allow the declared `scope`), is not dependency-complete (a required dep is missing from the profile's pack set, or present but at a version that does not satisfy the required range), or is mis-ordered (a pack's required dep appears later than it). (Per RFC-0034 D5/§24 the lint's invariants are scope-homogeneity + dep-completeness + order-validity; adapter-homogeneity is deliberately *not* a lint invariant — adapter mismatch is handled at install time by the resolve-once + refuse-and-suggest contract in AC5, per RFC-0034 D5 step 2.)
+- [x] `agentbundle list-profiles <catalogue>` lists each profile's id, scope, and description.
+- [x] `--profile` and `--pack` are mutually exclusive (a required mutex group); `--scope` is rejected when combined with `--profile`.
+- [x] No profile is recorded in state; per-pack rows are written at the profile's scope exactly as a manual per-pack install would; `STATE_SCHEMA_VERSION` is unchanged.
+- [x] `install_route` on each profile-installed pack's state row reads `"profile"` (RFC-0034 OQ3, accepted); the adapter contract version is unchanged.
+- [x] Two first-party profiles ship: `profiles/solution-architect.toml` (`scope = "user"`) and `profiles/full-ceremony.toml` (`scope = "repo"`), each installing cleanly against the live catalogue.
+- [x] No change to `.claude-plugin/marketplace.json`, the build pipeline, or self-host. Verified by a name-only `git diff --name-only origin/main` over the feature's diff showing none of those paths are touched — sufficient for this additive, CLI-route-only PR (`profiles/` is a new top-level dir outside `packs/`, so `build-self` never aggregates it into `marketplace.json`). Wiring profiles into any of those surfaces would be a separate change with its own review; this AC asserts this PR does not.
 
 ## Assumptions
 
@@ -76,6 +80,7 @@ before proceeding; *Never do* is a hard rule, even under time pressure.
 - Technical: the required-dependency gate is `validate_dependencies_required` (`install.py:3203`), evaluated against union state; the batch-aware parameter extends it. (source: `packages/agentbundle/agentbundle/commands/install.py:3203`)
 - Technical: scope resolves via `scope.resolve` (`scope.py:117`) with `ScopeRefused` on an out-of-`allowed-scopes` request; adapter via `_resolve_target_adapter` with `DEFAULT_ADAPTER`. (source: `packages/agentbundle/agentbundle/scope.py`, `commands/install.py`)
 - Technical: `solution-architect` packs (`architect`/`research`/`contracts`) are `default-scope = "user"` with no `[pack.dependencies]`, and all three also allow repo scope (`allowed-scopes = ["user","repo"]`); `full-ceremony` packs are repo-scope and the three non-core packs each declare required `core ^0.1`. The scope-homogeneity lint therefore checks `allowed-scopes` *membership* of the declared scope, not `default-scope`. (source: `packs/{architect,research,contracts,core,governance-extras,user-guide-diataxis,monorepo-extras}/pack.toml`)
+- Technical: the `solution-architect` packs' `allowed-adapters` sets *differ* — only `architect` lists `kiro-cli`; all three list `claude-code` (the resolution default). Their intersection is therefore non-empty and contains the default, so the profile resolves cleanly on a default environment (guarded by the AC14 smoke test). The batch adapter is resolved **once** and asserted per-pack (AC5); a mismatch is handled at install time by refuse-and-suggest, *not* by an author-time lint invariant (RFC-0034 D5 step 2 designs the runtime refusal; line 24 fixes the lint to scope/dep/order only). (source: `packs/{architect,research,contracts}/pack.toml`; RFC-0034 D5)
 - Technical: new lint/tool code is authored in Python, invoked via `sys.executable`, for Windows portability. (source: `AGENTS.local.md` convention; user memory)
 - Process: this spec is constrained by RFC-0034 (Accepted 2026-06-14) and ADR-0025; it makes no new design decisions. (source: `docs/rfc/0034-pack-profiles.md`, `docs/adr/0025-pack-profiles-single-scope-cli-manifest.md`)
 - Product: the feature serves adopters installing a role's user-scope toolkit or a repo's setup bundle in one command. (source: RFC-0034; user confirmation 2026-06-14)

--- a/packages/agentbundle/agentbundle/_data/profile.schema.json
+++ b/packages/agentbundle/agentbundle/_data/profile.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "required": ["scope", "description", "packs"],
+  "additionalProperties": false,
+  "properties": {
+    "scope": {"enum": ["repo", "user"]},
+    "description": {"type": "string"},
+    "packs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["pack"],
+        "additionalProperties": false,
+        "properties": {
+          "pack": {"type": "string"}
+        }
+      }
+    }
+  }
+}

--- a/packages/agentbundle/agentbundle/cli.py
+++ b/packages/agentbundle/agentbundle/cli.py
@@ -1,9 +1,11 @@
 """`agentbundle` CLI dispatcher — argparse over the eleven F-cli subcommands.
 
 Subcommand order on the parser matches the canonical install-workflow order
-from the spec (discovery-first): `list-packs`, `list-targets`, `scaffold`,
-`install`, `validate`, `render`, `adapt`, `diff`, `upgrade`, `uninstall`,
-`init-state`.
+from the spec (discovery-first): `list-packs`, `list-profiles`, `list-targets`,
+`scaffold`, `install`, `validate`, `render`, `adapt`, `diff`, `upgrade`,
+`uninstall`, `init-state`, `config`, `reconcile`. `list-profiles` (RFC-0034)
+lists the catalogue's curated single-scope install profiles; `install
+--profile <name>` installs one.
 
 Each subcommand's `run(args) -> int` lives under `agentbundle.commands.*`;
 this module wires `argparse` and prints `--version`. No business logic here.
@@ -192,6 +194,14 @@ def _build_parser() -> argparse.ArgumentParser:
     sp.add_argument("catalogue", help="Catalogue URI (local path or git+https://...).")
     sp.set_defaults(func=_lazy("list_packs"))
 
+    # --- list-profiles --- (catalogue query; profiles declare their own scope)
+    sp = subparsers.add_parser(
+        "list-profiles",
+        help="List curated install profiles available in a catalogue URI.",
+    )
+    sp.add_argument("catalogue", help="Catalogue URI (local path or git+https://...).")
+    sp.set_defaults(func=_lazy("list_profiles"))
+
     # --- list-targets --- (--scope as read-only filter)
     sp = subparsers.add_parser(
         "list-targets",
@@ -215,7 +225,23 @@ def _build_parser() -> argparse.ArgumentParser:
         "install",
         help="Install a pack from a catalogue URI into the adopter repo.",
     )
-    sp.add_argument("--pack", required=True)
+    # pack-profiles: `--pack` and `--profile` are a required mutually-exclusive
+    # group. `--pack` was a bare `required=True` arg; making it a member of a
+    # required mutex group keeps "exactly one of pack/profile" without losing
+    # the requiredness. `--scope` with `--profile` is rejected at the handler
+    # (a profile declares its own scope); argparse can't express that mutex
+    # because `--scope` is valid alongside `--pack`.
+    _pack_or_profile = sp.add_mutually_exclusive_group(required=True)
+    _pack_or_profile.add_argument("--pack")
+    _pack_or_profile.add_argument(
+        "--profile",
+        help=(
+            "Install a curated single-scope set of packs from "
+            "<catalogue>/profiles/<name>.toml in one command (RFC-0034). "
+            "Mutually exclusive with --pack; --scope is not allowed (the "
+            "profile declares its own scope)."
+        ),
+    )
     sp.add_argument("catalogue", help="Catalogue URI (local path or git+https://...).")
     sp.add_argument("--output", default=".")
     sp.add_argument("--scope", choices=("repo", "user"))

--- a/packages/agentbundle/agentbundle/commands/install.py
+++ b/packages/agentbundle/agentbundle/commands/install.py
@@ -96,6 +96,21 @@ def run(args: "argparse.Namespace") -> int:
     from agentbundle import safety, scope as scope_mod
     from agentbundle.build import scope_rails
 
+    # pack-profiles (RFC-0034): `install --profile <name>` dispatches to the
+    # batch orchestrator. The CLI mutex guarantees exactly one of --pack /
+    # --profile; `--scope` is rejected here because a profile declares its own
+    # scope (argparse can't express that mutex — --scope is valid with --pack).
+    # Guarded before `args.pack` is read, which is None under --profile.
+    if getattr(args, "profile", None):
+        if getattr(args, "scope", None) is not None:
+            print(
+                "install: --scope is not allowed with --profile; a profile "
+                "declares its own scope in its manifest",
+                file=sys.stderr,
+            )
+            return 1
+        return _run_profile(args)
+
     pack_name: str = args.pack
     catalogue_uri: str = args.catalogue
     cli_scope: str | None = getattr(args, "scope", None)
@@ -333,7 +348,12 @@ def run(args: "argparse.Namespace") -> int:
     _effective_user_state: "State" = user_state if user_state is not None else _State()
     try:
         validate_dependencies_required(
-            pack_toml, repo_state=repo_state, user_state=_effective_user_state
+            pack_toml,
+            repo_state=repo_state,
+            user_state=_effective_user_state,
+            # pack-profiles AC7: under a profile install, a required dep may be
+            # satisfied by another pack in the same batch. None for single-pack.
+            also_installing=getattr(args, "_batch_packs", None),
         )
     except RuntimeError as exc:
         print(str(exc), file=sys.stderr)
@@ -859,7 +879,10 @@ def run(args: "argparse.Namespace") -> int:
         new_pack_state = PackState(
             installed_version=pack_version,
             source="agent-ready-repo",
-            install_route="cli",
+            # pack-profiles AC13: a profile install records "profile"; the
+            # orchestrator sets `args._install_route`. Default "cli" keeps
+            # single-pack callers unchanged.
+            install_route=getattr(args, "_install_route", "cli"),
             scope=plan.scope,
             primitives=_collect_primitives(pack_dir),
             files={},
@@ -3266,6 +3289,7 @@ def validate_dependencies_required(
     *,
     repo_state: "State",
     user_state: "State",
+    also_installing: "set[str] | None" = None,
 ) -> None:
     """Enforce [pack.dependencies.required] before any file write.
 
@@ -3278,10 +3302,23 @@ def validate_dependencies_required(
     version ``A.B.C`` satisfies ``^X.Y`` when ``A == X AND (B > Y OR (B
     == Y AND C >= 0))``, i.e. ``>= X.Y.0 AND < (X+1).0.0``.
 
+    ``also_installing`` (pack-profiles AC7) — names of packs being installed in
+    the *same batch* as this one (a profile install). A required dep whose name
+    is in this set is treated as satisfied **by name**: at pre-flight nothing is
+    written yet, so the dep carries no on-disk version to range-check. The
+    version range is enforced for real at write time — the profile orchestrator
+    writes deps-first, so each dependent's per-pack gate re-runs against actual
+    state with the dep's real version — and the profile lint
+    (``tools/lint-profiles.py``) independently checks in-batch version
+    satisfiability at author-time. The version-range *grammar* is still
+    validated even for an in-batch dep (a malformed range is a manifest bug).
+    Default ``None`` → existing single-pack behavior, byte-for-byte.
+
     Raises:
         RuntimeError: on unsupported range grammar or missing/out-of-range dep.
             Caller is expected to print str(exc) to stderr and exit 1.
     """
+    batch = also_installing or set()
     import re
 
     _CARET_RE = re.compile(r"^\^([0-9]+)\.([0-9]+)$")
@@ -3321,10 +3358,22 @@ def validate_dependencies_required(
 
         dep_version = installed.get(dep_name)
         if dep_version is None:
+            # Not on disk. Batch-aware (pack-profiles AC7): a dep being
+            # installed *later in this same batch* satisfies the gate by name —
+            # at pre-flight nothing is written yet, so there is no version to
+            # range-check. Deps-first write order means it will be on disk
+            # before its dependent's write gate re-runs, where the real version
+            # check below fires. The grammar above is already validated.
+            if dep_name in batch:
+                continue
             raise RuntimeError(
                 f"install: pack {pack_name!r} requires {dep_name!r} "
                 f"(version {dep_range}); install {dep_name} first"
             )
+        # On disk — always range-check the *actual* installed version, even
+        # when the dep is also in the batch. This is what makes the write-time
+        # gate real: a dep pre-installed (or written earlier in the batch) at a
+        # version that does not satisfy the range is refused, not name-bypassed.
 
         # Parse installed version X.Y.Z (allow fewer components).
         parts = dep_version.split(".")
@@ -3351,6 +3400,281 @@ def validate_dependencies_required(
                 f"install: pack {pack_name!r} requires {dep_name!r} "
                 f"(version {dep_range}); install {dep_name} first"
             )
+
+
+def _profile_pack_allowed_adapters(pack_toml: dict) -> list[str] | None:
+    """Extract a pack's declared ``allowed-adapters`` (None ⇒ unconstrained).
+
+    Mirrors the gated extraction in ``run()``: the ``[pack.install]`` table is
+    only honoured for contract version >= 0.2 (a stray table on a v0.1 pack is
+    ignored).
+    """
+    from agentbundle.config import pack_spec_version
+
+    version = pack_spec_version(pack_toml)
+    if version is None or version == "0.1":
+        return None
+    install = pack_toml.get("pack", {}).get("install")
+    if not isinstance(install, dict):
+        return None
+    raw = install.get("allowed-adapters")
+    if isinstance(raw, list):
+        return [s for s in raw if isinstance(s, str)]
+    return None
+
+
+def _run_profile(args: "argparse.Namespace") -> int:
+    """Install a curated, single-scope set of packs in one command (RFC-0034).
+
+    A thin orchestrator over single-pack ``run()``: it pins one scope and one
+    adapter for the whole batch, runs the full read-only pre-flight (each pack's
+    ``run(dry_run=True)``, Steps 1–8 incl. the path-jail probe) for **every**
+    pack before writing **any**, then writes each pack by calling ``run()`` in
+    deps-first authored order. It reimplements none of ``run()``'s write logic;
+    it only sequences and gates. See ``docs/specs/pack-profiles/``.
+
+    Returns 0 on success, non-zero on any pre-flight refusal or write failure.
+    """
+    import argparse
+    import contextlib
+    import io
+
+    from agentbundle.catalogue import CatalogueError, resolve_catalogue
+    from agentbundle.commands.profile import ProfileError, load_profile
+    from agentbundle.config import ConfigError, load_pack_toml, load_state
+    from agentbundle import safety
+    from agentbundle import scope as scope_mod
+
+    profile_id: str = args.profile
+    catalogue_uri: str = args.catalogue
+    cli_adapter: str | None = getattr(args, "adapter", None)
+    user_config = getattr(args, "_user_config", None)
+    output_root = Path(args.output).resolve()
+
+    # ── Resolve catalogue + load the profile manifest ─────────────────────────
+    try:
+        catalogue_dir = resolve_catalogue(catalogue_uri)
+    except CatalogueError as exc:
+        print(f"install: {exc}", file=sys.stderr)
+        return 1
+    try:
+        profile = load_profile(catalogue_dir, profile_id)
+    except ProfileError as exc:
+        print(f"install: {exc}", file=sys.stderr)
+        return 1
+
+    scope_value = profile.scope
+    pack_names = list(profile.packs)
+    batch = set(pack_names)
+
+    # ── Locate every pack + load its manifest (existence pre-check, AC4) ───────
+    pack_dirs: dict[str, Path] = {}
+    pack_tomls: dict[str, dict] = {}
+    for name in pack_names:
+        pack_dir = _locate_pack(catalogue_dir, name)
+        if pack_dir is None:
+            print(
+                f"install: profile {profile_id!r}: pack {name!r} not found in "
+                f"catalogue at {catalogue_dir}",
+                file=sys.stderr,
+            )
+            return 1
+        try:
+            pack_tomls[name] = load_pack_toml(pack_dir / "pack.toml")
+        except ConfigError as exc:
+            print(f"install: profile {profile_id!r}: {exc}", file=sys.stderr)
+            return 1
+        pack_dirs[name] = pack_dir
+
+    # ── Resolve ONE adapter for the whole batch, assert each pack allows it ───
+    # Explicit --adapter, else the scope's normal resolution run once (via the
+    # first pack). Then assert membership per pack; refuse-and-suggest on a
+    # mismatch before any write (AC5, RFC-0034 D5 step 2).
+    from agentbundle.config import pack_spec_version
+
+    def _contract_version(name: str) -> str | None:
+        return pack_spec_version(pack_tomls[name])
+
+    first = pack_names[0]
+    try:
+        batch_adapter = _resolve_target_adapter(
+            pack_dirs[first],
+            scope=scope_value,
+            adapter=cli_adapter,
+            allowed_adapters=_profile_pack_allowed_adapters(pack_tomls[first]),
+            contract_version=_contract_version(first),
+            state_adapter=None,
+            command_name="install",
+            user_config=user_config,
+        )
+    except _AdapterResolutionRefused as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    # Suggestion set: intersection of declared allowed-adapters across the batch
+    # (packs that declare none impose no constraint). Used only for the refusal
+    # message — never for resolution.
+    suggestion: set[str] = set(scope_mod.shipped_adapters_from_contract())
+    for name in pack_names:
+        declared = _profile_pack_allowed_adapters(pack_tomls[name])
+        if declared is not None:
+            suggestion &= set(declared)
+
+    for name in pack_names:
+        try:
+            _resolve_target_adapter(
+                pack_dirs[name],
+                scope=scope_value,
+                adapter=batch_adapter,
+                allowed_adapters=_profile_pack_allowed_adapters(pack_tomls[name]),
+                contract_version=_contract_version(name),
+                state_adapter=None,
+                command_name="install",
+                user_config=user_config,
+            )
+        except _AdapterResolutionRefused:
+            compat = (
+                f" compatible adapters for this profile: "
+                f"{sorted(suggestion)}" if suggestion else ""
+            )
+            print(
+                f"install: profile {profile_id!r}: pack {name!r} does not allow "
+                f"adapter {batch_adapter!r}; refusing before any write."
+                f"{compat}",
+                file=sys.stderr,
+            )
+            return 1
+
+    # ── Determine already-installed packs at the declared scope (AC6) ─────────
+    if scope_value == "repo":
+        state_path = output_root / ".agentbundle-state.toml"
+    else:
+        try:
+            user_root = scope_mod.resolve_user_root()
+        except scope_mod.UserScopeUnresolvable:
+            print(
+                "install: cannot resolve user scope: $HOME unset or invalid",
+                file=sys.stderr,
+            )
+            return 1
+        state_path = user_root / ".agentbundle" / "state.toml"
+    try:
+        state = load_state(state_path)
+    except ConfigError as exc:
+        print(f"install: {exc}", file=sys.stderr)
+        return 1
+    already = {name for name in pack_names if name in state.packs}
+    remaining = [name for name in pack_names if name not in already]
+
+    # ── Refuse cross-scope: a pack present at the *opposite* scope ────────────
+    # A profile is single-scope (Boundary: never mix scopes). A pack already
+    # installed at the other scope cannot be cleanly handled — the single-pack
+    # path would need --force to dual-install, which the profile surface does
+    # not expose. Refuse with a profile-aware message instead of letting the
+    # per-pack dry-run surface the misleading single-pack "pass --force" line.
+    opposite = "user" if scope_value == "repo" else "repo"
+    opp_state = None
+    try:
+        if opposite == "repo":
+            opp_state = load_state(output_root / ".agentbundle-state.toml")
+        else:
+            opp_root = scope_mod.resolve_user_root()
+            opp_state = load_state(opp_root / ".agentbundle" / "state.toml")
+    except (scope_mod.UserScopeUnresolvable, ConfigError):
+        opp_state = None  # opposite scope unreadable → nothing to conflict with
+    if opp_state is not None:
+        cross = [name for name in remaining if name in opp_state.packs]
+        if cross:
+            print(
+                f"install: profile {profile_id!r}: pack(s) {cross} already "
+                f"installed at {opposite} scope; a profile installs only at its "
+                f"declared {scope_value} scope and will not install the same "
+                f"pack across scopes. Uninstall them from {opposite} scope "
+                f"first, or install them individually.",
+                file=sys.stderr,
+            )
+            return 1
+
+    # ── Per-pack args factory (catalogue pre-resolved to avoid re-cloning) ────
+    def _pack_args(name: str, *, dry_run: bool) -> "argparse.Namespace":
+        ns = argparse.Namespace()
+        ns.pack = name
+        ns.profile = None  # so run()'s dispatch does not recurse
+        ns.catalogue = str(catalogue_dir)
+        ns.output = args.output
+        ns.scope = scope_value  # pin the declared scope for every pack
+        ns.adapter = batch_adapter  # pin the one resolved adapter
+        ns.force = False
+        ns.force_merge = False
+        ns.emit_install_routes = False  # modern per-IDE projection at repo scope
+        ns.dry_run = dry_run
+        ns._user_config = user_config
+        ns._install_route = "profile"  # AC13
+        ns._batch_packs = batch  # AC7 — in-batch deps satisfy the gate
+        return ns
+
+    # ── Pre-flight: dry-run EVERY remaining pack before ANY write (AC4) ───────
+    # run(dry_run=True) exercises Steps 1–8 — scope, batch dep gate, adapter,
+    # render, and the read-only path-jail probe — and returns non-zero without
+    # writing. Suppress its stdout (the per-file plan); let stderr (the real
+    # error) flow so the adopter sees why.
+    for name in remaining:
+        with contextlib.redirect_stdout(io.StringIO()):
+            rc = run(_pack_args(name, dry_run=True))
+        if rc != 0:
+            print(
+                f"install: profile {profile_id!r}: pre-flight failed for pack "
+                f"{name!r}; aborting before any write",
+                file=sys.stderr,
+            )
+            return rc or 1
+
+    # ── Write: install each remaining pack in deps-first authored order ───────
+    summary: list[tuple[str, str]] = []
+    for idx, name in enumerate(pack_names):
+        if name in already:
+            summary.append((name, "already present, skipped"))
+            continue
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                rc = run(_pack_args(name, dry_run=False))
+        except (safety.WriteError, OSError) as exc:
+            # single-pack run()'s projection write loop catches only
+            # PathJailError; a genuine I/O failure (disk full) propagates here.
+            print(
+                f"install: profile {profile_id!r}: pack {name!r} failed to "
+                f"write: {exc}",
+                file=sys.stderr,
+            )
+            rc = 1
+        if rc != 0:
+            summary.append((name, "failed"))
+            # Packs after the failure were never attempted (no rollback of the
+            # consistent prefix already written). Report them so the summary
+            # reflects the whole batch's state, not just up to the failure.
+            for later in pack_names[idx + 1:]:
+                summary.append(
+                    (later, "already present, skipped"
+                     if later in already else "not attempted")
+                )
+            _emit_profile_summary(profile_id, scope_value, batch_adapter, summary)
+            return 1
+        summary.append((name, "installed"))
+
+    _emit_profile_summary(profile_id, scope_value, batch_adapter, summary)
+    return 0
+
+
+def _emit_profile_summary(
+    profile_id: str,
+    scope_value: str,
+    adapter: str,
+    summary: list[tuple[str, str]],
+) -> None:
+    """Print the per-pack profile-install summary to stdout (AC8)."""
+    print(f"profile {profile_id} ({scope_value} scope, adapter {adapter}):")
+    for name, status in summary:
+        print(f"  {name}: {status}")
 
 
 def _collect_primitives(pack_dir: Path) -> list[str]:

--- a/packages/agentbundle/agentbundle/commands/list_profiles.py
+++ b/packages/agentbundle/agentbundle/commands/list_profiles.py
@@ -1,0 +1,63 @@
+"""``agentbundle list-profiles`` subcommand (RFC-0034 / spec pack-profiles).
+
+Resolves a catalogue URI, enumerates every valid ``profiles/*.toml``, and
+prints a stable table of id, scope, description to stdout. Modeled on
+``list_packs``.
+
+Exit codes:
+  0  — success (an empty listing is not an error).
+  1  — catalogue resolution error (one-line stderr from CatalogueError).
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import argparse
+
+
+def run(args: "argparse.Namespace") -> int:
+    """Entry point for ``agentbundle list-profiles``.
+
+    Args:
+        args.catalogue — catalogue URI (local path or git+https://...).
+
+    Returns 0 on success, 1 on catalogue resolution failure.
+    """
+    from agentbundle.catalogue import CatalogueError, resolve_catalogue
+    from agentbundle.commands.profile import list_profiles
+
+    catalogue_uri: str = args.catalogue
+
+    try:
+        catalogue_dir = resolve_catalogue(catalogue_uri)
+    except CatalogueError as exc:
+        print(f"list-profiles: {exc}", file=sys.stderr)
+        return 1
+
+    profiles = list_profiles(catalogue_dir)
+    _print_table(profiles)
+    return 0
+
+
+def _print_table(profiles) -> None:
+    """Print a fixed-column table to stdout: ID, SCOPE, DESCRIPTION.
+
+    Deterministic: ``list_profiles`` returns id-sorted rows; column widths are
+    derived from content so the table is alignment-stable.
+    """
+    headers = ["ID", "SCOPE", "DESCRIPTION"]
+    rows = [(p.id, p.scope, p.description) for p in profiles]
+
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(cell))
+
+    fmt = "  ".join(f"{{:<{w}}}" for w in widths)
+    print(fmt.format(*headers))
+    print(fmt.format(*("-" * w for w in widths)))
+    for row in rows:
+        print(fmt.format(*row))

--- a/packages/agentbundle/agentbundle/commands/profile.py
+++ b/packages/agentbundle/agentbundle/commands/profile.py
@@ -1,0 +1,155 @@
+"""Profile-manifest reader (RFC-0034 / spec pack-profiles, T1).
+
+A *profile* is a first-party-curated, single-scope set of packs an adopter
+installs in one command. It is a hand-authored ``profiles/<name>.toml`` at the
+catalogue root, read **only** by the ``agentbundle`` CLI — it adds zero
+primitives, zero runtime, and zero adapter-contract surface (RFC-0034).
+
+This module owns reading and validating those manifests. It does **not**
+orchestrate installs (that is ``commands/install.py``'s ``_run_profile``) and it
+does **not** lint the catalogue's profiles against the live ``packs/`` tree
+(that is ``tools/lint-profiles.py``).
+
+Manifest shape (closed schema ``_data/profile.schema.json``)::
+
+    scope = "user"            # required, "user" | "repo"
+    description = "..."        # required
+    [[packs]]                  # required, ordered (deps-first), >= 1 entry
+    pack = "architect"
+    [[packs]]
+    pack = "research"
+
+The profile **id** is the filename stem, not a manifest field; it must match
+``^[a-z0-9][a-z0-9-]*$`` (the same grammar packs use).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+try:  # Python 3.11+ stdlib; the package targets 3.11+.
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - 3.10 fallback if ever needed
+    import tomli as tomllib  # type: ignore[no-redef]
+
+# Same grammar as pack names (docs/CONVENTIONS.md) and ``install._PACK_NAME_RE``.
+PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+_HERE = Path(__file__).resolve().parent
+
+
+class ProfileError(Exception):
+    """A profile manifest could not be located, parsed, or validated.
+
+    Callers print ``str(exc)`` to stderr and exit non-zero, mirroring the
+    ``ConfigError`` / ``CatalogueError`` handling in the install/list-packs
+    command handlers.
+    """
+
+
+@dataclass(frozen=True)
+class Profile:
+    """A parsed, schema-valid profile manifest.
+
+    ``packs`` is the authored (deps-first) order, preserved from the TOML
+    array-of-tables — the orchestrator installs in exactly this order and the
+    lint enforces it is dependency-respecting.
+    """
+
+    id: str
+    scope: str
+    description: str
+    packs: tuple[str, ...]
+
+
+def _schema_path() -> Path:
+    """Locate the bundled ``_data/profile.schema.json``.
+
+    Unlike ``pack.schema.json`` (which also ships to ``docs/contracts/`` as an
+    adopter-facing contract), the profile schema is internal and lives only at
+    ``_data/`` — it ships with both the editable checkout and the zipapp. The
+    caller surfaces a clear error if it is ever absent.
+    """
+    return _HERE.parent / "_data" / "profile.schema.json"
+
+
+def profiles_dir(catalogue_dir: Path) -> Path:
+    """Return the catalogue's ``profiles/`` directory (may not exist)."""
+    return catalogue_dir / "profiles"
+
+
+def _parse_and_validate(profile_id: str, toml_path: Path) -> Profile:
+    """Parse + schema-validate one manifest into a :class:`Profile`.
+
+    Raises :class:`ProfileError` with a one-line, profile-named message on any
+    failure (bad id grammar, missing file, bad TOML, schema violation).
+    """
+    if not PROFILE_ID_RE.fullmatch(profile_id):
+        raise ProfileError(
+            f"profile {profile_id!r} has invalid id: "
+            f"must match ^[a-z0-9][a-z0-9-]*$ (the filename stem)"
+        )
+    if not toml_path.exists():
+        raise ProfileError(
+            f"profile {profile_id!r} not found at {toml_path}; "
+            f"expected <catalogue>/profiles/{profile_id}.toml"
+        )
+    try:
+        raw = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        raise ProfileError(f"profile {profile_id!r}: invalid TOML: {exc}") from exc
+
+    # In-house validator (no jsonschema dependency), same one validate.py uses.
+    from agentbundle.build.validate import validate as validate_instance
+
+    schema_path = _schema_path()
+    if not schema_path.exists():
+        raise ProfileError(
+            f"profile.schema.json not found at {schema_path}"
+        )
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    errors = validate_instance(raw, schema)
+    if errors:
+        raise ProfileError(f"profile {profile_id!r}: schema error — {errors[0]}")
+
+    packs = tuple(entry["pack"] for entry in raw["packs"])
+    return Profile(
+        id=profile_id,
+        scope=raw["scope"],
+        description=raw["description"],
+        packs=packs,
+    )
+
+
+def load_profile(catalogue_dir: Path, profile_id: str) -> Profile:
+    """Load a single profile by id from ``<catalogue_dir>/profiles/<id>.toml``.
+
+    Raises :class:`ProfileError` on any failure.
+    """
+    toml_path = profiles_dir(catalogue_dir) / f"{profile_id}.toml"
+    return _parse_and_validate(profile_id, toml_path)
+
+
+def list_profiles(catalogue_dir: Path) -> list[Profile]:
+    """Return every valid profile under ``<catalogue_dir>/profiles/``.
+
+    Sorted by id. A file whose stem is not a valid profile id, or whose body
+    fails the schema, is skipped with a stderr note (mirrors ``list-packs``
+    skipping a malformed ``pack.toml``) rather than aborting the listing.
+    """
+    pdir = profiles_dir(catalogue_dir)
+    if not pdir.is_dir():
+        return []
+    out: list[Profile] = []
+    for toml_path in sorted(pdir.glob("*.toml"), key=lambda p: p.stem):
+        profile_id = toml_path.stem
+        try:
+            out.append(_parse_and_validate(profile_id, toml_path))
+        except ProfileError as exc:
+            print(f"list-profiles: skipping {toml_path.name}: {exc}", file=sys.stderr)
+            continue
+    return out

--- a/packages/agentbundle/tests/integration/test_config_cascade.py
+++ b/packages/agentbundle/tests/integration/test_config_cascade.py
@@ -7,7 +7,7 @@ Three integration tests cover AC15:
     up the configured value.
   - **(c)** AST static check walking every `_resolve_target_adapter`
     call in install.py + upgrade.py — every call passes
-    `user_config=` keyword; the total count equals 7.
+    `user_config=` keyword; the total count equals 9.
 
 The conftest fixture sandboxes HOME/XDG_CONFIG_HOME/APPDATA per test,
 so each test's subprocess and in-process IO land under tmp_path.
@@ -146,7 +146,7 @@ def test_in_process_resolver_honors_user_config(tmp_path: Path) -> None:
 
 def test_resolve_target_adapter_callers_thread_user_config() -> None:
     AGENTBUNDLE_DIR = Path(agentbundle.__file__).parent
-    EXPECTED = 7  # 5 in install.py, 2 in upgrade.py
+    EXPECTED = 9  # 7 in install.py (2 added by pack-profiles _run_profile), 2 in upgrade.py
     found = 0
     for src in [
         AGENTBUNDLE_DIR / "commands" / "install.py",

--- a/packages/agentbundle/tests/integration/test_install_profile.py
+++ b/packages/agentbundle/tests/integration/test_install_profile.py
@@ -1,0 +1,394 @@
+"""T5 (pack-profiles AC3–AC8, AC12, AC13): `install --profile` orchestrator.
+
+End-to-end against a fixture catalogue + temp scope roots. Verifies one command
+installs the batch in authored order, at one scope, on one pinned adapter, with
+`install_route="profile"` rows and no profile state entity; that already-
+installed packs are skipped (never tripping refuse-on-reinstall); that a later
+pack's pre-flight failure (path-jail / adapter mismatch) aborts before any
+write; and that a genuine write-phase I/O failure leaves a consistent prefix
+plus a per-pack summary.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Hygiene — pin $HOME and reset install.py's once-per-process detection sets.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home_and_caches(tmp_path, monkeypatch):
+    from agentbundle.commands import install
+
+    home = tmp_path / "iso_home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    install._clear_inband_detection_seen()
+    install._clear_dropped_warning_seen()
+    yield
+    install._clear_inband_detection_seen()
+    install._clear_dropped_warning_seen()
+
+
+# ---------------------------------------------------------------------------
+# Fixture-catalogue builders
+# ---------------------------------------------------------------------------
+
+
+def _stage_pack(cat, name, *, version="0.1.0", scope="repo", deps=None,
+                allowed_adapters=None):
+    pdir = cat / "packs" / name
+    skill = pdir / ".apm" / "skills" / f"{name}-skill"
+    skill.mkdir(parents=True)
+    lines = [
+        "[pack]",
+        f'name = "{name}"',
+        f'version = "{version}"',
+        'description = "fixture"',
+        "[pack.adapter-contract]",
+        'version = "0.6"',
+        "[pack.install]",
+        f'default-scope = "{scope}"',
+        f'allowed-scopes = ["{scope}"]',
+    ]
+    if allowed_adapters is not None:
+        lines.append(
+            "allowed-adapters = [" + ", ".join(f'"{a}"' for a in allowed_adapters) + "]"
+        )
+    for dep_name, dep_range in deps or []:
+        lines += [
+            "[[pack.dependencies.required]]",
+            'catalogue = "agent-ready-repo"',
+            f'pack = "{dep_name}"',
+            f'version = "{dep_range}"',
+        ]
+    (pdir / "pack.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    (skill / "SKILL.md").write_text(
+        f"---\ndescription: fixture skill for {name}.\n---\n\n# {name}\n",
+        encoding="utf-8",
+    )
+
+
+def _stage_profile(cat, name, scope, packs):
+    pdir = cat / "profiles"
+    pdir.mkdir(parents=True, exist_ok=True)
+    body = [f'scope = "{scope}"', 'description = "fixture profile"']
+    for p in packs:
+        body += ["[[packs]]", f'pack = "{p}"']
+    (pdir / f"{name}.toml").write_text("\n".join(body) + "\n", encoding="utf-8")
+
+
+def _three_pack_repo_catalogue(cat):
+    """pf-core (no deps) + two addons that each require pf-core ^0.1."""
+    _stage_pack(cat, "pf-core", version="0.4.9", scope="repo")
+    _stage_pack(cat, "pf-addon-a", scope="repo", deps=[("pf-core", "^0.1")])
+    _stage_pack(cat, "pf-addon-b", scope="repo", deps=[("pf-core", "^0.1")])
+    _stage_profile(cat, "test-bundle", "repo", ["pf-core", "pf-addon-a", "pf-addon-b"])
+
+
+def _run_install(argv):
+    """Run `agentbundle install <argv>` via the real parser; capture output."""
+    from agentbundle.cli import _build_parser
+    from agentbundle.commands import install
+    from agentbundle.user_config import load_user_config
+
+    parser = _build_parser()
+    args = parser.parse_args(["install"] + argv)
+    args._user_config = load_user_config()
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        rc = install.run(args)
+    return rc, out.getvalue(), err.getvalue()
+
+
+def _repo_state(target):
+    from agentbundle.config import load_state
+
+    return load_state(target / ".agentbundle-state.toml")
+
+
+# ---------------------------------------------------------------------------
+# AC3, AC5, AC12, AC13 — ordered, one scope, one adapter, profile route
+# ---------------------------------------------------------------------------
+
+
+def test_profile_installs_ordered_one_scope_one_adapter_with_route(tmp_path):
+    cat = tmp_path / "cat"
+    target = tmp_path / "repo"
+    target.mkdir()
+    _three_pack_repo_catalogue(cat)
+
+    rc, out, err = _run_install(["--profile", "test-bundle", str(cat), "--output", str(target)])
+    assert rc == 0, f"profile install failed: {err}"
+
+    state = _repo_state(target)
+    for name in ("pf-core", "pf-addon-a", "pf-addon-b"):
+        assert name in state.packs, f"{name} missing from state"
+        ps = state.packs[name]
+        assert ps.install_route == "profile", f"{name} route={ps.install_route!r}"
+        assert ps.scope == "repo"
+        assert ps.adapter == "claude-code"
+
+    # On-disk files landed under the one adapter's repo projection.
+    assert (target / ".claude" / "skills" / "pf-core-skill" / "SKILL.md").exists()
+    assert (target / ".claude" / "skills" / "pf-addon-a-skill" / "SKILL.md").exists()
+
+    # Summary in authored deps-first order.
+    assert out.index("pf-core") < out.index("pf-addon-a") < out.index("pf-addon-b")
+    assert "installed" in out
+
+    # No profile entity in state — only per-pack rows.
+    assert "test-bundle" not in state.packs
+
+
+def test_profile_state_schema_version_unchanged(tmp_path):
+    from agentbundle.config import STATE_SCHEMA_VERSION
+
+    cat = tmp_path / "cat"
+    target = tmp_path / "repo"
+    target.mkdir()
+    _three_pack_repo_catalogue(cat)
+    _run_install(["--profile", "test-bundle", str(cat), "--output", str(target)])
+    assert _repo_state(target).schema_version == STATE_SCHEMA_VERSION
+
+
+# ---------------------------------------------------------------------------
+# AC6 — already-installed packs skipped, refuse-on-reinstall not tripped
+# ---------------------------------------------------------------------------
+
+
+def test_profile_skips_already_installed(tmp_path):
+    from agentbundle.config import PackState, State, dump_state
+
+    cat = tmp_path / "cat"
+    target = tmp_path / "repo"
+    target.mkdir()
+    _three_pack_repo_catalogue(cat)
+
+    # Pre-seed pf-core at repo scope.
+    state = State()
+    state.packs["pf-core"] = PackState(installed_version="0.4.9", scope="repo")
+    (target / ".agentbundle-state.toml").write_text(dump_state(state), encoding="utf-8")
+
+    rc, out, err = _run_install(["--profile", "test-bundle", str(cat), "--output", str(target)])
+    assert rc == 0, f"profile install failed: {err}"
+    assert "pf-core: already present, skipped" in out
+    assert "use 'upgrade'" not in err  # refuse-on-reinstall not tripped
+
+    final = _repo_state(target)
+    assert final.packs["pf-addon-a"].install_route == "profile"
+    assert final.packs["pf-addon-b"].install_route == "profile"
+
+
+# ---------------------------------------------------------------------------
+# AC5 — pinned adapter disallowed by a batch pack → refuse before any write
+# ---------------------------------------------------------------------------
+
+
+def test_profile_refuses_when_a_pack_disallows_the_pinned_adapter(tmp_path):
+    cat = tmp_path / "cat"
+    target = tmp_path / "repo"
+    target.mkdir()
+    # pf-core legacy (→ claude-code default); pf-addon-b only allows codex.
+    _stage_pack(cat, "pf-core", version="0.4.9", scope="repo")
+    _stage_pack(cat, "pf-addon-b", scope="repo", deps=[("pf-core", "^0.1")],
+                allowed_adapters=["codex"])
+    _stage_profile(cat, "split", "repo", ["pf-core", "pf-addon-b"])
+
+    rc, out, err = _run_install(["--profile", "split", str(cat), "--output", str(target)])
+    assert rc == 1
+    assert "pf-addon-b" in err
+    assert "does not allow adapter 'claude-code'" in err
+    assert "codex" in err  # compatible-adapter suggestion
+    # Refused before any write: no state file, no projected files.
+    assert not (target / ".agentbundle-state.toml").exists()
+    assert not (target / ".claude").exists()
+
+
+# ---------------------------------------------------------------------------
+# AC4 — path-jail failure on a later pack aborts before any write
+# ---------------------------------------------------------------------------
+
+
+def test_profile_path_jail_on_later_pack_aborts_before_any_write(tmp_path, monkeypatch):
+    from agentbundle import safety
+
+    cat = tmp_path / "cat"
+    target = tmp_path / "repo"
+    target.mkdir()
+    _three_pack_repo_catalogue(cat)
+
+    # Simulate a path-jail escape for pf-addon-a's projection during the
+    # read-only Step-8 probe (which runs inside the dry-run pre-flight).
+    orig = safety.assert_under
+
+    def fake_assert_under(root, target_path):
+        if "pf-addon-a-skill" in str(target_path):
+            raise safety.PathJailError("simulated jail escape for pf-addon-a")
+        return orig(root, target_path)
+
+    monkeypatch.setattr(safety, "assert_under", fake_assert_under)
+
+    rc, out, err = _run_install(["--profile", "test-bundle", str(cat), "--output", str(target)])
+    assert rc != 0
+    assert "pre-flight failed for pack 'pf-addon-a'" in err
+    # Zero files written for ANY pack — including the well-formed pf-core.
+    assert not (target / ".agentbundle-state.toml").exists()
+    assert not (target / ".claude").exists()
+
+
+# ---------------------------------------------------------------------------
+# AC8 — genuine write-phase I/O failure: consistent prefix + per-pack summary
+# ---------------------------------------------------------------------------
+
+
+def test_profile_partial_write_failure_leaves_consistent_prefix(tmp_path, monkeypatch):
+    from agentbundle import safety
+
+    cat = tmp_path / "cat"
+    target = tmp_path / "repo"
+    target.mkdir()
+    _three_pack_repo_catalogue(cat)
+
+    # WriteError (the genuine-I/O residual — distinct from PathJailError) on
+    # pf-addon-a's write loop only. Pre-flight (dry-run) never calls
+    # write_jailed, so all packs pass pre-flight; the failure is mid-write.
+    orig = safety.write_jailed
+
+    def fake_write_jailed(root, relpath, content, **kw):
+        if "pf-addon-a-skill" in relpath:
+            raise safety.WriteError("simulated disk full")
+        return orig(root, relpath, content, **kw)
+
+    monkeypatch.setattr(safety, "write_jailed", fake_write_jailed)
+
+    rc, out, err = _run_install(["--profile", "test-bundle", str(cat), "--output", str(target)])
+    assert rc == 1
+
+    # pf-core (the prefix) persisted; pf-addon-a failed; no rollback.
+    state = _repo_state(target)
+    assert "pf-core" in state.packs
+    assert (target / ".claude" / "skills" / "pf-core-skill" / "SKILL.md").exists()
+    assert "pf-addon-a" not in state.packs
+    assert not (target / ".claude" / "skills" / "pf-addon-a-skill").exists()
+
+    # Per-pack summary reports the split, including the unattempted tail.
+    assert "pf-core: installed" in out
+    assert "pf-addon-a: failed" in out
+    assert "pf-addon-b: not attempted" in out
+
+
+# ---------------------------------------------------------------------------
+# AC4/AC7 — pre-flight refusals through the orchestrator (before any write)
+# ---------------------------------------------------------------------------
+
+
+def test_profile_refuses_when_dep_preinstalled_at_unsatisfying_version(tmp_path):
+    """A dep already on disk at a version that does not satisfy the range is
+    refused at pre-flight — name-membership must not bypass the version check."""
+    from agentbundle.config import PackState, State, dump_state
+
+    cat = tmp_path / "cat"
+    target = tmp_path / "repo"
+    target.mkdir()
+    _three_pack_repo_catalogue(cat)
+
+    # pf-core present at 0.0.1 (does NOT satisfy pf-addon-a's pf-core ^0.1).
+    state = State()
+    state.packs["pf-core"] = PackState(installed_version="0.0.1", scope="repo")
+    (target / ".agentbundle-state.toml").write_text(dump_state(state), encoding="utf-8")
+
+    rc, out, err = _run_install(["--profile", "test-bundle", str(cat), "--output", str(target)])
+    assert rc != 0
+    assert "pre-flight failed for pack 'pf-addon-a'" in err
+    # No addon files written (refused before any write).
+    assert not (target / ".claude" / "skills" / "pf-addon-a-skill").exists()
+    assert "pf-addon-a" not in _repo_state(target).packs
+
+
+def test_profile_refuses_when_pack_requires_dep_not_in_batch(tmp_path):
+    """A profile pack whose required dep is neither installed nor in the
+    profile is refused through the orchestrator (AC4 dep precondition)."""
+    cat = tmp_path / "cat"
+    target = tmp_path / "repo"
+    target.mkdir()
+    _stage_pack(cat, "pf-core", version="0.4.9", scope="repo")
+    _stage_pack(cat, "pf-addon-a", scope="repo", deps=[("pf-core", "^0.1")])
+    # Profile omits pf-core — pf-addon-a's dep is out of the batch.
+    _stage_profile(cat, "incomplete", "repo", ["pf-addon-a"])
+
+    rc, out, err = _run_install(["--profile", "incomplete", str(cat), "--output", str(target)])
+    assert rc != 0
+    assert "pre-flight failed for pack 'pf-addon-a'" in err
+    assert not (target / ".agentbundle-state.toml").exists()
+
+
+def test_profile_refuses_scope_mismatch(tmp_path):
+    """A user-scope profile naming a repo-only pack is refused at pre-flight
+    (AC4 scope precondition)."""
+    cat = tmp_path / "cat"
+    target = tmp_path / "repo"
+    target.mkdir()
+    _stage_pack(cat, "pf-core", version="0.4.9", scope="repo")  # repo-only
+    _stage_profile(cat, "userbad", "user", ["pf-core"])
+
+    rc, out, err = _run_install(["--profile", "userbad", str(cat), "--output", str(target)])
+    assert rc != 0
+    assert "pre-flight failed for pack 'pf-core'" in err
+
+
+def test_profile_refuses_pack_installed_at_opposite_scope(tmp_path, monkeypatch):
+    """A profile pack already installed at the opposite scope is refused with a
+    clear, profile-aware message (not the single-pack '--force' line)."""
+    from agentbundle.config import PackState, State, dump_state
+    from agentbundle import scope as scope_mod
+
+    cat = tmp_path / "cat"
+    target = tmp_path / "repo"
+    target.mkdir()
+    # Dual-scope packs so the user-scope profile is otherwise valid.
+    _stage_pack(cat, "pf-tool", scope="user")
+    # Make it dual-scope by hand (allowed-scopes both).
+    (cat / "packs" / "pf-tool" / "pack.toml").write_text(
+        '[pack]\nname = "pf-tool"\nversion = "0.1.0"\ndescription = "fixture"\n'
+        '[pack.adapter-contract]\nversion = "0.6"\n'
+        '[pack.install]\ndefault-scope = "user"\nallowed-scopes = ["user", "repo"]\n',
+        encoding="utf-8",
+    )
+    (cat / "packs" / "pf-tool" / ".apm" / "skills" / "pf-tool-skill").mkdir(parents=True, exist_ok=True)
+    (cat / "packs" / "pf-tool" / ".apm" / "skills" / "pf-tool-skill" / "SKILL.md").write_text(
+        "---\ndescription: fixture.\n---\n\n# pf-tool\n", encoding="utf-8"
+    )
+    _stage_profile(cat, "userset", "user", ["pf-tool"])
+
+    # Pre-install pf-tool at REPO scope (the opposite of the profile's user scope).
+    repo_state = State()
+    repo_state.packs["pf-tool"] = PackState(installed_version="0.1.0", scope="repo")
+    (target / ".agentbundle-state.toml").write_text(dump_state(repo_state), encoding="utf-8")
+
+    rc, out, err = _run_install(["--profile", "userset", str(cat), "--output", str(target)])
+    assert rc == 1
+    assert "already" in err and "repo scope" in err
+    assert "--force" not in err  # not the misleading single-pack remedy
+
+
+# ---------------------------------------------------------------------------
+# AC13 — single-pack install still records install_route="cli"
+# ---------------------------------------------------------------------------
+
+
+def test_single_pack_install_still_records_cli_route(tmp_path):
+    cat = tmp_path / "cat"
+    target = tmp_path / "repo"
+    target.mkdir()
+    _stage_pack(cat, "pf-core", version="0.4.9", scope="repo")
+
+    rc, out, err = _run_install(["--pack", "pf-core", str(cat), "--output", str(target)])
+    assert rc == 0, f"single-pack install failed: {err}"
+    assert _repo_state(target).packs["pf-core"].install_route == "cli"

--- a/packages/agentbundle/tests/integration/test_install_profile_live.py
+++ b/packages/agentbundle/tests/integration/test_install_profile_live.py
@@ -1,0 +1,84 @@
+"""T6 (pack-profiles AC14): the two shipped profiles install cleanly against
+the live catalogue (the repo root) into temp scope roots.
+
+Goal-based smoke: `full-ceremony` (repo) and `solution-architect` (user) each
+install end-to-end with default adapter resolution, every pack landing at the
+declared scope with `install_route="profile"`. This is the real-artifact
+exercise the work-loop requires for a user-invoked CLI feature.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+from pathlib import Path
+
+import pytest
+
+# repo root: packages/agentbundle/tests/integration/<file> → parents[4].
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home_and_caches(tmp_path, monkeypatch):
+    from agentbundle.commands import install
+
+    home = tmp_path / "iso_home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    install._clear_inband_detection_seen()
+    install._clear_dropped_warning_seen()
+    yield
+    install._clear_inband_detection_seen()
+    install._clear_dropped_warning_seen()
+
+
+def _run_install(argv):
+    from agentbundle.cli import _build_parser
+    from agentbundle.commands import install
+    from agentbundle.user_config import load_user_config
+
+    parser = _build_parser()
+    args = parser.parse_args(["install"] + argv)
+    args._user_config = load_user_config()
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        rc = install.run(args)
+    return rc, out.getvalue(), err.getvalue()
+
+
+def test_full_ceremony_installs_at_repo_scope(tmp_path):
+    from agentbundle.config import load_state
+
+    target = tmp_path / "repo"
+    target.mkdir()
+    rc, out, err = _run_install(
+        ["--profile", "full-ceremony", str(REPO_ROOT), "--output", str(target)]
+    )
+    assert rc == 0, f"full-ceremony install failed: {err}"
+
+    state = load_state(target / ".agentbundle-state.toml")
+    for name in ("core", "governance-extras", "user-guide-diataxis", "monorepo-extras"):
+        assert name in state.packs, f"{name} missing; summary:\n{out}\nstderr:\n{err}"
+        assert state.packs[name].install_route == "profile"
+        assert state.packs[name].scope == "repo"
+
+
+def test_solution_architect_installs_at_user_scope(tmp_path, monkeypatch):
+    from agentbundle import scope as scope_mod
+    from agentbundle.config import load_state
+
+    # User-scope install writes under $HOME (isolated by the autouse fixture);
+    # --output is irrelevant to user scope but pinned to tmp so a future
+    # output-resolution change can't scribble into the working tree.
+    rc, out, err = _run_install(
+        ["--profile", "solution-architect", str(REPO_ROOT), "--output", str(tmp_path)]
+    )
+    assert rc == 0, f"solution-architect install failed: {err}"
+
+    user_root = scope_mod.resolve_user_root()
+    state = load_state(user_root / ".agentbundle" / "state.toml")
+    for name in ("architect", "research", "contracts"):
+        assert name in state.packs, f"{name} missing; summary:\n{out}\nstderr:\n{err}"
+        assert state.packs[name].install_route == "profile"
+        assert state.packs[name].scope == "user"

--- a/packages/agentbundle/tests/unit/test_cli_profile_surface.py
+++ b/packages/agentbundle/tests/unit/test_cli_profile_surface.py
@@ -1,0 +1,87 @@
+"""T4 (pack-profiles AC10, AC11): CLI surface for profiles.
+
+  - `--profile` and `--pack` are a required mutually-exclusive group: passing
+    both, or neither, exits non-zero.
+  - `--scope` combined with `--profile` is rejected at the handler.
+  - `list-profiles <catalogue>` lists id + scope + description.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+
+import pytest
+
+from agentbundle import cli
+
+
+def _run(argv):
+    """Invoke cli.main, returning (exit_code, stdout, stderr).
+
+    argparse errors raise SystemExit (code 2); handler returns are ints.
+    """
+    out, err = io.StringIO(), io.StringIO()
+    code = 0
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        try:
+            code = cli.main(argv)
+        except SystemExit as exc:  # argparse parse error
+            code = int(exc.code or 0)
+    return code, out.getvalue(), err.getvalue()
+
+
+def _catalogue(tmp_path):
+    pdir = tmp_path / "profiles"
+    pdir.mkdir()
+    (pdir / "solution-architect.toml").write_text(
+        'scope = "user"\ndescription = "Architect toolkit"\n'
+        '[[packs]]\npack = "architect"\n[[packs]]\npack = "research"\n',
+        encoding="utf-8",
+    )
+    (pdir / "full-ceremony.toml").write_text(
+        'scope = "repo"\ndescription = "Full governance bundle"\n'
+        '[[packs]]\npack = "core"\n',
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def test_pack_and_profile_are_mutually_exclusive(tmp_path):
+    code, _, err = _run(
+        ["install", "--pack", "core", "--profile", "x", str(tmp_path)]
+    )
+    assert code == 2
+    assert "not allowed with" in err or "mutually exclusive" in err.lower()
+
+
+def test_neither_pack_nor_profile_is_rejected(tmp_path):
+    code, _, err = _run(["install", str(tmp_path)])
+    assert code == 2
+    # argparse names the required group members.
+    assert "--pack" in err and "--profile" in err
+
+
+def test_scope_with_profile_is_rejected(tmp_path):
+    code, _, err = _run(
+        ["install", "--profile", "solution-architect", "--scope", "repo", str(tmp_path)]
+    )
+    assert code == 1
+    assert "--scope is not allowed with --profile" in err
+
+
+def test_list_profiles_lists_id_scope_description(tmp_path):
+    cat = _catalogue(tmp_path)
+    code, out, _ = _run(["list-profiles", str(cat)])
+    assert code == 0
+    assert "ID" in out and "SCOPE" in out and "DESCRIPTION" in out
+    assert "solution-architect" in out and "user" in out and "Architect toolkit" in out
+    assert "full-ceremony" in out and "repo" in out and "Full governance bundle" in out
+    # id-sorted: full-ceremony before solution-architect.
+    assert out.index("full-ceremony") < out.index("solution-architect")
+
+
+def test_list_profiles_empty_catalogue_is_not_an_error(tmp_path):
+    code, out, _ = _run(["list-profiles", str(tmp_path)])
+    assert code == 0
+    assert "ID" in out  # header still prints

--- a/packages/agentbundle/tests/unit/test_dependencies_batch.py
+++ b/packages/agentbundle/tests/unit/test_dependencies_batch.py
@@ -1,0 +1,110 @@
+"""T3 (pack-profiles AC7): batch-aware required-dependency gate.
+
+``validate_dependencies_required`` gains an optional ``also_installing`` set so
+a pack's required dep can be satisfied by another pack *in the same batch*
+(profile install). Name-membership satisfies at pre-flight; the version range is
+enforced for real at write time against actual state (deps-first order) and by
+the lint at author-time. The default call (no ``also_installing``) is unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentbundle.config import PackState, State
+from agentbundle.commands.install import validate_dependencies_required
+
+
+def _pack_requiring_core() -> dict:
+    return {
+        "pack": {
+            "name": "governance-extras",
+            "version": "0.1.2",
+            "dependencies": {
+                "required": [
+                    {"catalogue": "agent-ready-repo", "pack": "core", "version": "^0.1"}
+                ]
+            },
+        }
+    }
+
+
+def _empty() -> State:
+    return State()
+
+
+def test_dep_in_batch_satisfies_when_not_in_state():
+    # core is not installed, but it is being installed in this batch.
+    validate_dependencies_required(
+        _pack_requiring_core(),
+        repo_state=_empty(),
+        user_state=_empty(),
+        also_installing={"core"},
+    )  # must not raise
+
+
+def test_dep_missing_from_state_and_batch_still_fails():
+    with pytest.raises(RuntimeError) as exc:
+        validate_dependencies_required(
+            _pack_requiring_core(),
+            repo_state=_empty(),
+            user_state=_empty(),
+            also_installing={"some-other-pack"},
+        )
+    assert "core" in str(exc.value)
+
+
+def test_default_call_without_batch_is_unchanged_behavior():
+    # No also_installing → existing single-pack behavior: core absent → fail.
+    with pytest.raises(RuntimeError) as exc:
+        validate_dependencies_required(
+            _pack_requiring_core(),
+            repo_state=_empty(),
+            user_state=_empty(),
+        )
+    assert "install core first" in str(exc.value)
+
+
+def test_dep_in_state_still_satisfies_with_batch_param():
+    state = State(packs={"core": PackState(installed_version="0.4.9", scope="repo")})
+    validate_dependencies_required(
+        _pack_requiring_core(),
+        repo_state=state,
+        user_state=_empty(),
+        also_installing={"governance-extras"},
+    )  # must not raise
+
+
+def test_dep_on_disk_at_unsatisfying_version_fails_even_if_in_batch():
+    # core is pre-installed at 0.0.1 (does NOT satisfy ^0.1) AND named in the
+    # batch. Name-membership must not bypass the version check for an on-disk
+    # dep — the write-time gate stays real (pack-profiles AC7).
+    state = State(packs={"core": PackState(installed_version="0.0.1", scope="repo")})
+    with pytest.raises(RuntimeError) as exc:
+        validate_dependencies_required(
+            _pack_requiring_core(),
+            repo_state=state,
+            user_state=_empty(),
+            also_installing={"core", "governance-extras"},
+        )
+    assert "core" in str(exc.value)
+
+
+def test_batch_param_does_not_bypass_grammar_check():
+    # A malformed range must still raise even if the dep name is in the batch.
+    bad = {
+        "pack": {
+            "name": "x",
+            "version": "0.1.0",
+            "dependencies": {
+                "required": [
+                    {"catalogue": "agent-ready-repo", "pack": "core", "version": "0.1"}
+                ]
+            },
+        }
+    }
+    with pytest.raises(RuntimeError) as exc:
+        validate_dependencies_required(
+            bad, repo_state=_empty(), user_state=_empty(), also_installing={"core"}
+        )
+    assert "unsupported version range" in str(exc.value)

--- a/packages/agentbundle/tests/unit/test_profile_reader.py
+++ b/packages/agentbundle/tests/unit/test_profile_reader.py
@@ -1,0 +1,173 @@
+"""T1 (pack-profiles AC1, AC2): profile-manifest schema + reader.
+
+Compressible invariant: valid manifests parse into a typed structure with id
+derived from the filename stem and order preserved; invalid manifests (missing
+``scope``, unknown field, non-kebab id, empty/non-list ``packs``, bad enum) are
+rejected with a clear, profile-named error.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agentbundle.commands.profile import (
+    Profile,
+    ProfileError,
+    list_profiles,
+    load_profile,
+)
+
+
+def _write(catalogue: Path, name: str, body: str) -> Path:
+    pdir = catalogue / "profiles"
+    pdir.mkdir(parents=True, exist_ok=True)
+    path = pdir / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+_VALID = """\
+scope = "user"
+description = "Solution architect's portable toolkit."
+
+[[packs]]
+pack = "architect"
+
+[[packs]]
+pack = "research"
+
+[[packs]]
+pack = "contracts"
+"""
+
+
+def test_valid_manifest_parses_with_id_from_stem_and_order_preserved(tmp_path):
+    _write(tmp_path, "solution-architect.toml", _VALID)
+    prof = load_profile(tmp_path, "solution-architect")
+    assert isinstance(prof, Profile)
+    assert prof.id == "solution-architect"
+    assert prof.scope == "user"
+    assert prof.description == "Solution architect's portable toolkit."
+    # Authored deps-first order is preserved verbatim.
+    assert prof.packs == ("architect", "research", "contracts")
+
+
+def test_repo_scope_manifest_parses(tmp_path):
+    _write(
+        tmp_path,
+        "full-ceremony.toml",
+        'scope = "repo"\ndescription = "x"\n[[packs]]\npack = "core"\n',
+    )
+    prof = load_profile(tmp_path, "full-ceremony")
+    assert prof.scope == "repo"
+    assert prof.packs == ("core",)
+
+
+def test_missing_scope_is_rejected(tmp_path):
+    _write(tmp_path, "p.toml", 'description = "x"\n[[packs]]\npack = "core"\n')
+    with pytest.raises(ProfileError) as exc:
+        load_profile(tmp_path, "p")
+    assert "scope" in str(exc.value)
+
+
+def test_missing_description_is_rejected(tmp_path):
+    _write(tmp_path, "p.toml", 'scope = "repo"\n[[packs]]\npack = "core"\n')
+    with pytest.raises(ProfileError):
+        load_profile(tmp_path, "p")
+
+
+def test_unknown_top_level_field_is_rejected(tmp_path):
+    _write(
+        tmp_path,
+        "p.toml",
+        'scope = "repo"\ndescription = "x"\nadapter = "claude-code"\n'
+        '[[packs]]\npack = "core"\n',
+    )
+    with pytest.raises(ProfileError):
+        load_profile(tmp_path, "p")
+
+
+def test_unknown_pack_entry_field_is_rejected(tmp_path):
+    _write(
+        tmp_path,
+        "p.toml",
+        'scope = "repo"\ndescription = "x"\n[[packs]]\npack = "core"\nversion = "^0.1"\n',
+    )
+    with pytest.raises(ProfileError):
+        load_profile(tmp_path, "p")
+
+
+def test_scope_not_in_enum_is_rejected(tmp_path):
+    _write(
+        tmp_path,
+        "p.toml",
+        'scope = "both"\ndescription = "x"\n[[packs]]\npack = "core"\n',
+    )
+    with pytest.raises(ProfileError):
+        load_profile(tmp_path, "p")
+
+
+def test_empty_packs_list_is_rejected(tmp_path):
+    _write(tmp_path, "p.toml", 'scope = "repo"\ndescription = "x"\npacks = []\n')
+    with pytest.raises(ProfileError):
+        load_profile(tmp_path, "p")
+
+
+def test_packs_entry_missing_pack_key_is_rejected(tmp_path):
+    _write(
+        tmp_path,
+        "p.toml",
+        'scope = "repo"\ndescription = "x"\n[[packs]]\nname = "core"\n',
+    )
+    with pytest.raises(ProfileError):
+        load_profile(tmp_path, "p")
+
+
+def test_non_kebab_id_is_rejected(tmp_path):
+    _write(tmp_path, "Bad_Name.toml", _VALID)
+    with pytest.raises(ProfileError) as exc:
+        load_profile(tmp_path, "Bad_Name")
+    assert "invalid id" in str(exc.value)
+
+
+def test_missing_file_is_rejected(tmp_path):
+    (tmp_path / "profiles").mkdir()
+    with pytest.raises(ProfileError) as exc:
+        load_profile(tmp_path, "nope")
+    assert "not found" in str(exc.value)
+
+
+def test_invalid_toml_is_rejected(tmp_path):
+    _write(tmp_path, "p.toml", "scope = = =\n")
+    with pytest.raises(ProfileError) as exc:
+        load_profile(tmp_path, "p")
+    assert "invalid TOML" in str(exc.value)
+
+
+def test_list_profiles_returns_sorted_valid_profiles(tmp_path):
+    _write(tmp_path, "solution-architect.toml", _VALID)
+    _write(
+        tmp_path,
+        "full-ceremony.toml",
+        'scope = "repo"\ndescription = "y"\n[[packs]]\npack = "core"\n',
+    )
+    profs = list_profiles(tmp_path)
+    assert [p.id for p in profs] == ["full-ceremony", "solution-architect"]
+
+
+def test_list_profiles_skips_malformed(tmp_path, capsys):
+    _write(
+        tmp_path,
+        "good.toml",
+        'scope = "repo"\ndescription = "y"\n[[packs]]\npack = "core"\n',
+    )
+    _write(tmp_path, "bad.toml", 'description = "no scope"\n[[packs]]\npack = "core"\n')
+    profs = list_profiles(tmp_path)
+    assert [p.id for p in profs] == ["good"]
+    assert "skipping bad.toml" in capsys.readouterr().err
+
+
+def test_list_profiles_empty_when_no_dir(tmp_path):
+    assert list_profiles(tmp_path) == []

--- a/profiles/full-ceremony.toml
+++ b/profiles/full-ceremony.toml
@@ -1,0 +1,25 @@
+# Pack profile: full-ceremony (RFC-0034)
+#
+# A repo's full governance setup in one command — the "full ceremony" bundle
+# RFC-0001 blesses as prose, promoted to an executable unit. Single-scope
+# (repo); deps-first ordered (core first — the other three require core ^0.1):
+#   agentbundle install --profile full-ceremony <catalogue>
+#
+# Lint invariants (tools/lint-profiles.py): scope-homogeneous (every pack is
+# repo-scope), dependency-complete (core satisfies each addon's core ^0.1),
+# deps-first ordered (core before its dependents).
+
+scope = "repo"
+description = "A repo's full governance setup: the core workflow plus RFC/ADR ceremony, Diataxis guides, and monorepo conventions."
+
+[[packs]]
+pack = "core"
+
+[[packs]]
+pack = "governance-extras"
+
+[[packs]]
+pack = "user-guide-diataxis"
+
+[[packs]]
+pack = "monorepo-extras"

--- a/profiles/solution-architect.toml
+++ b/profiles/solution-architect.toml
@@ -1,0 +1,20 @@
+# Pack profile: solution-architect (RFC-0034)
+#
+# A solution architect's portable, user-scope toolkit — installed once and
+# carried across every repo. Single-scope (user); installs in one command:
+#   agentbundle install --profile solution-architect <catalogue>
+#
+# Lint invariants (tools/lint-profiles.py): scope-homogeneous (every pack
+# allows user scope), dependency-complete, deps-first ordered.
+
+scope = "user"
+description = "Solution architect's portable user-scope toolkit: architecture design, research, and contract-driven specs."
+
+[[packs]]
+pack = "architect"
+
+[[packs]]
+pack = "research"
+
+[[packs]]
+pack = "contracts"

--- a/tools/lint-profiles.py
+++ b/tools/lint-profiles.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Lint the catalogue's install profiles (RFC-0034 / spec pack-profiles, T2).
+
+A *profile* is a hand-authored ``profiles/<name>.toml`` listing a single-scope,
+deps-first set of packs an adopter installs in one command. This lint enforces
+the three author-time invariants RFC-0034 fixes (D5 / §24) against the live
+``packs/`` tree:
+
+  1. **Scope-homogeneity** — the profile's declared ``scope`` is in every named
+     pack's ``allowed-scopes`` *membership* (not ``default-scope``; the
+     ``solution-architect`` packs are dual-scope). A ``scope = "user"`` profile
+     naming a repo-only pack, or vice-versa, fails.
+
+  2. **Dependency-completeness** — every required dep of every pack in the
+     profile is itself in the profile's pack set, at a catalogue version that
+     satisfies the declared ``^X.Y`` range. A dep missing from the set, or
+     present at an unsatisfying version, fails.
+
+  3. **Order-validity** — a pack's required dep is listed *earlier* than it
+     (deps-first), since the orchestrator installs in authored order.
+
+Adapter-homogeneity is deliberately **not** a lint invariant — RFC-0034 D5
+step 2 designs an install-time resolve-once + refuse-and-suggest for adapter
+mismatch instead.
+
+Pure-stdlib (no ``agentbundle`` import) so it runs standalone on every OS,
+matching the other ``tools/`` lints. The ``^X.Y`` caret-minor grammar mirrors
+``agentbundle.commands.install.validate_dependencies_required`` — the canonical
+runtime gate — kept in sync by hand (the grammar is frozen).
+
+Usage:
+    python tools/lint-profiles.py [--root .]
+
+``--root`` contains ``profiles/`` and ``packs/`` (default: the repo root). A
+catalogue with no ``profiles/`` directory lints clean (nothing to check).
+
+Exit codes: 0 = pass, 1 = one or more violations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - 3.10 fallback
+    import tomli as tomllib  # type: ignore[no-redef]
+
+_CARET_RE = re.compile(r"^\^([0-9]+)\.([0-9]+)$")
+
+
+def _allowed_scopes(pack_toml: dict) -> list[str]:
+    """Resolve a pack's allowed-scopes membership (legacy/v0.1 → ['repo'])."""
+    install = pack_toml.get("pack", {}).get("install")
+    if isinstance(install, dict):
+        scopes = install.get("allowed-scopes")
+        if isinstance(scopes, list) and scopes:
+            return [s for s in scopes if isinstance(s, str)]
+        default = install.get("default-scope")
+        if isinstance(default, str):
+            return [default]
+    return ["repo"]
+
+
+def _required_deps(pack_toml: dict) -> list[tuple[str, str]]:
+    """Return [(dep_pack_name, version_range), ...] from [pack.dependencies.required]."""
+    deps = pack_toml.get("pack", {}).get("dependencies", {})
+    out: list[tuple[str, str]] = []
+    if isinstance(deps, dict):
+        for entry in deps.get("required") or []:
+            if isinstance(entry, dict):
+                out.append((entry.get("pack", ""), entry.get("version", "")))
+    return out
+
+
+def _satisfies(installed_version: str, dep_range: str) -> bool | None:
+    """``^X.Y`` caret-minor satisfaction. None ⇒ unsupported range grammar.
+
+    Mirrors ``validate_dependencies_required``: ``A.B.C`` satisfies ``^X.Y``
+    when ``A == X`` and version ``>= X.Y.0`` (and ``< (X+1).0.0`` implied).
+    """
+    m = _CARET_RE.match(dep_range)
+    if m is None:
+        return None
+    req_major, req_minor = int(m.group(1)), int(m.group(2))
+    parts = installed_version.split(".")
+    try:
+        ima = int(parts[0]) if len(parts) > 0 else 0
+        imi = int(parts[1]) if len(parts) > 1 else 0
+        ipa = int(parts[2]) if len(parts) > 2 else 0
+    except (ValueError, IndexError):
+        return False
+    return ima == req_major and (imi > req_minor or (imi == req_minor and ipa >= 0))
+
+
+def _load_packs(packs_dir: Path) -> dict[str, dict]:
+    """Map pack name → parsed pack.toml for every packs/<name>/pack.toml."""
+    out: dict[str, dict] = {}
+    if not packs_dir.is_dir():
+        return out
+    for pack_dir in sorted(packs_dir.iterdir()):
+        toml_path = pack_dir / "pack.toml"
+        if not toml_path.exists():
+            continue
+        try:
+            data = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+        except (tomllib.TOMLDecodeError, OSError):
+            continue
+        name = data.get("pack", {}).get("name") or pack_dir.name
+        out[name] = data
+    return out
+
+
+def _lint_profile(
+    profile_id: str, raw: dict, packs: dict[str, dict]
+) -> list[str]:
+    """Return a list of violation strings for one parsed profile (empty = clean)."""
+    violations: list[str] = []
+    scope = raw.get("scope")
+    if scope not in ("user", "repo"):
+        violations.append(
+            f"profile {profile_id!r}: scope must be 'user' or 'repo', got {scope!r}"
+        )
+    entries = raw.get("packs")
+    if not isinstance(entries, list) or not entries:
+        violations.append(f"profile {profile_id!r}: 'packs' must be a non-empty list")
+        return violations
+
+    names = [e.get("pack") for e in entries if isinstance(e, dict) and e.get("pack")]
+    index = {name: i for i, name in enumerate(names)}
+
+    for i, name in enumerate(names):
+        pack_toml = packs.get(name)
+        if pack_toml is None:
+            violations.append(
+                f"profile {profile_id!r}: pack {name!r} not found in packs/"
+            )
+            continue
+
+        # 1. Scope-homogeneity (membership of the declared scope).
+        if scope in ("user", "repo"):
+            allowed = _allowed_scopes(pack_toml)
+            if scope not in allowed:
+                violations.append(
+                    f"profile {profile_id!r}: pack {name!r} does not allow scope "
+                    f"{scope!r} (allowed-scopes: {allowed})"
+                )
+
+        # 2 + 3. Dependency-completeness + order-validity.
+        for dep_name, dep_range in _required_deps(pack_toml):
+            if dep_name not in index:
+                violations.append(
+                    f"profile {profile_id!r}: pack {name!r} requires {dep_name!r} "
+                    f"({dep_range}), which is not in the profile "
+                    f"(dependency-incomplete)"
+                )
+                continue
+            if index[dep_name] >= i:
+                violations.append(
+                    f"profile {profile_id!r}: pack {dep_name!r} (required by "
+                    f"{name!r}) is listed at or after it; required deps must come "
+                    f"first (mis-ordered)"
+                )
+            dep_toml = packs.get(dep_name)
+            if dep_toml is not None:
+                dep_version = dep_toml.get("pack", {}).get("version", "")
+                sat = _satisfies(dep_version, dep_range)
+                if sat is None:
+                    violations.append(
+                        f"profile {profile_id!r}: pack {name!r} declares an "
+                        f"unsupported version range {dep_range!r} for {dep_name!r} "
+                        f"(only ^X.Y is supported)"
+                    )
+                elif sat is False:
+                    violations.append(
+                        f"profile {profile_id!r}: pack {name!r} requires "
+                        f"{dep_name!r} {dep_range}, but the catalogue ships "
+                        f"{dep_name} v{dep_version}, which does not satisfy it "
+                        f"(dependency-incomplete)"
+                    )
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="Directory containing profiles/ and packs/ (default: repo root).",
+    )
+    args = parser.parse_args(argv)
+    root = Path(args.root)
+
+    profiles_dir = root / "profiles"
+    packs = _load_packs(root / "packs")
+
+    if not profiles_dir.is_dir():
+        print("lint-profiles: no profiles/ directory; nothing to lint.")
+        return 0
+
+    all_violations: list[str] = []
+    checked = 0
+    for toml_path in sorted(profiles_dir.glob("*.toml")):
+        profile_id = toml_path.stem
+        try:
+            raw = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+        except (tomllib.TOMLDecodeError, OSError) as exc:
+            all_violations.append(f"profile {profile_id!r}: cannot parse: {exc}")
+            continue
+        checked += 1
+        all_violations.extend(_lint_profile(profile_id, raw, packs))
+
+    if all_violations:
+        for v in all_violations:
+            print(f"lint-profiles: {v}", file=sys.stderr)
+        print(
+            f"lint-profiles: {len(all_violations)} violation(s) across "
+            f"{checked} profile(s).",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"lint-profiles: {checked} profile(s) OK.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/pre-pr-catalogue.py
+++ b/tools/pre-pr-catalogue.py
@@ -74,6 +74,8 @@ def main() -> int:
     _run("knowledge-surface parity", [py, "tools/lint-knowledge-surface-parity.py"])
     _run("knowledge-surface parity self-test",
          [py, "tools/test-lint-knowledge-surface-parity.py"])
+    _run("profiles lint", [py, "tools/lint-profiles.py", "--root", "."])
+    _run("profiles lint self-test", [py, "tools/test-lint-profiles.py"])
 
     # Delegate to the shipped adopter-facing hook for the work-loop caps gate.
     result = subprocess.run(

--- a/tools/test-lint-profiles.py
+++ b/tools/test-lint-profiles.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Self-test for tools/lint-profiles.py (pack-profiles AC9, T2).
+
+Pure-stdlib Python so the suite runs on Windows without an MSYS shell.
+Pattern: build a fixture tree (profiles/ + packs/) in a tempdir, run the linter
+via subprocess against it (`--root <tmp>`), and assert exit code + substrings —
+real-invocation, not synthesised import.
+
+Trees:
+  A — happy: solution-architect (user, no deps) + full-ceremony (repo, core
+      first, governance-extras requires core ^0.1 satisfied by core v0.4.9).
+      Exit 0.
+  B — scope mismatch: a user profile naming a repo-only pack. Exit 1.
+  C — dependency-incomplete: full-ceremony with core removed. Exit 1.
+  D — mis-ordered: governance-extras before its dep core. Exit 1.
+  E — dependency version mismatch: dep present but at an unsatisfying version.
+      Exit 1.
+  F — unknown pack: a profile naming a pack not in packs/. Exit 1.
+  G — no profiles/ dir: nothing to lint. Exit 0.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+LINTER = REPO_ROOT / "tools" / "lint-profiles.py"
+
+
+def fail(label: str, msg: str, output: str = "") -> None:
+    print(f"✖ {label}: {msg}", file=sys.stderr)
+    if output:
+        print("---", file=sys.stderr)
+        print(output, file=sys.stderr)
+        print("---", file=sys.stderr)
+    sys.exit(1)
+
+
+def run_linter(root: pathlib.Path) -> tuple[int, str]:
+    proc = subprocess.run(
+        [sys.executable, str(LINTER), "--root", str(root)],
+        capture_output=True,
+        text=True,
+    )
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+def _pack(packs_dir: pathlib.Path, name: str, version: str,
+          allowed_scopes: list[str], required: list[tuple[str, str]]) -> None:
+    pdir = packs_dir / name
+    pdir.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "[pack]",
+        f'name = "{name}"',
+        f'version = "{version}"',
+        'adapter-contract = { version = "0.6" }',
+        "[pack.install]",
+        f'default-scope = "{allowed_scopes[0]}"',
+        "allowed-scopes = [" + ", ".join(f'"{s}"' for s in allowed_scopes) + "]",
+    ]
+    for dep_name, dep_range in required:
+        lines += [
+            "[[pack.dependencies.required]]",
+            'catalogue = "agent-ready-repo"',
+            f'pack = "{dep_name}"',
+            f'version = "{dep_range}"',
+        ]
+    (pdir / "pack.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _profile(root: pathlib.Path, name: str, scope: str, packs: list[str]) -> None:
+    pdir = root / "profiles"
+    pdir.mkdir(parents=True, exist_ok=True)
+    body = [f'scope = "{scope}"', 'description = "fixture"']
+    for p in packs:
+        body += ["[[packs]]", f'pack = "{p}"']
+    (pdir / f"{name}.toml").write_text("\n".join(body) + "\n", encoding="utf-8")
+
+
+def _standard_packs(root: pathlib.Path) -> None:
+    packs = root / "packs"
+    # user-scope, dual-allowed, no deps
+    for n in ("architect", "research", "contracts"):
+        _pack(packs, n, "0.3.0", ["user", "repo"], [])
+    # repo-scope governance packs
+    _pack(packs, "core", "0.4.9", ["repo"], [])
+    _pack(packs, "governance-extras", "0.1.2", ["repo"], [("core", "^0.1")])
+    _pack(packs, "monorepo-extras", "0.1.2", ["repo"], [("core", "^0.1")])
+
+
+def main() -> int:
+    # Tree A — happy.
+    with tempfile.TemporaryDirectory() as d:
+        root = pathlib.Path(d)
+        _standard_packs(root)
+        _profile(root, "solution-architect", "user", ["architect", "research", "contracts"])
+        _profile(root, "full-ceremony", "repo", ["core", "governance-extras", "monorepo-extras"])
+        code, out = run_linter(root)
+        if code != 0:
+            fail("A/happy", f"expected exit 0, got {code}", out)
+        if "OK" not in out:
+            fail("A/happy", "expected an OK summary", out)
+
+    # Tree B — scope mismatch (user profile naming repo-only core).
+    with tempfile.TemporaryDirectory() as d:
+        root = pathlib.Path(d)
+        _standard_packs(root)
+        _profile(root, "bad-scope", "user", ["architect", "core"])
+        code, out = run_linter(root)
+        if code != 1:
+            fail("B/scope", f"expected exit 1, got {code}", out)
+        if "does not allow scope 'user'" not in out:
+            fail("B/scope", "expected scope-homogeneity violation", out)
+
+    # Tree C — dependency-incomplete (governance-extras without core).
+    with tempfile.TemporaryDirectory() as d:
+        root = pathlib.Path(d)
+        _standard_packs(root)
+        _profile(root, "no-core", "repo", ["governance-extras"])
+        code, out = run_linter(root)
+        if code != 1:
+            fail("C/incomplete", f"expected exit 1, got {code}", out)
+        if "dependency-incomplete" not in out:
+            fail("C/incomplete", "expected dependency-incomplete violation", out)
+
+    # Tree D — mis-ordered (governance-extras before core).
+    with tempfile.TemporaryDirectory() as d:
+        root = pathlib.Path(d)
+        _standard_packs(root)
+        _profile(root, "misordered", "repo", ["governance-extras", "core"])
+        code, out = run_linter(root)
+        if code != 1:
+            fail("D/order", f"expected exit 1, got {code}", out)
+        if "mis-ordered" not in out:
+            fail("D/order", "expected mis-ordered violation", out)
+
+    # Tree E — dep present but version unsatisfying.
+    with tempfile.TemporaryDirectory() as d:
+        root = pathlib.Path(d)
+        packs = root / "packs"
+        _pack(packs, "core", "0.4.9", ["repo"], [])
+        _pack(packs, "needs-v2", "0.1.0", ["repo"], [("core", "^2.0")])
+        _profile(root, "bad-version", "repo", ["core", "needs-v2"])
+        code, out = run_linter(root)
+        if code != 1:
+            fail("E/version", f"expected exit 1, got {code}", out)
+        if "does not satisfy it" not in out:
+            fail("E/version", "expected version-mismatch violation", out)
+
+    # Tree F — unknown pack.
+    with tempfile.TemporaryDirectory() as d:
+        root = pathlib.Path(d)
+        _standard_packs(root)
+        _profile(root, "ghost", "repo", ["core", "does-not-exist"])
+        code, out = run_linter(root)
+        if code != 1:
+            fail("F/unknown", f"expected exit 1, got {code}", out)
+        if "not found in packs/" not in out:
+            fail("F/unknown", "expected unknown-pack violation", out)
+
+    # Tree G — no profiles/ dir.
+    with tempfile.TemporaryDirectory() as d:
+        root = pathlib.Path(d)
+        _standard_packs(root)
+        code, out = run_linter(root)
+        if code != 0:
+            fail("G/empty", f"expected exit 0, got {code}", out)
+
+    print("✓ test-lint-profiles: all trees pass")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What does this change?

Adds `agentbundle install --profile <name> <catalogue>` and `agentbundle list-profiles <catalogue>`. A first-party, single-scope, catalogue-owned `profiles/<name>.toml` installs its packs in deps-first order, at one declared scope, on one pinned adapter, with every precondition checked before any write. Two profiles ship: `solution-architect` (user) and `full-ceremony` (repo).

## Why?

- Implements: `docs/specs/pack-profiles/spec.md` (+ `plan.md`)
- Follows from: [RFC-0034](docs/rfc/0034-pack-profiles.md) (Accepted) + [ADR-0025](docs/adr/0025-pack-profiles-single-scope-cli-manifest.md)

Setting up a role's toolkit or a repo's governance bundle was N separate `--pack` invocations, and the curated knowledge (which packs go together, in what order) lived only in a human's head. RFC-0034 promotes those blessed combinations from prose into one executable unit — distribution hygiene over the existing single-pack install path, not package-manager infrastructure.

A profile is a **thin orchestrator** over single-pack `install.run`: it pins one scope and one adapter for the batch, dry-run pre-flights **every** pack (Steps 1–8, including the read-only path-jail probe) before writing **any**, then writes each pack via `run()` in authored order. It reimplements none of `run()`'s write logic.

**Boundaries honored:** no state-schema bump (`STATE_SCHEMA_VERSION` unchanged), no adapter-contract bump, no new install route, no marketplace.json / build-pipeline / self-host change. Per-pack rows record `install_route="profile"`. `profiles/` is a new top-level dir — sanctioned by RFC-0034, which defines it as the catalogue-root manifest location.

## How do I verify it?

```bash
# Unit + integration (also wired into CI: build-check.yml + docs.yml)
cd packages/agentbundle && python -m pytest \
  tests/unit/test_profile_reader.py tests/unit/test_dependencies_batch.py \
  tests/unit/test_cli_profile_surface.py \
  tests/integration/test_install_profile.py tests/integration/test_install_profile_live.py

# The profile lint + its self-test (CI: docs.yml lint-profiles job, pre-pr-catalogue)
python tools/test-lint-profiles.py && python tools/lint-profiles.py --root .

# Real artifact, end-to-end against the live catalogue
python -m agentbundle list-profiles .
python -m agentbundle install --profile full-ceremony . --output /tmp/demo-repo
```

Full `agentbundle` suite: **2019 passed, 1 skipped**. `lint-packs`, `lint-profiles` (+ self-test), workflow YAML, and `lint-spec-status` (pack-profiles clean) all green.

## What did you not change that you considered?

- **No adapter-homogeneity lint invariant.** RFC-0034 fixes the lint triad to scope/dep/order and designs an install-time *resolve-once + refuse-and-suggest* for adapter mismatch instead — adding a fourth invariant would exceed the frozen RFC. Implemented the runtime refusal (names the pack, suggests a compatible adapter from the batch's `allowed-adapters` intersection).
- **No profile state entity, no profile `upgrade`/`uninstall`.** Per-pack rows only (Boundary).
- **No runtime topological sort.** Order is authored and lint-enforced.
- **Left a harmless `ipa >= 0` tautology in the caret-version check** in both `tools/lint-profiles.py` and `install.py` — kept byte-identical so the standalone lint stays a faithful mirror of the canonical gate.
- **No `docs/guides/` page** (reasonable follow-up; discovery is covered by `--help`, `list-profiles`, and the changelog).

## Process notes

- **Pre-EXECUTE adversarial review (3 rounds)** corrected the spec before any code — most notably that single-pack `install.run`'s path-jail probe (Step 8) runs *inside* `dry_run=True` before the return, so the faithful design dry-run-pre-flights the whole batch (not a write-time-only guarantee). RFC-grounded the adapter-lint and AC15 decisions.
- **Post-implementation review** (adversarial + security + quality) found one real correctness Blocker: the batch dep gate name-satisfied an *on-disk* dep, bypassing its version check. Fixed so an on-disk dep is always range-checked; name-satisfaction applies only to a not-yet-written in-batch dep (regression tests added). All three reviewers: **Clean**.

### Bundled fixes
- `tests/integration/test_config_cascade.py`: `EXPECTED` `_resolve_target_adapter` caller count 7 → 9 (the two new `_run_profile` callers both thread `user_config`; the test's real invariant — every caller threads it — still holds).

### Deferred
- None. A `docs/guides/` how-to for profiles is a candidate follow-up (not required by the spec).

## Checklist

- [x] Tests pass locally (`cd packages/agentbundle && python -m pytest` → 2019 passed)
- [x] Lint passes (`make lint-packs`, `tools/lint-profiles.py`); no typecheck gate in this repo
- [x] Self-review via reviewer subagents — adversarial + security + quality, all returned Clean; the one correctness Blocker addressed
- [x] Spec and code agree (spec marked Shipped, all 15 ACs checked, plan Done)
- [x] `docs/product/changelog.md` updated
- [ ] `docs/guides/` — not added (see "did not change"); `--help`/`list-profiles`/changelog cover discovery
- [x] No material `docs/architecture/` change (additive within `agentbundle`)
- [x] New top-level dir `profiles/` is RFC-sanctioned (RFC-0034)
- [x] Conventional commit format
- [x] Learnings captured (the dry-run/path-jail-probe insight is recorded in `plan.md` Design decisions)