### PR TITLE
feat(product-engineering): Amendment B — human-craft structural-tell check in voice-and-microcopy (0.10.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -205,7 +205,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "product-engineering",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.10.0"
+      "version": "0.10.1"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`voice-and-microcopy` gains a human-craft structural-tell check (product-engineering 0.10.1).** A new reference file, `human-craft-check.md`, inlines six structural AI tells — treadmill effect, symmetrical lists, false precision, performative thoroughness, nice-nice wrap, subtext vacuum — and a four-question self-check for longer copy (onboarding text, feature descriptions, help text). The content checklist gains an eighth item, Human-crafted, that routes longer copy through this check. Self-contained within the pack; no cross-pack references.
+
 ### Changed
 
 - **`architect-diagram` gains portable Mermaid title, accessibility, and pipeline-orientation guidance (architect 0.11.0).** Three Mermaid-native additions to the skill's references: (1) `flowchart LR` is now explicitly the orientation for pipeline / ETL / CI-CD / data-flow diagrams (a decision-table row plus strengthened flowchart guidance); (2) the config-frontmatter `title:` is documented as the in-source diagram title (Mermaid ≥ 10.5), with the prose scope sentence kept as the always-portable baseline; (3) `accTitle` / `accDescr` are documented as the diagram's screen-reader alt text. The change also explicitly rejects three renderer-proprietary conventions (`:::external`, `label\|tech`, `%% title:`) that no-op or break in stock Mermaid (GitHub, Confluence, `mmdc`, and the repo's own renderers) — they contradict the skill's "survive enterprise wiki rendering" north star. Guidance only; no renderer or skill-contract change.

--- a/packs/product-engineering/.apm/skills/voice-and-microcopy/references/content-checklist.md
+++ b/packs/product-engineering/.apm/skills/voice-and-microcopy/references/content-checklist.md
@@ -20,6 +20,11 @@ catch the misses and fix them. Each item is one question; a "no" is a fix.
       sentence-shaped labels, self-describing out of context.
 - [ ] **Inclusive and plain.** Plain language; no idioms that don't translate, no
       jargon the user didn't bring, no assumptions about who the user is.
+- [ ] **Human-crafted.** Does longer copy (onboarding text, help text, feature
+      descriptions) avoid the structural tells that make writing feel generated —
+      treadmill effect, symmetrical lists, false precision, performative
+      thoroughness, nice-nice wrap, subtext vacuum? See `human-craft-check.md`
+      for the full structural-tell rundown and four-question self-check.
 
 ## How to use it
 

--- a/packs/product-engineering/.apm/skills/voice-and-microcopy/references/human-craft-check.md
+++ b/packs/product-engineering/.apm/skills/voice-and-microcopy/references/human-craft-check.md
@@ -1,0 +1,50 @@
+# Human-craft check — structural tells in copy
+
+Machine-made copy often passes a word-level vocabulary check and still reads flat.
+These structural patterns are why. They survive the surface pass because they are
+shape problems, not vocabulary problems.
+
+Run this check on longer copy: onboarding text, empty-state explanations, feature
+descriptions, help text. Short strings — button labels, single-line error messages —
+are caught by the items in `content-checklist.md`; this check is for the paragraphs.
+
+## Structural tells
+
+- **Treadmill effect.** Each sentence restates the previous one rather than
+  advancing. The copy circles an idea without arriving anywhere. Fix: read the first
+  and last sentence of each paragraph — the last should move past the first, not
+  echo it.
+
+- **Symmetrical lists.** Bullet items of identical length, parallel construction,
+  and equal weight — as if generated to fill a template rather than to capture
+  genuinely distinct points. A real list of three features is rarely three identical
+  sentences. Vary length and depth to match the actual shape of the content.
+
+- **False precision.** Authoritative framing — "research shows", "studies indicate",
+  "it's important to note" — without a grounded specific behind it. If you can't
+  name the study, the finding, or the number, replace the framing with a concrete
+  claim or cut it.
+
+- **Performative thoroughness.** Seven benefit bullets when two drive the decision.
+  The extra five exist to signal completeness, not to inform. Cut the padding; leave
+  the two that matter.
+
+- **Nice-nice wrap.** Both sides of a tension hedged to avoid commitment — the copy
+  names a tradeoff but refuses to land on a position. A reader should be able to
+  disagree with a claim in your copy. If there's nothing to push back on, there's
+  nothing being said.
+
+- **Subtext vacuum.** Flat, safe-for-any-audience prose with no implied reader.
+  Human writing carries a register — a sense of who it's for and what they already
+  know. Copy written for everyone reads as copy written for no one.
+
+## Four-question self-check
+
+Run these on any copy longer than a sentence to catch structural tells a word-level
+pass will miss:
+
+1. Does the argument advance sentence to sentence, or restate?
+2. Does each list item earn its slot, or pad?
+3. Is there a position the copy can be disagreed with?
+4. Is any specific detail grounded — a name, a date, a count, an observation —
+   or is specificity only performed?

--- a/packs/product-engineering/.claude-plugin/plugin.json
+++ b/packs/product-engineering/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "product-engineering",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Shape product intent into shippable specs — and into the words users read. Habits — frame-intent, de-risk-intent, decompose-intent — over a recursive, level-tagged `intent` (product-vision, product-strategy, capability, and feature intents are the same artifact at different levels — Level is an open recognized set decoupled from Scale): outcome+opportunity framing, a choosable prototype-approach to de-risk the riskiest assumption, and decomposition into the briefs/specs your delivery loop already builds — at app scale, or sliced per component across a business-unit value stream coordinated by `align-value-stream`. `voice-and-microcopy` adds the content layer: characterize a product's voice and write blame-free, actionable UI copy. Upstream of the build loop, the `discovery-loop` (run by the `discovery-lead` agent) turns a raw idea into a build-ready decision brief — diverging across candidate product shapes, converging through a lens roster with two discovery reviewers, and emitting a connected hypothesis with validation hooks — no engine. Markdown skills + agent definitions, user-scope."
 }

--- a/packs/product-engineering/pack.toml
+++ b/packs/product-engineering/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "product-engineering"
-version = "0.10.0"
+version = "0.10.1"
 description = "Shape product intent into shippable specs — and into the words users read. Habits — frame-intent, de-risk-intent, decompose-intent — over a recursive, level-tagged `intent` (product-vision, product-strategy, capability, and feature intents are the same artifact at different levels — Level is an open recognized set decoupled from Scale): outcome+opportunity framing, a choosable prototype-approach to de-risk the riskiest assumption, and decomposition into the briefs/specs your delivery loop already builds — at app scale, or sliced per component across a business-unit value stream coordinated by `align-value-stream`. `voice-and-microcopy` adds the content layer: characterize a product's voice and write blame-free, actionable UI copy. Upstream of the build loop, the `discovery-loop` (run by the `discovery-lead` agent) turns a raw idea into a build-ready decision brief — diverging across candidate product shapes, converging through a lens roster with two discovery reviewers, and emitting a connected hypothesis with validation hooks — no engine. Markdown skills + agent definitions, user-scope."
 readme = "README.md"
 display_name = "Product Engineering"


### PR DESCRIPTION
## Summary

- New `packs/product-engineering/.apm/skills/voice-and-microcopy/references/human-craft-check.md`: six structural AI tells (treadmill effect, symmetrical lists, false precision, performative thoroughness, nice-nice wrap, subtext vacuum) + four-question self-check, fully self-contained — no cross-pack references.
- `references/content-checklist.md`: 8th item — **Human-crafted** — routes longer copy (onboarding text, help text, feature descriptions) through the new reference.
- Pack version bumped 0.10.0 → 0.10.1 in `pack.toml` and `.claude-plugin/plugin.json`; `marketplace.json` updated via `FORCE=1 make build-self`.

## Context

Part of a three-amendment copywriting improvement series. Amendment A (#514, merged) added the structural AI tells rubric to `user-guide-diataxis`'s `new-guide/references/clear-prose.md`. This amendment independently inlines the same rubric into `product-engineering`'s `voice-and-microcopy` skill. Packs are independent — `human-craft-check.md` is a standalone file with no reference to `clear-prose.md` or any `user-guide-diataxis` path.

The spec's "never do" boundary ("cross-reference, don't restate" for items that overlap `clear-prose.md`) applies to the *checklist items themselves* — the checklist item here is a pointer to the new reference file, which is within the same pack.

## Build check

`make build-check` result:
- ✓ agents-md hygiene
- ✓ agent-artifact lint
- ✓ skill-spec lint
- ✓ knowledge lint
- ✖ lint-build: `web` top-level directory — **pre-existing, unrelated to this change**

## Test plan

- [ ] `human-craft-check.md` exists at the correct path with all six structural tells and the four-question self-check
- [ ] `content-checklist.md` has exactly 8 checklist items, with item 8 pointing to `human-craft-check.md`
- [ ] `pack.toml` and `plugin.json` both read `0.10.1`
- [ ] No reference to `clear-prose.md` or `user-guide-diataxis` in `human-craft-check.md`