### PR TITLE
docs(rfc): reconcile release-loop reviewer reuse with repo-scope co-location

### DIFF
--- a/docs/rfc/0048-autonomous-product-team-operating-model.md
+++ b/docs/rfc/0048-autonomous-product-team-operating-model.md
@@ -628,6 +628,7 @@ contract:
 | Discovery reviewers | `discovery-threat-reviewer` + `discovery-reliability-reviewer` (user-scope, distinct-named); `core`'s depth libraries are optional detect-and-degrade enhancers. | RFC-0053 / `discovery-loop` (DRIFT-E) |
 | Spec up-edge | `new-spec` produces the `Discovery:` header + discovery `type:` markers; must land before the traceability lint runs `--strict`. | CONVENTIONS / `new-spec` follow-on (DRIFT-G) |
 | Backlog handoff | RFC-0053's implementing spec owns decision-brief → work-item decomposition and `loop-cohort` cross-component ingestion. | RFC-0053 implementing spec (DRIFT-H) |
+| Release-loop reviewer reuse | `release-engineering` is **repo-scope**, installed in the build repo; `release-lead` therefore **reuses** `core`'s repo-scope `quality-engineer` / `security-reviewer` / `operational-safety` — sound because release runs **downstream, in the build repo** where `core` is installed. The scope-inverse of discovery's own-reviewer resolution (user-scope, pre-repo); same footgun rule, opposite scope. | RFC-0049 / [release-loop spec](../specs/release-loop/spec.md) |
 
 ### Amendment history / audit trail
 
@@ -796,6 +797,33 @@ superseded wording, the current-state table above wins.
   doctrine file), and its design-lens deliverable ships **discovery's own user-scope reviewers**
   (not a mode-edit to `core`'s two agents); note 06's `core` ⊕ delta and note 08's layout move
   with it. DRIFT-B/E/I below carry revised pointers.
+- **2026-06-28 — release-loop reviewer reuse reconciled as the scope-symmetric inverse of
+  discovery's own-reviewer resolution, by RFC-0049.** The 2026-06-26 company-OS SRE-seat entry
+  above recorded that `release-lead` **reuses** `core`'s `operational-safety` +
+  `quality-engineer` + `security-reviewer` ("no new reviewer"); the scope-decoupling entry
+  directly above established that the **user-scope** `discovery-lead` must ship its **own**
+  user-scope reviewers rather than reuse `core`'s repo-scope ones (the "a user-scope and a
+  repo-scope agent sharing a name is a resolution footgun" rule). A review pass surfaced that
+  RFC-0049 never stated *why* release may reuse where discovery may not — leaving the two
+  children apparently contradicting the same footgun rule, and leaving `release-engineering`'s
+  scope undeclared. **Resolution (recorded in
+  [RFC-0049](0049-the-release-loop-and-company-os.md) OQ1):** the two are the *same* rule
+  applied at opposite scopes — **scope follows where the work happens**. Discovery runs
+  **upstream of G3**, in non-repo document workspaces that cannot assume a `core` install →
+  user-scope, own reviewers. Release runs **downstream of the build, in the build repo** that
+  holds the deploy-ready component and therefore has `core` repo-installed → **`release-engineering`
+  is repo-scope**, co-located with the reviewers it reuses, exactly as `work-loop`'s own
+  (repo-scope `core`) supervisor reuses them. The company-OS scope boundary falls at the G3
+  handoff. This **extends** the SRE-seat entry (pinning the previously-unstated scope of
+  `release-engineering` and the soundness precondition of its reuse) and is **consistent with**
+  DRIFT-E (same footgun rule, opposite scope), contradicting neither. The cross-repo /
+  value-stream case (`release-loop` per-component-repo + cross-component e2e in a repo that
+  also carries `core` + `release-engineering`) reuses the
+  [ADR-0022](../adr/0022-value-stream-meta-repo-cross-component-layer.md) reference mechanism,
+  per the 2026-06-25 note-08 generalization above. **Owner:** RFC-0049 / its
+  [release-loop spec](../specs/release-loop/spec.md) — the spec records the resolved repo
+  scope at AC2 and the co-location reuse precondition at AC9 (landed together with this
+  entry). **Not** an RFC-0048 acceptance blocker.
 
 ### Foundation reconciliation discharge — the composed-set reconciliation (2026-06-26)
 

--- a/docs/rfc/0049-the-release-loop-and-company-os.md
+++ b/docs/rfc/0049-the-release-loop-and-company-os.md
@@ -15,9 +15,9 @@
 - **Recommended outcome:** accept.
 - **Change if accepted:**
   - Split the loop into **inner** (`work-loop`, local with local-infra-equivalents) and **outer** (`release-loop`, ephemeral deploy + e2e + iterate-to-converge).
-  - Add a `release-lead` agent + `release-loop` skill in a new opt-in `release-engineering` pack, reusing `operational-safety` + `quality-engineer` + `security-reviewer` + the RFC-0053 sidecar — **no new runtime, no new reviewer**.
+  - Add a `release-lead` agent + `release-loop` skill in a new opt-in, **repo-scope** `release-engineering` pack, reusing `operational-safety` + `quality-engineer` + `security-reviewer` + the RFC-0053 sidecar — **no new runtime, no new reviewer** (the reuse of `core`'s repo-scope reviewers is sound because the pack is **repo-scope and co-located in the build repo** where `core` is installed — see OQ1).
   - Carve autonomy by **minimum-regret**: agents run inner + outer loops on ephemeral envs unwatched; humans gate prod / data / spend / security / irreversible (G5).
-- **Affected surface:** a new `release-engineering` pack + agent + skill; CONVENTIONS (the inner/outer split + the minimum-regret deploy carve); reuse of `core`'s operational/security reviewers + the RFC-0053 sidecar; the `omnigent` harness (ephemeral envs).
+- **Affected surface:** a new **repo-scope** `release-engineering` pack (installed into the build repo) + agent + skill; CONVENTIONS (the inner/outer split + the minimum-regret deploy carve); reuse of `core`'s operational/security reviewers + the RFC-0053 sidecar; the `omnigent` harness (ephemeral envs).
 - **Stakes:** costly-to-reverse — it sets deploy-to-prod autonomy doctrine (an irreversible + security boundary); the prod-ship step itself stays human-gated, so the irreversible move is bounded.
 - **Review focus:** (1) the minimum-regret carve draws the agent/human line correctly (reversible ⇒ autonomous on ephemeral; irreversible ⇒ human); (2) the no-new-runtime / no-new-reviewer claim holds for the release loop.
 - **Not in scope:** building the harness; the exact `release-lead` agent shape (OQ2 — resolved by the child spec; the pack home, OQ1, already resolves to a new `release-engineering` pack); RFC-0048's G0–G4 discovery+build foundation (this is its G4→G5 extension).
@@ -138,7 +138,54 @@ rather than re-litigates.*
    which ships `discovery-lead` in the opt-in `product-engineering` pack, not `core`
    (RFC-0053 D1). The pack **hard-depends on `core`** (`operational-safety` +
    `quality-engineer` + `security-reviewer`) and detect-and-degrades on
-   cloud/platform packs. It **consumes the sidecar schema by convention** — reading the
+   cloud/platform packs.
+
+   **Scope — repo-scope, co-located in the build repo (this is what makes the
+   reviewer reuse sound).** `release-engineering` installs at **repo scope**, into the
+   same repo `work-loop` (the inner loop) ran in — the repo that holds the built,
+   deploy-ready component and where `core` is therefore repo-installed. That co-location
+   is *precisely what makes reusing `core`'s repo-scope `quality-engineer` /
+   `security-reviewer` / `operational-safety` sound*: the reused reviewers and
+   `release-lead` sit at the same scope in the same repo, so the reuse resolves by
+   construction — `release-lead` is the downstream, repo-scope peer of `work-loop`'s
+   supervisor (itself `core`, repo-scope) reusing the same reviewers, **not** a
+   user-scope agent reaching for repo-scope reviewers it cannot assume are present. This
+   is the **deliberate scope-inverse of the discovery loop's resolution**
+   ([RFC-0048](0048-autonomous-product-team-operating-model.md) § Amendments — the
+   2026-06-26 scope-decoupling entry + DRIFT-E): `discovery-lead` is **user-scope**
+   because discovery runs *upstream of G3*, in non-repo document workspaces that cannot
+   assume a `core` install, so it ships its **own** user-scope reviewers
+   (`discovery-threat-reviewer` / `discovery-reliability-reviewer`); `release-lead` runs
+   *downstream of the build, in the build repo*, so it **reuses** `core`'s. The same
+   "user-scope-agent-reaching-for-a-repo-scope-reviewer is a footgun" rule, applied at
+   opposite scopes — *scope follows where the work happens*, and the company-OS scope
+   boundary falls at the G3 handoff where shaping becomes a concrete repo. ("Parallels
+   `product-engineering`" below is a **discipline/seat-name** parallel, not a scope claim
+   — the two packs are opt-in for different prerequisite reasons and need not share
+   scope.)
+
+   **Cross-repo / value-stream reach.** In a single product monorepo the build repo *is*
+   the integrated whole, so the above holds directly. In a **polyrepo / value-stream**
+   topology the "integrated whole" spans component repos. Two distinct mechanisms are in
+   play, and conflating them would re-import the very presence assumption the discovery
+   footgun rule forbids: **(i) reviewer presence is an adopter precondition, not something
+   ADR-0022 provides** — each component repo, and whatever repo hosts the cross-component
+   integrated-whole deploy + e2e (a value-stream meta-repo or a designated integration
+   repo), must *itself* install `core` + `release-engineering` at repo scope; **absent that
+   install the per-repo reuse is not sound, and the loop surfaces the gap rather than
+   assuming the reviewers are present** (the same fail-closed posture as the discovery loop,
+   one scope up). **(ii) artifact referencing across repos** — pointing at the other
+   components' contracts / specs / built versions — uses the cross-repo mechanism already
+   decided in [ADR-0022](../adr/0022-value-stream-meta-repo-cross-component-layer.md)
+   (reference-by-version + the read-only courier snapshot), the same mechanism RFC-0048's
+   traceability chain crosses repos with (§ Amendments, the 2026-06-25 note-08
+   generalization), **not** a new coordinator. So `release-loop` runs **per-component-repo**
+   (reuse sound where both packs are installed), and the cross-component e2e runs in its
+   `core`-bearing host repo. The monorepo case is the minimum; the per-repo + named-install
+   precondition + reference-by-version model is the generalization, detailed by the
+   implementing spec where a concrete topology needs it.
+
+   It **consumes the sidecar schema by convention** — reading the
    produced `_state/` instances and checking the `schema_version` stamp, not importing a
    shared definition (the schema *definition* is carried in `product-engineering`'s
    `discovery-loop` skill, per RFC-0048 § Amendments 2026-06-26 / RFC-0053 D2), so it adds no

--- a/docs/specs/release-loop/spec.md
+++ b/docs/specs/release-loop/spec.md
@@ -192,8 +192,11 @@ of change, and the worked-example validation RFC-0053's coordinator spike used.
   and `discovery-lead`, **not** a `work-loop` outer-mode — the skill and the agent
   state that the two loops have different inputs, verifiers, and autonomy postures
   and **must not be conflated**.
-- [ ] **AC2 — the pack home (RFC-0049 OQ1).** The capability ships in a **new
-  opt-in `release-engineering` pack** (not `core`), which **hard-depends** on `core`
+- [ ] **AC2 — the pack home + scope (RFC-0049 OQ1; RFC-0048 § Amendments 2026-06-28).**
+  The capability ships in a **new opt-in `release-engineering` pack** (not `core`),
+  installed at **repo scope** into the **build repo** — the same repo `work-loop` ran in,
+  which holds the deploy-ready component and therefore has `core` repo-installed. The pack
+  **hard-depends** on `core`
   (`operational-safety` + `quality-engineer` + `security-reviewer`) and
   **consumes the sidecar schema by convention** — reading produced `_state/` instances
   + a `schema_version` stamp, not importing a shared definition (the schema *definition*
@@ -206,7 +209,13 @@ of change, and the worked-example validation RFC-0053's coordinator spike used.
   silently proceeding; when **present**, it consumes them. `core` is
   unchanged except for the version touch its `marketplace.json` aggregation
   requires. The pack carries `pack.toml`, `.claude-plugin/plugin.json`, and a
-  `README.md`, and is registered in the catalogue / `marketplace.json`.
+  `README.md`, and is registered in the catalogue / `marketplace.json`. The **repo-scope
+  co-location is load-bearing for AC9's reuse**: `release-lead` and the reused `core`
+  reviewers sit at the same scope in the same repo, so the reuse resolves by construction
+  — the deliberate scope-inverse of the user-scope `discovery-lead`, which ships its *own*
+  reviewers because it runs upstream in non-repo workspaces that cannot assume a `core`
+  install (RFC-0048 DRIFT-E). ("Parallels `product-engineering`" in § Ask first is a
+  discipline/seat-name parallel, not a scope claim.)
 - [ ] **AC3 — the carve, autonomous zone (RFC-0049 D2).** The skill enumerates the
   **reversibility zone** the agent runs unwatched: the inner loop; the outer loop
   **on ephemeral environments** (deploy / e2e / observe / iterate / teardown); and
@@ -277,7 +286,17 @@ of change, and the worked-example validation RFC-0053's coordinator spike used.
   **reuses `security-reviewer`** on deploy diffs. It adds **no new reviewer agent** (the
   CHARTER three-reviewer ceiling holds; the operational lens is a *mode* of
   `quality-engineer`, not a new agent) and **no executable code** as the feature
-  mechanism. `loop-cohort.py` / `lint-spec-status.py` are byte-unchanged.
+  mechanism. `loop-cohort.py` / `lint-spec-status.py` are byte-unchanged. **The reuse is
+  sound because the reused reviewers are present where the loop runs:** per AC2 the pack is
+  **repo-scope and co-located in the build repo** where `core` is repo-installed, so the
+  repo-scope `quality-engineer` / `security-reviewer` resolve at the same scope — not a
+  user-scope agent reaching for repo-scope reviewers it cannot assume are present (the
+  discovery footgun, avoided here by scope-inversion). In a **polyrepo / value-stream**
+  topology each component repo and the cross-component-e2e host repo must *themselves*
+  install `core` + `release-engineering`; **absent that install the per-repo reuse is not
+  sound and the loop surfaces the gap** (the same fail-closed posture as AC2's
+  detect-and-degrade and AC10(c)'s no-lens surface), while cross-repo *artifact
+  referencing* uses ADR-0022 (RFC-0049 OQ1; RFC-0048 § Amendments 2026-06-28).
 - [ ] **AC10 — the security & integrity contract (mirrors RFC-0053, extended for
   the deploy boundary).** The skill / agent specify, as first-class controls:
   **(a) verdict write-authority** — the prod / irreversible consent verdict is


### PR DESCRIPTION
## What does this change?

Resolves the unstated scope of the `release-engineering` pack to **repo-scope, co-located in the build repo**, and records why `release-lead` may reuse `core`'s repo-scope reviewers where the user-scope `discovery-lead` may not. Touches RFC-0049 (the resolution), RFC-0048 § Amendments (the cross-child reconciliation), and the release-loop spec (AC2/AC9 alignment).

## Why?

A review of RFC-0049 surfaced that it reuses `core`'s repo-scope reviewers (`quality-engineer`, `security-reviewer`, `operational-safety`) with "no new reviewer," while RFC-0048 § Amendments (the 2026-06-26 scope-decoupling entry + DRIFT-E) had already ruled that the **user-scope** `discovery-lead` must ship its *own* reviewers because it runs in non-repo workspaces that can't assume a `core` install — "a user-scope and a repo-scope agent sharing a name is a resolution footgun." RFC-0049 never stated why release is exempt, nor declared `release-engineering`'s scope.

Resolution: the two are the **same footgun rule at opposite scopes** — scope follows where the work happens. Discovery runs upstream of G3 (user-scope, own reviewers); release runs downstream in the build repo where `core` is installed (repo-scope, reuses `core`'s). The company-OS scope boundary falls at the G3 handoff.

- Follows from: RFC-0048 (foundation, Open), RFC-0049 (release loop, Open)
- Recorded in: RFC-0048 § Amendments (2026-06-28 entry; **not** an acceptance blocker)

## How do I verify it?

- `python .claude/skills/work-loop/scripts/lint-spec-status.py --root .` — clean except the pre-existing warn-only `packs/release-engineering/pack.toml` reference (the pack isn't built yet; unrelated to this PR).
- Read the chain: RFC-0049 OQ1 (resolution) → RFC-0048 § Amendments row + 2026-06-28 entry (reconciliation) → release-loop spec AC2 + AC9 (inherited). Confirm the polyrepo case names reviewer *presence* as an adopter precondition (fail-closed if absent), distinct from artifact *referencing* via ADR-0022.
- Two `adversarial-reviewer` passes (RFC edits, then spec edits) returned `Clean`.

## What did you not change that you considered?

- **The `release-engineering` pack itself** — not built yet; this is governance/spec only.
- **User-scope as the alternative resolution** — declined; it reintroduces the exact footgun discovery avoided. Repo-scope makes the reuse sound by construction.
- **New machinery for the polyrepo "integrated whole"** — declined; reused ADR-0022's existing cross-repo reference mechanism rather than inventing a coordinator.
- **No changelog entry** — these are governance docs and a not-yet-built spec, not shipped pack behavior.

## Checklist

- [x] Self-review run via `adversarial-reviewer` (two rounds, both `Clean`); no security boundary crossed by the docs change
- [x] Spec and RFCs agree (spec AC2/AC9 updated in this PR to match the resolution)
- [x] No changelog needed (governance docs + not-yet-built spec, no user-visible behavior change)
- [x] No new top-level directories
- [x] Conventional commit format