### PR TITLE
docs(specs): research-methodology-shape spec + plan + accept RFC-0057

### DIFF
--- a/docs/rfc/0057-research-methodology-shape.md
+++ b/docs/rfc/0057-research-methodology-shape.md
@@ -1,10 +1,10 @@
 # RFC-0057: Research methodology shape
 
-- **Status:** Open <!-- Draft | Open | Final Comment Period | Accepted | Rejected | Withdrawn | Experimental -->
+- **Status:** Accepted <!-- Draft | Open | Final Comment Period | Accepted | Rejected | Withdrawn | Experimental -->
 - **Author:** eugenelim
 - **Approver:** eugenelim
 - **Date opened:** 2026-06-30
-- **Date closed:** <!-- filled in when status reaches a terminal state -->
+- **Date closed:** 2026-06-30
 - **Decision weight:** standard <!-- extends (does not reverse) RFC-0039/ADR-0029; additive; two surfaces but prompt-only, reversible -->
 - **Related:** RFC-0039 (research project mode + typed artifacts — the two-axis model this extends), ADR-0029 (depth × lifecycle), `packs/research` (the pack this extends), `packs/converters` skill `markdown-to-pptx` (the downstream slide consumer), `packs/product-engineering` skill `frame-domain` and `packs/experience` skill `map-internal-process` (the two neighbours this fences off)
 
@@ -192,8 +192,7 @@ The shape's distinctness (the riskiest assumption) is argued definitionally abov
 
 ## Follow-on artifacts
 
-Filled in on acceptance. Anticipated:
-- **ADR** — a *new* ADR (which *references*, never edits, the immutable Accepted ADR-0029) recording that shapes/types are the extension point for new output topologies and that `methodology` is the first to span both surfaces — only if the decision warrants its own record.
-- **Spec** — `docs/specs/research-methodology-shape/`: the six-section template, the episodic row, the project-mode `shape:` value + synthesize branch, the D4 disambiguation edits, the D5 handoff note.
-- **Reference** — `packs/research/.apm/skills/research/references/methodology-shape-template.md` (named distinctly from the existing `methodologies.md` to avoid misfiling): the artifact template + disciplinary grounding + worked exemplar.
-- **Pack bump** — `packs/research` minor version; `docs/product/changelog.md` `[Unreleased]` entry.
+- **Spec** — ✅ authored: [`docs/specs/research-methodology-shape/`](../specs/research-methodology-shape/spec.md) (+ [`plan.md`](../specs/research-methodology-shape/plan.md) and a `notes/adapter-web-tools-scope.md`). Encodes the six-section template, the episodic row, the project-mode `shape:` value + synthesize branch, the D4 disambiguation edits (including the `frame-domain`-wraps-`research` fence), and the D5 handoff note; also folds in the research-pack web-tools install nudge (Claude-Code-scoped).
+- **ADR** — anticipated (not yet authored): a *new* ADR (which *references*, never edits, the immutable Accepted ADR-0029) recording that shapes/types are the extension point for new output topologies and that `methodology` is the first to span both surfaces — only if the decision warrants its own record.
+- **Reference** — implementing follow-on: `packs/research/.apm/skills/research/references/methodology-shape-template.md` (named distinctly from the existing `methodologies.md` to avoid misfiling): the artifact template + disciplinary grounding + worked exemplar.
+- **Pack bump** — implementing follow-on: `packs/research` minor version (`0.5.1` → `0.6.0`); `docs/product/changelog.md` `[Unreleased]` entry.

--- a/docs/specs/research-methodology-shape/notes/adapter-web-tools-scope.md
+++ b/docs/specs/research-methodology-shape/notes/adapter-web-tools-scope.md
@@ -1,0 +1,34 @@
+# Adapter scope of the research retrieval-subagent web-tools nudge
+
+**Question.** The research pack's two retrieval subagents
+(`packs/research/.apm/agents/evidence-retriever.md`, `source-extractor.md`)
+declare `tools: Read, Grep, Glob, WebFetch, WebSearch`. After a fresh install, on
+which adapters can they actually do live web retrieval, and on which must the
+adopter first grant web-tool permission? This scopes the install-nudge AC in
+[`../spec.md`](../spec.md) (Web-tools install nudge).
+
+**Finding (2026-06-30 adapter investigation).** The gap is **Claude Code-specific.**
+
+| Adapter | Supports the subagent primitive? | Web-tool grant needed at install? | Evidence |
+|---|---|---|---|
+| **Claude Code** | yes (`.claude/agents/<name>.md`) | **YES** | non-interactive subagents cannot surface an approval prompt, so a permission-gated tool absent from `permissions.allow` is denied; `packages/agentbundle/agentbundle/build/adapters/claude_code.py` (direct-file agent projection) |
+| Copilot | yes (`.github/agents/<name>.agent.md`) | no | `WebFetch`/`WebSearch` pass through and Copilot resolves both to its built-in `web` tool on CLI + app; `packages/agentbundle/agentbundle/build/projections/copilot_agent_md.py` docstring; `docs/specs/copilot-skills-and-web/spec.md` |
+| Cursor | yes (`.cursor/agents/<name>.md`) | no | subagents inherit all parent tools; no per-agent allowlist; `packages/agentbundle/agentbundle/build/adapters/cursor.py`; ADR-0015 |
+| Gemini | yes (`.gemini/agents/<name>.md`) | no | tools name-mapped at build time, not runtime-gated; `packages/agentbundle/agentbundle/build/adapters/gemini.py`; ADR-0016 |
+| Codex | yes (`.codex/agents/<name>.toml`) | no | tools preserved in the agent TOML; no runtime allowlist; `packages/agentbundle/agentbundle/build/adapters/codex.py` |
+| Kiro (IDE + CLI) | yes (`.kiro/agents/<name>.{md,json}`) | no | tools normalized into the agent JSON/frontmatter at build time; `packages/agentbundle/agentbundle/build/adapters/kiro.py`, `kiro_ide.py` |
+
+**Bottom line.** Only Claude Code gates the subagents' web tools behind an
+allow-list a non-interactive sub-invocation cannot satisfy. On every other
+adapter the tools are passed through to the parent session's model or baked in at
+projection time. So the README install-nudge is **scoped to Claude Code**.
+
+**Corroborating project memory** (session context, not a repo artifact): the
+subagent web-tools finding (an allow-list gap, not a scope wall — user-scope
+`~/.claude/settings.local.json` with both tools works, empirically confirmed) and
+the standing research-pack TODO to surface the grant at install/adapt time as a
+guidance note, **not** as bundle-managed `permissions.allow` machinery.
+
+**To re-confirm at implementation time.** The adapter projection files above are
+the ground truth; re-grep them if the adapter set or projection model has changed
+before the implementing PR lands.

--- a/docs/specs/research-methodology-shape/plan.md
+++ b/docs/specs/research-methodology-shape/plan.md
@@ -1,0 +1,295 @@
+# Plan: research-methodology-shape
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Drafting <!-- Drafting | Executing | Done -->
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn. When it changes substantially
+> (a different approach, not just a re-ordering), note why in the changelog
+> at the bottom.
+
+## Approach
+
+The change is **prompt-only, additive, and confined to the `research` pack**
+(plus one reciprocal disambiguation line in each of two neighbour skills and the
+usual pack-metadata + changelog housekeeping). The shape of the work: author the
+six-section artifact template once as the load-bearing reference, then wire it
+into both surfaces the pack already has — the episodic `<type>` vocabulary in
+`research/SKILL.md` and the project `shape:` vocabulary + synthesize branch in
+the two `research-project-*` skills — and fence it against `frame-domain` and
+`map-internal-process` with reciprocal "do NOT use" pointers. The riskiest part
+is **not** any single edit (each is a small vocabulary/prose addition) but
+**keeping the shape from collapsing into a survey**: the template must make §3
+(contingency) and §4 (maturity) mandatory with worked exemplars, because those
+two sections plus the direction axis are the entire differentiator from an
+`applied` survey and from `map-internal-process`. The web-tools nudge is a
+one-line, Claude-Code-scoped README note folded in as the next research-pack
+touch. Verification is goal-based (grep/file-existence + the pack gate); the
+shape's distinctness is validated by post-ship dogfood, not gated in this PR.
+
+Files touched by the implementing PR:
+
+- `packs/research/.apm/skills/research/references/methodology-shape-template.md` (new)
+- `packs/research/.apm/skills/research/SKILL.md` (Type vocabulary row + trigger + D4 pointers + template link)
+- `packs/research/.apm/skills/research-project-start/SKILL.md` (`shape:` vocabulary)
+- `packs/research/.apm/skills/research-project-synthesize/SKILL.md` (synthesize branch)
+- `packs/product-engineering/.apm/skills/frame-domain/SKILL.md` (reciprocal pointer)
+- `packs/experience/.apm/skills/map-internal-process/SKILL.md` (reciprocal pointer)
+- `packs/research/README.md` (Claude-Code-scoped web-tools nudge)
+- `packs/research/pack.toml` + `packs/research/.claude-plugin/plugin.json` (minor bump)
+- `docs/product/changelog.md` (`[Unreleased]` entry)
+
+## Constraints
+
+- **RFC-0057** — the design being implemented; D1–D6, the six sections, `applied`
+  default, the structure-only handoff, both surfaces. This plan implements it and
+  reverses nothing. **RFC-0057 is `Accepted` (2026-06-30)** — the acceptance gate
+  is cleared and the implementing PR may proceed.
+- **RFC-0039 / ADR-0029** — the depth × lifecycle two-axis model. This spec
+  extends the shape/type set and the project `shape:` vocabulary; it must not
+  touch the depth-cue vocabulary or the mode machinery.
+- **Charter Principle 3** — prompt-only. No script produces the filename or the
+  structure; no engine, index, or daemon.
+- **Self-host / pack-scope (build gotcha for the implementer to confirm):**
+  `packs/research` is a **user-scope-default pack, not in this repo's self-host
+  projection**, so editing its `.apm/skills/**` does **not** require
+  `make build-self` to refresh a projected copy. But the **version bump** touches
+  `plugin.json`, and top-level `marketplace.json` aggregates version from
+  `plugin.json` — so the bump drifts `marketplace.json` and `build-check`
+  red-fails until it is reconciled. Expect the gate to be `lint-packs` +
+  `validate` + `build` + `pytest`; confirm the exact reconciliation step
+  (`make build-self` vs. a targeted marketplace refresh) against the local build
+  before opening the PR. (See project memory: self-host pack scope; non-projected
+  pack bump drifts marketplace.json; pack bump needs plugin.json too.)
+- **No test pins the vocabularies** — the mode-cue conformance test
+  (`test_research_retrievers_conformance.py`) single-sources only the *mode* cue
+  tuples, which this shape does not touch. Adding a shape/type is prose-only; no
+  conformance test needs updating.
+
+## Construction tests
+
+The implementation is prompt/docs-only, so there are no unit/property
+construction tests. Verification is goal-based one-liners (below, per task) plus
+the pack gate.
+
+**Integration tests:** none beyond per-task goal-based checks.
+**Manual verification:** the post-ship dogfood comparison (RFC-0057 Experiment /
+validation) — run the methodology shape on 2–3 real topics (e.g.
+dog-training-by-breed, an Ab-Initio→Databricks migration workbench) and confirm
+each artifact carries §3/§4 content a same-topic `applied` survey lacks. This is
+**post-ship validation, not a gate for this PR**; record results in a linked
+spike note.
+
+## Design (LLD)
+
+n/a — prompt/prose change. No component decomposition, data schema, interface, or
+LLD applies. The "design" is the six-section artifact template itself, authored
+in T1 and specified by RFC-0057 §D2; each downstream task consumes it.
+
+## Tasks
+
+### T1: The six-section artifact template exists and is grounded
+
+**Depends on:** none
+
+**Tests:**
+- `test -f packs/research/.apm/skills/research/references/methodology-shape-template.md`
+  → the file exists (verifies D2 AC1).
+- `grep` confirms all six section headings and their 1:1 discipline groundings
+  (SIPOC · process discovery · situational method engineering · Dreyfus ·
+  cognitive task analysis · GRADE) (D2 AC1).
+- `grep -c '^# ' <template>` and `grep -c '^## ' <template>` confirm sections are
+  `H1` and stages `H2`; `grep -n '^### ' <template>` returns **nothing** — no
+  `H3` (D2 AC2, D5 AC2).
+- `grep` confirms §3 and §4 are labelled mandatory and each carries a worked
+  exemplar; the "a methodology missing §3/§4 is a survey with headings and is
+  flagged incomplete" statement is present (D2 AC3).
+- `grep` confirms at least one full worked exemplar artifact (D2 AC4).
+- `grep` confirms §4 documents the reframe-never-omit rule (capability-maturity /
+  crawl→walk→run axis for one-off deliverables) (Open Question 1 AC).
+
+**Approach:**
+- Author `references/methodology-shape-template.md` per RFC-0057 §D2: the six
+  sections, each with its discipline grounding and a per-section authoring note.
+- Materialize §3 and §4 as mandatory with worked exemplars; add the incomplete-if-
+  missing rule.
+- Include one full worked exemplar artifact (choose a motivating case, e.g.
+  dog-training-by-breed or the migration workbench).
+- Author sub-steps as bullets only — no `H3` anywhere.
+- Name the file distinctly from the existing `methodologies.md`; do not edit
+  `methodologies.md`.
+
+**Done when:** the file exists, all six groundings and the mandatory-§3/§4 +
+reframe rules are greppable, and the no-`H3` check returns empty. (D2 is split
+across tasks: T1 authors the template; **D2 AC5 — the `research` skill body's
+link to the template — is delivered in T2**, the skill-edit task.)
+
+### T2: The episodic `methodology` shape is wired into `/research`
+
+**Depends on:** T1
+
+**Tests:**
+- `grep` for a `process / methodology / lifecycle` row → `<topic-slug>-methodology.md`
+  in the "Type vocabulary" table of `research/SKILL.md` (D1 AC1).
+- `grep` confirms the trigger phrasing ("best way to do/run/build/train X",
+  "process/lifecycle/playbook for X", "how do you go about X end to end") (D1 AC2).
+- `grep` confirms the skill body links `references/methodology-shape-template.md`
+  and states the `applied` default with scholarly override (D2 AC5, D3 AC).
+- `grep` confirms `markdown-to-pptx` is named as consumer by reference only (no
+  `requires`/import/version pin) (D5 AC1).
+- A diff/grep shows **no new executable** added to the research pack for this
+  shape (D1 AC3).
+- A diff confirms the `research` skill's Modes / Cue-precedence blocks and the
+  closed cue tuples in `test_research_retrievers_conformance.py` are **unchanged**
+  — the shape adds a `<type>`, not a depth mode (D3 negative-check AC).
+
+**Approach:**
+- Add the vocabulary row and the trigger prose to `research/SKILL.md`.
+- Point at the new template; state the `applied` depth default and the
+  structure-only `markdown-to-pptx` handoff (H1/H2, bullets, no H3).
+- Leave the depth-cue vocabulary and mode machinery untouched.
+
+**Done when:** the row, trigger, template link, depth default, and handoff note
+are all present and greppable; no code was added; the depth-cue/mode blocks are
+byte-unchanged.
+
+### T3: The project-mode surface gains the `methodology` shape
+
+**Depends on:** T1
+
+**Tests:**
+- `grep` confirms `research-project-start/SKILL.md` lists `methodology` in **both**
+  the `shape:` frontmatter vocabulary line **and** the `overview.md` schema
+  comment — the two surfaces must not drift (D6 AC1).
+- `grep` confirms `research-project-synthesize/SKILL.md` has a `methodology`
+  branch that writes `methodology.md` (bare-named in the folder) (D6 AC2).
+- Diff review confirms no existing artifact is renamed and no consumer changed —
+  migration: none (D6 AC3).
+
+**Approach:**
+- Add `methodology` to the `shape:` frontmatter vocabulary and the `overview.md`
+  schema comment in `research-project-start`.
+- Add the `methodology → methodology.md` case to the typed-synthesis section of
+  `research-project-synthesize`, mirroring the existing shape→file mappings.
+
+**Done when:** both project skills carry the value/branch and the diff is
+additive-only.
+
+### T4: The shape is fenced against `frame-domain` and `map-internal-process`
+
+**Depends on:** T2
+
+**Tests:**
+- `grep` in `research/SKILL.md` confirms explicit "do NOT use" pointers to
+  `frame-domain` and `map-internal-process` (D4 AC1).
+- `grep` in `frame-domain/SKILL.md` and `map-internal-process/SKILL.md` confirms
+  reciprocal pointers back to the methodology shape (D4 AC2).
+- `grep` confirms the boundary prose names the honest SIPOC + process-discovery
+  overlap and rests the boundary on source+direction plus §3/§4/§5 (D4 AC3).
+- `grep` in `research/SKILL.md` and `frame-domain/SKILL.md` confirms both state
+  that the methodology shape **does not fire on `frame-domain`'s wrapped
+  `research` applied-mode call** — the wrapped grounding pass stays an `applied`
+  survey (D4 wrapped-call AC). `frame-domain` wraps `research` applied mode at
+  `packs/product-engineering/.apm/skills/frame-domain/SKILL.md:51-62`, so the
+  reciprocal pointer alone is insufficient — the no-fire-on-wrapped-call rule is
+  explicit.
+
+**Approach:**
+- Add the "do NOT use" pointers and the boundary explanation (source+direction +
+  the three non-shared disciplines; honest overlap named) to the methodology
+  shape's trigger prose.
+- Add one reciprocal disambiguation line to each neighbour skill; in the
+  `frame-domain` line, state that its wrapped `research` applied-mode call is not
+  reshaped into a methodology artifact.
+
+**Done when:** all four greps pass, the two neighbour skills each carry a
+back-pointer, and the wrapped-call fence is stated on both ends.
+
+### T5: The Claude-Code-scoped web-tools install nudge
+
+**Depends on:** none
+
+**Tests:**
+- `grep` in `packs/research/README.md` confirms a note naming `WebSearch` +
+  `WebFetch`, the two retrieval subagents, and **Claude Code** as the scope
+  (Web-tools install nudge AC).
+- Review confirms the note is guidance only — no projector, no permission-grant
+  machinery, no edit to `permissions.allow`.
+- `test -f docs/specs/research-methodology-shape/notes/adapter-web-tools-scope.md`
+  → the in-repo adapter-scope finding the README's Claude-Code scoping cites
+  exists.
+
+**Approach:**
+- The adapter-scope finding is captured in
+  `notes/adapter-web-tools-scope.md` (authored with this spec) so the
+  Claude-Code-only scoping is verifiable from an in-repo artifact, not only from
+  session memory.
+- Add a one-line install/adapt note to `packs/research/README.md`: on **Claude
+  Code**, add `WebSearch` and `WebFetch` to `permissions.allow` so the
+  `evidence-retriever` / `source-extractor` subagents can do live web retrieval.
+- Scope it to Claude Code explicitly — the adapter investigation confirmed the
+  gap is Claude-Code-specific (Copilot resolves both to its `web` tool;
+  Cursor/Gemini/Codex/Kiro preserve or name-map the tools at build time).
+
+**Done when:** the README carries the Claude-Code-scoped note, the notes file
+exists, and no machinery was added.
+
+### T6: Ship mechanics — version bump + changelog
+
+**Depends on:** T1, T2, T3, T4, T5
+
+**Tests:**
+- `grep` confirms `packs/research/pack.toml` and `.claude-plugin/plugin.json`
+  both read `0.6.0` (Ship mechanics AC1).
+- `grep` confirms a `docs/product/changelog.md` `[Unreleased]` entry for the
+  methodology shape (Ship mechanics AC2).
+- The pack gate passes: `lint-packs` + `validate` + `build` + `pytest`, and
+  `marketplace.json` drift is reconciled / `build-check` green (Ship mechanics
+  AC3).
+
+**Approach:**
+- Bump both version files (minor: `0.5.1` → `0.6.0`).
+- Add the `[Unreleased]` changelog entry (user-visible: the new methodology
+  shape on both surfaces).
+- Reconcile `marketplace.json` drift per the build gotcha in Constraints; run the
+  pack gate and confirm green before opening the PR.
+
+**Done when:** both version files read `0.6.0`, the changelog entry exists, and
+build-check is green.
+
+## Rollout
+
+- **Delivery:** big-bang, additive, fully reversible — a new prompt-only shape on
+  an existing pack. Rollback is deleting the vocabulary rows/value, the reference
+  file, and the reciprocal pointers, then reverting the bump. Nothing
+  irreversible ships (no data migration, no published event, no renamed artifact).
+- **Infrastructure:** none.
+- **External-system integration:** none. `markdown-to-pptx` is a consumer by
+  reference, not a build- or run-time dependency.
+- **Deployment sequencing:** the shape ships when `packs/research` `0.6.0` is
+  published to the catalogue (the ordinary pack-release path — a separate step
+  after this spec's implementing PR merges, per the standing release decision on
+  publishable-pack work).
+
+## Risks
+
+- **The shape collapses into a survey** (the RFC's top pre-mortem). Mitigation:
+  T1 makes §3/§4 mandatory with worked exemplars and an incomplete-if-missing
+  rule; the post-ship dogfood validates it empirically.
+- **Boundary bleed** — users fire it for product-MVP grounding or their own ops.
+  Mitigation: T4's reciprocal "do NOT use" pointers.
+- **Slide-coupling creep** — a later change hard-wires the converter. Mitigation:
+  the spec's Never-do rule + T2's by-reference-only check.
+- **Build reconciliation surprise** — the `marketplace.json` drift from the
+  version bump can red-fail build-check unexpectedly. Mitigation: called out in
+  Constraints and T6; the implementer confirms the reconciliation step against
+  the local build.
+
+## Changelog
+
+- 2026-06-30: initial plan. Authored from RFC-0057 (Accepted 2026-06-30, PR #472).
+  Web-tools
+  nudge folded in and scoped to Claude Code after a parallel adapter
+  investigation confirmed the permission gap is Claude-Code-specific (Copilot /
+  Cursor / Gemini / Codex / Kiro pass web tools through to the parent session or
+  bake them in at build time).

--- a/docs/specs/research-methodology-shape/spec.md
+++ b/docs/specs/research-methodology-shape/spec.md
@@ -1,0 +1,277 @@
+# Spec: research-methodology-shape
+
+- **Status:** Approved <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** RFC-0057, RFC-0039, ADR-0029
+- **Brief:** none
+- **Discovery:** none
+- **Contract:** none — prompt-only shape; no API surface, no `contracts/` file
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+> **Acceptance gate — cleared.** RFC-0057 is **Accepted** (2026-06-30). This
+> spec is Approved: the design is ratified and the implementing PR (skill edits,
+> the six-section template, reciprocal fencing, the README nudge, the pack bump)
+> may proceed.
+
+## Objective
+
+A user asking *"what's the best way to do X, end to end, for my situation"* — run
+a data-migration workbench, progress a training plan, bring AI-SDLC
+modernization to a delivery stream, train this dog breed — gets a **`methodology`
+output shape** from the `research` pack: a staged, contingency-adapted,
+maturity-aware, evidence-graded description of how the activity is done, not a
+claim-organized survey they must re-shape by hand into a sequence. Success is:
+the pack routes process-shaped questions to a `methodology` artifact on **both**
+its surfaces — one-shot (episodic `/research`) and sustained (project mode) — the
+artifact is slide-ready for `markdown-to-pptx` with no reshaping, and it is
+fenced cleanly against the two neighbouring "process" skills (`frame-domain`,
+`map-internal-process`). The change is **prompt-only** (Charter Principle 3):
+no code, no new dependency, no runtime engine. It also closes the standing
+research-pack TODO — the retrieval subagents' web-tool permission nudge — folded
+in as the next research-pack touch.
+
+## Boundaries
+
+The three-tier guard that keeps an implementing agent inside the lines.
+*Always do* applies without asking; *Ask first* requires human sign-off
+before proceeding; *Never do* is a hard rule, even under time pressure.
+
+### Always do
+
+- Add the shape as a **row/value in the existing vocabularies**, following the
+  precedent of the shapes already present (`comparison-matrix`, `shortlist`,
+  `blueprint`, `hypotheses`) — filename and structure produced by the agent
+  following the skill, never by a script.
+- Keep the artifact **authored for `markdown-to-pptx`**: sections at `H1`,
+  stages at `H2`, all finer detail as bullet lists.
+- Distinguish the **two field names by surface**: the episodic side gains a
+  `<type>` stem (`methodology`); the project side gains a `shape:` frontmatter
+  value (`methodology`). These are distinct fields — do not invent a new
+  `shape`-named episodic field.
+- Name the **honest overlap** with `map-internal-process` (SIPOC scope frame +
+  process-discovery spine are shared) and rest the boundary on source+direction
+  plus the three non-shared disciplines.
+- Bump `packs/research` (minor) in **both** `pack.toml` and
+  `.claude-plugin/plugin.json`, and add a `[Unreleased]` changelog entry.
+
+### Ask first
+
+- Any change to the **depth axis** (quick/standard/applied/deep) — this spec
+  extends the shape/type set only and reverses nothing in RFC-0039/ADR-0029.
+- Graduating `methodology` to its own standalone skill or skill-family
+  (RFC-0057 Open Question 2 — decided **no for v1**; revisit is post-ship).
+- Authoring the follow-on **ADR** (that shapes/types are the extension point for
+  new output topologies) — anticipated but out of this spec's scope.
+
+### Never do
+
+- **No runtime engine, index, daemon, or counter** — the shape is prompt-only,
+  exactly like every existing shape.
+- **No hard dependency** from `research` on `converters` — `markdown-to-pptx` is
+  named as a consumer by reference only; a repo without the converters pack
+  still gets the artifact.
+- **No `H3` for sub-steps** in the artifact — `markdown-to-pptx` maps only
+  `H1`/`H2` to slides and renders the literal `###` text into the parent slide
+  body; sub-steps are always bullets.
+- **No agentbundle-managed permission grants** — the web-tools fix is an
+  install/adapt-time *note*, not projector machinery (`permissions.allow` is a
+  shared, user-co-authored key the bundle cannot own).
+- **No migration** — the change is purely additive; no existing artifact is
+  renamed and no consumer changes.
+
+## Testing Strategy
+
+The implementation is **prompt/docs-only** (skill bodies, a reference template,
+the README, pack metadata, the changelog). Verification is therefore
+**goal-based** for the structural facts and **manual/dogfood** for the shape's
+distinctness:
+
+- **Goal-based check** (the ship gate for the implementing PR): each vocabulary
+  edit, the new reference file, the reciprocal disambiguation edits, the version
+  bump, and the changelog entry are verified by `grep`/file-existence one-liners,
+  plus the pack gate `lint-packs` + `validate` + `build` + `pytest`
+  (`packs/research` is a user-scope-default pack, not in this repo's self-host
+  projection — see plan Constraints).
+- **Manual QA / dogfood** (post-ship validation, **not** a gate for the
+  implementing PR): RFC-0057's predeclared experiment — run the shape on 2–3
+  real topics and confirm each artifact carries §3 contingency and §4 maturity
+  content a same-topic `applied` survey lacks. This validates the riskiest
+  assumption after ship; it does not reopen the decision to build the shape.
+
+No TDD-mode tasks: there is no compressible code invariant — the shape is prose
+the agent produces by following the skill.
+
+## Acceptance Criteria
+
+<!-- All open at authoring time; the implementing PR checks them. -->
+
+**Verification mode per criterion:** every AC below (D1–D6, Open Question 1,
+Web-tools nudge, Ship mechanics) is **goal-based** — checked by the `grep` /
+file-existence one-liner named in the matching plan task, plus the pack gate. The
+sole **manual/dogfood** check is RFC-0057's shape-distinctness experiment, which
+is **post-ship validation, not an AC** (see Testing Strategy).
+
+### D1 — the episodic `methodology` shape
+
+- [ ] `packs/research/.apm/skills/research/SKILL.md` "Type vocabulary" table
+  gains a `process / methodology / lifecycle` row mapping to
+  `<topic-slug>-methodology.md`.
+- [ ] The `research` skill body documents the shape's trigger phrasing — *"the
+  best way to do / run / build / train X"*, *"the process / lifecycle / playbook
+  for X"*, *"how do you go about X end to end"*.
+- [ ] The filename is produced by the agent following the skill — no script, no
+  code added (Charter Principle 3): a `grep` shows no new executable added to the
+  research pack for this shape.
+
+### D2 — the six-section artifact template
+
+- [ ] A new reference
+  `packs/research/.apm/skills/research/references/methodology-shape-template.md`
+  exists, encoding the six sections, each grounded 1:1 in its discipline: §1
+  Scope frame (SIPOC) · §2 Stage spine (process discovery + hierarchical task
+  decomposition) · §3 Contingency branches (situational method engineering) · §4
+  Maturity ladder (Dreyfus) · §5 Failure modes (cognitive task analysis) · §6
+  Evidence & confidence (GRADE, inherited unchanged).
+- [ ] The template is authored heading-per-section (`H1`) and heading-per-stage
+  (`H2`), with sub-steps as bullet lists and **no `H3`**.
+- [ ] §3 (contingency) and §4 (maturity) are marked **mandatory** with worked
+  exemplars; the template states a methodology artifact missing them is a survey
+  with headings and is flagged incomplete.
+- [ ] The template carries at least one **worked exemplar** of the full
+  six-section artifact.
+- [ ] The template is named distinctly from the existing
+  `references/methodologies.md` (which catalogues the pack's *research-method*
+  disciplines and is **not** edited), and the `research` skill body points at the
+  new template.
+
+### D3 — defaults to `applied` depth
+
+- [ ] The methodology shape defaults to **`applied`** depth, and the skill body
+  states scholarly domains override to `standard`/`deep` via the ordinary depth
+  cues.
+- [ ] The shape **does not touch the depth-cue vocabulary or the mode
+  machinery** — a diff confirms the `research` skill's Modes / Cue-precedence
+  blocks and the closed cue tuples in
+  `test_research_retrievers_conformance.py` are unchanged (RFC-0039/ADR-0029
+  two-axis invariant).
+
+### D4 — fenced against the two neighbours
+
+- [ ] The methodology shape's trigger prose carries explicit **"do NOT use"**
+  pointers to `frame-domain` (product/MVP grounding) and `map-internal-process`
+  (an org's own operations).
+- [ ] Reciprocal disambiguation lines are added to the `frame-domain` and
+  `map-internal-process` skills pointing back to the methodology shape.
+- [ ] The boundary is documented as resting on **source + direction**
+  (world best-practice, outside-in, any domain vs *your own* operations,
+  inside-out) plus the three non-shared disciplines (contingency §3, maturity §4,
+  failure-modes §5); the honest SIPOC + process-discovery overlap with
+  `map-internal-process` is named, not hidden.
+- [ ] The **`frame-domain`-wraps-`research` interaction** is fenced: because
+  `frame-domain` internally invokes `research` in `applied` mode to ground its
+  real-world-activity half, the methodology shape **does not fire on that wrapped
+  call** — the wrapped invocation stays an `applied` survey. The methodology
+  shape's trigger prose and the `frame-domain` reciprocal pointer both state this,
+  so `frame-domain`'s grounding pass is never silently reshaped into a
+  methodology artifact.
+
+### D5 — structure-only PowerPoint handoff
+
+- [ ] The methodology skill body names `markdown-to-pptx` as the natural slide
+  consumer **by reference only** — no import, no `requires`, no version pin;
+  `research` gains no dependency on `converters`.
+- [ ] The artifact structure keeps sections at `H1` and stages at `H2` with
+  finer detail as bullets, so the handoff is a one-prompt operation.
+
+### D6 — both surfaces
+
+- [ ] `packs/research/.apm/skills/research-project-start/SKILL.md` gains
+  `methodology` in **both** the `shape:` frontmatter vocabulary and the
+  `overview.md` schema comment that documents it (today both read
+  `survey | comparison | decision | structural | adjudication`) — the two must
+  not drift.
+- [ ] `packs/research/.apm/skills/research-project-synthesize/SKILL.md` gains a
+  branch: a `methodology` shape writes `methodology.md` (bare-named inside the
+  project folder, per the existing convention) alongside the `<topic-slug>-brief.md`
+  governance handoff.
+- [ ] The change is purely additive: no existing artifact is renamed, no existing
+  consumer changes (**migration: none**).
+
+### Open Question 1 — maturity ladder for one-off deliverables
+
+- [ ] The template resolves RFC-0057 Open Question 1 with **reframe, never omit
+  silently**: when skill-progression does not apply (a one-off deliverable), §4
+  is authored as an adoption/capability-maturity axis (crawl → walk → run of the
+  deliverable) so the "journey" section/slide always exists.
+
+### Web-tools install nudge (folded-in TODO)
+
+> This concern is folded into this spec at the **operator's explicit request**
+> (it is the standing "next research-pack touch" the TODO waited for). It rides
+> along under the same pack; the implementing PR lists it under `Bundled fixes:`
+> with a one-line reason. It is distinct from the methodology shape (different
+> subagents, `README.md` vs skill bodies).
+
+- [ ] The research pack's `README.md` carries a one-line note that names
+  **`WebSearch`** and **`WebFetch`**, the two retrieval subagents
+  (`evidence-retriever`, `source-extractor`), and **Claude Code** as the scope,
+  telling adopters to grant those two tools before the subagents can do live web
+  retrieval. The note is guidance only — no projector, no permission-grant
+  machinery, no edit to `permissions.allow`. *(This AC checks the note's content;
+  the correctness of the Claude-Code-only scoping rests on the adapter finding
+  captured in [`notes/adapter-web-tools-scope.md`](notes/adapter-web-tools-scope.md)
+  and recorded in Assumptions.)*
+
+### Ship mechanics
+
+- [ ] `packs/research` version is bumped **minor** (`0.5.1` → `0.6.0`) in **both**
+  `pack.toml` and `.claude-plugin/plugin.json`.
+- [ ] `docs/product/changelog.md` `[Unreleased]` carries an entry describing the
+  new methodology shape (user-visible skill capability).
+- [ ] The version bump's drift into top-level `marketplace.json` is reconciled,
+  and the pack gate is green — `lint-packs` + `validate` + `build` + `pytest`
+  pass and `build-check` is clean.
+
+## Assumptions
+
+<!-- Audit trail for the assumption-surfacing checkpoint at spec time. -->
+
+- Technical: `methodology` is a **shape** (output topology), not a **depth
+  "mode"**; it extends RFC-0039/ADR-0029's two-axis model and reverses nothing.
+  (source: RFC-0057 D1; ADR-0029)
+- Technical: the episodic `<type>` stem and the project `shape:` value are
+  **distinct fields**; there is no `shape`-named episodic field today. (source:
+  RFC-0057 §D1 terminology note; `research/SKILL.md` § Typed, topic-named
+  artifacts + `research-project-start/SKILL.md` `overview.md` schema, read
+  2026-06-30)
+- Technical: `markdown-to-pptx` maps `H1`/`H2` → one slide, list items → bullets,
+  a table → a slide table, and renders a literal `###` into the parent slide
+  body — so sub-steps must be bullets, never `H3`. (source:
+  `packs/converters/.apm/skills/markdown-to-pptx/SKILL.md`, read 2026-06-30)
+- Technical: no test pins the project `shape:` vocabulary or the episodic `<type>`
+  set; the conformance test
+  (`packages/agentbundle/tests/unit/test_research_retrievers_conformance.py`)
+  single-sources only the *mode* cue tuples, which this shape does not touch.
+  (source: repo grep, 2026-06-30)
+- Process: `packs/research` is a **user-scope-default pack not in this repo's
+  self-host projection**; the pack gate is `lint-packs` + `validate` + `build` +
+  `pytest`, and a version bump also drifts top-level `marketplace.json` (all-packs
+  aggregation from `plugin.json`), which the implementing PR must reconcile.
+  (source: project memory — self-host pack scope + non-projected pack bump; to be
+  re-confirmed by the implementer against the local build)
+- Product: the web-tools permission gap is **Claude-Code-specific**. A parallel
+  adapter investigation confirmed that only Claude Code gates the retrieval
+  subagents' `WebFetch`/`WebSearch` behind an allow-list a non-interactive
+  subagent cannot satisfy; Copilot resolves both to its built-in `web` tool,
+  and Cursor / Gemini / Codex / Kiro preserve or name-map the tools at build
+  time with no install-time allow-list step. So the README nudge is scoped to
+  Claude Code, and the fix is a guidance-note, not bundle-managed grants.
+  (source: project memory — research-pack web-tools install nudge + subagent
+  web-tools finding; adapter investigation 2026-06-30, evidence in the plan's
+  T5 + Changelog)
+- Product: RFC-0057 Open Question 1 is resolved at spec time per its recommended
+  default (reframe, never omit); Open Question 2 (graduate to a skill) stays a
+  post-ship review, out of scope here. (source: RFC-0057 Open questions)


### PR DESCRIPTION
## What does this change?

Accepts **RFC-0057** (research methodology shape) and lands its follow-on **spec + plan** under `docs/specs/research-methodology-shape/`. Docs only — no code, no pack edits (the implementation is a separate gated PR).

## Why?

- Implements: `docs/specs/research-methodology-shape/spec.md`
- Follows from: RFC-0057 (accepted in this PR; Accepted 2026-06-30)

The `research` pack has shapes organized around a *claim* (survey, comparison-matrix, hypotheses) but none around a *process*. RFC-0057 adds a `methodology` output shape — a staged, contingency-adapted, maturity-aware, evidence-graded description of *how an activity is done end-to-end* — on both research surfaces (episodic `<type>` + project `shape:`), slide-ready for `markdown-to-pptx`. This PR authors the build contract for it.

Spec-time decisions worth a reviewer's eye:
- **RFC accepted here**, so the spec ships **Approved** (its acceptance gate is now cleared) rather than Draft.
- **Open Question 1 resolved** per the RFC's recommended default: the §4 maturity ladder is *reframed, never omitted* (capability-maturity axis for one-off deliverables).
- **`frame-domain`-wraps-`research` fence** (adversarial-reviewer catch): because `frame-domain` internally invokes `research` in applied mode, a D4 acceptance criterion requires the methodology shape to *not* fire on that wrapped call.
- **Web-tools nudge folded in and scoped to Claude Code.** The research retrieval subagents need `WebFetch`/`WebSearch` granted before live web works — but only on Claude Code (non-interactive subagents can't prompt for permission). Copilot resolves both to its `web` tool; Cursor/Gemini/Codex/Kiro preserve or name-map at build time. Evidence table in `notes/adapter-web-tools-scope.md`.

## How do I verify it?

- `python .claude/skills/work-loop/scripts/lint-spec-status.py --root .` → `spec metadata clean`.
- RFC-0057 status reads `Accepted` with a closed date; its follow-on section links the spec.
- Spec has 24 acceptance criteria (all open, awaiting the implementing PR) mapping 1:1 onto the plan's 6 tasks.

## What did you not change that you considered?

- **The implementation** (skill bodies, the six-section reference template, `frame-domain`/`map-internal-process` reciprocal pointers, README nudge, pack bump `0.5.1`→`0.6.0`, changelog) — deferred to the gated follow-on PR; this PR is the contract only.
- **The follow-on ADR** (shapes/types as the extension point) — anticipated but not authored; left to the implementer's judgment on whether it warrants its own record.

Bundled fixes: none.
Deferred: none.

---

Reviewed via two `adversarial-reviewer` passes (spec/plan-review mode), iterated to clean; all Blockers/Concerns resolved.