### PR TITLE
test(agentbundle): track DEFAULT_ADAPTER in default-fallback resolver tests

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -118,6 +118,19 @@ jobs:
         working-directory: packages/agentbundle
         run: python -m pytest tests/unit/test_version.py
 
+      # adapter resolver (RFC-0011/0012 six-step lookup) + ADR-0004
+      # single-constant rebrand: the default-fallback assertions reference
+      # DEFAULT_ADAPTER so a downstream rebrand that flips the constant stays
+      # green. make build-check runs no pytest, so wire these paths explicitly
+      # or the resolver coverage never gates.
+      - name: pytest adapter resolver (RFC-0011/0012, ADR-0004 rebrand)
+        working-directory: packages/agentbundle
+        run: >-
+          python -m pytest
+          tests/unit/test_resolve_user_scope_target_adapter.py
+          tests/unit/test_resolve_target_adapter_user_config.py
+          tests/unit/test_install_argparse_adapter_flag.py
+
       - name: pytest converters install/uninstall (AC6a)
         working-directory: packages/agentbundle
         run: python -m pytest tests/integration/test_install_converters_user_scope.py

--- a/docs/specs/rebrand-safe-default-adapter-tests/plan.md
+++ b/docs/specs/rebrand-safe-default-adapter-tests/plan.md
@@ -58,12 +58,11 @@ Verification: goal-based.
 
 ## Decisions surfaced
 
-- **The three resolver test files are not in CI's curated path list** (only ~18
-  of 86 `tests/unit/` files gate; see the self-documenting comment in
-  `test_install_argparse_adapter_flag.py`). Pre-existing gap, not introduced
-  here. The change still meets its goal — the downstream playbook runs full
-  `pytest`. Wiring these into `build-check.yml` so the rebrand-safety enforces
-  upstream too is a separate decision, left to the human.
+- **The three resolver test files were not in CI's curated path list** (only ~18
+  of 86 `tests/unit/` files gate). Pre-existing gap, not introduced here.
+  **Resolved in this PR (human go-ahead):** added a `pytest adapter resolver`
+  step to `build-check.yml` running all three files, so the rebrand-safety now
+  enforces upstream too.
 
 ## Changelog
 

--- a/docs/specs/rebrand-safe-default-adapter-tests/plan.md
+++ b/docs/specs/rebrand-safe-default-adapter-tests/plan.md
@@ -1,0 +1,71 @@
+# Plan: rebrand-safe-default-adapter-tests
+
+Mode: light. Single logical task (no inter-task dependencies); verification is
+goal-based (run the suite) plus one manual rebrand-property check.
+
+## Declined-pattern register
+
+- **Tempted to parametrize the default-fallback tests over the full shipped
+  adapter set** — declining: the value-tracking coverage (resolved adapter
+  follows a flipped `DEFAULT_ADAPTER`) already exists via the in-file monkeypatch
+  tests (`test_greenfield_monkeypatch_default_to_kiro`,
+  `test_repo_scope_legacy_heuristic_honors_monkey_patched_default`); adding more
+  would re-test one behaviour with more values for no marginal coverage.
+- **Tempted to move the rebrand assertions into per-adapter files "so we can
+  take them out" downstream** — declining: constant-ref makes them pass under a
+  rebrand unchanged, so there is nothing to take out; stripping would only lose
+  coverage in the fork.
+- **Tempted to add a module-level `DEFAULT_ADAPTER` and reuse it in the
+  monkeypatch tests** — declining: those tests deliberately patch
+  `agentbundle.scope.DEFAULT_ADAPTER` and read it via their own local binding;
+  the module-level import is consumed only by the non-patching base tests.
+
+## Tasks
+
+### T1 — constant-ref the genuine default-fallback assertions
+
+Verification: goal-based (`pytest` on the file).
+
+- Add module-level `from agentbundle.scope import DEFAULT_ADAPTER`.
+- Replace the literal in the seven default-fallback assertions (the resolver
+  returned the default): `test_greenfield_returns_default_when_default_in_pack_list`,
+  `test_legacy_v05_pack_with_agents_returns_default_adapter`,
+  `test_legacy_v05_pack_without_agents_returns_claude_code`,
+  `test_v06_pack_omitting_allowed_adapters_uses_legacy_heuristic`,
+  `test_repo_scope_greenfield_returns_default_adapter`,
+  `test_repo_scope_legacy_heuristic_for_pre_v07_pack` (two asserts).
+- Drop the now-redundant `# DEFAULT_ADAPTER` trailing comment where present.
+- **Bundled fix:** rename `test_legacy_v05_pack_without_agents_returns_claude_code`
+  → `test_legacy_v05_pack_without_agents_returns_default_adapter` to match its
+  `with_agents` sibling and the constant-ref'd assertion (same-file, same-concern,
+  mechanical).
+
+### T2 — label the upstream-default pin
+
+Verification: goal-based.
+
+- In `test_default_adapter_value_unchanged`, add a one-line note that this is the
+  single assertion a downstream rebrand (ADR-0004) flips. Keep the literal.
+
+### T3 — gates + rebrand-property check
+
+- Run the unit file + the broader unit suite (green). ✓
+- Temporarily set `scope.DEFAULT_ADAPTER = "kiro-ide"`, run the file: AC1
+  assertions stay green, only the AC3 pin fails. Revert. ✓ (caught a real bug —
+  the two greenfield-in-list lists now build from `DEFAULT_ADAPTER`.)
+- **No changelog entry** — test-only, no user-visible behaviour change; the
+  changelog is for user-visible changes and there is no CI changelog gate.
+
+## Decisions surfaced
+
+- **The three resolver test files are not in CI's curated path list** (only ~18
+  of 86 `tests/unit/` files gate; see the self-documenting comment in
+  `test_install_argparse_adapter_flag.py`). Pre-existing gap, not introduced
+  here. The change still meets its goal — the downstream playbook runs full
+  `pytest`. Wiring these into `build-check.yml` so the rebrand-safety enforces
+  upstream too is a separate decision, left to the human.
+
+## Changelog
+
+- 2026-06-25 — Plan authored (light mode); T1 corrected mid-EXECUTE after the
+  rebrand-property check failed two greenfield-in-list tests.

--- a/docs/specs/rebrand-safe-default-adapter-tests/spec.md
+++ b/docs/specs/rebrand-safe-default-adapter-tests/spec.md
@@ -1,0 +1,65 @@
+# Spec: rebrand-safe-default-adapter-tests
+
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** ADR-0004 (single-constant enterprise rebrand)
+- **Brief:** none
+- **Contract:** none
+- **Shape:** service
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+`Mode: light (no risk trigger fired)` — test-only change, no production code, no
+structural or public-interface change.
+
+## Objective
+
+ADR-0004 makes `scope.DEFAULT_ADAPTER` the single-constant enterprise-rebrand
+lever: flip the constant and both install scopes follow. The resolver honours it
+and is already proven rebrand-safe by monkeypatch tests. But a handful of
+default-*fallback* unit assertions in
+`test_resolve_user_scope_target_adapter.py` hardcode the literal `"claude-code"`
+where they mean "the resolver returned `DEFAULT_ADAPTER`". A downstream rebrand
+that flips the constant breaks those assertions even though the behaviour they
+test is correct. The user here is the maintainer of a rebranded/downstream
+distribution (and anyone reading the upstream tests): after this change, the
+genuine default-fallback assertions track `DEFAULT_ADAPTER` instead of a magic
+string, so the rebrand is zero-churn for them and the one assertion that *does*
+pin the upstream default is unambiguous.
+
+## Acceptance Criteria
+
+- [x] **AC1** — Every assertion in `test_resolve_user_scope_target_adapter.py`
+  that checks the resolver fell back to `DEFAULT_ADAPTER` (greenfield-default-in-list
+  and legacy-heuristic paths, user and repo scope) references the
+  `DEFAULT_ADAPTER` constant rather than the literal `"claude-code"`.
+- [x] **AC2** — Assertions whose literal value is genuinely the contract are
+  left unchanged: probe results (a specific `~/.<ide>/` was populated), explicit
+  `--adapter` round-trips, and fall-back-to-`allowed_adapters[0]` cases (where
+  `"claude-code"` is the first allowed adapter, not the default).
+- [x] **AC3** — The upstream-default pin `test_default_adapter_value_unchanged`
+  keeps its literal `assert DEFAULT_ADAPTER == "claude-code"` and carries a
+  one-line note that this is the single assertion a downstream rebrand flips.
+- [x] **AC4** — Flipping `scope.DEFAULT_ADAPTER` to a non-claude-code value
+  leaves every AC1 assertion green; only the AC3 pin fails. Verified by a
+  temporary local flip, then reverted.
+- [x] **AC5** — The agentbundle unit suite is green
+  (`pytest packages/agentbundle/tests/unit/test_resolve_user_scope_target_adapter.py`
+  and the broader unit run).
+
+## Notes
+
+The sibling files `test_resolve_target_adapter_user_config.py` and
+`test_install_argparse_adapter_flag.py` were inspected and need no change: the
+former's only default-fallback assertion already references `DEFAULT_ADAPTER`
+and its other `"claude-code"` literals are probe/explicit results; the latter's
+are explicit `--adapter` round-trips. No new parametrized rebrand test is added
+— the value-tracking coverage (the resolved adapter actually follows a flipped
+`DEFAULT_ADAPTER`) already exists via the in-file monkeypatch tests
+(`test_greenfield_monkeypatch_default_to_kiro`,
+`test_repo_scope_legacy_heuristic_honors_monkey_patched_default`). (The
+parametrized `test_repo_scope_adapter_flag_admits_all_shipped_adapters` pins
+explicit `--adapter` admissibility, not default-following, so it is not part of
+this coverage claim.)

--- a/packages/agentbundle/tests/unit/test_resolve_user_scope_target_adapter.py
+++ b/packages/agentbundle/tests/unit/test_resolve_user_scope_target_adapter.py
@@ -28,6 +28,7 @@ from agentbundle.commands.install import (
     _AdapterResolutionRefused,
     _resolve_target_adapter,
 )
+from agentbundle.scope import DEFAULT_ADAPTER
 
 
 def _resolve_user_scope_target_adapter(*args, **kwargs):
@@ -145,13 +146,16 @@ def test_first_match_wins_declared_order(tmp_path, fake_home):
 
 def test_greenfield_returns_default_when_default_in_pack_list(tmp_path, fake_home):
     pack = _make_pack(tmp_path)
+    # The list must contain DEFAULT_ADAPTER for this scenario; built from the
+    # constant so a downstream rebrand keeps the default in-list (else the
+    # resolver correctly falls back to allowed_adapters[0]).
     result = _resolve_user_scope_target_adapter(
         pack,
         adapter=None,
-        allowed_adapters=["claude-code", "kiro"],
+        allowed_adapters=[DEFAULT_ADAPTER, "kiro"],
         contract_version="0.6",
     )
-    assert result == "claude-code"  # DEFAULT_ADAPTER
+    assert result == DEFAULT_ADAPTER
 
 
 def test_greenfield_monkeypatch_default_to_kiro(tmp_path, fake_home, monkeypatch):
@@ -332,10 +336,10 @@ def test_legacy_v05_pack_with_agents_returns_default_adapter(tmp_path, fake_home
         allowed_adapters=None,
         contract_version="0.5",
     )
-    assert result == "claude-code"
+    assert result == DEFAULT_ADAPTER
 
 
-def test_legacy_v05_pack_without_agents_returns_claude_code(tmp_path, fake_home):
+def test_legacy_v05_pack_without_agents_returns_default_adapter(tmp_path, fake_home):
     pack = _make_pack(tmp_path, with_agents=False)
     result = _resolve_user_scope_target_adapter(
         pack,
@@ -343,7 +347,7 @@ def test_legacy_v05_pack_without_agents_returns_claude_code(tmp_path, fake_home)
         allowed_adapters=None,
         contract_version="0.5",
     )
-    assert result == "claude-code"
+    assert result == DEFAULT_ADAPTER
 
 
 def test_v06_pack_omitting_allowed_adapters_uses_legacy_heuristic(tmp_path, fake_home):
@@ -357,7 +361,7 @@ def test_v06_pack_omitting_allowed_adapters_uses_legacy_heuristic(tmp_path, fake
         allowed_adapters=None,
         contract_version="0.6",
     )
-    assert result == "claude-code"
+    assert result == DEFAULT_ADAPTER
 
 
 def test_stray_allowed_adapters_on_v05_pack_uses_legacy(tmp_path, fake_home):
@@ -527,14 +531,15 @@ def test_repo_scope_greenfield_returns_default_adapter(tmp_path, fake_home):
     """Spec AC9 step 4 (repo branch) — no --adapter, no probe; returns
     DEFAULT_ADAPTER if in allowed_adapters."""
     pack = _make_pack_v07(tmp_path)
+    # List built from the constant so the default stays in-list under a rebrand.
     result = _resolve_target_adapter(
         pack,
         scope="repo",
         adapter=None,
-        allowed_adapters=["claude-code", "kiro"],
+        allowed_adapters=[DEFAULT_ADAPTER, "kiro"],
         contract_version="0.7",
     )
-    assert result == "claude-code"
+    assert result == DEFAULT_ADAPTER
 
 
 def test_repo_scope_greenfield_falls_back_to_first_when_default_absent(
@@ -567,7 +572,7 @@ def test_repo_scope_legacy_heuristic_for_pre_v07_pack(tmp_path, fake_home):
         allowed_adapters=None,
         contract_version="0.6",
     )
-    assert result == "claude-code"
+    assert result == DEFAULT_ADAPTER
 
     pack_no_agents = _make_pack_v07(tmp_path / "alt", with_agents=False)
     result_no_agents = _resolve_target_adapter(
@@ -577,7 +582,7 @@ def test_repo_scope_legacy_heuristic_for_pre_v07_pack(tmp_path, fake_home):
         allowed_adapters=None,
         contract_version="0.6",
     )
-    assert result_no_agents == "claude-code"
+    assert result_no_agents == DEFAULT_ADAPTER
 
 
 def test_repo_scope_legacy_heuristic_honors_monkey_patched_default(
@@ -642,7 +647,14 @@ def test_repo_scope_state_hint_short_circuit(tmp_path, fake_home):
 
 
 def test_default_adapter_value_unchanged():
-    """The renamed constant carries the same value (claude-code)."""
+    """The renamed constant carries the same value (claude-code).
+
+    This is the single assertion an ADR-0004 enterprise-rebrand flips: a
+    downstream distribution that sets ``DEFAULT_ADAPTER`` to its own default
+    (e.g. ``kiro-ide``) updates this literal and nothing else here — every
+    other default-fallback assertion in this module references the constant and
+    stays green.
+    """
     from agentbundle.scope import DEFAULT_ADAPTER
 
     assert DEFAULT_ADAPTER == "claude-code"


### PR DESCRIPTION
## What & why

ADR-0004 makes `scope.DEFAULT_ADAPTER` the single-constant enterprise-rebrand lever: flip the constant and both install scopes follow. The resolver honours it and is already proven rebrand-safe by monkeypatch tests. But several default-*fallback* assertions in `test_resolve_user_scope_target_adapter.py` hardcoded the literal `"claude-code"` where they mean "the resolver returned `DEFAULT_ADAPTER`". A downstream rebrand that flips the constant broke those assertions even though the behaviour they test is correct.

This references the constant instead, so the rebrand is zero-churn for them, and removes the magic strings (a test-quality improvement on its own).

## What changed

- Module-level `from agentbundle.scope import DEFAULT_ADAPTER`.
- 7 genuine default-fallback assertions → `== DEFAULT_ADAPTER`.
- The two greenfield-default-in-list tests build `allowed_adapters=[DEFAULT_ADAPTER, "kiro"]` so the default stays in-list under a rebrand (else the resolver correctly falls back to `allowed_adapters[0]`).
- The upstream-default pin `test_default_adapter_value_unchanged` keeps its literal and now documents that it is the single assertion a rebrand flips.
- Probe, explicit-`--adapter`, and fall-back-to-first literals left unchanged — their value is the contract.

Sibling files `test_resolve_target_adapter_user_config.py` and `test_install_argparse_adapter_flag.py` were inspected and need no change.

Lean spec/plan under `docs/specs/rebrand-safe-default-adapter-tests/` (work-loop light mode).

## How verified

- Full agentbundle unit suite green; ruff clean; `lint-spec-status` clean.
- **Rebrand-property check**: temporarily flipped `DEFAULT_ADAPTER` → `"kiro-ide"` — only the upstream-default pin failed, every other assertion stayed green; restored. (This caught a real bug in the first cut — constant-ref alone wasn't enough for the in-list tests.)
- adversarial-reviewer: one doc-accuracy Concern, fixed.

## Anything contentious?

No behaviour change, test-only. No changelog entry (not user-visible; no CI changelog gate).

**Bundled fixes:** renamed `test_legacy_v05_pack_without_agents_returns_claude_code` → `..._returns_default_adapter` to match its `with_agents` sibling.

**Deferred:** these three resolver test files are not in CI's curated path list (~18/86 `tests/unit/` files gate — a pre-existing gap, not introduced here). Wiring them into `build-check.yml` so the rebrand-safety enforces upstream is left as a separate decision.
