### PR TITLE
feat(core): extend work-loop context hygiene to output economy

### DIFF
--- a/.agents/skills/work-loop/SKILL.md
+++ b/.agents/skills/work-loop/SKILL.md
@@ -761,6 +761,12 @@ summarize-on-read, strip comments, or treat RAG chunks as the truth for an edit:
 read-compaction fails *silent*. Skeleton repo-maps are fine for orientation,
 never the bytes you edit against.
 
+**Emit less, too.** Your output becomes resident context next turn, so the
+levers above apply to what you *write*: don't restate code, files, diffs, or
+tool output already in the conversation — cite path and line — and skip
+narrating a tool call that succeeded. This is waste reduction, not terseness:
+keep the rationale, edge cases, and findings the reader needs.
+
 ## Unattended (AFK) loops
 
 The work-loop above is an *in-session* loop: one conversation, state in

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -87,7 +87,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "core",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.4.10"
+      "version": "0.4.11"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -761,6 +761,12 @@ summarize-on-read, strip comments, or treat RAG chunks as the truth for an edit:
 read-compaction fails *silent*. Skeleton repo-maps are fine for orientation,
 never the bytes you edit against.
 
+**Emit less, too.** Your output becomes resident context next turn, so the
+levers above apply to what you *write*: don't restate code, files, diffs, or
+tool output already in the conversation — cite path and line — and skip
+narrating a tool call that succeeded. This is waste reduction, not terseness:
+keep the rationale, edge cases, and findings the reader needs.
+
 ## Unattended (AFK) loops
 
 The work-loop above is an *in-session* loop: one conversation, state in

--- a/docs/guides/core/explanation/token-economy.md
+++ b/docs/guides/core/explanation/token-economy.md
@@ -37,6 +37,7 @@ These are the tokens that buy nothing, and the loop is built to avoid them:
 - **It budgets the always-resident files.** `AGENTS.md` is capped on purpose, because it is re-read every single session; detail lives in docs and skills that load only when relevant.
 - **It drops report text after recording it.** Once a reviewer's findings are captured, the verbatim report leaves resident context. The decision survives; the bulk does not.
 - **It doesn't restate what the runtime already does.** Every supported tool ships context-isolating sub-agents and already steers toward delegation. Re-teaching that in the pack would itself be resident-context cost for no gain.
+- **It doesn't re-emit what's already in context.** When the agent restates a diff, pastes back a file it just read, or narrates each tool result, it duplicates resident content — and because output becomes cached input, every duplicated line is re-read on every later turn at the ~190× multiplier above. This is not the prose-trimming rounding error from the table; the cost is the restated *context* riding inside the message. The loop's practice is to reference by path and line instead, while keeping the rationale and findings a reader actually needs.
 
 None of these trade away quality. They remove tokens that were doing no work.
 

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -69,6 +69,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The `work-loop` skill's Context hygiene section now covers output, not just
+  input (`core` pack, bumped to `0.4.11`).** A new *Emit less, too* note adds two
+  zero-cost habits to the existing window-management guidance: don't restate code,
+  files, diffs, or tool output already in the conversation — reference them by path
+  and line — and continue with the substance instead of narrating a tool call's
+  success. It is framed as waste reduction, not terseness for its own sake: the
+  rationale, edge cases, and findings prose that review and the human actually read
+  stay in.
 - **The `new-adr` skill and ADR template now follow MADR conventions
   (`governance-extras` pack, bumped to `0.2.0`).** The ADR template gains a
   `Rejected` status (a declined proposal is now kept as a record, not deleted)

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -761,6 +761,12 @@ summarize-on-read, strip comments, or treat RAG chunks as the truth for an edit:
 read-compaction fails *silent*. Skeleton repo-maps are fine for orientation,
 never the bytes you edit against.
 
+**Emit less, too.** Your output becomes resident context next turn, so the
+levers above apply to what you *write*: don't restate code, files, diffs, or
+tool output already in the conversation — cite path and line — and skip
+narrating a tool call that succeeded. This is waste reduction, not terseness:
+keep the rationale, edge cases, and findings the reader needs.
+
 ## Unattended (AFK) loops
 
 The work-loop above is an *in-session* loop: one conversation, state in

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "0.4.10"
+version = "0.4.11"
 description = "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 readme = "README.md"
 display_name = "Core"


### PR DESCRIPTION
## What

Extends the `work-loop` skill's **Context hygiene** section — which governed what the agent *loads* — to also cover what it *emits*, via a new **"Emit less, too"** note:

> Your output becomes resident context next turn, so the levers above apply to what you *write*: don't restate code, files, diffs, or tool output already in the conversation — cite path and line — and skip narrating a tool call that succeeded. This is waste reduction, not terseness: keep the rationale, edge cases, and findings the reader needs.

Companion update to `docs/guides/core/explanation/token-economy.md` adds a matching bullet to *What the loop refuses to waste*.

## Why

The agent's own output becomes cached input that is re-read on every later turn. Re-emitting content already in context (diffs, file dumps, tool-result narration) is therefore double-paid at the ~190× re-read multiplier the token-economy guide already establishes.

The scope is deliberately the quality-neutral habits only — *don't re-emit what's already present* — and stops short of dropping rationale or going telegraphic, which would trade quality for tokens. It's a default that holds regardless of usage, not usage-based tuning.

## Care taken

- **No contradiction with existing doctrine.** The guide already states that trimming agent prose is a rounding error (~6.5%). The new bullet explicitly says *this isn't that* — the cost is the restated **context** riding inside the message, tied to the 190× re-read lever, not prose length.
- Lands in an existing section (Context hygiene), not a new behavior.

## Files

- `packs/core/.apm/skills/work-loop/SKILL.md` (source) + `.claude/` and `.agents/` projections
- core version `0.4.10 → 0.4.11` (`pack.toml`, `plugin.json`, `marketplace.json`)
- `docs/product/changelog.md` — `[Unreleased] › Changed`
- `docs/guides/core/explanation/token-economy.md`

## Verification

- `make build-check` → exit 0 (drift, lint-packs, lint-spec-status, bandit, pip-audit, semgrep)
- `tools/lint-agent-artifacts.py` → passed