### PR TITLE
feat(pack-user-guide-diataxis-evals): activation + LLM-judge eval coverage for new-guide + standing eval-coverage policy

### DIFF
--- a/.agents/skills/new-guide/evals/eval_queries.json
+++ b/.agents/skills/new-guide/evals/eval_queries.json
@@ -1,0 +1,23 @@
+[
+  {"query": "Write a guide for how to rotate an expired API token before the next deploy", "should_trigger": true},
+  {"query": "We need a getting-started tutorial that walks a brand-new user through deploying their first project", "should_trigger": true},
+  {"query": "Add a reference page documenting every flag the CLI accepts", "should_trigger": true},
+  {"query": "Write an explanation of why our sessions are cookie-based rather than token-based", "should_trigger": true},
+  {"query": "Document how an operator configures SSO — write the how-to", "should_trigger": true},
+  {"query": "Create a new tutorial for setting up the local dev environment from scratch", "should_trigger": true},
+  {"query": "We need user-facing docs for the bulk-export feature — write a guide", "should_trigger": true},
+  {"query": "Draft a reference page for the config-file format and its fields", "should_trigger": true},
+  {"query": "Write a how-to for migrating data between two workspaces", "should_trigger": true},
+  {"query": "Write a new explanation page about how our caching model works", "should_trigger": true},
+
+  {"query": "Write a spec for the new CSV export feature before we build it", "should_trigger": false},
+  {"query": "Record the decision to store our guides in Markdown instead of reStructuredText", "should_trigger": false},
+  {"query": "Draft a proposal to reorganize how we structure our documentation", "should_trigger": false},
+  {"query": "Document how the build pipeline is wired for contributors working on the codebase", "should_trigger": false},
+  {"query": "Update the existing installation how-to to mention the new --force flag", "should_trigger": false},
+  {"query": "Add docstrings to the exporter module so the API is documented", "should_trigger": false},
+  {"query": "Write the release notes for the 2.0 release", "should_trigger": false},
+  {"query": "Fix the broken link in the installation guide", "should_trigger": false},
+  {"query": "Write the empty-state and error microcopy for the upload screen", "should_trigger": false},
+  {"query": "Write a blog post announcing our new export feature", "should_trigger": false}
+]

--- a/.agents/skills/new-guide/evals/evals.json
+++ b/.agents/skills/new-guide/evals/evals.json
@@ -1,0 +1,18 @@
+{
+  "skill_name": "new-guide",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Author the user-facing guide the user asked for, following the Diátaxis framework.",
+      "expected_output": "A guide that sits cleanly in exactly ONE Diátaxis quadrant (tutorial, how-to, reference, or explanation), chosen by the reader's posture rather than the topic, and does the job of that quadrant without blending in the adjacent ones — when adjacent material is tempting it is LINKED OUT, not folded in. The guide serves one identifiable reader. A task-shaped guide (tutorial/how-to) stays focused on a single named task and its steps are concrete, runnable, and verifiable — each step says what to do and what the reader should see — with no digression into theory or option-dumps; a reference page is neutral, complete, and consistently structured; an explanation stays bounded by an \"About <topic>\" frame and carries no step-by-step. The prose reads like a knowledgeable friend wrote it (second person, active voice, present tense), with no reader-blaming fillers (\"simply\", \"just\", \"easy\", \"obviously\"), no softened imperatives (\"please click\"), and no inline version history (current behavior only — evolution is linked, not narrated). Cross-links point only to sibling pages that exist.",
+      "assertions": [
+        "Sits in exactly one Diátaxis quadrant and does that quadrant's job — no quadrant-mixing (adjacent-quadrant material is linked out, not blended in)",
+        "Quadrant is chosen by reader posture rather than topic, and the guide serves one identifiable reader",
+        "A task-shaped guide (tutorial/how-to) stays focused on one named task with no digression; a reference/explanation guide stays within its quadrant's job (neutral + complete / bounded by an \"About <topic>\" frame, no step-by-step)",
+        "Procedural steps are concrete, runnable, and verifiable — each says what to do and what the reader should see — not abstract narration",
+        "Prose reads human and task-respecting: second person, active voice, present tense; no reader-blaming fillers (simply/just/easy/obviously), no softened imperatives (please), no inline version-history narration",
+        "Cross-links (\"See also\") point only to sibling pages that exist — no fabricated or broken links"
+      ]
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -221,7 +221,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "user-guide-diataxis",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.1.4"
+      "version": "0.1.5"
     }
   ]
 }

--- a/.claude/skills/new-guide/evals/eval_queries.json
+++ b/.claude/skills/new-guide/evals/eval_queries.json
@@ -1,0 +1,23 @@
+[
+  {"query": "Write a guide for how to rotate an expired API token before the next deploy", "should_trigger": true},
+  {"query": "We need a getting-started tutorial that walks a brand-new user through deploying their first project", "should_trigger": true},
+  {"query": "Add a reference page documenting every flag the CLI accepts", "should_trigger": true},
+  {"query": "Write an explanation of why our sessions are cookie-based rather than token-based", "should_trigger": true},
+  {"query": "Document how an operator configures SSO — write the how-to", "should_trigger": true},
+  {"query": "Create a new tutorial for setting up the local dev environment from scratch", "should_trigger": true},
+  {"query": "We need user-facing docs for the bulk-export feature — write a guide", "should_trigger": true},
+  {"query": "Draft a reference page for the config-file format and its fields", "should_trigger": true},
+  {"query": "Write a how-to for migrating data between two workspaces", "should_trigger": true},
+  {"query": "Write a new explanation page about how our caching model works", "should_trigger": true},
+
+  {"query": "Write a spec for the new CSV export feature before we build it", "should_trigger": false},
+  {"query": "Record the decision to store our guides in Markdown instead of reStructuredText", "should_trigger": false},
+  {"query": "Draft a proposal to reorganize how we structure our documentation", "should_trigger": false},
+  {"query": "Document how the build pipeline is wired for contributors working on the codebase", "should_trigger": false},
+  {"query": "Update the existing installation how-to to mention the new --force flag", "should_trigger": false},
+  {"query": "Add docstrings to the exporter module so the API is documented", "should_trigger": false},
+  {"query": "Write the release notes for the 2.0 release", "should_trigger": false},
+  {"query": "Fix the broken link in the installation guide", "should_trigger": false},
+  {"query": "Write the empty-state and error microcopy for the upload screen", "should_trigger": false},
+  {"query": "Write a blog post announcing our new export feature", "should_trigger": false}
+]

--- a/.claude/skills/new-guide/evals/evals.json
+++ b/.claude/skills/new-guide/evals/evals.json
@@ -1,0 +1,18 @@
+{
+  "skill_name": "new-guide",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Author the user-facing guide the user asked for, following the Diátaxis framework.",
+      "expected_output": "A guide that sits cleanly in exactly ONE Diátaxis quadrant (tutorial, how-to, reference, or explanation), chosen by the reader's posture rather than the topic, and does the job of that quadrant without blending in the adjacent ones — when adjacent material is tempting it is LINKED OUT, not folded in. The guide serves one identifiable reader. A task-shaped guide (tutorial/how-to) stays focused on a single named task and its steps are concrete, runnable, and verifiable — each step says what to do and what the reader should see — with no digression into theory or option-dumps; a reference page is neutral, complete, and consistently structured; an explanation stays bounded by an \"About <topic>\" frame and carries no step-by-step. The prose reads like a knowledgeable friend wrote it (second person, active voice, present tense), with no reader-blaming fillers (\"simply\", \"just\", \"easy\", \"obviously\"), no softened imperatives (\"please click\"), and no inline version history (current behavior only — evolution is linked, not narrated). Cross-links point only to sibling pages that exist.",
+      "assertions": [
+        "Sits in exactly one Diátaxis quadrant and does that quadrant's job — no quadrant-mixing (adjacent-quadrant material is linked out, not blended in)",
+        "Quadrant is chosen by reader posture rather than topic, and the guide serves one identifiable reader",
+        "A task-shaped guide (tutorial/how-to) stays focused on one named task with no digression; a reference/explanation guide stays within its quadrant's job (neutral + complete / bounded by an \"About <topic>\" frame, no step-by-step)",
+        "Procedural steps are concrete, runnable, and verifiable — each says what to do and what the reader should see — not abstract narration",
+        "Prose reads human and task-respecting: second person, active voice, present tense; no reader-blaming fillers (simply/just/easy/obviously), no softened imperatives (please), no inline version-history narration",
+        "Cross-links (\"See also\") point only to sibling pages that exist — no fabricated or broken links"
+      ]
+    }
+  ]
+}

--- a/AGENTS.local.md
+++ b/AGENTS.local.md
@@ -284,6 +284,41 @@ version.
 > itself, which ships to adopters who receive none of the governance it was
 > written under.)
 
+## Eval coverage is part of pack work — build or update the harness
+
+A new pack, or a **non-cosmetic** update to an existing one, must also build
+or update that pack's **eval harness**. This is the standing default the
+[`pack-eval-coverage-rollout`](docs/backlog.md) backlog item is rolling across
+the catalogue, made a rule here so it stops being a one-off. Per the
+[`pack-activation-evals` spec](docs/specs/pack-activation-evals/spec.md):
+
+- **Tier-A activation** — `evals/eval_queries.json` (~8–10 should-trigger +
+  ~8–10 near-miss should-NOT-trigger queries) plus a `[pack.evals]` block
+  listing **every user-triggered skill**. Exclude only reviewer-internal /
+  non-prompt skills (`security-checklists`, `work-loop`), as `core` does.
+- **Tier-4 LLM-judge rubric** — `evals/evals.json` (`expected_output` +
+  `assertions`) for **each judgment/authoring skill** — one that produces a
+  spec, diagram, critique, guide, or intent by judgment, with no deterministic
+  artifact.
+- **Tier-B-lite** — additionally an `expect` block + an `evals/files/` fixture
+  **where the skill is deterministic** (it runs a script and emits a checkable
+  artifact, as the `converters` skills do).
+
+Then **verify the harness actually works** by running it in Tier-B light mode:
+
+```bash
+python tools/run-pack-evals.py --pack <pack> --mode judge \
+  --judge-adapter claude-code --artifacts <file>
+```
+
+This points the LLM-judge — a different lens (the rubric) on the same model
+running the session — at a good and a weak artifact. It is a lightweight
+smoke-check that the rubric loads and discriminates (good artifact PASS, weak
+artifact FAIL), **not** a calibration gate: report-only, like the rest of the
+harness. The full per-pack sweep, the calibration baseline, and any
+report-only→gating promotion stay the scheduled `pack-evals.yml` workflow's
+job — that detail lives in the spec and the backlog item, not here.
+
 ## Authoring or editing a skill
 
 Skills live under `packs/<pack>/.apm/skills/<name>/SKILL.md` (the seed)

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -765,19 +765,22 @@ coverage today: **`core`** (5 skills, Tier-A activation), **`converters`**
 **Tier-4 LLM-judge rubrics** for all of **`architect`** (3 skills) and
 **`product-engineering`** (5 skills), **`design-craft`** (4 skills,
 Tier-A activation **+** Tier-4 LLM-judge — both layers, no B-lite since the
-four skills are judgment/authoring), and **`governance-extras`** (3 skills,
+four skills are judgment/authoring), **`governance-extras`** (3 skills,
 Tier-A activation **+** Tier-4 LLM-judge — both layers, no B-lite; the three
-skills are governance authoring/judgment) — `expected_output` + `assertions`
-per skill, gradable via `--mode judge`. Every other pack has **no eval coverage
-yet**. Remaining work, tiered by what it needs:
+skills are governance authoring/judgment), and **`user-guide-diataxis`**
+(1 skill — `new-guide` — Tier-A activation **+** Tier-4 LLM-judge — both
+layers, no B-lite; `new-guide` is judgment/authoring) — `expected_output` +
+`assertions` per skill, gradable via `--mode judge`. Every other pack has
+**no eval coverage yet**. Remaining work, tiered by what it needs:
 
 - **Tier 1 — activation (Tier-A) for the rest of the catalogue (tractable now,
-  no deps/execution).** ~28 user-triggered skills across `architect` (3),
+  no deps/execution).** ~27 user-triggered skills across `architect` (3),
   `contracts` (2),
-  `monorepo-extras` (1), `product-engineering` (5), `research` (7),
-  `user-guide-diataxis` (1) need `evals/eval_queries.json` + a `[pack.evals]`
+  `monorepo-extras` (1), `product-engineering` (5), `research` (7)
+  need `evals/eval_queries.json` + a `[pack.evals]`
   block (the same ~8–10-each-way near-miss pattern as `core`). `design-craft`
-  (4) and `governance-extras` (3) are **done** (this rollout). Exclude
+  (4), `governance-extras` (3), and `user-guide-diataxis` (1, `new-guide`) are
+  **done** (this rollout). Exclude
   reviewer-internal / non-prompt skills (`security-checklists`, `work-loop`,
   `credential-setup`), as `core` does. This is the bulk of the gap.
 - **Tier 2 — B-lite behavior for other *deterministic* skills.** Assess
@@ -795,8 +798,9 @@ yet**. Remaining work, tiered by what it needs:
   remaining work here is **(a)** a per-skill **lens map** (point each skill at
   the right rubric / reviewer lens — e.g. `architect-review` for `architect-design`),
   authoring the `expected_output`/`assertions` rubrics — **done for all of
-  `architect` (3), `product-engineering` (5), `design-craft` (4), and
-  `governance-extras` (3)**; remaining for `research`, `new-guide`,
+  `architect` (3), `product-engineering` (5), `design-craft` (4),
+  `governance-extras` (3), and `user-guide-diataxis` (`new-guide`)**;
+  remaining for `research`,
   `new-package`, and `core`'s judgment skills — and **(b)** the **full
   Tier-B** pieces still deferred: `benchmark.json` **deltas**, the
   **with/without-skill** comparison, the **train/validation split**, and the

--- a/docs/specs/pack-activation-evals/notes/manual-qa.md
+++ b/docs/specs/pack-activation-evals/notes/manual-qa.md
@@ -286,3 +286,45 @@ lint clean; `governance-extras` bumped 0.3.0 → 0.3.1 and the self-host project
 (`.claude/skills/`, `.agents/skills/`) + `marketplace.json` refreshed via
 `make build-self` (the projection drift is covered by `make build-check`, which
 is green — unlike `design-craft`, `governance-extras` is self-host-projected).
+
+## 10. `user-guide-diataxis` — both layers (Tier-A activation + Tier-4 judge), 2026-06-23
+
+`new-guide` is a user-triggered judgment/authoring skill (it drafts Diátaxis
+user-facing guides — tutorial / how-to / reference / explanation — by judgment,
+no deterministic artifact), so **both** layers that apply to judgment skills
+were added: Tier-A activation (`evals/eval_queries.json` + a `[pack.evals]`
+block, 10 should-trigger + 10 near-miss) **and** a Tier-4 LLM-judge rubric
+(`evals/evals.json` — `expected_output` + `assertions` matched to the skill's
+discipline). No B-lite layer (a guide has no deterministic post-condition to
+re-derive). The 10 near-misses route across the sibling authoring skills
+(`new-spec` / `new-rfc` / `new-adr`), to contributor-facing architecture docs
+(documentation, but not a *user* guide), to editing an existing guide (a normal
+PR, not `new-guide`), to code docstrings / release notes / a blog post, and to
+`voice-and-microcopy` (UI words, not documentation prose) — each shares
+"write" / "document" / "guide" vocabulary but needs a different skill.
+
+| skill | rubric grades |
+| --- | --- |
+| new-guide | single Diátaxis quadrant chosen by reader posture (no quadrant-mixing — adjacent material linked out), task-focused with concrete runnable/verifiable steps, prose hygiene (no reader-blaming fillers / softened imperatives / inline version-history), See-also links only to existing siblings |
+
+The `new-guide` rubric was spot-checked live (`--mode judge --judge-adapter
+claude-code`) with good-vs-weak artifacts to confirm it discriminates: a focused
+how-to (one named task — rotate an expired API token — concrete steps each with
+a "you should see…" checkpoint, clean prose, one defensible cross-link)
+**PASS** ("a well-formed how-to guide that satisfies all rubric assertions") /
+a quadrant-mixed blob (all four quadrants in one document, vague unverifiable
+steps, reader-blaming fillers + inline version history, fabricated cross-links)
+**FAIL** ("fails every assertion … blends all four Diátaxis quadrants in one
+document"). This same `--mode judge` run **is** the Tier-B light-mode harness
+smoke-check the standing `AGENTS.local.md` eval-coverage policy requires —
+report-only, confirming the rubric loads and discriminates, not a calibration
+gate.
+
+The rubric lints clean; `user-guide-diataxis` bumped 0.1.4 → 0.1.5 and the
+self-host projection (`.claude/skills/new-guide/evals/`,
+`.agents/skills/new-guide/evals/`) + `marketplace.json` refreshed via
+`make build-self` (the projection drift is covered by `make build-check`, which
+is green). **Note:** `user-guide-diataxis` is `default-scope = "repo"` and is
+self-host-projected — like `core` / `governance-extras`, not like the
+user-scope `design-craft` — so the added eval files **do** project into
+`.claude/` and `.agents/`, and `make build-check` is the gate that covers them.

--- a/packs/user-guide-diataxis/.apm/skills/new-guide/evals/eval_queries.json
+++ b/packs/user-guide-diataxis/.apm/skills/new-guide/evals/eval_queries.json
@@ -1,0 +1,23 @@
+[
+  {"query": "Write a guide for how to rotate an expired API token before the next deploy", "should_trigger": true},
+  {"query": "We need a getting-started tutorial that walks a brand-new user through deploying their first project", "should_trigger": true},
+  {"query": "Add a reference page documenting every flag the CLI accepts", "should_trigger": true},
+  {"query": "Write an explanation of why our sessions are cookie-based rather than token-based", "should_trigger": true},
+  {"query": "Document how an operator configures SSO — write the how-to", "should_trigger": true},
+  {"query": "Create a new tutorial for setting up the local dev environment from scratch", "should_trigger": true},
+  {"query": "We need user-facing docs for the bulk-export feature — write a guide", "should_trigger": true},
+  {"query": "Draft a reference page for the config-file format and its fields", "should_trigger": true},
+  {"query": "Write a how-to for migrating data between two workspaces", "should_trigger": true},
+  {"query": "Write a new explanation page about how our caching model works", "should_trigger": true},
+
+  {"query": "Write a spec for the new CSV export feature before we build it", "should_trigger": false},
+  {"query": "Record the decision to store our guides in Markdown instead of reStructuredText", "should_trigger": false},
+  {"query": "Draft a proposal to reorganize how we structure our documentation", "should_trigger": false},
+  {"query": "Document how the build pipeline is wired for contributors working on the codebase", "should_trigger": false},
+  {"query": "Update the existing installation how-to to mention the new --force flag", "should_trigger": false},
+  {"query": "Add docstrings to the exporter module so the API is documented", "should_trigger": false},
+  {"query": "Write the release notes for the 2.0 release", "should_trigger": false},
+  {"query": "Fix the broken link in the installation guide", "should_trigger": false},
+  {"query": "Write the empty-state and error microcopy for the upload screen", "should_trigger": false},
+  {"query": "Write a blog post announcing our new export feature", "should_trigger": false}
+]

--- a/packs/user-guide-diataxis/.apm/skills/new-guide/evals/evals.json
+++ b/packs/user-guide-diataxis/.apm/skills/new-guide/evals/evals.json
@@ -1,0 +1,18 @@
+{
+  "skill_name": "new-guide",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Author the user-facing guide the user asked for, following the Diátaxis framework.",
+      "expected_output": "A guide that sits cleanly in exactly ONE Diátaxis quadrant (tutorial, how-to, reference, or explanation), chosen by the reader's posture rather than the topic, and does the job of that quadrant without blending in the adjacent ones — when adjacent material is tempting it is LINKED OUT, not folded in. The guide serves one identifiable reader. A task-shaped guide (tutorial/how-to) stays focused on a single named task and its steps are concrete, runnable, and verifiable — each step says what to do and what the reader should see — with no digression into theory or option-dumps; a reference page is neutral, complete, and consistently structured; an explanation stays bounded by an \"About <topic>\" frame and carries no step-by-step. The prose reads like a knowledgeable friend wrote it (second person, active voice, present tense), with no reader-blaming fillers (\"simply\", \"just\", \"easy\", \"obviously\"), no softened imperatives (\"please click\"), and no inline version history (current behavior only — evolution is linked, not narrated). Cross-links point only to sibling pages that exist.",
+      "assertions": [
+        "Sits in exactly one Diátaxis quadrant and does that quadrant's job — no quadrant-mixing (adjacent-quadrant material is linked out, not blended in)",
+        "Quadrant is chosen by reader posture rather than topic, and the guide serves one identifiable reader",
+        "A task-shaped guide (tutorial/how-to) stays focused on one named task with no digression; a reference/explanation guide stays within its quadrant's job (neutral + complete / bounded by an \"About <topic>\" frame, no step-by-step)",
+        "Procedural steps are concrete, runnable, and verifiable — each says what to do and what the reader should see — not abstract narration",
+        "Prose reads human and task-respecting: second person, active voice, present tense; no reader-blaming fillers (simply/just/easy/obviously), no softened imperatives (please), no inline version-history narration",
+        "Cross-links (\"See also\") point only to sibling pages that exist — no fabricated or broken links"
+      ]
+    }
+  ]
+}

--- a/packs/user-guide-diataxis/.claude-plugin/plugin.json
+++ b/packs/user-guide-diataxis/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "user-guide-diataxis",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Di\u00e1taxis-shaped user-guide skeleton: guides/ + tutorials/how-to/reference/explanation seed READMEs, new-guide skill."
 }

--- a/packs/user-guide-diataxis/pack.toml
+++ b/packs/user-guide-diataxis/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "user-guide-diataxis"
-version = "0.1.4"
+version = "0.1.5"
 description = "Di\u00e1taxis-shaped user-guide skeleton: guides/ + tutorials/how-to/reference/explanation seed READMEs, new-guide skill."
 readme = "README.md"
 display_name = "User Guide (Diátaxis)"
@@ -17,6 +17,17 @@ version = "0.8"
 [pack.install]
 default-scope = "repo"
 allowed-scopes = ["repo"]
+
+# pack-activation-evals (RFC-0037 / ADR-0028): the Tier-A activation-eval
+# coverage allowlist. The covered skill ships evals/eval_queries.json and is
+# measured by tools/run-pack-evals.py. new-guide is a user-triggered
+# judgment/authoring skill (it drafts Diátaxis guides — no deterministic
+# artifact), so it also ships a Tier-4 LLM-judge rubric (evals/evals.json,
+# graded via --mode judge); there is no Tier-B-lite layer (nothing
+# deterministic to re-derive). The pack has no reviewer-internal / non-prompt
+# skill to exclude.
+[pack.evals]
+skills = ["new-guide"]
 
 # Per adapt-to-project AC17/AC18.
 [[pack.dependencies.required]]


### PR DESCRIPTION
## What does this change?

Adds eval coverage for the `new-guide` skill (pack `user-guide-diataxis`, previously none) and turns the eval-coverage rollout into a standing default for all future pack work.

## Why?

Continues `pack-eval-coverage-rollout` ([`docs/backlog.md`](docs/backlog.md)) under the Shipped [`pack-activation-evals` spec](docs/specs/pack-activation-evals/spec.md), following the merged precedents #360 (design-craft) and #362 (governance-extras). `new-guide` is a judgment/authoring skill — it drafts Diátaxis user-facing guides, no deterministic artifact — so it gets the two layers that apply to judgment skills:

- **Tier-A activation** — `evals/eval_queries.json` (10 should-trigger + 10 near-miss, near-misses routing to `new-spec`/`new-rfc`/`new-adr`, contributor-facing architecture docs, editing-an-existing-guide, docstrings/release-notes/blog, and `voice-and-microcopy`) + a `[pack.evals]` block.
- **Tier-4 LLM-judge rubric** — `evals/evals.json`, `expected_output` + `assertions` matched to the skill's discipline (single Diátaxis quadrant chosen by reader posture, link-out-don't-blend, task-focused runnable/verifiable steps, prose hygiene, See-also-only-existing).

No B-lite layer (a guide has no deterministic post-condition to re-derive).

The second piece adds a standing policy to `AGENTS.local.md` (repo-local-only): a new pack or non-cosmetic update must build/update its eval harness, verified via a report-only `--mode judge` smoke-check. It cross-references the spec + backlog rather than duplicating detail.

## How do I verify it?

- `python tools/lint-skill-spec.py` — clean (validates the `eval_queries.json` schema + `[pack.evals]` coverage).
- Live rubric spot-check (also the Tier-B light-mode harness smoke the new policy requires):
  `python tools/run-pack-evals.py --pack user-guide-diataxis --mode judge --judge-adapter claude-code --artifacts <file>` — a focused how-to graded **PASS** ("a well-formed how-to guide that satisfies all rubric assertions"); a quadrant-mixed blob graded **FAIL** ("blends all four Diátaxis quadrants in one document").
- `make build-check` — green (exit 0), zero projection drift after `make build-self`. `user-guide-diataxis` is `default-scope = "repo"` and self-host-projected (like core/governance-extras), so the eval files **do** project into `.claude/skills/new-guide/evals/` + `.agents/skills/new-guide/evals/`; version bumped 0.1.4 → 0.1.5 in `pack.toml` + `plugin.json`; `marketplace.json` refreshed. Full live detail in `docs/specs/pack-activation-evals/notes/manual-qa.md` §10.
- adversarial-reviewer: Clean.

> **Correction noted:** the task brief described `user-guide-diataxis` as user-scope and expected nothing under `.claude/.agents` to change. Verified false — it is `default-scope = "repo"` and self-host-projected, so the eval files project (the governance-extras case), and `make build-check` is the gate that covers them. Handled accordingly.

## What did you not change that you considered?

- **No new spec/RFC for the standing policy** — `AGENTS.local.md` is the repo-local maintainer doc the brief names, and the policy cross-references existing governance rather than minting new doctrine (a CONVENTIONS/CHARTER change would be RFC-gated; this isn't one).
- **No B-lite `expect` block / fixture** — a Diátaxis guide has no deterministic artifact to re-derive; Tier-4 judge only, like design-craft/governance-extras.
- **No `loop-cohort` state machine** — no new spec/plan to gate; this is a coverage increment on a Shipped spec, matching #360/#362.
- **`security-reviewer` / `quality-engineer` not run** — no security boundary crossed (JSON data + a repo-local doc; no auth/secrets/input/network code) and no code/test logic to assess.