### PR TITLE
test(agentbundle): guard CLI_VERSION ↔ pyproject version drift

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -109,6 +109,15 @@ jobs:
       - name: Install agentbundle (editable) + pytest
         run: pip install -e packages/agentbundle/ pytest
 
+      # version-drift guard: CLI_VERSION (agentbundle/version.py) must equal
+      # [project].version (pyproject.toml). make build-check runs no pytest, so
+      # wire this path explicitly or the guard is dead. A stale CLI_VERSION
+      # makes `agentbundle --version` lie (it was stuck at 0.1.0 across several
+      # releases); the release workflow only asserts the tag matches pyproject.
+      - name: pytest version constants (CLI_VERSION ↔ pyproject drift guard)
+        working-directory: packages/agentbundle
+        run: python -m pytest tests/unit/test_version.py
+
       - name: pytest converters install/uninstall (AC6a)
         working-directory: packages/agentbundle
         run: python -m pytest tests/integration/test_install_converters_user_scope.py

--- a/.github/workflows/release-agentbundle.yml
+++ b/.github/workflows/release-agentbundle.yml
@@ -45,6 +45,22 @@ jobs:
           if tag_ver != pp_ver:
               print(f"::error::tag {tag} declares version {tag_ver} but pyproject.toml has {pp_ver}", file=sys.stderr)
               sys.exit(1)
+          # CLI_VERSION (what `agentbundle --version` reports) is independent of
+          # pyproject and has shipped stale before (stuck at 0.1.0). Refuse a
+          # mismatched release at tag time, not just in unit tests. Read it from
+          # source text: the package isn't installed at this step, and importing
+          # version.py would pull in the adapter.toml read. This step is
+          # tag-only; PR-time drift coverage is delegated to build-check.yml's
+          # `test_version.py` step (test_cli_version_matches_pyproject) — keep
+          # that step if these triggers are ever narrowed, or this gap reopens.
+          src = open("packages/agentbundle/agentbundle/version.py", encoding="utf-8").read()
+          cm = re.search(r'^CLI_VERSION\s*=\s*"([^"]+)"', src, re.MULTILINE)
+          if not cm:
+              print("::error::could not find CLI_VERSION literal in agentbundle/version.py", file=sys.stderr)
+              sys.exit(1)
+          if cm.group(1) != pp_ver:
+              print(f"::error::CLI_VERSION is {cm.group(1)} but pyproject.toml has {pp_ver}; `agentbundle --version` would lie. Bump CLI_VERSION in agentbundle/version.py.", file=sys.stderr)
+              sys.exit(1)
           PY
 
       - name: Assert tag is on main

--- a/packages/agentbundle/tests/unit/test_version.py
+++ b/packages/agentbundle/tests/unit/test_version.py
@@ -61,6 +61,26 @@ def test_python_m_agentbundle_version_prints_versions():
     assert contract_version in out
 
 
+def test_cli_version_matches_pyproject():
+    """Regression guard: the two independent version strings must agree.
+
+    `CLI_VERSION` (agentbundle/version.py) is what `agentbundle --version` and
+    `agentbundle.__version__` report; `[project].version` (pyproject.toml) is
+    what's published to PyPI. Nothing in the code keeps them in sync, and the
+    release workflow only asserts the git tag matches pyproject — so a stale
+    CLI_VERSION can ship and `--version` will lie (it was stuck at 0.1.0 across
+    several releases). This test fails the build the moment they diverge.
+    """
+    import tomllib
+
+    from agentbundle.version import CLI_VERSION
+
+    pyproject = tomllib.loads(
+        (PACKAGE_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    assert CLI_VERSION == pyproject["project"]["version"]
+
+
 def test_spec_version_is_read_at_import_time(tmp_path):
     """Mutate adapter.toml on disk after import; SPEC_VERSION must not change.
 


### PR DESCRIPTION
## What

agentbundle's version lives in two independent places:

1. `packages/agentbundle/pyproject.toml` → `[project].version` (published to PyPI)
2. `packages/agentbundle/agentbundle/version.py` → `CLI_VERSION` (what `agentbundle --version` and `agentbundle.__version__` report; consumed at `cli.py` ~line 149)

Nothing kept them in sync. The release workflow asserted the git tag matches the *pyproject* version but never checked `CLI_VERSION` — so a release could ship with a stale `CLI_VERSION` and `agentbundle --version` would lie. This bit before (`CLI_VERSION` stuck at `0.1.0` across several releases). Both are `0.8.0` today, so this is a pure regression guard — **no behavior change, no version bump.**

## Changes

- **`tests/unit/test_version.py`** — add `test_cli_version_matches_pyproject()`, asserting `CLI_VERSION == pyproject [project].version` (uses the file's existing `PACKAGE_ROOT`).
- **`.github/workflows/build-check.yml`** — wire `tests/unit/test_version.py` in as an explicit pytest step. `make build-check` runs **no** pytest and CI wires package tests per-path; the test was not wired anywhere, so without this the guard would be dead.
- **`.github/workflows/release-agentbundle.yml`** — extend the existing tag-assert step to also refuse a release where `CLI_VERSION != pyproject version`, so a mismatched release is rejected at tag time, not only in unit tests. Read from source text via regex because the package isn't installed at that step.

## Trade-off (release-workflow step)

The release-workflow check is largely belt-and-braces: tags must be ancestors of `main` (asserted in the same job), and `main` passed `build-check` (which now runs the unit test). The release step adds defense-in-depth at the exact moment of publish and is nearly free (extends an existing step). It's tag-gated; PR-time drift coverage is delegated to `build-check.yml`'s `test_version.py` step — a comment flags this so a future trigger-narrowing doesn't silently reopen the gap.

Per the brief, `CLI_VERSION` is **not** refactored to derive from `importlib.metadata` (that's a behavior change with its own fragility); the guard is the cheap, safe fix.

## Verification

- `cd packages/agentbundle && python -m pytest tests/unit/test_version.py` → 5 passed.
- Confirmed the release-workflow regex extracts `CLI_VERSION` correctly and matches pyproject.
- adversarial-reviewer: clean.