### PR TITLE
docs(guides): engagement-shaping guides — vision, strategy, architecture concept

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -27,7 +27,7 @@ Some guides are about the catalogue itself — installing it, upgrading it, seei
 
 - **Install & upgrade** — [from a clone](_shared/how-to/install-agentbundle-from-clone.md), into [Codex](_shared/how-to/install-user-scope-pack-into-codex.md) or [Kiro](_shared/how-to/install-user-scope-pack-into-kiro.md), [preview first with `--dry-run`](_shared/how-to/preview-install-or-upgrade.md), [upgrade an installed pack](_shared/how-to/upgrade-packs.md).
 - **Reference** — the [`agentbundle` CLI](_shared/reference/agentbundle.md) and the [adapter support matrix](_shared/reference/adapter-support.md).
-- **Understand** — [install routes](_shared/explanation/install-routes.md), [the pack catalogue](_shared/explanation/pack-catalogue.md), and [the file-safety contract](_shared/explanation/file-safety-contract.md) (your edits are never silently overwritten).
+- **Understand** — [install routes](_shared/explanation/install-routes.md), [the pack catalogue](_shared/explanation/pack-catalogue.md), [the file-safety contract](_shared/explanation/file-safety-contract.md) (your edits are never silently overwritten), and [shaping a new engagement](_shared/explanation/shaping-a-new-engagement.md) (how a product vision, a product strategy, and an architecture concept co-shape each other at the start).
 - **Contribute** — [how to author a skill](_shared/how-to/author-a-skill.md) for any pack.
 
 ## The four kinds

--- a/docs/guides/_shared/explanation/shaping-a-new-engagement.md
+++ b/docs/guides/_shared/explanation/shaping-a-new-engagement.md
@@ -1,0 +1,47 @@
+# Shaping a new engagement: product intent and the architecture concept
+
+*About how a product vision, a product strategy, and an architecture concept inform each other when you start a new engagement.* This page is the *why*; the procedures live in the how-tos it links, and the stage-by-stage menu lives in [Run a full inception](../how-to/run-a-full-inception.md).
+
+The start of a new engagement is where the most expensive mistakes are the cheapest to fix. Build the wrong product and no architecture saves it; pick an architecture that can't meet the bet and the product never ships. Two kinds of shaping run here — *what should exist and for whom*, and *how it should be built* — and they are not sequential phases so much as two tracks that keep checking each other. This page is about how they relate.
+
+## Two tracks, one artifact each
+
+The product track lives in the `product-engineering` pack. Its one artifact is the **intent** — an outcome plus the opportunity behind it — written at the altitude you're operating at. A [product vision](../../product-engineering/how-to/frame-a-product-vision.md) and a [product strategy](../../product-engineering/how-to/shape-a-product-strategy.md) are the same artifact one rung apart, not two document types.
+
+The architecture track lives in the `architect` pack. Its first artifact is the **[architecture concept](../../architect/how-to/shape-an-architecture-concept.md)** — a ≤½-page shape that gets agreed before anyone writes a multi-page design doc.
+
+Both tracks share a habit: shape something small, get it agreed, and only then commit depth. The vision is a bet you can kill in a sentence; the concept is a shape you can redraw in a sentence. That's deliberate — depth before agreement is the expensive mistake both packs exist to prevent.
+
+## Vision and strategy: the same bet, one rung apart
+
+The vision is the **existence bet** — why this product should exist, for whom, and through what wedge. The strategy is the **path** — the central challenge, the guiding policy, the coherent actions, and which problem you solve for which segment, in what order. Vision sits above strategy; both sit above the capability and feature work that follows.
+
+What makes them one artifact rather than two is that the *kind of risk* shifts with the altitude, not the shape of the thing you write. At both product altitudes the bet is **market-existence** — will anyone want this, and can it be a business — tested once at the top, not re-argued at every feature below. The intent tree explains why the altitudes nest this way; this page won't re-derive it.
+
+## Where the architecture concept meets the product
+
+This is the join most engagements get wrong, in both directions.
+
+**The product shapes the architecture.** The strategy's bets are the concept's inputs. The viability half of the market-existence bet sets the cost and quality envelope the architecture has to live inside. The wedge says what must be built first and what can wait. The problem/segment sequence tells the concept what to be ready for and what it's safe to defer. An architecture concept drawn without the strategy in view optimizes for the wrong attributes — gold-plating a path the product won't take.
+
+**The architecture talks back.** The concept can kill or reshape a product bet, and should be allowed to. If the cheapest shape that meets the top quality attribute blows the viability guardrail, that's not a detail to handle later — it's a finding for the strategy. The concept's *key tradeoff* and its grounded platform limits are exactly the kind of news that changes what the product should promise. Treating architecture as downstream-only — product decides, architecture implements — is how a team discovers in month three that the bet was never affordable.
+
+The healthy pattern is a short loop: shape the strategy, shape a concept against it, let what the concept surfaces revise the strategy, settle. Neither track finishes before the other starts.
+
+## Sequence is a default, not a gate
+
+Vision → strategy → concept is the order when you're carrying all three uncertainties. You rarely are. You reach for a stage only when you hold the uncertainty it removes: skip the vision when the product clearly should exist, skip the strategy when the path is obvious, go straight to a concept when the only open question is *how*. A clear idea with obvious value and a familiar stack needs none of this — it goes straight to a brief and the build loop. [Run a full inception](../how-to/run-a-full-inception.md) lays out that menu of stages against the uncertainties they answer.
+
+## What this is not
+
+- **Not a waterfall.** The stages are keyed to uncertainty, not arranged as phase gates. Running all of them on an engagement whose value and shape are already clear is ceremony, and ceremony is its own kind of risk.
+- **The concept is not the design doc.** The concept is the shape; the design doc is the depth that follows once the shape is agreed. Collapsing the two loses the cheap-to-change window the concept exists to hold open.
+- **The intent tree is not a tracker.** Vision, strategy, and the capabilities below them form a tree that's deeper than any board. Trackers are a one-way projection of it, never the model itself.
+
+## See also
+
+- [Frame a product vision](../../product-engineering/how-to/frame-a-product-vision.md) — shape the existence bet.
+- [Shape a product strategy](../../product-engineering/how-to/shape-a-product-strategy.md) — shape the path that realizes it.
+- [Shape an architecture concept](../../architect/how-to/shape-an-architecture-concept.md) — shape the technical concept it builds toward.
+- [The intent tree](../../product-engineering/explanation/the-intent-tree.md) — the model behind the product altitudes.
+- [Run a full inception](../how-to/run-a-full-inception.md) — the full menu of inception stages and the packs each needs.

--- a/docs/guides/_shared/how-to/run-a-full-inception.md
+++ b/docs/guides/_shared/how-to/run-a-full-inception.md
@@ -125,6 +125,9 @@ The upstream stages earn their place only against real uncertainty.
 
 ## See also
 
+- [Shaping a new engagement](../explanation/shaping-a-new-engagement.md) — the
+  *why*: how the product vision, the product strategy, and the architecture
+  concept co-shape each other across the stages this guide sequences.
 - [From idea to a walking skeleton](../../core/tutorials/start-a-new-project.md)
   — the `core`-only walkthrough this guide wraps.
 - [Receive a product brief](../../core/how-to/receive-a-product-brief-and-decompose-it-into-specs.md)

--- a/docs/guides/architect/README.md
+++ b/docs/guides/architect/README.md
@@ -13,6 +13,7 @@ New here? [Establish your repo's reference architecture](how-to/establish-refere
 ## How-to
 
 - [Establish your repo's reference architecture](how-to/establish-reference-architecture.md) — capture the stack, patterns, and constraints the architect skills design against.
+- [Shape an architecture concept](how-to/shape-an-architecture-concept.md) — get a ≤½-page Stage-0 concept agreed with `architect-design` before committing to a full design doc.
 - [Diagram a system](how-to/diagram-a-system.md) — draw a system, flow, state, data-model, or deployment-topology diagram with `architect-diagram`.
 - [Review an architecture artifact](how-to/review-an-architecture-artifact.md) — get a severity-tagged critique of a design doc, diagram, RFC, or ADR with `architect-review`, or an independent forked-context pass with the `design-reviewer` subagent.
 

--- a/docs/guides/architect/how-to/shape-an-architecture-concept.md
+++ b/docs/guides/architect/how-to/shape-an-architecture-concept.md
@@ -1,0 +1,49 @@
+# Shape an architecture concept
+
+> Get a ≤½-page architecture concept agreed before you commit to a full design doc. Assumes you know roughly what you're building; if the product bet itself is still unsettled, shape that first with [`product-engineering`](../../product-engineering/).
+
+You have a product to build — a strategy, a brief, or a clear feature — and a real technical choice to make. Before writing a multi-page design doc, `architect-design` shapes a **Stage-0 concept**: the elevator-pitch version of the architecture that gets the shape agreed cheaply, while changing it still costs a sentence. Install the `architect` pack, then work the steps below.
+
+## 1. Invoke architect-design and frame the problem
+
+Run `architect-design`. It asks only what's genuinely missing — what you're building, who's affected, why now, what counts as success — three to five questions at most. Anything you've already said, it skips; anything you can't answer becomes an open question rather than a blocker.
+
+The skill **steers off your `reference.md`** and is **knowledge-surface aware**. If your repo has a [`reference.md` golden path](establish-reference-architecture.md), the concept measures against it, so establish that first if you haven't. When an internal knowledge surface is reachable, `architect-design` consults it before proposing and names what it drew from.
+
+## 2. Agree the concept before the doc
+
+The concept is a ≤½-page artifact (`architect-design/assets/concept.md`), and the skill **waits for you to agree the shape** before going further. It carries the shaping essentials and deliberately none of the design doc's heavy sections:
+
+- **Problem & context** — the user-visible problem and why now, in two or three sentences.
+- **Constraints** — the hard edges: deadline, budget, team shape, regulatory, existing-system shape. At least one should be non-obvious.
+- **Candidate shapes (1–2)** — one line each; a second only when there's a real second option.
+- **Provider / provider-class** — AWS, Azure, GCP, a primitives provider, local-first, or none. One *by-construction* line on which quality attributes managed services meet versus what you'd build yourself.
+- **Top 2–3 quality attributes** — ranked by business-importance × architectural-risk, each with a one-line reason it ranks where it does.
+- **Key tradeoff / open decision** — the one or two calls the full doc will turn on.
+
+This is *shaping* — context, constraints, and the choice — not a stripped-down proposal. If the concept collapses into "here's the answer", you've skipped the shaping it exists to do.
+
+Ground any load-bearing platform claim. For every managed service on a critical path, `architect-design` grounds its *binding* contract — non-configurable limits, scaling floors, cold-start behaviour, network and identity needs — in an authoritative source, and lowers the confidence on anything it couldn't ground. A limit recalled wrong is the miss that surfaces two days into the build, not at review.
+
+## 3. Converge into the design doc
+
+Once you agree the concept, `architect-design` offers to draft the full Google-style design doc — TL;DR, context, goals and non-goals, proposal, alternatives, risks, rollout, open questions — and converges it against review, auto-resolving mechanical findings and surfacing judgment calls as explicit decisions. If the concept is all you need right now, stop there: it's a real artifact, not a draft of something else.
+
+When the doc captures discrete decisions — a technology choice, a structural commitment, an interface contract — `architect-design` ends by flagging them as ADR-worthy. Capture them with your ADR skill.
+
+## Verify
+
+You have a usable architecture concept when:
+
+- It fits on half a page and names the problem, the constraints, the candidate shapes, the provider, and the top quality attributes.
+- Every quality attribute names why it ranks where it does.
+- The key tradeoff is a genuine decision, not a foregone conclusion dressed as one.
+- Someone who wasn't in the room could say what's being built and what's still open.
+
+## See also
+
+- [Establish your repo's reference architecture](establish-reference-architecture.md) — the golden path the concept measures against.
+- [Diagram a system](diagram-a-system.md) — when the concept needs a picture to reason about.
+- [Review an architecture artifact](review-an-architecture-artifact.md) — get a severity-tagged critique of the concept or the design doc.
+- [Shape a product strategy](../../product-engineering/how-to/shape-a-product-strategy.md) — the product path the concept builds toward.
+- [Shaping a new engagement](../../_shared/explanation/shaping-a-new-engagement.md) — how the architecture concept relates to the product vision and strategy.

--- a/docs/guides/product-engineering/README.md
+++ b/docs/guides/product-engineering/README.md
@@ -2,10 +2,12 @@
 
 Shape product intent into work your delivery loop can build. The pack turns an idea, a request, or a strategy into a level-tagged `intent` — an outcome with a parent and children — and walks it down the tree: `frame-intent` to shape it, `de-risk-intent` to test the bet, `decompose-intent` to break it into the next level or a shippable slice, and `align-value-stream` to coordinate the work across many component repos. At the leaf, an intent becomes a brief or a spec and rejoins the normal build loop. Once the feature is being built, `voice-and-microcopy` shapes the actual words users read — the product's voice and its error, empty, button, and label copy.
 
-New here? Start with [the intent tree](explanation/the-intent-tree.md) for the model, then [shape a feature intent](how-to/shape-a-feature-intent.md) in your own repo.
+New here? Start with [the intent tree](explanation/the-intent-tree.md) for the model, then [shape a feature intent](how-to/shape-a-feature-intent.md) in your own repo. Starting a brand-new product or engagement? Begin at the top of the tree with [frame a product vision](how-to/frame-a-product-vision.md).
 
 ## How-to
 
+- [Frame a product vision](how-to/frame-a-product-vision.md) — shape the existence bet at the top of the tree, then de-risk it as a market-existence question.
+- [Shape a product strategy](how-to/shape-a-product-strategy.md) — turn a vision into the path: central challenge, guiding policy, coherent actions, and problem/segment sequence.
 - [Shape a feature intent in an app repo](how-to/shape-a-feature-intent.md) — frame, de-risk, and decompose a single piece of work down to a spec.
 - [Run a capability across a value stream](how-to/run-a-capability-across-a-value-stream.md) — coordinate one capability across several component repos from a meta-repo.
 - [Write a product's voice and microcopy](how-to/write-product-microcopy.md) — characterize the product's voice, then write the error, empty, button, and label copy from blame-free formulas.

--- a/docs/guides/product-engineering/explanation/the-intent-tree.md
+++ b/docs/guides/product-engineering/explanation/the-intent-tree.md
@@ -1,6 +1,6 @@
 # The intent tree — level-agnostic product shaping
 
-> **Diátaxis: explanation.** Why the `product-engineering` pack shapes work the way it does. For the step-by-step, see the how-to *Shape a feature intent*; for field definitions, the reference *Intent fields and modes*.
+> **Diátaxis: explanation.** Why the `product-engineering` pack shapes work the way it does. For the step-by-step, see the how-tos [*Frame a product vision*](../how-to/frame-a-product-vision.md), [*Shape a product strategy*](../how-to/shape-a-product-strategy.md), and [*Shape a feature intent*](../how-to/shape-a-feature-intent.md); for field definitions, the reference [*Intent fields and modes*](../reference/intent-fields-and-modes.md). For how these product altitudes meet the architecture concept at the start of an engagement, see [*Shaping a new engagement*](../../_shared/explanation/shaping-a-new-engagement.md).
 
 ## The problem it solves
 

--- a/docs/guides/product-engineering/how-to/frame-a-product-vision.md
+++ b/docs/guides/product-engineering/how-to/frame-a-product-vision.md
@@ -1,0 +1,40 @@
+# How to frame a product vision
+
+> **Diátaxis: how-to.** Shape the top of the intent tree — the *existence bet* for a new product or engagement. For the model behind the altitudes, see the explanation [*The intent tree*](../explanation/the-intent-tree.md); for the feature-altitude walk, [*Shape a feature intent*](shape-a-feature-intent.md); for how vision, strategy, and the architecture concept fit together at the start of an engagement, [*Shaping a new engagement*](../../_shared/explanation/shaping-a-new-engagement.md).
+
+You are starting a new engagement with a product idea, and the real question is not which features to build but whether this product should exist at all, and for whom. A product vision answers that as a bet you can test. Install the `product-engineering` pack, then work the three moves below.
+
+## 1. Frame the vision at the product-vision altitude
+
+Invoke `frame-intent`. It runs intake first: it infers **Scale** (a single repo with app code → `app`; many component pointers and no app code → `business-unit`), confirms it, and asks whether the work is **greenfield or brownfield**. For a greenfield product concept it asks the altitude outright instead of defaulting to `feature` — answer **`product-vision`**. Scale only *suggests* a starting altitude; you set it in a word.
+
+The intent template (`frame-intent/assets/intent-template.md`) lands at `docs/product/intents/<slug>.md`. Stamp `Level: product-vision` and fill three fields:
+
+- **Outcome** — a steerable *input* you can move, the *lagging* result it should drive, and a *guardrail* that must not get worse. At the vision altitude you are pre-product, so a **qualitative-but-falsifiable** outcome is first-class: name the signal you would accept as proof, not a conversion number you don't have traffic for.
+- **Opportunity** — the job the user is trying to get done, framed without a solution. "Get back into my account on my own", not "add a reset-link button". A vision built around a solution can't be tested as a bet.
+- **Assumptions** — what must be true for the product to exist as a business, one line each.
+
+The existence bet has a shape worth holding to: **why this product should exist, for whom, and through what wedge** — the narrow first foothold, not the eventual platform.
+
+`frame-intent` is knowledge-surface aware. When it can reach an internal knowledge surface — an enterprise-knowledge MCP tool, an internal CLI, an in-repo doc set — it consults the business-domain and in-flight areas so the vision uses your org's real terms and doesn't re-bet something already being delivered, and it names the surface it used (or "none", with confidence lowered to match).
+
+## 2. De-risk the market-existence bet
+
+Invoke `de-risk-intent`. At the product altitudes the riskiest assumption is **market-existence**, not feature desirability: *will anyone want this at all* and *can it be a business*. The viability half is named so it can't quietly drop out, and you test it **once at the top** rather than re-litigating it per feature later.
+
+Predeclare the **kill condition before you probe**. Pre-product, that's a qualitative bar stated in 0-to-1 terms — "proceed only if at least four of six target buyers say they'd switch and name a budget" — not a fabricated threshold. Writing the line down before you see the result is what separates a real test from theatre.
+
+The verdict is **survive or kill**. Killed → reframe the vision or drop it; a product nobody wants fails differently from a feature nobody uses, and the top of the tree is the cheapest place to learn that. Survived → decompose.
+
+## 3. Decompose toward a strategy
+
+Invoke `decompose-intent`. A surviving product-vision intent produces the **next level down** — a `product-strategy` child (or an intervening `initiative` if your org names one), not specs. Don't skip levels: the strategy is where the path gets named. Record *why* the cut went the way it did on the parent's `Decomposition`, so a later reader doesn't re-litigate a branch you already ruled out.
+
+From here, [shape the product strategy](shape-a-product-strategy.md).
+
+## See also
+
+- [The intent tree](../explanation/the-intent-tree.md) — why one recursive artifact covers vision through feature.
+- [Shape a product strategy](shape-a-product-strategy.md) — the next altitude down.
+- [Shaping a new engagement](../../_shared/explanation/shaping-a-new-engagement.md) — how the vision relates to strategy and the architecture concept.
+- [Run a full inception](../../_shared/how-to/run-a-full-inception.md) — where product shaping sits among research, architecture, and the build loop.

--- a/docs/guides/product-engineering/how-to/shape-a-feature-intent.md
+++ b/docs/guides/product-engineering/how-to/shape-a-feature-intent.md
@@ -4,7 +4,7 @@
 
 You have an idea or a request and you want to turn it into a spec your delivery loop can build, without skipping the thinking. Install the `product-engineering` pack, then:
 
-> **Starting higher than a feature.** This walkthrough shapes a *feature* intent, but `Level` is an open set (`product-vision › product-strategy › capability › feature`) and is **no longer stamped from `Scale`**. An app-scale **greenfield product concept** — where the real question is "should this product exist at all" — can start at a **product altitude** (`product-vision`), not only at `feature`. `frame-intent` asks the altitude for concept-shaped input; Scale only *suggests* a starting point you override in a word. The rest of the loop (de-risk, decompose) is the same shape at any level.
+> **Starting higher than a feature.** This walkthrough shapes a *feature* intent, but `Level` is an open set (`product-vision › product-strategy › capability › feature`) and is **no longer stamped from `Scale`**. An app-scale **greenfield product concept** — where the real question is "should this product exist at all" — can start at a **product altitude** (`product-vision`), not only at `feature`; for that route see [*Frame a product vision*](frame-a-product-vision.md) and [*Shape a product strategy*](shape-a-product-strategy.md). `frame-intent` asks the altitude for concept-shaped input; Scale only *suggests* a starting point you override in a word. The rest of the loop (de-risk, decompose) is the same shape at any level.
 
 ## 1. Frame the intent
 

--- a/docs/guides/product-engineering/how-to/shape-a-product-strategy.md
+++ b/docs/guides/product-engineering/how-to/shape-a-product-strategy.md
@@ -1,0 +1,39 @@
+# How to shape a product strategy
+
+> **Diátaxis: how-to.** Shape the *path* from a product vision — the second product altitude. For the model, see [*The intent tree*](../explanation/the-intent-tree.md); for the altitude above, [*Frame a product vision*](frame-a-product-vision.md); for how the pieces fit at engagement start, [*Shaping a new engagement*](../../_shared/explanation/shaping-a-new-engagement.md).
+
+You have a product vision that survived its market-existence test, and now you need the path to realize it: which problem, for which segment, in what order, and why now. That path is a **product-strategy** intent. Install the `product-engineering` pack, then work the moves below.
+
+## 1. Decompose the vision, or frame the strategy directly
+
+If you came from a vision, invoke `decompose-intent` on it. A surviving `product-vision` intent produces a `product-strategy` child that inherits the vision's outcome context and carries a `Parent intent:` back-link.
+
+If you're entering at the strategy altitude with no framed vision above it, invoke `frame-intent` and answer the altitude as **`product-strategy`**. When the work really needs a vision above it, `decompose-intent` and `frame-intent` both carry a *missing-parent* offer — they'll propose framing the parent and hanging the strategy beneath it. It's an offer, never a block; accept it or proceed.
+
+## 2. Write the strategy as challenge, policy, actions
+
+A product-strategy intent is the same artifact as any other — `Outcome`, `Opportunity`, `Assumptions`, `Decomposition` — but the **opportunity reads as a path**. Name four things:
+
+- **The central challenge** — a diagnosis of the one obstacle that, left unaddressed, sinks the vision. Not a list of problems; the crux.
+- **The guiding policy** — the overall approach you'll take to that challenge.
+- **The coherent actions** — the few moves that deliver on the policy and reinforce each other rather than scatter effort.
+- **The problem/segment sequence** — which problem for which segment, in what order, and why now.
+
+Keep the outcome honest: a steerable input, the lagging result it drives, a guardrail that must not get worse. Don't bolt a quantified target onto a path you've already chosen — name the input you can actually steer.
+
+## 3. De-risk at the product level
+
+Invoke `de-risk-intent`. A strategy bet is still **market-existence** in kind — will this *path* reach a market that pays — not feature desirability. Predeclare the kill condition before you probe, take the survive/kill verdict, and fold what you learn back into the strategy. A killed strategy reshapes the vision above it; it doesn't spawn capabilities that inherit a dead bet.
+
+## 4. Decompose toward capabilities
+
+Invoke `decompose-intent` on the survived strategy. It produces the **next level down** — `capability` intents, each of which re-enters the loop (`frame → de-risk → decompose`) until the leaf is a `core` brief your delivery loop can build. Don't skip the capability rung: it's where the architectural and adoption bets live, distinct from the market bet you tested up top.
+
+Before you commit to *how* the capabilities get built, shape the [architecture concept](../../architect/how-to/shape-an-architecture-concept.md) against this strategy — the strategy's bets are its inputs.
+
+## See also
+
+- [Frame a product vision](frame-a-product-vision.md) — the altitude above, where the existence bet is tested.
+- [The intent tree](../explanation/the-intent-tree.md) — why vision, strategy, capability, and feature are one recursive artifact.
+- [Shape an architecture concept](../../architect/how-to/shape-an-architecture-concept.md) — the technical shaping the strategy feeds.
+- [Shaping a new engagement](../../_shared/explanation/shaping-a-new-engagement.md) — how product intent and the architecture concept co-shape each other.

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -32,6 +32,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Guides for shaping a new engagement — product vision, product strategy, and
+  the architecture concept.** Three new how-tos document the top of the shaping
+  funnel that previously had no guide:
+  [*Frame a product vision*](../guides/product-engineering/how-to/frame-a-product-vision.md)
+  and [*Shape a product strategy*](../guides/product-engineering/how-to/shape-a-product-strategy.md)
+  in the `product-engineering` pack (the two product altitudes of `frame-intent`,
+  with their market-existence de-risk), and
+  [*Shape an architecture concept*](../guides/architect/how-to/shape-an-architecture-concept.md)
+  in the `architect` pack (the ≤½-page Stage-0 concept `architect-design` agrees
+  before a full design doc). A new cross-pack explanation,
+  [*Shaping a new engagement*](../guides/_shared/explanation/shaping-a-new-engagement.md),
+  ties them together — how product intent and the architecture concept co-shape
+  each other at engagement start — and the affected pack indexes and existing
+  guides gain cross-links.
 - **`architect` grounds the design phase in platform reality — a backed
   serverless workload-class lens plus two dual-consumed disciplines.** The
   `architect` pack gains **`lens-serverless.md`** (in both `architect-design`

--- a/docs/specs/engagement-shaping-guides/spec.md
+++ b/docs/specs/engagement-shaping-guides/spec.md
@@ -1,0 +1,125 @@
+# Spec: Engagement-shaping guides (product vision → strategy → architecture concept)
+
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+
+Mode: full (multi-feature risk trigger — four new guides). Scoped to docs:
+the operative gates are `new-guide`'s per-guide audience-contract checkpoint,
+the per-quadrant Diátaxis rules, the `clear-prose` pass, and an
+`adversarial-reviewer` pass. No security/infra machinery applies (repo-owned
+Markdown under `docs/guides/`, which is not projected, so `build-self` drift
+does not gate it).
+
+## Objective
+
+Give the practitioner who shapes a **new engagement / project** the recipes for
+the three upstream shaping artifacts the catalogue's skills already produce but
+that no guide yet documents — a **product vision**, a **product strategy**, and
+an **architecture concept** — plus one explanation that ties them into a single
+co-shaping arc. Frame every piece for that reader (delivery lead, product owner,
+or solution architect starting an engagement), org-neutral.
+
+## Why these four (and not more)
+
+The two product altitudes and the architect-design Stage-0 concept have **no
+how-to today** (`product-engineering` ships only `shape-a-feature-intent` at the
+feature altitude; `architect` ships diagram/review/reference-architecture but no
+`architect-design` how-to). Those are the real gaps.
+
+The relations the user asked for are **already partly covered**, so this spec
+does not duplicate them:
+
+- vision ↔ strategy relation → `product-engineering/explanation/the-intent-tree.md`
+  (+ `frame-intent/references/intent-model.md`).
+- product → architecture **sequence** for a new project →
+  `_shared/how-to/run-a-full-inception.md`.
+
+What is *not* yet written is the **why product and architecture co-shape each
+other** at engagement start — an explanation, which a how-to cannot carry. One
+new explanation covers both the vision↔strategy and product↔architecture
+relations as a connected arc, and cross-links (not restates) the two existing
+pieces above.
+
+## Deliverables
+
+New files:
+
+1. `docs/guides/product-engineering/how-to/frame-a-product-vision.md` — how-to.
+2. `docs/guides/product-engineering/how-to/shape-a-product-strategy.md` — how-to.
+3. `docs/guides/architect/how-to/shape-an-architecture-concept.md` — how-to.
+4. `docs/guides/_shared/explanation/shaping-a-new-engagement.md` — explanation
+   (cross-pack; the co-shaping arc and the relations).
+
+README updates (per-pack indexes — the only index files; `new-guide` forbids
+touching the per-quadrant framework READMEs):
+
+5. `docs/guides/product-engineering/README.md` — add the two new how-to lines.
+6. `docs/guides/architect/README.md` — add the new how-to line.
+7. `docs/guides/README.md` — add the new `_shared` explanation under the
+   "Not tied to one pack" section.
+
+## Acceptance criteria
+
+- [x] AC1 — Each of guides 1–3 is a true **how-to**: titled by the reader's
+  problem, no reteaching of basics, names the real variations/pitfalls,
+  documents a skill that **ships** (`frame-intent`, `architect-design`).
+- [x] AC2 — Guide 1 documents `frame-intent` at the **`product-vision`** altitude
+  (the existence bet; market-existence de-risk), not the feature altitude;
+  it cross-links `shape-a-feature-intent` and `the-intent-tree`.
+- [x] AC3 — Guide 2 documents `frame-intent` at the **`product-strategy`**
+  altitude (central challenge, guiding policy, coherent actions, problem/segment
+  sequence) and how it decomposes from a vision.
+- [x] AC4 — Guide 3 documents the **Stage-0 architecture concept** from
+  `architect-design` (≤½-page: problem/constraints, candidate shapes, provider,
+  top quality attributes, key tradeoff) and the offer to converge into a full
+  design doc — it does **not** re-document the full design-doc flow.
+- [x] AC5 — Guide 4 is a true **explanation** (an *About <X>* frame, no
+  step-by-step), explaining vision↔strategy and product↔architecture-concept
+  co-shaping for a new engagement; it **cross-links** `the-intent-tree`,
+  `run-a-full-inception`, and the three new how-tos rather than restating them.
+- [x] AC6 — Every new guide opens matching its pack's existing convention: the
+  `> **Diátaxis: <quadrant>.**` banner where the pack already uses one
+  (product-engineering how-tos and explanations do), a plain `>` lead in the
+  architect pack, and a plain prose lead (with an italic *About …* frame for the
+  explanation) in `_shared`, where the sibling pages carry no banner. Each guide
+  carries a `See also` section that links **only files that exist** (no broken
+  links; placeholders surfaced, not invented).
+- [x] AC7 — The three README indexes list the new guides with one-line
+  descriptions matching the house style; existing reverse-links added from the
+  cross-linked existing guides where the house style already does so.
+- [x] AC8 — Prose passes the `clear-prose` checklist (no *simply/just*, no
+  throat-clearing, no AI-tells, retcon discipline) and an `adversarial-reviewer`
+  pass returns clean.
+
+## Boundaries
+
+- **Never do:** duplicate `the-intent-tree.md` or `run-a-full-inception.md`;
+  re-document the full `architect-design` design-doc flow inside the concept
+  how-to; bake a specific org name into the prose (keep it engagement-neutral);
+  edit the per-quadrant framework READMEs under `_shared/<quadrant>/`.
+- **Ask first:** splitting guide 4 into two separate explanations; placing the
+  cross-pack explanation somewhere other than `_shared/explanation/`.
+- **Always do:** match the surrounding per-pack guide structure and voice;
+  honour `new-guide`'s audience-contract checkpoint per guide.
+
+## Tasks
+
+- T1 — Confirm the four audience contracts (gated; this surface). Depends on: none.
+- T2 — Draft guide 1 (frame-a-product-vision). Depends on: T1.
+- T3 — Draft guide 2 (shape-a-product-strategy). Depends on: T1.
+- T4 — Draft guide 3 (shape-an-architecture-concept). Depends on: T1.
+- T5 — Draft guide 4 (shaping-a-new-engagement explanation). Depends on: T2,T3,T4
+  (it cross-links them). 
+- T6 — Update the three README indexes + reverse cross-links. Depends on: T2–T5.
+- T7 — clear-prose pass + adversarial-reviewer; fix; finish checklist. Depends on: T6.
+
+## Declined temptations
+
+- Tempted to add a standalone vision↔strategy explanation; declining —
+  `the-intent-tree.md` already owns it; cross-link instead.
+- Tempted to add a fifth "engagement inception" how-to; declining —
+  `run-a-full-inception.md` already is that how-to; guide 4 is the missing
+  *explanation*, not another recipe.
+- Tempted to add a tutorial for the vision→strategy→concept arc; declining —
+  no one asked for a guaranteed-result lesson, and the arc is reader-driven, not
+  a single deterministic path.


### PR DESCRIPTION
## What & why

Three upstream shaping artifacts the catalogue's skills already produce had **no guide**: the `product-vision` and `product-strategy` altitudes of `frame-intent`, and `architect-design`'s Stage-0 concept. This adds the recipes plus one explanation tying them into a co-shaping arc for a **new engagement / project**, framed for a delivery lead / product owner / solution architect and kept org-neutral.

### New guides
- `product-engineering/how-to/frame-a-product-vision.md` — the existence bet + market-existence de-risk.
- `product-engineering/how-to/shape-a-product-strategy.md` — challenge · policy · actions · problem/segment sequence.
- `architect/how-to/shape-an-architecture-concept.md` — the ≤½-page Stage-0 concept, with the offer to converge into a full design doc (not a re-doc of the design-doc flow).
- `_shared/explanation/shaping-a-new-engagement.md` — *why* product intent and the architecture concept co-shape each other.

### Index + cross-link updates
The two pack indexes and the top guides index; reverse cross-links from `the-intent-tree.md`, `run-a-full-inception.md`, and `shape-a-feature-intent.md`; a changelog `[Unreleased]` entry.

### Deliberately not built
A standalone vision↔strategy explanation (`the-intent-tree.md` owns it) and a fifth inception how-to (`run-a-full-inception.md` is it) — the relations ride the one explanation + cross-links instead.

## How it was built
Full-mode work-loop, scoped to docs. Spec at `docs/specs/engagement-shaping-guides/spec.md` (Shipped, AC1–AC8 checked). Gates: all relative links resolve, `lint-spec-status` clean for this spec. `adversarial-reviewer` returned no Blockers; its two Concerns (spec status/ACs, changelog entry) and one Nit (`_shared` banner convention) are all addressed.

## Review questions
- **Spec & design:** does the vision→strategy→concept arc match how you'd run an engagement?
- **Tests/verification:** docs change — verified by link resolution + the per-quadrant Diátaxis self-check + adversarial review.
- **Risk:** repo-owned guides under `docs/guides/` (not projected), so no `build-self` / adopter surface impact.
- **Docs:** the guides *are* the docs; changelog updated.