### PR TITLE
feat(agentbundle): terminal-aware word-wrap for list-packs / list-profiles tables

### DIFF
--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -8,6 +8,18 @@ the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 
 ## [Unreleased]
 
+### Changed
+
+- **`agentbundle list-packs` and `list-profiles` word-wrap the DESCRIPTION
+  column to fit the terminal.** On an interactive terminal whose width the
+  table would overflow, the long description column wraps to the leftover
+  width — every physical line stays within the terminal, continuation lines
+  align under the column, and the columns that follow it (DEPENDENCIES) stay on
+  the row's first line. When stdout is **not** a terminal (piped or
+  redirected), output is unchanged: full content-width columns, untruncated, so
+  `grep`/`awk`/`cut` still see stable columns — the convention `gh`, `git`, and
+  `ls` follow. Both commands now share one terminal-aware table renderer.
+
 ## [0.7.0] — 2026-06-24
 
 ### Changed

--- a/packages/agentbundle/agentbundle/commands/_common.py
+++ b/packages/agentbundle/agentbundle/commands/_common.py
@@ -291,3 +291,100 @@ def confirm_or_refuse(
         print(abort_message, file=sys.stderr)
         return False
     return True
+
+
+# ---------------------------------------------------------------------------
+# Terminal-aware table rendering (shared by `list-packs`, `list-profiles`)
+# ---------------------------------------------------------------------------
+
+# Floor for the wrapped column so a very narrow terminal still gets a readable
+# (if tall) cell rather than one-character-per-line. Below this we let the row
+# overflow the terminal rather than shred the text.
+_MIN_WRAP_WIDTH = 20
+
+# Spaces between columns.
+_COL_GAP = 2
+
+
+def _stream_is_tty(stream: Any) -> bool:
+    """True only when *stream* is a real interactive terminal.
+
+    A closed or non-tty stream (pytest's capture, a pipe, a file) answers
+    False — and may raise ``ValueError`` on a closed file — so we swallow both.
+    """
+    try:
+        return bool(stream.isatty())
+    except (AttributeError, ValueError):
+        return False
+
+
+def render_table(
+    headers: list[str],
+    rows: list[list[str]],
+    *,
+    wrap_col: int | None = None,
+    stream: Any = None,
+) -> None:
+    """Print a left-justified, content-sized column table to *stream*.
+
+    Columns are sized to the widest of their header and cells. When *wrap_col*
+    is given **and** the destination is an interactive terminal **and** the
+    natural table would overflow that terminal's width, that one column is
+    word-wrapped to the leftover width; every other column keeps its content
+    width, the row spans as many physical lines as the wrap needs, and the
+    columns that follow the wrapped one appear on the row's first line only.
+
+    Wrapping is deliberately suppressed when stdout is **not** a TTY (piped or
+    redirected): the table is emitted at full content width, untruncated, so
+    downstream tools (`grep`, `awk`, `cut`) see stable, parseable columns — the
+    convention `gh`, `git`, and `ls` follow. It is likewise suppressed when the
+    natural table already fits, leaving that output byte-identical to a plain
+    content-width table.
+
+    ``stream`` defaults to ``sys.stdout`` (read at call time, not import time,
+    so a window resize between invocations is honoured).
+    """
+    import shutil
+    import textwrap
+
+    if stream is None:
+        stream = sys.stdout
+
+    ncols = len(headers)
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for i in range(ncols):
+            widths[i] = max(widths[i], len(row[i]))
+
+    # Decide the wrapped column's width, if any.
+    wrap_width: int | None = None
+    if wrap_col is not None and _stream_is_tty(stream):
+        term_cols = shutil.get_terminal_size(fallback=(80, 24)).columns
+        natural = sum(widths) + _COL_GAP * (ncols - 1)
+        if natural > term_cols:
+            others = natural - widths[wrap_col]
+            wrap_width = max(_MIN_WRAP_WIDTH, term_cols - others)
+            widths[wrap_col] = wrap_width
+
+    gap = " " * _COL_GAP
+
+    def emit(cells: list[str]) -> None:
+        if wrap_width is None:
+            line = gap.join(cells[i].ljust(widths[i]) for i in range(ncols))
+            print(line.rstrip(), file=stream)
+            return
+        chunks = textwrap.wrap(cells[wrap_col], width=wrap_width) or [""]
+        for li, chunk in enumerate(chunks):
+            parts = [
+                (chunk if i == wrap_col else (cells[i] if li == 0 else "")).ljust(
+                    widths[i]
+                )
+                for i in range(ncols)
+            ]
+            print(gap.join(parts).rstrip(), file=stream)
+
+    emit(headers)
+    # Separator built directly so a long dash run is never word-wrapped.
+    print(gap.join("-" * widths[i] for i in range(ncols)).rstrip(), file=stream)
+    for row in rows:
+        emit(row)

--- a/packages/agentbundle/agentbundle/commands/list_packs.py
+++ b/packages/agentbundle/agentbundle/commands/list_packs.py
@@ -151,36 +151,24 @@ def _extract_row(toml: dict) -> dict:
 
 
 def _print_table(rows: list[dict]) -> None:
-    """Print a fixed-column table to stdout.
+    """Print the pack table to stdout.
 
-    Columns: name, version, description, dependencies.
-    Output is deterministic: rows are already sorted by caller; column
-    widths are derived from content so the table is alignment-stable.
+    Columns: name, version, description, dependencies. Rows arrive sorted from
+    the caller; column widths are content-derived so the table is
+    alignment-stable. The long DESCRIPTION column word-wraps to fit an
+    interactive terminal — see ``_common.render_table`` for the TTY / non-TTY
+    contract.
     """
-    headers = ["NAME", "VERSION", "DESCRIPTION", "DEPENDENCIES"]
+    from agentbundle.commands._common import render_table
 
-    # Convert deps list to a display string.
-    display_rows = [
-        {
-            "name": r["name"],
-            "version": r["version"],
-            "description": r["description"],
-            "dependencies": ", ".join(r["dependencies"]) if r["dependencies"] else "-",
-        }
+    headers = ["NAME", "VERSION", "DESCRIPTION", "DEPENDENCIES"]
+    table_rows = [
+        [
+            r["name"],
+            r["version"],
+            r["description"],
+            ", ".join(r["dependencies"]) if r["dependencies"] else "-",
+        ]
         for r in rows
     ]
-
-    # Compute column widths.
-    col_keys = ["name", "version", "description", "dependencies"]
-    widths = [len(h) for h in headers]
-    for row in display_rows:
-        for i, key in enumerate(col_keys):
-            widths[i] = max(widths[i], len(row[key]))
-
-    # Format string: left-justify each column.
-    fmt = "  ".join(f"{{:<{w}}}" for w in widths)
-
-    print(fmt.format(*headers))
-    print(fmt.format(*("-" * w for w in widths)))
-    for row in display_rows:
-        print(fmt.format(*(row[k] for k in col_keys)))
+    render_table(headers, table_rows, wrap_col=2)

--- a/packages/agentbundle/agentbundle/commands/list_profiles.py
+++ b/packages/agentbundle/agentbundle/commands/list_profiles.py
@@ -43,21 +43,15 @@ def run(args: "argparse.Namespace") -> int:
 
 
 def _print_table(profiles) -> None:
-    """Print a fixed-column table to stdout: ID, SCOPE, DESCRIPTION.
+    """Print the profile table to stdout: ID, SCOPE, DESCRIPTION.
 
     Deterministic: ``list_profiles`` returns id-sorted rows; column widths are
-    derived from content so the table is alignment-stable.
+    content-derived so the table is alignment-stable. The long DESCRIPTION
+    column word-wraps to fit an interactive terminal — see
+    ``_common.render_table`` for the TTY / non-TTY contract.
     """
+    from agentbundle.commands._common import render_table
+
     headers = ["ID", "SCOPE", "DESCRIPTION"]
-    rows = [(p.id, p.scope, p.description) for p in profiles]
-
-    widths = [len(h) for h in headers]
-    for row in rows:
-        for i, cell in enumerate(row):
-            widths[i] = max(widths[i], len(cell))
-
-    fmt = "  ".join(f"{{:<{w}}}" for w in widths)
-    print(fmt.format(*headers))
-    print(fmt.format(*("-" * w for w in widths)))
-    for row in rows:
-        print(fmt.format(*row))
+    rows = [[p.id, p.scope, p.description] for p in profiles]
+    render_table(headers, rows, wrap_col=2)

--- a/packages/agentbundle/tests/unit/test_render_table.py
+++ b/packages/agentbundle/tests/unit/test_render_table.py
@@ -1,0 +1,162 @@
+"""Unit tests for `commands/_common.render_table`.
+
+The shared terminal-aware table printer behind `list-packs` / `list-profiles`.
+Pins the width contract: non-TTY emits full-width untruncated columns (so piped
+output stays grep/awk-stable); an interactive TTY whose width the natural table
+would overflow word-wraps the flex column, keeping every physical line within
+the terminal and aligning continuation lines under that column; a TTY wide
+enough leaves the table unwrapped.
+"""
+
+from __future__ import annotations
+
+import io
+
+from agentbundle.commands._common import _MIN_WRAP_WIDTH, render_table
+
+HEADERS = ["NAME", "VERSION", "DESCRIPTION", "DEPS"]
+LONG = "Core agent-ready-repo: work-loop, new-spec and bug-fix skills for agents."
+ROWS = [
+    ["core", "0.4.14", LONG, "-"],
+    ["research", "0.3.0", "Evidence-grounded research portable across every repo.", "core@^0.1"],
+]
+
+
+class _FakeTTY(io.StringIO):
+    """A StringIO that claims to be an interactive terminal."""
+
+    def isatty(self) -> bool:  # noqa: D401 - trivial
+        return True
+
+
+def _set_width(monkeypatch, cols: int) -> None:
+    import os
+    import shutil
+
+    monkeypatch.setattr(
+        shutil, "get_terminal_size", lambda fallback=(80, 24): os.terminal_size((cols, 24))
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Non-TTY → full content width, never wrapped, never truncated
+# ---------------------------------------------------------------------------
+
+def test_non_tty_emits_full_width_untruncated(monkeypatch):
+    # Even a tiny "terminal" is irrelevant when the stream is not a TTY.
+    _set_width(monkeypatch, 40)
+    buf = io.StringIO()  # plain StringIO → isatty() is False
+    render_table(HEADERS, ROWS, wrap_col=2, stream=buf)
+    out = buf.getvalue()
+    # The long description appears intact on a single line — no wrap, no ellipsis.
+    assert LONG in out
+    assert all(len(line) == 0 or "  " in line for line in out.splitlines())
+
+
+def test_non_tty_has_no_trailing_whitespace(monkeypatch):
+    _set_width(monkeypatch, 40)
+    buf = io.StringIO()
+    render_table(HEADERS, ROWS, wrap_col=2, stream=buf)
+    for line in buf.getvalue().splitlines():
+        assert line == line.rstrip(), "rows must not carry trailing whitespace"
+
+
+# ---------------------------------------------------------------------------
+# 2. TTY narrow → wrap the flex column, every line fits
+# ---------------------------------------------------------------------------
+
+def test_tty_narrow_wraps_within_width(monkeypatch):
+    _set_width(monkeypatch, 80)
+    buf = _FakeTTY()
+    render_table(HEADERS, ROWS, wrap_col=2, stream=buf)
+    lines = buf.getvalue().splitlines()
+    assert all(len(line) <= 80 for line in lines), "no physical line may exceed the terminal"
+    # The description wrapped — its text spans more than one physical line.
+    assert len(lines) > 1 + 1 + len(ROWS), "wrapping should add continuation lines"
+
+
+def test_tty_continuation_lines_align_under_flex_column(monkeypatch):
+    _set_width(monkeypatch, 80)
+    buf = _FakeTTY()
+    render_table(HEADERS, ROWS, wrap_col=2, stream=buf)
+    lines = buf.getvalue().splitlines()
+    # Column start of DESCRIPTION = len("NAME"/"core" widths) deduced from header.
+    header = lines[0]
+    desc_start = header.index("DESCRIPTION")
+    # A continuation line is one whose leading run is all spaces up to desc_start.
+    cont = [line for line in lines if line[:desc_start].strip() == "" and line.strip()]
+    assert cont, "expected at least one indented continuation line"
+    for line in cont:
+        assert line[:desc_start] == " " * desc_start
+
+
+def test_tty_following_column_only_on_first_line(monkeypatch):
+    _set_width(monkeypatch, 80)
+    buf = _FakeTTY()
+    render_table(HEADERS, ROWS, wrap_col=2, stream=buf)
+    out = buf.getvalue()
+    # The dependency token sits on a first row line, never repeated on a
+    # wrapped continuation line.
+    assert out.count("core@^0.1") == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. TTY wide enough → no wrapping (byte-identical to the simple table)
+# ---------------------------------------------------------------------------
+
+def test_tty_wide_does_not_wrap(monkeypatch):
+    _set_width(monkeypatch, 200)
+    tty = _FakeTTY()
+    render_table(HEADERS, ROWS, wrap_col=2, stream=tty)
+
+    plain = io.StringIO()
+    render_table(HEADERS, ROWS, wrap_col=2, stream=plain)
+    assert tty.getvalue() == plain.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# 4. Degenerate width → clamp to the floor, do not shred to one char per line
+# ---------------------------------------------------------------------------
+
+def test_tty_tiny_width_clamps_to_floor(monkeypatch):
+    import textwrap
+
+    _set_width(monkeypatch, 10)  # below the floor → must clamp to _MIN_WRAP_WIDTH
+    buf = _FakeTTY()
+    render_table(HEADERS, ROWS, wrap_col=2, stream=buf)
+    lines = [line for line in buf.getvalue().splitlines() if line.strip()]
+
+    # The description column must have been clamped to the floor, not collapsed
+    # toward the 10-col terminal. On a continuation line (NAME/VERSION blank) the
+    # wrapped chunk stands alone, so its width is the chunk width — the widest
+    # must equal the widest chunk textwrap produces at the floor width.
+    desc_start = lines[0].index("DESCRIPTION")
+    cont = [line for line in lines if line[:desc_start].strip() == "" and line.strip()]
+    cont_widths = [len(line.strip()) for line in cont]
+    expected_max = max(len(chunk) for chunk in textwrap.wrap(LONG, _MIN_WRAP_WIDTH))
+    assert max(cont_widths) == expected_max
+    assert expected_max <= _MIN_WRAP_WIDTH
+
+
+# ---------------------------------------------------------------------------
+# 5. wrap_col=None → no wrapping even on a narrow TTY
+# ---------------------------------------------------------------------------
+
+def test_no_wrap_col_never_wraps(monkeypatch):
+    _set_width(monkeypatch, 40)
+    buf = _FakeTTY()
+    render_table(HEADERS, ROWS, wrap_col=None, stream=buf)
+    assert LONG in buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# 6. Empty body → header + separator only, no crash
+# ---------------------------------------------------------------------------
+
+def test_empty_rows_prints_header_and_separator():
+    buf = io.StringIO()
+    render_table(HEADERS, [], wrap_col=2, stream=buf)
+    lines = buf.getvalue().splitlines()
+    assert lines[0].startswith("NAME")
+    assert set(lines[1].replace(" ", "")) == {"-"}
+    assert len(lines) == 2


### PR DESCRIPTION
## What

`agentbundle list-packs` and `list-profiles` sized their `DESCRIPTION` column purely from content width, so long descriptions (up to ~689 chars in this catalogue) blew past the terminal and wrapped raggedly at the terminal boundary.

This adds a shared, terminal-aware `render_table` helper in `commands/_common.py` (stdlib only, lazily imported) and routes both commands through it.

## Behaviour

- **Interactive terminal that would overflow** → the long column word-wraps to the leftover width (clamped to a 20-col floor). Every physical line stays within the terminal, continuation lines align under the column, and the columns that follow it (e.g. `DEPENDENCIES`) stay on the row's first line.
- **Piped / redirected (non-TTY)** → output is unchanged: full content-width columns, untruncated, so `grep`/`awk`/`cut` still see stable columns. This is the convention `gh`, `git`, and `ls` follow — adapt to width only for a human at a terminal, stay machine-parseable otherwise.
- **Terminal wide enough** → no wrapping; byte-identical to the previous plain table (modulo trailing-whitespace stripping).

## Research basis

Surveyed how real CLIs handle width-responsive tables. The convergent practice: detect width via `shutil.get_terminal_size()`, split behaviour on `isatty()`, give leftover width to one flex column, and word-wrap (not truncate) when the column's payload is the value the user is reading. Measured the real catalogue data — descriptions reach ~689 chars while `NAME`/`VERSION`/`DEPENDENCIES` are all ≤20 — confirming `DESCRIPTION` as the sole wrap target.

## Scope

Checked the rest of the CLI: `config` already emits tab-separated key/value output (immune to this) and `list-targets` is single-column. Those two `list-*` commands were the entire fixed-width-table surface, so both are fixed here; a shared helper is justified by the two callers.

## Tests

- New `tests/unit/test_render_table.py` (9 cases): non-TTY full-width-untruncated, TTY-narrow wrap-within-width, continuation alignment, following-column-on-first-line-only, wide-TTY no-wrap, tiny-width floor clamp, `wrap_col=None`, empty rows.
- E2E against the real catalogue at widths 100 and 70: zero overflow lines.
- Full `agentbundle` unit + integration suite green; lint clean.
- One adversarial-review pass; tightened a loose floor-clamp assertion it flagged.

## Release

Left in `CHANGELOG.md` `[Unreleased]` — no version bump in this PR. Cut a release separately when ready to publish.