### PR TITLE
fix(agentbundle): forward --adapter through the install→upgrade offer (0.10.2)

### DIFF
--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -8,6 +8,17 @@ the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 
 ## [Unreleased]
 
+## [0.10.2] — 2026-06-30
+
+### Fixed
+
+- **`install --adapter X` now carries that adapter through when it hands off to
+  `upgrade`.** Installing a pack that is already present, with `--adapter`
+  specified, offers to upgrade instead — but the hand-off dropped the adapter,
+  so a pack installed for more than one adapter at that scope hit upgrade's
+  "pass `--adapter` to pick one" disambiguator even though you had just passed
+  it. The offered upgrade now targets the adapter you named.
+
 ## [0.10.1] — 2026-06-30
 
 ### Fixed

--- a/packages/agentbundle/agentbundle/commands/install.py
+++ b/packages/agentbundle/agentbundle/commands/install.py
@@ -1888,9 +1888,9 @@ def _offer_upgrade(
     ``yes=True``. Builds the FULL attribute set ``upgrade.run`` reads — mapping
     ``install.output`` → ``upgrade.root``, pinning the concrete install-resolved
     ``scope`` (never ``None`` so upgrade's own multi-scope disambiguator is a
-    no-op), threading ``_user_config`` so adapter resolution matches a direct
-    ``upgrade`` invocation, and leaving all five primitive flags unset
-    (whole-pack). Returns ``upgrade.run``'s exit code.
+    no-op), forwarding ``--adapter`` and threading ``_user_config`` so adapter
+    resolution matches a direct ``upgrade`` invocation, and leaving all five
+    primitive flags unset (whole-pack). Returns ``upgrade.run``'s exit code.
     """
     import argparse as _argparse
 
@@ -1904,6 +1904,11 @@ def _offer_upgrade(
     ns.catalogue = catalogue_uri
     ns.root = getattr(args, "output", ".")
     ns.scope = scope
+    # RFC-0052: forward the install-side `--adapter` so upgrade targets the same
+    # adapter the user picked. Without this, a pack installed for multiple
+    # adapters at one scope trips upgrade's multi-adapter disambiguator even
+    # though the operator already passed `--adapter` to `install`.
+    ns.adapter = getattr(args, "adapter", None)
     ns.yes = True
     ns.dry_run = False
     ns.skill = ns.agent = ns.hook = ns.seed = ns.command = None

--- a/packages/agentbundle/agentbundle/version.py
+++ b/packages/agentbundle/agentbundle/version.py
@@ -14,7 +14,7 @@ import tomllib
 from importlib.resources import files
 from pathlib import Path
 
-CLI_VERSION = "0.10.1"
+CLI_VERSION = "0.10.2"
 
 _HERE = Path(__file__).resolve().parent
 

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentbundle"
-version = "0.10.1"
+version = "0.10.2"
 description = "npm for your coding agent. Install packs of skills, subagents, and hooks into any repo, for every major agent."
 requires-python = ">=3.11"
 dependencies = []

--- a/packages/agentbundle/tests/integration/test_install_default_source.py
+++ b/packages/agentbundle/tests/integration/test_install_default_source.py
@@ -106,6 +106,24 @@ def test_offer_upgrade_hands_off_resolved_uri(monkeypatch):
     assert captured["ns"].catalogue == "git+https://resolved/x"
 
 
+def test_offer_upgrade_forwards_adapter(monkeypatch):
+    # RFC-0052 regression: the install→upgrade-offer hand-off must forward the
+    # install-side `--adapter`, otherwise upgrade's multi-adapter disambiguator
+    # demands `--adapter` even though the operator passed it to `install`.
+    from agentbundle.commands import upgrade as _upgrade
+
+    captured = {}
+    monkeypatch.setattr(_upgrade, "run", lambda ns: captured.setdefault("ns", ns) and 0)
+
+    args = argparse.Namespace(
+        catalogue=None, output=".", _user_config=None, adapter="claude-code"
+    )
+    install._offer_upgrade(
+        args, pack_name="research", scope="user", catalogue_uri="git+https://resolved/x"
+    )
+    assert captured["ns"].adapter == "claude-code"
+
+
 def test_bare_list_packs_resolves_default_source(tmp_path):
     # RFC-0047: a bare `list-packs` (no catalogue) resolves the source via the
     # same chain and lists the catalogue's packs.

--- a/packages/agentbundle/tests/integration/test_install_upgrade_offer.py
+++ b/packages/agentbundle/tests/integration/test_install_upgrade_offer.py
@@ -79,6 +79,7 @@ def test_offer_accept_runs_upgrade_with_full_handoff(tmp_path, monkeypatch):
     assert ns.yes is True
     assert ns.dry_run is False
     assert ns.skill is ns.agent is ns.hook is ns.seed is ns.command is None
+    assert ns.adapter is None, "handoff must carry the install-side --adapter (None here)"
     assert hasattr(ns, "_user_config")
 
 


### PR DESCRIPTION
## What

`agentbundle install --pack X --scope user --adapter Y` of an already-installed pack offers to upgrade instead — but the offered upgrade dropped the `--adapter`, so a pack installed for more than one adapter at that scope hit upgrade's "pass `--adapter` to pick one" disambiguator even though the operator had just passed it.

Repro (the reported case):

```
$ agentbundle install --pack research --scope user --adapter claude-code
research is already installed at user. Upgrade it instead? [y/N] y
upgrade: research installed for multiple adapters at user scope; pass --adapter to pick one: claude-code (0.5.1), codex (0.5.1)
```

## Root cause

`_offer_upgrade` in `install.py` builds a fresh `Namespace` for `upgrade.run` and threads through `scope`, `catalogue`, `_user_config`, and the primitive flags — but never set `ns.adapter`. `upgrade.run` reads it via `getattr(args, "adapter", None)`, got `None`, and fell into the multi-adapter disambiguator. The docstring already claimed the hand-off made "adapter resolution match a direct upgrade invocation"; the flag was simply missing.

## Fix

Forward `ns.adapter = getattr(args, "adapter", None)` in the hand-off (RFC-0052), plus a docstring correction.

## Tests

- New `test_offer_upgrade_forwards_adapter` — asserts the hand-off namespace carries the install-side `--adapter` (raised `AttributeError` before the fix).
- Strengthened the existing full-hand-off test to assert `ns.adapter` is present.

## Release

Patch bump `0.10.1 → 0.10.2` (`pyproject.toml` + `CLI_VERSION` + CHANGELOG). No user-facing capability change, so the README is untouched. Tag `agentbundle-v0.10.2` after merge to publish.
