### PR TITLE
fix(web): import z from astro/zod, not the deprecated astro:content re-export

### DIFF
--- a/web/src/content.config.ts
+++ b/web/src/content.config.ts
@@ -1,4 +1,5 @@
-import { defineCollection, z } from 'astro:content';
+import { defineCollection } from 'astro:content';
+import { z } from 'astro/zod';
 import { glob } from 'astro/loaders';
 
 const packs = defineCollection({


### PR DESCRIPTION
## What

`web/src/content.config.ts` imported the Zod helper via
`import { defineCollection, z } from 'astro:content'`. Astro 7 **deprecates**
the `z` re-export from `astro:content` (and `astro:schema`), so `astro check`
and the Astro IDE language server flag `ts(6385): 'z' is deprecated` on every
schema field — 42 diagnostics across the file.

This is the pre-existing `web/` lint noise introduced with the platform-site
content-collections work ([RFC-0061](../docs/rfc/0061-web-top-level-directory.md)),
unrelated to any feature work.

## Fix

Split the import: `defineCollection` stays on `astro:content`; `z` now comes
from `astro/zod` — the canonical source Astro's own type defs point to
(`astro:content`/`astro:schema` `export * from 'astro/zod'` and are marked
"will be removed in Astro 7"). Same Zod instance, so every schema definition
and all frontmatter validation are unchanged.

## Verification

- `npx astro check` → **0 errors, 0 warnings**; deprecation diagnostics in
  `content.config.ts` drop 42 → 0.
- `npm run build` → all **32 pages** still emit, sitemap generated.
- `grep` confirms `content.config.ts` is the only file importing `z` from
  `astro:content`, so no sibling sites remain on the deprecated path.

## Root cause (why it wasn't caught)

`astro check` isn't wired into CI — only the Pages workflow runs `astro build`,
which does **not** typecheck. So Astro-language-server deprecations never gated.

## Deferred (out of scope — noted per bug-fix discipline)

- **Wire `astro check` into CI** to close the coverage gap above. Requires
  adding `@astrojs/check` + `typescript` as devDependencies and a Pages-workflow
  step (a dependency + CI change) — surfacing as a decision rather than widening
  this narrow fix.
- **Pre-existing unrelated hint:** `web/scripts/generate-social.mjs:11` —
  `require` declared but never read (`ts(6133)`). Untouched here.