### PR TITLE
feat(atlassian): SSO web-session cookie auth for jira + confluence-crawler reads (RFC-0035)

### DIFF
--- a/.agentbundle/lib/credbroker/__init__.py
+++ b/.agentbundle/lib/credbroker/__init__.py
@@ -48,7 +48,26 @@ from ._core import (
 from ._core import _parse_schema as parse_schema
 from ._core import _tier2_backend_label as tier2_backend_label
 
-__version__ = "0.1.1"
+# SSO web-session cookie family (RFC-0035) — a second consumer-resolution family
+# alongside the token ``creds`` family above. Resolves a captured SSO session to
+# an on-disk cookie-jar path via the unchanged ``sso-broker.py`` engine, with
+# reusable validation primitives for the consumer's ``sso-config.toml`` and the
+# load-time cookie-domain confinement. Imported eagerly: ``_sso`` is stdlib-only,
+# so it keeps the base import graph free of any third-party dependency.
+from ._sso import (
+    SsoBrokerNotInstalledError,
+    SsoConfigError,
+    SsoError,
+    SsoSessionUnavailableError,
+    domain_in_cookie_domains,
+    filter_jar_to_domains,
+    load_sso_cookies,
+    require_host_in_cookie_domains,
+    validate_https_url,
+    validate_root_relative_endpoint,
+)
+
+__version__ = "0.2.0"
 
 __all__ = [
     # Resolver + container.
@@ -77,5 +96,17 @@ __all__ = [
     "source_vault_master",
     "store_vault_master",
     "store_in_vault",
+    # SSO web-session cookie family (RFC-0035).
+    "load_sso_cookies",
+    "SsoError",
+    "SsoBrokerNotInstalledError",
+    "SsoSessionUnavailableError",
+    "SsoConfigError",
+    # SSO confinement primitives (RFC-0035; security-control surface).
+    "validate_https_url",
+    "validate_root_relative_endpoint",
+    "domain_in_cookie_domains",
+    "filter_jar_to_domains",
+    "require_host_in_cookie_domains",
     "__version__",
 ]

--- a/.agentbundle/lib/credbroker/_sso.py
+++ b/.agentbundle/lib/credbroker/_sso.py
@@ -1,0 +1,226 @@
+"""SSO web-session cookie resolution (RFC-0035).
+
+A second consumer-resolution family alongside the token ``creds`` family. Where
+``load_credentials`` resolves a token, ``load_sso_cookies`` resolves a *captured
+SSO web session* into an on-disk cookie-jar path by subprocess-invoking the
+unchanged ``sso-broker.py`` engine.
+
+Two contracts shape this module:
+
+* **Path-not-value handoff (RFC-0013 § 1).** The resolver returns the jar's
+  *path*, never its bytes. No cookie value crosses ``argv`` (only the profile
+  name does), no cookie value is logged, and the engine writes the jar to its own
+  ``0600`` floor — the consumer reads it in-process and is responsible for never
+  echoing it (the at-rest floor is the broker's own responsibility).
+* **Fail-closed.** Anything other than a clean exit-0-with-readable-path raises
+  :class:`SsoSessionUnavailableError` with a verbatim re-``register`` remediation.
+  It never returns a path it could not verify, and a caller on the cookie path
+  must never fall through to the token path on this error.
+
+The validation primitives that guard the consumer's ``sso-config.toml`` and the
+load-time cookie-jar confinement live alongside this resolver (added in spec task
+T2) so the security-control surface is single-sourced and reusable by any
+platform integration, not just atlassian.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable
+from urllib.parse import urlsplit
+
+__all__ = [
+    "SsoError",
+    "SsoBrokerNotInstalledError",
+    "SsoSessionUnavailableError",
+    "SsoConfigError",
+    "load_sso_cookies",
+    "validate_https_url",
+    "validate_root_relative_endpoint",
+    "domain_in_cookie_domains",
+    "filter_jar_to_domains",
+    "require_host_in_cookie_domains",
+]
+
+# The engine is installed by the credential-brokers pack at this user-scope path
+# (RFC-0013 § 1; mirrored by ``sso-broker.py``'s own module docstring). Composed
+# from parts so no full literal path string appears, matching the broker's own
+# convention.
+_BROKER_TAIL = (".agentbundle", "bin", "sso-broker.py")
+
+
+class SsoError(Exception):
+    """Base class for SSO consumer-resolution failures."""
+
+
+class SsoBrokerNotInstalledError(SsoError):
+    """The ``sso-broker.py`` engine is not installed at its expected path."""
+
+
+class SsoSessionUnavailableError(SsoError):
+    """No usable SSO session for the profile — the caller must re-``register``.
+
+    Raised for every non-success branch of ``get-cookies`` (the engine returns a
+    non-zero exit for both "profile not registered" and "no jar"), for an
+    unreadable jar path, and for any uncaught engine exception. Fail-closed: the
+    cookie path must surface this, never silently downgrade to the token path.
+    """
+
+
+class SsoConfigError(SsoError):
+    """An ``sso-config.toml`` value, or a runtime host, violates the SSO
+    confinement contract — a non-``https`` URL, a non-root-relative endpoint, or a
+    send-host outside the declared ``cookie_domains``. Validation primitives raise
+    this; the consumer fails closed before any cookie-bearing request leaves the
+    process.
+    """
+
+
+def _broker_path() -> Path:
+    """Resolve the engine path under the user's home (``~/.agentbundle/bin``)."""
+    return Path.home().joinpath(*_BROKER_TAIL)
+
+
+def load_sso_cookies(profile: str) -> Path:
+    """Resolve *profile*'s captured SSO session to an on-disk cookie-jar path.
+
+    Subprocess-invokes ``sso-broker.py get-cookies <profile>`` with the parent
+    interpreter, inheriting the process environment (corporate proxy / trust-store
+    passthrough, RFC-0013 § 1). Proceeds **only** on exit 0 with a readable jar
+    path; every other outcome fails closed.
+
+    :returns: the path to the ``0600`` cookie jar the engine materialised.
+    :raises SsoBrokerNotInstalledError: the engine is absent at its expected path.
+    :raises SsoSessionUnavailableError: the profile is unregistered, no jar
+        exists, the jar path is unreadable, or the engine raised.
+    """
+    broker = _broker_path()
+    if not broker.is_file():
+        raise SsoBrokerNotInstalledError(
+            f"sso-broker not installed at {broker}; install the credential-brokers "
+            f"pack, then run 'sso-broker register {profile}'"
+        )
+
+    remediation = (
+        f"SSO session unavailable for profile {profile}; "
+        f"run 'sso-broker register {profile}'"
+    )
+
+    try:
+        result = subprocess.run(
+            [sys.executable, str(broker), "get-cookies", profile],
+            capture_output=True,
+            text=True,
+            check=False,
+            env={**os.environ},
+        )
+    except OSError as exc:
+        # Engine present but unspawnable (permissions, interpreter gone, …).
+        raise SsoSessionUnavailableError(remediation) from exc
+
+    if result.returncode != 0:
+        raise SsoSessionUnavailableError(remediation)
+
+    jar_path = Path(result.stdout.strip())
+    if not jar_path.is_file():
+        raise SsoSessionUnavailableError(remediation)
+
+    return jar_path
+
+
+# --- SSO confinement primitives (RFC-0035; spec task T2) ---------------------
+#
+# These are the security-control surface the unchanged ``sso-broker.py`` engine
+# does *not* perform and that this RFC adds *above* it: an https-only scheme guard,
+# a root-relative endpoint guard, and the cookie-domain confinement that filters
+# the engine's deliberately over-broad captured jar down to the declared domains.
+# They are pure functions (no I/O), reusable by any platform integration, so the
+# control can't drift across consumers.
+
+
+def validate_https_url(value: str, *, field: str) -> None:
+    """Reject *value* unless its scheme is exactly ``https`` (AC3).
+
+    Applied to ``login_url``, ``success_url_pattern``, and ``base_url`` — the
+    cookie jar is a bearer secret, so a plaintext (``http``) or scheme-less
+    destination is refused. ``success_url_pattern`` may carry pattern characters
+    after the scheme; only the scheme is checked here.
+    """
+    scheme = urlsplit(value).scheme.lower()
+    if scheme != "https":
+        raise SsoConfigError(
+            f"{field} must be an https URL (got scheme {scheme or '(none)'!r}): {value!r}"
+        )
+
+
+def validate_root_relative_endpoint(value: str, *, field: str = "validation_endpoint") -> None:
+    """Reject *value* unless it is a root-relative path (AC3).
+
+    Must lead with a single ``/`` and carry no scheme, host, or protocol-relative
+    ``//`` prefix — so a validation endpoint can never be redirected off-host.
+    """
+    if not value.startswith("/") or value.startswith("//") or "://" in value:
+        raise SsoConfigError(
+            f"{field} must be a root-relative path (lead with '/', no scheme/host, "
+            f"no '//'): {value!r}"
+        )
+
+
+def _normalize_domain(domain: str) -> str:
+    """Lower-case and strip a leading dot — the broker stores domains via
+    ``lstrip('.')`` while cookie ``domain`` fields keep a leading dot (AC4)."""
+    return domain.lstrip(".").lower()
+
+
+def domain_in_cookie_domains(domain: str, cookie_domains: Iterable[str]) -> bool:
+    """Normalized label-boundary suffix match (AC4, AC6).
+
+    Both sides are dot-stripped and lower-cased; *domain* is admitted iff it
+    equals an allowed domain or is a dot-delimited subdomain of one. The label
+    boundary is load-bearing: ``evil-corp.example.com`` is rejected against
+    ``corp.example.com`` (no ``.`` before ``corp``), while ``jira.corp.example.com``
+    is admitted. This is the single normalization primitive shared by the
+    cookie-jar filter (AC4) and the send-host check (AC6).
+    """
+    cand = _normalize_domain(domain)
+    if not cand:
+        return False
+    for allowed in cookie_domains:
+        norm = _normalize_domain(allowed)
+        if not norm:
+            continue
+        if cand == norm or cand.endswith("." + norm):
+            return True
+    return False
+
+
+def filter_jar_to_domains(
+    cookies: list[dict], cookie_domains: Iterable[str]
+) -> list[dict]:
+    """Reduce an over-broad captured jar to cookies within *cookie_domains* (AC4).
+
+    The engine captures every cookie observed across the SSO/IdP/analytics
+    redirect chain; the consumer filters that loaded jar to the declared domains
+    at load time, before attaching it. Returns a new list; the caller must never
+    write the result back to the broker path (AC10). A cookie with no ``domain``
+    field is dropped (fail closed).
+    """
+    allowed = list(cookie_domains)
+    return [c for c in cookies if domain_in_cookie_domains(c.get("domain", ""), allowed)]
+
+
+def require_host_in_cookie_domains(host: str, cookie_domains: Iterable[str]) -> None:
+    """Fail closed unless *host* is within the declared ``cookie_domains`` (AC6).
+
+    The consumer client's request base host must be a member of the confinement
+    set before any cookie-bearing request leaves the process; a mismatch (a
+    downstream edit drifting the base URL off-domain) raises.
+    """
+    if not domain_in_cookie_domains(host, cookie_domains):
+        raise SsoConfigError(
+            f"request host {host!r} is not within the declared cookie_domains "
+            f"{list(cookie_domains)!r}; refusing to send the session cookie"
+        )

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "atlassian",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.2.0"
+      "version": "0.3.0"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -103,7 +103,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "credential-brokers",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.1.3"
+      "version": "0.2.0"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/.github/workflows/build-check-windows.yml
+++ b/.github/workflows/build-check-windows.yml
@@ -143,6 +143,20 @@ jobs:
         # The bash test_session_start.sh sibling is intentionally skipped
         # on Windows — pytest discovery only picks up test_*.py.
 
+      # atlassian-sso-cookie (RFC-0035): the cookie-path security suites must
+      # gate on Windows too — corporate-SSO dev machines are commonly Windows,
+      # and the fake-broker subprocess + asyncio + SSL-context wiring are
+      # path/platform-sensitive. credbroker is pip-installed here so the suites
+      # actually run (their `importorskip("credbroker")` would otherwise skip).
+      - name: pip install credbroker + httpx for the atlassian SSO suites (RFC-0035)
+        run: pip install -e ./packages/credbroker "httpx>=0.27"
+      - name: pytest jira SSO suites (atlassian-sso-cookie)
+        working-directory: packs/atlassian/.apm/skills/jira/scripts
+        run: python -m pytest test_sso_config.py test_sso_client.py test_setup_sso.py
+      - name: pytest confluence-crawler SSO suites (atlassian-sso-cookie)
+        working-directory: packs/atlassian/.apm/skills/confluence-crawler/scripts
+        run: python -m pytest test_sso_config.py test_sso_client.py test_setup_sso.py
+
       - name: design-craft framework-agnosticism lint + self-test (design-craft-pack AC8)
         # RFC-0033: proves the design-craft agnosticism linter behaves on
         # Windows. `python` (not `python3`) is the safe cross-platform

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -167,6 +167,22 @@ jobs:
         working-directory: packs/credential-brokers/.apm/skills/credential-setup/scripts
         run: python -m pytest test_setup.py
 
+      # atlassian-sso-cookie (RFC-0035): the jira + confluence-crawler cookie-path
+      # security suites (mock-transport — cookie confinement, no-Authorization,
+      # write refusal, off-domain-302 leak prevention, 401 remediation; the config
+      # loader/selector; the setup helper) live under the skill scripts/, which
+      # neither `make build-check` nor any package pytest discovers. Wire them
+      # explicitly or the client-side security contract never gates. credbroker is
+      # installed editable above; httpx is the only extra runtime dep.
+      - name: pip install httpx for the atlassian SSO suites (RFC-0035)
+        run: pip install 'httpx>=0.27'
+      - name: pytest jira SSO suites (atlassian-sso-cookie)
+        working-directory: packs/atlassian/.apm/skills/jira/scripts
+        run: python -m pytest test_sso_config.py test_sso_client.py test_setup_sso.py
+      - name: pytest confluence-crawler SSO suites (atlassian-sso-cookie)
+        working-directory: packs/atlassian/.apm/skills/confluence-crawler/scripts
+        run: python -m pytest test_sso_config.py test_sso_client.py test_setup_sso.py
+
       # credbroker-user-scope T3: the build pipeline vendors credbroker to the
       # per-scope lib floor (.agentbundle/lib/) + the catalogue pack copy,
       # drift-gated. `make build-check` exercises the live drift gate, but the

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -1029,6 +1029,9 @@ metadata:
   credentialed: true
   primitive-class: credentialed-cli   # or mcp-server
   auth: creds                         # env / cli / creds / sso-cookie
+  # auth-fallback: creds              # optional: dual-auth — the broker to fall
+  #                                   #   back to when the active one can't resolve
+  #                                   #   (e.g. sso-cookie with a creds fallback)
   # broker-specific extras follow:
   # namespace: <ns>                   # required for auth: creds and auth: env
   # keys: ["<KEY>"]                   # required for auth: creds and auth: env
@@ -1041,8 +1044,13 @@ The keys live under `metadata:` rather than at top level because the
 pins the top-level frontmatter set to `name`, `description`,
 `license`, `compatibility`, `metadata`, `allowed-tools` and reserves
 `metadata:` as the project-specific escape hatch. `tools/lint-agent-artifacts.py`
-refuses any top-level key outside that set; `tools/lint-credentialed-skills.sh`
+refuses any top-level key outside that set; `tools/lint_credentialed_skills.py`
 scopes its checks to skills with `metadata.credentialed: true`.
+
+`metadata.auth-fallback` is optional and names a second broker a **dual-auth**
+skill falls back to when the active one can't resolve (e.g. an `auth: sso-cookie`
+skill that drops to `creds` on a non-SSO instance). When present, the skill's
+Security section must satisfy **both** brokers' don't-block phrase sets.
 
 ### Four brokers — pick one per skill
 
@@ -1064,18 +1072,21 @@ four ids are pinned by
   build-projected `credentials_shim` it replaced is retired for
   `creds` consumers (the four-broker taxonomy above is unchanged).
 - **`sso-cookie`** — session cookie acquired via a headed-browser SSO
-  flow. The skill subprocess-invokes
-  `~/.agentbundle/bin/sso-broker.py` (projected by the
-  `credential-brokers` pack at user scope).
+  flow. The skill resolves the session through the `credbroker` SSO
+  resolver (`from credbroker import load_sso_cookies`), which
+  subprocess-invokes `~/.agentbundle/bin/sso-broker.py` (projected by the
+  `credential-brokers` pack at user scope) — mirroring how `creds` moved
+  broker resolution into `credbroker`. A skill that still resolves the
+  broker in its own `scripts/` is also accepted.
 
 The broker-agnostic invariants below apply to every credentialed
 primitive regardless of broker. Broker-specific lint extensions layer
 on top (`auth: creds` requires a credential-resolver import in
 `scripts/` — `from credbroker import …`, or the legacy
 `from .credentials_shim …`; `auth: env` requires each declared `<NAMESPACE>_<KEY>` to
-be read at least once; `auth: sso-cookie` requires
-subprocess-invocation of the canonical
-`Path.home() / ".agentbundle" / "bin" / "sso-broker.py"` path; `auth:
+be read at least once; `auth: sso-cookie` requires either a credbroker SSO import
+(`from credbroker import load_sso_cookies`) or subprocess-invocation of the
+canonical `Path.home() / ".agentbundle" / "bin" / "sso-broker.py"` path; `auth:
 cli` falls through to broker-agnostic checks only).
 
 ### Three storage tiers
@@ -1104,7 +1115,7 @@ Credentialed-CLI-class primitives must refuse the value-shaped flags
 `--password`. The CLI verb's `setup` subparser registers these as
 *tombstone arguments* whose action emits the verbatim sentinel
 `tokens cannot be passed via argv` and exits non-zero; the
-`tools/lint-credentialed-skills.sh` lint refuses any primitive's
+`tools/lint_credentialed_skills.py` lint refuses any primitive's
 script that declares one of the banned names in an
 `argparse.ArgumentParser.add_argument` call. MCP-server-class
 primitives may accept *header-naming* flags (`--bearer-header`,

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -194,6 +194,34 @@ run the read flow against (the same gap RFC-0013 § 9 reason (b) named; RFC-0035
 asserts it is now resolvable). Also fills the `sso-cookie × <os>` row pending
 under `## credential-broker-contract`.
 
+### atlassian-sso-cookie-success-url-pattern-host-confinement
+
+**Source:** security-reviewer Concern (implementation pass). The consumer
+validates `success_url_pattern` for https scheme (AC3) but does not confine its
+*host* to `cookie_domains`. Deferred because these `[sso]` URL fields drive the
+broker's headed-browser login flow (`login_url` legitimately points at the
+off-domain corporate **IdP**, so a blanket "host ∈ cookie_domains" rule does not
+apply uniformly), the pattern may carry regex/glob metacharacters that make host
+extraction unreliable, and the consumer's cookie-**send** confinement is already
+independently enforced on every outbound request (AC4/AC5/AC6/AC20). **Unblocks
+when:** the live-DC transcript clarifies how the broker treats the pattern host,
+or a follow-on tightens pattern-host validation at the broker (capture-time)
+layer where it belongs.
+
+### atlassian-sso-cookie-selector-integration-test
+
+**Source:** quality-engineer Concern (whole-spec pass). The `_run` /
+`main_async` auth selector (config absent → token path; `sso-cookie` →
+`from_sso_cookies`; malformed → `EXIT_USER_ACTION`) has no end-to-end test; its
+inputs (`load_sso_config` → `None | SsoConfig`) and outputs (`from_sso_cookies`
+fail-closed; token-path byte-identity, AC13) are each unit-tested, leaving a
+~6-line branch uncovered. Deferred because driving the async CLI entrypoint
+requires importing a module designed for `python <script>` invocation (its
+bootstrap sets `__package__` for relative imports) and stubbing the command
+layer — disproportionate to the residual risk. **Unblocks when:** the CLI
+entrypoints grow an import-safe seam, or the selector is extracted to a directly
+testable function.
+
 ## `agentbundle-wheel-release`
 
 Implementation shipped (`.github/workflows/release-agentbundle.yml`, three

--- a/docs/guides/atlassian/how-to/authenticate-jira-confluence-with-sso-cookies.md
+++ b/docs/guides/atlassian/how-to/authenticate-jira-confluence-with-sso-cookies.md
@@ -1,0 +1,70 @@
+# Authenticate Jira / Confluence with an SSO web session
+
+On an Atlassian **Data Center** instance fronted by corporate SSO where personal
+access tokens are blocked, [`jira`](../../../../packs/atlassian/.apm/skills/jira/)
+reads and [`confluence-crawler`](../../../../packs/atlassian/.apm/skills/confluence-crawler/)
+can authenticate by a captured web session (a cookie jar) instead of a token. This
+is the `auth: sso-cookie` path (RFC-0035); both skills keep a `creds` (token)
+fallback, so nothing changes for token users.
+
+> **Scope.** Data Center only, **reads only** (JQL search, get issue/project/user;
+> Confluence space crawl). Writes over the cookie path are refused pending XSRF
+> design. Cloud is out of scope — use a token there.
+
+## 1. Pre-bake the instance config (once, per org)
+
+Each skill ships `references/sso-config.toml` placeholder-shaped (`auth_default =
+"creds"`, `*.invalid` hosts). An enterprise edits it to point at the corporate
+instance and flips the default:
+
+```toml
+auth_default = "sso-cookie"
+
+[sso]
+profile = "jira"
+base_url = "https://jira.corp.example.com"          # https only
+login_url = "https://sso.corp.example.com/login"
+success_url_pattern = "https://jira.corp.example.com/secure/Dashboard.jspa"
+cookie_domains = ["corp.example.com"]                # the jar is confined to these
+validation_endpoint = "/rest/api/2/myself"           # root-relative
+```
+
+Distribute this as a pack customization so a developer installs the pack already
+pointed at your instance. The config carries **no secrets** — only connection
+parameters; the session cookie never lives here.
+
+## 2. Register the session (once, per developer)
+
+```bash
+python scripts/setup_sso.py        # in the jira (or confluence-crawler) skill dir
+```
+
+This validates the config, then drives `sso-broker register`, which opens a headed
+browser for interactive SSO sign-in and captures the session into the broker's
+`0600` store. Re-run it whenever the session expires (a `401` from a read tells
+you to). The agent never runs this for you — it's an interactive browser flow.
+
+## 3. Use the skills normally
+
+```bash
+python scripts/jira.py check                         # confirms the session
+python scripts/jira.py search 'project = ABC' --limit 20
+python scripts/crawl_space.py --space ENG
+```
+
+On the cookie path the skill attaches the confined jar to its HTTP client, sends
+**no** `Authorization` header, and honors your corporate proxy and CA bundle
+(`HTTPS_PROXY` / `NO_PROXY`, `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE`). The session
+cookie is a bearer secret — the skill resolves it through the broker and never
+prints it.
+
+## Upgrading a pre-baked config without losing your edits
+
+`references/sso-config.toml` is upstream-owned but locally edited — exactly the
+case the [`adapt-to-project`](../../core/how-to/adapt-to-project.md) **class-2
+`.upstream` companion merge** handles. When a later catalogue release ships a new
+upstream `sso-config.toml`, install writes it alongside yours as a `.upstream`
+companion rather than clobbering your instance config; `adapt-to-project` then
+walks you through merging any new upstream keys into your edited file. So an
+org's pre-baked config survives upgrades — you reconcile new connection-param
+keys deliberately, you don't lose them.

--- a/docs/guides/atlassian/reference/atlassian-skills.md
+++ b/docs/guides/atlassian/reference/atlassian-skills.md
@@ -10,6 +10,7 @@ Credentialed skills resolve secrets in-process through the tier ladder (environm
 - **Primary inputs.** Subcommands: `check`, `whoami`, `get-issue`, `search`, `create-issue`, `update-issue`, `delete-issue`, `list-transitions`, `transition`, `comment`, `attach`, `get-project`, `list-projects`, `get-user`, `list-users`, `raw`. Global flags: `--format json|jsonl|csv`, `--output FILE`, `--verbose`, `--insecure`. `search` takes `--fields`, `--limit`, `--page-size` (≤ 100); write subcommands take repeatable `--field KEY=VALUE` (JSON-parsed) or `--data-file`; `delete-issue` requires `--yes`.
 - **Outputs.** Issue / project / user JSON, JSONL, or CSV to stdout or `--output`. Read-only and mutating both available.
 - **Required credentials.** `JIRA_BASE_URL` (required), `JIRA_API_TOKEN` (required), `JIRA_EMAIL` (Cloud only), `JIRA_FLAVOR` (optional — auto-detected). Cloud token from `id.atlassian.com → API tokens`; Server PAT from the user's profile.
+- **Auth (dual).** `auth: sso-cookie` with a `creds` fallback (RFC-0035). On a Data Center instance behind corporate SSO where tokens are blocked, pre-bake `references/sso-config.toml` (`auth_default = "sso-cookie"`) and run `python scripts/setup_sso.py` once; reads then authenticate by a captured web session (no token). Absent SSO config, the token path above is unchanged. Cookie-path reads only (writes are refused pending XSRF design).
 - **Source.** [`jira`](../../../../packs/atlassian/.apm/skills/jira/)
 
 ## `jira-align`
@@ -26,6 +27,7 @@ Credentialed skills resolve secrets in-process through the tier ladder (environm
 - **Primary inputs.** `crawl_space.py` with `--check`, `--space KEY` (required), `--root PAGE_ID`, `--depth N`, `--output DIR` (default `./confluence-out`), `--force`, `--no-attachments`, `--concurrency N` (default 4), `--min-delay-ms N` (default 100), `--insecure`, `--verbose`.
 - **Outputs.** `<output>/<slug>.md` per page (flat layout) with frontmatter (`confluence_id`, `version`, `space_key`, `updated`, `author`, `parent_id`, `labels`, `url`, `slug`); `<output>/attachments/<page_id>/<filename>` for attachments. Final log line `wrote N pages (failed: X, skipped: Y)`.
 - **Required credentials.** `CONFLUENCE_BASE_URL` (required — Cloud must include `/wiki`), `CONFLUENCE_API_TOKEN` (required), `CONFLUENCE_EMAIL` (Cloud only), `CONFLUENCE_FLAVOR` (optional — auto-detected). Shares the `confluence` namespace with `confluence-publisher`.
+- **Auth (dual).** `auth: sso-cookie` with a `creds` fallback (RFC-0035), like `jira`: on a Data Center instance behind corporate SSO, pre-bake `references/sso-config.toml` and run `python scripts/setup_sso.py` once to crawl by captured web session. Absent SSO config, the token path is unchanged.
 - **Source.** [`confluence-crawler`](../../../../packs/atlassian/.apm/skills/confluence-crawler/)
 
 ## `confluence-publisher`

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -19,6 +19,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **SSO web-session cookie auth for `jira` reads + `confluence-crawler` (atlassian
+  pack, RFC-0035).** On an Atlassian Data Center instance behind corporate SSO
+  where API tokens are blocked, both skills can now authenticate by a captured web
+  session instead of a token: pre-bake `references/sso-config.toml`
+  (`auth_default = "sso-cookie"`), run `python scripts/setup_sso.py` once to
+  register the session, and reads work with no token. The session is resolved
+  through the `credbroker` SSO resolver (new `load_sso_cookies`, credbroker 0.2.0)
+  and the captured jar is confined to the declared `cookie_domains`; no
+  `Authorization` header is sent and redirects are not followed (the session
+  cookie never crosses to another host). Both skills keep a `creds` (token)
+  fallback — token users with no SSO config see no change. Data Center reads only;
+  writes are refused pending XSRF design; Cloud is unchanged. See
+  [Authenticate Jira / Confluence with an SSO web session](../guides/atlassian/how-to/authenticate-jira-confluence-with-sso-cookies.md).
 - **`jira-brief-intake` skill (atlassian pack).** Turns a Jira epic — or a
   board / sprint / JQL selection of issues — into shippable specs for teams who
   plan kanban-style in Jira. It pulls the epic and its children via the `jira`

--- a/docs/specs/atlassian-sso-cookie/plan.md
+++ b/docs/specs/atlassian-sso-cookie/plan.md
@@ -1,7 +1,7 @@
 # Plan: atlassian-sso-cookie
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Drafting <!-- Drafting | Executing | Done -->
+- **Status:** Done <!-- Drafting | Executing | Done -->
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
 > document is allowed to change as you learn. When it changes substantially

--- a/docs/specs/atlassian-sso-cookie/plan.md
+++ b/docs/specs/atlassian-sso-cookie/plan.md
@@ -155,8 +155,13 @@ the two skills under `packs/atlassian/.apm/skills/`.
 
 **Depends on:** none
 
-**Touches:** `packs/credential-brokers/.apm/user-libs/credbroker/*.py`,
-`packages/agentbundle/tests/unit/*`
+**Touches:** `packages/credbroker/credbroker/*.py` (source of truth — byte-projected
+to `packs/credential-brokers/.apm/user-libs/credbroker/` by `agentbundle.build`),
+`packages/credbroker/{pyproject.toml,README.md,CHANGELOG.md}`,
+`packages/credbroker/tests/unit/*`, `packages/credbroker/tests/unit/test_public_surface.py`,
+the pack-version sites `packs/credential-brokers/{pack.toml,.claude-plugin/plugin.json}`,
+`.claude-plugin/marketplace.json`, and the version assertion in
+`packages/agentbundle/tests/integration/test_credential_brokers_pack_install.py`.
 
 **Tests:**
 - `get-cookies` exit 0 + readable path → returns the path (AC1).
@@ -166,21 +171,38 @@ the two skills under `packs/atlassian/.apm/skills/`.
   with install-the-pack remediation (AC1).
 - `subprocess.run` is the only process-spawn used; no cookie value crosses argv
   or is logged (AC10).
+- `test_public_surface.py` updated so the new public names (`load_sso_cookies` +
+  the T2 primitives) are in `__all__` and don't break the no-underscore invariant.
 
 **Approach:**
-- Add `_sso.py` (or extend `_core`) with `load_sso_cookies(profile)`; re-export
-  from `__init__.__all__`; bump `__version__` to `0.2.0`.
+- Edit the **source of truth** `packages/credbroker/credbroker/` (not the pack
+  copy — a drift gate enforces byte-equality; run `make build` to re-project to
+  the pack copy). Add `_sso.py` (or extend `_core`) with `load_sso_cookies(profile)`;
+  re-export from `__init__.__all__`; bump `__version__` to `0.2.0` in **both**
+  `__init__.py` and `pyproject.toml`.
 - Fake the broker in tests with a stub script returning canned exit/stdout.
+- **PyPI README + CHANGELOG (explicit ask):** add an "SSO web-session cookies"
+  section to `packages/credbroker/README.md` documenting `load_sso_cookies(profile)`
+  (path-not-value handoff, fail-closed), and a `## [0.2.0]` entry to
+  `packages/credbroker/CHANGELOG.md`.
+- **Pack version bump:** credential-brokers is a user-scope-default (non-projected)
+  pack, so bump `pack.toml` + `plugin.json` `0.1.3 → 0.2.0`, regenerate
+  `.claude-plugin/marketplace.json` (aggregate, via `make build`), and update the
+  `"0.1.3"` assertion in `test_credential_brokers_pack_install.py` to `"0.2.0"`.
 
-**Done when:** new credbroker SSO-resolver unit tests green; `credbroker`
-imports with no third-party dependency; version asserted 0.2.0.
+**Done when:** new credbroker SSO-resolver unit tests green (`packages/credbroker`
+suite + the `packages/agentbundle` install/integration suite, run by hand per the
+version-bump trap); `credbroker` imports with no third-party dependency; library
+`__version__` and pyproject both `0.2.0`; pack version `0.2.0` across pack.toml,
+plugin.json, marketplace.json, and the install-test assertion; README + CHANGELOG
+document the SSO surface.
 
 ### T2: `credbroker` SSO validation primitives + load-time jar filter
 
 **Depends on:** none
 
-**Touches:** `packs/credential-brokers/.apm/user-libs/credbroker/*.py`,
-`packages/agentbundle/tests/unit/*`
+**Touches:** `packages/credbroker/credbroker/*.py` (source of truth; re-projected
+to the pack copy by `make build`), `packages/credbroker/tests/unit/*`.
 
 **Tests:**
 - non-`https` `login_url`/`success_url_pattern`/`base_url` rejected; `https`
@@ -232,8 +254,10 @@ placeholder-shaped (AC12).
 
 **Depends on:** T3
 
-**Touches:** `tools/lint-sso-config.py` (new), `tools/hooks/pre-pr.py`,
-CI wiring, `tools/test-lint-sso-config.py` (new).
+**Touches:** `tools/lint-sso-config.py` (new), `tools/test-lint-sso-config.py`
+(new), `tools/pre-pr-catalogue.py` (the repo's own catalogue lint gate — **not**
+`tools/hooks/pre-pr.py`, which is the adopter-facing hook that deliberately runs
+no project linters).
 
 **Tests:**
 - upstream files pass; a fixture with an unknown `[sso]` key, a cookie-value-
@@ -244,8 +268,10 @@ CI wiring, `tools/test-lint-sso-config.py` (new).
 
 **Approach:**
 - `.py` (Windows portability); parse TOML, assert key-set ⊆ schema, value shapes,
-  placeholder invariants. Wire into `pre-pr.py` and the build-check/CI surface
-  that runs the lint family.
+  placeholder invariants. Wire the lint **and** its self-test into
+  `tools/pre-pr-catalogue.py` as a `_run(...)` pair (mirroring the
+  `credentialed-skill lint` + self-test pair already there); `make build-check`
+  runs `pre-pr-catalogue.py`, so CI picks it up with no separate workflow edit.
 
 **Done when:** lint green on repo, red on each crafted fixture; wired into the
 gate.
@@ -262,9 +288,15 @@ gate.
   the outbound request; sent cookie set ⊆ declared domains (AC4, AC5, AC7).
 - GET/HEAD reach the wire; `raw("POST", …)`/PUT/DELETE raise the verbatim
   writes-refused message and the transport records **zero** requests (AC9).
-- base host ∉ `cookie_domains` → fail closed before any request (AC6).
+- base host ∉ `cookie_domains` → fail closed before any request; non-`https`
+  resolved base URL refused at client construction (AC6).
+- `follow_redirects=False` on the cookie-path client; a `302` from a permitted host
+  to an off-`cookie_domains` host produces **zero** cookie-bearing requests to that
+  off-domain host; cookie-subset asserted across **every** observed request, not
+  just the first (AC20, AC5).
 - `401` → verbatim re-`register` remediation, no browser retry, stale jar not
-  reused (AC11).
+  reused; no cookie value in the surfaced error/trace text on the `401` or redirect
+  path (AC11).
 - jar read in-process from the broker path only; never re-written/copied/logged
   (AC10).
 - proxy/trust-store wiring present (`trust_env`, SSL context, `REQUESTS_CA_BUNDLE`
@@ -275,8 +307,13 @@ gate.
 **Approach:**
 - Add a cookie-path branch in `load_credentials`/client construction selected by
   the T3 selector; resolve cookies via `credbroker.load_sso_cookies`, filter via
-  `credbroker.filter_jar_to_domains`; build the httpx client with the filtered jar
-  and no auth header; add the GET/HEAD allowlist at `_request` (covers `raw()`).
+  `credbroker.filter_jar_to_domains`; build the httpx client with the filtered jar,
+  no auth header, and `follow_redirects=False`; reject a non-`https` resolved base
+  URL at construction; add the GET/HEAD allowlist at `_request` (covers `raw()`).
+- CA-bundle precedence: an explicit SSL context honors `SSL_CERT_FILE`/`SSL_CERT_DIR`
+  and maps `REQUESTS_CA_BUNDLE`; when both `SSL_CERT_FILE` and `REQUESTS_CA_BUNDLE`
+  are set, `SSL_CERT_FILE` wins (native httpx env takes precedence over the mapped
+  requests-compat var); the wiring test pins this precedence.
 
 **Done when:** jira cookie-path tests green; token-path regression green. The
 jira-side mock-level coverage (broker invocation shape, jar attachment,
@@ -290,10 +327,12 @@ toward the AC17 rollup (T6 mirrors it for confluence-crawler).
 **Touches:** `packs/atlassian/.apm/skills/confluence-crawler/scripts/_client.py`,
 its tests.
 
-**Tests:** the AC4/AC5/AC6/AC7/AC8/AC10/AC11/AC13 set, mirrored for
-confluence-crawler. **AC9 differs:** confluence-crawler has no `raw()`, so assert
-the `_request` chokepoint refuses a non-GET/HEAD `method` argument before the wire
-(transport records zero requests) — not a `raw("POST")` test.
+**Tests:** the AC4/AC5/AC6/AC7/AC8/AC10/AC11/AC13/AC20 set, mirrored for
+confluence-crawler (including `follow_redirects=False` + the off-`cookie_domains`
+302 near-miss, the non-`https`-base-URL refusal, and the CA-bundle precedence).
+**AC9 differs:** confluence-crawler has no `raw()`, so assert the `_request`
+chokepoint refuses a non-GET/HEAD `method` argument before the wire (transport
+records zero requests) — not a `raw("POST")` test.
 
 **Approach:** apply the settled T5 shape to confluence-crawler's client; the
 allowlist guards its `_request` `method` parameter.
@@ -306,7 +345,9 @@ green; the confluence-crawler half of the AC17 mock-coverage rollup lands
 
 **Depends on:** T3
 
-**Touches:** the per-skill setup path that drives `sso-broker register`.
+**Touches:** new per-skill setup helpers
+`packs/atlassian/.apm/skills/jira/scripts/setup_sso.py` and
+`…/confluence-crawler/scripts/setup_sso.py` (net-new files), plus their tests.
 
 **Tests:** goal-based — helper reads the validated config and invokes
 `sso-broker register <profile> --login-url … --cookie-domain …` with values from
@@ -327,7 +368,20 @@ malformed-config fixture is rejected before `register`.
 
 **Touches:** `jira/SKILL.md`, `confluence-crawler/SKILL.md`,
 `tools/lint_credentialed_skills.py`, `tools/test-lint-credentialed-skills.py`,
-`packs/core/seeds/docs/CONVENTIONS.md` (+ projected `docs/CONVENTIONS.md`).
+`packs/core/seeds/docs/CONVENTIONS.md` (+ projected `docs/CONVENTIONS.md`),
+the atlassian pack-version sites `packs/atlassian/{pack.toml,.claude-plugin/plugin.json}`
++ `.claude-plugin/marketplace.json` (atlassian is a non-projected user-scope pack,
+so a skill change bumps the pack `0.2.0 → 0.3.0` and drifts the aggregate
+marketplace, regenerated via `make build` — the aggregate drifts; run the full
+`packages/agentbundle` suite by hand per the version-bump trap), and the
+hand-maintained skill-reference mirror
+`docs/guides/atlassian/reference/atlassian-skills.md` (mirrors `description:`/
+frontmatter verbatim; sweep it for the `auth`/Security-section change).
+
+**CONVENTIONS anchor (AC16 contract):** the `metadata.auth-fallback: creds` marker
+is a net-new frontmatter key — add it to the CONVENTIONS § Frontmatter schema
+section (in the same seed edit) so the dual-auth marker the lint now branches on is
+contract-anchored, not lint-only.
 
 **Bundled fix (same-concern ride-along):** correct the two stale
 `tools/lint-credentialed-skills.sh` references in CONVENTIONS § Frontmatter schema
@@ -336,7 +390,9 @@ malformed-config fixture is rejected before `register`.
 self-host-projected (`self_host.py` allow-list), so edit the **seed**
 `packs/core/seeds/docs/CONVENTIONS.md` and run `make build-self` to regenerate the
 projection — do not hand-edit the projected file. This task already touches the
-same lint, so the reference fix lands with it rather than as a loose flag.
+same lint, so the reference fix lands with it rather than as a loose flag. The PR's
+`Bundled fixes:` line must state it is a two-line mechanical `.sh`→`.py` rename, so
+the ride-along stays visibly smaller than T8's primary lint change (volume guard).
 
 **Tests:**
 - amended lint: a skill carrying the `metadata.auth-fallback: creds` marker must
@@ -413,6 +469,19 @@ implementing PR per the set-final-status-in-the-implementing-PR convention.
 
 ## Changelog
 
+- 2026-06-16: pre-EXECUTE review pass (adversarial + security spec-stage). Spec
+  sharpened: new **AC20** (cookie-path `follow_redirects=False` — httpx re-attaches
+  the session cookie by domain match on every hop, so an off-`cookie_domains` 302
+  would exfiltrate it); AC5 now binds every request in a redirect chain; AC6 adds an
+  https-only base-URL guard at client construction; AC11 forbids cookie bytes in
+  surfaced error text. Plan corrected: T1 now bumps the credential-brokers pack
+  (0.1.3→0.2.0: pack.toml + plugin.json + marketplace.json + install-test assertion)
+  and updates the credbroker PyPI README/CHANGELOG; credbroker tests relocated to
+  `packages/credbroker/tests/` with the source-of-truth at `packages/credbroker/credbroker/`;
+  T4 retargeted from the adopter `tools/hooks/pre-pr.py` to the repo gate
+  `tools/pre-pr-catalogue.py`; T7 names concrete `setup_sso.py` files; T8 bumps the
+  atlassian pack (0.2.0→0.3.0 + marketplace + reference-guide sweep) and anchors the
+  `auth-fallback` marker in CONVENTIONS.
 - 2026-06-16: initial plan. SSO consumer-resolution placed in `credbroker`
   (platform-agnostic) rather than a new user-lib or per-client duplication, after
   establishing that RFC-0023 retired in-pack shared-module projection and that

--- a/docs/specs/atlassian-sso-cookie/plan.md
+++ b/docs/specs/atlassian-sso-cookie/plan.md
@@ -244,8 +244,12 @@ valid/invalid table.
 **Approach:**
 - Ship placeholder-shaped files (`auth_default = "creds"`, `*.invalid` hosts) per
   RFC-0035 § 3.
-- Loader is small and per-skill (the schema is consumer-specific); selector keys
-  solely on `auth_default` (no separate `enabled` flag).
+- Loader is small and per-skill — duplicated byte-for-byte across the two skills
+  because RFC-0023 forbids a shared projected `scripts/` module, not because the
+  schema diverges (it is identical today; a `test-lint-sso-config` parity guard
+  pins the four duplicated files byte-equal and the lint↔loader `[sso]` key set
+  equal so a one-sided edit fails loudly). Selector keys solely on `auth_default`
+  (no separate `enabled` flag).
 
 **Done when:** loader/selector unit tests green; reference files present and
 placeholder-shaped (AC12).

--- a/docs/specs/atlassian-sso-cookie/spec.md
+++ b/docs/specs/atlassian-sso-cookie/spec.md
@@ -1,6 +1,6 @@
 # Spec: atlassian-sso-cookie
 
-- **Status:** Approved <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** RFC-0035, RFC-0013, RFC-0023, ADR-0026
@@ -114,25 +114,25 @@ before proceeding; *Never do* is a hard rule, even under time pressure.
 
 Numbered for plan traceability; each maps to one or more `plan.md` tasks.
 
-- [ ] **AC1.** `credbroker` exposes a public SSO consumer resolver (e.g.
+- [x] **AC1.** `credbroker` exposes a public SSO consumer resolver (e.g.
   `load_sso_cookies(profile)`) that resolves `sso-broker.py` at
   `Path.home()/.agentbundle/bin/sso-broker.py`, runs `get-cookies <profile>` via
   `subprocess.run`, and returns the on-disk jar path; a broker-absent resolution
   raises with the install-the-pack remediation. `credbroker` base import graph
   stays stdlib-only and its version is bumped (0.1.1 → 0.2.0).
-- [ ] **AC2.** The resolver proceeds on the cookie path **only** when
+- [x] **AC2.** The resolver proceeds on the cookie path **only** when
   `get-cookies` exits `0` with a readable jar path; any non-zero exit (the broker
   returns `2` for both "not registered" and "no jar"), a broker-absent failure, or
   an uncaught broker exception fails closed with the verbatim remediation
   `"SSO session unavailable for profile <profile>; run 'sso-broker register
   <profile>'"` — it never falls through to `creds` when `auth_default =
   "sso-cookie"`.
-- [ ] **AC3.** `credbroker` exposes reusable validation primitives that reject: a
+- [x] **AC3.** `credbroker` exposes reusable validation primitives that reject: a
   non-`https` `login_url`, `success_url_pattern`, **or `base_url`**; a
   `validation_endpoint` that is not a root-relative path (must lead with `/`, no
   scheme, host, or protocol-relative `//`); and any cookie whose domain is outside
   the declared `cookie_domains`.
-- [ ] **AC4.** Because the unchanged broker captures an over-broad jar (every
+- [x] **AC4.** Because the unchanged broker captures an over-broad jar (every
   cookie observed across the SSO redirect chain — `--cookie-domain` only writes
   profile metadata, and `get-cookies` re-materialises the *full* jar to the `0600`
   floor on every call), the **consumer** filters the loaded jar to the declared
@@ -144,65 +144,65 @@ Numbered for plan traceability; each maps to one or more `plan.md` tasks.
   against `corp.example.com`, and `jira.corp.example.com` is admitted). The filter
   is applied on **every** resolution and its result is never written back to the
   broker path (the on-disk jar stays over-broad; see AC10).
-- [ ] **AC5.** On the cookie path the cookie set that actually leaves the process
+- [x] **AC5.** On the cookie path the cookie set that actually leaves the process
   is a subset of the declared `cookie_domains`, asserted on **every request the
   mock transport observes** (the initial request and any redirect hop, not merely a
   base-host check). The test matrix includes the `evil-corp.example.com` vs
   `corp.example.com` static near-miss **and** the off-`cookie_domains` `302` case
   (see AC20).
-- [ ] **AC6.** The consumer client's request base host is a member of
+- [x] **AC6.** The consumer client's request base host is a member of
   `cookie_domains`; a mismatch fails closed before any cookie-bearing request
   leaves the process. The resolved base URL scheme must also be `https` at client
   construction (defense-in-depth below the config-layer AC3 guard — the cookie jar
   is a bearer secret, so the token path's `http://` tolerance must not extend to
   the cookie path); a non-`https` base URL fails closed at construction.
-- [ ] **AC7.** On the cookie path, the HTTP client sends **no** `Authorization`
+- [x] **AC7.** On the cookie path, the HTTP client sends **no** `Authorization`
   header and attaches the (filtered) cookie jar; verified on the outbound request
   via a mock transport.
-- [ ] **AC8.** The cookie-path HTTP client honors `HTTPS_PROXY`/`NO_PROXY` and the
+- [x] **AC8.** The cookie-path HTTP client honors `HTTPS_PROXY`/`NO_PROXY` and the
   system/corporate trust store (CA bundle), wired against actual httpx behavior
   (`trust_env=True`; an explicit SSL context that honors `SSL_CERT_FILE`/
   `SSL_CERT_DIR` and maps `REQUESTS_CA_BUNDLE`; the trust store is not clobbered
   by a bare `verify=True`).
-- [ ] **AC9.** Only GET/HEAD reach the wire on the cookie path, enforced by an
+- [x] **AC9.** Only GET/HEAD reach the wire on the cookie path, enforced by an
   allowlist at the `_request` chokepoint in both clients. In `jira` (which exposes
   a `raw(method, …)` escape hatch) a mutating call — including `raw("POST", …)` —
   raises "writes over SSO-cookie auth are not supported yet (RFC-0035 v1); use a
   personal access token, or wait for the XSRF follow-on"; `confluence-crawler`
   (no `raw()`) refuses a non-GET/HEAD `method` at the same chokepoint. In both,
   the mock transport records **zero** requests for a refused verb.
-- [ ] **AC10.** The consumer reads the jar in-process from the broker-supplied
+- [x] **AC10.** The consumer reads the jar in-process from the broker-supplied
   path only — it never re-writes, copies, or logs the jar or its contents,
   including never persisting the AC4-filtered jar back to the broker path (the
   `0600` at-rest floor is the broker's responsibility, verified by the broker's
   own tests).
-- [ ] **AC11.** On a `401` from a read call, the client surfaces the verbatim
+- [x] **AC11.** On a `401` from a read call, the client surfaces the verbatim
   re-`register` remediation `"401 Unauthorized — SSO session expired; run
   'sso-broker register <profile>' to re-authenticate"`, does **not** silently
   retry into a browser flow, and stops using the known-stale jar (no further
   cookie-bearing request with that session). No cookie value appears in any
   surfaced error or trace text on the `401` or redirect (AC20) paths — the
   remediation names the profile, never the session bytes.
-- [ ] **AC12.** `jira` and `confluence-crawler` ship `references/sso-config.toml`,
+- [x] **AC12.** `jira` and `confluence-crawler` ship `references/sso-config.toml`,
   placeholder-shaped upstream: `auth_default = "creds"`, `*.invalid` hosts, no
   cookie values.
-- [ ] **AC13.** The selector resolves the cookie path iff `auth_default =
+- [x] **AC13.** The selector resolves the cookie path iff `auth_default =
   "sso-cookie"` and a profile is registered; with the config absent or
   `auth_default = "creds"` the outbound request headers and the resolved
   `Credentials` are identical to today's `creds` path (a token user with no SSO
   config sees no behavior change).
-- [ ] **AC14.** The setup helper reads the validated `sso-config.toml` and drives
+- [x] **AC14.** The setup helper reads the validated `sso-config.toml` and drives
   `sso-broker register <profile>` from it (RFC-0035 Open Q2), passing no cookie
   value on argv, and validates `login_url`/`base_url` scheme + `validation_endpoint`
   (AC3 primitives) **before** invoking `register`, so no unvalidated value is ever
   seeded into the profile the unchanged broker's `test`/`get-cookies` read.
-- [ ] **AC15.** A new structural lint parses the upstream
+- [x] **AC15.** A new structural lint parses the upstream
   `references/sso-config.toml` and fails if any `[sso]` key is outside the declared
   connection-param schema, if any value matches a cookie-value shape, if
   `auth_default != "creds"`, or if any host is not `*.invalid`. The check is
   TOML-key structural, **not** a substring scan (no false-positive on
   `crowd.token_key`, `session_filename`, `success_url_pattern`).
-- [ ] **AC16.** `jira` and `confluence-crawler` declare `auth: sso-cookie` with a
+- [x] **AC16.** `jira` and `confluence-crawler` declare `auth: sso-cookie` with a
   `metadata.auth-fallback: creds` marker, and their Security sections carry
   **both** brokers' required phrase sets. `lint_credentialed_skills.py` is amended
   so that (a) a skill carrying the `auth-fallback: creds` marker must satisfy both
@@ -210,11 +210,11 @@ Numbered for plan traceability; each maps to one or more `plan.md` tasks.
   import satisfies the broker-invocation requirement (mirroring RFC-0023's
   `has_credbroker_import` for `creds`) in place of an in-`scripts/`
   `sso-broker.py` path expression.
-- [ ] **AC17.** Mock-level tests cover broker invocation shape, cookie-jar
+- [x] **AC17.** Mock-level tests cover broker invocation shape, cookie-jar
   attachment, the no-`Authorization` assertion, the writes-refused error, the
   fail-closed branches, and cookie-domain confinement (capture-filter + send
   subset).
-- [ ] **AC18.** The upstream-upgrade path for a pre-baked `sso-config.toml` is
+- [x] **AC18.** The upstream-upgrade path for a pre-baked `sso-config.toml` is
   documented as the adapt-to-project `.upstream` companion merge (class-2), so an
   org's edited instance config is not clobbered by a later catalogue release.
 - [ ] **AC19.** (deferred: atlassian-sso-cookie-live-dc-read-transcript) A live
@@ -223,7 +223,7 @@ Numbered for plan traceability; each maps to one or more `plan.md` tasks.
   `notes/live-dc-read.md`. This is the gate that flips the feature Experimental →
   Accepted; it reopens when a real corporate-SSO DC instance is available (the
   plan's `## Construction tests` → Manual verification owns the gesture).
-- [ ] **AC20.** The cookie-path HTTP client is built with `follow_redirects=False`
+- [x] **AC20.** The cookie-path HTTP client is built with `follow_redirects=False`
   so no redirect is followed with cookies attached. (httpx re-derives the `Cookie`
   header from the client store by domain match on **every** hop, so following an
   off-`cookie_domains` `30x` — open redirect, reverse-proxy misconfig, or an

--- a/docs/specs/atlassian-sso-cookie/spec.md
+++ b/docs/specs/atlassian-sso-cookie/spec.md
@@ -92,10 +92,12 @@ before proceeding; *Never do* is a hard rule, even under time pressure.
   control surface, so each rejection path — and the over-broad-jar → filtered-jar
   reduction — is a test. Unit level.
 - **Cookie-path HTTP wiring (no `Authorization` header; cookie jar attached;
-  GET/HEAD allowlist refuses writes incl. `raw("POST", …)`; proxy/trust-store
-  env honored): TDD via a mock transport.** Assert on the *outbound request*
-  (headers, cookies, refusal) through httpx's `MockTransport`, not on internal
-  client attributes. Unit/integration level.
+  GET/HEAD allowlist refuses writes incl. `raw("POST", …)`; `follow_redirects=False`
+  with an off-`cookie_domains` `302` attaching zero cookies; non-`https` base URL
+  refused at construction; proxy/trust-store env honored): TDD via a mock
+  transport.** Assert on the *outbound request* (headers, cookies, refusal) across
+  **every** request the transport observes, through httpx's `MockTransport`, not on
+  internal client attributes. Unit/integration level.
 - **`auth_default` selector + `creds` fallback (absent/`creds` → token path
   byte-identical; `sso-cookie` + registered → cookie path; `sso-cookie` +
   unavailable → fail closed): TDD.** Unit level.
@@ -143,12 +145,17 @@ Numbered for plan traceability; each maps to one or more `plan.md` tasks.
   is applied on **every** resolution and its result is never written back to the
   broker path (the on-disk jar stays over-broad; see AC10).
 - [ ] **AC5.** On the cookie path the cookie set that actually leaves the process
-  is a subset of the declared `cookie_domains`, asserted on the **outbound request**
-  via a mock transport (not merely on a base-host check). The test matrix includes
-  the `evil-corp.example.com` vs `corp.example.com` near-miss.
+  is a subset of the declared `cookie_domains`, asserted on **every request the
+  mock transport observes** (the initial request and any redirect hop, not merely a
+  base-host check). The test matrix includes the `evil-corp.example.com` vs
+  `corp.example.com` static near-miss **and** the off-`cookie_domains` `302` case
+  (see AC20).
 - [ ] **AC6.** The consumer client's request base host is a member of
   `cookie_domains`; a mismatch fails closed before any cookie-bearing request
-  leaves the process.
+  leaves the process. The resolved base URL scheme must also be `https` at client
+  construction (defense-in-depth below the config-layer AC3 guard — the cookie jar
+  is a bearer secret, so the token path's `http://` tolerance must not extend to
+  the cookie path); a non-`https` base URL fails closed at construction.
 - [ ] **AC7.** On the cookie path, the HTTP client sends **no** `Authorization`
   header and attaches the (filtered) cookie jar; verified on the outbound request
   via a mock transport.
@@ -173,7 +180,9 @@ Numbered for plan traceability; each maps to one or more `plan.md` tasks.
   re-`register` remediation `"401 Unauthorized — SSO session expired; run
   'sso-broker register <profile>' to re-authenticate"`, does **not** silently
   retry into a browser flow, and stops using the known-stale jar (no further
-  cookie-bearing request with that session).
+  cookie-bearing request with that session). No cookie value appears in any
+  surfaced error or trace text on the `401` or redirect (AC20) paths — the
+  remediation names the profile, never the session bytes.
 - [ ] **AC12.** `jira` and `confluence-crawler` ship `references/sso-config.toml`,
   placeholder-shaped upstream: `auth_default = "creds"`, `*.invalid` hosts, no
   cookie values.
@@ -214,6 +223,17 @@ Numbered for plan traceability; each maps to one or more `plan.md` tasks.
   `notes/live-dc-read.md`. This is the gate that flips the feature Experimental →
   Accepted; it reopens when a real corporate-SSO DC instance is available (the
   plan's `## Construction tests` → Manual verification owns the gesture).
+- [ ] **AC20.** The cookie-path HTTP client is built with `follow_redirects=False`
+  so no redirect is followed with cookies attached. (httpx re-derives the `Cookie`
+  header from the client store by domain match on **every** hop, so following an
+  off-`cookie_domains` `30x` — open redirect, reverse-proxy misconfig, or an
+  attacker-influenced `Location` — would re-attach and exfiltrate the session
+  cookie; `follow_redirects=False` closes that path.) A `30x` response is surfaced
+  to the caller rather than followed. Verified on a mock transport: a `302` from a
+  permitted host to an off-`cookie_domains` host produces **zero** cookie-bearing
+  requests to that off-domain host. DC read endpoints return `200`; redirect-to-
+  login as an expired-session signal is part of the deferred live-DC transcript
+  (AC19).
 
 ## Assumptions
 

--- a/packages/agentbundle/tests/integration/test_credential_brokers_pack_install.py
+++ b/packages/agentbundle/tests/integration/test_credential_brokers_pack_install.py
@@ -56,8 +56,10 @@ class PackManifestShapeTests(unittest.TestCase):
         self.assertEqual(pack["name"], "credential-brokers")
         # Bumped 0.1.0 → 0.1.1 (metadata enrichment) → 0.1.2 (per-pack
         # guide-home `documentation` link) → 0.1.3 (missing-credbroker guard +
-        # credentials_shim→credbroker description fix); adapter-contract unchanged.
-        self.assertEqual(pack["version"], "0.1.3")
+        # credentials_shim→credbroker description fix) → 0.2.0 (credbroker SSO
+        # consumer family, RFC-0035: load_sso_cookies + confinement primitives);
+        # adapter-contract unchanged.
+        self.assertEqual(pack["version"], "0.2.0")
 
     def test_description_names_the_three_artefacts(self) -> None:
         # The description names the artefacts the pack ships. Since RFC-0023 the

--- a/packages/credbroker/CHANGELOG.md
+++ b/packages/credbroker/CHANGELOG.md
@@ -6,6 +6,23 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 — a minor bump on a 0.x release MAY be breaking.
 
+## [0.2.0] — 2026-06-16
+
+### Added
+
+- **SSO web-session cookie family (RFC-0035)** — a second consumer-resolution
+  family alongside the token `creds` family. `load_sso_cookies(profile)` resolves
+  a captured SSO web session to an on-disk `0600` cookie-jar **path** (path-not-
+  value handoff) by subprocess-invoking the unchanged `sso-broker` engine; it
+  fails closed (`SsoSessionUnavailableError` / `SsoBrokerNotInstalledError`) and
+  never silently falls back to the token path.
+- **SSO confinement primitives** — `filter_jar_to_domains`,
+  `domain_in_cookie_domains`, `require_host_in_cookie_domains`,
+  `validate_https_url`, and `validate_root_relative_endpoint`: the reusable
+  https-only / root-relative / cookie-domain guards the engine does not perform,
+  with a label-boundary suffix match (`evil-corp.example.com` is rejected against
+  `corp.example.com`). The base import graph stays stdlib-only.
+
 ## [0.1.1] — 2026-06-12
 
 ### Changed

--- a/packages/credbroker/README.md
+++ b/packages/credbroker/README.md
@@ -56,6 +56,23 @@ The returned object is immutable, and its `repr` lists key names only. A stray `
 
 Linux and other platforms have no keyring tier. Resolution skips straight from the environment variable to the dotfile floor. Without `[crypto]`, that floor is the plaintext `0600` dotfile.
 
+## SSO web-session cookies
+
+Some enterprise instances sit behind corporate SSO and block personal API tokens outright. For those, `credbroker` resolves a *captured web session* instead of a token. The companion `sso-broker` engine drives a one-time browser login and stores the cookie jar; your skill resolves it in-process:
+
+```python
+from credbroker import load_sso_cookies, SsoSessionUnavailableError
+
+try:
+    jar_path = load_sso_cookies("corp")   # returns a path, never the bytes
+except SsoSessionUnavailableError as exc:
+    raise SystemExit(str(exc))            # "...run 'sso-broker register corp'"
+```
+
+Same discipline as the token path: the secret never crosses the model boundary. `load_sso_cookies` hands back the *path* to a `0600` cookie jar — not the cookie values — and fails closed (it never silently falls back to a token) when the session is missing or expired, surfacing a remediation that tells the user to re-`register`.
+
+The confinement helpers that keep a captured jar from over-reaching ship alongside it: `filter_jar_to_domains` reduces the engine's deliberately broad capture down to the domains you declare, `domain_in_cookie_domains` / `require_host_in_cookie_domains` enforce a label-boundary host match (so `evil-corp.example.com` never matches `corp.example.com`), and `validate_https_url` / `validate_root_relative_endpoint` guard the connection config. See [RFC-0035](https://github.com/eugenelim/agent-ready-repo/blob/main/docs/rfc/0035-sso-cookie-auth-for-atlassian-pack.md) for the full design.
+
 ## Learn more
 
 For local development, install from a repo clone: `pip install -e ./packages/credbroker`.

--- a/packages/credbroker/credbroker/__init__.py
+++ b/packages/credbroker/credbroker/__init__.py
@@ -48,7 +48,26 @@ from ._core import (
 from ._core import _parse_schema as parse_schema
 from ._core import _tier2_backend_label as tier2_backend_label
 
-__version__ = "0.1.1"
+# SSO web-session cookie family (RFC-0035) — a second consumer-resolution family
+# alongside the token ``creds`` family above. Resolves a captured SSO session to
+# an on-disk cookie-jar path via the unchanged ``sso-broker.py`` engine, with
+# reusable validation primitives for the consumer's ``sso-config.toml`` and the
+# load-time cookie-domain confinement. Imported eagerly: ``_sso`` is stdlib-only,
+# so it keeps the base import graph free of any third-party dependency.
+from ._sso import (
+    SsoBrokerNotInstalledError,
+    SsoConfigError,
+    SsoError,
+    SsoSessionUnavailableError,
+    domain_in_cookie_domains,
+    filter_jar_to_domains,
+    load_sso_cookies,
+    require_host_in_cookie_domains,
+    validate_https_url,
+    validate_root_relative_endpoint,
+)
+
+__version__ = "0.2.0"
 
 __all__ = [
     # Resolver + container.
@@ -77,5 +96,17 @@ __all__ = [
     "source_vault_master",
     "store_vault_master",
     "store_in_vault",
+    # SSO web-session cookie family (RFC-0035).
+    "load_sso_cookies",
+    "SsoError",
+    "SsoBrokerNotInstalledError",
+    "SsoSessionUnavailableError",
+    "SsoConfigError",
+    # SSO confinement primitives (RFC-0035; security-control surface).
+    "validate_https_url",
+    "validate_root_relative_endpoint",
+    "domain_in_cookie_domains",
+    "filter_jar_to_domains",
+    "require_host_in_cookie_domains",
     "__version__",
 ]

--- a/packages/credbroker/credbroker/_sso.py
+++ b/packages/credbroker/credbroker/_sso.py
@@ -1,0 +1,226 @@
+"""SSO web-session cookie resolution (RFC-0035).
+
+A second consumer-resolution family alongside the token ``creds`` family. Where
+``load_credentials`` resolves a token, ``load_sso_cookies`` resolves a *captured
+SSO web session* into an on-disk cookie-jar path by subprocess-invoking the
+unchanged ``sso-broker.py`` engine.
+
+Two contracts shape this module:
+
+* **Path-not-value handoff (RFC-0013 § 1).** The resolver returns the jar's
+  *path*, never its bytes. No cookie value crosses ``argv`` (only the profile
+  name does), no cookie value is logged, and the engine writes the jar to its own
+  ``0600`` floor — the consumer reads it in-process and is responsible for never
+  echoing it (the at-rest floor is the broker's own responsibility).
+* **Fail-closed.** Anything other than a clean exit-0-with-readable-path raises
+  :class:`SsoSessionUnavailableError` with a verbatim re-``register`` remediation.
+  It never returns a path it could not verify, and a caller on the cookie path
+  must never fall through to the token path on this error.
+
+The validation primitives that guard the consumer's ``sso-config.toml`` and the
+load-time cookie-jar confinement live alongside this resolver (added in spec task
+T2) so the security-control surface is single-sourced and reusable by any
+platform integration, not just atlassian.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable
+from urllib.parse import urlsplit
+
+__all__ = [
+    "SsoError",
+    "SsoBrokerNotInstalledError",
+    "SsoSessionUnavailableError",
+    "SsoConfigError",
+    "load_sso_cookies",
+    "validate_https_url",
+    "validate_root_relative_endpoint",
+    "domain_in_cookie_domains",
+    "filter_jar_to_domains",
+    "require_host_in_cookie_domains",
+]
+
+# The engine is installed by the credential-brokers pack at this user-scope path
+# (RFC-0013 § 1; mirrored by ``sso-broker.py``'s own module docstring). Composed
+# from parts so no full literal path string appears, matching the broker's own
+# convention.
+_BROKER_TAIL = (".agentbundle", "bin", "sso-broker.py")
+
+
+class SsoError(Exception):
+    """Base class for SSO consumer-resolution failures."""
+
+
+class SsoBrokerNotInstalledError(SsoError):
+    """The ``sso-broker.py`` engine is not installed at its expected path."""
+
+
+class SsoSessionUnavailableError(SsoError):
+    """No usable SSO session for the profile — the caller must re-``register``.
+
+    Raised for every non-success branch of ``get-cookies`` (the engine returns a
+    non-zero exit for both "profile not registered" and "no jar"), for an
+    unreadable jar path, and for any uncaught engine exception. Fail-closed: the
+    cookie path must surface this, never silently downgrade to the token path.
+    """
+
+
+class SsoConfigError(SsoError):
+    """An ``sso-config.toml`` value, or a runtime host, violates the SSO
+    confinement contract — a non-``https`` URL, a non-root-relative endpoint, or a
+    send-host outside the declared ``cookie_domains``. Validation primitives raise
+    this; the consumer fails closed before any cookie-bearing request leaves the
+    process.
+    """
+
+
+def _broker_path() -> Path:
+    """Resolve the engine path under the user's home (``~/.agentbundle/bin``)."""
+    return Path.home().joinpath(*_BROKER_TAIL)
+
+
+def load_sso_cookies(profile: str) -> Path:
+    """Resolve *profile*'s captured SSO session to an on-disk cookie-jar path.
+
+    Subprocess-invokes ``sso-broker.py get-cookies <profile>`` with the parent
+    interpreter, inheriting the process environment (corporate proxy / trust-store
+    passthrough, RFC-0013 § 1). Proceeds **only** on exit 0 with a readable jar
+    path; every other outcome fails closed.
+
+    :returns: the path to the ``0600`` cookie jar the engine materialised.
+    :raises SsoBrokerNotInstalledError: the engine is absent at its expected path.
+    :raises SsoSessionUnavailableError: the profile is unregistered, no jar
+        exists, the jar path is unreadable, or the engine raised.
+    """
+    broker = _broker_path()
+    if not broker.is_file():
+        raise SsoBrokerNotInstalledError(
+            f"sso-broker not installed at {broker}; install the credential-brokers "
+            f"pack, then run 'sso-broker register {profile}'"
+        )
+
+    remediation = (
+        f"SSO session unavailable for profile {profile}; "
+        f"run 'sso-broker register {profile}'"
+    )
+
+    try:
+        result = subprocess.run(
+            [sys.executable, str(broker), "get-cookies", profile],
+            capture_output=True,
+            text=True,
+            check=False,
+            env={**os.environ},
+        )
+    except OSError as exc:
+        # Engine present but unspawnable (permissions, interpreter gone, …).
+        raise SsoSessionUnavailableError(remediation) from exc
+
+    if result.returncode != 0:
+        raise SsoSessionUnavailableError(remediation)
+
+    jar_path = Path(result.stdout.strip())
+    if not jar_path.is_file():
+        raise SsoSessionUnavailableError(remediation)
+
+    return jar_path
+
+
+# --- SSO confinement primitives (RFC-0035; spec task T2) ---------------------
+#
+# These are the security-control surface the unchanged ``sso-broker.py`` engine
+# does *not* perform and that this RFC adds *above* it: an https-only scheme guard,
+# a root-relative endpoint guard, and the cookie-domain confinement that filters
+# the engine's deliberately over-broad captured jar down to the declared domains.
+# They are pure functions (no I/O), reusable by any platform integration, so the
+# control can't drift across consumers.
+
+
+def validate_https_url(value: str, *, field: str) -> None:
+    """Reject *value* unless its scheme is exactly ``https`` (AC3).
+
+    Applied to ``login_url``, ``success_url_pattern``, and ``base_url`` — the
+    cookie jar is a bearer secret, so a plaintext (``http``) or scheme-less
+    destination is refused. ``success_url_pattern`` may carry pattern characters
+    after the scheme; only the scheme is checked here.
+    """
+    scheme = urlsplit(value).scheme.lower()
+    if scheme != "https":
+        raise SsoConfigError(
+            f"{field} must be an https URL (got scheme {scheme or '(none)'!r}): {value!r}"
+        )
+
+
+def validate_root_relative_endpoint(value: str, *, field: str = "validation_endpoint") -> None:
+    """Reject *value* unless it is a root-relative path (AC3).
+
+    Must lead with a single ``/`` and carry no scheme, host, or protocol-relative
+    ``//`` prefix — so a validation endpoint can never be redirected off-host.
+    """
+    if not value.startswith("/") or value.startswith("//") or "://" in value:
+        raise SsoConfigError(
+            f"{field} must be a root-relative path (lead with '/', no scheme/host, "
+            f"no '//'): {value!r}"
+        )
+
+
+def _normalize_domain(domain: str) -> str:
+    """Lower-case and strip a leading dot — the broker stores domains via
+    ``lstrip('.')`` while cookie ``domain`` fields keep a leading dot (AC4)."""
+    return domain.lstrip(".").lower()
+
+
+def domain_in_cookie_domains(domain: str, cookie_domains: Iterable[str]) -> bool:
+    """Normalized label-boundary suffix match (AC4, AC6).
+
+    Both sides are dot-stripped and lower-cased; *domain* is admitted iff it
+    equals an allowed domain or is a dot-delimited subdomain of one. The label
+    boundary is load-bearing: ``evil-corp.example.com`` is rejected against
+    ``corp.example.com`` (no ``.`` before ``corp``), while ``jira.corp.example.com``
+    is admitted. This is the single normalization primitive shared by the
+    cookie-jar filter (AC4) and the send-host check (AC6).
+    """
+    cand = _normalize_domain(domain)
+    if not cand:
+        return False
+    for allowed in cookie_domains:
+        norm = _normalize_domain(allowed)
+        if not norm:
+            continue
+        if cand == norm or cand.endswith("." + norm):
+            return True
+    return False
+
+
+def filter_jar_to_domains(
+    cookies: list[dict], cookie_domains: Iterable[str]
+) -> list[dict]:
+    """Reduce an over-broad captured jar to cookies within *cookie_domains* (AC4).
+
+    The engine captures every cookie observed across the SSO/IdP/analytics
+    redirect chain; the consumer filters that loaded jar to the declared domains
+    at load time, before attaching it. Returns a new list; the caller must never
+    write the result back to the broker path (AC10). A cookie with no ``domain``
+    field is dropped (fail closed).
+    """
+    allowed = list(cookie_domains)
+    return [c for c in cookies if domain_in_cookie_domains(c.get("domain", ""), allowed)]
+
+
+def require_host_in_cookie_domains(host: str, cookie_domains: Iterable[str]) -> None:
+    """Fail closed unless *host* is within the declared ``cookie_domains`` (AC6).
+
+    The consumer client's request base host must be a member of the confinement
+    set before any cookie-bearing request leaves the process; a mismatch (a
+    downstream edit drifting the base URL off-domain) raises.
+    """
+    if not domain_in_cookie_domains(host, cookie_domains):
+        raise SsoConfigError(
+            f"request host {host!r} is not within the declared cookie_domains "
+            f"{list(cookie_domains)!r}; refusing to send the session cookie"
+        )

--- a/packages/credbroker/pyproject.toml
+++ b/packages/credbroker/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "credbroker"
-version = "0.1.1"
+version = "0.2.0"
 description = "Standalone, pip-installable credential resolver for credentialed agent skills (env -> OS keyring -> dotfile, with an optional encrypted-at-rest vault)."
 requires-python = ">=3.11"
 dependencies = []

--- a/packages/credbroker/tests/unit/test_public_surface.py
+++ b/packages/credbroker/tests/unit/test_public_surface.py
@@ -41,6 +41,28 @@ def test_public_replacements_for_private_shim_symbols() -> None:
     assert "tier2_backend_label" in credbroker.__all__
 
 
+# SSO web-session cookie family (RFC-0035) — the second consumer-resolution
+# family; every name must be importable from the top-level package.
+SSO_PUBLIC_NAMES = [
+    "load_sso_cookies",
+    "SsoError",
+    "SsoBrokerNotInstalledError",
+    "SsoSessionUnavailableError",
+    "SsoConfigError",
+    "validate_https_url",
+    "validate_root_relative_endpoint",
+    "domain_in_cookie_domains",
+    "filter_jar_to_domains",
+    "require_host_in_cookie_domains",
+]
+
+
+def test_sso_surface_is_reexported() -> None:
+    for name in SSO_PUBLIC_NAMES:
+        assert hasattr(credbroker, name), f"missing public name: {name}"
+        assert name in credbroker.__all__, f"{name} not in credbroker.__all__"
+
+
 def test_no_underscore_names_in_public_all() -> None:
     # The public surface must not advertise private/underscore names
     # (other than the dunder __version__).

--- a/packages/credbroker/tests/unit/test_sso_resolver.py
+++ b/packages/credbroker/tests/unit/test_sso_resolver.py
@@ -1,0 +1,128 @@
+"""SSO consumer-resolver contract (spec task T1; AC1, AC2, AC10).
+
+``load_sso_cookies`` subprocess-invokes the unchanged ``sso-broker.py`` engine and
+returns the on-disk jar path, proceeding only on exit-0-with-readable-path and
+failing closed otherwise. The engine is faked here with a stub script returning
+canned exit codes / stdout, plus monkeypatched ``subprocess.run`` for the branches
+a real subprocess can't reach deterministically.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import credbroker
+from credbroker import _sso
+
+
+def _install_fake_broker(home: Path, *, exit_code: int, stdout: str = "") -> Path:
+    """Write a stub ``sso-broker.py`` under *home* that prints *stdout* and exits
+    *exit_code* when run as ``python sso-broker.py get-cookies <profile>``."""
+    bin_dir = home / ".agentbundle" / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    broker = bin_dir / "sso-broker.py"
+    broker.write_text(
+        "import sys\n"
+        f"sys.stdout.write({stdout!r})\n"
+        f"sys.exit({exit_code})\n",
+        encoding="utf-8",
+    )
+    return broker
+
+
+@pytest.fixture()
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point ``Path.home()`` (and thus the resolver's broker lookup) at tmp."""
+    monkeypatch.setattr(_sso.Path, "home", staticmethod(lambda: tmp_path))
+    return tmp_path
+
+
+def test_exit0_readable_path_returns_path(fake_home: Path) -> None:
+    jar = fake_home / "session.jar"
+    jar.write_text("[]", encoding="utf-8")
+    _install_fake_broker(fake_home, exit_code=0, stdout=f"{jar}\n")
+
+    assert _sso.load_sso_cookies("corp") == jar
+
+
+def test_exit2_raises_session_unavailable_with_verbatim_remediation(
+    fake_home: Path,
+) -> None:
+    _install_fake_broker(fake_home, exit_code=2, stdout="")
+
+    with pytest.raises(_sso.SsoSessionUnavailableError) as exc:
+        _sso.load_sso_cookies("corp")
+    # Verbatim AC2 remediation; names the profile, never the session bytes.
+    assert str(exc.value) == (
+        "SSO session unavailable for profile corp; run 'sso-broker register corp'"
+    )
+
+
+def test_broker_absent_raises_not_installed(fake_home: Path) -> None:
+    # No broker written under fake_home → install-the-pack remediation (AC1).
+    with pytest.raises(_sso.SsoBrokerNotInstalledError) as exc:
+        _sso.load_sso_cookies("corp")
+    assert "install the credential-brokers pack" in str(exc.value)
+
+
+def test_exit0_unreadable_path_fails_closed(fake_home: Path) -> None:
+    # Engine exits 0 but the path it prints does not exist → fail closed.
+    _install_fake_broker(
+        fake_home, exit_code=0, stdout=f"{fake_home / 'missing.jar'}\n"
+    )
+    with pytest.raises(_sso.SsoSessionUnavailableError):
+        _sso.load_sso_cookies("corp")
+
+
+def test_uncaught_engine_oserror_fails_closed(
+    fake_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_fake_broker(fake_home, exit_code=0, stdout="ignored\n")
+
+    def _boom(*_a, **_k):
+        raise OSError("interpreter vanished")
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+    with pytest.raises(_sso.SsoSessionUnavailableError):
+        _sso.load_sso_cookies("corp")
+
+
+def test_argv_carries_only_profile_no_cookie_value(
+    fake_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_fake_broker(fake_home, exit_code=2)
+    seen: dict[str, list[str]] = {}
+
+    real_run = subprocess.run
+
+    def _capture(argv, *a, **k):
+        seen["argv"] = list(argv)
+        return real_run(argv, *a, **k)
+
+    monkeypatch.setattr(subprocess, "run", _capture)
+    with pytest.raises(_sso.SsoSessionUnavailableError):
+        _sso.load_sso_cookies("corp")
+
+    argv = seen["argv"]
+    # Exactly: [interpreter, broker, "get-cookies", "corp"] — only the profile
+    # name leaves the process; no cookie value crosses argv (AC10).
+    assert argv[-2:] == ["get-cookies", "corp"]
+    assert "sso-broker.py" in argv[1]
+    for banned in ("--token", "--cookie", "--api-token", "Cookie", "JSESSIONID"):
+        assert all(banned not in part for part in argv), argv
+
+
+def test_subprocess_run_is_the_only_spawn() -> None:
+    # AC10 structural: the resolver uses subprocess.run, not Popen / os.system /
+    # os.exec*; and it never writes/copies the jar (only reads its path).
+    src = Path(_sso.__file__).read_text(encoding="utf-8")
+    assert "subprocess.run(" in src
+    for banned in ("subprocess.Popen", "os.system(", "os.exec"):
+        assert banned not in src, banned
+
+
+def test_version_bumped_to_0_2_0() -> None:
+    assert credbroker.__version__ == "0.2.0"

--- a/packages/credbroker/tests/unit/test_sso_validation.py
+++ b/packages/credbroker/tests/unit/test_sso_validation.py
@@ -1,0 +1,115 @@
+"""SSO confinement primitives (spec task T2; AC3, AC4, AC6).
+
+Table-driven over the security-control surface: the https-only scheme guard, the
+root-relative endpoint guard, the cookie-domain confinement match (with the
+label-boundary near-miss), the load-time over-broad-jar filter, and the send-host
+membership fail-closed check.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from credbroker import _sso
+from credbroker._sso import SsoConfigError
+
+COOKIE_DOMAINS = ["corp.example.com", "jira.example.invalid"]
+
+
+# --- https-only scheme guard (AC3) -------------------------------------------
+
+@pytest.mark.parametrize("url", [
+    "https://corp.example.com",
+    "https://corp.example.com/rest/api/2/myself",
+    "https://corp\\.example\\.com/dashboard.*",  # success_url_pattern shape
+])
+def test_validate_https_url_accepts_https(url: str) -> None:
+    _sso.validate_https_url(url, field="login_url")  # no raise
+
+
+@pytest.mark.parametrize("url", [
+    "http://corp.example.com",          # plaintext
+    "ftp://corp.example.com",           # smuggling scheme
+    "corp.example.com/path",            # scheme-less
+    "//corp.example.com",               # protocol-relative
+])
+def test_validate_https_url_rejects_non_https(url: str) -> None:
+    with pytest.raises(SsoConfigError):
+        _sso.validate_https_url(url, field="base_url")
+
+
+# --- root-relative endpoint guard (AC3) --------------------------------------
+
+@pytest.mark.parametrize("endpoint", [
+    "/rest/api/2/myself",
+    "/",
+    "/wiki/rest/api/space",
+])
+def test_validate_root_relative_endpoint_accepts(endpoint: str) -> None:
+    _sso.validate_root_relative_endpoint(endpoint)  # no raise
+
+
+@pytest.mark.parametrize("endpoint", [
+    "rest/api/2/myself",                       # no leading slash
+    "https://corp.example.com/rest/api",       # scheme + host
+    "//evil.example.com/rest",                 # protocol-relative
+    "http://x/y",                              # scheme
+    "",                                        # empty
+])
+def test_validate_root_relative_endpoint_rejects(endpoint: str) -> None:
+    with pytest.raises(SsoConfigError):
+        _sso.validate_root_relative_endpoint(endpoint)
+
+
+# --- cookie-domain confinement match (AC3 membership, AC4 normalization) ------
+
+@pytest.mark.parametrize("domain,expected", [
+    ("corp.example.com", True),            # exact
+    (".corp.example.com", True),           # leading dot (cookie domain shape)
+    ("jira.corp.example.com", True),       # subdomain admitted
+    ("CORP.EXAMPLE.COM", True),            # case-insensitive
+    ("evil-corp.example.com", False),      # label-boundary near-miss — REJECTED
+    ("example.com", False),                # parent, not subdomain
+    ("corp.example.com.evil.net", False),  # suffix-injection attempt
+    ("", False),                           # empty
+])
+def test_domain_in_cookie_domains(domain: str, expected: bool) -> None:
+    assert _sso.domain_in_cookie_domains(domain, COOKIE_DOMAINS) is expected
+
+
+# --- load-time over-broad-jar filter (AC4) -----------------------------------
+
+def test_filter_jar_to_domains_reduces_overbroad_jar() -> None:
+    # The engine captures the session cookies PLUS IdP / analytics cookies seen
+    # across the redirect chain. The consumer keeps only the declared domains.
+    jar = [
+        {"name": "JSESSIONID", "domain": "corp.example.com", "value": "s1"},
+        {"name": "crowd.token_key", "domain": ".corp.example.com", "value": "s2"},
+        {"name": "atl_token", "domain": "jira.example.invalid", "value": "s3"},
+        {"name": "idp_session", "domain": "login.okta.com", "value": "x"},       # IdP
+        {"name": "_ga", "domain": ".doubleclick.net", "value": "x"},             # analytics
+        {"name": "near_miss", "domain": "evil-corp.example.com", "value": "x"},   # near-miss
+    ]
+    filtered = _sso.filter_jar_to_domains(jar, COOKIE_DOMAINS)
+    kept = {c["name"] for c in filtered}
+    assert kept == {"JSESSIONID", "crowd.token_key", "atl_token"}
+    # The over-broad source is not mutated (never written back; AC10).
+    assert len(jar) == 6
+
+
+def test_filter_jar_drops_domainless_cookie() -> None:
+    jar = [{"name": "no_domain", "value": "x"}]
+    assert _sso.filter_jar_to_domains(jar, COOKIE_DOMAINS) == []
+
+
+# --- send-host membership, fail-closed (AC6) ---------------------------------
+
+@pytest.mark.parametrize("host", ["corp.example.com", "jira.corp.example.com"])
+def test_require_host_in_cookie_domains_passes(host: str) -> None:
+    _sso.require_host_in_cookie_domains(host, COOKIE_DOMAINS)  # no raise
+
+
+@pytest.mark.parametrize("host", ["evil-corp.example.com", "example.com", "other.net"])
+def test_require_host_in_cookie_domains_fails_closed(host: str) -> None:
+    with pytest.raises(SsoConfigError):
+        _sso.require_host_in_cookie_domains(host, COOKIE_DOMAINS)

--- a/packs/atlassian/.apm/skills/confluence-crawler/SKILL.md
+++ b/packs/atlassian/.apm/skills/confluence-crawler/SKILL.md
@@ -4,7 +4,8 @@ description: Crawl an authenticated Confluence space (Atlassian Cloud or on-prem
 metadata:
   credentialed: true
   primitive-class: credentialed-cli
-  auth: creds
+  auth: sso-cookie
+  auth-fallback: creds
   namespace: confluence
   keys: ["API_TOKEN"]
 ---
@@ -54,6 +55,22 @@ Populate any tier by running `credential-setup` skill.
 - If `--check` reports missing or invalid creds, tell the user to run
   `credential-setup` skill themselves.
   It's interactive — do not run it for them.
+
+This skill is **dual-auth** (`auth: sso-cookie` with a `creds` fallback): on a
+Data Center instance behind corporate SSO it authenticates by a captured web
+session (cookie jar) resolved through the `sso-broker`; everywhere else it uses
+the token (`creds`) path above. On the SSO-cookie path:
+
+- The session cookie jar lives only under the broker's `0600` store; the skill
+  reads it in-process via the `credbroker` resolver, which returns a *path*, not
+  the bytes. **Never** read the jar file directly, print its contents, or echo
+  cookie values.
+- **Never** put a session cookie on the command line. The skill attaches cookies
+  to its HTTP client internally and sends no `Authorization` header on this path.
+- If the SSO session is missing or expired, tell the user to run
+  `python scripts/setup_sso.py` (which drives `sso-broker register`) themselves —
+  it opens a browser for interactive sign-in, so do not run any setup helper for
+  them.
 
 ### Step 1: Verify the environment
 

--- a/packs/atlassian/.apm/skills/confluence-crawler/references/sso-config.toml
+++ b/packs/atlassian/.apm/skills/confluence-crawler/references/sso-config.toml
@@ -1,0 +1,34 @@
+# SSO web-session cookie config (RFC-0035) — Atlassian Data Center only.
+#
+# This file is PLACEHOLDER-SHAPED upstream: auth_default = "creds", *.invalid
+# hosts, and no cookie values. With it untouched, `confluence-crawler` behaves
+# exactly as today (token / `creds` auth) — the SSO-cookie path is dark until an
+# enterprise opts in.
+#
+# An enterprise pre-bakes its instance config here (a pack customization), then a
+# developer runs `python scripts/setup_sso.py` (drives `sso-broker register`)
+# once. Upgrades to a pre-baked file merge as an adapt-to-project `.upstream`
+# companion (class-2), so an org's edits survive a later catalogue release.
+#
+# auth_default selects the path: "creds" (token, the default) or "sso-cookie".
+
+auth_default = "creds"
+
+[sso]
+# The sso-broker profile name (passed to `sso-broker register/get-cookies`).
+profile = "confluence"
+# Data Center base URL. https only (a bearer cookie must never travel plaintext).
+base_url = "https://confluence.example.invalid"
+# Corporate SSO sign-in entry point (headed-browser capture lands here first).
+login_url = "https://sso.example.invalid/login"
+# Post-login landing URL the broker waits for to confirm a successful sign-in.
+success_url_pattern = "https://confluence.example.invalid/dashboard.action"
+# Cookie-domain confinement: the captured jar is filtered to these at load time,
+# and the request base host must be a member. Label-boundary match.
+cookie_domains = ["confluence.example.invalid"]
+# Root-relative read endpoint used to validate a live session (`sso-broker test`).
+validation_endpoint = "/rest/api/space"
+# Filename for the stored session jar under the broker's 0600 floor.
+session_filename = "confluence-session.json"
+# Advisory session lifetime hint (minutes); informational only.
+ttl_hint_minutes = 480

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/_client.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/_client.py
@@ -14,13 +14,19 @@ Override auto-detection by setting CONFLUENCE_FLAVOR=cloud|server.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
+import os
 import secrets
+import ssl
 from dataclasses import dataclass
-from typing import AsyncIterator
+from typing import TYPE_CHECKING, AsyncIterator
 from urllib.parse import urlparse
 
 import httpx
+
+if TYPE_CHECKING:
+    from _sso_config import SsoConfig
 
 log = logging.getLogger("confluence_crawler.client")
 
@@ -78,6 +84,30 @@ def detect_flavor(base_url: str) -> str:
     return FLAVOR_CLOUD if host.endswith(".atlassian.net") else FLAVOR_SERVER
 
 
+def _sso_cafile_capath() -> tuple[str | None, str | None]:
+    """Resolve the CA bundle file + dir for the cookie-path SSL context (AC8).
+
+    httpx (``trust_env``) natively honors ``SSL_CERT_FILE`` / ``SSL_CERT_DIR`` but
+    does **not** read ``REQUESTS_CA_BUNDLE``; we map it here. Precedence:
+    ``SSL_CERT_FILE`` wins over ``REQUESTS_CA_BUNDLE`` when both are set.
+    """
+    cafile = os.environ.get("SSL_CERT_FILE") or os.environ.get("REQUESTS_CA_BUNDLE")
+    capath = os.environ.get("SSL_CERT_DIR")
+    return (cafile or None, capath or None)
+
+
+def _sso_ssl_context() -> ssl.SSLContext:
+    """SSL context for the cookie path: the system trust store *plus* any
+    ``SSL_CERT_FILE`` / ``SSL_CERT_DIR`` / ``REQUESTS_CA_BUNDLE`` the corporate
+    environment sets — loaded on top of (never clobbering) the default store (AC8).
+    """
+    ctx = ssl.create_default_context()
+    cafile, capath = _sso_cafile_capath()
+    if cafile or capath:
+        ctx.load_verify_locations(cafile=cafile, capath=capath)
+    return ctx
+
+
 class ConfluenceClient:
     """Async wrapper around the Confluence v1 REST API (works for both
     Cloud and Server/Data Center)."""
@@ -97,6 +127,10 @@ class ConfluenceClient:
 
         self._base = base_url.rstrip("/")
         self._flavor = credentials.flavor
+        # Token path. The SSO-cookie path is built via from_sso_cookies and sets
+        # these to "sso-cookie" / the profile name; _request branches on them.
+        self._auth_mode = "creds"
+        self._profile: str | None = None
         headers = {
             "Accept": "application/json",
             "User-Agent": "atlassian-confluence-crawler/0.1",
@@ -122,6 +156,80 @@ class ConfluenceClient:
         self._last_request = 0.0
         self._lock = asyncio.Lock()
 
+    @classmethod
+    def from_sso_cookies(
+        cls,
+        sso_config: "SsoConfig",
+        *,
+        concurrency: int = DEFAULT_CONCURRENCY,
+        min_delay_ms: int = DEFAULT_MIN_DELAY_MS,
+        timeout_s: float = DEFAULT_TIMEOUT_S,
+    ) -> "ConfluenceClient":
+        """Build a Data Center client authenticated by a captured SSO cookie jar.
+
+        Resolves the jar via credbroker (fail-closed), filters it to the declared
+        ``cookie_domains`` (AC4), confirms the base host is within those domains
+        (AC6), and builds an httpx client with the confined jar attached, **no**
+        ``Authorization`` header (AC7), ``follow_redirects=False`` (AC20), and the
+        corporate proxy / trust store honored (AC8). GET/HEAD only (AC9).
+        """
+        import credbroker
+
+        base_url = sso_config.base_url
+        parsed = urlparse(base_url)
+        if parsed.scheme != "https":
+            raise AuthError(
+                "SSO-cookie base_url must be https (the session cookie is a bearer secret)"
+            )
+        host = parsed.hostname or ""
+        try:
+            credbroker.require_host_in_cookie_domains(host, sso_config.cookie_domains)
+            jar_path = credbroker.load_sso_cookies(sso_config.profile)
+        except credbroker.SsoError as exc:
+            raise AuthError(str(exc)) from exc
+
+        raw_cookies = json.loads(jar_path.read_text(encoding="utf-8"))
+        confined = credbroker.filter_jar_to_domains(
+            raw_cookies, sso_config.cookie_domains
+        )
+
+        self = cls.__new__(cls)
+        self._base = base_url.rstrip("/")
+        self._flavor = FLAVOR_SERVER  # DC only — Cloud cookie auth is out of scope
+        self._auth_mode = "sso-cookie"
+        self._profile = sso_config.profile
+
+        cookies = httpx.Cookies()
+        for c in confined:
+            # Preserve the jar's domain verbatim (keep any leading dot) so httpx's
+            # cookiejar subdomain matching attaches a ".corp.example.com" cookie
+            # to jira/confluence.corp.example.com.
+            cookies.set(
+                c["name"],
+                c.get("value", ""),
+                domain=c.get("domain", ""),
+                path=c.get("path") or "/",
+            )
+
+        headers = {
+            "Accept": "application/json",
+            "User-Agent": "atlassian-confluence-crawler/0.1",
+        }  # deliberately NO Authorization header on the cookie path (AC7)
+        self._client = httpx.AsyncClient(
+            base_url=self._base,
+            headers=headers,
+            cookies=cookies,
+            timeout=timeout_s,
+            verify=_sso_ssl_context(),
+            trust_env=True,  # corporate proxy + SSL_CERT_FILE/SSL_CERT_DIR (AC8)
+            follow_redirects=False,  # AC20 — never re-attach the cookie cross-host
+        )
+        self._sem = asyncio.Semaphore(concurrency)
+        self._min_delay = min_delay_ms / 1000.0
+        self._last_request = 0.0
+        self._lock = asyncio.Lock()
+        return self
+
     async def __aenter__(self) -> "ConfluenceClient":
         return self
 
@@ -129,6 +237,15 @@ class ConfluenceClient:
         await self._client.aclose()
 
     async def _request(self, method: str, path: str, **kwargs: object) -> httpx.Response:
+        # Cookie-path write refusal (AC9). confluence-crawler has no raw() escape
+        # hatch, so the allowlist guards the _request method parameter directly;
+        # raised before any request reaches the wire.
+        if self._auth_mode == "sso-cookie" and method.upper() not in ("GET", "HEAD"):
+            raise ConfluenceError(
+                "writes over SSO-cookie auth are not supported yet (RFC-0035 v1); "
+                "use a personal access token, or wait for the XSRF follow-on"
+            )
+
         async with self._sem:
             async with self._lock:
                 now = asyncio.get_running_loop().time()
@@ -147,9 +264,25 @@ class ConfluenceClient:
                     continue
 
                 if resp.status_code == 401:
+                    if self._auth_mode == "sso-cookie":
+                        # Stop using the known-stale jar; remediation names the
+                        # profile, never the cookie bytes (AC11).
+                        self._client.cookies.clear()
+                        raise AuthError(
+                            f"401 Unauthorized — SSO session expired; run "
+                            f"'sso-broker register {self._profile}' to re-authenticate"
+                        )
                     raise AuthError(
                         "401 Unauthorized — credentials are missing, invalid, or expired. "
                         "Re-run `credential-setup` skill."
+                    )
+                if self._auth_mode == "sso-cookie" and 300 <= resp.status_code < 400:
+                    # follow_redirects disabled on the cookie path (AC20): surface a
+                    # 30x, never follow it (which would re-attach the session cookie).
+                    raise AuthError(
+                        f"SSO session may have expired (HTTP {resp.status_code} "
+                        f"redirect, not followed); run 'sso-broker register "
+                        f"{self._profile}' to re-authenticate"
                     )
                 if resp.status_code == 403:
                     raise AuthError(

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/_client.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/_client.py
@@ -412,6 +412,18 @@ class ConfluenceClient:
     async def download_attachment(self, download_path: str, dest: Path) -> None:
         if not download_path:
             raise ConfluenceError("attachment has no download path")
+        # This streaming GET bypasses the _request chokepoint, so it carries the
+        # cookie-path confinement inline: refuse an absolute / off-host download
+        # link (server-supplied) so the session cookie can never leave the base
+        # host. follow_redirects=False already blocks a cross-host 30x; this also
+        # blocks an absolute Location-style `download` value (AC4/AC6/AC20 spirit).
+        if self._auth_mode == "sso-cookie":
+            parsed = urlparse(download_path)
+            if parsed.scheme or parsed.netloc:
+                raise ConfluenceError(
+                    "refusing an absolute attachment download URL on the SSO-cookie "
+                    f"path (must be a path relative to the base host): {download_path!r}"
+                )
         dest.parent.mkdir(parents=True, exist_ok=True)
         async with self._sem:
             async with self._client.stream("GET", download_path) as resp:

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/_sso_config.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/_sso_config.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 
 import tomllib
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from urllib.parse import urlsplit
 
 # The atlassian ``[sso]`` connection-param schema. The structural lint
 # (``tools/lint-sso-config.py``) pins this key set; keep the two in sync.
@@ -83,6 +84,7 @@ def load_sso_config(config_path: Path | None = None) -> SsoConfig | None:
     # skill bootstrap appends to sys.path is in place before resolution.
     from credbroker import (
         SsoConfigError,
+        domain_in_cookie_domains,
         validate_https_url,
         validate_root_relative_endpoint,
     )
@@ -114,6 +116,40 @@ def load_sso_config(config_path: Path | None = None) -> SsoConfig | None:
         or not all(isinstance(d, str) for d in domains)
     ):
         raise SsoConfigError("cookie_domains must be a non-empty list of strings")
+    # Reject a dangerously broad confinement set: a single-label domain (no dot,
+    # e.g. "com") would admit the over-broad captured jar against any corporate
+    # host. The instance domain must have at least one label boundary.
+    for dom in domains:
+        if "." not in dom.strip("."):
+            raise SsoConfigError(
+                f"cookie_domains entry {dom!r} is too broad (single-label); "
+                f"declare the instance domain (e.g. corp.example.com)"
+            )
+    # The base host must itself be within cookie_domains — the runtime client
+    # also checks this, but pinning it at load fails a typo'd config closed early.
+    base_host = urlsplit(sso["base_url"]).hostname or ""
+    if not domain_in_cookie_domains(base_host, domains):
+        raise SsoConfigError(
+            f"base_url host {base_host!r} is not within cookie_domains {domains!r}"
+        )
+
+    # session_filename is forwarded to `sso-broker register --session-filename`;
+    # confine it to a bare filename so an adopter-supplied value can't seed a
+    # path-traversal into the broker's store.
+    session_filename = sso.get("session_filename")
+    if session_filename is not None:
+        bad = (
+            session_filename in ("", ".", "..")
+            or "/" in session_filename
+            or "\\" in session_filename
+            or PurePosixPath(session_filename).name != session_filename
+            or PureWindowsPath(session_filename).name != session_filename
+        )
+        if bad:
+            raise SsoConfigError(
+                f"session_filename must be a bare filename (no path separators): "
+                f"{session_filename!r}"
+            )
 
     return SsoConfig(
         profile=str(sso["profile"]),
@@ -122,6 +158,6 @@ def load_sso_config(config_path: Path | None = None) -> SsoConfig | None:
         success_url_pattern=sso["success_url_pattern"],
         cookie_domains=tuple(domains),
         validation_endpoint=sso["validation_endpoint"],
-        session_filename=sso.get("session_filename"),
+        session_filename=session_filename,
         ttl_hint_minutes=sso.get("ttl_hint_minutes"),
     )

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/_sso_config.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/_sso_config.py
@@ -1,0 +1,127 @@
+"""SSO config loader + ``auth_default`` selector (RFC-0035; spec task T3).
+
+Reads ``references/sso-config.toml``, validates the ``[sso]`` connection params
+with the shared ``credbroker`` confinement primitives, and decides the auth path.
+The *schema* (the ``[sso]`` key set) is consumer-specific and lives here; the
+security *primitives* it calls (https-only / root-relative guards) are
+single-sourced in ``credbroker`` so they cannot drift between consumers.
+
+The selector is the return value: ``None`` means the ``creds`` (token) path —
+returned when the file is absent or ``auth_default = "creds"`` — and an
+:class:`SsoConfig` means the SSO-cookie path. When ``auth_default = "sso-cookie"``
+the ``[sso]`` table is validated and a malformed value raises (fail closed; never
+downgrade to ``creds``).
+"""
+
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+# The atlassian ``[sso]`` connection-param schema. The structural lint
+# (``tools/lint-sso-config.py``) pins this key set; keep the two in sync.
+_ALLOWED_SSO_KEYS = frozenset(
+    {
+        "profile",
+        "base_url",
+        "login_url",
+        "success_url_pattern",
+        "cookie_domains",
+        "validation_endpoint",
+        "session_filename",
+        "ttl_hint_minutes",
+    }
+)
+_REQUIRED_SSO_KEYS = frozenset(
+    {
+        "profile",
+        "base_url",
+        "login_url",
+        "success_url_pattern",
+        "cookie_domains",
+        "validation_endpoint",
+    }
+)
+
+_DEFAULT_CONFIG_PATH = (
+    Path(__file__).resolve().parent.parent / "references" / "sso-config.toml"
+)
+
+
+@dataclass(frozen=True)
+class SsoConfig:
+    """Validated ``[sso]`` connection config for the cookie path."""
+
+    profile: str
+    base_url: str
+    login_url: str
+    success_url_pattern: str
+    cookie_domains: tuple[str, ...]
+    validation_endpoint: str
+    session_filename: str | None = None
+    ttl_hint_minutes: int | None = None
+
+
+def load_sso_config(config_path: Path | None = None) -> SsoConfig | None:
+    """Resolve the auth path from ``sso-config.toml``.
+
+    :returns: ``None`` for the ``creds`` (token) path (file absent or
+        ``auth_default = "creds"``); an :class:`SsoConfig` for the SSO-cookie path.
+    :raises credbroker.SsoConfigError: ``auth_default = "sso-cookie"`` but the
+        ``[sso]`` table is missing, has unknown/missing keys, or carries a
+        non-``https`` URL or non-root-relative endpoint (fail closed).
+    """
+    path = config_path or _DEFAULT_CONFIG_PATH
+    if not path.is_file():
+        return None
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    if data.get("auth_default", "creds") != "sso-cookie":
+        return None
+
+    # Imported here (not at module top) so the credbroker user-scope floor the
+    # skill bootstrap appends to sys.path is in place before resolution.
+    from credbroker import (
+        SsoConfigError,
+        validate_https_url,
+        validate_root_relative_endpoint,
+    )
+
+    sso = data.get("sso")
+    if not isinstance(sso, dict):
+        raise SsoConfigError(
+            "auth_default = 'sso-cookie' but the [sso] table is missing"
+        )
+
+    unknown = set(sso) - _ALLOWED_SSO_KEYS
+    if unknown:
+        raise SsoConfigError(f"unknown [sso] keys: {sorted(unknown)}")
+    missing = _REQUIRED_SSO_KEYS - set(sso)
+    if missing:
+        raise SsoConfigError(f"missing required [sso] keys: {sorted(missing)}")
+
+    validate_https_url(sso["base_url"], field="base_url")
+    validate_https_url(sso["login_url"], field="login_url")
+    validate_https_url(sso["success_url_pattern"], field="success_url_pattern")
+    validate_root_relative_endpoint(
+        sso["validation_endpoint"], field="validation_endpoint"
+    )
+
+    domains = sso["cookie_domains"]
+    if (
+        not isinstance(domains, list)
+        or not domains
+        or not all(isinstance(d, str) for d in domains)
+    ):
+        raise SsoConfigError("cookie_domains must be a non-empty list of strings")
+
+    return SsoConfig(
+        profile=str(sso["profile"]),
+        base_url=sso["base_url"],
+        login_url=sso["login_url"],
+        success_url_pattern=sso["success_url_pattern"],
+        cookie_domains=tuple(domains),
+        validation_endpoint=sso["validation_endpoint"],
+        session_filename=sso.get("session_filename"),
+        ttl_hint_minutes=sso.get("ttl_hint_minutes"),
+    )

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/crawl_space.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/crawl_space.py
@@ -77,6 +77,7 @@ try:
     )
     from ._convert import to_markdown  # noqa: E402
     from ._links import LinkTargets  # noqa: E402
+    from ._sso_config import load_sso_config  # noqa: E402
 except ModuleNotFoundError as _import_exc:  # noqa: E402
     # A missing module here is a non-secret dependency (e.g. httpx);
     # `credbroker` is imported lazily inside load_credentials(), so its
@@ -387,20 +388,38 @@ async def _run_check(client: ConfluenceClient, flavor: str) -> int:
 
 
 async def main_async(args: argparse.Namespace) -> int:
+    # Auth selector (RFC-0035): sso-config.toml with auth_default = "sso-cookie"
+    # routes to the cookie path; absent or "creds" → today's token path unchanged.
     try:
-        creds: Credentials = load_credentials()
+        sso_config = load_sso_config()
+    except Exception as exc:  # noqa: BLE001 — malformed SSO config → fail closed
+        log.error("%s", exc)
+        return EXIT_USER_ACTION
+
+    try:
+        if sso_config is not None:
+            client = ConfluenceClient.from_sso_cookies(
+                sso_config,
+                concurrency=args.concurrency,
+                min_delay_ms=args.min_delay_ms,
+            )
+            flavor = "server"
+        else:
+            creds: Credentials = load_credentials()
+            client = ConfluenceClient(
+                creds,
+                concurrency=args.concurrency,
+                min_delay_ms=args.min_delay_ms,
+                verify_tls=not args.insecure,
+            )
+            flavor = creds.flavor
     except AuthError as exc:
         log.error("%s", exc)
         return EXIT_USER_ACTION
 
-    async with ConfluenceClient(
-        creds,
-        concurrency=args.concurrency,
-        min_delay_ms=args.min_delay_ms,
-        verify_tls=not args.insecure,
-    ) as client:
+    async with client:
         if args.check:
-            return await _run_check(client, creds.flavor)
+            return await _run_check(client, flavor)
 
         if not args.space:
             log.error("--space is required unless --check is used")

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/setup_sso.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/setup_sso.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Seed the sso-broker profile from references/sso-config.toml (RFC-0035; T7).
+
+Reads and **validates** the ``[sso]`` config through the loader (which applies the
+credbroker scheme / root-relative primitives — AC3 — *before* the broker is
+touched), then drives ``sso-broker register <profile>`` with the connection
+parameters from the file. No cookie value is ever passed on argv — only validated
+connection parameters (RFC-0013 § 1 path-not-value; AC14). The headed-browser
+capture and at-rest storage are the unchanged broker's job.
+
+Run once after an enterprise pre-bakes ``references/sso-config.toml`` with
+``auth_default = "sso-cookie"``::
+
+    python scripts/setup_sso.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Make sibling modules importable when run as ``python scripts/setup_sso.py`` and
+# append the credbroker user-scope floor (lowest precedence) so the loader's
+# validation primitives resolve in a no-repo install. (Mirrors jira.py.)
+_here = Path(__file__).resolve().parent
+if str(_here) not in sys.path:
+    sys.path.insert(0, str(_here))
+_floor = Path("~/.agentbundle/lib").expanduser()
+if _floor.is_dir() and str(_floor) not in sys.path:
+    sys.path.append(str(_floor))
+
+import subprocess  # noqa: E402
+
+from _sso_config import SsoConfig, load_sso_config  # noqa: E402
+
+
+def _broker_path() -> Path:
+    return Path.home() / ".agentbundle" / "bin" / "sso-broker.py"
+
+
+def build_register_argv(broker: Path, cfg: SsoConfig) -> list[str]:
+    """Translate a validated SsoConfig into a ``sso-broker register`` argv.
+
+    Only connection parameters cross argv — never a cookie value.
+    """
+    argv = [
+        sys.executable,
+        str(broker),
+        "register",
+        cfg.profile,
+        "--login-url",
+        cfg.login_url,
+        "--success-url-pattern",
+        cfg.success_url_pattern,
+        "--validation-endpoint",
+        cfg.validation_endpoint,
+    ]
+    for domain in cfg.cookie_domains:
+        argv += ["--cookie-domain", domain]
+    if cfg.session_filename:
+        argv += ["--session-filename", cfg.session_filename]
+    if cfg.ttl_hint_minutes:
+        argv += ["--ttl-hint-minutes", str(cfg.ttl_hint_minutes)]
+    return argv
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        cfg = load_sso_config()  # validates (AC3) before we touch the broker
+    except Exception as exc:  # noqa: BLE001 — malformed config → don't register
+        print(f"error: invalid sso-config.toml: {exc}", file=sys.stderr)
+        return 2
+
+    if cfg is None:
+        print(
+            'sso-config.toml: auth_default = "creds" — nothing to register '
+            "(token auth is in effect).",
+            file=sys.stderr,
+        )
+        return 0
+
+    broker = _broker_path()
+    if not broker.is_file():
+        print(
+            f"error: sso-broker not installed at {broker}; install the "
+            "credential-brokers pack first.",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(
+        f"running: sso-broker register {cfg.profile} "
+        "(opens a headed browser for SSO sign-in; the cookie jar is captured and "
+        "stored by the broker — no cookie value passes through this helper).",
+        file=sys.stderr,
+    )
+    return subprocess.run(build_register_argv(broker, cfg)).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/test_setup_sso.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/test_setup_sso.py
@@ -1,0 +1,89 @@
+"""setup_sso helper — seed the broker profile from the file (spec task T7; AC14).
+
+Goal-based: the helper reads the validated config and drives `sso-broker register`
+with connection params from the file (no cookie value on argv), and a malformed
+config is rejected *before* register is invoked.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import setup_sso
+from _sso_config import SsoConfig
+
+CFG = SsoConfig(
+    profile="jira",
+    base_url="https://jira.corp.example.com",
+    login_url="https://sso.corp.example.com/login",
+    success_url_pattern="https://jira.corp.example.com/secure/Dashboard.jspa",
+    cookie_domains=("jira.corp.example.com", "corp.example.com"),
+    validation_endpoint="/rest/api/2/myself",
+    session_filename="jira-session.json",
+    ttl_hint_minutes=480,
+)
+
+
+def test_build_register_argv_carries_connection_params_no_cookie(tmp_path):
+    broker = tmp_path / "sso-broker.py"
+    argv = setup_sso.build_register_argv(broker, CFG)
+
+    assert argv[2:4] == ["register", "jira"]
+    assert argv[argv.index("--login-url") + 1] == CFG.login_url
+    assert argv[argv.index("--validation-endpoint") + 1] == "/rest/api/2/myself"
+    # one --cookie-domain per declared domain
+    assert argv.count("--cookie-domain") == 2
+    assert "corp.example.com" in argv and "jira.corp.example.com" in argv
+    assert argv[argv.index("--ttl-hint-minutes") + 1] == "480"
+    # No cookie *value* shape anywhere on argv (AC14 path-not-value).
+    assert not any(token in part for part in argv for token in ("JSESSIONID", "Cookie:", "crowd.token"))
+
+
+def test_main_creds_default_is_noop(monkeypatch):
+    # Real reference file is creds → load_sso_config() returns None; register
+    # must NOT be invoked.
+    called = {"run": False}
+
+    def _no_run(*a, **k):
+        called["run"] = True
+        raise AssertionError("subprocess.run must not be called on the creds path")
+
+    monkeypatch.setattr(setup_sso.subprocess, "run", _no_run)
+    assert setup_sso.main() == 0
+    assert called["run"] is False
+
+
+def test_main_rejects_malformed_config_before_register(monkeypatch):
+    def _raise():
+        raise ValueError("non-https base_url")
+
+    monkeypatch.setattr(setup_sso, "load_sso_config", _raise)
+
+    def _no_run(*a, **k):
+        raise AssertionError("register must not run when the config is malformed")
+
+    monkeypatch.setattr(setup_sso.subprocess, "run", _no_run)
+    assert setup_sso.main() == 2
+
+
+def test_main_drives_register_when_configured(monkeypatch, tmp_path):
+    broker = tmp_path / "sso-broker.py"
+    broker.write_text("# fake", encoding="utf-8")
+    monkeypatch.setattr(setup_sso, "load_sso_config", lambda: CFG)
+    monkeypatch.setattr(setup_sso, "_broker_path", lambda: broker)
+
+    seen = {}
+
+    class _Result:
+        returncode = 0
+
+    def _capture(argv, *a, **k):
+        seen["argv"] = list(argv)
+        return _Result()
+
+    monkeypatch.setattr(setup_sso.subprocess, "run", _capture)
+    assert setup_sso.main() == 0
+    assert "register" in seen["argv"] and "jira" in seen["argv"]
+    assert str(broker) in seen["argv"]

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/test_sso_client.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/test_sso_client.py
@@ -193,3 +193,34 @@ def test_token_path_unchanged(monkeypatch):
     req = seen[0]
     assert req.headers["authorization"] == "Bearer TOK"
     assert "cookie" not in {k.lower() for k in req.headers}
+
+
+def test_token_path_follows_redirects(monkeypatch):
+    # Token path keeps follow_redirects=True; cookie path disables it (AC20).
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        if len(seen) == 1:
+            return httpx.Response(
+                302,
+                headers={"Location": "https://confluence.corp.example.com/rest/api/user/current"},
+            )
+        return httpx.Response(200, json={"type": "known"})
+
+    mock = httpx.MockTransport(handler)
+    real = httpx.AsyncClient
+    monkeypatch.setattr(
+        _client.httpx, "AsyncClient",
+        lambda *a, **k: real(*a, **{**k, "transport": mock}),
+    )
+    creds = _client.Credentials(
+        base_url="https://confluence.corp.example.com", token="TOK", flavor="server", email=None
+    )
+
+    async def go():
+        async with _client.ConfluenceClient(creds) as client:
+            await client.whoami()
+
+    asyncio.run(go())
+    assert len(seen) == 2  # redirect followed on the token path

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/test_sso_client.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/test_sso_client.py
@@ -1,0 +1,195 @@
+"""confluence-crawler cookie-path client — mock-transport security contract (T6).
+
+Mirrors the jira T5 contract (AC4/5/6/7/8/10/11/13/20). AC9 differs:
+confluence-crawler has no raw() escape hatch, so the GET/HEAD allowlist is asserted
+directly on the _request chokepoint's method argument.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import httpx
+import pytest
+
+import _client
+from _sso_config import SsoConfig
+
+pytest.importorskip("credbroker")
+import credbroker  # noqa: E402
+
+JAR_COOKIES = [
+    {"name": "JSESSIONID", "domain": "confluence.corp.example.com", "value": "sess1", "path": "/"},
+    {"name": "crowd.token_key", "domain": ".corp.example.com", "value": "tok1", "path": "/"},
+    {"name": "_ga", "domain": ".doubleclick.net", "value": "analytics", "path": "/"},
+    {"name": "near", "domain": "evil-corp.example.com", "value": "nearmiss", "path": "/"},
+]
+
+SSO = SsoConfig(
+    profile="confluence",
+    base_url="https://confluence.corp.example.com",
+    login_url="https://sso.corp.example.com/login",
+    success_url_pattern="https://confluence.corp.example.com/dashboard.action",
+    cookie_domains=("corp.example.com",),
+    validation_endpoint="/rest/api/space",
+)
+
+
+@pytest.fixture()
+def broker_jar(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path
+    bin_dir = home / ".agentbundle" / "bin"
+    bin_dir.mkdir(parents=True)
+    jar = home / "session.jar"
+    jar.write_text(json.dumps(JAR_COOKIES), encoding="utf-8")
+    (bin_dir / "sso-broker.py").write_text(
+        "import sys\n" f"sys.stdout.write({str(jar)!r} + '\\n')\n" "sys.exit(0)\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(credbroker._sso.Path, "home", staticmethod(lambda: home))
+    return jar
+
+
+def _cookie_client(monkeypatch, handler, sso: SsoConfig = SSO) -> _client.ConfluenceClient:
+    mock = httpx.MockTransport(handler)
+    real = httpx.AsyncClient
+    monkeypatch.setattr(
+        _client.httpx,
+        "AsyncClient",
+        lambda *a, **k: real(*a, **{**k, "transport": mock}),
+    )
+    return _client.ConfluenceClient.from_sso_cookies(sso)
+
+
+def test_no_authorization_header_and_confined_cookies(broker_jar, monkeypatch):
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={"type": "known"})
+
+    async def go():
+        async with _cookie_client(monkeypatch, handler) as client:
+            await client.whoami()
+
+    asyncio.run(go())
+    req = seen[0]
+    assert "authorization" not in {k.lower() for k in req.headers}  # AC7
+    cookie = req.headers.get("cookie", "")
+    assert "JSESSIONID=sess1" in cookie and "crowd.token_key=tok1" in cookie
+    assert "_ga" not in cookie and "near" not in cookie  # AC4/AC5
+
+
+@pytest.mark.parametrize("method", ["POST", "PUT", "DELETE"])
+def test_writes_refused_at_chokepoint(broker_jar, monkeypatch, method):
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200)
+
+    async def go():
+        async with _cookie_client(monkeypatch, handler) as client:
+            with pytest.raises(_client.ConfluenceError, match="writes over SSO-cookie auth"):
+                await client._request(method, "/rest/api/content")
+
+    asyncio.run(go())
+    assert seen == []
+
+
+def test_off_domain_redirect_not_followed(broker_jar, monkeypatch):
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(302, headers={"Location": "https://evil.example.net/steal"})
+
+    async def go():
+        async with _cookie_client(monkeypatch, handler) as client:
+            with pytest.raises(_client.AuthError):
+                await client.whoami()
+
+    asyncio.run(go())
+    assert len(seen) == 1
+    assert seen[0].url.host == "confluence.corp.example.com"
+
+
+def test_401_surfaces_reregister_without_cookie_value(broker_jar, monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401)
+
+    async def go():
+        async with _cookie_client(monkeypatch, handler) as client:
+            with pytest.raises(_client.AuthError) as exc:
+                await client.whoami()
+            return str(exc.value)
+
+    msg = asyncio.run(go())
+    assert "sso-broker register confluence" in msg
+    assert "sess1" not in msg and "tok1" not in msg
+
+
+def test_base_host_outside_cookie_domains_fails_closed(broker_jar, monkeypatch):
+    bad = replace(SSO, base_url="https://confluence.evil.net")
+    with pytest.raises(_client.AuthError):
+        _cookie_client(monkeypatch, lambda r: httpx.Response(200), bad)
+
+
+def test_non_https_base_url_fails_closed(broker_jar, monkeypatch):
+    bad = replace(SSO, base_url="http://confluence.corp.example.com")
+    with pytest.raises(_client.AuthError, match="must be https"):
+        _cookie_client(monkeypatch, lambda r: httpx.Response(200), bad)
+
+
+def test_jar_not_rewritten(broker_jar, monkeypatch):
+    before = broker_jar.read_bytes()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"type": "known"})
+
+    async def go():
+        async with _cookie_client(monkeypatch, handler) as client:
+            await client.whoami()
+
+    asyncio.run(go())
+    assert broker_jar.read_bytes() == before
+
+
+def test_ca_bundle_precedence(monkeypatch):
+    monkeypatch.setenv("SSL_CERT_FILE", "/etc/ssl/sslcert.pem")
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", "/etc/ssl/requests.pem")
+    cafile, _ = _client._sso_cafile_capath()
+    assert cafile == "/etc/ssl/sslcert.pem"
+    monkeypatch.delenv("SSL_CERT_FILE")
+    cafile, _ = _client._sso_cafile_capath()
+    assert cafile == "/etc/ssl/requests.pem"
+
+
+def test_token_path_unchanged(monkeypatch):
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={"type": "known"})
+
+    mock = httpx.MockTransport(handler)
+    real = httpx.AsyncClient
+    monkeypatch.setattr(
+        _client.httpx, "AsyncClient",
+        lambda *a, **k: real(*a, **{**k, "transport": mock}),
+    )
+    creds = _client.Credentials(
+        base_url="https://confluence.corp.example.com", token="TOK", flavor="server", email=None
+    )
+
+    async def go():
+        async with _client.ConfluenceClient(creds) as client:
+            await client.whoami()
+
+    asyncio.run(go())
+    req = seen[0]
+    assert req.headers["authorization"] == "Bearer TOK"
+    assert "cookie" not in {k.lower() for k in req.headers}

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/test_sso_config.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/test_sso_config.py
@@ -84,6 +84,32 @@ def test_fail_closed_on_malformed_values(tmp_path: Path, mutation: tuple[str, st
         load_sso_config(_write(tmp_path, body))
 
 
+def test_over_broad_single_label_cookie_domain_rejected(tmp_path: Path) -> None:
+    body = _VALID_COOKIE.replace(
+        'cookie_domains = ["jira.corp.example.com"]', 'cookie_domains = ["com"]'
+    )
+    with pytest.raises(SsoConfigError):
+        load_sso_config(_write(tmp_path, body))
+
+
+def test_base_host_outside_cookie_domains_rejected(tmp_path: Path) -> None:
+    body = _VALID_COOKIE.replace(
+        'cookie_domains = ["jira.corp.example.com"]',
+        'cookie_domains = ["other.example.com"]',
+    )
+    with pytest.raises(SsoConfigError):
+        load_sso_config(_write(tmp_path, body))
+
+
+def test_session_filename_with_separator_rejected(tmp_path: Path) -> None:
+    body = _VALID_COOKIE.replace(
+        'session_filename = "jira-session.json"',
+        'session_filename = "../../evil.json"',
+    )
+    with pytest.raises(SsoConfigError):
+        load_sso_config(_write(tmp_path, body))
+
+
 def test_unknown_sso_key_rejected(tmp_path: Path) -> None:
     body = _VALID_COOKIE.replace(
         'ttl_hint_minutes = 480', 'ttl_hint_minutes = 480\nrogue_key = "x"'

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/test_sso_config.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/test_sso_config.py
@@ -1,0 +1,114 @@
+"""SSO config loader + selector (spec task T3; AC3, AC12, AC13, fail-closed AC2).
+
+Exercises the per-skill loader against the real placeholder reference file and a
+table of crafted fixtures. Requires ``credbroker`` (the validation primitives) on
+the path — pip-installed in CI.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+import _sso_config
+from _sso_config import SsoConfig, load_sso_config
+
+pytest.importorskip("credbroker")
+from credbroker import SsoConfigError  # noqa: E402
+
+
+_VALID_COOKIE = textwrap.dedent(
+    """
+    auth_default = "sso-cookie"
+
+    [sso]
+    profile = "jira"
+    base_url = "https://jira.corp.example.com"
+    login_url = "https://sso.corp.example.com/login"
+    success_url_pattern = "https://jira.corp.example.com/secure/Dashboard.jspa"
+    cookie_domains = ["jira.corp.example.com"]
+    validation_endpoint = "/rest/api/2/myself"
+    session_filename = "jira-session.json"
+    ttl_hint_minutes = 480
+    """
+)
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    p = tmp_path / "sso-config.toml"
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+def test_real_reference_file_is_creds_path() -> None:
+    # Upstream placeholder: auth_default = "creds" → None (token path). AC12/AC13.
+    assert load_sso_config() is None
+
+
+def test_absent_file_is_creds_path(tmp_path: Path) -> None:
+    assert load_sso_config(tmp_path / "nope.toml") is None
+
+
+def test_explicit_creds_default_is_none(tmp_path: Path) -> None:
+    cfg = _write(tmp_path, 'auth_default = "creds"\n[sso]\nprofile = "x"\n')
+    assert load_sso_config(cfg) is None
+
+
+def test_valid_sso_cookie_config_parses(tmp_path: Path) -> None:
+    cfg = load_sso_config(_write(tmp_path, _VALID_COOKIE))
+    assert isinstance(cfg, SsoConfig)
+    assert cfg.profile == "jira"
+    assert cfg.base_url == "https://jira.corp.example.com"
+    assert cfg.cookie_domains == ("jira.corp.example.com",)
+    assert cfg.validation_endpoint == "/rest/api/2/myself"
+    assert cfg.ttl_hint_minutes == 480
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        ('base_url = "https://jira.corp.example.com"', 'base_url = "http://jira.corp.example.com"'),
+        ('login_url = "https://sso.corp.example.com/login"', 'login_url = "ftp://sso.corp.example.com"'),
+        ('success_url_pattern = "https://jira.corp.example.com/secure/Dashboard.jspa"', 'success_url_pattern = "jira.corp.example.com/x"'),
+        ('validation_endpoint = "/rest/api/2/myself"', 'validation_endpoint = "https://jira.corp.example.com/rest"'),
+        ('validation_endpoint = "/rest/api/2/myself"', 'validation_endpoint = "//evil.example.com/rest"'),
+        ('cookie_domains = ["jira.corp.example.com"]', "cookie_domains = []"),
+    ],
+)
+def test_fail_closed_on_malformed_values(tmp_path: Path, mutation: tuple[str, str]) -> None:
+    old, new = mutation
+    body = _VALID_COOKIE.replace(old, new)
+    with pytest.raises(SsoConfigError):
+        load_sso_config(_write(tmp_path, body))
+
+
+def test_unknown_sso_key_rejected(tmp_path: Path) -> None:
+    body = _VALID_COOKIE.replace(
+        'ttl_hint_minutes = 480', 'ttl_hint_minutes = 480\nrogue_key = "x"'
+    )
+    with pytest.raises(SsoConfigError):
+        load_sso_config(_write(tmp_path, body))
+
+
+def test_missing_required_key_rejected(tmp_path: Path) -> None:
+    body = _VALID_COOKIE.replace(
+        'validation_endpoint = "/rest/api/2/myself"\n', ""
+    )
+    with pytest.raises(SsoConfigError):
+        load_sso_config(_write(tmp_path, body))
+
+
+def test_missing_sso_table_rejected(tmp_path: Path) -> None:
+    with pytest.raises(SsoConfigError):
+        load_sso_config(_write(tmp_path, 'auth_default = "sso-cookie"\n'))
+
+
+def test_schema_key_set_matches_reference_file() -> None:
+    # The loader's allowed-key set must cover exactly the reference file's [sso]
+    # keys (drift guard between the loader and the shipped placeholder).
+    import tomllib
+
+    data = tomllib.loads(_sso_config._DEFAULT_CONFIG_PATH.read_text(encoding="utf-8"))
+    assert set(data["sso"]) <= _sso_config._ALLOWED_SSO_KEYS

--- a/packs/atlassian/.apm/skills/jira/SKILL.md
+++ b/packs/atlassian/.apm/skills/jira/SKILL.md
@@ -4,7 +4,8 @@ description: Read and mutate Jira (Atlassian Cloud or self-hosted Server / Data 
 metadata:
   credentialed: true
   primitive-class: credentialed-cli
-  auth: creds
+  auth: sso-cookie
+  auth-fallback: creds
   namespace: jira
   keys: ["API_TOKEN"]
 ---
@@ -71,6 +72,22 @@ walks the schema interactively and writes the values where you choose.
 - If `check` exits with the "missing credentials" code, tell the
   user to run `credential-setup` skill themselves.
   It's interactive — do not run it for them.
+
+This skill is **dual-auth** (`auth: sso-cookie` with a `creds` fallback): on a
+Data Center instance behind corporate SSO it authenticates by a captured web
+session (cookie jar) resolved through the `sso-broker`; everywhere else it uses
+the token (`creds`) path above. On the SSO-cookie path:
+
+- The session cookie jar lives only under the broker's `0600` store; the skill
+  reads it in-process via the `credbroker` resolver, which returns a *path*, not
+  the bytes. **Never** read the jar file directly, print its contents, or echo
+  cookie values.
+- **Never** put a session cookie on the command line. The skill attaches cookies
+  to its HTTP client internally and sends no `Authorization` header on this path.
+- If the SSO session is missing or expired, tell the user to run
+  `python scripts/setup_sso.py` (which drives `sso-broker register`) themselves —
+  it opens a browser for interactive sign-in, so do not run any setup helper for
+  them.
 
 ### Step 1: Verify the environment
 

--- a/packs/atlassian/.apm/skills/jira/references/sso-config.toml
+++ b/packs/atlassian/.apm/skills/jira/references/sso-config.toml
@@ -1,0 +1,34 @@
+# SSO web-session cookie config (RFC-0035) — Atlassian Data Center only.
+#
+# This file is PLACEHOLDER-SHAPED upstream: auth_default = "creds", *.invalid
+# hosts, and no cookie values. With it untouched, `jira` behaves exactly as
+# today (token / `creds` auth) — the SSO-cookie path is dark until an enterprise
+# opts in.
+#
+# An enterprise pre-bakes its instance config here (a pack customization), then a
+# developer runs `python scripts/setup_sso.py` (drives `sso-broker register`)
+# once. Upgrades to a pre-baked file merge as an adapt-to-project `.upstream`
+# companion (class-2), so an org's edits survive a later catalogue release.
+#
+# auth_default selects the path: "creds" (token, the default) or "sso-cookie".
+
+auth_default = "creds"
+
+[sso]
+# The sso-broker profile name (passed to `sso-broker register/get-cookies`).
+profile = "jira"
+# Data Center base URL. https only (a bearer cookie must never travel plaintext).
+base_url = "https://jira.example.invalid"
+# Corporate SSO sign-in entry point (headed-browser capture lands here first).
+login_url = "https://sso.example.invalid/login"
+# Post-login landing URL the broker waits for to confirm a successful sign-in.
+success_url_pattern = "https://jira.example.invalid/secure/Dashboard.jspa"
+# Cookie-domain confinement: the captured jar is filtered to these at load time,
+# and the request base host must be a member. Label-boundary match.
+cookie_domains = ["jira.example.invalid"]
+# Root-relative read endpoint used to validate a live session (`sso-broker test`).
+validation_endpoint = "/rest/api/2/myself"
+# Filename for the stored session jar under the broker's 0600 floor.
+session_filename = "jira-session.json"
+# Advisory session lifetime hint (minutes); informational only.
+ttl_hint_minutes = 480

--- a/packs/atlassian/.apm/skills/jira/scripts/_client.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/_client.py
@@ -24,13 +24,19 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import json
 import logging
+import os
 import secrets
+import ssl
 from dataclasses import dataclass
-from typing import Any, AsyncIterator, Mapping
+from typing import TYPE_CHECKING, Any, AsyncIterator, Mapping
 from urllib.parse import urlparse
 
 import httpx
+
+if TYPE_CHECKING:
+    from _sso_config import SsoConfig
 
 log = logging.getLogger("jira.client")
 
@@ -76,6 +82,31 @@ def _api_prefix(flavor: str) -> str:
     return "/rest/api/3" if flavor == FLAVOR_CLOUD else "/rest/api/2"
 
 
+def _sso_cafile_capath() -> tuple[str | None, str | None]:
+    """Resolve the CA bundle file + dir for the cookie-path SSL context (AC8).
+
+    httpx (``trust_env``) natively honors ``SSL_CERT_FILE`` / ``SSL_CERT_DIR`` but
+    does **not** read ``REQUESTS_CA_BUNDLE``; we map it here. Precedence:
+    ``SSL_CERT_FILE`` wins over ``REQUESTS_CA_BUNDLE`` when both are set (the
+    native httpx env takes precedence over the requests-compat var).
+    """
+    cafile = os.environ.get("SSL_CERT_FILE") or os.environ.get("REQUESTS_CA_BUNDLE")
+    capath = os.environ.get("SSL_CERT_DIR")
+    return (cafile or None, capath or None)
+
+
+def _sso_ssl_context() -> ssl.SSLContext:
+    """SSL context for the cookie path: the system trust store *plus* any
+    ``SSL_CERT_FILE`` / ``SSL_CERT_DIR`` / ``REQUESTS_CA_BUNDLE`` the corporate
+    environment sets — loaded on top of (never clobbering) the default store, so a
+    bare ``verify=True`` can't drop the corporate CA (AC8)."""
+    ctx = ssl.create_default_context()
+    cafile, capath = _sso_cafile_capath()
+    if cafile or capath:
+        ctx.load_verify_locations(cafile=cafile, capath=capath)
+    return ctx
+
+
 class JiraClient:
     """Async wrapper around the Jira REST API.
 
@@ -100,6 +131,10 @@ class JiraClient:
         self._base = base_url.rstrip("/")
         self._flavor = credentials.flavor
         self._api = _api_prefix(self._flavor)
+        # Token path. The SSO-cookie path is built via from_sso_cookies and sets
+        # these to "sso-cookie" / the profile name; _request branches on them.
+        self._auth_mode = "creds"
+        self._profile: str | None = None
 
         if self._flavor == FLAVOR_CLOUD:
             if not credentials.email:
@@ -130,6 +165,88 @@ class JiraClient:
         # rate-limited endpoints comes from the API's own 429 + Retry-After
         # response, which the request loop honors.
         self._sem = asyncio.Semaphore(concurrency)
+
+    @classmethod
+    def from_sso_cookies(
+        cls,
+        sso_config: "SsoConfig",
+        *,
+        concurrency: int = DEFAULT_CONCURRENCY,
+        timeout_s: float = DEFAULT_TIMEOUT_S,
+    ) -> "JiraClient":
+        """Build a Data Center client authenticated by a captured SSO cookie jar.
+
+        Resolves the jar via credbroker (fail-closed, never downgrades to a
+        token), filters it to the declared ``cookie_domains`` (AC4), confirms the
+        base host is within those domains (AC6), and builds an httpx client with
+        the confined jar attached, **no** ``Authorization`` header (AC7),
+        ``follow_redirects=False`` so the session cookie is never re-attached
+        across a redirect (AC20), and the corporate proxy / trust store honored
+        (AC8). The cookie path is GET/HEAD only, enforced in ``_request`` (AC9).
+        """
+        import credbroker
+
+        base_url = sso_config.base_url
+        parsed = urlparse(base_url)
+        # Defense-in-depth https guard at construction (AC6): the cookie jar is a
+        # bearer secret, so the token path's http:// tolerance must not extend
+        # here, even though the config layer (AC3) already rejects a non-https URL.
+        if parsed.scheme != "https":
+            raise AuthError(
+                "SSO-cookie base_url must be https (the session cookie is a bearer secret)"
+            )
+        host = parsed.hostname or ""
+        # Send-host confinement (AC6) + fail-closed jar resolution (AC1/AC2). Both
+        # credbroker fail-closed paths re-raise as AuthError so the skill surfaces
+        # them as a single user-action (the remediation text is preserved).
+        try:
+            credbroker.require_host_in_cookie_domains(host, sso_config.cookie_domains)
+            jar_path = credbroker.load_sso_cookies(sso_config.profile)
+        except credbroker.SsoError as exc:
+            raise AuthError(str(exc)) from exc
+
+        # Confine the deliberately over-broad captured jar to the declared domains
+        # before attaching it (AC4); the result is never written back (AC10).
+        raw_cookies = json.loads(jar_path.read_text(encoding="utf-8"))
+        confined = credbroker.filter_jar_to_domains(
+            raw_cookies, sso_config.cookie_domains
+        )
+
+        self = cls.__new__(cls)
+        self._base = base_url.rstrip("/")
+        self._flavor = FLAVOR_SERVER  # DC only — Cloud cookie auth is out of scope
+        self._api = _api_prefix(self._flavor)
+        self._auth_mode = "sso-cookie"
+        self._profile = sso_config.profile
+
+        cookies = httpx.Cookies()
+        for c in confined:
+            # Preserve the jar's domain verbatim (keep any leading dot): httpx's
+            # cookiejar uses domain_initial_dot for subdomain matching, so a
+            # ".corp.example.com" domain cookie must keep its dot to attach to
+            # jira.corp.example.com. Stripping it would break attachment.
+            cookies.set(
+                c["name"],
+                c.get("value", ""),
+                domain=c.get("domain", ""),
+                path=c.get("path") or "/",
+            )
+
+        headers = {
+            "Accept": "application/json",
+            "User-Agent": "atlassian-jira/0.1",
+        }  # deliberately NO Authorization header on the cookie path (AC7)
+        self._client = httpx.AsyncClient(
+            base_url=self._base,
+            headers=headers,
+            cookies=cookies,
+            timeout=timeout_s,
+            verify=_sso_ssl_context(),
+            trust_env=True,  # corporate proxy + SSL_CERT_FILE/SSL_CERT_DIR (AC8)
+            follow_redirects=False,  # AC20 — never re-attach the cookie cross-host
+        )
+        self._sem = asyncio.Semaphore(concurrency)
+        return self
 
     async def __aenter__(self) -> "JiraClient":
         return self
@@ -166,6 +283,17 @@ class JiraClient:
             # of the multipart form, masking the mistake. Fail loudly.
             raise ValueError("cannot send json_body and files in the same request")
 
+        # Cookie-path write refusal (AC9). This chokepoint is the single point
+        # every call funnels through — including the raw() escape hatch — so a
+        # GET/HEAD allowlist here covers future verbs by construction. Raised
+        # before any request reaches the wire (the transport records zero
+        # requests for a refused verb).
+        if self._auth_mode == "sso-cookie" and method.upper() not in ("GET", "HEAD"):
+            raise JiraError(
+                "writes over SSO-cookie auth are not supported yet (RFC-0035 v1); "
+                "use a personal access token, or wait for the XSRF follow-on"
+            )
+
         async with self._sem:
             last_exc: Exception | None = None
             last_status: int | None = None
@@ -185,10 +313,29 @@ class JiraClient:
                     continue
 
                 if resp.status_code == 401:
+                    if self._auth_mode == "sso-cookie":
+                        # Stop using the known-stale jar — no further
+                        # cookie-bearing request with this session (AC11). The
+                        # remediation names the profile, never the cookie bytes.
+                        self._client.cookies.clear()
+                        raise AuthError(
+                            f"401 Unauthorized — SSO session expired; run "
+                            f"'sso-broker register {self._profile}' to re-authenticate"
+                        )
                     raise AuthError(
                         "401 Unauthorized — Jira credentials are missing, "
                         "invalid, or expired. Re-run "
                         "`credential-setup` skill."
+                    )
+                if self._auth_mode == "sso-cookie" and 300 <= resp.status_code < 400:
+                    # follow_redirects is disabled on the cookie path (AC20), so a
+                    # 30x is surfaced, never followed (which would re-attach the
+                    # session cookie to the redirect target). A redirect to login
+                    # is the DC expired-session signal.
+                    raise AuthError(
+                        f"SSO session may have expired (HTTP {resp.status_code} "
+                        f"redirect, not followed); run 'sso-broker register "
+                        f"{self._profile}' to re-authenticate"
                     )
                 if resp.status_code == 403:
                     # On Cloud, 403 with X-Seraph-LoginReason often means

--- a/packs/atlassian/.apm/skills/jira/scripts/_sso_config.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/_sso_config.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 
 import tomllib
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from urllib.parse import urlsplit
 
 # The atlassian ``[sso]`` connection-param schema. The structural lint
 # (``tools/lint-sso-config.py``) pins this key set; keep the two in sync.
@@ -83,6 +84,7 @@ def load_sso_config(config_path: Path | None = None) -> SsoConfig | None:
     # skill bootstrap appends to sys.path is in place before resolution.
     from credbroker import (
         SsoConfigError,
+        domain_in_cookie_domains,
         validate_https_url,
         validate_root_relative_endpoint,
     )
@@ -114,6 +116,40 @@ def load_sso_config(config_path: Path | None = None) -> SsoConfig | None:
         or not all(isinstance(d, str) for d in domains)
     ):
         raise SsoConfigError("cookie_domains must be a non-empty list of strings")
+    # Reject a dangerously broad confinement set: a single-label domain (no dot,
+    # e.g. "com") would admit the over-broad captured jar against any corporate
+    # host. The instance domain must have at least one label boundary.
+    for dom in domains:
+        if "." not in dom.strip("."):
+            raise SsoConfigError(
+                f"cookie_domains entry {dom!r} is too broad (single-label); "
+                f"declare the instance domain (e.g. corp.example.com)"
+            )
+    # The base host must itself be within cookie_domains — the runtime client
+    # also checks this, but pinning it at load fails a typo'd config closed early.
+    base_host = urlsplit(sso["base_url"]).hostname or ""
+    if not domain_in_cookie_domains(base_host, domains):
+        raise SsoConfigError(
+            f"base_url host {base_host!r} is not within cookie_domains {domains!r}"
+        )
+
+    # session_filename is forwarded to `sso-broker register --session-filename`;
+    # confine it to a bare filename so an adopter-supplied value can't seed a
+    # path-traversal into the broker's store.
+    session_filename = sso.get("session_filename")
+    if session_filename is not None:
+        bad = (
+            session_filename in ("", ".", "..")
+            or "/" in session_filename
+            or "\\" in session_filename
+            or PurePosixPath(session_filename).name != session_filename
+            or PureWindowsPath(session_filename).name != session_filename
+        )
+        if bad:
+            raise SsoConfigError(
+                f"session_filename must be a bare filename (no path separators): "
+                f"{session_filename!r}"
+            )
 
     return SsoConfig(
         profile=str(sso["profile"]),
@@ -122,6 +158,6 @@ def load_sso_config(config_path: Path | None = None) -> SsoConfig | None:
         success_url_pattern=sso["success_url_pattern"],
         cookie_domains=tuple(domains),
         validation_endpoint=sso["validation_endpoint"],
-        session_filename=sso.get("session_filename"),
+        session_filename=session_filename,
         ttl_hint_minutes=sso.get("ttl_hint_minutes"),
     )

--- a/packs/atlassian/.apm/skills/jira/scripts/_sso_config.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/_sso_config.py
@@ -1,0 +1,127 @@
+"""SSO config loader + ``auth_default`` selector (RFC-0035; spec task T3).
+
+Reads ``references/sso-config.toml``, validates the ``[sso]`` connection params
+with the shared ``credbroker`` confinement primitives, and decides the auth path.
+The *schema* (the ``[sso]`` key set) is consumer-specific and lives here; the
+security *primitives* it calls (https-only / root-relative guards) are
+single-sourced in ``credbroker`` so they cannot drift between consumers.
+
+The selector is the return value: ``None`` means the ``creds`` (token) path —
+returned when the file is absent or ``auth_default = "creds"`` — and an
+:class:`SsoConfig` means the SSO-cookie path. When ``auth_default = "sso-cookie"``
+the ``[sso]`` table is validated and a malformed value raises (fail closed; never
+downgrade to ``creds``).
+"""
+
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+# The atlassian ``[sso]`` connection-param schema. The structural lint
+# (``tools/lint-sso-config.py``) pins this key set; keep the two in sync.
+_ALLOWED_SSO_KEYS = frozenset(
+    {
+        "profile",
+        "base_url",
+        "login_url",
+        "success_url_pattern",
+        "cookie_domains",
+        "validation_endpoint",
+        "session_filename",
+        "ttl_hint_minutes",
+    }
+)
+_REQUIRED_SSO_KEYS = frozenset(
+    {
+        "profile",
+        "base_url",
+        "login_url",
+        "success_url_pattern",
+        "cookie_domains",
+        "validation_endpoint",
+    }
+)
+
+_DEFAULT_CONFIG_PATH = (
+    Path(__file__).resolve().parent.parent / "references" / "sso-config.toml"
+)
+
+
+@dataclass(frozen=True)
+class SsoConfig:
+    """Validated ``[sso]`` connection config for the cookie path."""
+
+    profile: str
+    base_url: str
+    login_url: str
+    success_url_pattern: str
+    cookie_domains: tuple[str, ...]
+    validation_endpoint: str
+    session_filename: str | None = None
+    ttl_hint_minutes: int | None = None
+
+
+def load_sso_config(config_path: Path | None = None) -> SsoConfig | None:
+    """Resolve the auth path from ``sso-config.toml``.
+
+    :returns: ``None`` for the ``creds`` (token) path (file absent or
+        ``auth_default = "creds"``); an :class:`SsoConfig` for the SSO-cookie path.
+    :raises credbroker.SsoConfigError: ``auth_default = "sso-cookie"`` but the
+        ``[sso]`` table is missing, has unknown/missing keys, or carries a
+        non-``https`` URL or non-root-relative endpoint (fail closed).
+    """
+    path = config_path or _DEFAULT_CONFIG_PATH
+    if not path.is_file():
+        return None
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    if data.get("auth_default", "creds") != "sso-cookie":
+        return None
+
+    # Imported here (not at module top) so the credbroker user-scope floor the
+    # skill bootstrap appends to sys.path is in place before resolution.
+    from credbroker import (
+        SsoConfigError,
+        validate_https_url,
+        validate_root_relative_endpoint,
+    )
+
+    sso = data.get("sso")
+    if not isinstance(sso, dict):
+        raise SsoConfigError(
+            "auth_default = 'sso-cookie' but the [sso] table is missing"
+        )
+
+    unknown = set(sso) - _ALLOWED_SSO_KEYS
+    if unknown:
+        raise SsoConfigError(f"unknown [sso] keys: {sorted(unknown)}")
+    missing = _REQUIRED_SSO_KEYS - set(sso)
+    if missing:
+        raise SsoConfigError(f"missing required [sso] keys: {sorted(missing)}")
+
+    validate_https_url(sso["base_url"], field="base_url")
+    validate_https_url(sso["login_url"], field="login_url")
+    validate_https_url(sso["success_url_pattern"], field="success_url_pattern")
+    validate_root_relative_endpoint(
+        sso["validation_endpoint"], field="validation_endpoint"
+    )
+
+    domains = sso["cookie_domains"]
+    if (
+        not isinstance(domains, list)
+        or not domains
+        or not all(isinstance(d, str) for d in domains)
+    ):
+        raise SsoConfigError("cookie_domains must be a non-empty list of strings")
+
+    return SsoConfig(
+        profile=str(sso["profile"]),
+        base_url=sso["base_url"],
+        login_url=sso["login_url"],
+        success_url_pattern=sso["success_url_pattern"],
+        cookie_domains=tuple(domains),
+        validation_endpoint=sso["validation_endpoint"],
+        session_filename=sso.get("session_filename"),
+        ttl_hint_minutes=sso.get("ttl_hint_minutes"),
+    )

--- a/packs/atlassian/.apm/skills/jira/scripts/jira.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/jira.py
@@ -85,6 +85,7 @@ try:
         JiraError,
         load_credentials,
     )
+    from ._sso_config import load_sso_config  # noqa: E402
 except ModuleNotFoundError as _import_exc:  # noqa: E402
     # A missing module here is a non-secret dependency (e.g. httpx);
     # `credbroker` is imported lazily inside load_credentials(), so its
@@ -707,17 +708,27 @@ def _csv_scalar(value: Any) -> str:
 
 
 async def _run(args: argparse.Namespace) -> int:
+    # Auth selector (RFC-0035): an sso-config.toml with auth_default = "sso-cookie"
+    # routes to the cookie path; absent or "creds" → today's token path unchanged.
     try:
-        credentials = load_credentials()
+        sso_config = load_sso_config()
+    except Exception as exc:  # noqa: BLE001 — malformed SSO config → fail closed
+        print(f"error: {exc}", file=sys.stderr)
+        return EXIT_USER_ACTION
+
+    try:
+        if sso_config is not None:
+            client = JiraClient.from_sso_cookies(sso_config)
+        else:
+            credentials = load_credentials()
+            client = JiraClient(credentials, verify_tls=not args.insecure)
     except AuthError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return EXIT_USER_ACTION
 
     writer = OutputWriter(args.format, args.output)
     try:
-        async with JiraClient(
-            credentials, verify_tls=not args.insecure
-        ) as client:
+        async with client:
             cmd = args.command
             if cmd == "check":
                 return await _cmd_check(client)

--- a/packs/atlassian/.apm/skills/jira/scripts/setup_sso.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/setup_sso.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Seed the sso-broker profile from references/sso-config.toml (RFC-0035; T7).
+
+Reads and **validates** the ``[sso]`` config through the loader (which applies the
+credbroker scheme / root-relative primitives — AC3 — *before* the broker is
+touched), then drives ``sso-broker register <profile>`` with the connection
+parameters from the file. No cookie value is ever passed on argv — only validated
+connection parameters (RFC-0013 § 1 path-not-value; AC14). The headed-browser
+capture and at-rest storage are the unchanged broker's job.
+
+Run once after an enterprise pre-bakes ``references/sso-config.toml`` with
+``auth_default = "sso-cookie"``::
+
+    python scripts/setup_sso.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Make sibling modules importable when run as ``python scripts/setup_sso.py`` and
+# append the credbroker user-scope floor (lowest precedence) so the loader's
+# validation primitives resolve in a no-repo install. (Mirrors jira.py.)
+_here = Path(__file__).resolve().parent
+if str(_here) not in sys.path:
+    sys.path.insert(0, str(_here))
+_floor = Path("~/.agentbundle/lib").expanduser()
+if _floor.is_dir() and str(_floor) not in sys.path:
+    sys.path.append(str(_floor))
+
+import subprocess  # noqa: E402
+
+from _sso_config import SsoConfig, load_sso_config  # noqa: E402
+
+
+def _broker_path() -> Path:
+    return Path.home() / ".agentbundle" / "bin" / "sso-broker.py"
+
+
+def build_register_argv(broker: Path, cfg: SsoConfig) -> list[str]:
+    """Translate a validated SsoConfig into a ``sso-broker register`` argv.
+
+    Only connection parameters cross argv — never a cookie value.
+    """
+    argv = [
+        sys.executable,
+        str(broker),
+        "register",
+        cfg.profile,
+        "--login-url",
+        cfg.login_url,
+        "--success-url-pattern",
+        cfg.success_url_pattern,
+        "--validation-endpoint",
+        cfg.validation_endpoint,
+    ]
+    for domain in cfg.cookie_domains:
+        argv += ["--cookie-domain", domain]
+    if cfg.session_filename:
+        argv += ["--session-filename", cfg.session_filename]
+    if cfg.ttl_hint_minutes:
+        argv += ["--ttl-hint-minutes", str(cfg.ttl_hint_minutes)]
+    return argv
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        cfg = load_sso_config()  # validates (AC3) before we touch the broker
+    except Exception as exc:  # noqa: BLE001 — malformed config → don't register
+        print(f"error: invalid sso-config.toml: {exc}", file=sys.stderr)
+        return 2
+
+    if cfg is None:
+        print(
+            'sso-config.toml: auth_default = "creds" — nothing to register '
+            "(token auth is in effect).",
+            file=sys.stderr,
+        )
+        return 0
+
+    broker = _broker_path()
+    if not broker.is_file():
+        print(
+            f"error: sso-broker not installed at {broker}; install the "
+            "credential-brokers pack first.",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(
+        f"running: sso-broker register {cfg.profile} "
+        "(opens a headed browser for SSO sign-in; the cookie jar is captured and "
+        "stored by the broker — no cookie value passes through this helper).",
+        file=sys.stderr,
+    )
+    return subprocess.run(build_register_argv(broker, cfg)).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packs/atlassian/.apm/skills/jira/scripts/test_setup_sso.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/test_setup_sso.py
@@ -1,0 +1,89 @@
+"""setup_sso helper — seed the broker profile from the file (spec task T7; AC14).
+
+Goal-based: the helper reads the validated config and drives `sso-broker register`
+with connection params from the file (no cookie value on argv), and a malformed
+config is rejected *before* register is invoked.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import setup_sso
+from _sso_config import SsoConfig
+
+CFG = SsoConfig(
+    profile="jira",
+    base_url="https://jira.corp.example.com",
+    login_url="https://sso.corp.example.com/login",
+    success_url_pattern="https://jira.corp.example.com/secure/Dashboard.jspa",
+    cookie_domains=("jira.corp.example.com", "corp.example.com"),
+    validation_endpoint="/rest/api/2/myself",
+    session_filename="jira-session.json",
+    ttl_hint_minutes=480,
+)
+
+
+def test_build_register_argv_carries_connection_params_no_cookie(tmp_path):
+    broker = tmp_path / "sso-broker.py"
+    argv = setup_sso.build_register_argv(broker, CFG)
+
+    assert argv[2:4] == ["register", "jira"]
+    assert argv[argv.index("--login-url") + 1] == CFG.login_url
+    assert argv[argv.index("--validation-endpoint") + 1] == "/rest/api/2/myself"
+    # one --cookie-domain per declared domain
+    assert argv.count("--cookie-domain") == 2
+    assert "corp.example.com" in argv and "jira.corp.example.com" in argv
+    assert argv[argv.index("--ttl-hint-minutes") + 1] == "480"
+    # No cookie *value* shape anywhere on argv (AC14 path-not-value).
+    assert not any(token in part for part in argv for token in ("JSESSIONID", "Cookie:", "crowd.token"))
+
+
+def test_main_creds_default_is_noop(monkeypatch):
+    # Real reference file is creds → load_sso_config() returns None; register
+    # must NOT be invoked.
+    called = {"run": False}
+
+    def _no_run(*a, **k):
+        called["run"] = True
+        raise AssertionError("subprocess.run must not be called on the creds path")
+
+    monkeypatch.setattr(setup_sso.subprocess, "run", _no_run)
+    assert setup_sso.main() == 0
+    assert called["run"] is False
+
+
+def test_main_rejects_malformed_config_before_register(monkeypatch):
+    def _raise():
+        raise ValueError("non-https base_url")
+
+    monkeypatch.setattr(setup_sso, "load_sso_config", _raise)
+
+    def _no_run(*a, **k):
+        raise AssertionError("register must not run when the config is malformed")
+
+    monkeypatch.setattr(setup_sso.subprocess, "run", _no_run)
+    assert setup_sso.main() == 2
+
+
+def test_main_drives_register_when_configured(monkeypatch, tmp_path):
+    broker = tmp_path / "sso-broker.py"
+    broker.write_text("# fake", encoding="utf-8")
+    monkeypatch.setattr(setup_sso, "load_sso_config", lambda: CFG)
+    monkeypatch.setattr(setup_sso, "_broker_path", lambda: broker)
+
+    seen = {}
+
+    class _Result:
+        returncode = 0
+
+    def _capture(argv, *a, **k):
+        seen["argv"] = list(argv)
+        return _Result()
+
+    monkeypatch.setattr(setup_sso.subprocess, "run", _capture)
+    assert setup_sso.main() == 0
+    assert "register" in seen["argv"] and "jira" in seen["argv"]
+    assert str(broker) in seen["argv"]

--- a/packs/atlassian/.apm/skills/jira/scripts/test_sso_client.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/test_sso_client.py
@@ -112,6 +112,26 @@ def test_writes_refused_records_zero_requests(broker_jar, monkeypatch, method):
     assert seen == []  # nothing reached the wire
 
 
+# --- AC9 accept arm: raw("GET") reaches the wire with confined cookies, no auth
+
+def test_raw_get_reaches_wire_with_confined_cookies(broker_jar, monkeypatch):
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={"ok": True})
+
+    async def go():
+        async with _cookie_client(monkeypatch, handler) as client:
+            await client.raw("GET", "/rest/api/2/myself")
+
+    asyncio.run(go())
+    req = seen[0]
+    assert req.method == "GET"
+    assert "authorization" not in {k.lower() for k in req.headers}
+    assert "JSESSIONID=sess1" in req.headers.get("cookie", "")
+
+
 # --- AC20: follow_redirects=False — an off-domain 302 leaks no cookie
 
 def test_off_domain_redirect_not_followed(broker_jar, monkeypatch):
@@ -228,3 +248,34 @@ def test_token_path_unchanged(monkeypatch):
     req = seen[0]
     assert req.headers["authorization"] == "Bearer TOK"
     assert "cookie" not in {k.lower() for k in req.headers}
+
+
+def test_token_path_follows_redirects(monkeypatch):
+    # The token path keeps follow_redirects=True (unchanged); the cookie path
+    # deliberately disables it (AC20). Pin the difference: a 302 is followed.
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        if len(seen) == 1:
+            return httpx.Response(
+                302, headers={"Location": "https://jira.corp.example.com/rest/api/2/myself"}
+            )
+        return httpx.Response(200, json={"name": "me"})
+
+    mock = httpx.MockTransport(handler)
+    real = httpx.AsyncClient
+    monkeypatch.setattr(
+        _client.httpx, "AsyncClient",
+        lambda *a, **k: real(*a, **{**k, "transport": mock}),
+    )
+    creds = _client.Credentials(
+        base_url="https://jira.corp.example.com", token="TOK", flavor="server", email=None
+    )
+
+    async def go():
+        async with _client.JiraClient(creds) as client:
+            await client.whoami()
+
+    asyncio.run(go())
+    assert len(seen) == 2  # redirect followed on the token path

--- a/packs/atlassian/.apm/skills/jira/scripts/test_sso_client.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/test_sso_client.py
@@ -1,0 +1,230 @@
+"""jira cookie-path client — mock-transport security contract (spec task T5).
+
+Covers AC4/AC5 (cookie confinement on the outbound request), AC6 (send-host +
+https guard at construction), AC7 (no Authorization header), AC8 (CA-bundle
+precedence), AC9 (GET/HEAD allowlist incl. raw("POST")), AC10 (jar not rewritten),
+AC11 (401 remediation, no cookie in error), AC13 (token path unchanged), AC20
+(follow_redirects=False — off-domain 302 leaks no cookie).
+
+All HTTP assertions are made on the *outbound request* via httpx.MockTransport,
+not on internal client attributes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import httpx
+import pytest
+
+import _client
+from _sso_config import SsoConfig
+
+pytest.importorskip("credbroker")
+import credbroker  # noqa: E402
+
+JAR_COOKIES = [
+    {"name": "JSESSIONID", "domain": "jira.corp.example.com", "value": "sess1", "path": "/"},
+    {"name": "crowd.token_key", "domain": ".corp.example.com", "value": "tok1", "path": "/"},
+    {"name": "_ga", "domain": ".doubleclick.net", "value": "analytics", "path": "/"},
+    {"name": "near", "domain": "evil-corp.example.com", "value": "nearmiss", "path": "/"},
+]
+
+SSO = SsoConfig(
+    profile="jira",
+    base_url="https://jira.corp.example.com",
+    login_url="https://sso.corp.example.com/login",
+    success_url_pattern="https://jira.corp.example.com/secure/Dashboard.jspa",
+    cookie_domains=("corp.example.com",),
+    validation_endpoint="/rest/api/2/myself",
+)
+
+
+@pytest.fixture()
+def broker_jar(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Fake sso-broker that prints a real jar file's path; point Path.home() at it."""
+    home = tmp_path
+    bin_dir = home / ".agentbundle" / "bin"
+    bin_dir.mkdir(parents=True)
+    jar = home / "session.jar"
+    jar.write_text(json.dumps(JAR_COOKIES), encoding="utf-8")
+    (bin_dir / "sso-broker.py").write_text(
+        "import sys\n" f"sys.stdout.write({str(jar)!r} + '\\n')\n" "sys.exit(0)\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(credbroker._sso.Path, "home", staticmethod(lambda: home))
+    return jar
+
+
+def _cookie_client(monkeypatch, handler, sso: SsoConfig = SSO) -> _client.JiraClient:
+    """Build a cookie-path JiraClient whose httpx client uses *handler* as transport."""
+    mock = httpx.MockTransport(handler)
+    real = httpx.AsyncClient
+    monkeypatch.setattr(
+        _client.httpx,
+        "AsyncClient",
+        lambda *a, **k: real(*a, **{**k, "transport": mock}),
+    )
+    return _client.JiraClient.from_sso_cookies(sso)
+
+
+# --- AC7 / AC4 / AC5: no Authorization, confined cookies on the outbound request
+
+def test_no_authorization_header_and_confined_cookies(broker_jar, monkeypatch):
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={"name": "me"})
+
+    async def go():
+        async with _cookie_client(monkeypatch, handler) as client:
+            await client.whoami()
+
+    asyncio.run(go())
+    req = seen[0]
+    assert "authorization" not in {k.lower() for k in req.headers}  # AC7
+    cookie = req.headers.get("cookie", "")
+    assert "JSESSIONID=sess1" in cookie  # in-domain (subdomain) kept
+    assert "crowd.token_key=tok1" in cookie  # in-domain (dotted) kept
+    assert "_ga" not in cookie and "near" not in cookie  # AC4/AC5 over-broad dropped
+
+
+# --- AC9: GET/HEAD allowlist refuses writes (incl. raw("POST")) before the wire
+
+@pytest.mark.parametrize("method", ["POST", "PUT", "DELETE", "PATCH"])
+def test_writes_refused_records_zero_requests(broker_jar, monkeypatch, method):
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200)
+
+    async def go():
+        async with _cookie_client(monkeypatch, handler) as client:
+            with pytest.raises(_client.JiraError, match="writes over SSO-cookie auth"):
+                await client.raw(method, "/rest/api/2/issue", json_body={})
+
+    asyncio.run(go())
+    assert seen == []  # nothing reached the wire
+
+
+# --- AC20: follow_redirects=False — an off-domain 302 leaks no cookie
+
+def test_off_domain_redirect_not_followed(broker_jar, monkeypatch):
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(302, headers={"Location": "https://evil.example.net/steal"})
+
+    async def go():
+        async with _cookie_client(monkeypatch, handler) as client:
+            with pytest.raises(_client.AuthError):
+                await client.whoami()
+
+    asyncio.run(go())
+    # Exactly one request — to the permitted host — and no follow to the off-domain
+    # target (which would re-attach the session cookie).
+    assert len(seen) == 1
+    assert seen[0].url.host == "jira.corp.example.com"
+
+
+# --- AC11: 401 surfaces the re-register remediation; no cookie value in the error
+
+def test_401_surfaces_reregister_without_cookie_value(broker_jar, monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401)
+
+    async def go():
+        async with _cookie_client(monkeypatch, handler) as client:
+            with pytest.raises(_client.AuthError) as exc:
+                await client.whoami()
+            return str(exc.value)
+
+    msg = asyncio.run(go())
+    assert "sso-broker register jira" in msg
+    assert "sess1" not in msg and "tok1" not in msg  # no cookie bytes in the error
+
+
+# --- AC6: send-host + https guards fail closed at construction
+
+def test_base_host_outside_cookie_domains_fails_closed(broker_jar, monkeypatch):
+    bad = replace(SSO, base_url="https://jira.evil.net")
+    with pytest.raises(_client.AuthError):
+        _cookie_client(monkeypatch, lambda r: httpx.Response(200), bad)
+
+
+def test_non_https_base_url_fails_closed(broker_jar, monkeypatch):
+    bad = replace(SSO, base_url="http://jira.corp.example.com")
+    with pytest.raises(_client.AuthError, match="must be https"):
+        _cookie_client(monkeypatch, lambda r: httpx.Response(200), bad)
+
+
+# --- AC10: the broker jar file is read, never rewritten
+
+def test_jar_not_rewritten(broker_jar, monkeypatch):
+    before = broker_jar.read_bytes()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"name": "me"})
+
+    async def go():
+        async with _cookie_client(monkeypatch, handler) as client:
+            await client.whoami()
+
+    asyncio.run(go())
+    assert broker_jar.read_bytes() == before
+
+
+# --- AC8: CA-bundle precedence + trust-store wiring
+
+def test_ca_bundle_precedence(monkeypatch):
+    monkeypatch.setenv("SSL_CERT_FILE", "/etc/ssl/sslcert.pem")
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", "/etc/ssl/requests.pem")
+    monkeypatch.setenv("SSL_CERT_DIR", "/etc/ssl/dir")
+    cafile, capath = _client._sso_cafile_capath()
+    assert cafile == "/etc/ssl/sslcert.pem"  # SSL_CERT_FILE wins
+    assert capath == "/etc/ssl/dir"
+
+    monkeypatch.delenv("SSL_CERT_FILE")
+    cafile, _ = _client._sso_cafile_capath()
+    assert cafile == "/etc/ssl/requests.pem"  # falls back to REQUESTS_CA_BUNDLE
+
+
+def test_ssl_context_is_built():
+    import ssl
+
+    assert isinstance(_client._sso_ssl_context(), ssl.SSLContext)
+
+
+# --- AC13: token path is byte-identical (Authorization header, no cookies)
+
+def test_token_path_unchanged(monkeypatch):
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={"name": "me"})
+
+    mock = httpx.MockTransport(handler)
+    real = httpx.AsyncClient
+    monkeypatch.setattr(
+        _client.httpx, "AsyncClient",
+        lambda *a, **k: real(*a, **{**k, "transport": mock}),
+    )
+    creds = _client.Credentials(
+        base_url="https://jira.corp.example.com", token="TOK", flavor="server", email=None
+    )
+
+    async def go():
+        async with _client.JiraClient(creds) as client:
+            await client.whoami()
+
+    asyncio.run(go())
+    req = seen[0]
+    assert req.headers["authorization"] == "Bearer TOK"
+    assert "cookie" not in {k.lower() for k in req.headers}

--- a/packs/atlassian/.apm/skills/jira/scripts/test_sso_config.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/test_sso_config.py
@@ -84,6 +84,32 @@ def test_fail_closed_on_malformed_values(tmp_path: Path, mutation: tuple[str, st
         load_sso_config(_write(tmp_path, body))
 
 
+def test_over_broad_single_label_cookie_domain_rejected(tmp_path: Path) -> None:
+    body = _VALID_COOKIE.replace(
+        'cookie_domains = ["jira.corp.example.com"]', 'cookie_domains = ["com"]'
+    )
+    with pytest.raises(SsoConfigError):
+        load_sso_config(_write(tmp_path, body))
+
+
+def test_base_host_outside_cookie_domains_rejected(tmp_path: Path) -> None:
+    body = _VALID_COOKIE.replace(
+        'cookie_domains = ["jira.corp.example.com"]',
+        'cookie_domains = ["other.example.com"]',
+    )
+    with pytest.raises(SsoConfigError):
+        load_sso_config(_write(tmp_path, body))
+
+
+def test_session_filename_with_separator_rejected(tmp_path: Path) -> None:
+    body = _VALID_COOKIE.replace(
+        'session_filename = "jira-session.json"',
+        'session_filename = "../../evil.json"',
+    )
+    with pytest.raises(SsoConfigError):
+        load_sso_config(_write(tmp_path, body))
+
+
 def test_unknown_sso_key_rejected(tmp_path: Path) -> None:
     body = _VALID_COOKIE.replace(
         'ttl_hint_minutes = 480', 'ttl_hint_minutes = 480\nrogue_key = "x"'

--- a/packs/atlassian/.apm/skills/jira/scripts/test_sso_config.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/test_sso_config.py
@@ -1,0 +1,114 @@
+"""SSO config loader + selector (spec task T3; AC3, AC12, AC13, fail-closed AC2).
+
+Exercises the per-skill loader against the real placeholder reference file and a
+table of crafted fixtures. Requires ``credbroker`` (the validation primitives) on
+the path — pip-installed in CI.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+import _sso_config
+from _sso_config import SsoConfig, load_sso_config
+
+pytest.importorskip("credbroker")
+from credbroker import SsoConfigError  # noqa: E402
+
+
+_VALID_COOKIE = textwrap.dedent(
+    """
+    auth_default = "sso-cookie"
+
+    [sso]
+    profile = "jira"
+    base_url = "https://jira.corp.example.com"
+    login_url = "https://sso.corp.example.com/login"
+    success_url_pattern = "https://jira.corp.example.com/secure/Dashboard.jspa"
+    cookie_domains = ["jira.corp.example.com"]
+    validation_endpoint = "/rest/api/2/myself"
+    session_filename = "jira-session.json"
+    ttl_hint_minutes = 480
+    """
+)
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    p = tmp_path / "sso-config.toml"
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+def test_real_reference_file_is_creds_path() -> None:
+    # Upstream placeholder: auth_default = "creds" → None (token path). AC12/AC13.
+    assert load_sso_config() is None
+
+
+def test_absent_file_is_creds_path(tmp_path: Path) -> None:
+    assert load_sso_config(tmp_path / "nope.toml") is None
+
+
+def test_explicit_creds_default_is_none(tmp_path: Path) -> None:
+    cfg = _write(tmp_path, 'auth_default = "creds"\n[sso]\nprofile = "x"\n')
+    assert load_sso_config(cfg) is None
+
+
+def test_valid_sso_cookie_config_parses(tmp_path: Path) -> None:
+    cfg = load_sso_config(_write(tmp_path, _VALID_COOKIE))
+    assert isinstance(cfg, SsoConfig)
+    assert cfg.profile == "jira"
+    assert cfg.base_url == "https://jira.corp.example.com"
+    assert cfg.cookie_domains == ("jira.corp.example.com",)
+    assert cfg.validation_endpoint == "/rest/api/2/myself"
+    assert cfg.ttl_hint_minutes == 480
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        ('base_url = "https://jira.corp.example.com"', 'base_url = "http://jira.corp.example.com"'),
+        ('login_url = "https://sso.corp.example.com/login"', 'login_url = "ftp://sso.corp.example.com"'),
+        ('success_url_pattern = "https://jira.corp.example.com/secure/Dashboard.jspa"', 'success_url_pattern = "jira.corp.example.com/x"'),
+        ('validation_endpoint = "/rest/api/2/myself"', 'validation_endpoint = "https://jira.corp.example.com/rest"'),
+        ('validation_endpoint = "/rest/api/2/myself"', 'validation_endpoint = "//evil.example.com/rest"'),
+        ('cookie_domains = ["jira.corp.example.com"]', "cookie_domains = []"),
+    ],
+)
+def test_fail_closed_on_malformed_values(tmp_path: Path, mutation: tuple[str, str]) -> None:
+    old, new = mutation
+    body = _VALID_COOKIE.replace(old, new)
+    with pytest.raises(SsoConfigError):
+        load_sso_config(_write(tmp_path, body))
+
+
+def test_unknown_sso_key_rejected(tmp_path: Path) -> None:
+    body = _VALID_COOKIE.replace(
+        'ttl_hint_minutes = 480', 'ttl_hint_minutes = 480\nrogue_key = "x"'
+    )
+    with pytest.raises(SsoConfigError):
+        load_sso_config(_write(tmp_path, body))
+
+
+def test_missing_required_key_rejected(tmp_path: Path) -> None:
+    body = _VALID_COOKIE.replace(
+        'validation_endpoint = "/rest/api/2/myself"\n', ""
+    )
+    with pytest.raises(SsoConfigError):
+        load_sso_config(_write(tmp_path, body))
+
+
+def test_missing_sso_table_rejected(tmp_path: Path) -> None:
+    with pytest.raises(SsoConfigError):
+        load_sso_config(_write(tmp_path, 'auth_default = "sso-cookie"\n'))
+
+
+def test_schema_key_set_matches_reference_file() -> None:
+    # The loader's allowed-key set must cover exactly the reference file's [sso]
+    # keys (drift guard between the loader and the shipped placeholder).
+    import tomllib
+
+    data = tomllib.loads(_sso_config._DEFAULT_CONFIG_PATH.read_text(encoding="utf-8"))
+    assert set(data["sso"]) <= _sso_config._ALLOWED_SSO_KEYS

--- a/packs/atlassian/.claude-plugin/plugin.json
+++ b/packs/atlassian/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "atlassian",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Atlassian primitives: jira / jira-align / confluence-crawler (credentialed CLI), plus the flow-metrics, ai-adoption-report, jira-defect-flow, and jira-brief-intake workflows that compose them."
 }

--- a/packs/atlassian/pack.toml
+++ b/packs/atlassian/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "atlassian"
-version = "0.2.0"
+version = "0.3.0"
 description = "Atlassian primitives: jira / jira-align / confluence-crawler (credentialed CLI), plus the flow-metrics, ai-adoption-report, jira-defect-flow, and jira-brief-intake workflows that compose them."
 readme = "README.md"
 display_name = "Atlassian"

--- a/packs/core/seeds/docs/CONVENTIONS.md
+++ b/packs/core/seeds/docs/CONVENTIONS.md
@@ -1029,6 +1029,9 @@ metadata:
   credentialed: true
   primitive-class: credentialed-cli   # or mcp-server
   auth: creds                         # env / cli / creds / sso-cookie
+  # auth-fallback: creds              # optional: dual-auth — the broker to fall
+  #                                   #   back to when the active one can't resolve
+  #                                   #   (e.g. sso-cookie with a creds fallback)
   # broker-specific extras follow:
   # namespace: <ns>                   # required for auth: creds and auth: env
   # keys: ["<KEY>"]                   # required for auth: creds and auth: env
@@ -1041,8 +1044,13 @@ The keys live under `metadata:` rather than at top level because the
 pins the top-level frontmatter set to `name`, `description`,
 `license`, `compatibility`, `metadata`, `allowed-tools` and reserves
 `metadata:` as the project-specific escape hatch. `tools/lint-agent-artifacts.py`
-refuses any top-level key outside that set; `tools/lint-credentialed-skills.sh`
+refuses any top-level key outside that set; `tools/lint_credentialed_skills.py`
 scopes its checks to skills with `metadata.credentialed: true`.
+
+`metadata.auth-fallback` is optional and names a second broker a **dual-auth**
+skill falls back to when the active one can't resolve (e.g. an `auth: sso-cookie`
+skill that drops to `creds` on a non-SSO instance). When present, the skill's
+Security section must satisfy **both** brokers' don't-block phrase sets.
 
 ### Four brokers — pick one per skill
 
@@ -1064,18 +1072,21 @@ four ids are pinned by
   build-projected `credentials_shim` it replaced is retired for
   `creds` consumers (the four-broker taxonomy above is unchanged).
 - **`sso-cookie`** — session cookie acquired via a headed-browser SSO
-  flow. The skill subprocess-invokes
-  `~/.agentbundle/bin/sso-broker.py` (projected by the
-  `credential-brokers` pack at user scope).
+  flow. The skill resolves the session through the `credbroker` SSO
+  resolver (`from credbroker import load_sso_cookies`), which
+  subprocess-invokes `~/.agentbundle/bin/sso-broker.py` (projected by the
+  `credential-brokers` pack at user scope) — mirroring how `creds` moved
+  broker resolution into `credbroker`. A skill that still resolves the
+  broker in its own `scripts/` is also accepted.
 
 The broker-agnostic invariants below apply to every credentialed
 primitive regardless of broker. Broker-specific lint extensions layer
 on top (`auth: creds` requires a credential-resolver import in
 `scripts/` — `from credbroker import …`, or the legacy
 `from .credentials_shim …`; `auth: env` requires each declared `<NAMESPACE>_<KEY>` to
-be read at least once; `auth: sso-cookie` requires
-subprocess-invocation of the canonical
-`Path.home() / ".agentbundle" / "bin" / "sso-broker.py"` path; `auth:
+be read at least once; `auth: sso-cookie` requires either a credbroker SSO import
+(`from credbroker import load_sso_cookies`) or subprocess-invocation of the
+canonical `Path.home() / ".agentbundle" / "bin" / "sso-broker.py"` path; `auth:
 cli` falls through to broker-agnostic checks only).
 
 ### Three storage tiers
@@ -1104,7 +1115,7 @@ Credentialed-CLI-class primitives must refuse the value-shaped flags
 `--password`. The CLI verb's `setup` subparser registers these as
 *tombstone arguments* whose action emits the verbatim sentinel
 `tokens cannot be passed via argv` and exits non-zero; the
-`tools/lint-credentialed-skills.sh` lint refuses any primitive's
+`tools/lint_credentialed_skills.py` lint refuses any primitive's
 script that declares one of the banned names in an
 `argparse.ArgumentParser.add_argument` call. MCP-server-class
 primitives may accept *header-naming* flags (`--bearer-header`,

--- a/packs/credential-brokers/.apm/user-libs/credbroker/__init__.py
+++ b/packs/credential-brokers/.apm/user-libs/credbroker/__init__.py
@@ -48,7 +48,26 @@ from ._core import (
 from ._core import _parse_schema as parse_schema
 from ._core import _tier2_backend_label as tier2_backend_label
 
-__version__ = "0.1.1"
+# SSO web-session cookie family (RFC-0035) — a second consumer-resolution family
+# alongside the token ``creds`` family above. Resolves a captured SSO session to
+# an on-disk cookie-jar path via the unchanged ``sso-broker.py`` engine, with
+# reusable validation primitives for the consumer's ``sso-config.toml`` and the
+# load-time cookie-domain confinement. Imported eagerly: ``_sso`` is stdlib-only,
+# so it keeps the base import graph free of any third-party dependency.
+from ._sso import (
+    SsoBrokerNotInstalledError,
+    SsoConfigError,
+    SsoError,
+    SsoSessionUnavailableError,
+    domain_in_cookie_domains,
+    filter_jar_to_domains,
+    load_sso_cookies,
+    require_host_in_cookie_domains,
+    validate_https_url,
+    validate_root_relative_endpoint,
+)
+
+__version__ = "0.2.0"
 
 __all__ = [
     # Resolver + container.
@@ -77,5 +96,17 @@ __all__ = [
     "source_vault_master",
     "store_vault_master",
     "store_in_vault",
+    # SSO web-session cookie family (RFC-0035).
+    "load_sso_cookies",
+    "SsoError",
+    "SsoBrokerNotInstalledError",
+    "SsoSessionUnavailableError",
+    "SsoConfigError",
+    # SSO confinement primitives (RFC-0035; security-control surface).
+    "validate_https_url",
+    "validate_root_relative_endpoint",
+    "domain_in_cookie_domains",
+    "filter_jar_to_domains",
+    "require_host_in_cookie_domains",
     "__version__",
 ]

--- a/packs/credential-brokers/.apm/user-libs/credbroker/_sso.py
+++ b/packs/credential-brokers/.apm/user-libs/credbroker/_sso.py
@@ -1,0 +1,226 @@
+"""SSO web-session cookie resolution (RFC-0035).
+
+A second consumer-resolution family alongside the token ``creds`` family. Where
+``load_credentials`` resolves a token, ``load_sso_cookies`` resolves a *captured
+SSO web session* into an on-disk cookie-jar path by subprocess-invoking the
+unchanged ``sso-broker.py`` engine.
+
+Two contracts shape this module:
+
+* **Path-not-value handoff (RFC-0013 § 1).** The resolver returns the jar's
+  *path*, never its bytes. No cookie value crosses ``argv`` (only the profile
+  name does), no cookie value is logged, and the engine writes the jar to its own
+  ``0600`` floor — the consumer reads it in-process and is responsible for never
+  echoing it (the at-rest floor is the broker's own responsibility).
+* **Fail-closed.** Anything other than a clean exit-0-with-readable-path raises
+  :class:`SsoSessionUnavailableError` with a verbatim re-``register`` remediation.
+  It never returns a path it could not verify, and a caller on the cookie path
+  must never fall through to the token path on this error.
+
+The validation primitives that guard the consumer's ``sso-config.toml`` and the
+load-time cookie-jar confinement live alongside this resolver (added in spec task
+T2) so the security-control surface is single-sourced and reusable by any
+platform integration, not just atlassian.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable
+from urllib.parse import urlsplit
+
+__all__ = [
+    "SsoError",
+    "SsoBrokerNotInstalledError",
+    "SsoSessionUnavailableError",
+    "SsoConfigError",
+    "load_sso_cookies",
+    "validate_https_url",
+    "validate_root_relative_endpoint",
+    "domain_in_cookie_domains",
+    "filter_jar_to_domains",
+    "require_host_in_cookie_domains",
+]
+
+# The engine is installed by the credential-brokers pack at this user-scope path
+# (RFC-0013 § 1; mirrored by ``sso-broker.py``'s own module docstring). Composed
+# from parts so no full literal path string appears, matching the broker's own
+# convention.
+_BROKER_TAIL = (".agentbundle", "bin", "sso-broker.py")
+
+
+class SsoError(Exception):
+    """Base class for SSO consumer-resolution failures."""
+
+
+class SsoBrokerNotInstalledError(SsoError):
+    """The ``sso-broker.py`` engine is not installed at its expected path."""
+
+
+class SsoSessionUnavailableError(SsoError):
+    """No usable SSO session for the profile — the caller must re-``register``.
+
+    Raised for every non-success branch of ``get-cookies`` (the engine returns a
+    non-zero exit for both "profile not registered" and "no jar"), for an
+    unreadable jar path, and for any uncaught engine exception. Fail-closed: the
+    cookie path must surface this, never silently downgrade to the token path.
+    """
+
+
+class SsoConfigError(SsoError):
+    """An ``sso-config.toml`` value, or a runtime host, violates the SSO
+    confinement contract — a non-``https`` URL, a non-root-relative endpoint, or a
+    send-host outside the declared ``cookie_domains``. Validation primitives raise
+    this; the consumer fails closed before any cookie-bearing request leaves the
+    process.
+    """
+
+
+def _broker_path() -> Path:
+    """Resolve the engine path under the user's home (``~/.agentbundle/bin``)."""
+    return Path.home().joinpath(*_BROKER_TAIL)
+
+
+def load_sso_cookies(profile: str) -> Path:
+    """Resolve *profile*'s captured SSO session to an on-disk cookie-jar path.
+
+    Subprocess-invokes ``sso-broker.py get-cookies <profile>`` with the parent
+    interpreter, inheriting the process environment (corporate proxy / trust-store
+    passthrough, RFC-0013 § 1). Proceeds **only** on exit 0 with a readable jar
+    path; every other outcome fails closed.
+
+    :returns: the path to the ``0600`` cookie jar the engine materialised.
+    :raises SsoBrokerNotInstalledError: the engine is absent at its expected path.
+    :raises SsoSessionUnavailableError: the profile is unregistered, no jar
+        exists, the jar path is unreadable, or the engine raised.
+    """
+    broker = _broker_path()
+    if not broker.is_file():
+        raise SsoBrokerNotInstalledError(
+            f"sso-broker not installed at {broker}; install the credential-brokers "
+            f"pack, then run 'sso-broker register {profile}'"
+        )
+
+    remediation = (
+        f"SSO session unavailable for profile {profile}; "
+        f"run 'sso-broker register {profile}'"
+    )
+
+    try:
+        result = subprocess.run(
+            [sys.executable, str(broker), "get-cookies", profile],
+            capture_output=True,
+            text=True,
+            check=False,
+            env={**os.environ},
+        )
+    except OSError as exc:
+        # Engine present but unspawnable (permissions, interpreter gone, …).
+        raise SsoSessionUnavailableError(remediation) from exc
+
+    if result.returncode != 0:
+        raise SsoSessionUnavailableError(remediation)
+
+    jar_path = Path(result.stdout.strip())
+    if not jar_path.is_file():
+        raise SsoSessionUnavailableError(remediation)
+
+    return jar_path
+
+
+# --- SSO confinement primitives (RFC-0035; spec task T2) ---------------------
+#
+# These are the security-control surface the unchanged ``sso-broker.py`` engine
+# does *not* perform and that this RFC adds *above* it: an https-only scheme guard,
+# a root-relative endpoint guard, and the cookie-domain confinement that filters
+# the engine's deliberately over-broad captured jar down to the declared domains.
+# They are pure functions (no I/O), reusable by any platform integration, so the
+# control can't drift across consumers.
+
+
+def validate_https_url(value: str, *, field: str) -> None:
+    """Reject *value* unless its scheme is exactly ``https`` (AC3).
+
+    Applied to ``login_url``, ``success_url_pattern``, and ``base_url`` — the
+    cookie jar is a bearer secret, so a plaintext (``http``) or scheme-less
+    destination is refused. ``success_url_pattern`` may carry pattern characters
+    after the scheme; only the scheme is checked here.
+    """
+    scheme = urlsplit(value).scheme.lower()
+    if scheme != "https":
+        raise SsoConfigError(
+            f"{field} must be an https URL (got scheme {scheme or '(none)'!r}): {value!r}"
+        )
+
+
+def validate_root_relative_endpoint(value: str, *, field: str = "validation_endpoint") -> None:
+    """Reject *value* unless it is a root-relative path (AC3).
+
+    Must lead with a single ``/`` and carry no scheme, host, or protocol-relative
+    ``//`` prefix — so a validation endpoint can never be redirected off-host.
+    """
+    if not value.startswith("/") or value.startswith("//") or "://" in value:
+        raise SsoConfigError(
+            f"{field} must be a root-relative path (lead with '/', no scheme/host, "
+            f"no '//'): {value!r}"
+        )
+
+
+def _normalize_domain(domain: str) -> str:
+    """Lower-case and strip a leading dot — the broker stores domains via
+    ``lstrip('.')`` while cookie ``domain`` fields keep a leading dot (AC4)."""
+    return domain.lstrip(".").lower()
+
+
+def domain_in_cookie_domains(domain: str, cookie_domains: Iterable[str]) -> bool:
+    """Normalized label-boundary suffix match (AC4, AC6).
+
+    Both sides are dot-stripped and lower-cased; *domain* is admitted iff it
+    equals an allowed domain or is a dot-delimited subdomain of one. The label
+    boundary is load-bearing: ``evil-corp.example.com`` is rejected against
+    ``corp.example.com`` (no ``.`` before ``corp``), while ``jira.corp.example.com``
+    is admitted. This is the single normalization primitive shared by the
+    cookie-jar filter (AC4) and the send-host check (AC6).
+    """
+    cand = _normalize_domain(domain)
+    if not cand:
+        return False
+    for allowed in cookie_domains:
+        norm = _normalize_domain(allowed)
+        if not norm:
+            continue
+        if cand == norm or cand.endswith("." + norm):
+            return True
+    return False
+
+
+def filter_jar_to_domains(
+    cookies: list[dict], cookie_domains: Iterable[str]
+) -> list[dict]:
+    """Reduce an over-broad captured jar to cookies within *cookie_domains* (AC4).
+
+    The engine captures every cookie observed across the SSO/IdP/analytics
+    redirect chain; the consumer filters that loaded jar to the declared domains
+    at load time, before attaching it. Returns a new list; the caller must never
+    write the result back to the broker path (AC10). A cookie with no ``domain``
+    field is dropped (fail closed).
+    """
+    allowed = list(cookie_domains)
+    return [c for c in cookies if domain_in_cookie_domains(c.get("domain", ""), allowed)]
+
+
+def require_host_in_cookie_domains(host: str, cookie_domains: Iterable[str]) -> None:
+    """Fail closed unless *host* is within the declared ``cookie_domains`` (AC6).
+
+    The consumer client's request base host must be a member of the confinement
+    set before any cookie-bearing request leaves the process; a mismatch (a
+    downstream edit drifting the base URL off-domain) raises.
+    """
+    if not domain_in_cookie_domains(host, cookie_domains):
+        raise SsoConfigError(
+            f"request host {host!r} is not within the declared cookie_domains "
+            f"{list(cookie_domains)!r}; refusing to send the session cookie"
+        )

--- a/packs/credential-brokers/.claude-plugin/plugin.json
+++ b/packs/credential-brokers/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "credential-brokers",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "User-scope credential brokering: the credbroker library (pip-installed, in-process resolver for auth: creds skills), sso-broker (subprocess at ~/.agentbundle/bin/ for auth: sso-cookie skills), plus one LLM-cooperative credential-setup skill."
 }

--- a/packs/credential-brokers/pack.toml
+++ b/packs/credential-brokers/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "credential-brokers"
-version = "0.1.3"
+version = "0.2.0"
 description = "User-scope credential brokering: the credbroker library (pip-installed, in-process resolver for auth: creds skills), sso-broker (subprocess at ~/.agentbundle/bin/ for auth: sso-cookie skills), plus one LLM-cooperative credential-setup skill."
 readme = "README.md"
 display_name = "Credential Brokers"

--- a/tools/lint-sso-config.py
+++ b/tools/lint-sso-config.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Structural lint for upstream ``references/sso-config.toml`` (RFC-0035; AC15).
+
+Every shipped ``sso-config.toml`` must be PLACEHOLDER-shaped so no real instance
+config, captured cookie value, or non-``creds`` default can ship upstream:
+
+  - ``auth_default == "creds"`` (the SSO-cookie path is opt-in by the adopter);
+  - the ``[sso]`` key set is a subset of the declared connection-param schema;
+  - every URL / cookie-domain host is a ``*.invalid`` placeholder;
+  - no scalar value matches a cookie-value (opaque-token) shape.
+
+This is **TOML-key structural** — it parses the file with ``tomllib`` and reasons
+about keys and typed values, never a substring grep. So ``crowd.token_key`` (a
+cookie *name*, not present here), ``session_filename``, and ``success_url_pattern``
+never false-positive (contrast the credentialed-lint substring trap).
+
+Usage::
+
+    python tools/lint-sso-config.py            # scan the repo's shipped files
+    python tools/lint-sso-config.py <file>...  # scan specific files (self-test)
+
+Exit 0 = clean; 1 = findings (printed to stderr).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+from urllib.parse import urlsplit
+
+# The atlassian [sso] connection-param schema (keep in sync with each skill's
+# scripts/_sso_config.py _ALLOWED_SSO_KEYS).
+_ALLOWED_SSO_KEYS = frozenset(
+    {
+        "profile",
+        "base_url",
+        "login_url",
+        "success_url_pattern",
+        "cookie_domains",
+        "validation_endpoint",
+        "session_filename",
+        "ttl_hint_minutes",
+    }
+)
+_URL_KEYS = ("base_url", "login_url", "success_url_pattern")
+
+# An opaque token blob: >=20 chars of a base64/urlsafe alphabet with NO ``.``,
+# ``/``, ``:`` or whitespace — so URLs, paths, domains, and filenames (which all
+# carry a separator) can't match, but a pasted JSESSIONID/crowd-token value does.
+_COOKIE_VALUE_SHAPE = re.compile(r"^[A-Za-z0-9_\-+=]{20,}$")
+
+
+def _host_of(value: str) -> str:
+    return (urlsplit(value).hostname or "").lower()
+
+
+def _walk_strings(obj: object):
+    """Yield every scalar string anywhere in the parsed TOML."""
+    if isinstance(obj, str):
+        yield obj
+    elif isinstance(obj, dict):
+        for v in obj.values():
+            yield from _walk_strings(v)
+    elif isinstance(obj, list):
+        for v in obj:
+            yield from _walk_strings(v)
+
+
+def lint_file(path: Path) -> list[str]:
+    findings: list[str] = []
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        return [f"{path}: cannot parse TOML: {exc}"]
+
+    if data.get("auth_default") != "creds":
+        findings.append(
+            f"{path}: auth_default must be \"creds\" upstream "
+            f"(got {data.get('auth_default')!r}); the SSO-cookie path is adopter opt-in"
+        )
+
+    sso = data.get("sso")
+    if not isinstance(sso, dict):
+        findings.append(f"{path}: missing [sso] table")
+        sso = {}
+
+    unknown = sorted(set(sso) - _ALLOWED_SSO_KEYS)
+    if unknown:
+        findings.append(f"{path}: unknown [sso] keys (outside the schema): {unknown}")
+
+    for key in _URL_KEYS:
+        if key in sso:
+            host = _host_of(str(sso[key]))
+            if not host.endswith(".invalid"):
+                findings.append(
+                    f"{path}: [sso].{key} host {host!r} is not a *.invalid placeholder"
+                )
+
+    for dom in sso.get("cookie_domains", []) or []:
+        if not str(dom).endswith(".invalid"):
+            findings.append(
+                f"{path}: [sso].cookie_domains entry {dom!r} is not a *.invalid placeholder"
+            )
+
+    for value in _walk_strings(data):
+        if _COOKIE_VALUE_SHAPE.match(value):
+            findings.append(
+                f"{path}: a value matches a cookie-value (opaque-token) shape: "
+                f"{value[:8]}… — no captured cookie value may ship upstream"
+            )
+
+    return findings
+
+
+def _default_paths() -> list[Path]:
+    root = Path(__file__).resolve().parent.parent
+    return sorted(root.glob("packs/*/.apm/skills/*/references/sso-config.toml"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    paths = [Path(a) for a in args] if args else _default_paths()
+
+    findings: list[str] = []
+    for path in paths:
+        findings.extend(lint_file(path))
+
+    if findings:
+        for f in findings:
+            sys.stderr.write(f"sso-config lint: {f}\n")
+        sys.stderr.write(f"sso-config lint: {len(findings)} finding(s)\n")
+        return 1
+
+    sys.stderr.write(f"sso-config lint: {len(paths)} file(s) scanned, 0 finding(s)\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_credentialed_skills.py
+++ b/tools/lint_credentialed_skills.py
@@ -444,6 +444,40 @@ def has_credbroker_import(py_path):
     return False
 
 
+# The credbroker SSO resolver entry point (RFC-0035). Importing/using it is the
+# moral equivalent of the old in-`scripts/` sso-broker path expression +
+# subprocess.run — the broker invocation now lives single-sourced in credbroker.
+_CREDBROKER_SSO_RESOLVER = "load_sso_cookies"
+
+
+def has_credbroker_sso_import(py_path):
+    """True iff *py_path* uses the credbroker SSO resolver — either
+    `from credbroker import load_sso_cookies` or `credbroker.load_sso_cookies`
+    (after `import credbroker`).
+
+    RFC-0035 moved SSO broker resolution into the `credbroker` library (mirroring
+    RFC-0023's move of the `creds` resolver), so an `auth: sso-cookie` consumer
+    satisfies the broker-invocation requirement with this import in place of an
+    in-`scripts/` `sso-broker.py` path expression.
+    """
+    tree = _ast_for(py_path)
+    if tree is None:
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and (node.module or "").split(".")[0] == "credbroker":
+            for alias in node.names:
+                if alias.name == _CREDBROKER_SSO_RESOLVER:
+                    return True
+        if (
+            isinstance(node, ast.Attribute)
+            and node.attr == _CREDBROKER_SSO_RESOLVER
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "credbroker"
+        ):
+            return True
+    return False
+
+
 def env_reads(py_path):
     """Yield literal env-var names read via os.environ[...] /
     os.environ.get(...) / os.getenv(...). Only first-arg
@@ -773,6 +807,9 @@ for skill_md in skill_md_files:
 
     primitive_class = metadata.get("primitive-class", "")
     auth = metadata.get("auth", "") or ""
+    # RFC-0035 AC16a: a dual-auth skill declares a fallback broker; its Security
+    # section must satisfy BOTH phrase sets (the active broker and the fallback).
+    auth_fallback = metadata.get("auth-fallback", "") or ""
     namespace = metadata.get("namespace", "") or ""
     keys = metadata.get("keys", [])
     if isinstance(keys, str):
@@ -787,22 +824,30 @@ for skill_md in skill_md_files:
         report(skill_md, f"missing heading: {SECURITY_HEADING}")
     else:
         normalised = normalize_whitespace(section)
-        phrases = REQUIRED_PHRASES_BY_BROKER.get(auth)
-        if phrases is None:
-            # Skill declares an unknown auth value — refused upstream
-            # by lint-agent-artifacts.py (AC26), but be defensive.
-            report(
-                skill_md,
-                f"unknown metadata.auth={auth!r} "
-                f"(expected one of {sorted(REQUIRED_PHRASES_BY_BROKER)})",
-            )
-        else:
+        # The active broker, plus any declared dual-auth fallback (AC16a): the
+        # Security section must carry EVERY required phrase set, so a skill that
+        # can resolve via either broker documents both don't-block contracts.
+        required_brokers = [auth]
+        if auth_fallback:
+            required_brokers.append(auth_fallback)
+        for broker in required_brokers:
+            phrases = REQUIRED_PHRASES_BY_BROKER.get(broker)
+            if phrases is None:
+                # Unknown auth / auth-fallback value — refused upstream by
+                # lint-agent-artifacts.py (AC26), but be defensive.
+                field = "auth" if broker == auth else "auth-fallback"
+                report(
+                    skill_md,
+                    f"unknown metadata.{field}={broker!r} "
+                    f"(expected one of {sorted(REQUIRED_PHRASES_BY_BROKER)})",
+                )
+                continue
             for phrase in phrases:
                 if normalize_whitespace(phrase) not in normalised:
                     report(
                         skill_md,
                         f"security section missing required phrase "
-                        f"for broker {auth!r}: {phrase!r}",
+                        f"for broker {broker!r}: {phrase!r}",
                     )
 
     scripts_dir = skill_dir / "scripts"
@@ -930,6 +975,11 @@ for skill_md in skill_md_files:
     elif auth == "sso-cookie":
         targets_home = False
         any_subprocess_run = False
+        # RFC-0035: a consumer may resolve the broker via the credbroker SSO
+        # resolver instead of an in-`scripts/` path expression + subprocess.run.
+        resolves_via_credbroker = any(
+            has_credbroker_sso_import(p) for p in consumer_py_files
+        )
         for p in consumer_py_files:
             for bad_name, lineno in disallowed_subprocess_calls(p):
                 report(
@@ -965,13 +1015,21 @@ for skill_md in skill_md_files:
                         f"Path.home() / {DOTFILE_PARENT!r} / "
                         f"{SSO_BROKER_BIN_DIR!r} / {SSO_BROKER_BASENAME!r}",
                     )
-        if not targets_home:
+        if resolves_via_credbroker:
+            # The credbroker SSO import (load_sso_cookies) satisfies the
+            # broker-invocation requirement (RFC-0035 AC16b); the in-`scripts/`
+            # path expression + subprocess.run are not required. The disallowed-
+            # subprocess and no-Playwright checks above still apply, and an
+            # absolute hard-coded broker path is still flagged if one is present.
+            pass
+        elif not targets_home:
             report(
                 skill_md,
-                f"auth=sso-cookie requires a path expression resolving to "
-                f"Path.home() / {DOTFILE_PARENT!r} / "
+                f"auth=sso-cookie requires either a credbroker SSO import "
+                f"(`from credbroker import {_CREDBROKER_SSO_RESOLVER}`) or a path "
+                f"expression resolving to Path.home() / {DOTFILE_PARENT!r} / "
                 f"{SSO_BROKER_BIN_DIR!r} / {SSO_BROKER_BASENAME!r} "
-                f"in scripts/ (none found)",
+                f"in scripts/ (neither found)",
             )
         elif not any_subprocess_run:
             report(

--- a/tools/pre-pr-catalogue.py
+++ b/tools/pre-pr-catalogue.py
@@ -71,6 +71,8 @@ def main() -> int:
     _run("credentialed-skill lint", [py, "tools/lint_credentialed_skills.py"])
     _run("credentialed-skill lint self-test",
          [py, "tools/test-lint-credentialed-skills.py"])
+    _run("sso-config lint", [py, "tools/lint-sso-config.py"])
+    _run("sso-config lint self-test", [py, "tools/test-lint-sso-config.py"])
     _run("knowledge-surface parity", [py, "tools/lint-knowledge-surface-parity.py"])
     _run("knowledge-surface parity self-test",
          [py, "tools/test-lint-knowledge-surface-parity.py"])

--- a/tools/test-lint-credentialed-skills.py
+++ b/tools/test-lint-credentialed-skills.py
@@ -78,7 +78,8 @@ SECURITY_BLOCKS = {
 
 
 def make_skill_md(broker: str, *, namespace: str = "", keys: list[str] | None = None,
-                  body_extra: str = "", security_override: str | None = None) -> str:
+                  body_extra: str = "", security_override: str | None = None,
+                  auth_fallback: str = "") -> str:
     lines = [
         "---",
         f"name: fixture-{broker}",
@@ -88,6 +89,8 @@ def make_skill_md(broker: str, *, namespace: str = "", keys: list[str] | None = 
         "  primitive-class: credentialed-cli",
         f"  auth: {broker}",
     ]
+    if auth_fallback:
+        lines.append(f"  auth-fallback: {auth_fallback}")
     if namespace:
         lines.append(f"  namespace: {namespace}")
     if keys is not None:
@@ -355,6 +358,87 @@ def _(root: Path) -> None:
         "import subprocess\nimport sys\nfrom pathlib import Path\n"
         "broker = str(Path.home() / \".agentbundle\" / \"bin\" / \"sso-broker.py\")\n"
         "subprocess.run([sys.executable, broker, 'test'])\n",
+    )
+
+
+# ── RFC-0035 AC16b: credbroker SSO resolver import satisfies broker-invocation
+
+@case(
+    # The credbroker SSO import (load_sso_cookies) stands in for the in-scripts/
+    # path expression + subprocess.run — no broker path or subprocess in scripts/.
+    "sso-cookie-credbroker-resolver-ok",
+    expect_exit=0,
+)
+def _(root: Path) -> None:
+    sk = root / "packs" / "p" / ".apm" / "skills" / "fixture-sso-cookie"
+    write(sk / "SKILL.md", make_skill_md("sso-cookie"))
+    write(
+        sk / "scripts" / "cli.py",
+        "from credbroker import load_sso_cookies\n"
+        "jar = load_sso_cookies('corp')\nprint(jar)\n",
+    )
+
+
+@case(
+    # Neither an in-scripts/ broker path nor a credbroker SSO import → refused;
+    # the message names the credbroker SSO import as the accepted alternative.
+    "sso-cookie-no-resolver-refused",
+    expect_exit=1,
+    expect_substrings=["credbroker SSO import", "load_sso_cookies"],
+)
+def _(root: Path) -> None:
+    sk = root / "packs" / "p" / ".apm" / "skills" / "fixture-sso-cookie"
+    write(sk / "SKILL.md", make_skill_md("sso-cookie"))
+    write(sk / "scripts" / "cli.py", "print('no broker resolution at all')\n")
+
+
+# ── RFC-0035 AC16a: dual-auth skill must carry BOTH phrase sets
+
+_DUAL_SECURITY = (
+    "### Security rules (non-negotiable)\n\n"
+    "- Secrets live only in the dotfile / cookie jar.\n"
+    "  **Never** read that file, print it, or echo the token.\n"
+    "- **Never** put the token on the command line.\n"
+    "- If check fails, tell the user to run setup — do not run it for them.\n"
+    "- **Never** read the jar file directly, print its contents, or echo cookie values.\n"
+    "- **Never** put a session cookie on the command line.\n"
+    "- If SSO expired, tell the user — do not run any setup helper for them.\n"
+)
+
+
+@case(
+    # auth: sso-cookie + auth-fallback: creds, but the Security section carries
+    # only the sso-cookie phrases → the missing creds phrase is reported.
+    "dual-auth-missing-fallback-phrases-refused",
+    expect_exit=1,
+    expect_substrings=["missing required phrase for broker 'creds'"],
+)
+def _(root: Path) -> None:
+    sk = root / "packs" / "p" / ".apm" / "skills" / "fixture-sso-cookie"
+    write(
+        sk / "SKILL.md",
+        make_skill_md("sso-cookie", auth_fallback="creds"),  # default sso-cookie block only
+    )
+    write(
+        sk / "scripts" / "cli.py",
+        "from credbroker import load_sso_cookies\nprint(load_sso_cookies('corp'))\n",
+    )
+
+
+@case(
+    # Both phrase sets present + a credbroker SSO import → passes.
+    "dual-auth-both-phrase-sets-ok",
+    expect_exit=0,
+)
+def _(root: Path) -> None:
+    sk = root / "packs" / "p" / ".apm" / "skills" / "fixture-sso-cookie"
+    write(
+        sk / "SKILL.md",
+        make_skill_md("sso-cookie", auth_fallback="creds", security_override=_DUAL_SECURITY),
+    )
+    write(
+        sk / "scripts" / "cli.py",
+        "from credbroker import load_sso_cookies\nprint(load_sso_cookies('corp'))\n",
     )
 
 

--- a/tools/test-lint-sso-config.py
+++ b/tools/test-lint-sso-config.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Self-test for tools/lint-sso-config.py (RFC-0035; AC15).
+
+Runs the lint as a real subprocess against crafted fixtures (the documented
+file-path invocation), asserting the exit code is the contract. Includes the
+substring-trap no-false-positive cases (`session_filename`, `success_url_pattern`,
+a value containing the literal "token").
+
+Run directly: ``python tools/test-lint-sso-config.py`` (exit 0 = pass).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+_LINT = Path(__file__).resolve().parent / "lint-sso-config.py"
+
+_VALID = """
+auth_default = "creds"
+
+[sso]
+profile = "jira"
+base_url = "https://jira.example.invalid"
+login_url = "https://sso.example.invalid/login"
+success_url_pattern = "https://jira.example.invalid/secure/Dashboard.jspa"
+cookie_domains = ["jira.example.invalid"]
+validation_endpoint = "/rest/api/2/myself"
+session_filename = "session-token.json"
+ttl_hint_minutes = 480
+"""
+
+
+def _run(body: str) -> int:
+    with tempfile.TemporaryDirectory() as d:
+        f = Path(d) / "sso-config.toml"
+        f.write_text(textwrap.dedent(body), encoding="utf-8")
+        return subprocess.run(
+            [sys.executable, str(_LINT), str(f)], capture_output=True, text=True
+        ).returncode
+
+
+CASES: list[tuple[str, str, int]] = [
+    # (label, body, expected_exit)
+    ("valid placeholder passes", _VALID, 0),
+    (
+        "no false-positive on session_filename / success_url_pattern / 'token' substring",
+        _VALID,  # carries session_filename="session-token.json" + success_url_pattern
+        0,
+    ),
+    ("auth_default != creds fails", _VALID.replace('"creds"', '"sso-cookie"'), 1),
+    (
+        "unknown [sso] key fails",
+        _VALID.replace("ttl_hint_minutes = 480", 'ttl_hint_minutes = 480\nrogue = "x"'),
+        1,
+    ),
+    (
+        "non-*.invalid url host fails",
+        _VALID.replace("jira.example.invalid", "jira.corp.example.com"),
+        1,
+    ),
+    (
+        "non-*.invalid cookie_domain fails",
+        _VALID.replace(
+            'cookie_domains = ["jira.example.invalid"]',
+            'cookie_domains = ["jira.corp.example.com"]',
+        ),
+        1,
+    ),
+    (
+        "cookie-value-shaped value fails",
+        _VALID.replace(
+            'session_filename = "session-token.json"',
+            'session_filename = "AQIC5wM2LY4Sfczssession9eyJhbGciOi"',
+        ),
+        1,
+    ),
+]
+
+
+def main() -> int:
+    failures: list[str] = []
+    for label, body, expected in CASES:
+        got = _run(body)
+        if got != expected:
+            failures.append(f"{label}: expected exit {expected}, got {got}")
+
+    # The real shipped files must pass (no-arg invocation scans the repo).
+    repo_scan = subprocess.run(
+        [sys.executable, str(_LINT)], capture_output=True, text=True
+    ).returncode
+    if repo_scan != 0:
+        failures.append(f"repo scan: expected exit 0, got {repo_scan}")
+
+    for f in failures:
+        sys.stderr.write(f"FAIL {f}\n")
+    if failures:
+        return 1
+    sys.stderr.write(f"ok — {len(CASES)} cases + repo scan passed\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test-lint-sso-config.py
+++ b/tools/test-lint-sso-config.py
@@ -81,12 +81,58 @@ CASES: list[tuple[str, str, int]] = [
 ]
 
 
+_REPO = Path(__file__).resolve().parent.parent
+_JIRA = _REPO / "packs/atlassian/.apm/skills/jira/scripts"
+_CONF = _REPO / "packs/atlassian/.apm/skills/confluence-crawler/scripts"
+# The per-skill SSO files RFC-0023 forbids sharing as a projected module, so they
+# are duplicated byte-for-byte across the two skills. Pin them equal here so a
+# one-sided edit to the security-control loader fails loudly instead of drifting.
+_DUPLICATED = ("_sso_config.py", "setup_sso.py", "test_sso_config.py", "test_setup_sso.py")
+
+
+def _load_module(path: Path, name: str):
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    # Register before exec so `@dataclass` (which resolves cls.__module__ via
+    # sys.modules) works while loading the loader from a file path.
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _parity_failures() -> list[str]:
+    fails: list[str] = []
+    for fn in _DUPLICATED:
+        jb, cb = (_JIRA / fn), (_CONF / fn)
+        if not jb.is_file() or not cb.is_file():
+            fails.append(f"missing duplicated file: {fn}")
+        elif jb.read_bytes() != cb.read_bytes():
+            fails.append(f"{fn} differs between jira and confluence-crawler scripts/")
+    # The lint's schema set must equal the loader's (the triplicated [sso] key set
+    # must not drift between the lint that pins it and the loader that enforces it).
+    try:
+        lint_mod = _load_module(_LINT, "lint_sso_config")
+        loader_mod = _load_module(_JIRA / "_sso_config.py", "sso_loader")
+        if lint_mod._ALLOWED_SSO_KEYS != loader_mod._ALLOWED_SSO_KEYS:
+            fails.append(
+                "lint _ALLOWED_SSO_KEYS != loader _ALLOWED_SSO_KEYS "
+                f"({sorted(lint_mod._ALLOWED_SSO_KEYS)} vs {sorted(loader_mod._ALLOWED_SSO_KEYS)})"
+            )
+    except Exception as exc:  # noqa: BLE001
+        fails.append(f"schema-parity check crashed: {exc!r}")
+    return fails
+
+
 def main() -> int:
     failures: list[str] = []
     for label, body, expected in CASES:
         got = _run(body)
         if got != expected:
             failures.append(f"{label}: expected exit {expected}, got {got}")
+
+    failures.extend(_parity_failures())
 
     # The real shipped files must pass (no-arg invocation scans the repo).
     repo_scan = subprocess.run(


### PR DESCRIPTION
Implements the `atlassian-sso-cookie` spec (RFC-0035): `jira` reads and `confluence-crawler` can authenticate to an Atlassian **Data Center** instance behind corporate SSO by a captured web session (cookie jar) instead of an API token. Token users with no SSO config see no change.

Spec: `docs/specs/atlassian-sso-cookie/spec.md` (Status: Shipped; AC1–AC18 + AC20 met, AC19 deferred). Built bottom-up across 4 commits (credbroker → atlassian clients → lint/setup/dual-auth/docs → review fixes).

## What this delivers

- **credbroker SSO consumer family** (0.1.1→0.2.0): `load_sso_cookies(profile)` resolves a captured SSO session to an on-disk `0600` jar **path** (path-not-value handoff) via the unchanged `sso-broker` engine, fail-closed (never downgrades to creds), plus reusable confinement primitives (https/root-relative guards, label-boundary cookie-domain match, load-time over-broad-jar filter, send-host check). PyPI README + CHANGELOG updated. Base import graph stays stdlib-only.
- **Both clients** gain a `from_sso_cookies` path: confined jar attached, **no `Authorization` header**, `follow_redirects=False` (the session cookie is never re-attached across a redirect), corporate proxy/trust store honored, GET/HEAD allowlist at the `_request` chokepoint (covers jira's `raw()`). Reads only — writes refused pending XSRF design.
- Placeholder `references/sso-config.toml` + per-skill loader/`auth_default` selector; structural `tools/lint-sso-config.py` (+ self-test, wired into the catalogue gate); `setup_sso.py` (drives `sso-broker register` from the validated config, no cookie on argv).
- **Dual-auth**: frontmatter flips to `auth: sso-cookie` + `metadata.auth-fallback: creds`; `lint_credentialed_skills.py` amended to require both phrase sets and accept a credbroker SSO import in place of an in-`scripts/` broker path. CONVENTIONS anchors the marker.
- Pack bumps (credential-brokers 0.1.3→0.2.0, atlassian 0.2.0→0.3.0 + marketplace); how-to guide + changelog; new SSO suites wired into `build-check.yml` + `build-check-windows.yml`.

## Security

A pre-EXECUTE security review caught a redirect-exfiltration gap → new **AC20** (`follow_redirects=False`): httpx re-derives the `Cookie` header by domain match on every hop, so following an off-`cookie_domains` 302 would leak the session cookie. The implementation review added base-host-in-`cookie_domains` + over-broad-domain rejection, a `session_filename` traversal guard, and a `download_attachment` off-host guard. The captured jar is filtered to the declared domains at load (the broker captures an over-broad jar); the cookie set leaving the process is asserted ⊆ `cookie_domains` on every request via mock transport, including the `evil-corp.example.com` vs `corp.example.com` near-miss.

## Verification

credbroker 105 tests · jira 36 · confluence-crawler 33 · `lint-sso-config` + `lint_credentialed_skills` + self-tests + a parity guard (pins the byte-identical per-skill files + lint↔loader schema). adversarial + security + quality reviewers all returned clean. Governance: ADR-0026 + RFC-0013 § Errata (recorded with the spec).

## Four questions

- **What & why:** SSO-cookie auth for DC reads where API tokens are blocked; reverses RFC-0013 § 9's deferral (its "just a frontmatter change" premise was false — clients build only Basic/Bearer via credbroker).
- **Risk:** Additive and dark by default (`auth_default = "creds"` upstream). The cookie path is fail-closed and read-only. Rollback = revert the PR(s).
- **Test:** TDD throughout (mock-transport for the clients, table-driven for the primitives); the live-DC read transcript is deferred (no DC in CI) and gates Experimental → Accepted.
- **Rollout:** No infra change in-repo; per-developer the `sso-broker` Playwright dep surfaces on first `register`.

## Deferred

- `atlassian-sso-cookie-live-dc-read-transcript` (AC19) — manual QA against a real DC instance.
- `atlassian-sso-cookie-success-url-pattern-host-confinement` — broker-flow URL, not a cookie-send target.
- `atlassian-sso-cookie-selector-integration-test` — CLI entrypoint not import-safe.

All recorded in `docs/backlog.md`.