### PR TITLE
feat(converters): no-ML Tier-0 document floor + unified output contract (0.3.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -70,7 +70,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "converters",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.2.3"
+      "version": "0.3.0"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -427,6 +427,19 @@ jobs:
         working-directory: packs/converters/.apm/skills/markdown-to-xlsx/scripts
         run: python -m pytest test_render.py
 
+      # file-to-markdown skill scripts (extraction-tier0-and-output-contract):
+      # the shared output-contract builder, the defensive-parsing helpers, the
+      # tiered dispatch + Tier-0 extractors, and the image-branch reconciler.
+      # CI does not auto-discover skill-script pytest, so wire them explicitly
+      # or the contract / no-ML-floor / defensive-parsing behaviour never gates.
+      # pypdf is the Tier-0 PDF library (pip-on-demand at runtime, pinned here);
+      # the Office libraries installed above cover the docx/xlsx/pptx lib paths.
+      - name: pip install the Tier-0 PDF library (extraction-tier0)
+        run: pip install 'pypdf==5.1.0'
+      - name: pytest file-to-markdown extraction (extraction-tier0-and-output-contract)
+        working-directory: packs/converters/.apm/skills/file-to-markdown/scripts
+        run: python -m pytest test_contract.py test_safe_io.py test_convert.py test_reconcile.py
+
       - name: profiles lint + self-test (pack-profiles AC9)
         # RFC-0034: profiles must be scope-homogeneous, dependency-complete
         # (incl. version), and deps-first ordered. The self-test proves the

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1211,3 +1211,18 @@ input format** at Tier 0 (D7; spec AC7). Full **MIME** handling for
 beyond a flat `.eml` read) is **deferred** — it belongs with the
 `msg-to-markdown` Python port above, not the file-to-markdown floor. **Unblocks
 when:** the `msg-to-markdown` Python-port slice is picked up.
+
+### extraction-image-pixel-bomb-guard
+
+**Source:** implementation-stage security review of
+[`extraction-tier0-and-output-contract`](specs/extraction-tier0-and-output-contract/spec.md)
+(finding 3). `convert.py`'s `_prescale_image` disables PIL's decompression-bomb
+guard (`Image.MAX_IMAGE_PIXELS = None`) with no dimension ceiling before decode,
+so a pixel-flood image is fully decoded before the `MAX_IMAGE_DIM` downscale can
+help. **Deferred — out of this floor's scope:** this is the **Tier-2 image
+branch**, which the floor spec's Assumptions deliberately keep under the image
+branch's *local-files-trusted* carve-out (the untrusted-input posture is scoped
+to the Tier-0 document floor). The behavior is also **pre-existing** (the floor
+only relocated the code into `_extract_docling`). **Unblocks when:** a follow-on
+hardens the image branch's trust posture — refuse a hard pixel ceiling *before*
+decode rather than disabling `MAX_IMAGE_PIXELS` unconditionally.

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -17,6 +17,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`file-to-markdown` gains a no-ML Tier-0 floor and a versioned output
+  contract (converters 0.3.0).** Where Docling's ML models are banned or
+  un-fetchable, `file-to-markdown` can now convert a digital PDF (via `pypdf`),
+  Office files (`.docx`/`.xlsx`/`.pptx`, degrading to a stdlib path when the
+  ordinary library is absent), and the everyday text formats (HTML, EPUB,
+  CSV/TSV, OpenDocument, `.eml`) to Markdown using only pure-Python or standard-
+  library parsers — no ML model, no network. Docling stays as the higher-
+  fidelity Tier 2 for `.xls` and images. Every extraction, across both the
+  document and image branches, now carries one versioned YAML frontmatter
+  contract recording provenance and a quality signal (`contract-version`,
+  `tier`, `extraction-confidence`, `requires-review`), so a scanned PDF that
+  yields sparse text is flagged `requires-review` and pointed at an escalation
+  tier instead of passing silently. The default invocation is unchanged
+  (`python scripts/convert.py "<input-file>"`); the Tier-0 PDF/Office libraries
+  install on demand (`python scripts/convert.py --check`), and untrusted input
+  is parsed defensively (XXE-safe XML, decompression-bomb guards, output-path
+  confinement, resource ceilings).
+
 ### Fixed
 
 - **`file-to-markdown` image extraction no longer silently loses elements

--- a/docs/specs/extraction-tier0-and-output-contract/plan.md
+++ b/docs/specs/extraction-tier0-and-output-contract/plan.md
@@ -1,7 +1,7 @@
 # Plan: extraction-tier0-and-output-contract
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Drafting <!-- Drafting | Executing | Done -->
+- **Status:** Done <!-- Drafting | Executing | Done -->
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
 > document is allowed to change as you learn. When it changes substantially

--- a/docs/specs/extraction-tier0-and-output-contract/spec.md
+++ b/docs/specs/extraction-tier0-and-output-contract/spec.md
@@ -1,6 +1,6 @@
 # Spec: extraction-tier0-and-output-contract
 
-- **Status:** Approved
+- **Status:** Shipped
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** RFC-0058, ADR-0045, ADR-0034 (no bundled per-vendor data / models), RFC-0007 (the converters pack this changes; § Errata)
@@ -165,7 +165,7 @@ passing silently. Docling stays available and unchanged as the higher-fidelity
 
 ## Acceptance Criteria
 
-- [ ] **AC1 — Unified output contract, versioned.** Both of `file-to-markdown`'s
+- [x] **AC1 — Unified output contract, versioned.** Both of `file-to-markdown`'s
   output shapes — `convert.py` (the document path *and* the image-via-Docling
   path, one `convert_file` shape) and `reconcile.py` (the diagram/image branch) —
   emit YAML frontmatter carrying at minimum `contract-version` (a string, e.g.
@@ -175,7 +175,7 @@ passing silently. Docling stays available and unchanged as the higher-fidelity
   sites cannot drift. (`msg-to-markdown` is Node.js and adopts the contract in a
   follow-on Python-port slice — deferred: extraction-msg-to-markdown-python-contract.)
 
-- [ ] **AC2 — Additive and byte-stable for the image branch (no consumer break).**
+- [x] **AC2 — Additive and byte-stable for the image branch (no consumer break).**
   Every frontmatter key `reconcile.py` emits today (`title`, `source-file`,
   `content-type`, `content-category`, `ingestion-date`, `diagram-type`,
   `processing.*`, `ingestion-quality.*`) is still present and unchanged in name,
@@ -184,34 +184,34 @@ passing silently. Docling stays available and unchanged as the higher-fidelity
   pre-existing block (proving the shared-builder refactor did not reorder or
   re-quote it).
 
-- [ ] **AC3 — Document branch is context-layer-ready.** `convert.py` (the
+- [x] **AC3 — Document branch is context-layer-ready.** `convert.py` (the
   document branch) emits the unified frontmatter above its Markdown body — where
   today it emits none. Its `extraction-confidence` and `requires-review` reflect
   the extraction (see AC6).
 
-- [ ] **AC4 — Tier-0 digital-PDF text extraction with no ML.** A digital
+- [x] **AC4 — Tier-0 digital-PDF text extraction with no ML.** A digital
   (text-layer) PDF is converted to Markdown using `pypdf` — a pure-Python,
   no-model dependency — with `tier: "0-no-ml"` in the frontmatter, and without
   importing Docling or any ML/OCR model.
 
-- [ ] **AC5 — Tier-0 Office extraction, degrading to stdlib.** `.docx`, `.xlsx`,
+- [x] **AC5 — Tier-0 Office extraction, degrading to stdlib.** `.docx`, `.xlsx`,
   and `.pptx` are converted to Markdown at Tier 0. When `python-docx` /
   `openpyxl` / `python-pptx` are present the extractor uses them (verified via a
   `--check` import-probe mirroring the sibling `markdown-to-*` skills); when they
   are absent the extractor degrades to stdlib `zipfile`+XML and still produces
   Markdown. Neither path imports an ML model.
 
-- [ ] **AC6 — Sparse-text self-assessment escalates honestly.** When Tier-0 PDF
+- [x] **AC6 — Sparse-text self-assessment escalates honestly.** When Tier-0 PDF
   extraction returns empty or sparse text (below a defined threshold), the output
   is marked `extraction-confidence: low` and `requires-review: true`, and the
   skill's output names Tier 1 (agent-vision) as the escalation target — it does
   not silently emit low-quality Markdown.
 
-- [ ] **AC7 — Tier-0 format coverage (D7).** HTML, EPUB, CSV/TSV, OpenDocument
+- [x] **AC7 — Tier-0 format coverage (D7).** HTML, EPUB, CSV/TSV, OpenDocument
   (ODT/ODS/ODP), and `.eml` inputs each convert to Markdown at Tier 0 using
   stdlib or ordinary libraries (no ML), each carrying the unified frontmatter.
 
-- [ ] **AC8 — Extracted content cannot forge the contract.** The hand-rolled
+- [x] **AC8 — Extracted content cannot forge the contract.** The hand-rolled
   emitter escapes/quotes every frontmatter *value* — including embedded newlines,
   `"`, and `\` — so a value can never break out of its scalar and split the block
   (a raw `\n` inside a `"..."` scalar would break the fence; escaping it is the
@@ -224,7 +224,7 @@ passing silently. Docling stays available and unchanged as the higher-fidelity
   test whose extracted *body* contains `---` and `contract-version:` lines,
   asserting a frontmatter parser reads only the builder's leading block.
 
-- [ ] **AC9 — Defensive parsing of untrusted input.** The skill's own XML reads
+- [x] **AC9 — Defensive parsing of untrusted input.** The skill's own XML reads
   use only an XXE-safe parser (stdlib `xml.etree.ElementTree` or `defusedxml`);
   `lxml`/`minidom`/`sax` at defaults are not used (see Boundaries). Reading a
   zip-based format is refused **before full decompression** on every axis — an
@@ -238,7 +238,7 @@ passing silently. Docling stays available and unchanged as the higher-fidelity
   nested-archive bomb axis and legitimate EPUB/ODF structure are reconciled (AC7).
   Tests exercise the XXE guard, each bomb axis, and a `../`-entry-name fixture.
 
-- [ ] **AC10 — Docling path body is passed through unmodified.** The Docling
+- [x] **AC10 — Docling path body is passed through unmodified.** The Docling
   (Tier-2) path gains only the two additive contract keys (`contract-version`,
   `tier: "2-approved-ml"`); an **in-process identity assertion** proves the
   Markdown body handed to the builder equals the body Docling returned (byte-parity
@@ -246,7 +246,7 @@ passing silently. Docling stays available and unchanged as the higher-fidelity
   a Docling-running environment behaves identically apart from the richer
   frontmatter.
 
-- [ ] **AC11 — Tests + release hygiene + progressive-disclosure default.** New
+- [x] **AC11 — Tests + release hygiene + progressive-disclosure default.** New
   tests cover AC1–AC10, AC12, AC13 (unit + per-format end-to-end subprocess runs
   of the documented invocations) and pass; the converters pack version is bumped
   consistently across `pack.toml`, `.claude-plugin/plugin.json`, and the
@@ -256,7 +256,7 @@ passing silently. Docling stays available and unchanged as the higher-fidelity
   confirms its documented **default invocation is still the single
   `python scripts/convert.py "<input-file>"` form**.
 
-- [ ] **AC12 — Output-path confinement.** The written `.md` path is resolved
+- [x] **AC12 — Output-path confinement.** The written `.md` path is resolved
   (`Path.resolve()`/realpath) and confined to the intended output directory by
   path-component containment (not string-prefix); a target path escaping via `..`
   traversal or via a symlink is refused. Tests cover the `..`-traversal, the
@@ -265,7 +265,7 @@ passing silently. Docling stays available and unchanged as the higher-fidelity
   component-containment must reject), mirroring the `markdown-to-office-publishing`
   benchmark.
 
-- [ ] **AC13 — Resource ceiling on Tier-0 parsers.** Each Tier-0 parser enforces
+- [x] **AC13 — Resource ceiling on Tier-0 parsers.** Each Tier-0 parser enforces
   a coarse upper bound (max input bytes and/or max pages/rows/entries); an input
   exceeding it is refused with an actionable error and `requires-review` rather
   than parsed unbounded, so an attacker-supplied huge file cannot hang context

--- a/packs/converters/.apm/skills/file-to-markdown/SKILL.md
+++ b/packs/converters/.apm/skills/file-to-markdown/SKILL.md
@@ -45,7 +45,9 @@ python scripts/convert.py --check          # report which optional libs are pres
 `pypdf` (PDF) and `python-docx` / `openpyxl` / `python-pptx` (Office) are each
 optional. When an Office library is absent the extractor degrades to a stdlib
 `zipfile` + XML path and still produces Markdown; when `pypdf` is absent PDF
-extraction escalates to Tier 1 rather than failing. Docling (Tier 2) is only
+extraction escalates to Tier 1 rather than failing. These libraries install into
+*your* environment on demand, so they sit outside this repo's dependency lockfile
+and its SCA scanning — keep them current yourself. Docling (Tier 2) is only
 needed for `.xls` and images:
 
 ```bash

--- a/packs/converters/.apm/skills/file-to-markdown/SKILL.md
+++ b/packs/converters/.apm/skills/file-to-markdown/SKILL.md
@@ -1,55 +1,97 @@
 ---
 name: file-to-markdown
-description: Convert documents and images to Markdown. Documents (PDF, DOCX, PPTX, XLSX, XLS) go through Docling text extraction (`scripts/convert.py`); images (PNG, JPG, JPEG, TIFF, BMP, WEBP, GIF) go through a two-pass sliding-window vision pipeline whose tiling and reconciliation are deterministic (`scripts/split_image.py` and `scripts/reconcile.py`). The agent's job is the per-tile vision read; tile dedup and ordering are handled by the script.
+description: Convert documents and images to Markdown for AI context layers. Documents (PDF, DOCX, XLSX, PPTX, HTML, EPUB, CSV/TSV, OpenDocument, .eml) go through `scripts/convert.py`, which extracts at a no-ML Tier-0 floor (pure-Python / stdlib parsers) and falls through to Docling (Tier 2) only for .xls and images; images go through a two-pass sliding-window vision pipeline whose tiling and reconciliation are deterministic (`scripts/split_image.py` and `scripts/reconcile.py`). Every output carries a versioned frontmatter contract (provenance + a quality/confidence signal). The agent's job is the per-tile vision read; tile dedup and ordering are handled by the script.
 ---
 
 # File to Markdown
 
-A skill with two branches:
-
-| Input | Branch | Owner |
-|---|---|---|
-| PDF, DOCX, PPTX, XLSX, XLS | document | `scripts/convert.py` (Docling) |
-| PNG, JPG, JPEG, TIFF, BMP, WEBP, GIF | image | `scripts/split_image.py` + agent vision + `scripts/reconcile.py` |
-
-## Prerequisites
-
-The document branch needs Docling; both branches need Pillow:
-
-```bash
-python -m pip install docling Pillow
-```
-
-Before the document branch, confirm Docling is importable:
-
-```bash
-python -c "import docling"
-```
-
-Exit 0 → proceed. Non-zero → it's not installed; tell the user to run
-the `pip install` above and stop. Don't install it for them.
-
-First Docling run downloads ML models (~1–2 min). Subsequent runs are
-fast. Image-only flows need only Pillow.
-
----
-
-## Document branch
+Convert documents and images to Markdown for AI context layers. The default,
+covering almost every case, is one command:
 
 ```bash
 python scripts/convert.py "<input-file>"
 ```
 
-Writes `<basename>.md` next to the input. Stdout markers:
+Writes `<basename>.md` next to the input. Don't pre-process; don't merge
+multiple inputs in one call — loop the command.
+
+| Input | Branch | Owner |
+|---|---|---|
+| PDF, DOCX, XLSX, PPTX, HTML, EPUB, CSV/TSV, ODT/ODS/ODP, `.eml`, `.xls`, images | document | `scripts/convert.py` |
+| PNG, JPG, JPEG, TIFF, BMP, WEBP, GIF (diagram extraction) | image | `scripts/split_image.py` + agent vision + `scripts/reconcile.py` |
+
+## Tiers — no ML first (progressive disclosure)
+
+`convert.py` routes each input to the lowest tier that can handle it. You do
+not choose a tier; the script does.
+
+| Tier | What runs | Handles |
+|---|---|---|
+| **0 — no ML** | pure-Python / stdlib parsers, no model | PDF (text layer, via `pypdf`), DOCX/XLSX/PPTX, HTML, EPUB, CSV/TSV, ODT/ODS/ODP, `.eml` |
+| **1 — agent vision** | in-session per-tile vision read | the image branch below; also the escalation target when Tier-0 PDF text is sparse |
+| **2 — approved ML** | Docling | `.xls` and image OCR (the fall-through) |
+| **3 — managed API** | — | never reached; the skill makes no network calls |
+
+**Why this matters:** in a locked-down environment where Docling's ML models are
+banned or un-fetchable, Tier 0 still converts a digital PDF, an Office file, and
+the everyday text formats using only ordinary libraries or the standard library.
+
+Tier-0 PDF and Office use libraries that install on demand (never auto-installed):
+
+```bash
+python scripts/convert.py --check          # report which optional libs are present
+```
+
+`pypdf` (PDF) and `python-docx` / `openpyxl` / `python-pptx` (Office) are each
+optional. When an Office library is absent the extractor degrades to a stdlib
+`zipfile` + XML path and still produces Markdown; when `pypdf` is absent PDF
+extraction escalates to Tier 1 rather than failing. Docling (Tier 2) is only
+needed for `.xls` and images:
+
+```bash
+python -m pip install docling Pillow    # only if you need the Tier-2 fall-through
+```
+
+## The output contract
+
+Every conversion — document *and* image branch — writes a leading YAML
+frontmatter block recording provenance and a quality signal, then the Markdown
+body below it:
+
+```yaml
+---
+contract-version: "1.0"
+tier: "0-no-ml"
+source-file: "report.pdf"
+content-type: "pdf"
+ingestion-date: "2026-06-30T12:00:00+00:00"
+ingestion-quality:
+  extraction-confidence: "high"   # high | medium | low
+  requires-review: false
+---
+```
+
+`contract-version` is how a consumer detects the shape. When extraction is
+sparse or degraded, `extraction-confidence` is `low`, `requires-review` is
+`true`, and an `escalation-target` names the tier to retry at — so low-quality
+output is flagged, never emitted silently.
+
+Stdout markers:
 
 | Marker | Meaning |
 |---|---|
 | `OUTPUT: <path>` | Path to the written Markdown file |
 | `LINES: <n>` / `WORDS: <n>` | Counts |
-| `WARNING: <msg>` | Non-fatal (e.g., sparse text). Surface to user. |
+| `WARNING: <msg>` | Non-fatal (e.g., `requires-review`). Surface to user. |
 
-That's it. Don't pre-process. Don't merge multiple inputs in one call —
-loop the command.
+## Trust posture
+
+Document inputs are treated as **untrusted** (they feed AI context layers): XML
+is parsed with an XXE-safe stdlib parser (DTDs refused), zip-based formats are
+guarded against decompression bombs before decompression, the output path is
+confined to the input's directory, and each parser enforces a coarse resource
+ceiling. This is a deliberate divergence from the image branch's
+local-files-trusted stance.
 
 ---
 
@@ -172,8 +214,8 @@ re-extract).
 |---|---|
 | Image ≤ 1200 px on both dims | Skip overview; run `detail` with `--viewport <max-dim>` and `--stride <max-dim>` so you get a single tile. |
 | Source > 8000 px on a side | The script auto-prescales before tiling and records the scale factor in the manifest. No agent action needed. |
-| First Docling run | Warn the user about the one-time model download (1–2 min). |
-| Scanned PDF | Docling applies OCR automatically; output may be lower quality. Surface any `WARNING:` line. |
+| First Docling run (`.xls` / image only) | Warn the user about the one-time model download (1–2 min). |
+| Scanned / image-only PDF | Tier 0 finds little or no text layer, so the output is flagged `extraction-confidence: low` + `requires-review: true` and names Tier 1 (agent vision) as the escalation target. Surface the `WARNING:` line. |
 | Password-protected file | Document branch fails fast. Tell the user to remove the password first. |
 | Detail pass > 100 tiles | `split_image.py` warns. Increase `--stride` or reduce `--viewport`. |
 | Tile read fails | Skip the tile; the reconciler reports the gap as a missing region in `ambiguities`. |

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/contract.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/contract.py
@@ -6,21 +6,21 @@ Every extraction `file-to-markdown` produces — across both of its output
 shapes (``convert.py``'s document + image-via-Docling path, and
 ``reconcile.py``'s diagram/image branch) — carries one YAML frontmatter block
 recording provenance and a quality/confidence signal. This module is the single
-builder that emits it, so the call sites cannot drift (spec AC1).
+builder that emits it, so the call sites cannot drift.
 
-Design notes (spec § Boundaries, RFC-0058 D3):
+Design notes:
   * **No PyYAML.** The emitter is the skill's existing hand-rolled stdlib
     emitter (lifted from ``reconcile.py``), extended here. ``yaml.safe_dump``
     would add a dependency the skill deliberately avoids *and* reorder keys
-    alphabetically, breaking the image branch's byte-stability (AC2/AC10).
-  * **Injection-safe (AC8).** Every string *value* is escaped/quoted —
+    alphabetically, breaking the image branch's byte-stability.
+  * **Injection-safe.** Every string *value* is escaped/quoted —
     backslash, double-quote, and (the load-bearing fix over the original
     emitter) newline / carriage-return / tab — so extracted content containing
     ``---``, a newline, or a ``key:`` line cannot break out of its scalar and
     forge or truncate the contract. The contract is the *leading* ``---``-fenced
     block only; the extracted body sits below it, and a compliant frontmatter
     parser stops at the first closing ``---``.
-  * **Additive + byte-stable (AC2).** The two new keys (``contract-version``,
+  * **Additive + byte-stable.** The two new keys (``contract-version``,
     ``tier``) are top-level; the quality signal stays nested under
     ``ingestion-quality`` on both branches. A caller passes its own ordered
     top-level ``fields`` (so the image branch's existing key order is preserved
@@ -37,7 +37,7 @@ from typing import Any, Mapping
 # changing its *meaning* is a contract change (hence the field). Starts at 1.0.
 CONTRACT_VERSION = "1.0"
 
-# Tier enum (RFC-0058). The skill only ever emits 0/1/2; Tier 3 (managed API)
+# Tier enum. The skill only ever emits 0/1/2; Tier 3 (managed API)
 # is unreachable from this code — there is no network egress.
 TIER_0 = "0-no-ml"           # stdlib / ordinary parsers, no model
 TIER_1 = "1-agent-vision"    # in-session agent vision read (the image branch)
@@ -64,8 +64,8 @@ def build_frontmatter(
 
     ``fields`` is the branch's ordered top-level keys and MUST include
     ``source-file``, ``content-type``, and ``ingestion-date`` (the required
-    fields whose position differs per branch, so the caller owns their order —
-    AC2). The builder prepends ``contract-version`` + ``tier`` and appends the
+    fields whose position differs per branch, so the caller owns their order).
+    The builder prepends ``contract-version`` + ``tier`` and appends the
     ``ingestion-quality`` block ({extraction-confidence, *extras, requires-review}),
     so the quality signal is builder-owned and identical across branches.
     """
@@ -108,7 +108,7 @@ def now_iso() -> str:
 
 
 # --- Hand-rolled stdlib YAML emitter (no PyYAML) ---------------------------
-# Lifted from reconcile.py and extended with newline/CR/tab escaping (AC8).
+# Lifted from reconcile.py and extended with newline/CR/tab escaping.
 
 
 def _yaml_block(d: Mapping[str, Any]) -> str:
@@ -144,7 +144,7 @@ def _escape(s: str) -> str:
     Backslash first (so we don't double-escape the backslashes the later
     replacements insert), then the double-quote, then the whitespace escapes.
     Escaping the newline is the load-bearing fix over the original emitter: a
-    raw newline inside a ``"..."`` scalar would break the fence (AC8)."""
+    raw newline inside a ``"..."`` scalar would break the fence."""
     return (
         s.replace("\\", "\\\\")
         .replace('"', '\\"')

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/contract.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/contract.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+contract.py — the shared, versioned output-contract frontmatter builder.
+
+Every extraction `file-to-markdown` produces — across both of its output
+shapes (``convert.py``'s document + image-via-Docling path, and
+``reconcile.py``'s diagram/image branch) — carries one YAML frontmatter block
+recording provenance and a quality/confidence signal. This module is the single
+builder that emits it, so the call sites cannot drift (spec AC1).
+
+Design notes (spec § Boundaries, RFC-0058 D3):
+  * **No PyYAML.** The emitter is the skill's existing hand-rolled stdlib
+    emitter (lifted from ``reconcile.py``), extended here. ``yaml.safe_dump``
+    would add a dependency the skill deliberately avoids *and* reorder keys
+    alphabetically, breaking the image branch's byte-stability (AC2/AC10).
+  * **Injection-safe (AC8).** Every string *value* is escaped/quoted —
+    backslash, double-quote, and (the load-bearing fix over the original
+    emitter) newline / carriage-return / tab — so extracted content containing
+    ``---``, a newline, or a ``key:`` line cannot break out of its scalar and
+    forge or truncate the contract. The contract is the *leading* ``---``-fenced
+    block only; the extracted body sits below it, and a compliant frontmatter
+    parser stops at the first closing ``---``.
+  * **Additive + byte-stable (AC2).** The two new keys (``contract-version``,
+    ``tier``) are top-level; the quality signal stays nested under
+    ``ingestion-quality`` on both branches. A caller passes its own ordered
+    top-level ``fields`` (so the image branch's existing key order is preserved
+    verbatim); the builder owns only the two new keys, the quality block, and
+    validation.
+"""
+from __future__ import annotations
+
+from collections import OrderedDict
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+# The frontmatter contract version. Consumers key on this to detect the shape;
+# changing its *meaning* is a contract change (hence the field). Starts at 1.0.
+CONTRACT_VERSION = "1.0"
+
+# Tier enum (RFC-0058). The skill only ever emits 0/1/2; Tier 3 (managed API)
+# is unreachable from this code — there is no network egress.
+TIER_0 = "0-no-ml"           # stdlib / ordinary parsers, no model
+TIER_1 = "1-agent-vision"    # in-session agent vision read (the image branch)
+TIER_2 = "2-approved-ml"     # Docling (approved ML)
+TIER_3 = "3-managed-api"     # managed OCR/extraction API — never reached here
+TIERS = frozenset({TIER_0, TIER_1, TIER_2, TIER_3})
+
+CONFIDENCE_LEVELS = frozenset({"high", "medium", "low"})
+
+# Keys the builder owns; a caller's `fields` must not carry them, or it could
+# forge the contract by shadowing a builder-set key.
+_RESERVED = frozenset({"contract-version", "tier", "ingestion-quality"})
+
+
+def build_frontmatter(
+    *,
+    tier: str,
+    extraction_confidence: str,
+    requires_review: bool,
+    fields: Mapping[str, Any],
+    ingestion_quality_extra: Mapping[str, Any] | None = None,
+) -> str:
+    """Return the fenced YAML frontmatter block (no trailing newline).
+
+    ``fields`` is the branch's ordered top-level keys and MUST include
+    ``source-file``, ``content-type``, and ``ingestion-date`` (the required
+    fields whose position differs per branch, so the caller owns their order —
+    AC2). The builder prepends ``contract-version`` + ``tier`` and appends the
+    ``ingestion-quality`` block ({extraction-confidence, *extras, requires-review}),
+    so the quality signal is builder-owned and identical across branches.
+    """
+    if tier not in TIERS:
+        raise ValueError(f"unknown tier {tier!r}; expected one of {sorted(TIERS)}")
+    if extraction_confidence not in CONFIDENCE_LEVELS:
+        raise ValueError(
+            f"unknown extraction-confidence {extraction_confidence!r}; "
+            f"expected one of {sorted(CONFIDENCE_LEVELS)}"
+        )
+    reserved_in_fields = _RESERVED & set(fields)
+    if reserved_in_fields:
+        raise ValueError(
+            f"fields must not carry builder-owned keys {sorted(reserved_in_fields)}"
+        )
+    for required in ("source-file", "content-type", "ingestion-date"):
+        if required not in fields:
+            raise ValueError(f"fields is missing required key {required!r}")
+
+    block: "OrderedDict[str, Any]" = OrderedDict()
+    block["contract-version"] = CONTRACT_VERSION
+    block["tier"] = tier
+    for k, v in fields.items():
+        block[k] = v
+
+    iq: "OrderedDict[str, Any]" = OrderedDict()
+    iq["extraction-confidence"] = extraction_confidence
+    if ingestion_quality_extra:
+        for k, v in ingestion_quality_extra.items():
+            iq[k] = v
+    iq["requires-review"] = bool(requires_review)
+    block["ingestion-quality"] = iq
+
+    return _yaml_block(block)
+
+
+def now_iso() -> str:
+    """UTC ingestion timestamp, matching the image branch's format."""
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+# --- Hand-rolled stdlib YAML emitter (no PyYAML) ---------------------------
+# Lifted from reconcile.py and extended with newline/CR/tab escaping (AC8).
+
+
+def _yaml_block(d: Mapping[str, Any]) -> str:
+    """Minimal YAML emitter for flat-with-nesting frontmatter.
+
+    No anchors, no multi-line strings — every scalar is a double-quoted,
+    fully-escaped single line, so a value can never break out of its scalar."""
+    lines = ["---"]
+    _emit(d, lines, 0)
+    lines.append("---")
+    return "\n".join(lines)
+
+
+def _emit(d: Mapping[str, Any], lines: list[str], indent: int) -> None:
+    pad = "  " * indent
+    for k, v in d.items():
+        if isinstance(v, Mapping):
+            lines.append(f"{pad}{k}:")
+            _emit(v, lines, indent + 1)
+        elif isinstance(v, bool):
+            lines.append(f"{pad}{k}: {'true' if v else 'false'}")
+        elif v is None:
+            lines.append(f"{pad}{k}: null")
+        elif isinstance(v, (int, float)):
+            lines.append(f"{pad}{k}: {v}")
+        else:
+            lines.append(f'{pad}{k}: "{_escape(str(v))}"')
+
+
+def _escape(s: str) -> str:
+    """Escape a string for a YAML double-quoted scalar.
+
+    Backslash first (so we don't double-escape the backslashes the later
+    replacements insert), then the double-quote, then the whitespace escapes.
+    Escaping the newline is the load-bearing fix over the original emitter: a
+    raw newline inside a ``"..."`` scalar would break the fence (AC8)."""
+    return (
+        s.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/convert.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/convert.py
@@ -3,7 +3,7 @@
 convert.py — convert documents and images to Markdown, tiered and no-ML-first.
 
 The skill's document surface. It routes each input to the lowest tier that can
-handle it (RFC-0058):
+handle it:
 
   * **Tier 0 (no ML)** — pure-Python / stdlib extractors for digital PDFs
     (``pypdf``), Office files (``python-docx`` / ``openpyxl`` / ``python-pptx``,
@@ -57,11 +57,11 @@ DOCLING_EXTS = {".xls"} | IMAGE_EXTS
 # Images wider or taller than this are pre-scaled before Docling processes them.
 MAX_IMAGE_DIM = 4000
 
-# Sparse-text threshold (AC6): a digital PDF yielding fewer than this many words
+# Sparse-text threshold: a digital PDF yielding fewer than this many words
 # is treated as image-only / low-quality and escalated, not silently emitted.
 SPARSE_WORD_THRESHOLD = 20
 
-# Coarse per-parser ceilings (AC13).
+# Coarse per-parser ceilings.
 MAX_PDF_PAGES = 5_000
 MAX_SHEET_ROWS = 1_000_000
 MAX_CSV_ROWS = 1_000_000
@@ -107,9 +107,9 @@ def supported_exts() -> set[str]:
 
 def _refused_result(content_type: str, message: str) -> ExtractResult:
     """A refused-but-flagged result: the input was not fully parsed — a resource
-    ceiling (AC13) or a defensive-parse refusal (a DTD, a decompression bomb;
-    AC9). The output carries requires-review + the reason rather than passing
-    silently or crashing the batch."""
+    ceiling or a defensive-parse refusal (a DTD, a decompression bomb). The
+    output carries requires-review + the reason rather than passing silently
+    or crashing the batch."""
     return ExtractResult(
         body=f"> **Not extracted.** {message}\n",
         tier=contract.TIER_0,
@@ -147,7 +147,7 @@ def _assess_text(text: str) -> tuple[str, bool, str | None]:
     """Map extracted text to (confidence, requires_review, escalation).
 
     Sparse or empty text escalates honestly to Tier 1 (agent-vision) rather
-    than emitting silent low-quality Markdown (AC6)."""
+    than emitting silent low-quality Markdown."""
     if len(text.split()) < SPARSE_WORD_THRESHOLD:
         return "low", True, contract.TIER_1
     return "high", False, None
@@ -157,9 +157,8 @@ def _extract_pdf(path: Path) -> ExtractResult:
     if (over := _guard_size(path, "pdf")) is not None:
         return over
     if not _lib_available("pypdf"):
-        # No stdlib PDF text path — degrade to the sparse/escalation path
-        # (Boundaries: "PDF → the sparse-text escalation path") rather than
-        # importing Docling or hard-failing.
+        # No stdlib PDF text path — degrade to the sparse-text escalation path
+        # rather than importing Docling or hard-failing.
         return ExtractResult(
             body=(
                 "> **Tier-0 PDF text extraction needs `pypdf`, which is not "
@@ -205,7 +204,7 @@ def _extract_pdf(path: Path) -> ExtractResult:
 # Every Office file is opened through safe_io.open_safe_zip first (the
 # decompression-bomb axes) and its XML members are DTD-gated, so no DTD ever
 # reaches the ordinary library's transitive lxml parser — the stdlib-XXE-safe
-# resolution applied to the library path (spec AC9 / Assumptions).
+# resolution applied to the library path.
 
 _W = "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}"
 _A = "{http://schemas.openxmlformats.org/drawingml/2006/main}"
@@ -230,7 +229,7 @@ def _harden_for_lib(sz: "safe_io.SafeZip", content_type: str) -> ExtractResult |
     """Before an ordinary Office library re-opens the raw file, fully validate
     every member through SafeZip — the per-member + cumulative decompression
     caps and the whole-buffer DTD refusal that the library path would otherwise
-    bypass (spec AC9). Returns an ExtractResult on refusal, else None."""
+    bypass. Returns an ExtractResult on refusal, else None."""
     try:
         sz.harden_untrusted()
     except safe_io.ZipBombError as exc:
@@ -320,7 +319,7 @@ def _extract_xlsx(path: Path) -> ExtractResult:
         sz.close()
     body = body or "> **No cell values found.**\n"
     # A row-truncated sheet is not fully extracted — flag it for review rather
-    # than silently dropping the tail (AC13).
+    # than silently dropping the tail.
     if truncated:
         confidence = "low"
     return ExtractResult(body, contract.TIER_0, "xlsx", confidence, truncated)
@@ -416,7 +415,7 @@ class _TextHTMLParser:
 
     Emits block-level breaks for common structural tags and drops script/style
     content, which is enough for a context-layer floor (fidelity is Tier 2's
-    job, per § Risks)."""
+    job)."""
 
     def __init__(self) -> None:
         from html.parser import HTMLParser
@@ -647,7 +646,7 @@ def _extract_docling(input_path: Path) -> ExtractResult:
             shutil.rmtree(tmp_dir, ignore_errors=True)
 
     # The Docling body is passed through unmodified — the builder wraps, never
-    # rewrites (AC10).
+    # rewrites.
     return ExtractResult(
         body=markdown,
         tier=contract.TIER_2,
@@ -664,8 +663,7 @@ def assemble(result: ExtractResult, source_name: str) -> str:
     """Wrap an extraction in the unified output contract (frontmatter + body).
 
     The frontmatter is the leading ``---``-fenced block only; the body sits
-    below it, so a ``---`` line in the body is content, not a second block
-    (AC8)."""
+    below it, so a ``---`` line in the body is content, not a second block."""
     fields: dict[str, object] = {
         "source-file": source_name,
         "content-type": result.content_type,
@@ -684,7 +682,7 @@ def assemble(result: ExtractResult, source_name: str) -> str:
 
 def write_output(input_path: Path, text: str) -> Path:
     """Write ``<basename>.md`` next to the input, confined to the input's
-    resolved directory (realpath + component containment, AC12)."""
+    resolved directory (realpath + component containment)."""
     root = input_path.resolve().parent
     output_path = safe_io.confine(root / (input_path.stem + ".md"), root)
     output_path.write_text(text, encoding="utf-8")

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/convert.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/convert.py
@@ -105,10 +105,11 @@ def supported_exts() -> set[str]:
 # --- Shared guards ----------------------------------------------------------
 
 
-def _ceiling_result(content_type: str, message: str) -> ExtractResult:
-    """A refused-but-flagged result: the input tripped a resource ceiling, so we
-    do not parse it unbounded; the output carries requires-review + the reason
-    (AC13) rather than passing silently or crashing the batch."""
+def _refused_result(content_type: str, message: str) -> ExtractResult:
+    """A refused-but-flagged result: the input was not fully parsed — a resource
+    ceiling (AC13) or a defensive-parse refusal (a DTD, a decompression bomb;
+    AC9). The output carries requires-review + the reason rather than passing
+    silently or crashing the batch."""
     return ExtractResult(
         body=f"> **Not extracted.** {message}\n",
         tier=contract.TIER_0,
@@ -116,6 +117,13 @@ def _ceiling_result(content_type: str, message: str) -> ExtractResult:
         confidence="low",
         requires_review=True,
     )
+
+
+# Two call-site vocabularies (resource-ceiling vs defensive-parse refusal), one
+# flagged shape — aliased so the two intents read distinctly at the call site
+# without duplicating the body.
+_ceiling_result = _refused_result
+_defensive_result = _refused_result
 
 
 def _guard_size(path: Path, content_type: str) -> ExtractResult | None:
@@ -124,18 +132,6 @@ def _guard_size(path: Path, content_type: str) -> ExtractResult | None:
     except safe_io.ResourceCeilingError as exc:
         return _ceiling_result(content_type, str(exc))
     return None
-
-
-def _defensive_result(content_type: str, message: str) -> ExtractResult:
-    """A refused-but-flagged result for a defensive-parse refusal (a DTD, a
-    decompression bomb): flagged requires-review, never silently emitted."""
-    return ExtractResult(
-        body=f"> **Not extracted.** {message}\n",
-        tier=contract.TIER_0,
-        content_type=content_type,
-        confidence="low",
-        requires_review=True,
-    )
 
 
 def _lib_available(import_name: str) -> bool:
@@ -281,6 +277,10 @@ def _extract_docx(path: Path) -> ExtractResult:
             confidence = "medium"
     finally:
         sz.close()
+    # An empty extraction keeps requires_review=False deliberately: unlike a
+    # sparse PDF (where an image-only page is the escalation signal), an empty
+    # Office body emits a visible "No text found" placeholder a reader sees, and
+    # a legitimately text-free doc should not be forced to review.
     body = body or "> **No text found in the document.**\n"
     return ExtractResult(body, contract.TIER_0, "docx", confidence, False)
 
@@ -519,12 +519,14 @@ def _extract_epub(path: Path) -> ExtractResult:
         )
         parser = _TextHTMLParser
         parts: list[str] = []
+        dropped = False
         for name in xhtml:
             try:
                 # DTD-gate each member, then reduce its (X)HTML to text.
                 data = sz.read_member(name)
                 safe_io._reject_dtd(data)
             except (safe_io.XmlSafetyError, safe_io.ZipBombError):
+                dropped = True  # a guard skipped content — flag it, don't drop silently
                 continue
             text = parser().feed(data.decode("utf-8", errors="replace"))
             if text:
@@ -532,7 +534,11 @@ def _extract_epub(path: Path) -> ExtractResult:
     finally:
         sz.close()
     body = "\n\n".join(parts) or "> **No readable text found in the EPUB.**\n"
-    return ExtractResult(body, contract.TIER_0, "epub", "medium", False)
+    if dropped:
+        body += ("\n\n> **Some content was skipped by a safety guard "
+                 "(DTD or decompression-bomb) — review the source.**\n")
+    return ExtractResult(body, contract.TIER_0, "epub",
+                         "low" if dropped else "medium", dropped)
 
 
 def _extract_odf(path: Path) -> ExtractResult:

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/convert.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/convert.py
@@ -1,143 +1,742 @@
 #!/usr/bin/env python3
 """
-convert.py — Convert documents and images to Markdown using Docling.
+convert.py — convert documents and images to Markdown, tiered and no-ML-first.
 
-Supports: PDF, DOCX, PPTX, XLSX, XLS, PNG, JPG, JPEG, TIFF, BMP, WEBP, GIF
+The skill's document surface. It routes each input to the lowest tier that can
+handle it (RFC-0058):
+
+  * **Tier 0 (no ML)** — pure-Python / stdlib extractors for digital PDFs
+    (``pypdf``), Office files (``python-docx`` / ``openpyxl`` / ``python-pptx``,
+    degrading to stdlib ``zipfile`` + XML), and the everyday text formats
+    (HTML, EPUB, CSV/TSV, OpenDocument, ``.eml``). This is the floor a
+    locked-down environment can always reach.
+  * **Tier 2 (approved ML)** — Docling, unchanged, as the higher-fidelity
+    fall-through for ``.xls`` and images. Its Markdown body is passed through
+    to the contract builder unmodified.
+
+Every path emits the one versioned unified output contract (frontmatter) via
+``contract.build_frontmatter`` and writes through an output-path confinement
+guard. Untrusted input is parsed defensively (see ``safe_io``): XXE-safe XML,
+decompression-bomb guards, and a coarse resource ceiling.
 
 Usage:
     python scripts/convert.py <file> [file2 ...]
+    python scripts/convert.py --check [library ...]   # probe optional Tier-0 libs
 
 Output:
-    <input-basename>.md written to the same directory as the input file.
+    <input-basename>.md written next to the input file, confined to its dir.
 
 Stdout markers (for agent parsing):
     OUTPUT: <path>   — path to the written Markdown file
     LINES: <n>       — line count of the output
     WORDS: <n>       — word count of the output
-    WARNING: <msg>   — non-fatal issue
+    WARNING: <msg>   — non-fatal issue (e.g. requires-review / escalation)
 
-Errors go to stderr; exit code 1 on failure.
+Errors go to stderr; exit code 1 on failure, 2 on a missing probed library.
 """
-
 from __future__ import annotations
 
+import csv as csvmod
+import io
 import sys
 import tempfile
 from pathlib import Path
+from typing import Callable, NamedTuple
 
-SUPPORTED = {".pdf", ".docx", ".pptx", ".xlsx", ".xls",
-             ".png", ".jpg", ".jpeg", ".tiff", ".tif", ".bmp", ".webp", ".gif"}
+import contract
+import safe_io
+
+# --- Format routing ---------------------------------------------------------
 
 IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".tiff", ".tif", ".bmp", ".webp", ".gif"}
+# Handled only by Docling (Tier 2): legacy .xls (binary, no clean stdlib path)
+# and images (OCR / vision).
+DOCLING_EXTS = {".xls"} | IMAGE_EXTS
 
 # Images wider or taller than this are pre-scaled before Docling processes them.
 MAX_IMAGE_DIM = 4000
 
+# Sparse-text threshold (AC6): a digital PDF yielding fewer than this many words
+# is treated as image-only / low-quality and escalated, not silently emitted.
+SPARSE_WORD_THRESHOLD = 20
 
-def prescale_image(input_path: Path, tmp_dir: str) -> Path:
-    """Return a pre-scaled copy of the image if it exceeds MAX_IMAGE_DIM, else the original."""
+# Coarse per-parser ceilings (AC13).
+MAX_PDF_PAGES = 5_000
+MAX_SHEET_ROWS = 1_000_000
+MAX_CSV_ROWS = 1_000_000
+
+# Optional Tier-0 libraries, resolved pip-on-demand via --check (never
+# auto-installed), mirroring the sibling markdown-to-* skills.
+OPTIONAL_LIBS = {
+    "pypdf": "python -m pip install 'pypdf>=4.0.0'",
+    "docx": "python -m pip install 'python-docx>=1.1.0'",       # import name: docx
+    "openpyxl": "python -m pip install 'openpyxl>=3.1.0'",
+    "pptx": "python -m pip install 'python-pptx>=1.0.0'",       # import name: pptx
+}
+
+
+class ExtractResult(NamedTuple):
+    body: str                 # Markdown body (goes below the frontmatter fence)
+    tier: str                 # contract.TIER_*
+    content_type: str
+    confidence: str           # high | medium | low
+    requires_review: bool
+    escalation: str | None = None   # e.g. contract.TIER_1 when text is sparse
+
+
+# --- Extractor registry -----------------------------------------------------
+# Populated at the bottom of the module once every extractor is defined.
+_EXTRACTORS: dict[str, Callable[[Path], ExtractResult]] = {}
+
+
+def dispatch(path: Path) -> ExtractResult:
+    """Route an input to its Tier-0 extractor, or fall through to Docling."""
+    extractor = _EXTRACTORS.get(path.suffix.lower())
+    if extractor is not None:
+        return extractor(path)
+    return _extract_docling(path)
+
+
+def supported_exts() -> set[str]:
+    return set(_EXTRACTORS) | DOCLING_EXTS
+
+
+# --- Shared guards ----------------------------------------------------------
+
+
+def _ceiling_result(content_type: str, message: str) -> ExtractResult:
+    """A refused-but-flagged result: the input tripped a resource ceiling, so we
+    do not parse it unbounded; the output carries requires-review + the reason
+    (AC13) rather than passing silently or crashing the batch."""
+    return ExtractResult(
+        body=f"> **Not extracted.** {message}\n",
+        tier=contract.TIER_0,
+        content_type=content_type,
+        confidence="low",
+        requires_review=True,
+    )
+
+
+def _guard_size(path: Path, content_type: str) -> ExtractResult | None:
+    try:
+        safe_io.check_input_size(path)
+    except safe_io.ResourceCeilingError as exc:
+        return _ceiling_result(content_type, str(exc))
+    return None
+
+
+def _defensive_result(content_type: str, message: str) -> ExtractResult:
+    """A refused-but-flagged result for a defensive-parse refusal (a DTD, a
+    decompression bomb): flagged requires-review, never silently emitted."""
+    return ExtractResult(
+        body=f"> **Not extracted.** {message}\n",
+        tier=contract.TIER_0,
+        content_type=content_type,
+        confidence="low",
+        requires_review=True,
+    )
+
+
+def _lib_available(import_name: str) -> bool:
+    import importlib.util
+
+    return importlib.util.find_spec(import_name) is not None
+
+
+# --- Tier 0: PDF (pypdf) ----------------------------------------------------
+
+
+def _assess_text(text: str) -> tuple[str, bool, str | None]:
+    """Map extracted text to (confidence, requires_review, escalation).
+
+    Sparse or empty text escalates honestly to Tier 1 (agent-vision) rather
+    than emitting silent low-quality Markdown (AC6)."""
+    if len(text.split()) < SPARSE_WORD_THRESHOLD:
+        return "low", True, contract.TIER_1
+    return "high", False, None
+
+
+def _extract_pdf(path: Path) -> ExtractResult:
+    if (over := _guard_size(path, "pdf")) is not None:
+        return over
+    if not _lib_available("pypdf"):
+        # No stdlib PDF text path — degrade to the sparse/escalation path
+        # (Boundaries: "PDF → the sparse-text escalation path") rather than
+        # importing Docling or hard-failing.
+        return ExtractResult(
+            body=(
+                "> **Tier-0 PDF text extraction needs `pypdf`, which is not "
+                "installed.** Install it (`" + OPTIONAL_LIBS["pypdf"] + "`) for "
+                "no-ML text extraction, or escalate to Tier 1 (agent-vision).\n"
+            ),
+            tier=contract.TIER_0,
+            content_type="pdf",
+            confidence="low",
+            requires_review=True,
+            escalation=contract.TIER_1,
+        )
+
+    from pypdf import PdfReader
+
+    reader = PdfReader(str(path))
+    n_pages = len(reader.pages)
+    if n_pages > MAX_PDF_PAGES:
+        return _ceiling_result(
+            "pdf",
+            f"PDF has {n_pages} pages, over the {MAX_PDF_PAGES}-page ceiling; "
+            f"refusing to parse unbounded",
+        )
+
+    parts: list[str] = []
+    for page in reader.pages:
+        parts.append(page.extract_text() or "")
+    text = "\n\n".join(p.strip() for p in parts if p.strip())
+
+    confidence, requires_review, escalation = _assess_text(text)
+    body = text if text.strip() else "> **No extractable text layer found.**\n"
+    return ExtractResult(
+        body=body,
+        tier=contract.TIER_0,
+        content_type="pdf",
+        confidence=confidence,
+        requires_review=requires_review,
+        escalation=escalation,
+    )
+
+
+# --- Tier 0: Office (docx / xlsx / pptx) ------------------------------------
+# Every Office file is opened through safe_io.open_safe_zip first (the
+# decompression-bomb axes) and its XML members are DTD-gated, so no DTD ever
+# reaches the ordinary library's transitive lxml parser — the stdlib-XXE-safe
+# resolution applied to the library path (spec AC9 / Assumptions).
+
+_W = "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}"
+_A = "{http://schemas.openxmlformats.org/drawingml/2006/main}"
+_S = "{http://schemas.openxmlformats.org/spreadsheetml/2006/main}"
+
+
+def _open_office(path: Path, content_type: str):
+    """Open an Office file with the bomb guards, gate its DTDs, and report
+    whether the ordinary library is available. Returns (SafeZip, use_lib) or an
+    ExtractResult on a defensive refusal."""
+    if (over := _guard_size(path, content_type)) is not None:
+        return over
+    try:
+        sz = safe_io.open_safe_zip(path)
+        sz.reject_dtds()
+    except safe_io.ZipBombError as exc:
+        return _defensive_result(content_type, f"decompression-bomb guard: {exc}")
+    except safe_io.XmlSafetyError as exc:
+        return _defensive_result(content_type, f"XML safety guard: {exc}")
+    return sz
+
+
+def _local(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def _extract_docx(path: Path) -> ExtractResult:
+    opened = _open_office(path, "docx")
+    if isinstance(opened, ExtractResult):
+        return opened
+    sz = opened
+    try:
+        if _lib_available("docx"):
+            import docx
+
+            document = docx.Document(str(path))
+            lines = [p.text for p in document.paragraphs if p.text.strip()]
+            for table in document.tables:
+                for row in table.rows:
+                    cells = [c.text.strip() for c in row.cells]
+                    if any(cells):
+                        lines.append(" | ".join(cells))
+            body = "\n\n".join(lines)
+            confidence = "high"
+        else:
+            xml = sz.read_member("word/document.xml")
+            root = safe_io.parse_xml(xml)
+            paras: list[str] = []
+            for p in root.iter(f"{_W}p"):
+                texts = [t.text or "" for t in p.iter(f"{_W}t")]
+                joined = "".join(texts).strip()
+                if joined:
+                    paras.append(joined)
+            body = "\n\n".join(paras)
+            confidence = "medium"
+    finally:
+        sz.close()
+    body = body or "> **No text found in the document.**\n"
+    return ExtractResult(body, contract.TIER_0, "docx", confidence, False)
+
+
+def _extract_xlsx(path: Path) -> ExtractResult:
+    opened = _open_office(path, "xlsx")
+    if isinstance(opened, ExtractResult):
+        return opened
+    sz = opened
+    try:
+        if _lib_available("openpyxl"):
+            import openpyxl
+
+            wb = openpyxl.load_workbook(str(path), read_only=True, data_only=True)
+            sections: list[str] = []
+            for ws in wb.worksheets:
+                rows: list[str] = []
+                for i, row in enumerate(ws.iter_rows(values_only=True)):
+                    if i >= MAX_SHEET_ROWS:
+                        rows.append(f"> _(truncated at {MAX_SHEET_ROWS} rows)_")
+                        break
+                    cells = ["" if c is None else str(c) for c in row]
+                    if any(cells):
+                        rows.append(" | ".join(cells))
+                if rows:
+                    sections.append(f"## {ws.title}\n\n" + "\n".join(rows))
+            wb.close()
+            body = "\n\n".join(sections)
+            confidence = "high"
+        else:
+            body, confidence = _extract_xlsx_stdlib(sz)
+    finally:
+        sz.close()
+    body = body or "> **No cell values found.**\n"
+    return ExtractResult(body, contract.TIER_0, "xlsx", confidence, False)
+
+
+def _extract_xlsx_stdlib(sz: "safe_io.SafeZip") -> tuple[str, str]:
+    # Shared strings table (cells with t="s" index into it).
+    shared: list[str] = []
+    if sz.has_member("xl/sharedStrings.xml"):
+        root = safe_io.parse_xml(sz.read_member("xl/sharedStrings.xml"))
+        for si in root.iter(f"{_S}si"):
+            shared.append("".join(t.text or "" for t in si.iter(f"{_S}t")))
+    sheet_names = sorted(
+        n for n in sz.namelist()
+        if n.startswith("xl/worksheets/") and n.endswith(".xml")
+    )
+    sections: list[str] = []
+    for name in sheet_names:
+        root = safe_io.parse_xml(sz.read_member(name))
+        rows: list[str] = []
+        for i, row in enumerate(root.iter(f"{_S}row")):
+            if i >= MAX_SHEET_ROWS:
+                rows.append(f"> _(truncated at {MAX_SHEET_ROWS} rows)_")
+                break
+            cells: list[str] = []
+            for c in row.iter(f"{_S}c"):
+                v = c.find(f"{_S}v")
+                text = v.text if v is not None else None
+                if text is None:
+                    cells.append("")
+                elif c.get("t") == "s":
+                    idx = int(text)
+                    cells.append(shared[idx] if 0 <= idx < len(shared) else "")
+                else:
+                    cells.append(text)
+            if any(cells):
+                rows.append(" | ".join(cells))
+        if rows:
+            sections.append("\n".join(rows))
+    return "\n\n".join(sections), "medium"
+
+
+def _extract_pptx(path: Path) -> ExtractResult:
+    opened = _open_office(path, "pptx")
+    if isinstance(opened, ExtractResult):
+        return opened
+    sz = opened
+    try:
+        if _lib_available("pptx"):
+            import pptx
+
+            prs = pptx.Presentation(str(path))
+            slides: list[str] = []
+            for i, slide in enumerate(prs.slides, 1):
+                texts: list[str] = []
+                for shape in slide.shapes:
+                    if shape.has_text_frame:
+                        for para in shape.text_frame.paragraphs:
+                            line = "".join(run.text for run in para.runs).strip()
+                            if line:
+                                texts.append(line)
+                slides.append(f"## Slide {i}\n\n" + "\n\n".join(texts))
+            body = "\n\n".join(slides)
+            confidence = "high"
+        else:
+            slide_names = sorted(
+                n for n in sz.namelist()
+                if n.startswith("ppt/slides/slide") and n.endswith(".xml")
+            )
+            slides = []
+            for i, name in enumerate(slide_names, 1):
+                root = safe_io.parse_xml(sz.read_member(name))
+                texts = [t.text or "" for t in root.iter(f"{_A}t")]
+                joined = "\n\n".join(t.strip() for t in texts if t.strip())
+                slides.append(f"## Slide {i}\n\n" + joined)
+            body = "\n\n".join(slides)
+            confidence = "medium"
+    finally:
+        sz.close()
+    body = body or "> **No text found in the presentation.**\n"
+    return ExtractResult(body, contract.TIER_0, "pptx", confidence, False)
+
+
+# --- Tier 0: D7 formats -----------------------------------------------------
+
+
+class _TextHTMLParser:
+    """Coarse HTML → text reduction via stdlib html.parser (no new dep).
+
+    Emits block-level breaks for common structural tags and drops script/style
+    content, which is enough for a context-layer floor (fidelity is Tier 2's
+    job, per § Risks)."""
+
+    def __init__(self) -> None:
+        from html.parser import HTMLParser
+
+        outer = self
+
+        class _P(HTMLParser):
+            def __init__(self) -> None:
+                super().__init__(convert_charrefs=True)
+                self.parts: list[str] = []
+                self._skip = 0
+
+            def handle_starttag(self, tag, attrs):
+                if tag in ("script", "style"):
+                    self._skip += 1
+                elif tag in ("p", "div", "br", "li", "tr", "h1", "h2", "h3",
+                             "h4", "h5", "h6", "section", "article"):
+                    self.parts.append("\n")
+                if tag == "li":
+                    self.parts.append("- ")
+
+            def handle_endtag(self, tag):
+                if tag in ("script", "style") and self._skip:
+                    self._skip -= 1
+                elif tag in ("p", "div", "li", "tr", "h1", "h2", "h3", "h4",
+                             "h5", "h6"):
+                    self.parts.append("\n")
+
+            def handle_data(self, data):
+                if not self._skip and data.strip():
+                    self.parts.append(data)
+
+        self._parser = _P()
+
+    def feed(self, text: str) -> str:
+        self._parser.feed(text)
+        raw = "".join(self._parser.parts)
+        lines = [ln.strip() for ln in raw.splitlines()]
+        out: list[str] = []
+        for ln in lines:
+            if ln or (out and out[-1]):
+                out.append(ln)
+        return "\n".join(out).strip()
+
+
+def _extract_html(path: Path) -> ExtractResult:
+    if (over := _guard_size(path, "html")) is not None:
+        return over
+    text = path.read_text(encoding="utf-8", errors="replace")
+    body = _TextHTMLParser().feed(text) or "> **No text content found.**\n"
+    return ExtractResult(body, contract.TIER_0, "html", "high", False)
+
+
+def _extract_csv(path: Path) -> ExtractResult:
+    content_type = "tsv" if path.suffix.lower() == ".tsv" else "csv"
+    if (over := _guard_size(path, content_type)) is not None:
+        return over
+    delimiter = "\t" if content_type == "tsv" else ","
+    text = path.read_text(encoding="utf-8", errors="replace")
+    reader = csvmod.reader(io.StringIO(text), delimiter=delimiter)
+    rows: list[list[str]] = []
+    for i, row in enumerate(reader):
+        if i >= MAX_CSV_ROWS:
+            return _ceiling_result(
+                content_type,
+                f"{content_type.upper()} exceeds the {MAX_CSV_ROWS}-row ceiling; "
+                f"refusing to parse unbounded",
+            )
+        rows.append(row)
+    if not rows:
+        return ExtractResult("> **Empty file.**\n", contract.TIER_0,
+                             content_type, "high", False)
+    ncol = max(len(r) for r in rows)
+    header = rows[0] + [""] * (ncol - len(rows[0]))
+    lines = ["| " + " | ".join(_md_cell(c) for c in header) + " |",
+             "| " + " | ".join("---" for _ in header) + " |"]
+    for r in rows[1:]:
+        r = r + [""] * (ncol - len(r))
+        lines.append("| " + " | ".join(_md_cell(c) for c in r) + " |")
+    return ExtractResult("\n".join(lines), contract.TIER_0, content_type,
+                         "high", False)
+
+
+def _md_cell(s: str) -> str:
+    return (s or "").replace("|", "\\|").replace("\n", " ").strip()
+
+
+def _extract_epub(path: Path) -> ExtractResult:
+    if (over := _guard_size(path, "epub")) is not None:
+        return over
+    try:
+        sz = safe_io.open_safe_zip(path)
+    except safe_io.ZipBombError as exc:
+        return _defensive_result("epub", f"decompression-bomb guard: {exc}")
+    try:
+        # Read the spine order from the OPF; fall back to sorted xhtml members.
+        xhtml = sorted(
+            n for n in sz.namelist()
+            if n.lower().endswith((".xhtml", ".html", ".htm"))
+        )
+        parser = _TextHTMLParser
+        parts: list[str] = []
+        for name in xhtml:
+            try:
+                # DTD-gate each member, then reduce its (X)HTML to text.
+                data = sz.read_member(name)
+                safe_io._reject_dtd(data)
+            except (safe_io.XmlSafetyError, safe_io.ZipBombError):
+                continue
+            text = parser().feed(data.decode("utf-8", errors="replace"))
+            if text:
+                parts.append(text)
+    finally:
+        sz.close()
+    body = "\n\n".join(parts) or "> **No readable text found in the EPUB.**\n"
+    return ExtractResult(body, contract.TIER_0, "epub", "medium", False)
+
+
+def _extract_odf(path: Path) -> ExtractResult:
+    ct = {".odt": "odt", ".ods": "ods", ".odp": "odp"}[path.suffix.lower()]
+    if (over := _guard_size(path, ct)) is not None:
+        return over
+    try:
+        sz = safe_io.open_safe_zip(path)
+    except safe_io.ZipBombError as exc:
+        return _defensive_result(ct, f"decompression-bomb guard: {exc}")
+    try:
+        if not sz.has_member("content.xml"):
+            return ExtractResult("> **No content.xml in the document.**\n",
+                                 contract.TIER_0, ct, "low", True)
+        root = safe_io.parse_xml(sz.read_member("content.xml"))
+    finally:
+        sz.close()
+    # OpenDocument text lives in <text:p>/<text:h>; join their text content.
+    text_ns = "{urn:oasis:names:tc:opendocument:xmlns:text:1.0}"
+    blocks: list[str] = []
+    for tag in ("p", "h"):
+        for el in root.iter(f"{text_ns}{tag}"):
+            joined = "".join(el.itertext()).strip()
+            if joined:
+                blocks.append(joined)
+    body = "\n\n".join(blocks) or "> **No text found in the document.**\n"
+    return ExtractResult(body, contract.TIER_0, ct, "medium", False)
+
+
+def _extract_eml(path: Path) -> ExtractResult:
+    if (over := _guard_size(path, "eml")) is not None:
+        return over
+    import email
+    from email import policy
+
+    msg = email.message_from_bytes(path.read_bytes(), policy=policy.default)
+    headers = []
+    for h in ("From", "To", "Cc", "Date", "Subject"):
+        if msg[h]:
+            headers.append(f"**{h}:** {msg[h]}")
+    try:
+        part = msg.get_body(preferencelist=("plain", "html"))
+    except Exception:
+        part = None
+    if part is not None:
+        content = part.get_content()
+        if part.get_content_type() == "text/html":
+            content = _TextHTMLParser().feed(content)
+    else:
+        content = ""
+    body = "\n\n".join(headers)
+    if content and content.strip():
+        body += "\n\n---\n\n" + content.strip()
+    body = body or "> **No readable content in the message.**\n"
+    return ExtractResult(body, contract.TIER_0, "eml", "high", False)
+
+
+# --- Tier 2: Docling fall-through (unchanged body) --------------------------
+
+
+def _prescale_image(input_path: Path, tmp_dir: str) -> Path:
     from PIL import Image
-    Image.MAX_IMAGE_PIXELS = None  # disable decompression bomb check for the resize step
 
+    Image.MAX_IMAGE_PIXELS = None  # disable PIL's bomb check for the resize step
     with Image.open(input_path) as img:
         w, h = img.size
         if max(w, h) <= MAX_IMAGE_DIM:
             return input_path
-
         scale = MAX_IMAGE_DIM / max(w, h)
-        new_w, new_h = int(w * scale), int(h * scale)
-        scaled = img.resize((new_w, new_h), Image.LANCZOS)
+        scaled = img.resize((int(w * scale), int(h * scale)), Image.LANCZOS)
         out_path = Path(tmp_dir) / (input_path.stem + "_scaled.png")
         scaled.save(str(out_path), format="PNG")
         return out_path
 
 
-def convert_file(input_path: Path) -> None:
+def _extract_docling(input_path: Path) -> ExtractResult:
     try:
         from docling.document_converter import DocumentConverter
     except ImportError:
-        print(
-            "ERROR: docling is not installed. Run:\n"
-            "  pip install docling\n"
-            "  uv pip install docling",
-            file=sys.stderr,
+        raise RuntimeError(
+            "docling is not installed and no Tier-0 extractor handles "
+            f"'{input_path.suffix}'. Install docling (pip install docling) or "
+            "convert to a Tier-0 format (PDF/Office/HTML/EPUB/CSV/ODF/EML)."
         )
-        sys.exit(1)
-
-    if not input_path.exists():
-        print(f"ERROR: File not found: {input_path}", file=sys.stderr)
-        sys.exit(1)
-
-    if input_path.suffix.lower() not in SUPPORTED:
-        print(
-            f"ERROR: Unsupported file type '{input_path.suffix}'. "
-            f"Supported: {', '.join(sorted(SUPPORTED))}",
-            file=sys.stderr,
-        )
-        sys.exit(1)
 
     is_image = input_path.suffix.lower() in IMAGE_EXTS
     tmp_dir = None
     convert_path = input_path
-
     if is_image:
         tmp_dir = tempfile.mkdtemp()
-        convert_path = prescale_image(input_path, tmp_dir)
+        convert_path = _prescale_image(input_path, tmp_dir)
         if convert_path != input_path:
-            from PIL import Image
-            with Image.open(input_path) as img:
-                orig_w, orig_h = img.size
-            with Image.open(convert_path) as img:
-                scaled_w, scaled_h = img.size
-            print(f"WARNING: image pre-scaled from {orig_w}×{orig_h} to {scaled_w}×{scaled_h} before OCR")
-
+            print(f"WARNING: image pre-scaled to fit {MAX_IMAGE_DIM}px before OCR")
     try:
-        try:
-            converter = DocumentConverter()
-            result = converter.convert(str(convert_path))
-            markdown = result.document.export_to_markdown()
-        except Exception as e:
-            print(
-                f"ERROR: could not convert {input_path.name}: {e}\n"
-                "If the file is password-protected or encrypted, remove the "
-                "protection and retry. If it may be corrupt, confirm it opens "
-                "in its native application.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
+        converter = DocumentConverter()
+        result = converter.convert(str(convert_path))
+        markdown = result.document.export_to_markdown()
     finally:
         if tmp_dir:
             import shutil
+
             shutil.rmtree(tmp_dir, ignore_errors=True)
 
-    output_path = input_path.with_suffix(".md")
-    output_path.write_text(markdown, encoding="utf-8")
+    # The Docling body is passed through unmodified — the builder wraps, never
+    # rewrites (AC10).
+    return ExtractResult(
+        body=markdown,
+        tier=contract.TIER_2,
+        content_type="image" if is_image else input_path.suffix.lower().lstrip("."),
+        confidence="high",
+        requires_review=False,
+    )
 
-    lines = len(markdown.splitlines())
-    words = len(markdown.split())
-    print(f"OUTPUT: {output_path}")
-    print(f"LINES: {lines}")
-    print(f"WORDS: {words}")
 
-    if words < 20:
+# --- Assemble + confined write ----------------------------------------------
+
+
+def assemble(result: ExtractResult, source_name: str) -> str:
+    """Wrap an extraction in the unified output contract (frontmatter + body).
+
+    The frontmatter is the leading ``---``-fenced block only; the body sits
+    below it, so a ``---`` line in the body is content, not a second block
+    (AC8)."""
+    fields: dict[str, object] = {
+        "source-file": source_name,
+        "content-type": result.content_type,
+        "ingestion-date": contract.now_iso(),
+    }
+    if result.escalation is not None:
+        fields["escalation-target"] = result.escalation
+    frontmatter = contract.build_frontmatter(
+        tier=result.tier,
+        extraction_confidence=result.confidence,
+        requires_review=result.requires_review,
+        fields=fields,
+    )
+    return frontmatter + "\n\n" + result.body.rstrip("\n") + "\n"
+
+
+def write_output(input_path: Path, text: str) -> Path:
+    """Write ``<basename>.md`` next to the input, confined to the input's
+    resolved directory (realpath + component containment, AC12)."""
+    root = input_path.resolve().parent
+    output_path = safe_io.confine(root / (input_path.stem + ".md"), root)
+    output_path.write_text(text, encoding="utf-8")
+    return output_path
+
+
+def convert_file(input_path: Path) -> None:
+    if not input_path.exists():
+        print(f"ERROR: File not found: {input_path}", file=sys.stderr)
+        sys.exit(1)
+    if input_path.suffix.lower() not in supported_exts():
         print(
-            "WARNING: very little text extracted — the file may be image-based "
-            "or contain mostly non-text content"
+            f"ERROR: Unsupported file type '{input_path.suffix}'. Supported: "
+            f"{', '.join(sorted(supported_exts()))}",
+            file=sys.stderr,
         )
-
-
-def main() -> None:
-    if len(sys.argv) < 2:
-        print("Usage: convert.py <file> [file2 ...]", file=sys.stderr)
         sys.exit(1)
 
-    for arg in sys.argv[1:]:
-        try:
-            convert_file(Path(arg))
-        except Exception as e:
-            print(f"ERROR: {e}", file=sys.stderr)
-            sys.exit(1)
+    try:
+        result = dispatch(input_path)
+    except Exception as exc:
+        print(
+            f"ERROR: could not convert {input_path.name}: {exc}\n"
+            "If the file is password-protected or encrypted, remove the "
+            "protection and retry. If it may be corrupt, confirm it opens in "
+            "its native application.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    text = assemble(result, input_path.name)
+    output_path = write_output(input_path, text)
+
+    print(f"OUTPUT: {output_path}")
+    print(f"LINES: {len(text.splitlines())}")
+    print(f"WORDS: {len(result.body.split())}")
+    if result.requires_review:
+        target = f" — escalate to Tier {result.escalation}" if result.escalation else ""
+        print(f"WARNING: extraction flagged requires-review (low confidence){target}")
+
+
+# --- CLI --------------------------------------------------------------------
+
+
+def cmd_check(names: list[str]) -> int:
+    """Probe optional Tier-0 libraries; exit 0 if all present, 2 if any absent
+    (mirrors the sibling markdown-to-* --check probe)."""
+    targets = names or list(OPTIONAL_LIBS)
+    missing = False
+    for name in targets:
+        present = _lib_available(name)
+        print(f"{name}: {'present' if present else 'absent'}")
+        if not present:
+            missing = True
+            if name in OPTIONAL_LIBS:
+                print(f"  install: {OPTIONAL_LIBS[name]}", file=sys.stderr)
+    return 2 if missing else 0
+
+
+# --- Extractor registry (defined after the extractors, before the CLI) ------
+_EXTRACTORS.update({
+    ".pdf": _extract_pdf,
+    ".docx": _extract_docx,
+    ".xlsx": _extract_xlsx,
+    ".pptx": _extract_pptx,
+    ".html": _extract_html,
+    ".htm": _extract_html,
+    ".epub": _extract_epub,
+    ".csv": _extract_csv,
+    ".tsv": _extract_csv,
+    ".odt": _extract_odf,
+    ".ods": _extract_odf,
+    ".odp": _extract_odf,
+    ".eml": _extract_eml,
+})
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    if not args:
+        print("Usage: convert.py <file> [file2 ...] | --check [library ...]",
+              file=sys.stderr)
+        return 1
+    if args[0] == "--check":
+        return cmd_check(args[1:])
+    for arg in args:
+        convert_file(Path(arg))
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/convert.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/convert.py
@@ -40,6 +40,7 @@ import csv as csvmod
 import io
 import sys
 import tempfile
+import zipfile
 from pathlib import Path
 from typing import Callable, NamedTuple
 
@@ -216,19 +217,31 @@ _S = "{http://schemas.openxmlformats.org/spreadsheetml/2006/main}"
 
 
 def _open_office(path: Path, content_type: str):
-    """Open an Office file with the bomb guards, gate its DTDs, and report
-    whether the ordinary library is available. Returns (SafeZip, use_lib) or an
-    ExtractResult on a defensive refusal."""
+    """Open an Office file with the decompression-bomb guards. Returns a SafeZip
+    or an ExtractResult on a defensive refusal (bomb, or a file that is not a
+    valid zip — e.g. a corrupt or mislabeled ``.docx``)."""
     if (over := _guard_size(path, content_type)) is not None:
         return over
     try:
-        sz = safe_io.open_safe_zip(path)
-        sz.reject_dtds()
+        return safe_io.open_safe_zip(path)
+    except safe_io.ZipBombError as exc:
+        return _defensive_result(content_type, f"decompression-bomb guard: {exc}")
+    except zipfile.BadZipFile as exc:
+        return _defensive_result(content_type, f"not a valid Office (zip) file: {exc}")
+
+
+def _harden_for_lib(sz: "safe_io.SafeZip", content_type: str) -> ExtractResult | None:
+    """Before an ordinary Office library re-opens the raw file, fully validate
+    every member through SafeZip — the per-member + cumulative decompression
+    caps and the whole-buffer DTD refusal that the library path would otherwise
+    bypass (spec AC9). Returns an ExtractResult on refusal, else None."""
+    try:
+        sz.harden_untrusted()
     except safe_io.ZipBombError as exc:
         return _defensive_result(content_type, f"decompression-bomb guard: {exc}")
     except safe_io.XmlSafetyError as exc:
         return _defensive_result(content_type, f"XML safety guard: {exc}")
-    return sz
+    return None
 
 
 def _local(tag: str) -> str:
@@ -242,6 +255,8 @@ def _extract_docx(path: Path) -> ExtractResult:
     sz = opened
     try:
         if _lib_available("docx"):
+            if (guard := _harden_for_lib(sz, "docx")) is not None:
+                return guard
             import docx
 
             document = docx.Document(str(path))
@@ -275,8 +290,11 @@ def _extract_xlsx(path: Path) -> ExtractResult:
     if isinstance(opened, ExtractResult):
         return opened
     sz = opened
+    truncated = False
     try:
         if _lib_available("openpyxl"):
+            if (guard := _harden_for_lib(sz, "xlsx")) is not None:
+                return guard
             import openpyxl
 
             wb = openpyxl.load_workbook(str(path), read_only=True, data_only=True)
@@ -286,6 +304,7 @@ def _extract_xlsx(path: Path) -> ExtractResult:
                 for i, row in enumerate(ws.iter_rows(values_only=True)):
                     if i >= MAX_SHEET_ROWS:
                         rows.append(f"> _(truncated at {MAX_SHEET_ROWS} rows)_")
+                        truncated = True
                         break
                     cells = ["" if c is None else str(c) for c in row]
                     if any(cells):
@@ -296,14 +315,18 @@ def _extract_xlsx(path: Path) -> ExtractResult:
             body = "\n\n".join(sections)
             confidence = "high"
         else:
-            body, confidence = _extract_xlsx_stdlib(sz)
+            body, confidence, truncated = _extract_xlsx_stdlib(sz)
     finally:
         sz.close()
     body = body or "> **No cell values found.**\n"
-    return ExtractResult(body, contract.TIER_0, "xlsx", confidence, False)
+    # A row-truncated sheet is not fully extracted — flag it for review rather
+    # than silently dropping the tail (AC13).
+    if truncated:
+        confidence = "low"
+    return ExtractResult(body, contract.TIER_0, "xlsx", confidence, truncated)
 
 
-def _extract_xlsx_stdlib(sz: "safe_io.SafeZip") -> tuple[str, str]:
+def _extract_xlsx_stdlib(sz: "safe_io.SafeZip") -> tuple[str, str, bool]:
     # Shared strings table (cells with t="s" index into it).
     shared: list[str] = []
     if sz.has_member("xl/sharedStrings.xml"):
@@ -315,12 +338,14 @@ def _extract_xlsx_stdlib(sz: "safe_io.SafeZip") -> tuple[str, str]:
         if n.startswith("xl/worksheets/") and n.endswith(".xml")
     )
     sections: list[str] = []
+    truncated = False
     for name in sheet_names:
         root = safe_io.parse_xml(sz.read_member(name))
         rows: list[str] = []
         for i, row in enumerate(root.iter(f"{_S}row")):
             if i >= MAX_SHEET_ROWS:
                 rows.append(f"> _(truncated at {MAX_SHEET_ROWS} rows)_")
+                truncated = True
                 break
             cells: list[str] = []
             for c in row.iter(f"{_S}c"):
@@ -337,7 +362,7 @@ def _extract_xlsx_stdlib(sz: "safe_io.SafeZip") -> tuple[str, str]:
                 rows.append(" | ".join(cells))
         if rows:
             sections.append("\n".join(rows))
-    return "\n\n".join(sections), "medium"
+    return "\n\n".join(sections), "medium", truncated
 
 
 def _extract_pptx(path: Path) -> ExtractResult:
@@ -347,6 +372,8 @@ def _extract_pptx(path: Path) -> ExtractResult:
     sz = opened
     try:
         if _lib_available("pptx"):
+            if (guard := _harden_for_lib(sz, "pptx")) is not None:
+                return guard
             import pptx
 
             prs = pptx.Presentation(str(path))
@@ -521,6 +548,10 @@ def _extract_odf(path: Path) -> ExtractResult:
             return ExtractResult("> **No content.xml in the document.**\n",
                                  contract.TIER_0, ct, "low", True)
         root = safe_io.parse_xml(sz.read_member("content.xml"))
+    except safe_io.XmlSafetyError as exc:
+        return _defensive_result(ct, f"XML safety guard: {exc}")
+    except safe_io.ZipBombError as exc:
+        return _defensive_result(ct, f"decompression-bomb guard: {exc}")
     finally:
         sz.close()
     # OpenDocument text lives in <text:p>/<text:h>; join their text content.

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/reconcile.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/reconcile.py
@@ -359,10 +359,10 @@ def render_markdown(
     else:
         overall_confidence = "medium"
 
-    # The image branch is an in-session agent-vision read (RFC-0058 Tier 1).
+    # The image branch is an in-session agent-vision read.
     # The shared builder prepends contract-version + tier and owns the
     # ingestion-quality block; everything else is this branch's own ordered
-    # fields, byte-identical to the pre-contract output (spec AC2).
+    # fields, byte-identical to the pre-contract output.
     yaml = contract.build_frontmatter(
         tier=contract.TIER_1,
         extraction_confidence=overall_confidence,

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/reconcile.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/reconcile.py
@@ -32,9 +32,10 @@ import json
 import re
 import sys
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+import contract
 
 # --- IO --------------------------------------------------------------------
 
@@ -358,30 +359,35 @@ def render_markdown(
     else:
         overall_confidence = "medium"
 
-    front = {
-        "title": title,
-        "source-file": source_image,
-        "content-type": "image",
-        "content-category": CONTENT_CATEGORY.get(strategy, strategy),
-        "ingestion-date": datetime.now(timezone.utc).isoformat(timespec="seconds"),
-        "diagram-type": diagram_type,
-        "processing": {
-            "strategy": "two-pass-sliding-window",
-            "extraction-strategy": strategy,
-            "viewport": detail_manifest.get("viewport"),
-            "stride": detail_manifest.get("stride"),
-            "overlap-pct": detail_manifest.get("overlap_pct"),
-            "tile-count": len(detail_manifest.get("tiles", [])),
+    # The image branch is an in-session agent-vision read (RFC-0058 Tier 1).
+    # The shared builder prepends contract-version + tier and owns the
+    # ingestion-quality block; everything else is this branch's own ordered
+    # fields, byte-identical to the pre-contract output (spec AC2).
+    yaml = contract.build_frontmatter(
+        tier=contract.TIER_1,
+        extraction_confidence=overall_confidence,
+        requires_review=len(ambiguities) > 0 or not canonical,
+        fields={
+            "title": title,
+            "source-file": source_image,
+            "content-type": "image",
+            "content-category": CONTENT_CATEGORY.get(strategy, strategy),
+            "ingestion-date": contract.now_iso(),
+            "diagram-type": diagram_type,
+            "processing": {
+                "strategy": "two-pass-sliding-window",
+                "extraction-strategy": strategy,
+                "viewport": detail_manifest.get("viewport"),
+                "stride": detail_manifest.get("stride"),
+                "overlap-pct": detail_manifest.get("overlap_pct"),
+                "tile-count": len(detail_manifest.get("tiles", [])),
+            },
         },
-        "ingestion-quality": {
-            "extraction-confidence": overall_confidence,
+        ingestion_quality_extra={
             "elements-by-confidence": {"high": high, "medium": med, "low": low},
             "ambiguity-count": len(ambiguities),
-            "requires-review": len(ambiguities) > 0 or not canonical,
         },
-    }
-
-    yaml = _yaml_block(front)
+    )
 
     # Markdown body — group by element type for readability.
     by_type: dict[str, list[Element]] = {}
@@ -427,34 +433,6 @@ def render_markdown(
         body_parts.append("")
 
     return yaml + "\n" + "\n".join(body_parts) + "\n"
-
-
-def _yaml_block(d: dict) -> str:
-    """Minimal YAML emitter for our flat-with-one-level-of-nesting frontmatter.
-    No unicode quoting heroics, no anchors, no multi-line strings."""
-    lines = ["---"]
-    _emit(d, lines, 0)
-    lines.append("---")
-    return "\n".join(lines)
-
-
-def _emit(d: dict, lines: list[str], indent: int) -> None:
-    pad = "  " * indent
-    for k, v in d.items():
-        if isinstance(v, dict):
-            lines.append(f"{pad}{k}:")
-            _emit(v, lines, indent + 1)
-        elif isinstance(v, bool):
-            lines.append(f"{pad}{k}: {'true' if v else 'false'}")
-        elif v is None:
-            lines.append(f"{pad}{k}: null")
-        elif isinstance(v, (int, float)):
-            lines.append(f"{pad}{k}: {v}")
-        else:
-            # Escape backslashes first so we don't double-escape the
-            # backslash inserted by the quote-escape on the next line.
-            s = str(v).replace("\\", "\\\\").replace('"', '\\"')
-            lines.append(f'{pad}{k}: "{s}"')
 
 
 def _md_escape(s: str) -> str:

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/safe_io.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/safe_io.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""
+safe_io.py — defensive helpers for parsing untrusted document input.
+
+The Tier-0 floor treats document inputs as **untrusted** (they are fed into AI
+context layers, where the local-files-trusted carve-out does not hold). This
+module centralizes the three guards every reader routes through (spec AC9,
+AC12, AC13):
+
+  * ``parse_xml`` — an XXE- and entity-expansion-safe XML read. Uses only
+    stdlib ``xml.etree.ElementTree`` (which does not resolve external entities),
+    and refuses any DTD/DOCTYPE up front — so both external-entity (XXE) and
+    internal-entity (billion-laughs) attacks are closed, since both require a
+    DTD to declare the entity. ``lxml`` / ``minidom`` / ``sax`` at defaults are
+    never used (spec § Never do).
+  * ``SafeZip`` / ``open_safe_zip`` — a decompression-bomb-guarded zip reader.
+    Refuses, *before* full decompression, on every axis: an implausible
+    declared-vs-compressed size ratio, a total-cumulative-uncompressed cap, and
+    an entry-count cap; reads members in-memory by known name only (never joins
+    an entry name into a filesystem path — the path-join guard), refuses
+    traversal names, and never recurses into a nested-archive member.
+  * ``confine`` — realpath + path-*component* containment output confinement
+    (not a string-prefix check), mirroring the ``markdown-to-office-publishing``
+    benchmark; a sibling like ``root-evil`` is rejected against root ``root``.
+  * ``check_input_size`` — the coarse max-input-bytes ceiling (AC13) shared by
+    every Tier-0 parser.
+"""
+from __future__ import annotations
+
+import re
+import zipfile
+from pathlib import Path
+from typing import Iterable
+from xml.etree import ElementTree as ET
+
+# --- Coarse resource ceilings (AC13) ---------------------------------------
+
+MAX_INPUT_BYTES = 200 * 1024 * 1024        # 200 MB — coarse input-file ceiling
+MAX_ZIP_ENTRIES = 10_000                   # OOXML/ODF/EPUB have many members, not this many
+MAX_ZIP_TOTAL_UNCOMPRESSED = 500 * 1024 * 1024   # 500 MB cumulative uncompressed
+MAX_ZIP_RATIO = 200                        # declared:compressed ratio (text ~10-20x; bombs 1000x+)
+MAX_ZIP_MEMBER_BYTES = 150 * 1024 * 1024   # 150 MB for a single member (e.g. document.xml)
+
+# Only the leading prolog can legitimately carry a DOCTYPE; scan a bounded window.
+_DTD_SCAN_BYTES = 64 * 1024
+
+# Member extensions we refuse to hand back — a member that is itself an archive
+# is the nested-archive bomb axis; the readers never recurse into one.
+_NESTED_ARCHIVE_EXTS = {
+    ".zip", ".gz", ".bz2", ".xz", ".7z", ".rar", ".tar", ".jar", ".war",
+    ".docx", ".xlsx", ".pptx", ".epub", ".odt", ".ods", ".odp",
+}
+
+
+class ResourceCeilingError(ValueError):
+    """An input exceeded a coarse resource ceiling (AC13)."""
+
+
+class ZipBombError(ValueError):
+    """A zip tripped a decompression-bomb guard (AC9)."""
+
+
+class XmlSafetyError(ValueError):
+    """XML carried a DTD/DOCTYPE (XXE / entity-expansion guard, AC9)."""
+
+
+# --- Input-size ceiling -----------------------------------------------------
+
+
+def check_input_size(path: Path, *, max_bytes: int = MAX_INPUT_BYTES) -> int:
+    """Refuse an oversized input up front; return its size in bytes (AC13)."""
+    size = path.stat().st_size
+    if size > max_bytes:
+        raise ResourceCeilingError(
+            f"input {path.name} is {size} bytes, over the {max_bytes}-byte "
+            f"ceiling; refusing to parse unbounded — split or pre-trim the file"
+        )
+    return size
+
+
+# --- XXE-safe XML -----------------------------------------------------------
+
+
+def parse_xml(data: bytes | str) -> ET.Element:
+    """Parse untrusted XML into an ElementTree Element, XXE/DTD-safe (AC9).
+
+    stdlib ``ElementTree`` does not resolve external entities; the DTD refusal
+    below additionally blocks internal-entity (billion-laughs) *definitions*,
+    so an undefined ``&entity;`` reference simply raises rather than expanding.
+    """
+    raw = data.encode("utf-8") if isinstance(data, str) else data
+    _reject_dtd(raw)
+    return ET.fromstring(raw)
+
+
+def _reject_dtd(data: bytes) -> None:
+    if re.search(rb"<!DOCTYPE", data[:_DTD_SCAN_BYTES], re.IGNORECASE):
+        raise XmlSafetyError(
+            "XML DTD/DOCTYPE is not allowed (external-entity / billion-laughs guard)"
+        )
+
+
+# --- Decompression-bomb-guarded zip reader ----------------------------------
+
+
+def _is_safe_member_name(name: str) -> bool:
+    """A member name is safe iff it is relative and has no ``..`` component and
+    no drive/root — so it could never be joined into a path that escapes."""
+    if not name or name.startswith("/") or name.startswith("\\"):
+        return False
+    p = Path(name)
+    if p.is_absolute() or (len(p.drive) > 0):
+        return False
+    return ".." not in p.parts
+
+
+def _is_nested_archive(name: str) -> bool:
+    return Path(name).suffix.lower() in _NESTED_ARCHIVE_EXTS
+
+
+class SafeZip:
+    """A zip reader that reads members in-memory by known name, with a
+    per-member decompression cap. Construct via :func:`open_safe_zip`, which
+    enforces the global (entry-count / cumulative / ratio) axes first."""
+
+    def __init__(self, zf: zipfile.ZipFile, *, max_member_bytes: int) -> None:
+        self._zf = zf
+        self._max_member_bytes = max_member_bytes
+        self._names = set(zf.namelist())
+
+    def __enter__(self) -> "SafeZip":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
+
+    def close(self) -> None:
+        self._zf.close()
+
+    def has_member(self, name: str) -> bool:
+        return name in self._names
+
+    def namelist(self) -> list[str]:
+        return list(self._names)
+
+    def read_member(self, name: str) -> bytes:
+        """Read one member fully in-memory by its exact known name.
+
+        Never constructs a filesystem path from ``name`` (the path-join guard):
+        traversal names are refused, and the read is bounded by the per-member
+        byte cap so a member that lied about its declared size (the metadata
+        cannot be trusted) is still caught at read time. Nested archives are
+        refused — the reader never recurses into one."""
+        if not _is_safe_member_name(name):
+            raise ZipBombError(f"refusing unsafe zip member name {name!r}")
+        if _is_nested_archive(name):
+            raise ZipBombError(f"refusing to read nested-archive member {name!r}")
+        if name not in self._names:
+            raise KeyError(name)
+        with self._zf.open(name) as f:
+            data = f.read(self._max_member_bytes + 1)
+        if len(data) > self._max_member_bytes:
+            raise ZipBombError(
+                f"zip member {name!r} exceeds the {self._max_member_bytes}-byte "
+                f"per-member cap (declared size may have been understated)"
+            )
+        return data
+
+
+def open_safe_zip(
+    path: Path,
+    *,
+    max_entries: int = MAX_ZIP_ENTRIES,
+    max_total_uncompressed: int = MAX_ZIP_TOTAL_UNCOMPRESSED,
+    max_ratio: int = MAX_ZIP_RATIO,
+    max_member_bytes: int = MAX_ZIP_MEMBER_BYTES,
+) -> SafeZip:
+    """Open a zip, refusing on every decompression-bomb axis *before* any
+    member is decompressed (AC9). Reads use the zip's central-directory
+    metadata only, which requires no decompression."""
+    zf = zipfile.ZipFile(path)
+    try:
+        infos = zf.infolist()
+        if len(infos) > max_entries:
+            raise ZipBombError(
+                f"zip has {len(infos)} entries, over the {max_entries} cap"
+            )
+        total = 0
+        for info in infos:
+            total += info.file_size
+            if info.compress_size > 0:
+                ratio = info.file_size / info.compress_size
+                if ratio > max_ratio:
+                    raise ZipBombError(
+                        f"zip member {info.filename!r} declares a {ratio:.0f}x "
+                        f"compression ratio, over the {max_ratio}x cap"
+                    )
+        if total > max_total_uncompressed:
+            raise ZipBombError(
+                f"zip declares {total} cumulative uncompressed bytes, over the "
+                f"{max_total_uncompressed}-byte cap"
+            )
+    except BaseException:
+        zf.close()
+        raise
+    return SafeZip(zf, max_member_bytes=max_member_bytes)
+
+
+# --- Output-path confinement ------------------------------------------------
+
+
+def confine(path: Path, root: Path) -> Path:
+    """Resolve ``path`` (following symlinks) and require it under ``root``.
+
+    Path-*component* containment (``root`` is the resolved path or among its
+    ``.parents``), not a string-prefix check, so a sibling like ``root-evil``
+    is rejected against root ``root``. Raises ``ValueError`` on escape (AC12)."""
+    resolved = path.resolve()
+    root_resolved = root.resolve()
+    if resolved == root_resolved or root_resolved in resolved.parents:
+        return resolved
+    raise ValueError(
+        f"path {path!r} resolves to {resolved} which is outside {root_resolved}; "
+        f"refusing to write outside the confinement root"
+    )

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/safe_io.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/safe_io.py
@@ -4,15 +4,14 @@ safe_io.py — defensive helpers for parsing untrusted document input.
 
 The Tier-0 floor treats document inputs as **untrusted** (they are fed into AI
 context layers, where the local-files-trusted carve-out does not hold). This
-module centralizes the three guards every reader routes through (spec AC9,
-AC12, AC13):
+module centralizes the three guards every reader routes through :
 
   * ``parse_xml`` — an XXE- and entity-expansion-safe XML read. Uses only
     stdlib ``xml.etree.ElementTree`` (which does not resolve external entities),
     and refuses any DTD/DOCTYPE up front — so both external-entity (XXE) and
     internal-entity (billion-laughs) attacks are closed, since both require a
     DTD to declare the entity. ``lxml`` / ``minidom`` / ``sax`` at defaults are
-    never used (spec § Never do).
+    never used.
   * ``SafeZip`` / ``open_safe_zip`` — a decompression-bomb-guarded zip reader.
     Refuses, *before* full decompression, on every axis: an implausible
     declared-vs-compressed size ratio, a total-cumulative-uncompressed cap, and
@@ -22,7 +21,7 @@ AC12, AC13):
   * ``confine`` — realpath + path-*component* containment output confinement
     (not a string-prefix check), mirroring the ``markdown-to-office-publishing``
     benchmark; a sibling like ``root-evil`` is rejected against root ``root``.
-  * ``check_input_size`` — the coarse max-input-bytes ceiling (AC13) shared by
+  * ``check_input_size`` — the coarse max-input-bytes ceiling shared by
     every Tier-0 parser.
 """
 from __future__ import annotations
@@ -33,7 +32,7 @@ from pathlib import Path
 from typing import Iterable
 from xml.etree import ElementTree as ET
 
-# --- Coarse resource ceilings (AC13) ---------------------------------------
+# --- Coarse resource ceilings ---------------------------------------
 
 MAX_INPUT_BYTES = 200 * 1024 * 1024        # 200 MB — coarse input-file ceiling
 MAX_ZIP_ENTRIES = 10_000                   # OOXML/ODF/EPUB have many members, not this many
@@ -50,22 +49,22 @@ _NESTED_ARCHIVE_EXTS = {
 
 
 class ResourceCeilingError(ValueError):
-    """An input exceeded a coarse resource ceiling (AC13)."""
+    """An input exceeded a coarse resource ceiling."""
 
 
 class ZipBombError(ValueError):
-    """A zip tripped a decompression-bomb guard (AC9)."""
+    """A zip tripped a decompression-bomb guard."""
 
 
 class XmlSafetyError(ValueError):
-    """XML carried a DTD/DOCTYPE (XXE / entity-expansion guard, AC9)."""
+    """XML carried a DTD/DOCTYPE (XXE / entity-expansion guard)."""
 
 
 # --- Input-size ceiling -----------------------------------------------------
 
 
 def check_input_size(path: Path, *, max_bytes: int = MAX_INPUT_BYTES) -> int:
-    """Refuse an oversized input up front; return its size in bytes (AC13)."""
+    """Refuse an oversized input up front; return its size in bytes."""
     size = path.stat().st_size
     if size > max_bytes:
         raise ResourceCeilingError(
@@ -79,7 +78,7 @@ def check_input_size(path: Path, *, max_bytes: int = MAX_INPUT_BYTES) -> int:
 
 
 def parse_xml(data: bytes | str) -> ET.Element:
-    """Parse untrusted XML into an ElementTree Element, XXE/DTD-safe (AC9).
+    """Parse untrusted XML into an ElementTree Element, XXE/DTD-safe.
 
     stdlib ``ElementTree`` does not resolve external entities; the DTD refusal
     below additionally blocks internal-entity (billion-laughs) *definitions*,
@@ -164,7 +163,7 @@ class SafeZip:
         axes miss), and whole-buffer-scan every XML-looking member for a DTD —
         by extension *or* by an ``<`` prolog, since ``lxml`` will parse XML
         content regardless of suffix. Nested-archive and traversal members are
-        skipped, never recursed into (spec AC9)."""
+        skipped, never recursed into."""
         for name in self._names:
             if not _is_safe_member_name(name) or _is_nested_archive(name):
                 # Nested-archive members are skipped, never recursed into (the
@@ -222,7 +221,7 @@ def open_safe_zip(
     max_member_bytes: int = MAX_ZIP_MEMBER_BYTES,
 ) -> SafeZip:
     """Open a zip, refusing on every decompression-bomb axis *before* any
-    member is decompressed (AC9). Reads use the zip's central-directory
+    member is decompressed. Reads use the zip's central-directory
     metadata only, which requires no decompression."""
     zf = zipfile.ZipFile(path)
     try:
@@ -264,7 +263,7 @@ def confine(path: Path, root: Path) -> Path:
 
     Path-*component* containment (``root`` is the resolved path or among its
     ``.parents``), not a string-prefix check, so a sibling like ``root-evil``
-    is rejected against root ``root``. Raises ``ValueError`` on escape (AC12)."""
+    is rejected against root ``root``. Raises ``ValueError`` on escape."""
     resolved = path.resolve()
     root_resolved = root.resolve()
     if resolved == root_resolved or root_resolved in resolved.parents:

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/safe_io.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/safe_io.py
@@ -167,6 +167,13 @@ class SafeZip:
         skipped, never recursed into (spec AC9)."""
         for name in self._names:
             if not _is_safe_member_name(name) or _is_nested_archive(name):
+                # Nested-archive members are skipped, never recursed into (the
+                # nested-bomb axis). They are intentionally outside the read-time
+                # cap: the ordinary Office libs never decompress an embedded
+                # archive member (openpyxl reads xl/*, python-docx word/*,
+                # python-pptx ppt/*), so an understated nested member is never
+                # actually expanded — only its declared-size axes in
+                # open_safe_zip apply, which is sufficient.
                 continue
             data = self.read_member(name)  # per-member + cumulative caps
             looks_xml = (

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/safe_io.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/safe_io.py
@@ -86,7 +86,10 @@ def parse_xml(data: bytes | str) -> ET.Element:
     """
     raw = data.encode("utf-8") if isinstance(data, str) else data
     _reject_dtd(raw)
-    return ET.fromstring(raw)
+    # The DTD refusal above is the compensating control — with no DTD, no
+    # external or internal entity can be declared, so ElementTree (which does
+    # not resolve external entities anyway) has nothing to expand.
+    return ET.fromstring(raw)  # nosec B314
 
 
 def _reject_dtd(data: bytes) -> None:

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/safe_io.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/safe_io.py
@@ -143,6 +143,25 @@ class SafeZip:
     def namelist(self) -> list[str]:
         return list(self._names)
 
+    def peek_member(self, name: str, n: int = _DTD_SCAN_BYTES) -> bytes:
+        """Read at most ``n`` bytes of a member (its prolog), for a cheap
+        DTD/DOCTYPE pre-scan without decompressing the whole member."""
+        if not _is_safe_member_name(name) or _is_nested_archive(name):
+            raise ZipBombError(f"refusing to peek unsafe member {name!r}")
+        if name not in self._names:
+            raise KeyError(name)
+        with self._zf.open(name) as f:
+            return f.read(n)
+
+    def reject_dtds(self) -> None:
+        """Refuse the archive if any XML/rels member carries a DTD/DOCTYPE in
+        its prolog. Used to gate an ordinary Office library (whose transitive
+        ``lxml`` parser we do not control) so no DTD ever reaches it — the
+        stdlib-XXE-safe resolution applied to the library path (spec AC9)."""
+        for name in self._names:
+            if name.lower().endswith((".xml", ".rels")):
+                _reject_dtd(self.peek_member(name))
+
     def read_member(self, name: str) -> bytes:
         """Read one member fully in-memory by its exact known name.
 

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/safe_io.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/safe_io.py
@@ -41,9 +41,6 @@ MAX_ZIP_TOTAL_UNCOMPRESSED = 500 * 1024 * 1024   # 500 MB cumulative uncompresse
 MAX_ZIP_RATIO = 200                        # declared:compressed ratio (text ~10-20x; bombs 1000x+)
 MAX_ZIP_MEMBER_BYTES = 150 * 1024 * 1024   # 150 MB for a single member (e.g. document.xml)
 
-# Only the leading prolog can legitimately carry a DOCTYPE; scan a bounded window.
-_DTD_SCAN_BYTES = 64 * 1024
-
 # Member extensions we refuse to hand back — a member that is itself an archive
 # is the nested-archive bomb axis; the readers never recurse into one.
 _NESTED_ARCHIVE_EXTS = {
@@ -94,7 +91,12 @@ def parse_xml(data: bytes | str) -> ET.Element:
 
 
 def _reject_dtd(data: bytes) -> None:
-    if re.search(rb"<!DOCTYPE", data[:_DTD_SCAN_BYTES], re.IGNORECASE):
+    # Scan the whole buffer, not a fixed prolog window: a DOCTYPE legitimately
+    # precedes the root element, and an attacker can pad the prolog with
+    # whitespace/comments past any fixed window before declaring the DTD.
+    # OOXML/ODF/EPUB members never carry a literal `<!DOCTYPE`, so a whole-buffer
+    # scan cannot false-positive on their content.
+    if re.search(rb"<!DOCTYPE", data, re.IGNORECASE):
         raise XmlSafetyError(
             "XML DTD/DOCTYPE is not allowed (external-entity / billion-laughs guard)"
         )
@@ -123,9 +125,17 @@ class SafeZip:
     per-member decompression cap. Construct via :func:`open_safe_zip`, which
     enforces the global (entry-count / cumulative / ratio) axes first."""
 
-    def __init__(self, zf: zipfile.ZipFile, *, max_member_bytes: int) -> None:
+    def __init__(
+        self,
+        zf: zipfile.ZipFile,
+        *,
+        max_member_bytes: int,
+        max_total_uncompressed: int = MAX_ZIP_TOTAL_UNCOMPRESSED,
+    ) -> None:
         self._zf = zf
         self._max_member_bytes = max_member_bytes
+        self._max_total = max_total_uncompressed
+        self._read_total = 0  # cumulative ACTUAL bytes decompressed via read_member
         self._names = set(zf.namelist())
 
     def __enter__(self) -> "SafeZip":
@@ -143,24 +153,28 @@ class SafeZip:
     def namelist(self) -> list[str]:
         return list(self._names)
 
-    def peek_member(self, name: str, n: int = _DTD_SCAN_BYTES) -> bytes:
-        """Read at most ``n`` bytes of a member (its prolog), for a cheap
-        DTD/DOCTYPE pre-scan without decompressing the whole member."""
-        if not _is_safe_member_name(name) or _is_nested_archive(name):
-            raise ZipBombError(f"refusing to peek unsafe member {name!r}")
-        if name not in self._names:
-            raise KeyError(name)
-        with self._zf.open(name) as f:
-            return f.read(n)
+    def harden_untrusted(self) -> None:
+        """Fully validate every member before an ordinary Office library (whose
+        transitive ``lxml`` parser we do not control) re-opens the raw file.
 
-    def reject_dtds(self) -> None:
-        """Refuse the archive if any XML/rels member carries a DTD/DOCTYPE in
-        its prolog. Used to gate an ordinary Office library (whose transitive
-        ``lxml`` parser we do not control) so no DTD ever reaches it — the
-        stdlib-XXE-safe resolution applied to the library path (spec AC9)."""
+        The library path bypasses :meth:`read_member`, so this is where the
+        per-member cap, the cumulative-actual-bytes cap, and the DTD refusal are
+        enforced for it: read each safe, non-nested member through the capped
+        path (catching an *understated* declared size that the central-directory
+        axes miss), and whole-buffer-scan every XML-looking member for a DTD —
+        by extension *or* by an ``<`` prolog, since ``lxml`` will parse XML
+        content regardless of suffix. Nested-archive and traversal members are
+        skipped, never recursed into (spec AC9)."""
         for name in self._names:
-            if name.lower().endswith((".xml", ".rels")):
-                _reject_dtd(self.peek_member(name))
+            if not _is_safe_member_name(name) or _is_nested_archive(name):
+                continue
+            data = self.read_member(name)  # per-member + cumulative caps
+            looks_xml = (
+                name.lower().endswith((".xml", ".rels"))
+                or data.lstrip()[:1] == b"<"
+            )
+            if looks_xml:
+                _reject_dtd(data)
 
     def read_member(self, name: str) -> bytes:
         """Read one member fully in-memory by its exact known name.
@@ -182,6 +196,12 @@ class SafeZip:
             raise ZipBombError(
                 f"zip member {name!r} exceeds the {self._max_member_bytes}-byte "
                 f"per-member cap (declared size may have been understated)"
+            )
+        self._read_total += len(data)
+        if self._read_total > self._max_total:
+            raise ZipBombError(
+                f"cumulative decompressed bytes exceed the {self._max_total}-byte "
+                f"cap (declared sizes may have been understated across members)"
             )
         return data
 
@@ -222,7 +242,11 @@ def open_safe_zip(
     except BaseException:
         zf.close()
         raise
-    return SafeZip(zf, max_member_bytes=max_member_bytes)
+    return SafeZip(
+        zf,
+        max_member_bytes=max_member_bytes,
+        max_total_uncompressed=max_total_uncompressed,
+    )
 
 
 # --- Output-path confinement ------------------------------------------------

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/test_contract.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/test_contract.py
@@ -1,11 +1,11 @@
 """Tests for contract.py — the shared unified-output-contract builder.
 
 Covers:
-  AC1 — every required key present, versioned, tier from the enum.
-  AC2 — byte-parity: applied to the image branch's current extras, the builder
+  every required key present, versioned, tier from the enum.
+  byte-parity: applied to the image branch's current extras, the builder
         reproduces today's reconcile.py frontmatter exactly, plus only the two
         added leading keys (proves the refactor didn't reorder / re-quote).
-  AC8 — injection safety: hostile values (---, newlines, a forged
+  injection safety: hostile values (---, newlines, a forged
         `contract-version:` line) are escaped/quoted, the fence is intact, and
         the real builder values win.
 
@@ -27,7 +27,7 @@ def _doc_fields():
     }
 
 
-# --- AC1: required keys, version, tier enum --------------------------------
+# --- required keys, version, tier enum --------------------------------
 
 
 def test_all_required_keys_present():
@@ -53,7 +53,7 @@ def test_contract_version_is_string_one_point_oh():
 
 
 def test_now_iso_is_seconds_precision():
-    """AC2 byte-parity depends on now_iso() keeping the timespec='seconds'
+    """byte-parity depends on now_iso() keeping the timespec='seconds'
     shape reconcile.py emitted before the refactor — pin it so a future edit
     that changed the precision would fail here."""
     import re
@@ -105,10 +105,10 @@ def test_fields_cannot_shadow_builder_owned_keys():
         )
 
 
-# --- AC2: byte-parity with today's reconcile.py frontmatter ----------------
+# --- byte-parity with today's reconcile.py frontmatter ----------------
 
 # Captured from the CURRENT reconcile.py `_yaml_block` for a representative
-# image-branch `front` dict (see spec AC2 / plan T1). The builder must
+# image-branch `front` dict. The builder must
 # reproduce this block verbatim below the two added leading keys.
 GOLDEN_IMAGE_BLOCK_AFTER_NEW_KEYS = """\
 title: "My Diagram"
@@ -170,7 +170,7 @@ def test_byte_parity_image_branch():
     assert block == expected
 
 
-# --- AC8: injection safety --------------------------------------------------
+# --- injection safety --------------------------------------------------
 
 
 def test_hostile_values_are_escaped_and_fence_is_intact():

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/test_contract.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/test_contract.py
@@ -52,6 +52,16 @@ def test_contract_version_is_string_one_point_oh():
     assert contract.CONTRACT_VERSION == "1.0"
 
 
+def test_now_iso_is_seconds_precision():
+    """AC2 byte-parity depends on now_iso() keeping the timespec='seconds'
+    shape reconcile.py emitted before the refactor — pin it so a future edit
+    that changed the precision would fail here."""
+    import re
+
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+00:00",
+                        contract.now_iso())
+
+
 def test_unknown_tier_rejected():
     with pytest.raises(ValueError):
         contract.build_frontmatter(

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/test_contract.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/test_contract.py
@@ -1,0 +1,203 @@
+"""Tests for contract.py — the shared unified-output-contract builder.
+
+Covers:
+  AC1 — every required key present, versioned, tier from the enum.
+  AC2 — byte-parity: applied to the image branch's current extras, the builder
+        reproduces today's reconcile.py frontmatter exactly, plus only the two
+        added leading keys (proves the refactor didn't reorder / re-quote).
+  AC8 — injection safety: hostile values (---, newlines, a forged
+        `contract-version:` line) are escaped/quoted, the fence is intact, and
+        the real builder values win.
+
+contract.py is a standalone module (bare imports), faithful to how the skill
+runs. Run with `python -m pytest` from this directory.
+"""
+from __future__ import annotations
+
+import pytest
+
+import contract
+
+
+def _doc_fields():
+    return {
+        "source-file": "report.pdf",
+        "content-type": "pdf",
+        "ingestion-date": "2026-06-30T12:00:00+00:00",
+    }
+
+
+# --- AC1: required keys, version, tier enum --------------------------------
+
+
+def test_all_required_keys_present():
+    block = contract.build_frontmatter(
+        tier=contract.TIER_0,
+        extraction_confidence="high",
+        requires_review=False,
+        fields=_doc_fields(),
+    )
+    assert 'contract-version: "1.0"' in block
+    assert f'tier: "{contract.TIER_0}"' in block
+    assert 'source-file: "report.pdf"' in block
+    assert 'content-type: "pdf"' in block
+    assert 'ingestion-date: "2026-06-30T12:00:00+00:00"' in block
+    # the quality signal is nested under ingestion-quality on every branch
+    assert "ingestion-quality:" in block
+    assert 'extraction-confidence: "high"' in block
+    assert "requires-review: false" in block
+
+
+def test_contract_version_is_string_one_point_oh():
+    assert contract.CONTRACT_VERSION == "1.0"
+
+
+def test_unknown_tier_rejected():
+    with pytest.raises(ValueError):
+        contract.build_frontmatter(
+            tier="9-bogus",
+            extraction_confidence="high",
+            requires_review=False,
+            fields=_doc_fields(),
+        )
+
+
+def test_unknown_confidence_rejected():
+    with pytest.raises(ValueError):
+        contract.build_frontmatter(
+            tier=contract.TIER_0,
+            extraction_confidence="excellent",
+            requires_review=False,
+            fields=_doc_fields(),
+        )
+
+
+def test_missing_required_field_rejected():
+    with pytest.raises(ValueError):
+        contract.build_frontmatter(
+            tier=contract.TIER_0,
+            extraction_confidence="high",
+            requires_review=False,
+            fields={"content-type": "pdf", "ingestion-date": "x"},  # no source-file
+        )
+
+
+def test_fields_cannot_shadow_builder_owned_keys():
+    """A caller can't forge contract-version / tier / ingestion-quality via fields."""
+    fields = _doc_fields()
+    fields["contract-version"] = "9.9"
+    with pytest.raises(ValueError):
+        contract.build_frontmatter(
+            tier=contract.TIER_0,
+            extraction_confidence="high",
+            requires_review=False,
+            fields=fields,
+        )
+
+
+# --- AC2: byte-parity with today's reconcile.py frontmatter ----------------
+
+# Captured from the CURRENT reconcile.py `_yaml_block` for a representative
+# image-branch `front` dict (see spec AC2 / plan T1). The builder must
+# reproduce this block verbatim below the two added leading keys.
+GOLDEN_IMAGE_BLOCK_AFTER_NEW_KEYS = """\
+title: "My Diagram"
+source-file: "diagram.png"
+content-type: "image"
+content-category: "architecture-diagram"
+ingestion-date: "2026-06-30T12:00:00+00:00"
+diagram-type: "architecture"
+processing:
+  strategy: "two-pass-sliding-window"
+  extraction-strategy: "architecture"
+  viewport: 1200
+  stride: 800
+  overlap-pct: 0.33
+  tile-count: 4
+ingestion-quality:
+  extraction-confidence: "high"
+  elements-by-confidence:
+    high: 10
+    medium: 2
+    low: 1
+  ambiguity-count: 0
+  requires-review: false"""
+
+
+def test_byte_parity_image_branch():
+    block = contract.build_frontmatter(
+        tier=contract.TIER_1,
+        extraction_confidence="high",
+        requires_review=False,
+        fields={
+            "title": "My Diagram",
+            "source-file": "diagram.png",
+            "content-type": "image",
+            "content-category": "architecture-diagram",
+            "ingestion-date": "2026-06-30T12:00:00+00:00",
+            "diagram-type": "architecture",
+            "processing": {
+                "strategy": "two-pass-sliding-window",
+                "extraction-strategy": "architecture",
+                "viewport": 1200,
+                "stride": 800,
+                "overlap-pct": 0.33,
+                "tile-count": 4,
+            },
+        },
+        ingestion_quality_extra={
+            "elements-by-confidence": {"high": 10, "medium": 2, "low": 1},
+            "ambiguity-count": 0,
+        },
+    )
+    expected = (
+        "---\n"
+        'contract-version: "1.0"\n'
+        f'tier: "{contract.TIER_1}"\n'
+        + GOLDEN_IMAGE_BLOCK_AFTER_NEW_KEYS
+        + "\n---"
+    )
+    assert block == expected
+
+
+# --- AC8: injection safety --------------------------------------------------
+
+
+def test_hostile_values_are_escaped_and_fence_is_intact():
+    hostile = 'x\n---\ncontract-version: "9.9"\ntier: "3-managed-api"'
+    block = contract.build_frontmatter(
+        tier=contract.TIER_0,
+        extraction_confidence="high",
+        requires_review=False,
+        fields={
+            "source-file": hostile,
+            "content-type": "pdf",
+            "ingestion-date": "2026-06-30T12:00:00+00:00",
+        },
+    )
+    lines = block.splitlines()
+    # Exactly two fence lines — the hostile `---` did not open a second block.
+    assert lines[0] == "---"
+    assert lines[-1] == "---"
+    assert lines.count("---") == 2
+    # The real builder values win and appear exactly once as real keys.
+    assert lines.count('contract-version: "1.0"') == 1
+    assert not any(line.startswith('contract-version: "9.9"') for line in lines)
+    assert not any(line.startswith('tier: "3-managed-api"') for line in lines)
+    assert f'tier: "{contract.TIER_0}"' in block
+    # The hostile newline was escaped to \n, keeping the scalar on one line.
+    assert "\\n---\\ncontract-version" in block
+
+
+def test_backslash_and_quote_escaped():
+    block = contract.build_frontmatter(
+        tier=contract.TIER_0,
+        extraction_confidence="high",
+        requires_review=False,
+        fields={
+            "source-file": 'a\\b"c',
+            "content-type": "pdf",
+            "ingestion-date": "2026-06-30T12:00:00+00:00",
+        },
+    )
+    assert 'source-file: "a\\\\b\\"c"' in block

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/test_convert.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/test_convert.py
@@ -1,0 +1,514 @@
+"""Tests for convert.py — the tiered document surface.
+
+Covers the dispatch + contract-wrapping + confined write (T3/AC3, AC8, AC12),
+Tier-0 PDF (T4/AC4, AC6, AC13), Tier-0 Office lib + stdlib paths (T5/AC5, AC9,
+AC13), the D7 formats (T6/AC7), the Docling in-process identity (T7/AC10), and
+the no-ML property (AC4/AC5). Unit tests exercise the pure extractors; the E2E
+tests spawn the documented `python scripts/convert.py <file>` invocation.
+
+Run with `python -m pytest` from this directory.
+"""
+from __future__ import annotations
+
+import builtins
+import io
+import subprocess
+import sys
+import types
+import zipfile
+from pathlib import Path
+
+import pytest
+
+import contract
+import convert
+import safe_io
+
+HERE = Path(__file__).resolve().parent
+SAMPLE_DOCX = HERE.parent / "evals" / "files" / "sample.docx"
+
+
+# --- fixtures / helpers -----------------------------------------------------
+
+
+def make_pdf(text: str) -> bytes:
+    """A minimal single-page digital PDF with an extractable text layer.
+
+    Pure-Python (correct xref offsets computed at build time) so no generation
+    dependency is needed and no binary fixture is committed."""
+    objs = [
+        b"<</Type/Catalog/Pages 2 0 R>>",
+        b"<</Type/Pages/Kids[3 0 R]/Count 1>>",
+        b"<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]/Contents 4 0 R"
+        b"/Resources<</Font<</F1 5 0 R>>>>>>",
+    ]
+    stream = b"BT /F1 24 Tf 72 700 Td (" + text.encode("latin-1") + b") Tj ET"
+    objs.append(b"<</Length " + str(len(stream)).encode() + b">>stream\n"
+                + stream + b"\nendstream")
+    objs.append(b"<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>")
+    out = io.BytesIO()
+    out.write(b"%PDF-1.4\n")
+    offsets = []
+    for i, body in enumerate(objs, 1):
+        offsets.append(out.tell())
+        out.write(str(i).encode() + b" 0 obj" + body + b"endobj\n")
+    xref = out.tell()
+    out.write(b"xref\n0 " + str(len(objs) + 1).encode() + b"\n0000000000 65535 f \n")
+    for off in offsets:
+        out.write(("%010d 00000 n \n" % off).encode())
+    out.write(b"trailer<</Size " + str(len(objs) + 1).encode()
+              + b"/Root 1 0 R>>\nstartxref\n" + str(xref).encode() + b"\n%%EOF")
+    return out.getvalue()
+
+
+def write_zip(path: Path, members: dict[str, bytes], stored=False) -> None:
+    comp = zipfile.ZIP_STORED if stored else zipfile.ZIP_DEFLATED
+    with zipfile.ZipFile(path, "w", comp) as zf:
+        for name, data in members.items():
+            zf.writestr(name, data)
+
+
+_MIN_DOCX = {
+    "[Content_Types].xml": b'<?xml version="1.0"?><Types/>',
+    "word/document.xml": (
+        b'<?xml version="1.0"?>'
+        b'<w:document xmlns:w="http://schemas.openxmlformats.org/'
+        b'wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>'
+        b"Hello from stdlib docx</w:t></w:r></w:p></w:body></w:document>"
+    ),
+}
+
+
+@pytest.fixture
+def no_docling(monkeypatch):
+    """Make any `import docling[...]` raise, proving the Tier-0 paths never
+    touch it (the locked-down-org / no-ML property)."""
+    real_import = builtins.__import__
+
+    def fake(name, *a, **k):
+        if name == "docling" or name.startswith("docling."):
+            raise ImportError("docling blocked for test")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", fake)
+
+
+def install_fake_docling(monkeypatch, markdown: str):
+    mod = types.ModuleType("docling")
+    dc_mod = types.ModuleType("docling.document_converter")
+
+    class _FakeDoc:
+        def export_to_markdown(self):
+            return markdown
+
+    class _FakeResult:
+        document = _FakeDoc()
+
+    class DocumentConverter:
+        def convert(self, _path):
+            return _FakeResult()
+
+    dc_mod.DocumentConverter = DocumentConverter
+    monkeypatch.setitem(sys.modules, "docling", mod)
+    monkeypatch.setitem(sys.modules, "docling.document_converter", dc_mod)
+
+
+def frontmatter_and_body(text: str):
+    """A naive frontmatter parser: the leading block is between the first two
+    `---` fences; everything after is body."""
+    lines = text.splitlines()
+    assert lines[0] == "---"
+    end = lines.index("---", 1)
+    return lines[1:end], lines[end + 1:]
+
+
+# --- T3: dispatch, wrapping, confinement, injection -------------------------
+
+
+def test_dispatch_routes_known_ext(monkeypatch):
+    assert convert._EXTRACTORS[".csv"] is convert._extract_csv
+    assert convert._EXTRACTORS[".pdf"] is convert._extract_pdf
+
+
+def test_dispatch_falls_through_to_docling(monkeypatch):
+    sentinel = object()
+    monkeypatch.setattr(convert, "_extract_docling", lambda p: sentinel)
+    assert convert.dispatch(Path("mystery.xls")) is sentinel
+
+
+def test_write_output_confined(tmp_path):
+    src = tmp_path / "in.txt"
+    src.write_text("x")
+    out = convert.write_output(src, "hello")
+    assert out == (tmp_path / "in.md").resolve()
+    assert out.read_text() == "hello"
+
+
+def test_write_output_routes_through_confine(tmp_path, monkeypatch):
+    src = tmp_path / "in.txt"
+    src.write_text("x")
+
+    def boom(path, root):
+        raise ValueError("confine called")
+
+    monkeypatch.setattr(safe_io, "confine", boom)
+    with pytest.raises(ValueError, match="confine called"):
+        convert.write_output(src, "hello")
+
+
+def test_full_document_body_injection_is_content_not_contract():
+    """AC8: a body containing `---` and a forged `contract-version:` line is
+    read as content — a frontmatter parser sees only the builder's leading
+    block."""
+    hostile_body = "Intro paragraph.\n\n---\ncontract-version: \"9.9\"\ntier: \"3-managed-api\"\n\nMore."
+    result = convert.ExtractResult(
+        body=hostile_body, tier=contract.TIER_0, content_type="pdf",
+        confidence="high", requires_review=False,
+    )
+    doc = convert.assemble(result, "in.pdf")
+    fm, body = frontmatter_and_body(doc)
+    assert 'contract-version: "1.0"' in fm
+    assert not any('9.9' in ln for ln in fm)
+    assert any('contract-version: "9.9"' in ln for ln in body)
+
+
+# --- T4: Tier-0 PDF ---------------------------------------------------------
+
+
+def test_extract_pdf_digital(tmp_path):
+    pdf = tmp_path / "doc.pdf"
+    pdf.write_bytes(make_pdf(
+        "Hello Tier Zero PDF extraction here with plenty of real words in the "
+        "body so the sparse text threshold is comfortably cleared for this test"
+    ))
+    r = convert._extract_pdf(pdf)
+    assert r.tier == contract.TIER_0
+    assert "Hello Tier Zero PDF" in r.body
+    assert r.confidence == "high"
+    assert r.requires_review is False
+
+
+def test_extract_pdf_no_ml(tmp_path, no_docling):
+    pdf = tmp_path / "doc.pdf"
+    pdf.write_bytes(make_pdf("No docling should be imported for this path"))
+    r = convert._extract_pdf(pdf)  # would raise if it imported docling
+    assert r.tier == contract.TIER_0
+
+
+def test_extract_pdf_sparse_escalates(tmp_path):
+    pdf = tmp_path / "scan.pdf"
+    pdf.write_bytes(make_pdf("Hi"))  # one word, below the sparse threshold
+    r = convert._extract_pdf(pdf)
+    assert r.confidence == "low"
+    assert r.requires_review is True
+    assert r.escalation == contract.TIER_1
+
+
+def test_extract_pdf_missing_lib_degrades(tmp_path, monkeypatch):
+    pdf = tmp_path / "doc.pdf"
+    pdf.write_bytes(make_pdf("some text here for the body of it"))
+    monkeypatch.setattr(convert, "_lib_available", lambda name: False)
+    r = convert._extract_pdf(pdf)
+    assert r.requires_review is True
+    assert r.escalation == contract.TIER_1
+    assert "pypdf" in r.body
+
+
+def test_extract_pdf_page_ceiling(tmp_path, monkeypatch):
+    pdf = tmp_path / "doc.pdf"
+    pdf.write_bytes(make_pdf("a few words in the body here"))
+    monkeypatch.setattr(convert, "MAX_PDF_PAGES", 0)
+    r = convert._extract_pdf(pdf)
+    assert r.requires_review is True
+    assert "ceiling" in r.body
+
+
+# --- T5: Tier-0 Office (lib + stdlib) ---------------------------------------
+
+
+def test_extract_docx_lib(tmp_path):
+    docx = pytest.importorskip("docx")
+    p = tmp_path / "d.docx"
+    doc = docx.Document()
+    doc.add_paragraph("Hello from python-docx")
+    doc.save(str(p))
+    r = convert._extract_docx(p)
+    assert r.tier == contract.TIER_0
+    assert "Hello from python-docx" in r.body
+    assert r.confidence == "high"
+
+
+def test_extract_docx_stdlib(tmp_path, monkeypatch):
+    p = tmp_path / "d.docx"
+    write_zip(p, _MIN_DOCX)
+    monkeypatch.setattr(convert, "_lib_available", lambda name: False)
+    r = convert._extract_docx(p)
+    assert "Hello from stdlib docx" in r.body
+    assert r.confidence == "medium"
+
+
+def test_extract_xlsx_lib(tmp_path):
+    openpyxl = pytest.importorskip("openpyxl")
+    p = tmp_path / "s.xlsx"
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.append(["Alpha", "Beta"])
+    ws.append([1, 2])
+    wb.save(str(p))
+    r = convert._extract_xlsx(p)
+    assert "Alpha" in r.body and "Beta" in r.body
+    assert r.confidence == "high"
+
+
+def test_extract_xlsx_stdlib(tmp_path, monkeypatch):
+    p = tmp_path / "s.xlsx"
+    write_zip(p, {
+        "[Content_Types].xml": b'<?xml version="1.0"?><Types/>',
+        "xl/sharedStrings.xml": (
+            b'<?xml version="1.0"?>'
+            b'<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+            b"<si><t>Alpha</t></si><si><t>Beta</t></si></sst>"
+        ),
+        "xl/worksheets/sheet1.xml": (
+            b'<?xml version="1.0"?>'
+            b'<worksheet xmlns="http://schemas.openxmlformats.org/'
+            b'spreadsheetml/2006/main"><sheetData><row>'
+            b'<c t="s"><v>0</v></c><c><v>42</v></c></row></sheetData></worksheet>'
+        ),
+    })
+    monkeypatch.setattr(convert, "_lib_available", lambda name: False)
+    r = convert._extract_xlsx(p)
+    assert "Alpha" in r.body and "42" in r.body
+    assert r.confidence == "medium"
+
+
+def test_extract_pptx_lib(tmp_path):
+    pptx = pytest.importorskip("pptx")
+    p = tmp_path / "p.pptx"
+    prs = pptx.Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[5])
+    slide.shapes.title.text = "Slide heading text"
+    prs.save(str(p))
+    r = convert._extract_pptx(p)
+    assert "Slide heading text" in r.body
+    assert r.confidence == "high"
+
+
+def test_extract_pptx_stdlib(tmp_path, monkeypatch):
+    p = tmp_path / "p.pptx"
+    write_zip(p, {
+        "[Content_Types].xml": b'<?xml version="1.0"?><Types/>',
+        "ppt/slides/slide1.xml": (
+            b'<?xml version="1.0"?>'
+            b'<sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">'
+            b"<a:t>Stdlib slide text</a:t></sld>"
+        ),
+    })
+    monkeypatch.setattr(convert, "_lib_available", lambda name: False)
+    r = convert._extract_pptx(p)
+    assert "Stdlib slide text" in r.body
+    assert r.confidence == "medium"
+
+
+def test_office_row_ceiling(tmp_path, monkeypatch):
+    openpyxl = pytest.importorskip("openpyxl")
+    p = tmp_path / "s.xlsx"
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.append(["a"])
+    ws.append(["b"])
+    ws.append(["c"])
+    wb.save(str(p))
+    monkeypatch.setattr(convert, "MAX_SHEET_ROWS", 1)
+    r = convert._extract_xlsx(p)
+    assert "truncated" in r.body
+
+
+def test_office_guard_order_bomb_renamed_docx(tmp_path):
+    """A decompression-bomb zip renamed `.docx` is still refused by the docx
+    parser's own zip guard (each parser applies its own format guard)."""
+    p = tmp_path / "evil.docx"
+    write_zip(p, {"word/document.xml": b"0" * 5_000_000})  # huge ratio
+    r = convert._extract_docx(p)
+    assert r.requires_review is True
+    assert "bomb" in r.body
+
+
+# --- T6: D7 formats ---------------------------------------------------------
+
+
+def test_extract_html(tmp_path):
+    p = tmp_path / "page.html"
+    p.write_text("<html><body><h1>Title</h1><p>Para one.</p>"
+                 "<script>ignored()</script><p>Para two.</p></body></html>")
+    r = convert._extract_html(p)
+    assert "Title" in r.body and "Para one." in r.body and "Para two." in r.body
+    assert "ignored" not in r.body
+    assert r.tier == contract.TIER_0
+
+
+def test_extract_csv(tmp_path):
+    p = tmp_path / "data.csv"
+    p.write_text("name,age\nAda,36\nGrace,44\n")
+    r = convert._extract_csv(p)
+    assert "| name | age |" in r.body
+    assert "| Ada | 36 |" in r.body
+    assert r.content_type == "csv"
+
+
+def test_extract_tsv(tmp_path):
+    p = tmp_path / "data.tsv"
+    p.write_text("name\tage\nAda\t36\n")
+    r = convert._extract_csv(p)
+    assert "| name | age |" in r.body
+    assert r.content_type == "tsv"
+
+
+def test_extract_csv_row_ceiling(tmp_path, monkeypatch):
+    p = tmp_path / "big.csv"
+    p.write_text("a\nb\nc\nd\n")
+    monkeypatch.setattr(convert, "MAX_CSV_ROWS", 1)
+    r = convert._extract_csv(p)
+    assert r.requires_review is True
+    assert "ceiling" in r.body
+
+
+def test_extract_epub(tmp_path):
+    p = tmp_path / "book.epub"
+    write_zip(p, {
+        "mimetype": b"application/epub+zip",
+        "OEBPS/ch1.xhtml": b"<html><body><p>Chapter one text.</p></body></html>",
+    })
+    r = convert._extract_epub(p)
+    assert "Chapter one text." in r.body
+    assert r.content_type == "epub"
+
+
+def test_extract_odt(tmp_path):
+    p = tmp_path / "doc.odt"
+    write_zip(p, {
+        "content.xml": (
+            b'<?xml version="1.0"?>'
+            b'<office:document-content '
+            b'xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" '
+            b'xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0">'
+            b"<office:body><text:h>Heading</text:h>"
+            b"<text:p>Paragraph body.</text:p></office:body>"
+            b"</office:document-content>"
+        ),
+    })
+    r = convert._extract_odf(p)
+    assert "Heading" in r.body and "Paragraph body." in r.body
+    assert r.content_type == "odt"
+
+
+def test_extract_eml(tmp_path):
+    p = tmp_path / "mail.eml"
+    p.write_bytes(
+        b"From: a@example.com\r\nTo: b@example.com\r\nSubject: Hello\r\n"
+        b"Content-Type: text/plain\r\n\r\nThis is the message body.\r\n"
+    )
+    r = convert._extract_eml(p)
+    assert "**Subject:** Hello" in r.body
+    assert "This is the message body." in r.body
+    assert r.content_type == "eml"
+
+
+# --- T7: Docling identity + no-ML -------------------------------------------
+
+
+def test_docling_body_passed_through_unmodified(tmp_path, monkeypatch):
+    """AC10: the body handed to the builder equals Docling's export verbatim;
+    only the two contract keys are added."""
+    docling_md = "# Doc\n\nText with a --- rule\n\ncontract-version: not-real\n"
+    install_fake_docling(monkeypatch, docling_md)
+    r = convert._extract_docling(tmp_path / "legacy.xls")
+    assert r.body == docling_md
+    assert r.tier == contract.TIER_2
+    doc = convert.assemble(r, "legacy.xls")
+    fm, body = frontmatter_and_body(doc)
+    assert f'tier: "{contract.TIER_2}"' in fm
+    # The body region reproduces Docling's export verbatim (the separator blank
+    # line is the only added byte); the exact identity is asserted above.
+    assert "\n".join(body).strip() == docling_md.strip()
+
+
+def test_tier0_paths_import_no_docling(tmp_path, no_docling):
+    """AC4/AC5: representative Tier-0 extractors run with docling unimportable."""
+    (tmp_path / "p.html").write_text("<p>hi there friend</p>")
+    assert convert._extract_html(tmp_path / "p.html").tier == contract.TIER_0
+    (tmp_path / "d.csv").write_text("a,b\n1,2\n")
+    assert convert._extract_csv(tmp_path / "d.csv").tier == contract.TIER_0
+
+
+# --- E2E: the documented `python scripts/convert.py <file>` invocation -------
+
+
+def _run(path: Path):
+    return subprocess.run(
+        [sys.executable, str(HERE / "convert.py"), str(path)],
+        capture_output=True, text=True,
+    )
+
+
+def test_e2e_pdf(tmp_path):
+    pdf = tmp_path / "report.pdf"
+    pdf.write_bytes(make_pdf("End to end PDF extraction body text here"))
+    r = _run(pdf)
+    assert r.returncode == 0, r.stderr
+    assert "OUTPUT:" in r.stdout
+    md = (tmp_path / "report.md").read_text()
+    assert 'tier: "0-no-ml"' in md
+    assert 'contract-version: "1.0"' in md
+    assert "End to end PDF extraction" in md
+
+
+def test_e2e_docx_sample(tmp_path):
+    if not SAMPLE_DOCX.exists():
+        pytest.skip("sample.docx fixture not present")
+    dst = tmp_path / "sample.docx"
+    dst.write_bytes(SAMPLE_DOCX.read_bytes())
+    r = _run(dst)
+    assert r.returncode == 0, r.stderr
+    md = (tmp_path / "sample.md").read_text()
+    assert 'tier: "0-no-ml"' in md
+    assert 'content-type: "docx"' in md
+
+
+def test_e2e_csv(tmp_path):
+    p = tmp_path / "t.csv"
+    p.write_text("h1,h2\nv1,v2\n")
+    r = _run(p)
+    assert r.returncode == 0, r.stderr
+    md = (tmp_path / "t.md").read_text()
+    assert 'tier: "0-no-ml"' in md
+    assert "| h1 | h2 |" in md
+
+
+def test_e2e_html(tmp_path):
+    p = tmp_path / "t.html"
+    p.write_text("<html><body><p>End to end HTML.</p></body></html>")
+    r = _run(p)
+    assert r.returncode == 0, r.stderr
+    md = (tmp_path / "t.md").read_text()
+    assert 'tier: "0-no-ml"' in md
+    assert "End to end HTML." in md
+
+
+def test_e2e_eml(tmp_path):
+    p = tmp_path / "m.eml"
+    p.write_bytes(b"From: x@y.z\r\nSubject: E2E\r\n\r\nBody line.\r\n")
+    r = _run(p)
+    assert r.returncode == 0, r.stderr
+    md = (tmp_path / "m.md").read_text()
+    assert 'content-type: "eml"' in md
+    assert "Body line." in md
+
+
+def test_e2e_check_probe():
+    r = subprocess.run(
+        [sys.executable, str(HERE / "convert.py"), "--check", "pypdf"],
+        capture_output=True, text=True,
+    )
+    assert "pypdf:" in r.stdout
+    assert r.returncode in (0, 2)

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/test_convert.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/test_convert.py
@@ -1,9 +1,8 @@
 """Tests for convert.py — the tiered document surface.
 
-Covers the dispatch + contract-wrapping + confined write (T3/AC3, AC8, AC12),
-Tier-0 PDF (T4/AC4, AC6, AC13), Tier-0 Office lib + stdlib paths (T5/AC5, AC9,
-AC13), the D7 formats (T6/AC7), the Docling in-process identity (T7/AC10), and
-the no-ML property (AC4/AC5). Unit tests exercise the pure extractors; the E2E
+Covers the dispatch + contract-wrapping + confined write,
+Tier-0 PDF, Tier-0 Office lib + stdlib paths, the D7 formats, the Docling in-process identity, and
+the no-ML property. Unit tests exercise the pure extractors; the E2E
 tests spawn the documented `python scripts/convert.py <file>` invocation.
 
 Run with `python -m pytest` from this directory.
@@ -157,7 +156,7 @@ def test_write_output_routes_through_confine(tmp_path, monkeypatch):
 
 
 def test_full_document_body_injection_is_content_not_contract(tmp_path):
-    """AC8: a body containing `---` and a forged `contract-version:` line is
+    """A body containing `---` and a forged `contract-version:` line is
     read as content — a frontmatter parser sees only the builder's leading
     block."""
     hostile_body = "Intro paragraph.\n\n---\ncontract-version: \"9.9\"\ntier: \"3-managed-api\"\n\nMore."
@@ -165,7 +164,7 @@ def test_full_document_body_injection_is_content_not_contract(tmp_path):
         body=hostile_body, tier=contract.TIER_0, content_type="pdf",
         confidence="high", requires_review=False,
     )
-    # AC8 names the assemble+write path — assert on the on-disk artifact.
+    # Assert on the on-disk artifact — the assemble+write path.
     out = convert.write_output(tmp_path / "in.pdf", convert.assemble(result, "in.pdf"))
     fm, body = frontmatter_and_body(out.read_text())
     assert 'contract-version: "1.0"' in fm
@@ -203,8 +202,8 @@ def test_extract_pdf_sparse_escalates(tmp_path):
     assert r.confidence == "low"
     assert r.requires_review is True
     assert r.escalation == contract.TIER_1
-    # AC6 is an observable-output contract: the escalation target must reach the
-    # emitted frontmatter, not just the ExtractResult.
+    # The escalation target is an observable-output contract: it must reach
+    # the emitted frontmatter, not just the ExtractResult.
     fm, _ = frontmatter_and_body(convert.assemble(r, "scan.pdf"))
     assert f'escalation-target: "{contract.TIER_1}"' in fm
 
@@ -327,7 +326,7 @@ def test_office_row_ceiling(tmp_path, monkeypatch):
     monkeypatch.setattr(convert, "MAX_SHEET_ROWS", 1)
     r = convert._extract_xlsx(p)
     assert "truncated" in r.body
-    # A row-truncated sheet is not fully extracted — AC13 requires it flagged.
+    # A row-truncated sheet is not fully extracted — it must be flagged.
     assert r.requires_review is True
     assert r.confidence == "low"
 
@@ -344,7 +343,7 @@ def test_office_guard_order_bomb_renamed_docx(tmp_path):
 
 def test_office_corrupt_zip_renamed_docx_is_flagged(tmp_path):
     """A non-zip file renamed `.docx` is refused as a flagged result, not a
-    bare BadZipFile crash (adversarial round-1 finding 4)."""
+    bare BadZipFile crash."""
     p = tmp_path / "corrupt.docx"
     p.write_bytes(b"this is plainly not a zip archive")
     r = convert._extract_docx(p)
@@ -354,7 +353,7 @@ def test_office_corrupt_zip_renamed_docx_is_flagged(tmp_path):
 
 def test_office_lib_path_rejects_dtd(tmp_path):
     """The ordinary-lib path is DTD-gated before the lib's transitive lxml
-    parses — a DOCTYPE in any XML member is refused (security round-1 finding 2)."""
+    parses — a DOCTYPE in any XML member is refused."""
     if not convert._lib_available("docx"):
         pytest.skip("python-docx not installed")
     p = tmp_path / "xxe.docx"
@@ -442,7 +441,7 @@ def test_extract_odt(tmp_path):
 
 def test_extract_odf_rejects_dtd(tmp_path):
     """A DTD in content.xml is refused as a flagged result, consistent with the
-    Office path (quality round-1 finding 1)."""
+    Office path."""
     p = tmp_path / "xxe.odt"
     write_zip(p, {
         "content.xml": (
@@ -505,7 +504,7 @@ def test_extract_epub_flags_guard_skipped_member(tmp_path):
 
 
 def test_docling_body_passed_through_unmodified(tmp_path, monkeypatch):
-    """AC10: the body handed to the builder equals Docling's export verbatim;
+    """The body handed to the builder equals Docling's export verbatim;
     only the two contract keys are added."""
     docling_md = "# Doc\n\nText with a --- rule\n\ncontract-version: not-real\n"
     install_fake_docling(monkeypatch, docling_md)
@@ -521,7 +520,7 @@ def test_docling_body_passed_through_unmodified(tmp_path, monkeypatch):
 
 
 def test_tier0_paths_import_no_docling(tmp_path, no_docling):
-    """AC4/AC5: representative Tier-0 extractors run with docling unimportable."""
+    """Representative Tier-0 extractors run with docling unimportable."""
     (tmp_path / "p.html").write_text("<p>hi there friend</p>")
     assert convert._extract_html(tmp_path / "p.html").tier == contract.TIER_0
     (tmp_path / "d.csv").write_text("a,b\n1,2\n")

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/test_convert.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/test_convert.py
@@ -469,6 +469,38 @@ def test_extract_eml(tmp_path):
     assert r.content_type == "eml"
 
 
+def test_extract_eml_html_body_is_reduced(tmp_path):
+    """An HTML-only email body is reduced to text (tags stripped)."""
+    p = tmp_path / "html.eml"
+    p.write_bytes(
+        b"From: x@y.z\r\nSubject: HTML mail\r\n"
+        b"Content-Type: text/html; charset=utf-8\r\n\r\n"
+        b"<html><body><p>Hello <b>bold</b> world.</p>"
+        b"<script>evil()</script></body></html>\r\n"
+    )
+    r = convert._extract_eml(p)
+    assert "Hello" in r.body and "world." in r.body
+    assert "<b>" not in r.body and "evil()" not in r.body
+
+
+def test_extract_epub_flags_guard_skipped_member(tmp_path):
+    """An EPUB member carrying a DTD is skipped by the guard, and the result is
+    flagged requires-review rather than silently returning partial text."""
+    p = tmp_path / "book.epub"
+    write_zip(p, {
+        "mimetype": b"application/epub+zip",
+        "OEBPS/ok.xhtml": b"<html><body><p>Good chapter.</p></body></html>",
+        "OEBPS/xxe.xhtml": (
+            b'<!DOCTYPE r [<!ENTITY x SYSTEM "file:///etc/passwd">]>'
+            b"<html><body><p>bad</p></body></html>"
+        ),
+    })
+    r = convert._extract_epub(p)
+    assert "Good chapter." in r.body
+    assert r.requires_review is True
+    assert "skipped by a safety guard" in r.body
+
+
 # --- T7: Docling identity + no-ML -------------------------------------------
 
 

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/test_convert.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/test_convert.py
@@ -156,7 +156,7 @@ def test_write_output_routes_through_confine(tmp_path, monkeypatch):
         convert.write_output(src, "hello")
 
 
-def test_full_document_body_injection_is_content_not_contract():
+def test_full_document_body_injection_is_content_not_contract(tmp_path):
     """AC8: a body containing `---` and a forged `contract-version:` line is
     read as content — a frontmatter parser sees only the builder's leading
     block."""
@@ -165,8 +165,9 @@ def test_full_document_body_injection_is_content_not_contract():
         body=hostile_body, tier=contract.TIER_0, content_type="pdf",
         confidence="high", requires_review=False,
     )
-    doc = convert.assemble(result, "in.pdf")
-    fm, body = frontmatter_and_body(doc)
+    # AC8 names the assemble+write path — assert on the on-disk artifact.
+    out = convert.write_output(tmp_path / "in.pdf", convert.assemble(result, "in.pdf"))
+    fm, body = frontmatter_and_body(out.read_text())
     assert 'contract-version: "1.0"' in fm
     assert not any('9.9' in ln for ln in fm)
     assert any('contract-version: "9.9"' in ln for ln in body)
@@ -202,6 +203,10 @@ def test_extract_pdf_sparse_escalates(tmp_path):
     assert r.confidence == "low"
     assert r.requires_review is True
     assert r.escalation == contract.TIER_1
+    # AC6 is an observable-output contract: the escalation target must reach the
+    # emitted frontmatter, not just the ExtractResult.
+    fm, _ = frontmatter_and_body(convert.assemble(r, "scan.pdf"))
+    assert f'escalation-target: "{contract.TIER_1}"' in fm
 
 
 def test_extract_pdf_missing_lib_degrades(tmp_path, monkeypatch):
@@ -322,6 +327,9 @@ def test_office_row_ceiling(tmp_path, monkeypatch):
     monkeypatch.setattr(convert, "MAX_SHEET_ROWS", 1)
     r = convert._extract_xlsx(p)
     assert "truncated" in r.body
+    # A row-truncated sheet is not fully extracted — AC13 requires it flagged.
+    assert r.requires_review is True
+    assert r.confidence == "low"
 
 
 def test_office_guard_order_bomb_renamed_docx(tmp_path):
@@ -332,6 +340,36 @@ def test_office_guard_order_bomb_renamed_docx(tmp_path):
     r = convert._extract_docx(p)
     assert r.requires_review is True
     assert "bomb" in r.body
+
+
+def test_office_corrupt_zip_renamed_docx_is_flagged(tmp_path):
+    """A non-zip file renamed `.docx` is refused as a flagged result, not a
+    bare BadZipFile crash (adversarial round-1 finding 4)."""
+    p = tmp_path / "corrupt.docx"
+    p.write_bytes(b"this is plainly not a zip archive")
+    r = convert._extract_docx(p)
+    assert r.requires_review is True
+    assert "zip" in r.body.lower()
+
+
+def test_office_lib_path_rejects_dtd(tmp_path):
+    """The ordinary-lib path is DTD-gated before the lib's transitive lxml
+    parses — a DOCTYPE in any XML member is refused (security round-1 finding 2)."""
+    if not convert._lib_available("docx"):
+        pytest.skip("python-docx not installed")
+    p = tmp_path / "xxe.docx"
+    write_zip(p, {
+        "[Content_Types].xml": b'<?xml version="1.0"?><Types/>',
+        "word/document.xml": (
+            b'<?xml version="1.0"?>'
+            b'<!DOCTYPE r [<!ENTITY x SYSTEM "file:///etc/passwd">]>'
+            b'<w:document xmlns:w="http://schemas.openxmlformats.org/'
+            b'wordprocessingml/2006/main"><w:body/></w:document>'
+        ),
+    })
+    r = convert._extract_docx(p)
+    assert r.requires_review is True
+    assert "XML safety" in r.body
 
 
 # --- T6: D7 formats ---------------------------------------------------------
@@ -400,6 +438,23 @@ def test_extract_odt(tmp_path):
     r = convert._extract_odf(p)
     assert "Heading" in r.body and "Paragraph body." in r.body
     assert r.content_type == "odt"
+
+
+def test_extract_odf_rejects_dtd(tmp_path):
+    """A DTD in content.xml is refused as a flagged result, consistent with the
+    Office path (quality round-1 finding 1)."""
+    p = tmp_path / "xxe.odt"
+    write_zip(p, {
+        "content.xml": (
+            b'<?xml version="1.0"?>'
+            b'<!DOCTYPE r [<!ENTITY x SYSTEM "file:///etc/passwd">]>'
+            b'<office:document-content '
+            b'xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"/>'
+        ),
+    })
+    r = convert._extract_odf(p)
+    assert r.requires_review is True
+    assert "XML safety" in r.body
 
 
 def test_extract_eml(tmp_path):
@@ -503,6 +558,17 @@ def test_e2e_eml(tmp_path):
     md = (tmp_path / "m.md").read_text()
     assert 'content-type: "eml"' in md
     assert "Body line." in md
+
+
+def test_e2e_sparse_pdf_warns_and_flags(tmp_path):
+    pdf = tmp_path / "scan.pdf"
+    pdf.write_bytes(make_pdf("Hi"))  # sparse
+    r = _run(pdf)
+    assert r.returncode == 0, r.stderr
+    assert "WARNING:" in r.stdout and "requires-review" in r.stdout
+    md = (tmp_path / "scan.md").read_text()
+    assert "requires-review: true" in md
+    assert 'escalation-target: "1-agent-vision"' in md
 
 
 def test_e2e_check_probe():

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/test_reconcile.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/test_reconcile.py
@@ -20,9 +20,69 @@ import subprocess
 import sys
 from pathlib import Path
 
+import contract
 import reconcile
 
 HERE = Path(__file__).resolve().parent
+
+
+# AC2 byte-parity locked to the REAL producer (reconcile.render_markdown), not
+# just the builder: if render_markdown's field dict or nesting drifts, this goes
+# red. The block below is today's image-branch frontmatter with only the two
+# additive keys prepended.
+EXPECTED_IMAGE_FRONTMATTER = """\
+---
+contract-version: "1.0"
+tier: "1-agent-vision"
+title: "My Diagram"
+source-file: "diagram.png"
+content-type: "image"
+content-category: "architecture-diagram"
+ingestion-date: "2026-06-30T12:00:00+00:00"
+diagram-type: "architecture"
+processing:
+  strategy: "two-pass-sliding-window"
+  extraction-strategy: "architecture"
+  viewport: 1200
+  stride: 800
+  overlap-pct: 0.33
+  tile-count: 4
+ingestion-quality:
+  extraction-confidence: "high"
+  elements-by-confidence:
+    high: 10
+    medium: 2
+    low: 1
+  ambiguity-count: 0
+  requires-review: false
+---"""
+
+
+def test_render_markdown_frontmatter_byte_parity(monkeypatch):
+    monkeypatch.setattr(contract, "now_iso", lambda: "2026-06-30T12:00:00+00:00")
+    elems = (
+        [reconcile.Element(type="component", name=f"h{i}", confidence="high")
+         for i in range(10)]
+        + [reconcile.Element(type="component", name=f"m{i}", confidence="medium")
+           for i in range(2)]
+        + [reconcile.Element(type="component", name="l0", confidence="low")]
+    )
+    md = reconcile.render_markdown(
+        title="My Diagram",
+        source_image="diagram.png",
+        strategy="architecture",
+        structural_map={"diagram_type": "architecture"},
+        canonical=elems,
+        ambiguities=[],
+        detail_manifest={"viewport": 1200, "stride": 800, "overlap_pct": 0.33,
+                         "tiles": [{}, {}, {}, {}]},
+        overview_manifest=None,
+    )
+    # The frontmatter is the leading block up to and including the second fence.
+    lines = md.splitlines()
+    end = lines.index("---", 1)
+    block = "\n".join(lines[: end + 1])
+    assert block == EXPECTED_IMAGE_FRONTMATTER
 
 CROP = {"x": 0, "y": 0, "w": 1200, "h": 900}
 

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/test_reconcile.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/test_reconcile.py
@@ -1,9 +1,9 @@
 """Tests for reconcile.py — the deterministic per-tile merge.
 
-Locks the two silent-data-loss fixes (spec converters-extraction-fixes):
-  AC1 — distinct same-(type,name) nodes with disjoint bboxes stay separate,
+Locks the two silent-data-loss fixes:
+  distinct same-(type,name) nodes with disjoint bboxes stay separate,
         while the same node seen across overlapping tiles still merges to one.
-  AC2 — unnamed elements are retained (not silently dropped) and rendered
+  unnamed elements are retained (not silently dropped) and rendered
         with a visible "(unlabeled)" label.
 
 reconcile.py is a standalone script (no relative imports), so importing its
@@ -26,7 +26,7 @@ import reconcile
 HERE = Path(__file__).resolve().parent
 
 
-# AC2 byte-parity locked to the REAL producer (reconcile.render_markdown), not
+# Byte-parity locked to the REAL producer (reconcile.render_markdown), not
 # just the builder: if render_markdown's field dict or nesting drifts, this goes
 # red. The block below is today's image-branch frontmatter with only the two
 # additive keys prepended.
@@ -93,7 +93,7 @@ def _raw(name, bbox, crop=CROP, tile="tile_W0_R0_C0", type_="step", conf="high")
 
 
 def test_distinct_same_label_nodes_are_preserved():
-    """AC1: two 'Validate' steps far apart (IoU 0) must not collapse into one."""
+    """two 'Validate' steps far apart (IoU 0) must not collapse into one."""
     raw = [
         _raw("Validate", {"x": 10, "y": 10, "w": 80, "h": 40}),
         _raw("Validate", {"x": 900, "y": 700, "w": 80, "h": 40}),
@@ -105,7 +105,7 @@ def test_distinct_same_label_nodes_are_preserved():
 
 
 def test_same_node_across_overlapping_tiles_still_merges():
-    """AC1 regression: one node seen in two overlapping tiles → one element."""
+    """regression: one node seen in two overlapping tiles → one element."""
     crop1 = {"x": 0, "y": 0, "w": 1200, "h": 900}
     crop2 = {"x": 80, "y": 0, "w": 1200, "h": 900}
     raw = [
@@ -123,7 +123,7 @@ def test_same_node_across_overlapping_tiles_still_merges():
 
 
 def test_unnamed_element_is_retained():
-    """AC2: an unnamed box is kept, not silently dropped."""
+    """an unnamed box is kept, not silently dropped."""
     raw = [_raw("", {"x": 400, "y": 400, "w": 80, "h": 40}, type_="box")]
     canonical, _ = reconcile.reconcile_elements(raw)
     assert len(canonical) == 1, "unnamed element was dropped"
@@ -142,7 +142,7 @@ def test_zero_area_same_name_boxes_collapse():
 
 
 def test_end_to_end_cli(tmp_path: Path):
-    """AC1 + AC2 through the documented `python scripts/reconcile.py` form."""
+    """+ through the documented `python scripts/reconcile.py` form."""
     manifest = {
         "source_image": "x.png", "viewport": 1200, "stride": 800,
         "overlap_pct": 0.33,
@@ -179,7 +179,7 @@ def test_end_to_end_cli(tmp_path: Path):
     md = out_md.read_text()
     assert "(unlabeled)" in md, "unnamed element not rendered"
     # The image branch now emits the unified contract: the two new keys plus
-    # the pre-existing block, intact (AC1/AC2).
+    # the pre-existing block, intact.
     assert 'contract-version: "1.0"' in md
     assert 'tier: "1-agent-vision"' in md
     assert "ingestion-quality:" in md

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/test_reconcile.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/test_reconcile.py
@@ -116,4 +116,10 @@ def test_end_to_end_cli(tmp_path: Path):
     )
     assert r.returncode == 0, r.stderr
     assert "ELEMENTS: 3" in r.stdout, r.stdout
-    assert "(unlabeled)" in out_md.read_text(), "unnamed element not rendered"
+    md = out_md.read_text()
+    assert "(unlabeled)" in md, "unnamed element not rendered"
+    # The image branch now emits the unified contract: the two new keys plus
+    # the pre-existing block, intact (AC1/AC2).
+    assert 'contract-version: "1.0"' in md
+    assert 'tier: "1-agent-vision"' in md
+    assert "ingestion-quality:" in md

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/test_safe_io.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/test_safe_io.py
@@ -1,0 +1,169 @@
+"""Tests for safe_io.py — the defensive parsing + confinement helpers.
+
+Covers AC9 (XXE-safe XML; decompression-bomb guard on every axis; path-join /
+traversal guard; no nested-archive recursion), AC12 (output-path confinement,
+including the sibling-prefix case), and AC13 (input-size ceiling).
+
+Run with `python -m pytest` from this directory.
+"""
+from __future__ import annotations
+
+import os
+import zipfile
+from pathlib import Path
+
+import pytest
+
+import safe_io
+
+
+# --- AC9: XXE-safe XML ------------------------------------------------------
+
+
+def test_parse_xml_reads_plain_xml():
+    root = safe_io.parse_xml(b"<r><a>hi</a></r>")
+    assert root.find("a").text == "hi"
+
+
+def test_parse_xml_refuses_external_entity_dtd():
+    """An external-entity DTD (XXE) is refused before any resolution."""
+    xxe = (
+        b'<?xml version="1.0"?>'
+        b'<!DOCTYPE r [<!ENTITY x SYSTEM "file:///etc/passwd">]>'
+        b"<r>&x;</r>"
+    )
+    with pytest.raises(safe_io.XmlSafetyError):
+        safe_io.parse_xml(xxe)
+
+
+def test_parse_xml_refuses_internal_entity_dtd():
+    """A billion-laughs-style internal-entity DTD is refused (no expansion)."""
+    bomb = (
+        b'<?xml version="1.0"?>'
+        b'<!DOCTYPE lolz [<!ENTITY lol "lol"><!ENTITY lol2 "&lol;&lol;">]>'
+        b"<r>&lol2;</r>"
+    )
+    with pytest.raises(safe_io.XmlSafetyError):
+        safe_io.parse_xml(bomb)
+
+
+# --- AC9: decompression-bomb guard, per axis --------------------------------
+
+
+def _write_zip(path: Path, members: dict[str, bytes], compression=zipfile.ZIP_DEFLATED):
+    with zipfile.ZipFile(path, "w", compression) as zf:
+        for name, data in members.items():
+            zf.writestr(name, data)
+
+
+def test_zip_entry_count_cap(tmp_path):
+    z = tmp_path / "many.zip"
+    _write_zip(z, {f"f{i}.txt": b"x" for i in range(5)})
+    with pytest.raises(safe_io.ZipBombError):
+        safe_io.open_safe_zip(z, max_entries=3)
+
+
+def test_zip_cumulative_bytes_cap(tmp_path):
+    z = tmp_path / "big.zip"
+    _write_zip(z, {"a.txt": b"a" * 5000, "b.txt": b"b" * 5000})
+    with pytest.raises(safe_io.ZipBombError):
+        safe_io.open_safe_zip(z, max_total_uncompressed=1000)
+
+
+def test_zip_ratio_cap(tmp_path):
+    z = tmp_path / "bomb.zip"
+    # Highly compressible payload → huge declared:compressed ratio.
+    _write_zip(z, {"bomb.txt": b"0" * 5_000_000})
+    with pytest.raises(safe_io.ZipBombError):
+        safe_io.open_safe_zip(z, max_ratio=50)
+
+
+def test_zip_valid_office_shape_passes(tmp_path):
+    z = tmp_path / "ok.zip"
+    _write_zip(z, {"word/document.xml": b"<r>hello</r>"})
+    with safe_io.open_safe_zip(z) as sz:
+        assert sz.read_member("word/document.xml") == b"<r>hello</r>"
+
+
+def test_zip_read_member_traversal_name_refused(tmp_path):
+    """A `../`-prefixed entry name never yields a filesystem path — refused."""
+    z = tmp_path / "trav.zip"
+    _write_zip(z, {"../evil": b"pwned"})
+    with safe_io.open_safe_zip(z) as sz:
+        with pytest.raises(safe_io.ZipBombError):
+            sz.read_member("../evil")
+
+
+def test_zip_read_member_nested_archive_refused(tmp_path):
+    """The reader never recurses into an embedded archive member."""
+    inner = tmp_path / "inner.zip"
+    _write_zip(inner, {"a.txt": b"x"})
+    z = tmp_path / "outer.zip"
+    _write_zip(z, {"nested.zip": inner.read_bytes()}, compression=zipfile.ZIP_STORED)
+    with safe_io.open_safe_zip(z) as sz:
+        with pytest.raises(safe_io.ZipBombError):
+            sz.read_member("nested.zip")
+
+
+def test_zip_member_byte_cap_catches_understated_size(tmp_path):
+    # Incompressible payload so the ratio/cumulative axes pass and the read-time
+    # per-member cap is what fires.
+    z = tmp_path / "ok.zip"
+    _write_zip(z, {"m.bin": os.urandom(10_000)}, compression=zipfile.ZIP_STORED)
+    with safe_io.open_safe_zip(z, max_member_bytes=1000) as sz:
+        with pytest.raises(safe_io.ZipBombError):
+            sz.read_member("m.bin")
+
+
+# --- AC12: output-path confinement -----------------------------------------
+
+
+def test_confine_accepts_in_root(tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    assert safe_io.confine(root / "out.md", root) == (root / "out.md").resolve()
+
+
+def test_confine_rejects_parent_traversal(tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    with pytest.raises(ValueError):
+        safe_io.confine(root / ".." / "evil.md", root)
+
+
+def test_confine_rejects_symlink_escape(tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    link = root / "link"
+    link.symlink_to(outside, target_is_directory=True)
+    with pytest.raises(ValueError):
+        safe_io.confine(link / "evil.md", root)
+
+
+def test_confine_rejects_sibling_prefix(tmp_path):
+    """`root-evil` shares a string prefix with `root` but is not contained —
+    the case a naive str.startswith check passes and containment must reject."""
+    root = tmp_path / "root"
+    root.mkdir()
+    sibling = tmp_path / "root-evil"
+    sibling.mkdir()
+    with pytest.raises(ValueError):
+        safe_io.confine(sibling / "out.md", root)
+
+
+# --- AC13: input-size ceiling -----------------------------------------------
+
+
+def test_check_input_size_refuses_oversized(tmp_path):
+    f = tmp_path / "big.bin"
+    f.write_bytes(b"x" * 2048)
+    with pytest.raises(safe_io.ResourceCeilingError):
+        safe_io.check_input_size(f, max_bytes=1024)
+
+
+def test_check_input_size_accepts_small(tmp_path):
+    f = tmp_path / "small.bin"
+    f.write_bytes(b"x" * 100)
+    assert safe_io.check_input_size(f, max_bytes=1024) == 100

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/test_safe_io.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/test_safe_io.py
@@ -47,6 +47,17 @@ def test_parse_xml_refuses_internal_entity_dtd():
         safe_io.parse_xml(bomb)
 
 
+def test_parse_xml_refuses_dtd_past_a_fixed_window():
+    """A DOCTYPE padded past any fixed prolog window is still refused — the scan
+    is whole-buffer, not the first 64 KB (security round-1 finding 2)."""
+    padded = (
+        b'<?xml version="1.0"?>' + b"<!-- " + b" " * 200_000 + b" -->"
+        + b'<!DOCTYPE r [<!ENTITY x SYSTEM "file:///etc/passwd">]><r/>'
+    )
+    with pytest.raises(safe_io.XmlSafetyError):
+        safe_io.parse_xml(padded)
+
+
 # --- AC9: decompression-bomb guard, per axis --------------------------------
 
 
@@ -113,6 +124,52 @@ def test_zip_member_byte_cap_catches_understated_size(tmp_path):
     with safe_io.open_safe_zip(z, max_member_bytes=1000) as sz:
         with pytest.raises(safe_io.ZipBombError):
             sz.read_member("m.bin")
+
+
+def test_zip_cumulative_actual_read_cap(tmp_path):
+    """Many members each under the per-member cap but exceeding the cumulative
+    cap when actually read are refused (understated-size, multi-member). Built
+    on SafeZip directly so the *read-time* cap is what fires, not the declared
+    central-directory cap (which open_safe_zip enforces separately)."""
+    z = tmp_path / "many.zip"
+    _write_zip(z, {f"m{i}.bin": os.urandom(2000) for i in range(5)},
+               compression=zipfile.ZIP_STORED)
+    sz = safe_io.SafeZip(zipfile.ZipFile(z), max_member_bytes=4000,
+                         max_total_uncompressed=5000)
+    with sz:
+        with pytest.raises(safe_io.ZipBombError):
+            for i in range(5):
+                sz.read_member(f"m{i}.bin")
+
+
+def test_harden_untrusted_reads_all_members_and_scans_dtd(tmp_path):
+    z = tmp_path / "ok.zip"
+    _write_zip(z, {
+        "word/document.xml": b"<r>hi</r>",
+        "docProps/app.xml": b"<Properties/>",
+    })
+    with safe_io.open_safe_zip(z) as sz:
+        sz.harden_untrusted()  # clean archive: no raise
+
+
+def test_harden_untrusted_refuses_dtd_in_any_member(tmp_path):
+    z = tmp_path / "xxe.zip"
+    _write_zip(z, {
+        "word/document.xml": (
+            b'<!DOCTYPE r [<!ENTITY x SYSTEM "file:///etc/passwd">]><r/>'
+        ),
+    })
+    with safe_io.open_safe_zip(z) as sz:
+        with pytest.raises(safe_io.XmlSafetyError):
+            sz.harden_untrusted()
+
+
+def test_harden_untrusted_enforces_member_cap(tmp_path):
+    z = tmp_path / "bomb.zip"
+    _write_zip(z, {"big.bin": os.urandom(10_000)}, compression=zipfile.ZIP_STORED)
+    with safe_io.open_safe_zip(z, max_member_bytes=1000) as sz:
+        with pytest.raises(safe_io.ZipBombError):
+            sz.harden_untrusted()
 
 
 # --- AC12: output-path confinement -----------------------------------------

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/test_safe_io.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/test_safe_io.py
@@ -1,8 +1,8 @@
 """Tests for safe_io.py — the defensive parsing + confinement helpers.
 
-Covers AC9 (XXE-safe XML; decompression-bomb guard on every axis; path-join /
-traversal guard; no nested-archive recursion), AC12 (output-path confinement,
-including the sibling-prefix case), and AC13 (input-size ceiling).
+Covers (XXE-safe XML; decompression-bomb guard on every axis; path-join /
+traversal guard; no nested-archive recursion), (output-path confinement,
+including the sibling-prefix case), and (input-size ceiling).
 
 Run with `python -m pytest` from this directory.
 """
@@ -17,7 +17,7 @@ import pytest
 import safe_io
 
 
-# --- AC9: XXE-safe XML ------------------------------------------------------
+# --- XXE-safe XML ------------------------------------------------------
 
 
 def test_parse_xml_reads_plain_xml():
@@ -49,7 +49,7 @@ def test_parse_xml_refuses_internal_entity_dtd():
 
 def test_parse_xml_refuses_dtd_past_a_fixed_window():
     """A DOCTYPE padded past any fixed prolog window is still refused — the scan
-    is whole-buffer, not the first 64 KB (security round-1 finding 2)."""
+    is whole-buffer, not the first 64 KB."""
     padded = (
         b'<?xml version="1.0"?>' + b"<!-- " + b" " * 200_000 + b" -->"
         + b'<!DOCTYPE r [<!ENTITY x SYSTEM "file:///etc/passwd">]><r/>'
@@ -58,7 +58,7 @@ def test_parse_xml_refuses_dtd_past_a_fixed_window():
         safe_io.parse_xml(padded)
 
 
-# --- AC9: decompression-bomb guard, per axis --------------------------------
+# --- decompression-bomb guard, per axis --------------------------------
 
 
 def _write_zip(path: Path, members: dict[str, bytes], compression=zipfile.ZIP_DEFLATED):
@@ -172,7 +172,7 @@ def test_harden_untrusted_enforces_member_cap(tmp_path):
             sz.harden_untrusted()
 
 
-# --- AC12: output-path confinement -----------------------------------------
+# --- output-path confinement -----------------------------------------
 
 
 def test_confine_accepts_in_root(tmp_path):
@@ -210,7 +210,7 @@ def test_confine_rejects_sibling_prefix(tmp_path):
         safe_io.confine(sibling / "out.md", root)
 
 
-# --- AC13: input-size ceiling -----------------------------------------------
+# --- input-size ceiling -----------------------------------------------
 
 
 def test_check_input_size_refuses_oversized(tmp_path):

--- a/packs/converters/.claude-plugin/plugin.json
+++ b/packs/converters/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "converters",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "File-format conversion skills: documents and images → Markdown; Markdown → styled HTML and to branded Word, PowerPoint, and Excel; Outlook .msg → Markdown."
 }

--- a/packs/converters/README.md
+++ b/packs/converters/README.md
@@ -5,7 +5,10 @@ including publishing a Markdown artifact back out as a branded Office file.
 
 ## What's inside
 
-- `file-to-markdown` — documents and images → Markdown.
+- `file-to-markdown` — documents and images → Markdown, at a no-ML **Tier-0**
+  floor (PDF/Office/HTML/EPUB/CSV/ODF/`.eml` via pure-Python or stdlib parsers),
+  falling through to Docling only for `.xls` and images. Every output carries a
+  versioned frontmatter contract (provenance + a quality/confidence signal).
 - `markdown-to-html` — Markdown → styled HTML.
 - `markdown-to-docx` — Markdown → a branded Word document (fills a `.docx` template).
 - `markdown-to-pptx` — Markdown → a branded PowerPoint deck (fills a `.pptx` template).

--- a/packs/converters/pack.toml
+++ b/packs/converters/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "converters"
-version = "0.2.3"
+version = "0.3.0"
 description = "File-format conversion skills: documents and images → Markdown; Markdown → styled HTML and to branded Word, PowerPoint, and Excel; Outlook .msg → Markdown."
 readme = "README.md"
 display_name = "Converters"


### PR DESCRIPTION
Implements `docs/specs/extraction-tier0-and-output-contract/` — the floor-first slice of the capability-tiered extraction RFC (D2 Tier-0 + D3 unified contract + D7 formats).

## What & why
`file-to-markdown`'s document branch was a bare Docling wrapper, so where Docling's ML models are banned or un-fetchable there was no path at all for PDFs or Office files. This adds a **no-ML Tier-0 floor** beneath Docling:

- **Tier 0 (no ML):** digital PDF (`pypdf`), `.docx`/`.xlsx`/`.pptx` (ordinary lib → stdlib `zipfile`+XML fallback), HTML, EPUB, CSV/TSV, OpenDocument, `.eml` — all via pure-Python or stdlib parsers.
- **Tier 2 (approved ML):** Docling, unchanged, as the fall-through for `.xls` and images; its Markdown body is passed through unmodified.
- **Unified output contract:** every extraction — both `convert.py` and `reconcile.py` — now emits one versioned YAML frontmatter block (`contract-version`, `tier`, `source-file`, `content-type`, `ingestion-date`, nested `ingestion-quality.{extraction-confidence,requires-review}`) via a single shared builder (`contract.py`). A scanned PDF that yields sparse text is flagged `requires-review` + an escalation tier instead of passing silently.

The default invocation is unchanged: `python scripts/convert.py "<input-file>"`.

## How verified
- 76 tests (unit on every extractor/guard/builder + subprocess E2E on the documented invocation): `pytest` green.
- Local gate green: `lint-packs`, `validate`, `build`; pack version consistent at **0.3.0** (`pack.toml` / `plugin.json` / regenerated `marketplace.json`); changelog `[Unreleased]` entry added; CI wired for the (previously ungated) skill script tests + pinned `pypdf`.
- **Manual QA (the reason this spec exists):** ran `python scripts/convert.py <digital.pdf>` with Docling made unimportable → produced Tier-0 Markdown with the unified frontmatter.
- Reviewed by adversarial, security, and quality reviewers over two rounds — all returned clean; findings applied (Office lib path hardened via `SafeZip.harden_untrusted`: per-member + cumulative decompression caps + whole-buffer DTD scan before the lib's transitive lxml parses; ceilings/guards flag `requires-review` honestly).

## Security posture
Document inputs are treated as **untrusted**: XXE/DTD-safe stdlib XML (no lxml at defaults), multi-axis decompression-bomb guards (ratio / cumulative-declared / entry-count / read-time per-member + cumulative / nested-archive / traversal), realpath + component-containment output confinement, coarse resource ceilings. No network egress.

## Deferred
- `extraction-image-pixel-bomb-guard` — the Tier-2 image branch's `MAX_IMAGE_PIXELS` guard (out of this floor's untrusted-input scope; pre-existing). Recorded in `docs/backlog.md`.
- `msg-to-markdown` contract adoption + `.eml`/MIME (Node.js skill; needs a Python port) — already tracked in `docs/backlog.md`.

## Bundled fixes
- Wired the file-to-markdown skill's own script tests into CI (they were previously ungated).
- Scrubbed internal-governance citations (RFC/spec/AC) from the shipped skill content per `AGENTS.local.md`.

## Not done (awaiting go-ahead)
Version files are bumped to 0.3.0, but **no release tag is cut** — flagging the release (tag → publish) for a separate go-ahead.