### PR TITLE
feat(operational-safety): operational-safety reference library for infra/destructive work (core 0.4.13)

### DIFF
--- a/.agents/skills/operational-safety/SKILL.md
+++ b/.agents/skills/operational-safety/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: operational-safety
+description: Progressive-disclosure operational-safety-depth modules for the quality-engineer reviewer. Holds six failure-mode-keyed checklists (state-and-idempotency, blast-radius, environment-isolation, cost-and-teardown, drift-and-rollback, observability-and-smoke) as references/, each grounded in standing operational taxonomy (AWS Well-Architected, Google SRE, the Terraform/Pulumi Day-1/Day-2 split). The work-loop's orchestrator loads only the matching modules and inlines them into the quality-engineer's brief when infra/destructive work is detected; the subagent never self-discovers this skill. Not a reviewer prompt itself — it is the depth library the reviewer reasons from. Carves against security-checklists on the reliability-vs-security lens — security-checklists owns security config while operational-safety owns reliability/ops config.
+---
+
+# Skill: operational-safety
+
+This skill is the **depth library** behind the `quality-engineer` agent for
+infrastructure and destructive operational work. The reviewer's body carries
+the *universal method* (its testability / observability / reliability /
+maintainability lens, the severity rubric, the report format). The
+*shape-specific depth* — what to actually check at each operational failure
+mode — lives here, in six `references/<module>.md` modules, so the agent prompt
+stays lean and the depth scales without bloat. It is the operational-lens twin
+of [`security-checklists`](../security-checklists/SKILL.md), built on the same
+orchestrator-loaded, table-routed mechanism — **no new reviewer** (the CHARTER
+three-reviewer ceiling; ADR-0023), no executable code (ADR-0031).
+
+## How it loads (orchestrator-driven, not self-discovered)
+
+**The orchestrator drives loading; the subagent does not.** There is no
+mechanism to force a subagent to invoke a skill, skill discovery is
+model-invoked and adapter-variable, and the `quality-engineer`'s `tools:` list
+does not include a Skill tool. So depth must not depend on the reviewer finding
+this library itself.
+
+Concretely, at the work-loop's REVIEW `quality-engineer` step, when the change
+is infra/destructive (the destructive/irreversible risk trigger routed it to
+full mode, and the diff touches IaC / deploy config / a stateful migration),
+the orchestrator:
+
+1. Detects which **operational failure modes** the diff or spec crosses.
+2. Loads **only the matching modules** via the deterministic failure-mode→module
+   routing table in `work-loop/SKILL.md` (the `operational-safety` table,
+   beside the `security-checklists` one).
+3. **Inlines the selected modules' content** into the `quality-engineer`
+   subagent's brief — so the reviewer receives a focused checklist as prompt
+   text, never a path to resolve.
+
+Loaded 1–N per the routing table, never a flat march of all six. Where an
+adapter *does* support subagent skill auto-discovery, that is a redundant
+convenience layered on top — never the load-bearing mechanism.
+
+## The reliability-vs-security carve (load-bearing)
+
+This library and [`security-checklists`](../security-checklists/SKILL.md) split
+infrastructure review along one clean line, and the split must stay clean both
+ways:
+
+- **`security-checklists` owns *security* config.** Over-broad IAM, public
+  exposure, secrets in state, unencrypted-at-rest, metadata SSRF, CORS — the
+  security failure classes. Its `config-misconfig` module is the IaC-security
+  home.
+- **`operational-safety` (this skill) owns *reliability / ops* config.**
+  Idempotent convergence, blast radius, environment isolation, cost/teardown,
+  drift/rollback, observability/smoke — the operational failure classes.
+
+The routing therefore assigns **IaC-security → `config-misconfig`**,
+**IaC-reliability → `operational-safety`**. Do not duplicate security config
+into an operational module, and do not migrate operational config out of where
+it correctly lives. When a check seems to belong to both lenses, ask which
+*failure* it guards against — a leaked credential is security; a half-applied,
+non-convergent stack is reliability.
+
+## The three-bucket delegation legend
+
+Every check in every module is tagged so the reviewer knows who owns it —
+the same legend `security-checklists` uses, read through the operational lens:
+
+- **`tool`** — scanner / CI-gate-owned. Confirm the gate is *wired*; don't
+  re-check by hand. The operational analogs of the security scanners are the
+  policy-as-code / CSPM scanner (which also feeds the security pass), the
+  cost-diff gate, and the plan-parse destroy/replace counter. If the delegated
+  gate is **absent**, do not silently skip: either reason the class best-effort
+  and flag it `degraded: no gate`, or state the gap explicitly. A silent skip
+  is the worst outcome — it looks like coverage.
+- **`hybrid`** — the gate surfaces the signal; *you* judge the fix. A plan
+  diff or a drift report points at the change, but whether the apply converges,
+  whether the destroy is intended, or whether the rollback path is real is
+  reasoning work.
+- **`reason`** — reviewer-only. Whether the loop is genuinely idempotent,
+  whether proposer≠approver holds for a destructive op, whether a smoke probe
+  actually exercises the artifact end-to-end — the classes no scanner sees. The
+  highest-value findings live here.
+
+## Module index
+
+| Module | Operational failure mode | Grounded in |
+|---|---|---|
+| [`state-and-idempotency`](references/state-and-idempotency.md) | convergent re-apply, state locking, single-writer | F1.2, F1.3 |
+| [`blast-radius`](references/blast-radius.md) | destroy/replace gating, `prevent_destroy`, proposer≠approver | F3.1, F3.2 |
+| [`environment-isolation`](references/environment-isolation.md) | throwaway/staging vs prod, separate state/accounts | F3.3 |
+| [`cost-and-teardown`](references/cost-and-teardown.md) | cost-ceiling-as-gate, destroy-on-fail, TTL, no orphans | F3.4, F3.5 |
+| [`drift-and-rollback`](references/drift-and-rollback.md) | read-only drift detection, known-good re-apply path | F1.4, F2.6 |
+| [`observability-and-smoke`](references/observability-and-smoke.md) | active end-to-end probe, log access, health, verify-status | F2.2; taxonomy follow-up |
+
+`state-and-idempotency` (write-path convergence) and `drift-and-rollback`
+(divergence detection + recovery) are kept **deliberately separate** — every
+major operational taxonomy splits the two (AWS Well-Architected *Change
+Management* vs *Failure Management*; Google SRE *Release Engineering* vs
+*Incident Response*; Terraform `apply` vs `-refresh-only`; Pulumi Day-1 vs
+Day-2). `observability-and-smoke` is its own sixth module, not folded into
+reliability prose, because "load the real URL, confirm render, read the logs to
+debug a failed smoke" is a distinct active-probe + telemetry concern.

--- a/.agents/skills/operational-safety/references/blast-radius.md
+++ b/.agents/skills/operational-safety/references/blast-radius.md
@@ -1,0 +1,50 @@
+# blast-radius — destroy/replace gating, prevent-destroy, proposer≠approver
+
+> **Loaded when:** the change can delete or replace existing infrastructure,
+> alters a resource whose replacement is destructive (a recreated database, a
+> renamed stateful resource), or runs a destroy/teardown path against a shared
+> or production environment.
+> **Grounded in:** F3.1 (parse the plan structurally; gate on destroy/replace
+> counts), F3.2 (decouple proposer identity from approver identity).
+> Operational taxonomy: the destructive-op-needs-human-approval rule already in
+> AGENTS.md "Check before acting".
+> **Delegation legend:** `tool` = scanner / CI-gate-owned · `hybrid` = gate
+> surfaces the signal, you judge the fix · `reason` = reviewer-only judgment.
+
+The cost of a wrong line here is the highest in the loop — a single misjudged
+replace can drop a production datastore. Gate on **what the plan will actually
+destroy**, not on a hopeful read of the diff.
+
+## Implementation checks
+
+- `tool` **Parse the plan structurally; gate on destroy/replace counts.**
+  Compute the planned `delete` / `replace` actions from the machine-readable
+  plan (the structured plan output, not grepped text), and fail the step on a
+  nonzero destructive count unless an explicit override is present. Confirm this
+  parse-and-gate runs before any apply.
+- `reason` **Destructive count never read from text.** Grepping apply logs or
+  the human-readable diff for "destroy" is unreliable; the gate must read the
+  structured plan. Flag any gate that pattern-matches prose.
+- `reason` **Proposer ≠ approver for irreversible ops.** The identity that
+  proposes a destructive change must not be the identity that approves it — the
+  agent proposes, a *different* identity (the human) approves. This maps onto
+  "get user confirmation for destructive commands" in AGENTS.md; flag a path
+  where the agent could self-approve a destroy/replace.
+- `reason` **Must-survive resources are pinned.** Resources that must not be
+  destroyed carry an explicit prevent-destroy guard — and the reviewer notes
+  that such guards are bypassable (removing the block, surgical state edits), so
+  a change that *removes* a prevent-destroy guard is itself a destructive-intent
+  signal worth surfacing.
+
+## Established-pattern bypass
+
+Resolve the repo's sanctioned destructive-op gate — the plan-parse check in CI,
+the required-reviewer environment, the change-approval workflow — and flag a
+change that routes a destroy around it (a direct teardown command, a
+`--auto-approve` on a destructive apply). The blessed gate is where
+proposer≠approver was already enforced.
+
+*Illustrative only (never normative):* `plan -out` → structured-plan parse →
+count `delete`/`replace`, or a required-reviewer rule on a protected
+environment, exhibit this shape — but the check is the *property*
+(parsed-plan gating + identity separation), not any one tool.

--- a/.agents/skills/operational-safety/references/cost-and-teardown.md
+++ b/.agents/skills/operational-safety/references/cost-and-teardown.md
@@ -1,0 +1,48 @@
+# cost-and-teardown — cost-ceiling-as-gate, destroy-on-fail, TTL, no orphans
+
+> **Loaded when:** the change provisions billable resources, creates ephemeral
+> or per-iteration infrastructure, or runs a teardown path — anything that can
+> leave a paid-for resource running after the work is done.
+> **Grounded in:** F3.4 (cost is a first-class CI gate, not a post-deploy
+> surprise), F3.5 (tag-at-creation TTL + destroy-on-close prevents orphans;
+> destroy needs its own plan). Operational taxonomy: AWS Well-Architected Cost
+> Optimization; the ephemeral-environment lifecycle pattern.
+> **Delegation legend:** `tool` = scanner / CI-gate-owned · `hybrid` = gate
+> surfaces the signal, you judge the fix · `reason` = reviewer-only judgment.
+
+An agentic loop that provisions on each iteration leaks money invisibly: the
+failure mode is not a crash but a bill. Estimate cost **from the plan, before
+apply**, and make teardown as deliberate as creation.
+
+## Implementation checks
+
+- `tool` **Cost is estimated from the plan and gated on a ceiling.** A
+  cost-diff runs on the planned change and a budget ceiling (absolute, percent,
+  or budget) blocks the apply when exceeded. Confirm the cost gate is wired; if
+  none is detected, flag `degraded: no cost gate` rather than passing silently.
+- `reason` **Destroy-on-fail / no half-built stacks.** A failed apply or smoke
+  must tear down what it created rather than leaving a partial stack accruing
+  cost. Flag a path where a failed run exits leaving resources up with no
+  cleanup.
+- `reason` **TTL / tag-at-creation for ephemeral resources.** Resources created
+  for iteration carry a TTL or ownership tag a scheduled cleanup can find, so an
+  abandoned run is reclaimable. Untagged, unbounded-lifetime ephemeral resources
+  are the orphan source.
+- `reason` **Destroy has its own plan.** A teardown is a destructive operation
+  in its own right — preview the destroy plan before running it (it inherits the
+  `blast-radius` gating), don't fire an unreviewed bulk destroy.
+- `hybrid` **No orphans after a normal run.** After a successful iterate-and-
+  teardown cycle, no created resource is left behind. Confirm the teardown
+  enumerates everything the apply created.
+
+## Established-pattern bypass
+
+Resolve the repo's sanctioned lifecycle harness — the cost-diff CI gate, the
+ephemeral-environment create/destroy automation, the TTL-tag-and-sweep
+convention — and flag a change that provisions billable resources outside it
+(no cost gate, no teardown, no TTL tag).
+
+*Illustrative only (never normative):* a cost-diff status check on PRs plus a
+TTL tag swept by a scheduled cleanup, or create-on-open / destroy-on-close
+per-PR environments, exhibit this shape — but the check is the *property*
+(cost-as-gate + bounded lifecycle + no orphans), not any one tool.

--- a/.agents/skills/operational-safety/references/drift-and-rollback.md
+++ b/.agents/skills/operational-safety/references/drift-and-rollback.md
@@ -1,0 +1,67 @@
+# drift-and-rollback — read-only drift detection, known-good re-apply path
+
+> **Loaded when:** the change manages long-lived infrastructure that can drift
+> from its declared state, or where a deploy needs a defined recovery path if
+> the smoke probe fails.
+> **Grounded in:** F1.4 (drift detection is read-only and separable from
+> remediation; auto-remediation default is contested), F2.6 (no atomic
+> rollback — re-apply the prior known-good config). Operational taxonomy: AWS
+> Well-Architected Failure Management; Google SRE Incident Response; Pulumi
+> Day-2 drift detection + remediation.
+> **Delegation legend:** `tool` = scanner / CI-gate-owned · `hybrid` = gate
+> surfaces the signal, you judge the fix · `reason` = reviewer-only judgment.
+
+This is the **divergence-detection-and-recovery** lens — deliberately separate
+from `state-and-idempotency`'s write-path convergence (every major operational
+taxonomy splits the two). Detection is safe, frequent, and read-only; recovery
+is mutating and gated.
+
+## Implementation checks
+
+- `reason` **Drift detection is read-only.** The "are we drifted?" check must
+  not mutate — it compares declared vs. live state and reports, separate from
+  any remediation step. Flag a detection path that silently corrects as it
+  reads.
+- `reason` **A known-good re-apply path is named *before* the first apply.**
+  There is no atomic rollback for a partially applied deploy; the recovery path
+  is re-applying the previous versioned known-good config, not state surgery.
+  Confirm this path is named in the plan's `## Rollout` (the work-loop's infra
+  verification mode requires it before the first apply).
+- `reason` **Early detection over hard rollback.** Because rollback is hard,
+  small increments and a real smoke probe (see `observability-and-smoke`) are
+  what keep rollback rarely needed. Flag a large, all-at-once apply with no
+  early-detection layer in front of it.
+
+## The auto-remediation default — an unresolved tension (surface, do not resolve)
+
+Whether detected drift should be **gated** (detect → alert → a human decides
+whether to re-apply) or **auto-synced** (continuously reconcile, auto-reverting
+any out-of-band change) is a **genuine, unresolved tension** — both defaults are
+well-evidenced under different conditions:
+
+- **Gate it** — the Terraform-community default: detection is read-only and
+  remediation is a separate, human-gated step, because an auto-revert can stomp
+  a legitimate emergency hotfix applied out-of-band.
+- **Auto-sync** — the GitOps default (Argo CD, Flux): continuous reconciliation
+  treats the declared state as the single source of truth and auto-reverts
+  drift, because allowing drift to persist is itself the risk.
+
+**This module surfaces the tension; it does not pick a side.** When reviewing,
+name which default the change assumes and whether that default fits *this*
+resource's risk profile — an auto-syncing reconciler on a resource that takes
+legitimate emergency edits is a finding; a gated detector on a
+must-never-drift security control may be too lax. The right answer is
+context-dependent, so flag a mismatch, don't impose one default.
+
+## Established-pattern bypass
+
+Resolve the repo's sanctioned drift / recovery model — the scheduled read-only
+drift check, the versioned-config re-apply runbook, the GitOps reconciler — and
+flag a change that introduces a divergent recovery story (state surgery as the
+rollback plan, an auto-sync reconciler bolted onto a gated environment).
+
+*Illustrative only (never normative):* `plan -refresh-only` for read-only
+drift, re-applying a previous tagged config for recovery, or an Argo CD / Flux
+reconciler for auto-sync, exhibit these shapes — but the checks are the
+*properties* (read-only detection, a named re-apply path, a context-fit
+remediation default), not any one tool.

--- a/.agents/skills/operational-safety/references/environment-isolation.md
+++ b/.agents/skills/operational-safety/references/environment-isolation.md
@@ -1,0 +1,45 @@
+# environment-isolation — throwaway/staging vs prod, separate state/accounts
+
+> **Loaded when:** the change provisions or iterates against an environment
+> that is, or could touch, production — or where the iteration loop needs a
+> safe place to fail that is not prod.
+> **Grounded in:** F3.3 (environment isolation by account/state boundary).
+> Operational taxonomy: AWS multi-account-per-stage; separate state backends as
+> the IaC-level isolation enforcement.
+> **Delegation legend:** `tool` = scanner / CI-gate-owned · `hybrid` = gate
+> surfaces the signal, you judge the fix · `reason` = reviewer-only judgment.
+
+Iterate **away from prod**. The strongest isolation unit is the
+account / subscription / project boundary; separate state enforces it in IaC.
+The agentic refinement loop — apply, observe, fix, re-apply — belongs in a
+throwaway or staging environment, never against the production stack.
+
+## Implementation checks
+
+- `reason` **Iteration target is not prod.** The change's apply/test/teardown
+  loop runs against a throwaway or staging environment isolated from
+  production. Flag any iteration that converges by repeatedly applying to prod.
+- `reason` **State backends are separated by stage.** Staging credentials and
+  state cannot reach production resources — separate state backends (not a
+  shared backend with a workspace toggle that a typo can cross) enforce the
+  boundary. A single shared state across stages is the finding.
+- `reason` **Account / subscription / project boundary where the blast radius
+  warrants it.** For high-blast-radius infra, the strongest isolation is a
+  distinct account boundary with guardrail policies, not just a namespace. Note
+  where the isolation is weaker than the blast radius justifies.
+- `hybrid` **Credentials are stage-scoped.** The credentials the change runs
+  under are scoped to the target stage; a smoke or teardown step cannot
+  accidentally authenticate against prod. Confirm the scoping; judge whether the
+  scope is genuinely narrow.
+
+## Established-pattern bypass
+
+Resolve the repo's sanctioned environment model — the per-stage account map,
+the separate-state convention, the ephemeral-per-PR environment harness — and
+flag a change that points a new resource at the shared/prod backend instead of
+the stage-isolated one.
+
+*Illustrative only (never normative):* an AWS account-per-stage layout with
+separate Terraform state backends, or per-PR ephemeral environments, exhibit
+this shape — but the check is the *property* (isolation by account/state
+boundary), not any one tool or cloud.

--- a/.agents/skills/operational-safety/references/environment-isolation.md
+++ b/.agents/skills/operational-safety/references/environment-isolation.md
@@ -30,7 +30,10 @@ throwaway or staging environment, never against the production stack.
 - `hybrid` **Credentials are stage-scoped.** The credentials the change runs
   under are scoped to the target stage; a smoke or teardown step cannot
   accidentally authenticate against prod. Confirm the scoping; judge whether the
-  scope is genuinely narrow.
+  scope is genuinely narrow. *(Carve note: the failure guarded here is the
+  iteration loop converging on prod — a reliability/blast-containment failure;
+  whether a grant is over-broad for **privilege-escalation** purposes is the
+  security lens, owned by `security-checklists`' `config-misconfig`.)*
 
 ## Established-pattern bypass
 

--- a/.agents/skills/operational-safety/references/observability-and-smoke.md
+++ b/.agents/skills/operational-safety/references/observability-and-smoke.md
@@ -1,0 +1,52 @@
+# observability-and-smoke — active end-to-end probe, log access, health, verify-status
+
+> **Loaded when:** the change deploys a service, site, or endpoint a user
+> reaches — anything where "created" does not yet mean "works" and the deploy
+> needs an active probe plus the telemetry to debug a failed one.
+> **Grounded in:** F2.2 ("created" ≠ "works"; smoke / health checks are
+> mandatory before promotion); taxonomy follow-up — AWS Well-Architected
+> Operational Excellence (understand operational health), Google SRE monitoring
+> as a first-class practice.
+> **Delegation legend:** `tool` = scanner / CI-gate-owned · `hybrid` = gate
+> surfaces the signal, you judge the fix · `reason` = reviewer-only judgment.
+
+A provisioned resource is not a working one. This module is the operational
+extension of the work-loop's visual/manual-QA doctrine ("exercise the real
+built artifact end-to-end") to a deployed system — and the observability that
+lets the agent **debug a failed smoke itself** rather than relay errors to a
+human.
+
+## Implementation checks
+
+- `reason` **Active end-to-end smoke, not a status check.** The verification is
+  a multi-hop probe: seed test / mock users → load the **real** CDN / site URL
+  → assert it actually renders → on failure, pull access / error logs and debug
+  → tear down. A single "stack status: CREATE_COMPLETE" is not a smoke test —
+  flag a deploy whose only post-apply check is resource status.
+- `reason` **A verify-status signal exists.** There is a defined signal that
+  answers "did the deploy report healthy?" — a health endpoint, a post-apply
+  runtime assertion — distinct from the provisioning tool's own exit code.
+- `hybrid` **Access / error logs are reachable for debugging.** When the smoke
+  fails, the logs needed to diagnose it (access logs, error logs, the
+  application's own telemetry) are accessible to the agent driving the deploy —
+  log-driven debugging is the loop, not a human relaying the error back.
+- `reason` **Health / telemetry is designed in, not bolted on.** The service
+  exposes the operational health signals (health endpoint, the key
+  golden-signal metrics) the smoke and ongoing operation depend on. Missing
+  observability is a reliability finding, not a nice-to-have.
+- `reason` **Seed + teardown bracket the probe.** The smoke seeds the test data
+  / mock users it needs and tears them (and any ephemeral resources) down after
+  — so the probe is repeatable and leaves no residue (this meets
+  `cost-and-teardown`).
+
+## Established-pattern bypass
+
+Resolve the repo's sanctioned smoke / observability harness — the end-to-end
+probe script, the health-endpoint convention, the log-access path the deploy
+pipeline already wires — and flag a deploy that declares success on
+provisioning status alone, with no active probe and no reachable logs.
+
+*Illustrative only (never normative):* a post-apply HTTP assertion against the
+live URL plus structured access/error logs, or a deploy-validate-undeploy probe
+harness, exhibit this shape — but the check is the *property* (active
+end-to-end probe + reachable telemetry), not any one tool.

--- a/.agents/skills/operational-safety/references/state-and-idempotency.md
+++ b/.agents/skills/operational-safety/references/state-and-idempotency.md
@@ -1,0 +1,50 @@
+# state-and-idempotency — convergent re-apply, state locking, single-writer
+
+> **Loaded when:** the change provisions or mutates infrastructure, edits
+> infrastructure-as-code, or drives a stateful migration of a running system —
+> anything where the *write path* may be re-run after a failure.
+> **Grounded in:** F1.2 (declarative + idempotent re-apply is what makes retry
+> safe; imperative scripts collide), F1.3 (shared state needs a single-writer
+> lock). Operational taxonomy: AWS Well-Architected Change Management; the
+> Terraform/Pulumi declarative-convergence model.
+> **Delegation legend:** `tool` = scanner / CI-gate-owned · `hybrid` = gate
+> surfaces the signal, you judge the fix · `reason` = reviewer-only judgment.
+
+Idempotent convergent apply is the **precondition the whole infra loop rests
+on**: re-running after a fix must *converge, not collide*. A non-idempotent
+imperative step is the retry-collision root cause — the thing to fix first
+rather than iterate around.
+
+## Implementation checks
+
+- `reason` **Convergent re-apply.** Re-running the change from a partially
+  applied state must reach the desired state with no duplicate creates and no
+  inconsistent leftovers ("if already in desired state, no actions taken").
+  Declarative definitions get this structurally; an imperative script must add
+  existence-check / conditional-create guards to match it. Flag any step that
+  would re-create an existing resource or error on a second run.
+- `reason` **No imperative non-idempotent step on the write path.** A
+  hand-rolled create/start/stop sequence with no guard is the
+  "manual stop/start errors" failure mode — each failed retry is a fresh mess.
+  Require the guard, or convert the step to declarative.
+- `hybrid` **Single-writer lock on shared state.** When an agent and a human,
+  or two agents, could apply against the same state concurrently, mutation must
+  serialize through a state lock. Confirm the lock mechanism is configured;
+  judge whether the concurrency window is actually closed.
+- `reason` **State integrity over the retry.** A failed apply must not leave
+  state and live resources diverged in a way the next apply can't reconcile.
+  The next run should *read* current reality and converge, not assume the prior
+  run's intent.
+
+## Established-pattern bypass
+
+Resolve the repo's sanctioned convergence mechanism — the declarative IaC
+module, the shared apply wrapper, the locked state backend — and flag a change
+that hand-rolls an imperative provisioning sequence inline instead of extending
+it. The blessed mechanism is where idempotency and single-writer locking were
+already decided, once.
+
+*Illustrative only (never normative):* a `terraform apply` against a
+lock-enabled S3 backend, or a Pulumi `up` against a locked stack, exhibit this
+shape — but the check is the *property* (convergent, single-writer), not any
+one tool.

--- a/.agents/skills/security-checklists/SKILL.md
+++ b/.agents/skills/security-checklists/SKILL.md
@@ -13,6 +13,14 @@ footer, the output format). The *shape-specific depth* — what to actually
 check at each trust boundary — lives here, in ten `references/<module>.md`
 modules, so the agent prompt stays lean and the depth scales without bloat.
 
+> **Reliability-vs-security carve.** This library owns *security* config; the
+> *reliability / ops* side of infrastructure (idempotent convergence, blast
+> radius, environment isolation, cost/teardown, drift/rollback,
+> observability/smoke) lives in the [`operational-safety`](../operational-safety/SKILL.md)
+> skill, consumed by `quality-engineer`. The routing splits IaC-security →
+> `config-misconfig`, IaC-reliability → `operational-safety`. The two are
+> complementary lenses on the same infra diff — keep the split clean both ways.
+
 ## How it loads (orchestrator-driven, not self-discovered)
 
 **The orchestrator drives loading; the subagent does not.** There is no

--- a/.agents/skills/security-checklists/references/config-misconfig.md
+++ b/.agents/skills/security-checklists/references/config-misconfig.md
@@ -36,6 +36,38 @@ V14; Proactive Controls 2024 C5).
   `Content-Security-Policy`, TLS verification disabled, or downgraded
   protocol/cipher settings.
 
+## Deferred authority (per-provider secure-config depth)
+
+This module reasons from cross-cutting standards and catches security failure
+*classes*; it deliberately does **not** carry per-provider secure-config
+baselines (they would be stale on arrival and break tool-neutrality). The
+per-provider depth lives in two places, named here by **stable publisher +
+document, with no URL and no version** so the pointer stays evergreen by naming
+rather than linking:
+
+- **CIS Benchmarks** — the per-service hardening baselines.
+- **AWS Well-Architected Security Pillar**, **Microsoft Cloud Adoption
+  Framework / Azure Well-Architected Security**, and **Google Cloud
+  Architecture Framework (Security)** — each provider's standing
+  well-architected security guidance.
+
+The **actual, current per-provider depth lives in the self-updating
+policy-as-code / CSPM scanner** the work-loop's infra preflight requires (its
+vendor-maintained rulesets *are* these baselines, kept fresh by the vendor) —
+not in this pointer. A stale name here never gates a real check; the scanner
+does. Confirm the scanner is wired (the `tool` bullet above) rather than
+re-deriving provider baselines by hand.
+
+## The reliability-vs-security carve
+
+This module owns **IaC *security* config** (IAM, CORS, public exposure, secrets
+posture, TLS). The **reliability / ops** side of infrastructure — idempotent
+convergence, blast radius, environment isolation, cost/teardown, drift/rollback,
+observability/smoke — lives in the **`operational-safety`** skill, consumed by
+`quality-engineer`. Route IaC-security here; route IaC-reliability there. Don't
+pull operational checks into this module, and don't let security config drift
+into an operational one.
+
 ## Established-helper bypass
 
 Resolve the repo's sanctioned config/module (the hardened web-server base, the

--- a/.agents/skills/work-loop/SKILL.md
+++ b/.agents/skills/work-loop/SKILL.md
@@ -704,6 +704,39 @@ note in the summary, not a blocker.
   Different lens from adversarial-reviewer — don't skip it because the spec
   already shipped.
 
+  **Inline operational depth on infra/destructive work, don't make it
+  self-discover.** When the diff is **infra-flavored** — the
+  **destructive/irreversible risk trigger** routed it to full mode *and* it
+  provisions, mutates, deploys, or tears down infrastructure — the
+  `quality-engineer` is the consumer of a second progressive-disclosure depth
+  library, [`operational-safety`](../operational-safety/SKILL.md), exactly as
+  `security-reviewer` consumes `security-checklists`. Detect which operational
+  failure modes the change raises, load **only** the matching
+  `operational-safety` modules, and inline their content into the subagent's
+  brief (reusing the same on-demand `references/*.md` loading) — the
+  `quality-engineer`'s `tools:` has no Skill tool, so loading is
+  orchestrator-driven, not model-relevance-judged. **No new reviewer** — this
+  feeds the existing `quality-engineer` (ADR-0023). Route deterministically:
+
+  <a id="operational-safety-routing-table"></a>
+
+  | Operational failure mode the infra/destructive change raises | Inline module(s) |
+  | --- | --- |
+  | Provisioning or mutating infra; stateful migration; any re-runnable write path | `state-and-idempotency` |
+  | Can delete or replace existing infra; destroy/teardown path; removing a prevent-destroy guard | `blast-radius` |
+  | Iterating against (or able to touch) production; shared vs throwaway/staging state | `environment-isolation` |
+  | Provisions billable resources; ephemeral/per-iteration infra; teardown path | `cost-and-teardown` |
+  | Long-lived infra that can drift; a deploy needing a defined recovery path | `drift-and-rollback` |
+  | Deploys a service / site / endpoint a user reaches; needs smoke + telemetry | `observability-and-smoke` |
+
+  Load 1–N modules as the change warrants, **never a flat march of all six** —
+  a one-line config tweak pulls one; a new public-facing stack pulls several.
+  This is the operational twin of the `security-checklists` routing table
+  above, and the **reliability-vs-security carve** holds: IaC-security →
+  `config-misconfig` (the `security-reviewer` pass); IaC-reliability →
+  `operational-safety` (this pass). The two passes are complementary lenses on
+  the same infra diff, not substitutes.
+
 **Dispatch reviewers in parallel when you invoke more than one** per
 the [Parallel dispatch discipline](#parallel-dispatch-discipline)
 documented under EXECUTE — the same rules cover both fan-out sites in

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -87,7 +87,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "core",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.4.12"
+      "version": "0.4.13"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/.claude/agents/quality-engineer.md
+++ b/.claude/agents/quality-engineer.md
@@ -38,6 +38,17 @@ from the prompt and say which you picked.
    local test style before recommending against it).
 5. Any `packages/<name>/AGENTS.md` for the package being changed —
    per-package test conventions live there.
+6. **On infra/destructive work: the `operational-safety` modules the
+   orchestrator inlined into your brief.** When the change provisions,
+   mutates, deploys, or tears down infrastructure, the work-loop detects which
+   operational failure modes it raises and inlines only the matching
+   `operational-safety` modules (idempotency, blast radius, environment
+   isolation, cost/teardown, drift/rollback, observability/smoke) as prompt
+   text — that is your operational depth reference for this change, the
+   reliability-side twin of how `security-reviewer` consumes `security-checklists`.
+   You do **not** load the skill yourself; if no modules were inlined, fall back
+   to your own reliability/observability checklists and say so. **You remain the
+   consumer — no new reviewer is added** for operational safety.
 
 If you skip step 1 you cannot do your job — recommending a test style
 the repo has already rejected is the most common quality-reviewer

--- a/.claude/skills/operational-safety/SKILL.md
+++ b/.claude/skills/operational-safety/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: operational-safety
+description: Progressive-disclosure operational-safety-depth modules for the quality-engineer reviewer. Holds six failure-mode-keyed checklists (state-and-idempotency, blast-radius, environment-isolation, cost-and-teardown, drift-and-rollback, observability-and-smoke) as references/, each grounded in standing operational taxonomy (AWS Well-Architected, Google SRE, the Terraform/Pulumi Day-1/Day-2 split). The work-loop's orchestrator loads only the matching modules and inlines them into the quality-engineer's brief when infra/destructive work is detected; the subagent never self-discovers this skill. Not a reviewer prompt itself — it is the depth library the reviewer reasons from. Carves against security-checklists on the reliability-vs-security lens — security-checklists owns security config while operational-safety owns reliability/ops config.
+---
+
+# Skill: operational-safety
+
+This skill is the **depth library** behind the `quality-engineer` agent for
+infrastructure and destructive operational work. The reviewer's body carries
+the *universal method* (its testability / observability / reliability /
+maintainability lens, the severity rubric, the report format). The
+*shape-specific depth* — what to actually check at each operational failure
+mode — lives here, in six `references/<module>.md` modules, so the agent prompt
+stays lean and the depth scales without bloat. It is the operational-lens twin
+of [`security-checklists`](../security-checklists/SKILL.md), built on the same
+orchestrator-loaded, table-routed mechanism — **no new reviewer** (the CHARTER
+three-reviewer ceiling; ADR-0023), no executable code (ADR-0031).
+
+## How it loads (orchestrator-driven, not self-discovered)
+
+**The orchestrator drives loading; the subagent does not.** There is no
+mechanism to force a subagent to invoke a skill, skill discovery is
+model-invoked and adapter-variable, and the `quality-engineer`'s `tools:` list
+does not include a Skill tool. So depth must not depend on the reviewer finding
+this library itself.
+
+Concretely, at the work-loop's REVIEW `quality-engineer` step, when the change
+is infra/destructive (the destructive/irreversible risk trigger routed it to
+full mode, and the diff touches IaC / deploy config / a stateful migration),
+the orchestrator:
+
+1. Detects which **operational failure modes** the diff or spec crosses.
+2. Loads **only the matching modules** via the deterministic failure-mode→module
+   routing table in `work-loop/SKILL.md` (the `operational-safety` table,
+   beside the `security-checklists` one).
+3. **Inlines the selected modules' content** into the `quality-engineer`
+   subagent's brief — so the reviewer receives a focused checklist as prompt
+   text, never a path to resolve.
+
+Loaded 1–N per the routing table, never a flat march of all six. Where an
+adapter *does* support subagent skill auto-discovery, that is a redundant
+convenience layered on top — never the load-bearing mechanism.
+
+## The reliability-vs-security carve (load-bearing)
+
+This library and [`security-checklists`](../security-checklists/SKILL.md) split
+infrastructure review along one clean line, and the split must stay clean both
+ways:
+
+- **`security-checklists` owns *security* config.** Over-broad IAM, public
+  exposure, secrets in state, unencrypted-at-rest, metadata SSRF, CORS — the
+  security failure classes. Its `config-misconfig` module is the IaC-security
+  home.
+- **`operational-safety` (this skill) owns *reliability / ops* config.**
+  Idempotent convergence, blast radius, environment isolation, cost/teardown,
+  drift/rollback, observability/smoke — the operational failure classes.
+
+The routing therefore assigns **IaC-security → `config-misconfig`**,
+**IaC-reliability → `operational-safety`**. Do not duplicate security config
+into an operational module, and do not migrate operational config out of where
+it correctly lives. When a check seems to belong to both lenses, ask which
+*failure* it guards against — a leaked credential is security; a half-applied,
+non-convergent stack is reliability.
+
+## The three-bucket delegation legend
+
+Every check in every module is tagged so the reviewer knows who owns it —
+the same legend `security-checklists` uses, read through the operational lens:
+
+- **`tool`** — scanner / CI-gate-owned. Confirm the gate is *wired*; don't
+  re-check by hand. The operational analogs of the security scanners are the
+  policy-as-code / CSPM scanner (which also feeds the security pass), the
+  cost-diff gate, and the plan-parse destroy/replace counter. If the delegated
+  gate is **absent**, do not silently skip: either reason the class best-effort
+  and flag it `degraded: no gate`, or state the gap explicitly. A silent skip
+  is the worst outcome — it looks like coverage.
+- **`hybrid`** — the gate surfaces the signal; *you* judge the fix. A plan
+  diff or a drift report points at the change, but whether the apply converges,
+  whether the destroy is intended, or whether the rollback path is real is
+  reasoning work.
+- **`reason`** — reviewer-only. Whether the loop is genuinely idempotent,
+  whether proposer≠approver holds for a destructive op, whether a smoke probe
+  actually exercises the artifact end-to-end — the classes no scanner sees. The
+  highest-value findings live here.
+
+## Module index
+
+| Module | Operational failure mode | Grounded in |
+|---|---|---|
+| [`state-and-idempotency`](references/state-and-idempotency.md) | convergent re-apply, state locking, single-writer | F1.2, F1.3 |
+| [`blast-radius`](references/blast-radius.md) | destroy/replace gating, `prevent_destroy`, proposer≠approver | F3.1, F3.2 |
+| [`environment-isolation`](references/environment-isolation.md) | throwaway/staging vs prod, separate state/accounts | F3.3 |
+| [`cost-and-teardown`](references/cost-and-teardown.md) | cost-ceiling-as-gate, destroy-on-fail, TTL, no orphans | F3.4, F3.5 |
+| [`drift-and-rollback`](references/drift-and-rollback.md) | read-only drift detection, known-good re-apply path | F1.4, F2.6 |
+| [`observability-and-smoke`](references/observability-and-smoke.md) | active end-to-end probe, log access, health, verify-status | F2.2; taxonomy follow-up |
+
+`state-and-idempotency` (write-path convergence) and `drift-and-rollback`
+(divergence detection + recovery) are kept **deliberately separate** — every
+major operational taxonomy splits the two (AWS Well-Architected *Change
+Management* vs *Failure Management*; Google SRE *Release Engineering* vs
+*Incident Response*; Terraform `apply` vs `-refresh-only`; Pulumi Day-1 vs
+Day-2). `observability-and-smoke` is its own sixth module, not folded into
+reliability prose, because "load the real URL, confirm render, read the logs to
+debug a failed smoke" is a distinct active-probe + telemetry concern.

--- a/.claude/skills/operational-safety/references/blast-radius.md
+++ b/.claude/skills/operational-safety/references/blast-radius.md
@@ -1,0 +1,50 @@
+# blast-radius — destroy/replace gating, prevent-destroy, proposer≠approver
+
+> **Loaded when:** the change can delete or replace existing infrastructure,
+> alters a resource whose replacement is destructive (a recreated database, a
+> renamed stateful resource), or runs a destroy/teardown path against a shared
+> or production environment.
+> **Grounded in:** F3.1 (parse the plan structurally; gate on destroy/replace
+> counts), F3.2 (decouple proposer identity from approver identity).
+> Operational taxonomy: the destructive-op-needs-human-approval rule already in
+> AGENTS.md "Check before acting".
+> **Delegation legend:** `tool` = scanner / CI-gate-owned · `hybrid` = gate
+> surfaces the signal, you judge the fix · `reason` = reviewer-only judgment.
+
+The cost of a wrong line here is the highest in the loop — a single misjudged
+replace can drop a production datastore. Gate on **what the plan will actually
+destroy**, not on a hopeful read of the diff.
+
+## Implementation checks
+
+- `tool` **Parse the plan structurally; gate on destroy/replace counts.**
+  Compute the planned `delete` / `replace` actions from the machine-readable
+  plan (the structured plan output, not grepped text), and fail the step on a
+  nonzero destructive count unless an explicit override is present. Confirm this
+  parse-and-gate runs before any apply.
+- `reason` **Destructive count never read from text.** Grepping apply logs or
+  the human-readable diff for "destroy" is unreliable; the gate must read the
+  structured plan. Flag any gate that pattern-matches prose.
+- `reason` **Proposer ≠ approver for irreversible ops.** The identity that
+  proposes a destructive change must not be the identity that approves it — the
+  agent proposes, a *different* identity (the human) approves. This maps onto
+  "get user confirmation for destructive commands" in AGENTS.md; flag a path
+  where the agent could self-approve a destroy/replace.
+- `reason` **Must-survive resources are pinned.** Resources that must not be
+  destroyed carry an explicit prevent-destroy guard — and the reviewer notes
+  that such guards are bypassable (removing the block, surgical state edits), so
+  a change that *removes* a prevent-destroy guard is itself a destructive-intent
+  signal worth surfacing.
+
+## Established-pattern bypass
+
+Resolve the repo's sanctioned destructive-op gate — the plan-parse check in CI,
+the required-reviewer environment, the change-approval workflow — and flag a
+change that routes a destroy around it (a direct teardown command, a
+`--auto-approve` on a destructive apply). The blessed gate is where
+proposer≠approver was already enforced.
+
+*Illustrative only (never normative):* `plan -out` → structured-plan parse →
+count `delete`/`replace`, or a required-reviewer rule on a protected
+environment, exhibit this shape — but the check is the *property*
+(parsed-plan gating + identity separation), not any one tool.

--- a/.claude/skills/operational-safety/references/cost-and-teardown.md
+++ b/.claude/skills/operational-safety/references/cost-and-teardown.md
@@ -1,0 +1,48 @@
+# cost-and-teardown — cost-ceiling-as-gate, destroy-on-fail, TTL, no orphans
+
+> **Loaded when:** the change provisions billable resources, creates ephemeral
+> or per-iteration infrastructure, or runs a teardown path — anything that can
+> leave a paid-for resource running after the work is done.
+> **Grounded in:** F3.4 (cost is a first-class CI gate, not a post-deploy
+> surprise), F3.5 (tag-at-creation TTL + destroy-on-close prevents orphans;
+> destroy needs its own plan). Operational taxonomy: AWS Well-Architected Cost
+> Optimization; the ephemeral-environment lifecycle pattern.
+> **Delegation legend:** `tool` = scanner / CI-gate-owned · `hybrid` = gate
+> surfaces the signal, you judge the fix · `reason` = reviewer-only judgment.
+
+An agentic loop that provisions on each iteration leaks money invisibly: the
+failure mode is not a crash but a bill. Estimate cost **from the plan, before
+apply**, and make teardown as deliberate as creation.
+
+## Implementation checks
+
+- `tool` **Cost is estimated from the plan and gated on a ceiling.** A
+  cost-diff runs on the planned change and a budget ceiling (absolute, percent,
+  or budget) blocks the apply when exceeded. Confirm the cost gate is wired; if
+  none is detected, flag `degraded: no cost gate` rather than passing silently.
+- `reason` **Destroy-on-fail / no half-built stacks.** A failed apply or smoke
+  must tear down what it created rather than leaving a partial stack accruing
+  cost. Flag a path where a failed run exits leaving resources up with no
+  cleanup.
+- `reason` **TTL / tag-at-creation for ephemeral resources.** Resources created
+  for iteration carry a TTL or ownership tag a scheduled cleanup can find, so an
+  abandoned run is reclaimable. Untagged, unbounded-lifetime ephemeral resources
+  are the orphan source.
+- `reason` **Destroy has its own plan.** A teardown is a destructive operation
+  in its own right — preview the destroy plan before running it (it inherits the
+  `blast-radius` gating), don't fire an unreviewed bulk destroy.
+- `hybrid` **No orphans after a normal run.** After a successful iterate-and-
+  teardown cycle, no created resource is left behind. Confirm the teardown
+  enumerates everything the apply created.
+
+## Established-pattern bypass
+
+Resolve the repo's sanctioned lifecycle harness — the cost-diff CI gate, the
+ephemeral-environment create/destroy automation, the TTL-tag-and-sweep
+convention — and flag a change that provisions billable resources outside it
+(no cost gate, no teardown, no TTL tag).
+
+*Illustrative only (never normative):* a cost-diff status check on PRs plus a
+TTL tag swept by a scheduled cleanup, or create-on-open / destroy-on-close
+per-PR environments, exhibit this shape — but the check is the *property*
+(cost-as-gate + bounded lifecycle + no orphans), not any one tool.

--- a/.claude/skills/operational-safety/references/drift-and-rollback.md
+++ b/.claude/skills/operational-safety/references/drift-and-rollback.md
@@ -1,0 +1,67 @@
+# drift-and-rollback — read-only drift detection, known-good re-apply path
+
+> **Loaded when:** the change manages long-lived infrastructure that can drift
+> from its declared state, or where a deploy needs a defined recovery path if
+> the smoke probe fails.
+> **Grounded in:** F1.4 (drift detection is read-only and separable from
+> remediation; auto-remediation default is contested), F2.6 (no atomic
+> rollback — re-apply the prior known-good config). Operational taxonomy: AWS
+> Well-Architected Failure Management; Google SRE Incident Response; Pulumi
+> Day-2 drift detection + remediation.
+> **Delegation legend:** `tool` = scanner / CI-gate-owned · `hybrid` = gate
+> surfaces the signal, you judge the fix · `reason` = reviewer-only judgment.
+
+This is the **divergence-detection-and-recovery** lens — deliberately separate
+from `state-and-idempotency`'s write-path convergence (every major operational
+taxonomy splits the two). Detection is safe, frequent, and read-only; recovery
+is mutating and gated.
+
+## Implementation checks
+
+- `reason` **Drift detection is read-only.** The "are we drifted?" check must
+  not mutate — it compares declared vs. live state and reports, separate from
+  any remediation step. Flag a detection path that silently corrects as it
+  reads.
+- `reason` **A known-good re-apply path is named *before* the first apply.**
+  There is no atomic rollback for a partially applied deploy; the recovery path
+  is re-applying the previous versioned known-good config, not state surgery.
+  Confirm this path is named in the plan's `## Rollout` (the work-loop's infra
+  verification mode requires it before the first apply).
+- `reason` **Early detection over hard rollback.** Because rollback is hard,
+  small increments and a real smoke probe (see `observability-and-smoke`) are
+  what keep rollback rarely needed. Flag a large, all-at-once apply with no
+  early-detection layer in front of it.
+
+## The auto-remediation default — an unresolved tension (surface, do not resolve)
+
+Whether detected drift should be **gated** (detect → alert → a human decides
+whether to re-apply) or **auto-synced** (continuously reconcile, auto-reverting
+any out-of-band change) is a **genuine, unresolved tension** — both defaults are
+well-evidenced under different conditions:
+
+- **Gate it** — the Terraform-community default: detection is read-only and
+  remediation is a separate, human-gated step, because an auto-revert can stomp
+  a legitimate emergency hotfix applied out-of-band.
+- **Auto-sync** — the GitOps default (Argo CD, Flux): continuous reconciliation
+  treats the declared state as the single source of truth and auto-reverts
+  drift, because allowing drift to persist is itself the risk.
+
+**This module surfaces the tension; it does not pick a side.** When reviewing,
+name which default the change assumes and whether that default fits *this*
+resource's risk profile — an auto-syncing reconciler on a resource that takes
+legitimate emergency edits is a finding; a gated detector on a
+must-never-drift security control may be too lax. The right answer is
+context-dependent, so flag a mismatch, don't impose one default.
+
+## Established-pattern bypass
+
+Resolve the repo's sanctioned drift / recovery model — the scheduled read-only
+drift check, the versioned-config re-apply runbook, the GitOps reconciler — and
+flag a change that introduces a divergent recovery story (state surgery as the
+rollback plan, an auto-sync reconciler bolted onto a gated environment).
+
+*Illustrative only (never normative):* `plan -refresh-only` for read-only
+drift, re-applying a previous tagged config for recovery, or an Argo CD / Flux
+reconciler for auto-sync, exhibit these shapes — but the checks are the
+*properties* (read-only detection, a named re-apply path, a context-fit
+remediation default), not any one tool.

--- a/.claude/skills/operational-safety/references/environment-isolation.md
+++ b/.claude/skills/operational-safety/references/environment-isolation.md
@@ -1,0 +1,45 @@
+# environment-isolation — throwaway/staging vs prod, separate state/accounts
+
+> **Loaded when:** the change provisions or iterates against an environment
+> that is, or could touch, production — or where the iteration loop needs a
+> safe place to fail that is not prod.
+> **Grounded in:** F3.3 (environment isolation by account/state boundary).
+> Operational taxonomy: AWS multi-account-per-stage; separate state backends as
+> the IaC-level isolation enforcement.
+> **Delegation legend:** `tool` = scanner / CI-gate-owned · `hybrid` = gate
+> surfaces the signal, you judge the fix · `reason` = reviewer-only judgment.
+
+Iterate **away from prod**. The strongest isolation unit is the
+account / subscription / project boundary; separate state enforces it in IaC.
+The agentic refinement loop — apply, observe, fix, re-apply — belongs in a
+throwaway or staging environment, never against the production stack.
+
+## Implementation checks
+
+- `reason` **Iteration target is not prod.** The change's apply/test/teardown
+  loop runs against a throwaway or staging environment isolated from
+  production. Flag any iteration that converges by repeatedly applying to prod.
+- `reason` **State backends are separated by stage.** Staging credentials and
+  state cannot reach production resources — separate state backends (not a
+  shared backend with a workspace toggle that a typo can cross) enforce the
+  boundary. A single shared state across stages is the finding.
+- `reason` **Account / subscription / project boundary where the blast radius
+  warrants it.** For high-blast-radius infra, the strongest isolation is a
+  distinct account boundary with guardrail policies, not just a namespace. Note
+  where the isolation is weaker than the blast radius justifies.
+- `hybrid` **Credentials are stage-scoped.** The credentials the change runs
+  under are scoped to the target stage; a smoke or teardown step cannot
+  accidentally authenticate against prod. Confirm the scoping; judge whether the
+  scope is genuinely narrow.
+
+## Established-pattern bypass
+
+Resolve the repo's sanctioned environment model — the per-stage account map,
+the separate-state convention, the ephemeral-per-PR environment harness — and
+flag a change that points a new resource at the shared/prod backend instead of
+the stage-isolated one.
+
+*Illustrative only (never normative):* an AWS account-per-stage layout with
+separate Terraform state backends, or per-PR ephemeral environments, exhibit
+this shape — but the check is the *property* (isolation by account/state
+boundary), not any one tool or cloud.

--- a/.claude/skills/operational-safety/references/environment-isolation.md
+++ b/.claude/skills/operational-safety/references/environment-isolation.md
@@ -30,7 +30,10 @@ throwaway or staging environment, never against the production stack.
 - `hybrid` **Credentials are stage-scoped.** The credentials the change runs
   under are scoped to the target stage; a smoke or teardown step cannot
   accidentally authenticate against prod. Confirm the scoping; judge whether the
-  scope is genuinely narrow.
+  scope is genuinely narrow. *(Carve note: the failure guarded here is the
+  iteration loop converging on prod — a reliability/blast-containment failure;
+  whether a grant is over-broad for **privilege-escalation** purposes is the
+  security lens, owned by `security-checklists`' `config-misconfig`.)*
 
 ## Established-pattern bypass
 

--- a/.claude/skills/operational-safety/references/observability-and-smoke.md
+++ b/.claude/skills/operational-safety/references/observability-and-smoke.md
@@ -1,0 +1,52 @@
+# observability-and-smoke — active end-to-end probe, log access, health, verify-status
+
+> **Loaded when:** the change deploys a service, site, or endpoint a user
+> reaches — anything where "created" does not yet mean "works" and the deploy
+> needs an active probe plus the telemetry to debug a failed one.
+> **Grounded in:** F2.2 ("created" ≠ "works"; smoke / health checks are
+> mandatory before promotion); taxonomy follow-up — AWS Well-Architected
+> Operational Excellence (understand operational health), Google SRE monitoring
+> as a first-class practice.
+> **Delegation legend:** `tool` = scanner / CI-gate-owned · `hybrid` = gate
+> surfaces the signal, you judge the fix · `reason` = reviewer-only judgment.
+
+A provisioned resource is not a working one. This module is the operational
+extension of the work-loop's visual/manual-QA doctrine ("exercise the real
+built artifact end-to-end") to a deployed system — and the observability that
+lets the agent **debug a failed smoke itself** rather than relay errors to a
+human.
+
+## Implementation checks
+
+- `reason` **Active end-to-end smoke, not a status check.** The verification is
+  a multi-hop probe: seed test / mock users → load the **real** CDN / site URL
+  → assert it actually renders → on failure, pull access / error logs and debug
+  → tear down. A single "stack status: CREATE_COMPLETE" is not a smoke test —
+  flag a deploy whose only post-apply check is resource status.
+- `reason` **A verify-status signal exists.** There is a defined signal that
+  answers "did the deploy report healthy?" — a health endpoint, a post-apply
+  runtime assertion — distinct from the provisioning tool's own exit code.
+- `hybrid` **Access / error logs are reachable for debugging.** When the smoke
+  fails, the logs needed to diagnose it (access logs, error logs, the
+  application's own telemetry) are accessible to the agent driving the deploy —
+  log-driven debugging is the loop, not a human relaying the error back.
+- `reason` **Health / telemetry is designed in, not bolted on.** The service
+  exposes the operational health signals (health endpoint, the key
+  golden-signal metrics) the smoke and ongoing operation depend on. Missing
+  observability is a reliability finding, not a nice-to-have.
+- `reason` **Seed + teardown bracket the probe.** The smoke seeds the test data
+  / mock users it needs and tears them (and any ephemeral resources) down after
+  — so the probe is repeatable and leaves no residue (this meets
+  `cost-and-teardown`).
+
+## Established-pattern bypass
+
+Resolve the repo's sanctioned smoke / observability harness — the end-to-end
+probe script, the health-endpoint convention, the log-access path the deploy
+pipeline already wires — and flag a deploy that declares success on
+provisioning status alone, with no active probe and no reachable logs.
+
+*Illustrative only (never normative):* a post-apply HTTP assertion against the
+live URL plus structured access/error logs, or a deploy-validate-undeploy probe
+harness, exhibit this shape — but the check is the *property* (active
+end-to-end probe + reachable telemetry), not any one tool.

--- a/.claude/skills/operational-safety/references/state-and-idempotency.md
+++ b/.claude/skills/operational-safety/references/state-and-idempotency.md
@@ -1,0 +1,50 @@
+# state-and-idempotency — convergent re-apply, state locking, single-writer
+
+> **Loaded when:** the change provisions or mutates infrastructure, edits
+> infrastructure-as-code, or drives a stateful migration of a running system —
+> anything where the *write path* may be re-run after a failure.
+> **Grounded in:** F1.2 (declarative + idempotent re-apply is what makes retry
+> safe; imperative scripts collide), F1.3 (shared state needs a single-writer
+> lock). Operational taxonomy: AWS Well-Architected Change Management; the
+> Terraform/Pulumi declarative-convergence model.
+> **Delegation legend:** `tool` = scanner / CI-gate-owned · `hybrid` = gate
+> surfaces the signal, you judge the fix · `reason` = reviewer-only judgment.
+
+Idempotent convergent apply is the **precondition the whole infra loop rests
+on**: re-running after a fix must *converge, not collide*. A non-idempotent
+imperative step is the retry-collision root cause — the thing to fix first
+rather than iterate around.
+
+## Implementation checks
+
+- `reason` **Convergent re-apply.** Re-running the change from a partially
+  applied state must reach the desired state with no duplicate creates and no
+  inconsistent leftovers ("if already in desired state, no actions taken").
+  Declarative definitions get this structurally; an imperative script must add
+  existence-check / conditional-create guards to match it. Flag any step that
+  would re-create an existing resource or error on a second run.
+- `reason` **No imperative non-idempotent step on the write path.** A
+  hand-rolled create/start/stop sequence with no guard is the
+  "manual stop/start errors" failure mode — each failed retry is a fresh mess.
+  Require the guard, or convert the step to declarative.
+- `hybrid` **Single-writer lock on shared state.** When an agent and a human,
+  or two agents, could apply against the same state concurrently, mutation must
+  serialize through a state lock. Confirm the lock mechanism is configured;
+  judge whether the concurrency window is actually closed.
+- `reason` **State integrity over the retry.** A failed apply must not leave
+  state and live resources diverged in a way the next apply can't reconcile.
+  The next run should *read* current reality and converge, not assume the prior
+  run's intent.
+
+## Established-pattern bypass
+
+Resolve the repo's sanctioned convergence mechanism — the declarative IaC
+module, the shared apply wrapper, the locked state backend — and flag a change
+that hand-rolls an imperative provisioning sequence inline instead of extending
+it. The blessed mechanism is where idempotency and single-writer locking were
+already decided, once.
+
+*Illustrative only (never normative):* a `terraform apply` against a
+lock-enabled S3 backend, or a Pulumi `up` against a locked stack, exhibit this
+shape — but the check is the *property* (convergent, single-writer), not any
+one tool.

--- a/.claude/skills/security-checklists/SKILL.md
+++ b/.claude/skills/security-checklists/SKILL.md
@@ -13,6 +13,14 @@ footer, the output format). The *shape-specific depth* — what to actually
 check at each trust boundary — lives here, in ten `references/<module>.md`
 modules, so the agent prompt stays lean and the depth scales without bloat.
 
+> **Reliability-vs-security carve.** This library owns *security* config; the
+> *reliability / ops* side of infrastructure (idempotent convergence, blast
+> radius, environment isolation, cost/teardown, drift/rollback,
+> observability/smoke) lives in the [`operational-safety`](../operational-safety/SKILL.md)
+> skill, consumed by `quality-engineer`. The routing splits IaC-security →
+> `config-misconfig`, IaC-reliability → `operational-safety`. The two are
+> complementary lenses on the same infra diff — keep the split clean both ways.
+
 ## How it loads (orchestrator-driven, not self-discovered)
 
 **The orchestrator drives loading; the subagent does not.** There is no

--- a/.claude/skills/security-checklists/references/config-misconfig.md
+++ b/.claude/skills/security-checklists/references/config-misconfig.md
@@ -36,6 +36,38 @@ V14; Proactive Controls 2024 C5).
   `Content-Security-Policy`, TLS verification disabled, or downgraded
   protocol/cipher settings.
 
+## Deferred authority (per-provider secure-config depth)
+
+This module reasons from cross-cutting standards and catches security failure
+*classes*; it deliberately does **not** carry per-provider secure-config
+baselines (they would be stale on arrival and break tool-neutrality). The
+per-provider depth lives in two places, named here by **stable publisher +
+document, with no URL and no version** so the pointer stays evergreen by naming
+rather than linking:
+
+- **CIS Benchmarks** — the per-service hardening baselines.
+- **AWS Well-Architected Security Pillar**, **Microsoft Cloud Adoption
+  Framework / Azure Well-Architected Security**, and **Google Cloud
+  Architecture Framework (Security)** — each provider's standing
+  well-architected security guidance.
+
+The **actual, current per-provider depth lives in the self-updating
+policy-as-code / CSPM scanner** the work-loop's infra preflight requires (its
+vendor-maintained rulesets *are* these baselines, kept fresh by the vendor) —
+not in this pointer. A stale name here never gates a real check; the scanner
+does. Confirm the scanner is wired (the `tool` bullet above) rather than
+re-deriving provider baselines by hand.
+
+## The reliability-vs-security carve
+
+This module owns **IaC *security* config** (IAM, CORS, public exposure, secrets
+posture, TLS). The **reliability / ops** side of infrastructure — idempotent
+convergence, blast radius, environment isolation, cost/teardown, drift/rollback,
+observability/smoke — lives in the **`operational-safety`** skill, consumed by
+`quality-engineer`. Route IaC-security here; route IaC-reliability there. Don't
+pull operational checks into this module, and don't let security config drift
+into an operational one.
+
 ## Established-helper bypass
 
 Resolve the repo's sanctioned config/module (the hardened web-server base, the

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -704,6 +704,39 @@ note in the summary, not a blocker.
   Different lens from adversarial-reviewer — don't skip it because the spec
   already shipped.
 
+  **Inline operational depth on infra/destructive work, don't make it
+  self-discover.** When the diff is **infra-flavored** — the
+  **destructive/irreversible risk trigger** routed it to full mode *and* it
+  provisions, mutates, deploys, or tears down infrastructure — the
+  `quality-engineer` is the consumer of a second progressive-disclosure depth
+  library, [`operational-safety`](../operational-safety/SKILL.md), exactly as
+  `security-reviewer` consumes `security-checklists`. Detect which operational
+  failure modes the change raises, load **only** the matching
+  `operational-safety` modules, and inline their content into the subagent's
+  brief (reusing the same on-demand `references/*.md` loading) — the
+  `quality-engineer`'s `tools:` has no Skill tool, so loading is
+  orchestrator-driven, not model-relevance-judged. **No new reviewer** — this
+  feeds the existing `quality-engineer` (ADR-0023). Route deterministically:
+
+  <a id="operational-safety-routing-table"></a>
+
+  | Operational failure mode the infra/destructive change raises | Inline module(s) |
+  | --- | --- |
+  | Provisioning or mutating infra; stateful migration; any re-runnable write path | `state-and-idempotency` |
+  | Can delete or replace existing infra; destroy/teardown path; removing a prevent-destroy guard | `blast-radius` |
+  | Iterating against (or able to touch) production; shared vs throwaway/staging state | `environment-isolation` |
+  | Provisions billable resources; ephemeral/per-iteration infra; teardown path | `cost-and-teardown` |
+  | Long-lived infra that can drift; a deploy needing a defined recovery path | `drift-and-rollback` |
+  | Deploys a service / site / endpoint a user reaches; needs smoke + telemetry | `observability-and-smoke` |
+
+  Load 1–N modules as the change warrants, **never a flat march of all six** —
+  a one-line config tweak pulls one; a new public-facing stack pulls several.
+  This is the operational twin of the `security-checklists` routing table
+  above, and the **reliability-vs-security carve** holds: IaC-security →
+  `config-misconfig` (the `security-reviewer` pass); IaC-reliability →
+  `operational-safety` (this pass). The two passes are complementary lenses on
+  the same infra diff, not substitutes.
+
 **Dispatch reviewers in parallel when you invoke more than one** per
 the [Parallel dispatch discipline](#parallel-dispatch-discipline)
 documented under EXECUTE — the same rules cover both fan-out sites in

--- a/.codex/agents/quality-engineer.toml
+++ b/.codex/agents/quality-engineer.toml
@@ -39,6 +39,17 @@ from the prompt and say which you picked.
    local test style before recommending against it).
 5. Any `packages/<name>/AGENTS.md` for the package being changed —
    per-package test conventions live there.
+6. **On infra/destructive work: the `operational-safety` modules the
+   orchestrator inlined into your brief.** When the change provisions,
+   mutates, deploys, or tears down infrastructure, the work-loop detects which
+   operational failure modes it raises and inlines only the matching
+   `operational-safety` modules (idempotency, blast radius, environment
+   isolation, cost/teardown, drift/rollback, observability/smoke) as prompt
+   text — that is your operational depth reference for this change, the
+   reliability-side twin of how `security-reviewer` consumes `security-checklists`.
+   You do **not** load the skill yourself; if no modules were inlined, fall back
+   to your own reliability/observability checklists and say so. **You remain the
+   consumer — no new reviewer is added** for operational safety.
 
 If you skip step 1 you cannot do your job — recommending a test style
 the repo has already rejected is the most common quality-reviewer

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -19,6 +19,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`operational-safety` reference library for infra/destructive work (core
+  0.4.12 → 0.4.13; RFC-0041 P3 / ADR-0031).** Infrastructure and destructive
+  operational work now gets a first-class operational-safety depth library — a
+  new `operational-safety` skill of six failure-mode-keyed prose modules
+  (`state-and-idempotency`, `blast-radius`, `environment-isolation`,
+  `cost-and-teardown`, `drift-and-rollback`, `observability-and-smoke`),
+  structurally identical to `security-checklists`. When the work-loop detects
+  infra/destructive work, the orchestrator loads only the matching modules
+  (1–N, never all six) and inlines them into the **existing `quality-engineer`**
+  reviewer's brief — so idempotency, blast radius, environment isolation,
+  cost/teardown, drift/rollback, and observability/smoke get reviewer depth
+  with **no fourth reviewer** (ADR-0023). The split against `security-checklists`
+  is clean: security config → `security-checklists` (`security-reviewer`);
+  reliability/ops config → `operational-safety` (`quality-engineer`).
+  `security-checklists`' `config-misconfig` also gains a URL-free, version-free
+  deferred-authority pointer (CIS Benchmarks + the per-provider well-architected
+  security guidance) noting the real per-provider depth lives in the
+  self-updating scanner. Prose only — no executable code ships.
 - **One consolidated, namespaced pack-output layout file — `agentbundle-layout.toml`
   (RFC-0040 / ADR-0030).** An adopter who wants to control where a pack's durable
   output lands now edits **one** namespaced file instead of a per-pack config.

--- a/docs/specs/operational-safety-checklists/plan.md
+++ b/docs/specs/operational-safety-checklists/plan.md
@@ -1,7 +1,7 @@
 # Plan: operational-safety-checklists
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Executing <!-- Drafting | Executing | Done -->
+- **Status:** Done <!-- Drafting | Executing | Done -->
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
 > document is allowed to change as you learn. When it changes substantially

--- a/docs/specs/operational-safety-checklists/plan.md
+++ b/docs/specs/operational-safety-checklists/plan.md
@@ -1,7 +1,7 @@
 # Plan: operational-safety-checklists
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Drafting <!-- Drafting | Executing | Done -->
+- **Status:** Executing <!-- Drafting | Executing | Done -->
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
 > document is allowed to change as you learn. When it changes substantially
@@ -83,13 +83,19 @@ structure is a deliberate mirror of `security-checklists`, not a fresh design.
   (orchestrator-driven, not self-discovered)" section, and the
   reliability-vs-security carve (spec AC: skill exists, mirrors the pattern;
   carve stated).
-- Each module carries a greppable `> **Grounded in:**` line naming its RFC-table
-  groundings, `grep`s for its coverage terms, and contains no tool-specific
-  normative sentence (illustrative examples labelled) (spec AC: grounded
-  greppably + tool-neutral).
+- Each module carries a greppable `> **Grounded in:**` line naming its **exact**
+  RFC-table groundings (spec AC3 pins them per module: state-and-idempotency →
+  F1.2/F1.3; blast-radius → F3.1/F3.2; environment-isolation → F3.3;
+  cost-and-teardown → F3.4/F3.5; drift-and-rollback → F1.4/F2.6;
+  observability-and-smoke → F2.2 + taxonomy follow-up), `grep`s for its coverage
+  terms, and contains no tool-specific normative sentence (illustrative examples
+  labelled) (spec AC: grounded greppably + tool-neutral).
 - `drift-and-rollback.md` `grep`s for the unresolved auto-remediation tension
   (gate-it vs auto-sync), surfaced not resolved (spec AC: six modules —
   drift-and-rollback).
+- `find packs/core/.apm/skills/operational-safety/ -type f` returns only `.md`
+  files and there is no `scripts/` dir — the skill ships prose only (spec AC: no
+  executable mechanism).
 
 **Approach:**
 - Copy the `security-checklists/SKILL.md` skeleton; rewrite the `description`,
@@ -158,6 +164,13 @@ consumer and no new reviewer is introduced; the rest of the agent is unchanged.
 - State the carve in `security-checklists` SKILL.md (it already scopes itself to
   security; add the one-line "operational config → `operational-safety`" pointer)
   and in `operational-safety` SKILL.md (the converse).
+
+> **Note — additive edit to a shipped skill.** The `security-checklists` side
+> of this task (the `config-misconfig` pointer + the SKILL.md carve sentence) is
+> the *only* edit in this PR that touches already-shipped, in-the-wild skill
+> content; adopters get the new prose on their next pull. It is strictly
+> additive — one pointer sentence in `config-misconfig.md` + one carve sentence
+> in `security-checklists` SKILL.md — and changes **no existing check**.
 
 **Done when:** both greps match; the no-URL/no-version grep is empty; the carve
 reads symmetrically in both skills.

--- a/docs/specs/operational-safety-checklists/spec.md
+++ b/docs/specs/operational-safety-checklists/spec.md
@@ -1,6 +1,6 @@
 # Spec: operational-safety-checklists
 
-- **Status:** Implementing <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** ADR-0031, RFC-0041 (P3 + the deferred-authority pointer); ADR-0018 (orchestrator-loaded progressive-disclosure depth library — the `security-checklists` pattern this mirrors); ADR-0023 (the three-reviewer ceiling — why this feeds `quality-engineer`, not a new reviewer); ADR-0017 (the SAST/SCA scanner family the deferred-authority pointer complements)
@@ -108,13 +108,13 @@ mirrors how `security-checklists` and `work-loop-light-mode` were verified.
 
 ## Acceptance Criteria
 
-- [ ] **Skill exists, mirrors the pattern.** `packs/core/.apm/skills/
+- [x] **Skill exists, mirrors the pattern.** `packs/core/.apm/skills/
   operational-safety/SKILL.md` exists with a front-matter `description`, a "How
   it loads (orchestrator-driven, not self-discovered)" section stating the
   orchestrator loads matching modules and inlines them into a reviewer's brief
   (the subagent never self-discovers the skill), and the reliability-vs-security
   carve. It is a depth library, **not** a reviewer prompt.
-- [ ] **Six modules, exact names, each a distinct failure-mode family.**
+- [x] **Six modules, exact names, each a distinct failure-mode family.**
   Verification is the checkable claim — `references/` holds **exactly the six
   RFC-0041 Decision-4 modules, no more, no fewer**, each a distinct
   operational-failure-mode family per the RFC's taxonomy follow-up (not the
@@ -133,7 +133,7 @@ mirrors how `security-checklists` and `work-loop-light-mode` were verified.
   log-driven debugging). `state-and-idempotency` and `drift-and-rollback` are
   **kept separate** (write-path convergence vs divergence-detection/recovery),
   and observability is its own sixth module.
-- [ ] **Each module grounded (greppably) and tool-neutral.** Each module carries
+- [x] **Each module grounded (greppably) and tool-neutral.** Each module carries
   a `> **Grounded in:**` line near its top naming the **exact** RFC-0041
   module-table groundings it rests on — pinned per module so the grep asserts
   the *right* groundings, not merely the line's presence:
@@ -149,39 +149,39 @@ mirrors how `security-checklists` and `work-loop-light-mode` were verified.
   `> **Standards:**` line — so grounding is mechanically checkable (grep), not
   merely asserted. Every module is written tool-neutral; illustrative examples
   are labelled illustrative, never normative.
-- [ ] **Routing table in `work-loop` SKILL.md.** `work-loop` SKILL.md gains an
+- [x] **Routing table in `work-loop` SKILL.md.** `work-loop` SKILL.md gains an
   `operational-safety` boundary→module routing table (mirroring the existing
   `security-checklists` routing table) so the orchestrator loads 1–N matching
   modules on the infra/destructive trigger and inlines them into the
   `quality-engineer` brief — never a flat march of all six.
-- [ ] **`quality-engineer` consumer wiring.** `quality-engineer.md` carries a note
+- [x] **`quality-engineer` consumer wiring.** `quality-engineer.md` carries a note
   that it consumes orchestrator-inlined `operational-safety` depth (mirroring how
   `security-reviewer` consumes `security-checklists`), without self-discovering
   the skill — `quality-engineer` remains the consumer; **no new reviewer** is
   added (ADR-0023).
-- [ ] **Deferred-authority pointer in `config-misconfig`.** `security-checklists`'
+- [x] **Deferred-authority pointer in `config-misconfig`.** `security-checklists`'
   `config-misconfig.md` gains a thin pointer naming the standing authorities —
   **CIS Benchmarks** and each provider's well-architected security guidance (AWS
   Well-Architected Security Pillar; Microsoft Cloud Adoption Framework / Azure
   Well-Architected Security; Google Cloud Architecture Framework Security) —
   **by stable publisher + document name, with no URL and no version**, and noting
   the actual per-provider depth lives in the self-updating scanner.
-- [ ] **Carve stated both ways.** The reliability-vs-security carve is stated in
+- [x] **Carve stated both ways.** The reliability-vs-security carve is stated in
   both `operational-safety` and `security-checklists` (front matter / body): the
   security library owns security config; the operational library owns
   reliability/ops config; the routing splits IaC-security → `config-misconfig`,
   IaC-reliability → `operational-safety`. No security config is duplicated into
   `operational-safety`.
-- [ ] **Eval exclusion.** `operational-safety` is excluded from `[pack.evals]` in
+- [x] **Eval exclusion.** `operational-safety` is excluded from `[pack.evals]` in
   `packs/core/pack.toml`, with a comment naming it as reviewer-internal / never
   self-discovered (mirroring the `security-checklists` exclusion).
-- [ ] **No executable mechanism.** The skill ships prose only — no scripts, no
+- [x] **No executable mechanism.** The skill ships prose only — no scripts, no
   runtime. The primary check is on the new skill dir itself:
   `packs/core/.apm/skills/operational-safety/` contains **no `scripts/`
   directory and no non-`.md` files** (goal-based — `find` returns only `.md`).
   As a secondary guard against an unrelated regression, `loop-cohort.py` and
   `lint-spec-status.py` are byte-unchanged.
-- [ ] **Projection + lint + release hygiene.** `make build-self` projects the new
+- [x] **Projection + lint + release hygiene.** `make build-self` projects the new
   skill to `.claude/skills/operational-safety/` cleanly; `make build-check`,
   `python tools/lint-agent-artifacts.py`, and `python tools/lint-agents-md.py`
   all pass; `packs/core/pack.toml` version is bumped and `marketplace.json`

--- a/docs/specs/operational-safety-checklists/spec.md
+++ b/docs/specs/operational-safety-checklists/spec.md
@@ -1,6 +1,6 @@
 # Spec: operational-safety-checklists
 
-- **Status:** Draft <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Status:** Implementing <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** ADR-0031, RFC-0041 (P3 + the deferred-authority pointer); ADR-0018 (orchestrator-loaded progressive-disclosure depth library — the `security-checklists` pattern this mirrors); ADR-0023 (the three-reviewer ceiling — why this feeds `quality-engineer`, not a new reviewer); ADR-0017 (the SAST/SCA scanner family the deferred-authority pointer complements)
@@ -114,7 +114,11 @@ mirrors how `security-checklists` and `work-loop-light-mode` were verified.
   orchestrator loads matching modules and inlines them into a reviewer's brief
   (the subagent never self-discovers the skill), and the reliability-vs-security
   carve. It is a depth library, **not** a reviewer prompt.
-- [ ] **Six modules, exact names, MECE by failure mode.** `references/` holds
+- [ ] **Six modules, exact names, each a distinct failure-mode family.**
+  Verification is the checkable claim — `references/` holds **exactly the six
+  RFC-0041 Decision-4 modules, no more, no fewer**, each a distinct
+  operational-failure-mode family per the RFC's taxonomy follow-up (not the
+  unfalsifiable assertion "MECE"). `references/` holds
   exactly six files — `state-and-idempotency.md` (convergent re-apply, state
   locking, single-writer), `blast-radius.md` (parse-plan destroy/replace gating,
   `prevent_destroy`, proposer≠approver for destructive ops), `environment-isolation.md`
@@ -130,13 +134,21 @@ mirrors how `security-checklists` and `work-loop-light-mode` were verified.
   **kept separate** (write-path convergence vs divergence-detection/recovery),
   and observability is its own sixth module.
 - [ ] **Each module grounded (greppably) and tool-neutral.** Each module carries
-  a `> **Grounded in:**` line near its top naming the RFC-0041 module-table
-  groundings it rests on (the relevant F-citations and taxonomy sources — e.g.
-  AWS Well-Architected, Google SRE, the Terraform/Pulumi Day-1/Day-2 split),
-  mirroring how each `security-checklists` module carries a `> **Standards:**`
-  line — so grounding is mechanically checkable (grep), not merely asserted.
-  Every module is written tool-neutral; illustrative examples are labelled
-  illustrative, never normative.
+  a `> **Grounded in:**` line near its top naming the **exact** RFC-0041
+  module-table groundings it rests on — pinned per module so the grep asserts
+  the *right* groundings, not merely the line's presence:
+  - `state-and-idempotency.md` → **F1.2, F1.3**
+  - `blast-radius.md` → **F3.1, F3.2**
+  - `environment-isolation.md` → **F3.3**
+  - `cost-and-teardown.md` → **F3.4, F3.5**
+  - `drift-and-rollback.md` → **F1.4, F2.6**
+  - `observability-and-smoke.md` → **F2.2** + the taxonomy follow-up (AWS WAF
+    Operational Excellence, Google SRE monitoring)
+
+  This mirrors how each `security-checklists` module carries a
+  `> **Standards:**` line — so grounding is mechanically checkable (grep), not
+  merely asserted. Every module is written tool-neutral; illustrative examples
+  are labelled illustrative, never normative.
 - [ ] **Routing table in `work-loop` SKILL.md.** `work-loop` SKILL.md gains an
   `operational-safety` boundary→module routing table (mirroring the existing
   `security-checklists` routing table) so the orchestrator loads 1–N matching
@@ -164,7 +176,11 @@ mirrors how `security-checklists` and `work-loop-light-mode` were verified.
   `packs/core/pack.toml`, with a comment naming it as reviewer-internal / never
   self-discovered (mirroring the `security-checklists` exclusion).
 - [ ] **No executable mechanism.** The skill ships prose only — no scripts, no
-  runtime. `loop-cohort.py` and `lint-spec-status.py` are byte-unchanged.
+  runtime. The primary check is on the new skill dir itself:
+  `packs/core/.apm/skills/operational-safety/` contains **no `scripts/`
+  directory and no non-`.md` files** (goal-based — `find` returns only `.md`).
+  As a secondary guard against an unrelated regression, `loop-cohort.py` and
+  `lint-spec-status.py` are byte-unchanged.
 - [ ] **Projection + lint + release hygiene.** `make build-self` projects the new
   skill to `.claude/skills/operational-safety/` cleanly; `make build-check`,
   `python tools/lint-agent-artifacts.py`, and `python tools/lint-agents-md.py`
@@ -194,10 +210,13 @@ mirrors how `security-checklists` and `work-loop-light-mode` were verified.
   the AGENTS hygiene lint; those run by hand / in CI (source:
   `work-loop-light-mode` spec Assumptions).
 - Process: this spec and `infra-aware-work-loop` **both edit `work-loop`
-  SKILL.md** — this one adds the `operational-safety` routing table, the other
-  edits the verification-mode step + security wiring. Land them sequentially
-  (`infra-aware-work-loop` first) or in one PR to avoid a co-edit collision
-  (source: the two specs' scopes; RFC-0041 Follow-on artifacts).
+  SKILL.md** — this one adds the `operational-safety` routing table at the
+  REVIEW `quality-engineer` bullet, the other edited the verification-mode step
+  + the `security-reviewer` bullet. `infra-aware-work-loop` **already shipped**
+  (commit `f62f0fe`, core 0.4.12), so the co-edit collision is resolved: the
+  two edits target distinct bullets, and this spec's routing-table edit applies
+  cleanly onto the now-present infra-flavor prose (source: the two specs'
+  scopes; RFC-0041 Follow-on artifacts; git history).
 - Process: decision frozen in ADR-0031 (Accepted) + RFC-0041 (Accepted
   2026-06-22); the module taxonomy (six, with state/drift kept separate and
   observability sixth) was resolved by the RFC's follow-up research (source:

--- a/packs/core/.apm/agents/quality-engineer.md
+++ b/packs/core/.apm/agents/quality-engineer.md
@@ -38,6 +38,17 @@ from the prompt and say which you picked.
    local test style before recommending against it).
 5. Any `packages/<name>/AGENTS.md` for the package being changed —
    per-package test conventions live there.
+6. **On infra/destructive work: the `operational-safety` modules the
+   orchestrator inlined into your brief.** When the change provisions,
+   mutates, deploys, or tears down infrastructure, the work-loop detects which
+   operational failure modes it raises and inlines only the matching
+   `operational-safety` modules (idempotency, blast radius, environment
+   isolation, cost/teardown, drift/rollback, observability/smoke) as prompt
+   text — that is your operational depth reference for this change, the
+   reliability-side twin of how `security-reviewer` consumes `security-checklists`.
+   You do **not** load the skill yourself; if no modules were inlined, fall back
+   to your own reliability/observability checklists and say so. **You remain the
+   consumer — no new reviewer is added** for operational safety.
 
 If you skip step 1 you cannot do your job — recommending a test style
 the repo has already rejected is the most common quality-reviewer

--- a/packs/core/.apm/skills/operational-safety/SKILL.md
+++ b/packs/core/.apm/skills/operational-safety/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: operational-safety
+description: Progressive-disclosure operational-safety-depth modules for the quality-engineer reviewer. Holds six failure-mode-keyed checklists (state-and-idempotency, blast-radius, environment-isolation, cost-and-teardown, drift-and-rollback, observability-and-smoke) as references/, each grounded in standing operational taxonomy (AWS Well-Architected, Google SRE, the Terraform/Pulumi Day-1/Day-2 split). The work-loop's orchestrator loads only the matching modules and inlines them into the quality-engineer's brief when infra/destructive work is detected; the subagent never self-discovers this skill. Not a reviewer prompt itself — it is the depth library the reviewer reasons from. Carves against security-checklists on the reliability-vs-security lens — security-checklists owns security config while operational-safety owns reliability/ops config.
+---
+
+# Skill: operational-safety
+
+This skill is the **depth library** behind the `quality-engineer` agent for
+infrastructure and destructive operational work. The reviewer's body carries
+the *universal method* (its testability / observability / reliability /
+maintainability lens, the severity rubric, the report format). The
+*shape-specific depth* — what to actually check at each operational failure
+mode — lives here, in six `references/<module>.md` modules, so the agent prompt
+stays lean and the depth scales without bloat. It is the operational-lens twin
+of [`security-checklists`](../security-checklists/SKILL.md), built on the same
+orchestrator-loaded, table-routed mechanism — **no new reviewer** (the CHARTER
+three-reviewer ceiling; ADR-0023), no executable code (ADR-0031).
+
+## How it loads (orchestrator-driven, not self-discovered)
+
+**The orchestrator drives loading; the subagent does not.** There is no
+mechanism to force a subagent to invoke a skill, skill discovery is
+model-invoked and adapter-variable, and the `quality-engineer`'s `tools:` list
+does not include a Skill tool. So depth must not depend on the reviewer finding
+this library itself.
+
+Concretely, at the work-loop's REVIEW `quality-engineer` step, when the change
+is infra/destructive (the destructive/irreversible risk trigger routed it to
+full mode, and the diff touches IaC / deploy config / a stateful migration),
+the orchestrator:
+
+1. Detects which **operational failure modes** the diff or spec crosses.
+2. Loads **only the matching modules** via the deterministic failure-mode→module
+   routing table in `work-loop/SKILL.md` (the `operational-safety` table,
+   beside the `security-checklists` one).
+3. **Inlines the selected modules' content** into the `quality-engineer`
+   subagent's brief — so the reviewer receives a focused checklist as prompt
+   text, never a path to resolve.
+
+Loaded 1–N per the routing table, never a flat march of all six. Where an
+adapter *does* support subagent skill auto-discovery, that is a redundant
+convenience layered on top — never the load-bearing mechanism.
+
+## The reliability-vs-security carve (load-bearing)
+
+This library and [`security-checklists`](../security-checklists/SKILL.md) split
+infrastructure review along one clean line, and the split must stay clean both
+ways:
+
+- **`security-checklists` owns *security* config.** Over-broad IAM, public
+  exposure, secrets in state, unencrypted-at-rest, metadata SSRF, CORS — the
+  security failure classes. Its `config-misconfig` module is the IaC-security
+  home.
+- **`operational-safety` (this skill) owns *reliability / ops* config.**
+  Idempotent convergence, blast radius, environment isolation, cost/teardown,
+  drift/rollback, observability/smoke — the operational failure classes.
+
+The routing therefore assigns **IaC-security → `config-misconfig`**,
+**IaC-reliability → `operational-safety`**. Do not duplicate security config
+into an operational module, and do not migrate operational config out of where
+it correctly lives. When a check seems to belong to both lenses, ask which
+*failure* it guards against — a leaked credential is security; a half-applied,
+non-convergent stack is reliability.
+
+## The three-bucket delegation legend
+
+Every check in every module is tagged so the reviewer knows who owns it —
+the same legend `security-checklists` uses, read through the operational lens:
+
+- **`tool`** — scanner / CI-gate-owned. Confirm the gate is *wired*; don't
+  re-check by hand. The operational analogs of the security scanners are the
+  policy-as-code / CSPM scanner (which also feeds the security pass), the
+  cost-diff gate, and the plan-parse destroy/replace counter. If the delegated
+  gate is **absent**, do not silently skip: either reason the class best-effort
+  and flag it `degraded: no gate`, or state the gap explicitly. A silent skip
+  is the worst outcome — it looks like coverage.
+- **`hybrid`** — the gate surfaces the signal; *you* judge the fix. A plan
+  diff or a drift report points at the change, but whether the apply converges,
+  whether the destroy is intended, or whether the rollback path is real is
+  reasoning work.
+- **`reason`** — reviewer-only. Whether the loop is genuinely idempotent,
+  whether proposer≠approver holds for a destructive op, whether a smoke probe
+  actually exercises the artifact end-to-end — the classes no scanner sees. The
+  highest-value findings live here.
+
+## Module index
+
+| Module | Operational failure mode | Grounded in |
+|---|---|---|
+| [`state-and-idempotency`](references/state-and-idempotency.md) | convergent re-apply, state locking, single-writer | F1.2, F1.3 |
+| [`blast-radius`](references/blast-radius.md) | destroy/replace gating, `prevent_destroy`, proposer≠approver | F3.1, F3.2 |
+| [`environment-isolation`](references/environment-isolation.md) | throwaway/staging vs prod, separate state/accounts | F3.3 |
+| [`cost-and-teardown`](references/cost-and-teardown.md) | cost-ceiling-as-gate, destroy-on-fail, TTL, no orphans | F3.4, F3.5 |
+| [`drift-and-rollback`](references/drift-and-rollback.md) | read-only drift detection, known-good re-apply path | F1.4, F2.6 |
+| [`observability-and-smoke`](references/observability-and-smoke.md) | active end-to-end probe, log access, health, verify-status | F2.2; taxonomy follow-up |
+
+`state-and-idempotency` (write-path convergence) and `drift-and-rollback`
+(divergence detection + recovery) are kept **deliberately separate** — every
+major operational taxonomy splits the two (AWS Well-Architected *Change
+Management* vs *Failure Management*; Google SRE *Release Engineering* vs
+*Incident Response*; Terraform `apply` vs `-refresh-only`; Pulumi Day-1 vs
+Day-2). `observability-and-smoke` is its own sixth module, not folded into
+reliability prose, because "load the real URL, confirm render, read the logs to
+debug a failed smoke" is a distinct active-probe + telemetry concern.

--- a/packs/core/.apm/skills/operational-safety/references/blast-radius.md
+++ b/packs/core/.apm/skills/operational-safety/references/blast-radius.md
@@ -1,0 +1,50 @@
+# blast-radius — destroy/replace gating, prevent-destroy, proposer≠approver
+
+> **Loaded when:** the change can delete or replace existing infrastructure,
+> alters a resource whose replacement is destructive (a recreated database, a
+> renamed stateful resource), or runs a destroy/teardown path against a shared
+> or production environment.
+> **Grounded in:** F3.1 (parse the plan structurally; gate on destroy/replace
+> counts), F3.2 (decouple proposer identity from approver identity).
+> Operational taxonomy: the destructive-op-needs-human-approval rule already in
+> AGENTS.md "Check before acting".
+> **Delegation legend:** `tool` = scanner / CI-gate-owned · `hybrid` = gate
+> surfaces the signal, you judge the fix · `reason` = reviewer-only judgment.
+
+The cost of a wrong line here is the highest in the loop — a single misjudged
+replace can drop a production datastore. Gate on **what the plan will actually
+destroy**, not on a hopeful read of the diff.
+
+## Implementation checks
+
+- `tool` **Parse the plan structurally; gate on destroy/replace counts.**
+  Compute the planned `delete` / `replace` actions from the machine-readable
+  plan (the structured plan output, not grepped text), and fail the step on a
+  nonzero destructive count unless an explicit override is present. Confirm this
+  parse-and-gate runs before any apply.
+- `reason` **Destructive count never read from text.** Grepping apply logs or
+  the human-readable diff for "destroy" is unreliable; the gate must read the
+  structured plan. Flag any gate that pattern-matches prose.
+- `reason` **Proposer ≠ approver for irreversible ops.** The identity that
+  proposes a destructive change must not be the identity that approves it — the
+  agent proposes, a *different* identity (the human) approves. This maps onto
+  "get user confirmation for destructive commands" in AGENTS.md; flag a path
+  where the agent could self-approve a destroy/replace.
+- `reason` **Must-survive resources are pinned.** Resources that must not be
+  destroyed carry an explicit prevent-destroy guard — and the reviewer notes
+  that such guards are bypassable (removing the block, surgical state edits), so
+  a change that *removes* a prevent-destroy guard is itself a destructive-intent
+  signal worth surfacing.
+
+## Established-pattern bypass
+
+Resolve the repo's sanctioned destructive-op gate — the plan-parse check in CI,
+the required-reviewer environment, the change-approval workflow — and flag a
+change that routes a destroy around it (a direct teardown command, a
+`--auto-approve` on a destructive apply). The blessed gate is where
+proposer≠approver was already enforced.
+
+*Illustrative only (never normative):* `plan -out` → structured-plan parse →
+count `delete`/`replace`, or a required-reviewer rule on a protected
+environment, exhibit this shape — but the check is the *property*
+(parsed-plan gating + identity separation), not any one tool.

--- a/packs/core/.apm/skills/operational-safety/references/cost-and-teardown.md
+++ b/packs/core/.apm/skills/operational-safety/references/cost-and-teardown.md
@@ -1,0 +1,48 @@
+# cost-and-teardown — cost-ceiling-as-gate, destroy-on-fail, TTL, no orphans
+
+> **Loaded when:** the change provisions billable resources, creates ephemeral
+> or per-iteration infrastructure, or runs a teardown path — anything that can
+> leave a paid-for resource running after the work is done.
+> **Grounded in:** F3.4 (cost is a first-class CI gate, not a post-deploy
+> surprise), F3.5 (tag-at-creation TTL + destroy-on-close prevents orphans;
+> destroy needs its own plan). Operational taxonomy: AWS Well-Architected Cost
+> Optimization; the ephemeral-environment lifecycle pattern.
+> **Delegation legend:** `tool` = scanner / CI-gate-owned · `hybrid` = gate
+> surfaces the signal, you judge the fix · `reason` = reviewer-only judgment.
+
+An agentic loop that provisions on each iteration leaks money invisibly: the
+failure mode is not a crash but a bill. Estimate cost **from the plan, before
+apply**, and make teardown as deliberate as creation.
+
+## Implementation checks
+
+- `tool` **Cost is estimated from the plan and gated on a ceiling.** A
+  cost-diff runs on the planned change and a budget ceiling (absolute, percent,
+  or budget) blocks the apply when exceeded. Confirm the cost gate is wired; if
+  none is detected, flag `degraded: no cost gate` rather than passing silently.
+- `reason` **Destroy-on-fail / no half-built stacks.** A failed apply or smoke
+  must tear down what it created rather than leaving a partial stack accruing
+  cost. Flag a path where a failed run exits leaving resources up with no
+  cleanup.
+- `reason` **TTL / tag-at-creation for ephemeral resources.** Resources created
+  for iteration carry a TTL or ownership tag a scheduled cleanup can find, so an
+  abandoned run is reclaimable. Untagged, unbounded-lifetime ephemeral resources
+  are the orphan source.
+- `reason` **Destroy has its own plan.** A teardown is a destructive operation
+  in its own right — preview the destroy plan before running it (it inherits the
+  `blast-radius` gating), don't fire an unreviewed bulk destroy.
+- `hybrid` **No orphans after a normal run.** After a successful iterate-and-
+  teardown cycle, no created resource is left behind. Confirm the teardown
+  enumerates everything the apply created.
+
+## Established-pattern bypass
+
+Resolve the repo's sanctioned lifecycle harness — the cost-diff CI gate, the
+ephemeral-environment create/destroy automation, the TTL-tag-and-sweep
+convention — and flag a change that provisions billable resources outside it
+(no cost gate, no teardown, no TTL tag).
+
+*Illustrative only (never normative):* a cost-diff status check on PRs plus a
+TTL tag swept by a scheduled cleanup, or create-on-open / destroy-on-close
+per-PR environments, exhibit this shape — but the check is the *property*
+(cost-as-gate + bounded lifecycle + no orphans), not any one tool.

--- a/packs/core/.apm/skills/operational-safety/references/drift-and-rollback.md
+++ b/packs/core/.apm/skills/operational-safety/references/drift-and-rollback.md
@@ -1,0 +1,67 @@
+# drift-and-rollback — read-only drift detection, known-good re-apply path
+
+> **Loaded when:** the change manages long-lived infrastructure that can drift
+> from its declared state, or where a deploy needs a defined recovery path if
+> the smoke probe fails.
+> **Grounded in:** F1.4 (drift detection is read-only and separable from
+> remediation; auto-remediation default is contested), F2.6 (no atomic
+> rollback — re-apply the prior known-good config). Operational taxonomy: AWS
+> Well-Architected Failure Management; Google SRE Incident Response; Pulumi
+> Day-2 drift detection + remediation.
+> **Delegation legend:** `tool` = scanner / CI-gate-owned · `hybrid` = gate
+> surfaces the signal, you judge the fix · `reason` = reviewer-only judgment.
+
+This is the **divergence-detection-and-recovery** lens — deliberately separate
+from `state-and-idempotency`'s write-path convergence (every major operational
+taxonomy splits the two). Detection is safe, frequent, and read-only; recovery
+is mutating and gated.
+
+## Implementation checks
+
+- `reason` **Drift detection is read-only.** The "are we drifted?" check must
+  not mutate — it compares declared vs. live state and reports, separate from
+  any remediation step. Flag a detection path that silently corrects as it
+  reads.
+- `reason` **A known-good re-apply path is named *before* the first apply.**
+  There is no atomic rollback for a partially applied deploy; the recovery path
+  is re-applying the previous versioned known-good config, not state surgery.
+  Confirm this path is named in the plan's `## Rollout` (the work-loop's infra
+  verification mode requires it before the first apply).
+- `reason` **Early detection over hard rollback.** Because rollback is hard,
+  small increments and a real smoke probe (see `observability-and-smoke`) are
+  what keep rollback rarely needed. Flag a large, all-at-once apply with no
+  early-detection layer in front of it.
+
+## The auto-remediation default — an unresolved tension (surface, do not resolve)
+
+Whether detected drift should be **gated** (detect → alert → a human decides
+whether to re-apply) or **auto-synced** (continuously reconcile, auto-reverting
+any out-of-band change) is a **genuine, unresolved tension** — both defaults are
+well-evidenced under different conditions:
+
+- **Gate it** — the Terraform-community default: detection is read-only and
+  remediation is a separate, human-gated step, because an auto-revert can stomp
+  a legitimate emergency hotfix applied out-of-band.
+- **Auto-sync** — the GitOps default (Argo CD, Flux): continuous reconciliation
+  treats the declared state as the single source of truth and auto-reverts
+  drift, because allowing drift to persist is itself the risk.
+
+**This module surfaces the tension; it does not pick a side.** When reviewing,
+name which default the change assumes and whether that default fits *this*
+resource's risk profile — an auto-syncing reconciler on a resource that takes
+legitimate emergency edits is a finding; a gated detector on a
+must-never-drift security control may be too lax. The right answer is
+context-dependent, so flag a mismatch, don't impose one default.
+
+## Established-pattern bypass
+
+Resolve the repo's sanctioned drift / recovery model — the scheduled read-only
+drift check, the versioned-config re-apply runbook, the GitOps reconciler — and
+flag a change that introduces a divergent recovery story (state surgery as the
+rollback plan, an auto-sync reconciler bolted onto a gated environment).
+
+*Illustrative only (never normative):* `plan -refresh-only` for read-only
+drift, re-applying a previous tagged config for recovery, or an Argo CD / Flux
+reconciler for auto-sync, exhibit these shapes — but the checks are the
+*properties* (read-only detection, a named re-apply path, a context-fit
+remediation default), not any one tool.

--- a/packs/core/.apm/skills/operational-safety/references/environment-isolation.md
+++ b/packs/core/.apm/skills/operational-safety/references/environment-isolation.md
@@ -1,0 +1,45 @@
+# environment-isolation — throwaway/staging vs prod, separate state/accounts
+
+> **Loaded when:** the change provisions or iterates against an environment
+> that is, or could touch, production — or where the iteration loop needs a
+> safe place to fail that is not prod.
+> **Grounded in:** F3.3 (environment isolation by account/state boundary).
+> Operational taxonomy: AWS multi-account-per-stage; separate state backends as
+> the IaC-level isolation enforcement.
+> **Delegation legend:** `tool` = scanner / CI-gate-owned · `hybrid` = gate
+> surfaces the signal, you judge the fix · `reason` = reviewer-only judgment.
+
+Iterate **away from prod**. The strongest isolation unit is the
+account / subscription / project boundary; separate state enforces it in IaC.
+The agentic refinement loop — apply, observe, fix, re-apply — belongs in a
+throwaway or staging environment, never against the production stack.
+
+## Implementation checks
+
+- `reason` **Iteration target is not prod.** The change's apply/test/teardown
+  loop runs against a throwaway or staging environment isolated from
+  production. Flag any iteration that converges by repeatedly applying to prod.
+- `reason` **State backends are separated by stage.** Staging credentials and
+  state cannot reach production resources — separate state backends (not a
+  shared backend with a workspace toggle that a typo can cross) enforce the
+  boundary. A single shared state across stages is the finding.
+- `reason` **Account / subscription / project boundary where the blast radius
+  warrants it.** For high-blast-radius infra, the strongest isolation is a
+  distinct account boundary with guardrail policies, not just a namespace. Note
+  where the isolation is weaker than the blast radius justifies.
+- `hybrid` **Credentials are stage-scoped.** The credentials the change runs
+  under are scoped to the target stage; a smoke or teardown step cannot
+  accidentally authenticate against prod. Confirm the scoping; judge whether the
+  scope is genuinely narrow.
+
+## Established-pattern bypass
+
+Resolve the repo's sanctioned environment model — the per-stage account map,
+the separate-state convention, the ephemeral-per-PR environment harness — and
+flag a change that points a new resource at the shared/prod backend instead of
+the stage-isolated one.
+
+*Illustrative only (never normative):* an AWS account-per-stage layout with
+separate Terraform state backends, or per-PR ephemeral environments, exhibit
+this shape — but the check is the *property* (isolation by account/state
+boundary), not any one tool or cloud.

--- a/packs/core/.apm/skills/operational-safety/references/environment-isolation.md
+++ b/packs/core/.apm/skills/operational-safety/references/environment-isolation.md
@@ -30,7 +30,10 @@ throwaway or staging environment, never against the production stack.
 - `hybrid` **Credentials are stage-scoped.** The credentials the change runs
   under are scoped to the target stage; a smoke or teardown step cannot
   accidentally authenticate against prod. Confirm the scoping; judge whether the
-  scope is genuinely narrow.
+  scope is genuinely narrow. *(Carve note: the failure guarded here is the
+  iteration loop converging on prod — a reliability/blast-containment failure;
+  whether a grant is over-broad for **privilege-escalation** purposes is the
+  security lens, owned by `security-checklists`' `config-misconfig`.)*
 
 ## Established-pattern bypass
 

--- a/packs/core/.apm/skills/operational-safety/references/observability-and-smoke.md
+++ b/packs/core/.apm/skills/operational-safety/references/observability-and-smoke.md
@@ -1,0 +1,52 @@
+# observability-and-smoke — active end-to-end probe, log access, health, verify-status
+
+> **Loaded when:** the change deploys a service, site, or endpoint a user
+> reaches — anything where "created" does not yet mean "works" and the deploy
+> needs an active probe plus the telemetry to debug a failed one.
+> **Grounded in:** F2.2 ("created" ≠ "works"; smoke / health checks are
+> mandatory before promotion); taxonomy follow-up — AWS Well-Architected
+> Operational Excellence (understand operational health), Google SRE monitoring
+> as a first-class practice.
+> **Delegation legend:** `tool` = scanner / CI-gate-owned · `hybrid` = gate
+> surfaces the signal, you judge the fix · `reason` = reviewer-only judgment.
+
+A provisioned resource is not a working one. This module is the operational
+extension of the work-loop's visual/manual-QA doctrine ("exercise the real
+built artifact end-to-end") to a deployed system — and the observability that
+lets the agent **debug a failed smoke itself** rather than relay errors to a
+human.
+
+## Implementation checks
+
+- `reason` **Active end-to-end smoke, not a status check.** The verification is
+  a multi-hop probe: seed test / mock users → load the **real** CDN / site URL
+  → assert it actually renders → on failure, pull access / error logs and debug
+  → tear down. A single "stack status: CREATE_COMPLETE" is not a smoke test —
+  flag a deploy whose only post-apply check is resource status.
+- `reason` **A verify-status signal exists.** There is a defined signal that
+  answers "did the deploy report healthy?" — a health endpoint, a post-apply
+  runtime assertion — distinct from the provisioning tool's own exit code.
+- `hybrid` **Access / error logs are reachable for debugging.** When the smoke
+  fails, the logs needed to diagnose it (access logs, error logs, the
+  application's own telemetry) are accessible to the agent driving the deploy —
+  log-driven debugging is the loop, not a human relaying the error back.
+- `reason` **Health / telemetry is designed in, not bolted on.** The service
+  exposes the operational health signals (health endpoint, the key
+  golden-signal metrics) the smoke and ongoing operation depend on. Missing
+  observability is a reliability finding, not a nice-to-have.
+- `reason` **Seed + teardown bracket the probe.** The smoke seeds the test data
+  / mock users it needs and tears them (and any ephemeral resources) down after
+  — so the probe is repeatable and leaves no residue (this meets
+  `cost-and-teardown`).
+
+## Established-pattern bypass
+
+Resolve the repo's sanctioned smoke / observability harness — the end-to-end
+probe script, the health-endpoint convention, the log-access path the deploy
+pipeline already wires — and flag a deploy that declares success on
+provisioning status alone, with no active probe and no reachable logs.
+
+*Illustrative only (never normative):* a post-apply HTTP assertion against the
+live URL plus structured access/error logs, or a deploy-validate-undeploy probe
+harness, exhibit this shape — but the check is the *property* (active
+end-to-end probe + reachable telemetry), not any one tool.

--- a/packs/core/.apm/skills/operational-safety/references/state-and-idempotency.md
+++ b/packs/core/.apm/skills/operational-safety/references/state-and-idempotency.md
@@ -1,0 +1,50 @@
+# state-and-idempotency — convergent re-apply, state locking, single-writer
+
+> **Loaded when:** the change provisions or mutates infrastructure, edits
+> infrastructure-as-code, or drives a stateful migration of a running system —
+> anything where the *write path* may be re-run after a failure.
+> **Grounded in:** F1.2 (declarative + idempotent re-apply is what makes retry
+> safe; imperative scripts collide), F1.3 (shared state needs a single-writer
+> lock). Operational taxonomy: AWS Well-Architected Change Management; the
+> Terraform/Pulumi declarative-convergence model.
+> **Delegation legend:** `tool` = scanner / CI-gate-owned · `hybrid` = gate
+> surfaces the signal, you judge the fix · `reason` = reviewer-only judgment.
+
+Idempotent convergent apply is the **precondition the whole infra loop rests
+on**: re-running after a fix must *converge, not collide*. A non-idempotent
+imperative step is the retry-collision root cause — the thing to fix first
+rather than iterate around.
+
+## Implementation checks
+
+- `reason` **Convergent re-apply.** Re-running the change from a partially
+  applied state must reach the desired state with no duplicate creates and no
+  inconsistent leftovers ("if already in desired state, no actions taken").
+  Declarative definitions get this structurally; an imperative script must add
+  existence-check / conditional-create guards to match it. Flag any step that
+  would re-create an existing resource or error on a second run.
+- `reason` **No imperative non-idempotent step on the write path.** A
+  hand-rolled create/start/stop sequence with no guard is the
+  "manual stop/start errors" failure mode — each failed retry is a fresh mess.
+  Require the guard, or convert the step to declarative.
+- `hybrid` **Single-writer lock on shared state.** When an agent and a human,
+  or two agents, could apply against the same state concurrently, mutation must
+  serialize through a state lock. Confirm the lock mechanism is configured;
+  judge whether the concurrency window is actually closed.
+- `reason` **State integrity over the retry.** A failed apply must not leave
+  state and live resources diverged in a way the next apply can't reconcile.
+  The next run should *read* current reality and converge, not assume the prior
+  run's intent.
+
+## Established-pattern bypass
+
+Resolve the repo's sanctioned convergence mechanism — the declarative IaC
+module, the shared apply wrapper, the locked state backend — and flag a change
+that hand-rolls an imperative provisioning sequence inline instead of extending
+it. The blessed mechanism is where idempotency and single-writer locking were
+already decided, once.
+
+*Illustrative only (never normative):* a `terraform apply` against a
+lock-enabled S3 backend, or a Pulumi `up` against a locked stack, exhibit this
+shape — but the check is the *property* (convergent, single-writer), not any
+one tool.

--- a/packs/core/.apm/skills/security-checklists/SKILL.md
+++ b/packs/core/.apm/skills/security-checklists/SKILL.md
@@ -13,6 +13,14 @@ footer, the output format). The *shape-specific depth* — what to actually
 check at each trust boundary — lives here, in ten `references/<module>.md`
 modules, so the agent prompt stays lean and the depth scales without bloat.
 
+> **Reliability-vs-security carve.** This library owns *security* config; the
+> *reliability / ops* side of infrastructure (idempotent convergence, blast
+> radius, environment isolation, cost/teardown, drift/rollback,
+> observability/smoke) lives in the [`operational-safety`](../operational-safety/SKILL.md)
+> skill, consumed by `quality-engineer`. The routing splits IaC-security →
+> `config-misconfig`, IaC-reliability → `operational-safety`. The two are
+> complementary lenses on the same infra diff — keep the split clean both ways.
+
 ## How it loads (orchestrator-driven, not self-discovered)
 
 **The orchestrator drives loading; the subagent does not.** There is no

--- a/packs/core/.apm/skills/security-checklists/references/config-misconfig.md
+++ b/packs/core/.apm/skills/security-checklists/references/config-misconfig.md
@@ -36,6 +36,38 @@ V14; Proactive Controls 2024 C5).
   `Content-Security-Policy`, TLS verification disabled, or downgraded
   protocol/cipher settings.
 
+## Deferred authority (per-provider secure-config depth)
+
+This module reasons from cross-cutting standards and catches security failure
+*classes*; it deliberately does **not** carry per-provider secure-config
+baselines (they would be stale on arrival and break tool-neutrality). The
+per-provider depth lives in two places, named here by **stable publisher +
+document, with no URL and no version** so the pointer stays evergreen by naming
+rather than linking:
+
+- **CIS Benchmarks** — the per-service hardening baselines.
+- **AWS Well-Architected Security Pillar**, **Microsoft Cloud Adoption
+  Framework / Azure Well-Architected Security**, and **Google Cloud
+  Architecture Framework (Security)** — each provider's standing
+  well-architected security guidance.
+
+The **actual, current per-provider depth lives in the self-updating
+policy-as-code / CSPM scanner** the work-loop's infra preflight requires (its
+vendor-maintained rulesets *are* these baselines, kept fresh by the vendor) —
+not in this pointer. A stale name here never gates a real check; the scanner
+does. Confirm the scanner is wired (the `tool` bullet above) rather than
+re-deriving provider baselines by hand.
+
+## The reliability-vs-security carve
+
+This module owns **IaC *security* config** (IAM, CORS, public exposure, secrets
+posture, TLS). The **reliability / ops** side of infrastructure — idempotent
+convergence, blast radius, environment isolation, cost/teardown, drift/rollback,
+observability/smoke — lives in the **`operational-safety`** skill, consumed by
+`quality-engineer`. Route IaC-security here; route IaC-reliability there. Don't
+pull operational checks into this module, and don't let security config drift
+into an operational one.
+
 ## Established-helper bypass
 
 Resolve the repo's sanctioned config/module (the hardened web-server base, the

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -704,6 +704,39 @@ note in the summary, not a blocker.
   Different lens from adversarial-reviewer — don't skip it because the spec
   already shipped.
 
+  **Inline operational depth on infra/destructive work, don't make it
+  self-discover.** When the diff is **infra-flavored** — the
+  **destructive/irreversible risk trigger** routed it to full mode *and* it
+  provisions, mutates, deploys, or tears down infrastructure — the
+  `quality-engineer` is the consumer of a second progressive-disclosure depth
+  library, [`operational-safety`](../operational-safety/SKILL.md), exactly as
+  `security-reviewer` consumes `security-checklists`. Detect which operational
+  failure modes the change raises, load **only** the matching
+  `operational-safety` modules, and inline their content into the subagent's
+  brief (reusing the same on-demand `references/*.md` loading) — the
+  `quality-engineer`'s `tools:` has no Skill tool, so loading is
+  orchestrator-driven, not model-relevance-judged. **No new reviewer** — this
+  feeds the existing `quality-engineer` (ADR-0023). Route deterministically:
+
+  <a id="operational-safety-routing-table"></a>
+
+  | Operational failure mode the infra/destructive change raises | Inline module(s) |
+  | --- | --- |
+  | Provisioning or mutating infra; stateful migration; any re-runnable write path | `state-and-idempotency` |
+  | Can delete or replace existing infra; destroy/teardown path; removing a prevent-destroy guard | `blast-radius` |
+  | Iterating against (or able to touch) production; shared vs throwaway/staging state | `environment-isolation` |
+  | Provisions billable resources; ephemeral/per-iteration infra; teardown path | `cost-and-teardown` |
+  | Long-lived infra that can drift; a deploy needing a defined recovery path | `drift-and-rollback` |
+  | Deploys a service / site / endpoint a user reaches; needs smoke + telemetry | `observability-and-smoke` |
+
+  Load 1–N modules as the change warrants, **never a flat march of all six** —
+  a one-line config tweak pulls one; a new public-facing stack pulls several.
+  This is the operational twin of the `security-checklists` routing table
+  above, and the **reliability-vs-security carve** holds: IaC-security →
+  `config-misconfig` (the `security-reviewer` pass); IaC-reliability →
+  `operational-safety` (this pass). The two passes are complementary lenses on
+  the same infra diff, not substitutes.
+
 **Dispatch reviewers in parallel when you invoke more than one** per
 the [Parallel dispatch discipline](#parallel-dispatch-discipline)
 documented under EXECUTE — the same rules cover both fan-out sites in

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "0.4.12"
+version = "0.4.13"
 description = "Core agent-ready-repo: work-loop, new-spec, bug-fix skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 readme = "README.md"
 display_name = "Core"
@@ -31,6 +31,9 @@ allowed-scopes = ["repo"]
 # measured by tools/run-pack-evals.py. Deliberately excluded:
 #   - security-checklists — reviewer-internal, never self-discovered (no
 #     user-prompt activation surface).
+#   - operational-safety — reviewer-internal, never self-discovered (the
+#     orchestrator inlines its modules into the quality-engineer brief; it has
+#     no user-prompt activation surface — exactly as security-checklists).
 #   - work-loop — loaded broadly by the plan→execute→review discipline, not by
 #     a narrow user-prompt surface; a clean negative set isn't writable for it.
 [pack.evals]


### PR DESCRIPTION
Implements `docs/specs/operational-safety-checklists/` (RFC-0041 P3 / ADR-0031), a follow-on to Accepted RFC-0041. Adds a prose-only `operational-safety` reference library that gives infra/destructive work an operational-safety depth library the **existing `quality-engineer`** reviewer reasons from — the reliability-side twin of `security-checklists`, **no fourth reviewer** (ADR-0023), **no executable code** (ADR-0031).

## What changed

- **New `operational-safety` skill** — `SKILL.md` + six failure-mode-keyed `references/*.md` modules (`state-and-idempotency`, `blast-radius`, `environment-isolation`, `cost-and-teardown`, `drift-and-rollback`, `observability-and-smoke`), each grounded in the exact RFC-0041 module-table F-citations, written tool-neutral (illustrative examples labelled). `state-and-idempotency` (write-path convergence) is kept deliberately separate from `drift-and-rollback` (divergence detection + recovery), per the RFC taxonomy follow-up; `drift-and-rollback` surfaces the auto-remediation tension (gate-it vs auto-sync) without picking a side.
- **`work-loop` SKILL.md** — `operational-safety` routing table at the REVIEW `quality-engineer` bullet (loads 1–N modules on infra/destructive work, never all six).
- **`quality-engineer.md`** — one consumer note (orchestrator-inlined depth, no self-discovery, remains the consumer; no new reviewer).
- **`security-checklists` `config-misconfig.md`** — URL-free / version-free deferred-authority pointer (CIS Benchmarks + the per-provider well-architected security guidance; the real per-provider depth lives in the self-updating scanner). Reliability-vs-security carve stated in **both** skills.
- **Release hygiene** — `core` 0.4.12 → 0.4.13 (`pack.toml` + `plugin.json`), `marketplace.json` reprojected via `make build-self`, `[Unreleased]` changelog entry, `operational-safety` excluded from `[pack.evals]`.

## How verified

Goal-based + judgmental (no executable logic, mirrors how `security-checklists` was verified):
- `make build-check` exit 0; `tools/lint-agent-artifacts.py` + `tools/lint-agents-md.py` pass; `lint-spec-status.py` clean (Shipped transition, all 10 ACs `[x]`). SAST legitimately skipped — prose/toml/json only, no SAST-relevant file.
- Greps confirm: six modules with exact names + exact per-module F-citations; routing table 1–N; pointer URL/version-free; carve both ways; no security config leaked into operational modules; `loop-cohort.py`/`lint-spec-status.py` byte-unchanged; skill ships only `.md` (no `scripts/`).
- **REVIEW:** pre-EXECUTE `adversarial-reviewer` (spec/plan) → applied 4 Concerns + 2 Nits sharpening the spec (AC2 reworded to "exactly the six RFC-0041 modules", AC3 pins per-module F-citations, AC8 broadened to a no-scripts check). Diff-stage `adversarial-reviewer` (no Blockers) + `quality-engineer` (`Clean`) — applied both findings (carve self-doc note in `environment-isolation`; flipped spec to Shipped + checked ACs).

## Notes

- Spec sharpened in this PR (same-PR amendment); spec Status → **Shipped**, plan → **Done** (spec+code land atomically).
- Sibling `infra-aware-work-loop` already shipped (`f62f0fe`); the `work-loop` co-edit targets the distinct `quality-engineer` bullet, so no collision.
- No separate publish step — for a catalogue pack, the version bump + `marketplace.json` reprojection (at HEAD on merge) *is* the release.