### PR TITLE
feat(core): root→leaf reachability pass in the traceability lint (closes AC34 gap)

### DIFF
--- a/.agents/skills/work-loop/scripts/lint-traceability.py
+++ b/.agents/skills/work-loop/scripts/lint-traceability.py
@@ -50,16 +50,28 @@ Two sources, one classifier:
   A matrix↔artifact disagreement is reported as **drift, warn-only** until the
   sidecar schema is pinned (deferred: sidecar-drift-hard-fail).
 
+On the authoritative sidecar graph the lint also runs a **root→leaf reachability**
+pass (`reachability_sidecar`): a node is reachable iff it is forward-reachable from
+`root` AND can reach a clean terminus (a `leaf_kind` node or a rollup-resolved
+`satisfied-by-reference` endpoint). A node off every root→leaf path is `UNREACHABLE`
+(the disconnected-subtree finding the discovery-loop cascade backstop depends on,
+RFC-0053 AC34) — additive to, and non-overlapping with, the presence orphans. An
+*unresolvable* cross-repo hop is **not** a clean terminus (the sidecar is untrusted
+input — a forged out-edge must not silently green a stranded subtree); a node whose
+only escape is such a hop is surfaced informationally, never fatal. Reachability is
+sidecar-only — a standalone derived graph is legitimately partial / multi-root.
+
 Exit codes:
-  0 = clean / reported. Structural orphans are informational in default mode;
-      unresolvable cross-repo endpoints, unpinned references, and drift are
-      never fatal.
+  0 = clean / reported. Structural orphans and `UNREACHABLE` findings are
+      informational in default mode; unresolvable cross-repo endpoints, the
+      `reaches a leaf only via an unresolved cross-repo reference` finding,
+      unpinned references, and drift are never fatal.
   1 = a hard violation — a dangling edge (a pointer to a missing local target,
       or malformed) or a cycle, **in every mode**; or, under `--strict`, any
-      structural orphan (the convergence-/CI-gate enforcing "traceability
-      closed", RFC-0048 O6). `--strict` degrades gracefully where the producer
-      `Discovery:` headers / `type:` markers are absent (a separate CONVENTIONS
-      follow-on lands those).
+      structural orphan or `UNREACHABLE` node (the convergence-/CI-gate enforcing
+      "traceability closed", RFC-0048 O6). `--strict` degrades gracefully where the
+      producer `Discovery:` headers / `type:` markers are absent (a separate
+      CONVENTIONS follow-on lands those).
 
 No chain artifacts at all → exit 0 with no diagnostic (the
 `lint-brief-coverage.py` no-brief precedent).
@@ -749,11 +761,15 @@ def classify_sidecar(g: Graph) -> list[tuple[str, str, str]]:
     `check_sidecar` rule (RFC-0053 spike): `root` is exempt from an in-edge,
     `leaf_kind` from an out-edge, everything else needs both. The sidecar's
     edges already encode any layer-skip explicitly, so no populated-layer
-    inference is applied."""
+    inference is applied. A **reference (external) endpoint** registered by
+    `resolve_sidecar_endpoints` is never orphan-checked — it is the cross-repo
+    boundary, not a chain node owing a local producer/consumer."""
     has_in = {to for _, to in g.edges}
     has_out = {frm for frm, _ in g.edges}
     orphans: list[tuple[str, str, str]] = []
     for nid, kind in sorted(g.nodes.items()):
+        if nid in g.ref_state:  # external reference endpoint — never orphan-checked
+            continue
         missing: list[str] = []
         if nid != g.root and nid not in has_in:
             missing.append("no producer (up-edge)")
@@ -765,10 +781,128 @@ def classify_sidecar(g: Graph) -> list[tuple[str, str, str]]:
 
 
 def sidecar_dangling(g: Graph) -> list[str]:
-    """Sidecar edge endpoints naming a node absent from the inventory."""
+    """Sidecar edge endpoints naming a node absent from the inventory. After
+    `resolve_sidecar_endpoints` has run, a well-formed cross-repo reference is in
+    the inventory as an `external` node, so only a bare/malformed missing-local
+    token remains here — a hard violation in every mode."""
     return sorted({
         p for e in g.edges for p in e if p not in g.nodes
     })
+
+
+def resolve_sidecar_endpoints(g: Graph, rollup: dict[str, bool]) -> None:
+    """Resolve each sidecar edge endpoint absent from the local inventory against
+    the value-stream rollup (the open-world cross-repo posture, extended from
+    endpoint *resolution* to *reachability*). A well-formed cross-repo reference
+    becomes a `satisfied-by-reference` / `unresolvable` **external** node — so it is
+    no longer a `sidecar_dangling` endpoint and can serve as a reachability terminus
+    — while a bare / malformed token is left out of inventory for `sidecar_dangling`
+    to flag (hard, every mode). Mirrors the standalone `_wire` endpoint handling;
+    reuses `resolve_endpoint`, never a parallel scheme. The sidecar graph is
+    untrusted input, so this only ever *adds* a clearly-labelled external node — it
+    never silences a missing-local target."""
+    local_ids = set(g.nodes)
+    for a, b in sorted(g.edges):
+        for ep in (a, b):
+            if ep in local_ids or ep in g.ref_state:
+                continue
+            state, pinned, _ = resolve_endpoint(ep, local_ids, rollup)
+            if state in ("satisfied-by-reference", "unresolvable"):
+                g.ref_state[ep] = state
+                g.ref_pinned[ep] = pinned
+                g.nodes.setdefault(ep, "external")
+
+
+def _reach(seeds: set[str], adj: dict[str, list[str]]) -> set[str]:
+    """Iterative (explicit-stack) reachability over adjacency `adj` from `seeds`
+    (seeds included). A visited set bounds it to **O(V+E)** and terminates on a
+    cyclic or deep untrusted graph — the same posture as `_find_cycles`, no
+    recursion-limit DoS."""
+    seen = set(seeds)
+    stack = list(seeds)
+    while stack:
+        node = stack.pop()
+        for nxt in adj.get(node, ()):
+            if nxt not in seen:
+                seen.add(nxt)
+                stack.append(nxt)
+    return seen
+
+
+def reachability_sidecar(
+    g: Graph,
+) -> tuple[list[tuple[str, str, str]], list[tuple[str, str, str]], list[str]]:
+    """Root→leaf reachability over the authoritative sidecar graph (sidecar mode
+    only — `root` + `leaf_kind` are declared there and the graph is a closed,
+    single-rooted DAG; the standalone derived graph is legitimately partial /
+    multi-root and keeps presence + layer-skip).
+
+    A node is *reachable* iff it is **forward-reachable from `root`** AND **can reach
+    a clean terminus** — a node of `leaf_kind`, or a rollup-resolved
+    `satisfied-by-reference` endpoint. Returns `(unreachable, soft, notes)`:
+
+    - `unreachable` — `(id, kind, reason)` for a node not on any root→leaf path
+      (not forward-reachable, or reaches no terminus at all): the `UNREACHABLE`
+      disconnected-subtree finding. The caller subtracts presence orphans + dangling
+      sources so the two diagnostics stay non-overlapping (one break, one class).
+    - `soft` — `(id, kind, reason)` for a node whose only escape from a dead branch
+      is an **`unresolvable`** cross-repo hop. Because the sidecar is untrusted
+      input, a forged `x/y` out-edge must not silently green a stranded subtree, so
+      an unresolvable hop is **not** a clean terminus: it is surfaced as a distinct
+      informational finding (never fatal — `--strict` does not promote it), making
+      the fabricated-edge gap *visible* rather than forgeably green.
+
+    Degrades in isolation (a note, empty findings) when no `root` is declared / in
+    inventory, or no `leaf_kind` terminus exists — never a crash, never the
+    whole-lint exit-0 backstop."""
+    notes: list[str] = []
+    if not g.root or g.root not in g.nodes:
+        notes.append(
+            f"reachability skipped — declared root '{g.root}' absent from inventory"
+            if g.root else "reachability skipped — sidecar declares no root"
+        )
+        return [], [], notes
+
+    clean_termini = {nid for nid, kind in g.nodes.items() if kind == g.leaf_kind}
+    clean_termini |= {nid for nid, st in g.ref_state.items()
+                      if st == "satisfied-by-reference"}
+    if not clean_termini:
+        # No leaf to reach — presence (a bottom node with no consumer is a forward
+        # orphan) already covers a leaf-less chain; flagging every node here is noise.
+        notes.append("reachability skipped — no leaf_kind terminus in inventory")
+        return [], [], notes
+    soft_termini = {nid for nid, st in g.ref_state.items() if st == "unresolvable"}
+
+    fwd: dict[str, list[str]] = {}
+    rev: dict[str, list[str]] = {}
+    for a, b in g.edges:
+        fwd.setdefault(a, []).append(b)
+        rev.setdefault(b, []).append(a)
+    forward = _reach({g.root}, fwd)              # forward-reachable from root
+    reach_clean = _reach(clean_termini, rev)     # can reach a clean terminus
+    reach_any = _reach(clean_termini | soft_termini, rev)  # … incl. via unresolved
+
+    unreachable: list[tuple[str, str, str]] = []
+    soft: list[tuple[str, str, str]] = []
+    for nid, kind in sorted(g.nodes.items()):
+        # The root anchors the graph (never "unreachable"); a reference endpoint is
+        # the cross-repo boundary — neither is itself reachability-checked.
+        if nid == g.root or nid in g.ref_state or kind == "external":
+            continue
+        in_fwd = nid in forward
+        if in_fwd and nid in reach_clean:
+            continue  # cleanly on a root→leaf path
+        if in_fwd and nid in reach_any:
+            soft.append((nid, kind,
+                         "reaches a leaf only via an unresolved cross-repo reference"))
+            continue
+        why: list[str] = []
+        if not in_fwd:
+            why.append("not forward-reachable from root")
+        if nid not in reach_any:
+            why.append("reaches no leaf")
+        unreachable.append((nid, kind, "; ".join(why) or "off the root→leaf path"))
+    return unreachable, soft, notes
 
 
 # --------------------------------------------------------------------------
@@ -944,6 +1078,10 @@ def check(root: Path, strict: bool) -> tuple[list[str], list[str], int]:
 
     if not using_sidecar:
         build_standalone(root, layout, g, rollup)
+    else:
+        # Resolve any cross-repo edge endpoint against the rollup so a federated
+        # sidecar's external leaf is a reachability terminus, not a dangling edge.
+        resolve_sidecar_endpoints(g, rollup)
 
     # No chain anchor at all → no-op clean (the lint-brief-coverage no-brief
     # precedent). The anchor is a *discovery-side* artifact — a sidecar, a
@@ -978,6 +1116,27 @@ def check(root: Path, strict: bool) -> tuple[list[str], list[str], int]:
                      for d in sidecar_dangling(g)]
     cycles = _find_cycles(g)
 
+    # Root→leaf reachability (sidecar-authoritative mode only). The reported set is
+    # additive: stranded nodes minus the presence orphans and dangling-edge sources
+    # already reported, so a single break is one class, never two (AC9). Its own
+    # degradations are notes; it never crashes or fails the whole lint.
+    unreachable: list[tuple[str, str, str]] = []
+    soft_unresolved: list[tuple[str, str, str]] = []
+    if using_sidecar:
+        unreach, soft, rnotes = reachability_sidecar(g)
+        g.notes.extend(rnotes)
+        orphan_ids = {nid for nid, _, _ in orphans}
+        dangling_set = set(sidecar_dangling(g))
+        # One break, one class (AC9): a node adjacent to a dangling edge — whether
+        # the edge's source (its target is missing) or its consumer (its producer
+        # is missing) — is already surfaced by that DANGLING violation, so it is not
+        # also reported as UNREACHABLE.
+        dangling_adjacent = ({a for a, b in g.edges if b in dangling_set}
+                             | {b for a, b in g.edges if a in dangling_set})
+        skip = orphan_ids | dangling_adjacent
+        unreachable = [t for t in unreach if t[0] not in skip]
+        soft_unresolved = [t for t in soft if t[0] not in skip]
+
     for nid, st in sorted(g.ref_state.items()):
         if st == "satisfied-by-reference":
             flag = "pinned" if g.ref_pinned.get(nid) else "unpinned (soft warning)"
@@ -991,6 +1150,12 @@ def check(root: Path, strict: bool) -> tuple[list[str], list[str], int]:
 
     for nid, kind, why in orphans:
         out.append(f"  - ORPHAN {nid} [{kind}]: {why}")
+
+    for nid, kind, why in unreachable:
+        out.append(f"  - UNREACHABLE {nid} [{kind}]: {why}")
+
+    for nid, kind, why in soft_unresolved:
+        out.append(f"  - {nid} [{kind}]: {why} (informational)")
 
     # Drift cross-check: sidecar present AND artifacts derivable — warn-only
     # until the matrix schema is pinned (deferred: sidecar-drift-hard-fail).
@@ -1006,6 +1171,14 @@ def check(root: Path, strict: bool) -> tuple[list[str], list[str], int]:
         out.append("lint-traceability: no structural orphans — every node has "
                    "a producer and a consumer.")
 
+    # Reachability summary on its own line — a --strict exit caused by a
+    # disconnected subtree is legible, not folded into the orphan count.
+    if unreachable:
+        verb = ("disconnected subtree — FAIL (--strict)" if strict
+                else "disconnected subtree (informational)")
+        out.append(f"lint-traceability: {len(unreachable)} unreachable node(s), "
+                   f"{verb}.")
+
     for d in dangling:
         hard.append(f"DANGLING — {d}")
     for c in cycles:
@@ -1014,7 +1187,7 @@ def check(root: Path, strict: bool) -> tuple[list[str], list[str], int]:
     exit_hint = 0
     if hard:
         exit_hint = 1
-    elif orphans and strict:
+    elif (orphans or unreachable) and strict:
         exit_hint = 1
     return out, hard, exit_hint
 

--- a/.agents/skills/work-loop/scripts/test-lint-traceability.py
+++ b/.agents/skills/work-loop/scripts/test-lint-traceability.py
@@ -487,6 +487,220 @@ def case_dangling_up_field_still_fires() -> None:
 
 
 # --------------------------------------------------------------------------
+# Root→leaf reachability (sidecar mode) — the AC34 disconnected-subtree backstop
+# --------------------------------------------------------------------------
+
+# A healthy chain (root=o → spec-h → comp-h, a real component leaf) shared by the
+# reachability fixtures so a clean terminus exists; each case bolts a broken branch
+# onto the root `o`.
+_HEALTHY_NODES = [
+    {"id": "o", "kind": "outcome"},
+    {"id": "spec-h", "kind": "spec"},
+    {"id": "comp-h", "kind": "component"},
+]
+_HEALTHY_EDGES = [{"from": "o", "to": "spec-h"}, {"from": "spec-h", "to": "comp-h"}]
+
+
+def case_reach_dead_end_subtree_whole_not_just_tip() -> None:
+    """The preconverge "whole subtree" case: a locally-edged dead-end branch where
+    every interior node has a producer AND a consumer edge, but the branch never
+    reaches a leaf. Presence flags only the tip (no out-edge); reachability flags
+    the stranded interior the presence check passes — union = the whole subtree."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        nodes = _HEALTHY_NODES + [
+            {"id": "cap-d", "kind": "capability"},
+            {"id": "scr-d", "kind": "screen"},
+            {"id": "svc-d", "kind": "service"},  # tip — no out-edge
+        ]
+        edges = _HEALTHY_EDGES + [
+            {"from": "o", "to": "cap-d"}, {"from": "cap-d", "to": "scr-d"},
+            {"from": "scr-d", "to": "svc-d"},
+        ]
+        write_sidecar(root, nodes=nodes, edges=edges, root_id="o")
+        rc, out, err = run(root)
+        # Presence flags ONLY the tip; the interior is passed by presence.
+        expect("ORPHAN svc-d" in out and "no consumer" in out,
+               f"presence flags the tip svc-d: {out}")
+        expect("ORPHAN cap-d" not in out and "ORPHAN scr-d" not in out,
+               f"presence passes the interior nodes: {out}")
+        # Reachability flags the interior (which presence passed) — not just the tip.
+        expect("UNREACHABLE cap-d" in out and "UNREACHABLE scr-d" in out,
+               f"reachability flags the stranded interior: {out}")
+        # AC9 — one break, one class: the tip is the presence ORPHAN, not also
+        # double-reported as UNREACHABLE.
+        expect("UNREACHABLE svc-d" not in out,
+               f"tip is the presence orphan, not also UNREACHABLE: {out}")
+        # Union covers the whole subtree {cap-d, scr-d, svc-d}.
+        expect(rc == 0, f"reachability informational by default → exit 0, got {rc}")
+        rc2, _, _ = run(root, "--strict")
+        expect(rc2 == 1, f"UNREACHABLE + --strict → exit 1, got {rc2}")
+
+
+def case_reach_floating_subtree_disconnected_from_root() -> None:
+    """The forward-from-root clause: a subtree internally edged and even reaching a
+    leaf, but with no path from `root`, is flagged (its source is a presence
+    backward orphan; its leaf — passed by presence — is UNREACHABLE)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        nodes = _HEALTHY_NODES + [
+            {"id": "spec-f", "kind": "spec"},
+            {"id": "comp-f", "kind": "component"},
+        ]
+        edges = _HEALTHY_EDGES + [{"from": "spec-f", "to": "comp-f"}]
+        write_sidecar(root, nodes=nodes, edges=edges, root_id="o")
+        rc, out, err = run(root)
+        expect("ORPHAN spec-f" in out and "no producer" in out,
+               f"floating source is a presence backward orphan: {out}")
+        expect("UNREACHABLE comp-f" in out and "not forward-reachable" in out,
+               f"floating leaf flagged not-reachable-from-root: {out}")
+        expect(rc == 0, f"informational by default → exit 0, got {rc}")
+
+
+def case_reach_federated_resolved_terminus_not_flagged() -> None:
+    """Open-world: a branch whose leaf is a rollup-RESOLVED satisfied-by-reference
+    endpoint reaches a clean terminus across the boundary — never flagged."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        nodes = _HEALTHY_NODES + [{"id": "spec-x", "kind": "spec"}]
+        edges = _HEALTHY_EDGES + [
+            {"from": "o", "to": "spec-x"}, {"from": "spec-x", "to": "ext-comp@2"},
+        ]
+        write_sidecar(root, nodes=nodes, edges=edges, root_id="o")
+        write_rollup(root, ["| `ext-comp@2` | `r` · `s` | x@1 | delivered | y |\n"])
+        rc, out, err = run(root)
+        expect(rc == 0, f"federated resolved terminus → exit 0, got {rc}: {err}")
+        expect("satisfied-by-reference (pinned)" in out,
+               f"cross-repo leaf is a resolved reference: {out}")
+        expect("UNREACHABLE spec-x" not in out and "ORPHAN spec-x" not in out,
+               f"a federated branch is not flagged: {out}")
+        expect("DANGLING" not in err,
+               f"a cross-repo sidecar endpoint is not dangling: {err}")
+        rc2, _, _ = run(root, "--strict")
+        expect(rc2 == 0, f"--strict + only a resolved federated leaf → exit 0, got {rc2}")
+
+
+def case_reach_unresolvable_tip_surfaced_never_silently_green() -> None:
+    """The fabricated-edge boundary: a stranded tip whose only out-edge is an
+    UNRESOLVABLE (forged-eligible) cross-repo token is NOT a clean terminus — the
+    branch is surfaced as a distinct informational finding, never silently green and
+    never promoted by --strict (the untrusted-input control-integrity guard)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        nodes = _HEALTHY_NODES + [
+            {"id": "cap-u", "kind": "capability"},
+            {"id": "scr-u", "kind": "screen"},
+        ]
+        edges = _HEALTHY_EDGES + [
+            {"from": "o", "to": "cap-u"}, {"from": "cap-u", "to": "scr-u"},
+            {"from": "scr-u", "to": "forged/x"},  # unresolvable cross-repo token
+        ]
+        write_sidecar(root, nodes=nodes, edges=edges, root_id="o")
+        rc, out, err = run(root)
+        expect(rc == 0, f"unresolvable tip → never fatal, exit 0, got {rc}: {err}")
+        expect("DANGLING" not in err,
+               f"a well-formed cross-repo token is not dangling: {err}")
+        expect("unknown / not-yet-catalogued" in out,
+               f"the forged endpoint is surfaced honestly: {out}")
+        expect("reaches a leaf only via an unresolved cross-repo reference" in out,
+               f"the stranded branch is surfaced, not silently green: {out}")
+        expect("(informational)" in out, f"surfaced informationally: {out}")
+        # Critically NOT flagged as a clean pass and NOT promoted by --strict.
+        rc2, out2, _ = run(root, "--strict")
+        expect(rc2 == 0,
+               f"--strict does NOT promote an unresolvable hop, got {rc2}: {out2}")
+
+
+def case_reach_dangling_adjacent_not_double_reported() -> None:
+    """AC9 one-break-one-class: a node whose sole producer edge has a *dangling
+    source* (the producer is a missing-local target) is surfaced by the DANGLING
+    violation, not ALSO as UNREACHABLE."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        nodes = _HEALTHY_NODES + [{"id": "mid", "kind": "spec"}]
+        edges = _HEALTHY_EDGES + [
+            {"from": "ghostsrc", "to": "mid"},  # ghostsrc absent → dangling source
+            {"from": "mid", "to": "comp-h"},    # mid does reach a leaf
+        ]
+        write_sidecar(root, nodes=nodes, edges=edges, root_id="o")
+        rc, out, err = run(root)
+        expect(rc == 1, f"dangling source → exit 1 every mode, got {rc}")
+        expect("DANGLING" in err and "ghostsrc" in err,
+               f"the dangling edge is the hard violation: {err}")
+        expect("UNREACHABLE mid" not in out,
+               f"the dangling-edge consumer is not also UNREACHABLE (AC9): {out}")
+
+
+def case_reach_skips_without_root() -> None:
+    """Graceful, isolated degradation: a sidecar with no declared root, or a root
+    absent from the inventory, skips ONLY the reachability pass (a note, no crash)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        nodes = [{"id": "a", "kind": "spec"}, {"id": "comp", "kind": "component"}]
+        edges = [{"from": "a", "to": "comp"}]
+        write_sidecar(root, nodes=nodes, edges=edges, root_id="")  # → root None
+        rc, out, err = run(root)
+        expect("reachability skipped" in out and "no root" in out,
+               f"rootless sidecar skips reachability with a note: {out}")
+        expect("Traceback" not in err, f"no crash on a rootless sidecar: {err}")
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        nodes = [{"id": "a", "kind": "spec"}, {"id": "comp", "kind": "component"}]
+        edges = [{"from": "a", "to": "comp"}]
+        write_sidecar(root, nodes=nodes, edges=edges, root_id="ghost-root")
+        rc, out, err = run(root)
+        expect("reachability skipped" in out and "absent from inventory" in out,
+               f"absent declared root skips reachability with a note: {out}")
+        expect("Traceback" not in err, f"no crash on an absent-root sidecar: {err}")
+
+
+def case_reach_degenerate_cases() -> None:
+    """Degenerate graphs: a single-node root==leaf is clean; an empty-edge graph
+    strands non-root nodes (caught by presence; reachability adds nothing — the
+    non-overlap property); a self-loop is termination-safe."""
+    # (1) Single node, root == leaf → reachable/clean, no skip.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_sidecar(root, nodes=[{"id": "comp", "kind": "component"}], edges=[],
+                      root_id="comp")
+        rc, out, err = run(root)
+        expect(rc == 0 and "no structural orphans" in out,
+               f"single-node root==leaf is clean: {out}")
+        expect("UNREACHABLE" not in out and "reachability skipped" not in out,
+               f"root==leaf is reachable, pass runs: {out}")
+    # (2) Empty edges, multiple nodes → every non-root node is a presence orphan;
+    # reachability adds NO UNREACHABLE (all stranded nodes already presence orphans).
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_sidecar(root, nodes=[{"id": "o", "kind": "outcome"},
+                                   {"id": "x", "kind": "spec"},
+                                   {"id": "comp", "kind": "component"}],
+                      edges=[], root_id="o")
+        rc, out, err = run(root)
+        expect("ORPHAN x" in out and "ORPHAN comp" in out,
+               f"empty-edge non-root nodes are presence orphans: {out}")
+        expect("UNREACHABLE" not in out,
+               f"reachability is additive — no double-report on presence orphans: {out}")
+        expect("Traceback" not in err, f"no crash on an empty-edge sidecar: {err}")
+    # (3) Self-loop on an on-path node → termination-safe, not spuriously flagged
+    # (the self-edge itself is the hard violation; reachability must not hang).
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_sidecar(root, nodes=[{"id": "o", "kind": "outcome"},
+                                   {"id": "a", "kind": "spec"},
+                                   {"id": "comp", "kind": "component"}],
+                      edges=[{"from": "o", "to": "a"}, {"from": "a", "to": "a"},
+                             {"from": "a", "to": "comp"}], root_id="o")
+        rc, out, err = run(root)
+        expect(rc == 1 and "self-referential" in err.lower(),
+               f"self-edge is the hard violation: {err}")
+        expect("Traceback" not in err and "RecursionError" not in err,
+               f"reachability terminates on a self-loop: {err}")
+        expect("UNREACHABLE a" not in out and "UNREACHABLE comp" not in out,
+               f"on-path nodes not spuriously flagged despite the self-loop: {out}")
+
+
+# --------------------------------------------------------------------------
 # Container-embedded + file-backed recognition (AC1, AC2)
 # --------------------------------------------------------------------------
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -87,7 +87,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "core",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.7.0"
+      "version": "0.7.1"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/.claude/skills/work-loop/scripts/lint-traceability.py
+++ b/.claude/skills/work-loop/scripts/lint-traceability.py
@@ -50,16 +50,28 @@ Two sources, one classifier:
   A matrix↔artifact disagreement is reported as **drift, warn-only** until the
   sidecar schema is pinned (deferred: sidecar-drift-hard-fail).
 
+On the authoritative sidecar graph the lint also runs a **root→leaf reachability**
+pass (`reachability_sidecar`): a node is reachable iff it is forward-reachable from
+`root` AND can reach a clean terminus (a `leaf_kind` node or a rollup-resolved
+`satisfied-by-reference` endpoint). A node off every root→leaf path is `UNREACHABLE`
+(the disconnected-subtree finding the discovery-loop cascade backstop depends on,
+RFC-0053 AC34) — additive to, and non-overlapping with, the presence orphans. An
+*unresolvable* cross-repo hop is **not** a clean terminus (the sidecar is untrusted
+input — a forged out-edge must not silently green a stranded subtree); a node whose
+only escape is such a hop is surfaced informationally, never fatal. Reachability is
+sidecar-only — a standalone derived graph is legitimately partial / multi-root.
+
 Exit codes:
-  0 = clean / reported. Structural orphans are informational in default mode;
-      unresolvable cross-repo endpoints, unpinned references, and drift are
-      never fatal.
+  0 = clean / reported. Structural orphans and `UNREACHABLE` findings are
+      informational in default mode; unresolvable cross-repo endpoints, the
+      `reaches a leaf only via an unresolved cross-repo reference` finding,
+      unpinned references, and drift are never fatal.
   1 = a hard violation — a dangling edge (a pointer to a missing local target,
       or malformed) or a cycle, **in every mode**; or, under `--strict`, any
-      structural orphan (the convergence-/CI-gate enforcing "traceability
-      closed", RFC-0048 O6). `--strict` degrades gracefully where the producer
-      `Discovery:` headers / `type:` markers are absent (a separate CONVENTIONS
-      follow-on lands those).
+      structural orphan or `UNREACHABLE` node (the convergence-/CI-gate enforcing
+      "traceability closed", RFC-0048 O6). `--strict` degrades gracefully where the
+      producer `Discovery:` headers / `type:` markers are absent (a separate
+      CONVENTIONS follow-on lands those).
 
 No chain artifacts at all → exit 0 with no diagnostic (the
 `lint-brief-coverage.py` no-brief precedent).
@@ -749,11 +761,15 @@ def classify_sidecar(g: Graph) -> list[tuple[str, str, str]]:
     `check_sidecar` rule (RFC-0053 spike): `root` is exempt from an in-edge,
     `leaf_kind` from an out-edge, everything else needs both. The sidecar's
     edges already encode any layer-skip explicitly, so no populated-layer
-    inference is applied."""
+    inference is applied. A **reference (external) endpoint** registered by
+    `resolve_sidecar_endpoints` is never orphan-checked — it is the cross-repo
+    boundary, not a chain node owing a local producer/consumer."""
     has_in = {to for _, to in g.edges}
     has_out = {frm for frm, _ in g.edges}
     orphans: list[tuple[str, str, str]] = []
     for nid, kind in sorted(g.nodes.items()):
+        if nid in g.ref_state:  # external reference endpoint — never orphan-checked
+            continue
         missing: list[str] = []
         if nid != g.root and nid not in has_in:
             missing.append("no producer (up-edge)")
@@ -765,10 +781,128 @@ def classify_sidecar(g: Graph) -> list[tuple[str, str, str]]:
 
 
 def sidecar_dangling(g: Graph) -> list[str]:
-    """Sidecar edge endpoints naming a node absent from the inventory."""
+    """Sidecar edge endpoints naming a node absent from the inventory. After
+    `resolve_sidecar_endpoints` has run, a well-formed cross-repo reference is in
+    the inventory as an `external` node, so only a bare/malformed missing-local
+    token remains here — a hard violation in every mode."""
     return sorted({
         p for e in g.edges for p in e if p not in g.nodes
     })
+
+
+def resolve_sidecar_endpoints(g: Graph, rollup: dict[str, bool]) -> None:
+    """Resolve each sidecar edge endpoint absent from the local inventory against
+    the value-stream rollup (the open-world cross-repo posture, extended from
+    endpoint *resolution* to *reachability*). A well-formed cross-repo reference
+    becomes a `satisfied-by-reference` / `unresolvable` **external** node — so it is
+    no longer a `sidecar_dangling` endpoint and can serve as a reachability terminus
+    — while a bare / malformed token is left out of inventory for `sidecar_dangling`
+    to flag (hard, every mode). Mirrors the standalone `_wire` endpoint handling;
+    reuses `resolve_endpoint`, never a parallel scheme. The sidecar graph is
+    untrusted input, so this only ever *adds* a clearly-labelled external node — it
+    never silences a missing-local target."""
+    local_ids = set(g.nodes)
+    for a, b in sorted(g.edges):
+        for ep in (a, b):
+            if ep in local_ids or ep in g.ref_state:
+                continue
+            state, pinned, _ = resolve_endpoint(ep, local_ids, rollup)
+            if state in ("satisfied-by-reference", "unresolvable"):
+                g.ref_state[ep] = state
+                g.ref_pinned[ep] = pinned
+                g.nodes.setdefault(ep, "external")
+
+
+def _reach(seeds: set[str], adj: dict[str, list[str]]) -> set[str]:
+    """Iterative (explicit-stack) reachability over adjacency `adj` from `seeds`
+    (seeds included). A visited set bounds it to **O(V+E)** and terminates on a
+    cyclic or deep untrusted graph — the same posture as `_find_cycles`, no
+    recursion-limit DoS."""
+    seen = set(seeds)
+    stack = list(seeds)
+    while stack:
+        node = stack.pop()
+        for nxt in adj.get(node, ()):
+            if nxt not in seen:
+                seen.add(nxt)
+                stack.append(nxt)
+    return seen
+
+
+def reachability_sidecar(
+    g: Graph,
+) -> tuple[list[tuple[str, str, str]], list[tuple[str, str, str]], list[str]]:
+    """Root→leaf reachability over the authoritative sidecar graph (sidecar mode
+    only — `root` + `leaf_kind` are declared there and the graph is a closed,
+    single-rooted DAG; the standalone derived graph is legitimately partial /
+    multi-root and keeps presence + layer-skip).
+
+    A node is *reachable* iff it is **forward-reachable from `root`** AND **can reach
+    a clean terminus** — a node of `leaf_kind`, or a rollup-resolved
+    `satisfied-by-reference` endpoint. Returns `(unreachable, soft, notes)`:
+
+    - `unreachable` — `(id, kind, reason)` for a node not on any root→leaf path
+      (not forward-reachable, or reaches no terminus at all): the `UNREACHABLE`
+      disconnected-subtree finding. The caller subtracts presence orphans + dangling
+      sources so the two diagnostics stay non-overlapping (one break, one class).
+    - `soft` — `(id, kind, reason)` for a node whose only escape from a dead branch
+      is an **`unresolvable`** cross-repo hop. Because the sidecar is untrusted
+      input, a forged `x/y` out-edge must not silently green a stranded subtree, so
+      an unresolvable hop is **not** a clean terminus: it is surfaced as a distinct
+      informational finding (never fatal — `--strict` does not promote it), making
+      the fabricated-edge gap *visible* rather than forgeably green.
+
+    Degrades in isolation (a note, empty findings) when no `root` is declared / in
+    inventory, or no `leaf_kind` terminus exists — never a crash, never the
+    whole-lint exit-0 backstop."""
+    notes: list[str] = []
+    if not g.root or g.root not in g.nodes:
+        notes.append(
+            f"reachability skipped — declared root '{g.root}' absent from inventory"
+            if g.root else "reachability skipped — sidecar declares no root"
+        )
+        return [], [], notes
+
+    clean_termini = {nid for nid, kind in g.nodes.items() if kind == g.leaf_kind}
+    clean_termini |= {nid for nid, st in g.ref_state.items()
+                      if st == "satisfied-by-reference"}
+    if not clean_termini:
+        # No leaf to reach — presence (a bottom node with no consumer is a forward
+        # orphan) already covers a leaf-less chain; flagging every node here is noise.
+        notes.append("reachability skipped — no leaf_kind terminus in inventory")
+        return [], [], notes
+    soft_termini = {nid for nid, st in g.ref_state.items() if st == "unresolvable"}
+
+    fwd: dict[str, list[str]] = {}
+    rev: dict[str, list[str]] = {}
+    for a, b in g.edges:
+        fwd.setdefault(a, []).append(b)
+        rev.setdefault(b, []).append(a)
+    forward = _reach({g.root}, fwd)              # forward-reachable from root
+    reach_clean = _reach(clean_termini, rev)     # can reach a clean terminus
+    reach_any = _reach(clean_termini | soft_termini, rev)  # … incl. via unresolved
+
+    unreachable: list[tuple[str, str, str]] = []
+    soft: list[tuple[str, str, str]] = []
+    for nid, kind in sorted(g.nodes.items()):
+        # The root anchors the graph (never "unreachable"); a reference endpoint is
+        # the cross-repo boundary — neither is itself reachability-checked.
+        if nid == g.root or nid in g.ref_state or kind == "external":
+            continue
+        in_fwd = nid in forward
+        if in_fwd and nid in reach_clean:
+            continue  # cleanly on a root→leaf path
+        if in_fwd and nid in reach_any:
+            soft.append((nid, kind,
+                         "reaches a leaf only via an unresolved cross-repo reference"))
+            continue
+        why: list[str] = []
+        if not in_fwd:
+            why.append("not forward-reachable from root")
+        if nid not in reach_any:
+            why.append("reaches no leaf")
+        unreachable.append((nid, kind, "; ".join(why) or "off the root→leaf path"))
+    return unreachable, soft, notes
 
 
 # --------------------------------------------------------------------------
@@ -944,6 +1078,10 @@ def check(root: Path, strict: bool) -> tuple[list[str], list[str], int]:
 
     if not using_sidecar:
         build_standalone(root, layout, g, rollup)
+    else:
+        # Resolve any cross-repo edge endpoint against the rollup so a federated
+        # sidecar's external leaf is a reachability terminus, not a dangling edge.
+        resolve_sidecar_endpoints(g, rollup)
 
     # No chain anchor at all → no-op clean (the lint-brief-coverage no-brief
     # precedent). The anchor is a *discovery-side* artifact — a sidecar, a
@@ -978,6 +1116,27 @@ def check(root: Path, strict: bool) -> tuple[list[str], list[str], int]:
                      for d in sidecar_dangling(g)]
     cycles = _find_cycles(g)
 
+    # Root→leaf reachability (sidecar-authoritative mode only). The reported set is
+    # additive: stranded nodes minus the presence orphans and dangling-edge sources
+    # already reported, so a single break is one class, never two (AC9). Its own
+    # degradations are notes; it never crashes or fails the whole lint.
+    unreachable: list[tuple[str, str, str]] = []
+    soft_unresolved: list[tuple[str, str, str]] = []
+    if using_sidecar:
+        unreach, soft, rnotes = reachability_sidecar(g)
+        g.notes.extend(rnotes)
+        orphan_ids = {nid for nid, _, _ in orphans}
+        dangling_set = set(sidecar_dangling(g))
+        # One break, one class (AC9): a node adjacent to a dangling edge — whether
+        # the edge's source (its target is missing) or its consumer (its producer
+        # is missing) — is already surfaced by that DANGLING violation, so it is not
+        # also reported as UNREACHABLE.
+        dangling_adjacent = ({a for a, b in g.edges if b in dangling_set}
+                             | {b for a, b in g.edges if a in dangling_set})
+        skip = orphan_ids | dangling_adjacent
+        unreachable = [t for t in unreach if t[0] not in skip]
+        soft_unresolved = [t for t in soft if t[0] not in skip]
+
     for nid, st in sorted(g.ref_state.items()):
         if st == "satisfied-by-reference":
             flag = "pinned" if g.ref_pinned.get(nid) else "unpinned (soft warning)"
@@ -991,6 +1150,12 @@ def check(root: Path, strict: bool) -> tuple[list[str], list[str], int]:
 
     for nid, kind, why in orphans:
         out.append(f"  - ORPHAN {nid} [{kind}]: {why}")
+
+    for nid, kind, why in unreachable:
+        out.append(f"  - UNREACHABLE {nid} [{kind}]: {why}")
+
+    for nid, kind, why in soft_unresolved:
+        out.append(f"  - {nid} [{kind}]: {why} (informational)")
 
     # Drift cross-check: sidecar present AND artifacts derivable — warn-only
     # until the matrix schema is pinned (deferred: sidecar-drift-hard-fail).
@@ -1006,6 +1171,14 @@ def check(root: Path, strict: bool) -> tuple[list[str], list[str], int]:
         out.append("lint-traceability: no structural orphans — every node has "
                    "a producer and a consumer.")
 
+    # Reachability summary on its own line — a --strict exit caused by a
+    # disconnected subtree is legible, not folded into the orphan count.
+    if unreachable:
+        verb = ("disconnected subtree — FAIL (--strict)" if strict
+                else "disconnected subtree (informational)")
+        out.append(f"lint-traceability: {len(unreachable)} unreachable node(s), "
+                   f"{verb}.")
+
     for d in dangling:
         hard.append(f"DANGLING — {d}")
     for c in cycles:
@@ -1014,7 +1187,7 @@ def check(root: Path, strict: bool) -> tuple[list[str], list[str], int]:
     exit_hint = 0
     if hard:
         exit_hint = 1
-    elif orphans and strict:
+    elif (orphans or unreachable) and strict:
         exit_hint = 1
     return out, hard, exit_hint
 

--- a/.claude/skills/work-loop/scripts/test-lint-traceability.py
+++ b/.claude/skills/work-loop/scripts/test-lint-traceability.py
@@ -487,6 +487,220 @@ def case_dangling_up_field_still_fires() -> None:
 
 
 # --------------------------------------------------------------------------
+# Root→leaf reachability (sidecar mode) — the AC34 disconnected-subtree backstop
+# --------------------------------------------------------------------------
+
+# A healthy chain (root=o → spec-h → comp-h, a real component leaf) shared by the
+# reachability fixtures so a clean terminus exists; each case bolts a broken branch
+# onto the root `o`.
+_HEALTHY_NODES = [
+    {"id": "o", "kind": "outcome"},
+    {"id": "spec-h", "kind": "spec"},
+    {"id": "comp-h", "kind": "component"},
+]
+_HEALTHY_EDGES = [{"from": "o", "to": "spec-h"}, {"from": "spec-h", "to": "comp-h"}]
+
+
+def case_reach_dead_end_subtree_whole_not_just_tip() -> None:
+    """The preconverge "whole subtree" case: a locally-edged dead-end branch where
+    every interior node has a producer AND a consumer edge, but the branch never
+    reaches a leaf. Presence flags only the tip (no out-edge); reachability flags
+    the stranded interior the presence check passes — union = the whole subtree."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        nodes = _HEALTHY_NODES + [
+            {"id": "cap-d", "kind": "capability"},
+            {"id": "scr-d", "kind": "screen"},
+            {"id": "svc-d", "kind": "service"},  # tip — no out-edge
+        ]
+        edges = _HEALTHY_EDGES + [
+            {"from": "o", "to": "cap-d"}, {"from": "cap-d", "to": "scr-d"},
+            {"from": "scr-d", "to": "svc-d"},
+        ]
+        write_sidecar(root, nodes=nodes, edges=edges, root_id="o")
+        rc, out, err = run(root)
+        # Presence flags ONLY the tip; the interior is passed by presence.
+        expect("ORPHAN svc-d" in out and "no consumer" in out,
+               f"presence flags the tip svc-d: {out}")
+        expect("ORPHAN cap-d" not in out and "ORPHAN scr-d" not in out,
+               f"presence passes the interior nodes: {out}")
+        # Reachability flags the interior (which presence passed) — not just the tip.
+        expect("UNREACHABLE cap-d" in out and "UNREACHABLE scr-d" in out,
+               f"reachability flags the stranded interior: {out}")
+        # AC9 — one break, one class: the tip is the presence ORPHAN, not also
+        # double-reported as UNREACHABLE.
+        expect("UNREACHABLE svc-d" not in out,
+               f"tip is the presence orphan, not also UNREACHABLE: {out}")
+        # Union covers the whole subtree {cap-d, scr-d, svc-d}.
+        expect(rc == 0, f"reachability informational by default → exit 0, got {rc}")
+        rc2, _, _ = run(root, "--strict")
+        expect(rc2 == 1, f"UNREACHABLE + --strict → exit 1, got {rc2}")
+
+
+def case_reach_floating_subtree_disconnected_from_root() -> None:
+    """The forward-from-root clause: a subtree internally edged and even reaching a
+    leaf, but with no path from `root`, is flagged (its source is a presence
+    backward orphan; its leaf — passed by presence — is UNREACHABLE)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        nodes = _HEALTHY_NODES + [
+            {"id": "spec-f", "kind": "spec"},
+            {"id": "comp-f", "kind": "component"},
+        ]
+        edges = _HEALTHY_EDGES + [{"from": "spec-f", "to": "comp-f"}]
+        write_sidecar(root, nodes=nodes, edges=edges, root_id="o")
+        rc, out, err = run(root)
+        expect("ORPHAN spec-f" in out and "no producer" in out,
+               f"floating source is a presence backward orphan: {out}")
+        expect("UNREACHABLE comp-f" in out and "not forward-reachable" in out,
+               f"floating leaf flagged not-reachable-from-root: {out}")
+        expect(rc == 0, f"informational by default → exit 0, got {rc}")
+
+
+def case_reach_federated_resolved_terminus_not_flagged() -> None:
+    """Open-world: a branch whose leaf is a rollup-RESOLVED satisfied-by-reference
+    endpoint reaches a clean terminus across the boundary — never flagged."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        nodes = _HEALTHY_NODES + [{"id": "spec-x", "kind": "spec"}]
+        edges = _HEALTHY_EDGES + [
+            {"from": "o", "to": "spec-x"}, {"from": "spec-x", "to": "ext-comp@2"},
+        ]
+        write_sidecar(root, nodes=nodes, edges=edges, root_id="o")
+        write_rollup(root, ["| `ext-comp@2` | `r` · `s` | x@1 | delivered | y |\n"])
+        rc, out, err = run(root)
+        expect(rc == 0, f"federated resolved terminus → exit 0, got {rc}: {err}")
+        expect("satisfied-by-reference (pinned)" in out,
+               f"cross-repo leaf is a resolved reference: {out}")
+        expect("UNREACHABLE spec-x" not in out and "ORPHAN spec-x" not in out,
+               f"a federated branch is not flagged: {out}")
+        expect("DANGLING" not in err,
+               f"a cross-repo sidecar endpoint is not dangling: {err}")
+        rc2, _, _ = run(root, "--strict")
+        expect(rc2 == 0, f"--strict + only a resolved federated leaf → exit 0, got {rc2}")
+
+
+def case_reach_unresolvable_tip_surfaced_never_silently_green() -> None:
+    """The fabricated-edge boundary: a stranded tip whose only out-edge is an
+    UNRESOLVABLE (forged-eligible) cross-repo token is NOT a clean terminus — the
+    branch is surfaced as a distinct informational finding, never silently green and
+    never promoted by --strict (the untrusted-input control-integrity guard)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        nodes = _HEALTHY_NODES + [
+            {"id": "cap-u", "kind": "capability"},
+            {"id": "scr-u", "kind": "screen"},
+        ]
+        edges = _HEALTHY_EDGES + [
+            {"from": "o", "to": "cap-u"}, {"from": "cap-u", "to": "scr-u"},
+            {"from": "scr-u", "to": "forged/x"},  # unresolvable cross-repo token
+        ]
+        write_sidecar(root, nodes=nodes, edges=edges, root_id="o")
+        rc, out, err = run(root)
+        expect(rc == 0, f"unresolvable tip → never fatal, exit 0, got {rc}: {err}")
+        expect("DANGLING" not in err,
+               f"a well-formed cross-repo token is not dangling: {err}")
+        expect("unknown / not-yet-catalogued" in out,
+               f"the forged endpoint is surfaced honestly: {out}")
+        expect("reaches a leaf only via an unresolved cross-repo reference" in out,
+               f"the stranded branch is surfaced, not silently green: {out}")
+        expect("(informational)" in out, f"surfaced informationally: {out}")
+        # Critically NOT flagged as a clean pass and NOT promoted by --strict.
+        rc2, out2, _ = run(root, "--strict")
+        expect(rc2 == 0,
+               f"--strict does NOT promote an unresolvable hop, got {rc2}: {out2}")
+
+
+def case_reach_dangling_adjacent_not_double_reported() -> None:
+    """AC9 one-break-one-class: a node whose sole producer edge has a *dangling
+    source* (the producer is a missing-local target) is surfaced by the DANGLING
+    violation, not ALSO as UNREACHABLE."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        nodes = _HEALTHY_NODES + [{"id": "mid", "kind": "spec"}]
+        edges = _HEALTHY_EDGES + [
+            {"from": "ghostsrc", "to": "mid"},  # ghostsrc absent → dangling source
+            {"from": "mid", "to": "comp-h"},    # mid does reach a leaf
+        ]
+        write_sidecar(root, nodes=nodes, edges=edges, root_id="o")
+        rc, out, err = run(root)
+        expect(rc == 1, f"dangling source → exit 1 every mode, got {rc}")
+        expect("DANGLING" in err and "ghostsrc" in err,
+               f"the dangling edge is the hard violation: {err}")
+        expect("UNREACHABLE mid" not in out,
+               f"the dangling-edge consumer is not also UNREACHABLE (AC9): {out}")
+
+
+def case_reach_skips_without_root() -> None:
+    """Graceful, isolated degradation: a sidecar with no declared root, or a root
+    absent from the inventory, skips ONLY the reachability pass (a note, no crash)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        nodes = [{"id": "a", "kind": "spec"}, {"id": "comp", "kind": "component"}]
+        edges = [{"from": "a", "to": "comp"}]
+        write_sidecar(root, nodes=nodes, edges=edges, root_id="")  # → root None
+        rc, out, err = run(root)
+        expect("reachability skipped" in out and "no root" in out,
+               f"rootless sidecar skips reachability with a note: {out}")
+        expect("Traceback" not in err, f"no crash on a rootless sidecar: {err}")
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        nodes = [{"id": "a", "kind": "spec"}, {"id": "comp", "kind": "component"}]
+        edges = [{"from": "a", "to": "comp"}]
+        write_sidecar(root, nodes=nodes, edges=edges, root_id="ghost-root")
+        rc, out, err = run(root)
+        expect("reachability skipped" in out and "absent from inventory" in out,
+               f"absent declared root skips reachability with a note: {out}")
+        expect("Traceback" not in err, f"no crash on an absent-root sidecar: {err}")
+
+
+def case_reach_degenerate_cases() -> None:
+    """Degenerate graphs: a single-node root==leaf is clean; an empty-edge graph
+    strands non-root nodes (caught by presence; reachability adds nothing — the
+    non-overlap property); a self-loop is termination-safe."""
+    # (1) Single node, root == leaf → reachable/clean, no skip.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_sidecar(root, nodes=[{"id": "comp", "kind": "component"}], edges=[],
+                      root_id="comp")
+        rc, out, err = run(root)
+        expect(rc == 0 and "no structural orphans" in out,
+               f"single-node root==leaf is clean: {out}")
+        expect("UNREACHABLE" not in out and "reachability skipped" not in out,
+               f"root==leaf is reachable, pass runs: {out}")
+    # (2) Empty edges, multiple nodes → every non-root node is a presence orphan;
+    # reachability adds NO UNREACHABLE (all stranded nodes already presence orphans).
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_sidecar(root, nodes=[{"id": "o", "kind": "outcome"},
+                                   {"id": "x", "kind": "spec"},
+                                   {"id": "comp", "kind": "component"}],
+                      edges=[], root_id="o")
+        rc, out, err = run(root)
+        expect("ORPHAN x" in out and "ORPHAN comp" in out,
+               f"empty-edge non-root nodes are presence orphans: {out}")
+        expect("UNREACHABLE" not in out,
+               f"reachability is additive — no double-report on presence orphans: {out}")
+        expect("Traceback" not in err, f"no crash on an empty-edge sidecar: {err}")
+    # (3) Self-loop on an on-path node → termination-safe, not spuriously flagged
+    # (the self-edge itself is the hard violation; reachability must not hang).
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_sidecar(root, nodes=[{"id": "o", "kind": "outcome"},
+                                   {"id": "a", "kind": "spec"},
+                                   {"id": "comp", "kind": "component"}],
+                      edges=[{"from": "o", "to": "a"}, {"from": "a", "to": "a"},
+                             {"from": "a", "to": "comp"}], root_id="o")
+        rc, out, err = run(root)
+        expect(rc == 1 and "self-referential" in err.lower(),
+               f"self-edge is the hard violation: {err}")
+        expect("Traceback" not in err and "RecursionError" not in err,
+               f"reachability terminates on a self-loop: {err}")
+        expect("UNREACHABLE a" not in out and "UNREACHABLE comp" not in out,
+               f"on-path nodes not spuriously flagged despite the self-loop: {out}")
+
+
+# --------------------------------------------------------------------------
 # Container-embedded + file-backed recognition (AC1, AC2)
 # --------------------------------------------------------------------------
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1099,19 +1099,18 @@ user-triggered ones to `[pack.evals]`.
 
 ### discovery-loop-traceability-reachability
 
-**The AC34 cross-spec gap.** **Spec:** [discovery-loop](specs/discovery-loop/spec.md) (AC34) ·
-[traceability-lint](specs/traceability-lint/spec.md) (child-4, the owner)
-
-AC34 names a dependency on child-4's traceability lint performing a **root→leaf
-reachability** pass so the cascade/backstop can detect a disconnected-subtree /
-fabricated-edge failure. The **shipped** lint (`lint-traceability.py`
-`classify_sidecar`) does per-node edge-**presence**, not reachability — confirmed
-by the `0053-notes/spike/traceability.preconverge.json` comment ("the presence-check
-lint flags the tip … a reachability-to-leaf refinement would flag the whole
-subtree"). The `discovery-loop` skill **names the dependency** (AC34 met) and flags
-the gap. **Unblocks when:** child-4 (`traceability-lint`) adds the root→leaf
-reachability pass, at which point the discovery backstop catches the whole broken
-subtree, not just its orphan tip.
+**Resolved 2026-06-30.** Child-4's traceability lint
+([traceability-lint](specs/traceability-lint/spec.md), amended 2026-06-30) gained the
+**root→leaf reachability** pass (`reachability_sidecar`): on the authoritative
+sidecar graph a node off every root→leaf path is `UNREACHABLE`, so the
+`discovery-loop` cascade backstop (AC34) now catches the **whole** disconnected
+subtree, not just the orphan *tip* the per-node presence check flagged — exactly the
+refinement the `0053-notes/spike/traceability.preconverge.json` comment predicted.
+Scoped honestly: reachability closes the disconnected-subtree half and *surfaces*
+(informationally, never silently green) the fabricated-edge half — an open-world
+graph cannot mechanically tell a forged cross-repo token from a not-yet-catalogued
+one. This tombstone is **retained** (not removed) because the discovery-loop spec's
+checked AC34 links this `#anchor`.
 
 ### discovery-loop-type-marker-producers
 

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -17,6 +17,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The traceability lint gains a root→leaf reachability pass (core 0.7.1).** On the
+  authoritative sidecar graph, `work-loop`'s `lint-traceability.py` now flags every
+  node that does not lie on a path from `root` to a leaf — a **`UNREACHABLE`
+  (disconnected subtree)** finding, additive to and non-overlapping with the
+  existing per-node orphan check. Where the presence check caught only the orphan
+  *tip* of a broken branch, reachability catches the **whole** stranded subtree —
+  the refinement the `discovery-loop` cascade backstop depends on (RFC-0053 AC34).
+  A cross-repo reference resolved through the value-stream rollup is a clean
+  terminus (a legitimately federated graph is never failed); an *unresolvable*
+  cross-repo hop is surfaced informationally, **never silently counted as closed**
+  (the sidecar is untrusted input — a fabricated edge must not green a stranded
+  subtree). `UNREACHABLE` joins the `--strict` tier (exit 1); dangling edges and
+  cycles stay hard in every mode. Reachability runs in sidecar mode only — a
+  standalone derived graph is legitimately partial and multi-root. The
+  `discovery-loop` skill's traceability seam is updated to record the dependency as
+  met. *(Amends the `traceability-lint` spec; closes the
+  `discovery-loop-traceability-reachability` backlog item and the RFC-0048
+  § Amendments 2026-06-30 cross-spec gap.)*
+
 ### Added
 
 - **`new-rfc` now drafts RFCs that read from zero prior context and hands you

--- a/docs/specs/discovery-loop/spec.md
+++ b/docs/specs/discovery-loop/spec.md
@@ -342,14 +342,16 @@ end-to-end validation run that is the load-bearing gate for the modelled-not-run
   non-skippable coverage record). It runs the full battery (unlike `work-loop`'s net-new slice).
 - [x] **AC34.** **The traceability slot** this spec defines is consumed by **child-4's lint**
   (`docs/specs/traceability-lint/`), and the D3 cascade transition walks the **same edges**. **Child-4
-  dependency — named, with the gap flagged honestly:** the disconnected-subtree / fabricated-edge
-  backstop relies on a **root→leaf reachability** pass; this spec **names that dependency** (in the
-  skill's traceability seam) — but the **currently-shipped** child-4 lint does per-node
-  edge-**presence**, not reachability, so the backstop today catches the orphan *tip* of a broken
-  subtree, not the whole subtree. The reachability pass is tracked as a child-4 follow-up
-  (`docs/backlog.md` → `discovery-loop-traceability-reachability`). *This spec's obligation — consume
-  the slot, walk the same edges, name the dependency, and not be load-bearing on a claim that isn't
-  true — is met; closing the reachability gap is child-4's.*
+  dependency — now MET:** the disconnected-subtree backstop relies on a **root→leaf reachability**
+  pass, and child-4's lint **now performs it** (`traceability-lint`, amended 2026-06-30 — the
+  `reachability_sidecar` pass on the authoritative sidecar graph). The cascade backstop therefore
+  catches the **whole** disconnected subtree, not merely the orphan *tip* the earlier per-node
+  presence check flagged. Scoped honestly: reachability **closes** the disconnected-subtree half and
+  **surfaces** (informationally, never silently green — it cannot mechanically distinguish a forged
+  cross-repo token from a not-yet-catalogued one in an open-world graph) the fabricated-edge half.
+  *This spec's obligation — consume the slot, walk the same edges, and rest only on a claim that is
+  now true — is met; the formerly-tracked gap is resolved
+  (`docs/backlog.md` → `discovery-loop-traceability-reachability`).*
 - [x] **AC35.** **The backlog bridge**: the decision brief decomposes into an **ordered, dependency-aware
   backlog** (parked sub-ideas carried as first-class entries); `loop-cohort` orders it; `work-loop`
   pulls one item at a time.
@@ -432,10 +434,10 @@ end-to-end validation run that is the load-bearing gate for the modelled-not-run
   are transcribed from RFC-0053 §§ Decision 2 / Decision 3 / Security & integrity contract (source:
   `docs/rfc/0053-the-discovery-loop.md`, read 2026-06-30); the prototype artifacts demonstrating the
   connectedness lint live in `docs/rfc/0053-notes/spike/`.
-- Process: child-4's traceability lint is owned by `docs/specs/traceability-lint/` (Shipped 2026-06-29);
-  this spec **depends on** its **root→leaf reachability** pass for the backstop claim and sequences the
-  `--strict` flip after the `Discovery:` header lands (source: RFC-0053 § Security & integrity contract
-  + § Follow-on DRIFT-G).
+- Process: child-4's traceability lint is owned by `docs/specs/traceability-lint/` (Shipped 2026-06-29;
+  amended 2026-06-30 to add the **root→leaf reachability** pass this spec's backstop claim depends on —
+  the dependency is now MET) and sequences the `--strict` flip after the `Discovery:` header lands
+  (source: RFC-0053 § Security & integrity contract + § Follow-on DRIFT-G).
 - Process/governance: the spec slug is `discovery-loop/` (RFC-0053 § Follow-on offered
   `coordinator-contract/` or `discovery-loop/`; resolved to the skill-matching name — a naming call the
   RFC authorized either way) (source: RFC-0053 § Follow-on → Spec; resolve-vs-surface disposition,

--- a/docs/specs/traceability-lint/notes/reachability-review.md
+++ b/docs/specs/traceability-lint/notes/reachability-review.md
@@ -1,0 +1,15 @@
+# Reachability amendment — review round (2026-06-30)
+
+Spec-stage: adversarial + security both raised a Blocker — open-world terminus
+made the backstop forgeable (a fabricated unresolvable cross-repo edge would
+false-green a stranded subtree). Resolved: only rollup-RESOLVED satisfied-by-
+reference endpoints terminate cleanly; an unresolvable hop is surfaced
+informationally, never silently green, never --strict-promoted.
+
+Diff-stage:
+- security-reviewer: Clean — ready to commit.
+- adversarial-reviewer findings:
+
+**1. AC9 non-overlap leaks for the consumer of a dangling-source edge.** `packs/core/.apm/skills/work-loop/scripts/lint-traceability.py:1130`. A node whose sole producer edge has a dangling source was reported as both DANGLING and UNREACHABLE. Fix: broadened the AC9 skip set to also drop consumers of dangling-source edges (`{b for a,b if a in dangling_set}`); spec AC9 wording aligned; regression test `case_reach_dangling_adjacent_not_double_reported` added. APPLIED.
+
+**2. external-node count inflation.** `lint-traceability.py:1108`. `len(g.nodes)` now includes synthesized external termini. Disposition: DEFER (kept). The count reflects the resolved working graph — consistent with standalone mode's long-standing behavior (which has always counted `_wire`-resolved externals). Cosmetic; noted in PR.

--- a/docs/specs/traceability-lint/spec.md
+++ b/docs/specs/traceability-lint/spec.md
@@ -1,6 +1,6 @@
 # Spec: traceability-lint
 
-- **Status:** Shipped (2026-06-29) <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Status:** Shipped (2026-06-29; amended 2026-06-30 — root→leaf reachability pass) <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** RFC-0048 (governing — Decision 6); RFC-0053 (the traceability slot, the `schema_version` convention, and the child-4-consumes-the-slot relationship); RFC-0040, RFC-0019, RFC-0025, RFC-0030, ADR-0022, RFC-0049 (mechanism precedent)
@@ -55,9 +55,15 @@ open-world posture every federated catalog takes.
 Success is: the maintainer runs one command — in a single module repo, or in the
 meta-repo over the federated rollup — and learns exactly which nodes are
 disconnected and in which direction, which references cross a repo boundary and
-whether they are pinned, and which targets are not yet catalogued. A strict mode
-fails a convergence or CI gate when the local chain must be closed; graceful
-silence in a workspace with no chain artifacts at all. The lint checks *structure
+whether they are pinned, and which targets are not yet catalogued. On the
+authoritative sidecar graph the lint goes one step further than per-node edge
+presence and runs a **root→leaf reachability** pass: a node that has both a local
+producer and consumer edge but sits on a branch that never reaches a leaf is
+*stranded*, and presence alone catches only the orphan **tip** of such a subtree —
+reachability flags the whole disconnected subtree, the refinement the
+discovery-loop cascade backstop (`docs/specs/discovery-loop/`, AC34) depends on. A
+strict mode fails a convergence or CI gate when the local chain must be closed;
+graceful silence in a workspace with no chain artifacts at all. The lint checks *structure
 only*; whether a node is parented to the **right** outcome (semantic scope-creep)
 is never its call — structural presence is mechanizable, semantic correctness is
 not (the established traceability split).
@@ -114,8 +120,11 @@ before proceeding; *Never do* is a hard rule, even under time pressure.
 - **Never invent a parallel cross-repo pointer or id scheme** — reuse the
   value-stream / Backstage conventions; a second scheme forks the graph.
 - **Never treat a well-formed cross-repo reference as a dangling edge**, nor a
-  not-yet-catalogued target as silently satisfied — the two opposite false
-  verdicts a naive single-tree scan produces.
+  not-yet-catalogued target as silently satisfied **— for endpoint resolution *or*
+  for reachability** (an unresolvable cross-repo endpoint is never a clean
+  reachability terminus; the subtree it terminates is surfaced informationally, not
+  counted closed) — the two opposite false verdicts a naive single-tree scan
+  produces.
 - **Never wire the lint into the projected `pre-pr` hook body** — that body
   projects to adopter trees and would mis-fire (no PR-open hook event in an adopter
   repo); the agent-invoked finish-time checklist and an explicit CI gate are the
@@ -132,6 +141,24 @@ before proceeding; *Never do* is a hard rule, even under time pressure.
 - **Structural-orphan detection (up/backward, down/forward, terminal exemption,
   layer-skip): TDD.** A compressible invariant over a graph — fixture workspaces
   in, exact orphan list out. The core of the lint.
+- **Root→leaf reachability (sidecar mode): TDD.** Fixtures pin each discriminator:
+  (a) a locally-edged **dead-end subtree** — every interior node carries a producer
+  and a consumer edge, but the branch never reaches a `leaf_kind` node — asserts
+  presence passes the interior nodes and flags only the tip, while reachability
+  flags the stranded interior (union = the whole subtree); (b) a **floating subtree
+  disconnected from `root`** (internally edged, even reaching a leaf) asserts the
+  forward-from-root clause flags it; (c) a **federated branch whose leaf is a
+  rollup-resolved satisfied-by-reference** endpoint asserts the branch is **not**
+  flagged (clean open-world terminus); (d) a stranded tip carrying a **forged /
+  unresolvable** cross-repo out-edge asserts it is surfaced as
+  `reaches a leaf only via an unresolved cross-repo reference` (informational, exit
+  0 even under `--strict`) and **never silently green** — the fabricated-edge
+  boundary; (e) a sidecar with no / absent `root` asserts graceful skip; (f) the **degenerate
+  cases** — a single-node sidecar whose `root` is itself `leaf_kind` is
+  reachable/clean, an empty-edge multi-node sidecar strands every non-root node, and
+  a self-loop node is termination-safe (visited-set) and not a clean terminus; and
+  the exit-code matrix asserts `UNREACHABLE` is informational by default and exit 1
+  under `--strict`.
 - **The three endpoint states (local / satisfied-by-reference / unresolvable) and
   the three defect classes (orphan / dangling / cycle): TDD.** Each is
   deterministic; fixtures cover the discriminators — a well-formed cross-repo
@@ -204,11 +231,80 @@ before proceeding; *Never do* is a hard rule, even under time pressure.
 - [x] An **unresolvable cross-repo endpoint** (and a not-yet-catalogued rollup row)
   is reported as **`unknown / not-yet-catalogued`** — **informational, never fatal
   and never silently satisfied** (the open-world, federated-catalog posture).
-- [x] **Exit codes are coherent:** default mode — structural orphans are
-  **informational (exit 0)**; **`--strict`** — any structural orphan **exits 1**
-  (the convergence-/CI-gate enforcing "traceability closed", RFC-0048 O6); dangling
-  edges and cycles **exit 1 in every mode**; unresolvable-cross-repo, unpinned
-  references, and drift are **never fatal**.
+- [x] **Exit codes are coherent:** default mode — structural orphans **and
+  `UNREACHABLE` reachability findings** are **informational (exit 0)**, each named
+  in its own one-line summary count on stdout (a `--strict` exit-1 caused by
+  reachability alone is legible, not folded into the orphan count); **`--strict`** —
+  any structural orphan **or `UNREACHABLE` finding exits 1** (the
+  convergence-/CI-gate enforcing "traceability closed", RFC-0048 O6); dangling edges
+  and cycles **exit 1 in every mode**; unresolvable-cross-repo, the
+  `reaches a leaf only via an unresolved cross-repo reference` finding, unpinned
+  references, and drift are **never fatal** (not promoted by `--strict`).
+- [x] **Reachability — every node lies on a root→leaf path (sidecar-authoritative
+  mode).** Beyond per-node edge *presence*, the lint runs a **root→leaf
+  reachability** pass on the authoritative sidecar graph: a node is *reachable* iff
+  it is **forward-reachable from `root`** (following edges) **and can reach a clean
+  terminus** (a node of `leaf_kind`, or a **rollup-resolved satisfied-by-reference**
+  endpoint — see the next AC). A node that is reachable from neither direction — not
+  forward-reachable from `root`, **or** unable to reach any terminus — is a **new
+  finding class, `UNREACHABLE` (disconnected subtree)**, distinct from a presence
+  orphan. The pass is computed by **two bounded iterative traversals over the
+  identical edge set `classify_sidecar` uses** — a forward BFS/DFS from `root` and a
+  backward BFS/DFS from the terminus set, each with an explicit stack and a visited
+  set, terminating in **O(V+E)** on cyclic or deep untrusted graphs (mirroring
+  `_find_cycles`'s iterative posture — no recursion-limit DoS). Reachability is
+  **strictly additive and non-overlapping**: the reported `UNREACHABLE` set is the
+  stranded nodes **minus** every node `classify_sidecar` already returned as a
+  presence orphan **and minus** every node adjacent to a dangling edge — its source
+  *or* its consumer (one break, one class — AC9). So a presence orphan flags the orphan *tip* of a broken local
+  subtree and `UNREACHABLE` flags the stranded **interior** ancestors a presence
+  check passes (a node carrying both a local producer and consumer edge yet on a
+  branch that never reaches a leaf); their union is the whole local disconnected
+  subtree. The pass runs **only in sidecar-authoritative mode**, where `root` and
+  `leaf_kind` are explicitly declared and the graph is a closed, single-rooted DAG;
+  the **standalone derive-from-artifacts mode keeps presence + layer-skip only** — a
+  derived graph is legitimately partial and multi-root (no single declared root),
+  so a strict root→leaf pass there would false-fail an ordinary partial single-repo
+  chain. This closes the RFC-0048 § Amendments (2026-06-30) cross-spec gap and the
+  `discovery-loop` AC34 **disconnected-subtree** backstop dependency: the cascade
+  backstop now catches a whole disconnected subtree, not just its orphan tip.
+  Reachability **degrades gracefully and in isolation** — a sidecar with no declared
+  `root`, or a `root` absent from the node inventory, reports the degradation
+  informationally and skips **only** the reachability pass (never a crash, and never
+  the top-level `except` that would degrade the whole lint to a false-green exit 0);
+  an edge endpoint absent from `nodes` is tolerated (it is the existing
+  `sidecar edge endpoint not in inventory` dangling case), never a `KeyError`.
+- [x] **Reachability is open-world across a repo boundary — only a *resolved*
+  reference terminates cleanly; an *unresolvable* one is surfaced, never silently
+  green.** A node whose only forward path to a leaf crosses a repo boundary into a
+  **rollup-resolved satisfied-by-reference** endpoint (**pinned or unpinned** —
+  pinning is the orthogonal soft-warning flag, never a reachability gate) is
+  **reachable, clean** — the lint cannot follow the chain into another repo, and the
+  value-stream rollup vouches for the target, so it must never declare a
+  legitimately **federated** graph "can't reach a leaf" (the open-world posture this
+  spec already takes for endpoint *resolution*, extended to *reachability*). An
+  **unresolvable** cross-repo endpoint (well-formed shape, **not** rollup-resolved)
+  is **NOT a clean terminus** — because the sidecar graph is **untrusted input**, a
+  hand-authored fabricated `x/y` / `a@1` out-edge on a stranded tip would otherwise
+  false-green the backstop (the *fabricated-edge* evasion). Instead a node whose
+  only escape from a dead branch is an unresolvable hop is surfaced as a **distinct
+  informational finding, `reaches a leaf only via an unresolved cross-repo
+  reference`** — **never silently counted as closed, and never fatal** (consistent
+  with this spec's standing "unresolvable is informational, never fatal, never
+  silently satisfied" posture; `--strict` does not promote it, mirroring
+  unpinned/unresolvable). This bounds the AC34 claim honestly: reachability closes
+  the **disconnected-subtree** half of the backstop and **surfaces** (does not
+  hard-catch) the **fabricated-edge** half — an open-world graph cannot
+  mechanically distinguish a forged token from a not-yet-catalogued one, so it makes
+  the gap *visible* rather than *forgeably green*. To make this real in sidecar mode,
+  a sidecar edge endpoint absent from the local inventory is **resolved against the
+  value-stream rollup**: a well-formed cross-repo reference is recorded as a
+  **satisfied-by-reference / unresolvable external terminus (never a dangling
+  edge)** — aligning sidecar mode with this spec's standing *Never treat a
+  well-formed cross-repo reference as a dangling edge* boundary; a non-inventory
+  endpoint that is **not** a well-formed cross-repo reference (a bare/malformed
+  token) stays a **dangling** hard violation in every mode. A reference (external)
+  endpoint is **never** itself orphan- or reachability-checked.
 - [x] The lint runs in **two postures**: **single-repo** (checks the local
   sub-chain and validates that outbound cross-repo pointers are well-formed — carry
   a stable-id — reporting an unpinned outbound pointer informationally), and
@@ -295,6 +391,17 @@ before proceeding; *Never do* is a hard rule, even under time pressure.
   (RFC-0048 D7) with a **derive-from-artifacts standalone mode when absent**; the
   refinement is reconciled into RFC-0048 as a tracked amendment per its
   provisional-foundation note (source: RFC-0048 D7 + the shippable-standalone goal).
+- Technical/governance: **reachability is a sidecar-authoritative-mode pass** —
+  `root` + `leaf_kind` are declared there and the graph is a closed single-rooted
+  DAG; the standalone derived graph is legitimately partial / multi-root, so it
+  keeps presence + layer-skip and no strict root→leaf pass. A cross-repo reference
+  (satisfied-by-reference pinned or unpinned, or unresolvable) is a valid
+  reachability terminus — the open-world rule that prevents false-failing a
+  federated graph (source: the AC34 cross-spec gap, RFC-0048 § Amendments
+  2026-06-30; the preconverge spike comment
+  `docs/rfc/0053-notes/spike/traceability.preconverge.json` — "a
+  reachability-to-leaf refinement would flag the whole subtree; the presence-check
+  lint flags the tip").
 - Process: the structural-vs-semantic split is grounded — structural link presence
   is mechanizable, semantic link correctness is not reliably so (the SoK
   traceability survey; ReqToCode's "structural presence, not semantic correctness";

--- a/packs/core/.apm/skills/work-loop/scripts/lint-traceability.py
+++ b/packs/core/.apm/skills/work-loop/scripts/lint-traceability.py
@@ -50,16 +50,28 @@ Two sources, one classifier:
   A matrix↔artifact disagreement is reported as **drift, warn-only** until the
   sidecar schema is pinned (deferred: sidecar-drift-hard-fail).
 
+On the authoritative sidecar graph the lint also runs a **root→leaf reachability**
+pass (`reachability_sidecar`): a node is reachable iff it is forward-reachable from
+`root` AND can reach a clean terminus (a `leaf_kind` node or a rollup-resolved
+`satisfied-by-reference` endpoint). A node off every root→leaf path is `UNREACHABLE`
+(the disconnected-subtree finding the discovery-loop cascade backstop depends on,
+RFC-0053 AC34) — additive to, and non-overlapping with, the presence orphans. An
+*unresolvable* cross-repo hop is **not** a clean terminus (the sidecar is untrusted
+input — a forged out-edge must not silently green a stranded subtree); a node whose
+only escape is such a hop is surfaced informationally, never fatal. Reachability is
+sidecar-only — a standalone derived graph is legitimately partial / multi-root.
+
 Exit codes:
-  0 = clean / reported. Structural orphans are informational in default mode;
-      unresolvable cross-repo endpoints, unpinned references, and drift are
-      never fatal.
+  0 = clean / reported. Structural orphans and `UNREACHABLE` findings are
+      informational in default mode; unresolvable cross-repo endpoints, the
+      `reaches a leaf only via an unresolved cross-repo reference` finding,
+      unpinned references, and drift are never fatal.
   1 = a hard violation — a dangling edge (a pointer to a missing local target,
       or malformed) or a cycle, **in every mode**; or, under `--strict`, any
-      structural orphan (the convergence-/CI-gate enforcing "traceability
-      closed", RFC-0048 O6). `--strict` degrades gracefully where the producer
-      `Discovery:` headers / `type:` markers are absent (a separate CONVENTIONS
-      follow-on lands those).
+      structural orphan or `UNREACHABLE` node (the convergence-/CI-gate enforcing
+      "traceability closed", RFC-0048 O6). `--strict` degrades gracefully where the
+      producer `Discovery:` headers / `type:` markers are absent (a separate
+      CONVENTIONS follow-on lands those).
 
 No chain artifacts at all → exit 0 with no diagnostic (the
 `lint-brief-coverage.py` no-brief precedent).
@@ -749,11 +761,15 @@ def classify_sidecar(g: Graph) -> list[tuple[str, str, str]]:
     `check_sidecar` rule (RFC-0053 spike): `root` is exempt from an in-edge,
     `leaf_kind` from an out-edge, everything else needs both. The sidecar's
     edges already encode any layer-skip explicitly, so no populated-layer
-    inference is applied."""
+    inference is applied. A **reference (external) endpoint** registered by
+    `resolve_sidecar_endpoints` is never orphan-checked — it is the cross-repo
+    boundary, not a chain node owing a local producer/consumer."""
     has_in = {to for _, to in g.edges}
     has_out = {frm for frm, _ in g.edges}
     orphans: list[tuple[str, str, str]] = []
     for nid, kind in sorted(g.nodes.items()):
+        if nid in g.ref_state:  # external reference endpoint — never orphan-checked
+            continue
         missing: list[str] = []
         if nid != g.root and nid not in has_in:
             missing.append("no producer (up-edge)")
@@ -765,10 +781,128 @@ def classify_sidecar(g: Graph) -> list[tuple[str, str, str]]:
 
 
 def sidecar_dangling(g: Graph) -> list[str]:
-    """Sidecar edge endpoints naming a node absent from the inventory."""
+    """Sidecar edge endpoints naming a node absent from the inventory. After
+    `resolve_sidecar_endpoints` has run, a well-formed cross-repo reference is in
+    the inventory as an `external` node, so only a bare/malformed missing-local
+    token remains here — a hard violation in every mode."""
     return sorted({
         p for e in g.edges for p in e if p not in g.nodes
     })
+
+
+def resolve_sidecar_endpoints(g: Graph, rollup: dict[str, bool]) -> None:
+    """Resolve each sidecar edge endpoint absent from the local inventory against
+    the value-stream rollup (the open-world cross-repo posture, extended from
+    endpoint *resolution* to *reachability*). A well-formed cross-repo reference
+    becomes a `satisfied-by-reference` / `unresolvable` **external** node — so it is
+    no longer a `sidecar_dangling` endpoint and can serve as a reachability terminus
+    — while a bare / malformed token is left out of inventory for `sidecar_dangling`
+    to flag (hard, every mode). Mirrors the standalone `_wire` endpoint handling;
+    reuses `resolve_endpoint`, never a parallel scheme. The sidecar graph is
+    untrusted input, so this only ever *adds* a clearly-labelled external node — it
+    never silences a missing-local target."""
+    local_ids = set(g.nodes)
+    for a, b in sorted(g.edges):
+        for ep in (a, b):
+            if ep in local_ids or ep in g.ref_state:
+                continue
+            state, pinned, _ = resolve_endpoint(ep, local_ids, rollup)
+            if state in ("satisfied-by-reference", "unresolvable"):
+                g.ref_state[ep] = state
+                g.ref_pinned[ep] = pinned
+                g.nodes.setdefault(ep, "external")
+
+
+def _reach(seeds: set[str], adj: dict[str, list[str]]) -> set[str]:
+    """Iterative (explicit-stack) reachability over adjacency `adj` from `seeds`
+    (seeds included). A visited set bounds it to **O(V+E)** and terminates on a
+    cyclic or deep untrusted graph — the same posture as `_find_cycles`, no
+    recursion-limit DoS."""
+    seen = set(seeds)
+    stack = list(seeds)
+    while stack:
+        node = stack.pop()
+        for nxt in adj.get(node, ()):
+            if nxt not in seen:
+                seen.add(nxt)
+                stack.append(nxt)
+    return seen
+
+
+def reachability_sidecar(
+    g: Graph,
+) -> tuple[list[tuple[str, str, str]], list[tuple[str, str, str]], list[str]]:
+    """Root→leaf reachability over the authoritative sidecar graph (sidecar mode
+    only — `root` + `leaf_kind` are declared there and the graph is a closed,
+    single-rooted DAG; the standalone derived graph is legitimately partial /
+    multi-root and keeps presence + layer-skip).
+
+    A node is *reachable* iff it is **forward-reachable from `root`** AND **can reach
+    a clean terminus** — a node of `leaf_kind`, or a rollup-resolved
+    `satisfied-by-reference` endpoint. Returns `(unreachable, soft, notes)`:
+
+    - `unreachable` — `(id, kind, reason)` for a node not on any root→leaf path
+      (not forward-reachable, or reaches no terminus at all): the `UNREACHABLE`
+      disconnected-subtree finding. The caller subtracts presence orphans + dangling
+      sources so the two diagnostics stay non-overlapping (one break, one class).
+    - `soft` — `(id, kind, reason)` for a node whose only escape from a dead branch
+      is an **`unresolvable`** cross-repo hop. Because the sidecar is untrusted
+      input, a forged `x/y` out-edge must not silently green a stranded subtree, so
+      an unresolvable hop is **not** a clean terminus: it is surfaced as a distinct
+      informational finding (never fatal — `--strict` does not promote it), making
+      the fabricated-edge gap *visible* rather than forgeably green.
+
+    Degrades in isolation (a note, empty findings) when no `root` is declared / in
+    inventory, or no `leaf_kind` terminus exists — never a crash, never the
+    whole-lint exit-0 backstop."""
+    notes: list[str] = []
+    if not g.root or g.root not in g.nodes:
+        notes.append(
+            f"reachability skipped — declared root '{g.root}' absent from inventory"
+            if g.root else "reachability skipped — sidecar declares no root"
+        )
+        return [], [], notes
+
+    clean_termini = {nid for nid, kind in g.nodes.items() if kind == g.leaf_kind}
+    clean_termini |= {nid for nid, st in g.ref_state.items()
+                      if st == "satisfied-by-reference"}
+    if not clean_termini:
+        # No leaf to reach — presence (a bottom node with no consumer is a forward
+        # orphan) already covers a leaf-less chain; flagging every node here is noise.
+        notes.append("reachability skipped — no leaf_kind terminus in inventory")
+        return [], [], notes
+    soft_termini = {nid for nid, st in g.ref_state.items() if st == "unresolvable"}
+
+    fwd: dict[str, list[str]] = {}
+    rev: dict[str, list[str]] = {}
+    for a, b in g.edges:
+        fwd.setdefault(a, []).append(b)
+        rev.setdefault(b, []).append(a)
+    forward = _reach({g.root}, fwd)              # forward-reachable from root
+    reach_clean = _reach(clean_termini, rev)     # can reach a clean terminus
+    reach_any = _reach(clean_termini | soft_termini, rev)  # … incl. via unresolved
+
+    unreachable: list[tuple[str, str, str]] = []
+    soft: list[tuple[str, str, str]] = []
+    for nid, kind in sorted(g.nodes.items()):
+        # The root anchors the graph (never "unreachable"); a reference endpoint is
+        # the cross-repo boundary — neither is itself reachability-checked.
+        if nid == g.root or nid in g.ref_state or kind == "external":
+            continue
+        in_fwd = nid in forward
+        if in_fwd and nid in reach_clean:
+            continue  # cleanly on a root→leaf path
+        if in_fwd and nid in reach_any:
+            soft.append((nid, kind,
+                         "reaches a leaf only via an unresolved cross-repo reference"))
+            continue
+        why: list[str] = []
+        if not in_fwd:
+            why.append("not forward-reachable from root")
+        if nid not in reach_any:
+            why.append("reaches no leaf")
+        unreachable.append((nid, kind, "; ".join(why) or "off the root→leaf path"))
+    return unreachable, soft, notes
 
 
 # --------------------------------------------------------------------------
@@ -944,6 +1078,10 @@ def check(root: Path, strict: bool) -> tuple[list[str], list[str], int]:
 
     if not using_sidecar:
         build_standalone(root, layout, g, rollup)
+    else:
+        # Resolve any cross-repo edge endpoint against the rollup so a federated
+        # sidecar's external leaf is a reachability terminus, not a dangling edge.
+        resolve_sidecar_endpoints(g, rollup)
 
     # No chain anchor at all → no-op clean (the lint-brief-coverage no-brief
     # precedent). The anchor is a *discovery-side* artifact — a sidecar, a
@@ -978,6 +1116,27 @@ def check(root: Path, strict: bool) -> tuple[list[str], list[str], int]:
                      for d in sidecar_dangling(g)]
     cycles = _find_cycles(g)
 
+    # Root→leaf reachability (sidecar-authoritative mode only). The reported set is
+    # additive: stranded nodes minus the presence orphans and dangling-edge sources
+    # already reported, so a single break is one class, never two (AC9). Its own
+    # degradations are notes; it never crashes or fails the whole lint.
+    unreachable: list[tuple[str, str, str]] = []
+    soft_unresolved: list[tuple[str, str, str]] = []
+    if using_sidecar:
+        unreach, soft, rnotes = reachability_sidecar(g)
+        g.notes.extend(rnotes)
+        orphan_ids = {nid for nid, _, _ in orphans}
+        dangling_set = set(sidecar_dangling(g))
+        # One break, one class (AC9): a node adjacent to a dangling edge — whether
+        # the edge's source (its target is missing) or its consumer (its producer
+        # is missing) — is already surfaced by that DANGLING violation, so it is not
+        # also reported as UNREACHABLE.
+        dangling_adjacent = ({a for a, b in g.edges if b in dangling_set}
+                             | {b for a, b in g.edges if a in dangling_set})
+        skip = orphan_ids | dangling_adjacent
+        unreachable = [t for t in unreach if t[0] not in skip]
+        soft_unresolved = [t for t in soft if t[0] not in skip]
+
     for nid, st in sorted(g.ref_state.items()):
         if st == "satisfied-by-reference":
             flag = "pinned" if g.ref_pinned.get(nid) else "unpinned (soft warning)"
@@ -991,6 +1150,12 @@ def check(root: Path, strict: bool) -> tuple[list[str], list[str], int]:
 
     for nid, kind, why in orphans:
         out.append(f"  - ORPHAN {nid} [{kind}]: {why}")
+
+    for nid, kind, why in unreachable:
+        out.append(f"  - UNREACHABLE {nid} [{kind}]: {why}")
+
+    for nid, kind, why in soft_unresolved:
+        out.append(f"  - {nid} [{kind}]: {why} (informational)")
 
     # Drift cross-check: sidecar present AND artifacts derivable — warn-only
     # until the matrix schema is pinned (deferred: sidecar-drift-hard-fail).
@@ -1006,6 +1171,14 @@ def check(root: Path, strict: bool) -> tuple[list[str], list[str], int]:
         out.append("lint-traceability: no structural orphans — every node has "
                    "a producer and a consumer.")
 
+    # Reachability summary on its own line — a --strict exit caused by a
+    # disconnected subtree is legible, not folded into the orphan count.
+    if unreachable:
+        verb = ("disconnected subtree — FAIL (--strict)" if strict
+                else "disconnected subtree (informational)")
+        out.append(f"lint-traceability: {len(unreachable)} unreachable node(s), "
+                   f"{verb}.")
+
     for d in dangling:
         hard.append(f"DANGLING — {d}")
     for c in cycles:
@@ -1014,7 +1187,7 @@ def check(root: Path, strict: bool) -> tuple[list[str], list[str], int]:
     exit_hint = 0
     if hard:
         exit_hint = 1
-    elif orphans and strict:
+    elif (orphans or unreachable) and strict:
         exit_hint = 1
     return out, hard, exit_hint
 

--- a/packs/core/.apm/skills/work-loop/scripts/test-lint-traceability.py
+++ b/packs/core/.apm/skills/work-loop/scripts/test-lint-traceability.py
@@ -487,6 +487,220 @@ def case_dangling_up_field_still_fires() -> None:
 
 
 # --------------------------------------------------------------------------
+# Root→leaf reachability (sidecar mode) — the AC34 disconnected-subtree backstop
+# --------------------------------------------------------------------------
+
+# A healthy chain (root=o → spec-h → comp-h, a real component leaf) shared by the
+# reachability fixtures so a clean terminus exists; each case bolts a broken branch
+# onto the root `o`.
+_HEALTHY_NODES = [
+    {"id": "o", "kind": "outcome"},
+    {"id": "spec-h", "kind": "spec"},
+    {"id": "comp-h", "kind": "component"},
+]
+_HEALTHY_EDGES = [{"from": "o", "to": "spec-h"}, {"from": "spec-h", "to": "comp-h"}]
+
+
+def case_reach_dead_end_subtree_whole_not_just_tip() -> None:
+    """The preconverge "whole subtree" case: a locally-edged dead-end branch where
+    every interior node has a producer AND a consumer edge, but the branch never
+    reaches a leaf. Presence flags only the tip (no out-edge); reachability flags
+    the stranded interior the presence check passes — union = the whole subtree."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        nodes = _HEALTHY_NODES + [
+            {"id": "cap-d", "kind": "capability"},
+            {"id": "scr-d", "kind": "screen"},
+            {"id": "svc-d", "kind": "service"},  # tip — no out-edge
+        ]
+        edges = _HEALTHY_EDGES + [
+            {"from": "o", "to": "cap-d"}, {"from": "cap-d", "to": "scr-d"},
+            {"from": "scr-d", "to": "svc-d"},
+        ]
+        write_sidecar(root, nodes=nodes, edges=edges, root_id="o")
+        rc, out, err = run(root)
+        # Presence flags ONLY the tip; the interior is passed by presence.
+        expect("ORPHAN svc-d" in out and "no consumer" in out,
+               f"presence flags the tip svc-d: {out}")
+        expect("ORPHAN cap-d" not in out and "ORPHAN scr-d" not in out,
+               f"presence passes the interior nodes: {out}")
+        # Reachability flags the interior (which presence passed) — not just the tip.
+        expect("UNREACHABLE cap-d" in out and "UNREACHABLE scr-d" in out,
+               f"reachability flags the stranded interior: {out}")
+        # AC9 — one break, one class: the tip is the presence ORPHAN, not also
+        # double-reported as UNREACHABLE.
+        expect("UNREACHABLE svc-d" not in out,
+               f"tip is the presence orphan, not also UNREACHABLE: {out}")
+        # Union covers the whole subtree {cap-d, scr-d, svc-d}.
+        expect(rc == 0, f"reachability informational by default → exit 0, got {rc}")
+        rc2, _, _ = run(root, "--strict")
+        expect(rc2 == 1, f"UNREACHABLE + --strict → exit 1, got {rc2}")
+
+
+def case_reach_floating_subtree_disconnected_from_root() -> None:
+    """The forward-from-root clause: a subtree internally edged and even reaching a
+    leaf, but with no path from `root`, is flagged (its source is a presence
+    backward orphan; its leaf — passed by presence — is UNREACHABLE)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        nodes = _HEALTHY_NODES + [
+            {"id": "spec-f", "kind": "spec"},
+            {"id": "comp-f", "kind": "component"},
+        ]
+        edges = _HEALTHY_EDGES + [{"from": "spec-f", "to": "comp-f"}]
+        write_sidecar(root, nodes=nodes, edges=edges, root_id="o")
+        rc, out, err = run(root)
+        expect("ORPHAN spec-f" in out and "no producer" in out,
+               f"floating source is a presence backward orphan: {out}")
+        expect("UNREACHABLE comp-f" in out and "not forward-reachable" in out,
+               f"floating leaf flagged not-reachable-from-root: {out}")
+        expect(rc == 0, f"informational by default → exit 0, got {rc}")
+
+
+def case_reach_federated_resolved_terminus_not_flagged() -> None:
+    """Open-world: a branch whose leaf is a rollup-RESOLVED satisfied-by-reference
+    endpoint reaches a clean terminus across the boundary — never flagged."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        nodes = _HEALTHY_NODES + [{"id": "spec-x", "kind": "spec"}]
+        edges = _HEALTHY_EDGES + [
+            {"from": "o", "to": "spec-x"}, {"from": "spec-x", "to": "ext-comp@2"},
+        ]
+        write_sidecar(root, nodes=nodes, edges=edges, root_id="o")
+        write_rollup(root, ["| `ext-comp@2` | `r` · `s` | x@1 | delivered | y |\n"])
+        rc, out, err = run(root)
+        expect(rc == 0, f"federated resolved terminus → exit 0, got {rc}: {err}")
+        expect("satisfied-by-reference (pinned)" in out,
+               f"cross-repo leaf is a resolved reference: {out}")
+        expect("UNREACHABLE spec-x" not in out and "ORPHAN spec-x" not in out,
+               f"a federated branch is not flagged: {out}")
+        expect("DANGLING" not in err,
+               f"a cross-repo sidecar endpoint is not dangling: {err}")
+        rc2, _, _ = run(root, "--strict")
+        expect(rc2 == 0, f"--strict + only a resolved federated leaf → exit 0, got {rc2}")
+
+
+def case_reach_unresolvable_tip_surfaced_never_silently_green() -> None:
+    """The fabricated-edge boundary: a stranded tip whose only out-edge is an
+    UNRESOLVABLE (forged-eligible) cross-repo token is NOT a clean terminus — the
+    branch is surfaced as a distinct informational finding, never silently green and
+    never promoted by --strict (the untrusted-input control-integrity guard)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        nodes = _HEALTHY_NODES + [
+            {"id": "cap-u", "kind": "capability"},
+            {"id": "scr-u", "kind": "screen"},
+        ]
+        edges = _HEALTHY_EDGES + [
+            {"from": "o", "to": "cap-u"}, {"from": "cap-u", "to": "scr-u"},
+            {"from": "scr-u", "to": "forged/x"},  # unresolvable cross-repo token
+        ]
+        write_sidecar(root, nodes=nodes, edges=edges, root_id="o")
+        rc, out, err = run(root)
+        expect(rc == 0, f"unresolvable tip → never fatal, exit 0, got {rc}: {err}")
+        expect("DANGLING" not in err,
+               f"a well-formed cross-repo token is not dangling: {err}")
+        expect("unknown / not-yet-catalogued" in out,
+               f"the forged endpoint is surfaced honestly: {out}")
+        expect("reaches a leaf only via an unresolved cross-repo reference" in out,
+               f"the stranded branch is surfaced, not silently green: {out}")
+        expect("(informational)" in out, f"surfaced informationally: {out}")
+        # Critically NOT flagged as a clean pass and NOT promoted by --strict.
+        rc2, out2, _ = run(root, "--strict")
+        expect(rc2 == 0,
+               f"--strict does NOT promote an unresolvable hop, got {rc2}: {out2}")
+
+
+def case_reach_dangling_adjacent_not_double_reported() -> None:
+    """AC9 one-break-one-class: a node whose sole producer edge has a *dangling
+    source* (the producer is a missing-local target) is surfaced by the DANGLING
+    violation, not ALSO as UNREACHABLE."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        nodes = _HEALTHY_NODES + [{"id": "mid", "kind": "spec"}]
+        edges = _HEALTHY_EDGES + [
+            {"from": "ghostsrc", "to": "mid"},  # ghostsrc absent → dangling source
+            {"from": "mid", "to": "comp-h"},    # mid does reach a leaf
+        ]
+        write_sidecar(root, nodes=nodes, edges=edges, root_id="o")
+        rc, out, err = run(root)
+        expect(rc == 1, f"dangling source → exit 1 every mode, got {rc}")
+        expect("DANGLING" in err and "ghostsrc" in err,
+               f"the dangling edge is the hard violation: {err}")
+        expect("UNREACHABLE mid" not in out,
+               f"the dangling-edge consumer is not also UNREACHABLE (AC9): {out}")
+
+
+def case_reach_skips_without_root() -> None:
+    """Graceful, isolated degradation: a sidecar with no declared root, or a root
+    absent from the inventory, skips ONLY the reachability pass (a note, no crash)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        nodes = [{"id": "a", "kind": "spec"}, {"id": "comp", "kind": "component"}]
+        edges = [{"from": "a", "to": "comp"}]
+        write_sidecar(root, nodes=nodes, edges=edges, root_id="")  # → root None
+        rc, out, err = run(root)
+        expect("reachability skipped" in out and "no root" in out,
+               f"rootless sidecar skips reachability with a note: {out}")
+        expect("Traceback" not in err, f"no crash on a rootless sidecar: {err}")
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        nodes = [{"id": "a", "kind": "spec"}, {"id": "comp", "kind": "component"}]
+        edges = [{"from": "a", "to": "comp"}]
+        write_sidecar(root, nodes=nodes, edges=edges, root_id="ghost-root")
+        rc, out, err = run(root)
+        expect("reachability skipped" in out and "absent from inventory" in out,
+               f"absent declared root skips reachability with a note: {out}")
+        expect("Traceback" not in err, f"no crash on an absent-root sidecar: {err}")
+
+
+def case_reach_degenerate_cases() -> None:
+    """Degenerate graphs: a single-node root==leaf is clean; an empty-edge graph
+    strands non-root nodes (caught by presence; reachability adds nothing — the
+    non-overlap property); a self-loop is termination-safe."""
+    # (1) Single node, root == leaf → reachable/clean, no skip.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_sidecar(root, nodes=[{"id": "comp", "kind": "component"}], edges=[],
+                      root_id="comp")
+        rc, out, err = run(root)
+        expect(rc == 0 and "no structural orphans" in out,
+               f"single-node root==leaf is clean: {out}")
+        expect("UNREACHABLE" not in out and "reachability skipped" not in out,
+               f"root==leaf is reachable, pass runs: {out}")
+    # (2) Empty edges, multiple nodes → every non-root node is a presence orphan;
+    # reachability adds NO UNREACHABLE (all stranded nodes already presence orphans).
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_sidecar(root, nodes=[{"id": "o", "kind": "outcome"},
+                                   {"id": "x", "kind": "spec"},
+                                   {"id": "comp", "kind": "component"}],
+                      edges=[], root_id="o")
+        rc, out, err = run(root)
+        expect("ORPHAN x" in out and "ORPHAN comp" in out,
+               f"empty-edge non-root nodes are presence orphans: {out}")
+        expect("UNREACHABLE" not in out,
+               f"reachability is additive — no double-report on presence orphans: {out}")
+        expect("Traceback" not in err, f"no crash on an empty-edge sidecar: {err}")
+    # (3) Self-loop on an on-path node → termination-safe, not spuriously flagged
+    # (the self-edge itself is the hard violation; reachability must not hang).
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_sidecar(root, nodes=[{"id": "o", "kind": "outcome"},
+                                   {"id": "a", "kind": "spec"},
+                                   {"id": "comp", "kind": "component"}],
+                      edges=[{"from": "o", "to": "a"}, {"from": "a", "to": "a"},
+                             {"from": "a", "to": "comp"}], root_id="o")
+        rc, out, err = run(root)
+        expect(rc == 1 and "self-referential" in err.lower(),
+               f"self-edge is the hard violation: {err}")
+        expect("Traceback" not in err and "RecursionError" not in err,
+               f"reachability terminates on a self-loop: {err}")
+        expect("UNREACHABLE a" not in out and "UNREACHABLE comp" not in out,
+               f"on-path nodes not spuriously flagged despite the self-loop: {out}")
+
+
+# --------------------------------------------------------------------------
 # Container-embedded + file-backed recognition (AC1, AC2)
 # --------------------------------------------------------------------------
 

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix, contract-acquisition skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "0.7.0"
+version = "0.7.1"
 description = "Core agent-ready-repo: work-loop, new-spec, bug-fix, contract-acquisition skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 readme = "README.md"
 display_name = "Core"

--- a/packs/product-engineering/.apm/skills/discovery-loop/SKILL.md
+++ b/packs/product-engineering/.apm/skills/discovery-loop/SKILL.md
@@ -303,13 +303,12 @@ with the round/cost counters reset. *(AC15.)*
   **until the header is in place the lint stays warn-only** (specs without the
   header are warnings, not failures). Producer-before-consumer: the header lands
   first, the `--strict` flip is sequenced after. *(AC37.)* **Child-4
-  dependency:** the backstop against a disconnected-subtree / fabricated-edge
-  failure relies on the lint's **root→leaf reachability** pass — named here so this
-  loop's backstop claim is not load-bearing on a weaker presence check. *(AC34.)*
-  *(Caveat — the currently-shipped lint is a per-node edge-**presence** check, not
-  full root→leaf reachability; until child-4 adds the reachability pass the
-  backstop catches the orphan **tip** of a broken subtree, not the whole subtree.
-  Flagged as a cross-spec gap.)*
+  dependency (MET):** the backstop against a disconnected-subtree failure relies on
+  the lint's **root→leaf reachability** pass — and the lint now performs it, so the
+  backstop catches the **whole** disconnected subtree, not just the orphan tip a
+  presence check flags. A fabricated cross-repo edge is *surfaced* informationally
+  (an open-world graph cannot tell a forged token from a not-yet-catalogued one),
+  never silently green. *(AC34.)*
 - **The backlog bridge:** the decision brief decomposes into an ordered,
   dependency-aware backlog (parked sub-ideas carried as **first-class entries**);
   `loop-cohort` orders it; `work-loop` pulls one item at a time. *(AC35.)*


### PR DESCRIPTION
## What & why

The shipped traceability lint flagged structural orphans by per-node edge **presence**, which catches only the orphan *tip* of a broken branch. RFC-0053's discovery-loop cascade backstop (**AC34**) and RFC-0048 § Amendments (2026-06-30) depend on **root→leaf reachability** to catch the *whole* disconnected subtree — the one cross-spec gap the discovery-loop build left open.

On the authoritative sidecar graph the lint now runs `reachability_sidecar`: a node is reachable iff **forward-reachable from `root`** AND able to **reach a clean terminus** (a `leaf_kind` node, or a rollup-resolved `satisfied-by-reference` endpoint). A node off every root→leaf path is a new **`UNREACHABLE`** finding — additive to and non-overlapping with the presence orphans (it catches the stranded *interior* a presence check passes; one break, one class — AC9). Verified against the real `0053-notes/spike/traceability.preconverge.json`: presence flags the 2 service tips, reachability adds the 3 stranded ancestors — the whole subtree the spike comment predicted.

### The control-integrity decision (caught at pre-EXECUTE review)
The sidecar is **untrusted input**. Treating an *unresolvable* cross-repo endpoint as a clean terminus would be **forgeable** — a fabricated `x/y` out-edge could false-green a stranded subtree. Resolution: **only rollup-resolved `satisfied-by-reference` terminates cleanly** (a legitimately federated graph is never failed); an *unresolvable* hop is surfaced as a distinct **informational** finding — never silently green, never `--strict`-promoted. Reachability therefore **closes the disconnected-subtree half** of the backstop and **surfaces (does not hard-catch) the fabricated-edge half** — an open-world graph cannot tell a forged token from a not-yet-catalogued one. Both reviewers (adversarial + security) raised this as a Blocker at spec stage; the AC and changelog state it honestly.

## How verified
- `test-lint-traceability.py` — **39 cases** pass (7 new: dead-end-subtree-whole-not-tip, floating-from-root, federated-resolved-terminus, unresolvable-tip-surfaced-never-green, rootless skip, degenerate cases, dangling-adjacent AC9). Real-subprocess against the documented CLI invocation.
- Exercised the **real CLI** against the preconverge spike fixture (whole subtree flagged; exit 0 default / exit 1 `--strict`).
- `lint-spec-status.py` clean for the touched specs; projections (`.claude/`, `.agents/`) byte-identical to source; `packages/agentbundle` pytest exit 0; reachability iterative (no recursion-limit DoS), degrades in isolation.
- **Reviews**: security-reviewer **Clean**; adversarial-reviewer — one Concern (AC9 double-report for a dangling-edge consumer) **fixed** with a regression test + spec wording aligned.

## Scope
Amends `docs/specs/traceability-lint`; flips `discovery-loop` AC34 to **MET** and updates the discovery-loop skill's traceability seam; tombstones the `discovery-loop-traceability-reachability` backlog item. **core 0.7.0 → 0.7.1** (additive refinement to a shipped lint, not auto-invoked anywhere).

## Risks / anything contentious
Reachability is **sidecar-mode only** — a standalone derived graph is legitimately partial and multi-root, so a strict root→leaf pass there would false-fail an ordinary partial chain. `resolve_sidecar_endpoints` now classifies a well-formed cross-repo sidecar endpoint as satisfied/unresolvable rather than dangling (aligning with the existing "never treat a well-formed cross-repo reference as dangling" boundary); a bare/malformed token still stays dangling (hard, every mode) — no existing test regresses.

**Deferred:** node-count line (`N node(s)`) now includes synthesized external termini — kept, consistent with standalone mode's long-standing behavior (cosmetic; adversarial Nit). Recorded in `docs/specs/traceability-lint/notes/reachability-review.md`.