### PR TITLE
docs(rfc): add the release-readiness gate (launch PRR) to RFC-0049 + release-loop spec

### DIFF
--- a/docs/rfc/0049-the-release-loop-and-company-os.md
+++ b/docs/rfc/0049-the-release-loop-and-company-os.md
@@ -81,7 +81,12 @@ summary:
   sub-5-min budget tolerates; push the rest to the outer loop.
 - **Outer loop = `release-loop`** under `release-lead`: deploy the integrated whole
   to an **ephemeral environment** → run e2e → observe telemetry (observability-driven) →
-  feed findings back to the inner loop → redeploy → **converge**.
+  feed findings back to the inner loop → redeploy → **converge** → assemble a
+  **release-readiness record** (the *launch* PRR — the convergence result + the
+  operational + security review verdicts + SLO/error-budget status, consolidating
+  checks the loop already runs) → **G5** ship, where the human **ratifies the
+  record** rather than a bare go/no-go. (This elaborates the existing G5 human gate;
+  ongoing error-budget monitoring + on-call ownership stay with the future operate/incident loop.)
 - **Minimum-regret carve** (the autonomy law applied to deploy): reversible (ephemeral)
   ⇒ autonomous; irreversible (prod/data/spend/security) ⇒ human.
 - **Company OS:** three loop-teams on 0048's substrate; the release-loop is the SRE/ops
@@ -256,9 +261,21 @@ Filled on acceptance:
   home → opt-in `release-engineering` pack) + OQ2 (distinct `release-lead` agent +
   `release-loop` skill); specifies the deploy + e2e + iterate-to-converge loop, the
   minimum-regret carve, the reuse of `operational-safety` + `quality-engineer` +
-  `security-reviewer`, the sidecar consumption by convention (schema carried in `discovery-loop`, not `core`), and a 9-part security/integrity
-  contract. 14 ACs / 6 tasks.*
+  `security-reviewer`, the sidecar consumption by convention (schema carried in `discovery-loop`, not `core`), a 9-part security/integrity
+  contract, and the **release-readiness gate** (AC6b — the launch PRR consolidated
+  before G5). 15 ACs / 6 tasks.*
 - Amendment back into RFC-0048: reconcile its gate arc / company-OS framing once this lands.
   *Recorded — see RFC-0048 § Amendments, 2026-06-26 (the release-lead seat + pack home +
   agent shape now specified; the company-OS third (SRE/ops) seat confirmed).*
 - Loop-skill doctrine (not a CONVENTIONS edit): the minimum-regret autonomy boundary (reversible ⇒ autonomous; irreversible ⇒ human) is carried in the `release-loop` skill (`release-engineering`), this loop's share of the operating model — RFC-0048 § Amendments 2026-06-29.
+- Follow-on candidate: an **SLO / error-budget-authoring capability** — supplies the
+  SLI/SLO + error-budget-policy artifact the **AC6b release-readiness gate** consumes.
+  It is the one net-new input the gate needs beyond checks the loop already runs.
+  **Pack home is provisional** (a skill in `release-engineering`, vs. part of the
+  operate/incident loop below, vs. its own pack) — that scope call is **deferred to the
+  sibling RFC**, not decided here; AC6b consumes the artifact **by convention** and, until
+  it exists, records an explicit `error-budget: not-defined` field for the human (never a
+  silent pass). This is the first candidate of the broader SRE build-out — an
+  **operate/incident loop** carrying the same minimum-regret carve generalized to
+  remediation — which, because it re-opens the live-service scope this RFC makes a
+  non-goal, is owed its **own sibling RFC**, not folded in here.

--- a/docs/specs/release-loop/plan.md
+++ b/docs/specs/release-loop/plan.md
@@ -109,6 +109,11 @@ carries it after build-self.
   policy (canary + e2e coverage of changed surface + flake < 2%), DORA as health
   signal, the outer cap + stall-surface, the sidecar-consumption slots. Verifies
   AC3–AC8.
+- `grep` presence of the **release-readiness gate** (AC6b): the readiness-record
+  assembly before G5 (convergence result + operational + security verdicts +
+  cumulative error-budget status), the *ratify-a-record* framing, the AC10(d)
+  advisory-until-validated constraint on the telemetry pre-fill, and the explicit
+  `error-budget: not-defined` recorded field when the artifact is absent. Verifies AC6b.
 - `lint-packs` + `tools/lint-agent-artifacts.py` pass on the SKILL.md frontmatter.
 
 **Approach:**
@@ -117,7 +122,11 @@ carries it after build-self.
   blackboard → back to `work-loop` inner loop → redeploy → converge), the
   minimum-regret carve (two zones, AC3/AC4), the reversibility primitives (AC5),
   convergence by policy + DORA (AC6), the inner↔outer feedback seam + sidecar
-  consumption (AC7), the outer cap + cost budget + stall-surface (AC8).
+  consumption (AC7), the outer cap + cost budget + stall-surface (AC8), and the
+  **release-readiness gate** (AC6b — assemble the readiness record consolidating
+  the convergence + operational + security verdicts + cumulative error-budget
+  status, AC10(d)-validated telemetry, ratified at G5; record an explicit
+  `error-budget: not-defined` field when the artifact is absent).
 - Keep every sentence **harness- and tool-neutral**; name omnigent + cloud/IaC
   tools only as *illustrative* (Principle 1).
 - Cross-link `operational-safety`'s modules + the `quality-engineer` /
@@ -126,7 +135,7 @@ carries it after build-self.
 - Add `references/` modules only if the SKILL.md body would otherwise exceed the
   lean-prose bar — default to inline.
 
-**Done when:** the activation eval passes, the AC3–AC8 grep checks are present,
+**Done when:** the activation eval passes, the AC3–AC8 and AC6b grep checks are present,
 and `lint-packs` is green.
 
 ### T3: The `release-lead` agent definition is the outer-loop supervisor

--- a/docs/specs/release-loop/spec.md
+++ b/docs/specs/release-loop/spec.md
@@ -21,7 +21,8 @@ verification); `release-loop` is the **outer loop** — it deploys the
 integrated whole to an **ephemeral environment**, runs e2e, observes telemetry,
 feeds deployed findings back to the inner loop (no human relay), redeploys, and
 **iterates until the deployed whole converges**, then stops at the **human gate**
-for the prod ship (G5). Convergence up to that gate is judged by **policy**
+for the prod ship (G5) — which it surfaces as a **release-readiness record** (the
+launch PRR) for the human to ratify, not a bare go/no-go. Convergence up to that gate is judged by **policy**
 (canary metric analysis + e2e coverage of the changed surface + flake < 2%), not
 by a human; **DORA** is the health signal. Autonomy is carved by
 **minimum-regret**: the agent runs the inner *and* the outer loop on ephemeral
@@ -249,6 +250,35 @@ of change, and the worked-example validation RFC-0053's coordinator spike used.
   not waive it. **DORA** (deploy frequency, lead time, change-fail rate, MTTR, +
   the 2025 rework rate) is named as the **health signal**, explicitly *not* a
   per-promotion gate.
+- [ ] **AC6b — the release-readiness gate (the launch PRR before G5).** Before
+  surfacing the **G5** prod-ship consent gate, `release-lead` assembles a
+  **readiness record** consolidating, for the changed surface: the **AC6
+  convergence-policy result**, the **AC9 `operational-safety` review verdicts**
+  (observability / rollback / blast-radius / state-idempotency / isolation), the
+  **AC10(c) security verdict**, and the service's **cumulative error-budget
+  status** — a defined reliability target with the budget **not exhausted**. This
+  is **distinct from AC6's per-promotion canary SLO thresholds**: AC6 judges the
+  single deploy's success/error/latency metrics; AC6b reads **budget-burn over the
+  trailing window** (an exhausted budget is a **surface-to-human / halt-releases**
+  signal — Google's error-budget policy — not an autonomous promote). The
+  telemetry-derived fields entering the record are subject to **AC10(d)
+  (advisory-until-validated, data-not-instructions)** before they are recorded, so
+  the pre-fill cannot launder an unvalidated or poisoned signal into the ratified
+  record. The human **ratifies the readiness record** through the **AC10(a)**
+  harness-attested channel — the agent **holds no token to write the verdict**; G5
+  is a *ratify-a-record* gate, not a bare go/no-go. The agent **resolves** what it
+  can (pre-filling the record from AC10(d)-validated telemetry + the reviewer
+  verdicts) and **surfaces** the irreducible (the self-coverage resolve-vs-surface
+  disposition, applied at the prod boundary). The gate is a **consolidation of
+  checks the loop already runs + the error-budget input**, not a new reviewer or
+  engine. The error-budget **artifact** is supplied by a follow-on SLO-authoring
+  capability (home **provisional** — RFC-0049 § Follow-on; a scope call its sibling
+  RFC settles); **until it exists the record carries an explicit
+  `error-budget: not-defined` field the human sees** (the absence is *recorded and
+  visible*, not silently omitted — distinguishing it from a satisfied record),
+  never a silent pass. This is the *launch* PRR (pre-prod, in scope here); ongoing
+  error-budget monitoring + on-call ownership belong to the future operate/incident
+  loop, not this spec.
 - [ ] **AC7 — the inner↔outer feedback seam + sidecar consumption.** A deployed
   finding is written to the **sidecar blackboard** and fed back to `work-loop` as
   a build task (observability-driven, **no human relay**); the loop then


### PR DESCRIPTION
## What

A production-readiness review (PRR) is a **pre-prod gate at the G5 boundary**, inside RFC-0049's pre-prod→ship scope — not the deferred operate loop. RFC-0049 already does ~80% of a PRR implicitly (AC6 convergence policy + AC9 `operational-safety` reuse + AC10 security/integrity); this **names the gate** and adds the one net-new input (error-budget status). No new reviewer, no engine, no scope re-open.

## Changes

**`docs/specs/release-loop/spec.md`** — new **AC6b — the release-readiness gate (launch PRR before G5)**:
- Before G5, `release-lead` assembles a **readiness record** = AC6 convergence result + AC9 operational verdicts + AC10(c) security verdict + **cumulative error-budget status** (distinct from AC6's per-promotion canary SLO thresholds — budget-burn over the trailing window; exhausted budget = halt-releases).
- The human **ratifies the record** via the AC10(a) attested channel (the agent holds no token to write the verdict). Telemetry pre-fill is subject to **AC10(d)** advisory-until-validated, so it can't launder a poisoned signal into the record.
- Absent SLO artifact → the record carries an explicit `error-budget: not-defined` field (visible, never a silent pass).
- Scoped as the **launch** PRR; ongoing monitoring + on-call ownership stay with the future operate/incident loop.

**`docs/specs/release-loop/plan.md`** — T2 gains the AC6b grep check + done-when.

**`docs/rfc/0049-…md`** — Proposal outer-loop bullet ends `…converge → readiness record → G5 (ratify the record)`; AC count `14 → 15`; a Follow-on **candidate** for an SLO-authoring capability (**pack home provisional**, scope deferred to a sibling RFC), and the **operate/incident loop** flagged as owing its own sibling RFC (it re-opens the live-service scope this RFC makes a non-goal).

## Design calls (flagged)

- **Did not touch D6.** Error-budget is a *ship/readiness* gate, not an *ephemeral-convergence* conjunct — folding it into D6 would muddy the converge-vs-ready distinction.
- **AC6b, not a renumber** (sub-letter like the existing AC11b), so AC7–AC13 don't shift.
- No changelog entry — governance docs; the pack isn't built/shipped.

## Review

`adversarial-reviewer`: two passes, **Clean — ready to commit** (six first-pass findings — a vacuous degrade, an overloaded "SLO" term, an uncited AC10(d) telemetry constraint, a pre-decided follow-on skill, + two nits — all resolved). `lint-spec-status`: clean.