### PR TITLE
feat(agentbundle): preview/confirm the remaining mutating CLI verbs; drop dead --scope flags

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -272,6 +272,24 @@ jobs:
           tests/unit/test_install_event_dropped_wirings.py
           tests/unit/test_validate_hook_wiring_per_file_compatibility.py
 
+      # CLI-hygiene sweep (agentbundle-cli-hygiene spec): the shared confirm
+      # helper, uninstall --dry-run/--yes/confirm, install --force confirm +
+      # the install→upgrade offer, and the dropped --scope flags. The CLI
+      # command suites are not otherwise CI-wired (CI does not auto-discover
+      # package pytest), so the new preview/confirm behaviour would never gate
+      # without this step.
+      - name: pytest CLI-hygiene sweep (agentbundle-cli-hygiene)
+        working-directory: packages/agentbundle
+        run: >-
+          python -m pytest
+          tests/unit/test_confirm_helper.py
+          tests/integration/test_uninstall_cmd.py
+          tests/integration/test_install_upgrade_offer.py
+          tests/unit/test_install_inband_detection.py
+          tests/unit/test_cli_scope_flags.py
+          tests/integration/test_reconcile.py
+          tests/unit/test_list_targets_cmd.py
+
       - name: converters source-attribution scrub (AC2)
         run: |
           # rg exits 0 with hits, 1 with no matches, ≥2 on error

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -943,3 +943,31 @@ GenAI/agentic overlay only; ML / SaaS / serverless stay **named-but-unbacked**
 (status quo), neither backed nor removed. **Unblocks when:** a future RFC takes
 on backing one of them with its own workload-class lens reference; until then
 the rubric names them as known, deferred gaps.
+
+### scope-disambiguator-extraction
+
+**Spec:** [agentbundle-cli-hygiene](specs/agentbundle-cli-hygiene/spec.md)
+(§ Declined / deferred). The multi-scope disambiguator block — read both state
+files + the identical "installed at multiple scopes; pass --scope {repo, user}"
+refusal — is duplicated across `commands/uninstall.py`, `commands/upgrade.py`,
+and `commands/diff.py`. The CLI-hygiene sweep extracted the confirm mechanics to
+`_common` but deferred this one: each command's *downstream* of the detection
+diverges sharply (root rebind + `user_prefixes`; `allowed_prefixes` + recorded
+adapter; `pack_state` for the render-shape pick), so a helper leaves most of each
+block behind and would pull `diff` (otherwise untouched) into a security-sensitive
+path-jail refactor. **Unblocks when:** someone is already touching all three
+commands' scope handling and can carry the shared detection + refusal into a
+`_common` helper as a net simplification.
+
+### force-cleanup-symlink-confinement
+
+**Spec:** [agentbundle-cli-hygiene](specs/agentbundle-cli-hygiene/spec.md)
+(§ Declined / deferred; diff-stage security-review Nit). `install`'s
+`_scan_dist_tree_artifacts` uses `base.rglob("*")` and the `--force` cleanup uses
+`shutil.rmtree(subtree)` — neither follows the `os.walk(followlinks=False)` +
+per-entry symlink-skip convention the pack-content walks elsewhere use, so a
+symlink planted under `claude-plugins/<pack>/` or `apm/<pack>/` could be listed /
+deleted through. **Pre-existing**, not introduced by the preview/confirm sweep;
+listing the subtree root as the deletion unit avoids widening the divergence.
+**Unblocks when:** a hardening pass adopts the no-follow walk convention for the
+`--force` scan + delete, consistent with `commands/_common.deliver_seeds`.

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -19,6 +19,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`agentbundle uninstall` gains `--dry-run` and `--yes`, and confirms before
+  removing anything.** Previously `uninstall` deleted every bundle-owned (Tier-1)
+  file immediately with no preview. It now classifies each recorded file
+  (`remove` Tier-1 / `keep` Tier-2) and: `--dry-run` prints that plan and writes
+  nothing; without `--dry-run` it asks before the first removal (`--yes` skips
+  the prompt; a non-interactive stdin refuses rather than hanging). Adopter-edited
+  files are still preserved exactly as before.
+- **`agentbundle install --force` confirms before its destructive cleanup, and
+  `install` offers to upgrade an already-installed pack.** `--force` now lists the
+  paths it will remove (the pre-RFC-0012 dist-tree subtrees, or orphan files) and
+  asks before deleting; `install` gains `--yes` to skip that prompt. Used purely
+  as a cross-scope bypass (no deletion), `--force` is unchanged and never prompts.
+  **Migration:** CI that runs the *deleting* form of `install --force`
+  non-interactively must now add `--yes` (a non-TTY without `--yes` refuses rather
+  than deleting unattended — mirroring `upgrade`). Separately, installing a pack
+  already installed at the requested scope now offers to run `upgrade` instead of
+  flatly refusing; `install --yes` runs it, and a non-interactive stdin keeps the
+  old `use 'upgrade'` refusal.
+- **`agentbundle reconcile` and `list-targets` drop their dead `--scope` flag.**
+  `reconcile`'s `--scope` had a single legal value (`user`) equal to its default,
+  and `list-targets`'s `--scope` was parsed but never read; both are removed, so
+  passing `--scope` to either now reports `unknown flag for <verb>: --scope`.
+  Default behaviour of both verbs is unchanged.
+
 - **`agentbundle upgrade` no longer takes `--to`; it derives the version and
   confirms (breaking).** The upgrade target is now read from the catalogue you
   point at (its `pack.toml` `[pack] version`) instead of an operator-supplied

--- a/docs/specs/agentbundle-cli-hygiene/plan.md
+++ b/docs/specs/agentbundle-cli-hygiene/plan.md
@@ -1,0 +1,123 @@
+# Plan: agentbundle CLI-hygiene sweep
+
+One PR. The `agentbundle 0.6.0 → 0.7.0` release is cut separately after merge;
+this plan does NOT bump the version.
+
+## Trio
+
+- **Files touched**: `commands/_common.py` (new confirm helper),
+  `commands/uninstall.py`, `commands/install.py`, `commands/upgrade.py`
+  (refactor to the helper), `commands/reconcile.py`, `commands/list_targets.py`,
+  `cli.py` (flags + docstring); tests under `tests/`; `docs/product/changelog.md`;
+  `docs/backlog.md`.
+- **Done when**: all ACs pass via `python -m pytest packages/agentbundle/tests/`;
+  the four CLI verbs exercised end-to-end (real argparse invocation) for the new
+  preview/confirm paths; existing string-pinning tests unchanged.
+- **Not changing**: Tier-1/2/3 file-safety, upgrade target resolution,
+  `reconcile` read-only posture, the profile/batch install path, the
+  `--dry-run`/`--force` mutex.
+
+**Declined temptations**: (1) extracting the multi-scope disambiguator into
+`_common` — declined/deferred (see spec § Declined; divergent downstreams + pulls
+`diff` into a path-jail refactor). (2) a generic `--dry-run` plan abstraction for
+uninstall's remove/keep verbs — declining; `format_plan_line` is reused as-is and
+uninstall prints its own one-line summary (its verbs differ from
+install/upgrade's create/overwrite/companion, so `summarize_plan` doesn't fit).
+(3) adding `--dry-run --force` preview to install — declining; confirm is the
+preview, mutex kept.
+
+## Task 1 — shared confirm helper in `_common.py`
+
+`confirm_or_refuse(*, yes, question, refuse_message, abort_message) -> bool`:
+returns True to proceed; on `yes` returns True without touching stdin; on
+non-TTY prints `refuse_message` to stderr and returns False; on TTY reads
+`input(question)` (EOF → ""), returns True only for `y`/`yes` (case-insensitive,
+stripped), else prints `abort_message` and returns False. Caller owns the
+`--dry-run` short-circuit (dry-run returns before calling).
+
+- **Verification mode**: TDD.
+- **Tests** (`tests/unit/test_confirm_helper.py`): yes→True no input; non-TTY→
+  False + refuse_message on stderr; TTY "y"/"yes"/"  YES "→True; TTY "n"/""→False
+  + abort_message; EOF→False.
+- **Approach**: pure-stdlib helper; `sys.stdin.isatty()` + `input()`.
+
+## Task 2 — refactor `upgrade.py` to the helper
+
+Replace upgrade's inline confirm block (the `not yes and not dry_run` branch)
+with a `confirm_or_refuse` call, preserving the exact `already_current` prompt
+wording, the refuse message, and the `"upgrade: aborted; no changes made"`
+abort message. The `already_current` "is already at … ; re-applying" stderr in
+the `--yes`/`--dry-run` branch stays inline.
+
+- **Verification mode**: goal-based (existing `test_upgrade_cmd.py` confirm
+  tests are the contract — they must stay green unchanged).
+- **Tests**: existing `test_upgrade_cmd.py::test_confirmation_*`,
+  `test_yes_skips_prompt`, `test_non_tty_without_yes_refuses`,
+  `test_dry_run_no_prompt_no_write`.
+- **Depends on**: Task 1.
+
+## Task 3 — `uninstall` dry-run + confirm
+
+Restructure `uninstall.run` into a classification pass (build an ordered
+`decisions: list[(relpath, "remove"|"keep")]`, printing jail/prefix
+"refusing to touch" warnings as today, skipping absent files), then:
+`--dry-run` → print `format_plan_line` per decision + one-line summary, return 0;
+else `confirm_or_refuse` (skip on `--yes`); else the execution pass
+(os.remove for `remove`, "keeping adopter-edited file" warning for `keep`),
+then the existing hook-wiring unproject + prune + state write + summary.
+
+- **Verification mode**: visual/manual QA (CLI) + integration tests.
+- **Tests** (`test_uninstall_cmd.py`): update `_run_uninstall` to default
+  `yes=True`, add `dry_run` param; add dry-run-writes-nothing, TTY accept/decline/
+  EOF, `--yes`-no-input, non-TTY-refuses, remove/keep-parity.
+- **Manual QA**: run `python -m agentbundle uninstall --pack <p> --dry-run` and
+  the real confirm against a temp install; record stdout/exit.
+- **Depends on**: Task 1.
+
+## Task 4 — `install --force` confirm + `--yes` flag + upgrade offer
+
+(a) Add `--yes` to install argparse (cli.py). (b) In `_classify_pre_rfc0012_state`,
+thread `yes: bool`; in each `if force:` destructive branch, `confirm_or_refuse`
+**before the first mutation** (decline → return 1, nothing deleted/popped/rewritten).
+Dist-tree branch: list the subtree roots (`claude-plugins/<pack>`, `apm/<pack>`)
+that exist — the actual `rmtree` unit — and gate the rmtree + `packs.pop` + state
+rewrite atomically. Orphan branch: list the exact files, gate the `unlink` loop.
+(c) In Step 4a (already-installed-at-requested-scope), keep the non-TTY/dry-run
+refusal (message preserves `already installed at <scope>` + `use 'upgrade' to
+change version`) but on TTY-without-`--yes` offer to upgrade, and on `--yes` run
+upgrade. The handoff (`_offer_upgrade` helper) builds an upgrade namespace with
+the FULL attribute set `upgrade.run` reads — `pack`, `catalogue`, `root`
+(=`args.output`), `scope` (concrete `requested_scope`, never None), `yes=True`,
+`dry_run=False`, `skill=agent=hook=seed=command=None`, `_user_config` threaded —
+and returns `upgrade.run(ns)`.
+
+- **Verification mode**: visual/manual QA (CLI) + integration tests.
+- **Tests**: `test_install_inband_detection.py::test_b_force_cleans_*` +
+  `test_install_orphan_reshape.py` + `test_orphan_cleanup_respects_foreign_state.py`
+  pass `--yes`/`yes=True`; new tests for force-confirm-lists-paths,
+  non-TTY-refuse-with-**zero-deletions** (assert subtree/orphans still on disk),
+  offer-accept-runs-upgrade, `--yes`-runs-upgrade, non-TTY-keeps-refusal,
+  dry-run-keeps-refusal.
+- **Manual QA**: real argparse invocation of the offer + force confirm.
+- **Depends on**: Task 1.
+
+## Task 5 — drop dead `--scope` flags
+
+Remove `--scope` from `reconcile` and `list-targets` in cli.py; remove the dead
+`cli_scope != "user"` refusal in `reconcile.run`; update the cli.py module
+docstring (RFC-0004 surface list) to drop `list-targets` and note `reconcile`.
+
+- **Verification mode**: goal-based + unit.
+- **Tests**: `test_cli_scope_flags.py` — move `list-targets` from accepted →
+  rejected, add `reconcile`, fix the "six subcommands" docstring/count; assert
+  `reconcile`/`list-targets` reject `--scope`. `test_reconcile.py` /
+  `test_list_targets_cmd.py` unchanged in behaviour.
+- **Depends on**: none (independent of Tasks 1–4).
+
+## Task 6 — changelog + backlog
+
+`docs/product/changelog.md` `[Unreleased]`: add the three bullets. `docs/backlog.md`:
+record the deferred scope-disambiguator extraction.
+
+- **Verification mode**: goal-based (CI changelog warn).
+- **Depends on**: Tasks 3–5 (describes their shipped behaviour).

--- a/docs/specs/agentbundle-cli-hygiene/spec.md
+++ b/docs/specs/agentbundle-cli-hygiene/spec.md
@@ -1,0 +1,226 @@
+# Spec: agentbundle CLI-hygiene sweep
+
+- **Status:** Shipped
+- **Mode:** full (risk triggers: public-interface change; destructive/irreversible operation; security boundary — file deletion)
+
+Follow-up to merged PR #374 (which removed `agentbundle upgrade --to` and
+added a derive-version-from-catalogue + interactive-confirm flow). This sweep
+applies the same critical lens to the rest of the `agentbundle` CLI surface:
+the mutating verbs that lack a preview/confirm, and two dead `--scope` flags.
+
+## Objective
+
+Bring the remaining `agentbundle` CLI verbs up to the safety bar PR #374 set
+for `upgrade`: every mutating verb previews and confirms before it writes or
+deletes, and dead flags are removed. Specifically:
+
+1. `uninstall` gains `--dry-run`, `--yes`, and an interactive confirmation —
+   today it is the only mutating verb with no preview, and it `os.remove`s
+   every Tier-1 file immediately.
+2. `install --force` confirms (listing the paths) before its destructive
+   cleanup — today the cleanup (`rmtree` of `claude-plugins/<pack>` and
+   `apm/<pack>`, plus orphan `unlink`) runs with no preview, and `--force` is
+   mutex with `--dry-run`, so the deletion is unpreviewable.
+3. `install` gains `--yes` and turns its already-installed "use 'upgrade'"
+   refusal into an interactive offer that runs the upgrade on confirmation.
+4. The dead `--scope` flags on `reconcile` (single legal value `user`, also the
+   default) and `list-targets` (parsed but never read) are dropped.
+
+The confirmation / non-TTY-refuse / `--yes` mechanics are factored out of
+`commands/upgrade.py` into a shared `commands/_common.py` helper and reused.
+
+## Acceptance Criteria
+
+### `uninstall` preview + confirm
+
+- [x] **AC1** — `uninstall --dry-run` previews the per-file plan (one line per
+  recorded file: `remove tier-1 <path>` for files whose on-disk SHA matches the
+  recorded SHA, `keep tier-2 <path>` for adopter-edited / SHA-mismatched files)
+  plus a one-line summary, and writes nothing: no file removed, no state
+  rewrite, no hook-wiring unproject, no empty-dir prune. Exits 0.
+- [x] **AC2** — `uninstall` without `--dry-run` and without `--yes`, on an
+  interactive TTY, prompts before the first `os.remove`; declining (anything
+  other than `y`/`yes`, including EOF) aborts with a stderr message and writes
+  nothing (exit 1).
+- [x] **AC3** — `uninstall --yes` proceeds without reading stdin (never calls
+  `input()`).
+- [x] **AC4** — `uninstall` on a non-TTY stdin without `--yes` refuses with a
+  stderr message naming `--yes`, never blocks on `input()`, and writes nothing
+  (exit 1). `--dry-run` short-circuits this refusal (a dry run writes nothing,
+  so it is safe non-interactively without `--yes`).
+- [x] **AC5** — the remove/keep decision shown by `--dry-run` and the prompt's
+  file counts are computed by the same Tier-1/Tier-2 classification the real
+  removal uses; a real `uninstall --yes` removes exactly the files `--dry-run`
+  labelled `remove` and preserves byte-for-byte exactly those labelled `keep`
+  (the existing Tier-2 preservation contract is unchanged). The execution pass
+  acts on the classification pass's recorded decisions — it does **not** re-hash
+  between the preview/prompt and the `os.remove` — so the bytes shown are the
+  bytes removed (the Tier-1 SHA is captured once, at classification time; the
+  confirm-reading window is not re-checked, matching the no-divergence property
+  the preview promises).
+
+### `install --force` confirm
+
+- [x] **AC6** — when `install --force` would delete on-disk paths, it lists what
+  it will remove on stderr and confirms before deleting. The listed unit is the
+  actual deletion unit: for the dist-tree branch, the subtree roots
+  (`claude-plugins/<pack>`, `apm/<pack>`) that `shutil.rmtree` removes (not an
+  rglob file list that could diverge from what `rmtree` actually takes); for the
+  orphan branch, the exact files to be `unlink`ed. The confirm gates the **whole
+  destructive block atomically** — for the dist-tree branch that is the `rmtree`
+  **and** the in-memory `repo_state.packs.pop` **and** the `.agentbundle-state.toml`
+  rewrite — so declining returns 1 having mutated neither disk files, nor the
+  state file, nor in-memory state (the confirm sits before the first mutation).
+- [x] **AC7** — `install --force --yes` performs the cleanup without reading
+  stdin; `install --force` on a non-TTY stdin without `--yes` refuses (names
+  `--yes`) and exits 1 with **zero** filesystem deletions — the subtree / orphan
+  files still exist on disk after the refusal (the refuse is the first
+  side-effecting gate, reached before any `rmtree` / `unlink`).
+- [x] **AC8** — `install --force` that does NOT trigger a destructive cleanup
+  (e.g. the cross-scope-conflict bypass, where nothing on disk is deleted) does
+  not prompt — behaviour is unchanged from today.
+- [x] **AC9** — `--dry-run` remains mutex with `--force` (the existing refusal
+  is kept); the confirm is the preview mechanism for `--force`.
+
+### `install` → `upgrade` offer
+
+- [x] **AC10** — `install` gains `--yes` (defaults False), accepted by argparse.
+- [x] **AC11** — `install` of a pack already installed at the requested scope,
+  on an interactive TTY without `--yes`, offers to run `upgrade` instead;
+  confirming runs the whole-pack upgrade against the same catalogue/scope and
+  returns its exit code. The handoff passes the **concrete** install-resolved
+  scope (never `None`) so `upgrade`'s own multi-scope disambiguator is a no-op.
+- [x] **AC12** — `install --yes` of a pack already installed at the requested
+  scope runs the upgrade without prompting (the handoff calls `upgrade.run` with
+  `yes=True`, since the install-side offer is the confirmation).
+- [x] **AC13** — `install` of an already-installed pack on a non-TTY stdin
+  without `--yes` (the existing behaviour for CI) still refuses with a stderr
+  message containing `already installed at <scope>` and `use 'upgrade' to
+  change version`, and exits 1 — no silent upgrade. `install --dry-run` of an
+  already-installed pack keeps the same refusal (no offer, no prompt).
+- [x] **AC14** — the offer applies to the single-pack `install` path only; the
+  profile/batch path's already-installed handling (skip already-installed packs
+  before calling `run`, per `docs/specs/pack-profiles/spec.md` AC6 / RFC-0034)
+  is unchanged and still never emits the "use 'upgrade'" line
+  (`test_install_profile.py` pins `"use 'upgrade'" not in err`).
+
+### Dead-flag removal
+
+- [x] **AC15** — `reconcile` no longer registers `--scope`; `reconcile` (no
+  flag) runs the user-scope report exactly as before, and `reconcile --scope
+  user` now refuses with the documented `unknown flag for reconcile: --scope`.
+- [x] **AC16** — `list-targets` no longer registers `--scope`; `list-targets`
+  output is unchanged, and `list-targets --scope user` refuses with
+  `unknown flag for list-targets: --scope`.
+
+### Shared mechanics
+
+- [x] **AC17** — the confirm/refuse/`--yes` *decision* (yes→proceed; non-TTY→
+  refuse; TTY→prompt; `y`/`yes`→proceed, else→abort; EOF→abort) lives in one
+  helper in `commands/_common.py`, used by `uninstall`, `install --force`, the
+  `install`→`upgrade` offer, and `upgrade` (refactored to call it). Command-
+  specific pre/post messaging (e.g. `upgrade`'s already-current "re-applying"
+  notice in its `--yes`/`--dry-run` branch, and the per-branch path listing for
+  `install --force`) stays at the call site, which passes the
+  `question`/`refuse_message`/`abort_message` strings — so the exact stderr
+  strings every existing test pins are preserved.
+
+## Boundaries
+
+### Always do
+
+- Route every write/delete through the existing `safety.write_jailed` /
+  path-jail and Tier classification — the confirm/preview sits *in front of*
+  those, never replaces them.
+- Preserve the exact stderr substrings existing tests assert (notably
+  `already installed at <scope>` + `use 'upgrade' to change version`, and the
+  Tier-2 "keeping adopter-edited file" preservation contract).
+
+### Ask first
+
+- Any change to the upgrade target-resolution or Tier-classification logic
+  itself (this sweep is about preview/confirm and flag hygiene, not re-deriving
+  what gets written).
+
+### Never do
+
+- Do not allow `--dry-run --force` on `install` (kept mutex; the confirm is the
+  preview for `--force`).
+- Do not add a `--apply` mode to `reconcile` (it stays read-only).
+- Do not change the Tier-1/2/3 file-safety contract or what `uninstall` /
+  `install` actually remove.
+- Do not extend the install→upgrade offer to the profile/batch path.
+
+## Testing Strategy
+
+- Unit (argparse surface): `--yes` on `install` defaults False and is accepted;
+  `--scope` removed from `reconcile` and `list-targets` (rejected with the
+  documented stderr); existing `--scope`-accepted set drops `list-targets`.
+- Integration (`uninstall`): dry-run previews + writes nothing; TTY confirm
+  accept/decline/EOF; `--yes` skips prompt; non-TTY refuses; remove/keep parity
+  with the real run.
+- Integration (`install --force`): destructive cleanup confirms + lists paths;
+  `--yes` skips; non-TTY refuses + deletes nothing; non-destructive `--force`
+  does not prompt.
+- Integration (`install`→`upgrade`): TTY offer accept runs upgrade; `--yes`
+  runs upgrade; non-TTY + no `--yes` keeps the refusal; dry-run keeps refusal;
+  profile path unchanged.
+- Confirm-helper TTY/non-TTY/EOF behaviour is exercised through the four call
+  sites; `upgrade`'s existing confirm tests continue to pass unchanged.
+
+## Assumptions
+
+- **Verified** — `install --yes` semantics: `--yes` answers yes to both the
+  force-cleanup confirm and the upgrade offer (one flag, two confirm sites).
+  This makes `install --yes` on an already-installed pack run an upgrade rather
+  than no-op-refuse; this is the intended "make it so" semantic and is
+  documented in the changelog.
+- **Verified** — the force-confirm is placed inside the destructive branches of
+  `_classify_pre_rfc0012_state`, so `--force` used purely as a cross-scope
+  bypass (no on-disk deletion) does not prompt; only the rmtree/unlink paths do.
+- **Verified** — the install→upgrade handoff constructs an `upgrade` args
+  namespace carrying the full attribute set `upgrade.run` reads: `pack`,
+  `catalogue` (the install catalogue), `root` (= `install.output`), `scope` (the
+  **concrete** install-resolved scope, never `None`), `yes=True` (the install
+  offer is the confirmation), `dry_run=False`, all five primitive flags
+  (`skill`/`agent`/`hook`/`seed`/`command`) set `None` (whole-pack), and
+  `_user_config` threaded through (so adapter resolution matches a direct
+  `upgrade` invocation). It calls `upgrade.run` and returns that exit code.
+
+### Backward-compatibility note
+
+- `install --force` used purely as a **cross-scope-conflict bypass** (no on-disk
+  deletion) is unchanged — it does not prompt and runs non-interactively as
+  before (AC8). But `install --force` that would **delete** files (the
+  pre-RFC-0012 dist-tree cleanup or orphan cleanup) now refuses on a non-TTY
+  stdin without `--yes`, where previously it deleted unattended. CI that relies
+  on the deleting form of `--force` must add `--yes`. This is the intended
+  safety hardening (it mirrors `upgrade`'s non-TTY posture from PR #374) and is
+  called out in the changelog.
+
+## Declined / deferred
+
+- **Extracting the multi-scope disambiguator block** (duplicated across
+  `uninstall` / `upgrade` / `diff`) into `_common` — *deferred* (backlog anchor
+  `scope-disambiguator-extraction`). The shared part (read both state files +
+  the identical "installed at multiple scopes" refusal) is real, but each
+  command's downstream diverges sharply (root rebind + `user_prefixes`;
+  `allowed_prefixes` + recorded adapter; `pack_state` for the render-shape pick),
+  so a helper leaves most of each block behind and pulls `diff` — otherwise
+  untouched by this sweep — into the blast radius of a security-sensitive
+  (path-jail) refactor for a marginal net line change.
+- **Symlink confinement of the `--force` destructive scans** — *deferred*
+  (backlog anchor `force-cleanup-symlink-confinement`). `_scan_dist_tree_artifacts`
+  uses `base.rglob("*")` and the cleanup uses `shutil.rmtree(subtree)` — neither
+  uses the `os.walk(followlinks=False)` + per-entry symlink-skip convention the
+  pack-content walks elsewhere follow. Pre-existing (not introduced by this
+  sweep); listing the subtree root as the deletion unit (AC6) avoids *widening*
+  the divergence, but adopting the no-follow convention is a separate hardening.
+
+## Changelog
+
+- `agentbundle uninstall` gains `--dry-run` / `--yes` + a confirmation.
+- `agentbundle install --force` confirms (lists paths) before destructive
+  cleanup; `install` gains `--yes` and offers to upgrade an already-installed
+  pack.
+- `agentbundle reconcile` / `list-targets` drop their dead `--scope` flag.

--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -10,6 +10,34 @@ the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 
 ### Changed
 
+- **`agentbundle uninstall` gains `--dry-run` and `--yes`, and confirms before
+  removing.** It classifies each recorded file into `remove` (Tier-1, bundle-
+  owned) or `keep` (Tier-2, adopter-edited): `--dry-run` prints that plan and
+  writes nothing (no removal, no hook-wiring unproject, no state change);
+  otherwise it confirms before the first `os.remove` (`--yes` skips; a non-TTY
+  stdin refuses rather than blocking). The execution acts on the previewed
+  classification without re-hashing, so the bytes a dry-run / prompt shows are
+  exactly the bytes removed. Tier-2 preservation is unchanged.
+- **`agentbundle install --force` confirms before its destructive cleanup; new
+  `--yes`.** When `--force` would delete on-disk paths, it lists the deletion
+  unit — the dist-tree subtree roots (`claude-plugins/<pack>`, `apm/<pack>`) or
+  the orphan files — and confirms before deleting; the whole destructive block
+  (rmtree + state-row drop + state-file rewrite) is gated atomically, so a
+  decline mutates nothing. `--yes` skips the prompt; a non-TTY without `--yes`
+  refuses with zero deletions. `--force` used only as a cross-scope bypass (no
+  deletion) is unchanged and never prompts. **Migration:** CI using the deleting
+  form of `install --force` must add `--yes`.
+- **`agentbundle install` offers to upgrade an already-installed pack.** Instead
+  of flatly refusing with `use 'upgrade'`, installing a pack already present at
+  the requested scope now offers (on a TTY) to run `upgrade` against the same
+  catalogue/scope; `install --yes` runs it without prompting. A non-interactive
+  stdin without `--yes`, and `install --dry-run`, keep the historical refusal.
+- **`agentbundle reconcile` and `list-targets` drop their dead `--scope` flag.**
+  `reconcile --scope` had a single legal value (`user`) equal to its default, and
+  `list-targets --scope` was parsed but never read. Both are removed; passing
+  `--scope` to either now reports `unknown flag for <verb>: --scope`. Default
+  behaviour is unchanged.
+
 - **`agentbundle upgrade` no longer takes `--to` (breaking).** The upgrade
   target is now derived from the resolved catalogue's `pack.toml` `[pack]
   version` — the catalogue is the single source of truth, and there is no

--- a/packages/agentbundle/README.md
+++ b/packages/agentbundle/README.md
@@ -4,47 +4,57 @@
 [![Python](https://img.shields.io/pypi/pyversions/agentbundle)](https://pypi.org/project/agentbundle/)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](https://github.com/eugenelim/agent-ready-repo#license)
 
-**The installer for [agent-ready-repo](https://github.com/eugenelim/agent-ready-repo).** Think npm, but for the skills, subagents, and hooks your coding agent runs on.
+**The installer for [agent-ready-repo](https://github.com/eugenelim/agent-ready-repo).** Think npm, but for the skills, subagents, and hooks your coding agent runs on. One pack, one command, every major agent — Claude Code, Codex, Cursor, Copilot, Gemini, and Kiro (both the CLI and the IDE).
 
-`agentbundle` installs packs of agent primitives into your repo or your home directory. It projects each primitive into the layout every agent expects. One pack. One command. Every major agent.
+## Quick start
 
 ```bash
 pip install agentbundle
+```
+
+**Install into a repo** — so everyone who clones it gets the pack. `core` is the flagship pack, the loop itself:
+
+```bash
 agentbundle install --pack core git+https://github.com/eugenelim/agent-ready-repo
 ```
 
-That lands `core`, the flagship pack and the loop itself, in your repo. Claude Code, Codex, Cursor, Copilot, Gemini, and Kiro — both the CLI and the IDE — all read it, subagents and skills included.
+It lands in the repo's agent config — subagents and skills included — and you commit it like any other project file. This is the default scope: the pack belongs to the project and the whole team.
 
-## Common commands
+**Install for yourself, everywhere** — so a pack follows you across every project, with no per-repo setup:
 
 ```bash
-# See what's in a catalogue
-agentbundle list-packs git+https://github.com/eugenelim/agent-ready-repo
+agentbundle install --pack research git+https://github.com/eugenelim/agent-ready-repo --scope user
+```
 
-# See the catalogue's curated install profiles
+User-scope packs land in your home directory, not the repo — they're yours, not the team's, and they're there in every project you open.
+
+A catalogue is a git URL or a local path, and the install auto-detects your agent (`--adapter` overrides).
+
+## More commands
+
+```bash
+# See what a catalogue offers
+agentbundle list-packs    git+https://github.com/eugenelim/agent-ready-repo
 agentbundle list-profiles git+https://github.com/eugenelim/agent-ready-repo
 
 # Install a whole curated profile — a single-scope set of packs — in one command
 agentbundle install --profile inception git+https://github.com/eugenelim/agent-ready-repo
 
-# Install the flagship loop into this repo
-agentbundle install --pack core git+https://github.com/eugenelim/agent-ready-repo
-
-# Install a pack at user scope, so it follows you across every project
-agentbundle install --pack research git+https://github.com/eugenelim/agent-ready-repo --scope user
-
-# Preview an install without writing a file
+# Preview any install without writing a file
 agentbundle install --pack core git+https://github.com/eugenelim/agent-ready-repo --dry-run
 
-# Upgrade a pack to the version the catalogue ships — it shows installed → target,
-# asks before writing, and reports any .upstream files you need to reconcile
+# Upgrade to the version the catalogue ships — shows installed → target, asks first
 agentbundle upgrade --pack core git+https://github.com/eugenelim/agent-ready-repo
+agentbundle upgrade --pack core git+https://github.com/eugenelim/agent-ready-repo --yes  # skip the prompt (CI)
 
-# Skip the confirmation prompt (required for non-interactive / CI use)
-agentbundle upgrade --pack core git+https://github.com/eugenelim/agent-ready-repo --yes
+# Uninstall — previews remove (Tier-1) vs keep (your edits), asks first
+agentbundle uninstall --pack core --dry-run
+agentbundle uninstall --pack core --yes
 ```
 
-A catalogue is a git URL or a local path. Installs auto-detect your agent; pass `--adapter` to override. A **profile** is a catalogue-curated, single-scope set of packs you install in one command — it declares its own scope, so `--scope` doesn't apply. **Upgrade takes no version** — the target is whatever the catalogue you point at declares; to move to a specific past version, point the catalogue at that git ref.
+A **profile** is a catalogue-curated, single-scope set of packs you install in one command — it declares its own scope, so `--scope` doesn't apply. **Upgrade takes no version** — the target is whatever the catalogue you point at declares; to pin a past version, point the catalogue at that git ref. Install a pack that's **already there** and `agentbundle` offers to `upgrade` it instead (`--yes` runs it straight away).
+
+**Mutating commands ask first.** `uninstall`, the `--force` cleanup, and the upgrade offer all preview what they'll do and confirm before touching anything; `--dry-run` previews without writing, and `--yes` skips the prompt for non-interactive / CI use (where, without it, they refuse rather than hang).
 
 ## Build your own catalogue
 

--- a/packages/agentbundle/agentbundle/cli.py
+++ b/packages/agentbundle/agentbundle/cli.py
@@ -1,4 +1,4 @@
-"""`agentbundle` CLI dispatcher — argparse over the eleven F-cli subcommands.
+"""`agentbundle` CLI dispatcher — argparse over the F-cli subcommands.
 
 Subcommand order on the parser matches the canonical install-workflow order
 from the spec (discovery-first): `list-packs`, `list-profiles`, `list-targets`,
@@ -11,9 +11,12 @@ Each subcommand's `run(args) -> int` lives under `agentbundle.commands.*`;
 this module wires `argparse` and prints `--version`. No business logic here.
 
 RFC-0004 surface additions:
-  - `--scope {repo,user}` on install, uninstall, upgrade, diff, init-state,
-    list-targets (the six subcommands enumerated in spec § *Install-scope
-    dimension*).
+  - `--scope {repo,user}` on install, uninstall, upgrade, diff, init-state
+    (the spec § *Install-scope dimension* subcommands). The original RFC-0004
+    set also listed `list-targets`, and `reconcile` carried a single-value
+    `--scope user`; both were dead (parsed-but-never-read / only-legal-value-
+    equals-default) and dropped in the CLI-hygiene sweep, so passing `--scope`
+    to either now surfaces `unknown flag for <verb>: --scope`.
   - `--force` on install only (cross-scope conflict bypass; see
     spec § *Dual-scope install conflict*).
   - Forbidden flags on the five excluded subcommands surface with the
@@ -202,12 +205,11 @@ def _build_parser() -> argparse.ArgumentParser:
     sp.add_argument("catalogue", help="Catalogue URI (local path or git+https://...).")
     sp.set_defaults(func=_lazy("list_profiles"))
 
-    # --- list-targets --- (--scope as read-only filter)
+    # --- list-targets --- (no flags; queries the adapter registry)
     sp = subparsers.add_parser(
         "list-targets",
         help="List adapter targets the CLI supports (claude-code, kiro-ide, kiro-cli, kiro (deprecated → kiro-ide), copilot, codex).",
     )
-    sp.add_argument("--scope", choices=("repo", "user"))
     sp.set_defaults(func=_lazy("list_targets"))
 
     # --- scaffold --- (no --scope; always repo-targeted)
@@ -307,6 +309,17 @@ def _build_parser() -> argparse.ArgumentParser:
             "marker, and no chained adapt. Refused with --force (its destructive "
             "cleanup is incompatible with a read-only preview). Exits 0 on a "
             "successful preview, even with Tier-2 collisions present."
+        ),
+    )
+    sp.add_argument(
+        "--yes",
+        action="store_true",
+        help=(
+            "Answer yes to install's interactive confirmations: the --force "
+            "destructive-cleanup prompt (removing leftover files), and the "
+            "offer to upgrade a pack already installed at the requested scope. "
+            "Required for non-interactive use of those paths; without it they "
+            "prompt on a TTY and refuse rather than block on a non-TTY."
         ),
     )
     sp.set_defaults(func=_lazy("install"))
@@ -415,6 +428,24 @@ def _build_parser() -> argparse.ArgumentParser:
     sp.add_argument("--pack", required=True)
     sp.add_argument("--root", default=".")
     sp.add_argument("--scope", choices=("repo", "user"))
+    sp.add_argument(
+        "--yes",
+        action="store_true",
+        help=(
+            "Skip the uninstall confirmation prompt. Required for non-interactive "
+            "use (CI, pipes); without it the uninstall asks before removing any "
+            "file, and refuses rather than blocking when stdin is not a TTY."
+        ),
+    )
+    sp.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Preview the per-file plan (remove tier-1 / keep tier-2) without "
+            "removing anything — no file removed, no hook-wiring unproject, no "
+            "state change. Exits 0."
+        ),
+    )
     sp.set_defaults(func=_lazy("uninstall"))
 
     # --- init-state --- (--scope selector; --migrate flag)
@@ -466,10 +497,9 @@ def _build_parser() -> argparse.ArgumentParser:
             "RFC-0005: read-only orphan reporter — walks Claude Code "
             "settings.json and Kiro agent JSONs named in user-scope state, "
             "reports entries the file/state pair disagrees on. Read-only; "
-            "no --apply flag."
+            "no --apply flag. User-scope only; no --scope flag."
         ),
     )
-    sp.add_argument("--scope", choices=("user",), default="user")
     sp.set_defaults(func=_lazy("reconcile"))
 
     return parser

--- a/packages/agentbundle/agentbundle/commands/_common.py
+++ b/packages/agentbundle/agentbundle/commands/_common.py
@@ -243,3 +243,51 @@ def summarize_plan(actions: list[str]) -> str:
     ]
     body = ", ".join(parts) if parts else "no files"
     return f"dry-run: {len(actions)} file(s) — {body}. Nothing written."
+
+
+# ---------------------------------------------------------------------------
+# Destructive-confirmation mechanics (shared by `uninstall`, `install --force`,
+# the `install`→`upgrade` offer, and `upgrade`)
+# ---------------------------------------------------------------------------
+
+
+def confirm_or_refuse(
+    *,
+    yes: bool,
+    question: str,
+    refuse_message: str,
+    abort_message: str,
+) -> bool:
+    """Decide whether a destructive command may proceed.
+
+    The single home for the confirm / non-TTY-refuse / ``--yes`` mechanics first
+    introduced for ``upgrade`` in PR #374, so ``uninstall``, ``install --force``,
+    and the ``install``→``upgrade`` offer share one implementation:
+
+      - ``yes`` (the ``--yes`` flag) → return ``True`` without touching stdin.
+      - non-interactive stdin (``not sys.stdin.isatty()``) → print
+        ``refuse_message`` to stderr and return ``False`` (never block on
+        ``input()``).
+      - interactive stdin → prompt with ``question``; return ``True`` only when
+        the reply is ``y``/``yes`` (case-insensitive, stripped). Any other reply
+        — including EOF — prints ``abort_message`` to stderr and returns
+        ``False``.
+
+    The caller owns the ``--dry-run`` short-circuit (a dry run writes nothing, so
+    it must return *before* calling this), and owns every command-specific
+    message string passed in here — so each call site preserves its own exact
+    stderr contract.
+    """
+    if yes:
+        return True
+    if not sys.stdin.isatty():
+        print(refuse_message, file=sys.stderr)
+        return False
+    try:
+        reply = input(question)
+    except EOFError:
+        reply = ""
+    if reply.strip().lower() not in ("y", "yes"):
+        print(abort_message, file=sys.stderr)
+        return False
+    return True

--- a/packages/agentbundle/agentbundle/commands/install.py
+++ b/packages/agentbundle/agentbundle/commands/install.py
@@ -81,6 +81,7 @@ def run(args: "argparse.Namespace") -> int:
     from agentbundle.catalogue import CatalogueError, resolve_catalogue
     from agentbundle.commands._common import (
         check_spec_version_gate,
+        confirm_or_refuse,
         format_plan_line,
         plan_action,
         summarize_plan,
@@ -117,6 +118,7 @@ def run(args: "argparse.Namespace") -> int:
     force: bool = bool(getattr(args, "force", False))
     force_merge: bool = bool(getattr(args, "force_merge", False))
     dry_run: bool = bool(getattr(args, "dry_run", False))
+    yes: bool = bool(getattr(args, "yes", False))
     cli_adapter: str | None = getattr(args, "adapter", None)
     # User-config attached by `cli.py:main()` via args._user_config.
     # Default to None for callers that construct an args namespace by
@@ -426,6 +428,7 @@ def run(args: "argparse.Namespace") -> int:
             repo_target_adapter=repo_target_adapter,
             allowed_prefixes_repo=allowed_prefixes_repo,
             force=force,
+            yes=yes,
             projection_relpaths=_orphan_filter_relpaths,
         )
         if rc is not None:
@@ -441,17 +444,44 @@ def run(args: "argparse.Namespace") -> int:
     installed_at_user = user_state is not None and pack_name in user_state.packs
 
     # ── Step 4: Branch on already-installed shape ─────────────────────────────
-    # 4a. Already at requested scope → refuse (use 'upgrade'); --force does
+    # 4a. Already at requested scope → offer to upgrade instead; --force does
     #     not bypass this case.
+    #
+    #   - `--dry-run` keeps the historical refusal (a read-only preview makes no
+    #     offer and never prompts).
+    #   - On a non-TTY without `--yes`, `confirm_or_refuse` prints the historical
+    #     refusal (`already installed at <scope>` + `use 'upgrade' to change
+    #     version`) and returns 1 — the CI/test contract is unchanged.
+    #   - On a TTY, it offers to upgrade; `--yes` auto-confirms. Confirming hands
+    #     off to `upgrade.run` against the same catalogue/scope (CLI-hygiene
+    #     AC11/AC12).
     if (requested_scope == "repo" and installed_at_repo) or (
         requested_scope == "user" and installed_at_user
     ):
-        print(
-            f"install: {pack_name} already installed at {requested_scope}; "
-            "use 'upgrade' to change version",
-            file=sys.stderr,
-        )
-        return 1
+        if dry_run:
+            print(
+                f"install: {pack_name} already installed at {requested_scope}; "
+                "use 'upgrade' to change version",
+                file=sys.stderr,
+            )
+            return 1
+        if not confirm_or_refuse(
+            yes=yes,
+            question=(
+                f"{pack_name} is already installed at {requested_scope}. "
+                f"Upgrade it instead? [y/N] "
+            ),
+            refuse_message=(
+                f"install: {pack_name} already installed at {requested_scope}; "
+                "use 'upgrade' to change version"
+            ),
+            abort_message=(
+                f"install: {pack_name} already installed at {requested_scope}; "
+                "not upgrading. Use 'upgrade' to change version"
+            ),
+        ):
+            return 1
+        return _offer_upgrade(args, pack_name=pack_name, scope=requested_scope)
 
     # 4b. Already at the *other* scope, no --force → refuse cross-scope.
     other_scope = "user" if requested_scope == "repo" else "repo"
@@ -1689,6 +1719,33 @@ def _scan_dist_tree_artifacts(root: Path, pack_name: str) -> list[Path]:
     return sorted(out)
 
 
+def _offer_upgrade(args: "argparse.Namespace", *, pack_name: str, scope: str) -> int:
+    """Hand off an already-installed `install` to `upgrade` (CLI-hygiene AC11/12).
+
+    The install-side offer is the confirmation, so the upgrade runs with
+    ``yes=True``. Builds the FULL attribute set ``upgrade.run`` reads — mapping
+    ``install.output`` → ``upgrade.root``, pinning the concrete install-resolved
+    ``scope`` (never ``None`` so upgrade's own multi-scope disambiguator is a
+    no-op), threading ``_user_config`` so adapter resolution matches a direct
+    ``upgrade`` invocation, and leaving all five primitive flags unset
+    (whole-pack). Returns ``upgrade.run``'s exit code.
+    """
+    import argparse as _argparse
+
+    from agentbundle.commands import upgrade as _upgrade
+
+    ns = _argparse.Namespace()
+    ns.pack = pack_name
+    ns.catalogue = args.catalogue
+    ns.root = getattr(args, "output", ".")
+    ns.scope = scope
+    ns.yes = True
+    ns.dry_run = False
+    ns.skill = ns.agent = ns.hook = ns.seed = ns.command = None
+    ns._user_config = getattr(args, "_user_config", None)
+    return _upgrade.run(ns)
+
+
 def _classify_pre_rfc0012_state(
     *,
     output_root: Path,
@@ -1698,6 +1755,7 @@ def _classify_pre_rfc0012_state(
     repo_target_adapter: str,
     allowed_prefixes_repo: list[str],
     force: bool,
+    yes: bool = False,
     projection_relpaths: "set[str] | None" = None,
 ) -> int | None:
     """RFC-0012 AC24: in-band detection of pre-RFC-0012 state.
@@ -1707,12 +1765,22 @@ def _classify_pre_rfc0012_state(
     ``(output_root, pack_name)`` per process; subsequent calls
     short-circuit to silence.
 
+    When ``--force`` would *delete* on-disk paths (the dist-tree (b) and
+    orphan (c) branches), the deletion is confirmed first: ``yes`` skips the
+    prompt, a non-interactive stdin refuses rather than deleting unattended,
+    and the paths to be removed are listed on stderr before the prompt
+    (CLI-hygiene AC6/AC7). The confirm gates the *whole* destructive block —
+    for (b) that is the ``rmtree`` plus the in-memory ``packs.pop`` plus the
+    state-file rewrite — so a decline mutates nothing.
+
     Returns:
       - ``None`` — no trigger fired, or ``--force`` cleared the
         trigger's on-disk shape; caller proceeds with the install.
-      - ``1`` — refused with pinned stderr; caller returns 1.
+      - ``1`` — refused with pinned stderr (or the operator declined the
+        ``--force`` cleanup); caller returns 1.
     """
     from agentbundle import safety
+    from agentbundle.commands._common import confirm_or_refuse
 
     key = (str(output_root), pack_name)
     if key in _INBAND_DETECTION_SEEN:
@@ -1745,6 +1813,41 @@ def _classify_pre_rfc0012_state(
                 import shutil
 
                 from agentbundle.config import dump_state
+
+                # CLI-hygiene AC6/AC7: confirm before the FIRST mutation. The
+                # deletion unit is the subtree root `rmtree` removes (not the
+                # scanned file list, which could diverge from what rmtree
+                # actually takes). Decline → return 1 having touched nothing:
+                # no rmtree, no packs.pop, no state rewrite.
+                subtree_roots = [
+                    f"{top}/{pack_name}"
+                    for top in ("claude-plugins", "apm")
+                    if (output_root / top / pack_name).exists()
+                ]
+                for root_rel in subtree_roots:
+                    print(
+                        f"install --force will REMOVE pre-RFC-0012 dist-tree "
+                        f"subtree: {root_rel}/ (recursively)",
+                        file=sys.stderr,
+                    )
+                if not confirm_or_refuse(
+                    yes=yes,
+                    question=(
+                        f"Remove the listed dist-tree subtree(s) for "
+                        f"{pack_name} and reinstall? [y/N] "
+                    ),
+                    refuse_message=(
+                        f"install: refusing to remove dist-tree files for "
+                        f"{pack_name} without confirmation; pass --yes to "
+                        f"clean and reinstall non-interactively"
+                    ),
+                    abort_message="install: aborted; no changes made",
+                ):
+                    # Decline/refuse: discard the once-per-session marker so a
+                    # later in-process retry re-prompts instead of short-
+                    # circuiting to a plain install over the un-cleaned shape.
+                    _INBAND_DETECTION_SEEN.discard(key)
+                    return 1
 
                 for top in ("claude-plugins", "apm"):
                     subtree = output_root / top / pack_name
@@ -1870,6 +1973,33 @@ def _classify_pre_rfc0012_state(
         if orphans:
             _INBAND_DETECTION_SEEN.add(key)
             if force:
+                # CLI-hygiene AC6/AC7: list the exact files to be unlinked and
+                # confirm before the FIRST unlink. Decline → return 1, nothing
+                # removed.
+                for orphan in orphans:
+                    print(
+                        f"install --force will REMOVE orphan file: "
+                        f"{orphan.relative_to(output_root).as_posix()}",
+                        file=sys.stderr,
+                    )
+                if not confirm_or_refuse(
+                    yes=yes,
+                    question=(
+                        f"Remove the listed orphan file(s) for {pack_name} "
+                        f"and reinstall? [y/N] "
+                    ),
+                    refuse_message=(
+                        f"install: refusing to remove orphan files for "
+                        f"{pack_name} without confirmation; pass --yes to "
+                        f"clean and reinstall non-interactively"
+                    ),
+                    abort_message="install: aborted; no changes made",
+                ):
+                    # Decline/refuse: discard the once-per-session marker so a
+                    # later in-process retry re-prompts instead of short-
+                    # circuiting to a plain install over the orphan files.
+                    _INBAND_DETECTION_SEEN.discard(key)
+                    return 1
                 for orphan in orphans:
                     try:
                         orphan.unlink()
@@ -3756,6 +3886,10 @@ def _run_profile(args: "argparse.Namespace") -> int:
         ns.force_merge = False
         ns.emit_install_routes = False  # modern per-IDE projection at repo scope
         ns.dry_run = dry_run
+        # Batch pre-filters already-installed packs before calling run(), so
+        # the Step 4a upgrade-offer never fires here; pin yes=False explicitly
+        # since the namespace is hand-built and run() now reads `args.yes`.
+        ns.yes = False
         ns._user_config = user_config
         ns._install_route = "profile"  # AC13
         ns._batch_packs = batch  # AC7 — in-batch deps satisfy the gate

--- a/packages/agentbundle/agentbundle/commands/reconcile.py
+++ b/packages/agentbundle/agentbundle/commands/reconcile.py
@@ -35,23 +35,16 @@ if TYPE_CHECKING:
     import argparse
 
 
-def run(args: "argparse.Namespace") -> int:
+def run(args: "argparse.Namespace") -> int:  # noqa: ARG001
     """Entry point for ``agentbundle reconcile``.
 
-    The only supported scope today is ``user`` (RFC-0005's report
-    surface). A future RFC may extend to repo scope; ``--scope``
-    is accepted with that single value for now.
+    The report surface is user-scope only (RFC-0005). The old ``--scope``
+    flag had a single legal value (``user``) that equalled its default, so
+    it could never select anything — it was dropped (CLI-hygiene sweep). A
+    future RFC that adds a second scope can reintroduce the flag then.
     """
     from agentbundle import scope as scope_mod
     from agentbundle.config import ConfigError, load_state
-
-    cli_scope: str | None = getattr(args, "scope", None)
-    if cli_scope != "user":
-        print(
-            "reconcile: only --scope user is supported today",
-            file=sys.stderr,
-        )
-        return 1
 
     try:
         user_root = scope_mod.resolve_user_root()

--- a/packages/agentbundle/agentbundle/commands/uninstall.py
+++ b/packages/agentbundle/agentbundle/commands/uninstall.py
@@ -3,10 +3,16 @@
 Algorithm:
   1. Load ``.agentbundle-state.toml`` from ``args.root``.
      Exit non-zero with stderr if the pack is not in state.
-  2. For each file recorded under ``[pack.<name>.files]``:
-     - Compute the on-disk SHA.
-     - If it matches the state-recorded SHA (Tier-1) → ``os.remove``.
-     - If it differs (or file is absent) → Tier-2 → warn on stderr and keep.
+  2a. Classify each file recorded under ``[pack.<name>.files]`` (no mutation):
+      - Compute the on-disk SHA. Match (Tier-1) → ``remove``; differ / absent-
+        sha (Tier-2) → ``keep``. Absent-on-disk files are skipped.
+  2a'. ``--dry-run`` → print the per-file plan + a one-line summary and exit 0,
+       writing nothing (no remove, unproject, prune, or state rewrite).
+  2b. Confirm before the first removal (``--yes`` skips; a non-TTY stdin refuses
+      rather than blocking on ``input()``).
+  2c. Execute the classified plan: ``os.remove`` each ``remove``; warn-and-keep
+      each ``keep``. Acts on the classification without re-hashing.
+  2d. Unproject any hook-wiring-owned entries from their merge target.
   3. Best-effort: remove empty parent directories left behind by removals.
   4. Save the updated state file with ``[pack.<name>]`` table dropped.
   5. Print summary to stdout: N removed, M kept.
@@ -30,8 +36,11 @@ def run(args: "argparse.Namespace") -> int:
     """Entry point for ``agentbundle uninstall``.
 
     Args:
-        args.pack  — name of the pack to uninstall (required).
-        args.root  — repo root directory (default '.').
+        args.pack     — name of the pack to uninstall (required).
+        args.root     — repo root directory (default '.').
+        args.scope    — {repo, user} disambiguator (optional).
+        args.dry_run  — preview the per-file plan; write nothing (optional).
+        args.yes      — skip the confirmation prompt (optional, default off).
 
     Returns 0 on success, non-zero on error.
     """
@@ -122,8 +131,10 @@ def run(args: "argparse.Namespace") -> int:
         return 1
 
     pack_state = state.packs[pack_name]
+    dry_run: bool = bool(getattr(args, "dry_run", False))
+    yes: bool = bool(getattr(args, "yes", False))
 
-    # ── Step 2: Walk the pack's recorded files ────────────────────────────────
+    # ── Step 2a: Classify the pack's recorded files (no mutation) ─────────────
     # State-file relpaths are *untrusted input* — a malicious state file
     # could record `relpath = "../.ssh/authorized_keys"` and the
     # `os.remove` below would happily delete a path outside the jail.
@@ -131,9 +142,15 @@ def run(args: "argparse.Namespace") -> int:
     # directory; at repo scope it's still wrong even though smaller.
     # `safety.assert_under` + (at user scope) the prefix-list check
     # refuses any entry that escapes the per-scope jail before any
-    # filesystem operation runs.
-    removed: list[str] = []
-    kept: list[str] = []
+    # filesystem operation runs. These "refusing to touch" warnings apply
+    # equally to a real run and a `--dry-run` preview, so they print here.
+    #
+    # The classification is computed once, into `decisions`, and the
+    # execution pass (Step 2c) acts on it WITHOUT re-hashing — so the bytes
+    # a `--dry-run` / prompt shows are exactly the bytes a real run removes
+    # (the Tier-1 SHA is captured here, once; the confirm-reading window is
+    # not re-checked — see spec AC5).
+    decisions: list[tuple[str, str]] = []  # (relpath, "remove" | "keep")
 
     for relpath, entry in sorted(pack_state.files.items()):
         on_disk = root / relpath
@@ -167,7 +184,58 @@ def run(args: "argparse.Namespace") -> int:
         # Compute on-disk SHA and compare against the recorded value.
         on_disk_sha = safety.sha256_file(on_disk)
         if recorded_sha and on_disk_sha == recorded_sha:
-            # Tier-1: the bundle owns this file — safe to remove.
+            decisions.append((relpath, "remove"))  # Tier-1: bundle owns it.
+        else:
+            decisions.append((relpath, "keep"))  # Tier-2: adopter-edited.
+
+    n_remove = sum(1 for _, d in decisions if d == "remove")
+    n_keep = len(decisions) - n_remove
+
+    # ── Step 2a': --dry-run preview — print the plan and write nothing ────────
+    # Returns BEFORE the hook-wiring unproject (Step 2b), the empty-dir prune
+    # (Step 3), and the state rewrite (Step 4): a dry run mutates nothing on
+    # disk or in state (spec AC1).
+    if dry_run:
+        from agentbundle.commands._common import format_plan_line
+
+        for relpath, decision in decisions:
+            tier = "tier-1" if decision == "remove" else "tier-2"
+            print(format_plan_line(decision, tier, relpath))
+        print(
+            f"dry-run: {len(decisions)} file(s) — {n_remove} remove, "
+            f"{n_keep} keep. Nothing written."
+        )
+        return 0
+
+    # ── Step 2b: Confirm before the first os.remove (spec AC2/AC3/AC4) ────────
+    # `--yes` skips the prompt; a non-interactive stdin refuses rather than
+    # blocking on input(). Mirrors `upgrade`'s posture via the shared helper.
+    from agentbundle.commands._common import confirm_or_refuse
+
+    if not confirm_or_refuse(
+        yes=yes,
+        question=(
+            f"Uninstall {pack_name} at {effective_scope} scope? This removes "
+            f"{n_remove} file(s); {n_keep} adopter-edited file(s) will be kept. "
+            f"[y/N] "
+        ),
+        refuse_message=(
+            f"uninstall: refusing to uninstall {pack_name} at {effective_scope} "
+            f"scope without confirmation; pass --yes to uninstall non-interactively"
+        ),
+        abort_message="uninstall: aborted; no changes made",
+    ):
+        return 1
+
+    # ── Step 2c: Execute the classified plan ──────────────────────────────────
+    # Acts on `decisions` directly (no re-hash): the bytes shown above are the
+    # bytes removed. The "keeping adopter-edited file" warning preserves the
+    # pre-existing Tier-2 notice.
+    removed: list[str] = []
+    kept: list[str] = []
+    for relpath, decision in decisions:
+        on_disk = root / relpath
+        if decision == "remove":
             try:
                 os.remove(on_disk)
             except OSError as exc:
@@ -178,14 +246,13 @@ def run(args: "argparse.Namespace") -> int:
                 return 1
             removed.append(relpath)
         else:
-            # Tier-2: adopter-edited (or no recorded SHA) — preserve with warning.
             print(
                 f"uninstall: keeping adopter-edited file: {relpath}",
                 file=sys.stderr,
             )
             kept.append(relpath)
 
-    # ── Step 2b: RFC-0005 T8b — unproject hook-wiring-owned entries ─────────
+    # ── Step 2d: RFC-0005 T8b — unproject hook-wiring-owned entries ─────────
     # When the pack has hook_wiring_owned rows (v0.3 user-scope hooks),
     # dispatch to the right merge engine's `unproject` to remove those
     # entries from the merge target file. Empty `hooks.<event>` arrays

--- a/packages/agentbundle/agentbundle/commands/upgrade.py
+++ b/packages/agentbundle/agentbundle/commands/upgrade.py
@@ -76,6 +76,7 @@ def run(args: "argparse.Namespace") -> int:
     from agentbundle.catalogue import CatalogueError, resolve_catalogue
     from agentbundle.commands._common import (
         check_spec_version_gate,
+        confirm_or_refuse,
         format_plan_line,
         plan_action,
         summarize_plan,
@@ -273,14 +274,6 @@ def run(args: "argparse.Namespace") -> int:
     # short-circuits the refusal: a dry run never writes, so it is safe
     # non-interactively without ``--yes``.
     if not getattr(args, "yes", False) and not getattr(args, "dry_run", False):
-        if not sys.stdin.isatty():
-            print(
-                f"upgrade: refusing to upgrade {confirm_label} from "
-                f"{from_version} to {to_version} without confirmation; pass "
-                f"--yes to upgrade non-interactively",
-                file=sys.stderr,
-            )
-            return 1
         if already_current:
             question = (
                 f"{confirm_label} is already at {to_version}. Re-apply at "
@@ -291,12 +284,16 @@ def run(args: "argparse.Namespace") -> int:
                 f"Upgrade {confirm_label} at {effective_scope} scope from "
                 f"{from_version} to {to_version}? [y/N] "
             )
-        try:
-            reply = input(question)
-        except EOFError:
-            reply = ""
-        if reply.strip().lower() not in ("y", "yes"):
-            print("upgrade: aborted; no changes made", file=sys.stderr)
+        if not confirm_or_refuse(
+            yes=False,
+            question=question,
+            refuse_message=(
+                f"upgrade: refusing to upgrade {confirm_label} from "
+                f"{from_version} to {to_version} without confirmation; pass "
+                f"--yes to upgrade non-interactively"
+            ),
+            abort_message="upgrade: aborted; no changes made",
+        ):
             return 1
     elif already_current:
         # --yes / --dry-run skipped the prompt, but still state the situation.

--- a/packages/agentbundle/tests/integration/test_install_converters_user_scope.py
+++ b/packages/agentbundle/tests/integration/test_install_converters_user_scope.py
@@ -153,6 +153,7 @@ class ConvertersUserScopeInstallTests(unittest.TestCase):
             pack="converters",
             root=str(self.repo),
             scope="user",
+            yes=True,
         )
         rc, stdout, stderr = _run_uninstall(uninstall_args)
         self.assertEqual(rc, 0, f"uninstall failed: stdout={stdout!r} stderr={stderr!r}")

--- a/packages/agentbundle/tests/integration/test_install_dual_scope.py
+++ b/packages/agentbundle/tests/integration/test_install_dual_scope.py
@@ -316,7 +316,9 @@ def test_uninstall_at_user_scope_writes_dot_directory_state(tmp_path, monkeypatc
     assert rc == 0
     assert (fake_home / ".agentbundle" / "state.toml").exists()
 
-    args = argparse.Namespace(pack="demo-both", root=str(target), scope="user")
+    args = argparse.Namespace(
+        pack="demo-both", root=str(target), scope="user", yes=True
+    )
     out = io.StringIO()
     err = io.StringIO()
     with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):

--- a/packages/agentbundle/tests/integration/test_install_orphan_reshape.py
+++ b/packages/agentbundle/tests/integration/test_install_orphan_reshape.py
@@ -31,6 +31,10 @@ def _install_core(target: Path, *, force: bool = False) -> tuple[int, str, str]:
         scope="repo",
         emit_install_routes=False,
         force=force,
+        # `yes=True` so the new --force destructive-cleanup confirm (CLI-hygiene
+        # AC7) does not refuse on the non-TTY test stdin; harmless when no
+        # cleanup fires.
+        yes=True,
     )
     out, err = io.StringIO(), io.StringIO()
     with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):

--- a/packages/agentbundle/tests/integration/test_install_research_user_scope.py
+++ b/packages/agentbundle/tests/integration/test_install_research_user_scope.py
@@ -158,6 +158,7 @@ class ResearchUserScopeInstallTests(unittest.TestCase):
             pack="research",
             root=str(self.repo),
             scope="user",
+            yes=True,
         )
         rc, stdout, stderr = _run_uninstall(uninstall_args)
         self.assertEqual(rc, 0, f"uninstall failed: stdout={stdout!r} stderr={stderr!r}")

--- a/packages/agentbundle/tests/integration/test_install_upgrade_offer.py
+++ b/packages/agentbundle/tests/integration/test_install_upgrade_offer.py
@@ -1,0 +1,150 @@
+"""CLI-hygiene AC10–AC14: `install` of an already-installed pack offers to
+`upgrade` instead of the old flat "use 'upgrade'" refusal.
+
+  - TTY + 'y' → runs the whole-pack upgrade against the same catalogue/scope.
+  - --yes → runs the upgrade without prompting.
+  - non-TTY without --yes → keeps the historical refusal (CI contract).
+  - --dry-run → keeps the historical refusal (no offer, no prompt).
+
+The handoff namespace (`_offer_upgrade`) is asserted to carry the full attribute
+set `upgrade.run` reads, with the concrete resolved scope and whole-pack flags.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+from pathlib import Path
+
+import pytest
+
+FIXTURE_CATALOGUE = (
+    Path(__file__).parent.parent / "fixtures" / "install" / "catalogue"
+)
+
+
+def _install_args(output: str, **overrides) -> argparse.Namespace:
+    base = dict(
+        pack="alpha",
+        catalogue=str(FIXTURE_CATALOGUE),
+        output=output,
+        scope=None,
+        force=False,
+        force_merge=False,
+        dry_run=False,
+        yes=False,
+        adapter=None,
+        emit_install_routes=True,  # dist-tree shape (fixture predates per-IDE)
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def _run_install(args: argparse.Namespace) -> tuple[int, str, str]:
+    from agentbundle.commands.install import run
+
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        rc = run(args)
+    return rc, out.getvalue(), err.getvalue()
+
+
+def _install_alpha(tmp_path: Path) -> None:
+    rc, _, err = _run_install(_install_args(str(tmp_path)))
+    assert rc == 0, f"initial install failed: {err}"
+
+
+def test_offer_accept_runs_upgrade_with_full_handoff(tmp_path, monkeypatch):
+    """AC11: a TTY 'y' hands off to upgrade.run with the full, concrete namespace."""
+    _install_alpha(tmp_path)
+
+    captured = {}
+
+    def _fake_upgrade(ns):
+        captured["ns"] = ns
+        return 0
+
+    monkeypatch.setattr("agentbundle.commands.upgrade.run", _fake_upgrade)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda prompt="": "y")
+
+    rc, _out, _err = _run_install(_install_args(str(tmp_path)))
+    assert rc == 0
+    ns = captured["ns"]
+    assert ns.pack == "alpha"
+    assert ns.catalogue == str(FIXTURE_CATALOGUE)
+    assert ns.root == str(tmp_path)
+    assert ns.scope == "repo", "handoff must pass the concrete resolved scope, not None"
+    assert ns.yes is True
+    assert ns.dry_run is False
+    assert ns.skill is ns.agent is ns.hook is ns.seed is ns.command is None
+    assert hasattr(ns, "_user_config")
+
+
+def test_yes_runs_upgrade_without_prompting(tmp_path, monkeypatch):
+    """AC12: install --yes of an already-installed pack runs upgrade, no prompt."""
+    _install_alpha(tmp_path)
+
+    captured = {}
+
+    def _fake_upgrade(ns):
+        captured["ns"] = ns
+        return 0
+
+    def _boom(prompt=""):
+        raise AssertionError("input() must not be called with --yes")
+
+    monkeypatch.setattr("agentbundle.commands.upgrade.run", _fake_upgrade)
+    monkeypatch.setattr("builtins.input", _boom)
+
+    rc, _out, _err = _run_install(_install_args(str(tmp_path), yes=True))
+    assert rc == 0
+    assert captured["ns"].yes is True
+
+
+def test_non_tty_without_yes_keeps_refusal(tmp_path, monkeypatch):
+    """AC13: a non-TTY without --yes keeps the historical refusal (no upgrade)."""
+    _install_alpha(tmp_path)
+
+    def _fake_upgrade(ns):
+        raise AssertionError("upgrade.run must not be called on the refusal path")
+
+    monkeypatch.setattr("agentbundle.commands.upgrade.run", _fake_upgrade)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    rc, _out, err = _run_install(_install_args(str(tmp_path)))
+    assert rc == 1
+    assert "already installed at repo" in err
+    assert "use 'upgrade' to change version" in err
+
+
+def test_dry_run_keeps_refusal_no_offer(tmp_path, monkeypatch):
+    """AC13: install --dry-run of an already-installed pack refuses, no prompt."""
+    _install_alpha(tmp_path)
+
+    def _fake_upgrade(ns):
+        raise AssertionError("upgrade.run must not be called under --dry-run")
+
+    def _boom(prompt=""):
+        raise AssertionError("input() must not be called under --dry-run")
+
+    monkeypatch.setattr("agentbundle.commands.upgrade.run", _fake_upgrade)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", _boom)
+
+    # dry-run + force is mutex, so dry-run alone (force=False) here.
+    rc, _out, err = _run_install(_install_args(str(tmp_path), dry_run=True))
+    assert rc == 1
+    assert "use 'upgrade' to change version" in err
+
+
+def test_yes_runs_real_upgrade_end_to_end(tmp_path):
+    """AC12 (real wiring): install --yes of an already-installed pack actually
+    drives upgrade.run (no monkeypatch) and exits 0 with the upgrade recap."""
+    _install_alpha(tmp_path)
+    rc, out, err = _run_install(_install_args(str(tmp_path), yes=True))
+    assert rc == 0, f"real upgrade handoff failed: {err}"
+    # upgrade prints an `upgraded: <pack> @ <scope> <from> -> <to>` recap —
+    # assert the specific recap so a silent no-op / error can't pass.
+    assert "upgraded: alpha @ repo" in out, f"missing upgrade recap; stdout={out!r}"

--- a/packages/agentbundle/tests/integration/test_tier_invariants.py
+++ b/packages/agentbundle/tests/integration/test_tier_invariants.py
@@ -193,6 +193,7 @@ def _run_uninstall(root: Path, pack_dir: Path) -> int:
     args = argparse.Namespace(
         pack=pack_dir.name,
         root=str(root),
+        yes=True,
     )
     return run(args)
 

--- a/packages/agentbundle/tests/integration/test_uninstall_cmd.py
+++ b/packages/agentbundle/tests/integration/test_uninstall_cmd.py
@@ -39,9 +39,16 @@ def _run_install(pack: str, catalogue: str, output: str) -> int:
     ))
 
 
-def _run_uninstall(pack: str, root: str) -> int:
+def _run_uninstall(
+    pack: str, root: str, *, yes: bool = True, dry_run: bool = False
+) -> int:
     from agentbundle.commands.uninstall import run
-    return run(types.SimpleNamespace(pack=pack, root=root))
+    # `yes=True` by default so the pre-existing non-prompt tests don't block on
+    # input(); the confirmation-flow tests pass yes=False and monkeypatch
+    # input/isatty (mirrors test_upgrade_cmd.py's `_run_upgrade`).
+    return run(types.SimpleNamespace(
+        pack=pack, root=root, yes=yes, dry_run=dry_run,
+    ))
 
 
 def _seed_state(tmp_path: Path, pack_name: str, files: dict[str, str]) -> None:
@@ -216,3 +223,154 @@ def test_missing_pack_exits_nonzero(tmp_path, capsys):
     assert "nonexistent" in captured.err, (
         "stderr must mention the missing pack name"
     )
+
+
+# ---------------------------------------------------------------------------
+# 6. --dry-run / --yes / confirmation (CLI-hygiene AC1–AC5)
+# ---------------------------------------------------------------------------
+
+
+def _snapshot_tree(root: Path) -> dict[str, bytes]:
+    """Map every file under `root` to its bytes (for write-nothing assertions)."""
+    return {
+        str(p.relative_to(root)): p.read_bytes()
+        for p in sorted(root.rglob("*"))
+        if p.is_file()
+    }
+
+
+def test_dry_run_previews_and_writes_nothing(tmp_path, capsys):
+    """AC1: `uninstall --dry-run` prints the per-file plan + summary, exits 0,
+    and mutates nothing — no file removed, no state change."""
+    from agentbundle.render import render_pack
+
+    rc = _run_install("alpha", str(FIXTURE_CATALOGUE), str(tmp_path))
+    assert rc == 0
+    capsys.readouterr()  # drain install output
+
+    before = _snapshot_tree(tmp_path)
+    rc = _run_uninstall("alpha", str(tmp_path), dry_run=True)
+    assert rc == 0, "dry-run must exit 0"
+
+    out = capsys.readouterr().out
+    assert "Nothing written." in out
+    # Every projected file is previewed as `remove tier-1`.
+    for relpath in render_pack(ALPHA_PACK_DIR):
+        assert f"remove" in out and relpath in out
+
+    assert _snapshot_tree(tmp_path) == before, "dry-run must write nothing"
+
+
+def test_yes_skips_prompt(tmp_path, monkeypatch):
+    """AC3: --yes proceeds without reading stdin."""
+    rc = _run_install("alpha", str(FIXTURE_CATALOGUE), str(tmp_path))
+    assert rc == 0
+
+    def _boom(prompt=""):
+        raise AssertionError("input() must not be called with --yes")
+
+    monkeypatch.setattr("builtins.input", _boom)
+    rc = _run_uninstall("alpha", str(tmp_path), yes=True)
+    assert rc == 0
+
+
+def test_confirmation_accept_proceeds(tmp_path, monkeypatch):
+    """AC2: an interactive 'y' proceeds with the removal."""
+    from agentbundle.config import load_state
+
+    rc = _run_install("alpha", str(FIXTURE_CATALOGUE), str(tmp_path))
+    assert rc == 0
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda prompt="": "  YES ")
+    rc = _run_uninstall("alpha", str(tmp_path), yes=False)
+    assert rc == 0
+    state = load_state(tmp_path / ".agentbundle-state.toml")
+    assert "alpha" not in state.packs
+
+
+def test_confirmation_decline_writes_nothing(tmp_path, capsys, monkeypatch):
+    """AC2: declining aborts and removes nothing."""
+    from agentbundle.config import load_state
+
+    rc = _run_install("alpha", str(FIXTURE_CATALOGUE), str(tmp_path))
+    assert rc == 0
+    capsys.readouterr()
+    before = _snapshot_tree(tmp_path)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda prompt="": "n")
+    rc = _run_uninstall("alpha", str(tmp_path), yes=False)
+    assert rc == 1
+    assert "aborted" in capsys.readouterr().err
+    assert _snapshot_tree(tmp_path) == before, "decline must write nothing"
+    state = load_state(tmp_path / ".agentbundle-state.toml")
+    assert "alpha" in state.packs, "declined uninstall keeps the pack in state"
+
+
+def test_confirmation_eof_treated_as_decline(tmp_path, capsys, monkeypatch):
+    """AC2: EOF on the prompt declines."""
+    rc = _run_install("alpha", str(FIXTURE_CATALOGUE), str(tmp_path))
+    assert rc == 0
+    capsys.readouterr()
+
+    def _raise(prompt=""):
+        raise EOFError
+
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", _raise)
+    rc = _run_uninstall("alpha", str(tmp_path), yes=False)
+    assert rc == 1
+    assert "aborted" in capsys.readouterr().err
+
+
+def test_non_tty_without_yes_refuses(tmp_path, capsys, monkeypatch):
+    """AC4: a non-TTY stdin without --yes refuses, names --yes, writes nothing."""
+    rc = _run_install("alpha", str(FIXTURE_CATALOGUE), str(tmp_path))
+    assert rc == 0
+    capsys.readouterr()
+    before = _snapshot_tree(tmp_path)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    def _boom(prompt=""):
+        raise AssertionError("input() must not be called on a non-TTY")
+
+    monkeypatch.setattr("builtins.input", _boom)
+    rc = _run_uninstall("alpha", str(tmp_path), yes=False)
+    assert rc == 1
+    assert "--yes" in capsys.readouterr().err
+    assert _snapshot_tree(tmp_path) == before, "refusal must write nothing"
+
+
+def test_dry_run_remove_keep_parity_with_real_run(tmp_path, capsys):
+    """AC5: the remove/keep split shown by --dry-run is exactly what a real
+    --yes run removes/keeps (Tier-2 file shown `keep` is preserved byte-identical)."""
+    from agentbundle.render import render_pack
+
+    rc = _run_install("alpha", str(FIXTURE_CATALOGUE), str(tmp_path))
+    assert rc == 0
+    capsys.readouterr()
+
+    # Edit one projected file → Tier-2 (should be labelled `keep`).
+    tier2_relpath = sorted(render_pack(ALPHA_PACK_DIR).keys())[0]
+    tier2_file = tmp_path / tier2_relpath
+    edited = b"adopter-edited -- keep me\n"
+    tier2_file.write_bytes(edited)
+
+    rc = _run_uninstall("alpha", str(tmp_path), dry_run=True)
+    assert rc == 0
+    plan = capsys.readouterr().out
+    # Parse the plan lines into (decision, relpath).
+    previewed_remove = set()
+    previewed_keep = set()
+    for line in plan.splitlines():
+        parts = line.split()
+        if len(parts) >= 3 and parts[0] in ("remove", "keep"):
+            (previewed_remove if parts[0] == "remove" else previewed_keep).add(parts[2])
+    assert tier2_relpath in previewed_keep
+    assert tier2_relpath not in previewed_remove
+
+    # Real run removes exactly the previewed `remove` set; keeps the Tier-2 file.
+    rc = _run_uninstall("alpha", str(tmp_path), yes=True)
+    assert rc == 0
+    for relpath in previewed_remove:
+        assert not (tmp_path / relpath).exists(), f"{relpath} previewed remove must be gone"
+    assert tier2_file.read_bytes() == edited, "previewed `keep` file must be byte-identical"

--- a/packages/agentbundle/tests/integration/test_uninstall_user_hooks.py
+++ b/packages/agentbundle/tests/integration/test_uninstall_user_hooks.py
@@ -62,6 +62,7 @@ def _uninstall_args(pack: str, output: str, scope: str | None = None):
         pack=pack,
         root=output,
         scope=scope,
+        yes=True,
     )
 
 

--- a/packages/agentbundle/tests/integration/test_upgrade_user_hooks.py
+++ b/packages/agentbundle/tests/integration/test_upgrade_user_hooks.py
@@ -94,7 +94,7 @@ class UpgradeThenUninstallTests(_UpgradeBase):
 
         # Uninstall.
         un_args = argparse.Namespace(
-            pack="kiro-user-hooks", root=str(self.repo), scope="user",
+            pack="kiro-user-hooks", root=str(self.repo), scope="user", yes=True,
         )
         with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
             rc = uninstall_cmd.run(un_args)

--- a/packages/agentbundle/tests/unit/test_cli_scope_flags.py
+++ b/packages/agentbundle/tests/unit/test_cli_scope_flags.py
@@ -1,12 +1,15 @@
-"""T16: argparse surface gains --scope on six subcommands + --force on install.
+"""T16: argparse surface gains --scope on the install-scope subcommands +
+--force on install.
 
-Verifies AC #(RFC-0004) for the agent-spec-cli spec:
+Verifies AC #(RFC-0004) for the agent-spec-cli spec, as narrowed by the
+CLI-hygiene sweep (which dropped the dead --scope on `list-targets` — parsed
+but never read — and on `reconcile` — single legal value equal to its default):
   - --scope {repo,user} is accepted on install, uninstall, upgrade, diff,
-    init-state, and list-targets.
+    and init-state.
   - Passing --scope to any forbidden subcommand (list-packs, scaffold,
-    validate, render, adapt) exits non-zero with the documented stderr
-    `unknown flag for <verb>: --scope`. Parametrised across both
-    space-separated (`--scope user`) and value-glued (`--scope=user`)
+    validate, render, adapt, and now list-targets / reconcile) exits non-zero
+    with the documented stderr `unknown flag for <verb>: --scope`. Parametrised
+    across both space-separated (`--scope user`) and value-glued (`--scope=user`)
     forms.
   - --force is accepted only on install; any other verb refuses with
     `unknown flag for <verb>: --force`.
@@ -37,6 +40,7 @@ _BASE_ARGS = {
     "diff": ["packs/core"],
     "init-state": ["--pack", "core"],
     "list-targets": [],
+    "reconcile": [],
     "list-packs": ["/fake/catalogue"],
     "scaffold": ["--output", "/tmp/out"],
     "validate": ["packs/core"],
@@ -58,13 +62,13 @@ def _parse(argv: list[str]) -> tuple[int | None, str]:
 
 
 # ---------------------------------------------------------------------------
-# --scope is accepted on the six subcommands
+# --scope is accepted on the install-scope subcommands
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
     "subcommand",
-    ["install", "uninstall", "upgrade", "diff", "init-state", "list-targets"],
+    ["install", "uninstall", "upgrade", "diff", "init-state"],
 )
 @pytest.mark.parametrize("flag_form", ["space", "glued"])
 def test_scope_accepted(subcommand, flag_form):
@@ -81,12 +85,15 @@ def test_scope_accepted(subcommand, flag_form):
 
 
 # ---------------------------------------------------------------------------
-# --scope is rejected on the five forbidden subcommands with exact stderr
+# --scope is rejected on the forbidden subcommands with exact stderr.
+# list-targets and reconcile join this set after the CLI-hygiene sweep.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
-    "subcommand", ["list-packs", "scaffold", "validate", "render", "adapt"]
+    "subcommand",
+    ["list-packs", "scaffold", "validate", "render", "adapt",
+     "list-targets", "reconcile"],
 )
 @pytest.mark.parametrize("flag_form", ["space", "glued"])
 def test_scope_rejected_with_documented_stderr(subcommand, flag_form):

--- a/packages/agentbundle/tests/unit/test_confirm_helper.py
+++ b/packages/agentbundle/tests/unit/test_confirm_helper.py
@@ -1,0 +1,68 @@
+"""Unit tests for `commands/_common.confirm_or_refuse` (CLI-hygiene AC17).
+
+The shared confirm/refuse/--yes helper that `uninstall`, `install --force`, the
+`install`→`upgrade` offer, and `upgrade` all call. Pins the four-way decision:
+yes → proceed (no stdin); non-TTY → refuse; TTY accept → proceed; TTY decline /
+EOF → abort.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentbundle.commands._common import confirm_or_refuse
+
+
+def test_yes_proceeds_without_touching_stdin(monkeypatch):
+    def _boom(prompt=""):
+        raise AssertionError("input() must not be called with yes=True")
+
+    monkeypatch.setattr("builtins.input", _boom)
+    # isatty must not even be consulted under --yes, but patch it defensively.
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    assert confirm_or_refuse(
+        yes=True, question="Q? ", refuse_message="REFUSE", abort_message="ABORT"
+    ) is True
+
+
+def test_non_tty_refuses_and_never_prompts(monkeypatch, capsys):
+    def _boom(prompt=""):
+        raise AssertionError("input() must not be called on a non-TTY")
+
+    monkeypatch.setattr("builtins.input", _boom)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    assert confirm_or_refuse(
+        yes=False, question="Q? ", refuse_message="REFUSE-LINE", abort_message="ABORT"
+    ) is False
+    assert "REFUSE-LINE" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("reply", ["y", "yes", "YES", "  Yes  ", "  y\n"])
+def test_tty_accept_proceeds(monkeypatch, reply):
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda prompt="": reply)
+    assert confirm_or_refuse(
+        yes=False, question="Q? ", refuse_message="REFUSE", abort_message="ABORT"
+    ) is True
+
+
+@pytest.mark.parametrize("reply", ["n", "no", "", "  ", "anything"])
+def test_tty_decline_aborts(monkeypatch, capsys, reply):
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda prompt="": reply)
+    assert confirm_or_refuse(
+        yes=False, question="Q? ", refuse_message="REFUSE", abort_message="ABORT-LINE"
+    ) is False
+    assert "ABORT-LINE" in capsys.readouterr().err
+
+
+def test_tty_eof_treated_as_decline(monkeypatch, capsys):
+    def _raise(prompt=""):
+        raise EOFError
+
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", _raise)
+    assert confirm_or_refuse(
+        yes=False, question="Q? ", refuse_message="REFUSE", abort_message="ABORT-LINE"
+    ) is False
+    assert "ABORT-LINE" in capsys.readouterr().err

--- a/packages/agentbundle/tests/unit/test_install_inband_detection.py
+++ b/packages/agentbundle/tests/unit/test_install_inband_detection.py
@@ -35,6 +35,7 @@ import unittest
 from contextlib import redirect_stderr
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 
 def _make_pack(
@@ -181,8 +182,10 @@ class TriggerBShapeMismatchTests(unittest.TestCase):
                 "{}", encoding="utf-8"
             )
 
+            # `--yes` so the new force-cleanup confirm (CLI-hygiene AC7) does
+            # not refuse on the non-TTY test stdin.
             rc, stderr = _run_install(
-                ["--pack", "demo", "--scope", "repo", "--force",
+                ["--pack", "demo", "--scope", "repo", "--force", "--yes",
                  "--output", str(adopter), str(packs_dir)]
             )
             self.assertEqual(
@@ -479,3 +482,89 @@ class EmitInstallRoutesBypassesDetectionTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ForceCleanupConfirmTests(unittest.TestCase):
+    """CLI-hygiene AC6/AC7: the ``--force`` destructive cleanup (trigger (b))
+    lists what it removes and confirms before deleting."""
+
+    def setUp(self) -> None:
+        _clear_session_set()
+
+    def _setup_b(self, tmp: Path):
+        """Plant the (b) shape — state row + a dist-tree subtree — and return
+        ``(packs_dir, adopter)``."""
+        packs_dir = tmp / "packs"
+        packs_dir.mkdir()
+        _make_pack(packs_dir, allowed_adapters=["claude-code", "kiro"])
+        adopter = tmp / "adopter"
+        adopter.mkdir()
+        _plant_state(adopter, pack_name="demo")
+        (adopter / "claude-plugins" / "demo").mkdir(parents=True)
+        (adopter / "claude-plugins" / "demo" / "plugin.json").write_text(
+            "{}", encoding="utf-8"
+        )
+        return packs_dir, adopter
+
+    def _argv(self, adopter: Path, packs_dir: Path) -> list[str]:
+        return ["--pack", "demo", "--scope", "repo", "--force",
+                "--output", str(adopter), str(packs_dir)]
+
+    def test_force_confirm_lists_subtree_and_proceeds_on_yes(self) -> None:
+        with TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            packs_dir, adopter = self._setup_b(tmp)
+            with patch("sys.stdin.isatty", return_value=True), \
+                 patch("builtins.input", return_value="y"):
+                rc, stderr = _run_install(self._argv(adopter, packs_dir))
+            self.assertEqual(rc, 0, f"install did not complete on 'y': {stderr!r}")
+            self.assertIn("will REMOVE", stderr)
+            self.assertIn("claude-plugins", stderr)
+            self.assertIn("demo", stderr)
+            self.assertFalse(
+                (adopter / "claude-plugins" / "demo").exists(),
+                "subtree must be removed after a confirmed --force",
+            )
+
+    def test_force_confirm_decline_deletes_nothing(self) -> None:
+        with TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            packs_dir, adopter = self._setup_b(tmp)
+            with patch("sys.stdin.isatty", return_value=True), \
+                 patch("builtins.input", return_value="n"):
+                rc, stderr = _run_install(self._argv(adopter, packs_dir))
+            self.assertNotEqual(rc, 0)
+            self.assertIn("aborted", stderr)
+            self.assertTrue(
+                (adopter / "claude-plugins" / "demo" / "plugin.json").exists(),
+                "a declined --force must delete nothing",
+            )
+            # AC6 atomicity: decline must not pop the state row or rewrite
+            # state either — the whole destructive block is gated.
+            import tomllib
+
+            state = tomllib.loads(
+                (adopter / ".agentbundle-state.toml").read_text(encoding="utf-8")
+            )
+            self.assertIn(
+                "demo", state.get("pack", {}),
+                "a declined --force must leave the state row intact",
+            )
+
+    def test_force_non_tty_without_yes_refuses_zero_deletions(self) -> None:
+        with TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            packs_dir, adopter = self._setup_b(tmp)
+
+            def _boom(prompt=""):
+                raise AssertionError("input() must not be called on a non-TTY")
+
+            with patch("sys.stdin.isatty", return_value=False), \
+                 patch("builtins.input", _boom):
+                rc, stderr = _run_install(self._argv(adopter, packs_dir))
+            self.assertNotEqual(rc, 0)
+            self.assertIn("--yes", stderr)
+            self.assertTrue(
+                (adopter / "claude-plugins" / "demo" / "plugin.json").exists(),
+                "a non-TTY --force without --yes must delete nothing (AC7)",
+            )

--- a/packages/agentbundle/tests/unit/test_install_messages_repo_scope.py
+++ b/packages/agentbundle/tests/unit/test_install_messages_repo_scope.py
@@ -168,6 +168,9 @@ class OrphanRefusalTests(unittest.TestCase):
                     "--scope",
                     "repo",
                     "--force",
+                    # `--yes` so the orphan-cleanup confirm (CLI-hygiene AC7)
+                    # does not refuse on the non-TTY test stdin.
+                    "--yes",
                     "--output",
                     str(adopter),
                     str(packs_dir),
@@ -182,6 +185,101 @@ class OrphanRefusalTests(unittest.TestCase):
             self.assertTrue(
                 (adopter / ".claude" / "skills" / "demo-skill" / "SKILL.md").exists(),
                 "the pack's real projection must land after --force reinstall",
+            )
+
+    def _setup_orphan(self, tmp: Path):
+        """Plant the (c) orphan shape and return ``(packs_dir, adopter, orphan)``."""
+        packs_dir = tmp / "packs"
+        packs_dir.mkdir()
+        self._make_pack(packs_dir)
+        adopter = tmp / "adopter"
+        adopter.mkdir()
+        orphan = adopter / ".claude" / "skills" / "demo-skill" / "STALE.md"
+        orphan.parent.mkdir(parents=True)
+        orphan.write_text("stale", encoding="utf-8")
+        return packs_dir, adopter, orphan
+
+    def _argv(self, adopter: Path, packs_dir: Path, *, yes: bool = False) -> list[str]:
+        argv = ["install", "--pack", "demo", "--scope", "repo", "--force"]
+        if yes:
+            argv.append("--yes")
+        return argv + ["--output", str(adopter), str(packs_dir)]
+
+    def test_orphan_force_confirm_lists_files_and_proceeds_on_yes(self) -> None:
+        """CLI-hygiene AC6: the orphan (c) --force confirm lists the exact files
+        and proceeds on a TTY 'y'."""
+        import io
+        from contextlib import redirect_stderr
+        from unittest.mock import patch
+
+        from agentbundle.cli import _build_parser
+        from agentbundle.commands import install
+
+        with TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            packs_dir, adopter, orphan = self._setup_orphan(tmp)
+            args = _build_parser().parse_args(self._argv(adopter, packs_dir))
+            buf = io.StringIO()
+            with patch("sys.stdin.isatty", return_value=True), \
+                 patch("builtins.input", return_value="y"), \
+                 redirect_stderr(buf):
+                rc = install.run(args)
+            stderr = buf.getvalue()
+            self.assertEqual(rc, 0, stderr)
+            self.assertIn("will REMOVE orphan file:", stderr)
+            self.assertIn("STALE.md", stderr)
+            self.assertFalse(orphan.exists(), "confirmed --force must remove the orphan")
+
+    def test_orphan_force_confirm_decline_deletes_nothing(self) -> None:
+        """CLI-hygiene AC6: declining the orphan --force confirm deletes nothing."""
+        import io
+        from contextlib import redirect_stderr
+        from unittest.mock import patch
+
+        from agentbundle.cli import _build_parser
+        from agentbundle.commands import install
+
+        with TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            packs_dir, adopter, orphan = self._setup_orphan(tmp)
+            args = _build_parser().parse_args(self._argv(adopter, packs_dir))
+            buf = io.StringIO()
+            with patch("sys.stdin.isatty", return_value=True), \
+                 patch("builtins.input", return_value="n"), \
+                 redirect_stderr(buf):
+                rc = install.run(args)
+            self.assertNotEqual(rc, 0)
+            self.assertIn("aborted", buf.getvalue())
+            self.assertTrue(orphan.exists(), "a declined --force must delete nothing")
+
+    def test_orphan_force_non_tty_without_yes_refuses_zero_deletions(self) -> None:
+        """CLI-hygiene AC7: a non-TTY orphan --force without --yes refuses and
+        leaves the orphan on disk."""
+        import io
+        from contextlib import redirect_stderr
+        from unittest.mock import patch
+
+        from agentbundle.cli import _build_parser
+        from agentbundle.commands import install
+
+        with TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            packs_dir, adopter, orphan = self._setup_orphan(tmp)
+            args = _build_parser().parse_args(self._argv(adopter, packs_dir))
+
+            def _boom(prompt=""):
+                raise AssertionError("input() must not be called on a non-TTY")
+
+            buf = io.StringIO()
+            with patch("sys.stdin.isatty", return_value=False), \
+                 patch("builtins.input", _boom), \
+                 redirect_stderr(buf):
+                rc = install.run(args)
+            self.assertNotEqual(rc, 0)
+            self.assertIn("--yes", buf.getvalue())
+            self.assertTrue(
+                orphan.exists(),
+                "a non-TTY --force without --yes must delete nothing (AC7)",
             )
 
 


### PR DESCRIPTION
Follow-up to merged #374 (which removed `upgrade --to` and added derive-version-from-catalogue + confirm). Applies the same critical lens to the rest of the `agentbundle` CLI surface. **No version bump** — 0.6.0 → 0.7.0 is cut separately after this merges.

## What changed

A shared `commands/_common.confirm_or_refuse` (yes → proceed / non-TTY → refuse / TTY → prompt; EOF → abort) now backs every confirm site:

- **`uninstall` — `--dry-run`, `--yes`, confirmation.** It was the only mutating verb with no preview (it `os.remove`d every Tier-1 file immediately). `--dry-run` previews the per-file `remove tier-1` / `keep tier-2` plan and writes nothing (no removal, no hook-wiring unproject, no state change); otherwise it confirms before the first removal. Execution acts on the recorded classification **without re-hashing**, so the preview equals the action. Tier-2 preservation unchanged.
- **`install --force` — confirm before destructive cleanup.** Lists the actual deletion unit (the `rmtree` subtree roots `claude-plugins/<pack>` / `apm/<pack>`, or the exact orphan files) and gates the whole block — rmtree + state-row pop + state-file rewrite — atomically. `--yes` skips; a non-TTY refuses with **zero deletions**. `--force` used purely as a cross-scope bypass (no deletion) is unchanged and never prompts. Declining discards the once-per-session marker so an in-process retry re-prompts.
- **`install` → `upgrade` offer.** `install` gains `--yes`; an already-installed-at-scope `install` now offers to run `upgrade` (TTY) / runs it (`--yes`) instead of flatly refusing. A non-TTY without `--yes`, and `--dry-run`, keep the historical `already installed … use 'upgrade'` refusal.
- **Dropped dead `--scope` flags** on `reconcile` (single legal value `user`, = default) and `list-targets` (parsed but never read).
- **`upgrade`** refactored onto the shared helper (exact stderr preserved).

## Migration

CI that runs the **deleting** form of `install --force` non-interactively must add `--yes` (a non-TTY now refuses rather than deleting unattended — mirroring `upgrade`). Cross-scope-bypass `--force` is unaffected.

## Verification

- Full `packages/agentbundle/tests/` suite green; new tests for the confirm helper, uninstall dry-run/confirm, install force-confirm (dist-tree + orphan branches: lists / declines / non-TTY-zero-deletions), and the upgrade offer (incl. one real end-to-end). Wired into `build-check.yml` (CI does not auto-discover package pytest).
- Real CLI exercised end-to-end (dry-run preview, --yes removal, both dropped flags refuse).
- Reviewed: adversarial + security-reviewer returned Clean; quality-engineer concerns applied (orphan-branch tests, decline-state atomicity, session-marker discard).

Spec/plan: `docs/specs/agentbundle-cli-hygiene/`.

## Deferred (in `docs/backlog.md`)

- `scope-disambiguator-extraction` — the multi-scope disambiguator block is duplicated across uninstall/upgrade/diff; deferred because each downstream diverges sharply and extracting would pull `diff` into a path-jail refactor for marginal gain.
- `force-cleanup-symlink-confinement` — pre-existing `rglob`/`rmtree` symlink-following in the `--force` scan; not introduced here (listing the subtree root as the deletion unit avoids widening it).