### PR TITLE
chore(release): agentbundle 0.11.0 — `show <pack>` command

### DIFF
--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -8,6 +8,21 @@ the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 
 ## [Unreleased]
 
+## [0.11.0] — 2026-07-03
+
+### Added
+
+- **New `agentbundle show <pack>` command — a pack's skills and agents, derived
+  live.** Answers "what does this pack contain?" by walking the pack's `.apm/`
+  source tree on each call, printing its `pack.toml` metadata alongside the full,
+  sorted skill and agent inventory. `--format json` emits a stable object
+  (`name`, `version`, `description`, `skills`, `agents`, `source`) for scripts and
+  agents. Nothing is persisted and no manifest is touched, so the answer can't
+  drift from what the pack ships. When the catalogue can't be resolved, an
+  *installed* pack still reports its inventory from the install-state files
+  (`source: installed-state`, recovered across both scopes and every adapter row);
+  a not-installed pack errors and exits non-zero. Implements RFC-0060 / ADR-0049.
+
 ## [0.10.2] — 2026-06-30
 
 ### Fixed

--- a/packages/agentbundle/agentbundle/version.py
+++ b/packages/agentbundle/agentbundle/version.py
@@ -14,7 +14,7 @@ import tomllib
 from importlib.resources import files
 from pathlib import Path
 
-CLI_VERSION = "0.10.2"
+CLI_VERSION = "0.11.0"
 
 _HERE = Path(__file__).resolve().parent
 

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentbundle"
-version = "0.10.2"
+version = "0.11.0"
 description = "npm for your coding agent. Install packs of skills, subagents, and hooks into any repo, for every major agent."
 requires-python = ">=3.11"
 dependencies = []


### PR DESCRIPTION
## What does this change?

Cuts the agentbundle **0.11.0** release for the `show <pack>` live-inventory command (RFC-0060, merged in #493). Bumps `pyproject` `version` and `CLI_VERSION` 0.10.2 → 0.11.0 and finalizes the package CHANGELOG `[0.11.0]` section.

## Why?

The `show` feature merged without a version bump, so it can't reach PyPI users. Minor bump — additive new command. `release-agentbundle.yml` asserts tag == pyproject == `CLI_VERSION`; both are bumped in lockstep here.

## How do I verify it?

```
cd packages/agentbundle
python -m pytest tests/ -k version -q          # version-consistency tests pass
agentbundle --version                          # agentbundle 0.11.0 (spec 0.17)
```

On merge, tag `agentbundle-v0.11.0` → the release workflow builds + publishes to PyPI.

## What did you not change that you considered?

- **No code changes** — the `show` command already merged in #493; this is version metadata + changelog only.
- The repo-level `docs/product/changelog.md` entry and the PyPI README note already landed with #493.

## Notes

The commit carries `Engine-Change-RFC: RFC-0060` — the catalogue-curation guard (RFC-0059) gates any `packages/agentbundle/**` change, and this release is authorized by RFC-0060.