### PR TITLE
docs: revamp README and guides for full Company OS representation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # agent-ready-repo
 
-**A loop your coding agent can't cut corners in — and a catalogue of kits for the jobs around the code.**
+**The complete AI operating model for software teams — from first idea to production.**
 
-The sharpest **loop engineering** for coding agents: plan, execute, verify, review — with gates it can't pass on red and a reviewer that reads every diff cold. Any repo, any agent.
+Three supervised loops covering the full software lifecycle. Fourteen curated packs for every job role. One installer. Any agent, any stack.
 
 [![PyPI](https://img.shields.io/pypi/v/agentbundle)](https://pypi.org/project/agentbundle/) [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](#license)
 
-[Quick Start](#quick-start) · [The Loop](#the-loop) · [The Catalogue](#the-catalogue) · [Build a Pack](#how-a-pack-is-laid-out) · [Docs](docs/guides/) · [Contributing](CONTRIBUTING.md)
+[Quick Start](#quick-start) · [The Three Loops](#the-three-loops) · [The Catalogue](#the-catalogue) · [Build a Pack](#how-a-pack-is-laid-out) · [Docs](docs/guides/) · [Contributing](CONTRIBUTING.md)
 
 > "You shouldn't be prompting coding agents anymore. You should be designing loops that prompt your agents." — [Peter Steinberger](https://x.com/steipete/status/2063697162748260627)
 
 The leverage in agent coding moved from the prompt to the **loop** — it plans, executes, verifies, and decides what comes next, so you stop babysitting every turn. But a loop running unattended is also a loop making mistakes unattended, so it has to check its own work harder than you would.
 
-`core` is the flagship pack: that discipline made concrete — planning, hard gates, cold-eyed review, working as one loop the agent can't self-certify its way out of.
+Software delivery needs more than one loop. Product managers shape ideas into build-ready briefs; engineers build and gate their changes; SRE teams validate what reaches production. This repository makes all three concrete: a **discovery loop** that takes a raw idea through multi-lens convergence to a ratified brief, a **build loop** that gates every change with hard mechanical checks and cold-eyed review, and a **release loop** that validates the deployed whole end-to-end before any human touches a prod switch. Three peer supervisors. One handoff chain. Human gates only where the decision is irreversible.
+
+`core` is the flagship pack: the build discipline made concrete — planning, hard gates, cold-eyed review, working as one loop the agent can't self-certify its way out of.
 
 ```bash
 pip install agentbundle
@@ -21,7 +23,7 @@ agentbundle install --pack core
 
 One line lands the loop in your repo — no catalogue argument needed; it defaults to this catalogue. Any agent that reads a skill file inherits it: Claude Code, Codex, Cursor, Copilot, Gemini, Kiro.
 
-Behind `core` is a **catalogue of kits** — research, integration contract authoring, solution architecture, product shaping, and more — each a cohesive set of skills, subagents, and hooks that delivers one whole job, installed one line at a time. [See the catalogue.](#the-catalogue)
+Behind `core` is a **catalogue of curated kits** — each pack distilled from the best practices of its discipline through research, RFCs, and architecture decisions. Research, architecture, product discovery, experience design, integration contracts, and more — each is a cohesive set of skills, subagents, and hooks that delivers one whole job, installed in one line. [See the catalogue.](#the-catalogue)
 
 ## Quick start
 
@@ -72,16 +74,38 @@ The default is user-global: set it once and it applies whether you install into 
 
 When more than one is in play, the most specific wins: a per-install `--adapter` beats the pinned default, which beats auto-detect — and re-running an install keeps whatever adapter that install already uses.
 
-## The loop
+## The three loops
 
-Most agent workflows are `prompt → code → ship`. `core` replaces that one-shot path: it splits the maker from the verifier, and it won't skip a step.
+Three packs form the **company operating model** — peer supervisors spanning the full software lifecycle:
 
-1. **Plan, and surface the assumptions.** Before any code, the agent writes down what it's building, what it won't touch, and what it's assuming. When an assumption breaks mid-run, the loop stops and says so — no guessing past the problem.
-2. **Hard gates between "done" and done.** Lint, typecheck, and tests run as gates. No path through the loop lets the agent claim success on a red gate.
-3. **Adversarial review in a fresh session.** Once the gates pass, specialist reviewer agents read the diff cold — no attachment to the design, no sunk cost in the code. The loop fixes and re-reviews until the reviewers say `Clean — ready to commit.`
-4. **Capture what it learned.** The model forgets between sessions; the repo doesn't. A run that trips over an undocumented convention lands the gap as a proposed edit to `CONVENTIONS.md`. Mistakes become the project's memory instead of evaporating.
+```
+product-engineering              core                    release-engineering
+───────────────────              ────                    ───────────────────
+discovery-lead                   work-loop supervisor    release-lead
+Raw idea → Decision brief  ─G3─▶ Spec → Shipped code ─G4─▶ Built → Production
+```
 
-The reviewers aren't generic critics. Each reviewer has its own unique sharp lenses, picked by what the change actually touches:
+Each loop is autonomous where the work is reversible and surfaces to a human where it isn't. No loop is a mode of another — each is a **peer supervisor** with its own agent, its own skill doctrine, and its own consent gates.
+
+→ [The three loops as a system](docs/guides/_shared/explanation/the-three-loops.md)
+
+### The discovery loop — `product-engineering`
+
+`discovery-lead` takes a raw product idea and walks it through a structured diverge/converge cycle: five candidate shapes explored in parallel, then collapsed through product, UX, architecture, and safety lenses simultaneously — results written to a shared blackboard, no chat relay. A ratified **decision brief** exits at G2; a decomposed feature-level plan exits at G3 into `work-loop`.
+
+The result isn't a validated solution — it's a **connected hypothesis with validation hooks**: the riskiest bets named explicitly, the MVP boundary set by a human, the decision log append-only and hash-chained. Recursion is data: sub-problems are nodes in a tree, not separate projects.
+
+Three human consent gates: **G0** (ratify the value seed), **G1.5** (ratify the MVP boundary), **G2** (ratify the decision). The loop never auto-advances past an irreversible gate.
+
+→ [Discovery loop guide](docs/guides/product-engineering/) · [Walk a discovery end-to-end](docs/guides/product-engineering/tutorials/walk-a-discovery-end-to-end.md)
+
+### The build loop — `core`
+
+Every change goes through: plan (name the assumptions and what won't be touched), hard gates (lint, typecheck, tests — no path through the loop passes on red), adversarial review in a fresh session (specialist reviewers with no sunk cost in the design), and capture what was learned (gaps land as proposed `CONVENTIONS.md` edits, not as evaporated knowledge).
+
+The loop scales by risk: **light mode** for low-risk work (lean inline spec, single adversarial pass); **full mode** when any risk trigger fires — unfamiliar territory, new dependency, compliance surface, multi-person work, destructive operation. The mode is chosen by the work's risk profile, not by file count.
+
+Three specialist reviewers each read every diff cold:
 
 | Reviewer | Lens | When it runs |
 | --- | --- | --- |
@@ -89,17 +113,29 @@ The reviewers aren't generic critics. Each reviewer has its own unique sharp len
 | `security-reviewer` | OWASP 2025 + ASVS, STRIDE + LINDDUN — depth pulled per boundary | security-boundary work, at spec stage *and* on the diff |
 | `quality-engineer` | testability, observability, reliability — the "cost to live with this code" | logic and interfaces worth maintaining |
 
-The security lens **shifts left**: on security-boundary work it also runs at spec stage, catching a missing control as a one-sentence acceptance criterion instead of a post-implementation round-trip, and pulls its depth from a progressive-disclosure checklist library scoped to the boundaries a change crosses (OWASP 2025, ASVS, CWE Top 25) — current without bloating the prompt. The quality lens holds every diff to a raised maintainability floor by doctrine, whether or not a strict static-analysis gate is wired in. A fourth subagent, `implementer`, is the loop's own executor: it runs independent tasks in parallel.
+The security lens **shifts left**: on security-boundary work it also runs at spec stage, catching a missing control as a one-sentence acceptance criterion instead of a post-implementation round-trip, and pulls its depth from a progressive-disclosure checklist library scoped to the boundaries a change crosses — current without bloating the prompt. The quality lens holds every diff to a raised maintainability floor by doctrine, whether or not a strict static-analysis gate is wired in. A fourth subagent, `implementer`, is the loop's own executor: it runs independent tasks in parallel.
 
-→ [The core pack as a system](docs/guides/core/explanation/core-pack.md) walks through how the parts compose, and how it compares to vibe-coding, GitHub's Spec Kit, and Kiro's spec mode.
+→ [The `core` pack as a system](docs/guides/core/explanation/core-pack.md) walks through how the parts compose, and how it compares to vibe-coding, GitHub's Spec Kit, and Kiro's spec mode.
+
+### The release loop — `release-engineering`
+
+`release-lead` takes the locally built, deploy-ready artifact and validates it deployed: deploy to an **ephemeral environment** (no real data, isolated from prod, teardownable), run e2e against the real artifact, observe telemetry, feed deployed findings back to `work-loop` as build tasks (no human relay), redeploy, and iterate until the deployed whole converges by policy. Then surface a **release-readiness record** for the prod-ship consent gate.
+
+Autonomy is carved by **minimum-regret**: reversible operations (deploy to ephemeral, e2e, observe, iterate, teardown) run unattended. Irreversible operations (first real users, data migrations, spend over threshold, the **prod ship**) always surface to a human. The G5 prod-ship gate is never autonomous.
+
+The outer loop hard-depends on `core` and reuses its `quality-engineer` (in operational mode), `security-reviewer`, and `operational-safety` modules — no new reviewer agents needed. Deploy credentials are broker-mediated and scoped to the ephemeral tier only; no credential can reach prod.
+
+→ [Release loop guide](docs/guides/release-engineering/) · [The release loop explained](docs/guides/release-engineering/explanation/the-release-loop.md)
 
 ## The catalogue
 
-The flagship `core` pack brings loop engineering to supercharge development in your code repos. Each other pack is a **kit** that delivers a use case end to end — a cohesive set of related skills, subagents, and hooks. Install only the kits needed at user scope or needed by your repo.
+The three loop packs anchor the operating model. The remaining packs are **curated kits** — each distilled from the best practices of its discipline, shaped through practitioner research and governed through the RFC and architecture-decision process. Install only the kits your team and repo need.
 
 | Pack | Scope | Agentic use case |
 | --- | --- | --- |
-| [`core`](docs/guides/core/) | **repo** | **The flagship loop, on every change.** `work-loop`, `new-spec`, `bug-fix`, `adapt-to-project`, the four reviewer/executor subagents, `pre-pr` + `session-start` hooks, governance seeds. **Install this even if you install nothing else.** |
+| [`core`](docs/guides/core/) | **repo** | **The build loop, on every change.** `work-loop`, `new-spec`, `bug-fix`, `adapt-to-project`, the four reviewer/executor subagents, `pre-pr` + `session-start` hooks, governance seeds. **Install this even if you install nothing else.** |
+| [`product-engineering`](docs/guides/product-engineering/) | user | **The discovery loop — raw idea to build-ready brief.** `discovery-loop`, `frame-intent`, `de-risk-intent`, `decompose-intent`; `voice-and-microcopy` for UI copy; `align-value-stream` for multi-repo capability coordination. |
+| [`release-engineering`](docs/guides/release-engineering/) | **repo** | **The release loop — build to production.** `release-loop`, `release-lead`; autonomous e2e convergence on ephemeral environments; inner↔outer feedback seam; release-readiness record at the G5 prod-ship gate. Hard-depends on `core`. |
 | [`governance-extras`](docs/guides/governance-extras/) | repo | **Keep a written trail of decisions.** RFC/ADR ceremony for teams and long-lived repos — `new-rfc`, `new-adr`, `update-conventions`, plus the `docs/rfc/` and `docs/adr/` shapes. |
 | [`user-guide-diataxis`](docs/guides/user-guide-diataxis/) | repo | **Stand up a docs site.** Diátaxis skeleton — `docs/guides/{tutorials,how-to,reference,explanation}` plus `new-guide`. |
 | [`monorepo-extras`](docs/guides/monorepo-extras/) | repo | **Scaffold packages in a monorepo.** `new-package` and a `packages/_example/` template. |
@@ -109,10 +145,9 @@ The flagship `core` pack brings loop engineering to supercharge development in y
 | [`atlassian`](docs/guides/atlassian/) | user / repo | **Work Jira and Confluence from the agent.** `jira`, `jira-align`, `confluence-crawler`, `confluence-publisher` (credentialed), plus `flow-metrics`, `ai-adoption-report`, `jira-defect-flow`. |
 | [`figma`](docs/guides/figma/) | user / repo | **Read and render Figma designs.** Figma REST primitive (credentialed) — files/nodes/comments/variables, frame renders, FigJam → Mermaid. |
 | [`architect`](docs/guides/architect/) | user / repo | **Design a system and pressure-test it.** `architect-design`, `architect-diagram`, `architect-review`, plus a read-only, forked-context `design-reviewer` subagent. |
-| [`product-engineering`](docs/guides/product-engineering/) | user / repo | **Shape product intent into shippable specs.** `frame-intent`, `de-risk-intent`, `decompose-intent` over a recursive, level-tagged `intent`; `voice-and-microcopy` for UI copy; `align-value-stream` for the business-unit cross-component layer. |
 | [`experience`](docs/guides/experience/) | user / repo | **Carry the whole design thread — journey to realization.** `map-customer-journey`, `map-screen-flow`, `blueprint-service`, `map-internal-process`, `aesthetic-direction`, `design-system-foundations`, `layout-and-information-architecture`, `interaction-design`, `design-critique`, a shared `quality-floor` checklist, and a forked-context `experience-reviewer` agent. Points to WCAG / W3C Design Tokens / Apple HIG / Material 3 / APQC / BPMN, never a stack. |
 
-Swap `core` for any pack name in the command above. Repo-scope packs build on `core`; user-scope packs follow you across every project.
+Swap `core` for any pack name in the install command above. Repo-scope packs build on `core`; user-scope packs follow you across every project.
 
 **Or stack several kits in one command.** A profile is a blessed combination of packs: `full-ceremony` adds the repo governance packs to `core`; `solution-architect` lands the `architect` + `research` + `contracts` toolkit; `inception` lands `research` + `product-engineering` + `architect` for taking an idea from zero to a buildable repo. `agentbundle list-profiles <catalogue>` shows them all — see the [install-a-profile how-to](docs/guides/_shared/how-to/install-a-profile.md).
 
@@ -123,6 +158,7 @@ Nothing here is a black box. Your skills, subagents, and hooks are files you own
 - **Harness-agnostic.** One adapter pipeline projects the same primitives into Claude Code, Codex, Copilot, Cursor, Gemini, and Kiro layouts.
 - **Inspectable and forkable.** The mechanics are prose you can read and `git diff`. Outgrow a default? Edit the file instead of filing a feature request.
 - **Composable.** Packs layer cleanly, and your edits are never silently overwritten — colliding files land as `*.upstream` companions to merge, not clobber.
+- **Curated by discipline.** Every pack is shaped through practitioner research and an RFC-and-ADR governance process — not random defaults, but the best available practices for each job role encoded as runnable skills.
 
 The two packages underneath are standalone, pip-installable, and useful well beyond this repo:
 
@@ -154,10 +190,11 @@ One rule governs every change: **edit the upstream, never the projection.** Chan
 
 ## Going deeper
 
-Full documentation lives in **[`docs/guides/`](docs/guides/)**, organized by pack with tutorials, how-tos, reference, and explanation ([Diátaxis](https://diataxis.fr/)). The table jumps straight to the cross-cutting topics.
+Full documentation lives in **[`docs/guides/`](docs/guides/)**, organized by goal and role with tutorials, how-tos, reference, and explanation. The table below jumps straight to the cross-cutting topics.
 
 | Topic | Link |
 | --- | --- |
+| The three loops as a system — company OS, the inner/outer split, peer supervisors | [the three loops](docs/guides/_shared/explanation/the-three-loops.md) |
 | All four install routes (CLI, APM, Claude plugins, local clone) | [install routes](docs/guides/_shared/how-to/install-agentbundle-from-clone.md) |
 | What each agent tool supports — skill / subagent / command / hook — and where it degrades | [adapter support matrix](docs/guides/_shared/reference/adapter-support.md) |
 | Your edits are never silently overwritten — the file-safety contract | [file-safety contract](docs/guides/_shared/explanation/file-safety-contract.md) |

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,36 +1,82 @@
 # Guides
 
-The user-facing documentation for the catalogue, organized **by pack**. You install `core`, maybe `research`, maybe `atlassian` — each pack has its own guide home with the four [Diátaxis](https://diataxis.fr/) kinds inside it. Find your pack, start at its home page.
+Documentation for the agent-ready-repo catalogue, organized to get you to the right place fast — by what you're trying to do, by your role, or by pack.
 
-> The adopter-facing `user-guide-diataxis` seed scaffold stays organized by quadrant, not by pack — see [ADR-0020](../adr/0020-per-pack-diataxis-hierarchy-for-guides.md).
+## What do you want to do?
 
-## Find your pack
+**Ship a new feature or fix a bug →** [Install `core`](../guides/core/) and run `work-loop`. The build loop handles planning, gating, and adversarial review.
 
-| Pack | Start here | What it ships |
+**Turn a product idea into something buildable →** [Install `product-engineering`](product-engineering/) and run `discovery-loop`. Goes from a raw idea to a ratified decision brief in one supervised session.
+
+**Validate and ship to production →** [Install `release-engineering`](release-engineering/) and run `release-lead`. Deploys to an ephemeral environment, runs e2e, feeds back to the build loop, and surfaces a release-readiness record at the prod-ship gate.
+
+**Understand the full picture →** [The three loops as a system](../guides/_shared/explanation/the-three-loops.md) — how discovery, build, and release compose into a complete operating model.
+
+---
+
+## By role
+
+| I work as… | Start here | Also useful |
 | --- | --- | --- |
-| [`core`](core/) | **The flagship.** | The loop — `work-loop`, `new-spec`, `bug-fix`, `adapt-to-project`, the reviewers, the hooks. Install this even if you install nothing else. |
-| [`architect`](architect/) | [home](architect/) | Solution architecture — `architect-design`, `architect-diagram`, `architect-review`, and the `reference.md` golden path. |
-| [`research`](research/) | [home](research/) | Evidence-grounded research — `research` with selectable depth, plus the pipeline skills (`source-map`, `compare-hypotheses`, `devils-advocate`, …). |
-| [`product-engineering`](product-engineering/) | [home](product-engineering/) | Shape product intent into shippable specs — the recursive `intent` tree (`frame`, `de-risk`, `decompose`, `align-value-stream`). |
-| [`credential-brokers`](credential-brokers/) | [home](credential-brokers/) | The broker behind credentialed skills — secrets resolve in-process and never reach the model. |
-| [`atlassian`](atlassian/) | [home](atlassian/) | Jira, Confluence, and flow metrics over the REST APIs — `jira`, `confluence-crawler`/`-publisher`, `flow-metrics`, `jira-defect-flow`, `jira-brief-intake`, and more. |
-| [`contracts`](contracts/) | [home](contracts/) | Contract-first design — `api-contract` (OpenAPI 3.1) and `event-contract` (AsyncAPI), with a pluggable house standard. |
-| [`converters`](converters/) | [home](converters/) | Get documents into Markdown and back out — `file-to-markdown`, `markdown-to-html`, `mermaid-renderer`, `msg-to-markdown`. |
+| **Engineer** | [`core`](core/) — the build loop | [`architect`](architect/) for design; [`contracts`](contracts/) for API authoring; [`converters`](converters/) for document handling |
+| **Product manager / strategist** | [`product-engineering`](product-engineering/) — intent shaping and the discovery loop | [`research`](research/) for evidence; [`governance-extras`](governance-extras/) for decision trails |
+| **Designer / UX** | [`experience`](experience/) — journey mapping, screen flows, service blueprints, design critique | [`figma`](figma/) for Figma reads; [`product-engineering`](product-engineering/) for voice and microcopy |
+| **Architect** | [`architect`](architect/) — system design and pressure-testing | [`contracts`](contracts/) for API contracts; [`research`](research/) for prior art |
+| **SRE / DevOps** | [`release-engineering`](release-engineering/) — the release loop, ephemeral deploy, e2e convergence | [`core`](core/) (required dependency) |
+| **Researcher / analyst** | [`research`](research/) — evidence-grounded research with selectable depth | [`converters`](converters/) for document ingestion |
+| **Everyone, once** | [`core`](core/) — **install this even if you install nothing else** | — |
+
+---
+
+## The three loops
+
+This repository covers the full software delivery lifecycle through three peer supervisors:
+
+| Loop | Pack | Agent | Scope | What it does |
+| --- | --- | --- | --- | --- |
+| Discovery | [`product-engineering`](product-engineering/) | `discovery-lead` | user | Raw idea → build-ready decision brief via multi-lens diverge/converge |
+| Build | [`core`](core/) | `work-loop` supervisor | repo | Spec → shipped code with hard gates and cold-eyed review |
+| Release | [`release-engineering`](release-engineering/) | `release-lead` | repo | Built code → production via ephemeral e2e convergence and G5 prod-ship gate |
+
+Each loop is autonomous where the work is reversible, and surfaces to a human where it isn't. The G3 handoff moves a decision brief from discovery into the build loop; the G4 handoff moves a built artifact into the release loop; G5 is the human prod-ship consent gate.
+
+→ [The three loops as a system](_shared/explanation/the-three-loops.md)
+
+---
+
+## All packs
+
+| Pack | Home | What it ships |
+| --- | --- | --- |
+| [`core`](core/) | **The flagship.** | The build loop — `work-loop`, `new-spec`, `bug-fix`, `adapt-to-project`, the four reviewer/executor subagents, `pre-pr` + `session-start` hooks, governance seeds. Install this even if you install nothing else. |
+| [`product-engineering`](product-engineering/) | [home](product-engineering/) | The discovery loop and intent shaping — `discovery-loop`, `frame-intent`, `de-risk-intent`, `decompose-intent`, `voice-and-microcopy`, `align-value-stream`. |
+| [`release-engineering`](release-engineering/) | [home](release-engineering/) | The release loop — `release-loop`, `release-lead`; autonomous e2e convergence on ephemeral envs; inner↔outer feedback seam; release-readiness record at G5. |
+| [`architect`](architect/) | [home](architect/) | Solution architecture — `architect-design`, `architect-diagram`, `architect-review`, and the read-only `design-reviewer` subagent. |
+| [`research`](research/) | [home](research/) | Evidence-grounded research — `research` with selectable depth, plus `source-map`, `compare-hypotheses`, `devils-advocate`, and retrieval subagents. |
+| [`experience`](experience/) | [home](experience/) | The full design thread — journey mapping, screen flows, service blueprints, aesthetic direction, design systems, design critique, and the `experience-reviewer` subagent. |
+| [`credential-brokers`](credential-brokers/) | [home](credential-brokers/) | The broker behind credentialed skills — secrets resolve in-process, never reaching the model. |
+| [`atlassian`](atlassian/) | [home](atlassian/) | Jira, Confluence, and flow metrics — `jira`, `confluence-crawler`/`-publisher`, `flow-metrics`, `jira-defect-flow`, and more. |
+| [`contracts`](contracts/) | [home](contracts/) | Contract-first API design — `api-contract` (OpenAPI 3.1) with a pluggable house standard. |
+| [`converters`](converters/) | [home](converters/) | Documents in and out of Markdown — `file-to-markdown`, `markdown-to-docx`/`-pptx`/`-xlsx`, `mermaid-renderer`, `msg-to-markdown`. |
 | [`figma`](figma/) | [home](figma/) | The Figma REST primitive — read files, nodes, and comments; render frames; turn FigJam into Mermaid. |
 | [`governance-extras`](governance-extras/) | [home](governance-extras/) | A written trail for decisions — `new-rfc`, `new-adr`, `update-conventions`. |
-| [`monorepo-extras`](monorepo-extras/) | [home](monorepo-extras/) | Monorepo scaffolding — `new-package` and a package template that ships its own conventions. |
-| [`user-guide-diataxis`](user-guide-diataxis/) | [home](user-guide-diataxis/) | The docs skeleton you're reading right now — Diátaxis quadrants plus `new-guide`. |
+| [`monorepo-extras`](monorepo-extras/) | [home](monorepo-extras/) | Monorepo scaffolding — `new-package` and a package template. |
+| [`user-guide-diataxis`](user-guide-diataxis/) | [home](user-guide-diataxis/) | The docs skeleton — Diátaxis quadrants plus `new-guide`. |
 
-## Shared
+---
 
-Some guides are about the catalogue itself — installing it, upgrading it, seeing what each agent tool supports — rather than any single pack. They live in [`_shared/`](_shared/):
+## Shared guides
+
+Cross-cutting topics — about the catalogue itself, not any single pack — live in [`_shared/`](_shared/):
 
 - **Install & upgrade** — [from a clone](_shared/how-to/install-agentbundle-from-clone.md), into [Codex](_shared/how-to/install-user-scope-pack-into-codex.md) or [Kiro](_shared/how-to/install-user-scope-pack-into-kiro.md), [preview first with `--dry-run`](_shared/how-to/preview-install-or-upgrade.md), [upgrade an installed pack](_shared/how-to/upgrade-packs.md).
 - **Reference** — the [`agentbundle` CLI](_shared/reference/agentbundle.md) and the [adapter support matrix](_shared/reference/adapter-support.md).
-- **Understand** — [install routes](_shared/explanation/install-routes.md), [the pack catalogue](_shared/explanation/pack-catalogue.md), [the file-safety contract](_shared/explanation/file-safety-contract.md) (your edits are never silently overwritten), and [shaping a new engagement](_shared/explanation/shaping-a-new-engagement.md) (how a product vision, a product strategy, and an architecture concept co-shape each other at the start).
+- **Understand** — [the three loops](_shared/explanation/the-three-loops.md), [install routes](_shared/explanation/install-routes.md), [the pack catalogue](_shared/explanation/pack-catalogue.md), [the file-safety contract](_shared/explanation/file-safety-contract.md), and [shaping a new engagement](_shared/explanation/shaping-a-new-engagement.md).
 - **Contribute** — [how to author a skill](_shared/how-to/author-a-skill.md) for any pack.
 
-## The four kinds
+---
+
+## For guide authors — the four Diátaxis kinds
 
 Within every pack (and within `_shared/`), guides are sorted into the four Diátaxis kinds. Each piece of content belongs in **exactly one** — mixing kinds is the most common cause of docs that frustrate everyone.
 

--- a/docs/guides/_shared/README.md
+++ b/docs/guides/_shared/README.md
@@ -18,6 +18,7 @@ Guides about the catalogue itself — installing it, upgrading it, seeing what e
 
 ## Explanation
 
+- [The three loops as a system](explanation/the-three-loops.md) — how discovery, build, and release compose into a complete operating model, and why each loop is a peer supervisor.
 - [Install routes](explanation/install-routes.md) — the four ways pack content reaches a repo, and where each lands.
 - [The pack catalogue](explanation/pack-catalogue.md) — what a pack is, how the catalogue is composed, and how you build your own.
 - [The file-safety contract](explanation/file-safety-contract.md) — why your edits are never silently overwritten.

--- a/docs/guides/_shared/explanation/the-three-loops.md
+++ b/docs/guides/_shared/explanation/the-three-loops.md
@@ -1,0 +1,124 @@
+# The three loops — the company operating model
+
+Software delivery has always had three distinct jobs: shaping what to build, building it, and getting it to production. Those three jobs have different failure modes, different decision authorities, and different reversibility profiles. A single loop can't govern all three well — and an agent that tries will either move too slowly (treating every change as a prod ship) or too recklessly (treating a prod ship as just another change).
+
+This catalogue makes all three loops concrete.
+
+## The handoff chain
+
+```
+product-engineering              core                    release-engineering
+───────────────────              ────                    ───────────────────
+discovery-lead                   work-loop supervisor    release-lead
+Raw idea → Decision brief  ─G3─▶ Spec → Shipped code ─G4─▶ Built → Production
+   (user scope)                  (repo scope)              (repo scope)
+```
+
+Each loop is a **peer supervisor** — not a mode of another, not a sub-phase. Each has its own agent, its own skill doctrine, and its own consent gates. The handoffs between them (G3: discovery → build; G4: build → release; G5: release → prod) are explicit gates where a human ratifies the decision before the next loop begins.
+
+## Why three loops, not one
+
+**Different reversibility profiles.** Exploring product shapes is cheap and reversible — you can explore five candidates in parallel and discard four. Deploying to production is expensive and often irreversible. Treating them with the same autonomy level is wrong in both directions: too much caution on exploration, too little on shipping.
+
+**Different decision authorities.** Whether a product shape is worth building is a business decision. Whether code compiles is a mechanical gate. Whether a deployed system meets its SLOs is an operational judgment. These decisions belong to different people and different loops.
+
+**Different failure modes.** The discovery loop fails when it converges on the wrong product shape. The build loop fails when it ships code that doesn't work. The release loop fails when it promotes something that breaks in production. Each failure mode requires a different set of checks, reviewers, and escalation paths.
+
+## The discovery loop
+
+**Pack:** `product-engineering` | **Agent:** `discovery-lead` | **Scope:** user
+
+The upstream loop. Takes a raw product idea and walks it through a structured diverge/converge cycle before any code is written. The output is a **decision brief** — a ratified statement of what to build, what not to build, what the riskiest assumptions are, and how to validate them.
+
+**Key mechanics:**
+
+- **Diverge before converging.** Five candidate product shapes are explored in parallel against the customer segment and job-to-be-done. The goal is to surface the best shape by comparison, not to optimize the first idea.
+- **Multi-lens convergence.** Product, UX, architecture, and safety lenses run simultaneously against a shared blackboard — results posted to slots, never relayed through chat. Each lens is a distinct specialist reviewer, not a re-run of the same one.
+- **Recursion is data.** Sub-problems discovered during discovery become child nodes in an intent tree, not separate projects. The same loop governs every level of scope.
+- **Hash-chained decision log.** Every human verdict is recorded append-only and hash-chained — the agent cannot forge or retroactively alter a ratified decision.
+
+**Human gates:**
+- **G0** — Ratify the value seed: the problem statement, the customer segment, and the existence bet.
+- **G1.5** — Ratify the MVP boundary: which features are in scope for the initial bet.
+- **G2** — Ratify the decision brief: the full convergence output including riskiest assumptions and validation hooks.
+- **G3** — Ratify the handoff to `work-loop`: feature-level breakdown ready to spec.
+
+→ [Discovery loop guide](../../product-engineering/) · [Walk a discovery end-to-end](../../product-engineering/tutorials/walk-a-discovery-end-to-end.md)
+
+## The build loop
+
+**Pack:** `core` | **Agent:** `work-loop` supervisor | **Scope:** repo
+
+The inner loop. Every change — feature, bug fix, refactor, migration, dependency upgrade — goes through: plan, execute, gate, review, decide. The loop replaces "feel done" with objective criteria: gates the agent can't bypass and reviewers that read every diff cold.
+
+**Key mechanics:**
+
+- **Risk-scaled modes.** Light mode for low-risk work (lean inline spec, single adversarial pass). Full mode when any risk trigger fires — unfamiliar territory, new dependency, compliance surface, multi-person work, destructive operation. The mode is chosen by the work's risk profile, not by file count.
+- **Hard gates.** Lint, typecheck, and tests run as mechanical gates. No path through the loop lets the agent claim success on a red gate.
+- **Cold-eyed review.** Three specialist reviewers — adversarial (spec/plan/impl drift), security (OWASP 2025 + ASVS + STRIDE), quality (testability, observability, reliability) — each read every diff in a fresh context with no sunk cost in the design. The loop iterates on findings until reviewers say `Clean — ready to commit.`
+- **Progressive disclosure.** The security checklist pulls only the depth relevant to the boundaries a change crosses — current without bloating the prompt. Depth is added on demand per security boundary type (auth, secrets, user input, deserialization, file I/O, LLM code).
+- **Capture what was learned.** Gaps in project conventions discovered during a run land as proposed `CONVENTIONS.md` edits — mistakes become the project's memory instead of evaporating between sessions.
+
+**No human gates in the loop itself** — only at escalation exits: Blockers surface to the human; the agent routes Concerns and Nits by whether they're mechanical.
+
+→ [Core pack guide](../../core/) · [The `core` pack as a system](../../core/explanation/core-pack.md)
+
+## The release loop
+
+**Pack:** `release-engineering` | **Agent:** `release-lead` | **Scope:** repo
+
+The outer loop. Takes the locally built, deploy-ready artifact and validates it **deployed** — not as it runs on the developer's machine, but as it runs in an environment that resembles production.
+
+**Key mechanics:**
+
+- **Ephemeral environments only.** The outer loop never touches prod. It deploys to purpose-built ephemeral environments: no real user data, cannot reach production, isolated from each other, teardown on completion. The isolation guarantee is what makes unattended operation safe.
+- **Minimum-regret autonomy carve.** Reversible operations (deploy to ephemeral, run e2e, observe telemetry, redeploy, teardown) run autonomously. Irreversible operations (first real users, data migrations, spend over threshold, the prod ship) always surface to a human.
+- **Inner↔outer feedback seam.** When the outer loop surfaces a deployed failure, it feeds it back to `work-loop` as a build task — not a raw error message to the human. The inner loop fixes it; the outer loop redeploys. No human relay needed for build-level fixes.
+- **Convergence by policy.** The loop iterates until: canary passes SLOs, changed-surface e2e coverage is met, flake rate is below threshold, and the error budget is not exhausted. When convergence is reached, it stops and surfaces a release-readiness record — not a bare go/no-go.
+- **Release-readiness record.** The convergence output is a structured assessment: convergence result, operational verdict, security verdict, and cost/budget status. The human ratifies this at G5 — the only gate between convergence and the prod ship.
+
+**Human gates:**
+- **G5** — Ratify the prod ship. The only autonomous-to-irreversible transition. Never bypassed, never auto-advanced.
+
+→ [Release loop guide](../../release-engineering/) · [The release loop explained](../../release-engineering/explanation/the-release-loop.md)
+
+## The scope boundary
+
+The scope model follows where the work happens:
+
+- **Discovery runs at user scope.** Product shaping happens in document workspaces — Notion, Figma, presentation decks — not in a repo. `discovery-lead` ships its own specialist reviewer agents because it can't assume a `core` repo-scope install is present.
+- **Build runs at repo scope.** Code lives in repos. `core` installs into the repo where the code is, and its reviewer agents are available to anything installed at repo scope in the same repo.
+- **Release runs at repo scope.** The release loop runs in the same repo as the build loop, downstream of it. It hard-depends on `core` and reuses its reviewers — this is architecturally sound only because both are at repo scope in the same repo.
+
+This means the G3 handoff — where a decision brief from discovery becomes a feature spec in a repo — is also a scope boundary: from user scope (documents, ideas) to repo scope (code, gates).
+
+## The autonomy model
+
+Each loop enforces autonomy proportional to the reversibility of what it's doing:
+
+| Tier | Operations | Autonomy |
+| --- | --- | --- |
+| Fully autonomous | Exploring product shapes; writing and running tests; deploying to ephemeral; iterating on build failures | Runs unattended |
+| Surfaces to human | Blockers in the build loop; convergence reached in the release loop | Pauses and presents the situation |
+| Requires human consent | G0, G1.5, G2, G3 (discovery); G5 (release) — all irreversible exits | Never proceeds without explicit ratification |
+
+The G5 prod-ship gate is always in the "requires human consent" tier. There is no configuration, mode, or flag that removes it.
+
+## Installing the operating model
+
+Install all three loops in dependency order:
+
+```bash
+# 1. The build loop — always first; the other loops depend on it
+agentbundle install --pack core
+
+# 2. The discovery loop — at user scope (follows you across all repos)
+agentbundle install --pack product-engineering --scope user
+
+# 3. The release loop — at repo scope (into the same repo as core)
+agentbundle install --pack release-engineering
+```
+
+Or install the `full-ceremony` profile to get `core` plus governance in one command, and add the others as your team adopts them.
+
+Each loop is independent — install only what your team uses. Most teams start with `core` and add `product-engineering` when the product-shaping conversations start happening in Notion docs instead of GitHub issues.

--- a/docs/guides/release-engineering/README.md
+++ b/docs/guides/release-engineering/README.md
@@ -1,11 +1,44 @@
-# release-engineering guides
+# `release-engineering` — guides
 
-Guides for the `release-engineering` pack — the SRE/ops **outer loop** (deployed
-end-to-end validation above `work-loop`'s inner build loop).
+`release-engineering` is the SRE/ops outer loop: deployed end-to-end validation above `work-loop`'s inner build loop. Where `core` validates that code works locally — it compiles, tests pass, the diff is clean — `release-engineering` validates that the **deployed whole** works: the integrated artifact, running in a real environment, observed through real telemetry.
 
-Full guides are not written yet. Until they land, the canonical references are:
+The pack ships two primitives: `release-lead` (the supervisor agent) and `release-loop` (the skill doctrine). Together they cover the full arc from "deploy-ready artifact" to "prod ship ratified by a human" — autonomously on ephemeral environments, and with an explicit consent gate at the only irreversible exit.
 
-- **The pack:** [`packs/release-engineering/README.md`](../../../packs/release-engineering/README.md) — what the pack ships and how it installs.
-- **The design:** [RFC-0049](../../rfc/0049-the-release-loop-and-company-os.md) — the release loop, the minimum-regret deploy carve, and the company-OS composition.
-- **The contract:** [`docs/specs/release-loop/`](../../specs/release-loop/spec.md) — what "done" means for the loop.
-- **The decision:** [ADR-0044](../../adr/0044-inner-outer-loop-split-and-minimum-regret-deploy-carve.md) — the inner/outer split + the minimum-regret deploy carve.
+**Before you start:** `release-engineering` hard-depends on `core`. Install `core` first.
+
+```bash
+agentbundle install --pack core           # required first
+agentbundle install --pack release-engineering
+```
+
+New here? Read [The release loop explained](explanation/the-release-loop.md) for the *why* — the inner/outer split and the minimum-regret autonomy carve. Then run your first release with [Your first release](tutorials/your-first-release.md).
+
+---
+
+## Tutorials
+
+Learning-oriented walkthroughs.
+
+- [Your first release](tutorials/your-first-release.md) — from a deploy-ready build to a ratified prod ship, end to end.
+
+## How-to
+
+Task-oriented recipes for when you already know what you're doing.
+
+- [Run a release](how-to/run-a-release.md) — trigger `release-lead`, monitor convergence rounds, review the release-readiness record, and ratify at G5.
+
+## Reference
+
+Information-oriented — dry, complete, look-it-up-when-you-need-it.
+
+- [The release-readiness record](reference/release-readiness-record.md) — the convergence output format: every field, what each verdict means, and how to read the record at G5.
+
+## Explanation
+
+Understanding-oriented — the *why* behind the design.
+
+- [The release loop explained](explanation/the-release-loop.md) — the inner/outer loop split, the minimum-regret autonomy carve, the ephemeral environment model, the convergence policy, and the feedback seam between the outer and inner loops.
+
+---
+
+Cross-cutting guides — installing the catalogue, upgrading packs, the adapter support matrix — live in [`../_shared/`](../_shared/). For the full picture of how the release loop composes with discovery and build, see [the three loops as a system](../_shared/explanation/the-three-loops.md).

--- a/docs/guides/release-engineering/explanation/the-release-loop.md
+++ b/docs/guides/release-engineering/explanation/the-release-loop.md
@@ -1,0 +1,104 @@
+# The release loop explained
+
+## The problem it solves
+
+When `work-loop` finishes, you have code that compiles, passes tests, and survives adversarial review. What you don't have is proof that it works **deployed** — that the artifact running in an integrated environment behaves the way the tests assumed, that the latency holds under real infrastructure, that the database migration runs cleanly, that the config values resolve correctly against a real secrets store.
+
+The gap between "tests pass locally" and "works in production" has historically been filled by humans: developers watching deploy logs, SREs triaging production errors, on-call engineers running rollbacks at 2 AM. The release loop closes that gap autonomously — on reversible infrastructure — before any human touches a prod switch.
+
+The key insight is **reversibility**. Deploying to an ephemeral environment is reversible: no real data, no real users, tear it down when you're done. Deploying to production is not: real users may see broken behavior before a rollback can be deployed. The release loop runs autonomously on what's reversible and surfaces to a human on what isn't. This is the **minimum-regret carve**.
+
+## The inner/outer loop split
+
+`core`'s `work-loop` is the **inner loop**: local build + verification. `release-engineering`'s `release-loop` is the **outer loop**: deployed validation.
+
+The two loops are peers, not parent/child. The inner loop doesn't call the outer loop. The outer loop doesn't control the inner loop. They communicate through a **feedback seam**: when the outer loop surfaces a deployed failure, it creates a build task that the inner loop picks up and fixes. The outer loop then redeploys. No human relay needed for build-level failures.
+
+```
+Inner loop (core)                    Outer loop (release-engineering)
+─────────────────                    ────────────────────────────────
+spec → code → gates → review          deploy → e2e → observe → converge
+         ↑                                     │
+         └─── build task ◄──── deployed failure┘
+                                 (feedback seam, no human relay)
+```
+
+The inner loop exits by pushing a deploy-ready artifact. The outer loop takes that artifact and validates it end-to-end. If the outer loop finds a bug that's clearly a build issue, it feeds it back to the inner loop. If it finds a configuration or infrastructure issue, it surfaces to the human with a specific question.
+
+## The ephemeral environment model
+
+The outer loop only operates on **ephemeral environments** — purpose-built, short-lived environments that:
+
+- Contain no real user data
+- Cannot reach production systems or production databases
+- Are isolated from each other (concurrent releases don't interfere)
+- Are torn down automatically on completion, whether successful or not
+
+Isolation is not a suggestion — it's the architectural guarantee that makes unattended operation safe. An agent that can reach production during the release loop is an agent that can cause production incidents without a human in the loop.
+
+What counts as an ephemeral environment depends on your stack. It might be:
+- A fresh Kubernetes namespace spun up by your deploy tooling
+- A preview environment on Vercel, Railway, or Render
+- An isolated Docker Compose stack on a test runner
+- A Terraform-provisioned AWS environment in a sandbox account
+
+The release loop is agnostic to the platform. It consumes whatever deploy, smoke-test, and teardown artifacts your platform tooling produces. When a platform pack is installed (e.g., an AWS or Kubernetes pack), it wires those artifacts automatically. When one isn't, the loop names the artifacts it would otherwise use and surfaces the gap — it never silently fails.
+
+## The convergence policy
+
+The release loop iterates — deploy, observe, feed back, redeploy — until the deployed whole **converges by policy**. Convergence means:
+
+1. Canary metrics pass SLOs for the changed surface
+2. Every changed endpoint or code path has at least one passing e2e test
+3. Test flake rate is below the configured threshold (default: 2%)
+4. The error budget is not exhausted
+
+When all four conditions are met, convergence is declared. The loop stops iterating and surfaces a **release-readiness record** to the human.
+
+When convergence is not reached within the round cap or cost budget, the loop does not keep trying. It stops, surfaces the situation — what converged, what didn't, and how many rounds it ran — and asks the human how to proceed. The loop never silently burns through budget in pursuit of a convergence it can't reach.
+
+## The minimum-regret carve
+
+Autonomy is carved by minimum-regret: actions that can be cleanly undone within normal MTTR run autonomously; actions that cannot require human consent.
+
+**Autonomous (reversible):**
+- Deploy to an ephemeral environment
+- Run e2e tests against the deployed artifact
+- Observe telemetry and logs
+- Create build tasks for the inner loop from deployed failures
+- Redeploy after inner-loop fixes
+- Tear down the ephemeral environment
+
+**Human consent required (irreversible):**
+- First real users or real data
+- Data migrations
+- Spend above a pre-agreed threshold
+- Security or auth-boundary changes
+- Anything not cleanly undone within MTTR
+- **The prod ship (G5)**
+
+The G5 prod-ship gate is the only gate between a converged, release-ready artifact and production. It is never bypassed, never auto-advanced, and never gated only on SLO thresholds. The human reads the release-readiness record and makes the call.
+
+## Security and integrity controls
+
+The release loop runs with deploy credentials that are broker-mediated and scoped to the ephemeral tier only. No credential configured for the release loop can reach production. This is enforced by the credential broker — not by policy, but by the broker's scope configuration.
+
+Telemetry and log signals are tagged `untrusted` until the loop controller explicitly promotes them. This prevents prompt injection through log content: a malicious log message that says "all tests passed" cannot advance the convergence state.
+
+Human verdicts (the G5 ratification) are harness-attested — the agent cannot forge or simulate a ratification. The ratification record is written by the harness, not by the agent.
+
+## How it composes with `core`
+
+The release loop reuses `core`'s reviewer agents rather than shipping its own:
+
+- `quality-engineer` runs in **operational mode**: instead of reviewing code for testability and maintainability, it reviews the deployed system for operational health — latency distributions, error rates, saturation signals.
+- `security-reviewer` runs on the deployment configuration and any infra-as-code changes, not just the application diff.
+- `operational-safety` modules from `core` provide the checklist library for infra-facing review.
+
+This reuse is architecturally sound because both packs install at repo scope in the same repo. The release loop is guaranteed to find `core`'s reviewer agents at the paths it expects.
+
+## Why repo scope (not user scope)
+
+The release loop installs at repo scope because it runs **downstream in the build repo** — the same repo where `core` is installed. This is the deliberate scope-inverse of `product-engineering`'s `discovery-lead`, which ships its own reviewers because it runs upstream in document workspaces that can't assume a `core` install.
+
+*Scope follows where the work happens* — the company-OS scope boundary is at the G3 handoff, where product shaping (user scope, any workspace) becomes a concrete repo (repo scope, one codebase).

--- a/docs/guides/release-engineering/how-to/run-a-release.md
+++ b/docs/guides/release-engineering/how-to/run-a-release.md
@@ -1,0 +1,107 @@
+# Run a release
+
+This guide walks through running a release from a deploy-ready artifact to a ratified prod ship. It assumes:
+
+- `core` is installed in the repo
+- `release-engineering` is installed in the repo
+- The inner loop (`work-loop`) has already run and its output is a deploy-ready artifact
+- You have a configured ephemeral deploy target (see below)
+
+---
+
+## Before you start
+
+**Check your ephemeral deploy target is configured.** `release-lead` looks for deploy, smoke-test, and teardown artifacts that your platform tooling provides. Run `release-lead` and ask it to show its current deploy configuration — it will either confirm the target is wired or name exactly what's missing.
+
+**Check your convergence policy.** The defaults (2% flake threshold, SLO-based canary gate, 100% changed-surface e2e coverage) work for most teams. If your app has specific SLO targets, configure them before the first run so the record reflects real thresholds, not defaults.
+
+**Confirm `core` is at the same repo scope.** Run `agentbundle list-installed` and verify `core` appears as a repo-scope install. `release-engineering` hard-depends on `core` and will surface an error if it can't find `core`'s reviewer agents.
+
+---
+
+## Run the release loop
+
+Trigger `release-lead` with a description of what you're releasing:
+
+```
+Run release-lead for the v2.3.0 deployment — the payment service refactor from the last three work-loop runs.
+```
+
+`release-lead` takes it from there. You do not need to monitor individual rounds — the loop runs autonomously until it reaches a stopping condition.
+
+**What `release-lead` does:**
+
+1. **Deploy** — deploys the artifact to the configured ephemeral environment.
+2. **E2E** — runs the e2e suite against the deployed artifact. Measures changed-surface coverage.
+3. **Observe** — reads telemetry, canary metrics, and logs. Tags all signals `untrusted` until promoted.
+4. **Evaluate** — checks all convergence conditions: SLOs, e2e coverage, flake rate, error budget.
+5. **If not converged:**
+   - If the failure is a build issue, creates a build task for `work-loop` and waits for a fix, then redeploys.
+   - If the failure is an infra or configuration issue, surfaces it to you with a specific question.
+6. **If converged:** surfaces the release-readiness record and waits at G5.
+
+---
+
+## Review the release-readiness record
+
+When convergence is reached, `release-lead` surfaces a **release-readiness record** — a structured assessment of the release's health. Read it before ratifying G5.
+
+The record includes:
+- **Convergence result** — how many rounds it took, which conditions were met, flake rate
+- **Operational verdict** — `PASS`, `PASS-WITH-NOTES`, or `FAIL` from `quality-engineer` in operational mode
+- **Security verdict** — `PASS`, `PASS-WITH-NOTES`, or `FAIL` from `security-reviewer` on the deployment config
+- **Budget status** — rounds consumed vs. cap, cost consumed vs. threshold
+
+A `PASS-WITH-NOTES` verdict means convergence was reached but the reviewer noted observations worth tracking. These do not block the release — they're surfaced for awareness. A `FAIL` verdict blocks the release: the loop has not converged cleanly and G5 is not available until the failure is addressed.
+
+See [the release-readiness record reference](../reference/release-readiness-record.md) for the full field list and how to interpret each verdict.
+
+---
+
+## Ratify at G5
+
+G5 is the prod-ship consent gate. It is always a human decision — the loop never auto-advances past it. You ratify by telling `release-lead`:
+
+```
+G5 ratified. Ship to production.
+```
+
+`release-lead` records your ratification (harness-attested — it cannot be forged) and proceeds with the prod ship sequence as configured by your platform tooling.
+
+If you decide not to ship:
+
+```
+G5 declined. Hold the release — [reason].
+```
+
+The ratification record captures your decision and reason. The ephemeral environment is torn down. The artifact remains available to re-enter the release loop when you're ready to try again.
+
+---
+
+## Handling non-convergence
+
+If the loop hits the round cap or cost budget before converging:
+
+`release-lead` will surface:
+- The current state of each convergence condition
+- How many rounds were consumed
+- What failed in the last round
+- A recommendation for the most likely path to convergence
+
+Your options:
+- Fix the build issue and re-enter the loop
+- Adjust the convergence policy (e.g., a flake threshold that's too strict for a known-flaky test)
+- Investigate an infrastructure issue with your platform team
+- Decide not to release this version
+
+---
+
+## Configuring an ephemeral deploy target
+
+If `release-lead` surfaces a gap at startup — "I would look for a deploy artifact at X, but I don't see one" — you need to wire your platform tooling. The exact steps depend on your stack:
+
+- **Kubernetes:** configure the `release-loop.deploy-target` to point to a namespace-provisioning script and a manifest apply step.
+- **Cloud preview environments:** configure the deploy target to call your platform's preview-create API and output the preview URL for e2e targeting.
+- **Docker Compose:** configure the deploy target to run `docker compose up -d` against a compose file scoped to the test environment.
+
+When a platform pack is installed that covers your stack, wiring is automatic. Ask `release-lead` what platform packs are available for your stack, or check the catalogue.

--- a/docs/guides/release-engineering/reference/release-readiness-record.md
+++ b/docs/guides/release-engineering/reference/release-readiness-record.md
@@ -1,0 +1,112 @@
+# Release-readiness record
+
+The release-readiness record is the structured output `release-lead` surfaces at G5 — the convergence assessment a human reads before ratifying the prod ship. It is not a go/no-go; it is a structured snapshot of the release's health at the moment convergence was declared.
+
+The record is written by `release-lead` at the end of the final convergence round. It is append-only and harness-attested: the agent cannot alter it after writing, and the human ratification is recorded by the harness (not by the agent).
+
+---
+
+## Format
+
+```
+## Release-readiness record — <release-name> / <date>
+
+### Convergence
+- Rounds: <n> / <cap> cap
+- E2e: <passing>/<total> passing, <coverage>% changed-surface coverage
+- Canary: <p50> p50, <p99> p99 (<SLO status>), error rate <rate>
+- Flake rate: <rate>%
+- Error budget: <rounds consumed> rounds, <cost> of <threshold> threshold
+
+### Operational verdict — <PASS | PASS-WITH-NOTES | FAIL>
+<quality-engineer (operational mode) findings>
+
+### Security verdict — <PASS | PASS-WITH-NOTES | FAIL>
+<security-reviewer findings on deployment config and infra changes>
+
+### Budget status
+- Rounds: <consumed>/<cap>
+- Cost: ~<consumed> / <threshold>
+```
+
+---
+
+## Fields
+
+### Convergence
+
+| Field | What it means |
+| --- | --- |
+| **Rounds** | How many deploy-e2e-observe cycles ran before convergence was declared. A low round count (1–2) is typical for a healthy change. A high count (near the cap) warrants investigation even if convergence was declared. |
+| **E2e** | Number of passing / total e2e tests, plus changed-surface coverage. Changed-surface coverage is the fraction of changed endpoints or code paths that have at least one passing e2e test. 100% is required for convergence. |
+| **Canary** | Latency distribution (p50, p99) and error rate for the changed surface, against the configured SLOs. Canary passing SLOs is required for convergence. |
+| **Flake rate** | Fraction of e2e tests that ran more than once (indicating a retry was needed). Above the configured threshold (default: 2%) blocks convergence. Flake above 2% typically means either the test is genuinely flaky (fix it) or the underlying feature is non-deterministic under load (investigate before shipping). |
+| **Error budget** | Cost in rounds and dollars consumed against the configured caps. Consuming near the full budget is a signal worth noting even when convergence was reached — it may indicate underlying fragility. |
+
+### Operational verdict
+
+The `quality-engineer` subagent running in operational mode — observing the deployed system's health rather than the code's maintainability.
+
+| Verdict | Meaning |
+| --- | --- |
+| `PASS` | No operational concerns. The system is healthy by all measured signals. |
+| `PASS-WITH-NOTES` | Convergence was declared and the system is healthy, but the reviewer noted observations worth tracking. Notes do not block the release — they're surfaced for awareness. |
+| `FAIL` | A significant operational concern was found. Convergence has not cleanly converged. G5 is not available until the failure is addressed. |
+
+Common operational findings:
+- Latency regressions on the changed surface (elevated p99 compared to baseline)
+- Saturation signals (CPU or memory trending up under load)
+- Migration duration that may be problematic at production data volumes
+- Missing index on a newly queried column
+- Error rate above threshold on non-changed routes (collateral impact)
+
+### Security verdict
+
+The `security-reviewer` subagent running on the deployment configuration and any infra-as-code changes in scope for this release.
+
+| Verdict | Meaning |
+| --- | --- |
+| `PASS` | No security concerns found in the deployment config or infra changes. |
+| `PASS-WITH-NOTES` | No blocking issues, but observations worth tracking — e.g., a credential present in a deployment variable that could be moved to the broker. |
+| `FAIL` | A security concern was found that should be addressed before shipping — e.g., a credential visible in a log line, a new network path opened without a corresponding firewall rule, or a migration that backfills sensitive data in cleartext. |
+
+The security reviewer at this stage does **not** re-review the application code — that was done during the build loop's adversarial review. It focuses on the deployment: how the artifact is configured to run, what credentials it receives, and what network boundaries it crosses.
+
+### Budget status
+
+| Field | What it means |
+| --- | --- |
+| **Rounds consumed/cap** | How many deploy-e2e-observe cycles ran vs. the maximum allowed. Hitting the cap without convergence terminates the loop and surfaces a non-convergence report (not a release-readiness record). |
+| **Cost consumed/threshold** | Approximate cost of the release loop run vs. the configured spend threshold. This covers ephemeral environment runtime, not the cost of the inner loop. Exceeding the threshold during the loop triggers an escalation — the loop pauses and asks whether to continue. |
+
+---
+
+## Verdicts and G5 availability
+
+G5 (the prod-ship consent gate) is available when:
+- All convergence conditions are met
+- No `FAIL` verdict in any section
+
+G5 is **not** available when:
+- Convergence conditions are not met (even partially)
+- Any section carries a `FAIL` verdict
+
+G5 is available despite `PASS-WITH-NOTES` verdicts — notes are surfaced for awareness, not as blockers. The human deciding at G5 can read the notes and decide whether they warrant holding the release.
+
+---
+
+## The G5 ratification record
+
+When you ratify G5, the harness appends a ratification record to the release-readiness record:
+
+```
+### G5 ratification
+- Ratified by: <identity>
+- At: <timestamp>
+- Decision: Ratified / Declined
+- Reason: <optional — required if Declined>
+```
+
+This record is harness-attested: the agent cannot write or alter it. It serves as the audit trail for the prod-ship decision.
+
+If you decline at G5, the ephemeral environment is torn down. The release-readiness record and the G5 ratification record (with your decline reason) are retained. The artifact can re-enter the release loop when you're ready.

--- a/docs/guides/release-engineering/tutorials/your-first-release.md
+++ b/docs/guides/release-engineering/tutorials/your-first-release.md
@@ -1,0 +1,170 @@
+# Your first release
+
+This tutorial walks you through a complete release cycle from end to end — from a deploy-ready build to a ratified prod ship — so you understand what each stage does and what you're looking at when `release-lead` surfaces a result.
+
+We'll follow a concrete scenario: a small team just finished a work-loop run that ships a new `/payments/refund` API endpoint and a related database migration. `core` is installed, tests are green, the adversarial review says `Clean`. Now it's time to get it to production.
+
+**What you'll learn:**
+- What the release loop does at each stage
+- How to read the release-readiness record
+- What the G5 consent gate looks like in practice
+- How the inner↔outer feedback seam works when something goes wrong
+
+**Time:** reading this tutorial takes about 15 minutes. An actual release loop run takes however long your e2e suite and deploy pipeline take — from a few minutes for a small service to 30+ minutes for a large one with a thorough e2e suite.
+
+---
+
+## Prerequisites
+
+Before starting, verify:
+
+```bash
+agentbundle list-installed
+```
+
+You should see both `core` and `release-engineering` listed at repo scope. If not, install them:
+
+```bash
+agentbundle install --pack core
+agentbundle install --pack release-engineering
+```
+
+You'll also need a configured ephemeral deploy target. For this tutorial, we'll assume one is already wired. If yours isn't, see [run a release](../how-to/run-a-release.md#configuring-an-ephemeral-deploy-target).
+
+---
+
+## Step 1: Trigger the release loop
+
+With `release-lead` active, you start the release like this:
+
+```
+Run release-lead for the payment refund endpoint — includes a database migration and the new /payments/refund POST route. This came out of three work-loop runs on the `feature/payment-refund` branch, now merged to main.
+```
+
+`release-lead` will:
+1. Read the deploy configuration to understand your ephemeral target
+2. Confirm what artifact it's releasing and what convergence policy applies
+3. Ask any clarifying questions before starting (e.g., "Should the database migration run before or after the app boots?")
+
+Once you confirm, the loop starts. You don't need to watch — it runs autonomously until it reaches a stopping condition.
+
+**What to expect:** You'll see output as each round progresses, or you can check back later. The loop does not wait for you between rounds.
+
+---
+
+## Step 2: Round 1 — deploy and run e2e
+
+In the first round, `release-lead`:
+
+**Deploys the artifact** to the ephemeral environment. For our scenario, this means:
+- Running the database migration against the ephemeral database
+- Starting the application server
+- Running a smoke test to confirm the app is reachable
+
+**Runs e2e tests** against the deployed artifact. The e2e suite exercises the new `/payments/refund` endpoint plus the existing `/payments/*` routes (since the migration touched the payments schema). `release-lead` measures changed-surface coverage: every changed endpoint must have at least one passing e2e test.
+
+**Observes telemetry.** Response time distributions, error rates, and saturation signals are read and tagged as `untrusted` until promoted. This matters: a log message cannot advance the convergence state by claiming "all tests passed."
+
+At the end of round 1, `release-lead` evaluates convergence conditions. In our scenario, suppose round 1 surfaces an issue: the `/payments/refund` endpoint returns a 500 when the `reason` field is missing from the request body — the e2e test for the missing-field case is failing.
+
+---
+
+## Step 3: The feedback seam — no human relay needed
+
+This is where the inner↔outer feedback seam does its job.
+
+`release-lead` identifies that the 500 is a build issue: the endpoint isn't validating its input and the error falls through to an unhandled exception. It creates a build task and hands it to `work-loop`:
+
+> Build task: The `/payments/refund` POST endpoint returns HTTP 500 when `reason` is missing from the request body. Expected: HTTP 422 with a validation error. The e2e test at `tests/e2e/payments/test_refund.py::test_refund_missing_reason` is failing with this. Fix the missing input validation and ensure the test passes.
+
+`work-loop` picks this up, fixes the validation, runs the local gates (lint, typecheck, tests), and pushes the fix. No human relay — you didn't have to read a raw stack trace and file a bug report.
+
+`release-lead` sees the fix is ready and starts round 2.
+
+---
+
+## Step 4: Round 2 — convergence
+
+Round 2 runs the same sequence. This time:
+
+- Deploy succeeds ✓
+- E2e runs: 47/47 passing, including the missing-reason case ✓
+- Changed-surface coverage: 100% (all three changed endpoints have passing e2e tests) ✓
+- Canary metrics: p99 latency within SLO, error rate 0.0% ✓
+- Flake rate: 0% (no test ran more than once) ✓
+- Error budget: 2 rounds consumed, cap is 10 ✓
+
+All convergence conditions met. **The loop stops.** `release-lead` surfaces the release-readiness record.
+
+---
+
+## Step 5: Read the release-readiness record
+
+The release-readiness record looks like this (abbreviated):
+
+```
+## Release-readiness record — payment-refund / 2026-07-01
+
+### Convergence
+- Rounds: 2 / 10 cap
+- E2e: 47/47 passing, 100% changed-surface coverage
+- Canary: p50 42ms, p99 187ms (within SLO), error rate 0.0%
+- Flake rate: 0.0%
+- Error budget: 2 rounds consumed, 0.3% cost of $15 threshold
+
+### Operational verdict — PASS
+quality-engineer (operational mode): Response time distributions are healthy.
+The migration ran in 340ms on the ephemeral database (13k rows affected).
+No saturation signals observed. Recommend monitoring the payments table
+index size after the migration runs in production — the new refund_reason
+column was added but not indexed; high refund volume could surface this.
+[Note, not a blocker]
+
+### Security verdict — PASS
+security-reviewer: No credentials visible in the deployment config. The
+/payments/refund endpoint validates and sanitizes the reason field
+(max 500 chars, stripped). No new auth boundaries introduced.
+
+### Budget status
+- Rounds: 2/10
+- Cost: ~$0.04 / $15 threshold
+```
+
+Read through it top to bottom. Notes are surfaced for awareness — they don't block the release but they're worth tracking. In this case: watch the payments index after migration.
+
+See [the release-readiness record reference](../reference/release-readiness-record.md) for the complete field specification.
+
+---
+
+## Step 6: Ratify at G5
+
+G5 is yours. The loop has done everything it can autonomously — the prod ship is an irreversible action that belongs to a human.
+
+Read the record, confirm you're satisfied, and ratify:
+
+```
+G5 ratified. Ship to production.
+```
+
+`release-lead` records your ratification (harness-attested) and executes the prod ship sequence: apply the migration, roll out the artifact, verify the canary, update the deployment record.
+
+The ephemeral environment is torn down. The release is done.
+
+---
+
+## What you learned
+
+- The release loop runs **autonomously on reversible infrastructure** — you don't watch individual rounds.
+- The **feedback seam** routes build-level failures back to `work-loop` without you in the middle.
+- **Convergence by policy** means the loop stops when objective conditions are met, not when it feels done.
+- The **release-readiness record** is a structured artifact — notes don't block, fails do.
+- **G5 is always yours** — no flag, mode, or configuration removes it.
+
+---
+
+## Next steps
+
+- [Run a release](../how-to/run-a-release.md) — the condensed how-to for when you know what you're doing.
+- [The release loop explained](../explanation/the-release-loop.md) — the *why* behind the design.
+- [The release-readiness record](../reference/release-readiness-record.md) — the complete field reference.
+- [The three loops as a system](../../_shared/explanation/the-three-loops.md) — how the release loop composes with discovery and build.


### PR DESCRIPTION
## Summary

- **README.md**: New tagline capturing the complete SDLC scope; Company OS intro for executives; \"The Three Loops\" section replacing the single-loop \"The loop\" section; `release-engineering` added to the catalogue table (it was missing); \"curated by discipline\" angle in the ecosystem section
- **docs/guides/README.md**: New navigable spine — leads with goal-based and role-based paths before the pack table; three-loops summary with agent/scope/purpose per loop; `release-engineering` added to pack index
- **docs/guides/_shared/explanation/the-three-loops.md**: New deep-dive on the Company OS composition — why three loops, each loop's mechanics, scope model (user vs. repo), autonomy tiers, and install sequence
- **docs/guides/release-engineering/**: Full guide suite replacing the stub that previously only pointed at RFCs:
  - `README.md` — proper Diátaxis index
  - `explanation/the-release-loop.md` — inner/outer loop split, minimum-regret carve, ephemeral environment model, convergence policy, security/integrity controls, composition with `core`
  - `how-to/run-a-release.md` — trigger `release-lead`, monitor rounds, review the release-readiness record, ratify at G5, handle non-convergence, configure a deploy target
  - `tutorials/your-first-release.md` — concrete payment-refund scenario walking through every stage including the inner↔outer feedback seam in action
  - `reference/release-readiness-record.md` — complete field spec: every field, all three verdict levels, G5 availability rules, harness-attested ratification record format

## What this sets up

The guides index now leads with goal/role navigation rather than "find your pack" — this is the foundation for the GitHub Pages site, where the primary nav will follow the same goal/role/loops spine rather than exposing Diátaxis quadrants as top-level nav.

## Test plan

- [ ] README renders correctly in GitHub (three-loop diagram, catalogue table with release-engineering row)
- [ ] All new guide links resolve from the guides/README.md spine
- [ ] `docs/guides/_shared/explanation/the-three-loops.md` links back to correct pack guide paths
- [ ] Release-engineering tutorial narrative is internally consistent (round counts, verdicts, G5 flow)
- [ ] No internal RFC/ADR citations in the adopter-facing guide files