### PR TITLE
feat(web): platform-site Phase 3 — six priority-2 journey pages

### DIFF
--- a/docs/specs/platform-site/spec.md
+++ b/docs/specs/platform-site/spec.md
@@ -81,7 +81,7 @@ Two journey slugs differ from their pack slugs: `discovery` → `product-enginee
 | 0 — MkDocs token alignment | Amber-gold CSS swap; global primary button override | Complete (all ACs met) |
 | 1 — Astro scaffold + homepage | Astro in `web/`, 9 homepage sections, CI pipeline | Complete (all ACs met; shipped in Phase 1 PR) |
 | 2 — Pack catalogue + core journeys | 14 pack pages + journey index + 3 core journey pages | Complete (all ACs met) |
-| 3 — Priority-2 journeys | research, architect, experience, contracts, converters, atlassian | Planned (content-gated) |
+| 3 — Priority-2 journeys | research, architect, experience, contracts, converters, atlassian | Complete (all ACs met) |
 | 4 — Remaining journeys + SEO | figma, governance-extras, credential-brokers, monorepo-extras, user-guide-diataxis; SEO metadata + sitemap | Planned (content-gated) |
 
 ## Objective
@@ -161,11 +161,11 @@ This spec uses goal-based checks and visual/manual QA. The Astro marketing site 
 
 ### Phase 3 — Priority-2 journey pages
 
-- [ ] Six journey pages authored and live: `/journeys/research`, `/journeys/architect`, `/journeys/experience`, `/journeys/contracts`, `/journeys/converters`, `/journeys/atlassian`
-- [ ] Each of the six pages renders the full 8-section structure from [journey-page-template.md](journey-page-template.md)
-- [ ] Journey index at `/journeys/` links to all 9 live journey pages (3 from Phase 2 + 6 from Phase 3); the remaining 5 show as "coming soon"
-- [ ] The six corresponding pack detail pages (`/packs/research`, `/packs/architect`, `/packs/experience`, `/packs/contracts`, `/packs/converters`, `/packs/atlassian`) show an active journey link (not "coming soon")
-- [ ] `npx pa11y http://localhost:4321/journeys/research --standard WCAG2AA` exits with 0 errors (verified on `research`; same template applies to all 6)
+- [x] Six journey pages authored and live: `/journeys/research`, `/journeys/architect`, `/journeys/experience`, `/journeys/contracts`, `/journeys/converters`, `/journeys/atlassian`
+- [x] Each of the six pages renders the full 8-section structure from [journey-page-template.md](journey-page-template.md)
+- [x] Journey index at `/journeys/` links to all 9 live journey pages (3 from Phase 2 + 6 from Phase 3); the remaining 5 show as "coming soon"
+- [x] The six corresponding pack detail pages (`/packs/research`, `/packs/architect`, `/packs/experience`, `/packs/contracts`, `/packs/converters`, `/packs/atlassian`) show an active journey link (not "coming soon")
+- [x] `npx pa11y http://localhost:4321/journeys/research --standard WCAG2AA` exits with 0 errors (verified on `research`; same template applies to all 6)
 
 ### Phase 4 — Remaining journey pages + SEO
 

--- a/web/src/content/journeys/architect.md
+++ b/web/src/content/journeys/architect.md
@@ -1,0 +1,83 @@
+---
+pack: architect
+scope: user
+tagline: "Design docs, diagrams, and reviews — workspace-agnostic."
+prerequisitePacks: []
+whatChanges: "After installing architect, every architecture artifact gets a method: `architect-design` produces Google-style design docs grounded against your repo's `reference.md`, `architect-diagram` draws the system in Mermaid (C4, sequence, state, ER, deployment), and `architect-review` critiques any design artifact with a severity-tagged rubric. The forked-context `design-reviewer` subagent gives every design an independent read — a reviewer that has not seen the authoring session."
+skills:
+  - name: architect-design
+    description: "Authors a Google-style technical design doc: Stage 0 concept → Stage 1 full write-up → Stage 2 review-ready artifact, grounded against the repo's reference architecture."
+    humanTouches: 2
+  - name: architect-diagram
+    description: "Draws the system, data model, flow, state, or deployment in Mermaid — C4 component, sequence, state, ER, or deployment topology."
+    humanTouches: 1
+  - name: architect-review
+    description: "Critiques an existing design doc, diagram, RFC, or ADR with a rubric-routed severity-tagged review; dispatches the independent forked-context design-reviewer subagent."
+    humanTouches: 1
+humanGates:
+  - id: G-concept
+    globalGate: null
+    label: "Approve the Stage 0 concept"
+    trigger: "After architect-design emits the initial Stage 0 concept framing"
+    duration: "5–10 minutes"
+    whatToCheck:
+      - "Is the problem statement clear and bounded — does it eliminate non-solutions?"
+      - "Are the listed constraints real constraints (things that cannot change) or preferences?"
+      - "Does the concept name the users and success criteria, not just the proposed approach?"
+      - "Is there an alternatives section, even at Stage 0 — at least two candidate approaches considered?"
+    whatGoodLooksLike: "A half-page concept that names the problem, real constraints, and a candidate approach — specific enough to commit to a full design doc or redirect before one is written."
+    whatBadLooksLike: "A concept that describes an approach without stating what problem it solves, or one that lists constraints the team would actually trade away if asked."
+    consequence: "The concept approval gates the full write-up. A wrong concept means the agent writes a polished doc for the wrong problem — the cost is a full write-up cycle, not a concept cycle."
+  - id: G-review
+    globalGate: null
+    label: "Review the design and independent critique"
+    trigger: "After architect-review or the design-reviewer subagent returns its findings"
+    duration: "15–25 minutes"
+    whatToCheck:
+      - "Did the independent design-reviewer flag any Blockers? (These are unchecked assumptions or missing alternatives — the ones a stakeholder would ask about.)"
+      - "Is the alternatives section complete — does it explain why alternatives were rejected, not just that they were?"
+      - "Are the open questions named explicitly — things not decided yet, distinguished from things decided badly?"
+      - "Does the doc match the Stage 0 concept you approved, or did it drift?"
+    whatGoodLooksLike: "A design doc with a clean independent review, a full alternatives section with reasoning, and explicitly named open questions."
+    whatBadLooksLike: "A design doc that passes review because the reviewer was given the authoring context and couldn't disagree. Or one that omits the alternatives the team already considered."
+    consequence: "The design doc is the artifact future engineers read when they encounter the system. An incomplete design doc creates an undocumented system — and every reader will form their own theory of why it works the way it does."
+typicalSession:
+  agentTurns: "6–10"
+  humanTouches: 2
+  wallClockMinutes: "30–60"
+docsUrl: /docs/guides/architect/
+packUrl: /packs/architect/
+relatedJourneys:
+  - core
+  - experience
+---
+
+## Stage 1 — Establish the reference
+
+Before any design work began, the agent checked for a `reference.md` in the repo — the golden-path file that describes the stack, patterns, and constraints the architecture skills design against. If one didn't exist, the agent offered to create it.
+
+**You did:** Confirmed the reference was accurate for this task. A grounded `reference.md` is what keeps the agent's designs inside your actual architecture, not an idealized one. If the reference was stale or missing a key constraint, update it before the design session starts — the agent will design against whatever it finds.
+
+---
+
+## Stage 2 — Stage 0 concept
+
+You described the design problem. The agent ran `architect-design` in Stage 0 mode, producing a half-page concept framing the problem, naming constraints, and proposing a candidate approach with at least one alternative.
+
+**You did:** Read the concept at the G-concept gate. If the framing missed the real constraint — for example, it proposed a new service when the constraint was "must run inside the existing Lambda" — redirect here, before the full write-up. The concept gate is the cheapest point to course-correct. If the alternatives section felt thin, ask for one more before approving.
+
+---
+
+## Stage 3 — Full design document
+
+After concept approval, the agent wrote the full Stage 1 design document: problem statement, alternatives considered with rejection reasoning, proposed design, open questions, and success criteria. It grounded the design against the repo's `reference.md` throughout.
+
+**You did:** Watched the doc take shape. If the alternatives section omitted an approach the team had already discussed and ruled out, mention it — a design doc that doesn't address the alternatives an experienced reader would ask about is one that will generate questions in review. If the agent drifted from the approved concept, note it.
+
+---
+
+## Stage 4 — Independent review
+
+The agent ran `architect-review`, which dispatched the `design-reviewer` subagent in a forked context — a reviewer that had not seen the authoring session. The reviewer returned findings grouped by severity (Blockers, Concerns, Nits).
+
+**You did:** Read the review findings at the G-review gate. For each Blocker, decide whether to fix it or provide a one-sentence reason it doesn't apply — "this is expected because the constraint was already accepted in the RFC." For Concerns and Nits, apply or defer with a reason. The independent read is the closest thing to "a colleague who just walked in" before the doc goes to stakeholders.

--- a/web/src/content/journeys/atlassian.md
+++ b/web/src/content/journeys/atlassian.md
@@ -1,0 +1,89 @@
+---
+pack: atlassian
+scope: user
+tagline: "Jira and Confluence from the agent — with DORA metrics."
+prerequisitePacks: []
+whatChanges: "After installing atlassian, Jira and Confluence are reachable from your agent session via credentialed REST API calls. `jira` and `jira-align` search, fetch, create, and update issues. `confluence-crawler` and `confluence-publisher` read and write wiki pages. `flow-metrics` computes DORA and Flow Framework metrics over a Jira scope. `jira-brief-intake` turns a Jira epic into a structured engineering brief. The credential resolves in-process via credential-brokers — it never reaches the model."
+skills:
+  - name: jira
+    description: "Searches issues with JQL (auto-paginated), fetches issue detail, creates, and updates issues through the Jira REST API."
+    humanTouches: 1
+  - name: jira-align
+    description: "Queries and manages Jira Align portfolio data — objectives, programs, and teams at the portfolio level."
+    humanTouches: 1
+  - name: jira-brief-intake
+    description: "Converts a Jira epic into a structured engineering brief: problem, user, success criteria, and constraints — the input to a work-loop spec."
+    humanTouches: 1
+  - name: jira-defect-flow
+    description: "Drives a defect from triage through root-cause analysis to fix, with the Jira issue updated at each stage."
+    humanTouches: 2
+  - name: flow-metrics
+    description: "Computes cycle time, throughput, and DORA metrics (deployment frequency, lead time, MTTR, change failure rate) over a scoped Jira project."
+    humanTouches: 1
+  - name: confluence-crawler
+    description: "Mirrors a Confluence space or page tree to Markdown for local analysis or ingestion into another workflow."
+    humanTouches: 0
+  - name: confluence-publisher
+    description: "Publishes a Markdown artifact to a Confluence page — creates or updates the page in place."
+    humanTouches: 1
+  - name: ai-adoption-report
+    description: "Generates an AI adoption report across a portfolio of Jira projects, measuring agent usage and impact."
+    humanTouches: 1
+humanGates:
+  - id: G-scope
+    globalGate: null
+    label: "Set the JQL scope and confirm the credential"
+    trigger: "Before any Jira query or Confluence operation is executed"
+    duration: "2–5 minutes"
+    whatToCheck:
+      - "Is the JQL scope specific enough to return the right issues — not the entire backlog or workspace?"
+      - "Is the credential configured for credential-brokers? (The agent will fail with a confusing error if the credential is absent or expired.)"
+      - "For flow-metrics: is the date range and project scope set to a meaningful period — not just 'all time'?"
+      - "For confluence-publisher: is the target space and parent page confirmed before any write operation?"
+    whatGoodLooksLike: "A scoped JQL query confirmed against the Jira project, a valid credential in place, and a named date range for time-based metrics."
+    whatBadLooksLike: "A JQL query that returns all issues in the workspace — the agent guessing scope instead of you defining it. Or a credential check skipped because 'it worked last time' — credentials expire."
+    consequence: "A miscoped JQL query produces metrics over the wrong population. For flow metrics this is a silent error — the numbers look plausible but measure the wrong thing. A missing credential stops the session mid-run."
+  - id: G-output
+    globalGate: null
+    label: "Review the output before it is published or acted on"
+    trigger: "After flow-metrics, jira-brief-intake, or confluence-publisher completes"
+    duration: "5–15 minutes"
+    whatToCheck:
+      - "For metrics: do the computed values match your informal expectation? An MTTR of 15 seconds or 15 months are both suspicious."
+      - "For briefs: does the engineering brief reflect the actual intent of the epic — or the most recent comment in the Jira thread, which may be noise?"
+      - "For Confluence publish: is the page in the right space and under the right parent page?"
+      - "Are there cancelled or out-of-scope issues in the metrics scope that should have been excluded?"
+    whatGoodLooksLike: "Metrics that match your intuition (or have a clear explanation when they don't). A brief that a senior engineer could implement from. A Confluence page that landed in the right place with the right parent."
+    whatBadLooksLike: "Metrics that are technically correct but meaningless — computed over a scope that wasn't cleaned up to exclude cancelled issues or unrelated projects. Or a Confluence page that published to the wrong space."
+    consequence: "Atlassian skills operate on live systems. A Confluence publish goes to the live wiki immediately. A flow metrics report shared with leadership is acted on. Review before the output leaves the session — there is no undo for a published Confluence page."
+typicalSession:
+  agentTurns: "5–10"
+  humanTouches: 2
+  wallClockMinutes: "15–40"
+docsUrl: /docs/guides/atlassian/
+packUrl: /packs/atlassian/
+relatedJourneys:
+  - core
+---
+
+## Stage 1 — Configure credentials and scope
+
+Before any API call, the agent checked that a credential was configured via `credential-brokers`. It then asked you to confirm the JQL scope or Confluence target before running the first query.
+
+**You did:** Confirmed the credential was in place — or set it up if this was the first run. Named the JQL scope explicitly: project key, issue type, status, and date range. A scoped query takes 10 seconds to define; an unscoped query returns thousands of issues and the agent has to guess which ones to include.
+
+---
+
+## Stage 2 — Fetch and process
+
+With credentials and scope confirmed, the agent ran the appropriate skill. For `jira`, it ran the JQL query with auto-pagination and returned the result set. For `flow-metrics`, it computed cycle time, throughput, and DORA metrics over the scoped data. For `jira-brief-intake`, it read the epic and structured it into a brief.
+
+**You did:** Watched the fetch complete. If the result set looked wrong — too many issues, too few, or issues from the wrong project — stop the agent and restate the scope. It's faster to re-scope than to post-process a wrong result set.
+
+---
+
+## Stage 3 — Review before publish or act
+
+The agent presented its output — a metrics table, a structured brief, or a proposed Confluence page — for review before taking any write action.
+
+**You did:** Reviewed the output at the G-output gate before the agent published to Confluence, posted a Jira update, or shared metrics. Atlassian skills operate on live systems; there is no draft mode for Confluence publishes. Check the content is correct, the target is right, and any Jira transitions are the ones you intended before approving the write.

--- a/web/src/content/journeys/contracts.md
+++ b/web/src/content/journeys/contracts.md
@@ -1,0 +1,60 @@
+---
+pack: contracts
+scope: user
+tagline: "OpenAPI 3.1 and AsyncAPI — API-first design."
+prerequisitePacks: []
+whatChanges: "After installing contracts, API design starts from the contract, not the code. `api-contract` produces a validated OpenAPI 3.1 spec from requirements, user stories, or a domain model. `event-contract` produces an AsyncAPI 2.x spec for event-driven interfaces. Both skills apply a pluggable house standard — the Zalando guidelines by default, your own base + delta bundle without forking the skill."
+skills:
+  - name: api-contract
+    description: "Authors an OpenAPI 3.1 contract from requirements or user stories — endpoints, request/response schemas, error codes, and the consumer-perspective check built in."
+    humanTouches: 1
+  - name: event-contract
+    description: "Authors an AsyncAPI 2.x event contract for a stream interface — message shape, channel bindings, and the producer/consumer boundary made explicit."
+    humanTouches: 1
+humanGates:
+  - id: G-contract
+    globalGate: null
+    label: "Review the contract before it drives implementation"
+    trigger: "After api-contract or event-contract produces the first complete draft"
+    duration: "10–20 minutes"
+    whatToCheck:
+      - "Does the contract reflect the agreed API surface — not a superset, not a subset of what was agreed?"
+      - "Are the error codes complete? A contract that only specifies 200 responses is a best-case spec, not a contract."
+      - "Are schema field names consistent with the team's existing naming conventions?"
+      - "Does the contract specify what the consumer needs — or what the producer finds convenient to produce?"
+      - "For event contracts: is the producer/consumer boundary explicit — does the contract name who owns the channel?"
+    whatGoodLooksLike: "A contract that names all resources, all error codes, and all schemas — and reads from the consumer's perspective, not the implementation's. Every developer who reads it could build a compatible client without asking the author."
+    whatBadLooksLike: "A contract that matches an existing implementation exactly — this means the agent described the implementation rather than the agreed surface. Or a contract that omits all 4xx/5xx error cases."
+    consequence: "The contract is the implementation brief for every consumer of this API or event stream. A contract approved with missing error codes means every consumer discovers those errors through production failures, not through the spec."
+typicalSession:
+  agentTurns: "4–8"
+  humanTouches: 1
+  wallClockMinutes: "15–30"
+docsUrl: /docs/guides/contracts/
+packUrl: /packs/contracts/
+relatedJourneys:
+  - architect
+  - core
+---
+
+## Stage 1 — Author the contract
+
+You described the API surface — the resources, actions, and consumers. The agent ran `api-contract` or `event-contract` with the pluggable house standard configured (Zalando guidelines by default). It produced a first-draft contract: endpoints, request/response schemas, error codes, and the consumer-perspective check.
+
+**You did:** Watched the draft take shape and noted corrections as they arose — don't wait for the full draft to redirect on a naming convention or a missing error case. Small corrections mid-draft are faster than a full re-generate. If you knew the consumer would call this API in a specific way, say so before the agent finalizes the response schemas.
+
+---
+
+## Stage 2 — Review from the consumer's perspective
+
+After the first complete draft, the agent ran a self-review against the house standard. You reviewed the contract at the G-contract gate — reading from the consumer's perspective, not the producer's.
+
+**You did:** Read through the error responses first. The most common failure mode is a contract that specifies the happy path thoroughly but skips error cases — a 200 response with no corresponding 400, 404, or 500. If an error case was missing, name it explicitly: the agent can't infer which errors are real without domain knowledge. If the schema field names used inconsistent conventions (camelCase in some places, snake_case in others), correct them here before implementation begins.
+
+---
+
+## Stage 3 — Versioned output
+
+The ratified contract was emitted as a versioned OpenAPI 3.1 or AsyncAPI 2.x file, ready to commit alongside the implementation it governs.
+
+**You did:** Confirmed the contract file was placed alongside the service it governs — not in a separate repository or a documentation folder that would diverge from the service over time. A contract that lives apart from its implementation will drift silently until a consumer discovers the mismatch.

--- a/web/src/content/journeys/converters.md
+++ b/web/src/content/journeys/converters.md
@@ -1,0 +1,76 @@
+---
+pack: converters
+scope: user
+tagline: "Document conversion — between every format your team uses."
+prerequisitePacks: []
+whatChanges: "After installing converters, document conversion is a named operation with a verifiable output. `file-to-markdown` converts PDFs, DOCX, and images to clean Markdown. `msg-to-markdown` converts Outlook .msg and MIME .eml email. `mermaid-renderer` bakes Mermaid fence blocks to SVG or PNG. The four Markdown-to-* skills fill a named template and produce styled office output. `render-proof` renders a Markdown draft as an offline HTML proof for human review. A three-tier capability model ensures the floor works in locked-down environments."
+skills:
+  - name: file-to-markdown
+    description: "Converts documents — PDF, DOCX, PPTX, XLSX, and images — to clean Markdown using a three-tier capability model (no-dep, local-tools, agent-vision)."
+    humanTouches: 0
+  - name: msg-to-markdown
+    description: "Converts Outlook .msg and MIME .eml email to Markdown, preserving headers, body structure, and attachment inventory."
+    humanTouches: 0
+  - name: render-proof
+    description: "Renders a Markdown file as a self-contained offline HTML proof artifact for human review — muted palette deliberately distinct from the publication look."
+    humanTouches: 0
+  - name: markdown-to-html
+    description: "Produces a styled, self-contained HTML page from a Markdown source — shareable without external assets."
+    humanTouches: 0
+  - name: markdown-to-docx
+    description: "Fills a branded Word template from a Markdown source — brand intact, no manual reformatting."
+    humanTouches: 0
+  - name: markdown-to-pptx
+    description: "Fills a branded PowerPoint template from a Markdown source — slide structure derived from headings."
+    humanTouches: 0
+  - name: markdown-to-xlsx
+    description: "Fills a branded Excel template from a Markdown source — tables and structured data mapped to sheets."
+    humanTouches: 0
+  - name: mermaid-renderer
+    description: "Renders Mermaid fence blocks from a Markdown file to SVG or PNG — for tools that don't render Mermaid live."
+    humanTouches: 0
+humanGates:
+  - id: G-output
+    globalGate: null
+    label: "Review the converted output"
+    trigger: "After any converter skill reports completion"
+    duration: "2–5 minutes"
+    whatToCheck:
+      - "Is all key content present — no silent truncation of large sections or long tables?"
+      - "For office output: does the template apply correctly — brand, fonts, and structure intact, not plain Times New Roman?"
+      - "For Markdown extraction: are code blocks, tables, and document structure preserved as intended?"
+      - "For mermaid-renderer: does the rendered image match the diagram in the source — no missing nodes or broken edges?"
+    whatGoodLooksLike: "An output that faithfully represents the source content in the target format, with structure and styling preserved — something you'd be comfortable sending to a stakeholder."
+    whatBadLooksLike: "An output that passes the file-exists check but silently dropped a section or table. Or office output where the template wasn't applied — the agent reported success but the file opened in the wrong font."
+    consequence: "Converter outputs are usually shared with stakeholders or used as input to another workflow. A silently incomplete conversion is discovered by the stakeholder, not the agent — and by then it's too late to re-run quietly."
+typicalSession:
+  agentTurns: "2–4"
+  humanTouches: 1
+  wallClockMinutes: "5–15"
+docsUrl: /docs/guides/converters/
+packUrl: /packs/converters/
+relatedJourneys:
+  - core
+---
+
+## Stage 1 — Invoke the converter
+
+You named the source file and the target format. The agent invoked the appropriate skill: `file-to-markdown` for a PDF or Office document, `markdown-to-docx` or `markdown-to-pptx` for output artifacts, `mermaid-renderer` for diagrams embedded in a Markdown file.
+
+**You did:** Named the source file explicitly and confirmed the target format. For office output, also named which template to use — the agent cannot discover your organization's brand template without you pointing to it. If the source was a large PDF and you only needed a specific section, say so before the agent converts the whole document.
+
+---
+
+## Stage 2 — Tier selection (for file-to-markdown)
+
+For document extraction, the agent selected the appropriate capability tier: Tier 1 (no external tools — pure text extraction), Tier 2 (local tools like Pandoc or Poppler), or Tier 3 (agent vision for scanned or image-heavy documents). It reported which tier was used and why.
+
+**You did:** Confirmed the tier made sense for the document type. If the document was a scanned PDF and the agent selected Tier 1, the extracted Markdown would contain garbled text — redirect to Tier 3 or flag the document as needing OCR before extraction.
+
+---
+
+## Stage 3 — Review the output
+
+The agent reported where the output landed and emitted a brief summary of what it converted.
+
+**You did:** Opened the output file and reviewed it at the G-output gate. The agent's report says "conversion complete" — what it cannot tell you is whether the resulting file is what you needed. Checked for truncation, structure loss, and template application. If a section was missing, re-run with an explicit instruction to include it.

--- a/web/src/content/journeys/experience.md
+++ b/web/src/content/journeys/experience.md
@@ -1,0 +1,122 @@
+---
+pack: experience
+scope: user
+tagline: "The design/UX seat for product teams."
+prerequisitePacks: []
+whatChanges: "After installing experience, product-engineering work has a full design thread from outcome to realization. `map-customer-journey` and `map-screen-flow` derive the screen list from a named outcome. `aesthetic-direction` and `design-system-foundations` establish the visual constraints before any screen is designed. `interaction-design` and `design-critique` craft and critique each screen to a shared quality floor. The forked-context `experience-reviewer` gives every design an independent pass — handle-all-states, WCAG 2.2 AA, reduced-motion."
+skills:
+  - name: map-customer-journey
+    description: "Maps the current and desired customer journey to derive the key touchpoints and failure modes a product must address."
+    humanTouches: 1
+  - name: map-screen-flow
+    description: "Derives the screen inventory and flow from the customer journey — what screens exist, what state each handles, what the transitions are."
+    humanTouches: 1
+  - name: blueprint-service
+    description: "Maps front-stage screen flows to the back-stage processes and human actors that support them — the service blueprint."
+    humanTouches: 0
+  - name: map-internal-process
+    description: "Documents the internal processes that run behind user-facing screens — the APQC/BPMN model of what people do."
+    humanTouches: 0
+  - name: aesthetic-direction
+    description: "Establishes the visual direction for a surface — palette, typography, spacing — as a named aesthetic reference that all subsequent screens must satisfy."
+    humanTouches: 1
+  - name: design-system-foundations
+    description: "Derives the design token set from the aesthetic direction — the primitive and semantic tokens that carry the design into code."
+    humanTouches: 0
+  - name: layout-and-information-architecture
+    description: "Designs the layout zones and information hierarchy for a screen, given its per-screen brief."
+    humanTouches: 0
+  - name: interaction-design
+    description: "Designs the interactive behaviors for a screen — states, transitions, feedback patterns — against WCAG 2.2 AA."
+    humanTouches: 0
+  - name: design-critique
+    description: "Critiques an existing screen design against the quality floor — handle-all-states, accessibility, reduced-motion — before the independent review."
+    humanTouches: 0
+humanGates:
+  - id: G-journey
+    globalGate: null
+    label: "Approve the customer journey and derived screen list"
+    trigger: "After map-customer-journey and map-screen-flow complete"
+    duration: "10–15 minutes"
+    whatToCheck:
+      - "Does the journey capture the outcome the user is trying to achieve — not just the tasks they perform in the current product?"
+      - "Is the screen list derived from the journey, not from the existing implementation or a wish list?"
+      - "Are the key failure modes named — the moments the current journey breaks down, and why?"
+      - "Is every screen in the list implied by the journey? (Remove screens that aren't.)"
+    whatGoodLooksLike: "A journey map that names the outcome, the failure modes, and a screen list with a clear derivation — each screen traceable to a moment in the journey."
+    whatBadLooksLike: "A screen list that maps to the current implementation screen-by-screen. This means the agent documented the status quo instead of designing for the outcome."
+    consequence: "The screen list is the contract for all design work that follows. A screen list derived from the wrong model means the design thread designs the wrong product — faithfully."
+  - id: G-aesthetic
+    globalGate: null
+    label: "Approve the aesthetic direction and token set"
+    trigger: "After aesthetic-direction and optionally design-system-foundations complete"
+    duration: "5–10 minutes"
+    whatToCheck:
+      - "Does the aesthetic direction name a specific visual character — not just 'clean and modern'?"
+      - "Are the contrast ratios in the token set verified at WCAG 2.2 AA minimum?"
+      - "Is the palette constrained to a small number of semantic roles — does adding a new color require a decision?"
+      - "Are the tokens derived from the aesthetic direction, not borrowed from a generic design system?"
+    whatGoodLooksLike: "A named aesthetic reference with a token set that derives directly from it, passes the contrast floor, and could be handed to a developer without ambiguity."
+    whatBadLooksLike: "An aesthetic direction that could apply to any product, or a token set that introduces hardcoded values outside the semantic token system."
+    consequence: "The aesthetic direction is the constraint every subsequent screen must satisfy. Approving a vague direction means screens drift with no shared reference to hold them together — and the experience-reviewer will flag every screen for the same missing constraint."
+  - id: G-experience-review
+    globalGate: null
+    label: "Review the designs after the independent experience-reviewer pass"
+    trigger: "After the experience-reviewer subagent returns findings on the completed screen designs"
+    duration: "15–25 minutes"
+    whatToCheck:
+      - "Did the reviewer flag any handle-all-states violations? (Missing empty, loading, error, or success states are the most common finding.)"
+      - "Are all WCAG 2.2 AA requirements met — color contrast, label associations, focus order?"
+      - "Is reduced-motion handled — are transitions guarded with prefers-reduced-motion?"
+      - "Are the screens consistent with the approved aesthetic direction — or did any screen introduce its own visual language?"
+    whatGoodLooksLike: "A design set that the independent reviewer marks clean — all states handled, accessibility floor met, aesthetic direction consistently applied across every screen."
+    whatBadLooksLike: "Screens that look good in the happy-path state but have no designed empty state, loading state, or error recovery. Or screens that pass visually but fail the accessibility audit."
+    consequence: "The experience-reviewer is the design analogue of adversarial-reviewer in the build loop. Its findings are the last check before design intent feeds the build. An unreviewed design is a set of unverified assumptions about how the product behaves when things go wrong."
+typicalSession:
+  agentTurns: "8–15"
+  humanTouches: 3
+  wallClockMinutes: "45–90"
+docsUrl: /docs/guides/experience/
+packUrl: /packs/experience/
+relatedJourneys:
+  - architect
+  - core
+---
+
+## Stage 1 — Map the customer journey
+
+You described the feature, user, and outcome. The agent ran `map-customer-journey` to produce the customer journey map — the current state (what happens today), the desired state (what should happen after this feature), and the key moments where the current journey breaks down.
+
+**You did:** Read the journey map and approved it at the G-journey gate. This is the most important gate in the experience thread — the screen list flows directly from it. If the map describes what the current product does rather than what the user is trying to achieve, redirect before the screen flow is derived. A one-sentence correction here saves a full design cycle.
+
+---
+
+## Stage 2 — Derive the screen flow
+
+With the journey approved, the agent ran `map-screen-flow` to derive the screen inventory: what screens exist, what state each one handles (empty, loading, populated, error), and what the transitions between them are. Each screen got a per-screen brief: the user's goal, the information they need, the states to handle.
+
+**You did:** Checked that the screen list felt right — that it didn't add screens not implied by the journey, and didn't miss screens the journey required. If the agent added a screen that looked useful but wasn't derived from the journey, remove it here.
+
+---
+
+## Stage 3 — Establish design intent
+
+Before designing any screen, the agent ran `aesthetic-direction` to establish the visual character of the surface — palette, typography, spacing — as a named aesthetic reference. It then ran `design-system-foundations` to derive the design token set.
+
+**You did:** Approved the aesthetic direction at the G-aesthetic gate. An aesthetic direction that says "clean and professional" is not an aesthetic direction — it needs to name a specific visual character with enough specificity to say whether a given design decision is consistent or not. If the tokens introduced hardcoded values outside the semantic token system, reject them.
+
+---
+
+## Stage 4 — Design each screen
+
+The agent ran `layout-and-information-architecture` and `interaction-design` on each screen in the flow, working from each screen's per-screen brief. It then ran `design-critique` on each screen before the independent review — a self-check against the quality floor.
+
+**You did:** Watched each screen take shape. If a screen was missing a state — no empty state for a list that could be empty, no loading state for an async action — name it. The agent will miss states not explicitly mentioned in the brief; that's what the experience-reviewer catches, but catching it here is cheaper.
+
+---
+
+## Stage 5 — Independent review
+
+The agent ran the `experience-reviewer` subagent in a forked context — a reviewer that had not seen the authoring session. The reviewer returned findings on the full screen set: handle-all-states violations, accessibility failures, aesthetic inconsistencies.
+
+**You did:** Read the review findings at the G-experience-review gate. Handle-all-states violations are the most common finding — a screen that works for the happy path but has no designed error state. WCAG findings affect all users. Apply Blockers before the design intent feeds the build loop; they represent the floor the spec says all screens must clear.

--- a/web/src/content/journeys/research.md
+++ b/web/src/content/journeys/research.md
@@ -1,0 +1,99 @@
+---
+pack: research
+scope: user
+tagline: "Evidence-grounded research — portable across every repo."
+prerequisitePacks: []
+whatChanges: "After installing research, every question your agent takes on is grounded before it answers. `/research` runs scoping, source curation, and synthesis in one session across four depth modes. For sustained investigations, the four `research-project-*` skills run a multi-week lifecycle that accumulates a corpus and ends in a brief you can hand to a decision."
+skills:
+  - name: research
+    description: "The primary research skill. Runs scoping, source curation, and synthesis in a single session, selecting depth from four modes — shallow through exhaustive."
+    humanTouches: 1
+  - name: source-map
+    description: "Maps the canonical sources for a topic before evidence retrieval begins — prevents wasting citations on secondary sources that restate a primary."
+    humanTouches: 0
+  - name: build-outline
+    description: "Builds a research outline from the source map, structuring the question before the agent fetches anything."
+    humanTouches: 1
+  - name: identify-perspectives
+    description: "Identifies the stakeholder perspectives and intellectual traditions bearing on a question before synthesis."
+    humanTouches: 0
+  - name: compare-hypotheses
+    description: "Runs the competing-hypotheses pipeline against a set of candidate answers, producing a scored matrix."
+    humanTouches: 0
+  - name: devils-advocate
+    description: "Steelmans the opposing case for a position — used after compare-hypotheses to stress-test the top candidate."
+    humanTouches: 0
+  - name: decision-archaeology
+    description: "Reconstructs why a prior decision was made from artifacts, commit history, and design docs — used when the answer is historical rather than open."
+    humanTouches: 0
+  - name: research-project-start
+    description: "Initializes a research project folder with a scoped question, source list, and corpus skeleton."
+    humanTouches: 1
+  - name: research-project-check
+    description: "Snapshots progress: which sources are captured, what the corpus covers, and what remains."
+    humanTouches: 0
+  - name: research-project-digest
+    description: "Summarizes the accumulated corpus into a digest artifact — the input to the final synthesis."
+    humanTouches: 0
+  - name: research-project-synthesize
+    description: "Synthesizes the corpus digest into a brief graded by confidence, ready to hand to a decision."
+    humanTouches: 1
+humanGates:
+  - id: G-scope
+    globalGate: null
+    label: "Set scope and depth"
+    trigger: "Before /research or research-project-start runs"
+    duration: "3–5 minutes"
+    whatToCheck:
+      - "Is the question specific enough to return a useful answer? (Vague questions return vague syntheses.)"
+      - "Is the correct depth mode selected — shallow for orientation, deep or exhaustive for a decision-quality brief?"
+      - "Is there a prior corpus this question should extend, or is this a fresh start?"
+      - "Is there a success criterion — how will you know when the research is complete?"
+    whatGoodLooksLike: "A specific, answerable question with a chosen depth mode and a clear success criterion — something a colleague could pick up and continue."
+    whatBadLooksLike: "A question that can't be falsified or finished — 'what is the best approach to X?' with no scope boundary or success criterion."
+    consequence: "The scope gate sets the direction for everything that follows. A bad scope means the agent searches the wrong space and returns a synthesis that looks complete but answers the wrong question."
+  - id: G-synthesis
+    globalGate: null
+    label: "Review the synthesized brief"
+    trigger: "After the synthesis step completes"
+    duration: "10–20 minutes"
+    whatToCheck:
+      - "Does the synthesis cite primary sources, not just secondary summaries?"
+      - "Is the confidence grade honest? (A GRADE-C answer dressed as GRADE-A is worse than an honest gap.)"
+      - "Does the brief directly answer the original question — or an easier adjacent question?"
+      - "Are the gaps named explicitly, with a note on what would be needed to fill them?"
+    whatGoodLooksLike: "A synthesis that names its sources, grades its confidence honestly, and directly answers the scoped question — including an explicit gap map where confidence is low."
+    whatBadLooksLike: "A synthesis that sounds authoritative but can't be traced to primary sources. Or one that confidently answers a different question than the one you asked."
+    consequence: "The synthesis is the final output. A confident but wrong synthesis is actively harmful. If the confidence grade is low, the right response is to narrow the question or run another retrieval pass — not to ship the draft."
+typicalSession:
+  agentTurns: "4–8"
+  humanTouches: 2
+  wallClockMinutes: "15–40"
+docsUrl: /docs/guides/research/
+packUrl: /packs/research/
+relatedJourneys:
+  - architect
+  - core
+---
+
+## Stage 1 — Scope the question
+
+You gave the agent a question and selected a depth mode. For a single-session query, the agent activated `/research` and ran a scoping pass — identifying what kind of question this was (factual, comparative, historical, open-ended) and which sources it should consult. For a project-mode investigation, it ran `research-project-start` to create a corpus folder and an initial source list.
+
+**You did:** Read the scope statement the agent produced before it began fetching. A bad scope leads to a confident answer to the wrong question — the cheapest fix is here, not after the synthesis returns. If the agent's framing missed the real question, redirect with one sentence before the retrieval subagents run.
+
+---
+
+## Stage 2 — Source curation
+
+The agent ran `source-map` or its equivalent, identifying the canonical sources for the question domain. Two retrieval subagents — `evidence-retriever` and `source-extractor` — fetched and synthesized source material without polluting the main session context.
+
+**You did:** Watched the source list take shape. If a key source was missing — a specific industry report, a primary author's original paper, an internal standard you know exists — name it explicitly. The agent doesn't know what you know about your domain. A one-sentence nudge here is faster than a post-synthesis correction.
+
+---
+
+## Stage 3 — Synthesis and grading
+
+After sources were captured, the agent synthesized a brief graded by confidence (GRADE A–D). Each claim cited its source. Unsupported claims were marked explicitly as gaps, not silently omitted.
+
+**You did:** Reviewed the synthesis at the G-synthesis gate. The confidence grades are the first thing to read — a GRADE-C synthesis needs a different follow-on action (narrow the question, run another retrieval pass, seek a domain expert) than a GRADE-A synthesis (act on it). If a claim lacked a source citation, check whether it's an inference the agent labeled correctly or an assertion it presented as fact.

--- a/web/src/content/packs/architect.md
+++ b/web/src/content/packs/architect.md
@@ -8,6 +8,7 @@ skills:
   - architect-review
 installCommand: "agentbundle install --pack architect --scope user"
 docsUrl: /docs/guides/architect/
+journeyUrl: /journeys/architect/
 ---
 
 Architect installs three solution-architecture skills: `architect-design` (Google-style design docs), `architect-diagram` (Mermaid diagrams — C4, sequence, state, ER), and `architect-review` (rubric-routed critique). A forked-context `design-reviewer` subagent gives every design an independent read — it does not review its own work. No required configuration; workspace-agnostic by default.

--- a/web/src/content/packs/atlassian.md
+++ b/web/src/content/packs/atlassian.md
@@ -13,6 +13,7 @@ skills:
   - ai-adoption-report
 installCommand: "agentbundle install --pack atlassian --scope user"
 docsUrl: /docs/guides/atlassian/
+journeyUrl: /journeys/atlassian/
 ---
 
 Atlassian installs Jira and Confluence primitives (credentialed CLI with SSO-cookie auth) plus four workflow skills: `flow-metrics` (DORA + cycle time), `ai-adoption-report` (measuring agent adoption across a portfolio), `jira-defect-flow` (triage to fix), and `jira-brief-intake` (turning Jira tickets into structured engineering briefs). Credentials resolved via `credential-brokers` — cleartext never reaches the model.

--- a/web/src/content/packs/contracts.md
+++ b/web/src/content/packs/contracts.md
@@ -7,6 +7,7 @@ skills:
   - event-contract
 installCommand: "agentbundle install --pack contracts --scope user"
 docsUrl: /docs/guides/contracts/
+journeyUrl: /journeys/contracts/
 ---
 
 Contracts installs two contract-authoring skills: `api-contract` (OpenAPI 3.1 for synchronous REST/HTTP APIs) and `event-contract` (AsyncAPI 2.x for event-driven interfaces). Both skills are user-scope by default — contract style is portable across projects and reflects the engineer's discipline, not the repo's.

--- a/web/src/content/packs/converters.md
+++ b/web/src/content/packs/converters.md
@@ -5,6 +5,7 @@ tagline: "Document conversion — between every format your team uses."
 skills:
   - file-to-markdown
   - msg-to-markdown
+  - render-proof
   - markdown-to-html
   - markdown-to-docx
   - markdown-to-pptx
@@ -12,6 +13,7 @@ skills:
   - mermaid-renderer
 installCommand: "agentbundle install --pack converters --scope user"
 docsUrl: /docs/guides/converters/
+journeyUrl: /journeys/converters/
 ---
 
 Converters installs seven file-format conversion skills. `file-to-markdown` converts documents (PDF, DOCX, images) to Markdown. `msg-to-markdown` converts Outlook .msg and MIME .eml email. The four Markdown-to-* skills produce styled HTML, branded Word, PowerPoint, and Excel output. `mermaid-renderer` renders Mermaid diagrams to SVG or PNG. A three-tier capability model (no-dep, local-tools, agent-vision) ensures the floor works in locked-down environments.

--- a/web/src/content/packs/experience.md
+++ b/web/src/content/packs/experience.md
@@ -14,6 +14,7 @@ skills:
   - interaction-design
 installCommand: "agentbundle install --pack experience --scope user"
 docsUrl: /docs/guides/experience/
+journeyUrl: /journeys/experience/
 ---
 
 Experience installs the full design thread from outcome to realization. Connective skills walk customer-journey → screen-flow → service-blueprint and the inside-out sibling (internal process). Craft skills design each screen (aesthetic-direction, design-system-foundations, layout, interaction-design) and critique it (design-critique), all held to one shared quality floor — handle-all-states, WCAG 2.2 AA, reduced-motion. A forked-context `experience-reviewer` gives every design an independent review.

--- a/web/src/content/packs/research.md
+++ b/web/src/content/packs/research.md
@@ -16,6 +16,7 @@ skills:
   - research-project-synthesize
 installCommand: "agentbundle install --pack research --scope user"
 docsUrl: /docs/guides/research/
+journeyUrl: /journeys/research/
 ---
 
 Research installs eleven skills grounded in seven convergent disciplines (STORM, PRISMA, ACH, Wikipedia V/RS/NPOV, OSINT, GIJN, GRADE). A single-query mode runs scoping, source curation, and synthesis in one session. A project mode runs sustained multi-week investigations through four lifecycle phases. Two retrieval subagents (`evidence-retriever`, `source-extractor`) fetch and synthesize external sources without polluting the main session context.

--- a/web/src/pages/journeys/index.astro
+++ b/web/src/pages/journeys/index.astro
@@ -7,13 +7,13 @@ import { withBase } from '../../lib/paths';
 const liveJourneys = await getCollection('journeys');
 const liveSlugSet = new Set(liveJourneys.map((e) => e.id.replace(/\.md$/, '')));
 
-// All 14 journey slugs in priority order; 3 are live in Phase 2, 11 are coming soon.
+// All 14 journey slugs in priority order; 9 are live (Phase 2 + 3), 5 are coming soon (Phase 4).
 const allJourneys = [
   // Phase 2 — live
   { slug: 'core', name: 'Core', phase: 2 },
   { slug: 'discovery', name: 'Discovery (Product Engineering)', phase: 2 },
   { slug: 'release', name: 'Release Engineering', phase: 2 },
-  // Phase 3 — coming soon
+  // Phase 3 — live
   { slug: 'research', name: 'Research', phase: 3 },
   { slug: 'architect', name: 'Architect', phase: 3 },
   { slug: 'experience', name: 'Experience', phase: 3 },


### PR DESCRIPTION
## Summary

- Authors 6 new journey pages for the Phase-3 packs: research, architect, experience, contracts, converters, and atlassian
- Each journey uses the full 8-section structure from `journey-page-template.md` (hero, what-changes, skills, staged narrative, human gates, good-output, session stats, install + next steps)
- Updates the 6 corresponding pack pages to replace "coming soon" with active journey links
- Journey index at `/journeys/` now shows 9 live journeys + 5 coming soon (Phase 4 only)

## Gates

- `astro build` exits 0; all 6 new routes generated
- `npx pa11y /journeys/research/ --standard WCAG2AA`: 0 errors
- `npx pa11y /journeys/atlassian/ --standard WCAG2AA`: 0 errors
- All 6 pack pages: `journey-link` present, `journey-coming-soon` absent
- Adversarial review: clean after fixes

## Bundled fixes

- `render-proof` added to converters journey skills list and `packs/converters.md` — was present in the pack but omitted from both surfaces by prior oversight; guide docs also omit it (pre-existing)
- `journeys/index.astro` comments updated: "3 live, 11 coming soon" → "9 live, 5 coming soon"
- `spec.md` Phase 3 ACs checked off; Phase 3 summary row updated to "Complete (all ACs met)"

## Deferred

Nothing deferred. Phase 4 (figma, governance-extras, credential-brokers, monorepo-extras, user-guide-diataxis + SEO) remains in the spec as planned.