### PR TITLE
docs(rfc): scope self-coverage to work-loop-thin / discovery-full; update D4 to ADR-0042

### DIFF
--- a/docs/rfc/0048-autonomous-product-team-operating-model.md
+++ b/docs/rfc/0048-autonomous-product-team-operating-model.md
@@ -70,7 +70,7 @@ can the catalogue become an autonomous product team without violating Principle 
 | D2 | Frame D1, D3–D6 as doctrine + pure-markdown skills + reference libraries (no new runtime engine), with the build loop reusing `core`'s code reviewers and discovery shipping its own distinct-named user-scope design-time reviewers? | Adopt (the coordinator's no-engine fit is excepted — it is the Decision-7 spike) | The Accepted RFC-0041/0043 precedent; leaves the CHARTER three-reviewer ceiling untouched | RFC accept | Confirm the no-runtime framing + the loop-scoped discovery reviewer roster |
 | D3 | Grow the design/UX seat (`map-customer-journey`, `blueprint-service`, `inventory-screens`, `map-internal-process` + grounding/taste + voice wiring + the `experience-reviewer`) and rename `design-craft → experience`? | Adopt; rename adopted (v0.1.1 user-scope ⇒ low migration cost; `contract-acquisition` precedent — rename dirs + a governance erratum, no install-time alias) | The missing column is the design/UX seat, and `experience` names it better | RFC accept (records ADR-0038) | Confirm the seat additions + the rename + its migration path (modelled in RFC-0050) |
 | D4 | Add the `frame-domain` primitive — one skill producing two typed artifacts (Domain Framing + Scope Boundary)? | Adopt (split into two artifacts — § Amendments 2026-06-26) | The single biggest correctness lever against domain-hallucination and over-scoping | RFC accept | Confirm the two-artifact split |
-| D5 | Add **self-coverage** — the goal that each loop maximizes autonomy by substituting rigorous checklists for human-surfacing (**resolve-vs-surface**) — realized **per loop with loop-appropriate checklists** (design/build loops run the seven-module gate; the release loop its operational composite) and packaged as **per-loop controller doctrine** (each loop carries its own; no shared `core` library, no cross-pack coupling), non-skippable, no new reviewer? | Adopt (reframed as a cross-loop goal + packaging revised by child-3 — see § Amendments 2026-06-29) | Fixes the knowing-doing gap that lets errors compound between human gates; per-loop co-scoping keeps it present wherever each controller runs (a `core` library would be absent for the user-scope/pre-repo discovery loop) | RFC accept | Confirm the goal + the non-skippable per-loop packaging |
+| D5 | Add **self-coverage** — the goal that each loop maximizes autonomy by substituting rigorous checklists for human-surfacing (**resolve-vs-surface**) — realized **per loop with loop-appropriate checklists** (`discovery-loop` runs the full seven-module gate, `work-loop` only the net-new slice atop the passes it already runs, the release loop its operational composite) and packaged as **per-loop controller doctrine** (each loop carries its own; no shared `core` library, no cross-pack coupling), non-skippable, no new reviewer? | Adopt (reframed as a cross-loop goal + packaging revised by child-3 — see § Amendments 2026-06-29) | Fixes the knowing-doing gap that lets errors compound between human gates; per-loop co-scoping keeps it present wherever each controller runs (a `core` library would be absent for the user-scope/pre-repo discovery loop) | RFC accept | Confirm the goal + the non-skippable per-loop packaging |
 | D6 | Add the traceability lint — structural-orphan detection generalizing `receive-brief`'s coverage lint? | Adopt (semantic scope-creep deferred to the coordinator spike / O10; MVP stays a human call at G1.5) | Mechanizes the chain's structural integrity | RFC accept | Confirm the structural-only scope |
 | D7 | Adopt `omnigent` as the (temporary) harness and run a sidecar + chief-loop validation — a spike, not a from-scratch coordinator build? | Sidecar-prototype-first (validate the typed sidecar, the chief, and consent rejection/recovery + outer cap against the worked example) | The sidecar is the connectedness verifier | RFC accept | Confirm spike-first, not build |
 | D8 | Ship the chief — `discovery-lead` — as an agent + the `discovery-loop` convergence-loop skill, in `product-engineering`? | Adopt (shape confirmed by the Decision-7 prototype) | The user-facing orchestrator is content, not infra; the two-loop split keeps each loop honest | RFC accept | Confirm the agent+skill shape, the `product-engineering` home, and the G3 hand-off to `work-loop` |
@@ -179,9 +179,9 @@ grounding/taste enhancements. The full producer→consumer artifact inventory (8
 
 **D4–D6 — primitives.** Domain-anchor (typed artifact + `research` wiring); self-coverage
 (the cross-loop goal — autonomy via checklists that substitute for human-surfacing — realized
-per loop with loop-appropriate checklists; design/build loops run the seven-module gate, the
-release loop its operational composite; no new reviewer; packaging revised by child-3,
-§ Amendments 2026-06-29); the traceability/scope-creep lint (a tool).
+per loop with loop-appropriate checklists; `discovery-loop` runs the full seven-module gate,
+`work-loop` only the net-new slice, the release loop its operational composite; no new reviewer;
+packaging + share revised by child-3, § Amendments 2026-06-29); the traceability/scope-creep lint (a tool).
 
 **D7 / D8 — the two loops, the `discovery-lead`, and the sidecar (design proposal).**
 
@@ -430,9 +430,10 @@ runtime, a workflow engine, or a CI matrix are all valid hosts — none is codif
   would otherwise be surfaced to a human** — resolve autonomously everything a referent or checklist
   can resolve (**resolve-vs-surface**), and surface only the irreducible (value origination,
   irreversible risk, value conflict). It is realized **per loop, with loop-appropriate checklists**:
-  the design/build loops (`work-loop`, `discovery-loop`) run the **seven-module gate**
-  ([RFC-0051](0051-the-self-coverage-gate.md) owns the primitive — wired in `work-loop`, and for
-  discovery in [RFC-0053](0053-the-discovery-loop.md)); the **release loop** realizes the same
+  `discovery-loop` runs the **full seven-module gate** while `work-loop` adopts only the **net-new
+  slice** atop the passes it already runs ([RFC-0051](0051-the-self-coverage-gate.md) owns the
+  primitive — its full instantiation is `discovery-loop`'s, wired by
+  [RFC-0053](0053-the-discovery-loop.md); `work-loop`'s thin slice is wired here); the **release loop** realizes the same
   goal through an **operational composite** — `operational-safety` + `security-reviewer` +
   `quality-engineer` + the automated convergence policy + the minimum-regret carve as its
   resolve-vs-surface disposition ([RFC-0049](0049-the-release-loop-and-company-os.md)). The shared
@@ -704,7 +705,7 @@ contract:
 | Release-loop reviewer reuse | `release-engineering` is **repo-scope**, installed in the build repo; `release-lead` therefore **reuses** `core`'s repo-scope `quality-engineer` / `security-reviewer` / `operational-safety` — sound because release runs **downstream, in the build repo** where `core` is installed. The scope-inverse of discovery's own-reviewer resolution (user-scope, pre-repo); same footgun rule, opposite scope. | RFC-0049 / [release-loop spec](../specs/release-loop/spec.md) |
 | Agent-addition governance | The reviewer-ceiling reading is **generalized** into a loop/work-type-keyed agent-addition policy ([ADR-0042](../adr/0042-agent-additions-keyed-to-loop-and-work-type.md), supersedes ADR-0023): add an agent only where it clears a value test (independence / parallelism / distinct surface-cadence); the core `work-loop` code-review gate stays capped at three lenses. The discovery roster and any new design-time reviewer are decided *within* this policy. | ADR-0042 (Accepted) / RFC-0050 D7 |
 | UX/design design-time reviewer | **RFC-0050 D7 adopted** (binds on RFC-0050 acceptance): the UX/design lens gains an opt-in forked `experience-reviewer` (collision-hardened, *not* `design-reviewer`) for autonomous design review between human-value-add gates; `design-critique` stays the authoring-time skill. | RFC-0050 D7 |
-| Self-coverage scope + packaging | **A cross-loop goal realized per loop, packaged as per-loop co-scoped doctrine — not a shared `core` library** (reframes + revises D5). *Goal:* each loop maximizes autonomy by substituting rigorous checklists for human-surfacing (resolve-vs-surface). *Instantiation:* the design/build loops (`work-loop`, `discovery-loop`) run the **seven-module gate**; the **release loop** realizes the same goal through an **operational composite** (`operational-safety` + `security-reviewer` + `quality-engineer` + the convergence policy + the minimum-regret carve) — RFC-0049. *Packaging:* each loop carries its own copy co-scoped (`work-loop` in `core`/repo; `discovery-loop` in `product-engineering`/user when built; release in `release-engineering`/repo), no shared library, no cross-pack coupling. "Run by every loop controller" (D5) means **every loop runs the same goal** through a loop-appropriate instantiation, not that they read one file — because `core` is repo-scope but `discovery-loop` is user-scope/pre-repo, and a non-skippable gate cannot detect-and-degrade. | RFC-0051 (child 3, owns the goal + seam + design/build gate) / RFC-0049 (release-loop instantiation) / RFC-0053 (wires discovery) |
+| Self-coverage scope + packaging | **A cross-loop goal realized per loop, packaged as per-loop co-scoped doctrine — not a shared `core` library** (reframes + revises D5). *Goal:* each loop maximizes autonomy by substituting rigorous checklists for human-surfacing (resolve-vs-surface). *Instantiation:* `discovery-loop` runs the **full seven-module gate** (its native design-convergence altitude), while `work-loop` adopts only the **net-new slice** (a resolve-vs-surface disposition record + conditional domain-grounding) atop the passes it already runs; the **release loop** realizes the same goal through an **operational composite** (`operational-safety` + `security-reviewer` + `quality-engineer` + the convergence policy + the minimum-regret carve) — RFC-0049. *Packaging:* each loop carries its own copy co-scoped (`work-loop` in `core`/repo; `discovery-loop` in `product-engineering`/user when built; release in `release-engineering`/repo), no shared library, no cross-pack coupling. "Run by every loop controller" (D5) means **every loop runs the same goal** through a loop-appropriate instantiation, not that they read one file — because `core` is repo-scope but `discovery-loop` is user-scope/pre-repo, and a non-skippable gate cannot detect-and-degrade. | RFC-0051 (child 3, owns the goal + seam + the full seven-module design-convergence gate, discovery's home) / RFC-0049 (release-loop instantiation) / RFC-0053 (wires discovery) |
 
 ### Amendment history / audit trail
 
@@ -928,9 +929,10 @@ superseded wording, the current-state table above wins.
   *self-coverage is the goal* bullet now carry the revised wording in-body, this RFC being Open and
   editable; this entry is the audit trail of why). **Reframe:** self-coverage is a *goal* — each
   loop maximizes autonomy by substituting rigorous checklists for what would otherwise be surfaced
-  to a human (resolve-vs-surface) — realized **per loop with loop-appropriate checklists**: the
-  design/build loops (`work-loop`, `discovery-loop`) run the **seven-module gate**; the **release
-  loop** realizes the *same goal* through an **operational composite** (`operational-safety` +
+  to a human (resolve-vs-surface) — realized **per loop with loop-appropriate checklists**:
+  `discovery-loop` runs the **full seven-module gate** while `work-loop` adopts only the **net-new
+  slice** atop the passes it already runs (a further refinement by child-3's design pass — see
+  below); the **release loop** realizes the *same goal* through an **operational composite** (`operational-safety` +
   `security-reviewer` + `quality-engineer` + the convergence policy + the minimum-regret carve as
   its resolve-vs-surface disposition — [RFC-0049](0049-the-release-loop-and-company-os.md)). So
   self-coverage spans **all three loops**, not two. Child-3's design pass
@@ -951,14 +953,20 @@ superseded wording, the current-state table above wins.
   pack stands alone (the release loop's composite lives co-scoped in `release-engineering`). D5's
   "run by every loop controller" is reconciled to mean **every loop runs the same goal** through a
   loop-appropriate instantiation, not that they read one file. The shared cross-loop **seam** is the
-  *goal + resolve-vs-surface + the non-skippable coverage record* (not the seven steps — those are
-  the design/build instantiation, shared by `work-loop` and `discovery-loop` only). This is sound
+  *goal + resolve-vs-surface + the non-skippable coverage record* (not the seven steps — the full
+  seven are `discovery-loop`'s design-convergence instantiation; `work-loop` adopts only the net-new
+  slice because its existing structure (REVIEW, Surface + DECIDE, the assumption trio +
+  declined-pattern register) and its already-progressive spec time cover the rest). This is sound
   because, *unlike* `operational-safety` (consumed by a Skill-less subagent that needs the modules
   inlined into its brief), the gate runs in the **controller's own context** and needs no external
-  shareable skill. **Revises + widens D5** on scope grounds; re-opens no value call (the gate's
-  existence, non-skippability, and no-new-reviewer framing are unchanged — only its scope widens to
-  three loops and its packaging goes per-loop). **Owners:** RFC-0051 (the goal + seam + the
-  design/build gate + its implementing spec `docs/specs/self-coverage-gate/`, wiring `work-loop`);
+  shareable skill. **Revises + widens D5** on scope grounds, and **refines its share**: D5's "both
+  design/build loops run the seven-module gate" is corrected to *`discovery-loop` carries the full
+  seven (its native design-convergence altitude); `work-loop` adopts only the net-new slice* — child-3's
+  design pass found most of the gate already lives in `work-loop`, so bolting the full battery onto
+  the build loop would be ceremony. Re-opens no value call (the gate's existence, non-skippability,
+  and no-new-reviewer framing are unchanged — its scope widens to three loops, its packaging goes
+  per-loop, and its `work-loop` share narrows to net-new). **Owners:** RFC-0051 (the goal + seam + the
+  full seven-module design-convergence instantiation + its implementing spec `docs/specs/self-coverage-gate/`, wiring `work-loop`'s thin slice);
   RFC-0053 (wires `discovery-loop`'s copy); RFC-0049 (the release-loop operational instantiation).
   **Not** an RFC-0048 acceptance blocker. See [RFC-0051](0051-the-self-coverage-gate.md) § The ask
   (*What self-coverage is*) + § Proposal + § Follow-on artifacts.

--- a/docs/rfc/0051-the-self-coverage-gate.md
+++ b/docs/rfc/0051-the-self-coverage-gate.md
@@ -1,4 +1,4 @@
-# RFC-0051: the self-coverage gate — non-skippable coverage doctrine each loop controller carries
+# RFC-0051: the self-coverage gate — non-skippable coverage doctrine, realized loop-appropriately (full in `discovery-loop`, a thin slice in `work-loop`)
 
 - **Status:** Open <!-- Draft | Open | Final Comment Period | Accepted | Rejected | Withdrawn | Experimental -->
 - **Author:** eugenelim
@@ -6,20 +6,21 @@
 - **Date opened:** 2026-06-25
 - **Date closed:**
 - **Decision weight:** standard <!-- light | standard | heavy — additive loop doctrine: each controller carries the gate in its own skill at its own scope; no new pack, no cross-pack coupling, no new runtime, no new reviewer. It adds one refusal item to `work-loop`'s done-checklist (an additive doctrine change, not a checklist rewrite). It does *amend* one in-flight foundation decision (RFC-0048 D5's "a `core` library loaded by both controllers" packaging), recorded as a tracked amendment to that Open RFC, not a reversal of a frozen decision — so it stays below the governance-boundary line, the same standard-weight framing the analogous additive RFC-0055 convention used. -->
-- **Related:** [RFC-0048](0048-autonomous-product-team-operating-model.md) (the foundation — this is **child 3**, Decision 5; the provisional foundation this drift-aligns back to) · [RFC-0041](0041-infra-aware-work-loop.md) + ADR-0031 (the `operational-safety` reference-library + reuse-the-reviewer precedent this RFC mirrors on *form* and *reuse* — *no new runtime, no new reviewer* — diverging only on *locus*: per-loop co-scoped copies, not one shared library, because this gate's consumers straddle the repo/user scope boundary) · RFC-0025 (`work-loop` light/full mode + risk triggers — the right-sizing model this reuses) · `operational-safety` + `security-checklists` skills (the controller-loaded progressive-disclosure shape) · `work-loop` skill (the consuming controller; PLAN trio + declined-pattern register + REVIEW adversarial pass + the done-checklist refusal items this gate joins) · RFC-0048 D8 (`discovery-loop` / `discovery-lead` — the *second* controller, not built yet) · promoted research in RFC-0048's [`0048-notes/03`](0048-notes/03-autonomy-and-gate-economics.md) (the floor-raiser table) and [`0048-notes/09`](0048-notes/09-gap-resolutions.md) (the resolve-vs-surface sample-bank this seeds into a per-loop bank)
+- **Related:** [RFC-0048](0048-autonomous-product-team-operating-model.md) (the foundation — this is **child 3**, Decision 5; the provisional foundation this drift-aligns back to) · [RFC-0041](0041-infra-aware-work-loop.md) + ADR-0031 (the `operational-safety` reference-library + reuse-the-reviewer precedent this RFC mirrors on *form* and *reuse* — *no new runtime, no new reviewer* — diverging only on *locus*: per-loop co-scoped copies, not one shared library, because this gate's consumers straddle the repo/user scope boundary) · [ADR-0042](../adr/0042-agent-additions-keyed-to-loop-and-work-type.md) (the reviewer-selection authority Decision 4 follows — agent additions keyed to loop and work type, superseding ADR-0023) · RFC-0025 (`work-loop` light/full mode + risk triggers — the right-sizing model this reuses) · `operational-safety` + `security-checklists` skills (the controller-loaded progressive-disclosure shape) · `work-loop` skill (the consuming controller; PLAN trio + declined-pattern register + REVIEW adversarial pass + the done-checklist refusal items this gate joins) · RFC-0048 D8 (`discovery-loop` / `discovery-lead` — the *second* controller, not built yet) · promoted research in RFC-0048's [`0048-notes/03`](0048-notes/03-autonomy-and-gate-economics.md) (the floor-raiser table) and [`0048-notes/09`](0048-notes/09-gap-resolutions.md) (the resolve-vs-surface sample-bank this seeds into a per-loop bank)
 
 ## Reviewer brief
 
-- **Decision:** whether to ship the self-coverage gate as **per-loop controller doctrine** — each loop controller carries the gate in its own skill, at its own scope, with progressive-disclosure depth modules and a per-loop sample-bank — non-skippable, with **no shared library, no cross-pack coupling**, no new runtime, and no new reviewer.
+- **Decision:** whether to (1) **own the cross-loop self-coverage goal + seam** here, and (2) realize it per loop with a **loop-appropriate share** — the **full seven-module design-convergence gate for `discovery-loop`** (its native altitude), and only the **net-new slice for `work-loop`**, because `work-loop`'s existing structure (REVIEW, Surface + DECIDE, the assumption trio + declined-pattern register) and its **already-progressive spec time** (light/full, RFC-0025) cover most of the gate. Per-loop co-scoped; no shared library; no cross-pack coupling; no new runtime; no new reviewer; non-skippable.
 - **Recommended outcome:** accept.
 - **Change if accepted:**
-  - Add the gate's seven step-modules + a per-loop sample-bank as **progressive-disclosure reference files under the consuming loop's own skill** (loaded on demand by the gate phase — not a standalone skill, not a shared pack).
-  - Make it **non-skippable** via a controller-gate phase + a done/converged-checklist refusal (doctrine + a mechanical coverage record), not a runtime lock — enforced per loop, and *guaranteed present wherever each controller runs* (`work-loop` today; `discovery-loop` when D8 ships its own copy) because the gate is co-scoped with its controller.
-  - `work-loop` (in `core`, repo-scope) is the first consumer and the only one wired now; `discovery-loop` (in `product-engineering`, user-scope) carries its **own** copy of the same method when RFC-0048 D8 ships it — neither pack depends on the other. Right-size light/full mirroring `work-loop`.
-- **Affected surface:** the `work-loop` skill — its SKILL.md (the gate phase + a checklist-refusal item) and new `references/self-coverage/` modules (seven step-modules + a seeded per-loop sample-bank); reuse of `adversarial-reviewer` / `devils-advocate`; the cross-loop seam (goal + resolve-vs-surface + the non-skippable record) + the seven-module instantiation specified for `discovery-loop` to carry its own copy; a tracked amendment to RFC-0048 D5.
-- **Stakes:** reversible — additive doctrine + reference modules carried by one loop; no runtime, no new reviewer, no new pack; degrades to the prior done-checklist if reverted.
-- **Review focus:** (1) the non-skippable mechanism is genuinely non-skippable yet harness-neutral (controller-gate + checklist-refusal, never a self-discovered skill); (2) **per-loop co-scoping (not a shared `core` library) is the right call** — it dissolves the scope-coupling a shared library hits when `discovery-loop` runs user-scope/pre-repo, and keeps `core` and `product-engineering` standalone; (3) light/full right-sizing reuses RFC-0025 rather than inventing a second knob.
-- **Not in scope:** a fourth reviewer agent; a runtime lock; a shared cross-pack library or a dependency between `core` and `product-engineering`; a new standalone skill/pack for the gate; semantic scope-creep detection (RFC-0048 D6 / O10).
+  - Establish the **goal** (raise autonomy between human gates via resolve-vs-surface) and the **cross-loop seam** (the resolve-vs-surface disposition + a non-skippable coverage record) as the invariant every loop conforms to.
+  - **For `work-loop` — a thin edit, not a new gate.** Most of the gate already lives there (§ Inventory). Name its existing passes as the gate's steps (REVIEW *is* fresh-context-adversarial; the assumption trio + declined-pattern register *are* the pre-mortem hook; Surface + DECIDE *are* the resolve-vs-surface bones), and add only the **net-new**: a resolve-vs-surface **disposition record** and a **conditional domain-grounding** check, both at spec time / DECIDE under the **light/full progressive mode `work-loop` already activates at spec time**. Do **not** bolt the heavy design-convergence modules (the ones the § Inventory marks "not adopted") onto the build loop, and do **not** add a second right-sizing knob. One done-checklist refusal item (the disposition record).
+  - **For `discovery-loop`** (RFC-0048 D8 / RFC-0053, not built) — adopt the **full seven-module gate** as its pre-convergence (G2) gate, in its own skill at user scope, right-sized by its own progressive mode. This is the **primary home** of the full design-convergence instantiation: the altitude where myopic-greedy commitment is the live risk and a design artifact exists to ground.
+  - Make it **non-skippable** via a controller-gate phase + a done/converged-checklist refusal (doctrine + a mechanical coverage record), not a runtime lock — co-scoped with each controller so it is present wherever the controller runs.
+- **Affected surface:** the `work-loop` skill — a **thin** SKILL.md edit (name the existing passes; add the disposition record + conditional domain-grounding at spec time / DECIDE; one checklist-refusal item) — **no new heavy reference modules under `work-loop`**; the cross-loop seam + the **full seven-module instantiation specified for `discovery-loop` to carry**; reuse of `adversarial-reviewer` / `devils-advocate`; a tracked amendment + refinement to RFC-0048 D5.
+- **Stakes:** reversible — additive doctrine; no runtime, no new reviewer, no new pack; the `work-loop` edit degrades to the prior done-checklist if reverted.
+- **Review focus:** (1) the non-skippable mechanism is genuinely non-skippable yet harness-neutral (controller-gate + checklist-refusal, never a self-discovered skill); (2) the **`work-loop` adoption is honestly scoped to net-new** — it names what already applies and attaches the thin remainder to the spec time that is *already* progressive, rather than bolting a convergence battery onto the build loop; (3) **`discovery-loop`, not `work-loop`, is the primary consumer of the full seven** — confirm the altitude is right; (4) per-loop co-scoping (not a shared `core` library) keeps `core` and `product-engineering` standalone.
+- **Not in scope:** a new reviewer agent of any kind — and specifically no fourth *core-loop* lens (ADR-0042; the gate reuses each loop's work-type-keyed roster); a runtime lock; a shared cross-pack library or a dependency between `core` and `product-engineering`; a new standalone skill/pack for the gate; **the heavy design-convergence modules as new `work-loop` surface** (they are `discovery-loop`'s); a second right-sizing knob (reuse each loop's existing progressive mode); semantic scope-creep detection (RFC-0048 D6 / O10).
 
 ## The ask
 
@@ -32,25 +33,36 @@ irreducible (value origination, irreversible risk, value conflict). The remainin
 taxonomy, saturation, fresh-context review, scenario-variation). Every loop with a human handoff
 realizes this goal — **with checklists appropriate to its own work**. This RFC owns the goal, the
 **seam** (the goal + the resolve-vs-surface disposition + the non-skippable coverage record that
-every loop's instantiation conforms to), and the **design/build instantiation** — the seven modules
-below — and wires `work-loop`. `discovery-loop` carries the same seven modules (wired by
-[RFC-0053](0053-the-discovery-loop.md)); `release-loop` realizes the same goal + seam through
-a deploy-appropriate *composite* ([RFC-0049](0049-the-release-loop-and-company-os.md)). See
-*Consumers & sequencing*.
+every loop's instantiation conforms to), and the **design-convergence instantiation** — the seven
+modules below. It specifies the **full seven-module gate for `discovery-loop`** to carry as its
+pre-convergence gate (wired by [RFC-0053](0053-the-discovery-loop.md)), and wires the **goal + seam
+into `work-loop` as a thin, loop-appropriate slice** — because most of the gate already lives in
+`work-loop` and its spec time is already progressive (§ Inventory). `release-loop` realizes the same
+goal + seam through a deploy-appropriate *composite* ([RFC-0049](0049-the-release-loop-and-company-os.md)).
+See *Consumers & sequencing*.
 
-**Recommendation (BLUF).** Ship the self-coverage gate as **per-loop controller doctrine**:
-each loop controller carries the gate *in its own skill, at its own scope*, with **no shared
-library and no coupling between packs** — no new runtime, no new reviewer. The gate is a named
-phase in the consuming loop's SKILL.md; its depth is seven **progressive-disclosure reference
-modules** (domain-grounding table · pre-mortem · taxonomy walk · saturation declaration ·
-fresh-context adversarial pass · scenario-variation · resolve-vs-surface) plus a **per-loop
-sample-bank**, loaded on demand by the gate phase (light loads the always-on core; full loads
-all seven). It is **non-skippable** because it runs in the **loop controller's own context** as
-a named gate phase whose coverage record the done/converged checklist refuses to pass without,
-*not* a skill the controller may discover. `work-loop` (in `core`, repo-scope) is the first
-consumer and the only one wired now; `discovery-loop` (in `product-engineering`, user-scope)
-carries its **own** copy of the same method when RFC-0048 D8 ships it — neither pack depends on
-the other.
+**Recommendation (BLUF).** Own the self-coverage **goal + cross-loop seam** here, and realize it
+per loop as **per-loop controller doctrine** (each loop carries its own copy at its own scope —
+no shared library, no cross-pack coupling, no new runtime, no new reviewer) with a
+**loop-appropriate share**:
+
+- **`discovery-loop`** is the **primary consumer of the full seven-module design-convergence gate**
+  (domain-grounding · pre-mortem · taxonomy-walk · saturation-declaration · fresh-context-adversarial
+  · scenario-variation · resolve-vs-surface), carried as progressive-disclosure reference modules
+  under its own skill and run as its pre-convergence (G2) gate. That altitude — a design artifact
+  being converged, myopic-greedy commitment as the live risk — is where the battery earns its place.
+- **`work-loop`** adopts the **same goal + seam with a thin slice, not the full gate**. Most of the
+  gate already lives in `work-loop`, and its spec time is **already progressive** (light/full,
+  RFC-0025): REVIEW *is* fresh-context-adversarial, Surface + DECIDE *are* the resolve-vs-surface
+  bones, the assumption trio + declined-pattern register *are* the pre-mortem hook, and the light/full
+  knob already right-sizes how much spec convergence runs. The only net-new is a resolve-vs-surface
+  **disposition record** and a **conditional domain-grounding** check, attached at spec time / DECIDE
+  under that existing progressive mode — never a convergence battery bolted onto the build loop, never
+  a second knob.
+
+It is **non-skippable** because it runs in the **loop controller's own context** as a named gate
+phase (or, for `work-loop`, as named existing phases plus one done-checklist refusal item), *not* a
+skill the controller may discover. Co-scoping guarantees it is present wherever each controller runs.
 
 **Why per-loop and not a shared `core` library.** RFC-0048 D5 framed this as "a reference
 library in `core`, loaded by both loop controllers." That packaging does not survive the scope
@@ -88,11 +100,11 @@ lock, without a fourth reviewer, and without coupling two packs that should stan
 
 | ID | Question | Recommendation | Why | Decide by | Reviewer action |
 | --- | --- | --- | --- | --- | --- |
-| D1 | Ship it as **per-loop controller doctrine** — each loop carries the gate in its own skill at its own scope (progressive-disclosure reference modules under the consuming loop's skill), with **no shared library and no cross-pack coupling** — never a self-discovered skill? | Adopt (**amends RFC-0048 D5**) | Dissolves the scope-coupling a shared `core` library hits when `discovery-loop` runs user-scope/pre-repo; keeps each pack standalone; the controller-context (not subagent) means no external shareable skill is needed | RFC accept | Confirm the per-loop shape + the amendment to D5 |
+| D1 | Ship it as **per-loop controller doctrine with a loop-appropriate share** — each loop carries its own copy at its own scope (no shared library, no cross-pack coupling, never a self-discovered skill); **`discovery-loop` carries the full seven-module gate**, **`work-loop` adopts only the net-new slice** atop the passes it already runs? | Adopt (**amends + refines RFC-0048 D5**) | Dissolves the scope-coupling a shared `core` library hits when `discovery-loop` runs user-scope/pre-repo; keeps each pack standalone; most of the gate already lives in `work-loop`, so the full battery is `discovery-loop`'s, not the build loop's | RFC accept | Confirm the per-loop shape, the work-loop/discovery share, and the amendment to D5 |
 | D2 | Make it non-skippable by a controller-gate + checklist-refusal mechanism — doctrine + a mechanical coverage record, not a runtime lock — enforced per loop? | Adopt | The one design question RFC-0048 left to the child; co-scoping guarantees the gate is present wherever the controller runs (no cross-scope absence to degrade around) | RFC accept | Confirm the non-skippable mechanism is genuine yet harness-neutral |
-| D3 | Decompose into seven **progressive-disclosure** step-modules + a per-loop sample-bank, loaded on demand by mode and the axes the design crosses (not a flat march, not all inlined into SKILL.md)? | Adopt | The module shape keeps each step lean and lets light mode load only the core | RFC accept | Confirm the seven-module decomposition + progressive disclosure |
-| D4 | No new reviewer — the fresh-context adversarial step reuses the existing `adversarial-reviewer` (and `devils-advocate` for research/design) in a fresh context? | Adopt | The CHARTER three-reviewer ceiling; the parent's no-new-reviewer; the dispatch already exists in `work-loop` REVIEW | RFC accept | Confirm no fourth reviewer |
-| D5 | Right-size light/full, mirroring `work-loop` (light loads the always-on core; full loads all seven)? | Adopt | The gate must not become ceremony on a one-line change; reuse RFC-0025 rather than a second knob | RFC accept | Confirm the light/full right-sizing |
+| D3 | Decompose the **design-convergence instantiation** into seven progressive-disclosure step-modules + a per-loop sample-bank — **adopted in full by `discovery-loop`**, while **`work-loop` adopts only the net-new slice** (the resolve-vs-surface disposition record + conditional domain-grounding) atop the passes it already runs, under its existing progressive spec time? | Adopt | The module shape keeps each step lean; the full battery is design-convergence work that fits `discovery-loop`'s altitude, not every loop | RFC accept | Confirm the seven-module decomposition + the work-loop/discovery split |
+| D4 | No new reviewer — the fresh-context adversarial step dispatches **the reviewer(s) the loop and work type warrant, selected per [ADR-0042](../adr/0042-agent-additions-keyed-to-loop-and-work-type.md) from each loop's existing roster**, in a fresh context — not a fixed reviewer? | Adopt | ADR-0042 (supersedes ADR-0023): reviewers are keyed to loop + work type, not a global pair; this gate reuses each loop's roster and adds no agent — and no fourth *core-loop* lens (the cap ADR-0042 carries forward) | RFC accept | Confirm no new reviewer and no fourth core-loop lens; selection follows ADR-0042 |
+| D5 | Right-size by reusing each loop's **existing** progressive mode — `work-loop`'s light/full spec time (RFC-0025) and `discovery-loop`'s own — rather than inventing a second knob? (`work-loop` *already* activates progressive mode at spec time; the gate just uses it.) | Adopt | The gate must not become ceremony; the right-sizing knob already exists at spec time, so reuse it | RFC accept | Confirm right-sizing reuses the existing per-loop progressive mode |
 | D6 | Seed a **per-loop** resolve-vs-surface sample-bank — append-only within each loop's own scope, not a shared cross-scope bank? | Adopt | The lens hits the right call only ~half the time without an externalized scaffold; per-loop keeps the bank co-scoped with its controller and avoids cross-pack coupling | RFC accept | Confirm the per-loop sample-bank |
 
 ## Problem & goals
@@ -148,8 +160,8 @@ deliver.
 - Keep each loop's pack **standalone** — the gate must not couple `core` to
   `product-engineering`; each carries its own copy, so either installs without the other.
 - Keep each step **lean and load-only-what-applies** via progressive disclosure, so the gate is
-  proportionate (a one-line change pulls the core; a multi-discipline convergence pulls all seven)
-  and the loop's SKILL.md stays lean.
+  proportionate (in `discovery-loop`, a light pass pulls the core; a multi-discipline convergence
+  pulls all seven) and the loop's SKILL.md stays lean.
 - Give the **resolve-vs-surface lens** a durable home **per loop**, so the calibration that lives
   in one RFC note becomes a living scaffold each loop accretes in its own scope.
 
@@ -162,15 +174,17 @@ deliver.
   the consuming loop's own skill — a whole pack for one markdown gate is overkill.
 - *A self-discovered skill.* Explicitly rejected by RFC-0048 D5; a trigger-matched skill is
   skippable at the agent's discretion, which defeats a *gate*.
-- *A fourth reviewer agent.* The CHARTER caps reviewers at three; the fresh-context step
-  reuses `adversarial-reviewer` / `devils-advocate` (Decision 4).
+- *A new reviewer agent — of any kind.* Per [ADR-0042](../adr/0042-agent-additions-keyed-to-loop-and-work-type.md)
+  the core `work-loop` code-review gate stays capped at its three lenses (no fourth core-loop lens, a
+  charter question this RFC does not raise), and this gate adds no agent in any loop: the
+  fresh-context step reuses each loop's existing, work-type-keyed roster (Decision 4).
 - *An executable gate runtime / lock.* A program that structurally blocks the agent from
   writing past the gate is runtime infrastructure (Principle 3) and harness-specific; we
   ship the doctrine such a harness enforces, not the harness.
-- *Building `discovery-loop`.* The second controller is RFC-0048 D8's child; this RFC wires
-  the **first** consumer (`work-loop`) and specifies the cross-loop seam (goal + resolve-vs-surface
-  + the non-skippable record) plus the seven-module design/build instantiation the second will
-  carry in its own copy.
+- *Building `discovery-loop`.* The full gate's primary home is RFC-0048 D8's child (wired by
+  RFC-0053); this RFC wires the **thin `work-loop` slice** and specifies the cross-loop seam (goal +
+  resolve-vs-surface + the non-skippable record) plus the **full seven-module design-convergence
+  instantiation** that `discovery-loop` will carry in its own copy.
 - *The Domain Framing + Scope Boundary typed artifacts and the traceability lint* (RFC-0048 D4/D6, sibling
   children). The domain-grounding step *consumes* a Domain Framing where one exists and
   degrades to in-gate grounding where it does not; it does not define that artifact.
@@ -235,7 +249,10 @@ honesty is the same posture `operational-safety` ships under ("if the delegated 
 absent, do not silently skip — reason it best-effort and flag the gap").
 
 **Decision 3 — the seven step-modules + the per-loop sample-bank, progressively disclosed.**
-Each step is a `references/self-coverage/<step>.md` module **under the consuming loop's skill**;
+These seven define the **full design-convergence gate `discovery-loop` carries**; **`work-loop`
+adopts only the net-new subset** (the resolve-vs-surface disposition record + conditional
+domain-grounding — see § Inventory). Each step is a `references/self-coverage/<step>.md` module
+**under the consuming loop's skill**;
 the gate phase's Module index in that loop's SKILL.md routes by **mode** (which steps light vs
 full loads) and, for scenario-variation, by **which axes the design crosses** — progressive
 disclosure, loaded on demand, never a flat march and never all inlined into the SKILL.md. The
@@ -247,7 +264,7 @@ seven, with the failure each guards and its grounding:
 | `pre-mortem` | prospective hindsight — assume it shipped and failed; enumerate failure modes, each tagged to a design element | < N scenarios, or any untagged | note 03 (+30% failure ID); Klein prospective hindsight |
 | `taxonomy-walk` | an external dimension register walked one paragraph each (a substantive paragraph, never yes/no) | any dimension blank | note 03 (recall→recognition; external scaffolds beat free recall) |
 | `saturation-declaration` | a grounded-theory stop rule — declare convergence only when a full pass surfaces no new open question and no invalidating edit | declaration absent | note 03; `research-project-check`'s stop-signal (RFC-0048 O6) |
-| `fresh-context-adversarial` | dispatch `adversarial-reviewer` (or `devils-advocate`) in a **fresh context** so the reviewer is not anchored to what was just produced | any finding unresolved | note 03 (plan-mode fresh-context lesson); reuse, no new reviewer |
+| `fresh-context-adversarial` | dispatch the **work-type-appropriate reviewer(s)** (ADR-0042 — `adversarial-reviewer` for code, `design-reviewer` / `devils-advocate` for a design/research artifact, the discovery roster in `discovery-loop`) in a **fresh context** so the reviewer is not anchored to what was just produced | any finding unresolved | note 03 (plan-mode fresh-context lesson); reuse per ADR-0042, no new reviewer |
 | `scenario-variation` | re-run the design against a varied **domain / stakes-level / scale / platform / harness** — orthogonal-axis modelling, loaded only for the axes in play | a crossed axis left unvaried | RFC-0048 D5 (catches stakes- and conflict-class gaps without the human) |
 | `resolve-vs-surface` | a pass over every open item — solve referent-groundable items and cite the referent; surface only value-origination / irreversible-risk / value-conflict (or a referent that genuinely failed) | any open item neither resolved-with-referent nor surfaced-with-reason | RFC-0048 D5; note 09 sample-bank |
 
@@ -256,28 +273,40 @@ resolve-vs-surface are RFC-0048 D5's two additions. The **per-loop sample-bank**
 (`references/self-coverage/resolve-vs-surface-sample-bank.md` under the consuming loop's skill) is
 the calibration the `resolve-vs-surface` module points to — see Decision 6.
 
-**Decision 4 — no new reviewer.** The `fresh-context-adversarial` module *invokes* the
-existing reviewers; it adds none. For a build/spec/implementation artifact that is
-`adversarial-reviewer`; for a research or design artifact it is `devils-advocate`
-([`0048-notes/06`](0048-notes/06-pack-delta-and-orchestration.md):61). The novelty is not a
-new agent but a *named obligation* to run the existing one in a separated context, which
-`work-loop`'s REVIEW already does — the gate formalizes and names it as one of its seven
-steps rather than duplicating it.
+**Decision 4 — no new reviewer; selection follows ADR-0042.** The `fresh-context-adversarial`
+module *invokes* whichever reviewer(s) the **loop and work type** warrant and **adds none** — the
+selection rule is [ADR-0042](../adr/0042-agent-additions-keyed-to-loop-and-work-type.md) (agent
+additions keyed to loop and work type, superseding ADR-0023's narrower three-lens framing), not a
+fixed reviewer. In the `work-loop` code-review gate that is the core lenses the diff warrants
+(`adversarial-reviewer` always; `security-reviewer` / `quality-engineer` as the work crosses their
+boundary, exactly as REVIEW already routes them) — and the gate adds **no fourth core-loop lens**,
+the cap ADR-0042 carries forward. In `discovery-loop` it is that loop's own design-time roster
+(`discovery-threat-reviewer`, `discovery-reliability-reviewer`, the reused `design-reviewer`, and
+the `experience-reviewer` — RFC-0048 §lens-team roster, RFC-0050 D7); for a research or design
+artifact, `design-reviewer` / `devils-advocate`
+([`0048-notes/06`](0048-notes/06-pack-delta-and-orchestration.md)). The novelty is not a new
+agent but a *named obligation* to run the work-appropriate reviewer in a separated context, which
+`work-loop`'s REVIEW already does — the gate formalizes and names it rather than duplicating it.
 
-**Decision 5 — right-size light/full.** The gate reuses `work-loop`'s existing light/full
-distinction (RFC-0025) rather than inventing a second knob:
+**Decision 5 — right-size by each loop's existing progressive mode (no second knob).** The gate
+reuses each loop's **own** light/full distinction rather than inventing one:
 
-- **Light mode** loads the **always-on core**: `domain-grounding` + `resolve-vs-surface` +
-  a **single bounded** `fresh-context-adversarial` pass. A surfaced Blocker that survives
-  one re-review **escalates to full mode** — the exact bounded-pass rule `work-loop` light
-  mode already uses (SKILL.md:94-97).
-- **Full mode** loads **all seven**: the core plus `pre-mortem`, `taxonomy-walk`,
-  `saturation-declaration`, and `scenario-variation` across the axes the design crosses,
-  with the `fresh-context-adversarial` pass **iterated to clean** (not bounded).
+- **`work-loop`** already activates a light/full progressive mode **at spec time** (RFC-0025):
+  full mode authors a full `new-spec`, light mode a lean inline spec. Its self-coverage share —
+  the resolve-vs-surface **disposition record** plus a **conditional domain-grounding** check —
+  attaches to that spec time and is governed by the same knob; it is small in both modes by
+  construction, so there is nothing extra to right-size. The existing light-mode **bounded**
+  `adversarial-reviewer` pass (escalate-to-full on a surviving Blocker — SKILL.md:94-97) is the
+  fresh-context step it already runs.
+- **`discovery-loop`** reuses its **own** progressive mode for the full seven: light loads the
+  always-on core (`domain-grounding` + `resolve-vs-surface` + a single bounded
+  `fresh-context-adversarial` pass); full loads all seven — `pre-mortem`, `taxonomy-walk`,
+  `saturation-declaration`, and `scenario-variation` across the axes the design crosses, with the
+  `fresh-context-adversarial` pass **iterated to clean** (not bounded).
 
-This keeps the gate proportionate — a one-line change in light mode runs three cheap steps;
-a multi-discipline convergence in full mode runs the full battery — and it inherits
-right-sizing from the loop instead of re-deciding it.
+This keeps the gate proportionate and inherits right-sizing from each loop instead of re-deciding
+it — and, for `work-loop`, confirms the point that drove this RFC's framing: the progressive knob
+already exists at spec time, so the gate plugs into it rather than adding one.
 
 **Decision 6 — a per-loop sample-bank.** The resolve-vs-surface sample-bank currently lives
 in [`0048-notes/09`](0048-notes/09-gap-resolutions.md) as a "living artifact — expectation
@@ -304,28 +333,52 @@ in note 09 (its pre-seeding home); the seeding move itself is a follow-on of *th
 implementing spec. The build-self/projection mechanics are a spec-time detail, not an open design
 question (OQ2 records the recommended default).
 
-*The seam with `work-loop` (Principle 2 — no duplication).* The gate does **not** re-implement
-REVIEW. An inventory diff against `work-loop` today: the `fresh-context-adversarial` step *is* the
-existing REVIEW adversarial pass (named, not duplicated); the `pre-mortem` and the open-item
-disposition have partial hooks in PLAN's assumption trio and declined-pattern register;
-`domain-grounding`, `taxonomy-walk`, `saturation-declaration`, and `scenario-variation` are
-**net-new surface** the loop does not carry today. So the gate supplies depth for steps the loop
-already gestures at and adds the missing steps — the same inventory-diff argument RFC-0041 used to
-clear Principle 2 for `operational-safety`.
+*Inventory — what `work-loop` already covers, what's net-new, and what it does **not** adopt
+(Principle 2 — no duplication).* The gate does **not** re-implement REVIEW, and it does **not** bolt
+a design-convergence battery onto the build loop. The load-bearing fact: `work-loop` **already has a
+progressive spec time** — its PLAN phase authors the spec (full mode → `new-spec`; light mode → a
+lean inline spec), and the light/full knob (RFC-0025) already right-sizes how much spec ceremony
+runs. So the gate needs **no new right-sizing knob**, and any convergence depth `work-loop` wants
+attaches to **full-mode spec time**, already gated — never to EXECUTE, never to every loop. The
+honest per-module inventory:
 
-*Consumers & sequencing — three loops, two instantiations.* Self-coverage is a **goal** every
-loop with a human handoff realizes (§ The ask → *What self-coverage is*), and the seven modules are
-its instantiation for **generative design/build** work, where myopic-greedy commitment is the
-risk. So:
+| Module | In `work-loop` today | `work-loop` adopts | `discovery-loop` adopts |
+|---|---|---|---|
+| `fresh-context-adversarial` | **already applies** — *is* the REVIEW pass (and the pre-EXECUTE spec/plan pass at spec time) | name it; add nothing | full |
+| `resolve-vs-surface` | **bones present** — the `Surface` verb + DECIDE's apply/defer routing ("every Concern/Nit resolves into one of the two") | **net-new: the disposition *record*** (the artifact, not the routing) | full |
+| `pre-mortem` | **hook present** — PLAN's assumption trio + declined-pattern register | keep the hook; not a separate module | full prospective-hindsight |
+| `domain-grounding` | partly served by the EXECUTE contract-grounding gate (API contracts, not domain claims) | **net-new but conditional** — fires when the build rests on an ungrounded load-bearing domain claim; degrades to "the spec already grounds this" | full |
+| `taxonomy-walk` | — | **not adopted** — design-convergence; if full-mode spec time wants it, pull it under the existing light/full knob, not a new gate | full |
+| `saturation-declaration` | terminates on gates + review + caps, not "no new open question" | **not adopted** — a design-convergence stop rule, same disposition | full |
+| `scenario-variation` | — | **not adopted** — design-convergence, same disposition | full (axes the design crosses) |
 
-- **`work-loop`** is the **first** consumer of the design/build instantiation: the gate runs at its
-  REVIEW→DECIDE boundary as the pre-done coverage pass, carrying the seven modules under its own
-  skill. Wired **here**.
-- **`discovery-loop`** (RFC-0048 D8, not built) is the **second**: it runs the same seven modules
-  as its pre-convergence (pre-G2) gate — where [`0048-notes/05`](0048-notes/05-judgment-decomposition-and-phases.md):51
-  places it — carrying **its own** copy under its own skill in `product-engineering`. Wired by
-  **[RFC-0053](0053-the-discovery-loop.md)** (the discovery-loop RFC), which consumes this
-  RFC's seam.
+So `work-loop`'s adoption is **thin**: name the passes it already runs, and add two net-new items at
+spec time / DECIDE — the resolve-vs-surface **disposition record** and a **conditional
+domain-grounding** check — both governed by the progressive mode it already carries. The full
+seven-module design-convergence gate is **`discovery-loop`'s**, at its native altitude (next). This
+is the same inventory-diff argument RFC-0041 used to clear Principle 2 for `operational-safety`,
+applied honestly: supply only what the loop lacks.
+
+*Consumers & sequencing — three loops, a goal realized loop-appropriately.* Self-coverage is a
+**goal** every loop with a human handoff realizes (§ The ask → *What self-coverage is*). The seven
+modules are its instantiation for **generative design-convergence** work, where myopic-greedy
+commitment is the live risk and a design artifact exists to ground — that altitude is
+**`discovery-loop`'s**, not the build loop's. So:
+
+- **`discovery-loop`** (RFC-0048 D8, not built) is the **primary consumer of the full seven-module
+  gate**: it runs all seven as its pre-convergence (pre-G2) gate — where
+  [`0048-notes/05`](0048-notes/05-judgment-decomposition-and-phases.md):51 places it — carrying its
+  **own** copy under its own skill in `product-engineering`, right-sized by its own progressive mode.
+  This is where the design-convergence battery earns its place. Wired by
+  **[RFC-0053](0053-the-discovery-loop.md)** (the discovery-loop RFC), which consumes this RFC's seam
+  and the seven-module instantiation specified here.
+- **`work-loop`** (in `core`, repo-scope) realizes the **same goal + seam with a thin,
+  loop-appropriate share** — it does **not** carry the full seven. Most of the gate already lives in
+  `work-loop` (§ Inventory): REVIEW *is* fresh-context-adversarial, Surface + DECIDE *are* the
+  resolve-vs-surface bones, the assumption trio + declined-pattern register *are* the pre-mortem hook,
+  and its **light/full progressive spec time already right-sizes** how much convergence runs. The
+  net-new is two items at spec time / DECIDE: the resolve-vs-surface **disposition record** and a
+  **conditional domain-grounding** check. Wired **here** as a thin edit.
 - **`release-loop`** ([RFC-0049](0049-the-release-loop-and-company-os.md)) realizes the **same goal
   and the same seam** (resolve-vs-surface + the non-skippable coverage record) through a
   **different, deploy-appropriate instantiation** — a *composite*, not a single checklist. No one
@@ -341,10 +394,12 @@ risk. So:
   seam it conforms to.
 
 This RFC specifies the **seam** — the goal + the resolve-vs-surface disposition + the non-skippable
-mechanism — as the cross-loop invariant each loop implements in its own co-scoped copy; it does
+mechanism — as the cross-loop invariant each loop implements in its own co-scoped copy, plus the
+**full seven-module design-convergence instantiation** that `discovery-loop` carries; it does
 **not** ship a file any other loop imports. That satisfies RFC-0048 D5's "every loop controller
-runs it" the honest way: each loop runs the same *goal* through a loop-appropriate instantiation,
-neither pack depending on the other.
+runs it" the honest way: each loop runs the same *goal* through a **loop-appropriate** instantiation
+— the full seven where the altitude warrants it (`discovery-loop`), a thin slice where the loop
+already covers the rest (`work-loop`) — neither pack depending on the other.
 
 ## Options considered
 
@@ -358,7 +413,7 @@ Options are MECE along it; prior art grounds each.
 | **A. Do nothing** — leave the steps as scattered prose in `work-loop` | none · discretionary | Cost of delay: the knowing-doing gap (note 03) recurs on every product; the steps stay unnamed, unrouted, and skippable by omission. Rejected. |
 | **B. Self-discovered skill** the agent invokes when it judges it relevant | skill · discretionary | A trigger-matched skill is skippable at the agent's discretion under anchoring — which defeats a *gate*. **Explicitly rejected by RFC-0048 D5.** Rejected. |
 | **C. Controller doctrine + progressive-disclosure reference modules** ★ | controller-co-located reference modules + doctrine · mechanical-record (+ structural where the harness offers it) | **Recommended.** The `operational-safety` / RFC-0041 idiom for *form and reuse* — but the modules sit under the consuming loop's own skill, not in a shareable standalone library (Principle 1: the controller reads its own context, never an external skill). Clears Principles 1–3; non-skippable via the done-checklist refusal the loop already enforces. (Locus settled by Axis 2 → per-loop.) |
-| **D. A fourth reviewer agent** dedicated to coverage | new agent · discretionary | Fails the CHARTER three-reviewer ceiling; the fresh-context step already reuses the existing reviewers. Rejected. |
+| **D. A new reviewer agent** dedicated to coverage | new agent · discretionary | Fails [ADR-0042](../adr/0042-agent-additions-keyed-to-loop-and-work-type.md): in the core loop it would be a fourth *core-loop* lens (a charter question the ADR does not pre-authorize), and in any loop it adds no value an existing work-type-keyed reviewer in a fresh context doesn't already give. The fresh-context step reuses them. Rejected. |
 | **E. Executable gate runtime / lock** that structurally blocks writing past the gate | runtime · structural | The strongest enforcement, but it is runtime infrastructure (Principle 3) and harness-specific (the RFC-0041 P4 harness-neutrality posture). We ship the doctrine such a harness enforces, not the harness. Rejected as the *shipped* form; folded into Option C's layer 3 where the harness provides it. |
 
 **Axis 2 (within C): where does the depth live, given two controllers in different scopes?**
@@ -371,7 +426,7 @@ Options are MECE along it; prior art grounds each.
 |---|---|---|
 | **C1. One shared copy in `core`** (RFC-0048 D5's stated packaging) | repo-scope, shared | Absent when `discovery-loop` runs user-scope/pre-repo; the gate would have to detect-and-degrade, which is self-defeating for the floor-raiser. **Rejected — this RFC amends D5.** |
 | **C2. One shared copy in a new pack** at the broader (user) scope | user-scope, shared | Reachable by both, but a whole pack (pack.toml, evals, guide, marketplace entry, version) for one markdown gate is overkill, and it forces a `core`↔new-pack dependency that couples packs which should stand alone. Rejected. |
-| **C3. One copy per loop, each under its own skill at its own scope** ★ | co-scoped, per-loop | **Recommended.** Guaranteed present wherever each controller runs; zero cross-pack coupling; "loaded by both" = "both run the same method." The duplication cost is bounded — today only `work-loop` exists, and the future discovery copy is *intended* to differ in depth — with two standing cross-copy invariants once D8 exists: the cross-loop **seam** (all loops — goal + resolve-vs-surface + the non-skippable record) and, narrower, the shared **seven-module instantiation** (design/build loops only) (see Risks). |
+| **C3. One copy per loop, each under its own skill at its own scope** ★ | co-scoped, per-loop | **Recommended.** Guaranteed present wherever each controller runs; zero cross-pack coupling; "loaded by both" = "both realize the same goal with a loop-appropriate share." The duplication cost is bounded — today only `work-loop` exists and it carries only the thin slice, while the future discovery copy carries the full seven (the depths are *intended* to differ). The standing cross-copy invariant is the cross-loop **seam** (all loops — goal + resolve-vs-surface + the non-skippable record); the full **seven-module instantiation** is `discovery-loop`'s, not a shared obligation (see Risks). |
 
 Prior art for the recommended shape: `operational-safety` and `security-checklists`
 in-repo (controller-loaded progressive-disclosure libraries the loop already inlines);
@@ -397,12 +452,13 @@ Option C's layer 3.
 - *The two loops' per-loop copies drift apart.* Per-loop doctrine means `work-loop` and (future)
   `discovery-loop` each carry the method, so the prose can diverge. **Mitigation:** today there is
   exactly one copy — `discovery-loop` is unbuilt — so the drift is hypothetical until D8; and when
-  D8 builds the second, divergence is *intended* (a build done-declaration and a discovery
-  convergence genuinely differ in emphasis). The shared invariants are specified *here*: the
-  cross-loop **seam** (the goal, resolve-vs-surface, the non-skippable coverage record) that *all*
-  loops conform to, plus — for the two design/build loops specifically — the **seven-module
-  instantiation** the discovery child implements against. So the method stays aligned even though
-  the files are separate. This is cheaper than the cross-pack coupling a single shared file would
+  D8 builds the second, divergence is *intended and by design* — `work-loop` carries only the thin
+  net-new slice while `discovery-loop` carries the full seven, so the depths are meant to differ.
+  The one cross-copy invariant specified *here* is the cross-loop **seam** (the goal,
+  resolve-vs-surface, the non-skippable coverage record) that *all* loops conform to; the full
+  **seven-module instantiation** is owned here as `discovery-loop`'s to implement against, not a
+  shape `work-loop` must also match. So the goal stays aligned even though the files — and their
+  depths — are separate. This is cheaper than the cross-pack coupling a single shared file would
   force, and the alternative (one shared copy) was rejected outright on the scope split (Options
   C1/C2).
 - *Light mode loads too little and a real coverage gap ships under "light".*
@@ -421,27 +477,31 @@ Option C's layer 3.
   detects it, layer 2 is weaker than claimed and the gate needs the lint that
   `lint-spec-status.py` is for doc-drift. (Believed sufficient; the done-checklist already
   enforces comparable refusal items.)
-- *The cross-loop seam is general enough for every loop, and the seven design/build modules are
-  altitude-neutral enough to be shared by both design/build loops.* The seam (goal +
-  resolve-vs-surface + the non-skippable record) must hold for design, build, *and* deploy work, or
-  "every loop realizes the same goal" is hollow; and the seven modules must fit both `work-loop` and
-  `discovery-loop`, or the design/build instantiation splits. (Believed true; resolve-vs-surface and
-  the coverage record are altitude- and work-type-neutral — they apply to a deploy carve as much as
-  a spec done-declaration — and grounding/pre-mortem/saturation apply to a spec done-declaration as
-  much as a convergence, which is why RFC-0048 names every loop. If a design/build module turns out
-  build-only or discovery-only, the instantiation records which modules are shared vs loop-specific
-  — a cheaper outcome under per-loop copies than under one shared file.)
+- *The cross-loop seam is general enough for every loop, and the net-new slice `work-loop` adopts
+  is genuinely the only part not already covered there.* The seam (goal + resolve-vs-surface + the
+  non-skippable record) must hold for design, build, *and* deploy work, or "every loop realizes the
+  same goal" is hollow. And the inventory claim must be right: if a module marked "already applies"
+  or "not adopted" for `work-loop` turns out to leave a real coverage gap on build work, the thin
+  slice is too thin. (Believed true; resolve-vs-surface and the coverage record are altitude- and
+  work-type-neutral — they apply to a deploy carve as much as a spec done-declaration — and the
+  inventory is conservative: it credits `work-loop` only for passes it demonstrably runs today and
+  routes everything genuinely new through its already-progressive spec time. If the slice proves too
+  thin, the fix is to promote one more module into `work-loop`'s spec-time adoption — cheaper under
+  per-loop copies than under one shared file.)
 - *Right-sizing by `work-loop`'s light/full is the right granularity.* If the gate needs a
   finer dial than two modes, this under-serves it. (Believed adequate; the per-axis routing
   of `scenario-variation` already adds a second dimension within full mode.)
 
-**Drawbacks.** A new set of reference modules under `work-loop` to maintain alongside the
-existing `operational-safety` and `security-checklists` libraries — real surface-area cost,
-justified because the gate is universal (it runs on *every* full-mode loop, not only
-infra/security ones). When `discovery-loop` is built it carries a second copy of the method —
-duplication is the price of zero cross-pack coupling, and is bounded by specifying the shared
-invariants here as a seam. Added prose in `work-loop`'s REVIEW/DECIDE and the done-checklist. A
-per-loop sample-bank that needs curation discipline to stay a scaffold rather than a junk drawer.
+**Drawbacks.** `work-loop`'s cost is small but real: added prose in its REVIEW/DECIDE naming the
+existing passes as the gate's steps, the two net-new spec-time/DECIDE checks (the disposition
+record + conditional domain-grounding), one done-checklist refusal item, and a seeded
+`resolve-vs-surface-sample-bank.md` to curate — **no heavy reference-module set under `work-loop`**.
+The heavy surface-area cost — a `references/self-coverage/` module library to maintain alongside
+`operational-safety` and `security-checklists` — lands on **`discovery-loop`** when it is built,
+where the full battery earns its place. That second copy is duplication, but it is the price of zero
+cross-pack coupling and is bounded by specifying the shared invariants here as a seam (and the
+copies' depths are *intended* to differ — thin in `work-loop`, full in `discovery-loop`). Each
+loop's sample-bank needs curation discipline to stay a scaffold rather than a junk drawer.
 
 ## Evidence & prior art
 
@@ -505,31 +565,41 @@ naming/mechanics details, not because the research is unfinished).
 
 Filled in on acceptance.
 
-- **ADR:** record "the self-coverage gate is **per-loop controller doctrine** — each loop carries
-  the gate (a named phase + progressive-disclosure reference modules + a per-loop sample-bank) in
-  its own skill at its own scope, non-skippable via a coverage-record checklist refusal, with **no
-  shared library and no cross-pack coupling** — no new reviewer, no new runtime" (the sibling of
-  ADR-0031 for `operational-safety`; **amends/extends** RFC-0048 D5's "one `core` library loaded by
-  both controllers").
-- **Spec:** `docs/specs/self-coverage-gate/` — the `work-loop` gate phase + its
-  `references/self-coverage/<step>.md` modules (seven steps + the seeded per-loop
-  `resolve-vs-surface-sample-bank.md`) under the `work-loop` skill, the Module index routing
-  (mode + axis), the `work-loop` REVIEW/DECIDE wiring + the done-checklist refusal item, and the
-  sample-bank seeding (note 09 → the `work-loop` bank) with its build-self projection wiring.
-- **`discovery-loop` seam:** consumed by RFC-0048 D8's child, which carries its **own** copy of the
-  gate (phase + modules + its own sample-bank) in `product-engineering` at user scope, implementing
-  the shared method/invariants specified here (the gate as `discovery-loop`'s pre-convergence G2
-  gate) — *not* a file it imports from `core`.
+- **ADR:** record "the self-coverage gate is **per-loop controller doctrine with a loop-appropriate
+  share** — each loop carries its own copy at its own scope (no shared library, no cross-pack
+  coupling, no new reviewer, no new runtime); **`discovery-loop` carries the full seven-module
+  design-convergence gate**, while **`work-loop` adopts only the net-new slice** (a resolve-vs-surface
+  disposition record + conditional domain-grounding) atop the passes it already runs and under its
+  existing progressive spec time" (the sibling of ADR-0031 for `operational-safety`; **amends +
+  refines** RFC-0048 D5's "one `core` library loaded by both controllers").
+- **Spec:** `docs/specs/self-coverage-gate/` — **a thin `work-loop` edit**: name its existing passes
+  as the gate's steps, add the resolve-vs-surface **disposition record** and a **conditional
+  domain-grounding** check at spec time / DECIDE under the existing light/full mode, add **one**
+  done-checklist refusal item (the disposition record), and seed the `work-loop`
+  `resolve-vs-surface-sample-bank.md` (note 09 → the `work-loop` bank) with its build-self projection
+  wiring. **No heavy design-convergence reference modules ship under `work-loop`** — the full
+  seven-module instantiation is specified here for **`discovery-loop`** to carry (next), not built in
+  `core`.
+- **`discovery-loop` seam (the full gate's home):** consumed by RFC-0048 D8's child (RFC-0053),
+  which carries its **own** copy of the **full seven-module gate** (phase + modules + its own
+  sample-bank) in `product-engineering` at user scope, right-sized by its own progressive mode,
+  implementing the seam + the seven-module instantiation specified here (the gate as
+  `discovery-loop`'s pre-convergence G2 gate) — *not* a file it imports from `core`.
 - **CONVENTIONS touch:** name the self-coverage gate in the operating-model section
   (RFC-0048's CONVENTIONS slice), as the floor-raiser each loop carries.
 - **Changelog:** `docs/product/changelog.md` `[Unreleased]` entry for the `work-loop`
   behavior change.
-- **Pack version:** bump `core` (`work-loop` edits + new reference modules). No new skill, no new
-  pack, no marketplace addition — the gate lives under the existing `work-loop` skill.
-- **Foundation reconciliation:** **amends RFC-0048 D5.** D5's packaging ("a reference library in
-  `core`, loaded by both loop controllers") does not survive the operating model's own scope split
-  — `discovery-loop` is user-scope/pre-repo where a repo-scope `core` library is absent. Reconciled
-  to **per-loop co-scoped doctrine** (each loop carries its own copy; no shared library; no
-  `core`↔`product-engineering` coupling); "loaded by both controllers" = "both loops run the same
-  method." Recorded at [RFC-0048 § Amendments](0048-autonomous-product-team-operating-model.md#amendments-foundation-reconciliations)
+- **Pack version:** bump `core` (the thin `work-loop` SKILL.md edits + the seeded
+  `resolve-vs-surface-sample-bank.md`; **no heavy reference modules** under `work-loop`). No new
+  skill, no new pack, no marketplace addition — the gate lives under the existing `work-loop` skill.
+- **Foundation reconciliation:** **amends + refines RFC-0048 D5.** *(Packaging)* D5's "a reference
+  library in `core`, loaded by both loop controllers" does not survive the operating model's own
+  scope split — `discovery-loop` is user-scope/pre-repo where a repo-scope `core` library is absent —
+  so it is reconciled to **per-loop co-scoped doctrine** (each loop carries its own copy; no shared
+  library; no `core`↔`product-engineering` coupling). *(Share)* D5's "both design/build loops run the
+  seven-module gate" is **refined**: `discovery-loop` carries the **full** seven (its native
+  design-convergence altitude), while `work-loop` adopts only the **net-new slice** because its
+  existing structure and already-progressive spec time cover the rest — so "loaded by both
+  controllers" = "both loops realize the same goal, each with a loop-appropriate share." Recorded at
+  [RFC-0048 § Amendments](0048-autonomous-product-team-operating-model.md#amendments-foundation-reconciliations)
   (2026-06-29) per the D9 series-execution obligation.

--- a/docs/rfc/0053-the-discovery-loop.md
+++ b/docs/rfc/0053-the-discovery-loop.md
@@ -6,7 +6,7 @@
 - **Date opened:** 2026-06-26
 - **Date closed:**
 - **Decision weight:** heavy <!-- light | standard | heavy — sets the upstream orchestration contract the whole operating model hangs from, ships a new agent + skill + a versioned sidecar schema, and carries a security/integrity + data-classification surface; explicit Approver sign-off is warranted. -->
-- **Related:** [RFC-0048](0048-autonomous-product-team-operating-model.md) (the foundation — this is **child 5**, the coordinator spike→RFC for Decisions 7 + 8; the provisional foundation this drift-aligns back to) · [RFC-0049](0049-the-release-loop-and-company-os.md) (the sibling *downstream* outer loop — `release-lead` + `release-loop`, the same agent-def + skill + harness pattern this RFC establishes upstream; both build on the same RFC-0048 substrate (the sidecar + the gate arc), and this RFC specifies the sidecar schema RFC-0049's release loop would also consume) · [RFC-0051](0051-the-self-coverage-gate.md) (the self-coverage gate — RFC-0051 owns the goal + seam + the seven-module design/build instantiation; `discovery-loop` carries its **own** co-scoped copy as its pre-G2 phase, wired here) · [RFC-0050](0050-the-experience-pack.md) (the `experience` lens this loop detect-and-degrades on) · [RFC-0041](0041-infra-aware-work-loop.md) + ADR-0031 (the *doctrine + reference library + reuse, no engine/no new reviewer* precedent the framing rests on) · RFC-0025 (`work-loop` light/full + the iteration cap this loop's outer cap mirrors) · RFC-0040 (the three-tier layout resolution the sidecar paths obey) · RFC-0019 (`receive-brief` — the brief→spec join at G3; its coverage lint child-4's traceability lint generalizes) · [ADR-0022](../adr/0022-value-stream-meta-repo-cross-component-layer.md) (the cross-repo reference-by-version mechanism the traceability slot reuses) · [`docs/specs/traceability-lint/`](../specs/traceability-lint/spec.md) (child-4 — the lint that consumes the traceability slot) · promoted research + the empirical prototype in [`0053-notes/`](0053-notes/); [`0048-notes/09`](0048-notes/09-gap-resolutions.md) (the paper resolutions this spike confirms) and [`0048-notes/02`](0048-notes/02-worked-example-flow-trace.md) (the worked example it was run against)
+- **Related:** [RFC-0048](0048-autonomous-product-team-operating-model.md) (the foundation — this is **child 5**, the coordinator spike→RFC for Decisions 7 + 8; the provisional foundation this drift-aligns back to) · [RFC-0049](0049-the-release-loop-and-company-os.md) (the sibling *downstream* outer loop — `release-lead` + `release-loop`, the same agent-def + skill + harness pattern this RFC establishes upstream; both build on the same RFC-0048 substrate (the sidecar + the gate arc), and this RFC specifies the sidecar schema RFC-0049's release loop would also consume) · [RFC-0051](0051-the-self-coverage-gate.md) (the self-coverage gate — RFC-0051 owns the goal + seam and specifies the full seven-module design-convergence instantiation; `discovery-loop` is that instantiation's **primary home**, carrying its **own** co-scoped copy of all seven modules as its pre-G2 phase, wired here — whereas `work-loop` adopts only the net-new slice) · [RFC-0050](0050-the-experience-pack.md) (the `experience` lens this loop detect-and-degrades on) · [RFC-0041](0041-infra-aware-work-loop.md) + ADR-0031 (the *doctrine + reference library + reuse, no engine/no new reviewer* precedent the framing rests on) · RFC-0025 (`work-loop` light/full + the iteration cap this loop's outer cap mirrors) · RFC-0040 (the three-tier layout resolution the sidecar paths obey) · RFC-0019 (`receive-brief` — the brief→spec join at G3; its coverage lint child-4's traceability lint generalizes) · [ADR-0022](../adr/0022-value-stream-meta-repo-cross-component-layer.md) (the cross-repo reference-by-version mechanism the traceability slot reuses) · [`docs/specs/traceability-lint/`](../specs/traceability-lint/spec.md) (child-4 — the lint that consumes the traceability slot) · promoted research + the empirical prototype in [`0053-notes/`](0053-notes/); [`0048-notes/09`](0048-notes/09-gap-resolutions.md) (the paper resolutions this spike confirms) and [`0048-notes/02`](0048-notes/02-worked-example-flow-trace.md) (the worked example it was run against)
 
 ## Reviewer brief
 
@@ -117,10 +117,15 @@ and **writes the contract** the prototype validated (Decisions 2–5).
   transition that walks its edges. The spike's `check_sidecar.py` is a *demonstrator*, not
   the shipped lint.
 - *The self-coverage gate's modules.* RFC-0051 (child-3) owns the self-coverage **goal + seam**
-  and ships the **design/build instantiation** (the seven modules); this RFC names it as
-  `discovery-loop`'s pre-G2 phase, carrying its **own** co-scoped copy of those modules in
-  `product-engineering` (the seam RFC-0051 specified — both design/build loops share the
-  seven-module instantiation; the release loop realizes the same goal differently per RFC-0049).
+  and specifies the **full seven-module design-convergence instantiation**. **`discovery-loop` is
+  that instantiation's primary home** — this RFC names it as `discovery-loop`'s pre-G2 phase,
+  carrying its **own** co-scoped copy of all seven modules in `product-engineering`, right-sized by
+  this loop's own progressive mode. This is the altitude the battery is built for: a design artifact
+  is being converged and myopic-greedy commitment is the live risk. (Per RFC-0051's reframe,
+  `work-loop` does **not** carry the full seven — most of the gate already lives in `work-loop`, so
+  it adopts only the net-new slice; the release loop realizes the same goal through a deploy
+  composite per RFC-0049. Each loop conforms to the same cross-loop seam with a **loop-appropriate
+  share**.)
 - *The downstream / deploy loop.* `work-loop` (G3–G5 build) is unchanged; the
   release/deploy outer loop is RFC-0049's `release-lead`. This RFC is the **upstream**
   (G0–G2) coordinator only; the two loops hand off at G3 and must not be conflated.
@@ -370,10 +375,13 @@ RFC ships no code, so it specifies the controls, it does not implement them):
 - **G3 handoff to `work-loop`** (unchanged): `discovery-loop` emits a brief → `new-spec` →
   `work-loop`. The two loops meet here; different inputs, different verifier, different
   autonomy posture.
-- **The self-coverage gate** (RFC-0051) runs as `discovery-loop`'s **pre-G2 phase** — discovery
-  carries its own co-scoped copy of the seven-module design/build instantiation, conforming to
-  RFC-0051's cross-loop seam (goal + resolve-vs-surface + a non-skippable coverage record); wired
-  here.
+- **The self-coverage gate** (RFC-0051) runs as `discovery-loop`'s **pre-G2 phase**, and this loop
+  is the **primary home of the full seven-module design-convergence instantiation** — discovery
+  carries its own co-scoped copy of all seven modules, right-sized by this loop's own progressive
+  mode, conforming to RFC-0051's cross-loop seam (goal + resolve-vs-surface + a non-skippable
+  coverage record); wired here. Unlike `work-loop` (which adopts only the net-new slice because the
+  rest already lives in its loop), discovery runs the full battery: this is the altitude it was
+  built for.
 - **The traceability lint** (child-4) consumes the **traceability slot** this RFC defines;
   the cascade-invalidation transition (D3) walks the same edges. The lint is authoritative
   when the matrix is present and derives from on-disk artifacts when the sidecar is absent
@@ -486,7 +494,7 @@ paper resolutions this confirms) and [`02`](0048-notes/02-worked-example-flow-tr
 worked example); RFC-0041 + ADR-0031 (the doctrine + reference-library + reuse, no-engine
 idiom); RFC-0049 (the sibling downstream loop shipped as `release-lead` agent + skill +
 harness — the exact pattern this establishes upstream); RFC-0051 (the self-coverage gate —
-`discovery-loop` carries its own copy of the seven-module design/build instantiation); RFC-0050 (the `experience` lens);
+`discovery-loop` is the primary home of the full seven-module design-convergence instantiation, carried as its own co-scoped copy); RFC-0050 (the `experience` lens);
 `work-loop`'s supervisor mode + `loop-cohort` (doctrine + a scheduler-*script*, not a
 service — the precedent that a scheduler can be a lint); RFC-0025 (the iteration cap +
 light/full); RFC-0040 (the three-tier layout the sidecar paths obey); RFC-0019's


### PR DESCRIPTION
## What

Reframes the self-coverage gate (RFC-0051) to be honest about what `work-loop` already covers, and updates D4's reviewer-selection framing to the current ADR.

### 1. Self-coverage scope — `work-loop`-thin / `discovery-loop`-full

RFC-0051 previously made `work-loop` the "first consumer" carrying the **full seven-module gate**, with `discovery-loop` a second consumer carrying the same. That over-scoped the build loop. The reframe:

- **`work-loop` adopts only the net-new slice.** Most of the gate already lives there — REVIEW *is* the `fresh-context-adversarial` pass; Surface + DECIDE *are* the `resolve-vs-surface` bones; the assumption trio + declined-pattern register *are* the `pre-mortem` hook; and its light/full spec time (RFC-0025) is **already progressive**. So `work-loop` adds only: a resolve-vs-surface **disposition record**, a **conditional domain-grounding** check, and **one** done-checklist refusal item. No heavy reference modules under `work-loop`.
- **`discovery-loop` is the primary home of the full seven-module design-convergence gate** — its native altitude (a design artifact being converged; myopic-greedy commitment the live risk). RFC-0053 updated to match.
- A new central **§ Inventory table** in RFC-0051 records, per module, what already applies / what's net-new / what `work-loop` does not adopt.

### 2. D4 — reviewer selection follows ADR-0042

D4 previously said the fresh-context step "reuses `adversarial-reviewer` (and `devils-advocate` for research/design)" and cited "the CHARTER three-reviewer ceiling." **ADR-0042** (Accepted, supersedes ADR-0023) establishes that reviewers are keyed to **loop and work type**, and the three-lens cap binds only the **core `work-loop` code-review gate**. D4 and all coupled spots (Decision 4 prose, the non-goal, Option D, the module dispatch row, the Reviewer brief, the Related line) now say: dispatch the work-type-appropriate reviewer(s) per ADR-0042 from each loop's existing roster, in a fresh context; no new reviewer; no fourth core-loop lens.

### 3. RFC-0048 amended (Open RFC)

The reframe refines RFC-0048 D5. Its authoritative current-state table, D5 row, D4–D6 prose, operating-model bullet, and the 2026-06-29 self-coverage amendment entry were updated to read discovery-full / work-loop-thin, keeping the foundation consistent with its children.

## Scope / notes

- **Docs-only** governance change across three RFCs. No code, no tests.
- RFC-0048 stays **Open**; the edit is recorded as a tracked amendment in its § Amendments audit trail.
- Branch name (`…work-loop-vs-build-loop-rename`) predates this work — the rename/extraction it referred to was considered and **declined as too impactful**; this PR is the RFC reframe only.

## Review

Two adversarial-reviewer passes run to `Clean — ready to commit.` — caught and fixed the RFC-0048 inconsistency (foundation table contradicting the children) and two stale spots (Drawbacks + Pack-version follow-on) the reframe had left.