### PR TITLE
docs(core): call out frontend-engineering in pack description and website docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -92,7 +92,7 @@
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",
       "category": "governance",
-      "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix, contract-acquisition skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds.",
+      "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix, frontend-engineering, contract-acquisition skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds.",
       "displayName": "Core",
       "homepage": "https://github.com/eugenelim/agent-ready-repo",
       "keywords": [

--- a/docs/guides/core/explanation/core-pack.md
+++ b/docs/guides/core/explanation/core-pack.md
@@ -48,6 +48,8 @@ The reviewers are diff-source-agnostic — the work loop points them at your own
 
 Plus a sibling skill that runs alongside the six: **`bug-fix`** ships in `core` too and runs a parallel discipline (reproduce → red test → root vs. symptom → minimum fix → regression test stays) without entering the spec / loop pipeline. It composes with `work-loop` when the fix grows past one file. See [how to fix a bug](../how-to/bug-fix.md).
 
+And a depth skill the loop reaches for by surface: **`frontend-engineering`** is loaded inline by `work-loop` whenever a task's primary output is HTML, CSS, or JS. It carries the design pre-flight (a named aesthetic reference, a seed token block, the six-state matrix), the codified craft rules that govern EXECUTE, and the GATES verification commands (html-validate, pa11y/axe, stylelint) — and it upgrades the design-intent pass from a recommendation to mandatory for that surface. It has no user-prompt activation surface of its own; the loop pulls it in, the way it pulls in `security-checklists` and `operational-safety` for the reviewers.
+
 ## How they tie together
 
 A feature lifecycle, end to end, with the parts named:

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
   "version": "0.11.0",
-  "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix, contract-acquisition skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
+  "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix, frontend-engineering, contract-acquisition skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 }

--- a/packs/core/README.md
+++ b/packs/core/README.md
@@ -1,7 +1,9 @@
 # core
 
 The core pack ships the agent-ready-repo skills (work-loop, new-spec,
-new-rfc, …), the four specialist subagents (adversarial-reviewer,
+new-rfc, …) — including `frontend-engineering`, the depth skill the
+work-loop loads inline whenever a task's primary output is HTML, CSS,
+or JS — the four specialist subagents (adversarial-reviewer,
 security-reviewer, quality-engineer, implementer), the canonical
 session-start and work-loop-check hooks, and the `/adapt-to-project`
 command.

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,7 +1,7 @@
 [pack]
 name = "core"
 version = "0.11.0"
-description = "Core agent-ready-repo: work-loop, new-spec, bug-fix, contract-acquisition skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
+description = "Core agent-ready-repo: work-loop, new-spec, bug-fix, frontend-engineering, contract-acquisition skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 readme = "README.md"
 display_name = "Core"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
## What

The \`frontend-engineering\` skill shipped in core 0.11.0 (#502) but was never surfaced in the catalogue-facing pack description or on the website. This adds it to those surfaces so adopters can discover it.

## Changes

- **`packs/core/pack.toml`** — add \`frontend-engineering\` to the pack \`description\`, synced byte-identical to its two projections (\`packs/core/.claude-plugin/plugin.json\`, \`.claude-plugin/marketplace.json\`) so the drift gate stays clean.
- **`packs/core/README.md`** (renders as the \`packs/core.md\` site page) — call out \`frontend-engineering\` as the depth skill the work-loop loads inline whenever a task's primary output is HTML, CSS, or JS.
- **`docs/guides/core/explanation/core-pack.md`** (mirrored into the site guides) — add a paragraph in "The parts" describing what it carries (design pre-flight, craft rules, GATES) and that, like \`security-checklists\`/\`operational-safety\`, it has no user-prompt activation surface of its own.

## Notes / deferred

- **No version bump.** The description is catalogue-facing metadata, not a functional change, and the skill's addition is already logged under changelog \`[Unreleased]\`. Happy to cut a \`0.11.1\` if a clean catalogue re-publish is wanted.
- **Left the terse packs-index blurb** (\`tools/build-site.py:30\`) unchanged — that's the pack's elevator pitch where the build loop is the headline; a depth skill doesn't belong in the one-liner.
- Verified: \`tools/build-site.py --dry-run\` passes; the description string is byte-identical across all three manifest files.