### PR TITLE
feat: consolidated agentbundle-layout.toml — three pack consumers + installer append (RFC-0040)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "architect",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.6.1"
+      "version": "0.7.0"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",
@@ -187,7 +187,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "product-engineering",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.4.2"
+      "version": "0.5.0"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",
@@ -204,7 +204,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "research",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.4.0"
+      "version": "0.5.0"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -246,6 +246,17 @@ jobs:
           tests/unit/test_enriched_pack_metadata.py
           tests/integration/test_list_packs_cmd.py
 
+      # consolidated-pack-layout (RFC-0040): the installer _append_layout_section
+      # construction tests (never-create / never-overwrite / injection-safe emit
+      # incl. the table header / re-emit type-validation / per-scope write-jail /
+      # symlink-fails-closed) live in tests/unit, which `make build-check` does not
+      # run. Wire it in explicitly or it never gates (CI does not auto-discover
+      # package pytest). The [pack.layout] schema + contract-version 0.16 assertions
+      # for this change ride the test_pack_schema.py / test_contract.py steps above.
+      - name: pytest consolidated-pack-layout installer append (RFC-0040)
+        working-directory: packages/agentbundle
+        run: python -m pytest tests/unit/test_append_layout_section.py
+
       # core work-loop activation hook (work-loop-activation-hook spec): the
       # kiro-ide-hook validate rail + real-pack projection + hook-body invocation
       # gate only here — make build-check / lint-packs / the make validate target

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@
 # *is* the scope (repo-scope marker only here — user-scope marker
 # lives inside ~/.agentbundle/, outside any repo).
 .adapt-install-marker.toml
+# Adopter-owned pack-output layout file (RFC-0040). A contributor who
+# exercises a consumer skill (research / architect / product-engineering)
+# in this catalogue may hand-write one at the repo root; it must never be
+# committed (and would otherwise trip the self-host drift gate).
+agentbundle-layout.toml
 
 # Work-loop session state — per-spec scratch, never committed.
 docs/specs/**/state.json

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -899,3 +899,16 @@ disposable **test backend / sandbox tenant** with broker-provisioned test
 credentials. **Unblocks when:** the full Tier-B grading RFC (LLM-judge / deltas)
 takes this on, or a maintainer wants backend-skill behavior coverage sooner; it
 is out of scope for the lightweight B-lite check.
+
+### layout-append-user-scope-no-op-dir-side-effect
+
+**Spec:** [consolidated-pack-layout](specs/consolidated-pack-layout/spec.md) (T2,
+diff-stage security-review Nit). In `_append_layout_section` at user scope,
+`safety.user_state_path(home=root)` runs (creating/probing `~/.agentbundle/` at
+0o700) *before* the `layout_path.exists()` never-create check, so a pack with no
+user-scope layout file triggers the dot-directory creation even on the no-op
+path. **Harmless today** — the marker append (`_append_install_marker`) creates
+the same directory on the same install — so it is a wasted side-effect, not a
+correctness or security defect. **Unblocks when:** someone wants the
+micro-optimization; fix by computing `layout_path` lazily or probing existence
+before the `user_state_path` call.

--- a/docs/contracts/adapter.toml
+++ b/docs/contracts/adapter.toml
@@ -77,7 +77,14 @@
 # the default agent's `.kiro/skills` auto-discovery (RFC-0022 E4; kiro
 # #6887/#6888/#4993). Additive `inject-resources` on BOTH the kiro-cli and
 # kiro-ide agent projections (CLI → agent JSON, IDE → quoted .md frontmatter).
-version = "0.15"
+# RFC-0040 / ADR-0030 / docs/specs/consolidated-pack-layout (v0.16): pack.toml
+# gains an optional scope-keyed [pack.layout] table (optional .repo / .user
+# sub-tables, each a `parent` base and/or a within-pack template-path) naming
+# where a consuming pack's durable output lands. Consumed by the new installer
+# `_append_layout_section` step (append-if-exists / never-create / never-
+# overwrite) into an adopter-owned `agentbundle-layout.toml`. Additive +
+# optional — packs pinned below v0.16 build and validate unchanged.
+version = "0.16"
 
 # Sibling schemas this contract references — pack metadata and the
 # per-pack Claude-plugin manifest. Defined by spec AC #3 + #4.

--- a/docs/contracts/pack.schema.json
+++ b/docs/contracts/pack.schema.json
@@ -131,6 +131,25 @@
             "type": "string",
             "pattern": "^[^/].*"
           }
+        },
+        "layout": {
+          "type": "object",
+          "properties": {
+            "repo": {
+              "type": "object",
+              "properties": {
+                "parent": {"type": "string"},
+                "template": {"type": "string"}
+              }
+            },
+            "user": {
+              "type": "object",
+              "properties": {
+                "parent": {"type": "string"},
+                "template": {"type": "string"}
+              }
+            }
+          }
         }
       },
       "if": {

--- a/docs/guides/architect/reference/reference-architecture.md
+++ b/docs/guides/architect/reference/reference-architecture.md
@@ -37,6 +37,21 @@ A `reference.md` can be authored by hand, proposed by the `adapt-to-project` har
 
 A consequence of the first two clauses: **no bundler override field exists or is needed.** The sole-producer case has nothing to collide with, and the two-producer case is handled by the existing `.upstream` companion plus merge — so there is no "this pack's `reference.md` wins" switch to configure.
 
+## Where design docs land
+
+Each `architect-design` effort now lands in its own **per-effort folder**
+`<parent>/<topic-slug>/` — the design doc, diagrams, and notes all go inside it
+rather than as a loose file. The base `<parent>` defaults to `docs/design` and
+can be overridden by the `[architect]` table of an adopter-created
+`agentbundle-layout.toml` (repo-root overrides user-profile per table). When no
+`[architect]` section resolves, the skill falls back to scanning `docs/design/`,
+`design/`, `architecture/`, `docs/` in order and asking if none exists.
+
+For the full schema — two-location read, anchor rules, realpath/`..`-rejection,
+surface-before-write, and the untrusted-origin posture — see the
+`agentbundle-layout.md` schema doc that ships in the `architect-design` skill's
+`references/` directory.
+
 ## See also
 
 - [Foundation vs. map](../../core/explanation/foundation-vs-map.md) — why `reference.md` is normative and `overview.md` is descriptive.

--- a/docs/guides/product-engineering/reference/intent-fields-and-modes.md
+++ b/docs/guides/product-engineering/reference/intent-fields-and-modes.md
@@ -42,6 +42,18 @@ At `business-unit` Scale the feature intent is sliced per component into one `co
 
 The hard limits are stated honestly: **no atomic cross-repo commit**, **no shared release train**, and the rollup is a **snapshot, not a live feed**. See the how-to *Run a capability across a value stream*.
 
+## Output locations — config-driven, `docs/product` by default
+
+`frame-intent` writes intents to `<parent>/intents/<slug>.md` and
+`align-value-stream` writes rollups to `<parent>/rollups/<slug>.md`. Both resolve
+`parent` from the `[product-engineering]` table of an adopter-created
+`agentbundle-layout.toml` (repo-root file overrides user-profile file per table;
+default `docs/product` when no section resolves). Each intent and rollup is a
+single file — a per-topic folder is deliberately not used. Full schema and
+anchor/security-rail details are in each skill's
+`references/agentbundle-layout.md`. `decompose-intent`'s
+`docs/product/briefs/<slug>.md` output is pinned and not governed by this config.
+
 ## Contract maturity by stage
 
 The detailed wire contract is pinned at the **spec** stage, not at intent.

--- a/docs/guides/research/README.md
+++ b/docs/guides/research/README.md
@@ -18,7 +18,7 @@ New here? Walk [your first research session](tutorials/research-first-session.md
 
 ## Reference
 
-- [Research pack reference](reference/research-pack.md) — every skill (episodic and project), the two retrieval subagents, the depth modes, the project folder layout and `research-layout.toml`, and the GRADE confidence schema.
+- [Research pack reference](reference/research-pack.md) — every skill (episodic and project), the two retrieval subagents, the depth modes, the project folder layout and `agentbundle-layout.toml`'s `[research]` table, and the GRADE confidence schema.
 
 ## Explanation
 

--- a/docs/guides/research/how-to/run-a-research-project-into-an-rfc.md
+++ b/docs/guides/research/how-to/run-a-research-project-into-an-rfc.md
@@ -96,7 +96,7 @@ Link the companion explicitly, e.g. *"Full evidence in
   way.
 - **You want the reasoning trail to survive.** Scratch is gitignored and
   per-workspace, so it won't outlive the workspace. For a high-stakes decision,
-  point `research-layout.toml` at a durable parent and link it from the brief —
+  point `agentbundle-layout.toml`'s `[research]` `parent` at a durable base and link it from the brief —
   but still commit only the brief into the RFC companion.
 
 ## See also
@@ -106,6 +106,6 @@ Link the companion explicitly, e.g. *"Full evidence in
 - [Run the research pipelines](research-pipelines.md) — the one-off (episodic)
   recipes, for when a project is more than you need.
 - [Research pack reference](../reference/research-pack.md) — the four project
-  skills, the folder layout, and the `research-layout.toml` keys.
+  skills, the folder layout, and the `agentbundle-layout.toml` `[research]` keys.
 - [Episodic vs project research](../explanation/episodic-vs-project-research.md)
   — when to reach for which.

--- a/docs/guides/research/reference/research-pack.md
+++ b/docs/guides/research/reference/research-pack.md
@@ -193,7 +193,7 @@ reproduced verbatim from each SKILL.md frontmatter.
 
 **name:** `research-project-start`.
 
-**description:** Start a stateful, multi-week research project — the lifecycle axis, orthogonal to the depth axis the `/research` skill carries. Triggers on explicit project-lifecycle phrasing — "start a research project", "set up a research project on X", "begin a sustained investigation", "open a research dossier" — never on a one-shot lookup. Scaffolds the three-layer project folder (overview.md + a raw sources/ layer + the later digest and synthesis), records the question and a possibly-empty working hypothesis, and sets phase to capture. Resolves the project parent from an adopter-created research-layout.toml, else a scratch / out-of-repo default, else by eliciting — never the committed repo tree. Prompt-only: phase is a frontmatter string the agent reads and writes; no engine, index, daemon, or counter. Does not replace /research — episodic quick/standard/applied/deep lookups stay there.
+**description:** Start a stateful, multi-week research project — the lifecycle axis, orthogonal to the depth axis the `/research` skill carries. Triggers on explicit project-lifecycle phrasing — "start a research project", "set up a research project on X", "begin a sustained investigation", "open a research dossier" — never on a one-shot lookup. Scaffolds the three-layer project folder (overview.md + a raw sources/ layer + the later digest and synthesis), records the question and a possibly-empty working hypothesis, and sets phase to capture. Resolves the project parent from the [research] table of an adopter-created agentbundle-layout.toml, else a scratch .context/research default, else by eliciting — never the committed repo tree. Prompt-only: phase is a frontmatter string the agent reads and writes; no engine, index, daemon, or counter. Does not replace /research — episodic quick/standard/applied/deep lookups stay there.
 
 ### research-project-digest
 
@@ -240,17 +240,30 @@ travels out of the folder.
 | `stop_signal` | string | qualitative, set by `/research-project-check` |
 | `verdict_status` | string (optional) | the only state `/research-project-check` may write |
 
-### `research-layout.toml` (adopter-created, optional)
+### `agentbundle-layout.toml` `[research]` (adopter-created, optional)
 
-Read at `research-project-start` to resolve where projects live. Adopter-created
-at a known path (repo root or `~/.agentbundle/research-layout.toml`); never
-shipped into a projected path.
+Read at `research-project-start` to resolve where projects live. `agentbundle-layout.toml`
+is the one shared, adopter-created layout file (a `[<pack>]` table per
+output-producing pack); never shipped into a projected path. The skill reads the
+**repo-root `./agentbundle-layout.toml`** `[research]` table, else the
+**user-profile `~/.agentbundle/agentbundle-layout.toml`** table (repo overrides
+user per table).
+
+```toml
+[research]
+parent = "~/research-projects"   # a base; project folders are created *under* it
+```
 
 | Key | Meaning |
 |---|---|
-| `parent` | directory under which project folders are created (default: scratch / out-of-repo) |
+| `parent` | **base** directory under which each `<YYYY-MM-DD>-<topic-slug>/` project folder is created (default: gitignored `.context/research/` — scratch / out-of-repo) |
 
-Resolution order: `research-layout.toml` → scratch / out-of-repo default → elicit. The committed repo tree is never the default.
+Anchored by the file's location (repo file → repo-relative; user file →
+absolute); resolved to a realpath-resolved absolute path, `..` rejected, and
+**surfaced before the first write**. Resolution order: `[research]` table →
+`.context/research` default → elicit. The committed repo tree is never the
+default. (A clean rename of an undistributed predecessor file — no alias, since
+nothing in the wild held the old name.)
 
 ### Source provenance axes (optional)
 

--- a/docs/guides/research/tutorials/your-first-research-project.md
+++ b/docs/guides/research/tutorials/your-first-research-project.md
@@ -47,9 +47,9 @@ Open `overview.md`. Its frontmatter records your `question`, a
 
 > Where did the folder land? By default, in scratch / out-of-repo space (a
 > gitignored `.context/research/` or a user-level path) — a code repo commits
-> the *decision*, never the whole corpus. You can point it elsewhere with a
-> `research-layout.toml`; the [reference](../reference/research-pack.md) has the
-> keys.
+> the *decision*, never the whole corpus. You can point it elsewhere with the
+> `[research]` table of an `agentbundle-layout.toml`; the
+> [reference](../reference/research-pack.md) has the keys.
 
 ## Step 2 — capture a few sources
 
@@ -184,6 +184,6 @@ is the shape of every research project.
   into an RFC](../how-to/run-a-research-project-into-an-rfc.md) picks up exactly
   where this tutorial ends.
 - Want the full catalogue of the four project skills, their phases, and the
-  `research-layout.toml` keys? See the [reference](../reference/research-pack.md).
+  `agentbundle-layout.toml` `[research]` keys? See the [reference](../reference/research-pack.md).
 - Wondering when a project is overkill and a one-off `/research` would do?
   [Episodic vs project research](../explanation/episodic-vs-project-research.md).

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -19,6 +19,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **One consolidated, namespaced pack-output layout file — `agentbundle-layout.toml`
+  (RFC-0040 / ADR-0030).** An adopter who wants to control where a pack's durable
+  output lands now edits **one** namespaced file instead of a per-pack config.
+  `agentbundle-layout.toml` carries one `[<pack>]` table per output-producing pack
+  (`research`, `architect`, `product-engineering`), each with a single `parent`
+  **base** under which the skill creates a topic-named folder per unit of work. Two
+  locations resolve with clear precedence — a checked-in `./agentbundle-layout.toml`
+  overrides a personal `~/.agentbundle/agentbundle-layout.toml`, per table. The file
+  is **adopter-owned and never shipped**: it comes into being by hand, or an
+  `agentbundle install` step **appends** a pack's default section to one that already
+  exists (never creating it, never overwriting a section you wrote). Reading stays
+  **prompt-only** (Charter Principle 3 — no engine, index, daemon, or watcher); each
+  consumer confines the resolved path (realpath-resolve, reject `..`, surface the
+  absolute path before the first write) and treats a repo-sourced out-of-tree
+  `parent` as an Ask-first, untrusted-origin case. Each consuming pack ships a
+  `references/agentbundle-layout.md` schema doc and a scope-keyed `[pack.layout]`
+  manifest default; `pack.toml` gains the optional `[pack.layout]` table (adapter
+  contract → v0.16). `architect` (0.6.1 → 0.7.0) and `product-engineering`
+  (0.4.2 → 0.5.0) become consumers; `research` (0.4.0 → 0.5.0) migrates from the
+  undistributed `research-layout.toml` by a **clean rename, no alias**.
 - **Research project mode — a four-skill lifecycle for sustained investigations
   (`research` pack, bumped to `0.4.0`).** Alongside the existing depth axis
   (`/research` quick/standard/applied/deep), the pack gains a *lifecycle* axis
@@ -31,9 +51,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `<topic-slug>-brief.md` that governance can lift whole into an RFC; and
   `research-project-check` is a passive saturation stop-signal that reads the
   matrix by eye and recommends — it never advances the lifecycle. Projects live
-  in scratch / out-of-repo by default (configurable via an adopter-created
-  `research-layout.toml`); the corpus is never committed to the repo, only the
-  distilled brief. Prompt-only by construction (no engine, index, or counter);
+  in scratch / out-of-repo by default (configurable via the `[research]` table
+  of an adopter-created `agentbundle-layout.toml`); the corpus is never committed
+  to the repo, only the distilled brief. Prompt-only by construction (no engine, index, or counter);
   the seven existing skills are reused as phase operations. RFCs may now carry an
   optional `docs/rfc/NNNN-notes/` companion folder for promoted research.
 - **Pack activation evals (Tier A) — `tools/run-pack-evals.py` + `[pack.evals]`
@@ -117,6 +137,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`architect-design` writes each design effort into its own per-effort folder**
+  (`<parent>/<topic-slug>/`) instead of scanning for a loose-file home every run
+  (RFC-0040). The previous `docs/design/`→`design/`→`architecture/`→`docs/`
+  scan-then-elicit becomes the **default** when no `[architect]` layout section
+  resolves. Additive — a folder around what was a file — and documented in the
+  pack's `references/agentbundle-layout.md`.
 - **`new-rfc` now surfaces the optional `NNNN-notes/` companion
   (`governance-extras` pack, bumped to `0.3.0`).** The skill and its RFC
   template point authors at the optional sibling `docs/rfc/NNNN-notes/` folder

--- a/docs/specs/consolidated-pack-layout/plan.md
+++ b/docs/specs/consolidated-pack-layout/plan.md
@@ -1,7 +1,7 @@
 # Plan: consolidated-pack-layout
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Drafting
+- **Status:** Done
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
 > document is allowed to change as you learn. When it changes substantially
@@ -47,8 +47,10 @@ scan-target today); `product-engineering` → `docs/product`.
 otherwise touches its own pack dir + its own guides). T6's self-host / AC12
 `find` gates also require T3–T5's `make build` projections to have landed first.
 
-This spec/plan PR authors **governance docs only**; T1–T6 below are the
-**implementing PR**'s work-breakdown, not work done here.
+The spec/plan first landed in a **governance-docs PR** (#359); T1–T6 below were
+then **implemented** in the follow-on PR (this one), which also carries the
+pre-EXECUTE-review refinements recorded in the changelog. All six tasks are done;
+every AC is checked.
 
 ## Constraints
 

--- a/docs/specs/consolidated-pack-layout/plan.md
+++ b/docs/specs/consolidated-pack-layout/plan.md
@@ -32,6 +32,21 @@ carry the realpath / reject-`..` / surface / untrusted-origin rails verbatim
 enough that `rg` and the smoke can verify them, generalising the rail
 `research-project-start` already takes.
 
+**Per-pack defaults (settled at PLAN, pre-EXECUTE review):** all three consumers
+default to **user** scope but their output is per-repo, so none has a sensible
+*absolute* user default. Each therefore declares only `[pack.layout.repo]` and
+**omits `[pack.layout.user]`** (user-scope append is a no-op; the commented
+placeholder lives in the schema doc as adopter guidance). Repo defaults:
+`research` → `.context/research` (gitignored scratch — honours research's
+"never the committed tree" posture); `architect` → `docs/design` (its first
+scan-target today); `product-engineering` → `docs/product`.
+
+**Sequencing constraint:** T3, T4, and T5 each append to the single
+`docs/product/changelog.md`, so they are **not** file-disjoint and must merge
+**sequentially** — no parallel implementer wave (the only shared file; each
+otherwise touches its own pack dir + its own guides). T6's self-host / AC12
+`find` gates also require T3–T5's `make build` projections to have landed first.
+
 This spec/plan PR authors **governance docs only**; T1–T6 below are the
 **implementing PR**'s work-breakdown, not work done here.
 
@@ -144,8 +159,12 @@ Most tests live per-task below. Cross-cutting:
 **Depends on:** none
 
 **Touches:** `packages/agentbundle/agentbundle/_data/pack.schema.json`,
+`packages/agentbundle/agentbundle/_data/adapter.toml`,
+`docs/contracts/adapter.toml`, `docs/contracts/pack.schema.json`,
 `packages/agentbundle/agentbundle/build/main.py`,
-`packages/agentbundle/tests/**`
+`packages/agentbundle/tests/**`,
+`packages/agentbundle/agentbundle/build/tests/**` (4 of the 5 `== "0.15"`
+contract-version assertions live in this second, CI-ungated test root)
 
 **Tests:**
 - Goal-based: `validate_pack_metadata` accepts a `pack.toml` carrying
@@ -157,14 +176,25 @@ Most tests live per-task below. Cross-cutting:
   `packages/agentbundle/tests/` and `…/agentbundle/build/tests/`) to catch lexical
   version-compare and stale-assertion traps. Verifies AC10.
 
-**Approach:**
-- First settle *which* version field governs the `pack.toml` manifest contract
-  (schema `version`, adapter-contract, or a manifest constant) before bumping —
-  this is the contract-bump trap's entry point.
-- Add `[pack.layout]` to `pack.schema.json` as an optional property with optional
-  `.repo` / `.user` sub-tables, each allowing a `parent` string and/or a
-  template-path string.
-- Bump the governing version field; sweep both test roots for version assertions.
+**Approach (version field settled):** the governing field is the `adapter.toml`
+`[contract] version` → `SPEC_VERSION` (the umbrella manifest/projection contract;
+direct precedent — the enriched-pack-manifest extension, contract v0.14, bumped this
+same field). Bump it **`"0.15"` → `"0.16"`** in *both* byte-identical copies
+(`_data/adapter.toml` and `docs/contracts/adapter.toml`, drift-gated by
+`BundledCopiesMatchTests`) with a dated ledger comment citing this spec.
+- Add `[pack.layout]` to `pack.schema.json` (both copies) as an optional `object`
+  property under `pack.properties` with optional `.repo` / `.user` sub-tables, each
+  allowing a `parent` string and/or a template-path string. The change is purely
+  additive (`pack` has no `additionalProperties: false`).
+- Leave the **stale install-gate enum** (`["0.2","0.3","0.6"]`) and each shipped
+  pack's `[pack.adapter-contract] version` **untouched** — the runtime gate is
+  major-only, so a 0.x pack declaring `[pack.layout]` still validates; re-arming the
+  enum would be an out-of-scope behaviour change.
+- Update the 5 exact-string `== "0.15"` assertions: `tests/unit/test_contract_v0_3_schema.py`
+  (+ its ledger comment), `build/tests/test_contract.py`, `build/tests/test_adapter_gemini.py`,
+  `build/tests/test_adapter_kiro_ide.py`, `build/tests/test_adapter_cursor.py`. (The
+  `>=`-tuple assertions in `test_contract_v07/v08/scope.py` are numeric and safe.)
+- Run the full `agentbundle` package pytest by hand in **both** test roots.
 
 **Done when:** `validate_pack_metadata` accepts/rejects per the tests, the version
 bump is asserted, and the full package pytest is green in both roots.
@@ -196,6 +226,9 @@ bump is asserted, and the full package pytest is green in both roots.
 - Re-emit type-validation: feed a tampered existing section (`parent = 42`,
   `parent = ["x"]`) and assert it is dropped/coerced before re-emit, not crashed
   on — mirroring `_append_install_marker`'s parsed-field hardening. Verifies AC11.
+- Symlink fails-closed: when the layout *file path itself* is a symlink escaping
+  `root`, the append's `write_jailed` → `assert_under` realpath-resolve raises
+  `PathJailError` (never follows the link). Verifies AC11/AC14.
 
 **Approach:**
 - Add `_append_layout_section`, modelled on `_append_install_marker`'s upsert:
@@ -364,3 +397,14 @@ description records the smoke observations.
 ## Changelog
 
 - 2026-06-22: initial plan (governance-docs PR; T1–T6 are the implementing PR).
+- 2026-06-22: implementing-PR pre-EXECUTE review refinements (no behaviour change
+  vs RFC-0040 — all within its optional-sub-table latitude): settled the version
+  field as `adapter.toml` `[contract] version` 0.15→0.16 (T1); recorded that all
+  three consumers omit `[pack.layout.user]` (no sensible absolute default) so the
+  commented placeholder is schema-doc guidance only, never installer-emitted
+  (resolves the net-new-emit-shape concern); fixed per-pack repo defaults
+  (`.context/research` / `docs/design` / `docs/product`); added the symlink-target
+  fails-closed test (T2) and the second test root to T1 Touches; clarified AC11/AC15
+  (append type-validates but never path-confines `parent`); scoped AC17's
+  rename-sweep to live consumer surfaces, exempting the frozen `research-project-mode`
+  spec/plan + its `docs/specs/README.md` row.

--- a/docs/specs/consolidated-pack-layout/spec.md
+++ b/docs/specs/consolidated-pack-layout/spec.md
@@ -64,10 +64,17 @@ before proceeding; *Never do* is a hard rule, even under time pressure.
   install scope's location, ensure `[<pack>]` is present — appending the pack's
   default if missing, leaving an existing section untouched.
 - Source the appended default from the pack's **scope-keyed `[pack.layout]`
-  manifest table** (`[pack.layout.repo]` / `[pack.layout.user]`), so the appended
-  default matches the target file's anchor (repo-relative for the repo file,
-  absolute / `~`-anchored — or a commented placeholder when no sensible absolute
-  default exists — for the user file).
+  manifest table** (`[pack.layout.repo]` / `[pack.layout.user]`, both optional), so
+  the appended default matches the target file's anchor: repo-relative for the repo
+  file; absolute / `~`-anchored for the user file. When a pack has **no sensible
+  absolute user-scope default** (true for all three current consumers, whose output
+  is per-repo), it **omits `[pack.layout.user]` entirely** — the user-scope append is
+  then a **no-op**, and the commented-placeholder shape appears only in the
+  `references/agentbundle-layout.md` schema doc as adopter guidance, never as
+  installer-emitted output (this keeps every installer-written line on the
+  injection-safe `config._emit_basic_string` path; a comment line has no such
+  serialiser and would be a net-new emit shape with no `_append_install_marker`
+  precedent).
 - Serialise every pack-sourced string in the append through the existing
   injection-safe `config._emit_basic_string` and write via the path-jailed atomic
   `safety.write_jailed`.
@@ -258,8 +265,15 @@ append is real code and is **TDD**.
   `.repo` / `.user` sub-tables (declaring the section inline or pointing at a
   within-pack `agentbundle-layout.toml` template); `pack.schema.json` accepts it
   and `validate_pack_metadata` validates it; the install scope selects which
-  sub-table sources the appended default. The manifest schema / contract version
-  field that governs `pack.toml` is bumped per the repo's contract-bump discipline.
+  sub-table sources the appended default. **A pack may declare only `.repo`** (the
+  three current consumers do, since their output is per-repo and they have no
+  sensible absolute user default); a scope whose sub-table is absent **appends
+  nothing** (no-op). The governing manifest / contract version field is the
+  `adapter.toml` `[contract] version` (direct precedent: the enriched-pack-manifest
+  manifest extension bumped it); it is bumped per the repo's contract-bump
+  discipline. The additive optional `[pack.layout]` property leaves the stale
+  `pack.schema.json` install-gate enum and each pack's `[pack.adapter-contract]
+  version` untouched (the runtime version gate is major-only).
   Verification: `validate_pack_metadata` accepts a `[pack.layout]`-carrying
   `pack.toml` and rejects a malformed one; the version bump is asserted; the full
   `agentbundle` package pytest is run by hand (contract-bump traps).
@@ -290,8 +304,17 @@ append is real code and is **TDD**.
   against a real `allowed-prefixes.user` list (not merely that the `TypeError`
   fires when the list is omitted); a **re-emit type-validation** test feeding a
   tampered existing section (`parent = 42`, `parent = ["x"]`) asserts it is
-  dropped/coerced, not crashed on; plus the never-overwrite / never-create tests
-  of AC9. *(RFC-0040 spec-stage security AC 4.)*
+  dropped/coerced, not crashed on; a **symlink-target fails-closed** test confirms
+  that when the layout *file path itself* is a symlink escaping `root`,
+  `write_jailed`'s `assert_under` realpath-resolve raises `PathJailError` (the append
+  fails closed, never following the link); plus the never-overwrite / never-create
+  tests of AC9. **Scope note:** the append validates the *type* of a re-read `parent`
+  (str-vs-non-str, mirroring `_append_install_marker`) and serialises it
+  injection-safely, but it deliberately does **not** validate `parent`'s *path
+  semantics* — a hostile `parent = "../../etc"` round-trips intact and well-formed,
+  because confining the resolved `parent` value is wholly the prompt-only reader's
+  job (AC13–AC15), not the path-jailed *file* write's. *(RFC-0040 spec-stage security
+  AC 4.)*
 
 - [ ] **AC12 — Reading is prompt-only; no engine creeps in.** No consumer ships a
   script, daemon, index, counter, or any runtime code that reads
@@ -319,7 +342,9 @@ append is real code and is **TDD**.
   (security).** A `parent` taken from the repo-root file that resolves outside the
   repo tree is treated as untrusted-origin and **confirmed before writing** (the
   cloned-untrusted-repo case); the user-profile file is foot-gun-only (adopter is
-  the author). Verification: goal-based / manual-QA — `rg` confirms the
+  the author). This trust posture is the **reader's** (AC13–AC15); the install-time
+  append still type-validates the user file's re-read `parent` per AC11 regardless of
+  scope, so the two ACs do not contradict on who trusts the user file. Verification: goal-based / manual-QA — `rg` confirms the
   untrusted-origin Ask-first rail in each body; the AC16 smoke exercises a hostile
   repo-root `parent` (e.g. an absolute `~/.ssh`, or a relative `../../<outside>`
   that escapes the repo via `..`) and confirms the skill asks rather than writing.
@@ -341,7 +366,13 @@ append is real code and is **TDD**.
   catalogue does not trip the self-host drift gate; adopters ship **no** gitignore
   rule. Verification: `rg -F 'agentbundle-layout.toml' .gitignore` returns a hit in
   the install-time-scratch section, and `rg` finds no surviving `research-layout.toml`
-  reference outside the RFC/ADR and historical changelog entries.
+  reference **on a live consumer surface** — the three skill bodies and the
+  `docs/guides/research/**` guides. The old name legitimately survives in **historical
+  record**, which the sweep exempts: this spec/plan and its RFC-0040 / ADR-0030; the
+  **frozen** `docs/specs/research-project-mode/` spec & plan and that spec's row in the
+  living `docs/specs/README.md` index (CONVENTIONS forbids editing a frozen spec's
+  body — it is historical description of what that spec shipped); and historical
+  `docs/product/changelog.md` entries.
 
 - [ ] **AC18 — Pack version bumps + changelog.** `research` is bumped 0.4.0 →
   0.5.0; `architect` and `product-engineering` get the appropriate next bump for a

--- a/docs/specs/consolidated-pack-layout/spec.md
+++ b/docs/specs/consolidated-pack-layout/spec.md
@@ -1,6 +1,6 @@
 # Spec: consolidated-pack-layout
 
-- **Status:** Draft
+- **Status:** Shipped
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** RFC-0040, ADR-0030, ADR-0029 (the `research-layout.toml` this generalises), ADR-0021 (`pack.toml` source of truth — home for `[pack.layout]`), RFC-0035 (namespaced adopter-editable TOML + shipped-placeholder delivery), RFC-0038 (forward-only migration — considered, found not to apply)
@@ -178,7 +178,7 @@ append is real code and is **TDD**.
 
 ## Acceptance Criteria
 
-- [ ] **AC1 — One namespaced file, two locations, repo overrides user per table.**
+- [x] **AC1 — One namespaced file, two locations, repo overrides user per table.**
   `agentbundle-layout.toml` carries one `[<pack>]` table per consumer, each with a
   single `parent` key. A skill reads the **repo-root `./agentbundle-layout.toml`**
   `[<pack>]` table if present, else the **user-profile
@@ -188,14 +188,14 @@ append is real code and is **TDD**.
   `references/agentbundle-layout.md` docs names both locations and the
   repo-overrides-user-per-table rule.
 
-- [ ] **AC2 — `parent` is a base; each unit of work gets its own topic-named
+- [x] **AC2 — `parent` is a base; each unit of work gets its own topic-named
   folder.** `parent` is the directory the pack writes *under*, never the leaf the
   work lands *in*. Per-pack folder shape: `research` → `<parent>/<YYYY-MM-DD>-<topic-slug>/`;
   `architect` → `<parent>/<topic-slug>/`; `product-engineering` → file-per-slug
   under `<parent>/{intents,rollups}/`. Verification: `rg` confirms each body and
   its schema doc state the pack's folder shape and that `parent` is a base.
 
-- [ ] **AC3 — `parent` is anchored by the layout file's own location.** A
+- [x] **AC3 — `parent` is anchored by the layout file's own location.** A
   **repo-root** file's `parent` is **repo-root-relative** (an absolute value is
   permitted but warned as non-portable); a **user-profile** file's `parent` **must
   be an explicit absolute path** (`~`-anchored ok) and a relative value there is an
@@ -203,7 +203,7 @@ append is real code and is **TDD**.
   Verification: `rg` against each consumer body + schema doc documents both anchor
   rules.
 
-- [ ] **AC4 — Resolve to, and surface, the full absolute path before the first
+- [x] **AC4 — Resolve to, and surface, the full absolute path before the first
   write.** Regardless of anchor, each consumer resolves `parent` to a full absolute
   path (realpath, `~`-expanded, `..` rejected) and **surfaces that path to the
   adopter before creating the work folder**. The `..` rejection and realpath
@@ -213,7 +213,7 @@ append is real code and is **TDD**.
   `rg` against each consumer body names the resolve-then-surface-then-write order
   and the reject-`..`-after-anchoring invariant.
 
-- [ ] **AC5 — `research` migrates by a clean rename, no alias.**
+- [x] **AC5 — `research` migrates by a clean rename, no alias.**
   `research-layout.toml`'s top-level `parent` becomes the `[research]` table's
   `parent` in `agentbundle-layout.toml`; `research-project-start`'s body and the
   research reference / how-to / tutorial guides are updated to name the new file
@@ -222,7 +222,7 @@ append is real code and is **TDD**.
   `agentbundle-layout.toml` + `[research]` and the RFC-0038-alias-not-applied
   reasoning; AC17 confirms the old name is gone.
 
-- [ ] **AC6 — `architect` is a consumer, with a per-effort folder.**
+- [x] **AC6 — `architect` is a consumer, with a per-effort folder.**
   `architect-design` reads the `[architect]` table and writes each design effort
   into its own `<parent>/<topic-slug>/` folder (the design doc, diagrams, notes)
   instead of scanning for a loose-file home every run; its existing
@@ -232,7 +232,7 @@ append is real code and is **TDD**.
   and the scan-then-elicit default; the `references/agentbundle-layout.md` doc
   documents the folder shape and the file→folder shift.
 
-- [ ] **AC7 — `product-engineering` is a consumer, file-per-slug.** `frame-intent`
+- [x] **AC7 — `product-engineering` is a consumer, file-per-slug.** `frame-intent`
   and `align-value-stream` read the `[product-engineering]` table and write
   `<parent>/intents/<slug>.md` and `<parent>/rollups/<slug>.md` (default
   `parent = docs/product`); a per-topic *folder* is deliberately **not** used
@@ -243,7 +243,7 @@ append is real code and is **TDD**.
   read and the file-per-slug shape; `rg` confirms `decompose-intent` still pins
   `docs/product/briefs/`.
 
-- [ ] **AC8 — Each consumer ships a `references/agentbundle-layout.md` schema
+- [x] **AC8 — Each consumer ships a `references/agentbundle-layout.md` schema
   doc.** A normal projected pack file in each of the three packs documents that
   pack's `[<pack>]` section — `parent`, the default base, the per-unit folder
   shape, and the posture (committed-docs vs out-of-repo). The skill body reads it
@@ -251,7 +251,7 @@ append is real code and is **TDD**.
   three files exist under `packs/{research,architect,product-engineering}/.apm/skills/<skill>/references/agentbundle-layout.md`
   and each names its pack's `parent`, default, and folder shape.
 
-- [ ] **AC9 — Installer `_append_layout_section`: append-if-exists, never-create,
+- [x] **AC9 — Installer `_append_layout_section`: append-if-exists, never-create,
   never-overwrite.** `agentbundle install <pack>` gains an `_append_layout_section`
   step (modelled on `_append_install_marker`), called from the Step-11 per-scope
   loop: *if* a layout file exists at the install scope's location, ensure
@@ -260,7 +260,7 @@ append is real code and is **TDD**.
   never-overwrite + never-create construction tests (Testing Strategy) pass; `rg`
   confirms the Step-11 loop calls the new step per scope.
 
-- [ ] **AC10 — Scope-keyed `[pack.layout]` manifest extension + validator +
+- [x] **AC10 — Scope-keyed `[pack.layout]` manifest extension + validator +
   version bump.** `pack.toml` gains an optional `[pack.layout]` table with optional
   `.repo` / `.user` sub-tables (declaring the section inline or pointing at a
   within-pack `agentbundle-layout.toml` template); `pack.schema.json` accepts it
@@ -278,7 +278,7 @@ append is real code and is **TDD**.
   `pack.toml` and rejects a malformed one; the version bump is asserted; the full
   `agentbundle` package pytest is run by hand (contract-bump traps).
 
-- [ ] **AC11 — The append is injection-safe, path-jailed, and re-emit-safe.**
+- [x] **AC11 — The append is injection-safe, path-jailed, and re-emit-safe.**
   Every pack-sourced string the append writes passes through
   `config._emit_basic_string`, and the write goes through `safety.write_jailed`
   with the jail contract **modelled exactly on `_append_install_marker`** (the
@@ -316,7 +316,7 @@ append is real code and is **TDD**.
   job (AC13–AC15), not the path-jailed *file* write's. *(RFC-0040 spec-stage security
   AC 4.)*
 
-- [ ] **AC12 — Reading is prompt-only; no engine creeps in.** No consumer ships a
+- [x] **AC12 — Reading is prompt-only; no engine creeps in.** No consumer ships a
   script, daemon, index, counter, or any runtime code that reads
   `agentbundle-layout.toml`; resolution lives in the skill body. The only code
   touching the file is the install-time append. Verification: the three consumer
@@ -324,21 +324,21 @@ append is real code and is **TDD**.
   (`find … \( -name '*.py' -o -name '*.sh' \)` returns nothing layout-reading);
   `rg` confirms each body frames resolution as prompt-driven.
 
-- [ ] **AC13 — Confinement + `..` rejection + surface-before-write (security).**
+- [x] **AC13 — Confinement + `..` rejection + surface-before-write (security).**
   Each consumer confines the resolved `parent` + work folder to the pack's intended
   root, rejects `..` escapes, and surfaces the resolved absolute path before the
   first write. Verification: goal-based / manual-QA — `rg` confirms the rail prose
   in each body; the AC16 smoke confirms a `..`-containing `parent` is rejected and
   the resolved path surfaced. *(RFC-0040 spec-stage security AC 1.)*
 
-- [ ] **AC14 — Realpath resolution makes symlinks visible (security).** The
+- [x] **AC14 — Realpath resolution makes symlinks visible (security).** The
   resolved path is realpath-resolved so a symlinked `parent` or ancestor is visible
   and not silently followed out of tree. Verification: goal-based / manual-QA —
   `rg` confirms each body specifies realpath resolution; the AC16 smoke confirms a
   symlinked `parent` surfaces its real target before any write. *(RFC-0040
   spec-stage security AC 2.)*
 
-- [ ] **AC15 — Repo-root-sourced out-of-tree `parent` is untrusted-origin
+- [x] **AC15 — Repo-root-sourced out-of-tree `parent` is untrusted-origin
   (security).** A `parent` taken from the repo-root file that resolves outside the
   repo tree is treated as untrusted-origin and **confirmed before writing** (the
   cloned-untrusted-repo case); the user-profile file is foot-gun-only (adopter is
@@ -350,7 +350,7 @@ append is real code and is **TDD**.
   that escapes the repo via `..`) and confirms the skill asks rather than writing.
   *(RFC-0040 spec-stage security AC 3.)*
 
-- [ ] **AC16 — One observable smoke project.** A real end-to-end run of one
+- [x] **AC16 — One observable smoke project.** A real end-to-end run of one
   consumer with a hand-written repo-root `agentbundle-layout.toml` produces the
   topic-named folder under the resolved `parent` and surfaces the absolute path;
   a hostile/out-of-tree `parent` triggers the Ask-first confirmation; and
@@ -360,7 +360,7 @@ append is real code and is **TDD**.
   surfaced path, the Ask-first prompt, and the append/never-overwrite/never-create
   outcomes (self-report is not sufficient; the files are the signal).
 
-- [ ] **AC17 — `.gitignore` housekeeping (this repo only).**
+- [x] **AC17 — `.gitignore` housekeeping (this repo only).**
   `agentbundle-layout.toml` is added to this repo's `.gitignore` alongside
   `.adapt-install-marker.toml`, so a contributor exercising a consumer skill in the
   catalogue does not trip the self-host drift gate; adopters ship **no** gitignore
@@ -374,7 +374,7 @@ append is real code and is **TDD**.
   body — it is historical description of what that spec shipped); and historical
   `docs/product/changelog.md` entries.
 
-- [ ] **AC18 — Pack version bumps + changelog.** `research` is bumped 0.4.0 →
+- [x] **AC18 — Pack version bumps + changelog.** `research` is bumped 0.4.0 →
   0.5.0; `architect` and `product-engineering` get the appropriate next bump for a
   new-consumer + (architect) behaviour-change; each pack's `pack.toml` and
   `plugin.json` move together; `docs/product/changelog.md` `[Unreleased]` records

--- a/packages/agentbundle/agentbundle/_data/adapter.toml
+++ b/packages/agentbundle/agentbundle/_data/adapter.toml
@@ -77,7 +77,14 @@
 # the default agent's `.kiro/skills` auto-discovery (RFC-0022 E4; kiro
 # #6887/#6888/#4993). Additive `inject-resources` on BOTH the kiro-cli and
 # kiro-ide agent projections (CLI → agent JSON, IDE → quoted .md frontmatter).
-version = "0.15"
+# RFC-0040 / ADR-0030 / docs/specs/consolidated-pack-layout (v0.16): pack.toml
+# gains an optional scope-keyed [pack.layout] table (optional .repo / .user
+# sub-tables, each a `parent` base and/or a within-pack template-path) naming
+# where a consuming pack's durable output lands. Consumed by the new installer
+# `_append_layout_section` step (append-if-exists / never-create / never-
+# overwrite) into an adopter-owned `agentbundle-layout.toml`. Additive +
+# optional — packs pinned below v0.16 build and validate unchanged.
+version = "0.16"
 
 # Sibling schemas this contract references — pack metadata and the
 # per-pack Claude-plugin manifest. Defined by spec AC #3 + #4.

--- a/packages/agentbundle/agentbundle/_data/pack.schema.json
+++ b/packages/agentbundle/agentbundle/_data/pack.schema.json
@@ -131,6 +131,25 @@
             "type": "string",
             "pattern": "^[^/].*"
           }
+        },
+        "layout": {
+          "type": "object",
+          "properties": {
+            "repo": {
+              "type": "object",
+              "properties": {
+                "parent": {"type": "string"},
+                "template": {"type": "string"}
+              }
+            },
+            "user": {
+              "type": "object",
+              "properties": {
+                "parent": {"type": "string"},
+                "template": {"type": "string"}
+              }
+            }
+          }
         }
       },
       "if": {

--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_cursor.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_cursor.py
@@ -53,10 +53,11 @@ class CursorContractTests(unittest.TestCase):
     def test_contract_version_is_0_11(self) -> None:
         """AC1 — contract bumped to 0.11 by cursor-full-parity; subsequently
         0.12 (copilot-skills-and-web), 0.13 (docs/specs/gemini-full-parity),
-        0.14 (docs/specs/enriched-pack-manifest), then 0.15
-        (docs/specs/kiro-cli-agent-skill-resources).
+        0.14 (docs/specs/enriched-pack-manifest), 0.15
+        (docs/specs/kiro-cli-agent-skill-resources), then 0.16
+        (docs/specs/consolidated-pack-layout).
         Name preserved to keep the diff small."""
-        self.assertEqual(self.contract["contract"]["version"], "0.15")
+        self.assertEqual(self.contract["contract"]["version"], "0.16")
 
     def test_cursor_block_projects_five_primitives(self) -> None:
         """AC2 — the five standard primitives are in the projection array."""

--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_gemini.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_gemini.py
@@ -151,9 +151,9 @@ class GeminiContractTests(unittest.TestCase):
         cls.contract = load_contract(CONTRACT_PATH)
 
     def test_contract_version_is_0_14(self) -> None:
-        """Contract version is 0.15 (docs/specs/kiro-cli-agent-skill-resources
-        bumped it from enriched-pack-manifest's 0.14). Name preserved."""
-        self.assertEqual(self.contract["contract"]["version"], "0.15")
+        """Contract version is 0.16 (docs/specs/consolidated-pack-layout
+        bumped it from kiro-cli-agent-skill-resources' 0.15). Name preserved."""
+        self.assertEqual(self.contract["contract"]["version"], "0.16")
 
     def test_gemini_block_projects_five_primitives(self) -> None:
         """AC2 — five standard primitives with their gemini targets."""

--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro_ide.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro_ide.py
@@ -172,13 +172,13 @@ class KiroIdeAdapterTests(unittest.TestCase):
         self.assertIn(".kiro.hook", target_repo)
 
     def test_contract_version_is_0_9(self) -> None:
-        """Contract version is 0.15 (docs/specs/kiro-cli-agent-skill-resources,
-        atop enriched-pack-manifest's 0.14 and gemini-full-parity's 0.13).
+        """Contract version is 0.16 (docs/specs/consolidated-pack-layout,
+        atop kiro-cli-agent-skill-resources' 0.15 and enriched-pack-manifest's 0.14).
         Name preserved to keep the diff small."""
         self.assertEqual(
             self.contract["contract"]["version"],
-            "0.15",
-            "adapter.toml [contract] version must be '0.15' after kiro-cli-agent-skill-resources",
+            "0.16",
+            "adapter.toml [contract] version must be '0.16' after consolidated-pack-layout",
         )
 
     def test_kiro_ide_hook_projects_with_flat_prefix_path(self) -> None:

--- a/packages/agentbundle/agentbundle/build/tests/test_contract.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_contract.py
@@ -452,16 +452,16 @@ class ContractV05Tests(unittest.TestCase):
         self.schema = _load_schema()
 
     def test_contract_version_is_v05(self) -> None:
-        """tomllib.loads of adapter.toml returns contract.version == "0.15"
-        (bumped from enriched-pack-manifest's "0.14" by
-        docs/specs/kiro-cli-agent-skill-resources: kiro-cli agents inject a
-        skill-resources glob so headless `--agent` runs reach skills).
-        Class/method names preserved to avoid churn.
+        """tomllib.loads of adapter.toml returns contract.version == "0.16"
+        (bumped from kiro-cli-agent-skill-resources' "0.15" by
+        docs/specs/consolidated-pack-layout: pack.toml gains an optional
+        scope-keyed [pack.layout] table). Class/method names preserved to
+        avoid churn.
         """
         self.assertEqual(
             self.contract["contract"]["version"],
-            "0.15",
-            "adapter.toml [contract] version must be '0.15' after kiro-cli-agent-skill-resources",
+            "0.16",
+            "adapter.toml [contract] version must be '0.16' after consolidated-pack-layout",
         )
 
     def test_claude_code_install_routes_includes_apm(self) -> None:

--- a/packages/agentbundle/agentbundle/build/tests/test_pack_schema.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_pack_schema.py
@@ -399,6 +399,85 @@ description = "Core skills."
         self.assertEqual(errors, [], "\n".join(errors))
 
 
+class PackSchemaLayoutTests(unittest.TestCase):
+    """consolidated-pack-layout T1: optional scope-keyed [pack.layout] table.
+
+    pack.schema.json gains an optional `[pack.layout]` table with optional
+    `.repo` / `.user` sub-tables, each carrying a `parent` base and/or a
+    within-pack `template` path. Every field is optional and the change is
+    additive — a manifest omitting it must still validate (legacy invariance),
+    and a pack may declare only `.repo` (the three current consumers do, since
+    their output is per-repo and they have no sensible absolute user default).
+    """
+
+    def test_accepts_layout_with_repo_and_user(self) -> None:
+        """A manifest carrying [pack.layout.repo] and [pack.layout.user] validates."""
+        from agentbundle.build.validate import validate
+
+        schema = _load_schema()
+        toml_text = """
+[pack]
+name = "research"
+version = "0.5.0"
+
+[pack.layout.repo]
+parent = ".context/research"
+
+[pack.layout.user]
+parent = "~/research-projects"
+template = "references/agentbundle-layout.toml"
+"""
+        instance = _parse_toml(toml_text)
+        errors = validate(instance, schema)
+        self.assertEqual(errors, [], "\n".join(errors))
+
+    def test_accepts_layout_repo_only(self) -> None:
+        """A pack may declare only [pack.layout.repo] — the consumer shape."""
+        from agentbundle.build.validate import validate
+
+        schema = _load_schema()
+        toml_text = """
+[pack]
+name = "product-engineering"
+version = "0.5.0"
+
+[pack.layout.repo]
+parent = "docs/product"
+"""
+        instance = _parse_toml(toml_text)
+        errors = validate(instance, schema)
+        self.assertEqual(errors, [], "\n".join(errors))
+
+    def test_accepts_manifest_omitting_layout(self) -> None:
+        """Optionality: a manifest with no [pack.layout] validates (legacy invariance)."""
+        from agentbundle.build.validate import validate
+
+        schema = _load_schema()
+        toml_text = """
+[pack]
+name = "core"
+version = "0.4.0"
+"""
+        instance = _parse_toml(toml_text)
+        errors = validate(instance, schema)
+        self.assertEqual(errors, [], "\n".join(errors))
+
+    def test_rejects_non_string_parent(self) -> None:
+        """[pack.layout.repo].parent must be a string; a non-string is rejected."""
+        from agentbundle.build.validate import validate
+
+        schema = _load_schema()
+        instance = {
+            "pack": {
+                "name": "core",
+                "version": "0.1.0",
+                "layout": {"repo": {"parent": 42}},
+            }
+        }
+        errors = validate(instance, schema)
+        self.assertTrue(errors, "schema accepted a non-string layout.repo.parent")
+
+
 class PackSchemaLoadsTests(unittest.TestCase):
     """Smoke test: the schema file loads and has the expected top-level shape."""
 

--- a/packages/agentbundle/agentbundle/commands/install.py
+++ b/packages/agentbundle/agentbundle/commands/install.py
@@ -1106,6 +1106,12 @@ def run(args: "argparse.Namespace") -> int:
         if repo_projection is not None
         else []
     )
+    # RFC-0040 / spec AC9: maintain an adopter-owned `agentbundle-layout.toml`
+    # if one already exists at the scope's location — append the pack's
+    # scope-keyed `[pack.layout.<scope>]` default, never creating the file and
+    # never overwriting an existing section. No-op for packs that ship no
+    # `[pack.layout]` (most), and for any scope whose sub-table is omitted.
+    pack_layout = pack_toml.get("pack", {}).get("layout", {})
     for plan in plans:
         scope_markers = repo_unresolved_markers if plan.scope == "repo" else []
         try:
@@ -1116,6 +1122,13 @@ def run(args: "argparse.Namespace") -> int:
                 pack_version=pack_version,
                 unresolved_markers=scope_markers,
                 new_companions=plan.new_companions,
+                allowed_prefixes=plan.allowed_prefixes,
+            )
+            _append_layout_section(
+                plan.root,
+                plan.scope,
+                pack_name=pack_name,
+                pack_layout=pack_layout,
                 allowed_prefixes=plan.allowed_prefixes,
             )
         except (OSError, safety.PathJailError) as exc:
@@ -2225,6 +2238,141 @@ def _append_install_marker(
         content,
         scope=scope,
         allowed_prefixes=marker_prefixes,
+    )
+
+
+def _append_layout_section(
+    root: Path,
+    scope: str,
+    *,
+    pack_name: str,
+    pack_layout: dict,
+    allowed_prefixes: list[str] | None,
+) -> None:
+    """Append a ``[<pack_name>]`` table to an adopter-owned
+    ``agentbundle-layout.toml`` at *root* — but **only if the file already
+    exists** and the section is **absent** (RFC-0040 / spec AC9). Repo-scope
+    file lives at ``<repo>/agentbundle-layout.toml``; user-scope at
+    ``<user-root>/.agentbundle/agentbundle-layout.toml``.
+
+    Append-if-exists / never-create / never-overwrite. The file is
+    adopter-owned, so this step never brings it into being and never
+    rewrites a section the adopter already authored.
+
+    Modelled on :func:`_append_install_marker`'s upsert (spec AC11): read +
+    type-validate + re-emit, with **every** emitted string — including each
+    re-emitted table header, since a parsed section key can itself contain
+    ``]`` or a newline — routed through :func:`config._emit_basic_string`, and
+    the write going through :func:`safety.write_jailed` with the
+    marker-mirrored per-scope jail (repo: top-level relpath, no prefixes;
+    user: ``root=<home>`` + ``.agentbundle/`` relpath + ``allowed-prefixes.user``
+    via :func:`safety.user_state_path`).
+
+    The appended default is sourced from the pack's scope-keyed
+    ``[pack.layout.<scope>].parent`` manifest table. A scope whose sub-table
+    (or its ``parent``) is absent appends **nothing** — e.g. all three current
+    consumers omit ``[pack.layout.user]``, so the user-scope append is a no-op
+    (spec AC10). A pack with no ``[pack.layout]`` at all (most packs) no-ops too,
+    so this is safe to call unconditionally per scope.
+    """
+    import tomllib
+
+    from agentbundle import safety
+    from agentbundle.config import _emit_basic_string
+
+    if scope == "user":
+        # Mirror `_append_install_marker`: route through `user_state_path`
+        # so the dot-directory is created 0o700 with the symlink probe, then
+        # sit the layout file next to `state.toml`.
+        state_path = safety.user_state_path(home=root)
+        layout_path = state_path.parent / "agentbundle-layout.toml"
+        layout_relpath = ".agentbundle/agentbundle-layout.toml"
+    else:
+        layout_path = root / "agentbundle-layout.toml"
+        layout_relpath = "agentbundle-layout.toml"
+
+    # Never-create: the file is adopter-owned; absent ⇒ no-op.
+    if not layout_path.exists():
+        return
+
+    # Scope-keyed default. A missing sub-table or missing/`non-str` `parent`
+    # ⇒ no-op (e.g. consumers that omit `[pack.layout.user]`).
+    scope_table = pack_layout.get(scope) if isinstance(pack_layout, dict) else None
+    default_parent = (
+        scope_table.get("parent") if isinstance(scope_table, dict) else None
+    )
+    if not isinstance(default_parent, str):
+        return
+
+    # Read + parse existing sections. A malformed file is left **untouched**
+    # (warn) — appending to a file we cannot parse risks a duplicate
+    # `[<pack>]` or a corrupt write, both worse than a skipped maintenance.
+    try:
+        existing = tomllib.loads(layout_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(
+            f"install: warning: existing layout file at {layout_path} is "
+            f"malformed ({exc}); leaving it untouched (no [{pack_name}] appended)",
+            file=sys.stderr,
+        )
+        return
+
+    # Never-overwrite: section already present ⇒ no-op.
+    if isinstance(existing.get(pack_name), dict):
+        return
+
+    # Re-emit: preserve each existing `[<pack>]` section's `parent`, type-
+    # validating it (drop a non-`str` `parent` before re-emission, mirroring
+    # `_append_install_marker`'s parsed-field hardening), then append the new
+    # section. Every emitted string — header key and value alike — routes
+    # through `_emit_basic_string`, so a tampered existing `parent` (or a
+    # hostile section key) cannot land phantom TOML structure on re-emit.
+    sections: list[tuple[str, str]] = []
+    for key, val in existing.items():
+        if not isinstance(val, dict):
+            # Off-schema top-level scalar/array we don't model (the documented
+            # file schema is `[<pack>]` tables only). Dropped on re-emit, as
+            # the marker model drops anything off its schema.
+            print(
+                f"install: warning: layout file at {layout_path} has an "
+                f"off-schema top-level key {key!r} ({type(val).__name__}); "
+                f"dropping it on re-emit",
+                file=sys.stderr,
+            )
+            continue
+        parent = val.get("parent")
+        if not isinstance(parent, str):
+            print(
+                f"install: warning: layout section [{key}] at {layout_path} "
+                f"has non-string parent (got {type(parent).__name__}); "
+                f"dropping the section on re-emit",
+                file=sys.stderr,
+            )
+            continue
+        sections.append((key, parent))
+    sections.append((pack_name, default_parent))
+
+    lines: list[str] = []
+    for name, parent in sections:
+        lines.append(f"[{_emit_basic_string(name)}]")
+        lines.append(f"parent = {_emit_basic_string(parent)}")
+        lines.append("")
+    content = "\n".join(lines).rstrip() + "\n"
+
+    # Per-scope jail, mirroring `_append_install_marker`: at repo scope the
+    # layout file is a top-level `agentbundle-layout.toml` (not under a
+    # declared prefix), so the per-prefix check is skipped; at user scope it
+    # sits under `.agentbundle/` and the adapter's `allowed-prefixes.user`
+    # list applies.
+    layout_prefixes = allowed_prefixes
+    if scope == "repo" and layout_relpath == "agentbundle-layout.toml":
+        layout_prefixes = None
+    safety.write_jailed(
+        root,
+        layout_relpath,
+        content,
+        scope=scope,
+        allowed_prefixes=layout_prefixes,
     )
 
 

--- a/packages/agentbundle/tests/unit/test_append_layout_section.py
+++ b/packages/agentbundle/tests/unit/test_append_layout_section.py
@@ -1,0 +1,240 @@
+"""Unit tests for `commands.install._append_layout_section` (T2).
+
+Spec: docs/specs/consolidated-pack-layout/spec.md (AC9, AC10, AC11).
+
+`_append_layout_section` maintains an adopter-owned `agentbundle-layout.toml`:
+it appends a pack's scope-keyed `[pack.layout.<scope>]` default as a `[<pack>]`
+table **only if the file already exists and the section is absent**. It never
+creates the file and never overwrites an existing section. It is modelled on
+`_append_install_marker`'s read + type-validate + re-emit upsert, so every
+emitted string (table header and value alike) routes through
+`_emit_basic_string`, and the write goes through the per-scope `write_jailed`
+jail.
+"""
+
+from __future__ import annotations
+
+import tomllib
+
+import pytest
+
+from agentbundle.commands.install import _append_layout_section
+from agentbundle.safety import PathJailError
+
+
+# ---------------------------------------------------------------------------
+# never-create / never-overwrite (AC9)
+# ---------------------------------------------------------------------------
+
+
+def test_never_create_no_op_when_file_absent(tmp_path):
+    """No layout file at the scope location ⇒ the append writes nothing."""
+    _append_layout_section(
+        tmp_path,
+        "repo",
+        pack_name="research",
+        pack_layout={"repo": {"parent": ".context/research"}},
+        allowed_prefixes=None,
+    )
+    assert not (tmp_path / "agentbundle-layout.toml").exists()
+
+
+def test_never_overwrite_leaves_existing_section_byte_identical(tmp_path):
+    """An existing `[<pack>]` section is left untouched — the whole file,
+    comments and all, is byte-identical (the never-overwrite check returns
+    before any re-emit)."""
+    layout = tmp_path / "agentbundle-layout.toml"
+    original = (
+        "# my hand-written layout\n"
+        '[research]\n'
+        'parent = "~/my-research"  # custom\n'
+    )
+    layout.write_text(original, encoding="utf-8")
+    _append_layout_section(
+        tmp_path,
+        "repo",
+        pack_name="research",
+        pack_layout={"repo": {"parent": ".context/research"}},
+        allowed_prefixes=None,
+    )
+    assert layout.read_text(encoding="utf-8") == original
+
+
+def test_appends_missing_section_when_file_exists(tmp_path):
+    """A pre-existing file missing `[research]` gains it (the other section
+    survives)."""
+    layout = tmp_path / "agentbundle-layout.toml"
+    layout.write_text('[architect]\nparent = "docs/design"\n', encoding="utf-8")
+    _append_layout_section(
+        tmp_path,
+        "repo",
+        pack_name="research",
+        pack_layout={"repo": {"parent": ".context/research"}},
+        allowed_prefixes=None,
+    )
+    parsed = tomllib.loads(layout.read_text(encoding="utf-8"))
+    assert parsed["architect"]["parent"] == "docs/design"
+    assert parsed["research"]["parent"] == ".context/research"
+
+
+# ---------------------------------------------------------------------------
+# scope-keyed selection + omit-`.user` no-op (AC10)
+# ---------------------------------------------------------------------------
+
+
+def test_scope_keyed_selection_repo_vs_user(tmp_path):
+    """Repo scope sources `[pack.layout.repo]`; user scope sources
+    `[pack.layout.user]`."""
+    pack_layout = {
+        "repo": {"parent": ".context/research"},
+        "user": {"parent": "/abs/user/research"},
+    }
+    # Repo scope.
+    repo_layout = tmp_path / "agentbundle-layout.toml"
+    repo_layout.write_text('[architect]\nparent = "docs/design"\n', encoding="utf-8")
+    _append_layout_section(
+        tmp_path, "repo", pack_name="research", pack_layout=pack_layout,
+        allowed_prefixes=None,
+    )
+    assert tomllib.loads(repo_layout.read_text())["research"]["parent"] == ".context/research"
+
+    # User scope — pre-create `.agentbundle/agentbundle-layout.toml`.
+    home = tmp_path / "home"
+    (home / ".agentbundle").mkdir(parents=True)
+    user_layout = home / ".agentbundle" / "agentbundle-layout.toml"
+    user_layout.write_text('[architect]\nparent = "docs/design"\n', encoding="utf-8")
+    _append_layout_section(
+        home, "user", pack_name="research", pack_layout=pack_layout,
+        allowed_prefixes=[".agentbundle/"],
+    )
+    assert tomllib.loads(user_layout.read_text())["research"]["parent"] == "/abs/user/research"
+
+
+def test_omit_user_subtable_is_user_scope_no_op(tmp_path):
+    """A pack declaring only `[pack.layout.repo]` ⇒ the user-scope append is a
+    no-op even though the file exists (the three current consumers' shape)."""
+    home = tmp_path / "home"
+    (home / ".agentbundle").mkdir(parents=True)
+    user_layout = home / ".agentbundle" / "agentbundle-layout.toml"
+    original = '[architect]\nparent = "docs/design"\n'
+    user_layout.write_text(original, encoding="utf-8")
+    _append_layout_section(
+        home,
+        "user",
+        pack_name="research",
+        pack_layout={"repo": {"parent": ".context/research"}},  # no `.user`
+        allowed_prefixes=[".agentbundle/"],
+    )
+    assert user_layout.read_text(encoding="utf-8") == original
+
+
+def test_no_layout_table_is_no_op(tmp_path):
+    """A pack shipping no `[pack.layout]` at all ⇒ no-op (safe to call for
+    every pack)."""
+    layout = tmp_path / "agentbundle-layout.toml"
+    original = '[architect]\nparent = "docs/design"\n'
+    layout.write_text(original, encoding="utf-8")
+    _append_layout_section(
+        tmp_path, "repo", pack_name="core", pack_layout={}, allowed_prefixes=None,
+    )
+    assert layout.read_text(encoding="utf-8") == original
+
+
+# ---------------------------------------------------------------------------
+# injection-safe emit + re-emit type-validation (AC11)
+# ---------------------------------------------------------------------------
+
+
+def test_injection_safe_roundtrip_of_default_parent(tmp_path):
+    """A `[pack.layout]` default containing `"`, `]`, newline, and `../`
+    round-trips intact and well-formed; no smuggled sibling table materialises."""
+    layout = tmp_path / "agentbundle-layout.toml"
+    layout.write_text('[architect]\nparent = "docs/design"\n', encoding="utf-8")
+    hostile = 'a"b]c\n[evil]\nx = "../../etc"'
+    _append_layout_section(
+        tmp_path, "repo", pack_name="research",
+        pack_layout={"repo": {"parent": hostile}}, allowed_prefixes=None,
+    )
+    text = layout.read_text(encoding="utf-8")
+    parsed = tomllib.loads(text)  # raises if malformed
+    assert parsed["research"]["parent"] == hostile  # intact
+    assert "evil" not in parsed  # no phantom table
+    assert set(parsed) == {"architect", "research"}
+
+
+def test_reemit_drops_tampered_existing_parent(tmp_path):
+    """A tampered existing section (`parent = 42`, `parent = ["x"]`) is dropped
+    on re-emit, not crashed on; the new section still lands."""
+    layout = tmp_path / "agentbundle-layout.toml"
+    layout.write_text(
+        '[architect]\nparent = 42\n\n[oldpack]\nparent = ["x"]\n',
+        encoding="utf-8",
+    )
+    _append_layout_section(
+        tmp_path, "repo", pack_name="research",
+        pack_layout={"repo": {"parent": ".context/research"}},
+        allowed_prefixes=None,
+    )
+    parsed = tomllib.loads(layout.read_text(encoding="utf-8"))
+    assert parsed["research"]["parent"] == ".context/research"
+    assert "architect" not in parsed  # non-str parent dropped
+    assert "oldpack" not in parsed
+
+
+def test_malformed_file_left_untouched(tmp_path):
+    """An unparseable existing file is left byte-identical (warn + no-op),
+    never corrupted by an append."""
+    layout = tmp_path / "agentbundle-layout.toml"
+    original = "this is not = valid toml ] [\n"
+    layout.write_text(original, encoding="utf-8")
+    _append_layout_section(
+        tmp_path, "repo", pack_name="research",
+        pack_layout={"repo": {"parent": ".context/research"}},
+        allowed_prefixes=None,
+    )
+    assert layout.read_text(encoding="utf-8") == original
+
+
+# ---------------------------------------------------------------------------
+# jailed write — user scope succeeds; symlink target fails closed (AC11, AC14)
+# ---------------------------------------------------------------------------
+
+
+def test_user_scope_write_succeeds_against_real_prefix_list(tmp_path):
+    """The user-scope write succeeds against a real `allowed-prefixes.user`
+    list carrying `.agentbundle/` (not merely the TypeError-when-omitted rail)."""
+    home = tmp_path / "home"
+    (home / ".agentbundle").mkdir(parents=True)
+    user_layout = home / ".agentbundle" / "agentbundle-layout.toml"
+    user_layout.write_text('[architect]\nparent = "docs/design"\n', encoding="utf-8")
+    _append_layout_section(
+        home,
+        "user",
+        pack_name="research",
+        pack_layout={"user": {"parent": "~/research-projects"}},
+        allowed_prefixes=[".claude/", ".agentbundle/"],
+    )
+    parsed = tomllib.loads(user_layout.read_text(encoding="utf-8"))
+    assert parsed["research"]["parent"] == "~/research-projects"
+
+
+def test_symlink_layout_file_fails_closed(tmp_path):
+    """When the layout *file path itself* is a symlink escaping `root`, the
+    append's `write_jailed` → `assert_under` realpath-resolve raises
+    `PathJailError` — it never follows the link out of tree."""
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    real_target = outside / "agentbundle-layout.toml"
+    real_target.write_text('[architect]\nparent = "docs/design"\n', encoding="utf-8")
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    link = repo / "agentbundle-layout.toml"
+    link.symlink_to(real_target)  # escapes `repo`
+
+    with pytest.raises(PathJailError):
+        _append_layout_section(
+            repo, "repo", pack_name="research",
+            pack_layout={"repo": {"parent": ".context/research"}},
+            allowed_prefixes=None,
+        )

--- a/packages/agentbundle/tests/unit/test_contract_v0_3_schema.py
+++ b/packages/agentbundle/tests/unit/test_contract_v0_3_schema.py
@@ -80,8 +80,9 @@ class ContractVersionTests(unittest.TestCase):
         # parity bumped it to v0.10; RFC-0026 / cursor-full-parity bumped it to
         # v0.11; docs/specs/gemini-full-parity bumped it to v0.13;
         # docs/specs/enriched-pack-manifest bumped it to v0.14;
-        # docs/specs/kiro-cli-agent-skill-resources bumps it to v0.15.
-        self.assertEqual(_load_contract()["contract"]["version"], "0.15")
+        # docs/specs/kiro-cli-agent-skill-resources bumped it to v0.15;
+        # docs/specs/consolidated-pack-layout bumps it to v0.16.
+        self.assertEqual(_load_contract()["contract"]["version"], "0.16")
 
 
 # ---------------------------------------------------------------------------

--- a/packs/architect/.apm/skills/architect-design/SKILL.md
+++ b/packs/architect/.apm/skills/architect-design/SKILL.md
@@ -80,10 +80,73 @@ If any check fails, push back rather than proceeding.
    the pass cap / stasis escape. **Never auto-resolve a judgment finding** —
    surface the tradeoff / risk / low-confidence calls as explicit decisions.
 
-7. **Offer to save.** Scan the working directory for an obvious home —
-   `docs/design/`, `design/`, `architecture/`, or `docs/`. Suggest a
-   kebab-case filename based on the doc's title. If nothing fits, ask
-   the user where it should go. Saving is an offer, never automatic.
+7. **Offer to save — config-driven, per-effort folder.** Resolve where the
+   design effort lands, in this order, **in this skill body**. Reading is
+   **prompt-only** (Charter Principle 3): this skill reads a file and
+   reasons about a path — there is no engine, index, daemon, or watcher
+   behind it, and the only code that ever *writes* the layout file is the
+   install-time append. See
+   [`references/agentbundle-layout.md`](references/agentbundle-layout.md)
+   for the `[architect]` section's full schema.
+
+   **Resolution order:**
+
+   a. **Read `agentbundle-layout.toml`'s `[architect]` table** if the
+      adopter created one. Two locations, **repo-root overrides user-profile
+      per table**: the repo-root `./agentbundle-layout.toml` `[architect]`
+      table if present, else the user-profile
+      `~/.agentbundle/agentbundle-layout.toml` `[architect]` table. The
+      file is **adopter-owned**, never shipped into a projected path. Its
+      `parent` key is a **base** directory under which each design effort
+      gets its own topic-named folder — never the leaf the effort lands in:
+
+      ```toml
+      # agentbundle-layout.toml (adopter-created; optional)
+      [architect]
+      parent = "docs/design"   # a base; per-effort folders are created under it
+      ```
+
+   b. **Fall back to the scan-then-elicit default** when no `[architect]`
+      section resolves: scan the working directory for an obvious home —
+      `docs/design/`, `design/`, `architecture/`, or `docs/` — and use the
+      first that exists. If nothing fits, ask the user where the effort
+      should live. The scan default base is `docs/design` (the pack's
+      `[pack.layout.repo]` default).
+
+   **Once the base is resolved**, each design effort gets its own
+   **per-effort folder**: `<parent>/<topic-slug>/` where `<topic-slug>` is a
+   short (~2–5 word) kebab-case slug derived from the design doc's title.
+   The design doc, diagrams, and notes all go inside that folder — not as
+   a loose file beside it. This is a change from the old single-file output;
+   the schema doc at `references/agentbundle-layout.md` documents the shift.
+
+   **Anchor `parent` by the layout file's own location**, never against the
+   ambient cwd: a **repo-root** file's `parent` is **repo-root-relative**
+   (an absolute value is permitted but warn it as non-portable); a
+   **user-profile** file's `parent` **must be an explicit absolute path**
+   (`~`-anchored is fine), and a *relative* value there is an Ask-first
+   deviation, never silently resolved.
+
+   **Resolve, then surface, then write.** After anchoring, resolve `parent`
+   to its **full absolute path** — `~`-expand it and **realpath-resolve it**
+   so any symlink in the path is made visible and never silently followed
+   out of the intended root — and **reject any `..` escape**. The `..`
+   rejection and the realpath happen **after** anchoring, so a relative
+   repo-file value that escapes via `..` (e.g. `parent = "../../etc"`) is
+   caught regardless of which file supplied it; anchoring never blesses a
+   `..`-bearing value as in-tree. Then **surface the resolved absolute path
+   to the adopter before creating the effort folder** — the first write is
+   always preceded by the path you are about to write under.
+
+   **A repo-root-sourced `parent` that resolves outside the repo tree** —
+   or whose resolution required following a symlink out of the intended root
+   — is **untrusted-origin**: a cloned, untrusted repo can carry a hostile
+   `parent` (`../../etc`, `~/.ssh`, an out-of-tree symlink). **Confirm the
+   resolved absolute path with the adopter before writing.** The user-profile
+   file is foot-gun-only (the adopter authored it), but still surface its
+   resolved path.
+
+   Saving is an offer, never automatic.
 
 8. **Decision-moment prompt.** If the doc captures one or more discrete
    decisions (technology choice, structural commitment, interface

--- a/packs/architect/.apm/skills/architect-design/references/agentbundle-layout.md
+++ b/packs/architect/.apm/skills/architect-design/references/agentbundle-layout.md
@@ -1,0 +1,69 @@
+# `agentbundle-layout.toml` — the `[architect]` section
+
+`agentbundle-layout.toml` is a single, **adopter-owned** file that controls where
+output-producing packs write their durable work. It is never shipped into a
+projected path; you create it by hand (or an `agentbundle install` step appends a
+default section to one you already have). This page documents the `[architect]`
+section that `architect-design` reads.
+
+## The `[architect]` table
+
+One key:
+
+```toml
+[architect]
+parent = "docs/design"   # a base directory; per-effort folders go *under* it
+```
+
+- **`parent` is a base, not the leaf.** Each design effort gets its own
+  topic-named child folder under `parent`: `<parent>/<topic-slug>/` where
+  `<topic-slug>` is a short (~2–5 word) kebab-case slug derived from the design
+  doc's title. The design doc, diagrams, and notes all go inside that folder.
+  `parent` is never the folder a single effort lands in.
+
+## File→folder shift
+
+Before this change, `architect-design` offered to save a single loose file,
+scanning `docs/design/`, `design/`, `architecture/`, or `docs/` for a home. The
+output is now a **per-effort folder** `<parent>/<topic-slug>/`. The scan-then-elicit
+behaviour (scanning those four directories) becomes the **default** when no
+`[architect]` section resolves — the scan default base is `docs/design`.
+
+## Two locations, repo overrides user
+
+The skill reads the **repo-root `./agentbundle-layout.toml`** `[architect]` table
+if present, else the **user-profile `~/.agentbundle/agentbundle-layout.toml`**
+table. When both define `[architect]`, the repo file's table wins; a table present
+only in the user file still applies. This lets a team commit a repo-wide choice
+while an individual keeps a personal default across repos.
+
+## `parent` is anchored by the file's own location
+
+- A **repo-root** file's `parent` is **repo-root-relative** (an absolute value is
+  allowed but flagged non-portable).
+- A **user-profile** file's `parent` **must be an explicit absolute path**
+  (`~`-anchored is fine). A relative value there is an *Ask-first* deviation —
+  never silently resolved against the ambient working directory.
+
+Regardless of anchor, the skill resolves `parent` to its full absolute path
+(realpath-resolved, `~`-expanded, `..` rejected) and **surfaces that path before
+the first write**. A repo-root-sourced `parent` that resolves outside the repo
+tree is treated as untrusted-origin and confirmed before writing.
+
+## Default and posture
+
+When no `[architect]` section resolves, the skill falls back to the scan-then-elicit
+default: it scans `docs/design/`, `design/`, `architecture/`, `docs/` in order and
+uses the first that exists; if none exists, it asks the user. The pack's
+`[pack.layout.repo]` default is `docs/design`.
+
+`architect` ships **no `[pack.layout.user]` default** — its output is per-repo
+(design docs belong in the repository they describe) and there is no sensible
+*absolute* user-scope base. For a personal cross-repo default, write an
+`[architect]` section into your user-profile file by hand:
+
+```toml
+# ~/.agentbundle/agentbundle-layout.toml
+[architect]
+# parent = "/abs/path/to/design-docs"   # uncomment + set an absolute path
+```

--- a/packs/architect/.apm/skills/architect-design/references/agentbundle-layout.md
+++ b/packs/architect/.apm/skills/architect-design/references/agentbundle-layout.md
@@ -3,7 +3,11 @@
 `agentbundle-layout.toml` is a single, **adopter-owned** file that controls where
 output-producing packs write their durable work. It is never shipped into a
 projected path; you create it by hand (or an `agentbundle install` step appends a
-default section to one you already have). This page documents the `[architect]`
+default section to one you already have — **append-if-exists / never-create /
+never-overwrite**). On the rare append of a *missing* section, the installer
+re-emits the file and does **not** preserve freeform comments or off-schema keys;
+an existing section is left byte-identical (the re-emit runs only when your
+section is absent). This page documents the `[architect]`
 section that `architect-design` reads.
 
 ## The `[architect]` table

--- a/packs/architect/.claude-plugin/plugin.json
+++ b/packs/architect/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "architect",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Solution-architecture skills (architect-design, architect-diagram, architect-review) plus a forked-context design-reviewer subagent. Workspace-agnostic, user-scope by default, no required configuration."
 }

--- a/packs/architect/pack.toml
+++ b/packs/architect/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "architect"
-version = "0.6.1"
+version = "0.7.0"
 description = "Solution-architecture skills (architect-design, architect-diagram, architect-review) plus a forked-context design-reviewer subagent. Workspace-agnostic, user-scope by default, no required configuration. Mermaid for diagrams; Google-style design docs; rubric-routed critique."
 readme = "README.md"
 display_name = "Architect"
@@ -28,6 +28,16 @@ allowed-scopes = ["user", "repo"]
 # `kiro-ide` precedes `kiro-cli` so a Kiro user's `~/.kiro/` auto-probe resolves
 # to the IDE; `cursor` then `gemini` appended last (append-only).
 allowed-adapters = ["claude-code", "codex", "copilot", "kiro-ide", "kiro-cli", "cursor", "gemini"]
+
+# RFC-0040 / ADR-0030 / consolidated-pack-layout: the scope-keyed default for the
+# [architect] section of an adopter-owned `agentbundle-layout.toml`. Each design
+# effort lands in its own per-effort folder <parent>/<topic-slug>/ under the base.
+# No `[pack.layout.user]`: architect's output is per-repo (design docs belong in
+# the repository they describe) and there is no sensible *absolute* user base, so
+# the user-scope install append is a no-op (adopters write an [architect] section
+# by hand; see the skill's references/agentbundle-layout.md).
+[pack.layout.repo]
+parent = "docs/design"
 
 # enriched-pack-manifest (RFC-0031 / ADR-0021): catalogue-facing links
 # + maintainer, including the `documentation` link to the per-pack guide home.

--- a/packs/product-engineering/.apm/skills/align-value-stream/SKILL.md
+++ b/packs/product-engineering/.apm/skills/align-value-stream/SKILL.md
@@ -50,14 +50,71 @@ Before aligning, confirm:
    lives **here**; each component repo's own `reference.md` links to and conforms
    to it rather than re-deriving the system view. This is the `architect` seam.
 
-5. **Keep the rollup current.** Maintain the cross-component rollup (copy this
-   skill's `assets/rollup-template.md` to `docs/product/rollups/<slug>.md`): one
-   row per slice `decompose-intent`
-   produced → its brief → a **status snapshot + a pointer** to that repo's own
-   auto-derived coverage. The **AND across rows** is the answer; an absent-source
-   row is `unknown / not-yet-catalogued`, never silently delivered. See
-   `references/cross-component-rollup.md` and, for the discipline that keeps every
-   artifact above honest, `references/catalog-currency.md`.
+5. **Keep the rollup current.** Resolve `parent` using the config-driven
+   procedure below, then maintain the cross-component rollup (copy this skill's
+   `assets/rollup-template.md` to `<parent>/rollups/<slug>.md`): one row per
+   slice `decompose-intent` produced → its brief → a **status snapshot + a
+   pointer** to that repo's own auto-derived coverage. The **AND across rows** is
+   the answer; an absent-source row is `unknown / not-yet-catalogued`, never
+   silently delivered. See `references/cross-component-rollup.md` and, for the
+   discipline that keeps every artifact above honest, `references/catalog-currency.md`.
+
+## Where the rollup lives — config-driven, `docs/product` by default
+
+Resolve the rollup **parent** directory in this order, **in this skill body**.
+Reading is **prompt-only** (Charter Principle 3): this skill reads a file and
+reasons about a path — there is no engine, index, daemon, or watcher behind it,
+and the only code that ever *writes* the layout file is the install-time append.
+See [`references/agentbundle-layout.md`](references/agentbundle-layout.md) for the
+`[product-engineering]` section's full schema.
+
+1. **Read `agentbundle-layout.toml`'s `[product-engineering]` table** if the
+   adopter created one. Two locations, **repo-root overrides user-profile per
+   table**: the repo-root `./agentbundle-layout.toml` `[product-engineering]`
+   table if present, else the user-profile
+   `~/.agentbundle/agentbundle-layout.toml` `[product-engineering]` table. The
+   file is **adopter-owned**, never shipped into a projected path. Its `parent`
+   key is a **base** directory under which rollups are written as individual
+   files — never a per-topic folder:
+
+   ```toml
+   # agentbundle-layout.toml (adopter-created; optional)
+   [product-engineering]
+   parent = "docs/product"   # a base; rollups land at <parent>/rollups/<slug>.md
+   ```
+
+2. **Fall back to the pack's own default** — `docs/product`.
+3. **Elicit** if neither resolves — ask the user where rollups should live.
+
+**Anchor `parent` by the layout file's own location**, never against the ambient
+cwd: a **repo-root** file's `parent` is **repo-root-relative** (an absolute value
+is permitted but warn it as non-portable); a **user-profile** file's `parent`
+**must be an explicit absolute path** (`~`-anchored is fine), and a *relative*
+value there is an Ask-first deviation, never silently resolved.
+
+**Resolve, then surface, then write.** After anchoring, resolve `parent` to its
+**full absolute path** — `~`-expand it and **realpath-resolve it** so any symlink
+in the path is made visible and never silently followed out of the intended root
+— and **reject any `..` escape**. The `..` rejection and the realpath happen
+**after** anchoring, so a relative repo-file value that escapes via `..` (e.g.
+`parent = "../../etc"`) is caught regardless of which file supplied it; anchoring
+never blesses a `..`-bearing value as in-tree. Then **surface the resolved
+absolute path to the adopter before creating the rollup file** — the first write
+is always preceded by the path you are about to write under.
+
+**A repo-root-sourced `parent` that resolves outside the repo tree** — or whose
+resolution required following a symlink out of the intended root — is
+**untrusted-origin**: a cloned, untrusted repo can carry a hostile `parent`
+(`../../etc`, `~/.ssh`, an out-of-tree symlink). **Confirm the resolved absolute
+path with the adopter before writing.** The user-profile file is foot-gun-only
+(the adopter authored it), but still surface its resolved path.
+
+**Output shape — file-per-slug, not a per-topic folder.** Rollup files live
+directly under `<parent>/rollups/<slug>.md`. A per-topic folder is deliberately
+**not** used: each rollup is a single file. `decompose-intent`'s
+`docs/product/briefs/<slug>.md` output stays **pinned** — that path is the
+hand-off to core's `receive-brief` and is not governed by this config (RFC-0040
+non-goal).
 
 ## Hard limits — state them honestly
 

--- a/packs/product-engineering/.apm/skills/align-value-stream/references/agentbundle-layout.md
+++ b/packs/product-engineering/.apm/skills/align-value-stream/references/agentbundle-layout.md
@@ -1,0 +1,72 @@
+# `agentbundle-layout.toml` — the `[product-engineering]` section
+
+`agentbundle-layout.toml` is a single, **adopter-owned** file that controls where
+output-producing packs write their durable work. It is never shipped into a
+projected path; you create it by hand (or an `agentbundle install` step appends a
+default section to one you already have). This page documents the
+`[product-engineering]` section that `frame-intent` and `align-value-stream` read.
+
+## The `[product-engineering]` table
+
+One key:
+
+```toml
+[product-engineering]
+parent = "docs/product"   # a base directory; output files go *under* it
+```
+
+- **`parent` is a base, not the leaf.** Each output file is written directly
+  under a subdirectory of `parent` — never to `parent` itself. The file-per-slug
+  shapes are:
+  - `frame-intent` → `<parent>/intents/<slug>.md`
+  - `align-value-stream` → `<parent>/rollups/<slug>.md`
+
+  A **per-topic folder** is deliberately **not** used: each intent and each
+  rollup is a single file handed downstream (`de-risk-intent`, `decompose-intent`,
+  `receive-brief`).
+
+## Two locations, repo overrides user
+
+The skill reads the **repo-root `./agentbundle-layout.toml`**
+`[product-engineering]` table if present, else the **user-profile
+`~/.agentbundle/agentbundle-layout.toml`** table. When both define
+`[product-engineering]`, the repo file's table wins; a table present only in the
+user file still applies. This lets a team commit a repo-wide choice while an
+individual keeps a personal default across repos.
+
+## `parent` is anchored by the file's own location
+
+- A **repo-root** file's `parent` is **repo-root-relative** (an absolute value is
+  allowed but flagged non-portable).
+- A **user-profile** file's `parent` **must be an explicit absolute path**
+  (`~`-anchored is fine). A relative value there is an *Ask-first* deviation —
+  never silently resolved against the ambient working directory.
+
+Regardless of anchor, the skill resolves `parent` to its full absolute path
+(realpath-resolved, `~`-expanded, `..` rejected) and **surfaces that path before
+the first write**. A repo-root-sourced `parent` that resolves outside the repo
+tree is treated as untrusted-origin and confirmed before writing.
+
+## Default and posture
+
+When no `[product-engineering]` section resolves, the pack defaults to
+`docs/product` (its `[pack.layout.repo]` default) — committed product docs, the
+natural home for intents and rollups in a product engineering repo.
+
+`product-engineering` ships **no `[pack.layout.user]` default** — its output is
+per-repo and there is no sensible *absolute* user-scope base. For a personal
+cross-repo default, write a `[product-engineering]` section into your user-profile
+file by hand:
+
+```toml
+# ~/.agentbundle/agentbundle-layout.toml
+[product-engineering]
+# parent = "/abs/path/to/product-docs"   # uncomment + set an absolute path
+```
+
+## Pinned output — `decompose-intent`'s briefs
+
+`decompose-intent`'s `docs/product/briefs/<slug>.md` output is **not** governed
+by this table. That path is the hand-off to core's `receive-brief` skill and
+stays pinned (RFC-0040 non-goal). Only `frame-intent` (intents) and
+`align-value-stream` (rollups) read `[product-engineering]`.

--- a/packs/product-engineering/.apm/skills/align-value-stream/references/agentbundle-layout.md
+++ b/packs/product-engineering/.apm/skills/align-value-stream/references/agentbundle-layout.md
@@ -3,7 +3,11 @@
 `agentbundle-layout.toml` is a single, **adopter-owned** file that controls where
 output-producing packs write their durable work. It is never shipped into a
 projected path; you create it by hand (or an `agentbundle install` step appends a
-default section to one you already have). This page documents the
+default section to one you already have — **append-if-exists / never-create /
+never-overwrite**). On the rare append of a *missing* section, the installer
+re-emits the file and does **not** preserve freeform comments or off-schema keys;
+an existing section is left byte-identical (the re-emit runs only when your
+section is absent). This page documents the
 `[product-engineering]` section that `frame-intent` and `align-value-stream` read.
 
 ## The `[product-engineering]` table

--- a/packs/product-engineering/.apm/skills/frame-intent/SKILL.md
+++ b/packs/product-engineering/.apm/skills/frame-intent/SKILL.md
@@ -23,7 +23,8 @@ Before framing, confirm:
    business. If the work is a pure refactor or chore with no user-facing
    outcome, it doesn't need an intent; say so.
 3. This skill ships the `intent` template at `assets/intent-template.md`.
-   Copy it to `docs/product/intents/<slug>.md`; fill what you have.
+   Resolve where to write it using the config-driven procedure below, then
+   write it to `<parent>/intents/<slug>.md`; fill what you have.
 
 ## Procedure
 
@@ -74,10 +75,69 @@ Before framing, confirm:
    line each. Don't test them here; `de-risk-intent` picks the riskiest and
    predeclares a kill condition. Leave `Decomposition` empty.
 
-7. **Hand off.** Record the intent at `docs/product/intents/<slug>.md` and point
-   the user at `de-risk-intent` (to test the riskiest assumption) or, once it
-   survives, `decompose-intent` (to break it down). See
+7. **Hand off.** Resolve `parent` using the config-driven procedure below and
+   record the intent at `<parent>/intents/<slug>.md` (file-per-slug — a single
+   file handed downstream, not a per-topic folder). Point the user at
+   `de-risk-intent` (to test the riskiest assumption) or, once it survives,
+   `decompose-intent` (to break it down). See
    `examples/feature-intent-to-brief.md` for a worked app-scale walk-through.
+
+## Where the intent lives — config-driven, `docs/product` by default
+
+Resolve the intent **parent** directory in this order, **in this skill body**.
+Reading is **prompt-only** (Charter Principle 3): this skill reads a file and
+reasons about a path — there is no engine, index, daemon, or watcher behind it,
+and the only code that ever *writes* the layout file is the install-time append.
+See [`references/agentbundle-layout.md`](references/agentbundle-layout.md) for the
+`[product-engineering]` section's full schema.
+
+1. **Read `agentbundle-layout.toml`'s `[product-engineering]` table** if the
+   adopter created one. Two locations, **repo-root overrides user-profile per
+   table**: the repo-root `./agentbundle-layout.toml` `[product-engineering]`
+   table if present, else the user-profile
+   `~/.agentbundle/agentbundle-layout.toml` `[product-engineering]` table. The
+   file is **adopter-owned**, never shipped into a projected path. Its `parent`
+   key is a **base** directory under which intents are written as individual
+   files — never a per-topic folder:
+
+   ```toml
+   # agentbundle-layout.toml (adopter-created; optional)
+   [product-engineering]
+   parent = "docs/product"   # a base; intents land at <parent>/intents/<slug>.md
+   ```
+
+2. **Fall back to the pack's own default** — `docs/product`.
+3. **Elicit** if neither resolves — ask the user where intents should live.
+
+**Anchor `parent` by the layout file's own location**, never against the ambient
+cwd: a **repo-root** file's `parent` is **repo-root-relative** (an absolute value
+is permitted but warn it as non-portable); a **user-profile** file's `parent`
+**must be an explicit absolute path** (`~`-anchored is fine), and a *relative*
+value there is an Ask-first deviation, never silently resolved.
+
+**Resolve, then surface, then write.** After anchoring, resolve `parent` to its
+**full absolute path** — `~`-expand it and **realpath-resolve it** so any symlink
+in the path is made visible and never silently followed out of the intended root
+— and **reject any `..` escape**. The `..` rejection and the realpath happen
+**after** anchoring, so a relative repo-file value that escapes via `..` (e.g.
+`parent = "../../etc"`) is caught regardless of which file supplied it; anchoring
+never blesses a `..`-bearing value as in-tree. Then **surface the resolved
+absolute path to the adopter before creating the intent file** — the first write
+is always preceded by the path you are about to write under.
+
+**A repo-root-sourced `parent` that resolves outside the repo tree** — or whose
+resolution required following a symlink out of the intended root — is
+**untrusted-origin**: a cloned, untrusted repo can carry a hostile `parent`
+(`../../etc`, `~/.ssh`, an out-of-tree symlink). **Confirm the resolved absolute
+path with the adopter before writing.** The user-profile file is foot-gun-only
+(the adopter authored it), but still surface its resolved path.
+
+**Output shape — file-per-slug, not a per-topic folder.** Intent files live
+directly under `<parent>/intents/<slug>.md`. A per-topic folder is deliberately
+**not** used: each intent is a single file handed downstream to `de-risk-intent`
+and `decompose-intent`. `decompose-intent`'s `docs/product/briefs/<slug>.md`
+output stays **pinned** — that path is the hand-off to core's `receive-brief`
+and is not governed by this config (RFC-0040 non-goal).
 
 ## Anti-patterns to refuse
 

--- a/packs/product-engineering/.apm/skills/frame-intent/references/agentbundle-layout.md
+++ b/packs/product-engineering/.apm/skills/frame-intent/references/agentbundle-layout.md
@@ -1,0 +1,72 @@
+# `agentbundle-layout.toml` — the `[product-engineering]` section
+
+`agentbundle-layout.toml` is a single, **adopter-owned** file that controls where
+output-producing packs write their durable work. It is never shipped into a
+projected path; you create it by hand (or an `agentbundle install` step appends a
+default section to one you already have). This page documents the
+`[product-engineering]` section that `frame-intent` and `align-value-stream` read.
+
+## The `[product-engineering]` table
+
+One key:
+
+```toml
+[product-engineering]
+parent = "docs/product"   # a base directory; output files go *under* it
+```
+
+- **`parent` is a base, not the leaf.** Each output file is written directly
+  under a subdirectory of `parent` — never to `parent` itself. The file-per-slug
+  shapes are:
+  - `frame-intent` → `<parent>/intents/<slug>.md`
+  - `align-value-stream` → `<parent>/rollups/<slug>.md`
+
+  A **per-topic folder** is deliberately **not** used: each intent and each
+  rollup is a single file handed downstream (`de-risk-intent`, `decompose-intent`,
+  `receive-brief`).
+
+## Two locations, repo overrides user
+
+The skill reads the **repo-root `./agentbundle-layout.toml`**
+`[product-engineering]` table if present, else the **user-profile
+`~/.agentbundle/agentbundle-layout.toml`** table. When both define
+`[product-engineering]`, the repo file's table wins; a table present only in the
+user file still applies. This lets a team commit a repo-wide choice while an
+individual keeps a personal default across repos.
+
+## `parent` is anchored by the file's own location
+
+- A **repo-root** file's `parent` is **repo-root-relative** (an absolute value is
+  allowed but flagged non-portable).
+- A **user-profile** file's `parent` **must be an explicit absolute path**
+  (`~`-anchored is fine). A relative value there is an *Ask-first* deviation —
+  never silently resolved against the ambient working directory.
+
+Regardless of anchor, the skill resolves `parent` to its full absolute path
+(realpath-resolved, `~`-expanded, `..` rejected) and **surfaces that path before
+the first write**. A repo-root-sourced `parent` that resolves outside the repo
+tree is treated as untrusted-origin and confirmed before writing.
+
+## Default and posture
+
+When no `[product-engineering]` section resolves, the pack defaults to
+`docs/product` (its `[pack.layout.repo]` default) — committed product docs, the
+natural home for intents and rollups in a product engineering repo.
+
+`product-engineering` ships **no `[pack.layout.user]` default** — its output is
+per-repo and there is no sensible *absolute* user-scope base. For a personal
+cross-repo default, write a `[product-engineering]` section into your user-profile
+file by hand:
+
+```toml
+# ~/.agentbundle/agentbundle-layout.toml
+[product-engineering]
+# parent = "/abs/path/to/product-docs"   # uncomment + set an absolute path
+```
+
+## Pinned output — `decompose-intent`'s briefs
+
+`decompose-intent`'s `docs/product/briefs/<slug>.md` output is **not** governed
+by this table. That path is the hand-off to core's `receive-brief` skill and
+stays pinned (RFC-0040 non-goal). Only `frame-intent` (intents) and
+`align-value-stream` (rollups) read `[product-engineering]`.

--- a/packs/product-engineering/.apm/skills/frame-intent/references/agentbundle-layout.md
+++ b/packs/product-engineering/.apm/skills/frame-intent/references/agentbundle-layout.md
@@ -3,7 +3,11 @@
 `agentbundle-layout.toml` is a single, **adopter-owned** file that controls where
 output-producing packs write their durable work. It is never shipped into a
 projected path; you create it by hand (or an `agentbundle install` step appends a
-default section to one you already have). This page documents the
+default section to one you already have — **append-if-exists / never-create /
+never-overwrite**). On the rare append of a *missing* section, the installer
+re-emits the file and does **not** preserve freeform comments or off-schema keys;
+an existing section is left byte-identical (the re-emit runs only when your
+section is absent). This page documents the
 `[product-engineering]` section that `frame-intent` and `align-value-stream` read.
 
 ## The `[product-engineering]` table

--- a/packs/product-engineering/.claude-plugin/plugin.json
+++ b/packs/product-engineering/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "product-engineering",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Shape product intent into shippable specs — and into the words users read. Habits — frame-intent, de-risk-intent, decompose-intent — over a recursive, level-tagged `intent` (a capability intent and a feature intent are the same artifact at different levels): outcome+opportunity framing, a choosable prototype-approach to de-risk the riskiest assumption, and decomposition into the briefs/specs your delivery loop already builds — at app scale, or sliced per component across a business-unit value stream coordinated by `align-value-stream`. `voice-and-microcopy` adds the content layer: characterize a product's voice and write blame-free, actionable UI copy. Pure-markdown, user-scope."
 }

--- a/packs/product-engineering/pack.toml
+++ b/packs/product-engineering/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "product-engineering"
-version = "0.4.2"
+version = "0.5.0"
 description = "Shape product intent into shippable specs — and into the words users read. Habits — frame-intent, de-risk-intent, decompose-intent — over a recursive, level-tagged `intent` (a capability intent and a feature intent are the same artifact at different levels): outcome+opportunity framing, a choosable prototype-approach to de-risk the riskiest assumption, and decomposition into the briefs/specs your delivery loop already builds — at app scale, or sliced per component across a business-unit value stream coordinated by `align-value-stream`. `voice-and-microcopy` adds the content layer: characterize a product's voice and write blame-free, actionable UI copy. Pure-markdown, user-scope."
 readme = "README.md"
 display_name = "Product Engineering"
@@ -22,6 +22,16 @@ allowed-scopes = ["user", "repo"]
 # RFC-0011 / pack-allowed-adapters. Declared order is load-bearing (append-only);
 # `kiro-ide` precedes the others so a Kiro user's auto-probe resolves to the IDE.
 allowed-adapters = ["claude-code", "kiro-ide", "codex", "copilot", "cursor", "gemini"]
+
+# RFC-0040 / ADR-0030 / consolidated-pack-layout: the scope-keyed default for the
+# [product-engineering] section of an adopter-owned `agentbundle-layout.toml`.
+# The repo default is docs/product — the natural home for product intents and
+# rollups. No `[pack.layout.user]`: product-engineering's output is per-repo and
+# there is no sensible *absolute* user base, so the user-scope install append is
+# a no-op (adopters write a user `[product-engineering]` section by hand; see
+# the skill's references/agentbundle-layout.md).
+[pack.layout.repo]
+parent = "docs/product"
 
 # enriched-pack-manifest (RFC-0031 / ADR-0021): catalogue-facing links
 # + maintainer, including the `documentation` link to the per-pack guide home.

--- a/packs/research/.apm/skills/research-project-start/SKILL.md
+++ b/packs/research/.apm/skills/research-project-start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research-project-start
-description: "Start a stateful, multi-week research project — the lifecycle axis, orthogonal to the depth axis the `/research` skill carries. Triggers on explicit project-lifecycle phrasing — \"start a research project\", \"set up a research project on X\", \"begin a sustained investigation\", \"open a research dossier\" — never on a one-shot lookup. Scaffolds the three-layer project folder (overview.md + a raw sources/ layer + the later digest and synthesis), records the question and a possibly-empty working hypothesis, and sets phase to capture. Resolves the project parent from an adopter-created research-layout.toml, else a scratch / out-of-repo default, else by eliciting — never the committed repo tree. Prompt-only: phase is a frontmatter string the agent reads and writes; no engine, index, daemon, or counter. Does not replace /research — episodic quick/standard/applied/deep lookups stay there."
+description: "Start a stateful, multi-week research project — the lifecycle axis, orthogonal to the depth axis the `/research` skill carries. Triggers on explicit project-lifecycle phrasing — \"start a research project\", \"set up a research project on X\", \"begin a sustained investigation\", \"open a research dossier\" — never on a one-shot lookup. Scaffolds the three-layer project folder (overview.md + a raw sources/ layer + the later digest and synthesis), records the question and a possibly-empty working hypothesis, and sets phase to capture. Resolves the project parent from the [research] table of an adopter-created agentbundle-layout.toml, else a scratch .context/research default, else by eliciting — never the committed repo tree. Prompt-only: phase is a frontmatter string the agent reads and writes; no engine, index, daemon, or counter. Does not replace /research — episodic quick/standard/applied/deep lookups stay there."
 ---
 
 # /research-project-start
@@ -82,23 +82,55 @@ prior is fine too; it is held loosely and revised, never defended.
 
 ## Where the project lives — config-driven, scratch by default
 
-Resolve the project **parent** directory in this order:
+Resolve the project **parent** directory in this order, **in this skill body**.
+Reading is **prompt-only** (Charter Principle 3): this skill reads a file and
+reasons about a path — there is no engine, index, daemon, or watcher behind it,
+and the only code that ever *writes* the layout file is the install-time append.
+See [`references/agentbundle-layout.md`](references/agentbundle-layout.md) for the
+`[research]` section's full schema.
 
-1. **Read `research-layout.toml`** if the adopter created one — at the
-   documented known path (the repo root, or `~/.agentbundle/research-layout.toml`
-   for a user-level default). It is **adopter-created**, never shipped into a
-   projected path (that would trip the self-host drift gate). Keys:
+1. **Read `agentbundle-layout.toml`'s `[research]` table** if the adopter created
+   one. Two locations, **repo-root overrides user-profile per table**: the
+   repo-root `./agentbundle-layout.toml` `[research]` table if present, else the
+   user-profile `~/.agentbundle/agentbundle-layout.toml` `[research]` table. The
+   file is **adopter-owned**, never shipped into a projected path (that would trip
+   the self-host drift gate). Its `parent` key is a **base** directory under which
+   each project gets its own topic-named folder — never the leaf the project lands
+   in:
 
    ```toml
-   # research-layout.toml (adopter-created; optional)
-   parent = "~/research-projects"   # where project folders are created
-   # filename / schema overrides are optional and rarely needed
+   # agentbundle-layout.toml (adopter-created; optional)
+   [research]
+   parent = "~/research-projects"   # a base; project folders are created under it
    ```
 
-2. **Fall back to the scratch / out-of-repo default** — a gitignored
-   `.context/research/` under the repo, or a user-level path. The default is
-   **scratch**: a code repo commits the *decision* (the brief), never the corpus.
+2. **Fall back to the pack's own default** — a gitignored `.context/research/`
+   under the repo. The default is **scratch**: a code repo commits the *decision*
+   (the brief), never the corpus.
 3. **Elicit** if neither resolves — ask the user where the project should live.
+
+**Anchor `parent` by the layout file's own location**, never against the ambient
+cwd: a **repo-root** file's `parent` is **repo-root-relative** (an absolute value
+is permitted but warn it as non-portable); a **user-profile** file's `parent`
+**must be an explicit absolute path** (`~`-anchored is fine), and a *relative*
+value there is an Ask-first deviation, never silently resolved.
+
+**Resolve, then surface, then write.** After anchoring, resolve `parent` to its
+**full absolute path** — `~`-expand it and **realpath-resolve it** so any symlink
+in the path is made visible and never silently followed out of the intended root
+— and **reject any `..` escape**. The `..` rejection and the realpath happen
+**after** anchoring, so a relative repo-file value that escapes via `..` (e.g.
+`parent = "../../etc"`) is caught regardless of which file supplied it; anchoring
+never blesses a `..`-bearing value as in-tree. Then **surface the resolved
+absolute path to the adopter before creating the project folder** — the first
+write is always preceded by the path you are about to write under.
+
+**A repo-root-sourced `parent` that resolves outside the repo tree** — or whose
+resolution required following a symlink out of the intended root — is
+**untrusted-origin**: a cloned, untrusted repo can carry a hostile `parent`
+(`../../etc`, `~/.ssh`, an out-of-tree symlink). **Confirm the resolved absolute
+path with the adopter before writing.** The user-profile file is foot-gun-only
+(the adopter authored it), but still surface its resolved path.
 
 **Never create the project inside the committed repo tree** (`docs/`, repo
 root). Pointing the layout at a durable vault or the committed tree is an
@@ -107,6 +139,12 @@ configured exception for product research). `.context/` is per-workspace and
 gitignored, so a scratch corpus does not survive the workspace — for a
 high-stakes reasoning trail, configure a durable-but-separate parent and link it
 from the brief.
+
+This generalises the read `research-project-mode` shipped via the old
+`research-layout.toml` into the shared `agentbundle-layout.toml` `[research]`
+table — a **clean rename, no alias** (the old file was undistributed, so nothing
+in the wild holds the old name). RFC-0038's forward-only migration alias was
+considered and found not to apply.
 
 ## Source provenance — optional, additive axes
 

--- a/packs/research/.apm/skills/research-project-start/references/agentbundle-layout.md
+++ b/packs/research/.apm/skills/research-project-start/references/agentbundle-layout.md
@@ -1,0 +1,60 @@
+# `agentbundle-layout.toml` — the `[research]` section
+
+`agentbundle-layout.toml` is a single, **adopter-owned** file that controls where
+output-producing packs write their durable work. It is never shipped into a
+projected path; you create it by hand (or an `agentbundle install` step appends a
+default section to one you already have). This page documents the `[research]`
+section that `research-project-start` reads.
+
+## The `[research]` table
+
+One key:
+
+```toml
+[research]
+parent = "~/research-projects"   # a base directory; project folders go *under* it
+```
+
+- **`parent` is a base, not the leaf.** Each project gets its own topic-named
+  child folder under `parent`: `<parent>/<YYYY-MM-DD>-<topic-slug>/` (the start
+  date + the question's kebab-case slug). `parent` is never the folder a single
+  project lands in.
+
+## Two locations, repo overrides user
+
+The skill reads the **repo-root `./agentbundle-layout.toml`** `[research]` table
+if present, else the **user-profile `~/.agentbundle/agentbundle-layout.toml`**
+table. When both define `[research]`, the repo file's table wins; a table present
+only in the user file still applies. This lets a team commit a repo-wide choice
+while an individual keeps a personal default across repos.
+
+## `parent` is anchored by the file's own location
+
+- A **repo-root** file's `parent` is **repo-root-relative** (an absolute value is
+  allowed but flagged non-portable).
+- A **user-profile** file's `parent` **must be an explicit absolute path**
+  (`~`-anchored is fine). A relative value there is an *Ask-first* deviation —
+  never silently resolved against the ambient working directory.
+
+Regardless of anchor, the skill resolves `parent` to its full absolute path
+(realpath-resolved, `~`-expanded, `..` rejected) and **surfaces that path before
+the first write**. A repo-root-sourced `parent` that resolves outside the repo
+tree is treated as untrusted-origin and confirmed before writing.
+
+## Default and posture
+
+When no `[research]` section resolves, the pack defaults to a gitignored
+`.context/research/` (its `[pack.layout.repo]` default) — **scratch / out-of-repo
+by default**, because a code repo commits the *decision* (the brief), never the
+corpus. **Never the committed repo tree** (`docs/`, repo root); pointing at a
+durable vault is the deliberate, configured exception.
+
+`research` ships **no `[pack.layout.user]` default** — its output is per-repo and
+there is no sensible *absolute* user-scope base. For a personal cross-repo
+default, write a `[research]` section into your user-profile file by hand:
+
+```toml
+# ~/.agentbundle/agentbundle-layout.toml
+[research]
+# parent = "/abs/path/to/research-projects"   # uncomment + set an absolute path
+```

--- a/packs/research/.apm/skills/research-project-start/references/agentbundle-layout.md
+++ b/packs/research/.apm/skills/research-project-start/references/agentbundle-layout.md
@@ -3,7 +3,11 @@
 `agentbundle-layout.toml` is a single, **adopter-owned** file that controls where
 output-producing packs write their durable work. It is never shipped into a
 projected path; you create it by hand (or an `agentbundle install` step appends a
-default section to one you already have). This page documents the `[research]`
+default section to one you already have — **append-if-exists / never-create /
+never-overwrite**). On the rare append of a *missing* section, the installer
+re-emits the file and does **not** preserve freeform comments or off-schema keys;
+an existing section is left byte-identical (the re-emit runs only when your
+section is absent). This page documents the `[research]`
 section that `research-project-start` reads.
 
 ## The `[research]` table

--- a/packs/research/.claude-plugin/plugin.json
+++ b/packs/research/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "research",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Evidence-grounded research portable across every repo. Eleven skills (scoping, source curation, synthesis, adversarial review, decision support, rationale reconstruction, plus a four-skill project-mode lifecycle for sustained multi-week investigations) plus two retrieval subagents; methodology grounded in seven convergent disciplines (STORM, PRISMA, ACH, Wikipedia V/RS/NPOV, OSINT, GIJN, GRADE)."
 }

--- a/packs/research/pack.toml
+++ b/packs/research/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "research"
-version = "0.4.0"
+version = "0.5.0"
 description = "Evidence-grounded research portable across every repo. Eleven skills (scoping, source curation, synthesis, adversarial review, decision support, rationale reconstruction, plus a four-skill project-mode lifecycle for sustained multi-week investigations) plus two retrieval subagents; methodology grounded in seven convergent disciplines (STORM, PRISMA, ACH, Wikipedia V/RS/NPOV, OSINT, GIJN, GRADE)."
 readme = "README.md"
 display_name = "Research"
@@ -34,6 +34,16 @@ allowed-adapters = ["claude-code", "kiro-ide", "codex", "copilot", "cursor", "ge
 # **not** degraded there. The read-only restriction is preserved (no
 # edit/execute). The one narrow non-coverage is the Copilot **cloud agent**
 # (served only via repo `.github/`), which has no `web` tool.
+
+# RFC-0040 / ADR-0030 / consolidated-pack-layout: the scope-keyed default for the
+# [research] section of an adopter-owned `agentbundle-layout.toml`. The repo
+# default is gitignored scratch — research commits the *decision* (the brief),
+# never the corpus, and never the committed repo tree. No `[pack.layout.user]`:
+# research's output is per-repo and there is no sensible *absolute* user base, so
+# the user-scope install append is a no-op (adopters write a user `[research]`
+# section by hand; see the skill's references/agentbundle-layout.md).
+[pack.layout.repo]
+parent = ".context/research"
 
 # enriched-pack-manifest (RFC-0031 / ADR-0021): catalogue-facing links
 # + maintainer, including the `documentation` link to the per-pack guide home.


### PR DESCRIPTION
## What does this change?

Implements the `consolidated-pack-layout` spec (RFC-0040 / ADR-0030): one adopter-owned, namespaced **`agentbundle-layout.toml`** that three output-producing packs (`research`, `architect`, `product-engineering`) read **prompt-only** to decide where their durable output lands. Adds the optional scope-keyed `[pack.layout]` manifest extension (adapter contract `0.15 → 0.16`) and an installer `_append_layout_section` step (append-if-exists / never-create / never-overwrite).

## Why?

- **Implements:** `docs/specs/consolidated-pack-layout/spec.md` (18 ACs, all checked; Status → Shipped)
- **Follows from:** RFC-0040 (Accepted) + ADR-0030; the governance spec/plan landed in #359, this is the implementing PR (T1–T6).

An adopter who wants to control output location now edits **one** namespaced file instead of a per-pack config. `parent` is a **base** under which each unit of work gets its own topic-named folder. Two locations resolve with clear precedence (repo-root `./agentbundle-layout.toml` overrides personal `~/.agentbundle/agentbundle-layout.toml`, per table). Replaces the undistributed `research-layout.toml` by a **clean rename, no alias**.

## How do I verify it?

```bash
# manifest extension + contract bump (the contract-bump trap → both test roots by hand):
cd packages/agentbundle && python -m pytest tests agentbundle/build/tests -q   # green (needs: pip install -e ./packages/credbroker)
# installer append construction tests (11):
python -m pytest tests/unit/test_append_layout_section.py -q
# full local gate:
SKIP_SAST=1 make build-check   # exit 0; lint-spec-status clean
```

**AC16 observable smoke (recorded):**

_Installer append (real `_append_layout_section`):_
- never-create (no file present): **no file written** ✓
- append-if-exists (`[architect]` present, `[research]` missing): appended → `{architect: docs/design, research: .context/research}` ✓
- never-overwrite (idempotent re-run with a poisoned default): **byte-identical** ✓

_Consumer prompt-only behavior (`research-project-start`) against a hand-written repo-root `agentbundle-layout.toml`:_
- surfaced resolved absolute parent **before any write**: `…/myrepo/research-out` ✓
- produced topic folder: `research-out/2026-06-23-llm-eval-harness/overview.md` ✓
- hostile `parent = "../../../../../../etc"` → resolves to `/private/var/etc` → **OUTSIDE repo tree → ASK-FIRST / not written** ✓

## What did you not change that you considered?

- **No fourth consumer, no `[core]` table, no relocation of `decompose-intent`'s `docs/product/briefs/`** — RFC-0040 non-goals; `decompose-intent` stays pinned and untouched.
- **No `[pack.layout.user]` on any of the three packs** — their output is per-repo with no sensible *absolute* user default, so each declares only `[pack.layout.repo]` and the user-scope append is a no-op. Stays within RFC-0040's optional-sub-table latitude (no erratum). The commented placeholder lives in the schema docs as adopter guidance, never installer-emitted — which keeps every installer-written line on the injection-safe `_emit_basic_string` path.
- **Left the stale `pack.schema.json` install-gate enum and the per-pack `[pack.adapter-contract]` versions alone** — the runtime gate is major-only, so the additive `[pack.layout]` needs neither.

**Bundled fixes:** none.

**Deferred:** `docs/backlog.md#layout-append-user-scope-no-op-dir-side-effect` — a harmless wasted `~/.agentbundle/` dir-creation on the user-scope no-op append path (the marker append creates the same dir on the same install). Security-review Nit; not a correctness/security defect.

## Reviews run

- **Pre-EXECUTE:** `adversarial-reviewer` (spec/plan, iterated to Clean) + `security-reviewer` (spec-stage secure-design) — drove the version-field decision, the omit-`.user` resolution, the AC17 frozen-spec exemption, and AC11/AC15 clarifications.
- **Diff-stage:** `security-reviewer` → **Clean**; `adversarial-reviewer` → Blockers (Status/ACs/AC16-record) + 1 Concern (re-emit reflow disclosure) all addressed.

---

## Checklist

- [x] Tests pass locally (full `agentbundle` pytest both roots; 11 new append tests)
- [x] Lint and typecheck pass (`make build-check` exit 0)
- [x] Self-review run via reviewer subagents (adversarial + security; blockers addressed)
- [x] Spec and code agree (spec Status → Shipped, all 18 ACs checked in this PR)
- [x] Living docs match reality (`changelog.md` `[Unreleased]`; research/architect/product-engineering guides; per-pack `references/agentbundle-layout.md` schema docs)
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured (plan changelog + reusable build-learnings memory)
