### PR TITLE
chore(architect): bump version to 0.13.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "architect",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.12.0"
+      "version": "0.13.0"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/packs/architect/.claude-plugin/plugin.json
+++ b/packs/architect/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "architect",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Solution-architecture skills (architect-design, architect-diagram, architect-review) plus a forked-context design-reviewer subagent. Workspace-agnostic, user-scope by default, no required configuration."
 }

--- a/packs/architect/pack.toml
+++ b/packs/architect/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "architect"
-version = "0.12.0"
+version = "0.13.0"
 description = "Solution-architecture skills (architect-design, architect-diagram, architect-review) plus a forked-context design-reviewer subagent. Workspace-agnostic, user-scope by default, no required configuration. Mermaid for diagrams; Google-style design docs; rubric-routed critique."
 readme = "README.md"
 display_name = "Architect"


### PR DESCRIPTION
Version bump missed in #520. Updates `pack.toml`, `plugin.json`, and `marketplace.json` from 0.12.0 → 0.13.0 to match the commit message on that PR.