### PR TITLE
feat(web): platform-site Phase 2 — pack catalogue + journey pages

### DIFF
--- a/docs/specs/platform-site/journey-page-template.md
+++ b/docs/specs/platform-site/journey-page-template.md
@@ -88,7 +88,7 @@ Every journey page uses this section sequence. Content varies; structure does no
 
 ### Section 1 — Pack hero
 **Component:** `JourneyHero.astro`  
-**Surface:** Dark zone
+**Surface:** Light zone (`--ds-surface-alt`) — override: owner decision (2026-07-16) — journey pages are fully light zone for consistency with the homepage Human Gates section; amber accents provide visual weight without a dark band
 
 Elements:
 - Pack name (display scale, amber)
@@ -122,58 +122,40 @@ Example for `core`:
 ---
 
 ### Section 4 — The journey (staged narrative)
-**Component:** `JourneyStage.astro` (one per stage)  
-**Surface:** Alternating light / slightly-lighter
+**Component:** Markdown body (`<Content />` rendered from the journey `.md` file)  
+**Surface:** Light zone
 
-**Job:** Walk through a real session. Each stage is a numbered step showing what the agent does and what the human does. This is the primary content — the rest is scaffolding for it.
+**Job:** Walk through a real session in past tense, second person. Each stage is a named step describing what happened — what the agent did and what the human did. This is the primary content — the rest is scaffolding for it.
 
-Each stage block contains:
+**Authoring convention (per journey `.md` body):**
 
-```
-┌─────────────────────────────────────────────────────┐
-│  Stage N — [Stage label]                            │
-│  Initiated by: [human prompt / previous stage]      │
-├─────────────────────────────────────────────────────┤
-│  AGENT DOES                                         │
-│  [Bullet list — what the agent does, not will do]   │
-│                                                     │
-│  YOU DO          ← amber left-border, distinct bg   │
-│  [What the human does at this stage]                │
-│                                                     │
-│  ⚑ GATE: [gate label]  ← if this stage has a gate │
-│  [What to check — see gate detail below]            │
-└─────────────────────────────────────────────────────┘
-```
+- Use past tense, second person: "You opened a task. The agent activated `work-loop`."
+- Name the skill, not just the loop: "The agent ran `adversarial-reviewer` in a fresh session."
+- Name the failure mode at every gate — what does a bad plan look like? What does a bad PR look like?
+- Each stage has a `**You did:**` paragraph describing the human's active role — watching at key moments, redirecting, reading output, making decisions. Do not write "You did: Nothing."
 
 **Example stage sequence for `core` / `work-loop`:**
 
-**Stage 1 — Brief the loop**
-- Initiated by: You write a task description to your agent
-- Agent does: Activates `work-loop`. Checks whether it's light or full mode. Writes the lean inline spec (trio: problem, user, success criteria). Identifies risk triggers. Surfaces assumptions.
-- You do: Read the trio. Confirm the scope is correct. If a risk trigger fires, confirm the mode is right.
-- Gate: Plan approval (see gate detail below)
+```markdown
+## Stage 1 — Brief the loop
+You described the task. The agent activated `work-loop`, checked for risk triggers,
+wrote the inline spec (trio: problem, user, success criteria), and surfaced assumptions.
 
-**Stage 2 — Execution**
-- Initiated by: Your plan approval
-- Agent does: Implements against the spec. Runs lint, typecheck, and tests. If any gate fails, loops to fix before proceeding.
-- You do: Nothing during execution — the agent runs the gates. You'll be called back only if the agent hits a blocker it can't resolve.
+**You did:** Read the trio. Confirmed scope. Approved the plan. 5–10 minutes.
 
-**Stage 3 — Specialist review**
-- Initiated by: Mechanical gates passing
-- Agent does: Runs `adversarial-reviewer` in a fresh session. May also run `security-reviewer` or `quality-engineer` if risk triggers fired. Each reviewer reads the diff cold — no context from the build session.
-- You do: Nothing — reviewers run unattended. The loop iterates until the reviewer reports clean.
+## Stage 2 — Execution
+The agent implemented against the spec, running lint, typecheck, and tests after
+each logical change. When a gate failed, it fixed and re-ran before continuing.
 
-**Stage 4 — PR and merge**
-- Initiated by: All reviewers reporting clean
-- Agent does: Opens the PR with a description including: what changed, why, what was deferred, what was found mid-implementation.
-- You do: Review the PR. Check that the spec and implementation align. Merge when satisfied.
-- Gate: G4 — Merge the PR (see gate detail below)
+**You did:** Watched at key moments — skimmed output after each logical task.
+Answered quickly if the agent surfaced a question. Let it run when all was well.
+```
 
 ---
 
 ### Section 5 — Human gates (detailed)
 **Component:** `GateDetail.astro`  
-**Surface:** Dark zone (second dark band — visual weight signals importance)
+**Surface:** Light zone (`--ds-surface-alt`) — override: owner decision (2026-07-16) — amber left-border cards on light background provide the visual weight; no dark band needed
 
 **Job:** For each gate, give the human everything they need to make a confident decision. This is the section that makes the page distinctive — no other resource explains what the human actually does at each gate.
 
@@ -217,19 +199,18 @@ For `core`: Screenshot of a clean PR description showing the trio, what was defe
 ---
 
 ### Section 7 — Typical session shape
-**Component:** `StatStrip.astro` (reused)  
+**Component:** Inline `.session-stats` grid (bespoke, not a shared component)  
 **Surface:** Light zone
 
-Three or four stats from the frontmatter:
+Three stats from the `typicalSession` frontmatter field:
 - Agent turns (range)
 - Human touches
 - Wall-clock time
-- Gates passed (mechanical)
 
 ---
 
 ### Section 8 — Install and next steps
-**Component:** `InstallTerminal.astro` (reused, compact variant)  
+**Component:** Inline `.install-block` (bespoke, not a shared component)  
 **Surface:** Light zone (`--ds-surface-alt`)
 
 Install command from frontmatter.

--- a/docs/specs/platform-site/spec.md
+++ b/docs/specs/platform-site/spec.md
@@ -79,8 +79,8 @@ Two journey slugs differ from their pack slugs: `discovery` → `product-enginee
 | Phase | Scope | Status |
 |---|---|---|
 | 0 — MkDocs token alignment | Amber-gold CSS swap; global primary button override | Complete (all ACs met) |
-| 1 — Astro scaffold + homepage | Astro in `web/`, 9 homepage sections, CI pipeline | In progress (this PR — homepage + CI built; `/packs/` and `/journeys/` routes land in Phase 2) |
-| 2 — Pack catalogue + core journeys | 14 pack pages + journey index + 3 core journey pages | Planned |
+| 1 — Astro scaffold + homepage | Astro in `web/`, 9 homepage sections, CI pipeline | Complete (all ACs met; shipped in Phase 1 PR) |
+| 2 — Pack catalogue + core journeys | 14 pack pages + journey index + 3 core journey pages | Complete (all ACs met) |
 | 3 — Priority-2 journeys | research, architect, experience, contracts, converters, atlassian | Planned (content-gated) |
 | 4 — Remaining journeys + SEO | figma, governance-extras, credential-brokers, monorepo-extras, user-guide-diataxis; SEO metadata + sitemap | Planned (content-gated) |
 
@@ -153,11 +153,11 @@ This spec uses goal-based checks and visual/manual QA. The Astro marketing site 
 
 ### Phase 2 — Pack catalogue and journey pages
 
-- [ ] `/packs/` renders an index of all 14 packs with name, scope tag, and tagline
-- [ ] Each of the 14 packs has a `/packs/[slug]` page with: header, scope badge, skill list, install command, and journey link
-- [ ] Each pack detail page shows: pack name, scope badge (`user`|`repo`), full skill list, install command, and a link to its journey page (or a "coming soon" state for packs whose journey page is not yet live)
-- [ ] Journey page template renders the 8-section structure from [journey-page-template.md](journey-page-template.md)
-- [ ] Three core journey pages authored: `/journeys/core`, `/journeys/discovery`, `/journeys/release`
+- [x] `/packs/` renders an index of all 14 packs with name, scope tag, and tagline
+- [x] Each of the 14 packs has a `/packs/[slug]` page with: header, scope badge, skill list, install command, and journey link
+- [x] Each pack detail page shows: pack name, scope badge (`user`|`repo`), full skill list, install command, and a link to its journey page (or a "coming soon" state for packs whose journey page is not yet live)
+- [x] Journey page template renders the 8-section structure from [journey-page-template.md](journey-page-template.md)
+- [x] Three core journey pages authored: `/journeys/core`, `/journeys/discovery`, `/journeys/release`
 
 ### Phase 3 — Priority-2 journey pages
 

--- a/web/package.json
+++ b/web/package.json
@@ -14,5 +14,9 @@
   },
   "dependencies": {
     "astro": "7.1.0"
+  },
+  "allowScripts": {
+    "esbuild@0.28.1": true,
+    "fsevents@2.3.3": true
   }
 }

--- a/web/src/components/journey/GateDetail.astro
+++ b/web/src/components/journey/GateDetail.astro
@@ -1,0 +1,203 @@
+---
+// Gate detail card — Section 5 of the journey page. Light zone with amber left
+// border (task instruction: "amber-bordered gate cards on #fafaf9 background").
+// Uses <details>/<summary> for expandable what-to-check content — zero JS.
+
+interface Gate {
+  id: string;
+  globalGate: string | null;
+  label: string;
+  trigger: string;
+  duration: string;
+  whatToCheck: string[];
+  whatGoodLooksLike: string;
+  whatBadLooksLike: string;
+  consequence: string;
+}
+
+interface Props {
+  gate: Gate;
+}
+
+const { gate } = Astro.props;
+---
+
+<div class="gate-card">
+  <div class="gate-card__header">
+    <div class="gate-card__id-row">
+      <span class="gate-id">{gate.id}</span>
+      {gate.globalGate && <span class="global-gate">{gate.globalGate}</span>}
+    </div>
+    <h3 class="gate-card__label">{gate.label}</h3>
+    <dl class="gate-card__meta">
+      <dt>Trigger</dt>
+      <dd>{gate.trigger}</dd>
+      <dt>Time</dt>
+      <dd>{gate.duration}</dd>
+    </dl>
+  </div>
+
+  <details class="gate-card__details">
+    <summary class="gate-card__summary">What to check, good, bad, consequence</summary>
+
+    <div class="gate-card__body">
+      <section class="gate-section">
+        <h4 class="gate-section__title">What to check</h4>
+        <ul class="check-list">
+          {gate.whatToCheck.map((item) => (
+            <li class="check-list__item">
+              <span class="check-box" aria-hidden="true">□</span>
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section class="gate-section">
+        <h4 class="gate-section__title gate-section__title--good">What good looks like</h4>
+        <p>{gate.whatGoodLooksLike}</p>
+      </section>
+
+      <section class="gate-section">
+        <h4 class="gate-section__title gate-section__title--bad">What bad looks like</h4>
+        <p>{gate.whatBadLooksLike}</p>
+      </section>
+
+      <section class="gate-section gate-section--consequence">
+        <h4 class="gate-section__title">Consequence of skipping</h4>
+        <p>{gate.consequence}</p>
+      </section>
+    </div>
+  </details>
+</div>
+
+<style>
+  .gate-card {
+    background-color: var(--ds-surface-alt);
+    border: 1px solid var(--ds-border);
+    border-left: 4px solid var(--ds-accent);
+    border-radius: var(--ds-radius-md);
+  }
+
+  .gate-card__header {
+    padding: var(--ds-space-6);
+    padding-bottom: var(--ds-space-4);
+  }
+
+  .gate-card__id-row {
+    display: flex;
+    align-items: center;
+    gap: var(--ds-space-3);
+    margin-bottom: var(--ds-space-3);
+  }
+
+  .gate-id {
+    font-family: var(--ds-font-mono);
+    font-weight: var(--ds-weight-heavy);
+    font-size: var(--ds-type-body-lg);
+    color: var(--ds-accent-deep);
+  }
+
+  .global-gate {
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--ds-track-label);
+    background-color: var(--ds-accent-subtle);
+    color: var(--ds-accent-deep);
+    padding: 0.1rem 0.5rem;
+    border-radius: var(--ds-radius-sm);
+  }
+
+  .gate-card__label {
+    font-size: var(--ds-type-h3);
+    margin-bottom: var(--ds-space-4);
+    color: var(--ds-on-surface);
+  }
+
+  .gate-card__meta {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: var(--ds-space-1) var(--ds-space-4);
+    font-size: var(--ds-type-sm);
+  }
+
+  .gate-card__meta dt {
+    font-weight: var(--ds-weight-semibold);
+    color: var(--ds-on-surface-muted);
+    text-transform: uppercase;
+    letter-spacing: var(--ds-track-label);
+    font-size: var(--ds-type-xs);
+    align-self: baseline;
+  }
+
+  .gate-card__meta dd {
+    color: var(--ds-on-surface-2);
+  }
+
+  .gate-card__summary {
+    display: block;
+    padding: var(--ds-space-4) var(--ds-space-6);
+    font-size: var(--ds-type-sm);
+    font-weight: var(--ds-weight-semibold);
+    color: var(--ds-accent-deep);
+    cursor: pointer;
+    border-top: 1px solid var(--ds-border);
+    list-style: none;
+  }
+
+  .gate-card__summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .gate-card__details[open] .gate-card__summary {
+    border-bottom: 1px solid var(--ds-border);
+  }
+
+  .gate-card__body {
+    padding: var(--ds-space-6);
+    display: grid;
+    gap: var(--ds-space-5);
+  }
+
+  .gate-section__title {
+    font-size: var(--ds-type-xs);
+    font-weight: var(--ds-weight-semibold);
+    text-transform: uppercase;
+    letter-spacing: var(--ds-track-label);
+    color: var(--ds-on-surface-muted);
+    margin-bottom: var(--ds-space-3);
+  }
+
+  .check-list {
+    display: grid;
+    gap: var(--ds-space-2);
+  }
+
+  .check-list__item {
+    display: flex;
+    gap: var(--ds-space-3);
+    font-size: var(--ds-type-body);
+    color: var(--ds-on-surface-2);
+    align-items: baseline;
+  }
+
+  .check-box {
+    color: var(--ds-accent-deep);
+    font-weight: var(--ds-weight-bold);
+    flex-shrink: 0;
+  }
+
+  .gate-section--consequence {
+    background-color: var(--ds-accent-subtle);
+    border-radius: var(--ds-radius-md);
+    padding: var(--ds-space-4);
+    margin: 0;
+  }
+
+  .gate-section p {
+    font-size: var(--ds-type-body);
+    color: var(--ds-on-surface-2);
+    line-height: var(--ds-lead-body);
+  }
+</style>

--- a/web/src/components/journey/JourneyHero.astro
+++ b/web/src/components/journey/JourneyHero.astro
@@ -1,0 +1,154 @@
+---
+// Section 1 — Pack hero for journey pages. Light zone (no dark band on journey
+// pages — task instruction: "all journey pages are light zone #fafaf9 with
+// amber-bordered gate cards"). Amber accents provide visual weight.
+import { withBase } from '../../lib/paths';
+
+interface Props {
+  name: string;
+  scope: 'user' | 'repo';
+  tagline: string;
+  skillCount: number;
+  humanTouches: number;
+  wallClockMinutes: string;
+  packUrl: string;
+  docsUrl: string;
+}
+
+const { name, scope, tagline, skillCount, humanTouches, wallClockMinutes, packUrl, docsUrl } = Astro.props;
+---
+
+<header class="journey-hero">
+  <div class="journey-hero__inner">
+    <div class="journey-hero__meta">
+      <span class="scope-chip">{scope}</span>
+    </div>
+    <h1 class="journey-hero__name">{name}</h1>
+    <p class="journey-hero__tagline">{tagline}</p>
+    <div class="journey-hero__stats" aria-label="Session statistics">
+      <span class="stat"><strong>{skillCount}</strong> skills</span>
+      <span class="stat-sep" aria-hidden="true">·</span>
+      <span class="stat"><strong>{humanTouches}</strong> {humanTouches === 1 ? 'human gate' : 'human gates'}</span>
+      <span class="stat-sep" aria-hidden="true">·</span>
+      <span class="stat"><strong>{wallClockMinutes}</strong> min/session</span>
+    </div>
+    <div class="journey-hero__actions">
+      <a class="btn-primary" href={withBase(packUrl)}>Install this pack <span aria-hidden="true">→</span></a>
+      <a class="btn-ghost" href={withBase(docsUrl)}>Read the reference <span aria-hidden="true">↗</span></a>
+    </div>
+  </div>
+</header>
+
+<style>
+  .journey-hero {
+    background-color: var(--ds-surface-alt);
+    border-bottom: 1px solid var(--ds-border);
+    padding-block: var(--ds-space-9);
+  }
+
+  .journey-hero__inner {
+    max-width: var(--ds-content-max);
+    margin-inline: auto;
+    padding-inline: var(--ds-content-pad-x);
+  }
+
+  .journey-hero__meta {
+    margin-bottom: var(--ds-space-4);
+  }
+
+  .scope-chip {
+    display: inline-block;
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--ds-track-label);
+    background-color: var(--ds-accent-subtle);
+    color: var(--ds-accent-deep);
+    padding: 0.1rem 0.5rem;
+    border-radius: var(--ds-radius-sm);
+  }
+
+  .journey-hero__name {
+    font-size: var(--ds-type-display);
+    font-weight: var(--ds-weight-heavy);
+    color: var(--ds-accent-deep);
+    letter-spacing: var(--ds-track-display);
+    line-height: var(--ds-lead-display);
+    margin-bottom: var(--ds-space-4);
+  }
+
+  .journey-hero__tagline {
+    font-size: var(--ds-type-body-lg);
+    color: var(--ds-on-surface-2);
+    max-width: 60ch;
+    line-height: var(--ds-lead-body);
+    margin-bottom: var(--ds-space-5);
+  }
+
+  .journey-hero__stats {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--ds-space-2);
+    margin-bottom: var(--ds-space-7);
+    font-size: var(--ds-type-body);
+    color: var(--ds-on-surface-muted);
+  }
+
+  .stat strong {
+    color: var(--ds-on-surface);
+    font-weight: var(--ds-weight-semibold);
+  }
+
+  .stat-sep {
+    color: var(--ds-on-surface-muted);
+  }
+
+  .journey-hero__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--ds-space-4);
+    align-items: center;
+  }
+
+  .btn-primary {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--ds-space-2);
+    background-color: var(--ds-cta-primary-bg);
+    color: var(--ds-cta-primary-fg);
+    font-weight: var(--ds-weight-semibold);
+    padding: 0.7rem 1.6rem;
+    border-radius: var(--ds-radius-pill);
+    text-decoration: none;
+    transition: background-color var(--ds-dur-moderate) var(--ds-ease-std);
+  }
+
+  .btn-primary:hover {
+    background-color: var(--ds-cta-primary-bg-hover);
+  }
+
+  .btn-ghost {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--ds-space-2);
+    color: var(--ds-cta-ghost-light-fg);
+    font-weight: var(--ds-weight-semibold);
+    padding: 0.7rem 1.6rem;
+    border-radius: var(--ds-radius-pill);
+    border: 1px solid var(--ds-cta-ghost-light-border);
+    text-decoration: none;
+    transition: background-color var(--ds-dur-moderate) var(--ds-ease-std);
+  }
+
+  .btn-ghost:hover {
+    background-color: var(--ds-accent-subtle);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .btn-primary,
+    .btn-ghost {
+      transition: none;
+    }
+  }
+</style>

--- a/web/src/components/pack/PackCard.astro
+++ b/web/src/components/pack/PackCard.astro
@@ -1,0 +1,91 @@
+---
+// Pack card used on /packs/ index grid. Shows name, scope badge, tagline; links
+// to the pack detail page.
+import { withBase } from '../../lib/paths';
+
+interface Props {
+  slug: string;
+  name: string;
+  scope: 'user' | 'repo';
+  tagline: string;
+}
+
+const { slug, name, scope, tagline } = Astro.props;
+---
+
+<li class="pack-card">
+  <a class="pack-card__link" href={withBase(`/packs/${slug}/`)}>
+    <div class="pack-card__head">
+      <h3 class="pack-card__name">{name}</h3>
+      <span class="scope-chip">{scope}</span>
+    </div>
+    <p class="pack-card__tagline">{tagline}</p>
+    <span class="pack-card__cta" aria-hidden="true">Explore →</span>
+  </a>
+</li>
+
+<style>
+  .pack-card {
+    background-color: var(--ds-surface-alt);
+    border: 1px solid var(--ds-border);
+    border-radius: var(--ds-radius-lg);
+    transition: border-color var(--ds-dur-moderate) var(--ds-ease-std);
+  }
+
+  .pack-card:hover {
+    border-color: var(--ds-accent);
+  }
+
+  .pack-card__link {
+    display: block;
+    padding: var(--ds-space-6);
+    text-decoration: none;
+    color: inherit;
+    height: 100%;
+  }
+
+  .pack-card__head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--ds-space-3);
+    margin-bottom: var(--ds-space-3);
+  }
+
+  .pack-card__name {
+    font-size: var(--ds-type-h3);
+    color: var(--ds-on-surface);
+  }
+
+  .scope-chip {
+    display: inline-block;
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--ds-track-label);
+    background-color: var(--ds-accent-subtle);
+    color: var(--ds-accent-deep);
+    padding: 0.1rem 0.5rem;
+    border-radius: var(--ds-radius-sm);
+    flex-shrink: 0;
+  }
+
+  .pack-card__tagline {
+    font-size: var(--ds-type-body);
+    color: var(--ds-on-surface-2);
+    margin-bottom: var(--ds-space-4);
+    line-height: var(--ds-lead-body);
+  }
+
+  .pack-card__cta {
+    font-size: var(--ds-type-sm);
+    font-weight: var(--ds-weight-semibold);
+    color: var(--ds-accent-deep);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .pack-card {
+      transition: none;
+    }
+  }
+</style>

--- a/web/src/components/pack/PackHero.astro
+++ b/web/src/components/pack/PackHero.astro
@@ -1,0 +1,78 @@
+---
+// Header section for /packs/[slug] detail pages. Light zone — pack detail pages
+// do not use a dark hero band; amber accents provide the visual anchor.
+interface Props {
+  name: string;
+  scope: 'user' | 'repo';
+  tagline: string;
+  skillCount: number;
+}
+
+const { name, scope, tagline, skillCount } = Astro.props;
+---
+
+<header class="pack-hero">
+  <div class="pack-hero__inner">
+    <div class="pack-hero__meta">
+      <span class="scope-chip">{scope}</span>
+      <span class="skill-count">{skillCount} {skillCount === 1 ? 'skill' : 'skills'}</span>
+    </div>
+    <h1 class="pack-hero__name">{name}</h1>
+    <p class="pack-hero__tagline">{tagline}</p>
+  </div>
+</header>
+
+<style>
+  .pack-hero {
+    background-color: var(--ds-surface-alt);
+    border-bottom: 1px solid var(--ds-border);
+    padding-block: var(--ds-space-9);
+  }
+
+  .pack-hero__inner {
+    max-width: var(--ds-content-max);
+    margin-inline: auto;
+    padding-inline: var(--ds-content-pad-x);
+  }
+
+  .pack-hero__meta {
+    display: flex;
+    align-items: center;
+    gap: var(--ds-space-3);
+    margin-bottom: var(--ds-space-4);
+  }
+
+  .scope-chip {
+    display: inline-block;
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--ds-track-label);
+    background-color: var(--ds-accent-subtle);
+    color: var(--ds-accent-deep);
+    padding: 0.1rem 0.5rem;
+    border-radius: var(--ds-radius-sm);
+  }
+
+  .skill-count {
+    font-size: var(--ds-type-sm);
+    color: var(--ds-on-surface-muted);
+    font-family: var(--ds-font-mono);
+  }
+
+  .pack-hero__name {
+    font-size: var(--ds-type-display);
+    font-weight: var(--ds-weight-heavy);
+    color: var(--ds-accent-deep);
+    letter-spacing: var(--ds-track-display);
+    line-height: var(--ds-lead-display);
+    margin-bottom: var(--ds-space-4);
+  }
+
+  .pack-hero__tagline {
+    font-size: var(--ds-type-body-lg);
+    color: var(--ds-on-surface-2);
+    max-width: 60ch;
+    line-height: var(--ds-lead-body);
+  }
+</style>

--- a/web/src/content.config.ts
+++ b/web/src/content.config.ts
@@ -1,0 +1,56 @@
+import { defineCollection, z } from 'astro:content';
+import { glob } from 'astro/loaders';
+
+const packs = defineCollection({
+  loader: glob({ pattern: '*.md', base: './src/content/packs' }),
+  schema: z.object({
+    name: z.string(),
+    scope: z.enum(['user', 'repo']),
+    tagline: z.string(),
+    skills: z.array(z.string()),
+    installCommand: z.string(),
+    docsUrl: z.string(),
+    journeyUrl: z.string().optional(),
+  }),
+});
+
+const journeys = defineCollection({
+  loader: glob({ pattern: '*.md', base: './src/content/journeys' }),
+  schema: z.object({
+    pack: z.string(),
+    scope: z.enum(['user', 'repo']),
+    tagline: z.string(),
+    prerequisitePacks: z.array(z.string()).default([]),
+    whatChanges: z.string().optional(),
+    skills: z.array(
+      z.object({
+        name: z.string(),
+        description: z.string(),
+        humanTouches: z.number().int().min(0),
+      })
+    ),
+    humanGates: z.array(
+      z.object({
+        id: z.string(),
+        globalGate: z.string().nullable(),
+        label: z.string(),
+        trigger: z.string(),
+        duration: z.string(),
+        whatToCheck: z.array(z.string()),
+        whatGoodLooksLike: z.string(),
+        whatBadLooksLike: z.string(),
+        consequence: z.string(),
+      })
+    ),
+    typicalSession: z.object({
+      agentTurns: z.string(),
+      humanTouches: z.number().int(),
+      wallClockMinutes: z.string(),
+    }),
+    docsUrl: z.string(),
+    packUrl: z.string(),
+    relatedJourneys: z.array(z.string()).default([]),
+  }),
+});
+
+export const collections = { packs, journeys };

--- a/web/src/content/journeys/core.md
+++ b/web/src/content/journeys/core.md
@@ -1,0 +1,88 @@
+---
+pack: core
+scope: repo
+tagline: "Spec → shipped code. Supervised."
+prerequisitePacks: []
+whatChanges: "After installing core, every coding task in your repo runs through work-loop: plan → execute → verify → adversarial review. You get lint, typecheck, and tests as mechanical gates. Three specialist reviewers read every diff cold. The loop cannot self-certify — it always surfaces to you for plan approval and PR merge."
+skills:
+  - name: work-loop
+    description: "The build loop. Plans, executes, verifies, and reviews — mechanical gates and human checkpoints the agent cannot bypass."
+    humanTouches: 2
+  - name: new-spec
+    description: "Authors a spec document before the build loop starts. Captures the trio (problem, user, success criteria) and acceptance criteria."
+    humanTouches: 1
+  - name: bug-fix
+    description: "Diagnoses and fixes a bug with a targeted root-cause analysis before writing a line of code."
+    humanTouches: 1
+  - name: frontend-engineering
+    description: "Establishes design intent and craft rules before writing HTML/CSS — pre-flight before any frontend surface change."
+    humanTouches: 0
+  - name: contract-acquisition
+    description: "Grounds agent code against an unfamiliar API or library contract before implementation — prevents guessed signatures."
+    humanTouches: 0
+humanGates:
+  - id: G-plan
+    globalGate: null
+    label: "Approve the plan"
+    trigger: "Before work-loop begins execution — after the agent writes the trio and risk-trigger assessment"
+    duration: "5–10 minutes"
+    whatToCheck:
+      - "Is the Trio complete? (problem, user, success criteria — each in one sentence)"
+      - "Do the stated risk triggers match the actual change? (a one-file auth change is full-mode; a familiar two-file change can be light)"
+      - "Is the plan scoped to what was asked — nothing more?"
+      - "Are the assumption surfacings plausible, not defensive?"
+    whatGoodLooksLike: "A bounded plan with a clear trio, no scope creep, correct risk-trigger assessment, and plausible assumptions."
+    whatBadLooksLike: "A plan that extends the scope of the request, missing risk triggers that should have fired, or a trio that doesn't name a specific user."
+    consequence: "If you approve a bad plan, the agent executes it faithfully. The cost of a bad plan is the cost of a full loop iteration — plan approval is the cheapest gate."
+  - id: G-pr
+    globalGate: "G4"
+    label: "Merge the PR"
+    trigger: "After all mechanical gates pass and adversarial review is clean"
+    duration: "10–20 minutes"
+    whatToCheck:
+      - "Is adversarial review marked clean? (Re-run if in doubt — it's fast.)"
+      - "Does the implementation match the spec? If not, did the spec update?"
+      - "Are the tests testing behavior, not implementation details?"
+      - "Is there anything in the diff that wasn't in the plan?"
+    whatGoodLooksLike: "Green gates, clean adversarial review, spec and implementation aligned, no unexplained diff."
+    whatBadLooksLike: "Adversarial reviewer flagged a Blocker and you merged anyway. Or the spec drifted from the implementation without an update."
+    consequence: "G4 is the last line of defense before the build loop output goes to release. A bad merge is harder to undo than a bad plan."
+typicalSession:
+  agentTurns: "8–12"
+  humanTouches: 2
+  wallClockMinutes: "25–45"
+docsUrl: /docs/guides/core/
+packUrl: /packs/core/
+relatedJourneys:
+  - release
+---
+
+## Stage 1 — Brief the loop
+
+You opened a task and described it to your agent. The agent activated `work-loop`, checked whether risk triggers required full mode, wrote the lean inline spec (trio: problem, user, success criteria), identified risk triggers, and surfaced assumptions.
+
+**You did:** Read the trio in the chat. Confirmed the scope matched what you asked for — or redirected if the agent overreached. Checked that the correct mode (light or full) was selected. Approved the plan. 5–10 minutes of focused reading; this is the gate that costs least and protects most.
+
+---
+
+## Stage 2 — Execution
+
+After your plan approval, the agent implemented against the spec. It ran lint, typecheck, and tests after each logical change. When a gate failed, it fixed the issue and re-ran the gate before continuing.
+
+**You did:** Watched the chat at key moments — after each logical task completes, skim the agent's output to catch early drift. You do not need to read every line; look for file names you didn't expect, for scope creep, and for the agent surfacing a question. If it surfaces, answer quickly — a blocked agent costs more time than a fast redirect. If all is well, let it run.
+
+---
+
+## Stage 3 — Specialist review
+
+After all mechanical gates passed, the agent ran `adversarial-reviewer` in a fresh session. The reviewer read the diff cold — no context from the build session. It returned findings grouped by severity (Blockers, Concerns, Nits). The loop iterated on Blockers until the reviewer reported clean.
+
+**You did:** Monitored the review output as it landed. If the reviewer flagged a Blocker you disagreed with, provide a brief direction to the agent ("this is expected behavior because…") so the next fix targets the real issue. For Concerns and Nits, scan them — you may choose to apply or defer without waiting for the loop to finish.
+
+---
+
+## Stage 4 — PR and merge
+
+After all reviewers reported clean, the agent opened the PR with a description including: what changed, why, what was deferred, and what was found mid-implementation.
+
+**You did:** Reviewed the PR diff in GitHub or your editor. Read the description, not just the diff — the description tells you what the agent decided when it had choices. Checked that the spec and implementation aligned. Looked for anything in the diff that wasn't in the plan you approved. Merged when satisfied.

--- a/web/src/content/journeys/discovery.md
+++ b/web/src/content/journeys/discovery.md
@@ -1,0 +1,134 @@
+---
+pack: product-engineering
+scope: user
+tagline: "Raw idea → build-ready decision brief."
+prerequisitePacks: []
+whatChanges: "After installing product-engineering, upstream intent work runs through discovery-loop: frame → explore → converge → commit. The discovery-lead agent diverges across candidate product shapes, drives the lens roster to convergence, and emits a connected hypothesis with validation hooks — no engine. You review at four human gates; the agent runs everything between them."
+skills:
+  - name: discovery-loop
+    description: "The discovery supervisor. Diverges across candidate product shapes, drives the lens roster to convergence, and emits a connected hypothesis with validation hooks."
+    humanTouches: 4
+  - name: frame-intent
+    description: "Establishes product framing — problem, user, outcome — before the loop begins."
+    humanTouches: 1
+  - name: de-risk-intent
+    description: "Surfaces the riskiest assumption and designs a prototype approach to de-risk it before committing to build."
+    humanTouches: 1
+  - name: decompose-intent
+    description: "Decomposes the chosen direction into briefs and specs for the delivery loop."
+    humanTouches: 1
+  - name: explore-options
+    description: "Generates candidate product shapes with distinct tradeoff profiles."
+    humanTouches: 0
+  - name: plan-validation
+    description: "Validates a plan against the discovery sidecar — checks that the build plan addresses the grounded hypothesis."
+    humanTouches: 0
+  - name: voice-and-microcopy
+    description: "Characterizes a product's voice and writes blame-free, actionable UI copy."
+    humanTouches: 1
+  - name: align-value-stream
+    description: "Coordinates a multi-component product intent across a business-unit value stream."
+    humanTouches: 1
+humanGates:
+  - id: G0
+    globalGate: "G0"
+    label: "Shape intent"
+    trigger: "After frame-intent emits the initial framing"
+    duration: "10–15 minutes"
+    whatToCheck:
+      - "Is the problem statement specific enough to eliminate candidates? (A vague problem cannot be de-risked.)"
+      - "Is the user named specifically — not 'users' or 'teams'?"
+      - "Is the outcome measurable — what would change in the world if this succeeded?"
+    whatGoodLooksLike: "A framing that names a specific user, a falsifiable problem, and a measurable outcome."
+    whatBadLooksLike: "A framing that could apply to any product — 'improve developer productivity' is not a problem statement."
+    consequence: "G0 is the framing gate. A bad framing means the entire discovery loop explores the wrong space."
+  - id: "G1.5"
+    globalGate: null
+    label: "Mid-discovery check"
+    trigger: "After explore-options and the first lens-roster pass"
+    duration: "15–20 minutes"
+    whatToCheck:
+      - "Which candidates survived the lens roster? Do the survivors feel right?"
+      - "Are eliminated candidates genuinely eliminated, or just deprioritized?"
+      - "Is there a candidate missing that should be explored?"
+    whatGoodLooksLike: "A clear field of two or three differentiated candidates, each with a distinct tradeoff profile."
+    whatBadLooksLike: "All candidates converged to the same shape before the lens roster ran — the diverge step didn't diverge."
+    consequence: "The mid-discovery check prevents the loop from converging on a bad candidate without the human noticing."
+  - id: G2
+    globalGate: null
+    label: "Reconcile"
+    trigger: "After the full lens-roster pass on the surviving candidates"
+    duration: "20–30 minutes"
+    whatToCheck:
+      - "Did both discovery reviewers (threat + reliability) flag anything that would block the build?"
+      - "Does the validated candidate's hypothesis have a clear validation hook?"
+      - "Is the decomposition granular enough to fit in one build-loop iteration?"
+    whatGoodLooksLike: "A build-ready decision brief — reviewers clean, falsifiable hypothesis, decomposition that fits the delivery loop."
+    whatBadLooksLike: "A brief that passes the gate but skips the riskiest assumption. Or a decomposition too large for one loop."
+    consequence: "G2 produces the build commitment artifact. A bad brief means the delivery loop builds the wrong thing faithfully."
+  - id: G3
+    globalGate: "G3"
+    label: "Commit to build"
+    trigger: "After the reconciliation record is ratified"
+    duration: "5 minutes"
+    whatToCheck:
+      - "Is the decision brief complete? (intent, assumption-test, validated candidate, decomposition)"
+      - "Is there anything in the brief you are not prepared to ship?"
+    whatGoodLooksLike: "You ratify the brief and hand it to the delivery loop."
+    whatBadLooksLike: "You ratify with reservations and don't surface them. The delivery loop builds faithfully to a brief you had doubts about."
+    consequence: "G3 is the discovery-to-delivery handoff. After this gate, the delivery loop builds."
+typicalSession:
+  agentTurns: "12–20"
+  humanTouches: 4
+  wallClockMinutes: "60–120"
+docsUrl: /docs/guides/product-engineering/
+packUrl: /packs/product-engineering/
+relatedJourneys:
+  - core
+---
+
+## Stage 1 — Shape intent
+
+You described a product idea or problem to the `discovery-lead` agent. The agent activated `discovery-loop`, ran `frame-intent` to establish product framing (problem, user, outcome), and emitted an intent document.
+
+**You did:** Read the intent document — the framing is only a page. Gave concrete corrections if the problem statement was too vague ("users want to collaborate faster" → "the PM can't see which stories are blocked without checking three tools"). Provided the G0 consent once the framing was specific enough to eliminate candidates from. This gate sets the direction for everything that follows.
+
+---
+
+## Stage 2 — Diverge
+
+The agent ran `explore-options` to generate candidate product shapes with distinct tradeoff profiles. Each candidate represented a meaningfully different approach to the problem.
+
+**You did:** Watched as candidates appeared. If a candidate was obviously out-of-scope or repeated a prior approach, say so before the lens roster runs — it saves a review cycle. Otherwise, let the diverge step complete.
+
+---
+
+## Stage 3 — Lens roster
+
+After generating candidates, the agent ran two discovery reviewers — threat and reliability — against each candidate. Each reviewer read cold and returned findings. Candidates that failed the reviewers were eliminated.
+
+**You did:** Monitored the review output. If a candidate you wanted to keep was eliminated, read the finding that killed it — sometimes the finding is correct and you needed to hear it; sometimes it rests on a false premise you can correct with one sentence.
+
+---
+
+## Stage 4 — Mid-discovery check
+
+The agent surfaced the surviving candidates for a mid-course human check. You reviewed which candidates remained and whether the field felt right.
+
+**You did:** At G1.5 you made a call. If only one candidate survived and it felt too easy, ask the agent to re-explore from a different angle. If the survivors felt genuinely distinct, confirm and let the loop converge. This is the last moment to expand the option space cheaply.
+
+---
+
+## Stage 5 — Converge
+
+The agent ran `de-risk-intent` to surface the riskiest assumption and design a prototype approach to test it. It then ran `decompose-intent` to decompose the chosen direction into specs and briefs for the delivery loop.
+
+**You did:** Watched the assumption-test take shape. If the prototype approach the agent proposed was too expensive or wouldn't actually test the assumption, redirect. A bad de-risk approach means the brief reaches the delivery loop with an untested assumption at its core.
+
+---
+
+## Stage 6 — Reconcile and commit
+
+The agent presented the full discovery sidecar — intent, assumption-test, validated candidate, decomposition. You reviewed the G2 reconciliation record and confirmed the decision brief was build-ready.
+
+**You did:** Read the full brief — all sections. At G2 you ratified the reconciliation record; at G3 you committed the brief to the delivery loop. These are two distinct decisions: G2 is "is this brief complete?" and G3 is "am I ready to build this?" A brief can be complete but still wrong.

--- a/web/src/content/journeys/release.md
+++ b/web/src/content/journeys/release.md
@@ -1,0 +1,56 @@
+---
+pack: release-engineering
+scope: repo
+tagline: "Deploy. Verify. Converge. Then ship."
+prerequisitePacks:
+  - core
+whatChanges: "After installing release-engineering, completed build-loop output goes through release-loop before reaching production. The release-lead agent deploys to an ephemeral environment, runs e2e tests, observes telemetry, and feeds deployed findings back to the inner loop — no human relay. You review at one gate: the prod ship."
+skills:
+  - name: release-loop
+    description: "The release supervisor. Deploys to ephemeral env, runs e2e, feeds findings back to the inner loop, iterates to convergence, then surfaces for prod ship approval."
+    humanTouches: 1
+humanGates:
+  - id: G5
+    globalGate: "G5"
+    label: "Approve the prod ship"
+    trigger: "After the deployed whole converges — e2e clean, telemetry stable, security review done"
+    duration: "15–30 minutes"
+    whatToCheck:
+      - "Is the release readiness record complete? (e2e results, telemetry snapshot, security review)"
+      - "Are there any borderline gates in the record? (The agent surfaces these — don't skip them.)"
+      - "Is there anything in the diff that wasn't in the scope of this release?"
+      - "Is the rollback path documented and tested?"
+    whatGoodLooksLike: "A release readiness record showing convergence — e2e clean, telemetry stable, security reviewer clean, no borderline gates."
+    whatBadLooksLike: "A record that notes borderline gates you wave through. Or a record that omits the security diff review."
+    consequence: "G5 gates the prod ship. The agent cannot ship to production without your ratification. After this gate, the change reaches real users or real data — irreversible."
+typicalSession:
+  agentTurns: "varies"
+  humanTouches: 1
+  wallClockMinutes: "15–30"
+docsUrl: /docs/guides/release-engineering/
+packUrl: /packs/release-engineering/
+relatedJourneys:
+  - core
+---
+
+## Stage 1 — Trigger release loop
+
+A completed inner build loop (work-loop + adversarial review clean) triggered the release loop. The `release-lead` agent activated `release-loop` and deployed the integrated whole to an ephemeral environment.
+
+**You did:** Watched the initial deploy log in the chat to confirm the right environment was targeted. You do not intervene in the deploy itself, but reading the first deploy confirms the agent is operating on the right branch and config. If the deploy target looks wrong, stop it early — it's cheaper than a mid-cycle redirect.
+
+---
+
+## Stage 2 — E2E validation and convergence
+
+The agent ran end-to-end tests against the deployed environment, observed telemetry, and fed deployed findings back to the inner loop — no human relay. It redeployed after each inner-loop fix. It iterated until the deployed whole converged: e2e clean, telemetry stable.
+
+**You did:** Checked in at the end of each outer loop iteration — after each redeploy, skim the e2e results and the telemetry snapshot. You're looking for anomalies the agent might not flag: a test that passes but whose assertion is too weak to catch a real failure, or a telemetry spike the agent marked as noise. The agent handles the mechanical convergence; you provide the judgment on what "stable" means for your service.
+
+---
+
+## Stage 3 — Release readiness record
+
+After the deployed whole converged, the agent generated a release readiness record: e2e results, telemetry snapshot, security review on the deployed diff, what was deferred, and any borderline gates.
+
+**You did:** At G5, read the full release readiness record — not just the summary. The borderline gates section is the one that matters most: these are cases where the agent decided "close enough" and you may decide differently. Ratified if satisfied. Rejected with a one-line reason if not — the agent will re-enter the loop. This gate is the only one between the ephemeral environment and production.

--- a/web/src/content/packs/architect.md
+++ b/web/src/content/packs/architect.md
@@ -1,0 +1,13 @@
+---
+name: Architect
+scope: user
+tagline: "Design docs, diagrams, and reviews — workspace-agnostic."
+skills:
+  - architect-design
+  - architect-diagram
+  - architect-review
+installCommand: "agentbundle install --pack architect --scope user"
+docsUrl: /docs/guides/architect/
+---
+
+Architect installs three solution-architecture skills: `architect-design` (Google-style design docs), `architect-diagram` (Mermaid diagrams — C4, sequence, state, ER), and `architect-review` (rubric-routed critique). A forked-context `design-reviewer` subagent gives every design an independent read — it does not review its own work. No required configuration; workspace-agnostic by default.

--- a/web/src/content/packs/atlassian.md
+++ b/web/src/content/packs/atlassian.md
@@ -1,0 +1,18 @@
+---
+name: Atlassian
+scope: user
+tagline: "Jira and Confluence from the agent — with DORA metrics."
+skills:
+  - jira
+  - jira-align
+  - jira-brief-intake
+  - jira-defect-flow
+  - flow-metrics
+  - confluence-crawler
+  - confluence-publisher
+  - ai-adoption-report
+installCommand: "agentbundle install --pack atlassian --scope user"
+docsUrl: /docs/guides/atlassian/
+---
+
+Atlassian installs Jira and Confluence primitives (credentialed CLI with SSO-cookie auth) plus four workflow skills: `flow-metrics` (DORA + cycle time), `ai-adoption-report` (measuring agent adoption across a portfolio), `jira-defect-flow` (triage to fix), and `jira-brief-intake` (turning Jira tickets into structured engineering briefs). Credentials resolved via `credential-brokers` — cleartext never reaches the model.

--- a/web/src/content/packs/contracts.md
+++ b/web/src/content/packs/contracts.md
@@ -1,0 +1,12 @@
+---
+name: Contracts
+scope: user
+tagline: "OpenAPI 3.1 and AsyncAPI — API-first design."
+skills:
+  - api-contract
+  - event-contract
+installCommand: "agentbundle install --pack contracts --scope user"
+docsUrl: /docs/guides/contracts/
+---
+
+Contracts installs two contract-authoring skills: `api-contract` (OpenAPI 3.1 for synchronous REST/HTTP APIs) and `event-contract` (AsyncAPI 2.x for event-driven interfaces). Both skills are user-scope by default — contract style is portable across projects and reflects the engineer's discipline, not the repo's.

--- a/web/src/content/packs/converters.md
+++ b/web/src/content/packs/converters.md
@@ -1,0 +1,17 @@
+---
+name: Converters
+scope: user
+tagline: "Document conversion — between every format your team uses."
+skills:
+  - file-to-markdown
+  - msg-to-markdown
+  - markdown-to-html
+  - markdown-to-docx
+  - markdown-to-pptx
+  - markdown-to-xlsx
+  - mermaid-renderer
+installCommand: "agentbundle install --pack converters --scope user"
+docsUrl: /docs/guides/converters/
+---
+
+Converters installs seven file-format conversion skills. `file-to-markdown` converts documents (PDF, DOCX, images) to Markdown. `msg-to-markdown` converts Outlook .msg and MIME .eml email. The four Markdown-to-* skills produce styled HTML, branded Word, PowerPoint, and Excel output. `mermaid-renderer` renders Mermaid diagrams to SVG or PNG. A three-tier capability model (no-dep, local-tools, agent-vision) ensures the floor works in locked-down environments.

--- a/web/src/content/packs/core.md
+++ b/web/src/content/packs/core.md
@@ -1,0 +1,19 @@
+---
+name: Core
+scope: repo
+tagline: "The build loop. Spec → shipped code. Supervised."
+skills:
+  - work-loop
+  - new-spec
+  - bug-fix
+  - frontend-engineering
+  - contract-acquisition
+  - receive-brief
+  - init-project
+  - adapt-to-project
+installCommand: "agentbundle install --pack core"
+docsUrl: /docs/guides/core/
+journeyUrl: /journeys/core/
+---
+
+Core is the engine of the build loop. After installing it, every coding task runs through `work-loop`: plan → execute → verify → adversarial review. You get mechanical gates (lint, typecheck, tests) and three specialist reviewers who read every diff cold. The loop cannot self-certify — it always surfaces to you at plan approval and PR merge.

--- a/web/src/content/packs/credential-brokers.md
+++ b/web/src/content/packs/credential-brokers.md
@@ -1,0 +1,11 @@
+---
+name: Credential Brokers
+scope: user
+tagline: "Credential resolution — env → OS keyring → dotfile. Never cleartext."
+skills:
+  - credential-setup
+installCommand: "agentbundle install --pack credential-brokers --scope user"
+docsUrl: /docs/guides/credential-brokers/
+---
+
+Credential Brokers installs user-scope credential brokering: the `credbroker` library (pip-installed, in-process resolver for `auth: creds` skills) and `sso-broker` (subprocess-based resolver for `auth: sso-cookie` skills). The `credential-setup` skill walks through establishing credentials for a service. Cleartext credentials never reach the model — the broker resolves at invocation time and passes the value directly to the skill.

--- a/web/src/content/packs/experience.md
+++ b/web/src/content/packs/experience.md
@@ -1,0 +1,19 @@
+---
+name: Experience
+scope: user
+tagline: "The design/UX seat for product teams."
+skills:
+  - aesthetic-direction
+  - design-critique
+  - design-system-foundations
+  - layout-and-information-architecture
+  - map-customer-journey
+  - blueprint-service
+  - map-screen-flow
+  - map-internal-process
+  - interaction-design
+installCommand: "agentbundle install --pack experience --scope user"
+docsUrl: /docs/guides/experience/
+---
+
+Experience installs the full design thread from outcome to realization. Connective skills walk customer-journey → screen-flow → service-blueprint and the inside-out sibling (internal process). Craft skills design each screen (aesthetic-direction, design-system-foundations, layout, interaction-design) and critique it (design-critique), all held to one shared quality floor — handle-all-states, WCAG 2.2 AA, reduced-motion. A forked-context `experience-reviewer` gives every design an independent review.

--- a/web/src/content/packs/figma.md
+++ b/web/src/content/packs/figma.md
@@ -1,0 +1,11 @@
+---
+name: Figma
+scope: user
+tagline: "Read and render Figma designs — files, frames, variables."
+skills:
+  - figma
+installCommand: "agentbundle install --pack figma --scope user"
+docsUrl: /docs/guides/figma/
+---
+
+Figma installs a credentialed CLI primitive that reads from the Figma REST API: files, nodes, metadata, versions, comments, variables, and dev resources. It renders frame images, posts comments, and converts FigJam connector graphs to Mermaid diagrams. Requires a Figma Personal Access Token resolved via `credential-brokers`.

--- a/web/src/content/packs/governance-extras.md
+++ b/web/src/content/packs/governance-extras.md
@@ -1,0 +1,13 @@
+---
+name: Governance Extras
+scope: repo
+tagline: "Decision trail — RFCs, ADRs, and conventions for long-lived repos."
+skills:
+  - new-rfc
+  - new-adr
+  - update-conventions
+installCommand: "agentbundle install --pack governance-extras"
+docsUrl: /docs/guides/governance-extras/
+---
+
+Governance Extras installs three governance skills: `new-rfc` (propose a cross-cutting change through an RFC with proposer/objector perspectives), `new-adr` (record an architectural decision with critique tracks), and `update-conventions` (evolve the CONVENTIONS.md with tracked changes). Ships RFC and ADR templates and seed READMEs. Repo-scope by default — governance artifacts belong to the project, not the engineer.

--- a/web/src/content/packs/monorepo-extras.md
+++ b/web/src/content/packs/monorepo-extras.md
@@ -1,0 +1,11 @@
+---
+name: Monorepo Extras
+scope: repo
+tagline: "Package scaffolding for monorepos."
+skills:
+  - new-package
+installCommand: "agentbundle install --pack monorepo-extras"
+docsUrl: /docs/guides/monorepo-extras/
+---
+
+Monorepo Extras installs one skill (`new-package`) plus the `packages/` seed README and `packages/_example/` template. `new-package` scaffolds a new package in your monorepo with the correct structure, AGENTS.md, and build configuration. Repo-scope by default — monorepo structure is per-project.

--- a/web/src/content/packs/product-engineering.md
+++ b/web/src/content/packs/product-engineering.md
@@ -1,0 +1,20 @@
+---
+name: Product Engineering
+scope: user
+tagline: "Raw idea → build-ready decision brief."
+skills:
+  - frame-intent
+  - de-risk-intent
+  - decompose-intent
+  - align-value-stream
+  - voice-and-microcopy
+  - frame-domain
+  - discovery-loop
+  - explore-options
+  - plan-validation
+installCommand: "agentbundle install --pack product-engineering --scope user"
+docsUrl: /docs/guides/product-engineering/
+journeyUrl: /journeys/discovery/
+---
+
+Product Engineering installs upstream of the build loop. The `discovery-loop` (run by the `discovery-lead` agent) turns a raw idea into a build-ready decision brief: diverging across candidate product shapes, converging through a lens roster with two discovery reviewers, and emitting a connected hypothesis with validation hooks. `frame-intent`, `de-risk-intent`, and `decompose-intent` run as habits over a recursive intent hierarchy. `voice-and-microcopy` adds the content layer.

--- a/web/src/content/packs/release-engineering.md
+++ b/web/src/content/packs/release-engineering.md
@@ -1,0 +1,12 @@
+---
+name: Release Engineering
+scope: repo
+tagline: "Deploy. Verify. Converge. Then ship."
+skills:
+  - release-loop
+installCommand: "agentbundle install --pack release-engineering"
+docsUrl: /docs/guides/release-engineering/
+journeyUrl: /journeys/release/
+---
+
+Release Engineering installs the SRE outer loop. The `release-lead` agent drives `release-loop`: deploys the integrated whole to an ephemeral environment, runs end-to-end tests, observes telemetry, feeds deployed findings back to the inner loop — no human relay — and iterates until the deployed whole converges. Autonomy is carved by minimum-regret: the agent runs on reversible ephemeral environments unwatched; humans gate the irreversible exits. Hard-depends on `core`.

--- a/web/src/content/packs/research.md
+++ b/web/src/content/packs/research.md
@@ -1,0 +1,21 @@
+---
+name: Research
+scope: user
+tagline: "Evidence-grounded research — portable across every repo."
+skills:
+  - research
+  - source-map
+  - build-outline
+  - identify-perspectives
+  - compare-hypotheses
+  - devils-advocate
+  - decision-archaeology
+  - research-project-start
+  - research-project-check
+  - research-project-digest
+  - research-project-synthesize
+installCommand: "agentbundle install --pack research --scope user"
+docsUrl: /docs/guides/research/
+---
+
+Research installs eleven skills grounded in seven convergent disciplines (STORM, PRISMA, ACH, Wikipedia V/RS/NPOV, OSINT, GIJN, GRADE). A single-query mode runs scoping, source curation, and synthesis in one session. A project mode runs sustained multi-week investigations through four lifecycle phases. Two retrieval subagents (`evidence-retriever`, `source-extractor`) fetch and synthesize external sources without polluting the main session context.

--- a/web/src/content/packs/user-guide-diataxis.md
+++ b/web/src/content/packs/user-guide-diataxis.md
@@ -1,0 +1,11 @@
+---
+name: User Guide (Diátaxis)
+scope: repo
+tagline: "Diátaxis-shaped documentation skeleton."
+skills:
+  - new-guide
+installCommand: "agentbundle install --pack user-guide-diataxis"
+docsUrl: /docs/guides/user-guide-diataxis/
+---
+
+User Guide (Diátaxis) installs a `guides/` skeleton shaped to the Diátaxis framework: separate directories for tutorials, how-to guides, reference, and explanation. The `new-guide` skill scaffolds a new guide document in the correct Diátaxis category. Repo-scope by default — documentation structure is per-project.

--- a/web/src/pages/journeys/[journey].astro
+++ b/web/src/pages/journeys/[journey].astro
@@ -1,0 +1,406 @@
+---
+import { getCollection, render } from 'astro:content';
+import SiteLayout from '../../components/layout/SiteLayout.astro';
+import Section from '../../components/layout/Section.astro';
+import JourneyHero from '../../components/journey/JourneyHero.astro';
+import GateDetail from '../../components/journey/GateDetail.astro';
+import { withBase } from '../../lib/paths';
+
+export async function getStaticPaths() {
+  const journeys = await getCollection('journeys');
+  return journeys.map((entry) => ({
+    params: { journey: entry.id.replace(/\.md$/, '') },
+    props: { entry },
+  }));
+}
+
+const { entry } = Astro.props;
+const { data } = entry;
+const { Content } = await render(entry);
+
+// Human touches per session — from typicalSession frontmatter (author-specified)
+const totalHumanTouches = data.typicalSession.humanTouches;
+
+// Derived install command from pack slug + scope
+const installCommand =
+  data.scope === 'user'
+    ? `agentbundle install --pack ${data.pack} --scope user`
+    : `agentbundle install --pack ${data.pack}`;
+
+---
+
+<SiteLayout
+  title={`${data.pack} journey — agent-ready-repo`}
+  description={data.tagline}
+>
+  <!-- Section 1: Pack hero (light zone, amber accents) -->
+  <JourneyHero
+    name={data.pack}
+    scope={data.scope}
+    tagline={data.tagline}
+    skillCount={data.skills.length}
+    humanTouches={totalHumanTouches}
+    wallClockMinutes={data.typicalSession.wallClockMinutes}
+    packUrl={data.packUrl}
+    docsUrl={data.docsUrl}
+  />
+
+  <!-- Section 2: What changes when you install this -->
+  <Section tone="surface">
+    <div class="content-body">
+      <h2 class="section-h2">What changes when you install this</h2>
+      {data.whatChanges ? (
+        <p class="what-changes">{data.whatChanges}</p>
+      ) : (
+        <p class="what-changes">
+          After installing this pack, the skills and agents it provides are available in every session on the relevant scope.
+        </p>
+      )}
+
+      {data.prerequisitePacks.length > 0 && (
+        <div class="prereqs">
+          <p class="prereqs__label">Requires:</p>
+          <ul class="prereqs__list">
+            {data.prerequisitePacks.map((p) => (
+              <li><a href={withBase(`/packs/${p}/`)}><code>{p}</code></a></li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  </Section>
+
+  <!-- Section 3: Skills in this pack -->
+  <Section tone="surface-alt">
+    <div class="content-body">
+      <h2 class="section-h2">Skills in this pack</h2>
+      <ul class="skills-list" role="list">
+        {data.skills.map((skill) => (
+          <li class="skill-row">
+            <div class="skill-row__head">
+              <code class="skill-chip">{skill.name}</code>
+              {skill.humanTouches > 0 && (
+                <span class="skill-touches">
+                  {skill.humanTouches} {skill.humanTouches === 1 ? 'gate' : 'gates'}
+                </span>
+              )}
+            </div>
+            <p class="skill-desc">{skill.description}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </Section>
+
+  <!-- Section 4: The journey — staged narrative from markdown body -->
+  <Section tone="surface">
+    <div class="content-body">
+      <h2 class="section-h2">The journey</h2>
+      <div class="journey-narrative">
+        <Content />
+      </div>
+    </div>
+  </Section>
+
+  <!-- Section 5: Human gates (detailed) — amber-bordered cards on light bg -->
+  <Section tone="surface-alt">
+    <div class="content-body">
+      <h2 class="section-h2">Human gates</h2>
+      <p class="gates-intro">
+        For each gate, everything you need to make a confident decision.
+      </p>
+      <ul class="gates-list" role="list">
+        {data.humanGates.map((gate) => (
+          <li>
+            <GateDetail gate={gate} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  </Section>
+
+  <!-- Section 6: What good output looks like -->
+  <Section tone="surface">
+    <div class="content-body">
+      <h2 class="section-h2">What good output looks like</h2>
+      <p class="placeholder-note">
+        <em>Content authored progressively. A well-completed session produces: clean mechanical gates (lint, typecheck, tests), a reviewer report marked <code>Clean — ready to commit.</code>, a PR description that names what changed, what was deferred, and what was found mid-implementation, and a spec that matches the implementation.</em>
+      </p>
+    </div>
+  </Section>
+
+  <!-- Section 7: Typical session shape -->
+  <Section tone="surface-alt">
+    <div class="content-body">
+      <h2 class="section-h2">Typical session</h2>
+      <dl class="session-stats">
+        <div class="session-stat">
+          <dt>Agent turns</dt>
+          <dd>{data.typicalSession.agentTurns}</dd>
+        </div>
+        <div class="session-stat">
+          <dt>Human gates</dt>
+          <dd>{data.typicalSession.humanTouches}</dd>
+        </div>
+        <div class="session-stat">
+          <dt>Wall-clock time</dt>
+          <dd>{data.typicalSession.wallClockMinutes} min</dd>
+        </div>
+      </dl>
+    </div>
+  </Section>
+
+  <!-- Section 8: Install and next steps -->
+  <Section tone="surface">
+    <div class="content-body">
+      <h2 class="section-h2">Install and next steps</h2>
+      <div class="install-block">
+        <pre class="install-block__code"><code>{installCommand}</code></pre>
+      </div>
+
+      <nav class="next-steps" aria-label="Next steps">
+        <ul class="next-steps__list" role="list">
+          <li>
+            <a class="next-link" href={withBase(data.docsUrl)}>
+              Read the full reference <span aria-hidden="true">↗</span>
+            </a>
+          </li>
+          {data.relatedJourneys.map((slug) => (
+            <li>
+              <a class="next-link" href={withBase(`/journeys/${slug}/`)}>
+                Explore the {slug} journey <span aria-hidden="true">→</span>
+              </a>
+            </li>
+          ))}
+          <li>
+            <a class="next-link" href={withBase('/packs/')}>
+              Browse the pack catalogue <span aria-hidden="true">→</span>
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </Section>
+</SiteLayout>
+
+<style>
+  .content-body {
+    max-width: 72ch;
+  }
+
+  .section-h2 {
+    font-size: var(--ds-type-h2);
+    letter-spacing: var(--ds-track-heading);
+    margin-bottom: var(--ds-space-5);
+    color: var(--ds-on-surface);
+  }
+
+  /* Section 2 */
+  .what-changes {
+    font-size: var(--ds-type-body-lg);
+    color: var(--ds-on-surface-2);
+    line-height: var(--ds-lead-body);
+    margin-bottom: var(--ds-space-5);
+  }
+
+  .prereqs {
+    display: flex;
+    align-items: baseline;
+    gap: var(--ds-space-3);
+    font-size: var(--ds-type-sm);
+    flex-wrap: wrap;
+  }
+
+  .prereqs__label {
+    font-weight: var(--ds-weight-semibold);
+    color: var(--ds-on-surface-muted);
+  }
+
+  .prereqs__list {
+    display: flex;
+    gap: var(--ds-space-3);
+    flex-wrap: wrap;
+  }
+
+  .prereqs__list a {
+    color: var(--ds-accent-deep);
+  }
+
+  /* Section 3 */
+  .skills-list {
+    display: grid;
+    gap: var(--ds-space-5);
+  }
+
+  .skill-row__head {
+    display: flex;
+    align-items: center;
+    gap: var(--ds-space-3);
+    margin-bottom: var(--ds-space-2);
+  }
+
+  .skill-chip {
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-mono-sm);
+    background-color: var(--ds-accent-subtle);
+    color: var(--ds-accent-deep);
+    padding: 0.25rem 0.6rem;
+    border-radius: var(--ds-radius-sm);
+  }
+
+  .skill-touches {
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--ds-track-label);
+    color: var(--ds-accent-deep);
+    background-color: var(--ds-accent-subtle);
+    padding: 0.1rem 0.4rem;
+    border-radius: var(--ds-radius-sm);
+  }
+
+  .skill-desc {
+    font-size: var(--ds-type-body);
+    color: var(--ds-on-surface-2);
+    line-height: var(--ds-lead-body);
+  }
+
+  /* Section 4 — journey narrative markdown */
+  .journey-narrative {
+    font-size: var(--ds-type-body);
+    color: var(--ds-on-surface-2);
+    line-height: var(--ds-lead-body);
+  }
+
+  .journey-narrative :global(h2) {
+    font-size: var(--ds-type-h3);
+    color: var(--ds-on-surface);
+    margin-top: var(--ds-space-7);
+    margin-bottom: var(--ds-space-3);
+    padding-bottom: var(--ds-space-2);
+    border-bottom: 1px solid var(--ds-border);
+  }
+
+  .journey-narrative :global(h2:first-child) {
+    margin-top: 0;
+  }
+
+  .journey-narrative :global(p) {
+    margin-bottom: var(--ds-space-4);
+  }
+
+  .journey-narrative :global(strong) {
+    color: var(--ds-on-surface);
+    font-weight: var(--ds-weight-semibold);
+  }
+
+  .journey-narrative :global(code) {
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-mono-sm);
+    background-color: var(--ds-accent-subtle);
+    color: var(--ds-accent-deep);
+    padding: 0.1rem 0.4rem;
+    border-radius: var(--ds-radius-sm);
+  }
+
+  .journey-narrative :global(hr) {
+    border: none;
+    border-top: 1px solid var(--ds-border);
+    margin-block: var(--ds-space-6);
+  }
+
+  /* Section 5 */
+  .gates-intro {
+    font-size: var(--ds-type-body);
+    color: var(--ds-on-surface-muted);
+    margin-bottom: var(--ds-space-6);
+  }
+
+  .gates-list {
+    display: grid;
+    gap: var(--ds-space-5);
+  }
+
+  /* Section 6 */
+  .placeholder-note {
+    font-size: var(--ds-type-body);
+    color: var(--ds-on-surface-muted);
+    line-height: var(--ds-lead-body);
+    padding: var(--ds-space-5) var(--ds-space-6);
+    background-color: var(--ds-surface-alt);
+    border-radius: var(--ds-radius-md);
+    border: 1px solid var(--ds-border);
+  }
+
+  .placeholder-note :global(code) {
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-mono-sm);
+    background-color: var(--ds-accent-subtle);
+    color: var(--ds-accent-deep);
+    padding: 0.1rem 0.3rem;
+    border-radius: var(--ds-radius-sm);
+  }
+
+  /* Section 7 */
+  .session-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: var(--ds-space-5);
+  }
+
+  .session-stat {
+    background-color: var(--ds-surface);
+    border: 1px solid var(--ds-border);
+    border-radius: var(--ds-radius-md);
+    padding: var(--ds-space-5);
+  }
+
+  .session-stat dt {
+    font-size: var(--ds-type-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--ds-track-label);
+    color: var(--ds-on-surface-muted);
+    margin-bottom: var(--ds-space-2);
+  }
+
+  .session-stat dd {
+    font-size: var(--ds-type-h3);
+    font-weight: var(--ds-weight-semibold);
+    color: var(--ds-accent-deep);
+    font-family: var(--ds-font-mono);
+  }
+
+  /* Section 8 */
+  .install-block {
+    background-color: var(--ds-hero-bg);
+    border-radius: var(--ds-radius-md);
+    padding: var(--ds-space-5) var(--ds-space-6);
+    margin-bottom: var(--ds-space-7);
+  }
+
+  .install-block__code {
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-mono-sm);
+    color: var(--ds-hero-fg);
+    line-height: var(--ds-lead-mono);
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    margin: 0;
+  }
+
+  .next-steps__list {
+    display: grid;
+    gap: var(--ds-space-4);
+  }
+
+  .next-link {
+    font-weight: var(--ds-weight-semibold);
+    font-size: var(--ds-type-body-lg);
+    color: var(--ds-accent-deep);
+    text-decoration: none;
+  }
+
+  .next-link:hover {
+    text-decoration: underline;
+  }
+</style>

--- a/web/src/pages/journeys/index.astro
+++ b/web/src/pages/journeys/index.astro
@@ -1,0 +1,175 @@
+---
+import { getCollection } from 'astro:content';
+import SiteLayout from '../../components/layout/SiteLayout.astro';
+import Section from '../../components/layout/Section.astro';
+import { withBase } from '../../lib/paths';
+
+const liveJourneys = await getCollection('journeys');
+const liveSlugSet = new Set(liveJourneys.map((e) => e.id.replace(/\.md$/, '')));
+
+// All 14 journey slugs in priority order; 3 are live in Phase 2, 11 are coming soon.
+const allJourneys = [
+  // Phase 2 — live
+  { slug: 'core', name: 'Core', phase: 2 },
+  { slug: 'discovery', name: 'Discovery (Product Engineering)', phase: 2 },
+  { slug: 'release', name: 'Release Engineering', phase: 2 },
+  // Phase 3 — coming soon
+  { slug: 'research', name: 'Research', phase: 3 },
+  { slug: 'architect', name: 'Architect', phase: 3 },
+  { slug: 'experience', name: 'Experience', phase: 3 },
+  { slug: 'contracts', name: 'Contracts', phase: 3 },
+  { slug: 'converters', name: 'Converters', phase: 3 },
+  { slug: 'atlassian', name: 'Atlassian', phase: 3 },
+  // Phase 4 — coming soon
+  { slug: 'figma', name: 'Figma', phase: 4 },
+  { slug: 'governance-extras', name: 'Governance Extras', phase: 4 },
+  { slug: 'credential-brokers', name: 'Credential Brokers', phase: 4 },
+  { slug: 'monorepo-extras', name: 'Monorepo Extras', phase: 4 },
+  { slug: 'user-guide-diataxis', name: 'User Guide (Diátaxis)', phase: 4 },
+];
+
+const liveItems = allJourneys.filter((j) => liveSlugSet.has(j.slug));
+const comingSoonItems = allJourneys.filter((j) => !liveSlugSet.has(j.slug));
+---
+
+<SiteLayout
+  title="Journeys — agent-ready-repo"
+  description="Staged walkthroughs of what it's like to use each pack — plan approval, execution, review, and merge gates explained."
+>
+  <Section tone="surface" labelledby="journeys-heading">
+    <h1 id="journeys-heading" class="journeys__headline">Journeys.</h1>
+    <p class="journeys__subhead">
+      Each journey is a staged walkthrough of a real usage session — what the agent
+      does, what you do, and what each human gate asks of you.
+    </p>
+
+    <div class="journeys__live">
+      <h2 class="journeys__group-title">Available now</h2>
+      <ul class="journeys-grid">
+        {liveItems.map((j) => (
+          <li class="journey-card">
+            <a class="journey-card__link" href={withBase(`/journeys/${j.slug}/`)}>
+              <h3 class="journey-card__name">{j.name}</h3>
+              <span class="journey-card__cta" aria-hidden="true">Read the journey →</span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+
+    {comingSoonItems.length > 0 && (
+      <div class="journeys__coming-soon">
+        <h2 class="journeys__group-title">Coming soon</h2>
+        <ul class="journeys-grid journeys-grid--muted">
+          {comingSoonItems.map((j) => (
+            <li class="journey-card journey-card--muted">
+              <span class="journey-card__name">{j.name}</span>
+              <span class="coming-soon-chip">Phase {j.phase}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    )}
+  </Section>
+</SiteLayout>
+
+<style>
+  .journeys__headline {
+    margin-bottom: var(--ds-space-3);
+  }
+
+  .journeys__subhead {
+    font-size: var(--ds-type-body-lg);
+    color: var(--ds-on-surface-2);
+    max-width: 60ch;
+    margin-bottom: var(--ds-space-8);
+    line-height: var(--ds-lead-body);
+  }
+
+  .journeys__group-title {
+    font-size: var(--ds-type-h3);
+    margin-bottom: var(--ds-space-5);
+    color: var(--ds-on-surface);
+  }
+
+  .journeys__live {
+    margin-bottom: var(--ds-space-9);
+  }
+
+  .journeys__coming-soon {
+    padding-top: var(--ds-space-7);
+    border-top: 1px solid var(--ds-border);
+  }
+
+  .journeys-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: var(--ds-space-5);
+  }
+
+  .journey-card {
+    background-color: var(--ds-surface-alt);
+    border: 1px solid var(--ds-border);
+    border-left: 4px solid var(--ds-accent);
+    border-radius: var(--ds-radius-md);
+    padding: var(--ds-space-6);
+    transition: border-color var(--ds-dur-moderate) var(--ds-ease-std);
+  }
+
+  .journey-card:hover {
+    border-color: var(--ds-accent);
+  }
+
+  .journey-card--muted {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--ds-space-3);
+    opacity: 0.6;
+    border-left-color: var(--ds-border);
+  }
+
+  .journey-card__link {
+    display: block;
+    text-decoration: none;
+    color: inherit;
+  }
+
+  .journey-card__name {
+    display: block;
+    font-size: var(--ds-type-body-lg);
+    font-weight: var(--ds-weight-semibold);
+    color: var(--ds-on-surface);
+    margin-bottom: var(--ds-space-3);
+  }
+
+  .journey-card--muted .journey-card__name {
+    font-size: var(--ds-type-body);
+    font-weight: var(--ds-weight-medium);
+    margin-bottom: 0;
+  }
+
+  .journey-card__cta {
+    font-size: var(--ds-type-sm);
+    font-weight: var(--ds-weight-semibold);
+    color: var(--ds-accent-deep);
+  }
+
+  .coming-soon-chip {
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--ds-track-label);
+    background-color: var(--ds-border);
+    color: var(--ds-on-surface-muted);
+    padding: 0.1rem 0.5rem;
+    border-radius: var(--ds-radius-sm);
+    flex-shrink: 0;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .journey-card {
+      transition: none;
+    }
+  }
+</style>

--- a/web/src/pages/packs/[pack].astro
+++ b/web/src/pages/packs/[pack].astro
@@ -1,0 +1,231 @@
+---
+import { getCollection, render } from 'astro:content';
+import SiteLayout from '../../components/layout/SiteLayout.astro';
+import PackHero from '../../components/pack/PackHero.astro';
+import Section from '../../components/layout/Section.astro';
+import { withBase } from '../../lib/paths';
+
+export async function getStaticPaths() {
+  const packs = await getCollection('packs');
+  return packs.map((entry) => ({
+    params: { pack: entry.id.replace(/\.md$/, '') },
+    props: { entry },
+  }));
+}
+
+const { entry } = Astro.props;
+const { data } = entry;
+const { Content } = await render(entry);
+
+const hasJourney = !!data.journeyUrl;
+---
+
+<SiteLayout
+  title={`${data.name} pack — agent-ready-repo`}
+  description={data.tagline}
+>
+  <PackHero
+    name={data.name}
+    scope={data.scope}
+    tagline={data.tagline}
+    skillCount={data.skills.length}
+  />
+
+  <Section tone="surface">
+    <div class="pack-body">
+      <!-- Description -->
+      <div class="pack-description">
+        <Content />
+      </div>
+
+      <!-- Skills -->
+      <div class="pack-section">
+        <h2 class="pack-section__title">Skills in this pack</h2>
+        <ul class="skills-list">
+          {data.skills.map((skill) => (
+            <li class="skill-item">
+              <code class="skill-name">{skill}</code>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <!-- Install -->
+      <div class="pack-section">
+        <h2 class="pack-section__title">Install</h2>
+        <div class="install-block">
+          <pre class="install-block__code"><code>{data.installCommand}</code></pre>
+        </div>
+        <p class="install-note">
+          Requires <a href={withBase('/docs/getting-started/')}>agentbundle</a>.
+        </p>
+      </div>
+
+      <!-- Journey -->
+      <div class="pack-section">
+        <h2 class="pack-section__title">Journey</h2>
+        {hasJourney ? (
+          <a class="journey-link" href={withBase(data.journeyUrl!)}>
+            <div class="journey-link__inner">
+              <span class="journey-link__label">Explore the {data.name} journey</span>
+              <span class="journey-link__sub">See what it's like to use this pack — staged narrative with gate-by-gate guidance.</span>
+            </div>
+            <span class="journey-link__arrow" aria-hidden="true">→</span>
+          </a>
+        ) : (
+          <div class="journey-coming-soon">
+            <span class="journey-coming-soon__label">Journey coming soon</span>
+            <p class="journey-coming-soon__sub">The narrative walkthrough for this pack is being authored. Check back after Phase 2.</p>
+          </div>
+        )}
+      </div>
+
+      <!-- Docs -->
+      <div class="pack-section">
+        <a class="docs-link" href={withBase(data.docsUrl)}>
+          Read the full reference <span aria-hidden="true">↗</span>
+        </a>
+      </div>
+    </div>
+  </Section>
+</SiteLayout>
+
+<style>
+  .pack-body {
+    max-width: 72ch;
+    display: grid;
+    gap: var(--ds-space-9);
+  }
+
+  .pack-description {
+    font-size: var(--ds-type-body-lg);
+    color: var(--ds-on-surface-2);
+    line-height: var(--ds-lead-body);
+  }
+
+  .pack-section__title {
+    font-size: var(--ds-type-h3);
+    margin-bottom: var(--ds-space-4);
+    color: var(--ds-on-surface);
+  }
+
+  .skills-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--ds-space-3);
+  }
+
+  .skill-item {
+    list-style: none;
+  }
+
+  .skill-name {
+    display: inline-block;
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-mono-sm);
+    background-color: var(--ds-accent-subtle);
+    color: var(--ds-accent-deep);
+    padding: 0.25rem 0.6rem;
+    border-radius: var(--ds-radius-sm);
+  }
+
+  .install-block {
+    background-color: var(--ds-hero-bg);
+    border-radius: var(--ds-radius-md);
+    padding: var(--ds-space-5) var(--ds-space-6);
+    margin-bottom: var(--ds-space-3);
+  }
+
+  .install-block__code {
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-mono-sm);
+    color: var(--ds-hero-fg);
+    line-height: var(--ds-lead-mono);
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    margin: 0;
+  }
+
+  .install-note {
+    font-size: var(--ds-type-sm);
+    color: var(--ds-on-surface-muted);
+  }
+
+  .journey-link {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--ds-space-4);
+    background-color: var(--ds-surface-alt);
+    border: 1px solid var(--ds-border);
+    border-left: 4px solid var(--ds-accent);
+    border-radius: var(--ds-radius-md);
+    padding: var(--ds-space-6);
+    text-decoration: none;
+    color: inherit;
+    transition: border-color var(--ds-dur-moderate) var(--ds-ease-std);
+  }
+
+  .journey-link:hover {
+    border-color: var(--ds-accent);
+    border-left-color: var(--ds-accent);
+  }
+
+  .journey-link__label {
+    display: block;
+    font-weight: var(--ds-weight-semibold);
+    font-size: var(--ds-type-body-lg);
+    color: var(--ds-on-surface);
+    margin-bottom: var(--ds-space-2);
+  }
+
+  .journey-link__sub {
+    font-size: var(--ds-type-sm);
+    color: var(--ds-on-surface-muted);
+    line-height: var(--ds-lead-body);
+  }
+
+  .journey-link__arrow {
+    font-size: var(--ds-type-h3);
+    color: var(--ds-accent);
+    flex-shrink: 0;
+  }
+
+  .journey-coming-soon {
+    background-color: var(--ds-surface-alt);
+    border: 1px solid var(--ds-border);
+    border-radius: var(--ds-radius-md);
+    padding: var(--ds-space-6);
+  }
+
+  .journey-coming-soon__label {
+    display: inline-block;
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--ds-track-label);
+    background-color: var(--ds-border);
+    color: var(--ds-on-surface-muted);
+    padding: 0.1rem 0.5rem;
+    border-radius: var(--ds-radius-sm);
+    margin-bottom: var(--ds-space-3);
+  }
+
+  .journey-coming-soon__sub {
+    font-size: var(--ds-type-sm);
+    color: var(--ds-on-surface-muted);
+    line-height: var(--ds-lead-body);
+  }
+
+  .docs-link {
+    font-weight: var(--ds-weight-semibold);
+    font-size: var(--ds-type-body-lg);
+    color: var(--ds-accent-deep);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .journey-link {
+      transition: none;
+    }
+  }
+</style>

--- a/web/src/pages/packs/index.astro
+++ b/web/src/pages/packs/index.astro
@@ -1,0 +1,59 @@
+---
+import { getCollection } from 'astro:content';
+import SiteLayout from '../../components/layout/SiteLayout.astro';
+import Section from '../../components/layout/Section.astro';
+import PackCard from '../../components/pack/PackCard.astro';
+
+const allPacks = await getCollection('packs');
+const packs = allPacks.sort((a, b) => {
+  // Keep the three loops first, then alpha by name
+  const order = ['core', 'product-engineering', 'release-engineering'];
+  const ai = order.indexOf(a.id.replace(/\.md$/, ''));
+  const bi = order.indexOf(b.id.replace(/\.md$/, ''));
+  if (ai !== -1 && bi !== -1) return ai - bi;
+  if (ai !== -1) return -1;
+  if (bi !== -1) return 1;
+  return a.data.name.localeCompare(b.data.name);
+});
+---
+
+<SiteLayout title="Pack catalogue — agent-ready-repo" description="14 packs covering the full software development lifecycle — from discovery to build to release.">
+  <Section tone="surface" labelledby="packs-heading">
+    <h1 id="packs-heading" class="packs__headline">The pack catalogue.</h1>
+    <p class="packs__subhead">
+      14 packs covering the full SDLC — discovery, build, release, and beyond.
+      Start with the loops.
+    </p>
+
+    <ul class="packs-grid">
+      {packs.map((entry) => (
+        <PackCard
+          slug={entry.id.replace(/\.md$/, '')}
+          name={entry.data.name}
+          scope={entry.data.scope}
+          tagline={entry.data.tagline}
+        />
+      ))}
+    </ul>
+  </Section>
+</SiteLayout>
+
+<style>
+  .packs__headline {
+    margin-bottom: var(--ds-space-3);
+  }
+
+  .packs__subhead {
+    font-size: var(--ds-type-body-lg);
+    color: var(--ds-on-surface-2);
+    max-width: 60ch;
+    margin-bottom: var(--ds-space-8);
+    line-height: var(--ds-lead-body);
+  }
+
+  .packs-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: var(--ds-space-5);
+  }
+</style>


### PR DESCRIPTION
## Summary

- Adds 14 pack pages (`/packs/[slug]`) and a pack index grid (`/packs/`)
- Adds 3 core journey pages (`/journeys/core`, `/journeys/discovery`, `/journeys/release`) with the full 8-section structure per `journey-page-template.md`
- Journey pages are fully light zone (`#fafaf9`); gate cards use amber left-border (`GateDetail.astro`, `<details>/<summary>`, zero JS)
- 11 packs with no live journey show a "coming soon" state via optional `journeyUrl` frontmatter field
- Journey narratives describe an active human role: watching at key moments, redirecting, reading review output, making gate decisions

## Design decisions in this PR

- **Light zone only on journey pages** — owner decision 2026-07-16; `journey-page-template.md` updated to reflect the override (was "Dark zone" for Sections 1 and 5)
- **`discovery` journey → `/packs/product-engineering/`** — slug mismatch is intentional; resolved via `packUrl` frontmatter field on each journey, not a code mapping table
- **`installCommand` derived at render time** on journey pages (from `pack` + `scope` frontmatter fields) — not stored in journeys frontmatter, which has no such field per the template
- **Amber-gold as sole chromatic accent** — `GateDetail` good/bad headings use `var(--ds-on-surface-muted)`, not green/red

## Gates

- `astro build` exits 0 — 21 pages generated
- pa11y WCAG2AA exits 0 on `/packs/` and `/journeys/core/`
- Adversarial review clean (one Concern resolved: template drift in `journey-page-template.md`; two Nits: unused variable removed, dead CSS modifier dropped)

## Phase 2 ACs

All 5 Phase 2 ACs checked in `docs/specs/platform-site/spec.md`.

## Deferred to Phase 3+

- Phases 3–4 journey pages (11 packs, content-gated)
- Section 6 "what good output looks like" screenshots (placeholder prose in place)
- SEO metadata + sitemap