### PR TITLE
release(agentbundle): 0.5.0 — ship pack profiles + kiro alias parity

### DIFF
--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -6,6 +6,29 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 — a minor bump on a 0.x release MAY be breaking.
 
+## [0.5.0] — 2026-06-16
+
+### Added
+
+- **Curated install profiles — `install --profile <name>` and `list-profiles`**
+  (RFC-0034). A profile is a first-party `profiles/<name>.toml` at a catalogue
+  root naming a single-scope, deps-first set of packs an adopter installs in
+  one command. `agentbundle install --profile <name> <catalogue>` pins one
+  scope and one adapter for the whole batch, runs the full read-only pre-flight
+  for every pack before writing any, then installs each in authored order;
+  `agentbundle list-profiles <catalogue>` browses what a catalogue offers.
+  Adds zero primitives and zero adapter-contract surface — the CLI reads the
+  manifest, the catalogue carries it.
+
+### Fixed
+
+- **`agentbundle install --adapter kiro` now behaves exactly like `kiro-ide`**
+  (RFC-0022 alias parity). The `kiro` → `kiro-ide` alias is now canonicalized
+  at every install-path decision site, not just the build registry.
+- **`--version` reports the package version.** `CLI_VERSION` had drifted to
+  `0.1.0` and was printed by `agentbundle --version` regardless of the released
+  version; it now tracks the package version (`0.5.0`).
+
 ## [0.4.0] — 2026-06-14
 
 ### Added

--- a/packages/agentbundle/README.md
+++ b/packages/agentbundle/README.md
@@ -21,6 +21,12 @@ That lands `core`, the flagship pack and the loop itself, in your repo. Claude C
 # See what's in a catalogue
 agentbundle list-packs git+https://github.com/eugenelim/agent-ready-repo
 
+# See the catalogue's curated install profiles
+agentbundle list-profiles git+https://github.com/eugenelim/agent-ready-repo
+
+# Install a whole curated profile — a single-scope set of packs — in one command
+agentbundle install --profile inception git+https://github.com/eugenelim/agent-ready-repo
+
 # Install the flagship loop into this repo
 agentbundle install --pack core git+https://github.com/eugenelim/agent-ready-repo
 
@@ -34,7 +40,7 @@ agentbundle install --pack core git+https://github.com/eugenelim/agent-ready-rep
 agentbundle upgrade --pack core --to 0.4.0 git+https://github.com/eugenelim/agent-ready-repo
 ```
 
-A catalogue is a git URL or a local path. Installs auto-detect your agent; pass `--adapter` to override.
+A catalogue is a git URL or a local path. Installs auto-detect your agent; pass `--adapter` to override. A **profile** is a catalogue-curated, single-scope set of packs you install in one command — it declares its own scope, so `--scope` doesn't apply.
 
 ## Build your own catalogue
 

--- a/packages/agentbundle/agentbundle/version.py
+++ b/packages/agentbundle/agentbundle/version.py
@@ -14,7 +14,7 @@ import tomllib
 from importlib.resources import files
 from pathlib import Path
 
-CLI_VERSION = "0.1.0"
+CLI_VERSION = "0.5.0"
 
 _HERE = Path(__file__).resolve().parent
 

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentbundle"
-version = "0.4.0"
+version = "0.5.0"
 description = "npm for your coding agent. Install packs of skills, subagents, and hooks into any repo, for every major agent."
 requires-python = ">=3.11"
 dependencies = []


### PR DESCRIPTION
## Why

PyPI `agentbundle 0.4.0` **can't install by profile** — it has no `install --profile` flag and no `list-profiles` command:

```
$ agentbundle install --profile inception .
error: the following arguments are required: --pack
$ agentbundle list-profiles .
error: argument <command>: invalid choice: 'list-profiles'
```

The profile feature lives in the agentbundle **wheel** (`commands/profile.py`, `_run_profile` in `install.py`, the `--profile` arg in `cli.py`), not the catalogue — so no catalogue change can deliver it to a 0.4.0 user. The feature (RFC-0034, #331) and the kiro→kiro-ide alias parity fix (RFC-0022, #330) both landed **after** the 0.4.0 release (`65fcc76`, #327) without bumping the version. Repo-HEAD and PyPI are both labelled `0.4.0` but are different code.

## What

- **Bump `pyproject.toml` 0.4.0 → 0.5.0** (new feature = SemVer minor) so the profile feature can be published.
- **Fix `CLI_VERSION` drift** — it was hardcoded `"0.1.0"` and printed by `agentbundle --version` for every release (the release workflow only asserts `pyproject==tag`, never `CLI_VERSION`). Now tracks the package version: `agentbundle 0.5.0 (spec 0.14)`.
- **`CHANGELOG.md`** `[0.5.0]` section covering profiles, the kiro alias fix, and the `--version` correction. (The project-level `docs/product/changelog.md` already records the user-visible profile + kiro entries under `[Unreleased]`.)
- **PyPI README** — `packages/agentbundle/README.md` is the package long-description and had no mention of profiles. Added `list-profiles` + `install --profile` to **Common commands** and a one-line profile definition, so the 0.5.0 PyPI page both has the capability and describes it.

## Shipping

This PR only prepares the release. After merge to `main`, push tag `agentbundle-v0.5.0` to trigger `release-agentbundle.yml` (build + smoke + PyPI publish).

## Follow-up (surfaced, not done here)

The `CLI_VERSION` drift recurs every release because nothing asserts it equals `pyproject` version. Recommend a guard in `release-agentbundle.yml` (or a unit test) asserting `CLI_VERSION == pyproject version` so `--version` can't silently lie again. Out of scope for this bump — flagging for a decision.