### PR TITLE
docs(rfc): RFC-0042 follow-on — ADR-0032 + agentic-well-architected-overlay spec/plan

### DIFF
--- a/docs/adr/0032-agentic-overlay-is-a-design-and-review-workload-class-lens.md
+++ b/docs/adr/0032-agentic-overlay-is-a-design-and-review-workload-class-lens.md
@@ -1,0 +1,103 @@
+# ADR-0032: The agentic well-architected overlay is a first-class workload-class lens applied at design *and* review — a routing axis plus progressive taxonomy on the existing `architect` skills, not a new primitive
+
+- **Status:** Accepted
+- **Date:** 2026-06-23
+- **Decision-makers:** eugenelim
+- **Consulted:** RFC-0042 (the accepted decision this records, incl. its AWS-Agentic-Lens spike result and the D1–D5 decision set); the spec-stage adversarial + design + security review of this ADR and the implementing spec
+- **Supersedes:** none
+- **Related:** RFC-0042 (the accepted decision this ADR records); `docs/specs/well-architected-cloud/` (Shipped/frozen — the spec whose review-time-only scoping this widens, and the source of the five-concern lens being expanded); RFC-0032 (the `architect` `design-reviewer` / fresh-context critique whose value the design-time-only alternative would have lost); ADR-0023 (the three-reviewer ceiling scopes the core *code-review* lenses — cited to show a design-time skill lens does not engage it); RFC-0029 (the `security-checklists` `llm-agent` module the overlay's security-boundary concerns route to); RFC-0041 / ADR-0031 (the precedent for a progressive-disclosure concern library consumed by a pack lens, and for naming an emerging-standard's maturity caveat honestly)
+
+## Context
+
+The `architect` pack ships a GenAI/agentic well-architected overlay, and `architect-review`'s well-architected (WA) mode can apply it as a workload-class lens (`rubric-well-architected.md:11-19`). But the overlay is **mis-wired** and **under-scoped**, and both gaps trace to one frozen scoping decision.
+
+- **Mis-wired (design-time gap).** `architect-design` makes a design "well-architected by construction" at its Stage 0 (`SKILL.md:45-60`) by routing on **provider / provider-class** (named cloud → pillars; primitives → capability gaps; local-first → local-dev), plus a leading-edge-novelty fallback for domains no shipped reference fits. There is **no workload-class axis**. The GenAI/agentic lens file is duplicated into the design skill, but no step in the procedure references it — it is a dead copy, and the leading-edge fallback can't reach it (agentic *has* a shipped reference, so that branch never fires). An agentic system is therefore shaped against flat pillars, and the overlay enters — if at all — only when a reviewer happens to run WA mode and its findings feed the convergence loop.
+- **Under-scoped (content gap).** The shipped lens names five concerns — prompt injection, tool-use authz, data egress, evals/observability, token cost (`spec.md:254-257`). It does not make **human oversight / HITL**, **bounded autonomy / intent verification**, or **auditable, attributable action trails** first-class — precisely the concerns that distinguish a system that *acts* from one that only *generates text*, and the ones the major clouds, OWASP, and NIST now treat as baseline.
+
+Both gaps follow from the `well-architected-cloud` spec's deliberate decision that the workload-class lens axis lives in *review*, with design consuming it second-hand (`spec.md:32-41`, `:219-220`). That spec is **Shipped/frozen** — its body is immutable (`CONVENTIONS.md` § Document lifecycle, Frozen row) — and **no ADR or RFC governs the review-time-only scoping** (`plan.md:35`), so there is nothing to mechanically supersede: the scoping must be *named explicitly and widened* by a new decision.
+
+Constraints in force when deciding:
+
+- **CHARTER Principle 3 (a habit, not infrastructure).** The repo ships doctrine and prose the agent reasons from, never a runtime engine or executable tooling. This forecloses shipping evals or an executable overlay.
+- **CHARTER Principle 2 (no duplication).** A capability belongs in exactly one place; a parallel skill that re-implements `architect-design`'s framing is rejected.
+- **The pack's "no required composition / per-skill duplication" shape** (`architect/README.md:54-57`, `:153-156`). Each skill stands alone; shared references are duplicated per skill with a duplication note rather than shared by inter-skill reference.
+- **The three-reviewer ceiling (ADR-0023).** Core code-review has exactly three lenses — `adversarial-reviewer`, `security-reviewer`, `quality-engineer`. A fourth is out of bounds.
+- **The pack's altitude:** reason about boundaries and authority, name frameworks never, apply what bites; route control-level verification to `security-reviewer` / `security-checklists`.
+
+RFC-0042 settled *whether* and *how* to close these gaps (decisions D1–D5, with the riskiest assumption — that leading practice treats agentic as a workload-class lens applied at *both* design and review — confirmed against the AWS Well-Architected Agentic AI Lens). This ADR records the load-bearing, expensive-to-reverse calls — the *lifecycle position*, the *routing form*, the *taxonomy shape*, and the *autonomy framing* — so a future maintainer doesn't re-litigate them. The mechanical detail (the exact routing-branch wording, the Tier A/B/C concern list, the coverage-parity criterion) is spec-level and lives in the implementing spec, not here.
+
+## Decision
+
+> We will treat the GenAI/agentic well-architected overlay as a **first-class workload-class lens consumed by construction at design time *and* at review time, from one logical lens (physically duplicated per the pack's per-skill shape, kept byte-identical)**; expand it into a **progressive, capability-tiered taxonomy** (Tier A *the LLM is on the path* → Tier B *the system acts* → Tier C *the agent persists or collaborates*); and ship it as a **routing branch plus reference-content expansion on the existing `architect` skills** — not as a new reviewer, a new skill, or any executable tooling.
+
+Four sub-decisions, each expensive to reverse:
+
+- **Lifecycle position — design *and* review, one *logical* lens (the reversal).** The overlay is applied by construction when a design is *shaped* (`architect-design` Stage 0) and re-checked when a design is *critiqued* (`architect-review` WA mode), consuming the **same** `lens-genai-agentic.md` — one *logical* lens, physically duplicated per the pack's per-skill shape and kept byte-identical (not a single physical file — which refines RFC-0042's "no divergence" goal into "divergence *caught at review*" once the physical-duplication constraint is admitted). This **names the frozen `well-architected-cloud` spec's review-time-only scoping explicitly and widens it**; the frozen spec stays as the record of what shipped. This is the call the implementing spec (D1's "new spec") carries forward; the frozen body is not edited.
+- **Routing form — workload-class as a second, orthogonal axis in design's by-construction step.** `architect-design`'s Stage 0 gains a *workload-class* axis alongside its existing *provider* axis. The two are orthogonal: an agentic system on a named cloud loads both the cloud pillars and the agentic overlay. This mirrors `architect-review`'s already-shipped concern-lens × workload-class split (`rubric-well-architected.md:11-19`) — the design side adopts the model review already has. The trigger is the system *acting* (the design names tool-use, autonomous action, or an agent loop); a non-acting generative design (plain RAG/chat) loads only Tier A.
+- **Taxonomy shape — progressive, capability-tiered (A→B→C), not flat and not pillar-keyed.** Concerns are grouped by the capability that triggers them, so an adopter applies only the tier that matches how agentic their system is. The tiers are a **filter, not a worklist** — the shipped lens's "apply the concerns that bite for THIS system" instruction is preserved. Both AWS (GenAI Lens → Agentic Lens) and Azure ("retrieval → task-based → autonomous") escalate guidance by capability; a flat list would burden a plain-RAG design with multi-agent concerns, and a pillar-keyed list would bury the act-vs-generate distinction the overlay exists to draw.
+- **Graduated-autonomy framing — engineering judgment, not a standards mandate.** The overlay includes graduated autonomy ("begin with oversight at decision boundaries, widen as a measured track record accumulates") as an engineering-judgment principle. It does **not** assert that any standard prescribes threshold-gated checkpoint removal — none does, and Anthropic's own autonomy research argues against prescriptive per-action thresholds. The framing carries the explicit cap that **irreversibility and blast radius bound how far autonomy widens regardless of track record**: a clean record justifies widening on reversible actions, never on the irreversible / outbound / spending actions Tier B already says to gate. A **partially-reversible or reversible-at-a-cost** action (a rollback-able deploy, a refundable charge) defaults to the *gated* side absent a deliberate per-action judgment to treat it as reversible — the gated-by-default partition is the safe default, not an exhaustive classification.
+
+Boundaries on the decision:
+
+- **No new primitive.** This is a routing-line change plus reference-content expansion on existing `architect` skills — not a new reviewer agent and not a new skill. A standalone "agentic-design" skill is rejected against Principle 2 and the pack's three-peer-skill shape; a fourth reviewer is rejected against ADR-0023. The three-reviewer ceiling is **cited, not engaged** — a design-time workload-class lens is a *skill behaviour*, not a code-review reviewer: ADR-0023 scopes reviewers of a *code diff*, and the overlay shapes a design artifact before any code exists and adds no diff-review pass, so the ceiling's subject is simply absent.
+- **Prose only.** No executable tooling, evals, or runtime ships, consistent with Principle 3 and the rest of the pack. The expansion lives in the on-demand reference file (progressive disclosure); `architect-design/SKILL.md` gains one routing branch, not the taxonomy.
+- **Security-boundary concerns name the boundary at design altitude and route control-level verification to `security-reviewer` / `security-checklists` (`llm-agent` module)** — exactly as the shipped lens does. The overlay does not own controls. The implementing spec makes **coverage parity** between the overlay's security-boundary concern set and the `llm-agent` module an explicit, **bidirectional** acceptance criterion (every module control is covered by an overlay concern, *and* every overlay security concern resolves to a named module check or an explicit design-altitude-only status). Where the overlay names an agentic boundary the `llm-agent` module does not yet enumerate (execution isolation, inter-agent identity/privilege propagation, memory poisoning), the spec records the module extension as a deferred backlog item rather than letting the route-out land on a missing control — the overlay still names the boundary at design altitude meanwhile, since `security-reviewer` reasons from cross-cutting standards (OWASP/STRIDE/LINDDUN), not the module text alone.
+- **Scope is GenAI/agentic only.** ML / SaaS / serverless remain named-but-unbacked in `rubric-well-architected.md` (status quo); this decision neither backs nor removes them. The deferral is recorded in `docs/backlog.md`, not left as RFC-only prose.
+
+## Decision drivers
+
+- **Leading practice treats agentic as a workload-class lens used at *both* design and review** — drives the dual-consumption + workload-class framing. Confirmed against the AWS Well-Architected Agentic AI Lens (a workload-class lens explicitly scoped to "Designing a new agentic AI system… or Reviewing an existing agentic AI deployment," with bounded autonomy, tiered human oversight, and auditability as first-class principles); Azure structures the same content as design areas plus a testing/evaluation gate. No surveyed framework attaches agentic guidance to review only.
+- **The design-time gap is real, present pain** — drives the routing branch. The design skill has no workload-class axis and the lens copy is a dead file; agentic systems are shaped against flat pillars today.
+- **Principle 2 + the pack's three-peer-skill shape** — rules out a new `agentic-design` skill; a routing branch in the existing skill suffices, and a parallel skill would duplicate `architect-design`'s framing.
+- **Principle 3 (habit, not infrastructure)** — rules out evals or executable tooling; the overlay stays prose.
+- **The three-reviewer ceiling (ADR-0023)** — rules out a fourth, agentic-lens reviewer; cited to show that a design-time skill lens does not engage it.
+- **The pack's "name the boundary, route controls out" altitude** — drives the route-to-`security-reviewer` boundary and the coverage-parity criterion, keeping the overlay from drifting into control-level prescriptions it shouldn't own.
+- **Anthropic's autonomy research as counter-evidence** — drives D4's engineering-judgment framing over a prescriptive oversight-threshold matrix.
+
+## Consequences
+
+**Positive:**
+
+- The overlay is **built in at design time and re-checked at review time from one logical lens** — physically two per-skill copies kept byte-identical per the pack's duplication shape, with divergence a maintenance burden *caught at review* rather than prevented by construction — so design and review reason from the same content, matching the strongest prior art (the AWS Agentic Lens's explicit design-or-review scoping).
+- The design side **reuses the orthogonal concern × workload-class axis model `architect-review` already ships**, so this is a second consumer of an existing pattern, not a new mechanism.
+- **Progressive disclosure keeps the surface small**: `architect-design/SKILL.md` gains one routing branch; the expanded taxonomy lives in the on-demand reference, so a plain-RAG design isn't burdened with Tier B/C concerns and the skill body doesn't bloat.
+- The overlay's content moves up to current practice (the trust triad — HITL, intent verification, attributable action trails — becomes first-class) without leaving the pack's design altitude.
+
+**Negative:**
+
+- A **frozen-spec scope decision is reversed**, which costs a new spec and a clear "we changed our mind, here's why" in governance (this ADR + the implementing spec). Recorded deliberately rather than worked around.
+- The overlay grows from five concerns to a **materially larger, tier-gated set** — more surface to maintain as the practice moves (the agentic-security standards and OTel GenAI conventions are still settling).
+- **Design-time routing adds an "is this agentic?" judgment call early**, when the concept is least settled. Mitigated: the trigger is the system *acting*, and Tier A is the explicit non-acting baseline, so over-firing drags in at most Tier A.
+
+**Neutral / to revisit:**
+
+- **OTel GenAI semantic conventions are "Development" status.** The overlay may name them as the converging instrumentation standard *with an explicit maturity caveat* (the RFC-0041 pattern) — revisit and drop the caveat when they stabilise. (RFC-0042 open question 1, resolved to this default.)
+- **Tier C's gate is split** — memory & context integrity fires on *stateful*, while sub-agent provenance + multi-agent coordination/identity-propagation fire on *multi-agent* (tool/MCP *source* provenance moves up to Tier B, where any externally-sourced tool/MCP load is the LLM03 supply-chain trust question) — so a single stateful agent picks up only the memory concern. This is the sharpest instance of RFC-0042's falsifiable assumption that the capability-tiered grouping is the right cut (adopters can tell which tier they're in); if the Tier-C split proves ambiguous in practice, that assumption — and the taxonomy-shape sub-decision — is what fails. Revisit then. (RFC-0042 open question 2, resolved to this default.)
+- **ML / SaaS / serverless stay deferred**, named-but-unbacked. A future RFC that backs any of them reopens this scope.
+
+## Confirmation
+
+- The implementing spec's acceptance criteria encode the decision — the workload-class routing branch in `architect-design` Stage 0, the expanded progressive Tier A/B/C `lens-genai-agentic.md` in **both** skill copies, the trust triad and graduated-autonomy framing, the Tier-C gate split, the coverage-parity criterion against the `llm-agent` module, and the dogfood run — so conformance is checkable against the spec.
+- The spec-stage and diff review passes (adversarial + design + security) confirm that **no new primitive creeps in** (the standing scope-inflation risk), that the overlay **stays prose at design altitude** with no control-level prescriptions, that the **route-to-`security-reviewer` boundary holds**, and that the **two lens copies stay identical** (the pack's per-skill duplication, not divergence).
+- **Enforcement is deliberately review-time, not a standing CI gate.** Conformance is confirmed at the implementing PR (the spec's ACs) and thereafter by the three reviewer passes' standing doctrine; there is no machine fitness function asserting "the overlay ships no executable tooling" or "the two copies match" against future drift. This matches Principle 3 (the bar that forecloses a code gate is the same one that keeps the overlay prose) and ADR-0030/0031's precedent of accepting a prose-enforced, reviewer-held residual. A later optional governance lint (e.g. asserting the two lens copies are byte-identical modulo the duplication note) could harden it without reversing this ADR, and is recorded as a possible follow-up, not a requirement.
+
+## Alternatives considered
+
+- **Do nothing — keep the lens review-only and at five concerns.** Rejected against the **design-time-gap** driver: agentic systems keep being shaped against flat pillars, and the trust/oversight/audit gap persists. This is the status-quo cell, and it is the outlier against all surveyed prior art.
+- **Review-time only, expand content.** Rejected as half the ask — it fixes the content gap but not the wiring gap; design still shapes against generic pillars first and the overlay arrives as rework.
+- **Design-time only — load the overlay by construction, drop the review-side lens.** Rejected against **RFC-0032's fresh-context-critique value**: a design would mark its own homework, regressing the independent review pass.
+- **A new standalone "agentic-design" skill.** Rejected against **Principle 2 and the pack's three-peer-skill shape** — a parallel skill re-implements `architect-design`'s framing; a routing branch suffices.
+- **A fourth, agentic-lens reviewer.** Rejected against **the three-reviewer ceiling (ADR-0023)** — the design-time lens is a skill behaviour, not a code-review reviewer.
+- **A flat or pillar-keyed taxonomy** instead of capability-tiered. Rejected against the **prior-art escalate-by-capability pattern**: a flat list burdens plain-RAG designs with multi-agent concerns, and a pillar-keyed list buries the act-vs-generate distinction.
+- **Graduated autonomy as a prescribed oversight-threshold matrix.** Rejected against **Anthropic's autonomy research** (per-action thresholds create friction without commensurate safety) and the absence of any standard formalising threshold-gated checkpoint removal — hence the engineering-judgment framing with the irreversibility/blast-radius cap.
+
+## References
+
+- RFC-0042 — Agentic well-architected overlay as a first-class workload-class lens (the accepted decision this ADR records; decisions D1–D5, the AWS-Agentic-Lens spike, and the evidence base).
+- `docs/specs/well-architected-cloud/` — the Shipped/frozen spec whose review-time-only scoping is widened and whose five-concern lens is expanded.
+- RFC-0032 — the `architect` `design-reviewer` / fresh-context critique (the value the design-time-only alternative would lose).
+- ADR-0023 — the three-reviewer ceiling scopes the core code-review lenses (cited; not engaged by a design-time skill lens).
+- RFC-0029 — the `security-checklists` `llm-agent` module the overlay's security-boundary concerns route to.
+- RFC-0041 / ADR-0031 — precedent for a progressive-disclosure concern library consumed by a pack lens, and for honestly caveating an emerging standard's maturity.
+- [AWS Well-Architected Agentic AI Lens](https://docs.aws.amazon.com/wellarchitected/latest/agentic-ai-lens/agentic-ai-lens.html) — the prior art confirming the workload-class, design-and-review framing.
+- CHARTER Principles 2 and 3 — the no-duplication and habit-not-infrastructure bars this decision clears.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -37,6 +37,7 @@
 | 0029 | [Research pack structure — two orthogonal axes (depth × lifecycle), with a prompt-only project mode](0029-research-two-axes-depth-and-lifecycle.md) | Accepted |
 | 0030 | [Consolidated, namespaced pack-output layout contract (`agentbundle-layout.toml`)](0030-consolidated-pack-output-layout-contract.md) | Accepted |
 | 0031 | [Infra `work-loop` support is doctrine on existing reviewers — `quality-engineer` for operational safety, a mandatory `security-reviewer` + scanner pair for security — not a new reviewer or runtime](0031-infra-support-is-doctrine-on-existing-reviewers-not-a-new-reviewer-or-runtime.md) | Accepted |
+| 0032 | [The agentic well-architected overlay is a first-class workload-class lens applied at design *and* review — a routing axis plus progressive taxonomy on the existing `architect` skills, not a new primitive](0032-agentic-overlay-is-a-design-and-review-workload-class-lens.md) | Accepted |
 
 ## Adding a new ADR
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -932,3 +932,28 @@ the same directory on the same install — so it is a wasted side-effect, not a
 correctness or security defect. **Unblocks when:** someone wants the
 micro-optimization; fix by computing `layout_path` lazily or probing existence
 before the `user_state_path` call.
+
+### ml-saas-serverless-workload-class-lenses
+
+**Spec:** [agentic-well-architected-overlay](specs/agentic-well-architected-overlay/spec.md)
+(final AC; ADR-0032 / RFC-0042 D5). `rubric-well-architected.md` names four
+workload-class lenses — ML, GenAI/agentic, SaaS, serverless — but only
+GenAI/agentic is backed by a lens file. ADR-0032 widens and expands the
+GenAI/agentic overlay only; ML / SaaS / serverless stay **named-but-unbacked**
+(status quo), neither backed nor removed. **Unblocks when:** a future RFC takes
+on backing one of them with its own workload-class lens reference; until then
+the rubric names them as known, deferred gaps.
+
+### llm-agent-module-agentic-boundary-extension
+
+**Spec:** [agentic-well-architected-overlay](specs/agentic-well-architected-overlay/spec.md)
+(coverage-parity AC; ADR-0032). The agentic overlay names three security
+boundaries at design altitude that the `security-checklists` `llm-agent` control
+module does not yet enumerate — **execution isolation & blast radius**,
+**inter-agent identity/privilege propagation**, and **memory poisoning** (OWASP
+Agentic Top 10: tool misuse, identity/privilege abuse, memory poisoning). Until
+the module gains matching checks, the overlay routes these concerns out at
+design altitude and the `security-reviewer` reasons from cross-cutting standards
+(OWASP/STRIDE/LINDDUN) rather than module text. **Unblocks when:** the
+`llm-agent` module (RFC-0029 surface) is extended with Agentic-Top-10 checks for
+these three boundaries, closing the route-out destination gap.

--- a/docs/specs/agentic-well-architected-overlay/plan.md
+++ b/docs/specs/agentic-well-architected-overlay/plan.md
@@ -1,0 +1,157 @@
+# Plan: agentic-well-architected-overlay
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Drafting <!-- Drafting | Executing | Done -->
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn. When it changes substantially
+> (a different approach, not just a re-ordering), note why in the changelog
+> at the bottom.
+
+## Approach
+
+The change has two halves that meet at one shared file. **First, author the canonical expanded lens** (`lens-genai-agentic.md`) — reorganise the five shipped concerns into the progressive Tier A/B/C taxonomy and add the missing concerns (the Tier-B trust triad, output handling, execution isolation, reliability-under-non-determinism; the Tier-C memory/provenance/coordination set), keeping the route-to-`security-reviewer` boundary and the apply-what-bites instruction. **Second, wire it in at design time** — add the workload-class routing branch to `architect-design` Stage 0 so the (today dead) lens copy becomes live. The lens is duplicated per skill, so the canonical content is written once and mirrored byte-for-byte into both copies (modulo each copy's duplication note). The review side already routes to the lens, so it picks up the expansion for free; the only review-side task is a no-regression check.
+
+The riskiest part is **content parity and altitude**: the security-boundary concerns must cover the `llm-agent` module's surface without sliding into control-level prescriptions the pack shouldn't own. That is the focus of the coverage-parity task and the security-reviewer pass. The routing branch itself is a small, well-bounded SKILL.md edit. Order: author the lens (T1), mirror it (T2), wire design-time routing (T3), then the parity/no-regression/version/dogfood checks (T4–T7).
+
+This plan describes the **implementing PR**; the governance PR that introduces ADR-0032 and this spec/plan does not execute it.
+
+## Constraints
+
+- **ADR-0032** — the load-bearing decisions: design-and-review one-shared-file, workload-class as an orthogonal routing axis, progressive A/B/C taxonomy, graduated autonomy as engineering judgment, no new primitive, prose only.
+- **RFC-0042** — D1–D5 and the open-question defaults (OQ1 OTel-with-caveat, OQ2 Tier-C gate split).
+- **CHARTER Principles 2 & 3** — no duplication (no new skill), habit not infrastructure (no executable tooling/evals).
+- **ADR-0023** — the three-reviewer ceiling (no fourth reviewer).
+- **The pack's per-skill duplication shape** — both lens copies stand alone, each with a duplication note (`architect/README.md:54-57`).
+
+## Construction tests
+
+Most verification is per-task below. Cross-cutting checks that span tasks:
+
+**Integration / cross-cutting checks:**
+- **Both-copies-identical:** `diff` the two `lens-genai-agentic.md` files with their duplication-note lines normalised — they are otherwise byte-identical.
+- **Coverage parity:** a reviewer-checkable mapping from each overlay security-boundary concern to a `security-checklists/references/llm-agent.md` item; no overlay security concern is unmapped, and the `llm-agent` surface is fully covered by the overlay's concern set.
+- **No SKILL.md taxonomy inlining:** `grep` confirms `architect-design/SKILL.md` references the lens file but does not enumerate the Tier A/B/C concern list.
+
+**Manual verification:**
+- Dogfood `architect-design` end-to-end on one agentic concept and one plain-RAG concept; record what the skill loads and produces (T7).
+
+## Tasks
+
+### T1: Author the expanded progressive lens (canonical content)
+
+**Depends on:** none
+
+**Tests:**
+- `grep` confirms the three tier headings (Tier A / Tier B / Tier C) and their gating instructions are present (AC: progressive taxonomy).
+- `grep` confirms each named concern from the spec's Tier A/B/C ACs is present (injection, egress/disclosure, evaluation, token cost, observability; tool-authz+bounded-autonomy+intent-verification, tool/MCP source provenance, output handling, execution isolation, human oversight, auditability, reliability; memory integrity, sub-agent provenance, multi-agent/identity-propagation).
+- `grep` confirms the Tier-C gate split is written as **distinct** triggers — memory & context integrity on *stateful*, sub-agent provenance + coordination/identity-propagation on *multi-agent*, tool/MCP source provenance on *Tier B* — not collapsed into one gate (AC: Tier-C gate split; tool/MCP provenance on Tier B).
+- `grep`/read confirms each trust-triad item (human oversight/HITL, intent verification, auditable action trails) is its **own** named concern entry, not a sub-clause of the tool-authz or observability bullets (AC: trust triad first-class).
+- `grep`/read confirms the Tier-B authz concern forces the explicit "tool allowlist + which actions require confirmation" question (AC: Tier B authz, the named design-time miss).
+- `grep` confirms the Tier-C memory/poisoning concern carries the **LLM04** anchor, the Tier-A retrieved-content/embedding surface carries the **LLM08** anchor, and the Tier-A token-cost + Tier-B loop-cap concerns carry the **LLM10** anchor (AC: OWASP anchors; bidirectional parity direction (a) for LLM10).
+- `grep` confirms the graduated-autonomy text names the irreversibility/blast-radius cap (incl. the partially-reversible default-to-gated case) and contains no "a standard requires/prescribes" claim about threshold-gated checkpoint removal (AC: engineering-judgment framing).
+- `grep` confirms OTel GenAI conventions are named with a maturity caveat (AC: OQ1).
+- `grep` confirms the route-to-`security-reviewer` / `llm-agent` block and the apply-what-bites instruction are retained (AC: altitude).
+
+**Approach:**
+- Start from the shipped `lens-genai-agentic.md`; regroup its five concerns under Tier A/B and add the missing concerns per the spec's Tier A/B/C ACs.
+- Write the per-tier gating instruction (Tier A always; Tier B once the system acts; Tier C split — memory on *stateful*, provenance/coordination on *multi-agent*).
+- Keep the "Distinct from the managed-platform diagram refs", "Routes into the security boundary", and "Use, don't recite" sections; extend the security-boundary section to enumerate the full Tier A/B/C security-boundary concern set that routes out.
+
+**Done when:** the canonical lens text exists and all T1 greps pass against it.
+
+### T2: Mirror the lens into both skill copies identically
+
+**Depends on:** T1
+
+**Tests:**
+- `diff` of the two `lens-genai-agentic.md` copies (duplication-note lines normalised) is empty (AC: both copies identical).
+- `grep` confirms each copy retains its own one-line duplication note pointing at the sibling skill (AC: per-skill duplication preserved).
+
+**Approach:**
+- Write the canonical content into `architect-design/references/lens-genai-agentic.md` and `architect-review/references/lens-genai-agentic.md`, preserving each file's existing duplication-note line.
+
+**Done when:** the both-copies-identical cross-cutting check passes.
+
+### T3: Add the workload-class routing branch to `architect-design` Stage 0
+
+**Depends on:** T2
+
+**Tests:**
+- `grep` confirms Stage 0 (`SKILL.md:45-60` region) now references `references/lens-genai-agentic.md` behind an agentic-workload trigger (names tool-use / autonomous action / agent loop) (AC: routing axis exists).
+- `grep` confirms the branch is additive to provider routing (the provider routing text is unchanged and the agentic branch loads alongside it) (AC: orthogonal axes).
+- `grep` confirms the Tier A/B/C concern list is **not** inlined into `SKILL.md` (AC: routing branch is the only SKILL.md addition) — cross-cutting "no taxonomy inlining" check.
+
+**Approach:**
+- In the Stage 0 step, add a workload-class sentence parallel to the provider sentence: when the concept's workload is agentic, load `references/lens-genai-agentic.md` and shape against the applicable tier(s); the two axes are orthogonal.
+- Keep the addition to one routing branch — no concern enumeration in the skill body.
+
+**Done when:** the three T3 greps pass and the dead lens copy is now reachable from the procedure.
+
+### T4: Bidirectional coverage parity with the `llm-agent` control module
+
+**Depends on:** T1
+
+**Tests:**
+- The **bidirectional** parity mapping (cross-cutting check) holds: (a) every `llm-agent` control item (LLM01/02/03/05/06/10 + spec-stage proactive control) maps to an overlay concern, **and** (b) every overlay security-boundary concern resolves to a named `llm-agent` check **or** an explicit design-altitude-only status (AC: bidirectional coverage parity).
+- The three net-new agentic boundaries (execution isolation, inter-agent identity/privilege propagation, memory poisoning) are each named at design altitude **and** carry the deferred backlog pointer `llm-agent-module-agentic-boundary-extension` (AC: net-new boundaries reconciled).
+
+**Approach:**
+- Build the concern↔module mapping both ways; for each overlay security concern with no `llm-agent` check, mark it design-altitude-only and confirm the deferred backlog entry covers the module extension.
+- Confirm the lens routes control-level verification out (names the boundary only), not control prescriptions.
+
+**Done when:** the bidirectional mapping is complete — no `llm-agent` control unmapped, and every overlay security concern resolves to a check or a recorded design-altitude-only status with a backlog pointer.
+
+### T5: Confirm `architect-review` WA-mode routing is unregressed
+
+**Depends on:** T2
+
+**Tests:**
+- `grep` confirms `rubric-well-architected.md` still selects `lens-genai-agentic.md` for the GenAI/agentic workload class, with its concern-lens × workload-class axes intact (AC: review-side route preserved).
+- `grep` confirms the rubric's ML / SaaS / serverless workload-class entries are **unchanged** — still named, still unbacked (AC: ML/SaaS/serverless remain named-but-unbacked, the status-quo half).
+
+**Approach:**
+- Read `rubric-well-architected.md`'s lens-selection section; verify the GenAI/agentic route is unchanged and now resolves to the expanded shared file, and that ML/SaaS/serverless are still named without backing files.
+
+**Done when:** the rubric routes to the expanded lens with no edit required (or a one-line pointer fix if the route drifted), and ML/SaaS/serverless are confirmed unchanged.
+
+### T6: Bump the `architect` pack version and refresh projection
+
+**Depends on:** T1-T5
+
+**Tests:**
+- `grep`/build confirms `pack.toml` `[pack].version` and `plugin.json` are bumped in lockstep and the projection (`.claude/skills/architect-*`, marketplace aggregation) is regenerated and drift-clean (AC: version bump).
+
+**Approach:**
+- Bump `packs/architect/pack.toml` and the pack's `plugin.json`; run the pack build/projection; confirm the build-check drift gate is clean.
+- Add the `[Unreleased] → Added` changelog entry (AC: changelog).
+
+**Done when:** the version is bumped in both files, projection is drift-clean, and the changelog carries the entry.
+
+### T7: Dogfood the overlay end-to-end
+
+**Depends on:** T3, T6
+
+**Tests:**
+- Manual QA: run `architect-design` on an agentic concept (tool-using) — record that the workload-class branch fires, the lens loads, and the applicable tier(s) gate as intended.
+- Manual QA: run `architect-design` on a plain-RAG concept — record that only Tier A applies (the branch does not drag in Tier B/C).
+
+**Approach:**
+- Exercise the built skill the way a user would; capture the observed behaviour (what loaded, what tiers applied) in the PR description.
+
+**Done when:** both runs are recorded and show the routing fires for the agentic concept and stays Tier A for the RAG concept.
+
+## Rollout
+
+Pure skill-prose / reference-content change. **Delivery:** ships with the next `architect` pack release (version bumped in T6); reversible by reverting the routing branch and lens edits. No infrastructure, no external-system integration, no deployment sequencing. **Irreversible:** none. Adopters pick up the expanded overlay on pack upgrade.
+
+## Risks
+
+- **Coverage parity drifts as OWASP moves.** The overlay and the `llm-agent` module can diverge over time. Mitigation: the parity criterion is an AC and a reviewer-checked mapping; the route-out boundary means the module stays the control source of truth.
+- **Routing over-fires**, tagging every LLM feature "agentic." Mitigation: the trigger is the system *acting*; Tier A is the explicit non-acting baseline, so over-firing costs at most Tier A. Exercised in the T7 RAG dogfood.
+- **Altitude creep** — the expanded security-boundary content slides into control-level prescriptions. Mitigation: the security-reviewer pass and the Always-do/Never-do boundaries; the lens names boundaries and routes controls out.
+- **The two copies drift** during authoring. Mitigation: the both-copies-identical cross-cutting check; a possible follow-up governance lint (noted in ADR-0032, not required here).
+
+## Changelog
+
+- 2026-06-23: initial plan (governance PR — ADR-0032 + this spec/plan). Implementation deferred to a separate PR.

--- a/docs/specs/agentic-well-architected-overlay/spec.md
+++ b/docs/specs/agentic-well-architected-overlay/spec.md
@@ -1,0 +1,80 @@
+# Spec: agentic-well-architected-overlay
+
+- **Status:** Draft <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** ADR-0032, RFC-0042 (D1–D5 + open-question defaults OQ1/OQ2); RFC-0029 (the `security-checklists` `llm-agent` module the security-boundary concerns route to — the coverage-parity target); the Shipped/frozen `well-architected-cloud` spec (the review-time-only scoping this widens and the five-concern lens this expands)
+- **Contract:** none <!-- pure-markdown skill content; no API/event/RPC surface -->
+- **Shape:** n/a — skill prose + reference-content authoring across two `architect` skills; no application LLD
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+A solution architect using the `architect` pack designs an agentic system — one that uses tools, takes autonomous action, or runs an agent loop — and gets the GenAI/agentic well-architected overlay **applied by construction at design time**, not only if a reviewer later runs well-architected (WA) mode. The overlay reflects current practice for systems that *act*: alongside the shipped prompt-injection / tool-authz / data-egress / evals / cost concerns, it makes human oversight, bounded autonomy with intent verification, and auditable action trails first-class. It is **progressive** — a plain RAG/chat design applies only the baseline tier; a multi-agent system with outbound spend authority applies all three — so an adopter is never made to recite concerns that don't bite for their system. Design time and review time consume **one shared lens file**, so the two never diverge, and the overlay keeps the pack's altitude: name the boundary and the question it forces, name no frameworks, route control-level verification to `security-reviewer` / `security-checklists`.
+
+## Boundaries
+
+The three-tier guard that keeps an implementing agent inside the lines.
+*Always do* applies without asking; *Ask first* requires human sign-off
+before proceeding; *Never do* is a hard rule, even under time pressure.
+
+### Always do
+
+- Keep the overlay **prose at design altitude** — name the concern and the question it forces; route control-level verification to `security-reviewer` / `security-checklists` (`llm-agent` module).
+- Expand **both** copies of `lens-genai-agentic.md` (`architect-design` and `architect-review`) identically, each keeping its one-line duplication note (the pack's per-skill duplication is the principle, not a bug).
+- Keep the per-tier gating a **filter, not a worklist** — preserve the shipped lens's "apply the concerns that bite for THIS system" instruction.
+- Bump the `architect` pack version (`pack.toml` + `plugin.json`) and refresh its projection, since this changes a user-facing capability.
+
+### Ask first
+
+- Any change to `architect-review`'s WA-mode rubric (`rubric-well-architected.md`) beyond keeping its GenAI/agentic route pointed at the shared lens — the review side's lens-selection model is already shipped and out of scope to redesign.
+- Backing any of ML / SaaS / serverless (they are explicitly deferred — see AC and the backlog register).
+
+### Never do
+
+- Ship a new reviewer agent, a new skill, or any executable tooling / evals for the overlay (Principle 3; ADR-0023 ceiling; ADR-0032).
+- Inline the Tier A/B/C concern list into `architect-design/SKILL.md` — the routing branch loads the reference; the taxonomy lives in the reference (progressive disclosure).
+- Edit the frozen `well-architected-cloud` spec body or the frozen RFC-0042 body.
+- Assert that any standard prescribes threshold-gated checkpoint removal — graduated autonomy is engineering judgment, not a standards mandate.
+
+## Testing Strategy
+
+This is a skill-prose / reference-content change; verification is **goal-based** and **manual QA**, with no TDD-mode logic:
+
+- **Routing branch wiring, lens structure, both-copies-identical, coverage parity, pack-version bump, rubric-route-preserved** — *goal-based*: a `grep` / `diff` / build one-liner verifies each outcome. (Several are cross-cutting checks that span the touched files — see `plan.md` Construction tests.)
+- **The overlay fires and gates as intended on a real agentic concept** — *manual QA, exercised end-to-end*: run `architect-design` on an agentic concept and on a plain-RAG concept and record what the skill actually loads and produces (the workload-class branch fires for the agentic one and loads the tier(s) that apply; the RAG one stays Tier A). A passing grep alone does not satisfy this — the built artifact (the skill, run as a user would) must produce the right behaviour.
+
+## Acceptance Criteria
+
+- [ ] **Workload-class routing axis exists.** `architect-design`'s Stage 0 (the "well-architected by construction" step, `SKILL.md:45-60`) gains a **workload-class** axis alongside its existing **provider** axis. When the concept's workload is agentic — the design names tool-use, autonomous action, or an agent loop — the step loads `references/lens-genai-agentic.md` and shapes the concept against the tier(s) that apply.
+- [ ] **The two axes are orthogonal.** An agentic system on a named cloud loads **both** the cloud pillars (`well-architected-pillars.md`) and the agentic overlay; routing is additive, not either/or. A non-acting generative design (plain RAG/chat) loads only Tier A.
+- [ ] **The routing branch is the only `SKILL.md` addition.** The Tier A/B/C concern list is **not** inlined into `architect-design/SKILL.md`; the branch loads the reference file (progressive disclosure).
+- [ ] **The shared lens is reorganised into a progressive, capability-tiered taxonomy** — Tier A *the LLM is on the path* → Tier B *the system acts* → Tier C *the agent persists or collaborates* — with explicit per-tier gating instructions (apply Tier A always; Tier B once the system can act; Tier C once it persists state or runs multiple agents).
+- [ ] **Tier A** carries: prompt injection / instruction-vs-data trust boundary; data egress & disclosure boundary (bidirectional — what crosses *to* the model and what can be extracted *from* the system); evaluation (eval set, LLM-as-judge + deterministic, corroborate); token cost (p50/p99, multi-turn-history term — the **LLM10** Unbounded-Consumption / denial-of-wallet anchor, paired with the Tier-B loop-cap concern); observability (prompts/tool-calls/responses traceable, content off by default).
+- [ ] **Tier B** carries: tool-use authorization & bounded autonomy — least privilege, gated destructive/spending tools, **intent verification** (surface the planned action chain before irreversible/outbound actions, prefer reversible actions, confused-deputy framing); the bullet **forces the explicit design-time question** *what is the tool allowlist, and which actions require confirmation?* (an "the agent can take actions" design with no allowlist or confirmation criteria is the named design-time miss). Also: **tool / MCP source provenance** (where do the tools and MCP servers this agent loads come from, and is the source trusted? — the LLM03 supply-chain trust question, firing for any externally-sourced tool/MCP load, single-agent included); **output handling** (model output is untrusted input to the next sink — validated before it drives a tool/shell/query/follow-on action); **execution isolation & blast radius** (sandbox posture for code-running/untrusted-content tools, distinct from authorization); **human oversight & graduated autonomy**; **auditability & attributable action trails**; reliability under non-determinism (max-iteration/loop caps enforced outside the model, idempotent calls, graceful degradation — the runaway-loop half of the **LLM10** Unbounded-Consumption anchor).
+- [ ] **Tier C** carries: memory & context integrity; **sub-agent** provenance (a design-time trust question for delegated agents — it shares the **LLM03** supply-chain route with Tier-B tool/MCP provenance, as the multi-agent-gated facet of the same control, not a distinct module check); multi-agent coordination, inter-agent trust & **identity/privilege propagation across a delegation chain**.
+- [ ] **The trust triad is first-class in Tier B** — human oversight & HITL, intent verification, and auditable/attributable action trails each appear as a named concern with the question it forces, not folded into the existing tool-authz or observability bullets.
+- [ ] **Graduated autonomy is framed as engineering judgment, not a standards mandate.** The lens names the *question* (what is the oversight posture, and what evidence would justify widening it?) and carries the explicit cap that **irreversibility and blast radius bound how far autonomy widens regardless of track record**. It does not assert that any standard prescribes threshold-gated checkpoint removal.
+- [ ] **Tier C's gate is split** — memory & context integrity fires on *stateful*; **sub-agent** provenance + multi-agent coordination/identity-propagation fire on *multi-agent*; **tool/MCP source provenance fires on Tier B** (any system that loads external tools, single-agent included — aligning the design-time gate with the `llm-agent` LLM03 trigger) — so a single stateful agent picks up only the memory concern (RFC-0042 OQ2 default, refined so single-agent tool-supply-chain trust isn't gated out).
+- [ ] **Observability names OTel GenAI semantic conventions as the converging instrumentation standard with an explicit maturity caveat** (they are "Development" status) — the RFC-0041 honest-caveat pattern (RFC-0042 OQ1 default).
+- [ ] **Coverage parity with the `llm-agent` control module is bidirectional.** Every Tier A/B/C **security-boundary** concern (prompt injection, data egress/disclosure, tool-use authz, output handling, execution isolation, inter-agent comms, identity/privilege propagation, tool/MCP + sub-agent provenance, memory poisoning) names the boundary at design altitude and routes control-level verification to `security-reviewer` / `security-checklists` (`llm-agent`). The mapping is checked **both ways**: (a) every `llm-agent` control item (LLM01/02/03/05/06/10 + the spec-stage proactive control) is covered by an overlay concern, **and** (b) every overlay security-boundary concern resolves to a named `llm-agent` check **or** to an explicit *design-altitude-only* status — so the route-out never silently points at a missing control.
+- [ ] **The overlay's net-new agentic boundaries are reconciled with the module.** Execution isolation & blast radius, inter-agent identity/privilege propagation, and memory poisoning exceed the current `llm-agent` module's surface (it stops at LLM01/02/03/05/06/10, with no Agentic-Top-10 content). Each is named at design altitude in the overlay; the corresponding `llm-agent` module extension (Agentic Top 10: tool misuse, identity/privilege abuse, memory poisoning) is recorded as a deferred backlog entry, so the route-out has a tracked destination rather than landing on a missing control. (deferred: llm-agent-module-agentic-boundary-extension)
+- [ ] **OWASP anchors cover the poisoning & retrieval surface.** The overlay's memory & context integrity / poisoning concern (Tier C) carries the **LLM04** (Data & Model Poisoning) anchor, and its retrieved-content / embedding surface (Tier A injection + egress) carries the **LLM08** (Vector & Embedding Weaknesses) anchor — both omitted from RFC-0042's OWASP mapping (the frozen RFC can't be edited; this spec is the corrected record).
+- [ ] **Both lens copies are identical** (modulo the per-skill duplication note): `architect-design/references/lens-genai-agentic.md` and `architect-review/references/lens-genai-agentic.md` carry the same expanded taxonomy, each retaining its duplication note.
+- [ ] **`architect-review` WA mode still routes GenAI/agentic to the shared lens** — `rubric-well-architected.md`'s workload-class lens selection continues to load `lens-genai-agentic.md` with no regression to its concern-lens × workload-class axes.
+- [ ] **The overlay keeps the pack's altitude** — names the concern + the question it forces, names no frameworks, and preserves the apply-what-bites instruction; the tiers filter, they do not become a recite-the-whole-list checklist.
+- [ ] **The `architect` pack version is bumped** (`pack.toml` `[pack].version` + `plugin.json`) and its projection refreshed, per the user-facing-capability-change rule.
+- [ ] **A `[Unreleased] → Added` changelog entry** is added in the implementing PR (`docs/product/changelog.md`).
+- [ ] **The overlay is dogfooded end-to-end** — `architect-design` run on a real agentic concept loads the workload-class branch and gates the tiers as intended, and on a plain-RAG concept loads only Tier A; the observed behaviour is recorded (manual QA).
+- [ ] **ML / SaaS / serverless remain named-but-unbacked** in `rubric-well-architected.md`; the deferral is recorded in the backlog register, not RFC-only prose. (deferred: ml-saas-serverless-workload-class-lenses)
+
+## Assumptions
+
+- Technical: `architect-design` Stage 0 routes on provider/provider-class today with no workload-class axis, and the duplicated `lens-genai-agentic.md` is a dead copy in that skill (no procedure step references it) (source: `packs/architect/.apm/skills/architect-design/SKILL.md:45-60`, probe 2026-06-23).
+- Technical: `architect-review`'s WA mode already models the orthogonal concern-lens × workload-class axes and loads `lens-genai-agentic.md` for the GenAI/agentic class (source: `rubric-well-architected.md:11-19`, probe 2026-06-23).
+- Technical: the shared lens ships at five concerns and routes its security-boundary concerns to `security-checklists` `llm-agent` today (source: `lens-genai-agentic.md`, probe 2026-06-23).
+- Process: the implementation of the skill edits lands in a **separate** PR; this spec + ADR-0032 + the plan are the governance deliverable, and the spec stays `Draft` until that implementing PR flips it (source: RFC-0042 § Follow-on artifacts; repo pattern, RFC-0041 follow-on #363).
+- Process: a frozen spec cannot be amended, so the review-time-only scoping is widened by ADR-0032 + this new spec rather than by editing `well-architected-cloud` (source: `CONVENTIONS.md` § Document lifecycle, Frozen row; RFC-0042 D1).
+- Product: the two RFC open questions are settled to their RFC-recommended defaults — OTel named with a maturity caveat (OQ1), Tier C's gate split into stateful-vs-multi-agent (OQ2) (source: RFC-0042 § Open questions, decide-by "implementing-spec authoring").


### PR DESCRIPTION
## What & why

Authors the follow-on governance artifacts for the accepted **RFC-0042** (agentic well-architected overlay as a first-class workload-class lens). Implementation of the `architect` skill edits is a **separate PR** — this is the governance deliverable (ADR + spec/plan), per the RFC's follow-on split and the RFC-0041 follow-on pattern (#363).

- **ADR-0032** records the load-bearing, expensive-to-reverse calls: the overlay is consumed by construction at design time *and* at review time from one *logical* lens (physically duplicated per the pack's per-skill shape, kept byte-identical); workload-class becomes an orthogonal routing axis in `architect-design` Stage 0; the taxonomy is progressive and capability-tiered (A→B→C); graduated autonomy is engineering judgment, not a standards mandate; no new primitive (ADR-0023's three-reviewer ceiling cited, not engaged). It names — and widens — the frozen `well-architected-cloud` spec's review-time-only scoping.
- **`docs/specs/agentic-well-architected-overlay/`** carries the implementing contract: the routing branch, the expanded progressive lens in both skill copies, **bidirectional** coverage parity with the `security-checklists` `llm-agent` module, the dogfood run, and the `architect` pack bump. The changelog entry and final spec status are deferred to the implementing PR (spec ships `Draft`).
- **`docs/backlog.md`** records two deferrals, each anchored to a deferred AC: ML/SaaS/serverless staying named-but-unbacked, and extending the `llm-agent` module for the overlay's three net-new agentic boundaries (execution isolation, identity/privilege propagation, memory poisoning).

## How verified

- `lint-spec-status.py` clean; `loop-cohort approve-plan`; `make build-check` green (incl. Bandit / pip-audit / Semgrep).
- Spec-stage review iterated to clean across three lenses: **adversarial-reviewer** (`Clean`), **design-reviewer** (`SHIP IT`), **security-reviewer** (`Clean`). Findings applied: bidirectional parity + the net-new-boundary reconciliation, tool/MCP-vs-sub-agent provenance gate split (aligns with LLM03's single-agent trigger), the "one logical lens" honesty fix, the graduated-autonomy partially-reversible default, and LLM04/LLM08/LLM10 OWASP anchors the frozen RFC omitted.

## Review questions (four-question template)

1. **What's the change?** Governance authoring for RFC-0042 — ADR-0032 + the implementing spec/plan + backlog deferrals. No skill code changes.
2. **Why this approach?** Mirrors the repo's governance-PR-then-implementation-PR split (RFC-0036, RFC-0041 #363); the ADR records expensive-to-reverse calls, the spec carries the mechanical contract.
3. **What's the risk?** Low — additive governance docs; the frozen RFC-0042 and `well-architected-cloud` spec bodies are untouched. The decision reverses a frozen-spec scoping, recorded explicitly.
4. **What did you not do?** The skill edits (routing branch + expanded lens) and the changelog entry — they belong to the separate implementing PR; ML/SaaS/serverless stay deferred.