### PR TITLE
docs: cover pack profiles (RFC-0034) — how-to, catalogue explanation, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ agentbundle install --pack core git+https://github.com/eugenelim/agent-ready-rep
 
 One line lands the loop in your repo. Any agent that reads a skill file inherits it: Claude Code, Codex, Cursor, Copilot, Gemini, Kiro.
 
+Want a whole set at once? A **profile** installs a curated bundle in one command — `agentbundle install --profile full-ceremony git+https://github.com/eugenelim/agent-ready-repo` lands `core` plus the governance packs; `--profile solution-architect` lands an architect's portable toolkit. See [The catalogue](#the-catalogue).
+
 ## The loop
 
 Most agent workflows are `prompt → code → ship`. `core` replaces that one-shot path. It splits the maker from the verifier, and it won't skip a step.
@@ -65,6 +67,8 @@ A fourth subagent, `implementer`, is the loop's own executor. It runs independen
 | [`design-craft`](docs/guides/design-craft/) | user / repo | Framework-agnostic design discipline — `aesthetic-direction`, `design-system-foundations`, `layout-and-information-architecture`, `design-critique`, plus a shared `quality-floor` checklist. Authors the upstream design intent the build consumes; points to WCAG / W3C Design Tokens, never a stack or a values table. |
 
 Repo-scope packs install into the current repo and build on `core`. User-scope packs install into `~/.claude/` (or your harness's home root) and follow you across every project. Swap `core` for any pack name in the command above.
+
+**Or install a curated set in one command.** Profiles bundle the blessed combinations: `agentbundle install --profile full-ceremony <catalogue>` lands the four repo governance packs (deps-first), and `--profile solution-architect <catalogue>` lands the `architect` + `research` + `contracts` user-scope toolkit. `agentbundle list-profiles <catalogue>` shows what's available; see the [install-a-profile how-to](docs/guides/_shared/how-to/install-a-profile.md).
 
 ## Ecosystem building blocks
 

--- a/docs/guides/_shared/explanation/pack-catalogue.md
+++ b/docs/guides/_shared/explanation/pack-catalogue.md
@@ -34,6 +34,17 @@ The catalogue's eight packs split by where they land on disk.
 
 The two scopes never share files. A user-scope pack installed with `--scope repo` projects into that repo's working tree the way a repo-scope pack would; otherwise it stays in your user directory.
 
+## Profiles: a curated set in one command
+
+Some pack combinations are blessed — a solution architect's toolkit is `architect` + `research` + `contracts`; a repo's full governance setup is `core` + `governance-extras` + `user-guide-diataxis` + `monorepo-extras`. (Each name is a pack from [the README's catalogue table](../../../../README.md#the-catalogue), the authoritative menu.) A **profile** promotes that curated knowledge from prose into one executable unit: `agentbundle install --profile <name> <catalogue>` installs the whole set in one command, and `agentbundle list-profiles <catalogue>` shows what's on offer.
+
+A profile is a thin pointer list, not a pack — a hand-authored `profiles/<name>.toml` at the catalogue root that names packs in dependency-first order. It adds no primitives, no new dependency edges, and no state entity: the packs install exactly as they would one at a time, just sequenced and gated as a batch. Two properties make it safe rather than a mega-bundle:
+
+- **Single-scope.** A profile is repo-only or user-only — it never mixes scopes, so there's no half-applied cross-scope install to reason about. The scope is declared in the manifest; you don't pass `--scope`.
+- **All-or-nothing pre-flight.** Every pack's preconditions run before the first write, on one pinned adapter, so the batch is no less safe than installing each pack by hand.
+
+Profiles cover *installing* a set; there is no `upgrade --profile` or `uninstall --profile` — you act on the individual packs afterward. See [how to install a profile](../how-to/install-a-profile.md) for the walkthrough.
+
 ## The composition rule
 
 Packs compose by convention, not by import — no pack ever imports code from another pack. The rule is one-directional: repo-scope packs depend on `core`; user-scope packs don't.

--- a/docs/guides/_shared/how-to/install-a-profile.md
+++ b/docs/guides/_shared/how-to/install-a-profile.md
@@ -1,0 +1,67 @@
+# How to install a curated set of packs in one command
+
+Install a role's whole toolkit, or a repo's full governance setup, in one command instead of running `install --pack` N times. A **profile** is a first-party-curated, single-scope set of packs the catalogue ships ready to install.
+
+## Prerequisites
+
+- The `agentbundle` CLI on your PATH (`pip install agentbundle`, or the [clone-and-pip route](install-agentbundle-from-clone.md)).
+- A catalogue URI — a local checkout path or `git+https://github.com/eugenelim/agent-ready-repo`.
+
+## Discover what's available
+
+```bash
+agentbundle list-profiles <catalogue>
+```
+
+It prints each profile's id, scope, and description. The two shipped profiles:
+
+| Profile | Scope | Installs |
+| --- | --- | --- |
+| `solution-architect` | user | `architect` + `research` + `contracts` — a solution architect's portable toolkit, carried across every repo. |
+| `full-ceremony` | repo | `core` + `governance-extras` + `user-guide-diataxis` + `monorepo-extras` — a repo's full governance setup. |
+
+## Install a profile
+
+```bash
+agentbundle install --profile <name> <catalogue>
+```
+
+For example, to set up a repo's full governance bundle:
+
+```bash
+agentbundle install --profile full-ceremony git+https://github.com/eugenelim/agent-ready-repo
+```
+
+The command installs every pack in the profile **at the profile's declared scope**, in the authored dependency-first order (so `core` lands before the packs that build on it), onto **one** adapter target. A pack already installed at that scope is left alone and reported `already present, skipped`. When it finishes, you get a per-pack summary of what was installed, skipped, or failed.
+
+A profile install is never less safe than installing each pack by hand: it runs every pack's preconditions — scope, dependencies, adapter, path confinement — **before writing anything**. If any pack can't be installed, the command refuses before the first write and names the pack.
+
+## Pick the adapter
+
+By default the install resolves one adapter for the whole batch the same way a single-pack install does (your configured adapter, else the auto-detected one, else the default). To pin a specific IDE for every pack in the profile:
+
+```bash
+agentbundle install --profile solution-architect <catalogue> --adapter codex
+```
+
+The adapter is applied to every pack. If one pack in the profile doesn't support the chosen adapter, the command refuses before any write and suggests a compatible one.
+
+## Upgrade or remove later
+
+A profile is a one-time convenience for *installing* a set — it is not recorded as an entity. To change versions or remove packs afterward, act on the individual packs with the normal verbs: [`agentbundle upgrade --pack <name>`](upgrade-packs.md) and `agentbundle uninstall --pack <name>`. There is no `upgrade --profile` or `uninstall --profile`.
+
+## Pitfalls
+
+> **`--profile` and `--pack` are mutually exclusive.** Pick one. To install a single pack, use `--pack`; to install a set, use `--profile`.
+
+> **`--scope` is rejected with `--profile`.** A profile declares its own scope in its manifest — `solution-architect` is user-scope, `full-ceremony` is repo-scope. You don't (and can't) choose the scope at install time.
+
+> **A pack already installed at the *other* scope blocks the profile.** Profiles are single-scope and won't install the same pack across scopes. If a pack in the profile is already installed at the opposite scope, the command refuses and names it — uninstall it from that scope first, or install the remaining packs individually.
+
+> **A partial install is not rolled back.** On a genuine I/O failure mid-batch (a full disk, say), packs already written stay; the dependency-first order guarantees the installed prefix is still consistent, and the per-pack summary tells you exactly where it stopped. Re-running the command resumes — already-installed packs are skipped.
+
+## Related
+
+- [The pack catalogue](../explanation/pack-catalogue.md) — what packs and profiles are, and the two-scope model.
+- [Install routes](../explanation/install-routes.md) — the install→adapt chain a profile install inherits per pack.
+- [How to upgrade an installed pack](upgrade-packs.md) — the per-pack upgrade verb.


### PR DESCRIPTION
## What does this change?

Adds the user-facing docs for pack profiles (shipped in #331): a how-to, a catalogue-explanation section, and a light README touch.

## Why?

- Closes: #332 (the deferred-docs follow-up from #331)
- Follows from: [RFC-0034](docs/rfc/0034-pack-profiles.md) / `docs/specs/pack-profiles/spec.md`

#331 shipped the feature but deferred user docs (discovery was covered by `--help` + `list-profiles` + the changelog). This fills that gap so an adopter can find and use profiles from the guides and the front-door README.

- **`docs/guides/_shared/how-to/install-a-profile.md`** (new) — task-oriented, modeled on the sibling `install-*`/`upgrade-packs` how-tos: `list-profiles`, `install --profile`, the two shipped profiles, `--adapter` override, per-pack upgrade/uninstall, and the realistic pitfalls (`--pack` mutex, `--scope` rejection, opposite-scope refusal, partial-failure-no-rollback).
- **`docs/guides/_shared/explanation/pack-catalogue.md`** — a "Profiles: a curated set in one command" section (single-scope, all-or-nothing pre-flight, pointer-list not a pack).
- **`README.md`** — a one-command profile example in the quick-start and a profiles note in the catalogue section.

## How do I verify it?

Docs-only. Internal cross-links verified to resolve; the README `#the-catalogue` anchor exists. No code, lint, or build surface touched (`docs/guides/**` is repo-owned — `build-self` skips it). Factual claims were reviewed line-by-line against `_run_profile` in `commands/install.py` and the shipped `profiles/*.toml`.

## What did you not change that you considered?

- **The pre-existing "Eight packs / four user-scope" staleness in `pack-catalogue.md`** — its two-scope inventory predates `research`, `architect`, `product-engineering`, and `design-craft` and is wrong independent of profiles. Fixing the count is a separate concern (out of scope here); I resolved the one dangling reference my new content created by pointing the profile's pack names at the README's authoritative catalogue table. **Recommend a follow-up to refresh that inventory.**
- **No reference page for the profile manifest schema** — it's internal (first-party-curated, not an adopter-facing contract per the spec).
- **No changelog entry** — docs-only follow-up of an already-announced feature; #331's `[Unreleased]` entry stands and there's no user-visible behavior change.

## Checklist

- [x] Self-review via `adversarial-reviewer` — factual accuracy verified against the implementation, voice/Diátaxis fit confirmed; the one Concern (dangling pack reference) addressed
- [x] Internal links resolve; README anchor present
- [x] `docs/guides/` updated (the point of this PR), right Diátaxis buckets (how-to + explanation)
- [x] No code/behavior change → no changelog/architecture/test updates needed
- [x] No new top-level directories
- [x] Conventional commit format