### PR TITLE
docs(rfc): retrofit open RFC cluster + ADR-0038 to current templates

### DIFF
--- a/docs/adr/0038-rename-design-craft-pack-to-experience.md
+++ b/docs/adr/0038-rename-design-craft-pack-to-experience.md
@@ -6,6 +6,14 @@
 - **Supersedes:** none
 - **Related:** RFC-0048 Decision 3 (adopted the rename at the foundation level), RFC-0050 (the `experience`-pack child RFC that models it), RFC-0033 + ADR-0024 (created the `design-craft` pack and its posture — **frozen, bridged here**), RFC-0047 § Errata 2026-06-25 (the `infra-contract-acquisition → contract-acquisition` skill rename — the precedent this follows), `docs/specs/design-craft-pack/` (Shipped — **frozen, bridged here**)
 
+## Decision summary
+
+- **Decision:** We will rename the `design-craft` pack to `experience` — renaming the live surface and bridging frozen governance, with no install-time alias.
+- **Because:** "experience" names the whole seat (flow + service + screen + taste + words) better than "design-craft", and the pre-stable, user-scope window makes the rename cheap now.
+- **Applies to:** the pack *identity* (name + the live surfaces that carry it); the pack's posture (ADR-0024 agnosticism + all-skills-zero-agents) is unchanged.
+- **Tradeoff accepted:** adopters with an installed `design-craft` must uninstall and reinstall as `experience` (no alias), and the name appears in two forms across the repo (frozen-historical vs. live).
+- **Revisit if:** a pack-alias mechanism is ever designed (deferred, RFC-0048 OQ) — a future rename could then smooth the install tail (this rename does not wait for it).
+
 ## Context
 
 The `design-craft` pack (RFC-0033, ADR-0024) ships four framework-agnostic
@@ -102,17 +110,13 @@ all-skills-zero-agents commitments carry forward to `experience` verbatim.
 - `design-craft` now appears in two namings across the repo (frozen-historical
   vs. live), a small ongoing legibility cost the bridge note carries.
 
-**Neutral / to revisit:**
-- If a pack-alias mechanism is ever designed (deferred, RFC-0048 OQ), a future
-  rename could smooth the install tail — but this rename does not wait for it.
+**Revisit if:** a pack-alias mechanism is ever designed (deferred, RFC-0048 OQ) — a future rename could then smooth the install tail (this rename does not wait for it).
 
 ## Confirmation
 
-- The implementing spec (`docs/specs/experience-pack/`) and CI manifest/lint
-  gates confirm the live surface carries `experience` consistently (pack dir,
-  manifests, marketplace aggregation, guides, cross-links) and that no live
-  surface still names `design-craft`.
-- A `docs/product/changelog.md` entry records the user-visible rename.
+- **Mode:** lint/CI.
+- **Signal:** the implementing spec (`docs/specs/experience-pack/`) and the CI manifest/lint gates confirm the live surface carries `experience` consistently (pack dir, manifests, marketplace aggregation, guides, cross-links) and that no live surface still names `design-craft`; a `docs/product/changelog.md` entry records the user-visible rename.
+- **Owner:** RFC-0050's implementing-spec owner (the `experience-pack` spec + its CI gates).
 
 ## Alternatives considered
 

--- a/docs/rfc/0048-autonomous-product-team-operating-model.md
+++ b/docs/rfc/0048-autonomous-product-team-operating-model.md
@@ -21,7 +21,21 @@
 - **Approver:** eugenelim
 - **Date opened:** 2026-06-25
 - **Date closed:**
+- **Decision weight:** heavy <!-- light | standard | heavy — sets catalogue-wide product-team doctrine, edits CONVENTIONS + work-loop, names a multi-RFC roadmap, and carries a rename + migration tail; a one-way-ish foundation, so explicit Approver sign-off and the named acceptance blockers gate it. -->
 - **Related:** RFC-0043 (product rung — the `product-vision`/`product-strategy` altitudes this model's G0/G1 build on) · RFC-0030 (the `product-engineering` pack) · RFC-0041 (infra-aware `work-loop` — the *doctrine + reference-library + reuse-existing-reviewer, no new runtime* precedent this RFC mirrors) · RFC-0025 (`work-loop` light/full mode + risk triggers — the gate model this extends) · RFC-0019 (`receive-brief` — the brief→spec join, and its coverage-lint the traceability lint generalizes) · ADR-0019 (intent ontology) · `design-craft` pack (renamed by a follow-on ADR) · promoted research in [`0048-notes/`](0048-notes/)
+
+## Reviewer brief
+
+- **Decision:** whether to adopt an operating model that lets the catalogue act as an autonomous product team from vision → deploy-ready code, delivered as doctrine + pure-markdown skills + reference libraries (no new runtime), plus the child-effort roadmap that builds it.
+- **Recommended outcome:** accept — Open → Accepted once the named acceptance blockers land.
+- **Change if accepted:**
+  - Adopt the two-regime gate ladder (G0–G5) + surfacing predicate + three-act human boundary as `work-loop` / CONVENTIONS doctrine.
+  - Add four primitives — the `experience` pack (rename + connective UX skills), `frame-domain`, the self-coverage gate, the traceability lint — plus the `discovery-lead` agent + `discovery-loop` skill.
+  - Spike (not build) the coordinator on the `omnigent` harness behind a carried sidecar-schema contract.
+- **Affected surface:** CONVENTIONS (the operating model), `work-loop` doctrine, the `experience` / `product-engineering` / `core` packs, four new skills + a user-scope discovery reviewer roster; **no runtime / daemon / service**.
+- **Stakes:** costly-to-reverse — it sets catalogue-wide product-team doctrine and a multi-RFC roadmap, and the rename + CONVENTIONS edits carry a migration tail; acceptance is gated by named blockers, not a single one-way door.
+- **Review focus:** (1) the human-gate boundary is exactly the three irreducible acts and nothing substitutable leaks across it; (2) the no-runtime claim holds for every *delivered* artifact (the coordinator is spiked, not built).
+- **Not in scope:** a new orchestration runtime / daemon / service; building the coordinator here; the G4→G5 release/deploy loop + G5 ship mechanics ([RFC-0049](0049-the-release-loop-and-company-os.md)); PMM / go-to-market seats; a 1:1 agent-per-role org chart; pixel/Figma comps; between-gate autonomy for regulated / high-assurance work.
 
 ## The ask
 
@@ -50,141 +64,20 @@ can the catalogue become an autonomous product team without violating Principle 
 
 **Decisions requested.**
 
-1. **Adopt the operating model as doctrine** — the two regimes (generative upstream =
-   human-ratified; verifiable downstream = agent-autonomous), the judgment
-   decomposition → equipping map, and the **gate placement (G0–G5) + surfacing
-   predicate**. The **human boundary is three irreducible acts** — originate value ·
-   accept irreversible risk · **adjudicate genuine value conflicts** (people, not facts,
-   disagree, and no referent settles it); the predicate gains a condition for the third,
-   protected by a **conflict artifact** (reuse `identify-perspectives`' tension map).
-   **Human-gate density scales with stakes:** low/moderate-stakes work right-sizes
-   *down* (light), regulated/safety-critical right-sizes *up* (more gates; audit trail
-   and compliance grounding become first-class) — autonomy between gates is a
-   low/moderate-stakes claim, not universal. The gate ladder's *rejection/recovery
-   transitions and outer iteration cap* (O11/O12) are **resolved on paper** (note 09) and
-   the Decision-7 spike confirms them empirically. · *why:* it is the spine every child
-   effort hangs from. · decide-by: RFC accept · default: adopt (placement + predicate +
-   three-act boundary + stakes-density; O11/O12 resolved on paper, spike-confirmed).
-2. **Frame D1, D3–D6 as doctrine + pure-markdown skills + reference libraries — no new
-   runtime engine** (the shared claim RFC-0041 and RFC-0043 both support; note this RFC
-   *does* add four new skills, so the borrowed precedent is "no new runtime engine", not
-   RFC-0043's stricter "no new skill"). The build loop (`work-loop`, G4) **reuses the
-   existing code reviewers**; the *discovery* design-time reviewers are a separate matter —
-   discovery ships its **own distinct-named, user-scope design-time reviewers** rather than
-   overloading `core`'s code `security-reviewer` / `quality-engineer` with a mode (a
-   user-scope and a repo-scope agent sharing a name is a resolution footgun), and they
-   **detect-and-degrade** to `core`'s depth libraries when `core` is present — see the
-   **discovery reviewer roster** under D7/D8. This leaves the CHARTER's "three reviewers"
-   ceiling untouched: that ceiling is a `work-loop` / code-review cap, and the discovery
-   roster is loop-scoped and user-scope. The coordinator's no-engine fit is **excepted** —
-   it is the Decision-7 spike, not decided here. · decide-by: RFC accept · default: adopt.
-3. **Grow the design/UX seat:** add `map-journey`, `blueprint-service`,
-   `inventory-screens` (states deferring to the existing handle-all-states floor; **emits
-   a per-screen brief — a self-contained generation unit + references to the shared
-   design contract — so one screen can be generated in isolation while the whole stays
-   coherent**); enhance `aesthetic-direction` (grounded in persona+precedent+standards) and
-   `design-critique` (evidence-grounded taste mode); wire `voice-and-microcopy` to
-   consume the screen inventory. The journey, screen inventory, and `aesthetic-direction`
-   carry a **platform/surface axis** (responsive web · iOS · Android · cross-platform),
-   grounded in platform conventions (HIG / Material / responsive breakpoints / PWA).
-   **Rename `design-craft` → `experience` — adopted** (more recognizable; v0.1.1 ⇒ low
-   migration cost now). No pack-level rename/alias field exists (surfaces and date pinned
-   in § Evidence & prior art → *Source pins for current-state claims*), so
-   migration follows the actual `contract-acquisition` precedent: rename the dirs + a
-   governance erratum, no install-time alias. · *why:* the missing column is the design/UX
-   seat; one pack = one seat, and `experience` names it better than `design-craft`. ·
-   decide-by: RFC accept (records an ADR).
-4. **Add the frame-domain primitive** — one skill producing **two** typed artifacts:
-   **Domain Framing** (real-activity grounding + best practice + naive-failure modes,
-   produced via `research` applied mode; for **brownfield** a **current-system half**
-   reverse-engineered from code/docs via `decision-archaeology` + architecture
-   extraction alongside the real-world-activity half, plus *reverse* traceability
-   code→artifacts) and **Scope Boundary** (the MVP/appetite **out-of-scope register**,
-   the upstream scope-creep guard the brief inherits/refines at G3). · *why:* the
-   single biggest correctness lever against domain-hallucination and over-scoping. ·
-   decide-by: RFC accept · default: adopt. (Split into two artifacts — § Amendments
-   2026-06-26.)
-5. **Add the self-coverage gate** — its content (domain-grounding table · pre-mortem ·
-   taxonomy walk · saturation declaration · fresh-context adversarial · a
-   **scenario-variation** step that re-runs the design against a varied domain /
-   stakes-level / scale / platform / harness — orthogonal-axis modelling, so the gate
-   catches stakes- and conflict-class gaps without the human · a **resolve-vs-surface
-   pass** over every open item — solve referent-groundable items, surface only
-   value/scope/conflict — calibrated by a **living sample-bank** that every effort in the
-   series appends to, refining the loop's self-thought across situations
-   ([`0048-notes/09`](0048-notes/09-gap-resolutions.md))), consumed by `work-loop`,
-   **no new reviewer**. **Packaging resolved: a reference library + doctrine (the
-   `operational-safety` shape) in `core`, loaded by both loop controllers, right-sized
-   light/full — *not* a self-discovered skill**, because the gate must be non-skippable
-   (a self-discovered skill could be skipped at the agent's discretion, defeating it); the
-   sample-bank graduates into this library. · *why:* fixes the knowing-doing gap that lets
-   errors compound between human gates. · decide-by: RFC accept · default: adopt.
-6. **Add the traceability lint** — a tool that detects *structural* orphans (a node
-   with no producer or consumer along the chain), generalizing `receive-brief`'s
-   coverage lint. *Semantic* scope-creep detection (a node wrongly parented to an
-   in-appetite outcome) is **not** mechanizable by this lint and is deferred to the
-   coordinator spike (O10); MVP scope stays a human call at G1.5. · *why:*
-   mechanizes the chain's structural integrity. · decide-by: RFC accept · default:
-   adopt.
-7. **Adopt `omnigent` as the harness (temporarily) and run a *sidecar + chief-loop*
-   validation — not a from-scratch coordinator build.** `omnigent` (DAIS 2026) already
-   provides the runner/server harness, gates-outside-the-prompt, worktree blackboard,
-   YAML agent defs, and cross-vendor review (this feature set is pinned to its source and
-   date — and flagged unverified-against-a-pinned-commit — in § Evidence & prior art → *Source pins
-   for current-state claims*) — so "can a harness exist / is the no-engine
-   framing real" is **answered**, and a bespoke harness is **deferred** (build our own
-   one day, optional; the catalogue ships harness-neutral doctrine + skills + the sidecar
-   *schema*, so it runs on omnigent now). What **remains to validate** is exactly what
-   omnigent lacks and this doctrine adds:
-   (a) the **typed state sidecar** — blackboard slots (= the artifact inventory), the
-   **open-questions queue**, the **traceability matrix**, and the **gate-outcome /
-   decision log** — *without which the "everything holds together" claim is an assertion,
-   not a check* (omnigent's worktrees hold artifacts, not the typed convergence state);
-   (b) the **chief shipped as an agent definition + a convergence-loop skill** (the
-   *upstream* supervisor — see Decision 8); (c) the consent-gate **rejection/recovery
-   transitions + outer cap**. These design blockers are now **resolved on paper** in
-   [`0048-notes/09`](0048-notes/09-gap-resolutions.md) (descent, lint, live-lens,
-   saturation, spec-linkage, rejection/recovery, outer cap, the harness seam — each
-   settled by a named referent); the spike's job shrinks to **confirming those
-   resolutions empirically** via a prototype on `omnigent` against the worked example —
-   not a paper design. · *why:* the sidecar is the connectedness verifier. · decide-by:
-   RFC accept · default: sidecar-prototype-first.
-8. **Ship the chief — proposed `discovery-lead` — as an agent + the `discovery-loop`
-   convergence-loop skill, in `product-engineering`** (an *opt-in product capability*, not
-   `core`: unlike `work-loop` it is product-discipline-specific, so it ships in the
-   product pack an adopter chooses, not the universal base). It depends **hard** on
-   product-engineering's own intent skills + the carried sidecar-schema contract + the G3
-   handoff to `work-loop` (schema home revised — § Amendments 2026-06-26), and
-   **optionally** (Tier-1 detect-and-degrade) on `research` / `experience` / `architect`
-   *and on `core`'s reviewers + depth libraries* — so it runs a product-only discovery with
-   just **product-engineering** installed (the schema contract and its design lenses travel
-   with the pack; `core` is an optional depth enhancer, not required), and **lights up into
-   full cross-discipline convergence as more packs are
-   installed**. It is the human-facing **upstream supervisor** (peer of
-   `work-loop` / `implementer`): it runs `discovery-loop` (intents → frame-domain →
-   blackboard → decision brief at consent gates → emits briefs/specs), holds the
-   blackboard in **one reasoning context**, fans
-   out only to disjoint workers, and talks to the human at the consent gates. It is a
-   *peer* of `work-loop`'s supervisor, **not the same loop** — `work-loop` supervises the
-   *downstream* spec→build loop; the chief supervises the *upstream* vision→brief loop;
-   they **hand off at G3 and must not be conflated**. Shipping it as an agent def + skill
-   (like `implementer`) does **not** violate Principle 3 — that constrains shipping a
-   *runtime*, which is the harness, which we do not ship. · *why:* the user-facing
-   orchestrator is content, not infra; the two-loop split keeps each loop honest. ·
-   decide-by: RFC accept · default: adopt (shape confirmed by the Decision-7 prototype).
-9. **Adopt a series-execution standard.** Every subsequent effort in this series — each
-   child RFC, spec, subagent, and skill design — **automatically researches and models
-   its own space as far as it can** (applying the resolve-vs-surface lens: solve
-   referent-groundable items, surface only value/scope/conflict), **vigorously plans and
-   runs its pressure test** (scenario-variation + a fresh-context adversarial pass), and
-   **carries itself through the complete lifecycle** (the `new-rfc` research→de-risk→
-   draft→adversarial→Draft→Open→Accepted→follow-ons gates, or the spec/skill equivalent).
-   Each appends its sample reads to the living sample-bank (`0048-notes/09`), **and
-   reconciles any drift it surfaces back into this foundation RFC** (a tracked amendment) —
-   which is why RFC-0048 stays **Open with acceptance blocked** until the child set is complete
-   and aligned (see the Acceptance note). · *why:* the discipline this RFC was built with
-   becomes the standard the series runs by, not a one-off — and the foundation earns acceptance
-   only by surviving the children. · decide-by: RFC accept · default: adopt.
+| ID | Question | Recommendation | Why | Decide by | Reviewer action |
+| --- | --- | --- | --- | --- | --- |
+| D1 | Adopt the operating model as doctrine — two regimes, the judgment→equipping map, the gate ladder G0–G5 + surfacing predicate, the three-act human boundary, and stakes-scaled gate density? | Adopt (placement + predicate + three-act boundary + stakes-density; O11/O12 resolved on paper, spike-confirmed) | It is the spine every child effort hangs from | RFC accept | Confirm the model + that the human boundary is exactly the three irreducible acts |
+| D2 | Frame D1, D3–D6 as doctrine + pure-markdown skills + reference libraries (no new runtime engine), with the build loop reusing `core`'s code reviewers and discovery shipping its own distinct-named user-scope design-time reviewers? | Adopt (the coordinator's no-engine fit is excepted — it is the Decision-7 spike) | The Accepted RFC-0041/0043 precedent; leaves the CHARTER three-reviewer ceiling untouched | RFC accept | Confirm the no-runtime framing + the loop-scoped discovery reviewer roster |
+| D3 | Grow the design/UX seat (`map-journey`, `blueprint-service`, `inventory-screens` + grounding/taste + voice wiring) and rename `design-craft → experience`? | Adopt; rename adopted (v0.1.1 user-scope ⇒ low migration cost; `contract-acquisition` precedent — rename dirs + a governance erratum, no install-time alias) | The missing column is the design/UX seat, and `experience` names it better | RFC accept (records ADR-0038) | Confirm the seat additions + the rename + its migration path |
+| D4 | Add the `frame-domain` primitive — one skill producing two typed artifacts (Domain Framing + Scope Boundary)? | Adopt (split into two artifacts — § Amendments 2026-06-26) | The single biggest correctness lever against domain-hallucination and over-scoping | RFC accept | Confirm the two-artifact split |
+| D5 | Add the self-coverage gate — a `core` reference library + doctrine, run by both loop controllers, non-skippable, no new reviewer? | Adopt | Fixes the knowing-doing gap that lets errors compound between human gates | RFC accept | Confirm the non-skippable packaging |
+| D6 | Add the traceability lint — structural-orphan detection generalizing `receive-brief`'s coverage lint? | Adopt (semantic scope-creep deferred to the coordinator spike / O10; MVP stays a human call at G1.5) | Mechanizes the chain's structural integrity | RFC accept | Confirm the structural-only scope |
+| D7 | Adopt `omnigent` as the (temporary) harness and run a sidecar + chief-loop validation — a spike, not a from-scratch coordinator build? | Sidecar-prototype-first (validate the typed sidecar, the chief, and consent rejection/recovery + outer cap against the worked example) | The sidecar is the connectedness verifier | RFC accept | Confirm spike-first, not build |
+| D8 | Ship the chief — `discovery-lead` — as an agent + the `discovery-loop` convergence-loop skill, in `product-engineering`? | Adopt (shape confirmed by the Decision-7 prototype) | The user-facing orchestrator is content, not infra; the two-loop split keeps each loop honest | RFC accept | Confirm the agent+skill shape, the `product-engineering` home, and the G3 hand-off to `work-loop` |
+| D9 | Adopt a series-execution standard — each child researches + pressure-tests + carries its full lifecycle + reconciles drift back into this RFC? | Adopt | The discipline this RFC was built with becomes the series standard; the foundation earns acceptance only by surviving its children | RFC accept | Confirm the standard + the reconcile-back-to-RFC-0048 obligation |
+
+*(Detail for each decision cascades under § Proposal — D1, D3–D9 — and the notes it links.)*
+
 *(The release/deploy **outer loop**, the minimum-regret deploy carve, and the
 "company OS" composition are **split into the sibling [RFC-0049](0049-the-release-loop-and-company-os.md)**,
 which cites this RFC as its foundation. RFC-0048 scopes the **discovery + build**

--- a/docs/rfc/0049-the-release-loop-and-company-os.md
+++ b/docs/rfc/0049-the-release-loop-and-company-os.md
@@ -6,7 +6,21 @@
 - **Approver:** eugenelim
 - **Date opened:** 2026-06-25
 - **Date closed:**
+- **Decision weight:** heavy <!-- light | standard | heavy — defines deploy-to-prod autonomy doctrine (an irreversible + security boundary) and adds a new opt-in pack + agent; it reuses existing reviewers and runtime, but the prod / data / spend / irreversible gating is the heavy part, so explicit Approver sign-off is warranted. -->
 - **Related:** [RFC-0048](0048-autonomous-product-team-operating-model.md) (the discovery+build foundation this extends — it details G0–G4; this details G4→G5) · RFC-0041 (infra-aware `work-loop` — whose deploy *flavor* this graduates into a proper outer loop) · RFC-0025 (`work-loop`) · `operational-safety` pack (the reliability/observability reference library this reuses) · omnigent (the harness; ephemeral-env + option-card support) · promoted design in [`0049-notes/`](0049-notes/)
+
+## Reviewer brief
+
+- **Decision:** whether to add a deployed e2e-validation **release loop** (the outer loop) above `work-loop`'s inner build loop, carve deploy autonomy by minimum-regret, and add a `release-lead` SRE/ops seat — completing the product → engineering → SRE "company OS".
+- **Recommended outcome:** accept.
+- **Change if accepted:**
+  - Split the loop into **inner** (`work-loop`, local with local-infra-equivalents) and **outer** (`release-loop`, ephemeral deploy + e2e + iterate-to-converge).
+  - Add a `release-lead` agent + `release-loop` skill in a new opt-in `release-engineering` pack, reusing `operational-safety` + `quality-engineer` + `security-reviewer` + the RFC-0053 sidecar — **no new runtime, no new reviewer**.
+  - Carve autonomy by **minimum-regret**: agents run inner + outer loops on ephemeral envs unwatched; humans gate prod / data / spend / security / irreversible (G5).
+- **Affected surface:** a new `release-engineering` pack + agent + skill; CONVENTIONS (the inner/outer split + the minimum-regret deploy carve); reuse of `core`'s operational/security reviewers + the RFC-0053 sidecar; the `omnigent` harness (ephemeral envs).
+- **Stakes:** costly-to-reverse — it sets deploy-to-prod autonomy doctrine (an irreversible + security boundary); the prod-ship step itself stays human-gated, so the irreversible move is bounded.
+- **Review focus:** (1) the minimum-regret carve draws the agent/human line correctly (reversible ⇒ autonomous on ephemeral; irreversible ⇒ human); (2) the no-new-runtime / no-new-reviewer claim holds for the release loop.
+- **Not in scope:** building the harness; the exact `release-lead` agent shape (OQ2 — resolved by the child spec; the pack home, OQ1, already resolves to a new `release-engineering` pack); RFC-0048's G0–G4 discovery+build foundation (this is its G4→G5 extension).
 
 ## The ask
 
@@ -32,30 +46,14 @@ iterate-until-converge — so the human becomes the relay for deployed findings.
 *Question:* how far into deploy + e2e can agents go autonomously, with minimum regret?
 
 **Decisions requested.**
-1. **Adopt the inner/outer split.** `work-loop` = inner (local, with local-infra-
-   equivalents); a new **`release-loop`** = outer (ephemeral deploy + e2e + iterate).
-   · decide-by: RFC accept · default: adopt.
-2. **The minimum-regret carve.** Autonomous on the inner loop **and the outer loop on
-   ephemeral envs** (deploy / e2e / iterate / teardown + canary with auto-rollback);
-   **human-gated** at first real users/data, data migrations, spend over threshold,
-   security boundaries, anything irreversible, and prod ship (G5). The unlock is the
-   **reversibility primitives** — ephemeral envs + feature flags + auto-rollback. ·
-   decide-by: RFC accept · default: adopt.
-3. **Local-infra-equivalents as a build-loop obligation.** Packs/skills produce the
-   fidelity ladder — fakes → contract tests (Pact) → Testcontainers → LocalStack →
-   docker-compose — so software runs and verifies locally before deploy. · decide-by:
-   RFC accept · default: adopt.
-4. **Ship `release-lead`** (the outer-loop supervisor / SRE-ops seat) as an agent +
-   a `release-loop` skill, reusing `operational-safety` + `quality-engineer` +
-   RFC-0041. Its **pack home and exact agent shape** (distinct agent vs a `work-loop`
-   outer-mode) are OQ1/OQ2. · decide-by: RFC accept (the seat) · default: adopt.
-5. **The company-OS composition.** Three loop-teams — product (discovery) → engineering
-   (build) → SRE/ops (release) — on RFC-0048's shared substrate (sidecar + gate arc +
-   harness); leads hand off at G3 (brief→spec), at deploy (work→release), and at G5
-   (release→prod). · decide-by: RFC accept · default: adopt.
-6. **Convergence by policy.** Promotion is judged by automated policy (canary metric
-   analysis + e2e coverage of the changed surface + flake < 2%) up to the irreversible
-   human gate; **DORA** is the health signal. · decide-by: RFC accept · default: adopt.
+| ID | Question | Recommendation | Why | Decide by | Reviewer action |
+| --- | --- | --- | --- | --- | --- |
+| D1 | Adopt the inner/outer split — `work-loop` = inner (local, with local-infra-equivalents); a new `release-loop` = outer (ephemeral deploy + e2e + iterate)? | Adopt | The inner loop can't surface deployed-only failures; the outer loop iterates the deployed whole to convergence | RFC accept | Confirm the inner/outer split |
+| D2 | Adopt the minimum-regret carve — autonomous on the inner loop and the outer loop on ephemeral envs; human-gated at first real users/data, migrations, spend over threshold, security, anything irreversible, and prod ship (G5)? | Adopt | The reversibility primitives (ephemeral envs + feature flags + auto-rollback) make unwatched autonomy safe up to the irreversible line | RFC accept | Confirm where the carve draws the agent/human line |
+| D3 | Make local-infra-equivalents a build-loop obligation — the fidelity ladder (fakes → contract tests → Testcontainers → LocalStack → docker-compose)? | Adopt | Software must run and verify locally before deploy, so the inner loop is self-sufficient | RFC accept | Confirm the obligation + the ladder |
+| D4 | Ship `release-lead` (the outer-loop / SRE-ops seat) as an agent + a `release-loop` skill, reusing `operational-safety` + `quality-engineer` + RFC-0041? | Adopt | A reuse-not-rebuild seat; no new runtime, no new reviewer | RFC accept (the seat) | Confirm the seat; pack home (OQ1) resolves to a new `release-engineering` pack, exact agent shape is OQ2 |
+| D5 | Adopt the company-OS composition — three loop-teams (discovery → build → release) on RFC-0048's shared substrate, handing off at G3, at deploy, and at G5? | Adopt | Completes the autonomous product team end to end on one substrate | RFC accept | Confirm the three-team composition + the hand-offs |
+| D6 | Adopt convergence by policy — promotion judged by automated policy (canary analysis + e2e coverage of the changed surface + flake < 2%) up to the irreversible human gate, with DORA as the health signal? | Adopt | Makes outer-loop promotion a checkable policy, not a human relay | RFC accept | Confirm the promotion policy + DORA as the signal |
 
 ## Problem & goals
 

--- a/docs/rfc/0050-the-experience-pack.md
+++ b/docs/rfc/0050-the-experience-pack.md
@@ -5,7 +5,21 @@
 - **Approver:** eugenelim
 - **Date opened:** 2026-06-25
 - **Date closed:**
+- **Decision weight:** standard <!-- light | standard | heavy — additive and reversible: pure-markdown skills, zero new agents, user-scope v0.1.1; it renames a published pack (a small migration tail, no install-time alias) and records ADR-0038, but reverses no frozen decision and crosses no security boundary. -->
 - **Related:** **RFC-0048** (the autonomous product-team operating model — this is its child-1, the `experience`-pack effort; Decision 3 adopted everything below at the foundation level, this RFC *models it out*) · RFC-0033 (`design-craft` pack — the pack being renamed and grown; **frozen, bridged by ADR-0038**) · ADR-0024 (`design-craft` agnosticism + all-skills-zero-agents posture — **frozen, bridged by ADR-0038**) · RFC-0047 § Errata 2026-06-25 (the *actual* `infra-contract-acquisition → contract-acquisition` rename — the dirs+erratum, no-alias precedent this migration follows) · RFC-0040 / ADR-0030 (`agentbundle-layout.toml` path-resolution contract) · RFC-0037 / ADR-0028 (pack-activation-evals) · RFC-0030 (`product-engineering` — `voice-and-microcopy`'s home) · RFC-0032 / ADR-0023 (the `design-reviewer` subagent + the "three reviewers is a code-review ceiling" reading) · RFC-0004 (install-scope-per-pack, Rail A) · promoted research in [`0048-notes/04`](0048-notes/04-artifact-inventory.md), [`/06`](0048-notes/06-pack-delta-and-orchestration.md), [`/07`](0048-notes/07-screen-brief-format.md), [`/09`](0048-notes/09-gap-resolutions.md)
+
+## Reviewer brief
+
+- **Decision:** whether to grow the design/UX seat into the **`experience` pack** — rename `design-craft → experience`, add three connective UX skills, ground taste, and wire `voice-and-microcopy` — all pure-markdown, zero new agents.
+- **Recommended outcome:** accept.
+- **Change if accepted:**
+  - Rename `design-craft → experience` (dirs + `name` + manifests + cross-links + guides dir + layout key); **no install-time alias**; frozen governance bridged by ADR-0038.
+  - Add `map-journey`, `blueprint-service`, `inventory-screens` (connective, platform/surface axis, per-screen briefs); ground `aesthetic-direction` + add a taste mode to `design-critique`.
+  - Wire `voice-and-microcopy` (staying in `product-engineering`) to the screen inventory; add an `[experience]` layout table (default `parent = "docs/design"`).
+- **Affected surface:** the `design-craft` → `experience` pack (rename + 3 new skills + 2 enhanced); `product-engineering` (the `voice-and-microcopy` cross-link); `agentbundle-layout.toml`; records ADR-0038; frozen RFC-0033 / ADR-0024 bridged.
+- **Stakes:** reversible — pure-markdown, user-scope v0.1.1; the rename's small migration tail (no install-time alias) is revertible before acceptance.
+- **Review focus:** (1) the additions preserve `design-craft`'s two guardrails — stack-neutrality (no values tables) and all-skills-zero-agents (ADR-0024); (2) the rename's no-alias migration is complete and bridges frozen governance.
+- **Not in scope:** a new reviewer agent (`design-critique` stays an interactive skill; the live-lens reviewer is `core` / `architect`'s seat); pixel/Figma comps; re-opening RFC-0048 Decision 3 (this models it).
 
 ## The ask
 
@@ -15,12 +29,14 @@
 
 **Decisions requested.**
 
-1. **Rename `design-craft → experience`.** Migrate via the **`contract-acquisition` precedent** (RFC-0047 § Errata): rename the dirs + `name` + manifests + cross-links + the guides dir + the layout key; **no install-time alias** (none exists, grep-confirmed by RFC-0048); frozen governance (RFC-0033, ADR-0024, the Shipped `design-craft-pack` spec, README index rows) keeps `design-craft` as historical record, **bridged by ADR-0038**. · *why:* `experience` names the seat better than `design-craft`, and v0.1.1 user-scope keeps migration cheap. · decide-by: RFC accept (records **ADR-0038**).
-2. **Add three connective skills** — `map-journey`, `blueprint-service`, `inventory-screens` — pure-markdown, no new agents, framework-agnostic intent specs. Each carries the **platform/surface axis** where it applies; `inventory-screens` **emits one per-screen brief per screen**. · decide-by: RFC accept.
-3. **Carry the platform/surface axis** (responsive web · iOS · Android · cross-platform) on `map-journey`, `inventory-screens`, and `aesthetic-direction`, grounded in **platform conventions** (HIG / Material 3 / responsive breakpoints / PWA) — *pointed to, never reprinted* (the stack-neutral guardrail holds). · decide-by: RFC accept.
-4. **Ground `aesthetic-direction`** in persona + precedent + standards + platform conventions (a stable taste referent), and **add a taste mode to `design-critique`** (evidence-grounded critique against that referent + platform fit). `design-critique` stays an **interactive skill, not a reviewer agent** — the live-lens reviewer (RFC-0048 O5) is `core`/`architect`'s seat, out of this RFC. · decide-by: RFC accept.
-5. **Wire `voice-and-microcopy`** (resident in `product-engineering`) to consume the screen inventory's per-screen state matrix (closes RFC-0048 GAP-C1), and cross-link the two packs. · decide-by: RFC accept.
-6. **Resolve artifact paths config → default → discover-by-marker** (never hardcoded): a new `[experience]` table in `agentbundle-layout.toml` (default `parent = "docs/design"`), mirroring `product-engineering`'s pattern (RFC-0040). · decide-by: RFC accept.
+| ID | Question | Recommendation | Why | Decide by | Reviewer action |
+| --- | --- | --- | --- | --- | --- |
+| D1 | Rename `design-craft → experience` via the `contract-acquisition` precedent (rename dirs + manifests + cross-links + layout key; no install-time alias; frozen governance bridged by ADR-0038)? | Adopt | `experience` names the seat better, and v0.1.1 user-scope keeps migration cheap | RFC accept (records ADR-0038) | Confirm the rename + the no-alias migration path |
+| D2 | Add three connective skills — `map-journey`, `blueprint-service`, `inventory-screens` (pure-markdown, no new agents; `inventory-screens` emits one per-screen brief per screen)? | Adopt | They are the missing connective layer (outcome → journey → screen → backing service) | RFC accept | Confirm the three skills + the per-screen brief |
+| D3 | Carry the platform/surface axis (responsive web · iOS · Android · cross-platform) on `map-journey`, `inventory-screens`, and `aesthetic-direction`, grounded in platform conventions — pointed to, never reprinted? | Adopt | Platform fit matters without violating the stack-neutral guardrail | RFC accept | Confirm the axis stays pointed-to, not reprinted |
+| D4 | Ground `aesthetic-direction` in persona + precedent + standards + platform conventions, and add a taste mode to `design-critique` (which stays an interactive skill, not a reviewer agent)? | Adopt | A stable taste referent enables evidence-grounded critique without adding a reviewer | RFC accept | Confirm the grounding + that `design-critique` stays a skill |
+| D5 | Wire `voice-and-microcopy` (resident in `product-engineering`) to the screen inventory's per-screen state matrix, and cross-link the two packs? | Adopt | Closes RFC-0048 GAP-C1 — copy currently ties to no screen list | RFC accept | Confirm the cross-pack wiring |
+| D6 | Resolve artifact paths config → default → discover-by-marker via a new `[experience]` table in `agentbundle-layout.toml` (default `parent = "docs/design"`)? | Adopt | Never hardcode paths; mirror `product-engineering`'s RFC-0040 pattern | RFC accept | Confirm the layout table + default |
 
 *Default if no objection: adopt all six. Each is already decided at the foundation level by RFC-0048 Decision 3; this RFC's job is to model them, pressure-test them, and reconcile any drift back into RFC-0048 (the series-execution standard, RFC-0048 Decision 9).*
 

--- a/docs/rfc/0051-the-self-coverage-gate.md
+++ b/docs/rfc/0051-the-self-coverage-gate.md
@@ -5,7 +5,21 @@
 - **Approver:** eugenelim
 - **Date opened:** 2026-06-25
 - **Date closed:**
+- **Decision weight:** standard <!-- light | standard | heavy — an additive `core` reference library + loop doctrine; no new runtime, no new reviewer. It adds one refusal item to `work-loop`'s done-checklist (an additive doctrine change, not a checklist rewrite) and reverses no frozen decision, so it sits below the governance-boundary line — the same standard-weight framing the analogous additive RFC-0055 convention used. -->
 - **Related:** [RFC-0048](0048-autonomous-product-team-operating-model.md) (the foundation — this is **child 3**, Decision 5; the provisional foundation this drift-aligns back to) · [RFC-0041](0041-infra-aware-work-loop.md) + ADR-0031 (the `operational-safety` reference-library + reuse-the-reviewer precedent this RFC mirrors exactly — *no new runtime, no new reviewer*) · RFC-0025 (`work-loop` light/full mode + risk triggers — the right-sizing model this reuses) · `operational-safety` + `security-checklists` skills (the controller-loaded progressive-disclosure shape) · `work-loop` skill (the consuming controller; PLAN trio + declined-pattern register + REVIEW adversarial pass + the done-checklist refusal items this gate joins) · RFC-0048 D8 (`discovery-loop` / `discovery-lead` — the *second* controller, not built yet) · promoted research in RFC-0048's [`0048-notes/03`](0048-notes/03-autonomy-and-gate-economics.md) (the floor-raiser table) and [`0048-notes/09`](0048-notes/09-gap-resolutions.md) (the resolve-vs-surface sample-bank this graduates)
+
+## Reviewer brief
+
+- **Decision:** whether to build the self-coverage gate as a `core` reference library + loop doctrine — a non-skippable coverage phase both loop controllers run — with no new runtime and no new reviewer.
+- **Recommended outcome:** accept.
+- **Change if accepted:**
+  - Add a `core` skill holding seven step-modules + a living sample-bank (the `operational-safety` shape), controller-loaded.
+  - Make it **non-skippable** via a controller-gate + a done/converged-checklist refusal (doctrine + a mechanical coverage record), not a runtime lock.
+  - `work-loop` is the first consumer; `discovery-loop` becomes the second when RFC-0048 D8 ships; right-size light/full mirroring `work-loop`.
+- **Affected surface:** a new `core` reference-library skill + its seven `references/<step>.md` modules; `work-loop` SKILL.md (the gate phase + a checklist-refusal item); reuse of `adversarial-reviewer` / `devils-advocate`; the sample-bank graduating from `0048-notes/09`.
+- **Stakes:** reversible — additive doctrine + a reference library; no runtime, no new reviewer; degrades to the prior done-checklist if reverted.
+- **Review focus:** (1) the non-skippable mechanism is genuinely non-skippable yet harness-neutral (controller-gate + checklist-refusal, never a self-discovered skill); (2) light/full right-sizing reuses RFC-0025 rather than inventing a second knob.
+- **Not in scope:** a fourth reviewer agent; a runtime lock; semantic scope-creep detection (RFC-0048 D6 / O10).
 
 ## The ask
 
@@ -34,43 +48,14 @@ lock and without a fourth reviewer?
 
 **Decisions requested.**
 
-1. **Build it as a `core` reference library + loop doctrine, the `operational-safety`
-   shape — never a self-discovered skill.** A skill-packaged `references/<step>.md` set
-   (so depth scales without bloating any prose), whose loading is *controller-driven*. ·
-   *why:* it is the precedent RFC-0048 D5 named and RFC-0041/ADR-0031 already accepted. ·
-   decide-by: RFC accept · default: adopt.
-2. **Make it non-skippable by the controller-gate + checklist-refusal mechanism, stated
-   honestly as doctrine + a mechanical record, not a runtime lock.** The consuming loop's
-   SKILL.md names the gate a required phase; the done/converged checklist refuses to
-   declare done without the **coverage record** artifact and with any fresh-context finding
-   unresolved — joining the existing refusal items (reviewer-clean, doc-drift invariants)
-   at `work-loop` SKILL.md:675-713. On harnesses that enforce gates outside the prompt
-   (omnigent), the same gate becomes structural; harness-neutrally it is doctrine + the
-   coverage-record check. · *why:* this is the one design question RFC-0048 left to the
-   child, and the honest answer is the same posture `operational-safety` already ships. ·
-   decide-by: RFC accept · default: adopt.
-3. **Decompose into seven step-modules + the living sample-bank**, routed by mode and by
-   the axes the design crosses (not a flat march). · *why:* the operational-safety module
-   shape keeps each step lean and lets light mode load only the core. · decide-by: RFC
-   accept · default: adopt.
-4. **No new reviewer — the fresh-context adversarial step reuses the existing
-   `adversarial-reviewer` (and `devils-advocate` for the research/design case) dispatched
-   in a fresh context.** · *why:* the CHARTER three-reviewer ceiling; the parent's "no new
-   reviewer"; the existing fresh-context dispatch already exists in `work-loop`'s REVIEW. ·
-   decide-by: RFC accept · default: adopt.
-5. **Right-size light/full, mirroring `work-loop`.** Light mode loads the always-on core
-   (domain-grounding + resolve-vs-surface + a single bounded fresh-context pass; a
-   surviving Blocker escalates to full); full mode loads all seven — running
-   scenario-variation across the axes in play and the fresh-context pass iterated to clean.
-   · *why:* the gate must not become ceremony on a one-line change; reuse
-   RFC-0025's right-sizing rather than invent a second knob. · decide-by: RFC accept ·
-   default: adopt.
-6. **Graduate the resolve-vs-surface sample-bank into the library as a living, append-only
-   reference**, seeded from [`0048-notes/09`](0048-notes/09-gap-resolutions.md). Until
-   RFC-0048 is Accepted, appends continue in note 09; on acceptance the bank's durable home
-   is this library. · *why:* the lens hits the right call only ~half the time without an
-   externalized scaffold (note 09); the bank *is* that scaffold, and it applies repo-wide,
-   not just to this RFC. · decide-by: RFC accept · default: adopt.
+| ID | Question | Recommendation | Why | Decide by | Reviewer action |
+| --- | --- | --- | --- | --- | --- |
+| D1 | Build it as a `core` reference library + loop doctrine (the `operational-safety` shape, controller-driven loading) — never a self-discovered skill? | Adopt | The precedent RFC-0048 D5 named and RFC-0041 / ADR-0031 already accepted | RFC accept | Confirm the library + doctrine shape |
+| D2 | Make it non-skippable by a controller-gate + checklist-refusal mechanism — doctrine + a mechanical coverage record, not a runtime lock? | Adopt | The one design question RFC-0048 left to the child; the honest answer is the posture `operational-safety` already ships | RFC accept | Confirm the non-skippable mechanism is genuine yet harness-neutral |
+| D3 | Decompose into seven step-modules + the living sample-bank, routed by mode and the axes the design crosses (not a flat march)? | Adopt | The module shape keeps each step lean and lets light mode load only the core | RFC accept | Confirm the seven-module decomposition |
+| D4 | No new reviewer — the fresh-context adversarial step reuses the existing `adversarial-reviewer` (and `devils-advocate` for research/design) in a fresh context? | Adopt | The CHARTER three-reviewer ceiling; the parent's no-new-reviewer; the dispatch already exists in `work-loop` REVIEW | RFC accept | Confirm no fourth reviewer |
+| D5 | Right-size light/full, mirroring `work-loop` (light loads the always-on core; full loads all seven)? | Adopt | The gate must not become ceremony on a one-line change; reuse RFC-0025 rather than a second knob | RFC accept | Confirm the light/full right-sizing |
+| D6 | Graduate the resolve-vs-surface sample-bank into the library as a living, append-only reference (seeded from `0048-notes/09`)? | Adopt | The lens hits the right call only ~half the time without an externalized scaffold; the bank is that scaffold | RFC accept | Confirm the sample-bank's durable home |
 
 ## Problem & goals
 

--- a/docs/rfc/0053-the-coordinator-contract.md
+++ b/docs/rfc/0053-the-coordinator-contract.md
@@ -5,7 +5,21 @@
 - **Approver:** eugenelim
 - **Date opened:** 2026-06-26
 - **Date closed:**
+- **Decision weight:** heavy <!-- light | standard | heavy — sets the upstream orchestration contract the whole operating model hangs from, ships a new agent + skill + a versioned sidecar schema, and carries a security/integrity + data-classification surface; explicit Approver sign-off is warranted. -->
 - **Related:** [RFC-0048](0048-autonomous-product-team-operating-model.md) (the foundation — this is **child 5**, the coordinator spike→RFC for Decisions 7 + 8; the provisional foundation this drift-aligns back to) · [RFC-0049](0049-the-release-loop-and-company-os.md) (the sibling *downstream* outer loop — `release-lead` + `release-loop`, the same agent-def + skill + harness pattern this RFC establishes upstream; both build on the same RFC-0048 substrate (the sidecar + the gate arc), and this RFC specifies the sidecar schema RFC-0049's release loop would also consume) · [RFC-0051](0051-the-self-coverage-gate.md) (the self-coverage gate — `discovery-loop` is its **second controller**; the gate is `discovery-loop`'s pre-G2 phase, seam specified there, wired here) · [RFC-0050](0050-the-experience-pack.md) (the `experience` lens this loop detect-and-degrades on) · [RFC-0041](0041-infra-aware-work-loop.md) + ADR-0031 (the *doctrine + reference library + reuse, no engine/no new reviewer* precedent the framing rests on) · RFC-0025 (`work-loop` light/full + the iteration cap this loop's outer cap mirrors) · RFC-0040 (the three-tier layout resolution the sidecar paths obey) · RFC-0019 (`receive-brief` — the brief→spec join at G3; its coverage lint child-4's traceability lint generalizes) · [ADR-0022](../adr/0022-value-stream-meta-repo-cross-component-layer.md) (the cross-repo reference-by-version mechanism the traceability slot reuses) · [`docs/specs/traceability-lint/`](../specs/traceability-lint/spec.md) (child-4 — the lint that consumes the traceability slot) · promoted research + the empirical prototype in [`0053-notes/`](0053-notes/); [`0048-notes/09`](0048-notes/09-gap-resolutions.md) (the paper resolutions this spike confirms) and [`0048-notes/02`](0048-notes/02-worked-example-flow-trace.md) (the worked example it was run against)
+
+## Reviewer brief
+
+- **Decision:** whether to adopt the no-engine **coordinator contract** — `discovery-lead` (agent) + `discovery-loop` (skill) + the typed sidecar schema as a carried contract — confirmed by an empirical prototype.
+- **Recommended outcome:** accept.
+- **Change if accepted:**
+  - Ship `discovery-lead` + `discovery-loop` in `product-engineering`, with the sidecar schema (blackboard · open-questions · traceability · decision-log) carried in the producing skill — **no new runtime engine**.
+  - Adopt the gate state machine — consent checkpoint/resume + rejection/recovery with cascade-invalidation along traceability edges — plus an outer round cap + cost budget.
+  - Adopt the solo / lens-team supervisor topology, MAST-safe by construction (lenses bounce through the blackboard, never agent-to-agent).
+- **Affected surface:** `product-engineering` (new agent + skill + the sidecar `references/` schema); the traceability lint + `work-loop` + the release loop (sidecar consumers, by convention + `schema_version`); `omnigent` (the store + gate enforcement); a security/integrity contract.
+- **Stakes:** costly-to-reverse — it sets the upstream orchestration contract the whole operating model hangs from, plus a security/integrity + data-classification surface; demonstrated on one example (residual scale risk named).
+- **Review focus:** (1) the no-engine claim survives — every transition is markdown+JSON edits, not a framework call; (2) the security/integrity + data-handling controls on the sidecar are specified at the right depth (write-authority, append-only decision log, cascade-invalidation circuit-breaker).
+- **Not in scope:** a new runtime engine; homing the schema in `core` (it is carried at user scope — RFC-0048 § Amendments 2026-06-26); a second-example replication run (carried as an implementing-spec validation).
 
 ## The ask
 
@@ -42,43 +56,13 @@ worked example as engine-free content, and what exactly is the harness-neutral c
 
 **Decisions requested.**
 
-1. **Adopt the no-engine coordinator contract — `discovery-lead` (agent) + `discovery-loop`
-   (skill) in `product-engineering`, the sidecar *schema* carried in the `discovery-loop` skill — confirmed by the
-   prototype.** The spike refutes the failure mode (no transition needed a scheduler, bus,
-   or convergence solver); the catalogue ships content + schema, the harness supplies the
-   store and gate enforcement. · *why:* it is the one D7/D8 claim that was hypothesized, now
-   demonstrated; it is the spine every step of the operating model hangs from. · decide-by:
-   RFC accept · default: adopt (spike-confirmed).
-2. **Ship the typed sidecar schema as a carried contract in the producing skill — the connectedness verifier.** (Not `core` — RFC-0048 § Amendments 2026-06-26.) The
-   slots `blackboard` · `open-questions` · `traceability` · `decision-log`, each typed to a
-   named schema, harness-neutral; the **store is the harness's** (omnigent's worktree).
-   Paths resolve config → default → discover-by-marker (RFC-0040), never hardcoded. · *why:*
-   omnigent's worktrees hold artifact *files*; only this typed state makes "everything holds
-   together" *checkable* — and the prototype showed a ~60-line lint over it suffices. ·
-   decide-by: RFC accept · default: adopt.
-3. **Adopt the gate state machine — consent checkpoint/resume (A1/A2) + rejection/recovery
-   with cascade-invalidation (O11).** A consent gate writes the decision brief, sets
-   `status=awaiting-human`, surfaces an option card, records the verdict to the decision
-   log, and resumes. A rejection emits reason→correction, re-enters the gate's phase,
-   **cascade-invalidates downstream blackboard slots by walking the traceability edges**
-   (mark stale, drop their edges), and re-runs only the affected lenses — the edge set
-   *scopes the blast radius*. · *why:* the prototype ran this as a markdown+JSON edit, not a
-   framework call; it is what makes a rejection cheap and bounded. · decide-by: RFC accept ·
-   default: adopt.
-4. **Adopt the outer cap + cost budget (O12).** `discovery-loop` carries an outer round cap
-   and a cost budget (tunable defaults); on cap-with-unconverged-state the loop **does not
-   loop forever** — it writes a stall record and **surfaces to the human** (surfacing
-   predicate clause c). · *why:* the same safety valve `work-loop`'s cap and omnigent's
-   `cost_budget` provide, lifted to the upstream loop; the prototype confirmed the counter
-   is a `meta` field the controller increments, no runtime. · decide-by: RFC accept ·
-   default: adopt (defaults: 12 rounds / a per-initiative cost budget, tunable).
-5. **Adopt the supervisor topology — solo / lens-team right-sizing + a loop-scoped lens
-   roster, MAST-safe by construction.** `discovery-lead` right-sizes between **solo**
-   (switches lenses in one context) and **lens-team** (dispatches parallel lens-agents that
-   bounce off each other *through the blackboard*, never agent-to-agent chat). The discovery
-   roster is **loop-scoped** and distinct from `work-loop`'s three code reviewers. · *why:*
-   the prototype's ripple settled with zero negotiation-to-consensus — the MAST guardrail
-   held by topology, not by limiting the roster. · decide-by: RFC accept · default: adopt.
+| ID | Question | Recommendation | Why | Decide by | Reviewer action |
+| --- | --- | --- | --- | --- | --- |
+| D1 | Adopt the no-engine coordinator contract — `discovery-lead` (agent) + `discovery-loop` (skill) in `product-engineering`, the sidecar schema carried in the skill — confirmed by the prototype? | Adopt (spike-confirmed) | The spike refutes the failure mode (no transition needed a scheduler, bus, or solver); it is the spine the operating model hangs from | RFC accept | Confirm the no-engine contract |
+| D2 | Ship the typed sidecar schema as a carried contract in the producing skill (not `core`) — slots blackboard · open-questions · traceability · decision-log, harness-neutral, store is the harness's? | Adopt | Only this typed state makes "everything holds together" checkable; a ~60-line lint over it suffices | RFC accept | Confirm the schema + carried-not-`core` home |
+| D3 | Adopt the gate state machine — consent checkpoint/resume (A1/A2) + rejection/recovery with cascade-invalidation along traceability edges (O11)? | Adopt | The prototype ran this as a markdown+JSON edit, not a framework call; the edge set scopes the blast radius | RFC accept | Confirm the state machine + cascade-invalidation |
+| D4 | Adopt the outer cap + cost budget (O12) — on cap-with-unconverged-state the loop writes a stall record and surfaces to the human? | Adopt (defaults: 12 rounds / a per-initiative cost budget, tunable) | The `work-loop` cap / omnigent `cost_budget` safety valve lifted to the upstream loop; the counter is a `meta` field, no runtime | RFC accept | Confirm the cap + the stall-and-surface behavior |
+| D5 | Adopt the supervisor topology — solo / lens-team right-sizing + a loop-scoped lens roster, MAST-safe by construction? | Adopt | The prototype's ripple settled with zero negotiation-to-consensus — MAST safety held by topology, not by limiting the roster | RFC accept | Confirm the topology + that it is loop-scoped, distinct from `work-loop`'s code reviewers |
 
 ## Problem & goals
 

--- a/docs/specs/open-rfc-format-retrofit/spec.md
+++ b/docs/specs/open-rfc-format-retrofit/spec.md
@@ -1,6 +1,6 @@
 # Spec: Retrofit the open RFC cluster to the current RFC format
 
-- **Status:** Draft (work complete + reviewer-verified; pending the user's commit/PR decision)
+- **Status:** Shipped
 - **Mode:** full (governance-surface risk trigger — edits the `docs/rfc/` governance corpus)
 - **Author:** eugenelim
 - **Date:** 2026-06-28

--- a/docs/specs/open-rfc-format-retrofit/spec.md
+++ b/docs/specs/open-rfc-format-retrofit/spec.md
@@ -1,0 +1,99 @@
+# Spec: Retrofit the open RFC cluster to the current RFC format
+
+- **Status:** Draft (work complete + reviewer-verified; pending the user's commit/PR decision)
+- **Mode:** full (governance-surface risk trigger — edits the `docs/rfc/` governance corpus)
+- **Author:** eugenelim
+- **Date:** 2026-06-28
+
+## Objective
+
+Bring the five **Open** RFCs authored 2026-06-25/26 — RFC-0048, RFC-0049,
+RFC-0050, RFC-0051, RFC-0053 — up to the RFC template format that landed
+**after** they were written (commits `ee54a5d1`, `bd84d0d4`, `f924dab5`, all
+2026-06-27/28), so they are as scannable for a reviewer as the RFCs authored
+under the new template (RFC-0054/0055/0056). This is a **meaning-preserving
+readability retrofit**, explicitly sanctioned by RFC-0055 D5 ("open-RFC retrofit
+is handled separately").
+
+The three format additions per RFC:
+
+1. **`Decision weight` header field** (`light | standard | heavy` + a one-line
+   rationale comment), inserted before `- **Related:**`.
+2. **`## Reviewer brief` section** — the fixed scannable grid (Decision /
+   Recommended outcome / Change if accepted / Affected surface / Stakes / Review
+   focus / Not in scope), inserted before `## The ask`.
+3. **`Decisions requested` → table form** (`| ID | Question | Recommendation |
+   Why | Decide by | Reviewer action |`), replacing the numbered list while the
+   cascading per-decision detail stays in `## Proposal`.
+
+Then verify, via the work-loop's reviewers, that each retrofit preserved meaning
+and that the RFCs remain internally consistent with each other and with the
+specs/plans already created (frame-domain, traceability-lint, release-loop). Fix
+any genuine gap in those underlying specs/plans that the review surfaces.
+
+## Acceptance criteria
+
+- [x] **AC1** — Each of the 5 open RFCs carries a `- **Decision weight:**` line
+  with a tier and a rationale comment, in the template-mandated header position.
+- [x] **AC2** — Each of the 5 open RFCs has a `## Reviewer brief` section before
+  `## The ask`, with the seven fixed lines, none of which restates the BLUF
+  verbatim.
+- [x] **AC3** — Each of the 5 open RFCs renders `Decisions requested` as the
+  six-column table; every decision in the prior numbered list maps to exactly
+  one row (no decision dropped, none invented), and the per-decision detail is
+  retained in `## Proposal`.
+- [x] **AC4** — No substantive content changed: the recommendation, decision
+  set, non-goals, risks, and follow-ons of each RFC are unchanged in meaning
+  (diff is additive front-matter + a list→table transform). Verified by
+  `adversarial-reviewer` reporting no meaning-drift Blocker.
+- [x] **AC5** — RFC-0048's existing `## Amendments` section is confirmed to
+  already conform to the new two-layer Errata/Amendments convention (it does);
+  no change forced there.
+- [x] **AC6** — A `design-reviewer` (or `adversarial-reviewer`) pass over the
+  retrofitted cluster surfaces no Blocker. Any gap it raises that traces to an
+  underlying spec/plan (frame-domain / traceability-lint / release-loop) is
+  either fixed in this PR or recorded with a one-line reason.
+- [x] **AC7** — ADR-0038 (the one cluster-related ADR, per Approver direction)
+  carries the new ADR-format additions — a `## Decision summary`, a structured
+  `**Revisit if:**` line in Consequences (mirrored in the summary), and a
+  `Mode / Signal / Owner` Confirmation — with no change to the decision, drivers,
+  consequences, or alternatives in meaning.
+
+## Boundaries
+
+- **Related ADRs — scoped by Approver direction to this cluster's own open
+  items.** The new ADR format (Decision summary / structured `Revisit if:` /
+  `Mode·Signal·Owner` Confirmation) is forward-only and frozen ADRs are normally
+  immutable, but the Approver (eugenelim) ruled this cluster's related ADRs to be
+  **open items** and authorized a **readability-only** retrofit (no semantic
+  change). **ADR-0038** (rename `design-craft → experience`) is the one ADR
+  created as a follow-on *of this cluster* (Date 2026-06-25; Related →
+  RFC-0048/RFC-0050) — it is retrofitted. The other ADRs the RFCs merely *cite*
+  (ADR-0022, ADR-0023, ADR-0024, ADR-0031, …) are frozen decisions from unrelated
+  prior tracks, not this cluster's open items, and are **left untouched**
+  (genuinely forward-only).
+- **No status changes.** RFC-0048 stays Open with its acceptance blockers; the
+  others stay Open. The retrofit is presentation only.
+- **No re-opening of decided substance.** The retrofit does not re-litigate any
+  decision, non-goal, or risk; it re-presents them.
+
+## Testing strategy
+
+This is a docs change; the "gates" are mechanical + judgmental review, not a
+test suite:
+
+- **Mechanical:** `git diff` confirms each RFC's diff is additive (new header
+  line + new section + list→table) with no deletions of substantive prose;
+  `python .claude/skills/work-loop/scripts/lint-spec-status.py --root .` stays
+  green for this spec.
+- **Judgmental:** `adversarial-reviewer` against this spec + the diff (meaning
+  preservation, AC4), then a `design-reviewer` pass over the retrofitted RFCs as
+  artifacts (internal consistency, gaps pointing at the underlying specs).
+
+## Assumptions
+
+- The five Open RFCs are the complete "open cluster"; RFCs 0054/0055/0056 were
+  authored under the new template and need no retrofit (verified: they already
+  carry Decision weight + Reviewer brief + Decisions table).
+- RFC-0055 D5's "open-RFC retrofit is handled separately" authorizes this work;
+  the forward-only rule binds frozen artifacts, not in-flight Open ones.


### PR DESCRIPTION
## What & why

The five **Open** RFCs — RFC-0048, 0049, 0050, 0051, 0053 — were authored 2026-06-25/26, *before* the current RFC template landed (commits `ee54a5d1`, `bd84d0d4`, `f924dab5`, all 2026-06-27/28). They read less scannably than RFCs authored under the new template (0054/0055/0056). This PR retrofits the cluster to that template — **readability-only, meaning-preserving** — which RFC-0055 D5 explicitly sanctions ("open-RFC retrofit is handled separately").

## Changes

Per RFC:
- add a **`Decision weight`** header field (light/standard/heavy + rationale) — 0048/0049/0053 `heavy`, 0050/0051 `standard`
- add a **`## Reviewer brief`** scannable grid before `## The ask`
- convert **`Decisions requested`** from a numbered list to the six-column table (`ID | Question | Recommendation | Why | Decide by | Reviewer action`), with the per-decision detail staying in the body

ADR-0038 (the one ADR created as a follow-on *of this cluster*) gets the post-RFC-0056 ADR format: a `## Decision summary`, a structured `Revisit if:` line, and a `Mode / Signal / Owner` Confirmation. Per the Approver's call to treat the cluster's related ADRs as open items; cited-but-unrelated frozen ADRs (0022/0023/0024/0031) are left untouched (forward-only).

Net-reductive diff (mostly RFC-0048's verbose numbered decisions — redundant with its Proposal — collapsing into a table).

## Verification

- `adversarial-reviewer` on the diff + the anchoring spec: **no Blockers** — all nine of RFC-0048's decisions survive in its body, every decision maps 1:1 to a table row across all five RFCs (none dropped/invented), no Reviewer-brief claim is absent from the body, ADR-0038 unchanged in meaning. Three findings (verbatim `Revisit if:` mirror; RFC-0051 weight rationale; RFC-0049 OQ1 phrasing) all fixed.
- `lint-spec-status.py` clean. No status changes — every RFC stays Open.
- No gaps found in the underlying specs (`frame-domain` / `traceability-lint` / `release-loop`).

Anchoring spec: `docs/specs/open-rfc-format-retrofit/`.