### PR TITLE
docs(rfc): add sidecar data-handling to current-state table (R10)

### DIFF
--- a/docs/rfc/0048-autonomous-product-team-operating-model.md
+++ b/docs/rfc/0048-autonomous-product-team-operating-model.md
@@ -730,6 +730,7 @@ contract:
 | Area | Current rule | Owner / blocker |
 | --- | --- | --- |
 | Sidecar schema | Carried in `discovery-loop` at user scope; consumers read instances by convention + a `schema_version` stamp. | RFC-0053 implementing spec **AC0** (DRIFT-I) |
+| Sidecar data handling | Sidecar slots are a **data-classification surface**; regulated/secret-bearing artifacts surface to the human / `discovery-threat-reviewer` lens before shared repo-backed writes (`_state/`). | RFC-0053 implementing spec owns per-slot classification, redaction, retention/export (R10) |
 | Discovery layout | The `docs/discovery/<initiative>/` config key is owned by RFC-0053's implementing spec; default + marker only until it binds. | RFC-0053 implementing spec (DRIFT-C) |
 | Discovery reviewers | `discovery-threat-reviewer` + `discovery-reliability-reviewer` (user-scope, distinct-named); `core`'s depth libraries are optional detect-and-degrade enhancers. | RFC-0053 / `discovery-loop` (DRIFT-E) |
 | Spec up-edge | `new-spec` produces the `Discovery:` header + discovery `type:` markers; must land before the traceability lint runs `--strict`. | CONVENTIONS / `new-spec` follow-on (DRIFT-G) |


### PR DESCRIPTION
Follow-up closing the last gap on R10 (data-handling / privacy boundary for the sidecar).

The R10 boundary already landed in PR #438 across three surfaces: the RFC-0048 sidecar doctrine, the RFC-0053 § Security & integrity contract, and the RFC-0048 amendment history. But it was **not** in the **Current reconciliation state** table — the layer RFC-0048 itself flags as the authoritative *"read these, not the log"* present contract. The rule lived only in the Proposal prose and the audit-trail log.

This adds the one missing row:

| Sidecar data handling | Sidecar slots are a data-classification surface; regulated/secret-bearing artifacts surface to the human / `discovery-threat-reviewer` lens before shared repo-backed writes (`_state/`). | RFC-0053 implementing spec owns per-slot classification, redaction, retention/export (R10) |

The owner cell is tagged `(R10)` rather than a fabricated `DRIFT-` id — the `DRIFT-A…I` series is the 2026-06-26 foundation-reconciliation discharge set; R10 is a fresh review finding tracked under its own label.

With this, R10 is closed: the current-contract surface now carries the rule.

Docs-only; RFC-0048 is Open.