### PR TITLE
docs(guides): surface shaping-a-new-engagement in _shared index; rename root section to Shared

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -21,7 +21,7 @@ The user-facing documentation for the catalogue, organized **by pack**. You inst
 | [`monorepo-extras`](monorepo-extras/) | [home](monorepo-extras/) | Monorepo scaffolding — `new-package` and a package template that ships its own conventions. |
 | [`user-guide-diataxis`](user-guide-diataxis/) | [home](user-guide-diataxis/) | The docs skeleton you're reading right now — Diátaxis quadrants plus `new-guide`. |
 
-## Not tied to one pack
+## Shared
 
 Some guides are about the catalogue itself — installing it, upgrading it, seeing what each agent tool supports — rather than any single pack. They live in [`_shared/`](_shared/):
 

--- a/docs/guides/_shared/README.md
+++ b/docs/guides/_shared/README.md
@@ -21,6 +21,7 @@ Guides about the catalogue itself — installing it, upgrading it, seeing what e
 - [Install routes](explanation/install-routes.md) — the four ways pack content reaches a repo, and where each lands.
 - [The pack catalogue](explanation/pack-catalogue.md) — what a pack is, how the catalogue is composed, and how you build your own.
 - [The file-safety contract](explanation/file-safety-contract.md) — why your edits are never silently overwritten.
+- [Shaping a new engagement](explanation/shaping-a-new-engagement.md) — how a product vision, a product strategy, and an architecture concept co-shape each other at the start of a new engagement.
 
 ---
 


### PR DESCRIPTION
## What

Follow-on cleanup to #400. Two stale guide indexes:

- **`docs/guides/_shared/README.md`** — #400 added `_shared/explanation/shaping-a-new-engagement.md` and linked it from the guides root README, but never listed it in the `_shared` pack index itself, so the guide didn't surface from its own home page. Added it to the Explanation section.
- **`docs/guides/README.md`** — renamed the section heading **"Not tied to one pack" → "Shared"** to match the `_shared/README.md` title ("Shared guides").

## Why

The pack-level READMEs #400 touched (`architect/`, `product-engineering/`) were already correctly updated, but the `_shared` index was missed. These are repo-owned docs (not projected), so the edits stand directly — no `build-self` needed.

## Scope

Docs-only; two lines changed across two files.