### PR TITLE
chore(skills): make shipped skill content self-contained

### DIFF
--- a/.agents/skills/contract-acquisition/SKILL.md
+++ b/.agents/skills/contract-acquisition/SKILL.md
@@ -58,7 +58,7 @@ This skill is **user- and agent-invoked** (it has an activation surface, unlike
 the reviewer-internal depth libraries). It fires when the agent is about to
 author against a contract it doesn't already hold — at `work-loop`'s
 **EXECUTE contract-grounding gate**, which routes **two surfaces** here (one
-gate, one skill — ADR-0037 D1):
+gate, one skill):
 
 - **Infra** — before generating a CLI invocation, an IaC resource, or
   application code that runs on a managed runtime (a function handler whose

--- a/.agents/skills/new-rfc/SKILL.md
+++ b/.agents/skills/new-rfc/SKILL.md
@@ -190,7 +190,7 @@ push back: a normal PR (or a spec, if it's a feature) is enough.
    the first time it appears in the body — **inline, in a few words, not in a
    separate glossary section**. Don't lean on vocabulary inherited from related
    RFCs as if the reader already holds it: a reviewer arrives at the RFC from the
-   index, cold. (RFC-0053 is the cautionary case — it had to be hand-patched with
+   index, cold. (The cautionary case: an RFC that has to be hand-patched with
    inline glosses *after* drafting because the draft assumed its siblings' terms;
    the cold-reader check in the gate, step 6, exists to catch this before
    handoff.)
@@ -342,8 +342,8 @@ present rules without diffing the whole log by hand:
   the section so a reader knows which layer to trust.
 - The layer *names* above are illustrative; the contract is the two-layer split
   (authoritative current state over a dated audit trail), not the exact heading
-  wording. RFC-0048 / PR #430 is the worked precedent this generalizes — it uses
-  "Current reconciliation state" over an "Amendment history / audit trail."
+  wording. One worked precedent uses "Current reconciliation state" over an
+  "Amendment history / audit trail."
 
 ### Append-only and supersession
 
@@ -358,8 +358,8 @@ present rules without diffing the whole log by hand:
   in-flight Amendments** (a Frozen RFC's entries can't be touched).
 - **Whole-RFC replacement is out of scope.** When an entire RFC — not one
   correction within it — is superseded by a later one, record that as an
-  **Errata entry naming the superseding RFC** (e.g. RFC-0012 carries an erratum
-  recording that its Alternative #7 was superseded by RFC-0052). This convention
+  **Errata entry naming the superseding RFC** (e.g. an RFC carries an erratum
+  recording that its Alternative #7 was superseded by a later RFC). This convention
   governs corrections *within* an RFC; it neither defines nor changes the
   whole-RFC-supersession mechanism.
 

--- a/.agents/skills/operational-safety/SKILL.md
+++ b/.agents/skills/operational-safety/SKILL.md
@@ -16,7 +16,7 @@ below), so the agent prompt stays lean and the depth scales without bloat. It
 is the operational-lens twin of
 [`security-checklists`](../security-checklists/SKILL.md), built on the same
 orchestrator-loaded, table-routed mechanism — **no new reviewer** (the CHARTER
-three-reviewer ceiling; ADR-0023), no executable code (ADR-0031).
+three-reviewer ceiling), no executable code.
 
 ## How it loads (orchestrator-driven, not self-discovered)
 
@@ -47,13 +47,13 @@ flat march through every module. Where an
 adapter *does* support subagent skill auto-discovery, that is a redundant
 convenience layered on top — never the load-bearing mechanism.
 
-**The EXECUTE-consumer extension (`cloud-implementation-craft`).** ADR-0031
-established this library as a REVIEW-only depth source for `quality-engineer`.
+**The EXECUTE-consumer extension (`cloud-implementation-craft`).** This library
+is, by default, a REVIEW-only depth source for `quality-engineer`.
 One module — `cloud-implementation-craft` — is **also** inlined into the
 **implementer's EXECUTE brief** on infra-flavored work, by the same
 orchestrator on the same Module index, so its golden practices
 (least-privilege-but-sufficient permissions, timing/retry, packaging,
-externalized config) shape the build, not only the review (ADR-0034). The
+externalized config) shape the build, not only the review. The
 mechanism is unchanged — the orchestrator inlines; the subagent does not
 self-discover — only the *consumer* is extended from the reviewer to the
 implementer. `quality-engineer` still loads it at REVIEW to check the craft
@@ -107,8 +107,8 @@ This index is the **deterministic failure-mode→module routing authority** — 
 `work-loop` REVIEW `quality-engineer` bullet (and, for `cloud-implementation-craft`,
 the EXECUTE implementer brief) dispatches against the **Load when** column rather
 than carrying its own copy. Match the operational failure mode the infra/destructive
-change raises to its module(s). The `> **Grounded in:**` cells pin each module to
-its RFC-0041 module-table groundings.
+change raises to its module(s). The **Grounded in** column pins each module to
+the operational failure modes it covers.
 
 | Module | Load when — the operational failure mode the change raises | Grounded in |
 |---|---|---|
@@ -118,7 +118,7 @@ its RFC-0041 module-table groundings.
 | [`cost-and-teardown`](references/cost-and-teardown.md) | provisions billable resources; ephemeral/per-iteration infra; teardown path — covers cost-ceiling-as-gate, destroy-on-fail, TTL, no orphans | F3.4, F3.5 |
 | [`drift-and-rollback`](references/drift-and-rollback.md) | long-lived infra that can drift; a deploy needing a defined recovery path — covers read-only drift detection, known-good re-apply path | F1.4, F2.6 |
 | [`observability-and-smoke`](references/observability-and-smoke.md) | deploys a service / site / endpoint a user reaches; needs smoke + telemetry — covers active end-to-end probe, log access, health, verify-status, symptom→layer log playbook | F2.2; taxonomy follow-up |
-| [`cloud-implementation-craft`](references/cloud-implementation-craft.md) | authoring infra / a managed-runtime deployment / live interaction (**also inlined into the implementer's EXECUTE brief**) — **EXECUTE-craft**: least-privilege-but-sufficient permissions, timing/retry, packaging / entrypoint model, externalized config (also REVIEW) | RFC-0044 Author·behavioral + packaging gap |
+| [`cloud-implementation-craft`](references/cloud-implementation-craft.md) | authoring infra / a managed-runtime deployment / live interaction (**also inlined into the implementer's EXECUTE brief**) — **EXECUTE-craft**: least-privilege-but-sufficient permissions, timing/retry, packaging / entrypoint model, externalized config (also REVIEW) | Author·behavioral + packaging gap |
 
 `state-and-idempotency` (write-path convergence) and `drift-and-rollback`
 (divergence detection + recovery) are kept **deliberately separate** — every

--- a/.agents/skills/operational-safety/references/cloud-implementation-craft.md
+++ b/.agents/skills/operational-safety/references/cloud-implementation-craft.md
@@ -7,7 +7,7 @@
 > reviewer's REVIEW brief), the deliberate EXECUTE-consumer extension of the
 > depth-library pattern. `quality-engineer` also loads it at REVIEW to check the
 > craft against deployed reality.
-> **Grounded in:** RFC-0044's field report — the **Author · behavioral** family
+> **Grounded in:** a production field report — the **Author · behavioral** family
 > (permissions iterated reactively, undesigned propagation waits, escalating
 > timeouts and sprinkled `sleep`s, no client cold-start tolerance, dependency
 > cycles fixed by trial) and the **packaging gap** from Author · structural (a

--- a/.agents/skills/receive-brief/scripts/lint-brief-coverage.py
+++ b/.agents/skills/receive-brief/scripts/lint-brief-coverage.py
@@ -241,6 +241,8 @@ def _repo_root() -> Path:
         if r.returncode == 0 and r.stdout.strip():
             return Path(r.stdout.strip())
     except FileNotFoundError:
+        # `git` may be unavailable on PATH; fall through to the
+        # script-relative root, which is the intended fallback.
         pass
     return Path(__file__).resolve().parent.parent
 

--- a/.agents/skills/work-loop/SKILL.md
+++ b/.agents/skills/work-loop/SKILL.md
@@ -70,8 +70,8 @@ are net-new. In order:
    referent that genuinely failed). The
    [resolve-vs-surface reference](references/self-coverage/resolve-vs-surface.md)
    calibrates the call.
-4. **Fresh-context-adversarial review** — *existing (REVIEW):* reviewers selected per
-   ADR-0042 from the work-type-keyed roster.
+4. **Fresh-context-adversarial review** — *existing (REVIEW):* reviewers selected
+   from the work-type-keyed roster.
 5. **Resolve-vs-surface routing** — *existing (DECIDE):* `Surface` + apply/defer.
 6. **Done-checklist refusal** — *net-new (DECIDE):* don't declare done until the
    disposition record exists and every fresh-context finding is resolved.
@@ -358,8 +358,8 @@ Match the discipline to the verification mode you picked during PLAN:
 Before generating code against a contract you do not already hold, acquire it
 via the [`contract-acquisition`](../contract-acquisition/SKILL.md)
 skill — never guess a flag, schema shape, field constraint, signature, or
-packaging assumption. **Two surfaces, one gate and one skill** (ADR-0037 D1 —
-extend the one gate, never fork a parallel skill): **(1) infra** — a CLI
+packaging assumption. **Two surfaces, one gate and one skill** (extend the one
+gate, never fork a parallel skill): **(1) infra** — a CLI
 invocation, an IaC resource, or application code on a managed runtime, against an
 unfamiliar platform; **(2) software** — code against an **unfamiliar internal
 framework or third-party library** whose contract (a versioned signature, a
@@ -372,8 +372,7 @@ behavioral contract; the gate now also covers the software case it was
 abstracted from, not infra alone. It is **universal** (fires in light mode too;
 heavier infra-flavor layers fire only on the infra-flavored signal), and is for
 the *unfamiliar-contract* case — **not** every import, not familiar code whose
-contract the agent already holds. (RFC-0044 § Errata 2026-06-24; RFC-0047
-Decisions 1–2 / ADR-0037 D1; detail in
+contract the agent already holds. (Detail in
 [`references/infra-verification.md`](references/infra-verification.md).)
 
 For each task, implement the smallest coherent unit of work toward the
@@ -630,7 +629,7 @@ note in the summary, not a blocker.
   failure modes raised, load **only** the matching modules, and inline them into
   the subagent's brief (orchestrator-driven — its `tools:` has no Skill tool, so
   loading is not model-relevance-judged). **No new reviewer** — feeds the existing
-  `quality-engineer` (ADR-0023). Route deterministically via
+  `quality-engineer`. Route deterministically via
   [`operational-safety`' **Module index**](../operational-safety/SKILL.md#module-index)
   — the failure-mode→module mapping is the routing authority and lives there,
   beside the depth it routes to.
@@ -643,7 +642,7 @@ note in the summary, not a blocker.
   `operational-safety` (this pass). The two passes are complementary lenses on
   the same infra diff, not substitutes.
 
-  **Independent contract re-derivation (Delivery — no new agent, ADR-0023).**
+  **Independent contract re-derivation (Delivery — no new agent).**
   When a diff was authored against a contract grounded at the EXECUTE gate, the
   orchestrator inlines
   [`contract-acquisition`](../contract-acquisition/SKILL.md) into the

--- a/.agents/skills/work-loop/references/infra-verification.md
+++ b/.agents/skills/work-loop/references/infra-verification.md
@@ -60,7 +60,7 @@ generating the resource?*; V1 owns *is a green early oracle being mistaken for
 "works" at verify?*** — the same oracle output, two different jobs
 (ground-before-authoring vs. don't-mistake-cheap-for-done).
 
-### Readiness-aware data-plane probe (V2 — refines layer 4 / RFC-0041 P2)
+### Readiness-aware data-plane probe (V2 — refines layer 4)
 
 The active end-to-end smoke (layer 4) has a specific shape, distinct from app
 verification: **in-network if private** (probe from *inside* the network
@@ -137,7 +137,7 @@ the loop requires "tests exist" without mandating a framework. The loop names
 these as prerequisite tasks and offers to scaffold them; it does not ship them
 as executable tooling.
 
-## EXECUTE — drive the deploy yourself (RFC-0041 P4)
+## EXECUTE — drive the deploy yourself
 
 Implement the change (one task may span several GATES layers), then **drive the
 deploy yourself and read the real environment output**: run the apply, the smoke
@@ -182,7 +182,7 @@ fires in light mode too; the heavier infra-flavor layers (the
 `cloud-implementation-craft` craft load at EXECUTE, the V2 data-plane probe, the
 `quality-engineer` infra wiring) fire only on the **infra-flavored signal** (the
 destructive/irreversible trigger + the `security-checklists` Module index's IaC /
-deploy-config entry). (RFC-0044 § Errata 2026-06-24.)
+deploy-config entry).
 
 ## EXECUTE — `cloud-implementation-craft` loaded into the implementer's brief
 
@@ -196,14 +196,14 @@ packaging / entrypoint-import model, and externalized script configuration —
 into the **implementer's EXECUTE brief**, via the
 [`operational-safety` Module index](../../operational-safety/SKILL.md#module-index)
 (the routing authority). This is the **deliberate EXECUTE-consumer extension** of
-`operational-safety`: ADR-0031 established it as a REVIEW-only depth library for
+`operational-safety`: by default a REVIEW-only depth library for
 `quality-engineer`; here the **same module, on the same routing mechanism**, is
 pointed at the implementer so the craft shapes the build, not only the review.
 Loading is **orchestrator-driven** (the subagent's `tools:` carries no Skill
 tool), never subagent self-discovery — exactly as the REVIEW-side
 `operational-safety` and `security-checklists` inlining works.
 
-## EXECUTE — reusable-script corollary (sharpens RFC-0041 P4, not a new failure family)
+## EXECUTE — reusable-script corollary (a discipline sharpening, not a new failure family)
 
 **Every** live-environment interaction — deploy, smoke probe, **log pull, debug
 step** — goes through a **reusable, idempotent, credential-reusing script** that
@@ -217,8 +217,8 @@ inline**. That lets the harness **honour an organization's naming + tagging
 conventions** without editing script bodies, and **port across accounts to stand
 up like-for-like environments** — the property V2's ephemeral, uniquely-named
 probe target and `environment-isolation`'s per-PR ephemeral harness both rest
-on. This is a **discipline sharpening agent-drives-verification (RFC-0041 P4)**,
-not a new failure family. (RFC-0044 § Errata 2026-06-24.)
+on. This is a **discipline sharpening agent-drives-verification**,
+not a new failure family.
 
 ## REVIEW — mandatory, multi-module security on infra-flavored work
 
@@ -277,12 +277,12 @@ oracle (or reads the curated skill / versioned docs) itself, never trusting the
 implementer's citation; this fires on any software-contract-citing diff, not
 only an infra-flavored one, so the broadened EXECUTE software surface ships with
 its matching REVIEW half. This adds **no new reviewer or agent** (the
-three-reviewer ceiling, ADR-0023): contract-conformance rides the **existing**
+three-reviewer ceiling): contract-conformance rides the **existing**
 `quality-engineer`, already the infra reviewer in spirit. The
 **auth-flow-contradiction class** (a spec whose auth design contradicts itself)
 is caught **earlier, at spec stage, by `design-reviewer`** where the architect
 pack is installed — otherwise it falls to the spec-stage adversarial pass. A
 **dedicated `infra-contract-reviewer` is deferred** behind a named evidence
-trigger (RFC-0044 Decision 8 — a spike showing oracle-execution traffic, large
-`plan` / `synth` output, measurably degrades `quality-engineer`'s other lenses);
+trigger (a spike showing oracle-execution traffic — large
+`plan` / `synth` output — measurably degrades `quality-engineer`'s other lenses);
 fetching the contract in *slices* softens the isolation case meanwhile.

--- a/.agents/skills/work-loop/references/self-coverage/resolve-vs-surface.md
+++ b/.agents/skills/work-loop/references/self-coverage/resolve-vs-surface.md
@@ -4,8 +4,7 @@ The calibration reference for the
 [self-coverage gate](../../SKILL.md#the-self-coverage-gate)'s disposition record. The
 loop reaches the right resolve-vs-surface call only about half the time without a
 scaffold; an explicit rubric plus calibrated examples climbs that rate. This is
-`work-loop`'s own per-loop copy, seeded from the RFC-0048-series reads in
-`docs/rfc/0048-notes/09-gap-resolutions.md`.
+`work-loop`'s own per-loop copy of the calibration examples.
 
 ## The rubric
 
@@ -40,7 +39,7 @@ and the **tell** — the cue that should have fired.
 
 ## Examples
 
-*(Seeded from the RFC-0048-series reads, note 09. Non-exhaustive by design.)*
+*(Non-exhaustive by design.)*
 
 - "How is the backlog handled?" → **resolve** (referent: how product teams work).
   *Tell: should not have waited to be asked.*
@@ -80,7 +79,8 @@ and the **tell** — the cue that should have fired.
   exists to catch.*
 - *A contradiction between two of your own clauses is resolve-with-referent, not
   surface.* The spec said both "this PR seeds the reference" and "appends continue in
-  note 09 until accepted." → **resolve** (referent: the per-loop copy is a *distinct*
-  file from the series reads — this PR creates the former, the rule governs the latter).
+  the upstream source until accepted." → **resolve** (referent: the per-loop copy is a
+  *distinct* file from the upstream source — this PR creates the former, the rule
+  governs the latter).
   *Tell: when two clauses collide, check whether they name the same object before
   treating it as an open question.*

--- a/.agents/skills/work-loop/scripts/lint-spec-status.py
+++ b/.agents/skills/work-loop/scripts/lint-spec-status.py
@@ -268,6 +268,8 @@ def _repo_root() -> Path:
         if r.returncode == 0 and r.stdout.strip():
             return Path(r.stdout.strip())
     except FileNotFoundError:
+        # `git` may be unavailable on PATH; fall through to the
+        # script-relative root, which is the intended fallback.
         pass
     return Path(__file__).resolve().parent.parent
 

--- a/.agents/skills/work-loop/scripts/lint-traceability.py
+++ b/.agents/skills/work-loop/scripts/lint-traceability.py
@@ -23,13 +23,13 @@ content, not a separate node.
 
 **Structure only.** Whether a node is parented to the *right* outcome (semantic
 scope-creep) is never this lint's call — structural presence is mechanizable,
-semantic correctness is not (the established traceability split; RFC-0048
-Decision 6, deferred to the coordinator spike O10, a human call at G1.5).
+semantic correctness is not (the established traceability split — semantic
+scope-creep is a human call at G1.5, never this lint's).
 
 **The chain spans repos, because the loops do.** `work-loop` builds per module
 (one repo, or one `packages/<c>/`); `discovery-loop` and the release loop work
 within or across modules, so the upstream discovery artifacts and shared
-contracts commonly live in a discovery / value-stream meta-repo (ADR-0022). A
+contracts commonly live in a discovery / value-stream meta-repo. A
 single working tree therefore sees only part of the chain. The crossing is
 handled by **convention, not path**: every node carries a stable,
 location-independent id (a marker slug, a `contract@version`, a Backstage
@@ -41,7 +41,7 @@ open-world federated-catalog posture — never fatal, never silently satisfied).
 
 Two sources, one classifier:
   - When a recognized sidecar `traceability.json` (a `schema_version`-stamped
-    `_state/` instance, RFC-0053 D7) is present it supplies the authoritative
+    `_state/` instance) is present it supplies the authoritative
     edge set. The schema *definition* is carried in `product-engineering`'s
     `discovery-loop` skill — this lint reads the produced instance by
     convention + the stamp, it never imports the definition.
@@ -54,8 +54,8 @@ On the authoritative sidecar graph the lint also runs a **root→leaf reachabili
 pass (`reachability_sidecar`): a node is reachable iff it is forward-reachable from
 `root` AND can reach a clean terminus (a `leaf_kind` node or a rollup-resolved
 `satisfied-by-reference` endpoint). A node off every root→leaf path is `UNREACHABLE`
-(the disconnected-subtree finding the discovery-loop cascade backstop depends on,
-RFC-0053 AC34) — additive to, and non-overlapping with, the presence orphans. An
+(the disconnected-subtree finding the discovery-loop cascade backstop depends
+on) — additive to, and non-overlapping with, the presence orphans. An
 *unresolvable* cross-repo hop is **not** a clean terminus (the sidecar is untrusted
 input — a forged out-edge must not silently green a stranded subtree); a node whose
 only escape is such a hop is surfaced informationally, never fatal. Reachability is
@@ -69,7 +69,7 @@ Exit codes:
   1 = a hard violation — a dangling edge (a pointer to a missing local target,
       or malformed) or a cycle, **in every mode**; or, under `--strict`, any
       structural orphan or `UNREACHABLE` node (the convergence-/CI-gate enforcing
-      "traceability closed", RFC-0048 O6). `--strict` degrades gracefully where the
+      "traceability closed"). `--strict` degrades gracefully where the
       producer `Discovery:` headers / `type:` markers are absent (a separate
       CONVENTIONS follow-on lands those).
 
@@ -93,11 +93,11 @@ try:  # py311+ stdlib; degrade where a layout config exists but tomllib doesn't.
 except ModuleNotFoundError:  # pragma: no cover - py<3.11
     tomllib = None  # type: ignore[assignment]
 
-# The canonical nine-node chain, in order (RFC-0048 note 08). Index = layer
+# The canonical nine-node chain, in order. Index = layer
 # depth; used for adjacency, terminal exemption, and the globally-unpopulated
 # layer-skip. `outcome` is the root (never a backward orphan); `component` is
 # the leaf (never a forward orphan — its cross-repo consumer is the release
-# loop, RFC-0049).
+# loop).
 CHAIN = (
     "outcome", "opportunity", "capability", "screen", "action",
     "service", "contract", "spec", "component",
@@ -122,7 +122,7 @@ KNOWN_SCHEMA_VERSIONS = frozenset({"0.1"})
 # marker); no discovery logic elsewhere may name a path literal (the no-
 # hardcoded-path NFR, AC1/AC2; the self-test greps this block's exclusivity).
 # Each layer: realization, default base (path segments under the root), and the
-# layout-config key (RFC-0040 `agentbundle-layout.toml`, tier 1).
+# layout-config key (`agentbundle-layout.toml`, tier 1).
 #
 # realization ∈ {file, container, ladder} — mirrors the sidecar's `backed_by`.
 _DEFAULT_BASES = {
@@ -205,7 +205,7 @@ def _token(raw: str) -> str:
 
 
 # --------------------------------------------------------------------------
-# Layer 0 — three-tier base resolution (RFC-0040)
+# Layer 0 — three-tier base resolution
 # --------------------------------------------------------------------------
 
 def load_layout(root: Path) -> dict:
@@ -471,7 +471,7 @@ def recognize_contracts(base: Path, root: Path, g: Graph) -> None:
 
 def recognize_ladder(base: Path, root: Path, g: Graph) -> dict[str, Path]:
     """Container/ladder `outcome`/`opportunity`/`capability` nodes from the
-    intent ladder `<intents-base>/*.md`. Per RFC-0048 note 04 the ladder tags
+    intent ladder `<intents-base>/*.md`. The ladder tags
     `outcome`/`opportunity` *kinds* across `vision`/`strategy`/`capability`/
     `feature` *levels*, so `capability` is a level while the other two are
     kinds. The extractor maps `**Kind:** outcome|opportunity` → that chain node,
@@ -533,7 +533,7 @@ def load_rollup_ids(root: Path, layout: dict) -> dict[str, bool]:
     The rollup row schema is
     `| Component | Brief (repo+slug) | Contract@version | Status | Coverage |`;
     a `<contract>@<version>` cell is a pinned reference, a bare id is unpinned.
-    Reused verbatim — never a parallel mechanism (ADR-0022)."""
+    Reused verbatim — never a parallel mechanism."""
     refs: dict[str, bool] = {}
     base, _ = _anchor_base(root, layout, "rollups", _ROLLUPS_BASE)
     if base is None:
@@ -767,7 +767,7 @@ def classify_standalone(g: Graph, briefs_present: bool) -> list[tuple[str, str, 
 
 def classify_sidecar(g: Graph) -> list[tuple[str, str, str]]:
     """Orphan classification for the authoritative sidecar graph — the
-    `check_sidecar` rule (RFC-0053 spike): `root` is exempt from an in-edge,
+    `check_sidecar` rule: `root` is exempt from an in-edge,
     `leaf_kind` from an out-edge, everything else needs both. The sidecar's
     edges already encode any layer-skip explicitly, so no populated-layer
     inference is applied. A **reference (external) endpoint** registered by
@@ -1226,6 +1226,9 @@ def _repo_root() -> Path:
         if r.returncode == 0 and r.stdout.strip():
             return Path(r.stdout.strip())
     except (FileNotFoundError, OSError):
+        # `git` may be unavailable on PATH (or the subprocess otherwise
+        # fails); fall through to the script-relative root, which is the
+        # intended fallback.
         pass
     return Path(__file__).resolve().parent.parent
 

--- a/.agents/skills/work-loop/scripts/loop-cohort.py
+++ b/.agents/skills/work-loop/scripts/loop-cohort.py
@@ -44,7 +44,6 @@ import hashlib
 import json
 import os
 import re
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -124,6 +123,9 @@ def write_state_atomic(spec_dir: Path, state: dict) -> None:
         try:
             os.unlink(tmp)
         except OSError:
+            # Best-effort cleanup of the temp file: if the original write or
+            # os.replace failed, a failed unlink here must not mask that
+            # original failure, which we re-raise below.
             pass
         raise
 

--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -38,7 +38,7 @@ In this order:
    model, externalized script config) as prompt text — that is your craft
    reference for this change. You do **not** load the skill yourself; if it was
    not inlined, fall back to your own judgment and say so. This is the
-   EXECUTE-consumer extension of `operational-safety` (ADR-0034); review of the
+   EXECUTE-consumer extension of `operational-safety`; review of the
    same craft still rides `quality-engineer`, no new reviewer is added.
 
 If the supervisor's brief omits the spec/plan paths, ask — don't guess.

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -18,14 +18,18 @@ tool, used often enough to stick — live in
 | Skill | What it does |
 | ----- | ------------ |
 | [`work-loop`](work-loop/SKILL.md) | The standard plan → execute → verify → review loop for non-trivial work. Start here for any feature, fix, or refactor. |
-| [`new-adr`](new-adr/SKILL.md) | Create a new ADR with the next available number, from the template |
-| [`new-rfc`](new-rfc/SKILL.md) | Open a new RFC with a research-phase gate (repo + external sweep, recommendations on unresolved questions) before drafting |
 | [`new-spec`](new-spec/SKILL.md) | Scaffold a new spec directory, surface assumptions, then fill `spec.md` and `plan.md` |
 | [`bug-fix`](bug-fix/SKILL.md) | Fix a defect — reproduce → failing test → root cause → minimum fix → root-vs-symptom verify → commit body documents *why* |
-| [`new-package`](new-package/SKILL.md) | Scaffold a new package in `packages/` |
+| [`new-adr`](new-adr/SKILL.md) | Create a new ADR with the next available number, from the template |
+| [`new-rfc`](new-rfc/SKILL.md) | Open a new RFC with a research-phase gate (repo + external sweep, recommendations on unresolved questions) before drafting |
 | [`update-conventions`](update-conventions/SKILL.md) | Open an RFC to change `docs/CONVENTIONS.md` |
+| [`new-guide`](new-guide/SKILL.md) | Draft a new user-facing guide under `docs/guides/<quadrant>/` following the Diátaxis framework |
+| [`init-project`](init-project/SKILL.md) | Turn an idea into a structured new repo — trigger/value gates, a foundation ADR plus a golden-path `reference.md`, a walking-skeleton spec, then hand off to the build loop |
+| [`receive-brief`](receive-brief/SKILL.md) | Turn an externally-authored multi-feature brief (PRD, handoff) into shippable specs — elicit the load-bearing fields, decompose by shippability, run each slice through `new-spec` then `work-loop` |
 | [`adapt-to-project`](adapt-to-project/SKILL.md) | Walk the adopter through the four classes of post-install change (substitution, `.upstream` companion merges, discovery + restructuring, within-layout consolidation). Per-scope; class-1 shells out to `agentbundle adapt` |
-| [`new-guide`](new-guide/SKILL.md) | *(stub — full body in a follow-on PR)* Draft a new user-facing guide under `docs/guides/<quadrant>/` following the Diátaxis framework |
+| [`contract-acquisition`](contract-acquisition/SKILL.md) | Acquire an unfamiliar contract (a CLI flag, a schema shape, a library signature) before generating code against it, via the tiered version → type-checker → curated-skill → versioned-docs → runtime-probe protocol |
+| [`security-checklists`](security-checklists/SKILL.md) | Boundary-keyed security-depth modules the `security-reviewer` reasons from; the orchestrator inlines only the modules a change's boundaries match (not a reviewer prompt itself) |
+| [`operational-safety`](operational-safety/SKILL.md) | Orchestrator-loaded reliability/ops depth library for infra review (and the `cloud-implementation-craft` EXECUTE module) — feeds the existing `quality-engineer`, no new reviewer |
 
 ## Authoring skills
 

--- a/.claude/skills/contract-acquisition/SKILL.md
+++ b/.claude/skills/contract-acquisition/SKILL.md
@@ -58,7 +58,7 @@ This skill is **user- and agent-invoked** (it has an activation surface, unlike
 the reviewer-internal depth libraries). It fires when the agent is about to
 author against a contract it doesn't already hold — at `work-loop`'s
 **EXECUTE contract-grounding gate**, which routes **two surfaces** here (one
-gate, one skill — ADR-0037 D1):
+gate, one skill):
 
 - **Infra** — before generating a CLI invocation, an IaC resource, or
   application code that runs on a managed runtime (a function handler whose

--- a/.claude/skills/new-rfc/SKILL.md
+++ b/.claude/skills/new-rfc/SKILL.md
@@ -190,7 +190,7 @@ push back: a normal PR (or a spec, if it's a feature) is enough.
    the first time it appears in the body — **inline, in a few words, not in a
    separate glossary section**. Don't lean on vocabulary inherited from related
    RFCs as if the reader already holds it: a reviewer arrives at the RFC from the
-   index, cold. (RFC-0053 is the cautionary case — it had to be hand-patched with
+   index, cold. (The cautionary case: an RFC that has to be hand-patched with
    inline glosses *after* drafting because the draft assumed its siblings' terms;
    the cold-reader check in the gate, step 6, exists to catch this before
    handoff.)
@@ -342,8 +342,8 @@ present rules without diffing the whole log by hand:
   the section so a reader knows which layer to trust.
 - The layer *names* above are illustrative; the contract is the two-layer split
   (authoritative current state over a dated audit trail), not the exact heading
-  wording. RFC-0048 / PR #430 is the worked precedent this generalizes — it uses
-  "Current reconciliation state" over an "Amendment history / audit trail."
+  wording. One worked precedent uses "Current reconciliation state" over an
+  "Amendment history / audit trail."
 
 ### Append-only and supersession
 
@@ -358,8 +358,8 @@ present rules without diffing the whole log by hand:
   in-flight Amendments** (a Frozen RFC's entries can't be touched).
 - **Whole-RFC replacement is out of scope.** When an entire RFC — not one
   correction within it — is superseded by a later one, record that as an
-  **Errata entry naming the superseding RFC** (e.g. RFC-0012 carries an erratum
-  recording that its Alternative #7 was superseded by RFC-0052). This convention
+  **Errata entry naming the superseding RFC** (e.g. an RFC carries an erratum
+  recording that its Alternative #7 was superseded by a later RFC). This convention
   governs corrections *within* an RFC; it neither defines nor changes the
   whole-RFC-supersession mechanism.
 

--- a/.claude/skills/operational-safety/SKILL.md
+++ b/.claude/skills/operational-safety/SKILL.md
@@ -16,7 +16,7 @@ below), so the agent prompt stays lean and the depth scales without bloat. It
 is the operational-lens twin of
 [`security-checklists`](../security-checklists/SKILL.md), built on the same
 orchestrator-loaded, table-routed mechanism — **no new reviewer** (the CHARTER
-three-reviewer ceiling; ADR-0023), no executable code (ADR-0031).
+three-reviewer ceiling), no executable code.
 
 ## How it loads (orchestrator-driven, not self-discovered)
 
@@ -47,13 +47,13 @@ flat march through every module. Where an
 adapter *does* support subagent skill auto-discovery, that is a redundant
 convenience layered on top — never the load-bearing mechanism.
 
-**The EXECUTE-consumer extension (`cloud-implementation-craft`).** ADR-0031
-established this library as a REVIEW-only depth source for `quality-engineer`.
+**The EXECUTE-consumer extension (`cloud-implementation-craft`).** This library
+is, by default, a REVIEW-only depth source for `quality-engineer`.
 One module — `cloud-implementation-craft` — is **also** inlined into the
 **implementer's EXECUTE brief** on infra-flavored work, by the same
 orchestrator on the same Module index, so its golden practices
 (least-privilege-but-sufficient permissions, timing/retry, packaging,
-externalized config) shape the build, not only the review (ADR-0034). The
+externalized config) shape the build, not only the review. The
 mechanism is unchanged — the orchestrator inlines; the subagent does not
 self-discover — only the *consumer* is extended from the reviewer to the
 implementer. `quality-engineer` still loads it at REVIEW to check the craft
@@ -107,8 +107,8 @@ This index is the **deterministic failure-mode→module routing authority** — 
 `work-loop` REVIEW `quality-engineer` bullet (and, for `cloud-implementation-craft`,
 the EXECUTE implementer brief) dispatches against the **Load when** column rather
 than carrying its own copy. Match the operational failure mode the infra/destructive
-change raises to its module(s). The `> **Grounded in:**` cells pin each module to
-its RFC-0041 module-table groundings.
+change raises to its module(s). The **Grounded in** column pins each module to
+the operational failure modes it covers.
 
 | Module | Load when — the operational failure mode the change raises | Grounded in |
 |---|---|---|
@@ -118,7 +118,7 @@ its RFC-0041 module-table groundings.
 | [`cost-and-teardown`](references/cost-and-teardown.md) | provisions billable resources; ephemeral/per-iteration infra; teardown path — covers cost-ceiling-as-gate, destroy-on-fail, TTL, no orphans | F3.4, F3.5 |
 | [`drift-and-rollback`](references/drift-and-rollback.md) | long-lived infra that can drift; a deploy needing a defined recovery path — covers read-only drift detection, known-good re-apply path | F1.4, F2.6 |
 | [`observability-and-smoke`](references/observability-and-smoke.md) | deploys a service / site / endpoint a user reaches; needs smoke + telemetry — covers active end-to-end probe, log access, health, verify-status, symptom→layer log playbook | F2.2; taxonomy follow-up |
-| [`cloud-implementation-craft`](references/cloud-implementation-craft.md) | authoring infra / a managed-runtime deployment / live interaction (**also inlined into the implementer's EXECUTE brief**) — **EXECUTE-craft**: least-privilege-but-sufficient permissions, timing/retry, packaging / entrypoint model, externalized config (also REVIEW) | RFC-0044 Author·behavioral + packaging gap |
+| [`cloud-implementation-craft`](references/cloud-implementation-craft.md) | authoring infra / a managed-runtime deployment / live interaction (**also inlined into the implementer's EXECUTE brief**) — **EXECUTE-craft**: least-privilege-but-sufficient permissions, timing/retry, packaging / entrypoint model, externalized config (also REVIEW) | Author·behavioral + packaging gap |
 
 `state-and-idempotency` (write-path convergence) and `drift-and-rollback`
 (divergence detection + recovery) are kept **deliberately separate** — every

--- a/.claude/skills/operational-safety/references/cloud-implementation-craft.md
+++ b/.claude/skills/operational-safety/references/cloud-implementation-craft.md
@@ -7,7 +7,7 @@
 > reviewer's REVIEW brief), the deliberate EXECUTE-consumer extension of the
 > depth-library pattern. `quality-engineer` also loads it at REVIEW to check the
 > craft against deployed reality.
-> **Grounded in:** RFC-0044's field report — the **Author · behavioral** family
+> **Grounded in:** a production field report — the **Author · behavioral** family
 > (permissions iterated reactively, undesigned propagation waits, escalating
 > timeouts and sprinkled `sleep`s, no client cold-start tolerance, dependency
 > cycles fixed by trial) and the **packaging gap** from Author · structural (a

--- a/.claude/skills/receive-brief/scripts/lint-brief-coverage.py
+++ b/.claude/skills/receive-brief/scripts/lint-brief-coverage.py
@@ -241,6 +241,8 @@ def _repo_root() -> Path:
         if r.returncode == 0 and r.stdout.strip():
             return Path(r.stdout.strip())
     except FileNotFoundError:
+        # `git` may be unavailable on PATH; fall through to the
+        # script-relative root, which is the intended fallback.
         pass
     return Path(__file__).resolve().parent.parent
 

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -70,8 +70,8 @@ are net-new. In order:
    referent that genuinely failed). The
    [resolve-vs-surface reference](references/self-coverage/resolve-vs-surface.md)
    calibrates the call.
-4. **Fresh-context-adversarial review** — *existing (REVIEW):* reviewers selected per
-   ADR-0042 from the work-type-keyed roster.
+4. **Fresh-context-adversarial review** — *existing (REVIEW):* reviewers selected
+   from the work-type-keyed roster.
 5. **Resolve-vs-surface routing** — *existing (DECIDE):* `Surface` + apply/defer.
 6. **Done-checklist refusal** — *net-new (DECIDE):* don't declare done until the
    disposition record exists and every fresh-context finding is resolved.
@@ -358,8 +358,8 @@ Match the discipline to the verification mode you picked during PLAN:
 Before generating code against a contract you do not already hold, acquire it
 via the [`contract-acquisition`](../contract-acquisition/SKILL.md)
 skill — never guess a flag, schema shape, field constraint, signature, or
-packaging assumption. **Two surfaces, one gate and one skill** (ADR-0037 D1 —
-extend the one gate, never fork a parallel skill): **(1) infra** — a CLI
+packaging assumption. **Two surfaces, one gate and one skill** (extend the one
+gate, never fork a parallel skill): **(1) infra** — a CLI
 invocation, an IaC resource, or application code on a managed runtime, against an
 unfamiliar platform; **(2) software** — code against an **unfamiliar internal
 framework or third-party library** whose contract (a versioned signature, a
@@ -372,8 +372,7 @@ behavioral contract; the gate now also covers the software case it was
 abstracted from, not infra alone. It is **universal** (fires in light mode too;
 heavier infra-flavor layers fire only on the infra-flavored signal), and is for
 the *unfamiliar-contract* case — **not** every import, not familiar code whose
-contract the agent already holds. (RFC-0044 § Errata 2026-06-24; RFC-0047
-Decisions 1–2 / ADR-0037 D1; detail in
+contract the agent already holds. (Detail in
 [`references/infra-verification.md`](references/infra-verification.md).)
 
 For each task, implement the smallest coherent unit of work toward the
@@ -630,7 +629,7 @@ note in the summary, not a blocker.
   failure modes raised, load **only** the matching modules, and inline them into
   the subagent's brief (orchestrator-driven — its `tools:` has no Skill tool, so
   loading is not model-relevance-judged). **No new reviewer** — feeds the existing
-  `quality-engineer` (ADR-0023). Route deterministically via
+  `quality-engineer`. Route deterministically via
   [`operational-safety`' **Module index**](../operational-safety/SKILL.md#module-index)
   — the failure-mode→module mapping is the routing authority and lives there,
   beside the depth it routes to.
@@ -643,7 +642,7 @@ note in the summary, not a blocker.
   `operational-safety` (this pass). The two passes are complementary lenses on
   the same infra diff, not substitutes.
 
-  **Independent contract re-derivation (Delivery — no new agent, ADR-0023).**
+  **Independent contract re-derivation (Delivery — no new agent).**
   When a diff was authored against a contract grounded at the EXECUTE gate, the
   orchestrator inlines
   [`contract-acquisition`](../contract-acquisition/SKILL.md) into the

--- a/.claude/skills/work-loop/references/infra-verification.md
+++ b/.claude/skills/work-loop/references/infra-verification.md
@@ -60,7 +60,7 @@ generating the resource?*; V1 owns *is a green early oracle being mistaken for
 "works" at verify?*** — the same oracle output, two different jobs
 (ground-before-authoring vs. don't-mistake-cheap-for-done).
 
-### Readiness-aware data-plane probe (V2 — refines layer 4 / RFC-0041 P2)
+### Readiness-aware data-plane probe (V2 — refines layer 4)
 
 The active end-to-end smoke (layer 4) has a specific shape, distinct from app
 verification: **in-network if private** (probe from *inside* the network
@@ -137,7 +137,7 @@ the loop requires "tests exist" without mandating a framework. The loop names
 these as prerequisite tasks and offers to scaffold them; it does not ship them
 as executable tooling.
 
-## EXECUTE — drive the deploy yourself (RFC-0041 P4)
+## EXECUTE — drive the deploy yourself
 
 Implement the change (one task may span several GATES layers), then **drive the
 deploy yourself and read the real environment output**: run the apply, the smoke
@@ -182,7 +182,7 @@ fires in light mode too; the heavier infra-flavor layers (the
 `cloud-implementation-craft` craft load at EXECUTE, the V2 data-plane probe, the
 `quality-engineer` infra wiring) fire only on the **infra-flavored signal** (the
 destructive/irreversible trigger + the `security-checklists` Module index's IaC /
-deploy-config entry). (RFC-0044 § Errata 2026-06-24.)
+deploy-config entry).
 
 ## EXECUTE — `cloud-implementation-craft` loaded into the implementer's brief
 
@@ -196,14 +196,14 @@ packaging / entrypoint-import model, and externalized script configuration —
 into the **implementer's EXECUTE brief**, via the
 [`operational-safety` Module index](../../operational-safety/SKILL.md#module-index)
 (the routing authority). This is the **deliberate EXECUTE-consumer extension** of
-`operational-safety`: ADR-0031 established it as a REVIEW-only depth library for
+`operational-safety`: by default a REVIEW-only depth library for
 `quality-engineer`; here the **same module, on the same routing mechanism**, is
 pointed at the implementer so the craft shapes the build, not only the review.
 Loading is **orchestrator-driven** (the subagent's `tools:` carries no Skill
 tool), never subagent self-discovery — exactly as the REVIEW-side
 `operational-safety` and `security-checklists` inlining works.
 
-## EXECUTE — reusable-script corollary (sharpens RFC-0041 P4, not a new failure family)
+## EXECUTE — reusable-script corollary (a discipline sharpening, not a new failure family)
 
 **Every** live-environment interaction — deploy, smoke probe, **log pull, debug
 step** — goes through a **reusable, idempotent, credential-reusing script** that
@@ -217,8 +217,8 @@ inline**. That lets the harness **honour an organization's naming + tagging
 conventions** without editing script bodies, and **port across accounts to stand
 up like-for-like environments** — the property V2's ephemeral, uniquely-named
 probe target and `environment-isolation`'s per-PR ephemeral harness both rest
-on. This is a **discipline sharpening agent-drives-verification (RFC-0041 P4)**,
-not a new failure family. (RFC-0044 § Errata 2026-06-24.)
+on. This is a **discipline sharpening agent-drives-verification**,
+not a new failure family.
 
 ## REVIEW — mandatory, multi-module security on infra-flavored work
 
@@ -277,12 +277,12 @@ oracle (or reads the curated skill / versioned docs) itself, never trusting the
 implementer's citation; this fires on any software-contract-citing diff, not
 only an infra-flavored one, so the broadened EXECUTE software surface ships with
 its matching REVIEW half. This adds **no new reviewer or agent** (the
-three-reviewer ceiling, ADR-0023): contract-conformance rides the **existing**
+three-reviewer ceiling): contract-conformance rides the **existing**
 `quality-engineer`, already the infra reviewer in spirit. The
 **auth-flow-contradiction class** (a spec whose auth design contradicts itself)
 is caught **earlier, at spec stage, by `design-reviewer`** where the architect
 pack is installed — otherwise it falls to the spec-stage adversarial pass. A
 **dedicated `infra-contract-reviewer` is deferred** behind a named evidence
-trigger (RFC-0044 Decision 8 — a spike showing oracle-execution traffic, large
-`plan` / `synth` output, measurably degrades `quality-engineer`'s other lenses);
+trigger (a spike showing oracle-execution traffic — large
+`plan` / `synth` output — measurably degrades `quality-engineer`'s other lenses);
 fetching the contract in *slices* softens the isolation case meanwhile.

--- a/.claude/skills/work-loop/references/self-coverage/resolve-vs-surface.md
+++ b/.claude/skills/work-loop/references/self-coverage/resolve-vs-surface.md
@@ -4,8 +4,7 @@ The calibration reference for the
 [self-coverage gate](../../SKILL.md#the-self-coverage-gate)'s disposition record. The
 loop reaches the right resolve-vs-surface call only about half the time without a
 scaffold; an explicit rubric plus calibrated examples climbs that rate. This is
-`work-loop`'s own per-loop copy, seeded from the RFC-0048-series reads in
-`docs/rfc/0048-notes/09-gap-resolutions.md`.
+`work-loop`'s own per-loop copy of the calibration examples.
 
 ## The rubric
 
@@ -40,7 +39,7 @@ and the **tell** — the cue that should have fired.
 
 ## Examples
 
-*(Seeded from the RFC-0048-series reads, note 09. Non-exhaustive by design.)*
+*(Non-exhaustive by design.)*
 
 - "How is the backlog handled?" → **resolve** (referent: how product teams work).
   *Tell: should not have waited to be asked.*
@@ -80,7 +79,8 @@ and the **tell** — the cue that should have fired.
   exists to catch.*
 - *A contradiction between two of your own clauses is resolve-with-referent, not
   surface.* The spec said both "this PR seeds the reference" and "appends continue in
-  note 09 until accepted." → **resolve** (referent: the per-loop copy is a *distinct*
-  file from the series reads — this PR creates the former, the rule governs the latter).
+  the upstream source until accepted." → **resolve** (referent: the per-loop copy is a
+  *distinct* file from the upstream source — this PR creates the former, the rule
+  governs the latter).
   *Tell: when two clauses collide, check whether they name the same object before
   treating it as an open question.*

--- a/.claude/skills/work-loop/scripts/lint-spec-status.py
+++ b/.claude/skills/work-loop/scripts/lint-spec-status.py
@@ -268,6 +268,8 @@ def _repo_root() -> Path:
         if r.returncode == 0 and r.stdout.strip():
             return Path(r.stdout.strip())
     except FileNotFoundError:
+        # `git` may be unavailable on PATH; fall through to the
+        # script-relative root, which is the intended fallback.
         pass
     return Path(__file__).resolve().parent.parent
 

--- a/.claude/skills/work-loop/scripts/lint-traceability.py
+++ b/.claude/skills/work-loop/scripts/lint-traceability.py
@@ -23,13 +23,13 @@ content, not a separate node.
 
 **Structure only.** Whether a node is parented to the *right* outcome (semantic
 scope-creep) is never this lint's call — structural presence is mechanizable,
-semantic correctness is not (the established traceability split; RFC-0048
-Decision 6, deferred to the coordinator spike O10, a human call at G1.5).
+semantic correctness is not (the established traceability split — semantic
+scope-creep is a human call at G1.5, never this lint's).
 
 **The chain spans repos, because the loops do.** `work-loop` builds per module
 (one repo, or one `packages/<c>/`); `discovery-loop` and the release loop work
 within or across modules, so the upstream discovery artifacts and shared
-contracts commonly live in a discovery / value-stream meta-repo (ADR-0022). A
+contracts commonly live in a discovery / value-stream meta-repo. A
 single working tree therefore sees only part of the chain. The crossing is
 handled by **convention, not path**: every node carries a stable,
 location-independent id (a marker slug, a `contract@version`, a Backstage
@@ -41,7 +41,7 @@ open-world federated-catalog posture — never fatal, never silently satisfied).
 
 Two sources, one classifier:
   - When a recognized sidecar `traceability.json` (a `schema_version`-stamped
-    `_state/` instance, RFC-0053 D7) is present it supplies the authoritative
+    `_state/` instance) is present it supplies the authoritative
     edge set. The schema *definition* is carried in `product-engineering`'s
     `discovery-loop` skill — this lint reads the produced instance by
     convention + the stamp, it never imports the definition.
@@ -54,8 +54,8 @@ On the authoritative sidecar graph the lint also runs a **root→leaf reachabili
 pass (`reachability_sidecar`): a node is reachable iff it is forward-reachable from
 `root` AND can reach a clean terminus (a `leaf_kind` node or a rollup-resolved
 `satisfied-by-reference` endpoint). A node off every root→leaf path is `UNREACHABLE`
-(the disconnected-subtree finding the discovery-loop cascade backstop depends on,
-RFC-0053 AC34) — additive to, and non-overlapping with, the presence orphans. An
+(the disconnected-subtree finding the discovery-loop cascade backstop depends
+on) — additive to, and non-overlapping with, the presence orphans. An
 *unresolvable* cross-repo hop is **not** a clean terminus (the sidecar is untrusted
 input — a forged out-edge must not silently green a stranded subtree); a node whose
 only escape is such a hop is surfaced informationally, never fatal. Reachability is
@@ -69,7 +69,7 @@ Exit codes:
   1 = a hard violation — a dangling edge (a pointer to a missing local target,
       or malformed) or a cycle, **in every mode**; or, under `--strict`, any
       structural orphan or `UNREACHABLE` node (the convergence-/CI-gate enforcing
-      "traceability closed", RFC-0048 O6). `--strict` degrades gracefully where the
+      "traceability closed"). `--strict` degrades gracefully where the
       producer `Discovery:` headers / `type:` markers are absent (a separate
       CONVENTIONS follow-on lands those).
 
@@ -93,11 +93,11 @@ try:  # py311+ stdlib; degrade where a layout config exists but tomllib doesn't.
 except ModuleNotFoundError:  # pragma: no cover - py<3.11
     tomllib = None  # type: ignore[assignment]
 
-# The canonical nine-node chain, in order (RFC-0048 note 08). Index = layer
+# The canonical nine-node chain, in order. Index = layer
 # depth; used for adjacency, terminal exemption, and the globally-unpopulated
 # layer-skip. `outcome` is the root (never a backward orphan); `component` is
 # the leaf (never a forward orphan — its cross-repo consumer is the release
-# loop, RFC-0049).
+# loop).
 CHAIN = (
     "outcome", "opportunity", "capability", "screen", "action",
     "service", "contract", "spec", "component",
@@ -122,7 +122,7 @@ KNOWN_SCHEMA_VERSIONS = frozenset({"0.1"})
 # marker); no discovery logic elsewhere may name a path literal (the no-
 # hardcoded-path NFR, AC1/AC2; the self-test greps this block's exclusivity).
 # Each layer: realization, default base (path segments under the root), and the
-# layout-config key (RFC-0040 `agentbundle-layout.toml`, tier 1).
+# layout-config key (`agentbundle-layout.toml`, tier 1).
 #
 # realization ∈ {file, container, ladder} — mirrors the sidecar's `backed_by`.
 _DEFAULT_BASES = {
@@ -205,7 +205,7 @@ def _token(raw: str) -> str:
 
 
 # --------------------------------------------------------------------------
-# Layer 0 — three-tier base resolution (RFC-0040)
+# Layer 0 — three-tier base resolution
 # --------------------------------------------------------------------------
 
 def load_layout(root: Path) -> dict:
@@ -471,7 +471,7 @@ def recognize_contracts(base: Path, root: Path, g: Graph) -> None:
 
 def recognize_ladder(base: Path, root: Path, g: Graph) -> dict[str, Path]:
     """Container/ladder `outcome`/`opportunity`/`capability` nodes from the
-    intent ladder `<intents-base>/*.md`. Per RFC-0048 note 04 the ladder tags
+    intent ladder `<intents-base>/*.md`. The ladder tags
     `outcome`/`opportunity` *kinds* across `vision`/`strategy`/`capability`/
     `feature` *levels*, so `capability` is a level while the other two are
     kinds. The extractor maps `**Kind:** outcome|opportunity` → that chain node,
@@ -533,7 +533,7 @@ def load_rollup_ids(root: Path, layout: dict) -> dict[str, bool]:
     The rollup row schema is
     `| Component | Brief (repo+slug) | Contract@version | Status | Coverage |`;
     a `<contract>@<version>` cell is a pinned reference, a bare id is unpinned.
-    Reused verbatim — never a parallel mechanism (ADR-0022)."""
+    Reused verbatim — never a parallel mechanism."""
     refs: dict[str, bool] = {}
     base, _ = _anchor_base(root, layout, "rollups", _ROLLUPS_BASE)
     if base is None:
@@ -767,7 +767,7 @@ def classify_standalone(g: Graph, briefs_present: bool) -> list[tuple[str, str, 
 
 def classify_sidecar(g: Graph) -> list[tuple[str, str, str]]:
     """Orphan classification for the authoritative sidecar graph — the
-    `check_sidecar` rule (RFC-0053 spike): `root` is exempt from an in-edge,
+    `check_sidecar` rule: `root` is exempt from an in-edge,
     `leaf_kind` from an out-edge, everything else needs both. The sidecar's
     edges already encode any layer-skip explicitly, so no populated-layer
     inference is applied. A **reference (external) endpoint** registered by
@@ -1226,6 +1226,9 @@ def _repo_root() -> Path:
         if r.returncode == 0 and r.stdout.strip():
             return Path(r.stdout.strip())
     except (FileNotFoundError, OSError):
+        # `git` may be unavailable on PATH (or the subprocess otherwise
+        # fails); fall through to the script-relative root, which is the
+        # intended fallback.
         pass
     return Path(__file__).resolve().parent.parent
 

--- a/.claude/skills/work-loop/scripts/loop-cohort.py
+++ b/.claude/skills/work-loop/scripts/loop-cohort.py
@@ -44,7 +44,6 @@ import hashlib
 import json
 import os
 import re
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -124,6 +123,9 @@ def write_state_atomic(spec_dir: Path, state: dict) -> None:
         try:
             os.unlink(tmp)
         except OSError:
+            # Best-effort cleanup of the temp file: if the original write or
+            # os.replace failed, a failed unlink here must not mask that
+            # original failure, which we re-raise below.
             pass
         raise
 

--- a/.codex/agents/implementer.toml
+++ b/.codex/agents/implementer.toml
@@ -39,7 +39,7 @@ In this order:
    model, externalized script config) as prompt text — that is your craft
    reference for this change. You do **not** load the skill yourself; if it was
    not inlined, fall back to your own judgment and say so. This is the
-   EXECUTE-consumer extension of `operational-safety` (ADR-0034); review of the
+   EXECUTE-consumer extension of `operational-safety`; review of the
    same craft still rides `quality-engineer`, no new reviewer is added.
 
 If the supervisor's brief omits the spec/plan paths, ask — don't guess.

--- a/AGENTS.local.md
+++ b/AGENTS.local.md
@@ -371,6 +371,23 @@ them right the first time. See
 [`.claude/skills/README.md`](.claude/skills/README.md#spec-compliance)
 for the full ruleset.
 
+The mechanics above are linted; the **craft** is not, so hold it in your
+head while authoring — the canonical rules live in
+[`.claude/skills/README.md` § Authoring skills](.claude/skills/README.md#authoring-skills):
+
+- **The frontmatter `description` is the activation trigger surface.** It
+  alone decides whether the right skill fires (and the wrong ones don't) —
+  write it as a sharp, differentiable trigger, not a summary.
+- **Keep the body terse — the token budget is real.** A skill loads into
+  context when triggered; bloat crowds out the user's actual task. Push
+  depth into `references/` the body links on demand, not the body itself.
+- **Keep the body disjoint from the trigger.** It answers *what to do once
+  invoked* (preconditions, judgment, procedure); it must not restate *when*
+  to invoke — that is the `description`'s job.
+- **No internal-governance citations** — per *Shipped pack content carries
+  no internal-governance citations* above; that rule applies to every
+  SKILL.md body and its `references/`, `scripts/`, and `assets/`.
+
 ## Install-test coverage rule
 
 Tests that exercise an on-disk projection layout, the per-pack orphan

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -19,6 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Shipped skill content is now self-contained — internal RFC/ADR citations removed.**
+  Skills, subagents, reference docs, and scripts across `core`, `governance-extras`,
+  `atlassian`, `converters`, `research`, and `product-engineering` no longer cite the
+  bundle's own governance artifacts (`RFC-00xx`, `ADR-00xx`, `docs/rfc/…`, spec
+  task/AC numbers) as load-bearing references — each rule now reads on its own terms.
+  Adopters install these skills without the bundle's `docs/` tree, so a dangling
+  `RFC-00xx` pointer was an unresolvable reference; the rules are unchanged, only the
+  provenance citations are gone. Real external standards (e.g. RFC-1918, RFC-9457) are
+  left intact. Also: the `.claude/skills/` README inventory now matches the projected
+  skill set, the scaffolded `docs/product/roadmap.md` is marked as a template, and the
+  `work-loop` activation hook's docstring points at `tools/hooks/README.md` for wiring.
 - **The traceability lint gains a root→leaf reachability pass (core 0.7.1).** On the
   authoritative sidecar graph, `work-loop`'s `lint-traceability.py` now flags every
   node that does not lie on a path from `root` to a leaf — a **`UNREACHABLE`

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -1,5 +1,9 @@
 # Roadmap
 
+> **Template.** Scaffolded by the bundle — replace the `<theme>` placeholders
+> and the `YYYY-MM-DD` dates with your project's real roadmap and review dates
+> before relying on it.
+
 > Direction for the next 2-4 quarters. **Not** commitments. The whole point
 > of writing this down is that it can change.
 

--- a/packs/atlassian/.apm/skills/confluence-crawler/references/sso-config.toml
+++ b/packs/atlassian/.apm/skills/confluence-crawler/references/sso-config.toml
@@ -1,4 +1,4 @@
-# SSO web-session cookie config (RFC-0035) — Atlassian Data Center only.
+# SSO web-session cookie config — Atlassian Data Center only.
 #
 # This file is PLACEHOLDER-SHAPED upstream: auth_default = "creds", *.invalid
 # hosts, and no cookie values. With it untouched, `confluence-crawler` behaves

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/_client.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/_client.py
@@ -85,7 +85,7 @@ def detect_flavor(base_url: str) -> str:
 
 
 def _sso_cafile_capath() -> tuple[str | None, str | None]:
-    """Resolve the CA bundle file + dir for the cookie-path SSL context (AC8).
+    """Resolve the CA bundle file + dir for the cookie-path SSL context.
 
     httpx (``trust_env``) natively honors ``SSL_CERT_FILE`` / ``SSL_CERT_DIR`` but
     does **not** read ``REQUESTS_CA_BUNDLE``; we map it here. Precedence:
@@ -99,7 +99,7 @@ def _sso_cafile_capath() -> tuple[str | None, str | None]:
 def _sso_ssl_context() -> ssl.SSLContext:
     """SSL context for the cookie path: the system trust store *plus* any
     ``SSL_CERT_FILE`` / ``SSL_CERT_DIR`` / ``REQUESTS_CA_BUNDLE`` the corporate
-    environment sets — loaded on top of (never clobbering) the default store (AC8).
+    environment sets — loaded on top of (never clobbering) the default store.
     """
     ctx = ssl.create_default_context()
     cafile, capath = _sso_cafile_capath()
@@ -168,10 +168,10 @@ class ConfluenceClient:
         """Build a Data Center client authenticated by a captured SSO cookie jar.
 
         Resolves the jar via credbroker (fail-closed), filters it to the declared
-        ``cookie_domains`` (AC4), confirms the base host is within those domains
-        (AC6), and builds an httpx client with the confined jar attached, **no**
-        ``Authorization`` header (AC7), ``follow_redirects=False`` (AC20), and the
-        corporate proxy / trust store honored (AC8). GET/HEAD only (AC9).
+        ``cookie_domains``, confirms the base host is within those domains,
+        and builds an httpx client with the confined jar attached, **no**
+        ``Authorization`` header, ``follow_redirects=False``, and the
+        corporate proxy / trust store honored. GET/HEAD only.
         """
         import credbroker
 
@@ -214,15 +214,15 @@ class ConfluenceClient:
         headers = {
             "Accept": "application/json",
             "User-Agent": "atlassian-confluence-crawler/0.1",
-        }  # deliberately NO Authorization header on the cookie path (AC7)
+        }  # deliberately NO Authorization header on the cookie path
         self._client = httpx.AsyncClient(
             base_url=self._base,
             headers=headers,
             cookies=cookies,
             timeout=timeout_s,
             verify=_sso_ssl_context(),
-            trust_env=True,  # corporate proxy + SSL_CERT_FILE/SSL_CERT_DIR (AC8)
-            follow_redirects=False,  # AC20 — never re-attach the cookie cross-host
+            trust_env=True,  # corporate proxy + SSL_CERT_FILE/SSL_CERT_DIR
+            follow_redirects=False,  # never re-attach the cookie cross-host
         )
         self._sem = asyncio.Semaphore(concurrency)
         self._min_delay = min_delay_ms / 1000.0
@@ -237,12 +237,12 @@ class ConfluenceClient:
         await self._client.aclose()
 
     async def _request(self, method: str, path: str, **kwargs: object) -> httpx.Response:
-        # Cookie-path write refusal (AC9). confluence-crawler has no raw() escape
+        # Cookie-path write refusal. confluence-crawler has no raw() escape
         # hatch, so the allowlist guards the _request method parameter directly;
         # raised before any request reaches the wire.
         if self._auth_mode == "sso-cookie" and method.upper() not in ("GET", "HEAD"):
             raise ConfluenceError(
-                "writes over SSO-cookie auth are not supported yet (RFC-0035 v1); "
+                "writes over SSO-cookie auth are not supported yet; "
                 "use a personal access token, or wait for the XSRF follow-on"
             )
 
@@ -266,7 +266,7 @@ class ConfluenceClient:
                 if resp.status_code == 401:
                     if self._auth_mode == "sso-cookie":
                         # Stop using the known-stale jar; remediation names the
-                        # profile, never the cookie bytes (AC11).
+                        # profile, never the cookie bytes.
                         self._client.cookies.clear()
                         raise AuthError(
                             f"401 Unauthorized — SSO session expired; run "
@@ -277,7 +277,7 @@ class ConfluenceClient:
                         "Re-run `credential-setup` skill."
                     )
                 if self._auth_mode == "sso-cookie" and 300 <= resp.status_code < 400:
-                    # follow_redirects disabled on the cookie path (AC20): surface a
+                    # follow_redirects disabled on the cookie path: surface a
                     # 30x, never follow it (which would re-attach the session cookie).
                     raise AuthError(
                         f"SSO session may have expired (HTTP {resp.status_code} "
@@ -416,7 +416,7 @@ class ConfluenceClient:
         # cookie-path confinement inline: refuse an absolute / off-host download
         # link (server-supplied) so the session cookie can never leave the base
         # host. follow_redirects=False already blocks a cross-host 30x; this also
-        # blocks an absolute Location-style `download` value (AC4/AC6/AC20 spirit).
+        # blocks an absolute Location-style `download` value (same spirit).
         if self._auth_mode == "sso-cookie":
             parsed = urlparse(download_path)
             if parsed.scheme or parsed.netloc:

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/_sso_config.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/_sso_config.py
@@ -1,4 +1,4 @@
-"""SSO config loader + ``auth_default`` selector (RFC-0035; spec task T3).
+"""SSO config loader + ``auth_default`` selector.
 
 Reads ``references/sso-config.toml``, validates the ``[sso]`` connection params
 with the shared ``credbroker`` confinement primitives, and decides the auth path.

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/crawl_space.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/crawl_space.py
@@ -388,7 +388,7 @@ async def _run_check(client: ConfluenceClient, flavor: str) -> int:
 
 
 async def main_async(args: argparse.Namespace) -> int:
-    # Auth selector (RFC-0035): sso-config.toml with auth_default = "sso-cookie"
+    # Auth selector: sso-config.toml with auth_default = "sso-cookie"
     # routes to the cookie path; absent or "creds" → today's token path unchanged.
     try:
         sso_config = load_sso_config()

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/setup_sso.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/setup_sso.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""Seed the sso-broker profile from references/sso-config.toml (RFC-0035; T7).
+"""Seed the sso-broker profile from references/sso-config.toml.
 
 Reads and **validates** the ``[sso]`` config through the loader (which applies the
-credbroker scheme / root-relative primitives — AC3 — *before* the broker is
+credbroker scheme / root-relative primitives *before* the broker is
 touched), then drives ``sso-broker register <profile>`` with the connection
 parameters from the file. No cookie value is ever passed on argv — only validated
-connection parameters (RFC-0013 § 1 path-not-value; AC14). The headed-browser
+connection parameters (path-not-value). The headed-browser
 capture and at-rest storage are the unchanged broker's job.
 
 Run once after an enterprise pre-bakes ``references/sso-config.toml`` with
@@ -66,7 +66,7 @@ def build_register_argv(broker: Path, cfg: SsoConfig) -> list[str]:
 
 def main(argv: list[str] | None = None) -> int:
     try:
-        cfg = load_sso_config()  # validates (AC3) before we touch the broker
+        cfg = load_sso_config()  # validates before we touch the broker
     except Exception as exc:  # noqa: BLE001 — malformed config → don't register
         print(f"error: invalid sso-config.toml: {exc}", file=sys.stderr)
         return 2

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/test_setup_sso.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/test_setup_sso.py
@@ -1,4 +1,4 @@
-"""setup_sso helper — seed the broker profile from the file (spec task T7; AC14).
+"""setup_sso helper — seed the broker profile from the file.
 
 Goal-based: the helper reads the validated config and drives `sso-broker register`
 with connection params from the file (no cookie value on argv), and a malformed
@@ -37,7 +37,7 @@ def test_build_register_argv_carries_connection_params_no_cookie(tmp_path):
     assert argv.count("--cookie-domain") == 2
     assert "corp.example.com" in argv and "jira.corp.example.com" in argv
     assert argv[argv.index("--ttl-hint-minutes") + 1] == "480"
-    # No cookie *value* shape anywhere on argv (AC14 path-not-value).
+    # No cookie *value* shape anywhere on argv (path-not-value).
     assert not any(token in part for part in argv for token in ("JSESSIONID", "Cookie:", "crowd.token"))
 
 

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/test_sso_client.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/test_sso_client.py
@@ -1,6 +1,6 @@
-"""confluence-crawler cookie-path client — mock-transport security contract (T6).
+"""confluence-crawler cookie-path client — mock-transport security contract.
 
-Mirrors the jira T5 contract (AC4/5/6/7/8/10/11/13/20). AC9 differs:
+Mirrors the jira cookie-path contract. The GET/HEAD allowlist differs:
 confluence-crawler has no raw() escape hatch, so the GET/HEAD allowlist is asserted
 directly on the _request chokepoint's method argument.
 """
@@ -77,10 +77,10 @@ def test_no_authorization_header_and_confined_cookies(broker_jar, monkeypatch):
 
     asyncio.run(go())
     req = seen[0]
-    assert "authorization" not in {k.lower() for k in req.headers}  # AC7
+    assert "authorization" not in {k.lower() for k in req.headers}
     cookie = req.headers.get("cookie", "")
     assert "JSESSIONID=sess1" in cookie and "crowd.token_key=tok1" in cookie
-    assert "_ga" not in cookie and "near" not in cookie  # AC4/AC5
+    assert "_ga" not in cookie and "near" not in cookie
 
 
 @pytest.mark.parametrize("method", ["POST", "PUT", "DELETE"])
@@ -196,7 +196,7 @@ def test_token_path_unchanged(monkeypatch):
 
 
 def test_token_path_follows_redirects(monkeypatch):
-    # Token path keeps follow_redirects=True; cookie path disables it (AC20).
+    # Token path keeps follow_redirects=True; cookie path disables it.
     seen: list[httpx.Request] = []
 
     def handler(request: httpx.Request) -> httpx.Response:

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/test_sso_config.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/test_sso_config.py
@@ -1,4 +1,4 @@
-"""SSO config loader + selector (spec task T3; AC3, AC12, AC13, fail-closed AC2).
+"""SSO config loader + selector (fail-closed).
 
 Exercises the per-skill loader against the real placeholder reference file and a
 table of crafted fixtures. Requires ``credbroker`` (the validation primitives) on
@@ -43,7 +43,7 @@ def _write(tmp_path: Path, body: str) -> Path:
 
 
 def test_real_reference_file_is_creds_path() -> None:
-    # Upstream placeholder: auth_default = "creds" → None (token path). AC12/AC13.
+    # Upstream placeholder: auth_default = "creds" → None (token path).
     assert load_sso_config() is None
 
 

--- a/packs/atlassian/.apm/skills/jira-brief-intake/SKILL.md
+++ b/packs/atlassian/.apm/skills/jira-brief-intake/SKILL.md
@@ -231,7 +231,7 @@ is installed):
 - **Don't force a single ticket into a brief.** One issue is one feature →
   `new-spec`. A defect → `jira-defect-flow`.
 - **Don't become a cross-repo coordination hub.** Carry the epic key as the
-  `Epic:` pointer only; do not reimplement a tracker (RFC-0019 own-the-slice).
+  `Epic:` pointer only; do not reimplement a tracker (own the slice).
 - **Don't hardcode a sibling skill or template path.** Look skills up by name.
 
 ## Edge cases

--- a/packs/atlassian/.apm/skills/jira/references/sso-config.toml
+++ b/packs/atlassian/.apm/skills/jira/references/sso-config.toml
@@ -1,4 +1,4 @@
-# SSO web-session cookie config (RFC-0035) — Atlassian Data Center only.
+# SSO web-session cookie config — Atlassian Data Center only.
 #
 # This file is PLACEHOLDER-SHAPED upstream: auth_default = "creds", *.invalid
 # hosts, and no cookie values. With it untouched, `jira` behaves exactly as

--- a/packs/atlassian/.apm/skills/jira/scripts/_client.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/_client.py
@@ -83,7 +83,7 @@ def _api_prefix(flavor: str) -> str:
 
 
 def _sso_cafile_capath() -> tuple[str | None, str | None]:
-    """Resolve the CA bundle file + dir for the cookie-path SSL context (AC8).
+    """Resolve the CA bundle file + dir for the cookie-path SSL context.
 
     httpx (``trust_env``) natively honors ``SSL_CERT_FILE`` / ``SSL_CERT_DIR`` but
     does **not** read ``REQUESTS_CA_BUNDLE``; we map it here. Precedence:
@@ -99,7 +99,7 @@ def _sso_ssl_context() -> ssl.SSLContext:
     """SSL context for the cookie path: the system trust store *plus* any
     ``SSL_CERT_FILE`` / ``SSL_CERT_DIR`` / ``REQUESTS_CA_BUNDLE`` the corporate
     environment sets — loaded on top of (never clobbering) the default store, so a
-    bare ``verify=True`` can't drop the corporate CA (AC8)."""
+    bare ``verify=True`` can't drop the corporate CA."""
     ctx = ssl.create_default_context()
     cafile, capath = _sso_cafile_capath()
     if cafile or capath:
@@ -177,26 +177,26 @@ class JiraClient:
         """Build a Data Center client authenticated by a captured SSO cookie jar.
 
         Resolves the jar via credbroker (fail-closed, never downgrades to a
-        token), filters it to the declared ``cookie_domains`` (AC4), confirms the
-        base host is within those domains (AC6), and builds an httpx client with
-        the confined jar attached, **no** ``Authorization`` header (AC7),
+        token), filters it to the declared ``cookie_domains``, confirms the
+        base host is within those domains, and builds an httpx client with
+        the confined jar attached, **no** ``Authorization`` header,
         ``follow_redirects=False`` so the session cookie is never re-attached
-        across a redirect (AC20), and the corporate proxy / trust store honored
-        (AC8). The cookie path is GET/HEAD only, enforced in ``_request`` (AC9).
+        across a redirect, and the corporate proxy / trust store honored.
+        The cookie path is GET/HEAD only, enforced in ``_request``.
         """
         import credbroker
 
         base_url = sso_config.base_url
         parsed = urlparse(base_url)
-        # Defense-in-depth https guard at construction (AC6): the cookie jar is a
+        # Defense-in-depth https guard at construction: the cookie jar is a
         # bearer secret, so the token path's http:// tolerance must not extend
-        # here, even though the config layer (AC3) already rejects a non-https URL.
+        # here, even though the config layer already rejects a non-https URL.
         if parsed.scheme != "https":
             raise AuthError(
                 "SSO-cookie base_url must be https (the session cookie is a bearer secret)"
             )
         host = parsed.hostname or ""
-        # Send-host confinement (AC6) + fail-closed jar resolution (AC1/AC2). Both
+        # Send-host confinement + fail-closed jar resolution. Both
         # credbroker fail-closed paths re-raise as AuthError so the skill surfaces
         # them as a single user-action (the remediation text is preserved).
         try:
@@ -206,7 +206,7 @@ class JiraClient:
             raise AuthError(str(exc)) from exc
 
         # Confine the deliberately over-broad captured jar to the declared domains
-        # before attaching it (AC4); the result is never written back (AC10).
+        # before attaching it; the result is never written back.
         raw_cookies = json.loads(jar_path.read_text(encoding="utf-8"))
         confined = credbroker.filter_jar_to_domains(
             raw_cookies, sso_config.cookie_domains
@@ -235,15 +235,15 @@ class JiraClient:
         headers = {
             "Accept": "application/json",
             "User-Agent": "atlassian-jira/0.1",
-        }  # deliberately NO Authorization header on the cookie path (AC7)
+        }  # deliberately NO Authorization header on the cookie path
         self._client = httpx.AsyncClient(
             base_url=self._base,
             headers=headers,
             cookies=cookies,
             timeout=timeout_s,
             verify=_sso_ssl_context(),
-            trust_env=True,  # corporate proxy + SSL_CERT_FILE/SSL_CERT_DIR (AC8)
-            follow_redirects=False,  # AC20 — never re-attach the cookie cross-host
+            trust_env=True,  # corporate proxy + SSL_CERT_FILE/SSL_CERT_DIR
+            follow_redirects=False,  # never re-attach the cookie cross-host
         )
         self._sem = asyncio.Semaphore(concurrency)
         return self
@@ -283,14 +283,14 @@ class JiraClient:
             # of the multipart form, masking the mistake. Fail loudly.
             raise ValueError("cannot send json_body and files in the same request")
 
-        # Cookie-path write refusal (AC9). This chokepoint is the single point
+        # Cookie-path write refusal. This chokepoint is the single point
         # every call funnels through — including the raw() escape hatch — so a
         # GET/HEAD allowlist here covers future verbs by construction. Raised
         # before any request reaches the wire (the transport records zero
         # requests for a refused verb).
         if self._auth_mode == "sso-cookie" and method.upper() not in ("GET", "HEAD"):
             raise JiraError(
-                "writes over SSO-cookie auth are not supported yet (RFC-0035 v1); "
+                "writes over SSO-cookie auth are not supported yet; "
                 "use a personal access token, or wait for the XSRF follow-on"
             )
 
@@ -315,7 +315,7 @@ class JiraClient:
                 if resp.status_code == 401:
                     if self._auth_mode == "sso-cookie":
                         # Stop using the known-stale jar — no further
-                        # cookie-bearing request with this session (AC11). The
+                        # cookie-bearing request with this session. The
                         # remediation names the profile, never the cookie bytes.
                         self._client.cookies.clear()
                         raise AuthError(
@@ -328,7 +328,7 @@ class JiraClient:
                         "`credential-setup` skill."
                     )
                 if self._auth_mode == "sso-cookie" and 300 <= resp.status_code < 400:
-                    # follow_redirects is disabled on the cookie path (AC20), so a
+                    # follow_redirects is disabled on the cookie path, so a
                     # 30x is surfaced, never followed (which would re-attach the
                     # session cookie to the redirect target). A redirect to login
                     # is the DC expired-session signal.

--- a/packs/atlassian/.apm/skills/jira/scripts/_sso_config.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/_sso_config.py
@@ -1,4 +1,4 @@
-"""SSO config loader + ``auth_default`` selector (RFC-0035; spec task T3).
+"""SSO config loader + ``auth_default`` selector.
 
 Reads ``references/sso-config.toml``, validates the ``[sso]`` connection params
 with the shared ``credbroker`` confinement primitives, and decides the auth path.

--- a/packs/atlassian/.apm/skills/jira/scripts/jira.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/jira.py
@@ -708,7 +708,7 @@ def _csv_scalar(value: Any) -> str:
 
 
 async def _run(args: argparse.Namespace) -> int:
-    # Auth selector (RFC-0035): an sso-config.toml with auth_default = "sso-cookie"
+    # Auth selector: an sso-config.toml with auth_default = "sso-cookie"
     # routes to the cookie path; absent or "creds" → today's token path unchanged.
     try:
         sso_config = load_sso_config()

--- a/packs/atlassian/.apm/skills/jira/scripts/setup_sso.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/setup_sso.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""Seed the sso-broker profile from references/sso-config.toml (RFC-0035; T7).
+"""Seed the sso-broker profile from references/sso-config.toml.
 
 Reads and **validates** the ``[sso]`` config through the loader (which applies the
-credbroker scheme / root-relative primitives — AC3 — *before* the broker is
+credbroker scheme / root-relative primitives *before* the broker is
 touched), then drives ``sso-broker register <profile>`` with the connection
 parameters from the file. No cookie value is ever passed on argv — only validated
-connection parameters (RFC-0013 § 1 path-not-value; AC14). The headed-browser
+connection parameters (path-not-value). The headed-browser
 capture and at-rest storage are the unchanged broker's job.
 
 Run once after an enterprise pre-bakes ``references/sso-config.toml`` with
@@ -66,7 +66,7 @@ def build_register_argv(broker: Path, cfg: SsoConfig) -> list[str]:
 
 def main(argv: list[str] | None = None) -> int:
     try:
-        cfg = load_sso_config()  # validates (AC3) before we touch the broker
+        cfg = load_sso_config()  # validates before we touch the broker
     except Exception as exc:  # noqa: BLE001 — malformed config → don't register
         print(f"error: invalid sso-config.toml: {exc}", file=sys.stderr)
         return 2

--- a/packs/atlassian/.apm/skills/jira/scripts/test_setup_sso.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/test_setup_sso.py
@@ -1,4 +1,4 @@
-"""setup_sso helper — seed the broker profile from the file (spec task T7; AC14).
+"""setup_sso helper — seed the broker profile from the file.
 
 Goal-based: the helper reads the validated config and drives `sso-broker register`
 with connection params from the file (no cookie value on argv), and a malformed
@@ -37,7 +37,7 @@ def test_build_register_argv_carries_connection_params_no_cookie(tmp_path):
     assert argv.count("--cookie-domain") == 2
     assert "corp.example.com" in argv and "jira.corp.example.com" in argv
     assert argv[argv.index("--ttl-hint-minutes") + 1] == "480"
-    # No cookie *value* shape anywhere on argv (AC14 path-not-value).
+    # No cookie *value* shape anywhere on argv (path-not-value).
     assert not any(token in part for part in argv for token in ("JSESSIONID", "Cookie:", "crowd.token"))
 
 

--- a/packs/atlassian/.apm/skills/jira/scripts/test_sso_client.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/test_sso_client.py
@@ -1,10 +1,10 @@
-"""jira cookie-path client — mock-transport security contract (spec task T5).
+"""jira cookie-path client — mock-transport security contract.
 
-Covers AC4/AC5 (cookie confinement on the outbound request), AC6 (send-host +
-https guard at construction), AC7 (no Authorization header), AC8 (CA-bundle
-precedence), AC9 (GET/HEAD allowlist incl. raw("POST")), AC10 (jar not rewritten),
-AC11 (401 remediation, no cookie in error), AC13 (token path unchanged), AC20
-(follow_redirects=False — off-domain 302 leaks no cookie).
+Covers cookie confinement on the outbound request, the send-host +
+https guard at construction, no Authorization header, CA-bundle
+precedence, the GET/HEAD allowlist (incl. raw("POST")), the jar not being rewritten,
+401 remediation (no cookie in error), the token path unchanged, and
+follow_redirects=False (an off-domain 302 leaks no cookie).
 
 All HTTP assertions are made on the *outbound request* via httpx.MockTransport,
 not on internal client attributes.
@@ -71,7 +71,7 @@ def _cookie_client(monkeypatch, handler, sso: SsoConfig = SSO) -> _client.JiraCl
     return _client.JiraClient.from_sso_cookies(sso)
 
 
-# --- AC7 / AC4 / AC5: no Authorization, confined cookies on the outbound request
+# --- no Authorization, confined cookies on the outbound request
 
 def test_no_authorization_header_and_confined_cookies(broker_jar, monkeypatch):
     seen: list[httpx.Request] = []
@@ -86,14 +86,14 @@ def test_no_authorization_header_and_confined_cookies(broker_jar, monkeypatch):
 
     asyncio.run(go())
     req = seen[0]
-    assert "authorization" not in {k.lower() for k in req.headers}  # AC7
+    assert "authorization" not in {k.lower() for k in req.headers}
     cookie = req.headers.get("cookie", "")
     assert "JSESSIONID=sess1" in cookie  # in-domain (subdomain) kept
     assert "crowd.token_key=tok1" in cookie  # in-domain (dotted) kept
-    assert "_ga" not in cookie and "near" not in cookie  # AC4/AC5 over-broad dropped
+    assert "_ga" not in cookie and "near" not in cookie  # over-broad dropped
 
 
-# --- AC9: GET/HEAD allowlist refuses writes (incl. raw("POST")) before the wire
+# --- GET/HEAD allowlist refuses writes (incl. raw("POST")) before the wire
 
 @pytest.mark.parametrize("method", ["POST", "PUT", "DELETE", "PATCH"])
 def test_writes_refused_records_zero_requests(broker_jar, monkeypatch, method):
@@ -112,7 +112,7 @@ def test_writes_refused_records_zero_requests(broker_jar, monkeypatch, method):
     assert seen == []  # nothing reached the wire
 
 
-# --- AC9 accept arm: raw("GET") reaches the wire with confined cookies, no auth
+# --- accept arm: raw("GET") reaches the wire with confined cookies, no auth
 
 def test_raw_get_reaches_wire_with_confined_cookies(broker_jar, monkeypatch):
     seen: list[httpx.Request] = []
@@ -132,7 +132,7 @@ def test_raw_get_reaches_wire_with_confined_cookies(broker_jar, monkeypatch):
     assert "JSESSIONID=sess1" in req.headers.get("cookie", "")
 
 
-# --- AC20: follow_redirects=False — an off-domain 302 leaks no cookie
+# --- follow_redirects=False — an off-domain 302 leaks no cookie
 
 def test_off_domain_redirect_not_followed(broker_jar, monkeypatch):
     seen: list[httpx.Request] = []
@@ -153,7 +153,7 @@ def test_off_domain_redirect_not_followed(broker_jar, monkeypatch):
     assert seen[0].url.host == "jira.corp.example.com"
 
 
-# --- AC11: 401 surfaces the re-register remediation; no cookie value in the error
+# --- 401 surfaces the re-register remediation; no cookie value in the error
 
 def test_401_surfaces_reregister_without_cookie_value(broker_jar, monkeypatch):
     def handler(request: httpx.Request) -> httpx.Response:
@@ -170,7 +170,7 @@ def test_401_surfaces_reregister_without_cookie_value(broker_jar, monkeypatch):
     assert "sess1" not in msg and "tok1" not in msg  # no cookie bytes in the error
 
 
-# --- AC6: send-host + https guards fail closed at construction
+# --- send-host + https guards fail closed at construction
 
 def test_base_host_outside_cookie_domains_fails_closed(broker_jar, monkeypatch):
     bad = replace(SSO, base_url="https://jira.evil.net")
@@ -184,7 +184,7 @@ def test_non_https_base_url_fails_closed(broker_jar, monkeypatch):
         _cookie_client(monkeypatch, lambda r: httpx.Response(200), bad)
 
 
-# --- AC10: the broker jar file is read, never rewritten
+# --- the broker jar file is read, never rewritten
 
 def test_jar_not_rewritten(broker_jar, monkeypatch):
     before = broker_jar.read_bytes()
@@ -200,7 +200,7 @@ def test_jar_not_rewritten(broker_jar, monkeypatch):
     assert broker_jar.read_bytes() == before
 
 
-# --- AC8: CA-bundle precedence + trust-store wiring
+# --- CA-bundle precedence + trust-store wiring
 
 def test_ca_bundle_precedence(monkeypatch):
     monkeypatch.setenv("SSL_CERT_FILE", "/etc/ssl/sslcert.pem")
@@ -221,7 +221,7 @@ def test_ssl_context_is_built():
     assert isinstance(_client._sso_ssl_context(), ssl.SSLContext)
 
 
-# --- AC13: token path is byte-identical (Authorization header, no cookies)
+# --- token path is byte-identical (Authorization header, no cookies)
 
 def test_token_path_unchanged(monkeypatch):
     seen: list[httpx.Request] = []
@@ -252,7 +252,7 @@ def test_token_path_unchanged(monkeypatch):
 
 def test_token_path_follows_redirects(monkeypatch):
     # The token path keeps follow_redirects=True (unchanged); the cookie path
-    # deliberately disables it (AC20). Pin the difference: a 302 is followed.
+    # deliberately disables it. Pin the difference: a 302 is followed.
     seen: list[httpx.Request] = []
 
     def handler(request: httpx.Request) -> httpx.Response:

--- a/packs/atlassian/.apm/skills/jira/scripts/test_sso_config.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/test_sso_config.py
@@ -1,4 +1,4 @@
-"""SSO config loader + selector (spec task T3; AC3, AC12, AC13, fail-closed AC2).
+"""SSO config loader + selector (fail-closed).
 
 Exercises the per-skill loader against the real placeholder reference file and a
 table of crafted fixtures. Requires ``credbroker`` (the validation primitives) on
@@ -43,7 +43,7 @@ def _write(tmp_path: Path, body: str) -> Path:
 
 
 def test_real_reference_file_is_creds_path() -> None:
-    # Upstream placeholder: auth_default = "creds" → None (token path). AC12/AC13.
+    # Upstream placeholder: auth_default = "creds" → None (token path).
     assert load_sso_config() is None
 
 

--- a/packs/converters/.apm/skills/markdown-to-docx/scripts/render.py
+++ b/packs/converters/.apm/skills/markdown-to-docx/scripts/render.py
@@ -89,7 +89,7 @@ def confine(path: Path, root: Path) -> Path:
 def build_context(text: str) -> dict:
     """Project a Markdown artifact onto a docxtpl Jinja context.
 
-    Mapping (RFC-0036): front-matter ``key: value`` lines → top-level scalars
+    Mapping: front-matter ``key: value`` lines → top-level scalars
     (for ``{{ key }}``); the first list → ``items`` (for a ``{%p for %}``
     paragraph loop); the first Markdown table → ``rows`` as a list of
     ``{column: value}`` dicts (for a ``{%tr for %}`` row loop). A ``sections``

--- a/packs/converters/.apm/skills/markdown-to-pptx/scripts/render.py
+++ b/packs/converters/.apm/skills/markdown-to-pptx/scripts/render.py
@@ -68,7 +68,7 @@ def confine(path: Path, root: Path) -> Path:
 def parse_markdown(text: str) -> dict:
     """Project a Markdown artifact onto the pptx content model.
 
-    Mapping (RFC-0036): front-matter ``key: value`` lines → ``scalars``; each
+    Mapping: front-matter ``key: value`` lines → ``scalars``; each
     H1/H2 heading → one ``section`` (→ one slide); list items under a heading →
     ``bullets``; a Markdown table under a heading → ``table`` (rows of cells).
 

--- a/packs/converters/.apm/skills/markdown-to-xlsx/scripts/render.py
+++ b/packs/converters/.apm/skills/markdown-to-xlsx/scripts/render.py
@@ -95,7 +95,7 @@ def confine(path: Path, root: Path) -> Path:
 def parse_markdown(text: str) -> dict:
     """Project a Markdown artifact onto the xlsx content model.
 
-    Mapping (RFC-0036): front-matter ``key: value`` lines → ``scalars`` (each
+    Mapping: front-matter ``key: value`` lines → ``scalars`` (each
     written into a single-cell *named range* of the same name); the first
     Markdown table → ``table`` (``{header, rows}``, written into an Excel
     *Table* data region). Pure transform — no I/O.

--- a/packs/core/.apm/agents/implementer.md
+++ b/packs/core/.apm/agents/implementer.md
@@ -38,7 +38,7 @@ In this order:
    model, externalized script config) as prompt text — that is your craft
    reference for this change. You do **not** load the skill yourself; if it was
    not inlined, fall back to your own judgment and say so. This is the
-   EXECUTE-consumer extension of `operational-safety` (ADR-0034); review of the
+   EXECUTE-consumer extension of `operational-safety`; review of the
    same craft still rides `quality-engineer`, no new reviewer is added.
 
 If the supervisor's brief omits the spec/plan paths, ask — don't guess.

--- a/packs/core/.apm/hooks/work-loop-check.py
+++ b/packs/core/.apm/hooks/work-loop-check.py
@@ -3,12 +3,12 @@
 work-loop skill for non-trivial work.
 
 Wired to the per-prompt event of each tool's hook surface — Claude Code
-`UserPromptSubmit` (and Copilot / Cursor / Gemini / Codex equivalents)
-via `.apm/hook-wiring/work-loop-check.toml`. The Kiro IDE counterpart is
-`.apm/kiro-ide-hooks/work-loop-check.kiro.hook` (an `askAgent` hook on
-`promptSubmit`), which carries the *same* instruction as a prompt because
-the IDE drops hook-wiring and `runCommand` does not feed the agent. Keep
-the two messages semantically aligned (both must mention `work-loop`).
+`UserPromptSubmit`, the Codex equivalent in `.codex/hooks.json`, and the
+Copilot / Cursor / Gemini equivalents. Kiro IDE gets the same nudge via a
+companion `promptSubmit` hook that carries the *same* instruction as a
+prompt (the IDE drops hook-wiring and `runCommand` does not feed the
+agent), so keep the two messages semantically aligned (both must mention
+`work-loop`). See `tools/hooks/README.md` § Wiring for what lands where.
 
 Pure-stdlib, input-free: prints a fixed reminder to stdout and exits 0.
 It deliberately does not parse the prompt or classify triviality — that

--- a/packs/core/.apm/skills/contract-acquisition/SKILL.md
+++ b/packs/core/.apm/skills/contract-acquisition/SKILL.md
@@ -58,7 +58,7 @@ This skill is **user- and agent-invoked** (it has an activation surface, unlike
 the reviewer-internal depth libraries). It fires when the agent is about to
 author against a contract it doesn't already hold — at `work-loop`'s
 **EXECUTE contract-grounding gate**, which routes **two surfaces** here (one
-gate, one skill — ADR-0037 D1):
+gate, one skill):
 
 - **Infra** — before generating a CLI invocation, an IaC resource, or
   application code that runs on a managed runtime (a function handler whose

--- a/packs/core/.apm/skills/operational-safety/SKILL.md
+++ b/packs/core/.apm/skills/operational-safety/SKILL.md
@@ -16,7 +16,7 @@ below), so the agent prompt stays lean and the depth scales without bloat. It
 is the operational-lens twin of
 [`security-checklists`](../security-checklists/SKILL.md), built on the same
 orchestrator-loaded, table-routed mechanism — **no new reviewer** (the CHARTER
-three-reviewer ceiling; ADR-0023), no executable code (ADR-0031).
+three-reviewer ceiling), no executable code.
 
 ## How it loads (orchestrator-driven, not self-discovered)
 
@@ -47,13 +47,13 @@ flat march through every module. Where an
 adapter *does* support subagent skill auto-discovery, that is a redundant
 convenience layered on top — never the load-bearing mechanism.
 
-**The EXECUTE-consumer extension (`cloud-implementation-craft`).** ADR-0031
-established this library as a REVIEW-only depth source for `quality-engineer`.
+**The EXECUTE-consumer extension (`cloud-implementation-craft`).** This library
+is, by default, a REVIEW-only depth source for `quality-engineer`.
 One module — `cloud-implementation-craft` — is **also** inlined into the
 **implementer's EXECUTE brief** on infra-flavored work, by the same
 orchestrator on the same Module index, so its golden practices
 (least-privilege-but-sufficient permissions, timing/retry, packaging,
-externalized config) shape the build, not only the review (ADR-0034). The
+externalized config) shape the build, not only the review. The
 mechanism is unchanged — the orchestrator inlines; the subagent does not
 self-discover — only the *consumer* is extended from the reviewer to the
 implementer. `quality-engineer` still loads it at REVIEW to check the craft
@@ -107,8 +107,8 @@ This index is the **deterministic failure-mode→module routing authority** — 
 `work-loop` REVIEW `quality-engineer` bullet (and, for `cloud-implementation-craft`,
 the EXECUTE implementer brief) dispatches against the **Load when** column rather
 than carrying its own copy. Match the operational failure mode the infra/destructive
-change raises to its module(s). The `> **Grounded in:**` cells pin each module to
-its RFC-0041 module-table groundings.
+change raises to its module(s). The **Grounded in** column pins each module to
+the operational failure modes it covers.
 
 | Module | Load when — the operational failure mode the change raises | Grounded in |
 |---|---|---|
@@ -118,7 +118,7 @@ its RFC-0041 module-table groundings.
 | [`cost-and-teardown`](references/cost-and-teardown.md) | provisions billable resources; ephemeral/per-iteration infra; teardown path — covers cost-ceiling-as-gate, destroy-on-fail, TTL, no orphans | F3.4, F3.5 |
 | [`drift-and-rollback`](references/drift-and-rollback.md) | long-lived infra that can drift; a deploy needing a defined recovery path — covers read-only drift detection, known-good re-apply path | F1.4, F2.6 |
 | [`observability-and-smoke`](references/observability-and-smoke.md) | deploys a service / site / endpoint a user reaches; needs smoke + telemetry — covers active end-to-end probe, log access, health, verify-status, symptom→layer log playbook | F2.2; taxonomy follow-up |
-| [`cloud-implementation-craft`](references/cloud-implementation-craft.md) | authoring infra / a managed-runtime deployment / live interaction (**also inlined into the implementer's EXECUTE brief**) — **EXECUTE-craft**: least-privilege-but-sufficient permissions, timing/retry, packaging / entrypoint model, externalized config (also REVIEW) | RFC-0044 Author·behavioral + packaging gap |
+| [`cloud-implementation-craft`](references/cloud-implementation-craft.md) | authoring infra / a managed-runtime deployment / live interaction (**also inlined into the implementer's EXECUTE brief**) — **EXECUTE-craft**: least-privilege-but-sufficient permissions, timing/retry, packaging / entrypoint model, externalized config (also REVIEW) | Author·behavioral + packaging gap |
 
 `state-and-idempotency` (write-path convergence) and `drift-and-rollback`
 (divergence detection + recovery) are kept **deliberately separate** — every

--- a/packs/core/.apm/skills/operational-safety/references/cloud-implementation-craft.md
+++ b/packs/core/.apm/skills/operational-safety/references/cloud-implementation-craft.md
@@ -7,7 +7,7 @@
 > reviewer's REVIEW brief), the deliberate EXECUTE-consumer extension of the
 > depth-library pattern. `quality-engineer` also loads it at REVIEW to check the
 > craft against deployed reality.
-> **Grounded in:** RFC-0044's field report — the **Author · behavioral** family
+> **Grounded in:** a production field report — the **Author · behavioral** family
 > (permissions iterated reactively, undesigned propagation waits, escalating
 > timeouts and sprinkled `sleep`s, no client cold-start tolerance, dependency
 > cycles fixed by trial) and the **packaging gap** from Author · structural (a

--- a/packs/core/.apm/skills/receive-brief/scripts/lint-brief-coverage.py
+++ b/packs/core/.apm/skills/receive-brief/scripts/lint-brief-coverage.py
@@ -241,6 +241,8 @@ def _repo_root() -> Path:
         if r.returncode == 0 and r.stdout.strip():
             return Path(r.stdout.strip())
     except FileNotFoundError:
+        # `git` may be unavailable on PATH; fall through to the
+        # script-relative root, which is the intended fallback.
         pass
     return Path(__file__).resolve().parent.parent
 

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -70,8 +70,8 @@ are net-new. In order:
    referent that genuinely failed). The
    [resolve-vs-surface reference](references/self-coverage/resolve-vs-surface.md)
    calibrates the call.
-4. **Fresh-context-adversarial review** — *existing (REVIEW):* reviewers selected per
-   ADR-0042 from the work-type-keyed roster.
+4. **Fresh-context-adversarial review** — *existing (REVIEW):* reviewers selected
+   from the work-type-keyed roster.
 5. **Resolve-vs-surface routing** — *existing (DECIDE):* `Surface` + apply/defer.
 6. **Done-checklist refusal** — *net-new (DECIDE):* don't declare done until the
    disposition record exists and every fresh-context finding is resolved.
@@ -358,8 +358,8 @@ Match the discipline to the verification mode you picked during PLAN:
 Before generating code against a contract you do not already hold, acquire it
 via the [`contract-acquisition`](../contract-acquisition/SKILL.md)
 skill — never guess a flag, schema shape, field constraint, signature, or
-packaging assumption. **Two surfaces, one gate and one skill** (ADR-0037 D1 —
-extend the one gate, never fork a parallel skill): **(1) infra** — a CLI
+packaging assumption. **Two surfaces, one gate and one skill** (extend the one
+gate, never fork a parallel skill): **(1) infra** — a CLI
 invocation, an IaC resource, or application code on a managed runtime, against an
 unfamiliar platform; **(2) software** — code against an **unfamiliar internal
 framework or third-party library** whose contract (a versioned signature, a
@@ -372,8 +372,7 @@ behavioral contract; the gate now also covers the software case it was
 abstracted from, not infra alone. It is **universal** (fires in light mode too;
 heavier infra-flavor layers fire only on the infra-flavored signal), and is for
 the *unfamiliar-contract* case — **not** every import, not familiar code whose
-contract the agent already holds. (RFC-0044 § Errata 2026-06-24; RFC-0047
-Decisions 1–2 / ADR-0037 D1; detail in
+contract the agent already holds. (Detail in
 [`references/infra-verification.md`](references/infra-verification.md).)
 
 For each task, implement the smallest coherent unit of work toward the
@@ -630,7 +629,7 @@ note in the summary, not a blocker.
   failure modes raised, load **only** the matching modules, and inline them into
   the subagent's brief (orchestrator-driven — its `tools:` has no Skill tool, so
   loading is not model-relevance-judged). **No new reviewer** — feeds the existing
-  `quality-engineer` (ADR-0023). Route deterministically via
+  `quality-engineer`. Route deterministically via
   [`operational-safety`' **Module index**](../operational-safety/SKILL.md#module-index)
   — the failure-mode→module mapping is the routing authority and lives there,
   beside the depth it routes to.
@@ -643,7 +642,7 @@ note in the summary, not a blocker.
   `operational-safety` (this pass). The two passes are complementary lenses on
   the same infra diff, not substitutes.
 
-  **Independent contract re-derivation (Delivery — no new agent, ADR-0023).**
+  **Independent contract re-derivation (Delivery — no new agent).**
   When a diff was authored against a contract grounded at the EXECUTE gate, the
   orchestrator inlines
   [`contract-acquisition`](../contract-acquisition/SKILL.md) into the

--- a/packs/core/.apm/skills/work-loop/references/infra-verification.md
+++ b/packs/core/.apm/skills/work-loop/references/infra-verification.md
@@ -60,7 +60,7 @@ generating the resource?*; V1 owns *is a green early oracle being mistaken for
 "works" at verify?*** — the same oracle output, two different jobs
 (ground-before-authoring vs. don't-mistake-cheap-for-done).
 
-### Readiness-aware data-plane probe (V2 — refines layer 4 / RFC-0041 P2)
+### Readiness-aware data-plane probe (V2 — refines layer 4)
 
 The active end-to-end smoke (layer 4) has a specific shape, distinct from app
 verification: **in-network if private** (probe from *inside* the network
@@ -137,7 +137,7 @@ the loop requires "tests exist" without mandating a framework. The loop names
 these as prerequisite tasks and offers to scaffold them; it does not ship them
 as executable tooling.
 
-## EXECUTE — drive the deploy yourself (RFC-0041 P4)
+## EXECUTE — drive the deploy yourself
 
 Implement the change (one task may span several GATES layers), then **drive the
 deploy yourself and read the real environment output**: run the apply, the smoke
@@ -182,7 +182,7 @@ fires in light mode too; the heavier infra-flavor layers (the
 `cloud-implementation-craft` craft load at EXECUTE, the V2 data-plane probe, the
 `quality-engineer` infra wiring) fire only on the **infra-flavored signal** (the
 destructive/irreversible trigger + the `security-checklists` Module index's IaC /
-deploy-config entry). (RFC-0044 § Errata 2026-06-24.)
+deploy-config entry).
 
 ## EXECUTE — `cloud-implementation-craft` loaded into the implementer's brief
 
@@ -196,14 +196,14 @@ packaging / entrypoint-import model, and externalized script configuration —
 into the **implementer's EXECUTE brief**, via the
 [`operational-safety` Module index](../../operational-safety/SKILL.md#module-index)
 (the routing authority). This is the **deliberate EXECUTE-consumer extension** of
-`operational-safety`: ADR-0031 established it as a REVIEW-only depth library for
+`operational-safety`: by default a REVIEW-only depth library for
 `quality-engineer`; here the **same module, on the same routing mechanism**, is
 pointed at the implementer so the craft shapes the build, not only the review.
 Loading is **orchestrator-driven** (the subagent's `tools:` carries no Skill
 tool), never subagent self-discovery — exactly as the REVIEW-side
 `operational-safety` and `security-checklists` inlining works.
 
-## EXECUTE — reusable-script corollary (sharpens RFC-0041 P4, not a new failure family)
+## EXECUTE — reusable-script corollary (a discipline sharpening, not a new failure family)
 
 **Every** live-environment interaction — deploy, smoke probe, **log pull, debug
 step** — goes through a **reusable, idempotent, credential-reusing script** that
@@ -217,8 +217,8 @@ inline**. That lets the harness **honour an organization's naming + tagging
 conventions** without editing script bodies, and **port across accounts to stand
 up like-for-like environments** — the property V2's ephemeral, uniquely-named
 probe target and `environment-isolation`'s per-PR ephemeral harness both rest
-on. This is a **discipline sharpening agent-drives-verification (RFC-0041 P4)**,
-not a new failure family. (RFC-0044 § Errata 2026-06-24.)
+on. This is a **discipline sharpening agent-drives-verification**,
+not a new failure family.
 
 ## REVIEW — mandatory, multi-module security on infra-flavored work
 
@@ -277,12 +277,12 @@ oracle (or reads the curated skill / versioned docs) itself, never trusting the
 implementer's citation; this fires on any software-contract-citing diff, not
 only an infra-flavored one, so the broadened EXECUTE software surface ships with
 its matching REVIEW half. This adds **no new reviewer or agent** (the
-three-reviewer ceiling, ADR-0023): contract-conformance rides the **existing**
+three-reviewer ceiling): contract-conformance rides the **existing**
 `quality-engineer`, already the infra reviewer in spirit. The
 **auth-flow-contradiction class** (a spec whose auth design contradicts itself)
 is caught **earlier, at spec stage, by `design-reviewer`** where the architect
 pack is installed — otherwise it falls to the spec-stage adversarial pass. A
 **dedicated `infra-contract-reviewer` is deferred** behind a named evidence
-trigger (RFC-0044 Decision 8 — a spike showing oracle-execution traffic, large
-`plan` / `synth` output, measurably degrades `quality-engineer`'s other lenses);
+trigger (a spike showing oracle-execution traffic — large
+`plan` / `synth` output — measurably degrades `quality-engineer`'s other lenses);
 fetching the contract in *slices* softens the isolation case meanwhile.

--- a/packs/core/.apm/skills/work-loop/references/self-coverage/resolve-vs-surface.md
+++ b/packs/core/.apm/skills/work-loop/references/self-coverage/resolve-vs-surface.md
@@ -4,8 +4,7 @@ The calibration reference for the
 [self-coverage gate](../../SKILL.md#the-self-coverage-gate)'s disposition record. The
 loop reaches the right resolve-vs-surface call only about half the time without a
 scaffold; an explicit rubric plus calibrated examples climbs that rate. This is
-`work-loop`'s own per-loop copy, seeded from the RFC-0048-series reads in
-`docs/rfc/0048-notes/09-gap-resolutions.md`.
+`work-loop`'s own per-loop copy of the calibration examples.
 
 ## The rubric
 
@@ -40,7 +39,7 @@ and the **tell** — the cue that should have fired.
 
 ## Examples
 
-*(Seeded from the RFC-0048-series reads, note 09. Non-exhaustive by design.)*
+*(Non-exhaustive by design.)*
 
 - "How is the backlog handled?" → **resolve** (referent: how product teams work).
   *Tell: should not have waited to be asked.*
@@ -80,7 +79,8 @@ and the **tell** — the cue that should have fired.
   exists to catch.*
 - *A contradiction between two of your own clauses is resolve-with-referent, not
   surface.* The spec said both "this PR seeds the reference" and "appends continue in
-  note 09 until accepted." → **resolve** (referent: the per-loop copy is a *distinct*
-  file from the series reads — this PR creates the former, the rule governs the latter).
+  the upstream source until accepted." → **resolve** (referent: the per-loop copy is a
+  *distinct* file from the upstream source — this PR creates the former, the rule
+  governs the latter).
   *Tell: when two clauses collide, check whether they name the same object before
   treating it as an open question.*

--- a/packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py
+++ b/packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py
@@ -268,6 +268,8 @@ def _repo_root() -> Path:
         if r.returncode == 0 and r.stdout.strip():
             return Path(r.stdout.strip())
     except FileNotFoundError:
+        # `git` may be unavailable on PATH; fall through to the
+        # script-relative root, which is the intended fallback.
         pass
     return Path(__file__).resolve().parent.parent
 

--- a/packs/core/.apm/skills/work-loop/scripts/lint-traceability.py
+++ b/packs/core/.apm/skills/work-loop/scripts/lint-traceability.py
@@ -23,13 +23,13 @@ content, not a separate node.
 
 **Structure only.** Whether a node is parented to the *right* outcome (semantic
 scope-creep) is never this lint's call — structural presence is mechanizable,
-semantic correctness is not (the established traceability split; RFC-0048
-Decision 6, deferred to the coordinator spike O10, a human call at G1.5).
+semantic correctness is not (the established traceability split — semantic
+scope-creep is a human call at G1.5, never this lint's).
 
 **The chain spans repos, because the loops do.** `work-loop` builds per module
 (one repo, or one `packages/<c>/`); `discovery-loop` and the release loop work
 within or across modules, so the upstream discovery artifacts and shared
-contracts commonly live in a discovery / value-stream meta-repo (ADR-0022). A
+contracts commonly live in a discovery / value-stream meta-repo. A
 single working tree therefore sees only part of the chain. The crossing is
 handled by **convention, not path**: every node carries a stable,
 location-independent id (a marker slug, a `contract@version`, a Backstage
@@ -41,7 +41,7 @@ open-world federated-catalog posture — never fatal, never silently satisfied).
 
 Two sources, one classifier:
   - When a recognized sidecar `traceability.json` (a `schema_version`-stamped
-    `_state/` instance, RFC-0053 D7) is present it supplies the authoritative
+    `_state/` instance) is present it supplies the authoritative
     edge set. The schema *definition* is carried in `product-engineering`'s
     `discovery-loop` skill — this lint reads the produced instance by
     convention + the stamp, it never imports the definition.
@@ -54,8 +54,8 @@ On the authoritative sidecar graph the lint also runs a **root→leaf reachabili
 pass (`reachability_sidecar`): a node is reachable iff it is forward-reachable from
 `root` AND can reach a clean terminus (a `leaf_kind` node or a rollup-resolved
 `satisfied-by-reference` endpoint). A node off every root→leaf path is `UNREACHABLE`
-(the disconnected-subtree finding the discovery-loop cascade backstop depends on,
-RFC-0053 AC34) — additive to, and non-overlapping with, the presence orphans. An
+(the disconnected-subtree finding the discovery-loop cascade backstop depends
+on) — additive to, and non-overlapping with, the presence orphans. An
 *unresolvable* cross-repo hop is **not** a clean terminus (the sidecar is untrusted
 input — a forged out-edge must not silently green a stranded subtree); a node whose
 only escape is such a hop is surfaced informationally, never fatal. Reachability is
@@ -69,7 +69,7 @@ Exit codes:
   1 = a hard violation — a dangling edge (a pointer to a missing local target,
       or malformed) or a cycle, **in every mode**; or, under `--strict`, any
       structural orphan or `UNREACHABLE` node (the convergence-/CI-gate enforcing
-      "traceability closed", RFC-0048 O6). `--strict` degrades gracefully where the
+      "traceability closed"). `--strict` degrades gracefully where the
       producer `Discovery:` headers / `type:` markers are absent (a separate
       CONVENTIONS follow-on lands those).
 
@@ -93,11 +93,11 @@ try:  # py311+ stdlib; degrade where a layout config exists but tomllib doesn't.
 except ModuleNotFoundError:  # pragma: no cover - py<3.11
     tomllib = None  # type: ignore[assignment]
 
-# The canonical nine-node chain, in order (RFC-0048 note 08). Index = layer
+# The canonical nine-node chain, in order. Index = layer
 # depth; used for adjacency, terminal exemption, and the globally-unpopulated
 # layer-skip. `outcome` is the root (never a backward orphan); `component` is
 # the leaf (never a forward orphan — its cross-repo consumer is the release
-# loop, RFC-0049).
+# loop).
 CHAIN = (
     "outcome", "opportunity", "capability", "screen", "action",
     "service", "contract", "spec", "component",
@@ -122,7 +122,7 @@ KNOWN_SCHEMA_VERSIONS = frozenset({"0.1"})
 # marker); no discovery logic elsewhere may name a path literal (the no-
 # hardcoded-path NFR, AC1/AC2; the self-test greps this block's exclusivity).
 # Each layer: realization, default base (path segments under the root), and the
-# layout-config key (RFC-0040 `agentbundle-layout.toml`, tier 1).
+# layout-config key (`agentbundle-layout.toml`, tier 1).
 #
 # realization ∈ {file, container, ladder} — mirrors the sidecar's `backed_by`.
 _DEFAULT_BASES = {
@@ -205,7 +205,7 @@ def _token(raw: str) -> str:
 
 
 # --------------------------------------------------------------------------
-# Layer 0 — three-tier base resolution (RFC-0040)
+# Layer 0 — three-tier base resolution
 # --------------------------------------------------------------------------
 
 def load_layout(root: Path) -> dict:
@@ -471,7 +471,7 @@ def recognize_contracts(base: Path, root: Path, g: Graph) -> None:
 
 def recognize_ladder(base: Path, root: Path, g: Graph) -> dict[str, Path]:
     """Container/ladder `outcome`/`opportunity`/`capability` nodes from the
-    intent ladder `<intents-base>/*.md`. Per RFC-0048 note 04 the ladder tags
+    intent ladder `<intents-base>/*.md`. The ladder tags
     `outcome`/`opportunity` *kinds* across `vision`/`strategy`/`capability`/
     `feature` *levels*, so `capability` is a level while the other two are
     kinds. The extractor maps `**Kind:** outcome|opportunity` → that chain node,
@@ -533,7 +533,7 @@ def load_rollup_ids(root: Path, layout: dict) -> dict[str, bool]:
     The rollup row schema is
     `| Component | Brief (repo+slug) | Contract@version | Status | Coverage |`;
     a `<contract>@<version>` cell is a pinned reference, a bare id is unpinned.
-    Reused verbatim — never a parallel mechanism (ADR-0022)."""
+    Reused verbatim — never a parallel mechanism."""
     refs: dict[str, bool] = {}
     base, _ = _anchor_base(root, layout, "rollups", _ROLLUPS_BASE)
     if base is None:
@@ -767,7 +767,7 @@ def classify_standalone(g: Graph, briefs_present: bool) -> list[tuple[str, str, 
 
 def classify_sidecar(g: Graph) -> list[tuple[str, str, str]]:
     """Orphan classification for the authoritative sidecar graph — the
-    `check_sidecar` rule (RFC-0053 spike): `root` is exempt from an in-edge,
+    `check_sidecar` rule: `root` is exempt from an in-edge,
     `leaf_kind` from an out-edge, everything else needs both. The sidecar's
     edges already encode any layer-skip explicitly, so no populated-layer
     inference is applied. A **reference (external) endpoint** registered by
@@ -1226,6 +1226,9 @@ def _repo_root() -> Path:
         if r.returncode == 0 and r.stdout.strip():
             return Path(r.stdout.strip())
     except (FileNotFoundError, OSError):
+        # `git` may be unavailable on PATH (or the subprocess otherwise
+        # fails); fall through to the script-relative root, which is the
+        # intended fallback.
         pass
     return Path(__file__).resolve().parent.parent
 

--- a/packs/core/.apm/skills/work-loop/scripts/loop-cohort.py
+++ b/packs/core/.apm/skills/work-loop/scripts/loop-cohort.py
@@ -44,7 +44,6 @@ import hashlib
 import json
 import os
 import re
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -124,6 +123,9 @@ def write_state_atomic(spec_dir: Path, state: dict) -> None:
         try:
             os.unlink(tmp)
         except OSError:
+            # Best-effort cleanup of the temp file: if the original write or
+            # os.replace failed, a failed unlink here must not mask that
+            # original failure, which we re-raise below.
             pass
         raise
 

--- a/packs/core/seeds/docs/product/roadmap.md
+++ b/packs/core/seeds/docs/product/roadmap.md
@@ -1,5 +1,9 @@
 # Roadmap
 
+> **Template.** Scaffolded by the bundle — replace the `<theme>` placeholders
+> and the `YYYY-MM-DD` dates with your project's real roadmap and review dates
+> before relying on it.
+
 > Direction for the next 2-4 quarters. **Not** commitments. The whole point
 > of writing this down is that it can change.
 

--- a/packs/credential-brokers/.apm/skills/credential-setup/scripts/setup.py
+++ b/packs/credential-brokers/.apm/skills/credential-setup/scripts/setup.py
@@ -19,7 +19,7 @@ import pathlib
 import re
 import sys
 
-# credbroker is a pip-installed package (RFC-0023), so this is an absolute
+# credbroker is a pip-installed package, so this is an absolute
 # import — no ``__package__`` bootstrap is needed (the former relative
 # sibling-resolver import did require one for file-path invocation).
 #

--- a/packs/credential-brokers/.apm/skills/credential-setup/scripts/test_setup.py
+++ b/packs/credential-brokers/.apm/skills/credential-setup/scripts/test_setup.py
@@ -1,4 +1,4 @@
-"""credential-setup tests (spec task T8) — credential-setup ships none today.
+"""credential-setup tests — credential-setup ships none today.
 
 Exercises the three Tier-selection orchestration paths after the migration onto
 credbroker's public write API, plus the import-surface invariant (no
@@ -182,7 +182,7 @@ def test_missing_credbroker_exits_3_with_install_hint(tmp_path):
 def test_non_credbroker_import_error_is_reraised(tmp_path):
     """A ModuleNotFoundError whose ``.name`` is not ``credbroker`` (credbroker
     present but importing a broken/absent dependency) surfaces unchanged — it is
-    NOT reported as "credbroker not found" (AC3). Guards the ``exc.name``
+    NOT reported as "credbroker not found". Guards the ``exc.name``
     narrowing branch against a mutation that drops it and treats every
     ModuleNotFoundError as a missing install.
 

--- a/packs/governance-extras/.apm/skills/new-rfc/SKILL.md
+++ b/packs/governance-extras/.apm/skills/new-rfc/SKILL.md
@@ -190,7 +190,7 @@ push back: a normal PR (or a spec, if it's a feature) is enough.
    the first time it appears in the body — **inline, in a few words, not in a
    separate glossary section**. Don't lean on vocabulary inherited from related
    RFCs as if the reader already holds it: a reviewer arrives at the RFC from the
-   index, cold. (RFC-0053 is the cautionary case — it had to be hand-patched with
+   index, cold. (The cautionary case: an RFC that has to be hand-patched with
    inline glosses *after* drafting because the draft assumed its siblings' terms;
    the cold-reader check in the gate, step 6, exists to catch this before
    handoff.)
@@ -342,8 +342,8 @@ present rules without diffing the whole log by hand:
   the section so a reader knows which layer to trust.
 - The layer *names* above are illustrative; the contract is the two-layer split
   (authoritative current state over a dated audit trail), not the exact heading
-  wording. RFC-0048 / PR #430 is the worked precedent this generalizes — it uses
-  "Current reconciliation state" over an "Amendment history / audit trail."
+  wording. One worked precedent uses "Current reconciliation state" over an
+  "Amendment history / audit trail."
 
 ### Append-only and supersession
 
@@ -358,8 +358,8 @@ present rules without diffing the whole log by hand:
   in-flight Amendments** (a Frozen RFC's entries can't be touched).
 - **Whole-RFC replacement is out of scope.** When an entire RFC — not one
   correction within it — is superseded by a later one, record that as an
-  **Errata entry naming the superseding RFC** (e.g. RFC-0012 carries an erratum
-  recording that its Alternative #7 was superseded by RFC-0052). This convention
+  **Errata entry naming the superseding RFC** (e.g. an RFC carries an erratum
+  recording that its Alternative #7 was superseded by a later RFC). This convention
   governs corrections *within* an RFC; it neither defines nor changes the
   whole-RFC-supersession mechanism.
 

--- a/packs/product-engineering/.apm/agents/discovery-threat-reviewer.md
+++ b/packs/product-engineering/.apm/agents/discovery-threat-reviewer.md
@@ -52,7 +52,7 @@ If any check fails, say so and stop.
 
 ## Depth & degradation (non-negotiable)
 
-Your *depth* keys on a **risk trigger** (mirroring RFC-0025). When an intent or
+Your *depth* keys on a **risk trigger**. When an intent or
 artifact crosses a **security boundary** (auth, untrusted-input-to-memory,
 regulated data):
 

--- a/packs/product-engineering/.apm/skills/discovery-loop/SKILL.md
+++ b/packs/product-engineering/.apm/skills/discovery-loop/SKILL.md
@@ -77,7 +77,7 @@ state-machine engine**. The proven pattern is **Hierarchical-Task-Network planni
 over a blackboard**: a *plan tree* held as data (`assets/plan-tree.md`), walked
 depth-first by **one controller** that decomposes the next node and updates
 status. The "state machine" is **status fields per node** + the decision log —
-*data the controller reads*, not an executed engine. *(AC2.)*
+*data the controller reads*, not an executed engine.
 
 `discovery-lead` is the **upstream supervisor — a *peer* of `work-loop`'s
 supervisor, not its supervisor.** It holds the blackboard in one context, fans out
@@ -87,7 +87,7 @@ at G3.
 **Honest bet.** Choosing the next node, accounting spend per branch, and deciding
 descend-vs-surface is itself in-context scheduling; the spike's single solo walk
 does not evidence it at depth. So the no-engine win is a **defensible bet on a
-shallow tree, gated conservatively by D4's depth/breadth bounds**. Scheduling many
+shallow tree, gated conservatively by the depth/breadth bounds**. Scheduling many
 concurrent or long-parked threads across initiatives stays the **harness's** job.
 
 ## The gate ladder
@@ -116,7 +116,7 @@ each other only through the open-questions queue — never chat**: *product*
 
 ## Consent gates are a pause, not a runtime
 
-A consent gate (G0, G1.5, G2) is a **pause**, not a special runtime *(AC10)*:
+A consent gate (G0, G1.5, G2) is a **pause**, not a special runtime:
 
 1. `discovery-lead` writes the decision brief, sets `status=awaiting-human`, and
    emits an **option card** — `{gate, summary, decisions-requested, recommended,
@@ -126,26 +126,25 @@ A consent gate (G0, G1.5, G2) is a **pause**, not a special runtime *(AC10)*:
    token for** (see Security).
 3. The next round reads the log and resumes.
 
-Non-consent gates auto-advance **unless a risk trigger (RFC-0025) fires**.
+Non-consent gates auto-advance **unless a risk trigger fires**.
 
 ## The verdict is a typed set, not yes/no
 
 The human's answer is richer than approve/reject. Each verdict has its own
 transition; **every blackboard-changing row reuses the one cascade mechanism**
-(walk traceability out-edges → mark `stale` → re-run only the affected lenses)
-*(AC12)*:
+(walk traceability out-edges → mark `stale` → re-run only the affected lenses):
 
 | Verdict | What the human means |
 | --- | --- |
 | **approve** | proceed as recommended |
 | **approve-with-constraint** | OK, but a scope cut that **must be honoured before proceeding** |
 | **redirect / steer** | not this — go *this* way |
-| **explore-alternatives** | show me other paths first (routes back to the D6 divergence phase) |
+| **explore-alternatives** | show me other paths first (routes back to the divergence phase) |
 | **abandon** | kill it (cascade the subtree to `abandoned`) |
 | **park / defer** | not now (resumable; advance siblings) |
 | **extend / override** | keep going past a bound (the row used at a `paused-at-bound` gate) |
 
-**Two integrity guards bind every row** *(AC13)*:
+**Two integrity guards bind every row**:
 
 1. **Impact-before-blast** — any verdict that would invalidate/change slots
    **first shows the affected set and waits for confirmation** before cascading.
@@ -157,13 +156,12 @@ transition; **every blackboard-changing row reuses the one cascade mechanism**
 
 Full per-verdict transitions, the rejection/recovery + cascade-invalidation
 transition, and the two-tier persistence + resume design are in
-[`references/gate-state-machine.md`](references/gate-state-machine.md). *(AC11,
-AC14, AC15.)*
+[`references/gate-state-machine.md`](references/gate-state-machine.md).
 
 ## Bounds — pause-and-confirm, never auto-terminal
 
 The `meta` block and each plan-tree node carry `round`/`round_cap` and
-`cost_budget`/`cost_spent` — **data counters, no runtime** *(AC16)*:
+`cost_budget`/`cost_spent` — **data counters, no runtime**:
 
 - **Per-initiative** enforcement (one budget + round cap for the whole tree).
 - **Per-node convergence round cap** + **per-node spend** (observability).
@@ -173,7 +171,7 @@ The `meta` block and each plan-tree node carry `round`/`round_cap` and
 - **Structural bounds** — a max sub-walk **depth** and max **open sub-ideas**
   (breadth), guarding against nesting explosion.
 
-**Every bound is a pause-and-confirm/override gate, not an auto-terminal** *(AC17)*:
+**Every bound is a pause-and-confirm/override gate, not an auto-terminal**:
 hitting any bound sets `status: paused-at-bound` (a *paused-awaiting-human* state,
 **not** a terminal `stalled` walk-away), writes an option card, and surfaces the
 verdict set (**extend/override** / narrow / park / abandon). A paused-at-bound
@@ -182,7 +180,7 @@ another consent gate.
 
 ## Supervisor topology — solo / lens-team, never chat-to-consensus
 
-`discovery-lead` right-sizes *(AC18)*:
+`discovery-lead` right-sizes:
 
 - **Solo** (small discovery) — holds the blackboard in one context, switches
   lenses itself. The prototype ran solo.
@@ -198,8 +196,8 @@ mesh consumes (the briefs / `contract@version` ids / backlogs), **not the mesh**
 
 ## The discovery roster — loop-scoped, required at G2
 
-The roster is **loop-scoped per RFC-0048's roster table** — this skill adds no
-roster of its own *(AC19)*:
+The roster is **loop-scoped** — this skill adds no
+roster of its own:
 
 - **Required at G2 reconcile:** `discovery-threat-reviewer` +
   `discovery-reliability-reviewer` — design-time roles (threat-modeling +
@@ -216,8 +214,8 @@ roster of its own *(AC19)*:
   blackboard; **value → the human at G2** (the conflict-adjudication act).
 
 The CHARTER's "three reviewers is the ceiling" stays a **`work-loop`/code-review
-cap**; the loop-scoped discovery roster is recorded as a **tracked RFC-0048
-amendment, not a CHARTER edit** *(AC20)*.
+cap**; the loop-scoped discovery roster is recorded as a **tracked amendment,
+not a CHARTER edit**.
 
 ## Security & integrity — falsifiable controls, not prose
 
@@ -228,63 +226,63 @@ full set (verdict write-authority, append-only attested log + hash-chain,
 non-degradable security lens, lens-write integrity, cascade circuit-breaker,
 `reversibility-class` enumeration, slot data-classification) is in
 [`references/security-and-integrity.md`](references/security-and-integrity.md).
-The load-bearing ones in brief *(AC25–AC31)*:
+The load-bearing ones in brief:
 
-- **No forged consent (AC25).** The `human` verdict is written through a
+- **No forged consent.** The `human` verdict is written through a
   **harness-attested channel the agent has no token for**. Resume **re-derives
   `human` provenance only from that untokened store and rejects any
   `ratified_by: human` row not attested there** — not self-asserted in a file the
-  agent also writes. The AC tests the *channel*, not the slot's append-only-ness.
+  agent also writes. The control tests the *channel*, not the slot's append-only-ness.
   **An adopter whose harness cannot provide an agent-untokened channel cannot run
   the loop unattended safely.**
-- **Decision log is a real audit trail (AC26).** Append-only + per-row actor
+- **Decision log is a real audit trail.** Append-only + per-row actor
   attestation + a **SHA-256 hash-chain whose tip is anchored in the
   agent-untokened / harness-immutable store** (the bare chain alone is re-chainable
   by the writing agent) + trusted timestamp, paired with a lint/CI add-only
   assertion.
-- **Non-degradable security lens on a boundary (AC27).** The
+- **Non-degradable security lens on a boundary.** The
   `discovery-threat-reviewer`'s *depth* keys on a risk trigger; a security-boundary
   crossing with only baseline depth installed **surfaces to the human** rather than
   degrading silently.
-- **Lens-write integrity (AC28).** A lens only *proposes*; only the controller
+- **Lens-write integrity.** A lens only *proposes*; only the controller
   promotes; untrusted external content is data, not instructions.
-- **Cascade circuit-breaker (AC29).** Cascade re-runs **count against the cost
+- **Cascade circuit-breaker.** Cascade re-runs **count against the cost
   budget**, and an invalidation exceeding a **fan-out threshold surfaces to the
   human** rather than auto-cascading — **default: more than `1/3` of the active
   matrix *or* more than `8` nodes absolute, whichever is smaller** (the absolute
   companion stops a shrink-the-denominator bypass).
-- **`reversibility-class` is an enumeration (AC30)** — `reversible` /
+- **`reversibility-class` is an enumeration** — `reversible` /
   `costly-to-reverse` / `one-way-door`; `one-way-door` binds to a **mandatory
   consent gate** regardless of which gate it arose at.
-- **Data-classification (AC31).** Each slot is classified; a
+- **Data-classification.** Each slot is classified; a
   `sensitive`/`regulated` slot is **redacted-or-surfaced before** the checkpoint
-  write reaches a shared store (the check composes with the checkpoint, AC8).
+  write reaches a shared store (the check composes with the checkpoint).
 
 ## Persistence & checkpointing
 
 The discovery-workspace is **durably checkpointed at each round and each consent
 gate** (not per keystroke) — to the **harness's own store/branch, never the
 product repo's main line** — under the data-classification controls, with the
-state branch **protected against history rewrite** *(AC8)*. This is what makes the
+state branch **protected against history rewrite**. This is what makes the
 loop resumable and the decision log a real audit trail. The two-tier persistence +
 the resume design (entry / reconstruction / re-entry by per-node status / integrity
 on resume) are in [`references/gate-state-machine.md`](references/gate-state-machine.md).
 
-**Cross-teardown resume — AC choice.** Tier 2 carries a **per-gate snapshot of
+**Cross-teardown resume.** Tier 2 carries a **per-gate snapshot of
 `meta` + per-node status** so cross-teardown resume is faithful (the recommended
-default — D4's bounds and "resume where it stopped" depend on the counters
+default — the bounds and "resume where it stopped" depend on the counters
 surviving). Absent the snapshot, cross-teardown resume is **gate-granularity only**,
-with the round/cost counters reset. *(AC15.)*
+with the round/cost counters reset.
 
 ## Seams with the rest of the operating model
 
 - **G3 handoff to `work-loop`** (unchanged): `discovery-loop` emits a brief →
-  `new-spec` → `work-loop`. Different inputs, verifier, autonomy posture. *(AC32.)*
-- **The self-coverage gate (RFC-0051) runs as the pre-G2 phase**, and
+  `new-spec` → `work-loop`. Different inputs, verifier, autonomy posture.
+- **The self-coverage gate runs as the pre-G2 phase**, and
   `discovery-loop` is the **primary home of the full seven-module
   design-convergence instantiation** — it carries its **own co-scoped copy of all
   seven modules** in `product-engineering`, right-sized by this loop's progressive
-  mode, conforming to RFC-0051's cross-loop seam (goal + resolve-vs-surface + a
+  mode, conforming to the cross-loop seam (goal + resolve-vs-surface + a
   non-skippable coverage record). Unlike `work-loop` (the net-new slice only),
   discovery runs the **full battery** — this is the altitude it was built for. The
   seven modules:
@@ -294,24 +292,24 @@ with the round/cost counters reset. *(AC15.)*
   [`fresh-context.md`](references/self-coverage/fresh-context.md),
   [`domain-grounding.md`](references/self-coverage/domain-grounding.md),
   [`resolve-vs-surface.md`](references/self-coverage/resolve-vs-surface.md),
-  [`coverage-record.md`](references/self-coverage/coverage-record.md). *(AC33.)*
-- **The traceability lint (child-4)** consumes the **traceability slot** this loop
-  produces; the D3 cascade transition walks **the same edges**. The loop runs the
+  [`coverage-record.md`](references/self-coverage/coverage-record.md).
+- **The traceability lint** consumes the **traceability slot** this loop
+  produces; the cascade transition walks **the same edges**. The loop runs the
   lint at the **G2 / convergence gate**: once the `Discovery:` up-edge header has
   landed (the producer — `new-spec` + `CONVENTIONS.md` § 4), the loop runs it
   **fail-closed (`--strict`)** at G2 so a structural orphan blocks convergence;
   **until the header is in place the lint stays warn-only** (specs without the
   header are warnings, not failures). Producer-before-consumer: the header lands
-  first, the `--strict` flip is sequenced after. *(AC37.)* **Child-4
-  dependency (MET):** the backstop against a disconnected-subtree failure relies on
+  first, the `--strict` flip is sequenced after. The backstop against a
+  disconnected-subtree failure relies on
   the lint's **root→leaf reachability** pass — and the lint now performs it, so the
   backstop catches the **whole** disconnected subtree, not just the orphan tip a
   presence check flags. A fabricated cross-repo edge is *surfaced* informationally
   (an open-world graph cannot tell a forged token from a not-yet-catalogued one),
-  never silently green. *(AC34.)*
+  never silently green.
 - **The backlog bridge:** the decision brief decomposes into an ordered,
   dependency-aware backlog (parked sub-ideas carried as **first-class entries**);
-  `loop-cohort` orders it; `work-loop` pulls one item at a time. *(AC35.)*
+  `loop-cohort` orders it; `work-loop` pulls one item at a time.
 
 ## Folding in traditional requirements capture
 
@@ -320,20 +318,20 @@ use cases / RTM) and adds **no requirements pillar of its own** — it *maps* th
 artifacts onto what it already produces, **ingests** them as input, and can **emit**
 in their format for sign-off. The full crosswalk is
 [`references/requirements-crosswalk.md`](references/requirements-crosswalk.md). In
-brief *(AC38)*:
+brief:
 
 - **Requirements as input** — `receive-brief` + `frame-intent` brownfield ingest
   seeds the loop (a thin `receive-brief` extension at most — **not** a new skill).
 - **The traceability slot serves as the RTM.**
 - **Requirements as output** — a formal BRD/SRS/RTM with sign-off rides the
-  **converters / md-to-office projection adapter** (RFC-0036), not a discovery
+  **converters / md-to-office projection adapter**, not a discovery
   skill.
 
 ## Loop-skill doctrine (carried here, not in CONVENTIONS)
 
 The **two-loop split** (discovery vs delivery) and the **surfacing predicate's
 stall clause** are carried in **this skill's doctrine — not a `CONVENTIONS.md`
-operating-model section** *(AC41)*:
+operating-model section**:
 
 - **Two loops, not one.** Discovery (vision → brief, this loop) and delivery (spec
   → build, `work-loop`) have different inputs, verifiers, and autonomy postures.

--- a/packs/product-engineering/.apm/skills/discovery-loop/assets/plan-tree.md
+++ b/packs/product-engineering/.apm/skills/discovery-loop/assets/plan-tree.md
@@ -4,10 +4,10 @@ This is the **instantiable scaffold** for the recursive intent tree
 (`_state/plan-tree.json`). `discovery-lead` **copies it to start an initiative**
 and fills it in as the loop runs. It is what makes "HTN-over-blackboard, no
 engine" a *concrete artifact the controller fills and the traceability lint
-walks* — **there is no planner engine; the template is the mechanism.** *(AC6.)*
+walks* — **there is no planner engine; the template is the mechanism.**
 
-A **node** is an `intent` slot + `parent_id` (so the tree nests — Decision 1) +
-a **per-node status lifecycle** + the **Decision 6** shapes (a candidate set +
+A **node** is an `intent` slot + `parent_id` (so the tree nests) +
+a **per-node status lifecycle** + the **two extension** shapes (a candidate set +
 selection, and a validation status + hook). One plan-tree per initiative; relate
 initiatives by stable id, never by sharing a tree.
 
@@ -23,7 +23,7 @@ Each node carries (and the conformance lint walks):
 - **`candidates` + `selection`** (at a divergence point) — N sibling candidate
   shapes under a `diverging` parent, and the one promoted to `converging`. The
   **not-chosen are retained** as `rejected` / `parked` **with rationale** — never
-  deleted, so they stay revivable (D3 persistence + `decision-archaeology`'s
+  deleted, so they stay revivable (durable persistence + `decision-archaeology`'s
   revival check).
 - **`validation_hook`** — the kill-condition + the real-world activity that would
   confirm or enrich the node's load-bearing assumption.
@@ -109,14 +109,14 @@ node knows where it is from its `lifecycle` + `validation_status`.
 2. **Account spend per branch.** Increment the node's `round` / `cost_spent`; the
    `meta` block bounds the whole initiative. A node exceeding the **concentration
    bound** (~40% of budget) or the **depth/breadth** structural bounds pauses the
-   loop at `paused-at-bound` (Decision 4) — never a silent stop.
+   loop at `paused-at-bound` — never a silent stop.
 3. **Validate, don't just converge.** When a node ratifies, set its
    `validation_status` and attach a `validation_hook` (via `plan-validation`); the
    provisional spine at G2 labels every node **grounded** / **surfaced** /
    **to-validate**.
 4. **Surface descend-vs-park.** Choosing the next node, accounting spend, and
    deciding descend-vs-surface is itself scheduling the controller does
-   in-context — **a defensible bet on a shallow tree**, gated by the D4
+   in-context — **a defensible bet on a shallow tree**, gated by the
    depth/breadth bounds. Scheduling many concurrent / long-parked threads stays
    the **harness's** job.
 

--- a/packs/product-engineering/.apm/skills/discovery-loop/references/agentbundle-layout.md
+++ b/packs/product-engineering/.apm/skills/discovery-loop/references/agentbundle-layout.md
@@ -6,9 +6,8 @@ projected path; you create it by hand (or an `agentbundle install` step appends 
 default section to one you already have — **append-if-exists / never-create /
 never-overwrite**). This page **mints and documents** the `[discovery]` section
 that `discovery-loop` (and the discovery-side skills `frame-domain` /
-`explore-options` / `plan-validation`) read — the discovery-tree layout key
-RFC-0048 § Amendments (DRIFT-C) assigns this implementing spec to mint, on the
-`[experience]` precedent.
+`explore-options` / `plan-validation`) read — the discovery-tree layout key this
+skill mints, on the `[experience]` precedent.
 
 > **Why its own table, not `[product-engineering]` or `[pack.layout]`.** The
 > `[<pack>]` *adopter-file* table is the read target (not the manifest-side
@@ -37,7 +36,7 @@ parent = "docs/discovery"   # a base directory; one subdirectory per initiative 
   directories; they cross-link by stable id, never by sharing a tree.
 - **Lazy creation.** Directories are created on first write, never up front.
 
-## Three-tier resolution (RFC-0040)
+## Three-tier resolution
 
 `discovery-loop` resolves the discovery root in this order — **config → designed
 default → discover-by-marker** — and surfaces ambiguity rather than guessing:

--- a/packs/product-engineering/.apm/skills/discovery-loop/references/requirements-crosswalk.md
+++ b/packs/product-engineering/.apm/skills/discovery-loop/references/requirements-crosswalk.md
@@ -5,7 +5,7 @@ requirements work — a BRD, a PRD, an SRS/FRD, use cases, a requirements-tracea
 matrix (RTM) — and often refine requirements at several levels at different times.
 This loop does **not** replace that and adds **no requirements pillar of its own**;
 it *maps* those artifacts onto what it already produces, **ingests** them as input,
-and can **emit** in their format for sign-off. *(AC38.)*
+and can **emit** in their format for sign-off.
 
 ## The crosswalk
 
@@ -39,7 +39,7 @@ and can **emit** in their format for sign-off. *(AC38.)*
 - **Requirements as output (emit for sign-off).** Where governance *requires* a
   formal BRD/SRS/RTM with sign-off, the loop **projects** its decision brief +
   traceability matrix + spec ACs into that format — a **formatting/projection
-  adapter** (the converters / md-to-office path, RFC-0036), **not** a discovery
+  adapter** (the converters / md-to-office path), **not** a discovery
   skill; the decision-log + the security & integrity controls supply the auditable
   sign-off trail.
 

--- a/packs/product-engineering/.apm/skills/discovery-loop/references/security-and-integrity.md
+++ b/packs/product-engineering/.apm/skills/discovery-loop/references/security-and-integrity.md
@@ -7,7 +7,7 @@ implementing run can falsify** — not prose. The decision-log row schema and th
 data-classification table live in
 [`sidecar-schema.md`](sidecar-schema.md); this file is *how the controls behave*.
 
-## 1. Verdict write-authority — no forged consent *(AC25)*
+## 1. Verdict write-authority — no forged consent
 
 The *same* reasoning context both sets `status=awaiting-human` and reads the
 decision log to resume, so the contract must prevent the controller (or a poisoned
@@ -32,7 +32,7 @@ human never saw.
   records that the forged row is **rejected/flagged** (or, for a harness without the
   untokened channel, records that the loop **refuses unattended operation**).
 
-## 2. Decision-log as a real audit trail *(AC26)*
+## 2. Decision-log as a real audit trail
 
 The slot is **append-only** + **per-row actor attestation** + **tamper-evidence** +
 a **trusted timestamp**, paired with a lint/CI assertion that the slot's commits
@@ -48,8 +48,8 @@ are add-only.
   tamper-evident against the in-scope adversary (the agent that writes it). The
   chain is tamper-evident **only when its tip is anchored where the agent has no
   token to rewrite it** — the **same agent-untokened / harness-immutable store as
-  the AC25 verdict channel** (or the tip is signed with a key the agent lacks). The
-  falsifiable AC26-(a) requirement is **that anchored tip**, not the bare hash
+  the verdict channel in control 1** (or the tip is signed with a key the agent lacks). The
+  falsifiable requirement for option (a) is **that anchored tip**, not the bare hash
   field; the verify-lint compares the recomputed chain against the
   externally-held tip. **or**
 - **(b) a harness-provided immutable log** — an explicit harness-conformance
@@ -58,21 +58,21 @@ are add-only.
 The validation run exercises a **tamper attempt** (an in-place prior-row edit) and
 records that it is **detected**.
 
-## 3. Non-degradable security lens on a boundary *(AC27)*
+## 3. Non-degradable security lens on a boundary
 
 The `discovery-threat-reviewer` is a hard dep (required at G2; ships in
 `product-engineering`, the floor) and degrades only in *depth* — never silently
 skipped. Its baseline checklist must not silently stand in for full depth on a
 security-relevant product.
 
-- Tie the lens's *depth* to a **risk trigger** (mirroring RFC-0025 / the surfacing
+- Tie the lens's *depth* to a **risk trigger** (mirroring the surfacing
   predicate): when an intent or artifact crosses a security boundary (auth,
   untrusted-input-to-memory, regulated data) **and** `core`'s `security-checklists`
   depth is absent (only the reviewer's baseline checklist is available), the loop
   **surfaces to the human** — *"security-relevant boundary crossed, only baseline
   security depth installed"* — rather than degrading silently.
 
-## 4. Lens-write integrity — no blackboard poisoning *(AC28)*
+## 4. Lens-write integrity — no blackboard poisoning
 
 In lens-team mode, lens-agents write the blackboard the controller trusts for
 convergence and cascade-invalidation; a lens that ingests untrusted external
@@ -91,7 +91,7 @@ content (web `research`, adopter docs) is an injection sink.
   implementer satisfies this control by wiring the marker + the inert-promote rule,
   not by repeating the property.
 
-## 5. Cascade-invalidation circuit-breaker *(AC29)*
+## 5. Cascade-invalidation circuit-breaker
 
 The edge-walk *scopes* a rejection, but the same primitive is a
 denial-of-convergence lever (spurious edges from a high-fan-out node could
@@ -99,7 +99,7 @@ invalidate the whole blackboard and burn the budget).
 
 - Cascade re-runs **count against the cost budget**.
 - An invalidation exceeding a **fan-out threshold surfaces to the human** rather
-  than auto-cascading. The threshold is a **spec-tunable default** (mirroring D4's
+  than auto-cascading. The threshold is a **spec-tunable default** (mirroring the
   ~40% concentration default — a modelled-not-run control must not ship without a
   value): **surface when an invalidation touches more than `1/3` of the active
   matrix *or* more than `N` nodes absolute (default `N = 8`), whichever is
@@ -111,7 +111,7 @@ invalidate the whole blackboard and burn the budget).
 - The validation run **forces one over-threshold invalidation** and records that it
   **surfaced** rather than auto-cascading.
 
-## 6. `reversibility-class` is an enumeration *(AC30)*
+## 6. `reversibility-class` is an enumeration
 
 It gates consent stakes, so an agent must not under-classify a one-way door as
 `reversible`.
@@ -121,7 +121,7 @@ It gates consent stakes, so an agent must not under-classify a one-way door as
 - `one-way-door` binds to a **mandatory consent gate regardless of which gate it
   arose at**.
 
-## 7. Sidecar data-handling / classification *(AC31)*
+## 7. Sidecar data-handling / classification
 
 The slots carry product strategy, personas, security findings, customer/domain
 facts, and consent rationale — sensitive and potentially regulated data.
@@ -135,7 +135,7 @@ facts, and consent rationale — sensitive and potentially regulated data.
 - **A regulated- or secret-bearing artifact surfaces** to the human /
   `discovery-threat-reviewer` before being written to a shared repo-backed
   sidecar — the same surface-don't-degrade-silently posture as control 3.
-- **Composition with the checkpoint (AC8).** The classification check is a
+- **Composition with the checkpoint.** The classification check is a
   **precondition on the per-round/per-gate checkpoint write**: a
   `sensitive`/`regulated` slot is redacted-or-surfaced **before** it reaches the
   shared store, not as a separate later step. The two requirements **compose** —

--- a/packs/product-engineering/.apm/skills/discovery-loop/references/self-coverage/coverage-record.md
+++ b/packs/product-engineering/.apm/skills/discovery-loop/references/self-coverage/coverage-record.md
@@ -1,16 +1,16 @@
 # Self-coverage gate — the module index + the coverage record
 
 `discovery-loop` is the **primary home of the full seven-module design-convergence
-instantiation** of RFC-0051's self-coverage gate. Unlike `work-loop` (which adopts
+instantiation** of the self-coverage gate. Unlike `work-loop` (which adopts
 only the net-new slice atop the passes it already runs), discovery runs the **full
 battery** — this is the altitude it was built for. The gate runs as the **pre-G2
 phase**, right-sized by this loop's progressive mode (solo runs it lean; a
-lens-team run runs it in full). *(AC33.)*
+lens-team run runs it in full).
 
 This is `discovery-loop`'s **own co-scoped copy** of the modules; it does not
 import `work-loop`'s copy (which carries only `resolve-vs-surface`). A schema/seam
-change moves both copies — they conform to the **same cross-loop seam** RFC-0051
-fixes (the goal + resolve-vs-surface + a non-skippable coverage record), never
+change moves both copies — they conform to the **same cross-loop seam**
+(the goal + resolve-vs-surface + a non-skippable coverage record), never
 re-worded.
 
 ## The discipline
@@ -48,5 +48,5 @@ record** — a short, durable artifact (promoted into the decision-log / brief) 
 
 **Done-checklist refusal.** The loop does **not** declare G2 reached until the
 coverage record exists and every fresh-context finding is resolved. This refusal
-item is what makes the gate non-skippable — the same backstop RFC-0051's seam
+item is what makes the gate non-skippable — the same backstop the cross-loop seam
 requires of every loop.

--- a/packs/product-engineering/.apm/skills/discovery-loop/references/self-coverage/fresh-context.md
+++ b/packs/product-engineering/.apm/skills/discovery-loop/references/self-coverage/fresh-context.md
@@ -14,7 +14,7 @@ reviewer toward agreeing).
 
 ## Who runs
 
-The **loop-scoped discovery reviewer roster** (selected per ADR-0042, keyed to
+The **loop-scoped discovery reviewer roster** (keyed to
 loop + work type), **required at G2 reconcile**:
 
 - **`discovery-threat-reviewer`** — the threat-modeling + regulated-domain

--- a/packs/product-engineering/.apm/skills/discovery-loop/references/self-coverage/resolve-vs-surface.md
+++ b/packs/product-engineering/.apm/skills/discovery-loop/references/self-coverage/resolve-vs-surface.md
@@ -4,7 +4,7 @@ The calibration reference for the [self-coverage gate](coverage-record.md)'s
 coverage record. The loop reaches the right resolve-vs-surface call only about half
 the time without a scaffold; an explicit rubric plus calibrated examples climbs
 that rate. This is `discovery-loop`'s **own per-loop copy** — a distinct file from
-`work-loop`'s, conforming to the **same cross-loop seam** RFC-0051 fixes, never
+`work-loop`'s, conforming to the **same cross-loop seam**, never
 re-worded.
 
 ## The rubric
@@ -57,6 +57,6 @@ referent or trigger, and the **tell** — the cue that should have fired.
   (over the fan-out threshold; impact-before-blast). *Tell: a large blast radius is
   itself a surface trigger, however correct the edge-walk.*
 - *Parent pre-decided the value calls → resolve, don't re-surface.* When every
-  candidate surface item traces to a referent RFC-0053 / RFC-0048 already cited, the
+  candidate surface item traces to a referent already cited, the
   honest output is a recommendation, not a question. *Tell: a child must not
   re-litigate what the foundation settled.*

--- a/packs/product-engineering/.apm/skills/discovery-loop/references/sidecar-schema.md
+++ b/packs/product-engineering/.apm/skills/discovery-loop/references/sidecar-schema.md
@@ -12,7 +12,7 @@ self-discovered skill, and **not** duplicated as prose in `work-loop`.
 > read the produced `_state/` instances **by slot-name + the `schema_version`
 > stamp** and check compatibility. They never import this file. A schema bump
 > moves this definition and its producing skill (`discovery-loop`) **atomically**,
-> so there is one owner and no cross-pack version skew. *(AC3.)*
+> so there is one owner and no cross-pack version skew.
 
 **Current `schema_version`: `0.1`.** This is the value the traceability lint
 recognizes (`lint-traceability`'s `KNOWN_SCHEMA_VERSIONS`); an instance carrying
@@ -36,7 +36,6 @@ the bump.
 
 Working state and durable record are split into two tiers, and there is **one
 plan-tree per initiative** — a *forest*, never one master tree the loop walks.
-*(AC7.)*
 
 - **Tier 1 — the working store (`_state/`).** Durable while the initiative is
   active; the live plan-tree, slot statuses, the `meta` counters. Torn down on
@@ -69,16 +68,15 @@ default, else elicited; **dirs created lazily on first write**):
 ```
 
 **Initiatives that relate cross-link by stable ids** — slug / `contract@version`
-/ Backstage `kind:namespace/name` (the ADR-0022 cross-boundary convention) —
+/ Backstage `kind:namespace/name` (the cross-boundary convention) —
 **never by sharing a tree**. A portfolio index across initiatives is **not** a
 contract file; it is the harness's (concurrency/scheduling) or an adopter
 roadmap.
 
 ## The five working slots
 
-Field-sets are given as the prototype instantiated them
-(`<rfc-0053-notes>/spike/`). All working slots carry `initiative` and
-`schema_version`.
+Field-sets are given as the prototype instantiated them. All working slots carry
+`initiative` and `schema_version`.
 
 ### 1. `blackboard` — the typed artifact slots
 
@@ -108,7 +106,7 @@ The artifact inventory. Each slot:
 | `lens` | `product \| research \| ux \| design \| tech \| controller \| security \| reliability` |
 | `path?` | the Tier-2 committed artifact's path, when it has one |
 | `round_last_touched` | the convergence round it last changed in |
-| `parent_id?` | **the optional pointer that makes `intent` slots nest into a recursive tree** (Decision 1) |
+| `parent_id?` | **the optional pointer that makes `intent` slots nest into a recursive tree** |
 
 The blackboard carries a **`meta` block** (or a sibling `meta.json`) — see slot 5.
 
@@ -135,7 +133,7 @@ chat** (the MAST guardrail). Each entry:
 
 **This slot is the lint-authoritative file** (`_state/traceability.json`,
 **JSON**). The traceability lint reads it by convention + the `schema_version`
-stamp; the D3 cascade transition walks **the same edges**.
+stamp; the cascade transition walks **the same edges**.
 
 ```json
 {
@@ -157,15 +155,14 @@ stamp; the D3 cascade transition walks **the same edges**.
 
 - **typed `nodes`** — each `{id, kind, backed_by}`. `backed_by ∈ file | container
   | ladder`: `file` (its own file), `container` (an entry embedded in a
-  journey-map / service-blueprint), `ladder` (a rung of the intent ladder — the
-  child-4 reconciliation that four chain rungs are intent-ladder rungs, not
-  files).
+  journey-map / service-blueprint), `ladder` (a rung of the intent ladder — four
+  chain rungs are intent-ladder rungs, not files).
 - **`edges`** — `{from = producer, to = consumer}`.
 - **`root`** (exempt from an in-edge) and **`leaf_kind`** (exempt from an
   out-edge); every other node needs both.
 - **Node ids are stable and location-independent** (slug / `contract@version` /
   `kind:namespace/name`), so the chain crosses repo boundaries by convention, not
-  path (the ADR-0022 reuse).
+  path (the cross-boundary id reuse).
 
 The canonical chain the lint walks is
 `outcome → opportunity → capability → screen → action → service → contract →
@@ -195,17 +192,16 @@ properties below. Canonical field order:
 | `gate` | the gate the decision was made at (`G0`, `G1.5`, `G2`, a bound pause, …) |
 | `decision` | the verdict (one of the typed verdict set — see the skill) |
 | `ratified_by` | `human \| discovery-lead` — **per-row actor attestation** |
-| `reversibility_class` | the enumeration `reversible \| costly-to-reverse \| one-way-door` (never free text — AC30) |
+| `reversibility_class` | the enumeration `reversible \| costly-to-reverse \| one-way-door` (never free text) |
 | `rationale` | why |
-| `prev_hash`, `hash` | **the hash-chain** — each row's `hash` is a **SHA-256** over the row's canonical-field-order JSON **plus the prior row's `hash`** (AC26 option (a)). Tamper-evident **only when the chain tip is anchored** in the agent-untokened / harness-immutable store (see below) |
+| `prev_hash`, `hash` | **the hash-chain** — each row's `hash` is a **SHA-256** over the row's canonical-field-order JSON **plus the prior row's `hash`** (the anchored-hash-chain option). Tamper-evident **only when the chain tip is anchored** in the agent-untokened / harness-immutable store (see below) |
 
-**Integrity properties (each a hard AC the skill enforces):**
+**Integrity properties (each a hard requirement the skill enforces):**
 
 - **Append-only** — paired with a lint/CI assertion that the slot's commits are
   add-only.
 - **Per-row actor attestation** — the `ratified_by` field, and a **`human` row
-  the controller cannot forge** (written through the harness-attested channel —
-  AC25).
+  the controller cannot forge** (written through the harness-attested channel).
 - **Tamper-evidence — verified, not asserted.** The schema ships a **hash-chain**
   (`prev_hash`/`hash`, SHA-256 over canonical-field-order JSON + the prior hash) so
   an in-place edit of a prior row's `rationale`/`decision` that keeps the
@@ -216,7 +212,7 @@ properties below. Canonical field order:
   token to rewrite it** (the same agent-untokened / harness-immutable store as the
   verdict channel, or a signature over a key the agent lacks). Alternatively, an
   adopter whose harness provides an **immutable log** may delegate the chain to it
-  — recorded as an explicit harness-conformance precondition (AC26 option (b)). See
+  — recorded as an explicit harness-conformance precondition (the immutable-log option). See
   `security-and-integrity.md` control 2.
 - **Trusted timestamp** — the `ts` field, ideally harness-provided.
 
@@ -239,28 +235,28 @@ Carried on the blackboard (or a sibling `meta.json`):
 `status` carries the **meta gate-state** namespace — `awaiting-human` /
 `paused-at-bound` / `stalled-at-cap` (plus working values like `converged`). The
 counters (`round`/`round_cap`, `cost_budget`/`cost_spent`) are **data the
-controller increments — no runtime** (Decision 4). Each plan-tree node carries
+controller increments — no runtime**. Each plan-tree node carries
 its own `round`/`round_cap` + `cost_spent` too (per-node spend for observability
 + the concentration bound).
 
-## Two extension slots (Decision 6)
+## Two extension slots
 
 - **`validation-plan`** — the assumption → kill-condition → real-world-activity
   ledger `plan-validation` produces. Each entry `{assumption, kill_condition,
   activity, validation_status}` where `validation_status ∈ hypothesis →
   validating → validated | refuted`. This makes *converged ≠ validated* a
-  **structural property** of the workspace. *(AC22, AC23.)*
+  **structural property** of the workspace.
 - **The `decision-brief`'s required success-metrics / North-Star slot.** The
   decision-brief slot carries a **required, structured** `success_metrics` field
   (the outcome + its North-Star + done-criterion). A brief **cannot reach G3
   without it** — so the build loop always has a done-criterion to iterate
   against. It is **not** a new skill (`frame-intent` / `decompose-intent` already
   name outcomes); it is a required slot. Metric *instrumentation* stays downstream
-  / out of charter. *(AC24.)*
+  / out of charter.
 
 ## Three status namespaces, not one drifting enum
 
-The statuses live on **distinct fields** *(AC5)*:
+The statuses live on **distinct fields**:
 
 | Namespace | Field | Values |
 | --- | --- | --- |
@@ -275,14 +271,14 @@ A single verdict typically writes across **more than one** namespace.
 
 Which fields each verdict writes (the controller is the writer; every
 blackboard-changing row **reuses the one cascade mechanism** — walk traceability
-out-edges → mark `stale` → re-run only the affected lenses) *(AC5, AC12)*:
+out-edges → mark `stale` → re-run only the affected lenses):
 
 | Verdict | Slot status | Node lifecycle | Meta / log |
 | --- | --- | --- | --- |
 | **approve** | gate's slots → `ratified` | node → `ratified` | log row; advance |
 | **approve-with-constraint** | constrained slots re-run; touched → `proposed`→`ratified` on re-converge | node stays `converging` until re-converged | record constraint in Scope Boundary; **do not advance** |
 | **redirect / steer** | obsoleted slots → `stale` (after impact-before-blast confirm) | node re-enters `converging` with the steer | new `intent` steer; cascade the scoped set |
-| **explore-alternatives** | — | node → `diverging` (route back to D6) | regenerate candidate shapes |
+| **explore-alternatives** | — | node → `diverging` (route back to divergence) | regenerate candidate shapes |
 | **abandon** | subtree slots → `stale` | node → `abandoned` | log kill + rationale; close node |
 | **park / defer** | — | node → `parked` (in the sub-idea index) | resumable; advance siblings |
 | **extend / override** | — | node resumes prior lifecycle | grant `round_cap`/`cost_budget` or lift a bound; the row used at a `paused-at-bound` gate |
@@ -291,7 +287,7 @@ out-edges → mark `stale` → re-run only the affected lenses) *(AC5, AC12)*:
 
 The would-be writers are **not all in one pack** (lenses span `experience` /
 `architect` / `contracts`), so same-pack co-location cannot be the guarantee.
-Drift is prevented structurally *(AC9)*:
+Drift is prevented structurally:
 
 1. **The controller is the principal slot-writer.** Cross-pack lenses emit their
    **native artifacts** (a journey map, a C4 model) and *propose* through the
@@ -315,12 +311,12 @@ A lens may only **propose** (`status: proposed`); **only the controller
 promotes** to `ratified`. Lens-asserted traceability edges are **advisory until
 the controller validates** them. Any lens ingesting untrusted external content
 (web `research`, adopter docs) is a **trust boundary** whose output is **data,
-not instructions**, to the controller. *(AC28.)*
+not instructions**, to the controller.
 
 ## Data classification & handling
 
 Each slot carries — or the skill assigns at write time — a **data-classification
-level** *(AC31)*:
+level**:
 
 | Level | Examples in this schema | Handling |
 | --- | --- | --- |
@@ -336,7 +332,7 @@ level** *(AC31)*:
   retention/export policy; the state branch is **protected against history
   rewrite** (so the decision-log's append-only/hash-chain properties hold).
 - **The classification check is a precondition on the per-round/per-gate
-  checkpoint write** (it composes with the D2 checkpoint requirement, not a
+  checkpoint write** (it composes with the checkpoint requirement, not a
   separate later step): a `sensitive`/`regulated` slot is **redacted-or-surfaced
   before** it reaches the shared store. The two requirements **compose** — they
   are not independently satisfiable.

--- a/packs/product-engineering/.apm/skills/frame-domain/SKILL.md
+++ b/packs/product-engineering/.apm/skills/frame-domain/SKILL.md
@@ -46,7 +46,7 @@ Before framing, confirm:
 This skill is **invokable standalone** with **no hard dependency on the
 coordinator / discovery-loop** (which is unbuilt). It produces on demand; the
 non-skippable "cannot proceed without it" gate property is the coordinator's to
-own (RFC-0048 child 5), not this skill's.
+own, not this skill's.
 
 ## Wrapping `research` applied mode — the real-world-activity half
 
@@ -169,7 +169,7 @@ literal path**; it always runs the three tiers and surfaces ambiguity rather tha
 guessing.
 
 1. **Config — the adopter's discovery base from `agentbundle-layout.toml`.** Read
-   the adopter-created `agentbundle-layout.toml` (RFC-0040 / ADR-0030 adopter-file
+   the adopter-created `agentbundle-layout.toml` (the adopter-file
    mechanism) for the **discovery base** the cross-cutting layout effort settles.
    `docs/discovery/` is a **shared discovery-loop home**, so its config key is the
    **discovery layout key** — **not** `product-engineering`'s file-per-slug
@@ -181,8 +181,7 @@ guessing.
    **not** mint a new table itself, and it never *writes* the layout file.
 2. **Designed default** — `docs/discovery/<initiative>/domain-framing.md` and
    `docs/discovery/<initiative>/scope-boundary.md`. `docs/discovery/` is a
-   *resolved default*, not a path this skill mints (RFC-0048's layout note
-   introduces it).
+   *resolved default*, not a path this skill mints.
 3. **Discover-by-marker** — search the workspace for each artifact's **canonical
    filename + frontmatter `type:`** (`domain-framing.md` + `type: domain-framing`,
    `scope-boundary.md` + `type: scope-boundary`). The **marker, not the path, is
@@ -200,7 +199,7 @@ eventually bound, surface the resolved path before the first write and reject an
 ## Detect-and-degrade on optional dependencies
 
 `research` and `decision-archaeology` are **optional, Tier-1 detect-and-degrade**
-dependencies (RFC-0048 Decision 8 progressive enhancement). Because this is a
+dependencies (progressive enhancement). Because this is a
 prompt-only skill with no script, the **detect primitive is the agent checking
 its available-skills roster** — the same roster-check `new-spec` already relies on
 — **not** a body-level `shutil.which`.
@@ -246,4 +245,4 @@ If `research` (or, in brownfield, `decision-archaeology`) is **not installed**:
 - **Hardcoding a write path.** Always run the three-tier resolve and surface
   ambiguity; never write to a literal path.
 - **Promoting this skill to a mandatory gate.** It produces standalone; the
-  non-skippable enforcement is the coordinator's (RFC-0048 child 5).
+  non-skippable enforcement is the coordinator's.

--- a/packs/product-engineering/.apm/skills/frame-domain/examples/example-assistant.md
+++ b/packs/product-engineering/.apm/skills/frame-domain/examples/example-assistant.md
@@ -4,7 +4,7 @@
 > `frame-domain` run and the two typed artifacts it produces. Your domain will
 > look different; copy the *moves*, not the wording.
 
-The RFC-0048 worked example — `example-assistant`, a secure personal-assistant
+A worked example — `example-assistant`, a secure personal-assistant
 agent that helps an owner plan recurring tasks, track resource state, generate a
 derived list, and improve through approved learning. After `decompose-intent`
 produced its capabilities, the agent runs `frame-domain` at **G1.5 Domain &

--- a/packs/product-engineering/.apm/skills/frame-intent/references/intent-model.md
+++ b/packs/product-engineering/.apm/skills/frame-intent/references/intent-model.md
@@ -94,7 +94,7 @@ deeper than any tracker, and projects **one-way** onto trackers (see
 
 When you run the discovery-traceability chain, the structural-orphan lint walks the
 nine-node product chain `outcome → opportunity → capability → screen → action →
-service → contract → spec → component` (RFC-0048 note 04 — the opportunity-solution
+service → contract → spec → component` (the opportunity-solution
 tree viewed as a structural chain, with the North-Star **outcome** as its root and
 **opportunities** as its children). An intent declares which **chain rung** it
 occupies through two **optional** markers the lint reads:

--- a/packs/research/.apm/skills/research-project-start/SKILL.md
+++ b/packs/research/.apm/skills/research-project-start/SKILL.md
@@ -143,7 +143,7 @@ from the brief.
 This generalises the read `research-project-mode` shipped via the old
 `research-layout.toml` into the shared `agentbundle-layout.toml` `[research]`
 table — a **clean rename, no alias** (the old file was undistributed, so nothing
-in the wild holds the old name). RFC-0038's forward-only migration alias was
+in the wild holds the old name). A forward-only migration alias was
 considered and found not to apply.
 
 ## Source provenance — optional, additive axes

--- a/packs/research/.apm/skills/research/SKILL.md
+++ b/packs/research/.apm/skills/research/SKILL.md
@@ -157,7 +157,7 @@ derived from the research question — "OAuth PKCE for SPAs" → `oauth-pkce`;
 single investigation so that study's artifacts sort together.
 
 **Type vocabulary.** The `<type>` stem is fixed by the research mode and the
-shape of the answer (RFC-0039 Decision 2):
+shape of the answer:
 
 | Mode / answer shape | Artifact |
 |---|---|
@@ -179,7 +179,7 @@ the answer takes that shape — a `fact-check` verdict, a decision
 type-descriptive stems (`perspectives`, `outline`, `sources`, `archaeology`).
 
 **Legacy alias.** `research.md` was the prior name for the survey artifact,
-retained as a recognised legacy alias for one release (RFC-0038 forward-only
+retained as a recognised legacy alias for one release (a forward-only
 migration) so existing references and muscle memory still resolve. The skill
 emits **only** the typed name — never a second `research.md` written alongside
 it.

--- a/tools/hooks/work-loop-check.py
+++ b/tools/hooks/work-loop-check.py
@@ -3,12 +3,12 @@
 work-loop skill for non-trivial work.
 
 Wired to the per-prompt event of each tool's hook surface — Claude Code
-`UserPromptSubmit` (and Copilot / Cursor / Gemini / Codex equivalents)
-via `.apm/hook-wiring/work-loop-check.toml`. The Kiro IDE counterpart is
-`.apm/kiro-ide-hooks/work-loop-check.kiro.hook` (an `askAgent` hook on
-`promptSubmit`), which carries the *same* instruction as a prompt because
-the IDE drops hook-wiring and `runCommand` does not feed the agent. Keep
-the two messages semantically aligned (both must mention `work-loop`).
+`UserPromptSubmit`, the Codex equivalent in `.codex/hooks.json`, and the
+Copilot / Cursor / Gemini equivalents. Kiro IDE gets the same nudge via a
+companion `promptSubmit` hook that carries the *same* instruction as a
+prompt (the IDE drops hook-wiring and `runCommand` does not feed the
+agent), so keep the two messages semantically aligned (both must mention
+`work-loop`). See `tools/hooks/README.md` § Wiring for what lands where.
 
 Pure-stdlib, input-free: prints a fixed reminder to stdout and exits 0.
 It deliberately does not parse the prompt or classify triviality — that


### PR DESCRIPTION
## What

Removes the bundle's **internal governance citations** (`RFC-00xx`, `ADR-00xx`, `docs/rfc/…`, `docs/adr/…`, and allied spec task / `AC` / `Decision` provenance) from **shipped skill content**, rewriting each as a self-contained rule. Adopters install these skills *without* the bundle's `docs/` tree, so a dangling `RFC-00xx` pointer was an unresolvable reference. The rules are unchanged — only the provenance citations are gone. Real external standards (RFC-1918, RFC-9457, …) are left intact.

Scope swept: `core`, `governance-extras`, `atlassian`, `converters`, `research`, `product-engineering` — SKILL.md bodies, reference docs, subagent prompts, and script comments/docstrings.

## Also in this PR

- **Empty `except` handlers** in `lint-brief-coverage` / `lint-spec-status` / `lint-traceability` `_repo_root()` and `loop-cohort` `write_state_atomic` now carry explanatory comments (behavior unchanged).
- **Dropped unused `import shutil`** from `loop-cohort.py`.
- **`.claude/skills/README.md` inventory** now matches the projected skill set — removed `new-package`, de-stubbed `new-guide`, added `receive-brief` / `init-project` / `contract-acquisition` / `security-checklists` / `operational-safety`.
- **`work-loop` activation-hook docstring** points at `tools/hooks/README.md` § Wiring instead of bundle-internal `.apm/` paths (misleading in the projected `tools/hooks/` copy).
- **`docs/product/roadmap.md`** (and its seed) marked explicitly as a scaffolded **template** rather than carrying bare `YYYY-MM-DD` placeholders as if real.

Sources edited under `packs/<pack>/.apm/**` (and `packs/core/seeds/**`); `.claude/` and `.agents/` projections regenerated via `build-self`.

## Deliberately out of scope (surfaced as decisions)

- **`.codex/hooks.json` keeps bare `python`** (not `python3`). It is *generated* from a single shared wiring TOML consumed by all five adapters, and bare `python` is the documented Windows + POSIX single-string portability convention (`tools/hooks/README.md` § Runtime). A `python3` change would diverge Codex from every other adapter and contradict the convention.
- **`packs/credential-brokers/.apm/user-libs/credbroker/`** is a byte-wise projection of the published `packages/credbroker` library (enforced by a drift gate), not skill content — its internal RFC provenance is left as-is to avoid entangling a package release.
- **`work-loop` SKILL.md size** (>500 lines) and **`receive-brief`'s `examples/` dir** remain warn-only, intentional shapes — not restructured here.

## Validation

- `build-self` clean; `lint-skill-spec` and `lint-agent-artifacts` pass (0 errors).
- Script self-tests green: `lint-traceability` (40), `lint-spec-status`, `lint-brief-coverage`, `loop-cohort` (45).
- Pack tests green: atlassian jira (45) + confluence-crawler (42), credential-setup (9), converters render (39).

---

## Follow-up: prevent recurrence (commit 2)

The citations leaked because the *no-internal-governance-citations* rule, while documented in `AGENTS.local.md`, has **no automated lint for `.apm/**`** (it's hand-checked; an analogue of `lint-seeds` is RFC-gated, tracked at `docs/backlog.md § apm-leak-lint-rfc`). The companion authoring **craft** rules (frontmatter `description` = activation trigger surface, terse bodies for the token budget, body disjoint from the trigger) lived only in `.claude/skills/README.md`, which an authoring agent doesn't auto-read.

`docs(agents): surface skill-authoring craft rules in AGENTS.local.md` names those craft rules inline in the auto-loaded repo context (single-sourced — the full ruleset stays in the README's *Authoring skills* section, now linked) and reaffirms the citation rule covers every SKILL.md body plus its `references/`/`scripts/`/`assets/`.