### PR TITLE
docs(rfc): RFC-0043 follow-on — ADR-0033 + product-rung spec/plan

### DIFF
--- a/docs/adr/0019-product-intent-ontology-and-brief-projection.md
+++ b/docs/adr/0019-product-intent-ontology-and-brief-projection.md
@@ -4,6 +4,7 @@
 - **Date:** 2026-06-13
 - **Deciders:** eugenelim
 - **Supersedes:** none
+- **Refined by:** ADR-0033 — its part 1 only (the `Level` enum is reopened to an open recognized set and decoupled from `Scale`); parts 2–3 stand. ADR-0019 stays Accepted; this is a metadata back-pointer, not a body edit.
 - **Related:** RFC-0030 (the product-engineering pack — the decision this records) · ADR-0009 (the brief layer this reframes) · ADR-0008 + RFC-0017 + RFC-0018 (the contract-authoring seam this stages) · RFC-0019 (receive-brief)
 
 ## Context

--- a/docs/adr/0033-intent-level-open-recognized-set-decoupled-from-scale.md
+++ b/docs/adr/0033-intent-level-open-recognized-set-decoupled-from-scale.md
@@ -1,0 +1,105 @@
+# ADR-0033: The intent `Level` is reopened to an open recognized set (`product-vision › product-strategy › capability › feature`) and decoupled from `Scale` — a refinement of ADR-0019, prompt-only
+
+- **Status:** Accepted <!-- Proposed | Accepted | Rejected | Deprecated | Superseded by ADR-NNNN -->
+- **Date:** 2026-06-23
+- **Decision-makers:** eugenelim
+- **Consulted:** RFC-0043 (the accepted decision this records, incl. its no-engine-change spike result and the D1–D6 decision set); the spec-stage adversarial + design review of this ADR and the implementing spec
+- **Supersedes:** none
+- **Related:** ADR-0019 (the recursive level-tagged `intent` ontology this **refines** — its part 1 `Level` enum, not its whole; ADR-0019 stays Accepted and its parts 2–3 stand) · RFC-0043 (the accepted decision this ADR records) · RFC-0030 (the `product-engineering` pack's founding RFC, whose steel-thread already named a "vision/intent root" this ships) · RFC-0019 (`receive-brief`, the level-agnostic universal receiver this does not touch) · core `init-project` (the greenfield front door the seam connects to) · `docs/specs/product-rung/` (the implementing spec these decisions are confirmed against)
+
+## Context
+
+RFC-0030 / ADR-0019 (both Accepted 2026-06-13) shipped the `product-engineering` pack: product shaping as a **recursive, level-tagged `intent` tree** whose leaf is a shippable spec/slice, with `Level` **open by design** ("the levels disagree across tools… reifying the pyramid encodes the story=spec falsehood" — ADR-0019, *Alternatives*, rejecting fixed SAFe ladders). The v1 implementation, however, has two coupled defects that trace to one over-narrowing:
+
+- **The ladder tops out at `capability`.** The shipped `Level` enum is `capability | feature` (`intent-template.md:11`), and `intent-model.md` defines `capability` as *architectural span* with an *architectural/adoption* de-risk kind. A greenfield **product concept** — a bet about whether a product should exist at all, for whom, through what wedge — is neither a feature nor an architectural span. That altitude has no rung, even though ADR-0019 intended `Level` to be open.
+- **`Level` is welded to `Scale`.** `scale-intake.md:29` stamps `app → feature` / `business-unit → capability`, and `frame-intent` step 3 nudges hard ("At `app` Scale most intents are `feature`-level"). So "one repo" is treated as proof you already know your feature. Scale (how many repos) and Level (altitude of the bet) are orthogonal; fusing them mis-routes every single-repo product concept.
+
+The consequence, observed in practice (n=1, the reporting user): a product concept fed to `frame-intent` either collapses to a single feature intent (altitude lost) or fans out into **multiple feature intents with no shared parent** — sibling bets that each silently re-assume the product should exist, whose "does anyone want this" question is tested piecemeal (validation theatre) or not at all.
+
+Constraints in force when deciding:
+
+- **CHARTER Principle 3 (a habit, not infrastructure).** The pack ships prompt-only doctrine the agent reasons from — markdown, file-per-artifact — never a runtime engine, hook, or executable tooling. This forecloses importing a heavyweight product-ops toolkit's machinery (a large fixed-type ontology, write-time hooks, mandatory phase-gates, a multi-section handoff packet).
+- **CHARTER Principle 2 (no duplication).** A capability belongs in exactly one place; a parallel `vision.md` / `strategy.md` artifact type that forks the one recursive `intent` is rejected.
+- **ADR-0019's "one recursive artifact at every level" model.** A capability intent, a feature intent, and a PRD are the *same artifact* at different `Level`s. Any product rung must be the same shape one level higher, not a new type.
+- **ADR-0019's "no fixed ladder."** `Level` is open by design; a closed, N-deep `product→strategy→capability→feature→story` ladder is the SAFe shape ADR-0019 already rejected.
+- **The pack's altitude:** name the bet and the question it forces; reuse the existing recursion, de-risk, and decomposition mechanisms rather than adding new ones.
+
+RFC-0043 settled *whether* and *how* to close these gaps (decisions D1–D6), with the riskiest assumption — that this is enum + prompt work needing **no engine change** — confirmed by a spike against the shipped pack (the recursion already produces "the next level down" at any level; the Scale→Level edit is a stamp→suggestion change that does **not** sever Scale's load-bearing leaf-projection role; the `market-existence` bet reuses `kill-condition.md`'s pre-PMF qualitative bar). This ADR records the load-bearing, expensive-to-reverse calls — the *artifact-model commitment*, the *open-field shape*, the *Level/Scale decoupling*, the *distinct de-risk kind*, and the *cross-pack seam* — so a future maintainer doesn't re-litigate them. The mechanical detail (the exact field-set bullets, the prompt wording, the tracker-projection rows, the sibling-spawn trip text) is spec-level and lives in the implementing spec, not here.
+
+## Decision
+
+> We **refine ADR-0019's intent ontology**: `Level` is an **open** field carrying a **recognized set** — `product-vision` › `product-strategy` › `capability` › `feature` — and is **decoupled from `Scale`**, whose Level role becomes a *suggested starting altitude* rather than a silent stamp (its leaf-projection role is preserved). The two product rungs are **higher `Level`s of the same recursive `intent` artifact** (not a new type), the product-existence bet is a **distinct de-risk kind** (`market-existence` = market desirability + viability, not the feature-level `desirability` token reused), and core's `init-project` gains `intent` / `frame-intent` as a **fourth recognized discovery source, by reference only**. The mechanism is **prompt-only — no engine, hook, new skill, or new artifact type.**
+
+**D1–D4 below refine ADR-0019's part 1** (the `Level` enum and its Scale coupling); **D5 is a net-new cross-pack decision** that ADR-0019 did not address (it never mentions `init-project`) — so this ADR is a refinement *and* a new structural call, and the scope claim is split rather than overloaded. ADR-0019's part 2 (a brief is a feature-level intent projected onto one repo; `receive-brief` stays in `core`, level-agnostic, no `level:` field) and part 3 (contracts mature by SDLC stage) **stand untouched**; ADR-0019 remains **Accepted** with a `Refined by: ADR-0033` back-pointer added to its header (a metadata-only edit; its body stays immutable). ADRs are immutable, so this realignment is recorded as a new ADR rather than a body edit.
+
+Five sub-decisions, each expensive to reverse. (These are this ADR's grouping of the load-bearing calls; they map to RFC-0043's Proposal decisions **D1–D4 + D6**. RFC-0043's D5 — the seeded field sets — is mechanical and lives in the implementing spec, not here.)
+
+- **D1 — Artifact model: a new rung is a higher `Level` of the same recursive `intent` (the option choice).** `product-vision` and `product-strategy` are the existing `intent` artifact at a higher altitude — they reuse the recursion (`recursive-decomposition.md`), the per-intent de-risk loop, and the decomposition boundary, and require no new file type, layout, discovery wiring, or hook. This is the call that keeps the pack inside ADR-0019's "same artifact at every level" model and away from the heavyweight-toolkit mass a parallel artifact type accretes.
+- **D2 — `Level` is open with a recognized set (reopen, don't re-narrow).** The field stays string-valued and open (an adopter may name an intervening altitude); the recognized set `product-vision › product-strategy › capability › feature` names the altitudes the skills prompt for and the templates seed. This **realigns the implementation with ADR-0019's "open by design" decision** rather than reversing it — the v1 `capability | feature` enum over-narrowed an intentionally open ontology. Lint cannot enforce a closed set; that is the accepted cost of an open field.
+- **D3 — `Level` is decoupled from `Scale` (the root-cause fix).** `Scale` carries two roles in `scale-intake.md`: it sets the *default Level* **and** the *leaf-projection* (`app` → a same-repo brief; `business-unit` → a per-component slice). This decision changes **only the first** — the Scale→Level *stamp* becomes a *suggested starting altitude* (`app` greenfield concept → offer `product-vision`; `app` known feature → `feature`; `business-unit` → `product-strategy` or `capability`), overridable in one word. The Scale→leaf-projection role is **preserved unchanged** — it is load-bearing for `app` vs `business-unit` leaf shape (ADR-0019 part 2) and severing it would break the brief projection.
+- **D4 — The product-existence bet is a distinct de-risk kind, `market-existence`, never the `desirability` token reused.** `de-risk-intent` maps the dominant assumption kind to the intent's level (`capability → architectural/adoption`; `feature → desirability`). The product rungs add one row: `product-vision` / `product-strategy` → **`market-existence`** = will-anyone-want-this-at-all (market desirability) **+** can-this-be-a-business (viability) — closing the Cagan/SVPG viability risk the pack does not cover today. It is **categorically distinct** from `feature → desirability` ("do users want *this feature*"); giving both the same token is exactly the conflation that produces validation theatre, so the kinds get **different tokens** and the prose says so. It reuses `kill-condition.md`'s existing pre-PMF **qualitative-bar** machinery — no new de-risk mechanism — and is tested **once at the top**, not re-litigated N times across sibling features.
+- **D5 — The `init-project` seam is a by-reference cross-pack edge (recorded here because it is structural).** Core's `init-project` stage 2 ("value gate") consumes fed-in discovery from three named sources (`research`, a PRD, a `receive-brief` brief) and never names `frame-intent`. The decision adds `intent` / `frame-intent` as a **fourth recognized discovery source** and documents that `frame → de-risk → decompose` hands its leaf into `init-project`. `init-project` composes **by reference, never by import**, and **performs no discovery itself**; the seam respects both — it names one more upstream discovery *shape* `init-project` *receives*, importing nothing from `product-engineering`. Because this adds a named cross-pack reference (a structural change under `docs/CONVENTIONS.md`'s risk triggers), it is recorded in this ADR and the spec, not merely a changelog line.
+
+Boundaries on the decision:
+
+- **No new artifact type, file layout, hook, engine, or skill.** The change is an enum widening, prompt edits, two seeded level-conditional field blocks, one de-risk-kind row, tracker-projection rows, and one by-reference seam doc — prose only, consistent with Principle 3 and the rest of the pack.
+- **Neither rung is mandatory; either is authorable directly; skipping is allowed but observable.** A feature-first repo never sees the rungs. A *sibling-spawn detector* (qualitative: the intent won't reduce to a single shippable slice) **offers** to frame the product parent — it never blocks. A *retroactive-parent* affordance reconstructs and back-links a parent via the existing `Parent intent:` field, at an **inferred** altitude (architectural slices of one buildable thing → `capability`; independent value bets that together make one product → `product-vision`/`product-strategy`), named and user-correctable.
+- **The fixed `product→strategy→capability→feature→story` ladder is rejected** — it is the closed SAFe ladder ADR-0019 already rejected and RFC-0043 lists as a non-goal. Two *seeded* rungs over an *open* field is the middle that prior art supports and the charter tolerates.
+- **One merged product rung is rejected** — it would lose the well-attested vision (the existence bet) vs. strategy (the path) distinction.
+- **`receive-brief`'s level-agnostic contract and Scale's leaf-projection role are out of scope** — both are ADR-0019 part 2 and are preserved.
+
+## Decision drivers
+
+- **The shipped v1 over-narrowed an intentionally-open ontology (ADR-0019).** Drives D2 — reopen `Level` to a recognized set rather than inventing a new mechanism.
+- **The Scale→Level weld is the root cause of the observed misroute.** Drives D3 — decouple the stamp into a suggestion while preserving leaf-projection.
+- **CHARTER Principle 3 (habit, not infrastructure).** Rules out the heavyweight product-ops toolkit's hooks / phase-gates / fixed-type ontology; drives D1's prose-only, same-artifact choice.
+- **CHARTER Principle 2 (no duplication) + ADR-0019's one-recursive-artifact model.** Rule out a parallel `vision.md` / `strategy.md` type; drive D1.
+- **The Cagan/SVPG four-risks viability gap.** The pack covers value + feasibility but not viability; drives D4's distinct `market-existence` kind.
+- **RFC-0030's steel-thread already named a "vision/intent root" above outcome** that v1 collapsed. This decision ships the root that founding RFC anticipated, rather than adding a novel concept.
+- **The no-engine-change spike** (RFC-0043 Evidence). Confirms the whole change is enum + prompt + field-set work; nothing here needs a code or recursion change.
+
+## Consequences
+
+**Positive:**
+
+- The product altitude gets a home **inside the one recursive `intent` model** — no new artifact type, layout, discovery wiring, or hook — so a greenfield product concept stops misrouting to a feature intent, and the existence bet is anchored and de-risked **once at the top** instead of piecemeal across orphaned siblings.
+- **Reuses what already ships**: the recursion, `de-risk-intent`'s kill-condition loop (including the pre-PMF qualitative bar), and `decompose-intent`'s upward-feedback / `Parent intent:` edge. The change is additive and the migration is empty — existing `capability`/`feature` intents stay valid, since the recognized set is a superset.
+- **Scale and Level become orthogonal**, so an `app`-Scale (one-repo) greenfield concept can legitimately start at a product altitude, while Scale keeps doing the one job it must (leaf-projection shape).
+- **Closes the greenfield seam** between the product loop and core's repo front door without coupling code — `init-project` receives one more discovery shape by reference.
+
+**Negative:**
+
+- **Two more recognized levels widen the surface** every `product-engineering` skill reasons about (frame, de-risk, decompose, tracker-projection, the guide). More prose to keep coherent.
+- **An open `Level` field trades enum-tidiness for flexibility** — lint cannot enforce a closed set, so a typo'd or off-ladder `Level` is caught by a reviewer, not a gate.
+- **The `init-project` seam couples a `core` doc to a `product-engineering` concept by name** (not by import) — a small narrative coupling that a pure-engineering adopter who never installs the product pack reads as a dangling reference to an optional upstream.
+
+**Neutral / to revisit:**
+
+- **Adopter demand is n=1** (the reporting user). The design's optionality makes it a low-cost bet even if uptake is thin; revisit on post-ship feedback (RFC-0043 OQ3).
+- **Tracker-projection rows for the two rungs** are settled at spec time to the higher/intervening-tier default (Jira Align Theme/Strategy tier; Linear → Initiative/label; `none` → markdown) (RFC-0043 OQ1).
+- **Whether vision and strategy blur in practice** — if adopters can't tell them apart, the open field lets a user collapse to one rung; that is the escape hatch, and the signal to revisit the two-rung split (RFC-0043 risk).
+
+## Confirmation
+
+- The implementing spec (`docs/specs/product-rung/`) encodes the decision as acceptance criteria — the open `Level` + recognized set, the Scale→Level suggestion (with leaf-projection preserved), the two seeded field blocks, the `market-existence` de-risk kind, the sibling-spawn + retroactive-parent behaviors, the tracker-projection rows, and the by-reference `init-project` seam — so conformance is checkable against the spec at the implementing PR.
+- **Enforcement is deliberately review-time, not a standing CI gate.** An open `Level` field cannot be machine-checked against a closed set, and the prose-only, no-new-mechanism shape is exactly the bar that keeps the pack a habit not infrastructure (Principle 3). Conformance is confirmed at the implementing PR (the spec's ACs) and thereafter by the reviewer passes' standing doctrine — matching ADR-0030/0031/0032's precedent of accepting a prose-enforced, reviewer-held residual.
+
+## Alternatives considered
+
+- **A. Do nothing — tell users to stamp `Level: capability` by hand.** Rejected against the **over-narrowing** and **root-cause** drivers: `capability` is *architectural span* with the wrong de-risk kind, the Scale→Level stamp still misroutes, and orphaned siblings persist. Every greenfield product concept keeps misrouting.
+- **B. Overload `capability` to also mean product altitude.** Rejected: it conflates architectural-span and product-existence — two different de-risk kinds — and still leaves no vision-vs-strategy distinction.
+- **C. New rung(s), same recursive `intent` (chosen).** The only option that closes the altitude gap *and* the Scale↔Level coupling while staying inside the one-recursive-`intent`, prompt-only model.
+- **D. A new parallel artifact type (`vision.md` / `strategy.md`).** Rejected against **Principle 2 and ADR-0019's one-recursive-artifact model** — it breaks the "same artifact at every level" shape, needs new layout / discovery / decompose wiring, and trends toward the heavyweight-toolkit mass Principle 3 forecloses.
+- **One merged product rung** (sub-axis under C). Rejected: loses the vision (existence bet) vs. strategy (the path) distinction that is well attested across the prior art (Cagan; the surveyed toolkits).
+- **An N-deep fixed product ladder** (sub-axis under C). Rejected: it is precisely the fixed SAFe ladder **ADR-0019 already rejected** and RFC-0043 lists as a non-goal; this sub-axis defers to that rejection rather than re-deciding it.
+- **Reuse the `desirability` token for the product-existence bet** (sub-axis under D4). Rejected: naming the feature-level and product-level bets identically is the conflation that produces validation theatre; the product-existence bet asks "is there a product here at all," not "do users want *this feature*."
+
+## References
+
+- RFC-0043 — A product rung two altitudes above capability, Level decoupled from Scale (the accepted decision this ADR records; decisions D1–D6, the no-engine-change spike, the OQ defaults, and the promoted survey).
+- ADR-0019 — Product shaping is a recursive level-tagged `intent` tree (the ontology this refines; its part 1 `Level` enum is reopened/decoupled, parts 2–3 stand, status stays Accepted).
+- RFC-0030 — the `product-engineering` pack's founding RFC, whose steel-thread named the "vision/intent root" this ships.
+- core `init-project/SKILL.md` — the greenfield front door whose stage-2 discovery sources the seam extends, by reference.
+- `docs/specs/product-rung/` — the implementing spec these decisions are confirmed against.
+- `docs/rfc/0043-notes/survey-product-rung.md` — the promoted applied-mode survey (findings F1–F5, citations) grounding the field sets and the `market-existence` kind.
+- CHARTER Principles 2 and 3 — the no-duplication and habit-not-infrastructure bars this decision clears.

--- a/docs/specs/product-rung/notes/spec-stage-review.md
+++ b/docs/specs/product-rung/notes/spec-stage-review.md
@@ -1,0 +1,17 @@
+# Spec-stage review — product-rung (RFC-0043 follow-on)
+
+Reviewers: adversarial-reviewer + design-reviewer (parallel), 2026-06-23.
+Design verdict: SHIP WITH CHANGES. No Blockers from either.
+
+All findings resolved in the same PR:
+1. (adv) ADR-0019 lacked a forward pointer → added `Refined by: ADR-0033` metadata line.
+2. (adv) `Constrained by:` overstated OQ3 (decide-by is post-ship) → reworded.
+3. (adv) market-existence viability half not checkable → AC now requires both halves named.
+4. (design M1) ADR title under-described the enum reopening → retitled to lead with it.
+5. (design M2) "refines only part 1" absorbed D5 (net-new seam) → framing split (D1–D4 refine / D5 net-new).
+6. (design M3) Status Proposed inconsistent with Accepted RFC + ADR-0032 precedent → flipped to Accepted.
+7. (design m4) ADR D1–D5 vs RFC D1–D6 numbering → added a one-line map.
+8. (design R2) core seam should be optional-upstream → seam AC + plan T7 now require "when product-engineering is installed" framing.
+
+No action: adv#2 (spec already cites :143-146 correctly), adv#5 (AC count fine),
+design#5 (house pattern, now truthful post-review), risk register R1/R3/R4/R5 (documented risk-acceptance).

--- a/docs/specs/product-rung/plan.md
+++ b/docs/specs/product-rung/plan.md
@@ -1,0 +1,204 @@
+# Plan: product-rung
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Drafting <!-- Drafting | Executing | Done -->
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn. When it changes substantially
+> (a different approach, not just a re-ordering), note why in the changelog
+> at the bottom.
+
+## Approach
+
+The change is **prompt-only** edits across the three `product-engineering` skills plus one `core` seam, in two clusters that meet at the `intent` template. **First, the model edits** (the load-bearing semantics): reopen `Level` to an open field with a recognized set, turn the Scale→Level stamp into a suggestion while preserving Scale's leaf-projection role, and add the `market-existence` de-risk kind. **Second, the seeded content and behaviours** that sit on top of the model: the two level-conditional field blocks, the sibling-spawn detector, the retroactive-parent affordance, the tracker-projection rows, and — in `core` — the by-reference `init-project` discovery-source seam.
+
+The riskiest part is **altitude and adopter-cleanliness of the seeded prose**: the field sets must read as a *prompt sheet, not a schema* (an empty heading is a prompt, not an error), stay at the pack's name-the-bet altitude, and carry **no** internal-governance citations (no `RFC-0043`, no ADR/RFC numbers, no `docs/rfc/…` paths, no backlog anchors) since they ship into adopters' repos under `.apm/**`. That is the focus of the adopter-clean cross-cutting grep and the adversarial/quality reviewer passes. The model edits themselves are small, well-bounded prose changes; the spike (RFC-0043 Evidence) already confirmed no engine or recursion change is needed.
+
+This plan describes the **implementing PR**. The governance PR that introduces ADR-0033 and this spec/plan **does not execute it** — it ships the ADR + spec + plan only, and the spec stays `Draft` until the implementing PR flips it.
+
+## Constraints
+
+- **ADR-0033** — the load-bearing decisions: open `Level` + recognized set; Level decoupled from Scale (stamp → suggestion, leaf-projection preserved); the two rungs are the same recursive `intent`; `market-existence` a distinct de-risk kind; the `init-project` seam by reference only; prompt-only, no new primitive.
+- **RFC-0043** — D1–D6 and the open-question defaults (OQ1 tracker rows → higher/intervening tier; OQ2 `product-strategy` at any Scale; OQ3 demand watched post-ship).
+- **ADR-0019** — refined, not superseded; its part 2 (`receive-brief` level-agnostic, brief has no `level:`, Scale's leaf-projection) and part 3 (staged contracts) are preserved and out of scope.
+- **CHARTER Principles 2 & 3** — no duplication (no new artifact type / skill), habit not infrastructure (no engine, hook, or executable tooling).
+- **`AGENTS.local.md` adopter-clean rule** — shipped `.apm/**` content carries no internal-governance citations.
+- **Self-host projection scope** — `core` is self-host-projected (the `init-project` seam needs `make build-self`); `product-engineering` is **not** (its bump drifts only `marketplace.json`).
+
+## Construction tests
+
+Most verification is per-task below. Cross-cutting checks that span tasks:
+
+**Integration / cross-cutting checks:**
+- **Adopter-clean:** a `grep` over every shipped file this change touches — `packs/product-engineering/.apm/**`, `packs/core/.apm/**`, and `packs/product-engineering/README.md` (the pack README ships to adopters) — finds no `RFC-\d`, `ADR-\d`, `docs/rfc/`, or `docs/backlog.md` anchor citation. The repo-owned `docs/guides/**` pages are exempt (not shipped to adopters).
+- **Both field blocks present + level-conditional:** `grep` confirms `intent-template.md` carries both a `product-vision` and a `product-strategy` field block, each marked filled-only-at-that-rung.
+- **Projection drift-clean:** after `make build-self`, `git status` shows only the expected `.claude/skills/init-project/SKILL.md` drift (core) and, after `make build`, only the expected `marketplace.json` version line (product-engineering) — no unexpected reverts.
+
+**Manual verification:**
+- Dogfood the rungs end-to-end (T10): `frame-intent` on a greenfield product concept offers `product-vision`; `de-risk-intent` on it picks `market-existence`; the sibling-spawn path offers the product parent.
+
+## Tasks
+
+### T1: Reopen `Level` to an open field with a recognized set
+
+**Depends on:** none
+
+**Tests:**
+- `grep` confirms `intent-model.md` documents the recognized set `product-vision › product-strategy › capability › feature` and states `Level` stays open-valued (AC: Level open + recognized set).
+- `grep` confirms `intent-template.md:11`'s `Level:` comment is widened from `<capability | feature>` to show the recognized set without closing the field (AC: Level open).
+- `grep`/read confirms `intent-model.md` documents `product-vision` (existence bet) and `product-strategy` (the path) semantics, vision above strategy above capability (AC: semantics).
+
+**Approach:**
+- Edit `frame-intent/references/intent-model.md` to add the recognized set + the two-rung semantics, keeping the "no fixed ladder / open field" framing.
+- Widen the `intent-template.md` `Level:` field comment to the recognized set, leaving the value a free string.
+
+**Done when:** the recognized set and the two-rung semantics are documented in `intent-model.md` and the template comment, with `Level` still an open field, and the T1 greps pass.
+
+### T2: Decouple Scale→Level to a suggestion; preserve leaf-projection
+
+**Depends on:** T1
+
+**Tests:**
+- `grep` confirms `scale-intake.md`'s "default level" wording is reframed as a *suggested starting altitude* and `frame-intent` SKILL.md step 3 no longer hard-nudges `feature` at `app` Scale (AC: stamp → suggestion).
+- `grep` confirms `scale-intake.md`'s leaf-projection sentence and the intake table's "Leaf lands as" column are **unchanged in meaning** — `app` → same-repo brief, `business-unit` → per-component slices (AC: leaf-projection preserved).
+- `grep`/read confirms `frame-intent` step 3 asks the altitude explicitly for concept-shaped / greenfield input and offers the suggested starting points (AC: ask altitude for concepts).
+
+**Approach:**
+- In `scale-intake.md`, split Scale's two roles explicitly: keep leaf-projection as-is; reword the "default level" role to a suggestion (`app` greenfield concept → `product-vision`; `app` known feature → `feature`; `business-unit` → `product-strategy`/`capability`), overridable in one word.
+- In `frame-intent/SKILL.md` step 3, replace the hard `feature`-at-`app` nudge with an explicit altitude question for concept-shaped/greenfield input.
+
+**Done when:** Scale suggests rather than stamps the altitude, the leaf-projection role is provably untouched, and the T2 greps pass.
+
+### T3: Seed the `product-vision` and `product-strategy` field blocks
+
+**Depends on:** T1
+
+**Tests:**
+- `grep` confirms `intent-template.md` carries a `product-vision` field block with all nine elements (customer-shaped pitch, the change, job + struggling moment, who-by-circumstance, existing alternatives, narrowest wedge, demand evidence, tiered open assumptions, counter-metrics) (AC: vision block).
+- `grep` confirms a `product-strategy` field block with its five elements (central challenge, guiding policy, coherent actions, problem/segment sequence, horizon) (AC: strategy block).
+- `grep`/read confirms both blocks are marked **level-conditional** (filled only at that rung) and live in the single `intent-template.md` file with no new schema (AC: level-conditional, prompt-not-schema).
+
+**Approach:**
+- Add the two level-conditional field blocks to `frame-intent/assets/intent-template.md`, each prose/short-field, each with a one-line "fill only when `Level:` is this rung" cue and the template-not-schema posture preserved.
+- Keep the prose adopter-clean — no RFC/backlog citation.
+
+**Done when:** both blocks exist, are level-conditional, and the T3 greps pass.
+
+### T4: Add the `market-existence` de-risk kind
+
+**Depends on:** T1
+
+**Tests:**
+- `grep` confirms `de-risk-intent/SKILL.md` and `intent-model.md`'s level→kind mapping gain `product-vision`/`product-strategy` → `market-existence` (market desirability + viability) (AC: market-existence kind).
+- `grep`/read confirms the prose states `market-existence` is **categorically distinct** from `feature → desirability` and uses a **different token** (the word `desirability` is not reused for the product-level bet) (AC: distinct token).
+- `grep`/read confirms the kind reuses `kill-condition.md`'s pre-PMF qualitative bar and is framed as tested **once at the top** (AC: reuses qualitative bar).
+
+**Approach:**
+- Add the `market-existence` row to the level→kind mapping in `de-risk-intent/SKILL.md` (the `## Skill` intro mapping) and mirror it in `intent-model.md`'s two-consequences section.
+- State the value+viability content and the distinct-token rule in prose; point at the existing qualitative-bar in `kill-condition.md` rather than adding a mechanism.
+
+**Done when:** the `market-existence` row exists with a distinct token, reuses the qualitative bar, and the T4 greps pass.
+
+### T5: Sibling-spawn detector + retroactive-parent affordance
+
+**Depends on:** T1, T2
+
+**Tests:**
+- `grep`/read confirms `frame-intent` / `decompose-intent` carry the **sibling-spawn detector** — trips on the qualitative shippability test (won't reduce to one shippable slice; count is a signal not a threshold) and **offers** to frame the product parent, never blocks (AC: sibling-spawn detector).
+- `grep`/read confirms the **retroactive-parent** affordance with its altitude-inference rule (architectural slices → `capability`; independent value bets → `product-vision`/`product-strategy`), back-linking via `Parent intent:`, naming the inferred altitude as user-correctable (AC: retroactive parent).
+- `grep` confirms `recursive-decomposition.md` reads for any level above the leaf (no two-level ceiling wording) (AC: recursion reads for any level).
+
+**Approach:**
+- Add the offer-not-block sibling-spawn behaviour to `frame-intent/SKILL.md` and `decompose-intent/SKILL.md`, anchored on the existing shippability test.
+- Add the retroactive-parent affordance (reusing the `Parent intent:` field and `decompose-intent`'s upward-feedback edge) with the explicit altitude-inference rule.
+- Generalize any `recursive-decomposition.md` wording that implied a `capability | feature` ceiling.
+
+**Done when:** both behaviours are prompt-only, the recursion reads for the new rungs, and the T5 greps pass.
+
+### T6: Tracker-projection rows for the two rungs
+
+**Depends on:** T1
+
+**Tests:**
+- `grep` confirms `tracker-projection.md`'s profile table gains rows for `product-vision` and `product-strategy`, each mapping to a higher/intervening tier — Jira Align Theme/Strategy tier; Linear → Initiative/label; `none` → markdown — with the existing `top (capability)` and `feature` rows preserved (AC: tracker rows, OQ1 default).
+
+**Approach:**
+- Add the two rows to the profiles table in `decompose-intent/references/tracker-projection.md` per the OQ1 default; keep the one-way / `none`-first-class framing.
+
+**Done when:** the two rows exist at the higher/intervening tier and the T6 grep passes.
+
+### T7: The `init-project` seam — fourth discovery source, by reference
+
+**Depends on:** none
+
+**Tests:**
+- `grep` confirms `core/init-project/SKILL.md` stage 2 names `intent` / `frame-intent` as a **fourth** recognized discovery source alongside `research`, a PRD, and a `receive-brief` brief (AC: seam added).
+- `grep`/read confirms the source is framed as an **optional upstream** ("when the `product-engineering` pack is installed", mirroring the `research`-pack "when installed" framing) so a `core`-only adopter reads it as optional, not a dangling reference (AC: by reference only; design-review R2).
+- `grep`/read confirms `init-project` still imports nothing from `product-engineering` and still performs no discovery (the `:128` anti-pattern and the `:143-146` by-reference rule are intact, the latter naming `frame-intent` only as an upstream discovery shape it receives) (AC: by reference only, no discovery).
+
+**Approach:**
+- In `init-project/SKILL.md` stage 2 (and the matching anti-pattern bullet), add `intent` / `frame-intent` as a fourth recognized fed-in discovery shape, phrased as an optional upstream ("when the `product-engineering` pack is installed"), and document the `frame → de-risk → decompose` → `init-project` hand-off, by reference only.
+
+**Done when:** the fourth source is named by reference, the no-discovery / no-import rules still hold, and the T7 greps pass.
+
+### T8: Guides + READMEs touch-up
+
+**Depends on:** T1-T7
+
+**Tests:**
+- `grep`/read confirms the four `product-engineering` guide pages describe the rungs and the Level-vs-Scale model: `explanation/the-intent-tree.md` (the two altitudes), `reference/intent-fields-and-modes.md` (recognized-set `Level` values + the two field blocks + the `market-existence` kind), `README.md` (overview names the altitudes), `how-to/shape-a-feature-intent.md` (the app-scale-greenfield-can-start-at-a-product-altitude note) (AC: user guides touched up).
+- `grep`/read confirms `packs/product-engineering/README.md` names `product-vision` / `product-strategy` and states `Level` is an open recognized set decoupled from `Scale` — both the "same artifact at different levels" line and the `frame-intent` row updated (AC: pack README updated).
+- `grep`/read confirms the core inception guide(s) name `intent` / `frame-intent` as a fourth `init-project` discovery source, framed as optional upstream — `docs/guides/_shared/how-to/run-a-full-inception.md` and the discovery-source list in `docs/guides/core/tutorials/start-a-new-project.md` (AC: core inception guide names the seam).
+
+**Approach:**
+- Extend the four `product-engineering` guide pages: the explanation with the two altitudes + Level/Scale orthogonality; the reference with the recognized-set values, the two field blocks, and `market-existence`; the index overview and the feature-shaping how-to with the altitude option for greenfield concepts.
+- Update `packs/product-engineering/README.md`'s "same artifact at different levels" line and the `frame-intent` table row.
+- Add the fourth discovery source to the core inception flow guide(s) where the source list / pack composition is taught, by reference and optional.
+- Keep all guide / README prose adopter-clean (no RFC/ADR/backlog citation).
+
+**Done when:** all four guide pages, the pack README, and the core inception guide(s) describe the rungs / the seam, and the T8 checks pass. (The pack README re-projects via `make build` in T9; guides and the pack README are repo-owned — no `build-self`.)
+
+### T9: Version bumps, projection refresh, changelog
+
+**Depends on:** T1-T8
+
+**Tests:**
+- `grep`/build confirms `product-engineering` `pack.toml` `[pack].version` and `.claude-plugin/plugin.json` `version` are bumped `0.5.1 → 0.6.0` in lockstep and `marketplace.json` re-aggregates the new version drift-clean (AC: version bump). `product-engineering` is **not** self-host-projected — there is no `.claude/skills/frame-intent` projection; the only drift target is `marketplace.json` via `make build`.
+- `make build-self` refreshes the projected `.claude/skills/init-project/SKILL.md` for the `core` seam and bump; `git status` shows only the expected drift (AC: version bump / projection — core is projected).
+- `grep` confirms the `[Unreleased] → Added` changelog entry exists (AC: changelog).
+
+**Approach:**
+- Bump `packs/product-engineering/pack.toml` + `.claude-plugin/plugin.json` to `0.6.0`; bump `packs/core/pack.toml` + `plugin.json` (patch/minor) for the seam; run `make build` (re-aggregate `marketplace.json`) and `make build-self` (refresh the projected `init-project`); confirm drift is only the expected version lines + the projected seam.
+- Add the `[Unreleased] → Added` entry to `docs/product/changelog.md`, written for users.
+
+**Done when:** both packs are bumped, `marketplace.json` and the `core` projection are drift-clean, and the changelog carries the entry.
+
+### T10: Dogfood the rungs end-to-end
+
+**Depends on:** T7, T9
+
+**Tests:**
+- Manual QA: run `frame-intent` on a greenfield product concept — record that it **offers `product-vision`** (not a silent `feature` stamp) and asks the altitude.
+- Manual QA: run `de-risk-intent` on the resulting `product-vision` intent — record that it picks **`market-existence`** and reuses the qualitative bar.
+- Manual QA: drive a concept that won't reduce to one slice — record that the sibling-spawn detector **offers** the product parent rather than emitting orphaned siblings.
+
+**Approach:**
+- Exercise the built skills the way a user would; capture the observed behaviour (what altitude was offered, what de-risk kind, the sibling-spawn offer) in the PR description.
+
+**Done when:** all three runs are recorded and show the rungs route correctly.
+
+## Rollout
+
+Pure skill-prose / template / reference change. **Delivery:** ships with the next `product-engineering` release (`0.6.0`, T9) and the next `core` release (the seam bump); reversible by reverting the prose edits and the version bumps. No infrastructure, no external-system integration. **Deployment sequencing:** the model edits (T1–T4) land before the behaviours that sit on them (T5), and the version bump / projection refresh (T9) lands after all content edits so `build-self` and `marketplace.json` re-aggregation see the final tree. **Irreversible:** none — the migration is empty and additive (existing intents stay valid). Adopters pick up the new rungs on pack upgrade.
+
+## Risks
+
+- **Field-set prose drifts toward a schema or PM ceremony.** Mitigation: the prompt-sheet altitude and "apply what bites / an empty heading is a prompt" posture are spec Boundaries; the adversarial + quality reviewer passes check it.
+- **An internal-governance citation leaks into shipped `.apm/**`.** Mitigation: the adopter-clean cross-cutting grep (a Construction test) and the `Never do` boundary; provenance lives in the spec/ADR only.
+- **The two rungs blur** (users fill vision and strategy with the same content). Mitigation: distinct field sets + a one-line "vision = why it should exist; strategy = the path" cue; the open field lets a user collapse to one rung.
+- **The no-engine-change assumption is wrong.** Mitigation: the RFC spike confirmed it against the shipped pack; T1 re-confirms the recursion needs no change before any behaviour is built on it.
+- **The `core` seam reads as a dangling reference** to a pack a pure-engineering adopter never installs. Mitigation: it is named as an *optional upstream discovery shape*, by reference, consistent with `init-project`'s existing optional-source framing (`research` pack "when installed").
+
+## Changelog
+
+- 2026-06-23: initial plan (governance PR — ADR-0033 + this spec/plan). Implementation deferred to a separate PR; this plan describes that implementing PR.

--- a/docs/specs/product-rung/spec.md
+++ b/docs/specs/product-rung/spec.md
@@ -1,0 +1,92 @@
+# Spec: product-rung
+
+- **Status:** Draft <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** ADR-0033, RFC-0043 (D1–D6 + open-question defaults OQ1/OQ2; OQ3 deferred to post-ship review, not settled here); ADR-0019 (the recursive level-tagged `intent` ontology this refines — its part 1 `Level` enum only; parts 2–3 are preserved and out of scope); RFC-0030 (the `product-engineering` pack's founding RFC)
+- **Contract:** none <!-- prompt-only markdown skill content; no API/event/RPC surface -->
+- **Shape:** n/a — skill prose + template/reference authoring across the three `product-engineering` skills plus one `core` `init-project` seam; no application LLD
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+A user shaping a **greenfield product concept** (or a multi-feature bet) with the `product-engineering` pack can frame it at a **product altitude** — `product-vision` (the existence bet: why this product should exist, for whom, through what wedge) or `product-strategy` (the path: the central challenge, guiding policy, coherent actions, and problem/segment sequence) — instead of being coerced to a `feature` intent by the old Scale→Level stamp. `Level` is an **open** field carrying a **recognized set** (`product-vision` › `product-strategy` › `capability` › `feature`); `Scale` *suggests* a starting altitude but never silently stamps one, and keeps its load-bearing leaf-projection role. Either rung is authorable directly; **skipping is allowed but observable** — a sibling-spawn detector offers to frame the product parent when a concept won't reduce to one shippable slice, and a retroactive-parent affordance back-links orphaned siblings at an inferred altitude. The product-existence bet is de-risked **once at the top** as `market-existence` (market desirability + viability), a kind categorically distinct from feature-level `desirability`. The greenfield product loop connects to core's `init-project` as a recognized discovery source. Everything is **prompt-only**: no engine, hook, new skill, or new artifact type.
+
+## Boundaries
+
+The three-tier guard that keeps an implementing agent inside the lines.
+*Always do* applies without asking; *Ask first* requires human sign-off
+before proceeding; *Never do* is a hard rule, even under time pressure.
+
+### Always do
+
+- Keep every change **prompt-only** — enum widening, prompt edits, two seeded level-conditional field blocks, one de-risk-kind row, tracker-projection rows, and one by-reference seam doc. No engine, hook, new skill, or new artifact type.
+- Keep `Level` **open-valued**; document the recognized set `product-vision › product-strategy › capability › feature` as the seeded/prompted altitudes, not a closed enum.
+- Preserve `Scale`'s **leaf-projection** role unchanged (`app` → a same-repo `core` brief; `business-unit` → per-component slices); only the Scale→Level **stamp** becomes a suggested starting altitude.
+- Give the product-existence bet a **distinct de-risk token** (`market-existence`); never reuse the word `desirability`. Reuse the existing pre-PMF qualitative-bar in `kill-condition.md` — add no new de-risk mechanism.
+- Make either rung **authorable directly** and skipping **safe-but-observable** — the sibling-spawn detector *offers*, never blocks; the retroactive parent's altitude is *inferred and confirmable*, never assumed.
+- Bump `product-engineering` `0.5.1 → 0.6.0` (`pack.toml` + `.claude-plugin/plugin.json`) and re-aggregate `marketplace.json`; bump `core` (patch/minor) for the seam and run `make build-self` (the `core` `init-project` skill **is** self-host-projected).
+- Add a `[Unreleased] → Added` changelog entry (`docs/product/changelog.md`) in the implementing PR.
+
+### Ask first
+
+- Any change to `Scale`'s leaf-projection role, or to `receive-brief`'s level-agnostic contract / the brief's no-`level:`-field shape (these are ADR-0019 part 2 — preserved and out of scope to redesign).
+- Renaming either rung away from `product-vision` / `product-strategy` (the RFC-0043-Accepted tokens).
+- Mandating either rung, or turning the sibling-spawn detector into a gate rather than an offer.
+
+### Never do
+
+- Cite `RFC-0043`, any ADR/RFC number, `docs/rfc/…` paths, or a `docs/backlog.md` anchor in any **shipped `.apm/**`** content (the seeded field sets, prompts, references) — the `AGENTS.local.md` adopter-clean rule. Provenance lives in this spec and ADR-0033, never in shipped prose.
+- Edit the **immutable** ADR-0019 body or the **frozen** RFC-0043 body.
+- Import `product-engineering` code into core's `init-project` — the seam is **by reference only**, and `init-project` still performs no discovery itself.
+- Ship a new artifact type (`vision.md` / `strategy.md`), a fixed N-deep `Level` ladder, write-time hooks, or a heavyweight fixed-type ontology.
+
+## Testing Strategy
+
+This is a skill-prose / template / reference change; verification is **goal-based** and **manual QA**, with no TDD-mode logic:
+
+- **Enum widening, recognized-set doc, Scale→Level suggestion, leaf-projection preserved, both field blocks present + level-conditional, `market-existence` row, tracker rows, the `init-project` seam, version bump, changelog, guide touch-up, adopter-clean** — *goal-based*: a `grep` / `diff` / build one-liner verifies each outcome. (The adopter-clean grep and the both-blocks-present check are cross-cutting — see `plan.md` Construction tests.)
+- **The rungs route correctly end-to-end** — *manual QA, exercised end-to-end*: run `frame-intent` on a greenfield product concept and confirm it **offers `product-vision`** (not a silent `feature` stamp); run `de-risk-intent` on a `product-vision` intent and confirm it picks **`market-existence`** (not `desirability`); drive the sibling-spawn path and confirm it **offers** the product parent rather than emitting orphaned siblings. A passing grep alone does not satisfy this — the built skills, run as a user would, must produce the right behaviour.
+
+## Acceptance Criteria
+
+- [ ] **`Level` is open with a recognized set.** `intent-model.md` and `intent-template.md` document the recognized set `product-vision › product-strategy › capability › feature` and state the field stays **open-valued** (an adopter may name an intervening altitude); the `intent-template.md:11` `Level:` comment is widened from `<capability | feature>` to show the recognized set without closing it.
+- [ ] **The two rungs are the same recursive `intent` at a higher `Level`** — no new artifact type, file layout, discovery wiring, or hook is introduced; the `intent` template, recursion, de-risk loop, and decomposition boundary are reused unchanged in shape.
+- [ ] **`product-vision` and `product-strategy` semantics are documented.** `intent-model.md` (and the guide, per the guide AC) state that `product-vision` is the *existence bet* (why this product should exist, for whom, through what wedge) and `product-strategy` is the *path* (central challenge, guiding policy, coherent actions, problem/segment sequence), with vision sitting above strategy and both above `capability`.
+- [ ] **The Scale→Level stamp becomes a suggestion.** `scale-intake.md`'s "default level" role and `frame-intent` SKILL.md step 3 no longer hard-stamp / hard-nudge an altitude from Scale; they offer a *suggested starting altitude* (`app` greenfield concept → `product-vision`; `app` known feature → `feature`; `business-unit` → `product-strategy` or `capability`) that the user overrides in one word.
+- [ ] **`Scale`'s leaf-projection role is preserved unchanged.** `scale-intake.md`'s leaf-projection sentence and the intake table's "Leaf lands as" column still map `app` → a same-repo `core` brief and `business-unit` → per-component slices; no edit weakens or removes this.
+- [ ] **`frame-intent` asks the altitude explicitly for concept-shaped / greenfield input** rather than defaulting to `feature`; for a clearly-scoped feature it still proceeds at `feature` without ceremony.
+- [ ] **The `product-vision` field block is seeded** (level-conditional, filled only at that rung) in `intent-template.md`: customer-shaped pitch · the change (what's different for the customer) · the job + struggling moment · who, by circumstance (early adopter, not demographic) · existing alternatives (what they do today, badly) · narrowest wedge (smallest version someone pays for now) · demand evidence (behaviour/payment, not stated interest) · open assumptions tiered (`must-test-before-shipping` / `accept-as-bet` / `will-monitor-post-ship`) · counter-metrics.
+- [ ] **The `product-strategy` field block is seeded** (level-conditional): central challenge (diagnosis) · guiding policy · coherent actions (3–5) · problem/segment sequence (which, in what order, why now) · horizon.
+- [ ] **The field blocks are prose / short-field and live in the single `intent-template.md` markdown file** — no new per-rung template, layout, or schema; an empty heading remains a prompt, not an error (the pack's template-not-schema posture holds).
+- [ ] **`market-existence` is added as a distinct de-risk kind.** `de-risk-intent` SKILL.md and `intent-model.md`'s level→kind mapping gain a row: `product-vision` / `product-strategy` → `market-existence`. The seeded gloss **names both halves explicitly** — will-anyone-want-this-at-all (market desirability) **and** can-this-be-a-business (viability) — so the Cagan/SVPG viability gap is visibly closed, not just the token renamed. The prose states it is **categorically distinct** from `feature → desirability`, and the two kinds carry **different tokens** (the word `desirability` is not reused for the product-level bet).
+- [ ] **`market-existence` reuses the existing pre-PMF qualitative-bar** in `kill-condition.md` (no new de-risk mechanism), and the bet is named as tested **once at the top**, not re-litigated per sibling feature.
+- [ ] **The sibling-spawn detector is added** to `frame-intent` / `decompose-intent` as prompt-only behaviour: it trips on the **qualitative shippability test** (the intent won't reduce to a single shippable slice — the sibling *count* is a signal, not a fixed threshold) and **offers** to frame the product parent instead of silently emitting orphaned siblings. It offers, never blocks.
+- [ ] **The retroactive-parent affordance is added** with an **altitude-inference rule**: when a rung was skipped and multiple intents already exist, the agent reconstructs a parent and back-links the siblings via the existing `Parent intent:` field (`intent-template.md:14`), inferring the altitude (**architectural slices of one buildable thing → `capability`**; **independent value bets that together constitute one product → `product-vision` / `product-strategy`**), naming the inferred altitude and letting the user correct it.
+- [ ] **`recursive-decomposition.md` reads for any level above the leaf** — the existing "Above feature level → produce child intents at the next lower `Level:`" rule is confirmed to already cover the new rungs (no engine or recursion change); any wording that implied a two-level `capability | feature` ceiling is generalized.
+- [ ] **`tracker-projection.md` gains rows for the two rungs** (OQ1 default): both map to a higher/intervening tier — Jira Align Theme/Strategy tier; Linear → Initiative / label; `none` → markdown (unchanged) — with the existing `top (capability)` and `feature` rows preserved.
+- [ ] **The `init-project` seam is added, by reference only.** Core's `init-project` stage 2 ("value gate") names `intent` / `frame-intent` as a **fourth** recognized discovery source alongside `research`, a PRD, and a `receive-brief` brief, and documents that `frame → de-risk → decompose` hands its leaf into `init-project`. The seam names it as an **optional upstream** — phrased "when the `product-engineering` pack is installed", mirroring `init-project`'s existing `research`-pack "when installed" framing — so a `core`-only adopter reads it as a clearly-optional source, not a dangling cross-reference. `init-project` **imports nothing** from `product-engineering` and **still performs no discovery itself** (the anti-pattern at `init-project/SKILL.md:128` and the by-reference rule at `:143-146` both hold).
+- [ ] **Migration is empty and additive.** Existing `capability` / `feature` intents stay valid (the recognized set is a superset); no data migration is needed; the only schema-shaped change is the widened `Level:` comment.
+- [ ] **Versions are bumped and projections refreshed.** `product-engineering` `pack.toml` `[pack].version` + `.claude-plugin/plugin.json` `version` go `0.5.1 → 0.6.0` in lockstep and `marketplace.json` re-aggregates drift-clean (this pack is **not** self-host-projected — no `.claude/skills/` copy); `core` is bumped (patch/minor) for the seam and `make build-self` refreshes the projected `.claude/skills/init-project/SKILL.md`; `git status` shows only the expected drift.
+- [ ] **A `[Unreleased] → Added` changelog entry** is added in the implementing PR (`docs/product/changelog.md`), written for users (the new product altitudes; Level decoupled from Scale).
+- [ ] **The `product-engineering` user guides are touched up** to describe the two rungs and the Level-vs-Scale model, across every page that currently encodes the two-level `capability | feature` model or the `app → feature` stamp:
+  - explanation `the-intent-tree.md` — the two product altitudes (`product-vision`, `product-strategy`) and why one recursive shape still covers them;
+  - reference `intent-fields-and-modes.md` — the recognized-set `Level` values, the two seeded field blocks, and the `market-existence` de-risk kind;
+  - the guides index `README.md` — the overview names the product altitudes alongside capability/feature (not just "a strategy, an epic, and a feature");
+  - how-to `shape-a-feature-intent.md` — a note that an app-scale **greenfield concept** can start at a product altitude (`Level` is no longer stamped from `Scale`), not only at `feature`.
+- [ ] **The `product-engineering` pack README is updated** (`packs/product-engineering/README.md`) — the "same artifact at different levels" line and the `frame-intent` table row name the product altitudes (`product-vision` / `product-strategy`) and state that `Level` is an open recognized set **decoupled from `Scale`**. Repo-owned source; it ships via `make build` (no `build-self` — `product-engineering` is not self-host-projected).
+- [ ] **The core inception guide names the seam** — wherever the `init-project` discovery sources or the cross-pack inception flow are taught (`docs/guides/_shared/how-to/run-a-full-inception.md`, where `product-engineering` already sits around the `core` spine; and the discovery-source list in `docs/guides/core/tutorials/start-a-new-project.md`), `intent` / `frame-intent` is named as a fourth discovery source feeding `init-project`, framed as optional upstream.
+- [ ] **Shipped content is adopter-clean.** No shipped file touched by this change — anything under `packs/product-engineering/.apm/**`, `packs/core/.apm/**`, or `packs/product-engineering/README.md` (the pack README ships to adopters via `make build`) — cites `RFC-0043`, any ADR/RFC number, a `docs/rfc/…` path, or a `docs/backlog.md` anchor; provenance lives in this spec and ADR-0033. (The repo-owned `docs/guides/**` pages are *not* shipped to adopters and are exempt — cross-cutting grep, see `plan.md`.)
+
+## Assumptions
+
+- Technical: `Level` is hardcoded `<capability | feature>` at `intent-template.md:11`; `intent-model.md` defines only `capability` (architectural span) and `feature` (desirability) kinds; the recursion ("Above feature level → produce child intents at the next lower `Level:`", `recursive-decomposition.md:14`) already supports N levels above feature with **no engine change** (source: reads of the three files, probe 2026-06-23 — RFC-0043 spike re-verified).
+- Technical: `Scale` has two roles in `scale-intake.md:29-30` — the default Level (which becomes a suggestion) and the `app`-brief / `business-unit`-slice leaf-projection (which is preserved); only the first changes (source: `scale-intake.md`, probe 2026-06-23).
+- Technical: `kill-condition.md:16-19` carries a pre-PMF / 0-to-1 **qualitative-bar** mode that fits the `market-existence` currency, so no new de-risk mechanism is needed (source: `kill-condition.md`, probe 2026-06-23).
+- Technical: `product-engineering` is **not** part of this repo's self-host projection (no `.claude/skills/frame-intent` etc.), so its version bump drifts only `marketplace.json` via `make build`; `core`'s `init-project` **is** projected (`.claude/skills/init-project/SKILL.md`), so the seam edit needs `make build-self` (source: `ls .claude/skills`, probe 2026-06-23; memory: self-host pack scope).
+- Process: implementation lands in a **separate** PR; this spec + ADR-0033 + `plan.md` are the **governance deliverable**, and the spec stays `Draft` until that implementing PR flips it (source: RFC-0043 § Follow-on artifacts; the RFC-0042 → ADR-0032 + `agentic-well-architected-overlay` precedent).
+- Process: ADR-0019 is **refined, not superseded** — only its part 1 `Level` enum is reopened/decoupled; parts 2 (brief = feature-intent projection) and 3 (staged contracts) stand, and ADR-0019 stays Accepted (source: RFC-0043 Related line + the immutable-ADR convention, `CONVENTIONS.md`).
+- Process: shipped `.apm/**` content carries no internal-governance citations (RFC/ADR numbers, `docs/rfc/…` paths, backlog anchors) (source: `AGENTS.local.md` § Shipped pack content carries no internal-governance citations).
+- Product: RFC-0043's open questions are settled to their RFC-recommended defaults — OQ1 tracker rows → higher/intervening tier; OQ2 `product-strategy` available at any Scale, mandatory at none; OQ3 adopter demand beyond n=1 → watch post-ship feedback (source: RFC-0043 § Open questions defaults, decide-by "spec").


### PR DESCRIPTION
## What

The follow-on governance artifacts RFC-0043 (Accepted) calls for, mirroring the RFC-0042 → ADR-0032 + spec/plan precedent. **Governance only** — the skill edits, version bumps, guides, and pack README land in a separate implementing PR; the spec stays `Draft` until then.

- **`docs/adr/0033-…`** (Accepted) — records the load-bearing, expensive-to-reverse calls: two product rungs (`product-vision` › `product-strategy`) as the *same recursive `intent`* (not a new type); `Level` reopened to an open recognized set; `Level` decoupled from `Scale` (stamp → suggestion, leaf-projection preserved); the distinct `market-existence` de-risk kind; the by-reference `init-project` seam.
- **`docs/adr/0019-…`** — `Refined by: ADR-0033` metadata back-pointer (body untouched; stays Accepted).
- **`docs/specs/product-rung/{spec,plan}.md`** — 23 checkable ACs across D1–D6 + OQ defaults; a 10-task implementing plan. Doc-surface ACs cover the four `product-engineering` guides, the pack README, and the core inception guide, with the repo-owned-vs-shipped projection distinction made explicit.

## How it was verified

- `lint-spec-status.py` clean; loop-cohort plan approved (full mode).
- Spec-stage **adversarial-reviewer** + **design-reviewer** (verdict SHIP WITH CHANGES, **no blockers**); all 8 findings applied in-PR. Review summary at `docs/specs/product-rung/notes/spec-stage-review.md`.
- `security-reviewer` / `quality-engineer` not warranted — prompt-only governance docs, no security boundary or code diff.

## Decision to confirm

ADR-0033 is set **Accepted** (matching the Accepted RFC and the ADR-0032 precedent, single owner/approver). Flip to `Proposed` if you'd rather gate it behind an explicit sign-off step.

## Notes

- Implementation is a deliberate follow-up PR (skill edits across `product-engineering` + the `core` seam, version bumps, guides, pack README). The plan describes that PR.