### PR TITLE
docs(spec): reconcile three spec drifts against retrofitted RFCs

### DIFF
--- a/docs/specs/frame-domain/spec.md
+++ b/docs/specs/frame-domain/spec.md
@@ -89,8 +89,9 @@ before proceeding; *Never do* is a hard rule, even under time pressure.
 
 - **Adding a component beyond the ones this spec fixes** — Domain Framing's two
   halves (real-world-activity, brownfield current-system) and Scope Boundary's
-  out-of-scope register — e.g. folding the persona in as a co-product (RFC-0048's
-  artifact inventory lists it as a *separate* artifact; it is out of scope here),
+  out-of-scope register — e.g. folding the persona in as a co-product (per RFC-0048
+  DRIFT-F persona is *elicited inline by its first consumer*, not a separately
+  produced artifact; it is out of scope here),
   or adding a third artifact to the `frame-domain` skill's output.
 - **Changing either canonical filename or frontmatter `type:` value**
   (`domain-framing.md` / `type: domain-framing`, `scope-boundary.md` /

--- a/docs/specs/release-loop/plan.md
+++ b/docs/specs/release-loop/plan.md
@@ -279,7 +279,7 @@ updated.
   as Never-do / Ask-first; the worked example references but does not author
   local-infra-equivalents.
 - **The security/integrity controls under-specified.** The `security-reviewer`
-  spec-stage pass is the check; mirror RFC-0053's six-control depth exactly.
+  spec-stage pass is the check; mirror RFC-0049's nine-control depth exactly.
 
 ## Changelog
 

--- a/docs/specs/release-loop/spec.md
+++ b/docs/specs/release-loop/spec.md
@@ -163,7 +163,7 @@ of change, and the worked-example validation RFC-0053's coordinator spike used.
   whole" / "iterate the deployed env" prompts and *not* on inner-loop build
   prompts (the inner/outer boundary is legible to the model).
 - **Content presence** (the carve's two zones; the convergence policy; the outer
-  cap + stall-surface; the sidecar consumption; the reuse wiring; the six
+  cap + stall-surface; the sidecar consumption; the reuse wiring; the nine
   security/integrity controls; *no* executable engine added): goal-based —
   `grep` / `git diff` checks against the Acceptance Criteria.
 - **Doctrine correctness** (does the prose actually *carve* autonomy at the

--- a/docs/specs/traceability-lint/spec.md
+++ b/docs/specs/traceability-lint/spec.md
@@ -3,7 +3,7 @@
 - **Status:** Draft <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
-- **Constrained by:** RFC-0048 (governing — Decision 6); RFC-0040, RFC-0019, RFC-0025, RFC-0030, ADR-0022, RFC-0049 (mechanism precedent)
+- **Constrained by:** RFC-0048 (governing — Decision 6); RFC-0053 (the traceability slot, the `schema_version` convention, and the child-4-consumes-the-slot relationship); RFC-0040, RFC-0019, RFC-0025, RFC-0030, ADR-0022, RFC-0049 (mechanism precedent)
 - **Brief:** none
 - **Contract:** none
 - **Shape:** service


### PR DESCRIPTION
Three documentation-only drift fixes across three Draft specs. All three predate the 2026-06-28 RFC retrofit (the specs carry 2026-06-26/06-27 dates and weren't re-touched) — exactly where count/citation drift settles.

## 1. release-loop — stale control count (should-fix)

`spec.md:166` said "the six security/integrity controls", but AC10 enumerates eight, lettered (a)–(h), and RFC-0049 (`0049:222`) now describes a 9-part contract (the eight in AC10 + the AC7 artifact-provenance control). The plan already counted correctly ("nine" at `plan.md:169,180,189`).

- `spec.md:166` — "six" → "nine".
- `plan.md:282` — "mirror RFC-0053's six-control depth exactly" → "mirror RFC-0049's nine-control depth exactly". The RFC reference moves with the number: RFC-0053 genuinely holds six controls, so changing only the count would have produced the false claim "RFC-0053's nine-control depth". The release loop's depth target is RFC-0049's nine.

(The `spec.md:175` mention of "the pass that produced RFC-0053's § Security & integrity contract" refers to the security-reviewer *methodology*, not a count, and is left unchanged.)

## 2. traceability-lint — missing citation (should-fix)

`spec.md:6` Constrained-by cited RFC-0048/0040/0019/0025/0030, ADR-0022, RFC-0049 — but not RFC-0053, which is where the traceability slot, the `schema_version` convention, and the "child-4's lint consumes the slot" relationship are actually specified. Added RFC-0053.

DRIFT-A and the D7 amendment in RFC-0048 were retrofitted to match this spec's wording — truth flowed spec→RFC there, so this spec stays canonical for that wording and those are *not* added as upstream constraints.

## 3. frame-domain — superseded rationale (cosmetic)

`spec.md:92-93` described persona using note-04's pre-amendment "separate artifact" framing. DRIFT-F (which post-dates and resolves against this spec) corrected that: persona is elicited inline by its first consumer, not a separately produced artifact. The spec's actual behavior was already correct (excludes persona, makes adding it Ask-first); only the parenthetical rationale was stale.

## Risk / verification

Docs-only, three Draft specs. No code, no AC semantics changed — counts and citations brought back into agreement with the now-canonical RFCs. Verified no other "six"-control references remain in the release-loop files.