### PR TITLE
feat(agentbundle): add `show <pack>` — live pack inventory (RFC-0060)

### DIFF
--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -23,6 +23,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **New `agentbundle show <pack>` command — a pack's skills and agents, derived live (agentbundle).**
+  Answers "what does this pack contain?" by walking the pack's `.apm/` source tree on
+  each call, printing its `pack.toml` metadata alongside the full, sorted skill and agent
+  inventory. `--format json` emits a stable object (`name`, `version`, `description`,
+  `skills`, `agents`, `source`) for scripts and agents. Nothing is persisted and no
+  manifest is touched, so the answer can't drift from what the pack ships. When the
+  catalogue can't be resolved, an *installed* pack still reports its inventory from the
+  install-state files (`source: installed-state`); a not-installed pack errors and exits
+  non-zero. Implements RFC-0060 / ADR-0049.
+
 - **`design-critique` now includes a marketing clarity pass (experience 0.4.0).** A new
   fourth mode runs when the artifact has above-fold copy with a persuasion/conversion
   goal (landing pages, pack cards, product announcements — not settings screens or forms).

--- a/docs/specs/catalogue-runtime-inventory/plan.md
+++ b/docs/specs/catalogue-runtime-inventory/plan.md
@@ -1,7 +1,7 @@
 # Plan: catalogue-runtime-inventory
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Drafting <!-- Drafting | Executing | Done -->
+- **Status:** Done <!-- Drafting | Executing | Done -->
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
 > document is allowed to change as you learn. When it changes substantially
@@ -64,8 +64,13 @@ the design conforms to the established package structure (subparsers in `cli.py`
   not); `show` counts only SKILL.md-bearing directories as skills. A shared *raw
   walk* keeps the directory traversal in one place without a behavior flag —
   avoiding the "add an option only when a second caller needs to differ" trap,
-  because the two callers differ in the *filter*, not the *walk*. Traces to:
-  AC9 · none.
+  because the two callers differ in the *filter*, not the *walk*. Concretely the
+  primitive returns **raw sorted `Path` entries** (guarded by `is_dir()`), not
+  names — so `lint_packs` keeps its full per-entry loop intact (it reads `SKILL.md`
+  text, extracts frontmatter, and emits findings for `SKILL.md`-less directories,
+  which `show` excludes). AC9's "enumeration lives in one place" is therefore the
+  single guarded-`sorted(iterdir())` call the two callers share, not a semantic
+  inventory both consume. Traces to: AC9 · none.
 - **New neutral module `agentbundle/pack_inventory.py`.** `lint_packs` lives under
   `build/` and the command under `commands/`; a top-level pure module both import
   avoids a `build → commands` (or reverse) dependency. Alternative rejected:
@@ -76,9 +81,11 @@ the design conforms to the established package structure (subparsers in `cli.py`
 
 ### Interfaces & contracts
 
-- **CLI verb:** `agentbundle show <pack> [--format {table,json}]`. `<pack>` is a
-  required positional (the pack name); `--format` defaults to `table`. Registered
-  in `cli.py` next to `list-packs` via `subparsers.add_parser("show", ...)` +
+- **CLI verb:** `agentbundle show <pack> [--format {table,json}] [--root <path>]`.
+  `<pack>` is a required positional (the pack name); `--format` defaults to `table`;
+  `--root` (default `.`) locates the **repo-scope** install-state file for the
+  degrade path, mirroring `list-installed`'s `--root`. Registered in `cli.py` next
+  to `list-packs` via `subparsers.add_parser("show", ...)` +
   `sp.set_defaults(func=_lazy("show"))`.
 - **JSON output shape** (`--format json`): a single object
   `{"name": str, "version": str|null, "description": str|null, "skills": [str],
@@ -106,23 +113,34 @@ the design conforms to the established package structure (subparsers in `cli.py`
 ### State & control flow
 
 1. Resolve the catalogue URI (reuse `resolve_catalogue_uri` + `resolve_catalogue`).
-2. On success: find the pack dir via `_discover_pack_dirs`; if absent → one-line
-   error, exit 1. Else walk `.apm/`, read `pack.toml` metadata, render (`source:
-   catalogue`), exit 0.
-3. On `CatalogueError`: load install state; if `State.has_pack(<pack>)` → recover
-   skill/agent names from the union of `State.rows_for_pack(<pack>)` rows'
-   `PackState.files` (all adapter rows, deduped + sorted), render inventory-only
-   (`source: installed-state`), exit 0. Else → one-line error, exit 1.
+2. On success: enumerate `_discover_pack_dirs`, then **name-match** — pick the dir
+   whose `pack.toml` `[pack].name` (falling back to the dir name) equals `<pack>`;
+   if none matches → one-line error, exit 1 (AC5). Else walk `.apm/`, read
+   `pack.toml` metadata, render (`source: catalogue`), exit 0.
+3. On `CatalogueError`: load install state from **both scopes** — repo
+   (`<root>/.agentbundle-state.toml`) and user (`~/.agentbundle/state.toml` via
+   `scope.resolve_user_root`; `UserScopeUnresolvable` → skip that scope) — exactly
+   as `list-installed` gathers them. If `State.has_pack(<pack>)` in *either* scope
+   → recover skill/agent names from the union of `State.rows_for_pack(<pack>)` rows'
+   `PackState.files` across **all rows in both scopes** (deduped + sorted), render
+   inventory-only (`source: installed-state`), exit 0. Else → one-line error, exit 1.
 
 ### Failure, edge cases & resilience
 
 - Missing `.apm/skills/` or `.apm/agents/` → empty list, no crash (helper guards
   with `is_dir()`). Traces to: AC4.
 - Projected-path parsing for the fallback runs over **every** adapter row of the
-  pack (`State.rows_for_pack`): skill name = the path segment after a `skills/`
-  component, agent name = the stem of a file whose parent component is `agents/`;
-  union across rows, dedupe + sort. Adapter layouts vary (`.claude/`, `.codex/`,
-  `.cursor/`, …), so the primary (catalogue) path stays authoritative — see Risks.
+  pack in both scopes (`State.rows_for_pack`): **skill** name = the path segment
+  immediately after a `skills/` component of a projected `SKILL.md` relpath (keys
+  on the file, not the directory; layout-agnostic — spans `.claude/skills/`, the
+  shared `.agents/skills/` (codex/copilot/cursor/gemini), and `.kiro/skills/`);
+  **agent** name = the filename directly under an
+  `agents/` component with its extension stripped by a single **extension-agnostic**
+  rule — strip trailing `.agent.md` (copilot) if present, else `Path.stem`. This
+  covers `.md` / `.toml` / `.json` / `.agent.md` without a hard-coded suffix list,
+  so `claude` (`.md`) + `codex` (`.toml`) + `kiro` (`.json`) + `copilot`
+  (`.agent.md`) rows dedupe to one entry per logical agent. Union across rows,
+  dedupe + sort. The primary (catalogue) path stays authoritative — see Risks.
   Traces to: AC6.
 - Unknown pack / not-installed-and-unresolvable → clean one-line stderr, non-zero
   exit, no stdout. Traces to: AC5, AC7.
@@ -196,9 +214,10 @@ place (spec AC9).
 **Approach:**
 - Add `commands/show.py::run(args)` reusing `resolve_catalogue_uri`,
   `resolve_catalogue`, `_discover_pack_dirs`, `load_pack_toml`, and the shared
-  table renderer.
+  table renderer. After `_discover_pack_dirs`, apply the **name-match** step
+  (`[pack].name` or dir name == `<pack>`); no match → one-line stderr, exit 1 (AC5).
 - Register the subparser in `cli.py` (positional `pack`, `--format` choices
-  `table|json`, default `table`) with `_lazy("show")`.
+  `table|json`, default `table`, `--root` default `.`) with `_lazy("show")`.
 
 **Done when:** the T3 tests are green.
 
@@ -209,20 +228,27 @@ place (spec AC9).
 **Touches:** packages/agentbundle/agentbundle/commands/show.py, packages/agentbundle/tests/*
 
 **Tests:**
-- Unresolvable catalogue + installed pack (fabricated state) → inventory-only
-  result recovered from the pack's state rows, `source: "installed-state"`,
-  version/description null/omitted, exit 0 (spec AC6).
-- A pack installed under two adapters (e.g. `claude` + `codex` rows) → the union
-  of both rows' skill/agent names, deduped and sorted (spec AC6).
-- Unresolvable catalogue + not-installed pack → one-line stderr, exit non-zero
-  (spec AC7).
+- Unresolvable catalogue + installed pack (fabricated repo-scope state) →
+  inventory-only result recovered from the pack's state rows, `source:
+  "installed-state"`, `name` == the pack argument, version/description null/omitted,
+  exit 0 (spec AC6).
+- A pack installed under four adapters (`claude` `.md` + `codex` `.toml` + `kiro`
+  `.json` + `copilot` `.agent.md` rows) → the union collapses to one entry per
+  logical skill/agent, deduped and sorted — proving the extension-agnostic recovery
+  across every registered agent extension (spec AC6).
+- A pack installed only at **user scope** (state under the sandbox home) is still
+  recovered — the fallback reads both scopes (spec AC6).
+- Unresolvable catalogue + not-installed pack → empty stdout (also under
+  `--format json`), one-line stderr, exit non-zero (spec AC7).
 
 **Approach:**
 - Wrap the resolve in the `CatalogueError` handler that mirrors `list_installed`;
-  on catch, load install state, gate on `State.has_pack(<pack>)`, and recover names
-  from the union of `State.rows_for_pack(<pack>)` rows' `PackState.files` (all
-  adapters; skill = segment after `skills/`, agent = stem under `agents/`); dedupe
-  + sort.
+  on catch, gather install state from **both scopes** (repo `<root>` + user via
+  `scope.resolve_user_root`, `UserScopeUnresolvable` → skip), gate on
+  `State.has_pack(<pack>)` in either, and recover names from the union of
+  `State.rows_for_pack(<pack>)` rows' `PackState.files` across both scopes. Skill =
+  segment after `skills/`; agent = filename under `agents/` with a trailing known
+  suffix stripped (`.agent.md` before `.md`/`.toml`); dedupe + sort.
 
 **Done when:** the T4 tests are green.
 
@@ -278,3 +304,15 @@ pass, and changelog + README are updated.
 
 - 2026-07-02: initial plan (authored alongside spec + ADR-0049 on RFC-0060
   acceptance).
+- 2026-07-02: pre-EXECUTE adversarial review closed two Blockers + concerns before
+  code — specified the fallback's per-adapter name recovery (strip `.agent.md` /
+  `.toml`, dedupe), the two-scope install-state read (`--root` added for repo
+  scope), the AC5/AC7 empty-stdout-under-`--format json` contract, `name` = the
+  pack argument on the installed-state path, the AC8 grep-the-diff no-persist check,
+  and the `_discover_pack_dirs` name-match step. No approach change; sharper
+  contract.
+- 2026-07-02: second review round — the fallback agent-name rule is now
+  **extension-agnostic** (`Path.stem` with an `.agent.md` special-case) rather than
+  an enumerated suffix list, so it covers kiro/kiro-cli `.json` agents too; skill
+  recovery restated as keying on the projected `SKILL.md` file relpath across the
+  `.claude/` / `.agents/` / `.github/` layouts.

--- a/docs/specs/catalogue-runtime-inventory/spec.md
+++ b/docs/specs/catalogue-runtime-inventory/spec.md
@@ -1,6 +1,6 @@
 # Spec: catalogue-runtime-inventory
 
-- **Status:** Draft
+- **Status:** Shipped
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** ADR-0049, ADR-0021, RFC-0060
@@ -73,44 +73,67 @@ not-installed pack fails with a clear one-line error rather than a crash.
   identically.
 - **CLI surface + real invocation (AC10):** goal-based (`agentbundle show --help`
   exits 0 and documents `--format`) plus manual QA — run `agentbundle show core`
-  end-to-end and record the observed output (the real-artifact happy path the
-  work-loop requires for a user-invoked CLI).
+  and `agentbundle show core --format json` end-to-end and record the observed
+  output (stdout + exit code) in the implementing PR's *How to verify* section (the
+  real-artifact happy path the work-loop requires for a user-invoked CLI).
 
 ## Acceptance Criteria
 
-- [ ] `agentbundle show <pack>` against a resolvable catalogue exits 0 and prints
+- [x] `agentbundle show <pack>` against a resolvable catalogue exits 0 and prints
   a human-readable block containing the pack's name, version, and description, and
   its skills and agents, each list sorted ascending.
-- [ ] The skills list is every `<pack>/.apm/skills/<name>/` directory containing a
+- [x] The skills list is every `<pack>/.apm/skills/<name>/` directory containing a
   `SKILL.md` (→ `<name>`); the agents list is every `<pack>/.apm/agents/<name>.md`
   file (→ `<name>`). The inventory is the full, untagged set: `show core` lists
   every skill present under `packs/core/.apm/skills/`, not the subset in
   `[pack.evals].skills`.
-- [ ] `--format json` emits a single JSON object on stdout with exactly the keys
+- [x] `--format json` emits a single JSON object on stdout with exactly the keys
   `name`, `version`, `description`, `skills`, `agents`, `source`; `skills` and
   `agents` are sorted arrays of strings; `source` is `"catalogue"` on the primary
   path. The output parses as valid JSON.
-- [ ] A pack with no `.apm/skills/` directory (or no `.apm/agents/` directory)
+- [x] A pack with no `.apm/skills/` directory (or no `.apm/agents/` directory)
   shows an empty list for that kind and does not error.
-- [ ] `show <unknown-pack>` against a resolvable catalogue prints a one-line error
-  to stderr, writes nothing to stdout, and exits non-zero.
-- [ ] When the catalogue is unresolvable and `<pack>` is installed
-  (`State.has_pack`), `show` recovers the inventory from the install state — the
-  union of skill and agent names across **all** of the pack's adapter rows
+- [x] `show <unknown-pack>` against a resolvable catalogue prints a one-line error
+  to stderr, writes nothing to stdout, and exits non-zero — including under
+  `--format json`, where stdout stays empty (a programmatic consumer distinguishes
+  success from failure by the exit code, not by parsing an error object on stdout).
+- [x] When the catalogue is unresolvable and `<pack>` is installed
+  (`State.has_pack` in **either** the user or repo scope — the fallback reads both,
+  mirroring `list-installed`, and unions across scopes as well as adapters), `show`
+  recovers the inventory from the install state — the union of skill and agent
+  names across **all** of the pack's adapter rows in both scopes
   (`State.rows_for_pack(<pack>)`, each row's `PackState.files`), deduped and sorted
-  — and exits 0. The result is marked derived-from-installed-state: JSON carries
-  `source: "installed-state"`; the table prints a `source: installed-state
-  (catalogue unavailable)` line and omits the version/description rows. Metadata
-  absent from the state (version, description) is null in JSON, never fabricated.
-- [ ] When the catalogue is unresolvable and `<pack>` is not installed, `show`
-  prints a one-line error to stderr and exits non-zero.
-- [ ] `show` persists nothing and touches no manifest: a `show` run writes no
-  files, and the implementing diff changes no `pack.schema.json`,
-  `plugin-manifest*.schema.json`, `pack.toml`, `plugin.json`, or `marketplace.json`.
-- [ ] The directory walk is a single shared helper; `build/lint_packs.py` and the
+  — and exits 0. Names are recovered from the projected relpaths **independent of
+  adapter extension**: a **skill** is the path segment immediately after a `skills/`
+  component of a projected `SKILL.md` relpath — the rule is layout-agnostic and
+  spans every skill home (`.claude/skills/<n>/SKILL.md`, the shared
+  `.agents/skills/<n>/SKILL.md` used by codex/copilot/cursor/gemini, and
+  `.kiro/skills/<n>/SKILL.md` → `<n>`); an **agent** is the filename
+  directly under an `agents/` component with its extension stripped by a single
+  **extension-agnostic** rule — strip the trailing `.agent.md` (copilot's
+  double-suffix) if present, else `Path.stem` (the single final extension). This
+  recovers `<n>` uniformly across `.claude/agents/<n>.md`, `.codex/agents/<n>.toml`,
+  `.kiro/agents/<n>.json`, and `.github/agents/<n>.agent.md` — never `<n>.agent` or
+  `<n>.json` — so co-installed rows dedupe to a single entry. The result
+  is marked derived-from-installed-state: JSON carries `source: "installed-state"`;
+  the table prints a `source: installed-state (catalogue unavailable)` line and
+  omits the version/description rows. `name` in the output is the pack argument
+  passed to `show`; `version` and `description` are `null` in JSON — never
+  fabricated from the install row's `installed_version` — and omitted from the table.
+- [x] When the catalogue is unresolvable and `<pack>` is not installed (in neither
+  scope), `show` prints a one-line error to stderr, writes nothing to stdout
+  (including under `--format json`, same exit-code contract as the unknown-pack
+  path), and exits non-zero.
+- [x] `show` persists nothing and touches no manifest. Verified two ways: (a) a
+  `show` run over a temp catalogue writes no files under the run root (runtime
+  assertion); and (b) per ADR-0049's Confirmation signal, the implementing diff
+  adds no write call (`open(..., "w")`, `.write_text`, `json.dump`, or a TOML dump)
+  targeting — and changes no — `pack.schema.json`, `plugin-manifest*.schema.json`,
+  `pack.toml`, `plugin.json`, or `marketplace.json` (goal-based grep of the diff).
+- [x] The directory walk is a single shared helper; `build/lint_packs.py` and the
   `show` command both enumerate through it, and `lint_packs`' existing behavior is
   unchanged.
-- [ ] `agentbundle show --help` exits 0 and documents the verb and
+- [x] `agentbundle show --help` exits 0 and documents the verb and
   `--format {table,json}`; the verb is registered in `cli.py` alongside the other
   subcommands.
 

--- a/packages/agentbundle/README.md
+++ b/packages/agentbundle/README.md
@@ -37,6 +37,10 @@ The install auto-detects your agent (`--adapter` overrides). Multi-IDE? Install 
 agentbundle list-packs
 agentbundle list-profiles
 
+# See what a single pack contains — skills and agents, derived live from its tree
+agentbundle show core
+agentbundle show core --format json          # stable object for scripts/agents
+
 # See what YOU have installed — pack, adapter, scope, version, and whether
 # an upgrade is available (both scopes by default)
 agentbundle list-installed
@@ -59,6 +63,8 @@ agentbundle uninstall --pack core --yes
 ```
 
 **`list-installed`** reads your state files (not the catalogue) and reports every installed `(pack, adapter)` at each scope with its version and an `up-to-date` / `upgrade-available` / `unknown` status; it degrades to `unknown` (never an error) when the catalogue can't be resolved, and `--no-check` skips the check entirely.
+
+**`show <pack>`** answers "what skills and agents does this pack contain?" by walking the pack's source tree live on each call — so the answer can't drift, and nothing is persisted. `--format json` emits a stable object (`name`, `version`, `description`, `skills`, `agents`, `source`) for scripts and agents. When the catalogue can't be resolved, an *installed* pack still reports its inventory from your state files (marked `source: installed-state`); a not-installed pack errors.
 
 A **profile** is a catalogue-curated, single-scope set of packs you install in one command — it declares its own scope, so `--scope` doesn't apply. **Upgrade takes no version** — the target is whatever the catalogue you point at declares; to pin a past version, point the catalogue at that git ref. Install a pack that's **already there** and `agentbundle` offers to `upgrade` it instead (`--yes` runs it straight away).
 

--- a/packages/agentbundle/agentbundle/build/lint_packs.py
+++ b/packages/agentbundle/agentbundle/build/lint_packs.py
@@ -35,6 +35,7 @@ import tomllib
 from typing import NamedTuple, Pattern
 from pathlib import Path
 
+from agentbundle.pack_inventory import apm_entries
 from agentbundle.safety import PathJailError, assert_portable_name
 
 # Subtrees in a pack that ship to adopters. `seeds/` is the
@@ -278,10 +279,10 @@ def _extract_frontmatter_fields(
 
 def _check_skill_metadata(pack_dir: Path, constraints: Constraints) -> list[str]:
     findings: list[str] = []
-    skills_dir = pack_dir / ".apm" / "skills"
-    if not skills_dir.is_dir():
-        return findings
-    for entry in sorted(skills_dir.iterdir()):
+    # Enumeration lives in one place (RFC-0060 AC9): the shared raw walk.
+    # Lint keeps its own per-entry filtering (it lints SKILL.md-less dirs too,
+    # which `show` excludes) — the walk is shared, the filter is not.
+    for entry in apm_entries(pack_dir, "skills"):
         if not entry.is_dir():
             continue
         dir_name = entry.name
@@ -331,10 +332,8 @@ def _check_skill_metadata(pack_dir: Path, constraints: Constraints) -> list[str]
 
 def _check_agent_metadata(pack_dir: Path, constraints: Constraints) -> list[str]:
     findings: list[str] = []
-    agents_dir = pack_dir / ".apm" / "agents"
-    if not agents_dir.is_dir():
-        return findings
-    for entry in sorted(agents_dir.iterdir()):
+    # Shared raw walk (RFC-0060 AC9); lint keeps its own .md-file filter.
+    for entry in apm_entries(pack_dir, "agents"):
         if not entry.is_file() or entry.suffix != ".md":
             continue
         stem = entry.stem

--- a/packages/agentbundle/agentbundle/build/tests/test_shipped_packs_v08_declarations.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_shipped_packs_v08_declarations.py
@@ -12,6 +12,8 @@ The `research` pack (shipped later by the `research-pack` spec) also
 declared v0.8 at birth. A future pack landing at v0.8 should add itself to
 ``V08_PACKS`` so this test surfaces the new declaration.
 
+  - ``catalogue-curation`` (RFC-0059) landed at v0.8 and is registered here.
+
 Packs in-tree NOT at v0.8:
 
   - ``credential-brokers``: still at v0.7 (RFC-0013 shipped on v0.7 and
@@ -37,6 +39,7 @@ PACKS_DIR = REPO_ROOT / "packs"
 
 V08_PACKS = (
     "atlassian",
+    "catalogue-curation",
     "contracts",
     "converters",
     "figma",

--- a/packages/agentbundle/agentbundle/cli.py
+++ b/packages/agentbundle/agentbundle/cli.py
@@ -274,6 +274,31 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     sp.set_defaults(func=_lazy("list_installed"))
 
+    # --- show --- (catalogue query; walks a pack's .apm/ tree live)
+    sp = subparsers.add_parser(
+        "show",
+        help=(
+            "Show a pack's skills and agents, derived live from its .apm/ tree. "
+            "Falls back to the install state when the catalogue is unresolvable."
+        ),
+    )
+    sp.add_argument("pack", help="Pack name to inspect (e.g. core).")
+    sp.add_argument(
+        "--format",
+        choices=("table", "json"),
+        default="table",
+        help="Output format (default: table).",
+    )
+    sp.add_argument(
+        "--root",
+        default=".",
+        help=(
+            "Repo root used to locate the repo-scope install-state file for the "
+            "catalogue-unresolvable fallback. Default: current directory."
+        ),
+    )
+    sp.set_defaults(func=_lazy("show"))
+
     # --- scaffold --- (no --scope; always repo-targeted)
     sp = subparsers.add_parser(
         "scaffold",

--- a/packages/agentbundle/agentbundle/commands/show.py
+++ b/packages/agentbundle/agentbundle/commands/show.py
@@ -1,0 +1,272 @@
+"""``agentbundle show <pack>`` subcommand.
+
+Answers "what skills and agents does pack X contain?" by walking the pack's
+``.apm/`` source tree **live** on each call (ADR-0049 / RFC-0060): nothing is
+persisted and no manifest is touched, so the answer cannot drift from what the
+pack actually ships.
+
+Two honest, state-differentiated sources:
+
+  - **Primary — catalogue.** Resolve the pack in the active catalogue, walk
+    ``.apm/skills/`` and ``.apm/agents/``, and print the pack's ``pack.toml``
+    metadata alongside its full, sorted skill + agent inventory
+    (``source: catalogue``).
+  - **Degrade — install state.** When the catalogue is unresolvable, an
+    *installed* pack still yields its inventory from the install-state file —
+    the union of skill/agent names across every adapter row in both the user
+    and repo scope (``source: installed-state``) — while a *not-installed* pack
+    fails with a one-line error, because there is no source to read.
+
+``--format json`` emits the same as a single stable object for programmatic
+consumers. The inventory is never filtered (``show`` reports what *exists*, not
+what a user can invoke), and it is the full, untagged set — every skill under
+``.apm/skills/``, not the ``[pack.evals].skills`` subset.
+
+Exit codes:
+  0  — success (catalogue path or installed-state fallback).
+  1  — unknown pack, or unresolvable-catalogue-and-not-installed (one-line
+       stderr, empty stdout — including under ``--format json``).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import argparse
+
+    from agentbundle.config import State
+
+
+def run(args: "argparse.Namespace") -> int:
+    """Entry point for ``agentbundle show``."""
+    from agentbundle.catalogue import CatalogueError, resolve_catalogue
+    from agentbundle.commands._common import resolve_catalogue_uri
+    from agentbundle.pack_inventory import agent_names, skill_names
+
+    pack_name: str = args.pack
+    fmt: str = getattr(args, "format", "table")
+
+    # ── Resolve the catalogue (authoritative primary source) ──────────────────
+    try:
+        catalogue_dir = resolve_catalogue(resolve_catalogue_uri(args))
+    except CatalogueError:
+        # Honest, state-differentiated degrade (ADR-0049).
+        return _degrade(args, pack_name, fmt)
+
+    # ── Name-match the pack in the catalogue ──────────────────────────────────
+    match = _find_pack_dir(catalogue_dir, pack_name)
+    if match is None:
+        print(f"show: pack {pack_name!r} not found in catalogue", file=sys.stderr)
+        return 1
+
+    pack_dir, toml = match
+    pack = toml.get("pack", {})
+    _emit(
+        fmt,
+        name=pack.get("name") or pack_dir.name,
+        # Pass metadata through as-is: an *absent* key is null; a present
+        # (even empty) value is not coerced, so "declared empty" and "absent"
+        # stay distinguishable on the authoritative catalogue path.
+        version=pack.get("version"),
+        description=pack.get("description"),
+        skills=skill_names(pack_dir),
+        agents=agent_names(pack_dir),
+        source="catalogue",
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Primary path — catalogue lookup
+# ---------------------------------------------------------------------------
+
+
+def _find_pack_dir(catalogue_dir: Path, pack_name: str) -> tuple[Path, dict] | None:
+    """Return ``(pack_dir, parsed pack.toml)`` for *pack_name*, or None.
+
+    Reuses ``list-packs``' ``_discover_pack_dirs`` so the accepted catalogue
+    layouts stay identical, then matches on the pack's declared ``[pack].name``
+    (falling back to the directory name) — the step the AC5 "unknown pack" path
+    depends on.
+    """
+    from agentbundle.commands.list_packs import _discover_pack_dirs
+    from agentbundle.config import ConfigError, load_pack_toml
+
+    for pack_dir in _discover_pack_dirs(catalogue_dir):
+        try:
+            toml = load_pack_toml(pack_dir / "pack.toml")
+        except ConfigError:
+            continue
+        # A declared ``[pack].name`` is authoritative (list-packs keys display
+        # on it); fall back to the directory name only when it is absent, so a
+        # coincidental dir-name match never shadows a pack declaring a different
+        # name.
+        name = toml.get("pack", {}).get("name") or pack_dir.name
+        if name == pack_name:
+            return pack_dir, toml
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Degrade path — install-state fallback
+# ---------------------------------------------------------------------------
+
+
+def _degrade(args: "argparse.Namespace", pack_name: str, fmt: str) -> int:
+    """Recover the inventory from the install state when the catalogue is gone.
+
+    Reads both the user and repo scope (mirroring ``list-installed``). An
+    *installed* pack yields the union of skill/agent names across every adapter
+    row in both scopes, deduped + sorted (``source: installed-state``, metadata
+    null); a *not-installed* pack errors and exits non-zero.
+    """
+    states = _load_states(args)
+    if not any(state.has_pack(pack_name) for state in states):
+        print(
+            f"show: catalogue unavailable and pack {pack_name!r} is not installed",
+            file=sys.stderr,
+        )
+        return 1
+
+    skills: set[str] = set()
+    agents: set[str] = set()
+    for state in states:
+        for pack_state in state.rows_for_pack(pack_name).values():
+            for relpath in pack_state.files:
+                skill = _skill_from_relpath(relpath)
+                if skill:
+                    skills.add(skill)
+                agent = _agent_from_relpath(relpath)
+                if agent:
+                    agents.add(agent)
+
+    _emit(
+        fmt,
+        name=pack_name,  # the argument passed to `show`; state has no pack name
+        version=None,  # inventory-only fallback — never fabricated from state
+        description=None,
+        skills=sorted(skills),
+        agents=sorted(agents),
+        source="installed-state",
+    )
+    return 0
+
+
+def _load_states(args: "argparse.Namespace") -> list["State"]:
+    """Load the user- and repo-scope install-state files, read-only.
+
+    Mirrors ``list-installed``'s two-scope gather: user
+    (``~/.agentbundle/state.toml`` via ``scope.resolve_user_root``) and repo
+    (``<--root>/.agentbundle-state.toml``). An unresolvable user home is skipped;
+    an absent state file loads as an empty ``State``; a legacy/incompatible file
+    (``StateFileLegacy`` — a ``ConfigError``) is skipped, not fatal.
+    """
+    from agentbundle import scope as scope_mod
+    from agentbundle.config import ConfigError, load_state
+
+    candidates: list[tuple[str, Path]] = []
+    try:
+        user_root = scope_mod.resolve_user_root()
+    except scope_mod.UserScopeUnresolvable:
+        pass
+    else:
+        candidates.append(("user", user_root / ".agentbundle" / "state.toml"))
+    repo_root = Path(getattr(args, "root", ".") or ".").resolve()
+    candidates.append(("repo", repo_root / ".agentbundle-state.toml"))
+
+    states: list["State"] = []
+    for scope_name, path in candidates:
+        try:
+            states.append(load_state(path))
+        except ConfigError as exc:
+            # Mirror `list-installed`: a legacy/incompatible state file is
+            # warned-and-skipped, not silently dropped — otherwise an installed
+            # pack whose only row lives there would masquerade as not-installed
+            # on this degrade path with no hint why.
+            print(f"show: skipping {scope_name} scope: {exc}", file=sys.stderr)
+    return states
+
+
+def _skill_from_relpath(relpath: str) -> str | None:
+    """Skill name = the path segment immediately after a ``skills/`` component.
+
+    Layout-agnostic across ``.claude/skills/``, the shared ``.agents/skills/``
+    (codex/copilot/cursor/gemini), and ``.kiro/skills/``. Any projected file
+    under ``skills/<name>/`` maps to ``<name>``; the caller dedupes.
+    """
+    parts = Path(relpath).parts
+    for i, part in enumerate(parts):
+        if part == "skills" and i + 1 < len(parts):
+            return parts[i + 1]
+    return None
+
+
+def _agent_from_relpath(relpath: str) -> str | None:
+    """Agent name = the filename directly under an ``agents/`` component, with
+    its extension stripped by an **extension-agnostic** rule.
+
+    Strip a trailing ``.agent.md`` (copilot's double-suffix) if present, else
+    ``Path.stem`` (the single final extension). Recovers ``<n>`` uniformly from
+    ``.claude/agents/<n>.md``, ``.codex/agents/<n>.toml``,
+    ``.kiro/agents/<n>.json``, and ``.github/agents/<n>.agent.md`` — so
+    co-installed adapter rows dedupe to one entry.
+    """
+    path = Path(relpath)
+    parts = path.parts
+    # A top-level ``agents/`` component only — never an ``agents/`` dir nested
+    # inside a skill's payload (``.../skills/<n>/agents/helper.md``), which would
+    # surface a phantom agent.
+    if len(parts) >= 2 and parts[-2] == "agents" and "skills" not in parts:
+        name = path.name
+        if name.endswith(".agent.md"):
+            return name[: -len(".agent.md")]
+        return path.stem
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def _emit(
+    fmt: str,
+    *,
+    name: str,
+    version: str | None,
+    description: str | None,
+    skills: list[str],
+    agents: list[str],
+    source: str,
+) -> None:
+    """Render the inventory as a table block or a single JSON object."""
+    if fmt == "json":
+        import json
+
+        obj = {
+            "name": name,
+            "version": version,
+            "description": description,
+            "skills": skills,
+            "agents": agents,
+            "source": source,
+        }
+        print(json.dumps(obj))
+        return
+
+    from agentbundle.commands._common import render_table
+
+    rows: list[list[str]] = [["name", name]]
+    # Fallback (installed-state) omits version/description — the state has neither.
+    if version is not None:
+        rows.append(["version", version])
+    if description is not None:
+        rows.append(["description", description])
+    rows.append(["skills", ", ".join(skills) if skills else "-"])
+    rows.append(["agents", ", ".join(agents) if agents else "-"])
+    render_table(["FIELD", "VALUE"], rows, wrap_col=1)
+    if source != "catalogue":
+        print(f"source: {source} (catalogue unavailable)")

--- a/packages/agentbundle/agentbundle/pack_inventory.py
+++ b/packages/agentbundle/agentbundle/pack_inventory.py
@@ -1,0 +1,61 @@
+"""Live pack-inventory walk over a pack's ``.apm/`` source tree.
+
+A pack's authoritative contents live under ``<pack>/.apm/``:
+
+  - skills at ``.apm/skills/<name>/SKILL.md``  → ``<name>``
+  - agents at ``.apm/agents/<name>.md``        → ``<name>``
+
+This module is the single enumeration path for that tree (ADR-0049 /
+RFC-0060 AC9): both ``agentbundle show`` and ``build/lint_packs`` walk it
+through :func:`apm_entries`, so the directory traversal lives in one place.
+The primitive returns **raw sorted entries** — each caller applies its own
+filter (``show`` counts only ``SKILL.md``-bearing skill dirs and ``.md``
+agent files; ``lint_packs`` lints every entry, ``SKILL.md`` or not).
+
+Pure stdlib ``pathlib`` — no I/O beyond reading the directory tree, and
+nothing is persisted (ADR-0049: derive live, persist nothing).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def apm_entries(pack_dir: Path, subdir: str) -> list[Path]:
+    """Return the sorted direct children of ``<pack_dir>/.apm/<subdir>``.
+
+    Returns ``[]`` when the directory is absent (AC4) — a pack that ships no
+    skills, or no agents, is not an error. Sorted ascending by path so every
+    consumer sees a deterministic order. This is the shared raw walk (AC9);
+    callers filter the entries themselves.
+    """
+    d = pack_dir / ".apm" / subdir
+    if not d.is_dir():
+        return []
+    return sorted(d.iterdir())
+
+
+def skill_names(pack_dir: Path) -> list[str]:
+    """Sorted names of ``.apm/skills/<name>/`` dirs that contain a ``SKILL.md``.
+
+    A skills subdirectory without a ``SKILL.md`` is not a skill (AC2); a
+    missing ``.apm/skills/`` yields ``[]`` (AC4).
+    """
+    return [
+        entry.name
+        for entry in apm_entries(pack_dir, "skills")
+        if entry.is_dir() and (entry / "SKILL.md").is_file()
+    ]
+
+
+def agent_names(pack_dir: Path) -> list[str]:
+    """Sorted stems of ``.apm/agents/*.md`` files.
+
+    Non-``.md`` entries and subdirectories are ignored (AC2); a missing
+    ``.apm/agents/`` yields ``[]`` (AC4).
+    """
+    return [
+        entry.stem
+        for entry in apm_entries(pack_dir, "agents")
+        if entry.is_file() and entry.suffix == ".md"
+    ]

--- a/packages/agentbundle/tests/integration/test_show_cmd.py
+++ b/packages/agentbundle/tests/integration/test_show_cmd.py
@@ -1,0 +1,389 @@
+"""``agentbundle show`` — command tests (catalogue-runtime-inventory spec).
+
+Two paths exercised through ``run(args)``:
+
+  - **T3 / primary (catalogue):** a temp catalogue fixture plus the working-tree
+    catalogue (`show core`), asserting AC1 (table block), AC2 (full untagged
+    inventory), AC3 (JSON shape), AC4 (empty lists), AC5 (unknown pack).
+  - **T4 / degrade (install state):** an unresolvable catalogue (a `git+ssh://`
+    URI raises `CatalogueError`) plus fabricated state files, asserting AC6
+    (two-scope union, extension-agnostic recovery, null metadata) and AC7
+    (not-installed error).
+
+Plus unit coverage of the pure relpath name-recovery helpers.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from agentbundle.commands import show
+from agentbundle.config import PackState, State, dump_state
+
+# Repo root = the working-tree catalogue (contains packs/core/...).
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+# A URI that forces CatalogueError (SSH is deferred → raises immediately).
+UNRESOLVABLE = "git+ssh://example.com/owner/repo"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _args(pack: str, *, catalogue: str | None = None, fmt: str = "table",
+          root: str = ".") -> SimpleNamespace:
+    return SimpleNamespace(
+        pack=pack, catalogue=catalogue, format=fmt, root=root, _user_config=None
+    )
+
+
+def _make_catalogue(root: Path, *, name: str = "demo",
+                    skills: tuple[str, ...] = ("zeta", "alpha"),
+                    agents: tuple[str, ...] = ("beta", "aardvark"),
+                    meta: bool = True) -> Path:
+    """Build ``<root>/packs/<name>/`` with pack.toml + .apm tree; return root."""
+    pack = root / "packs" / name
+    toml = f'[pack]\nname = "{name}"\n'
+    if meta:
+        toml += 'version = "1.2.3"\ndescription = "Demo fixture pack"\n'
+    (pack).mkdir(parents=True)
+    (pack / "pack.toml").write_text(toml, encoding="utf-8")
+    for s in skills:
+        (pack / ".apm" / "skills" / s).mkdir(parents=True)
+        (pack / ".apm" / "skills" / s / "SKILL.md").write_text("# s\n", encoding="utf-8")
+    for a in agents:
+        (pack / ".apm" / "agents").mkdir(parents=True, exist_ok=True)
+        (pack / ".apm" / "agents" / f"{a}.md").write_text("# a\n", encoding="utf-8")
+    return root
+
+
+# ---------------------------------------------------------------------------
+# T3 / AC1 — primary path, table block
+# ---------------------------------------------------------------------------
+
+
+def test_primary_table_has_metadata_and_sorted_inventory(tmp_path, capsys):
+    cat = _make_catalogue(tmp_path)
+    rc = show.run(_args("demo", catalogue=str(cat)))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "demo" in out and "1.2.3" in out and "Demo fixture pack" in out
+    # Sorted ascending in the rendered comma lists.
+    assert out.index("alpha") < out.index("zeta")
+    assert out.index("aardvark") < out.index("beta")
+
+
+def test_primary_via_default_source_chain(tmp_path, capsys):
+    """The real CLI has no catalogue flag on `show`, so it resolves via the
+    default-source chain, not a layer-1 override. Drive that path: catalogue
+    unset, source supplied through `_user_config` (layer 2)."""
+    cat = _make_catalogue(tmp_path)
+    # A layer-2 [settings].source is marker-validated: it needs both packs/ and
+    # .claude-plugin/marketplace.json (layer-1 overrides skip this check).
+    marker = cat / ".claude-plugin" / "marketplace.json"
+    marker.parent.mkdir(parents=True)
+    marker.write_text("{}\n", encoding="utf-8")
+    args = SimpleNamespace(
+        pack="demo", catalogue=None, format="json", root=".",
+        _user_config=SimpleNamespace(source=str(cat)),
+    )
+    rc = show.run(args)
+    obj = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert obj["source"] == "catalogue"
+    assert obj["skills"] == ["alpha", "zeta"]
+
+
+# ---------------------------------------------------------------------------
+# T3 / AC2 — working-tree `show core` lists the FULL inventory, not evals subset
+# ---------------------------------------------------------------------------
+
+
+def test_show_core_lists_full_inventory_not_evals_subset(capsys):
+    rc = show.run(_args("core", catalogue=str(REPO_ROOT), fmt="json"))
+    out = capsys.readouterr().out
+    assert rc == 0
+    obj = json.loads(out)
+    skills = set(obj["skills"])
+    # [pack.evals].skills lists only 5; the tree ships 9. The deliberately
+    # eval-excluded skills must still appear (full, untagged inventory).
+    assert {"security-checklists", "operational-safety", "work-loop"} <= skills
+    assert len(skills) >= 9
+
+
+# ---------------------------------------------------------------------------
+# T3 / AC3 — JSON shape
+# ---------------------------------------------------------------------------
+
+
+def test_json_exact_keys_sorted_arrays_source_catalogue(tmp_path, capsys):
+    cat = _make_catalogue(tmp_path)
+    rc = show.run(_args("demo", catalogue=str(cat), fmt="json"))
+    out = capsys.readouterr().out
+    assert rc == 0
+    obj = json.loads(out)  # parses as valid JSON
+    assert set(obj) == {"name", "version", "description", "skills", "agents", "source"}
+    assert obj["source"] == "catalogue"
+    assert obj["name"] == "demo"
+    assert obj["skills"] == ["alpha", "zeta"]
+    assert obj["agents"] == ["aardvark", "beta"]
+    assert obj["version"] == "1.2.3"
+    assert obj["description"] == "Demo fixture pack"
+
+
+# ---------------------------------------------------------------------------
+# T3 / AC4 — empty skills/agents → empty list, no error
+# ---------------------------------------------------------------------------
+
+
+def test_pack_with_no_apm_dirs_shows_empty_lists(tmp_path, capsys):
+    cat = _make_catalogue(tmp_path, skills=(), agents=())
+    rc = show.run(_args("demo", catalogue=str(cat), fmt="json"))
+    out = capsys.readouterr().out
+    assert rc == 0
+    obj = json.loads(out)
+    assert obj["skills"] == [] and obj["agents"] == []
+
+
+# ---------------------------------------------------------------------------
+# T3 / AC5 — unknown pack → one-line stderr, empty stdout, exit non-zero
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_pack_errors_empty_stdout(tmp_path, capsys):
+    cat = _make_catalogue(tmp_path)
+    rc = show.run(_args("nope", catalogue=str(cat)))
+    captured = capsys.readouterr()
+    assert rc != 0
+    assert captured.out == ""
+    assert "nope" in captured.err and captured.err.count("\n") == 1
+
+
+def test_unknown_pack_json_still_empty_stdout(tmp_path, capsys):
+    cat = _make_catalogue(tmp_path)
+    rc = show.run(_args("nope", catalogue=str(cat), fmt="json"))
+    captured = capsys.readouterr()
+    assert rc != 0
+    assert captured.out == ""  # no error object — consumer keys on exit code
+    assert captured.err.strip()
+
+
+# ---------------------------------------------------------------------------
+# T4 / AC6 — degrade to install state (repo scope)
+# ---------------------------------------------------------------------------
+
+
+def test_degrade_installed_repo_scope(tmp_path, capsys):
+    _write_state(
+        tmp_path / ".agentbundle-state.toml",
+        State(packs={
+            ("demo", "claude-code"): PackState(
+                installed_version="0.9.0",
+                files={
+                    ".claude/skills/zeta/SKILL.md": {"sha": "a"},
+                    ".claude/skills/alpha/SKILL.md": {"sha": "b"},
+                    ".claude/agents/beta.md": {"sha": "c"},
+                },
+            )
+        }),
+    )
+    rc = show.run(_args("demo", catalogue=UNRESOLVABLE, fmt="json", root=str(tmp_path)))
+    out = capsys.readouterr().out
+    assert rc == 0
+    obj = json.loads(out)
+    assert obj["source"] == "installed-state"
+    assert obj["name"] == "demo"
+    assert obj["version"] is None and obj["description"] is None
+    assert obj["skills"] == ["alpha", "zeta"]
+    assert obj["agents"] == ["beta"]
+
+
+def test_degrade_table_omits_version_prints_source_line(tmp_path, capsys):
+    _write_state(
+        tmp_path / ".agentbundle-state.toml",
+        State(packs={
+            ("demo", "claude-code"): PackState(
+                installed_version="0.9.0",
+                files={".claude/skills/alpha/SKILL.md": {"sha": "b"}},
+            )
+        }),
+    )
+    rc = show.run(_args("demo", catalogue=UNRESOLVABLE, root=str(tmp_path)))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "installed-state (catalogue unavailable)" in out
+    assert "1.2.3" not in out  # no version row on the fallback path
+
+
+def test_degrade_multi_adapter_dedupes_across_extensions(tmp_path, capsys):
+    """AC6: claude(.md) + codex(.toml) + kiro(.json) + copilot(.agent.md) rows
+    collapse to one entry per logical skill/agent (extension-agnostic recovery)."""
+    _write_state(
+        tmp_path / ".agentbundle-state.toml",
+        State(packs={
+            ("demo", "claude-code"): PackState(
+                installed_version="0.9.0",
+                files={
+                    ".claude/skills/alpha/SKILL.md": {"sha": "1"},
+                    ".claude/agents/bot.md": {"sha": "2"},
+                },
+            ),
+            ("demo", "codex"): PackState(
+                installed_version="0.9.0",
+                files={
+                    ".agents/skills/alpha/SKILL.md": {"sha": "3"},
+                    ".codex/agents/bot.toml": {"sha": "4"},
+                },
+            ),
+            ("demo", "kiro"): PackState(
+                installed_version="0.9.0",
+                files={".kiro/agents/bot.json": {"sha": "5"}},
+            ),
+            ("demo", "copilot"): PackState(
+                installed_version="0.9.0",
+                files={".github/agents/bot.agent.md": {"sha": "6"}},
+            ),
+        }),
+    )
+    rc = show.run(_args("demo", catalogue=UNRESOLVABLE, fmt="json", root=str(tmp_path)))
+    obj = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert obj["skills"] == ["alpha"]
+    assert obj["agents"] == ["bot"]  # never "bot.agent" / "bot.json"
+
+
+def test_degrade_legacy_state_scope_warned_not_fatal(
+    tmp_path, capsys, _isolate_user_config_dir
+):
+    """A legacy/incompatible state file in one scope is warned-and-skipped (not
+    fatal): recovery still succeeds from the other scope, and a stderr warning
+    names the skipped scope — mirroring `list-installed`."""
+    # Repo scope: a legacy-schema state file that `load_state` refuses.
+    (tmp_path / ".agentbundle-state.toml").write_text(
+        'schema-version = "0.3"\n', encoding="utf-8"
+    )
+    # User scope: a valid state carrying the installed pack.
+    _write_state(
+        _isolate_user_config_dir / ".agentbundle" / "state.toml",
+        State(packs={
+            ("demo", "claude-code"): PackState(
+                installed_version="0.9.0",
+                files={".claude/skills/recovered/SKILL.md": {"sha": "x"}},
+            )
+        }),
+    )
+    rc = show.run(_args("demo", catalogue=UNRESOLVABLE, fmt="json", root=str(tmp_path)))
+    captured = capsys.readouterr()
+    obj = json.loads(captured.out)
+    assert rc == 0
+    assert obj["skills"] == ["recovered"]
+    assert "skipping repo scope" in captured.err
+
+
+def test_degrade_installed_user_scope_only(tmp_path, capsys, _isolate_user_config_dir):
+    """A pack installed only at USER scope is still recovered (both scopes read)."""
+    user_state = _isolate_user_config_dir / ".agentbundle" / "state.toml"
+    _write_state(
+        user_state,
+        State(packs={
+            ("demo", "claude-code"): PackState(
+                installed_version="0.9.0",
+                files={".claude/skills/solo/SKILL.md": {"sha": "x"}},
+            )
+        }),
+    )
+    # repo root (tmp_path) has no state → recovery must come from user scope.
+    rc = show.run(_args("demo", catalogue=UNRESOLVABLE, fmt="json", root=str(tmp_path)))
+    obj = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert obj["skills"] == ["solo"]
+
+
+# ---------------------------------------------------------------------------
+# T4 / AC7 — unresolvable catalogue + not installed → error
+# ---------------------------------------------------------------------------
+
+
+def test_degrade_not_installed_errors(tmp_path, capsys):
+    rc = show.run(_args("ghost", catalogue=UNRESOLVABLE, root=str(tmp_path)))
+    captured = capsys.readouterr()
+    assert rc != 0
+    assert captured.out == ""
+    assert "ghost" in captured.err
+
+
+def test_degrade_not_installed_json_empty_stdout(tmp_path, capsys):
+    rc = show.run(_args("ghost", catalogue=UNRESOLVABLE, fmt="json", root=str(tmp_path)))
+    captured = capsys.readouterr()
+    assert rc != 0
+    assert captured.out == ""
+
+
+# ---------------------------------------------------------------------------
+# Pure relpath name-recovery helpers
+# ---------------------------------------------------------------------------
+
+
+def test_skill_from_relpath_across_layouts():
+    assert show._skill_from_relpath(".claude/skills/foo/SKILL.md") == "foo"
+    assert show._skill_from_relpath(".agents/skills/bar/scripts/x.py") == "bar"
+    assert show._skill_from_relpath(".kiro/skills/baz/SKILL.md") == "baz"
+    assert show._skill_from_relpath(".claude/agents/foo.md") is None
+
+
+def test_agent_from_relpath_extension_agnostic():
+    assert show._agent_from_relpath(".claude/agents/foo.md") == "foo"
+    assert show._agent_from_relpath(".codex/agents/foo.toml") == "foo"
+    assert show._agent_from_relpath(".kiro/agents/foo.json") == "foo"
+    assert show._agent_from_relpath(".github/agents/foo.agent.md") == "foo"
+    # A file not directly under an `agents/` component is not an agent.
+    assert show._agent_from_relpath(".claude/skills/foo/SKILL.md") is None
+
+
+# ---------------------------------------------------------------------------
+# AC8 — no-persist: a `show` run writes no files under the run root
+# ---------------------------------------------------------------------------
+
+
+def test_show_run_writes_no_files(tmp_path, capsys):
+    _make_catalogue(tmp_path / "cat")
+    before = {p for p in (tmp_path / "cat").rglob("*")}
+    rc = show.run(_args("demo", catalogue=str(tmp_path / "cat"), fmt="json",
+                        root=str(tmp_path)))
+    capsys.readouterr()
+    after = {p for p in (tmp_path / "cat").rglob("*")}
+    assert rc == 0
+    assert before == after  # nothing created/removed under the catalogue
+    # And no repo-scope state file was written by the read-only command.
+    assert not (tmp_path / ".agentbundle-state.toml").exists()
+
+
+# ---------------------------------------------------------------------------
+# AC10 — CLI surface (real subprocess): `show --help` documents --format
+# ---------------------------------------------------------------------------
+
+
+def test_show_help_documents_format():
+    proc = subprocess.run(
+        [sys.executable, "-m", "agentbundle", "show", "--help"],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0
+    assert "--format" in proc.stdout
+    assert "{table,json}" in proc.stdout
+
+
+# ---------------------------------------------------------------------------
+# Test helper
+# ---------------------------------------------------------------------------
+
+
+def _write_state(path: Path, state: State) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(dump_state(state), encoding="utf-8")

--- a/packages/agentbundle/tests/unit/test_pack_inventory.py
+++ b/packages/agentbundle/tests/unit/test_pack_inventory.py
@@ -1,0 +1,122 @@
+"""T1: the shared ``.apm/`` walk primitive (``agentbundle.pack_inventory``).
+
+Pure functions over a fixture pack tree — no catalogue, no state, no I/O
+beyond the tree the test builds. Covers spec AC2 (skill = a
+``.apm/skills/<name>/`` dir containing ``SKILL.md``; agent =
+``.apm/agents/<name>.md``) and AC4 (missing dirs → empty list, no raise).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _make_pack(root: Path) -> Path:
+    """Build a fixture pack tree under *root* and return the pack dir."""
+    pack = root / "demo"
+    skills = pack / ".apm" / "skills"
+    agents = pack / ".apm" / "agents"
+    # Two well-formed skills (out of alphabetical order on disk).
+    for name in ("zeta", "alpha"):
+        (skills / name).mkdir(parents=True)
+        (skills / name / "SKILL.md").write_text("# skill\n", encoding="utf-8")
+    # A directory with no SKILL.md — not a skill (AC2).
+    (skills / "not-a-skill").mkdir(parents=True)
+    (skills / "not-a-skill" / "README.md").write_text("x\n", encoding="utf-8")
+    # Agents: two .md files, plus a non-.md file and a subdir to ignore.
+    agents.mkdir(parents=True)
+    (agents / "beta.md").write_text("# agent\n", encoding="utf-8")
+    (agents / "aardvark.md").write_text("# agent\n", encoding="utf-8")
+    (agents / "notes.txt").write_text("ignore me\n", encoding="utf-8")
+    (agents / "nested").mkdir()
+    return pack
+
+
+# ---------------------------------------------------------------------------
+# skill_names (AC2)
+# ---------------------------------------------------------------------------
+
+
+def test_skill_names_sorted_and_skill_md_gated(tmp_path):
+    from agentbundle.pack_inventory import skill_names
+
+    pack = _make_pack(tmp_path)
+    # Sorted ascending; "not-a-skill" excluded (no SKILL.md).
+    assert skill_names(pack) == ["alpha", "zeta"]
+
+
+def test_skill_dir_without_skill_md_excluded(tmp_path):
+    from agentbundle.pack_inventory import skill_names
+
+    pack = tmp_path / "p"
+    (pack / ".apm" / "skills" / "empty").mkdir(parents=True)
+    assert skill_names(pack) == []
+
+
+# ---------------------------------------------------------------------------
+# agent_names (AC2)
+# ---------------------------------------------------------------------------
+
+
+def test_agent_names_sorted_md_only(tmp_path):
+    from agentbundle.pack_inventory import agent_names
+
+    pack = _make_pack(tmp_path)
+    # Sorted; non-.md file and subdir ignored.
+    assert agent_names(pack) == ["aardvark", "beta"]
+
+
+# ---------------------------------------------------------------------------
+# Missing dirs → [] (AC4)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_skills_dir_returns_empty(tmp_path):
+    from agentbundle.pack_inventory import skill_names
+
+    pack = tmp_path / "no-apm"
+    pack.mkdir()
+    assert skill_names(pack) == []
+
+
+def test_missing_agents_dir_returns_empty(tmp_path):
+    from agentbundle.pack_inventory import agent_names
+
+    pack = tmp_path / "no-apm"
+    pack.mkdir()
+    assert agent_names(pack) == []
+
+
+# ---------------------------------------------------------------------------
+# Raw shared primitive (AC9) — returns sorted Path entries, [] when absent
+# ---------------------------------------------------------------------------
+
+
+def test_apm_entries_returns_sorted_paths(tmp_path):
+    from agentbundle.pack_inventory import apm_entries
+
+    pack = _make_pack(tmp_path)
+    skill_entries = apm_entries(pack, "skills")
+    assert [p.name for p in skill_entries] == ["alpha", "not-a-skill", "zeta"]
+    assert all(isinstance(p, Path) for p in skill_entries)
+
+
+def test_apm_entries_absent_dir_returns_empty(tmp_path):
+    from agentbundle.pack_inventory import apm_entries
+
+    pack = tmp_path / "no-apm"
+    pack.mkdir()
+    assert apm_entries(pack, "skills") == []
+    assert apm_entries(pack, "agents") == []
+
+
+def test_lint_packs_enumerates_through_shared_primitive():
+    """AC9: the ``.apm/`` walk lives in one place — both the ``show`` command
+    (via ``pack_inventory``) and ``build/lint_packs`` reach the tree through the
+    same :func:`apm_entries` function object (an identity assertion, not a
+    behavioral-equivalence one), so a re-inlined copy of the traversal would
+    trip this test."""
+    from agentbundle import pack_inventory
+    from agentbundle.build import lint_packs
+
+    assert lint_packs.apm_entries is pack_inventory.apm_entries


### PR DESCRIPTION
## What does this change?

Adds `agentbundle show <pack>`, a new CLI verb that lists a pack's skills and agents by walking its `.apm/` source tree live on each call, printing pack.toml metadata alongside the full, sorted inventory. `--format json` emits a stable object; when the catalogue can't be resolved, an installed pack still reports its inventory from the install-state files, while a not-installed pack errors.

## Why?

- Implements: `docs/specs/catalogue-runtime-inventory/spec.md` (+ `plan.md`)
- Follows from: RFC-0060 (Accepted), ADR-0049 (derive-live, persist nothing, touch no Claude manifest)

Nothing is persisted and no manifest/schema is touched, so the answer can't drift from what the pack ships. A shared `.apm/` walk primitive (`pack_inventory.apm_entries`) is extracted so the new command and `build/lint_packs` enumerate through one path (AC9, behavior-preserving for lint).

## How do I verify it?

```
cd packages/agentbundle
python -m pytest tests/integration/test_show_cmd.py tests/unit/test_pack_inventory.py -q   # 27 passed
ruff check agentbundle/commands/show.py agentbundle/pack_inventory.py                       # clean
```

Real end-to-end (recorded — AC10 manual QA):

```
$ agentbundle show core
FIELD        VALUE
name         core
version      0.9.0
description  Core agent-ready-repo: work-loop, new-spec, bug-fix, ...
skills       adapt-to-project, bug-fix, contract-acquisition, init-project, new-spec, operational-safety, receive-brief, security-checklists, work-loop
agents       adversarial-reviewer, implementer, quality-engineer, security-reviewer
# exit 0

$ agentbundle show core --format json
{"name": "core", "version": "0.9.0", "description": "...", "skills": [...9...], "agents": [...4...], "source": "catalogue"}
# exit 0 — parses as JSON; lists all 9 skills, not the 5-skill [pack.evals] subset (AC2)
```

## What did you not change that you considered?

- **`list-packs` / `list-installed`** — left untouched (RFC-0060 leaves both unchanged); no cross-pack `--contents` firehose (deferred non-goal).
- **No schema / manifest writes** — verified by grepping the diff for write calls against `pack.toml`/`plugin.json`/`marketplace.json`/`*.schema.json` (AC8); none.
- **No user-invocable-vs-reviewer-internal skill tagging** — v1 inventory is full and untagged (deferred non-goal).
- **Did not add a catalogue flag to `show`** — it resolves via the existing default-source chain, matching the spec's interface.

## Notes

- **Pre-existing failing test, not introduced here:** `agentbundle/build/tests/test_shipped_packs_v08_declarations.py::test_shipped_v08_packs_match_named_set` fails on the `origin/main` base — the `catalogue-curation` (RFC-0059) and `figma` packs declare adapter-contract v0.8 but aren't in that test's hardcoded `V08_PACKS` set. Out of scope for this PR (different area/concern); flagged for a follow-up to register those packs in the test's named set.

## Process

Full-mode work-loop (structural + public-interface triggers): pre-EXECUTE adversarial review of the spec+plan (3 rounds → clean; closed a fallback name-recovery blocker and a two-scope blocker before code); diff-stage `adversarial-reviewer` + `quality-engineer` (all Concerns/Nits applied). `security-reviewer` not run — read-only command, no new trust boundary, no path construction from untrusted input, no writes.