### PR TITLE
feat(new-rfc): document RFC correction convention (Errata / Amendments)

### DIFF
--- a/.agents/skills/new-rfc/SKILL.md
+++ b/.agents/skills/new-rfc/SKILL.md
@@ -265,6 +265,71 @@ concrete next steps — usually:
 
 The RFC itself is then "done" and stays as historical record.
 
+## Recording corrections (Errata / Amendments)
+
+An RFC's body freezes, but the proposal can still need a correction after it
+publishes — a spec finds a gap, a later RFC reframes a decision. Record the
+correction *inside the RFC*, in one of two sections chosen by the RFC's
+lifecycle class (the Document-lifecycle table in
+`docs/CONVENTIONS.md` § Document lifecycle — Frozen vs. Governance), **never**
+by editing the frozen body:
+
+- **`## Errata`** — for a **Frozen** RFC (Accepted or Rejected). The body is
+  immutable; corrections are appended here, Approver-signed. This is the common
+  case — most corrections are found after acceptance.
+- **`## Amendments`** — for an **in-flight** RFC (Open / Governance class) that
+  needs to track reconciliations *while still being worked*, without rewriting
+  its body. The rare case.
+
+The heading itself signals whether the text beneath it is immutable, so the two
+never coexist in one RFC: an Open RFC carrying `## Amendments` renames the
+section to `## Errata` if and when it is Accepted (a status-driven edit the
+Frozen rule already permits).
+
+### The two-layer structure — optional, threshold-gated
+
+A single one-line erratum stays a plain dated bullet. Split the section into two
+layers **only once it crosses the threshold — more than one entry, *or* any
+entry supersedes another** — at which point a reader can no longer recover the
+present rules without diffing the whole log by hand:
+
+```
+## Errata            (or ## Amendments)
+
+### Current state
+<an authoritative summary — usually a table — of the corrections in force:
+ "read this, not the log", for the present contract>
+
+### History / audit trail
+<dated entries explaining how each correction was reached>
+```
+
+- The **current-state** layer is the authoritative present contract. **Where it
+  disagrees with a historical entry, the current-state layer wins** — say so in
+  the section so a reader knows which layer to trust.
+- The layer *names* above are illustrative; the contract is the two-layer split
+  (authoritative current state over a dated audit trail), not the exact heading
+  wording. RFC-0048 / PR #430 is the worked precedent this generalizes — it uses
+  "Current reconciliation state" over an "Amendment history / audit trail."
+
+### Append-only and supersession
+
+- Correction sections are **append-only**. A later entry supersedes an earlier
+  one simply by being later; the **newest entry plus the current-state layer**
+  carry present truth. Earlier entries are never deleted — they *are* the audit
+  trail.
+- **No per-entry ritual is required.** On a Frozen RFC's `## Errata`, prior
+  entries cannot be reworded anyway (immutable body). On an in-flight
+  `## Amendments`, an author *may* optionally reword a stale entry in place,
+  tagging it `*(Superseded: …)*` — permitted, not required, and **only for
+  in-flight Amendments** (a Frozen RFC's entries can't be touched).
+- **Whole-RFC replacement is out of scope.** When an entire RFC — not one
+  correction within it — is superseded by a later one, record that as an
+  **Errata entry naming the superseding RFC** (e.g. RFC-0012 carries an erratum
+  recording that its Alternative #7 was superseded by RFC-0052). This convention
+  governs corrections *within* an RFC; it neither defines nor changes the
+  whole-RFC-supersession mechanism.
+
 ## Anti-patterns to refuse
 
 - Writing into the RFC body before the checkpoint clears → see step 4.

--- a/.agents/skills/new-rfc/assets/rfc.md
+++ b/.agents/skills/new-rfc/assets/rfc.md
@@ -153,3 +153,47 @@ Filled in when the RFC is accepted. The bridge from "we agreed" to "we did it".
 - Spec: docs/specs/<feature>/
 - Convention change: docs/CONVENTIONS.md, section X
 -->
+
+<!--
+CORRECTIONS — DELETE THIS WHOLE BLOCK unless this RFC is accumulating
+post-publication corrections. Do NOT ship it as an empty section on a fresh
+RFC. See the new-rfc skill, "Recording corrections (Errata / Amendments)", for
+the full rules; the shape below is the optional, threshold-gated scaffold.
+
+Pick the heading by lifecycle class: `## Errata` for a Frozen RFC
+(Accepted/Rejected), `## Amendments` for an in-flight Open one. (Rename
+`## Amendments` → `## Errata` if this RFC is later Accepted.)
+
+A single one-line correction stays a plain dated bullet under the heading — no
+table — like this:
+
+## Errata        (or ## Amendments)
+
+- **YYYY-MM-DD — <short title>.** <what was corrected and why>.
+
+Split into the two layers below ONLY once the section crosses the threshold:
+more than one entry, or any entry supersedes another. Heading wording is your
+call; the two-layer split (authoritative current state over a dated audit trail,
+current state wins on disagreement) is the contract.
+
+## Errata        (or ## Amendments)
+
+### Current state
+
+The corrections in force today — read these, not the log, for the present
+contract. Where this layer disagrees with a historical entry below, this layer
+wins.
+
+| Area | Current rule | Owner / note |
+| --- | --- | --- |
+| <area> | <the rule in force> | <owner / blocker> |
+
+### History / audit trail
+
+Dated, append-only entries explaining how each correction was reached. Never
+delete an entry — it is the audit trail. (On an in-flight `## Amendments` you
+MAY reword a stale entry in place, tagging it `*(Superseded: …)*`; on a Frozen
+`## Errata` the entries are immutable.)
+
+- **YYYY-MM-DD — <short title>.** <what was corrected and why>.
+-->

--- a/.claude/skills/new-rfc/SKILL.md
+++ b/.claude/skills/new-rfc/SKILL.md
@@ -265,6 +265,71 @@ concrete next steps — usually:
 
 The RFC itself is then "done" and stays as historical record.
 
+## Recording corrections (Errata / Amendments)
+
+An RFC's body freezes, but the proposal can still need a correction after it
+publishes — a spec finds a gap, a later RFC reframes a decision. Record the
+correction *inside the RFC*, in one of two sections chosen by the RFC's
+lifecycle class (the Document-lifecycle table in
+`docs/CONVENTIONS.md` § Document lifecycle — Frozen vs. Governance), **never**
+by editing the frozen body:
+
+- **`## Errata`** — for a **Frozen** RFC (Accepted or Rejected). The body is
+  immutable; corrections are appended here, Approver-signed. This is the common
+  case — most corrections are found after acceptance.
+- **`## Amendments`** — for an **in-flight** RFC (Open / Governance class) that
+  needs to track reconciliations *while still being worked*, without rewriting
+  its body. The rare case.
+
+The heading itself signals whether the text beneath it is immutable, so the two
+never coexist in one RFC: an Open RFC carrying `## Amendments` renames the
+section to `## Errata` if and when it is Accepted (a status-driven edit the
+Frozen rule already permits).
+
+### The two-layer structure — optional, threshold-gated
+
+A single one-line erratum stays a plain dated bullet. Split the section into two
+layers **only once it crosses the threshold — more than one entry, *or* any
+entry supersedes another** — at which point a reader can no longer recover the
+present rules without diffing the whole log by hand:
+
+```
+## Errata            (or ## Amendments)
+
+### Current state
+<an authoritative summary — usually a table — of the corrections in force:
+ "read this, not the log", for the present contract>
+
+### History / audit trail
+<dated entries explaining how each correction was reached>
+```
+
+- The **current-state** layer is the authoritative present contract. **Where it
+  disagrees with a historical entry, the current-state layer wins** — say so in
+  the section so a reader knows which layer to trust.
+- The layer *names* above are illustrative; the contract is the two-layer split
+  (authoritative current state over a dated audit trail), not the exact heading
+  wording. RFC-0048 / PR #430 is the worked precedent this generalizes — it uses
+  "Current reconciliation state" over an "Amendment history / audit trail."
+
+### Append-only and supersession
+
+- Correction sections are **append-only**. A later entry supersedes an earlier
+  one simply by being later; the **newest entry plus the current-state layer**
+  carry present truth. Earlier entries are never deleted — they *are* the audit
+  trail.
+- **No per-entry ritual is required.** On a Frozen RFC's `## Errata`, prior
+  entries cannot be reworded anyway (immutable body). On an in-flight
+  `## Amendments`, an author *may* optionally reword a stale entry in place,
+  tagging it `*(Superseded: …)*` — permitted, not required, and **only for
+  in-flight Amendments** (a Frozen RFC's entries can't be touched).
+- **Whole-RFC replacement is out of scope.** When an entire RFC — not one
+  correction within it — is superseded by a later one, record that as an
+  **Errata entry naming the superseding RFC** (e.g. RFC-0012 carries an erratum
+  recording that its Alternative #7 was superseded by RFC-0052). This convention
+  governs corrections *within* an RFC; it neither defines nor changes the
+  whole-RFC-supersession mechanism.
+
 ## Anti-patterns to refuse
 
 - Writing into the RFC body before the checkpoint clears → see step 4.

--- a/.claude/skills/new-rfc/assets/rfc.md
+++ b/.claude/skills/new-rfc/assets/rfc.md
@@ -153,3 +153,47 @@ Filled in when the RFC is accepted. The bridge from "we agreed" to "we did it".
 - Spec: docs/specs/<feature>/
 - Convention change: docs/CONVENTIONS.md, section X
 -->
+
+<!--
+CORRECTIONS — DELETE THIS WHOLE BLOCK unless this RFC is accumulating
+post-publication corrections. Do NOT ship it as an empty section on a fresh
+RFC. See the new-rfc skill, "Recording corrections (Errata / Amendments)", for
+the full rules; the shape below is the optional, threshold-gated scaffold.
+
+Pick the heading by lifecycle class: `## Errata` for a Frozen RFC
+(Accepted/Rejected), `## Amendments` for an in-flight Open one. (Rename
+`## Amendments` → `## Errata` if this RFC is later Accepted.)
+
+A single one-line correction stays a plain dated bullet under the heading — no
+table — like this:
+
+## Errata        (or ## Amendments)
+
+- **YYYY-MM-DD — <short title>.** <what was corrected and why>.
+
+Split into the two layers below ONLY once the section crosses the threshold:
+more than one entry, or any entry supersedes another. Heading wording is your
+call; the two-layer split (authoritative current state over a dated audit trail,
+current state wins on disagreement) is the contract.
+
+## Errata        (or ## Amendments)
+
+### Current state
+
+The corrections in force today — read these, not the log, for the present
+contract. Where this layer disagrees with a historical entry below, this layer
+wins.
+
+| Area | Current rule | Owner / note |
+| --- | --- | --- |
+| <area> | <the rule in force> | <owner / blocker> |
+
+### History / audit trail
+
+Dated, append-only entries explaining how each correction was reached. Never
+delete an entry — it is the audit trail. (On an in-flight `## Amendments` you
+MAY reword a stale entry in place, tagging it `*(Superseded: …)*`; on a Frozen
+`## Errata` the entries are immutable.)
+
+- **YYYY-MM-DD — <short title>.** <what was corrected and why>.
+-->

--- a/docs/guides/governance-extras/how-to/new-rfc.md
+++ b/docs/guides/governance-extras/how-to/new-rfc.md
@@ -135,6 +135,8 @@ An accepted RFC is rarely the last artifact. It points at concrete follow-on wor
 
 The RFC's job is done once the follow-on artifacts exist. It stays as history.
 
+A published RFC can still need a correction later — a spec finds a gap, a later RFC reframes a decision. You record it *inside* the RFC (never by editing the frozen body), under an `## Errata` section for a Frozen RFC or `## Amendments` for an in-flight one, following the `new-rfc` skill's [Recording corrections (Errata / Amendments)](../../../../packs/governance-extras/.apm/skills/new-rfc/SKILL.md) convention — append-only, with an optional two-layer current-state-over-audit-trail structure once corrections accumulate. The skill is the canonical home for the rules; this guide just points at it.
+
 ## Pitfalls
 
 > **Writing body content before the research phase clears.** The skill refuses to do this; if you find yourself filling sections by hand to "save time", you've skipped the part of the workflow that makes the RFC worth reading. Let the research phase emit, sign off, *then* let the body fill.

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -19,6 +19,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The `new-rfc` skill now documents a convention for recording post-publication
+  RFC corrections (governance-extras 0.4.0, implementing RFC-0055).** A published
+  RFC's body is frozen, but it can still need a correction — a spec finds a gap, a
+  later RFC reframes a decision. The skill now names two lifecycle-keyed sections
+  for recording one *inside* the RFC: `## Errata` for a Frozen RFC
+  (Accepted/Rejected) and `## Amendments` for an in-flight Open one. Corrections
+  are append-only, and once a section accumulates (more than one entry, or any
+  entry supersedes another) it splits into an optional two-layer structure — an
+  authoritative *current state* layer over a dated *audit trail*, where the
+  current-state layer wins on disagreement. The bundled `assets/rfc.md` template
+  carries the same shape as a clearly-conditional commented scaffold, so it travels
+  into every RFC an adopter drafts without being filled into empty sections.
+  Forward-only — existing correction sections are untouched.
 - **The `new-rfc` skill now sizes each RFC to its two humans — the author and
   the reviewer (governance-extras 0.4.0, implementing RFC-0054).** Four changes,
   the deferred half of the human-consumption work whose RFC-0014-clean half

--- a/docs/specs/rfc-correction-convention/plan.md
+++ b/docs/specs/rfc-correction-convention/plan.md
@@ -1,7 +1,7 @@
 # Plan: RFC correction convention (Errata / Amendments)
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Drafting <!-- Drafting | Executing | Done -->
+- **Status:** Done <!-- Drafting | Executing | Done -->
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
 > document is allowed to change as you learn. When it changes substantially

--- a/docs/specs/rfc-correction-convention/spec.md
+++ b/docs/specs/rfc-correction-convention/spec.md
@@ -1,6 +1,6 @@
 # Spec: RFC correction convention (Errata / Amendments)
 
-- **Status:** Draft <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** RFC-0055
@@ -86,35 +86,35 @@ which is **manual QA**:
 
 ## Acceptance Criteria
 
-- [ ] `new-rfc` `SKILL.md` documents recording RFC corrections under two
+- [x] `new-rfc` `SKILL.md` documents recording RFC corrections under two
   lifecycle-keyed sections — **Errata** for a Frozen RFC (Accepted/Rejected),
   **Amendments** for an in-flight Open RFC — selected by the RFC's
   Document-lifecycle class (RFC-0055 D1).
-- [ ] `SKILL.md` documents the optional, threshold-gated two-layer structure — an
+- [x] `SKILL.md` documents the optional, threshold-gated two-layer structure — an
   authoritative *Current state* layer over a *History / audit trail* (these layer
   names are illustrative; the contract is the two-layer split, not the exact
   heading text) — names the threshold (more than one entry, **or** any entry
   supersedes another), and states that the current-state layer wins on
   disagreement (RFC-0055 D2).
-- [ ] `SKILL.md` documents the append-only rule with no per-entry ritual, the
+- [x] `SKILL.md` documents the append-only rule with no per-entry ritual, the
   optional in-place reword (tagged `*(Superseded: …)*`) **for in-flight Amendments
   only**, and that whole-RFC replacement is out of scope — recorded as an Errata
   entry naming the superseding RFC (RFC-0055 D3).
-- [ ] `assets/rfc.md` carries an optional, clearly-conditional **commented**
+- [x] `assets/rfc.md` carries an optional, clearly-conditional **commented**
   scaffold for the correction section, headed by a delete-unless-accumulating
   instruction, whose two-layer shape matches `SKILL.md` — heading wording is the
   author's call; the structure is the contract (RFC-0055 D2 shape, in the D4
   template home).
-- [ ] No `docs/CONVENTIONS.md` change is made (RFC-0055 D4) and no file under
+- [x] No `docs/CONVENTIONS.md` change is made (RFC-0055 D4) and no file under
   `docs/rfc/*.md` is modified (RFC-0055 D5, forward-only) — verifiable from the diff.
-- [ ] The repo-only guide `docs/guides/governance-extras/how-to/new-rfc.md` gains
+- [x] The repo-only guide `docs/guides/governance-extras/how-to/new-rfc.md` gains
   a short note pointing at the convention; it does not restate the convention and
   does not ship with the pack.
-- [ ] `docs/product/changelog.md` `[Unreleased]` records the skill-behavior change,
+- [x] `docs/product/changelog.md` `[Unreleased]` records the skill-behavior change,
   naming RFC-0055 and the current unreleased `governance-extras` version (0.4.0 today).
-- [ ] `make build-self` projects the source edits to `.claude/skills/new-rfc/` with
+- [x] `make build-self` projects the source edits to `.claude/skills/new-rfc/` with
   a clean drift gate; `lint-packs` and `tools/lint-agent-artifacts.py` pass.
-- [ ] Dogfood walk (manual QA): applying the documented convention to RFC-0048 /
+- [x] Dogfood walk (manual QA): applying the documented convention to RFC-0048 /
   PR #430 reproduces the same two-layer *structure* it already carries — a
   current-state layer (authoritative, wins on disagreement) over a dated
   append-only audit trail — even though RFC-0048 predates the convention and uses

--- a/packs/governance-extras/.apm/skills/new-rfc/SKILL.md
+++ b/packs/governance-extras/.apm/skills/new-rfc/SKILL.md
@@ -265,6 +265,71 @@ concrete next steps — usually:
 
 The RFC itself is then "done" and stays as historical record.
 
+## Recording corrections (Errata / Amendments)
+
+An RFC's body freezes, but the proposal can still need a correction after it
+publishes — a spec finds a gap, a later RFC reframes a decision. Record the
+correction *inside the RFC*, in one of two sections chosen by the RFC's
+lifecycle class (the Document-lifecycle table in
+`docs/CONVENTIONS.md` § Document lifecycle — Frozen vs. Governance), **never**
+by editing the frozen body:
+
+- **`## Errata`** — for a **Frozen** RFC (Accepted or Rejected). The body is
+  immutable; corrections are appended here, Approver-signed. This is the common
+  case — most corrections are found after acceptance.
+- **`## Amendments`** — for an **in-flight** RFC (Open / Governance class) that
+  needs to track reconciliations *while still being worked*, without rewriting
+  its body. The rare case.
+
+The heading itself signals whether the text beneath it is immutable, so the two
+never coexist in one RFC: an Open RFC carrying `## Amendments` renames the
+section to `## Errata` if and when it is Accepted (a status-driven edit the
+Frozen rule already permits).
+
+### The two-layer structure — optional, threshold-gated
+
+A single one-line erratum stays a plain dated bullet. Split the section into two
+layers **only once it crosses the threshold — more than one entry, *or* any
+entry supersedes another** — at which point a reader can no longer recover the
+present rules without diffing the whole log by hand:
+
+```
+## Errata            (or ## Amendments)
+
+### Current state
+<an authoritative summary — usually a table — of the corrections in force:
+ "read this, not the log", for the present contract>
+
+### History / audit trail
+<dated entries explaining how each correction was reached>
+```
+
+- The **current-state** layer is the authoritative present contract. **Where it
+  disagrees with a historical entry, the current-state layer wins** — say so in
+  the section so a reader knows which layer to trust.
+- The layer *names* above are illustrative; the contract is the two-layer split
+  (authoritative current state over a dated audit trail), not the exact heading
+  wording. RFC-0048 / PR #430 is the worked precedent this generalizes — it uses
+  "Current reconciliation state" over an "Amendment history / audit trail."
+
+### Append-only and supersession
+
+- Correction sections are **append-only**. A later entry supersedes an earlier
+  one simply by being later; the **newest entry plus the current-state layer**
+  carry present truth. Earlier entries are never deleted — they *are* the audit
+  trail.
+- **No per-entry ritual is required.** On a Frozen RFC's `## Errata`, prior
+  entries cannot be reworded anyway (immutable body). On an in-flight
+  `## Amendments`, an author *may* optionally reword a stale entry in place,
+  tagging it `*(Superseded: …)*` — permitted, not required, and **only for
+  in-flight Amendments** (a Frozen RFC's entries can't be touched).
+- **Whole-RFC replacement is out of scope.** When an entire RFC — not one
+  correction within it — is superseded by a later one, record that as an
+  **Errata entry naming the superseding RFC** (e.g. RFC-0012 carries an erratum
+  recording that its Alternative #7 was superseded by RFC-0052). This convention
+  governs corrections *within* an RFC; it neither defines nor changes the
+  whole-RFC-supersession mechanism.
+
 ## Anti-patterns to refuse
 
 - Writing into the RFC body before the checkpoint clears → see step 4.

--- a/packs/governance-extras/.apm/skills/new-rfc/assets/rfc.md
+++ b/packs/governance-extras/.apm/skills/new-rfc/assets/rfc.md
@@ -153,3 +153,47 @@ Filled in when the RFC is accepted. The bridge from "we agreed" to "we did it".
 - Spec: docs/specs/<feature>/
 - Convention change: docs/CONVENTIONS.md, section X
 -->
+
+<!--
+CORRECTIONS — DELETE THIS WHOLE BLOCK unless this RFC is accumulating
+post-publication corrections. Do NOT ship it as an empty section on a fresh
+RFC. See the new-rfc skill, "Recording corrections (Errata / Amendments)", for
+the full rules; the shape below is the optional, threshold-gated scaffold.
+
+Pick the heading by lifecycle class: `## Errata` for a Frozen RFC
+(Accepted/Rejected), `## Amendments` for an in-flight Open one. (Rename
+`## Amendments` → `## Errata` if this RFC is later Accepted.)
+
+A single one-line correction stays a plain dated bullet under the heading — no
+table — like this:
+
+## Errata        (or ## Amendments)
+
+- **YYYY-MM-DD — <short title>.** <what was corrected and why>.
+
+Split into the two layers below ONLY once the section crosses the threshold:
+more than one entry, or any entry supersedes another. Heading wording is your
+call; the two-layer split (authoritative current state over a dated audit trail,
+current state wins on disagreement) is the contract.
+
+## Errata        (or ## Amendments)
+
+### Current state
+
+The corrections in force today — read these, not the log, for the present
+contract. Where this layer disagrees with a historical entry below, this layer
+wins.
+
+| Area | Current rule | Owner / note |
+| --- | --- | --- |
+| <area> | <the rule in force> | <owner / blocker> |
+
+### History / audit trail
+
+Dated, append-only entries explaining how each correction was reached. Never
+delete an entry — it is the audit trail. (On an in-flight `## Amendments` you
+MAY reword a stale entry in place, tagging it `*(Superseded: …)*`; on a Frozen
+`## Errata` the entries are immutable.)
+
+- **YYYY-MM-DD — <short title>.** <what was corrected and why>.
+-->


### PR DESCRIPTION
## What does this change?

Implements RFC-0055's amendment & errata convention in the `governance-extras` `new-rfc` skill. The skill now documents how an RFC records post-publication corrections — a lifecycle-keyed `## Errata` / `## Amendments` split, an optional threshold-gated two-layer structure, and append-only supersession rules — and ships a clearly-conditional commented scaffold in the template so the shape travels to adopters.

## Why?

- Implements: `docs/specs/rfc-correction-convention/spec.md` (Status: Shipped, 9/9 ACs)
- Constrained by: [RFC-0055](docs/rfc/0055-rfc-amendment-and-errata-convention.md) (Accepted 2026-06-28), decisions D1–D5.

There was no written convention for RFC corrections: a de-facto practice grew ad-hoc (16 `Errata` + 8 `Amendments`, 7 of the latter misapplied to Frozen RFCs), and long correction logs garble until a reader can only recover the present rules by diffing the whole history by hand. RFC-0055 codifies the fix; this PR lands it in the one place that ships with the tooling.

**Key decisions encoded:** D1 lifecycle-keyed split (Frozen → Errata, in-flight Open → Amendments); D2 optional, threshold-gated two-layer (current-state layer wins); D3 append-only, in-place reword tagged `*(Superseded: …)*` for in-flight Amendments only, whole-RFC replacement out of scope; D4 skill is the sole source of truth (**no `CONVENTIONS.md` change** — keeps a `governance-extras` feature out of a `core`-seeded doc); D5 forward-only.

Rides the unreleased `governance-extras` 0.4.0 with a changelog entry — **no version bump** (a release is a separate decision).

## How do I verify it?

```bash
# Convention documented (D1/D2/D3)
grep -nE '## Errata|## Amendments|two-layer|current-state layer wins|append-only|superseding RFC' packs/governance-extras/.apm/skills/new-rfc/SKILL.md
# Conditional scaffold present and fully commented (D4)
grep -nE 'CORRECTIONS — DELETE THIS WHOLE BLOCK' packs/governance-extras/.apm/skills/new-rfc/assets/rfc.md
# Boundaries hold (D4/D5): no CONVENTIONS or docs/rfc edits
git diff --name-only origin/main...HEAD | grep -E 'CONVENTIONS.md|docs/rfc/' || echo "OK: none"
# Projection + both lint surfaces
make build-self FORCE=1 && make lint-packs && python tools/lint-agent-artifacts.py
```

**Dogfood walk (manual QA — AC9).** Applied the documented `SKILL.md` procedure to RFC-0048's live correction state (status **Open** → in-flight class → convention prescribes `## Amendments`, which is exactly the heading RFC-0048 uses). RFC-0048 reproduces the documented two-layer *structure*: `### Current reconciliation state` (the authoritative current-state layer — "read these, not the log") over `### Amendment history / audit trail` (dated append-only entries), with "the current-state table wins" on disagreement. Heading wording differs from the convention's illustrative names — exactly as the convention allows ("the layer names are illustrative; the contract is the two-layer split"). RFC-0048 predates the convention and was read, not retrofitted (forward-only, D5). The convention generalizes the precedent rather than inventing a shape — the walk is a real check.

## What did you not change that you considered?

- **No `docs/CONVENTIONS.md` edit** — the repo's prevailing pattern (Option C) pairs a `CONVENTIONS.md §` with the tooling, but D4 forbids it here to avoid coupling a `governance-extras` feature to a `core`-seeded doc.
- **No mechanical lint** enforcing the structure — RFC-0055's open question recommends *no* (the structure is optional and threshold-gated; "erratum vs amendment" is a lifecycle judgment, not a regex).
- **No retrofit** of the 24 existing correction sections — forward-only (D5); a big-bang diff against frozen history is churn for cosmetics.
- **No `governance-extras` version bump** — rides the unreleased 0.4.0; a release is a separate decision.

**Deferred (declined):** quality-engineer Nit — adding a "no lint exists; the Approver/reviewer is the enforcement point" note to `SKILL.md`. Declined: RFC-0055 deliberately declined enforcement, `SKILL.md` already states Errata entries are Approver-signed, and the prose isn't required by any AC; the reviewer offered "accept silently per RFC-0055" as a valid resolution.

## Review

- `adversarial-reviewer`: **Clean** (2 passes — D1–D5 fidelity, all 9 ACs genuinely satisfied, projections byte-identical, doc-drift invariants hold, no forbidden files).
- `quality-engineer`: no Blockers; 1 Concern + 1 Nit **applied** (asset scaffold now shows the sub-threshold plain-bullet form and the Open→Accepted rename reminder), 1 Nit declined (above).
- `security-reviewer`: not warranted — pure documentation/convention change, no security boundary.