### PR TITLE
feat(pack-design-craft-evals): activation + LLM-judge eval coverage for design-craft

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -121,7 +121,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "design-craft",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -762,17 +762,20 @@ than a documented accepted-state.
 **Spec:** [pack-activation-evals](specs/pack-activation-evals/spec.md). Eval
 coverage today: **`core`** (5 skills, Tier-A activation), **`converters`**
 (6 skills, Tier-A activation **+** Tier-B-lite behavior, all 6 run for real),
-and **Tier-4 LLM-judge rubrics** for all of **`architect`** (3 skills) and
-**`product-engineering`** (5 skills) — `expected_output` + `assertions` per
+**Tier-4 LLM-judge rubrics** for all of **`architect`** (3 skills) and
+**`product-engineering`** (5 skills), and **`design-craft`** (4 skills,
+Tier-A activation **+** Tier-4 LLM-judge — both layers, no B-lite since the
+four skills are judgment/authoring) — `expected_output` + `assertions` per
 skill, gradable via `--mode judge`. Every other pack has **no eval coverage
 yet**. Remaining work, tiered by what it needs:
 
 - **Tier 1 — activation (Tier-A) for the rest of the catalogue (tractable now,
-  no deps/execution).** ~35 user-triggered skills across `architect` (3),
-  `contracts` (2), `design-craft` (4), `governance-extras` (3),
+  no deps/execution).** ~31 user-triggered skills across `architect` (3),
+  `contracts` (2), `governance-extras` (3),
   `monorepo-extras` (1), `product-engineering` (5), `research` (7),
   `user-guide-diataxis` (1) need `evals/eval_queries.json` + a `[pack.evals]`
-  block (the same ~8–10-each-way near-miss pattern as `core`). Exclude
+  block (the same ~8–10-each-way near-miss pattern as `core`). `design-craft`
+  (4) is **done** (this rollout). Exclude
   reviewer-internal / non-prompt skills (`security-checklists`, `work-loop`,
   `credential-setup`), as `core` does. This is the bulk of the gap.
 - **Tier 2 — B-lite behavior for other *deterministic* skills.** Assess
@@ -790,9 +793,9 @@ yet**. Remaining work, tiered by what it needs:
   remaining work here is **(a)** a per-skill **lens map** (point each skill at
   the right rubric / reviewer lens — e.g. `architect-review` for `architect-design`),
   authoring the `expected_output`/`assertions` rubrics — **done for all of
-  `architect` (3) and `product-engineering` (5)**; remaining for `research`,
-  `design-craft`, `governance-extras`, `new-guide`, `new-package`, and `core`'s
-  judgment skills — and **(b)** the **full
+  `architect` (3), `product-engineering` (5), and `design-craft` (4)**;
+  remaining for `research`, `governance-extras`, `new-guide`, `new-package`,
+  and `core`'s judgment skills — and **(b)** the **full
   Tier-B** pieces still deferred: `benchmark.json` **deltas**, the
   **with/without-skill** comparison, the **train/validation split**, and the
   formal **human-calibration** (`feedback.json`) loop. *(Note: `contracts` and

--- a/docs/specs/pack-activation-evals/notes/design-craft-evals-plan.md
+++ b/docs/specs/pack-activation-evals/notes/design-craft-evals-plan.md
@@ -1,0 +1,81 @@
+# Lean spec — design-craft eval coverage (pack-eval-coverage-rollout, Tier 1 + Tier 4)
+
+Mode: light (no risk trigger fired). Single logical task — extend the
+`pack-activation-evals` rollout to the `design-craft` pack, copying the
+byte-shape already shipped in `core`/`converters` (Tier-A activation) and
+`architect`/`product-engineering` (Tier-4 LLM-judge). Familiar pattern,
+single-person, no inter-task dependencies, no new module/layer/dependency,
+reversible. Recorded against the parent spec (Shipped/frozen) the way the
+architect/product-engineering rollout was — `notes/` + `manual-qa.md` +
+`docs/backlog.md`, no competing top-level spec.
+
+## Objective
+
+Give all four `design-craft` judgment/authoring skills the two eval layers
+that apply to judgment skills (no deterministic B-lite layer):
+
+- **Tier-A activation** — `evals/eval_queries.json` per skill (~8–10
+  should-trigger + ~8–10 near-miss should-NOT-trigger) + a `[pack.evals]`
+  block in `pack.toml`.
+- **Tier-4 LLM-judge** — `evals/evals.json` per skill (`expected_output`
+  + `assertions` matched to the skill's discipline).
+
+Skills: `aesthetic-direction`, `design-critique`, `design-system-foundations`,
+`layout-and-information-architecture`.
+
+## Acceptance criteria
+
+- [x] Each of the 4 skills ships `evals/eval_queries.json`: a flat JSON array
+      of `{query: non-empty str, should_trigger: bool}`, ~8–10 each way (10/10
+      per skill), the negatives near-misses (share design vocabulary/concepts
+      but route to a different design-craft skill — or to a `build`/copy/architect
+      concern — not trivially-irrelevant prompts). Validates under `lint-skill-spec.py`.
+- [x] `pack.toml` carries `[pack.evals]` with `skills = [<all four>]`.
+- [x] Each of the 4 skills ships `evals/evals.json`: `{skill_name (==dir),
+      evals: [{id, prompt, expected_output, assertions:[…]}]}`, no `expect`/
+      `files` (judgment skills, no B-lite). Assertions trace to each skill's
+      procedure + anti-patterns. Validates under `lint-skill-spec.py`.
+- [x] `design-critique` rubric spot-checked live via `run-pack-evals.py --pack
+      design-craft --mode judge --judge-adapter codex` and seen to discriminate:
+      a rubric-complete critique **PASS** / a vague "bigger buttons, nicer blue"
+      polish note **FAIL** (and gradient near-miss FAILs en route confirmed the
+      rubric grades strictly per assertion).
+- [x] `lint-skill-spec.py` passes (and the design-craft agnosticism lint).
+- [x] `design-craft` bumped `0.1.0 → 0.1.1` in `pack.toml` and
+      `.claude-plugin/plugin.json`; `make build-self` refreshes
+      `marketplace.json` to `0.1.1` (verified: the `self` subcommand
+      regenerates the marketplace aggregation).
+- [x] `pack-eval-coverage-rollout` backlog entry + `manual-qa.md` updated to
+      record design-craft coverage.
+
+## Task list
+
+1. Author 4 × `eval_queries.json` (activation).
+2. Author 4 × `evals.json` (judge rubrics).
+3. `[pack.evals]` block + version bump (pack.toml, plugin.json).
+4. `make build-self` → marketplace.json.
+5. Live judge spot-check (good vs weak).
+6. `lint-skill-spec.py` + the design-craft agnosticism lint + gates.
+7. Update backlog + manual-qa.md.
+
+## Boundaries
+
+- **Never** print stack tokens or values (hex, px/rem, ARIA roles, framework
+  names) anywhere — the rubrics *grade for* agnosticism; queries/rubrics stay
+  portable method. (The `*.md` agnosticism lint does not scan JSON, but the
+  discipline is the pack's whole point.)
+- **Never** add a B-lite `expect`/`files` block — these are judgment skills.
+- **Touch only** the design-craft pack's `evals/`, its `pack.toml`/`plugin.json`
+  version + `[pack.evals]`, `marketplace.json` (via build-self), the backlog
+  entry, and `manual-qa.md`. No runner/lint code changes.
+
+## Declined temptations
+
+- Tempted to add `expect`/`files` deterministic blocks; declining — the four
+  skills produce judgment artifacts (docs/critiques), not deterministic files.
+- Tempted to wire a design-craft line into the converters `evals.json`
+  carry-over CI gate; declining — that gate is converters-specific (backlog
+  `pack-evals-converters-gate-consolidation` owns consolidation), and judge
+  evals.json is keyed by file presence, not a pack allowlist.
+- Tempted to create a new top-level spec; declining — the parent spec is the
+  home, frozen; rollout is recorded in notes/manual-qa/backlog per precedent.

--- a/docs/specs/pack-activation-evals/notes/manual-qa.md
+++ b/docs/specs/pack-activation-evals/notes/manual-qa.md
@@ -205,3 +205,29 @@ confirm they discriminate: `architect-review` (a proper severity-tagged critique
 **PASS** / a "looks good, consider scalability" hand-wave **FAIL**) and
 `voice-and-microcopy` (blame-free + actionable copy **PASS** / "You entered an
 invalid code" / "Submit" / "Nothing here" **FAIL**). All 8 rubrics lint clean.
+
+## 8. `design-craft` — both layers (Tier-A activation + Tier-4 judge), 2026-06-22
+
+`design-craft`'s four skills are judgment/authoring skills (an aesthetic
+direction, a token taxonomy, an IA doc, a heuristic critique — no deterministic
+artifact), so **both** the layers that apply to judgment skills were added:
+Tier-A activation (`evals/eval_queries.json` + a `[pack.evals]` block, all four
+skills covered) **and** Tier-4 LLM-judge rubrics (`evals/evals.json` —
+`expected_output` + `assertions` matched to each skill's procedure and
+anti-patterns). No B-lite layer (nothing deterministic to re-derive).
+
+| skill | rubric grades |
+| --- | --- |
+| aesthetic-direction | named + ranked goals, dominant-goal tiebreak, recorded arbitration, no values printed, accessibility-floor wins, stops at direction |
+| design-critique | surface framed, quality-floor + heuristics, principle-mapped, 0–4 severity, worst-first headline, design-intent (not stack) recommendations |
+| design-system-foundations | tokens trace to goals, semantic-role names, single ratio with symbolic steps, accessibility floor → WCAG, atomic composition + W3C Design Tokens, method-not-values |
+| layout-and-information-architecture | job+audience per surface, forced primary rank, F/Z from the job, progressive disclosure + depth-vs-breadth nav, wayfinding as mental model, all states, concepts-not-code |
+
+The `design-critique` rubric was spot-checked live (`--mode judge
+--judge-adapter codex`) with good-vs-weak artifacts to confirm it discriminates:
+a proper severity-tagged, principle-mapped, worst-first critique with a
+quality-floor pass **PASS** / a "looks pretty good, bigger buttons, nicer blue,
+more whitespace" polish note **FAIL** ("a brief polish note, not a
+rubric-compliant design critique"). All 12 rubrics across the three judgment
+packs lint clean; `design-craft` bumped 0.1.0 → 0.1.1 and `marketplace.json`
+refreshed via `make build-self`.

--- a/packs/design-craft/.apm/skills/aesthetic-direction/evals/eval_queries.json
+++ b/packs/design-craft/.apm/skills/aesthetic-direction/evals/eval_queries.json
@@ -1,0 +1,23 @@
+[
+  {"query": "Make it feel premium and calm — I can't describe it better than that yet", "should_trigger": true},
+  {"query": "I want this product to feel like a high-end spa, before we touch any colors", "should_trigger": true},
+  {"query": "What's the vibe for our new landing page? Help me name it", "should_trigger": true},
+  {"query": "We need a look and feel for the brand but I can't articulate what it should be", "should_trigger": true},
+  {"query": "I want it to feel trustworthy and serious, like a bank but warmer", "should_trigger": true},
+  {"query": "Help me turn this mood board into a named design direction", "should_trigger": true},
+  {"query": "Before we pick type or color, let's pin down the feeling we're going for", "should_trigger": true},
+  {"query": "Our app feels generic — I want a distinctive emotional direction for it", "should_trigger": true},
+  {"query": "Let's define the aesthetic goals for the product before any design work starts", "should_trigger": true},
+  {"query": "I keep saying 'make it pop' but I need to name what I actually want it to feel like", "should_trigger": true},
+
+  {"query": "Derive a spacing and type scale from our aesthetic direction", "should_trigger": false},
+  {"query": "Set up our design tokens and name them by role", "should_trigger": false},
+  {"query": "Critique this landing-page mockup and rank the issues", "should_trigger": false},
+  {"query": "What's wrong with this checkout screen's usability?", "should_trigger": false},
+  {"query": "Structure the information architecture for the dashboard", "should_trigger": false},
+  {"query": "How should the navigation for this app be organized?", "should_trigger": false},
+  {"query": "Lay out the visual hierarchy of this settings page", "should_trigger": false},
+  {"query": "Write the empty-state copy for the inbox", "should_trigger": false},
+  {"query": "Build the React component for the hero section", "should_trigger": false},
+  {"query": "Pick the final hex codes for our button palette", "should_trigger": false}
+]

--- a/packs/design-craft/.apm/skills/aesthetic-direction/evals/evals.json
+++ b/packs/design-craft/.apm/skills/aesthetic-direction/evals/evals.json
@@ -1,0 +1,18 @@
+{
+  "skill_name": "aesthetic-direction",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Turn the vibe the user described into an aesthetic direction.",
+      "expected_output": "A small set of NAMED emotional/brand goals, each a short noun phrase a non-designer can recall, RANKED so a tie can break, with a single dominant goal that wins when goals conflict. Likely conflicts carry recorded arbitration (which goal wins and why), and the whole thing is captured as an aesthetic-direction doc (what each goal means, what would violate it, the dominant goal, open questions). It names DIRECTION only — no palette, font name, spacing, or timing values — and where a goal pulls against the accessibility floor, the floor wins, logged as an open question rather than a negotiated trade-off. It stops at named goals and does not jump ahead to deriving tokens or critiquing a screen.",
+      "assertions": [
+        "Produces a small set of named goals, each a short noun phrase (not a sentence or a single vague mood word)",
+        "Ranks the goals and names a single dominant goal that breaks ties",
+        "Records arbitration for at least one likely conflict (which goal wins and why)",
+        "Does NOT print any values — no palette/hex, font name, spacing, or timing numbers",
+        "When a goal conflicts with the accessibility floor, the floor wins (logged as an open question, not traded away)",
+        "Stops at direction — does not derive tokens/scales or critique an existing screen"
+      ]
+    }
+  ]
+}

--- a/packs/design-craft/.apm/skills/design-critique/evals/eval_queries.json
+++ b/packs/design-craft/.apm/skills/design-critique/evals/eval_queries.json
@@ -1,0 +1,23 @@
+[
+  {"query": "Critique this design and tell me what's wrong with it", "should_trigger": true},
+  {"query": "Review this checkout screen — what are the usability problems?", "should_trigger": true},
+  {"query": "Do a heuristic evaluation of our onboarding flow", "should_trigger": true},
+  {"query": "Is this dashboard usable? Tell me what's off about it", "should_trigger": true},
+  {"query": "Evaluate this signup mockup against usability principles", "should_trigger": true},
+  {"query": "Here's our settings page — give me a prioritized list of UX issues", "should_trigger": true},
+  {"query": "Run a design critique on this flow and rate the issues by severity", "should_trigger": true},
+  {"query": "Why does this form feel hard to use? Assess it properly", "should_trigger": true},
+  {"query": "Look over this screen and flag the worst usability issues first", "should_trigger": true},
+  {"query": "Heuristic review of this mockup, please — map each problem to a principle", "should_trigger": true},
+
+  {"query": "Name the aesthetic direction for this product", "should_trigger": false},
+  {"query": "Make it feel more premium and calm", "should_trigger": false},
+  {"query": "Derive our token taxonomy from the direction", "should_trigger": false},
+  {"query": "What spacing scale should we use for this system?", "should_trigger": false},
+  {"query": "Structure the information architecture for this page", "should_trigger": false},
+  {"query": "Lay out the reading flow for this article page", "should_trigger": false},
+  {"query": "Review this pull request for correctness bugs", "should_trigger": false},
+  {"query": "Critique this architecture design doc and give a verdict", "should_trigger": false},
+  {"query": "Write better error messages for this screen", "should_trigger": false},
+  {"query": "Design a brand-new dashboard for us from scratch", "should_trigger": false}
+]

--- a/packs/design-craft/.apm/skills/design-critique/evals/evals.json
+++ b/packs/design-craft/.apm/skills/design-critique/evals/evals.json
@@ -1,0 +1,18 @@
+{
+  "skill_name": "design-critique",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Run a design critique on the screen or flow the user provided.",
+      "expected_output": "A prioritized, severity-rated findings list. It first frames the surface — the user, the primary task, and the steps under review — so every severity call is anchored. It runs the shared quality-floor pass (all states, the accessibility floor, the reduced-motion principle) AND a heuristic evaluation against recognized usability principles, recording what was observed before judging. Each finding maps to the single best-fit usability principle (or floor commitment), with accessibility misses starting at major; each carries a 0–4 severity naming the frequency × impact × persistence factors behind it. Findings are sorted worst-first under a count-by-severity headline, and each has one concrete recommendation expressed as DESIGN INTENT — never a stack-specific implementation (no framework, property, or value).",
+      "assertions": [
+        "Frames the user, primary task, and steps under review before judging",
+        "Runs the quality-floor pass (states, accessibility floor, reduced-motion) in addition to the heuristics, with accessibility misses starting at major",
+        "Maps every finding to a single named usability principle or floor commitment",
+        "Assigns a 0–4 severity to each finding and names the factors that set it",
+        "Sorts findings worst-first and leads with a count-by-severity headline",
+        "Recommendations are design intent, not stack-specific — no framework, CSS property, or literal value is prescribed"
+      ]
+    }
+  ]
+}

--- a/packs/design-craft/.apm/skills/design-system-foundations/evals/eval_queries.json
+++ b/packs/design-craft/.apm/skills/design-system-foundations/evals/eval_queries.json
@@ -1,0 +1,23 @@
+[
+  {"query": "Derive a spacing scale from our aesthetic direction", "should_trigger": true},
+  {"query": "Set up our design tokens and name them by role", "should_trigger": true},
+  {"query": "Turn the named aesthetic direction into a design system", "should_trigger": true},
+  {"query": "What should our type scale be, structurally — what ratio organizes it?", "should_trigger": true},
+  {"query": "We have named goals; now build the token taxonomy from them", "should_trigger": true},
+  {"query": "Establish a semantic token system for the product", "should_trigger": true},
+  {"query": "Define the scale that generates both our spacing and type steps", "should_trigger": true},
+  {"query": "How should we organize tokens so values can change without renaming everything?", "should_trigger": true},
+  {"query": "Create the foundational design-system rules from our direction", "should_trigger": true},
+  {"query": "Set up the token and scale taxonomy for our component library", "should_trigger": true},
+
+  {"query": "Name the emotional direction for this product first", "should_trigger": false},
+  {"query": "I want it to feel calm and premium", "should_trigger": false},
+  {"query": "Critique this screen's usability and rank the issues", "should_trigger": false},
+  {"query": "Review this mockup against the heuristics", "should_trigger": false},
+  {"query": "Structure the information architecture for the dashboard", "should_trigger": false},
+  {"query": "Pick the reading pattern and content hierarchy for this page", "should_trigger": false},
+  {"query": "Write the design doc for this backend payments service", "should_trigger": false},
+  {"query": "Design the database system architecture for our API", "should_trigger": false},
+  {"query": "Implement these tokens as CSS variables in our codebase", "should_trigger": false},
+  {"query": "Write the microcopy for our button labels", "should_trigger": false}
+]

--- a/packs/design-craft/.apm/skills/design-system-foundations/evals/evals.json
+++ b/packs/design-craft/.apm/skills/design-system-foundations/evals/evals.json
@@ -1,0 +1,18 @@
+{
+  "skill_name": "design-system-foundations",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Derive the token/scale taxonomy from the user's named aesthetic direction.",
+      "expected_output": "A token/scale taxonomy and the rationale behind it, derived from the named direction — every token decision tracing back to one of the goals. Tokens are named by SEMANTIC ROLE (the job they do), not by literal appearance, so a value can change without a rename. A single ratio is chosen as the organizing concept and generates the spacing and type scales, with steps expressed SYMBOLICALLY (step −1, base, step +1) rather than as numbers. Accessibility is a derivation-time floor that points to the recognized standard (WCAG, at the context's conformance level) rather than reprinting a contrast ratio, and a contrast budget is allocated across the screen. The system composes atomically (primitive tokens → composed components → pages) and is serialized in the W3C Design Tokens interchange shape. It hands back the METHOD and a symbolic taxonomy shape — never a reprinted palette, spacing, or type table with literal values.",
+      "assertions": [
+        "Traces token decisions back to the named aesthetic-direction goals",
+        "Names tokens by semantic role, not by literal appearance",
+        "Organizes scales by a single ratio-as-concept with steps expressed symbolically, not as numeric values",
+        "Treats accessibility as a derivation-time floor and points to WCAG rather than reprinting a contrast ratio",
+        "Composes atomically (primitives → components → pages) and serializes in the W3C Design Tokens interchange shape",
+        "Ships the method and a symbolic taxonomy shape — does NOT reprint a values table (no hex, no px/rem numbers)"
+      ]
+    }
+  ]
+}

--- a/packs/design-craft/.apm/skills/layout-and-information-architecture/evals/eval_queries.json
+++ b/packs/design-craft/.apm/skills/layout-and-information-architecture/evals/eval_queries.json
@@ -1,0 +1,23 @@
+[
+  {"query": "Structure this screen — what goes where and in what order?", "should_trigger": true},
+  {"query": "Work out the information architecture for the dashboard", "should_trigger": true},
+  {"query": "Lay out this signup flow so users stay oriented", "should_trigger": true},
+  {"query": "What should the visual hierarchy be on this page?", "should_trigger": true},
+  {"query": "How should this app's navigation be organized?", "should_trigger": true},
+  {"query": "Why does this page feel cluttered? Reorganize what's on it", "should_trigger": true},
+  {"query": "Plan the reading flow for this landing page", "should_trigger": true},
+  {"query": "Order the content on this settings screen by priority", "should_trigger": true},
+  {"query": "Design the wayfinding for this multi-step flow", "should_trigger": true},
+  {"query": "What should be primary versus secondary on this screen?", "should_trigger": true},
+
+  {"query": "Name the aesthetic direction for this product", "should_trigger": false},
+  {"query": "Make this feel more playful and energetic", "should_trigger": false},
+  {"query": "Critique this mockup's usability and rate the issues", "should_trigger": false},
+  {"query": "Review this screen against the usability heuristics", "should_trigger": false},
+  {"query": "Derive our token taxonomy from the direction", "should_trigger": false},
+  {"query": "Set up the spacing and type scale for the system", "should_trigger": false},
+  {"query": "Write the actual HTML and CSS layout for this page", "should_trigger": false},
+  {"query": "Design the system architecture for the backend services", "should_trigger": false},
+  {"query": "Write the empty-state and error copy for this view", "should_trigger": false},
+  {"query": "Pick the final color palette for the navigation bar", "should_trigger": false}
+]

--- a/packs/design-craft/.apm/skills/layout-and-information-architecture/evals/evals.json
+++ b/packs/design-craft/.apm/skills/layout-and-information-architecture/evals/evals.json
@@ -1,0 +1,18 @@
+{
+  "skill_name": "layout-and-information-architecture",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Produce the information architecture and layout reasoning for the surface(s) the user described.",
+      "expected_output": "An information-architecture and layout-reasoning doc. It frames each surface's one job and its audience, then ranks the content primary / secondary / tertiary — forcing a single primary rather than a flat 'everything important'. It picks a reading pattern (F for dense, scannable surfaces; Z for sparse, hero-style ones) FROM the surface's job, not habit, and lays the ranked content along that scan path. It stages complexity with progressive disclosure, shapes a navigation tree trading depth against breadth and grouped by how users look for things (not by the data schema or org chart), and designs wayfinding as the user's mental model — where am I, where can I go, how do I get back — never as platform roles or attributes. It walks the empty / loading / error / partial states and how each changes the IA. The whole output is reasoning and concepts only — no layout, markup, or styling code.",
+      "assertions": [
+        "Frames each surface's one job and its audience",
+        "Ranks content primary/secondary/tertiary and forces a single primary (no flat 'everything important')",
+        "Chooses a reading pattern (F or Z) justified by the surface's job, not by habit",
+        "Covers progressive disclosure and a depth-vs-breadth navigation tree grouped by how users look for things, not the schema/org chart",
+        "Describes wayfinding as the user's mental model, never as platform roles or attributes",
+        "Designs the empty/loading/error/partial states, and outputs concepts/reasoning only — no layout or styling code"
+      ]
+    }
+  ]
+}

--- a/packs/design-craft/.claude-plugin/plugin.json
+++ b/packs/design-craft/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "design-craft",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Framework-agnostic design-craft discipline for interaction/visual designers — authors of the upstream design intent the build consumes. Four skills (aesthetic-direction, design-system-foundations, layout-and-information-architecture, design-critique) plus a shared quality-floor checklist (handle-all-states, accessibility floor, reduced-motion principle). Pure method: no stack, no values tables — points to WCAG / W3C Design Tokens, never reprints them."
 }

--- a/packs/design-craft/pack.toml
+++ b/packs/design-craft/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "design-craft"
-version = "0.1.0"
+version = "0.1.1"
 description = "Framework-agnostic design-craft discipline for interaction/visual designers — authors of the upstream design intent the build consumes. Four skills (aesthetic-direction, design-system-foundations, layout-and-information-architecture, design-critique) plus a shared quality-floor checklist (handle-all-states, accessibility floor, reduced-motion principle). Pure method: no stack, no values tables — points to WCAG / W3C Design Tokens, never reprints them."
 readme = "README.md"
 display_name = "Design Craft"
@@ -24,6 +24,16 @@ allowed-scopes = ["user", "repo"]
 # adapter that supports the skill primitive. Declared order is load-bearing
 # (RFC-0011): append-only; `kiro-ide` precedes `kiro-cli`.
 allowed-adapters = ["claude-code", "codex", "copilot", "kiro-ide", "kiro-cli", "cursor", "gemini"]
+
+# pack-activation-evals (RFC-0037 / ADR-0028): the Tier-A activation-eval
+# coverage allowlist. Each listed skill ships evals/eval_queries.json and is
+# measured by tools/run-pack-evals.py. All four design-craft skills are
+# user-triggered judgment/authoring skills, so all four are covered; each also
+# ships a Tier-4 LLM-judge rubric (evals/evals.json, keyed by file presence,
+# graded via --mode judge). No skill is excluded — the pack has no
+# reviewer-internal / non-prompt skill (unlike core's security-checklists).
+[pack.evals]
+skills = ["aesthetic-direction", "design-critique", "design-system-foundations", "layout-and-information-architecture"]
 
 # enriched-pack-manifest (RFC-0031 / ADR-0021): catalogue-facing links
 # + maintainer, including the `documentation` link to the per-pack guide home.


### PR DESCRIPTION
Extends the pack-activation-evals / RFC-0037 rollout (tracked under `pack-eval-coverage-rollout` in `docs/backlog.md`) to the **`design-craft`** pack. The four skills are judgment/authoring skills, so the two layers that apply to judgment skills are both added — no deterministic B-lite layer.

## What changed

- **Tier-A activation** — `evals/eval_queries.json` for each of the four skills (`aesthetic-direction`, `design-critique`, `design-system-foundations`, `layout-and-information-architecture`): 10 should-trigger + 10 near-miss should-NOT-trigger each. The negatives share design vocabulary/concepts but route to a *different* design-craft skill (or to a build/copy/architect concern) — not trivially-irrelevant filler. Plus a `[pack.evals]` block in `pack.toml` listing all four, same shape as `core`/`converters`.
- **Tier-4 LLM-judge** — `evals/evals.json` per skill (`expected_output` + `assertions`), each assertion traced to that skill's own Procedure step or Anti-pattern. Same shape as `architect`/`product-engineering`; no `expect`/`files` blocks.
- **Version + manifest** — `design-craft` `0.1.0 → 0.1.1` (`pack.toml` + `.claude-plugin/plugin.json`); `marketplace.json` refreshed via `make build-self`.
- **Docs** — `pack-eval-coverage-rollout` backlog entry and the `pack-activation-evals` `manual-qa.md` updated to record design-craft coverage.

## How verified

- `tools/lint-skill-spec.py` passes (eval JSON schema + `[pack.evals]` coverage); the design-craft framework-agnosticism lint passes; `make validate` and `make build-self` clean.
- **Live judge spot-check** of the `design-critique` rubric (`run-pack-evals.py --pack design-craft --mode judge --judge-adapter codex`): a rubric-complete severity-tagged critique **PASS** / a vague "bigger buttons, nicer blue, more whitespace" polish note **FAIL**. Gradient near-miss FAILs en route (missing reduced-motion check; double-mapped finding; missing severity factors) confirmed the rubric grades strictly per assertion — it discriminates, it doesn't rubber-stamp.

Ran through the work-loop skill in light mode (no risk trigger fired — familiar pattern, single logical task, no new module/layer/dependency). Single adversarial-reviewer pass clean after override of one false-positive (it claimed `make build-self` doesn't refresh `marketplace.json`; verified empirically that the `self` subcommand does regenerate the marketplace aggregation).