### PR TITLE
feat(architect): portable Mermaid title, a11y & pipeline guidance for architect-diagram (architect 0.11.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "architect",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.10.0"
+      "version": "0.11.0"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`architect-diagram` gains portable Mermaid title, accessibility, and pipeline-orientation guidance (architect 0.11.0).** Three Mermaid-native additions to the skill's references: (1) `flowchart LR` is now explicitly the orientation for pipeline / ETL / CI-CD / data-flow diagrams (a decision-table row plus strengthened flowchart guidance); (2) the config-frontmatter `title:` is documented as the in-source diagram title (Mermaid ≥ 10.5), with the prose scope sentence kept as the always-portable baseline; (3) `accTitle` / `accDescr` are documented as the diagram's screen-reader alt text. The change also explicitly rejects three renderer-proprietary conventions (`:::external`, `label\|tech`, `%% title:`) that no-op or break in stock Mermaid (GitHub, Confluence, `mmdc`, and the repo's own renderers) — they contradict the skill's "survive enterprise wiki rendering" north star. Guidance only; no renderer or skill-contract change.
+
 ### Fixed
 
 - **`aesthetic-direction` grounding reference now cites WCAG thresholds by name, not literal values (experience 0.4.1).** The Standards section of the grounding reference described contrast thresholds using specific ratio and point-size literals, which violated RFC-0033's portable-method rule. The section now refers to the named WCAG SC thresholds and the OS-level reduced-motion preference concept rather than reprinting the values table. No change to skill behavior — only the reference prose that informs the aesthetic-direction pass.

--- a/docs/specs/architect-diagram-mermaid-guidance/spec.md
+++ b/docs/specs/architect-diagram-mermaid-guidance/spec.md
@@ -1,0 +1,51 @@
+# Spec: architect-diagram — portable Mermaid guidance
+
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Contract:** none — guidance-only prose edits to skill reference files; no API/event/RPC surface.
+
+Mode: light (no risk trigger fired)
+
+## Objective
+
+Improve `architect-diagram`'s Mermaid guidance with three portable,
+Mermaid-native additions, and explicitly reject three renderer-proprietary
+conventions that were proposed (`:::external`, `label|tech`, `%% title:`) —
+they no-op or break in stock Mermaid (GitHub, Confluence, `mmdc`, and the
+repo's own `render-proof` / `markdown-to-html` CDN renderers), contradicting
+the skill's "survive enterprise wiki rendering" north star.
+
+## Acceptance Criteria
+
+- [x] **AC1 — pipeline/data-flow orientation.** `references/mermaid-flowchart.md`
+      and `references/notation-routing.md` name `flowchart LR` for
+      pipeline / ETL / CI-CD / data-flow diagrams where left-to-right reading
+      order matters (strengthening the existing "best for request flows" text,
+      not duplicating it).
+- [x] **AC2 — portable title mechanism.** `references/mermaid-flowchart.md`
+      documents the Mermaid config-frontmatter `title:` as the in-diagram title
+      mechanism (v10.5+), and `references/diagram-rubric.md`'s universal
+      "Title or scope sentence" bullet references it. The prose scope-sentence
+      baseline stays the always-portable option; the frontmatter title carries
+      the same venue-caveat the skill applies to other version-dependent
+      features.
+- [x] **AC3 — accessibility metadata.** `references/mermaid-flowchart.md`
+      documents `accTitle` / `accDescr` for screen-reader accessibility, noting
+      it applies across diagram types, and `references/diagram-rubric.md` carries
+      a universal accessibility check gated on the target venue exposing it.
+- [x] **AC4 — examples parse.** Every new Mermaid snippet parses under `mmdc`.
+- [x] **AC5 — release surface.** `packs/architect/pack.toml` and
+      `.claude-plugin/plugin.json` bump to `0.11.0`; `.claude-plugin/marketplace.json`
+      regenerated to match; `docs/product/changelog.md [Unreleased]` gains an entry.
+
+## Boundaries
+
+Out of scope: adding the rejected conventions; a label-escaping pitfalls
+section (belongs to a later change if wanted); editing the sequence / state /
+er / c4 syntax references (title + a11y documented once in the flowchart ref
+with a cross-type note); any change to the renderers themselves.
+
+## Testing Strategy
+
+Goal-based: `grep` the new guidance is present; `mmdc` parses each new snippet;
+`python .claude/skills/work-loop/scripts/lint-spec-status.py --root .` clean.

--- a/packs/architect/.apm/skills/architect-diagram/references/diagram-rubric.md
+++ b/packs/architect/.apm/skills/architect-diagram/references/diagram-rubric.md
@@ -18,7 +18,13 @@ check, not a suggestion.
 - [ ] **Edge budget.** Roughly **≤20 edges**. A diagram whose edges dwarf its
       nodes is a hairball; split by scope sentence before adding more.
 - [ ] **Title or scope sentence** above the diagram tells the reader
-      *what they are looking at* without scrolling.
+      *what they are looking at* without scrolling. A prose sentence is
+      the always-portable baseline; a Mermaid config-frontmatter `title:`
+      (see `references/mermaid-flowchart.md`) is the in-source option and
+      augments it. Never a `%% title:` comment — `%%` is dropped.
+- [ ] **Accessibility metadata.** A diagram shipping in a docs page or
+      wiki carries `accTitle` / `accDescr` — the diagram's alt text —
+      unless the target venue is known to strip it.
 - [ ] **No fabricated names** in document mode. Where a name is
       genuinely missing, label `<unnamed>` or ask.
 - [ ] **Renders.** Paste the Mermaid into the live editor and confirm

--- a/packs/architect/.apm/skills/architect-diagram/references/mermaid-flowchart.md
+++ b/packs/architect/.apm/skills/architect-diagram/references/mermaid-flowchart.md
@@ -17,8 +17,53 @@ flowchart TB
 ````
 
 `flowchart TB` is top-to-bottom — best for deployment hierarchies.
-`flowchart LR` is left-to-right — best for request flows. Pick one
+`flowchart LR` is left-to-right — best for anything with a reading
+order: request flows, and **pipelines / ETL / CI-CD stages /
+data-flow** where the eye should track stages start-to-finish. Pick one
 and stick with it within a diagram.
+
+## Title and accessibility metadata
+
+Give the diagram an in-source title with Mermaid's **config frontmatter**
+(a YAML block fenced by `---` at the very top of the Mermaid source,
+Mermaid ≥ 10.5) — it renders as a heading above the diagram:
+
+````
+```mermaid
+---
+title: Order ingestion pipeline
+---
+flowchart LR
+    Ingest --> Validate --> Ledger
+```
+````
+
+This is the portable version of a diagram title — it renders in current
+Mermaid (`mmdc` and the repo's `render-proof` / `markdown-to-html`
+renderers pin `mermaid@11`). It is still a version-dependent feature, so
+carry the same venue caveat the skill applies to `architecture-beta` /
+`timeline` and friends: **the prose scope sentence above the diagram
+stays the always-portable baseline** — the frontmatter title augments it,
+it doesn't replace it. Do **not** reach for a `%% title:` comment: `%%`
+is Mermaid's comment marker and is dropped by every renderer.
+
+For screen-reader accessibility, add `accTitle` (short) and `accDescr`
+(longer) inside the diagram body — they emit to the SVG's `<title>` /
+`<desc>` and are supported across diagram types (flowchart, sequence,
+state, er, …), not just flowcharts:
+
+````
+```mermaid
+flowchart LR
+    accTitle: Order ingestion pipeline
+    accDescr: Ingest validates each order, then writes it to the ledger.
+    Ingest --> Validate --> Ledger
+```
+````
+
+Recommended for any diagram that will ship in a docs page or wiki; it is
+the diagram analogue of alt text. Renderers vary in whether they expose
+it, so treat it as reinforcement, never the sole carrier of meaning.
 
 ## Node shapes (architecture-relevant)
 

--- a/packs/architect/.apm/skills/architect-diagram/references/notation-routing.md
+++ b/packs/architect/.apm/skills/architect-diagram/references/notation-routing.md
@@ -12,6 +12,7 @@ notation is the most common reason a diagram is unreadable.
 | "What states does this go through" — lifecycle | State diagram | `stateDiagram-v2` |
 | "What is the shape of the data" — model | Entity-relationship | `erDiagram` |
 | "Where does it run" — deployment / infra | Deployment view | `flowchart TB` with subgraph nesting for region / VPC / subnet |
+| "How does data move through the stages" — pipeline / ETL / CI-CD / data-flow | Left-to-right flow | `flowchart LR` (reading order is the point) |
 | "Who decided what when" — workflow / approvals | Flowchart with decision diamonds | `flowchart TD` |
 | "What happened when" — roadmap / chronology / release history | Timeline † | `timeline` |
 | "Prioritize these" — 2×2 / effort-vs-impact / positioning | Quadrant † | `quadrantChart` |

--- a/packs/architect/.claude-plugin/plugin.json
+++ b/packs/architect/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "architect",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Solution-architecture skills (architect-design, architect-diagram, architect-review) plus a forked-context design-reviewer subagent. Workspace-agnostic, user-scope by default, no required configuration."
 }

--- a/packs/architect/pack.toml
+++ b/packs/architect/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "architect"
-version = "0.10.0"
+version = "0.11.0"
 description = "Solution-architecture skills (architect-design, architect-diagram, architect-review) plus a forked-context design-reviewer subagent. Workspace-agnostic, user-scope by default, no required configuration. Mermaid for diagrams; Google-style design docs; rubric-routed critique."
 readme = "README.md"
 display_name = "Architect"


### PR DESCRIPTION
## What does this change?

Adds three portable, Mermaid-native guidance improvements to the `architect-diagram` skill — `flowchart LR` for pipeline/data-flow diagrams, config-frontmatter `title:`, and `accTitle`/`accDescr` accessibility metadata — and explicitly rejects three renderer-proprietary conventions (`:::external`, `label|tech`, `%% title:`) that no-op or render as literal text in stock Mermaid.

## Why?

A user proposed four conventions for the skill. Investigation showed three of them describe a renderer this repo does not have: every renderer here — `mermaid-renderer` (via `mmdc`), `render-proof`, and `markdown-to-html` — uses stock Mermaid v11, which drops `:::external` (no `classDef`), drops `%% title:` (it's a comment), and renders `label|tech` as literal text. Teaching agents to emit that syntax contradicts the skill's "survive enterprise wiki rendering" north star. The one sound proposal (`flowchart LR` for pipelines) is adopted; the other three intents are met with their portable Mermaid-native equivalents instead.

- Implements: `docs/specs/architect-diagram-mermaid-guidance/spec.md`

## How do I verify it?

- `python3 .claude/skills/work-loop/scripts/lint-spec-status.py --root .` → clean
- `python3 -m agentbundle.build lint-packs --packs-dir packs` → exit 0
- Both new Mermaid snippets parse under `mmdc` (v11.15); frontmatter `title:` renders to a heading and `accTitle`/`accDescr` emit to SVG `<title>`/`<desc>` (confirmed on generated SVG)
- `marketplace.json` diff is the single architect `0.10.0 → 0.11.0` version field

## What did you not change that you considered?

- **A label-escaping pitfalls section** — genuinely useful, but out of the endorsed scope for this change; deferred to a future edit if wanted.
- **Editing the sequence/state/er/c4 syntax references** — title + accessibility metadata are documented once in the workhorse `mermaid-flowchart.md` with an explicit "applies to all diagram types" note, rather than duplicated across six files.
- **Making `accTitle`/`accDescr` a hard rubric non-negotiable** — enterprise wikis vary in exposing it, so it's a venue-gated check, consistent with the skill's existing caveat discipline for `timeline`/`quadrant`/`architecture-beta`.
- **A renderer change** — none of the renderers were touched; this is guidance-only.

## Checklist

- [x] Lint passes (`lint-spec-status.py`, `lint-packs`)
- [x] Self-review run via `adversarial-reviewer`; both findings addressed (spec status flipped to Shipped + ACs checked; a11y rubric line reframed as a gated check)
- [x] Spec and code agree (light-mode spec, all 5 ACs checked, status Shipped)
- [x] `docs/product/changelog.md` updated
- [x] No new top-level directories
- [x] Conventional commit format