### PR TITLE
feat(converters): markdown→office publishing skills (RFC-0036)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -57,19 +57,20 @@
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",
       "category": "file-conversion",
-      "description": "File-format conversion skills: documents and images \u2192 Markdown; Markdown \u2192 styled HTML; Outlook .msg \u2192 Markdown.",
+      "description": "File-format conversion skills: documents and images \u2192 Markdown; Markdown \u2192 styled HTML and to branded Word, PowerPoint, and Excel; Outlook .msg \u2192 Markdown.",
       "displayName": "Converters",
       "homepage": "https://github.com/eugenelim/agent-ready-repo",
       "keywords": [
         "markdown",
         "html",
         "msg",
-        "pdf"
+        "pdf",
+        "office"
       ],
       "license": "Apache-2.0 OR MIT",
       "name": "converters",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.1.2"
+      "version": "0.2.0"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -284,13 +284,14 @@ jobs:
 
       - name: converters evals.json carry-over disposition (AC4 + AC4a)
         run: |
-          # Pin the spec's three-skill disposition mechanically:
-          # file-to-markdown and markdown-to-html ship evals.json
-          # (carried verbatim from source); msg-to-markdown must NOT
-          # (spec § Never do: "No synthesised evals/evals.json for
-          # msg-to-markdown"). Enumerated rather than glob-iterated so
-          # a future skill addition can't silently change the contract.
-          for skill in file-to-markdown markdown-to-html; do
+          # Pin the spec's skill disposition mechanically:
+          # file-to-markdown, markdown-to-html, and the three Markdown→Office
+          # skills (markdown-to-docx/-pptx/-xlsx, RFC-0036) ship evals.json;
+          # msg-to-markdown must NOT (converters spec § Never do: "No
+          # synthesised evals/evals.json for msg-to-markdown"). Enumerated
+          # rather than glob-iterated so a future skill addition can't
+          # silently change the contract.
+          for skill in file-to-markdown markdown-to-html markdown-to-docx markdown-to-pptx markdown-to-xlsx; do
             f="packs/converters/.apm/skills/${skill}/evals/evals.json"
             if [ ! -f "$f" ]; then
               echo "::error::AC4: ${f} missing (carry-over disposition)"
@@ -302,6 +303,30 @@ jobs:
             echo "::error::AC4: msg-to-markdown/evals/ exists; spec forbids synthesised evals for this skill"
             exit 1
           fi
+
+      # markdown-to-office-publishing (RFC-0036): the three Markdown→Office
+      # render skills carry TDD suites under their skill scripts/, which neither
+      # `make build-check` nor any package pytest discovers. Wire each in
+      # explicitly or its renderer (manifest enumeration, content mapping,
+      # --check probe, output-path confinement, autoescape, chart survival, the
+      # per-format end-to-end render) never gates. Each Tier-1 render library is
+      # pip-installed first (these libraries are user-installed at runtime, not
+      # bundled), mirroring the atlassian httpx install above.
+      # Pinned to exact known-good versions so the gated artifact is
+      # reproducible (docxtpl's get_undeclared_template_variables() has had
+      # version-specific breakage — see plan § Risks). The SKILL.md prereqs
+      # keep the `>=floor` guidance for users; CI pins what it actually tested.
+      - name: pip install the Markdown→Office render libraries (RFC-0036)
+        run: pip install 'python-pptx==1.0.2' 'docxtpl==0.20.2' 'openpyxl==3.1.5' 'python-docx==1.2.0'
+      - name: pytest markdown-to-pptx renderer (markdown-to-office-publishing)
+        working-directory: packs/converters/.apm/skills/markdown-to-pptx/scripts
+        run: python -m pytest test_render.py
+      - name: pytest markdown-to-docx renderer (markdown-to-office-publishing)
+        working-directory: packs/converters/.apm/skills/markdown-to-docx/scripts
+        run: python -m pytest test_render.py
+      - name: pytest markdown-to-xlsx renderer (markdown-to-office-publishing)
+        working-directory: packs/converters/.apm/skills/markdown-to-xlsx/scripts
+        run: python -m pytest test_render.py
 
       - name: profiles lint + self-test (pack-profiles AC9)
         # RFC-0034: profiles must be scope-homogeneous, dependency-complete

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ A fourth subagent, `implementer`, is the loop's own executor. It runs independen
 | [`monorepo-extras`](docs/guides/monorepo-extras/) | repo | Monorepo scaffolding — `new-package` and a `packages/_example/` template. |
 | [`research`](docs/guides/research/) | user / repo | Evidence-grounded research — `research`, `source-map`, `compare-hypotheses`, `devils-advocate`, and more, plus two retrieval subagents. |
 | [`contracts`](docs/guides/contracts/) | user / repo | Contract authoring — `api-contract` for OpenAPI 3.1. |
-| [`converters`](docs/guides/converters/) | user / repo | `file-to-markdown` (PDF/DOCX/PPTX/XLSX + images), `markdown-to-html`, `msg-to-markdown`, `mermaid-renderer`. |
+| [`converters`](docs/guides/converters/) | user / repo | `file-to-markdown` (PDF/DOCX/PPTX/XLSX + images), `markdown-to-html`, `markdown-to-docx`/`markdown-to-pptx`/`markdown-to-xlsx` (Markdown → branded Word/PowerPoint/Excel by template-fill), `msg-to-markdown`, `mermaid-renderer`. |
 | [`atlassian`](docs/guides/atlassian/) | user / repo | `jira`, `jira-align`, `confluence-crawler`, `confluence-publisher` (credentialed) plus `flow-metrics`, `ai-adoption-report`, `jira-defect-flow`. |
 | [`figma`](docs/guides/figma/) | user / repo | Figma REST primitive (credentialed) — reads files/nodes/comments/variables, renders frames, FigJam → Mermaid. |
 | [`architect`](docs/guides/architect/) | user / repo | Solution architecture — `architect-design`, `architect-diagram`, `architect-review`, plus a read-only, forked-context `design-reviewer` subagent for independent design critique. |

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -734,3 +734,21 @@ projection), ordered correctly against the hook-wiring unproject (the orphaned
 agent JSON is also the old merge target) and gated to whole-pack (not
 `--<primitive>`) upgrades. Pinned by an `@unittest.expectedFailure` in
 `test_upgrade_user_hooks.py::LegacyKiroJsonUpgradeMigrationTests`.
+
+---
+
+## `markdown-to-office-publishing`
+
+### office-render-libs-pip-audit
+
+**Spec:** [markdown-to-office-publishing](specs/markdown-to-office-publishing/spec.md)
+No AC — a consciously-deferred follow-on (plan § Dependencies). The three Tier-1
+render libraries (`python-pptx` / `docxtpl` / `openpyxl`) install into the
+*user's* runtime and into CI ephemerally for the per-skill pytest steps, so they
+sit **outside the repo's SCA** (`make sast` / `pip-audit` only audits the repo's
+own pinned tree). A future CVE in any of them is invisible to the project's
+gates. This is the accepted Tier-1 "user owns currency" posture, not a defect.
+**Unblocks when:** a CI step runs `pip-audit` over the exact installed render-lib
+set (the versions pinned in `build-check.yml`'s "pip install the Markdown→Office
+render libraries" step), so the SCA gap becomes a tracked, gating check rather
+than a documented accepted-state.

--- a/docs/guides/converters/README.md
+++ b/docs/guides/converters/README.md
@@ -1,6 +1,6 @@
 # `converters` — guides
 
-Get documents into Markdown and back out again. The `converters` pack is four focused skills: pull text out of office files and diagrams (`file-to-markdown`), bake Mermaid fences into real images (`mermaid-renderer`), turn Markdown into a self-contained styled HTML page (`markdown-to-html`), and read Outlook `.msg` email into Markdown (`msg-to-markdown`). Each one is a thin wrapper: the agent invokes a script and reports where the output landed.
+Get documents into Markdown and back out again. The `converters` pack: pull text out of office files and diagrams (`file-to-markdown`), bake Mermaid fences into real images (`mermaid-renderer`), turn Markdown into a self-contained styled HTML page (`markdown-to-html`), publish Markdown back out as a branded Word doc / PowerPoint deck / Excel workbook by filling your template (`markdown-to-docx`, `markdown-to-pptx`, `markdown-to-xlsx`), and read Outlook `.msg` email into Markdown (`msg-to-markdown`). Each one is a thin wrapper: the agent invokes a script and reports where the output landed.
 
 New here? Start with [Convert documents to Markdown](how-to/convert-documents-to-markdown.md) — it's the entry point for most of what this pack does. Then chain the others: render the diagrams in your Markdown, or push it out as HTML.
 
@@ -11,6 +11,7 @@ Task-oriented recipes for a problem you already have.
 - [Convert documents to Markdown](how-to/convert-documents-to-markdown.md) — PDF, DOCX, PPTX, XLSX, and images into clean Markdown.
 - [Render Mermaid diagrams to images](how-to/render-mermaid-diagrams.md) — bake `mermaid` fences into PNG or SVG for tools that don't render Mermaid live.
 - [Convert Markdown to HTML and email to Markdown](how-to/convert-markdown-to-html-and-email.md) — Markdown out to a shareable HTML page, and Outlook `.msg` in to Markdown.
+- [Publish Markdown as a branded Office file](how-to/publish-markdown-to-office.md) — fill your Word / PowerPoint / Excel template from a Markdown artifact, brand intact.
 
 ## Reference
 

--- a/docs/guides/converters/how-to/publish-markdown-to-office.md
+++ b/docs/guides/converters/how-to/publish-markdown-to-office.md
@@ -1,0 +1,93 @@
+# Publish Markdown as a branded Office file
+
+You've got a polished Markdown artifact — a report, a deck outline, a tabular
+summary — and a stakeholder who wants it as a real Word doc, PowerPoint, or Excel
+file, on-brand. Three `converters` skills do that by **filling your branded
+template** at the fill-points a designer already laid out, so the cover page,
+slide master, logo, and named cell regions survive. They never convert Markdown
+into a fresh document, and they never invent a brand.
+
+| Want | Skill | Asks for |
+|---|---|---|
+| A Word document | `markdown-to-docx` | A `.docx` template with Jinja tags |
+| A PowerPoint deck | `markdown-to-pptx` | A `.pptx` template (layouts already have placeholders) |
+| An Excel workbook | `markdown-to-xlsx` | An `.xlsx` template with named ranges / Tables |
+
+## Just ask
+
+Lead with the file you have and the template to fill — the agent picks the right
+skill and runs the script:
+
+- "Turn `q3-report.md` into a Word doc using our `report-template.docx`."
+- "Make `q3-report.md` into a PowerPoint deck from `brand-deck.pptx`."
+- "Export the metrics table in `q3-report.md` to Excel, filling `metrics.xlsx`."
+
+The agent confirms the render library is installed, inspects the template's
+fill-points, projects your Markdown onto them, and reports the output path. You
+don't describe the placeholders or write any code.
+
+## The one thing each skill needs: a template with fill-points
+
+This is template-fill, not conversion — so each format needs somewhere to put
+the content:
+
+- **PowerPoint** is ready by construction. Every `.pptx` layout already carries
+  placeholders, so any deck works as a template.
+- **Word** needs **Jinja tags** typed into the `.docx`: `{{ title }}` for a
+  scalar, a `{%p for it in items %}{{ it }}{%p endfor %}` paragraph loop for a
+  list, a `{%tr for r in rows %}` row loop for a table. Author each tag in **one
+  uniform run** — if Word splits a tag across runs (a stray autocorrect mid-tag),
+  it won't fill. If the template has no tags, the skill tells you how to add them
+  rather than converting blindly.
+- **Excel** needs **named ranges** (Formulas → Define Name) for scalars and an
+  **Excel Table** (Insert → Table) for tabular data. Front-matter keys fill the
+  named range of the same name; a Markdown table fills the Table's data region.
+  If the workbook has none, the skill tells you how to add them.
+
+## How the Markdown maps
+
+Front-matter and document structure map onto the template the same way across
+the three skills:
+
+| Markdown | Where it lands |
+|---|---|
+| Front-matter `key: value` | A scalar fill-point named `key` (title placeholder / `{{ key }}` / named range) |
+| `#` / `##` headings | A slide per heading (pptx); a `sections` loop (docx) |
+| Lists | Bullet rows (pptx); a paragraph loop (docx) |
+| Tables | A slide table (pptx); a `{%tr %}` row loop (docx); an Excel Table data region (xlsx) |
+
+## Before the first run
+
+Each skill is **Tier-1** on its render library — you install it once, and the
+skill stops with the exact command if it's missing (it never installs for you):
+
+```bash
+python -m pip install 'python-pptx>=1.0.0'   # markdown-to-pptx
+python -m pip install 'docxtpl>=0.16.0'       # markdown-to-docx
+python -m pip install 'openpyxl>=3.1.0'       # markdown-to-xlsx
+```
+
+These libraries install into **your** environment, outside the repo's security
+scanning, so you own keeping them current.
+
+## What to watch for
+
+- **No template?** Say so explicitly. The skill will render with the library
+  default and tell you up front that the result is unbranded — it won't silently
+  guess a brand.
+- **Excel charts.** `markdown-to-xlsx` writes only into data cells and never
+  resizes a range, so a chart reading that range keeps working. For a workbook
+  with complex Excel-authored drawings, re-open the result and confirm the
+  visuals survived — openpyxl can drop shapes it can't parse.
+- **Untrusted templates.** Treat a template like any file you'd open — these
+  skills assume a trusted author. A `.docx` carries Jinja source, so don't fill a
+  template you didn't vet.
+
+## Next steps
+
+- Every flag and stdout marker: [Converter skills reference](../reference/converter-skills.md).
+- Coming the other way? [Convert documents to Markdown](convert-documents-to-markdown.md).
+- The skill sources:
+  [`markdown-to-docx`](../../../../packs/converters/.apm/skills/markdown-to-docx/SKILL.md),
+  [`markdown-to-pptx`](../../../../packs/converters/.apm/skills/markdown-to-pptx/SKILL.md),
+  [`markdown-to-xlsx`](../../../../packs/converters/.apm/skills/markdown-to-xlsx/SKILL.md).

--- a/docs/guides/converters/reference/converter-skills.md
+++ b/docs/guides/converters/reference/converter-skills.md
@@ -1,12 +1,15 @@
 # Converter skills
 
-The four skills in the `converters` pack, their inputs, outputs, flags, and prerequisites. Each skill is a thin wrapper: the agent invokes a script and reports the result.
+The skills in the `converters` pack, their inputs, outputs, flags, and prerequisites. Each skill is a thin wrapper: the agent invokes a script and reports the result.
 
 | Skill | Direction | Engine |
 | --- | --- | --- |
 | [`file-to-markdown`](#file-to-markdown) | documents/images → Markdown | Docling / vision pipeline |
 | [`mermaid-renderer`](#mermaid-renderer) | Markdown → Markdown + images | Mermaid CLI (`mmdc`) |
 | [`markdown-to-html`](#markdown-to-html) | Markdown → HTML | `marked` + `highlight.js` |
+| [`markdown-to-docx`](#markdown-to-docx) | Markdown → branded Word (template-fill) | `docxtpl` |
+| [`markdown-to-pptx`](#markdown-to-pptx) | Markdown → branded PowerPoint (template-fill) | `python-pptx` |
+| [`markdown-to-xlsx`](#markdown-to-xlsx) | Markdown → branded Excel (template-fill) | `openpyxl` |
 | [`msg-to-markdown`](#msg-to-markdown) | Outlook `.msg` → Markdown | `@nicecode/msg-reader` / `msgreader` |
 
 ---
@@ -170,6 +173,108 @@ Writes the HTML file and prints three stdout lines:
 | No headings | Sidebar shows `(no sections)`; output still works |
 | Unknown theme | Exits with the list of valid choices |
 | Offline output wanted with Mermaid present | Pass `--no-mermaid`; the block falls back to a plain `<pre>` |
+
+---
+
+## `markdown-to-docx`
+
+Fill a branded Word template from a Markdown artifact. Template-fill via `docxtpl` — the designer's cover page, styles, headers, and logo survive; the skill never converts Markdown into a fresh document.
+
+**Source:** [`packs/converters/.apm/skills/markdown-to-docx/`](../../../../packs/converters/.apm/skills/markdown-to-docx/SKILL.md)
+
+### Prerequisites
+
+Tier-1 on `docxtpl` (exact canonical PyPI package). Install with `python -m pip install 'docxtpl>=0.16.0'` (the floor clears a version where `get_undeclared_template_variables()` was broken). The library installs into your environment, outside the repo's SCA. Verify with `python scripts/render.py --check` (exit 0 → ready; exit 2 → not installed).
+
+### Commands
+
+```bash
+python scripts/render.py --check
+python scripts/render.py inspect <template.docx>
+python scripts/render.py render <markdown> --template <template.docx> [--output <path>]
+```
+
+| Verb | Purpose |
+| --- | --- |
+| `--check` | Import-probe `docxtpl`; exit 0/2. |
+| `inspect <template>` | List the template's declared Jinja variables. |
+| `render <markdown> --template <tpl>` | Fill the template and write a `.docx`. Default output: `<basename>.docx` in CWD. |
+
+### Fill-points and mapping
+
+A `.docx` has no fill-points until you add Jinja tags: `{{ var }}` (scalar), `{%p for it in items %}…{%p endfor %}` (paragraph loop), `{%tr for r in rows %}…{%tr endfor %}` (table-row loop). Mapping: front-matter `key: value` → `{{ key }}`; the first list → `items`; the first Markdown table → `rows` (list of `{column: value}` dicts). Author each tag in one uniform run or Word's run-splitting will hide it.
+
+### Outputs and edge cases
+
+Stdout: `OUTPUT:`, `FILLED:`, `WARNING:`, and `GUIDANCE:` (emitted instead of `OUTPUT:` when the template has no tags). Renders with `autoescape=True`, so user content with `<`/`&`/`{{` is XML-escaped, not interpolated. A user-supplied template is trusted-author input — a malicious template author could embed SSTI; that (and XXE / zip-bomb) is an accepted, out-of-scope risk. The output write is confined under the working directory. Omit `--template` only on the user's explicit opt-out — the skill then writes an unbranded `.docx` via `python-docx` (with a `WARNING:`).
+
+---
+
+## `markdown-to-pptx`
+
+Fill a branded PowerPoint template from a Markdown artifact. Template-fill via `python-pptx` — the slide master, theme, fonts, and placed logo survive.
+
+**Source:** [`packs/converters/.apm/skills/markdown-to-pptx/`](../../../../packs/converters/.apm/skills/markdown-to-pptx/SKILL.md)
+
+### Prerequisites
+
+Tier-1 on `python-pptx`. Install with `python -m pip install 'python-pptx>=1.0.0'`. Installs outside the repo's SCA. Verify with `python scripts/render.py --check`.
+
+### Commands
+
+```bash
+python scripts/render.py --check
+python scripts/render.py inspect <template.pptx>
+python scripts/render.py render <markdown> --template <template.pptx> [--output <path>]
+```
+
+| Verb | Purpose |
+| --- | --- |
+| `--check` | Import-probe `python-pptx`; exit 0/2. |
+| `inspect <template>` | List the layout placeholders (`layout`/`idx`/`type`/`name`). |
+| `render <markdown> --template <tpl>` | Fill the deck and write a `.pptx`. Default output: `<basename>.pptx` in CWD. |
+
+### Fill-points and mapping
+
+PowerPoint layouts already carry placeholders, keyed by their stable `idx` — so every `.pptx` is fillable (no "untagged template" case). Mapping: front-matter `title`/`subtitle` → the title slide; each `#`/`##` heading → one slide; list items → bullet rows; a Markdown table → a `TABLE` placeholder if the layout has one, else a table added to the slide.
+
+### Outputs and edge cases
+
+Stdout: `OUTPUT:`, `FILLED:`, `WARNING:`. `python-pptx` evaluates no template content as code, so there is no SSTI surface; XXE / zip-bomb on a crafted archive is an accepted, out-of-scope risk. The output write is confined under the working directory. Omit `--template` only on the user's explicit opt-out (renders with the python-pptx default master; unbranded).
+
+---
+
+## `markdown-to-xlsx`
+
+Fill a branded Excel template from a Markdown artifact. Template-fill via `openpyxl` — writes into named ranges and Excel Tables only, so formatting, formulas, and charts survive.
+
+**Source:** [`packs/converters/.apm/skills/markdown-to-xlsx/`](../../../../packs/converters/.apm/skills/markdown-to-xlsx/SKILL.md)
+
+### Prerequisites
+
+Tier-1 on `openpyxl`. Install with `python -m pip install 'openpyxl>=3.1.0'`. Installs outside the repo's SCA. Verify with `python scripts/render.py --check`.
+
+### Commands
+
+```bash
+python scripts/render.py --check
+python scripts/render.py inspect <template.xlsx>
+python scripts/render.py render <markdown> --template <template.xlsx> [--output <path>]
+```
+
+| Verb | Purpose |
+| --- | --- |
+| `--check` | Import-probe `openpyxl`; exit 0/2. |
+| `inspect <template>` | List named ranges + Excel Tables (`kind`/`name`/`ref`). |
+| `render <markdown> --template <tpl>` | Fill the data ranges and write a `.xlsx`. Default output: `<basename>.xlsx` in CWD. |
+
+### Fill-points and mapping
+
+A workbook needs **named ranges** (for scalars) and/or **Excel Tables** (for tabular data) defined beforehand. Mapping: front-matter `key: value` → the single-cell named range called `key`; the first Markdown table → the first Excel Table's data region (columns aligned by header, else by position).
+
+### Outputs and edge cases
+
+Stdout: `OUTPUT:`, `FILLED:`, `WARNING:`, and `GUIDANCE:` (when the workbook has no fill-points). The script writes only into data cells and never resizes a range, so a chart reading it keeps working; a Markdown table longer than the Excel Table is truncated with a `WARNING:`, never expanded. `openpyxl` preserves charts/images it can parse on round-trip, but its tutorial warns shapes it cannot read are lost — re-open and verify for complex templates. The output write is confined under the working directory. Omit `--template` only on the user's explicit opt-out — the skill then writes an unbranded `.xlsx` via a bare `openpyxl` workbook (with a `WARNING:`).
 
 ---
 

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -19,6 +19,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Markdown → Office publishing skills (`converters` pack, RFC-0036).** Three new
+  skills publish a Markdown artifact back out as a distribution-ready, on-brand
+  Office file by **filling a user-provided template** at its existing fill-points —
+  `markdown-to-docx` (Word, via `docxtpl`), `markdown-to-pptx` (PowerPoint, via
+  `python-pptx`), and `markdown-to-xlsx` (Excel, via `openpyxl`). A designer's
+  cover page, slide master, logo, and named cell regions survive because the skill
+  fills the template rather than converting Markdown into a fresh document. Each
+  detects a template, confirms or elicits one, and proceeds unbranded only on the
+  user's explicit opt-out — it never invents a brand and never auto-installs its
+  Tier-1 render library. This completes the pack's Office round-trip, which until
+  now ran only inward (Office → Markdown). The `converters` pack is bumped to
+  `0.2.0`. See
+  [Publish Markdown as a branded Office file](../guides/converters/how-to/publish-markdown-to-office.md).
 - **SSO web-session cookie auth for `jira` reads + `confluence-crawler` (atlassian
   pack, RFC-0035).** On an Atlassian Data Center instance behind corporate SSO
   where API tokens are blocked, both skills can now authenticate by a captured web

--- a/docs/rfc/0036-markdown-to-office-publishing.md
+++ b/docs/rfc/0036-markdown-to-office-publishing.md
@@ -221,3 +221,23 @@ Filled in on acceptance:
 - **Spec:** `docs/specs/markdown-to-office-publishing/` (via `new-spec`) — the three skills, each with a lean `SKILL.md` + `references/` + a deterministic render `scripts/` entry; the `## Prerequisites` Tier-1 `--check` verb; the detect→confirm→elicit→opt-out template flow; the inspect-then-map fill-point manifest + Markdown mapping; the `converters` version bump + `marketplace.json` refresh; activation-tuned names/descriptions.
 - **User docs (decision 7):** a new `docs/guides/converters/how-to/publish-markdown-to-office.md`, an extension to `docs/guides/converters/reference/converter-skills.md`, and a `docs/product/changelog.md` `[Unreleased]` entry — authored in the implementing PR alongside the skills.
 - **Possible ADR** — only if the template-fill-over-convert choice warrants a durable architectural record beyond this RFC; likely unnecessary (this RFC is the record).
+
+## Errata
+
+Post-acceptance corrections recorded against this frozen RFC (the original
+decisions stand; these refine imprecise wording surfaced during
+implementation).
+
+- **E1 — `openpyxl` chart/shape preservation (2026-06-17, implementing PR; Approver: eugenelim).**
+  The Risks/library-notes wording (this RFC's "*openpyxl drops charts/images on
+  load-and-save*" / "**never load-and-resave the chart objects**") diverges from
+  observed behavior: `openpyxl` 3.1.x **preserves** the charts and images it can
+  parse through a load-and-resave, and the loss its own tutorial documents is of
+  **shapes it cannot read**. Filling named ranges / Excel Tables *inherently*
+  requires a `load_workbook` + `save`, so a literal "never load-and-resave" rule
+  is unrealizable. The **decision is unchanged** — *inject into data ranges only;
+  never manipulate, recreate, or resize chart/shape objects or a range's extent*
+  — which is exactly what `markdown-to-xlsx` implements and what preserves a
+  chart that reads a filled range. The implementing spec's Boundary and AC carry
+  the corrected wording and the `SKILL.md` documents the accurate
+  shape-loss caveat. No change to the proposal's mitigation intent.

--- a/docs/specs/markdown-to-office-publishing/notes/activation-grading.md
+++ b/docs/specs/markdown-to-office-publishing/notes/activation-grading.md
@@ -1,0 +1,49 @@
+# Activation grading — markdown-to-{docx,pptx,xlsx}
+
+Recorded manual-QA pass (T4) over the three skills' `description` frontmatter and
+`evals/evals.json`, confirming the load-bearing decision of RFC-0036 §177: that
+three per-format skills disambiguate cleanly on natural phrasing. Graded by
+reading each skill's activation surface against representative prompts —
+**this file is the durable record** (the PR description rots after merge).
+
+Date: 2026-06-17 · Grader: eugenelim (implementing agent)
+
+## Activation surface per skill
+
+Each `description` seeds both the noun keywords and the imperative trigger
+phrasings RFC-0036 §2 names:
+
+| Skill | Noun keywords | Imperative triggers |
+|---|---|---|
+| `markdown-to-docx` | Word document, report, memo, statement of work, branded .docx | "turn this Markdown into a Word doc" |
+| `markdown-to-pptx` | PowerPoint, slide deck, presentation, branded .pptx | "turn this into slides" |
+| `markdown-to-xlsx` | Excel, spreadsheet, workbook, .xlsx | "export this table to Excel", "fill the .xlsx template" |
+
+## Graded prompts → expected activation
+
+| Prompt | Should fire | Fires? | Note |
+|---|---|---|---|
+| "Make this a PowerPoint." | `markdown-to-pptx` | ✓ | "PowerPoint" is unique to pptx. |
+| "Turn this Markdown into a Word doc." | `markdown-to-docx` | ✓ | Verbatim imperative in the docx description. |
+| "Export this table to Excel." | `markdown-to-xlsx` | ✓ | "Excel" + "export … to Excel" unique to xlsx. |
+| "Turn this into slides." | `markdown-to-pptx` | ✓ | "slides"/"slide deck" unique to pptx. |
+| "Make a statement of work .docx." | `markdown-to-docx` | ✓ | "statement of work" + ".docx" unique to docx. |
+| "Build a spreadsheet from this." | `markdown-to-xlsx` | ✓ | "spreadsheet"/"workbook" unique to xlsx. |
+| "Render this Markdown as HTML." | `markdown-to-html` (existing) | ✓ | No Office keyword; the three new skills don't claim HTML. |
+| "Convert this PDF to Markdown." | `file-to-markdown` (existing) | ✓ | Inward direction; new skills are outward-only. |
+
+## Disambiguation check
+
+The three descriptions share the stem "Fill a branded … template from a Markdown
+artifact" but each names a **distinct format and its synonyms** (Word/.docx vs
+PowerPoint/.pptx vs Excel/.xlsx). No two share a format noun, and each carries a
+distinct imperative trigger. There is no overlap with the inward
+`file-to-markdown` (which converts *into* Markdown) or with `markdown-to-html`
+(HTML, not Office). Risk of cross-firing among the three: **low** — the format
+nouns are mutually exclusive.
+
+## Verdict
+
+All eight graded prompts route to the intended skill. The three-skills
+decision (RFC-0036 §177) holds on the authored activation surface. No
+description edits were needed during grading.

--- a/docs/specs/markdown-to-office-publishing/plan.md
+++ b/docs/specs/markdown-to-office-publishing/plan.md
@@ -1,7 +1,7 @@
 # Plan: markdown-to-office-publishing
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Drafting <!-- Drafting | Executing | Done -->
+- **Status:** Done <!-- Drafting | Executing | Done -->
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
 > document is allowed to change as you learn. When it changes substantially
@@ -347,6 +347,20 @@ activation grading pass is recorded.
   integration test, pack bump to 0.2.0, CI wiring, docs follow-on. Resolves
   RFC-0036 Open Q1 (independent script sets), Q2 (minor bump, contract 0.8), and
   Q3 (library-default fallback).
+- 2026-06-17: implemented (T1–T5) and shipped. Three skills landed with TDD +
+  per-format end-to-end suites (39 tests, CI-wired per-path), pack bumped to
+  0.2.0, marketplace refreshed, docs landed. Post-implementation review changes:
+  (a) docx/xlsx gained the explicit-opt-out **library-default** render path
+  (`render_default_docx` / `render_default_xlsx`) that AC "template-less using
+  the library default" requires — only pptx had it; (b) the xlsx Boundary/AC
+  "never load-and-resave" wording was corrected to "never manipulate/resize
+  chart/shape objects" (filling ranges requires a resave; openpyxl preserves
+  parseable charts, drops only unreadable shapes) and the divergence recorded as
+  **RFC-0036 § Errata E1**; (c) docx `FILLED` no longer counts empty convenience
+  handles; (d) mutation-gap tests added for the unfilled-variable, no-body-
+  placeholder, multi-cell-named-range, overflow-truncation, and empty-input
+  branches; (e) CI pins exact render-lib versions; (f) the outside-SCA
+  pip-audit follow-on recorded in `docs/backlog.md`.
 - 2026-06-17: spec-stage adversarial + security review additions — pack
   README/`description` refresh folded into T4 (was drifting silently); recorded
   activation grading pass; output-path confinement AC + tests; docx

--- a/docs/specs/markdown-to-office-publishing/spec.md
+++ b/docs/specs/markdown-to-office-publishing/spec.md
@@ -1,6 +1,6 @@
 # Spec: markdown-to-office-publishing
 
-- **Status:** Draft <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** RFC-0036, RFC-0007 (the `converters` pack)
@@ -74,8 +74,14 @@ before proceeding; *Never do* is a hard rule, even under time pressure.
   implementation — template-fill only.
 - **No auto-install** of `docxtpl` / `python-pptx` / `openpyxl` (that is Tier-2
   behavior; banned here).
-- **No load-and-resave of an `openpyxl` workbook that carries charts or shapes**
-  — inject into data ranges only; `openpyxl` drops those objects on resave.
+- **Never manipulate, recreate, or resize the chart/shape objects (or a
+  table/named-range's extent) in an `openpyxl` workbook** — inject into data
+  ranges only. Filling named ranges/tables inherently requires a
+  load-and-resave; the realizable rule is to touch only data cells and never the
+  drawing objects. `openpyxl` preserves the charts/images it can parse on that
+  resave, but its tutorial warns it drops *shapes it cannot read* — refines the
+  frozen RFC-0036's "never load-and-resave" / "drops charts" wording; see
+  [RFC-0036 § Errata](../../rfc/0036-markdown-to-office-publishing.md#errata).
 
 ## Testing Strategy
 
@@ -113,26 +119,26 @@ before proceeding; *Never do* is a hard rule, even under time pressure.
 
 ## Acceptance Criteria
 
-- [ ] Three skills exist — `packs/converters/.apm/skills/{markdown-to-docx,markdown-to-pptx,markdown-to-xlsx}/` — each with a lean `SKILL.md` (detail in `references/`, the renderer in `scripts/`) that passes `tools/lint-skill-spec.py` and `tools/lint-agent-artifacts.py`.
-- [ ] Each `SKILL.md` `description` seeds the RFC-0036 activation vocabulary — both the noun keywords and the **imperative trigger phrasings** RFC-0036 §2 names (the load-bearing activation surface per §177): `markdown-to-docx` ("Word document", "report", "memo", "statement of work", "branded .docx", "turn this Markdown into a Word doc"); `markdown-to-pptx` ("PowerPoint", "slide deck", "presentation", "turn this into slides", "branded .pptx"); `markdown-to-xlsx` ("Excel", "spreadsheet", "workbook", "export this table to Excel", "fill the .xlsx template").
-- [ ] Each skill is **Tier-1**: `## Prerequisites` declares its library and the exact `pip install` line; the script's `--check` verb import-probes the library and exits `0` (present) / `2` (absent); on absence it prints the install line and stops; no code path auto-installs.
-- [ ] Each `SKILL.md` documents the **deterministic-renderer** contract — the script's argv shape and its stdout markers — and instructs the agent to assemble the content model and invoke the script, not to hand-write the Office file.
-- [ ] Each script's **inspect** verb emits a fill-point manifest: docx via `get_undeclared_template_variables()`; pptx by iterating `slide_layouts` → `placeholders` (idx, type, name); xlsx by iterating `defined_names` and worksheet `tables`.
-- [ ] Each script's **map** step projects the Markdown artifact onto the manifest per the RFC-0036 mapping table (front-matter → scalars; H1/H2 → sections/slides/sheets; lists → loops/rows; tables → row-loops/table-placeholder/data-region).
-- [ ] **Template flow** holds for all three: detect a template on disk → confirm the found one or elicit one → on explicit user opt-out, proceed **template-less using the library default** (a bare `docxtpl`/`python-pptx`/`openpyxl` document), communicated up front; the opt-out is never silent and no scaffold asset is shipped.
-- [ ] **No-fill-points guidance** for docx/xlsx: given an untagged `.docx` or a workbook with no named ranges, the skill explains how to add fill-points (insert Jinja tags in Word / define named ranges) rather than silently converting. `.pptx` is exempt — its layouts already carry placeholders.
-- [ ] `markdown-to-xlsx` injects into **data ranges only** and never load-and-resaves a workbook carrying charts/shapes; the chart-loss caveat is documented in its `SKILL.md`.
-- [ ] `markdown-to-docx` documents the `docxtpl` run-fragmentation guidance — author each tag in one uniform run.
-- [ ] `markdown-to-docx` passes `autoescape=True` at the `docxtpl` `render()` call (autoescape is **off** by default in docxtpl), verified by a unit test that a context value containing `{{`/XML metacharacters renders escaped, not interpolated.
-- [ ] Each script **confines the output write**: it fully resolves `--output` with `Path.resolve()` / `realpath` (following symlinks) and verifies the resolved path is the working-directory root or has it among `.parents` — a path-**component** containment check, **not** a string-prefix check (so `workdir-evil` is rejected against root `workdir`) — refusing a `--template`/input path that resolves outside the root. Verified by unit tests covering the `..`-traversal, symlink-escape, and sibling-prefix (`workdir-evil`) cases.
-- [ ] Each `SKILL.md` states the **template trust posture explicitly** — user-supplied templates are treated as trusted-author input (consistent with the converters pack's local-files-trusted stance) — and notes that SSTI via a malicious template author and XXE / zip-bomb on a crafted Office archive are accepted, out-of-scope risks for trusted-author templates.
-- [ ] Each `## Prerequisites` `pip install` line names the **exact canonical PyPI package** (`docxtpl` / `python-pptx` / `openpyxl`) with a minimum-version floor (justified by the docxtpl `get_undeclared_template_variables()` breakage history and any known advisory at authoring time), and notes that these Tier-1 libraries install into the user's environment **outside the repo's SCA** so the user is responsible for keeping them current.
-- [ ] Each skill's **TDD unit suite** (`scripts/test_*.py`) covers manifest enumeration, Markdown→model mapping, and the `--check` probe, and is **CI-gated** by an explicit per-path `python -m pytest` line in `.github/workflows/build-check.yml` (atlassian/credential-brokers precedent).
-- [ ] An **end-to-end integration test per format** renders a fixture template via the documented script invocation and re-opens the produced file to assert the filled values are present.
-- [ ] Each skill ships `evals/evals.json` (canonical `skill_name` + `evals` keys) with activation and don't-render-by-hand assertions; the converters evals carry-over CI check (`build-check.yml`, "converters evals.json carry-over disposition") is extended to enumerate the three new skills.
-- [ ] The pack version is bumped `0.1.2 → 0.2.0` in both `packs/converters/pack.toml` and `packs/converters/.claude-plugin/plugin.json`; `[pack.adapter-contract]` stays `0.8`; `make build` refreshes the top-level `.claude-plugin/marketplace.json` to the new version; `lint-packs` and `make build` are green.
-- [ ] The pack's user-facing surfaces are updated to reflect the Markdown→Office direction: `packs/converters/README.md`'s skill list adds the three skills, and the `description` in `pack.toml` + `plugin.json` (which propagates into `marketplace.json`) names the outward direction — not just the current inward-only wording.
-- [ ] User docs land in the implementing PR: a new `docs/guides/converters/how-to/publish-markdown-to-office.md`, an extension to `docs/guides/converters/reference/converter-skills.md`, and a `docs/product/changelog.md` `[Unreleased]` entry.
+- [x] Three skills exist — `packs/converters/.apm/skills/{markdown-to-docx,markdown-to-pptx,markdown-to-xlsx}/` — each with a lean `SKILL.md` (detail in `references/`, the renderer in `scripts/`) that passes `tools/lint-skill-spec.py` and `tools/lint-agent-artifacts.py`.
+- [x] Each `SKILL.md` `description` seeds the RFC-0036 activation vocabulary — both the noun keywords and the **imperative trigger phrasings** RFC-0036 §2 names (the load-bearing activation surface per §177): `markdown-to-docx` ("Word document", "report", "memo", "statement of work", "branded .docx", "turn this Markdown into a Word doc"); `markdown-to-pptx` ("PowerPoint", "slide deck", "presentation", "turn this into slides", "branded .pptx"); `markdown-to-xlsx` ("Excel", "spreadsheet", "workbook", "export this table to Excel", "fill the .xlsx template").
+- [x] Each skill is **Tier-1**: `## Prerequisites` declares its library and the exact `pip install` line; the script's `--check` verb import-probes the library and exits `0` (present) / `2` (absent); on absence it prints the install line and stops; no code path auto-installs.
+- [x] Each `SKILL.md` documents the **deterministic-renderer** contract — the script's argv shape and its stdout markers — and instructs the agent to assemble the content model and invoke the script, not to hand-write the Office file.
+- [x] Each script's **inspect** verb emits a fill-point manifest: docx via `get_undeclared_template_variables()`; pptx by iterating `slide_layouts` → `placeholders` (idx, type, name); xlsx by iterating `defined_names` and worksheet `tables`.
+- [x] Each script's **map** step projects the Markdown artifact onto the manifest per the RFC-0036 mapping table (front-matter → scalars; H1/H2 → sections/slides/sheets; lists → loops/rows; tables → row-loops/table-placeholder/data-region).
+- [x] **Template flow** holds for all three: detect a template on disk → confirm the found one or elicit one → on explicit user opt-out, proceed **template-less using the library default** (a bare `docxtpl`/`python-pptx`/`openpyxl` document), communicated up front; the opt-out is never silent and no scaffold asset is shipped.
+- [x] **No-fill-points guidance** for docx/xlsx: given an untagged `.docx` or a workbook with no named ranges, the skill explains how to add fill-points (insert Jinja tags in Word / define named ranges) rather than silently converting. `.pptx` is exempt — its layouts already carry placeholders.
+- [x] `markdown-to-xlsx` injects into **data ranges only** and never manipulates or resizes chart/shape objects or a table/named-range extent; the shape-loss caveat (`openpyxl` preserves charts/images it can parse on the unavoidable resave but may drop shapes it cannot read) is documented in its `SKILL.md`. Refines RFC-0036's literal "never load-and-resave" wording — see [RFC-0036 § Errata](../../rfc/0036-markdown-to-office-publishing.md#errata).
+- [x] `markdown-to-docx` documents the `docxtpl` run-fragmentation guidance — author each tag in one uniform run.
+- [x] `markdown-to-docx` passes `autoescape=True` at the `docxtpl` `render()` call (autoescape is **off** by default in docxtpl), verified by a unit test that a context value containing `{{`/XML metacharacters renders escaped, not interpolated.
+- [x] Each script **confines the output write**: it fully resolves `--output` with `Path.resolve()` / `realpath` (following symlinks) and verifies the resolved path is the working-directory root or has it among `.parents` — a path-**component** containment check, **not** a string-prefix check (so `workdir-evil` is rejected against root `workdir`) — refusing a `--template`/input path that resolves outside the root. Verified by unit tests covering the `..`-traversal, symlink-escape, and sibling-prefix (`workdir-evil`) cases.
+- [x] Each `SKILL.md` states the **template trust posture explicitly** — user-supplied templates are treated as trusted-author input (consistent with the converters pack's local-files-trusted stance) — and notes that SSTI via a malicious template author and XXE / zip-bomb on a crafted Office archive are accepted, out-of-scope risks for trusted-author templates.
+- [x] Each `## Prerequisites` `pip install` line names the **exact canonical PyPI package** (`docxtpl` / `python-pptx` / `openpyxl`) with a minimum-version floor (justified by the docxtpl `get_undeclared_template_variables()` breakage history and any known advisory at authoring time), and notes that these Tier-1 libraries install into the user's environment **outside the repo's SCA** so the user is responsible for keeping them current.
+- [x] Each skill's **TDD unit suite** (`scripts/test_*.py`) covers manifest enumeration, Markdown→model mapping, and the `--check` probe, and is **CI-gated** by an explicit per-path `python -m pytest` line in `.github/workflows/build-check.yml` (atlassian/credential-brokers precedent).
+- [x] An **end-to-end integration test per format** renders a fixture template via the documented script invocation and re-opens the produced file to assert the filled values are present.
+- [x] Each skill ships `evals/evals.json` (canonical `skill_name` + `evals` keys) with activation and don't-render-by-hand assertions; the converters evals carry-over CI check (`build-check.yml`, "converters evals.json carry-over disposition") is extended to enumerate the three new skills.
+- [x] The pack version is bumped `0.1.2 → 0.2.0` in both `packs/converters/pack.toml` and `packs/converters/.claude-plugin/plugin.json`; `[pack.adapter-contract]` stays `0.8`; `make build` refreshes the top-level `.claude-plugin/marketplace.json` to the new version; `lint-packs` and `make build` are green.
+- [x] The pack's user-facing surfaces are updated to reflect the Markdown→Office direction: `packs/converters/README.md`'s skill list adds the three skills, and the `description` in `pack.toml` + `plugin.json` (which propagates into `marketplace.json`) names the outward direction — not just the current inward-only wording.
+- [x] User docs land in the implementing PR: a new `docs/guides/converters/how-to/publish-markdown-to-office.md`, an extension to `docs/guides/converters/reference/converter-skills.md`, and a `docs/product/changelog.md` `[Unreleased]` entry.
 
 ## Assumptions
 

--- a/packs/converters/.apm/skills/markdown-to-docx/SKILL.md
+++ b/packs/converters/.apm/skills/markdown-to-docx/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: markdown-to-docx
+description: "Fill a branded Word template from a Markdown artifact — turn this Markdown into a Word doc, produce a report, a memo, a statement of work, or a branded .docx. The deterministic script fills the Jinja fill-points a designer placed in the template (front-matter, headings, lists, tables map onto them), so the cover page, styles, headers, and placed logo survive. Use when the user wants a Word document, report, memo, or .docx out of Markdown. Tier-1 on docxtpl (the user installs it; the skill detects it and stops if absent)."
+---
+
+# Markdown to Word
+
+A thin wrapper around `scripts/render.py`. The script is the renderer; you
+assemble nothing by hand. It **fills a user-provided, pre-tagged `.docx`
+template** at the Jinja fill-points the designer placed, via
+[`docxtpl`](https://pypi.org/project/docxtpl/) — rather than building a document
+from scratch — so the cover page, paragraph styles, headers/footers, and any
+placed logo survive.
+
+## Prerequisites
+
+This skill is **Tier-1** on `docxtpl` (the exact canonical PyPI package — a real
+but lower-profile single-maintainer package, so install the exact name). Install
+it once:
+
+```bash
+python -m pip install 'docxtpl>=0.16.0'
+```
+
+The `>=0.16.0` floor clears a version where
+`get_undeclared_template_variables()` was broken. `docxtpl` installs into
+**your** environment, **outside the repo's SCA** (`pip-audit` / CodeQL never
+scan it), so you own keeping it current. The skill never installs it for you.
+Verify before rendering:
+
+```bash
+python scripts/render.py --check
+```
+
+Exit `0` → proceed. Exit `2` → it's not installed; run the `pip install` above
+and stop.
+
+## The deterministic-renderer contract
+
+You drive three verbs; the script does the rendering:
+
+| Verb | What it does | Stdout markers |
+|---|---|---|
+| `--check` | Import-probe `docxtpl`; exit `0`/`2`. | — |
+| `inspect <template>` | List the template's declared Jinja variables. | `FILLPOINTS: <variable>` (or `GUIDANCE:` if untagged) |
+| `render <markdown> --template <tpl> [--output <path>]` | Fill the template and write a `.docx`. | `OUTPUT: <path>`, `FILLED: <n>`, `WARNING: <msg>`, `GUIDANCE: <msg>` |
+
+The mapping: front-matter `key: value` → `{{ key }}` scalars; the first list →
+an `items` list for a `{%p for it in items %}…{%p endfor %}` paragraph loop; the
+first Markdown table → `rows` (a list of `{column: value}` dicts) for a
+`{%tr for r in rows %}` row loop. Detail and how to add tags in Word are in
+[`references/fill-points.md`](references/fill-points.md).
+
+**Your job** is to assemble the Markdown content and invoke the script. Do not
+hand-write the `.docx` or its XML.
+
+## Template flow
+
+1. **Detect** — look for a `.docx` template on disk in the working directory.
+2. **Confirm or elicit** — confirm the found one, or ask the user for theirs.
+3. **No fill-points** — if the template carries no Jinja tags, the script emits
+   `GUIDANCE:` explaining how to add them (insert `{{ … }}`, `{%p … %}`,
+   `{%tr … %}` tags in Word) rather than silently converting. Relay it; don't
+   convert by hand.
+4. **Opt-out** — only if the user explicitly declines a template, render
+   **template-less** with the `docxtpl`/`python-docx` default document. Say so
+   up front: the result carries no brand. Never invent a brand or ship a default
+   template asset.
+
+### Authoring tags in Word — run fragmentation
+
+Word silently splits text into multiple "runs" when formatting or autocorrect
+changes mid-word, and a Jinja tag split across runs (`{` + `{ title }` + `}`)
+won't render. **Author each tag inside one uniform run:** type the whole tag in
+one go with consistent formatting, or paste it as plain text. If a tag isn't
+filling, this is the first thing to check.
+
+## Trust model
+
+A user-supplied template is **trusted-author input**, consistent with the
+converters pack's local-files-trusted stance. Because a `.docx` template carries
+Jinja2 *source*, a malicious template author could embed server-side template
+injection (SSTI) — this is an **accepted, out-of-scope risk** for a
+trusted-author template, as are XXE / zip-bomb on a deliberately crafted
+archive. Two cheap controls hold regardless and are enforced:
+
+- **`autoescape=True`** at the `docxtpl` `render()` call (it is **off** by
+  default), so a user-content value containing `{{` or XML metacharacters is
+  escaped, not interpolated as live markup.
+- **Output-path confinement** — the script resolves `--output`/`--template` and
+  refuses any path escaping the working directory (a model-influenced output
+  path is a local control, independent of template trust).
+
+## Don't
+
+- Don't hand-write the `.docx` or its XML — the script renders.
+- Don't convert an untagged document (Pandoc/Quarto) — relay the `GUIDANCE:`
+  instead. Template-fill only.
+- Don't ship or invent a default template — an absent template is the user's
+  explicit choice.
+- Don't auto-install `docxtpl` — print the install line and stop.
+
+## Edge cases
+
+| Situation | Behavior |
+|---|---|
+| `docxtpl` not installed | `--check` exits `2` with the install line; stop. |
+| Template has no Jinja tags | `GUIDANCE:` explains how to add them; no file written. |
+| A tag isn't filling | Likely run fragmentation — re-author the tag in one uniform run. |
+| Template declares a variable with no Markdown source | The script emits `WARNING:` naming it; the rest still fills. |

--- a/packs/converters/.apm/skills/markdown-to-docx/evals/evals.json
+++ b/packs/converters/.apm/skills/markdown-to-docx/evals/evals.json
@@ -1,0 +1,56 @@
+{
+  "skill_name": "markdown-to-docx",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Turn this Markdown into a Word doc using our branded report template report-template.docx.",
+      "expected_output": "The agent confirms docxtpl is installed (`render.py --check`), inspects the template's Jinja variables, then invokes `python scripts/render.py render <markdown> --template report-template.docx`. It reports OUTPUT and FILLED. It does not hand-write the .docx.",
+      "assertions": [
+        "Agent runs `python scripts/render.py --check` (or otherwise confirms docxtpl) before rendering",
+        "Agent invokes `python scripts/render.py render` with `--template report-template.docx`",
+        "Agent does NOT hand-write the .docx or its XML",
+        "Agent reports the OUTPUT: path and FILLED: count back to the user"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Make a statement of work .docx from this Markdown — here's our template sow.docx, but I'm not sure it has the right fields.",
+      "expected_output": "The agent runs `python scripts/render.py inspect sow.docx`. If the template has no Jinja tags, it relays the GUIDANCE about adding `{{ }}`/`{%p %}`/`{%tr %}` tags in Word rather than converting by hand.",
+      "assertions": [
+        "Agent invokes `python scripts/render.py inspect sow.docx`",
+        "If untagged, agent relays the guidance to add Jinja fill-points rather than silently converting",
+        "Agent does NOT hand-convert the Markdown into a fresh .docx, discarding the brand"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "A tag in my Word template isn't getting filled — {{ client_name }} just shows up as literal text.",
+      "expected_output": "The agent diagnoses run fragmentation: Word split the tag across runs. It advises re-typing the tag in one uniform run (or pasting as plain text), and notes that `inspect` won't list a fragmented tag.",
+      "assertions": [
+        "Agent identifies run fragmentation as the likely cause",
+        "Agent advises re-authoring the tag in a single uniform run (or pasting as plain text)",
+        "Agent does NOT suggest editing the output .docx XML by hand"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "My report has a customer name with an ampersand (Smith & Co) — will that break the Word output?",
+      "expected_output": "The agent explains the renderer passes autoescape=True, so `&` and other XML metacharacters are escaped and rendered as literal text, not interpolated as markup. No manual escaping is needed.",
+      "assertions": [
+        "Agent confirms the value is XML-escaped by the renderer (autoescape=True)",
+        "Agent does NOT instruct the user to pre-escape the ampersand by hand",
+        "Agent does NOT claim the value is executed or interpolated as markup"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "I don't have a Word template, just convert this Markdown to a .docx.",
+      "expected_output": "The agent surfaces that without a template the output is unbranded, confirms the explicit opt-out, then renders template-less. It does not invent a corporate brand.",
+      "assertions": [
+        "Agent states up front that a template-less .docx is unbranded",
+        "Agent proceeds only on the user's explicit opt-out",
+        "Agent does NOT invent a corporate brand or ship a default template"
+      ]
+    }
+  ]
+}

--- a/packs/converters/.apm/skills/markdown-to-docx/references/fill-points.md
+++ b/packs/converters/.apm/skills/markdown-to-docx/references/fill-points.md
@@ -1,0 +1,72 @@
+# Word fill-points: the Jinja-tag model
+
+`markdown-to-docx` fills the **Jinja tags** a designer placed in a `.docx`
+template, via [`docxtpl`](https://docxtpl.readthedocs.io/). This is the
+reference for what those tags are, how Markdown projects onto them, and how to
+add them in Word.
+
+## What a fill-point is
+
+Unlike PowerPoint (whose layouts ship placeholders) and Excel (whose workbooks
+carry named ranges), a Word document has **no fill-points until you add them**.
+A fill-point is a Jinja tag typed into the document text:
+
+| Tag | Where | Fills |
+|---|---|---|
+| `{{ variable }}` | inline, anywhere | a scalar value |
+| `{%p for it in items %}` … `{%p endfor %}` | each directive on its own paragraph; the paragraph(s) between repeat | a list, one paragraph per item |
+| `{%tr for r in rows %}` … `{%tr endfor %}` | each directive in its own table row; the row(s) between repeat | a table, one row per item |
+
+`inspect <template>` reports them via docxtpl's
+`get_undeclared_template_variables()`:
+
+```
+FILLPOINTS: items
+FILLPOINTS: rows
+FILLPOINTS: title
+```
+
+If a template carries no tags, `inspect` (and `render`) emit `GUIDANCE:` telling
+the user how to add them — the skill never silently converts an untagged
+document, because that would discard the brand.
+
+## How Markdown maps onto tags
+
+| Markdown | Context field | Tag it feeds |
+|---|---|---|
+| Front-matter `key: value` | `key` (scalar) | `{{ key }}` |
+| The first list | `items` (list of strings) | `{%p for it in items %}{{ it }}{%p endfor %}` |
+| The first Markdown table | `rows` (list of `{column: value}` dicts) | `{%tr for r in rows %}{{ r.Column }}{%tr endfor %}` |
+
+The script also provides a `sections` list mirroring the document structure, for
+templates that loop over headings. The context is pure data; the template
+decides where each value lands.
+
+**Reserved context names.** `items`, `rows`, and `sections` are the
+convenience handles the mapper always injects. A front-matter key with one of
+those exact names is shadowed by the handle — name your scalar front-matter keys
+something else (e.g. `summary`, not `sections`).
+
+## Adding tags in Word — the run-fragmentation trap
+
+Word stores text as **runs**, and it silently starts a new run whenever
+formatting changes — including mid-word from autocorrect, a stray bold toggle,
+or a spell-check fix. A Jinja tag whose characters land in different runs
+(`{` `{ title }` `}`) is invisible to docxtpl and won't render.
+
+**To author a tag safely:**
+
+- Type the entire tag in one motion with consistent formatting, or
+- paste it as plain text (so Word doesn't fragment it), and
+- if a tag stubbornly won't fill, re-type it from scratch in a clean paragraph.
+
+A symptom of fragmentation is a tag that `inspect` doesn't list even though you
+can see it in the document — the characters are there but split across runs.
+
+## Why `autoescape=True`
+
+The renderer passes `autoescape=True` to docxtpl's `render()` (autoescape is
+**off** by default). User content containing `<`, `&`, or `{{` is then
+XML-escaped and rendered as literal text rather than injected as live markup
+into the document XML. This is a cheap, always-on control independent of whether
+the template author is trusted.

--- a/packs/converters/.apm/skills/markdown-to-docx/scripts/render.py
+++ b/packs/converters/.apm/skills/markdown-to-docx/scripts/render.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""
+render.py — fill a branded Word template from a Markdown artifact.
+
+This is the deterministic renderer for the `markdown-to-docx` skill. The agent
+assembles the content model and invokes this script; the script fills a
+user-provided `.docx` template at its Jinja tags (via docxtpl) rather than
+building a document from scratch, so the designer's cover page, styles, headers,
+and placed logo survive.
+
+Verbs
+    --check                 import-probe docxtpl; exit 0 (present) / 2 (absent)
+    inspect <template>      print the template's declared Jinja variables
+    render  <markdown>      fill a template and write a .docx
+        --template <path>   pre-tagged .docx to fill; omit for the opt-out default
+        --output <path>     output path (default: <markdown-basename>.docx in CWD)
+
+Stdout markers (for agent parsing)
+    FILLPOINTS: <variable>  (inspect — one per declared template variable)
+    GUIDANCE: <msg>         template carries no Jinja tags; how to add them
+    OUTPUT: <path>          path to the written .docx
+    FILLED: <n>             count of template variables a value was supplied for
+    WARNING: <msg>          non-fatal issue, surface to the user
+
+Trust model
+    A user-supplied template is trusted-author input, consistent with the
+    converters pack's local-files-trusted stance. Because a `.docx` template
+    carries Jinja2 *source*, a malicious template author could embed
+    server-side template injection (SSTI); this is an accepted, out-of-scope
+    risk for a trusted-author template, as are XXE / zip-bomb on a crafted
+    archive. Two cheap controls hold regardless of template trust and are
+    enforced here: docxtpl `autoescape=True` (user content is XML-escaped, not
+    interpolated) and output-path confinement (the output path is assembled
+    from model-influenced content).
+
+Errors go to stderr; exit code 1 on failure, 2 on a missing library.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+PIP_INSTALL = "python -m pip install 'docxtpl>=0.16.0'"
+
+GUIDANCE_NO_TAGS = (
+    "this .docx carries no Jinja fill-points, so there is nothing to fill. Add "
+    "tags in Word where you want content: `{{ title }}` for a scalar, a "
+    "`{%p for it in items %}{{ it }}{%p endfor %}` paragraph loop for a list, and "
+    "a `{%tr for r in rows %}` row loop for a table. Author each tag inside one "
+    "uniform run (don't let Word split `{{`/`}}` across runs by autocorrect or "
+    "mid-tag formatting). Then re-run. The skill never silently converts an "
+    "untagged document — that would discard your brand."
+)
+
+
+class RenderResult(NamedTuple):
+    written: bool
+    filled: int
+    warnings: list[str]
+    guidance: str | None
+
+
+# --------------------------------------------------------------------------- #
+# Output-path confinement
+# --------------------------------------------------------------------------- #
+def confine(path: Path, root: Path) -> Path:
+    """Resolve ``path`` (following symlinks) and require it under ``root``.
+
+    Path-*component* containment (``root`` is the resolved path or among its
+    ``.parents``), not a string-prefix check, so a sibling like ``workdir-evil``
+    is rejected against root ``workdir``. Raises ``ValueError`` on escape.
+    """
+    resolved = path.resolve()
+    root_resolved = root.resolve()
+    if resolved == root_resolved or root_resolved in resolved.parents:
+        return resolved
+    raise ValueError(
+        f"path {path!r} resolves to {resolved} which is outside the working "
+        f"directory {root_resolved}; refusing to read/write outside the project"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Markdown → Jinja context (the map step)
+# --------------------------------------------------------------------------- #
+def build_context(text: str) -> dict:
+    """Project a Markdown artifact onto a docxtpl Jinja context.
+
+    Mapping (RFC-0036): front-matter ``key: value`` lines → top-level scalars
+    (for ``{{ key }}``); the first list → ``items`` (for a ``{%p for %}``
+    paragraph loop); the first Markdown table → ``rows`` as a list of
+    ``{column: value}`` dicts (for a ``{%tr for %}`` row loop). A ``sections``
+    list mirroring the document structure is always provided.
+
+    Pure transform — no I/O.
+    """
+    scalars: dict[str, str] = {}
+    sections: list[dict] = []
+    lines = text.splitlines()
+    i = 0
+
+    if lines and lines[0].strip() == "---":
+        j = 1
+        while j < len(lines) and lines[j].strip() != "---":
+            raw = lines[j]
+            if ":" in raw:
+                key, _, value = raw.partition(":")
+                scalars[key.strip()] = value.strip().strip("\"'")
+            j += 1
+        i = j + 1 if j < len(lines) else len(lines)
+
+    current: dict | None = None
+
+    def cell_split(row: str) -> list[str]:
+        return [c.strip() for c in row.strip().strip("|").split("|")]
+
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+
+        if stripped.startswith("#"):
+            level = len(stripped) - len(stripped.lstrip("#"))
+            current = {"heading": stripped[level:].strip(), "bullets": [], "table": None}
+            sections.append(current)
+            i += 1
+            continue
+
+        if current is not None and (stripped.startswith("- ") or stripped.startswith("* ")):
+            current["bullets"].append(stripped[2:].strip())
+            i += 1
+            continue
+
+        if (
+            current is not None
+            and stripped.startswith("|")
+            and i + 1 < len(lines)
+            and "-" in lines[i + 1]
+            and set(lines[i + 1].strip().replace("|", "").replace(":", "").strip()) <= {"-", " "}
+            and lines[i + 1].strip().replace("|", "").strip()
+        ):
+            header = cell_split(stripped)
+            body_rows = []
+            i += 2
+            while i < len(lines) and lines[i].strip().startswith("|"):
+                cells = cell_split(lines[i])
+                body_rows.append({header[k]: (cells[k] if k < len(cells) else "") for k in range(len(header))})
+                i += 1
+            current["table"] = {"header": header, "rows": body_rows}
+            continue
+
+        i += 1
+
+    # Top-level convenience handles for the common single-list / single-table doc.
+    items = next((s["bullets"] for s in sections if s["bullets"]), [])
+    rows = next((s["table"]["rows"] for s in sections if s["table"]), [])
+
+    context = dict(scalars)
+    context["sections"] = sections
+    context["items"] = items
+    context["rows"] = rows
+    return context
+
+
+# --------------------------------------------------------------------------- #
+# docxtpl helpers (imported lazily so --check runs without the library)
+# --------------------------------------------------------------------------- #
+def inspect_template(template: Path) -> list[str]:
+    """Return the sorted set of undeclared Jinja variables in the template."""
+    from docxtpl import DocxTemplate
+
+    doc = DocxTemplate(str(template))
+    return sorted(doc.get_undeclared_template_variables())
+
+
+def render_docx(text: str, template: Path, output: Path) -> RenderResult:
+    """Fill ``template`` from the Markdown in ``text``; write ``output``.
+
+    If the template carries no Jinja tags, returns guidance instead of writing
+    (never a silent convert). User content is escaped via ``autoescape=True``.
+    """
+    from docxtpl import DocxTemplate
+
+    doc = DocxTemplate(str(template))
+    variables = doc.get_undeclared_template_variables()
+    if not variables:
+        return RenderResult(written=False, filled=0, warnings=[], guidance=GUIDANCE_NO_TAGS)
+
+    context = build_context(text)
+    # autoescape is OFF by default in docxtpl; turn it ON so user content is
+    # XML-escaped rather than injected as raw markup into the document.
+    doc.render(context, autoescape=True)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    doc.save(str(output))
+
+    # FILLED counts variables a *non-empty* value was supplied for — the
+    # always-present convenience handles (items/rows/sections) don't inflate it.
+    filled = sum(1 for v in variables if context.get(v))
+    warnings = []
+    unfilled = variables - set(context.keys())
+    if unfilled:
+        warnings.append(
+            "template declares variables with no Markdown source: "
+            + ", ".join(sorted(unfilled))
+        )
+    return RenderResult(written=True, filled=filled, warnings=warnings, guidance=None)
+
+
+def render_default_docx(text: str, output: Path) -> RenderResult:
+    """Opt-out path: write the Markdown into a bare python-docx document.
+
+    Used only when the user explicitly declines a branded template. The result
+    is unbranded — front-matter scalars become paragraphs, headings become
+    Word headings, lists become bullets, the first table becomes a Word table.
+    Not the primary path: branding requires a template (``render_docx``).
+    """
+    from docx import Document
+
+    context = build_context(text)
+    doc = Document()
+    title = context.get("title")
+    if title:
+        doc.add_heading(str(title), level=0)
+    for key, value in context.items():
+        if key in ("title", "items", "rows", "sections"):
+            continue
+        doc.add_paragraph(f"{key}: {value}")
+
+    for section in context.get("sections", []):
+        if section.get("heading"):
+            doc.add_heading(section["heading"], level=1)
+        for bullet in section.get("bullets", []):
+            doc.add_paragraph(bullet, style="List Bullet")
+        table = section.get("table")
+        if table:
+            header, body = table["header"], table["rows"]
+            t = doc.add_table(rows=1, cols=len(header))
+            for c, h in enumerate(header):
+                t.rows[0].cells[c].text = h
+            for row in body:
+                cells = t.add_row().cells
+                for c, h in enumerate(header):
+                    cells[c].text = str(row.get(h, ""))
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    doc.save(str(output))
+    return RenderResult(
+        written=True,
+        filled=0,
+        warnings=["no template supplied — produced an UNBRANDED .docx via python-docx"],
+        guidance=None,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def cmd_check() -> int:
+    try:
+        import docxtpl  # noqa: F401
+    except ImportError:
+        print(f"docxtpl is not installed. Run:\n    {PIP_INSTALL}", file=sys.stderr)
+        return 2
+    return 0
+
+
+def cmd_inspect(args) -> int:
+    root = Path.cwd()
+    template = confine(Path(args.template), root)
+    if not template.is_file():
+        print(f"ERROR: template not found: {args.template}", file=sys.stderr)
+        return 1
+    variables = inspect_template(template)
+    if not variables:
+        print(f"GUIDANCE: {GUIDANCE_NO_TAGS}")
+        return 0
+    for v in variables:
+        print(f"FILLPOINTS: {v}")
+    return 0
+
+
+def cmd_render(args) -> int:
+    root = Path.cwd()
+    md_path = confine(Path(args.markdown), root)
+    if not md_path.is_file():
+        print(f"ERROR: markdown not found: {args.markdown}", file=sys.stderr)
+        return 1
+
+    output = Path(args.output) if args.output else Path(md_path.stem + ".docx")
+    output = confine(output, root)
+    text = md_path.read_text(encoding="utf-8")
+
+    if not args.template:
+        # Explicit opt-out (the agent omits --template only after the user
+        # declines a branded template, per SKILL.md): bare python-docx document.
+        result = render_default_docx(text, output)
+    else:
+        template = confine(Path(args.template), root)
+        if not template.is_file():
+            print(f"ERROR: template not found: {args.template}", file=sys.stderr)
+            return 1
+        result = render_docx(text, template, output)
+    if result.guidance:
+        print(f"GUIDANCE: {result.guidance}")
+        return 0
+    for w in result.warnings:
+        print(f"WARNING: {w}")
+    print(f"OUTPUT: {output}")
+    print(f"FILLED: {result.filled}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Fill a Word template from Markdown.")
+    parser.add_argument("--check", action="store_true", help="probe docxtpl; exit 0/2")
+    sub = parser.add_subparsers(dest="verb")
+
+    p_inspect = sub.add_parser("inspect", help="print the template's Jinja variables")
+    p_inspect.add_argument("template")
+
+    p_render = sub.add_parser("render", help="fill a template and write a .docx")
+    p_render.add_argument("markdown")
+    p_render.add_argument("--template", help="pre-tagged .docx to fill")
+    p_render.add_argument("--output", help="output path (default: <basename>.docx in CWD)")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.check:
+        return cmd_check()
+
+    rc = cmd_check()
+    if rc != 0:
+        return rc
+
+    try:
+        if args.verb == "inspect":
+            return cmd_inspect(args)
+        if args.verb == "render":
+            return cmd_render(args)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packs/converters/.apm/skills/markdown-to-docx/scripts/test_render.py
+++ b/packs/converters/.apm/skills/markdown-to-docx/scripts/test_render.py
@@ -1,0 +1,247 @@
+"""TDD suite for the markdown-to-docx renderer.
+
+Covers the contracts the spec names: Jinja-variable enumeration, Markdown→
+context mapping, the no-fill-points guidance, the Tier-1 `--check` probe,
+`autoescape=True` on user content, and output-path confinement — plus an
+end-to-end render that re-opens the produced .docx and asserts the filled
+values are present.
+
+The tagged fixture template is built with python-docx at test time rather than
+committed as an opaque binary; the builder below is its authorship. Run with
+`python -m pytest` from this directory.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+import render
+
+HERE = Path(__file__).resolve().parent
+
+MARKDOWN = """\
+---
+title: Q3 Review
+author: Finance
+---
+
+# Highlights
+
+- Revenue up 12%
+- Two new markets
+
+# Numbers
+
+| Metric | Value |
+| --- | --- |
+| ARR | 4.2M |
+| Churn | 1.1% |
+"""
+
+
+def _build_tagged_template(path: Path) -> Path:
+    """Author a Jinja-tagged .docx template (the fill-point authorship)."""
+    from docx import Document
+
+    doc = Document()
+    doc.add_paragraph("{{ title }}")
+    doc.add_paragraph("{%p for it in items %}")
+    doc.add_paragraph("{{ it }}")
+    doc.add_paragraph("{%p endfor %}")
+    table = doc.add_table(rows=3, cols=2)
+    table.cell(0, 0).text = "{%tr for r in rows %}"
+    table.cell(1, 0).text = "{{ r.Metric }}"
+    table.cell(1, 1).text = "{{ r.Value }}"
+    table.cell(2, 0).text = "{%tr endfor %}"
+    doc.save(str(path))
+    return path
+
+
+def _build_untagged_template(path: Path) -> Path:
+    from docx import Document
+
+    doc = Document()
+    doc.add_paragraph("A plain document with no Jinja tags.")
+    doc.save(str(path))
+    return path
+
+
+# --------------------------------------------------------------------------- #
+# inspect — declared Jinja variables
+# --------------------------------------------------------------------------- #
+def test_inspect_returns_undeclared_variables(tmp_path):
+    template = _build_tagged_template(tmp_path / "template.docx")
+    assert render.inspect_template(template) == ["items", "rows", "title"]
+
+
+# --------------------------------------------------------------------------- #
+# map — Markdown → Jinja context
+# --------------------------------------------------------------------------- #
+def test_build_context_projects_scalars_list_and_table_rows():
+    context = render.build_context(MARKDOWN)
+
+    # front-matter → {{ var }} scalars
+    assert context["title"] == "Q3 Review"
+    assert context["author"] == "Finance"
+
+    # a list → a {%p for %} loop context
+    assert context["items"] == ["Revenue up 12%", "Two new markets"]
+
+    # a Markdown table → a {%tr for %} row context (list of {column: value} dicts)
+    assert context["rows"] == [
+        {"Metric": "ARR", "Value": "4.2M"},
+        {"Metric": "Churn", "Value": "1.1%"},
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# no-fill-points guidance
+# --------------------------------------------------------------------------- #
+def test_empty_markdown_parses_without_crash():
+    assert render.build_context("") == {"items": [], "rows": [], "sections": []}
+
+
+def test_unfilled_template_variable_is_warned(tmp_path):
+    from docx import Document
+
+    doc = Document()
+    doc.add_paragraph("{{ title }}")
+    doc.add_paragraph("{{ author_signature }}")  # declared, no Markdown source
+    doc.save(str(tmp_path / "t.docx"))
+
+    out = tmp_path / "out.docx"
+    result = render.render_docx("---\ntitle: Q3\n---\n", tmp_path / "t.docx", out)
+    assert result.written is True
+    assert any("author_signature" in w for w in result.warnings)
+
+
+def test_filled_count_ignores_empty_convenience_handles(tmp_path):
+    # A template declaring `rows` but a Markdown doc with no table must not
+    # report rows as filled (the convenience handle defaults to []).
+    from docx import Document
+
+    doc = Document()
+    doc.add_paragraph("{{ title }}")
+    table = doc.add_table(rows=3, cols=1)
+    table.cell(0, 0).text = "{%tr for r in rows %}"
+    table.cell(1, 0).text = "{{ r.x }}"
+    table.cell(2, 0).text = "{%tr endfor %}"
+    doc.save(str(tmp_path / "t.docx"))
+
+    out = tmp_path / "out.docx"
+    result = render.render_docx("---\ntitle: Q3\n---\n", tmp_path / "t.docx", out)
+    assert result.filled == 1  # title only; empty `rows` is not counted
+
+
+def test_render_default_writes_unbranded_docx(tmp_path):
+    from docx import Document
+
+    out = tmp_path / "out.docx"
+    result = render.render_default_docx(MARKDOWN, out)
+    assert result.written is True
+    assert any("UNBRANDED" in w for w in result.warnings)
+    assert out.is_file()
+    blob = "\n".join(p.text for p in Document(str(out)).paragraphs)
+    assert "Q3 Review" in blob and "Revenue up 12%" in blob
+
+
+def test_untagged_template_yields_guidance_not_silent_convert(tmp_path):
+    template = _build_untagged_template(tmp_path / "plain.docx")
+    assert render.inspect_template(template) == []
+
+    out = tmp_path / "out.docx"
+    result = render.render_docx(MARKDOWN, template, out)
+    assert result.written is False
+    assert result.guidance and "fill-point" in result.guidance
+    assert not out.exists(), "an untagged template must not be silently converted"
+
+
+# --------------------------------------------------------------------------- #
+# --check — Tier-1 probe
+# --------------------------------------------------------------------------- #
+def test_check_exit_zero_when_present():
+    assert render.cmd_check() == 0
+
+
+def test_check_exit_two_when_absent(monkeypatch):
+    monkeypatch.setitem(sys.modules, "docxtpl", None)
+    assert render.cmd_check() == 2
+
+
+# --------------------------------------------------------------------------- #
+# autoescape — user content is escaped, not interpolated
+# --------------------------------------------------------------------------- #
+def test_user_content_is_xml_escaped(tmp_path):
+    template = _build_tagged_template(tmp_path / "template.docx")
+    md = "---\ntitle: <b>R&D</b>\n---\n\n# Heading\n\n- item\n"
+    out = tmp_path / "out.docx"
+    result = render.render_docx(md, template, out)
+    assert result.written is True
+
+    document_xml = zipfile.ZipFile(str(out)).read("word/document.xml").decode("utf-8")
+    # autoescape=True turns the `<`/`&` into entities; an off-by-default render
+    # would inject `<b>` as raw markup. Assert the escaped form is present and
+    # the metacharacters were not interpolated as live XML.
+    assert "&lt;b&gt;R&amp;D&lt;/b&gt;" in document_xml
+
+
+# --------------------------------------------------------------------------- #
+# confinement
+# --------------------------------------------------------------------------- #
+def test_confine_rejects_parent_traversal(tmp_path):
+    root = tmp_path / "workdir"
+    root.mkdir()
+    with pytest.raises(ValueError):
+        render.confine(root / ".." / "evil.docx", root)
+
+
+def test_confine_rejects_symlink_escape(tmp_path):
+    root = tmp_path / "workdir"
+    root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    link = root / "link"
+    link.symlink_to(outside, target_is_directory=True)
+    with pytest.raises(ValueError):
+        render.confine(link / "evil.docx", root)
+
+
+def test_confine_rejects_sibling_prefix(tmp_path):
+    root = tmp_path / "workdir"
+    root.mkdir()
+    (tmp_path / "workdir-evil").mkdir()
+    with pytest.raises(ValueError):
+        render.confine(tmp_path / "workdir-evil" / "out.docx", root)
+
+
+# --------------------------------------------------------------------------- #
+# end-to-end render (manual-QA mode, exercised as an integration test)
+# --------------------------------------------------------------------------- #
+def test_render_fills_template_and_reopened_values_present(tmp_path):
+    from docx import Document
+
+    _build_tagged_template(tmp_path / "template.docx")
+    (tmp_path / "report.md").write_text(MARKDOWN, encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(HERE / "render.py"), "render", "report.md",
+         "--template", "template.docx", "--output", "out.docx"],
+        cwd=tmp_path, capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OUTPUT:" in result.stdout
+    out = tmp_path / "out.docx"
+    assert out.is_file()
+
+    doc = Document(str(out))
+    paras = "\n".join(p.text for p in doc.paragraphs)
+    assert "Q3 Review" in paras
+    assert "Revenue up 12%" in paras
+
+    cells = [c.text for t in doc.tables for r in t.rows for c in r.cells]
+    assert "ARR" in cells and "4.2M" in cells

--- a/packs/converters/.apm/skills/markdown-to-pptx/SKILL.md
+++ b/packs/converters/.apm/skills/markdown-to-pptx/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: markdown-to-pptx
+description: "Fill a branded PowerPoint template from a Markdown artifact — turn this into slides, build a slide deck or presentation, produce a branded .pptx. The deterministic script inspects the template's layout placeholders and projects your Markdown (front-matter, headings, lists, tables) onto them, so the user's slide master, theme, and placed assets survive. Use when the user wants a PowerPoint, a slide deck, or a presentation out of Markdown. Tier-1 on python-pptx (the user installs it; the skill detects it and stops if absent)."
+---
+
+# Markdown to PowerPoint
+
+A thin wrapper around `scripts/render.py`. The script is the renderer; you
+assemble nothing by hand. It **fills a user-provided, branded `.pptx` template**
+at the placeholders the designer already laid out, rather than building a deck
+from scratch — so the slide master, theme, fonts, and any placed logo survive.
+
+## Prerequisites
+
+This skill is **Tier-1** on [`python-pptx`](https://pypi.org/project/python-pptx/)
+(the exact canonical PyPI package — not a look-alike). Install it once:
+
+```bash
+python -m pip install 'python-pptx>=1.0.0'
+```
+
+`python-pptx` installs into **your** environment, **outside the repo's SCA**
+(`pip-audit` / CodeQL never scan it), so you own keeping it current. The skill
+never installs it for you. Verify before rendering:
+
+```bash
+python scripts/render.py --check
+```
+
+Exit `0` → proceed. Exit `2` → it's not installed; run the `pip install` above
+and stop.
+
+## The deterministic-renderer contract
+
+You drive three verbs; the script does the rendering:
+
+| Verb | What it does | Stdout markers |
+|---|---|---|
+| `--check` | Import-probe `python-pptx`; exit `0`/`2`. | — |
+| `inspect <template>` | List the template's layout placeholders. | `FILLPOINTS: layout=<i> idx=<i> type=<NAME> name=<text>` |
+| `render <markdown> --template <tpl> [--output <path>]` | Fill the template and write a `.pptx`. | `OUTPUT: <path>`, `FILLED: <n>`, `WARNING: <msg>` |
+
+Placeholders are keyed by their **`idx`** (their stable identity), never by list
+position. The mapping: front-matter `title`/`subtitle` → the title slide; each
+H1/H2 heading → one slide; list items → bullet rows; a Markdown table → a table
+on the slide. Detail and the placeholder model are in
+[`references/fill-points.md`](references/fill-points.md).
+
+**Your job** is to assemble the Markdown content and invoke the script. Do not
+hand-write the `.pptx`, the slide XML, or the placeholder objects.
+
+## Template flow
+
+1. **Detect** — look for a `.pptx` template on disk in the working directory.
+2. **Confirm or elicit** — if you find one, confirm it's the brand to use; if you
+   find none, ask the user for their template.
+3. **Opt-out** — only if the user explicitly declines a template, render
+   **template-less** with the `python-pptx` default master. **Say so up front:**
+   the result carries no brand. Never invent a brand and never ship a default
+   template asset.
+
+PowerPoint layouts already carry placeholders, so a `.pptx` template is always
+fillable — there's no "untagged template" case as there is for Word/Excel.
+
+## Trust model
+
+A user-supplied template is **trusted-author input**, consistent with the
+converters pack's local-files-trusted stance. `python-pptx` does not evaluate
+template content as code, so there is no template-injection surface here; XXE or
+a zip-bomb on a deliberately crafted Office archive is an accepted, out-of-scope
+risk for a trusted-author template. The script still **confines its writes**: it
+resolves `--output`/`--template` and refuses any path that escapes the working
+directory (a model-influenced output path is a local control, independent of
+template trust).
+
+## Don't
+
+- Don't hand-write the `.pptx` or its slide XML — the script renders.
+- Don't convert Markdown to a fresh deck (Pandoc/Quarto) — that discards the
+  user's brand. Template-fill only.
+- Don't ship or invent a default template — an absent template is the user's
+  explicit choice.
+- Don't auto-install `python-pptx` — print the install line and stop.
+
+## Edge cases
+
+| Situation | Behavior |
+|---|---|
+| `python-pptx` not installed | `--check` exits `2` with the install line; stop. |
+| No template found | Ask for one; render template-less only on explicit opt-out. |
+| A layout exposes no body placeholder | The script emits `WARNING:` and drops those bullets. |
+| A section carries a table | Filled into a `TABLE` placeholder if the layout has one, else a table is added to the slide. |

--- a/packs/converters/.apm/skills/markdown-to-pptx/evals/evals.json
+++ b/packs/converters/.apm/skills/markdown-to-pptx/evals/evals.json
@@ -1,0 +1,57 @@
+{
+  "skill_name": "markdown-to-pptx",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Turn this Markdown report into a slide deck using our brand template deck-template.pptx.",
+      "expected_output": "The agent confirms python-pptx is installed (`render.py --check`), inspects the template, then invokes `python scripts/render.py render <markdown> --template deck-template.pptx`. It reports the OUTPUT path and FILLED count. It does not hand-write the .pptx.",
+      "assertions": [
+        "Agent runs `python scripts/render.py --check` (or otherwise confirms python-pptx) before rendering",
+        "Agent invokes `python scripts/render.py render` with `--template deck-template.pptx`",
+        "Agent does NOT hand-write the .pptx, slide XML, or placeholder objects",
+        "Agent reports the OUTPUT: path and FILLED: count back to the user"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Make this into a PowerPoint presentation.",
+      "expected_output": "Because no template is on disk, the agent asks the user for their branded .pptx template rather than rendering immediately. It explains that filling a template preserves their brand.",
+      "assertions": [
+        "Agent looks for a .pptx template and, finding none, asks the user for one",
+        "Agent does NOT silently render template-less without surfacing the choice",
+        "Agent does NOT ship or invent a default template asset"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "I don't have a template — just give me plain slides from this Markdown.",
+      "expected_output": "The agent confirms the explicit opt-out, states up front that the result carries no brand, then renders template-less (`render.py render <markdown>` with no --template), using the python-pptx default master.",
+      "assertions": [
+        "Agent acknowledges the explicit opt-out from a template",
+        "Agent states up front that the output will be unbranded",
+        "Agent invokes `render.py render` without `--template`",
+        "Agent does NOT invent a corporate brand or default template"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Which placeholders does our template fill? Here's brand.pptx.",
+      "expected_output": "The agent runs `python scripts/render.py inspect brand.pptx` and reports the FILLPOINTS lines (layout/idx/type/name), explaining that content maps onto these by placeholder idx.",
+      "assertions": [
+        "Agent invokes `python scripts/render.py inspect brand.pptx`",
+        "Agent reports the placeholder manifest (layout/idx/type/name)",
+        "Agent does NOT guess the placeholders without running inspect"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "The deck looks unstyled — can you fix the theme by editing the XML?",
+      "expected_output": "The agent explains that styling comes from the template's slide master, not from hand-edited XML. It re-checks that the right branded template was passed via --template, rather than editing the output's XML by hand.",
+      "assertions": [
+        "Agent attributes styling to the template's slide master/theme",
+        "Agent does NOT hand-edit the output .pptx XML",
+        "Agent suggests re-rendering with the correct branded template via --template"
+      ]
+    }
+  ]
+}

--- a/packs/converters/.apm/skills/markdown-to-pptx/references/fill-points.md
+++ b/packs/converters/.apm/skills/markdown-to-pptx/references/fill-points.md
@@ -1,0 +1,63 @@
+# PowerPoint fill-points: the placeholder model
+
+`markdown-to-pptx` fills the **placeholders** a slide layout defines. This is
+the reference for what those are and how Markdown projects onto them.
+
+## What a placeholder is
+
+A `.pptx` is built from **slide layouts** (e.g. "Title Slide", "Title and
+Content"), each defined on the slide master. A layout carries **placeholders** —
+the title box, the body/content box, a subtitle, a table region. Each
+placeholder has:
+
+- an **`idx`** — its stable identity within the layout. The script keys on this,
+  never on list position, because a designer can reorder placeholders without
+  changing their `idx`.
+- a **type** — `TITLE`, `CENTER_TITLE`, `SUBTITLE`, `BODY`, `OBJECT` (a generic
+  content box), `TABLE`, `PICTURE`, and so on.
+- a **name** — the human label shown in PowerPoint's selection pane.
+
+`inspect <template>` enumerates them:
+
+```
+FILLPOINTS: layout=0 idx=0 type=CENTER_TITLE name=Title 1
+FILLPOINTS: layout=0 idx=1 type=SUBTITLE name=Subtitle 2
+FILLPOINTS: layout=1 idx=0 type=TITLE name=Title 1
+FILLPOINTS: layout=1 idx=1 type=OBJECT name=Content Placeholder 2
+```
+
+Because layouts already ship placeholders, **every** `.pptx` is fillable — there
+is no "untagged template" case. (Contrast Word, which needs Jinja tags, and
+Excel, which needs named ranges.)
+
+## How Markdown maps onto placeholders
+
+| Markdown | Content-model field | Lands in |
+|---|---|---|
+| Front-matter `title` / `subtitle` | `scalars` | The title slide's `TITLE` / `SUBTITLE` placeholders |
+| Each `#` / `##` heading | a `section` | One new slide (a "Title and Content"-style layout) |
+| List items under a heading | `section.bullets` | The slide's `BODY` / `OBJECT` placeholder, one bullet per paragraph |
+| A Markdown table under a heading | `section.table` | A `TABLE` placeholder if the layout has one, else a table added to the slide |
+
+A plain prose line under a heading (not a list item, not a table row) is mapped
+to a body paragraph too — it lands in the slide's body placeholder as a
+marker-less line alongside any bullets. So free text under a heading becomes deck
+content rather than being dropped.
+
+The script builds an intermediate content model —
+`{scalars: {...}, sections: [{heading, bullets, table}]}` — then projects it onto
+the layout's placeholders. The model is pure data; no slide is touched until the
+render step writes the output file.
+
+## Implementation notes
+
+- **Re-fetch after insert.** Inserting a table into a placeholder replaces the
+  placeholder object; the script re-fetches the table from the returned graphic
+  frame rather than reusing the stale reference.
+- **Layout selection.** The title slide uses the first layout exposing a
+  `TITLE`/`CENTER_TITLE` placeholder; content slides use the first layout
+  exposing a `BODY`/`OBJECT` placeholder. A branded template's custom layouts are
+  matched the same way, by placeholder type.
+- **Empty placeholders are left alone.** A layout's footer, date, or
+  slide-number placeholders are not touched unless the Markdown supplies a value
+  for them.

--- a/packs/converters/.apm/skills/markdown-to-pptx/scripts/render.py
+++ b/packs/converters/.apm/skills/markdown-to-pptx/scripts/render.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""
+render.py — fill a branded PowerPoint template from a Markdown artifact.
+
+This is the deterministic renderer for the `markdown-to-pptx` skill. The
+agent assembles nothing here: it invokes this script, which inspects a
+user-provided `.pptx` template's layout placeholders and projects a Markdown
+document onto them. The user's slide master, theme, and placed assets survive
+because we fill an existing template rather than building a deck from scratch.
+
+Verbs
+    --check                 import-probe python-pptx; exit 0 (present) / 2 (absent)
+    inspect <template>      print the layout/placeholder manifest
+    render  <markdown>      fill a template (or the library default) and write a .pptx
+        --template <path>   branded template to fill; omit for the opt-out default
+        --output <path>     output path (default: <markdown-basename>.pptx in CWD)
+
+Stdout markers (for agent parsing)
+    FILLPOINTS: layout=<i> idx=<i> type=<NAME> name=<text>   (inspect)
+    OUTPUT: <path>          path to the written .pptx
+    FILLED: <n>             count of placeholders filled
+    WARNING: <msg>          non-fatal issue, surface to the user
+
+Trust model
+    A user-supplied template is treated as trusted-author input, consistent
+    with the converters pack's local-files-trusted stance. python-pptx does not
+    evaluate template content as code, so there is no SSTI surface here; XXE /
+    zip-bomb on a crafted Office archive is an accepted, out-of-scope risk for a
+    trusted-author template. Output-path confinement (below) is still enforced
+    because the output path is assembled from model-influenced content.
+
+Errors go to stderr; exit code 1 on failure, 2 on a missing library.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+PIP_INSTALL = "python -m pip install 'python-pptx>=1.0.0'"
+
+
+# --------------------------------------------------------------------------- #
+# Output-path confinement
+# --------------------------------------------------------------------------- #
+def confine(path: Path, root: Path) -> Path:
+    """Resolve ``path`` (following symlinks) and require it under ``root``.
+
+    Uses a path-*component* containment check (``root`` is the resolved path or
+    appears among its ``.parents``), not a string-prefix check, so a sibling
+    like ``workdir-evil`` is rejected against root ``workdir``. Raises
+    ``ValueError`` on escape.
+    """
+    resolved = path.resolve()
+    root_resolved = root.resolve()
+    if resolved == root_resolved or root_resolved in resolved.parents:
+        return resolved
+    raise ValueError(
+        f"path {path!r} resolves to {resolved} which is outside the working "
+        f"directory {root_resolved}; refusing to read/write outside the project"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Markdown → content model
+# --------------------------------------------------------------------------- #
+def parse_markdown(text: str) -> dict:
+    """Project a Markdown artifact onto the pptx content model.
+
+    Mapping (RFC-0036): front-matter ``key: value`` lines → ``scalars``; each
+    H1/H2 heading → one ``section`` (→ one slide); list items under a heading →
+    ``bullets``; a Markdown table under a heading → ``table`` (rows of cells).
+
+    Returns ``{"scalars": {...}, "sections": [{"heading", "bullets", "table"}]}``.
+    Pure transform — no I/O.
+    """
+    scalars: dict[str, str] = {}
+    sections: list[dict] = []
+    lines = text.splitlines()
+    i = 0
+
+    # YAML-ish front-matter: a leading `---` fence of simple `key: value` lines.
+    if lines and lines[0].strip() == "---":
+        j = 1
+        while j < len(lines) and lines[j].strip() != "---":
+            raw = lines[j]
+            if ":" in raw:
+                key, _, value = raw.partition(":")
+                scalars[key.strip()] = value.strip().strip("\"'")
+            j += 1
+        i = j + 1 if j < len(lines) else len(lines)
+
+    current: dict | None = None
+
+    def cell_split(row: str) -> list[str]:
+        parts = row.strip().strip("|").split("|")
+        return [c.strip() for c in parts]
+
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+
+        if stripped.startswith("#"):
+            level = len(stripped) - len(stripped.lstrip("#"))
+            if level in (1, 2):
+                current = {"heading": stripped[level:].strip(), "bullets": [], "table": None}
+                sections.append(current)
+                i += 1
+                continue
+
+        if current is not None and (stripped.startswith("- ") or stripped.startswith("* ")):
+            current["bullets"].append(stripped[2:].strip())
+            i += 1
+            continue
+
+        # Markdown table: a `|`-delimited row whose successor is a `---` divider.
+        if (
+            current is not None
+            and stripped.startswith("|")
+            and i + 1 < len(lines)
+            and "-" in lines[i + 1]
+            and set(lines[i + 1].strip().replace("|", "").replace(":", "").strip()) <= {"-", " "}
+            and lines[i + 1].strip().replace("|", "").strip()
+        ):
+            header = cell_split(stripped)
+            rows = [header]
+            i += 2  # skip header + divider
+            while i < len(lines) and lines[i].strip().startswith("|"):
+                rows.append(cell_split(lines[i]))
+                i += 1
+            current["table"] = rows
+            continue
+
+        # Plain prose line under a heading → a body paragraph (bullet without marker).
+        if current is not None and stripped:
+            current["bullets"].append(stripped)
+        i += 1
+
+    return {"scalars": scalars, "sections": sections}
+
+
+# --------------------------------------------------------------------------- #
+# python-pptx helpers (imported lazily so --check can run without the library)
+# --------------------------------------------------------------------------- #
+def _placeholder_type_name(ph) -> str:
+    try:
+        return str(ph.placeholder_format.type).split()[0].split(".")[-1]
+    except Exception:  # pragma: no cover — defensive
+        return "UNKNOWN"
+
+
+def inspect_template(template: Path) -> list[dict]:
+    """Return the layout/placeholder manifest for a .pptx template.
+
+    One record per placeholder across every slide layout, keyed by the layout
+    index and the placeholder ``idx`` (its stable identity — not list position).
+    """
+    from pptx import Presentation
+
+    prs = Presentation(str(template))
+    manifest: list[dict] = []
+    for layout_i, layout in enumerate(prs.slide_layouts):
+        for ph in layout.placeholders:
+            manifest.append(
+                {
+                    "layout": layout_i,
+                    "idx": ph.placeholder_format.idx,
+                    "type": _placeholder_type_name(ph),
+                    "name": ph.name,
+                }
+            )
+    return manifest
+
+
+def _find_layout(prs, *type_names):
+    """First slide layout that carries a placeholder of any of ``type_names``."""
+    for layout in prs.slide_layouts:
+        for ph in layout.placeholders:
+            if _placeholder_type_name(ph) in type_names:
+                return layout
+    return prs.slide_layouts[0]
+
+
+def _placeholder_by_type(slide, *type_names):
+    for ph in slide.placeholders:
+        if _placeholder_type_name(ph) in type_names:
+            return ph
+    return None
+
+
+def render_pptx(model: dict, template: Path | None, output: Path) -> tuple[int, list[str]]:
+    """Fill ``template`` (or the library default) from ``model``; write ``output``.
+
+    Returns ``(filled_count, warnings)``.
+    """
+    from pptx import Presentation
+    from pptx.util import Inches
+
+    warnings: list[str] = []
+    prs = Presentation(str(template)) if template is not None else Presentation()
+    if template is None:
+        warnings.append(
+            "no template supplied — rendering with the python-pptx default master; "
+            "the result carries no brand"
+        )
+    filled = 0
+
+    # Title slide from front-matter scalars.
+    scalars = model.get("scalars", {})
+    if scalars.get("title") or scalars.get("subtitle"):
+        title_layout = _find_layout(prs, "TITLE", "CENTER_TITLE")
+        slide = prs.slides.add_slide(title_layout)
+        title_ph = _placeholder_by_type(slide, "TITLE", "CENTER_TITLE")
+        if title_ph is not None and scalars.get("title"):
+            title_ph.text = scalars["title"]
+            filled += 1
+        sub_ph = _placeholder_by_type(slide, "SUBTITLE", "BODY")
+        if sub_ph is not None and scalars.get("subtitle"):
+            sub_ph.text = scalars["subtitle"]
+            filled += 1
+
+    content_layout = _find_layout(prs, "BODY", "OBJECT")
+    for section in model.get("sections", []):
+        slide = prs.slides.add_slide(content_layout)
+        title_ph = _placeholder_by_type(slide, "TITLE", "CENTER_TITLE")
+        if title_ph is not None:
+            title_ph.text = section.get("heading", "")
+            filled += 1
+
+        bullets = section.get("bullets") or []
+        if bullets:
+            body = _placeholder_by_type(slide, "BODY", "OBJECT")
+            if body is not None and body.has_text_frame:
+                tf = body.text_frame
+                tf.text = bullets[0]
+                for b in bullets[1:]:
+                    tf.add_paragraph().text = b
+                filled += 1
+            else:
+                warnings.append(
+                    f"slide '{section.get('heading')}' has bullets but the layout "
+                    "exposes no body placeholder; bullets dropped"
+                )
+
+        table = section.get("table")
+        if table:
+            # Fill a TABLE placeholder when the layout has one; otherwise add a
+            # table graphic frame to the slide. python-pptx returns a *new*
+            # graphic-frame object from insert_table — re-fetch, never reuse.
+            table_ph = _placeholder_by_type(slide, "TABLE")
+            rows, cols = len(table), max(len(r) for r in table)
+            if table_ph is not None:
+                gframe = table_ph.insert_table(rows=rows, cols=cols)
+                tbl = gframe.table
+            else:
+                gframe = slide.shapes.add_table(
+                    rows, cols, Inches(0.5), Inches(2.0), Inches(9.0), Inches(0.4 * rows)
+                )
+                tbl = gframe.table
+            for r, row in enumerate(table):
+                for c in range(cols):
+                    tbl.cell(r, c).text = row[c] if c < len(row) else ""
+            filled += 1
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    prs.save(str(output))
+    return filled, warnings
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def cmd_check() -> int:
+    try:
+        import pptx  # noqa: F401
+    except ImportError:
+        print(f"python-pptx is not installed. Run:\n    {PIP_INSTALL}", file=sys.stderr)
+        return 2
+    return 0
+
+
+def cmd_inspect(args) -> int:
+    root = Path.cwd()
+    template = confine(Path(args.template), root)
+    if not template.is_file():
+        print(f"ERROR: template not found: {args.template}", file=sys.stderr)
+        return 1
+    for rec in inspect_template(template):
+        print(
+            f"FILLPOINTS: layout={rec['layout']} idx={rec['idx']} "
+            f"type={rec['type']} name={rec['name']}"
+        )
+    return 0
+
+
+def cmd_render(args) -> int:
+    root = Path.cwd()
+    md_path = confine(Path(args.markdown), root)
+    if not md_path.is_file():
+        print(f"ERROR: markdown not found: {args.markdown}", file=sys.stderr)
+        return 1
+
+    template = confine(Path(args.template), root) if args.template else None
+    if template is not None and not template.is_file():
+        print(f"ERROR: template not found: {args.template}", file=sys.stderr)
+        return 1
+
+    output = Path(args.output) if args.output else Path(md_path.stem + ".pptx")
+    output = confine(output, root)
+
+    model = parse_markdown(md_path.read_text(encoding="utf-8"))
+    filled, warnings = render_pptx(model, template, output)
+
+    for w in warnings:
+        print(f"WARNING: {w}")
+    print(f"OUTPUT: {output}")
+    print(f"FILLED: {filled}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Fill a PowerPoint template from Markdown.")
+    parser.add_argument("--check", action="store_true", help="probe python-pptx; exit 0/2")
+    sub = parser.add_subparsers(dest="verb")
+
+    p_inspect = sub.add_parser("inspect", help="print the placeholder manifest")
+    p_inspect.add_argument("template")
+
+    p_render = sub.add_parser("render", help="fill a template and write a .pptx")
+    p_render.add_argument("markdown")
+    p_render.add_argument("--template", help="branded .pptx to fill (omit for the default)")
+    p_render.add_argument("--output", help="output path (default: <basename>.pptx in CWD)")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.check:
+        return cmd_check()
+
+    # Every other verb needs the library present.
+    rc = cmd_check()
+    if rc != 0:
+        return rc
+
+    try:
+        if args.verb == "inspect":
+            return cmd_inspect(args)
+        if args.verb == "render":
+            return cmd_render(args)
+    except ValueError as exc:  # confinement refusal
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packs/converters/.apm/skills/markdown-to-pptx/scripts/test_render.py
+++ b/packs/converters/.apm/skills/markdown-to-pptx/scripts/test_render.py
@@ -1,0 +1,193 @@
+"""TDD suite for the markdown-to-pptx renderer.
+
+Covers the four contracts the spec names: placeholder-manifest enumeration,
+Markdown→content-model mapping, the Tier-1 `--check` probe, and output-path
+confinement — plus an end-to-end render that re-opens the produced .pptx and
+asserts the filled values are present (the work-loop "exercise the real
+artifact" requirement).
+
+The fixture template is built from the python-pptx default presentation at test
+time rather than committed as an opaque binary: the builder below is its
+authorship, so a reviewer regenerates it by reading this file. Run with
+`python -m pytest` from this directory.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import render
+
+HERE = Path(__file__).resolve().parent
+
+MARKDOWN = """\
+---
+title: Q3 Review
+subtitle: Prepared for the board
+---
+
+# Highlights
+
+- Revenue up 12%
+- Two new markets
+
+# Numbers
+
+| Metric | Value |
+| --- | --- |
+| ARR | 4.2M |
+| Churn | 1.1% |
+"""
+
+
+def _build_template(path: Path) -> Path:
+    """Author a minimal .pptx template (the python-pptx default master)."""
+    from pptx import Presentation
+
+    Presentation().save(str(path))
+    return path
+
+
+# --------------------------------------------------------------------------- #
+# inspect — placeholder manifest
+# --------------------------------------------------------------------------- #
+def test_inspect_returns_manifest_keyed_by_idx(tmp_path):
+    template = _build_template(tmp_path / "template.pptx")
+    manifest = render.inspect_template(template)
+
+    assert manifest, "default template should expose layout placeholders"
+    assert all({"layout", "idx", "type", "name"} <= rec.keys() for rec in manifest)
+    # The title layout exposes a title placeholder at its stable idx 0.
+    title = [r for r in manifest if r["layout"] == 0 and r["idx"] == 0]
+    assert title and title[0]["type"] in {"TITLE", "CENTER_TITLE"}
+    # Records are keyed by placeholder idx, not list position: idx 11 (FOOTER)
+    # is present even though it is not the second placeholder in the layout.
+    assert any(r["idx"] == 11 for r in manifest)
+
+
+# --------------------------------------------------------------------------- #
+# map — Markdown → content model
+# --------------------------------------------------------------------------- #
+def test_empty_markdown_parses_without_crash():
+    assert render.parse_markdown("") == {"scalars": {}, "sections": []}
+
+
+def test_render_warns_when_layout_has_no_body_placeholder(tmp_path, monkeypatch):
+    template = _build_template(tmp_path / "template.pptx")
+    model = {"scalars": {}, "sections": [{"heading": "H", "bullets": ["a"], "table": None}]}
+    # Simulate a layout that exposes no body/object placeholder.
+    monkeypatch.setattr(render, "_placeholder_by_type", lambda *a, **k: None)
+    filled, warnings = render.render_pptx(model, template, tmp_path / "out.pptx")
+    assert any("body placeholder" in w and "dropped" in w for w in warnings)
+
+
+def test_map_projects_frontmatter_headings_lists_and_table():
+    model = render.parse_markdown(MARKDOWN)
+
+    # front-matter → scalars (the title-slide source)
+    assert model["scalars"]["title"] == "Q3 Review"
+    assert model["scalars"]["subtitle"] == "Prepared for the board"
+
+    # one H1/H2 heading → one section (→ one slide)
+    headings = [s["heading"] for s in model["sections"]]
+    assert headings == ["Highlights", "Numbers"]
+
+    # a list → bullet rows
+    assert model["sections"][0]["bullets"] == ["Revenue up 12%", "Two new markets"]
+    assert model["sections"][0]["table"] is None
+
+    # a Markdown table → table rows (placed into a TABLE-type placeholder at render)
+    assert model["sections"][1]["table"] == [["Metric", "Value"], ["ARR", "4.2M"], ["Churn", "1.1%"]]
+
+
+# --------------------------------------------------------------------------- #
+# --check — Tier-1 probe
+# --------------------------------------------------------------------------- #
+def test_check_exit_zero_when_present():
+    assert render.cmd_check() == 0
+
+
+def test_check_exit_two_when_absent(monkeypatch):
+    monkeypatch.setitem(sys.modules, "pptx", None)  # forces ImportError on `import pptx`
+    assert render.cmd_check() == 2
+
+
+# --------------------------------------------------------------------------- #
+# confinement — output/template path stays under the working directory
+# --------------------------------------------------------------------------- #
+def test_confine_rejects_parent_traversal(tmp_path):
+    root = tmp_path / "workdir"
+    root.mkdir()
+    with pytest.raises(ValueError):
+        render.confine(root / ".." / "evil.pptx", root)
+
+
+def test_confine_rejects_symlink_escape(tmp_path):
+    root = tmp_path / "workdir"
+    root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    link = root / "link"
+    link.symlink_to(outside, target_is_directory=True)
+    with pytest.raises(ValueError):
+        render.confine(link / "evil.pptx", root)
+
+
+def test_confine_rejects_sibling_prefix(tmp_path):
+    root = tmp_path / "workdir"
+    root.mkdir()
+    (tmp_path / "workdir-evil").mkdir()
+    with pytest.raises(ValueError):
+        render.confine(tmp_path / "workdir-evil" / "out.pptx", root)
+
+
+def test_confine_accepts_path_under_root(tmp_path):
+    root = tmp_path / "workdir"
+    root.mkdir()
+    assert render.confine(root / "deck.pptx", root) == (root / "deck.pptx").resolve()
+
+
+# --------------------------------------------------------------------------- #
+# end-to-end render (manual-QA mode, exercised as an integration test)
+# --------------------------------------------------------------------------- #
+def test_render_fills_template_and_reopened_values_present(tmp_path):
+    from pptx import Presentation
+
+    template = _build_template(tmp_path / "template.pptx")
+    (tmp_path / "deck.md").write_text(MARKDOWN, encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(HERE / "render.py"), "render", "deck.md",
+         "--template", "template.pptx", "--output", "out.pptx"],
+        cwd=tmp_path, capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OUTPUT:" in result.stdout
+    out = tmp_path / "out.pptx"
+    assert out.is_file()
+
+    # Re-open the produced file and assert the mapped values survived the render.
+    prs = Presentation(str(out))
+    texts = [
+        shape.text_frame.text
+        for slide in prs.slides
+        for shape in slide.shapes
+        if shape.has_text_frame
+    ]
+    blob = "\n".join(texts)
+    assert "Q3 Review" in blob
+    assert "Revenue up 12%" in blob
+
+    table_cells = [
+        cell.text
+        for slide in prs.slides
+        for shape in slide.shapes
+        if shape.has_table
+        for row in shape.table.rows
+        for cell in row.cells
+    ]
+    assert "ARR" in table_cells and "4.2M" in table_cells

--- a/packs/converters/.apm/skills/markdown-to-xlsx/SKILL.md
+++ b/packs/converters/.apm/skills/markdown-to-xlsx/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: markdown-to-xlsx
+description: "Fill a branded Excel template from a Markdown artifact — export this table to Excel, fill the .xlsx template, produce a spreadsheet or workbook. The deterministic script writes Markdown content into the named ranges and Excel Tables a designer defined (front-matter into single-cell names, a Markdown table into a Table data region), so the workbook's formatting, formulas, and charts survive. Use when the user wants Excel, a spreadsheet, or an .xlsx workbook out of Markdown. Tier-1 on openpyxl (the user installs it; the skill detects it and stops if absent)."
+---
+
+# Markdown to Excel
+
+A thin wrapper around `scripts/render.py`. The script is the renderer; you
+assemble nothing by hand. It writes Markdown content into the **data ranges** a
+designer already defined in a `.xlsx` template — its **named ranges** and **Excel
+Tables** — via [`openpyxl`](https://pypi.org/project/openpyxl/), rather than
+building a workbook from scratch. The template's formatting, formulas, and any
+chart that reads those ranges survive.
+
+## Prerequisites
+
+This skill is **Tier-1** on `openpyxl` (the exact canonical PyPI package).
+Install it once:
+
+```bash
+python -m pip install 'openpyxl>=3.1.0'
+```
+
+`openpyxl` installs into **your** environment, **outside the repo's SCA**
+(`pip-audit` / CodeQL never scan it), so you own keeping it current. The skill
+never installs it for you. Verify before rendering:
+
+```bash
+python scripts/render.py --check
+```
+
+Exit `0` → proceed. Exit `2` → it's not installed; run the `pip install` above
+and stop.
+
+## The deterministic-renderer contract
+
+You drive three verbs; the script does the rendering:
+
+| Verb | What it does | Stdout markers |
+|---|---|---|
+| `--check` | Import-probe `openpyxl`; exit `0`/`2`. | — |
+| `inspect <template>` | List the workbook's named ranges + Excel Tables. | `FILLPOINTS: kind=… name=… ref=…` (or `GUIDANCE:`) |
+| `render <markdown> --template <tpl> [--output <path>]` | Fill the data ranges and write a `.xlsx`. | `OUTPUT: <path>`, `FILLED: <n>`, `WARNING: <msg>`, `GUIDANCE: <msg>` |
+
+The mapping: front-matter `key: value` → the single-cell **named range** of the
+same name; the first Markdown table → the first **Excel Table**'s data region
+(columns aligned by header text, else by position). Detail and how to define
+ranges in Excel are in [`references/fill-points.md`](references/fill-points.md).
+
+**Your job** is to assemble the Markdown content and invoke the script. Do not
+hand-write the `.xlsx` or its XML.
+
+## Template flow
+
+1. **Detect** — look for a `.xlsx` template on disk in the working directory.
+2. **Confirm or elicit** — confirm the found one, or ask the user for theirs.
+3. **No fill-points** — if the workbook has no named ranges and no Excel Tables,
+   the script emits `GUIDANCE:` explaining how to add them (Define Name / Insert
+   Table) rather than silently converting. Relay it; don't convert by hand.
+4. **Opt-out** — only if the user explicitly declines a template, render
+   **template-less** with a bare `openpyxl` workbook. Say so up front: the result
+   carries no brand. Never invent a brand or ship a default template asset.
+
+## Charts and shapes — the data-ranges-only contract
+
+The script writes **only** into named-range and Excel-Table data cells. It never
+creates, manipulates, or resizes chart or shape objects, and never resizes a
+table's range — so a chart that reads a filled range keeps working. `openpyxl`
+preserves the charts and images it can parse through a load-and-save, **but its
+own tutorial warns that shapes it cannot read are lost when an existing file is
+opened and saved**. For a template with complex Excel-authored drawings,
+**re-open the produced file and confirm the visuals survived.** A Markdown table
+with more rows than the Excel Table has room for is truncated (with a
+`WARNING:`), never expanded, because resizing a range can break the charts that
+read it.
+
+## Trust model
+
+A user-supplied template is **trusted-author input**, consistent with the
+converters pack's local-files-trusted stance. `openpyxl` does not evaluate
+workbook content as code, so there is no template-injection surface here; XXE or
+a zip-bomb on a deliberately crafted Office archive is an accepted, out-of-scope
+risk for a trusted-author template. The script still **confines its writes**: it
+resolves `--output`/`--template` and refuses any path escaping the working
+directory.
+
+## Don't
+
+- Don't hand-write the `.xlsx` or its XML — the script renders.
+- Don't convert a workbook with no fill-points — relay the `GUIDANCE:` instead.
+- Don't resize a table or named range to fit more data — that can break charts.
+- Don't ship or invent a default template — an absent template is the user's
+  explicit choice.
+- Don't auto-install `openpyxl` — print the install line and stop.
+
+## Edge cases
+
+| Situation | Behavior |
+|---|---|
+| `openpyxl` not installed | `--check` exits `2` with the install line; stop. |
+| Workbook has no named ranges or Tables | `GUIDANCE:` explains how to add them; no file written. |
+| Markdown table longer than the Excel Table | Truncated with a `WARNING:`; the range is not resized. |
+| Template carries complex Excel-authored shapes | Re-open and verify; `openpyxl` may drop shapes it can't parse. |
+| A named range spans multiple cells | Skipped with a `WARNING:` (scalars target single-cell names). |

--- a/packs/converters/.apm/skills/markdown-to-xlsx/evals/evals.json
+++ b/packs/converters/.apm/skills/markdown-to-xlsx/evals/evals.json
@@ -1,0 +1,57 @@
+{
+  "skill_name": "markdown-to-xlsx",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Export this Markdown table to Excel using our workbook template metrics-template.xlsx.",
+      "expected_output": "The agent confirms openpyxl is installed (`render.py --check`), inspects the workbook's named ranges/tables, then invokes `python scripts/render.py render <markdown> --template metrics-template.xlsx`. It reports OUTPUT and FILLED. It does not hand-write the .xlsx.",
+      "assertions": [
+        "Agent runs `python scripts/render.py --check` (or otherwise confirms openpyxl) before rendering",
+        "Agent invokes `python scripts/render.py render` with `--template metrics-template.xlsx`",
+        "Agent does NOT hand-write the .xlsx or its XML",
+        "Agent reports the OUTPUT: path and FILLED: count back to the user"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Fill the .xlsx template — but it has a dashboard chart, don't break it.",
+      "expected_output": "The agent explains the script writes only into named ranges and Excel Table data cells and never touches chart objects or resizes ranges, so a chart reading those ranges keeps working. It advises re-opening the result to confirm complex Excel-authored shapes survived.",
+      "assertions": [
+        "Agent explains the renderer writes only to data ranges and does not manipulate the chart",
+        "Agent notes the range is not resized (so the chart wiring is preserved)",
+        "Agent advises re-opening to verify visuals for complex templates",
+        "Agent does NOT propose rebuilding the chart by hand"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Put this data into spreadsheet.xlsx — I just made a blank workbook.",
+      "expected_output": "The agent runs inspect, finds no named ranges or Tables, and relays the GUIDANCE about defining a Name and inserting a Table rather than silently converting.",
+      "assertions": [
+        "Agent invokes `python scripts/render.py inspect spreadsheet.xlsx`",
+        "Agent relays guidance to define named ranges / insert an Excel Table when there are no fill-points",
+        "Agent does NOT silently convert the Markdown into a fresh workbook, discarding formatting"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Which named ranges and tables does our workbook fill? Here's brand.xlsx.",
+      "expected_output": "The agent invokes `python scripts/render.py inspect brand.xlsx` and reports the FILLPOINTS lines (kind/name/ref), explaining front-matter fills single-cell names and a Markdown table fills a Table data region.",
+      "assertions": [
+        "Agent invokes `python scripts/render.py inspect brand.xlsx`",
+        "Agent reports the fill-points (named ranges and Excel Tables) with their refs",
+        "Agent does NOT guess the fill-points without running inspect"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "My table has 50 rows but the template's Excel Table only has 10 — what happens?",
+      "expected_output": "The agent explains the script fills the existing data region and truncates overflow with a WARNING rather than resizing the table, because resizing could break a chart that reads the range. It suggests enlarging the Table in Excel first if all rows are needed.",
+      "assertions": [
+        "Agent explains overflow rows are truncated with a WARNING, not auto-expanded",
+        "Agent ties the no-resize behavior to preserving chart wiring",
+        "Agent suggests enlarging the Excel Table in the template if all rows are required"
+      ]
+    }
+  ]
+}

--- a/packs/converters/.apm/skills/markdown-to-xlsx/references/fill-points.md
+++ b/packs/converters/.apm/skills/markdown-to-xlsx/references/fill-points.md
@@ -1,0 +1,64 @@
+# Excel fill-points: the named-range and Table model
+
+`markdown-to-xlsx` writes into the **data ranges** a designer defined in a
+`.xlsx` template, via [`openpyxl`](https://openpyxl.readthedocs.io/). This is the
+reference for what those are, how Markdown projects onto them, and how to define
+them in Excel.
+
+## What a fill-point is
+
+Like Word (and unlike PowerPoint), an Excel workbook has **no fill-points until
+you add them**. There are two kinds:
+
+| Kind | What it is | Good for |
+|---|---|---|
+| **Named range** | A name bound to a cell or range (Formulas → Define Name) | A single scalar — a title, a date, a prepared-by line |
+| **Excel Table** | A structured data block (Insert → Table) with a header row | Tabular content — a metrics table, a line-item list |
+
+`inspect <template>` reports both:
+
+```
+FILLPOINTS: kind=defined_name name=report_title ref=Data!$D$1
+FILLPOINTS: kind=table name=metrics ref=Data!A1:B3
+```
+
+If the workbook has neither, `inspect` (and `render`) emit `GUIDANCE:` telling
+the user how to add them — the skill never silently converts a workbook with no
+fill-points, because that would discard its formatting and any chart wiring.
+
+## How Markdown maps onto fill-points
+
+| Markdown | Content-model field | Lands in |
+|---|---|---|
+| Front-matter `key: value` | `scalars[key]` | The single-cell named range named `key` |
+| The first Markdown table | `table` (`{header, rows}`) | The first Excel Table's data region |
+
+Front-matter keys are matched to named ranges **by name** — a `report_title:`
+front-matter line fills the named range called `report_title`, and only if that
+name exists and points to a single cell. Markdown table columns are matched to
+the Excel Table's columns **by header text** where they match, else by position.
+
+## Defining fill-points in Excel
+
+- **Named range:** select the cell, then Formulas → Define Name, and give it a
+  name (e.g. `report_title`). Use the same name as the Markdown front-matter key.
+- **Excel Table:** select the data block including its header row, then Insert →
+  Table (or Ctrl/Cmd+T). Name it under Table Design → Table Name. The header row
+  labels should match your Markdown table's column headers.
+
+## Why data-ranges-only
+
+The script writes **only** into named-range and Table data cells. It never
+touches chart or shape objects, and never resizes a Table's range. This is the
+mitigation for openpyxl's documented round-trip limitation:
+
+> openpyxl does currently not read all possible items in an Excel file so shapes
+> will be lost from existing files if they are opened and saved with the same
+> name. *(openpyxl tutorial)*
+
+In practice openpyxl preserves the charts and images it **can** parse, so a
+chart reading a filled range keeps working. But for a template with complex
+Excel-authored drawings, **re-open the produced file and confirm the visuals
+survived** — the skill deliberately avoids resizing ranges (which would feed
+larger data into a chart) precisely so the chart wiring it can't see stays
+intact.

--- a/packs/converters/.apm/skills/markdown-to-xlsx/scripts/render.py
+++ b/packs/converters/.apm/skills/markdown-to-xlsx/scripts/render.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""
+render.py — fill a branded Excel template from a Markdown artifact.
+
+This is the deterministic renderer for the `markdown-to-xlsx` skill. The agent
+assembles the content model and invokes this script; the script writes Markdown
+content into the **data ranges** (named ranges and Excel Tables) a designer
+already defined in a `.xlsx` template, rather than building a workbook from
+scratch — so the template's formatting, formulas, and any chart that reads those
+ranges survive.
+
+Verbs
+    --check                 import-probe openpyxl; exit 0 (present) / 2 (absent)
+    inspect <template>      print the named ranges + Excel Tables (the fill-points)
+    render  <markdown>      fill a template and write a .xlsx
+        --template <path>   workbook with named ranges/tables; omit for default
+        --output <path>     output path (default: <markdown-basename>.xlsx in CWD)
+
+Stdout markers (for agent parsing)
+    FILLPOINTS: kind=<defined_name|table> name=<n> ref=<ref>   (inspect)
+    GUIDANCE: <msg>         workbook has no fill-points; how to add them
+    OUTPUT: <path>          path to the written .xlsx
+    FILLED: <n>             count of fill-points a value was written into
+    WARNING: <msg>          non-fatal issue, surface to the user
+
+Data-ranges-only contract
+    The script writes only into named-range and Excel-Table data cells. It never
+    creates, manipulates, or resizes chart/shape objects, and never resizes a
+    table's range — so charts that read those ranges keep working. openpyxl
+    preserves the charts and images it can parse on round-trip, but its tutorial
+    warns that *shapes it cannot read are lost when an existing file is opened
+    and saved*; for a template with complex Excel-authored drawings, re-open the
+    result and confirm the visuals survived.
+
+Trust model
+    A user-supplied template is trusted-author input, consistent with the
+    converters pack's local-files-trusted stance. openpyxl does not evaluate
+    workbook content as code, so there is no template-injection surface here;
+    XXE / zip-bomb on a crafted archive is an accepted, out-of-scope risk.
+    Output-path confinement is still enforced (the output path is assembled from
+    model-influenced content).
+
+Errors go to stderr; exit code 1 on failure, 2 on a missing library.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+PIP_INSTALL = "python -m pip install 'openpyxl>=3.1.0'"
+
+GUIDANCE_NO_FILLPOINTS = (
+    "this workbook has no named ranges or Excel Tables, so there are no "
+    "fill-points to write into. In Excel, select the cell(s) for a scalar and "
+    "give the selection a Name (Formulas → Define Name), and turn a data block "
+    "into a Table (Insert → Table) for tabular content. Then re-run. The skill "
+    "never silently converts an untagged workbook — that would discard your "
+    "formatting and any chart wiring."
+)
+
+
+class RenderResult(NamedTuple):
+    written: bool
+    filled: int
+    warnings: list[str]
+    guidance: str | None
+
+
+# --------------------------------------------------------------------------- #
+# Output-path confinement
+# --------------------------------------------------------------------------- #
+def confine(path: Path, root: Path) -> Path:
+    """Resolve ``path`` (following symlinks) and require it under ``root``.
+
+    Path-*component* containment (``root`` is the resolved path or among its
+    ``.parents``), not a string-prefix check, so a sibling like ``workdir-evil``
+    is rejected against root ``workdir``. Raises ``ValueError`` on escape.
+    """
+    resolved = path.resolve()
+    root_resolved = root.resolve()
+    if resolved == root_resolved or root_resolved in resolved.parents:
+        return resolved
+    raise ValueError(
+        f"path {path!r} resolves to {resolved} which is outside the working "
+        f"directory {root_resolved}; refusing to read/write outside the project"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Markdown → content model (the map step)
+# --------------------------------------------------------------------------- #
+def parse_markdown(text: str) -> dict:
+    """Project a Markdown artifact onto the xlsx content model.
+
+    Mapping (RFC-0036): front-matter ``key: value`` lines → ``scalars`` (each
+    written into a single-cell *named range* of the same name); the first
+    Markdown table → ``table`` (``{header, rows}``, written into an Excel
+    *Table* data region). Pure transform — no I/O.
+    """
+    scalars: dict[str, str] = {}
+    table: dict | None = None
+    lines = text.splitlines()
+    i = 0
+
+    if lines and lines[0].strip() == "---":
+        j = 1
+        while j < len(lines) and lines[j].strip() != "---":
+            raw = lines[j]
+            if ":" in raw:
+                key, _, value = raw.partition(":")
+                scalars[key.strip()] = value.strip().strip("\"'")
+            j += 1
+        i = j + 1 if j < len(lines) else len(lines)
+
+    def cell_split(row: str) -> list[str]:
+        return [c.strip() for c in row.strip().strip("|").split("|")]
+
+    while i < len(lines):
+        stripped = lines[i].strip()
+        if (
+            table is None
+            and stripped.startswith("|")
+            and i + 1 < len(lines)
+            and "-" in lines[i + 1]
+            and set(lines[i + 1].strip().replace("|", "").replace(":", "").strip()) <= {"-", " "}
+            and lines[i + 1].strip().replace("|", "").strip()
+        ):
+            header = cell_split(stripped)
+            rows = []
+            i += 2
+            while i < len(lines) and lines[i].strip().startswith("|"):
+                rows.append(cell_split(lines[i]))
+                i += 1
+            table = {"header": header, "rows": rows}
+            continue
+        i += 1
+
+    return {"scalars": scalars, "table": table}
+
+
+# --------------------------------------------------------------------------- #
+# openpyxl helpers (imported lazily so --check runs without the library)
+# --------------------------------------------------------------------------- #
+def _strip_abs(coord: str) -> str:
+    return coord.replace("$", "")
+
+
+def inspect_template(template: Path) -> list[dict]:
+    """Return the workbook's fill-points: defined names + Excel Tables."""
+    from openpyxl import load_workbook
+
+    wb = load_workbook(str(template))
+    fillpoints: list[dict] = []
+    for name in wb.defined_names:
+        dn = wb.defined_names[name]
+        ref = ";".join(f"{title}!{coord}" for title, coord in dn.destinations)
+        fillpoints.append({"kind": "defined_name", "name": name, "ref": ref})
+    for ws in wb.worksheets:
+        # TableList.values() yields Table objects; .items() yields raw (name, ref).
+        for tbl in ws.tables.values():
+            fillpoints.append({"kind": "table", "name": tbl.name, "ref": f"{ws.title}!{tbl.ref}"})
+    return fillpoints
+
+
+def _write_named_scalars(wb, scalars: dict) -> tuple[int, list[str]]:
+    """Write each front-matter scalar into the single-cell named range it matches."""
+    filled = 0
+    warnings: list[str] = []
+    for key, value in scalars.items():
+        if key not in wb.defined_names:
+            continue
+        dests = list(wb.defined_names[key].destinations)
+        # A single cell yields one destination whose coord has no ":" range
+        # separator; a multi-cell name yields a range coord (or several dests).
+        if len(dests) != 1 or ":" in dests[0][1]:
+            warnings.append(f"named range '{key}' is not a single cell; skipped")
+            continue
+        title, coord = dests[0]
+        wb[title][_strip_abs(coord)] = value
+        filled += 1
+    return filled, warnings
+
+
+def _write_table(wb, table: dict) -> tuple[int, list[str]]:
+    """Write the Markdown table into the first Excel Table's data region.
+
+    Columns align by header text where they match, else by position. Rows fill
+    the table's *existing* data region; the range is never resized (resizing
+    could break a chart that reads it). Overflow rows are truncated with a
+    warning.
+    """
+    from openpyxl.utils.cell import range_boundaries, get_column_letter
+
+    target_ws = target_tbl = None
+    for ws in wb.worksheets:
+        if ws.tables:
+            target_ws = ws
+            target_tbl = next(iter(ws.tables.values()))
+            break
+    if target_tbl is None:
+        return 0, []
+
+    min_col, min_row, max_col, max_row = range_boundaries(target_tbl.ref)
+    tbl_header = [target_ws.cell(row=min_row, column=c).value for c in range(min_col, max_col + 1)]
+
+    # Column index in the template table for each Markdown column (by header text).
+    md_header = table["header"]
+    col_for_md = {}
+    for mi, mh in enumerate(md_header):
+        if mh in tbl_header:
+            col_for_md[mi] = min_col + tbl_header.index(mh)
+        elif mi < (max_col - min_col + 1):
+            col_for_md[mi] = min_col + mi  # positional fallback
+
+    data_rows = max_row - min_row  # rows under the header
+    warnings: list[str] = []
+    if len(table["rows"]) > data_rows:
+        warnings.append(
+            f"Markdown table has {len(table['rows'])} rows but the Excel Table "
+            f"'{target_tbl.name}' has room for {data_rows}; extra rows were truncated "
+            "(the table range is not resized, to avoid breaking charts)"
+        )
+
+    filled = 0
+    for r, row in enumerate(table["rows"][:data_rows]):
+        for mi, value in enumerate(row):
+            col = col_for_md.get(mi)
+            if col is not None:
+                target_ws.cell(row=min_row + 1 + r, column=col, value=value)
+        filled += 1
+    if filled:
+        # touch get_column_letter so the import is exercised on the happy path
+        _ = get_column_letter(min_col)
+    return filled, warnings
+
+
+def render_xlsx(text: str, template: Path, output: Path) -> RenderResult:
+    """Fill ``template`` from the Markdown in ``text``; write ``output``.
+
+    Writes only into named ranges and Excel-Table data cells; never touches
+    chart/shape objects. If the workbook has no fill-points, returns guidance
+    instead of writing (never a silent convert).
+    """
+    from openpyxl import load_workbook
+
+    model = parse_markdown(text)
+    wb = load_workbook(str(template))
+
+    has_names = len(list(wb.defined_names)) > 0
+    has_tables = any(ws.tables for ws in wb.worksheets)
+    if not has_names and not has_tables:
+        return RenderResult(written=False, filled=0, warnings=[], guidance=GUIDANCE_NO_FILLPOINTS)
+
+    filled_s, warn_s = _write_named_scalars(wb, model["scalars"])
+    filled_t, warn_t = (0, [])
+    if model["table"] is not None:
+        filled_t, warn_t = _write_table(wb, model["table"])
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    wb.save(str(output))
+    return RenderResult(
+        written=True, filled=filled_s + filled_t, warnings=warn_s + warn_t, guidance=None
+    )
+
+
+def render_default_xlsx(text: str, output: Path) -> RenderResult:
+    """Opt-out path: write the Markdown into a bare openpyxl workbook.
+
+    Used only when the user explicitly declines a branded template. The result
+    is unbranded — front-matter scalars go into a key/value block, the first
+    Markdown table follows below. Not the primary path: branding requires a
+    template with named ranges / Tables (``render_xlsx``).
+    """
+    from openpyxl import Workbook
+
+    model = parse_markdown(text)
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Data"
+
+    row = 1
+    for key, value in model["scalars"].items():
+        ws.cell(row=row, column=1, value=key)
+        ws.cell(row=row, column=2, value=value)
+        row += 1
+    if model["scalars"] and model["table"]:
+        row += 1  # blank spacer between the scalar block and the table
+
+    table = model["table"]
+    if table:
+        for c, h in enumerate(table["header"], start=1):
+            ws.cell(row=row, column=c, value=h)
+        for r, data_row in enumerate(table["rows"], start=1):
+            for c, cell in enumerate(data_row, start=1):
+                ws.cell(row=row + r, column=c, value=cell)
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    wb.save(str(output))
+    return RenderResult(
+        written=True,
+        filled=0,
+        warnings=["no template supplied — produced an UNBRANDED .xlsx via openpyxl"],
+        guidance=None,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def cmd_check() -> int:
+    try:
+        import openpyxl  # noqa: F401
+    except ImportError:
+        print(f"openpyxl is not installed. Run:\n    {PIP_INSTALL}", file=sys.stderr)
+        return 2
+    return 0
+
+
+def cmd_inspect(args) -> int:
+    root = Path.cwd()
+    template = confine(Path(args.template), root)
+    if not template.is_file():
+        print(f"ERROR: template not found: {args.template}", file=sys.stderr)
+        return 1
+    fillpoints = inspect_template(template)
+    if not fillpoints:
+        print(f"GUIDANCE: {GUIDANCE_NO_FILLPOINTS}")
+        return 0
+    for fp in fillpoints:
+        print(f"FILLPOINTS: kind={fp['kind']} name={fp['name']} ref={fp['ref']}")
+    return 0
+
+
+def cmd_render(args) -> int:
+    root = Path.cwd()
+    md_path = confine(Path(args.markdown), root)
+    if not md_path.is_file():
+        print(f"ERROR: markdown not found: {args.markdown}", file=sys.stderr)
+        return 1
+
+    output = Path(args.output) if args.output else Path(md_path.stem + ".xlsx")
+    output = confine(output, root)
+    text = md_path.read_text(encoding="utf-8")
+
+    if not args.template:
+        # Explicit opt-out (the agent omits --template only after the user
+        # declines a branded template, per SKILL.md): bare openpyxl workbook.
+        result = render_default_xlsx(text, output)
+    else:
+        template = confine(Path(args.template), root)
+        if not template.is_file():
+            print(f"ERROR: template not found: {args.template}", file=sys.stderr)
+            return 1
+        result = render_xlsx(text, template, output)
+    if result.guidance:
+        print(f"GUIDANCE: {result.guidance}")
+        return 0
+    for w in result.warnings:
+        print(f"WARNING: {w}")
+    print(f"OUTPUT: {output}")
+    print(f"FILLED: {result.filled}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Fill an Excel template from Markdown.")
+    parser.add_argument("--check", action="store_true", help="probe openpyxl; exit 0/2")
+    sub = parser.add_subparsers(dest="verb")
+
+    p_inspect = sub.add_parser("inspect", help="print named ranges + Excel Tables")
+    p_inspect.add_argument("template")
+
+    p_render = sub.add_parser("render", help="fill a template and write a .xlsx")
+    p_render.add_argument("markdown")
+    p_render.add_argument("--template", help="workbook with named ranges/tables to fill")
+    p_render.add_argument("--output", help="output path (default: <basename>.xlsx in CWD)")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.check:
+        return cmd_check()
+
+    rc = cmd_check()
+    if rc != 0:
+        return rc
+
+    try:
+        if args.verb == "inspect":
+            return cmd_inspect(args)
+        if args.verb == "render":
+            return cmd_render(args)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packs/converters/.apm/skills/markdown-to-xlsx/scripts/test_render.py
+++ b/packs/converters/.apm/skills/markdown-to-xlsx/scripts/test_render.py
@@ -1,0 +1,247 @@
+"""TDD suite for the markdown-to-xlsx renderer.
+
+Covers the contracts the spec names: fill-point enumeration (named ranges +
+Excel Tables), Markdown→content-model mapping, the no-fill-points guidance, the
+data-ranges-only path leaving a chart intact, the Tier-1 `--check` probe, and
+output-path confinement — plus an end-to-end render that re-opens the produced
+.xlsx and asserts the filled values are present.
+
+The fixture workbook is built with openpyxl at test time rather than committed
+as an opaque binary; the builder below is its authorship. Run with
+`python -m pytest` from this directory.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import render
+
+HERE = Path(__file__).resolve().parent
+
+MARKDOWN = """\
+---
+report_title: Q3 Review
+prepared_by: Finance
+---
+
+# Numbers
+
+| Metric | Value |
+| --- | --- |
+| ARR | 4.2M |
+| Churn | 1.1% |
+"""
+
+
+def _build_template(path: Path, with_chart: bool = False) -> Path:
+    """Author a .xlsx template with a named range, an Excel Table, optional chart."""
+    from openpyxl import Workbook
+    from openpyxl.workbook.defined_name import DefinedName
+    from openpyxl.worksheet.table import Table
+
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Data"
+    # Title cell + a single-cell named range pointing at it.
+    ws["D1"] = ""
+    wb.defined_names.add(DefinedName("report_title", attr_text="Data!$D$1"))
+    # A data block headed by Metric/Value with two empty data rows, as a Table.
+    ws["A1"], ws["B1"] = "Metric", "Value"
+    for r in (2, 3):
+        ws.cell(row=r, column=1, value="")
+        ws.cell(row=r, column=2, value="")
+    ws.add_table(Table(displayName="metrics", ref="A1:B3"))
+
+    if with_chart:
+        from openpyxl.chart import BarChart, Reference
+
+        chart = BarChart()
+        chart.add_data(Reference(ws, min_col=2, min_row=1, max_row=3), titles_from_data=True)
+        ws.add_chart(chart, "F2")
+
+    wb.save(str(path))
+    return path
+
+
+def _build_empty_template(path: Path) -> Path:
+    from openpyxl import Workbook
+
+    wb = Workbook()
+    wb.active["A1"] = "no fill-points here"
+    wb.save(str(path))
+    return path
+
+
+# --------------------------------------------------------------------------- #
+# inspect — named ranges + Excel Tables
+# --------------------------------------------------------------------------- #
+def test_inspect_returns_defined_names_and_tables(tmp_path):
+    template = _build_template(tmp_path / "template.xlsx")
+    fillpoints = render.inspect_template(template)
+    kinds = {(fp["kind"], fp["name"]) for fp in fillpoints}
+    assert ("defined_name", "report_title") in kinds
+    assert ("table", "metrics") in kinds
+
+
+# --------------------------------------------------------------------------- #
+# map — Markdown → content model
+# --------------------------------------------------------------------------- #
+def test_map_projects_frontmatter_and_table():
+    model = render.parse_markdown(MARKDOWN)
+    # front-matter → single-cell named-range scalars
+    assert model["scalars"]["report_title"] == "Q3 Review"
+    assert model["scalars"]["prepared_by"] == "Finance"
+    # a Markdown table → a Table data region
+    assert model["table"]["header"] == ["Metric", "Value"]
+    assert model["table"]["rows"] == [["ARR", "4.2M"], ["Churn", "1.1%"]]
+
+
+# --------------------------------------------------------------------------- #
+# no-fill-points guidance
+# --------------------------------------------------------------------------- #
+def test_empty_markdown_parses_without_crash():
+    assert render.parse_markdown("") == {"scalars": {}, "table": None}
+
+
+def test_multi_cell_named_range_is_skipped_with_warning(tmp_path):
+    from openpyxl import Workbook
+    from openpyxl.workbook.defined_name import DefinedName
+
+    wb = Workbook()
+    wb.active.title = "Data"
+    wb.defined_names.add(DefinedName("report_title", attr_text="Data!$A$1:$A$2"))
+    wb.save(str(tmp_path / "t.xlsx"))
+
+    out = tmp_path / "out.xlsx"
+    result = render.render_xlsx("---\nreport_title: Q3\n---\n", tmp_path / "t.xlsx", out)
+    assert result.written is True
+    assert any("not a single cell" in w for w in result.warnings)
+
+
+def test_overflow_rows_truncated_with_warning(tmp_path):
+    from openpyxl import load_workbook
+
+    template = _build_template(tmp_path / "template.xlsx")  # Table A1:B3 → 2 data rows
+    md = (
+        "---\ntitle: x\n---\n\n# N\n\n| Metric | Value |\n| --- | --- |\n"
+        "| ARR | 1 |\n| Churn | 2 |\n| NRR | 3 |\n"
+    )
+    out = tmp_path / "out.xlsx"
+    result = render.render_xlsx(md, template, out)
+    assert any("truncated" in w for w in result.warnings)
+    ws = load_workbook(str(out))["Data"]
+    assert ws["A2"].value == "ARR" and ws["A3"].value == "Churn"
+    assert ws["A4"].value in (None, "")  # the 3rd row did not overflow the range
+
+
+def test_render_default_writes_unbranded_xlsx(tmp_path):
+    from openpyxl import load_workbook
+
+    out = tmp_path / "out.xlsx"
+    result = render.render_default_xlsx(MARKDOWN, out)
+    assert result.written is True
+    assert any("UNBRANDED" in w for w in result.warnings)
+    ws = load_workbook(str(out))["Data"]
+    cells = [c.value for row in ws.iter_rows() for c in row]
+    assert "Q3 Review" in cells and "ARR" in cells and "4.2M" in cells
+
+
+def test_no_fillpoints_yields_guidance(tmp_path):
+    template = _build_empty_template(tmp_path / "empty.xlsx")
+    assert render.inspect_template(template) == []
+    out = tmp_path / "out.xlsx"
+    result = render.render_xlsx(MARKDOWN, template, out)
+    assert result.written is False
+    assert result.guidance and "named range" in result.guidance
+    assert not out.exists()
+
+
+# --------------------------------------------------------------------------- #
+# data-ranges-only: a chart survives the render
+# --------------------------------------------------------------------------- #
+def test_render_preserves_chart_and_writes_only_data(tmp_path):
+    from openpyxl import load_workbook
+
+    template = _build_template(tmp_path / "template.xlsx", with_chart=True)
+    out = tmp_path / "out.xlsx"
+    result = render.render_xlsx(MARKDOWN, template, out)
+    assert result.written is True
+
+    wb = load_workbook(str(out))
+    ws = wb["Data"]
+    # the chart object is still present (the path never touched it)
+    assert len(ws._charts) == 1
+    # the data ranges were written
+    assert ws["D1"].value == "Q3 Review"
+    assert ws["A2"].value == "ARR" and ws["B2"].value == "4.2M"
+
+
+# --------------------------------------------------------------------------- #
+# --check — Tier-1 probe
+# --------------------------------------------------------------------------- #
+def test_check_exit_zero_when_present():
+    assert render.cmd_check() == 0
+
+
+def test_check_exit_two_when_absent(monkeypatch):
+    monkeypatch.setitem(sys.modules, "openpyxl", None)
+    assert render.cmd_check() == 2
+
+
+# --------------------------------------------------------------------------- #
+# confinement
+# --------------------------------------------------------------------------- #
+def test_confine_rejects_parent_traversal(tmp_path):
+    root = tmp_path / "workdir"
+    root.mkdir()
+    with pytest.raises(ValueError):
+        render.confine(root / ".." / "evil.xlsx", root)
+
+
+def test_confine_rejects_symlink_escape(tmp_path):
+    root = tmp_path / "workdir"
+    root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    link = root / "link"
+    link.symlink_to(outside, target_is_directory=True)
+    with pytest.raises(ValueError):
+        render.confine(link / "evil.xlsx", root)
+
+
+def test_confine_rejects_sibling_prefix(tmp_path):
+    root = tmp_path / "workdir"
+    root.mkdir()
+    (tmp_path / "workdir-evil").mkdir()
+    with pytest.raises(ValueError):
+        render.confine(tmp_path / "workdir-evil" / "out.xlsx", root)
+
+
+# --------------------------------------------------------------------------- #
+# end-to-end render (manual-QA mode, exercised as an integration test)
+# --------------------------------------------------------------------------- #
+def test_render_fills_template_and_reopened_values_present(tmp_path):
+    from openpyxl import load_workbook
+
+    _build_template(tmp_path / "template.xlsx")
+    (tmp_path / "report.md").write_text(MARKDOWN, encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(HERE / "render.py"), "render", "report.md",
+         "--template", "template.xlsx", "--output", "out.xlsx"],
+        cwd=tmp_path, capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OUTPUT:" in result.stdout
+    out = tmp_path / "out.xlsx"
+    assert out.is_file()
+
+    ws = load_workbook(str(out))["Data"]
+    assert ws["D1"].value == "Q3 Review"
+    assert ws["A2"].value == "ARR" and ws["B2"].value == "4.2M"
+    assert ws["A3"].value == "Churn" and ws["B3"].value == "1.1%"

--- a/packs/converters/.claude-plugin/plugin.json
+++ b/packs/converters/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "converters",
-  "version": "0.1.2",
-  "description": "File-format conversion skills: documents and images → Markdown; Markdown → styled HTML; Outlook .msg → Markdown."
+  "version": "0.2.0",
+  "description": "File-format conversion skills: documents and images → Markdown; Markdown → styled HTML and to branded Word, PowerPoint, and Excel; Outlook .msg → Markdown."
 }

--- a/packs/converters/README.md
+++ b/packs/converters/README.md
@@ -1,11 +1,15 @@
 # converters
 
-File-format conversion skills for getting content into and out of Markdown.
+File-format conversion skills for getting content into and out of Markdown —
+including publishing a Markdown artifact back out as a branded Office file.
 
 ## What's inside
 
 - `file-to-markdown` — documents and images → Markdown.
 - `markdown-to-html` — Markdown → styled HTML.
+- `markdown-to-docx` — Markdown → a branded Word document (fills a `.docx` template).
+- `markdown-to-pptx` — Markdown → a branded PowerPoint deck (fills a `.pptx` template).
+- `markdown-to-xlsx` — Markdown → a branded Excel workbook (fills a `.xlsx` template).
 - `msg-to-markdown` — Outlook `.msg` → Markdown.
 - `mermaid-renderer` — render Mermaid diagrams.
 
@@ -24,7 +28,14 @@ Ask your agent, for example:
 
 - "Convert this PDF to Markdown: <path>."
 - "Render this Markdown file as styled HTML."
+- "Turn this Markdown into a Word doc using our branded template."
+- "Make this Markdown into a PowerPoint deck from our slide template."
+- "Export this Markdown table to Excel, filling our workbook template."
 - "Convert this Outlook .msg export to Markdown."
+
+The Markdown→Office skills are **Tier-1** on their render libraries
+(`docxtpl` / `python-pptx` / `openpyxl`): you install the library once, and the
+skill detects it and stops with the exact `pip install` line if it's absent.
 
 ---
 

--- a/packs/converters/pack.toml
+++ b/packs/converters/pack.toml
@@ -1,12 +1,12 @@
 [pack]
 name = "converters"
-version = "0.1.2"
-description = "File-format conversion skills: documents and images → Markdown; Markdown → styled HTML; Outlook .msg → Markdown."
+version = "0.2.0"
+description = "File-format conversion skills: documents and images → Markdown; Markdown → styled HTML and to branded Word, PowerPoint, and Excel; Outlook .msg → Markdown."
 readme = "README.md"
 display_name = "Converters"
 license = "Apache-2.0 OR MIT"
 categories = ["file-conversion", "documentation"]
-keywords = ["markdown", "html", "msg", "pdf"]
+keywords = ["markdown", "html", "msg", "pdf", "office"]
 
 [pack.adapter-contract]
 version = "0.8"


### PR DESCRIPTION
## What does this change?

Adds three Tier-1 skills to the `converters` pack — `markdown-to-docx`, `markdown-to-pptx`, `markdown-to-xlsx` — that publish a Markdown artifact back out as a distribution-ready, on-brand Office file by **filling a user-provided template** at its existing fill-points (never converting). Completes the pack's Office round-trip, which until now ran only inward (Office → Markdown).

## Why?

- Implements: `docs/specs/markdown-to-office-publishing/spec.md` (Shipped, 20/20 ACs)
- Follows from: RFC-0036 (Accepted)

Each skill detects a template, confirms or elicits one, and renders unbranded via the library default only on the user's explicit opt-out — it never invents a brand and never auto-installs its render library (`--check` exits `0`/`2` and stops). docx renders with `autoescape=True`; all three confine the output write under the working directory (path-component check, not string-prefix). Template trust posture is trusted-author (SSTI/XXE/zip-bomb scoped as accepted out-of-scope).

## How do I verify it?

```bash
# render libs (dev): pip install 'python-pptx>=1.0.0' 'docxtpl>=0.16.0' 'openpyxl>=3.1.0' python-docx
for s in markdown-to-pptx markdown-to-docx markdown-to-xlsx; do
  (cd packs/converters/.apm/skills/$s/scripts && python -m pytest -q); done   # 39 tests
make lint-packs && python3 tools/lint-skill-spec.py && python3 tools/lint-agent-artifacts.py
```

CI wires the three suites per-path (deps pinned to exact known-good versions). The end-to-end test per format subprocesses `render.py` as documented and re-opens the produced `.docx`/`.pptx`/`.xlsx` to assert the filled values are present (the work-loop "exercise the real artifact" rule).

## What did you not change that you considered?

- **No shared "office engine" module** — v1 ships three independent script sets (spec Ask-first boundary; the `confine`/parser duplication is sanctioned). A fourth format is the trigger to revisit.
- **No convert-from-Markdown (Pandoc/Quarto) primary path** — template-fill only; the opt-out library-default render is a distinct, user-elected unbranded escape hatch (AC + RFC-0036 §90).
- **`[pack.adapter-contract]` stays `0.8`** — no primitive shape changed; pack version bumped `0.1.2 → 0.2.0`.

## Governance

- **RFC-0036 § Errata E1** (Approver-signed): openpyxl 3.1.x *preserves* parseable charts on resave; filling ranges requires a resave, so the spec Boundary/AC reword "never load-and-resave" → "never manipulate/resize chart/shape objects" (the realizable rule, which is what shipped). Decision unchanged.

## Bundled fixes

- None (scope held to the spec).

## Deferred

- `office-render-libs-pip-audit` (`docs/backlog.md`) — a CI `pip-audit` over the installed render-lib set; the libraries are user-runtime/CI-ephemeral and outside the repo's SCA today (accepted Tier-1 posture).