### PR TITLE
feat(pack-research-evals): activation + LLM-judge eval coverage for the research pack (pack-eval-coverage-rollout)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -204,7 +204,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "research",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.5.0"
+      "version": "0.5.1"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -769,20 +769,31 @@ activation), **`atlassian`** (8 skills, Tier-A activation), **`design-craft`**
 (4 skills, Tier-A activation **+** Tier-4 LLM-judge — both layers, no B-lite since the
 four skills are judgment/authoring), **`governance-extras`** (3 skills,
 Tier-A activation **+** Tier-4 LLM-judge — both layers, no B-lite; the three
-skills are governance authoring/judgment), and **`user-guide-diataxis`**
+skills are governance authoring/judgment), **`user-guide-diataxis`**
 (1 skill — `new-guide` — Tier-A activation **+** Tier-4 LLM-judge — both
-layers, no B-lite; `new-guide` is judgment/authoring) — `expected_output` +
+layers, no B-lite; `new-guide` is judgment/authoring), and **`research`**
+(11 skills — 8 Tier-A activation: the 7 scoping / source-curation / synthesis /
+decision-support / archaeology skills **+** `research-project-start` as the
+lifecycle entry point; **+** 8 Tier-4 LLM-judge rubrics: the 7 judgment skills
+that emit an artifact **+** `research-project-synthesize`'s governance brief;
+no B-lite — every research skill is judgment/authoring; the 3 project-mode
+*interior* steps — `research-project-check` / `-digest` / `-synthesize` — are
+excluded from Tier-A as reached within an active project, not by a cold prompt
+surface, per the `[pack.evals]` coverage note) — `expected_output` +
 `assertions` per skill, gradable via `--mode judge`. The judge rubrics for
 `architect` / `product-engineering` predate the activation layer; the
-`contracts` / `figma` / `atlassian` activation evals are this rollout
-(`pack-eval-coverage-rollout`). Remaining work, tiered by what it needs:
+`contracts` / `figma` / `atlassian` activation evals are an earlier rollout
+increment, and `research` is this one (all `pack-eval-coverage-rollout`).
+Remaining work, tiered by what it needs:
 
 - **Tier 1 — activation (Tier-A) for the rest of the catalogue (tractable now,
-  no deps/execution).** Remaining: `monorepo-extras` (1) and `research` (~11)
-  need `evals/eval_queries.json` + a `[pack.evals]`
+  no deps/execution).** Remaining: `monorepo-extras` (1)
+  needs `evals/eval_queries.json` + a `[pack.evals]`
   block (the same ~8–10-each-way near-miss pattern as `core`). `architect` (3),
   `product-engineering` (5), `contracts` (2), `design-craft`
-  (4), `governance-extras` (3), and `user-guide-diataxis` (1, `new-guide`) are
+  (4), `governance-extras` (3), `user-guide-diataxis` (1, `new-guide`), and
+  `research` (8 — 7 scoping/synthesis/decision skills + `research-project-start`;
+  the 3 project-interior steps excluded per its `[pack.evals]` coverage note) are
   **done**; the credentialed/backend `figma` (1) and `atlassian` (8) Tier-A
   activation is **done** too (see Tier 3). Exclude
   reviewer-internal / non-prompt skills (`security-checklists`, `work-loop`,
@@ -806,9 +817,11 @@ layers, no B-lite; `new-guide` is judgment/authoring) — `expected_output` +
   the right rubric / reviewer lens — e.g. `architect-review` for `architect-design`),
   authoring the `expected_output`/`assertions` rubrics — **done for all of
   `architect` (3), `product-engineering` (5), `design-craft` (4),
-  `governance-extras` (3), and `user-guide-diataxis` (`new-guide`)**;
-  remaining for `research`,
-  `new-package`, and `core`'s judgment skills — and **(b)** the **full
+  `governance-extras` (3), `user-guide-diataxis` (`new-guide`), and `research`
+  (8 — the 7 artifact-emitting judgment skills + `research-project-synthesize`'s
+  governance brief)**;
+  remaining for
+  `new-package` and `core`'s judgment skills — and **(b)** the **full
   Tier-B** pieces still deferred: `benchmark.json` **deltas**, the
   **with/without-skill** comparison, the **train/validation split**, and the
   formal **human-calibration** (`feedback.json`) loop. *(Note: `contracts` and

--- a/docs/specs/pack-activation-evals/notes/manual-qa.md
+++ b/docs/specs/pack-activation-evals/notes/manual-qa.md
@@ -401,3 +401,99 @@ Confluence" → `confluence-publisher`, "how should we architect…" →
 issue CRUD, rather than metrics strings that collide with `flow-metrics`. The
 broader `jira`-vs-metrics over-trigger is a known calibration item for the
 scheduled `pack-evals.yml` sweep, not a per-PR gate. `make build-check` is green.
+## 12. `research` — both layers across the largest pack (Tier-A activation + Tier-4 judge), 2026-06-23
+
+`research` is the catalogue's largest, most heterogeneous pack (11 skills): a
+set of one-shot scoping / source-curation / synthesis / decision-support /
+rationale-reconstruction skills, plus a four-skill project-mode lifecycle for
+sustained investigations. Every skill is judgment/authoring (a survey, an
+outline, a source map, a perspectives map, a hypotheses matrix, a counterpoints
+review, a decision archaeology, a governance brief — no deterministic artifact a
+script re-derives), so **both** judgment-skill layers were added and **no B-lite**
+layer (nothing deterministic to check):
+
+**Tier-A activation (8 skills).** `evals/eval_queries.json` + a `[pack.evals]`
+block, 9 should-trigger + 9 near-miss each. The near-misses are mostly
+**intra-pack sibling cross-routing** — the pack's own routing risk is skill ↔
+skill, not skill ↔ silence — so each negative set walks the sibling pipeline
+(`build-outline` ↔ `source-map` ↔ `research`; `identify-perspectives` ↔
+`compare-hypotheses`; backward-looking `decision-archaeology` ↔ forward-looking
+`compare-hypotheses`; `devils-advocate` ↔ `identify-perspectives`; episodic
+`research` ↔ lifecycle `research-project-start`) plus a few out-of-pack exits
+(`new-spec`, `bug-fix`, `new-adr`). `research-project-start`'s near-miss set
+includes "digest the sources I've already gathered" — a prompt that must route to
+the (excluded) `research-project-digest`, not to `-start`.
+
+| skill | Tier-A | rubric grades |
+| --- | :---: | --- |
+| research | ✓ | GRADE confidence per finding, citation-or-[synthesis]/[inference] on every claim, ≥3-source triangulation for material claims, named downgrade factors, Known-unknowns vs unknowables split |
+| source-map | ✓ | primacy grouping (primary/secondary/tertiary), per-entry citation, authority-type + recency tags, primacy-as-load-bearing for triangulation, [synthesis]/[inference] on bias notes |
+| build-outline | ✓ | sub-questions each with a *load-bearing argument* rationale, decomposition grounded in the question (not a fixed pillar template), open/second-order questions separated, [synthesis]/[inference] marks |
+| identify-perspectives | ✓ | named camps (claim + cited voices), missing-camps section, tension map of *irreducible* disagreements only (holds-when + forced-resolution-destroys), irreducible-vs-thin-evidence distinction |
+| compare-hypotheses | ✓ | per-hypothesis claim+confidence+strongest-for/against (cited), ACH directional matrix (++/+/0/-/--), most-supported ranking citing the matrix, thin-evidence flagged not overstated |
+| devils-advocate | ✓ | strongest non-strawman counter-position per finding, cited counter-evidence, exactly-one-verdict (downgrade OR do-not-resolve), do-not-resolve reserved for substantive-both-sides tensions |
+| decision-archaeology | ✓ | dated cited chronology, rationale chain back to a first cause, alternatives-considered, revival check (only rejection-rationales overtaken by changed constraints), [inference]/[synthesis] marks |
+| research-project-start | ✓ | *(Tier-A only — scaffolds a project folder, no judgment artifact to rubric)* |
+| research-project-synthesize | — | answer-first (BLUF) self-contained brief (no project-file cross-links, RFC-liftable), per-finding GRADE confidence + citations, ≥3-source triangulation, Known-unknowns vs unknowables split |
+| research-project-digest | — | *(excluded — project-interior step; no Tier-A, no rubric)* |
+| research-project-check | — | *(excluded — project-interior step; no Tier-A, no rubric)* |
+
+**Coverage judgment (the heterogeneity call).** The three project-mode *interior*
+steps — `research-project-check` / `-digest` / `-synthesize` — are excluded from
+Tier-A activation. They operate on state that only exists once
+`research-project-start` has scaffolded a project (a `sources/` corpus, a
+synthesis matrix) and are reached by the human walking the
+capture → digest → synthesize lifecycle inside an active project folder, not by a
+distinct cold user-prompt surface; the headless detector projects the pack into an
+empty dir with no project folder, so measuring them cold would conflate "no
+project exists" with "skill mis-routed". This mirrors how `core` excludes
+`work-loop` (discipline-loaded, not prompt-surfaced) rather than
+`security-checklists`' reviewer-internal exclusion. `research-project-start`
+carries Tier-A for the project-mode surface.
+
+Tier-4 is independent of Tier-A (the judge reads `evals/evals.json` directly via
+`--artifacts`, so a skill can have a rubric without an activation allowlist
+entry) — so the Tier-4 split is decided on its own terms, not inherited from the
+Tier-A exclusion. Within project mode the rubric attaches to
+`research-project-synthesize`'s **governance brief** — the terminal verdict, where
+the gradeable verdict disciplines (GRADE confidence, ≥3-source triangulation) are
+applied per the skill body — and **not** to `research-project-digest`'s synthesis
+matrix + memos, which are the *intermediate* structuring artifact `-digest` emits
+for `-check` and `-synthesize` to consume; the pack applies the
+confidence/triangulation rail downstream at synthesis, not at digest time. (So
+the `-digest` Tier-4 omission rests on this artifact-stage reason, not on the
+Tier-A project-interior one.)
+
+A note on the Tier-A set for `research` itself: its should-trigger queries
+deliberately span all four modes (casual "Look up…" / "Quick check:…" → `quick`,
+which is inline with *no* artifact, alongside "Research with citations…" /
+"Go deep…" → standard/deep). Tier-A measures *activation* (does `/research` fire),
+which is mode-independent; the Tier-4 rubric grades the *standard/applied survey*
+artifact. The two files are not in tension — they test different things.
+
+**Smoke-check (the standing `AGENTS.local.md` eval-coverage policy).** Ran the
+`research` rubric live in Tier-B light mode (`--mode judge --judge-adapter
+claude-code`) against a good-vs-weak artifact to confirm it loads and
+discriminates:
+
+| artifact | verdict |
+| --- | --- |
+| a GRADE-tagged, triangulated, citation-bearing survey with a Known-unknowns split | **PASS** ("satisfies every rubric criterion") |
+| a short unsupported opinion paragraph (no tags, no citations, no Known unknowns) | **FAIL** ("a short, unsupported opinion paragraph with no confidence tags") |
+
+The spot-check first caught a real defect in the draft good artifact — a finding
+tagged `[moderate]` (material) but resting on a single source — which the judge
+failed on the ≥3-source-triangulation assertion (5/6 assertions True); downgrading
+that single-org finding to `[low]` (non-material, so the triangulation rule does
+not bind) made it pass. Evidence the rubric discriminates on the substance, not
+the shape. Report-only, confirming the rubric works — not a calibration gate.
+
+All 8 rubrics + 8 eval-query sets lint clean (`tools/lint-skill-spec.py`, incl.
+the `[pack.evals]` coverage check); `agentbundle validate packs/research` passes.
+`research` bumped 0.5.0 → 0.5.1. **Note:** `research` is `default-scope = "user"`,
+so it is **not** self-host-projected to this repo's working tree — `make
+build-self` moved **only** `.claude-plugin/marketplace.json` (the all-packs
+aggregation, research entry 0.5.0 → 0.5.1) and **nothing** under `.claude/` or
+`.agents/` (confirmed via `git status`). The version-bump-drifts-marketplace gate
+is `lint-packs` + `validate` + `build` + the marketplace aggregation, all green in
+`make build-check`.

--- a/packs/research/.apm/skills/build-outline/evals/eval_queries.json
+++ b/packs/research/.apm/skills/build-outline/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "Decompose 'should we migrate to Kubernetes' into the sub-questions a thorough answer must address", "should_trigger": true},
+  {"query": "Break this broad research question into its component sub-questions first", "should_trigger": true},
+  {"query": "What are all the sub-questions I'd need to answer to evaluate event-driven architecture?", "should_trigger": true},
+  {"query": "Build an outline of the sub-questions for a survey of LLM evaluation methods", "should_trigger": true},
+  {"query": "Before I research, decompose the topic of database sharding into its must-answer questions", "should_trigger": true},
+  {"query": "Lay out the question structure for a comprehensive review of zero-trust networking", "should_trigger": true},
+  {"query": "Map the sub-questions a complete answer to 'is GraphQL worth it' would have to cover", "should_trigger": true},
+  {"query": "Give me the PICO-style decomposition of this systematic-review question", "should_trigger": true},
+  {"query": "Outline the second-order sub-questions that 'how do we cut cloud cost' raises", "should_trigger": true},
+
+  {"query": "Curate the authoritative sources on Kubernetes migration", "should_trigger": false},
+  {"query": "Look up the default pod scheduling algorithm in Kubernetes", "should_trigger": false},
+  {"query": "What are the named camps in the Kubernetes-vs-serverless debate?", "should_trigger": false},
+  {"query": "Compare the hypotheses for our recurring pod-eviction storms", "should_trigger": false},
+  {"query": "Why did we adopt Kubernetes in the first place?", "should_trigger": false},
+  {"query": "Argue against migrating to Kubernetes", "should_trigger": false},
+  {"query": "Start a multi-week research project on our platform strategy", "should_trigger": false},
+  {"query": "Write a spec for the Kubernetes migration", "should_trigger": false},
+  {"query": "Research with citations whether Kubernetes actually reduces ops toil", "should_trigger": false}
+]

--- a/packs/research/.apm/skills/build-outline/evals/evals.json
+++ b/packs/research/.apm/skills/build-outline/evals/evals.json
@@ -1,0 +1,17 @@
+{
+  "skill_name": "build-outline",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Decompose the research question the user gave into the sub-questions a thorough answer must address, and produce the outline.",
+      "expected_output": "An outline listing each sub-question with a one-sentence rationale that argues why the sub-question is load-bearing to the main question rather than restating it. The decomposition is grounded in the question's actual components (a PICO / multi-perspective breakdown), not a generic fixed-pillar template imposed before reading. Open and second-order sub-questions a thorough answer raises but does not itself resolve are surfaced in their own section, separate from the must-answer set. Cross-source integration is marked [synthesis] and deduction from precedent [inference], with a citation where a sub-question rests on a specific source.",
+      "assertions": [
+        "Lists discrete sub-questions, each with its own rationale",
+        "Each rationale argues why the sub-question is load-bearing to the main question, not a restatement of it",
+        "The decomposition is grounded in the question's actual components, not a fixed/generic pillar template imposed before reading",
+        "Surfaces open / second-order sub-questions in a section separate from the must-answer set",
+        "Marks cross-source integration [synthesis] / deduction [inference], and cites where a sub-question rests on a specific source"
+      ]
+    }
+  ]
+}

--- a/packs/research/.apm/skills/compare-hypotheses/evals/eval_queries.json
+++ b/packs/research/.apm/skills/compare-hypotheses/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "Compare the competing hypotheses for why our checkout conversion dropped, with an evidence matrix", "should_trigger": true},
+  {"query": "We have three theories for the latency spike — weigh them against the evidence and rank them", "should_trigger": true},
+  {"query": "Which hypothesis best explains the memory leak: build me an ACH-style evidence-for/against table", "should_trigger": true},
+  {"query": "Adjudicate between 'cache misses' and 'GC pauses' as the cause, ranked by the evidence", "should_trigger": true},
+  {"query": "Set up a hypotheses matrix for which vendor will best meet our SLA", "should_trigger": true},
+  {"query": "Compare the candidate explanations for the revenue dip and tell me the most-supported one", "should_trigger": true},
+  {"query": "Evaluate the competing hypotheses on what's causing the flaky tests, with evidence on both sides", "should_trigger": true},
+  {"query": "Rank the hypotheses for our churn increase against their supporting and contradicting evidence", "should_trigger": true},
+  {"query": "Build the evidence matrix comparing four database choices for this decision", "should_trigger": true},
+
+  {"query": "What are the named camps in the SQL-vs-NoSQL debate?", "should_trigger": false},
+  {"query": "Look up the typical causes of checkout conversion drops", "should_trigger": false},
+  {"query": "Curate the authoritative sources on conversion-rate optimization", "should_trigger": false},
+  {"query": "Decompose 'why did conversion drop' into the sub-questions to investigate", "should_trigger": false},
+  {"query": "Why did we choose our current checkout vendor originally?", "should_trigger": false},
+  {"query": "Argue against the hypothesis that GC pauses cause the latency", "should_trigger": false},
+  {"query": "Start a research project on our conversion funnel", "should_trigger": false},
+  {"query": "Fix the bug causing duplicate checkout charges", "should_trigger": false},
+  {"query": "Research with citations whether single-page checkouts convert better", "should_trigger": false}
+]

--- a/packs/research/.apm/skills/compare-hypotheses/evals/evals.json
+++ b/packs/research/.apm/skills/compare-hypotheses/evals/evals.json
@@ -1,0 +1,17 @@
+{
+  "skill_name": "compare-hypotheses",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Compare the competing hypotheses on the decision-shaped question the user gave, and produce the hypotheses analysis.",
+      "expected_output": "A hypotheses analysis with a per-hypothesis section (a one-sentence claim, a confidence tag, and its strongest supporting and strongest contradicting evidence — both cited), plus an ACH-style evidence matrix (hypotheses x evidence) whose cells use directional weights (++ strongly supports, + weakly supports, 0 neutral, - weakly contradicts, -- strongly contradicts), and a ranking led by the most-supported hypothesis whose rationale cites the matrix. Every cell traces to cited evidence; thin or single-sourced positions are flagged via the confidence rating rather than overstated.",
+      "assertions": [
+        "Enumerates each hypothesis with a one-sentence claim and a confidence tag",
+        "Gives each hypothesis its strongest supporting AND strongest contradicting evidence, both cited",
+        "Includes an ACH-style evidence matrix (hypotheses x evidence) with directional cells (++ / + / 0 / - / --)",
+        "Ranks the hypotheses with the most-supported first, and the ranking rationale cites the matrix",
+        "Flags thin or single-sourced evidence via a confidence rating rather than overstating it"
+      ]
+    }
+  ]
+}

--- a/packs/research/.apm/skills/decision-archaeology/evals/eval_queries.json
+++ b/packs/research/.apm/skills/decision-archaeology/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "Why did we choose Kafka over RabbitMQ two years ago? Reconstruct the rationale", "should_trigger": true},
+  {"query": "Walk the commits and PRs to figure out why we adopted this caching strategy", "should_trigger": true},
+  {"query": "Reconstruct the decision history behind our current auth architecture", "should_trigger": true},
+  {"query": "Dig through the old design docs to understand why we rejected GraphQL back then", "should_trigger": true},
+  {"query": "Before I refactor this, reconstruct why it was built this way from the git history", "should_trigger": true},
+  {"query": "Reconstruct the rationale chain for our switch to a monorepo, and flag any reasons that no longer hold", "should_trigger": true},
+  {"query": "The decision predates everyone on call — excavate why we picked this queue", "should_trigger": true},
+  {"query": "Trace the chronology of how we ended up with this database schema and what alternatives were rejected", "should_trigger": true},
+  {"query": "Surface the revival candidates among the options we rejected when we picked this vendor", "should_trigger": true},
+
+  {"query": "Compare the hypotheses for which message queue we should adopt now", "should_trigger": false},
+  {"query": "What are the named camps in the Kafka-vs-RabbitMQ debate?", "should_trigger": false},
+  {"query": "Look up the durability guarantees of Kafka and RabbitMQ", "should_trigger": false},
+  {"query": "Curate the authoritative sources on message-queue design", "should_trigger": false},
+  {"query": "Decompose 'which message queue should we use' into sub-questions", "should_trigger": false},
+  {"query": "Argue against keeping Kafka as our queue", "should_trigger": false},
+  {"query": "Start a research project on our messaging infrastructure", "should_trigger": false},
+  {"query": "Record the decision to adopt Kafka", "should_trigger": false},
+  {"query": "Research with citations whether Kafka outperforms RabbitMQ at scale", "should_trigger": false}
+]

--- a/packs/research/.apm/skills/decision-archaeology/evals/evals.json
+++ b/packs/research/.apm/skills/decision-archaeology/evals/evals.json
@@ -1,0 +1,17 @@
+{
+  "skill_name": "decision-archaeology",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Reconstruct the rationale for the past decision the user named by walking the time-ordered artifacts, and produce the archaeology.",
+      "expected_output": "An archaeology artifact with a dated chronology in which each entry is cited to a concrete artifact (commit / PR / design doc / path); a rationale chain that traces the decision back through its antecedents to a first cause or external constraint; an alternatives-considered section recording what was rejected and why as of the decision; and a revival check that — distinct from alternatives-considered — flags only those rejected alternatives whose original rejection rationale has since been overtaken by a changed constraint, citing the dated signal of the change. Inferred rationale is marked [inference] and cross-artifact synthesis [synthesis] rather than asserted.",
+      "assertions": [
+        "Presents a dated chronology, each entry cited to a concrete artifact (commit / PR / doc / path)",
+        "Traces a rationale chain from the decision back through its antecedents to a first cause / external constraint",
+        "Lists the alternatives considered and the reason each was rejected as of the decision",
+        "Runs a revival check that flags only rejected alternatives whose rejection rationale has been overtaken by a changed constraint, citing the dated change",
+        "Marks inferred rationale [inference] and cross-artifact synthesis [synthesis] rather than asserting them"
+      ]
+    }
+  ]
+}

--- a/packs/research/.apm/skills/devils-advocate/evals/eval_queries.json
+++ b/packs/research/.apm/skills/devils-advocate/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "Argue against the finding that we should adopt event sourcing", "should_trigger": true},
+  {"query": "Play devil's advocate on my conclusion that we should rewrite the service in Rust", "should_trigger": true},
+  {"query": "Find the counter-evidence to the claim that microservices improved our velocity", "should_trigger": true},
+  {"query": "What are the strongest objections to my recommendation to drop the on-call rotation?", "should_trigger": true},
+  {"query": "Stress-test this finding: 'caching solved our latency problem'", "should_trigger": true},
+  {"query": "Steelman the opposing case against migrating to a monorepo", "should_trigger": true},
+  {"query": "Challenge the claim that our A/B test proves the new flow is better", "should_trigger": true},
+  {"query": "Surface the best arguments against acting on this finding before I commit to it", "should_trigger": true},
+  {"query": "What does the other side say about my conclusion that we should self-host?", "should_trigger": true},
+
+  {"query": "What are the named camps in the monorepo-vs-polyrepo debate?", "should_trigger": false},
+  {"query": "Compare the hypotheses for why our velocity changed, with a matrix", "should_trigger": false},
+  {"query": "Look up the evidence on event-sourcing adoption rates", "should_trigger": false},
+  {"query": "Curate the authoritative sources on event sourcing", "should_trigger": false},
+  {"query": "Decompose 'should we adopt event sourcing' into sub-questions", "should_trigger": false},
+  {"query": "Why did we reject event sourcing two years ago?", "should_trigger": false},
+  {"query": "Start a research project on our architecture direction", "should_trigger": false},
+  {"query": "Research with citations the trade-offs of event sourcing", "should_trigger": false},
+  {"query": "Write a spec for the event-sourcing migration", "should_trigger": false}
+]

--- a/packs/research/.apm/skills/devils-advocate/evals/evals.json
+++ b/packs/research/.apm/skills/devils-advocate/evals/evals.json
@@ -1,0 +1,17 @@
+{
+  "skill_name": "devils-advocate",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Adversarially review the finding or claim the user gave: search for counter-evidence, name the strongest objections, and route each to a verdict.",
+      "expected_output": "A counterpoints artifact that, per finding, states the strongest counter-position — a credible, well-evidenced opposing view, not a strawman — with cited counter-evidence (or [inference] where uncited), and routes each finding to exactly one of two verdicts: a confidence-rating downgrade that names the downgrade factor, OR a do-not-resolve verdict for an irreducible tension that names the different conditions under which each side holds. Do-not-resolve is reserved for tensions with substantive evidence on both sides; it is never used as cover for thin evidence (which is an [uncertain] rating or a known-unknown gap).",
+      "assertions": [
+        "Names the strongest objection / counter-position per finding — a credible, well-evidenced view, not a strawman",
+        "Counter-evidence carries citations, or is marked [inference] when uncited",
+        "Each finding routes to exactly one verdict: a confidence-rating downgrade OR a do-not-resolve verdict",
+        "A rating downgrade names the downgrade factor; a do-not-resolve names the conditions under which each side holds",
+        "Reserves do-not-resolve for irreducible tensions with substantive evidence on both sides, not as cover for thin evidence"
+      ]
+    }
+  ]
+}

--- a/packs/research/.apm/skills/identify-perspectives/evals/eval_queries.json
+++ b/packs/research/.apm/skills/identify-perspectives/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "What are the named camps in the debate over remote vs in-office work?", "should_trigger": true},
+  {"query": "Enumerate the perspectives on whether AI coding assistants help or hurt junior developers", "should_trigger": true},
+  {"query": "Map the camps in the REST-vs-GraphQL debate, with their representative voices", "should_trigger": true},
+  {"query": "Lay out the contested positions on whether microservices are worth the complexity", "should_trigger": true},
+  {"query": "Who are the camps on nuclear power as a climate solution, and where are the irreducible tensions?", "should_trigger": true},
+  {"query": "Surface all the significant viewpoints on open-source AI model licensing", "should_trigger": true},
+  {"query": "Identify the perspectives and the do-not-resolve tensions in the privacy-vs-personalization debate", "should_trigger": true},
+  {"query": "Before we decide, enumerate the camps on monorepo vs polyrepo", "should_trigger": true},
+  {"query": "What are the dissenting and fringe positions on universal basic income, not just the mainstream two?", "should_trigger": true},
+
+  {"query": "Compare the competing hypotheses on why remote work affects productivity, with an evidence matrix", "should_trigger": false},
+  {"query": "Curate the authoritative sources on the remote-work productivity debate", "should_trigger": false},
+  {"query": "Look up the latest data on remote-work productivity", "should_trigger": false},
+  {"query": "Decompose 'should we go remote-first' into its sub-questions", "should_trigger": false},
+  {"query": "Why did we adopt a remote-first policy back in 2021?", "should_trigger": false},
+  {"query": "Argue against our remote-first policy", "should_trigger": false},
+  {"query": "Start a research project on the future of work", "should_trigger": false},
+  {"query": "Research with citations the evidence on remote-work burnout", "should_trigger": false},
+  {"query": "Record the decision to switch to a hybrid work model", "should_trigger": false}
+]

--- a/packs/research/.apm/skills/identify-perspectives/evals/evals.json
+++ b/packs/research/.apm/skills/identify-perspectives/evals/evals.json
@@ -1,0 +1,17 @@
+{
+  "skill_name": "identify-perspectives",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Enumerate the named camps on the contested topic the user gave, and produce the perspectives map.",
+      "expected_output": "A perspectives map listing each named camp with a one-sentence core claim and its representative voices (each voice cited, or marked [synthesis] / [inference]); a possibly-missing / under-represented camps section; and a tension map that — distinct from the camp list — records only the irreducible disagreements, each with the conditions under which each side holds and what a forced resolution would destroy. Irreducible status requires substantive evidence on both sides; thin evidence is treated as an [uncertain] rating or a known-unknown, not promoted to a tension.",
+      "assertions": [
+        "Lists named camps, each with a one-sentence core claim and representative voices",
+        "Representative voices are cited, or marked [synthesis] / [inference]",
+        "Includes a possibly-missing / under-represented camps section",
+        "The tension map records only irreducible disagreements, each with the conditions under which each side holds and what a forced resolution would destroy",
+        "Distinguishes irreducible tension (substantive evidence on both sides) from thin evidence (an [uncertain] rating or known-unknown, not a tension)"
+      ]
+    }
+  ]
+}

--- a/packs/research/.apm/skills/research-project-start/evals/eval_queries.json
+++ b/packs/research/.apm/skills/research-project-start/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "Start a research project on payments fraud that we'll work on over the next month", "should_trigger": true},
+  {"query": "Set up a research project on the competitive landscape for our product", "should_trigger": true},
+  {"query": "Begin a sustained investigation into LLM agent evaluation methods", "should_trigger": true},
+  {"query": "Open a research dossier on supply-chain security for our dependencies", "should_trigger": true},
+  {"query": "Let's stand up a multi-week research project on database migration strategy", "should_trigger": true},
+  {"query": "Kick off a long-running research project tracking the regulatory landscape for AI", "should_trigger": true},
+  {"query": "Create a project folder and scaffold for an ongoing investigation into our churn drivers", "should_trigger": true},
+  {"query": "I want a stateful research project on observability tooling, capturing sources as we go", "should_trigger": true},
+  {"query": "Set up a sustained research effort on post-quantum migration, with a question and working hypothesis", "should_trigger": true},
+
+  {"query": "Look up the current state of post-quantum cryptography standards", "should_trigger": false},
+  {"query": "Research with citations the evidence on churn-reduction tactics", "should_trigger": false},
+  {"query": "Curate the authoritative sources on supply-chain security", "should_trigger": false},
+  {"query": "Decompose the database-migration question into its sub-questions", "should_trigger": false},
+  {"query": "What are the named camps in the AI-regulation debate?", "should_trigger": false},
+  {"query": "Compare the hypotheses for our churn increase", "should_trigger": false},
+  {"query": "Why did we choose our current observability vendor?", "should_trigger": false},
+  {"query": "Digest the sources I've already gathered for the fraud project", "should_trigger": false},
+  {"query": "Start a new feature for fraud detection — write the spec", "should_trigger": false}
+]

--- a/packs/research/.apm/skills/research-project-synthesize/evals/evals.json
+++ b/packs/research/.apm/skills/research-project-synthesize/evals/evals.json
@@ -1,0 +1,17 @@
+{
+  "skill_name": "research-project-synthesize",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Synthesize the research project into its typed verdict and a self-contained governance brief.",
+      "expected_output": "A governance brief that opens answer-first (BLUF — the recommendation or bottom line is the top line, before supporting detail); is self-contained (no cross-links to other project files such as memos or the synthesis matrix, so it is safe to lift whole into an RFC, with external sources cited by URL); carries a citation and a GRADE confidence tag on every load-bearing claim exactly as a survey would; rests its material ([high]/[moderate]) claims on >=3-source triangulation; and ends with a `## Known unknowns` section splitting known-unknowns (with the evidence that would close them) from unknowables. It reasons from the evidence rather than restating the project question.",
+      "assertions": [
+        "Opens answer-first (BLUF): the recommendation / bottom line is the top line, before supporting detail",
+        "Is self-contained — no cross-links to other project files; safe to lift whole into an RFC; external sources cited by URL",
+        "Every load-bearing claim carries a citation and a GRADE confidence tag",
+        "Material ([high]/[moderate]) claims rest on >=3-source triangulation",
+        "Has a ## Known unknowns section splitting known-unknowns (with the evidence that would close them) from unknowables"
+      ]
+    }
+  ]
+}

--- a/packs/research/.apm/skills/research/evals/eval_queries.json
+++ b/packs/research/.apm/skills/research/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "Look up what the current rate limits are for the Stripe API", "should_trigger": true},
+  {"query": "Find out whether SQLite supports concurrent writers", "should_trigger": true},
+  {"query": "Research with citations the evidence on whether code review reduces defect rates", "should_trigger": true},
+  {"query": "Fact-check the claim that serverless is always cheaper at low traffic", "should_trigger": true},
+  {"query": "Survey the prior art on consensus algorithms for distributed databases", "should_trigger": true},
+  {"query": "What are the applied best practices for structured logging in Go services?", "should_trigger": true},
+  {"query": "Go deep on the evidence for and against four-day work weeks", "should_trigger": true},
+  {"query": "Give me an evidence-grounded survey of vector database options", "should_trigger": true},
+  {"query": "Quick check: does Postgres LISTEN/NOTIFY survive a dropped connection?", "should_trigger": true},
+
+  {"query": "Break this broad question into the sub-questions a thorough answer must address", "should_trigger": false},
+  {"query": "Curate the authoritative sources on this topic before I start reading", "should_trigger": false},
+  {"query": "We have three theories for the latency spike — compare them against the evidence and rank them", "should_trigger": false},
+  {"query": "What are the named camps in the monolith-vs-microservices debate?", "should_trigger": false},
+  {"query": "Why did we choose Kafka over RabbitMQ two years ago?", "should_trigger": false},
+  {"query": "Argue against the finding that we should adopt event sourcing", "should_trigger": false},
+  {"query": "Start a research project on payments fraud that we'll work on for weeks", "should_trigger": false},
+  {"query": "Write a spec for the new CSV export feature", "should_trigger": false},
+  {"query": "Fix the bug where search returns stale results", "should_trigger": false}
+]

--- a/packs/research/.apm/skills/research/evals/evals.json
+++ b/packs/research/.apm/skills/research/evals/evals.json
@@ -1,0 +1,18 @@
+{
+  "skill_name": "research",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Research the question the user asked and produce the evidence-grounded survey.",
+      "expected_output": "A survey in which every finding carries a GRADE-style confidence tag ([high] / [moderate] / [low] / [uncertain]); every factual claim carries a citation or is explicitly marked [synthesis] or [inference]; material ([high]/[moderate]) claims rest on at least three independent sources (triangulation), favouring primary and peer-reviewed material over rehashes; downgraded findings name the downgrade factor; and a `## Known unknowns` section splits genuinely-open questions (answerable in principle, naming the evidence that would close them) from unknowables. The survey reasons from the evidence rather than restating the question.",
+      "assertions": [
+        "Every finding carries a GRADE-style confidence tag ([high] / [moderate] / [low] / [uncertain])",
+        "Every factual claim carries a citation, or is explicitly marked [synthesis] or [inference]",
+        "Material ([high]/[moderate]) claims rest on >=3 independent sources, favouring primary / peer-reviewed material",
+        "Each downgraded finding names the downgrade factor, not just a lower tag",
+        "Has a ## Known unknowns section splitting known-unknowns (with the evidence that would close them) from unknowables",
+        "Reasons from the evidence rather than restating the question or asserting without support"
+      ]
+    }
+  ]
+}

--- a/packs/research/.apm/skills/source-map/evals/eval_queries.json
+++ b/packs/research/.apm/skills/source-map/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "Curate the authoritative sources on WebAuthn before I start researching", "should_trigger": true},
+  {"query": "Who are the primary sources on the safety of intermittent fasting?", "should_trigger": true},
+  {"query": "Map out the most authoritative voices on Rust async runtime design", "should_trigger": true},
+  {"query": "I need a source list grouped by primary, secondary, and tertiary for GDPR enforcement", "should_trigger": true},
+  {"query": "Scope which authorities actually exist on tokenizer design for LLMs", "should_trigger": true},
+  {"query": "Build me a curated reading list of the canonical sources on CRDTs", "should_trigger": true},
+  {"query": "Before I research this, find the original primary sources, not the blog rehashes", "should_trigger": true},
+  {"query": "Survey who the credible authorities are on container security", "should_trigger": true},
+  {"query": "Gather and rank the source material on post-quantum cryptography standards", "should_trigger": true},
+
+  {"query": "Look up whether WebAuthn supports passkeys across all major browsers", "should_trigger": false},
+  {"query": "Decompose the WebAuthn adoption question into its sub-questions", "should_trigger": false},
+  {"query": "What are the named camps in the static-vs-dynamic typing debate?", "should_trigger": false},
+  {"query": "Compare the hypotheses for why our error rate jumped, with an evidence matrix", "should_trigger": false},
+  {"query": "Reconstruct why we picked our current auth library originally", "should_trigger": false},
+  {"query": "Argue against using passkeys for our login flow", "should_trigger": false},
+  {"query": "Start a long-running research project on authentication trends", "should_trigger": false},
+  {"query": "Research with citations the evidence on passwordless adoption rates", "should_trigger": false},
+  {"query": "Diagnose and fix the broken OAuth redirect", "should_trigger": false}
+]

--- a/packs/research/.apm/skills/source-map/evals/evals.json
+++ b/packs/research/.apm/skills/source-map/evals/evals.json
@@ -1,0 +1,17 @@
+{
+  "skill_name": "source-map",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Curate the authoritative sources for the topic the user gave and produce the source map.",
+      "expected_output": "A source map grouping candidates by primacy (primary / secondary / tertiary), where each entry carries a citation (URL or local path), an authority-type tag (practitioner / researcher / vendor / journalist / community / regulator), and a recency bucket (current / recent / historical). Primacy is treated as load-bearing for downstream triangulation — the map flags when several tertiary sources collapse to a single primary so independence is not overcounted. Notes about a source's angle, bias, or credibility are marked [synthesis] or [inference] rather than asserted as fact, and sources reflect a survey of adjacent material rather than the model naming authorities directly.",
+      "assertions": [
+        "Groups sources by primacy: primary / secondary / tertiary",
+        "Every entry carries a citation (URL or local path)",
+        "Each source is tagged with an authority type and a recency bucket",
+        "Treats primacy as load-bearing for triangulation (e.g. notes when tertiary sources collapse to one primary)",
+        "Marks angle / bias / credibility notes [synthesis] or [inference] rather than stating them as fact"
+      ]
+    }
+  ]
+}

--- a/packs/research/.claude-plugin/plugin.json
+++ b/packs/research/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "research",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Evidence-grounded research portable across every repo. Eleven skills (scoping, source curation, synthesis, adversarial review, decision support, rationale reconstruction, plus a four-skill project-mode lifecycle for sustained multi-week investigations) plus two retrieval subagents; methodology grounded in seven convergent disciplines (STORM, PRISMA, ACH, Wikipedia V/RS/NPOV, OSINT, GIJN, GRADE)."
 }

--- a/packs/research/pack.toml
+++ b/packs/research/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "research"
-version = "0.5.0"
+version = "0.5.1"
 description = "Evidence-grounded research portable across every repo. Eleven skills (scoping, source curation, synthesis, adversarial review, decision support, rationale reconstruction, plus a four-skill project-mode lifecycle for sustained multi-week investigations) plus two retrieval subagents; methodology grounded in seven convergent disciplines (STORM, PRISMA, ACH, Wikipedia V/RS/NPOV, OSINT, GIJN, GRADE)."
 readme = "README.md"
 display_name = "Research"
@@ -34,6 +34,38 @@ allowed-adapters = ["claude-code", "kiro-ide", "codex", "copilot", "cursor", "ge
 # **not** degraded there. The read-only restriction is preserved (no
 # edit/execute). The one narrow non-coverage is the Copilot **cloud agent**
 # (served only via repo `.github/`), which has no `web` tool.
+
+# pack-eval-coverage-rollout: the Tier-A activation-eval coverage allowlist —
+# each listed skill ships evals/eval_queries.json and is measured by
+# tools/run-pack-evals.py. These are the prompt-triggered skills with a distinct
+# cold-prompt activation surface: the seven scoping / synthesis / decision-support
+# skills, plus research-project-start as the lifecycle entry point.
+#
+# Deliberately excluded (judgment, not oversight):
+#   - research-project-check / -digest / -synthesize — the *interior* steps of the
+#     project-mode lifecycle. They operate on state that only exists once
+#     research-project-start has scaffolded a project (a sources/ corpus, a
+#     synthesis matrix), and are reached by the human walking the
+#     capture -> digest -> synthesize lifecycle inside an active project folder,
+#     not by a distinct cold user-prompt surface. The headless activation detector
+#     projects the pack into an empty dir with no project folder, so it cannot
+#     reproduce the in-project context that legitimately routes to them — measuring
+#     them cold would conflate "no project exists" with "skill mis-routed". The
+#     lifecycle entry point (research-project-start) carries Tier-A coverage for the
+#     project-mode surface. (Mirrors how core excludes work-loop as discipline-loaded
+#     rather than prompt-surfaced — not security-checklists' reviewer-internal
+#     exclusion.)
+#
+# The Tier-4 LLM-judge rubrics (evals/evals.json — independent of the Tier-A
+# allowlist) attach to the artifact-emitting judgment skills. Within project mode
+# that is research-project-synthesize's governance brief (the terminal verdict,
+# where the gradeable verdict disciplines — GRADE confidence, >=3-source
+# triangulation — are applied per the skill body), NOT research-project-digest's
+# synthesis matrix + memos: those are the intermediate structuring artifact the
+# digest emits for -check and -synthesize to consume, and the pack applies the
+# confidence/triangulation rail downstream at synthesis, not at digest time.
+[pack.evals]
+skills = ["research", "source-map", "build-outline", "identify-perspectives", "compare-hypotheses", "devils-advocate", "decision-archaeology", "research-project-start"]
 
 # RFC-0040 / ADR-0030 / consolidated-pack-layout: the scope-keyed default for the
 # [research] section of an adopter-owned `agentbundle-layout.toml`. The repo


### PR DESCRIPTION
## What

Adds **both** judgment-skill eval layers to `research` — the catalogue's largest, most heterogeneous pack (11 skills) — under the shipped [`pack-activation-evals`](docs/specs/pack-activation-evals/spec.md) contract and the standing `AGENTS.local.md` eval-coverage policy. Sixth pack in the `pack-eval-coverage-rollout`.

- **Tier-A activation (8 skills)** — `evals/eval_queries.json` + a `[pack.evals]` block for `research`, `source-map`, `build-outline`, `identify-perspectives`, `compare-hypotheses`, `devils-advocate`, `decision-archaeology`, and `research-project-start`. 9 should-trigger + 9 near-miss each. Near-misses are mostly **intra-pack sibling cross-routing** — the pack's real routing risk is skill ↔ skill — walking the pipeline (`build-outline` ↔ `source-map` ↔ `research`; `identify-perspectives` ↔ `compare-hypotheses`; backward `decision-archaeology` ↔ forward `compare-hypotheses`; episodic `research` ↔ lifecycle `research-project-start`), plus a few out-of-pack exits.
- **Tier-4 LLM-judge rubrics (8 skills)** — `evals/evals.json` matched to each skill's discipline (research → GRADE confidence + ≥3-source triangulation + Known-unknowns split; compare-hypotheses → ACH matrix + ranked most-supported; devils-advocate → do-not-resolve verdict for irreducible tensions; research-project-synthesize → answer-first self-contained governance brief; etc.).
- **No B-lite layer** — every research skill is judgment/authoring (no deterministic script/artifact to re-derive).
- `research` version 0.5.0 → 0.5.1 (`pack.toml` + `plugin.json`); `marketplace.json` re-aggregated.

## Coverage judgment (the heterogeneity call)

The three project-mode **interior** steps — `research-project-check` / `-digest` / `-synthesize` — are excluded from **Tier-A** activation: they're reached within an active project (a scaffolded `sources/` corpus, a synthesis matrix), not by a cold prompt surface the headless detector can reproduce. This mirrors how `core` excludes `work-loop`. `research-project-start` (the cold lifecycle entry point) carries Tier-A. Tier-4 is decided independently: the rubric attaches to `research-project-synthesize`'s **terminal governance brief** (where the gradeable verdict disciplines apply), not `-digest`'s **intermediate** matrix+memos. Reasoning is in the `[pack.evals]` coverage note and `notes/manual-qa.md` §11.

## Why / Why this way

This is rollout work under a **shipped** spec + standing policy — recorded in the spec's `manual-qa.md` (§11) and `docs/backlog.md`, exactly as the 5 prior pack increments were. No new spec or structure (so no `loop-cohort` per-increment). One discipline-matched rubric per skill, matching the established architect/product-engineering shape.

## Risks / Tradeoffs

Eval coverage is test/report-only tooling — the runner is report-only and never on the PR critical path; adds no behavior change to any skill (hence no changelog entry, matching the prior increments). The Tier-A/Tier-4 split is a judgment call, documented transparently.

## Verification

- `tools/lint-skill-spec.py` clean (incl. the `[pack.evals]` coverage check); `agentbundle validate packs/research` clean; **`make build-check` green**.
- `research` is **user-scope** → `make build-self` moved **only** `marketplace.json` (research 0.5.0 → 0.5.1); **nothing** under `.claude/` or `.agents/` (confirmed via `git status`).
- **Tier-B light-mode judge smoke-check** (`--mode judge --judge-adapter claude-code`) on the `research` rubric **discriminates**: a GRADE-tagged, triangulated, citation-bearing survey → **PASS**; an unsupported opinion paragraph → **FAIL**. (The spot-check first caught a real defect in the draft good artifact — a `[moderate]` finding on a single source — proving it grades on substance.)
- `adversarial-reviewer` pass: clean after addressing one Concern (state the *Tier-4-specific* reason `-digest` carries no rubric, not the Tier-A one) and one Nit (note that the `research` Tier-A set spans all modes while the rubric grades the standard survey).