### PR TITLE
docs(rfc): drop security/compliance from RFC-0053's optional lens-skill set

### DIFF
--- a/docs/rfc/0053-the-coordinator-contract.md
+++ b/docs/rfc/0053-the-coordinator-contract.md
@@ -122,9 +122,12 @@ and **writes the contract** the prototype validated (Decisions 2–5).
 - *Building or forking the harness.* `omnigent` exists and is the reference runtime; we
   ship the contract it (or a successor) enforces, not the harness (RFC-0048 non-goal;
   RFC-0041 P4 harness-neutrality).
-- *The `experience`, `architect`, `research`, and security/compliance **lens skills
-  themselves.*** Those are RFC-0050 (child-1) and reused packs; this RFC wires them as
-  *optional detect-and-degrade lenses*, it does not author them.
+- *The `experience`, `architect`, and `research` **lens skills themselves.*** Those are
+  RFC-0050 (child-1) and reused packs; this RFC wires them as *optional detect-and-degrade
+  lenses*, it does not author them. (The security/compliance and reliability floors are **not**
+  in this optional set — they are carried by `product-engineering`'s **required** discovery
+  reviewers (`discovery-threat-reviewer` / `discovery-reliability-reviewer`, required at G2 per
+  RFC-0048's roster table) and degrade only in *depth*, never to nothing.)
 - *The traceability lint.* Child-4 (`docs/specs/traceability-lint/`) builds the lint; this
   RFC defines the **traceability slot** the lint reads and the **cascade-invalidation**
   transition that walks its edges. The spike's `check_sidecar.py` is a *demonstrator*, not


### PR DESCRIPTION
## What

Closes the last R1 contradiction. RFC-0053's non-goals bullet (`0053-...md:125`) still grouped the **security/compliance lens** with the optional detect-and-degrade lenses, contradicting RFC-0048's authoritative roster table — where the security/compliance and reliability floors are **required at G2 reconcile**.

## Change

Narrow the optional lens-skill set to **experience / architect / research** (the ones genuinely authored elsewhere and detect-and-degraded). Add a clarifying clause that the security/compliance and reliability floors are **not** in that set — they are carried by `product-engineering`'s required discovery reviewers (`discovery-threat-reviewer` / `discovery-reliability-reviewer`) and degrade only in *depth*, never to nothing.

Docs-only; one line. Follows #421.

With this, R1 is closed.