### PR TITLE
feat(architect): gitGraph + gantt refs, frontmatter config, diagram additions (0.13.0)

### DIFF
--- a/packs/architect/.apm/skills/architect-diagram/SKILL.md
+++ b/packs/architect/.apm/skills/architect-diagram/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: architect-diagram
-description: Use when the user asks for a diagram of a system, integration, flow, state, data model, deployment topology, roadmap, prioritization matrix, or decomposition. Triggers on "show me", "draw", "diagram of", or artifact-shaped nouns like "sequence", "C4 Container view", "state machine", "roadmap", "2×2", "mind map". Produces Mermaid diagrams (flowchart, sequenceDiagram, C4, stateDiagram-v2, erDiagram, plus timeline, quadrantChart, and mindmap for roadmaps, prioritization, and hierarchical decomposition) routed by intent. Cloud-aware (AWS, Azure, GCP, and primitives providers like Hetzner) and agentic-platform-aware (Bedrock AgentCore, AI Foundry, Vertex Agent Engine). Do NOT use for full design-doc drafting (use `architect-design`), critique (use `architect-review`), or comparison tables (use plain Markdown).
+description: Use when the user asks for a diagram of a system, integration, flow, state, data model, deployment topology, roadmap, prioritization matrix, or decomposition. Triggers on "show me", "draw", "diagram of", or artifact-shaped nouns like "sequence", "C4 Container view", "state machine", "roadmap", "2×2", "mind map", "branching strategy", "gantt", "sprint plan". Produces Mermaid diagrams (flowchart, sequenceDiagram, C4, stateDiagram-v2, erDiagram, gitGraph, gantt, plus timeline, quadrantChart, and mindmap for roadmaps, prioritization, and hierarchical decomposition) routed by intent. Cloud-aware (AWS, Azure, GCP, and primitives providers like Hetzner) and agentic-platform-aware (Bedrock AgentCore, AI Foundry, Vertex Agent Engine). Do NOT use for full design-doc drafting (use `architect-design`), critique (use `architect-review`), or comparison tables (use plain Markdown).
 ---
 
 # Skill: architect-diagram
@@ -58,8 +58,8 @@ If two modes plausibly fit, ask once which the user wants.
    cases (comparison, checklist, two-component flow).
 
 4. **Load the syntax reference for the chosen notation** —
-   `references/mermaid-{flowchart,sequence,c4,state,er}.md`, one file
-   per notation, on demand. For the three newer product/roadmap
+   `references/mermaid-{flowchart,sequence,c4,state,er,gitgraph,gantt}.md`,
+   one file per notation, on demand. For the three newer product/roadmap
    grammars, load `references/mermaid-{timeline,quadrant,mindmap}.md`
    — each carries the rendering caveat, the table/bullet-list fallback,
    and the per-type complexity budget. For C4 Container drafts, the
@@ -87,7 +87,23 @@ If two modes plausibly fit, ask once which the user wants.
    newer `architecture-beta` syntax as an alternative — load
    `references/mermaid-architecture-beta.md` for the trade-offs and
    skeleton before offering. Do not default to it; rendering is
-   inconsistent across enterprise wikis. **When the diagram
+   inconsistent across enterprise wikis. **To apply a theme, layout, or
+   look within the diagram itself**, use Mermaid's YAML frontmatter block
+   (Mermaid ≥ 10.5, mmdc v11+):
+
+   ```
+   ---
+   config:
+     theme: base        # default | forest | dark | neutral | base
+     layout: elk        # dagre (default) | elk — see mermaid-flowchart.md for venue caveats
+     look: handDrawn    # classic (default) | handDrawn
+   ---
+   ```
+
+   `look: handDrawn` signals "draft / not final" — offer it for informal
+   design artifacts, never default to it for documentation-grade diagrams.
+   The frontmatter and `%%{init}%%` produce identical output; prefer
+   frontmatter when setting two or more keys. **When the diagram
    distinguishes more than one category of thing or relationship, load
    `references/visual-encoding.md`** — map each visual channel (shape,
    grouping, position, edge style, marker) to meaning by data type, and
@@ -98,7 +114,10 @@ If two modes plausibly fit, ask once which the user wants.
    Container has a technology label; no bare relation labels; fits
    one screen (≤15 nodes); document mode never fabricates names;
    trust boundaries are visible (dashed subgraph border or explicit
-   comment).
+   comment). Also scan for `{}` in `%%` comment text — Mermaid silently
+   breaks on curly braces inside comments. Verify no token is misspelled:
+   the parser fails silently on unrecognised keywords, producing a blank
+   diagram with no error.
 
 8. **Offer to save.** Scan for an obvious home (`docs/architecture/`,
    `diagrams/`, `docs/`). Suggest a kebab-case `.mmd` filename.

--- a/packs/architect/.apm/skills/architect-diagram/references/diagram-rubric.md
+++ b/packs/architect/.apm/skills/architect-diagram/references/diagram-rubric.md
@@ -27,6 +27,10 @@ check, not a suggestion.
       unless the target venue is known to strip it.
 - [ ] **No fabricated names** in document mode. Where a name is
       genuinely missing, label `<unnamed>` or ask.
+- [ ] **No secrets in labels.** Node labels and edge labels never carry
+      real secret values, connection strings, API keys, or credentials.
+      Use a descriptive placeholder: `[secret key]`, `<conn-string>`,
+      `***`. A diagram with live credentials is a data leak.
 - [ ] **Renders.** Paste the Mermaid into the live editor and confirm
       it parses before showing the user.
 - [ ] **One notation per diagram.** No mixing `sequenceDiagram` blocks

--- a/packs/architect/.apm/skills/architect-diagram/references/mermaid-architecture-beta.md
+++ b/packs/architect/.apm/skills/architect-diagram/references/mermaid-architecture-beta.md
@@ -37,6 +37,8 @@ architecture-beta
 | Service / node | `service <id>(<icon>)[Label] in <group>` |
 | Junction (fan-in / fan-out) | `junction <id> in <group>` |
 | Edge | `<from>:<side> --> <side>:<to>` |
+| Group edge | `<from>{group}:<side> --> <side>:<to>` |
+| Bidirectional edge | `<from>:<side> <--> <side>:<to>` |
 
 Sides for connection points: `L`, `R`, `T`, `B` (left, right, top,
 bottom). The directional notation lets the renderer route edges
@@ -52,6 +54,25 @@ If iconify is available, vendor icons follow the pattern
 `logos:aws-lambda`, `logos:azure`, `logos:google-cloud`, etc.
 Confirm with the user before reaching for these — they fail silently
 on renderers without iconify.
+
+### Installing iconify packs for `mmdc`
+
+When rendering locally with the Mermaid CLI, install an icon pack and pass
+it via `--iconPacks`:
+
+```
+npm install @iconify-json/logos
+mmdc --iconPacks @iconify-json/logos -i diagram.mmd -o diagram.svg
+```
+
+| Pack | Install | Prefix |
+| --- | --- | --- |
+| Technology logos (AWS, Docker, GitHub…) | `npm i @iconify-json/logos` | `logos:` |
+| Material Design | `npm i @iconify-json/mdi` | `mdi:` |
+| Simple icons | `npm i @iconify-json/simple-icons` | `si:` |
+
+Usage: `service web(logos:docker)[Docker Container]`. Icon slugs follow the
+pack's own naming — check iconify.design for the exact name.
 
 ## When to use architecture-beta
 

--- a/packs/architect/.apm/skills/architect-diagram/references/mermaid-c4.md
+++ b/packs/architect/.apm/skills/architect-diagram/references/mermaid-c4.md
@@ -70,6 +70,11 @@ C4Container
 | Container DB | `ContainerDb(id, "Name", "Tech", "Desc")` | Persistent store |
 | Container queue | `ContainerQueue(id, "Name", "Tech", "Desc")` | Async transport |
 | Relationship | `Rel(from, to, "Label", "Tech")` | Directed call / dependency |
+| Bidirectional | `BiRel(from, to, "Label", "Tech")` | Mutual / bidirectional call |
+| System DB | `SystemDb(id, "Name", "Desc")` | Database system at Context level |
+| System queue | `SystemQueue(id, "Name", "Desc")` | Queue / message bus at Context level |
+| System DB ext | `SystemDb_Ext(id, "Name", "Desc")` | External database system |
+| System queue ext | `SystemQueue_Ext(id, "Name", "Desc")` | External queue system |
 
 ## Non-negotiables (matches `diagram-rubric.md`)
 
@@ -134,6 +139,51 @@ This is layout guidance, not a guarantee — `UpdateLayoutConfig()` and
 those tokens are silently ignored. Layout direction is fixed by the renderer.
 If you need a specific flow direction, fall back to a `flowchart TB` / `LR`
 with subgraphs.
+
+## Relationship label positioning
+
+When relationship labels overlap in a dense Context diagram, nudge them with
+`UpdateRelStyle`:
+
+```
+UpdateRelStyle(customer, orders, $offsetX="-50", $offsetY="-30")
+```
+
+`$offsetX` and `$offsetY` move the label relative to the midpoint of the
+arrow. Values are strings (quoted integers). Use sparingly — a diagram that
+needs many label nudges is crowded enough to split.
+
+## C4 Component skeleton
+
+Component view describes the internal structure of one container. It earns
+its place when the question is *how is this service built* — not for most
+architecture reviews (that is a Container question).
+
+```
+C4Component
+    title Component view — Order Service
+
+    ContainerDb(db, "Orders DB", "Postgres", "Stores orders and fulfillments")
+    ContainerQueue(queue, "Fulfillment queue", "Kafka", "orders.v1 topic")
+    System_Ext(payments, "Stripe", "Card payment processing")
+
+    Container_Boundary(orders, "Order Service") {
+        Component(ctrl, "REST controller", "Go, net/http", "HTTP endpoints")
+        Component(svc, "Order service", "Go", "Order lifecycle logic")
+        Component(repo, "Order repository", "Go, pgx", "DB reads and writes")
+        Component(pub, "Event publisher", "Go, kafka-go", "Publishes fulfillment events")
+    }
+
+    Rel(ctrl, svc, "Delegates to")
+    Rel(svc, repo, "Reads / writes", "SQL")
+    Rel(svc, pub, "Publishes", "Kafka")
+    Rel(svc, payments, "Charges card", "HTTPS / webhook")
+    Rel(repo, db, "Reads / writes", "SQL / pgx")
+    Rel(pub, queue, "Publishes orders.v1", "Kafka")
+```
+
+The non-negotiables at Component level match those at Container level:
+every `Component` has a technology label; every `Rel` carries a protocol.
 
 ## Common architecture pitfalls
 

--- a/packs/architect/.apm/skills/architect-diagram/references/mermaid-er.md
+++ b/packs/architect/.apm/skills/architect-diagram/references/mermaid-er.md
@@ -76,7 +76,45 @@ in`. Bare lines fail the rubric.
 | `UK` | Unique key / unique constraint |
 
 Mark every PK and every FK. UK only where the constraint is
-load-bearing for the design.
+load-bearing for the design. `NN` is **not** a valid Mermaid modifier
+— express not-null in the quoted comment instead (see below).
+
+A fourth token in quotes adds a freeform comment — use it for constraints,
+defaults, or notes that the modifier set can't encode:
+
+```
+erDiagram
+    USER {
+        uuid id PK
+        varchar email UK "NOT NULL, indexed"
+        varchar status "DEFAULT 'active', CHECK IN ('active','suspended')"
+        timestamp deleted_at "NULLABLE — soft-delete sentinel"
+    }
+```
+
+The comment renders alongside the column in the diagram and survives as
+documentation in the source file.
+
+## Self-referencing (hierarchical) entities
+
+An entity can relate to itself — useful for trees, parent-child hierarchies,
+and adjacency-list patterns:
+
+```
+erDiagram
+    CATEGORY ||--o{ CATEGORY : "parent of"
+
+    CATEGORY {
+        uuid id PK
+        uuid parent_id FK "NULL for root nodes"
+        string name
+        int sort_order
+    }
+```
+
+The `parent_id FK` on `CATEGORY` referencing `CATEGORY` makes the
+self-relationship explicit. The relationship label names the direction —
+`"parent of"` reads from left (parent) to right (child).
 
 ## Common types
 

--- a/packs/architect/.apm/skills/architect-diagram/references/mermaid-flowchart.md
+++ b/packs/architect/.apm/skills/architect-diagram/references/mermaid-flowchart.md
@@ -78,6 +78,7 @@ it, so treat it as reinforcement, never the sole carrier of meaning.
 | Diamond | `A{Label}` | Decision, conditional routing |
 | Hexagon | `A{{Label}}` | External system, third-party |
 | Circle | `A((Label))` | Junction, fan-in / fan-out |
+| Flag / banner | `A>Label]` | Annotation or event marker (use sparingly) |
 
 Be consistent across the diagram — pick one shape per *category* of
 thing and never mix.
@@ -92,9 +93,35 @@ thing and never mix.
 | `A --x B` | Failure path / terminates |
 | `A === B` | Strong / heavy coupling (used sparingly) |
 | `A -->|"label"| B` | Labeled edge — name the protocol or payload |
+| `A --- B` | Undirected link — dependency or association without direction |
+| `A ==> B` | Thick arrow — critical path or primary data flow |
+| `A ==Label==> B` | Labeled thick arrow |
 
 **Always label edges** that cross a trust boundary or carry data.
 "HTTPS" alone is fine; "gRPC orders.v2" is better; "uses" is wrong.
+
+### Edge semantic conventions
+
+Use these shapes consistently across diagrams in the same workspace so
+reviewers can read new diagrams without a legend:
+
+| Shape | Semantic |
+| --- | --- |
+| `-->` | Primary synchronous call / main data flow |
+| `-.->` | Asynchronous, optional, or out-of-band |
+| `==>` | Critical path — highlight the hot route |
+| `---` | Association or dependency (no direction implied) |
+
+### Multi-target shorthand
+
+Fan-out from a single source to several targets in one line:
+
+```
+A --> B & C & D
+```
+
+Equivalent to `A --> B`, `A --> C`, `A --> D`. Use when the edge carries
+the same label to all targets; create separate edges for different labels.
 
 ## Subgraphs — for boundaries
 
@@ -236,7 +263,8 @@ Lower it when long labels are clipping:
 ```
 
 Text-drives-layout: Mermaid derives node dimensions from label content —
-there is no per-node size override. Use `\n` to force a line break in a label.
+there is no per-node size override. Use `\n` to force a line break in a label
+(plain text output); use `<br/>` when the output is HTML or SVG.
 
 ## ELK renderer — for complex graphs
 

--- a/packs/architect/.apm/skills/architect-diagram/references/mermaid-gantt.md
+++ b/packs/architect/.apm/skills/architect-diagram/references/mermaid-gantt.md
@@ -1,0 +1,133 @@
+# Mermaid gantt — project schedule with durations
+
+The right notation for *when does each task happen, what depends on what*
+— a project schedule, a sprint plan, a migration timeline where task
+duration and sequencing matter. Has a time axis; models start dates,
+durations, and `after` dependencies.
+
+Use `gantt` for **illustrative schedules** — to communicate a plan or a
+constraint to a team. It does not update itself; it is a static diagram,
+not a live PM tool.
+
+When the question is purely chronological (what happened when, no
+durations), prefer `timeline` instead — gantt is overkill when you only
+need "what happened when."
+
+## Skeleton
+
+```mermaid
+gantt
+    title Q1 migration plan
+    dateFormat YYYY-MM-DD
+    section Discovery
+        Requirements   :done,  req,  2025-01-06, 2025-01-17
+        Architecture   :       arch, 2025-01-13, 2025-01-24
+    section Build
+        Implementation :crit,  impl, after arch, 30d
+        Testing        :crit,  test, after impl, 14d
+    section Release
+        Deploy         :       dep,  after test,  3d
+        Cutover        :milestone, cut, after dep, 0d
+```
+
+## Required header
+
+```
+gantt
+    title <text>           %% optional but recommended
+    dateFormat YYYY-MM-DD  %% required — tells Mermaid how to parse dates
+```
+
+Common `dateFormat` values: `YYYY-MM-DD`, `DD/MM/YYYY`, `MM-DD-YYYY`.
+The format must match every date string in the diagram exactly.
+
+## Sections
+
+```
+section <name>
+```
+
+Groups tasks visually into rows with a label on the left. All tasks below
+a `section` belong to it until the next `section`.
+
+## Task syntax
+
+```
+<Label>  :<modifiers>,  <id>,  <start>,  <end>
+```
+
+| Part | Notes |
+| --- | --- |
+| `<Label>` | Display name — keep ≤ 20 chars; long labels overflow the bar |
+| `<modifiers>` | Any combination of: `done`, `active`, `crit`, `milestone` |
+| `<id>` | Optional identifier — referenced by `after <id>` dependencies |
+| `<start>` | A date (`2025-01-06`) or `after <id>` |
+| `<end>` | A date, a duration (`30d`, `2w`), or another task id |
+
+### Status modifiers
+
+| Modifier | Rendering | Meaning |
+| --- | --- | --- |
+| `done` | Grey | Completed |
+| `active` | Blue | In progress |
+| `crit` | Red | Critical path |
+| `milestone` | Diamond | Key event — set duration to `0d` |
+| *(none)* | Teal | Default / planned |
+
+Modifiers combine: `crit, active` renders a red in-progress bar.
+
+### Dependencies with `after`
+
+```
+Implementation :impl, after arch, 30d
+```
+
+`after arch` starts the task immediately after the task with `id: arch`
+ends. The upstream task must be declared **before** the `after` reference.
+Chain multiple: `after arch req` starts after both finish.
+
+## Axis control
+
+```
+    axisFormat  %m/%d
+    tickInterval 1week
+    excludes weekends
+    excludes monday, tuesday
+```
+
+| Directive | Effect |
+| --- | --- |
+| `axisFormat %m/%d` | Date format on the X axis (strftime-like) |
+| `tickInterval 1week` | Spacing between ticks (`1day`, `1week`, `1month`) |
+| `excludes weekends` | Skip Saturday and Sunday from the axis |
+| `excludes <day>` | Skip a specific named day |
+
+## When `gantt` is the right choice
+
+- Sprint or quarter plan where task durations and blockers matter.
+- Migration schedule with sequential dependencies (step B can't start
+  until step A ships).
+- Communicating a deadline constraint to stakeholders.
+
+## When to use something else
+
+- **Pure chronology / roadmap (no durations)** → `timeline`; gantt adds
+  complexity without value when you only need order.
+- **More than ~20 tasks** → break into multiple diagrams by phase, or use
+  a proper PM tool. Dense gantt diagrams lose the "at a glance" value.
+- **Live project tracking** → gantt is a static artifact; it does not
+  update as work progresses.
+
+## Common pitfalls
+
+- **`after <id>` references an undefined id.** Mermaid renders blank.
+  Declare the upstream task with an explicit `id` before the `after`
+  reference.
+- **`dateFormat` missing.** Without it, date strings are unparsed and the
+  axis is wrong or empty.
+- **Long labels.** Mermaid clips labels at the bar width. Use ≤ 20
+  characters or abbreviate.
+- **Milestone with non-zero duration.** A milestone with a duration renders
+  as a bar, not a diamond — set it to `0d` explicitly.
+- **`after` chain not in declaration order.** If task B depends on task A
+  via `after A`, task A must appear in the diagram source before task B.

--- a/packs/architect/.apm/skills/architect-diagram/references/mermaid-gitgraph.md
+++ b/packs/architect/.apm/skills/architect-diagram/references/mermaid-gitgraph.md
@@ -1,0 +1,145 @@
+# Mermaid gitGraph — branching strategy and merge workflow
+
+The right notation for *how is version control structured* — a branching
+strategy, a release workflow, a rebase or cherry-pick pattern. Shows
+commits and branches as a communication artifact, not as an authoritative
+history.
+
+Use `gitGraph` to explain a strategy to a team or document a workflow
+decision. Do **not** use it to represent the real repository history —
+`git log --graph` is authoritative for that; a generated diagram is always
+out of date.
+
+## Skeleton
+
+```mermaid
+gitGraph
+    commit
+    branch develop
+    checkout develop
+    commit
+    commit
+    checkout main
+    merge develop tag: "v1.0"
+    commit
+```
+
+## Vocabulary
+
+| Statement | Effect |
+| --- | --- |
+| `commit` | Adds a commit to the current branch |
+| `commit id: "label"` | Named commit — the label appears on the node |
+| `commit type: HIGHLIGHT` | Visually accents the commit (also `REVERSE`, `NORMAL` default) |
+| `commit tag: "v1.0"` | Attaches a tag marker to the commit |
+| `branch <name>` | Creates a new branch and checks it out |
+| `checkout <name>` | Switches to an existing branch |
+| `merge <name>` | Merges the named branch into the current branch |
+| `merge <name> tag: "v1.0"` | Merge commit with a tag |
+| `cherry-pick id: "label"` | Cherry-picks the commit with that `id` onto the current branch |
+
+`cherry-pick` requires the source commit to have been declared with an
+explicit `id` earlier in the diagram — gitGraph does not know the real
+repository history.
+
+## Examples
+
+### Trunk-based development
+
+```mermaid
+gitGraph
+    commit
+    commit
+    branch feature/login
+    checkout feature/login
+    commit
+    commit
+    checkout main
+    merge feature/login
+    commit
+    branch feature/payments
+    checkout feature/payments
+    commit
+    checkout main
+    merge feature/payments tag: "v2.0"
+```
+
+### Git flow (abridged)
+
+```mermaid
+gitGraph
+    commit tag: "v1.0"
+    branch develop
+    checkout develop
+    commit
+    branch feature/orders
+    checkout feature/orders
+    commit
+    commit
+    checkout develop
+    merge feature/orders
+    branch release/1.1
+    checkout release/1.1
+    commit id: "bump version"
+    checkout main
+    merge release/1.1 tag: "v1.1"
+    checkout develop
+    merge release/1.1
+```
+
+## Configuration
+
+Control rendering with frontmatter (Mermaid ≥ 10.5):
+
+```
+---
+config:
+  gitGraph:
+    mainBranchName: main
+    showBranches: true
+    showCommitLabel: true
+    rotateCommitLabel: true
+    parallelCommits: false
+---
+gitGraph
+    commit
+    ...
+```
+
+| Key | Default | Effect |
+| --- | --- | --- |
+| `mainBranchName` | `main` | Renames the default branch label in the diagram |
+| `showBranches` | `true` | Show / hide branch lane lines |
+| `showCommitLabel` | `true` | Show / hide commit id labels |
+| `rotateCommitLabel` | `true` | Rotate labels 45° — prevents crowding on dense diagrams |
+| `parallelCommits` | `false` | Align commits at the same depth across parallel branches |
+
+## When `gitGraph` is the right choice
+
+- Explaining a branching strategy to a team ("here is how trunk-based
+  works for us").
+- Documenting a release or hotfix workflow decision in a design doc or PR.
+- Showing a cherry-pick or rebase pattern as a teaching aid.
+
+## When to use something else
+
+- **Project schedule / timeline** → use `gantt` or `timeline`; gitGraph
+  has no time axis and no duration concept.
+- **Actual commit history** → run `git log --graph --oneline` or use a GUI;
+  any generated diagram is already stale.
+- **Code or request flow** → use `sequenceDiagram` or `flowchart`.
+
+## Common pitfalls
+
+- **Committing on the wrong branch.** `branch x` creates *and* checks out
+  `x`. If you then do `commit` without `checkout main` first, those commits
+  go on `x`, not `main`. Be explicit about `checkout` before every run of
+  commits.
+- **`cherry-pick` references an unnamed commit.** The `id` in
+  `cherry-pick id: "label"` must match a `commit id: "label"` declared
+  earlier. Without the matching `id`, Mermaid renders a broken diagram.
+- **More than 6–8 branches.** The diagram becomes unreadable. Split into
+  two: one showing the main branching strategy, one showing the
+  release / hotfix flow.
+- **Treating the diagram as authoritative.** It is a design artifact. Update
+  it as the strategy changes; never generate it from the real history.

--- a/packs/architect/.apm/skills/architect-diagram/references/mermaid-sequence.md
+++ b/packs/architect/.apm/skills/architect-diagram/references/mermaid-sequence.md
@@ -99,6 +99,59 @@ loop every 30s
 end
 ```
 
+## Sequence numbers
+
+Add `autonumber` as the first statement to label every message with an
+incrementing number — useful in dense or nested flows where prose references
+"step 4":
+
+```
+sequenceDiagram
+    autonumber
+    User->>API: POST /login
+    API->>DB: query user
+    DB-->>API: user record
+    API-->>User: 200 OK + token
+```
+
+## Early exit — `break`
+
+`break` short-circuits the flow for a guard clause or validation failure.
+Different from `alt`: `break` is "stop here on this condition" (early
+return); `alt` is "take one of these paths" (branching).
+
+```
+sequenceDiagram
+    User->>API: POST /order
+    API->>Validator: check payload
+
+    break Payload invalid
+        API-->>User: 400 Bad Request
+    end
+
+    API->>DB: save order
+    DB-->>API: ok
+    API-->>User: 201 Created
+```
+
+## Participant links
+
+Attach a clickable link to a participant lane with `link`:
+
+```
+sequenceDiagram
+    participant API as Order API
+    link API: Docs @ https://docs.example.com/orders
+    link API: Runbook @ https://wiki.example.com/runbooks/orders
+
+    participant DB as Postgres
+    API->>DB: INSERT
+```
+
+Links render as clickable icons in renderers that support them. In
+unsupporting renderers the participant draws normally — links degrade
+gracefully.
+
 ## Common architecture pitfalls
 
 - **Happy path only.** Add at least one `alt` for the failure case

--- a/packs/architect/.apm/skills/architect-diagram/references/notation-routing.md
+++ b/packs/architect/.apm/skills/architect-diagram/references/notation-routing.md
@@ -19,6 +19,8 @@ notation is the most common reason a diagram is unreadable.
 | "Break this down" — decomposition / hierarchy / mind map | Mindmap † | `mindmap` |
 | Comparison ("X vs Y") | Markdown table — **not** Mermaid | — |
 | Internal class structure | Class diagram | `classDiagram` *(rarely the right answer for architecture; usually means the question is "code" not "architecture")* |
+| "How is version control structured" — branching strategy, merge / rebase workflow | Git graph | `gitGraph` |
+| "When does each task happen, what depends on what" — project schedule with durations | Gantt chart | `gantt` |
 
 † **Newer grammars — offer with a rendering caveat, don't default.**
 `timeline`, `quadrantChart`, and `mindmap` are the same class as


### PR DESCRIPTION
## Summary

- **Two new reference files**: `mermaid-gitgraph.md` (vocabulary, trunk-based + git-flow examples, config keys, pitfalls) and `mermaid-gantt.md` (dateFormat header, task syntax, status modifiers, `after` dependencies, axis control, pitfalls).
- **SKILL.md wiring**: gitGraph and gantt added to description triggers, step 4 reference list, and `notation-routing.md` decision table.
- **Frontmatter config block** guidance (theme / layout / look, including `handDrawn` for drafts) added to step 6.
- **`{}` in `%%` comment** silent-failure warning added to step 7.
- **diagram-rubric.md**: no-secrets-in-labels rule.
- **Existing reference enrichments**: autonumber + `break` + participant links (sequence); attribute quoted-comment + self-referencing entities + NN-is-invalid note (er); BiRel/SystemDb/SystemQueue vocab + UpdateRelStyle + C4Component skeleton (c4); flag shape + open/thick edges + edge semantics table + multi-target shorthand + `<br/>` note (flowchart); group edge + bidirectional edge + iconify pack install (architecture-beta).

## Adversarial review findings and fixes

One Blocker found and fixed: `NN` is not a recognized Mermaid erDiagram modifier (only PK/FK/UK are valid); attempting to use it causes a silent parse failure. Removed the table row; the existing quoted-comment example already covers the not-null use case.

Pre-existing `mermaid.live` references in the files (outside this diff) flagged — left for a follow-up.

## Test plan

- [ ] Adversarial-reviewer pass: clean (one Blocker found and fixed before commit)
- [ ] gitGraph and gantt examples render via `mmdc`
- [ ] ER attribute examples render via `mmdc` (no `NN` token)
- [ ] C4 Component skeleton renders via `mmdc`
- [ ] Flowchart fan-out (`A --> B & C & D`) renders via `mmdc`