### PR TITLE
fix(agentbundle): forward resolved adapter in install→upgrade offer when --adapter omitted

### DIFF
--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -8,6 +8,16 @@ the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 
 ## [Unreleased]
 
+### Fixed
+
+- **`install` without `--adapter` now targets the auto-resolved adapter when
+  handing off to `upgrade`.** Installing a pack already present for multiple
+  adapters at a scope (e.g. `claude-code` and `codex`) without specifying
+  `--adapter` triggered upgrade's "pass `--adapter` to pick one" disambiguator,
+  even though install's probe had already selected the right row. The offered
+  upgrade now forwards the auto-resolved adapter, matching the behavior when
+  `--adapter` is explicit.
+
 ## [0.11.0] — 2026-07-03
 
 ### Added

--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -8,6 +8,8 @@ the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 
 ## [Unreleased]
 
+## [0.11.1] — 2026-07-16
+
 ### Fixed
 
 - **`install` without `--adapter` now targets the auto-resolved adapter when

--- a/packages/agentbundle/agentbundle/commands/install.py
+++ b/packages/agentbundle/agentbundle/commands/install.py
@@ -534,6 +534,9 @@ def run(args: "argparse.Namespace") -> int:
             pack_name=pack_name,
             scope=requested_scope,
             catalogue_uri=catalogue_uri,
+            resolved_adapter=(
+                user_target_adapter if requested_scope == "user" else repo_target_adapter
+            ),
         )
 
     # 4b. Already at the *other* scope, no --force → refuse cross-scope.
@@ -1880,7 +1883,12 @@ def _scan_dist_tree_artifacts(root: Path, pack_name: str) -> list[Path]:
 
 
 def _offer_upgrade(
-    args: "argparse.Namespace", *, pack_name: str, scope: str, catalogue_uri: str
+    args: "argparse.Namespace",
+    *,
+    pack_name: str,
+    scope: str,
+    catalogue_uri: str,
+    resolved_adapter: "str | None" = None,
 ) -> int:
     """Hand off an already-installed `install` to `upgrade` (CLI-hygiene AC11/12).
 
@@ -1891,6 +1899,11 @@ def _offer_upgrade(
     no-op), forwarding ``--adapter`` and threading ``_user_config`` so adapter
     resolution matches a direct ``upgrade`` invocation, and leaving all five
     primitive flags unset (whole-pack). Returns ``upgrade.run``'s exit code.
+
+    ``resolved_adapter`` is the adapter install auto-detected for this run (may
+    differ from ``args.adapter`` when ``--adapter`` was omitted). Used as a
+    fallback so the upgrade targets the same row the install would have written,
+    even when the pack is installed for multiple adapters at this scope.
     """
     import argparse as _argparse
 
@@ -1908,7 +1921,11 @@ def _offer_upgrade(
     # adapter the user picked. Without this, a pack installed for multiple
     # adapters at one scope trips upgrade's multi-adapter disambiguator even
     # though the operator already passed `--adapter` to `install`.
-    ns.adapter = getattr(args, "adapter", None)
+    # Fall back to `resolved_adapter` when --adapter was omitted: install
+    # auto-detects a target adapter and the upgrade offer must target that same
+    # row rather than leaving upgrade to re-disambiguate (and fail) when multiple
+    # adapter rows exist at this scope.
+    ns.adapter = getattr(args, "adapter", None) or resolved_adapter
     ns.yes = True
     ns.dry_run = False
     ns.skill = ns.agent = ns.hook = ns.seed = ns.command = None

--- a/packages/agentbundle/agentbundle/version.py
+++ b/packages/agentbundle/agentbundle/version.py
@@ -14,7 +14,7 @@ import tomllib
 from importlib.resources import files
 from pathlib import Path
 
-CLI_VERSION = "0.11.0"
+CLI_VERSION = "0.11.1"
 
 _HERE = Path(__file__).resolve().parent
 

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentbundle"
-version = "0.11.0"
+version = "0.11.1"
 description = "npm for your coding agent. Install packs of skills, subagents, and hooks into any repo, for every major agent."
 requires-python = ">=3.11"
 dependencies = []

--- a/packages/agentbundle/tests/integration/test_install_default_source.py
+++ b/packages/agentbundle/tests/integration/test_install_default_source.py
@@ -118,10 +118,37 @@ def test_offer_upgrade_forwards_adapter(monkeypatch):
     args = argparse.Namespace(
         catalogue=None, output=".", _user_config=None, adapter="claude-code"
     )
+    # Pass a differing resolved_adapter to confirm CLI value wins over the fallback.
     install._offer_upgrade(
-        args, pack_name="research", scope="user", catalogue_uri="git+https://resolved/x"
+        args,
+        pack_name="research",
+        scope="user",
+        catalogue_uri="git+https://resolved/x",
+        resolved_adapter="codex",
     )
     assert captured["ns"].adapter == "claude-code"
+
+
+def test_offer_upgrade_uses_resolved_adapter_when_no_cli_adapter(monkeypatch):
+    # Regression: when --adapter is omitted, install auto-resolves a target adapter
+    # and the upgrade offer must forward it. Without this, upgrade's multi-adapter
+    # disambiguator fires and fails even though install already picked the row.
+    from agentbundle.commands import upgrade as _upgrade
+
+    captured = {}
+    monkeypatch.setattr(_upgrade, "run", lambda ns: captured.setdefault("ns", ns) and 0)
+
+    args = argparse.Namespace(
+        catalogue=None, output=".", _user_config=None, adapter=None
+    )
+    install._offer_upgrade(
+        args,
+        pack_name="research",
+        scope="user",
+        catalogue_uri="git+https://resolved/x",
+        resolved_adapter="codex",
+    )
+    assert captured["ns"].adapter == "codex"
 
 
 def test_bare_list_packs_resolves_default_source(tmp_path):

--- a/packages/agentbundle/tests/integration/test_install_upgrade_offer.py
+++ b/packages/agentbundle/tests/integration/test_install_upgrade_offer.py
@@ -15,9 +15,14 @@ from __future__ import annotations
 import argparse
 import contextlib
 import io
+import os
+import shutil
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
 
 FIXTURE_CATALOGUE = (
     Path(__file__).parent.parent / "fixtures" / "install" / "catalogue"
@@ -150,3 +155,81 @@ def test_yes_runs_real_upgrade_end_to_end(tmp_path):
     # re-apply, not a version change: the recap reads `re-applied: … (already
     # current)`, never `upgraded: X -> X` (install-state-visibility AC10).
     assert "re-applied: alpha @ repo" in out, f"missing re-apply recap; stdout={out!r}"
+
+
+def test_install_run_forwards_resolved_adapter_when_multi_adapter_and_no_cli_adapter(
+    tmp_path, monkeypatch
+):
+    """Regression: install.run() must pass user_target_adapter as resolved_adapter
+    to _offer_upgrade when --adapter is omitted and the pack is already installed
+    for multiple adapters at user scope.
+
+    Without this, _offer_upgrade forwards ns.adapter=None, and upgrade's
+    multi-adapter disambiguator fires ("pass --adapter to pick one") even though
+    install already selected the right row via its auto-detection probe.
+    """
+    converters_src = REPO_ROOT / "packs" / "converters"
+    if not converters_src.is_dir():
+        pytest.skip("converters pack not present in this checkout")
+
+    home = tmp_path / "home"
+    (home / ".claude").mkdir(parents=True)  # probe → claude-code
+
+    agentbundle_dir = home / ".agentbundle"
+    agentbundle_dir.mkdir()
+    from agentbundle.config import PackState, State, dump_state
+
+    two_adapter_state = State(
+        packs={
+            ("converters", "claude-code"): PackState(
+                installed_version="0.8.0", adapter="claude-code", scope="user"
+            ),
+            ("converters", "codex"): PackState(
+                installed_version="0.8.0", adapter="codex", scope="user"
+            ),
+        }
+    )
+    (agentbundle_dir / "state.toml").write_text(
+        dump_state(two_adapter_state), encoding="utf-8"
+    )
+
+    cat = tmp_path / "catalogue"
+    (cat / "packs").mkdir(parents=True)
+    shutil.copytree(converters_src, cat / "packs" / "converters")
+    (tmp_path / "repo").mkdir()
+
+    captured: dict = {}
+
+    def _spy_offer(*_args, **kwargs):
+        captured.update(kwargs)
+        return 0
+
+    from agentbundle.commands import install as _install_mod
+
+    monkeypatch.setattr(_install_mod, "_offer_upgrade", _spy_offer)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda prompt="": "y")
+
+    with patch.dict(os.environ, {"HOME": str(home), "USERPROFILE": str(home)}):
+        args = argparse.Namespace(
+            pack="converters",
+            catalogue=str(cat),
+            output=str(tmp_path / "repo"),
+            scope="user",
+            force=False,
+            force_merge=False,
+            dry_run=False,
+            yes=False,
+            adapter=None,
+            emit_install_routes=False,
+        )
+        rc = _install_mod.run(args)
+
+    assert "resolved_adapter" in captured, (
+        f"_offer_upgrade was not called with resolved_adapter; "
+        f"install.run() may have exited before the offer (rc={rc})"
+    )
+    assert captured["resolved_adapter"] == "claude-code", (
+        f"expected resolved_adapter='claude-code' (probe picks ~/.claude/), "
+        f"got {captured['resolved_adapter']!r}"
+    )


### PR DESCRIPTION
## Summary

- `install` without `--adapter` on a multi-adapter pack now offers to upgrade correctly — the hand-off forwarded `None` for the adapter, causing upgrade's disambiguator to fire ("pass --adapter to pick one") even though install had already auto-resolved the right row
- `_offer_upgrade` gains `resolved_adapter: str | None = None`; `ns.adapter = getattr(args, "adapter", None) or resolved_adapter` so the CLI value wins when set and the auto-resolved adapter is the fallback
- The call site in `install.run()` passes `user_target_adapter` / `repo_target_adapter` as `resolved_adapter`
- The explicit `--adapter` case (fixed in 0.10.2/PR #479) is preserved with a regression guard: `test_offer_upgrade_forwards_adapter` now passes a differing `resolved_adapter` and asserts the CLI value wins

## Test plan

- [ ] `test_install_upgrade_offer.py::test_install_run_forwards_resolved_adapter_when_multi_adapter_and_no_cli_adapter` — new integration test driving `install.run()` with a two-adapter state file and no `--adapter`; spies on `_offer_upgrade` to assert `resolved_adapter="claude-code"`
- [ ] `test_install_default_source.py::test_offer_upgrade_uses_resolved_adapter_when_no_cli_adapter` — unit test: `_offer_upgrade` with `adapter=None` and `resolved_adapter="codex"` → `ns.adapter == "codex"`
- [ ] `test_install_default_source.py::test_offer_upgrade_forwards_adapter` — updated to pass a differing `resolved_adapter` and confirm CLI wins

## Deferred

`emit_install_routes=True` repo path: `repo_target_adapter` is None in that path, so `resolved_adapter=None` is forwarded and upgrade's disambiguator could still fire if a dist-tree state has multi-adapter rows. Out of scope — the legacy dist-tree publisher doesn't produce per-adapter rows, so this is not a realistic failure path.