### PR TITLE
docs(rfc): reframe RFC-0048 DRIFT-I body as historical to close R2

### DIFF
--- a/docs/rfc/0048-autonomous-product-team-operating-model.md
+++ b/docs/rfc/0048-autonomous-product-team-operating-model.md
@@ -890,8 +890,9 @@ Cross-referenced as **DRIFT-x** in note 10.
   `loop-cohort`, or name a thin adapter). Assigned to that spec; flagged in the Follow-on list.
 - **DRIFT-I — the carried sidecar *schema reference* (in `discovery-loop`, user scope, not
   `core`) is owed as the first acceptance criterion of RFC-0053's implementing spec; its three
-  consumers sequence behind it.** D7 + RFC-0053 D2
-  decide the schema is single-sourced in `core`, but it exists only as **prose field-lists** —
+  consumers sequence behind it.** Earlier D7 / RFC-0053 D2 wording had treated the schema as
+  single-sourced in `core` (since revised — see the dated entry below), but it exists only as
+  **prose field-lists** —
   no implementing spec lands the reference file, while `discovery-loop`, the release loop
   ([release-loop spec](../specs/release-loop/spec.md) Assumptions name the dependency), and the
   traceability lint all consume it. **Resolution:** "land the carried sidecar-schema contract"


### PR DESCRIPTION
## What

Closes the last remaining piece of review finding **R2 — Sidecar Schema Home / Dependency Direction**.

After #424, the DRIFT-I *heading* and the dated **Revised 2026-06-26 (scope-decoupling)** addendum already carried the correct rule (schema carried in `discovery-loop`, not `core`). But the body's opening clause still asserted in present tense:

> D7 + RFC-0053 D2 **decide the schema is single-sourced in `core`**

That left a standing contradiction with the now-aligned RFC-0053 / RFC-0049 / release-loop / traceability-lint set.

## Fix

Reworded that one clause as historical context pointing to the revision directly below it:

> Earlier D7 / RFC-0053 D2 wording had **treated** the schema as single-sourced in `core` (since revised — see the dated entry below) …

The companion line at `:812` was already in the inline revise-in-place pattern (original claim immediately followed by "the schema is **no longer** single-sourced in `core`"), so it needed no change.

## Notes
- Single-file, single-clause doc fix; no shipped skill/agent behavior — no changelog entry.
- With this, R2 is fully closed.