### PR TITLE
chore(ci): upgrade Node.js from 22 to 24

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,7 +28,7 @@ jobs:
       # BEFORE MkDocs writes into build/docs/ — otherwise MkDocs output is wiped.
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: npm
           cache-dependency-path: web/package-lock.json
 

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -12,7 +12,7 @@ dependencies are recorded here before they are added.
 
 | Dependency | Version | Why |
 | --- | --- | --- |
-| Node.js | `>=22.12.0` (see `package.json` `engines`) | Astro build/runtime toolchain |
+| Node.js | `>=24.0.0` (see `package.json` `engines`) | Astro build/runtime toolchain |
 | [`astro`](https://astro.build) | pinned `7.1.0` (exact, not a range) | Static-site generator for the marketing pages; pinned for reproducible CI |
 | [`@astrojs/sitemap`](https://docs.astro.build/en/guides/integrations-guide/sitemap/) | pinned `3.7.3` (exact, not a range) | Generates `sitemap-index.xml` + `sitemap-0.xml` at build time for SEO (Phase 4) |
 

--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "engines": {
-    "node": ">=22.12.0"
+    "node": ">=24.0.0"
   },
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
## Summary

- `.github/workflows/pages.yml`: `node-version: "22"` → `"24"`
- `web/package.json`: `engines.node: ">=22.12.0"` → `">=24.0.0"`
- `web/AGENTS.md`: dependency record updated to match

## Why

GitHub Actions deprecated Node 20 runners and forces them to Node 24. We were on Node 22 — bumping to 24 eliminates the CI warning and aligns with the current LTS.

## Test plan

- [ ] CI build + deploy green with no Node deprecation warning