### PR TITLE
feat(core): frontend-engineering skill — design pre-flight, craft rules, GATES (core 0.11.0)

### DIFF
--- a/.agents/skills/frontend-engineering/SKILL.md
+++ b/.agents/skills/frontend-engineering/SKILL.md
@@ -1,0 +1,413 @@
+---
+name: frontend-engineering
+description: Load when a task's primary output is HTML, CSS, or JS. Provides design pre-flight, codified craft rules, and GATES verification commands for that surface.
+---
+
+# Skill: frontend-engineering
+
+Load this skill when a task's primary output is HTML, CSS, or JS — a new page,
+component, slide deck, dashboard, email template, or any standalone web artifact.
+It carries the design pre-flight requirements (named aesthetic reference, seed
+token block, state matrix), the craft rules that govern EXECUTE, and the GATES
+verification commands. It is not needed for incidental HTML edits to an existing
+surface already covered by a grounded aesthetic reference.
+
+## PLAN phase — Design Pre-flight
+
+Complete all three steps before writing any code. These are not suggestions;
+they are the contract for greenfield frontend work.
+
+### 1. Named aesthetic reference
+
+State a named product reference — not an adjective. The model has learned
+visual vocabulary from extensively documented products; vague adjectives
+produce the purple-gradient default (Tailwind's `bg-indigo-500` saturated
+training data, so "nice", "clean", "modern" all converge there).
+
+**Canonical reference set:**
+
+| Goal | Use |
+|---|---|
+| Professional / executive SaaS | Linear, Stripe, Vercel |
+| Data-dense / terminal | Raycast, Arc |
+| Minimal / editorial | Notion |
+| Warm / human | Toss |
+
+Name the reference in the spec: `Aesthetic reference: Linear (professional SaaS —
+dark surface, high contrast, no gradients)`. If the target must match an existing
+user-provided theme (e.g. a PPT brand), describe its key token values instead.
+
+### 2. Seed token block
+
+Provide a CSS custom properties block before writing any HTML. The model
+selects from `var(--ds-color-primary)` rather than fabricating `#5e6ad2` per
+session — token-seeding is the single strongest lever for visual consistency.
+
+**Three-tier architecture (one-way dependency):**
+```
+Primitive  →  Semantic  →  Component
+(raw hex)      (role)       (usage)
+```
+Only the semantic layer goes in the seed block; primitives are defined once
+at the top of the CSS file and referenced by semantics.
+
+**Minimum viable property set** (`--ds-` prefix for namespace clarity):
+
+```css
+:root {
+  /* Color roles — semantic, not raw hex */
+  --ds-color-surface:      #ffffff;
+  --ds-color-surface-alt:  #f8fafc;
+  --ds-color-on-surface:   #1a202c;
+  --ds-color-on-surface-2: rgba(0, 0, 0, 0.60);
+  --ds-color-primary:      #5e6ad2;
+  --ds-color-on-primary:   #ffffff;
+  --ds-color-error:        #dc2626;
+  --ds-color-on-error:     #ffffff;
+  --ds-color-outline:      rgba(0, 0, 0, 0.12);
+
+  /* Spacing — 4 px base, 8-step scale */
+  --ds-space-px: 2px;
+  --ds-space-1:  4px;
+  --ds-space-2:  8px;
+  --ds-space-3:  12px;
+  --ds-space-4:  16px;
+  --ds-space-5:  24px;
+  --ds-space-6:  32px;
+  --ds-space-7:  48px;
+  --ds-space-8:  64px;
+
+  /* Type scale */
+  --ds-text-sm:   0.75rem;
+  --ds-text-base: 0.875rem;
+  --ds-text-lg:   1rem;
+  --ds-text-xl:   1.125rem;
+  --ds-text-2xl:  1.25rem;
+  --ds-font-regular: 400;
+  --ds-font-medium:  500;
+  --ds-font-bold:    600;
+  --ds-leading-tight:  1.25;
+  --ds-leading-normal: 1.5;
+  --ds-leading-loose:  1.75;
+
+  /* Radius */
+  --ds-radius-sm: 4px;
+  --ds-radius-md: 8px;
+  --ds-radius-lg: 12px;
+  --ds-radius-full: 9999px;
+
+  /* Shadow */
+  --ds-shadow-sm: 0 1px 2px rgba(0,0,0,0.06);
+  --ds-shadow-md: 0 4px 8px rgba(0,0,0,0.08);
+  --ds-shadow-lg: 0 8px 24px rgba(0,0,0,0.10);
+
+  /* Motion */
+  --ds-duration-quick:    120ms;
+  --ds-duration-moderate: 200ms;
+  --ds-duration-gentle:   300ms;
+  --ds-ease-standard:     cubic-bezier(0.4, 0, 0.2, 1);
+  --ds-ease-decelerate:   cubic-bezier(0, 0, 0.2, 1);
+}
+```
+
+#### Print / PPT token block
+
+When the output targets a PPT slide or PDF export, add this block and use
+`pt` for typographic values:
+
+```css
+@page {
+  size: 960px 540px; /* 16:9 slide — standard widescreen */
+  margin: 0;
+}
+
+* {
+  -webkit-print-color-adjust: exact;
+  print-color-adjust: exact; /* preserve background fills */
+}
+
+@media print {
+  :root {
+    --ds-color-surface:    #ffffff;
+    --ds-color-on-surface: #000000;
+    --ds-shadow-sm: none;
+    --ds-shadow-md: none;
+    --ds-shadow-lg: none;
+  }
+
+  .slide            { page-break-after: always; }
+  h2, h3, figure,
+  table, blockquote { page-break-inside: avoid; }
+}
+```
+
+**Print safety:** `box-shadow` and `text-shadow` are unreliable across
+renderers (Chrome/WeasyPrint differ) — use `--ds-shadow-*: none` in the
+print override and rely on borders for separation instead. Avoid Tailwind
+responsive variants (`sm:`, `md:`) for fixed-dimension artifacts.
+
+### 3. State matrix
+
+Enumerate all states for every async component as a table in the spec.
+LLMs are trained predominantly on happy-path code; they will not generate
+missing-state branches without explicit enumeration. A 2025 study of
+50 AI-generated dashboards found 92% had no empty state and 78% had no
+error state.
+
+| State | Wrong | Right |
+|---|---|---|
+| **Loading** | Generic spinner | Skeleton screen matching the final layout (use spinner only when shape is unknown); add `aria-busy="true"` and `aria-label="Loading <thing>"` to the skeleton container |
+| **Empty** | Blank space | Illustration or icon + label describing the empty condition + primary CTA |
+| **Error** | Clear prior content; show only the error | Preserve prior content; show inline error message + retry affordance |
+| **Partial** | No indication more data exists | Pagination or load-more with a record count |
+| **Disabled** | Hide the element | Render it disabled with `aria-disabled="true"` and a tooltip or label explaining why |
+| **Content** | — | The normal loaded state — spec this too so the skeleton shape is known |
+
+**Skeleton vs spinner rule:** use a skeleton when the content shape is
+predictable (table rows, card grids, profile cards). The skeleton must
+match the final layout so there is no layout shift on load. Use a spinner
+only when shape is genuinely unknown.
+
+---
+
+## EXECUTE phase — Craft Rules
+
+### Avoid the AI Aesthetic
+
+AI-generated UI has recognisable failure patterns. Refuse all of them:
+
+| Pattern | Why it's a problem | Instead |
+|---|---|---|
+| Purple / indigo everything | Models default to `bg-indigo-500` — every generated app looks identical | Use the project's token palette; derive from the named aesthetic reference |
+| Excessive gradients | Add visual noise; clash with most design systems | Flat colour or a single subtle gradient matching the system |
+| Rounded everything (`rounded-2xl` / `border-radius: 16px` on all elements) | Ignores the radius hierarchy in real designs — cards, buttons, and inputs each have a distinct radius | Use the `--ds-radius-*` scale; vary by element type |
+| Generic hero sections | Template-driven layout with no connection to actual content or user need | Content-first layout driven by what the user needs to do |
+| Lorem ipsum placeholder copy | Hides layout problems that real content reveals (wrapping, overflow, long names) | Realistic-length placeholder text that approximates actual content |
+| Oversized equal padding everywhere | Destroys visual hierarchy; wastes screen space | Use the spacing scale; vary padding by component level |
+| Uniform card grids | Ignores information priority and scanning patterns | Purpose-driven layouts — group by relationship, not by grid slot |
+| Shadow-heavy design | Layered shadows compete with content; slow on low-end devices | Use `--ds-shadow-sm` sparingly; flat or a single elevation level |
+
+### HTML element selection rules
+
+Rules are in **WRONG → RIGHT** form. "Use semantic HTML" is not a rule;
+the specific forms below are.
+
+#### Interactive elements
+
+- WRONG: `<div onclick="…">`, `<span onclick="…">` / RIGHT: `<button type="button">` for any action
+- WRONG: `<a href="#" onclick="…">` for actions / RIGHT: `<a href="…">` for navigation only; `<button>` for actions — never cross them
+- WRONG: `<div role="button">` with no keyboard handler / RIGHT: `<button>` — it receives keyboard, focus, and activation natively; avoid `role="button"` on a non-button element unless a framework absolutely requires it, and then you must add `tabindex="0"` and `onkeydown` handlers for both Enter and Space
+
+#### Landmark elements
+
+- One `<main>` per page, no exceptions
+- One `<h1>` per page
+- Heading levels are sequential — never skip (h1 → h3 is wrong; heading level = outline position, never visual size)
+- `<section>` only when it has a heading as its first child; otherwise use `<div>`
+- Multiple `<nav>` elements require `aria-label` distinguishing them: `aria-label="Primary"`, `aria-label="Breadcrumb"`
+- `<article>` for self-contained distributable content; `<aside>` for tangentially related content
+
+#### Forms
+
+- WRONG: `<input placeholder="Email">` with no label / RIGHT: `<label for="email">Email</label><input id="email">` or `aria-labelledby`; `placeholder` is not a label — it fails WCAG 1.3.1 and disappears on input
+- WRONG: `aria-describedby` pointing to an element not yet in the DOM / RIGHT: place the target element in the DOM before the input receives focus; inject empty containers on page load
+- WRONG: ungrouped checkboxes/radios / RIGHT: `<fieldset><legend>…</legend>…</fieldset>` for every checkbox or radio group
+- `autocomplete` attribute is required on personal-data fields: `name`, `email`, `tel`, `current-password`, `new-password`, address fields
+
+#### Images and media
+
+- WRONG: `alt="image"`, `alt="photo of a dog"` / RIGHT: descriptive text without "image of" / "photo of" prefixes; `alt=""` for decorative images; max ~150 chars — use `<figcaption>` for longer descriptions
+- WRONG: `<img>` for decorative backgrounds / RIGHT: CSS `background-image` — the element is removed from the accessibility tree automatically
+- SVG used as a meaningful image: add `role="img"` and a `<title>` as the first child
+- SVG that is decorative: `aria-hidden="true"`
+
+#### Content
+
+- WRONG: lorem ipsum placeholder text / RIGHT: realistic-length placeholder text that approximates what real content looks like — long names, multi-line descriptions, edge-case values
+
+### CSS rules
+
+- WRONG: `color: #5e6ad2`, `background: #f8fafc`, `margin: 13px` / RIGHT: all colour and spacing values via `var(--ds-*)` — no hardcoded hex, rgb, hsl, or magic pixel values
+- WRONG: `z-index: 9999` / RIGHT: define a named z-index scale: `--z-base: 0; --z-overlay: 100; --z-modal: 200; --z-toast: 300` — use named custom properties only
+- WRONG: `line-height: 24px` / RIGHT: unitless — `line-height: var(--ds-leading-normal)` or `line-height: 1.5`
+- WRONG: `#nav {}`, `ul.nav {}` / RIGHT: class selectors only; no ID selectors; no qualified selectors
+- WRONG: selector depth > 3 levels / RIGHT: max 3 levels of nesting
+- WRONG: `tabindex="2"`, `tabindex="5"` (positive values) / RIGHT: `tabindex="0"` to enter tab order; `tabindex="-1"` for programmatic focus targets only; never positive values — they disrupt the natural tab sequence
+- WRONG: `.btn:hover { … }` with no focus style / RIGHT: every `:hover` rule has a matching `:focus` or `:focus-visible` rule
+- WRONG: `outline: none` / RIGHT: replace with a visible alternative — `outline: 2px solid var(--ds-color-primary); outline-offset: 2px` or a `box-shadow` equivalent
+
+### Accessibility rules
+
+#### ARIA discipline
+
+**First Rule of ARIA:** if a native HTML element provides the semantics and
+behaviour, use it — do not bolt ARIA onto a generic element.
+
+- WRONG: `<div role="button" onclick="…">` — no keyboard, no activation, no inherited states / RIGHT: `<button>`
+- WRONG: `aria-label="Submit"` on a `<button>Submit</button>` with visible text / RIGHT: omit `aria-label` — it overrides the visible label and breaks voice control ("Submit" no longer activates the button by name in Dragon NaturallySpeaking)
+- WRONG: `<input aria-label="Email" placeholder="Email">` when a visible label exists / RIGHT: use the `<label>` and omit the redundant `aria-label`
+
+**Dynamic ARIA state must update** — these are not static attributes:
+
+- `aria-expanded="false"` on a closed accordion must flip to `"true"` when open
+- `aria-selected` must update as tabs are navigated
+- `aria-sort` must update as columns are sorted
+- Setting them once in the HTML and never updating them with JS is wrong
+
+**`aria-live` regions:**
+
+- The container must be in the DOM *before* content is injected into it — add it empty on page load and update its text content to trigger the announcement; injecting a live region and populating it simultaneously causes the announcement to be dropped silently in most screen readers
+- `aria-live="polite"` for informational updates (toast success, search result counts)
+- `aria-live="assertive"` + `aria-atomic="true"` for errors and time-critical alerts (session timeout, form validation summary)
+
+#### WCAG contrast floor (WCAG 1.4.3 / 1.4.11)
+
+| Element | Minimum ratio |
+|---|---|
+| Body text | 4.5 : 1 |
+| Large text (≥ 18 pt or ≥ 14 pt bold) | 3 : 1 |
+| UI components (borders, focus rings, icons, input outlines) | 3 : 1 |
+| Placeholder text | 4.5 : 1 (counts as text) |
+
+Verify contrast at derivation time — never eyeball it.
+
+#### Reduced motion
+
+Every `animation`, `transition`, and `transform` must be guarded. Default to
+no motion; enable only when the user has not requested reduced motion:
+
+```css
+/* Default: no motion */
+.element {
+  transition: none;
+  animation: none;
+}
+
+/* Motion only when the user permits */
+@media (prefers-reduced-motion: no-preference) {
+  .element {
+    transition: opacity var(--ds-duration-moderate) var(--ds-ease-standard);
+  }
+}
+```
+
+Properties to guard: `animation`, `transition`, `transform` (slides, scales,
+rotates), `scroll-behavior: smooth`. Colour and opacity changes that carry
+meaning do not need guarding — only motion.
+
+#### Modal / dialog keyboard pattern (W3C APG)
+
+```
+role="dialog" + aria-modal="true" + aria-labelledby="<title-id>"
+On open:   move focus to first focusable element inside the dialog
+Tab:       cycle forward through focusable elements inside only (trap)
+Shift+Tab: cycle backward (trap)
+Escape:    close the dialog
+On close:  return focus to the element that opened the dialog
+```
+
+#### Tabs keyboard pattern (W3C APG)
+
+```
+Tab:         moves focus into the tablist, then out to the tabpanel — never between tabs
+Left/Right:  navigate between tabs (wrapping); activate on focus (auto-activation)
+Home/End:    jump to first / last tab
+```
+
+#### Programmatic focus — when it is required
+
+Move focus programmatically when:
+- A modal opens (to first focusable element inside) or closes (back to invoking element)
+- A SPA route changes (to the page `<h1>` or a skip-nav landmark with `tabindex="-1"`)
+- An inline error appears after form submit (to first invalid field or error summary)
+- Async content is inserted and the user needs to interact with it immediately
+
+---
+
+## GATES phase — Verification
+
+Run these after implementation, before review. Record actual command output —
+do not assert on internal state.
+
+### 1. Structural HTML validation (no browser required)
+
+```bash
+npx html-validate --preset standard,a11y --max-warnings 0 <file.html>
+```
+
+Catches without a browser: landmark structure (one `<main>`, unique landmarks),
+heading hierarchy (no skipped levels), label associations, ARIA role validity,
+`alt` attribute presence, and WCAG H-technique violations. Exits non-zero on any
+error.
+
+### 2. Accessibility audit (requires Chromium — runs headless, no display server)
+
+Either tool works; pa11y is lighter, axe-core has more rules:
+
+```bash
+# pa11y — local files via file:// path
+npx pa11y "file:///$(pwd)/file.html" --standard WCAG2AA --reporter cli
+
+# axe-core/cli — URL or file, CI-safe Chromium flags
+npx axe "file:///$(pwd)/file.html" \
+  --tags wcag21aa \
+  --chrome-options="no-sandbox,disable-setuid-sandbox,disable-dev-shm-usage"
+```
+
+Note: neither tool currently supports WCAG 2.2 tags — `wcag21aa` is the
+current ceiling. Chromium runs fully headless; no `DISPLAY` environment
+variable is required.
+
+### 3. CSS token enforcement (optional — run if stylelint is already configured)
+
+```json
+{
+  "plugins": ["stylelint-declaration-strict-value"],
+  "rules": {
+    "scale-unlimited/declaration-strict-value": [
+      ["color", "background-color", "border-color", "font-size"],
+      {
+        "ignoreValues": ["inherit", "transparent", "currentColor"],
+        "message": "Use design tokens (var(--ds-*)) — no hardcoded values"
+      }
+    ]
+  }
+}
+```
+
+Install: `npm install --save-dev stylelint stylelint-declaration-strict-value`
+
+### 4. Visual QA checklist (agent-executable, no tooling)
+
+- [ ] All state variants present in the HTML (loading / empty / error / partial / content / disabled) — not just the happy path
+- [ ] No hardcoded colour or spacing values outside the token-definition block — grep: `grep -E "#[0-9a-fA-F]{3,6}|rgba?\(|hsl\(|[0-9]+px" <file.css>` should return only the `:root` / primitive token-definition block, no other hex, rgb, or px values
+- [ ] Print output correct: if PPT/PDF context, open in browser and trigger print preview — check slide boundaries, colour preservation, no overflow
+- [ ] Screenshot taken and observed: Playwright headless (`page.screenshot()`) or browser devtools screenshot — assert on what you see, not on internal state
+
+---
+
+## Anti-patterns to refuse
+
+| Rationalisation | Reality |
+|---|---|
+| "Accessibility is a nice-to-have for now" | It is a legal requirement in many jurisdictions (WCAG 2.1 AA is the baseline for EU EAA, ADA, and AODA compliance) and an engineering quality standard — not a feature |
+| "We'll make it responsive later" | Retrofitting responsive design is 3× harder than building it from the start; skip this step only if the output is explicitly fixed-dimension (PPT/PDF) |
+| "This is just a prototype" | Prototypes become production code; the AI aesthetic baked in at prototype stage is the AI aesthetic shipped |
+| "The AI aesthetic is fine for now" | It signals low quality to every reviewer who sees it and anchors the design in a direction that is expensive to undo |
+| "I'll add the empty and error states later" | They will not be added; they are spec ACs, not follow-ons |
+| "Skip the design pre-flight — the spec is clear enough" | Technically correct output with no design sense is the exact failure mode this pre-flight prevents; the spec cannot substitute for token constraints |
+| "Use a spinner, it's simpler" | Spinners produce layout shift and feel slower than skeleton screens; use a skeleton when the content shape is known |
+
+---
+
+## Red flags
+
+A reviewer should treat any of these as a blocker:
+
+- Inline `style="…"` attributes or arbitrary pixel values not on the spacing scale
+- Any state variant missing (empty, error, loading, partial) — check by reading the HTML, not by reasoning about the code
+- `outline: none` or `outline: 0` with no visible replacement focus style
+- Color used as the sole state indicator (red/green without accompanying text, icon, or pattern)
+- Generic AI aesthetic visible in the output (purple gradients, equal oversized padding, `border-radius: 16px` on every element, shadow on every card)
+- `aria-expanded`, `aria-selected`, or `aria-sort` set once and never updated
+- A `<div onclick>` where a `<button>` would serve

--- a/.agents/skills/work-loop/SKILL.md
+++ b/.agents/skills/work-loop/SKILL.md
@@ -319,6 +319,14 @@ For anything beyond trivial, *think before you write code*. Concretely:
   common failure mode of technically correct surfaces with no design sense. Applies
   in both light and full mode as a recommendation; the mandatory fresh-context
   gate (`experience-reviewer`) runs in REVIEW for full-mode work.
+  **Frontend surface exception — mandatory, not recommended.** When the task's
+  primary output is HTML, CSS, or JS (a new page, component, slide deck,
+  dashboard, or standalone web artifact), this pass is mandatory in both modes:
+  load the `frontend-engineering` skill inline before writing code. It carries
+  the design pre-flight requirements (named aesthetic reference, seed token
+  block, state matrix), the craft rules, and the GATES verification commands
+  for that surface. The judgment call — whether the output is "primary"
+  HTML/CSS/JS or incidental — is the implementer's; when in doubt, load it.
 - **Initialize the loop's state file.** Run this skill's bundled
   `scripts/loop-cohort.py init docs/specs/<feature>`; the tool copies
   the bundled `assets/state.json` template into place, sets `feature`
@@ -384,6 +392,12 @@ heavier infra-flavor layers fire only on the infra-flavored signal), and is for
 the *unfamiliar-contract* case — **not** every import, not familiar code whose
 contract the agent already holds. (Detail in
 [`references/infra-verification.md`](references/infra-verification.md).)
+
+**Frontend-triggered work (HTML/CSS/JS primary output).** When the frontend
+surface trigger fires, the `frontend-engineering` skill has already been
+loaded inline during PLAN. Its craft rules govern all HTML element selection,
+CSS token discipline, accessibility patterns, and state completeness during
+EXECUTE; its GATES section defines the verification commands to run at step 3.
 
 For each task, implement the smallest coherent unit of work toward the
 goal. Resist the urge to fix unrelated things you notice along the way;

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -104,7 +104,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "core",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.10.0"
+      "version": "0.11.0"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/.claude/skills/frontend-engineering/SKILL.md
+++ b/.claude/skills/frontend-engineering/SKILL.md
@@ -1,0 +1,413 @@
+---
+name: frontend-engineering
+description: Load when a task's primary output is HTML, CSS, or JS. Provides design pre-flight, codified craft rules, and GATES verification commands for that surface.
+---
+
+# Skill: frontend-engineering
+
+Load this skill when a task's primary output is HTML, CSS, or JS — a new page,
+component, slide deck, dashboard, email template, or any standalone web artifact.
+It carries the design pre-flight requirements (named aesthetic reference, seed
+token block, state matrix), the craft rules that govern EXECUTE, and the GATES
+verification commands. It is not needed for incidental HTML edits to an existing
+surface already covered by a grounded aesthetic reference.
+
+## PLAN phase — Design Pre-flight
+
+Complete all three steps before writing any code. These are not suggestions;
+they are the contract for greenfield frontend work.
+
+### 1. Named aesthetic reference
+
+State a named product reference — not an adjective. The model has learned
+visual vocabulary from extensively documented products; vague adjectives
+produce the purple-gradient default (Tailwind's `bg-indigo-500` saturated
+training data, so "nice", "clean", "modern" all converge there).
+
+**Canonical reference set:**
+
+| Goal | Use |
+|---|---|
+| Professional / executive SaaS | Linear, Stripe, Vercel |
+| Data-dense / terminal | Raycast, Arc |
+| Minimal / editorial | Notion |
+| Warm / human | Toss |
+
+Name the reference in the spec: `Aesthetic reference: Linear (professional SaaS —
+dark surface, high contrast, no gradients)`. If the target must match an existing
+user-provided theme (e.g. a PPT brand), describe its key token values instead.
+
+### 2. Seed token block
+
+Provide a CSS custom properties block before writing any HTML. The model
+selects from `var(--ds-color-primary)` rather than fabricating `#5e6ad2` per
+session — token-seeding is the single strongest lever for visual consistency.
+
+**Three-tier architecture (one-way dependency):**
+```
+Primitive  →  Semantic  →  Component
+(raw hex)      (role)       (usage)
+```
+Only the semantic layer goes in the seed block; primitives are defined once
+at the top of the CSS file and referenced by semantics.
+
+**Minimum viable property set** (`--ds-` prefix for namespace clarity):
+
+```css
+:root {
+  /* Color roles — semantic, not raw hex */
+  --ds-color-surface:      #ffffff;
+  --ds-color-surface-alt:  #f8fafc;
+  --ds-color-on-surface:   #1a202c;
+  --ds-color-on-surface-2: rgba(0, 0, 0, 0.60);
+  --ds-color-primary:      #5e6ad2;
+  --ds-color-on-primary:   #ffffff;
+  --ds-color-error:        #dc2626;
+  --ds-color-on-error:     #ffffff;
+  --ds-color-outline:      rgba(0, 0, 0, 0.12);
+
+  /* Spacing — 4 px base, 8-step scale */
+  --ds-space-px: 2px;
+  --ds-space-1:  4px;
+  --ds-space-2:  8px;
+  --ds-space-3:  12px;
+  --ds-space-4:  16px;
+  --ds-space-5:  24px;
+  --ds-space-6:  32px;
+  --ds-space-7:  48px;
+  --ds-space-8:  64px;
+
+  /* Type scale */
+  --ds-text-sm:   0.75rem;
+  --ds-text-base: 0.875rem;
+  --ds-text-lg:   1rem;
+  --ds-text-xl:   1.125rem;
+  --ds-text-2xl:  1.25rem;
+  --ds-font-regular: 400;
+  --ds-font-medium:  500;
+  --ds-font-bold:    600;
+  --ds-leading-tight:  1.25;
+  --ds-leading-normal: 1.5;
+  --ds-leading-loose:  1.75;
+
+  /* Radius */
+  --ds-radius-sm: 4px;
+  --ds-radius-md: 8px;
+  --ds-radius-lg: 12px;
+  --ds-radius-full: 9999px;
+
+  /* Shadow */
+  --ds-shadow-sm: 0 1px 2px rgba(0,0,0,0.06);
+  --ds-shadow-md: 0 4px 8px rgba(0,0,0,0.08);
+  --ds-shadow-lg: 0 8px 24px rgba(0,0,0,0.10);
+
+  /* Motion */
+  --ds-duration-quick:    120ms;
+  --ds-duration-moderate: 200ms;
+  --ds-duration-gentle:   300ms;
+  --ds-ease-standard:     cubic-bezier(0.4, 0, 0.2, 1);
+  --ds-ease-decelerate:   cubic-bezier(0, 0, 0.2, 1);
+}
+```
+
+#### Print / PPT token block
+
+When the output targets a PPT slide or PDF export, add this block and use
+`pt` for typographic values:
+
+```css
+@page {
+  size: 960px 540px; /* 16:9 slide — standard widescreen */
+  margin: 0;
+}
+
+* {
+  -webkit-print-color-adjust: exact;
+  print-color-adjust: exact; /* preserve background fills */
+}
+
+@media print {
+  :root {
+    --ds-color-surface:    #ffffff;
+    --ds-color-on-surface: #000000;
+    --ds-shadow-sm: none;
+    --ds-shadow-md: none;
+    --ds-shadow-lg: none;
+  }
+
+  .slide            { page-break-after: always; }
+  h2, h3, figure,
+  table, blockquote { page-break-inside: avoid; }
+}
+```
+
+**Print safety:** `box-shadow` and `text-shadow` are unreliable across
+renderers (Chrome/WeasyPrint differ) — use `--ds-shadow-*: none` in the
+print override and rely on borders for separation instead. Avoid Tailwind
+responsive variants (`sm:`, `md:`) for fixed-dimension artifacts.
+
+### 3. State matrix
+
+Enumerate all states for every async component as a table in the spec.
+LLMs are trained predominantly on happy-path code; they will not generate
+missing-state branches without explicit enumeration. A 2025 study of
+50 AI-generated dashboards found 92% had no empty state and 78% had no
+error state.
+
+| State | Wrong | Right |
+|---|---|---|
+| **Loading** | Generic spinner | Skeleton screen matching the final layout (use spinner only when shape is unknown); add `aria-busy="true"` and `aria-label="Loading <thing>"` to the skeleton container |
+| **Empty** | Blank space | Illustration or icon + label describing the empty condition + primary CTA |
+| **Error** | Clear prior content; show only the error | Preserve prior content; show inline error message + retry affordance |
+| **Partial** | No indication more data exists | Pagination or load-more with a record count |
+| **Disabled** | Hide the element | Render it disabled with `aria-disabled="true"` and a tooltip or label explaining why |
+| **Content** | — | The normal loaded state — spec this too so the skeleton shape is known |
+
+**Skeleton vs spinner rule:** use a skeleton when the content shape is
+predictable (table rows, card grids, profile cards). The skeleton must
+match the final layout so there is no layout shift on load. Use a spinner
+only when shape is genuinely unknown.
+
+---
+
+## EXECUTE phase — Craft Rules
+
+### Avoid the AI Aesthetic
+
+AI-generated UI has recognisable failure patterns. Refuse all of them:
+
+| Pattern | Why it's a problem | Instead |
+|---|---|---|
+| Purple / indigo everything | Models default to `bg-indigo-500` — every generated app looks identical | Use the project's token palette; derive from the named aesthetic reference |
+| Excessive gradients | Add visual noise; clash with most design systems | Flat colour or a single subtle gradient matching the system |
+| Rounded everything (`rounded-2xl` / `border-radius: 16px` on all elements) | Ignores the radius hierarchy in real designs — cards, buttons, and inputs each have a distinct radius | Use the `--ds-radius-*` scale; vary by element type |
+| Generic hero sections | Template-driven layout with no connection to actual content or user need | Content-first layout driven by what the user needs to do |
+| Lorem ipsum placeholder copy | Hides layout problems that real content reveals (wrapping, overflow, long names) | Realistic-length placeholder text that approximates actual content |
+| Oversized equal padding everywhere | Destroys visual hierarchy; wastes screen space | Use the spacing scale; vary padding by component level |
+| Uniform card grids | Ignores information priority and scanning patterns | Purpose-driven layouts — group by relationship, not by grid slot |
+| Shadow-heavy design | Layered shadows compete with content; slow on low-end devices | Use `--ds-shadow-sm` sparingly; flat or a single elevation level |
+
+### HTML element selection rules
+
+Rules are in **WRONG → RIGHT** form. "Use semantic HTML" is not a rule;
+the specific forms below are.
+
+#### Interactive elements
+
+- WRONG: `<div onclick="…">`, `<span onclick="…">` / RIGHT: `<button type="button">` for any action
+- WRONG: `<a href="#" onclick="…">` for actions / RIGHT: `<a href="…">` for navigation only; `<button>` for actions — never cross them
+- WRONG: `<div role="button">` with no keyboard handler / RIGHT: `<button>` — it receives keyboard, focus, and activation natively; avoid `role="button"` on a non-button element unless a framework absolutely requires it, and then you must add `tabindex="0"` and `onkeydown` handlers for both Enter and Space
+
+#### Landmark elements
+
+- One `<main>` per page, no exceptions
+- One `<h1>` per page
+- Heading levels are sequential — never skip (h1 → h3 is wrong; heading level = outline position, never visual size)
+- `<section>` only when it has a heading as its first child; otherwise use `<div>`
+- Multiple `<nav>` elements require `aria-label` distinguishing them: `aria-label="Primary"`, `aria-label="Breadcrumb"`
+- `<article>` for self-contained distributable content; `<aside>` for tangentially related content
+
+#### Forms
+
+- WRONG: `<input placeholder="Email">` with no label / RIGHT: `<label for="email">Email</label><input id="email">` or `aria-labelledby`; `placeholder` is not a label — it fails WCAG 1.3.1 and disappears on input
+- WRONG: `aria-describedby` pointing to an element not yet in the DOM / RIGHT: place the target element in the DOM before the input receives focus; inject empty containers on page load
+- WRONG: ungrouped checkboxes/radios / RIGHT: `<fieldset><legend>…</legend>…</fieldset>` for every checkbox or radio group
+- `autocomplete` attribute is required on personal-data fields: `name`, `email`, `tel`, `current-password`, `new-password`, address fields
+
+#### Images and media
+
+- WRONG: `alt="image"`, `alt="photo of a dog"` / RIGHT: descriptive text without "image of" / "photo of" prefixes; `alt=""` for decorative images; max ~150 chars — use `<figcaption>` for longer descriptions
+- WRONG: `<img>` for decorative backgrounds / RIGHT: CSS `background-image` — the element is removed from the accessibility tree automatically
+- SVG used as a meaningful image: add `role="img"` and a `<title>` as the first child
+- SVG that is decorative: `aria-hidden="true"`
+
+#### Content
+
+- WRONG: lorem ipsum placeholder text / RIGHT: realistic-length placeholder text that approximates what real content looks like — long names, multi-line descriptions, edge-case values
+
+### CSS rules
+
+- WRONG: `color: #5e6ad2`, `background: #f8fafc`, `margin: 13px` / RIGHT: all colour and spacing values via `var(--ds-*)` — no hardcoded hex, rgb, hsl, or magic pixel values
+- WRONG: `z-index: 9999` / RIGHT: define a named z-index scale: `--z-base: 0; --z-overlay: 100; --z-modal: 200; --z-toast: 300` — use named custom properties only
+- WRONG: `line-height: 24px` / RIGHT: unitless — `line-height: var(--ds-leading-normal)` or `line-height: 1.5`
+- WRONG: `#nav {}`, `ul.nav {}` / RIGHT: class selectors only; no ID selectors; no qualified selectors
+- WRONG: selector depth > 3 levels / RIGHT: max 3 levels of nesting
+- WRONG: `tabindex="2"`, `tabindex="5"` (positive values) / RIGHT: `tabindex="0"` to enter tab order; `tabindex="-1"` for programmatic focus targets only; never positive values — they disrupt the natural tab sequence
+- WRONG: `.btn:hover { … }` with no focus style / RIGHT: every `:hover` rule has a matching `:focus` or `:focus-visible` rule
+- WRONG: `outline: none` / RIGHT: replace with a visible alternative — `outline: 2px solid var(--ds-color-primary); outline-offset: 2px` or a `box-shadow` equivalent
+
+### Accessibility rules
+
+#### ARIA discipline
+
+**First Rule of ARIA:** if a native HTML element provides the semantics and
+behaviour, use it — do not bolt ARIA onto a generic element.
+
+- WRONG: `<div role="button" onclick="…">` — no keyboard, no activation, no inherited states / RIGHT: `<button>`
+- WRONG: `aria-label="Submit"` on a `<button>Submit</button>` with visible text / RIGHT: omit `aria-label` — it overrides the visible label and breaks voice control ("Submit" no longer activates the button by name in Dragon NaturallySpeaking)
+- WRONG: `<input aria-label="Email" placeholder="Email">` when a visible label exists / RIGHT: use the `<label>` and omit the redundant `aria-label`
+
+**Dynamic ARIA state must update** — these are not static attributes:
+
+- `aria-expanded="false"` on a closed accordion must flip to `"true"` when open
+- `aria-selected` must update as tabs are navigated
+- `aria-sort` must update as columns are sorted
+- Setting them once in the HTML and never updating them with JS is wrong
+
+**`aria-live` regions:**
+
+- The container must be in the DOM *before* content is injected into it — add it empty on page load and update its text content to trigger the announcement; injecting a live region and populating it simultaneously causes the announcement to be dropped silently in most screen readers
+- `aria-live="polite"` for informational updates (toast success, search result counts)
+- `aria-live="assertive"` + `aria-atomic="true"` for errors and time-critical alerts (session timeout, form validation summary)
+
+#### WCAG contrast floor (WCAG 1.4.3 / 1.4.11)
+
+| Element | Minimum ratio |
+|---|---|
+| Body text | 4.5 : 1 |
+| Large text (≥ 18 pt or ≥ 14 pt bold) | 3 : 1 |
+| UI components (borders, focus rings, icons, input outlines) | 3 : 1 |
+| Placeholder text | 4.5 : 1 (counts as text) |
+
+Verify contrast at derivation time — never eyeball it.
+
+#### Reduced motion
+
+Every `animation`, `transition`, and `transform` must be guarded. Default to
+no motion; enable only when the user has not requested reduced motion:
+
+```css
+/* Default: no motion */
+.element {
+  transition: none;
+  animation: none;
+}
+
+/* Motion only when the user permits */
+@media (prefers-reduced-motion: no-preference) {
+  .element {
+    transition: opacity var(--ds-duration-moderate) var(--ds-ease-standard);
+  }
+}
+```
+
+Properties to guard: `animation`, `transition`, `transform` (slides, scales,
+rotates), `scroll-behavior: smooth`. Colour and opacity changes that carry
+meaning do not need guarding — only motion.
+
+#### Modal / dialog keyboard pattern (W3C APG)
+
+```
+role="dialog" + aria-modal="true" + aria-labelledby="<title-id>"
+On open:   move focus to first focusable element inside the dialog
+Tab:       cycle forward through focusable elements inside only (trap)
+Shift+Tab: cycle backward (trap)
+Escape:    close the dialog
+On close:  return focus to the element that opened the dialog
+```
+
+#### Tabs keyboard pattern (W3C APG)
+
+```
+Tab:         moves focus into the tablist, then out to the tabpanel — never between tabs
+Left/Right:  navigate between tabs (wrapping); activate on focus (auto-activation)
+Home/End:    jump to first / last tab
+```
+
+#### Programmatic focus — when it is required
+
+Move focus programmatically when:
+- A modal opens (to first focusable element inside) or closes (back to invoking element)
+- A SPA route changes (to the page `<h1>` or a skip-nav landmark with `tabindex="-1"`)
+- An inline error appears after form submit (to first invalid field or error summary)
+- Async content is inserted and the user needs to interact with it immediately
+
+---
+
+## GATES phase — Verification
+
+Run these after implementation, before review. Record actual command output —
+do not assert on internal state.
+
+### 1. Structural HTML validation (no browser required)
+
+```bash
+npx html-validate --preset standard,a11y --max-warnings 0 <file.html>
+```
+
+Catches without a browser: landmark structure (one `<main>`, unique landmarks),
+heading hierarchy (no skipped levels), label associations, ARIA role validity,
+`alt` attribute presence, and WCAG H-technique violations. Exits non-zero on any
+error.
+
+### 2. Accessibility audit (requires Chromium — runs headless, no display server)
+
+Either tool works; pa11y is lighter, axe-core has more rules:
+
+```bash
+# pa11y — local files via file:// path
+npx pa11y "file:///$(pwd)/file.html" --standard WCAG2AA --reporter cli
+
+# axe-core/cli — URL or file, CI-safe Chromium flags
+npx axe "file:///$(pwd)/file.html" \
+  --tags wcag21aa \
+  --chrome-options="no-sandbox,disable-setuid-sandbox,disable-dev-shm-usage"
+```
+
+Note: neither tool currently supports WCAG 2.2 tags — `wcag21aa` is the
+current ceiling. Chromium runs fully headless; no `DISPLAY` environment
+variable is required.
+
+### 3. CSS token enforcement (optional — run if stylelint is already configured)
+
+```json
+{
+  "plugins": ["stylelint-declaration-strict-value"],
+  "rules": {
+    "scale-unlimited/declaration-strict-value": [
+      ["color", "background-color", "border-color", "font-size"],
+      {
+        "ignoreValues": ["inherit", "transparent", "currentColor"],
+        "message": "Use design tokens (var(--ds-*)) — no hardcoded values"
+      }
+    ]
+  }
+}
+```
+
+Install: `npm install --save-dev stylelint stylelint-declaration-strict-value`
+
+### 4. Visual QA checklist (agent-executable, no tooling)
+
+- [ ] All state variants present in the HTML (loading / empty / error / partial / content / disabled) — not just the happy path
+- [ ] No hardcoded colour or spacing values outside the token-definition block — grep: `grep -E "#[0-9a-fA-F]{3,6}|rgba?\(|hsl\(|[0-9]+px" <file.css>` should return only the `:root` / primitive token-definition block, no other hex, rgb, or px values
+- [ ] Print output correct: if PPT/PDF context, open in browser and trigger print preview — check slide boundaries, colour preservation, no overflow
+- [ ] Screenshot taken and observed: Playwright headless (`page.screenshot()`) or browser devtools screenshot — assert on what you see, not on internal state
+
+---
+
+## Anti-patterns to refuse
+
+| Rationalisation | Reality |
+|---|---|
+| "Accessibility is a nice-to-have for now" | It is a legal requirement in many jurisdictions (WCAG 2.1 AA is the baseline for EU EAA, ADA, and AODA compliance) and an engineering quality standard — not a feature |
+| "We'll make it responsive later" | Retrofitting responsive design is 3× harder than building it from the start; skip this step only if the output is explicitly fixed-dimension (PPT/PDF) |
+| "This is just a prototype" | Prototypes become production code; the AI aesthetic baked in at prototype stage is the AI aesthetic shipped |
+| "The AI aesthetic is fine for now" | It signals low quality to every reviewer who sees it and anchors the design in a direction that is expensive to undo |
+| "I'll add the empty and error states later" | They will not be added; they are spec ACs, not follow-ons |
+| "Skip the design pre-flight — the spec is clear enough" | Technically correct output with no design sense is the exact failure mode this pre-flight prevents; the spec cannot substitute for token constraints |
+| "Use a spinner, it's simpler" | Spinners produce layout shift and feel slower than skeleton screens; use a skeleton when the content shape is known |
+
+---
+
+## Red flags
+
+A reviewer should treat any of these as a blocker:
+
+- Inline `style="…"` attributes or arbitrary pixel values not on the spacing scale
+- Any state variant missing (empty, error, loading, partial) — check by reading the HTML, not by reasoning about the code
+- `outline: none` or `outline: 0` with no visible replacement focus style
+- Color used as the sole state indicator (red/green without accompanying text, icon, or pattern)
+- Generic AI aesthetic visible in the output (purple gradients, equal oversized padding, `border-radius: 16px` on every element, shadow on every card)
+- `aria-expanded`, `aria-selected`, or `aria-sort` set once and never updated
+- A `<div onclick>` where a `<button>` would serve

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -319,6 +319,14 @@ For anything beyond trivial, *think before you write code*. Concretely:
   common failure mode of technically correct surfaces with no design sense. Applies
   in both light and full mode as a recommendation; the mandatory fresh-context
   gate (`experience-reviewer`) runs in REVIEW for full-mode work.
+  **Frontend surface exception — mandatory, not recommended.** When the task's
+  primary output is HTML, CSS, or JS (a new page, component, slide deck,
+  dashboard, or standalone web artifact), this pass is mandatory in both modes:
+  load the `frontend-engineering` skill inline before writing code. It carries
+  the design pre-flight requirements (named aesthetic reference, seed token
+  block, state matrix), the craft rules, and the GATES verification commands
+  for that surface. The judgment call — whether the output is "primary"
+  HTML/CSS/JS or incidental — is the implementer's; when in doubt, load it.
 - **Initialize the loop's state file.** Run this skill's bundled
   `scripts/loop-cohort.py init docs/specs/<feature>`; the tool copies
   the bundled `assets/state.json` template into place, sets `feature`
@@ -384,6 +392,12 @@ heavier infra-flavor layers fire only on the infra-flavored signal), and is for
 the *unfamiliar-contract* case — **not** every import, not familiar code whose
 contract the agent already holds. (Detail in
 [`references/infra-verification.md`](references/infra-verification.md).)
+
+**Frontend-triggered work (HTML/CSS/JS primary output).** When the frontend
+surface trigger fires, the `frontend-engineering` skill has already been
+loaded inline during PLAN. Its craft rules govern all HTML element selection,
+CSS token discipline, accessibility patterns, and state completeness during
+EXECUTE; its GATES section defines the verification commands to run at step 3.
 
 For each task, implement the smallest coherent unit of work toward the
 goal. Resist the urge to fix unrelated things you notice along the way;

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`frontend-engineering` skill added to core pack (core 0.11.0).** The work-loop now loads
+  inline craft rules — design pre-flight, HTML semantics, CSS token discipline,
+  accessibility, state completeness, and verification commands — whenever a
+  task's primary output is HTML, CSS, or JS. The design-intent pass is mandatory
+  (not a recommendation) for that surface.
+
 - **OWASP Agentic Skills Top 10 v1.0 compliance pass — all non-core packs.**
   All non-core packs audited and hardened against AST01–AST10. Three classes of changes:
   (1) AST05 — `research` skill now explicitly declares that fetched web content is untrusted

--- a/docs/specs/frontend-engineering-skill/plan.md
+++ b/docs/specs/frontend-engineering-skill/plan.md
@@ -1,0 +1,246 @@
+# Plan: frontend-engineering skill for core
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Drafting
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn. When it changes substantially
+> (a different approach, not just a re-ordering), note why in the changelog.
+
+## Approach
+
+**Skill first, amendment second, build third.** The skill file must exist before
+the work-loop amendment references it by name, so the tasks are ordered
+accordingly. The skill is a single cohesive markdown file — no
+`references/` subdirectory for v1. The work-loop amendment is additive only:
+two short paragraphs inserted into existing sections, no deletions.
+
+The riskiest part is the skill content itself: rules that are too vague provide
+no improvement over the status quo; rules that are too prescriptive create
+friction on legitimate variations. The bar is: every rule has a right/wrong form
+that a future adversarial-reviewer can check mechanically.
+
+## Constraints
+
+- Skill must be framework-agnostic — readable by an implementer using plain
+  HTML/CSS, Tailwind, or any other approach
+- Work-loop amendment is additive only — existing behavior unchanged
+- No new tooling shipped (CLI commands documented, not wrapped)
+- `make build-self` is the final mechanical gate
+
+## Construction tests
+
+All tasks use goal-based or visual/manual QA modes — no TDD stubs apply.
+
+Cross-cutting gate: after Task 3, `make build-self` exits 0 and
+`diff packs/core/.apm/skills/frontend-engineering/SKILL.md .claude/skills/frontend-engineering/SKILL.md`
+shows no unexpected differences (projection may add/strip a header comment).
+
+## Tasks
+
+### T1: Write the frontend-engineering skill file
+
+**Depends on:** none
+
+**Verification mode:** visual/manual QA
+
+**Tests:**
+Read the completed skill file top-to-bottom as if an implementer receiving it
+cold. For each AC below, record pass or fail:
+
+- AC1: valid frontmatter with `name:` and `description:` naming the trigger
+- AC2: self-contained — no dangling forward-references to files that don't exist
+- AC3: no framework-specific code: `grep -iE "react|vue|angular|jsx|usestate|useeffect|\bng-|@component|signal\(" packs/core/.apm/skills/frontend-engineering/SKILL.md` returns no hits
+- AC4: named aesthetic reference section with canonical product list and
+  purple-gradient failure explanation
+- AC5: seed token block with three-tier architecture and `--ds-` prefix;
+  all six minimum color roles present
+- AC6: state matrix six-row table; skeleton rule and `aria-busy` pattern present
+- AC7: print/PPT block with `@page`, `print-color-adjust`, `@media print`
+  override, `pt` unit guidance, `page-break-*` rules
+- AC8: AI aesthetic table with exactly 8 rows, each with a "why it's a problem"
+  entry
+- AC9: HTML rules — spot-check five (button/a/div rule; one `<main>`; form
+  label rule; alt text rule; realistic content rule) — each has right/wrong form
+- AC10: CSS rules — spot-check three (token-only, tabindex, hover/focus parity)
+  — each has right/wrong form
+- AC11: a11y rules — spot-check three (First Rule, reduced-motion guard,
+  `aria-live` DOM-before-inject) — each has right/wrong form
+- AC12–AC15: GATES section — confirm html-validate command is present and
+  runnable, pa11y/axe command has CI flags, stylelint config snippet has at
+  least the three named properties, visual QA checklist is enumerated
+- AC16–AC17: Anti-patterns and Red flags sections present
+
+**Approach:**
+
+Write `packs/core/.apm/skills/frontend-engineering/SKILL.md` with these
+sections in order:
+
+**Frontmatter** (description must be a single line — multi-line descriptions
+are silently truncated by lint-packs):
+```
+---
+name: frontend-engineering
+description: Load when a task's primary output is HTML, CSS, or JS. Provides design pre-flight, codified craft rules, and GATES verification commands for that surface.
+---
+```
+
+**Section order:**
+1. Overview (one paragraph: purpose, trigger, what it replaces, not-for cases)
+2. PLAN phase — Design Pre-flight
+   - Named aesthetic reference (canonical list, anti-adjective rule, why
+     purple-gradient is the default, mapping of each reference to aesthetic goal)
+   - Seed token block (three-tier architecture explanation, `--ds-` prefix,
+     minimum viable property set as CSS snippet, print/PPT override block)
+   - State matrix (six-row table with Wrong/Right columns, skeleton vs spinner
+     rule, `aria-busy` + `aria-label` pattern)
+3. EXECUTE phase — Craft Rules
+   - "Avoid the AI Aesthetic" (8-row table: pattern / why it's a problem /
+     production quality alternative)
+   - HTML element selection rules (grouped by: interactive elements, landmark
+     elements, headings, forms, images/media, content)
+   - CSS rules (grouped by: values, selectors, z-index, layout, keyboard)
+   - Accessibility rules (grouped by: ARIA discipline, dynamic state, contrast,
+     motion, live regions, keyboard patterns, focus management)
+4. GATES phase — Verification
+   - html-validate (command, what it catches, no-browser note)
+   - pa11y / axe-core (command with CI flags, WCAG level, headless note)
+   - stylelint token enforcement (config snippet)
+   - Visual QA checklist (enumerated items)
+5. Anti-patterns / Common Rationalizations (declined-pattern register format)
+6. Red flags (quick-scan list)
+
+**Done when:** all 17 ACs above pass visual/manual QA read-through; no
+framework-specific grep hits
+
+---
+
+### T2: Amend work-loop skill — add frontend trigger
+
+**Depends on:** T1
+
+**Verification mode:** goal-based check
+
+**Tests:**
+- `grep -n "frontend-engineering" packs/core/.apm/skills/work-loop/SKILL.md`
+  returns matches in at least 2 locations (PLAN section and EXECUTE section)
+- `grep -n "mandatory" packs/core/.apm/skills/work-loop/SKILL.md | grep -i "frontend"`
+  returns at least one match (the mandatory upgrade in the design-intent pass)
+- `git diff packs/core/.apm/skills/work-loop/SKILL.md` shows only additions,
+  no deleted lines from the existing text (AC20a)
+- `grep -c "risk-triggers:start" packs/core/.apm/skills/work-loop/SKILL.md`
+  returns 1 and the block content is unchanged — spot-check that the
+  risk-triggers wording between the comments is byte-identical to the original
+  (AC20b); compare against `git show HEAD:packs/core/.apm/skills/work-loop/SKILL.md`
+- The REVIEW specialist-reviewers roster paragraph (the one listing
+  `security-reviewer`, `quality-engineer`, `experience-reviewer`) is
+  byte-unchanged — confirm by diffing that section against HEAD (AC20c)
+- `grep -ciE "primary output is HTML|HTML/CSS/JS primary output" packs/core/.apm/skills/work-loop/SKILL.md`
+  returns ≥ 2 (trigger phrase present in both PLAN and EXECUTE amendments,
+  AC21)
+
+**Approach:**
+
+Two targeted, additive amendments to
+`packs/core/.apm/skills/work-loop/SKILL.md`:
+
+**Amendment 1 — PLAN section, end of the "Pre-EXECUTE design-intent pass"
+paragraph.** Current text ends with:
+> "Applies in both light and full mode as a recommendation; the mandatory
+> fresh-context gate (`experience-reviewer`) runs in REVIEW for full-mode work."
+
+Append after this sentence:
+> "**Frontend surface exception — mandatory, not recommended.** When the task's
+> primary output is HTML, CSS, or JS (a new page, component, slide deck,
+> dashboard, or standalone web artifact), this pass is mandatory in both modes:
+> load the `frontend-engineering` skill inline before writing code. It carries
+> the design pre-flight requirements (named aesthetic reference, seed token
+> block, state matrix), the craft rules, and the GATES verification commands
+> for that surface. The judgment call — whether the output is 'primary' HTML/CSS/JS
+> or incidental — is the implementer's; when in doubt, load it."
+
+**Amendment 2 — EXECUTE section, after the contract-grounding gate paragraph.**
+The contract-grounding gate ends at `work-loop/SKILL.md:386`:
+> `[`references/infra-verification.md`](references/infra-verification.md).)`
+
+Insert a blank line then a new paragraph immediately after line 386:
+> "**Frontend-triggered work (HTML/CSS/JS primary output).** When the frontend
+> surface trigger fires, the `frontend-engineering` skill has already been
+> loaded inline during PLAN. Its craft rules govern all HTML element selection,
+> CSS token discipline, accessibility patterns, and state completeness during
+> EXECUTE; its GATES section defines the verification commands to run at step 3."
+
+**Done when:** all three grep tests pass; `git diff` shows only additions
+
+---
+
+### T3: Build and verify projection
+
+**Depends on:** T1, T2
+
+**Verification mode:** goal-based check
+
+**Tests:**
+- `make build-self` exits 0 (AC23)
+- `ls .claude/skills/frontend-engineering/SKILL.md` exits 0 (AC24)
+- `grep -c "frontend-engineering" .claude/skills/work-loop/SKILL.md` returns
+  ≥ 2 (AC25 — work-loop projection reflects the amendment)
+- `head -5 .claude/skills/frontend-engineering/SKILL.md` shows the frontmatter
+
+**Approach:**
+Run `make build-self`. If it fails, check the error — common causes are invalid
+YAML frontmatter (unescaped colon in description; multi-line description) or
+missing required fields. Fix at the source files only, never at projected paths.
+Re-run until it exits 0.
+
+**Done when:** all four one-liners pass
+
+---
+
+### T4: Add changelog entry
+
+**Depends on:** T2
+
+**Verification mode:** goal-based check
+
+**Tests:**
+- `grep -A3 "frontend-engineering" docs/product/changelog.md` returns an
+  `Added` entry under `[Unreleased]`
+
+**Approach:**
+Add to the `### Added` block under `## [Unreleased]` in `docs/product/changelog.md`:
+
+```
+- **`frontend-engineering` skill added to core pack.** The work-loop now loads
+  inline craft rules — design pre-flight, HTML semantics, CSS token discipline,
+  accessibility, state completeness, and verification commands — whenever a
+  task's primary output is HTML, CSS, or JS. The design-intent pass is mandatory
+  (not a recommendation) for that surface.
+```
+
+**Done when:** grep test passes
+
+---
+
+## Rollout
+
+Single PR to `main`. No flag-gating. The skill is additive; the work-loop
+amendment is additive. Adopters who run `make build-self` pick it up
+automatically at next install.
+
+## Risks
+
+- **Skill content too vague:** if rules aren't specific enough (right/wrong
+  form), they provide no improvement. Mitigation: adversarial-reviewer pass
+  with an explicit "are these rules specific or just principles?" check.
+- **Work-loop amendment too broad:** if the frontend trigger is too broadly
+  defined, it fires on every template/docs HTML touch and creates friction.
+  Mitigation: the amendment text explicitly scopes to "primary output" and
+  gives the implementer the judgment call.
+- **build-self drift:** if the skill's frontmatter is malformed, build-self
+  fails silently or noisily. Mitigation: run build-self as Task 3, before
+  declaring done.
+
+## Changelog
+
+- 2026-07-16: initial draft

--- a/docs/specs/frontend-engineering-skill/spec.md
+++ b/docs/specs/frontend-engineering-skill/spec.md
@@ -1,0 +1,268 @@
+# Spec: frontend-engineering skill for core
+
+- **Status:** Implementing
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** [ADR-0023](../../adr/0023-reviewer-ceiling-scopes-core-code-review-lenses.md)
+  (reviewer-ceiling — no new reviewer role); [ADR-0042](../../adr/0042-agent-additions-keyed-to-loop-and-work-type.md)
+  (agent additions keyed to loop and work-type — context injection over domain
+  subagents); [ADR-0047](../../adr/0047-experience-reviewer-as-work-loop-gate.md)
+  (experience-reviewer gate — this skill supplements but does not replace it)
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+Mode: full (structural change — new module boundary in `packs/core`; public
+interface adopted by the work-loop and all downstream agents; multi-task
+dependency between skill authorship and work-loop amendment)
+
+## Objective
+
+Add a `frontend-engineering` depth skill to `packs/core` that the work-loop
+loads inline when a task's primary output is HTML, CSS, or JS. The skill gives
+the implementing agent codified, specific rules — not vague principles —
+covering design pre-flight, HTML semantics, CSS token discipline, accessibility,
+state completeness, and verification tooling. It also amends the work-loop's
+PLAN section to make the design-intent pass **mandatory** (not a
+recommendation) when the frontend trigger fires.
+
+**The problem this solves:** AI-generated frontend code is consistently
+technically correct but visually inconsistent, semantically wrong, and
+inaccessible by default. This is not a subagent problem — domain-partitioned
+subagents add coordination overhead and do not outperform context injection on
+sequential coding tasks. The right lever is codified rules loaded inline before
+EXECUTE begins.
+
+## Acceptance Criteria
+
+### Skill file
+
+- [x] AC1: Skill exists at `packs/core/.apm/skills/frontend-engineering/SKILL.md`
+  with valid frontmatter: `name: frontend-engineering` and a `description:` that
+  names the trigger condition ("HTML, CSS, or JS as a primary output artifact")
+- [x] AC2: Skill is self-contained — no unexplained terms and no dangling
+  references to files or concepts not defined within the skill; verified by
+  reading it cold and confirming every cross-reference resolves
+- [x] AC3: Skill is framework-agnostic — the following grep returns no hits:
+  `grep -iE "react|vue|angular|jsx|usestate|useeffect|\bng-|@component|signal\(" packs/core/.apm/skills/frontend-engineering/SKILL.md`
+
+### Design pre-flight section (PLAN phase)
+
+- [x] AC4: **Named aesthetic reference** — skill requires a product name from a
+  named canonical set (Linear, Stripe, Vercel, Raycast, Arc, Notion, Toss),
+  explains why vague adjectives ("beautiful", "modern") fail (purple-gradient
+  default), and maps each reference to its aesthetic goal
+- [x] AC5: **Seed token block** — skill specifies the three-tier token
+  architecture (Primitive → Semantic → Component; one-way dependency only),
+  names the `--ds-` prefix convention, and enumerates the minimum viable
+  property set: color roles (`--ds-color-surface`, `--ds-color-on-surface`,
+  `--ds-color-primary`, `--ds-color-on-primary`, `--ds-color-error`,
+  `--ds-color-outline`), 8-step spacing scale (`--ds-space-1` through
+  `--ds-space-8`, 4 px base), type scale (size / weight / line-height),
+  radius scale, shadow scale, motion tokens (duration + easing)
+- [x] AC6: **State matrix** — skill requires a six-row table for every async
+  component: content / loading / empty / error / partial / disabled. Rules: use
+  skeleton screen (not spinner) when layout is predictable; use
+  `aria-busy="true"` and `aria-label="Loading <thing>"` on the skeleton
+  container; empty state requires illustration + label + CTA; error state
+  preserves prior content and offers retry; disabled state renders visibly with
+  `aria-disabled="true"` and an explanation
+- [x] AC7: **Print/PPT token block** — skill includes a conditional section (when
+  output targets PPT/PDF) covering: `@page { size: 960px 540px; margin: 0; }`,
+  `-webkit-print-color-adjust: exact; print-color-adjust: exact`,
+  `@media print` override block for surface/shadow tokens, `pt` for
+  typographic values, `page-break-after: always` for slide boundaries,
+  `page-break-inside: avoid` on headings/figures/tables, and a warning that
+  `box-shadow` and `text-shadow` are unreliable in print renderers
+
+### EXECUTE craft rules
+
+- [x] AC8: **"Avoid the AI Aesthetic" table** — skill contains an 8-row
+  anti-pattern table (purple/indigo palette, excessive gradients, rounded
+  everything, generic hero sections, lorem ipsum copy, oversized equal padding,
+  uniform card grids, shadow-heavy design) with a "why it's a problem" column
+  for each
+- [x] AC9: **HTML element rules** — all rules are specific right/wrong form, not
+  vague principles, covering:
+  - Interactive: `<button>` for actions, `<a href>` for navigation; never
+    `<div onclick>`; never cross them
+  - Landmarks: exactly one `<main>`, one `<h1>`; sequential heading levels
+    (never skip); `<section>` only when it has a heading; multiple `<nav>`
+    requires `aria-label`
+  - Forms: every `<input>`/`<textarea>`/`<select>` requires `<label for>` or
+    `aria-labelledby`; `placeholder` is not a label; `aria-describedby` for
+    errors; `autocomplete` on personal-data fields; `<fieldset>`+`<legend>` for
+    checkbox/radio groups
+  - Images: `alt=""` for decorative, descriptive text for informational (no
+    "image of" prefix); CSS `background-image` for decorative backgrounds;
+    SVG as image requires `role="img"` + `<title>`; decorative SVG requires
+    `aria-hidden="true"`
+  - Content: use realistic-length placeholder text, not lorem ipsum
+- [x] AC10: **CSS rules** — specific, covering: token-only values (no hardcoded
+  hex/rgb/hsl; all via `var(--ds-*)`); z-index via named custom property scale;
+  unitless line-height; class selectors only (no `#id`); max 3 nesting levels;
+  no qualified selectors; `tabindex` never positive; every `:hover` has matching
+  `:focus-visible`; never `outline: none` without visible replacement
+- [x] AC11: **Accessibility rules** — specific right/wrong form, covering:
+  - First Rule of ARIA: use native HTML; ARIA only when HTML is insufficient;
+    specific violation examples (never `<div role="button">` when `<button>`
+    works)
+  - Dynamic ARIA: `aria-expanded`, `aria-selected`, `aria-sort` must update on
+    state change — they are not static attributes
+  - Never add `aria-label` to elements with visible text (creates
+    screen-reader/voice-control mismatch)
+  - WCAG contrast floor: 4.5:1 body text, 3:1 large text (≥18 pt or ≥14 pt
+    bold), 3:1 UI components (borders, focus rings, icons)
+  - Reduced-motion guard: every `animation`/`transition`/`transform` wrapped in
+    `@media (prefers-reduced-motion: no-preference)` (default: no motion)
+  - `aria-live` container must be in DOM before content is injected; `polite`
+    for informational, `assertive` + `aria-atomic="true"` for errors
+  - APG modal pattern (concise): `role="dialog"`, `aria-modal="true"`,
+    `aria-labelledby`, focus first focusable on open, Tab/Shift+Tab cycle inside
+    only, Escape closes, focus returns to invoking element
+  - Programmatic focus required after: modal open/close, route change, inline
+    error appearance
+
+### GATES verification
+
+- [x] AC12: **html-validate** — skill provides the exact runnable command:
+  `npx html-validate --preset standard,a11y --max-warnings 0 <file.html>`,
+  notes it requires no browser, and names what it catches (landmark structure,
+  heading hierarchy, label associations, ARIA role validity, alt presence)
+- [x] AC13: **pa11y / axe-core** — skill provides an exact runnable command for
+  at least one Chromium-based tool with CI-safe flags (`--no-sandbox`) and the
+  correct WCAG tag (`WCAG2AA` / `wcag21aa`), and notes that Chromium runs
+  headless without a display server
+- [x] AC14: **stylelint token enforcement** — skill provides an exact
+  `stylelint-declaration-strict-value` config snippet covering at minimum
+  `color`, `background-color`, and `font-size` properties
+- [x] AC15: **Visual QA checklist** — skill enumerates an agent-executable
+  checklist (no tooling required) covering: all state variants present,
+  no hardcoded values in CSS, print output correct if PPT/PDF context,
+  screenshot taken and observed
+
+### Anti-patterns and red flags
+
+- [x] AC16: **Anti-patterns / Common Rationalizations** section names at least
+  five refused rationalizations in declined-pattern register format, drawn from:
+  "accessibility is a nice-to-have", "we'll make it responsive later",
+  "this is just a prototype", "the AI aesthetic is fine for now",
+  "I'll add the empty/error states later"
+- [x] AC17: **Red flags** section provides a quick-scan list for review gates,
+  covering: inline styles or magic pixel values, missing any state (empty/error/
+  loading), no keyboard navigation, color as sole state indicator, generic AI
+  look (purple gradients/oversized cards)
+
+### Work-loop amendment
+
+- [x] AC18: Work-loop PLAN section amended so the design-intent pass is
+  **mandatory** (not "recommendation") when the frontend trigger fires — task's
+  primary output is HTML, CSS, or JS — and names loading `frontend-engineering`
+  inline as the required action
+- [x] AC19: Work-loop EXECUTE section amended with one sentence routing
+  implementers to the `frontend-engineering` skill's craft rules and GATES
+  commands when the frontend trigger fires
+- [x] AC20: The work-loop amendment adds text only — verified by: (a) `git diff`
+  shows zero deleted lines in `work-loop/SKILL.md`; (b) the risk-triggers block
+  (`<!-- risk-triggers:start -->` … `<!-- risk-triggers:end -->`) is
+  byte-unchanged; (c) the REVIEW specialist-reviewers roster paragraph is
+  byte-unchanged
+- [x] AC21: The trigger concept "primary output is HTML, CSS, or JS" (or
+  equivalent — "HTML/CSS/JS primary output" is accepted) appears in both
+  work-loop amendment sites; verified by:
+  `grep -ciE "primary output is HTML|HTML/CSS/JS primary output" packs/core/.apm/skills/work-loop/SKILL.md`
+  returns ≥ 2. Consistency within the skill file itself (frontmatter + Overview)
+  is verified by the T1 visual/manual QA read-through
+
+### Changelog
+
+- [x] AC22: `docs/product/changelog.md` `[Unreleased]` section has an `Added`
+  entry noting the new `frontend-engineering` skill and the mandatory
+  design-intent pass for the frontend trigger
+
+### Build and projection
+
+- [x] AC23: `make build-self` exits 0 after the new skill is added
+- [x] AC24: Skill projects to `.claude/skills/frontend-engineering/SKILL.md`
+  (confirmed by path existence after build-self)
+- [x] AC25: Regenerated `.claude/skills/work-loop/SKILL.md` reflects the
+  work-loop amendment (confirmed by `grep -c "frontend-engineering"
+  .claude/skills/work-loop/SKILL.md` returning ≥ 2)
+
+## Boundaries
+
+**In scope:**
+- New file: `packs/core/.apm/skills/frontend-engineering/SKILL.md`
+- Amendment: `packs/core/.apm/skills/work-loop/SKILL.md` (PLAN and EXECUTE
+  sections only — additive prose, ~3–5 sentences total)
+- Amendment: `docs/product/changelog.md` (`[Unreleased]` entry only)
+- Generated outputs: `.claude/skills/frontend-engineering/SKILL.md` (new),
+  `.claude/skills/work-loop/SKILL.md` (regenerated with amendment)
+- Core pack version bump (`pack.toml` + `.claude-plugin/plugin.json` → 0.11.0)
+  and `marketplace.json` regeneration — user confirmed ship
+
+**Out of scope:**
+- Experience pack skills (aesthetic-direction, design-system-foundations,
+  experience-reviewer) — not touched; they remain optional
+- Other core skills (security-checklists, operational-safety, contract-
+  acquisition, bug-fix, new-spec) — not touched
+- Verification scripts under `tools/` — CLI commands documented in skill,
+  not shipped as tooling
+- `references/` subdirectory for the new skill — single cohesive file for v1
+- Framework-specific content (React hooks, JSX, Vue SFCs) — not included
+- Per-package `CHANGELOG.md` and `ROADMAP` files — not touched
+
+## Testing Strategy
+
+All tasks use **goal-based check** or **visual/manual QA** — the artifact is
+markdown, not testable logic; no TDD mode applies.
+
+- Task 1 (write skill): visual/manual QA — read the skill top-to-bottom as if
+  an implementer receiving it; each AC2–AC17 is a checklist item verified by
+  inspection; framework-agnosticism verified by grep (AC3)
+- Task 2 (amend work-loop): goal-based check — greps for trigger language at
+  two locations; risk-triggers and reviewer-roster spot-checks for unchanged
+  bytes (AC20a/b/c); trigger-phrase consistency grep (AC21)
+- Task 3 (build-self): goal-based check — `make build-self` exits 0;
+  both projected files exist; work-loop projection grep passes (AC25)
+- Task 4 (changelog): goal-based check — `grep` for the entry under
+  `[Unreleased]` (AC22)
+
+## Assumptions
+
+**Trio:**
+- Touching: `packs/core/.apm/skills/frontend-engineering/SKILL.md` (new),
+  `packs/core/.apm/skills/work-loop/SKILL.md` (PLAN + EXECUTE only)
+- Done when: all ACs pass, `make build-self` green, adversarial-reviewer
+  returns Clean
+- Not changing: any existing trigger condition, mode selection, gate sequence,
+  reviewer roster, or other core skill
+
+**Resolve-vs-surface disposition (pre-EXECUTE):**
+- "Does the work-loop amendment require loop-cohort approve-plan?" → Resolved:
+  yes — spec amendment + new module boundary fires the pre-EXECUTE adversarial
+  review trigger per the work-loop's own rules
+- "Should print/PPT content be a `references/print-ppt.md` depth file?" →
+  Resolved: no — inline is right for v1; depth file is a follow-up if adopters
+  request it
+- "Should the frontend trigger fire on partial HTML (a component in a
+  server-rendered template)?" → Resolved: yes — "primary output" judgment is
+  left to the implementer; the skill notes this
+
+## Declined patterns
+
+- Tempted to add a `references/` subdirectory (like security-checklists
+  modules): declining — v1 lacks adopter feedback on which sections need depth;
+  single cohesive file is right
+- Tempted to add verification scripts to `tools/` (html-validate wrapper,
+  pa11y runner): declining — CLI commands are documented; tooling is a follow-up
+  if adopters request it
+- Tempted to make the trigger mandatory for all HTML edits (not just primary
+  output): declining — incremental edits to existing HTML are covered by the
+  existing work-loop design-intent recommendation
+- Tempted to include React-specific examples (hooks, JSX, component file
+  colocation): declining — core pack is framework-agnostic; React content
+  belongs in an opt-in react pack
+- Tempted to add domain-partitioned subagents (frontend-engineer,
+  backend-engineer): declining — research is clear that context injection
+  outperforms domain-partitioned subagents for sequential coding tasks

--- a/packs/core/.apm/skills/frontend-engineering/SKILL.md
+++ b/packs/core/.apm/skills/frontend-engineering/SKILL.md
@@ -1,0 +1,413 @@
+---
+name: frontend-engineering
+description: Load when a task's primary output is HTML, CSS, or JS. Provides design pre-flight, codified craft rules, and GATES verification commands for that surface.
+---
+
+# Skill: frontend-engineering
+
+Load this skill when a task's primary output is HTML, CSS, or JS — a new page,
+component, slide deck, dashboard, email template, or any standalone web artifact.
+It carries the design pre-flight requirements (named aesthetic reference, seed
+token block, state matrix), the craft rules that govern EXECUTE, and the GATES
+verification commands. It is not needed for incidental HTML edits to an existing
+surface already covered by a grounded aesthetic reference.
+
+## PLAN phase — Design Pre-flight
+
+Complete all three steps before writing any code. These are not suggestions;
+they are the contract for greenfield frontend work.
+
+### 1. Named aesthetic reference
+
+State a named product reference — not an adjective. The model has learned
+visual vocabulary from extensively documented products; vague adjectives
+produce the purple-gradient default (Tailwind's `bg-indigo-500` saturated
+training data, so "nice", "clean", "modern" all converge there).
+
+**Canonical reference set:**
+
+| Goal | Use |
+|---|---|
+| Professional / executive SaaS | Linear, Stripe, Vercel |
+| Data-dense / terminal | Raycast, Arc |
+| Minimal / editorial | Notion |
+| Warm / human | Toss |
+
+Name the reference in the spec: `Aesthetic reference: Linear (professional SaaS —
+dark surface, high contrast, no gradients)`. If the target must match an existing
+user-provided theme (e.g. a PPT brand), describe its key token values instead.
+
+### 2. Seed token block
+
+Provide a CSS custom properties block before writing any HTML. The model
+selects from `var(--ds-color-primary)` rather than fabricating `#5e6ad2` per
+session — token-seeding is the single strongest lever for visual consistency.
+
+**Three-tier architecture (one-way dependency):**
+```
+Primitive  →  Semantic  →  Component
+(raw hex)      (role)       (usage)
+```
+Only the semantic layer goes in the seed block; primitives are defined once
+at the top of the CSS file and referenced by semantics.
+
+**Minimum viable property set** (`--ds-` prefix for namespace clarity):
+
+```css
+:root {
+  /* Color roles — semantic, not raw hex */
+  --ds-color-surface:      #ffffff;
+  --ds-color-surface-alt:  #f8fafc;
+  --ds-color-on-surface:   #1a202c;
+  --ds-color-on-surface-2: rgba(0, 0, 0, 0.60);
+  --ds-color-primary:      #5e6ad2;
+  --ds-color-on-primary:   #ffffff;
+  --ds-color-error:        #dc2626;
+  --ds-color-on-error:     #ffffff;
+  --ds-color-outline:      rgba(0, 0, 0, 0.12);
+
+  /* Spacing — 4 px base, 8-step scale */
+  --ds-space-px: 2px;
+  --ds-space-1:  4px;
+  --ds-space-2:  8px;
+  --ds-space-3:  12px;
+  --ds-space-4:  16px;
+  --ds-space-5:  24px;
+  --ds-space-6:  32px;
+  --ds-space-7:  48px;
+  --ds-space-8:  64px;
+
+  /* Type scale */
+  --ds-text-sm:   0.75rem;
+  --ds-text-base: 0.875rem;
+  --ds-text-lg:   1rem;
+  --ds-text-xl:   1.125rem;
+  --ds-text-2xl:  1.25rem;
+  --ds-font-regular: 400;
+  --ds-font-medium:  500;
+  --ds-font-bold:    600;
+  --ds-leading-tight:  1.25;
+  --ds-leading-normal: 1.5;
+  --ds-leading-loose:  1.75;
+
+  /* Radius */
+  --ds-radius-sm: 4px;
+  --ds-radius-md: 8px;
+  --ds-radius-lg: 12px;
+  --ds-radius-full: 9999px;
+
+  /* Shadow */
+  --ds-shadow-sm: 0 1px 2px rgba(0,0,0,0.06);
+  --ds-shadow-md: 0 4px 8px rgba(0,0,0,0.08);
+  --ds-shadow-lg: 0 8px 24px rgba(0,0,0,0.10);
+
+  /* Motion */
+  --ds-duration-quick:    120ms;
+  --ds-duration-moderate: 200ms;
+  --ds-duration-gentle:   300ms;
+  --ds-ease-standard:     cubic-bezier(0.4, 0, 0.2, 1);
+  --ds-ease-decelerate:   cubic-bezier(0, 0, 0.2, 1);
+}
+```
+
+#### Print / PPT token block
+
+When the output targets a PPT slide or PDF export, add this block and use
+`pt` for typographic values:
+
+```css
+@page {
+  size: 960px 540px; /* 16:9 slide — standard widescreen */
+  margin: 0;
+}
+
+* {
+  -webkit-print-color-adjust: exact;
+  print-color-adjust: exact; /* preserve background fills */
+}
+
+@media print {
+  :root {
+    --ds-color-surface:    #ffffff;
+    --ds-color-on-surface: #000000;
+    --ds-shadow-sm: none;
+    --ds-shadow-md: none;
+    --ds-shadow-lg: none;
+  }
+
+  .slide            { page-break-after: always; }
+  h2, h3, figure,
+  table, blockquote { page-break-inside: avoid; }
+}
+```
+
+**Print safety:** `box-shadow` and `text-shadow` are unreliable across
+renderers (Chrome/WeasyPrint differ) — use `--ds-shadow-*: none` in the
+print override and rely on borders for separation instead. Avoid Tailwind
+responsive variants (`sm:`, `md:`) for fixed-dimension artifacts.
+
+### 3. State matrix
+
+Enumerate all states for every async component as a table in the spec.
+LLMs are trained predominantly on happy-path code; they will not generate
+missing-state branches without explicit enumeration. A 2025 study of
+50 AI-generated dashboards found 92% had no empty state and 78% had no
+error state.
+
+| State | Wrong | Right |
+|---|---|---|
+| **Loading** | Generic spinner | Skeleton screen matching the final layout (use spinner only when shape is unknown); add `aria-busy="true"` and `aria-label="Loading <thing>"` to the skeleton container |
+| **Empty** | Blank space | Illustration or icon + label describing the empty condition + primary CTA |
+| **Error** | Clear prior content; show only the error | Preserve prior content; show inline error message + retry affordance |
+| **Partial** | No indication more data exists | Pagination or load-more with a record count |
+| **Disabled** | Hide the element | Render it disabled with `aria-disabled="true"` and a tooltip or label explaining why |
+| **Content** | — | The normal loaded state — spec this too so the skeleton shape is known |
+
+**Skeleton vs spinner rule:** use a skeleton when the content shape is
+predictable (table rows, card grids, profile cards). The skeleton must
+match the final layout so there is no layout shift on load. Use a spinner
+only when shape is genuinely unknown.
+
+---
+
+## EXECUTE phase — Craft Rules
+
+### Avoid the AI Aesthetic
+
+AI-generated UI has recognisable failure patterns. Refuse all of them:
+
+| Pattern | Why it's a problem | Instead |
+|---|---|---|
+| Purple / indigo everything | Models default to `bg-indigo-500` — every generated app looks identical | Use the project's token palette; derive from the named aesthetic reference |
+| Excessive gradients | Add visual noise; clash with most design systems | Flat colour or a single subtle gradient matching the system |
+| Rounded everything (`rounded-2xl` / `border-radius: 16px` on all elements) | Ignores the radius hierarchy in real designs — cards, buttons, and inputs each have a distinct radius | Use the `--ds-radius-*` scale; vary by element type |
+| Generic hero sections | Template-driven layout with no connection to actual content or user need | Content-first layout driven by what the user needs to do |
+| Lorem ipsum placeholder copy | Hides layout problems that real content reveals (wrapping, overflow, long names) | Realistic-length placeholder text that approximates actual content |
+| Oversized equal padding everywhere | Destroys visual hierarchy; wastes screen space | Use the spacing scale; vary padding by component level |
+| Uniform card grids | Ignores information priority and scanning patterns | Purpose-driven layouts — group by relationship, not by grid slot |
+| Shadow-heavy design | Layered shadows compete with content; slow on low-end devices | Use `--ds-shadow-sm` sparingly; flat or a single elevation level |
+
+### HTML element selection rules
+
+Rules are in **WRONG → RIGHT** form. "Use semantic HTML" is not a rule;
+the specific forms below are.
+
+#### Interactive elements
+
+- WRONG: `<div onclick="…">`, `<span onclick="…">` / RIGHT: `<button type="button">` for any action
+- WRONG: `<a href="#" onclick="…">` for actions / RIGHT: `<a href="…">` for navigation only; `<button>` for actions — never cross them
+- WRONG: `<div role="button">` with no keyboard handler / RIGHT: `<button>` — it receives keyboard, focus, and activation natively; avoid `role="button"` on a non-button element unless a framework absolutely requires it, and then you must add `tabindex="0"` and `onkeydown` handlers for both Enter and Space
+
+#### Landmark elements
+
+- One `<main>` per page, no exceptions
+- One `<h1>` per page
+- Heading levels are sequential — never skip (h1 → h3 is wrong; heading level = outline position, never visual size)
+- `<section>` only when it has a heading as its first child; otherwise use `<div>`
+- Multiple `<nav>` elements require `aria-label` distinguishing them: `aria-label="Primary"`, `aria-label="Breadcrumb"`
+- `<article>` for self-contained distributable content; `<aside>` for tangentially related content
+
+#### Forms
+
+- WRONG: `<input placeholder="Email">` with no label / RIGHT: `<label for="email">Email</label><input id="email">` or `aria-labelledby`; `placeholder` is not a label — it fails WCAG 1.3.1 and disappears on input
+- WRONG: `aria-describedby` pointing to an element not yet in the DOM / RIGHT: place the target element in the DOM before the input receives focus; inject empty containers on page load
+- WRONG: ungrouped checkboxes/radios / RIGHT: `<fieldset><legend>…</legend>…</fieldset>` for every checkbox or radio group
+- `autocomplete` attribute is required on personal-data fields: `name`, `email`, `tel`, `current-password`, `new-password`, address fields
+
+#### Images and media
+
+- WRONG: `alt="image"`, `alt="photo of a dog"` / RIGHT: descriptive text without "image of" / "photo of" prefixes; `alt=""` for decorative images; max ~150 chars — use `<figcaption>` for longer descriptions
+- WRONG: `<img>` for decorative backgrounds / RIGHT: CSS `background-image` — the element is removed from the accessibility tree automatically
+- SVG used as a meaningful image: add `role="img"` and a `<title>` as the first child
+- SVG that is decorative: `aria-hidden="true"`
+
+#### Content
+
+- WRONG: lorem ipsum placeholder text / RIGHT: realistic-length placeholder text that approximates what real content looks like — long names, multi-line descriptions, edge-case values
+
+### CSS rules
+
+- WRONG: `color: #5e6ad2`, `background: #f8fafc`, `margin: 13px` / RIGHT: all colour and spacing values via `var(--ds-*)` — no hardcoded hex, rgb, hsl, or magic pixel values
+- WRONG: `z-index: 9999` / RIGHT: define a named z-index scale: `--z-base: 0; --z-overlay: 100; --z-modal: 200; --z-toast: 300` — use named custom properties only
+- WRONG: `line-height: 24px` / RIGHT: unitless — `line-height: var(--ds-leading-normal)` or `line-height: 1.5`
+- WRONG: `#nav {}`, `ul.nav {}` / RIGHT: class selectors only; no ID selectors; no qualified selectors
+- WRONG: selector depth > 3 levels / RIGHT: max 3 levels of nesting
+- WRONG: `tabindex="2"`, `tabindex="5"` (positive values) / RIGHT: `tabindex="0"` to enter tab order; `tabindex="-1"` for programmatic focus targets only; never positive values — they disrupt the natural tab sequence
+- WRONG: `.btn:hover { … }` with no focus style / RIGHT: every `:hover` rule has a matching `:focus` or `:focus-visible` rule
+- WRONG: `outline: none` / RIGHT: replace with a visible alternative — `outline: 2px solid var(--ds-color-primary); outline-offset: 2px` or a `box-shadow` equivalent
+
+### Accessibility rules
+
+#### ARIA discipline
+
+**First Rule of ARIA:** if a native HTML element provides the semantics and
+behaviour, use it — do not bolt ARIA onto a generic element.
+
+- WRONG: `<div role="button" onclick="…">` — no keyboard, no activation, no inherited states / RIGHT: `<button>`
+- WRONG: `aria-label="Submit"` on a `<button>Submit</button>` with visible text / RIGHT: omit `aria-label` — it overrides the visible label and breaks voice control ("Submit" no longer activates the button by name in Dragon NaturallySpeaking)
+- WRONG: `<input aria-label="Email" placeholder="Email">` when a visible label exists / RIGHT: use the `<label>` and omit the redundant `aria-label`
+
+**Dynamic ARIA state must update** — these are not static attributes:
+
+- `aria-expanded="false"` on a closed accordion must flip to `"true"` when open
+- `aria-selected` must update as tabs are navigated
+- `aria-sort` must update as columns are sorted
+- Setting them once in the HTML and never updating them with JS is wrong
+
+**`aria-live` regions:**
+
+- The container must be in the DOM *before* content is injected into it — add it empty on page load and update its text content to trigger the announcement; injecting a live region and populating it simultaneously causes the announcement to be dropped silently in most screen readers
+- `aria-live="polite"` for informational updates (toast success, search result counts)
+- `aria-live="assertive"` + `aria-atomic="true"` for errors and time-critical alerts (session timeout, form validation summary)
+
+#### WCAG contrast floor (WCAG 1.4.3 / 1.4.11)
+
+| Element | Minimum ratio |
+|---|---|
+| Body text | 4.5 : 1 |
+| Large text (≥ 18 pt or ≥ 14 pt bold) | 3 : 1 |
+| UI components (borders, focus rings, icons, input outlines) | 3 : 1 |
+| Placeholder text | 4.5 : 1 (counts as text) |
+
+Verify contrast at derivation time — never eyeball it.
+
+#### Reduced motion
+
+Every `animation`, `transition`, and `transform` must be guarded. Default to
+no motion; enable only when the user has not requested reduced motion:
+
+```css
+/* Default: no motion */
+.element {
+  transition: none;
+  animation: none;
+}
+
+/* Motion only when the user permits */
+@media (prefers-reduced-motion: no-preference) {
+  .element {
+    transition: opacity var(--ds-duration-moderate) var(--ds-ease-standard);
+  }
+}
+```
+
+Properties to guard: `animation`, `transition`, `transform` (slides, scales,
+rotates), `scroll-behavior: smooth`. Colour and opacity changes that carry
+meaning do not need guarding — only motion.
+
+#### Modal / dialog keyboard pattern (W3C APG)
+
+```
+role="dialog" + aria-modal="true" + aria-labelledby="<title-id>"
+On open:   move focus to first focusable element inside the dialog
+Tab:       cycle forward through focusable elements inside only (trap)
+Shift+Tab: cycle backward (trap)
+Escape:    close the dialog
+On close:  return focus to the element that opened the dialog
+```
+
+#### Tabs keyboard pattern (W3C APG)
+
+```
+Tab:         moves focus into the tablist, then out to the tabpanel — never between tabs
+Left/Right:  navigate between tabs (wrapping); activate on focus (auto-activation)
+Home/End:    jump to first / last tab
+```
+
+#### Programmatic focus — when it is required
+
+Move focus programmatically when:
+- A modal opens (to first focusable element inside) or closes (back to invoking element)
+- A SPA route changes (to the page `<h1>` or a skip-nav landmark with `tabindex="-1"`)
+- An inline error appears after form submit (to first invalid field or error summary)
+- Async content is inserted and the user needs to interact with it immediately
+
+---
+
+## GATES phase — Verification
+
+Run these after implementation, before review. Record actual command output —
+do not assert on internal state.
+
+### 1. Structural HTML validation (no browser required)
+
+```bash
+npx html-validate --preset standard,a11y --max-warnings 0 <file.html>
+```
+
+Catches without a browser: landmark structure (one `<main>`, unique landmarks),
+heading hierarchy (no skipped levels), label associations, ARIA role validity,
+`alt` attribute presence, and WCAG H-technique violations. Exits non-zero on any
+error.
+
+### 2. Accessibility audit (requires Chromium — runs headless, no display server)
+
+Either tool works; pa11y is lighter, axe-core has more rules:
+
+```bash
+# pa11y — local files via file:// path
+npx pa11y "file:///$(pwd)/file.html" --standard WCAG2AA --reporter cli
+
+# axe-core/cli — URL or file, CI-safe Chromium flags
+npx axe "file:///$(pwd)/file.html" \
+  --tags wcag21aa \
+  --chrome-options="no-sandbox,disable-setuid-sandbox,disable-dev-shm-usage"
+```
+
+Note: neither tool currently supports WCAG 2.2 tags — `wcag21aa` is the
+current ceiling. Chromium runs fully headless; no `DISPLAY` environment
+variable is required.
+
+### 3. CSS token enforcement (optional — run if stylelint is already configured)
+
+```json
+{
+  "plugins": ["stylelint-declaration-strict-value"],
+  "rules": {
+    "scale-unlimited/declaration-strict-value": [
+      ["color", "background-color", "border-color", "font-size"],
+      {
+        "ignoreValues": ["inherit", "transparent", "currentColor"],
+        "message": "Use design tokens (var(--ds-*)) — no hardcoded values"
+      }
+    ]
+  }
+}
+```
+
+Install: `npm install --save-dev stylelint stylelint-declaration-strict-value`
+
+### 4. Visual QA checklist (agent-executable, no tooling)
+
+- [ ] All state variants present in the HTML (loading / empty / error / partial / content / disabled) — not just the happy path
+- [ ] No hardcoded colour or spacing values outside the token-definition block — grep: `grep -E "#[0-9a-fA-F]{3,6}|rgba?\(|hsl\(|[0-9]+px" <file.css>` should return only the `:root` / primitive token-definition block, no other hex, rgb, or px values
+- [ ] Print output correct: if PPT/PDF context, open in browser and trigger print preview — check slide boundaries, colour preservation, no overflow
+- [ ] Screenshot taken and observed: Playwright headless (`page.screenshot()`) or browser devtools screenshot — assert on what you see, not on internal state
+
+---
+
+## Anti-patterns to refuse
+
+| Rationalisation | Reality |
+|---|---|
+| "Accessibility is a nice-to-have for now" | It is a legal requirement in many jurisdictions (WCAG 2.1 AA is the baseline for EU EAA, ADA, and AODA compliance) and an engineering quality standard — not a feature |
+| "We'll make it responsive later" | Retrofitting responsive design is 3× harder than building it from the start; skip this step only if the output is explicitly fixed-dimension (PPT/PDF) |
+| "This is just a prototype" | Prototypes become production code; the AI aesthetic baked in at prototype stage is the AI aesthetic shipped |
+| "The AI aesthetic is fine for now" | It signals low quality to every reviewer who sees it and anchors the design in a direction that is expensive to undo |
+| "I'll add the empty and error states later" | They will not be added; they are spec ACs, not follow-ons |
+| "Skip the design pre-flight — the spec is clear enough" | Technically correct output with no design sense is the exact failure mode this pre-flight prevents; the spec cannot substitute for token constraints |
+| "Use a spinner, it's simpler" | Spinners produce layout shift and feel slower than skeleton screens; use a skeleton when the content shape is known |
+
+---
+
+## Red flags
+
+A reviewer should treat any of these as a blocker:
+
+- Inline `style="…"` attributes or arbitrary pixel values not on the spacing scale
+- Any state variant missing (empty, error, loading, partial) — check by reading the HTML, not by reasoning about the code
+- `outline: none` or `outline: 0` with no visible replacement focus style
+- Color used as the sole state indicator (red/green without accompanying text, icon, or pattern)
+- Generic AI aesthetic visible in the output (purple gradients, equal oversized padding, `border-radius: 16px` on every element, shadow on every card)
+- `aria-expanded`, `aria-selected`, or `aria-sort` set once and never updated
+- A `<div onclick>` where a `<button>` would serve

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -319,6 +319,14 @@ For anything beyond trivial, *think before you write code*. Concretely:
   common failure mode of technically correct surfaces with no design sense. Applies
   in both light and full mode as a recommendation; the mandatory fresh-context
   gate (`experience-reviewer`) runs in REVIEW for full-mode work.
+  **Frontend surface exception — mandatory, not recommended.** When the task's
+  primary output is HTML, CSS, or JS (a new page, component, slide deck,
+  dashboard, or standalone web artifact), this pass is mandatory in both modes:
+  load the `frontend-engineering` skill inline before writing code. It carries
+  the design pre-flight requirements (named aesthetic reference, seed token
+  block, state matrix), the craft rules, and the GATES verification commands
+  for that surface. The judgment call — whether the output is "primary"
+  HTML/CSS/JS or incidental — is the implementer's; when in doubt, load it.
 - **Initialize the loop's state file.** Run this skill's bundled
   `scripts/loop-cohort.py init docs/specs/<feature>`; the tool copies
   the bundled `assets/state.json` template into place, sets `feature`
@@ -384,6 +392,12 @@ heavier infra-flavor layers fire only on the infra-flavored signal), and is for
 the *unfamiliar-contract* case — **not** every import, not familiar code whose
 contract the agent already holds. (Detail in
 [`references/infra-verification.md`](references/infra-verification.md).)
+
+**Frontend-triggered work (HTML/CSS/JS primary output).** When the frontend
+surface trigger fires, the `frontend-engineering` skill has already been
+loaded inline during PLAN. Its craft rules govern all HTML element selection,
+CSS token discipline, accessibility patterns, and state completeness during
+EXECUTE; its GATES section defines the verification commands to run at step 3.
 
 For each task, implement the smallest coherent unit of work toward the
 goal. Resist the urge to fix unrelated things you notice along the way;

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix, contract-acquisition skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "0.10.0"
+version = "0.11.0"
 description = "Core agent-ready-repo: work-loop, new-spec, bug-fix, contract-acquisition skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 readme = "README.md"
 display_name = "Core"


### PR DESCRIPTION
## Summary

- **New skill:** `packs/core/.apm/skills/frontend-engineering/SKILL.md` — a depth skill the work-loop loads inline when a task's primary output is HTML, CSS, or JS. Covers design pre-flight (named aesthetic reference, `--ds-*` three-tier token block, six-state matrix, print/PPT block), AI-aesthetic anti-pattern table (8 rows), HTML/CSS/a11y craft rules (right/wrong form throughout), and GATES verification commands (html-validate, pa11y/axe, stylelint).
- **Work-loop amendment:** Two additive paragraphs — upgrades the design-intent pass from a recommendation to **mandatory** for the frontend surface trigger; routes implementers to the skill's craft rules and GATES section in EXECUTE. Zero deletions; risk-triggers block and reviewer roster byte-unchanged.
- **Core pack:** bumped 0.10.0 → 0.11.0; `marketplace.json` regenerated.

## Motivation

AI-generated frontend code is consistently technically correct but visually inconsistent, semantically wrong, and inaccessible by default. The root cause is no codified rules at EXECUTE time — vague "make it look nice" instructions produce the purple-gradient AI aesthetic. This skill gives the implementing agent specific, checkable rules before any code is written.

Research finding that drove the design: context injection outperforms domain-partitioned subagents (+206% quality) for sequential coding tasks. The right lever is a depth skill loaded inline, not a frontend subagent.

## What's deferred

- `references/` subdirectory depth files (single cohesive file is right for v1; follow-up if adopters request it)
- Verification wrapper scripts under `tools/` (CLI commands are documented; tooling is a follow-up)
- Framework-specific content (React/Vue/Angular) belongs in an opt-in pack, not core

## Test plan

- [ ] `python3 -m agentbundle.build lint-packs --packs-dir packs` exits 0
- [ ] `make build-self FORCE=1` exits 0
- [ ] `ls .claude/skills/frontend-engineering/SKILL.md` exists
- [ ] `grep -c "frontend-engineering" .claude/skills/work-loop/SKILL.md` returns ≥ 2
- [ ] `grep -iE "react|vue|angular|jsx|usestate|useeffect|\bng-|@component|signal\(" packs/core/.apm/skills/frontend-engineering/SKILL.md` returns no hits
- [ ] Adversarial review: Clean (passed two rounds; all blockers and concerns resolved)