### PR TITLE
feat(core): optional adopter grounding surface (RFC-0047 Layer B / ADR-0037 D2)

### DIFF
--- a/.agents/skills/adapt-to-project/SKILL.md
+++ b/.agents/skills/adapt-to-project/SKILL.md
@@ -250,7 +250,12 @@ descriptive `overview.md` map. On adapt, when the repo has none, offer to
    the stack and runtimes in use, the reusable internal building blocks and
    shared libraries, the recurring component stereotypes, and the cross-cutting
    standards (error handling, logging, auth, validation) that already repeat
-   across the tree. A thin repo with no real decisions yet has nothing to
+   across the tree. If the repo deploys, also note the **deployment platform**
+   it targets and **where its verification tooling lives** (the deploy / smoke /
+   teardown / test-data commands — whose one-liners also belong in the optional
+   `AGENTS.md` infra block); these are **optional grounding coordinates** the
+   work-loop infra preflight reads if present, so offer to record them, never
+   require them. A thin repo with no real decisions yet has nothing to
    harvest — say so and stop rather than inventing constraints.
 2. **Instantiate.** Fill the arc42 template shipped with this skill at
    `assets/reference.md` (four sections: Constraints, Solution strategy,

--- a/.agents/skills/adapt-to-project/assets/reference.md
+++ b/.agents/skills/adapt-to-project/assets/reference.md
@@ -35,7 +35,10 @@ performance or availability targets, and the team conventions that outrank
 local preference.
 
 - **Technical constraints.** <Runtimes, language versions, platforms, and
-  hard external dependencies every component lives within.>
+  hard external dependencies every component lives within. Name the
+  **managed-runtime or deployment platform** you target (the serverless
+  runtime, the orchestrator, the managed service) — the work-loop infra
+  preflight reads this as a starting coordinate rather than rediscovering it.>
 - **Organizational / process constraints.** <Conventions, review rules,
   release cadence, or compliance obligations that shape how code is built.>
 - **Constraints you cannot change here.** <Anything a single feature must work
@@ -52,7 +55,10 @@ reason it won. This is the section a new contributor reads first to understand
   partitioned, how components communicate, where state lives — and why.>
 - **Key technology decisions.** <The load-bearing choices: framework, data
   store, transport, build tooling. One line each on *what* and *why this over
-  the obvious alternative*.>
+  the obvious alternative*. Where a choice carries a **framework- or
+  library-level contract** new work must honour — the entrypoint / packaging
+  model, a required base class or decorator, a config-loading convention — name
+  that contract here so a design conforms to it instead of guessing it.>
 - **Quality-goal strategy.** <For each top-priority quality (e.g. throughput,
   recoverability, security posture), the architectural move that delivers it.>
 
@@ -83,10 +89,16 @@ the default and "deviate" the thing that needs justifying.
 - **Error handling.** <How errors are raised, wrapped, surfaced, and logged —
   the one shape all components use.>
 - **Observability.** <Logging, metrics, and tracing conventions: what gets
-  recorded, in what shape, at what boundary.>
+  recorded, in what shape, at what boundary — and *where* the logs and metrics
+  surface for a deployed change (the dashboard, the log group), so a verifier
+  knows where to read ground truth.>
 - **Security & data handling.** <Authn/authz approach, secret handling, input
   validation at trust boundaries, data-classification rules.>
 - **Configuration & environments.** <How configuration is supplied and
   validated; what differs across environments and what must not.>
 - **Testing standards.** <The expected test shape per component stereotype —
-  what's unit-tested, what's contract-tested, what's verified end-to-end.>
+  what's unit-tested, what's contract-tested, what's verified end-to-end — and
+  **where the verification tooling lives**: the smoke / verify-status check, the
+  deploy and teardown harness, the test-data seeding (the commands their
+  one-liners live under in `AGENTS.md`). Naming where they live lets the
+  work-loop infra preflight seed acquisition from them instead of cold.>

--- a/.agents/skills/init-project/SKILL.md
+++ b/.agents/skills/init-project/SKILL.md
@@ -102,7 +102,11 @@ rationale** — a foundation you can hold later work to. Two artifacts:
   (the same golden-path template its reference-architecture harvest fills) —
   here you fill it forward from a decision rather than harvesting it from
   existing code. The core methodology stays stack-neutral; the chosen stack is
-  *yours*, recorded in your ADR and your `reference.md`.
+  *yours*, recorded in your ADR and your `reference.md`. If the project will
+  deploy, this is also the moment to record the **deployment platform** and
+  **where verification tooling will live** in the `reference.md` slots (and the
+  matching one-liners in the `AGENTS.md` infra block) — optional grounding the
+  work-loop infra preflight reads if present, never a prerequisite.
 
 Hand the foundation forward as the steering every later design conforms to.
 

--- a/.agents/skills/work-loop/references/infra-verification.md
+++ b/.agents/skills/work-loop/references/infra-verification.md
@@ -69,6 +69,42 @@ artifact. This **refines** P2 and cross-links the plan template's `## Rollout`
 (which owns sequencing); it does **not** re-author the GATES layer sequence
 above.
 
+## PLAN — read recorded coordinates first, then cold oracle discovery
+
+Before enumerating the multi-artifact preflight below and before the
+contract-grounding gate, do one cheap thing first: **check recorded
+coordinates → acquire via oracles**. The adopter may already have written down
+where they deploy and how they verify, in files they own:
+
+- the **`AGENTS.md` "Commands you'll need"** optional infra/verification block —
+  the `<deploy>` / `<smoke / verify-status>` / `<teardown>` / `<seed-test-data>`
+  one-liners; and
+- the **`reference.md`** platform/verification slots — the
+  **managed-runtime / platform target** under *Constraints*, the
+  **framework-/library-level contract** under *Solution strategy → Key
+  technology decisions*, and **where the verification tooling lives** under
+  *Crosscutting → Observability / Testing standards*.
+
+**Every one of these reads is presence-checked — read-if-present, degrade
+honestly if absent.** A repo that recorded nothing runs exactly as it does
+today: absence lowers only the *starting information* the preflight begins from,
+it **never fails the loop**, and it is **not enforced by any CI gate**. There is
+**no new config file** for this — no `grounding.toml`, no schema; the surface is
+the two adopter-owned files above. State which coordinates you found (or
+"none"), the same way `architect-design` states the surface it detected.
+
+**A recorded coordinate seeds acquisition; it never replaces it.** A found
+`<deploy command>` or platform target *seeds* the multi-artifact preflight and
+the contract-grounding gate — it tells you where to start — but the agent still
+derives the **live** contract from the toolchain's oracles
+([`infra-contract-acquisition`](../../infra-contract-acquisition/SKILL.md)) and
+still smokes the **real** deployed system. When a recorded value **contradicts**
+the oracle (the `reference.md` names a runtime the `plan` output disputes, a
+recorded smoke command targets an endpoint the deploy no longer exposes), that
+contradiction is a **surfaced drift signal**, not a fact to trust — exactly the
+AGENTS.md *"When this file is wrong"* posture: flag the drift, don't silently
+work around it.
+
 ## PLAN — the multi-artifact preflight (each its own task-zero)
 
 For infra/deploy the mechanism is rarely one artifact; the preflight enumerates

--- a/.claude/skills/adapt-to-project/SKILL.md
+++ b/.claude/skills/adapt-to-project/SKILL.md
@@ -250,7 +250,12 @@ descriptive `overview.md` map. On adapt, when the repo has none, offer to
    the stack and runtimes in use, the reusable internal building blocks and
    shared libraries, the recurring component stereotypes, and the cross-cutting
    standards (error handling, logging, auth, validation) that already repeat
-   across the tree. A thin repo with no real decisions yet has nothing to
+   across the tree. If the repo deploys, also note the **deployment platform**
+   it targets and **where its verification tooling lives** (the deploy / smoke /
+   teardown / test-data commands — whose one-liners also belong in the optional
+   `AGENTS.md` infra block); these are **optional grounding coordinates** the
+   work-loop infra preflight reads if present, so offer to record them, never
+   require them. A thin repo with no real decisions yet has nothing to
    harvest — say so and stop rather than inventing constraints.
 2. **Instantiate.** Fill the arc42 template shipped with this skill at
    `assets/reference.md` (four sections: Constraints, Solution strategy,

--- a/.claude/skills/adapt-to-project/assets/reference.md
+++ b/.claude/skills/adapt-to-project/assets/reference.md
@@ -35,7 +35,10 @@ performance or availability targets, and the team conventions that outrank
 local preference.
 
 - **Technical constraints.** <Runtimes, language versions, platforms, and
-  hard external dependencies every component lives within.>
+  hard external dependencies every component lives within. Name the
+  **managed-runtime or deployment platform** you target (the serverless
+  runtime, the orchestrator, the managed service) — the work-loop infra
+  preflight reads this as a starting coordinate rather than rediscovering it.>
 - **Organizational / process constraints.** <Conventions, review rules,
   release cadence, or compliance obligations that shape how code is built.>
 - **Constraints you cannot change here.** <Anything a single feature must work
@@ -52,7 +55,10 @@ reason it won. This is the section a new contributor reads first to understand
   partitioned, how components communicate, where state lives — and why.>
 - **Key technology decisions.** <The load-bearing choices: framework, data
   store, transport, build tooling. One line each on *what* and *why this over
-  the obvious alternative*.>
+  the obvious alternative*. Where a choice carries a **framework- or
+  library-level contract** new work must honour — the entrypoint / packaging
+  model, a required base class or decorator, a config-loading convention — name
+  that contract here so a design conforms to it instead of guessing it.>
 - **Quality-goal strategy.** <For each top-priority quality (e.g. throughput,
   recoverability, security posture), the architectural move that delivers it.>
 
@@ -83,10 +89,16 @@ the default and "deviate" the thing that needs justifying.
 - **Error handling.** <How errors are raised, wrapped, surfaced, and logged —
   the one shape all components use.>
 - **Observability.** <Logging, metrics, and tracing conventions: what gets
-  recorded, in what shape, at what boundary.>
+  recorded, in what shape, at what boundary — and *where* the logs and metrics
+  surface for a deployed change (the dashboard, the log group), so a verifier
+  knows where to read ground truth.>
 - **Security & data handling.** <Authn/authz approach, secret handling, input
   validation at trust boundaries, data-classification rules.>
 - **Configuration & environments.** <How configuration is supplied and
   validated; what differs across environments and what must not.>
 - **Testing standards.** <The expected test shape per component stereotype —
-  what's unit-tested, what's contract-tested, what's verified end-to-end.>
+  what's unit-tested, what's contract-tested, what's verified end-to-end — and
+  **where the verification tooling lives**: the smoke / verify-status check, the
+  deploy and teardown harness, the test-data seeding (the commands their
+  one-liners live under in `AGENTS.md`). Naming where they live lets the
+  work-loop infra preflight seed acquisition from them instead of cold.>

--- a/.claude/skills/init-project/SKILL.md
+++ b/.claude/skills/init-project/SKILL.md
@@ -102,7 +102,11 @@ rationale** — a foundation you can hold later work to. Two artifacts:
   (the same golden-path template its reference-architecture harvest fills) —
   here you fill it forward from a decision rather than harvesting it from
   existing code. The core methodology stays stack-neutral; the chosen stack is
-  *yours*, recorded in your ADR and your `reference.md`.
+  *yours*, recorded in your ADR and your `reference.md`. If the project will
+  deploy, this is also the moment to record the **deployment platform** and
+  **where verification tooling will live** in the `reference.md` slots (and the
+  matching one-liners in the `AGENTS.md` infra block) — optional grounding the
+  work-loop infra preflight reads if present, never a prerequisite.
 
 Hand the foundation forward as the steering every later design conforms to.
 

--- a/.claude/skills/work-loop/references/infra-verification.md
+++ b/.claude/skills/work-loop/references/infra-verification.md
@@ -69,6 +69,42 @@ artifact. This **refines** P2 and cross-links the plan template's `## Rollout`
 (which owns sequencing); it does **not** re-author the GATES layer sequence
 above.
 
+## PLAN — read recorded coordinates first, then cold oracle discovery
+
+Before enumerating the multi-artifact preflight below and before the
+contract-grounding gate, do one cheap thing first: **check recorded
+coordinates → acquire via oracles**. The adopter may already have written down
+where they deploy and how they verify, in files they own:
+
+- the **`AGENTS.md` "Commands you'll need"** optional infra/verification block —
+  the `<deploy>` / `<smoke / verify-status>` / `<teardown>` / `<seed-test-data>`
+  one-liners; and
+- the **`reference.md`** platform/verification slots — the
+  **managed-runtime / platform target** under *Constraints*, the
+  **framework-/library-level contract** under *Solution strategy → Key
+  technology decisions*, and **where the verification tooling lives** under
+  *Crosscutting → Observability / Testing standards*.
+
+**Every one of these reads is presence-checked — read-if-present, degrade
+honestly if absent.** A repo that recorded nothing runs exactly as it does
+today: absence lowers only the *starting information* the preflight begins from,
+it **never fails the loop**, and it is **not enforced by any CI gate**. There is
+**no new config file** for this — no `grounding.toml`, no schema; the surface is
+the two adopter-owned files above. State which coordinates you found (or
+"none"), the same way `architect-design` states the surface it detected.
+
+**A recorded coordinate seeds acquisition; it never replaces it.** A found
+`<deploy command>` or platform target *seeds* the multi-artifact preflight and
+the contract-grounding gate — it tells you where to start — but the agent still
+derives the **live** contract from the toolchain's oracles
+([`infra-contract-acquisition`](../../infra-contract-acquisition/SKILL.md)) and
+still smokes the **real** deployed system. When a recorded value **contradicts**
+the oracle (the `reference.md` names a runtime the `plan` output disputes, a
+recorded smoke command targets an endpoint the deploy no longer exposes), that
+contradiction is a **surfaced drift signal**, not a fact to trust — exactly the
+AGENTS.md *"When this file is wrong"* posture: flag the drift, don't silently
+work around it.
+
 ## PLAN — the multi-artifact preflight (each its own task-zero)
 
 For infra/deploy the mechanism is rarely one artifact; the preflight enumerates

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -46,6 +46,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ties them together — how product intent and the architecture concept co-shape
   each other at engagement start — and the affected pack indexes and existing
   guides gain cross-links.
+- **An optional grounding surface lets you record where you deploy and how you
+  verify — in files you already own.** The `core` seed `AGENTS.md` "Commands
+  you'll need" gains an **optional** infra/verification command block
+  (`<deploy>` / `<smoke / verify-status>` / `<teardown>` / `<seed-test-data>`),
+  and the `reference.md` golden-path slots now prompt for the managed-runtime /
+  platform target, framework-/library-level contracts, and where verification
+  tooling lives. The work-loop infra preflight reads these recorded coordinates
+  **if present** and falls back to cold oracle discovery if absent — a repo that
+  fills nothing runs exactly as before. Recorded values **seed** oracle
+  acquisition, never replace it; a coordinate that contradicts the live oracle
+  is surfaced as a drift signal. No new config file, and absence never fails the
+  loop or any CI gate. `adapt-to-project` and `init-project` now optionally
+  offer to record these coordinates.
 - **`architect` grounds the design phase in platform reality — a backed
   serverless workload-class lens plus two dual-consumed disciplines.** The
   `architect` pack gains **`lens-serverless.md`** (in both `architect-design`

--- a/docs/specs/adopter-grounding-surface/plan.md
+++ b/docs/specs/adopter-grounding-surface/plan.md
@@ -1,7 +1,7 @@
 # Plan: Adopter grounding surface — a persistent recording surface the adopter already owns
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Drafting <!-- Drafting | Executing | Done -->
+- **Status:** Done <!-- Drafting | Executing | Done -->
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
 > document is allowed to change as you learn. When it changes substantially
@@ -93,6 +93,22 @@ Three additive prose edits to existing seed/template/skill sources, then project
 
 **Done when:** build-self clean, lint clean, changelog present, manual-QA recorded.
 
+**Manual-QA pass recorded (2026-06-25, doctrine walkthrough).** This change is
+prose steering, not runnable code, so the two-repo check is a walkthrough of the
+new preflight step against two repo shapes:
+- *Filled repo* — `AGENTS.md`'s optional infra block carries real `<deploy>` /
+  `<smoke>` / `<teardown>` / `<seed-test-data>` one-liners and `reference.md`
+  names the platform target + where verification tooling lives. Following the
+  new step, the preflight reads those coordinates *first*, states what it found,
+  and **seeds** the multi-artifact preflight + contract-grounding gate from them
+  — then still derives the live contract via the oracles and smokes the real
+  system. Recorded values seed, never replace; a recorded value that disputes
+  the oracle surfaces as a drift signal.
+- *Empty repo* — neither surface filled. The step is presence-checked: it finds
+  no coordinates, states "none," and **degrades to today's cold oracle
+  discovery with no failure** — no loop failure, no CI gate. Confirms the
+  regression fence: a repo that fills nothing runs exactly as it does today.
+
 ## Rollout
 
 Additive seed/template/skill prose, projected by `make build-self`. No infra, no migration. Reversible by reverting the prose. Deployment sequencing: this spec and `catalogue-seeds-lint` touch disjoint files but share a **lint-name dependency** — this spec's seed edit (T1) must satisfy whichever lint name is current, so if they land in separate PRs, sequence the rename-aware one to rebase onto the other.
@@ -106,3 +122,8 @@ Additive seed/template/skill prose, projected by `make build-self`. No infra, no
 ## Changelog
 
 - 2026-06-25: initial plan (RFC-0047 Layer B follow-on).
+- 2026-06-25: implemented (T1–T5). AGENTS.md infra block, three sharpened
+  `reference.md` slots, the presence-checked preflight step, and optional
+  elicitation threaded into `adapt-to-project` (Detect) + `init-project`
+  (Foundation) — AC7 threaded, not deferred. Projected via `make build-self`;
+  spec marked Shipped, all ACs checked.

--- a/docs/specs/adopter-grounding-surface/spec.md
+++ b/docs/specs/adopter-grounding-surface/spec.md
@@ -1,6 +1,6 @@
 # Spec: Adopter grounding surface — a persistent recording surface the adopter already owns
 
-- **Status:** Approved <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** RFC-0047 (Decisions 3, 4), ADR-0037 (D2), ADR-0010 (reference-architecture foundation)
@@ -46,14 +46,14 @@ before proceeding; *Never do* is a hard rule, even under time pressure.
 
 ## Acceptance Criteria
 
-- [ ] `packs/core/seeds/AGENTS.md`'s "Commands you'll need" carries a short, optional infra/verification command block (deploy / smoke-or-verify-status / teardown / seed-test-data), each line marked optional ("if any").
-- [ ] The `reference.md` asset's existing slots are sharpened to explicitly name (a) managed-runtime/platform targets under **Constraints**, (b) framework-library contracts under **Key technology decisions**, and (c) *where the verification tooling lives* under **Observability / Testing standards** — without adding a new section.
-- [ ] The work-loop infra preflight (`references/infra-verification.md`) gains a first step: **read the recorded coordinates** (the `AGENTS.md` block + the `reference.md` platform/verification sections) *if present*, then fall back to cold oracle discovery — phrased as "check recorded coordinates → acquire via oracles".
-- [ ] **Every** new read is presence-checked: absence lowers only the starting information, never fails the loop, and is **not** enforced by any CI gate (explicit negative criterion).
-- [ ] The recorded surface is documented as a **seed for** oracle acquisition, never a replacement; a recorded value contradicting the oracle is surfaced as a drift signal (matching AGENTS.md's "when this file is wrong").
-- [ ] **No new top-level config file** is introduced (`grep` finds no `grounding.toml` or equivalent).
-- [ ] `adapt-to-project` / `init-project` elicitation optionally prompts for these coordinates, phrased as optional and non-mandating (or this AC is deferred with a backlog anchor if descoped from the implementing PR).
-- [ ] `make build-self` projects the edited sources and the tree is clean afterward; `lint-spec-status.py` clean.
+- [x] `packs/core/seeds/AGENTS.md`'s "Commands you'll need" carries a short, optional infra/verification command block (deploy / smoke-or-verify-status / teardown / seed-test-data), each line marked optional ("if any").
+- [x] The `reference.md` asset's existing slots are sharpened to explicitly name (a) managed-runtime/platform targets under **Constraints**, (b) framework-library contracts under **Key technology decisions**, and (c) *where the verification tooling lives* under **Observability / Testing standards** — without adding a new section.
+- [x] The work-loop infra preflight (`references/infra-verification.md`) gains a first step: **read the recorded coordinates** (the `AGENTS.md` block + the `reference.md` platform/verification sections) *if present*, then fall back to cold oracle discovery — phrased as "check recorded coordinates → acquire via oracles".
+- [x] **Every** new read is presence-checked: absence lowers only the starting information, never fails the loop, and is **not** enforced by any CI gate (explicit negative criterion).
+- [x] The recorded surface is documented as a **seed for** oracle acquisition, never a replacement; a recorded value contradicting the oracle is surfaced as a drift signal (matching AGENTS.md's "when this file is wrong").
+- [x] **No new top-level config file** is introduced (`grep` finds no `grounding.toml` or equivalent).
+- [x] `adapt-to-project` / `init-project` elicitation optionally prompts for these coordinates, phrased as optional and non-mandating (threaded into `adapt-to-project`'s reference-architecture-harvest Detect step and `init-project`'s Foundation phase, both read-if-present and non-mandating).
+- [x] `make build-self` projects the edited sources and the tree is clean afterward; `lint-spec-status.py` clean.
 
 ## Assumptions
 

--- a/packs/core/.apm/skills/adapt-to-project/SKILL.md
+++ b/packs/core/.apm/skills/adapt-to-project/SKILL.md
@@ -250,7 +250,12 @@ descriptive `overview.md` map. On adapt, when the repo has none, offer to
    the stack and runtimes in use, the reusable internal building blocks and
    shared libraries, the recurring component stereotypes, and the cross-cutting
    standards (error handling, logging, auth, validation) that already repeat
-   across the tree. A thin repo with no real decisions yet has nothing to
+   across the tree. If the repo deploys, also note the **deployment platform**
+   it targets and **where its verification tooling lives** (the deploy / smoke /
+   teardown / test-data commands — whose one-liners also belong in the optional
+   `AGENTS.md` infra block); these are **optional grounding coordinates** the
+   work-loop infra preflight reads if present, so offer to record them, never
+   require them. A thin repo with no real decisions yet has nothing to
    harvest — say so and stop rather than inventing constraints.
 2. **Instantiate.** Fill the arc42 template shipped with this skill at
    `assets/reference.md` (four sections: Constraints, Solution strategy,

--- a/packs/core/.apm/skills/adapt-to-project/assets/reference.md
+++ b/packs/core/.apm/skills/adapt-to-project/assets/reference.md
@@ -35,7 +35,10 @@ performance or availability targets, and the team conventions that outrank
 local preference.
 
 - **Technical constraints.** <Runtimes, language versions, platforms, and
-  hard external dependencies every component lives within.>
+  hard external dependencies every component lives within. Name the
+  **managed-runtime or deployment platform** you target (the serverless
+  runtime, the orchestrator, the managed service) — the work-loop infra
+  preflight reads this as a starting coordinate rather than rediscovering it.>
 - **Organizational / process constraints.** <Conventions, review rules,
   release cadence, or compliance obligations that shape how code is built.>
 - **Constraints you cannot change here.** <Anything a single feature must work
@@ -52,7 +55,10 @@ reason it won. This is the section a new contributor reads first to understand
   partitioned, how components communicate, where state lives — and why.>
 - **Key technology decisions.** <The load-bearing choices: framework, data
   store, transport, build tooling. One line each on *what* and *why this over
-  the obvious alternative*.>
+  the obvious alternative*. Where a choice carries a **framework- or
+  library-level contract** new work must honour — the entrypoint / packaging
+  model, a required base class or decorator, a config-loading convention — name
+  that contract here so a design conforms to it instead of guessing it.>
 - **Quality-goal strategy.** <For each top-priority quality (e.g. throughput,
   recoverability, security posture), the architectural move that delivers it.>
 
@@ -83,10 +89,16 @@ the default and "deviate" the thing that needs justifying.
 - **Error handling.** <How errors are raised, wrapped, surfaced, and logged —
   the one shape all components use.>
 - **Observability.** <Logging, metrics, and tracing conventions: what gets
-  recorded, in what shape, at what boundary.>
+  recorded, in what shape, at what boundary — and *where* the logs and metrics
+  surface for a deployed change (the dashboard, the log group), so a verifier
+  knows where to read ground truth.>
 - **Security & data handling.** <Authn/authz approach, secret handling, input
   validation at trust boundaries, data-classification rules.>
 - **Configuration & environments.** <How configuration is supplied and
   validated; what differs across environments and what must not.>
 - **Testing standards.** <The expected test shape per component stereotype —
-  what's unit-tested, what's contract-tested, what's verified end-to-end.>
+  what's unit-tested, what's contract-tested, what's verified end-to-end — and
+  **where the verification tooling lives**: the smoke / verify-status check, the
+  deploy and teardown harness, the test-data seeding (the commands their
+  one-liners live under in `AGENTS.md`). Naming where they live lets the
+  work-loop infra preflight seed acquisition from them instead of cold.>

--- a/packs/core/.apm/skills/init-project/SKILL.md
+++ b/packs/core/.apm/skills/init-project/SKILL.md
@@ -102,7 +102,11 @@ rationale** — a foundation you can hold later work to. Two artifacts:
   (the same golden-path template its reference-architecture harvest fills) —
   here you fill it forward from a decision rather than harvesting it from
   existing code. The core methodology stays stack-neutral; the chosen stack is
-  *yours*, recorded in your ADR and your `reference.md`.
+  *yours*, recorded in your ADR and your `reference.md`. If the project will
+  deploy, this is also the moment to record the **deployment platform** and
+  **where verification tooling will live** in the `reference.md` slots (and the
+  matching one-liners in the `AGENTS.md` infra block) — optional grounding the
+  work-loop infra preflight reads if present, never a prerequisite.
 
 Hand the foundation forward as the steering every later design conforms to.
 

--- a/packs/core/.apm/skills/work-loop/references/infra-verification.md
+++ b/packs/core/.apm/skills/work-loop/references/infra-verification.md
@@ -69,6 +69,42 @@ artifact. This **refines** P2 and cross-links the plan template's `## Rollout`
 (which owns sequencing); it does **not** re-author the GATES layer sequence
 above.
 
+## PLAN — read recorded coordinates first, then cold oracle discovery
+
+Before enumerating the multi-artifact preflight below and before the
+contract-grounding gate, do one cheap thing first: **check recorded
+coordinates → acquire via oracles**. The adopter may already have written down
+where they deploy and how they verify, in files they own:
+
+- the **`AGENTS.md` "Commands you'll need"** optional infra/verification block —
+  the `<deploy>` / `<smoke / verify-status>` / `<teardown>` / `<seed-test-data>`
+  one-liners; and
+- the **`reference.md`** platform/verification slots — the
+  **managed-runtime / platform target** under *Constraints*, the
+  **framework-/library-level contract** under *Solution strategy → Key
+  technology decisions*, and **where the verification tooling lives** under
+  *Crosscutting → Observability / Testing standards*.
+
+**Every one of these reads is presence-checked — read-if-present, degrade
+honestly if absent.** A repo that recorded nothing runs exactly as it does
+today: absence lowers only the *starting information* the preflight begins from,
+it **never fails the loop**, and it is **not enforced by any CI gate**. There is
+**no new config file** for this — no `grounding.toml`, no schema; the surface is
+the two adopter-owned files above. State which coordinates you found (or
+"none"), the same way `architect-design` states the surface it detected.
+
+**A recorded coordinate seeds acquisition; it never replaces it.** A found
+`<deploy command>` or platform target *seeds* the multi-artifact preflight and
+the contract-grounding gate — it tells you where to start — but the agent still
+derives the **live** contract from the toolchain's oracles
+([`infra-contract-acquisition`](../../infra-contract-acquisition/SKILL.md)) and
+still smokes the **real** deployed system. When a recorded value **contradicts**
+the oracle (the `reference.md` names a runtime the `plan` output disputes, a
+recorded smoke command targets an endpoint the deploy no longer exposes), that
+contradiction is a **surfaced drift signal**, not a fact to trust — exactly the
+AGENTS.md *"When this file is wrong"* posture: flag the drift, don't silently
+work around it.
+
 ## PLAN — the multi-artifact preflight (each its own task-zero)
 
 For infra/deploy the mechanism is rarely one artifact; the preflight enumerates

--- a/packs/core/seeds/AGENTS.md
+++ b/packs/core/seeds/AGENTS.md
@@ -134,6 +134,18 @@ tasks, not most — the work-loop skill covers when it's the right tool.
 <build command>             # produce build artifacts
 ```
 
+<!-- Optional — fill any of these only if this repo deploys to a platform.
+     Each is read-if-present by the work-loop infra preflight; leaving them
+     blank costs nothing. Keep them one-liners; where the tooling lives and
+     what it targets belongs in docs/architecture/reference.md, not here. -->
+
+```bash
+<deploy command>            # deploy to your platform — if any
+<smoke command>             # post-deploy verify-status / end-to-end smoke — if any
+<teardown command>          # tear down a failed or ephemeral deploy — if any
+<seed-test-data command>    # seed test / mock-user data for the smoke probe — if any
+```
+
 ## Code style
 
 We don't list style rules here — the linter does that job better than prose can.


### PR DESCRIPTION
Implements `docs/specs/adopter-grounding-surface/` (Approved) — RFC-0047 Decisions 3 & 4, ADR-0037 D2. Gives an adopter a **low-effort, optional recording surface in files they already own** for their platform and verification coordinates, and teaches the work-loop infra preflight to read those coordinates first before falling back to cold oracle discovery.

## What changed (prose-only, additive)

- **`packs/core/seeds/AGENTS.md`** — "Commands you'll need" gains a short, **optional** infra/verification command block (`<deploy>` / `<smoke / verify-status>` / `<teardown>` / `<seed-test-data>`), each line marked *"if any"* and placeholder-shaped (passes `lint-catalogue-seeds`).
- **`reference.md` arc42 slots** (the `adapt-to-project` asset) — three existing slots sharpened, **no new section**: managed-runtime/platform target under *Constraints*, framework-/library-level contract under *Key technology decisions*, and *where the verification tooling lives* under *Observability / Testing standards*.
- **`work-loop` `references/infra-verification.md`** — a new first preflight step: **check recorded coordinates → acquire via oracles**, read-if-present and degrading honestly to today's cold discovery when absent. Recorded values **seed** acquisition, never replace it; a recorded value contradicting the live oracle is surfaced as a drift signal (the AGENTS.md "when this file is wrong" posture).
- **`adapt-to-project` / `init-project`** — optional, non-mandating elicitation threaded into the existing reference-architecture-harvest Detect step and the Foundation phase (AC7 threaded, not deferred).
- **`docs/product/changelog.md`** — `[Unreleased]` entry.
- Projected to `.agents/` + `.claude/` via `make build-self`; spec → **Shipped** (all 8 ACs checked), plan → **Done** with the two-repo manual-QA walkthrough recorded.

## The load-bearing rail (ADR-0037 D2)

Every new read is **presence-checked**: a repo that fills nothing runs exactly as it does today. Spec **AC4 is an explicit negative criterion** — no read becomes load-bearing, and **no CI gate enforces presence**. **AC6**: no new config file (no `grounding.toml`) — the surface is the two adopter-owned files.

## Verification

- `lint-catalogue-seeds` clean (25 seeds; new block is placeholder-shaped).
- Per-AC grep checks green; `reference.md` section count unchanged (no new section).
- `make build-self` clean; projections byte-identical to sources (stability re-confirmed).
- `lint-spec-status.py` clean for this spec.
- `adversarial-reviewer`: **Clean — ready to commit** (one Concern — unrecorded manual-QA pass — resolved by recording the filled-vs-empty doctrine walkthrough under plan T5).
- `security-reviewer` / `quality-engineer` not warranted: prose doctrine, no security boundary and no code surface.

## Notes

- This spec and `catalogue-seeds-lint` (#399, merged) shared a lint-name dependency; the seed edit satisfies the current `lint-catalogue-seeds` name.