### PR TITLE
feat(core): per-prompt work-loop activation hook for Kiro IDE + Claude Code (core 0.4.10)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -75,7 +75,7 @@
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",
       "category": "governance",
-      "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr + session-start hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds.",
+      "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds.",
       "displayName": "Core",
       "homepage": "https://github.com/eugenelim/agent-ready-repo",
       "keywords": [
@@ -87,7 +87,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "core",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.4.9"
+      "version": "0.4.10"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -9,6 +9,16 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "command": "python tools/hooks/work-loop-check.py",
+            "type": "command"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -246,6 +246,21 @@ jobs:
           tests/unit/test_enriched_pack_metadata.py
           tests/integration/test_list_packs_cmd.py
 
+      # core work-loop activation hook (work-loop-activation-hook spec): the
+      # kiro-ide-hook validate rail + real-pack projection + hook-body invocation
+      # gate only here — make build-check / lint-packs / the make validate target
+      # never run the rail against core, and CI does not auto-discover pytest.
+      # The two drop-warning modules pin core's hook-wiring → kiro drop contract,
+      # which this spec changed (work-loop-check.toml joins session-start.toml as
+      # a dropped-for-kiro wiring); they were CI-ungated, so wire them too.
+      - name: pytest core work-loop activation hook + kiro drop-warning contract
+        working-directory: packages/agentbundle
+        run: >-
+          python -m pytest
+          tests/unit/test_core_work_loop_hook.py
+          tests/unit/test_install_event_dropped_wirings.py
+          tests/unit/test_validate_hook_wiring_per_file_compatibility.py
+
       - name: converters source-attribution scrub (AC2)
         run: |
           # rg exits 0 with hits, 1 with no matches, ≥2 on error

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -19,6 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Per-prompt work-loop activation hook (`core` pack).** A new
+  `work-loop-check` hook nudges the agent, on every prompt, to load the
+  work-loop skill for non-trivial work — closing a gap where the loop was
+  not reliably activated. It ships as a matched pair so it reaches both
+  surfaces: a `UserPromptSubmit` hook-wiring + hook body for Claude Code
+  (and Copilot / Cursor / Gemini / Codex), and a standalone `promptSubmit`
+  `askAgent` `.kiro.hook` for Kiro IDE, which reads only `.kiro/hooks/`
+  files and ignores hook-wiring. (`agentbundle validate core`'s info line
+  now lists both core hook-wirings as not projecting to the Kiro CLI
+  adapter — `session-start.toml` and `work-loop-check.toml` — since neither
+  declares `attach-to-agent`; this is informational, not a refusal.)
 - **Markdown → Office publishing skills (`converters` pack, RFC-0036).** Three new
   skills publish a Markdown artifact back out as a distribution-ready, on-brand
   Office file by **filling a user-provided template** at its existing fill-points —

--- a/docs/specs/work-loop-activation-hook/plan.md
+++ b/docs/specs/work-loop-activation-hook/plan.md
@@ -1,0 +1,193 @@
+# Plan: work-loop activation hook
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Done
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn.
+
+## Approach
+
+Pure pack content in `core`, no contract or adapter-code change. Three new source
+files form the matched pair: a hook body (`work-loop-check.py`) and a
+`UserPromptSubmit` `hook-wiring` (`work-loop-check.toml`) for the
+hook-wiring-consuming adapters (Claude Code, Copilot, Cursor, Gemini, Codex), and
+a standalone `kiro-ide-hook` (`work-loop-check.kiro.hook`, `promptSubmit` +
+`askAgent`) for Kiro IDE — which drops hook-wiring and reads only `.kiro.hook`
+files. The hook-wiring file is a structural clone of the proven `session-start.toml`
+(differing only in event + command), which de-risks the cross-adapter projection.
+The riskiest part is the kiro-ide-hook being the catalogue's *first*, so its
+verification leans on (a) the `check_kiro_ide_hook` validate rail, already wired
+into `build-check`, and (b) a focused projection test against the real `core`
+pack. Finish with the version bump, changelog, README/description sync, and
+`make build-self` to regenerate the committed `.codex/hooks.json` and
+`tools/hooks/` projections.
+
+## Constraints
+
+- RFC-0005 (hook-body / hook-wiring forks), RFC-0022 (kiro-ide-hook activation).
+- `session-start.toml` precedent: `core` hook-wiring carries no `attach-to-agent`
+  and is therefore out of scope for kiro/kiro-cli (the agent-JSON-merge adapters).
+- `SELF_HOST_ADAPTERS = ("claude-code", "codex")` — build-self does not emit
+  kiro-ide; the `.kiro.hook` is source + test verified only.
+- CONVENTIONS § version bump for non-cosmetic pack edits; changelog `[Unreleased]`.
+
+## Construction tests
+
+**Integration tests:** the kiro-ide-hook real-pack projection test (T3) spans the
+projector + the real `core` pack source; see its `Tests:`.
+**Manual verification:** none beyond the subprocess assertion in T3 (the body's
+real invocation is gated by a test, not left to manual QA).
+
+## Design (LLD)
+
+### Design decisions
+
+- **Two primitives, one intent.** The Claude side runs a `command` hook whose
+  stdout is injected as context; the Kiro IDE side fires `askAgent` with an inline
+  prompt. These are different mechanisms (Kiro IDE `runCommand` does *not* feed
+  the agent), so the reminder text is duplicated by necessity rather than shared
+  via a placeholder. Traces to: AC1–AC3.
+- **Static reminder, no classification.** The body emits a fixed nudge; deciding
+  triviality is the agent's job per the skill's "When this skill applies". Keeps
+  the body input-free and off every security boundary. Traces to: AC1.
+- **Event = `UserPromptSubmit` / `promptSubmit`** (per-prompt), the strongest
+  "always activated" guarantee, chosen over `SessionStart`. Traces to: AC2, AC3.
+
+### Interfaces & contracts
+
+- `hook-wiring` primitive → `.apm/hook-wiring/` (adapter.toml:95). `kiro-ide-hook`
+  primitive → `.apm/kiro-ide-hooks/` (adapter.toml:103). No contract file is
+  edited; both are shipped primitives. Traces to: AC2, AC3.
+
+## Tasks
+
+### T1: hook body emits a work-loop reminder
+
+**Depends on:** none
+
+**Tests:**
+- `python packs/core/.apm/hooks/work-loop-check.py` prints a non-empty reminder
+  mentioning the work-loop skill and exits 0 (manual QA — real invocation, AC1).
+- The script imports only stdlib and reads no stdin/env/files (inspection).
+
+**Approach:**
+- Write `packs/core/.apm/hooks/work-loop-check.py`: a `main()` that prints a
+  concise (2–4 line) reminder to stdout and returns 0. Pure stdlib; no args.
+- Header docstring notes the companion `.kiro.hook` carries the parallel prompt.
+
+**Done when:** running the script prints the reminder and exits 0; stdout
+recorded.
+
+### T2: hook-wiring binds the body to UserPromptSubmit
+
+**Depends on:** T1
+
+**Tests:**
+- After `make build-self`, `.codex/hooks.json` has a `UserPromptSubmit` entry
+  whose command is `python tools/hooks/work-loop-check.py`, alongside the
+  existing `SessionStart` (goal-based, AC6).
+- `make validate` / `lint-packs` green (AC4).
+
+**Approach:**
+- Write `packs/core/.apm/hook-wiring/work-loop-check.toml` as a structural clone
+  of `session-start.toml`: `[[hooks.UserPromptSubmit]]` with one
+  `{ type = "command", command = "python tools/hooks/work-loop-check.py" }`. No
+  `attach-to-agent`, no `id`. Update the header comment for the new event/command.
+
+**Done when:** lint/validate pass and the wiring is present in source.
+
+### T3: kiro-ide-hook for Kiro IDE + the focused CI-wired test
+
+**Depends on:** T1, T2 (the test exercises the body and references the wiring)
+
+**Tests:** (one new module, e.g. `packages/agentbundle/tests/unit/test_core_work_loop_hook.py`)
+- `check_kiro_ide_hook(packs/core, …)` returns `None` (AC3/AC4 schema floor).
+  Note: the rail IS reachable via the per-pack `agentbundle validate <pack>` CLI
+  (`commands/validate.py:268`), but `make build-check` / `lint-packs` / the `make
+  validate` target never run it against `core` — so this CI-wired test is the only
+  thing that gates the rail here.
+- Invoke `kiro_ide_hook.project()` with the **real on-disk contract values**:
+  read `target.repo` from `docs/contracts/adapter.toml` via stdlib `tomllib`
+  (`adapter."kiro-ide".projections."kiro-ide-hook".target.repo`) and pass it as
+  the projector's `target_template`; do **not** retype the path or synthesise it
+  like `test_kiro_ide_hook_e2e.py` (that fixture uses the wrong `<pack>/<name>`
+  separator). Run against `packs/core`; assert output file
+  `.kiro/hooks/core--work-loop-check.kiro.hook` with `when.type == "promptSubmit"`,
+  `then.type == "askAgent"`, non-empty `then.prompt` (AC4b/AC5 path proof).
+- `subprocess.run([sys.executable, "packs/core/.apm/hooks/work-loop-check.py"])`
+  → returncode 0, non-empty stdout, stdout mentions `work-loop` (AC1).
+- Both the body stdout and the `.kiro.hook` `then.prompt` mention `work-loop`
+  (alignment floor).
+
+**Approach:**
+- Write `packs/core/.apm/kiro-ide-hooks/work-loop-check.kiro.hook`: JSON with
+  `name`, `description`, `version: "1"`, `when: {type: promptSubmit}`,
+  `then: {type: askAgent, prompt: <work-loop reminder>}`.
+- Write the test module above; resolve repo root via `Path(__file__).parents[N]`
+  as the sibling tests do.
+- **Wire it into CI:** add an explicit step to `.github/workflows/build-check.yml`
+  (`working-directory: packages/agentbundle`, `python -m pytest
+  tests/unit/test_core_work_loop_hook.py`) — CI does not auto-discover pytest.
+
+**Done when:** the focused module is green locally and a CI step invokes it.
+
+### T4: version bump, changelog, doc/description sync
+
+**Depends on:** T1, T2, T3
+
+**Tests:**
+- `pack.toml` and `plugin.json` versions match and are bumped from 0.4.9
+  (inspection, AC7).
+- `docs/product/changelog.md` has an `[Unreleased]` entry naming the hook (AC7).
+- The `core` description (pack.toml + plugin.json) and `tools/hooks/README.md`
+  name the new hook (AC8 doc-sync).
+
+**Approach:**
+- Bump `core` 0.4.9 → 0.4.10 in `pack.toml` and `.claude-plugin/plugin.json`.
+- Update the `core` description (pack.toml + plugin.json) hook enumeration
+  ("pre-pr + session-start hooks" → include the work-loop nudge).
+- Add a `### work-loop-check.py` subsection to `tools/hooks/README.md` and fix
+  its "Two … hooks" count → three. Check `packs/core/README.md`'s hook prose and
+  sync only if it enumerates hooks.
+- Add the changelog `[Unreleased]` entry.
+
+**Done when:** versions/changelog/docs reflect the new hook.
+
+### T5: build-self + verify clean tree
+
+**Depends on:** T1, T2, T3, T4
+
+**Tests:**
+- `make build-self` succeeds; `git status` shows only intended files
+  (`tools/hooks/work-loop-check.py`, `.codex/hooks.json`,
+  `.claude-plugin/marketplace.json` reflecting core 0.4.10, plus the source +
+  docs + test + CI wiring); no stray `__pycache__` or reverted projections
+  (AC6, AC8). `.claude/settings.local.json` is gitignored and won't appear.
+- `make build-check` green (AC8).
+
+**Approach:**
+- Run `make build-self`; inspect diff; confirm marketplace.json regenerated to
+  0.4.10; clear any `__pycache__`; confirm against a clean expectation.
+
+**Done when:** `build-check` green and `git status` clean of unintended changes.
+
+## Rollout
+
+Pure content addition; reversible by removing the three source files and the
+version bump. No infra, no migration, no external system. Ships to adopters on
+the next `core` pack release; lands in this repo's tree via `build-self` (Claude
++ Codex surfaces) at merge.
+
+## Risks
+
+- **Per-prompt noise.** The nudge fires every turn, including on trivial prompts.
+  Mitigated by keeping it to 2–4 lines. Accepted per the product decision.
+- **First kiro-ide-hook in the catalogue.** Mitigated by the validate rail
+  (already in build-check) + the focused projection test.
+- **New test not CI-wired** (memory: package tests gate only by explicit
+  per-path wiring). Mitigated by extending an already-wired test module.
+
+## Changelog
+
+- 2026-06-19: initial plan.

--- a/docs/specs/work-loop-activation-hook/spec.md
+++ b/docs/specs/work-loop-activation-hook/spec.md
@@ -1,0 +1,151 @@
+# Spec: work-loop activation hook
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** RFC-0005 (hook-body / hook-wiring), RFC-0022 (kiro-ide-hook)
+- **Brief:** none
+- **Contract:** none (uses shipped `hook-wiring` + `kiro-ide-hook` primitives; no contract change)
+- **Shape:** integration
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+An agent working in a repo that installed the `core` pack is reliably reminded,
+on every prompt, to use the `work-loop` skill for non-trivial work — in **both
+Claude Code and Kiro IDE**. Today the only lifecycle hook (`session-start`) never
+mentions work-loop, and the hook surfaces diverge by tool: Claude Code (and
+Copilot/Cursor/Gemini/Codex) consume `hook-wiring`, while **Kiro IDE drops
+`hook-wiring` entirely** and reads only standalone `.kiro/hooks/*.kiro.hook`
+files — of which the catalogue ships none. So any Claude-side nudge can never
+reach Kiro IDE. Success: a matched pair of hook artifacts in `core` that emit the
+same "consider work-loop for non-trivial work" nudge on each surface's
+per-prompt event, so neither tool silently skips the loop.
+
+## Boundaries
+
+### Always do
+
+- Mirror the existing `session-start` hook's shape for the `hook-wiring` side
+  (no `attach-to-agent`, no `id`); change only the event (`UserPromptSubmit`)
+  and the command. This is the proven-safe shape across every adapter `core`
+  targets.
+- Keep the Claude-side message (hook-body stdout) and the Kiro-IDE-side message
+  (`then.prompt` of the `.kiro.hook`) semantically aligned — same instruction,
+  adapted to each mechanism.
+- Keep the hook body input-free: it prints a static reminder and reads no
+  stdin, env, files, or network (so it crosses no security boundary).
+- Bump the `core` pack version (`pack.toml` + `.claude-plugin/plugin.json`) and
+  add a `docs/product/changelog.md` `[Unreleased]` entry.
+- Run `make build-self` and verify the projected artifacts + a clean `git
+  status` (only the intended files changed).
+
+### Ask first
+
+- Extending the `hook-wiring` to the Kiro **CLI** (`kiro`/`kiro-cli`) targets.
+  That requires an `attach-to-agent` field the `session-start` precedent
+  deliberately omits ("Kiro is out of scope here"); Kiro IDE — the requested
+  target — is already covered by the `kiro-ide-hook`. Out of scope here.
+- Changing the per-prompt cadence to per-session, or making the nudge
+  configurable.
+
+### Never do
+
+- Edit the adapter contract (`docs/contracts/adapter.toml`) or any adapter's
+  projection code. This feature is pure pack content over shipped primitives.
+- Touch the existing `session-start` hook (body or wiring).
+- Have the hook body parse untrusted input or attempt to *classify* prompt
+  triviality — a hook can't do that reliably; the skill's own "When this skill
+  applies" governs the judgment.
+
+## Testing Strategy
+
+The catalogue's standard gates do **not** cover this work for free:
+`make validate` validates only the adapter contract schema, `lint-packs` checks
+only skill/agent metadata, and CI does not auto-discover pytest — every test path
+is hand-wired in `.github/workflows/build-check.yml`. So the `check_kiro_ide_hook`
+rail and the projection only gate if a test invokes them and that test is wired
+into CI explicitly. One focused pytest module, added to `build-check.yml` with an
+explicit step, is therefore the real gate; it covers:
+
+- **Schema correctness of the `.kiro.hook`** (required fields; `when.type` ∈
+  `ide-event-vocabulary`; `then.type` ∈ `ide-action-vocabulary`): goal-based —
+  the test calls `check_kiro_ide_hook(packs/core, …)` and asserts it returns
+  `None`.
+- **Kiro IDE end-to-end projection from the real `core` pack**: goal-based,
+  integration surface — the test invokes the shipped `kiro_ide_hook.project()`
+  with the **real on-disk contract values** against `packs/core` and asserts the
+  output path `.kiro/hooks/core--work-loop-check.kiro.hook` and the
+  `promptSubmit` / `askAgent` / non-empty `then.prompt` shape. This is the
+  primary proof of the Kiro IDE path, since `build-self` (adapters `claude-code`
+  + `codex` only) does not emit kiro-ide.
+- **Hook body real invocation**: goal-based — the test runs `python
+  packs/core/.apm/hooks/work-loop-check.py` via subprocess and asserts exit 0,
+  non-empty stdout, and that the output mentions `work-loop`.
+- **Message alignment**: goal-based — the test asserts both the body stdout and
+  the `.kiro.hook` `then.prompt` mention `work-loop` (the only enforceable floor
+  for the "keep semantically aligned" boundary).
+- **Claude Code / Codex projection of the `hook-wiring`**: goal-based,
+  exercised by running `make build-self` and asserting the `UserPromptSubmit`
+  entry lands in `.codex/hooks.json` and `tools/hooks/work-loop-check.py` is
+  projected.
+
+## Acceptance Criteria
+
+- [x] `packs/core/.apm/hooks/work-loop-check.py` exists, is pure-stdlib Python,
+  prints a work-loop reminder of **≤ 6 lines** to stdout, reads no input
+  (stdin/env/files/network), and exits 0.
+- [x] `packs/core/.apm/hook-wiring/work-loop-check.toml` wires that body to the
+  `UserPromptSubmit` event, structurally mirroring `session-start.toml` (no
+  `attach-to-agent`, no `id`).
+- [x] `packs/core/.apm/kiro-ide-hooks/work-loop-check.kiro.hook` is a valid
+  kiro-ide-hook: `when.type` = `promptSubmit`, `then.type` = `askAgent`, with a
+  `then.prompt` carrying the work-loop reminder.
+- [x] A focused pytest module asserts: (a) `check_kiro_ide_hook(packs/core, …)`
+  returns `None`; (b) the shipped projector produces
+  `.kiro/hooks/core--work-loop-check.kiro.hook` with the `promptSubmit` /
+  `askAgent` / non-empty `then.prompt` shape; (c) the hook body run via
+  subprocess exits 0 with non-empty stdout; (d) both the body stdout and the
+  `.kiro.hook` `then.prompt` mention `work-loop`. The module is wired into
+  `.github/workflows/build-check.yml` as an explicit pytest step.
+- [x] After `make build-self`, `.codex/hooks.json` contains the
+  `UserPromptSubmit` wiring alongside the existing `SessionStart`, and
+  `tools/hooks/work-loop-check.py` is present; `git status` shows only intended
+  changes.
+- [x] `core` pack version is bumped in both `pack.toml` and
+  `.claude-plugin/plugin.json`; `.claude-plugin/marketplace.json` reflects the
+  bumped `core` version after `make build-self`; `docs/product/changelog.md` has
+  an `[Unreleased]` entry naming the hook.
+- [x] Hook enumerations that would otherwise go stale are synced in the same PR:
+  the `core` description (`pack.toml` + `plugin.json`) and `tools/hooks/README.md`
+  name the new hook.
+- [x] The CI-ungated fixtures that pin core's hook-wiring → kiro drop-warning
+  contract (`test_install_event_dropped_wirings.py`,
+  `test_validate_hook_wiring_per_file_compatibility.py`) are updated for the new
+  `work-loop-check.toml` entry and wired into `build-check.yml`. (The adopter-
+  visible `agentbundle validate core` info line now lists two dropped wirings;
+  noted in the changelog.)
+- [x] `make build-check` is green.
+
+## Assumptions
+
+- Technical: Kiro IDE loads `.kiro/hooks/**/*.kiro.hook` natively, and
+  `kiro-ide` drops `hook-wiring`, so the IDE requires a `kiro-ide-hook` (source:
+  probe — adapter.toml:330-364, ground-truth from extension.js, 2026-06-19).
+- Technical: `UserPromptSubmit` is mapped by every adapter `core` targets —
+  copilot (`userPromptSubmitted`), cursor (`beforeSubmitPrompt`), gemini
+  (`BeforeAgent`), codex (verbatim merge-json) (source: probe —
+  copilot_hooks_json.py, adapter.toml:602/689, 2026-06-19).
+- Technical: `build-self` projects only `claude-code` + `codex`
+  (`SELF_HOST_ADAPTERS`), so the kiro-ide-hook is source-only in this repo and
+  proven by tests, not by a committed `.kiro/` artifact (source: probe —
+  self_host.py:85, 2026-06-19).
+- Technical: a `hook-wiring` without `attach-to-agent` is silently skipped for
+  kiro/kiro-cli projection, and the validate rail only refuses it when
+  kiro/kiro-cli is a target adapter — which `core` is not (source: probe —
+  kiro.py:340-341, scope_rails.py:309-355, session-start.toml comment,
+  2026-06-19).
+- Product: per-prompt cadence, ships to adopters via `core` (source: user
+  confirmation 2026-06-19).

--- a/packages/agentbundle/tests/unit/test_core_work_loop_hook.py
+++ b/packages/agentbundle/tests/unit/test_core_work_loop_hook.py
@@ -1,0 +1,111 @@
+"""Gate for the core pack's work-loop activation hook (matched pair).
+
+The `core` pack ships a per-prompt "use the work-loop skill" nudge as two
+artifacts: a `hook-wiring` (`UserPromptSubmit`) + hook body for the
+hook-wiring-consuming adapters, and a standalone `kiro-ide-hook`
+(`promptSubmit` + `askAgent`) for Kiro IDE.
+
+This module is the *only* thing that gates the kiro-ide-hook rail and the
+real-pack projection in CI: `make build-check` / `lint-packs` / the `make
+validate` target never run `check_kiro_ide_hook` against `core` (the rail is
+reachable only via the per-pack `agentbundle validate <pack>` CLI), and CI
+does not auto-discover pytest. The module is wired explicitly in
+`.github/workflows/build-check.yml`.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tomllib
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CORE_PACK = REPO_ROOT / "packs" / "core"
+CONTRACT = REPO_ROOT / "docs" / "contracts" / "adapter.toml"
+KIRO_HOOK = CORE_PACK / ".apm" / "kiro-ide-hooks" / "work-loop-check.kiro.hook"
+HOOK_BODY = CORE_PACK / ".apm" / "hooks" / "work-loop-check.py"
+
+
+def _kiro_ide_hook_contract() -> dict:
+    """The real on-disk kiro-ide-hook projection rule — sourced, not retyped,
+    so the `<pack>--<name>` separator is the contract's, not the test's."""
+    contract = tomllib.loads(CONTRACT.read_text(encoding="utf-8"))
+    return contract["adapter"]["kiro-ide"]["projections"]["kiro-ide-hook"]
+
+
+class TestCoreWorkLoopHook(unittest.TestCase):
+    def test_kiro_ide_hook_passes_validate_rail(self) -> None:
+        """check_kiro_ide_hook returns None for core against the real vocab."""
+        from agentbundle.build.scope_rails import check_kiro_ide_hook
+
+        rule = _kiro_ide_hook_contract()
+        refusal = check_kiro_ide_hook(
+            CORE_PACK,
+            "core",
+            target_adapters=("kiro-ide",),
+            ide_event_vocabulary=rule["ide-event-vocabulary"],
+            ide_action_vocabulary=rule["ide-action-vocabulary"],
+        )
+        self.assertIsNone(refusal, msg=refusal)
+
+    def test_kiro_ide_hook_projects_to_real_contract_path(self) -> None:
+        """The shipped projector emits the flat `core--<name>` path with the
+        promptSubmit / askAgent shape — using the contract's own template."""
+        from agentbundle.build.projections.kiro_ide_hook import project
+
+        target_template = _kiro_ide_hook_contract()["target"]["repo"]
+        with TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            project(
+                CORE_PACK,
+                out,
+                target_template=target_template,
+                hook_body_target_dir="tools/hooks",
+            )
+            projected = out / ".kiro" / "hooks" / "core--work-loop-check.kiro.hook"
+            self.assertTrue(projected.is_file(), f"missing {projected}")
+            body = json.loads(projected.read_text(encoding="utf-8"))
+
+        self.assertEqual(body["when"]["type"], "promptSubmit")
+        self.assertEqual(body["then"]["type"], "askAgent")
+        self.assertTrue(body["then"].get("prompt", "").strip(), "empty then.prompt")
+
+    def test_hook_body_runs_clean(self) -> None:
+        """The body invokes as documented: exit 0, non-empty stdout, mentions
+        work-loop, and is at most 6 lines (the spec's concision bar)."""
+        result = subprocess.run(
+            [sys.executable, str(HOOK_BODY)],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        stdout = result.stdout.strip()
+        self.assertTrue(stdout, "empty stdout")
+        self.assertIn("work-loop", stdout.lower())
+        # spec work-loop-activation-hook AC1: the reminder is bounded at 6 lines.
+        # A failure here means the REMINDER grew past that cap — trim it, don't
+        # bump the bound (the nudge fires on every prompt).
+        self.assertLessEqual(len(stdout.splitlines()), 6)
+
+    def test_both_messages_carry_the_same_instruction(self) -> None:
+        """The two reminders (hook-body stdout + .kiro.hook prompt) carry the
+        same core instruction. Asserting the shared loop phrase — not just the
+        `work-loop` header — is the enforceable floor against the two literals
+        drifting apart (they live in separate files by mechanism necessity)."""
+        prompt = json.loads(KIRO_HOOK.read_text(encoding="utf-8"))["then"]["prompt"]
+        stdout = subprocess.run(
+            [sys.executable, str(HOOK_BODY)],
+            capture_output=True,
+            text=True,
+        ).stdout
+        for text in (prompt, stdout):
+            self.assertIn("work-loop", text.lower())
+            self.assertIn("plan -> execute -> verify -> review", text.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/agentbundle/tests/unit/test_install_event_dropped_wirings.py
+++ b/packages/agentbundle/tests/unit/test_install_event_dropped_wirings.py
@@ -66,9 +66,10 @@ class TestEnumerateEventDroppedWirings(unittest.TestCase):
         self._tmp.cleanup()
 
     def test_enumerate_event_drops_core_against_kiro(self) -> None:
-        """core against kiro: session-start.toml uses SessionStart (not in
-        kiro's agent-event-vocabulary) AND lacks attach-to-agent, so two
-        entries fire.
+        """core against kiro: both core hook-wirings (session-start.toml and
+        work-loop-check.toml) use a PascalCase event outside kiro's
+        agent-event-vocabulary AND lack attach-to-agent, so two entries fire
+        per file — four in all.
 
         Deviation from plan test #1: the plan's prescribed assertion
         expected only the vocab entry, but packs/core/.apm/hook-wiring/
@@ -76,6 +77,8 @@ class TestEnumerateEventDroppedWirings(unittest.TestCase):
         that file says "No attach-to-agent: that's a Kiro-only field").
         The T3 Approach code fires both step 2a (vocab) and step 2b
         (attach-to-agent) independently; the correct result is two entries.
+        work-loop-check.toml (work-loop-activation-hook spec) mirrors that
+        shape, adding the second pair.
         """
         result = enumerate_event_dropped_wirings(
             _packs_dir() / "core",
@@ -87,6 +90,8 @@ class TestEnumerateEventDroppedWirings(unittest.TestCase):
             [
                 ("hook-wiring/session-start.toml", "event not in adapter vocabulary"),
                 ("hook-wiring/session-start.toml", "kiro requires 'attach-to-agent'"),
+                ("hook-wiring/work-loop-check.toml", "event not in adapter vocabulary"),
+                ("hook-wiring/work-loop-check.toml", "kiro requires 'attach-to-agent'"),
             ],
         )
 

--- a/packages/agentbundle/tests/unit/test_validate_hook_wiring_per_file_compatibility.py
+++ b/packages/agentbundle/tests/unit/test_validate_hook_wiring_per_file_compatibility.py
@@ -119,12 +119,13 @@ def test_validate_packs_core_exits_zero(capsys):
     assert "validate:" not in captured.err, (
         f"Unexpected 'validate:' refusal on stderr: {captured.err!r}"
     )
-    # AC2: two-reason form because session-start.toml lacks attach-to-agent
-    # AND uses an out-of-vocab event.
+    # AC2: two-reason form because both core hook-wirings (session-start.toml
+    # and work-loop-check.toml) lack attach-to-agent AND use an out-of-vocab
+    # PascalCase event for kiro.
     expected_info = (
         "info: pack core: the following hook-wiring file(s) will not project to kiro "
         "(event not in adapter vocabulary + kiro requires 'attach-to-agent'): "
-        "hook-wiring/session-start.toml."
+        "hook-wiring/session-start.toml, and hook-wiring/work-loop-check.toml."
     )
     assert expected_info in captured.out, (
         f"Expected info line not found in stdout.\n"

--- a/packs/core/.apm/hook-wiring/work-loop-check.toml
+++ b/packs/core/.apm/hook-wiring/work-loop-check.toml
@@ -1,0 +1,22 @@
+# Wires the work-loop-check.py hook body to Claude Code's UserPromptSubmit
+# event, so the work-loop nudge fires on every prompt (the strongest
+# "always activated" guarantee). The merge-json adapter rule
+# (packages/agentbundle/agentbundle/build/adapters/claude_code.py) merges
+# this under the `hooks` key of `.claude/settings.local.json`; Copilot,
+# Cursor, Gemini, and Codex consume the same wiring and remap the
+# PascalCase `UserPromptSubmit` event via their contract hook-event maps
+# (userPromptSubmitted / beforeSubmitPrompt / BeforeAgent / verbatim).
+#
+# Kiro IDE is reached separately by the companion
+# `.apm/kiro-ide-hooks/work-loop-check.kiro.hook` — the kiro-ide adapter
+# drops hook-wiring entirely.
+#
+# Shape mirrors session-start.toml: outer entry has no `matcher`; inner
+# `hooks` array carries `type = "command"` and the command string. No
+# `id` (repo-scope merge-json does not consume it) and no
+# `attach-to-agent` (a Kiro CLI-only field; core does not target the
+# agent-JSON-merge Kiro adapters, exactly as session-start does not).
+[[hooks.UserPromptSubmit]]
+hooks = [
+  { type = "command", command = "python tools/hooks/work-loop-check.py" },
+]

--- a/packs/core/.apm/hooks/work-loop-check.py
+++ b/packs/core/.apm/hooks/work-loop-check.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""work-loop activation hook: prints a per-prompt reminder to use the
+work-loop skill for non-trivial work.
+
+Wired to the per-prompt event of each tool's hook surface — Claude Code
+`UserPromptSubmit` (and Copilot / Cursor / Gemini / Codex equivalents)
+via `.apm/hook-wiring/work-loop-check.toml`. The Kiro IDE counterpart is
+`.apm/kiro-ide-hooks/work-loop-check.kiro.hook` (an `askAgent` hook on
+`promptSubmit`), which carries the *same* instruction as a prompt because
+the IDE drops hook-wiring and `runCommand` does not feed the agent. Keep
+the two messages semantically aligned (both must mention `work-loop`).
+
+Pure-stdlib, input-free: prints a fixed reminder to stdout and exits 0.
+It deliberately does not parse the prompt or classify triviality — that
+judgment is the agent's, governed by the work-loop skill's own
+"When this skill applies". Reading no stdin/env/files keeps it off every
+security boundary.
+"""
+
+from __future__ import annotations
+
+import sys
+
+# Spec work-loop-activation-hook AC1: keep this reminder <= 6 lines (the
+# focused test asserts the bound; the companion .kiro.hook prompt mirrors it).
+REMINDER = """\
+=== work-loop ===
+Before non-trivial work (a feature, a multi-file fix, a refactor, a
+migration, anything beyond a one-line edit), load the work-loop skill
+and run plan -> execute -> verify -> review with mechanical gates.
+Pick the mode by risk: light by default, full when a risk trigger fires.
+Skip only for a genuine one-line edit."""
+
+
+def main() -> int:
+    print(REMINDER)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packs/core/.apm/kiro-ide-hooks/work-loop-check.kiro.hook
+++ b/packs/core/.apm/kiro-ide-hooks/work-loop-check.kiro.hook
@@ -1,0 +1,12 @@
+{
+  "name": "work-loop activation",
+  "description": "On every prompt, remind the agent to use the work-loop skill for non-trivial work.",
+  "version": "1",
+  "when": {
+    "type": "promptSubmit"
+  },
+  "then": {
+    "type": "askAgent",
+    "prompt": "Before non-trivial work (a feature, a multi-file fix, a refactor, a migration, anything beyond a one-line edit), load the work-loop skill and run plan -> execute -> verify -> review with mechanical gates. Pick the mode by risk: light by default, full when a risk trigger fires. Skip only for a genuine one-line edit."
+  }
+}

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "0.4.9",
-  "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr + session-start hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
+  "version": "0.4.10",
+  "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 }

--- a/packs/core/README.md
+++ b/packs/core/README.md
@@ -3,7 +3,8 @@
 The core pack ships the agent-ready-repo skills (work-loop, new-spec,
 new-rfc, …), the four specialist subagents (adversarial-reviewer,
 security-reviewer, quality-engineer, implementer), the canonical
-session-start hook, and the `/adapt-to-project` command.
+session-start and work-loop-check hooks, and the `/adapt-to-project`
+command.
 
 ## Install routes and adaptation
 

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,7 +1,7 @@
 [pack]
 name = "core"
-version = "0.4.9"
-description = "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr + session-start hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
+version = "0.4.10"
+description = "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 readme = "README.md"
 display_name = "Core"
 license = "Apache-2.0 OR MIT"

--- a/tools/hooks/README.md
+++ b/tools/hooks/README.md
@@ -1,6 +1,6 @@
 # Lifecycle hooks
 
-Two agent-lifecycle hooks ship in this directory. Runtime: `python` ≥
+Three agent-lifecycle hooks ship in this directory. Runtime: `python` ≥
 3.11 (the hooks parse TOML via stdlib `tomllib`); no other
 dependencies. The hooks are stdlib-only and run on native Windows,
 macOS, and Linux — invoke via `python` (not `python3`) so the same
@@ -39,6 +39,23 @@ value exits 2 with `--scope requires a path or glob value`.
 
 See [`docs/knowledge/README.md`](../../docs/knowledge/README.md) for
 the schema and curation conventions.
+
+### `work-loop-check.py` (shipped, adopter-facing)
+
+Runs on every prompt. Prints a short `=== work-loop ===` reminder to
+stdout so the agent is nudged to load the work-loop skill for
+non-trivial work (anything beyond a one-line edit) rather than "just
+going". Input-free and stdlib-only; always exits 0. Wired to Claude
+Code's `UserPromptSubmit` (and the Copilot / Cursor / Gemini / Codex
+equivalents); Kiro IDE gets the same nudge via the companion
+`promptSubmit` `.kiro.hook`. Deciding what counts as non-trivial is the
+agent's call — the hook only reminds.
+
+Usage:
+
+```bash
+python tools/hooks/work-loop-check.py
+```
 
 ### `pre-pr.py` (shipped, adopter-facing)
 

--- a/tools/hooks/work-loop-check.py
+++ b/tools/hooks/work-loop-check.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""work-loop activation hook: prints a per-prompt reminder to use the
+work-loop skill for non-trivial work.
+
+Wired to the per-prompt event of each tool's hook surface — Claude Code
+`UserPromptSubmit` (and Copilot / Cursor / Gemini / Codex equivalents)
+via `.apm/hook-wiring/work-loop-check.toml`. The Kiro IDE counterpart is
+`.apm/kiro-ide-hooks/work-loop-check.kiro.hook` (an `askAgent` hook on
+`promptSubmit`), which carries the *same* instruction as a prompt because
+the IDE drops hook-wiring and `runCommand` does not feed the agent. Keep
+the two messages semantically aligned (both must mention `work-loop`).
+
+Pure-stdlib, input-free: prints a fixed reminder to stdout and exits 0.
+It deliberately does not parse the prompt or classify triviality — that
+judgment is the agent's, governed by the work-loop skill's own
+"When this skill applies". Reading no stdin/env/files keeps it off every
+security boundary.
+"""
+
+from __future__ import annotations
+
+import sys
+
+# Spec work-loop-activation-hook AC1: keep this reminder <= 6 lines (the
+# focused test asserts the bound; the companion .kiro.hook prompt mirrors it).
+REMINDER = """\
+=== work-loop ===
+Before non-trivial work (a feature, a multi-file fix, a refactor, a
+migration, anything beyond a one-line edit), load the work-loop skill
+and run plan -> execute -> verify -> review with mechanical gates.
+Pick the mode by risk: light by default, full when a risk trigger fires.
+Skip only for a genuine one-line edit."""
+
+
+def main() -> int:
+    print(REMINDER)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What & why

The `core` pack's only lifecycle hook (`session-start`) never mentioned the **work-loop** skill, so the loop was not reliably activated. Worse, the hook surfaces diverge by tool: Claude Code (and Copilot/Cursor/Gemini/Codex) consume `hook-wiring`, while **Kiro IDE drops `hook-wiring` entirely** and reads only standalone `.kiro/hooks/*.kiro.hook` files — of which the catalogue shipped **none**. So any Claude-side nudge could never reach Kiro IDE. This was structural, not a bug.

## What this does

Adds a **per-prompt** "use the work-loop skill for non-trivial work" nudge to `core`, as a matched pair so it reaches both surfaces:

| Surface | Source | Reaches |
| --- | --- | --- |
| `hook-wiring` (`UserPromptSubmit`) + hook body | `.apm/hook-wiring/work-loop-check.toml`, `.apm/hooks/work-loop-check.py` | Claude Code, Copilot, Cursor, Gemini, Codex |
| `kiro-ide-hook` (`promptSubmit` + `askAgent`) | `.apm/kiro-ide-hooks/work-loop-check.kiro.hook` | **Kiro IDE** (the catalogue's first `kiro-ide-hook`) |

The wiring mirrors `session-start.toml`'s shape (no `attach-to-agent`), so it's dropped-for-kiro-CLI via the same info path; `UserPromptSubmit` maps for every adapter `core` targets. A hook can't *force* a skill in either tool — it injects context/prompt and the agent acts — so this is a reliable reminder, not a hard call.

Pure pack content over shipped primitives (RFC-0005 / RFC-0022): **no contract or adapter-code change.**

## Testing

- New focused, **CI-wired** pytest (`tests/unit/test_core_work_loop_hook.py`) gates the `check_kiro_ide_hook` rail + real-pack projection (sourcing the `<pack>--<name>` separator from the real contract) + body subprocess invocation + cross-surface message alignment — none of which `make build-check` covers otherwise.
- Two formerly **CI-ungated** drop-warning fixtures that hard-coded core's dropped-for-kiro wiring list are updated for the new wiring and **wired into `build-check.yml`**.
- `make build-check` exits 0; 34 pytest green; `build-self` tree clean; projected body byte-identical to source.

## Process

Run through full-mode work-loop (spec → two pre-EXECUTE adversarial passes → implement → post-EXECUTE adversarial + quality-engineer). The reviews caught 5 real Blockers (the `check_kiro_ide_hook` rail is wired into no standard gate; CI hand-wires every pytest path; marketplace.json drift; two stale fixtures) — all resolved. Spec: `docs/specs/work-loop-activation-hook/`.

## Judgment call to flag

The nudge fires **every prompt** (the requested cadence) — the strongest "always activated" guarantee, but a standing per-turn context cost across five adapters. If noisy in practice, switching to `SessionStart`/`sessionStart` is a one-line change per file.

## Bundled fixes

- Updated + CI-wired two pre-existing drop-warning test fixtures (`test_install_event_dropped_wirings.py`, `test_validate_hook_wiring_per_file_compatibility.py`) whose subject this change altered.

## Adopter-visible note

`agentbundle validate core`'s info line now lists both core hook-wirings as not projecting to the Kiro CLI adapter (informational, not a refusal) — noted in the changelog.