### PR TITLE
feat(pack-eval-coverage-rollout): Tier-A activation evals for architect / product-engineering / contracts / figma / atlassian (19 skills)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "architect",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.7.0"
+      "version": "0.7.1"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",
@@ -35,7 +35,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "atlassian",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.3.0"
+      "version": "0.3.1"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",
@@ -52,7 +52,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "contracts",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.3.2"
+      "version": "0.3.3"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",
@@ -138,7 +138,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "figma",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.1.3"
+      "version": "0.1.4"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",
@@ -187,7 +187,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "product-engineering",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.5.0"
+      "version": "0.5.1"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -762,33 +762,40 @@ than a documented accepted-state.
 **Spec:** [pack-activation-evals](specs/pack-activation-evals/spec.md). Eval
 coverage today: **`core`** (5 skills, Tier-A activation), **`converters`**
 (6 skills, Tier-A activation **+** Tier-B-lite behavior, all 6 run for real),
-**Tier-4 LLM-judge rubrics** for all of **`architect`** (3 skills) and
-**`product-engineering`** (5 skills), **`design-craft`** (4 skills,
-Tier-A activation **+** Tier-4 LLM-judge — both layers, no B-lite since the
+**`architect`** (3 skills, Tier-A activation **+** Tier-4 LLM-judge),
+**`product-engineering`** (5 skills, Tier-A activation **+** Tier-4 LLM-judge),
+**`contracts`** (2 skills, Tier-A activation), **`figma`** (1 skill, Tier-A
+activation), **`atlassian`** (8 skills, Tier-A activation), **`design-craft`**
+(4 skills, Tier-A activation **+** Tier-4 LLM-judge — both layers, no B-lite since the
 four skills are judgment/authoring), **`governance-extras`** (3 skills,
 Tier-A activation **+** Tier-4 LLM-judge — both layers, no B-lite; the three
 skills are governance authoring/judgment), and **`user-guide-diataxis`**
 (1 skill — `new-guide` — Tier-A activation **+** Tier-4 LLM-judge — both
 layers, no B-lite; `new-guide` is judgment/authoring) — `expected_output` +
-`assertions` per skill, gradable via `--mode judge`. Every other pack has
-**no eval coverage yet**. Remaining work, tiered by what it needs:
+`assertions` per skill, gradable via `--mode judge`. The judge rubrics for
+`architect` / `product-engineering` predate the activation layer; the
+`contracts` / `figma` / `atlassian` activation evals are this rollout
+(`pack-eval-coverage-rollout`). Remaining work, tiered by what it needs:
 
 - **Tier 1 — activation (Tier-A) for the rest of the catalogue (tractable now,
-  no deps/execution).** ~27 user-triggered skills across `architect` (3),
-  `contracts` (2),
-  `monorepo-extras` (1), `product-engineering` (5), `research` (7)
+  no deps/execution).** Remaining: `monorepo-extras` (1) and `research` (~11)
   need `evals/eval_queries.json` + a `[pack.evals]`
-  block (the same ~8–10-each-way near-miss pattern as `core`). `design-craft`
+  block (the same ~8–10-each-way near-miss pattern as `core`). `architect` (3),
+  `product-engineering` (5), `contracts` (2), `design-craft`
   (4), `governance-extras` (3), and `user-guide-diataxis` (1, `new-guide`) are
-  **done** (this rollout). Exclude
+  **done**; the credentialed/backend `figma` (1) and `atlassian` (8) Tier-A
+  activation is **done** too (see Tier 3). Exclude
   reviewer-internal / non-prompt skills (`security-checklists`, `work-loop`,
-  `credential-setup`), as `core` does. This is the bulk of the gap.
+  `credential-setup`), as `core` does.
 - **Tier 2 — B-lite behavior for other *deterministic* skills.** Assess
   `contracts` (`api-contract` / `event-contract` — do they deterministically
   emit/validate a contract artifact? if so, add an `expect` block + fixture).
   Most non-converters skills are judgment/authoring → not B-lite-able.
-- **Tier 3 — credentialed/backend skills** (`atlassian` 8, `figma` 1): activation
-  only; behavior needs recorded cassettes / a test backend → see
+- **Tier 3 — credentialed/backend skills** (`atlassian` 8, `figma` 1): Tier-A
+  **activation is done** (`pack-eval-coverage-rollout`) — activation is observed
+  at the Skill-router level before the skill body runs, so no backend
+  credentials are needed to measure it. Only **behavior** testing remains, and it
+  needs recorded cassettes / a test backend → see
   `behavior-check-for-backend-skills`.
 - **Tier 4 — judgment / agent-workflow skills** (`core` 5, `architect`,
   `research`, `product-engineering`, `design-craft`, `governance-extras`,

--- a/docs/specs/pack-activation-evals/notes/manual-qa.md
+++ b/docs/specs/pack-activation-evals/notes/manual-qa.md
@@ -328,3 +328,76 @@ is green). **Note:** `user-guide-diataxis` is `default-scope = "repo"` and is
 self-host-projected — like `core` / `governance-extras`, not like the
 user-scope `design-craft` — so the added eval files **do** project into
 `.claude/` and `.agents/`, and `make build-check` is the gate that covers them.
+
+## 11. Tier-A activation backfill — architect / product-engineering / contracts / figma / atlassian, 2026-06-23
+
+Five packs already carried a layer above (LLM-judge rubrics for `architect`
+and `product-engineering`) or are credentialed/backend skills, but had skipped
+the cheaper **Tier-A activation** layer underneath. This rollout adds
+`evals/eval_queries.json` (~9–10 should-trigger + ~9–10 near-miss
+should-NOT-trigger each) and a `[pack.evals]` block to every user-prompt-triggered
+skill across all five — **activation only**; the existing `evals/evals.json`
+judge rubrics were left untouched:
+
+| pack | skills covered | version |
+| --- | --- | --- |
+| architect | architect-design, architect-diagram, architect-review (3) | 0.7.0 → 0.7.1 |
+| product-engineering | frame-intent, de-risk-intent, decompose-intent, align-value-stream, voice-and-microcopy (5) | 0.5.0 → 0.5.1 |
+| contracts | api-contract, event-contract (2) | 0.3.2 → 0.3.3 |
+| figma | figma (1) | 0.1.3 → 0.1.4 |
+| atlassian | jira, jira-align, jira-brief-intake, jira-defect-flow, flow-metrics, confluence-crawler, confluence-publisher, ai-adoption-report (8) | 0.3.0 → 0.3.1 |
+
+No exclusions: unlike `core` (`work-loop` / `security-checklists` are not
+user-prompt-triggered), all 19 skills here fire on a user prompt. The
+highest-value near-misses are **sibling mis-routing within each pack** — the
+tightly-clustered `atlassian` (8) and `product-engineering` (5) sets carry a
+deliberate chunk of negatives that route to a *sibling*, not just to an
+unrelated prompt: e.g. "show me sprint cycle time" → `flow-metrics` not `jira`;
+"publish this page to Confluence" → `confluence-publisher` not
+`confluence-crawler`; "compare our flow metrics to pre-AI" → `ai-adoption-report`
+not `flow-metrics`; "turn PROJ-100 into specs" → `jira-brief-intake` not `jira`;
+"test whether this bet holds" → `de-risk-intent` not `frame-intent`.
+
+**Credentialed packs need NO backend credentials.** Activation is observed at
+the **Skill-router level before the skill body runs**, so a Figma/Atlassian
+login is irrelevant to whether the skill fires — the evals are written and run
+normally. (Repeatable *behavior* testing of a backend skill still needs
+cassettes / a test backend, which stays future-Tier-B-RFC scope.)
+
+### Bounded headless spot-check (live, `claude` 2.1.185 on PATH)
+
+A full sweep is `pack-evals.yml`'s job; this PR ran one bounded headless check
+to validate the new content end-to-end. An ephemeral 2-skill mini-pack
+(`flow-metrics` + `jira`, so intra-pack exclusivity is observable) with a
+trimmed 3-query `flow-metrics` set, `--mode headless --runs 1`:
+
+| query | should_trigger | observed trigger_rate | graded |
+| --- | --- | --- | --- |
+| "What's our cycle time this quarter for PROJ?" | true | 1.00 | pass |
+| "Give me throughput and WIP for the Foo team" | true | 1.00 | pass |
+| "Search Jira for all open bugs in PROJ with JQL" | false | 0.00 | pass |
+
+All three graded correctly: `flow-metrics` fires on the two metrics prompts and
+stays quiet on the Jira-search near-miss (which correctly fired `jira` instead).
+The runner **also flagged `jira` co-firing** on the two metrics prompts (the
+`⚠ also fired: jira` intra-pack-exclusivity signal) — expected, since `jira`'s
+description spans broad Jira data access and "cycle time for PROJ" reads as a
+Jira query too. This is exactly the report-only calibration signal the harness
+exists to produce; it is **not** a grade failure for `flow-metrics` (the
+per-skill activation grade is whether *that* skill fired, and it did) and **not**
+a blocker for this PR. The mini-pack was deleted after the run.
+
+**Authoring consequence for `jira`'s negatives (adversarial-review finding).**
+Because `jira` is the broad catch-all skill, it over-fires on *bare metrics
+phrasings* — so reusing `flow-metrics`'s positive strings verbatim as `jira`
+negatives would assert `jira`-quiet on a prompt the spot-check shows `jira`
+fires. The `metrics → flow-metrics` routing is already exercised by
+`flow-metrics`'s own positive set (proven above); `jira`'s near-miss negatives
+therefore favor **workflow-outcome** asks — "diagnose and ship a fix" →
+`jira-defect-flow`, "decompose this epic into specs" → `jira-brief-intake`,
+"list features under a Jira Align program" → `jira-align`, "publish to
+Confluence" → `confluence-publisher`, "how should we architect…" →
+`architect-design` — where the user clearly wants a *different* skill than raw
+issue CRUD, rather than metrics strings that collide with `flow-metrics`. The
+broader `jira`-vs-metrics over-trigger is a known calibration item for the
+scheduled `pack-evals.yml` sweep, not a per-PR gate. `make build-check` is green.

--- a/packs/architect/.apm/skills/architect-design/evals/eval_queries.json
+++ b/packs/architect/.apm/skills/architect-design/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "How should we architect the new notification service?", "should_trigger": true},
+  {"query": "We need to design the integration between our billing system and Stripe", "should_trigger": true},
+  {"query": "What's the right way to build a multi-tenant data layer?", "should_trigger": true},
+  {"query": "Help me weigh Postgres vs DynamoDB for the event store", "should_trigger": true},
+  {"query": "Design a rate-limiting approach for our public API", "should_trigger": true},
+  {"query": "We're adding real-time sync — how should we structure it?", "should_trigger": true},
+  {"query": "Write a design doc for the new ingestion pipeline", "should_trigger": true},
+  {"query": "What architecture should we use for the offline-first mobile client?", "should_trigger": true},
+  {"query": "Let's figure out the right approach for sharding the user database", "should_trigger": true},
+
+  {"query": "Draw a diagram of the notification service", "should_trigger": false},
+  {"query": "Show me a sequence diagram for the checkout flow", "should_trigger": false},
+  {"query": "Review this design doc and tell me what's wrong with it", "should_trigger": false},
+  {"query": "Is this architecture any good? Here's the RFC", "should_trigger": false},
+  {"query": "Diagram the data model for the billing tables", "should_trigger": false},
+  {"query": "Critique my proposed approach to caching", "should_trigger": false},
+  {"query": "Write a spec for the CSV export feature", "should_trigger": false},
+  {"query": "Fix the bug where webhooks fire twice", "should_trigger": false},
+  {"query": "Record our decision to standardize on gRPC", "should_trigger": false}
+]

--- a/packs/architect/.apm/skills/architect-diagram/evals/eval_queries.json
+++ b/packs/architect/.apm/skills/architect-diagram/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "Draw a diagram of how the payment flow works", "should_trigger": true},
+  {"query": "Show me a C4 container view of our platform", "should_trigger": true},
+  {"query": "Diagram the state machine for an order's lifecycle", "should_trigger": true},
+  {"query": "Can you draw a sequence diagram for the login flow?", "should_trigger": true},
+  {"query": "I need an ER diagram for the subscription tables", "should_trigger": true},
+  {"query": "Sketch the deployment topology across our AWS accounts", "should_trigger": true},
+  {"query": "Show me a flowchart of the CI pipeline", "should_trigger": true},
+  {"query": "Diagram the data flow from ingestion to the dashboard", "should_trigger": true},
+  {"query": "Draw the bounded contexts for our checkout domain", "should_trigger": true},
+
+  {"query": "How should we design the payment flow?", "should_trigger": false},
+  {"query": "What's the right architecture for the order system?", "should_trigger": false},
+  {"query": "Review this sequence diagram and tell me what's wrong", "should_trigger": false},
+  {"query": "Is this C4 diagram any good?", "should_trigger": false},
+  {"query": "Write a design doc for the deployment topology", "should_trigger": false},
+  {"query": "Build me a comparison table of the message-queue options", "should_trigger": false},
+  {"query": "Generate an OpenAPI spec for the payments API", "should_trigger": false},
+  {"query": "Render this Figma frame to PNG", "should_trigger": false},
+  {"query": "Create a slide deck explaining the architecture", "should_trigger": false}
+]

--- a/packs/architect/.apm/skills/architect-review/evals/eval_queries.json
+++ b/packs/architect/.apm/skills/architect-review/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "Review this design doc and flag any issues", "should_trigger": true},
+  {"query": "What's wrong with this architecture proposal?", "should_trigger": true},
+  {"query": "Is this RFC any good? I pasted it below", "should_trigger": true},
+  {"query": "Critique the attached system design", "should_trigger": true},
+  {"query": "Here's our ADR — does the decision hold up?", "should_trigger": true},
+  {"query": "Can you do a well-architected review of this design?", "should_trigger": true},
+  {"query": "Tear apart this proposed caching strategy", "should_trigger": true},
+  {"query": "Assess whether this diagram captures the right abstraction", "should_trigger": true},
+  {"query": "Give me a verdict on this integration design", "should_trigger": true},
+
+  {"query": "How should we design the caching strategy?", "should_trigger": false},
+  {"query": "Draw a diagram of the integration", "should_trigger": false},
+  {"query": "Write an RFC proposing we move to gRPC", "should_trigger": false},
+  {"query": "Design the ingestion system from scratch", "should_trigger": false},
+  {"query": "Review this pull request for correctness bugs", "should_trigger": false},
+  {"query": "What's wrong with my failing test?", "should_trigger": false},
+  {"query": "Diagram the abstraction layers", "should_trigger": false},
+  {"query": "Record this architecture decision as an ADR", "should_trigger": false},
+  {"query": "Proofread this blog post about our architecture", "should_trigger": false}
+]

--- a/packs/architect/.claude-plugin/plugin.json
+++ b/packs/architect/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "architect",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Solution-architecture skills (architect-design, architect-diagram, architect-review) plus a forked-context design-reviewer subagent. Workspace-agnostic, user-scope by default, no required configuration."
 }

--- a/packs/architect/pack.toml
+++ b/packs/architect/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "architect"
-version = "0.7.0"
+version = "0.7.1"
 description = "Solution-architecture skills (architect-design, architect-diagram, architect-review) plus a forked-context design-reviewer subagent. Workspace-agnostic, user-scope by default, no required configuration. Mermaid for diagrams; Google-style design docs; rubric-routed critique."
 readme = "README.md"
 display_name = "Architect"
@@ -38,6 +38,13 @@ allowed-adapters = ["claude-code", "codex", "copilot", "kiro-ide", "kiro-cli", "
 # by hand; see the skill's references/agentbundle-layout.md).
 [pack.layout.repo]
 parent = "docs/design"
+
+# pack-activation-evals (RFC-0037 / ADR-0028) — pack-eval-coverage-rollout:
+# the Tier-A activation-eval coverage allowlist. Each listed skill ships
+# evals/eval_queries.json and is measured by tools/run-pack-evals.py. All three
+# architect skills are user-prompt-triggered, so none are excluded.
+[pack.evals]
+skills = ["architect-design", "architect-diagram", "architect-review"]
 
 # enriched-pack-manifest (RFC-0031 / ADR-0021): catalogue-facing links
 # + maintainer, including the `documentation` link to the per-pack guide home.

--- a/packs/atlassian/.apm/skills/ai-adoption-report/evals/eval_queries.json
+++ b/packs/atlassian/.apm/skills/ai-adoption-report/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "How do our flow metrics now compare to pre-AI?", "should_trigger": true},
+  {"query": "Within Q4, did AI-tagged tickets behave differently from untagged?", "should_trigger": true},
+  {"query": "What does Q4 look like across all teams in the program?", "should_trigger": true},
+  {"query": "Compare these two flow-metrics JSON outputs into a report", "should_trigger": true},
+  {"query": "Produce a baseline comparison report from before and after the AI rollout", "should_trigger": true},
+  {"query": "Run a cohort split: AI vs control within this window", "should_trigger": true},
+  {"query": "Roll up the flow-metrics comparison across all program scopes", "should_trigger": true},
+  {"query": "Generate the AI-adoption Markdown report from these metrics files", "should_trigger": true},
+  {"query": "Compare our cycle time before and after adopting Copilot", "should_trigger": true},
+
+  {"query": "Compute our cycle time this quarter for PROJ", "should_trigger": false},
+  {"query": "Give me throughput and WIP for the team", "should_trigger": false},
+  {"query": "Calculate the rework rate over Q4", "should_trigger": false},
+  {"query": "Search Jira for AI-tagged tickets", "should_trigger": false},
+  {"query": "Fetch the flow metrics for program 42", "should_trigger": false},
+  {"query": "Publish the comparison report to Confluence", "should_trigger": false},
+  {"query": "Fix the defect PROJ-123", "should_trigger": false},
+  {"query": "Turn this epic into specs", "should_trigger": false},
+  {"query": "Fetch this Jira Align portfolio", "should_trigger": false}
+]

--- a/packs/atlassian/.apm/skills/confluence-crawler/evals/eval_queries.json
+++ b/packs/atlassian/.apm/skills/confluence-crawler/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "Crawl our Confluence space and convert it to Markdown", "should_trigger": true},
+  {"query": "Mirror the ENG Confluence space locally", "should_trigger": true},
+  {"query": "Export every page under this Confluence space as Markdown", "should_trigger": true},
+  {"query": "Ingest our Confluence docs into Markdown with frontmatter", "should_trigger": true},
+  {"query": "Crawl the Confluence space by page hierarchy, depth 3", "should_trigger": true},
+  {"query": "Re-crawl the space idempotently and update changed pages", "should_trigger": true},
+  {"query": "Pull down all the pages in the PRODUCT Confluence space", "should_trigger": true},
+  {"query": "Convert this whole Confluence space to clean Markdown", "should_trigger": true},
+  {"query": "Mirror the on-prem Confluence Data Center space", "should_trigger": true},
+
+  {"query": "Publish this report to a Confluence page", "should_trigger": false},
+  {"query": "Push this Markdown doc up to Confluence", "should_trigger": false},
+  {"query": "Update the existing Confluence page with new content", "should_trigger": false},
+  {"query": "Search Jira for open issues", "should_trigger": false},
+  {"query": "What's our cycle time this quarter?", "should_trigger": false},
+  {"query": "Create a Jira issue from this doc", "should_trigger": false},
+  {"query": "Mirror our GitHub wiki locally", "should_trigger": false},
+  {"query": "Turn this epic into specs", "should_trigger": false},
+  {"query": "Compare flow metrics to last quarter", "should_trigger": false}
+]

--- a/packs/atlassian/.apm/skills/confluence-publisher/evals/eval_queries.json
+++ b/packs/atlassian/.apm/skills/confluence-publisher/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "Publish this report to a Confluence page", "should_trigger": true},
+  {"query": "Push this Markdown design doc up to Confluence", "should_trigger": true},
+  {"query": "Update the existing Confluence page with this content", "should_trigger": true},
+  {"query": "Create a new Confluence page from this document", "should_trigger": true},
+  {"query": "Publish this to Confluence under the ENG space", "should_trigger": true},
+  {"query": "Post this content to the Confluence page with ID 12345", "should_trigger": true},
+  {"query": "Push my flow-metrics report to our team's Confluence page", "should_trigger": true},
+  {"query": "Publish this storage-format XHTML to Confluence", "should_trigger": true},
+  {"query": "Update the Confluence page by its URL with the latest draft", "should_trigger": true},
+
+  {"query": "Crawl our Confluence space into Markdown", "should_trigger": false},
+  {"query": "Mirror the whole Confluence space locally", "should_trigger": false},
+  {"query": "Export every page in the space as Markdown", "should_trigger": false},
+  {"query": "Create a Jira issue for this task", "should_trigger": false},
+  {"query": "Comment on PROJ-100 in Jira", "should_trigger": false},
+  {"query": "Generate the flow-metrics report", "should_trigger": false},
+  {"query": "Compare flow metrics to pre-AI", "should_trigger": false},
+  {"query": "Write a tutorial for the export feature", "should_trigger": false},
+  {"query": "Turn this epic into specs", "should_trigger": false}
+]

--- a/packs/atlassian/.apm/skills/flow-metrics/evals/eval_queries.json
+++ b/packs/atlassian/.apm/skills/flow-metrics/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "What's our cycle time this quarter for PROJ?", "should_trigger": true},
+  {"query": "Give me throughput and WIP for the Foo team", "should_trigger": true},
+  {"query": "Compute lead time and flow efficiency for the last sprint", "should_trigger": true},
+  {"query": "Show me the rework rate for PROJ over Q4", "should_trigger": true},
+  {"query": "Roll up flow metrics across program 42", "should_trigger": true},
+  {"query": "Compare flow efficiency before and after the AI-pairing rollout via a cohort split", "should_trigger": true},
+  {"query": "What's our flow distribution across feature/defect/debt?", "should_trigger": true},
+  {"query": "Calculate the defect ratio for the Bar team this quarter", "should_trigger": true},
+  {"query": "Give me DORA metrics over the PROJ scope", "should_trigger": true},
+
+  {"query": "How do our flow metrics now compare to pre-AI?", "should_trigger": false},
+  {"query": "Roll up the comparison report across all teams in the program", "should_trigger": false},
+  {"query": "Search Jira for open issues", "should_trigger": false},
+  {"query": "Create a Jira issue", "should_trigger": false},
+  {"query": "Stream real-time deployment metrics to a live dashboard", "should_trigger": false},
+  {"query": "Fetch this Jira Align epic", "should_trigger": false},
+  {"query": "Fix the defect PROJ-123", "should_trigger": false},
+  {"query": "Turn this epic into specs", "should_trigger": false},
+  {"query": "What's our change failure rate and MTTR from deploy events?", "should_trigger": false}
+]

--- a/packs/atlassian/.apm/skills/jira-align/evals/eval_queries.json
+++ b/packs/atlassian/.apm/skills/jira-align/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "Fetch the Jira Align epic with ID 4521", "should_trigger": true},
+  {"query": "Update this feature in Jira Align", "should_trigger": true},
+  {"query": "List all portfolios in Jira Align", "should_trigger": true},
+  {"query": "Export Jira Align capabilities as CSV with an OData $filter", "should_trigger": true},
+  {"query": "Create a new program record in Jira Align", "should_trigger": true},
+  {"query": "Get the themes under portfolio 12 in Jira Align", "should_trigger": true},
+  {"query": "Paginate through all Jira Align features with $filter and $select", "should_trigger": true},
+  {"query": "Update the status of this Jira Align capability", "should_trigger": true},
+  {"query": "Pull the team records from Jira Align as JSONL", "should_trigger": true},
+
+  {"query": "Fetch the Jira issue PROJ-100", "should_trigger": false},
+  {"query": "Search Jira with JQL for open bugs", "should_trigger": false},
+  {"query": "Create a Jira issue for this bug", "should_trigger": false},
+  {"query": "What's the cycle time for program 42?", "should_trigger": false},
+  {"query": "Roll up flow metrics across the portfolio", "should_trigger": false},
+  {"query": "Turn this epic into shippable specs", "should_trigger": false},
+  {"query": "Fix the defect in PROJ-55", "should_trigger": false},
+  {"query": "Compare flow metrics across the program to pre-AI", "should_trigger": false},
+  {"query": "Publish the portfolio summary to Confluence", "should_trigger": false}
+]

--- a/packs/atlassian/.apm/skills/jira-brief-intake/evals/eval_queries.json
+++ b/packs/atlassian/.apm/skills/jira-brief-intake/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "Turn PROJ-100 into shippable specs", "should_trigger": true},
+  {"query": "Decompose this Jira epic into a product brief", "should_trigger": true},
+  {"query": "We plan kanban-style in Jira — break this epic into specs", "should_trigger": true},
+  {"query": "Take this board's issues and turn them into specs", "should_trigger": true},
+  {"query": "Convert epic PROJ-200 and its children into a brief", "should_trigger": true},
+  {"query": "Break down this sprint's selection of issues into a product brief", "should_trigger": true},
+  {"query": "Map this Jira epic onto a product brief and decompose it", "should_trigger": true},
+  {"query": "Turn this JQL selection of stories into shippable work", "should_trigger": true},
+  {"query": "Intake this epic as a brief and hand it off to build", "should_trigger": true},
+
+  {"query": "Create a Jira issue for this feature", "should_trigger": false},
+  {"query": "Fetch the details of PROJ-100", "should_trigger": false},
+  {"query": "Fix the defect PROJ-123 end to end", "should_trigger": false},
+  {"query": "Write a spec for a single new feature", "should_trigger": false},
+  {"query": "Decompose this 40-page PRD from the client", "should_trigger": false},
+  {"query": "What's the cycle time for this epic's stories?", "should_trigger": false},
+  {"query": "Fetch this Jira Align epic", "should_trigger": false},
+  {"query": "Shape the intent behind this initiative", "should_trigger": false},
+  {"query": "Publish the brief to Confluence", "should_trigger": false}
+]

--- a/packs/atlassian/.apm/skills/jira-defect-flow/evals/eval_queries.json
+++ b/packs/atlassian/.apm/skills/jira-defect-flow/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "Fix PROJ-123 end to end", "should_trigger": true},
+  {"query": "Work this bug ticket PROJ-88 and ship a fix", "should_trigger": true},
+  {"query": "Diagnose and ship a fix for defect PROJ-200", "should_trigger": true},
+  {"query": "Handle this Jira defect from diagnosis to PR", "should_trigger": true},
+  {"query": "Take PROJ-55, fix it, and update the ticket", "should_trigger": true},
+  {"query": "Resolve this bug ticket and link the PR back to Jira", "should_trigger": true},
+  {"query": "Pull PROJ-77, fix the root cause, open a PR, and transition it", "should_trigger": true},
+  {"query": "This defect ticket needs an end-to-end fix — PROJ-31", "should_trigger": true},
+  {"query": "Fix the bug in this Jira ticket and comment back with the PR", "should_trigger": true},
+
+  {"query": "Create a Jira issue for this defect", "should_trigger": false},
+  {"query": "Turn this epic into shippable specs", "should_trigger": false},
+  {"query": "Fix this bug in the codebase", "should_trigger": false},
+  {"query": "Implement the feature in PROJ-100", "should_trigger": false},
+  {"query": "What's the defect ratio this quarter?", "should_trigger": false},
+  {"query": "Transition PROJ-7 to Done", "should_trigger": false},
+  {"query": "Search Jira for all open defects", "should_trigger": false},
+  {"query": "Compare defect rates to pre-AI", "should_trigger": false},
+  {"query": "Diagnose why the login button does nothing", "should_trigger": false}
+]

--- a/packs/atlassian/.apm/skills/jira/evals/eval_queries.json
+++ b/packs/atlassian/.apm/skills/jira/evals/eval_queries.json
@@ -1,0 +1,23 @@
+[
+  {"query": "Search Jira for all open bugs in PROJ with JQL", "should_trigger": true},
+  {"query": "Create a Jira issue for the login regression", "should_trigger": true},
+  {"query": "Update the status of PROJ-42 to In Progress", "should_trigger": true},
+  {"query": "Add a comment to PROJ-15", "should_trigger": true},
+  {"query": "Export all issues in the Foo project as CSV", "should_trigger": true},
+  {"query": "Fetch the details of issue PROJ-100", "should_trigger": true},
+  {"query": "Transition PROJ-7 to Done", "should_trigger": true},
+  {"query": "List all projects in our Jira instance", "should_trigger": true},
+  {"query": "Pull every ticket assigned to me as JSONL", "should_trigger": true},
+  {"query": "Look up the user account for jdoe in Jira", "should_trigger": true},
+
+  {"query": "Diagnose and ship a fix for the defect in PROJ-90", "should_trigger": false},
+  {"query": "List all features under Jira Align program 42", "should_trigger": false},
+  {"query": "Turn PROJ-100 into shippable specs", "should_trigger": false},
+  {"query": "Decompose this Jira epic into a product brief", "should_trigger": false},
+  {"query": "Fix the bug in PROJ-123 end to end", "should_trigger": false},
+  {"query": "Fetch this Jira Align portfolio epic", "should_trigger": false},
+  {"query": "Mirror our Confluence space to Markdown", "should_trigger": false},
+  {"query": "Publish this report to a Confluence page", "should_trigger": false},
+  {"query": "Compare our flow metrics to last quarter", "should_trigger": false},
+  {"query": "How should we architect the issue-tracker integration?", "should_trigger": false}
+]

--- a/packs/atlassian/.claude-plugin/plugin.json
+++ b/packs/atlassian/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "atlassian",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Atlassian primitives: jira / jira-align / confluence-crawler (credentialed CLI), plus the flow-metrics, ai-adoption-report, jira-defect-flow, and jira-brief-intake workflows that compose them."
 }

--- a/packs/atlassian/pack.toml
+++ b/packs/atlassian/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "atlassian"
-version = "0.3.0"
+version = "0.3.1"
 description = "Atlassian primitives: jira / jira-align / confluence-crawler (credentialed CLI), plus the flow-metrics, ai-adoption-report, jira-defect-flow, and jira-brief-intake workflows that compose them."
 readme = "README.md"
 display_name = "Atlassian"
@@ -23,6 +23,16 @@ allowed-scopes = ["user", "repo"]
 # § 4d precondition); the consumer skills resolve the broker from
 # `~/.agentbundle/bin/`. Append-only (RFC-0011 declared-order).
 allowed-adapters = ["claude-code", "kiro-ide", "codex", "copilot", "cursor", "gemini"]
+
+# pack-activation-evals (RFC-0037 / ADR-0028) — pack-eval-coverage-rollout:
+# the Tier-A activation-eval coverage allowlist. Each listed skill ships
+# evals/eval_queries.json and is measured by tools/run-pack-evals.py.
+# Activation is observed at the Skill-router level before the skill body runs,
+# so the credentialed CLI / backend login is irrelevant to whether the skill
+# fires — no Atlassian credentials are needed to measure these (Tier-A only;
+# behavior testing of a backend skill is future-Tier-B-RFC scope, see the spec).
+[pack.evals]
+skills = ["jira", "jira-align", "jira-brief-intake", "jira-defect-flow", "flow-metrics", "confluence-crawler", "confluence-publisher", "ai-adoption-report"]
 
 # enriched-pack-manifest (RFC-0031 / ADR-0021): catalogue-facing links
 # + maintainer, including the `documentation` link to the per-pack guide home.

--- a/packs/contracts/.apm/skills/api-contract/evals/eval_queries.json
+++ b/packs/contracts/.apm/skills/api-contract/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "Generate an OpenAPI contract for the user-management API", "should_trigger": true},
+  {"query": "Author a REST API spec from these user stories", "should_trigger": true},
+  {"query": "Design the OpenAPI 3.1 spec for our payments endpoints", "should_trigger": true},
+  {"query": "Create an API contract for the orders service", "should_trigger": true},
+  {"query": "Write the REST contract for the catalog endpoints", "should_trigger": true},
+  {"query": "Turn these requirements into a validated OpenAPI YAML", "should_trigger": true},
+  {"query": "Design the HTTP API for our notifications service", "should_trigger": true},
+  {"query": "I need an OpenAPI spec ready for codegen and mocks", "should_trigger": true},
+  {"query": "Draft the REST endpoints contract for the admin panel", "should_trigger": true},
+
+  {"query": "Author an AsyncAPI contract for the order-placed event", "should_trigger": false},
+  {"query": "Design the event contract for our Kafka stream", "should_trigger": false},
+  {"query": "Write the message schema for the payment-completed event", "should_trigger": false},
+  {"query": "Generate a CloudEvents envelope for our event bus", "should_trigger": false},
+  {"query": "Build the GraphQL schema for our query layer", "should_trigger": false},
+  {"query": "How should we architect the orders service?", "should_trigger": false},
+  {"query": "Draw a sequence diagram of the API calls", "should_trigger": false},
+  {"query": "Write a spec for the new export feature", "should_trigger": false},
+  {"query": "Document how to call our public API", "should_trigger": false}
+]

--- a/packs/contracts/.apm/skills/event-contract/evals/eval_queries.json
+++ b/packs/contracts/.apm/skills/event-contract/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "Author an AsyncAPI contract for the order-placed event", "should_trigger": true},
+  {"query": "Design the event contract for our Kafka order stream", "should_trigger": true},
+  {"query": "Write the message schema for the payment-completed event we publish", "should_trigger": true},
+  {"query": "Create an AsyncAPI spec for the notifications event stream", "should_trigger": true},
+  {"query": "We own the user-signed-up event — author its contract", "should_trigger": true},
+  {"query": "Design the event-driven contract for our domain events", "should_trigger": true},
+  {"query": "Generate a validated AsyncAPI document for the inventory events", "should_trigger": true},
+  {"query": "Compose a CloudEvents envelope for the events we emit", "should_trigger": true},
+  {"query": "Author the message contract for the shipment-dispatched event", "should_trigger": true},
+
+  {"query": "Generate an OpenAPI spec for the REST orders API", "should_trigger": false},
+  {"query": "Design the HTTP API contract for payments", "should_trigger": false},
+  {"query": "Author the REST endpoints from these user stories", "should_trigger": false},
+  {"query": "Author a contract for an event we only consume from a third party", "should_trigger": false},
+  {"query": "How should we design the event-driven architecture?", "should_trigger": false},
+  {"query": "Diagram the event flow between services", "should_trigger": false},
+  {"query": "Write a spec for the new notifications feature", "should_trigger": false},
+  {"query": "Set up Kafka in our infra", "should_trigger": false},
+  {"query": "Document how our events work for consumers", "should_trigger": false}
+]

--- a/packs/contracts/.claude-plugin/plugin.json
+++ b/packs/contracts/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "contracts",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Contract-authoring skills: OpenAPI 3.1 (api-contract) and AsyncAPI events (event-contract)."
 }

--- a/packs/contracts/pack.toml
+++ b/packs/contracts/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "contracts"
-version = "0.3.2"
+version = "0.3.3"
 description = "Contract-authoring skills: OpenAPI 3.1 (api-contract) and AsyncAPI events (event-contract). User-scope default — contract style is portable across projects."
 readme = "README.md"
 display_name = "Contracts"
@@ -20,6 +20,13 @@ allowed-scopes = ["user", "repo"]
 # are admitted for credentialed CLIs now that both declare `.agentbundle/`
 # in `allowed-prefixes.user` (the § 4d precondition). Append-only.
 allowed-adapters = ["claude-code", "kiro-ide", "codex", "copilot", "cursor", "gemini"]
+
+# pack-activation-evals (RFC-0037 / ADR-0028) — pack-eval-coverage-rollout:
+# the Tier-A activation-eval coverage allowlist. Each listed skill ships
+# evals/eval_queries.json and is measured by tools/run-pack-evals.py. Both
+# skills are user-prompt-triggered, so none are excluded.
+[pack.evals]
+skills = ["api-contract", "event-contract"]
 
 # enriched-pack-manifest (RFC-0031 / ADR-0021): catalogue-facing links
 # + maintainer, including the `documentation` link to the per-pack guide home.

--- a/packs/figma/.apm/skills/figma/evals/eval_queries.json
+++ b/packs/figma/.apm/skills/figma/evals/eval_queries.json
@@ -1,0 +1,22 @@
+[
+  {"query": "Fetch the structure of this Figma file", "should_trigger": true},
+  {"query": "Render this Figma frame to PNG", "should_trigger": true},
+  {"query": "Export the design tokens from our Figma file", "should_trigger": true},
+  {"query": "Post a comment on this Figma node", "should_trigger": true},
+  {"query": "Pull the version history of the Figma file", "should_trigger": true},
+  {"query": "Inspect the layers of this Figma frame", "should_trigger": true},
+  {"query": "Convert this FigJam connector diagram to Mermaid", "should_trigger": true},
+  {"query": "Read the comments on our Figma design", "should_trigger": true},
+  {"query": "Get the metadata for this Figma file", "should_trigger": true},
+  {"query": "Render the checkout screen from Figma as SVG", "should_trigger": true},
+
+  {"query": "Change the button color in our Figma design", "should_trigger": false},
+  {"query": "Add a new frame to the Figma file", "should_trigger": false},
+  {"query": "Update the text layer in this Figma mockup", "should_trigger": false},
+  {"query": "Create a new design in Figma from scratch", "should_trigger": false},
+  {"query": "Draw a flowchart of the checkout flow", "should_trigger": false},
+  {"query": "Design a system architecture diagram", "should_trigger": false},
+  {"query": "Render this Markdown to HTML", "should_trigger": false},
+  {"query": "What should this button label say?", "should_trigger": false},
+  {"query": "Generate a PNG from this Mermaid diagram", "should_trigger": false}
+]

--- a/packs/figma/.claude-plugin/plugin.json
+++ b/packs/figma/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "figma",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Figma REST API primitive (credentialed CLI). Reads files / nodes / metadata / versions / comments / variables / dev resources, renders frame images, posts comments, and converts FigJam connector graphs to Mermaid."
 }

--- a/packs/figma/pack.toml
+++ b/packs/figma/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "figma"
-version = "0.1.3"
+version = "0.1.4"
 description = "Figma REST API primitive (credentialed CLI). Reads files / nodes / metadata / versions / comments / variables / dev resources, renders frame images, posts comments, and converts FigJam connector graphs to Mermaid."
 readme = "README.md"
 display_name = "Figma"
@@ -20,6 +20,14 @@ allowed-scopes = ["user", "repo"]
 # are admitted for credentialed CLIs now that both declare `.agentbundle/`
 # in `allowed-prefixes.user` (the § 4d precondition). Append-only.
 allowed-adapters = ["claude-code", "kiro-ide", "codex", "copilot", "cursor", "gemini"]
+
+# pack-activation-evals (RFC-0037 / ADR-0028) — pack-eval-coverage-rollout:
+# the Tier-A activation-eval coverage allowlist. The skill ships
+# evals/eval_queries.json and is measured by tools/run-pack-evals.py.
+# Activation is observed at the Skill-router level before the skill body
+# runs, so no Figma credentials are needed to measure it.
+[pack.evals]
+skills = ["figma"]
 
 # enriched-pack-manifest (RFC-0031 / ADR-0021): catalogue-facing links
 # + maintainer, including the `documentation` link to the per-pack guide home.

--- a/packs/product-engineering/.apm/skills/align-value-stream/evals/eval_queries.json
+++ b/packs/product-engineering/.apm/skills/align-value-stream/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "Set up a value-stream meta-repo for our program", "should_trigger": true},
+  {"query": "How do we coordinate delivery across our component repos?", "should_trigger": true},
+  {"query": "Stand up the cross-component Backstage catalog", "should_trigger": true},
+  {"query": "Where should the shared contract between our services live?", "should_trigger": true},
+  {"query": "Is the checkout feature delivered across all the repos yet?", "should_trigger": true},
+  {"query": "Roll up delivery status across the whole value stream", "should_trigger": true},
+  {"query": "We need one place for the cross-repo C4 architecture", "should_trigger": true},
+  {"query": "Create the coordinating repo for our polyrepo program", "should_trigger": true},
+  {"query": "Track this feature's rollout across every component repo", "should_trigger": true},
+
+  {"query": "Decompose this intent into a single repo's brief", "should_trigger": false},
+  {"query": "Shape the intent for the new capability", "should_trigger": false},
+  {"query": "Break this down into shippable specs", "should_trigger": false},
+  {"query": "Test whether the program bet holds", "should_trigger": false},
+  {"query": "Write a spec for the checkout feature", "should_trigger": false},
+  {"query": "Diagram our microservice topology", "should_trigger": false},
+  {"query": "Set up a brand-new repo for our CLI tool", "should_trigger": false},
+  {"query": "What should the cross-repo dashboard's empty state say?", "should_trigger": false},
+  {"query": "Crawl our Confluence space into Markdown", "should_trigger": false}
+]

--- a/packs/product-engineering/.apm/skills/de-risk-intent/evals/eval_queries.json
+++ b/packs/product-engineering/.apm/skills/de-risk-intent/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "De-risk this intent before we commit engineering time", "should_trigger": true},
+  {"query": "Is the assumption that users want SSO actually true?", "should_trigger": true},
+  {"query": "What would have to be true for the marketplace bet to pay off?", "should_trigger": true},
+  {"query": "Should we validate this with a prototype or just build it?", "should_trigger": true},
+  {"query": "Test the bet that self-serve will cut support load", "should_trigger": true},
+  {"query": "Name the riskiest assumption in the new pricing model", "should_trigger": true},
+  {"query": "What's the kill condition for the AI-summary feature?", "should_trigger": true},
+  {"query": "Is this a one-way door? Help me de-risk it before we proceed", "should_trigger": true},
+  {"query": "Run a quick validation on whether teams will adopt the dashboard", "should_trigger": true},
+
+  {"query": "Shape this idea into an intent", "should_trigger": false},
+  {"query": "Frame the problem behind the pricing change", "should_trigger": false},
+  {"query": "What's the intent behind the pricing change?", "should_trigger": false},
+  {"query": "Break this de-risked intent into specs", "should_trigger": false},
+  {"query": "Slice the marketplace intent into child intents", "should_trigger": false},
+  {"query": "Write the spec for SSO", "should_trigger": false},
+  {"query": "What should the empty state say?", "should_trigger": false},
+  {"query": "Coordinate delivery across our component repos", "should_trigger": false},
+  {"query": "Diagram the marketplace architecture", "should_trigger": false}
+]

--- a/packs/product-engineering/.apm/skills/decompose-intent/evals/eval_queries.json
+++ b/packs/product-engineering/.apm/skills/decompose-intent/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "Decompose this intent into child intents", "should_trigger": true},
+  {"query": "Break this capability down into shippable specs", "should_trigger": true},
+  {"query": "Slice the onboarding intent into deliverable pieces", "should_trigger": true},
+  {"query": "What specs come out of the marketplace intent?", "should_trigger": true},
+  {"query": "Push these child intents to Linear", "should_trigger": true},
+  {"query": "Break this down one level — what's next under it?", "should_trigger": true},
+  {"query": "Cut this intent into a spec at the leaf", "should_trigger": true},
+  {"query": "Project this decomposition onto our Jira board", "should_trigger": true},
+  {"query": "What's the next level down from this capability intent?", "should_trigger": true},
+
+  {"query": "Shape this idea into an intent", "should_trigger": false},
+  {"query": "What's the intent behind onboarding?", "should_trigger": false},
+  {"query": "Test whether this intent's bet holds", "should_trigger": false},
+  {"query": "Is the core assumption true before we commit?", "should_trigger": false},
+  {"query": "Set up the value-stream meta-repo for the program", "should_trigger": false},
+  {"query": "Decompose this 40-page PRD we got from the client", "should_trigger": false},
+  {"query": "Write the spec for the leaf feature", "should_trigger": false},
+  {"query": "Fix the failing onboarding test", "should_trigger": false},
+  {"query": "What should this button be labeled?", "should_trigger": false}
+]

--- a/packs/product-engineering/.apm/skills/frame-intent/evals/eval_queries.json
+++ b/packs/product-engineering/.apm/skills/frame-intent/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "Shape this idea into an intent before we spec it", "should_trigger": true},
+  {"query": "What's the intent behind the new referral program?", "should_trigger": true},
+  {"query": "Frame the problem we're actually solving with notifications", "should_trigger": true},
+  {"query": "Before we build the loyalty feature, let's get the intent down", "should_trigger": true},
+  {"query": "Turn this rough request into a product brief", "should_trigger": true},
+  {"query": "Help me articulate the outcome we want from the onboarding redesign", "should_trigger": true},
+  {"query": "We have a strategy doc — frame the capability intent from it", "should_trigger": true},
+  {"query": "Write a PRD-style intent for self-serve signup", "should_trigger": true},
+  {"query": "What outcome and opportunity are we chasing with the new dashboard?", "should_trigger": true},
+
+  {"query": "Test whether this bet holds before we build it", "should_trigger": false},
+  {"query": "What's the riskiest assumption in this intent?", "should_trigger": false},
+  {"query": "Break this intent down into shippable specs", "should_trigger": false},
+  {"query": "Slice this capability into child intents", "should_trigger": false},
+  {"query": "Should we validate this assumption or just build it?", "should_trigger": false},
+  {"query": "What should this error message say?", "should_trigger": false},
+  {"query": "Set up a value-stream meta-repo for the program", "should_trigger": false},
+  {"query": "Write the spec for the referral feature", "should_trigger": false},
+  {"query": "Fix the broken signup redirect", "should_trigger": false}
+]

--- a/packs/product-engineering/.apm/skills/voice-and-microcopy/evals/eval_queries.json
+++ b/packs/product-engineering/.apm/skills/voice-and-microcopy/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "What should this error message say?", "should_trigger": true},
+  {"query": "Write the empty-state copy for the inbox", "should_trigger": true},
+  {"query": "Name this button — it submits the form", "should_trigger": true},
+  {"query": "Characterize our product's voice", "should_trigger": true},
+  {"query": "Make this microcopy blame-free", "should_trigger": true},
+  {"query": "Review this copy before it ships", "should_trigger": true},
+  {"query": "Write the label for the password field", "should_trigger": true},
+  {"query": "Our error toasts feel harsh — rewrite them to be kind", "should_trigger": true},
+  {"query": "What should the loading-state text say?", "should_trigger": true},
+
+  {"query": "Shape the intent behind the onboarding feature", "should_trigger": false},
+  {"query": "Write a tutorial for the export feature", "should_trigger": false},
+  {"query": "Design the empty-state layout and visual hierarchy", "should_trigger": false},
+  {"query": "Write the API error-response schema", "should_trigger": false},
+  {"query": "Decompose this intent into specs", "should_trigger": false},
+  {"query": "What's the intent behind the new dashboard?", "should_trigger": false},
+  {"query": "Document how to rotate an API token", "should_trigger": false},
+  {"query": "Write the release notes for v2", "should_trigger": false},
+  {"query": "Critique this design doc", "should_trigger": false}
+]

--- a/packs/product-engineering/.claude-plugin/plugin.json
+++ b/packs/product-engineering/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "product-engineering",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Shape product intent into shippable specs — and into the words users read. Habits — frame-intent, de-risk-intent, decompose-intent — over a recursive, level-tagged `intent` (a capability intent and a feature intent are the same artifact at different levels): outcome+opportunity framing, a choosable prototype-approach to de-risk the riskiest assumption, and decomposition into the briefs/specs your delivery loop already builds — at app scale, or sliced per component across a business-unit value stream coordinated by `align-value-stream`. `voice-and-microcopy` adds the content layer: characterize a product's voice and write blame-free, actionable UI copy. Pure-markdown, user-scope."
 }

--- a/packs/product-engineering/pack.toml
+++ b/packs/product-engineering/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "product-engineering"
-version = "0.5.0"
+version = "0.5.1"
 description = "Shape product intent into shippable specs — and into the words users read. Habits — frame-intent, de-risk-intent, decompose-intent — over a recursive, level-tagged `intent` (a capability intent and a feature intent are the same artifact at different levels): outcome+opportunity framing, a choosable prototype-approach to de-risk the riskiest assumption, and decomposition into the briefs/specs your delivery loop already builds — at app scale, or sliced per component across a business-unit value stream coordinated by `align-value-stream`. `voice-and-microcopy` adds the content layer: characterize a product's voice and write blame-free, actionable UI copy. Pure-markdown, user-scope."
 readme = "README.md"
 display_name = "Product Engineering"
@@ -32,6 +32,13 @@ allowed-adapters = ["claude-code", "kiro-ide", "codex", "copilot", "cursor", "ge
 # the skill's references/agentbundle-layout.md).
 [pack.layout.repo]
 parent = "docs/product"
+
+# pack-activation-evals (RFC-0037 / ADR-0028) — pack-eval-coverage-rollout:
+# the Tier-A activation-eval coverage allowlist. Each listed skill ships
+# evals/eval_queries.json and is measured by tools/run-pack-evals.py. All five
+# skills are user-prompt-triggered, so none are excluded.
+[pack.evals]
+skills = ["frame-intent", "de-risk-intent", "decompose-intent", "align-value-stream", "voice-and-microcopy"]
 
 # enriched-pack-manifest (RFC-0031 / ADR-0021): catalogue-facing links
 # + maintainer, including the `documentation` link to the per-pack guide home.


### PR DESCRIPTION
## What & why

Backfills the **Tier-A activation** layer (`evals/eval_queries.json` + a `[pack.evals]` block) on the five packs that already carried an LLM-judge rubric (architect, product-engineering) or are credentialed/backend skills (figma, atlassian) but had **skipped the cheaper activation layer underneath**. Tracked under `pack-eval-coverage-rollout` in `docs/backlog.md`; pattern copied from `packs/core`.

**Activation only** — the existing `evals/evals.json` judge rubrics in architect/product-engineering are untouched.

| pack | skills covered | bump |
| --- | --- | --- |
| architect | architect-design, architect-diagram, architect-review (3) | 0.7.0 → 0.7.1 |
| product-engineering | frame-intent, de-risk-intent, decompose-intent, align-value-stream, voice-and-microcopy (5) | 0.5.0 → 0.5.1 |
| contracts | api-contract, event-contract (2) | 0.3.2 → 0.3.3 |
| figma | figma (1) | 0.1.3 → 0.1.4 |
| atlassian | jira, jira-align, jira-brief-intake, jira-defect-flow, flow-metrics, confluence-crawler, confluence-publisher, ai-adoption-report (8) | 0.3.0 → 0.3.1 |

Each file carries ~9–10 should-trigger + ~9–10 near-miss should-NOT-trigger. **No exclusions** — all 19 are user-prompt-triggered (unlike core's work-loop / security-checklists).

## Sibling mis-routing is the high-value near-miss class

The tightly-clustered **atlassian** (8) and **product-engineering** (5) sets carry a deliberate chunk of negatives that route to a *sibling*, not just unrelated prompts — e.g. "show me sprint cycle time" → `flow-metrics` not `jira`; "publish this page to Confluence" → `confluence-publisher` not `confluence-crawler`; "compare our flow metrics to pre-AI" → `ai-adoption-report` not `flow-metrics`; "turn PROJ-100 into specs" → `jira-brief-intake` not `jira`; "test whether this bet holds" → `de-risk-intent` not `frame-intent`.

**Credentialed packs (figma, atlassian) need NO backend credentials** — activation is observed at the Skill-router level before the skill body runs, so a Figma/Atlassian login is irrelevant to whether the skill fires.

## Verification (the four questions)

- **What does this change do?** Adds 19 `eval_queries.json` files + 5 `[pack.evals]` blocks + patch-bumps; refreshes `marketplace.json`.
- **How do I know it works?** `python tools/lint-skill-spec.py` green (eval_queries schema + `[pack.evals]` coverage); `make build-check` green. A bounded **headless spot-check** (claude 2.1.185) graded all queries correctly — recorded in `docs/specs/pack-activation-evals/notes/manual-qa.md` §11. The full activation sweep is the scheduled `pack-evals.yml`'s job, not this PR.
- **What did review catch?** The spot-check + adversarial review found that `jira` (broad catch-all) over-fires on bare metrics prompts. jira's two metrics-flavored negatives (which reused flow-metrics' positives verbatim) were replaced with non-duplicate workflow-outcome sibling near-misses; the metrics→flow-metrics routing stays covered by flow-metrics' own positives. Logged in §11 as a known calibration item for the scheduled sweep (report-only, never a PR gate).
- **What's the risk?** Low. Static eval data + version bumps + docs — no security boundary, no logic. All five packs are `default-scope = "user"`, so `make build-self` moved **only** `marketplace.json` (verified: nothing under `.claude/`/`.agents/`).

## Spec/doc status
`pack-activation-evals` spec stays **Shipped** (the mechanism shipped earlier; this is coverage expansion tracked in the backlog, like the prior `design-craft` / `governance-extras` / `user-guide-diataxis` rollouts). `lint-spec-status.py` reports spec metadata clean. Backlog `pack-eval-coverage-rollout` Tier 1 + Tier 3 updated; manual-qa §11 added.