### PR TITLE
feat(web,ci): claude plugin install — publish dist branch + /plugins/ catalogue

### DIFF
--- a/.github/workflows/publish-claude-plugins.yml
+++ b/.github/workflows/publish-claude-plugins.yml
@@ -1,0 +1,49 @@
+name: Publish Claude plugin packages
+
+# Builds the per-pack claude-plugins output and publishes it to the
+# `claude-plugins-dist` branch so adopters can install any pack directly
+# with `claude plugin install <url>`.
+#
+# Excludes `catalogue-curation/` (operator-only pack) but includes
+# `marketplace.json` at the branch root for machine-readable discovery.
+#
+# Skips committing when content is byte-for-byte identical to the
+# previous publish; cancels in-flight runs when a newer push lands.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: publish-claude-plugins
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history so worktree can reach the target branch
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install agentbundle (dev editable)
+        run: pip install -e packages/agentbundle
+
+      - name: Build claude-plugin artifacts
+        run: make build
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Publish to claude-plugins-dist branch
+        run: python3 tools/publish-claude-plugins.py

--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ agentbundle install --pack core
 
 ## Quick start
 
+**Install via Claude Code / Claude Desktop** (no extra tooling required):
+
+```bash
+# Install any pack directly — no CLI to set up
+claude plugin install https://github.com/eugenelim/agent-ready-repo/tree/claude-plugins-dist/core
+
+# Browse all available packs with install commands
+# → https://eugenelim.github.io/agent-ready-repo/plugins/
+```
+
+**Or install via agentbundle CLI** (supports all agent adapters):
+
 ```bash
 # Install the CLI (one-time)
 pip install agentbundle
@@ -54,6 +66,8 @@ agentbundle install --pack core --dry-run
 `--dry-run` previews every file before anything is written — one line per file, then a `create`/`overwrite` count. Installs auto-detect your agent and fall back to Claude Code; [configure a different default →](docs/guides/_shared/how-to/configure-adapter.md)
 
 Every source verb defaults to this catalogue when you don't name one; pass a git URL or local path to use a different one, or `agentbundle config set source <catalogue>` to change the default.
+
+**Machine-readable catalogue:** `https://raw.githubusercontent.com/eugenelim/agent-ready-repo/claude-plugins-dist/marketplace.json`
 
 ## The three loops
 

--- a/docs/specs/claude-plugins-publish-and-discover/plan.md
+++ b/docs/specs/claude-plugins-publish-and-discover/plan.md
@@ -1,0 +1,94 @@
+# Plan: claude-plugins-publish-and-discover
+
+- **Status:** Done
+- **Spec:** [`spec.md`](spec.md)
+
+## Constraints
+
+- No new external GitHub Actions; no changes to pack source files.
+- `catalogue-curation` excluded from publish + UI (directory excluded; also stripped from `marketplace.json`).
+- `claude-plugins-dist` is a dist branch — replaced atomically, not accumulated.
+
+## Declined patterns
+
+- Tempted to add `pluginUrl` field to each content file — declining, the URL is
+  derivable from pack name (`entry.id`) and adding it to 14 content files is
+  maintenance surface for no gain.
+- Tempted to use `peaceiris/actions-gh-pages` for the publish step — declining,
+  adds an external dependency (AGENTS.md risk trigger).
+- Tempted to inline plugin install commands on each PackCard — declining, the full
+  card is wrapped in an `<a>` anchor; nesting copy-blocks inside it is invalid HTML
+  and broken UX. A dedicated `/plugins/` page handles this cleanly instead.
+- Tempted to add a `claude://` deeplink — declining, deferred per prior decision
+  (agentbundle:// needs a registered OS protocol handler).
+
+## Tasks
+
+### T1 — CI workflow: publish built output to `claude-plugins-dist`
+
+**Depends on:** none
+**Verification:** goal-based check
+**Done when:** push to main triggers the workflow; `claude-plugins-dist` branch exists with correct structure (`.claude-plugin/plugin.json`, `.claude/skills/`, `.claude-plugin/scripts/install-marker.py`); `catalogue-curation/` directory absent from the branch; `marketplace.json` present at branch root with `catalogue-curation` entry stripped.
+
+**Approach:**
+- Create `.github/workflows/publish-claude-plugins.yml`
+- Trigger: `push: branches: [main]`; `workflow_dispatch` for manual runs
+- Steps: checkout (full), setup-python, install agentbundle dev, `make build`, publish script
+- Publish step: worktree approach against `claude-plugins-dist`; skips commit if no changes; excludes `catalogue-curation/` directory; writes filtered `marketplace.json` (catalogue-curation entry stripped) via `_write_filtered_marketplace()`
+- Permissions: `contents: write`
+
+### T2 — Web: Claude plugin install block on pack detail page
+
+**Depends on:** none (URL pattern is fixed; branch existence is a separate concern)
+**Verification:** visual/manual QA (`npm run dev` in `web/`)
+**Done when:** pack detail page for `experience` shows "Via Claude Code / Claude Desktop" install block with correct URL below the agentbundle route.
+
+**Approach:**
+- Edit `web/src/pages/packs/[pack].astro`
+- Derive `packSlug = entry.id.replace(/\.md$/, '')`
+- Add second install route below the agentbundle block
+- URL: `https://github.com/eugenelim/agent-ready-repo/tree/claude-plugins-dist/${packSlug}`
+- Uses dark `.install-block` (dark bg via hero tokens) with flex row + copy button
+
+### T3 — Web: Dedicated `/plugins/` catalogue page
+
+**Depends on:** none
+**Verification:** visual/manual QA (`npm run dev`, navigate to `/plugins/`)
+**Done when:** `/plugins/` page lists every installable pack (excluding `catalogue-curation`) with name, tagline, skills count, "View pack →" link, and a dark install block with copyable `claude plugin install` command and copy button.
+
+**Approach:**
+- Create `web/src/pages/plugins/index.astro`
+- Filter out `catalogue-curation`; sort three loops first then alpha
+- Dark hero zone (eyebrow, display heading, body, pack count + marketplace link)
+- Plugin grid: cards with `.plugin-install` dark footer zone, clipboard copy button with 2s "Copied!" feedback
+
+### T4 — Web: SiteNav link + packs index banner
+
+**Depends on:** none
+**Verification:** visual/manual QA
+**Done when:** "Plugins" appears in desktop + mobile nav between Packs and Journeys; packs/index.astro shows an amber-accent banner linking to `/plugins/`.
+
+**Approach:**
+- Add `{ label: 'Plugins', href: withBase('/plugins/') }` to SiteNav `links` array
+- Add `.packs__plugin-banner` div in `packs/index.astro` above the grid
+
+### T5 — README: mention claude plugin install route + marketplace URL
+
+**Depends on:** none
+**Verification:** goal-based check — `grep "claude plugin install" README.md`
+**Done when:** README Quick Start section mentions `claude plugin install <url>` as primary route (above agentbundle CLI), links to `/plugins/` for inventory, includes raw `marketplace.json` URL.
+
+**Approach:**
+- Add "Install via Claude Code / Claude Desktop" block above agentbundle CLI section
+- Add machine-readable catalogue URL at end of Quick Start
+
+### T6 — Bootstrap `claude-plugins-dist` branch
+
+**Depends on:** T1
+**Verification:** goal-based check — `git ls-remote --heads origin claude-plugins-dist` returns branch; `gh api "repos/eugenelim/agent-ready-repo/contents/product-engineering/.claude-plugin/plugin.json?ref=claude-plugins-dist"` returns JSON with `hooks.SessionStart`
+**Done when:** branch exists on remote with current build output; `catalogue-curation/` absent; `marketplace.json` present with `catalogue-curation` entry stripped.
+
+**Approach:**
+- Build into `dist/` via `PYTHONPATH=packages/agentbundle python3 -m agentbundle.build build --packs-dir packs --output-dir dist`
+- Run `python3 tools/publish-claude-plugins.py` (orphan branch path)
+- Verify: `gh api` call confirms `hooks.SessionStart` in `product-engineering/.claude-plugin/plugin.json`

--- a/docs/specs/claude-plugins-publish-and-discover/spec.md
+++ b/docs/specs/claude-plugins-publish-and-discover/spec.md
@@ -1,6 +1,6 @@
 # Spec: claude-plugins-publish-and-discover
 
-- **Status:** Shipped
+- **Status:** Implementing
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Mode:** full (CI/CD structural change, user-facing website surface)

--- a/docs/specs/claude-plugins-publish-and-discover/spec.md
+++ b/docs/specs/claude-plugins-publish-and-discover/spec.md
@@ -1,0 +1,88 @@
+# Spec: claude-plugins-publish-and-discover
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Mode:** full (CI/CD structural change, user-facing website surface)
+- **Constrained by:** [RFC-0008](../../rfc/0008-claude-plugins-install-route-parity.md)
+  (install-marker mechanism — already Shipped);
+  [`docs/specs/claude-plugins-install-route/spec.md`](../claude-plugins-install-route/spec.md)
+  (Shipped; this spec adds the publish + discover layer on top).
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+The `agentbundle build` pipeline already produces a complete, installable
+`dist/claude-plugins/<pack>/` artifact for every pack. Today that output is
+gitignored and never published, so no `claude plugin install <url>` URL exists
+for any pack.
+
+This spec closes the gap: publish the built artifacts to a
+`claude-plugins-dist` git branch on every push to `main`; add a dedicated
+`/plugins/` catalogue page to the marketing website with per-pack install URLs
+and site navigation; surface the install URL on each pack detail page; update
+the README.
+
+**Scope (in):**
+- CI workflow publishing `dist/claude-plugins/` content (including `marketplace.json`) to branch `claude-plugins-dist`, excluding only `catalogue-curation/`
+- `/plugins/` page listing all installable packs with `claude plugin install <url>` per pack
+- Nav link to `/plugins/` in `SiteNav.astro` and a link from the packs index page
+- `claude plugin install <url>` block on each pack detail page (all except `catalogue-curation` — no such page exists in the collection)
+- README Quick Start update mentioning `claude plugin install <url>` and linking to `/plugins/` and the raw `marketplace.json`
+- Bootstrap the `claude-plugins-dist` branch from the current build
+
+**Scope (out):**
+- `agentbundle://` or `claude://` deeplink (deferred per prior decision)
+- `uvx agentbundle install` web button (tracked separately)
+- APM install-route nudge parity (separate backlog item)
+- Changes to agentbundle Python package source or pack source plugin.json files
+
+## Acceptance Criteria
+
+- [x] **AC1** — CI workflow `.github/workflows/publish-claude-plugins.yml` triggers on push to `main` (and `workflow_dispatch`) and publishes `dist/claude-plugins/` content to branch `claude-plugins-dist`, excluding only the `catalogue-curation/` subdirectory. `marketplace.json` IS included at the branch root (with `catalogue-curation` entry stripped).
+- [x] **AC2** — The publish step skips committing when `git diff --cached --quiet` (no file-level changes vs previous publish); concurrent runs are cancelled by a `concurrency` group.
+- [x] **AC3** — After bootstrap, `https://github.com/eugenelim/agent-ready-repo/tree/claude-plugins-dist/product-engineering` resolves and the directory contains `.claude-plugin/plugin.json` with `hooks.SessionStart`, `.claude-plugin/scripts/install-marker.py`, and `.claude/skills/`. *(Verified via `gh api` during T6 bootstrap.)*
+- [x] **AC4** — A `/plugins/` page exists on the marketing site listing every installable pack (all except `catalogue-curation`) with its name, tagline, and a copyable `claude plugin install https://github.com/eugenelim/agent-ready-repo/tree/claude-plugins-dist/<pack>` block.
+- [x] **AC5** — `/plugins/` is reachable from primary site navigation (SiteNav desktop + mobile) and from a link on the packs index page.
+- [x] **AC6** — Each pack detail page shows a "Claude plugin" install block with the correct URL, rendered below the existing `agentbundle` install block. The block is absent for `catalogue-curation` (that pack has no detail page in the collection, so the guard is publish-side only).
+- [x] **AC7** — README Quick Start mentions `claude plugin install <url>` as an alternative, links to the `/plugins/` page for the full inventory, and includes the raw `marketplace.json` URL as the machine-readable catalogue endpoint.
+- [x] **AC8** — No new external GitHub Actions introduced beyond `actions/checkout` and `actions/setup-python`.
+- [ ] **AC9** — Existing CI gates (`build-check`, `pages`, `docs`, `lint-packs`) are unaffected and pass. *(Pending CI run on PR.)*
+
+## Testing Strategy
+
+- **AC1/AC2:** Goal-based check — workflow runs; `claude-plugins-dist` branch exists; `marketplace.json` present at root; `catalogue-curation/` absent; consecutive identical builds produce no new commit.
+- **AC3:** Goal-based check — `git show claude-plugins-dist:product-engineering/.claude-plugin/plugin.json | python3 -c "import sys,json; d=json.load(sys.stdin); assert 'hooks' in d"` exits 0.
+- **AC4/AC5/AC6:** Visual/manual QA — `npm run dev` in `web/`; navigate to `/plugins/` (reachable from nav), verify all installable packs listed with correct URLs; navigate to a pack detail page, verify Claude plugin block present.
+- **AC7:** Goal-based check — `grep "claude plugin install" README.md` and `grep "marketplace.json" README.md` both match.
+- **AC8:** Goal-based check — `grep "uses:" .github/workflows/publish-claude-plugins.yml` returns only `actions/checkout` and `actions/setup-python`.
+- **AC9:** Goal-based check — CI passes on PR.
+
+## Boundaries
+
+**Always do:**
+- Exclude `catalogue-curation/` from the published branch (operator-only pack).
+- Include `marketplace.json` at the branch root (machine-readable index).
+- Run `gh auth status` before any direct branch push.
+
+**Never do:**
+- Force-push to `main` or any branch-protection-covered branch.
+- Modify `packs/<pack>/.claude-plugin/plugin.json` source files (must stay hook-free per build spec AC10 gate 2).
+- Add `pluginUrl` to the web content schema (URL is derivable from pack slug).
+- Nest `<code>` copy-blocks inside the full-card `<a>` anchor in PackCard (invalid HTML / bad UX).
+
+**Ask first:**
+- Before renaming the `claude-plugins-dist` branch once published (would break live install URLs).
+- Before adding external GitHub Actions beyond the two already used.
+
+## Assumptions
+
+1. `claude plugin install` resolves GitHub tree URLs of the form `https://github.com/<owner>/<repo>/tree/<branch>/<path>` — documented in Claude Code plugin docs. The slash-free `claude-plugins-dist` branch name removes any ref/path ambiguity in naive parsers.
+2. The `agentbundle build` output is content-deterministic across runs on identical input (no timestamps or non-deterministic maps in generated files).
+3. The GitHub Actions runner has `contents: write` permission to push to `claude-plugins-dist`.
+
+## Design intent (pre-EXECUTE UX check)
+
+The `/plugins/` page follows the existing dark-hero + surface-section layout pattern used by `/packs/` and `/journeys/`. The per-pack install block reuses the `.install-block` / `.install-block__code` tokens already on the detail page. No new design primitives needed; the `experience-reviewer` pass in REVIEW will verify aesthetic coherence.

--- a/tools/publish-claude-plugins.py
+++ b/tools/publish-claude-plugins.py
@@ -1,7 +1,8 @@
 """Publish dist/claude-plugins/ to the claude-plugins-dist branch.
 
 Excludes catalogue-curation/ (operator-only pack, not for end-user installation).
-Includes marketplace.json at the branch root.
+Strips the catalogue-curation entry from marketplace.json before publishing.
+Includes all other content, including marketplace.json, at the branch root.
 Skips committing when the tree is byte-for-byte identical to the last publish.
 
 Run from the repo root:
@@ -13,9 +14,11 @@ Invoked by .github/workflows/publish-claude-plugins.yml after `make build`.
 from __future__ import annotations
 
 import json
+import shlex
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 DIST_DIR = Path("dist/claude-plugins")
@@ -23,13 +26,13 @@ BRANCH = "claude-plugins-dist"
 EXCLUDE = {"catalogue-curation"}  # operator-only pack
 
 
-def _run(cmd: str, **kwargs) -> subprocess.CompletedProcess:
-    print(f"+ {cmd}", flush=True)
-    return subprocess.run(cmd, shell=True, check=True, **kwargs)
+def _run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    print(f"+ {shlex.join(cmd)}", flush=True)
+    return subprocess.run(cmd, check=True, **kwargs)
 
 
-def _check(cmd: str, **kwargs) -> subprocess.CompletedProcess:
-    return subprocess.run(cmd, shell=True, check=False, **kwargs)
+def _check(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, check=False, **kwargs)
 
 
 def _write_filtered_marketplace(src: Path, dest: Path) -> None:
@@ -38,7 +41,7 @@ def _write_filtered_marketplace(src: Path, dest: Path) -> None:
     if "plugins" in data:
         data["plugins"] = [p for p in data["plugins"] if p.get("name") not in EXCLUDE]
     dest.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
-    print(f"  wrote filtered marketplace.json (excluded: {', '.join(EXCLUDE)})")
+    print(f"  wrote filtered marketplace.json (excluded: {', '.join(sorted(EXCLUDE))})")
 
 
 def main() -> None:
@@ -50,29 +53,29 @@ def main() -> None:
         sys.exit(1)
 
     sha = subprocess.check_output(
-        "git rev-parse --short HEAD", shell=True
+        ["git", "rev-parse", "--short", "HEAD"]
     ).decode().strip()
-
-    worktree = Path("/tmp/claude-plugins-publish")
-    if worktree.exists():
-        shutil.rmtree(worktree)
 
     # Does the target branch already exist on remote?
     probe = _check(
-        f"git ls-remote --heads origin {BRANCH}",
+        ["git", "ls-remote", "--heads", "origin", BRANCH],
         capture_output=True,
         text=True,
     )
     branch_exists = bool(probe.stdout.strip())
 
-    if branch_exists:
-        _run(f"git fetch origin {BRANCH}")
-        _run(f"git worktree add {worktree} origin/{BRANCH}")
-    else:
-        # --orphan takes branch name via -b; the positional commit-ish is incompatible.
-        _run(f"git worktree add --orphan -b {BRANCH} {worktree}")
+    worktree = Path(tempfile.mkdtemp(prefix="claude-plugins-publish-"))
+    # mkdtemp creates the dir; git worktree needs it absent or empty.
+    worktree.rmdir()
 
     try:
+        if branch_exists:
+            _run(["git", "fetch", "origin", BRANCH])
+            _run(["git", "worktree", "add", str(worktree), f"origin/{BRANCH}"])
+        else:
+            # --orphan takes the branch name via -b; positional commit-ish is incompatible.
+            _run(["git", "worktree", "add", "--orphan", "-b", BRANCH, str(worktree)])
+
         # Remove all tracked content from the worktree (preserve .git).
         for item in worktree.iterdir():
             if item.name == ".git":
@@ -97,22 +100,22 @@ def main() -> None:
                 shutil.copy2(item, dest)
 
         # Stage everything.
-        _run(f"git -C {worktree} add -A")
+        _run(["git", "-C", str(worktree), "add", "-A"])
 
         # Skip the commit if nothing changed.
-        no_diff = _check(f"git -C {worktree} diff --cached --quiet")
+        no_diff = _check(["git", "-C", str(worktree), "diff", "--cached", "--quiet"])
         if no_diff.returncode == 0:
             print("No changes to publish — branch is up to date.")
             return
 
-        _run(
-            f'git -C {worktree} commit -m '
-            f'"chore: publish claude-plugins [main@{sha}]"'
-        )
-        _run(f"git -C {worktree} push origin HEAD:{BRANCH}")
+        _run([
+            "git", "-C", str(worktree), "commit",
+            "-m", f"chore: publish claude-plugins [main@{sha}]",
+        ])
+        _run(["git", "-C", str(worktree), "push", "origin", f"HEAD:{BRANCH}"])
         print(f"Published to {BRANCH}.")
     finally:
-        _run(f"git worktree remove --force {worktree}")
+        _run(["git", "worktree", "remove", "--force", str(worktree)])
 
 
 if __name__ == "__main__":

--- a/tools/publish-claude-plugins.py
+++ b/tools/publish-claude-plugins.py
@@ -1,0 +1,119 @@
+"""Publish dist/claude-plugins/ to the claude-plugins-dist branch.
+
+Excludes catalogue-curation/ (operator-only pack, not for end-user installation).
+Includes marketplace.json at the branch root.
+Skips committing when the tree is byte-for-byte identical to the last publish.
+
+Run from the repo root:
+  python3 tools/publish-claude-plugins.py
+
+Invoked by .github/workflows/publish-claude-plugins.yml after `make build`.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+DIST_DIR = Path("dist/claude-plugins")
+BRANCH = "claude-plugins-dist"
+EXCLUDE = {"catalogue-curation"}  # operator-only pack
+
+
+def _run(cmd: str, **kwargs) -> subprocess.CompletedProcess:
+    print(f"+ {cmd}", flush=True)
+    return subprocess.run(cmd, shell=True, check=True, **kwargs)
+
+
+def _check(cmd: str, **kwargs) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, shell=True, check=False, **kwargs)
+
+
+def _write_filtered_marketplace(src: Path, dest: Path) -> None:
+    """Copy marketplace.json with excluded packs stripped from the plugins list."""
+    data = json.loads(src.read_text(encoding="utf-8"))
+    if "plugins" in data:
+        data["plugins"] = [p for p in data["plugins"] if p.get("name") not in EXCLUDE]
+    dest.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+    print(f"  wrote filtered marketplace.json (excluded: {', '.join(EXCLUDE)})")
+
+
+def main() -> None:
+    if not DIST_DIR.exists():
+        print(
+            f"error: {DIST_DIR} not found — run `make build` first.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    sha = subprocess.check_output(
+        "git rev-parse --short HEAD", shell=True
+    ).decode().strip()
+
+    worktree = Path("/tmp/claude-plugins-publish")
+    if worktree.exists():
+        shutil.rmtree(worktree)
+
+    # Does the target branch already exist on remote?
+    probe = _check(
+        f"git ls-remote --heads origin {BRANCH}",
+        capture_output=True,
+        text=True,
+    )
+    branch_exists = bool(probe.stdout.strip())
+
+    if branch_exists:
+        _run(f"git fetch origin {BRANCH}")
+        _run(f"git worktree add {worktree} origin/{BRANCH}")
+    else:
+        # --orphan takes branch name via -b; the positional commit-ish is incompatible.
+        _run(f"git worktree add --orphan -b {BRANCH} {worktree}")
+
+    try:
+        # Remove all tracked content from the worktree (preserve .git).
+        for item in worktree.iterdir():
+            if item.name == ".git":
+                continue
+            if item.is_dir():
+                shutil.rmtree(item)
+            else:
+                item.unlink()
+
+        # Copy dist/claude-plugins/ into the worktree, skipping excluded packs.
+        # marketplace.json is included but with excluded packs stripped from its list.
+        for item in sorted(DIST_DIR.iterdir()):
+            if item.name in EXCLUDE:
+                print(f"  skip {item.name} (excluded from publish)")
+                continue
+            dest = worktree / item.name
+            if item.is_dir():
+                shutil.copytree(item, dest)
+            elif item.name == "marketplace.json":
+                _write_filtered_marketplace(item, dest)
+            else:
+                shutil.copy2(item, dest)
+
+        # Stage everything.
+        _run(f"git -C {worktree} add -A")
+
+        # Skip the commit if nothing changed.
+        no_diff = _check(f"git -C {worktree} diff --cached --quiet")
+        if no_diff.returncode == 0:
+            print("No changes to publish — branch is up to date.")
+            return
+
+        _run(
+            f'git -C {worktree} commit -m '
+            f'"chore: publish claude-plugins [main@{sha}]"'
+        )
+        _run(f"git -C {worktree} push origin HEAD:{BRANCH}")
+        print(f"Published to {BRANCH}.")
+    finally:
+        _run(f"git worktree remove --force {worktree}")
+
+
+if __name__ == "__main__":
+    main()

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,7 +12,7 @@
         "astro": "7.1.0"
       },
       "engines": {
-        "node": ">=22.12.0"
+        "node": ">=24.0.0"
       }
     },
     "node_modules/@astrojs/compiler-binding": {

--- a/web/src/components/layout/SiteNav.astro
+++ b/web/src/components/layout/SiteNav.astro
@@ -7,6 +7,7 @@ import { withBase } from '../../lib/paths';
 const links = [
   { label: 'How it works', href: withBase('/#three-loops') },
   { label: 'Packs', href: withBase('/packs/') },
+  { label: 'Plugins', href: withBase('/plugins/') },
   { label: 'Journeys', href: withBase('/journeys/') },
 ];
 const homeHref = withBase('/');

--- a/web/src/pages/packs/[pack].astro
+++ b/web/src/pages/packs/[pack].astro
@@ -18,6 +18,11 @@ const { data } = entry;
 const { Content } = await render(entry);
 
 const hasJourney = !!data.journeyUrl;
+
+const PLUGIN_BRANCH = 'claude-plugins-dist';
+const REPO = 'eugenelim/agent-ready-repo';
+const packSlug = entry.id.replace(/\.md$/, '');
+const pluginInstallCmd = `claude plugin install https://github.com/${REPO}/tree/${PLUGIN_BRANCH}/${packSlug}`;
 ---
 
 <SiteLayout
@@ -53,11 +58,32 @@ const hasJourney = !!data.journeyUrl;
       <!-- Install -->
       <div class="pack-section">
         <h2 class="pack-section__title">Install</h2>
+
+        <!-- agentbundle route -->
+        <p class="install-route-label">Via agentbundle CLI</p>
         <div class="install-block">
           <pre class="install-block__code"><code>{data.installCommand}</code></pre>
         </div>
         <p class="install-note">
           Requires <a href={withBase('/docs/getting-started/')}>agentbundle</a>.
+        </p>
+
+        <!-- Claude plugin route -->
+        <p class="install-route-label install-route-label--spaced">Via Claude Code / Claude Desktop</p>
+        <div class="install-block">
+          <div class="install-block__plugin-row">
+            <pre class="install-block__code install-block__code--light"><code>{pluginInstallCmd}</code></pre>
+            <button
+              class="install-copy-btn"
+              data-cmd={pluginInstallCmd}
+              aria-label="Copy Claude plugin install command"
+              type="button"
+            >Copy</button>
+          </div>
+        </div>
+        <p class="install-note">
+          No extra tooling required — works directly in <a href="https://claude.ai/code" rel="noopener noreferrer">Claude Code</a> or Claude Desktop.
+          <a href={withBase('/plugins/')}>Browse all plugins →</a>
         </p>
       </div>
 
@@ -151,6 +177,69 @@ const hasJourney = !!data.journeyUrl;
     color: var(--ds-on-surface-muted);
   }
 
+  .install-route-label {
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--ds-track-label);
+    color: var(--ds-on-surface-muted);
+    margin-bottom: var(--ds-space-2);
+  }
+
+  .install-route-label--spaced {
+    margin-top: var(--ds-space-5);
+  }
+
+  .install-block__plugin-row {
+    display: flex;
+    align-items: center;
+    gap: var(--ds-space-3);
+    min-width: 0;
+  }
+
+  .install-block__code--light {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .install-copy-btn {
+    flex-shrink: 0;
+    background-color: var(--ds-hero-elevated);
+    border: 1px solid var(--ds-hero-border-card);
+    border-radius: var(--ds-radius-sm);
+    color: var(--ds-hero-fg-muted);
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-xs);
+    font-weight: var(--ds-weight-medium);
+    padding: 0.3rem 0.7rem;
+    cursor: pointer;
+    transition:
+      background-color var(--ds-dur-quick) var(--ds-ease-std),
+      color var(--ds-dur-quick) var(--ds-ease-std),
+      border-color var(--ds-dur-quick) var(--ds-ease-std);
+  }
+
+  .install-copy-btn:hover {
+    background-color: var(--ds-accent-subtle-dk);
+    border-color: var(--ds-accent);
+    color: var(--ds-accent);
+  }
+
+  .install-copy-btn--success {
+    background-color: var(--ds-accent-subtle-dk);
+    border-color: var(--ds-accent);
+    color: var(--ds-accent);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .install-copy-btn {
+      transition: none;
+    }
+  }
+
   .journey-link {
     display: flex;
     align-items: center;
@@ -229,3 +318,23 @@ const hasJourney = !!data.journeyUrl;
     }
   }
 </style>
+
+<script>
+  document.querySelectorAll<HTMLButtonElement>('.install-copy-btn').forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      const cmd = btn.dataset.cmd ?? '';
+      try {
+        await navigator.clipboard.writeText(cmd);
+        const orig = btn.textContent;
+        btn.textContent = 'Copied!';
+        btn.classList.add('install-copy-btn--success');
+        setTimeout(() => {
+          btn.textContent = orig;
+          btn.classList.remove('install-copy-btn--success');
+        }, 2000);
+      } catch {
+        // Clipboard API unavailable — command is still selectable in the code block.
+      }
+    });
+  });
+</script>

--- a/web/src/pages/packs/index.astro
+++ b/web/src/pages/packs/index.astro
@@ -3,6 +3,7 @@ import { getCollection } from 'astro:content';
 import SiteLayout from '../../components/layout/SiteLayout.astro';
 import Section from '../../components/layout/Section.astro';
 import PackCard from '../../components/pack/PackCard.astro';
+import { withBase } from '../../lib/paths';
 
 const allPacks = await getCollection('packs');
 const packs = allPacks.sort((a, b) => {
@@ -24,6 +25,15 @@ const packs = allPacks.sort((a, b) => {
       14 packs covering the full SDLC — discovery, build, release, and beyond.
       Start with the loops.
     </p>
+
+    <div class="packs__plugin-banner">
+      <span class="packs__plugin-banner-text">
+        Installing via Claude Code or Claude Desktop?
+      </span>
+      <a class="packs__plugin-link" href={withBase('/plugins/')}>
+        Browse the Claude plugin catalogue <span aria-hidden="true">→</span>
+      </a>
+    </div>
 
     <ul class="packs-grid">
       {packs.map((entry) => (
@@ -49,6 +59,35 @@ const packs = allPacks.sort((a, b) => {
     max-width: 60ch;
     margin-bottom: var(--ds-space-8);
     line-height: var(--ds-lead-body);
+  }
+
+  .packs__plugin-banner {
+    display: flex;
+    align-items: center;
+    gap: var(--ds-space-4);
+    flex-wrap: wrap;
+    background-color: var(--ds-accent-subtle);
+    border: 1px solid var(--ds-accent);
+    border-radius: var(--ds-radius-md);
+    padding: var(--ds-space-4) var(--ds-space-5);
+    margin-bottom: var(--ds-space-7);
+  }
+
+  .packs__plugin-banner-text {
+    font-size: var(--ds-type-sm);
+    color: var(--ds-on-surface-2);
+  }
+
+  .packs__plugin-link {
+    font-size: var(--ds-type-sm);
+    font-weight: var(--ds-weight-semibold);
+    color: var(--ds-accent-deep);
+    white-space: nowrap;
+  }
+
+  .packs__plugin-link:hover {
+    text-decoration: none;
+    color: var(--ds-accent);
   }
 
   .packs-grid {

--- a/web/src/pages/plugins/index.astro
+++ b/web/src/pages/plugins/index.astro
@@ -1,0 +1,421 @@
+---
+import { getCollection } from 'astro:content';
+import SiteLayout from '../../components/layout/SiteLayout.astro';
+import Section from '../../components/layout/Section.astro';
+import { withBase } from '../../lib/paths';
+
+const PLUGIN_BRANCH = 'claude-plugins-dist';
+const REPO = 'eugenelim/agent-ready-repo';
+const MARKETPLACE_RAW_URL =
+  `https://raw.githubusercontent.com/${REPO}/${PLUGIN_BRANCH}/marketplace.json`;
+
+// All packs except catalogue-curation (operator-only, not for end users).
+const allPacks = await getCollection('packs');
+const packs = allPacks
+  .filter((e) => e.id.replace(/\.md$/, '') !== 'catalogue-curation')
+  .sort((a, b) => {
+    const order = ['core', 'product-engineering', 'release-engineering'];
+    const ai = order.indexOf(a.id.replace(/\.md$/, ''));
+    const bi = order.indexOf(b.id.replace(/\.md$/, ''));
+    if (ai !== -1 && bi !== -1) return ai - bi;
+    if (ai !== -1) return -1;
+    if (bi !== -1) return 1;
+    return a.data.name.localeCompare(b.data.name);
+  })
+  .map((e) => {
+    const slug = e.id.replace(/\.md$/, '');
+    return {
+      slug,
+      name: e.data.name,
+      scope: e.data.scope,
+      tagline: e.data.tagline,
+      skillCount: e.data.skills.length,
+      installUrl: `https://github.com/${REPO}/tree/${PLUGIN_BRANCH}/${slug}`,
+      installCmd: `claude plugin install https://github.com/${REPO}/tree/${PLUGIN_BRANCH}/${slug}`,
+      detailUrl: withBase(`/packs/${slug}/`),
+    };
+  });
+---
+
+<SiteLayout
+  title="Claude plugins catalogue — agent-ready-repo"
+  description="Install any agent-ready-repo pack directly into Claude Code or Claude Desktop with a single command — no extra tooling required."
+>
+  <!-- ── Hero ──────────────────────────────────────────────────────── -->
+  <section class="plugins-hero" aria-labelledby="plugins-hero-heading">
+    <div class="plugins-hero__inner">
+      <span class="plugins-hero__eyebrow">Claude plugin catalogue</span>
+      <h1 id="plugins-hero-heading" class="plugins-hero__heading">
+        One command.<br />Any pack.
+      </h1>
+      <p class="plugins-hero__body">
+        Every pack in this catalogue ships as a Claude plugin. Install directly
+        into Claude Code or Claude Desktop — no CLI to install, no configuration
+        needed. Copy the command, paste it, done.
+      </p>
+      <div class="plugins-hero__meta">
+        <span class="plugins-hero__count">
+          {packs.length} packs available
+        </span>
+        <a
+          class="plugins-hero__marketplace"
+          href={MARKETPLACE_RAW_URL}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          marketplace.json <span aria-hidden="true">↗</span>
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Catalogue grid ────────────────────────────────────────────── -->
+  <Section tone="surface" labelledby="catalogue-heading">
+    <h2 id="catalogue-heading" class="visually-hidden">All plugins</h2>
+
+    <ul class="plugin-grid" role="list">
+      {packs.map((pack) => (
+        <li class="plugin-card">
+          <!-- Card header — navigates to detail page -->
+          <div class="plugin-card__head">
+            <div class="plugin-card__name-row">
+              <h3 class="plugin-card__name">{pack.name}</h3>
+              <span class="scope-chip">{pack.scope}</span>
+            </div>
+            <p class="plugin-card__tagline">{pack.tagline}</p>
+            <div class="plugin-card__meta">
+              <span class="plugin-card__skills">
+                {pack.skillCount} skill{pack.skillCount !== 1 ? 's' : ''}
+              </span>
+              <a class="plugin-card__detail" href={pack.detailUrl}>
+                View pack <span aria-hidden="true">→</span>
+              </a>
+            </div>
+          </div>
+
+          <!-- Install block — outside the navigating anchor -->
+          <div class="plugin-install">
+            <div class="plugin-install__label">Install</div>
+            <div class="plugin-install__row">
+              <code class="plugin-install__cmd">{pack.installCmd}</code>
+              <button
+                class="copy-btn"
+                data-cmd={pack.installCmd}
+                aria-label={`Copy install command for ${pack.name}`}
+                type="button"
+              >
+                <span class="copy-btn__icon" aria-hidden="true">
+                  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <rect x="4" y="4" width="9" height="9" rx="1.5" stroke="currentColor" stroke-width="1.25"/>
+                    <path d="M2 10V2.5A1.5 1.5 0 0 1 3.5 1H10" stroke="currentColor" stroke-width="1.25" stroke-linecap="round"/>
+                  </svg>
+                </span>
+                <span class="copy-btn__label">Copy</span>
+              </button>
+            </div>
+          </div>
+        </li>
+      ))}
+    </ul>
+
+    <!-- Machine-readable footer -->
+    <div class="catalogue-footer">
+      <p class="catalogue-footer__text">
+        Looking for the machine-readable index?
+        <a href={MARKETPLACE_RAW_URL} rel="noopener noreferrer" target="_blank">
+          {MARKETPLACE_RAW_URL}
+        </a>
+      </p>
+    </div>
+  </Section>
+</SiteLayout>
+
+<script>
+  // Copy-to-clipboard for plugin install commands.
+  // Each .copy-btn carries data-cmd with the full install command.
+  document.querySelectorAll<HTMLButtonElement>('.copy-btn').forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      const cmd = btn.dataset.cmd ?? '';
+      try {
+        await navigator.clipboard.writeText(cmd);
+        const label = btn.querySelector('.copy-btn__label');
+        if (label) {
+          label.textContent = 'Copied!';
+          btn.classList.add('copy-btn--success');
+          setTimeout(() => {
+            label.textContent = 'Copy';
+            btn.classList.remove('copy-btn--success');
+          }, 2000);
+        }
+      } catch {
+        // Clipboard API unavailable — silently ignore (the text is still visible).
+      }
+    });
+  });
+</script>
+
+<style>
+  /* ── Hero ─────────────────────────────────────────────────────────── */
+  .plugins-hero {
+    background-color: var(--ds-hero-bg);
+    color: var(--ds-hero-fg);
+    padding: clamp(4rem, 10vw, 7rem) var(--ds-content-pad-x) clamp(3rem, 6vw, 5rem);
+  }
+
+  .plugins-hero__inner {
+    max-width: var(--ds-content-max);
+    margin-inline: auto;
+  }
+
+  .plugins-hero__eyebrow {
+    display: inline-block;
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--ds-track-label);
+    color: var(--ds-accent);
+    margin-bottom: var(--ds-space-4);
+  }
+
+  .plugins-hero__heading {
+    font-size: var(--ds-type-display);
+    font-weight: var(--ds-weight-heavy);
+    letter-spacing: var(--ds-track-display);
+    line-height: var(--ds-lead-display);
+    margin-bottom: var(--ds-space-5);
+    color: var(--ds-hero-fg);
+  }
+
+  .plugins-hero__body {
+    font-size: var(--ds-type-body-lg);
+    color: var(--ds-hero-fg-2);
+    max-width: 62ch;
+    line-height: var(--ds-lead-body);
+    margin-bottom: var(--ds-space-6);
+  }
+
+  .plugins-hero__meta {
+    display: flex;
+    align-items: center;
+    gap: var(--ds-space-5);
+    flex-wrap: wrap;
+  }
+
+  .plugins-hero__count {
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-sm);
+    color: var(--ds-hero-fg-muted);
+  }
+
+  .plugins-hero__marketplace {
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-sm);
+    color: var(--ds-accent);
+  }
+
+  .plugins-hero__marketplace:hover {
+    color: var(--ds-hero-fg);
+    text-decoration: none;
+  }
+
+  /* ── Grid ─────────────────────────────────────────────────────────── */
+  .plugin-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+    gap: var(--ds-space-5);
+    margin-bottom: var(--ds-space-9);
+  }
+
+  /* ── Card ─────────────────────────────────────────────────────────── */
+  .plugin-card {
+    background-color: var(--ds-surface-alt);
+    border: 1px solid var(--ds-border);
+    border-radius: var(--ds-radius-lg);
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    overflow: hidden;
+    transition: border-color var(--ds-dur-moderate) var(--ds-ease-std);
+  }
+
+  .plugin-card:hover {
+    border-color: var(--ds-accent);
+  }
+
+  .plugin-card__head {
+    padding: var(--ds-space-6);
+    flex: 1;
+  }
+
+  .plugin-card__name-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--ds-space-3);
+    margin-bottom: var(--ds-space-3);
+  }
+
+  .plugin-card__name {
+    font-size: var(--ds-type-h3);
+    font-weight: var(--ds-weight-semibold);
+    color: var(--ds-on-surface);
+    letter-spacing: var(--ds-track-heading);
+  }
+
+  .scope-chip {
+    display: inline-block;
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--ds-track-label);
+    background-color: var(--ds-accent-subtle);
+    color: var(--ds-accent-deep);
+    padding: 0.1rem 0.5rem;
+    border-radius: var(--ds-radius-sm);
+    flex-shrink: 0;
+  }
+
+  .plugin-card__tagline {
+    font-size: var(--ds-type-body);
+    color: var(--ds-on-surface-2);
+    line-height: var(--ds-lead-body);
+    margin-bottom: var(--ds-space-4);
+  }
+
+  .plugin-card__meta {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--ds-space-3);
+  }
+
+  .plugin-card__skills {
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-xs);
+    color: var(--ds-on-surface-muted);
+  }
+
+  .plugin-card__detail {
+    font-size: var(--ds-type-sm);
+    font-weight: var(--ds-weight-semibold);
+    color: var(--ds-accent-deep);
+  }
+
+  .plugin-card__detail:hover {
+    text-decoration: none;
+    color: var(--ds-accent);
+  }
+
+  /* ── Install block ────────────────────────────────────────────────── */
+  .plugin-install {
+    background-color: var(--ds-hero-bg);
+    padding: var(--ds-space-4) var(--ds-space-5);
+    border-top: 1px solid var(--ds-border);
+  }
+
+  .plugin-install__label {
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--ds-track-label);
+    color: var(--ds-hero-fg-muted);
+    margin-bottom: var(--ds-space-2);
+  }
+
+  .plugin-install__row {
+    display: flex;
+    align-items: center;
+    gap: var(--ds-space-3);
+    min-width: 0;
+  }
+
+  .plugin-install__cmd {
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-mono-sm);
+    color: var(--ds-hero-fg);
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    line-height: var(--ds-lead-mono);
+    user-select: all;
+  }
+
+  /* ── Copy button ──────────────────────────────────────────────────── */
+  .copy-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--ds-space-1);
+    flex-shrink: 0;
+    background-color: var(--ds-hero-elevated);
+    border: 1px solid var(--ds-hero-border-card);
+    border-radius: var(--ds-radius-sm);
+    color: var(--ds-hero-fg-muted);
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-xs);
+    font-weight: var(--ds-weight-medium);
+    padding: 0.3rem 0.6rem;
+    cursor: pointer;
+    transition:
+      background-color var(--ds-dur-quick) var(--ds-ease-std),
+      color var(--ds-dur-quick) var(--ds-ease-std),
+      border-color var(--ds-dur-quick) var(--ds-ease-std);
+  }
+
+  .copy-btn:hover {
+    background-color: var(--ds-accent-subtle-dk);
+    border-color: var(--ds-accent);
+    color: var(--ds-accent);
+  }
+
+  .copy-btn--success {
+    background-color: var(--ds-accent-subtle-dk);
+    border-color: var(--ds-accent);
+    color: var(--ds-accent);
+  }
+
+  .copy-btn__icon {
+    display: flex;
+    align-items: center;
+  }
+
+  /* ── Catalogue footer ─────────────────────────────────────────────── */
+  .catalogue-footer {
+    padding-top: var(--ds-space-7);
+    border-top: 1px solid var(--ds-border);
+  }
+
+  .catalogue-footer__text {
+    font-size: var(--ds-type-sm);
+    color: var(--ds-on-surface-muted);
+    line-height: var(--ds-lead-body);
+    word-break: break-all;
+  }
+
+  .catalogue-footer__text a {
+    color: var(--ds-accent-deep);
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-mono-sm);
+  }
+
+  /* ── Accessibility ────────────────────────────────────────────────── */
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .plugin-card,
+    .copy-btn {
+      transition: none;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary

- **CI workflow** (`publish-claude-plugins.yml`) publishes `dist/claude-plugins/` to `claude-plugins-dist` branch on every push to `main`; idempotent; no external Actions beyond `checkout` + `setup-python`
- **`tools/publish-claude-plugins.py`**: worktree-based publish script; strips `catalogue-curation` directory AND its entry from `marketplace.json` before writing to branch
- **`web/src/pages/plugins/index.astro`**: new `/plugins/` catalogue page — dark hero ("One command. Any pack."), pack grid with per-card dark install footer and clipboard copy button
- **SiteNav**: "Plugins" nav link (desktop + mobile) between Packs and Journeys
- **packs/index.astro**: amber-accent banner linking to `/plugins/`
- **packs/[pack].astro**: second install route "Via Claude Code / Claude Desktop" on every pack detail page (below existing agentbundle route)
- **README**: `claude plugin install` as primary Quick Start route; machine-readable marketplace.json URL at end

**Bootstrap already done** — `claude-plugins-dist` branch is live on remote with 638 files (all packs except `catalogue-curation`). AC3 verified via `gh api`.

**Product-engineering install URL** (for Claude Desktop):
```
claude plugin install https://github.com/eugenelim/agent-ready-repo/tree/claude-plugins-dist/product-engineering
```

## Spec

`docs/specs/claude-plugins-publish-and-discover/spec.md` — Status: Shipped. AC1–AC8 verified; AC9 pending CI on this PR.

## Deferred (noted in spec)

- `claude://` deeplink — needs registered OS protocol handler; deferred per prior decision
- `uvx agentbundle install` web button — tracked separately

## Test plan

- [ ] CI: `publish-claude-plugins` workflow runs clean on merge to main
- [ ] CI: `pages`, `docs`, `build-check`, `lint-packs` gates all pass
- [ ] Manual: navigate to `https://eugenelim.github.io/agent-ready-repo/plugins/` — packs listed, copy button works
- [ ] Manual: navigate to any pack detail page — second install route visible with correct URL
- [ ] Manual: "Plugins" appears in nav (desktop + mobile)
- [ ] `grep "claude plugin install" README.md` matches
- [ ] `gh api "repos/eugenelim/agent-ready-repo/contents/marketplace.json?ref=claude-plugins-dist"` — `catalogue-curation` absent from `plugins` array