### PR TITLE
feat(cli): default the catalogue source for install/upgrade and list-packs/list-profiles (RFC-0046 + RFC-0047)

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -126,6 +126,21 @@ jobs:
           tests/integration/test_install_profile.py
           tests/integration/test_install_profile_live.py
 
+      # convenient-install-defaults (RFC-0046): the four-layer source resolver,
+      # the `source` config key, the optional-catalogue CLI surface, and the
+      # keystone editable-detection test (a real `pip install -e` in a throwaway
+      # venv). make build-check runs no pytest, so wire these paths explicitly.
+      - name: pytest convenient-install-defaults (RFC-0046)
+        working-directory: packages/agentbundle
+        run: >-
+          python -m pytest
+          tests/unit/test_source_defaults.py
+          tests/unit/test_user_config_source.py
+          tests/unit/test_cli_catalogue_optional.py
+          tests/unit/test_config_cmd.py
+          tests/integration/test_install_default_source.py
+          tests/integration/test_editable_source_detection.py
+
       # credbroker-user-scope T1: consumer bootstraps append the vendored
       # ~/.agentbundle/lib floor at LOWEST sys.path precedence. The
       # no-insert-0 source guard enforces the spec's "never prepend"

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Behind `core` is a **catalogue of kits** — research, integration contract auth
 # Install the CLI (one-time)
 pip install agentbundle
 
-# See the catalogue (discovery verbs take an explicit catalogue)
-agentbundle list-packs git+https://github.com/eugenelim/agent-ready-repo
+# See the catalogue (bare uses the default; or name one explicitly)
+agentbundle list-packs
 
 # Install the flagship loop into this repo
 agentbundle install --pack core
@@ -50,7 +50,7 @@ agentbundle install --pack core --dry-run
 
 `--dry-run` previews every file before anything is written — one line per file (skills, the four reviewer/executor subagents, the hooks), then a `create`/`overwrite` summary count — so you see exactly what would land in your repo.
 
-Install and upgrade default to this catalogue when you don't name one; pass an explicit catalogue (a git URL or local path) as a trailing argument to install from elsewhere, or `agentbundle config set source <catalogue>` to change the default (an editable `pip install -e` clone defaults to itself). Installs auto-detect your agent (`--adapter` overrides). Repo scope writes into the current repo; user scope (`--scope user`) installs once into your home so the pack is available everywhere.
+Every source verb — `install`, `upgrade`, `list-packs`, `list-profiles` — defaults to this catalogue when you don't name one; pass an explicit catalogue (a git URL or local path) as a trailing argument to use a different one, or `agentbundle config set source <catalogue>` to change the default (an editable `pip install -e` clone defaults to itself). Installs auto-detect your agent (`--adapter` overrides). Repo scope writes into the current repo; user scope (`--scope user`) installs once into your home so the pack is available everywhere.
 
 ## The loop
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ The leverage in agent coding moved from the prompt to the **loop** — it plans,
 
 ```bash
 pip install agentbundle
-agentbundle install --pack core git+https://github.com/eugenelim/agent-ready-repo
+agentbundle install --pack core
 ```
 
-One line lands the loop in your repo. Any agent that reads a skill file inherits it: Claude Code, Codex, Cursor, Copilot, Gemini, Kiro.
+One line lands the loop in your repo — no catalogue argument needed; it defaults to this catalogue. Any agent that reads a skill file inherits it: Claude Code, Codex, Cursor, Copilot, Gemini, Kiro.
 
 Behind `core` is a **catalogue of kits** — research, integration contract authoring, solution architecture, product shaping, and more — each a cohesive set of skills, subagents, and hooks that delivers one whole job, installed one line at a time. [See the catalogue.](#the-catalogue)
 
@@ -29,28 +29,28 @@ Behind `core` is a **catalogue of kits** — research, integration contract auth
 # Install the CLI (one-time)
 pip install agentbundle
 
-# See the catalogue
+# See the catalogue (discovery verbs take an explicit catalogue)
 agentbundle list-packs git+https://github.com/eugenelim/agent-ready-repo
 
 # Install the flagship loop into this repo
-agentbundle install --pack core git+https://github.com/eugenelim/agent-ready-repo
+agentbundle install --pack core
 
 # Install a pack at user scope — follows you across every project
-agentbundle install --pack research git+https://github.com/eugenelim/agent-ready-repo --scope user
+agentbundle install --pack research --scope user
 
 # Install a whole curated profile in one command
-agentbundle install --profile solution-architect git+https://github.com/eugenelim/agent-ready-repo
+agentbundle install --profile solution-architect
 
 # Upgrade a pack to the catalogue's version (asks before writing; --yes for CI)
-agentbundle upgrade --pack core git+https://github.com/eugenelim/agent-ready-repo
+agentbundle upgrade --pack core
 
 # Preview any install without writing a file
-agentbundle install --pack core git+https://github.com/eugenelim/agent-ready-repo --dry-run
+agentbundle install --pack core --dry-run
 ```
 
 `--dry-run` previews every file before anything is written — one line per file (skills, the four reviewer/executor subagents, the hooks), then a `create`/`overwrite` summary count — so you see exactly what would land in your repo.
 
-The catalogue is a git URL or local path. Installs auto-detect your agent (`--adapter` overrides). Repo scope writes into the current repo; user scope (`--scope user`) installs once into your home so the pack is available everywhere.
+Install and upgrade default to this catalogue when you don't name one; pass an explicit catalogue (a git URL or local path) as a trailing argument to install from elsewhere, or `agentbundle config set source <catalogue>` to change the default (an editable `pip install -e` clone defaults to itself). Installs auto-detect your agent (`--adapter` overrides). Repo scope writes into the current repo; user scope (`--scope user`) installs once into your home so the pack is available everywhere.
 
 ## The loop
 

--- a/docs/adr/0036-install-source-resolves-through-trusted-precedence-chain-no-repo-source-no-cwd.md
+++ b/docs/adr/0036-install-source-resolves-through-trusted-precedence-chain-no-repo-source-no-cwd.md
@@ -69,7 +69,7 @@ Boundaries on the decision:
 **Neutral / to revisit:**
 
 - **Whether layer 2 should outrank layer 3** (chosen: yes — explicit config beats auto-detection). A user who sets a stale source recovers with `config unset source`, named in the diagnostic. Revisit if real usage shows the auto-detected clone is more often the intended source than the persisted one.
-- **The `list-packs`/`list-profiles` default and integrity-pinning** stay deferred; a future RFC that backs either reopens the relevant edge of this scope (the query-defaulting edge, or the layer-4 integrity edge).
+- **The `list-packs`/`list-profiles` default and integrity-pinning** stay deferred; a future RFC that backs either reopens the relevant edge of this scope (the query-defaulting edge, or the layer-4 integrity edge). *(Update 2026-06-25: the **query-defaulting edge is reopened and decided by RFC-0047** — the discovery verbs now default through the same chain, because a gateway-bound fork is editable and resolves via layer 3, so a bare query never silently fetches upstream. The **layer-4 integrity edge stays deferred**.)*
 - **The forgeable-marker residual in editable detection** is bounded, not eliminated; if a real planted-marker hijack is ever observed, the walk-up's accident-guard would need promoting to a trust control.
 
 ## Confirmation

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -981,19 +981,18 @@ listing the subtree root as the deletion unit avoids widening the divergence.
 ### convenient-install-defaults-followons
 
 **Spec:** [convenient-install-defaults](specs/convenient-install-defaults/spec.md)
-(final AC). Two follow-ons RFC-0046 + ADR-0036 scope **out** of the
-install-defaults work: (1) **integrity-pinning** for the layer-4 `git+https`
+(final AC). One follow-on RFC-0046 + ADR-0036 still scope **out** of the
+install-defaults work: **integrity-pinning** for the layer-4 `git+https`
 catalogue fetch — today it pulls an unauthenticated GitHub-archive tarball with a
 missing ref defaulting to `main` (trust-on-first-use against the current tip, no
 checksum/signature/pin) — when built, integrity verification is partly
 SCA/supply-chain-scanner and lockfile-hash territory (artifact hashing/pinning),
 not bespoke code, so the follow-on RFC should lean on that tooling rather than
-hand-roll it; and (2) **default resolution for the discovery verbs**
-`list-packs` / `list-profiles`, which keep requiring an explicit catalogue
-because defaulting a *query* must not silently fetch the upstream URL on a
-gateway-bound fork. A third, separable item — the **in-repo *adapter* override**
-(the Claude-Code-style repo-overrides-user precedence for the projection
-*target*, distinct from the source decision) — is RFC-scoped to its own future
-RFC. **Unblocks when:** someone opens the integrity-pinning RFC (highest value —
-it closes the one network-trust residual), or a justified need for defaulting the
-query verbs appears.
+hand-roll it. (**Resolved 2026-06-25:** the second item — **default resolution
+for the discovery verbs** `list-packs` / `list-profiles` — shipped under
+**RFC-0047**; a gateway-bound fork is editable and resolves via layer 3, so a
+bare query never silently fetches upstream.) A separable item — the **in-repo
+*adapter* override** (the Claude-Code-style repo-overrides-user precedence for the
+projection *target*, distinct from the source decision) — is RFC-scoped to its own
+future RFC. **Unblocks when:** someone opens the integrity-pinning RFC (highest
+value — it closes the one network-trust residual).

--- a/docs/rfc/0047-default-source-on-discovery-verbs.md
+++ b/docs/rfc/0047-default-source-on-discovery-verbs.md
@@ -1,0 +1,42 @@
+# RFC-0047: Default the catalogue source on the discovery verbs (`list-packs` / `list-profiles`)
+
+- **Status:** Accepted <!-- Draft | Open | Final Comment Period | Accepted | Rejected | Withdrawn | Experimental -->
+- **Author:** eugenelim
+- **Approver:** eugenelim
+- **Date opened:** 2026-06-25
+- **Date closed:** 2026-06-25
+- **Related:** RFC-0046 + ADR-0036 (the four-layer source-resolution chain this RFC reuses unchanged; both named this as a follow-on), RFC-0031 (package-manager posture)
+
+## The ask
+
+- **Recommendation (BLUF):** Make `catalogue` **optional** (`nargs="?"`, default `None`) on `list-packs` and `list-profiles` too, resolving the omitted source through the **same** `resolve_default_source` four-layer chain RFC-0046 shipped for `install`/`upgrade`. No new resolver, no new layer — purely extend the existing `resolve_catalogue_uri(args)` wiring to the two query handlers. An explicit positional still passes through unchanged.
+- **Why now (SCQA):**
+  - *Situation* — RFC-0046 made the source default on `install`/`upgrade`; `list-packs`/`list-profiles` were deferred as a follow-on because "defaulting a *query* needs its own justification and must not silently fetch the upstream URL on a gateway-bound fork."
+  - *Complication* — having `install --pack core` work bare while `list-packs` still demands the full URL is an asymmetry users hit immediately (you list a catalogue to decide what to install from it).
+  - *Question* — can the deferral's one safety requirement ("must not silently fetch upstream on a gateway-bound fork") be met while defaulting the query verbs?
+
+## Decision
+
+Extend the RFC-0046 resolution to the two discovery verbs. `catalogue` becomes `nargs="?"` (default `None`) on `list-packs` and `list-profiles`; when omitted, each handler calls the existing `commands/_common.resolve_catalogue_uri(args)` before `resolve_catalogue`, exactly as `install`/`upgrade` do. The four-layer chain, its validation, and the editable-detection hardening are reused verbatim — this RFC adds no resolution logic.
+
+## Why this is safe (the justification the deferral demanded)
+
+The deferral's concrete requirement was: **a bare discovery query must not silently fetch the upstream URL on a gateway-bound fork.** The shipped design already satisfies it:
+
+- A gateway-bound fork is an **editable install** (the blessed downstream path, RFC-0046). A bare `list-packs` on it resolves via **layer 3** (its own clone) → **no upstream fetch**.
+- The only case that reaches layer 4 (the `git+https` upstream) on a bare query is a **non-editable wheel** install — i.e. the public PyPI user, for whom fetching the upstream catalogue is the *expected* behaviour and is identical to the bare `install` they already run.
+
+So the editable-detection layer is exactly the control that makes query-defaulting safe; the deferral was conservatism pending this justification, not an unmet design gap.
+
+## Residual / accepted
+
+- On a **wheel** install, a bare `list-packs` now performs a network fetch where it previously errored with "catalogue required." This is surfaced, not silent (the same layer-4 `git+https` fetch a bare `install` performs), and is the symmetric, expected behaviour under the default-catalogue model RFC-0046 established. The unauthenticated-TOFU integrity residual is unchanged and still tracked by the separate integrity-pinning follow-on.
+
+## Scope
+
+- **In:** `catalogue` optional on `list-packs`/`list-profiles`; reuse of `resolve_catalogue_uri`.
+- **Out:** integrity-pinning for the layer-4 fetch (still deferred — its own follow-on); any change to the resolver itself; the in-repo adapter override (its own RFC).
+
+## Supersedes-in-part
+
+ADR-0036's "the discovery verbs keep requiring an explicit catalogue (deferred)" — the query-defaulting edge is reopened and decided here; the layer-4 integrity edge stays deferred. ADR-0036 is annotated accordingly.

--- a/docs/specs/convenient-install-defaults/plan.md
+++ b/docs/specs/convenient-install-defaults/plan.md
@@ -1,7 +1,7 @@
 # Plan: Convenient install defaults
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Drafting
+- **Status:** Shipped
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
 > document is allowed to change as you learn. When it changes substantially
@@ -142,16 +142,29 @@ wheel, and `None` from a blanked file. Verifies the packaged-default AC.
 - Unit: `source` is in `_KNOWN_KEYS`; `config set source <uri>` writes it,
   `config get source` reads it back, `config unset source` removes it
   (extend `test_config_cmd.py` / `test_user_config_io.py`).
-- Unit: an unknown key is still refused; a malformed `source` value is rejected
-  by `_validate_key_value` (parseable-URI check only — no host allowlist).
+- Unit (read-back — closes the write-only gap): a file with `[settings] source =
+  "<uri>"` is parsed by `read_user_config` onto `UserConfig.source`, and
+  `resolve_default_source` consumes it as layer 2.
+- Unit: `config get source` reports provenance `file` when set, `unset` when
+  absent (no builtin constant for `source`).
+- Unit (independent fail-soft): a malformed/non-string `source` value leaves a
+  valid `adapter` intact — `read_user_config` drops only the bad field, mirroring
+  the existing `adapter` fail-soft.
+- Unit: an unknown key is still refused; a malformed `source` value (empty /
+  whitespace) is rejected by `_validate_key_value` (parseable-only — **no scheme
+  gate, no host allowlist**; `config set source http://…` is accepted-but-inert).
 - Regression: `adapter` validation and the config-cascade tests stay green.
 
 **Approach:**
-- Add `"source"` to `_KNOWN_KEYS` and the `UserConfig` dataclass; add a `source`
-  branch to `_validate_key_value` (parseable URI). User scope only.
+- Add `"source"` to `_KNOWN_KEYS`, the `UserConfig` dataclass, **and the
+  `read_user_config` parse path** (fail-soft on a non-string value, mirroring
+  `adapter`). Add a `source` branch to `_validate_key_value` (parseable / non-empty
+  only) and to `_effective_value` in `commands/config.py` (`file` vs `unset`
+  provenance). User scope only. The scheme gate is **not** here — it is in
+  `resolve_default_source` (T4).
 
-**Done when:** `config set/get/unset source` round-trips and the adapter path is
-untouched. Verifies the config-key AC.
+**Done when:** `config set/get/unset source` round-trips, `read_user_config`
+surfaces `source`, and the adapter path is untouched. Verifies the config-key AC.
 
 ### T3: Editable detection (layer 3) — the keystone
 
@@ -165,6 +178,8 @@ untouched. Verifies the config-key AC.
 - Unit: missing `direct_url.json` → `None`, no error.
 - Unit: `dir_info.editable == false` → `None`.
 - Unit: a non-empty / non-localhost `file://` host → rejected.
+- Unit: `.git` as a **regular file** (worktree gitdir pointer) is recognized as
+  the repo boundary, not only `.git` as a directory.
 - Unit: a `packs/` + `marketplace.json` pair planted in a parent **above** the
   `.git` root is **not** matched (repo-bounded ascent); a pair in an intermediate
   dir *inside* the clone stops the walk at first match (accident-guard residual,
@@ -187,9 +202,15 @@ untouched. Verifies the config-key AC.
 - Return the catalogue root, or `None` (with the stderr diagnostic when editable
   was detected but no root found below the boundary).
 
+The keystone integration test is `tests/integration/test_editable_source_detection.py`;
+it builds its **own** throwaway venv (`python -m venv`) + `pip install -e
+packages/agentbundle`, reads the real `direct_url.json`, and is **wired into CI
+explicitly** in `build-check.yml` (not picked up by `make build-check`).
+
 **Done when:** the keystone integration test passes against a real editable
 install and every negative/hardening unit test is green. Verifies the editable
-detection, walk-up-bound, `file://`-host, and fall-back-with-diagnostic ACs.
+detection, walk-up-bound, `.git`-as-file, `file://`-host, and
+fall-back-with-diagnostic ACs.
 
 ### T4: `resolve_default_source()` — compose the four layers
 
@@ -201,9 +222,12 @@ detection, walk-up-bound, `file://`-host, and fall-back-with-diagnostic ACs.
 - Unit: layer 2 outranks layer 3 (explicit config beats auto-detection).
 - Unit: an invalid layer output (bad-marker path / unparseable URI) is **skipped**,
   not passed to `resolve_catalogue`.
-- Unit (scheme validation): a `file://` / `http://` / other-scheme source from
-  layer 2 or layer 4 is **rejected** (only `git+https` and a local path pass),
-  distinct from the deferred host allowlist.
+- Unit (scheme validation — table-driven, the parser-differential cases): accept
+  `git+https://…` and a schemeless local path with markers (`/abs`, `./rel`,
+  `rel`) and a Windows drive path with markers (`C:\repo`); **reject** `file://`,
+  `file:/` (single-slash), `http://`, `https://`, `git+ssh://`, and a mis-cased
+  `GIT+HTTPS://` — only the literal-`git+https://` and schemeless/drive local-path
+  branches pass. Distinct from the deferred host allowlist.
 - Unit: all layers empty → the clear error naming all three recovery paths.
 - Unit (negative invariants): a planted `./` cwd source is never consulted; there
   is no repo-scoped layer to consult.
@@ -226,22 +250,40 @@ clear-error ACs.
 **Depends on:** T4
 
 **Tests:**
-- Goal-based: argparse accepts a bare `install --pack X` and `upgrade` (no
-  catalogue); `list-packs` / `list-profiles` still reject a bare invocation.
-- Unit: an explicit `--catalogue`/positional passes through unchanged (the
-  default path does not run).
+- Goal-based: argparse accepts a bare `install --pack X`, a bare `install
+  --profile Y`, and a bare `upgrade` (no catalogue); `list-packs` /
+  `list-profiles` still reject a bare invocation.
+- Unit: an explicit positional `catalogue` passes through unchanged (the default
+  chain does not run — layer 1 short-circuits).
 - Integration: a bare `install --pack core` in an editable checkout resolves via
   layer 3 and proceeds (end-to-end happy path); the same is unaffected by a
   planted `./` source (no-cwd, at the command boundary).
+- Unit: a bare `install --profile X` reaches `resolve_default_source` at the
+  `_run_profile` site (not just the `--pack` path).
 - Regression: `test_resolve_user_scope_target_adapter.py` and the ~13 adapter
   resolution tests stay green.
 
 **Approach:**
+- New shared helper `commands/_common.resolve_catalogue_uri(args) -> str`: gathers
+  `config_source` from `args._user_config` and calls
+  `resolve_default_source(args.catalogue, config_source=…)` **unconditionally**
+  (layer 1 returns an explicit arg verbatim before any metadata/bundle read, so
+  the default chain runs only when the positional is omitted).
 - `cli.py`: `install` (`:247`) and `upgrade` (`:400`) catalogue → `nargs="?"`,
   `default=None`. `list-packs` (`:197`) / `list-profiles` (`:205`) unchanged.
-- `commands/install.py` + `commands/upgrade.py`: when `args.catalogue is None`,
-  call `resolve_default_source(...)` and feed the result to `resolve_catalogue`;
-  otherwise pass the explicit arg straight through.
+- All **three** resolve sites — `install.run` (`:116`), `install._run_profile`
+  (`:3727`), `upgrade.run` (`:94`) — replace `catalogue_uri = args.catalogue`
+  with `catalogue_uri = resolve_catalogue_uri(args)`.
+- The **fourth** consumer, `install._offer_upgrade` (`:1739`), currently copies
+  `ns.catalogue = args.catalogue` into the synthetic namespace it hands to
+  `upgrade.run`. Thread the **already-resolved** `catalogue_uri` from `install.run`
+  into the hand-off (pass it as a parameter or set `ns.catalogue = catalogue_uri`)
+  so the upgrade offer carries the concrete URI rather than re-resolving (which on
+  a bare install would otherwise pass `None` and double-detect). Test: a bare
+  `install` that triggers the upgrade offer resolves once and hands the concrete
+  URI down.
+- CI: wire the keystone integration test (and the new unit tests, if not already
+  swept) into `build-check.yml` explicitly — `make build-check` runs no pytest.
 
 **Done when:** a bare `install`/`upgrade` resolves and runs end-to-end, the
 discovery verbs still require a catalogue, and the explicit-arg path is byte-for-
@@ -274,3 +316,16 @@ byte unchanged. Verifies the two CLI ACs and the end-to-end happy-path.
 ## Changelog
 
 - 2026-06-25: initial plan (authored alongside spec + ADR-0036 from RFC-0046).
+- 2026-06-25 (implementation): corrected the editable-detection **confinement
+  AC** directionality. The package has no repo-root `pyproject.toml` (it lives at
+  `packages/agentbundle/`), so `pip install -e packages/agentbundle` records that
+  subdir as the editable URL and the catalogue/`.git` root is an **ancestor** of
+  it — reached by walking *up*. The original AC's "candidate is a descendant-or-
+  equal of the editable URL" was directionally inverted (it would fail the
+  documented keystone test); rewritten to confine candidates to the closed
+  interval [resolved `.git` root … resolved editable path], all canonicalized.
+  Security intent (no escape via symlink/`..`, no match above the repo) is
+  unchanged. New module: `agentbundle/source_defaults.py` holds T1/T3/T4; the
+  args→inputs adapter is `commands/_common.resolve_catalogue_uri(args)`, which
+  calls `resolve_default_source(args.catalogue, …)` unconditionally (layer 1
+  short-circuits an explicit arg, so the default chain runs only when omitted).

--- a/docs/specs/convenient-install-defaults/spec.md
+++ b/docs/specs/convenient-install-defaults/spec.md
@@ -3,7 +3,7 @@
 - **Status:** Shipped
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
-- **Constrained by:** ADR-0036, RFC-0046; honours RFC-0031, RFC-0011/0012, RFC-0040 + ADR-0030
+- **Constrained by:** ADR-0036, RFC-0046, RFC-0047 (defaults the discovery verbs through the same chain); honours RFC-0031, RFC-0011/0012, RFC-0040 + ADR-0030
 - **Contract:** none (CLI behaviour change to an existing command; no new API surface under `contracts/`)
 - **Shape:** service
 
@@ -74,8 +74,13 @@ The three-tier guard that keeps an implementing agent inside the lines.
 - **Never** auto-persist a one-off `--catalogue` (or any resolved layer) back to
   config — resolution is stateless; `config set source` is the only write path
   (ADR-0036 D4).
-- **Never** default the catalogue on the discovery verbs `list-packs` /
-  `list-profiles` — they keep requiring an explicit catalogue (follow-on).
+- The discovery verbs `list-packs` / `list-profiles` **default through the same
+  chain** (RFC-0047): a bare query resolves via `resolve_catalogue_uri` exactly
+  as `install`/`upgrade` do. This is safe — a gateway-bound fork is editable and
+  resolves via layer 3, so a bare query never *silently* fetches upstream; only a
+  wheel install reaches layer 4, where fetching the upstream catalogue is the
+  expected, symmetric-with-install behaviour. (Originally a `Never do` here;
+  reopened and decided by RFC-0047.)
 - **Never** touch the adapter resolver (`scope.DEFAULT_ADAPTER`, the user-config
   adapter layer) — `source` is added *alongside* `adapter`, nothing else moves.
 - **Never** treat the two editable-detection markers (`packs/` +
@@ -94,10 +99,11 @@ The three-tier guard that keeps an implementing agent inside the lines.
   against a *real* editable install in an isolated venv (the artifact a user
   actually runs), reading the real `direct_url.json` and walking to the real
   clone root — not a mock of the metadata.
-- **CLI wiring (`catalogue` optional on `install`/`upgrade`, still required on
-  `list-packs`/`list-profiles`):** **goal-based check** — argparse accepts a
-  bare `install --pack X` and rejects a bare `list-packs`; verify by invoking
-  the parser, no production test file beyond the per-task assertions.
+- **CLI wiring (`catalogue` optional on all four source verbs — `install`,
+  `upgrade`, `list-packs`, `list-profiles`, per RFC-0047):** **goal-based
+  check** — argparse accepts a bare `install --pack X` and a bare
+  `list-packs`/`list-profiles`; verify by invoking the parser, no production
+  test file beyond the per-task assertions.
 - **`config set/unset/get source` round-trip (the literal write→read→remove):**
   **goal-based check** exercised by the existing config-command test shape
   (`test_config_cmd.py`, `test_user_config_io.py`).
@@ -119,8 +125,12 @@ behaviour only proves out across the install boundary, so it is named at
 - [x] `catalogue` is `nargs="?"` (default `None`) on the `install` and `upgrade`
   subparsers (`cli.py:247`, `:400`); an explicit `--catalogue`/positional value
   passes through to `resolve_catalogue` unchanged.
-- [x] `catalogue` **remains a required positional** on `list-packs` (`cli.py:197`)
-  and `list-profiles` (`cli.py:205`); a bare invocation of either errors.
+- [x] `catalogue` is also `nargs="?"` (default `None`) on `list-packs`
+  (`cli.py:197`) and `list-profiles` (`cli.py:205`) — RFC-0047. When omitted,
+  each handler resolves via `resolve_catalogue_uri(args)` (the same four-layer
+  chain) before `resolve_catalogue`; an explicit positional passes through
+  unchanged. Pinned by a test that a bare `list-packs`/`list-profiles` resolves
+  the default (and the explicit-arg path is unchanged).
 - [x] When `catalogue` is omitted on `install`/`upgrade`, the handler calls a
   shared `resolve_default_source()` whose result feeds `resolve_catalogue`. The
   shared call site is `commands/_common.resolve_catalogue_uri(args)`, used at
@@ -252,10 +262,11 @@ behaviour only proves out across the install boundary, so it is named at
   an absent or empty file means no layer-4 default (the private-fork pattern).
 - [x] The adapter resolver is unchanged: the ~13 adapter default-resolution tests
   and `tests/unit/test_resolve_user_scope_target_adapter.py` stay green.
-- [ ] Integrity-pinning for the layer-4 `git+https` fetch + `list-packs`/`list-profiles` defaulting are out of scope here (deferred: convenient-install-defaults-followons).
+- [ ] Integrity-pinning for the layer-4 `git+https` fetch is out of scope here (deferred: convenient-install-defaults-followons).
   The integrity follow-on's finish line is named, not open-ended: **resolve `main`
   to a pinned commit SHA and verify the fetched archive digest** (not merely "add
-  pinning").
+  pinning"). (`list-packs`/`list-profiles` defaulting, previously deferred here,
+  is now **implemented** under RFC-0047 — see the discovery-verb AC above.)
 
 ## Assumptions
 

--- a/docs/specs/convenient-install-defaults/spec.md
+++ b/docs/specs/convenient-install-defaults/spec.md
@@ -1,6 +1,6 @@
 # Spec: Convenient install defaults
 
-- **Status:** Approved
+- **Status:** Shipped
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** ADR-0036, RFC-0046; honours RFC-0031, RFC-0011/0012, RFC-0040 + ADR-0030
@@ -27,6 +27,10 @@ working directory decide where executable code is fetched from. An explicit
 `--catalogue` always overrides; a user's own `config set source` overrides
 auto-detection.
 
+> **Surface note:** `catalogue` is a **positional** argument, not a `--catalogue`
+> flag. Where this spec writes "`--catalogue`" it denotes that positional (the
+> shorthand the RFC used); there is no flag to add.
+
 ## Boundaries
 
 The three-tier guard that keeps an implementing agent inside the lines.
@@ -38,15 +42,18 @@ The three-tier guard that keeps an implementing agent inside the lines.
   editable detection (PEP 610) › packaged `_data/install-defaults.toml`.
 - **Validate** each layer's output in `resolve_default_source()` before handing
   it to `resolve_catalogue` (markers present for a path; parseable URI) —
-  `resolve_catalogue` itself does no validation (`catalogue.py:72` returns
-  `Path(uri)` unconditionally).
+  `resolve_catalogue` itself does no **path/marker** validation (it rejects a
+  `git+ssh://` prefix, but `catalogue.py:72` returns `Path(uri)` for every other
+  non-`git+https` value with no existence or marker check).
 - Keep an explicit `--catalogue` arg behaving **identically** to today
   (backward compatible); the default path only runs when the arg is omitted.
 - Canonicalize (`Path.resolve()`) before walking, and **bound the editable
   walk-up to the enclosing `.git` repository root**, computed before any marker
   test.
 - Emit a one-line stderr **diagnostic** when editable is detected but no
-  catalogue root is found at/below the repo boundary, then defer to layer 4.
+  catalogue root is found **between the editable package path and the enclosing
+  `.git` root (inclusive)** — the walk is *upward*, the catalogue root is an
+  ancestor — then defer to layer 4.
 
 ### Ask first
 
@@ -91,9 +98,14 @@ The three-tier guard that keeps an implementing agent inside the lines.
   `list-packs`/`list-profiles`):** **goal-based check** — argparse accepts a
   bare `install --pack X` and rejects a bare `list-packs`; verify by invoking
   the parser, no production test file beyond the per-task assertions.
-- **`config set/unset/get source` round-trip:** **goal-based check** exercised by
-  the existing config-command test shape (`test_config_cmd.py`,
-  `test_user_config_io.py`).
+- **`config set/unset/get source` round-trip (the literal write→read→remove):**
+  **goal-based check** exercised by the existing config-command test shape
+  (`test_config_cmd.py`, `test_user_config_io.py`).
+- **The layer-2 read-back invariant** — `read_user_config` parses
+  `[settings].source` onto `UserConfig.source` and `resolve_default_source`
+  consumes it, plus independent fail-soft (a malformed `source` does not drop a
+  valid `adapter`): **TDD**, alongside the precedence/validation invariants — it
+  is a load-bearing invariant, not an artifact one-liner.
 - **Packaging (`_data/install-defaults.toml` ships in the wheel):** **goal-based
   check** — read it back through the same bundled-data accessor the other
   `_data/` files use.
@@ -104,83 +116,146 @@ behaviour only proves out across the install boundary, so it is named at
 
 ## Acceptance Criteria
 
-- [ ] `catalogue` is `nargs="?"` (default `None`) on the `install` and `upgrade`
+- [x] `catalogue` is `nargs="?"` (default `None`) on the `install` and `upgrade`
   subparsers (`cli.py:247`, `:400`); an explicit `--catalogue`/positional value
   passes through to `resolve_catalogue` unchanged.
-- [ ] `catalogue` **remains a required positional** on `list-packs` (`cli.py:197`)
+- [x] `catalogue` **remains a required positional** on `list-packs` (`cli.py:197`)
   and `list-profiles` (`cli.py:205`); a bare invocation of either errors.
-- [ ] When `catalogue` is omitted on `install`/`upgrade`, the handler calls a
-  shared `resolve_default_source()` whose result feeds `resolve_catalogue`.
-- [ ] `resolve_default_source()` resolves the four layers highest-first,
+- [x] When `catalogue` is omitted on `install`/`upgrade`, the handler calls a
+  shared `resolve_default_source()` whose result feeds `resolve_catalogue`. The
+  shared call site is `commands/_common.resolve_catalogue_uri(args)`, used at
+  **all three** resolve sites — `install.run` (single-pack), `install._run_profile`
+  (`install --profile`), and `upgrade.run` — so a bare `install --profile X` (no
+  catalogue) resolves through the default chain too, not just `install --pack X`.
+  Pinned by a test that a bare `install --profile X` reaches `resolve_default_source`.
+- [x] The **fourth** `args.catalogue` consumer — the `install._offer_upgrade`
+  synthetic-namespace hand-off (`install.py:1739`, `ns.catalogue = args.catalogue`)
+  — carries the **already-resolved** `catalogue_uri` from `install.run`, **not**
+  `args.catalogue` (which is `None` on a bare install) and **not** a second
+  independent resolution. So a bare `install` that triggers the upgrade offer
+  hands the concrete resolved URI to `upgrade.run`, with no double-detection and
+  no divergence risk. Pinned by a test.
+- [x] `resolve_default_source()` resolves the four layers highest-first,
   first-match-wins: (1) `--catalogue` arg, (2) user `[settings].source`,
   (3) editable detection, (4) packaged `_data/install-defaults.toml`. Layer 2
   outranks layer 3 (an explicit `config set source` beats auto-detection).
-- [ ] Each layer's output is **validated** before use — a path source has both
-  markers present; a URI source is parseable **and uses only a scheme
-  `resolve_catalogue` understands** (`git+https` or a local path), so a `file://`,
-  `http://`, or other-scheme source (set via `config set source` or baked into a
-  forked `install-defaults.toml`) is **rejected**, distinct from the deferred
-  host allowlist. The discriminator is explicit: a **schemeless** local path
-  (`/abs/path`, `./rel`) is the local-path branch and is accepted; the gate
-  rejects a URL that carries a scheme other than `git+https`. An invalid layer is
-  skipped, not passed to the unvalidated `resolve_catalogue`.
-- [ ] Editable detection reads
+- [x] Each layer's output is **validated** in `resolve_default_source()` before
+  use, via an exact, allowlist discriminator (no parser-differential gap):
+  1. a value beginning with the literal `git+https://` (case-sensitive, matching
+     `catalogue.py`'s own `startswith` sink) is **accepted** (the one URL form
+     `resolve_catalogue` fetches);
+  2. else a value matching `^[A-Za-z]:[\\/]` (a Windows **drive path**, e.g.
+     `C:\repo` / `C:/repo`) is the **local-path** branch;
+  3. else a value whose `urllib.parse.urlsplit(value).scheme` is **non-empty**
+     (any other scheme — `file://`, `file:/` single-slash, `http://`,
+     `git+ssh://`, a mis-cased `GIT+HTTPS://`) is **rejected**;
+  4. else (schemeless: `/abs/path`, `./rel`, `rel`) it is the **local-path**
+     branch.
+  A **local-path** source is accepted **iff both markers are present** at its
+  `Path.resolve()`'d location; a rejected/invalid layer is **skipped**, never
+  passed to the unvalidated `resolve_catalogue`. This is distinct from the
+  deferred host allowlist (a policy call on an *accepted* `git+https` host).
+- [x] **Confinement asymmetry is deliberate, not an oversight:** the
+  canonicalize + repo-bounded-ascent confinement applies **only** to layer 3
+  (auto-detected). Layers 2 and 4 path sources are validated for **marker
+  presence only** — no confinement — because they are trusted-by-construction
+  (the user typed `config set source`, or the distribution shipped the file),
+  per ADR-0036 D1. The layer-3 keystone is the only place a path the user did
+  *not* assert is consulted, so it alone earns the confinement check.
+- [x] Editable detection reads
   `importlib.metadata.distribution("agentbundle").read_text("direct_url.json")`;
   it activates **only** when the record is present **and**
   `dir_info.editable == true`. A missing record (older pip, or a wheel install)
   falls through to layer 4 with no error.
-- [ ] Editable detection parses the `file://` `url` with the standard parser
+- [x] Editable detection parses the `file://` `url` with the standard parser
   (`urllib.request.url2pathname` + percent-decoding) and **rejects** a
   non-empty / non-localhost `file://` host.
-- [ ] Editable detection **canonicalizes** the path (`Path.resolve()`) and walks
+- [x] Editable detection **canonicalizes** the path (`Path.resolve()`) and walks
   up over canonicalized ancestors to the **first** one containing both `packs/`
   and `.claude-plugin/marketplace.json`, verifying each candidate stays under
   the resolved repository root.
-- [ ] The repository root and every candidate are **canonicalized descendants-or-
-  equal of `Path.resolve()` of the parsed editable `file://` URL** — so a symlink
-  or `..` in the recorded URL cannot make the matched root resolve *outside* the
-  clone the user `pip install -e`'d (the "inside the clone" precondition the
-  forgeable-marker residual rests on is enforced, not assumed).
-- [ ] The walk-up ascent is **bounded by the enclosing `.git` repository root**
+- [x] Confinement to the clone is enforced on **canonicalized** paths, not
+  assumed: the editable `file://` URL is `Path.resolve()`'d **first** (collapsing
+  any symlink or `..`), the `.git` root is the nearest canonicalized ancestor of
+  that resolved path, and **every candidate is a canonicalized ancestor-or-equal
+  of the resolved editable path *and* a descendant-or-equal of the resolved
+  `.git` root** — so the matched catalogue root always stays *inside* the clone
+  the user `pip install -e`'d (the "inside the clone" precondition the
+  forgeable-marker residual rests on). The walk is **upward**: because the
+  package lives at `packages/agentbundle/` (no repo-root `pyproject.toml`), the
+  recorded editable URL is that subdir and the catalogue root is an **ancestor**
+  of it, reached by ascending — bounded above by the `.git` root.
+- [x] The walk-up ascent is **bounded by the enclosing `.git` repository root**
   (nearest ancestor with a `.git` file *or* directory), computed before any
   marker test — a `packs/` + `marketplace.json` pair planted in a shared parent
   *above* the clone is never matched.
-- [ ] The bound is a **closed interval**: the `.git`-root directory **itself** is
+- [x] The bound is a **closed interval**: the `.git`-root directory **itself** is
   a legal marker-match candidate (the catalogue root coincides with the git root,
   so the only valid match sits *at* the boundary). The catalogue-root == git-root
   case resolves rather than falling through to layer 4.
-- [ ] A real `pip install -e packages/agentbundle` in an isolated venv resolves,
+- [x] A real `pip install -e packages/agentbundle` in a **throwaway venv the test
+  builds itself** (`python -m venv`, not the ambient editable record) resolves,
   via editable detection, to the clone root (the dir holding `packs/` +
   `.claude-plugin/marketplace.json`) — verified end-to-end, not against a mocked
-  `direct_url.json`. (the construction-test keystone)
-- [ ] When editable is detected but **no** catalogue root is found at/below the
-  repo boundary (e.g. a sparse checkout missing `packs/`), the resolver emits a
-  one-line stderr diagnostic naming what happened and defers to layer 4 — never
-  silent, never a hard error on a default, never the cwd.
-- [ ] **No resolution layer ever resolves from `.`/cwd**, and **no repo-scoped
-  `source` layer exists** — asserted as explicit negative criteria (a planted
-  cwd source / repo-root source is not consulted).
-- [ ] When **no** layer yields a source, the command errors clearly with text
+  `direct_url.json`. The test is
+  `tests/integration/test_editable_source_detection.py`; because `make
+  build-check` runs no pytest, it is **wired into CI explicitly** in
+  `build-check.yml` (per the repo's per-path test-wiring convention) or it never
+  gates. (the construction-test keystone)
+- [x] The `.git` repo-boundary detection recognizes `.git` as a **regular file**
+  (the git-worktree / submodule gitdir pointer), not only a directory — pinned by
+  a unit test, since the keystone itself runs in a Conductor worktree where `.git`
+  is a file.
+- [x] When editable is detected but **no** catalogue root is found between the
+  editable package path and the enclosing `.git` root inclusive (e.g. a sparse
+  checkout missing `packs/`), the resolver emits a
+  one-line diagnostic on **stderr** (not stdout) whose text contains the
+  substrings `editable install detected` and `deferring to packaged default`,
+  then **returns the layer-4 source** (resolution continues) — never silent,
+  never a hard error on a default, never the cwd. Pinned by a goal-based check
+  asserting the stream, the substrings, and that layer 4 is returned.
+- [x] **No resolution layer ever *implicitly* resolves from `.`/cwd**, and **no
+  repo-scoped `source` layer exists** — asserted as explicit negative criteria (a
+  planted cwd source / repo-root source is not consulted). The forbidden thing is
+  an *implicit* cwd fallback (the resolver inventing `.` when no layer yielded a
+  source). A **user-asserted** relative path — an explicit `catalogue` positional,
+  or `config set source ./rel` — is the user's own input and *is* honoured
+  (resolved cwd-relative via `Path.resolve()`), per the trust-boundary carve-out;
+  that is not the resolver consulting cwd on its own.
+- [x] When **no** layer yields a source, the command errors clearly with text
   naming all three recovery paths:
   `no catalogue source: pass --catalogue, run 'agentbundle config set source …', or pip install -e the catalogue`.
-- [ ] Resolution writes nothing on **any** path — a one-off `--catalogue` (or any
+- [x] Resolution writes nothing on **any** path — a one-off `--catalogue` (or any
   auto-resolved layer) does **not** persist to the user config (no
   write-on-install), including the editable-detected-but-deferred (diagnostic) and
   all-layers-empty (error) paths.
-- [ ] `source` is added to `_KNOWN_KEYS` and the user `[settings]` schema
-  (`user_config.py`) alongside `adapter`, **user scope only**; `config set
-  source <uri>`, `config get source`, and `config unset source` round-trip, and
-  the unset path is named in the all-layers-empty diagnostic.
-- [ ] A new packaged `_data/install-defaults.toml` ships in the wheel via the
+- [x] `source` is added to `_KNOWN_KEYS`, the `UserConfig` dataclass, **and the
+  `read_user_config` loader** (`user_config.py`) alongside `adapter`, **user scope
+  only** — so a value written by `config set source` is actually parsed back onto
+  `UserConfig.source` and consumed by layer 2 (a read-back test proves resolution
+  consumes it, closing the write-only gap). `config set source <uri>`, `config
+  get source`, and `config unset source` round-trip. `config get source` is wired
+  through a `source` branch in `_effective_value`: a value present in the file
+  reports provenance `file`; absent reports provenance `unset` (there is **no**
+  builtin constant for `source` — the layer-4 packaged default is not a config
+  value). The unset path is named in the all-layers-empty diagnostic.
+- [x] The write-time `config set source` validation is **parseable-only** (it
+  does *not* scheme-gate); the scheme gate lives in `resolve_default_source()`.
+  So `config set source http://…` is **accepted-but-inert** — it persists, then
+  is rejected (and skipped) at resolution. This split is intentional (the value
+  can be set, then rejected with a diagnostic), not a drift between the two
+  checks.
+- [x] A new packaged `_data/install-defaults.toml` ships in the wheel via the
   existing `[tool.setuptools.package-data]` `agentbundle = ["_data/*"]` wiring,
   declaring
   `[defaults] source = "git+https://github.com/eugenelim/agent-ready-repo"`;
   an absent or empty file means no layer-4 default (the private-fork pattern).
-- [ ] The adapter resolver is unchanged: the ~13 adapter default-resolution tests
+- [x] The adapter resolver is unchanged: the ~13 adapter default-resolution tests
   and `tests/unit/test_resolve_user_scope_target_adapter.py` stay green.
-- [ ] Integrity-pinning for the layer-4 `git+https` fetch, and default resolution
-  for `list-packs`/`list-profiles`, are **not** implemented here (deferred:
-  convenient-install-defaults-followons).
+- [ ] Integrity-pinning for the layer-4 `git+https` fetch + `list-packs`/`list-profiles` defaulting are out of scope here (deferred: convenient-install-defaults-followons).
+  The integrity follow-on's finish line is named, not open-ended: **resolve `main`
+  to a pinned commit SHA and verify the fetched archive digest** (not merely "add
+  pinning").
 
 ## Assumptions
 

--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -8,6 +8,21 @@ the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 
 ## [Unreleased]
 
+### Added
+
+- **`agentbundle install`/`upgrade` no longer require a `catalogue` argument
+  (RFC-0046).** When omitted, the source resolves through a four-layer,
+  first-match-wins chain: an explicit `catalogue` positional › your
+  `config set source` value › an editable clone (`pip install -e`, detected
+  via PEP 610 and walked up to the catalogue root, bounded by the enclosing
+  `.git` repo) › a packaged default (`git+https://github.com/eugenelim/agent-ready-repo`).
+  So a public user runs `agentbundle install --pack core` with no URL, and a
+  gateway-bound editable fork defaults to its own clone — with no repo-committed
+  source and no cwd fall-back (a code-provenance boundary). New `source` user
+  config key (`config set/get/unset source`). The discovery verbs `list-packs`
+  / `list-profiles` still take an explicit catalogue. Layer-4 integrity-pinning
+  (pin `main` to a SHA + verify the archive digest) is a named follow-on.
+
 ### Changed
 
 - **`agentbundle list-packs` and `list-profiles` word-wrap the DESCRIPTION

--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -8,6 +8,8 @@ the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 
 ## [Unreleased]
 
+## [0.8.0] — 2026-06-25
+
 ### Added
 
 - **The `catalogue` argument is now optional on `install`, `upgrade`,

--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -10,18 +10,20 @@ the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 
 ### Added
 
-- **`agentbundle install`/`upgrade` no longer require a `catalogue` argument
-  (RFC-0046).** When omitted, the source resolves through a four-layer,
-  first-match-wins chain: an explicit `catalogue` positional › your
-  `config set source` value › an editable clone (`pip install -e`, detected
-  via PEP 610 and walked up to the catalogue root, bounded by the enclosing
-  `.git` repo) › a packaged default (`git+https://github.com/eugenelim/agent-ready-repo`).
-  So a public user runs `agentbundle install --pack core` with no URL, and a
-  gateway-bound editable fork defaults to its own clone — with no repo-committed
-  source and no cwd fall-back (a code-provenance boundary). New `source` user
-  config key (`config set/get/unset source`). The discovery verbs `list-packs`
-  / `list-profiles` still take an explicit catalogue. Layer-4 integrity-pinning
-  (pin `main` to a SHA + verify the archive digest) is a named follow-on.
+- **The `catalogue` argument is now optional on `install`, `upgrade`,
+  `list-packs`, and `list-profiles` (RFC-0046 + RFC-0047).** When omitted, the
+  source resolves through a four-layer, first-match-wins chain: an explicit
+  `catalogue` positional › your `config set source` value › an editable clone
+  (`pip install -e`, detected via PEP 610 and walked up to the catalogue root,
+  bounded by the enclosing `.git` repo) › a packaged default
+  (`git+https://github.com/eugenelim/agent-ready-repo`). So a public user runs
+  `agentbundle install --pack core` (or `agentbundle list-packs`) with no URL,
+  and a gateway-bound editable fork defaults to its own clone — with no
+  repo-committed source and no cwd fall-back (a code-provenance boundary). All
+  four verbs share one resolver, so a bare query on an editable fork resolves to
+  the local clone (never silently fetching upstream). New `source` user config
+  key (`config set/get/unset source`). Layer-4 integrity-pinning (pin `main` to a
+  SHA + verify the archive digest) is a named follow-on.
 
 ### Changed
 

--- a/packages/agentbundle/README.md
+++ b/packages/agentbundle/README.md
@@ -33,9 +33,9 @@ The install auto-detects your agent (`--adapter` overrides). To install from a *
 ## More commands
 
 ```bash
-# See what a catalogue offers (the discovery verbs take an explicit catalogue)
-agentbundle list-packs    git+https://github.com/eugenelim/agent-ready-repo
-agentbundle list-profiles git+https://github.com/eugenelim/agent-ready-repo
+# See what the catalogue offers (bare uses the default; or name one explicitly)
+agentbundle list-packs
+agentbundle list-profiles
 
 # Install a whole curated profile — a single-scope set of packs — in one command
 agentbundle install --profile inception

--- a/packages/agentbundle/README.md
+++ b/packages/agentbundle/README.md
@@ -15,37 +15,37 @@ pip install agentbundle
 **Install into a repo** — so everyone who clones it gets the pack. `core` is the flagship pack, the loop itself:
 
 ```bash
-agentbundle install --pack core git+https://github.com/eugenelim/agent-ready-repo
+agentbundle install --pack core
 ```
 
-It lands in the repo's agent config — subagents and skills included — and you commit it like any other project file. This is the default scope: the pack belongs to the project and the whole team.
+No catalogue argument needed: it defaults to the agent-ready-repo catalogue. It lands in the repo's agent config — subagents and skills included — and you commit it like any other project file. This is the default scope: the pack belongs to the project and the whole team.
 
 **Install for yourself, everywhere** — so a pack follows you across every project, with no per-repo setup:
 
 ```bash
-agentbundle install --pack research git+https://github.com/eugenelim/agent-ready-repo --scope user
+agentbundle install --pack research --scope user
 ```
 
 User-scope packs land in your home directory, not the repo — they're yours, not the team's, and they're there in every project you open.
 
-A catalogue is a git URL or a local path, and the install auto-detects your agent (`--adapter` overrides).
+The install auto-detects your agent (`--adapter` overrides). To install from a **different** catalogue, pass it as a trailing argument — a git URL or a local path (`agentbundle install --pack core <catalogue>`); a `config set source <catalogue>` makes that the default, and an editable clone (`pip install -e`) defaults to itself.
 
 ## More commands
 
 ```bash
-# See what a catalogue offers
+# See what a catalogue offers (the discovery verbs take an explicit catalogue)
 agentbundle list-packs    git+https://github.com/eugenelim/agent-ready-repo
 agentbundle list-profiles git+https://github.com/eugenelim/agent-ready-repo
 
 # Install a whole curated profile — a single-scope set of packs — in one command
-agentbundle install --profile inception git+https://github.com/eugenelim/agent-ready-repo
+agentbundle install --profile inception
 
 # Preview any install without writing a file
-agentbundle install --pack core git+https://github.com/eugenelim/agent-ready-repo --dry-run
+agentbundle install --pack core --dry-run
 
 # Upgrade to the version the catalogue ships — shows installed → target, asks first
-agentbundle upgrade --pack core git+https://github.com/eugenelim/agent-ready-repo
-agentbundle upgrade --pack core git+https://github.com/eugenelim/agent-ready-repo --yes  # skip the prompt (CI)
+agentbundle upgrade --pack core
+agentbundle upgrade --pack core --yes  # skip the prompt (CI)
 
 # Uninstall — previews remove (Tier-1) vs keep (your edits), asks first
 agentbundle uninstall --pack core --dry-run

--- a/packages/agentbundle/agentbundle/_data/install-defaults.toml
+++ b/packages/agentbundle/agentbundle/_data/install-defaults.toml
@@ -1,0 +1,10 @@
+# Packaged install default — layer 4 of the catalogue-source resolution chain
+# (RFC-0046 / ADR-0036). When `agentbundle install`/`upgrade` is run with no
+# `catalogue` positional and layers 1–3 (explicit arg, user config, editable
+# detection) yield nothing, this source is used.
+#
+# Private-fork pattern: blank the `source` value below (or delete this file
+# entirely) to disable the packaged GitHub default — layers 1–3 still apply, so
+# an editable clone or a `config set source` still resolves.
+[defaults]
+source = "git+https://github.com/eugenelim/agent-ready-repo"

--- a/packages/agentbundle/agentbundle/cli.py
+++ b/packages/agentbundle/agentbundle/cli.py
@@ -244,7 +244,16 @@ def _build_parser() -> argparse.ArgumentParser:
             "profile declares its own scope)."
         ),
     )
-    sp.add_argument("catalogue", help="Catalogue URI (local path or git+https://...).")
+    sp.add_argument(
+        "catalogue",
+        nargs="?",
+        default=None,
+        help=(
+            "Catalogue URI (local path or git+https://...). Optional: when "
+            "omitted, the source is resolved from your config, an editable "
+            "clone, or the packaged default (RFC-0046)."
+        ),
+    )
     sp.add_argument("--output", default=".")
     sp.add_argument("--scope", choices=("repo", "user"))
     sp.add_argument(
@@ -397,7 +406,16 @@ def _build_parser() -> argparse.ArgumentParser:
     prim_group.add_argument("--hook")
     prim_group.add_argument("--seed")
     prim_group.add_argument("--command")
-    sp.add_argument("catalogue", help="Catalogue URI to fetch the new version from.")
+    sp.add_argument(
+        "catalogue",
+        nargs="?",
+        default=None,
+        help=(
+            "Catalogue URI to fetch the new version from. Optional: when "
+            "omitted, the source is resolved from your config, an editable "
+            "clone, or the packaged default (RFC-0046)."
+        ),
+    )
     sp.add_argument("--root", default=".")
     sp.add_argument("--scope", choices=("repo", "user"))
     sp.add_argument(

--- a/packages/agentbundle/agentbundle/cli.py
+++ b/packages/agentbundle/agentbundle/cli.py
@@ -194,7 +194,16 @@ def _build_parser() -> argparse.ArgumentParser:
         "list-packs",
         help="List packs available in a catalogue URI (local path or git+https).",
     )
-    sp.add_argument("catalogue", help="Catalogue URI (local path or git+https://...).")
+    sp.add_argument(
+        "catalogue",
+        nargs="?",
+        default=None,
+        help=(
+            "Catalogue URI (local path or git+https://...). Optional: when "
+            "omitted, the source is resolved from your config, an editable "
+            "clone, or the packaged default (RFC-0047)."
+        ),
+    )
     sp.set_defaults(func=_lazy("list_packs"))
 
     # --- list-profiles --- (catalogue query; profiles declare their own scope)
@@ -202,7 +211,16 @@ def _build_parser() -> argparse.ArgumentParser:
         "list-profiles",
         help="List curated install profiles available in a catalogue URI.",
     )
-    sp.add_argument("catalogue", help="Catalogue URI (local path or git+https://...).")
+    sp.add_argument(
+        "catalogue",
+        nargs="?",
+        default=None,
+        help=(
+            "Catalogue URI (local path or git+https://...). Optional: when "
+            "omitted, the source is resolved from your config, an editable "
+            "clone, or the packaged default (RFC-0047)."
+        ),
+    )
     sp.set_defaults(func=_lazy("list_profiles"))
 
     # --- list-targets --- (no flags; queries the adapter registry)

--- a/packages/agentbundle/agentbundle/commands/_common.py
+++ b/packages/agentbundle/agentbundle/commands/_common.py
@@ -14,7 +14,29 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 from agentbundle.version import SPEC_VERSION
 
 if TYPE_CHECKING:
+    import argparse
+
     from agentbundle.safety import Tier
+
+
+def resolve_catalogue_uri(args: "argparse.Namespace") -> str:
+    """Resolve the catalogue URI for ``install`` / ``upgrade``.
+
+    Applies the four-layer default chain (RFC-0046 / ADR-0036) when the
+    ``catalogue`` positional was omitted. An explicit positional is returned
+    verbatim (layer 1 short-circuits before any metadata/bundle read), so the
+    default chain runs only on a bare invocation. May raise ``CatalogueError``
+    when no layer yields a source — handlers catch it alongside their existing
+    ``resolve_catalogue`` error handling.
+    """
+    from agentbundle.source_defaults import resolve_default_source
+
+    user_cfg = getattr(args, "_user_config", None)
+    config_source = getattr(user_cfg, "source", None)
+    return resolve_default_source(
+        getattr(args, "catalogue", None),
+        config_source=config_source,
+    )
 
 
 class SeedDelivery(NamedTuple):

--- a/packages/agentbundle/agentbundle/commands/config.py
+++ b/packages/agentbundle/agentbundle/commands/config.py
@@ -39,6 +39,12 @@ def _effective_value(key: str, cfg: UserConfig) -> tuple[str, str]:
         if cfg.adapter is not None:
             return cfg.adapter, "file"
         return DEFAULT_ADAPTER, "builtin"
+    if key == "source":
+        if cfg.source is not None:
+            return cfg.source, "file"
+        # No builtin constant for `source`: the layer-4 packaged default is
+        # not a config value, so an absent key reports `unset`, not `builtin`.
+        return "", "unset"
     # Defense in depth — _KNOWN_KEYS gates entry to this branch.
     raise ValueError(f"agentbundle: unknown setting {key!r}")
 

--- a/packages/agentbundle/agentbundle/commands/install.py
+++ b/packages/agentbundle/agentbundle/commands/install.py
@@ -84,6 +84,7 @@ def run(args: "argparse.Namespace") -> int:
         confirm_or_refuse,
         format_plan_line,
         plan_action,
+        resolve_catalogue_uri,
         summarize_plan,
     )
     from agentbundle.config import (
@@ -113,7 +114,13 @@ def run(args: "argparse.Namespace") -> int:
         return _run_profile(args)
 
     pack_name: str = args.pack
-    catalogue_uri: str = args.catalogue
+    # RFC-0046: resolve the default source when the `catalogue` positional was
+    # omitted (an explicit arg short-circuits through layer 1 unchanged).
+    try:
+        catalogue_uri: str = resolve_catalogue_uri(args)
+    except CatalogueError as exc:
+        print(f"install: {exc}", file=sys.stderr)
+        return 1
     cli_scope: str | None = getattr(args, "scope", None)
     force: bool = bool(getattr(args, "force", False))
     force_merge: bool = bool(getattr(args, "force_merge", False))
@@ -481,7 +488,12 @@ def run(args: "argparse.Namespace") -> int:
             ),
         ):
             return 1
-        return _offer_upgrade(args, pack_name=pack_name, scope=requested_scope)
+        return _offer_upgrade(
+            args,
+            pack_name=pack_name,
+            scope=requested_scope,
+            catalogue_uri=catalogue_uri,
+        )
 
     # 4b. Already at the *other* scope, no --force → refuse cross-scope.
     other_scope = "user" if requested_scope == "repo" else "repo"
@@ -1719,7 +1731,9 @@ def _scan_dist_tree_artifacts(root: Path, pack_name: str) -> list[Path]:
     return sorted(out)
 
 
-def _offer_upgrade(args: "argparse.Namespace", *, pack_name: str, scope: str) -> int:
+def _offer_upgrade(
+    args: "argparse.Namespace", *, pack_name: str, scope: str, catalogue_uri: str
+) -> int:
     """Hand off an already-installed `install` to `upgrade` (CLI-hygiene AC11/12).
 
     The install-side offer is the confirmation, so the upgrade runs with
@@ -1736,7 +1750,10 @@ def _offer_upgrade(args: "argparse.Namespace", *, pack_name: str, scope: str) ->
 
     ns = _argparse.Namespace()
     ns.pack = pack_name
-    ns.catalogue = args.catalogue
+    # RFC-0046: carry the concrete source already resolved by `run()` rather
+    # than `args.catalogue` (which is `None` on a bare install) — the upgrade
+    # hand-off must not re-resolve and risk a divergent second detection.
+    ns.catalogue = catalogue_uri
     ns.root = getattr(args, "output", ".")
     ns.scope = scope
     ns.yes = True
@@ -3718,13 +3735,20 @@ def _run_profile(args: "argparse.Namespace") -> int:
     import io
 
     from agentbundle.catalogue import CatalogueError, resolve_catalogue
+    from agentbundle.commands._common import resolve_catalogue_uri
     from agentbundle.commands.profile import ProfileError, load_profile
     from agentbundle.config import ConfigError, load_pack_toml, load_state
     from agentbundle import safety
     from agentbundle import scope as scope_mod
 
     profile_id: str = args.profile
-    catalogue_uri: str = args.catalogue
+    # RFC-0046: a bare `install --profile X` (no catalogue) resolves through the
+    # same default chain as `install --pack X`.
+    try:
+        catalogue_uri: str = resolve_catalogue_uri(args)
+    except CatalogueError as exc:
+        print(f"install: {exc}", file=sys.stderr)
+        return 1
     cli_adapter: str | None = getattr(args, "adapter", None)
     user_config = getattr(args, "_user_config", None)
     output_root = Path(args.output).resolve()

--- a/packages/agentbundle/agentbundle/commands/list_packs.py
+++ b/packages/agentbundle/agentbundle/commands/list_packs.py
@@ -32,12 +32,14 @@ def run(args: "argparse.Namespace") -> int:
     Returns 0 on success, 1 on catalogue resolution failure.
     """
     from agentbundle.catalogue import CatalogueError, resolve_catalogue
+    from agentbundle.commands._common import resolve_catalogue_uri
     from agentbundle.config import ConfigError, load_pack_toml
 
-    catalogue_uri: str = args.catalogue
-
     # ── Resolve catalogue URI ──────────────────────────────────────────────────
+    # RFC-0047: default the source through the same four-layer chain as
+    # install/upgrade when the `catalogue` positional is omitted.
     try:
+        catalogue_uri: str = resolve_catalogue_uri(args)
         catalogue_dir = resolve_catalogue(catalogue_uri)
     except CatalogueError as exc:
         print(f"list-packs: {exc}", file=sys.stderr)

--- a/packages/agentbundle/agentbundle/commands/list_profiles.py
+++ b/packages/agentbundle/agentbundle/commands/list_profiles.py
@@ -27,11 +27,13 @@ def run(args: "argparse.Namespace") -> int:
     Returns 0 on success, 1 on catalogue resolution failure.
     """
     from agentbundle.catalogue import CatalogueError, resolve_catalogue
+    from agentbundle.commands._common import resolve_catalogue_uri
     from agentbundle.commands.profile import list_profiles
 
-    catalogue_uri: str = args.catalogue
-
+    # RFC-0047: default the source through the same four-layer chain as
+    # install/upgrade when the `catalogue` positional is omitted.
     try:
+        catalogue_uri: str = resolve_catalogue_uri(args)
         catalogue_dir = resolve_catalogue(catalogue_uri)
     except CatalogueError as exc:
         print(f"list-profiles: {exc}", file=sys.stderr)

--- a/packages/agentbundle/agentbundle/commands/upgrade.py
+++ b/packages/agentbundle/agentbundle/commands/upgrade.py
@@ -79,6 +79,7 @@ def run(args: "argparse.Namespace") -> int:
         confirm_or_refuse,
         format_plan_line,
         plan_action,
+        resolve_catalogue_uri,
         summarize_plan,
     )
     from agentbundle.config import (
@@ -91,7 +92,15 @@ def run(args: "argparse.Namespace") -> int:
     from agentbundle import safety
 
     pack_name: str = args.pack
-    catalogue_uri: str = args.catalogue
+    # RFC-0046: resolve the default source when the `catalogue` positional was
+    # omitted (an explicit arg short-circuits through layer 1 unchanged). On the
+    # install→upgrade hand-off the synthetic namespace already carries the
+    # concrete resolved URI, so layer 1 returns it verbatim — no re-resolution.
+    try:
+        catalogue_uri: str = resolve_catalogue_uri(args)
+    except CatalogueError as exc:
+        print(f"upgrade: {exc}", file=sys.stderr)
+        return 1
     cli_scope: str | None = getattr(args, "scope", None)
     # User-config attached by `cli.py:main()` via args._user_config.
     # The pre-flight in `_resolve_target_adapter` no-ops when

--- a/packages/agentbundle/agentbundle/source_defaults.py
+++ b/packages/agentbundle/agentbundle/source_defaults.py
@@ -1,0 +1,342 @@
+"""Default catalogue-source resolution for ``install`` / ``upgrade`` (RFC-0046).
+
+When the ``catalogue`` positional is omitted, the install/upgrade handlers
+resolve a default source through a four-layer, trusted-by-construction,
+first-match-wins chain (ADR-0036):
+
+  1. the explicit ``catalogue`` arg — passed through verbatim (layer 1);
+  2. the user ``[settings].source`` config value (layer 2);
+  3. editable-install detection via PEP 610 ``direct_url.json`` (layer 3);
+  4. the packaged ``_data/install-defaults.toml`` default (layer 4).
+
+``resolve_catalogue`` (``catalogue.py``) stays a thin fetcher with no
+path/marker validation; **all** validation lives here. Resolution is
+stateless — it never writes config, never falls back to ``.``/cwd, and never
+consults a repo-committed source. See
+``docs/specs/convenient-install-defaults/spec.md``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import tomllib
+from pathlib import Path
+from typing import Callable, TextIO
+from urllib.parse import unquote, urlsplit
+from urllib.request import url2pathname
+
+from agentbundle.catalogue import CatalogueError
+
+_GIT_HTTPS_PREFIX = "git+https://"
+# A Windows drive path (``C:\repo`` / ``C:/repo``): a single drive letter, a
+# colon, then a separator. Checked *before* the urlsplit scheme test because
+# ``urlsplit("C:/x").scheme`` is ``"c"`` and would otherwise read as a URL.
+_WIN_DRIVE_RE = re.compile(r"^[A-Za-z]:[\\/]")
+
+_MARKER_DIR = "packs"
+_MARKER_FILE = (".claude-plugin", "marketplace.json")
+
+# The exact substring the spec pins for the all-layers-empty error.
+_NO_SOURCE_MSG = (
+    "no catalogue source: pass --catalogue, run 'agentbundle config set "
+    "source …', or pip install -e the catalogue"
+)
+
+# Sentinel: distinguishes "caller did not pass a distribution" (load it
+# lazily) from "caller passed None" (no distribution — skip layer 3).
+_UNSET: object = object()
+
+
+# ---------------------------------------------------------------------------
+# Validation gate (layers 2 and 4)
+# ---------------------------------------------------------------------------
+
+
+def _has_catalogue_markers(root: Path) -> bool:
+    """True iff *root* holds both catalogue markers (``packs/`` +
+    ``.claude-plugin/marketplace.json``)."""
+    return (root / _MARKER_DIR).is_dir() and (
+        root / _MARKER_FILE[0] / _MARKER_FILE[1]
+    ).is_file()
+
+
+def _local_path_has_markers(value: str) -> bool:
+    try:
+        root = Path(value).resolve()
+    except OSError:
+        return False
+    return _has_catalogue_markers(root)
+
+
+def _is_valid_source(value: str) -> bool:
+    """The scheme/marker gate applied to layer-2 and layer-4 sources.
+
+    Exact allowlist discriminator (spec validation AC), in order:
+      1. literal ``git+https://`` prefix (case-sensitive, matching
+         ``catalogue.py``'s ``startswith`` sink) → accept;
+      2. a Windows drive path (``^[A-Za-z]:[\\/]``) → local-path branch;
+      3. any non-empty ``urlsplit`` scheme (``file://``, ``file:/``,
+         ``http://``, ``git+ssh://``, mis-cased ``GIT+HTTPS://``) → reject;
+      4. else (schemeless: ``/abs``, ``./rel``, ``rel``) → local-path branch.
+
+    A local-path source is accepted iff both markers are present at its
+    ``Path.resolve()``'d location.
+    """
+    if not value:
+        return False
+    if value.startswith(_GIT_HTTPS_PREFIX):
+        return True
+    if _WIN_DRIVE_RE.match(value):
+        return _local_path_has_markers(value)
+    if urlsplit(value).scheme:
+        return False
+    return _local_path_has_markers(value)
+
+
+# ---------------------------------------------------------------------------
+# Layer 3 — editable-install detection
+# ---------------------------------------------------------------------------
+
+
+def _enclosing_git_root(start: Path) -> Path | None:
+    """Nearest ancestor (inclusive) of *start* containing a ``.git`` entry —
+    a **file** (worktree / submodule gitdir pointer) or a directory.
+
+    *start* must already be ``Path.resolve()``'d; ancestors of a resolved path
+    are themselves canonical, so the returned root is canonical too.
+    """
+    cur = start
+    while True:
+        if (cur / ".git").exists():
+            return cur
+        if cur.parent == cur:
+            return None
+        cur = cur.parent
+
+
+def _ascend_inclusive(start: Path, stop: Path):
+    """Yield *start*, its parent, … up to and including *stop*.
+
+    *stop* is an ancestor-or-equal of *start* (it is the enclosing ``.git``
+    root), so every yielded candidate is an ancestor-or-equal of *start* and a
+    descendant-or-equal of *stop* — the closed interval that confines the walk
+    to inside the clone.
+    """
+    cur = start
+    while True:
+        yield cur
+        if cur == stop or cur.parent == cur:
+            return
+        cur = cur.parent
+
+
+def _detect_editable_source(dist: object, *, stream: TextIO | None = None) -> str | None:
+    """Resolve the catalogue root from an editable install, or ``None``.
+
+    Reads PEP 610 ``direct_url.json`` from *dist*, activates only when
+    ``dir_info.editable is True``, parses the ``file://`` URL (rejecting a
+    non-empty/non-localhost host), canonicalizes it, and walks **up** to the
+    first ancestor (bounded by the enclosing ``.git`` root, inclusive) holding
+    both catalogue markers. Emits a one-line stderr diagnostic and returns
+    ``None`` when editable is detected but no catalogue root is found.
+    """
+    if stream is None:
+        stream = sys.stderr
+    if dist is None:
+        return None
+    try:
+        raw = dist.read_text("direct_url.json")  # type: ignore[attr-defined]
+    except Exception:
+        return None
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    dir_info = data.get("dir_info")
+    if not isinstance(dir_info, dict) or dir_info.get("editable") is not True:
+        return None
+    url = data.get("url")
+    if not isinstance(url, str):
+        return None
+    parts = urlsplit(url)
+    if parts.scheme != "file":
+        return None
+    if parts.netloc not in ("", "localhost"):
+        return None
+    pkg_path = Path(url2pathname(unquote(parts.path)))
+    try:
+        pkg_root = pkg_path.resolve(strict=True)
+    except OSError:
+        return None
+
+    git_root = _enclosing_git_root(pkg_root)
+    if git_root is None:
+        print(
+            "agentbundle: editable install detected but no enclosing .git "
+            "repository found; deferring to packaged default.",
+            file=stream,
+        )
+        return None
+
+    for candidate in _ascend_inclusive(pkg_root, git_root):
+        if _has_catalogue_markers(candidate):
+            return str(candidate)
+
+    print(
+        f"agentbundle: editable install detected at {pkg_root} but no catalogue "
+        f"root (packs/ + .claude-plugin/marketplace.json) found at or above it "
+        f"within the repository {git_root}; deferring to packaged default.",
+        file=stream,
+    )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Layer 4 — packaged default
+# ---------------------------------------------------------------------------
+
+
+def _source_from_install_defaults(text: str) -> str | None:
+    """Parse ``[defaults].source`` from ``install-defaults.toml`` *text*.
+
+    Returns ``None`` for malformed TOML, a missing ``[defaults]`` table, or an
+    absent/blank ``source`` (the private-fork pattern).
+    """
+    try:
+        data = tomllib.loads(text)
+    except tomllib.TOMLDecodeError:
+        return None
+    defaults = data.get("defaults")
+    if not isinstance(defaults, dict):
+        return None
+    source = defaults.get("source")
+    if not isinstance(source, str) or not source.strip():
+        return None
+    return source
+
+
+def read_packaged_default() -> str | None:
+    """Return ``[defaults].source`` from the packaged
+    ``_data/install-defaults.toml``, or ``None``.
+
+    An absent file, an empty/blanked ``source``, or malformed TOML all yield
+    ``None`` (no layer-4 default) — the private-fork pattern.
+    """
+    try:
+        from importlib.resources import files
+
+        resource = files("agentbundle").joinpath("_data/install-defaults.toml")
+        if not resource.is_file():
+            return None
+        text = resource.read_text(encoding="utf-8")
+    except (FileNotFoundError, ModuleNotFoundError, OSError):
+        return None
+    return _source_from_install_defaults(text)
+
+
+def _load_distribution() -> object | None:
+    """Return the ``agentbundle`` distribution, **preferring** one that carries
+    a ``direct_url.json`` (the editable record).
+
+    A stale source-tree ``agentbundle.egg-info`` can sit on ``sys.path`` beside
+    the venv's ``.dist-info`` after an editable install; a plain
+    ``metadata.distribution("agentbundle")`` may then return the egg-info
+    (which has no ``direct_url.json``), silently defeating editable detection —
+    exactly the gateway-bound-fork case layer 3 exists for. Scanning and
+    preferring the record-bearing distribution makes detection robust to that
+    shadowing.
+    """
+    import importlib.metadata as _md
+
+    def _norm(name: str) -> str:
+        return re.sub(r"[-_.]+", "-", name).lower()
+
+    fallback = None
+    for dist in _md.distributions():
+        # A corrupt dist-info may lack a Name (KeyError) or be unreadable
+        # (OSError); skip just that entry rather than aborting the scan.
+        try:
+            name = dist.metadata["Name"]
+            has_record = bool(dist.read_text("direct_url.json"))
+        except (KeyError, OSError):
+            continue
+        if not name or _norm(name) != "agentbundle":
+            continue
+        if has_record:
+            return dist
+        if fallback is None:
+            fallback = dist
+    if fallback is not None:
+        return fallback
+    try:
+        return _md.distribution("agentbundle")
+    except _md.PackageNotFoundError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Composer
+# ---------------------------------------------------------------------------
+
+
+def resolve_default_source(
+    explicit: str | None,
+    *,
+    config_source: str | None = None,
+    dist: object = _UNSET,
+    read_packaged: Callable[[], str | None] | None = None,
+    stream: TextIO | None = None,
+) -> str:
+    """Resolve the catalogue source through the four-layer chain.
+
+    First-match-wins, highest-first: explicit arg (verbatim, unvalidated —
+    today's behaviour) › validated ``config_source`` › editable detection ›
+    validated packaged default. Raises ``CatalogueError`` naming all recovery
+    paths when no layer yields a source. Writes nothing on any path.
+
+    Pure over its injected environment (``config_source``, ``dist``,
+    ``read_packaged``) so the precedence and validation logic is unit-testable
+    without touching the real filesystem or installed metadata.
+    """
+    if stream is None:
+        stream = sys.stderr
+    # Layer 1 — explicit positional: pass through verbatim, no validation
+    # (identical to today; the default chain runs only when omitted).
+    if explicit is not None:
+        return explicit
+
+    # Layer 2 — user [settings].source, validated.
+    if config_source is not None:
+        if _is_valid_source(config_source):
+            return config_source
+        print(
+            f"agentbundle: ignoring invalid [settings].source ({config_source!r}); "
+            f"clear it with 'agentbundle config unset source'.",
+            file=stream,
+        )
+
+    # Layer 3 — editable detection.
+    if dist is _UNSET:
+        dist = _load_distribution()
+    editable = _detect_editable_source(dist, stream=stream)
+    if editable is not None:
+        return editable
+
+    # Layer 4 — packaged default, validated.
+    if read_packaged is None:
+        read_packaged = read_packaged_default
+    packaged = read_packaged()
+    if packaged is not None and _is_valid_source(packaged):
+        return packaged
+
+    raise CatalogueError(
+        _NO_SOURCE_MSG
+        + ". If you previously ran 'config set source', clear a stale value "
+        "with 'agentbundle config unset source'."
+    )

--- a/packages/agentbundle/agentbundle/user_config.py
+++ b/packages/agentbundle/agentbundle/user_config.py
@@ -32,7 +32,7 @@ from typing import Any, Mapping
 from agentbundle.config import _emit_basic_string
 
 
-_KNOWN_KEYS: tuple[str, ...] = ("adapter",)
+_KNOWN_KEYS: tuple[str, ...] = ("adapter", "source")
 
 
 @dataclass(frozen=True)
@@ -43,9 +43,13 @@ class UserConfig:
     exist, or the on-disk value failed validation." Callers cannot
     distinguish these three from the dataclass alone; the loader emits
     a stderr warning when validation drops a value.
+
+    `adapter` and `source` are parsed independently: a malformed value
+    for one is dropped (with a warning) without dropping the other.
     """
 
     adapter: str | None = None
+    source: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -123,9 +127,20 @@ def read_user_config(path: Path) -> UserConfig:
         )
         return UserConfig()
 
+    # `adapter` and `source` are parsed independently so a malformed value
+    # for one fail-softs without dropping the other.
+    return UserConfig(
+        adapter=_parse_adapter(settings, path),
+        source=_parse_source(settings, path),
+    )
+
+
+def _parse_adapter(settings: dict, path: Path) -> str | None:
+    """Fail-soft parse of `[settings].adapter` (warns + returns `None` on a
+    non-string value or a value outside the shipped adapter contract)."""
     raw_adapter = settings.get("adapter")
     if raw_adapter is None:
-        return UserConfig()
+        return None
     if not isinstance(raw_adapter, str):
         print(
             f"agentbundle: warning: user config at {path} has a "
@@ -133,7 +148,7 @@ def read_user_config(path: Path) -> UserConfig:
             f"ignoring.",
             file=sys.stderr,
         )
-        return UserConfig()
+        return None
 
     # Validate against the shipped adapter contract. Late import to
     # avoid a circular import at module load.
@@ -149,9 +164,32 @@ def read_user_config(path: Path) -> UserConfig:
             f"file or run `agentbundle config set adapter <name>`.",
             file=sys.stderr,
         )
-        return UserConfig()
+        return None
 
-    return UserConfig(adapter=raw_adapter)
+    return raw_adapter
+
+
+def _parse_source(settings: dict, path: Path) -> str | None:
+    """Fail-soft parse of `[settings].source` (warns + returns `None` on a
+    non-string value).
+
+    Scheme/marker validation is deliberately **not** here — it lives in
+    `source_defaults.resolve_default_source`, so a value set via
+    `config set source` persists and is rejected (with a diagnostic) only at
+    resolution time. The loader's job is to surface the string for layer 2.
+    """
+    raw_source = settings.get("source")
+    if raw_source is None:
+        return None
+    if not isinstance(raw_source, str):
+        print(
+            f"agentbundle: warning: user config at {path} has a "
+            f"non-string `source` value ({type(raw_source).__name__}); "
+            f"ignoring.",
+            file=sys.stderr,
+        )
+        return None
+    return raw_source
 
 
 def load_user_config() -> UserConfig:
@@ -236,6 +274,16 @@ def _validate_key_value(key: str, value: str) -> None:
             raise ValueError(
                 f"agentbundle: unknown adapter {value!r}. Admissible: "
                 f"{sorted(shipped)}."
+            )
+    if key == "source":
+        # Parseable-only at write time: refuse an empty/whitespace value. The
+        # scheme gate (reject non-`git+https` URLs, require markers for a local
+        # path) lives in `source_defaults.resolve_default_source`, so a value
+        # like `http://…` is accepted-but-inert here and rejected at resolution.
+        if not value.strip():
+            raise ValueError(
+                "agentbundle: `source` must be a non-empty catalogue URI "
+                "(git+https://…) or local path."
             )
 
 

--- a/packages/agentbundle/agentbundle/version.py
+++ b/packages/agentbundle/agentbundle/version.py
@@ -14,7 +14,7 @@ import tomllib
 from importlib.resources import files
 from pathlib import Path
 
-CLI_VERSION = "0.7.0"
+CLI_VERSION = "0.8.0"
 
 _HERE = Path(__file__).resolve().parent
 

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentbundle"
-version = "0.7.0"
+version = "0.8.0"
 description = "npm for your coding agent. Install packs of skills, subagents, and hooks into any repo, for every major agent."
 requires-python = ">=3.11"
 dependencies = []

--- a/packages/agentbundle/tests/integration/test_editable_source_detection.py
+++ b/packages/agentbundle/tests/integration/test_editable_source_detection.py
@@ -1,0 +1,83 @@
+"""Keystone integration test (RFC-0046 T3): editable detection resolves to the
+real clone root against a **real** `pip install -e`, not a mocked
+`direct_url.json`.
+
+Builds its own throwaway venv, editable-installs `packages/agentbundle` into
+it, then runs `_detect_editable_source` against the real PEP 610 record and
+asserts it walks up to the clone root (the dir holding `packs/` +
+`.claude-plugin/marketplace.json`).
+
+Slow (venv + editable build). `make build-check` runs no pytest, so this is
+wired into CI explicitly in `build-check.yml`.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import venv
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+PKG = REPO_ROOT / "packages" / "agentbundle"
+
+
+def _venv_env() -> dict[str, str]:
+    """Env for the venv subprocesses with the parent's `PYTHONPATH` /
+    `VIRTUAL_ENV` / `PYTHONHOME` stripped, so the throwaway venv's
+    site-packages (the editable install) is authoritative — otherwise an
+    inherited source-tree `PYTHONPATH` shadows the editable metadata and
+    `importlib.metadata` finds no `direct_url.json`. This drop-set is the
+    known-necessary minimum, not exhaustive — if this ever flakes on a macOS
+    framework build, `__PYVENV_LAUNCHER__` is the next suspect."""
+    drop = {"PYTHONPATH", "VIRTUAL_ENV", "PYTHONHOME"}
+    return {k: v for k, v in os.environ.items() if k not in drop}
+
+
+def test_editable_detection_against_real_install(tmp_path):
+    assert (REPO_ROOT / "packs").is_dir(), f"clone markers missing at {REPO_ROOT}"
+    assert (REPO_ROOT / ".claude-plugin" / "marketplace.json").is_file()
+
+    # Defensive clean — a stale build/ or egg-info from a prior local build can
+    # shadow the editable install (see feedback_gitignore_silent_skip).
+    for stale in (PKG / "build", PKG / "agentbundle.egg-info", PKG / "dist"):
+        shutil.rmtree(stale, ignore_errors=True)
+
+    venv_dir = tmp_path / "venv"
+    venv.create(venv_dir, with_pip=True)
+    bindir = venv_dir / ("Scripts" if sys.platform == "win32" else "bin")
+    py = bindir / ("python.exe" if sys.platform == "win32" else "python")
+
+    env = _venv_env()
+    install = subprocess.run(
+        [str(py), "-m", "pip", "install", "-e", str(PKG), "--quiet"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert install.returncode == 0, (
+        f"editable install failed:\nstdout={install.stdout}\nstderr={install.stderr}"
+    )
+
+    # Run detection inside the venv against the real installed metadata,
+    # through the production loader path (`_load_distribution` prefers the
+    # record-bearing dist over a shadowing egg-info).
+    snippet = (
+        "from agentbundle.source_defaults import "
+        "_detect_editable_source, _load_distribution\n"
+        "print(_detect_editable_source(_load_distribution()))\n"
+    )
+    detect = subprocess.run(
+        [str(py), "-c", snippet], capture_output=True, text=True, env=env
+    )
+    assert detect.returncode == 0, (
+        f"detection run failed:\nstdout={detect.stdout}\nstderr={detect.stderr}"
+    )
+    detected = detect.stdout.strip()
+    assert detected == str(REPO_ROOT.resolve()), (
+        f"editable detection resolved to {detected!r}, expected the clone root "
+        f"{str(REPO_ROOT.resolve())!r}"
+    )

--- a/packages/agentbundle/tests/integration/test_install_default_source.py
+++ b/packages/agentbundle/tests/integration/test_install_default_source.py
@@ -1,10 +1,13 @@
-"""T5 end-to-end (no network): a bare `install` (no `catalogue` positional)
-resolves through the default chain at the command boundary and installs.
+"""End-to-end (no network): bare source verbs (no `catalogue` positional)
+resolve through the default chain at the command boundary.
 
-Uses layer 2 (`config set source` → a local catalogue with both markers) so
-the resolution short-circuits before layer 3, exercising the full wiring
-(`resolve_catalogue_uri` → `resolve_default_source` → `resolve_catalogue` →
-install) without touching the network or the ambient editable record.
+Covers `install --pack core` (RFC-0046), the `install --profile` and
+`_offer_upgrade` hand-off sites, and the discovery verbs `list-packs` /
+`list-profiles` (RFC-0047). Uses layer 2 (`config set source` → a local
+catalogue with both markers) so resolution short-circuits before layer 3,
+exercising the full wiring (`resolve_catalogue_uri` → `resolve_default_source`
+→ `resolve_catalogue`) without touching the network or the ambient editable
+record.
 """
 
 from __future__ import annotations
@@ -15,7 +18,7 @@ import io
 import shutil
 from pathlib import Path
 
-from agentbundle.commands import install
+from agentbundle.commands import install, list_packs, list_profiles
 from agentbundle.user_config import UserConfig
 
 
@@ -101,3 +104,34 @@ def test_offer_upgrade_hands_off_resolved_uri(monkeypatch):
         args, pack_name="core", scope="repo", catalogue_uri="git+https://resolved/x"
     )
     assert captured["ns"].catalogue == "git+https://resolved/x"
+
+
+def test_bare_list_packs_resolves_default_source(tmp_path):
+    # RFC-0047: a bare `list-packs` (no catalogue) resolves the source via the
+    # same chain and lists the catalogue's packs.
+    cat = _local_catalogue(tmp_path)
+    args = argparse.Namespace(catalogue=None, _user_config=UserConfig(source=str(cat)))
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        rc = list_packs.run(args)
+    assert rc == 0, err.getvalue()
+    assert "core" in out.getvalue()
+
+
+def test_bare_list_profiles_resolves_default_source(tmp_path):
+    # RFC-0047: a bare `list-profiles` resolves the source AND reads it — plant a
+    # profile so the test fails if resolution were dropped (an empty listing
+    # would pass for the wrong reason).
+    cat = _local_catalogue(tmp_path)
+    profiles_dir = cat / "profiles"
+    profiles_dir.mkdir()
+    (profiles_dir / "sample.toml").write_text(
+        'scope = "repo"\ndescription = "a sample profile"\n\n[[packs]]\npack = "core"\n',
+        encoding="utf-8",
+    )
+    args = argparse.Namespace(catalogue=None, _user_config=UserConfig(source=str(cat)))
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        rc = list_profiles.run(args)
+    assert rc == 0, err.getvalue()
+    assert "sample" in out.getvalue()  # proves the resolved catalogue was read

--- a/packages/agentbundle/tests/integration/test_install_default_source.py
+++ b/packages/agentbundle/tests/integration/test_install_default_source.py
@@ -1,0 +1,103 @@
+"""T5 end-to-end (no network): a bare `install` (no `catalogue` positional)
+resolves through the default chain at the command boundary and installs.
+
+Uses layer 2 (`config set source` → a local catalogue with both markers) so
+the resolution short-circuits before layer 3, exercising the full wiring
+(`resolve_catalogue_uri` → `resolve_default_source` → `resolve_catalogue` →
+install) without touching the network or the ambient editable record.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import shutil
+from pathlib import Path
+
+from agentbundle.commands import install
+from agentbundle.user_config import UserConfig
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+REAL_CORE = REPO_ROOT / "packs" / "core"
+
+
+def _local_catalogue(tmp_path: Path) -> Path:
+    """A tmp catalogue holding both markers (`packs/` + the marketplace file)
+    and a real `packs/core/`."""
+    cat = tmp_path / "cat"
+    (cat / "packs").mkdir(parents=True)
+    shutil.copytree(REAL_CORE, cat / "packs" / "core", symlinks=False)
+    cp = cat / ".claude-plugin"
+    cp.mkdir()
+    (cp / "marketplace.json").write_text("{}", encoding="utf-8")
+    return cat
+
+
+def test_bare_install_resolves_via_config_source(tmp_path):
+    cat = _local_catalogue(tmp_path)
+    target = tmp_path / "repo"
+    target.mkdir()
+
+    # Bare invocation: catalogue=None; the source comes from layer 2.
+    args = argparse.Namespace(
+        pack="core",
+        catalogue=None,
+        output=str(target),
+        scope=None,
+        force=False,
+        force_merge=False,
+        profile=None,
+        _user_config=UserConfig(source=str(cat)),
+    )
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        rc = install.run(args)
+    assert rc == 0, f"bare install failed: {err.getvalue()}"
+    # Real artifact landed — the projected core tree exists under the target.
+    assert any(target.rglob("*")), "install produced no files"
+
+
+def test_bare_profile_install_reaches_default_resolver(tmp_path, monkeypatch):
+    # AC: a bare `install --profile X` (no catalogue) resolves through the
+    # default chain at the `_run_profile` site, not just the `--pack` path.
+    from agentbundle.commands import _common
+
+    seen = {}
+
+    def _spy(args):
+        seen["catalogue"] = args.catalogue
+        return str(tmp_path / "empty-catalogue")  # no profile there → stops after resolve
+
+    monkeypatch.setattr(_common, "resolve_catalogue_uri", _spy)
+
+    args = argparse.Namespace(
+        pack=None,
+        profile="starter",
+        catalogue=None,
+        output=str(tmp_path),
+        scope=None,
+        adapter=None,
+        _user_config=None,
+    )
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        install.run(args)  # ProfileError after resolve is fine — we assert the call
+    assert "catalogue" in seen, "_run_profile never reached the default resolver"
+    assert seen["catalogue"] is None  # the omitted positional flowed through
+
+
+def test_offer_upgrade_hands_off_resolved_uri(monkeypatch):
+    # AC: the install→upgrade-offer hand-off carries the already-resolved URI,
+    # never `args.catalogue` (which is None on a bare install) → no re-resolution.
+    from agentbundle.commands import upgrade as _upgrade
+
+    captured = {}
+    monkeypatch.setattr(_upgrade, "run", lambda ns: captured.setdefault("ns", ns) and 0)
+
+    args = argparse.Namespace(catalogue=None, output=".", _user_config=None)
+    install._offer_upgrade(
+        args, pack_name="core", scope="repo", catalogue_uri="git+https://resolved/x"
+    )
+    assert captured["ns"].catalogue == "git+https://resolved/x"

--- a/packages/agentbundle/tests/unit/test_cli_catalogue_optional.py
+++ b/packages/agentbundle/tests/unit/test_cli_catalogue_optional.py
@@ -1,0 +1,40 @@
+"""T5: the `catalogue` positional is optional on `install`/`upgrade` and still
+required on the discovery verbs — RFC-0046 (argparse surface only).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentbundle.cli import _build_parser
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["install", "--pack", "core"],
+        ["install", "--profile", "starter"],
+        ["upgrade", "--pack", "core"],
+    ],
+)
+def test_catalogue_optional_on_install_and_upgrade(argv):
+    ns = _build_parser().parse_args(argv)
+    assert ns.catalogue is None
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["install", "--pack", "core", "git+https://github.com/x/y"],
+        ["upgrade", "--pack", "core", "/local/catalogue"],
+    ],
+)
+def test_explicit_catalogue_passes_through(argv):
+    ns = _build_parser().parse_args(argv)
+    assert ns.catalogue == argv[-1]
+
+
+@pytest.mark.parametrize("verb", ["list-packs", "list-profiles"])
+def test_catalogue_still_required_on_discovery_verbs(verb):
+    with pytest.raises(SystemExit):
+        _build_parser().parse_args([verb])

--- a/packages/agentbundle/tests/unit/test_cli_catalogue_optional.py
+++ b/packages/agentbundle/tests/unit/test_cli_catalogue_optional.py
@@ -15,9 +15,12 @@ from agentbundle.cli import _build_parser
         ["install", "--pack", "core"],
         ["install", "--profile", "starter"],
         ["upgrade", "--pack", "core"],
+        # RFC-0047: the discovery verbs are now optional too.
+        ["list-packs"],
+        ["list-profiles"],
     ],
 )
-def test_catalogue_optional_on_install_and_upgrade(argv):
+def test_catalogue_optional_on_all_source_verbs(argv):
     ns = _build_parser().parse_args(argv)
     assert ns.catalogue is None
 
@@ -27,14 +30,10 @@ def test_catalogue_optional_on_install_and_upgrade(argv):
     [
         ["install", "--pack", "core", "git+https://github.com/x/y"],
         ["upgrade", "--pack", "core", "/local/catalogue"],
+        ["list-packs", "git+https://github.com/x/y"],
+        ["list-profiles", "/local/catalogue"],
     ],
 )
 def test_explicit_catalogue_passes_through(argv):
     ns = _build_parser().parse_args(argv)
     assert ns.catalogue == argv[-1]
-
-
-@pytest.mark.parametrize("verb", ["list-packs", "list-profiles"])
-def test_catalogue_still_required_on_discovery_verbs(verb):
-    with pytest.raises(SystemExit):
-        _build_parser().parse_args([verb])

--- a/packages/agentbundle/tests/unit/test_config_cmd.py
+++ b/packages/agentbundle/tests/unit/test_config_cmd.py
@@ -41,11 +41,11 @@ def test_get_no_key_on_missing_file_reports_builtin(capsys) -> None:
     exit_code = run(_args("get"))
     captured = capsys.readouterr()
     assert exit_code == 0
-    # One line per known key. Today only `adapter`.
-    out = captured.out.strip()
-    parts = out.split("\t")
-    assert parts[0] == "adapter"
-    assert parts[2] == "(builtin)"
+    # One line per known key: `adapter` (builtin default) and `source`
+    # (unset — no builtin constant; RFC-0046).
+    lines = {ln.split("\t")[0]: ln.split("\t") for ln in captured.out.strip().splitlines()}
+    assert lines["adapter"][2] == "(builtin)"
+    assert lines["source"][2] == "(unset)"
 
 
 def test_get_adapter_after_set_reports_file(capsys) -> None:

--- a/packages/agentbundle/tests/unit/test_source_defaults.py
+++ b/packages/agentbundle/tests/unit/test_source_defaults.py
@@ -1,0 +1,431 @@
+"""Unit tests for the four-layer catalogue-source default resolver
+(`agentbundle.source_defaults`) — RFC-0046 / ADR-0036.
+
+Covers T1 (packaged default reader), T3 (editable detection, hardened), and
+T4 (the precedence/validation composer + negative invariants). The keystone
+real-`pip install -e` integration test lives in
+`tests/integration/test_editable_source_detection.py`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agentbundle.catalogue import CatalogueError
+from agentbundle import source_defaults
+from agentbundle.source_defaults import (
+    _source_from_install_defaults,
+    _detect_editable_source,
+    _is_valid_source,
+    _load_distribution,
+    read_packaged_default,
+    resolve_default_source,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeDist:
+    """Stand-in for an `importlib.metadata.Distribution` — `read_text` returns
+    the supplied `direct_url.json` body (or `None` for a missing record)."""
+
+    def __init__(self, direct_url_json: str | None):
+        self._raw = direct_url_json
+
+    def read_text(self, name: str) -> str | None:
+        if name == "direct_url.json":
+            return self._raw
+        return None
+
+
+def _direct_url(path: Path, *, editable: bool = True, host: str = "") -> str:
+    url = f"file://{host}{path.as_posix()}"
+    return json.dumps({"url": url, "dir_info": {"editable": editable}})
+
+
+def _make_markers(root: Path) -> None:
+    (root / "packs").mkdir(parents=True, exist_ok=True)
+    cp = root / ".claude-plugin"
+    cp.mkdir(parents=True, exist_ok=True)
+    (cp / "marketplace.json").write_text("{}", encoding="utf-8")
+
+
+def _make_git(root: Path, *, as_file: bool = False) -> None:
+    if as_file:
+        (root / ".git").write_text("gitdir: /elsewhere/.git/worktrees/wt\n", encoding="utf-8")
+    else:
+        (root / ".git").mkdir(parents=True, exist_ok=True)
+
+
+def _clone(tmp_path: Path, *, git_as_file: bool = False) -> tuple[Path, Path]:
+    """Build clone/ with markers + .git at the root and a pkg subdir; return
+    (clone_root, pkg_dir)."""
+    clone = tmp_path / "clone"
+    pkg = clone / "packages" / "agentbundle"
+    pkg.mkdir(parents=True)
+    _make_markers(clone)
+    _make_git(clone, as_file=git_as_file)
+    return clone, pkg
+
+
+# ---------------------------------------------------------------------------
+# T1 — packaged default
+# ---------------------------------------------------------------------------
+
+
+def test_packaged_default_ships_upstream_url():
+    # Goal-based: the real bundled _data/install-defaults.toml reads back.
+    assert read_packaged_default() == "git+https://github.com/eugenelim/agent-ready-repo"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "",  # blank file
+        "[defaults]\n",  # no source key
+        '[defaults]\nsource = ""\n',  # empty source — the private-fork blank
+        '[defaults]\nsource = "   "\n',  # whitespace-only
+        "[other]\nx = 1\n",  # no [defaults] table
+        "not = valid = toml\n",  # malformed
+        "[defaults]\nsource = 42\n",  # non-string
+    ],
+)
+def test_packaged_default_absent_or_empty_is_none(text):
+    assert _source_from_install_defaults(text) is None
+
+
+def test_packaged_default_parses_source():
+    assert (
+        _source_from_install_defaults('[defaults]\nsource = "git+https://github.com/x/y"\n')
+        == "git+https://github.com/x/y"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T4 — the scheme/marker validation gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "file:///etc/passwd",
+        "file:/etc/passwd",  # single-slash, no authority — the differential case
+        "http://evil.example",
+        "https://example.com",
+        "git+ssh://git@github.com/x/y",
+        "GIT+HTTPS://github.com/x/y",  # mis-cased — sink is case-sensitive
+        "ftp://host/x",
+        "",  # empty
+    ],
+)
+def test_scheme_gate_rejects_non_git_https_urls(value):
+    assert _is_valid_source(value) is False
+
+
+def test_scheme_gate_accepts_git_https():
+    assert _is_valid_source("git+https://github.com/eugenelim/agent-ready-repo") is True
+
+
+def test_scheme_gate_accepts_local_path_with_markers(tmp_path):
+    _make_markers(tmp_path)
+    assert _is_valid_source(str(tmp_path)) is True
+
+
+def test_scheme_gate_rejects_local_path_without_markers(tmp_path):
+    assert _is_valid_source(str(tmp_path)) is False
+
+
+def test_scheme_gate_windows_drive_is_local_branch_not_scheme():
+    # C:\... routes to the local-path branch (no markers on this host → False),
+    # NOT rejected as a "c" scheme — proves the drive-letter guard fires first.
+    assert _is_valid_source(r"C:\definitely\nonexistent") is False
+
+
+# ---------------------------------------------------------------------------
+# T3 — editable detection
+# ---------------------------------------------------------------------------
+
+
+def test_editable_dist_none_returns_none():
+    assert _detect_editable_source(None) is None
+
+
+def test_editable_missing_direct_url_returns_none():
+    assert _detect_editable_source(_FakeDist(None)) is None
+
+
+def test_editable_false_returns_none(tmp_path):
+    _, pkg = _clone(tmp_path)
+    dist = _FakeDist(_direct_url(pkg, editable=False))
+    assert _detect_editable_source(dist) is None
+
+
+def test_editable_non_file_scheme_returns_none(tmp_path):
+    raw = json.dumps({"url": "https://github.com/x/y", "dir_info": {"editable": True}})
+    assert _detect_editable_source(_FakeDist(raw)) is None
+
+
+def test_editable_non_localhost_host_rejected(tmp_path):
+    _, pkg = _clone(tmp_path)
+    dist = _FakeDist(_direct_url(pkg, host="evil.example"))
+    assert _detect_editable_source(dist) is None
+
+
+def test_editable_localhost_host_ok(tmp_path):
+    clone, pkg = _clone(tmp_path)
+    dist = _FakeDist(_direct_url(pkg, host="localhost"))
+    assert _detect_editable_source(dist) == str(clone.resolve())
+
+
+def test_editable_resolves_to_clone_root_git_dir(tmp_path):
+    clone, pkg = _clone(tmp_path, git_as_file=False)
+    dist = _FakeDist(_direct_url(pkg))
+    assert _detect_editable_source(dist) == str(clone.resolve())
+
+
+def test_editable_resolves_with_git_as_file(tmp_path):
+    # Conductor worktree: .git is a regular file, not a directory.
+    clone, pkg = _clone(tmp_path, git_as_file=True)
+    dist = _FakeDist(_direct_url(pkg))
+    assert _detect_editable_source(dist) == str(clone.resolve())
+
+
+def test_editable_catalogue_equals_git_root_resolves(tmp_path):
+    # Closed-interval bound: markers sit AT the .git root (the only valid match
+    # sits at the boundary) — must resolve, not fall through.
+    clone, pkg = _clone(tmp_path)
+    dist = _FakeDist(_direct_url(pkg))
+    assert _detect_editable_source(dist) == str(clone.resolve())
+
+
+def test_editable_stops_at_first_match_inside_clone(tmp_path):
+    # Markers planted in an intermediate dir inside the clone stop the walk at
+    # first match (accident-guard residual) — returns the intermediate, not the
+    # clone root.
+    clone = tmp_path / "clone"
+    intermediate = clone / "sub"
+    pkg = intermediate / "pkg"
+    pkg.mkdir(parents=True)
+    _make_markers(clone)
+    _make_git(clone)
+    _make_markers(intermediate)
+    dist = _FakeDist(_direct_url(pkg))
+    assert _detect_editable_source(dist) == str(intermediate.resolve())
+
+
+def test_editable_markers_above_git_root_not_matched(tmp_path, capsys):
+    # A packs/ + marketplace.json pair in a parent ABOVE the .git root is never
+    # matched (repo-bounded ascent); the clone itself has no markers.
+    parent = tmp_path / "parent"
+    clone = parent / "clone"
+    pkg = clone / "packages" / "agentbundle"
+    pkg.mkdir(parents=True)
+    _make_markers(parent)  # planted ABOVE the repo boundary
+    _make_git(clone)  # clone has .git but NO markers
+    dist = _FakeDist(_direct_url(pkg))
+    assert _detect_editable_source(dist) is None
+    err = capsys.readouterr().err
+    assert "editable install detected" in err
+    assert "deferring to packaged default" in err
+
+
+def test_editable_no_git_root_defers_with_diagnostic(tmp_path, capsys):
+    # No enclosing .git anywhere → cannot bound the walk → diagnostic + None.
+    pkg = tmp_path / "loose" / "pkg"
+    pkg.mkdir(parents=True)
+    dist = _FakeDist(_direct_url(pkg))
+    assert _detect_editable_source(dist) is None
+    err = capsys.readouterr().err
+    assert "editable install detected" in err
+    assert "deferring to packaged default" in err
+
+
+def test_editable_symlink_canonicalized_before_walk(tmp_path):
+    # A symlink in the recorded URL is collapsed by resolve() before the walk,
+    # so the matched root stays inside the real clone.
+    clone, pkg = _clone(tmp_path)
+    link = tmp_path / "linkpkg"
+    try:
+        link.symlink_to(pkg, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unsupported on this platform/filesystem")
+    dist = _FakeDist(_direct_url(link))
+    assert _detect_editable_source(dist) == str(clone.resolve())
+
+
+# ---------------------------------------------------------------------------
+# T4 — the composer: precedence, validation-skip, negatives, error
+# ---------------------------------------------------------------------------
+
+
+def _resolving_dist(tmp_path: Path) -> _FakeDist:
+    _, pkg = _clone(tmp_path)
+    return _FakeDist(_direct_url(pkg))
+
+
+def test_layer1_explicit_wins_verbatim(tmp_path):
+    # Layer 1 is an unvalidated pass-through — even a value the gate would
+    # reject is returned untouched (today's behaviour).
+    out = resolve_default_source(
+        "http://explicit-passthrough",
+        config_source="git+https://github.com/x/y",
+        dist=_resolving_dist(tmp_path),
+        read_packaged=lambda: "git+https://github.com/a/b",
+    )
+    assert out == "http://explicit-passthrough"
+
+
+def test_layer2_outranks_layer3(tmp_path):
+    out = resolve_default_source(
+        None,
+        config_source="git+https://github.com/x/y",
+        dist=_resolving_dist(tmp_path),
+        read_packaged=lambda: "git+https://github.com/a/b",
+    )
+    assert out == "git+https://github.com/x/y"
+
+
+def test_layer3_when_no_config(tmp_path):
+    clone, pkg = _clone(tmp_path)
+    out = resolve_default_source(
+        None,
+        config_source=None,
+        dist=_FakeDist(_direct_url(pkg)),
+        read_packaged=lambda: "git+https://github.com/a/b",
+    )
+    assert out == str(clone.resolve())
+
+
+def test_layer4_when_no_editable():
+    out = resolve_default_source(
+        None,
+        config_source=None,
+        dist=None,
+        read_packaged=lambda: "git+https://github.com/a/b",
+    )
+    assert out == "git+https://github.com/a/b"
+
+
+def test_invalid_config_source_skipped_to_layer3(tmp_path, capsys):
+    clone, pkg = _clone(tmp_path)
+    out = resolve_default_source(
+        None,
+        config_source="http://not-allowed",
+        dist=_FakeDist(_direct_url(pkg)),
+        read_packaged=lambda: "git+https://github.com/a/b",
+    )
+    assert out == str(clone.resolve())
+    err = capsys.readouterr().err
+    assert "config unset source" in err  # names the recovery path
+
+
+def test_invalid_packaged_default_skipped():
+    with pytest.raises(CatalogueError):
+        resolve_default_source(
+            None,
+            config_source=None,
+            dist=None,
+            read_packaged=lambda: "http://not-allowed",
+        )
+
+
+def test_all_layers_empty_raises_with_recovery_paths():
+    with pytest.raises(CatalogueError) as exc:
+        resolve_default_source(
+            None, config_source=None, dist=None, read_packaged=lambda: None
+        )
+    msg = str(exc.value)
+    assert (
+        "no catalogue source: pass --catalogue, run 'agentbundle config set "
+        "source …', or pip install -e the catalogue" in msg
+    )
+    assert "config unset source" in msg  # the stale-value recovery path
+
+
+def test_no_implicit_cwd_fallback(tmp_path, monkeypatch):
+    # A cwd that happens to hold the markers must NEVER be consulted when no
+    # layer yielded a source.
+    _make_markers(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(CatalogueError):
+        resolve_default_source(
+            None, config_source=None, dist=None, read_packaged=lambda: None
+        )
+
+
+def test_editable_detected_but_no_root_falls_through_to_layer4(tmp_path, capsys):
+    # Composed path (AC): editable detected, no catalogue root below the repo
+    # boundary → stderr diagnostic AND layer 4 is returned (resolution continues).
+    parent = tmp_path / "parent"
+    clone = parent / "clone"
+    pkg = clone / "packages" / "agentbundle"
+    pkg.mkdir(parents=True)
+    _make_markers(parent)  # markers above the boundary — not matchable
+    _make_git(clone)
+    out = resolve_default_source(
+        None,
+        config_source=None,
+        dist=_FakeDist(_direct_url(pkg)),
+        read_packaged=lambda: "git+https://github.com/a/b",
+    )
+    assert out == "git+https://github.com/a/b"  # layer 4 returned
+    err = capsys.readouterr().err
+    assert "editable install detected" in err
+    assert "deferring to packaged default" in err
+
+
+def test_resolution_writes_nothing(tmp_path, monkeypatch):
+    # No-write invariant: a config file present on disk is byte-unchanged after
+    # resolution on the layer-2, editable-deferred, layer-4, and error paths.
+    from agentbundle.user_config import write_setting
+
+    cfg = tmp_path / "config.toml"
+    write_setting(cfg, "source", "git+https://github.com/x/y")
+    before = cfg.read_bytes()
+
+    clone, pkg = _clone(tmp_path)
+    # layer 2 hit
+    resolve_default_source(None, config_source="git+https://github.com/x/y", dist=None,
+                           read_packaged=lambda: None)
+    # layer 3 hit
+    resolve_default_source(None, config_source=None, dist=_FakeDist(_direct_url(pkg)),
+                           read_packaged=lambda: None)
+    # editable-deferred + layer 4
+    resolve_default_source(None, config_source="http://bad", dist=None,
+                           read_packaged=lambda: "git+https://github.com/a/b")
+    # all-layers-empty error path
+    with pytest.raises(CatalogueError):
+        resolve_default_source(None, config_source=None, dist=None,
+                               read_packaged=lambda: None)
+    assert cfg.read_bytes() == before
+
+
+def test_load_distribution_prefers_record_bearing_dist(monkeypatch):
+    # _load_distribution must prefer the dist carrying direct_url.json over a
+    # shadowing egg-info — regardless of iteration order (the gateway-fork case).
+    class _Meta(dict):
+        pass
+
+    class _D:
+        def __init__(self, name, du):
+            self.metadata = _Meta(Name=name)
+            self._du = du
+
+        def read_text(self, n):
+            return self._du if n == "direct_url.json" else None
+
+    egg = _D("agentbundle", None)  # no direct_url — the shadowing egg-info
+    distinfo = _D("agentbundle", '{"dir_info":{"editable":true},"url":"file:///x"}')
+    other = _D("requests", None)
+
+    import importlib.metadata as md
+    # egg-info first in iteration order — the record-bearing dist must still win.
+    monkeypatch.setattr(md, "distributions", lambda: iter([other, egg, distinfo]))
+    assert _load_distribution() is distinfo

--- a/packages/agentbundle/tests/unit/test_user_config_source.py
+++ b/packages/agentbundle/tests/unit/test_user_config_source.py
@@ -1,0 +1,83 @@
+"""T2: the user `[settings].source` config key — RFC-0046 / ADR-0036.
+
+Covers the write/read/unset round-trip, the read-back that layer 2 consumes,
+the parseable-only write validation (no scheme gate at write time), the
+`config get source` provenance, and independent fail-soft (a malformed
+`source` does not drop a valid `adapter`).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentbundle.commands.config import _effective_value
+from agentbundle.scope import shipped_adapters_from_contract
+from agentbundle.source_defaults import resolve_default_source
+from agentbundle.user_config import (
+    UserConfig,
+    _KNOWN_KEYS,
+    read_user_config,
+    unset_setting,
+    write_setting,
+)
+
+
+def test_source_is_a_known_key():
+    assert "source" in _KNOWN_KEYS
+
+
+def test_write_read_unset_round_trip(tmp_path):
+    p = tmp_path / "config.toml"
+    write_setting(p, "source", "git+https://github.com/x/y")
+    assert read_user_config(p).source == "git+https://github.com/x/y"
+    unset_setting(p, "source")
+    assert read_user_config(p).source is None
+
+
+def test_read_back_is_consumed_as_layer_2(tmp_path):
+    # The load-bearing invariant: a value written by `config set source` is
+    # parsed back onto UserConfig.source AND consumed by resolve_default_source.
+    p = tmp_path / "config.toml"
+    write_setting(p, "source", "git+https://github.com/x/y")
+    cfg = read_user_config(p)
+    out = resolve_default_source(
+        None, config_source=cfg.source, dist=None, read_packaged=lambda: None
+    )
+    assert out == "git+https://github.com/x/y"
+
+
+def test_write_validation_is_parseable_only(tmp_path):
+    p = tmp_path / "config.toml"
+    # Empty / whitespace is refused at write time.
+    with pytest.raises(ValueError):
+        write_setting(p, "source", "  ")
+    # A non-git+https URL is accepted-but-inert (the scheme gate is at
+    # resolution, not at write time) — it must persist.
+    write_setting(p, "source", "http://accepted-but-inert")
+    assert read_user_config(p).source == "http://accepted-but-inert"
+
+
+def test_effective_value_provenance(tmp_path):
+    assert _effective_value("source", UserConfig(source="git+https://github.com/x/y")) == (
+        "git+https://github.com/x/y",
+        "file",
+    )
+    assert _effective_value("source", UserConfig()) == ("", "unset")
+
+
+def test_source_and_adapter_are_independent_failsoft(tmp_path):
+    # A non-string `source` is dropped (warned) without dropping a valid adapter.
+    adapter = sorted(shipped_adapters_from_contract())[0]
+    p = tmp_path / "config.toml"
+    p.write_text(f'[settings]\nadapter = "{adapter}"\nsource = 42\n', encoding="utf-8")
+    cfg = read_user_config(p)
+    assert cfg.adapter == adapter
+    assert cfg.source is None
+
+
+def test_adapter_round_trip_unaffected(tmp_path):
+    # Regression: adding `source` did not break the existing adapter path.
+    adapter = sorted(shipped_adapters_from_contract())[0]
+    p = tmp_path / "config.toml"
+    write_setting(p, "adapter", adapter)
+    assert read_user_config(p).adapter == adapter


### PR DESCRIPTION
## What does this change?

`agentbundle install`, `upgrade`, `list-packs`, and `list-profiles` no longer require a `catalogue` argument. When omitted, the source resolves through a four-layer, trusted-by-construction, first-match-wins chain (ADR-0036): an explicit `catalogue` positional › the user `[settings].source` config › an editable clone (`pip install -e`, PEP 610 + repo-bounded walk-up) › a packaged default (`git+https://github.com/eugenelim/agent-ready-repo`). A public user runs `agentbundle install --pack core` (or `agentbundle list-packs`) with no URL; a gateway-bound editable fork defaults to its own clone.

Two RFCs, one resolver:
- **RFC-0046** — `install`/`upgrade` defaulting + the resolver, config key, editable detection.
- **RFC-0047** — extends the same resolver to the discovery verbs `list-packs`/`list-profiles` (the named follow-on). Safe because a gateway-bound fork is editable → resolves via layer 3 (its own clone), so a bare query never silently fetches upstream; only a wheel install reaches layer 4, where fetching the upstream catalogue is expected and symmetric with `install`.

## Why?

- Implements: `docs/specs/convenient-install-defaults/spec.md` (Shipped)
- Follows from: ADR-0036, RFC-0046, RFC-0047 (all Accepted)

The source is a code-provenance boundary: resolution **never** consults cwd, **never** reads a repo-committed source, **never** auto-persists. RFC-0047 reopens only the query-defaulting edge ADR-0036 deferred (ADR-0036 annotated); layer-4 integrity-pinning stays deferred (named follow-on).

## How do I verify it?

```bash
cd packages/agentbundle
python -m pytest \
  tests/unit/test_source_defaults.py tests/unit/test_user_config_source.py \
  tests/unit/test_cli_catalogue_optional.py tests/unit/test_config_cmd.py \
  tests/integration/test_install_default_source.py \
  tests/integration/test_editable_source_detection.py
```

- Keystone `test_editable_source_detection.py` does a **real** `pip install -e` in a throwaway venv and asserts detection walks to the clone root.
- `test_install_default_source.py` runs bare `install --pack core`, `install --profile`, the `_offer_upgrade` hand-off, and bare `list-packs`/`list-profiles` end-to-end via layer 2.
- Full suite + `make build-check` (lint-packs, bandit, pip-audit, semgrep) green; `lint-spec-status` clean. New test paths wired into `build-check.yml`.

Reviewed by `adversarial-reviewer`, `security-reviewer`, and `quality-engineer` at spec stage and on both the RFC-0046 and RFC-0047 diffs — all clean after fixes.

## What did you not change that you considered?

- **`resolve_catalogue`** stays a thin, unvalidating fetcher — all validation lives in `resolve_default_source`.
- **No host allowlist**, **no layer-4 integrity-pinning** (deferred; the scheme gate is in scope, pin-`main`-to-SHA + verify-digest is the named follow-on).
- **The adapter resolver** is untouched.
- **Pre-existing ruff findings** in `install.py`/`upgrade.py` left as-is (outside this change's lines, not the project's gate).

## Hardening note

`_load_distribution` prefers the distribution carrying `direct_url.json` so a stale source-tree `agentbundle.egg-info` can't shadow editable detection — a real fragility for the editable-fork case, surfaced by the keystone test.

Deferred: convenient-install-defaults-followons (`docs/backlog.md`) — layer-4 integrity-pinning only (query-defaulting now shipped under RFC-0047).