### PR TITLE
docs(rfc): RFC-0046 follow-ons — ADR-0036 + convenient-install-defaults spec/plan

### DIFF
--- a/docs/adr/0036-install-source-resolves-through-trusted-precedence-chain-no-repo-source-no-cwd.md
+++ b/docs/adr/0036-install-source-resolves-through-trusted-precedence-chain-no-repo-source-no-cwd.md
@@ -1,0 +1,101 @@
+# ADR-0036: The install-source default resolves through a trusted-by-construction precedence chain — editable detection as the downstream default, no repo-scoped source, no cwd fallback
+
+- **Status:** Accepted
+- **Date:** 2026-06-25
+- **Decision-makers:** eugenelim
+- **Consulted:** RFC-0046 (the accepted decision this records, incl. its five-decision set, the editable-detection spike, and the options-considered table); RFC-0031 (the package-manager posture — no server, no index, no daemon — and D7's "bare pack → public default catalogue" this locates); RFC-0011/0012 + the adapter state-hint (the resolver cascade, and the *correctness-not-convenience* nature of the state-hint that justifies **not** auto-persisting source); **RFC-0040 + ADR-0030 §Risks** (the untrusted-origin / confirm-before-write control for a hostile repo-root file — the precedent for omitting a repo-scoped source rather than gating it); ADR-0002 (per-pack install scope); the external layered-config prior art (Cargo `registry.default`, npm `.npmrc` precedence, pip CLI›env›config) confirmed in RFC-0046's evidence section
+- **Supersedes:** none
+- **Related:** RFC-0046 (the accepted decision this ADR records); RFC-0031 (the runtime-infra-free package-manager posture this honours); RFC-0011/0012 (the resolver cascade and adapter state-hint); RFC-0040 + ADR-0030 (the untrusted-origin precedent); `docs/specs/convenient-install-defaults/` (the implementing spec); `docs/CHARTER.md` Principle 3 ("a habit, not a tool… not infrastructure")
+
+## Context
+
+`agentbundle install` and `upgrade` take `catalogue` as a **required positional** with no default (`cli.py:247`, `:400`), so every invocation must spell out a full source URI. For the public PyPI user that URI is always the same GitHub repo — re-typed every time. For a downstream org fork behind an API gateway it is **unspecifiable**: `resolve_catalogue` only parses `git+https://github.com/...` (the `_HTTPS_RE` regex is hardcoded to `github.com`, `catalogue.py:43`), the gateway blocks direct internal-URL access, and a fixed filesystem path cannot be baked because every machine clones to a different location. RFC-0031 D7 already promises that a bare pack "resolves to the public default catalogue," and `resolve_catalogue` already accepts a local path (`catalogue.py:72`, returning `Path(uri)` **without any existence or marker validation**) — but nothing locates that default.
+
+The forces in play when deciding *how* to locate it:
+
+- **CHARTER Principle 3 (a habit, not infrastructure).** RFC-0031's posture forecloses a server, a hosted registry/index, or a discovery daemon. Whatever resolves the default must be **runtime resolution + reading files only**.
+- **The source is a code-provenance boundary.** The catalogue source decides *where executable packs are fetched from*. This is strictly higher-stakes than the adapter-projection *target* RFC-0040 governs (which decides only *where generated files are written* in the user's own tree). A wrong source runs someone else's code; a wrong target writes a file the user can inspect.
+- **RFC-0040's precedent for a repo-supplied control.** ADR-0030 / RFC-0040 §Risks already classified a **hostile repo-root config file** as untrusted-origin and gated the *lower-stakes* where-files-are-written case behind Ask-first / confirm-before-write. That precedent is available to copy — or to decline as insufficient for the higher-stakes case.
+- **Two populations, one command.** The public wheel user (no editable record, wants GitHub) and the editable gateway-bound fork (clone-anywhere, wants its local clone) must both get a working bare `install --pack X` with **zero extra command**.
+- **Layered-config-plus-baked-default is settled package-manager prior art.** Cargo (`registry.default = "crates-io"`, deeper-dir overrides home), npm (project `.npmrc` over `~/.npmrc`, CLI flag wins, default registry), and pip (CLI › env › config) all converge on a precedence chain terminating in a distribution-shipped default — but they put *project*-config **over** *user*-config for a project's own build tooling, a precedent that does **not** transfer to a code-fetch decision.
+
+## Decision
+
+> We will make `catalogue` **optional** on `install`/`upgrade` and resolve a default through a four-layer, **trusted-by-construction** precedence chain — `--catalogue` arg › user `[settings].source` › **editable-install detection** (PEP 610) › packaged `_data/install-defaults.toml` — with **no repo-supplied source layer** and **no fall-back to the current working directory**, because the source is a code-provenance boundary. Resolution is stateless (no write-on-install); persistence is the explicit `config set source`. The default ships in a packaged **data file** so a downstream fork re-points it with zero code edits.
+
+Five load-bearing, expensive-to-reverse sub-decisions. (The numbering here is the ADR's own. RFC-0046's D1 — make `catalogue` optional — is the change's premise, stated in the Decision sentence above and scoped under *Boundaries*; ADR D1/D2/D4/D5 record RFC-0046's D2/D3/D4/D5, and ADR D3 lifts the no-repo-source / no-cwd half of RFC-0046's D2 into its own decision given its security weight.)
+
+- **D1 — The precedence chain is trusted by construction, highest-first, first-wins.** The four layers, in order, are: (1) the `--catalogue` arg the user typed; (2) the user's own `[settings].source` set via `config set source` on their machine; (3) editable detection reading the user's own `pip install -e` record; (4) the distribution's packaged default. **Every layer reduces to something the user already trusts** — their invocation, their machine's config, their filesystem clone, or the wheel they installed. User-config (2) deliberately **outranks** editable detection (3): an explicit `config set source` is intentional and should beat auto-detection. When **no** layer yields a source the command **errors clearly** (`pass --catalogue, run 'agentbundle config set source …', or pip install -e the catalogue`) — never a silent fall-through.
+
+- **D2 — Editable detection is the blessed downstream default mechanism (PEP 610 + a hardened, repo-bounded walk-up).** Layer 3 reads this distribution's PEP 610 `direct_url.json` (`importlib.metadata.distribution("agentbundle").read_text("direct_url.json")`); when `dir_info.editable == true`, it parses the `file://` URL with the standard parser (rejecting a non-empty/non-localhost host), **canonicalizes** the path (`Path.resolve()`), then **walks up over canonicalized ancestors** to the first one containing **both** `packs/` and `.claude-plugin/marketplace.json` — **bounding the ascent to the enclosing repository root** (the nearest ancestor with a `.git` entry, file or directory, computed before any marker test). This is what lets the gateway-bound fork `pip install -e <wherever-cloned>` and get clone-location-independent bare installs with zero command. The two markers are an **accident-guard, not a trust control** — they are forgeable, so the residual (a pair planted in an *intermediate* dir inside the clone) is bounded by canonicalize + stop-at-first + no-ascent-above-the-repo-root, and is acceptable because writing inside the clone already implies write access to the user's own catalogue. No `direct_url.json` (an older pip, or a wheel install) → no detection → fall through to layer 4.
+
+- **D3 — There is no repo-scoped source and no cwd fall-back (the security-load-bearing call).** This is the decision this ADR's title turns on. A *cloned repo* dictating where executable code is fetched from is a supply-chain hazard. Rather than replicate RFC-0040's confirm-before-write gate for this higher-stakes case, **the layer is omitted entirely** — the explicit arg plus editable detection already meet the downstream need, so a repo-supplied source buys nothing and costs a code-provenance escalation. Likewise **no layer ever resolves from `.`/cwd**: the only terminal states are a validated source or a clear error. This is the deliberate divergence from the layered-config prior art, which *does* let project config win — that precedent governs build config, not a code-fetch decision.
+
+- **D4 — Resolution is stateless; `config set source` is the only persistence path (no auto-persist).** A one-off `--catalogue` never writes itself back to config. A user wanting a persistent custom default runs `config set source <uri>` (layer 2) — visible and intentional. This deliberately **departs** from the in-repo adapter state-hint, which remembers the adapter as a **correctness** mechanism (an upgrade/uninstall must re-target the adapter it actually wrote files for); source-memory would be mere convenience with no package-manager precedent and a surprising side-effect.
+
+- **D5 — The packaged default is a data file, not a constant, with an asymmetric integrity posture.** Layer 4 is a new packaged `_data/install-defaults.toml` (joining `adapter.toml`, the schemas, and `install-marker.py`, picked up by the existing `package-data = ["_data/*"]` wiring). Upstream ships `git+https://github.com/eugenelim/agent-ready-repo`; **a private downstream fork blanks or drops the file** (absent/empty = no layer-4 default), re-pointing with zero code edits — the baked-default-registry model (PyPI/crates-io). Layer 4's `git+https` default is the one path that **crosses the network**: the existing resolver fetches an **unauthenticated** GitHub-archive tarball with a missing ref defaulting to `main` (`catalogue.py:84` — TOFU against the current tip, no checksum/signature/pin). The integrity posture is therefore **asymmetric by layer** — layers 1–3 reduce to local trust (strong), layer 4 alone crosses the network unauthenticated. This is accepted for now because the network layer is the upstream public default, off the gateway-fork path; **integrity-pinning for the layer-4 fetch is a named follow-on, not part of this decision.**
+
+Boundaries on the decision:
+
+- **Scope is `install`/`upgrade` only.** The discovery verbs `list-packs`/`list-profiles` keep requiring an explicit catalogue — defaulting a *query* needs its own justification and must not silently fetch the upstream URL on a gateway-bound fork. Deferred to a follow-on.
+- **The adapter resolver is untouched.** `scope.DEFAULT_ADAPTER` and the user-config adapter layer are unchanged; this decision adds `source` alongside `adapter` in the `[settings]` schema and nothing more. The in-repo *adapter* override that some users want (the Claude-Code-style repo-overrides-user precedence for the projection *target*) is cleanly separable and spun out to its own future RFC.
+- **No new infrastructure, no new dependency.** Runtime resolution and stdlib file/metadata reads only (`importlib.metadata`, `urllib.request.url2pathname`, `pathlib`). Principle 3 holds.
+
+## Decision drivers
+
+- **The downstream gateway-fork is hard-blocked today** — drives doing this now over do-nothing: a `git+https`-github-only resolver plus a clone-anywhere fork has *no usable source at all*, and editable detection is the only mechanism that expresses "the clone, wherever it is."
+- **The source is a code-provenance boundary, not a file-write target** — drives D3 (no repo source, no cwd) and the asymmetric integrity framing: the cost of getting source wrong is running someone else's code, so the layer a hostile repo could supply is removed, not merely gated.
+- **Principle 3 (habit, not infrastructure)** — rules out a hosted registry/index/discovery service; forces runtime-resolution-plus-file-reads.
+- **No package-manager precedent for auto-persisting a one-off** — drives D4: npm/pip/cargo persist a source only via explicit config, never as a side-effect of an install.
+- **A fork must re-point with zero code edits** — drives D5's data-file-not-constant: a constant URL is dead for the gateway fork and un-substitutable per-distribution without a patch.
+- **Most users hit exactly one layer** — mitigates the one real cost (more precedence to reason about): the public user lands on layer 4, the fork on layer 3, and the table makes the order legible.
+
+## Consequences
+
+**Positive:**
+
+- A bare `agentbundle install --pack X` Just Works for both populations with **zero extra command** — the public user via the packaged GitHub default, the editable fork via clone-location-independent detection — closing RFC-0031 D7's promise.
+- The code-provenance boundary is **closed by omission, not by a gate** — there is simply no resolution layer a cloned repo or the cwd can drive, which is a stronger guarantee than a confirmation prompt and needs no new control surface.
+- A downstream fork's whole adoption story is **"blank `install-defaults.toml`, rely on editable detection"** — no patch to code, no baked path, clone anywhere.
+- Stays inside Principle 3 and adds **no dependency**: stdlib metadata + path reads only.
+
+**Negative:**
+
+- **More precedence to reason about** (four layers) than a single required arg — mitigated by the precedence table and by most users hitting one layer.
+- Detection is **install-method-dependent**: a *wheel* downstream loses layer 3 and must use explicit `--catalogue` or a bakeable source — accepted, since editable is the blessed downstream path.
+- The layer-4 default crosses the network **unauthenticated** (TOFU against `main`, no pin) — a real residual, scoped to the upstream public default and explicitly handed to an integrity-pinning follow-on.
+- The in-repo *adapter* override some users want is **deferred**, not delivered here — a known gap with its own future RFC.
+
+**Neutral / to revisit:**
+
+- **Whether layer 2 should outrank layer 3** (chosen: yes — explicit config beats auto-detection). A user who sets a stale source recovers with `config unset source`, named in the diagnostic. Revisit if real usage shows the auto-detected clone is more often the intended source than the persisted one.
+- **The `list-packs`/`list-profiles` default and integrity-pinning** stay deferred; a future RFC that backs either reopens the relevant edge of this scope (the query-defaulting edge, or the layer-4 integrity edge).
+- **The forgeable-marker residual in editable detection** is bounded, not eliminated; if a real planted-marker hijack is ever observed, the walk-up's accident-guard would need promoting to a trust control.
+
+## Confirmation
+
+- The implementing spec's acceptance criteria encode the decision — `catalogue` optional on `install`/`upgrade` (and **still required** on `list-packs`/`list-profiles`); `resolve_default_source()` walking the four layers in order and **validating** each output before handing it to the unvalidated `resolve_catalogue`; editable detection with a **real `pip install -e` construction test** plus the editable-detection hardening ACs from D2 (canonicalize-before-walk, reject non-localhost `file://` host, repo-bounded ascent, closed-interval `.git`-root match); the no-cwd and no-repo-source invariants as explicit negative criteria; `source` added to `_KNOWN_KEYS` and the user `[settings]` schema with a validator; the new `_data/install-defaults.toml`; and a clear-error AC for the all-layers-empty case — so conformance is checkable against the spec.
+- The spec-stage and diff review passes — **`security-reviewer` mandatory here** because the change crosses a code-provenance / path-and-file / supply-chain boundary, plus `adversarial-reviewer` for spec↔plan↔RFC drift — confirm that **no repo-scoped source or cwd fall-back creeps back in**, that editable detection's walk-up stays repo-bounded and canonicalized, and that the layer-4 network residual is documented rather than silently widened.
+- **Enforcement is review-time plus the existing test suite**, not a new CI gate — matching Principle 3. The ~13 adapter default-resolution tests and `tests/unit/test_resolve_user_scope_target_adapter.py` must stay green (the adapter resolver is untouched), which is the regression fence around "this changed source resolution and nothing else."
+
+## Alternatives considered
+
+- **(a) Do nothing — keep `catalogue` required.** Rejected against the **downstream-blocked** driver: the gateway-bound fork has no usable source at all, and every public install re-types the URI.
+- **(b) A single hardcoded constant.** Rejected against the **fork-must-re-point-with-zero-edits** driver: un-substitutable per-distribution without a code edit, and a constant URL is dead for the gateway fork.
+- **(c) Packaged default file only.** Rejected against the **clone-anywhere** need: substitutable by the fork, but cannot express "the clone, wherever it is" — the clone-anywhere fork still cannot bake a path.
+- **(d) Install-context detection only.** Rejected against the **public-user** need: a wheel (public PyPI) has no editable record, leaving the public user with no default.
+- **(e) The trusted layered chain (chosen).** Covers public (layer 4), editable fork (layer 3), and explicit/persistent overrides (layers 1–2) **without** a repo-supplied code-source — at the cost of more precedence, mitigated by the table.
+- **A repo-committed `source` (gated like RFC-0040's adapter-target).** Rejected against the **code-provenance-boundary** driver: source is higher-stakes than a file-write target, the downstream need is already met by editable detection, so the layer is **omitted entirely** rather than gated behind a confirmation — a stronger guarantee than a prompt.
+- **A cwd / `.` fall-back when no layer resolves.** Rejected against the same driver: fail-open to cwd is exactly the silent code-provenance escalation D3 forecloses; the terminal state is a clear error instead.
+- **Auto-persisting a one-off `--catalogue` to config.** Rejected against the **no-precedent** driver: a surprising side-effect with no package-manager analogue; `config set source` is the visible, intentional path (D4), and the adapter state-hint is *correctness*, not the convenience this would be.
+
+## References
+
+- RFC-0046 — Convenient install defaults (the accepted decision this ADR records; the five-decision set, the editable-detection spike, the options-considered table, and the asymmetric-integrity framing).
+- RFC-0031 — package-manager posture (no server, no index, no daemon; D7's "public default catalogue" this locates).
+- RFC-0011 / RFC-0012 + the adapter state-hint — the resolver cascade, and the correctness-not-convenience nature of the state-hint that justifies not auto-persisting source.
+- RFC-0040 + ADR-0030 §Risks — the untrusted-origin / confirm-before-write control for a hostile repo-root file (the precedent this ADR declines to replicate, omitting the layer instead).
+- `docs/specs/convenient-install-defaults/` — the implementing spec and plan.
+- [PEP 610](https://peps.python.org/pep-0610/) — `direct_url.json` carries `dir_info.editable` and an absolute `file://` url, and MUST NOT be created for index installs.
+- [Cargo config](https://doc.rust-lang.org/cargo/reference/config.html), [npm config](https://docs.npmjs.com/cli/v11/using-npm/config/), [pip configuration](https://pip.pypa.io/en/stable/topics/configuration/) — the layered-config-plus-baked-default prior art, and the project-over-user precedent this decision deliberately does **not** extend to `source`.
+- CHARTER Principle 3 — the habit-not-infrastructure bar this decision clears.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,6 +40,8 @@
 | 0032 | [The agentic well-architected overlay is a first-class workload-class lens applied at design *and* review — a routing axis plus progressive taxonomy on the existing `architect` skills, not a new primitive](0032-agentic-overlay-is-a-design-and-review-workload-class-lens.md) | Accepted |
 | 0033 | [The intent `Level` is reopened to an open recognized set (`product-vision › product-strategy › capability › feature`) and decoupled from `Scale` — a refinement of ADR-0019, prompt-only](0033-intent-level-open-recognized-set-decoupled-from-scale.md) | Accepted |
 | 0034 | [Grounding the infra inner loop in platform reality is toolchain-oracle doctrine + EXECUTE-loaded craft — one new `core` skill, not executable tooling, per-vendor data, or a new agent](0034-infra-grounding-toolchain-oracle-doctrine-not-tooling-vendor-data-or-agent.md) | Accepted |
+| 0035 | [Grounding the architect *design* phase in platform reality — the deferred serverless lens + a dual-consumed grounding discipline and sync-path viability check, prose-only on the existing routing axis](0035-architect-design-phase-grounded-in-platform-reality-dual-consumed-serverless-lens-and-contract-grounding.md) | Accepted |
+| 0036 | [The install-source default resolves through a trusted-by-construction precedence chain — editable detection as the downstream default, no repo-scoped source, no cwd fallback](0036-install-source-resolves-through-trusted-precedence-chain-no-repo-source-no-cwd.md) | Accepted |
 
 ## Adding a new ADR
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -975,3 +975,25 @@ deleted through. **Pre-existing**, not introduced by the preview/confirm sweep;
 listing the subtree root as the deletion unit avoids widening the divergence.
 **Unblocks when:** a hardening pass adopts the no-follow walk convention for the
 `--force` scan + delete, consistent with `commands/_common.deliver_seeds`.
+
+## convenient-install-defaults
+
+### convenient-install-defaults-followons
+
+**Spec:** [convenient-install-defaults](specs/convenient-install-defaults/spec.md)
+(final AC). Two follow-ons RFC-0046 + ADR-0036 scope **out** of the
+install-defaults work: (1) **integrity-pinning** for the layer-4 `git+https`
+catalogue fetch — today it pulls an unauthenticated GitHub-archive tarball with a
+missing ref defaulting to `main` (trust-on-first-use against the current tip, no
+checksum/signature/pin) — when built, integrity verification is partly
+SCA/supply-chain-scanner and lockfile-hash territory (artifact hashing/pinning),
+not bespoke code, so the follow-on RFC should lean on that tooling rather than
+hand-roll it; and (2) **default resolution for the discovery verbs**
+`list-packs` / `list-profiles`, which keep requiring an explicit catalogue
+because defaulting a *query* must not silently fetch the upstream URL on a
+gateway-bound fork. A third, separable item — the **in-repo *adapter* override**
+(the Claude-Code-style repo-overrides-user precedence for the projection
+*target*, distinct from the source decision) — is RFC-scoped to its own future
+RFC. **Unblocks when:** someone opens the integrity-pinning RFC (highest value —
+it closes the one network-trust residual), or a justified need for defaulting the
+query verbs appears.

--- a/docs/rfc/0046-convenient-install-defaults.md
+++ b/docs/rfc/0046-convenient-install-defaults.md
@@ -156,7 +156,7 @@ None remaining. The two prior open questions (the repo-scope settings file locat
 
 Filled in on acceptance:
 
-- ADR-NNNN: the install-source precedence chain + editable-detection-as-default + the no-repo-scoped-source / no-cwd trust decision.
-- Spec: `docs/specs/convenient-install-defaults/` — optional `catalogue` on install/upgrade, the four-layer chain, PEP 610 detection (with a real editable-install construction test + the canonicalize / repo-bounded-walk-up ACs), `_data/install-defaults.toml`, `config set source`.
+- [ADR-0036](../adr/0036-install-source-resolves-through-trusted-precedence-chain-no-repo-source-no-cwd.md): the install-source precedence chain + editable-detection-as-default + the no-repo-scoped-source / no-cwd trust decision.
+- Spec: [`docs/specs/convenient-install-defaults/`](../specs/convenient-install-defaults/spec.md) — optional `catalogue` on install/upgrade, the four-layer chain, PEP 610 detection (with a real editable-install construction test + the canonicalize / repo-bounded-walk-up ACs), `_data/install-defaults.toml`, `config set source`.
 - Adopter guide note: the private-fork "blank `install-defaults`, rely on editable detection" pattern.
 - Possible follow-on RFCs: the **in-repo adapter override** (the deferred Claude-Code-style repo-overrides-user precedence for the projection target); integrity-pinning for catalogue fetches; default resolution for the `list-packs`/`list-profiles` query verbs.

--- a/docs/specs/convenient-install-defaults/plan.md
+++ b/docs/specs/convenient-install-defaults/plan.md
@@ -1,0 +1,276 @@
+# Plan: Convenient install defaults
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Drafting
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn. When it changes substantially
+> (a different approach, not just a re-ordering), note why in the changelog
+> at the bottom.
+
+## Approach
+
+The change adds a single new resolution path in front of the existing
+`resolve_catalogue` call, plus three small data/config sources it draws from. The
+shape: build the three leaf layers first (the packaged default file, the `source`
+config key, and editable detection — all independent), then compose them in a new
+`resolve_default_source()` that the `install`/`upgrade` handlers call **only when
+`catalogue` is omitted**. The CLI change is the last, thinnest step (flip two
+positionals to `nargs="?"`) so the wiring lands on top of a tested resolver. The
+riskiest part is **editable detection** (T3): it is the keystone for the
+downstream fork and the one place a path-traversal / planted-marker mistake would
+matter, so it gets the real-`pip install -e` integration test and the hardened
+canonicalize + repo-bounded walk-up. `resolve_catalogue` is left untouched and
+unvalidating; all new validation lives in `resolve_default_source()`.
+
+## Constraints
+
+- **ADR-0036** — the four-layer trusted-by-construction chain, editable detection
+  as the downstream default, no repo-scoped source, no cwd fall-back, no
+  auto-persist, data-file (not constant) packaged default. The plan implements
+  exactly these five decisions and adds nothing past them.
+- **RFC-0046** — the decision set and the explicit follow-on boundaries
+  (`list-packs`/`list-profiles` defaulting and integrity-pinning are out of scope).
+- **RFC-0031 / CHARTER Principle 3** — runtime resolution + file reads only; no
+  server, index, or daemon; **no new dependency** (stdlib `importlib.metadata`,
+  `urllib.request`, `pathlib`, `tomllib`).
+- **RFC-0011/0012 + the adapter state-hint** — the adapter resolver and
+  `scope.DEFAULT_ADAPTER` are untouched; `source` is purely additive to the
+  `[settings]` schema.
+
+## Construction tests
+
+Most construction tests live per-task below. Cross-cutting:
+
+**Integration tests:**
+- A real `pip install -e packages/agentbundle` in an isolated venv → editable
+  detection resolves to the clone root (T3's keystone; the AC that must be
+  exercised against a real install, not a mocked `direct_url.json`).
+- End-to-end: a bare `agentbundle install --pack core` (no `--catalogue`) in
+  an editable checkout resolves and proceeds via the layer-3 → real catalogue
+  path; the same bare invocation with a planted `./` source present is **not**
+  influenced by cwd (the no-cwd invariant, exercised at the command boundary).
+
+**Manual verification:**
+- Run the built CLI's documented happy path end-to-end: `agentbundle install
+  --pack core` with no catalogue arg in (a) an editable checkout and (b) a
+  simulated wheel install with a packaged default — record the real stdout/exit
+  for each, per the work-loop's "exercise the artifact a user invokes" rule.
+
+## Design (LLD)
+
+### Design decisions
+
+- **One new resolver in front of an unchanged `resolve_catalogue`.** All
+  validation and layering lives in `resolve_default_source()`; `resolve_catalogue`
+  stays a thin `Path(uri)` / `git+https` fetcher. Rejected: validating inside
+  `resolve_catalogue` (would change the explicit-arg path's behaviour and the
+  ~13 resolution tests). Traces to: the validation + precedence ACs.
+- **Leaf layers are independent; only the composer depends on them.** Lets T1/T2/T3
+  proceed in any order and isolates the keystone (T3) for focused review.
+  Traces to: the four-layer precedence AC.
+- **Data file, not a constant, for layer 4.** A fork re-points by blanking the
+  file — zero code edit. Traces to: the packaged-default AC.
+
+### Interfaces & contracts
+
+- `resolve_default_source(explicit: str | None, *, config, dist, packaged) -> str`
+  — returns a source URI/path string, or raises a clear `CatalogueError`-style
+  error when no layer yields one. Pure over injected env (config reader, the
+  distribution metadata handle, the packaged-default reader) so it is unit-testable
+  without touching the real filesystem/metadata. Traces to: precedence +
+  clear-error ACs.
+- CLI: `catalogue` positional → `nargs="?"`, `default=None` on `install`/`upgrade`
+  only. `list-packs`/`list-profiles` unchanged. Traces to: the two CLI ACs.
+- Config: `source` joins `_KNOWN_KEYS`; `config set/get/unset source` reuse the
+  existing `write_setting`/`unset_setting`/`read_user_config` plumbing. Traces to:
+  the config round-trip AC.
+
+### Data & schema
+
+- `_data/install-defaults.toml`: `[defaults] source = "git+https://github.com/eugenelim/agent-ready-repo"`.
+  Absent/empty ⇒ no layer-4 default. Read through the same bundled-data accessor
+  the other `_data/` files use.
+- User `[settings].source`: a string URI, user scope only, validated as
+  parseable (not host-restricted — see spec Boundaries §Ask first).
+
+### Failure, edge cases & resilience
+
+- No `direct_url.json` (older pip / wheel) → skip layer 3, no error.
+- Editable detected, catalogue root not found below the repo boundary → one-line
+  stderr diagnostic, defer to layer 4.
+- Non-empty / non-localhost `file://` host → reject (do not walk).
+- Symlinked intermediate dir → canonicalize first, verify each candidate stays
+  under the resolved repo root.
+- All layers empty → clear error naming all three recovery paths; **never** cwd.
+- Stale persisted source → recover with `config unset source` (named in the error).
+
+### Quality attributes (NFRs)
+
+- **Security (code-provenance boundary):** no repo-scoped source, no cwd
+  fall-back — enforced as negative ACs and re-checked by the mandatory
+  `security-reviewer` pass (path-and-file + supply-chain + config-misconfig
+  lenses). The layer-4 network residual (unauthenticated TOFU against `main`) is
+  documented and handed to the integrity-pinning follow-on, not silently widened.
+  Traces to: the no-cwd / no-repo-source negative ACs and the deferred-followon AC.
+
+## Tasks
+
+### T1: Packaged `_data/install-defaults.toml` (layer 4)
+
+**Depends on:** none
+
+**Tests:**
+- Goal-based: the file ships in the wheel and reads back via the existing
+  bundled-data accessor with `[defaults].source` == the upstream GitHub URL.
+- Unit: an absent/empty file yields `None` (no layer-4 default) — the private-fork
+  case.
+
+**Approach:**
+- Add `agentbundle/_data/install-defaults.toml` with the `[defaults] source` key.
+- Add a small reader (mirroring how `adapter.toml`/schemas are read) returning the
+  source string or `None`.
+
+**Done when:** the bundled-data accessor returns the upstream URL from a built
+wheel, and `None` from a blanked file. Verifies the packaged-default AC.
+
+### T2: `source` key in the user `[settings]` schema + validator (layer 2 plumbing)
+
+**Depends on:** none
+
+**Tests:**
+- Unit: `source` is in `_KNOWN_KEYS`; `config set source <uri>` writes it,
+  `config get source` reads it back, `config unset source` removes it
+  (extend `test_config_cmd.py` / `test_user_config_io.py`).
+- Unit: an unknown key is still refused; a malformed `source` value is rejected
+  by `_validate_key_value` (parseable-URI check only — no host allowlist).
+- Regression: `adapter` validation and the config-cascade tests stay green.
+
+**Approach:**
+- Add `"source"` to `_KNOWN_KEYS` and the `UserConfig` dataclass; add a `source`
+  branch to `_validate_key_value` (parseable URI). User scope only.
+
+**Done when:** `config set/get/unset source` round-trips and the adapter path is
+untouched. Verifies the config-key AC.
+
+### T3: Editable detection (layer 3) — the keystone
+
+**Depends on:** none
+
+**Tests:**
+- Integration (keystone): a real `pip install -e packages/agentbundle` in an
+  isolated venv → detection reads the real `direct_url.json` and walks to the
+  real clone root (the dir with `packs/` + `.claude-plugin/marketplace.json`).
+  **Not** a mocked record.
+- Unit: missing `direct_url.json` → `None`, no error.
+- Unit: `dir_info.editable == false` → `None`.
+- Unit: a non-empty / non-localhost `file://` host → rejected.
+- Unit: a `packs/` + `marketplace.json` pair planted in a parent **above** the
+  `.git` root is **not** matched (repo-bounded ascent); a pair in an intermediate
+  dir *inside* the clone stops the walk at first match (accident-guard residual,
+  documented).
+- Unit: the **catalogue-root == git-root** case resolves (closed-interval bound —
+  the `.git`-root dir itself is a legal match), not falls through to layer 4.
+- Unit: the matched root is a **canonicalized descendant-or-equal** of
+  `Path.resolve()` of the parsed editable URL — a `..`/symlink in the recorded
+  URL cannot make the match escape the clone.
+- Unit: a symlinked intermediate dir is canonicalized before the under-root check.
+
+**Approach:**
+- Read `importlib.metadata.distribution("agentbundle").read_text("direct_url.json")`;
+  parse JSON; gate on `dir_info.editable`.
+- Parse the `file://` url with `urllib.request.url2pathname` + percent-decode;
+  reject a non-empty/non-localhost host.
+- `Path.resolve()`; compute the enclosing `.git` root (file or dir); walk up over
+  canonicalized ancestors to the first with both markers, never above the repo
+  root.
+- Return the catalogue root, or `None` (with the stderr diagnostic when editable
+  was detected but no root found below the boundary).
+
+**Done when:** the keystone integration test passes against a real editable
+install and every negative/hardening unit test is green. Verifies the editable
+detection, walk-up-bound, `file://`-host, and fall-back-with-diagnostic ACs.
+
+### T4: `resolve_default_source()` — compose the four layers
+
+**Depends on:** T1, T2, T3
+
+**Tests:**
+- Unit: precedence — with all four layers populated, layer 1 wins; remove it,
+  layer 2 wins; remove it, layer 3; remove it, layer 4 (table-driven).
+- Unit: layer 2 outranks layer 3 (explicit config beats auto-detection).
+- Unit: an invalid layer output (bad-marker path / unparseable URI) is **skipped**,
+  not passed to `resolve_catalogue`.
+- Unit (scheme validation): a `file://` / `http://` / other-scheme source from
+  layer 2 or layer 4 is **rejected** (only `git+https` and a local path pass),
+  distinct from the deferred host allowlist.
+- Unit: all layers empty → the clear error naming all three recovery paths.
+- Unit (negative invariants): a planted `./` cwd source is never consulted; there
+  is no repo-scoped layer to consult.
+- Unit/integration (no-write): the user config file is **byte-unchanged** after a
+  bare `install` resolves through layers 2/3/4, and on the editable-deferred and
+  all-layers-empty paths — a future regression that persisted the resolved source
+  fails here.
+
+**Approach:**
+- Compose layers 1→4, first non-`None` validated result wins; validate path
+  sources (markers present) and URI sources (parseable) before returning.
+- Raise the clear `no catalogue source: …` error on exhaustion.
+
+**Done when:** the precedence table, validation-skip, negative-invariant, and
+clear-error tests are all green. Verifies the precedence + validation + no-cwd +
+clear-error ACs.
+
+### T5: CLI wiring — optional `catalogue` on install/upgrade
+
+**Depends on:** T4
+
+**Tests:**
+- Goal-based: argparse accepts a bare `install --pack X` and `upgrade` (no
+  catalogue); `list-packs` / `list-profiles` still reject a bare invocation.
+- Unit: an explicit `--catalogue`/positional passes through unchanged (the
+  default path does not run).
+- Integration: a bare `install --pack core` in an editable checkout resolves via
+  layer 3 and proceeds (end-to-end happy path); the same is unaffected by a
+  planted `./` source (no-cwd, at the command boundary).
+- Regression: `test_resolve_user_scope_target_adapter.py` and the ~13 adapter
+  resolution tests stay green.
+
+**Approach:**
+- `cli.py`: `install` (`:247`) and `upgrade` (`:400`) catalogue → `nargs="?"`,
+  `default=None`. `list-packs` (`:197`) / `list-profiles` (`:205`) unchanged.
+- `commands/install.py` + `commands/upgrade.py`: when `args.catalogue is None`,
+  call `resolve_default_source(...)` and feed the result to `resolve_catalogue`;
+  otherwise pass the explicit arg straight through.
+
+**Done when:** a bare `install`/`upgrade` resolves and runs end-to-end, the
+discovery verbs still require a catalogue, and the explicit-arg path is byte-for-
+byte unchanged. Verifies the two CLI ACs and the end-to-end happy-path.
+
+## Rollout
+
+- **Delivery:** big-bang, fully backward compatible — an explicit `--catalogue`
+  behaves identically; the only new behaviour is on the previously-erroring
+  no-arg case. No flag, no migration. Reversible by reverting the PR.
+- **Infrastructure:** none (Principle 3 — runtime resolution + file reads).
+- **External-system integration:** none new; layer 4 reuses the existing
+  unauthenticated `git+https` GitHub fetch.
+- **Deployment sequencing:** none — single PR, no ordering dependency. The
+  `_data/install-defaults.toml` ships in the same wheel as the resolver that
+  reads it.
+
+## Risks
+
+- **Editable-detection traversal mistakes** (the keystone) — mitigated by the
+  real-`pip install -e` integration test, the canonicalize + repo-bounded ascent,
+  and the mandatory `security-reviewer` pass.
+- **Accidental cwd / repo-source regression** in a later refactor — mitigated by
+  the explicit negative ACs and tests, which fail loudly if a cwd/repo layer is
+  reintroduced.
+- **Layer-4 network residual** (unauthenticated TOFU against `main`) — known and
+  scoped to the upstream public default; integrity-pinning is a named follow-on,
+  not silently widened here.
+
+## Changelog
+
+- 2026-06-25: initial plan (authored alongside spec + ADR-0036 from RFC-0046).

--- a/docs/specs/convenient-install-defaults/spec.md
+++ b/docs/specs/convenient-install-defaults/spec.md
@@ -1,0 +1,217 @@
+# Spec: Convenient install defaults
+
+- **Status:** Approved
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** ADR-0036, RFC-0046; honours RFC-0031, RFC-0011/0012, RFC-0040 + ADR-0030
+- **Contract:** none (CLI behaviour change to an existing command; no new API surface under `contracts/`)
+- **Shape:** service
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+A user installing or upgrading packs should not have to spell out a catalogue
+source on every command, and a downstream org fork behind an API gateway should
+have a source it can actually point at. Today `catalogue` is a required
+positional on `install`/`upgrade` with no default: the public PyPI user re-types
+the same GitHub URI every time, and the gateway-bound editable fork has *no*
+usable source — the resolver is `github.com`-only, the gateway blocks the
+internal URL, and a fixed path can't be baked because every machine clones
+elsewhere. Success is a bare `agentbundle install --pack X` that resolves a
+sensible source with **zero extra command** for both populations — the public
+user (→ the packaged GitHub default) and the editable fork (→ its own local
+clone, wherever cloned) — while **never** letting a cloned repo or the current
+working directory decide where executable code is fetched from. An explicit
+`--catalogue` always overrides; a user's own `config set source` overrides
+auto-detection.
+
+## Boundaries
+
+The three-tier guard that keeps an implementing agent inside the lines.
+
+### Always do
+
+- Resolve a default **only** through the four trusted-by-construction layers, in
+  order, first-match-wins: `--catalogue` arg › user `[settings].source` ›
+  editable detection (PEP 610) › packaged `_data/install-defaults.toml`.
+- **Validate** each layer's output in `resolve_default_source()` before handing
+  it to `resolve_catalogue` (markers present for a path; parseable URI) —
+  `resolve_catalogue` itself does no validation (`catalogue.py:72` returns
+  `Path(uri)` unconditionally).
+- Keep an explicit `--catalogue` arg behaving **identically** to today
+  (backward compatible); the default path only runs when the arg is omitted.
+- Canonicalize (`Path.resolve()`) before walking, and **bound the editable
+  walk-up to the enclosing `.git` repository root**, computed before any marker
+  test.
+- Emit a one-line stderr **diagnostic** when editable is detected but no
+  catalogue root is found at/below the repo boundary, then defer to layer 4.
+
+### Ask first
+
+- Adding a **host** allowlist to the `source` validator (beyond the in-scope
+  scheme check) — the RFC scopes the network layer as the upstream public default
+  and flags integrity work as a separate follow-on; a host allowlist is a
+  policy call, not part of this spec. (Scheme validation *is* in scope — see
+  Acceptance Criteria.)
+
+### Never do
+
+- **Never** add a repo-scoped / repo-committed `source` layer. The source is a
+  code-provenance boundary; the layer is omitted entirely (ADR-0036 D3), not
+  gated behind a confirmation.
+- **Never** fall back to `.`/cwd, or to any path the user did not explicitly
+  supply, configure, or `pip install -e`. The only terminal states are a
+  validated source or a clear error.
+- **Never** auto-persist a one-off `--catalogue` (or any resolved layer) back to
+  config — resolution is stateless; `config set source` is the only write path
+  (ADR-0036 D4).
+- **Never** default the catalogue on the discovery verbs `list-packs` /
+  `list-profiles` — they keep requiring an explicit catalogue (follow-on).
+- **Never** touch the adapter resolver (`scope.DEFAULT_ADAPTER`, the user-config
+  adapter layer) — `source` is added *alongside* `adapter`, nothing else moves.
+- **Never** treat the two editable-detection markers (`packs/` +
+  `marketplace.json`) as a trust control — they are a forgeable accident-guard;
+  the trust comes from the canonicalize + stop-at-first + repo-bounded-ascent
+  rules.
+
+## Testing Strategy
+
+- **Layer precedence + validation + the no-cwd / no-repo-source invariants:**
+  **TDD**. These are pure resolution logic over a stubbed environment
+  (a fake `direct_url.json`, a tmp config, a tmp packaged default) with a
+  compressible invariant — the canonical case for red-green-refactor.
+- **Editable detection against a real `pip install -e`:** **manual QA exercised
+  by an integration test**. The keystone the RFC de-risked by spike; verify it
+  against a *real* editable install in an isolated venv (the artifact a user
+  actually runs), reading the real `direct_url.json` and walking to the real
+  clone root — not a mock of the metadata.
+- **CLI wiring (`catalogue` optional on `install`/`upgrade`, still required on
+  `list-packs`/`list-profiles`):** **goal-based check** — argparse accepts a
+  bare `install --pack X` and rejects a bare `list-packs`; verify by invoking
+  the parser, no production test file beyond the per-task assertions.
+- **`config set/unset/get source` round-trip:** **goal-based check** exercised by
+  the existing config-command test shape (`test_config_cmd.py`,
+  `test_user_config_io.py`).
+- **Packaging (`_data/install-defaults.toml` ships in the wheel):** **goal-based
+  check** — read it back through the same bundled-data accessor the other
+  `_data/` files use.
+
+These verification modes are the *altitude* of each check; the editable-detection
+behaviour only proves out across the install boundary, so it is named at
+**integration** surface.
+
+## Acceptance Criteria
+
+- [ ] `catalogue` is `nargs="?"` (default `None`) on the `install` and `upgrade`
+  subparsers (`cli.py:247`, `:400`); an explicit `--catalogue`/positional value
+  passes through to `resolve_catalogue` unchanged.
+- [ ] `catalogue` **remains a required positional** on `list-packs` (`cli.py:197`)
+  and `list-profiles` (`cli.py:205`); a bare invocation of either errors.
+- [ ] When `catalogue` is omitted on `install`/`upgrade`, the handler calls a
+  shared `resolve_default_source()` whose result feeds `resolve_catalogue`.
+- [ ] `resolve_default_source()` resolves the four layers highest-first,
+  first-match-wins: (1) `--catalogue` arg, (2) user `[settings].source`,
+  (3) editable detection, (4) packaged `_data/install-defaults.toml`. Layer 2
+  outranks layer 3 (an explicit `config set source` beats auto-detection).
+- [ ] Each layer's output is **validated** before use — a path source has both
+  markers present; a URI source is parseable **and uses only a scheme
+  `resolve_catalogue` understands** (`git+https` or a local path), so a `file://`,
+  `http://`, or other-scheme source (set via `config set source` or baked into a
+  forked `install-defaults.toml`) is **rejected**, distinct from the deferred
+  host allowlist. The discriminator is explicit: a **schemeless** local path
+  (`/abs/path`, `./rel`) is the local-path branch and is accepted; the gate
+  rejects a URL that carries a scheme other than `git+https`. An invalid layer is
+  skipped, not passed to the unvalidated `resolve_catalogue`.
+- [ ] Editable detection reads
+  `importlib.metadata.distribution("agentbundle").read_text("direct_url.json")`;
+  it activates **only** when the record is present **and**
+  `dir_info.editable == true`. A missing record (older pip, or a wheel install)
+  falls through to layer 4 with no error.
+- [ ] Editable detection parses the `file://` `url` with the standard parser
+  (`urllib.request.url2pathname` + percent-decoding) and **rejects** a
+  non-empty / non-localhost `file://` host.
+- [ ] Editable detection **canonicalizes** the path (`Path.resolve()`) and walks
+  up over canonicalized ancestors to the **first** one containing both `packs/`
+  and `.claude-plugin/marketplace.json`, verifying each candidate stays under
+  the resolved repository root.
+- [ ] The repository root and every candidate are **canonicalized descendants-or-
+  equal of `Path.resolve()` of the parsed editable `file://` URL** — so a symlink
+  or `..` in the recorded URL cannot make the matched root resolve *outside* the
+  clone the user `pip install -e`'d (the "inside the clone" precondition the
+  forgeable-marker residual rests on is enforced, not assumed).
+- [ ] The walk-up ascent is **bounded by the enclosing `.git` repository root**
+  (nearest ancestor with a `.git` file *or* directory), computed before any
+  marker test — a `packs/` + `marketplace.json` pair planted in a shared parent
+  *above* the clone is never matched.
+- [ ] The bound is a **closed interval**: the `.git`-root directory **itself** is
+  a legal marker-match candidate (the catalogue root coincides with the git root,
+  so the only valid match sits *at* the boundary). The catalogue-root == git-root
+  case resolves rather than falling through to layer 4.
+- [ ] A real `pip install -e packages/agentbundle` in an isolated venv resolves,
+  via editable detection, to the clone root (the dir holding `packs/` +
+  `.claude-plugin/marketplace.json`) — verified end-to-end, not against a mocked
+  `direct_url.json`. (the construction-test keystone)
+- [ ] When editable is detected but **no** catalogue root is found at/below the
+  repo boundary (e.g. a sparse checkout missing `packs/`), the resolver emits a
+  one-line stderr diagnostic naming what happened and defers to layer 4 — never
+  silent, never a hard error on a default, never the cwd.
+- [ ] **No resolution layer ever resolves from `.`/cwd**, and **no repo-scoped
+  `source` layer exists** — asserted as explicit negative criteria (a planted
+  cwd source / repo-root source is not consulted).
+- [ ] When **no** layer yields a source, the command errors clearly with text
+  naming all three recovery paths:
+  `no catalogue source: pass --catalogue, run 'agentbundle config set source …', or pip install -e the catalogue`.
+- [ ] Resolution writes nothing on **any** path — a one-off `--catalogue` (or any
+  auto-resolved layer) does **not** persist to the user config (no
+  write-on-install), including the editable-detected-but-deferred (diagnostic) and
+  all-layers-empty (error) paths.
+- [ ] `source` is added to `_KNOWN_KEYS` and the user `[settings]` schema
+  (`user_config.py`) alongside `adapter`, **user scope only**; `config set
+  source <uri>`, `config get source`, and `config unset source` round-trip, and
+  the unset path is named in the all-layers-empty diagnostic.
+- [ ] A new packaged `_data/install-defaults.toml` ships in the wheel via the
+  existing `[tool.setuptools.package-data]` `agentbundle = ["_data/*"]` wiring,
+  declaring
+  `[defaults] source = "git+https://github.com/eugenelim/agent-ready-repo"`;
+  an absent or empty file means no layer-4 default (the private-fork pattern).
+- [ ] The adapter resolver is unchanged: the ~13 adapter default-resolution tests
+  and `tests/unit/test_resolve_user_scope_target_adapter.py` stay green.
+- [ ] Integrity-pinning for the layer-4 `git+https` fetch, and default resolution
+  for `list-packs`/`list-profiles`, are **not** implemented here (deferred:
+  convenient-install-defaults-followons).
+
+## Assumptions
+
+- Technical: `pip install -e` records an absolute `file://` URL with
+  `dir_info.editable == true` per PEP 610, and the catalogue root is locatable by
+  a repo-bounded walk-up from the recorded editable-package path (source: RFC-0046
+  §Evidence spike; PEP 610).
+- Security: `direct_url.json` (in the venv's `*.dist-info/`, outside the clone) is
+  the layer-3 trust anchor and is **user-writable** — at the same trust level as
+  the clone itself. Its tampering is an **accepted residual**: anything running as
+  the user can already redirect their own install, and layers 1–3 are "local
+  trust" precisely on that basis. Named here so it is in-the-accepted-residual,
+  not silently assumed unwritable (source: probe — `dist-info` is user-writable;
+  RFC-0046 §Risks trust model).
+- Technical: `resolve_catalogue` accepts a local path but performs **no**
+  existence/marker validation — so `resolve_default_source()` must validate
+  before calling it (source: probe `catalogue.py:55-72`, confirmed 2026-06-25).
+- Technical: the user config file is OS-conventional, **not** a fixed
+  `~/.config/...` path — `~/Library/Application Support/agentbundle/config.toml`
+  (macOS), `%APPDATA%/agentbundle/config.toml` (Windows),
+  `$XDG_CONFIG_HOME` / `~/.config/agentbundle/config.toml` (Linux); the `source`
+  key joins the same `[settings]` table as `adapter` (source: probe
+  `user_config.py:35,56-79`, confirmed 2026-06-25 — corrects the RFC prose's
+  `~/.config` shorthand).
+- Technical: `_data/*` is already packaged by `pyproject.toml`'s
+  `[tool.setuptools.package-data]`, so a new `install-defaults.toml` is picked up
+  with no packaging change (source: probe `pyproject.toml`, confirmed 2026-06-25).
+- Technical: the catalogue root coincides with the git root (the `packs/` +
+  `marketplace.json` markers sit at the `.git` directory); a catalogue nested in a
+  larger repo or vendored as a submodule is out of scope for editable detection
+  and falls through to layer 4 (source: RFC-0046 §Key assumptions).
+- Process: implementation lands as a **separate PR**; this PR delivers only the
+  ADR + spec + plan (source: user direction 2026-06-25; RFC-0046 §Follow-on
+  artifacts).


### PR DESCRIPTION
## What

Authors the follow-on artifacts RFC-0046 (convenient install defaults, Accepted) names on acceptance: **ADR-0036** recording the install-source precedence decision, and the implementing **spec + plan** under `docs/specs/convenient-install-defaults/`. No production code — implementation lands in a separate PR, as the RFC scopes it.

## Why

RFC-0046 was accepted with `ADR-NNNN` / spec-path placeholders in its "Filled in on acceptance" section. This closes them out so the decision has a recorded ADR and a buildable spec/plan the implementation PR can execute against.

## Decision recorded (ADR-0036)

- The four-layer **trusted-by-construction** source chain: `--catalogue` arg › user `[settings].source` › editable detection (PEP 610) › packaged `_data/install-defaults.toml`.
- **Editable-detection-as-downstream-default** (clone-anywhere via PEP 610 `direct_url.json` + a canonicalize / repo-bounded closed-interval walk-up).
- The **no-repo-scoped-source / no-cwd** trust call — the security-load-bearing decision: source is a code-provenance boundary, so the layer a hostile repo could supply is *omitted entirely* rather than gated like RFC-0040's adapter-target.
- **No auto-persist** (`config set source` is the only write path) and a **data-file (not constant)** packaged default with an asymmetric integrity posture (layer 4 is the one unauthenticated network path; integrity-pinning is a named follow-on).

## Spec / plan

`spec.md` (**Approved**) + `plan.md` cover optional `catalogue` on `install`/`upgrade` (still required on `list-packs`/`list-profiles`), the validated four-layer `resolve_default_source()`, PEP 610 editable detection with a **real `pip install -e` construction test**, the canonicalize + repo-bounded closed-interval walk-up, scheme validation (reject `file://`/`http://`), the `source` config key, and `_data/install-defaults.toml`. Five tasks (T1–T5) with tests-first.

## Review

Authored through the work-loop in full mode (governance + code-provenance boundary).

- `adversarial-reviewer` (spec/plan drift) — **Clean**.
- `security-reviewer` (spec-stage secure-design, code-provenance boundary) — **Clean**; tightened the walk-up to a closed-interval `.git`-root match with canonicalized-descendant containment, added in-scope scheme validation, named `direct_url.json` as an accepted user-writable trust residual, and added no-write-on-install test coverage.
- `design-reviewer` (ADR) — SHIP WITH CHANGES; minors applied. Its one Major (a claim that `cli.py:247` was the `--profile` help line) was **a verified false positive** — `grep` confirms 247 is the install `catalogue` positional; overridden.

A grounding pass also corrected the RFC's `~/.config` shorthand: the config path is OS-conventional (`~/Library/Application Support/...` on macOS) — captured in the spec's Assumptions.

## Bundled fixes

- `docs/adr/README.md`: add the 0036 index row; restore the missing **0035** row (pre-existing index drift).
- `docs/backlog.md`: add the `convenient-install-defaults-followons` heading the spec's deferral anchor resolves to.
- `docs/rfc/0046-convenient-install-defaults.md`: fill the "Filled in on acceptance" ADR/spec placeholders with real links.

## Deferred

- design-reviewer's "Consulted paragraph too long" Minor — the long prose `Consulted:` matches the house style ADR-0035 established.
