### PR TITLE
feat(tools): opt-in catalogue-seeds lint, renamed lint-catalogue-seeds (RFC-0047 D6)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,8 @@ on:
       - 'packs/**/.apm/skills/**'
       - 'tools/lint-knowledge.py'
       - 'tools/test-lint-knowledge.sh'
-      - 'tools/lint-seeds.py'
+      - 'tools/lint-catalogue-seeds.py'
+      - 'tools/test-lint-catalogue-seeds.py'
       - 'profiles/**'
       - 'tools/lint-profiles.py'
       - 'tools/test-lint-profiles.py'
@@ -79,13 +80,15 @@ jobs:
       - name: Self-test the linter (schema-drift + content guards)
         run: bash tools/test-lint-knowledge.sh
 
-  lint-seeds:
+  lint-catalogue-seeds:
     name: Seed scaffolds
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Run seed-content linter (RFC-0002 scaffold contract)
-        run: python tools/lint-seeds.py
+      - name: Run catalogue seed-content linter (RFC-0002 scaffold contract, opt-in per RFC-0047 D6)
+        run: python tools/lint-catalogue-seeds.py
+      - name: Self-test the linter (opt-in gate — flagged enforced, unflagged skipped)
+        run: python tools/test-lint-catalogue-seeds.py
 
   lint-profiles:
     name: Install profiles

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -384,7 +384,7 @@ of their own yet.
 
 - **Follow-up (reviewer-flagged, not an unmet AC):** the adopter-facing
   leak guard (no `agent-ready-repo` / `RFC-NNNN` / catalogue-spec-name) is
-  enforced by `tools/lint-seeds.py` for **seed** files only. The shipped
+  enforced by `tools/lint-catalogue-seeds.py` for **seed** files only. The shipped
   `receive-brief/SKILL.md` and `receive-brief/examples/*.md` live under
   `packs/core/.apm/skills/` and are outside that lint's scope — clean today by
   inspection, but unguarded against regression. Extend the seed-content
@@ -679,7 +679,7 @@ in the quote-stripping branch.
 
 ### apm-leak-lint-rfc
 
-A `lint-seeds`-analogue for `packs/*/.apm/**` that mechanically catches
+A `lint-catalogue-seeds`-analogue for `packs/*/.apm/**` that mechanically catches
 internal-governance citations (RFC/ADR numbers, `docs/specs|rfc|adr` paths,
 `make`/`tools/lint` references, "this catalogue" identity asides) in shipped
 skills, agents, commands, and hooks. Today the rule is hand-checked

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -106,6 +106,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The catalogue's seed lint is now opt-in by construction and renamed
+  `lint-catalogue-seeds`.** `tools/lint-seeds.py` becomes
+  `tools/lint-catalogue-seeds.py` (the CI job, its path filters, the
+  `pre-pr-catalogue.py` gate, and the `tools/hooks/README.md` reference are
+  renamed in lockstep), and **all** of its checks — the anti-leak blocklist and
+  the placeholder-shape checks — now run only on packs whose `pack.toml` carries
+  `[pack].lint-seeds = true`. The four first-party scaffold packs (`core`,
+  `governance-extras`, `monorepo-extras`, `user-guide-diataxis`) carry the flag,
+  so their seeds stay enforced exactly as before; any other pack — including an
+  organization pack that intentionally ships filled-in *instance* content — omits
+  the flag and is unenforced by construction, with no edit to the lint or any
+  central pack list. The flag is catalogue-internal metadata and is not projected
+  to `plugin.json` / `marketplace.json`. (RFC-0047 Decision 6 / ADR-0037 D4.)
 - **`agentbundle uninstall` gains `--dry-run` and `--yes`, and confirms before
   removing anything.** Previously `uninstall` deleted every bundle-owned (Tier-1)
   file immediately with no preview. It now classifies each recorded file

--- a/docs/specs/catalogue-seeds-lint/plan.md
+++ b/docs/specs/catalogue-seeds-lint/plan.md
@@ -1,7 +1,7 @@
 # Plan: Catalogue-seeds lint — opt-in by construction, renamed `lint-catalogue-seeds`
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Drafting <!-- Drafting | Executing | Done -->
+- **Status:** Done <!-- Drafting | Executing | Done -->
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
 > document is allowed to change as you learn. When it changes substantially
@@ -107,3 +107,27 @@ Repo-internal catalogue tooling + manifest-field change. No runtime infra. **Dep
 ## Changelog
 
 - 2026-06-25: initial plan (RFC-0047 Decision 6 follow-on).
+- 2026-06-25: implemented and shipped. Gate added at `_enumerate_seed_files`
+  (one chokepoint, via a `_pack_opts_in` `pack.toml` read — no central list);
+  flag added to the four first-party packs; tool + CI job/path-filter/run-line +
+  `pre-pr-catalogue.py` + `tools/hooks/README.md` renamed in lockstep; new
+  `tools/test-lint-catalogue-seeds.py` self-test wired into `docs.yml`,
+  `pre-pr-catalogue.py`, and `test-all.py`. Confirmed no contract-version bump
+  (additive optional field, unmapped in `_pack_manifest_subset`, so `build-self`
+  leaves `plugin.json`/`marketplace.json` clean). `make build-check` green.
+- 2026-06-25: review (adversarial-reviewer + quality-engineer, no Blockers).
+  Applied: 3 fail-closed self-test cases (`_pack_opts_in` on missing /
+  malformed / non-table `pack.toml` → skip, no crash), a flagged
+  missing-placeholder case (second gated check, enforced direction), stderr
+  substring asserts on the failing cases, the `git init` isolation comment, and
+  AC1/AC9 wording tightened to "operative refs only" + the expected warn-only
+  delta. **Declined (with reason):** a loud "skipped N packs" diagnostic
+  (quality Nit 2) — it contradicts the spec's *unenforced-by-construction,
+  silent* intent for org packs, and the lint cannot distinguish an org pack
+  (wants silence) from a first-party pack that forgot the flag (wants noise)
+  without the central list the spec forbids. **Expected warn-only delta:** the
+  rename turns `tools/lint-seeds.py` references in frozen/shipped specs
+  (`doc-drift-prevention`, `self-hosting`, `spec-code-ref-lint`,
+  `value-stream-meta-repo`, …) and this spec's own rename-mapping/assumption
+  lines into `lint-spec-status` invariant-iii dangling-ref *warnings* (warn-only,
+  exit 0); left as historical record rather than rewriting frozen spec bodies.

--- a/docs/specs/catalogue-seeds-lint/spec.md
+++ b/docs/specs/catalogue-seeds-lint/spec.md
@@ -1,6 +1,6 @@
 # Spec: Catalogue-seeds lint — opt-in by construction, renamed `lint-catalogue-seeds`
 
-- **Status:** Approved <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Status:** Shipped (2026-06-25) <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** RFC-0047 (Decision 6), ADR-0037 (D4), ADR-0021 (pack-manifest source of truth + contract-version rule), RFC-0002 (the placeholder-only seed contract)
@@ -12,7 +12,7 @@
 
 ## Objective
 
-The catalogue's seed lint (`tools/lint-seeds.py`) enforces a *placeholder-only* scaffold contract on **every** pack that ships seeds — the anti-leak blocklist *and* the scaffold-shape checks (placeholder-required, fail-loud-on-unknown-seed, empty-`patterns.jsonl`). That is correct for the four first-party scaffold packs, but it is exactly wrong for an **organization pack**, which intentionally ships *instance content* (a filled-in `reference.md`, real conventions) — the inverse of the placeholder contract. An org pack must be unenforced **by construction**, with no edit to the lint and no central pack list to maintain. Success: the lint is renamed `lint-catalogue-seeds`, and **all** its checks are gated on an opt-in `[pack].lint-seeds = true` flag carried **only by the four first-party scaffold packs** (`core`, `governance-extras`, `monorepo-extras`, `user-guide-diataxis`), added in the **same change** so none silently loses enforcement. Any other pack — including any org pack — omits the flag and is unenforced by construction. It stays a **single tool, not split**.
+The catalogue's seed lint (`tools/lint-catalogue-seeds.py`, formerly `lint-seeds`) enforces a *placeholder-only* scaffold contract on **every** pack that ships seeds — the anti-leak blocklist *and* the scaffold-shape checks (placeholder-required, fail-loud-on-unknown-seed, empty-`patterns.jsonl`). That is correct for the four first-party scaffold packs, but it is exactly wrong for an **organization pack**, which intentionally ships *instance content* (a filled-in `reference.md`, real conventions) — the inverse of the placeholder contract. An org pack must be unenforced **by construction**, with no edit to the lint and no central pack list to maintain. Success: the lint is renamed `lint-catalogue-seeds`, and **all** its checks are gated on an opt-in `[pack].lint-seeds = true` flag carried **only by the four first-party scaffold packs** (`core`, `governance-extras`, `monorepo-extras`, `user-guide-diataxis`), added in the **same change** so none silently loses enforcement. Any other pack — including any org pack — omits the flag and is unenforced by construction. It stays a **single tool, not split**.
 
 ## Boundaries
 
@@ -47,15 +47,15 @@ before proceeding; *Never do* is a hard rule, even under time pressure.
 
 ## Acceptance Criteria
 
-- [ ] `tools/lint-seeds.py` is renamed to `tools/lint-catalogue-seeds.py`; the `.github/workflows/docs.yml` job, path-filter, and run line, the `tools/pre-pr-catalogue.py` invocation, and the `tools/hooks/README.md` mention are renamed in lockstep (no surviving `lint-seeds` reference except historical changelog/ADR text).
-- [ ] **All** lint checks (anti-leak blocklist, placeholder-required, fail-loud-on-unknown-seed, empty-`patterns.jsonl`) are gated on the pack carrying `[pack].lint-seeds = true`; a pack without the flag is **skipped entirely**.
-- [ ] All four first-party scaffold packs (`core`, `governance-extras`, `monorepo-extras`, `user-guide-diataxis`) carry `[pack].lint-seeds = true`, added in the **same change** as the gating flip.
-- [ ] A synthetic pack that ships seeds but **omits** the flag raises **no** violation even on instance-shaped content (unenforced by construction) — a regression test asserts this.
-- [ ] A flagged pack with a real leak or missing-placeholder violation still **fails** — a regression test asserts the enforcement is intact for first-party packs.
-- [ ] The lint reads the flag from each pack's `pack.toml`; it does **not** carry a central hardcoded first-party pack list **as the source of truth**. (A read-failure bootstrap fallback, if one exists per the Boundaries carve-out, is not the source of truth and does not violate this — verification is "the flag drives enforcement", not "no list literal exists anywhere".)
-- [ ] The new `[pack].lint-seeds` field is **not** projected to `plugin.json`, `marketplace.json`, or any adapter output (catalogue-internal metadata) — confirmed by build-self leaving those clean.
-- [ ] The **manifest contract-version question is resolved**: the plan records, with reasoning against ADR-0021's contract-version rule, whether the new optional field requires a bump — and the implementation matches that answer (default expectation: additive + optional ⇒ no bump).
-- [ ] `python tools/lint-catalogue-seeds.py` runs green on the current tree; `pre-pr-catalogue.py` invokes it; `lint-spec-status.py` clean.
+- [x] `tools/lint-seeds.py` is renamed to `tools/lint-catalogue-seeds.py`; the `.github/workflows/docs.yml` job, path-filter, and run line, the `tools/pre-pr-catalogue.py` invocation, and the `tools/hooks/README.md` mention are renamed in lockstep (no surviving **operative** `lint-seeds` reference — one that executes or breaks; frozen ADR/RFC/changelog and shipped-spec history may still name the old path as historical record, as may this spec's own rename-mapping and assumption lines).
+- [x] **All** lint checks (anti-leak blocklist, placeholder-required, fail-loud-on-unknown-seed, empty-`patterns.jsonl`) are gated on the pack carrying `[pack].lint-seeds = true`; a pack without the flag is **skipped entirely**.
+- [x] All four first-party scaffold packs (`core`, `governance-extras`, `monorepo-extras`, `user-guide-diataxis`) carry `[pack].lint-seeds = true`, added in the **same change** as the gating flip.
+- [x] A synthetic pack that ships seeds but **omits** the flag raises **no** violation even on instance-shaped content (unenforced by construction) — a regression test asserts this.
+- [x] A flagged pack with a real leak or missing-placeholder violation still **fails** — a regression test asserts the enforcement is intact for first-party packs.
+- [x] The lint reads the flag from each pack's `pack.toml`; it does **not** carry a central hardcoded first-party pack list **as the source of truth**. (A read-failure bootstrap fallback, if one exists per the Boundaries carve-out, is not the source of truth and does not violate this — verification is "the flag drives enforcement", not "no list literal exists anywhere".)
+- [x] The new `[pack].lint-seeds` field is **not** projected to `plugin.json`, `marketplace.json`, or any adapter output (catalogue-internal metadata) — confirmed by build-self leaving those clean.
+- [x] The **manifest contract-version question is resolved**: the plan records, with reasoning against ADR-0021's contract-version rule, whether the new optional field requires a bump — and the implementation matches that answer (default expectation: additive + optional ⇒ no bump).
+- [x] `python tools/lint-catalogue-seeds.py` runs green on the current tree; `pre-pr-catalogue.py` invokes it; `lint-spec-status.py` clean (exit 0 — its invariant-iii dangling-ref *warnings* on the old `tools/lint-seeds.py` path in this and frozen specs are warn-only and expected after the rename, not failures).
 
 ## Assumptions
 

--- a/packages/agentbundle/tests/hooks/test_pre_pr_py.py
+++ b/packages/agentbundle/tests/hooks/test_pre_pr_py.py
@@ -46,7 +46,7 @@ def test_catalogue_hook_runs_all_8_checks_and_delegates() -> None:
         "tools/lint-skill-spec.py",
         "tools/lint-knowledge.py",
         "tools/lint-build.py",
-        "tools/lint-seeds.py",
+        "tools/lint-catalogue-seeds.py",
         "tools/lint_credentialed_skills.py",
         "tools/test-lint-credentialed-skills.py",
     ):

--- a/packages/agentbundle/tests/integration/test_install_snapshot.py
+++ b/packages/agentbundle/tests/integration/test_install_snapshot.py
@@ -11,7 +11,7 @@ leak:
      "an expected scaffold file disappeared" regressions.
 
   2. **No catalogue-string leaks.** Each scaffolded file is scanned
-     against the same blocklist `tools/lint-seeds.py` uses — no
+     against the same blocklist `tools/lint-catalogue-seeds.py` uses — no
      `agent-ready-repo`, RFC-NNNN, K-NNNN, or internal-spec names.
      Catches "seed scrub got reverted" regressions.
 
@@ -24,7 +24,7 @@ see `docs/specs/core-install-seed-delivery/`). As of issue #190 the
 `build/tests/test_build_ships_seeds.py`); that copy is byte-verbatim from the
 same source tree this golden/leak test guards, so testing `scaffold` here
 remains sufficient to catch a seed-scrub regression at the source. AC21's
-`tools/lint-seeds.py` is the cross-source invariant.
+`tools/lint-catalogue-seeds.py` is the cross-source invariant.
 
 Goldens live at
 `packages/agentbundle/tests/fixtures/install_snapshot/<pack>.paths.txt`
@@ -54,8 +54,8 @@ FIXTURES_DIR = (
     / "install_snapshot"
 )
 
-# Mirror lint-seeds.py's blocklist. Sourced from RFC-0002 § Amendments
-# § 2026-05-25. Keep in sync; see lint-seeds.py:BLOCKLIST_PATTERNS.
+# Mirror lint-catalogue-seeds.py's blocklist. Sourced from RFC-0002 § Amendments
+# § 2026-05-25. Keep in sync; see lint-catalogue-seeds.py:BLOCKLIST_PATTERNS.
 BLOCKLIST_REGEXES = [
     re.compile(p)
     for p in (
@@ -72,7 +72,7 @@ BLOCKLIST_REGEXES = [
     )
 ]
 
-# Same single-line sentinel lint-seeds.py honours. Catalogue-attribution
+# Same single-line sentinel lint-catalogue-seeds.py honours. Catalogue-attribution
 # footer at `packs/core/seeds/AGENTS.md:171` is the documented exception.
 SENTINEL_RE = re.compile(
     r"^\s*<!--\s*seed-content-lint-ignore:\s*([^>]+?)\s*-->\s*$"

--- a/packages/agentbundle/tests/unit/test_reference_architecture.py
+++ b/packages/agentbundle/tests/unit/test_reference_architecture.py
@@ -12,7 +12,7 @@ Covers, per the spec's Testing Strategy:
     stack-pack-contract clauses, and the guides are adopter-clean.
 
 "Adopter-clean" = no internal-repo reference: no ``RFC-NNNN`` / ``ADR-NNNN``
-token and no ``docs/(specs|rfc|adr)/`` path string. ``lint-seeds`` enforces only
+token and no ``docs/(specs|rfc|adr)/`` path string. ``lint-catalogue-seeds`` enforces only
 RFC-number absence and only under ``packs/*/seeds/**`` — it covers neither the
 ``.apm/`` template/SKILL nor the ``docs/guides/`` files — so these checks carry
 the invariant for the surfaces lint misses.

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -8,6 +8,12 @@ license = "Apache-2.0 OR MIT"
 categories = ["governance", "code-review", "testing"]
 keywords = ["work-loop", "spec-driven", "reviewers", "agents"]
 
+# Opt into the catalogue seed lint (RFC-0047 Decision 6 / ADR-0037 D4): this is
+# a first-party scaffold pack whose seeds must stay placeholder-shaped, so
+# `tools/lint-catalogue-seeds.py` enforces the RFC-0002 contract here. Catalogue-
+# internal metadata — not projected to plugin.json / marketplace.json.
+lint-seeds = true
+
 # RFC-0004 ships the v0.2 contract bump alongside this pack's metadata.
 # The four shipped packs all declare the same shape so the catalogue's
 # published packs and the CLI release land in lockstep. core is

--- a/packs/governance-extras/pack.toml
+++ b/packs/governance-extras/pack.toml
@@ -8,6 +8,11 @@ license = "Apache-2.0 OR MIT"
 categories = ["governance", "documentation"]
 keywords = ["rfc", "adr", "conventions"]
 
+# Opt into the catalogue seed lint (RFC-0047 Decision 6 / ADR-0037 D4): a
+# first-party scaffold pack, so `tools/lint-catalogue-seeds.py` enforces the
+# RFC-0002 placeholder contract here. Catalogue-internal — not projected.
+lint-seeds = true
+
 # RFC-0004 v0.2 contract metadata. RFC/ADR ceremony is per-project, so
 # the pack is declared repo-only.
 [pack.adapter-contract]

--- a/packs/monorepo-extras/pack.toml
+++ b/packs/monorepo-extras/pack.toml
@@ -8,6 +8,11 @@ license = "Apache-2.0 OR MIT"
 categories = ["devops", "architecture"]
 keywords = ["monorepo", "scaffolding", "packages"]
 
+# Opt into the catalogue seed lint (RFC-0047 Decision 6 / ADR-0037 D4): a
+# first-party scaffold pack, so `tools/lint-catalogue-seeds.py` enforces the
+# RFC-0002 placeholder contract here. Catalogue-internal — not projected.
+lint-seeds = true
+
 # RFC-0004 v0.2 contract metadata. new-package scaffolds in `packages/`
 # — meaningless without a monorepo — so the pack is repo-only.
 [pack.adapter-contract]

--- a/packs/user-guide-diataxis/pack.toml
+++ b/packs/user-guide-diataxis/pack.toml
@@ -8,6 +8,11 @@ license = "Apache-2.0 OR MIT"
 categories = ["documentation"]
 keywords = ["diataxis", "tutorials", "how-to", "reference"]
 
+# Opt into the catalogue seed lint (RFC-0047 Decision 6 / ADR-0037 D4): a
+# first-party scaffold pack, so `tools/lint-catalogue-seeds.py` enforces the
+# RFC-0002 placeholder contract here. Catalogue-internal — not projected.
+lint-seeds = true
+
 # RFC-0004 v0.2 contract metadata. Scaffolds `docs/guides/` for *this*
 # project's users \u2014 no project, no scaffolding target \u2014 so the pack is
 # repo-only.

--- a/tools/hooks/README.md
+++ b/tools/hooks/README.md
@@ -74,7 +74,7 @@ Exits non-zero on the first failure; a missing tool is skipped, not fatal.
 **This catalogue's own full gate** is the repo-native, never-projected
 `tools/pre-pr-catalogue.py`: it runs the 8 catalogue checks
 (`lint-agents-md`, `lint-agent-artifacts`, `lint-skill-spec`, `lint-knowledge`,
-`lint-build`, `lint-seeds`, `lint_credentialed_skills`, and the
+`lint-build`, `lint-catalogue-seeds`, `lint_credentialed_skills`, and the
 `test-lint-credentialed-skills` self-test), then delegates to the shipped
 `pre-pr.py`. `make pre-pr` and `make build-check` run it. See
 [`docs/CONVENTIONS.md` § Enforcement](../../docs/CONVENTIONS.md#enforcement).

--- a/tools/lint-catalogue-seeds.py
+++ b/tools/lint-catalogue-seeds.py
@@ -1,11 +1,23 @@
 #!/usr/bin/env python3
-"""Lint pack seed files for the scaffold contract defined by RFC-0002 § Amendments § 2026-05-25.
+"""Lint first-party pack seed files for the scaffold contract defined by RFC-0002 § Amendments § 2026-05-25.
 
 Pack seeds under `packs/<pack>/seeds/` ship to adopters on first
 install. After the 2026-05-25 amendment, most former Projected paths
 are Manual at the projected path — the on-disk file is this repo's
 living instance, while the pack-side seed must remain a placeholder
-template adopters can fill in. This lint enforces two contracts:
+template adopters can fill in.
+
+**Opt-in by construction (RFC-0047 Decision 6 / ADR-0037 D4).** This
+lint enforces its contract *only* on packs whose `pack.toml` carries
+`[pack].lint-seeds = true` — the four first-party scaffold packs
+(`core`, `governance-extras`, `monorepo-extras`, `user-guide-diataxis`).
+Every other pack — including any organization pack, which intentionally
+ships *instance* content (the inverse of the placeholder contract) — omits
+the flag and is unenforced **by construction**: no edit to this lint and no
+central first-party pack list. The gate lives at one chokepoint
+(`_enumerate_seed_files`), so all checks below are gated together.
+
+This lint enforces two contracts on the packs that opt in:
 
   1. **Blocklist (negative check).** No catalogue-specific strings
      appear in any seed file: `agent-ready-repo`, `RFC-NNNN` refs to
@@ -41,6 +53,7 @@ import pathlib
 import re
 import subprocess
 import sys
+import tomllib
 from typing import Iterable
 
 
@@ -146,12 +159,42 @@ def _is_blank_or_comment(line: str) -> bool:
     return not s or (s.startswith("<!--") and s.endswith("-->"))
 
 
+def _pack_opts_in(pack_dir: pathlib.Path) -> bool:
+    """Return True iff the pack's `pack.toml` carries `[pack].lint-seeds = true`.
+
+    The flag is the single source of truth for which packs this lint enforces
+    (RFC-0047 Decision 6 / ADR-0037 D4): only the first-party scaffold packs
+    carry it, so an org pack that ships *instance* content is unenforced **by
+    construction** — no edit to this lint and no central pack list. A pack with
+    no `pack.toml`, an unreadable/malformed one, or the flag absent or not
+    literally `true` is skipped. No hardcoded first-party list backs this.
+    """
+    manifest = pack_dir / "pack.toml"
+    if not manifest.is_file():
+        return False
+    try:
+        data = tomllib.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return False
+    pack_table = data.get("pack")
+    if not isinstance(pack_table, dict):
+        return False
+    return pack_table.get("lint-seeds") is True
+
+
 def _enumerate_seed_files(repo_root: pathlib.Path) -> Iterable[pathlib.Path]:
-    """Yield every file under `packs/*/seeds/` in sorted order."""
+    """Yield every file under `packs/*/seeds/` for packs that opt in.
+
+    Only packs whose `pack.toml` carries `[pack].lint-seeds = true` are
+    enumerated (see `_pack_opts_in`); every other pack — including any org
+    pack — is skipped, so all checks below are gated at this one chokepoint.
+    """
     packs_root = repo_root / "packs"
     if not packs_root.is_dir():
         return
     for pack_dir in sorted(packs_root.iterdir()):
+        if not _pack_opts_in(pack_dir):
+            continue
         seeds_dir = pack_dir / "seeds"
         if not seeds_dir.is_dir():
             continue
@@ -172,7 +215,7 @@ def check_seed_file(path: pathlib.Path, seeds_root: pathlib.Path) -> list[str]:
     if relative not in REQUIRED_PLACEHOLDERS:
         return [
             f"{path}: unknown seed file — declare its expected "
-            "placeholder shape in tools/lint-seeds.py:REQUIRED_PLACEHOLDERS, "
+            "placeholder shape in tools/lint-catalogue-seeds.py:REQUIRED_PLACEHOLDERS, "
             "or remove the file. (Fail-loud policy: every seed under "
             "packs/<pack>/seeds/ must have a declared shape.)"
         ]
@@ -274,7 +317,7 @@ def main() -> int:
     repo_root = _repo_root()
     seeds_packs = repo_root / "packs"
     if not seeds_packs.is_dir():
-        print(f"lint-seeds: {seeds_packs} not a directory", file=sys.stderr)
+        print(f"lint-catalogue-seeds: {seeds_packs} not a directory", file=sys.stderr)
         return 1
 
     all_violations: list[str] = []
@@ -296,13 +339,13 @@ def main() -> int:
         for v in all_violations:
             print(v, file=sys.stderr)
         print(
-            f"\nlint-seeds: {len(all_violations)} violation(s) "
+            f"\nlint-catalogue-seeds: {len(all_violations)} violation(s) "
             f"across {seed_count} seed file(s).",
             file=sys.stderr,
         )
         return 1
 
-    print(f"lint-seeds: {seed_count} seed file(s) clean.")
+    print(f"lint-catalogue-seeds: {seed_count} seed file(s) clean.")
     return 0
 
 

--- a/tools/pre-pr-catalogue.py
+++ b/tools/pre-pr-catalogue.py
@@ -67,7 +67,9 @@ def main() -> int:
     _run("skill-spec lint",     [py, "tools/lint-skill-spec.py"])
     _run("knowledge lint",      [py, "tools/lint-knowledge.py"])
     _run("build lint",          [py, "tools/lint-build.py"])
-    _run("seeds lint",          [py, "tools/lint-seeds.py"])
+    _run("catalogue-seeds lint", [py, "tools/lint-catalogue-seeds.py"])
+    _run("catalogue-seeds lint self-test",
+         [py, "tools/test-lint-catalogue-seeds.py"])
     _run("credentialed-skill lint", [py, "tools/lint_credentialed_skills.py"])
     _run("credentialed-skill lint self-test",
          [py, "tools/test-lint-credentialed-skills.py"])

--- a/tools/test-all.py
+++ b/tools/test-all.py
@@ -42,6 +42,7 @@ def _repo_root() -> Path:
 # child runs with the same interpreter as the umbrella.
 TESTS: list[tuple[str, list[str]]] = [
     ("lint-agent-artifacts", ["bash", "tools/test-lint-agent-artifacts.sh"]),
+    ("lint-catalogue-seeds", [sys.executable, "tools/test-lint-catalogue-seeds.py"]),
     ("lint-knowledge",       ["bash", "tools/test-lint-knowledge.sh"]),
     ("lint-skill-spec",      [sys.executable, "tools/test-lint-skill-spec.py"]),
     ("loop-cohort",          ["bash", "tools/test-loop-cohort.sh"]),

--- a/tools/test-lint-catalogue-seeds.py
+++ b/tools/test-lint-catalogue-seeds.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Self-test for tools/lint-catalogue-seeds.py (RFC-0047 Decision 6 / ADR-0037 D4).
+
+Asserts the load-bearing invariant of the opt-in-by-construction gate: the lint
+enforces its placeholder/blocklist contract **only** on packs whose `pack.toml`
+carries `[pack].lint-seeds = true`, and skips every other pack entirely — so an
+organization pack that ships *instance* content is unenforced by construction,
+with no edit to the lint and no central first-party pack list.
+
+Runs the lint as a real subprocess against synthetic `packs/` trees (the
+documented `python tools/lint-catalogue-seeds.py` file-path invocation), each in
+its own git-initialised temp root so the lint's `git rev-parse --show-toplevel`
+repo-root discovery resolves to the fixture, not this catalogue.
+
+Run directly: ``python tools/test-lint-catalogue-seeds.py`` (exit 0 = pass).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+_LINT = Path(__file__).resolve().parent / "lint-catalogue-seeds.py"
+
+# A blocklisted catalogue string the lint flags in any enforced seed. The
+# `<project-name>` placeholder satisfies AGENTS.md's required-placeholder check,
+# so a failure here is unambiguously the blocklist firing (not a missing
+# placeholder). Source: lint-catalogue-seeds.py BLOCKLIST_PATTERNS + AGENTS.md
+# REQUIRED_PLACEHOLDERS.
+_LEAK_SEED = "<project-name> lives in agent-ready-repo\n"
+_CLEAN_SEED = "<project-name> goes here\n"
+# A known seed (docs/specs/README.md) whose required placeholder is *absent* —
+# trips the placeholder-required check (not the blocklist), so it exercises a
+# second gated check in the enforced direction. Source: REQUIRED_PLACEHOLDERS.
+_MISSING_PLACEHOLDER_SEED = "real content, no scaffold marker\n"
+
+# A pack fixture: (name, body, seeds). `body` is the literal `pack.toml` text, or
+# the sentinel None meaning "write no pack.toml at all".
+_FLAGGED = '[pack]\nname = "x"\nversion = "0.0.0"\nlint-seeds = true\n'
+_NO_FLAG = '[pack]\nname = "x"\nversion = "0.0.0"\n'
+_FLAG_FALSE = '[pack]\nname = "x"\nversion = "0.0.0"\nlint-seeds = false\n'
+_MALFORMED = '[pack]\nname = "x\nversion =\n'  # syntactically invalid TOML
+_NONTABLE = 'pack = "scalar-not-a-table"\n'  # [pack] is not a dict
+
+
+def _make_pack(root: Path, name: str, body: str | None, seeds: dict[str, str]) -> None:
+    pack_dir = root / "packs" / name
+    pack_dir.mkdir(parents=True, exist_ok=True)
+    if body is not None:
+        (pack_dir / "pack.toml").write_text(body, encoding="utf-8")
+    for rel, content in seeds.items():
+        seed = pack_dir / "seeds" / rel
+        seed.parent.mkdir(parents=True, exist_ok=True)
+        seed.write_text(content, encoding="utf-8")
+
+
+def _run(packs: list[tuple[str, str | None, dict[str, str]]]) -> tuple[int, str]:
+    """Build a git-initialised synthetic repo with *packs* and run the lint.
+
+    Returns (exit_code, stderr). The `git init` is load-bearing: it is what pins
+    the lint's `git rev-parse --show-toplevel` repo-root discovery to this
+    fixture rather than falling through to the real catalogue (which would let
+    the enforce-fail cases pass for the wrong reason).
+    """
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        for name, body, seeds in packs:
+            _make_pack(root, name, body, seeds)
+        subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+        proc = subprocess.run(
+            [sys.executable, str(_LINT)], cwd=root, capture_output=True, text=True
+        )
+        return proc.returncode, proc.stderr
+
+
+# (label, packs, expected_exit, expected_stderr_substring_or_None)
+CASES: list[tuple[str, list[tuple[str, str | None, dict[str, str]]], int, str | None]] = [
+    # AC2 / AC4: a pack with seeds but NO flag is skipped entirely — even a leak
+    # AND an unknown-seed path (normally fail-loud) raise no violation.
+    (
+        "unflagged pack skipped (leak + unknown-seed path both ignored)",
+        [("org-acme", _NO_FLAG, {"AGENTS.md": _LEAK_SEED, "docs/house-style.md": "anything\n"})],
+        0,
+        None,
+    ),
+    # AC4: an explicit `lint-seeds = false` is also opt-out.
+    (
+        "explicit lint-seeds=false is opt-out",
+        [("org-beta", _FLAG_FALSE, {"AGENTS.md": _LEAK_SEED})],
+        0,
+        None,
+    ),
+    # AC5: a flagged pack with a leak still fails — and the blocklist (not the
+    # placeholder check) is what fires, asserted via the stderr message.
+    (
+        "flagged pack with a leak fails (blocklist fires)",
+        [("core", _FLAGGED, {"AGENTS.md": _LEAK_SEED})],
+        1,
+        "agent-ready-repo",
+    ),
+    # AC5 (second gated check, enforced direction): a flagged pack whose seed is
+    # missing its required placeholder fails the placeholder-required check.
+    (
+        "flagged pack missing required placeholder fails (placeholder check fires)",
+        [("core", _FLAGGED, {"docs/specs/README.md": _MISSING_PLACEHOLDER_SEED})],
+        1,
+        "required placeholder missing",
+    ),
+    # A flagged pack with clean placeholder content passes.
+    (
+        "flagged pack clean passes",
+        [("core", _FLAGGED, {"AGENTS.md": _CLEAN_SEED})],
+        0,
+        None,
+    ),
+    # AC6: the FLAG drives enforcement, not the pack name. A pack named neither
+    # of the four first-party packs but carrying the flag is STILL enforced —
+    # proving there is no central first-party-name list as the source of truth.
+    (
+        "non-first-party pack name + flag is enforced (flag drives it, not a name list)",
+        [("org-acme", _FLAGGED, {"AGENTS.md": _LEAK_SEED})],
+        1,
+        "agent-ready-repo",
+    ),
+    # The two together: identical instance-shaped seed, enforced iff flagged.
+    (
+        "same seed: flagged fails, unflagged in same run is skipped",
+        [
+            ("flagged", _FLAGGED, {"AGENTS.md": _LEAK_SEED}),
+            ("unflagged", _NO_FLAG, {"AGENTS.md": _LEAK_SEED}),
+        ],
+        1,  # the flagged pack's leak fails the whole run; the unflagged one is silent
+        "agent-ready-repo",
+    ),
+    # Fail-closed-to-skip: a pack with seeds but no pack.toml at all is skipped
+    # (no flag readable ⇒ unenforced), not crashed or enforced.
+    (
+        "pack with seeds but no pack.toml is skipped (no crash)",
+        [("org-nopack", None, {"AGENTS.md": _LEAK_SEED})],
+        0,
+        None,
+    ),
+    # Fail-closed-to-skip: a malformed/unreadable pack.toml is skipped, not a crash.
+    (
+        "pack with malformed pack.toml is skipped (no crash)",
+        [("org-bad", _MALFORMED, {"AGENTS.md": _LEAK_SEED})],
+        0,
+        None,
+    ),
+    # Fail-closed-to-skip: a non-table `pack = "scalar"` is skipped, not a crash.
+    (
+        "pack with non-table [pack] is skipped (no crash)",
+        [("org-scalar", _NONTABLE, {"AGENTS.md": _LEAK_SEED})],
+        0,
+        None,
+    ),
+]
+
+
+def main() -> int:
+    failures = 0
+    for label, packs, expected_exit, expected_stderr in CASES:
+        actual_exit, stderr = _run(packs)
+        ok = actual_exit == expected_exit
+        if ok and expected_stderr is not None:
+            ok = expected_stderr in stderr
+        if ok:
+            print(f"✓ {label}")
+        else:
+            detail = f"expected exit {expected_exit}, got {actual_exit}"
+            if expected_stderr is not None and expected_stderr not in stderr:
+                detail += f"; stderr missing {expected_stderr!r}"
+            print(f"✖ {label}: {detail}", file=sys.stderr)
+            failures += 1
+    print()
+    if failures:
+        print(f"test-lint-catalogue-seeds: {failures} of {len(CASES)} failed", file=sys.stderr)
+        return 1
+    print(f"test-lint-catalogue-seeds: {len(CASES)} passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implements `docs/specs/catalogue-seeds-lint` (Status: **Shipped**) — RFC-0047 Decision 6 / ADR-0037 D4.

## What & why

The catalogue's seed lint enforces a *placeholder-only* scaffold contract on every pack that ships seeds. That's right for the four first-party scaffold packs but exactly wrong for an **organization pack**, which intentionally ships *instance* content (the inverse of the placeholder contract). This PR makes the lint **opt-in by construction**:

- Renames `tools/lint-seeds.py` → `tools/lint-catalogue-seeds.py`.
- Gates **all** its checks (anti-leak blocklist + placeholder-required + fail-loud-on-unknown-seed + empty-`patterns.jsonl`) on a `[pack].lint-seeds = true` flag, read per-pack from `pack.toml` at the single `_enumerate_seed_files` chokepoint (new `_pack_opts_in` helper — **reads the flag, no central first-party pack list**).
- Adds the flag to all four first-party packs (`core`, `governance-extras`, `monorepo-extras`, `user-guide-diataxis`) **in the same change**, so none silently loses enforcement. Any other pack — including an org pack — omits the flag and is unenforced **by construction**. Single tool, not split.

## How it was verified

- New `tools/test-lint-catalogue-seeds.py` (the lint had no self-test) drives the **real** script as a subprocess against synthetic `packs/` trees: flagged-enforced, unflagged-skipped (even leak + unknown-seed), **flag-not-name drives enforcement** (AC6), the placeholder check fires in the enforced direction, and fail-closed skip on missing/malformed/non-table `pack.toml`. Wired into `docs.yml`, `pre-pr-catalogue.py`, and `test-all.py`.
- `make build-check` green; `pre-pr-catalogue.py` green (incl. the renamed lint + self-test); touched `agentbundle` tests green; `lint-spec-status.py` exit 0.
- **No projection / no contract bump (AC7/AC8):** `agentbundle/build/main.py:_pack_manifest_subset` is a *fixed allowlist*, so the additive optional field is unmapped — `build-self` leaves `plugin.json`/`marketplace.json` clean. Recorded against ADR-0021: additive + optional + catalogue-internal ⇒ **no bump**.
- adversarial-reviewer: **Clean**. quality-engineer: **Clean**. security-reviewer: not run — the change reads trusted local `pack.toml` via `tomllib` and crosses no auth/secrets/untrusted-input boundary.

## Deliberate decisions

- **Operative refs renamed; historical refs left intact.** Old-name references in frozen ADR/RFC/changelog and shipped specs' `spec.md`/`plan.md` are historical record. The rename turns those into `lint-spec-status` invariant-iii dangling-ref *warnings* (warn-only, exit 0); rewriting frozen spec bodies would be scope creep. Delta noted in the plan changelog.
- **Declined** a loud "skipped N packs" diagnostic (quality-engineer Nit) — it contradicts the spec's *unenforced-by-construction, silent* intent for org packs, and the lint can't distinguish an org pack (wants silence) from a first-party pack that forgot the flag (wants noise) without the central list the spec forbids.

## Bundled fixes

- `tests/integration/test_install_snapshot.py`, `tests/unit/test_reference_architecture.py`, `docs/backlog.md` — updated stale pointers naming the renamed file.