### PR TITLE
feat(experience): Amendment C — audience-JTBD step in aesthetic-direction (0.4.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -139,7 +139,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "experience",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.4.1"
+      "version": "0.4.2"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/packs/experience/.apm/skills/aesthetic-direction/SKILL.md
+++ b/packs/experience/.apm/skills/aesthetic-direction/SKILL.md
@@ -18,13 +18,14 @@ Confirm all four before drafting; if any fails, push back and resolve it first.
 
 ## Procedure
 
-1. **Run the interrogation.** Open from the felt vibe, probe the emotions, associations, and brand attributes behind it, and converge on a short set of named goals — each a noun phrase a non-designer can recall. Sharpen each against its opposite. Load `references/interrogation-sequence.md`.
-2. **Ground each goal in stable referents.** For each named goal, name *what grounds it*: the persona it serves, any precedent that carries the quality, the standards it respects, and the platform conventions for the target surface. A goal without a referent is still a fresh opinion — ground it or push it back to Step 1. Load `references/grounding.md`.
-3. **Rank the goals.** Order them so a tie can break. The top goal is the dominant one that wins when goals conflict.
-4. **Record arbitration.** For each likely conflict, name which goal wins and why, so the build doesn't re-litigate it. Load `references/coherence-arbitration.md`.
-5. **Capture the doc.** Copy `assets/aesthetic-direction-template.md` into the user's repo and fill it: the surface, the ranked goals with their referents, what each means and what would violate it, the dominant goal, and open questions.
-6. **Hold the floor.** The direction must not fight the shared `quality-floor` checklist (`../design-critique/references/quality-floor.md`) — accessibility is not negotiable against aesthetics. If a goal pulls against the floor, the floor wins; record it as an open question, not a trade-off.
-7. **Hand off.** Once the goals are named, ranked, and grounded, hand to `design-system-foundations` to derive the tokens and scales that express them.
+1. **Map the audience.** Name each distinct reader type for this surface, write one JTBD sentence per type ("When {situation}, I want to {action}, so that {goal}"), and rank them (primary, secondary). Load `references/audience-jtbd.md`. Feed the ranked map into Step 2 — the vibe that emerges should serve the primary reader's cognitive mode. Record the map in the doc; it becomes the Persona referent for each named goal in Step 3.
+2. **Run the interrogation.** Open from the felt vibe, probe the emotions, associations, and brand attributes behind it, and converge on a short set of named goals — each a noun phrase a non-designer can recall. Sharpen each against its opposite. Load `references/interrogation-sequence.md`.
+3. **Ground each goal in stable referents.** For each named goal, name *what grounds it*: the persona it serves, any precedent that carries the quality, the standards it respects, and the platform conventions for the target surface. A goal without a referent is still a fresh opinion — ground it or push it back to Step 2. Load `references/grounding.md`.
+4. **Rank the goals.** Order them so a tie can break. The top goal is the dominant one that wins when goals conflict.
+5. **Record arbitration.** For each likely conflict, name which goal wins and why, so the build doesn't re-litigate it. Load `references/coherence-arbitration.md`.
+6. **Capture the doc.** Copy `assets/aesthetic-direction-template.md` into the user's repo and fill it: the surface, the ranked goals with their referents, what each means and what would violate it, the dominant goal, and open questions.
+7. **Hold the floor.** The direction must not fight the shared `quality-floor` checklist (`../design-critique/references/quality-floor.md`) — accessibility is not negotiable against aesthetics. If a goal pulls against the floor, the floor wins; record it as an open question, not a trade-off.
+8. **Hand off.** Once the goals are named, ranked, and grounded, hand to `design-system-foundations` to derive the tokens and scales that express them.
 
 ## Anti-patterns to refuse
 

--- a/packs/experience/.apm/skills/aesthetic-direction/evals/evals.json
+++ b/packs/experience/.apm/skills/aesthetic-direction/evals/evals.json
@@ -6,6 +6,7 @@
       "prompt": "Turn the vibe the user described into an aesthetic direction.",
       "expected_output": "A small set of NAMED emotional/brand goals, each a short noun phrase a non-designer can recall, RANKED so a tie can break, with a single dominant goal that wins when goals conflict. Likely conflicts carry recorded arbitration (which goal wins and why), and the whole thing is captured as an aesthetic-direction doc (what each goal means, what would violate it, the dominant goal, open questions). It names DIRECTION only — no palette, font name, spacing, or timing values — and where a goal pulls against the accessibility floor, the floor wins, logged as an open question rather than a negotiated trade-off. It stops at named goals and does not jump ahead to deriving tokens or critiquing a screen.",
       "assertions": [
+        "Names the primary reader type or audience for the surface and connects at least one named goal to that audience's needs",
         "Produces a small set of named goals, each a short noun phrase (not a sentence or a single vague mood word)",
         "Ranks the goals and names a single dominant goal that breaks ties",
         "Records arbitration for at least one likely conflict (which goal wins and why)",

--- a/packs/experience/.apm/skills/aesthetic-direction/references/audience-jtbd.md
+++ b/packs/experience/.apm/skills/aesthetic-direction/references/audience-jtbd.md
@@ -1,0 +1,72 @@
+# Audience JTBD mapping
+
+Before the interrogation runs, name who reads this surface and what they
+need to accomplish. Aesthetic goals named without an audience serve the
+team's taste; goals named for a ranked audience can be tested against a
+real need.
+
+## The JTBD template
+
+For each distinct reader type, complete one sentence:
+
+> **When** {situation}, **I want to** {action}, **so that** {goal}.
+
+- *Situation* — the moment that brought them here: a buying decision, a
+  technical evaluation, a handoff to a stakeholder, an onboarding sprint.
+- *Action* — the single thing they need to do with this surface right now:
+  evaluate, build, approve, quote, or share.
+- *Goal* — the outcome they carry when they leave: a confident
+  recommendation, a working integration, an approved budget, a headline
+  for the pitch deck.
+
+One sentence per type. If a sentence needs a second clause to make sense,
+the job isn't named yet — tighten it.
+
+## Per-audience cognitive mode
+
+Reader types arrive in different cognitive states. The aesthetic direction
+must meet the primary reader at their actual state, not an idealized
+composite.
+
+| Segment | Cognitive mode | Arrives wanting | Design failure mode |
+|---|---|---|---|
+| Senior engineering lead | Pattern-match — scanning for risk signals, team fit, and long-term maintenance cost | A fast yes/no signal: "is this solid, can my team own it?" | Signal buried in prose; no hierarchy to scan |
+| IC developer | Sequential — reading to build; needs examples, exact behavior, and the edge case that will bite them | Concrete artifacts: a working example, the error path, the "gotcha" callout | Principles without grounding; no path from reading to doing |
+| Non-technical reader (exec / PM / buyer) | Narrative — needs cause-and-effect to build conviction | A coherent why-this, why-now without jargon | Dense technical detail above the fold; no accessible hook |
+| Marketing / growth reader | Claim-harvest — scanning for sharp, repeatable copy hooks | Memorable differentiators they can pull into external messages | Hedged language; every sentence sounds like every competitor |
+
+Add or drop rows to match the real audience. The table is a prompt, not
+a census.
+
+## Messaging hierarchy
+
+When the audience is mixed, a single aesthetic direction fails each reader
+differently. Address that with a two-layer structure:
+
+1. **Open with a shared problem-hook.** One sentence true for all segments:
+   the tension, the cost of the status quo, the thing everyone already
+   recognizes as broken. Open with the problem, not the product.
+2. **Progressive disclosure by audience below the fold.** After the shared
+   hook, let each segment follow their own thread: the engineering lead gets
+   depth first; the executive gets the narrative arc; the growth reader gets
+   the claim. Each thread can live in a different place on the surface — what
+   matters is that each reader finds their thread without navigating through
+   the others'.
+3. **Rank the segments.** The primary audience drives vocabulary, density,
+   and hierarchy above the fold. Name it explicitly: "IC developer is
+   primary; senior lead is secondary; non-technical reader is served by
+   the landing page, not this doc." An unranked audience averages toward
+   none of them.
+
+## Exit
+
+The map is ready when you can answer three questions:
+
+1. Who is the primary reader, and what job are they doing on this surface?
+2. How many distinct secondary readers exist, and does a primary-audience
+   design fail them in a way that matters?
+3. If the direction serves the primary reader precisely, what does it
+   sacrifice for each secondary reader — and is that the intended trade?
+
+Record the map in the aesthetic-direction doc. It becomes the Persona
+referent for each named goal.

--- a/packs/experience/.claude-plugin/plugin.json
+++ b/packs/experience/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "experience",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "The design/UX seat for product teams — the grown-up successor to design-craft. Connective skills walk the thread from outcome to realization (map-customer-journey → map-screen-flow → blueprint-service) and map the inside-out sibling (map-internal-process); craft skills design each screen (aesthetic-direction, design-system-foundations, layout-and-information-architecture, interaction-design) and critique it (design-critique), all held to one shared quality-floor (handle-all-states, accessibility floor, reduced-motion). A forked-context experience-reviewer gives the design step an independent design-time review. Pure method: no stack, no values tables, no pixel comps — points to WCAG / W3C Design Tokens / Apple HIG / Material 3 / APQC / BPMN, never reprints them."
 }

--- a/packs/experience/pack.toml
+++ b/packs/experience/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "experience"
-version = "0.4.1"
+version = "0.4.2"
 description = "The design/UX seat for product teams — the grown-up successor to design-craft. Connective skills walk the thread from outcome to realization (map-customer-journey → map-screen-flow → blueprint-service) and map the inside-out sibling (map-internal-process); craft skills design each screen (aesthetic-direction, design-system-foundations, layout-and-information-architecture, interaction-design) and critique it (design-critique), all held to one shared quality-floor (handle-all-states, accessibility floor, reduced-motion). A forked-context experience-reviewer gives the design step an independent design-time review. Pure method: no stack, no values tables, no pixel comps — points to WCAG / W3C Design Tokens / Apple HIG / Material 3 / APQC / BPMN, never reprints them."
 readme = "README.md"
 display_name = "Experience"


### PR DESCRIPTION
## Summary

- Adds `references/audience-jtbd.md` to the `aesthetic-direction` skill — a fully self-contained reference that teaches the JTBD-per-reader-segment template, a per-audience cognitive-mode table (senior engineering lead / IC developer / non-technical / marketing), and the messaging-hierarchy technique (shared problem-hook → progressive disclosure by audience below the fold).
- Inserts a new Step 1 "Map the audience" into `SKILL.md` before the interrogation step, so named aesthetic goals are audience-grounded from the start. Steps 1–7 renumbered to 2–8; the cross-reference in the grounding step updated accordingly.
- Adds one eval assertion covering audience grounding in `evals/evals.json`.
- Bumps experience pack to 0.4.2 in `pack.toml` and `plugin.json`; `marketplace.json` re-aggregated.

## Conflict check

No "never do" boundary in the skill conflicts with adding an upstream audience-mapping step. The skill has no `docs/specs/aesthetic-direction/spec.md`, so there is no spec/implementation drift to surface.

## Gates

`make build-check` passes all skill-relevant gates (skill-spec lint ✓, agent-artifact lint ✓, agents-md hygiene ✓, knowledge lint ✓). The only failure is the pre-existing `lint-build: new top-level directories introduced … web`, which is unrelated to this change.

## Part of series

- Amendment A — structural AI tells rubric in `new-guide` (#514)
- Amendment B — human-craft structural-tell check in `voice-and-microcopy` (#515)
- **Amendment C — audience-JTBD step in `aesthetic-direction`** (this PR)