### PR TITLE
refactor(build): source self-host pack/adapter allow-lists from the recipe

### DIFF
--- a/.github/workflows/build-check-windows.yml
+++ b/.github/workflows/build-check-windows.yml
@@ -118,6 +118,13 @@ jobs:
         working-directory: packages/agentbundle
         run: python -m pytest agentbundle/build/tests/test_shared_libs_projection.py
 
+      # self_host derives SELF_HOST_PACKS / SELF_HOST_ADAPTERS from the recipe by
+      # resolving its path; run on Windows too since that resolution is
+      # path-sensitive. make build-check runs no pytest, so wire it explicitly.
+      - name: pytest self-host recipe config (externalize-self-host-config)
+        working-directory: packages/agentbundle
+        run: python -m pytest agentbundle/build/tests/test_self_host_recipe_config.py
+
       # credbroker-user-scope T3: prove the vendored credbroker floor projects
       # and is importable on Windows too — the projection's path handling +
       # file modes are platform-sensitive, and the floor must import

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -146,6 +146,12 @@ jobs:
         working-directory: packages/agentbundle
         run: python -m pytest agentbundle/build/tests/test_shared_libs_projection.py
 
+      # self_host derives SELF_HOST_PACKS / SELF_HOST_ADAPTERS from the recipe;
+      # make build-check runs no pytest, so wire this unit test explicitly.
+      - name: pytest self-host recipe config (externalize-self-host-config)
+        working-directory: packages/agentbundle
+        run: python -m pytest agentbundle/build/tests/test_self_host_recipe_config.py
+
       - name: Install credbroker (editable, with crypto extra)
         # Installing the [crypto] extra verifies it resolves (spec credbroker AC1)
         # AND runs the stdlib-purity gate under the *stronger* condition — with

--- a/docs/specs/externalize-self-host-config/spec.md
+++ b/docs/specs/externalize-self-host-config/spec.md
@@ -1,0 +1,55 @@
+# Spec: Externalize the self-host pack and adapter allow-lists
+
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Mode:** light (no risk trigger fired)
+
+## Objective
+
+The self-host projection set is split across two hand-synced sources: the
+`SELF_HOST_PACKS` / `SELF_HOST_ADAPTERS` constants in
+`agentbundle/build/self_host.py`, and the `recipes/self-host.toml` recipe whose
+`[recipe.adapters].targets` is a manual mirror of `SELF_HOST_ADAPTERS` (and
+which lists no packs at all). The recipe comment even says it "keeps this list
+in sync" by hand. Make the recipe the single authoritative source the code
+*reads*, collapsing the duplication so the self-host set is config-driven
+rather than hardcoded.
+
+## Acceptance Criteria
+
+- [x] AC1: `recipes/self-host.toml` declares the self-host pack allow-list under
+  `[recipe.packs].include` and keeps the adapter allow-list under
+  `[recipe.adapters].targets`; the adapter comment names the recipe as the
+  authoritative source rather than a hand-synced mirror.
+- [x] AC2: `self_host.py` derives `SELF_HOST_PACKS` and `SELF_HOST_ADAPTERS` by
+  reading those recipe keys, using the same filesystem-first /
+  `importlib.resources` fallback resolution pattern `build/main.py` already uses
+  for recipes.
+- [x] AC3: When the recipe file or a key is missing or malformed, both fall back
+  to the prior built-in literals — module import never raises.
+- [x] AC4: `make build-check` passes — the self-host projection is byte-identical
+  (the recipe carries today's values), and the existing self-host tests
+  (`test_self_host_check.py`, `test_adapter_cursor.py`, `test_adapter_gemini.py`)
+  stay green.
+
+## Tasks
+
+1. Add `[recipe.packs].include` to `recipes/self-host.toml` with the current
+   three packs; update the `[recipe.adapters]` comment to name the recipe as
+   authoritative.
+2. Add the recipe-reading loader to `self_host.py` and derive the two constants
+   from it, keeping the constant names so all call sites and tests are unchanged.
+3. Add a unit test: a pure extractor applies the defaults on empty/missing input
+   and reads values when present; the module constants match the shipped recipe.
+
+## Declined
+
+- Tempted to thread the parsed recipe through `cmd_self` into every filter call
+  site; declining — module-level derivation keeps the constant names and avoids
+  editing five call sites plus their tests for no behavioral gain.
+- Tempted to add a new top-level catalogue config file; declining — the
+  self-host recipe already exists and is the natural home; a new top-level file
+  is a heavier, RFC-shaped change.
+- Tempted to remove the `SELF_HOST_*` constants entirely; declining — they are
+  imported by tests and other call sites, so deriving them preserves the
+  interface with the smallest diff.

--- a/packages/agentbundle/agentbundle/build/recipes/self-host.toml
+++ b/packages/agentbundle/agentbundle/build/recipes/self-host.toml
@@ -10,8 +10,20 @@ type = "composite"
 description = "Overlay every pack's Claude Code projection onto this repo; compose AGENTS.md from packs/core/seeds and aggregate .claude-plugin/marketplace.json across packs."
 
 [recipe.adapters]
-# The self-host runtime reads `SELF_HOST_ADAPTERS` and keeps this list in sync.
+# Authoritative source for `SELF_HOST_ADAPTERS` — `self_host.py` reads this list.
+# Kiro and Copilot stay in the contract for distribution builds but are excluded
+# here so self-host does not project `.kiro/` or `.github/instructions/`.
 targets = ["claude-code", "codex"]
+
+[recipe.packs]
+# Authoritative source for `SELF_HOST_PACKS` — `self_host.py` reads this list.
+# This repo is the catalogue's home, not an adopter, so `make build-self` only
+# projects the in-house packs into the working tree. User-scope-default packs
+# (architect, atlassian, contracts, converters, credential-brokers, figma) are
+# advertised via `marketplace.json` but their primitives don't belong in this
+# repo's `.claude/skills/` tree; `monorepo-extras` is repo-only by metadata but
+# the bundle is not a canonical `new-package` consumer, so it's left out too.
+include = ["core", "governance-extras", "user-guide-diataxis"]
 
 [recipe.iterate]
 over = "packs/*/"

--- a/packages/agentbundle/agentbundle/build/self_host.py
+++ b/packages/agentbundle/agentbundle/build/self_host.py
@@ -24,7 +24,9 @@ consumer.
 Self-host scope (see docs/specs/self-hosting/spec.md § Phased rollout):
 the `SELF_HOST_ADAPTERS` allow-list runs `claude-code` and `codex`.
 Kiro and Copilot stay distribution-only so self-host does not project
-`.kiro/` or `.github/instructions/`.
+`.kiro/` or `.github/instructions/`. Both `SELF_HOST_ADAPTERS` and
+`SELF_HOST_PACKS` are sourced from `recipes/self-host.toml` (see the
+`_DEFAULT_*` block below); the values named here are the current defaults.
 """
 
 from __future__ import annotations
@@ -79,26 +81,75 @@ TARGET_PATHS = (
     Path("AGENTS.md"),
 )
 
-# Self-host allow-list (see self-hosting spec § Phased rollout).
-# Kiro and Copilot remain in the contract for distribution builds but
-# are excluded from the self-host runner.
-SELF_HOST_ADAPTERS: tuple[str, ...] = ("claude-code", "codex")
-
-# Self-host *pack* allow-list. This repo is the catalogue's home, not
-# an adopter — `make build-self` should only project the in-house
-# packs into the working tree. User-scope-default packs (architect,
-# atlassian, contracts, converters, credential-brokers, figma) are
-# advertised via `marketplace.json` but their primitives don't belong
-# in this repo's `.claude/skills/` (or future `.kiro/skills/`) tree.
-# `monorepo-extras` is repo-only by metadata but the bundle is not a
-# canonical monorepo consumer of `new-package`, so it's left out too.
-# `_aggregate_marketplace` intentionally ignores this filter — the
-# catalogue advertises every pack.
-SELF_HOST_PACKS: tuple[str, ...] = (
+# Built-in fallbacks for the self-host pack / adapter allow-lists. The
+# authoritative values live in `recipes/self-host.toml` (read at import below);
+# these are used only when that recipe is missing a key or can't be read, so
+# module import stays total. Kiro and Copilot remain in the contract for
+# distribution builds but are excluded from the self-host runner. This repo is
+# the catalogue's home, not an adopter, so `make build-self` only projects the
+# in-house packs; `_aggregate_marketplace` intentionally ignores the pack
+# filter — the catalogue advertises every pack. See the recipe for the full
+# rationale behind the pack selection.
+_DEFAULT_SELF_HOST_ADAPTERS: tuple[str, ...] = ("claude-code", "codex")
+_DEFAULT_SELF_HOST_PACKS: tuple[str, ...] = (
     "core",
     "governance-extras",
     "user-guide-diataxis",
 )
+
+_SELF_HOST_RECIPE = "self-host"
+
+
+def _read_recipe_text(name: str) -> str | None:
+    """Return the text of `recipes/<name>.toml`, or None if unreadable.
+
+    Mirrors `build.main`'s recipe resolution: filesystem first (dev / editable
+    install), then `importlib.resources` (zipapp, where the package lives inside
+    a `.pyz` archive that `Path.exists()` cannot traverse).
+    """
+    recipe_path = Path(__file__).resolve().parent / "recipes" / f"{name}.toml"
+    if recipe_path.exists():
+        return recipe_path.read_text(encoding="utf-8")
+    try:
+        from importlib.resources import files
+
+        resource = files("agentbundle.build").joinpath(f"recipes/{name}.toml")
+        if resource.is_file():
+            return resource.read_text(encoding="utf-8")
+    except (FileNotFoundError, ModuleNotFoundError):
+        pass
+    return None
+
+
+def _extract_self_host_lists(
+    recipe: dict,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Pull `(packs, adapters)` from a parsed self-host recipe, substituting the
+    built-in defaults for any list that is absent or empty."""
+    body = recipe.get("recipe", {})
+    packs = tuple(body.get("packs", {}).get("include", ())) or _DEFAULT_SELF_HOST_PACKS
+    adapters = (
+        tuple(body.get("adapters", {}).get("targets", ()))
+        or _DEFAULT_SELF_HOST_ADAPTERS
+    )
+    return packs, adapters
+
+
+def _load_self_host_lists() -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Read the self-host allow-lists from the recipe. Total: any read or parse
+    failure falls back to the built-in defaults so module import never raises."""
+    try:
+        text = _read_recipe_text(_SELF_HOST_RECIPE)
+        if text is None:
+            return _DEFAULT_SELF_HOST_PACKS, _DEFAULT_SELF_HOST_ADAPTERS
+        return _extract_self_host_lists(tomllib.loads(text))
+    except Exception:
+        # Unreadable (non-UTF-8 / permission / IO) or malformed recipe — fall
+        # back so module import is total (AC3).
+        return _DEFAULT_SELF_HOST_PACKS, _DEFAULT_SELF_HOST_ADAPTERS
+
+
+SELF_HOST_PACKS, SELF_HOST_ADAPTERS = _load_self_host_lists()
 
 
 def _filter_self_host_packs(pack_paths: list[Path]) -> list[Path]:

--- a/packages/agentbundle/agentbundle/build/tests/test_self_host_recipe_config.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_self_host_recipe_config.py
@@ -1,0 +1,113 @@
+"""The self-host pack / adapter allow-lists are sourced from the recipe.
+
+`SELF_HOST_PACKS` and `SELF_HOST_ADAPTERS` are derived at import from
+`recipes/self-host.toml` (`[recipe.packs].include` / `[recipe.adapters].targets`)
+rather than hardcoded. These tests pin the extractor's fallback behaviour, prove
+the read path is actually exercised (with values that differ from the defaults,
+so a silent fallback can't masquerade as a successful read), and confirm import
+stays total when the recipe is unreadable or malformed (AC3).
+"""
+
+from __future__ import annotations
+
+import tomllib
+import unittest
+from unittest import mock
+
+import agentbundle.build.self_host as sh
+from agentbundle.build.self_host import (
+    SELF_HOST_ADAPTERS,
+    SELF_HOST_PACKS,
+    _DEFAULT_SELF_HOST_ADAPTERS,
+    _DEFAULT_SELF_HOST_PACKS,
+    _extract_self_host_lists,
+    _read_recipe_text,
+)
+
+# Values deliberately unlike the defaults, so a test that sees them knows the
+# read→extract path ran rather than the total fallback.
+_DIFFERING_RECIPE = (
+    '[recipe.packs]\ninclude = ["only-pack"]\n'
+    '[recipe.adapters]\ntargets = ["only-adapter"]\n'
+)
+
+
+class ExtractSelfHostListsTest(unittest.TestCase):
+    def test_empty_recipe_falls_back_to_defaults(self):
+        packs, adapters = _extract_self_host_lists({})
+        self.assertEqual(packs, _DEFAULT_SELF_HOST_PACKS)
+        self.assertEqual(adapters, _DEFAULT_SELF_HOST_ADAPTERS)
+
+    def test_missing_keys_fall_back_per_list(self):
+        # adapters present, packs absent → packs default, adapters honoured
+        recipe = {"recipe": {"adapters": {"targets": ["codex"]}}}
+        packs, adapters = _extract_self_host_lists(recipe)
+        self.assertEqual(packs, _DEFAULT_SELF_HOST_PACKS)
+        self.assertEqual(adapters, ("codex",))
+
+    def test_present_lists_are_read(self):
+        recipe = {
+            "recipe": {
+                "packs": {"include": ["core", "extra"]},
+                "adapters": {"targets": ["claude-code"]},
+            }
+        }
+        packs, adapters = _extract_self_host_lists(recipe)
+        self.assertEqual(packs, ("core", "extra"))
+        self.assertEqual(adapters, ("claude-code",))
+
+
+class LoadSelfHostListsTest(unittest.TestCase):
+    """`_load_self_host_lists` is the read→extract path with a total fallback."""
+
+    def test_read_path_wins_with_differing_values(self):
+        # Differing values prove the recipe was actually read and extracted,
+        # not silently defaulted (the shipped recipe equals the defaults, so the
+        # module-constant test below can't distinguish read from fallback).
+        with mock.patch.object(sh, "_read_recipe_text", return_value=_DIFFERING_RECIPE):
+            packs, adapters = sh._load_self_host_lists()
+        self.assertEqual(packs, ("only-pack",))
+        self.assertEqual(adapters, ("only-adapter",))
+
+    def test_unreadable_recipe_falls_back(self):
+        with mock.patch.object(sh, "_read_recipe_text", return_value=None):
+            packs, adapters = sh._load_self_host_lists()
+        self.assertEqual(packs, _DEFAULT_SELF_HOST_PACKS)
+        self.assertEqual(adapters, _DEFAULT_SELF_HOST_ADAPTERS)
+
+    def test_read_error_falls_back(self):
+        # AC3: a read that raises (non-UTF-8 bytes, permission error) must not
+        # crash module import — it falls back to the defaults.
+        with mock.patch.object(sh, "_read_recipe_text", side_effect=OSError("boom")):
+            packs, adapters = sh._load_self_host_lists()
+        self.assertEqual(packs, _DEFAULT_SELF_HOST_PACKS)
+        self.assertEqual(adapters, _DEFAULT_SELF_HOST_ADAPTERS)
+
+    def test_malformed_toml_falls_back(self):
+        with mock.patch.object(sh, "_read_recipe_text", return_value="not = = valid"):
+            packs, adapters = sh._load_self_host_lists()
+        self.assertEqual(packs, _DEFAULT_SELF_HOST_PACKS)
+        self.assertEqual(adapters, _DEFAULT_SELF_HOST_ADAPTERS)
+
+    def test_real_read_text_error_falls_back(self):
+        # Exercise the actual `read_text(encoding="utf-8")` raise inside
+        # `_read_recipe_text` (the line the original blocker was about), not just
+        # a mocked boundary — a non-UTF-8 recipe must fall back, not crash.
+        boom = UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
+        with mock.patch("pathlib.Path.read_text", side_effect=boom):
+            packs, adapters = sh._load_self_host_lists()
+        self.assertEqual(packs, _DEFAULT_SELF_HOST_PACKS)
+        self.assertEqual(adapters, _DEFAULT_SELF_HOST_ADAPTERS)
+
+
+class ModuleConstantsMatchRecipeTest(unittest.TestCase):
+    def test_constants_derive_from_shipped_recipe(self):
+        text = _read_recipe_text("self-host")
+        self.assertIsNotNone(text, "self-host recipe must resolve")
+        packs, adapters = _extract_self_host_lists(tomllib.loads(text))
+        self.assertEqual(SELF_HOST_PACKS, packs)
+        self.assertEqual(SELF_HOST_ADAPTERS, adapters)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What & why

`SELF_HOST_PACKS` and `SELF_HOST_ADAPTERS` were hardcoded constants in `build/self_host.py`, while `recipes/self-host.toml` carried a hand-synced *mirror* of the adapter list (its comment literally said "keeps this list in sync") and no pack list at all. Two sources, one drift risk.

This makes the recipe the single authoritative source the code reads. `self_host.py` derives both constants at module load via `_load_self_host_lists()` (filesystem-first / `importlib.resources` fallback, matching `build/main.py`'s recipe resolution), with a **total fallback** to the prior literals so module import never raises. Constant names are preserved, so all five call sites and three test files are unchanged.

## How verified

- `make build-check` exit 0 — the self-host **drift gate is byte-identical** (the recipe carries today's values), spec-lint clean, SAST clean. This exercises the real `build-self` projection end-to-end.
- Full `agentbundle` pytest suite green.
- New `test_self_host_recipe_config.py` (9 tests): extractor fallback, a read-path test using values *unlike* the defaults (proves it reads rather than silently defaulting), and import-totality for unreadable / read-error / malformed-TOML / real non-UTF-8 `read_text` cases.
- New test wired explicitly into `build-check.yml` and `build-check-windows.yml` (the repo runs build-tests by per-path step; `make build-check` runs no pytest).
- Adversarial review: clean after one fix round (the read is now inside the fallback guard) + applied residuals.

## Risk

Low. Behavior-preserving — the projection is byte-identical and the constant interface is unchanged. The recipe is internal build config (not a published interface); a missing/malformed recipe degrades to the prior literals.

## Scope

Self-host build config only. No white-label, distribution, or runtime-install behavior is touched.

**Deferred / declined:** pinning the `_DEFAULT_*` literals equal to the recipe values — declined, since the defaults are an emergency floor (only fire on recipe-read failure, never in build-check) and pinning would re-introduce the two-place edit this refactor removes.