### PR TITLE
feat(profiles): add the inception profile for greenfield bootstrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ A fourth subagent, `implementer`, is the loop's own executor. It runs independen
 
 Repo-scope packs install into the current repo and build on `core`. User-scope packs install into `~/.claude/` (or your harness's home root) and follow you across every project. Swap `core` for any pack name in the command above.
 
-**Or install a curated set in one command.** Profiles bundle the blessed combinations: `agentbundle install --profile full-ceremony <catalogue>` lands `core` plus the repo governance packs (deps-first), and `--profile solution-architect <catalogue>` lands the `architect` + `research` + `contracts` user-scope toolkit. `agentbundle list-profiles <catalogue>` shows what's available; see the [install-a-profile how-to](docs/guides/_shared/how-to/install-a-profile.md).
+**Or install a curated set in one command.** Profiles bundle the blessed combinations: `agentbundle install --profile full-ceremony <catalogue>` lands `core` plus the repo governance packs (deps-first), `--profile solution-architect <catalogue>` lands the `architect` + `research` + `contracts` user-scope toolkit, and `--profile inception <catalogue>` lands the `research` + `product-engineering` + `architect` toolkit for taking an idea from zero to a buildable repo. `agentbundle list-profiles <catalogue>` shows what's available; see the [install-a-profile how-to](docs/guides/_shared/how-to/install-a-profile.md).
 
 ## Ecosystem building blocks
 

--- a/docs/guides/_shared/how-to/install-a-profile.md
+++ b/docs/guides/_shared/how-to/install-a-profile.md
@@ -18,6 +18,7 @@ It prints each profile's id, scope, and description. The profiles the catalogue 
 | Profile | Scope | Installs |
 | --- | --- | --- |
 | `solution-architect` | user | `architect` + `research` + `contracts` — a solution architect's portable toolkit, carried across every repo. |
+| `inception` | user | `research` + `product-engineering` + `architect` — the portable toolkit for taking an idea from zero to a buildable repo; use as much as the venture warrants. See [Run a full inception](run-a-full-inception.md). |
 | `full-ceremony` | repo | `core` + `governance-extras` + `user-guide-diataxis` + `monorepo-extras` — a repo's full governance setup. |
 
 ## Install a profile

--- a/docs/guides/_shared/how-to/run-a-full-inception.md
+++ b/docs/guides/_shared/how-to/run-a-full-inception.md
@@ -19,11 +19,19 @@ You need:
 - An idea, even a rough one.
 - The `core` pack, for `init-project`, `new-spec`, and `work-loop`.
 
-You don't install everything up front. Inception is a spine with optional
-stages in front of it. You add a stage, and the pack behind it, only when
-you're carrying the uncertainty it removes. For the install routes themselves
-see [Install routes](../explanation/install-routes.md), or
-[Install a curated set of packs](install-a-profile.md) to take several at once.
+The three upstream packs — `research`, `product-engineering`, `architect` —
+are the user-scope `inception` profile, so one command carries the whole
+toolkit across every venture:
+
+```bash
+agentbundle install --profile inception <catalogue>
+```
+
+You don't have to use all of it. Inception is a spine with optional stages in
+front of it. You reach for a stage only when you're carrying the uncertainty it
+removes — the profile just means the pack is already there when you do. For the
+install routes themselves see [Install routes](../explanation/install-routes.md),
+or [Install a curated set of packs](install-a-profile.md).
 
 ## The spine
 
@@ -49,8 +57,8 @@ Read it top to bottom and skip any row whose uncertainty you don't carry.
 - **Skills:** `research` (run it in `applied` mode for prior art, best
   practice, and known anti-patterns), plus `source-map`, `compare-hypotheses`,
   and `devils-advocate` for contested choices.
-- **Install:** `agentbundle install --pack research <catalogue>`. The
-  `solution-architect` profile bundles it with `architect`.
+- **Install:** in the `inception` profile, or on its own with
+  `agentbundle install --pack research <catalogue>`.
 - **How:** [Run the research pipelines](../../research/how-to/research-pipelines.md),
   or [your first research session](../../research/tutorials/research-first-session.md)
   if the pack is new to you.
@@ -61,7 +69,8 @@ Read it top to bottom and skip any row whose uncertainty you don't carry.
   `de-risk-intent` (test the riskiest assumption against a predeclared kill
   condition), `decompose-intent` (cut it into a `core` brief). At app scale the
   leaf intent *is* the brief.
-- **Install:** `agentbundle install --pack product-engineering <catalogue>`.
+- **Install:** in the `inception` profile, or on its own with
+  `agentbundle install --pack product-engineering <catalogue>`.
 - **How:** [Shape a feature intent](../../product-engineering/how-to/shape-a-feature-intent.md).
 
 ### `architect` — when the system shape is uncertain
@@ -69,8 +78,8 @@ Read it top to bottom and skip any row whose uncertainty you don't carry.
 - **Skills:** `architect-design` (concept → design doc, converged against
   review), `architect-diagram`, `architect-review`. The decisions it surfaces
   become the rationale `init-project` records.
-- **Install:** `agentbundle install --pack architect <catalogue>`, or the
-  `solution-architect` profile.
+- **Install:** in the `inception` profile, or on its own with
+  `agentbundle install --pack architect <catalogue>`.
 - **How:** [Establish your reference architecture](../../architect/how-to/establish-reference-architecture.md).
 
 ### `core` — always (you already have it)

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -72,6 +72,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no adapter-contract bump, no new install route — distribution hygiene over
   the existing single-pack install path.
 
+- **New `inception` profile.** A user-scope toolkit for taking an idea from
+  zero to a buildable repo — `research` + `product-engineering` + `architect`,
+  installed once and carried across ventures. Install with `agentbundle install
+  --profile inception <catalogue>`, then use as much of it as the venture
+  warrants: architecture alone for a learning project, plus product shaping for
+  a side project, plus research when sizing a market. The build loop itself
+  stays the repo-scope `core` pack, installed into the new repo at bootstrap.
+
 - **`design` joins the soft `categories` vocabulary.** `agentbundle validate`
   now recognizes `design` as a known pack category, so the `design-craft` pack
   (and any future design pack) declares it without a soft warning. The

--- a/profiles/inception.toml
+++ b/profiles/inception.toml
@@ -1,0 +1,28 @@
+# Pack profile: inception (RFC-0034)
+#
+# The portable, user-scope toolkit for one person carrying an idea from zero
+# to a buildable repo — playing the research, product, and architecture roles
+# themselves before any build loop. Installed once and carried across every
+# venture, whether that's a side project, a startup, or an enterprise
+# initiative. Single-scope (user); installs in one command:
+#   agentbundle install --profile inception <catalogue>
+#
+# Use as much or as little as the venture warrants: architecture alone for a
+# technical learning project, plus product shaping for a side project, plus
+# research when you're sizing a market. The build loop itself is the
+# repo-scope `core` pack, installed into the new repo at bootstrap.
+#
+# Lint invariants (tools/lint-profiles.py): scope-homogeneous (every pack
+# allows user scope), dependency-complete, deps-first ordered.
+
+scope = "user"
+description = "Portable user-scope toolkit for taking an idea from zero to a buildable repo: research the space, shape the product, design the system."
+
+[[packs]]
+pack = "research"
+
+[[packs]]
+pack = "product-engineering"
+
+[[packs]]
+pack = "architect"


### PR DESCRIPTION
## What

Adds `profiles/inception.toml` — a **user-scope** profile bundling `research` + `product-engineering` + `architect`: the portable upstream toolkit for one person taking an idea from zero to a buildable repo.

```bash
agentbundle install --profile inception <catalogue>
```

Use as much as the venture warrants — architecture alone for a learning project, plus product shaping for a side project, plus research when sizing a market. The build loop itself stays the repo-scope `core` pack, installed into the new repo at bootstrap; per RFC-0034 a single-scope profile can't span the portable toolkit (user) and the per-repo build governance (repo), and that's the right seam.

## Discoverability (so people know it exists and what it's for)

- **install-a-profile how-to** — new table row with its purpose, linking to the inception guide.
- **README** catalogue section — listed alongside `solution-architect` and `full-ceremony`.
- **Changelog** — `[Unreleased]` Added entry.
- **run-a-full-inception guide** — now routes readers to `--profile inception` instead of `solution-architect`.

## Notes

- Exercises the accepted RFC-0034 profile machinery; no RFC needed, no schema/contract/version bump.
- `tools/lint-profiles.py` passes (scope-homogeneous, deps-complete, deps-first); `agentbundle list-profiles` shows the new entry.
- Deliberately decoupled: no `init-project` behavior change and no orchestration wizard — those were considered and declined (session-length / scoped-handoff reasoning).