### PR TITLE
docs(new-guide): structural AI tells rubric + 4-question self-check (0.1.6)

### DIFF
--- a/.agents/skills/new-guide/references/clear-prose.md
+++ b/.agents/skills/new-guide/references/clear-prose.md
@@ -32,6 +32,35 @@ search for once you know its shape.
   "This section explains how to rotate a token." The reader already read the
   heading. Start rotating the token.
 
+## Structural tells
+
+These are harder to catch than vocabulary tells because they survive a word-level
+pass. A draft can have zero inflated verbs and still read as machine-made if it
+falls into these patterns.
+
+- **Treadmill effect.** Each paragraph restates the previous one rather than
+  advancing the argument. The text circles the idea without arriving anywhere. Fix:
+  read the first and last sentence of each paragraph — the last should move past the
+  first, not echo it.
+- **Symmetrical lists.** Bullet items of identical length, parallel construction,
+  and equal weight — as if generated to fill a template rather than to capture
+  genuinely distinct points. A real list of three items is rarely three identical
+  sentences. Vary length and depth to match the actual shape of the content.
+- **False precision.** Authoritative framing — "research shows", "studies indicate",
+  "it's important to note" — without a grounded specific behind it. If you can't
+  name the study, the finding, or the number, replace the framing with a concrete
+  claim or cut it.
+- **Performative thoroughness.** Seven considerations when two drive the decision.
+  The extra five exist to signal completeness, not to inform. Cut the padding; leave
+  the two that matter.
+- **Nice-nice wrap.** Both sides of a conflict hedged to avoid commitment — the text
+  names a tension but refuses to land on a position. A reader should be able to
+  disagree with a claim in your doc. If there's nothing to push back on, there's
+  nothing being said.
+- **Subtext vacuum.** Flat, safe-for-any-audience prose with no implied reader.
+  Human writing carries a register — a sense of who it's for and what they already
+  know. Writing for everyone reads as writing for no one.
+
 ## Habits to keep
 
 - **One claim per sentence.** If a sentence has two "and"s and a "which", it's
@@ -63,6 +92,15 @@ Read the draft cold, ideally out loud. The sentences you stumble over are the
 ones to cut or split. If a paragraph could be three bullets, make it three
 bullets. If a sentence survives only because it sounds finished, it's filler —
 cut it.
+
+Run these four questions on the draft to catch structural tells a vocabulary pass
+will miss:
+
+1. Does the argument advance paragraph to paragraph, or restate?
+2. Does each list item earn its slot, or pad?
+3. Is there a position the text can be disagreed with?
+4. Is any specific detail grounded — a name, a date, a count, an observation —
+   or is specificity only performed?
 
 When your environment has subagents, the skill's optional copyedit pass hands
 the draft and this checklist to a fresh reader so the style read stays off your

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -257,7 +257,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "user-guide-diataxis",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.1.5"
+      "version": "0.1.6"
     }
   ]
 }

--- a/.claude/skills/new-guide/references/clear-prose.md
+++ b/.claude/skills/new-guide/references/clear-prose.md
@@ -32,6 +32,35 @@ search for once you know its shape.
   "This section explains how to rotate a token." The reader already read the
   heading. Start rotating the token.
 
+## Structural tells
+
+These are harder to catch than vocabulary tells because they survive a word-level
+pass. A draft can have zero inflated verbs and still read as machine-made if it
+falls into these patterns.
+
+- **Treadmill effect.** Each paragraph restates the previous one rather than
+  advancing the argument. The text circles the idea without arriving anywhere. Fix:
+  read the first and last sentence of each paragraph — the last should move past the
+  first, not echo it.
+- **Symmetrical lists.** Bullet items of identical length, parallel construction,
+  and equal weight — as if generated to fill a template rather than to capture
+  genuinely distinct points. A real list of three items is rarely three identical
+  sentences. Vary length and depth to match the actual shape of the content.
+- **False precision.** Authoritative framing — "research shows", "studies indicate",
+  "it's important to note" — without a grounded specific behind it. If you can't
+  name the study, the finding, or the number, replace the framing with a concrete
+  claim or cut it.
+- **Performative thoroughness.** Seven considerations when two drive the decision.
+  The extra five exist to signal completeness, not to inform. Cut the padding; leave
+  the two that matter.
+- **Nice-nice wrap.** Both sides of a conflict hedged to avoid commitment — the text
+  names a tension but refuses to land on a position. A reader should be able to
+  disagree with a claim in your doc. If there's nothing to push back on, there's
+  nothing being said.
+- **Subtext vacuum.** Flat, safe-for-any-audience prose with no implied reader.
+  Human writing carries a register — a sense of who it's for and what they already
+  know. Writing for everyone reads as writing for no one.
+
 ## Habits to keep
 
 - **One claim per sentence.** If a sentence has two "and"s and a "which", it's
@@ -63,6 +92,15 @@ Read the draft cold, ideally out loud. The sentences you stumble over are the
 ones to cut or split. If a paragraph could be three bullets, make it three
 bullets. If a sentence survives only because it sounds finished, it's filler —
 cut it.
+
+Run these four questions on the draft to catch structural tells a vocabulary pass
+will miss:
+
+1. Does the argument advance paragraph to paragraph, or restate?
+2. Does each list item earn its slot, or pad?
+3. Is there a position the text can be disagreed with?
+4. Is any specific detail grounded — a name, a date, a count, an observation —
+   or is specificity only performed?
 
 When your environment has subagents, the skill's optional copyedit pass hands
 the draft and this checklist to a fresh reader so the style read stays off your

--- a/AGENTS.local.md
+++ b/AGENTS.local.md
@@ -126,12 +126,22 @@ The adopter-facing version of this craft ships in the `user-guide-diataxis`
 pack's `new-guide` skill (`references/clear-prose.md`); keep each in its own
 home rather than duplicating.
 
-- **Write prose that reads like a person wrote it.** Cut the tells that make
-  text feel machine-made: hedges ("it's worth noting"), uniform sentence
-  rhythm, em-dash overuse, the rule of three on a loop, throat-clearing
-  openers, inflated verbs ("leverage", "utilize", "delve"). Vary sentence
-  length, keep one claim per sentence, and prefer a concrete number or example
-  over an adjective.
+- **Write prose that reads like a person wrote it.** Cut the vocabulary tells:
+  hedges ("it's worth noting"), uniform sentence rhythm, em-dash overuse, the
+  rule of three on a loop, throat-clearing openers, inflated verbs ("leverage",
+  "utilize", "delve"). Vary sentence length, keep one claim per sentence, and
+  prefer a concrete number or example over an adjective.
+- **Also catch structural tells — these survive a vocabulary pass.** Check
+  each draft against four questions: (1) does the argument advance paragraph to
+  paragraph, or restate? (2) does each list item earn its slot, or pad? (3) is
+  there a position the text can be disagreed with? (4) is any specific detail
+  grounded (a name, a date, a count, an observation), or is specificity only
+  performed? Named patterns to watch for: treadmill effect (paragraphs circle
+  without arriving), symmetrical lists (identical-length bullets that pad a
+  template), false precision ("research shows" with nothing behind it),
+  performative thoroughness (seven points when two decide it), nice-nice wrap
+  (both sides hedged, no stance), subtext vacuum (written for everyone =
+  written for no one).
 - **State what is — don't leak rationale or identity.** An aside that
   justifies a choice mid-sentence ("organized this way because…") reads as
   internal thinking spilling onto the page; cut it, or give the *why* its own

--- a/packs/user-guide-diataxis/.apm/skills/new-guide/references/clear-prose.md
+++ b/packs/user-guide-diataxis/.apm/skills/new-guide/references/clear-prose.md
@@ -32,6 +32,35 @@ search for once you know its shape.
   "This section explains how to rotate a token." The reader already read the
   heading. Start rotating the token.
 
+## Structural tells
+
+These are harder to catch than vocabulary tells because they survive a word-level
+pass. A draft can have zero inflated verbs and still read as machine-made if it
+falls into these patterns.
+
+- **Treadmill effect.** Each paragraph restates the previous one rather than
+  advancing the argument. The text circles the idea without arriving anywhere. Fix:
+  read the first and last sentence of each paragraph — the last should move past the
+  first, not echo it.
+- **Symmetrical lists.** Bullet items of identical length, parallel construction,
+  and equal weight — as if generated to fill a template rather than to capture
+  genuinely distinct points. A real list of three items is rarely three identical
+  sentences. Vary length and depth to match the actual shape of the content.
+- **False precision.** Authoritative framing — "research shows", "studies indicate",
+  "it's important to note" — without a grounded specific behind it. If you can't
+  name the study, the finding, or the number, replace the framing with a concrete
+  claim or cut it.
+- **Performative thoroughness.** Seven considerations when two drive the decision.
+  The extra five exist to signal completeness, not to inform. Cut the padding; leave
+  the two that matter.
+- **Nice-nice wrap.** Both sides of a conflict hedged to avoid commitment — the text
+  names a tension but refuses to land on a position. A reader should be able to
+  disagree with a claim in your doc. If there's nothing to push back on, there's
+  nothing being said.
+- **Subtext vacuum.** Flat, safe-for-any-audience prose with no implied reader.
+  Human writing carries a register — a sense of who it's for and what they already
+  know. Writing for everyone reads as writing for no one.
+
 ## Habits to keep
 
 - **One claim per sentence.** If a sentence has two "and"s and a "which", it's
@@ -63,6 +92,15 @@ Read the draft cold, ideally out loud. The sentences you stumble over are the
 ones to cut or split. If a paragraph could be three bullets, make it three
 bullets. If a sentence survives only because it sounds finished, it's filler —
 cut it.
+
+Run these four questions on the draft to catch structural tells a vocabulary pass
+will miss:
+
+1. Does the argument advance paragraph to paragraph, or restate?
+2. Does each list item earn its slot, or pad?
+3. Is there a position the text can be disagreed with?
+4. Is any specific detail grounded — a name, a date, a count, an observation —
+   or is specificity only performed?
 
 When your environment has subagents, the skill's optional copyedit pass hands
 the draft and this checklist to a fresh reader so the style read stays off your

--- a/packs/user-guide-diataxis/.claude-plugin/plugin.json
+++ b/packs/user-guide-diataxis/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "user-guide-diataxis",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Di\u00e1taxis-shaped user-guide skeleton: guides/ + tutorials/how-to/reference/explanation seed READMEs, new-guide skill."
 }

--- a/packs/user-guide-diataxis/pack.toml
+++ b/packs/user-guide-diataxis/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "user-guide-diataxis"
-version = "0.1.5"
+version = "0.1.6"
 description = "Di\u00e1taxis-shaped user-guide skeleton: guides/ + tutorials/how-to/reference/explanation seed READMEs, new-guide skill."
 readme = "README.md"
 display_name = "User Guide (Diátaxis)"


### PR DESCRIPTION
## Summary

- Adds a **Structural tells** section to `new-guide/references/clear-prose.md` covering six patterns that survive a vocabulary pass: treadmill effect, symmetrical lists, false precision, performative thoroughness, nice-nice wrap, and subtext vacuum
- Upgrades the **fast self-check** in the same file to a four-question structural gate
- Mirrors the structural tell guidance into `AGENTS.local.md` house style for internal governance docs (specs, ADRs, RFCs), where agents won't load the `new-guide` skill directly
- Bumps `user-guide-diataxis` → **0.1.6**

## Context

Part of a three-amendment series (A, B, C) following a copywriting research + audit session. This PR covers amendments A and D:

- **A** — extend `clear-prose.md` with structural AI tells (this PR, `user-guide-diataxis` pack)
- **B** — embed the same rubric independently in `voice-and-microcopy` (`product-engineering` pack) — follow-on PR
- **C** — add audience-JTBD step to `aesthetic-direction` (`experience` pack) — follow-on, warrants spec review first

## Pre-existing failure

`lint-build` reports `web/` as an unregistered top-level directory. This failure exists on `main` before these changes (platform-site work, #511); it is not introduced here. All skill-spec, agent-artifact, and knowledge lint checks pass.

## Test plan

- [ ] `make build-check` skill-spec, agent-artifact, knowledge lint all green
- [ ] `clear-prose.md` structural tells section reads cleanly in context with the existing "Tells to cut" and "Habits to keep" sections
- [ ] `AGENTS.local.md` house style rule 1 extended without duplicating the full checklist
- [ ] Projections (`.claude/skills/new-guide/`, `.agents/skills/new-guide/`) match the pack source