### PR TITLE
fix(web): set Astro base to /agent-ready-repo (Pages sub-path)

### DIFF
--- a/docs/adr/0050-astro-marketing-site-toolchain-and-deploy.md
+++ b/docs/adr/0050-astro-marketing-site-toolchain-and-deploy.md
@@ -30,7 +30,7 @@ Concretely:
 - `web/astro.config.ts` sets `outDir: '../build'`; `site/mkdocs.yml` sets `site_dir: ../build/docs`.
 - **Build order is load-bearing:** `astro build` cleans its `outDir` (`build/`) on every run, so Astro MUST build before MkDocs writes into `build/docs/` — otherwise MkDocs output is silently wiped. `.github/workflows/pages.yml` sequences Node/Astro steps before the Python/MkDocs steps and uploads `./build`.
 - The design-system `--ds-*` token block is the sole colour/spacing authority on the Astro surface; **no CSS framework** (Tailwind, Bootstrap, UnoCSS) is used.
-- For Phase 1 the Astro `base` is left at `/` (root-served); the production sub-path (`/agent-ready-repo/`) is still to be confirmed (information-architecture.md) and is the trigger to set `base`.
+- The site is a GitHub Pages **project site** served under `/agent-ready-repo/`, so `web/astro.config.ts` sets `base: '/agent-ready-repo'`. Astro auto-prefixes its own bundled assets with `base`; hardcoded internal hrefs go through `src/lib/paths.ts` `withBase()`. (No custom domain — confirmed 2026-07-16.)
 
 ## Decision drivers
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1422,9 +1422,7 @@ the diagram.
 
 ### github-pages-first-deploy-verification
 
-**Source:** platform-site spec Phase 1 (RFC-0061 / ADR-0050). The "single GitHub Pages deploy serves Astro at `/` and MkDocs at `/docs/`" acceptance criterion can only be confirmed on the first live deploy from `main`. Locally the combined artifact is verified (`build/index.html` + `build/docs/index.html` coexist after Astro-then-MkDocs), but the served result — including whether the site sits at the origin root or the `/agent-ready-repo/` project sub-path, which decides the Astro `base` setting — is only observable once Pages publishes.
-
-**Unblocks when:** Phase 1 merges to `main` and the Pages deploy runs; verify `/` serves the Astro homepage and `/docs/` serves MkDocs, then confirm/adjust `web/astro.config.ts` `site`/`base` for the actual origin path. Tied to the forward-link decision (nav/CTA links to `/packs/` and `/journeys/` go live with Phase 2).
+**Resolved 2026-07-16.** Phase 1 merged (PR #507) and deployed. The first deploy revealed the site is a GitHub Pages **project site** served under `/agent-ready-repo/`, so `base: '/'` produced root-relative asset paths that 404'd (unstyled homepage). Fixed by setting `base: '/agent-ready-repo'` in `web/astro.config.ts` (no custom domain — owner-confirmed) and routing internal hrefs through `src/lib/paths.ts` `withBase()`; redeployed and verified live: `/agent-ready-repo/` serves the styled Astro homepage, `/agent-ready-repo/docs/` serves MkDocs. Forward-links to `/packs/` and `/journeys/` remain 404 until Phase 2 (accepted).
 
 ### catalogue-curation-retire-primitive
 

--- a/docs/specs/platform-site/plan.md
+++ b/docs/specs/platform-site/plan.md
@@ -398,8 +398,10 @@ Fully static Astro site. Client-side interactivity is minimal and JS-free where 
   section 9 is homepage-specific; it still merges visually with the dark footer.
   (b) Added a reusable `Section.astro` band wrapper (not in the decomposition) to
   keep the six content sections DRY. (c) `astro.config` is `.ts` per the plan;
-  `base` left at `/` for Phase 1 (root-served, matching the pa11y gate) — the
-  production sub-path is still to be confirmed (information-architecture.md).
+  `base` set to `/agent-ready-repo` (GitHub Pages project sub-path, no custom
+  domain — owner-confirmed 2026-07-16) after the first deploy showed root-relative
+  asset paths 404 at the sub-path; internal hrefs routed through
+  `src/lib/paths.ts` `withBase()`; dev server + pa11y now target `/agent-ready-repo/`.
   (d) RFC-0061 accepted; its follow-on ADR (Astro SSG + one-Pages-deploy + Node
   dependency) and `web/AGENTS.md` dependency record co-land in this PR.
   (e) PackCatalogue uses a `<details>` expander with a visible "See all 14 packs →"

--- a/docs/specs/platform-site/spec.md
+++ b/docs/specs/platform-site/spec.md
@@ -148,7 +148,7 @@ This spec uses goal-based checks and visual/manual QA. The Astro marketing site 
 - [x] Install section renders 4 tabs: Flagship loop, With discovery, Full inception, Solution architect (CSS-only radio-group tabs, zero JS)
 - [x] Nav matches [information-architecture.md](information-architecture.md): `Logo | How it works | Packs | Journeys | Docs ↗ | [Install →]`
 - [x] No inline `style=""` attributes and no hardcoded color values outside the token block; layout spacing (section/card padding, gaps, margins) uses the `--ds-space-*` / `--ds-radius-*` scale, except values the scale does not cover: media-query breakpoints, 1px/2px hairline borders, decorative icon sizing, component `max-width`s, the CTA padding `0.7rem 1.6rem` from design-system-foundations.md, and the sub-`--ds-space-1` micro-padding on inline chips/badges/pills, inline code, and the compact nav CTA (values below the 4px scale floor, where a token would be less legible than the literal)
-- [x] `npx pa11y http://localhost:4321 --standard WCAG2AA` exits with 0 errors
+- [x] `npx pa11y http://localhost:4321/agent-ready-repo/ --standard WCAG2AA` exits with 0 errors (the dev server serves under the configured `base`; the root path 404s by design)
 - [x] `/404.html` branded 404 page emitted (via `web/src/pages/404.astro`)
 
 ### Phase 2 — Pack catalogue and journey pages
@@ -180,7 +180,7 @@ This spec uses goal-based checks and visual/manual QA. The Astro marketing site 
 
 - [x] GitHub Actions workflow: Astro builds first → MkDocs builds second → artifact uploaded from `build/` (verified locally end-to-end: `build/index.html` and `build/docs/index.html` coexist, proving Astro's outDir clean does not wipe MkDocs output)
 - [x] `site/mkdocs.yml` `site_dir` is `../build/docs`
-- [ ] Single GitHub Pages deploy serves Astro at `/` and MkDocs at `/docs/` (deferred: github-pages-first-deploy-verification — artifact structure verified locally, live serving confirmed on first deploy from `main`)
+- [x] Single GitHub Pages deploy serves Astro at `/` (project sub-path `/agent-ready-repo/`) and MkDocs at `/docs/` — verified live after the first deploy from `main`; `base: '/agent-ready-repo'` set in `astro.config.ts` so assets/links resolve under the sub-path
 
 ## Assumptions
 

--- a/web/astro.config.ts
+++ b/web/astro.config.ts
@@ -7,9 +7,11 @@ import { defineConfig } from 'astro/config';
 // Astro must build BEFORE MkDocs writes into `build/docs/`. See
 // .github/workflows/pages.yml.
 export default defineConfig({
-  // GitHub Pages origin. `base` is intentionally left at `/`: Phase 1 serves at
-  // the root locally (the pa11y gate targets http://localhost:4321) and the
-  // production deploy sub-path is still to be confirmed (information-architecture.md).
+  // GitHub Pages project site: served under the /agent-ready-repo/ sub-path, so
+  // `base` must match or absolute asset/link paths resolve against the origin
+  // root and 404. Astro auto-prefixes its own bundled assets with `base`;
+  // hardcoded internal hrefs go through src/lib/paths.ts `withBase()`.
   site: 'https://eugenelim.github.io',
+  base: '/agent-ready-repo',
   outDir: '../build',
 });

--- a/web/src/components/layout/SiteFooter.astro
+++ b/web/src/components/layout/SiteFooter.astro
@@ -1,6 +1,7 @@
 ---
 // Footer — dark zone. Section 9 ("Build Your Org") closer is added in T6 above
 // these links; for now this is the minimal footer (GitHub, PyPI, Docs).
+import { withBase } from '../../lib/paths';
 const year = new Date().getFullYear();
 ---
 
@@ -8,7 +9,7 @@ const year = new Date().getFullYear();
   <div class="footer__inner">
     <p class="footer__brand">agent-ready-repo</p>
     <nav class="footer__links" aria-label="Footer">
-      <a href="/docs/" rel="noopener">Docs</a>
+      <a href={withBase('/docs/')} rel="noopener">Docs</a>
       <a href="https://github.com/eugenelim/agent-ready-repo" rel="noopener">GitHub</a>
       <a href="https://pypi.org/project/agentbundle/" rel="noopener">PyPI</a>
     </nav>

--- a/web/src/components/layout/SiteLayout.astro
+++ b/web/src/components/layout/SiteLayout.astro
@@ -2,6 +2,7 @@
 import '../../styles/global.css';
 import SiteNav from './SiteNav.astro';
 import SiteFooter from './SiteFooter.astro';
+import { withBase } from '../../lib/paths';
 
 interface Props {
   title: string;
@@ -19,7 +20,7 @@ const {
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href={withBase('/favicon.svg')} />
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
     <meta name="description" content={description} />

--- a/web/src/components/layout/SiteNav.astro
+++ b/web/src/components/layout/SiteNav.astro
@@ -3,28 +3,32 @@
 // Mobile menu is a <details>/<summary> disclosure: zero JavaScript.
 // Nav structure from information-architecture.md:
 //   Logo | How it works | Packs | Journeys | Docs ↗ | [Install →]
+import { withBase } from '../../lib/paths';
 const links = [
-  { label: 'How it works', href: '/#three-loops' },
-  { label: 'Packs', href: '/packs/' },
-  { label: 'Journeys', href: '/journeys/' },
+  { label: 'How it works', href: withBase('/#three-loops') },
+  { label: 'Packs', href: withBase('/packs/') },
+  { label: 'Journeys', href: withBase('/journeys/') },
 ];
+const homeHref = withBase('/');
+const docsHref = withBase('/docs/');
+const installHref = withBase('/#install');
 ---
 
 <nav class="nav" aria-label="Primary">
   <div class="nav__inner">
-    <a class="nav__logo" href="/">agent-ready-repo</a>
+    <a class="nav__logo" href={homeHref}>agent-ready-repo</a>
 
     <ul class="nav__links">
       {links.map((l) => (
         <li><a class="nav__link" href={l.href}>{l.label}</a></li>
       ))}
       <li>
-        <a class="nav__link nav__link--docs" href="/docs/" rel="noopener">
+        <a class="nav__link nav__link--docs" href={docsHref} rel="noopener">
           Docs <span aria-hidden="true">↗</span>
         </a>
       </li>
       <li>
-        <a class="nav__cta" href="/#install">Install <span aria-hidden="true">→</span></a>
+        <a class="nav__cta" href={installHref}>Install <span aria-hidden="true">→</span></a>
       </li>
     </ul>
 
@@ -37,12 +41,12 @@ const links = [
           <li><a class="nav__link" href={l.href}>{l.label}</a></li>
         ))}
         <li>
-          <a class="nav__link nav__link--docs" href="/docs/" rel="noopener">
+          <a class="nav__link nav__link--docs" href={docsHref} rel="noopener">
             Docs <span aria-hidden="true">↗</span>
           </a>
         </li>
         <li>
-          <a class="nav__cta" href="/#install">Install <span aria-hidden="true">→</span></a>
+          <a class="nav__cta" href={installHref}>Install <span aria-hidden="true">→</span></a>
         </li>
       </ul>
     </details>

--- a/web/src/components/marketing/BuildYourOrg.astro
+++ b/web/src/components/marketing/BuildYourOrg.astro
@@ -4,6 +4,7 @@
 // dark band — the only second dark band, reading as closure not interruption
 // (aesthetic-direction.md / homepage-screen-flow.md §9).
 import Section from '../layout/Section.astro';
+import { withBase } from '../../lib/paths';
 ---
 
 <Section tone="dark" labelledby="org-heading">
@@ -15,7 +16,7 @@ import Section from '../layout/Section.astro';
       one catalogue every engineer installs in a single line — the loop, the reviewers,
       and the standards come out identical on every machine and in every agent.
     </p>
-    <a class="org__cta" href="/docs/guides/_shared/how-to/build-an-org-stack-pack/">
+    <a class="org__cta" href={withBase('/docs/guides/_shared/how-to/build-an-org-stack-pack/')}>
       How to build your org's catalogue <span aria-hidden="true">→</span>
     </a>
   </div>

--- a/web/src/components/marketing/Hero.astro
+++ b/web/src/components/marketing/Hero.astro
@@ -3,6 +3,7 @@
 // nav above and the stat strip below. Radial amber glow + faint grid texture
 // (matching the MkDocs hero). One-shot 300ms opacity fade-in on load, guarded
 // by prefers-reduced-motion. No looping animation (aesthetic-direction.md).
+import { withBase } from '../../lib/paths';
 ---
 
 <section class="hero">
@@ -14,10 +15,10 @@
       can't certify its own work.
     </p>
     <div class="hero__actions">
-      <a class="hero__cta hero__cta--primary" href="/#install">
+      <a class="hero__cta hero__cta--primary" href={withBase('/#install')}>
         Install the core loop <span aria-hidden="true">→</span>
       </a>
-      <a class="hero__cta hero__cta--ghost" href="/packs/">
+      <a class="hero__cta hero__cta--ghost" href={withBase('/packs/')}>
         See the packs <span aria-hidden="true">→</span>
       </a>
     </div>

--- a/web/src/components/marketing/HumanGates.astro
+++ b/web/src/components/marketing/HumanGates.astro
@@ -3,6 +3,7 @@
 // comes from amber-bordered gate cards, not a dark band (aesthetic-direction.md:
 // one dark zone only; a light interruption between two dark bands disorients).
 import Section from '../layout/Section.astro';
+import { withBase } from '../../lib/paths';
 
 const gates = [
   { id: 'G0', name: 'Go / No-go', loop: 'Discovery', decide: 'Is this idea worth exploring?' },
@@ -37,7 +38,7 @@ const gates = [
     ))}
   </ul>
 
-  <a class="gates__cta" href="/journeys/core/">Explore a full journey <span aria-hidden="true">→</span></a>
+  <a class="gates__cta" href={withBase('/journeys/core/')}>Explore a full journey <span aria-hidden="true">→</span></a>
 </Section>
 
 <style>

--- a/web/src/components/marketing/PackCatalogue.astro
+++ b/web/src/components/marketing/PackCatalogue.astro
@@ -3,6 +3,7 @@
 // are always visible (large cards); the remaining 11 packs live behind a
 // <details> expander — zero JS. 3-always + 11-on-reveal (homepage-screen-flow.md).
 import Section from '../layout/Section.astro';
+import { withBase } from '../../lib/paths';
 
 const loops = [
   {
@@ -62,7 +63,7 @@ const repoPacks = [
         </div>
         <p class="loop-card__desc">{p.desc}</p>
         <p class="loop-card__install"><code>{p.install}</code></p>
-        <a class="loop-card__link" href={p.journey}>Read the journey <span aria-hidden="true">→</span></a>
+        <a class="loop-card__link" href={withBase(p.journey)}>Read the journey <span aria-hidden="true">→</span></a>
       </li>
     ))}
   </ul>

--- a/web/src/components/marketing/ThreeLoops.astro
+++ b/web/src/components/marketing/ThreeLoops.astro
@@ -2,6 +2,7 @@
 // Section 4 — HOW IT WORKS (Three supervised loops). Light zone (surface-alt).
 // Staged, not a grid — one loop per moment, showing the handoff chain.
 import Section from '../layout/Section.astro';
+import { withBase } from '../../lib/paths';
 
 const loops = [
   {
@@ -69,7 +70,7 @@ const pipelineGates = ['G3', 'G4'];
           <p class="loop__pack"><code>{l.pack}</code></p>
           <p class="loop__desc">{l.desc}</p>
           <p class="loop__gate"><strong>Human gate.</strong> {l.gate}</p>
-          <a class="loop__link" href={l.href}>{l.linkLabel} <span aria-hidden="true">→</span></a>
+          <a class="loop__link" href={withBase(l.href)}>{l.linkLabel} <span aria-hidden="true">→</span></a>
         </div>
       </li>
     ))}

--- a/web/src/lib/paths.ts
+++ b/web/src/lib/paths.ts
@@ -1,0 +1,11 @@
+// Prefix an internal absolute path with the configured base (`import.meta.env.BASE_URL`,
+// e.g. '/agent-ready-repo/' in production, '/' in a root-served build). Astro
+// auto-prefixes its own bundled assets, but hardcoded hrefs in markup are not
+// rewritten — route every internal link through here. External URLs pass through.
+const base = import.meta.env.BASE_URL;
+
+export function withBase(path: string): string {
+  if (/^https?:\/\//.test(path) || path.startsWith('mailto:')) return path;
+  const b = base.endsWith('/') ? base.slice(0, -1) : base;
+  return b + (path.startsWith('/') ? path : `/${path}`);
+}

--- a/web/src/pages/404.astro
+++ b/web/src/pages/404.astro
@@ -3,6 +3,7 @@
 // when this file exists (it is NOT automatic). Listed as a Phase-1 deliverable
 // in the platform-site spec inventory.
 import SiteLayout from '../components/layout/SiteLayout.astro';
+import { withBase } from '../lib/paths';
 ---
 
 <SiteLayout title="Page not found — agent-ready-repo">
@@ -15,8 +16,8 @@ import SiteLayout from '../components/layout/SiteLayout.astro';
         homepage or browse the reference docs.
       </p>
       <div class="notfound__actions">
-        <a class="notfound__cta notfound__cta--primary" href="/">Back home</a>
-        <a class="notfound__cta notfound__cta--ghost" href="/docs/">Read the docs</a>
+        <a class="notfound__cta notfound__cta--primary" href={withBase('/')}>Back home</a>
+        <a class="notfound__cta notfound__cta--ghost" href={withBase('/docs/')}>Read the docs</a>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Fix: unstyled live homepage

The Phase-1 deploy (PR #507) published under the GitHub Pages **project sub-path** `https://eugenelim.github.io/agent-ready-repo/`, but `base` was `/`. Astro's root-relative asset paths (`/_astro/*.css`) resolved against the origin root (`https://eugenelim.github.io/_astro/…` → 404), so the homepage rendered **unstyled**.

## Change

- `astro.config.ts`: `base: '/agent-ready-repo'` (no custom domain — owner-confirmed). Astro auto-prefixes its bundled assets.
- New `src/lib/paths.ts` `withBase()` helper; every hardcoded internal href (nav, CTAs, favicon, journey/docs links, 404) now routes through it. No bare-absolute internal links remain in the build output.
- Docs synced: ADR-0050, spec Phase-1 ACs (pa11y URL → `/agent-ready-repo/`, deploy AC now met), plan changelog, backlog (`github-pages-first-deploy-verification` resolved).

## Verification

- Built artifact references `/agent-ready-repo/_astro/…css`; `grep` confirms zero bare-absolute internal hrefs.
- Dev server serves at `/agent-ready-repo/` (root 404s by design); `pa11y` clean on `/agent-ready-repo/` and `/agent-ready-repo/404`.
- Full pipeline produces `build/index.html` + `build/docs/index.html`.
- Live verification of the styled site follows this merge + redeploy.
