### PR TITLE
feat(experience,core): design quality loop — marketing clarity, experience-reviewer gate, new-spec ui hook

### DIFF
--- a/.agents/skills/new-spec/SKILL.md
+++ b/.agents/skills/new-spec/SKILL.md
@@ -234,6 +234,46 @@ look like?" before any code.
    The headings in `## Design (LLD)` stay universal; the prose under them is the
    stack-specific instance you resolved here.
 
+4d. **Design-readiness check (ui-shaped trigger).** Fires when `Shape: ui` is
+   confirmed (step 4c). Before writing the spec body — especially the Acceptance
+   Criteria — settle two design-readiness questions and weave the result into the spec.
+
+   If the experience pack is absent (`aesthetic-direction` and `design-critique`
+   unavailable): **proceed and note it** in the spec's Assumptions —
+   `experience pack not installed; design intent for this surface is ungrounded` —
+   then skip the rest of this step. Absence is a named gap, not a silent pass.
+
+   - **Check for a grounded aesthetic reference.** Search the repo for an aesthetic-
+     direction doc (any file whose first heading matches `# Aesthetic direction:`).
+     If none exists, offer to run `aesthetic-direction` before writing design-facing
+     ACs. A UI spec's design-intent ACs are unverifiable without a grounded reference;
+     the direction doc is what lets "this screen should feel <goal>" be checkable. If
+     the user declines or has a direction outside the repo, ask them to name the ranked
+     goals so you can reference them concretely in the spec.
+   - **Check whether existing screens or flows are affected.** If the spec modifies
+     an existing surface, offer to run `design-critique` on it before writing ACs.
+     Findings from the existing surface establish the design debt the implementation
+     must clear — surfacing them as explicit ACs is better than discovering them post-ship.
+   - **Weave design intent into the spec.** Once design-readiness is settled:
+     - In the **Objective**: name the primary user task the surface supports *and* the
+       aesthetic goal from the grounded reference it must satisfy.
+     - In the **Acceptance Criteria**: include at least one design-intent AC whose
+       outcome is observable from the rendered surface — not derivable from the code.
+       Concrete shapes: *"Above-fold copy passes the five-second scan for <persona>"*;
+       *"Screen clears the quality-floor and Nielsen heuristics with no severity-3+
+       findings"*; *"Taste critique against the <named aesthetic goal> passes with no
+       Major findings."* An AC like "component renders without errors" is not a
+       design-intent AC.
+
+   This step is the spec-time analogue of `work-loop`'s pre-EXECUTE design-intent pass
+   — establishing design intent before the ACs are written, rather than recommending
+   it before code is written. Both target the same failure mode (technically correct
+   surfaces with no design sense); this step catches it earlier.
+
+   **Mixed-shape note.** Step 4d fires on `Shape: ui` only. For a `mixed`-shaped spec
+   that includes a user-facing screen or flow, apply the same design-readiness questions
+   to that sub-surface — it is not covered automatically.
+
 5. Fill in the plan second. The plan should:
    - Cite any ADRs or RFCs it follows from.
    - Break the work into tasks small enough to be a single PR each.

--- a/.agents/skills/work-loop/SKILL.md
+++ b/.agents/skills/work-loop/SKILL.md
@@ -309,6 +309,16 @@ For anything beyond trivial, *think before you write code*. Concretely:
   [`references/pre-execute-review.md`](references/pre-execute-review.md) and the
   REVIEW `security-reviewer` bullet. Same Profile-A opt-out and `approve-plan`
   gate; fallback if no `security-reviewer` is installed: proceed and note it.
+- **Pre-EXECUTE design-intent pass (user-facing surface trigger).** When the
+  change produces a user-facing surface — a new page, a redesigned screen, a
+  component, a pack card, a docs page — establish design intent **before writing
+  code**. Run `aesthetic-direction` (if no grounded aesthetic reference exists
+  yet) and/or `design-critique` (if there is an existing surface to evaluate)
+  and record the design intent in the spec. This is the design analogue of
+  "write the test first": design intent before implementation prevents the
+  common failure mode of technically correct surfaces with no design sense. Applies
+  in both light and full mode as a recommendation; the mandatory fresh-context
+  gate (`experience-reviewer`) runs in REVIEW for full-mode work.
 - **Initialize the loop's state file.** Run this skill's bundled
   `scripts/loop-cohort.py init docs/specs/<feature>`; the tool copies
   the bundled `assets/state.json` template into place, sets `feature`
@@ -656,6 +666,16 @@ note in the summary, not a blocker.
   infra wiring (the deferred `infra-contract-reviewer`, the `design-reviewer`
   spec-stage carve) in
   [`references/infra-verification.md`](references/infra-verification.md).
+- Match `experience-reviewer` — for diffs that change what a reader or adopter
+  sees (a new page, a redesigned screen, a pack card, a docs page) **in full-mode
+  work**. This is a design/experience lens, distinct from the three core
+  code-review lenses. Pass the **rendered output** (a described screen state, a
+  screenshot, or a path to the built artifact) **plus the grounded aesthetic
+  reference and constraints** (persona, outcome, platform surface) — not the
+  code diff; experience-reviewer reviews design artifacts, not code diffs, and
+  its confirm-before-reviewing gate requires the grounded reference. Fallback if
+  no `experience-reviewer` is installed (experience pack absent): proceed and
+  note it — absence of the experience pack is a named skip, not a silent pass.
 
 **Dispatch reviewers in parallel when you invoke more than one** per
 the [Parallel dispatch discipline](#parallel-dispatch-discipline)
@@ -723,8 +743,9 @@ mode below, then evaluate the terminal-state bullet last.
   - For each reviewer the diff warranted (`adversarial-reviewer`
     always; `security-reviewer` on security-boundary diffs;
     `quality-engineer` on every loop, plus a whole-spec pass on the
-    final loop of a multi-loop spec): either the subagent returned
-    `Clean — ready to commit.`, **or** no matching subagent was
+    final loop of a multi-loop spec; `experience-reviewer` on
+    user-facing surface diffs in full-mode work): either the subagent
+    returned `Clean — ready to commit.`, **or** no matching subagent was
     installed and the final summary names the missing review by its
     role label — e.g. `adversarial-reviewer: no matching subagent
     installed; review skipped`. *Silently skipping the reviewer is not

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -87,7 +87,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "core",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.7.2"
+      "version": "0.9.0"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",
@@ -122,7 +122,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "experience",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.3.0"
+      "version": "0.4.0"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/.claude/skills/new-spec/SKILL.md
+++ b/.claude/skills/new-spec/SKILL.md
@@ -234,6 +234,46 @@ look like?" before any code.
    The headings in `## Design (LLD)` stay universal; the prose under them is the
    stack-specific instance you resolved here.
 
+4d. **Design-readiness check (ui-shaped trigger).** Fires when `Shape: ui` is
+   confirmed (step 4c). Before writing the spec body — especially the Acceptance
+   Criteria — settle two design-readiness questions and weave the result into the spec.
+
+   If the experience pack is absent (`aesthetic-direction` and `design-critique`
+   unavailable): **proceed and note it** in the spec's Assumptions —
+   `experience pack not installed; design intent for this surface is ungrounded` —
+   then skip the rest of this step. Absence is a named gap, not a silent pass.
+
+   - **Check for a grounded aesthetic reference.** Search the repo for an aesthetic-
+     direction doc (any file whose first heading matches `# Aesthetic direction:`).
+     If none exists, offer to run `aesthetic-direction` before writing design-facing
+     ACs. A UI spec's design-intent ACs are unverifiable without a grounded reference;
+     the direction doc is what lets "this screen should feel <goal>" be checkable. If
+     the user declines or has a direction outside the repo, ask them to name the ranked
+     goals so you can reference them concretely in the spec.
+   - **Check whether existing screens or flows are affected.** If the spec modifies
+     an existing surface, offer to run `design-critique` on it before writing ACs.
+     Findings from the existing surface establish the design debt the implementation
+     must clear — surfacing them as explicit ACs is better than discovering them post-ship.
+   - **Weave design intent into the spec.** Once design-readiness is settled:
+     - In the **Objective**: name the primary user task the surface supports *and* the
+       aesthetic goal from the grounded reference it must satisfy.
+     - In the **Acceptance Criteria**: include at least one design-intent AC whose
+       outcome is observable from the rendered surface — not derivable from the code.
+       Concrete shapes: *"Above-fold copy passes the five-second scan for <persona>"*;
+       *"Screen clears the quality-floor and Nielsen heuristics with no severity-3+
+       findings"*; *"Taste critique against the <named aesthetic goal> passes with no
+       Major findings."* An AC like "component renders without errors" is not a
+       design-intent AC.
+
+   This step is the spec-time analogue of `work-loop`'s pre-EXECUTE design-intent pass
+   — establishing design intent before the ACs are written, rather than recommending
+   it before code is written. Both target the same failure mode (technically correct
+   surfaces with no design sense); this step catches it earlier.
+
+   **Mixed-shape note.** Step 4d fires on `Shape: ui` only. For a `mixed`-shaped spec
+   that includes a user-facing screen or flow, apply the same design-readiness questions
+   to that sub-surface — it is not covered automatically.
+
 5. Fill in the plan second. The plan should:
    - Cite any ADRs or RFCs it follows from.
    - Break the work into tasks small enough to be a single PR each.

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -309,6 +309,16 @@ For anything beyond trivial, *think before you write code*. Concretely:
   [`references/pre-execute-review.md`](references/pre-execute-review.md) and the
   REVIEW `security-reviewer` bullet. Same Profile-A opt-out and `approve-plan`
   gate; fallback if no `security-reviewer` is installed: proceed and note it.
+- **Pre-EXECUTE design-intent pass (user-facing surface trigger).** When the
+  change produces a user-facing surface — a new page, a redesigned screen, a
+  component, a pack card, a docs page — establish design intent **before writing
+  code**. Run `aesthetic-direction` (if no grounded aesthetic reference exists
+  yet) and/or `design-critique` (if there is an existing surface to evaluate)
+  and record the design intent in the spec. This is the design analogue of
+  "write the test first": design intent before implementation prevents the
+  common failure mode of technically correct surfaces with no design sense. Applies
+  in both light and full mode as a recommendation; the mandatory fresh-context
+  gate (`experience-reviewer`) runs in REVIEW for full-mode work.
 - **Initialize the loop's state file.** Run this skill's bundled
   `scripts/loop-cohort.py init docs/specs/<feature>`; the tool copies
   the bundled `assets/state.json` template into place, sets `feature`
@@ -656,6 +666,16 @@ note in the summary, not a blocker.
   infra wiring (the deferred `infra-contract-reviewer`, the `design-reviewer`
   spec-stage carve) in
   [`references/infra-verification.md`](references/infra-verification.md).
+- Match `experience-reviewer` — for diffs that change what a reader or adopter
+  sees (a new page, a redesigned screen, a pack card, a docs page) **in full-mode
+  work**. This is a design/experience lens, distinct from the three core
+  code-review lenses. Pass the **rendered output** (a described screen state, a
+  screenshot, or a path to the built artifact) **plus the grounded aesthetic
+  reference and constraints** (persona, outcome, platform surface) — not the
+  code diff; experience-reviewer reviews design artifacts, not code diffs, and
+  its confirm-before-reviewing gate requires the grounded reference. Fallback if
+  no `experience-reviewer` is installed (experience pack absent): proceed and
+  note it — absence of the experience pack is a named skip, not a silent pass.
 
 **Dispatch reviewers in parallel when you invoke more than one** per
 the [Parallel dispatch discipline](#parallel-dispatch-discipline)
@@ -723,8 +743,9 @@ mode below, then evaluate the terminal-state bullet last.
   - For each reviewer the diff warranted (`adversarial-reviewer`
     always; `security-reviewer` on security-boundary diffs;
     `quality-engineer` on every loop, plus a whole-spec pass on the
-    final loop of a multi-loop spec): either the subagent returned
-    `Clean — ready to commit.`, **or** no matching subagent was
+    final loop of a multi-loop spec; `experience-reviewer` on
+    user-facing surface diffs in full-mode work): either the subagent
+    returned `Clean — ready to commit.`, **or** no matching subagent was
     installed and the final summary names the missing review by its
     role label — e.g. `adversarial-reviewer: no matching subagent
     installed; review skipped`. *Silently skipping the reviewer is not

--- a/docs/adr/0047-experience-reviewer-as-work-loop-gate.md
+++ b/docs/adr/0047-experience-reviewer-as-work-loop-gate.md
@@ -1,0 +1,78 @@
+# ADR-0047: `experience-reviewer` is a conditional specialist reviewer in `work-loop` for user-facing surface diffs — select-or-note, full-mode only
+
+- **Status:** Accepted
+- **Date:** 2026-07-02
+- **Decision-makers:** eugenelim
+- **Related:** [ADR-0042](0042-agent-additions-keyed-to-loop-and-work-type.md) (agent additions keyed to loop and work type); [ADR-0014](0014-rigor-scales-with-risk-work-loop-modes.md) (rigor scales with risk); [RFC-0050](../rfc/0050-experience-pack-pressure-test.md) (§ D7 — the `experience-reviewer` admitted); backlog items `experience-reviewer-as-work-loop-gate` and `experience-loop-trigger-for-site-changes`
+
+## Decision summary
+
+- **Decision:** `experience-reviewer` is added to `work-loop`'s specialist reviewer roster as a **conditional specialist** — triggered when a full-mode diff changes what a reader or adopter sees (a new page, a redesigned screen, a pack card, a docs page). It carries the standard select-or-note fallback: absence of the experience pack is a named skip, not a silent pass. Light-mode user-facing changes (copy edits, minor tweaks) receive only the pre-EXECUTE design-intent recommendation, not the review gate.
+- **Because:** A frontend page can clear `adversarial-reviewer`, `security-reviewer`, and `quality-engineer` and still ship without design sense — those three lenses review code correctness, security, and testability but hold no design or experience lens. Autonomous design sessions (and solo work done without a design step) can produce pages that are technically sound but experientially broken.
+- **Applies to:** The `core` pack's `work-loop` SKILL.md; any adopter who has the `experience` pack installed.
+- **Tradeoff accepted:** The gate is degradable — when the experience pack is absent, the loop proceeds with a named skip rather than blocking. This is the same posture as `security-reviewer` on security-boundary diffs, and mirrors the broader select-or-note discipline (`work-loop` SKILL.md § 4 REVIEW). The result is a gate that fires when the right tools are available rather than a gate that blocks all adopters regardless of their pack configuration.
+- **Revisit if:** The experience-reviewer scope expands beyond design artifacts to code diffs (it would then need a different trigger); or the pack cross-dependency model changes (if core declares a hard dependency on experience, the select-or-note fallback becomes unnecessary).
+
+## Context
+
+### The gap
+
+`work-loop`'s specialist reviewer roster covers three lenses:
+- `adversarial-reviewer` — always-on; spec/plan drift, missing edge cases, scope creep.
+- `security-reviewer` — security-boundary diffs; auth, secrets, file/network I/O.
+- `quality-engineer` — every full-mode loop; testability, observability, maintainability.
+
+None of these holds a **design or experience lens**. When an agent builds a new docs page or redesigns a site section, the REVIEW phase has no reviewer that can flag "hero subtitle describes features not outcomes" or "five-second scan fails — reader cannot determine fit." The design quality gap was surfaced in sessions building the Ottawa site (session 2026-07-01): multiple iterations shipped pages with no design sense because no gate required a design-lens reviewer.
+
+### Why not a new risk trigger?
+
+The backlog items (`experience-reviewer-as-work-loop-gate`, `experience-loop-trigger-for-site-changes`) both proposed a "user-facing surface" risk trigger. There are two reasons to implement this as a REVIEW-roster entry rather than a risk trigger:
+
+1. **The existing trigger already covers the high-stakes case.** A net-new page published to a public site IS "a public or published interface" under the existing "Structural or public-interface change" trigger — it routes to full mode already. Adding a new trigger would be redundant for the exact case where the gate matters most.
+
+2. **Not all user-facing surface work warrants full-mode ceremony.** A minor copy edit on an existing page (fixing a typo, reordering a list) does not justify full-mode ceremony. A reviewer that fires only in full mode correctly scopes to the higher-risk changes (net-new pages, structural redesigns) where the architectural investment is already justified.
+
+The result: full-mode user-facing surface diffs get the experience-reviewer gate; light-mode surface changes get the pre-EXECUTE design-intent recommendation only.
+
+### ADR-0042 value test
+
+ADR-0042 requires a new reviewer to clear:
+1. **Different loop or work type than the core code-review gate.** ✓ — experience review is design/UX review, not code-diff review. It runs on rendered output (a described screen, a screenshot, a built page), not on the code diff itself.
+2. **Unique agent value** — forked-context independence, parallelism, or distinct surface/cadence. ✓ — forked-context independence (the reviewer has not seen the authoring session; `design-critique`'s existing note confirms same-session review marks its own homework); distinct surface/cadence (a generated screen, not a code diff; invoked after EXECUTE, not inline).
+3. **Charter's four principles.** ✓ — principle 3 in particular ("not a runtime engine") is satisfied; experience-reviewer is read-only and returns a findings block.
+4. **Collision-hardened by construction.** ✓ — "experience-reviewer" has a unique discipline-word head distinct from "adversarial-reviewer," "security-reviewer," and "quality-engineer."
+
+## Decision
+
+> `experience-reviewer` is a **conditional specialist reviewer** in `work-loop`'s REVIEW section — not a fourth core-code-review lens, not always-on, and not behind a new risk trigger. It fires when the diff crosses a user-facing surface in full-mode work, carrying the standard select-or-note fallback. The pre-EXECUTE design-intent pass (running `aesthetic-direction` / `design-critique` before writing code for user-facing surface work) is advisory in both light and full mode.
+
+Concretely:
+
+- **Trigger:** "for diffs that change what a reader or adopter sees — a new page, a redesigned screen, a pack card, a docs page — in full-mode work."
+- **Mandatory posture (select-or-note):** same enforcement surface as `security-reviewer`. The end-of-session checklist requires either a clean return or an explicit named skip. Absence of the experience pack is not a silent pass.
+- **Artifact handoff:** the orchestrator passes the rendered output (described screen, screenshot, or path to built artifact) **plus the grounded aesthetic reference and constraints** (persona, outcome, platform surface) — not the code diff. Experience-reviewer's confirm-before-reviewing gate requires the grounded reference; an orchestrator that omits it produces a degraded review.
+- **Light-mode advisory:** the pre-EXECUTE design-intent pass appears in the PLAN section with no full-mode gate. Light-mode changes receive the recommendation; only full-mode changes require the review gate.
+
+## Consequences
+
+**Positive:**
+- Net-new user-facing pages authored in full mode (which they are — they fire "Structural or public-interface change") get an independent design lens before merge.
+- The pattern is identical to `security-reviewer`'s conditional-specialist posture — easy to reason about, easy to extend.
+- Light-mode copy changes are not burdened with full reviewer ceremony.
+- Cross-pack dependency is soft (select-or-note fallback) — adopters without the experience pack are not blocked.
+
+**Negative:**
+- The gate degrades when the experience pack is absent — teams who skip experience pack installation will never see the gate fire even for net-new pages. Mitigated by the named-skip discipline (the final summary always names the skipped reviewer).
+- The full-mode-only scoping means a light-mode copy edit that ships misleading marketing copy gets only the advisory, not the gate. Mitigated by the marketing clarity criterion added to `design-critique` (same PR).
+
+## Confirmation
+
+- **Mode:** reviewer-checked
+- **Signal:** the `adversarial-reviewer` pass and the implementing PR author confirm: the experience-reviewer entry in the SKILL.md carries the select-or-note fallback, names the artifact handoff contract, and the end-of-session checklist includes the reviewer in the coverage line.
+- **Owner:** the PR author + the `adversarial-reviewer` pass.
+
+## Alternatives considered
+
+- **Add a "user-facing surface" risk trigger** to route all such changes to full mode. Declined: the existing "Structural or public-interface change" trigger already covers the high-stakes case (net-new pages); adding a new trigger would be redundant at the high end and too broad at the low end (minor copy edits do not warrant full-mode ceremony).
+- **Make experience-reviewer always-on** alongside the three core lenses. Declined: ADR-0042 explicitly caps core always-on lenses at three (adversarial, security, quality); adding a fourth is a charter question. The conditional-specialist posture avoids that bar.
+- **No gate — rely on author judgment.** Declined: the session record (Ottawa site, 2026-07-01) demonstrates this fails in practice. Multiple iterations shipped design-sense failures because no gate required a design-lens review.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -51,6 +51,8 @@
 | 0043 | [The upstream discovery coordinator is an agent + a skill + a carried sidecar-schema contract — no new runtime engine, spike-confirmed; the sidecar is the connectedness verifier](0043-the-discovery-coordinator-is-an-agent-plus-skill-plus-carried-sidecar-no-engine.md) | Accepted |
 | 0044 | [Split the build loop from a deployed-validation outer loop, and carve deploy autonomy by minimum-regret](0044-inner-outer-loop-split-and-minimum-regret-deploy-carve.md) | Accepted |
 | 0045 | [Document extraction is capability-tiered and presence-checked — a no-ML floor degrades up through agent-vision, approved-ML, and an explicit-only managed-API tier](0045-capability-tiered-document-extraction.md) | Accepted |
+| 0046 | [The `.msg` reader is `olefile` + hand-rolled MAPI parsing — permissive, no copyleft, no Python-2-broken dependency](0046-msg-reader-is-olefile-plus-hand-rolled-mapi-permissive-no-copyleft.md) | Accepted |
+| 0047 | [experience-reviewer is a conditional specialist reviewer in work-loop for user-facing surface diffs — select-or-note, full-mode only](0047-experience-reviewer-as-work-loop-gate.md) | Accepted |
 
 ## Adding a new ADR
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1272,44 +1272,29 @@ reviews against a design system but doesn't author one).
 
 ### design-critique-marketing-clarity-criterion
 
-**Source:** Session 2026-07-01 — `design-critique` covers UX/visual heuristics (Nielsen's 10,
-WCAG SCs, Hick's Law, Fitts's Law). It does not cover whether copy motivates, communicates to a
-skeptical evaluator, or passes basic conversion architecture tests.
-
-**Gap:** A reviewer using `design-critique` today would not flag "hero subtitle describes features
-not outcomes" or "zero social proof above the fold" — those are copy/conversion concerns, not
-UX/visual ones. The heuristics covering them (tweet test, five-second evaluator scan, painkiller
-framing) are absent from the skill's criterion set.
-
-**Proposed work (amendment, not a new skill):** Add a "marketing clarity" criterion section to
-`design-critique`: tweet test (headline stands alone as a conviction statement), five-second scan
-(does the above-fold answer: what is this / who is it for / should I care?), and painkiller-first
-structure check (does the copy lead with the reader's problem, not the author's feature list). This
-is a bounded amendment — no new skill file, no RFC needed unless the change crosses a public
-interface. Route as a normal PR with `adversarial-reviewer` pass.
-
-**Unblocks when:** taken as a `design-critique` skill amendment PR.
+> **Shipped — experience 0.4.0 (2026-07-02).** Marketing clarity pass added to
+> `design-critique` as mode 3: tweet test, five-second scan, painkiller-first. Fires on
+> above-fold copy with a persuasion/conversion goal. See spec
+> `design-critique-marketing-clarity` and changelog `[Unreleased]`.
 
 ### experience-reviewer-as-work-loop-gate
 
-**Source:** Session 2026-07-01 — no formal mechanism routes work-loop's reviewer roster to include
-`experience-reviewer` when a change crosses a user-facing surface. The reviewer is available but
-never auto-triggered.
+> **Shipped — core 0.8.0 (2026-07-02).** `experience-reviewer` added to `work-loop`'s specialist
+> reviewer roster as a conditional gate for full-mode user-facing surface diffs (select-or-note,
+> same posture as `security-reviewer`). Pre-EXECUTE design-intent pass added to PLAN (advisory in
+> both modes). ADR-0047 records the decision including the trigger-scoping rationale (full-mode only;
+> net-new pages already route to full mode via the existing "Structural or public-interface change"
+> trigger). See spec `experience-reviewer-work-loop-gate` and changelog `[Unreleased]`.
 
-**Gap:** Work-loop's risk triggers fire specialist reviewers (security-reviewer for auth/secrets,
-quality-engineer for testability). There is no analogous trigger for changes that affect what a
-reader sees — a new docs page, a site redesign, a pack card rewrite. The experience reviewer exists
-but must be invoked manually; the SDLC gate is missing.
+### new-spec-ui-design-readiness
 
-**Proposed work:** Define a "user-facing surface" risk trigger in work-loop: *does this change what
-a reader or adopter sees?* If yes → `experience-reviewer` runs as a mandatory gate alongside the
-standard reviewer roster. The full working hypothesis and governance implications are in
-[`experience-loop-trigger-for-site-changes`](#experience-loop-trigger-for-site-changes) in the
-site section. This is the pack-level policy decision; the site section is the concrete example.
-
-**Unblocks when:** ADR or RFC establishes the trigger contract and work-loop skill is updated.
-Needs a decision on mandatory vs. recommended (suggested: mandatory for net-new user-facing pages,
-recommended for copy changes).
+> **Shipped — core 0.9.0 (2026-07-02).** New step 4d added to `new-spec`: when `Shape: ui`
+> is confirmed, checks for a grounded aesthetic reference before ACs are written, offers
+> `aesthetic-direction` if none exists, offers `design-critique` on affected existing surfaces,
+> and requires at least one design-intent AC observable from the rendered surface. Select-or-note
+> fallback when experience pack is absent. This closes the spec-authoring gap: design intent
+> is now established before ACs are written, not discovered post-ship. See spec
+> `new-spec-ui-design-readiness` and changelog `[Unreleased]`.
 
 ---
 
@@ -1346,26 +1331,14 @@ routed through `work-loop` light mode.
 
 ### experience-loop-trigger-for-site-changes
 
-**Source:** Session 2026-07-01 — question raised about when `experience` pack
-skills should trigger for frontend or product changes that affect user-facing
-surfaces including this docs site.
-
-**Open:** Define the trigger points for experience pack skills (`aesthetic-direction`,
-`design-critique`, `experience-reviewer`) in the context of:
-- Changes to this GitHub Pages site (`site/docs/`, `site/mkdocs.yml`, `tools/build-site.py`)
-- Changes to user-facing product docs (`docs/guides/`, `docs/product/`)
-- New pack additions or removals that change the catalogue content
-
-**Working hypothesis:** experience pack trigger belongs in `work-loop`'s risk
-triggers — specifically under "Structural or public-interface change" when that
-change crosses a user-facing surface. The check would be: *does this change what
-a reader sees on the site?* If yes → experience reviewer runs in addition to the
-standard reviewer roster.
-
-**Unblocks when:** an RFC or ADR establishes the trigger contract and the
-`work-loop` skill is updated with a user-facing-surface risk trigger. Needs
-discussion on whether the experience loop is a mandatory gate or a recommended
-gate (suggested: mandatory for net-new pages, recommended for content changes).
+> **Shipped — core 0.8.0 / ADR-0047 (2026-07-02).** Resolved by the
+> `experience-reviewer-as-work-loop-gate` item above. ADR-0047 establishes: net-new pages and
+> substantial redesigns route to full mode via the existing "Structural or public-interface
+> change" trigger → experience-reviewer gate fires as a conditional specialist reviewer. The
+> pre-EXECUTE design-intent pass (aesthetic-direction / design-critique) is advisory in both
+> modes. This applies to site changes, product docs, and pack card changes equally — the trigger
+> is surface-type, not directory-specific. The content-strategy-and-marketing-copy-lens item
+> below covers the remaining open gaps.
 ### content-strategy-and-marketing-copy-lens
 
 **Source:** Session 2026-07-01 — building the GitHub Pages site exposed a gap:

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -19,6 +19,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`design-critique` now includes a marketing clarity pass (experience 0.4.0).** A new
+  fourth mode runs when the artifact has above-fold copy with a persuasion/conversion
+  goal (landing pages, pack cards, product announcements — not settings screens or forms).
+  It checks the tweet test (headline stands alone as a conviction statement), the
+  five-second scan (above-fold answers what / who / should I care), and painkiller-first
+  structure (copy leads with the reader's problem, not the author's feature list). Each
+  finding maps to the violated criterion with a `marketing` source label and a 0–4
+  severity using the existing frequency × impact × persistence rubric, where impact means
+  conversion/persuasion cost.
+
+- **`new-spec` now prompts for design-readiness on ui-shaped specs (core 0.9.0).** When
+  `Shape: ui` is confirmed, a new step 4d checks whether a grounded aesthetic reference
+  (`aesthetic-direction` output) exists before the Acceptance Criteria are written,
+  offers to run `design-critique` on any existing affected surface, and requires at
+  least one design-intent AC whose outcome is observable from the rendered surface —
+  not derivable from code. If the experience pack is absent, it notes that in Assumptions
+  and proceeds. This is the spec-authoring complement to `work-loop`'s pre-EXECUTE
+  design-intent pass: both target the same failure mode (technically correct surfaces
+  with no design sense) at different stages of the loop.
+
+- **`work-loop` now includes a pre-EXECUTE design-intent pass and an `experience-reviewer`
+  gate for user-facing surface diffs (core 0.8.0).** When a change produces a user-facing
+  surface — a new page, a redesigned screen, a pack card, a docs page — the PLAN section
+  now recommends running `aesthetic-direction` and/or `design-critique` before writing
+  code (advisory in both light and full mode, analogous to "write the test first"). For
+  full-mode user-facing surface diffs, `experience-reviewer` is added to the specialist
+  reviewer roster alongside `security-reviewer` and `quality-engineer`: it receives the
+  rendered output plus the grounded aesthetic reference and constraints, and runs with
+  the standard select-or-note fallback when the experience pack is absent. Decision
+  recorded in ADR-0047.
+
 - **`msg-to-markdown` is now a pure-Python skill that also reads `.eml`, and
   emits the unified output contract (converters 0.6.0).** The Outlook `.msg`
   converter is re-hosted from Node.js onto Python: `.msg` is read via `olefile` +

--- a/docs/specs/design-critique-marketing-clarity/plan.md
+++ b/docs/specs/design-critique-marketing-clarity/plan.md
@@ -1,0 +1,62 @@
+# Plan: design-critique-marketing-clarity
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Implementing
+
+## Tasks
+
+### Task 1: Add marketing clarity mode to design-critique SKILL.md
+
+**Verification mode:** Visual / manual QA
+
+**Done when:** `design-critique` SKILL.md contains a mode 3 (marketing clarity)
+with the three criteria (tweet test, five-second scan, painkiller-first), modes
+are renumbered 1–4, frontmatter description includes marketing trigger phrases,
+and a human reading the skill can trace exactly what gets checked on a marketing
+page.
+
+**Tests:** `no stub (mode)` — prose doc; scenario-based verification per spec.
+
+**Approach:**
+1. Edit `packs/experience/.apm/skills/design-critique/SKILL.md`:
+   - Update frontmatter `description:` to add marketing/copy trigger phrases
+   - Renumber existing mode 3 (taste) → mode 4
+   - Insert new mode 3 (marketing clarity) between heuristics and taste
+   - Add trigger condition, three criteria, severity mapping, source label
+2. Run `make lint-packs` to verify pack metadata is valid.
+3. Run `make build-self` to project the updated skill.
+
+**Depends on:** none
+
+### Task 2: Bump experience pack version
+
+**Verification mode:** Goal-based check
+
+**Done when:** `packs/experience/pack.toml` version reads `0.4.0` and
+`make build-self` produces a clean `marketplace.json` reflecting the new version.
+
+**Tests:** `no stub (mode)` — verify with `grep '"version": "0.4.0"' marketplace.json`
+
+**Approach:**
+1. Bump `[pack] version` in `packs/experience/pack.toml` from `0.3.0` to `0.4.0`.
+2. Bump `"version"` in `packs/experience/.claude-plugin/plugin.json` from `0.3.0`
+   to `0.4.0` (marketplace.json aggregates from plugin.json, not pack.toml).
+3. Run `make build-self` to regenerate marketplace.json.
+
+**Depends on:** Task 1 (build-self regenerates from source edits)
+
+### Task 3: Update changelog and close backlog item
+
+**Verification mode:** Goal-based check
+
+**Done when:** `docs/product/changelog.md` has an `[Unreleased]` entry for the
+marketing clarity mode; `docs/backlog.md` item
+`design-critique-marketing-clarity-criterion` is closed with a shipped note.
+
+**Tests:** `no stub (mode)` — grep for entry existence.
+
+**Approach:**
+1. Add entry to `docs/product/changelog.md` `[Unreleased]` / `### Added`.
+2. Add shipped tombstone to `docs/backlog.md` under the item heading.
+
+**Depends on:** Task 1

--- a/docs/specs/design-critique-marketing-clarity/spec.md
+++ b/docs/specs/design-critique-marketing-clarity/spec.md
@@ -1,0 +1,126 @@
+# Spec: design-critique-marketing-clarity
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** ADR-0042 (agent additions keyed to loop/work-type); backlog item `design-critique-marketing-clarity-criterion`
+- **Brief:** none
+- **Contract:** none
+- **Shape:** n/a — methodology/prose change (`design-critique` SKILL.md edit); no application LLD
+
+`Mode: full (governance + public-interface change — shipped skill method change with frontmatter description update)`
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+Agents running `design-critique` on a marketing page or landing page get a
+**marketing clarity pass** that the current skill omits. Today the skill walks
+Nielsen's 10 usability heuristics and checks the quality floor — both are
+usability lenses, not copy/conversion lenses. A reviewer applying the skill to
+the Ottawa site's homepage would not flag "hero subtitle describes features not
+outcomes" or "zero social proof above the fold" because those are not usability
+failures. The three missing criteria are the tweet test, the five-second scan,
+and painkiller-first structure. Success is: (P1) a new mode 3 (marketing clarity
+pass) is added to the skill, running when the artifact includes above-fold
+marketing copy; (P2) the frontmatter description is updated to include
+copy/marketing trigger phrases; (P3) the four modes are clearly ordered and the
+source mode label on findings distinguishes `marketing` from `floor` / `heuristic`
+/ `taste`; (P4) severity guidance applies to marketing clarity findings using the
+existing 0–4 rubric.
+
+## Boundaries
+
+### Always do
+- Edit the **source** `packs/experience/.apm/skills/design-critique/SKILL.md`.
+  Run `make build-self` after to regenerate projections.
+- Keep the three existing passes intact (quality-floor, heuristics, taste) —
+  marketing clarity is an additive fourth mode.
+- Marketing clarity runs as **mode 3**, between heuristics (mode 2) and taste
+  (mode 4). Renumber accordingly.
+- Bump experience pack to 0.4.0: `packs/experience/pack.toml` **and**
+  `packs/experience/.claude-plugin/plugin.json` (marketplace.json aggregates
+  version from plugin.json, not pack.toml — both must match).
+- Add a `docs/product/changelog.md` `[Unreleased]` entry.
+
+### Ask first
+- Adding a new `references/` file for marketing clarity depth — the three
+  criteria fit inline in the SKILL.md; only add a reference if the criteria
+  require more than a paragraph each.
+- Changing when the quality-floor or heuristics passes run.
+
+### Never do
+- Touch the risk-triggers block in `packs/core/.apm/skills/work-loop/SKILL.md`.
+- Create a new `marketing-critique` skill; this is a bounded amendment.
+- Add normative stack-specific implementation guidance (no "use a hero section
+  with H1 + subtitle" — express as design intent only).
+
+## Acceptance Criteria
+
+- [x] **AC1.** `design-critique` SKILL.md lists four modes, numbered 1–4:
+  quality-floor, heuristic evaluation, marketing clarity, taste critique.
+- [x] **AC2.** Marketing clarity mode specifies its trigger condition: runs
+  "when the artifact includes above-fold marketing copy (hero, tagline, CTA
+  section) with a persuasion/conversion goal" — and explicitly does NOT fire for
+  internal tools, forms, settings screens, or content pages with no conversion goal.
+- [x] **AC3.** Tweet test criterion: headline stands alone as a conviction
+  statement (shareable without context).
+- [x] **AC4.** Five-second scan criterion: above-fold answers what / who / should
+  I care within 5 seconds.
+- [x] **AC5.** Painkiller-first criterion: copy leads with the reader's
+  problem/desired outcome, not the author's feature list.
+- [x] **AC6.** Each marketing clarity finding maps to the criterion it violates
+  and carries a severity (0–4) with the `marketing` source mode label. Severity
+  reuses the frequency × impact × persistence rubric from `heuristics.md`, with
+  "impact" meaning conversion/persuasion cost (how badly the miss hurts the
+  reader's ability to determine fit and take the intended action); the SKILL.md
+  states this mapping explicitly so reviewers know it is a deliberate application
+  of the rubric, not a fresh opinion scale.
+- [x] **AC7.** Frontmatter description includes copy/marketing trigger phrases
+  (e.g., "is this copy compelling", "does this headline work", "tweet test",
+  "does this page convert").
+- [x] **AC8.** All existing prose references to the mode count ("three modes") and
+  to taste-as-mode-3 in `SKILL.md` are updated consistently: the intro list
+  (current line 10), the "always run in this order" sentence, the procedure step
+  numbering (steps 5 → 6 for taste, insert 5 for marketing clarity), the
+  "Mode:" source label set in the findings-output sentence, and any "all three
+  modes" references. Verified by reading the amended file and confirming no
+  orphaned "three" / "mode 3 = taste" reference survives.
+- [x] **AC9.** The existing anti-patterns list is unchanged (no new anti-patterns
+  added that would contradict the new mode).
+- [x] **AC10.** `make lint-packs` passes clean.
+- [x] **AC11.** `make build-self` completes without error and
+  `grep '"version"' marketplace.json` returns `"0.4.0"` for the experience pack.
+
+## Testing Strategy
+
+Verification mode: **Visual / manual QA** — this is a prose skill document;
+correctness is demonstrated by reading the amended skill and confirming it would
+surface marketing clarity findings on a sample scenario.
+
+**Scenario A (positive):** apply the amended `design-critique` skill to a landing page
+whose above-fold copy reads "Agent-ready-repo: A monorepo template for multi-adapter
+AI coding agents." Expected outcome: marketing clarity pass fires; tweet test finding
+raised (headline describes what it is but doesn't communicate why a developer should
+care — no conviction); five-second scan finding raised (reader can answer "what is
+this" but not "should I care"); painkiller-first finding raised (copy leads with the
+author's feature list, not the reader's pain).
+
+**Scenario B (negative):** apply the amended skill to a settings screen with four
+input fields and a Save button. Expected outcome: marketing clarity pass does NOT
+fire; only quality-floor, heuristics, and (if a grounded reference exists) taste
+passes run. No "marketing" source-label findings in output.
+
+**No unit tests** — skill is pure prose; correctness is by human + reviewer judgment.
+
+## Assumptions
+
+1. **Verified:** The existing three modes are correct and complete for
+   usability/taste review — no changes to quality-floor, heuristics, or taste passes.
+2. **Decided:** Marketing clarity criteria are bounded and stable enough to inline;
+   no dedicated `references/` file is added (the "Ask first" boundary commits to
+   this; reversed only if criteria expand beyond a paragraph).
+3. **Verified:** The experience pack has no existing "marketing" or "conversion"
+   criterion in any reference file (grep confirms: no match on "tweet test" or
+   "painkiller" in `packs/experience/`).

--- a/docs/specs/experience-reviewer-work-loop-gate/plan.md
+++ b/docs/specs/experience-reviewer-work-loop-gate/plan.md
@@ -1,0 +1,101 @@
+# Plan: experience-reviewer-work-loop-gate
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Implementing
+
+## Tasks
+
+### Task 1: Write ADR-0047 and update ADR README
+
+**Verification mode:** Visual / manual QA
+
+**Done when:** `docs/adr/0047-experience-reviewer-as-work-loop-gate.md` exists,
+status Accepted, records: the mandatory/recommended split (select-or-note for
+full-mode user-facing diffs; recommendation only for light mode); the trigger
+scoping rationale (existing "Structural or public-interface change" covers
+net-new pages); and the ADR-0042 value test clearance. `docs/adr/README.md`
+table includes ADR-0046 (if previously missing) and ADR-0047.
+
+**Tests:** `no stub (mode)` — prose ADR.
+
+**Approach:**
+1. Check `docs/adr/README.md` tail — add ADR-0046 entry if missing.
+2. Write `docs/adr/0047-experience-reviewer-as-work-loop-gate.md` following
+   the repo ADR format.
+3. Append ADR-0047 to `docs/adr/README.md` table.
+
+**Depends on:** none
+
+### Task 2: Update work-loop SKILL.md
+
+**Verification mode:** Visual / manual QA
+
+**Done when:** `packs/core/.apm/skills/work-loop/SKILL.md` contains:
+(a) pre-EXECUTE design-intent pass bullet in PLAN section (both modes, advisory);
+(b) experience-reviewer entry in specialist reviewer roster (REVIEW section) with
+trigger, select-or-note fallback, and artifact/seed contract;
+(c) experience-reviewer in end-of-session checklist reviewer-coverage line;
+and the risk-triggers block is byte-unchanged (verified by grep of the block span).
+
+**Tests:** `no stub (mode)` — prose skill; verified by reading the amended file.
+
+**Approach:**
+1. Edit `packs/core/.apm/skills/work-loop/SKILL.md`:
+   - After the "Pre-EXECUTE secure-design review" bullet, insert a
+     "Pre-EXECUTE design-intent pass (user-facing surface trigger)" bullet.
+     The bullet must carry **no full-mode gate** — it is advisory in both modes
+     (light mode reuses PLAN bullets verbatim; gating it to full-only would make
+     Scenario C unverifiable).
+   - After the `quality-engineer` specialist reviewer entry, add
+     `experience-reviewer` entry with trigger, select-or-note fallback, and
+     artifact/seed contract (rendered output + grounded reference + constraints).
+   - Update the end-of-session checklist reviewer-coverage line to include
+     `experience-reviewer on user-facing surface diffs (full mode)`.
+2. Verify risk-triggers block unmodified via diff:
+   `git diff packs/core/.apm/skills/work-loop/SKILL.md` should show no changes
+   inside the `<!-- risk-triggers:start -->...<!-- risk-triggers:end -->` span.
+
+**Depends on:** none
+
+### Task 3: Bump core pack, run build-self, verify gates
+
+**Verification mode:** Goal-based check
+
+**Done when:** `packs/core/pack.toml` and `packs/core/.claude-plugin/plugin.json`
+both read `0.8.0`; `make lint-packs` passes; `make build-self` completes without
+error; `grep '"version"' marketplace.json` returns `"0.8.0"` for the core pack;
+projected SKILL.md (`.claude/skills/work-loop/SKILL.md`) contains the new
+experience-reviewer entry; risk-triggers block in all canonical copies is
+byte-identical to the source.
+
+**Tests:** `no stub (mode)` — build output and grep.
+
+**Approach:**
+1. Bump `[pack] version` in `packs/core/pack.toml` from `0.7.2` to `0.8.0`.
+2. Bump `"version"` in `packs/core/.claude-plugin/plugin.json` from current
+   to `0.8.0` (marketplace.json aggregates from plugin.json).
+3. Run `make lint-packs`.
+4. Run `make build-self`.
+5. Verify risk-triggers block byte-equality via diff on the extracted span:
+   extract the `<!-- risk-triggers:start -->...<!-- risk-triggers:end -->` block
+   from each of the four canonical copies and diff them pairwise — any difference
+   is a gate failure. `git diff` on the block region also works.
+
+**Depends on:** Tasks 1 and 2
+
+### Task 4: Update changelog and close backlog items
+
+**Verification mode:** Goal-based check
+
+**Done when:** `docs/product/changelog.md` has an `[Unreleased]` entry for the
+experience-reviewer gate; backlog items `experience-reviewer-as-work-loop-gate`
+and `experience-loop-trigger-for-site-changes` have shipped tombstones referencing
+ADR-0047 and core 0.8.0.
+
+**Tests:** `no stub (mode)` — grep.
+
+**Approach:**
+1. Add entry to `docs/product/changelog.md` `[Unreleased]` / `### Added`.
+2. Add shipped tombstones to `docs/backlog.md` under both item headings.
+
+**Depends on:** Tasks 1, 2, and 3

--- a/docs/specs/experience-reviewer-work-loop-gate/spec.md
+++ b/docs/specs/experience-reviewer-work-loop-gate/spec.md
@@ -1,0 +1,151 @@
+# Spec: experience-reviewer-work-loop-gate
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** ADR-0042 (agent additions keyed to loop/work-type); ADR-0014 (rigor scales with risk); backlog items `experience-reviewer-as-work-loop-gate` and `experience-loop-trigger-for-site-changes`
+- **Brief:** none
+- **Contract:** none
+- **Shape:** n/a — methodology/prose change (`work-loop` SKILL.md edit + new ADR); no application LLD
+
+`Mode: full (structural or public-interface change — work-loop REVIEW section)`
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+Agents running the `work-loop` on a change that produces a user-facing surface
+(a new page, a redesigned screen, a component, a docs page) get an
+`experience-reviewer` pass as a conditional specialist reviewer gate — the same
+pattern as a security-boundary diff getting a `security-reviewer` pass. Today the
+specialist reviewer roster covers code correctness (`adversarial-reviewer`),
+security (`security-reviewer`), and quality (`quality-engineer`), but not design
+quality. A frontend page can clear all three and still ship with no design sense,
+because no reviewer in the roster holds a design lens.
+
+**Trigger scoping decision (ADR-0047):** the experience-reviewer gate applies to
+full-mode work only. Net-new pages and substantial redesigns already route to full
+mode under the existing "Structural or public-interface change" risk trigger
+(publishing new content to a public site IS publishing a public interface). Light-mode
+user-facing changes (minor copy edits, small ordering tweaks) get only the
+pre-EXECUTE design-intent recommendation, not the mandatory review gate. The ADR
+records this decision and the argument explicitly.
+
+Success is: (P1) work-loop documents a pre-EXECUTE design-intent pass for
+user-facing surface work (recommend `aesthetic-direction` / `design-critique`
+authoring-time skills before writing code); (P2) `experience-reviewer` is added to
+the specialist reviewer roster in the REVIEW section, triggered when the diff
+crosses a user-facing surface in full-mode work, with the same select-or-note
+fallback the other specialist reviewers carry; (P3) the end-of-session checklist
+names `experience-reviewer` in the reviewer coverage line; (P4) an ADR records the
+decision including the trigger scoping rationale.
+
+## Boundaries
+
+### Always do
+- Edit the **source** `packs/core/.apm/skills/work-loop/SKILL.md`. Run
+  `make build-self` after to regenerate projections.
+- Write ADR-0047 documenting the decision, including the trigger-scoping rationale.
+- Update `docs/adr/README.md` table with ADR-0046 (if missing) and ADR-0047.
+- Bump core pack to 0.8.0: `packs/core/pack.toml` AND
+  `packs/core/.claude-plugin/plugin.json`.
+- Add a `docs/product/changelog.md` `[Unreleased]` entry.
+- Close backlog items `experience-reviewer-as-work-loop-gate` and
+  `experience-loop-trigger-for-site-changes` with shipped tombstones referencing ADR-0047.
+
+### Ask first
+- Adding a new risk trigger to the risk-triggers block — the trigger-scoping
+  decision (ADR-0047) argues this is not needed; surface if implementation
+  reveals a gap the existing "Structural or public-interface change" trigger
+  doesn't cover.
+- Changing the three core code-review lenses (adversarial-reviewer,
+  security-reviewer, quality-engineer) — capped by ADR-0042.
+- Creating a new reviewer agent — experience-reviewer already handles
+  "generated screens" and this decision is within ADR-0042.
+
+### Never do
+- Touch the `<!-- risk-triggers:start --> ... <!-- risk-triggers:end -->` block
+  in `packs/core/.apm/skills/work-loop/SKILL.md` or any of its four canonical
+  copies. The existing triggers suffice; a new trigger is ADR-gated.
+- Make experience-reviewer always-on (that would elevate it to the core-loop
+  ceiling; conditional-on-surface is the ADR-0042-safe posture).
+
+## Acceptance Criteria
+
+- [x] **AC1.** Work-loop PLAN section includes a "Pre-EXECUTE design-intent pass
+  (user-facing surface trigger)" bullet: recommends running `aesthetic-direction`
+  (if no grounded reference exists) and/or `design-critique` before writing code
+  for changes that produce a user-facing surface. Applies to both light and full
+  mode as a recommendation.
+- [x] **AC2.** Work-loop REVIEW section's specialist reviewer roster includes
+  `experience-reviewer` after `quality-engineer`.
+- [x] **AC3.** The experience-reviewer entry names its trigger: "for diffs that
+  change what a reader or adopter sees — a new page, a redesigned screen, a pack
+  card, a docs page — in full-mode work."
+- [x] **AC4.** The entry carries the standard select-or-note fallback: "fallback
+  if no `experience-reviewer` is installed: proceed and note it — absence of the
+  experience pack is a named skip, not a silent pass." This matches the pattern
+  the `security-reviewer` entry uses.
+- [x] **AC5.** The entry names the artifact experience-reviewer receives: the
+  orchestrator passes the **rendered output** (a described screen state, a
+  screenshot, or a path to the built artifact) **plus the grounded aesthetic
+  reference and constraints** (persona, outcome, platform surface) — not the
+  code diff. Experience-reviewer's confirm-before-reviewing gate requires the
+  grounded reference; the orchestrator must supply it.
+- [x] **AC6.** End-of-session checklist reviewer-coverage line includes
+  `experience-reviewer on user-facing surface diffs (full mode)`.
+- [x] **AC7.** ADR-0047 is written, status Accepted, decision-makers eugenelim,
+  and records: the mandatory/recommended split (mandatory for full-mode user-facing
+  diffs under select-or-note; recommended for light-mode); why the existing
+  "Structural or public-interface change" trigger covers net-new pages; why the
+  gate is scoped to full mode; and how the decision clears ADR-0042's value test
+  (different work type, forked-context independence, distinct surface/cadence).
+- [x] **AC8.** `docs/adr/README.md` table includes ADR-0046 (if previously missing)
+  and ADR-0047.
+- [x] **AC9.** The risk-triggers block is byte-identical before and after
+  `make build-self` across all canonical copies (grep confirms no edit to the
+  `risk-triggers:start … risk-triggers:end` span).
+- [x] **AC10.** `make lint-packs` passes clean.
+- [x] **AC11.** `make build-self` completes without error.
+
+## Testing Strategy
+
+Verification mode: **Visual / manual QA** — this is a prose skill document and
+an ADR; correctness is demonstrated by reading the amended work-loop and confirming
+the design-intent pass and experience-reviewer gate are correctly wired.
+
+**Scenario A (positive, experience pack installed):** apply the amended `work-loop`
+to a full-mode task "add a new docs page for the experience pack." Expected outcome:
+PLAN section recommends a design-intent pass (aesthetic-direction / design-critique);
+REVIEW section uses experience-reviewer with the rendered page + grounded reference
++ constraints; checklist requires noting the result. Core reviewers unchanged.
+
+**Scenario B (experience pack absent):** apply the amended `work-loop` to the same
+full-mode task but experience pack is not installed. Expected outcome: the loop
+proceeds and the final summary explicitly names "experience-reviewer: no matching
+subagent installed; review skipped" — NOT a silent pass, NOT a loop failure.
+
+**Scenario C (light mode, copy edit):** apply the amended `work-loop` to a
+light-mode task "fix a typo on the Ottawa site homepage." Expected outcome: no
+experience-reviewer gate fires (light mode → no specialist reviewer run); the
+pre-EXECUTE design-intent pass recommendation appears in PLAN but is advisory only.
+
+**No unit tests** — skill and ADR are pure prose.
+
+## Assumptions
+
+1. **Verified:** `experience-reviewer` handles "a generated screen" as a design
+   artifact (`packs/experience/.apm/agents/experience-reviewer.md` scope list).
+2. **Verified:** The experience-reviewer gate is within ADR-0042 (different
+   loop/work-type — experience review vs. code-diff review; forked-context
+   independence; distinct surface/cadence).
+3. **Verified:** No existing spec or ADR conflicts with adding experience-reviewer
+   as a conditional specialist; ADR-0042 explicitly admits this class of reviewer.
+4. **Decided:** Trigger scoping is full-mode only. Net-new pages fire the existing
+   "Structural or public-interface change" risk trigger → full mode → gate reachable.
+   Light-mode changes get the recommendation, not the gate. Recorded in ADR-0047.
+5. **Verified:** The risk-triggers block is NOT changed by this spec (grep-equality
+   contract from work-loop-light-mode spec is maintained).
+6. **Verified:** `packs/core/.claude-plugin/plugin.json` exists and must be bumped
+   alongside `pack.toml` (marketplace.json aggregates version from plugin.json).

--- a/docs/specs/new-spec-ui-design-readiness/plan.md
+++ b/docs/specs/new-spec-ui-design-readiness/plan.md
@@ -1,0 +1,35 @@
+# Plan: new-spec-ui-design-readiness
+
+- **Status:** Done
+- **Spec:** [`spec.md`](spec.md)
+
+## Tasks
+
+### Task 1 — Add step 4d to new-spec SKILL.md
+
+- **Verification mode:** Visual / manual QA
+- **Depends on:** none
+- **Tests:** Read the amended file; confirm step 4d is present between 4c and 5;
+  confirm trigger condition (Shape: ui), aesthetic-reference check, design-critique
+  offer, design-intent AC requirement, select-or-note fallback, and work-loop
+  cross-reference are all present.
+- **Approach:** Edit `packs/core/.apm/skills/new-spec/SKILL.md`, inserting step 4d
+  between the closing line of step 4c and the opening of step 5.
+
+### Task 2 — Bump core pack to 0.9.0
+
+- **Verification mode:** goal-based check
+- **Depends on:** none
+- **Tests:** `grep '"version"' .claude-plugin/marketplace.json | grep core` returns
+  `0.9.0` after build-self.
+- **Approach:** Edit `packs/core/pack.toml` and `packs/core/.claude-plugin/plugin.json`
+  to `0.9.0`; run `make build-self FORCE=1`.
+
+### Task 3 — Update changelog and backlog
+
+- **Verification mode:** goal-based check
+- **Depends on:** Tasks 1, 2
+- **Tests:** `grep "new-spec-ui-design-readiness" docs/backlog.md` returns a Shipped
+  tombstone; `grep "new-spec" docs/product/changelog.md` returns an Unreleased entry.
+- **Approach:** Add `[Unreleased]` changelog entry; add Shipped tombstone to backlog
+  `## experience-pack` section.

--- a/docs/specs/new-spec-ui-design-readiness/spec.md
+++ b/docs/specs/new-spec-ui-design-readiness/spec.md
@@ -1,0 +1,128 @@
+# Spec: new-spec-ui-design-readiness
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** ADR-0042 (agent additions keyed to loop/work-type); ADR-0047 (experience-reviewer trigger scoping)
+- **Brief:** none
+- **Contract:** none
+- **Shape:** n/a — methodology/prose change (`new-spec` SKILL.md amendment); no application LLD
+
+`Mode: full (structural or public-interface change — shipped skill procedure change)`
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+When a `new-spec` author confirms `Shape: ui`, the skill has no guidance for
+baking design intent into the spec before the Acceptance Criteria are written.
+The result: UI feature specs routinely ship with only functional ACs — observable
+behavior the code must produce, but no design-intent criteria the rendered surface
+must satisfy. A spec like this drives an implementation that clears lint, tests,
+and adversarial review, yet ships with no design sense.
+
+The `work-loop` pre-EXECUTE design-intent pass (added in core 0.8.0) catches this
+at PLAN time — but only after the spec has already locked in functional-only ACs.
+This spec closes the earlier gap: add a conditional step 4d to `new-spec` that fires
+on `Shape: ui`, establishes design-readiness (grounded reference + existing-surface
+audit) before the ACs are written, and makes design-intent ACs mandatory for ui-shaped
+specs. The result is a spec that starts with design sense, not one that has to acquire
+it mid-implementation.
+
+Success is: (P1) a new step 4d in `new-spec` that fires on `Shape: ui`; (P2) step 4d
+checks for a grounded aesthetic reference and offers `aesthetic-direction` if absent;
+(P3) step 4d offers `design-critique` on existing affected surfaces; (P4) step 4d
+requires at least one design-intent AC in the spec; (P5) select-or-note fallback for
+when the experience pack is absent.
+
+## Boundaries
+
+### Always do
+- Edit the **source** `packs/core/.apm/skills/new-spec/SKILL.md`. Run
+  `make build-self` after to regenerate projections.
+- Insert step 4d between step 4c and step 5 — same conditional-step pattern as 4b
+  (contract authoring) and 4c (shape + stack).
+- The step must reference the `work-loop` pre-EXECUTE pass as the later-stage
+  analogue, so adopters understand the two-stage relationship.
+- Bump core pack to 0.9.0: `packs/core/pack.toml` AND
+  `packs/core/.claude-plugin/plugin.json`.
+- Add a `docs/product/changelog.md` `[Unreleased]` entry.
+
+### Ask first
+- Adding a canonical output path for `aesthetic-direction` docs — the skill does
+  not currently specify where the doc lives; adding a convention is an ADR-level
+  decision.
+- Making `aesthetic-direction` a mandatory prerequisite (the spec calls it
+  select-or-note, not mandatory; changing the posture is a separate decision).
+
+### Never do
+- Touch the risk-triggers block in `work-loop`.
+- Change when or how `work-loop`'s pre-EXECUTE design-intent pass fires — step 4d
+  and that pass are complementary, not substitutes.
+- Make step 4d fire for `Shape: service`, `data`, `integration`, or `mixed` — the
+  design lens applies to user-facing surfaces only.
+
+## Acceptance Criteria
+
+- [x] **AC1.** `new-spec` SKILL.md contains a step 4d that fires when `Shape: ui`
+  is confirmed in step 4c.
+- [x] **AC2.** Step 4d checks whether a grounded aesthetic reference exists (by
+  searching for a file matching `# Aesthetic direction:` in the repo) and offers to
+  run `aesthetic-direction` if none is found.
+- [x] **AC3.** Step 4d checks whether existing screens or flows are affected and
+  offers to run `design-critique` on existing surfaces before ACs are written.
+- [x] **AC4.** Step 4d requires the spec Objective to name the primary user task
+  and an aesthetic goal from the grounded reference.
+- [x] **AC5.** Step 4d requires at least one design-intent AC — observable from the
+  rendered surface, not derivable from code — with concrete example shapes provided.
+- [x] **AC6.** Step 4d carries the select-or-note fallback: if the experience pack
+  is absent, note it in Assumptions and proceed.
+- [x] **AC7.** Step 4d references `work-loop`'s pre-EXECUTE design-intent pass as
+  the later-stage analogue, naming the shared failure mode both target.
+- [x] **AC8.** `make lint-packs` passes clean.
+- [x] **AC9.** `make build-self` completes without error and marketplace.json shows
+  `"version": "0.9.0"` for the core pack.
+
+## Testing Strategy
+
+Verification mode: **Visual / manual QA** — this is a prose skill document;
+correctness is demonstrated by reading the amended skill and confirming step 4d
+would prompt the right behavior on a sample scenario.
+
+**Scenario A (experience pack installed, no existing reference):** run `new-spec`
+for "agent-docs-overhaul" with Shape: ui. Expected outcome: step 4d fires; agent
+checks for `# Aesthetic direction:` and finds nothing; agent offers to run
+`aesthetic-direction`; user confirms they'll handle it separately; agent notes the
+design intent is ungrounded and suggests the Objective name at least one aesthetic
+goal; final ACs include at least one design-intent criterion.
+
+**Scenario B (experience pack installed, reference exists):** run `new-spec` for
+"homepage-redesign" with Shape: ui. An `aesthetic-direction` doc exists. Expected
+outcome: step 4d fires; agent finds the reference; skips the offer; proceeds to
+ask whether existing screens are affected; writes at least one design-intent AC
+grounded in the named aesthetic goal.
+
+**Scenario C (experience pack absent):** run `new-spec` for a ui-shaped feature
+with no experience pack installed. Expected outcome: step 4d fires; agent notes
+experience pack absent in Assumptions; skips the offers; proceeds with functional
+ACs only. No silent pass.
+
+**Scenario D (Shape: service):** run `new-spec` for a backend service feature.
+Expected outcome: step 4d does NOT fire. Only steps 4a–4c and 4b run as applicable.
+
+**No unit tests** — skill is pure prose.
+
+## Assumptions
+
+1. **Verified:** `new-spec` step 4c already resolves `Shape:` before step 4d fires —
+   the trigger is clean (`packs/core/.apm/skills/new-spec/SKILL.md` step 4c).
+2. **Verified:** `aesthetic-direction` is in the experience pack and produces a doc
+   whose first heading is `# Aesthetic direction:` (confirmed from template).
+3. **Verified:** `design-critique` is in the experience pack and accepts an existing
+   surface as input.
+4. **Decided:** select-or-note posture for experience-pack absence matches ADR-0047
+   and the security-reviewer / experience-reviewer pattern already in `work-loop`.
+5. **Decided:** step 4d does not add an ADR — it follows the same rationale as
+   ADR-0047 (experience-reviewer as conditional specialist for user-facing surface
+   work) and extends it to spec-authoring time. No new architectural decision.

--- a/packs/core/.apm/skills/new-spec/SKILL.md
+++ b/packs/core/.apm/skills/new-spec/SKILL.md
@@ -234,6 +234,46 @@ look like?" before any code.
    The headings in `## Design (LLD)` stay universal; the prose under them is the
    stack-specific instance you resolved here.
 
+4d. **Design-readiness check (ui-shaped trigger).** Fires when `Shape: ui` is
+   confirmed (step 4c). Before writing the spec body — especially the Acceptance
+   Criteria — settle two design-readiness questions and weave the result into the spec.
+
+   If the experience pack is absent (`aesthetic-direction` and `design-critique`
+   unavailable): **proceed and note it** in the spec's Assumptions —
+   `experience pack not installed; design intent for this surface is ungrounded` —
+   then skip the rest of this step. Absence is a named gap, not a silent pass.
+
+   - **Check for a grounded aesthetic reference.** Search the repo for an aesthetic-
+     direction doc (any file whose first heading matches `# Aesthetic direction:`).
+     If none exists, offer to run `aesthetic-direction` before writing design-facing
+     ACs. A UI spec's design-intent ACs are unverifiable without a grounded reference;
+     the direction doc is what lets "this screen should feel <goal>" be checkable. If
+     the user declines or has a direction outside the repo, ask them to name the ranked
+     goals so you can reference them concretely in the spec.
+   - **Check whether existing screens or flows are affected.** If the spec modifies
+     an existing surface, offer to run `design-critique` on it before writing ACs.
+     Findings from the existing surface establish the design debt the implementation
+     must clear — surfacing them as explicit ACs is better than discovering them post-ship.
+   - **Weave design intent into the spec.** Once design-readiness is settled:
+     - In the **Objective**: name the primary user task the surface supports *and* the
+       aesthetic goal from the grounded reference it must satisfy.
+     - In the **Acceptance Criteria**: include at least one design-intent AC whose
+       outcome is observable from the rendered surface — not derivable from the code.
+       Concrete shapes: *"Above-fold copy passes the five-second scan for <persona>"*;
+       *"Screen clears the quality-floor and Nielsen heuristics with no severity-3+
+       findings"*; *"Taste critique against the <named aesthetic goal> passes with no
+       Major findings."* An AC like "component renders without errors" is not a
+       design-intent AC.
+
+   This step is the spec-time analogue of `work-loop`'s pre-EXECUTE design-intent pass
+   — establishing design intent before the ACs are written, rather than recommending
+   it before code is written. Both target the same failure mode (technically correct
+   surfaces with no design sense); this step catches it earlier.
+
+   **Mixed-shape note.** Step 4d fires on `Shape: ui` only. For a `mixed`-shaped spec
+   that includes a user-facing screen or flow, apply the same design-readiness questions
+   to that sub-surface — it is not covered automatically.
+
 5. Fill in the plan second. The plan should:
    - Cite any ADRs or RFCs it follows from.
    - Break the work into tasks small enough to be a single PR each.

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -309,6 +309,16 @@ For anything beyond trivial, *think before you write code*. Concretely:
   [`references/pre-execute-review.md`](references/pre-execute-review.md) and the
   REVIEW `security-reviewer` bullet. Same Profile-A opt-out and `approve-plan`
   gate; fallback if no `security-reviewer` is installed: proceed and note it.
+- **Pre-EXECUTE design-intent pass (user-facing surface trigger).** When the
+  change produces a user-facing surface — a new page, a redesigned screen, a
+  component, a pack card, a docs page — establish design intent **before writing
+  code**. Run `aesthetic-direction` (if no grounded aesthetic reference exists
+  yet) and/or `design-critique` (if there is an existing surface to evaluate)
+  and record the design intent in the spec. This is the design analogue of
+  "write the test first": design intent before implementation prevents the
+  common failure mode of technically correct surfaces with no design sense. Applies
+  in both light and full mode as a recommendation; the mandatory fresh-context
+  gate (`experience-reviewer`) runs in REVIEW for full-mode work.
 - **Initialize the loop's state file.** Run this skill's bundled
   `scripts/loop-cohort.py init docs/specs/<feature>`; the tool copies
   the bundled `assets/state.json` template into place, sets `feature`
@@ -656,6 +666,16 @@ note in the summary, not a blocker.
   infra wiring (the deferred `infra-contract-reviewer`, the `design-reviewer`
   spec-stage carve) in
   [`references/infra-verification.md`](references/infra-verification.md).
+- Match `experience-reviewer` — for diffs that change what a reader or adopter
+  sees (a new page, a redesigned screen, a pack card, a docs page) **in full-mode
+  work**. This is a design/experience lens, distinct from the three core
+  code-review lenses. Pass the **rendered output** (a described screen state, a
+  screenshot, or a path to the built artifact) **plus the grounded aesthetic
+  reference and constraints** (persona, outcome, platform surface) — not the
+  code diff; experience-reviewer reviews design artifacts, not code diffs, and
+  its confirm-before-reviewing gate requires the grounded reference. Fallback if
+  no `experience-reviewer` is installed (experience pack absent): proceed and
+  note it — absence of the experience pack is a named skip, not a silent pass.
 
 **Dispatch reviewers in parallel when you invoke more than one** per
 the [Parallel dispatch discipline](#parallel-dispatch-discipline)
@@ -723,8 +743,9 @@ mode below, then evaluate the terminal-state bullet last.
   - For each reviewer the diff warranted (`adversarial-reviewer`
     always; `security-reviewer` on security-boundary diffs;
     `quality-engineer` on every loop, plus a whole-spec pass on the
-    final loop of a multi-loop spec): either the subagent returned
-    `Clean — ready to commit.`, **or** no matching subagent was
+    final loop of a multi-loop spec; `experience-reviewer` on
+    user-facing surface diffs in full-mode work): either the subagent
+    returned `Clean — ready to commit.`, **or** no matching subagent was
     installed and the final summary names the missing review by its
     role label — e.g. `adversarial-reviewer: no matching subagent
     installed; review skipped`. *Silently skipping the reviewer is not

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "0.7.2",
+  "version": "0.9.0",
   "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix, contract-acquisition skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "0.7.2"
+version = "0.9.0"
 description = "Core agent-ready-repo: work-loop, new-spec, bug-fix, contract-acquisition skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 readme = "README.md"
 display_name = "Core"

--- a/packs/experience/.apm/agents/experience-reviewer.md
+++ b/packs/experience/.apm/agents/experience-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: experience-reviewer
-description: "Design-time / experience ONLY — a forked-context, read-only reviewer for design artifacts: a customer journey, a screen flow + its per-screen briefs, an aesthetic direction, or a generated screen. Use it for an independent design-time review that does not mark its own homework — it reviews against the grounded aesthetic reference, platform fit, cross-brief coherence, and the full quality floor (handle-all-states, accessibility, reduced-motion). It never reviews code diffs (use core's reviewers) and never architecture design docs (use architect's design-reviewer). Read-only; it flags, never rewrites. Returns the findings block only."
+description: "Design-time / experience ONLY — a forked-context, read-only reviewer for design artifacts: a customer journey, a screen flow + its per-screen briefs, an aesthetic direction, or a generated screen. Reviews against: grounded aesthetic fit, platform fit, cross-brief coherence, quality floor (handle-all-states, accessibility, reduced-motion), and marketing clarity (tweet test, five-second scan, painkiller-first — fires on above-fold conversion copy only). It never reviews code diffs (use core's reviewers) or architecture design docs (use architect's design-reviewer). Read-only; it flags, never rewrites. Returns findings block only."
 tools: Read, Grep, Glob
 model: opus
 ---
@@ -43,10 +43,10 @@ the artifacts' own stated goals rather than inventing a standard.
 
 If any check fails, say so and stop rather than reviewing.
 
-## What you review — the four lenses
+## What you review — the lenses
 
-Walk every lens that applies to the artifacts in scope. The four are
-load-bearing; do not silently drop one.
+Walk every lens that applies to the artifacts in scope. The first four are
+load-bearing; do not silently drop one. The fifth fires only on marketing surfaces.
 
 - **Grounded aesthetic fit (D4 shared design contract).** Does the design honor
   the *grounded* aesthetic reference — the named goals and what grounds each
@@ -78,6 +78,29 @@ load-bearing; do not silently drop one.
     do not eyeball a threshold.
   - **Reduced-motion** — every animation answers "what does this tell the user?",
     and a reduced-motion path preserves the information the motion carried.
+- **Marketing clarity (above-fold marketing surfaces only).** Fires when the
+  artifact includes above-fold copy with a persuasion or conversion goal — a
+  landing page, product announcement, or pack card. Does **not** fire for
+  internal tools, forms, settings screens, or content pages with no conversion
+  goal. Walk the three criteria:
+  - **Tweet test** — does the headline or tagline stand alone as a conviction
+    statement? If shared with no surrounding context, does it communicate what
+    this is and why it matters to the target reader? Failure: the line only
+    describes the product, names a category without a reader benefit, or requires
+    the page for meaning.
+  - **Five-second scan** — after 5 seconds on the above-fold, can a first-time
+    visitor answer *what is this / who is it for / should I care?* All three must
+    be answerable from visible content alone. Failure: one or more answers are
+    absent, ambiguous, or below the fold.
+  - **Painkiller-first structure** — does the copy lead with the reader's problem,
+    pain, or desired outcome before naming the product's features? Failure: copy
+    leads with the author's feature list or product identity rather than the
+    reader's recognized need.
+
+  Rate marketing clarity findings using the same frequency × impact × persistence
+  rubric, where **impact** means conversion/persuasion cost — how badly the miss
+  hurts the reader's ability to determine fit and take the intended action. Label
+  findings with the criterion they violate.
 
 ## Severity glossary
 

--- a/packs/experience/.apm/skills/design-critique/SKILL.md
+++ b/packs/experience/.apm/skills/design-critique/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: design-critique
-description: "Use to evaluate an existing screen, flow, or mockup — an interactive, authoring-time heuristic critique that reviews against recognized usability principles, maps each issue to the principle it violates, rates severity, and returns a prioritized findings list with a fix per finding. Also supports a taste mode, an evidence-grounded critique of a screen against the grounded aesthetic reference (from aesthetic-direction) and platform fit. Triggers on 'critique this design', 'review this screen', 'what is wrong with this mockup', 'do a heuristic eval', 'is this usable', 'does this fit our aesthetic', 'does this feel right for the platform'. Do NOT use to name a felt direction (use aesthetic-direction), to derive tokens or scales (use design-system-foundations), or to structure hierarchy and reading flow (use layout-and-information-architecture)."
+description: "Evaluate an existing screen, flow, or mockup with a severity-rated findings list: quality-floor pass (states, a11y, motion), heuristic eval (Nielsen's 10), marketing clarity pass (tweet test, five-second scan, painkiller-first — fires on above-fold copy with a persuasion goal), and taste critique (grounded aesthetic reference + platform fit). Triggers on 'critique this design', 'review this screen', 'what is wrong with this mockup', 'do a heuristic eval', 'is this usable', 'does this fit our aesthetic', 'does this page convert', 'is this copy compelling', 'tweet test'. Do NOT use to name a felt direction (use aesthetic-direction), to derive tokens (use design-system-foundations), or to structure hierarchy (use layout-and-information-architecture)."
 ---
 
 # Skill: design-critique
 
 Runs a structured evaluation of a screen, flow, or mockup and returns a **prioritized, severity-rated findings list** — each issue mapped to the recognized usability principle or aesthetic reference it violates, with one concrete, portable recommendation. The list is the artifact: it turns "this feels off" into something a stakeholder can argue and a builder can act on.
 
-Three modes, always run in this order:
+Four modes, always run in this order:
 
 1. **Quality-floor pass** — mandatory; checks all states, accessibility, and reduced-motion.
 2. **Heuristic evaluation** — walks the surface against recognized usability principles.
-3. **Taste critique** (when a grounded aesthetic reference is present) — checks the screen against the grounded aesthetic reference and platform fit.
+3. **Marketing clarity pass** (when the artifact includes above-fold copy with a persuasion/conversion goal — a landing page, marketing page, or product announcement) — checks the copy against the tweet test, five-second scan, and painkiller-first structure. Does **not** fire for internal tools, forms, settings screens, or content pages with no conversion goal.
+4. **Taste critique** (when a grounded aesthetic reference is present) — checks the screen against the grounded aesthetic reference and platform fit.
 
 > **Authoring-time self-review.** This skill is an **interactive, authoring-time** tool — it runs in the session, with the author. It is **not** a fresh-context pass and **not** an adversarial reviewer; a same-session critique marks its own homework. The genuine fresh-context UX review is the forked-context **`experience-reviewer`** agent — invoke it for an independent pass after the authoring session.
 
@@ -29,11 +30,17 @@ Confirm all three before drafting; if any fails, resolve it first.
 2. **Apply the shared floor first.** Run the `quality-floor` checklist at `references/quality-floor.md` against the surface — handle all states, the accessibility floor, the reduced-motion principle. Each miss is a finding mapped to the floor commitment it breaches; accessibility misses start at major.
 3. **Run the heuristic evaluation.** Walk the surface against the recognized usability principles in `references/heuristics.md`. For each problem, record what you observed before you judge it.
 4. **Map and rate.** Map each finding to the single best-fit principle (or floor commitment) and assign a 0–4 severity, naming the frequency × impact × persistence factors that set it. See `references/heuristics.md`.
-5. **Run the taste critique** (when a grounded aesthetic reference from `aesthetic-direction` is available). See `references/taste-critique.md` for the full method. In brief:
+5. **Run the marketing clarity pass** (when the artifact includes above-fold copy with a persuasion/conversion goal). For each of the three criteria, record what you observed, then map and rate:
+   a. **Tweet test** — can the headline or tagline stand alone as a conviction statement? If you shared just that line with no surrounding context, would it communicate what this is and why it matters to the target reader? Failure: the line only describes the product, names a category without a reader benefit, or requires the page for meaning.
+   b. **Five-second scan** — after 5 seconds on the above-fold, can a first-time visitor answer: *what is this / who is it for / should I care?* All three must be answerable from the visible content alone, not inferred. Failure: one or more answers are absent, ambiguous, or below the fold.
+   c. **Painkiller-first structure** — does the copy lead with the reader's problem, pain, or desired outcome before naming the product's features? A painkiller solves a known hurt; a vitamin is a nice-to-have. Failure: copy leads with the author's feature list or product identity rather than the reader's recognized need.
+   
+   Map each finding to the criterion it violates and assign a 0–4 severity using the frequency × impact × persistence rubric, where **impact** means conversion/persuasion cost — how badly the miss hurts the reader's ability to determine fit and take the intended action. (This is a deliberate application of the same rubric to a persuasion-cost dimension; it is not a separate scale.) Label source mode `marketing`. A settings screen or internal tool that is out of scope for this pass produces no findings with this label.
+6. **Run the taste critique** (when a grounded aesthetic reference from `aesthetic-direction` is available). See `references/taste-critique.md` for the full method. In brief:
    a. **Check aesthetic alignment** — for each named goal in the grounded reference, ask whether the screen advances, is neutral to, or contradicts it. Ground each verdict in the recorded referent (persona + precedent + standards), never in a fresh opinion.
    b. **Check platform fit** — verify the screen respects the platform surface's (responsive-web / iOS / Android / cross-platform) conventions; point to the platform standard as the warrant, never reprint its values.
    c. **Map and rate taste findings** — each taste finding maps to the aesthetic goal it contradicts or the platform convention it violates; rate 0–4 by the same severity rubric (frequency × impact × persistence), with 0 reserved for genuine disagreement where the referent does not clearly resolve the call.
-6. **Prioritize and recommend.** Merge all findings from all three modes. Sort worst-first across modes, lead with a count-by-severity headline, and give each finding one concrete, portable recommendation expressed as design intent — never a stack-specific implementation. Label the source mode (floor / heuristic / taste) so the reader knows which lens each finding came from.
+7. **Prioritize and recommend.** Merge all findings from all modes. Sort worst-first across modes, lead with a count-by-severity headline, and give each finding one concrete, portable recommendation expressed as design intent — never a stack-specific implementation. Label the source mode (`floor` / `heuristic` / `marketing` / `taste`) so the reader knows which lens each finding came from.
 
 ## Anti-patterns to refuse
 

--- a/packs/experience/.claude-plugin/plugin.json
+++ b/packs/experience/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "experience",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "The design/UX seat for product teams — the grown-up successor to design-craft. Connective skills walk the thread from outcome to realization (map-customer-journey → map-screen-flow → blueprint-service) and map the inside-out sibling (map-internal-process); craft skills design each screen (aesthetic-direction, design-system-foundations, layout-and-information-architecture, interaction-design) and critique it (design-critique), all held to one shared quality-floor (handle-all-states, accessibility floor, reduced-motion). A forked-context experience-reviewer gives the design step an independent design-time review. Pure method: no stack, no values tables, no pixel comps — points to WCAG / W3C Design Tokens / Apple HIG / Material 3 / APQC / BPMN, never reprints them."
 }

--- a/packs/experience/pack.toml
+++ b/packs/experience/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "experience"
-version = "0.3.0"
+version = "0.4.0"
 description = "The design/UX seat for product teams — the grown-up successor to design-craft. Connective skills walk the thread from outcome to realization (map-customer-journey → map-screen-flow → blueprint-service) and map the inside-out sibling (map-internal-process); craft skills design each screen (aesthetic-direction, design-system-foundations, layout-and-information-architecture, interaction-design) and critique it (design-critique), all held to one shared quality-floor (handle-all-states, accessibility floor, reduced-motion). A forked-context experience-reviewer gives the design step an independent design-time review. Pure method: no stack, no values tables, no pixel comps — points to WCAG / W3C Design Tokens / Apple HIG / Material 3 / APQC / BPMN, never reprints them."
 readme = "README.md"
 display_name = "Experience"


### PR DESCRIPTION
## What does this change?

Three related improvements that close the gap where UI work ships technically correct but with no design sense. Each targets a different stage of the build loop.

**1. `design-critique` marketing clarity pass (experience 0.4.0)**
New mode 3 fires when the artifact has above-fold copy with a persuasion/conversion goal (landing pages, pack cards, announcements — not settings screens or forms). Checks: tweet test (headline stands alone as conviction), five-second scan (above-fold answers what/who/should I care), painkiller-first structure (leads with reader's problem, not author's feature list). Findings use the existing severity rubric, `marketing` source label.

**2. `experience-reviewer` marketing clarity lens (experience 0.4.0)**
The fresh-context reviewer now has a matching 5th lens — same criteria, same negative boundary as design-critique mode 3. Without this, a landing page would pass the independent review on axes the authoring-time skill catches.

**3. `work-loop` pre-EXECUTE design-intent pass + `experience-reviewer` gate (core 0.8.0)**
Two additions: (a) pre-EXECUTE: recommends `aesthetic-direction`/`design-critique` before writing code for user-facing surface changes, advisory in both modes; (b) REVIEW: `experience-reviewer` as a conditional specialist reviewer for full-mode user-facing surface diffs — select-or-note fallback when experience pack absent. ADR-0047 records the scoping decision: full-mode only; net-new pages already reach full mode via the existing "Structural or public-interface change" trigger.

**4. `new-spec` ui design-readiness step (core 0.9.0)**
New step 4d fires when `Shape: ui` is confirmed. Before the ACs are written: checks for a grounded aesthetic reference, offers `aesthetic-direction` if absent, offers `design-critique` on existing affected surfaces, and requires at least one design-intent AC observable from the rendered surface. Mixed-shape note included. Select-or-note fallback when experience pack absent. This is the spec-authoring complement to the work-loop pre-EXECUTE pass — design intent before ACs, not discovered mid-implementation.

## Why?

The Ottawa site build exposed that multiple review passes (adversarial, quality-engineer) don't catch "no design sense" — none of the existing lenses hold a design lens. The work-loop could clear all gates and ship a page that was functionally correct and visually incoherent. This PR wires the design lens into all three stages: spec authoring (new-spec step 4d), pre-code (work-loop PLAN), and post-code review (work-loop REVIEW).

Spec: `docs/specs/design-critique-marketing-clarity/spec.md`
Spec: `docs/specs/experience-reviewer-work-loop-gate/spec.md`
Spec: `docs/specs/new-spec-ui-design-readiness/spec.md`
ADR: `docs/adr/0047-experience-reviewer-as-work-loop-gate.md`

## How do I verify it?

- `grep "Four modes\|marketing clarity" packs/experience/.apm/skills/design-critique/SKILL.md` — confirms mode 3 present
- `grep "Marketing clarity\|tweet test" packs/experience/.apm/agents/experience-reviewer.md` — confirms 5th lens
- `grep "Pre-EXECUTE design-intent\|experience-reviewer" packs/core/.apm/skills/work-loop/SKILL.md` — confirms both additions
- `grep "Design-readiness\|4d\." packs/core/.apm/skills/new-spec/SKILL.md` — confirms step 4d
- `grep '"version"' .claude-plugin/marketplace.json` — experience 0.4.0, core 0.9.0
- Read `docs/adr/0047-experience-reviewer-as-work-loop-gate.md` — scoping rationale, ADR-0042 clearance

## What was not changed?

- Risk-triggers block in `work-loop` — byte-identical across all 4 canonical copies; existing "Structural or public-interface change" trigger already routes net-new pages to full mode
- `experience-reviewer` was not made always-on (that would violate ADR-0042's conditional-specialist posture)
- No new `marketing-critique` skill created — marketing clarity is a bounded amendment to existing skills
- `aesthetic-direction` and `design-system-foundations` skills — gaps recorded in backlog (`copy-direction-skill-rfc`, `design-system-foundations-skill-gap`), out of scope here