### PR TITLE
feat(atlassian): jira-brief-intake — turn a Jira epic into a product brief (RFC-0019)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,7 +23,7 @@
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",
       "category": "integrations",
-      "description": "Atlassian primitives: jira / jira-align / confluence-crawler (credentialed CLI), plus the flow-metrics, ai-adoption-report, and jira-defect-flow workflows that compose them.",
+      "description": "Atlassian primitives: jira / jira-align / confluence-crawler (credentialed CLI), plus the flow-metrics, ai-adoption-report, jira-defect-flow, and jira-brief-intake workflows that compose them.",
       "displayName": "Atlassian",
       "homepage": "https://github.com/eugenelim/agent-ready-repo",
       "keywords": [
@@ -35,7 +35,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "atlassian",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.1.4"
+      "version": "0.2.0"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -68,7 +68,7 @@ catalogue listing — see [`pack-manifest.md`](pack-manifest.md).
 | `monorepo-extras` | repo only | `new-package` skill + `packages/_example/` template. Requires `core`. |
 | `contracts` | user (default) or repo | `api-contract` (OpenAPI 3.1) and `event-contract` (AsyncAPI). |
 | `converters` | user (default) or repo | Document/image → Markdown, Markdown → styled HTML, Outlook `.msg` → Markdown. |
-| `atlassian` | user (default) or repo | `jira`, `jira-align`, `confluence-crawler` (credentialed CLIs) + the `flow-metrics`, `ai-adoption-report`, `jira-defect-flow` workflows that compose them. |
+| `atlassian` | user (default) or repo | `jira`, `jira-align`, `confluence-crawler` (credentialed CLIs) + the `flow-metrics`, `ai-adoption-report`, `jira-defect-flow`, `jira-brief-intake` workflows that compose them. |
 | `figma` | user (default) or repo | `figma` credentialed CLI (REST API reads, frame renders, FigJam → Mermaid). |
 | `research` | user (default) or repo | Seven research skills (scoping → synthesis → decision support) + two read-only retrieval subagents. |
 | `architect` | user (default) or repo | `architect-design`, `architect-diagram`, `architect-review` (Mermaid + Google-style design docs). |

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -13,7 +13,7 @@ The user-facing documentation for the catalogue, organized **by pack**. You inst
 | [`research`](research/) | [home](research/) | Evidence-grounded research — `research` with selectable depth, plus the pipeline skills (`source-map`, `compare-hypotheses`, `devils-advocate`, …). |
 | [`product-engineering`](product-engineering/) | [home](product-engineering/) | Shape product intent into shippable specs — the recursive `intent` tree (`frame`, `de-risk`, `decompose`, `align-value-stream`). |
 | [`credential-brokers`](credential-brokers/) | [home](credential-brokers/) | The broker behind credentialed skills — secrets resolve in-process and never reach the model. |
-| [`atlassian`](atlassian/) | [home](atlassian/) | Jira, Confluence, and flow metrics over the REST APIs — `jira`, `confluence-crawler`/`-publisher`, `flow-metrics`, `jira-defect-flow`, and more. |
+| [`atlassian`](atlassian/) | [home](atlassian/) | Jira, Confluence, and flow metrics over the REST APIs — `jira`, `confluence-crawler`/`-publisher`, `flow-metrics`, `jira-defect-flow`, `jira-brief-intake`, and more. |
 | [`contracts`](contracts/) | [home](contracts/) | Contract-first design — `api-contract` (OpenAPI 3.1) and `event-contract` (AsyncAPI), with a pluggable house standard. |
 | [`converters`](converters/) | [home](converters/) | Get documents into Markdown and back out — `file-to-markdown`, `markdown-to-html`, `mermaid-renderer`, `msg-to-markdown`. |
 | [`figma`](figma/) | [home](figma/) | The Figma REST primitive — read files, nodes, and comments; render frames; turn FigJam into Mermaid. |

--- a/docs/guides/atlassian/README.md
+++ b/docs/guides/atlassian/README.md
@@ -1,6 +1,6 @@
 # `atlassian` — guides
 
-Jira, Jira Align, and Confluence over their REST APIs — plus the flow metrics you build on top of them. The pack ships seven skills: `jira` and `jira-align` for issue and portfolio data, `confluence-crawler` and `confluence-publisher` for wiki content, `jira-defect-flow` for end-to-end defect handling, and `flow-metrics` + `ai-adoption-report` for DORA / Flow Framework measurement. The four API-touching skills are credentialed: the secret resolves in-process and never reaches the model.
+Jira, Jira Align, and Confluence over their REST APIs — plus the flow metrics and intake workflows you build on top of them. The pack ships `jira` and `jira-align` for issue and portfolio data, `confluence-crawler` and `confluence-publisher` for wiki content, `jira-defect-flow` for end-to-end defect handling, `jira-brief-intake` to turn a Jira epic into a product brief, and `flow-metrics` + `ai-adoption-report` for DORA / Flow Framework measurement. The four API-touching skills are credentialed: the secret resolves in-process and never reaches the model.
 
 New here? Read [The `atlassian` pack as a system](explanation/atlassian-pack.md) first — it's the map. Then [work with Jira](how-to/work-with-jira.md) to search and mutate issues.
 

--- a/docs/guides/atlassian/explanation/atlassian-pack.md
+++ b/docs/guides/atlassian/explanation/atlassian-pack.md
@@ -13,11 +13,12 @@ The pack covers three Atlassian products across four direct-API skills:
 
 ## The skills that build on top
 
-Three skills compose the surfaces above instead of touching the API directly:
+Several skills compose the surfaces above instead of touching the API directly:
 
 - **[`flow-metrics`](../../../../packs/atlassian/.apm/skills/flow-metrics/)** computes DORA / Flow Framework metrics over a Jira scope. It reads through the `jira` skill, joins `jira-align` for program and portfolio scope, and emits canonical JSON / CSV. It is read-only — it never transitions, comments, or mutates.
 - **[`ai-adoption-report`](../../../../packs/atlassian/.apm/skills/ai-adoption-report/)** pairs `flow-metrics` JSON outputs and renders a Markdown comparison report. It makes no upstream calls; its only inputs are local JSON files.
 - **[`jira-defect-flow`](../../../../packs/atlassian/.apm/skills/jira-defect-flow/)** handles a Jira defect end-to-end: pulls the ticket via `jira`, hands the fix to the `bug-fix` skill, opens a PR, then comments and transitions the ticket.
+- **[`jira-brief-intake`](../../../../packs/atlassian/.apm/skills/jira-brief-intake/)** turns a Jira epic (or a board / JQL selection) into shippable specs: pulls the epic and its children via `jira`, maps them onto a Shape B product brief, and hands off to the `receive-brief` skill to elicit gaps, decompose, and build. Read-only against Jira; degrades gracefully when `receive-brief` is absent.
 
 ## The auth model
 

--- a/docs/guides/atlassian/reference/atlassian-skills.md
+++ b/docs/guides/atlassian/reference/atlassian-skills.md
@@ -59,3 +59,11 @@ Credentialed skills resolve secrets in-process through the tier ladder (environm
 - **Outputs.** A triage brief at `.context/defects/$KEY.md`, a feature branch, a PR whose `Why?` section carries `Closes: $KEY`, and Jira comments plus transitions on the ticket.
 - **Required credentials.** None of its own — Jira access is inherited through the `jira` skill. Requires `gh auth` for PR opening.
 - **Source.** [`jira-defect-flow`](../../../../packs/atlassian/.apm/skills/jira-defect-flow/)
+
+## `jira-brief-intake`
+
+- **Purpose.** Turn a Jira epic (or a board / sprint / JQL selection) into shippable specs. Pulls the epic and its children via the `jira` skill, maps them onto a Shape B product brief (epic → Outcome, child issues → `US-n` user stories tagged with their Jira key, epic key → `Epic:` provenance pointer), writes it to `docs/product/briefs/<slug>.md`, and hands off to the `receive-brief` skill to elicit gaps, decompose, and build. Read-only against Jira; gracefully degrades to an inlined decompose/execute instruction when `receive-brief` is absent. For an epic or multi-feature body of work — a single feature goes through `new-spec`, a defect through `jira-defect-flow`.
+- **Primary inputs.** A Jira epic key, or a JQL / board / sprint selection. Composes sibling and host skills by name: `jira` (reads only — `check`, `get-issue`, `search` with a flavor-correct child query) and `receive-brief` (soft dependency — degrades gracefully when absent).
+- **Outputs.** A Shape B product brief at `docs/product/briefs/<slug>.md`, then a hand-off to `receive-brief` (or an inlined decompose/execute instruction in the degraded path).
+- **Required credentials.** None of its own — Jira access is inherited through the `jira` skill.
+- **Source.** [`jira-brief-intake`](../../../../packs/atlassian/.apm/skills/jira-brief-intake/)

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -17,6 +17,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`jira-brief-intake` skill (atlassian pack).** Turns a Jira epic — or a
+  board / sprint / JQL selection of issues — into shippable specs for teams who
+  plan kanban-style in Jira. It pulls the epic and its children via the `jira`
+  skill, maps them onto a Shape B product brief (epic → Outcome, child issues →
+  `US-n` user stories tagged with their Jira key, epic key → `Epic:` provenance
+  pointer) at `docs/product/briefs/<slug>.md`, then hands off to the
+  `receive-brief` skill to elicit any missing fields, decompose, and build. It
+  is read-only against Jira and degrades gracefully — when `receive-brief` is
+  not installed it inlines a decompose/execute instruction for the agent to act
+  on directly. Pure choreography, mirroring `jira-defect-flow`.
+
 ### Fixed
 
 - **`agentbundle install --adapter kiro` now behaves exactly like `kiro-ide`.**

--- a/docs/specs/jira-brief-intake/plan.md
+++ b/docs/specs/jira-brief-intake/plan.md
@@ -1,0 +1,189 @@
+# Plan: jira-brief-intake
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Done <!-- Drafting | Executing | Done -->
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn. When it changes substantially
+> (a different approach, not just a re-ordering), note why in the changelog
+> at the bottom.
+
+## Approach
+
+Pure prose-choreography, modelled file-for-file on the pack's existing
+`jira-defect-flow` skill. The work is: author one new skill directory under
+`packs/atlassian/.apm/skills/jira-brief-intake/` (`SKILL.md`, `manifest.json`,
+`references/examples.md`), then sweep the four docs that enumerate the pack's
+skills, bump `pack.toml`, add a changelog entry, and regenerate
+`.claude-plugin/marketplace.json` via `make build`.
+
+The riskiest part is **not** code — there is none — it is *boundary
+discipline*: keeping the skill thin so it doesn't bleed into the two skills it
+composes. The SKILL.md must (a) route every Jira read through the `jira` skill
+by name, (b) hand elicitation/decomposition/execution to `receive-brief` by
+name, and (c) own only the Jira→brief mapping in between. The
+graceful-degradation path is the one place the skill carries
+`receive-brief`-shaped knowledge (a compact brief shape + a decompose/execute
+instruction); that is a deliberate, bounded duplication for the core-absent
+case, not a reimplementation — it hands the job to the agent rather than doing
+it inline.
+
+The brief mapping is the substance: a Jira epic becomes a **Shape B** brief
+(story-list), its children become `US-n` stories each tagged with the source
+Jira key, and the epic key drops into the `Epic:` provenance pointer. This
+gives a full traceability chain Jira key ↔ `US-n` ↔ spec AC (`receive-brief`
+stamps `Satisfies: US-n` on derived spec ACs downstream).
+
+## Constraints
+
+- No governance constraint (no ADR/RFC governs the atlassian pack's workflow
+  skills). The binding precedent is the in-pack `jira-defect-flow` skill: same
+  cross-skill-by-name contract, same manifest `deps` shape, same
+  reference-docs layout.
+- atlassian is user-scope-default — gate is `lint-packs` + `validate` +
+  `build` + package pytest (see spec Assumptions).
+
+## Construction tests
+
+No new executable logic ships, so there are no per-task unit tests. Verification
+is goal-based + manual QA (see spec Testing Strategy).
+
+**Integration tests:** none beyond the pack gate (`lint-packs`, `validate`,
+`build`, agentbundle pytest), which validates skill well-formedness and
+marketplace-drift.
+**Manual verification:**
+1. Reading-level dry-run of `SKILL.md` against a representative epic (e.g.
+   `PROJ-100` with children `PROJ-101..103`): confirm every dispatched `jira`
+   subcommand (`get-issue`, `search`) exists in `jira/SKILL.md`; confirm the
+   produced brief conforms to the carried shape (Outcome from epic, `US-n` from
+   children with Jira keys, `Epic: PROJ-100`); confirm hand-off to
+   `receive-brief` by name.
+2. Core-absent path: confirm the degraded branch inlines a decompose/execute
+   instruction, does not stop, **and** records the note that downstream
+   `new-spec` / `work-loop` may likewise be absent.
+3. Single-non-epic-issue path: confirm the skill recommends `new-spec` and asks
+   before proceeding.
+4. `jira`-prerequisite path: confirm the skill probes `jira: check` first and,
+   on exit 2, tells the user to run `credential-setup` and stops (no reads
+   dispatched into an auth failure).
+
+## Tasks
+
+### T1: jira-brief-intake skill authored and well-formed
+
+**Depends on:** none
+
+**Tests:**
+- `lint-packs` passes for the atlassian pack (skill frontmatter + structure
+  well-formed). Verifies spec AC1.
+- `grep` confirms no raw Jira REST call and no Jira write verb
+  (`create-issue|update-issue|delete-issue|transition|comment|attach`) appears
+  anywhere in the skill directory — `SKILL.md` **and** `references/`, including
+  "don't do this" examples. Verifies spec AC2.
+- `grep` confirms the skill names `receive-brief` and `jira` by name and the
+  manifest `deps.skills` lists both. Verifies spec AC4.
+- Reading-level dry-run (Manual verification 1–3). Verifies spec AC3, AC5, AC6.
+
+**Approach:**
+- Create `packs/atlassian/.apm/skills/jira-brief-intake/SKILL.md` mirroring
+  `jira-defect-flow`'s structure: frontmatter (`name`, trigger `description`,
+  `metadata.version`), a "choreography not invention" preamble, a
+  "cross-skill invocation by name" section, Prerequisites (incl. the
+  `receive-brief`-present probe that drives graceful degradation), a Lifecycle
+  with stages (Intake → enumerate children with the flavor-correct
+  `parent = $KEY` / `"Epic Link" = $KEY` query + fallback → Map to brief
+  (Shape B) → Hand off to receive-brief by name → Graceful-degradation
+  core-absent branch carrying a brief shape + decompose/execute instruction),
+  Don't, Edge cases (incl. single-non-epic-issue → recommend new-spec), Examples
+  pointer.
+- Create `manifest.json` mirroring `jira-defect-flow`'s, with `deps.skills` =
+  `jira` (this pack) + `receive-brief` (core; degrade gracefully if absent),
+  the runtime-by-name `_runtime_contract` note, `input`/`output` blocks.
+- Create `references/examples.md` with worked patterns: an epic-with-children
+  happy path, a JQL/board selection, the single-non-epic-issue→new-spec case,
+  and the core-absent degraded path.
+
+**Done when:** the skill directory exists, `lint-packs` is green for atlassian,
+and the greps + dry-run above hold.
+
+### T2: pack metadata bumped and marketplace regenerated
+
+**Depends on:** T1
+
+**Tests:**
+- `agentbundle validate` passes for the atlassian pack. Verifies spec AC8 (part).
+- `make build` regenerates `.claude-plugin/marketplace.json` with no remaining
+  drift (`git diff` shows only the intended additions). Verifies spec AC8.
+
+**Approach:**
+- Bump `packs/atlassian/pack.toml` `[pack].version` and extend its
+  `description` to name the new workflow skill.
+- Sync `packs/atlassian/.claude-plugin/plugin.json` (version + description) —
+  it is tracked and hand-mirrors `pack.toml`; build aggregates it into
+  `marketplace.json`.
+- Run `make build` to refresh `.claude-plugin/marketplace.json`.
+
+**Done when:** `validate` is green and `marketplace.json` matches the bumped
+pack with no drift.
+
+### T3: docs enumerations + changelog updated
+
+**Depends on:** T1
+
+**Touches:** packs/atlassian/README.md, docs/guides/atlassian/README.md, docs/guides/atlassian/reference/atlassian-skills.md, docs/guides/atlassian/explanation/atlassian-pack.md, docs/architecture/overview.md, docs/guides/README.md, docs/product/changelog.md
+
+**Tests:**
+- `grep` for `jira-brief-intake` hits all six enumeration docs. Verifies spec AC7.
+- Each doc's skill enumeration is **internally consistent** after the edit:
+  count words and role groupings ("seven skills", "three workflow skills",
+  "Three skills compose") match the actual skill set — hand-checked, since this
+  is prose no lint enforces. Verifies spec AC7.
+- `grep` for the new skill in `docs/product/changelog.md` `[Unreleased]`.
+  Verifies spec AC9.
+- The reference-guide section mirrors the skill's frontmatter `description`
+  (hand-checked byte-for-byte against `SKILL.md`).
+
+**Approach:**
+- `packs/atlassian/README.md`: add the skill to the workflow-skills sentence
+  and the "What's inside" bullets (de-count rather than bump a hardcoded count,
+  per the no-brittle-counts convention, where the edit already touches the line).
+- `docs/guides/atlassian/README.md`: add to the skill enumeration.
+- `docs/guides/atlassian/reference/atlassian-skills.md`: add a
+  `## jira-brief-intake` section (Purpose / Primary inputs / Outputs / Source)
+  mirroring the frontmatter.
+- `docs/guides/atlassian/explanation/atlassian-pack.md`: add a one-line bullet.
+- `docs/architecture/overview.md`: add the skill to the atlassian row's skill list.
+- `docs/guides/README.md`: add the skill to the atlassian pack-index row.
+- `docs/product/changelog.md`: add an `[Unreleased] → Added` entry.
+
+**Done when:** all six enumeration docs and the changelog name the skill, and
+the reference section mirrors the frontmatter.
+
+## Rollout
+
+Pure catalogue content — no infra, no migration, no deployment sequencing. The
+skill ships when the PR merges; adopters get it on their next `agentbundle
+install`/`upgrade` of the atlassian pack. Fully reversible (revert the PR).
+
+## Risks
+
+- **Boundary bleed** — the skill drifts into reimplementing `jira` reads or
+  `receive-brief` elicitation. Mitigated by the spec's Never-do rules and the
+  pre-EXECUTE + diff adversarial passes, which check exactly this against the
+  `jira-defect-flow` precedent.
+- **Marketplace drift** — forgetting `make build` leaves `marketplace.json`
+  stale and red-fails CI. Mitigated by T2's explicit build + drift check.
+- **Reference-guide frontmatter drift** — the reference section is
+  hand-maintained and invisible to `lint-packs`/`build`; only adversarial
+  review catches a mismatch. Mitigated by hand-checking it byte-for-byte in T3.
+- **Carried brief-shape drift** — the degraded core-absent path carries a
+  compact brief shape inside `SKILL.md`, invisible to `lint-packs`/`build`, so
+  it can silently drift from the canonical
+  `packs/core/seeds/docs/product/briefs/_template.md` as that template evolves
+  (same class as the frontmatter-drift risk above). Mitigated by keeping the
+  carried shape minimal (section headings + the `US-n` line format only, not a
+  full copy) so the drift surface is small, and by adversarial review.
+
+## Changelog
+
+- 2026-06-15: initial plan.

--- a/docs/specs/jira-brief-intake/spec.md
+++ b/docs/specs/jira-brief-intake/spec.md
@@ -1,0 +1,211 @@
+# Spec: jira-brief-intake
+
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** RFC-0019 <!-- scoped this Jira intake adapter to the non-core atlassian pack and pinned the no-cross-repo-hub boundary (`Epic:`-pointer-only) -->
+- **Brief:** none
+- **Contract:** none
+- **Shape:** integration <!-- composes the external Jira API + two sibling skills; ships choreography prose, not code, so the plan's `## Design (LLD)` is intentionally empty (the design lives in the Lifecycle prose, mirroring jira-defect-flow) -->
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+Teams that run their delivery kanban-style in Jira keep the *what/why* of a
+body of work in a Jira **epic and its child issues** (or a board / sprint /
+JQL selection), not in a written product brief. The `receive-brief` skill is
+the front door to spec-driven delivery, but it has no knowledge of Jira: it
+ingests a brief, elicits what's missing, decomposes into specs, and hands each
+to `new-spec` → `work-loop`. `jira-brief-intake` is the missing adapter
+between the two. It pulls a Jira epic (plus its children), or a set of issues,
+via the `jira` skill, maps the Jira-native shape onto a product brief — epic →
+**Outcome**, child issues → **Shape B user stories** (`US-n`), epic key →
+**`Epic:`** provenance pointer — writes a draft brief to
+`docs/product/briefs/<slug>.md`, and hands off to `receive-brief` by name to
+elicit gaps, decompose, and build. The user gets a single command —
+*"turn PROJ-100 into specs"* — that turns a kanban epic into shippable work
+without re-typing the brief.
+
+It is choreography, not invention, in the exact mould of the pack's existing
+`jira-defect-flow` (which maps a Jira defect onto the `bug-fix` skill). This
+skill never writes a raw Jira REST call (the `jira` skill owns that) and never
+reimplements elicitation, decomposition, or spec authoring (`receive-brief`
+and its downstream own that). Its sole contribution is the Jira→brief mapping
+that neither side can do alone.
+
+## Boundaries
+
+### Always do
+
+- Pull all Jira data through the `jira` skill addressed **by name**, never by
+  path and never via a raw REST call.
+- Enumerate an epic's children with a **flavor-correct** child query through the
+  `jira` skill's `search`: `parent = $KEY` (Cloud team-managed projects) and
+  `"Epic Link" = $KEY` (Server/DC and company-managed Cloud). Try one and fall
+  back to the other when it errors on a missing field or returns empty — never
+  assume a single form, since `"Epic Link"` does not exist on team-managed Cloud
+  and silently returns zero children there.
+- Map a Jira epic's children onto **Shape B** user stories, tagging each `US-n`
+  with its source Jira key so traceability is bidirectional
+  (Jira key ↔ `US-n` ↔ spec AC).
+- Stamp the source epic key into the brief's `Epic:` provenance pointer.
+- Probe the `jira` skill as a Prerequisite before any read (`jira: check`):
+  exit 0 → proceed; exit 2 → tell the user to authenticate via
+  `credential-setup` themselves (interactive) and stop. Never dispatch reads
+  into an auth failure. (`jira` is a hard runtime dependency — unlike
+  `receive-brief`, there is no degraded path without it.)
+- Hand off elicitation, decomposition, and spec authoring to `receive-brief`
+  by name; it is the owner of those stages.
+- Gracefully degrade: when `receive-brief` is not installed, inline a compact
+  decompose-and-execute instruction the agent can act on directly, using the
+  brief shape this skill carries.
+
+### Ask first
+
+- Before treating a **single non-epic issue with no children** as a brief —
+  one issue is one feature, which is `new-spec` territory, not a multi-feature
+  brief. Recommend `new-spec` and confirm before proceeding.
+- Before writing over an existing `docs/product/briefs/<slug>.md` — confirm the
+  slug and whether to merge or replace.
+
+### Never do
+
+- Never write a raw Jira REST call, or reimplement any `jira` subcommand,
+  inside this skill.
+- Never reimplement `receive-brief`'s Elicit stage — do not interrogate the
+  user for missing Outcome/Scope yourself; that is `receive-brief`'s job (and
+  its degraded-path instruction is a *handoff of that job to the agent*, not a
+  reimplementation here).
+- Never invoke any Jira **write** verb (`create-issue`, `update-issue`,
+  `delete-issue`, `transition`, `comment`, `attach`). Intake is read-only.
+- Never invent an Outcome, Scope, or story the Jira source does not support —
+  surface the gap and let `receive-brief` elicit it.
+- Never reference a sibling skill, or the brief template, by hardcoded path.
+- Never modify the `core` pack (or any pack other than `atlassian`), and never
+  add a pack dependency or new module — scope is the atlassian pack only, and
+  this skill is pure choreography over skills that already exist.
+- Never become a cross-repo coordination hub (RFC-0019 boundary): carry the
+  Jira epic key as an `Epic:` provenance pointer only; do not reimplement a
+  tracker or coordinate work above this repo's slice.
+
+## Testing Strategy
+
+This change ships **prose primitives** (a `SKILL.md`, a `manifest.json`,
+reference docs) plus catalogue metadata — there is no new executable logic, so
+no TDD-mode tasks.
+
+- **Skill content + pack metadata: goal-based check.** The skill is well-formed
+  and the pack still builds. Verified by `lint-packs`, `agentbundle validate`,
+  `make build` (regenerates `.claude-plugin/marketplace.json`), and the
+  agentbundle package pytest — the standing gate for a non-projected,
+  user-scope-default pack.
+- **Doc-drift: goal-based check.** Every place that enumerates the atlassian
+  skill set names the new skill. Verified by `grep`.
+- **Skill behavior: manual QA.** The skill is an agent-invoked artifact; its
+  "happy path" is a reading-level dry-run — trace the documented procedure
+  against a representative Jira epic and confirm each step dispatches a real
+  `jira` subcommand that exists, produces a brief conforming to the carried
+  shape, and hands off correctly in both the core-present and core-absent
+  paths. Recorded in the plan's Manual verification.
+
+## Acceptance Criteria
+
+- [x] A `jira-brief-intake` skill exists at
+  `packs/atlassian/.apm/skills/jira-brief-intake/` with a `SKILL.md` whose
+  frontmatter `description` triggers on turning a Jira epic / board / set of
+  issues into a product brief, and a `manifest.json` declaring its `jira` and
+  `receive-brief` dependencies by name (runtime-by-name contract, `source` as
+  install hint only).
+- [x] The skill's procedure pulls Jira data **only** through named `jira`
+  subcommands that exist in the `jira` skill (`get-issue`, `search`), and
+  invokes **none** of the six Jira write verbs the Boundaries Never-do bans —
+  `create-issue`, `update-issue`, `delete-issue`, `transition`, `comment`,
+  `attach` — anywhere in the skill directory (`SKILL.md` **and**
+  `references/`), including in "don't do this" examples.
+- [x] The skill enumerates an epic's children with a flavor-correct child query
+  — `parent = $KEY` **and** `"Epic Link" = $KEY`, with fallback between them —
+  rather than a single hardcoded form, so it returns the children on
+  team-managed Cloud as well as Server/DC and company-managed Cloud.
+- [x] The skill maps an epic's children onto **Shape B** user stories, each
+  `US-n` carrying its source Jira key, and stamps the epic key into the brief's
+  `Epic:` pointer — the brief it writes conforms to the brief shape (the core
+  template when present; the carried shape when core is absent).
+- [x] The Jira-child → `US-n` mapping has a **pinned, single format** the
+  downstream `Satisfies: US-n` trace can consume: each story line is
+  `- **US-n.** (JIRA-KEY) <story text>`, where the Jira key is a parenthetical
+  immediately after the id (this is the slot the brief template's bare
+  `- **US-n.** …` line does not itself define), and `<story text>` is the
+  child's summary reshaped into the template's *As a … I want … so that …*
+  grammar **when the source supports it**, else the child summary carried
+  verbatim for `receive-brief` to refine during Elicit — the skill never
+  invents a role/benefit the child issue does not state.
+- [x] The skill probes `jira` (`jira: check`) as a Prerequisite before any
+  read and defines the exit-2 (unauthenticated) path — tell the user to run
+  `credential-setup` themselves and stop — mirroring `jira-defect-flow`'s
+  Prerequisites; `jira` is a hard dependency with no degraded path.
+- [x] The skill hands off to `receive-brief` **by name** for Elicit /
+  Decompose / Execute, and does **not** reimplement elicitation.
+- [x] **Graceful degradation:** the skill's Prerequisites probe detects
+  `receive-brief`'s absence (by-name dispatch unavailable / not installed), and
+  in that case the `SKILL.md` carries a clearly-labelled core-absent branch
+  holding (a) a compact brief shape and (b) a decompose-and-execute instruction
+  the agent acts on directly — so the flow proceeds rather than stopping — and
+  notes that downstream `new-spec` / `work-loop` may likewise be absent.
+- [x] The skill recommends `new-spec` (and confirms before proceeding) when the
+  input is a single non-epic issue with no children — it does not force a
+  one-feature ticket into a brief.
+- [x] Every doc that enumerates the atlassian skill set names the new skill:
+  `packs/atlassian/README.md`, `docs/guides/atlassian/README.md`,
+  `docs/guides/atlassian/reference/atlassian-skills.md` (a section mirroring
+  the skill's frontmatter), `docs/guides/atlassian/explanation/atlassian-pack.md`,
+  `docs/architecture/overview.md` (the per-pack skill table), and
+  `docs/guides/README.md` (the pack-index row). The edit also keeps each doc's
+  **count and role-grouping prose internally consistent** — two distinct kinds
+  of count are corrected: the **total-skill count** ("seven skills" in the
+  guides README → eight, or de-counted) and the **workflow/role-group counts**
+  ("three workflow skills" in the pack README, "Three skills compose" in the
+  explanation → four / four, or de-counted), with `jira-brief-intake` placed as
+  a *composed/workflow* skill, not a CLI. Per the no-brittle-counts convention,
+  de-count the prose where the edit already touches the line rather than
+  perpetuating a hardcoded number.
+- [x] `packs/atlassian/pack.toml` version is bumped and its `description`
+  reflects the new workflow skill; `packs/atlassian/.claude-plugin/plugin.json`
+  is kept in sync (version + description); and `.claude-plugin/marketplace.json`
+  is regenerated by `make build` to match (no build-drift).
+- [x] A `docs/product/changelog.md` `[Unreleased]` entry records the new skill.
+- [x] The pack gate is green: `lint-packs`, `agentbundle validate`,
+  `make build`, and the agentbundle package pytest all pass.
+
+## Assumptions
+
+- Technical: the `jira` skill exposes read verbs `get-issue` (with
+  `--expand`/`--fields`) and `search` (JQL), which suffice to pull an epic, its
+  children, and arbitrary issue selections (source: read
+  `packs/atlassian/.apm/skills/jira/SKILL.md`).
+- Technical: `receive-brief` is robust to a sparse/incomplete brief — its
+  Elicit stage ingests a file and elicits missing Outcome/Scope rather than
+  rejecting, so this skill need not validate brief completeness (source: read
+  `packs/core/.apm/skills/receive-brief/SKILL.md` + its Shape B example,
+  probe 2026-06-15).
+- Technical: a Jira epic's child issues are the natural source for `receive-brief`
+  Shape B stories, and the brief template's `Epic:` field is defined for exactly
+  this kind of external-tracker provenance pointer (source: read
+  `packs/core/seeds/docs/product/briefs/_template.md`).
+- Process: atlassian is a user-scope-default pack, not projected into this
+  repo's working tree; adding a skill + bumping its version drifts
+  `.claude-plugin/marketplace.json`, so the gate is `lint-packs` + `validate` +
+  `build` + package pytest, not `build-self`/`pre-pr` (source: project memory +
+  `packs/atlassian/pack.toml`).
+- Product: a new composition skill (not a progressive-disclosure mode bolted
+  onto the `jira` primitive) is the chosen shape, mirroring `jira-defect-flow`
+  (source: user confirmation 2026-06-15).
+- Product: scope stays in the atlassian pack; `receive-brief` (core) is not
+  modified (source: user confirmation 2026-06-15).
+- Process: RFC-0019 (Accepted) explicitly anticipated this Jira intake adapter
+  living in the non-core atlassian pack (`jira-defect-flow` intake precedent;
+  Jira-specific work fails core's Universal principle) and pinned the
+  no-cross-repo-hub boundary the skill honours via the `Epic:` pointer (source:
+  read `docs/rfc/0019-product-brief-intake.md` §Decision 1 / :149, probe
+  2026-06-15).

--- a/packs/atlassian/.apm/skills/jira-brief-intake/SKILL.md
+++ b/packs/atlassian/.apm/skills/jira-brief-intake/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: jira-brief-intake
+description: Use this skill when the user points at a Jira epic (or a board / sprint / JQL selection of issues) and wants it turned into shippable specs -- "turn PROJ-100 into specs", "decompose this epic", "we plan kanban-style in Jira, break this epic into a product brief". The skill pulls the epic and its children via the `jira` skill, maps them onto a product brief (epic -> Outcome, child issues -> Shape B user stories tagged with their Jira key, epic key -> `Epic:` pointer), writes it to `docs/product/briefs/<slug>.md`, and hands off to the `receive-brief` skill to elicit gaps, decompose, and build. Do NOT use for a single feature (use `new-spec`) or a defect (use `jira-defect-flow`).
+metadata:
+  version: "1.0"
+---
+
+# Skill: jira-brief-intake
+
+This is choreography, not invention. It is the adapter between a tracker and
+the brief-intake pipeline, for teams that keep the *what/why* of a body of work
+in a Jira **epic and its child issues** rather than in a written brief. It
+composes two things that already exist:
+
+- **`jira` skill** (sibling in this pack) — every Jira read. You never write a
+  raw Jira REST call here, and this skill is **read-only**: it never transitions,
+  comments, attaches, creates, updates, or deletes.
+- **`receive-brief` skill** (shipped by the host repo's `core` pack; resolved
+  by name through the harness) — the brief inbox: it **elicits** missing
+  load-bearing fields conversationally, **decomposes** the brief into
+  independently-shippable slices, and **executes** each through `new-spec` →
+  `work-loop`. This skill does **not** re-explain or re-implement any of that —
+  least of all elicitation. It assembles the brief from Jira and hands off.
+
+The one thing this skill owns is the **Jira → brief mapping** that neither side
+can do alone: `receive-brief` knows nothing about Jira, and `jira` knows
+nothing about briefs. If you find yourself writing a Jira REST call, or
+interrogating the user for a missing Outcome, stop — the first belongs in
+`jira`, the second in `receive-brief`.
+
+## Cross-skill invocation — name, not path
+
+This skill names sibling skills (`jira`, `receive-brief`, `new-spec`) **by
+their `name:` field, never by path**. Install locations vary by IDE and scope,
+and skills can be renamed at install time. Path coupling silently breaks every
+alternative layout.
+
+The contract: when this skill says *"via the `jira` skill: `get-issue $KEY
+...`"*, the agent uses its native skill-dispatch mechanism to invoke the skill
+registered under that name with those arguments. In Claude Code that's the
+Skill tool (`/<skill-name>` or programmatic dispatch); in other IDEs it's the
+equivalent. **If you find yourself writing `~/.claude/skills/jira/...` or any
+other hardcoded path here, stop — look up the skill by name instead.**
+
+Install guidance for the named dependencies lives in `manifest.json` under
+`deps.skills` — that's a *where to get them* hint, not a runtime path.
+
+## Prerequisites
+
+Before stage 1, confirm two things — they behave differently:
+
+1. **`jira` is installed and authenticated — a hard dependency.** Invoke it:
+   `jira: check`.
+   - Exit 0 → proceed.
+   - Exit 2 → the user must act. Tell them to run `credential-setup`
+     themselves (it's interactive — do not run it for them), then stop. **Do
+     not dispatch any read into an auth failure.**
+   - There is **no degraded path** without `jira` — it performs every read this
+     skill depends on.
+
+2. **`receive-brief` is installed — a soft dependency.** Probe whether your
+   harness can dispatch a skill registered under the name `receive-brief`.
+   - Present → the normal flow (stage 3 hands off to it).
+   - Absent → the **graceful-degradation** flow (stage 4). You still produce the
+     brief; you just inline the decompose/execute instruction instead of
+     handing off. Decide this now so stage 2 knows which shape to write.
+
+## Lifecycle
+
+### Stage 1 — Intake: pull the epic and its children
+
+Fetch the epic with the fields a brief needs, via the `jira` skill:
+
+```
+get-issue $EPIC_KEY --fields "summary,description,labels,issuetype,status" --expand renderedFields
+```
+
+Then **enumerate its children**. Jira has no single "get children" verb, and the
+parent↔child relationship is named differently across flavors — so query both
+forms through the `jira` skill's `search` and use whichever returns issues:
+
+```
+# Cloud team-managed projects use `parent`:
+search "parent = $EPIC_KEY ORDER BY created ASC" --fields "summary,description,issuetype,status"
+
+# Server / Data Center and company-managed Cloud use the "Epic Link" field:
+search '"Epic Link" = $EPIC_KEY ORDER BY created ASC' --fields "summary,description,issuetype,status"
+```
+
+`"Epic Link"` **does not exist** on team-managed Cloud and a JQL referencing it
+errors there; `parent` is empty for an epic on company-managed/Server. Try one,
+and **fall back to the other** when it errors on a missing field or returns
+zero rows. Never assume a single form — silently returning zero children is the
+failure this guards against.
+
+**Other intake shapes** (kanban teams often have no epic):
+
+- **A board / sprint / JQL selection** instead of an epic: the user gives you a
+  JQL (or a saved-filter / board scope). The matched issues become the brief's
+  stories. There is then **no single parent to derive the Outcome from** —
+  record that as a gap for `receive-brief` to elicit (do not invent one).
+- **A single non-epic issue with no children**: that is *one feature*, not a
+  multi-feature brief. **Stop and recommend `new-spec`** (and, if it's a
+  defect, `jira-defect-flow`). Ask before treating it as a brief — do not force
+  a one-ticket scope into the intake pipeline.
+
+### Stage 2 — Map to a Shape B brief
+
+Write a draft brief to `docs/product/briefs/<slug>.md`, where `<slug>` is
+kebab-case derived from the epic summary (it must match the filename and the
+`Brief:` back-link `receive-brief` later stamps on derived specs). If core is
+installed, copy its `docs/product/briefs/_template.md`; otherwise use the
+**carried shape** below.
+
+The Jira → brief mapping is **Shape B** (story-list), because an epic with
+children *is* a story list:
+
+| Brief field | Jira source |
+|---|---|
+| `Outcome` | the epic's summary + description, in the user's terms (the problem and what changes for them) |
+| `Scope / Non-goals` | the epic description / labels, where stated — never invented |
+| `Epic:` pointer | the **epic key** (e.g. `PROJ-100`) — provenance back to the tracker, exactly what this field is for |
+| `User stories` (`US-n`) | one per child issue (below) |
+
+**Each child issue becomes one `US-n` line in this pinned format** — the trace
+`receive-brief` will complete with `Satisfies: US-n` on derived spec acceptance
+criteria depends on it:
+
+```
+- **US-1.** (PROJ-101) As a <role>, I want <capability>, so that <benefit>.
+- **US-2.** (PROJ-102) <child summary, carried verbatim when it isn't story-shaped>
+```
+
+The Jira key is a parenthetical immediately after the id — the slot the bare
+template line leaves undefined. Reshape the child's summary into the
+*As a … I want … so that …* grammar **only when the source supports it**;
+otherwise carry the summary verbatim and let `receive-brief` refine it during
+Elicit. **Never invent a role or benefit the child issue does not state.**
+
+Leave `Success metrics`, `Appetite`, and any silent `Scope` to
+`receive-brief` — surfacing and filling those gaps is its Elicit stage, not
+yours. The `Spec map`'s Status column is auto-derived downstream; leave it.
+
+### Stage 3 — Hand off to `receive-brief` (the normal flow)
+
+Invoke the `receive-brief` skill **by name**, pointing it at the brief file you
+just wrote. From here, `receive-brief` owns everything:
+
+- **Elicit** — it ingests the brief and asks the user for any missing
+  load-bearing field (Outcome, Scope). A thin epic is normal input; it elicits
+  rather than rejects. **Do not pre-empt this** by interrogating the user
+  yourself.
+- **Decompose** — it cuts the stories into independently-shippable slices and
+  surfaces the cut for confirmation.
+- **Execute** — it chains `new-spec` → `work-loop` per slice and stamps the
+  `Brief:` / `Satisfies: US-n` back-links.
+
+Your job ends at the handoff. Do not duplicate the Decompose/Execute stages.
+
+### Stage 4 — Graceful degradation (the `receive-brief`-absent flow)
+
+When the Prerequisites probe found **no** `receive-brief` skill, do not stop —
+you have still produced a useful brief. Inline the following instruction for the
+agent to act on directly, and note that the downstream `new-spec` and
+`work-loop` skills **may likewise be absent** (if `core` isn't installed, none
+of them are) — fall back to the host repo's own spec/build process where they
+are:
+
+> **Decompose & execute (inlined because `receive-brief` is not installed).**
+> 1. **Elicit the gaps.** The brief above may be missing its Outcome or Scope.
+>    Ask the user for those load-bearing fields — do not invent them. Offer
+>    defaults for Success metrics / Appetite; never block on them.
+> 2. **Decompose by shippability, not by component.** Cut into slices each
+>    *independently shippable and testable* — one feature a build loop can carry
+>    end to end. Group the `US-n` stories into slices. Flag any epic-sized story
+>    for splitting; flag any Outcome no slice covers as a gap.
+> 3. **Surface the cut and wait for confirmation** before authoring any spec.
+> 4. **Execute** each confirmed slice through your repo's spec process (the
+>    `new-spec` skill if installed, else your repo's equivalent), then build it
+>    (the `work-loop` skill if installed, else your repo's loop). Stamp each
+>    derived spec with a `Brief:` back-link to this brief and a
+>    `Satisfies: US-n` marker on the acceptance criteria that satisfy a story.
+
+#### Carried brief shape (used only when core's `_template.md` is absent)
+
+Keep this minimal — headings + the `US-n` line format, not a full copy of the
+canonical template (which lives at `docs/product/briefs/_template.md` when core
+is installed):
+
+```markdown
+# Brief: <one-line outcome>
+
+- **Slug:** `<slug>`
+- **Received:** <YYYY-MM-DD>
+- **Owner:** <who owns this repo's slice>
+- **Epic:** <JIRA-EPIC-KEY>
+
+## Outcome
+<the problem and the user-facing outcome — LOAD-BEARING; elicit if the epic is thin>
+
+## Success metrics
+<observable signals; offer a default if absent>
+
+## Scope / Non-goals
+**In scope:**
+-
+**Non-goals:**
+-
+
+## User stories
+- **US-1.** (JIRA-KEY) As a <role>, I want <capability>, so that <benefit>.
+
+## Spec map
+| Spec | Status |
+| --- | --- |
+| `<feature-slug>` | <auto> |
+```
+
+## Don't
+
+- **Don't write a raw Jira REST call**, or re-implement a `jira` subcommand. If
+  `jira` is missing a read verb you need, extend that skill — don't shim around it.
+- **Don't invoke any Jira write verb** — `create-issue`, `update-issue`,
+  `delete-issue`, `transition`, `comment`, `attach`. Intake is read-only. (The
+  one example showing these is the *banned* list, not a usage.)
+- **Don't reimplement `receive-brief`'s Elicit stage.** Do not interrogate the
+  user for a missing Outcome or Scope — produce the brief and hand off (or, in
+  the degraded path, hand the eliciting *instruction* to the agent).
+- **Don't invent an Outcome, Scope, or story** the Jira source doesn't state.
+  A thin epic is fine — surface the gap; `receive-brief` elicits it.
+- **Don't force a single ticket into a brief.** One issue is one feature →
+  `new-spec`. A defect → `jira-defect-flow`.
+- **Don't become a cross-repo coordination hub.** Carry the epic key as the
+  `Epic:` pointer only; do not reimplement a tracker (RFC-0019 own-the-slice).
+- **Don't hardcode a sibling skill or template path.** Look skills up by name.
+
+## Edge cases
+
+- **No epic, just a JQL/board scope.** The matched issues are the stories, but
+  there's no parent for the Outcome. Record the missing Outcome as a gap and
+  let `receive-brief` elicit it — don't fabricate one from the issue list.
+- **Epic with zero children found.** Confirm you tried *both* child-query forms
+  (stage 1). If genuinely empty, the epic is a one-liner with no decomposition —
+  ask the user whether it's really a single feature (`new-spec`) or whether the
+  children live under a different link type.
+- **Child issues that are themselves epics** (a hierarchy deeper than one
+  level). Flag them as epic-sized stories for splitting; don't silently flatten
+  a sub-epic into a single `US-n`.
+- **Custom fields hold the real scope** (some teams keep acceptance criteria in
+  a custom field). Resolve names with `jira`'s `--expand names` and map what's
+  there; if the scope isn't in any field you can read, surface the gap.
+- **`receive-brief` present but `new-spec`/`work-loop` absent.** `receive-brief`
+  itself surfaces that gap when it tries to execute — you've done your job by
+  handing off; don't pre-solve its downstream.
+
+## Examples
+
+See [`references/examples.md`](references/examples.md) for worked patterns: an
+epic-with-children happy path, a JQL/board selection, the single-non-epic-issue
+→ `new-spec` case, and the `receive-brief`-absent degraded path.

--- a/packs/atlassian/.apm/skills/jira-brief-intake/manifest.json
+++ b/packs/atlassian/.apm/skills/jira-brief-intake/manifest.json
@@ -1,0 +1,38 @@
+{
+  "id": "jira-brief-intake",
+  "name": "Jira Brief Intake",
+  "version": "1.0.0",
+  "description": "Turn a Jira epic (or a board / sprint / JQL selection) into shippable specs: pull the epic and its children via the `jira` skill, map them onto a Shape B product brief (epic -> Outcome, child issues -> `US-n` user stories tagged with their Jira key, epic key -> `Epic:` provenance pointer), write it to `docs/product/briefs/<slug>.md`, and hand off to the `receive-brief` skill to elicit gaps, decompose, and build. Read-only against Jira. Gracefully degrades to an inlined decompose/execute instruction when `receive-brief` is not installed. Pure choreography — composes existing skills by name, never by path.",
+  "category": "workflows",
+  "tags": ["jira", "brief", "receive-brief", "intake", "epic", "workflow", "orchestration", "read-only"],
+  "license": "MIT",
+  "deps": {
+    "_runtime_contract": "Sibling skills are addressed BY NAME at runtime. The agent's harness resolves the name to whatever install location the user picked. `source` below is install guidance only — never a runtime path.",
+    "skills": [
+      {
+        "name": "jira",
+        "source": "this pack — packs/atlassian/.apm/skills/jira/",
+        "purpose": "All Jira reads: check, get-issue, search (for the flavor-correct child query). The intake skill never makes a raw Jira REST call and never invokes a write verb (no transition, comment, attach, create / update / delete). Hard dependency — there is no degraded path without it."
+      },
+      {
+        "name": "receive-brief",
+        "source": "host repo — core pack — .apm/skills/receive-brief/ (projected to .claude/skills/receive-brief/)",
+        "purpose": "Owns Elicit (fill missing Outcome / Scope conversationally), Decompose (cut into shippable slices), and Execute (chain new-spec -> work-loop). The intake skill hands off the assembled brief and never reimplements elicitation. SOFT dependency: when absent, the skill degrades gracefully, producing the brief and inlining a decompose/execute instruction for the agent to act on."
+      }
+    ],
+    "system": []
+  },
+  "input": {
+    "arguments": "a Jira epic key (e.g., PROJ-100), or a JQL / board / sprint selection of issues that together form one multi-feature body of work. A single non-epic issue is out of scope — the skill recommends `new-spec` (or `jira-defect-flow` for a defect) instead.",
+    "env": {}
+  },
+  "output": {
+    "artifacts": [
+      "docs/product/briefs/<slug>.md — a Shape B product brief: Outcome from the epic, one `US-n` story per child issue tagged with its Jira key, the epic key as the `Epic:` provenance pointer. Gaps (Success metrics, Appetite, silent Scope) are left for `receive-brief` to elicit.",
+      "a hand-off to the `receive-brief` skill (normal flow), or an inlined decompose/execute instruction (degraded flow when `receive-brief` is absent)."
+    ]
+  },
+  "targets": {
+    "default": { "file": "SKILL.md" }
+  }
+}

--- a/packs/atlassian/.apm/skills/jira-brief-intake/references/examples.md
+++ b/packs/atlassian/.apm/skills/jira-brief-intake/references/examples.md
@@ -1,0 +1,138 @@
+# jira-brief-intake — canonical examples
+
+Four shapes you'll meet most often. Replace `PROJ-100` etc. with values from
+your environment. Every read here goes through the `jira` skill; this skill
+issues **no** Jira write verb, so none appears below.
+
+## Notation
+
+These examples reference sibling skills **by name**, never by path. A line like
+`jira: get-issue PROJ-100` means *invoke the skill registered under the name
+`jira` with subcommand `get-issue` and the given args*. How that dispatch
+happens depends on the IDE:
+
+- **Claude Code**: the Skill tool, or `/jira get-issue PROJ-100` (and similarly
+  for `receive-brief`).
+- **Cursor / Kiro / Codex / Gemini**: the IDE's skill/rule invocation equivalent.
+- **Raw CLI** (no IDE): `cd` to the `jira` skill's install dir and run
+  `python scripts/jira.py get-issue PROJ-100`. Where that dir lives depends on
+  where the user installed the skill.
+
+Path locations like `~/.claude/skills/jira/...` are install-time details, not
+contract.
+
+---
+
+## 1. Epic with children — the happy path
+
+User: *"Turn PROJ-100 into specs."*
+
+```
+# Prerequisites
+jira: check                      # exit 0 → proceed
+# (probe that `receive-brief` is dispatchable → present → normal flow)
+
+# Stage 1 — intake
+jira: get-issue PROJ-100 --fields "summary,description,labels,issuetype,status" --expand renderedFields
+
+# Enumerate children — try the team-managed form first, fall back to Epic Link:
+jira: search "parent = PROJ-100 ORDER BY created ASC" --fields "summary,description,issuetype,status"
+# → returns PROJ-101, PROJ-102, PROJ-103
+```
+
+Stage 2 writes `docs/product/briefs/team-billing-portal.md` (slug from the epic
+summary), Shape B:
+
+```markdown
+# Brief: Team admins manage their own billing
+
+- **Slug:** `team-billing-portal`
+- **Received:** 2026-06-15
+- **Owner:** billing team
+- **Epic:** PROJ-100
+
+## Outcome
+<from PROJ-100's description — the problem and what changes for admins>
+
+## Scope / Non-goals
+**In scope:** <from the epic description, where stated>
+**Non-goals:** <where stated; else leave for receive-brief to elicit>
+
+## User stories
+- **US-1.** (PROJ-101) As an admin, I want to change my team's plan, so that I don't email support.
+- **US-2.** (PROJ-102) As an admin, I want to update payment methods self-serve.
+- **US-3.** (PROJ-103) Download past invoices as PDF.   <!-- summary carried verbatim; not story-shaped -->
+
+## Spec map
+| Spec | Status |
+| --- | --- |
+| `<feature-slug>` | <auto> |
+```
+
+Stage 3 hands off: `receive-brief: docs/product/briefs/team-billing-portal.md`.
+`receive-brief` elicits the missing Outcome/metrics, decomposes the three
+stories into slices, and chains `new-spec` → `work-loop`.
+
+---
+
+## 2. Board / sprint / JQL selection — no single epic
+
+User: *"We run a kanban board; turn the 'Q3 onboarding' epic-less backlog into specs."*
+
+Kanban teams often have no parent epic. The user gives a JQL (or a saved filter
+/ board scope); the matched issues become the stories.
+
+```
+jira: search "project = ONB AND labels = q3-onboarding ORDER BY rank ASC" --fields "summary,description,issuetype,status"
+# → ONB-12, ONB-15, ONB-18, ...
+```
+
+There's no parent to derive the **Outcome** from. Write the stories
+(`- **US-1.** (ONB-12) …`) and **leave Outcome as a surfaced gap** — do not
+invent one. `Epic:` is omitted (there is no coordinator). Hand off; `receive-brief`
+elicits the Outcome from the user before it decomposes.
+
+---
+
+## 3. A single non-epic issue — recommend `new-spec`
+
+User: *"Make a brief from PROJ-250."* — but `PROJ-250` is a single Story with no
+children.
+
+```
+jira: get-issue PROJ-250 --fields "summary,issuetype,status"
+# issuetype = Story; a child query returns nothing
+jira: search "parent = PROJ-250" --fields summary     # → empty
+jira: search '"Epic Link" = PROJ-250' --fields summary  # → empty (or field-missing error)
+```
+
+One issue is one feature, not a multi-feature brief. **Stop and recommend
+`new-spec`** (or `jira-defect-flow` if it's a defect), and ask before treating
+it as a brief:
+
+> PROJ-250 is a single Story with no children — that's one feature, which
+> `new-spec` handles directly. Want me to scaffold a spec from it instead, or
+> did you mean a different (epic) key?
+
+---
+
+## 4. `receive-brief` not installed — graceful degradation
+
+User: *"Turn PROJ-100 into specs"* — but the `core` pack isn't installed, so the
+Prerequisites probe finds no `receive-brief`.
+
+Stages 1–2 are unchanged: you still pull the epic + children and write the brief
+(using the **carried shape** in `SKILL.md`, since core's `_template.md` is also
+absent). Stage 3 is replaced by stage 4: instead of handing off, you inline the
+decompose/execute instruction for the agent to act on, and note that `new-spec`
+/ `work-loop` may also be absent:
+
+> Wrote `docs/product/briefs/team-billing-portal.md` from PROJ-100 and its three
+> children. `receive-brief` isn't installed, so I'll continue inline: first I
+> need the Outcome (PROJ-100's description is thin) — what changes for admins
+> when this ships? Then I'll cut the three stories into independently-shippable
+> slices, surface the cut for your sign-off, and author each through this repo's
+> spec process (`new-spec` if present, else the repo's equivalent).
+
+The brief is still the durable artifact; only the hand-off degraded to an
+inlined instruction.

--- a/packs/atlassian/.claude-plugin/plugin.json
+++ b/packs/atlassian/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "atlassian",
-  "version": "0.1.4",
-  "description": "Atlassian primitives: jira / jira-align / confluence-crawler (credentialed CLI), plus the flow-metrics, ai-adoption-report, and jira-defect-flow workflows that compose them."
+  "version": "0.2.0",
+  "description": "Atlassian primitives: jira / jira-align / confluence-crawler (credentialed CLI), plus the flow-metrics, ai-adoption-report, jira-defect-flow, and jira-brief-intake workflows that compose them."
 }

--- a/packs/atlassian/README.md
+++ b/packs/atlassian/README.md
@@ -1,14 +1,16 @@
 # atlassian
 
-Atlassian primitives plus the workflows that compose them. Three credentialed
-CLIs — `jira`, `jira-align`, and `confluence-crawler` — and three workflow
-skills: `flow-metrics`, `ai-adoption-report`, and `jira-defect-flow`.
+Atlassian primitives plus the workflows that compose them. Credentialed CLIs —
+`jira`, `jira-align`, and `confluence-crawler`/`-publisher` — and workflow
+skills: `flow-metrics`, `ai-adoption-report`, `jira-defect-flow`, and
+`jira-brief-intake`.
 
 ## What's inside
 
 - Credentialed CLI primitives for Jira, Jira Align, and Confluence.
 - Workflow skills that turn those primitives into flow metrics, an
-  AI-adoption report, and a Jira defect-flow analysis.
+  AI-adoption report, a Jira defect-flow analysis, and a Jira-epic →
+  product-brief intake that feeds `receive-brief`.
 
 ## Install
 

--- a/packs/atlassian/pack.toml
+++ b/packs/atlassian/pack.toml
@@ -1,7 +1,7 @@
 [pack]
 name = "atlassian"
-version = "0.1.4"
-description = "Atlassian primitives: jira / jira-align / confluence-crawler (credentialed CLI), plus the flow-metrics, ai-adoption-report, and jira-defect-flow workflows that compose them."
+version = "0.2.0"
+description = "Atlassian primitives: jira / jira-align / confluence-crawler (credentialed CLI), plus the flow-metrics, ai-adoption-report, jira-defect-flow, and jira-brief-intake workflows that compose them."
 readme = "README.md"
 display_name = "Atlassian"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
## What does this change?

Adds a new composition skill, `jira-brief-intake`, to the `atlassian` pack. It takes a Jira epic (or a board / sprint / JQL selection of issues) and turns it into a product brief that feeds the `receive-brief` skill — for teams that plan their work kanban-style in Jira rather than in a written brief.

## Why?

- Implements: `docs/specs/jira-brief-intake/spec.md`
- Constrained by: **RFC-0019**, which explicitly anticipated a Jira intake adapter living in the non-core `atlassian` pack (Jira-specific work fails core's Universal principle) and pinned the own-the-repo-slice (`Epic:`-pointer-only) boundary.

It is the symmetric counterpart to the pack's existing `jira-defect-flow` (Jira defect → `bug-fix`). This one does Jira epic → `receive-brief`, and is pure choreography over skills that already exist:

- Pulls the epic + its children via the `jira` skill — **read-only**, no write verb anywhere — using a **flavor-correct child query** (`parent = $KEY` for team-managed Cloud, `"Epic Link" = $KEY` for Server/DC + company-managed, with fallback) so children resolve on every Jira flavor.
- Writes a **Shape B** brief: epic → Outcome, each child → `- **US-n.** (JIRA-KEY) <story>` (a pinned format the downstream `Satisfies: US-n` trace consumes), epic key → the `Epic:` provenance pointer. Full trace: Jira key ↔ `US-n` ↔ spec AC.
- Hands off to **`receive-brief` by name** for Elicit / Decompose / Execute — it does **not** reimplement elicitation, because `receive-brief` already elicits a thin brief's missing Outcome/Scope rather than rejecting it (verified against its contract + Shape B example).
- **Graceful degradation:** when `receive-brief`/core is absent, it still produces the brief and inlines a decompose/execute instruction for the agent to act on, noting downstream `new-spec`/`work-loop` may also be absent.

## How do I verify it?

- `make lint-packs` · `make validate` · `make build-self FORCE=1` (marketplace drift-clean) — all green.
- `python3 tools/lint-skill-spec.py` → new skill ✓; `python3 .claude/skills/work-loop/scripts/lint-spec-status.py --root .` → spec metadata clean.
- `PYTHONPATH=packages/agentbundle python3 -m pytest packages/agentbundle/agentbundle/build/tests/` → 100% green (the test root that gates pack content).
- Reading-level dry-run of `SKILL.md`: every dispatched `jira` subcommand (`check`, `get-issue`, `search`) exists; both child-query forms present; happy path, JQL/board, single-non-epic→`new-spec`, and core-absent degraded path all trace correctly.

> Heads-up: the `packages/agentbundle/tests/` CLI root has **3 pre-existing failures** in `test_credential_setup_skill.py` — they fail because the `credbroker` package isn't pip-installed in this environment (the test's subprocess imports it). This PR contains zero Python and doesn't touch that area; `python3 -c "import credbroker"` fails independently.

## What did you not change that you considered?

- **Did not add a progressive-disclosure mode to the `jira` skill** (the offered alternative). Kept `jira` a thin credentialed CLI and put the choreography in its own skill, matching the pack's primitive-vs-workflow separation and the `jira-defect-flow` precedent.
- **Did not modify the `core` `receive-brief` skill.** Its Elicit stage already handles incomplete input, so the adapter stays entirely in the `atlassian` pack.
- **Added no scripts and no dependency** — slug derivation and the brief mapping are prose; the skill composes existing skills by name.
- **Bundled fixes:** none.
- **Deferred:** none.
