### PR TITLE
feat(site): GitHub Pages site — design system, full-bleed hero, mobile, Kiro split

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,62 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Allow only one concurrent deployment; cancel in-flight runs on new push.
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history for git-revision-date plugin
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: site/requirements.txt
+
+      - name: Install site dependencies
+        run: pip install -r site/requirements.txt
+
+      - name: Aggregate content
+        run: python tools/build-site.py
+
+      - name: Build site
+        run: mkdocs build --config-file site/mkdocs.yml --strict
+        env:
+          # Suppress git-revision-date warnings when history is shallow
+          CI: "true"
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/built/
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,12 @@ dist/
 # Conductor scratch + per-workspace probe scaffolding.
 .context/
 .claude/scheduled_tasks.lock
+
+# GitHub Pages site — generated content and build output.
+# Hand-crafted sources under site/docs/ are committed; generated dirs are not.
+site/built/
+site/docs/packs/
+site/docs/guides/
+site/docs/changelog.md
+site/docs/contributing.md
+site/docs/.siteignore

--- a/Makefile
+++ b/Makefile
@@ -185,3 +185,20 @@ zipapp:
 
 release-preflight: lint-packs
 	@bash tools/release-check.sh
+
+# ── Site publishing ──────────────────────────────────────────────────────────
+# Requires: pip install -r site/requirements.txt
+
+.PHONY: site-sync site-build site-serve site-deploy
+
+site-sync:  ## Aggregate repo content into site/docs/ (run before build/serve)
+	$(PYTHON) tools/build-site.py
+
+site-build: site-sync  ## Build static site → site/built/ (strict, matches CI)
+	mkdocs build --config-file site/mkdocs.yml --strict
+
+site-serve: site-sync  ## Start live-reload dev server at http://localhost:8000
+	mkdocs serve --config-file site/mkdocs.yml
+
+site-deploy: site-sync  ## Deploy to gh-pages branch (CI uses pages.yml instead)
+	mkdocs gh-deploy --config-file site/mkdocs.yml --force

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1258,6 +1258,101 @@ hook rather than gating at their classification layer — at which point it is i
 own slice with its own security review (it changes the egress boundary
 `security-reviewer` gates).
 
+## `experience-pack`
+
+Open items for the `experience` pack skills — skill additions, amendments, and gaps in the
+design thread coverage. These are pack-level concerns, not site-specific; the site items that
+have an experience-pack implication are cross-referenced from `## github-pages-site` below.
+
+### copy-direction-skill-rfc
+
+**Source:** Session 2026-07-01 — building the GitHub Pages site exposed that `aesthetic-direction`
+covers visual voice but has no copy twin. The experience pack's design thread (journey → realization)
+is silent on copy: what the product says, not just how it looks.
+
+**Gap:** `aesthetic-direction` produces named visual goals grounded in persona, precedent, and
+platform standards. There is no equivalent skill for copy voice — no interrogation sequence for
+manifesto vs. instructional vs. warm, no tweet-test criterion, no grounding in copy precedents
+(Stripe's "The new standard in online payments"; Linear's "The issue tracker you'll enjoy using").
+The full gap analysis with concrete site examples is in
+[`content-strategy-and-marketing-copy-lens`](#content-strategy-and-marketing-copy-lens) below.
+
+**Proposed work:**
+A `copy-direction` skill in the `experience` pack — the copy twin of `aesthetic-direction`. Same
+interrogation structure (vibe → named goals → grounding → arbitration) applied to copy voice and
+positioned copy. Produces a `copy-direction.md` doc grounded in persona, copy precedents, and
+recognized persuasion standards (painkiller-first framing, tweet test, five-second evaluator scan).
+
+**Unblocks when:** RFC opened for the new skill (new skill = public interface = full-mode
+work-loop trigger). RFC should address: scope boundary relative to `voice-and-microcopy` (which
+covers UI microcopy but not marketing/conversion copy), and whether conversion architecture (CTA
+specificity, above-fold order, SEO semantics) belongs in this skill or a separate `growth-pack`
+track.
+
+### design-system-foundations-skill-gap
+
+**Source:** Session 2026-07-01 — `aesthetic-direction` anti-patterns explicitly refuse to produce
+token values ("no palette, font name, or spacing value here — hand off to `design-system-foundations`").
+But `design-system-foundations` does not exist in the catalogue.
+
+**Gap:** The experience pack's declared design thread ends at `aesthetic-direction` (named goals)
+with an explicit handoff to `design-system-foundations` — which is not a skill anyone can invoke.
+An adopter who runs `aesthetic-direction` has goals but no path to tokens. The gap was exposed
+building this site's CSS design token set from scratch with no skill guidance.
+
+**Proposed work:** Either (a) author `design-system-foundations` as the next skill in the experience
+pack — takes the direction doc as input, produces a token set (color roles, type scale, spacing
+rhythm, elevation, motion) grounded in the goals — or (b) extend `aesthetic-direction` to produce
+a lightweight token scaffold in addition to the direction doc, removing the phantom handoff.
+Option (a) is the cleaner skill decomposition; option (b) avoids a new skill that may be scope-creep
+(design-system-foundations is broader than aesthetic guidance).
+
+**Unblocks when:** RFC scopes the option decision and the boundary with `design-critique` (which
+reviews against a design system but doesn't author one).
+
+### design-critique-marketing-clarity-criterion
+
+**Source:** Session 2026-07-01 — `design-critique` covers UX/visual heuristics (Nielsen's 10,
+WCAG SCs, Hick's Law, Fitts's Law). It does not cover whether copy motivates, communicates to a
+skeptical evaluator, or passes basic conversion architecture tests.
+
+**Gap:** A reviewer using `design-critique` today would not flag "hero subtitle describes features
+not outcomes" or "zero social proof above the fold" — those are copy/conversion concerns, not
+UX/visual ones. The heuristics covering them (tweet test, five-second evaluator scan, painkiller
+framing) are absent from the skill's criterion set.
+
+**Proposed work (amendment, not a new skill):** Add a "marketing clarity" criterion section to
+`design-critique`: tweet test (headline stands alone as a conviction statement), five-second scan
+(does the above-fold answer: what is this / who is it for / should I care?), and painkiller-first
+structure check (does the copy lead with the reader's problem, not the author's feature list). This
+is a bounded amendment — no new skill file, no RFC needed unless the change crosses a public
+interface. Route as a normal PR with `adversarial-reviewer` pass.
+
+**Unblocks when:** taken as a `design-critique` skill amendment PR.
+
+### experience-reviewer-as-work-loop-gate
+
+**Source:** Session 2026-07-01 — no formal mechanism routes work-loop's reviewer roster to include
+`experience-reviewer` when a change crosses a user-facing surface. The reviewer is available but
+never auto-triggered.
+
+**Gap:** Work-loop's risk triggers fire specialist reviewers (security-reviewer for auth/secrets,
+quality-engineer for testability). There is no analogous trigger for changes that affect what a
+reader sees — a new docs page, a site redesign, a pack card rewrite. The experience reviewer exists
+but must be invoked manually; the SDLC gate is missing.
+
+**Proposed work:** Define a "user-facing surface" risk trigger in work-loop: *does this change what
+a reader or adopter sees?* If yes → `experience-reviewer` runs as a mandatory gate alongside the
+standard reviewer roster. The full working hypothesis and governance implications are in
+[`experience-loop-trigger-for-site-changes`](#experience-loop-trigger-for-site-changes) in the
+site section. This is the pack-level policy decision; the site section is the concrete example.
+
+**Unblocks when:** ADR or RFC establishes the trigger contract and work-loop skill is updated.
+Needs a decision on mandatory vs. recommended (suggested: mandatory for net-new user-facing pages,
+recommended for copy changes).
+
+---
+
 ## `github-pages-site`
 
 ### aesthetic-rubrics-research
@@ -1378,4 +1473,50 @@ Two separate work items:
 
 **Unblocks when:** RFC for `copy-direction` skill is opened; charter decision on
 growth scope resolves item 2.
+
+**Research findings (session 2026-07-01):** Agent skills for UX writing are well-established (segmented style-guide training + character-limit enforcement); marketing/conversion copy has no formal agent skill — best-available is a 5-step pipeline (VOC mining → competitive gap → value prop painkiller framing → brand voice training → creative-director output structure). No anthropic-cookbook examples exist for content/UX. Sources: UX Writing Hub (Sarah Kessler chained GPT pairs), aufaitux.com (Figma-resident UX writing agents), msitarzewski/agency-agents (Brand Guardian / Ad Strategist persona cards), Social Media Examiner (5-step conversion copy pipeline). Passable today: hero headline formulas, VOC extraction prompts, role-based persona subagent cards. Needs original work: formal SKILL.md for hero headline writing, copy critique with scoring rubrics, conversion architecture review as an agent workflow.
+
+### site-social-proof-band
+
+**Source:** experience-reviewer finding (session 2026-07-01). Page ships zero social proof or credibility signal — no version/recency signal, no install count, no adopter logos, no dogfooding claim. For a skeptical technical buyer this is the largest missing conversion lever.
+
+**Working approach:** The strongest available honest signal is dogfooding — the catalogue builds and governs *itself* (RFC/ADR trail, self-host projection, PyPI package recency, adapter count). A "proof band" section between the hero and the loops section could carry: `agentbundle` PyPI version badge, install count if available, "built with itself" dogfooding statement, adapter count. No fabricated logos.
+
+**Unblocks when:** someone decides what signal is available and honest enough to publish, then adds the band as a static section in `site/docs/index.md`. Does not require a formal spec; a normal PR with experience-reviewer review is sufficient.
+
+### site-catalogue-hierarchy
+
+**Source:** experience-reviewer finding (session 2026-07-01). "Fourteen" appears three times before the two-tier progressive-disclosure split ("start with loops / add what your team needs"). Hick's Law: presenting 14 equal-weight choices maximises perceived choice cost. The 11 "add what you need" cards have no sub-grouping.
+
+**Open work:**
+- Drop count from hero subtitle (already done in session: "These fourteen packs" → acceptable, but "fourteen" still appears in the catalogue section header). Consider "a curated catalogue" vs. naming the count up front.
+- Sub-group the 11 secondary cards — the `repo`/`user` scope tags already exist as a natural axis. Alternatively, group by discipline cluster (data/docs/infra/design/governance).
+
+**Unblocks when:** taken as a copy-only PR with experience-reviewer review.
+
+### site-handoff-diagram
+
+**Source:** experience-reviewer finding (session 2026-07-01). The G3→G4→G5 handoff chain is rendered as a plain ASCII code fence — reads as a debug artifact on a site claiming "leading developer site" polish. Gate labels (G0/G1.5/G2/G3/G4/G5) also lack a first-use definition anywhere outside the card bodies.
+
+**Working approach:** Replace the ASCII fence with a Mermaid diagram (the site already supports `superfences`/Mermaid rendering via MkDocs Material). Use `#5e6ad2` accent nodes to tie it to the visual voice. Add a short legend defining the Gx gate notation.
+
+**Unblocks when:** taken as a content PR. Mermaid support is already wired; no build changes needed.
+
+### site-design-system-spec
+
+**Source:** Session 2026-07-01 — design system lens applied. The CSS now has inline token roles documented (DARK ZONE / SURFACE-0/1/2 / ACCENT / TEXT-HIGH/MID/LOW), but there is no machine-readable token spec.
+
+**Open work:**
+- Author a `site/design-system.md` or `site/tokens.json` that formalizes: color tokens + their zones, typography scale (base/h1–h4/code), spacing rhythm, component vocabulary (card, badge, button, table), dark mode equivalents.
+- Wire a lint that catches zone violations (e.g. `#0f172a` appearing in a non-header/hero selector).
+- Audit all third-party components Material injects (search, announce bar, cookie consent if added) against the token spec.
+- Decide: card icon parity — the three "loop" cards use Material icons, the eleven "catalogue" cards do not. Either add icons to all, or remove from the three. The current split reads as two separate design systems inside one page.
+
+**Unblocks when:** someone opens this as a normal PR (no RFC needed — this is internal docs tooling, not a pack or skill change).
+
+### site-mobile-responsiveness
+
+**Source:** User request (session 2026-07-01). Mobile CSS was added for the hero section (reduced padding, stacked buttons, font-size clamp). Needs a full mobile audit pass: cards grid on narrow viewports, navigation on mobile, code block overflow for the ASCII diagram, table horizontal scroll, tab-panel usability on touch.
+
+**Unblocks when:** screened on actual mobile viewport (375px / 390px / 430px widths) and on a physical device. The dev server is accessible locally via `make site-serve`; use Chrome DevTools device emulation for an initial pass.
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1311,3 +1311,71 @@ standard reviewer roster.
 `work-loop` skill is updated with a user-facing-surface risk trigger. Needs
 discussion on whether the experience loop is a mandatory gate or a recommended
 gate (suggested: mandatory for net-new pages, recommended for content changes).
+### content-strategy-and-marketing-copy-lens
+
+**Source:** Session 2026-07-01 — building the GitHub Pages site exposed a gap:
+no skill in the catalogue covers marketing copy writing, conversion architecture,
+or digital evangelism voice. The current hero headline and above-fold content
+were written without any disciplined content-strategy method.
+
+**Gap analysis — covered vs. not:**
+
+*Covered in existing packs:*
+- UI microcopy (error/empty/label states): `product-engineering` → `voice-and-microcopy`
+- Brand voice character axes (formality/humor/respect/enthusiasm): `voice-and-microcopy`
+- Visual voice: `experience` → `aesthetic-direction`
+- Product vision/positioning as an intent: `product-engineering` → `frame-intent`
+
+*Not covered anywhere:*
+1. **Marketing copy / hero headline writing** — no skill for writing or critiquing
+   positioning headlines, taglines, or above-fold marketing copy. The "tweet test"
+   (can the headline stand alone as a conviction statement?) has no home.
+2. **Copy voice critique** — `design-critique` covers visual/UX heuristics; nothing
+   covers whether copy pulls, motivates, or communicates clearly to a skeptical
+   evaluator scanning in 5 seconds.
+3. **Conversion architecture** — above-fold order (social proof, feature hierarchy,
+   urgency, CTA specificity); no skill for thinking about the reader's evaluation
+   sequence or what belongs above vs. below the fold.
+4. **Digital evangelism / devrel voice** — the tone that builds community vs. just
+   documents: changelog entries that create excitement, README copy that spreads,
+   announcement copy. Different from `voice-and-microcopy`'s UI scope.
+5. **SEO semantics** — keyword intent targeting, meta descriptions, page titles.
+   "AI Operating Model" is our invented category; no skill interrogates whether
+   it's what the target audience actually searches for.
+
+*Concrete example — current site's above-fold:*
+- Headline "The Complete AI Operating Model for Software Teams" — "Complete"
+  is an unverified claim; "AI Operating Model" is invented category language,
+  not search-native; "for Software Teams" excludes individual practitioners.
+- Subtitle describes features (loops, packs, agents) not outcomes for the reader.
+- Zero social proof above the fold (no install count, no logos, no quotes).
+- CTAs "Get started" / "Browse packs" — generic, no urgency, no specificity.
+
+**What can be jerry-rigged from existing pack coverage:**
+- `aesthetic-direction` extended to produce a `copy-direction` doc as its twin:
+  same interrogation structure (vibe → named goals → grounding → arbitration) but
+  for copy voice: manifesto-grade vs. instructional vs. warm; what would the
+  corporate-bad version sound like; what does the headline feel like in the first
+  3 seconds? This is within the spirit of the experience pack and could be a
+  ride-along to an RFC.
+- `design-critique` could add a "marketing clarity" criterion: does the headline
+  pass the tweet test? Does the above-fold answer the three evaluator questions
+  in 5 seconds (what is this / who is it for / should I care)?
+
+**Proposed direction:**
+Two separate work items:
+1. **`copy-direction` skill** (experience pack extension): the copy twin of
+   `aesthetic-direction` — a skill that runs the same interrogation for copy
+   voice and produces a copy-direction doc grounded in persona, copy precedents
+   (Stripe's "The new standard in online payments"; Linear's "The issue tracker
+   you'll enjoy using"), and recognized persuasion standards. Ride-along to
+   `aesthetic-direction` in the same session. Route as an RFC (`work-loop` full
+   mode — new skill, public interface).
+2. **Conversion + SEO** (open, not in experience pack scope): belongs in a future
+   `growth` or `content-strategy` pack, or as an opt-in rider on
+   `product-engineering`. Blocked on charter decision — is growth/marketing within
+   the company OS scope?
+
+**Unblocks when:** RFC for `copy-direction` skill is opened; charter decision on
+growth scope resolves item 2.
+

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1263,23 +1263,31 @@ own slice with its own security review (it changes the egress boundary
 ### aesthetic-rubrics-research
 
 **Source:** Session 2026-07-01 — aesthetic direction pass on the GitHub Pages
-site surfaced rubrics borrowed from external precedent that are not yet encoded
-in the `aesthetic-direction` skill's grounding references.
+site surfaced rubrics not yet encoded in the `aesthetic-direction` skill.
 
-Used in this session (documented in memory `reference_aesthetic_direction_rubrics.md`):
-Nielsen information-scent, Hick's Law, Miller's Law / progressive disclosure,
-Hemingway iceberg rule, Stripe/Linear/Vercel/MDN precedents, WCAG 2.1 AA +
-specific SCs (1.4.1 color, 1.4.3 contrast, 2.4.7 focus, 2.3.3 reduced-motion).
+**Already added to `references/grounding.md` (ride-along, 2026-07-01):**
+- Visual voice as a grounding dimension distinct from correctness rubrics:
+  surface treatment (dark hero + grid texture + ambient glow pattern),
+  type scale philosophy (display vs. document, `clamp()`, letter-spacing),
+  color philosophy (one chromatic accent), elevation philosophy (border-not-shadow).
+- Stage 1.5 ambition-axis probe added to `references/interrogation-sequence.md`:
+  document-to-product-site spectrum, surface treatment claim, example treatments.
+- Memory `reference_aesthetic_direction_rubrics.md` captures what was used.
 
-**Open:** Research and encode a complete, MECE aesthetic rubric set into the
-`aesthetic-direction` skill's reference files — covering information architecture,
-typographic standards, authority/brand signals, and the quality floor with cited
-WCAG SCs. The skill currently provides procedure but not the grounding frameworks;
-future passes shouldn't need to re-derive them from external precedent.
+**Still open — needs a dedicated research session (`/research`):**
+1. MECE correctness rubric set with cited WCAG SCs (1.4.1, 1.4.3, 2.4.7, 2.3.3
+   etc.) so they can be applied from memory rather than re-derived each pass.
+2. Platform-specific visual voice precedents beyond responsive-web (iOS HIG,
+   Material 3 expressive tier, Android adaptive).
+3. Information architecture rubrics (Diátaxis, card-sorting, progressive
+   disclosure quantification) as grounding standards — currently absent from
+   the skill's Standards referent list.
+4. Typography research canon (optical sizing, variable-font weight axes,
+   fluid type scales via `clamp()` best practice).
 
-**Unblocks when:** a research session (using `/research`) catalogues the canonical
-rubric set and the `aesthetic-direction` skill's `references/grounding.md` is
-updated in the same PR. Route through `work-loop` light mode.
+**Unblocks when:** `/research` catalogues the above four areas and the
+`aesthetic-direction` skill's reference files are updated in a single PR,
+routed through `work-loop` light mode.
 
 ### experience-loop-trigger-for-site-changes
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1257,3 +1257,49 @@ wire in. **Not built.** **Unblocks when:** an adopter needs an in-skill redactio
 hook rather than gating at their classification layer — at which point it is its
 own slice with its own security review (it changes the egress boundary
 `security-reviewer` gates).
+
+## `github-pages-site`
+
+### aesthetic-rubrics-research
+
+**Source:** Session 2026-07-01 — aesthetic direction pass on the GitHub Pages
+site surfaced rubrics borrowed from external precedent that are not yet encoded
+in the `aesthetic-direction` skill's grounding references.
+
+Used in this session (documented in memory `reference_aesthetic_direction_rubrics.md`):
+Nielsen information-scent, Hick's Law, Miller's Law / progressive disclosure,
+Hemingway iceberg rule, Stripe/Linear/Vercel/MDN precedents, WCAG 2.1 AA +
+specific SCs (1.4.1 color, 1.4.3 contrast, 2.4.7 focus, 2.3.3 reduced-motion).
+
+**Open:** Research and encode a complete, MECE aesthetic rubric set into the
+`aesthetic-direction` skill's reference files — covering information architecture,
+typographic standards, authority/brand signals, and the quality floor with cited
+WCAG SCs. The skill currently provides procedure but not the grounding frameworks;
+future passes shouldn't need to re-derive them from external precedent.
+
+**Unblocks when:** a research session (using `/research`) catalogues the canonical
+rubric set and the `aesthetic-direction` skill's `references/grounding.md` is
+updated in the same PR. Route through `work-loop` light mode.
+
+### experience-loop-trigger-for-site-changes
+
+**Source:** Session 2026-07-01 — question raised about when `experience` pack
+skills should trigger for frontend or product changes that affect user-facing
+surfaces including this docs site.
+
+**Open:** Define the trigger points for experience pack skills (`aesthetic-direction`,
+`design-critique`, `experience-reviewer`) in the context of:
+- Changes to this GitHub Pages site (`site/docs/`, `site/mkdocs.yml`, `tools/build-site.py`)
+- Changes to user-facing product docs (`docs/guides/`, `docs/product/`)
+- New pack additions or removals that change the catalogue content
+
+**Working hypothesis:** experience pack trigger belongs in `work-loop`'s risk
+triggers — specifically under "Structural or public-interface change" when that
+change crosses a user-facing surface. The check would be: *does this change what
+a reader sees on the site?* If yes → experience reviewer runs in addition to the
+standard reviewer roster.
+
+**Unblocks when:** an RFC or ADR establishes the trigger contract and the
+`work-loop` skill is updated with a user-facing-surface risk trigger. Needs
+discussion on whether the experience loop is a mandatory gate or a recommended
+gate (suggested: mandatory for net-new pages, recommended for content changes).

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -229,18 +229,6 @@ jobs: build-and-smoke / publish-pypi / publish-artifactory). One AC remains
 open (AC14, Artifactory first-firing); the PyPI-side deferrals below resolved
 with the first publish (`agentbundle-v0.2.0`, 2026-06-07) + PR-B.
 
-### readme-route3-after-first-publish
-
-**Resolved by PR-B (2026-06-07).** AC11 — README install-route-3 headline now
-names `pip install agentbundle` directly; landed after the first PyPI publish
-made the claim true.
-
-### pypi-first-publish-gesture
-
-**Resolved 2026-06-07.** AC13 — first PyPI publish (`agentbundle-v0.2.0`) via
-Trusted-Publisher OIDC succeeded; clean-venv `pip install agentbundle` +
-`agentbundle --help` smoke confirmed.
-
 ### artifactory-first-publish-gesture
 
 AC14 — corp Artifactory publish first-firing. **Unblocks when:** the three
@@ -1183,34 +1171,6 @@ refactor in its own right. **Unblocks when:** taken as a focused refactor PR wit
 its own regression pass over upgrade/diff/uninstall scope resolution.
 
 ## `extraction-tier0-and-output-contract`
-
-### extraction-msg-to-markdown-python-contract
-
-**Source:** spec-stage adversarial review of
-[`extraction-tier0-and-output-contract`](specs/extraction-tier0-and-output-contract/spec.md).
-RFC-0058 D3 / Open-Q2 recommended `msg-to-markdown` adopt the unified output
-contract. It was **removed from the floor spec** once review confirmed
-`msg-to-markdown` is a **Node.js** skill (`scripts/convert.js` +
-`@nicecode/msg-reader`), so it cannot import the floor's shared **Python**
-frontmatter builder — a JS reimplementation would fork the contract and break
-the floor spec's "single builder, no drift" property (AC1). **Decision (owner:
-eugenelim):** adopt the contract by **porting `msg-to-markdown` to Python** (e.g.
-a pure-Python `.msg` reader such as `extract-msg`, swapping the npm dependency +
-Node runtime), so it shares the one builder — done as its **own slice** with its
-own adversarial + quality review and a **parity check** against today's Node
-output, not bundled into the floor. **Unblocks when:** the floor spec's
-`contract.py` builder ships (the interface to share) and the Python `.msg`-reader
-dependency clears the pack's dependency bar. Also folds in the `.eml`/MIME
-ingestion deferral below if MIME parsing lands in the same Python skill.
-
-### extraction-tier0-eml-mime
-
-**Source:** RFC-0058 Open-Q2. The floor spec adds `.eml` as a **file-to-markdown
-input format** at Tier 0 (D7; spec AC7). Full **MIME** handling for
-`msg-to-markdown` (multipart bodies, nested messages, richer header mapping
-beyond a flat `.eml` read) is **deferred** — it belongs with the
-`msg-to-markdown` Python port above, not the file-to-markdown floor. **Unblocks
-when:** the `msg-to-markdown` Python-port slice is picked up.
 
 ### extraction-image-pixel-bomb-guard
 

--- a/docs/specs/extraction-tier0-and-output-contract/spec.md
+++ b/docs/specs/extraction-tier0-and-output-contract/spec.md
@@ -340,8 +340,7 @@ passing silently. Docling stays available and unchanged as the higher-fidelity
   to Python. The port is the right move but is a distinct, sizable change (new
   Python `.msg` dependency, full rewrite, parity validation) that belongs in its
   own slice, not this floor (deferred:
-  extraction-msg-to-markdown-python-contract). `.eml`/MIME for that skill defers
-  with it (deferred: extraction-tier0-eml-mime); `.eml` as a *file-to-markdown
+  extraction-msg-to-markdown-python-contract). `.eml` as a *file-to-markdown
   input format* stays in this spec at Tier 0 (AC7).
 - Tempted to add a general HTML→Markdown dependency (e.g. `markdownify`) for
   richer D7 HTML output; declining unless a stdlib `html.parser`-based reduction

--- a/docs/specs/github-pages-site/plan.md
+++ b/docs/specs/github-pages-site/plan.md
@@ -1,0 +1,50 @@
+# Plan: GitHub Pages Publishing Toolchain
+
+## Tasks
+
+### T1 — Scaffold site directory structure
+**Depends on:** none  
+**Verification:** goal-based check (`ls site/mkdocs.yml site/requirements.txt site/docs/index.md`)  
+**Done when:** site/ exists with mkdocs.yml, requirements.txt, docs/index.md, docs/getting-started/, docs/stylesheets/
+
+### T2 — Write MkDocs Material config
+**Depends on:** T1  
+**Verification:** goal-based (`mkdocs build --config-file site/mkdocs.yml --strict` exits 0 after T6)  
+**Done when:** site/mkdocs.yml has theme config, full nav, markdown extensions, plugins
+
+### T3 — Write hand-crafted site pages
+**Depends on:** T1  
+**Verification:** visual/manual QA (mkdocs serve, inspect landing page)  
+**Done when:** index.md hero page, getting-started/{index,install,three-loops}.md, stylesheets/extra.css all present and render correctly
+
+### T4 — Write tools/build-site.py content aggregation script
+**Depends on:** none  
+**Verification:** goal-based (`python tools/build-site.py` exits 0; site/docs/packs/ and site/docs/guides/ populated)  
+**Done when:** script copies all 14 pack READMEs, mirrors guides/, copies changelog + contributing, generates packs/index.md, rewrites broken links (cross-pack, governance, stale)
+
+### T5 — Add Makefile targets
+**Depends on:** T2, T4  
+**Verification:** goal-based (`make site-sync` runs build-site.py; `make site-build` runs mkdocs --strict)  
+**Done when:** site-sync, site-build (--strict), site-serve, site-deploy targets present
+
+### T6 — Wire GitHub Actions deployment workflow
+**Depends on:** T2, T4  
+**Verification:** goal-based (workflow YAML validates; permissions correctly scoped)  
+**Done when:** .github/workflows/pages.yml builds + deploys on main push, scoped permissions
+
+### T7 — Update .gitignore for generated content
+**Depends on:** T4  
+**Verification:** goal-based (`git status` after build-site.py shows no unexpected tracked changes)  
+**Done when:** site/built/, site/docs/packs/, site/docs/guides/, site/docs/changelog.md, site/docs/contributing.md are gitignored
+
+### T8 — Full strict build passes clean
+**Depends on:** T2, T3, T4, T5, T6, T7  
+**Verification:** goal-based (`mkdocs build --config-file site/mkdocs.yml --strict` exits 0)  
+**Done when:** zero warnings, zero errors in strict build
+
+## Declined patterns
+
+- Social card plugin: requires `cairosvg` system library in CI (libcairo2 apt dep); not worth the CI complexity for a docs site
+- Astro/Starlight: Node.js build dependency in a Python repo
+- Committing generated content: double-maintenance; CI regenerates on every push
+- mkdocs-redirects: no page renames anticipated at this stage

--- a/docs/specs/github-pages-site/spec.md
+++ b/docs/specs/github-pages-site/spec.md
@@ -1,0 +1,65 @@
+# Spec: GitHub Pages Publishing Toolchain
+
+**Mode: full** (new dependency: mkdocs-material; structural: new top-level dir + GH Actions workflow; public interface: published site)
+
+- **Status:** Shipped
+
+## Objective
+
+Ship a professional MkDocs Material documentation site under `site/` that aggregates content from the repo's existing guides, packs, and product docs. Provide a `make site-sync/build/serve/deploy` toolchain so the site can be rebuilt from a single command and deployed automatically via GitHub Actions on every push to `main`.
+
+## Acceptance Criteria
+
+- [x] `site/mkdocs.yml` configures MkDocs Material with dark/light toggle, search, code copy, navigation tabs
+- [x] `site/requirements.txt` pins mkdocs-material and plugins
+- [x] `site/docs/index.md` is a rich hero landing page (three loops, pack catalogue, install command)
+- [x] `site/docs/getting-started/index.md` walks through quick start → first loop
+- [x] `site/docs/stylesheets/extra.css` adds custom polish on top of Material
+- [x] `tools/build-site.py` copies packs/*/README.md → site/docs/packs/<name>.md, docs/guides/** → site/docs/guides/**, changelog + contributing
+- [x] `tools/build-site.py` generates a `site/docs/packs/index.md` pack catalogue summary
+- [x] `make site-sync` runs the aggregation script
+- [x] `make site-build` runs site-sync then `mkdocs build`
+- [x] `make site-serve` runs site-sync then `mkdocs serve` for local dev
+- [x] `.github/workflows/pages.yml` builds and deploys to GitHub Pages on push to main
+- [x] `site/built/` and generated docs subdirs are gitignored
+- [x] Site builds clean (`mkdocs build --strict` passes)
+
+## Boundaries
+
+**Touching:** `site/` (new), `tools/build-site.py` (new), `.github/workflows/pages.yml` (new), `Makefile` (additive), `.gitignore` (additive), `docs/specs/github-pages-site/` (this spec)
+
+**Not touching:** existing `docs/` (read-only source), existing `packs/` (read-only source), existing Makefile targets, any pack source files
+
+## Testing Strategy
+
+Verification mode: goal-based check + visual/manual QA
+
+- `python tools/build-site.py` exits 0 and populates `site/docs/packs/`, `site/docs/guides/`
+- `mkdocs build --config-file site/mkdocs.yml` exits 0 (strict mode)
+- `mkdocs serve` starts and the landing page renders correctly
+
+## Assumptions (verified)
+
+- Python 3 is available (`python3` in PATH) — confirmed from repo's existing Makefile convention
+- GitHub repo is `eugenelim/agent-ready-repo` — confirmed from pack README link
+- `packs/` contains exactly 14 packs — confirmed from exploration
+- All 14 packs have `README.md` — to be confirmed by build-site.py at runtime (skip missing, warn)
+- `docs/guides/` is the full user-facing guide tree — confirmed (107 .md files mirrored by build-site.py)
+
+## Declined patterns
+
+- Astro/Starlight — adds Node.js build dependency to a Python repo; MkDocs fits the stack
+- Jekyll — GH-native but limited; Material's feature set is substantially better
+- Copying ALL of docs/ — most is internal governance (ADRs, RFCs, specs); only guides + product docs are user-facing
+- Custom theme from scratch — Material is already the best; custom overrides only
+- Committing generated content — CI regenerates on every push; no double-maintenance
+- mkdocs-gen-files plugin — unnecessary complexity when a simple Python script suffices
+
+## Resolve-vs-surface disposition
+
+| Item | Disposition |
+|---|---|
+| GitHub Pages URL for site_url | Resolved: `https://eugenelim.github.io/agent-ready-repo/` (from pack README link) |
+| Whether to use `--strict` | Resolved: yes in CI, not in serve (strict blocks warnings in dev) |
+| Nav: auto vs explicit | Resolved: explicit nav for key pages, auto for guide sub-pages |
+| Generated content: committed vs gitignored | Resolved: gitignored; CI runs sync then build |

--- a/packs/experience/README.md
+++ b/packs/experience/README.md
@@ -16,6 +16,14 @@ fixed token set, no pixel comps). The skills point to the recognized
 standards — WCAG, the W3C Design Tokens interchange shape, Apple HIG, Material
 3, APQC, BPMN — and ship the method to *derive* your design, never the values.
 
+**Correctness is the floor, not the ceiling.** Accessibility compliance,
+information hierarchy, and usability heuristics (WCAG, Nielsen, Laws of UX)
+are non-negotiable — but meeting them alone produces correct-but-tasteless
+work. The `aesthetic-direction` skill is the gate between the two: it grounds
+goals in persona, precedent, *and* visual voice — surface treatment, type scale
+ambition, color philosophy, and elevation philosophy. A direction doc that only
+names correctness goals has not cleared the gate.
+
 ## What's inside
 
 **The connective thread** — map the flow from outcome to realization:

--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,59 @@
+# Site
+
+MkDocs Material documentation site for agent-ready-repo.
+
+## Prerequisites
+
+```bash
+pip install -r site/requirements.txt
+```
+
+One-time. The three packages are `mkdocs-material`, `mkdocs-minify-plugin`, and `pymdown-extensions`.
+
+## Local development
+
+```bash
+make site-serve
+```
+
+Opens a live-reload server at **`http://127.0.0.1:8000/agent-ready-repo/`** (subpath mirrors the GitHub Pages URL). Edits to hand-crafted pages under `site/docs/` rebuild immediately; changes to source files in `packs/` or `docs/guides/` require re-running `make site-sync` to re-aggregate.
+
+## Build the static output
+
+```bash
+make site-build        # → site/built/
+open site/built/index.html
+```
+
+Strict mode — same flags as CI. Any warning is a build failure.
+
+## Workflow
+
+| Command | What it does |
+|---|---|
+| `make site-sync` | Aggregate repo content into `site/docs/` (copies pack READMEs, mirrors guides, rewrites cross-tree links) |
+| `make site-build` | `site-sync` + `mkdocs build --strict` → `site/built/` |
+| `make site-serve` | `site-sync` + `mkdocs serve` with live reload |
+| `make site-deploy` | `site-sync` + `mkdocs gh-deploy` (manual fallback; CI uses `pages.yml`) |
+
+## What's committed vs generated
+
+**Committed** (hand-crafted, edit these):
+- `site/mkdocs.yml` — theme, nav, plugins
+- `site/requirements.txt` — Python deps
+- `site/docs/index.md` — hero landing page
+- `site/docs/getting-started/` — quick start, install routes, three-loops explainer
+- `site/docs/stylesheets/extra.css` — custom CSS
+
+**Generated** by `make site-sync` (gitignored, don't edit):
+- `site/docs/packs/` — sourced from `packs/*/README.md`
+- `site/docs/guides/` — sourced from `docs/guides/`
+- `site/docs/changelog.md` — sourced from `docs/product/changelog.md`
+- `site/docs/contributing.md` — sourced from `CONTRIBUTING.md`
+- `site/built/` — MkDocs output
+
+## Deployment
+
+Push to `main`. The `.github/workflows/pages.yml` workflow runs `build-site.py` then `mkdocs build --strict` and deploys via `actions/deploy-pages`.
+
+Enable in repo settings → Pages → Source → **GitHub Actions**.

--- a/site/aesthetic-direction.md
+++ b/site/aesthetic-direction.md
@@ -1,0 +1,42 @@
+# Aesthetic Direction — agent-ready-repo site
+
+**Surface:** responsive-web documentation site  
+**Audience:** senior engineers and engineering leads evaluating adoption
+
+## Named goals (ranked)
+
+### 1. Signal clarity *(dominant)*
+A senior engineer scans the landing page in 15 seconds and knows exactly what this is, what the three loops do, and whether to read further. Every section has one job. Section breaks are whitespace, not rules or decorative chrome.
+
+**Referents:** Linear docs (information hierarchy unambiguous at every zoom level), Nielsen's information-scent principle  
+**Violates if:** badges, secondary metadata, or decorative dividers appear before the value proposition is clear
+
+### 2. Earned authority
+The site projects confidence through precision and restraint — not marketing inflection, not selling. Trust is built the way good technical writing builds it: by being exactly right.
+
+**Referents:** Vercel docs (no unnecessary chrome), Stripe developer docs (zero decoration, total clarity), Hemingway's iceberg rule  
+**Violates if:** superlatives, vague claims, or visual decoration substitute for specific, accurate description
+
+### 3. Typographic intelligence
+Code and prose are equal first-class citizens. The type scale is decisive, not decorative. Inline code doesn't interrupt reading; it clarifies it.
+
+**Referents:** Inter typeface design intent (clarity at text size, weight at display), MDN typography standards, JetBrains Mono (legibility in mixed prose contexts)  
+**Violates if:** code is visually heavier than prose, type sizes are arbitrary rather than scale-derived
+
+### 4. Measured depth
+The information architecture rewards exploration without demanding it. The above-fold view is the one job; everything else opens naturally from it.
+
+**Referents:** Progressive disclosure (Miller's Law), Hick's Law (fewer choices at decision points = faster decisions)  
+**Violates if:** 14 packs presented as equal-weight choices without hierarchy or entry point
+
+## Conflict arbitration
+
+| Conflict | Winner | Reason |
+|---|---|---|
+| Clarity vs. authority (dramatic hero obscures content) | Clarity | Signal first, always |
+| Authority vs. depth (more info = more noise) | Authority | Restrained surface, depth behind a click |
+| Typography vs. decoration | Typography | Icons earn their place or are cut |
+| Depth vs. clarity (first-load complexity) | Clarity | Collapse until asked |
+
+## Quality floor (non-negotiable)
+WCAG AA contrast ratios, visible focus states, `prefers-reduced-motion` respected. Floor wins over every aesthetic goal without exception.

--- a/site/docs/getting-started/index.md
+++ b/site/docs/getting-started/index.md
@@ -1,0 +1,99 @@
+# Get Started
+
+agent-ready-repo ships the complete AI operating model for software teams. This guide gets you from zero to your first loop in under five minutes.
+
+## What you're installing
+
+When you install a pack, you get:
+
+- **Skills** — slash commands your agent runs on request (`/work-loop`, `/new-spec`, `/bug-fix`)
+- **Subagents** — specialist reviewers that read your diff cold (`adversarial-reviewer`, `security-reviewer`, `quality-engineer`)
+- **Hooks** — automation that fires at session start and before a PR opens
+- **Seeds** — scaffolding for your repo's governance docs
+
+Everything lands as files in your repo (or your home directory for user-scope packs). No runtime, no service, no lock-in.
+
+## Step 1: Install the CLI
+
+```bash
+pip install agentbundle
+```
+
+The `agentbundle` CLI manages pack installation, upgrade, and discovery. One-time setup — upgrade it like any other pip package.
+
+## Step 2: Pick your starting point
+
+=== "Just the build loop"
+
+    The flagship pack. Works in any repo, any stack.
+
+    ```bash
+    agentbundle install --pack core
+    ```
+
+    You get: `work-loop`, `new-spec`, `bug-fix`, four reviewer subagents, session-start and pre-PR hooks.
+
+=== "Full company OS"
+
+    All three loops — discovery, build, release.
+
+    ```bash
+    agentbundle install --pack core
+    agentbundle install --pack product-engineering --scope user
+    agentbundle install --pack release-engineering
+    ```
+
+=== "Inception profile"
+
+    For taking a raw idea from zero to a buildable repo.
+
+    ```bash
+    agentbundle install --profile inception
+    ```
+
+    Lands: `research` + `product-engineering` + `architect`
+
+=== "Solution architect"
+
+    Design, research, and API contracts.
+
+    ```bash
+    agentbundle install --profile solution-architect
+    ```
+
+    Lands: `architect` + `research` + `contracts`
+
+## Step 3: Adapt to your repo
+
+After install, open your agent and run:
+
+```
+/adapt-to-project
+```
+
+This reads your repo's stack and conventions, then tailors the installed skills to match. It fills in the command stubs in your `AGENTS.md` and wires up the hooks correctly.
+
+## Step 4: Use the loop
+
+Your first real task:
+
+```
+Implement <feature> with the work-loop.
+```
+
+The build loop will:
+
+1. **Plan** — name the files it'll touch, write the tests, name what it won't change
+2. **Execute** — red-green-refactor or goal-based, depending on the task
+3. **Gate** — lint, typecheck, tests must all pass
+4. **Review** — adversarial reviewer reads the diff cold in a fresh context
+5. **Decide** — fix blockers, defer nits, ship
+
+---
+
+## What's next
+
+- [Install routes](install.md) — CLI, Claude Plugins, APM, and local clone
+- [The three loops explained](three-loops.md) — how discovery, build, and release compose
+- [Choose your packs](../packs/index.md) — the full catalogue with one-liner descriptions
+- [Adapter support matrix](../guides/_shared/reference/adapter-support.md) — what works in your agent

--- a/site/docs/getting-started/install.md
+++ b/site/docs/getting-started/install.md
@@ -1,0 +1,104 @@
+# Install Routes
+
+Four ways to get packs into your agent. Pick the one that matches your workflow.
+
+## Route 1: agentbundle CLI (recommended)
+
+The standard route. Installs into the current repo (repo scope) or your home directory (user scope).
+
+```bash
+pip install agentbundle
+agentbundle install --pack core
+```
+
+### Key commands
+
+```bash
+# See all available packs
+agentbundle list-packs
+
+# See what you have installed
+agentbundle list-installed
+
+# Install at user scope (follows you across every project)
+agentbundle install --pack research --scope user
+
+# Install a profile (curated pack bundle)
+agentbundle install --profile solution-architect
+
+# Preview before writing any files
+agentbundle install --pack core --dry-run
+
+# Upgrade to the latest version
+agentbundle upgrade --pack core
+
+# Target a specific agent adapter
+agentbundle install --pack core --adapter cursor
+agentbundle config set adapter cursor  # set once, apply everywhere
+```
+
+### Adapters
+
+Auto-detects your agent. Override with `--adapter`:
+
+| Adapter flag | Agent |
+|---|---|
+| `claude-code` | Claude Code (default fallback) |
+| `codex` | OpenAI Codex |
+| `cursor` | Cursor |
+| `copilot` | GitHub Copilot |
+| `gemini` | Gemini CLI |
+| `kiro-ide` | Kiro IDE |
+| `kiro-cli` | Kiro CLI |
+
+## Route 2: Claude Plugins
+
+Install directly from Claude's plugin marketplace without touching the CLI.
+
+```
+claude plugin install eugenelim/core
+claude plugin install eugenelim/research
+```
+
+Available for all 14 packs. Plugin names match the pack name.
+
+## Route 3: APM (Agent Package Manager)
+
+For teams using APM as their primary package manager:
+
+```bash
+apm install eugenelim/core
+apm install eugenelim/research --scope user
+```
+
+## Route 4: Local clone
+
+For catalogue contributors or teams building their own fork:
+
+```bash
+git clone https://github.com/eugenelim/agent-ready-repo
+cd agent-ready-repo
+pip install -e packages/agentbundle
+agentbundle install --pack core
+```
+
+With an editable install, `agentbundle` defaults to the local clone as its catalogue source — so `list-packs` shows local state and installs come from your working tree.
+
+---
+
+## Scopes
+
+Every pack has a natural install scope:
+
+| Scope | Where it lands | When to use |
+|---|---|---|
+| `repo` | `.claude/skills/`, `.codex/`, etc. in the current repo | Skills specific to this project |
+| `user` | `~/.claude/skills/`, etc. in your home dir | Skills that follow you across all repos |
+
+The pack's README documents which scope it defaults to. Override with `--scope user` or `--scope repo`.
+
+## File safety
+
+Installs never silently overwrite your edits. If a file you've modified would be overwritten, it lands as `<name>.upstream` instead — a companion file you merge at your own pace. Your edits are always preserved.
+
+→ [File safety contract explained](../guides/_shared/explanation/file-safety-contract.md)

--- a/site/docs/getting-started/three-loops.md
+++ b/site/docs/getting-started/three-loops.md
@@ -1,0 +1,95 @@
+# The Three Loops
+
+The three loops form the **company operating model** — peer supervisors spanning the full software lifecycle. No loop is a mode of another; each is independent with its own agent, skill doctrine, and consent gates.
+
+```
+product-engineering              core                    release-engineering
+───────────────────              ────                    ───────────────────
+discovery-lead                   work-loop supervisor    release-lead
+Raw idea → Decision brief  ─G3─▶ Spec → Shipped code ─G4─▶ Built → Production
+         G0  G1.5  G2                                         G5
+```
+
+Each loop is **autonomous where the work is reversible** and surfaces to a human where it isn't.
+
+---
+
+## The Discovery Loop — `product-engineering`
+
+`discovery-lead` takes a raw product idea and walks it through a structured diverge/converge cycle:
+
+1. Five candidate product shapes explored in parallel
+2. Collapsed through product, UX, architecture, and safety lenses simultaneously
+3. Results written to a shared blackboard — no chat relay between lenses
+4. A ratified **decision brief** exits at G2
+5. A decomposed feature-level plan exits at G3 into `work-loop`
+
+The result isn't a validated solution — it's a **connected hypothesis with validation hooks**: the riskiest bets named explicitly, the MVP boundary set by a human, the decision log append-only and hash-chained.
+
+**Three human consent gates:** G0 (ratify the value seed), G1.5 (ratify the MVP boundary), G2 (ratify the decision). The loop never auto-advances past an irreversible gate.
+
+→ [Discovery loop deep dive](../guides/product-engineering/explanation/the-discovery-loop.md)
+
+---
+
+## The Build Loop — `core`
+
+Every change goes through:
+
+| Phase | What happens |
+|---|---|
+| **Plan** | Name the assumptions, files to touch, tests to write, what won't change |
+| **Execute** | Red-green-refactor (TDD) or goal-based, matched to the task's verification mode |
+| **Gate** | Lint, typecheck, tests — no path through the loop passes on red |
+| **Review** | Adversarial reviewer in a fresh session, specialist reviewers when warranted |
+| **Decide** | Fix blockers, defer nits with backlog entries, ship |
+
+The loop scales by risk: **light mode** for low-risk work (lean inline spec, single adversarial pass); **full mode** when any risk trigger fires — unfamiliar territory, new dependency, compliance surface, multi-person work.
+
+**Three specialist reviewers:**
+
+| Reviewer | Lens | When |
+|---|---|---|
+| `adversarial-reviewer` | Spec/plan/impl drift, scope creep, missing edge cases | Every diff |
+| `security-reviewer` | OWASP 2025 + ASVS, STRIDE + LINDDUN — depth pulled per boundary | Security-boundary work, at spec stage *and* on the diff |
+| `quality-engineer` | Testability, observability, reliability — "cost to live with this code" | Logic and interfaces worth maintaining |
+
+The security lens **shifts left**: on security-boundary work it also runs at spec stage, catching a missing control as a one-sentence acceptance criterion instead of a post-implementation round-trip.
+
+→ [Core pack deep dive](../guides/core/explanation/core-pack.md)
+
+---
+
+## The Release Loop — `release-engineering`
+
+`release-lead` takes the locally built, deploy-ready artifact and validates it deployed:
+
+1. **Deploy** to an ephemeral environment (no real data, isolated from prod, teardownable)
+2. **Run e2e** against the real artifact
+3. **Observe** telemetry
+4. **Feed findings back** to `work-loop` as build tasks — no human relay
+5. **Redeploy** and iterate until the deployed whole converges by policy
+6. **Surface** a release-readiness record for the G5 prod-ship consent gate
+
+**Autonomy carved by minimum-regret:**
+
+- Reversible operations (deploy to ephemeral, e2e, observe, iterate, teardown) → run unattended
+- Irreversible operations (first real users, data migrations, spend over threshold, prod ship) → always surface to a human
+- **G5 is never autonomous**
+
+Deploy credentials are broker-mediated and scoped to the ephemeral tier only. No credential can reach prod.
+
+→ [Release loop deep dive](../guides/release-engineering/explanation/the-release-loop.md)
+
+---
+
+## How the loops connect
+
+The loops are **peers, not a hierarchy**. G3 is the handoff from discovery to build; G4 is the handoff from build to release. Each loop can run independently — a team can use `core` without `product-engineering`; a repo can use `release-engineering` without `core` (though it hard-depends on `core`).
+
+The inner/outer split:
+- **Inner loop** (build) — runs many times per day, per engineer
+- **Outer loops** (discovery, release) — run per feature or release cycle
+- **Feedback flows inward** — released findings return as build tasks; discovered constraints shape specs
+
+→ [The three loops as a system](../guides/_shared/explanation/the-three-loops.md)

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -1,0 +1,245 @@
+---
+hide:
+  - navigation
+  - toc
+---
+
+# The Complete AI Operating Model<br>for Software Teams
+
+**From first idea to production.** Three supervised loops. Fourteen curated packs. Any agent, any stack.
+
+[![PyPI](https://img.shields.io/pypi/v/agentbundle)](https://pypi.org/project/agentbundle/)
+[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](#)
+[![Agents](https://img.shields.io/badge/agents-Claude%20%7C%20Codex%20%7C%20Cursor%20%7C%20Copilot%20%7C%20Gemini%20%7C%20Kiro-purple)](#adapters)
+
+<div class="hero-actions" markdown>
+[Get started :octicons-arrow-right-24:](getting-started/index.md){ .md-button .md-button--primary .md-button--large }
+[Browse packs :octicons-arrow-right-24:](packs/index.md){ .md-button .md-button--large }
+</div>
+
+---
+
+## Three supervised loops. One handoff chain.
+
+The leverage in agent coding moved from the prompt to the **loop** — it plans, executes, verifies, and decides what comes next. But a loop running unattended is also a loop making mistakes unattended, so it has to check its own work harder than you would.
+
+Software delivery needs more than one loop. Three peer supervisors span the full lifecycle:
+
+<div class="grid cards" markdown>
+
+-   :material-lightbulb-outline:{ .lg .middle } **Discovery Loop**
+
+    ---
+
+    `product-engineering` · `discovery-lead`
+
+    Raw idea → ratified brief. Five candidate shapes explored in parallel, collapsed through product, UX, architecture, and safety lenses simultaneously. Human gates at G0, G1.5, G2. A **connected hypothesis with validation hooks** — not a validated solution.
+
+    [:octicons-arrow-right-24: Product Engineering](packs/product-engineering.md)
+
+-   :material-cog-outline:{ .lg .middle } **Build Loop**
+
+    ---
+
+    `core` · `work-loop`
+
+    Spec → shipped code. Hard mechanical gates (lint, typecheck, tests), three specialist reviewers each reading the diff cold, adversarial in a fresh session. The loop the agent can't self-certify its way out of.
+
+    [:octicons-arrow-right-24: Core pack](packs/core.md)
+
+-   :material-rocket-launch-outline:{ .lg .middle } **Release Loop**
+
+    ---
+
+    `release-engineering` · `release-lead`
+
+    Built → production. Autonomous e2e convergence on ephemeral environments. Deployed findings feed back to the build loop automatically. Prod ship always surfaces to a human — **G5 is never autonomous**.
+
+    [:octicons-arrow-right-24: Release Engineering](packs/release-engineering.md)
+
+</div>
+
+```
+product-engineering           core                    release-engineering
+───────────────────           ────                    ───────────────────
+discovery-lead                work-loop               release-lead
+Raw idea → Brief       ─G3─▶  Spec → Shipped   ─G4─▶  Built → Production
+```
+
+---
+
+## Install in one line
+
+=== "Flagship loop"
+
+    ```bash
+    pip install agentbundle
+    agentbundle install --pack core
+    ```
+
+=== "With discovery"
+
+    ```bash
+    agentbundle install --pack core
+    agentbundle install --pack product-engineering --scope user
+    ```
+
+=== "Full inception profile"
+
+    ```bash
+    agentbundle install --profile inception
+    ```
+
+=== "Solution architect"
+
+    ```bash
+    agentbundle install --profile solution-architect
+    ```
+
+One command lands the loop in your repo. Any agent that reads a skill file inherits it automatically.
+
+---
+
+## The catalogue
+
+Fourteen curated packs — each distilled from the best practices of its discipline through research and architecture decisions.
+
+<div class="grid cards" markdown>
+
+-   **Core** `repo`
+
+    The build loop. `work-loop`, `new-spec`, `bug-fix`, four specialist reviewers, hooks. **Install this even if you install nothing else.**
+
+    [:octicons-arrow-right-24: Core](packs/core.md)
+
+-   **Product Engineering** `user`
+
+    The discovery loop. `discovery-loop`, `frame-intent`, `de-risk-intent`, `decompose-intent`, `voice-and-microcopy`, `align-value-stream`.
+
+    [:octicons-arrow-right-24: Product Engineering](packs/product-engineering.md)
+
+-   **Release Engineering** `repo`
+
+    The release loop. `release-loop`, `release-lead`. Autonomous e2e convergence. Hard-depends on core.
+
+    [:octicons-arrow-right-24: Release Engineering](packs/release-engineering.md)
+
+-   **Research** `user`
+
+    Evidence-grounded research. `research`, `source-map`, `compare-hypotheses`, `devils-advocate`, `decision-archaeology`, two retrieval subagents.
+
+    [:octicons-arrow-right-24: Research](packs/research.md)
+
+-   **Architect** `user`
+
+    System design. `architect-design`, `architect-diagram`, `architect-review`, `design-reviewer` subagent.
+
+    [:octicons-arrow-right-24: Architect](packs/architect.md)
+
+-   **Experience** `user`
+
+    The full design thread — journey to realization. Journey mapping, screen flows, service blueprints, aesthetic direction, WCAG-aware quality floor.
+
+    [:octicons-arrow-right-24: Experience](packs/experience.md)
+
+-   **Contracts** `user`
+
+    API-first design. `api-contract` for OpenAPI 3.1, `event-contract` for AsyncAPI.
+
+    [:octicons-arrow-right-24: Contracts](packs/contracts.md)
+
+-   **Converters** `user`
+
+    Document conversion. PDF/DOCX/PPTX → Markdown, Markdown → HTML/Word/PowerPoint/Excel, email → Markdown, Mermaid rendering.
+
+    [:octicons-arrow-right-24: Converters](packs/converters.md)
+
+-   **Atlassian** `user`
+
+    Jira and Confluence from the agent. `jira`, `jira-align`, `confluence-crawler`, flow metrics, DORA metrics. SSO-cookie authenticated.
+
+    [:octicons-arrow-right-24: Atlassian](packs/atlassian.md)
+
+-   **Figma** `user`
+
+    Read and render Figma designs. Files, nodes, variables, frame renders, FigJam → Mermaid.
+
+    [:octicons-arrow-right-24: Figma](packs/figma.md)
+
+-   **Governance Extras** `repo`
+
+    Decision trail. `new-rfc`, `new-adr`, `update-conventions`, RFC/ADR ceremony for long-lived repos.
+
+    [:octicons-arrow-right-24: Governance Extras](packs/governance-extras.md)
+
+-   **User Guide (Diataxis)** `repo`
+
+    Docs scaffold. Diátaxis skeleton with `new-guide`.
+
+    [:octicons-arrow-right-24: User Guide Diataxis](packs/user-guide-diataxis.md)
+
+-   **Monorepo Extras** `repo`
+
+    Package scaffolding. `new-package`, example package template.
+
+    [:octicons-arrow-right-24: Monorepo Extras](packs/monorepo-extras.md)
+
+-   **Credential Brokers** `user`
+
+    Credential resolution. Environment variable → OS keyring → dotfile. Cleartext never reaches the model.
+
+    [:octicons-arrow-right-24: Credential Brokers](packs/credential-brokers.md)
+
+</div>
+
+---
+
+## Works with every major agent { #adapters }
+
+One adapter pipeline projects the same skills and subagents into the layout every agent expects.
+
+| Agent | Skills | Subagents | Hooks | Commands |
+|---|---|---|---|---|
+| Claude Code | ✓ | ✓ | ✓ | ✓ |
+| Codex | ✓ | ✓ | ✓ | — |
+| Cursor | ✓ | ✓ | ✓ | — |
+| Copilot | ✓ | ✓ | ✓ | — |
+| Gemini CLI | ✓ | ✓ | ✓ | — |
+| Kiro | ✓ | ✓ | — | — |
+
+---
+
+## Built on solid foundations
+
+<div class="grid" markdown>
+
+<div markdown>
+
+**Harness-agnostic.** One adapter pipeline projects the same primitives into every agent's layout. Switch adapters with one flag.
+
+**Inspectable and forkable.** Skills, subagents, and hooks are files you own — no SDK, runtime, or service to run. Outgrow a default? Edit the file.
+
+</div>
+
+<div markdown>
+
+**Composable.** Packs layer cleanly. Your edits are never silently overwritten — colliding files land as `*.upstream` companions to merge, not clobber.
+
+**Curated by discipline.** Every pack is shaped through practitioner research and RFC-and-ADR governance. Not random defaults — the best available practices encoded as runnable skills.
+
+</div>
+
+</div>
+
+The two pip packages underneath are standalone and useful beyond this repo:
+
+- **[`agentbundle`](https://pypi.org/project/agentbundle/)** — installs and upgrades packs, projects each primitive into the layout every agent expects, and builds catalogues of your own.
+- **[`credbroker`](https://pypi.org/project/credbroker/)** — credential resolution for credentialed skills. Resolves secrets through environment → OS keyring → dotfile. Cleartext never reaches the model.
+
+---
+
+## A foundation to build on
+
+Adopt the catalogue as-is, or fork it as your own. Write your house conventions and review standards into `core`, add skills for your stack, and ship one catalogue every engineer installs in a single line — the loop, the reviewers, and the standards come out identical on every machine and in every agent.
+
+[:octicons-arrow-right-24: How to build your org's catalogue](guides/_shared/how-to/build-an-org-stack-pack.md)

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -8,11 +8,11 @@ hide:
 # The Complete AI Operating Model<br>for Software Teams
 
 Three supervised loops, fourteen curated packs, any agent, any stack — from first idea to production.
-</div>
 
 <div class="hero-actions" markdown>
 [Get started :octicons-arrow-right-24:](getting-started/index.md){ .md-button .md-button--primary .md-button--large }
 [Browse packs :octicons-arrow-right-24:](packs/index.md){ .md-button .md-button--large }
+</div>
 </div>
 
 ## Three supervised loops. One handoff chain.

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -5,13 +5,13 @@ hide:
 ---
 
 <div class="hero-section" markdown>
-# The Complete AI Operating Model<br>for Software Teams
+# Discovery. Build. Release.<br>The full SDLC, agent-driven and supervised.
 
-Three supervised loops, fourteen curated packs, any agent, any stack — from first idea to production.
+An unattended loop makes unattended mistakes. These fourteen packs install hard mechanical gates, cold-read specialist reviewers, and mandatory human checkpoints across the full SDLC — so the agent cannot self-certify its own work.
 
 <div class="hero-actions" markdown>
-[Get started :octicons-arrow-right-24:](getting-started/index.md){ .md-button .md-button--primary .md-button--large }
-[Browse packs :octicons-arrow-right-24:](packs/index.md){ .md-button .md-button--large }
+[Install the core loop :octicons-arrow-right-24:](getting-started/index.md){ .md-button .md-button--primary .md-button--large }
+[See what's inside :octicons-arrow-right-24:](packs/index.md){ .md-button .md-button--large }
 </div>
 </div>
 
@@ -29,7 +29,7 @@ Software delivery needs more than one loop. Three peer supervisors span the full
 
     `product-engineering` · `discovery-lead`
 
-    Raw idea → ratified brief. Five candidate shapes explored in parallel, collapsed through product, UX, architecture, and safety lenses. Human gates at G0, G1.5, G2. A connected hypothesis with validation hooks — not a validated solution.
+    Raw idea → ratified brief. Five candidate shapes explored in parallel, collapsed through product, UX, architecture, and safety lenses. Human consent gates at G0 (go/no-go), G1.5 (shape sign-off), and G2 (brief ratification). A connected hypothesis with validation hooks — not a validated solution.
 
     [:octicons-arrow-right-24: Product Engineering](packs/product-engineering.md)
 
@@ -203,7 +203,8 @@ One adapter pipeline projects the same skills and subagents into the layout ever
 | Cursor | Yes | Yes | Yes | No |
 | Copilot | Yes | Yes | Yes | No |
 | Gemini CLI | Yes | Yes | Yes | No |
-| Kiro | Yes | Yes | No | No |
+| Kiro IDE | Yes | Yes | Yes | No |
+| Kiro CLI | Yes | Yes | Yes | No |
 
 ## Built on solid foundations
 

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -4,20 +4,16 @@ hide:
   - toc
 ---
 
+<div class="hero-section" markdown>
 # The Complete AI Operating Model<br>for Software Teams
 
-**From first idea to production.** Three supervised loops. Fourteen curated packs. Any agent, any stack.
-
-[![PyPI](https://img.shields.io/pypi/v/agentbundle)](https://pypi.org/project/agentbundle/)
-[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](#)
-[![Agents](https://img.shields.io/badge/agents-Claude%20%7C%20Codex%20%7C%20Cursor%20%7C%20Copilot%20%7C%20Gemini%20%7C%20Kiro-purple)](#adapters)
+Three supervised loops, fourteen curated packs, any agent, any stack — from first idea to production.
+</div>
 
 <div class="hero-actions" markdown>
 [Get started :octicons-arrow-right-24:](getting-started/index.md){ .md-button .md-button--primary .md-button--large }
 [Browse packs :octicons-arrow-right-24:](packs/index.md){ .md-button .md-button--large }
 </div>
-
----
 
 ## Three supervised loops. One handoff chain.
 
@@ -33,7 +29,7 @@ Software delivery needs more than one loop. Three peer supervisors span the full
 
     `product-engineering` · `discovery-lead`
 
-    Raw idea → ratified brief. Five candidate shapes explored in parallel, collapsed through product, UX, architecture, and safety lenses simultaneously. Human gates at G0, G1.5, G2. A **connected hypothesis with validation hooks** — not a validated solution.
+    Raw idea → ratified brief. Five candidate shapes explored in parallel, collapsed through product, UX, architecture, and safety lenses. Human gates at G0, G1.5, G2. A connected hypothesis with validation hooks — not a validated solution.
 
     [:octicons-arrow-right-24: Product Engineering](packs/product-engineering.md)
 
@@ -53,7 +49,7 @@ Software delivery needs more than one loop. Three peer supervisors span the full
 
     `release-engineering` · `release-lead`
 
-    Built → production. Autonomous e2e convergence on ephemeral environments. Deployed findings feed back to the build loop automatically. Prod ship always surfaces to a human — **G5 is never autonomous**.
+    Built → production. Autonomous e2e convergence on ephemeral environments. Deployed findings feed back to the build loop automatically. Prod ship always surfaces to a human — G5 is never autonomous.
 
     [:octicons-arrow-right-24: Release Engineering](packs/release-engineering.md)
 
@@ -65,8 +61,6 @@ product-engineering           core                    release-engineering
 discovery-lead                work-loop               release-lead
 Raw idea → Brief       ─G3─▶  Spec → Shipped   ─G4─▶  Built → Production
 ```
-
----
 
 ## Install in one line
 
@@ -98,11 +92,11 @@ Raw idea → Brief       ─G3─▶  Spec → Shipped   ─G4─▶  Built → 
 
 One command lands the loop in your repo. Any agent that reads a skill file inherits it automatically.
 
----
-
 ## The catalogue
 
-Fourteen curated packs — each distilled from the best practices of its discipline through research and architecture decisions.
+Fourteen curated packs — each distilled from the best practices of its discipline through research and architecture decisions. `repo` packs install into the current repository; `user` packs install once for all repos.
+
+**Start with the loops:**
 
 <div class="grid cards" markdown>
 
@@ -123,6 +117,12 @@ Fourteen curated packs — each distilled from the best practices of its discipl
     The release loop. `release-loop`, `release-lead`. Autonomous e2e convergence. Hard-depends on core.
 
     [:octicons-arrow-right-24: Release Engineering](packs/release-engineering.md)
+
+</div>
+
+**Add what your team needs:**
+
+<div class="grid cards" markdown>
 
 -   **Research** `user`
 
@@ -192,22 +192,18 @@ Fourteen curated packs — each distilled from the best practices of its discipl
 
 </div>
 
----
-
 ## Works with every major agent { #adapters }
 
 One adapter pipeline projects the same skills and subagents into the layout every agent expects.
 
 | Agent | Skills | Subagents | Hooks | Commands |
 |---|---|---|---|---|
-| Claude Code | ✓ | ✓ | ✓ | ✓ |
-| Codex | ✓ | ✓ | ✓ | — |
-| Cursor | ✓ | ✓ | ✓ | — |
-| Copilot | ✓ | ✓ | ✓ | — |
-| Gemini CLI | ✓ | ✓ | ✓ | — |
-| Kiro | ✓ | ✓ | — | — |
-
----
+| Claude Code | Yes | Yes | Yes | Yes |
+| Codex | Yes | Yes | Yes | No |
+| Cursor | Yes | Yes | Yes | No |
+| Copilot | Yes | Yes | Yes | No |
+| Gemini CLI | Yes | Yes | Yes | No |
+| Kiro | Yes | Yes | No | No |
 
 ## Built on solid foundations
 
@@ -235,8 +231,6 @@ The two pip packages underneath are standalone and useful beyond this repo:
 
 - **[`agentbundle`](https://pypi.org/project/agentbundle/)** — installs and upgrades packs, projects each primitive into the layout every agent expects, and builds catalogues of your own.
 - **[`credbroker`](https://pypi.org/project/credbroker/)** — credential resolution for credentialed skills. Resolves secrets through environment → OS keyring → dotfile. Cleartext never reaches the model.
-
----
 
 ## A foundation to build on
 

--- a/site/docs/stylesheets/extra.css
+++ b/site/docs/stylesheets/extra.css
@@ -1,21 +1,55 @@
-/* ── Hero landing page ─────────────────────────────────────────────────── */
+/* ── Hero section ───────────────────────────────────────────────────────── */
+
+.hero-section {
+  padding: 2rem 0 0.5rem;
+}
+
+.hero-section h1 {
+  font-size: 2.4rem;
+  font-weight: 700;
+  line-height: 1.15;
+  letter-spacing: -0.025em;
+  margin-bottom: 0.75rem;
+}
+
+.hero-section p {
+  font-size: 1.075rem;
+  color: var(--md-default-fg-color--light);
+  margin-bottom: 0;
+  line-height: 1.6;
+}
+
+/* ── Hero CTA buttons ───────────────────────────────────────────────────── */
 
 .hero-actions {
-  margin: 1.5rem 0 2rem;
+  margin: 1.75rem 0 2.5rem;
   display: flex;
   gap: 0.75rem;
   flex-wrap: wrap;
 }
 
-/* Large button variant */
 .md-button--large {
   padding: 0.75rem 1.75rem;
   font-size: 1rem;
 }
 
-/* Landing page: wider content area, no sidebar clutter */
+/* Explicit focus-visible for custom-styled interactive elements */
+.hero-actions .md-button:focus-visible {
+  outline: 3px solid var(--md-accent-fg-color);
+  outline-offset: 3px;
+}
+
+/* ── Page content width ─────────────────────────────────────────────────── */
+
 [data-md-color-scheme] .md-content__inner {
   max-width: 900px;
+}
+
+/* ── Section rhythm ─────────────────────────────────────────────────────── */
+
+.md-typeset h2 {
+  margin-top: 3rem;
+  letter-spacing: -0.015em;
 }
 
 /* ── Pack catalogue cards ──────────────────────────────────────────────── */
@@ -66,29 +100,25 @@
   font-weight: 600;
 }
 
-/* ── Scope badges inline ───────────────────────────────────────────────── */
-
-.scope-badge {
-  display: inline-block;
-  padding: 0.1em 0.5em;
-  border-radius: 4px;
-  font-size: 0.75em;
-  font-weight: 600;
-  font-family: var(--md-code-font-family);
-  background: var(--md-accent-fg-color--transparent);
-  color: var(--md-accent-fg-color);
-  vertical-align: middle;
-  margin-left: 0.25em;
-}
-
-/* ── Home page section headings ────────────────────────────────────────── */
-
-.md-typeset h2 {
-  margin-top: 2.5rem;
-}
-
 /* ── Announcement bar (optional) ────────────────────────────────────────── */
 
 .md-banner {
   font-size: 0.875rem;
+}
+
+/* ── Reduce-motion: honour system preference ────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .grid.cards > ul > li,
+  .grid.cards > ol > li {
+    transition: none;
+  }
+  /* Neutralise position shift on hover — use shadow-only affordance */
+  .grid.cards > ul > li:hover,
+  .grid.cards > ol > li:hover,
+  [data-md-color-scheme="slate"] .grid.cards > ul > li:hover,
+  [data-md-color-scheme="slate"] .grid.cards > ol > li:hover {
+    transform: none;
+    box-shadow: 0 0 0 2px var(--md-primary-fg-color);
+  }
 }

--- a/site/docs/stylesheets/extra.css
+++ b/site/docs/stylesheets/extra.css
@@ -1,25 +1,94 @@
-/* ── Hero section ───────────────────────────────────────────────────────── */
+/* ── Design tokens ──────────────────────────────────────────────────────── */
+/*
+ * Visual voice: deep indigo surface for hero, single chromatic accent
+ * (indigo-500), border-not-shadow cards, display-scale type.
+ * Dark mode uses a surface ladder (4 steps) not a flat dark gray.
+ * Reference: Linear/Vercel/Wicked-Estate pattern — one non-neutral
+ * move; everything else neutral and restrained.
+ */
+
+/* ── Dark mode surface ladder ───────────────────────────────────────────── */
+
+[data-md-color-scheme="slate"] {
+  --md-default-bg-color:            #0f1011;  /* surface-0: page canvas */
+  --md-code-bg-color:               #141516;  /* surface-1: raised code blocks */
+  --md-default-fg-color--lightest:  rgba(255, 255, 255, 0.07);
+  --md-default-fg-color--lighter:   rgba(255, 255, 255, 0.16);
+}
+
+/* ── Hero section — dark panel with grid texture ────────────────────────── */
 
 .hero-section {
-  padding: 2rem 0 0.5rem;
+  background-color: #0f172a;
+  background-image:
+    radial-gradient(ellipse 80% 55% at 50% -5%, rgba(99, 102, 241, 0.22) 0%, transparent 60%),
+    linear-gradient(rgba(255, 255, 255, 0.038) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.038) 1px, transparent 1px);
+  background-size: 100% 100%, 28px 28px, 28px 28px;
+  border-radius: 16px;
+  padding: 4.5rem 3rem 3.5rem;
+  margin-bottom: 3.5rem;
+  color: #f8fafc;
 }
 
 .hero-section h1 {
-  font-size: 2.4rem;
+  color: #f8fafc;
+  font-size: clamp(2.4rem, 5vw, 3.75rem);
   font-weight: 700;
-  line-height: 1.15;
-  letter-spacing: -0.025em;
-  margin-bottom: 0.75rem;
+  line-height: 1.1;
+  letter-spacing: -0.028em;
+  margin-bottom: 1rem;
 }
 
 .hero-section p {
-  font-size: 1.075rem;
-  color: var(--md-default-fg-color--light);
-  margin-bottom: 0;
+  color: rgba(248, 250, 252, 0.65);
+  font-size: 1.1rem;
   line-height: 1.6;
+  margin-bottom: 0;
+  max-width: 580px;
 }
 
-/* ── Hero CTA buttons ───────────────────────────────────────────────────── */
+/* ── Hero CTA buttons — inverted for dark context ───────────────────────── */
+
+.hero-section .hero-actions {
+  margin-top: 2rem;
+  margin-bottom: 0;
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.hero-section .md-button--primary {
+  background-color: #f8fafc !important;
+  color: #0f172a !important;
+  border-color: #f8fafc !important;
+  font-weight: 600;
+}
+
+.hero-section .md-button--primary:hover {
+  background-color: #e2e8f0 !important;
+  border-color: #e2e8f0 !important;
+}
+
+.hero-section .md-button:not(.md-button--primary) {
+  background-color: transparent !important;
+  border-color: rgba(248, 250, 252, 0.25) !important;
+  color: rgba(248, 250, 252, 0.8) !important;
+}
+
+.hero-section .md-button:not(.md-button--primary):hover {
+  background-color: rgba(248, 250, 252, 0.08) !important;
+  border-color: rgba(248, 250, 252, 0.45) !important;
+  color: #f8fafc !important;
+}
+
+/* Explicit focus-visible for hero buttons */
+.hero-section .md-button:focus-visible {
+  outline: 3px solid rgba(248, 250, 252, 0.7);
+  outline-offset: 3px;
+}
+
+/* ── Standalone hero-actions (outside hero-section, kept for non-hero pages) */
 
 .hero-actions {
   margin: 1.75rem 0 2.5rem;
@@ -31,12 +100,6 @@
 .md-button--large {
   padding: 0.75rem 1.75rem;
   font-size: 1rem;
-}
-
-/* Explicit focus-visible for custom-styled interactive elements */
-.hero-actions .md-button:focus-visible {
-  outline: 3px solid var(--md-accent-fg-color);
-  outline-offset: 3px;
 }
 
 /* ── Page content width ─────────────────────────────────────────────────── */
@@ -52,23 +115,33 @@
   letter-spacing: -0.015em;
 }
 
-/* ── Pack catalogue cards ──────────────────────────────────────────────── */
+/* ── Cards — border-not-shadow; border reveals on hover ─────────────────── */
 
 .grid.cards > ul > li,
 .grid.cards > ol > li {
-  border-radius: 8px;
-  transition: box-shadow 0.15s ease, transform 0.1s ease;
+  border-radius: 10px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  box-shadow: none;
+  transition: border-color 150ms ease, transform 100ms ease, box-shadow 150ms ease;
 }
 
 .grid.cards > ul > li:hover,
 .grid.cards > ol > li:hover {
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
-  transform: translateY(-1px);
+  border-color: var(--md-primary-fg-color);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 16px rgba(63, 81, 181, 0.12);
+}
+
+[data-md-color-scheme="slate"] .grid.cards > ul > li,
+[data-md-color-scheme="slate"] .grid.cards > ol > li {
+  border-color: rgba(255, 255, 255, 0.07);
+  background: #141516;
 }
 
 [data-md-color-scheme="slate"] .grid.cards > ul > li:hover,
 [data-md-color-scheme="slate"] .grid.cards > ol > li:hover {
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  border-color: rgba(99, 102, 241, 0.4);
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.5);
 }
 
 /* ── Code blocks ───────────────────────────────────────────────────────── */
@@ -100,20 +173,19 @@
   font-weight: 600;
 }
 
-/* ── Announcement bar (optional) ────────────────────────────────────────── */
+/* ── Announcement bar ────────────────────────────────────────────────────── */
 
 .md-banner {
   font-size: 0.875rem;
 }
 
-/* ── Reduce-motion: honour system preference ────────────────────────────── */
+/* ── Reduce-motion — honour system preference ────────────────────────────── */
 
 @media (prefers-reduced-motion: reduce) {
   .grid.cards > ul > li,
   .grid.cards > ol > li {
     transition: none;
   }
-  /* Neutralise position shift on hover — use shadow-only affordance */
   .grid.cards > ul > li:hover,
   .grid.cards > ol > li:hover,
   [data-md-color-scheme="slate"] .grid.cards > ul > li:hover,

--- a/site/docs/stylesheets/extra.css
+++ b/site/docs/stylesheets/extra.css
@@ -1,33 +1,153 @@
-/* ── Design tokens ──────────────────────────────────────────────────────── */
 /*
- * Visual voice: deep indigo surface for hero, single chromatic accent
- * (indigo-500), border-not-shadow cards, display-scale type.
- * Dark mode uses a surface ladder (4 steps) not a flat dark gray.
- * Reference: Linear/Vercel/Wicked-Estate pattern — one non-neutral
- * move; everything else neutral and restrained.
+ * ═══════════════════════════════════════════════════════════════════════════
+ * DESIGN SYSTEM — COLOR TOKEN ROLES
+ * ═══════════════════════════════════════════════════════════════════════════
+ *
+ * Each token has ONE zone. Using a token outside its zone is a design error.
+ *
+ * DARK ZONE (#0f172a)  — navbar, tabs, hero ONLY. Never in content area.
+ * SURFACE-0 (#ffffff)  — page background.
+ * SURFACE-1 (#f8fafc)  — card backgrounds, slightly lifted off white.
+ * SURFACE-2 (#f0f4f8)  — table headers, more elevated neutral areas.
+ * ACCENT    (#5e6ad2)  — ONE chromatic color: links, focus rings, hover
+ *                        borders, primary CTA on light bg. Never large fills.
+ * TEXT-HIGH  (#1a202c) — headings, primary labels.
+ * TEXT-MID   (rgba(0,0,0,0.72)) — body, secondary labels.
+ * TEXT-LOW   (rgba(0,0,0,0.45)) — muted, captions.
+ *
+ * DARK MODE equivalents:
+ * SURFACE-0  (#0f1011), SURFACE-1 (#141516), ACCENT (#818cf8)
+ *
+ * Rubrics applied:
+ * 1. Navbar-hero cohesion — header and hero share the DARK ZONE (#0f172a).
+ *    Generic indigo header = template tell.
+ * 2. Hero full-bleed — 100vw negative margin, no border-radius.
+ *    Card-hero = document; full-bleed = product.
+ * 3. Content area lift — cards use SURFACE-1, table headers use SURFACE-2.
+ *    DARK ZONE never appears in the content area.
+ * 4. One accent, neutral everything else — ACCENT resolves through CSS custom
+ *    properties so Material's own components inherit it.
+ * 5. Surface ladder (dark mode) — 3+ elevation steps, not flat dark gray.
+ * ═══════════════════════════════════════════════════════════════════════════
  */
+
+/* ── Accent token — single source of truth ──────────────────────────────── */
+/*
+ * MkDocs Material resolves links and focus rings through --md-accent-fg-color
+ * and --md-typeset-a-color. Without these overrides, Material's default
+ * indigo/cyan (from mkdocs.yml palette) would leak into body links, focus
+ * rings, and the active-nav marker — violating Rubric 4.
+ */
+
+:root,
+[data-md-color-scheme="default"] {
+  --md-accent-fg-color:              #5e6ad2;
+  --md-accent-fg-color--transparent: rgba(94, 106, 210, 0.1);
+  --md-typeset-a-color:              #5e6ad2;
+}
 
 /* ── Dark mode surface ladder ───────────────────────────────────────────── */
 
 [data-md-color-scheme="slate"] {
-  --md-default-bg-color:            #0f1011;  /* surface-0: page canvas */
-  --md-code-bg-color:               #141516;  /* surface-1: raised code blocks */
+  --md-default-bg-color:            #0f1011;
+  --md-code-bg-color:               #141516;
   --md-default-fg-color--lightest:  rgba(255, 255, 255, 0.07);
   --md-default-fg-color--lighter:   rgba(255, 255, 255, 0.16);
+  /* Slightly lighter on dark surface for 4.5:1 contrast */
+  --md-accent-fg-color:              #818cf8;
+  --md-accent-fg-color--transparent: rgba(129, 140, 248, 0.1);
+  --md-typeset-a-color:              #818cf8;
 }
 
-/* ── Hero section — dark panel with grid texture ────────────────────────── */
+/* ── Header: dark unified zone matching the hero ────────────────────────── */
+/*
+ * Rubric: the navbar is the first thing the eye hits. Generic Material blue
+ * announces "template." Dark header (#0f172a) creates navbar-hero cohesion —
+ * the dark zone extends from top of page to end of hero.
+ */
+
+.md-header {
+  background-color: #0f172a !important;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.md-header .md-header__title {
+  color: #f8fafc;
+}
+
+.md-header .md-header__button,
+.md-header .md-header-nav__button {
+  color: rgba(248, 250, 252, 0.85);
+}
+
+.md-header .md-header__button:hover {
+  color: #f8fafc;
+}
+
+/* Search input in dark header */
+.md-header .md-search__input {
+  background-color: rgba(255, 255, 255, 0.1);
+  color: rgba(248, 250, 252, 0.9);
+  border-radius: 6px;
+}
+
+.md-header .md-search__input::placeholder {
+  color: rgba(248, 250, 252, 0.45);
+}
+
+/* Nav tabs — same dark zone as the header */
+.md-tabs {
+  background-color: #0f172a !important;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.md-tabs .md-tabs__item {
+  color: rgba(248, 250, 252, 0.65);
+}
+
+.md-tabs .md-tabs__item--active,
+.md-tabs .md-tabs__link--active {
+  color: #f8fafc;
+}
+
+.md-tabs .md-tabs__link:hover {
+  color: #f8fafc;
+  opacity: 1;
+}
+
+/* ── Hero section — full-bleed dark panel ───────────────────────────────── */
+/*
+ * Rubric: full-bleed (100vw negative margin) signals "product site hero."
+ * A card floating on white signals "section in a document." No border-radius.
+ * Grid texture (28px, 4% opacity lines) + radial glow from accent: the
+ * "one non-neutral move" that separates leading from traditional.
+ */
 
 .hero-section {
+  /* Full-bleed: break out of the 900px content container */
+  width: 100vw;
+  position: relative;
+  left: 50%;
+  right: 50%;
+  margin-left: -50vw;
+  margin-right: -50vw;
+  box-sizing: border-box;
+
+  /* Horizontally center the inner content column */
+  padding-top: 5rem;
+  padding-bottom: 4.5rem;
+  padding-left: max(2rem, calc(50vw - 450px));
+  padding-right: max(2rem, calc(50vw - 450px));
+
+  /* Visual treatment */
   background-color: #0f172a;
   background-image:
-    radial-gradient(ellipse 80% 55% at 50% -5%, rgba(99, 102, 241, 0.22) 0%, transparent 60%),
+    radial-gradient(ellipse 70% 60% at 50% 0%, rgba(94, 106, 210, 0.2) 0%, transparent 65%),
     linear-gradient(rgba(255, 255, 255, 0.038) 1px, transparent 1px),
     linear-gradient(90deg, rgba(255, 255, 255, 0.038) 1px, transparent 1px);
   background-size: 100% 100%, 28px 28px, 28px 28px;
-  border-radius: 16px;
-  padding: 4.5rem 3rem 3.5rem;
-  margin-bottom: 3.5rem;
+  border-radius: 0;
+  margin-bottom: 4rem;
   color: #f8fafc;
 }
 
@@ -37,21 +157,22 @@
   font-weight: 700;
   line-height: 1.1;
   letter-spacing: -0.028em;
-  margin-bottom: 1rem;
+  margin-bottom: 1.25rem;
+  max-width: 800px;
 }
 
 .hero-section p {
   color: rgba(248, 250, 252, 0.65);
   font-size: 1.1rem;
-  line-height: 1.6;
+  line-height: 1.65;
   margin-bottom: 0;
-  max-width: 580px;
+  max-width: 620px;
 }
 
 /* ── Hero CTA buttons — inverted for dark context ───────────────────────── */
 
 .hero-section .hero-actions {
-  margin-top: 2rem;
+  margin-top: 2.25rem;
   margin-bottom: 0;
   display: flex;
   gap: 0.75rem;
@@ -82,13 +203,12 @@
   color: #f8fafc !important;
 }
 
-/* Explicit focus-visible for hero buttons */
 .hero-section .md-button:focus-visible {
   outline: 3px solid rgba(248, 250, 252, 0.7);
   outline-offset: 3px;
 }
 
-/* ── Standalone hero-actions (outside hero-section, kept for non-hero pages) */
+/* ── Standalone hero-actions (outside hero-section) ─────────────────────── */
 
 .hero-actions {
   margin: 1.75rem 0 2.5rem;
@@ -103,44 +223,127 @@
 }
 
 /* ── Page content width ─────────────────────────────────────────────────── */
+/*
+ * Center the article in the grid column (margin: auto) instead of Material's
+ * default left-aligned margin: 0 .8rem. This is required for the hero's
+ * full-bleed math to work: the negative-margin trick assumes the article is
+ * symmetrically centered in the viewport; left-aligned layout breaks it.
+ * Without centering, the hero undershoots the right edge by ~.8rem.
+ */
 
-[data-md-color-scheme] .md-content__inner {
+.md-content__inner {
   max-width: 900px;
+  margin-left: auto !important;
+  margin-right: auto !important;
+}
+
+/* Remove ALL top spacing when the page starts with a full-bleed hero,
+ * so the dark zone is continuous from navbar bottom to hero bottom.
+ * Three layers to cancel: md-main__inner padding, md-content__inner padding,
+ * and any residual via a negative margin on the hero itself. */
+
+/* Layer 1 — .md-main__inner has padding-top: 1.2rem by default */
+.md-main:has(.hero-section) > .md-main__inner {
+  padding-top: 0;
+}
+
+/* Layer 2 — .md-content__inner (the article) also has padding-top */
+article.md-content__inner:has(> .hero-section) {
+  padding-top: 0;
+}
+
+/* Layer 3 — belt-and-suspenders negative margin in case :has() misses */
+.md-content__inner > .hero-section {
+  margin-top: -1.5rem;
+}
+
+/* ── Mobile — hero scale ────────────────────────────────────────────────── */
+
+@media (max-width: 600px) {
+  .hero-section {
+    padding-top: 3rem;
+    padding-bottom: 3rem;
+  }
+
+  .hero-section h1 {
+    font-size: clamp(1.9rem, 8vw, 2.6rem);
+    letter-spacing: -0.02em;
+    line-height: 1.15;
+  }
+
+  .hero-section p {
+    font-size: 1rem;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .md-button--large {
+    padding: 0.65rem 1.4rem;
+    font-size: 0.95rem;
+    width: 100%;
+    text-align: center;
+    box-sizing: border-box;
+  }
+}
+
+/* Code blocks in the handoff diagram — prevent horizontal overflow on mobile */
+.md-typeset pre {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 /* ── Section rhythm ─────────────────────────────────────────────────────── */
+/*
+ * Material 9.x applies a bottom-border separator on h2 using
+ * --md-default-fg-color--lightest. On a white background this is acceptable,
+ * but the aesthetic direction (Vercel/Linear) uses whitespace — not rules —
+ * as section separators. Remove the border; the 3rem top-margin provides rhythm.
+ */
 
 .md-typeset h2 {
   margin-top: 3rem;
   letter-spacing: -0.015em;
+  border-bottom: none;
+  padding-bottom: 0;
 }
 
-/* ── Cards — border-not-shadow; border reveals on hover ─────────────────── */
+/* ── Cards — lifted tint + border reveal on hover ───────────────────────── */
+/*
+ * Rubric: cards on pure white have no visual weight (same plane as background).
+ * A tinted background (#f8fafc) lifts the card. Border (not shadow) names the
+ * card edge precisely. On hover: border brightens to the accent color (#5e6ad2).
+ * Shadow reserved for elevated overlays (modals, dropdowns), never cards.
+ */
 
 .grid.cards > ul > li,
 .grid.cards > ol > li {
+  background: #f8fafc;
   border-radius: 10px;
-  border: 1px solid rgba(0, 0, 0, 0.08);
+  border: 1px solid rgba(0, 0, 0, 0.09);
   box-shadow: none;
-  transition: border-color 150ms ease, transform 100ms ease, box-shadow 150ms ease;
+  transition: border-color 150ms ease, transform 100ms ease;
 }
 
 .grid.cards > ul > li:hover,
 .grid.cards > ol > li:hover {
-  border-color: var(--md-primary-fg-color);
+  border-color: #5e6ad2;
   transform: translateY(-2px);
-  box-shadow: 0 4px 16px rgba(63, 81, 181, 0.12);
+  box-shadow: 0 4px 16px rgba(94, 106, 210, 0.12);
 }
 
 [data-md-color-scheme="slate"] .grid.cards > ul > li,
 [data-md-color-scheme="slate"] .grid.cards > ol > li {
-  border-color: rgba(255, 255, 255, 0.07);
   background: #141516;
+  border-color: rgba(255, 255, 255, 0.07);
+  box-shadow: none;
 }
 
 [data-md-color-scheme="slate"] .grid.cards > ul > li:hover,
 [data-md-color-scheme="slate"] .grid.cards > ol > li:hover {
-  border-color: rgba(99, 102, 241, 0.4);
+  border-color: rgba(94, 106, 210, 0.5);
   box-shadow: 0 4px 24px rgba(0, 0, 0, 0.5);
 }
 
@@ -155,6 +358,28 @@
   line-height: 1.6;
 }
 
+/* ── Inline code inside cards — accent-tinted chip ──────────────────────── */
+/*
+ * Design system rule: inline code in cards (scope tags like `user`/`repo`,
+ * skill names like `work-loop`) uses a subtle ACCENT fill so these chips
+ * read as an intentional design element, not the default gray code style.
+ * Keeps the one-accent rule: same #5e6ad2 family, 7% opacity fill.
+ */
+
+.grid.cards > ul > li code,
+.grid.cards > ol > li code {
+  background: rgba(94, 106, 210, 0.07);
+  color: #3a4ab8;
+  font-size: 0.78rem;
+  border-radius: 4px;
+}
+
+[data-md-color-scheme="slate"] .grid.cards > ul > li code,
+[data-md-color-scheme="slate"] .grid.cards > ol > li code {
+  background: rgba(129, 140, 248, 0.1);
+  color: #a5b4fc;
+}
+
 /* ── Navigation ────────────────────────────────────────────────────────── */
 
 .md-nav__title {
@@ -162,15 +387,26 @@
 }
 
 /* ── Tables ────────────────────────────────────────────────────────────── */
+/*
+ * Table headers use a light neutral tint — the same family as cards (#f8fafc).
+ * Dark navy (#0f172a) belongs only in the navbar/hero zone, not the content area.
+ */
 
 .md-typeset table:not([class]) {
   font-size: 0.875rem;
 }
 
 .md-typeset table:not([class]) th {
-  background-color: var(--md-primary-fg-color);
-  color: var(--md-primary-bg-color);
+  background-color: #f0f4f8;
+  color: #1a202c;
   font-weight: 600;
+  border-bottom: 2px solid #e2e8f0;
+}
+
+[data-md-color-scheme="slate"] .md-typeset table:not([class]) th {
+  background-color: #141516;
+  color: rgba(248, 250, 252, 0.87);
+  border-bottom: 2px solid rgba(255, 255, 255, 0.08);
 }
 
 /* ── Announcement bar ────────────────────────────────────────────────────── */
@@ -179,7 +415,7 @@
   font-size: 0.875rem;
 }
 
-/* ── Reduce-motion — honour system preference ────────────────────────────── */
+/* ── Reduce-motion: honour system preference ────────────────────────────── */
 
 @media (prefers-reduced-motion: reduce) {
   .grid.cards > ul > li,
@@ -191,6 +427,7 @@
   [data-md-color-scheme="slate"] .grid.cards > ul > li:hover,
   [data-md-color-scheme="slate"] .grid.cards > ol > li:hover {
     transform: none;
-    box-shadow: 0 0 0 2px var(--md-primary-fg-color);
+    box-shadow: none;
+    border-color: #5e6ad2;
   }
 }

--- a/site/docs/stylesheets/extra.css
+++ b/site/docs/stylesheets/extra.css
@@ -1,0 +1,94 @@
+/* ── Hero landing page ─────────────────────────────────────────────────── */
+
+.hero-actions {
+  margin: 1.5rem 0 2rem;
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+/* Large button variant */
+.md-button--large {
+  padding: 0.75rem 1.75rem;
+  font-size: 1rem;
+}
+
+/* Landing page: wider content area, no sidebar clutter */
+[data-md-color-scheme] .md-content__inner {
+  max-width: 900px;
+}
+
+/* ── Pack catalogue cards ──────────────────────────────────────────────── */
+
+.grid.cards > ul > li,
+.grid.cards > ol > li {
+  border-radius: 8px;
+  transition: box-shadow 0.15s ease, transform 0.1s ease;
+}
+
+.grid.cards > ul > li:hover,
+.grid.cards > ol > li:hover {
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  transform: translateY(-1px);
+}
+
+[data-md-color-scheme="slate"] .grid.cards > ul > li:hover,
+[data-md-color-scheme="slate"] .grid.cards > ol > li:hover {
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+}
+
+/* ── Code blocks ───────────────────────────────────────────────────────── */
+
+.md-typeset code {
+  border-radius: 4px;
+}
+
+.md-typeset pre > code {
+  font-size: 0.85rem;
+  line-height: 1.6;
+}
+
+/* ── Navigation ────────────────────────────────────────────────────────── */
+
+.md-nav__title {
+  font-weight: 700;
+}
+
+/* ── Tables ────────────────────────────────────────────────────────────── */
+
+.md-typeset table:not([class]) {
+  font-size: 0.875rem;
+}
+
+.md-typeset table:not([class]) th {
+  background-color: var(--md-primary-fg-color);
+  color: var(--md-primary-bg-color);
+  font-weight: 600;
+}
+
+/* ── Scope badges inline ───────────────────────────────────────────────── */
+
+.scope-badge {
+  display: inline-block;
+  padding: 0.1em 0.5em;
+  border-radius: 4px;
+  font-size: 0.75em;
+  font-weight: 600;
+  font-family: var(--md-code-font-family);
+  background: var(--md-accent-fg-color--transparent);
+  color: var(--md-accent-fg-color);
+  vertical-align: middle;
+  margin-left: 0.25em;
+}
+
+/* ── Home page section headings ────────────────────────────────────────── */
+
+.md-typeset h2 {
+  margin-top: 2.5rem;
+}
+
+/* ── Announcement bar (optional) ────────────────────────────────────────── */
+
+.md-banner {
+  font-size: 0.875rem;
+}

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -1,0 +1,285 @@
+site_name: agent-ready-repo
+site_description: The complete AI operating model for software teams — from first idea to production.
+site_url: https://eugenelim.github.io/agent-ready-repo/
+repo_url: https://github.com/eugenelim/agent-ready-repo
+repo_name: eugenelim/agent-ready-repo
+edit_uri: ""
+
+docs_dir: docs
+site_dir: built
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: cyan
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: cyan
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+  font:
+    text: Inter
+    code: JetBrains Mono
+  features:
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.sections
+    - navigation.indexes
+    - navigation.top
+    - navigation.footer
+    - search.suggest
+    - search.highlight
+    - search.share
+    - content.code.copy
+    - content.code.annotate
+    - content.tabs.link
+    - toc.follow
+  icon:
+    repo: fontawesome/brands/github
+    logo: material/robot-outline
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/eugenelim/agent-ready-repo
+    - icon: fontawesome/brands/python
+      link: https://pypi.org/project/agentbundle/
+  generator: false
+
+extra_css:
+  - stylesheets/extra.css
+
+plugins:
+  - search:
+      lang: en
+  - minify:
+      minify_html: true
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+      title: On this page
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.critic
+  - pymdownx.caret
+  - pymdownx.keys
+  - pymdownx.mark
+  - pymdownx.tilde
+  - pymdownx.snippets
+
+nav:
+  - Home: index.md
+  - Get Started:
+    - getting-started/index.md
+    - Install: getting-started/install.md
+    - The Three Loops: getting-started/three-loops.md
+  - Packs:
+    - packs/index.md
+    - "Core — Build Loop": packs/core.md
+    - "Product Engineering": packs/product-engineering.md
+    - "Release Engineering": packs/release-engineering.md
+    - Research: packs/research.md
+    - Architect: packs/architect.md
+    - Experience: packs/experience.md
+    - Contracts: packs/contracts.md
+    - Converters: packs/converters.md
+    - Atlassian: packs/atlassian.md
+    - Figma: packs/figma.md
+    - "Governance Extras": packs/governance-extras.md
+    - "User Guide Diataxis": packs/user-guide-diataxis.md
+    - "Monorepo Extras": packs/monorepo-extras.md
+    - "Credential Brokers": packs/credential-brokers.md
+  - Guides:
+    - guides/README.md
+    - "The Build Loop (core)":
+      - guides/core/README.md
+      - Explanation:
+        - The Core Pack: guides/core/explanation/core-pack.md
+        - Foundation vs Map: guides/core/explanation/foundation-vs-map.md
+        - Token Economy: guides/core/explanation/token-economy.md
+        - Walking Skeleton: guides/core/explanation/walking-skeleton-vs-throwaway.md
+        - Why a Brief Layer: guides/core/explanation/why-a-brief-layer.md
+        - Why the Plan Owns LLD: guides/core/explanation/why-the-plan-owns-the-lld.md
+      - How-to:
+        - Adapt to Project: guides/core/how-to/adapt-to-project.md
+        - Bug Fix: guides/core/how-to/bug-fix.md
+        - Plan and Execute: guides/core/how-to/plan-and-execute-non-trivial-work.md
+        - Receive a Brief: guides/core/how-to/receive-a-product-brief-and-decompose-it-into-specs.md
+        - Record Foundation: guides/core/how-to/record-your-foundation-during-inception.md
+        - Review a PR: guides/core/how-to/review-someone-elses-pr.md
+      - Reference:
+        - Product Brief Fields: guides/core/reference/product-brief-fields.md
+        - Spec Shape & LLD: guides/core/reference/spec-shape-and-lld.md
+      - Tutorials:
+        - Start a New Project: guides/core/tutorials/start-a-new-project.md
+    - "Product Discovery":
+      - guides/product-engineering/README.md
+      - Explanation:
+        - The Discovery Loop: guides/product-engineering/explanation/the-discovery-loop.md
+        - The Intent Tree: guides/product-engineering/explanation/the-intent-tree.md
+      - How-to:
+        - Frame a Product Vision: guides/product-engineering/how-to/frame-a-product-vision.md
+        - Run a Discovery: guides/product-engineering/how-to/run-a-discovery.md
+        - Shape a Feature Intent: guides/product-engineering/how-to/shape-a-feature-intent.md
+        - Shape a Product Strategy: guides/product-engineering/how-to/shape-a-product-strategy.md
+        - Run a Value Stream: guides/product-engineering/how-to/run-a-capability-across-a-value-stream.md
+        - Write Microcopy: guides/product-engineering/how-to/write-product-microcopy.md
+      - Reference:
+        - Sidecar & Roster: guides/product-engineering/reference/discovery-sidecar-and-roster.md
+        - Intent Fields: guides/product-engineering/reference/intent-fields-and-modes.md
+      - Tutorials:
+        - Walk a Discovery: guides/product-engineering/tutorials/walk-a-discovery-end-to-end.md
+    - "Release Engineering":
+      - guides/release-engineering/README.md
+      - Explanation:
+        - The Release Loop: guides/release-engineering/explanation/the-release-loop.md
+      - How-to:
+        - Run a Release: guides/release-engineering/how-to/run-a-release.md
+      - Reference:
+        - Readiness Record: guides/release-engineering/reference/release-readiness-record.md
+      - Tutorials:
+        - Your First Release: guides/release-engineering/tutorials/your-first-release.md
+    - Research:
+      - guides/research/README.md
+      - Explanation:
+        - Episodic vs Project: guides/research/explanation/episodic-vs-project-research.md
+        - Research Methodology: guides/research/explanation/research-methodology.md
+      - How-to:
+        - Research Pipelines: guides/research/how-to/research-pipelines.md
+        - Research into an RFC: guides/research/how-to/run-a-research-project-into-an-rfc.md
+      - Reference:
+        - Research Pack: guides/research/reference/research-pack.md
+      - Tutorials:
+        - First Research Session: guides/research/tutorials/research-first-session.md
+        - First Research Project: guides/research/tutorials/your-first-research-project.md
+    - Architect:
+      - guides/architect/README.md
+      - How-to:
+        - Diagram a System: guides/architect/how-to/diagram-a-system.md
+        - Establish Reference Architecture: guides/architect/how-to/establish-reference-architecture.md
+        - Review an Architecture: guides/architect/how-to/review-an-architecture-artifact.md
+        - Shape a Concept: guides/architect/how-to/shape-an-architecture-concept.md
+      - Reference:
+        - Reference Architecture: guides/architect/reference/reference-architecture.md
+      - Tutorials:
+        - Create Reference Arch: guides/architect/tutorials/create-your-reference-architecture.md
+    - Experience:
+      - guides/experience/README.md
+      - Explanation:
+        - The Experience Thread: guides/experience/explanation/the-experience-thread.md
+      - How-to:
+        - Author Design Intent: guides/experience/how-to/author-design-intent.md
+      - Reference:
+        - Experience Pack: guides/experience/reference/experience.md
+    - Contracts:
+      - guides/contracts/README.md
+      - Explanation:
+        - Contract-First Design: guides/contracts/explanation/contract-first-design.md
+      - How-to:
+        - Generate an API Contract: guides/contracts/how-to/generate-an-api-contract.md
+        - Author an Event Contract: guides/contracts/how-to/author-an-event-contract.md
+      - Reference:
+        - Contract Skills: guides/contracts/reference/contract-skills.md
+    - Converters:
+      - guides/converters/README.md
+      - How-to:
+        - Documents to Markdown: guides/converters/how-to/convert-documents-to-markdown.md
+        - Markdown to HTML: guides/converters/how-to/convert-markdown-to-html-and-email.md
+        - Markdown to Office: guides/converters/how-to/publish-markdown-to-office.md
+        - Render Mermaid: guides/converters/how-to/render-mermaid-diagrams.md
+      - Reference:
+        - Converter Skills: guides/converters/reference/converter-skills.md
+    - Atlassian:
+      - guides/atlassian/README.md
+      - Explanation:
+        - The Atlassian Pack: guides/atlassian/explanation/atlassian-pack.md
+      - How-to:
+        - Authenticate with SSO: guides/atlassian/how-to/authenticate-jira-confluence-with-sso-cookies.md
+        - Crawl Confluence: guides/atlassian/how-to/crawl-and-publish-confluence.md
+        - DORA Metrics: guides/atlassian/how-to/measure-flow-and-dora-metrics.md
+        - Work with Jira: guides/atlassian/how-to/work-with-jira.md
+      - Reference:
+        - Atlassian Skills: guides/atlassian/reference/atlassian-skills.md
+    - Figma:
+      - guides/figma/README.md
+      - How-to:
+        - Inspect a Figma File: guides/figma/how-to/inspect-a-figma-file.md
+      - Reference:
+        - Figma Skill: guides/figma/reference/figma-skill.md
+    - "Governance Extras":
+      - guides/governance-extras/README.md
+      - How-to:
+        - New ADR: guides/governance-extras/how-to/new-adr.md
+        - New RFC: guides/governance-extras/how-to/new-rfc.md
+    - "Monorepo Extras":
+      - guides/monorepo-extras/README.md
+      - How-to:
+        - Scaffold a Package: guides/monorepo-extras/how-to/scaffold-a-new-package.md
+      - Reference:
+        - new-package: guides/monorepo-extras/reference/new-package.md
+    - "Credential Brokers":
+      - guides/credential-brokers/README.md
+      - Explanation:
+        - Credentialed Skills: guides/credential-brokers/explanation/credentialed-skills.md
+      - How-to:
+        - Add a Credentialed Skill: guides/credential-brokers/how-to/add-a-credentialed-skill.md
+    - "User Guide (Diataxis)":
+      - guides/user-guide-diataxis/README.md
+      - Explanation:
+        - The Diataxis Framework: guides/user-guide-diataxis/explanation/the-diataxis-framework.md
+      - How-to:
+        - Write a Guide: guides/user-guide-diataxis/how-to/write-a-guide.md
+    - Cross-cutting:
+      - Overview: guides/_shared/README.md
+      - Explanation:
+        - The Three Loops: guides/_shared/explanation/the-three-loops.md
+        - File Safety Contract: guides/_shared/explanation/file-safety-contract.md
+        - Install Routes: guides/_shared/explanation/install-routes.md
+        - Pack Catalogue: guides/_shared/explanation/pack-catalogue.md
+        - Shaping an Engagement: guides/_shared/explanation/shaping-a-new-engagement.md
+      - How-to:
+        - Author a Skill: guides/_shared/how-to/author-a-skill.md
+        - Build an Org Pack: guides/_shared/how-to/build-an-org-stack-pack.md
+        - Install a Profile: guides/_shared/how-to/install-a-profile.md
+        - Install from Clone: guides/_shared/how-to/install-agentbundle-from-clone.md
+        - Install User Scope (Codex): guides/_shared/how-to/install-user-scope-pack-into-codex.md
+        - Install User Scope (Kiro): guides/_shared/how-to/install-user-scope-pack-into-kiro.md
+        - Preview Install: guides/_shared/how-to/preview-install-or-upgrade.md
+        - Run a Full Inception: guides/_shared/how-to/run-a-full-inception.md
+        - Upgrade Packs: guides/_shared/how-to/upgrade-packs.md
+      - Reference:
+        - Adapter Support Matrix: guides/_shared/reference/adapter-support.md
+        - agentbundle CLI: guides/_shared/reference/agentbundle.md
+  - Changelog: changelog.md
+  - Contributing: contributing.md

--- a/site/requirements.txt
+++ b/site/requirements.txt
@@ -1,0 +1,3 @@
+mkdocs-material>=9.5,<10
+mkdocs-minify-plugin>=0.8
+pymdown-extensions>=10.7

--- a/tools/build-site.py
+++ b/tools/build-site.py
@@ -26,21 +26,21 @@ REPO_ROOT = Path(__file__).parent.parent.resolve()
 SITE_DOCS = REPO_ROOT / "site" / "docs"
 GITHUB_BASE = "https://github.com/eugenelim/agent-ready-repo/blob/main"
 
-PACKS: list[tuple[str, str, str]] = [
-    ("core",               "Core",                "repo"),
-    ("product-engineering","Product Engineering",  "user"),
-    ("release-engineering","Release Engineering",  "repo"),
-    ("research",           "Research",             "user"),
-    ("architect",          "Architect",            "user"),
-    ("experience",         "Experience",           "user"),
-    ("contracts",          "Contracts",            "user"),
-    ("converters",         "Converters",           "user"),
-    ("atlassian",          "Atlassian",            "user"),
-    ("figma",              "Figma",                "user"),
-    ("governance-extras",  "Governance Extras",    "repo"),
-    ("user-guide-diataxis","User Guide (Diataxis)", "repo"),
-    ("monorepo-extras",    "Monorepo Extras",       "repo"),
-    ("credential-brokers", "Credential Brokers",    "user"),
+PACKS: list[tuple[str, str, str, str]] = [
+    ("core",               "Core",                "repo", "The build loop — `work-loop`, `new-spec`, `bug-fix`, four specialist reviewers, hooks. **Install this first.**"),
+    ("product-engineering","Product Engineering",  "user", "The discovery loop — raw idea to ratified brief with human consent at G0, G1.5, G2."),
+    ("release-engineering","Release Engineering",  "repo", "The release loop — autonomous e2e convergence on ephemeral environments; prod gate is always human."),
+    ("research",           "Research",             "user", "Evidence-grounded research with typed artifacts, seven skills, and two retrieval subagents."),
+    ("architect",          "Architect",            "user", "System design, diagramming, and independent architecture review from a forked-context subagent."),
+    ("experience",         "Experience",           "user", "The full design thread: journey mapping, screen flows, aesthetic direction, WCAG quality floor."),
+    ("contracts",          "Contracts",            "user", "API-first design — OpenAPI 3.1 for HTTP, AsyncAPI for event streams."),
+    ("converters",         "Converters",           "user", "Document conversion: PDF/DOCX/PPTX/email → Markdown, Markdown → HTML/Word/PowerPoint/Excel."),
+    ("atlassian",          "Atlassian",            "user", "Jira and Confluence from the agent — SSO-cookie authenticated, flow and DORA metrics built in."),
+    ("figma",              "Figma",                "user", "Read and render Figma designs — files, nodes, variables, frame renders, FigJam → Mermaid."),
+    ("governance-extras",  "Governance Extras",    "repo", "RFC/ADR ceremony for long-lived repos: `new-rfc`, `new-adr`, `update-conventions`."),
+    ("user-guide-diataxis","User Guide (Diataxis)", "repo", "Diátaxis docs scaffold — four content modes with the `new-guide` skill."),
+    ("monorepo-extras",    "Monorepo Extras",       "repo", "Package scaffolding — `new-package` skill with an example package template."),
+    ("credential-brokers", "Credential Brokers",    "user", "In-process credential resolution: environment → OS keyring → dotfile. Cleartext never reaches the model."),
 ]
 
 PACK_INDEX_HEADER = """\
@@ -56,8 +56,8 @@ agentbundle install --pack <name>               # repo scope (default)
 agentbundle install --pack <name> --scope user  # user scope
 ```
 
----
-
+| Pack | Scope | Description |
+|---|---|---|
 """
 
 # ---------------------------------------------------------------------------
@@ -254,10 +254,8 @@ def mirror_dir(src: Path, dst: Path, rewriter=None, dry_run: bool = False) -> in
 
 def build_pack_index(packs_dir: Path, out_dir: Path, dry_run: bool = False) -> None:
     lines = [PACK_INDEX_HEADER]
-    for slug, display, scope in PACKS:
-        readme = packs_dir / slug / "README.md"
-        blurb = _extract_blurb(readme.read_text(encoding="utf-8")) if readme.exists() else "*(README not found)*"
-        lines.append(f"- **[{display}]({slug}.md)** `{scope}` — {blurb}\n")
+    for slug, display, scope, description in PACKS:
+        lines.append(f"| [**{display}**]({slug}.md) | `{scope}` | {description} |\n")
 
     content = "".join(lines)
     index_md = out_dir / "index.md"
@@ -265,21 +263,6 @@ def build_pack_index(packs_dir: Path, out_dir: Path, dry_run: bool = False) -> N
         print(f"  gen   site/docs/packs/index.md ({len(content)} bytes)")
     else:
         index_md.write_text(content, encoding="utf-8")
-
-
-def _extract_blurb(text: str) -> str:
-    in_code = False
-    for line in text.splitlines():
-        stripped = line.strip()
-        if stripped.startswith("```"):
-            in_code = not in_code
-            continue
-        if in_code or stripped.startswith("#") or stripped.startswith("|") or not stripped:
-            continue
-        if stripped.startswith(">"):
-            stripped = stripped.lstrip("> ").strip()
-        return stripped[:200] + ("…" if len(stripped) > 200 else "")
-    return ""
 
 
 def write_siteignore(paths: list[Path], dry_run: bool = False) -> None:
@@ -321,7 +304,7 @@ def main() -> None:
 
     print("build-site: copying pack READMEs …")
     packs_out.mkdir(parents=True, exist_ok=True)
-    for slug, _, _ in PACKS:
+    for slug, *_ in PACKS:
         src = packs_dir / slug / "README.md"
         dst = packs_out / f"{slug}.md"
         if src.exists():

--- a/tools/build-site.py
+++ b/tools/build-site.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""
+Aggregate repo content into site/docs/ for the MkDocs build.
+
+Copies:
+  packs/*/README.md         → site/docs/packs/<name>.md
+  docs/guides/**            → site/docs/guides/**
+  docs/product/changelog.md → site/docs/changelog.md  (links rewritten)
+  CONTRIBUTING.md           → site/docs/contributing.md (links rewritten)
+
+Generates:
+  site/docs/packs/index.md  (pack catalogue summary page)
+
+Usage:
+  python tools/build-site.py
+  python tools/build-site.py --dry-run
+  python tools/build-site.py --clean
+"""
+import argparse
+import re
+import shutil
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+SITE_DOCS = REPO_ROOT / "site" / "docs"
+GITHUB_BASE = "https://github.com/eugenelim/agent-ready-repo/blob/main"
+
+PACKS: list[tuple[str, str, str]] = [
+    ("core",               "Core",                "repo"),
+    ("product-engineering","Product Engineering",  "user"),
+    ("release-engineering","Release Engineering",  "repo"),
+    ("research",           "Research",             "user"),
+    ("architect",          "Architect",            "user"),
+    ("experience",         "Experience",           "user"),
+    ("contracts",          "Contracts",            "user"),
+    ("converters",         "Converters",           "user"),
+    ("atlassian",          "Atlassian",            "user"),
+    ("figma",              "Figma",                "user"),
+    ("governance-extras",  "Governance Extras",    "repo"),
+    ("user-guide-diataxis","User Guide (Diataxis)", "repo"),
+    ("monorepo-extras",    "Monorepo Extras",       "repo"),
+    ("credential-brokers", "Credential Brokers",    "user"),
+]
+
+PACK_INDEX_HEADER = """\
+# Pack Catalogue
+
+Fourteen curated packs — each distilled from the best practices of its discipline
+through practitioner research and RFC-and-ADR governance.
+
+Install any pack in one command:
+
+```bash
+agentbundle install --pack <name>               # repo scope (default)
+agentbundle install --pack <name> --scope user  # user scope
+```
+
+---
+
+"""
+
+# ---------------------------------------------------------------------------
+# Link rewriters
+# ---------------------------------------------------------------------------
+
+def _rewrite_changelog(text: str) -> str:
+    """Fix links in changelog.md when moved from docs/product/ to site/docs/.
+
+    In source: relative to docs/product/changelog.md
+      ../guides/... → guides/...  (in-site, rewrite)
+      ../rfc/...    → GitHub URL  (not in site)
+      ../specs/...  → GitHub URL  (not in site)
+    """
+    def replace(m: re.Match) -> str:
+        prefix, path, anchor = m.group(1), m.group(2), m.group(3) or ""
+        if path.startswith("../guides/"):
+            # Strip the leading ../
+            return f"{prefix}{path[3:]}{anchor})"
+        if path.startswith("../"):
+            # Convert to GitHub URL
+            clean = path[3:]  # remove ../
+            return f"{prefix}{GITHUB_BASE}/{clean}{anchor})"
+        return m.group(0)
+
+    # Match markdown links: [text](path#anchor)
+    return re.sub(r'(\]\()(\.\./[^)#]*)(#[^)]+)?\)', replace, text)
+
+
+def _rewrite_pack_readme(text: str, pack_src_path: Path) -> str:
+    """Rewrite links in pack READMEs moved from packs/<slug>/README.md to site/docs/packs/<slug>.md.
+
+    Cross-pack links (../other-pack/README.md) → other-pack.md (within site/docs/packs/).
+    Links outside packs/ that resolve in the repo → GitHub URL.
+    """
+    packs_root = (REPO_ROOT / "packs").resolve()
+    repo_root = REPO_ROOT.resolve()
+
+    def replace(m: re.Match) -> str:
+        prefix, path, anchor = m.group(1), m.group(2), m.group(3) or ""
+        if not path or path.startswith("http://") or path.startswith("https://") or path.startswith("#"):
+            return m.group(0)
+        try:
+            resolved = (pack_src_path.parent / path).resolve()
+        except Exception:
+            return m.group(0)
+
+        if _is_relative_to(resolved, packs_root):
+            # e.g. ../credential-brokers/README.md → credential-brokers.md
+            rel = resolved.relative_to(packs_root)
+            pack_name = rel.parts[0]
+            return f"{prefix}{pack_name}.md{anchor})"
+
+        if _is_relative_to(resolved, repo_root):
+            rel = resolved.relative_to(repo_root)
+            return f"{prefix}{GITHUB_BASE}/{rel}{anchor})"
+
+        return m.group(0)
+
+    return re.sub(r'(\]\()([^)#"\'\s]+)(#[^)]+)?\)', replace, text)
+
+
+def _rewrite_guide(text: str, guide_src_path: Path) -> str:
+    """Rewrite links in guide files that exit the guides tree.
+
+    Links within docs/guides/ are kept as-is (they work in the site).
+    Links that resolve within the repo but outside docs/guides/ are
+    converted to GitHub URLs so they don't produce dead references.
+    """
+    guides_root = (REPO_ROOT / "docs" / "guides").resolve()
+    repo_root = REPO_ROOT.resolve()
+
+    def replace(m: re.Match) -> str:
+        prefix, path, anchor = m.group(1), m.group(2), m.group(3) or ""
+        if not path or path.startswith("http://") or path.startswith("https://") or path.startswith("#"):
+            return m.group(0)
+
+        # Resolve the link relative to the guide file's source position
+        try:
+            resolved = (guide_src_path.parent / path).resolve()
+        except Exception:
+            return m.group(0)
+
+        # Within guides/ → check existence and handle directory links
+        if _is_relative_to(resolved, guides_root):
+            if resolved.is_dir():
+                # Bare directory link (e.g. `_shared/`) → README.md
+                readme = resolved / "README.md"
+                if readme.exists():
+                    # Rewrite to point at the README directly
+                    rel_guide = guide_src_path.parent
+                    rel_readme = readme.resolve()
+                    try:
+                        rel = rel_readme.relative_to(rel_guide.resolve())
+                        return f"{prefix}{rel}{anchor})"
+                    except ValueError:
+                        pass
+            elif resolved.exists():
+                return m.group(0)
+            # Stale or unresolvable link within guides/ — fall through to GitHub URL
+
+        # Within repo but outside guides/ → GitHub URL
+        if _is_relative_to(resolved, repo_root):
+            rel = resolved.relative_to(repo_root)
+            return f"{prefix}{GITHUB_BASE}/{rel}{anchor})"
+
+        # Outside repo or unresolvable → leave as-is
+        return m.group(0)
+
+    return re.sub(r'(\]\()([^)#"\'\s]+)(#[^)]+)?\)', replace, text)
+
+
+def _is_relative_to(path: Path, base: Path) -> bool:
+    try:
+        path.relative_to(base)
+        return True
+    except ValueError:
+        return False
+
+
+def _rewrite_contributing(text: str) -> str:
+    """Fix links in CONTRIBUTING.md when placed at site/docs/contributing.md.
+
+    CONTRIBUTING.md lives at the repo root; links are repo-root-relative.
+    Most targets (AGENTS.md, docs/CONVENTIONS.md, etc.) aren't in the site,
+    so we convert them to GitHub URLs using proper Path resolution.
+    """
+    contributing_src = REPO_ROOT / "CONTRIBUTING.md"
+    repo_root = REPO_ROOT.resolve()
+    guides_root = (REPO_ROOT / "docs" / "guides").resolve()
+
+    def replace(m: re.Match) -> str:
+        prefix, path, anchor = m.group(1), m.group(2), m.group(3) or ""
+        if not path or path.startswith("http://") or path.startswith("https://") or path.startswith("#"):
+            return m.group(0)
+        try:
+            resolved = (contributing_src.parent / path).resolve()
+        except Exception:
+            return m.group(0)
+
+        # Links within guides/ → site-relative (guides/ is in the site)
+        if _is_relative_to(resolved, guides_root):
+            rel = resolved.relative_to(guides_root)
+            return f"{prefix}guides/{rel}{anchor})"
+
+        # Any other repo-relative link → GitHub URL
+        if _is_relative_to(resolved, repo_root):
+            rel = resolved.relative_to(repo_root)
+            return f"{prefix}{GITHUB_BASE}/{rel}{anchor})"
+
+        return m.group(0)
+
+    return re.sub(r'(\]\()([^)#"\'\s]+)(#[^)]+)?\)', replace, text)
+
+
+# ---------------------------------------------------------------------------
+# Core operations
+# ---------------------------------------------------------------------------
+
+def copy_file(src: Path, dst: Path, rewriter=None, dry_run: bool = False) -> None:
+    """Copy src to dst, applying an optional rewriter(text) → text transform."""
+    if dry_run:
+        print(f"  copy  {src.relative_to(REPO_ROOT)} → {dst.relative_to(REPO_ROOT)}")
+        return
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    text = src.read_text(encoding="utf-8")
+    if rewriter:
+        text = rewriter(text)
+    dst.write_text(text, encoding="utf-8")
+
+
+def mirror_dir(src: Path, dst: Path, rewriter=None, dry_run: bool = False) -> int:
+    """Mirror src into dst, applying an optional per-file rewriter to .md files."""
+    count = 0
+    if not src.exists():
+        print(f"  warn  source dir missing: {src.relative_to(REPO_ROOT)}", file=sys.stderr)
+        return 0
+    for path in sorted(src.rglob("*")):
+        if path.is_file():
+            rel = path.relative_to(src)
+            target = dst / rel
+            if dry_run:
+                print(f"  copy  {path.relative_to(REPO_ROOT)} → {target.relative_to(REPO_ROOT)}")
+            else:
+                target.parent.mkdir(parents=True, exist_ok=True)
+                if rewriter and path.suffix == ".md":
+                    text = path.read_text(encoding="utf-8")
+                    target.write_text(rewriter(text, path), encoding="utf-8")
+                else:
+                    shutil.copy2(path, target)
+            count += 1
+    return count
+
+
+def build_pack_index(packs_dir: Path, out_dir: Path, dry_run: bool = False) -> None:
+    lines = [PACK_INDEX_HEADER]
+    for slug, display, scope in PACKS:
+        readme = packs_dir / slug / "README.md"
+        blurb = _extract_blurb(readme.read_text(encoding="utf-8")) if readme.exists() else "*(README not found)*"
+        lines.append(f"- **[{display}]({slug}.md)** `{scope}` — {blurb}\n")
+
+    content = "".join(lines)
+    index_md = out_dir / "index.md"
+    if dry_run:
+        print(f"  gen   site/docs/packs/index.md ({len(content)} bytes)")
+    else:
+        index_md.write_text(content, encoding="utf-8")
+
+
+def _extract_blurb(text: str) -> str:
+    in_code = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_code = not in_code
+            continue
+        if in_code or stripped.startswith("#") or stripped.startswith("|") or not stripped:
+            continue
+        if stripped.startswith(">"):
+            stripped = stripped.lstrip("> ").strip()
+        return stripped[:200] + ("…" if len(stripped) > 200 else "")
+    return ""
+
+
+def write_siteignore(paths: list[Path], dry_run: bool = False) -> None:
+    lines = [
+        "# Generated by tools/build-site.py — do not commit these paths.\n",
+        "# These are listed in .gitignore at the repo root.\n\n",
+    ]
+    for p in sorted(paths):
+        try:
+            rel = str(p.relative_to(SITE_DOCS))
+        except ValueError:
+            rel = str(p)
+        lines.append(f"{rel}\n")
+    if not dry_run:
+        (SITE_DOCS / ".siteignore").write_text("".join(lines), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--clean", action="store_true")
+    args = parser.parse_args()
+
+    packs_dir = REPO_ROOT / "packs"
+    packs_out = SITE_DOCS / "packs"
+    guides_src = REPO_ROOT / "docs" / "guides"
+    guides_out = SITE_DOCS / "guides"
+    generated = [packs_out, guides_out]
+
+    if args.clean and not args.dry_run:
+        for d in (packs_out, guides_out):
+            if d.exists():
+                shutil.rmtree(d)
+                print(f"  clean {d.relative_to(REPO_ROOT)}/")
+
+    print("build-site: copying pack READMEs …")
+    packs_out.mkdir(parents=True, exist_ok=True)
+    for slug, _, _ in PACKS:
+        src = packs_dir / slug / "README.md"
+        dst = packs_out / f"{slug}.md"
+        if src.exists():
+            copy_file(src, dst, rewriter=lambda t, p=src: _rewrite_pack_readme(t, p), dry_run=args.dry_run)
+        else:
+            print(f"  warn  packs/{slug}/README.md missing", file=sys.stderr)
+
+    print("build-site: generating packs/index.md …")
+    build_pack_index(packs_dir, packs_out, dry_run=args.dry_run)
+
+    print("build-site: mirroring guides …")
+    n = mirror_dir(guides_src, guides_out, rewriter=_rewrite_guide, dry_run=args.dry_run)
+    print(f"  {n} files from docs/guides/")
+
+    print("build-site: copying changelog …")
+    changelog_src = REPO_ROOT / "docs" / "product" / "changelog.md"
+    changelog_dst = SITE_DOCS / "changelog.md"
+    if changelog_src.exists():
+        copy_file(changelog_src, changelog_dst, rewriter=_rewrite_changelog, dry_run=args.dry_run)
+        generated.append(changelog_dst)
+    else:
+        print("  warn  docs/product/changelog.md missing", file=sys.stderr)
+
+    print("build-site: copying contributing guide …")
+    contributing_src = REPO_ROOT / "CONTRIBUTING.md"
+    contributing_dst = SITE_DOCS / "contributing.md"
+    if contributing_src.exists():
+        copy_file(contributing_src, contributing_dst, rewriter=_rewrite_contributing, dry_run=args.dry_run)
+        generated.append(contributing_dst)
+    else:
+        print("  warn  CONTRIBUTING.md missing", file=sys.stderr)
+
+    write_siteignore(generated, dry_run=args.dry_run)
+    print("build-site: done." + (" (dry run)" if args.dry_run else ""))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **Full GitHub Pages publishing toolchain** with MkDocs Material, `tools/build-site.py` content aggregator, and `pages.yml` CI workflow
- **Design system pass**: CSS color token roles (DARK ZONE / SURFACE-0/1/2 / ACCENT), one-accent rule enforced via `--md-accent-fg-color`/`--md-typeset-a-color`, SURFACE-2 table headers, SURFACE-1 card lift with border-reveal hover, accent-tinted inline code chips
- **Full-bleed hero**: `margin: auto` centering fix so the 100vw negative-margin technique works correctly; three-layer top-gap elimination for continuous dark zone from navbar to hero bottom; grid texture + radial accent glow
- **Mobile responsiveness**: hero padding/font scale, stacked CTAs, code block overflow
- **Hero copy**: painkiller-first subtitle leads with "An unattended loop makes unattended mistakes" rather than feature inventory
- **Adapters table fix**: split `Kiro` into `Kiro IDE` and `Kiro CLI` (per ADR-0012); both show Hooks: Yes (kiro-ide-hook and hook-wiring respectively)

## Backlog additions

- New `## experience-pack` section: `copy-direction` skill RFC, `design-system-foundations` gap, `design-critique` marketing clarity criterion, experience-reviewer as work-loop gate
- 4 closed items removed: `readme-route3-after-first-publish`, `pypi-first-publish-gesture` (resolved June 2026, no inbound links); `extraction-msg-to-markdown-python-contract`, `extraction-tier0-eml-mime` (Python port shipped in converters 0.6.0)

## Deploy

The `pages.yml` workflow builds on every PR (validation) and deploys only on push to `main`. Site URL: **https://eugenelim.github.io/agent-ready-repo/**

## Test plan

- [ ] CI build passes (`mkdocs build --strict`)
- [ ] Hero spans full viewport width on desktop and mobile viewports
- [ ] Adapters table shows Kiro IDE and Kiro CLI as separate rows, both with Hooks: Yes
- [ ] Dark zone continuous from navbar through hero (no white gap)
- [ ] Cards lift correctly on hover with accent border
- [ ] Table headers use SURFACE-2 (light neutral), not DARK ZONE navy