### PR TITLE
feat(new-adr): decision-capture guidance + harder evals (track 1)

### DIFF
--- a/.agents/skills/new-adr/SKILL.md
+++ b/.agents/skills/new-adr/SKILL.md
@@ -18,6 +18,11 @@ Before invoking, confirm:
    a venue for open-ended discussion — that's an RFC.
 3. There is a *concrete tradeoff* — at least one viable alternative was
    considered. If there's only one option, you don't need an ADR.
+4. The record is *one decision wide*. If you're packing three or more
+   load-bearing sub-decisions into a single ADR, stop and ask whether this is
+   really one decision — or an umbrella that should be an RFC spawning several
+   smaller ADRs. For an ADR, *complete* is not *exhaustive*: the RFC carries the
+   debate, the ADR records the durable outcome.
 
 If any of these checks fail, push back rather than proceeding.
 
@@ -41,7 +46,10 @@ If any of these checks fail, push back rather than proceeding.
    not `0007-decision-about-the-database.md`. The H1 title inside the file
    names the problem *and* the chosen solution together — "Primary store
    for user activity: Postgres over DynamoDB" — so the decision is legible
-   from the index alone; keep the `ADR-NNNN` ordinal prefix on it.
+   from the index alone; keep the `ADR-NNNN` ordinal prefix on it. **Keep it short: the title
+   *identifies* the decision, it doesn't encode the rationale** — the detail
+   belongs in the Decision section, not the H1. A title that compresses the whole
+   argument into a clause makes the ADR index hard to scan.
 
 3. Copy this skill's bundled `assets/adr.md` into `docs/adr/` and
    rename to `NNNN-<title>.md`. (Paths are skill-relative — the
@@ -52,9 +60,29 @@ If any of these checks fail, push back rather than proceeding.
    `Decision-makers` who own the call, and — when the decision was run past
    others — the `Consulted` (whose input was sought, two-way) and `Informed`
    (who is kept up to date, one-way). Delete the `Consulted`/`Informed` lines
-   if neither applies.
+   if neither applies. Keep the metadata *pointer-like* — `Consulted` and
+   `Related` are short lists of handles and ADR/RFC/spec references, not prose.
+   If a relationship needs explaining, the explanation goes in Context or
+   References, never in the frontmatter.
 
-5. Help the user draft the sections. Push back if any is empty or hand-wavy:
+5. **Frame the decision before drafting — offer, don't force.** An ADR records a
+   decision *already made*, so the job here is to isolate it cleanly, not to
+   re-open it. Read the request:
+   - **When the decision is already crisp** (a clear choice, a named driver, an
+     obvious tradeoff), infer the frame and go straight to drafting — don't make
+     the author answer a questionnaire they've already answered.
+   - **When it arrives tangled** (rationale, history, and several sub-decisions
+     in one breath — the RFC-residue an ADR should shed), walk a short decision
+     frame and reflect it back before drafting: the decision in one sentence; the
+     problem it resolves; the alternatives seriously considered; the driver that
+     made the chosen option win; what we're giving up; whether it replaces or
+     amends a prior ADR.
+
+   Synthesize the frame into the title, the Decision sentence, Context,
+   Consequences, and Alternatives below. The frame is a thinking aid, not a
+   required form — a half-shaped decision is normal input.
+
+6. Help the user draft the sections. Push back if any is empty or hand-wavy:
    - Context with no constraints listed → ask what's actually constraining
      this choice.
    - Decision without a single declarative sentence at the top → write one.
@@ -71,9 +99,9 @@ If any of these checks fail, push back rather than proceeding.
      periodic audit). Add it when the decision is the kind that erodes
      silently if no one checks.
 
-6. Update `docs/adr/README.md` to add the new ADR to the table.
+7. Update `docs/adr/README.md` to add the new ADR to the table.
 
-7. Leave the status `Proposed`. Once the decision-makers sign off, mark it
+8. Leave the status `Proposed`. Once the decision-makers sign off, mark it
    `Accepted`; if they decline it, mark it `Rejected` and keep the file — a
    recorded rejection stops the same option being re-proposed later. After
    `Accepted`, the body is frozen (see Lifecycle below).
@@ -99,3 +127,9 @@ If any of these checks fail, push back rather than proceeding.
   one instead.
 - Editing an accepted ADR's body → ADRs are immutable. A reversal is a *new*
   ADR that supersedes the old one (see Lifecycle above), never an edit.
+- A title that carries the whole rationale → shorten it to *identify* the
+  decision; the detail lives in the Decision section, and a scannable ADR index
+  depends on it.
+- Packing several independent load-bearing decisions into one ADR → split them.
+  One ADR, one durable decision; an umbrella belongs in an RFC that spawns the
+  ADRs.

--- a/.agents/skills/new-adr/assets/adr.md
+++ b/.agents/skills/new-adr/assets/adr.md
@@ -3,7 +3,9 @@
 <!--
 Title names the problem and the solution together, so the decision is legible
 from the index alone — "Primary store for user activity: Postgres over DynamoDB",
-not "Decision about the database". Keep the ADR-NNNN ordinal prefix.
+not "Decision about the database". Keep it short — it identifies the decision, it
+does not encode the whole rationale (that lives in the Decision section). Keep
+the ADR-NNNN ordinal prefix.
 -->
 
 - **Status:** Proposed <!-- Proposed | Accepted | Rejected | Deprecated | Superseded by ADR-NNNN -->
@@ -12,7 +14,7 @@ not "Decision about the database". Keep the ADR-NNNN ordinal prefix.
 - **Consulted:** <!-- whose input was sought, two-way; optional, delete if none -->
 - **Informed:** <!-- who is kept up to date, one-way; optional, delete if none -->
 - **Supersedes:** <!-- ADR-NNNN, or "none" -->
-- **Related:** <!-- RFCs, other ADRs, specs -->
+- **Related:** <!-- RFCs, other ADRs, specs — pointers, not prose; explanation goes in Context or References -->
 
 <!--
 Status lifecycle: Proposed → Accepted, or Proposed → Rejected. An Accepted ADR

--- a/.agents/skills/new-adr/evals/evals.json
+++ b/.agents/skills/new-adr/evals/evals.json
@@ -4,14 +4,27 @@
     {
       "id": 1,
       "prompt": "Record the architecture decision the user described as a new ADR.",
-      "expected_output": "An ADR created from the template with an H1 that names the problem AND the chosen solution together, and frontmatter filled in (status Proposed, today's date, Decision-makers). The Decision section leads with a single declarative sentence stating the choice (ADR/MADR layout puts Context before the Decision, so 'at the top' means leading its own section, not the document); Context lists the actual constraints driving the choice; Consequences include honest negatives (what is given up), not only upsides; at least one viable alternative is recorded, each rejected against a stated reason. The record is for a decision already made or formally proposed (not an open debate — that would be an RFC), and there is a concrete tradeoff (more than one option was viable). After Accepted the body is immutable — a reversal is a new superseding ADR, never an edit.",
+      "expected_output": "An ADR created from the template with an H1 that names the problem AND the chosen solution together — kept short, identifying the decision without encoding the whole rationale — and frontmatter filled in (status Proposed, today's date, Decision-makers) and kept pointer-like (Consulted/Related are short reference lists, not prose). The Decision section leads with a single declarative sentence stating the choice (ADR/MADR layout puts Context before the Decision, so 'at the top' means leading its own section, not the document); Context lists the actual constraints driving the choice; Consequences include honest negatives (what is given up), not only upsides; at least one viable alternative is recorded, each rejected against a stated reason. The record is for a decision already made or formally proposed (not an open debate — that would be an RFC), there is a concrete tradeoff (more than one option was viable), and it is one decision wide (not three-plus load-bearing sub-decisions packed into one ADR — that would be an umbrella RFC spawning smaller ADRs). After Accepted the body is immutable — a reversal is a new superseding ADR, never an edit.",
       "assertions": [
         "The Decision is stated as a single declarative sentence leading the Decision section",
         "Context lists the actual constraints driving the choice, not hand-wavy filler",
         "Consequences include honest negatives (what is given up), not only upsides",
         "At least one viable alternative is recorded, each rejected with a stated reason",
         "Records a decision already made or formally proposed — not an open-ended debate (which would be an RFC)",
-        "Frontmatter is filled (status, date, Decision-makers) and the H1 names the problem and the chosen solution together"
+        "Frontmatter is filled (status, date, Decision-makers) and the H1 names the problem and the chosen solution together — kept short, identifying the decision without encoding the whole rationale",
+        "Frontmatter metadata (Consulted, Related) is pointer-like — short lists of handles and ADR/RFC/spec references, not prose; any explanation lives in Context or References",
+        "The record is one decision wide — not three or more load-bearing sub-decisions packed into a single ADR (that would be an umbrella RFC spawning smaller ADRs)"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "The user dumps a tangled decision to record as an ADR — rationale, history, and several load-bearing sub-decisions in one breath (e.g. 'record that we'll move to event sourcing, AND switch the message bus to Kafka, AND adopt CQRS for the read side — here's the whole backstory and the three options we weighed for each').",
+      "expected_output": "Before drafting, the skill isolates the decision rather than transcribing the dump. Because the request packs three or more load-bearing sub-decisions, the skill pushes back per the one-decision-wide check — asking whether this is really one decision or an umbrella that should be an RFC spawning several smaller ADRs (the RFC carries the debate; each ADR records one durable outcome). For a genuinely single-but-tangled decision, the skill instead reflects back a short decision frame (the decision in one sentence, the problem it resolves, the alternatives, the winning driver, the tradeoff, any prior ADR amended) and confirms it before writing — it does not silently absorb the rationale and history into a dense title or a prose metadata block. The offer-don't-force shape holds: a half-shaped decision is normal input, not a questionnaire to complete.",
+      "assertions": [
+        "Pushes back on packing three or more load-bearing sub-decisions into one ADR, pointing at an umbrella RFC that spawns smaller ADRs",
+        "Reflects back a short decision frame (decision sentence, problem, alternatives, winning driver, tradeoff, prior ADR) before drafting, rather than transcribing the dump verbatim",
+        "Does not absorb the rationale/history into an over-long title or a prose Consulted/Related metadata block",
+        "Frames by offering, not by forcing a fixed questionnaire — a half-shaped decision is accepted as normal input"
       ]
     }
   ]

--- a/.claude/skills/new-adr/SKILL.md
+++ b/.claude/skills/new-adr/SKILL.md
@@ -18,6 +18,11 @@ Before invoking, confirm:
    a venue for open-ended discussion — that's an RFC.
 3. There is a *concrete tradeoff* — at least one viable alternative was
    considered. If there's only one option, you don't need an ADR.
+4. The record is *one decision wide*. If you're packing three or more
+   load-bearing sub-decisions into a single ADR, stop and ask whether this is
+   really one decision — or an umbrella that should be an RFC spawning several
+   smaller ADRs. For an ADR, *complete* is not *exhaustive*: the RFC carries the
+   debate, the ADR records the durable outcome.
 
 If any of these checks fail, push back rather than proceeding.
 
@@ -41,7 +46,10 @@ If any of these checks fail, push back rather than proceeding.
    not `0007-decision-about-the-database.md`. The H1 title inside the file
    names the problem *and* the chosen solution together — "Primary store
    for user activity: Postgres over DynamoDB" — so the decision is legible
-   from the index alone; keep the `ADR-NNNN` ordinal prefix on it.
+   from the index alone; keep the `ADR-NNNN` ordinal prefix on it. **Keep it short: the title
+   *identifies* the decision, it doesn't encode the rationale** — the detail
+   belongs in the Decision section, not the H1. A title that compresses the whole
+   argument into a clause makes the ADR index hard to scan.
 
 3. Copy this skill's bundled `assets/adr.md` into `docs/adr/` and
    rename to `NNNN-<title>.md`. (Paths are skill-relative — the
@@ -52,9 +60,29 @@ If any of these checks fail, push back rather than proceeding.
    `Decision-makers` who own the call, and — when the decision was run past
    others — the `Consulted` (whose input was sought, two-way) and `Informed`
    (who is kept up to date, one-way). Delete the `Consulted`/`Informed` lines
-   if neither applies.
+   if neither applies. Keep the metadata *pointer-like* — `Consulted` and
+   `Related` are short lists of handles and ADR/RFC/spec references, not prose.
+   If a relationship needs explaining, the explanation goes in Context or
+   References, never in the frontmatter.
 
-5. Help the user draft the sections. Push back if any is empty or hand-wavy:
+5. **Frame the decision before drafting — offer, don't force.** An ADR records a
+   decision *already made*, so the job here is to isolate it cleanly, not to
+   re-open it. Read the request:
+   - **When the decision is already crisp** (a clear choice, a named driver, an
+     obvious tradeoff), infer the frame and go straight to drafting — don't make
+     the author answer a questionnaire they've already answered.
+   - **When it arrives tangled** (rationale, history, and several sub-decisions
+     in one breath — the RFC-residue an ADR should shed), walk a short decision
+     frame and reflect it back before drafting: the decision in one sentence; the
+     problem it resolves; the alternatives seriously considered; the driver that
+     made the chosen option win; what we're giving up; whether it replaces or
+     amends a prior ADR.
+
+   Synthesize the frame into the title, the Decision sentence, Context,
+   Consequences, and Alternatives below. The frame is a thinking aid, not a
+   required form — a half-shaped decision is normal input.
+
+6. Help the user draft the sections. Push back if any is empty or hand-wavy:
    - Context with no constraints listed → ask what's actually constraining
      this choice.
    - Decision without a single declarative sentence at the top → write one.
@@ -71,9 +99,9 @@ If any of these checks fail, push back rather than proceeding.
      periodic audit). Add it when the decision is the kind that erodes
      silently if no one checks.
 
-6. Update `docs/adr/README.md` to add the new ADR to the table.
+7. Update `docs/adr/README.md` to add the new ADR to the table.
 
-7. Leave the status `Proposed`. Once the decision-makers sign off, mark it
+8. Leave the status `Proposed`. Once the decision-makers sign off, mark it
    `Accepted`; if they decline it, mark it `Rejected` and keep the file — a
    recorded rejection stops the same option being re-proposed later. After
    `Accepted`, the body is frozen (see Lifecycle below).
@@ -99,3 +127,9 @@ If any of these checks fail, push back rather than proceeding.
   one instead.
 - Editing an accepted ADR's body → ADRs are immutable. A reversal is a *new*
   ADR that supersedes the old one (see Lifecycle above), never an edit.
+- A title that carries the whole rationale → shorten it to *identify* the
+  decision; the detail lives in the Decision section, and a scannable ADR index
+  depends on it.
+- Packing several independent load-bearing decisions into one ADR → split them.
+  One ADR, one durable decision; an umbrella belongs in an RFC that spawns the
+  ADRs.

--- a/.claude/skills/new-adr/assets/adr.md
+++ b/.claude/skills/new-adr/assets/adr.md
@@ -3,7 +3,9 @@
 <!--
 Title names the problem and the solution together, so the decision is legible
 from the index alone — "Primary store for user activity: Postgres over DynamoDB",
-not "Decision about the database". Keep the ADR-NNNN ordinal prefix.
+not "Decision about the database". Keep it short — it identifies the decision, it
+does not encode the whole rationale (that lives in the Decision section). Keep
+the ADR-NNNN ordinal prefix.
 -->
 
 - **Status:** Proposed <!-- Proposed | Accepted | Rejected | Deprecated | Superseded by ADR-NNNN -->
@@ -12,7 +14,7 @@ not "Decision about the database". Keep the ADR-NNNN ordinal prefix.
 - **Consulted:** <!-- whose input was sought, two-way; optional, delete if none -->
 - **Informed:** <!-- who is kept up to date, one-way; optional, delete if none -->
 - **Supersedes:** <!-- ADR-NNNN, or "none" -->
-- **Related:** <!-- RFCs, other ADRs, specs -->
+- **Related:** <!-- RFCs, other ADRs, specs — pointers, not prose; explanation goes in Context or References -->
 
 <!--
 Status lifecycle: Proposed → Accepted, or Proposed → Rejected. An Accepted ADR

--- a/.claude/skills/new-adr/evals/evals.json
+++ b/.claude/skills/new-adr/evals/evals.json
@@ -4,14 +4,27 @@
     {
       "id": 1,
       "prompt": "Record the architecture decision the user described as a new ADR.",
-      "expected_output": "An ADR created from the template with an H1 that names the problem AND the chosen solution together, and frontmatter filled in (status Proposed, today's date, Decision-makers). The Decision section leads with a single declarative sentence stating the choice (ADR/MADR layout puts Context before the Decision, so 'at the top' means leading its own section, not the document); Context lists the actual constraints driving the choice; Consequences include honest negatives (what is given up), not only upsides; at least one viable alternative is recorded, each rejected against a stated reason. The record is for a decision already made or formally proposed (not an open debate — that would be an RFC), and there is a concrete tradeoff (more than one option was viable). After Accepted the body is immutable — a reversal is a new superseding ADR, never an edit.",
+      "expected_output": "An ADR created from the template with an H1 that names the problem AND the chosen solution together — kept short, identifying the decision without encoding the whole rationale — and frontmatter filled in (status Proposed, today's date, Decision-makers) and kept pointer-like (Consulted/Related are short reference lists, not prose). The Decision section leads with a single declarative sentence stating the choice (ADR/MADR layout puts Context before the Decision, so 'at the top' means leading its own section, not the document); Context lists the actual constraints driving the choice; Consequences include honest negatives (what is given up), not only upsides; at least one viable alternative is recorded, each rejected against a stated reason. The record is for a decision already made or formally proposed (not an open debate — that would be an RFC), there is a concrete tradeoff (more than one option was viable), and it is one decision wide (not three-plus load-bearing sub-decisions packed into one ADR — that would be an umbrella RFC spawning smaller ADRs). After Accepted the body is immutable — a reversal is a new superseding ADR, never an edit.",
       "assertions": [
         "The Decision is stated as a single declarative sentence leading the Decision section",
         "Context lists the actual constraints driving the choice, not hand-wavy filler",
         "Consequences include honest negatives (what is given up), not only upsides",
         "At least one viable alternative is recorded, each rejected with a stated reason",
         "Records a decision already made or formally proposed — not an open-ended debate (which would be an RFC)",
-        "Frontmatter is filled (status, date, Decision-makers) and the H1 names the problem and the chosen solution together"
+        "Frontmatter is filled (status, date, Decision-makers) and the H1 names the problem and the chosen solution together — kept short, identifying the decision without encoding the whole rationale",
+        "Frontmatter metadata (Consulted, Related) is pointer-like — short lists of handles and ADR/RFC/spec references, not prose; any explanation lives in Context or References",
+        "The record is one decision wide — not three or more load-bearing sub-decisions packed into a single ADR (that would be an umbrella RFC spawning smaller ADRs)"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "The user dumps a tangled decision to record as an ADR — rationale, history, and several load-bearing sub-decisions in one breath (e.g. 'record that we'll move to event sourcing, AND switch the message bus to Kafka, AND adopt CQRS for the read side — here's the whole backstory and the three options we weighed for each').",
+      "expected_output": "Before drafting, the skill isolates the decision rather than transcribing the dump. Because the request packs three or more load-bearing sub-decisions, the skill pushes back per the one-decision-wide check — asking whether this is really one decision or an umbrella that should be an RFC spawning several smaller ADRs (the RFC carries the debate; each ADR records one durable outcome). For a genuinely single-but-tangled decision, the skill instead reflects back a short decision frame (the decision in one sentence, the problem it resolves, the alternatives, the winning driver, the tradeoff, any prior ADR amended) and confirms it before writing — it does not silently absorb the rationale and history into a dense title or a prose metadata block. The offer-don't-force shape holds: a half-shaped decision is normal input, not a questionnaire to complete.",
+      "assertions": [
+        "Pushes back on packing three or more load-bearing sub-decisions into one ADR, pointing at an umbrella RFC that spawns smaller ADRs",
+        "Reflects back a short decision frame (decision sentence, problem, alternatives, winning driver, tradeoff, prior ADR) before drafting, rather than transcribing the dump verbatim",
+        "Does not absorb the rationale/history into an over-long title or a prose Consulted/Related metadata block",
+        "Frames by offering, not by forcing a fixed questionnaire — a half-shaped decision is accepted as normal input"
       ]
     }
   ]

--- a/docs/guides/governance-extras/how-to/new-adr.md
+++ b/docs/guides/governance-extras/how-to/new-adr.md
@@ -65,15 +65,15 @@ Before the skill scaffolds anything, it asks (explicitly or implicitly) about ar
 
 The skill runs its bundled `scripts/next-ordinal.py` helper (the path is skill-relative; the skill resolves it for you). It prints the next 4-digit ordinal — `0001` if `docs/adr/` is empty, max-plus-one otherwise. Numbers are sequential and never reused. The helper parses the full digit prefix, so transitions like `0099` → `0100` work correctly without manual zero-padding.
 
-The skill then picks a short kebab-case filename from your description (`0007-primary-store-postgres-over-dynamodb.md`, not `0007-decision-about-the-database.md`), copies its bundled `assets/adr.md` into `docs/adr/`, and renames. The H1 title inside names the problem and the chosen solution together (keeping the `ADR-NNNN` ordinal), so the decision reads clearly from the index.
+The skill then picks a short kebab-case filename from your description (`0007-primary-store-postgres-over-dynamodb.md`, not `0007-decision-about-the-database.md`), copies its bundled `assets/adr.md` into `docs/adr/`, and renames. The H1 title inside names the problem and the chosen solution together (keeping the `ADR-NNNN` ordinal), so the decision reads clearly from the index. The skill keeps it **short** — the title *identifies* the decision rather than encoding the whole rationale (that lives in the Decision section); a title that compresses the whole argument into a clause makes the index hard to scan.
 
 ## Step 4 — Fill in frontmatter
 
-Status starts as `Proposed`. Today's date. `Decision-makers` are the GitHub handles of the people who own the call; add `Consulted` (whose input was sought, two-way) and `Informed` (who is kept up to date, one-way) when the decision was run past others, and delete those two lines otherwise. `Supersedes:` is `none` for a greenfield ADR; otherwise the ADR number being replaced (see Variations).
+Status starts as `Proposed`. Today's date. `Decision-makers` are the GitHub handles of the people who own the call; add `Consulted` (whose input was sought, two-way) and `Informed` (who is kept up to date, one-way) when the decision was run past others, and delete those two lines otherwise. `Supersedes:` is `none` for a greenfield ADR; otherwise the ADR number being replaced (see Variations). Keep `Consulted` and `Related` **pointer-like** — short lists of handles and ADR/RFC/spec references, not prose; if a relationship needs explaining, that explanation goes in Context or References, not the frontmatter.
 
 ## Step 5 — Draft the body sections
 
-The skill walks you through Context, Decision, Consequences, and Alternatives, and offers two optional sections — **Decision drivers** (the criteria the choice was judged against, so each alternative is rejected against a stated criterion) and **Confirmation** (how conformance with the decision will be verified) — which it includes when they earn their place and drops otherwise. It pushes back on hand-wavy sections rather than accepting them:
+If your request arrives tangled — rationale, history, and several sub-decisions in one breath — the skill first reflects back a short **decision frame** (the decision in a sentence, the problem it resolves, the alternatives, the winning driver, what you're giving up) to isolate the call before drafting; when the decision is already crisp it skips the frame and drafts straight away. It then walks you through Context, Decision, Consequences, and Alternatives, and offers two optional sections — **Decision drivers** (the criteria the choice was judged against, so each alternative is rejected against a stated criterion) and **Confirmation** (how conformance with the decision will be verified) — which it includes when they earn their place and drops otherwise. It pushes back on hand-wavy sections rather than accepting them:
 
 - **Context with no listed constraints** → the skill asks what's actually constraining the choice. "We need a database" isn't context; "~10M records, query by `user_id` and time range, team of two who know Postgres" is.
 - **Decision without a single declarative sentence at the top** → the skill asks you to write one. ("We will use Postgres as the primary data store for user activity.")
@@ -131,6 +131,8 @@ The RFC carried the debate; its accepted outcome lists "one or more ADRs to reco
 > **Consequences with only positives.** Every decision has tradeoffs; an ADR that lists only upside isn't honest, and the next person will discount it. Push for at least one real negative or "to revisit" item.
 
 > **An ADR for a single feature's internals.** That's a spec (`docs/specs/<feature>/`), not an ADR. ADRs are for cross-cutting architectural and infrastructural calls.
+
+> **Packing several decisions into one ADR.** If a record carries three or more load-bearing sub-decisions, it's an umbrella — the skill pushes back and asks whether it should be an RFC that spawns several smaller ADRs. One ADR, one durable decision; *complete* is not *exhaustive*.
 
 ## When not to use this workflow
 

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -32,6 +32,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   carries the same shape as a clearly-conditional commented scaffold, so it travels
   into every RFC an adopter drafts without being filled into empty sections.
   Forward-only — existing correction sections are untouched.
+- **The `new-adr` skill now helps you isolate the decision before drafting, so
+  ADRs stay lean (governance-extras 0.4.0).** Four guidance refinements, none of
+  which changes the ADR template's sections or fields: (1) a "frame the decision
+  before drafting" step that *offers, doesn't force* — it infers the frame when
+  the decision is already crisp and walks a short decision frame (the decision in
+  a sentence, the problem, the alternatives, the winning driver, the tradeoff,
+  any prior ADR it amends) when the request arrives tangled; (2) stronger title
+  discipline — the title *identifies* the decision rather than encoding the whole
+  rationale; (3) a one-decision-wide push-back that routes an umbrella of three
+  or more load-bearing sub-decisions to an RFC spawning smaller ADRs; (4)
+  pointer-like metadata guidance — `Consulted`/`Related` are short reference
+  lists, not prose. The behavioral evals gain matching usability assertions.
 - **The `new-rfc` skill now sizes each RFC to its two humans — the author and
   the reviewer (governance-extras 0.4.0, implementing RFC-0054).** Four changes,
   the deferred half of the human-consumption work whose RFC-0014-clean half

--- a/docs/specs/new-adr-decision-capture/spec.md
+++ b/docs/specs/new-adr-decision-capture/spec.md
@@ -1,0 +1,84 @@
+# Spec: new-adr decision-capture polish
+
+Mode: light (no risk trigger fired)
+
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Plan:** none (light mode — task list inline below)
+
+> Track 1 of the `new-adr` critique. Skill-prose + behavioral-eval refinements
+> that guide the author to isolate the decision before drafting and keep the
+> record lean. The format-changing recommendations (a first-screen Decision
+> summary block, a structured `Revisit if:` field, a Confirmation
+> Mode/Signal/Owner sub-structure) are **out of scope** — they change the ADR
+> template that ADR-0027 froze ("MADR-aligned but lean") and are deferred to a
+> track-2 RFC.
+
+## Objective
+
+Close the "under-guided" gap in the `new-adr` skill: it asks the right
+*validity* questions but doesn't help the author *shape* the decision before
+writing, so heavy ADRs carry RFC-residue (long rationale, dense titles, prose
+metadata, multiple sub-decisions). Add decision-capture guidance and harden the
+behavioral evals — without touching the locked template format.
+
+## Acceptance Criteria
+
+- [x] **AC1 (R1 — decision-frame intake).** The skill gains a "frame the
+  decision before drafting" step that **offers, doesn't force** — infers the
+  frame when the decision is already crisp, walks a short decision frame when it
+  arrives tangled — mirroring `new-rfc`'s established guided-intake shape rather
+  than a mandatory questionnaire.
+- [x] **AC2 (R3 — short titles).** The skill's title guidance states the title
+  *identifies* the decision and does not encode the whole rationale (detail
+  belongs in the Decision section), with a matching anti-pattern. Examples stay
+  generic (no repo-internal ADR numbers an adopter wouldn't have).
+- [x] **AC3 (R4 — one decision wide).** The skill pushes back when one ADR packs
+  three or more load-bearing sub-decisions, pointing at an umbrella RFC +
+  smaller ADRs, with a matching anti-pattern.
+- [x] **AC4 (R5 — pointer-like metadata).** The skill states `Consulted` /
+  `Related` are short pointer lists, not prose; explanatory detail goes to
+  Context or References.
+- [x] **AC5 (R8 — usability evals).** `evals/evals.json` is extended with
+  behavioral assertions for the above (short decision-identifying H1;
+  pointer-like metadata; one durable decision). No assertion references a
+  track-2 field (no Decision summary, no Revisit-if). `eval_queries.json`
+  (trigger detection) is unchanged.
+- [x] **AC6 (no format change).** `assets/adr.md` gains no new section or field;
+  only guidance *comments* may be refined. The frozen ADR-0027 format holds.
+- [x] **AC7 (guide sync).** The repo-owned how-to guide
+  (`docs/guides/governance-extras/how-to/new-adr.md`) is synced for the
+  behaviors that materially change (title brevity, decision-frame, one-decision
+  pitfall, pointer-metadata pitfall) so it doesn't contradict the skill.
+- [x] **AC8 (changelog).** A `[Unreleased]` entry under governance-extras 0.4.0
+  records the user-visible skill change.
+- [x] **AC9 (projection clean).** `make build-self` projects the source change
+  to `.claude/` + `.agents/` (+ marketplace aggregation) and leaves a clean
+  tree; `lint-packs` and `tools/lint-agent-artifacts.py` pass.
+
+## Boundaries
+
+In: `packs/governance-extras/.apm/skills/new-adr/SKILL.md`, its
+`evals/evals.json`, guidance comments in `assets/adr.md`, the how-to guide, the
+changelog, and the resulting projections. Out: the ADR template's
+sections/fields (track-2 RFC), `eval_queries.json`, any other pack, any
+governance rule (CONVENTIONS/CHARTER), version bump (rides unreleased 0.4.0).
+
+## Testing Strategy
+
+Goal-based + manual-QA (prose + JSON; no production code). Done when:
+`python -c "import json,glob; [json.load(open(f)) for f in glob.glob('packs/governance-extras/.apm/skills/new-adr/evals/*.json')]"` parses;
+`lint-packs` and `lint-agent-artifacts.py` pass; `make build-self` leaves a
+clean `git status`; and a read-through confirms the skill reads coherently and
+the decision-frame mirrors `new-rfc`'s offer-don't-force shape.
+
+## Declined patterns
+
+- Tempted to implement R1's rigid 7-question INTAKE + DECISION FRAME verbatim;
+  declining — adapt to `new-rfc`'s "offer, don't force" shape, the established
+  house pattern.
+- Tempted to add a "Decision summary" first-screen section to hold the title
+  detail R3 sheds; declining — that's a frozen-template change (ADR-0027),
+  deferred to track 2.
+- Tempted to add a separate usability-eval file/harness for R8; declining —
+  `evals.json` is already behavioral, so the checks extend existing assertions.

--- a/packs/governance-extras/.apm/skills/new-adr/SKILL.md
+++ b/packs/governance-extras/.apm/skills/new-adr/SKILL.md
@@ -18,6 +18,11 @@ Before invoking, confirm:
    a venue for open-ended discussion — that's an RFC.
 3. There is a *concrete tradeoff* — at least one viable alternative was
    considered. If there's only one option, you don't need an ADR.
+4. The record is *one decision wide*. If you're packing three or more
+   load-bearing sub-decisions into a single ADR, stop and ask whether this is
+   really one decision — or an umbrella that should be an RFC spawning several
+   smaller ADRs. For an ADR, *complete* is not *exhaustive*: the RFC carries the
+   debate, the ADR records the durable outcome.
 
 If any of these checks fail, push back rather than proceeding.
 
@@ -41,7 +46,10 @@ If any of these checks fail, push back rather than proceeding.
    not `0007-decision-about-the-database.md`. The H1 title inside the file
    names the problem *and* the chosen solution together — "Primary store
    for user activity: Postgres over DynamoDB" — so the decision is legible
-   from the index alone; keep the `ADR-NNNN` ordinal prefix on it.
+   from the index alone; keep the `ADR-NNNN` ordinal prefix on it. **Keep it short: the title
+   *identifies* the decision, it doesn't encode the rationale** — the detail
+   belongs in the Decision section, not the H1. A title that compresses the whole
+   argument into a clause makes the ADR index hard to scan.
 
 3. Copy this skill's bundled `assets/adr.md` into `docs/adr/` and
    rename to `NNNN-<title>.md`. (Paths are skill-relative — the
@@ -52,9 +60,29 @@ If any of these checks fail, push back rather than proceeding.
    `Decision-makers` who own the call, and — when the decision was run past
    others — the `Consulted` (whose input was sought, two-way) and `Informed`
    (who is kept up to date, one-way). Delete the `Consulted`/`Informed` lines
-   if neither applies.
+   if neither applies. Keep the metadata *pointer-like* — `Consulted` and
+   `Related` are short lists of handles and ADR/RFC/spec references, not prose.
+   If a relationship needs explaining, the explanation goes in Context or
+   References, never in the frontmatter.
 
-5. Help the user draft the sections. Push back if any is empty or hand-wavy:
+5. **Frame the decision before drafting — offer, don't force.** An ADR records a
+   decision *already made*, so the job here is to isolate it cleanly, not to
+   re-open it. Read the request:
+   - **When the decision is already crisp** (a clear choice, a named driver, an
+     obvious tradeoff), infer the frame and go straight to drafting — don't make
+     the author answer a questionnaire they've already answered.
+   - **When it arrives tangled** (rationale, history, and several sub-decisions
+     in one breath — the RFC-residue an ADR should shed), walk a short decision
+     frame and reflect it back before drafting: the decision in one sentence; the
+     problem it resolves; the alternatives seriously considered; the driver that
+     made the chosen option win; what we're giving up; whether it replaces or
+     amends a prior ADR.
+
+   Synthesize the frame into the title, the Decision sentence, Context,
+   Consequences, and Alternatives below. The frame is a thinking aid, not a
+   required form — a half-shaped decision is normal input.
+
+6. Help the user draft the sections. Push back if any is empty or hand-wavy:
    - Context with no constraints listed → ask what's actually constraining
      this choice.
    - Decision without a single declarative sentence at the top → write one.
@@ -71,9 +99,9 @@ If any of these checks fail, push back rather than proceeding.
      periodic audit). Add it when the decision is the kind that erodes
      silently if no one checks.
 
-6. Update `docs/adr/README.md` to add the new ADR to the table.
+7. Update `docs/adr/README.md` to add the new ADR to the table.
 
-7. Leave the status `Proposed`. Once the decision-makers sign off, mark it
+8. Leave the status `Proposed`. Once the decision-makers sign off, mark it
    `Accepted`; if they decline it, mark it `Rejected` and keep the file — a
    recorded rejection stops the same option being re-proposed later. After
    `Accepted`, the body is frozen (see Lifecycle below).
@@ -99,3 +127,9 @@ If any of these checks fail, push back rather than proceeding.
   one instead.
 - Editing an accepted ADR's body → ADRs are immutable. A reversal is a *new*
   ADR that supersedes the old one (see Lifecycle above), never an edit.
+- A title that carries the whole rationale → shorten it to *identify* the
+  decision; the detail lives in the Decision section, and a scannable ADR index
+  depends on it.
+- Packing several independent load-bearing decisions into one ADR → split them.
+  One ADR, one durable decision; an umbrella belongs in an RFC that spawns the
+  ADRs.

--- a/packs/governance-extras/.apm/skills/new-adr/assets/adr.md
+++ b/packs/governance-extras/.apm/skills/new-adr/assets/adr.md
@@ -3,7 +3,9 @@
 <!--
 Title names the problem and the solution together, so the decision is legible
 from the index alone — "Primary store for user activity: Postgres over DynamoDB",
-not "Decision about the database". Keep the ADR-NNNN ordinal prefix.
+not "Decision about the database". Keep it short — it identifies the decision, it
+does not encode the whole rationale (that lives in the Decision section). Keep
+the ADR-NNNN ordinal prefix.
 -->
 
 - **Status:** Proposed <!-- Proposed | Accepted | Rejected | Deprecated | Superseded by ADR-NNNN -->
@@ -12,7 +14,7 @@ not "Decision about the database". Keep the ADR-NNNN ordinal prefix.
 - **Consulted:** <!-- whose input was sought, two-way; optional, delete if none -->
 - **Informed:** <!-- who is kept up to date, one-way; optional, delete if none -->
 - **Supersedes:** <!-- ADR-NNNN, or "none" -->
-- **Related:** <!-- RFCs, other ADRs, specs -->
+- **Related:** <!-- RFCs, other ADRs, specs — pointers, not prose; explanation goes in Context or References -->
 
 <!--
 Status lifecycle: Proposed → Accepted, or Proposed → Rejected. An Accepted ADR

--- a/packs/governance-extras/.apm/skills/new-adr/evals/evals.json
+++ b/packs/governance-extras/.apm/skills/new-adr/evals/evals.json
@@ -4,14 +4,27 @@
     {
       "id": 1,
       "prompt": "Record the architecture decision the user described as a new ADR.",
-      "expected_output": "An ADR created from the template with an H1 that names the problem AND the chosen solution together, and frontmatter filled in (status Proposed, today's date, Decision-makers). The Decision section leads with a single declarative sentence stating the choice (ADR/MADR layout puts Context before the Decision, so 'at the top' means leading its own section, not the document); Context lists the actual constraints driving the choice; Consequences include honest negatives (what is given up), not only upsides; at least one viable alternative is recorded, each rejected against a stated reason. The record is for a decision already made or formally proposed (not an open debate — that would be an RFC), and there is a concrete tradeoff (more than one option was viable). After Accepted the body is immutable — a reversal is a new superseding ADR, never an edit.",
+      "expected_output": "An ADR created from the template with an H1 that names the problem AND the chosen solution together — kept short, identifying the decision without encoding the whole rationale — and frontmatter filled in (status Proposed, today's date, Decision-makers) and kept pointer-like (Consulted/Related are short reference lists, not prose). The Decision section leads with a single declarative sentence stating the choice (ADR/MADR layout puts Context before the Decision, so 'at the top' means leading its own section, not the document); Context lists the actual constraints driving the choice; Consequences include honest negatives (what is given up), not only upsides; at least one viable alternative is recorded, each rejected against a stated reason. The record is for a decision already made or formally proposed (not an open debate — that would be an RFC), there is a concrete tradeoff (more than one option was viable), and it is one decision wide (not three-plus load-bearing sub-decisions packed into one ADR — that would be an umbrella RFC spawning smaller ADRs). After Accepted the body is immutable — a reversal is a new superseding ADR, never an edit.",
       "assertions": [
         "The Decision is stated as a single declarative sentence leading the Decision section",
         "Context lists the actual constraints driving the choice, not hand-wavy filler",
         "Consequences include honest negatives (what is given up), not only upsides",
         "At least one viable alternative is recorded, each rejected with a stated reason",
         "Records a decision already made or formally proposed — not an open-ended debate (which would be an RFC)",
-        "Frontmatter is filled (status, date, Decision-makers) and the H1 names the problem and the chosen solution together"
+        "Frontmatter is filled (status, date, Decision-makers) and the H1 names the problem and the chosen solution together — kept short, identifying the decision without encoding the whole rationale",
+        "Frontmatter metadata (Consulted, Related) is pointer-like — short lists of handles and ADR/RFC/spec references, not prose; any explanation lives in Context or References",
+        "The record is one decision wide — not three or more load-bearing sub-decisions packed into a single ADR (that would be an umbrella RFC spawning smaller ADRs)"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "The user dumps a tangled decision to record as an ADR — rationale, history, and several load-bearing sub-decisions in one breath (e.g. 'record that we'll move to event sourcing, AND switch the message bus to Kafka, AND adopt CQRS for the read side — here's the whole backstory and the three options we weighed for each').",
+      "expected_output": "Before drafting, the skill isolates the decision rather than transcribing the dump. Because the request packs three or more load-bearing sub-decisions, the skill pushes back per the one-decision-wide check — asking whether this is really one decision or an umbrella that should be an RFC spawning several smaller ADRs (the RFC carries the debate; each ADR records one durable outcome). For a genuinely single-but-tangled decision, the skill instead reflects back a short decision frame (the decision in one sentence, the problem it resolves, the alternatives, the winning driver, the tradeoff, any prior ADR amended) and confirms it before writing — it does not silently absorb the rationale and history into a dense title or a prose metadata block. The offer-don't-force shape holds: a half-shaped decision is normal input, not a questionnaire to complete.",
+      "assertions": [
+        "Pushes back on packing three or more load-bearing sub-decisions into one ADR, pointing at an umbrella RFC that spawns smaller ADRs",
+        "Reflects back a short decision frame (decision sentence, problem, alternatives, winning driver, tradeoff, prior ADR) before drafting, rather than transcribing the dump verbatim",
+        "Does not absorb the rationale/history into an over-long title or a prose Consulted/Related metadata block",
+        "Frames by offering, not by forcing a fixed questionnaire — a half-shaped decision is accepted as normal input"
       ]
     }
   ]


### PR DESCRIPTION
## What & why

**Track 1** of the `new-adr` skill critique (*"good but under-guided"*): guidance-prose + behavioral-eval refinements that help the author **isolate the decision before drafting** and keep the record lean. No ADR template format change — the format-changing recommendations (a first-screen Decision-summary block, a structured `Revisit if:` field, a Confirmation Mode/Signal/Owner sub-structure) are **deferred to a track-2 RFC**, because ADR-0027 froze the format as "MADR-aligned but lean" and that decision is RFC-owned.

| Rec | Change |
| --- | --- |
| R1 | A "frame the decision before drafting" step that **offers, doesn't force** — infers the frame when the decision is crisp, walks a short decision frame when the request arrives tangled. Mirrors `new-rfc`'s established guided-intake shape (not the critique's rigid 7-question form). |
| R3 | Stronger title discipline — the title *identifies* the decision, it doesn't encode the whole rationale (detail → Decision section). |
| R4 | A one-decision-wide push-back routing 3+ load-bearing sub-decisions to an umbrella RFC spawning smaller ADRs. |
| R5 | Pointer-like metadata — `Consulted`/`Related` are short reference lists, not prose. |
| R8 | `evals.json` (already behavioral) extended with matching assertions, plus a new tangled-multi-decision eval case so the new guidance has an assertion that fails if it's removed. |

Also: synced the repo-owned how-to guide for the changed behaviors, added a changelog `[Unreleased]` entry (gov-extras 0.4.0), regenerated `.claude/`+`.agents/` projections via `build-self`.

## How verified

`make build-self` (clean tree, projections match source byte-for-byte), `lint-packs` (0), `tools/lint-agent-artifacts.py` (passed), eval JSON validates, `lint-spec-status.py` (0 hard violations). Light-mode `adversarial-reviewer` pass: no Blockers; its one Concern (evals only rode the happy-path prompt) and spec-status nit both fixed.

## Anything tricky

- **Mode call:** light. No risk trigger cleanly fires — this changes a tool's *guidance prose + assertions*, not the governance rules or the frozen ADR format. The parts that *would* trip the governance/interface triggers were deliberately split into track 2.
- **No version bump:** gov-extras 0.4.0 is unreleased (already in `[Unreleased]`), so track 1 rides it.

## Follow-ups

- **Track 2 RFC** (R2/R6/R7) — amends RFC-0038; not in this PR.

Spec: `docs/specs/new-adr-decision-capture/spec.md`