### PR TITLE
refactor(build): move the build-self fixture guard into the CLI handler

### DIFF
--- a/.github/workflows/build-check-windows.yml
+++ b/.github/workflows/build-check-windows.yml
@@ -125,6 +125,12 @@ jobs:
         working-directory: packages/agentbundle
         run: python -m pytest agentbundle/build/tests/test_self_host_recipe_config.py
 
+      # The fixture-overwrite guard protects the make-free Windows entry; run
+      # its test on Windows too (as_posix path matching is platform-sensitive).
+      - name: pytest self-host fixture guard (windows-build-self-entry)
+        working-directory: packages/agentbundle
+        run: python -m pytest agentbundle/build/tests/test_self_host_fixture_guard.py
+
       # credbroker-user-scope T3: prove the vendored credbroker floor projects
       # and is importable on Windows too — the projection's path handling +
       # file modes are platform-sensitive, and the floor must import

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -152,6 +152,12 @@ jobs:
         working-directory: packages/agentbundle
         run: python -m pytest agentbundle/build/tests/test_self_host_recipe_config.py
 
+      # The fixture-overwrite guard now lives in cmd_self (not the Makefile);
+      # wire its test explicitly since make build-check runs no pytest.
+      - name: pytest self-host fixture guard (windows-build-self-entry)
+        working-directory: packages/agentbundle
+        run: python -m pytest agentbundle/build/tests/test_self_host_fixture_guard.py
+
       - name: Install credbroker (editable, with crypto extra)
         # Installing the [crypto] extra verifies it resolves (spec credbroker AC1)
         # AND runs the stdlib-purity gate under the *stronger* condition — with

--- a/Makefile
+++ b/Makefile
@@ -35,14 +35,11 @@ else
 endif
 endif
 
+# The tests/fixtures fixture-overwrite guard lives in the CLI handler
+# (agentbundle.build.self_host.cmd_self) so it protects the make-free
+# `python -m agentbundle.build self` entry on Windows too, honouring the same
+# ALLOW_FIXTURE_PACKS override.
 build-self: lint-packs
-	@case "$(PACKS_DIR)" in \
-		*tests/fixtures/*) \
-			if [ -z "$$ALLOW_FIXTURE_PACKS" ]; then \
-				echo "make build-self: refusing — PACKS_DIR points into tests/fixtures/; this would overwrite your working tree with fixture data. Set ALLOW_FIXTURE_PACKS=1 to override, or set PACKS_DIR=packs (when the F-dist migration lands)." >&2; \
-				exit 1; \
-			fi ;; \
-	esac
 ifeq ($(DRY_RUN),1)
 ifeq ($(FORCE),1)
 	$(PYTHON) -m agentbundle.build self --dry-run --force --packs-dir $(PACKS_DIR)

--- a/docs/architecture/agentbundle.md
+++ b/docs/architecture/agentbundle.md
@@ -97,7 +97,10 @@ packs/                                dist/
    `make build-check` runs the same dry-run as a CI gate that fails on
    any byte-divergence between source and projection — the single biggest
    source of CI noise, so the error message names the seed path you
-   should have edited.
+   should have edited. On Windows (no `make`), invoke build-self directly:
+   `python -m agentbundle.build self --packs-dir packs` (add `--dry-run` for
+   the diff). The fixture-overwrite guard is enforced in the CLI handler,
+   not the Makefile, so the direct entry is equally safe.
 
 ### The adapter contract
 

--- a/docs/specs/windows-build-self-entry/spec.md
+++ b/docs/specs/windows-build-self-entry/spec.md
@@ -1,0 +1,58 @@
+# Spec: First-class cross-platform build-self entry (port the fixture guard)
+
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Mode:** light — evaluated the destructive-operation trigger: this strengthens
+  an existing guard and is behavior-preserving on the real-write refusal path;
+  the inner destructive function (`run_self_host`) and its dirty-tree+`--force`
+  protection are untouched.
+
+## Objective
+
+`build-self` overwrites the working tree. Its guard against pointing
+`--packs-dir` into `tests/fixtures/` (which would overwrite the tree with
+fixture data) lives **only in Makefile bash** (`@case … ALLOW_FIXTURE_PACKS …`).
+On Windows there is no `make`, so the only way to run build-self —
+`python -m agentbundle.build self` — bypasses that guard entirely. Port the
+guard into the CLI handler (`cmd_self`) so the cross-platform invocation is
+safe, and remove the now-redundant Makefile bash guard so it is single-sourced.
+
+## Acceptance Criteria
+
+- [x] AC1: A real-write `cmd_self` invocation (`--packs-dir` under
+  `tests/fixtures/`, no `--dry-run`, `ALLOW_FIXTURE_PACKS` unset) refuses with a
+  clear stderr message and a non-zero exit, and does **not** call `run_self_host`.
+- [x] AC2: The guard is bypassed when `ALLOW_FIXTURE_PACKS` is set, on
+  `--dry-run` (non-destructive), and for a non-fixtures `--packs-dir` — matching
+  the historical Makefile semantics. Path matching is Windows-safe (`as_posix`).
+- [x] AC3: The guard lives in the CLI handler (`cmd_self`), not `run_self_host`,
+  so existing tests that drive `run_self_host` directly against fixture packs
+  are unaffected.
+- [x] AC4: The redundant Makefile bash guard is removed; `make build-self`
+  real-write still refuses a fixtures `PACKS_DIR` (now via the Python guard),
+  and `make build-check` stays green.
+- [x] AC5: `python -m agentbundle.build self --packs-dir packs` is documented as
+  the make-free (Windows) entry in `docs/architecture/agentbundle.md`.
+
+## Tasks
+
+1. Add a pure `_refuse_fixture_packs_dir(packs_dir, *, dry_run) -> int | None`
+   helper to `self_host.py` and call it at the top of `cmd_self` before
+   `run_self_host`.
+2. Remove the `@case … esac` bash guard from the Makefile `build-self` target.
+3. Document the cross-platform invocation in `docs/architecture/agentbundle.md`.
+4. Tests: the helper's four branches (refuse / env-override / dry-run /
+   non-fixtures) + a `cmd_self` wiring test that the guard fires and
+   `run_self_host` is not called.
+
+## Declined
+
+- Tempted to add a `--allow-fixture-packs` CLI flag; declining — `ALLOW_FIXTURE_PACKS`
+  is the existing override and no second caller needs a flag.
+- Tempted to put the guard in `run_self_host`; declining — tests drive that
+  function directly against fixtures with `force=True`, and the guard is a
+  CLI-entry concern (where the Makefile equivalent lived).
+- Tempted to guard `--dry-run` too; declining — dry-run writes to a shadow temp
+  dir (non-destructive), matching the existing dirty-tree guard's `not dry_run`
+  condition; the only behavior delta is `make build-self DRY_RUN=1` on a
+  fixtures dir now proceeding harmlessly.

--- a/packages/agentbundle/agentbundle/build/self_host.py
+++ b/packages/agentbundle/agentbundle/build/self_host.py
@@ -1514,10 +1514,42 @@ def run_build_check_drift_gates(
     return 0
 
 
+def _refuse_fixture_packs_dir(packs_dir: Path, *, dry_run: bool) -> int | None:
+    """Refuse a real-write self-host whose `packs_dir` points into
+    `tests/fixtures/` (which would overwrite the working tree with fixture
+    data), unless `ALLOW_FIXTURE_PACKS` is set.
+
+    This is the cross-platform home of the guard that used to live only in the
+    Makefile `build-self` recipe — so the make-free entry
+    `python -m agentbundle.build self` (the only way to run build-self on
+    Windows) is protected too. Returns a non-zero exit code to refuse, or
+    `None` to proceed. Dry-run writes to a shadow temp dir, so it is never
+    guarded (matching the `run_self_host` dirty-tree check). `as_posix()`
+    normalises separators so the match is Windows-safe.
+    """
+    if dry_run or os.environ.get("ALLOW_FIXTURE_PACKS"):
+        return None
+    # Trailing slash mirrors the historical Makefile glob `*tests/fixtures/*`
+    # exactly — so a sibling like `my-tests/fixtures-backup/` doesn't over-match.
+    if "tests/fixtures/" in packs_dir.as_posix():
+        print(
+            "self-host: refusing — --packs-dir points into tests/fixtures/; "
+            "this would overwrite your working tree with fixture data. Set "
+            "ALLOW_FIXTURE_PACKS=1 to override, or use --packs-dir packs.",
+            file=sys.stderr,
+        )
+        return 2
+    return None
+
+
 def cmd_self(args) -> int:
+    packs_dir = Path(args.packs_dir).resolve()
+    refusal = _refuse_fixture_packs_dir(packs_dir, dry_run=args.dry_run)
+    if refusal is not None:
+        return refusal
     return run_self_host(
         working_tree=Path(args.output_dir).resolve(),
-        packs_dir=Path(args.packs_dir).resolve(),
+        packs_dir=packs_dir,
         dry_run=args.dry_run,
         force=args.force,
         no_symlink=getattr(args, "no_symlink", False),

--- a/packages/agentbundle/agentbundle/build/tests/test_self_host_fixture_guard.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_self_host_fixture_guard.py
@@ -1,0 +1,88 @@
+"""The tests/fixtures fixture-overwrite guard lives in the CLI handler.
+
+`build-self` overwrites the working tree; pointing `--packs-dir` into
+`tests/fixtures/` would overwrite it with fixture data. That guard used to live
+only in the Makefile, so the make-free `python -m agentbundle.build self` entry
+(the only one available on Windows) bypassed it. It now lives in `cmd_self` via
+`_refuse_fixture_packs_dir`, honouring the same `ALLOW_FIXTURE_PACKS` override.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import agentbundle.build.self_host as sh
+from agentbundle.build.self_host import _refuse_fixture_packs_dir
+
+_FIXTURE_DIR = Path("/repo/packages/agentbundle/tests/fixtures/packs")
+_REAL_DIR = Path("/repo/packs")
+
+# Empty string is falsy, so this simulates "unset" for the guard regardless of
+# the ambient environment; "1" simulates the override being set.
+_ENV_UNSET = {"ALLOW_FIXTURE_PACKS": ""}
+_ENV_SET = {"ALLOW_FIXTURE_PACKS": "1"}
+
+
+class RefuseFixturePacksDirTest(unittest.TestCase):
+    def test_real_write_into_fixtures_refuses(self):
+        with mock.patch.dict(os.environ, _ENV_UNSET):
+            rc = _refuse_fixture_packs_dir(_FIXTURE_DIR, dry_run=False)
+        self.assertEqual(rc, 2)
+
+    def test_env_override_proceeds(self):
+        with mock.patch.dict(os.environ, _ENV_SET):
+            rc = _refuse_fixture_packs_dir(_FIXTURE_DIR, dry_run=False)
+        self.assertIsNone(rc)
+
+    def test_dry_run_is_never_guarded(self):
+        with mock.patch.dict(os.environ, _ENV_UNSET):
+            rc = _refuse_fixture_packs_dir(_FIXTURE_DIR, dry_run=True)
+        self.assertIsNone(rc)
+
+    def test_non_fixtures_dir_proceeds(self):
+        with mock.patch.dict(os.environ, _ENV_UNSET):
+            rc = _refuse_fixture_packs_dir(_REAL_DIR, dry_run=False)
+        self.assertIsNone(rc)
+
+
+class CmdSelfGuardWiringTest(unittest.TestCase):
+    def test_cmd_self_refuses_and_does_not_run(self):
+        args = argparse.Namespace(
+            output_dir=".",
+            packs_dir=str(_FIXTURE_DIR),
+            dry_run=False,
+            force=False,
+            no_symlink=False,
+        )
+        with mock.patch.dict(os.environ, _ENV_UNSET), mock.patch.object(
+            sh, "run_self_host"
+        ) as run:
+            rc = sh.cmd_self(args)
+        self.assertEqual(rc, 2)
+        run.assert_not_called()
+
+    def test_cmd_self_refuses_relative_fixtures_path(self):
+        # cmd_self resolves the packs-dir first; a *relative* tests/fixtures
+        # path must still match after resolve() + as_posix() (the real input
+        # shape, which the pure-helper tests above bypass).
+        args = argparse.Namespace(
+            output_dir=".",
+            packs_dir="agentbundle/build/tests/fixtures/packs",
+            dry_run=False,
+            force=False,
+            no_symlink=False,
+        )
+        with mock.patch.dict(os.environ, _ENV_UNSET), mock.patch.object(
+            sh, "run_self_host"
+        ) as run:
+            rc = sh.cmd_self(args)
+        self.assertEqual(rc, 2)
+        run.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What & why

`build-self` overwrites the working tree. Its guard against pointing `--packs-dir` into `tests/fixtures/` (which would overwrite the tree with fixture data) lived **only in Makefile bash**. On Windows there is no `make`, so the only build-self entry — `python -m agentbundle.build self` — bypassed the guard entirely.

This ports the guard into the CLI handler (`cmd_self`) as `_refuse_fixture_packs_dir`, so the cross-platform invocation is equally safe, and removes the now-redundant Makefile bash guard (single-sourced). It honours the same `ALLOW_FIXTURE_PACKS` override and matches the historical `*tests/fixtures/*` glob (trailing slash, so `my-tests/fixtures-backup/` doesn't over-match).

## How verified

- Full `agentbundle` pytest suite green (run from `packages/agentbundle`, which resolves the local edited code).
- Guard fires correctly **end-to-end** against the local code: `self-host: refusing — --packs-dir points into tests/fixtures/…`.
- New `test_self_host_fixture_guard.py` (6 tests): the four helper branches (refuse / `ALLOW_FIXTURE_PACKS` override / dry-run / non-fixtures) + two `cmd_self` wiring tests (absolute and relative paths) asserting it refuses and `run_self_host` is **not** called.
- Wired into both `build-check.yml` and `build-check-windows.yml` (per-path rule; Windows too, since `as_posix` matching is platform-sensitive).
- Adversarial review: clean after applying both findings (trailing-slash parity + the relative-path test).

## Risk

Low, and it **strengthens** an existing destructive-operation guard rather than weakening it. Behavior-preserving on the real-write refusal; `run_self_host` and its dirty-tree+`--force` protection are untouched. The guard is real-write-only (`not dry_run`), matching the existing dirty-tree check — the only behavior delta is that `make build-self DRY_RUN=1` on a fixtures dir now proceeds harmlessly (dry-run writes to a shadow temp dir).

## Scope

Build-self CLI entry + its guard. No projection/runtime-install behavior touched. No white-label or distribution behavior.

**Note:** `make build-check` from the repo root resolves a site-packages `agentbundle` (editable install of a sibling worktree), so the *local* `make build-check` does not exercise this diff — CI is the authoritative drift gate since it `pip install -e`'s this tree.