### PR TITLE
fix(render-proof): add @media print block for PDF print fidelity

### DIFF
--- a/packs/converters/.apm/skills/render-proof/scripts/render-proof.js
+++ b/packs/converters/.apm/skills/render-proof/scripts/render-proof.js
@@ -210,6 +210,18 @@ hr { border: none; border-top: 1px solid var(--proof-border); margin: 2rem 0; }
 input[type="checkbox"] { pointer-events: none; }
 ol, ul { padding-left: 1.5rem; }
 li { margin: 0.25rem 0; }
+@media print {
+  @page { margin: 2cm; }
+  body.proof-body { background: #fff; color: #000; padding: 0; }
+  main.proof-main { max-width: 100%; margin: 0; }
+  pre, .shiki { background: #f5f5f4 !important; border-radius: 0; overflow-x: visible; }
+  pre code, .shiki code { white-space: pre-wrap; overflow-wrap: break-word; color: #000; }
+  .shiki span[style] { color: inherit !important; background: none !important; }
+  h2, h3, h4 { break-after: avoid; }
+  pre, blockquote, table, figure { break-inside: avoid; }
+  a { color: #000; }
+  a[href^="http"]::after { content: " (" attr(href) ")"; font-size: 0.8em; color: #555; }
+}
 `;
 
 // ─── renderProof ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `@page` sets 2 cm margins to prevent border overruns on A4/Letter
- `main.proof-main` unconstrained from `72ch` (`max-width: 100%`) — 72ch overruns Letter paper at normal margins
- Code blocks: light background, `pre-wrap` + `overflow-wrap: break-word` to prevent right-edge clipping
- Shiki span colours stripped in print (avoids invisible text on white)
- `break-after: avoid` on headings; `break-inside: avoid` on `pre`/`blockquote`/`table`
- HTTP links annotated with href in print output

## Test plan

- [ ] All existing tests pass (`node test/renderer.test.js`, `pipeline.test.js`, `security.test.js`)
- [ ] Open a rendered proof in a browser → File → Print → verify no content clips at page edge
- [ ] Code block prints with light background and wrapped long lines