### PR TITLE
docs(architecture): call out the catalogue + skill/pack format, add llms.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Loop engineering relocates judgment, it doesn't remove it — keeping every piec
 
 ## A foundation to build on
 
-Adopt the catalogue as-is, or fork it as your own. The same bundler that installs these packs can publish yours: write your house conventions and review standards into `core`, add skills for your stack, and ship one catalogue every engineer installs in a single line — the loop, the reviewers, and the standards come out identical on every machine and in every agent. That makes this a foundation for an organization's AI dev kit, not just a set of defaults to consume.
+Adopt the catalogue as-is, or fork it as your own. The same bundler that installs these packs can publish yours: write your house conventions and review standards into `core`, add skills for your stack, and ship one catalogue every engineer installs in a single line — the loop, the reviewers, and the standards come out identical on every machine and in every agent. That makes this a foundation for an organization's AI dev kit, not just a set of defaults to consume. [What a catalogue is, and how to stand up your own →](docs/architecture/catalogue.md)
 
 ## How a pack is laid out
 
@@ -165,6 +165,8 @@ Full documentation lives in **[`docs/guides/`](docs/guides/)**, organized by pac
 | Upgrading an installed pack | [upgrade packs](docs/guides/_shared/how-to/upgrade-packs.md) |
 | Updating the agentbundle CLI itself — `pip install --upgrade agentbundle` | [PyPI](https://pypi.org/project/agentbundle/) |
 | Mission, scope, and the four principles | [`docs/CHARTER.md`](docs/CHARTER.md) |
+| What a catalogue is, and how to stand up your own | [the catalogue](docs/architecture/catalogue.md) |
+| The skill & pack format, layer by layer | [skill & pack format](docs/architecture/skill-and-pack-format.md) |
 | The catalogue distribution model | [RFC-0001](docs/rfc/0001-bundle-distribution-by-adapter-spec.md) |
 
 Skills follow the [agentskills.io specification](https://agentskills.io/specification) — each a self-contained folder with closed frontmatter and no hidden cross-skill dependencies, so they install, copy, and audit cleanly.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -6,9 +6,18 @@ How the code is *currently* organized. Not why (that's in
 
 - [`overview.md`](overview.md) — the map of the monorepo. What's in
   `packages/`, `tools/`, `packs/`, and how they relate. Read this first.
+- [`catalogue.md`](catalogue.md) — what a catalogue *is* on disk, how
+  `agentbundle` resolves one (the four-layer chain), and how to point it
+  at your own. The starting point for standing up your own catalogue.
+- [`skill-and-pack-format.md`](skill-and-pack-format.md) — the format map:
+  the agentskills.io skill standard we conform to, the pack envelope that
+  wraps it, and the projection that fans it out to every agent.
 - [`pack-layout.md`](pack-layout.md) — the canonical shape of a single
   pack: `pack.toml`, `.claude-plugin/`, `.apm/<primitive>/`, `seeds/`.
   What each directory contains and how the bundler reads it.
+- [`pack-manifest.md`](pack-manifest.md) — `pack.toml` as the single
+  source of truth for pack metadata, and how the build projects a lossy
+  subset into each route's manifest and the catalogue listing.
 - [`agentbundle.md`](agentbundle.md) — the `agentbundle` Python package:
   CLI verbs, bundler internals (recipes → adapters → projections), the
   adapter contract, and the install→adapt chain.

--- a/docs/architecture/catalogue.md
+++ b/docs/architecture/catalogue.md
@@ -1,0 +1,114 @@
+# The catalogue
+
+> What a catalogue *is* on disk, how `agentbundle` finds one, and how you
+> point it at your own. `packs/` in this repo is one catalogue; the same
+> shape lets any org stand up theirs.
+
+A catalogue is the thing `agentbundle install` reads packs *from*. This repo
+ships one — the `packs/` tree — but nothing about the tool is bound to it.
+Fork it, build a fresh one, or host one privately, and point the CLI at yours.
+
+## What a catalogue is
+
+A catalogue is a directory holding two things:
+
+```
+<catalogue-root>/
+├── packs/
+│   └── <pack>/…                     # one directory per shippable pack (see pack-layout.md)
+└── .claude-plugin/
+    └── marketplace.json             # the catalogue listing — aggregates every pack's plugin.json
+```
+
+Those two markers — a `packs/` directory and a
+`.claude-plugin/marketplace.json` file — **are** the contract. Anything that
+holds both is a catalogue the CLI will read; anything missing either is
+refused. The check is one function,
+[`source_defaults._has_catalogue_markers`](../../packages/agentbundle/agentbundle/source_defaults.py),
+and it is the whole definition — there is no registry service, no manifest
+schema beyond the per-pack `pack.toml`, and no network protocol.
+
+`marketplace.json` is the catalogue-level listing consumed by
+`/plugin marketplace add`; the build aggregates each pack's version and
+metadata into it from the pack's `.claude-plugin/plugin.json`. How a pack's
+`pack.toml` projects into that entry is covered in
+[`pack-manifest.md`](pack-manifest.md).
+
+## How agentbundle finds a catalogue
+
+Every source verb — `install`, `upgrade`, `list-packs`, `list-profiles`,
+`list-installed` — takes an optional trailing catalogue argument. When you
+omit it, the CLI resolves one through a four-layer, first-match-wins chain
+(RFC-0046 / ADR-0036, in
+[`source_defaults.resolve_default_source`](../../packages/agentbundle/agentbundle/source_defaults.py)):
+
+| Layer | Source | Set by |
+| --- | --- | --- |
+| 1 | The explicit trailing argument | `agentbundle install core <catalogue>` — passed through verbatim |
+| 2 | User config `[settings].source` | `agentbundle config set source <catalogue>` |
+| 3 | Editable-install detection | `pip install -e <clone>` — auto-detected |
+| 4 | Packaged default | `_data/install-defaults.toml` — baked into the wheel |
+
+Layer 3 is the one that makes a local clone "just work": when `agentbundle`
+is installed editable, it reads its own PEP 610 `direct_url.json`, and walks
+up from the package directory — bounded by the enclosing `.git` root — to the
+first ancestor carrying both catalogue markers. So a developer working inside
+a clone gets that clone as their catalogue with no configuration.
+
+When no layer yields a source, the CLI refuses with a message naming all three
+recovery paths rather than silently falling back to the current directory:
+
+```
+no catalogue source: pass a catalogue argument, run 'agentbundle config set
+source …', or pip install -e the catalogue
+```
+
+## Point agentbundle at your own catalogue
+
+A catalogue source is either a **local path** (containing both markers) or a
+**`git+https://` URL**. Two durable ways to switch, plus the one-off:
+
+```bash
+# Persist a default (layer 2) — survives across every verb, every repo.
+agentbundle config set source git+https://github.com/acme/agent-kit
+agentbundle config set source /abs/path/to/your/catalogue
+agentbundle config unset source          # clear it; fall back to layers 3–4
+
+# One-off (layer 1) — a trailing argument beats the configured default.
+agentbundle install core git+https://github.com/acme/agent-kit
+
+# Bind to a working clone (layer 3) — no config needed.
+pip install -e /abs/path/to/your/catalogue
+```
+
+The config value is stored in your OS config directory
+(`~/Library/Application Support/agentbundle/config.toml` on macOS,
+`$XDG_CONFIG_HOME/agentbundle/config.toml` on Linux). A `git+https://` value
+is accepted as-is; a local path is validated for both markers at resolution
+time, so a stale or wrong path fails loudly with a diagnostic rather than
+installing nothing.
+
+Note that `~/.agentbundle/` is a *destination* — the user-scope install root
+packs are projected **into** — not a source. You never point `source` at it.
+
+## Stand up your own catalogue
+
+The minimum is a directory with `packs/<your-pack>/` and a
+`.claude-plugin/marketplace.json`, then any of the switches above. The full,
+opinionated recipe — fork this catalogue, add an org pack carrying your house
+conventions, blank the packaged upstream default so stray installs can't reach
+it, and ship a one-command profile every engineer installs — lives in the
+adopter how-to:
+[Build an org stack pack](../guides/_shared/how-to/build-an-org-stack-pack.md).
+
+## Where to read next
+
+- [`pack-layout.md`](pack-layout.md) — the on-disk shape of a single pack
+  inside `packs/`.
+- [`pack-manifest.md`](pack-manifest.md) — how `pack.toml` projects into the
+  `marketplace.json` listing.
+- [`skill-and-pack-format.md`](skill-and-pack-format.md) — the format map:
+  the agentskills.io skill standard we conform to, wrapped by our pack
+  envelope and projection.
+- [Build an org stack pack](../guides/_shared/how-to/build-an-org-stack-pack.md) —
+  the full stand-up-your-own recipe.

--- a/docs/architecture/skill-and-pack-format.md
+++ b/docs/architecture/skill-and-pack-format.md
@@ -1,0 +1,74 @@
+# Skill & pack format
+
+> The format, in three layers: the open **skill** standard we conform to, the
+> **pack** envelope that wraps a skill for distribution, and the **projection**
+> that fans one pack source out to every agent. This page is the map; each
+> layer's detail lives in its own page, linked below.
+
+If you're authoring, the practical how-to is
+[Author a skill](../guides/_shared/how-to/author-a-skill.md). This page exists
+so the format is *called out in one place* — what conforms to an external
+standard, what we add, and where each part is specified.
+
+## The three layers
+
+| Layer | What it is | Authoritative page |
+| --- | --- | --- |
+| 1. Skill | A `SKILL.md` + optional bundled files. Conforms to the open [agentskills.io](https://agentskills.io/specification) standard. | agentskills.io (external) + [`author-a-skill.md`](../guides/_shared/how-to/author-a-skill.md) |
+| 2. Pack | The envelope that ships a skill (and other primitives): `pack.toml`, `.apm/<primitive>/`, `seeds/`, `.claude-plugin/plugin.json`. | [`pack-layout.md`](pack-layout.md), [`pack-manifest.md`](pack-manifest.md) |
+| 3. Projection | One pack source → many agent outputs, routed by the adapter contract. | [`agentbundle.md`](agentbundle.md), [`../contracts/adapter.toml`](../contracts/adapter.toml) |
+
+Above all three sits the [catalogue](catalogue.md) — the `packs/` +
+`marketplace.json` directory these packs live in.
+
+## Layer 1 — the skill (an open standard)
+
+A skill is a directory with a `SKILL.md` at its root and optional
+`scripts/`, `references/`, and `assets/` beside it. The file's shape — YAML
+frontmatter (`name`, `description`, and optional `license`, `compatibility`,
+`metadata`, `allowed-tools`) followed by Markdown instructions — is the
+**[agentskills.io specification](https://agentskills.io/specification)**, an
+open format Anthropic released and many agents adopted. We conform to it
+rather than inventing our own; the field table, character limits, and naming
+rules are canonical there and we do not restate them (restating would drift).
+
+What this repo adds on top of the standard is one constraint, enforced by the
+linters ([`tools/lint-agent-artifacts.py`](../../tools/lint-agent-artifacts.py)
+on projections, `lint-packs` on sources), not a schema change:
+
+- **Frontmatter uses only the agentskills.io keys.** Project-specific data
+  goes under the `metadata:` escape hatch the spec provides — never as a
+  bespoke top-level key.
+- **`description` is a single-line scalar** — no folded YAML or line
+  continuations, because several target harnesses parse it loosely.
+
+The other four primitives a pack can carry — `agent`, `hook-body`,
+`hook-wiring`, `command` — are our own shapes, tabulated in
+[`pack-layout.md`](pack-layout.md) and specified in the adapter contract.
+
+## Layer 2 — the pack (the distribution envelope)
+
+A skill never ships alone; it ships inside a pack. The pack adds the metadata
+(`pack.toml`), the install-scope rules, the governance `seeds/`, and the
+Claude Code `plugin.json` that make a set of primitives installable as one
+cohesive kit. The on-disk shape and every file's role are in
+[`pack-layout.md`](pack-layout.md); how `pack.toml` metadata projects into the
+catalogue listing is in [`pack-manifest.md`](pack-manifest.md).
+
+## Layer 3 — projection (one source, many agents)
+
+The same pack source projects into Claude Code, Codex, Cursor, Copilot,
+Gemini, and Kiro, each with its own layout for skills and agents. Which
+projection mode applies to each primitive per adapter is declared in
+[`../contracts/adapter.toml`](../contracts/adapter.toml) and executed by the
+build pipeline described in [`agentbundle.md`](agentbundle.md). The
+authoritative format spec for the projection modes is
+[`../specs/distribution-adapters/spec.md`](../specs/distribution-adapters/spec.md).
+
+## Where to read next
+
+- [`catalogue.md`](catalogue.md) — the directory these packs live in, and how
+  to stand up your own.
+- [Author a skill](../guides/_shared/how-to/author-a-skill.md) — the hands-on
+  how-to, including the `evals/` convention.
+- [`pack-layout.md`](pack-layout.md) — the pack's on-disk shape.

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -47,6 +47,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   applies to `architecture-beta` (with a table / bullet-list fallback), so
   flowchart and C4 stay the defaults. The diagram rubric also gains explicit
   per-type complexity budgets plus additive accent- and edge-count caps.
+- **Docs now call out the catalogue and skill/pack format as first-class, and ship an `llms.txt`.**
+  New `docs/architecture/catalogue.md` names what a catalogue *is* on disk (the
+  `packs/` + `.claude-plugin/marketplace.json` markers), how `agentbundle`
+  resolves one through its four-layer chain, and how to point it at your own —
+  the starting point for standing up your own catalogue. New
+  `docs/architecture/skill-and-pack-format.md` maps the format in three layers
+  (the agentskills.io skill standard, the pack envelope, projection). A root
+  `llms.txt` indexes the key docs so an agent can read the relevant pages
+  instead of scanning the whole repo. The architecture and top-level READMEs
+  route to both.
 - **`agentbundle list-installed` — see what you actually have installed (CLI 0.10.0).**
   A new read-only command lists every installed `(pack, adapter)` row across the
   user and repo scope with its version and an `up-to-date` / `upgrade-available`

--- a/docs/specs/convenient-install-defaults/spec.md
+++ b/docs/specs/convenient-install-defaults/spec.md
@@ -233,8 +233,10 @@ behaviour only proves out across the install boundary, so it is named at
   (resolved cwd-relative via `Path.resolve()`), per the trust-boundary carve-out;
   that is not the resolver consulting cwd on its own.
 - [x] When **no** layer yields a source, the command errors clearly with text
-  naming all three recovery paths:
-  `no catalogue source: pass --catalogue, run 'agentbundle config set source …', or pip install -e the catalogue`.
+  naming all three recovery paths (the user-facing text names the real surface —
+  a trailing catalogue argument — not the `--catalogue` shorthand this spec uses
+  elsewhere, since no such flag exists):
+  `no catalogue source: pass a catalogue argument, run 'agentbundle config set source …', or pip install -e the catalogue`.
 - [x] Resolution writes nothing on **any** path — a one-off `--catalogue` (or any
   auto-resolved layer) does **not** persist to the user config (no
   write-on-install), including the editable-detected-but-deferred (diagnostic) and

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,44 @@
+# agent-ready-repo
+
+> A loop your coding agent can't cut corners in, and a catalogue of installable
+> kits (skills, subagents, hooks) for the jobs around the code. `agentbundle`
+> installs packs from a catalogue into any agent (Claude Code, Codex, Cursor,
+> Copilot, Gemini, Kiro); `credbroker` resolves secrets without leaking them to
+> the model. This file indexes the docs so a tool can read the few relevant
+> pages instead of scanning the whole tree. Links point at raw file content.
+
+## Start here
+
+- [README](https://raw.githubusercontent.com/eugenelim/agent-ready-repo/main/README.md): what the project is, quick start, the catalogue table.
+- [AGENTS.md](https://raw.githubusercontent.com/eugenelim/agent-ready-repo/main/AGENTS.md): the canonical agent-context file — how to work in this repo.
+- [Charter](https://raw.githubusercontent.com/eugenelim/agent-ready-repo/main/docs/CHARTER.md): mission, scope, and the principles that gate what gets built.
+- [Conventions](https://raw.githubusercontent.com/eugenelim/agent-ready-repo/main/docs/CONVENTIONS.md): how we work — the loop, commits, the doc hierarchy.
+
+## Architecture
+
+- [Overview](https://raw.githubusercontent.com/eugenelim/agent-ready-repo/main/docs/architecture/overview.md): the map of the monorepo — packages, packs, docs. Read first.
+- [Catalogue](https://raw.githubusercontent.com/eugenelim/agent-ready-repo/main/docs/architecture/catalogue.md): what a catalogue is, how agentbundle finds one, and how to stand up your own.
+- [Skill & pack format](https://raw.githubusercontent.com/eugenelim/agent-ready-repo/main/docs/architecture/skill-and-pack-format.md): the format in three layers — the agentskills.io skill standard, the pack envelope, projection.
+- [Pack layout](https://raw.githubusercontent.com/eugenelim/agent-ready-repo/main/docs/architecture/pack-layout.md): the on-disk shape of a single pack and what each file does.
+- [Pack manifest](https://raw.githubusercontent.com/eugenelim/agent-ready-repo/main/docs/architecture/pack-manifest.md): how pack.toml projects into each route's listing.
+- [agentbundle](https://raw.githubusercontent.com/eugenelim/agent-ready-repo/main/docs/architecture/agentbundle.md): the CLI + build pipeline (recipes → adapters → projections).
+- [Credentials](https://raw.githubusercontent.com/eugenelim/agent-ready-repo/main/docs/architecture/credentials.md): the credbroker resolver and the credentialed-primitive model.
+
+## Format contracts
+
+- [Adapter contract](https://raw.githubusercontent.com/eugenelim/agent-ready-repo/main/docs/contracts/adapter.toml): the machine-readable per-adapter projection rules and primitive types.
+- [Pack schema](https://raw.githubusercontent.com/eugenelim/agent-ready-repo/main/docs/contracts/pack.schema.json): the JSON Schema for pack.toml.
+- [Distribution adapters spec](https://raw.githubusercontent.com/eugenelim/agent-ready-repo/main/docs/specs/distribution-adapters/spec.md): the authoritative spec for the projection modes.
+
+## Guides
+
+- [Guides index](https://raw.githubusercontent.com/eugenelim/agent-ready-repo/main/docs/guides/README.md): the Diátaxis guide set, organized by pack.
+- [Author a skill](https://raw.githubusercontent.com/eugenelim/agent-ready-repo/main/docs/guides/_shared/how-to/author-a-skill.md): the hands-on how-to for writing a SKILL.md, including evals.
+- [Build an org stack pack](https://raw.githubusercontent.com/eugenelim/agent-ready-repo/main/docs/guides/_shared/how-to/build-an-org-stack-pack.md): the full recipe for standing up your own catalogue.
+- [Why a catalogue](https://raw.githubusercontent.com/eugenelim/agent-ready-repo/main/docs/guides/_shared/explanation/pack-catalogue.md): the adopter-facing explanation of the catalogue model.
+
+## Optional
+
+- [RFC index](https://raw.githubusercontent.com/eugenelim/agent-ready-repo/main/docs/rfc/README.md): proposals and their status — the project's governance history.
+- [ADR index](https://raw.githubusercontent.com/eugenelim/agent-ready-repo/main/docs/adr/README.md): frozen architecture decisions and their rationale.
+- [Backlog](https://raw.githubusercontent.com/eugenelim/agent-ready-repo/main/docs/backlog.md): the top-level index of open spec items.

--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -8,6 +8,13 @@ the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 
 ## [Unreleased]
 
+### Fixed
+
+- **The "no catalogue source" error no longer sends you to a `--catalogue` flag
+  that doesn't exist.** The catalogue is a trailing positional argument; when no
+  source resolves, the recovery text now reads "pass a catalogue argument …" so
+  following it actually works.
+
 ## [0.9.0] — 2026-06-26
 
 ### Changed

--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -8,12 +8,35 @@ the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 
 ## [Unreleased]
 
+## [0.10.1] — 2026-06-30
+
 ### Fixed
 
 - **The "no catalogue source" error no longer sends you to a `--catalogue` flag
   that doesn't exist.** The catalogue is a trailing positional argument; when no
   source resolves, the recovery text now reads "pass a catalogue argument …" so
   following it actually works.
+
+## [0.10.0] — 2026-06-30
+
+_Backfilled: 0.10.0 shipped (tag `agentbundle-v0.10.0`) without a changelog
+entry; recorded here for the history._
+
+### Added
+
+- **`agentbundle list-installed` — a read-only view of what's actually installed.**
+  Lists every installed `(pack, adapter)` row across the user and repo scope with
+  its version and an `up-to-date` / `upgrade-available` / `unknown` status against
+  the catalogue; the check degrades to `unknown` (never an error) when the
+  catalogue can't be resolved. `--no-check` / `--offline` skips it, `--scope`
+  filters to one scope, and `--check-drift` adds a per-row count of files edited
+  locally since install (#468).
+
+### Changed
+
+- **Upgrade messaging now reports per-adapter versions and distinguishes a
+  re-applied install from a genuine upgrade**, and flags local drift from the
+  installed baseline (#468).
 
 ## [0.9.0] — 2026-06-26
 

--- a/packages/agentbundle/agentbundle/source_defaults.py
+++ b/packages/agentbundle/agentbundle/source_defaults.py
@@ -38,10 +38,13 @@ _WIN_DRIVE_RE = re.compile(r"^[A-Za-z]:[\\/]")
 _MARKER_DIR = "packs"
 _MARKER_FILE = (".claude-plugin", "marketplace.json")
 
-# The exact substring the spec pins for the all-layers-empty error.
+# The exact substring the spec pins for the all-layers-empty error. Names the
+# real surface: the catalogue is a trailing positional argument, not a
+# `--catalogue` flag (no such flag exists), so the recovery text must not send
+# the user to one.
 _NO_SOURCE_MSG = (
-    "no catalogue source: pass --catalogue, run 'agentbundle config set "
-    "source …', or pip install -e the catalogue"
+    "no catalogue source: pass a catalogue argument, run 'agentbundle config "
+    "set source …', or pip install -e the catalogue"
 )
 
 # Sentinel: distinguishes "caller did not pass a distribution" (load it

--- a/packages/agentbundle/agentbundle/version.py
+++ b/packages/agentbundle/agentbundle/version.py
@@ -14,7 +14,7 @@ import tomllib
 from importlib.resources import files
 from pathlib import Path
 
-CLI_VERSION = "0.10.0"
+CLI_VERSION = "0.10.1"
 
 _HERE = Path(__file__).resolve().parent
 

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentbundle"
-version = "0.10.0"
+version = "0.10.1"
 description = "npm for your coding agent. Install packs of skills, subagents, and hooks into any repo, for every major agent."
 requires-python = ">=3.11"
 dependencies = []

--- a/packages/agentbundle/tests/unit/test_source_defaults.py
+++ b/packages/agentbundle/tests/unit/test_source_defaults.py
@@ -343,8 +343,8 @@ def test_all_layers_empty_raises_with_recovery_paths():
         )
     msg = str(exc.value)
     assert (
-        "no catalogue source: pass --catalogue, run 'agentbundle config set "
-        "source …', or pip install -e the catalogue" in msg
+        "no catalogue source: pass a catalogue argument, run 'agentbundle config "
+        "set source …', or pip install -e the catalogue" in msg
     )
     assert "config unset source" in msg  # the stale-value recovery path
 


### PR DESCRIPTION
## What & why

The docs were strong on machine contracts (`pack.schema.json`, `adapter.toml`) but weak on adopter narrative: the skill/pack format was split across several files, the "catalogue" concept was never named as a contract, and there was no cheap way for a tool to index the docs. This makes the format first-class and gives adopters a clear path to stand up their own catalogue — modeled on how agentskills.io presents its format and how Terraform names its registry protocol.

## Changes

- **`docs/architecture/catalogue.md`** (new) — names the catalogue contract (`packs/` + `.claude-plugin/marketplace.json` as *the* contract), documents the four-layer source-resolution chain (explicit arg › `config set source` › editable-install detection › packaged default), and gives copy-paste recipes for pointing agentbundle at your own catalogue. Corrects the common "`~/.agentbundle/` is a source" confusion (it's a destination).
- **`docs/architecture/skill-and-pack-format.md`** (new) — the format in three layers: the agentskills.io skill standard we conform to → the pack envelope → projection. A map that links out to the authoritative pages, deliberately **not** a restatement of `pack-layout.md`.
- **`llms.txt`** (new, repo root) — an `llms.txt`-standard index using raw `raw.githubusercontent.com` URLs, so a tool reads the ~20 relevant docs instead of triggering an expensive full-repo scan. Deep governance is under `## Optional`.
- **Routing** — the architecture README and the top-level README both point to the two new docs.

## Bundled fixes (same-area)

- The "no catalogue source" error told users to `pass --catalogue`, but that flag doesn't exist — the catalogue is a **trailing positional** argument. Corrected to "pass a catalogue argument" across `source_defaults.py`, its unit test, and the spec AC in `convenient-install-defaults/spec.md`. The RFC/ADR/spec-prose `--catalogue` *shorthand* is left as-is (the spec's Surface note declares it deliberate). This is a user-facing `fix:` in the publishable `agentbundle` package — staged under `[Unreleased]`, wants a patch release when cut.
- Indexed the pre-existing `pack-manifest.md` in the architecture README (both new pages link to it, so leaving it out of the index was a dangling gap).

## Verification

- 45/45 `test_source_defaults.py` pass; every relative link in the new docs and `llms.txt` resolves.
- adversarial-reviewer pass: clean on substance (4-layer chain, markers, config location, error-string consistency, no duplication all verified against source).
- Changelogs updated: `agentbundle/CHANGELOG.md` (Fixed) + `docs/product/changelog.md` (Added).