### PR TITLE
docs: surface the guides home in README; install core before init-project

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ A fourth subagent, `implementer`, is the loop's own executor. It runs independen
 
 | Pack | Scope | What it ships |
 | --- | --- | --- |
-| [`core`](docs/guides/core/) | **repo** | **The flagship pack.** The loop: `work-loop`, `new-spec`, `bug-fix`, `adapt-to-project` skills, the four reviewer/executor subagents, `pre-pr` + `session-start` hooks, and governance seeds. **Install this even if you install nothing else.** |
+| [`core`](docs/guides/core/) | **repo** | **The flagship pack.** The loop: `init-project`, `work-loop`, `new-spec`, `bug-fix`, `adapt-to-project` skills, the four reviewer/executor subagents, `pre-pr` + `session-start` hooks, and governance seeds. **Install this even if you install nothing else.** |
 | [`governance-extras`](docs/guides/governance-extras/) | repo | RFC/ADR ceremony for teams and long-lived repos that need a written trail for decisions — `new-rfc`, `new-adr`, `update-conventions` plus the `docs/rfc/` and `docs/adr/` shapes. |
 | [`user-guide-diataxis`](docs/guides/user-guide-diataxis/) | repo | Diátaxis docs skeleton — `docs/guides/{tutorials,how-to,reference,explanation}` plus `new-guide`. |
 | [`monorepo-extras`](docs/guides/monorepo-extras/) | repo | Monorepo scaffolding — `new-package` and a `packages/_example/` template. |
@@ -94,6 +94,8 @@ Adopt the catalogue as-is, or use it as the base for your own. The same bundler 
 That makes this a foundation for an organization's AI dev kit, not just a set of defaults to consume.
 
 ## Going deeper
+
+The full user documentation lives in **[`docs/guides/`](docs/guides/)** — organized by pack, with tutorials, how-tos, reference, and explanation for each ([Diátaxis](https://diataxis.fr/)). Start there to learn a pack end to end; the table below jumps straight to the cross-cutting topics.
 
 | Topic | Link |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ A fourth subagent, `implementer`, is the loop's own executor. It runs independen
 
 | Pack | Scope | What it ships |
 | --- | --- | --- |
-| [`core`](docs/guides/core/) | **repo** | **The flagship pack.** The loop: `init-project`, `work-loop`, `new-spec`, `bug-fix`, `adapt-to-project` skills, the four reviewer/executor subagents, `pre-pr` + `session-start` hooks, and governance seeds. **Install this even if you install nothing else.** |
+| [`core`](docs/guides/core/) | **repo** | **The flagship pack.** The loop: `work-loop`, `new-spec`, `bug-fix`, `adapt-to-project` skills, the four reviewer/executor subagents, `pre-pr` + `session-start` hooks, and governance seeds. **Install this even if you install nothing else.** |
 | [`governance-extras`](docs/guides/governance-extras/) | repo | RFC/ADR ceremony for teams and long-lived repos that need a written trail for decisions — `new-rfc`, `new-adr`, `update-conventions` plus the `docs/rfc/` and `docs/adr/` shapes. |
 | [`user-guide-diataxis`](docs/guides/user-guide-diataxis/) | repo | Diátaxis docs skeleton — `docs/guides/{tutorials,how-to,reference,explanation}` plus `new-guide`. |
 | [`monorepo-extras`](docs/guides/monorepo-extras/) | repo | Monorepo scaffolding — `new-package` and a `packages/_example/` template. |

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -8,7 +8,7 @@ The user-facing documentation for the catalogue, organized **by pack**. You inst
 
 | Pack | Start here | What it ships |
 | --- | --- | --- |
-| [`core`](core/) | **The flagship.** | The loop — `init-project`, `work-loop`, `new-spec`, `bug-fix`, `adapt-to-project`, the reviewers, the hooks. Install this even if you install nothing else. |
+| [`core`](core/) | **The flagship.** | The loop — `work-loop`, `new-spec`, `bug-fix`, `adapt-to-project`, the reviewers, the hooks. Install this even if you install nothing else. |
 | [`architect`](architect/) | [home](architect/) | Solution architecture — `architect-design`, `architect-diagram`, `architect-review`, and the `reference.md` golden path. |
 | [`research`](research/) | [home](research/) | Evidence-grounded research — `research` with selectable depth, plus the pipeline skills (`source-map`, `compare-hypotheses`, `devils-advocate`, …). |
 | [`product-engineering`](product-engineering/) | [home](product-engineering/) | Shape product intent into shippable specs — the recursive `intent` tree (`frame`, `de-risk`, `decompose`, `align-value-stream`). |

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -8,7 +8,7 @@ The user-facing documentation for the catalogue, organized **by pack**. You inst
 
 | Pack | Start here | What it ships |
 | --- | --- | --- |
-| [`core`](core/) | **The flagship.** | The loop — `work-loop`, `new-spec`, `bug-fix`, `adapt-to-project`, the reviewers, the hooks. Install this even if you install nothing else. |
+| [`core`](core/) | **The flagship.** | The loop — `init-project`, `work-loop`, `new-spec`, `bug-fix`, `adapt-to-project`, the reviewers, the hooks. Install this even if you install nothing else. |
 | [`architect`](architect/) | [home](architect/) | Solution architecture — `architect-design`, `architect-diagram`, `architect-review`, and the `reference.md` golden path. |
 | [`research`](research/) | [home](research/) | Evidence-grounded research — `research` with selectable depth, plus the pipeline skills (`source-map`, `compare-hypotheses`, `devils-advocate`, …). |
 | [`product-engineering`](product-engineering/) | [home](product-engineering/) | Shape product intent into shippable specs — the recursive `intent` tree (`frame`, `de-risk`, `decompose`, `align-value-stream`). |

--- a/docs/guides/core/tutorials/start-a-new-project.md
+++ b/docs/guides/core/tutorials/start-a-new-project.md
@@ -11,7 +11,14 @@ We'll use one concrete idea throughout: **a URL-shortener service** — an API t
 You need:
 
 - An empty (or nearly empty) repo you can commit to.
-- The `init-project` skill available in your repo.
+- The `init-project` skill, which ships in the `core` pack. If you haven't installed `core` into this repo yet, do that first:
+
+  ```bash
+  pip install agentbundle
+  agentbundle install --pack core git+https://github.com/eugenelim/agent-ready-repo
+  ```
+
+  Then start a fresh agent session so it picks up the new skill.
 - A discovery shape to feed in — for this tutorial, a one-paragraph PRD is enough: *"Users paste a long URL and get back a short link they can share; links resolve fast and never expire. MVP: create a short link and resolve it."* (In real use this comes from the `research` skill or a `receive-brief` brief; a written PRD works the same way.)
 
 ## Step 1 — Start the flow and pass the trigger gate


### PR DESCRIPTION
## Why

Two discoverability gaps in the user docs:

1. **The root README never named `docs/guides/` as the documentation home.** The only paths into the guides were per-pack rows scattered in the catalogue table — there was no single "here are the docs" entry.
2. **The `start-a-new-project` tutorial assumed `init-project` was already "available in your repo"** without saying it ships in the `core` pack or how to install it. A reader following the greenfield front door would hit a skill that isn't there.

## What changed

- **README — guides home.** Added a pointer at the top of *Going deeper* naming `docs/guides/` as the full user documentation (by pack, Diátaxis-organized), with the topic table reframed as the cross-cutting shortcuts.
- **Tutorial — install `core` first.** `start-a-new-project.md` "Before you begin" now states `init-project` ships in `core`, gives the install one-liner, and notes a fresh agent session is needed to pick up the new skill.

## Notes

- All touched files are repo-owned (root README and `docs/guides/**` edited directly; `build-self` skips `docs/guides/**`) — no projection rebuild needed.
- Docs-only correctness/discoverability fix, no behavior change — no changelog entry (the changelog warn keys on code that changes user-visible behavior).
- No link/markdown lint gates these paths; verified `docs/guides/` resolves.