### PR TITLE
feat(work-loop): infra-aware work-loop — P1/P2/P4/P5 doctrine (core 0.4.12)

### DIFF
--- a/.agents/skills/work-loop/SKILL.md
+++ b/.agents/skills/work-loop/SKILL.md
@@ -191,6 +191,60 @@ For anything beyond trivial, *think before you write code*. Concretely:
     asserts **invariants** ("didn't crash, didn't render garbage, layout holds,
     no overflow") rather than specific outputs. Reach for it when the failure
     mode is open-ended and you can't enumerate the gestures up front.
+  - **infra/deploy** — provisioning or changing infrastructure: a cloud
+    deploy, an IaC apply, a stateful migration of a running system. This is the
+    fourth verification *mode* (the spec calls it a *flavor* — same thing).
+    Unlike the three modes above, its contract is a **layered GATES sequence**,
+    not a single check — because a deploy is slow, stateful, costs money, and is
+    partially irreversible. The layers, in order: (1) **static preflight** —
+    validate / lint / policy-as-code, run through the provider-appropriate
+    scanner the preflight obligation below requires as a task-zero (the
+    lint+typecheck analog); (2) **plan / preview** — a dry-run diff, reviewed
+    before any mutation; (3) **idempotent convergent apply — the precondition
+    the rest rests on**: re-running after a fix must *converge, not collide*, so
+    iteration is safe; an imperative, non-idempotent script is the
+    retry-collision root cause, and the thing to fix first rather than work
+    around; (4) **active end-to-end smoke** — not a single status check but a
+    multi-hop probe, and the direct extension of the visual/manual-QA "exercise
+    the real built artifact" doctrine to a deployed system: seed test / mock
+    users → load the real CDN / site URL → assert it actually renders → on
+    failure pull the access / error logs and debug → tear down; (5)
+    **rollback** — *before* the first apply, confirm a known-good re-apply path
+    is named (it belongs in `## Rollout`), since no atomic rollback exists for a
+    partially-applied deploy. This mode names *how we verify* a deploy; it does
+    **not** author *deployment sequencing*, which the plan template's
+    `## Rollout` section already owns — cross-reference it, don't duplicate it. Every layer is tool-neutral
+    (Terraform / Pulumi / CDK / CloudFormation / hand-rolled scripts alike);
+    any tool named here is illustrative, never normative.
+
+  **Confirm the mechanism exists before you claim the mode — task zero if it
+  doesn't.** Picking a verification mode obligates confirming that the
+  mechanism that mode depends on actually exists; if it does not, **building it
+  is task zero** — a precondition task in the plan, not an afterthought — and
+  the loop offers to scaffold it. This obligation is **agnostic and universal
+  across light and full mode**: it applies to a TDD task whose test runner
+  isn't wired, a goal-based task whose build command doesn't exist yet, and a
+  manual-QA task whose artifact can't yet be run, exactly as much as to a
+  missing infra smoke check. It strengthens the assumption-trio — "the
+  mechanism exists" is the kind of assumption that goes unsurfaced precisely
+  because it doesn't feel like one.
+
+  For **infra/deploy** the mechanism is rarely one artifact; the preflight
+  enumerates it as a **multi-artifact set, each its own task-zero**: (a) a
+  **verify-status** script (does the deploy report healthy?), (b) a
+  **teardown** script (clean down a failed or ephemeral run), (c) **test-data /
+  mock-user seeding** (so the smoke probe has something to exercise), and (d) a
+  **provider-appropriate policy-as-code / CSPM scanner**. The scanner is the
+  load-bearing one: it is the **per-provider-depth source**, its
+  vendor-maintained rulesets holding the per-service config checks the
+  standards-grounded reviewers cannot and should not carry — and the **same**
+  scanner feeds two layers, *operational* misconfig → the infra/deploy mode's
+  static preflight (layer 1) and *security* misconfig → the mandatory security
+  pass (REVIEW, below). The requirement is **mechanism-level, not tool-level**:
+  a scanner must exist; the adopter picks Checkov / tfsec / a cloud-native CSPM,
+  exactly as the loop requires "tests exist" without mandating a framework. The
+  loop names these as prerequisite tasks and offers to scaffold them; it does
+  not ship them as executable tooling.
 
   Spikes and throwaway exploration are out of scope.
 - **Design tests up front, before any code.** The contract lives in
@@ -284,6 +338,22 @@ For anything beyond trivial, *think before you write code*. Concretely:
   is not a re-use of either. Same Profile-A opt-out and the same
   `approve-plan` gate apply. Fallback if no `security-reviewer` subagent is
   installed: proceed and note the missing review in the final summary.
+
+  **For infra-flavored work this spec-stage pass is mandatory, not
+  discretionary.** "Infra-flavored" is a **defined signal, not an ad-hoc
+  judgement**: work that the **destructive/irreversible risk trigger** routes to
+  full mode *and* whose spec matches the
+  [boundary→module routing table](#boundarymodule-routing-table)'s IaC /
+  deploy-config entry — the same classifier that already drives security-module
+  loading (the spec-stage half keys this match on the spec; the diff-stage half
+  on the diff — same routing-table entry). When that signal is present the
+  `security-reviewer` runs at spec stage **regardless of** the discretionary
+  security-boundary trigger, and the orchestrator **force-loads** the
+  infra-relevant `security-checklists` modules (the candidate set the REVIEW
+  `security-reviewer` bullet names), loaded 1–N as the spec warrants per that
+  table. The matching diff-stage pass, the reviewer-plus-scanner pairing, and
+  the Profile-A / missing-subagent interaction all live in that REVIEW bullet —
+  this is the spec-stage half of the same non-skippable, both-stages pass.
 - **Initialize the loop's state file.** Run this skill's bundled
   `scripts/loop-cohort.py init docs/specs/<feature>`; the tool copies
   the bundled `assets/state.json` template into place, sets `feature`
@@ -318,6 +388,20 @@ Match the discipline to the verification mode you picked during PLAN:
 - **Visual / manual QA** — implement, then exercise the built artifact
   end-to-end through the documented workflow recorded in the task, and
   record what you observed (real output, not internal state).
+- **infra/deploy** — implement the change (one task may span several GATES
+  layers), then **drive the deploy yourself and read the real environment
+  output**: run the apply, the smoke
+  probe, the log pull, and the teardown, and read their *actual* output rather
+  than reasoning about what they would say. The **human-as-relay** pattern — a
+  human running the deploy command and pasting the error back into the session
+  by hand — is the anti-pattern this removes; the agent reads ground truth from
+  the environment at each step. This is **harness-agnostic doctrine** — do it
+  by hand on any agent. In Claude Code, background tasks (for long applies),
+  `asyncRewake` (to wake on a background deploy's exit with stderr surfaced),
+  and `PreToolUse` (to gate a destructive command before it runs) are an
+  **accelerant only, never a dependency** — matching how `/verify` and
+  `/simplify` are treated; adapters without them lose the shortcut, not the
+  doctrine.
 
 For each task, implement the smallest coherent unit of work toward the
 goal. Resist the urge to fix unrelated things you notice along the way;
@@ -576,6 +660,43 @@ note in the summary, not a blocker.
   Load 1–3 modules for a typical change, never a flat march of all ten; an
   auth-touching endpoint pulls `access-control` and often `authn-session`.
   This same table backs the pre-EXECUTE spec-stage dispatch above.
+
+  **Mandatory and multi-module on infra-flavored work.** When the change is
+  **infra-flavored** — the **destructive/irreversible risk trigger** routed it
+  to full mode *and* its diff matches the routing table's IaC / deploy-config
+  entry — the `security-reviewer` pass is **non-skippable** and runs at
+  **both the spec stage** (the pre-EXECUTE secure-design step above) **and on
+  the diff**, not via the discretionary security-boundary trigger. Because
+  "infra-flavored" keys on the existing classifier rather than a per-diff
+  judgement, the pass **cannot be silently skipped** on an infra diff. The
+  orchestrator force-loads from the infra-relevant **candidate set** —
+  `config-misconfig` (the IaC / deploy-config entry — IAM, CORS, deploy config —
+  present on any infra diff) plus `access-control` (when the change alters the
+  authorization *model*: role bindings or resource policies that change *who can
+  call what*), `secrets-and-crypto` (secrets in state or env, keys),
+  `outbound-ssrf` (public exposure, CDN / origin egress), and `supply-chain`
+  (provider / module pinning) — each pulled in when the diff trips *that
+  module's own* routing-table row, so the routing table stays the single
+  deterministic authority and the set loads **1–N**, never a flat always-five
+  march (a one-line config tweak pulls one; a new public-facing stack pulls
+  several). This adds **no new reviewer and no new
+  module**: it makes the *existing* security pass mandatory and multi-module.
+  The **Profile-A opt-out still applies wholesale** — a project that uses no
+  reviewer at all opts out of the loop entirely — but where `security-reviewer`
+  *is* in use the infra pass is **not individually skippable**, and a missing
+  `security-reviewer` subagent on infra-flavored work is a **loud blocker in the
+  final summary, not a silent proceed** (the one place the
+  select-or-note fallback hardens to a blocker, given the blast radius).
+
+  **Security on infra is a reviewer + scanner *pair*; neither substitutes for
+  the other.** `security-reviewer` is **not** the per-provider depth source — it
+  reasons from cross-cutting standards (OWASP / ASVS / CWE + STRIDE / LINDDUN)
+  and catches failure *classes* (over-broad IAM, public exposure,
+  unencrypted-at-rest, secrets in state, metadata SSRF, missing audit logging)
+  and control-completeness. The **per-provider secure-config depth** comes from
+  the policy-as-code / CSPM scanner the PLAN preflight requires as a task-zero
+  (its vendor-maintained rulesets *are* the provider baselines). Run both: the
+  scanner for per-provider breadth, the reviewer for failure-class reasoning.
 - Match `quality-engineer` — testability, observability, reliability, and
   maintainability lens, applying a raised default quality floor (universal
   maintainability smells + a mutation-testing mindset) even where no static

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -87,7 +87,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "core",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.4.11"
+      "version": "0.4.12"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -191,6 +191,60 @@ For anything beyond trivial, *think before you write code*. Concretely:
     asserts **invariants** ("didn't crash, didn't render garbage, layout holds,
     no overflow") rather than specific outputs. Reach for it when the failure
     mode is open-ended and you can't enumerate the gestures up front.
+  - **infra/deploy** — provisioning or changing infrastructure: a cloud
+    deploy, an IaC apply, a stateful migration of a running system. This is the
+    fourth verification *mode* (the spec calls it a *flavor* — same thing).
+    Unlike the three modes above, its contract is a **layered GATES sequence**,
+    not a single check — because a deploy is slow, stateful, costs money, and is
+    partially irreversible. The layers, in order: (1) **static preflight** —
+    validate / lint / policy-as-code, run through the provider-appropriate
+    scanner the preflight obligation below requires as a task-zero (the
+    lint+typecheck analog); (2) **plan / preview** — a dry-run diff, reviewed
+    before any mutation; (3) **idempotent convergent apply — the precondition
+    the rest rests on**: re-running after a fix must *converge, not collide*, so
+    iteration is safe; an imperative, non-idempotent script is the
+    retry-collision root cause, and the thing to fix first rather than work
+    around; (4) **active end-to-end smoke** — not a single status check but a
+    multi-hop probe, and the direct extension of the visual/manual-QA "exercise
+    the real built artifact" doctrine to a deployed system: seed test / mock
+    users → load the real CDN / site URL → assert it actually renders → on
+    failure pull the access / error logs and debug → tear down; (5)
+    **rollback** — *before* the first apply, confirm a known-good re-apply path
+    is named (it belongs in `## Rollout`), since no atomic rollback exists for a
+    partially-applied deploy. This mode names *how we verify* a deploy; it does
+    **not** author *deployment sequencing*, which the plan template's
+    `## Rollout` section already owns — cross-reference it, don't duplicate it. Every layer is tool-neutral
+    (Terraform / Pulumi / CDK / CloudFormation / hand-rolled scripts alike);
+    any tool named here is illustrative, never normative.
+
+  **Confirm the mechanism exists before you claim the mode — task zero if it
+  doesn't.** Picking a verification mode obligates confirming that the
+  mechanism that mode depends on actually exists; if it does not, **building it
+  is task zero** — a precondition task in the plan, not an afterthought — and
+  the loop offers to scaffold it. This obligation is **agnostic and universal
+  across light and full mode**: it applies to a TDD task whose test runner
+  isn't wired, a goal-based task whose build command doesn't exist yet, and a
+  manual-QA task whose artifact can't yet be run, exactly as much as to a
+  missing infra smoke check. It strengthens the assumption-trio — "the
+  mechanism exists" is the kind of assumption that goes unsurfaced precisely
+  because it doesn't feel like one.
+
+  For **infra/deploy** the mechanism is rarely one artifact; the preflight
+  enumerates it as a **multi-artifact set, each its own task-zero**: (a) a
+  **verify-status** script (does the deploy report healthy?), (b) a
+  **teardown** script (clean down a failed or ephemeral run), (c) **test-data /
+  mock-user seeding** (so the smoke probe has something to exercise), and (d) a
+  **provider-appropriate policy-as-code / CSPM scanner**. The scanner is the
+  load-bearing one: it is the **per-provider-depth source**, its
+  vendor-maintained rulesets holding the per-service config checks the
+  standards-grounded reviewers cannot and should not carry — and the **same**
+  scanner feeds two layers, *operational* misconfig → the infra/deploy mode's
+  static preflight (layer 1) and *security* misconfig → the mandatory security
+  pass (REVIEW, below). The requirement is **mechanism-level, not tool-level**:
+  a scanner must exist; the adopter picks Checkov / tfsec / a cloud-native CSPM,
+  exactly as the loop requires "tests exist" without mandating a framework. The
+  loop names these as prerequisite tasks and offers to scaffold them; it does
+  not ship them as executable tooling.
 
   Spikes and throwaway exploration are out of scope.
 - **Design tests up front, before any code.** The contract lives in
@@ -284,6 +338,22 @@ For anything beyond trivial, *think before you write code*. Concretely:
   is not a re-use of either. Same Profile-A opt-out and the same
   `approve-plan` gate apply. Fallback if no `security-reviewer` subagent is
   installed: proceed and note the missing review in the final summary.
+
+  **For infra-flavored work this spec-stage pass is mandatory, not
+  discretionary.** "Infra-flavored" is a **defined signal, not an ad-hoc
+  judgement**: work that the **destructive/irreversible risk trigger** routes to
+  full mode *and* whose spec matches the
+  [boundary→module routing table](#boundarymodule-routing-table)'s IaC /
+  deploy-config entry — the same classifier that already drives security-module
+  loading (the spec-stage half keys this match on the spec; the diff-stage half
+  on the diff — same routing-table entry). When that signal is present the
+  `security-reviewer` runs at spec stage **regardless of** the discretionary
+  security-boundary trigger, and the orchestrator **force-loads** the
+  infra-relevant `security-checklists` modules (the candidate set the REVIEW
+  `security-reviewer` bullet names), loaded 1–N as the spec warrants per that
+  table. The matching diff-stage pass, the reviewer-plus-scanner pairing, and
+  the Profile-A / missing-subagent interaction all live in that REVIEW bullet —
+  this is the spec-stage half of the same non-skippable, both-stages pass.
 - **Initialize the loop's state file.** Run this skill's bundled
   `scripts/loop-cohort.py init docs/specs/<feature>`; the tool copies
   the bundled `assets/state.json` template into place, sets `feature`
@@ -318,6 +388,20 @@ Match the discipline to the verification mode you picked during PLAN:
 - **Visual / manual QA** — implement, then exercise the built artifact
   end-to-end through the documented workflow recorded in the task, and
   record what you observed (real output, not internal state).
+- **infra/deploy** — implement the change (one task may span several GATES
+  layers), then **drive the deploy yourself and read the real environment
+  output**: run the apply, the smoke
+  probe, the log pull, and the teardown, and read their *actual* output rather
+  than reasoning about what they would say. The **human-as-relay** pattern — a
+  human running the deploy command and pasting the error back into the session
+  by hand — is the anti-pattern this removes; the agent reads ground truth from
+  the environment at each step. This is **harness-agnostic doctrine** — do it
+  by hand on any agent. In Claude Code, background tasks (for long applies),
+  `asyncRewake` (to wake on a background deploy's exit with stderr surfaced),
+  and `PreToolUse` (to gate a destructive command before it runs) are an
+  **accelerant only, never a dependency** — matching how `/verify` and
+  `/simplify` are treated; adapters without them lose the shortcut, not the
+  doctrine.
 
 For each task, implement the smallest coherent unit of work toward the
 goal. Resist the urge to fix unrelated things you notice along the way;
@@ -576,6 +660,43 @@ note in the summary, not a blocker.
   Load 1–3 modules for a typical change, never a flat march of all ten; an
   auth-touching endpoint pulls `access-control` and often `authn-session`.
   This same table backs the pre-EXECUTE spec-stage dispatch above.
+
+  **Mandatory and multi-module on infra-flavored work.** When the change is
+  **infra-flavored** — the **destructive/irreversible risk trigger** routed it
+  to full mode *and* its diff matches the routing table's IaC / deploy-config
+  entry — the `security-reviewer` pass is **non-skippable** and runs at
+  **both the spec stage** (the pre-EXECUTE secure-design step above) **and on
+  the diff**, not via the discretionary security-boundary trigger. Because
+  "infra-flavored" keys on the existing classifier rather than a per-diff
+  judgement, the pass **cannot be silently skipped** on an infra diff. The
+  orchestrator force-loads from the infra-relevant **candidate set** —
+  `config-misconfig` (the IaC / deploy-config entry — IAM, CORS, deploy config —
+  present on any infra diff) plus `access-control` (when the change alters the
+  authorization *model*: role bindings or resource policies that change *who can
+  call what*), `secrets-and-crypto` (secrets in state or env, keys),
+  `outbound-ssrf` (public exposure, CDN / origin egress), and `supply-chain`
+  (provider / module pinning) — each pulled in when the diff trips *that
+  module's own* routing-table row, so the routing table stays the single
+  deterministic authority and the set loads **1–N**, never a flat always-five
+  march (a one-line config tweak pulls one; a new public-facing stack pulls
+  several). This adds **no new reviewer and no new
+  module**: it makes the *existing* security pass mandatory and multi-module.
+  The **Profile-A opt-out still applies wholesale** — a project that uses no
+  reviewer at all opts out of the loop entirely — but where `security-reviewer`
+  *is* in use the infra pass is **not individually skippable**, and a missing
+  `security-reviewer` subagent on infra-flavored work is a **loud blocker in the
+  final summary, not a silent proceed** (the one place the
+  select-or-note fallback hardens to a blocker, given the blast radius).
+
+  **Security on infra is a reviewer + scanner *pair*; neither substitutes for
+  the other.** `security-reviewer` is **not** the per-provider depth source — it
+  reasons from cross-cutting standards (OWASP / ASVS / CWE + STRIDE / LINDDUN)
+  and catches failure *classes* (over-broad IAM, public exposure,
+  unencrypted-at-rest, secrets in state, metadata SSRF, missing audit logging)
+  and control-completeness. The **per-provider secure-config depth** comes from
+  the policy-as-code / CSPM scanner the PLAN preflight requires as a task-zero
+  (its vendor-maintained rulesets *are* the provider baselines). Run both: the
+  scanner for per-provider breadth, the reviewer for failure-class reasoning.
 - Match `quality-engineer` — testability, observability, reliability, and
   maintainability lens, applying a raised default quality floor (universal
   maintainability smells + a mutation-testing mindset) even where no static

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -39,6 +39,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   contract → v0.16). `architect` (0.6.1 → 0.7.0) and `product-engineering`
   (0.4.2 → 0.5.0) become consumers; `research` (0.4.0 → 0.5.0) migrates from the
   undistributed `research-layout.toml` by a **clean rename, no alias**.
+- **Infra-aware `work-loop` — the loop can now drive an infrastructure inner
+  loop end-to-end (`core` pack, bumped to `0.4.12`; RFC-0041 / ADR-0031).** The
+  loop's verification modes previously assumed the verification mechanism
+  already existed and assumed a fast, local, stateless, single-hop gate — so a
+  cloud deploy stalled the agent and the human became a relay, pasting deploy
+  errors back into the session by hand. Four doctrine additions close that gap,
+  all prose (no executable tooling, no new reviewer, no new risk trigger): (P1)
+  a **generalized verification-mechanism preflight** — picking a verification
+  mode now obligates confirming its mechanism exists, and if not, building it is
+  *task zero*; this is agnostic (a missing test runner or build command, not
+  just an infra smoke check) and **universal across light and full mode**, with
+  the infra mechanism enumerated as a multi-artifact set (verify-status +
+  teardown + test-data/mock-user seeding + a provider-appropriate
+  policy-as-code/CSPM scanner). (P2) a fourth **infra/deploy verification
+  flavor** whose contract is a layered GATES sequence (static preflight →
+  plan/preview → idempotent convergent apply → active end-to-end smoke →
+  rollback), cross-linked to the plan's `## Rollout` section. (P4) an
+  **agent-drives-verification** doctrine — the agent runs the deploy and reads
+  real environment output itself, with the human-as-relay named as the
+  anti-pattern and Claude Code background tasks / `asyncRewake` / `PreToolUse`
+  as accelerant only. (P5) **mandatory infra security** — infra-flavored work
+  non-skippably runs `security-reviewer` at both spec stage and on the diff,
+  force-loading the infra-relevant `security-checklists` modules, paired with
+  the P1 policy-as-code/CSPM scanner for per-provider depth.
 - **Research project mode — a four-skill lifecycle for sustained investigations
   (`research` pack, bumped to `0.4.0`).** Alongside the existing depth axis
   (`/research` quick/standard/applied/deep), the pack gains a *lifecycle* axis

--- a/docs/specs/infra-aware-work-loop/plan.md
+++ b/docs/specs/infra-aware-work-loop/plan.md
@@ -1,7 +1,7 @@
 # Plan: infra-aware-work-loop
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Drafting <!-- Drafting | Executing | Done -->
+- **Status:** Done <!-- Drafting | Executing | Done -->
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
 > document is allowed to change as you learn. When it changes substantially
@@ -226,3 +226,6 @@ intact.
 - 2026-06-23: initial plan (follow-on to Accepted RFC-0041; authored alongside
   ADR-0031 and the `operational-safety-checklists` spec in a docs-only PR;
   implementation is a separate later PR).
+- 2026-06-23: implementation landed (this PR) — T1–T5 complete; `work-loop`
+  SKILL.md edits (P1/P2/P4/P5), `core` bumped 0.4.11 → 0.4.12, changelog entry.
+  Status flipped to Done.

--- a/docs/specs/infra-aware-work-loop/spec.md
+++ b/docs/specs/infra-aware-work-loop/spec.md
@@ -1,6 +1,6 @@
 # Spec: infra-aware-work-loop
 
-- **Status:** Draft <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** ADR-0031, RFC-0041 (P1, P2, P4, P5); ADR-0014 + RFC-0025 (the destructive/irreversible risk trigger that routes `apply` to full mode); ADR-0018 (orchestrator-inlined progressive-disclosure security depth, the mechanism P5 reuses); ADR-0017 (the SAST/SCA scanner family the policy-as-code/CSPM scanner joins)
@@ -86,8 +86,9 @@ before proceeding; *Never do* is a hard rule, even under time pressure.
   loop *offers to scaffold* the P1 task-zero artifacts but does not ship them.
 - **Bind P2's infra-flavor prose to a specific IaC tool** (Principle 1).
 - **Make the infra security pass skippable** — P5 is non-skippable, runs at both
-  spec stage and on the diff, and force-loads more than one `security-checklists`
-  module (Decision 6).
+  spec stage and on the diff, and force-loads the infra `security-checklists`
+  modules **1–N** (multi-module-capable, keyed on the routing table — not the
+  single discretionary module) (Decision 6).
 - Edit the projected copy (`.claude/skills/work-loop/SKILL.md`) directly —
   `make build-self` reverts it; the source is the fix point.
 
@@ -117,14 +118,14 @@ strategy the `work-loop-light-mode` spec used for the same class of change.
 
 ## Acceptance Criteria
 
-- [ ] **P1 — generalized preflight.** The PLAN verification-mode step states that
+- [x] **P1 — generalized preflight.** The PLAN verification-mode step states that
   picking a verification mode requires confirming the mechanism for that mode
   exists; if it does not, creating it is **task zero** (a precondition task, not
   an afterthought), and the loop offers to scaffold it. The obligation is
   explicitly **agnostic** (it applies to a missing test runner or build command
   as much as a missing smoke check) and explicitly **universal across light and
   full mode**.
-- [ ] **P1 — infra multi-artifact set.** For infra work the preflight enumerates
+- [x] **P1 — infra multi-artifact set.** For infra work the preflight enumerates
   the mechanism as a multi-artifact set, **each its own task-zero**: (a) a
   verify-status script, (b) a teardown script, (c) test-data / mock-user
   seeding, and (d) a provider-appropriate policy-as-code/CSPM scanner. The
@@ -132,7 +133,7 @@ strategy the `work-loop-light-mode` spec used for the same class of change.
   P2's static preflight (operational misconfig) and P5's security depth
   (security misconfig). The requirement is **mechanism-level, not tool-level**
   (a scanner must exist; the adopter picks Checkov / tfsec / cloud-native CSPM).
-- [ ] **P2 — infra/deploy verification flavor.** The PLAN verification-mode list
+- [x] **P2 — infra/deploy verification flavor.** The PLAN verification-mode list
   gains a fourth flavor, **infra/deploy**, whose contract is a layered GATES
   sequence rather than a single check: (1) static preflight (validate/lint/
   policy-as-code via the P1 scanner); (2) plan/preview (dry-run diff reviewed
@@ -145,10 +146,10 @@ strategy the `work-loop-light-mode` spec used for the same class of change.
   extension of the existing visual-manual-QA "exercise the real built artifact"
   doctrine; (5) rollback (the known-good re-apply path named *before* the first
   apply, since no atomic rollback exists).
-- [ ] **P2 — cross-link, no duplication.** The infra/deploy flavor cross-links to
+- [x] **P2 — cross-link, no duplication.** The infra/deploy flavor cross-links to
   the plan template's `## Rollout` section (deployment sequencing) and does not
   duplicate it; the flavor names *how we verify*, Rollout owns *the sequencing*.
-- [ ] **P4 — agent drives verification.** The loop states as harness-agnostic
+- [x] **P4 — agent drives verification.** The loop states as harness-agnostic
   doctrine that the agent runs the deploy and reads the real environment output
   itself, and names the **human-as-relay** pattern (a human pasting deploy errors
   back) as the anti-pattern. Claude Code primitives — background tasks for long
@@ -157,7 +158,7 @@ strategy the `work-loop-light-mode` spec used for the same class of change.
   **accelerant only, never a dependency** (matching how `/verify` and
   `/simplify` are treated); adapters without them lose the shortcut, not the
   doctrine.
-- [ ] **P5 — mandatory infra security.** Infra-flavored work **non-skippably**
+- [x] **P5 — mandatory infra security.** Infra-flavored work **non-skippably**
   invokes `security-reviewer` at **both** the spec stage (secure-design pass: is
   the control specified as an acceptance criterion at the right depth?) and on
   the diff — not via the discretionary security-boundary trigger. **"Infra-flavored"
@@ -171,23 +172,28 @@ strategy the `work-loop-light-mode` spec used for the same class of change.
   `supply-chain`), loaded 1–N as the diff warrants per the existing
   boundary→module routing table. This adds **no new reviewer and no new
   module** — it makes the *existing* security pass mandatory and multi-module.
-- [ ] **P5 — reviewer + scanner pair.** The prose states that `security-reviewer`
+  The prose names the **opt-out / missing-subagent interaction** explicitly:
+  the Profile-A opt-out still applies wholesale, but where `security-reviewer`
+  is in use the infra pass is not individually skippable and a missing
+  `security-reviewer` subagent on infra-flavored work is a loud blocker in the
+  summary, not a silent proceed.
+- [x] **P5 — reviewer + scanner pair.** The prose states that `security-reviewer`
   is **not** the per-provider depth source: it reasons from cross-cutting
   standards (OWASP / ASVS / CWE + STRIDE/LINDDUN) and catches failure *classes*,
   while per-provider secure-config depth comes from the P1-required policy-as-code/
   CSPM scanner (its rulesets *are* the provider baselines). Security on infra is
   a **pair**; neither substitutes for the other.
-- [ ] **No executable mechanism.** The change adds no new skill directory, no new
+- [x] **No executable mechanism.** The change adds no new skill directory, no new
   artifact/template format, and no executable code as the feature mechanism
   (ADR-0031 structural constraint). `loop-cohort.py` and `lint-spec-status.py`
   are byte-unchanged (empty `git diff` for both; the sibling
   `operational-safety-checklists` spec asserts the same guard — one `git diff`
   satisfies both in a combined PR).
-- [ ] **Projection + lint.** `make build-self` regenerates the projected
+- [x] **Projection + lint.** `make build-self` regenerates the projected
   `work-loop` SKILL.md cleanly; `make build-check`, `python
   tools/lint-agent-artifacts.py`, and `python tools/lint-agents-md.py` all pass
   (the latter two are not in `make build-check`; run by hand / in CI).
-- [ ] **Release hygiene.** `packs/core/pack.toml` version is bumped, the
+- [x] **Release hygiene.** `packs/core/pack.toml` version is bumped, the
   projected `marketplace.json` reflects it after `make build-self`, and
   `docs/product/changelog.md` carries an `[Unreleased]` entry for the work-loop
   behavior change.

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -191,6 +191,60 @@ For anything beyond trivial, *think before you write code*. Concretely:
     asserts **invariants** ("didn't crash, didn't render garbage, layout holds,
     no overflow") rather than specific outputs. Reach for it when the failure
     mode is open-ended and you can't enumerate the gestures up front.
+  - **infra/deploy** — provisioning or changing infrastructure: a cloud
+    deploy, an IaC apply, a stateful migration of a running system. This is the
+    fourth verification *mode* (the spec calls it a *flavor* — same thing).
+    Unlike the three modes above, its contract is a **layered GATES sequence**,
+    not a single check — because a deploy is slow, stateful, costs money, and is
+    partially irreversible. The layers, in order: (1) **static preflight** —
+    validate / lint / policy-as-code, run through the provider-appropriate
+    scanner the preflight obligation below requires as a task-zero (the
+    lint+typecheck analog); (2) **plan / preview** — a dry-run diff, reviewed
+    before any mutation; (3) **idempotent convergent apply — the precondition
+    the rest rests on**: re-running after a fix must *converge, not collide*, so
+    iteration is safe; an imperative, non-idempotent script is the
+    retry-collision root cause, and the thing to fix first rather than work
+    around; (4) **active end-to-end smoke** — not a single status check but a
+    multi-hop probe, and the direct extension of the visual/manual-QA "exercise
+    the real built artifact" doctrine to a deployed system: seed test / mock
+    users → load the real CDN / site URL → assert it actually renders → on
+    failure pull the access / error logs and debug → tear down; (5)
+    **rollback** — *before* the first apply, confirm a known-good re-apply path
+    is named (it belongs in `## Rollout`), since no atomic rollback exists for a
+    partially-applied deploy. This mode names *how we verify* a deploy; it does
+    **not** author *deployment sequencing*, which the plan template's
+    `## Rollout` section already owns — cross-reference it, don't duplicate it. Every layer is tool-neutral
+    (Terraform / Pulumi / CDK / CloudFormation / hand-rolled scripts alike);
+    any tool named here is illustrative, never normative.
+
+  **Confirm the mechanism exists before you claim the mode — task zero if it
+  doesn't.** Picking a verification mode obligates confirming that the
+  mechanism that mode depends on actually exists; if it does not, **building it
+  is task zero** — a precondition task in the plan, not an afterthought — and
+  the loop offers to scaffold it. This obligation is **agnostic and universal
+  across light and full mode**: it applies to a TDD task whose test runner
+  isn't wired, a goal-based task whose build command doesn't exist yet, and a
+  manual-QA task whose artifact can't yet be run, exactly as much as to a
+  missing infra smoke check. It strengthens the assumption-trio — "the
+  mechanism exists" is the kind of assumption that goes unsurfaced precisely
+  because it doesn't feel like one.
+
+  For **infra/deploy** the mechanism is rarely one artifact; the preflight
+  enumerates it as a **multi-artifact set, each its own task-zero**: (a) a
+  **verify-status** script (does the deploy report healthy?), (b) a
+  **teardown** script (clean down a failed or ephemeral run), (c) **test-data /
+  mock-user seeding** (so the smoke probe has something to exercise), and (d) a
+  **provider-appropriate policy-as-code / CSPM scanner**. The scanner is the
+  load-bearing one: it is the **per-provider-depth source**, its
+  vendor-maintained rulesets holding the per-service config checks the
+  standards-grounded reviewers cannot and should not carry — and the **same**
+  scanner feeds two layers, *operational* misconfig → the infra/deploy mode's
+  static preflight (layer 1) and *security* misconfig → the mandatory security
+  pass (REVIEW, below). The requirement is **mechanism-level, not tool-level**:
+  a scanner must exist; the adopter picks Checkov / tfsec / a cloud-native CSPM,
+  exactly as the loop requires "tests exist" without mandating a framework. The
+  loop names these as prerequisite tasks and offers to scaffold them; it does
+  not ship them as executable tooling.
 
   Spikes and throwaway exploration are out of scope.
 - **Design tests up front, before any code.** The contract lives in
@@ -284,6 +338,22 @@ For anything beyond trivial, *think before you write code*. Concretely:
   is not a re-use of either. Same Profile-A opt-out and the same
   `approve-plan` gate apply. Fallback if no `security-reviewer` subagent is
   installed: proceed and note the missing review in the final summary.
+
+  **For infra-flavored work this spec-stage pass is mandatory, not
+  discretionary.** "Infra-flavored" is a **defined signal, not an ad-hoc
+  judgement**: work that the **destructive/irreversible risk trigger** routes to
+  full mode *and* whose spec matches the
+  [boundary→module routing table](#boundarymodule-routing-table)'s IaC /
+  deploy-config entry — the same classifier that already drives security-module
+  loading (the spec-stage half keys this match on the spec; the diff-stage half
+  on the diff — same routing-table entry). When that signal is present the
+  `security-reviewer` runs at spec stage **regardless of** the discretionary
+  security-boundary trigger, and the orchestrator **force-loads** the
+  infra-relevant `security-checklists` modules (the candidate set the REVIEW
+  `security-reviewer` bullet names), loaded 1–N as the spec warrants per that
+  table. The matching diff-stage pass, the reviewer-plus-scanner pairing, and
+  the Profile-A / missing-subagent interaction all live in that REVIEW bullet —
+  this is the spec-stage half of the same non-skippable, both-stages pass.
 - **Initialize the loop's state file.** Run this skill's bundled
   `scripts/loop-cohort.py init docs/specs/<feature>`; the tool copies
   the bundled `assets/state.json` template into place, sets `feature`
@@ -318,6 +388,20 @@ Match the discipline to the verification mode you picked during PLAN:
 - **Visual / manual QA** — implement, then exercise the built artifact
   end-to-end through the documented workflow recorded in the task, and
   record what you observed (real output, not internal state).
+- **infra/deploy** — implement the change (one task may span several GATES
+  layers), then **drive the deploy yourself and read the real environment
+  output**: run the apply, the smoke
+  probe, the log pull, and the teardown, and read their *actual* output rather
+  than reasoning about what they would say. The **human-as-relay** pattern — a
+  human running the deploy command and pasting the error back into the session
+  by hand — is the anti-pattern this removes; the agent reads ground truth from
+  the environment at each step. This is **harness-agnostic doctrine** — do it
+  by hand on any agent. In Claude Code, background tasks (for long applies),
+  `asyncRewake` (to wake on a background deploy's exit with stderr surfaced),
+  and `PreToolUse` (to gate a destructive command before it runs) are an
+  **accelerant only, never a dependency** — matching how `/verify` and
+  `/simplify` are treated; adapters without them lose the shortcut, not the
+  doctrine.
 
 For each task, implement the smallest coherent unit of work toward the
 goal. Resist the urge to fix unrelated things you notice along the way;
@@ -576,6 +660,43 @@ note in the summary, not a blocker.
   Load 1–3 modules for a typical change, never a flat march of all ten; an
   auth-touching endpoint pulls `access-control` and often `authn-session`.
   This same table backs the pre-EXECUTE spec-stage dispatch above.
+
+  **Mandatory and multi-module on infra-flavored work.** When the change is
+  **infra-flavored** — the **destructive/irreversible risk trigger** routed it
+  to full mode *and* its diff matches the routing table's IaC / deploy-config
+  entry — the `security-reviewer` pass is **non-skippable** and runs at
+  **both the spec stage** (the pre-EXECUTE secure-design step above) **and on
+  the diff**, not via the discretionary security-boundary trigger. Because
+  "infra-flavored" keys on the existing classifier rather than a per-diff
+  judgement, the pass **cannot be silently skipped** on an infra diff. The
+  orchestrator force-loads from the infra-relevant **candidate set** —
+  `config-misconfig` (the IaC / deploy-config entry — IAM, CORS, deploy config —
+  present on any infra diff) plus `access-control` (when the change alters the
+  authorization *model*: role bindings or resource policies that change *who can
+  call what*), `secrets-and-crypto` (secrets in state or env, keys),
+  `outbound-ssrf` (public exposure, CDN / origin egress), and `supply-chain`
+  (provider / module pinning) — each pulled in when the diff trips *that
+  module's own* routing-table row, so the routing table stays the single
+  deterministic authority and the set loads **1–N**, never a flat always-five
+  march (a one-line config tweak pulls one; a new public-facing stack pulls
+  several). This adds **no new reviewer and no new
+  module**: it makes the *existing* security pass mandatory and multi-module.
+  The **Profile-A opt-out still applies wholesale** — a project that uses no
+  reviewer at all opts out of the loop entirely — but where `security-reviewer`
+  *is* in use the infra pass is **not individually skippable**, and a missing
+  `security-reviewer` subagent on infra-flavored work is a **loud blocker in the
+  final summary, not a silent proceed** (the one place the
+  select-or-note fallback hardens to a blocker, given the blast radius).
+
+  **Security on infra is a reviewer + scanner *pair*; neither substitutes for
+  the other.** `security-reviewer` is **not** the per-provider depth source — it
+  reasons from cross-cutting standards (OWASP / ASVS / CWE + STRIDE / LINDDUN)
+  and catches failure *classes* (over-broad IAM, public exposure,
+  unencrypted-at-rest, secrets in state, metadata SSRF, missing audit logging)
+  and control-completeness. The **per-provider secure-config depth** comes from
+  the policy-as-code / CSPM scanner the PLAN preflight requires as a task-zero
+  (its vendor-maintained rulesets *are* the provider baselines). Run both: the
+  scanner for per-provider breadth, the reviewer for failure-class reasoning.
 - Match `quality-engineer` — testability, observability, reliability, and
   maintainability lens, applying a raised default quality floor (universal
   maintainability smells + a mutation-testing mindset) even where no static

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "0.4.11"
+version = "0.4.12"
 description = "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 readme = "README.md"
 display_name = "Core"


### PR DESCRIPTION
Implements `docs/specs/infra-aware-work-loop/` — the RFC-0041 follow-on (ADR-0031). Four prose-only additions to the `core` `work-loop` SKILL.md so the loop can drive an infrastructure inner loop end-to-end instead of stalling the moment a deploy is involved (the human-as-relay anti-pattern). Lands ahead of the sibling `operational-safety-checklists` spec, as the plan directs.

## What & why

- **P1 — generalized verification-mechanism preflight.** Picking a verification mode now obligates confirming its mechanism exists; if not, building it is *task zero*. Agnostic (a missing test runner / build command, not just an infra smoke check) and **universal across light and full mode**. For infra the mechanism is a multi-artifact task-zero set: verify-status + teardown + test-data/mock-user seeding + a provider-appropriate policy-as-code/CSPM scanner (the per-provider-depth source feeding both P2 and P5).
- **P2 — fourth infra/deploy verification mode.** Contract is a layered GATES sequence: static preflight → plan/preview → idempotent convergent apply (named as the precondition) → active end-to-end smoke (multi-hop: seed users → load real URL → assert render → read logs → debug → teardown) → rollback. Cross-linked to the plan's `## Rollout`, no duplication.
- **P4 — agent-drives-verification.** The agent runs the deploy and reads real environment output itself; human-as-relay named as the anti-pattern; Claude Code background tasks / `asyncRewake` / `PreToolUse` are accelerant only, never a dependency.
- **P5 — mandatory infra security.** Infra-flavored work non-skippably runs `security-reviewer` at spec stage **and** on the diff, force-loading the infra `security-checklists` candidate set (config-misconfig always; access-control/secrets-and-crypto/outbound-ssrf/supply-chain per their own routing-table rows), paired with the P1 scanner. Reviewer = failure-class reasoning; scanner = per-provider depth. Profile-A opt-out preserved wholesale; a missing subagent on infra work hardens to a loud blocker.

No executable tooling, no new reviewer, no new risk trigger (ADR-0031). `loop-cohort.py` / `lint-spec-status.py` byte-unchanged.

## How it was verified

- `make build-check`, `tools/lint-agent-artifacts.py`, `tools/lint-agents-md.py`, `lint-spec-status.py` — all exit 0.
- `make build-self` regenerates both projections byte-matching the source.
- `adversarial-reviewer`, `security-reviewer`, and `quality-engineer` all returned `Clean — ready to commit.` (iterated through B1/B2/C3 metadata, C1 fail-open seam, C2 routing-table coherence, and mode/flavor terminology fixes).

## What could break

Prose-only and fully reversible (revert the SKILL.md edits + version bump). Dormant weight for adopters who never deploy infra (the P1 preflight still earns its place on every task).

## Anything the reviewer should know

- `core` bumped 0.4.11 → 0.4.12 (`pack.toml` + `plugin.json` + projected `marketplace.json`); changelog `[Unreleased]` entry added. Spec **Shipped**, all 10 ACs checked; plan **Done**.
- The sibling `operational-safety-checklists` spec (P3 `operational-safety` library + `quality-engineer` routing + deferred-authority pointer) is deliberately **out of scope** here and untouched.