### PR TITLE
docs(guides): add full-inception how-to routing the upstream packs

### DIFF
--- a/docs/guides/_shared/how-to/run-a-full-inception.md
+++ b/docs/guides/_shared/how-to/run-a-full-inception.md
@@ -1,0 +1,121 @@
+# Run a full inception for a new project
+
+This guide is for someone starting a greenfield project who wants to know which
+packs to reach for, and in what order, before the build loop takes over.
+Inception is the stretch from a raw idea to a recorded foundation and a first
+buildable slice.
+
+It points you at the packs and skills each stage needs; the linked per-pack
+guides carry the actual procedure. If you only want the shortest path — feed an
+idea to `init-project` and get a walking skeleton — walk
+[From idea to a walking skeleton](../../core/tutorials/start-a-new-project.md)
+instead; that one uses `core` alone. This guide is the fuller flow: where
+research, product shaping, and system design fit around that core spine.
+
+## Before you start
+
+You need:
+
+- An idea, even a rough one.
+- The `core` pack, for `init-project`, `new-spec`, and `work-loop`.
+
+You don't install everything up front. Inception is a spine with optional
+stages in front of it. You add a stage, and the pack behind it, only when
+you're carrying the uncertainty it removes. For the install routes themselves
+see [Install routes](../explanation/install-routes.md), or
+[Install a curated set of packs](install-a-profile.md) to take several at once.
+
+## The spine
+
+Every inception ends the same way: `init-project` records a foundation and
+authors a walking-skeleton spec, then `work-loop` builds it. What changes is
+how much you do *before* `init-project`, and that depends on what you're
+unsure about.
+
+| What you're unsure about | Bring in | It produces |
+| --- | --- | --- |
+| Is this true? What's been built before? What's best practice? | `research` | a cited `research.md` |
+| Is this worth building? Does the bet hold? What exactly ships? | `product-engineering` | a `core` **brief** |
+| How should it be built? What's the system shape? | `architect` | a design doc and ADR-worthy decisions |
+| — always — | `core` (`init-project`) | an ADR, a `reference.md`, a skeleton spec |
+| — always — | `core` (`work-loop`) | shipped slices |
+
+Read it top to bottom and skip any row whose uncertainty you don't carry.
+
+## The packs and skills you reach for
+
+### `research` — when the space is unfamiliar or contested
+
+- **Skills:** `research` (run it in `applied` mode for prior art, best
+  practice, and known anti-patterns), plus `source-map`, `compare-hypotheses`,
+  and `devils-advocate` for contested choices.
+- **Install:** `agentbundle install --pack research <catalogue>`. The
+  `solution-architect` profile bundles it with `architect`.
+- **How:** [Run the research pipelines](../../research/how-to/research-pipelines.md),
+  or [your first research session](../../research/tutorials/research-first-session.md)
+  if the pack is new to you.
+
+### `product-engineering` — when the bet is uncertain
+
+- **Skills:** `frame-intent` (idea → outcome plus opportunity),
+  `de-risk-intent` (test the riskiest assumption against a predeclared kill
+  condition), `decompose-intent` (cut it into a `core` brief). At app scale the
+  leaf intent *is* the brief.
+- **Install:** `agentbundle install --pack product-engineering <catalogue>`.
+- **How:** [Shape a feature intent](../../product-engineering/how-to/shape-a-feature-intent.md).
+
+### `architect` — when the system shape is uncertain
+
+- **Skills:** `architect-design` (concept → design doc, converged against
+  review), `architect-diagram`, `architect-review`. The decisions it surfaces
+  become the rationale `init-project` records.
+- **Install:** `agentbundle install --pack architect <catalogue>`, or the
+  `solution-architect` profile.
+- **How:** [Establish your reference architecture](../../architect/how-to/establish-reference-architecture.md).
+
+### `core` — always (you already have it)
+
+- **Skills:** `init-project` (runs the trigger and value gates, records the
+  foundation — an ADR plus `reference.md` — and authors the walking-skeleton
+  spec via `new-spec`), then `work-loop` builds it. `receive-brief` is the
+  entry point when someone hands you a multi-feature brief instead of an idea.
+- **How:** [Decide and record your foundation](../../core/how-to/record-your-foundation-during-inception.md)
+  and [Plan and execute non-trivial work](../../core/how-to/plan-and-execute-non-trivial-work.md).
+
+`init-project` orchestrates the foundation and skeleton; it does not build the
+skeleton itself, and it consumes discovery rather than performing it. If the
+`architect` stage already established `reference.md`, the foundation step points
+at it rather than redoing it.
+
+## The lightest inception
+
+Clear idea, obvious value, familiar stack: skip the upstream packs entirely.
+Feed `init-project` a one-paragraph PRD and go straight to a walking skeleton.
+This is exactly the [core tutorial](../../core/tutorials/start-a-new-project.md).
+The upstream stages earn their place only against real uncertainty.
+
+## Common pitfalls
+
+- **Asking `init-project` to do the research.** It consumes discovery; it never
+  performs it. If you reach the value gate and can't state the business value,
+  the gate stops you. That's the signal to go back to `research` or
+  `product-engineering`, not to push through.
+- **No home for early notes.** There's no first-class inbox for thinking that
+  predates research. The durable options today are a `research.md` (even in
+  `quick` mode) or `docs/product/intents/<slug>.md` once you've framed an
+  intent. `.context/` is session scratch: it's gitignored and doesn't survive a
+  fresh workspace, so keep nothing load-bearing there.
+- **Treating the stages as mandatory gates.** They're optional stages keyed to
+  uncertainty, not a waterfall. Running all three upstream packs for a project
+  whose value and shape are already clear is ceremony.
+
+## See also
+
+- [From idea to a walking skeleton](../../core/tutorials/start-a-new-project.md)
+  — the `core`-only walkthrough this guide wraps.
+- [Receive a product brief](../../core/how-to/receive-a-product-brief-and-decompose-it-into-specs.md)
+  — when you start from someone else's multi-feature brief.
+- [Run a capability across a value stream](../../product-engineering/how-to/run-a-capability-across-a-value-stream.md)
+  — inception at business-unit scale, across many component repos.
+- [Install a curated set of packs](install-a-profile.md) — take the upstream
+  packs in one command.

--- a/docs/guides/core/tutorials/start-a-new-project.md
+++ b/docs/guides/core/tutorials/start-a-new-project.md
@@ -2,7 +2,7 @@
 
 > At the end of this tutorial you'll have a brand-new repo with a recorded foundation — an ADR and a `docs/architecture/reference.md` — and a walking-skeleton spec authored and ready to build. You'll learn the rhythm of the greenfield front door by walking it once.
 
-This is a learning walkthrough, not a reference. For *why* the skeleton is built this way, read [Why a walking skeleton beats a throwaway prototype](../explanation/walking-skeleton-vs-throwaway.md) afterward; for the foundation step on its own, see [Decide and record your foundation during inception](../how-to/record-your-foundation-during-inception.md).
+This is a learning walkthrough, not a reference. It uses the `core` pack alone. For the fuller inception — where the `research`, `product-engineering`, and `architect` packs fit around this core spine — see [Run a full inception for a new project](../../_shared/how-to/run-a-full-inception.md). For *why* the skeleton is built this way, read [Why a walking skeleton beats a throwaway prototype](../explanation/walking-skeleton-vs-throwaway.md) afterward; for the foundation step on its own, see [Decide and record your foundation during inception](../how-to/record-your-foundation-during-inception.md).
 
 We'll use one concrete idea throughout: **a URL-shortener service** — an API that takes a long URL and returns a short code, with a datastore behind it. It has real components, so it's a genuine project, not a throwaway.
 


### PR DESCRIPTION
## What

Adds `docs/guides/_shared/how-to/run-a-full-inception.md` — a cross-pack how-to that routes a greenfield reader to the right pack for the uncertainty they carry, around the `core` `init-project` → `work-loop` spine.

- **Decision-rule spine:** a table mapping *what you're unsure about* → *which pack to bring in* (`research` → `product-engineering` → `architect`) → *what it produces*.
- **Per-pack pointers:** the skills you'll use, the one-line install command, and a link to that pack's own guide — it routes rather than re-walking each procedure.
- **Lightest path:** skip the upstream packs and feed `init-project` a one-paragraph PRD (the existing core tutorial).
- **Honest gap:** there's no first-class pre-research notes inbox today; documents the durable options.

Cross-links the core `start-a-new-project.md` tutorial out to the new guide; the tutorial stays the generic `core`-only walkthrough.

## Why

Each pack documented its own piece, but nothing covered *which pack when* across a greenfield inception. This fills that gap.

## Notes

- Docs-only. `docs/guides/` is repo-owned (build-self skips it), so no projection step.
- No changelog entry: tracks behavior changes, not doc additions (precedent: #333 added guides without one).
- All 11 cross-links verified to resolve; reverse link verified.