### PR TITLE
docs(rfc): RFC-0041 follow-on — ADR-0031 + infra-aware-work-loop & operational-safety-checklists specs

### DIFF
--- a/docs/adr/0031-infra-support-is-doctrine-on-existing-reviewers-not-a-new-reviewer-or-runtime.md
+++ b/docs/adr/0031-infra-support-is-doctrine-on-existing-reviewers-not-a-new-reviewer-or-runtime.md
@@ -1,0 +1,98 @@
+# ADR-0031: Infra `work-loop` support is doctrine on existing reviewers — operational safety via `quality-engineer`, security via a mandatory `security-reviewer` + scanner pair — not a new reviewer or runtime
+
+- **Status:** Accepted
+- **Date:** 2026-06-23
+- **Decision-makers:** eugenelim
+- **Consulted:** RFC-0041's applied-mode research brief, its citation-integrity pass, and the module-taxonomy follow-up (`0041-notes/research.md`); the spec-stage adversarial + design review of this ADR and the two implementing specs
+- **Supersedes:** none
+- **Related:** RFC-0041 (the accepted decision this records); ADR-0023 (the three-reviewer ceiling scopes the core code-review lenses — the constraint that forecloses a fourth, infra-lens reviewer); ADR-0014 + RFC-0025 (risk triggers already route a destructive/irreversible `apply` to full mode — the hook point this builds on); ADR-0018 (shift security review left + deliver its depth via an orchestrator-loaded progressive-disclosure skill — the `security-checklists` pattern P3's `operational-safety` library reuses verbatim); ADR-0017 (Bandit + pip-audit + Semgrep as the SAST/SCA gate — the scanner family the infra policy-as-code/CSPM scanner joins, complementing not replacing the reviewer)
+
+## Context
+
+`work-loop` is the repo's standard inner loop, and its risk triggers already route every cloud `apply` — destructive and partially irreversible by nature — to full mode (ADR-0014, RFC-0025). So the loop already *enters the right gear* for infrastructure work. Once there, it has no infra content, and that gap surfaces three ways:
+
+- **The verification-mode step assumes the mechanism already exists.** PLAN says "pick the verification mode for each task" (the task's contract for "how do we know this is done"). TDD presupposes a runner; goal-based presupposes a build command; visual/manual-QA presupposes you can run the artifact. For a deploy, the mechanism — an idempotent apply you can safely re-run, a smoke check that proves "actually up", a throwaway target to iterate in, a teardown — frequently does not exist yet, and nothing makes the agent build it first.
+- **The verification modes assume a fast, local, stateless, single-hop gate.** GATES is "lint, typecheck, tests". A deploy is slow, stateful, costs money, partially irreversible, and multi-hop: verifying it means *building the harness to verify it* (verify-status script, teardown script, seeded test/mock users, a provider-appropriate scanner), and the smoke check itself is an active end-to-end sequence — seed users → load the real CDN/site URL → confirm it renders → pull access/error logs → debug → tear down.
+- **The security check on infra is discretionary, and a misconfigured deploy is high-blast-radius.** Infra changes routinely touch IAM, security groups, public buckets/CDNs, secrets, and network exposure; one wrong line ships prod open to the world. The existing security-boundary trigger *covers* this but only discretionarily.
+
+The compound symptom is the **human-as-relay anti-pattern**: because the loop doesn't equip the agent to drive deploy-and-verify itself, the human runs the command and pastes the error back into the session by hand.
+
+RFC-0041 settled *whether* and *how* to close this. This ADR records the load-bearing, expensive-to-reverse calls — the *form*, the *home*, and the *security posture* — so a future maintainer doesn't re-litigate them. The mechanical detail (the five-layer infra GATES sequence, the multi-artifact preflight enumeration, the exact six-module taxonomy) is spec-level and lives in the two implementing specs, not here.
+
+Constraints in force when deciding (CHARTER Principles 1–3, plus the reviewer ceiling; Principle 4 — earns-its-place — appears in Consequences, not as a discriminating constraint):
+
+- **Principle 3 (a habit, not infrastructure).** The repo ships doctrine and prose the agent reasons from, never a runtime engine, daemon, parser, or wrapper. This is the bar that put browser-bridge out of charter.
+- **Principle 2 (no duplication).** A capability belongs in exactly one place; a parallel surface that re-implements an existing one is rejected.
+- **Principle 1 (universal across stacks).** Anything that ships must hold for Terraform, Pulumi, CDK, CloudFormation, and hand-rolled scripts alike — no tool-specific bindings in normative prose.
+- **The three-reviewer ceiling (ADR-0023).** Core code-review has exactly three lenses — `adversarial-reviewer`, `security-reviewer`, `quality-engineer`. A fourth is out of bounds.
+
+## Decision
+
+> We will make `work-loop` function for infrastructure development as **doctrine plus a reference library inside the loop — never executable infra tooling** — routing the **operational-safety** lens to the existing **`quality-engineer`** reviewer (no new reviewer), and making the **security** lens on infra a **mandatory, non-skippable `security-reviewer` + policy-as-code/CSPM scanner *pair***.
+
+Three sub-decisions, each expensive to reverse:
+
+- **Form & home — doctrine + reference library, inside `work-loop`.** Everything ships as prose: edits to `work-loop`'s `SKILL.md` and a new `operational-safety` skill of boundary-keyed `references/*.md` modules, structurally identical to `security-checklists`. No executable code ships — no deploy wrapper, plan-parser, cost-gate, or runtime. This is the `security-checklists` shape, a depth library a reviewer reasons from, which the repo has already accepted as a *habit*.
+- **Operational safety is `quality-engineer`'s, not a new reviewer's.** The new `operational-safety` library (idempotency, blast radius, environment isolation, cost/teardown, drift/rollback, observability/smoke) is consumed by `quality-engineer`, whose existing lens — reliability, observability, maintainability — already owns exactly these concerns. The orchestrator loads only the matching modules and inlines them into the reviewer's brief via the same table-driven mechanism it already uses for `security-checklists`. **No fourth reviewer** (ADR-0023). The *security* lens on infra stays with `security-reviewer` (below); the carve is `security-checklists` owns security config, `operational-safety` owns reliability/ops config.
+- **Security on infra is mandatory, and is a reviewer + scanner pair.** Infra-flavored work **non-skippably** invokes `security-reviewer` — at the spec stage (is the control specified as an acceptance criterion?) *and* on the diff — rather than leaving it to the discretionary security-boundary trigger; the orchestrator force-loads the infra-relevant `security-checklists` modules (`config-misconfig`, `access-control`, `secrets-and-crypto`, `outbound-ssrf`, `supply-chain`, loaded 1–N as the diff warrants). The reviewer is **not** the per-provider depth source — it reasons from cross-cutting standards (OWASP/ASVS/CWE + STRIDE/LINDDUN) and catches failure *classes* (over-broad IAM, public exposure, unencrypted-at-rest, secrets in state, metadata SSRF, missing audit logging). The per-provider secure-config depth comes from a **provider-appropriate policy-as-code/CSPM scanner** (Checkov / tfsec / cloud-native CSPM — the adopter's choice, never pinned), whose vendor-maintained rulesets *are* the provider baselines. So security on infra is a **pair**: scanner for per-provider breadth + reviewer for failure-class reasoning; neither substitutes for the other.
+
+Boundaries on the decision:
+
+- This adds **no new risk trigger** for "infrastructure" — destructive/irreversible already routes `apply` to full mode (RFC-0025); a separate infra trigger would be redundant. **"Infra-flavored" is a defined signal, not an ad-hoc judgement:** work is infra-flavored when it trips that destructive/irreversible trigger *and* the diff/spec matches the boundary→module routing table's IaC/deploy-config entry in `work-loop` SKILL.md — the same classifier already drives security-module loading. The mandatory pass (below) keys on that signal, so it cannot be silently skipped on an infra diff.
+- It adds **no new reviewer and no new `security-checklists` module** — it makes the *existing* security pass mandatory and multi-module.
+- The scanner requirement is **mechanism-level, not tool-level** — a provider-appropriate scanner must exist, exactly as the repo requires "tests exist" without mandating a test framework.
+- Progressive delivery (canary / blue-green metric gates) is **deferred** — largely Kubernetes-specific, it fails the universal-stack bar and waits for a future RFC.
+
+## Decision drivers
+
+- **Principle 3 (habit, not infrastructure)** — the hard gate; rules out executable infra tooling (a plan-parser or deploy wrapper is runtime infrastructure), forcing the capability to be doctrine + a reviewer-consumed depth library.
+- **Principle 2 (no duplication)** — rules out a standalone `infra-deploy` skill; a parallel surface would re-implement the PLAN/GATES/REVIEW loop `work-loop` already owns. The capability belongs *in* the loop.
+- **The three-reviewer ceiling (ADR-0023)** — rules out a fourth, infra-lens reviewer; the infra reliability lens is `quality-engineer`'s existing concern, the infra security lens is `security-reviewer`'s.
+- **Principle 1 (universal across stacks)** — rules out per-provider secure-config baselines living in the reviewer (they would break universality and be stale on arrival); forces per-provider depth into the self-updating scanner and the doctrine prose to stay tool-neutral.
+- **Blast radius of a misconfigured deploy** — drives *mandatory* (non-skippable, spec-stage + diff) over the discretionary security-boundary trigger: the non-trivial case (a public bucket, an over-broad role) dominates the risk.
+- **A standards-grounded reviewer is not a per-provider rules engine** — drives the *pair*: the reviewer's strength is failure-class reasoning and control-completeness, not AWS/Azure/GCP per-service baselines, so the scanner must carry that depth alongside it.
+
+## Consequences
+
+**Positive:**
+
+- The capability reuses a proven, table-driven mechanism (the orchestrator already inlines `security-checklists` modules and already fires on IaC/deploy changes), so the operational-safety library is a second lens on an existing rail, not new infrastructure — clearing Principle 3.
+- The generalized verification-mechanism preflight (P1 in RFC-0041) is exercised on **every** task, not just infra — a goal-based task that claims a build command not yet wired, or a TDD task with no runner, is caught by the same obligation — so the change earns its place on every loop, not only the rare infra one.
+- Infra security is robust and proportionate to its blast radius: mandatory, multi-module, run at spec stage and on the diff, and backed by per-provider scanner depth the reviewer can't and shouldn't carry.
+
+**Negative:**
+
+- A second reference library is one more governed surface to maintain, and the change lengthens `work-loop`'s PLAN/REVIEW prose — real surface-area cost, justified by the recurring present pain and the universal reach of the preflight.
+- For adopters who never deploy infra, the infra verification flavor and the `operational-safety` modules are dormant weight (mitigated: the preflight still earns its place on every task; the infra layers load only on the destructive/irreversible trigger).
+- Requiring a provider-appropriate scanner edges toward tool-binding; the residual is accepted because the requirement is mechanism-level (a scanner must exist), not tool-level — the adopter picks the tool, exactly as with test frameworks.
+
+**Neutral / to revisit:**
+
+- **`quality-engineer`'s lens is assumed to stretch to operational safety** (blast radius, cost, teardown). Believed true — these are textbook reliability/observability concerns, and the agent already carries Observability and Reliability checklists — but this is the assumption to re-check if a reviewer-fit gap appears.
+- **The right default for auto-remediation of drift in an agentic loop is unsettled** — the Terraform community (gate it) and the GitOps community (auto-sync) disagree by risk tolerance, and no evidence settles it across both contexts. RFC-0041 names this as a tension to surface, not resolve; the `drift-and-rollback` module records it as such.
+- **Progressive delivery is deferred, not rejected** — a Kubernetes-using adopter who needs canary/blue-green metric gates reopens it as a follow-up RFC.
+
+## Confirmation
+
+- The two implementing specs' acceptance criteria encode the doctrine — the generalized preflight, the multi-artifact infra mechanism set, the layered infra GATES, the mandatory security reviewer + scanner pair, the six-module `operational-safety` library, and the `quality-engineer` consumer wiring — so conformance is checkable against the specs.
+- The adversarial + quality + security review passes on the implementing diff check that **no executable infra tooling creeps in** (the standing scope-inflation risk), that every module stays **tool-neutral** (Principle 1), and that the **reliability-vs-security carve** between `operational-safety` and `security-checklists` holds (no security config in the operational library, no operational config migrating into the security one).
+- The mandatory-security posture keys on the defined infra-flavor signal above (the destructive/irreversible trigger + the IaC/deploy-config routing entry): an infra-flavored diff that reaches DECIDE without a recorded `security-reviewer` pass (spec stage + diff) and a recorded scanner run is, by the doctrine, not done — and because "infra-flavored" is the routing-table classifier rather than a per-diff judgement, the requirement is checkable, not aspirational.
+
+**Enforcement posture is deliberately review-time, not a standing CI gate.** Conformance is confirmed at the implementing PR (the specs' ACs) and thereafter by the three reviewer passes' standing doctrine — there is no machine fitness function asserting "no executable infra tooling under these skills" or "the carve holds" against future drift. This matches Principle 3 (the bar that forecloses a code gate is the same one that makes the controls prose) and ADR-0030's precedent of accepting a prose-enforced, reviewer-held residual. The decision-maker accepts that drift residual; a later, optional governance lint (e.g. asserting the `work-loop` and `operational-safety` skills ship no executable deploy/parse/gate script) could harden it without reversing this ADR, and is recorded as a possible follow-up, not a requirement.
+
+## Alternatives considered
+
+- **New executable infra tooling** (a plan-parser, deploy wrapper, or cost-gate script / runtime). Rejected against **Principle 3** — that is runtime infrastructure, and it would need per-tool bindings, also breaking Principle 1. This is the option the form-and-home sub-decision rejects.
+- **A standalone `infra-deploy` skill.** Rejected against **Principle 2** — a parallel deploy skill re-implements the PLAN/GATES/REVIEW the loop already owns; the capability belongs *in* the loop, not beside it.
+- **A fourth, infra-lens reviewer.** Rejected against **the three-reviewer ceiling (ADR-0023)** — the infra reliability lens is `quality-engineer`'s existing concern; the infra security lens is `security-reviewer`'s. Three is the ceiling.
+- **Leaving infra security on the discretionary security-boundary trigger** (do-nothing on P5). Rejected against the **blast-radius** driver — a high-blast-radius misconfiguration (a public bucket, an over-broad IAM role) can ship because the security pass was optional rather than mandatory.
+- **Do nothing.** Rejected — the loop stays implicitly application-only; infra users keep relaying deploy errors by hand, and the agnostic preflight gap silently degrades non-infra work too (a claimed verification mode whose mechanism doesn't exist). The pain is recurring and present now.
+
+## References
+
+- RFC-0041 — make `work-loop` function for infrastructure development (the accepted decision this ADR records).
+- ADR-0023 — the three-reviewer ceiling scopes the core code-review lenses (the constraint foreclosing a fourth reviewer).
+- ADR-0018 — shift security review left + orchestrator-loaded progressive-disclosure depth library (the `security-checklists` pattern `operational-safety` reuses).
+- ADR-0014 / RFC-0025 — risk triggers route destructive/irreversible work to full mode (the hook point).
+- ADR-0017 — Bandit + pip-audit + Semgrep SAST/SCA gate (the scanner family the infra policy-as-code/CSPM scanner complements).
+- CHARTER Principles 1–3 — the universality, no-duplication, and habit-not-infrastructure bars this decision clears (Principle 4, earns-its-place, appears in Consequences).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,6 +36,7 @@
 | 0028 | [Pack-level activation evals adopt the agentskills.io trigger-eval convention; coverage in `pack.toml`; runner is catalogue-internal tooling](0028-pack-activation-evals.md) | Accepted |
 | 0029 | [Research pack structure — two orthogonal axes (depth × lifecycle), with a prompt-only project mode](0029-research-two-axes-depth-and-lifecycle.md) | Accepted |
 | 0030 | [Consolidated, namespaced pack-output layout contract (`agentbundle-layout.toml`)](0030-consolidated-pack-output-layout-contract.md) | Accepted |
+| 0031 | [Infra `work-loop` support is doctrine on existing reviewers — `quality-engineer` for operational safety, a mandatory `security-reviewer` + scanner pair for security — not a new reviewer or runtime](0031-infra-support-is-doctrine-on-existing-reviewers-not-a-new-reviewer-or-runtime.md) | Accepted |
 
 ## Adding a new ADR
 

--- a/docs/rfc/0041-infra-aware-work-loop.md
+++ b/docs/rfc/0041-infra-aware-work-loop.md
@@ -148,6 +148,7 @@ None remaining. The module-taxonomy question (five vs. merge, plus the observabi
 
 ## Amendments
 
+- **2026-06-23 (additive, Approver-signed: eugenelim) — P4 follow-on placement.** When the follow-on artifacts were authored, **P4 (agent-drives-verification, Decision 5)** was placed in the `docs/specs/infra-aware-work-loop/` spec alongside P1/P2/P5, because P4 is a `work-loop` SKILL.md edit that co-locates with P2's EXECUTE smoke step. The Follow-on-artifacts list below originally named only P1/P2/P5 for that spec (folding P4 implicitly under "the infra verification flavor"); this amendment records that P4 lands there explicitly, so an RFC→spec coverage audit reconciles. No reversal of any accepted decision; placement clarification only.
 - **2026-06-23 (additive, Approver-signed: eugenelim).** Strengthened P1/P5 after a review question — "is `security-reviewer` equipped for every cloud provider's checks?" — clarified the answer: *no, and by design.* (a) P1 now requires a **provider-appropriate policy-as-code/CSPM scanner** as a task-zero mechanism (it holds the per-provider depth; the same scanner feeds P2's static-preflight and P5's security depth). (b) P5 is reframed as a **reviewer + scanner pair** — the standards-grounded reviewer reasons about failure *classes*, the scanner holds per-provider baselines. (c) Added a **URL-free, version-less deferred-authority pointer** (CIS Benchmarks + per-provider well-architected security) in `config-misconfig`, kept evergreen by naming publishers not links and by keeping depth in the self-updating scanner. No reversal of any accepted decision; all additive.
 
 ## Follow-on artifacts
@@ -155,7 +156,7 @@ None remaining. The module-taxonomy question (five vs. merge, plus the observabi
 Filled in on acceptance.
 
 - **ADR-0031**: record "infra is a verification flavor consumed by `quality-engineer`, not a new reviewer; security on infra is a *mandatory* `security-reviewer` + scanner pair" (the three-reviewer-ceiling + mandatory-security decisions). (ADR-0030 was taken by RFC-0040.)
-- **Spec**: `docs/specs/infra-aware-work-loop/` — P1 multi-artifact preflight (incl. the required policy-as-code/CSPM scanner as a task-zero mechanism) + P2 active-end-to-end infra verification flavor + P5 mandatory-security wiring (reviewer + scanner pair) (work-loop SKILL.md edits).
+- **Spec**: `docs/specs/infra-aware-work-loop/` — P1 multi-artifact preflight (incl. the required policy-as-code/CSPM scanner as a task-zero mechanism) + P2 active-end-to-end infra verification flavor + P4 agent-drives-verification doctrine + P5 mandatory-security wiring (reviewer + scanner pair) (work-loop SKILL.md edits). See the P4-placement amendment above.
 - **Spec**: `docs/specs/operational-safety-checklists/` — P3 six-module reference library + routing-table entries + `quality-engineer` wiring + the URL-free deferred-authority pointer in `security-checklists`' `config-misconfig`.
 - **Convention touch**: none expected (the risk-trigger set is unchanged); confirm at spec time.
 - **Changelog**: `docs/product/changelog.md` `[Unreleased]` entry for the work-loop behavior change.

--- a/docs/specs/infra-aware-work-loop/plan.md
+++ b/docs/specs/infra-aware-work-loop/plan.md
@@ -1,0 +1,228 @@
+# Plan: infra-aware-work-loop
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Drafting <!-- Drafting | Executing | Done -->
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn. When it changes substantially
+> (a different approach, not just a re-ordering), note why in the changelog
+> at the bottom.
+
+## Approach
+
+The change is **prose in one file** — `packs/core/.apm/skills/work-loop/SKILL.md`
+— plus a version bump and a changelog line. The shape is four self-contained
+prose edits, each at a distinct, already-existing anchor in the skill, so they
+don't entangle:
+
+- **P1** edits the PLAN *"Pick the verification mode for each plan task"* step —
+  adds the mechanism-must-exist obligation (universal, light + full) and the
+  infra multi-artifact task-zero set.
+- **P2** edits the same PLAN verification-mode list — adds the fourth
+  **infra/deploy** flavor with its five-layer GATES sequence, cross-linked to the
+  plan template's `## Rollout`.
+- **P4** edits the EXECUTE step — the agent-drives-verification doctrine and the
+  Claude Code accelerant primitives, sitting beside P2's smoke layer.
+- **P5** edits the REVIEW *Specialist reviewers* step and the PLAN *pre-EXECUTE
+  secure-design review* step — makes `security-reviewer` non-skippable for
+  infra-flavored work and force-loads the infra-relevant `security-checklists`
+  modules, and states the reviewer-vs-scanner pairing.
+
+The riskiest part is **not the edits but the discipline**: keeping every
+sentence tool-neutral (Principle 1) and resisting the standing temptation to
+"just add a small plan-parser" (Decision 1). Verification is goal-based +
+judgmental: `make build-self` and the three lint surfaces prove projection and
+hygiene; the spec-mode + diff-mode adversarial pass (plus a spec-stage
+security-reviewer read, since the subject is a security boundary) proves the
+doctrine actually routes as written. No production test file — there is no
+compressible invariant to TDD.
+
+## Constraints
+
+- **ADR-0031** — doctrine + reference library only, no executable infra tooling;
+  operational safety → `quality-engineer`; security on infra → mandatory
+  `security-reviewer` + scanner pair. This plan must not contradict it.
+- **RFC-0041** (Accepted) — P1/P2/P4/P5 as specified; no new risk trigger; no new
+  reviewer; progressive delivery deferred.
+- **ADR-0014 / RFC-0025** — the destructive/irreversible trigger that routes
+  `apply` to full mode is unchanged; P2/P5 fire *because of* it, not via a new
+  trigger.
+- **ADR-0018** — the orchestrator-inlined progressive-disclosure mechanism P5
+  reuses; P5 changes posture (discretionary → mandatory), not mechanism.
+- **`work-loop-light-mode` spec** — the projection mechanics and the
+  three-lint-surface gate for a core SKILL.md prose change are established there;
+  reuse them.
+
+## Construction tests
+
+Per-task checks live under each task's `Tests:` subsection (all goal-based or
+judgmental — no production test file). Cross-cutting:
+
+**Integration tests:** none beyond per-task checks (single-file prose change).
+**Manual verification:** after `make build-self`, read the projected
+`.claude/skills/work-loop/SKILL.md` and confirm the four edits read coherently
+in place and the infra/deploy flavor's cross-link to `## Rollout` resolves.
+
+## Design (LLD)
+
+n/a — methodology/prose change to one SKILL.md. No application LLD; the
+"design" is the doctrine itself, fully specified by the spec's Acceptance
+Criteria. The stack-neutral category headings do not apply to a prose edit.
+
+## Tasks
+
+### T1: P1 generalized verification-mechanism preflight (universal) + infra multi-artifact set
+
+**Depends on:** none
+
+**Tests:**
+- `grep` the source SKILL.md PLAN verification-mode step for the
+  mechanism-must-exist obligation, the "task zero" framing, the "agnostic"
+  qualifier, and an explicit "universal across light and full mode" statement
+  (spec AC: P1 generalized preflight).
+- `grep` for the infra multi-artifact enumeration — verify-status, teardown,
+  test-data/mock-user seeding, policy-as-code/CSPM scanner — each as a task-zero,
+  with the scanner named as per-provider-depth source feeding P2 and P5, and the
+  requirement stated as mechanism-level not tool-level (spec AC: P1 infra set).
+
+**Approach:**
+- Edit the PLAN *"Pick the verification mode for each plan task"* step in
+  `packs/core/.apm/skills/work-loop/SKILL.md`: add the preflight obligation, kept
+  to roughly one sentence for the universal core, then a short infra paragraph
+  enumerating the multi-artifact set as task-zeros.
+- Keep all of it tool-neutral; ground it in walking-skeleton / tracer-bullet /
+  CD pipeline-first language (RFC-0041 research F4.1–4.2), not a specific tool.
+
+**Done when:** both greps match in the source; the universal-mode statement is
+present; no executable artifact is introduced (the loop *offers to scaffold*, it
+does not ship the scripts).
+
+### T2: P2 infra/deploy verification flavor (five-layer GATES) + Rollout cross-link
+
+**Depends on:** T1 (the infra flavor's static-preflight layer references the P1
+scanner task-zero introduced in T1)
+
+**Tests:**
+- `grep` for the fourth flavor name **infra/deploy** and all five layers (static
+  preflight, plan/preview, idempotent convergent apply *named as precondition*,
+  active end-to-end smoke, rollback) with the smoke layer's multi-hop probe
+  spelled out (seed users → load real URL → assert render → read logs → debug →
+  teardown) (spec AC: P2 verification flavor).
+- Confirm the flavor cross-links to the plan template's `## Rollout` section and
+  does not restate deployment sequencing (spec AC: P2 cross-link).
+
+**Approach:**
+- Add the infra/deploy flavor to the PLAN verification-mode list, after
+  visual-manual-QA, framing smoke as an extension of the existing "exercise the
+  real built artifact" doctrine.
+- Name idempotent convergent apply as the precondition that makes iteration safe
+  (research F1.2); name the known-good re-apply rollback path (F2.6).
+- Cross-link, don't duplicate, `## Rollout`.
+
+**Done when:** the grep matches all five layers; the cross-link resolves; every
+example is labelled illustrative and no sentence binds to one IaC tool.
+
+### T3: P4 agent-drives-verification doctrine + Claude Code accelerant
+
+**Depends on:** none
+
+**Tests:**
+- `grep` the EXECUTE step for the agent-runs-deploy-and-reads-real-output
+  doctrine, the **human-as-relay** anti-pattern by name, and the three Claude
+  Code primitives (background tasks, `asyncRewake`, `PreToolUse`) framed as
+  accelerant-not-dependency (spec AC: P4).
+
+**Approach:**
+- Edit the EXECUTE step (beside the visual/manual-QA discipline) to state the
+  doctrine harness-agnostically, matching how `/verify` / `/simplify` are treated
+  as optional accelerants.
+
+**Done when:** the grep matches; the primitives are explicitly "accelerant,
+never a dependency"; adapters without them are stated to lose only the shortcut.
+
+### T4: P5 mandatory infra security — non-skippable reviewer + scanner pair
+
+**Depends on:** T1 (the scanner half of the pair is the P1 task-zero scanner), T2
+(infra-flavored work is what triggers the mandatory pass)
+
+**Tests:**
+- `grep` the REVIEW *Specialist reviewers* step and the PLAN *pre-EXECUTE
+  secure-design review* step for the non-skippable framing, "spec stage **and**
+  diff", and the force-load of the five infra `security-checklists` modules
+  loaded 1–N per the existing routing table (spec AC: P5 mandatory).
+- `grep` for the reviewer-is-not-per-provider-depth / scanner-holds-baselines /
+  "pair" prose (spec AC: P5 pair).
+- Confirm no new reviewer and no new `security-checklists` module is added
+  (`git diff` shows only prose edits to existing anchors).
+
+**Approach:**
+- In the PLAN pre-EXECUTE security step and the REVIEW specialist-reviewers step,
+  state that an infra/deploy-flavored task makes the `security-reviewer` pass
+  mandatory at both stages and force-loads the named modules.
+- State the pairing: reviewer = failure-class reasoning from standards; scanner =
+  per-provider depth (its rulesets are the baselines).
+
+**Done when:** both greps match; `git diff` confirms only existing-anchor prose
+changed; the Profile-A opt-out and the no-matching-subagent fallback note remain
+intact.
+
+### T5: build-self, lint surfaces, version bump, changelog
+
+**Depends on:** T1-T4
+
+**Tests:**
+- `make build-self` exits 0 and regenerates `.claude/skills/work-loop/SKILL.md`
+  with no unexpected reverts elsewhere (`git status` review).
+- `make build-check`, `python tools/lint-agent-artifacts.py`, and `python
+  tools/lint-agents-md.py` all exit 0 (spec AC: projection + lint).
+- `git diff` shows `loop-cohort.py` and `lint-spec-status.py` byte-unchanged
+  (spec AC: no executable mechanism).
+- `packs/core/pack.toml` version bumped; projected `marketplace.json` reflects
+  it; `docs/product/changelog.md` `[Unreleased]` carries the entry (spec AC:
+  release hygiene).
+
+**Approach:**
+- Run `make build-self`; verify the projection. Bump `core` version. Add the
+  changelog `[Unreleased]` entry naming the infra-aware work-loop behavior.
+- Run the three lint surfaces by hand (the latter two are not in build-check).
+
+**Done when:** all gates green; version + changelog updated; projection clean.
+
+## Rollout
+
+- **Delivery:** big-bang prose change, fully reversible (revert the SKILL.md
+  edits + version bump). Nothing irreversible — no data, no published interface
+  beyond the projected skill text.
+- **Infrastructure:** none.
+- **External-system integration:** none. (The *subject* is infra deploys, but the
+  *change* is doctrine prose; it provisions nothing.)
+- **Deployment sequencing:** this spec and `operational-safety-checklists` both
+  edit `work-loop` SKILL.md — land this one first (or both in one PR) so the
+  `operational-safety` routing table (the other spec) is added against the
+  infra-flavor prose this spec introduces.
+
+## Risks
+
+- **Co-edit collision with `operational-safety-checklists`.** Both specs edit
+  `work-loop` SKILL.md, but at **different bullets of the REVIEW "Specialist
+  reviewers" step**: this spec's P5 (T4) edits the **`security-reviewer`** bullet
+  (plus the PLAN pre-EXECUTE secure-design step and the verification-mode step);
+  the sibling adds its routing table at the **`quality-engineer`** bullet. The
+  `quality-engineer` bullet is touched by exactly one spec (the sibling), the
+  `security-reviewer` bullet by exactly one (this one). Mitigation: sequence (this
+  spec first) or single PR; the conflict is small and mechanical.
+- **Scope inflation back into tooling.** The standing temptation to add a
+  "small plan-parser" or cost-gate. Mitigation: Boundaries' *Never do* and
+  ADR-0031 make executable infra an explicit out-of-bounds; the adversarial pass
+  checks for it.
+- **Tool-specific drift.** A sentence quietly assuming Terraform. Mitigation:
+  examples labelled illustrative; adversarial pass checks for stack-binding.
+- **P1 becomes box-ticking** ("mechanism exists: yes"). Mitigation: the
+  obligation is "name the mechanism or write task zero to build it" — a concrete
+  artifact, not a checkbox; the spec AC requires the multi-artifact enumeration.
+
+## Changelog
+
+- 2026-06-23: initial plan (follow-on to Accepted RFC-0041; authored alongside
+  ADR-0031 and the `operational-safety-checklists` spec in a docs-only PR;
+  implementation is a separate later PR).

--- a/docs/specs/infra-aware-work-loop/spec.md
+++ b/docs/specs/infra-aware-work-loop/spec.md
@@ -1,0 +1,233 @@
+# Spec: infra-aware-work-loop
+
+- **Status:** Draft <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** ADR-0031, RFC-0041 (P1, P2, P4, P5); ADR-0014 + RFC-0025 (the destructive/irreversible risk trigger that routes `apply` to full mode); ADR-0018 (orchestrator-inlined progressive-disclosure security depth, the mechanism P5 reuses); ADR-0017 (the SAST/SCA scanner family the policy-as-code/CSPM scanner joins)
+- **Brief:** none
+- **Contract:** none
+- **Shape:** n/a — methodology/prose change (`work-loop` SKILL.md edits); no application LLD
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+Agents and adopters running the `core` pack get a `work-loop` that can drive an
+**infrastructure inner loop end-to-end** instead of stalling the moment a deploy
+is involved. Today the loop's verification modes (TDD / goal-based /
+visual-manual-QA) silently assume the verification mechanism already exists and
+assume a fast, local, stateless, single-hop gate; a cloud deploy is slow,
+stateful, partially irreversible, multi-hop, and its mechanism (idempotent
+apply, a smoke check, a throwaway target, teardown) frequently *doesn't exist
+yet* — so the agent can't drive the loop and the human becomes a relay,
+copy-pasting deploy errors back into the session. Success is: (P1) picking any
+verification mode obligates confirming its mechanism exists — and if not,
+building it is task zero — stated universally across light and full mode; (P2) a
+fourth **infra/deploy** verification flavor gives infra work a layered GATES
+sequence that matches its stateful, multi-hop, partially-irreversible reality;
+(P4) the agent drives the deploy and reads real environment output itself, with
+the human-as-relay named as the anti-pattern; and (P5) infra-flavored work
+**non-skippably** runs `security-reviewer` (spec stage + diff) paired with the
+P1-required policy-as-code/CSPM scanner. The change is delivered by editing the
+`core` pack's `work-loop` SKILL.md source (a projected artifact), adds **no
+executable code, skill, or artifact type**, and ships to every core-pack
+adopter.
+
+## Boundaries
+
+The three-tier guard that keeps an implementing agent inside the lines.
+*Always do* applies without asking; *Ask first* requires human sign-off
+before proceeding; *Never do* is a hard rule, even under time pressure.
+
+### Always do
+
+- Edit the **source** `packs/core/.apm/skills/work-loop/SKILL.md`, then run
+  `make build-self` to regenerate the projected copy (`.claude/skills/work-loop/SKILL.md`).
+  Never edit the projection directly.
+- Run **all** lint surfaces before declaring done: `make build-check` (includes
+  `lint-packs`), `python tools/lint-agent-artifacts.py` (projection lint, not in
+  build-check), and `python tools/lint-agents-md.py` (AGENTS.md hygiene) — the
+  same three surfaces the `work-loop-light-mode` spec established for a core
+  SKILL.md prose change.
+- Keep P1 (the verification-mechanism preflight) **universal across both light
+  and full mode** — it is one sentence and cheap; only the heavier P2 infra
+  flavor and P5 mandatory-security wiring are full-mode-only (they fire on the
+  destructive/irreversible trigger that already routes `apply` to full mode).
+- Write **every** infra-flavor sentence tool-neutral — Terraform / Pulumi / CDK
+  / CloudFormation / hand-rolled scripts alike. Illustrative examples are
+  labelled as illustrative, never normative (Principle 1).
+- Express the P1 infra mechanism as a **multi-artifact set, each its own
+  task-zero**: a verify-status script, a teardown script, test-data / mock-user
+  seeding, and a provider-appropriate policy-as-code/CSPM scanner — and name the
+  scanner as the per-provider-depth source that feeds *both* P2's static
+  preflight and P5's security depth.
+- Cross-link P2's verification flavor to the plan template's existing
+  `## Rollout` section (which owns *deployment sequencing*); the flavor owns
+  *how we verify*. Cross-link, never duplicate.
+- Bump the `core` pack version (`packs/core/pack.toml` + the projected
+  `marketplace.json` via `make build-self`) and add a `docs/product/changelog.md`
+  `[Unreleased]` entry for the behavior change.
+
+### Ask first
+
+- **Adding, dropping, or reordering any risk trigger.** RFC-0041 adds **no new
+  trigger** (destructive/irreversible already routes `apply` to full mode);
+  if implementation seems to need one, stop and surface it.
+- **Introducing any executable code, script, or hook** as the feature mechanism
+  — Decision 1 / ADR-0031 forbid it; surface before adding.
+- Expanding scope to any skill other than `work-loop`, or editing
+  `loop-cohort.py` / `lint-spec-status.py` (frozen byte-unchanged by this spec).
+
+### Never do
+
+- **Ship any executable infra tooling** — no deploy wrapper, plan-parser,
+  cost-gate, or runtime. This spec ships doctrine + prose only (ADR-0031); the
+  loop *offers to scaffold* the P1 task-zero artifacts but does not ship them.
+- **Bind P2's infra-flavor prose to a specific IaC tool** (Principle 1).
+- **Make the infra security pass skippable** — P5 is non-skippable, runs at both
+  spec stage and on the diff, and force-loads more than one `security-checklists`
+  module (Decision 6).
+- Edit the projected copy (`.claude/skills/work-loop/SKILL.md`) directly —
+  `make build-self` reverts it; the source is the fix point.
+
+## Testing Strategy
+
+This change is agent-instruction prose in one SKILL.md — no executable logic —
+so verification is **goal-based** plus **judgmental review**, with no TDD
+(nothing carries a compressible invariant). This mirrors the verification
+strategy the `work-loop-light-mode` spec used for the same class of change.
+
+- **Projection correctness** (source → projected path agree after build-self):
+  goal-based — `make build-self` then the drift/projection gates are clean.
+- **Lint conformance**: goal-based — `make build-check`,
+  `tools/lint-agent-artifacts.py`, and `tools/lint-agents-md.py` all exit 0.
+- **Content presence/absence** (P1 obligation present and marked universal; the
+  infra/deploy flavor and its five layers present; P4 agent-drives doctrine
+  present; P5 mandatory-security wiring present; *no* executable code added;
+  `loop-cohort.py` / `lint-spec-status.py` byte-unchanged): goal-based —
+  `grep` / `git diff` checks.
+- **Doctrine correctness** (does the prose actually *obligate* the mechanism,
+  *sequence* the layered GATES with idempotent apply as a precondition, and
+  *force-load* the security modules at both stages?): judgmental — the spec-mode
+  and diff-mode `adversarial-reviewer` pass, since prose has no mechanical test.
+  Because the subject is a security boundary, a `security-reviewer` spec-stage
+  read confirms P5's controls are specified as acceptance criteria at the right
+  depth.
+
+## Acceptance Criteria
+
+- [ ] **P1 — generalized preflight.** The PLAN verification-mode step states that
+  picking a verification mode requires confirming the mechanism for that mode
+  exists; if it does not, creating it is **task zero** (a precondition task, not
+  an afterthought), and the loop offers to scaffold it. The obligation is
+  explicitly **agnostic** (it applies to a missing test runner or build command
+  as much as a missing smoke check) and explicitly **universal across light and
+  full mode**.
+- [ ] **P1 — infra multi-artifact set.** For infra work the preflight enumerates
+  the mechanism as a multi-artifact set, **each its own task-zero**: (a) a
+  verify-status script, (b) a teardown script, (c) test-data / mock-user
+  seeding, and (d) a provider-appropriate policy-as-code/CSPM scanner. The
+  scanner is named as the **per-provider-depth source** and as feeding *both*
+  P2's static preflight (operational misconfig) and P5's security depth
+  (security misconfig). The requirement is **mechanism-level, not tool-level**
+  (a scanner must exist; the adopter picks Checkov / tfsec / cloud-native CSPM).
+- [ ] **P2 — infra/deploy verification flavor.** The PLAN verification-mode list
+  gains a fourth flavor, **infra/deploy**, whose contract is a layered GATES
+  sequence rather than a single check: (1) static preflight (validate/lint/
+  policy-as-code via the P1 scanner); (2) plan/preview (dry-run diff reviewed
+  before any mutation); (3) **idempotent convergent apply, named as a
+  precondition** (re-running after a fix must converge, not collide — imperative
+  non-idempotent scripts flagged as the retry-collision root cause); (4) **active
+  end-to-end smoke** — a multi-hop probe, not a single status check (seed
+  test/mock users → load the real CDN/website URL → assert it actually renders →
+  on failure pull access/error logs and debug → tear down), stated as an
+  extension of the existing visual-manual-QA "exercise the real built artifact"
+  doctrine; (5) rollback (the known-good re-apply path named *before* the first
+  apply, since no atomic rollback exists).
+- [ ] **P2 — cross-link, no duplication.** The infra/deploy flavor cross-links to
+  the plan template's `## Rollout` section (deployment sequencing) and does not
+  duplicate it; the flavor names *how we verify*, Rollout owns *the sequencing*.
+- [ ] **P4 — agent drives verification.** The loop states as harness-agnostic
+  doctrine that the agent runs the deploy and reads the real environment output
+  itself, and names the **human-as-relay** pattern (a human pasting deploy errors
+  back) as the anti-pattern. Claude Code primitives — background tasks for long
+  applies, `asyncRewake` to wake on a background deploy's exit with stderr
+  surfaced, `PreToolUse` to gate destructive commands — are named as
+  **accelerant only, never a dependency** (matching how `/verify` and
+  `/simplify` are treated); adapters without them lose the shortcut, not the
+  doctrine.
+- [ ] **P5 — mandatory infra security.** Infra-flavored work **non-skippably**
+  invokes `security-reviewer` at **both** the spec stage (secure-design pass: is
+  the control specified as an acceptance criterion at the right depth?) and on
+  the diff — not via the discretionary security-boundary trigger. **"Infra-flavored"
+  is the defined signal, not an ad-hoc judgement** (ADR-0031): work the
+  destructive/irreversible risk trigger routes to full mode *and* whose diff/spec
+  matches the boundary→module routing table's IaC/deploy-config entry — so the
+  mandatory pass keys on the existing classifier and cannot be silently skipped
+  on an infra diff. The
+  orchestrator **force-loads** the infra-relevant `security-checklists` modules
+  (`config-misconfig`, `access-control`, `secrets-and-crypto`, `outbound-ssrf`,
+  `supply-chain`), loaded 1–N as the diff warrants per the existing
+  boundary→module routing table. This adds **no new reviewer and no new
+  module** — it makes the *existing* security pass mandatory and multi-module.
+- [ ] **P5 — reviewer + scanner pair.** The prose states that `security-reviewer`
+  is **not** the per-provider depth source: it reasons from cross-cutting
+  standards (OWASP / ASVS / CWE + STRIDE/LINDDUN) and catches failure *classes*,
+  while per-provider secure-config depth comes from the P1-required policy-as-code/
+  CSPM scanner (its rulesets *are* the provider baselines). Security on infra is
+  a **pair**; neither substitutes for the other.
+- [ ] **No executable mechanism.** The change adds no new skill directory, no new
+  artifact/template format, and no executable code as the feature mechanism
+  (ADR-0031 structural constraint). `loop-cohort.py` and `lint-spec-status.py`
+  are byte-unchanged (empty `git diff` for both; the sibling
+  `operational-safety-checklists` spec asserts the same guard — one `git diff`
+  satisfies both in a combined PR).
+- [ ] **Projection + lint.** `make build-self` regenerates the projected
+  `work-loop` SKILL.md cleanly; `make build-check`, `python
+  tools/lint-agent-artifacts.py`, and `python tools/lint-agents-md.py` all pass
+  (the latter two are not in `make build-check`; run by hand / in CI).
+- [ ] **Release hygiene.** `packs/core/pack.toml` version is bumped, the
+  projected `marketplace.json` reflects it after `make build-self`, and
+  `docs/product/changelog.md` carries an `[Unreleased]` entry for the work-loop
+  behavior change.
+
+## Assumptions
+
+- Technical: the `work-loop` skill source is
+  `packs/core/.apm/skills/work-loop/SKILL.md`; the `.claude/...` copy is
+  projected by `build-self`, not edited (source: `ls
+  packs/core/.apm/skills/work-loop/`; precedent: `work-loop-light-mode` spec).
+- Technical: the boundary→module routing table P5 reuses already exists in
+  `work-loop` SKILL.md and already routes "IaC / deploy config" →
+  `config-misconfig`, and the orchestrator already inlines `security-checklists`
+  modules into the `security-reviewer` brief — so P5 is a posture change
+  (discretionary → mandatory, one module → multi-module), not new mechanism
+  (source: RFC-0041 spike result; `security-checklists/SKILL.md` "How it loads").
+- Technical: `make build-check` (= `lint-packs build`) does not run build-self,
+  the projection lint, or the AGENTS hygiene lint; those run by hand / in CI
+  (source: `work-loop-light-mode` spec Assumptions; `Makefile`).
+- Process: P4 (agent-drives-verification, RFC-0041 Decision 5) is a `work-loop`
+  SKILL.md doctrine edit that co-locates with P2's smoke step, so it lands in
+  *this* spec, not `operational-safety-checklists`. RFC-0041's follow-on-artifacts
+  list originally named only P1/P2/P5 here; the **2026-06-23 P4-placement
+  amendment** to RFC-0041 records P4 landing here explicitly, so the `Constrained
+  by:` "(P1, P2, P4, P5)" above reconciles with the RFC rather than silently
+  diverging (source: RFC-0041 Decision 5 + Amendments).
+- Process: this spec and `operational-safety-checklists` **both edit `work-loop`
+  SKILL.md, but at different bullets of the REVIEW "Specialist reviewers" step**
+  — this spec's P5 edits the **`security-reviewer`** bullet (and the PLAN
+  pre-EXECUTE secure-design step + the verification-mode step); the sibling adds
+  its `operational-safety` routing table at the **`quality-engineer`** bullet.
+  The `quality-engineer` bullet is touched by exactly one spec (the sibling); the
+  `security-reviewer` bullet by exactly one (this spec). They land sequentially
+  (this spec first) or in one PR; either way the conflict is small and mechanical
+  (source: the two specs' scopes; `work-loop` SKILL.md "Specialist reviewers"
+  section).
+- Process: decision frozen in ADR-0031 (Accepted) + RFC-0041 (Accepted
+  2026-06-22); the risk-trigger set is unchanged, so no CONVENTIONS/AGENTS
+  risk-trigger edit is expected (confirm at implementation) (source:
+  `docs/adr/0031-…`, `docs/rfc/0041-…`).
+- Product: the infra-aware loop ships in `core` as the adopter-wide default,
+  consistent with how `work-loop-light-mode` shipped (source: RFC-0041 scope;
+  this is a follow-on of an Accepted RFC).

--- a/docs/specs/operational-safety-checklists/plan.md
+++ b/docs/specs/operational-safety-checklists/plan.md
@@ -1,0 +1,224 @@
+# Plan: operational-safety-checklists
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Drafting <!-- Drafting | Executing | Done -->
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn. When it changes substantially
+> (a different approach, not just a re-ordering), note why in the changelog
+> at the bottom.
+
+## Approach
+
+Build a second progressive-disclosure depth library by **copying the proven
+shape** of `security-checklists`, then wire its consumer and routing. The work is
+a new skill directory plus three small prose edits, ordered so the modules exist
+before anything routes to them:
+
+1. **Scaffold the skill** — `packs/core/.apm/skills/operational-safety/SKILL.md`
+   (front matter + "How it loads" + the reliability-vs-security carve) and the
+   six `references/*.md` modules, each grounded per the RFC-0041 module table and
+   written tool-neutral.
+2. **Add the routing table** to `work-loop` SKILL.md so the orchestrator loads
+   matching modules on the infra/destructive trigger and inlines them into the
+   `quality-engineer` brief.
+3. **Wire the consumer** — a one-line note in `quality-engineer.md` that it
+   consumes orchestrator-inlined `operational-safety` depth (mirroring how
+   `security-reviewer` consumes `security-checklists`).
+4. **Add the deferred-authority pointer** to `security-checklists`'
+   `config-misconfig.md` (URL-free, version-free) and state the carve in both
+   skills.
+5. **Manifest + projection** — exclude `operational-safety` from `[pack.evals]`,
+   bump `core`, `make build-self`, run the three lint surfaces, changelog.
+
+The riskiest part is **content discipline, not mechanism**: keeping the six
+modules MECE (especially the deliberate `state-and-idempotency` ÷
+`drift-and-rollback` split), tool-neutral, and on the reliability side of the
+carve — the `quality-engineer` read at REVIEW is the lens-fit check. The
+mechanism itself is a known-good copy of `security-checklists`. Verification is
+goal-based (structure, wiring presence, pointer hygiene, projection, lint) +
+judgmental (carve correctness, tool-neutrality). No production test file.
+
+## Constraints
+
+- **ADR-0031** — operational safety → `quality-engineer` (no new reviewer);
+  doctrine + reference library only, no executable code; the
+  reliability-vs-security carve against `security-checklists`.
+- **RFC-0041** — six modules exactly (Decision 4); state/drift kept separate;
+  observability the sixth; the URL-free deferred-authority pointer.
+- **ADR-0018** — the orchestrator-loaded progressive-disclosure mechanism this
+  reuses; the routing is table-driven, reused as-is for a second library.
+- **ADR-0023** — three-reviewer ceiling; `quality-engineer` is the consumer.
+- **`security-checklists`** — the structural template; mirror its SKILL.md
+  sections and `references/` shape rather than inventing a new one.
+
+## Construction tests
+
+Per-task checks live under each task's `Tests:` subsection (goal-based or
+judgmental — no production test file). Cross-cutting:
+
+**Integration tests:** none beyond per-task checks.
+**Manual verification:** after `make build-self`, confirm `.claude/skills/
+operational-safety/` is projected with all six modules, and read the
+`work-loop` routing table + `quality-engineer` note in their projected form to
+confirm they reference the library coherently.
+
+## Design (LLD)
+
+n/a — a new prose reference-library skill plus prose wiring edits. No application
+LLD; the module taxonomy (the "design") is fully specified by the spec's
+Acceptance Criteria and grounded in the RFC-0041 module table. The skill's
+structure is a deliberate mirror of `security-checklists`, not a fresh design.
+
+## Tasks
+
+### T1: Scaffold the `operational-safety` skill (SKILL.md + six modules)
+
+**Depends on:** none
+
+**Tests:**
+- `ls packs/core/.apm/skills/operational-safety/references/` returns exactly the
+  six named files (spec AC: six modules, exact names).
+- `grep` SKILL.md for the front-matter `description`, the "How it loads
+  (orchestrator-driven, not self-discovered)" section, and the
+  reliability-vs-security carve (spec AC: skill exists, mirrors the pattern;
+  carve stated).
+- Each module carries a greppable `> **Grounded in:**` line naming its RFC-table
+  groundings, `grep`s for its coverage terms, and contains no tool-specific
+  normative sentence (illustrative examples labelled) (spec AC: grounded
+  greppably + tool-neutral).
+- `drift-and-rollback.md` `grep`s for the unresolved auto-remediation tension
+  (gate-it vs auto-sync), surfaced not resolved (spec AC: six modules —
+  drift-and-rollback).
+
+**Approach:**
+- Copy the `security-checklists/SKILL.md` skeleton; rewrite the `description`,
+  "How it loads", carve, and the three-bucket legend for the operational lens.
+- Author the six modules from the RFC-0041 module table and `0041-notes/
+  research.md` groundings (F1.2/F1.3, F3.1/F3.2, F3.3, F3.4/F3.5, F1.4/F2.6, and
+  the observability follow-up). Keep `state-and-idempotency` (write-path
+  convergence) distinct from `drift-and-rollback` (divergence detection +
+  recovery).
+
+**Done when:** the six files exist; SKILL.md mirrors the security-checklists
+shape; no module binds to one IaC tool; no executable code is present.
+
+### T2: Add the `operational-safety` routing table to `work-loop` SKILL.md
+
+**Depends on:** T1 (the table routes to modules that must already exist)
+
+**Tests:**
+- `grep` `work-loop` SKILL.md for the `operational-safety` boundary→module
+  routing table and confirm it instructs loading 1–N matching modules (never a
+  flat march of all six) into the `quality-engineer` brief on the
+  infra/destructive trigger (spec AC: routing table).
+
+**Approach:**
+- Mirror the existing `security-checklists` boundary→module table; add it at the
+  REVIEW `quality-engineer` dispatch (and the orchestrator-loads description), so
+  the operational depth loads the way the security depth already does.
+
+**Done when:** the grep matches; the table coexists with the security routing
+table without duplicating it; this edit targets the **`quality-engineer`** bullet
+of the REVIEW "Specialist reviewers" step — distinct from `infra-aware-work-loop`'s
+P5 edit to the **`security-reviewer`** bullet of the same step (see Risks).
+
+### T3: Wire `quality-engineer` as the consumer
+
+**Depends on:** T1
+
+**Tests:**
+- `grep` `quality-engineer.md` for the one-line note that it consumes
+  orchestrator-inlined `operational-safety` depth without self-discovering the
+  skill (spec AC: consumer wiring).
+
+**Approach:**
+- Add a single note to `quality-engineer.md` mirroring how the agent already
+  relates to its inputs; do **not** rewrite its review checklists (out of scope).
+
+**Done when:** the grep matches; the note states `quality-engineer` is the
+consumer and no new reviewer is introduced; the rest of the agent is unchanged.
+
+### T4: Deferred-authority pointer in `config-misconfig` + carve both ways
+
+**Depends on:** T1
+
+**Tests:**
+- `grep` `security-checklists/references/config-misconfig.md` for the
+  pointer naming CIS Benchmarks + the three providers' well-architected security
+  guidance by document name (spec AC: deferred-authority pointer).
+- `grep` the added block for `http`, `www`, or a version pattern → **no match**
+  (spec AC: pointer hygiene; spec Testing Strategy).
+- Confirm the reliability-vs-security carve is stated in both
+  `operational-safety` and `security-checklists` (spec AC: carve stated both ways).
+
+**Approach:**
+- Add the thin pointer to `config-misconfig.md`, naming stable publisher +
+  document only and noting the real depth lives in the self-updating scanner.
+- State the carve in `security-checklists` SKILL.md (it already scopes itself to
+  security; add the one-line "operational config → `operational-safety`" pointer)
+  and in `operational-safety` SKILL.md (the converse).
+
+**Done when:** both greps match; the no-URL/no-version grep is empty; the carve
+reads symmetrically in both skills.
+
+### T5: Eval exclusion, build-self, lint surfaces, version bump, changelog
+
+**Depends on:** T1-T4
+
+**Tests:**
+- `packs/core/pack.toml` `[pack.evals]` excludes `operational-safety` with a
+  naming comment (spec AC: eval exclusion).
+- `make build-self` exits 0 and projects `.claude/skills/operational-safety/`
+  with all six modules; `git status` shows no unexpected reverts.
+- `make build-check`, `python tools/lint-agent-artifacts.py`, and `python
+  tools/lint-agents-md.py` all exit 0 (spec AC: projection + lint).
+- `git diff` shows `loop-cohort.py` / `lint-spec-status.py` byte-unchanged (spec
+  AC: no executable mechanism).
+- `core` version bumped; `marketplace.json` reflects it; `docs/product/
+  changelog.md` `[Unreleased]` entry present (spec AC: release hygiene).
+
+**Approach:**
+- Add the `[pack.evals]` exclusion comment. Bump `core`. `make build-self`. Add
+  the changelog entry. Run the three lint surfaces by hand.
+
+**Done when:** all gates green; projection clean; manifest + changelog updated.
+
+## Rollout
+
+- **Delivery:** big-bang prose addition, fully reversible (delete the skill dir +
+  revert the three wiring edits + version bump). Nothing irreversible.
+- **Infrastructure:** none.
+- **External-system integration:** none.
+- **Deployment sequencing:** land `infra-aware-work-loop` first (or both in one
+  PR) — both edit `work-loop` SKILL.md; this spec's routing-table edit is cleaner
+  to apply once the infra-flavor prose exists. The `operational-safety` modules
+  (T1) must exist before the routing table (T2) references them.
+
+## Risks
+
+- **Co-edit collision with `infra-aware-work-loop`.** Both specs edit `work-loop`
+  SKILL.md at the REVIEW "Specialist reviewers" step, but at **different bullets**:
+  this spec adds its routing table at the **`quality-engineer`** bullet; the
+  sibling's P5 edits the **`security-reviewer`** bullet (plus the verification-mode
+  step and the PLAN pre-EXECUTE secure-design step). Each bullet is touched by
+  exactly one spec. Mitigation: sequence (the sibling first) or single PR; the
+  conflict is small and mechanical.
+- **Carve blur.** Security config drifting into an operational module, or
+  reviewers confused about who owns IaC config. Mitigation: the carve is stated
+  in both skills' front matter + the routing table; the `quality-engineer` read
+  at REVIEW is the lens-fit check.
+- **Over-segmentation** — six modules tempt a reviewer to skip some. Mitigation:
+  the orchestrator loads 1–N by routing, never all six; the RFC's taxonomy
+  follow-up justifies each as a distinct failure-mode family.
+- **Pointer rot.** Mitigation: publisher + document name only, no URL/version;
+  the real depth lives in the self-updating scanner, so a stale name never gates
+  a real check.
+- **Tool-specific drift** in a module. Mitigation: examples labelled
+  illustrative; adversarial pass checks for stack-binding.
+
+## Changelog
+
+- 2026-06-23: initial plan (follow-on to Accepted RFC-0041; authored alongside
+  ADR-0031 and the `infra-aware-work-loop` spec in a docs-only PR; implementation
+  is a separate later PR).

--- a/docs/specs/operational-safety-checklists/spec.md
+++ b/docs/specs/operational-safety-checklists/spec.md
@@ -1,0 +1,207 @@
+# Spec: operational-safety-checklists
+
+- **Status:** Draft <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** ADR-0031, RFC-0041 (P3 + the deferred-authority pointer); ADR-0018 (orchestrator-loaded progressive-disclosure depth library — the `security-checklists` pattern this mirrors); ADR-0023 (the three-reviewer ceiling — why this feeds `quality-engineer`, not a new reviewer); ADR-0017 (the SAST/SCA scanner family the deferred-authority pointer complements)
+- **Brief:** none
+- **Contract:** none
+- **Shape:** n/a — new reference-library skill (prose modules) + prose wiring edits; no application LLD
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+Agents and adopters running the `core` pack get an **`operational-safety`
+reference library** — a new skill of boundary-keyed `references/*.md` modules,
+structurally identical to `security-checklists` — that gives infrastructure work
+an operational-safety depth library the **existing `quality-engineer` reviewer**
+reasons from. When the work-loop orchestrator detects infra/destructive work it
+loads only the matching modules and inlines them into the `quality-engineer`
+brief, via the same table-driven mechanism it already uses for
+`security-checklists` — so idempotency, blast radius, environment isolation,
+cost/teardown, drift/rollback, and observability/smoke get first-class reviewer
+depth **without a fourth reviewer** (ADR-0023). The skill carries **six** modules
+(MECE along operational failure mode), a routing-table entry in `work-loop`
+SKILL.md, a one-line consumer note in `quality-engineer.md`, and a URL-free,
+version-free deferred-authority pointer added to `security-checklists`'
+`config-misconfig` module. The change adds **no executable code**: the modules
+are prose the reviewer reasons from, exactly as the security depth library is.
+
+## Boundaries
+
+The three-tier guard that keeps an implementing agent inside the lines.
+*Always do* applies without asking; *Ask first* requires human sign-off
+before proceeding; *Never do* is a hard rule, even under time pressure.
+
+### Always do
+
+- Place the new skill at `packs/core/.apm/skills/operational-safety/`
+  (source), mirroring `security-checklists`' structure: a `SKILL.md` with a
+  front-matter `description`, a "How it loads (orchestrator-driven, not
+  self-discovered)" section, the carve statement, and a `references/` directory
+  of six module files. Then `make build-self` to project it to
+  `.claude/skills/operational-safety/`.
+- Name the six module files exactly: `state-and-idempotency.md`,
+  `blast-radius.md`, `environment-isolation.md`, `cost-and-teardown.md`,
+  `drift-and-rollback.md`, `observability-and-smoke.md`.
+- Write **every** module tool-neutral; illustrative examples are labelled
+  illustrative, never normative (Principle 1).
+- State the **reliability-vs-security carve** in both skills' front matter /
+  bodies: `security-checklists` owns *security* config; `operational-safety` owns
+  *reliability/ops* config. The routing assigns IaC-security → `config-misconfig`,
+  IaC-reliability → `operational-safety`.
+- Exclude `operational-safety` from `[pack.evals]` in `packs/core/pack.toml` and
+  add a comment naming it as deliberately excluded (reviewer-internal, never
+  self-discovered — exactly as `security-checklists` is excluded).
+- Run **all** lint surfaces before declaring done: `make build-check`,
+  `python tools/lint-agent-artifacts.py`, `python tools/lint-agents-md.py`.
+- Bump the `core` pack version (`pack.toml` + projected `marketplace.json` via
+  `make build-self`) and add a `docs/product/changelog.md` `[Unreleased]` entry.
+
+### Ask first
+
+- **Merging any `operational-safety` module with a `security-checklists`
+  module**, or moving content across the carve — the reliability-vs-security
+  split is load-bearing; surface before blurring it.
+- **Adding a seventh module** beyond the six RFC-0041 fixed — surface the case.
+- Editing `quality-engineer.md` beyond the one consumer note (its review
+  checklists are out of scope; the modules supply depth, they don't rewrite the
+  agent).
+
+### Never do
+
+- **Ship executable code in the skill** — the modules are prose the reviewer
+  reasons from (ADR-0031); no scripts, no runtime.
+- **Bind any module to a specific IaC tool** (Principle 1).
+- **Put a URL or a version number in the deferred-authority pointer** — it names
+  the stable publisher + document only (CIS Benchmarks; the per-provider
+  well-architected security guidance), kept evergreen by naming not linking; the
+  actual depth lives in the self-updating scanner, not the pointer.
+- **Duplicate security config into `operational-safety`**, or migrate operational
+  config out of where it correctly lives — the carve stays clean both ways.
+
+## Testing Strategy
+
+This change is a new prose skill plus prose wiring edits — no executable logic —
+so verification is **goal-based** plus **judgmental review**, with no TDD. This
+mirrors how `security-checklists` and `work-loop-light-mode` were verified.
+
+- **Skill structure** (the skill exists at the source path; six module files
+  present with the exact names; SKILL.md mirrors the `security-checklists` shape):
+  goal-based — `ls` / `grep`.
+- **Wiring presence** (the `operational-safety` routing table is in `work-loop`
+  SKILL.md; the `quality-engineer.md` consumer note is present; the
+  deferred-authority pointer is in `config-misconfig.md`): goal-based — `grep`.
+- **Deferred-authority pointer hygiene** (no URL, no version string in the
+  pointer): goal-based — `grep` for `http`/`www`/version patterns in the added
+  block returns nothing.
+- **Carve correctness** (no security config duplicated into `operational-safety`;
+  no operational config in `security-checklists` beyond `config-misconfig`'s
+  scope; each module is a distinct operational failure-mode family): judgmental —
+  the adversarial pass plus a `quality-engineer` read (the consumer of the
+  library) checking lens-fit.
+- **Tool-neutrality**: judgmental — adversarial pass checks for stack-binding.
+- **Projection + lint**: goal-based — `make build-self` clean; the three lint
+  surfaces exit 0.
+
+## Acceptance Criteria
+
+- [ ] **Skill exists, mirrors the pattern.** `packs/core/.apm/skills/
+  operational-safety/SKILL.md` exists with a front-matter `description`, a "How
+  it loads (orchestrator-driven, not self-discovered)" section stating the
+  orchestrator loads matching modules and inlines them into a reviewer's brief
+  (the subagent never self-discovers the skill), and the reliability-vs-security
+  carve. It is a depth library, **not** a reviewer prompt.
+- [ ] **Six modules, exact names, MECE by failure mode.** `references/` holds
+  exactly six files — `state-and-idempotency.md` (convergent re-apply, state
+  locking, single-writer), `blast-radius.md` (parse-plan destroy/replace gating,
+  `prevent_destroy`, proposer≠approver for destructive ops), `environment-isolation.md`
+  (throwaway/staging vs prod, separate state/accounts), `cost-and-teardown.md`
+  (cost-ceiling-as-gate, destroy-on-fail, TTL, no orphans), `drift-and-rollback.md`
+  (read-only drift detection, known-good re-apply path, and — per ADR-0031 and
+  RFC-0041 F1.4 — recording the **auto-remediation default as an unresolved
+  tension**: gate-it, per the Terraform community, vs auto-sync, per GitOps; the
+  module surfaces the tension, it does not pick a side), and
+  `observability-and-smoke.md` (active end-to-end probe — load real URL, assert
+  render — access/error-log access, health endpoints, the verify-status signal,
+  log-driven debugging). `state-and-idempotency` and `drift-and-rollback` are
+  **kept separate** (write-path convergence vs divergence-detection/recovery),
+  and observability is its own sixth module.
+- [ ] **Each module grounded (greppably) and tool-neutral.** Each module carries
+  a `> **Grounded in:**` line near its top naming the RFC-0041 module-table
+  groundings it rests on (the relevant F-citations and taxonomy sources — e.g.
+  AWS Well-Architected, Google SRE, the Terraform/Pulumi Day-1/Day-2 split),
+  mirroring how each `security-checklists` module carries a `> **Standards:**`
+  line — so grounding is mechanically checkable (grep), not merely asserted.
+  Every module is written tool-neutral; illustrative examples are labelled
+  illustrative, never normative.
+- [ ] **Routing table in `work-loop` SKILL.md.** `work-loop` SKILL.md gains an
+  `operational-safety` boundary→module routing table (mirroring the existing
+  `security-checklists` routing table) so the orchestrator loads 1–N matching
+  modules on the infra/destructive trigger and inlines them into the
+  `quality-engineer` brief — never a flat march of all six.
+- [ ] **`quality-engineer` consumer wiring.** `quality-engineer.md` carries a note
+  that it consumes orchestrator-inlined `operational-safety` depth (mirroring how
+  `security-reviewer` consumes `security-checklists`), without self-discovering
+  the skill — `quality-engineer` remains the consumer; **no new reviewer** is
+  added (ADR-0023).
+- [ ] **Deferred-authority pointer in `config-misconfig`.** `security-checklists`'
+  `config-misconfig.md` gains a thin pointer naming the standing authorities —
+  **CIS Benchmarks** and each provider's well-architected security guidance (AWS
+  Well-Architected Security Pillar; Microsoft Cloud Adoption Framework / Azure
+  Well-Architected Security; Google Cloud Architecture Framework Security) —
+  **by stable publisher + document name, with no URL and no version**, and noting
+  the actual per-provider depth lives in the self-updating scanner.
+- [ ] **Carve stated both ways.** The reliability-vs-security carve is stated in
+  both `operational-safety` and `security-checklists` (front matter / body): the
+  security library owns security config; the operational library owns
+  reliability/ops config; the routing splits IaC-security → `config-misconfig`,
+  IaC-reliability → `operational-safety`. No security config is duplicated into
+  `operational-safety`.
+- [ ] **Eval exclusion.** `operational-safety` is excluded from `[pack.evals]` in
+  `packs/core/pack.toml`, with a comment naming it as reviewer-internal / never
+  self-discovered (mirroring the `security-checklists` exclusion).
+- [ ] **No executable mechanism.** The skill ships prose only — no scripts, no
+  runtime. `loop-cohort.py` and `lint-spec-status.py` are byte-unchanged.
+- [ ] **Projection + lint + release hygiene.** `make build-self` projects the new
+  skill to `.claude/skills/operational-safety/` cleanly; `make build-check`,
+  `python tools/lint-agent-artifacts.py`, and `python tools/lint-agents-md.py`
+  all pass; `packs/core/pack.toml` version is bumped and `marketplace.json`
+  reflects it; `docs/product/changelog.md` `[Unreleased]` carries an entry.
+
+## Assumptions
+
+- Technical: `security-checklists` lives at
+  `packs/core/.apm/skills/security-checklists/` (SKILL.md + ten `references/*.md`)
+  and its SKILL.md already documents the orchestrator-loads-not-self-discovered
+  mechanism and the boundary→module routing table in `work-loop` SKILL.md —
+  `operational-safety` mirrors this exactly (source: `ls` +
+  `security-checklists/SKILL.md` "How it loads").
+- Technical: skills are **directory-discovered**, not enumerated in a manifest
+  array — adding `operational-safety/` under the pack and running `make
+  build-self` projects it; the only manifest touch is the `[pack.evals]`
+  exclusion comment and the version bump (which drifts the projected
+  `marketplace.json`) (source: `packs/core/pack.toml` `[pack.evals]` comment
+  block naming `security-checklists` as excluded; no `skills = [...]` array
+  beyond the evals allowlist).
+- Technical: `quality-engineer` source is `packs/core/.apm/agents/
+  quality-engineer.md`, and its existing lens already carries Observability and
+  Reliability checklists — so the `operational-safety` modules supply depth to an
+  existing lens, not a new persona (source: read `quality-engineer.md`).
+- Technical: `make build-check` does not run build-self, the projection lint, or
+  the AGENTS hygiene lint; those run by hand / in CI (source:
+  `work-loop-light-mode` spec Assumptions).
+- Process: this spec and `infra-aware-work-loop` **both edit `work-loop`
+  SKILL.md** — this one adds the `operational-safety` routing table, the other
+  edits the verification-mode step + security wiring. Land them sequentially
+  (`infra-aware-work-loop` first) or in one PR to avoid a co-edit collision
+  (source: the two specs' scopes; RFC-0041 Follow-on artifacts).
+- Process: decision frozen in ADR-0031 (Accepted) + RFC-0041 (Accepted
+  2026-06-22); the module taxonomy (six, with state/drift kept separate and
+  observability sixth) was resolved by the RFC's follow-up research (source:
+  `docs/rfc/0041-…` Decision 4 + `0041-notes/research.md` § Follow-up research).
+- Product: the library ships in `core` and is consumed by `quality-engineer` for
+  every adopter, dormant until the infra/destructive trigger fires (source:
+  RFC-0041 Decision 4).


### PR DESCRIPTION
Follow-on artifacts for **Accepted RFC-0041** (make `work-loop` function for infrastructure development). **Docs-only** — the `work-loop` SKILL.md edits and the new `operational-safety` skill land in a separate implementing PR.

## What this does
- **ADR-0031** — records the expensive-to-reverse decisions: doctrine + a reference library, *never* executable infra tooling; operational safety consumed by the existing **`quality-engineer`** (no new reviewer — three-reviewer ceiling, ADR-0023); security on infra is a **mandatory, non-skippable `security-reviewer` + policy-as-code/CSPM scanner *pair***. Enforcement posture named as review-time (not a CI gate), with an optional governance lint flagged as a follow-up, not a requirement.
- **`docs/specs/infra-aware-work-loop`** — P1 multi-artifact verification-mechanism preflight · P2 layered infra/deploy verification flavor · P4 agent-drives-verification · P5 mandatory-security wiring. "Infra-flavored" is a **defined signal** (the destructive/irreversible trigger + the IaC/deploy-config routing entry), not an ad-hoc judgement.
- **`docs/specs/operational-safety-checklists`** — six-module reference library (`security-checklists` shape), the `work-loop` routing table at the `quality-engineer` bullet, `quality-engineer` consumer wiring, and the URL-free/version-free deferred-authority pointer in `config-misconfig`.
- **RFC-0041** — additive, Approver-signed amendment recording P4's placement in the infra-aware spec (the follow-on list originally named only P1/P2/P5).

## Judgment calls (approved)
- **P4 placement** recorded as a frozen-RFC amendment rather than absorbed silently.
- **Two specs co-edit `work-loop/SKILL.md`** at *different bullets* of the REVIEW "Specialist reviewers" step (P5 → `security-reviewer`; operational-safety → `quality-engineer`); both plans name the disjoint anchors. **Land `infra-aware-work-loop` first**, or both in one PR.
- **Review-time enforcement posture** accepted as a named residual (matching ADR-0030), optional lint as follow-up.

## Work-loop
Full mode (governance + multi-feature). GATES: `lint-spec-status.py` clean. REVIEW: `adversarial-reviewer` → Clean (after one fix iteration); `design-reviewer` → SHIP WITH CHANGES, all majors addressed. Both specs `Status: Draft`; version bump / changelog / `build-self` are the *implementing* PR's acceptance criteria.

## Deferred
- ADR title length and Related/References density (design-reviewer nits) — left consistent with the ADR-0030 precedent.
- A standing fitness-function lint for the anti-tooling invariant — recorded in ADR-0031 Confirmation as an optional follow-up.

## Test plan
- [x] `lint-spec-status.py --root .` — spec metadata clean (no warnings from either new spec)
- [x] `adversarial-reviewer` (spec/plan-review) — Clean
- [x] `design-reviewer` (ADR) — SHIP WITH CHANGES, addressed