### PR TITLE
feat(product-engineering): extend human-craft-check with vocabulary tells and editorial methodology (0.11.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -205,7 +205,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "product-engineering",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.10.1"
+      "version": "0.11.0"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`voice-and-microcopy` human-craft check gains vocabulary tells, an editorial methodology, and voice authenticity tests (product-engineering 0.11.0).** `human-craft-check.md` now covers three additional layers beyond its existing structural tells: a vocabulary-tell section (hollow verbs, inflated adjectives, abstract container nouns, hedging openers — each with a concrete replacement rule); a three-pass editorial methodology (vocabulary scan → delete the opening → specificity audit); and three voice authenticity tests (pub test, founder test, one-person test). Scoped to the same context as before — longer copy: onboarding text, feature descriptions, help text — not short UI strings.
+
 ### Added
 
 - **`voice-and-microcopy` gains a human-craft structural-tell check (product-engineering 0.10.1).** A new reference file, `human-craft-check.md`, inlines six structural AI tells — treadmill effect, symmetrical lists, false precision, performative thoroughness, nice-nice wrap, subtext vacuum — and a four-question self-check for longer copy (onboarding text, feature descriptions, help text). The content checklist gains an eighth item, Human-crafted, that routes longer copy through this check. Self-contained within the pack; no cross-pack references.

--- a/packs/product-engineering/.apm/skills/voice-and-microcopy/references/content-checklist.md
+++ b/packs/product-engineering/.apm/skills/voice-and-microcopy/references/content-checklist.md
@@ -21,10 +21,9 @@ catch the misses and fix them. Each item is one question; a "no" is a fix.
 - [ ] **Inclusive and plain.** Plain language; no idioms that don't translate, no
       jargon the user didn't bring, no assumptions about who the user is.
 - [ ] **Human-crafted.** Does longer copy (onboarding text, help text, feature
-      descriptions) avoid the structural tells that make writing feel generated —
-      treadmill effect, symmetrical lists, false precision, performative
-      thoroughness, nice-nice wrap, subtext vacuum? See `human-craft-check.md`
-      for the full structural-tell rundown and four-question self-check.
+      descriptions) clear the structural tells, vocabulary tells, and voice
+      authenticity tests in `human-craft-check.md`? Run the three-pass editorial
+      methodology there before shipping any copy longer than a few sentences.
 
 ## How to use it
 

--- a/packs/product-engineering/.apm/skills/voice-and-microcopy/references/human-craft-check.md
+++ b/packs/product-engineering/.apm/skills/voice-and-microcopy/references/human-craft-check.md
@@ -1,12 +1,17 @@
-# Human-craft check — structural tells in copy
+# Human-craft check — structural and vocabulary tells
 
-Machine-made copy often passes a word-level vocabulary check and still reads flat.
-These structural patterns are why. They survive the surface pass because they are
-shape problems, not vocabulary problems.
+Machine-made copy fails at two levels: shape and word choice. Structural tells
+survive a vocabulary pass because they are pattern problems, not term problems.
+Vocabulary tells survive a structural pass because each sentence looks fine in
+isolation. Catching both requires two separate sweeps.
 
 Run this check on longer copy: onboarding text, empty-state explanations, feature
 descriptions, help text. Short strings — button labels, single-line error messages —
 are caught by the items in `content-checklist.md`; this check is for the paragraphs.
+
+*The equivalent checklist for documentation prose is `clear-prose.md` in the
+`new-guide` skill. The vocabulary and structural tells overlap — the context
+(product UI copy vs. docs) differs, not the patterns.*
 
 ## Structural tells
 
@@ -20,10 +25,9 @@ are caught by the items in `content-checklist.md`; this check is for the paragra
   genuinely distinct points. A real list of three features is rarely three identical
   sentences. Vary length and depth to match the actual shape of the content.
 
-- **False precision.** Authoritative framing — "research shows", "studies indicate",
-  "it's important to note" — without a grounded specific behind it. If you can't
-  name the study, the finding, or the number, replace the framing with a concrete
-  claim or cut it.
+- **False precision.** Authoritative framing — "research shows", "studies indicate"
+  — without a grounded specific behind it. If you can't name the study, the finding,
+  or the number, replace the framing with a concrete claim or cut it.
 
 - **Performative thoroughness.** Seven benefit bullets when two drive the decision.
   The extra five exist to signal completeness, not to inform. Cut the padding; leave
@@ -48,3 +52,64 @@ pass will miss:
 3. Is there a position the copy can be disagreed with?
 4. Is any specific detail grounded — a name, a date, a count, an observation —
    or is specificity only performed?
+
+## Vocabulary tells
+
+These survive the structural check because each sentence looks fine in isolation.
+They flag to any reader who's encountered a lot of generated output. They share
+one defect: they gesture at a concept without carrying it.
+
+**Hollow verbs:** leverage, harness, foster, streamline, empower, underscore,
+elevate, unleash. Replace with the actual action. "Lets you connect" not "empowers
+you to connect"; "maps" not "streamlines the process of mapping".
+
+**Inflated adjectives:** seamless, robust, cutting-edge, pivotal, transformative,
+unprecedented. They reach for authority without earning it. Replace with a specific
+quality. "Works without a separate login" not "seamless integration"; "handles a
+thousand rows without slowing" not "robust performance".
+
+**Abstract container nouns:** ecosystem, landscape, realm, tapestry, paradigm.
+These name the category a thing belongs to instead of naming the thing. Name the
+thing. "The skills directory" not "the skills ecosystem"; "how the agents hand off
+work" not "the agentic landscape".
+
+**Hedging openers:** "It is important to note that", "It is worth remembering",
+"Generally speaking". These delay the claim. Cut the opener; start with the claim.
+
+**Em-dash overuse.** One em-dash per paragraph is punctuation. A pattern of them
+in every sentence is a tell. Reach for a period or a comma first; keep the dash
+for the break that earns it.
+
+## Editorial methodology
+
+Three passes, run in order. Each catches what the previous misses.
+
+**Pass 1 — vocabulary scan.** Search for the flagged terms above and replace each
+with the concrete word it's standing in for. If the replacement doesn't come, the
+claim isn't grounded enough to make.
+
+**Pass 2 — delete the opening.** Cut the first paragraph of each section, or the
+first sentence of a short block. Generated copy front-loads context that delays the
+real point. The writing almost always starts better at the second paragraph. Restore
+only when removing it loses something specific: a named constraint, a reference, an
+orienting fact.
+
+**Pass 3 — specificity audit.** Run the False-precision tell as a dedicated sweep:
+every broad claim gets a grounding detail or becomes a direct claim. If it can't be
+grounded, cut it.
+
+## Voice authenticity tests
+
+Run these after the three passes. A "no" is a rewrite.
+
+- **Pub test.** Read the sentence aloud. Would you say this to a person in
+  conversation? If the phrasing would make someone glance at you sideways, rewrite
+  it.
+
+- **Founder test.** Would the person who built this product actually say this
+  sentence? Not "would they approve it" — would they *say* it? Inflated product
+  descriptions almost always fail this test.
+
+- **One-person test.** Is this addressed to one specific person, or to "users" and
+  "teams" generically? Pick one reader. The copy changes when the address is
+  specific.

--- a/packs/product-engineering/.claude-plugin/plugin.json
+++ b/packs/product-engineering/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "product-engineering",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Shape product intent into shippable specs — and into the words users read. Habits — frame-intent, de-risk-intent, decompose-intent — over a recursive, level-tagged `intent` (product-vision, product-strategy, capability, and feature intents are the same artifact at different levels — Level is an open recognized set decoupled from Scale): outcome+opportunity framing, a choosable prototype-approach to de-risk the riskiest assumption, and decomposition into the briefs/specs your delivery loop already builds — at app scale, or sliced per component across a business-unit value stream coordinated by `align-value-stream`. `voice-and-microcopy` adds the content layer: characterize a product's voice and write blame-free, actionable UI copy. Upstream of the build loop, the `discovery-loop` (run by the `discovery-lead` agent) turns a raw idea into a build-ready decision brief — diverging across candidate product shapes, converging through a lens roster with two discovery reviewers, and emitting a connected hypothesis with validation hooks — no engine. Markdown skills + agent definitions, user-scope."
 }

--- a/packs/product-engineering/pack.toml
+++ b/packs/product-engineering/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "product-engineering"
-version = "0.10.1"
+version = "0.11.0"
 description = "Shape product intent into shippable specs — and into the words users read. Habits — frame-intent, de-risk-intent, decompose-intent — over a recursive, level-tagged `intent` (product-vision, product-strategy, capability, and feature intents are the same artifact at different levels — Level is an open recognized set decoupled from Scale): outcome+opportunity framing, a choosable prototype-approach to de-risk the riskiest assumption, and decomposition into the briefs/specs your delivery loop already builds — at app scale, or sliced per component across a business-unit value stream coordinated by `align-value-stream`. `voice-and-microcopy` adds the content layer: characterize a product's voice and write blame-free, actionable UI copy. Upstream of the build loop, the `discovery-loop` (run by the `discovery-lead` agent) turns a raw idea into a build-ready decision brief — diverging across candidate product shapes, converging through a lens roster with two discovery reviewers, and emitting a connected hypothesis with validation hooks — no engine. Markdown skills + agent definitions, user-scope."
 readme = "README.md"
 display_name = "Product Engineering"


### PR DESCRIPTION
## Summary

- Extends `human-craft-check.md` with three new layers: vocabulary tells (hollow verbs, inflated adjectives, abstract container nouns, hedging openers, em-dash overuse), a three-pass editorial methodology, and three voice authenticity tests (pub, founder, one-person)
- Adds cross-reference to `clear-prose.md` in `new-guide` to surface the docs-prose equivalent and resolve the pre-existing fork without breaking pack independence
- Updates `content-checklist.md` item 8 to name all three layers so the pointer stays accurate
- Bumps `product-engineering` to 0.11.0; re-aggregates `marketplace.json`

## What this addresses

The existing `human-craft-check.md` (added at 0.10.1) caught structural AI tells — treadmill effect, symmetrical lists, false precision, etc. It didn't cover the word-level vocabulary patterns (leverage, seamless, robust, etc.), the editorial methodology for running the check, or the authenticity tests practitioners use to verify copy sounds human. All three were missing when scrubbing AI-generated copy on the platform site.

## Deferred

The larger gaps (new `copy-direction` skill, new `content-design` skill) remain open in the backlog and require an RFC before implementation.

## Test plan

- [ ] Read `human-craft-check.md` end-to-end: structural tells → vocabulary tells → methodology → authenticity tests flow coherently
- [ ] Confirm `content-checklist.md` item 8 names all three layers accurately
- [ ] Confirm cross-reference to `clear-prose.md` is accurate (file exists at `packs/user-guide-diataxis/.apm/skills/new-guide/references/clear-prose.md`)
- [ ] Confirm `pack.toml` and `plugin.json` both show 0.11.0
- [ ] Confirm `marketplace.json` reflects the version bump