### PR TITLE
chore(backlog): close 9 open items in one pass

### DIFF
--- a/.agentbundle/lib/credbroker/__init__.py
+++ b/.agentbundle/lib/credbroker/__init__.py
@@ -1,7 +1,7 @@
 """credbroker — a standalone, pip-installable credential resolver.
 
-RFC-0023 replaces the build-projected ``credentials_shim`` (byte-copied into
-every credentialed skill's ``scripts/`` by the build pipeline) with this
+This library replaces the build-projected ``credentials_shim`` (byte-copied into
+every credentialed skill's ``scripts/`` by the build pipeline) with an
 in-process library. The stdlib-only core resolves credentials through three
 tiers — environment variable, OS keyring, then a ``0600`` dotfile floor — with
 the same public surface the shim exposed, so consumer call sites change only
@@ -48,12 +48,12 @@ from ._core import (
 from ._core import _parse_schema as parse_schema
 from ._core import _tier2_backend_label as tier2_backend_label
 
-# SSO web-session cookie family (RFC-0035) — a second consumer-resolution family
-# alongside the token ``creds`` family above. Resolves a captured SSO session to
-# an on-disk cookie-jar path via the unchanged ``sso-broker.py`` engine, with
-# reusable validation primitives for the consumer's ``sso-config.toml`` and the
-# load-time cookie-domain confinement. Imported eagerly: ``_sso`` is stdlib-only,
-# so it keeps the base import graph free of any third-party dependency.
+# SSO web-session cookie family — a second consumer-resolution family alongside
+# the token ``creds`` family above. Resolves a captured SSO session to an on-disk
+# cookie-jar path via the unchanged ``sso-broker.py`` engine, with reusable
+# validation primitives for the consumer's ``sso-config.toml`` and the load-time
+# cookie-domain confinement. Imported eagerly: ``_sso`` is stdlib-only, so it
+# keeps the base import graph free of any third-party dependency.
 from ._sso import (
     SsoBrokerNotInstalledError,
     SsoConfigError,
@@ -96,13 +96,13 @@ __all__ = [
     "source_vault_master",
     "store_vault_master",
     "store_in_vault",
-    # SSO web-session cookie family (RFC-0035).
+    # SSO web-session cookie family.
     "load_sso_cookies",
     "SsoError",
     "SsoBrokerNotInstalledError",
     "SsoSessionUnavailableError",
     "SsoConfigError",
-    # SSO confinement primitives (RFC-0035; security-control surface).
+    # SSO confinement primitives (security-control surface).
     "validate_https_url",
     "validate_root_relative_endpoint",
     "domain_in_cookie_domains",

--- a/.agentbundle/lib/credbroker/_core.py
+++ b/.agentbundle/lib/credbroker/_core.py
@@ -1,11 +1,11 @@
 """Loader API and stdlib ``.env`` parser for credentialed primitives.
 
 This is ``credbroker``'s stdlib-only resolution core — a near-verbatim
-lift of the former build-projected ``credentials_shim`` (RFC-0023). It is
+lift of the former build-projected ``credentials_shim``. It is
 imported in-process by credentialed consumers via the package's public
 surface (``from credbroker import …``); the public names are re-exported
 from ``credbroker/__init__.py``. The lift preserves the resolver's
-semantics exactly (RFC-0006 tiers, Win32 error matrix, atomic-write
+semantics exactly (three tiers, Win32 error matrix, atomic-write
 discipline); what changed is *delivery* (a pip library, not a byte-copied
 sibling), not behaviour.
 
@@ -893,7 +893,7 @@ def _relative_schema_path(
     )
 
 
-# ── Public write API (RFC-0023 T8) ─────────────────────────────────────
+# ── Public write API (T8) ──────────────────────────────────────────────
 #
 # credential-setup (the interactive write skill) consumed the shim's private
 # write surface; these public functions replace it. All are non-interactive —

--- a/.agentbundle/lib/credbroker/_vault.py
+++ b/.agentbundle/lib/credbroker/_vault.py
@@ -1,6 +1,6 @@
 """Encrypted-at-rest credential vault for the `credbroker[crypto]` extra.
 
-RFC-0023's Tier-3 floor upgrade: instead of a plaintext `0600` dotfile, the
+The optional `[crypto]` Tier-3 floor upgrade: instead of a plaintext `0600` dotfile, the
 optional `[crypto]` extra stores values in an AEAD-encrypted file. This module's
 own top level pulls in `cryptography` and `argon2`, so the resolution core imports
 the vault **module lazily** — only inside the functions that need it, never at the

--- a/.agents/skills/new-adr/evals/evals.json
+++ b/.agents/skills/new-adr/evals/evals.json
@@ -37,5 +37,16 @@
         "When a ## Confirmation section is present it is concrete (a named Mode/Signal/Owner) or explicitly Mode: none with a one-line reason — not aspirational, and not silently omitted where a reader would expect a conformance check"
       ]
     }
+    ,
+    {
+      "id": 4,
+      "prompt": "Record a short, simple architecture decision as an ADR — a small, obvious choice with one clear winner and no long-term drift risk (e.g. 'we agreed to use Python Black as our code formatter with its default settings; the whole team runs it identically and there's nothing to revisit unless Black ceases to be maintained').",
+      "expected_output": "Because the ADR is short enough that the Decision is visible on the first screen, the skill omits the `## Decision summary` block — it would be pure redundancy on a decision this compact. For a decision that won't age, it writes the explicit `Revisit if: stable — no foreseeable trigger` in Consequences rather than omitting the line entirely (omitting it would leave the reader uncertain whether the field was overlooked). The `## Confirmation` section, if present, is honest about the decision's lightweight checkability: a one-line `Mode: none` with a reason (a formatter choice that passes CI doesn't need a separate conformance audit) or the section is omitted for a genuinely non-checkable choice — not left aspirational.",
+      "assertions": [
+        "A ## Decision summary block is present when the ADR is long enough that the Decision is not visible on the first screen, and is omitted on a short ADR where it would be pure redundancy",
+        "A Revisit if: trigger is present in Consequences for a decision likely to age, with 'stable — no foreseeable trigger' as the valid explicit value when it will not",
+        "When a ## Confirmation section is present it is concrete (a named Mode/Signal/Owner) or explicitly Mode: none with a one-line reason — not aspirational, and not silently omitted where a reader would expect a conformance check"
+      ]
+    }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -139,7 +139,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "experience",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.4.0"
+      "version": "0.4.1"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/.claude/skills/new-adr/evals/evals.json
+++ b/.claude/skills/new-adr/evals/evals.json
@@ -37,5 +37,16 @@
         "When a ## Confirmation section is present it is concrete (a named Mode/Signal/Owner) or explicitly Mode: none with a one-line reason — not aspirational, and not silently omitted where a reader would expect a conformance check"
       ]
     }
+    ,
+    {
+      "id": 4,
+      "prompt": "Record a short, simple architecture decision as an ADR — a small, obvious choice with one clear winner and no long-term drift risk (e.g. 'we agreed to use Python Black as our code formatter with its default settings; the whole team runs it identically and there's nothing to revisit unless Black ceases to be maintained').",
+      "expected_output": "Because the ADR is short enough that the Decision is visible on the first screen, the skill omits the `## Decision summary` block — it would be pure redundancy on a decision this compact. For a decision that won't age, it writes the explicit `Revisit if: stable — no foreseeable trigger` in Consequences rather than omitting the line entirely (omitting it would leave the reader uncertain whether the field was overlooked). The `## Confirmation` section, if present, is honest about the decision's lightweight checkability: a one-line `Mode: none` with a reason (a formatter choice that passes CI doesn't need a separate conformance audit) or the section is omitted for a genuinely non-checkable choice — not left aspirational.",
+      "assertions": [
+        "A ## Decision summary block is present when the ADR is long enough that the Decision is not visible on the first screen, and is omitted on a short ADR where it would be pure redundancy",
+        "A Revisit if: trigger is present in Consequences for a decision likely to age, with 'stable — no foreseeable trigger' as the valid explicit value when it will not",
+        "When a ## Confirmation section is present it is concrete (a named Mode/Signal/Owner) or explicitly Mode: none with a one-line reason — not aspirational, and not silently omitted where a reader would expect a conformance check"
+      ]
+    }
   ]
 }

--- a/AGENTS.local.md
+++ b/AGENTS.local.md
@@ -220,6 +220,25 @@ adopters receive on first install via brownfield rules):
    step 1 always trips it. Either commit the seed edits first, or run
    `FORCE=1 make build-self` — `FORCE=1` overrides the dirty-tree check only,
    and is the right call when the tree is dirty *because* you just edited seeds.
+   Direct equivalent (when Make is unavailable):
+   ```bash
+   python3 tools/build_gate_chain.py build-self --force --packs-dir packs
+   ```
+   **Critical ordering for mixed-edit sessions (seed + non-seed pack source):**
+   When a session edits both seeds *and* non-seed pack source files (e.g.,
+   `.apm/**` files, `pack.toml`, user-libs) in the same working tree, run
+   `build-self --force` AFTER all edits are applied — not between them. Build-self
+   is a full pack-build pipeline that can regenerate files in `packs/` from
+   cached or templated sources, silently reverting edits made before it ran. The
+   safe pattern: apply all edits → `FORCE=1 make build-self` → verify with
+   `git status` that the edits survived → `make build-check` → commit.
+   **Vendored copies and canonical sources (credbroker example):**
+   `packs/credential-brokers/.apm/user-libs/credbroker/` is byte-synced from
+   `packages/credbroker/credbroker/` (the canonical pip package source) by
+   build-self; `build-check` hard-fails on any divergence. To edit these files,
+   always edit `packages/credbroker/credbroker/*.py` (the canonical source) and
+   let `build-self --force` propagate to the vendored copy — never edit the
+   `.apm/user-libs/` copy directly.
 3. Run `make build-check` to confirm zero drift before committing.
 
 **How to discover the seed for a path you're unsure about:**

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -384,13 +384,12 @@ of their own yet.
   `import re` (matches install.py's local-import idiom; hoist if the module is
   ever refactored to module-level imports). Neither affects behaviour.
 
-- **`lint-plan-deps.py` is unwired (RFC-0015 / `wave-scheduled-supervisor` AC7).**
-  AC7's deliverable `tools/lint-plan-deps.py` (repo-wide plan-DAG sweep) is invoked
-  by **no gate** — not in `Makefile`, `.github/workflows/`, or `pre-pr` — and has no
-  test; `adopter-clean-enforcement-gate` removed its last anchor (the `new-spec`
-  `plan.md` template now points adopters at the shipped per-spec `loop-cohort
-  schedule`). Decide in `wave-scheduled-supervisor`: wire it into `build-check` to
-  enforce AC7 continuously, or retire it as redundant with `loop-cohort schedule`.
+- **`lint-plan-deps.py` — Resolved 2026-07-02.** Retired as redundant in
+  `eb0e538a` (`chore(tools): remove orphan lint-plan-deps.py`): it re-ran
+  `loop-cohort`'s `detect_cycles` / `detect_forward_refs` — the same engine
+  already invoked at dispatch and per-spec by `pre-pr.py` — with no unique
+  coverage, no test, and no gate wiring. The `adopter-clean-enforcement-gate`
+  spec records the deliberate non-touch. The "retire" option has been taken.
 - **Credentialed-authoring skills don't belong in adopter-facing `core` (RFC-0013 /
   `credential-broker-contract`).** From first principles the adopter artifact for
   *authoring* a credentialed skill is the **how-to** — which already exists
@@ -812,17 +811,15 @@ increment, and `research` is this one (all `pack-eval-coverage-rollout`).
 Remaining work, tiered by what it needs:
 
 - **Tier 1 — activation (Tier-A) for the rest of the catalogue (tractable now,
-  no deps/execution).** Remaining: `monorepo-extras` (1)
-  needs `evals/eval_queries.json` + a `[pack.evals]`
-  block (the same ~8–10-each-way near-miss pattern as `core`). `architect` (3),
-  `product-engineering` (5), `contracts` (2), `experience`
-  (9), `governance-extras` (3), `user-guide-diataxis` (1, `new-guide`), and
-  `research` (8 — 7 scoping/synthesis/decision skills + `research-project-start`;
-  the 3 project-interior steps excluded per its `[pack.evals]` coverage note) are
-  **done**; the credentialed/backend `figma` (1) and `atlassian` (8) Tier-A
-  activation is **done** too (see Tier 3). Exclude
-  reviewer-internal / non-prompt skills (`security-checklists`, `work-loop`,
-  `credential-setup`), as `core` does.
+  no deps/execution).** **All packs now done (2026-07-02):** `monorepo-extras`
+  (`new-package` eval_queries.json + `[pack.evals]` block added). `architect` (3),
+  `product-engineering` (5 + 4 new discovery/frame skills), `contracts` (2),
+  `experience` (9), `governance-extras` (3), `user-guide-diataxis` (1, `new-guide`),
+  and `research` (8 — 7 scoping/synthesis/decision skills + `research-project-start`;
+  the 3 project-interior steps excluded per its `[pack.evals]` coverage note) were
+  already **done**; the credentialed/backend `figma` (1) and `atlassian` (8) Tier-A
+  activation is **done** too (see Tier 3). Reviewer-internal / non-prompt skills
+  (`security-checklists`, `work-loop`, `credential-setup`) excluded, as `core` does.
 - **Tier 2 — B-lite behavior for other *deterministic* skills.** Assess
   `contracts` (`api-contract` / `event-contract` — do they deterministically
   emit/validate a contract artifact? if so, add an `expect` block + fixture).
@@ -1062,19 +1059,11 @@ single-thread reclaim, not the multi-process race).
 
 **Spec:** [adr-template-right-sizing](specs/adr-template-right-sizing/spec.md)
 
-The three behavioral evals (AC5) are pinned verbatim and each carries a
-two-branch assertion (present-when-long / omitted-when-short; trigger-present /
-`stable — no foreseeable trigger`). The authored eval scenario (`evals.json`
-id 3) prompts a single long, aging, conformance-expected ADR, so an LLM judge
-can only observe the first branch of each assertion — the omit-on-a-short-ADR
-and the explicit-`stable` branches are never exercised. AC5's contract (the
-three assertions present, parsing, contract-pinned) is fully met; this is the
-spec's deliberate pinned-string tradeoff and matches the existing id 1 / id 2
-multi-clause-against-single-prompt style, so it is a coverage Concern, not a
-shipped-AC gap. **Unblocks when:** someone adds a second eval scenario whose
-prompt is a *short* ADR (and a not-likely-to-age decision), reusing the same
-pinned assertion strings, so the judge can observe the omit / explicit-`stable`
-branches the assertions promise.
+**Resolved 2026-07-02.** Eval scenario id 4 added to
+`packs/governance-extras/.apm/skills/new-adr/evals/evals.json`: a short,
+stable, non-aging ADR (formatter choice) that exercises the omit-summary
+and explicit-`stable` branches the existing id 3 scenario never reaches.
+Reuses the same three pinned assertion strings from id 3.
 
 ## `frame-domain`
 
@@ -1082,29 +1071,18 @@ branches the assertions promise.
 
 **Spec:** [frame-domain](specs/frame-domain/spec.md)
 
-The `frame-domain` skill ships with `examples/` (the recorded worked-example QA)
-but no `evals/`, unlike its `product-engineering` siblings (`frame-intent`,
-`decompose-intent`, `de-risk-intent`). No acceptance criterion requires an eval —
-the spec's verification is the AC1–AC9 structural greps plus the AC2/AC6 recorded
-worked-example run — so this is a consistency gap, not a shipped-AC gap. **Unblocks
-when:** someone adds a minimal eval mirroring the sibling pattern (e.g. asserting
-skill activation on a domain-framing prompt and that both typed artifacts with
-their markers are produced).
+**Resolved 2026-07-02.** `packs/product-engineering/.apm/skills/frame-domain/evals/eval_queries.json`
+added (9 true / 8 false queries mirroring the sibling pattern). `frame-domain`
+added to `product-engineering`'s `[pack.evals].skills` list.
 
 ## `discovery-loop`
 
 ### discovery-loop-eval-coverage
 
-**Spec:** [discovery-loop](specs/discovery-loop/spec.md)
-
-The three new `product-engineering` skills (`discovery-loop`, `explore-options`,
-`plan-validation`) ship without `evals/eval_queries.json` and are not in
-`[pack.evals]` — matching the `frame-domain` precedent above, and no acceptance
-criterion or gate requires it (allowlist completeness is hand-maintained, not
-enforced). **Unblocks when:** someone adds minimal evals mirroring the sibling
-pattern (assert skill activation on a "scaffold the product vision for X" /
-"diverge on the product shape" / "plan the validation" prompt) and adds the
-user-triggered ones to `[pack.evals]`.
+**Resolved 2026-07-02.** `eval_queries.json` added for all three skills
+(`discovery-loop`: 7/7; `explore-options`: 7/7; `plan-validation`: 8/7 queries).
+All three added to `product-engineering`'s `[pack.evals].skills` list alongside
+`frame-domain`.
 
 ### discovery-loop-traceability-reachability
 
@@ -1302,32 +1280,24 @@ reviews against a design system but doesn't author one).
 
 ### aesthetic-rubrics-research
 
-**Source:** Session 2026-07-01 — aesthetic direction pass on the GitHub Pages
-site surfaced rubrics not yet encoded in the `aesthetic-direction` skill.
+**Resolved 2026-07-02.** All four open research areas encoded into
+`packs/experience/.apm/skills/aesthetic-direction/references/grounding.md`
+Standards and Platform-conventions sections:
 
-**Already added to `references/grounding.md` (ride-along, 2026-07-01):**
-- Visual voice as a grounding dimension distinct from correctness rubrics:
-  surface treatment (dark hero + grid texture + ambient glow pattern),
-  type scale philosophy (display vs. document, `clamp()`, letter-spacing),
-  color philosophy (one chromatic accent), elevation philosophy (border-not-shadow).
-- Stage 1.5 ambition-axis probe added to `references/interrogation-sequence.md`:
-  document-to-product-site spectrum, surface treatment claim, example treatments.
-- Memory `reference_aesthetic_direction_rubrics.md` captures what was used.
-
-**Still open — needs a dedicated research session (`/research`):**
-1. MECE correctness rubric set with cited WCAG SCs (1.4.1, 1.4.3, 2.4.7, 2.3.3
-   etc.) so they can be applied from memory rather than re-derived each pass.
-2. Platform-specific visual voice precedents beyond responsive-web (iOS HIG,
-   Material 3 expressive tier, Android adaptive).
-3. Information architecture rubrics (Diátaxis, card-sorting, progressive
-   disclosure quantification) as grounding standards — currently absent from
-   the skill's Standards referent list.
-4. Typography research canon (optical sizing, variable-font weight axes,
-   fluid type scales via `clamp()` best practice).
-
-**Unblocks when:** `/research` catalogues the above four areas and the
-`aesthetic-direction` skill's reference files are updated in a single PR,
-routed through `work-loop` light mode.
+1. **WCAG SCs** — 1.4.1, 1.4.3, 1.4.11, 2.4.7, 2.3.3 now cited with their
+   named tension against common aesthetic goals; APCA noted as the perceptual
+   complement.
+2. **Platform visual voice** — iOS HIG (*clarity, deference, depth*; SF Pro
+   legibility risk for branded directions; visionOS extension), Android
+   Material 3 Expressive tier (dynamic color coexistence, 2024 expressive
+   defaults), responsive-web (Stripe/Linear/Vercel vocabulary named explicitly
+   with the differentiation question).
+3. **IA rubrics** — Progressive disclosure, Diátaxis framework (four quadrant
+   types + structural standards), card-sorting (open vs. closed, evidence
+   requirement) added to Standards section.
+4. **Typography canon** — optical sizing (`opsz` axis), fluid type scale via
+   `clamp()`, variable `wght` axis for weight hierarchy, line-length (45–75
+   chars) and leading (1.4–1.6 × body, 1.1–1.2 × display) encoded.
 
 ### experience-loop-trigger-for-site-changes
 
@@ -1419,21 +1389,18 @@ growth scope resolves item 2.
 
 ### site-catalogue-hierarchy
 
-**Source:** experience-reviewer finding (session 2026-07-01). "Fourteen" appears three times before the two-tier progressive-disclosure split ("start with loops / add what your team needs"). Hick's Law: presenting 14 equal-weight choices maximises perceived choice cost. The 11 "add what you need" cards have no sub-grouping.
-
-**Open work:**
-- Drop count from hero subtitle (already done in session: "These fourteen packs" → acceptable, but "fourteen" still appears in the catalogue section header). Consider "a curated catalogue" vs. naming the count up front.
-- Sub-group the 11 secondary cards — the `repo`/`user` scope tags already exist as a natural axis. Alternatively, group by discipline cluster (data/docs/infra/design/governance).
-
-**Unblocks when:** taken as a copy-only PR with experience-reviewer review.
+**Resolved 2026-07-02.** All three "fourteen" occurrences removed from
+`site/docs/index.md`: hero subtitle → "these supervised loops and curated packs";
+catalogue header → "A curated catalogue of packs". Secondary cards split into two
+labelled groups by scope: "Install once, works across all your repos" (`user`: 8
+cards) and "Install per project" (`repo`: 3 cards).
 
 ### site-handoff-diagram
 
-**Source:** experience-reviewer finding (session 2026-07-01). The G3→G4→G5 handoff chain is rendered as a plain ASCII code fence — reads as a debug artifact on a site claiming "leading developer site" polish. Gate labels (G0/G1.5/G2/G3/G4/G5) also lack a first-use definition anywhere outside the card bodies.
-
-**Working approach:** Replace the ASCII fence with a Mermaid diagram (the site already supports `superfences`/Mermaid rendering via MkDocs Material). Use `#5e6ad2` accent nodes to tie it to the visual voice. Add a short legend defining the Gx gate notation.
-
-**Unblocks when:** taken as a content PR. Mermaid support is already wired; no build changes needed.
+**Resolved 2026-07-02.** ASCII code fence replaced with a Mermaid `flowchart LR`
+diagram in `site/docs/index.md`: three nodes styled with `#5e6ad2` accent fill,
+G3/G4 edge labels, G5 gate definition added as an inline blockquote legend below
+the diagram.
 
 ### site-design-system-spec
 

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`aesthetic-direction` grounding reference now cites WCAG thresholds by name, not literal values (experience 0.4.1).** The Standards section of the grounding reference described contrast thresholds using specific ratio and point-size literals, which violated RFC-0033's portable-method rule. The section now refers to the named WCAG SC thresholds and the OS-level reduced-motion preference concept rather than reprinting the values table. No change to skill behavior — only the reference prose that informs the aesthetic-direction pass.
+
 ### Added
 
 - **`design-critique` now includes a marketing clarity pass (experience 0.4.0).** A new

--- a/packages/credbroker/credbroker/__init__.py
+++ b/packages/credbroker/credbroker/__init__.py
@@ -1,7 +1,7 @@
 """credbroker — a standalone, pip-installable credential resolver.
 
-RFC-0023 replaces the build-projected ``credentials_shim`` (byte-copied into
-every credentialed skill's ``scripts/`` by the build pipeline) with this
+This library replaces the build-projected ``credentials_shim`` (byte-copied into
+every credentialed skill's ``scripts/`` by the build pipeline) with an
 in-process library. The stdlib-only core resolves credentials through three
 tiers — environment variable, OS keyring, then a ``0600`` dotfile floor — with
 the same public surface the shim exposed, so consumer call sites change only
@@ -48,12 +48,12 @@ from ._core import (
 from ._core import _parse_schema as parse_schema
 from ._core import _tier2_backend_label as tier2_backend_label
 
-# SSO web-session cookie family (RFC-0035) — a second consumer-resolution family
-# alongside the token ``creds`` family above. Resolves a captured SSO session to
-# an on-disk cookie-jar path via the unchanged ``sso-broker.py`` engine, with
-# reusable validation primitives for the consumer's ``sso-config.toml`` and the
-# load-time cookie-domain confinement. Imported eagerly: ``_sso`` is stdlib-only,
-# so it keeps the base import graph free of any third-party dependency.
+# SSO web-session cookie family — a second consumer-resolution family alongside
+# the token ``creds`` family above. Resolves a captured SSO session to an on-disk
+# cookie-jar path via the unchanged ``sso-broker.py`` engine, with reusable
+# validation primitives for the consumer's ``sso-config.toml`` and the load-time
+# cookie-domain confinement. Imported eagerly: ``_sso`` is stdlib-only, so it
+# keeps the base import graph free of any third-party dependency.
 from ._sso import (
     SsoBrokerNotInstalledError,
     SsoConfigError,
@@ -96,13 +96,13 @@ __all__ = [
     "source_vault_master",
     "store_vault_master",
     "store_in_vault",
-    # SSO web-session cookie family (RFC-0035).
+    # SSO web-session cookie family.
     "load_sso_cookies",
     "SsoError",
     "SsoBrokerNotInstalledError",
     "SsoSessionUnavailableError",
     "SsoConfigError",
-    # SSO confinement primitives (RFC-0035; security-control surface).
+    # SSO confinement primitives (security-control surface).
     "validate_https_url",
     "validate_root_relative_endpoint",
     "domain_in_cookie_domains",

--- a/packages/credbroker/credbroker/_core.py
+++ b/packages/credbroker/credbroker/_core.py
@@ -1,11 +1,11 @@
 """Loader API and stdlib ``.env`` parser for credentialed primitives.
 
 This is ``credbroker``'s stdlib-only resolution core — a near-verbatim
-lift of the former build-projected ``credentials_shim`` (RFC-0023). It is
+lift of the former build-projected ``credentials_shim``. It is
 imported in-process by credentialed consumers via the package's public
 surface (``from credbroker import …``); the public names are re-exported
 from ``credbroker/__init__.py``. The lift preserves the resolver's
-semantics exactly (RFC-0006 tiers, Win32 error matrix, atomic-write
+semantics exactly (three tiers, Win32 error matrix, atomic-write
 discipline); what changed is *delivery* (a pip library, not a byte-copied
 sibling), not behaviour.
 
@@ -893,7 +893,7 @@ def _relative_schema_path(
     )
 
 
-# ── Public write API (RFC-0023 T8) ─────────────────────────────────────
+# ── Public write API (T8) ──────────────────────────────────────────────
 #
 # credential-setup (the interactive write skill) consumed the shim's private
 # write surface; these public functions replace it. All are non-interactive —

--- a/packages/credbroker/credbroker/_vault.py
+++ b/packages/credbroker/credbroker/_vault.py
@@ -1,6 +1,6 @@
 """Encrypted-at-rest credential vault for the `credbroker[crypto]` extra.
 
-RFC-0023's Tier-3 floor upgrade: instead of a plaintext `0600` dotfile, the
+The optional `[crypto]` Tier-3 floor upgrade: instead of a plaintext `0600` dotfile, the
 optional `[crypto]` extra stores values in an AEAD-encrypted file. This module's
 own top level pulls in `cryptography` and `argon2`, so the resolution core imports
 the vault **module lazily** — only inside the functions that need it, never at the

--- a/packs/credential-brokers/.apm/user-libs/credbroker/__init__.py
+++ b/packs/credential-brokers/.apm/user-libs/credbroker/__init__.py
@@ -1,7 +1,7 @@
 """credbroker — a standalone, pip-installable credential resolver.
 
-RFC-0023 replaces the build-projected ``credentials_shim`` (byte-copied into
-every credentialed skill's ``scripts/`` by the build pipeline) with this
+This library replaces the build-projected ``credentials_shim`` (byte-copied into
+every credentialed skill's ``scripts/`` by the build pipeline) with an
 in-process library. The stdlib-only core resolves credentials through three
 tiers — environment variable, OS keyring, then a ``0600`` dotfile floor — with
 the same public surface the shim exposed, so consumer call sites change only
@@ -48,12 +48,12 @@ from ._core import (
 from ._core import _parse_schema as parse_schema
 from ._core import _tier2_backend_label as tier2_backend_label
 
-# SSO web-session cookie family (RFC-0035) — a second consumer-resolution family
-# alongside the token ``creds`` family above. Resolves a captured SSO session to
-# an on-disk cookie-jar path via the unchanged ``sso-broker.py`` engine, with
-# reusable validation primitives for the consumer's ``sso-config.toml`` and the
-# load-time cookie-domain confinement. Imported eagerly: ``_sso`` is stdlib-only,
-# so it keeps the base import graph free of any third-party dependency.
+# SSO web-session cookie family — a second consumer-resolution family alongside
+# the token ``creds`` family above. Resolves a captured SSO session to an on-disk
+# cookie-jar path via the unchanged ``sso-broker.py`` engine, with reusable
+# validation primitives for the consumer's ``sso-config.toml`` and the load-time
+# cookie-domain confinement. Imported eagerly: ``_sso`` is stdlib-only, so it
+# keeps the base import graph free of any third-party dependency.
 from ._sso import (
     SsoBrokerNotInstalledError,
     SsoConfigError,
@@ -96,13 +96,13 @@ __all__ = [
     "source_vault_master",
     "store_vault_master",
     "store_in_vault",
-    # SSO web-session cookie family (RFC-0035).
+    # SSO web-session cookie family.
     "load_sso_cookies",
     "SsoError",
     "SsoBrokerNotInstalledError",
     "SsoSessionUnavailableError",
     "SsoConfigError",
-    # SSO confinement primitives (RFC-0035; security-control surface).
+    # SSO confinement primitives (security-control surface).
     "validate_https_url",
     "validate_root_relative_endpoint",
     "domain_in_cookie_domains",

--- a/packs/credential-brokers/.apm/user-libs/credbroker/_core.py
+++ b/packs/credential-brokers/.apm/user-libs/credbroker/_core.py
@@ -1,11 +1,11 @@
 """Loader API and stdlib ``.env`` parser for credentialed primitives.
 
 This is ``credbroker``'s stdlib-only resolution core — a near-verbatim
-lift of the former build-projected ``credentials_shim`` (RFC-0023). It is
+lift of the former build-projected ``credentials_shim``. It is
 imported in-process by credentialed consumers via the package's public
 surface (``from credbroker import …``); the public names are re-exported
 from ``credbroker/__init__.py``. The lift preserves the resolver's
-semantics exactly (RFC-0006 tiers, Win32 error matrix, atomic-write
+semantics exactly (three tiers, Win32 error matrix, atomic-write
 discipline); what changed is *delivery* (a pip library, not a byte-copied
 sibling), not behaviour.
 
@@ -893,7 +893,7 @@ def _relative_schema_path(
     )
 
 
-# ── Public write API (RFC-0023 T8) ─────────────────────────────────────
+# ── Public write API (T8) ──────────────────────────────────────────────
 #
 # credential-setup (the interactive write skill) consumed the shim's private
 # write surface; these public functions replace it. All are non-interactive —

--- a/packs/credential-brokers/.apm/user-libs/credbroker/_vault.py
+++ b/packs/credential-brokers/.apm/user-libs/credbroker/_vault.py
@@ -1,6 +1,6 @@
 """Encrypted-at-rest credential vault for the `credbroker[crypto]` extra.
 
-RFC-0023's Tier-3 floor upgrade: instead of a plaintext `0600` dotfile, the
+The optional `[crypto]` Tier-3 floor upgrade: instead of a plaintext `0600` dotfile, the
 optional `[crypto]` extra stores values in an AEAD-encrypted file. This module's
 own top level pulls in `cryptography` and `argon2`, so the resolution core imports
 the vault **module lazily** — only inside the functions that need it, never at the

--- a/packs/experience/.apm/skills/aesthetic-direction/references/grounding.md
+++ b/packs/experience/.apm/skills/aesthetic-direction/references/grounding.md
@@ -67,19 +67,19 @@ must clear, regardless of direction:
 - **1.4.1 Use of Color** — information must not be conveyed by color alone;
   a goal around "color as the identity signal" must pair color with shape or
   label.
-- **1.4.3 Contrast Minimum** — text at 4.5:1 (normal), 3:1 (large ≥ 18 pt /
-  14 pt bold). A goal of "low-contrast, airy typography" is constrained by
-  this floor; name the tension explicitly.
+- **1.4.3 Contrast Minimum** — text must meet the WCAG-defined thresholds for
+  normal and large/bold text respectively. A goal of "low-contrast, airy
+  typography" is constrained by this floor; name the tension explicitly.
 - **1.4.11 Non-text Contrast** — interactive components and their focus
-  indicators at 3:1 against adjacent colors. A "borderless" aesthetic must
-  still clear this for inputs and buttons.
+  indicators must meet the Non-text Contrast threshold against adjacent
+  colors. A "borderless" aesthetic must still clear this for inputs and buttons.
 - **2.4.7 Focus Visible** — keyboard focus must be visually apparent. A
   dark-on-dark direction must name how focus is expressed without breaking
   the palette.
 - **2.3.3 Animation from Interactions (WCAG 2.1 AAA)** — non-essential
-  animation triggered by interaction must honor `prefers-reduced-motion`.
-  A goal with motion as a core quality should name the reduced-motion
-  fallback up front.
+  animation triggered by interaction must honor the OS-level reduced-motion
+  preference. A goal with motion as a core quality should name the
+  reduced-motion fallback up front.
 - **APCA (Accessible Perceptual Contrast Algorithm)** — where WCAG
   contrast is the regulatory floor, APCA gives a perceptual complement
   that better models how lightness differences read. For large display text
@@ -105,7 +105,7 @@ goal to a field-recognized mechanism:
 
 **Typography canon.** For goals with a typographic quality dimension:
 
-- **Optical sizing** — display text (≥ 32 pt) benefits from optically-sized
+- **Optical sizing** — display text at headline sizes benefits from optically-sized
   variants (`font-optical-sizing: auto` or explicit axis `opsz`); body text
   is set at the text optical size. A "premium, crafted" goal at large scale
   names whether the typeface has an optical size axis.

--- a/packs/experience/.apm/skills/aesthetic-direction/references/grounding.md
+++ b/packs/experience/.apm/skills/aesthetic-direction/references/grounding.md
@@ -54,17 +54,90 @@ reference itself.
 
 What recognized design principles or bodies of guidance align with this goal?
 
-Standards are the named, external bodies of guidance the field recognizes —
-interaction-design principles (Nielsen heuristics, Laws of UX), accessibility
-guidance (WCAG, APCA), motion guidance, typography research. Point to
-the standard that the goal respects or draws from; do not reprint its
-values.
+Standards are the named, external bodies of guidance the field recognizes.
+Point to the standard the goal respects or draws from; do not reprint its
+values. A goal aligned with a recognized standard is more defensible — it
+can be explained without reference to taste. When a goal has no standard
+behind it, it is either purely expressive (record that honestly) or not yet
+sharp enough (push back to Stage 2 of the interrogation).
 
-A goal aligned with a recognized standard is more defensible than one
-that is not — it can be explained without reference to taste. When a
-goal has no standard behind it, it is either purely expressive
-(record that honestly) or not yet sharp enough (push back to Stage 2
-of the interrogation).
+**Accessibility floor (WCAG 2.1 / 2.2).** Named SCs that aesthetic goals
+must clear, regardless of direction:
+
+- **1.4.1 Use of Color** — information must not be conveyed by color alone;
+  a goal around "color as the identity signal" must pair color with shape or
+  label.
+- **1.4.3 Contrast Minimum** — text at 4.5:1 (normal), 3:1 (large ≥ 18 pt /
+  14 pt bold). A goal of "low-contrast, airy typography" is constrained by
+  this floor; name the tension explicitly.
+- **1.4.11 Non-text Contrast** — interactive components and their focus
+  indicators at 3:1 against adjacent colors. A "borderless" aesthetic must
+  still clear this for inputs and buttons.
+- **2.4.7 Focus Visible** — keyboard focus must be visually apparent. A
+  dark-on-dark direction must name how focus is expressed without breaking
+  the palette.
+- **2.3.3 Animation from Interactions (WCAG 2.1 AAA)** — non-essential
+  animation triggered by interaction must honor `prefers-reduced-motion`.
+  A goal with motion as a core quality should name the reduced-motion
+  fallback up front.
+- **APCA (Accessible Perceptual Contrast Algorithm)** — where WCAG
+  contrast is the regulatory floor, APCA gives a perceptual complement
+  that better models how lightness differences read. For large display text
+  or decorative low-contrast intent, cite both: "clears 1.4.3 at X:1;
+  APCA Lc Y for this usage."
+
+**Interaction-design principles.** Heuristic anchors that connect a named
+goal to a field-recognized mechanism:
+
+- **Nielsen's 10 Heuristics** — especially #1 Visibility of System Status
+  (a "calm" goal should name how loading / error / success states express
+  calm, not just idle state), #4 Consistency and Standards (a "distinctive"
+  goal must name what it is distinctive *against*), and #8 Aesthetic and
+  Minimalist Design (every element competes for attention — the goal should
+  name what earns its place).
+- **Hick's Law** — time to decide grows with the number of options. A goal
+  of "effortless first run" is grounded by naming how choice cost is reduced
+  at key decision points (progressive disclosure, sensible defaults, default
+  opt-in paths).
+- **Information-scent (Peter Pirolli)** — users follow the path of highest
+  perceived information-scent; a navigation goal is grounded when it names
+  how the labeling strategy maximizes scent to the target content.
+
+**Typography canon.** For goals with a typographic quality dimension:
+
+- **Optical sizing** — display text (≥ 32 pt) benefits from optically-sized
+  variants (`font-optical-sizing: auto` or explicit axis `opsz`); body text
+  is set at the text optical size. A "premium, crafted" goal at large scale
+  names whether the typeface has an optical size axis.
+- **Fluid type scale via `clamp()`** — `font-size: clamp(min, preferred-vw,
+  max)` produces a scale that grows smoothly between breakpoints. A goal of
+  "consistent reading rhythm across viewports" is grounded by naming the
+  scale strategy (min/max values and the preferred rate of growth).
+- **Variable-font weight axes** — if the direction uses weight to carry
+  hierarchy (heavy display / light body), name whether the chosen typeface
+  has a `wght` axis for continuous interpolation rather than a step-function
+  optical weight jump.
+- **Line-length and leading** — body text reads best at 45–75 characters per
+  line (Bringhurst); leading of 1.4–1.6 × the font-size for body, tighter
+  (1.1–1.2) for display. A goal of "effortless reading" is grounded by
+  naming the target measure and leading.
+
+**Information-architecture rubrics.**
+
+- **Progressive disclosure** — reveal only what the user needs at each
+  decision point, surfacing complexity on demand. A "simple but powerful"
+  goal should name the disclosure strategy: what is shown at first glance
+  vs. one interaction deeper vs. in settings.
+- **Diátaxis framework** (Procida) — for product documentation surfaces:
+  tutorials (learning), how-to guides (doing), reference (information),
+  explanations (understanding). A goal of "trustworthy documentation" is
+  grounded by naming which Diátaxis quadrant the current surface belongs to
+  and the structural standards that quadrant imposes.
+- **Card sorting / IA testing** — when a goal involves navigation or
+  categorization, name whether open-card-sort evidence (user-generated
+  categories) or closed-card-sort validation (user-sorted into proposed
+  categories) has informed the structure. Without evidence, the goal is a
+  hypothesis.
 
 ### 4 — Platform conventions
 
@@ -74,17 +147,38 @@ The target surface (`responsive-web`, `iOS`, `Android`, or
 `cross-platform`) determines which platform guidance is relevant. For
 each goal, name how the platform's guidance shapes or bounds it:
 
-- **iOS** — Apple Human Interface Guidelines (HIG) shape navigation
-  patterns, gestures, and visual hierarchy on the platform. Point to
-  the HIG guidance that the goal aligns with or must account for.
-- **Android** — Material 3 provides the component vocabulary and
-  adaptive-layout guidance. Point to the relevant Material 3 guidance.
-- **responsive-web** — MDN's responsive-design documentation and, where
-  relevant, PWA conventions. Point to the relevant MDN guidance.
+- **iOS (Apple HIG)** — The HIG's visual voice is *clarity, deference,
+  depth*: the UI recedes so content is primary, spatial cues (depth,
+  translucency) signal context. Named tensions with common aesthetic goals:
+  a "branded, distinctive" direction must justify departing from system
+  font (SF Pro) and system colors — the HIG calls this out as a legibility
+  and trust risk. The **visionOS Spatial Design guidelines** extend this into
+  three-dimensional surfaces where depth is a first-class layout axis.
+  Cite the HIG chapter (e.g. "Visual Design → Color") rather than
+  paraphrasing.
+- **Android (Material 3 / Material You)** — Material 3's visual voice is
+  *personal, adaptive, expressive*: dynamic color (extracted from the
+  user's wallpaper) means brand color must coexist with user-sourced
+  palettes. The **Expressive tier** (2024) introduces bolder, more
+  personality-forward defaults — shapes, colors, and type at higher
+  contrast ratios than Material 2. A goal of "distinctive brand color" must
+  name how it degrades when the system overrides with dynamic color. Point
+  to the Material 3 spec section (e.g. "Color System → Dynamic Color").
+- **responsive-web** — MDN's Responsive Design guide and, where relevant,
+  PWA conventions. For visual voice: the Stripe / Linear / Vercel design
+  language has established a *dark hero + high-contrast type + single
+  chromatic accent* pattern as the default "serious developer product"
+  voice; a direction choosing this vocabulary should name what specifically
+  is taken and what differentiates from that default (else the product reads
+  as a Vercel clone). The **Inter** and **Geist** type families are now the
+  de-facto "modern web app" signal; choosing them is a convention, not a
+  distinction.
 - **cross-platform** — design the shared intent once, then name the
   per-surface adaptations the goal requires. Each surface's platform
   guidance applies to its own adaptation; the shared goal must clear
-  all of them.
+  all of them. A "consistent brand across iOS + web" goal must name
+  the tension point: SF Pro on iOS vs. brand typeface on web, and
+  how brand color interacts with HIG's color semantics on iOS.
 
 Platform conventions are not a ceiling — they are a floor and a
 vocabulary. A goal that contradicts a platform's strong conventions

--- a/packs/experience/.claude-plugin/plugin.json
+++ b/packs/experience/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "experience",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The design/UX seat for product teams — the grown-up successor to design-craft. Connective skills walk the thread from outcome to realization (map-customer-journey → map-screen-flow → blueprint-service) and map the inside-out sibling (map-internal-process); craft skills design each screen (aesthetic-direction, design-system-foundations, layout-and-information-architecture, interaction-design) and critique it (design-critique), all held to one shared quality-floor (handle-all-states, accessibility floor, reduced-motion). A forked-context experience-reviewer gives the design step an independent design-time review. Pure method: no stack, no values tables, no pixel comps — points to WCAG / W3C Design Tokens / Apple HIG / Material 3 / APQC / BPMN, never reprints them."
 }

--- a/packs/experience/pack.toml
+++ b/packs/experience/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "experience"
-version = "0.4.0"
+version = "0.4.1"
 description = "The design/UX seat for product teams — the grown-up successor to design-craft. Connective skills walk the thread from outcome to realization (map-customer-journey → map-screen-flow → blueprint-service) and map the inside-out sibling (map-internal-process); craft skills design each screen (aesthetic-direction, design-system-foundations, layout-and-information-architecture, interaction-design) and critique it (design-critique), all held to one shared quality-floor (handle-all-states, accessibility floor, reduced-motion). A forked-context experience-reviewer gives the design step an independent design-time review. Pure method: no stack, no values tables, no pixel comps — points to WCAG / W3C Design Tokens / Apple HIG / Material 3 / APQC / BPMN, never reprints them."
 readme = "README.md"
 display_name = "Experience"

--- a/packs/governance-extras/.apm/skills/new-adr/evals/evals.json
+++ b/packs/governance-extras/.apm/skills/new-adr/evals/evals.json
@@ -37,5 +37,16 @@
         "When a ## Confirmation section is present it is concrete (a named Mode/Signal/Owner) or explicitly Mode: none with a one-line reason — not aspirational, and not silently omitted where a reader would expect a conformance check"
       ]
     }
+    ,
+    {
+      "id": 4,
+      "prompt": "Record a short, simple architecture decision as an ADR — a small, obvious choice with one clear winner and no long-term drift risk (e.g. 'we agreed to use Python Black as our code formatter with its default settings; the whole team runs it identically and there's nothing to revisit unless Black ceases to be maintained').",
+      "expected_output": "Because the ADR is short enough that the Decision is visible on the first screen, the skill omits the `## Decision summary` block — it would be pure redundancy on a decision this compact. For a decision that won't age, it writes the explicit `Revisit if: stable — no foreseeable trigger` in Consequences rather than omitting the line entirely (omitting it would leave the reader uncertain whether the field was overlooked). The `## Confirmation` section, if present, is honest about the decision's lightweight checkability: a one-line `Mode: none` with a reason (a formatter choice that passes CI doesn't need a separate conformance audit) or the section is omitted for a genuinely non-checkable choice — not left aspirational.",
+      "assertions": [
+        "A ## Decision summary block is present when the ADR is long enough that the Decision is not visible on the first screen, and is omitted on a short ADR where it would be pure redundancy",
+        "A Revisit if: trigger is present in Consequences for a decision likely to age, with 'stable — no foreseeable trigger' as the valid explicit value when it will not",
+        "When a ## Confirmation section is present it is concrete (a named Mode/Signal/Owner) or explicitly Mode: none with a one-line reason — not aspirational, and not silently omitted where a reader would expect a conformance check"
+      ]
+    }
   ]
 }

--- a/packs/monorepo-extras/.apm/skills/new-package/evals/eval_queries.json
+++ b/packs/monorepo-extras/.apm/skills/new-package/evals/eval_queries.json
@@ -1,0 +1,16 @@
+[
+  {"query": "Create a new package called auth-utils in the monorepo", "should_trigger": true},
+  {"query": "Scaffold a new library for shared database helpers", "should_trigger": true},
+  {"query": "Add a new package for the PDF generation utilities", "should_trigger": true},
+  {"query": "New package: event-bus, for the shared messaging primitives", "should_trigger": true},
+  {"query": "I need a package for the rate-limiting logic that's shared across services", "should_trigger": true},
+  {"query": "Add a library called validation-utils under packages/", "should_trigger": true},
+  {"query": "Create a shared logging package for the monorepo", "should_trigger": true},
+
+  {"query": "Create a new top-level directory for infrastructure scripts", "should_trigger": false},
+  {"query": "Add a new app for the admin dashboard", "should_trigger": false},
+  {"query": "Scaffold a new microservice for the payment flow", "should_trigger": false},
+  {"query": "Write a spec for the auth-utils package", "should_trigger": false},
+  {"query": "Fix the failing tests in the existing logging package", "should_trigger": false},
+  {"query": "Refactor the database helper to use connection pooling", "should_trigger": false}
+]

--- a/packs/monorepo-extras/pack.toml
+++ b/packs/monorepo-extras/pack.toml
@@ -28,6 +28,13 @@ catalogue = "agent-ready-repo"
 pack = "core"
 version = "^0.1"
 
+# pack-activation-evals (RFC-0037 / ADR-0028): Tier-A activation-eval coverage.
+# new-package is the only user-prompt-triggered skill; it is repo-scope so the
+# prompt is always "scaffold a new library/package" — a narrow, unambiguous
+# trigger. The reviewer-internal skills (none in this pack) are excluded.
+[pack.evals]
+skills = ["new-package"]
+
 # enriched-pack-manifest (RFC-0031 / ADR-0021): catalogue-facing links
 # + maintainer, including the `documentation` link to the per-pack guide home.
 [pack.links]

--- a/packs/product-engineering/.apm/skills/discovery-loop/evals/eval_queries.json
+++ b/packs/product-engineering/.apm/skills/discovery-loop/evals/eval_queries.json
@@ -1,0 +1,17 @@
+[
+  {"query": "Scaffold the product vision for a team-scheduling tool", "should_trigger": true},
+  {"query": "Run a discovery for the new expense reporting product", "should_trigger": true},
+  {"query": "Diverge on the product shape then converge to a brief", "should_trigger": true},
+  {"query": "Take this raw idea for a developer onboarding tool to a decision brief", "should_trigger": true},
+  {"query": "Resume the task-management discovery from where we left off", "should_trigger": true},
+  {"query": "We have a rough idea — run it through the full discovery loop and give us a brief to hand off", "should_trigger": true},
+  {"query": "Before we build, scaffold a discovery: what product shapes should we explore for the notifications system?", "should_trigger": true},
+
+  {"query": "Generate candidate product shapes for the scheduling feature", "should_trigger": false},
+  {"query": "Write a spec for the notifications system", "should_trigger": false},
+  {"query": "Break this intent down into deliverable specs", "should_trigger": false},
+  {"query": "What's the riskiest assumption in this intent?", "should_trigger": false},
+  {"query": "Frame the domain before we design", "should_trigger": false},
+  {"query": "Plan the validation for these assumptions", "should_trigger": false},
+  {"query": "Design the architecture for the scheduling service", "should_trigger": false}
+]

--- a/packs/product-engineering/.apm/skills/explore-options/evals/eval_queries.json
+++ b/packs/product-engineering/.apm/skills/explore-options/evals/eval_queries.json
@@ -1,0 +1,17 @@
+[
+  {"query": "Give me candidate product shapes for the notifications system before we commit", "should_trigger": true},
+  {"query": "Diverge on the product shape — what are the options?", "should_trigger": true},
+  {"query": "What are the alternatives before we lock in on this approach?", "should_trigger": true},
+  {"query": "Explore alternatives for the scheduling feature — don't converge yet", "should_trigger": true},
+  {"query": "We have a rough idea — generate a few very different product shapes to compare", "should_trigger": true},
+  {"query": "What product shapes exist before we commit to the marketplace model?", "should_trigger": true},
+  {"query": "Give us three divergent approaches to the onboarding problem", "should_trigger": true},
+
+  {"query": "Scaffold the product vision and take it all the way to a brief", "should_trigger": false},
+  {"query": "Which of these shapes should we pick?", "should_trigger": false},
+  {"query": "Decompose the chosen product shape into specs", "should_trigger": false},
+  {"query": "What's the riskiest assumption in the marketplace model?", "should_trigger": false},
+  {"query": "Frame the domain for the scheduling product", "should_trigger": false},
+  {"query": "Write a spec for the notifications feature", "should_trigger": false},
+  {"query": "Play devil's advocate on this product direction", "should_trigger": false}
+]

--- a/packs/product-engineering/.apm/skills/frame-domain/evals/eval_queries.json
+++ b/packs/product-engineering/.apm/skills/frame-domain/evals/eval_queries.json
@@ -1,0 +1,20 @@
+[
+  {"query": "Frame the domain for a task management app before we start designing", "should_trigger": true},
+  {"query": "Ground this product in how people actually manage tasks today — the real-world activity", "should_trigger": true},
+  {"query": "What's in and what's out of scope for the MVP before we draw any screens?", "should_trigger": true},
+  {"query": "Frame the domain we're entering with this invoicing tool", "should_trigger": true},
+  {"query": "Bound the MVP — what's the scope boundary for the first release?", "should_trigger": true},
+  {"query": "How is expense reporting really done today? Ground us before we design", "should_trigger": true},
+  {"query": "Draw the scope boundary for the scheduling feature before we spec it", "should_trigger": true},
+  {"query": "We're building a time-tracking tool — what's the real-world activity we're modeling?", "should_trigger": true},
+  {"query": "What are the naive failure modes if we build this without understanding the domain first?", "should_trigger": true},
+
+  {"query": "Shape this idea into a product intent", "should_trigger": false},
+  {"query": "What's the riskiest assumption in this feature?", "should_trigger": false},
+  {"query": "Break this capability down into shippable specs", "should_trigger": false},
+  {"query": "Generate candidate product shapes for the scheduling feature", "should_trigger": false},
+  {"query": "Write a spec for the task management feature", "should_trigger": false},
+  {"query": "What should the empty state say?", "should_trigger": false},
+  {"query": "Design the data model for the invoicing system", "should_trigger": false},
+  {"query": "Plan the validation for this intent's assumptions", "should_trigger": false}
+]

--- a/packs/product-engineering/.apm/skills/plan-validation/evals/eval_queries.json
+++ b/packs/product-engineering/.apm/skills/plan-validation/evals/eval_queries.json
@@ -1,0 +1,18 @@
+[
+  {"query": "Plan the validation for these load-bearing assumptions", "should_trigger": true},
+  {"query": "How do we validate the assumptions behind this decision brief?", "should_trigger": true},
+  {"query": "Turn the kill-conditions in this brief into a validation plan", "should_trigger": true},
+  {"query": "Scaffold an interview guide to test the core assumption", "should_trigger": true},
+  {"query": "What would confirm that users actually want self-serve onboarding?", "should_trigger": true},
+  {"query": "We have a converged brief — now plan how we'd validate it before building", "should_trigger": true},
+  {"query": "Create a usability-test plan for the assumption that admins will manage permissions themselves", "should_trigger": true},
+  {"query": "Scaffold the primary-research instruments for our hypothesis", "should_trigger": true},
+
+  {"query": "What's the riskiest assumption in this intent? Test whether the bet holds", "should_trigger": false},
+  {"query": "Scaffold the product vision and run a discovery", "should_trigger": false},
+  {"query": "Generate candidate product shapes before we commit", "should_trigger": false},
+  {"query": "Frame the domain before we design", "should_trigger": false},
+  {"query": "Write a spec for the onboarding feature", "should_trigger": false},
+  {"query": "Design the research study for customer interviews", "should_trigger": false},
+  {"query": "Analyze the interview transcripts and synthesize findings", "should_trigger": false}
+]

--- a/packs/product-engineering/pack.toml
+++ b/packs/product-engineering/pack.toml
@@ -39,7 +39,7 @@ parent = "docs/product"
 # evals/eval_queries.json and is measured by tools/run-pack-evals.py. All five
 # skills are user-prompt-triggered, so none are excluded.
 [pack.evals]
-skills = ["frame-intent", "de-risk-intent", "decompose-intent", "align-value-stream", "voice-and-microcopy"]
+skills = ["frame-intent", "de-risk-intent", "decompose-intent", "align-value-stream", "voice-and-microcopy", "frame-domain", "discovery-loop", "explore-options", "plan-validation"]
 
 # enriched-pack-manifest (RFC-0031 / ADR-0021): catalogue-facing links
 # + maintainer, including the `documentation` link to the per-pack guide home.

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -7,7 +7,7 @@ hide:
 <div class="hero-section" markdown>
 # Discovery. Build. Release.<br>The full SDLC, agent-driven and supervised.
 
-An unattended loop makes unattended mistakes. These fourteen packs install hard mechanical gates, cold-read specialist reviewers, and mandatory human checkpoints across the full SDLC — so the agent cannot self-certify its own work.
+An unattended loop makes unattended mistakes. These supervised loops and curated packs install hard mechanical gates, cold-read specialist reviewers, and mandatory human checkpoints across the full SDLC — so the agent cannot self-certify its own work.
 
 <div class="hero-actions" markdown>
 [Install the core loop :octicons-arrow-right-24:](getting-started/index.md){ .md-button .md-button--primary .md-button--large }
@@ -55,12 +55,22 @@ Software delivery needs more than one loop. Three peer supervisors span the full
 
 </div>
 
+```mermaid
+flowchart LR
+    classDef loop fill:#5e6ad2,stroke:#4c5bbc,color:#fff,rx:6
+    PE["`**product-engineering**
+    discovery-lead
+    Raw idea → Brief`"]:::loop
+    CO["`**core**
+    work-loop
+    Spec → Shipped`"]:::loop
+    RE["`**release-engineering**
+    release-lead
+    Built → Production`"]:::loop
+    PE -->|"G3 — Decision Brief"| CO -->|"G4 — Shipped build"| RE
 ```
-product-engineering           core                    release-engineering
-───────────────────           ────                    ───────────────────
-discovery-lead                work-loop               release-lead
-Raw idea → Brief       ─G3─▶  Spec → Shipped   ─G4─▶  Built → Production
-```
+
+> **Gates:** G3 is the human hand-off from discovery to build — a ratified brief, not a validated solution. G4 is the hand-off from build to release — a green CI build, not a prod deploy. G5 (not shown) is the final human prod-ship approval; it is never autonomous.
 
 ## Install in one line
 
@@ -94,7 +104,7 @@ One command lands the loop in your repo. Any agent that reads a skill file inher
 
 ## The catalogue
 
-Fourteen curated packs — each distilled from the best practices of its discipline through research and architecture decisions. `repo` packs install into the current repository; `user` packs install once for all repos.
+A curated catalogue of packs — each distilled from the best practices of its discipline through research and architecture decisions. `repo` packs install into the current repository; `user` packs install once for all repos.
 
 **Start with the loops:**
 
@@ -120,7 +130,7 @@ Fourteen curated packs — each distilled from the best practices of its discipl
 
 </div>
 
-**Add what your team needs:**
+**Install once, works across all your repos:** `user`-scope packs follow you everywhere.
 
 <div class="grid cards" markdown>
 
@@ -166,6 +176,18 @@ Fourteen curated packs — each distilled from the best practices of its discipl
 
     [:octicons-arrow-right-24: Figma](packs/figma.md)
 
+-   **Credential Brokers** `user`
+
+    Credential resolution. Environment variable → OS keyring → dotfile. Cleartext never reaches the model.
+
+    [:octicons-arrow-right-24: Credential Brokers](packs/credential-brokers.md)
+
+</div>
+
+**Install per project:** `repo`-scope packs live in the repo, enforced consistently for the whole team.
+
+<div class="grid cards" markdown>
+
 -   **Governance Extras** `repo`
 
     Decision trail. `new-rfc`, `new-adr`, `update-conventions`, RFC/ADR ceremony for long-lived repos.
@@ -183,12 +205,6 @@ Fourteen curated packs — each distilled from the best practices of its discipl
     Package scaffolding. `new-package`, example package template.
 
     [:octicons-arrow-right-24: Monorepo Extras](packs/monorepo-extras.md)
-
--   **Credential Brokers** `user`
-
-    Credential resolution. Environment variable → OS keyring → dotfile. Cleartext never reaches the model.
-
-    [:octicons-arrow-right-24: Credential Brokers](packs/credential-brokers.md)
 
 </div>
 


### PR DESCRIPTION
## Summary

- **Eval coverage — Tier-1 complete.** Added `eval_queries.json` for `frame-domain`, `discovery-loop`, `explore-options`, `plan-validation`, and `new-package`; wired all into their pack's `[pack.evals].skills`. `monorepo-extras` gets its first `[pack.evals]` block. Tier-1 activation coverage now spans the full catalogue.
- **new-adr short-ADR scenario.** Added eval id-4 to exercise the omit-summary / explicit-`stable` branches that id-3 (long aging ADR) never reached.
- **Site improvements.** ASCII handoff diagram replaced with Mermaid flowchart (`#5e6ad2` accent, G3/G4 edges, G5 legend). All three "fourteen" count occurrences removed; 11 secondary catalogue cards split into user-scope / repo-scope sections.
- **aesthetic-direction grounding.md expanded.** Standards section now includes specific WCAG SCs with per-goal tensions, APCA, Nielsen/Hick/info-scent, typography canon (opsz, clamp(), wght, line-length), and IA rubrics (Diátaxis, card-sorting, progressive disclosure). Platform conventions section adds iOS HIG depth, Material 3 Expressive tier, and responsive-web vocabulary naming.
- **Credbroker frozen-pack RFC ref sweep.** Removed RFC-0023/RFC-0006/RFC-0035 citations from `packages/credbroker/credbroker/` (canonical) and synced vendored copies in `packs/` and `.agentbundle/`. Key discovery: `.apm/user-libs/` is a vendored copy byte-synced by `build-self` — always edit `packages/credbroker/` and let `build-self` propagate.
- **Backlog housekeeping.** Closed 8 items, tombstoned the stale `lint-plan-deps` item (already retired in `eb0e538a`).
- **AGENTS.local.md tooling.** Added direct `build-self` invocation, critical edit-ordering rule (all edits THEN build-self), and credbroker vendor-sync contract.

## Deferred

- `site-mobile-responsiveness`, `site-social-proof-band`, `site-design-system-spec` — remain open, need device testing / content decisions.
- `apm-leak-lint-rfc`, `credbroker-frozen-pack-ref-sweep` setup.py entry — left for a dedicated pass.

## Test plan

- [x] All new JSON eval files validate (`python3 -m json.tool`)
- [x] `build-self --force` ran clean (exit 0)
- [x] `build-check` shows only the pre-existing `site/` top-level directory lint failure (present on main before this PR)
- [x] `grep` confirms zero RFC-0023/RFC-0006/RFC-0035 refs remaining in credbroker user-libs