### PR TITLE
docs(rfc): reconcile RFC-0049 + release-loop spec with RFC-0048 acceptance

### DIFF
--- a/docs/rfc/0049-the-release-loop-and-company-os.md
+++ b/docs/rfc/0049-the-release-loop-and-company-os.md
@@ -1,7 +1,7 @@
 # RFC-0049: The release loop — deployed e2e validation, the minimum-regret deploy carve, and the company-OS composition
 
 - **Status:** Open <!-- Draft | Open | Final Comment Period | Accepted | Rejected | Withdrawn | Experimental -->
-- **Provisional:** a **child of [RFC-0048](0048-autonomous-product-team-operating-model.md)**, which stays provisional until its children (this included) are modelled and drift-aligned. This RFC may amend 0048 (the gate arc, the company-OS framing) as it lands.
+- **Parent:** a **child of [RFC-0048](0048-autonomous-product-team-operating-model.md)** (**Accepted 2026-06-30**). RFC-0048's child-set reconciliation treated this RFC as *modelled* — the `release-lead` seat is specified by the drafted [release-loop spec](../specs/release-loop/spec.md) and recorded at RFC-0048 § Amendments (the 2026-06-26 SRE-seat entry + the 2026-06-28 reviewer-reuse scope) — so 0048 could accept on RFC-0053's blockers **without** waiting on this RFC's implementation. **This RFC itself remains Open** (the release-loop spec is Draft, unimplemented); it may still amend 0048 (the gate arc, the company-OS framing) as it lands.
 - **Author:** eugenelim
 - **Approver:** eugenelim
 - **Date opened:** 2026-06-25

--- a/docs/specs/release-loop/plan.md
+++ b/docs/specs/release-loop/plan.md
@@ -41,8 +41,8 @@ or the sidecar schema (RFC-0053) — both fenced off as Never-do / Ask-first.
 - **RFC-0049** (the parent): the inner/outer split (D1), the minimum-regret carve
   (D2), convergence by policy (D6), the company-OS composition (D5); and its OQ1
   (pack home) + OQ2 (agent shape), which this plan resolves.
-- **RFC-0048** (the provisional foundation): the G4→G5 arc, the sidecar substrate,
-  the company-OS framing; reconciled here as a tracked amendment (D9
+- **RFC-0048** (the foundation, Accepted 2026-06-30): the G4→G5 arc, the sidecar
+  substrate, the company-OS framing; reconciled here as a tracked amendment (D9
   series-execution standard).
 - **RFC-0053** (the sibling): the sidecar schema this loop consumes by convention (carried in `product-engineering`'s `discovery-loop` skill, not `core`), the
   `agent-def + skill + no-engine` pattern, and the § Security & integrity contract

--- a/docs/specs/release-loop/spec.md
+++ b/docs/specs/release-loop/spec.md
@@ -3,7 +3,7 @@
 - **Status:** Draft <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
-- **Constrained by:** RFC-0049 (the parent — the release (outer) loop + minimum-regret deploy carve + company-OS composition; resolves its OQ1 pack-home + OQ2 agent-shape) · RFC-0048 (the provisional foundation — the G4→G5 arc, the sidecar substrate, the company-OS framing) · RFC-0053 (the sibling — the sidecar *schema* this loop consumes by convention (carried in `product-engineering`'s `discovery-loop` skill, not `core`; RFC-0048 § Amendments 2026-06-26), and the `agent-def + skill + no-engine` pattern + § Security & integrity contract shape it mirrors downstream) · RFC-0041 + ADR-0031 (the *doctrine + reference-library + reuse-existing-reviewers, no engine / no new reviewer* precedent; the deploy *flavor* this graduates into a proper outer loop; P5's non-skippable security posture) · ADR-0018 (the orchestrator-inlined progressive-disclosure depth mechanism the reuse rides) · RFC-0025 (`work-loop` light/full + the iteration cap this loop's outer cap mirrors) · RFC-0040 (the three-tier layout resolution the sidecar paths obey)
+- **Constrained by:** RFC-0049 (the parent — the release (outer) loop + minimum-regret deploy carve + company-OS composition; resolves its OQ1 pack-home + OQ2 agent-shape) · RFC-0048 (the foundation, **Accepted 2026-06-30** — the G4→G5 arc, the sidecar substrate, the company-OS framing) · RFC-0053 (the sibling — the sidecar *schema* this loop consumes by convention (carried in `product-engineering`'s `discovery-loop` skill, not `core`; RFC-0048 § Amendments 2026-06-26), and the `agent-def + skill + no-engine` pattern + § Security & integrity contract shape it mirrors downstream) · RFC-0041 + ADR-0031 (the *doctrine + reference-library + reuse-existing-reviewers, no engine / no new reviewer* precedent; the deploy *flavor* this graduates into a proper outer loop; P5's non-skippable security posture) · ADR-0018 (the orchestrator-inlined progressive-disclosure depth mechanism the reuse rides) · RFC-0025 (`work-loop` light/full + the iteration cap this loop's outer cap mirrors) · RFC-0040 (the three-tier layout resolution the sidecar paths obey)
 - **Brief:** none
 - **Contract:** none — the loop *consumes* the sidecar schema by convention (RFC-0053: blackboard · open-questions · traceability · decision-log; the schema *definition* is carried in `product-engineering`'s `discovery-loop` skill, not `core`, and consumed by reading produced `_state/` instances + a `schema_version` stamp); it authors no new `contracts/<type>/` surface.
 - **Shape:** n/a — content/methodology change (a new `release-engineering` pack holding a `release-lead` agent definition + a `release-loop` skill); no application LLD. The "contract" is the loop's state machine + the minimum-regret carve + the security/integrity controls, specified below as Acceptance Criteria.
@@ -410,10 +410,13 @@ of change, and the worked-example validation RFC-0053's coordinator spike used.
   RFC-0049 (the parent) sanctions exactly this one pack via OQ1, so no further RFC
   is needed for the directory (source: AGENTS.md § Check before acting; RFC-0049
   OQ1).
-- Process: this spec resolves the OQs and reconciles drift back into RFC-0048/0049
-  in the same PR, per the series-execution standard — RFC-0049 stays Open until
-  its OQs resolve; RFC-0048 stays provisional until its child set aligns (source:
-  RFC-0048 D9 + Amendments section; RFC-0053's reconciliation precedent).
+- Process: this spec resolves RFC-0049's OQ1/OQ2 and reconciles drift back into
+  RFC-0048/0049 in the same PR, per the series-execution standard. **RFC-0048 is now
+  Accepted (2026-06-30)** — its child-set reconciliation already treats this seat as
+  *modelled* (§ Amendments 2026-06-26 / 2026-06-28), so 0048's acceptance did not wait
+  on this spec; **RFC-0049 stays Open** until this implementing PR lands (whether it
+  flips to Accepted then is the operator's call — AC11b) (source: RFC-0048 D9 +
+  Amendments section; RFC-0053's reconciliation precedent).
 - Product: the release loop ships as an **opt-in** capability for adopters who
   deploy to ephemeral envs — not a `core`-wide default — because ephemeral-env
   infra is a real adopter prerequisite (source: RFC-0049 Drawbacks; the


### PR DESCRIPTION
## What

RFC-0048 moved **Open → Accepted** on 2026-06-30 (gated only on RFC-0053's four blockers). Its child-set reconciliation treated **RFC-0049 as *modelled*** — the `release-lead` seat specified by the drafted release-loop spec, recorded at RFC-0048 § Amendments (2026-06-26 SRE-seat + 2026-06-28 reviewer-reuse scope) — so 0048 accepted **without waiting on RFC-0049's implementation**.

RFC-0049, its spec, and its plan still described 0048 as *"the provisional foundation"* / *"stays provisional until its child set aligns."* That is now stale.

## Fix

RFC-0049 is **Open**, so these are in-body corrections (per RFC-0055, not errata). Four spots:

- `docs/rfc/0049-…` line 4 — reframe the `**Provisional:**` bullet → `**Parent:**`: child of RFC-0048 (Accepted 2026-06-30); 0048 accepted treating this RFC as modelled, not waiting on it; this RFC itself **remains Open** (spec still Draft).
- `docs/specs/release-loop/spec.md` — Constrained-by line + the Assumptions process note.
- `docs/specs/release-loop/plan.md` — Constraints line.

## Deliberately not changed

- **Open/Draft statuses** stay as-is — flipping RFC-0049 → Accepted is implementation-time work, and the spec's AC11b makes that the operator's call.
- The `0049-notes/` "name provisional" lines — a different sense (a frozen design snapshot; names since resolved to `release-engineering` / `release-lead` / `release-loop`).

## Checked, already consistent (no change)

Doctrine-home (carve is `release-loop` skill doctrine, not a CONVENTIONS edit — matches 0048's 2026-06-29 amendment); the self-coverage seam (conforms to the now-Accepted RFC-0051); the spec's "§ Amendments 2026-06-28" citations (point to the real reviewer-reuse entry).

`lint-spec-status` is clean (`spec metadata clean`).