### PR TITLE
fix(converters): stop file-to-markdown image extraction losing elements (0.2.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -70,7 +70,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "converters",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.2.2"
+      "version": "0.2.3"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -17,6 +17,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`file-to-markdown` image extraction no longer silently loses elements
+  (converters 0.2.3).** The image reconciler used to collapse every element
+  that shared a `(type, name)` into one before checking where it sat — so two
+  genuinely distinct nodes with the same label (a second "Validate" step, a
+  repeated "Queue") were merged into a single element with no warning, and
+  elements the model saw but couldn't label were dropped entirely. The
+  reconciler now clusters by position: same-named nodes that overlap across
+  tiles still merge, but spatially distinct ones are kept as separate elements,
+  and unlabeled elements are retained and shown as `(unlabeled)`. The document
+  branch (`convert.py`) now fails with actionable guidance — naming
+  password-protection/encryption and corruption as likely causes — instead of a
+  bare stack trace, and the image branch warns (to stderr; stdout stays clean)
+  when handed a multi-frame image (animated GIF, multi-page TIFF) that only its
+  first frame is read.
+
 ### Added
 
 - **`agentbundle list-installed` — see what you actually have installed (CLI 0.10.0).**

--- a/docs/specs/converters-extraction-fixes/spec.md
+++ b/docs/specs/converters-extraction-fixes/spec.md
@@ -1,0 +1,109 @@
+# Spec: converters-extraction-fixes
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Contract:** none — this spec fixes bugs in the existing `converters` pack
+  (`file-to-markdown` skill) without changing any documented I/O contract or
+  output schema.
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+<!-- Mode: light (work-loop). No risk trigger fired: familiar territory,
+single-person, independent fixes, NO new dependency, and no public-interface /
+schema change (the reconciler's JSON + frontmatter schema is unchanged; only its
+behavior becomes more faithful). Scope is the non-RFC subset of the
+doc-extraction pressure-test (.context/doc-extraction-pressure-test.md): the
+silent-data-loss bugs, one doc↔code drift, and one honesty warning. The
+architectural work (capability tiering, unified output contract, general-image
+mode, chunking, enrichment, timeouts) is deliberately deferred to a forthcoming
+RFC and is NOT in this PR. -->
+
+## Objective
+
+Fix correctness and honesty defects in `file-to-markdown` that cause **silent
+data loss** and **doc↔code drift**, without adding dependencies or changing the
+output schema. After this PR the image reconciler preserves every distinct
+element the agent reports, the document branch fails with actionable guidance,
+and the image branch is honest about multi-frame inputs.
+
+## Acceptance Criteria
+
+- [x] **AC1 — Distinct same-label nodes are preserved.** In `reconcile.py`, two
+  elements of the same `(type, name)` whose global bounding boxes are spatially
+  disjoint (IoU below the merge threshold) are kept as **separate** canonical
+  elements, not collapsed into one. Elements seen across overlapping tiles (IoU
+  ≥ threshold, or missing bbox) still merge to one with combined `tile_sources`
+  (no regression of the core dedup).
+
+- [x] **AC2 — Unnamed elements are no longer silently dropped.** An element with
+  an empty/absent `name` is retained (spatially deduped like any other) and
+  rendered with a visible `(unlabeled)` label in the Markdown table; it is
+  counted in `ELEMENTS`. The stored JSON `name` stays faithful (empty string).
+
+- [x] **AC3 — Actionable failure on the document branch.** When Docling raises
+  during conversion (`convert.py`), the script exits non-zero with a message
+  that names the likely causes (password-protected/encrypted, or corrupt file)
+  and the remedy — making the SKILL.md "fails fast; tell the user to remove the
+  password" claim true. No password *detector* is added (no new dependency).
+
+- [x] **AC4 — Multi-frame images are surfaced.** When the image branch opens a
+  multi-frame image (animated GIF, multi-page TIFF), `split_image.py` emits a
+  `WARNING:` to **stderr** stating only the first frame is processed. The
+  `recommend` JSON on stdout is unaffected (warning goes to stderr).
+
+- [x] **AC5 — Tests + release hygiene.** A `test_reconcile.py` locks AC1 + AC2
+  (unit + one real `python scripts/reconcile.py` subprocess invocation) and
+  passes. The `converters` pack patch version is bumped (`pack.toml`,
+  `plugin.json`, `marketplace.json` consistent — verified drift-clean via
+  build-self). A `docs/product/changelog.md` `[Unreleased]` entry records the
+  user-visible fixes.
+
+## Boundaries
+
+- **Always do:** keep the change to `packs/converters/.apm/skills/file-to-markdown/`
+  (source, not projections) + changelog + version files; preserve the existing
+  output schema and stdout markers.
+- **Never do:** add a runtime dependency; introduce a timeout/page-limit policy;
+  add enrichment, chunking, a general-image OCR mode, or a unified output
+  contract (all RFC-deferred); edit projected `.claude/` paths by hand.
+
+## Testing Strategy
+
+- **AC1, AC2 — TDD:** unit tests on `reconcile.py`'s pure functions (red first),
+  plus one end-to-end subprocess run of the documented `python scripts/reconcile.py`
+  invocation asserting `ELEMENTS` count and `(unlabeled)` in the Markdown.
+- **AC3 — goal-based/manual:** run `convert.py` against a deliberately corrupt
+  file; observe actionable stderr + exit 1.
+- **AC4 — goal-based/manual:** run `split_image.py` against a multi-frame GIF;
+  observe the stderr warning and clean stdout.
+- **AC5 — goal-based:** `pytest` green; `make build-self` leaves the tree
+  drift-clean; changelog grep.
+
+## Assumptions
+
+- The agent almost always supplies `bbox_in_tile` per the strategy references, so
+  bbox-less elements are an edge case; bbox-less same-`(type,name)` elements
+  collapse to one cluster (can't be spatially distinguished) — acceptable and
+  strictly better than the current drop. *Verified against the strategy
+  reference files, which all instruct emitting `bbox_in_tile`.*
+- A single node bisected at a tile edge (each tile reporting a partial
+  `bbox_in_tile`) can yield two global bboxes with IoU below the merge
+  threshold and therefore split into two elements — the inverse of the
+  over-merge bug this PR fixes. This is the accepted tradeoff: a visible
+  duplicate the user can reconcile beats silent loss of a distinct node. It is
+  mitigated by the pipeline's 33% default tile overlap and the strategy
+  guidance to emit whole-element bounding boxes.
+
+### Declined patterns
+
+- Tempted to add a `repeated_label` ambiguity record so repeated/split labels
+  surface for review; declining — it flips `requires-review` on every diagram
+  with a legitimately repeated label (noise), and review-surfacing belongs to
+  the RFC's output-contract work. The faithful fix (show both) is enough here.
+- Tempted to add a real PDF-encryption detector; declining — it needs a parser
+  dependency and this PR is explicitly no-new-deps. An actionable error message
+  satisfies the SKILL.md claim.
+- Tempted to also fix `convert.py`'s image path for multi-frame; declining —
+  that path feeds the Docling/ML tier the RFC will rework; the image branch
+  (`split_image.py`) is the canonical one and gets the fix.

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/convert.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/convert.py
@@ -92,9 +92,19 @@ def convert_file(input_path: Path) -> None:
             print(f"WARNING: image pre-scaled from {orig_w}×{orig_h} to {scaled_w}×{scaled_h} before OCR")
 
     try:
-        converter = DocumentConverter()
-        result = converter.convert(str(convert_path))
-        markdown = result.document.export_to_markdown()
+        try:
+            converter = DocumentConverter()
+            result = converter.convert(str(convert_path))
+            markdown = result.document.export_to_markdown()
+        except Exception as e:
+            print(
+                f"ERROR: could not convert {input_path.name}: {e}\n"
+                "If the file is password-protected or encrypted, remove the "
+                "protection and retry. If it may be corrupt, confirm it opens "
+                "in its native application.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
     finally:
         if tmp_dir:
             import shutil

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/reconcile.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/reconcile.py
@@ -137,15 +137,16 @@ def reconcile_elements(
     raw_elements: list of (tile_id, crop_box, element_dict).
     Returns (canonical_elements, ambiguities).
     """
-    # Stage 1: collapse exact (type, normalized_name) duplicates first.
-    by_key: dict[tuple[str, str], list[Element]] = {}
+    # Stage 1: group by (type, normalized_name), then split each group into
+    # spatial sub-clusters. This preserves legitimately repeated labels (the
+    # same name at different places on the diagram — common in process/
+    # architecture diagrams) while still collapsing the same node seen across
+    # overlapping tiles. Unnamed elements are grouped under an empty name and
+    # deduped spatially rather than dropped — dropping them loses real content.
+    by_key: dict[tuple[str, str], list[tuple[Element, dict]]] = {}
     for tile_id, crop_box, raw in raw_elements:
         e_type = (raw.get("type") or "").strip().lower() or "element"
         name = (raw.get("name") or "").strip()
-        if not name:
-            # Skip elements without a name — cannot dedupe sensibly
-            continue
-        key = (e_type, _normalize(name))
         gbbox = to_global_bbox(raw.get("bbox_in_tile"), crop_box)
         elem = Element(
             type=e_type,
@@ -158,16 +159,63 @@ def reconcile_elements(
                    if k not in {"type", "name", "description", "confidence",
                                 "bbox_in_tile"}},
         )
-        by_key.setdefault(key, []).append((elem, crop_box))
+        by_key.setdefault((e_type, _normalize(name)), []).append((elem, crop_box))
 
     canonical: list[Element] = []
-    for (e_type, _norm), group in by_key.items():
-        canonical.append(_pick_canonical(group))
+    for group in by_key.values():
+        for subcluster in _spatial_subclusters(group, iou_threshold):
+            canonical.append(_pick_canonical(subcluster))
 
-    # Stage 2: within the same type, merge anything with IoU > threshold.
+    # Stage 2: within the same type, merge anything with IoU >= threshold.
     canonical, ambiguities = _merge_by_iou(canonical, iou_threshold)
 
     return canonical, ambiguities
+
+
+def _spatial_subclusters(
+    group: list[tuple[Element, dict]], threshold: float
+) -> list[list[tuple[Element, dict]]]:
+    """Split one (type, name) group into spatially-distinct sub-clusters.
+
+    Elements whose global bboxes overlap (IoU >= threshold, transitively) are
+    the same instance seen across tiles and cluster together. Spatially
+    disjoint elements with the same name are distinct instances and stay
+    separate. Elements with no bbox cannot be distinguished, so they collapse
+    into a single cluster of their own.
+    """
+    # A zero-area bbox (w or h == 0) can't be spatially distinguished — IoU is
+    # 0 against everything — so treat it like a missing bbox and collapse it
+    # into the group's single no-bbox cluster rather than emitting duplicates.
+    def _has_area(e: Element) -> bool:
+        b = e.global_bbox
+        return bool(b) and b.get("w", 0) > 0 and b.get("h", 0) > 0
+
+    with_bbox = [(e, c) for (e, c) in group if _has_area(e)]
+    without_bbox = [(e, c) for (e, c) in group if not _has_area(e)]
+
+    clusters: list[list[tuple[Element, dict]]] = []
+    used = [False] * len(with_bbox)
+    for i in range(len(with_bbox)):
+        if used[i]:
+            continue
+        cluster = [with_bbox[i]]
+        used[i] = True
+        changed = True
+        while changed:  # transitively absorb anything overlapping the cluster
+            changed = False
+            for j in range(len(with_bbox)):
+                if used[j]:
+                    continue
+                if any(iou(m[0].global_bbox, with_bbox[j][0].global_bbox) >= threshold
+                       for m in cluster):
+                    cluster.append(with_bbox[j])
+                    used[j] = True
+                    changed = True
+        clusters.append(cluster)
+
+    if without_bbox:
+        clusters.append(without_bbox)
+    return clusters
 
 
 def _pick_canonical(group: list[tuple[Element, dict]]) -> Element:
@@ -359,8 +407,9 @@ def render_markdown(
         body_parts.append("|---|------|-------------|--------------|------------|")
         for i, e in enumerate(by_type[e_type], 1):
             tiles = ", ".join(e.tile_sources) or "-"
+            name = _md_escape(e.name) or "(unlabeled)"
             body_parts.append(
-                f"| {i} | {_md_escape(e.name)} | "
+                f"| {i} | {name} | "
                 f"{_md_escape(e.description)} | {tiles} | {e.confidence} |"
             )
         body_parts.append("")

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/split_image.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/split_image.py
@@ -81,7 +81,14 @@ def _validate_image(path: Path) -> Image.Image:
         sys.exit(f"ERROR: File not found: {path}")
     if path.suffix.lower() not in SUPPORTED_FORMATS:
         sys.exit(f"ERROR: Unsupported format: {path.suffix}")
-    return Image.open(path)
+    img = Image.open(path)
+    n_frames = getattr(img, "n_frames", 1)
+    if n_frames > 1:
+        print(
+            f"WARNING: {path.name} has {n_frames} frames; only the first is processed",
+            file=sys.stderr,
+        )
+    return img
 
 
 def _position_label(x: int, y: int, w: int, h: int, img_w: int, img_h: int) -> str:

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/test_reconcile.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/test_reconcile.py
@@ -1,0 +1,119 @@
+"""Tests for reconcile.py — the deterministic per-tile merge.
+
+Locks the two silent-data-loss fixes (spec converters-extraction-fixes):
+  AC1 — distinct same-(type,name) nodes with disjoint bboxes stay separate,
+        while the same node seen across overlapping tiles still merges to one.
+  AC2 — unnamed elements are retained (not silently dropped) and rendered
+        with a visible "(unlabeled)" label.
+
+reconcile.py is a standalone script (no relative imports), so importing its
+functions is faithful to how it runs; one end-to-end subprocess test also
+exercises the documented `python scripts/reconcile.py` invocation.
+
+Run with `python -m pytest` from this directory.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import reconcile
+
+HERE = Path(__file__).resolve().parent
+
+CROP = {"x": 0, "y": 0, "w": 1200, "h": 900}
+
+
+def _raw(name, bbox, crop=CROP, tile="tile_W0_R0_C0", type_="step", conf="high"):
+    return (tile, crop, {"type": type_, "name": name, "bbox_in_tile": bbox,
+                         "confidence": conf})
+
+
+def test_distinct_same_label_nodes_are_preserved():
+    """AC1: two 'Validate' steps far apart (IoU 0) must not collapse into one."""
+    raw = [
+        _raw("Validate", {"x": 10, "y": 10, "w": 80, "h": 40}),
+        _raw("Validate", {"x": 900, "y": 700, "w": 80, "h": 40}),
+    ]
+    canonical, ambiguities = reconcile.reconcile_elements(raw)
+    names = sorted(e.name for e in canonical)
+    assert len(canonical) == 2, f"expected 2 distinct nodes, got {len(canonical)}"
+    assert names == ["Validate", "Validate"]
+
+
+def test_same_node_across_overlapping_tiles_still_merges():
+    """AC1 regression: one node seen in two overlapping tiles → one element."""
+    crop1 = {"x": 0, "y": 0, "w": 1200, "h": 900}
+    crop2 = {"x": 80, "y": 0, "w": 1200, "h": 900}
+    raw = [
+        ("tile_A", crop1, {"type": "step", "name": "Fetch",
+                           "bbox_in_tile": {"x": 100, "y": 100, "w": 80, "h": 40},
+                           "confidence": "high"}),
+        # global bbox identical (100,100) → IoU 1.0 → same node
+        ("tile_B", crop2, {"type": "step", "name": "Fetch",
+                           "bbox_in_tile": {"x": 20, "y": 100, "w": 80, "h": 40},
+                           "confidence": "medium"}),
+    ]
+    canonical, _ = reconcile.reconcile_elements(raw)
+    assert len(canonical) == 1, f"expected merge to 1, got {len(canonical)}"
+    assert canonical[0].tile_sources == ["tile_A", "tile_B"]
+
+
+def test_unnamed_element_is_retained():
+    """AC2: an unnamed box is kept, not silently dropped."""
+    raw = [_raw("", {"x": 400, "y": 400, "w": 80, "h": 40}, type_="box")]
+    canonical, _ = reconcile.reconcile_elements(raw)
+    assert len(canonical) == 1, "unnamed element was dropped"
+    assert canonical[0].name == "", "stored name should stay faithful (empty)"
+
+
+def test_zero_area_same_name_boxes_collapse():
+    """Zero-area (degenerate) same-name boxes can't be spatially distinguished,
+    so they collapse to one rather than rendering as duplicate rows."""
+    raw = [
+        _raw("Node", {"x": 100, "y": 100, "w": 0, "h": 0}),
+        _raw("Node", {"x": 100, "y": 100, "w": 0, "h": 0}),
+    ]
+    canonical, _ = reconcile.reconcile_elements(raw)
+    assert len(canonical) == 1, "zero-area same-name boxes should collapse"
+
+
+def test_end_to_end_cli(tmp_path: Path):
+    """AC1 + AC2 through the documented `python scripts/reconcile.py` form."""
+    manifest = {
+        "source_image": "x.png", "viewport": 1200, "stride": 800,
+        "overlap_pct": 0.33,
+        "tiles": [{"filename": "tile_W0_R0_C0.png", "row": 0, "col": 0,
+                   "crop_box": CROP}],
+    }
+    extractions = {
+        "structural_map": {"layout": "left-to-right", "diagram_type": "process"},
+        "tiles": [{"tile_id": "tile_W0_R0_C0", "elements": [
+            {"type": "step", "name": "Validate",
+             "bbox_in_tile": {"x": 10, "y": 10, "w": 80, "h": 40}, "confidence": "high"},
+            {"type": "step", "name": "Validate",
+             "bbox_in_tile": {"x": 900, "y": 700, "w": 80, "h": 40}, "confidence": "high"},
+            {"type": "box", "name": "",
+             "bbox_in_tile": {"x": 400, "y": 400, "w": 80, "h": 40}, "confidence": "high"},
+        ]}],
+    }
+    man_p = tmp_path / "detail_manifest.json"
+    ext_p = tmp_path / "extractions.json"
+    man_p.write_text(json.dumps(manifest))
+    ext_p.write_text(json.dumps(extractions))
+    out_md = tmp_path / "out.md"
+    out_json = tmp_path / "out.json"
+
+    r = subprocess.run(
+        [sys.executable, str(HERE / "reconcile.py"),
+         "--manifest", str(man_p), "--extractions", str(ext_p),
+         "--strategy", "process", "--title", "T",
+         "--output-json", str(out_json), "--output-md", str(out_md)],
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 0, r.stderr
+    assert "ELEMENTS: 3" in r.stdout, r.stdout
+    assert "(unlabeled)" in out_md.read_text(), "unnamed element not rendered"

--- a/packs/converters/.claude-plugin/plugin.json
+++ b/packs/converters/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "converters",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "File-format conversion skills: documents and images → Markdown; Markdown → styled HTML and to branded Word, PowerPoint, and Excel; Outlook .msg → Markdown."
 }

--- a/packs/converters/pack.toml
+++ b/packs/converters/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "converters"
-version = "0.2.2"
+version = "0.2.3"
 description = "File-format conversion skills: documents and images → Markdown; Markdown → styled HTML and to branded Word, PowerPoint, and Excel; Outlook .msg → Markdown."
 readme = "README.md"
 display_name = "Converters"


### PR DESCRIPTION
## What does this change?

Fixes correctness and honesty defects in the `converters` pack's `file-to-markdown` skill that caused **silent data loss** and doc↔code drift. No new dependencies; the output schema is unchanged (behavior becomes more faithful).

## Why?

The image-branch reconciler collapsed every element sharing a `(type, normalized_name)` into one *before* any spatial check, so two genuinely distinct nodes with the same label (a second "Validate" step, a repeated "Queue") merged into one **with no warning**, and elements the model saw but couldn't label were dropped entirely. Verified by running the shipped code: three distinct inputs → one element, `AMBIGUITIES: 0`. The document branch also promised "fails fast; tell the user to remove the password" in SKILL.md but delivered a bare stack trace.

This is the non-RFC (bug-fix) slice of a larger extraction-improvement effort; the architectural work (capability tiering for locked-down/no-ML environments, a unified ingestion output contract, a general image→text mode, chunking, enrichment, timeouts) is deliberately deferred to a forthcoming RFC.

- Implements: `docs/specs/converters-extraction-fixes/spec.md`

## How do I verify it?

```bash
# reconciler unit + real-subprocess tests
cd packs/converters/.apm/skills/file-to-markdown/scripts && python3 -m pytest -q   # 5 passed

# gates
make lint-packs && make validate && make build-self-dry-run   # all exit 0, drift-clean
```

Manually verified the two script-level fixes against the real artifacts:
- corrupt PDF → `convert.py` exits 1 with actionable guidance (password/encryption/corruption);
- 3-frame animated GIF → `split_image.py` warns on stderr, `recommend` stdout stays clean JSON.

## What did you not change that you considered?

- **No new dependency, no encryption detector** — the SKILL.md password claim is satisfied by an actionable error message, not a parser that would need an unapproved dep. This is deliberate: locked-down environments ban optional OCR/ML libraries, which the coming RFC addresses head-on.
- **No `repeated_label` review-surfacing** — it would flip `requires-review` on every diagram with a legitimately repeated label; review-surfacing belongs to the RFC's output-contract work.
- **Partial-crop-at-tile-edge nodes may now split into a visible duplicate** — the accepted inverse of the over-merge bug (a visible duplicate the user can reconcile beats silent loss); documented in the spec's Assumptions, mitigated by the 33% tile overlap.
- **Did not touch** `convert.py`'s Docling image path, the document branch's missing provenance/quality metadata, or `msg-to-markdown` — all RFC-scoped.

## Checklist

- [x] Tests pass locally (`pytest` — 5 passed)
- [x] Lint pass (`make lint-packs`, `make validate`, `make build-self-dry-run` drift-clean)
- [x] Self-review run via `adversarial-reviewer`; blockers/concerns/nit addressed
- [x] Spec and code agree (spec authored + Shipped in this PR)
- [x] `docs/product/changelog.md` updated (`### Fixed`)
- [x] No new top-level directories
- [x] Conventional commit format