### PR TITLE
docs(web): rewrite 13 journey files to present tense, active voice

### DIFF
--- a/web/src/content/journeys/architect.md
+++ b/web/src/content/journeys/architect.md
@@ -54,30 +54,30 @@ relatedJourneys:
 
 ## Stage 1 — Establish the reference
 
-Before any design work began, the agent checked for a `reference.md` in the repo — the golden-path file that describes the stack, patterns, and constraints the architecture skills design against. If one didn't exist, the agent offered to create it.
+Before any design work begins, the agent checks for a `reference.md` in the repo — the golden-path file that describes the stack, patterns, and constraints the architecture skills design against. If one doesn't exist, the agent offers to create it.
 
-**You did:** Confirmed the reference was accurate for this task. A grounded `reference.md` is what keeps the agent's designs inside your actual architecture, not an idealized one. If the reference was stale or missing a key constraint, update it before the design session starts — the agent will design against whatever it finds.
+**You:** Confirm the reference is accurate for this task. A grounded `reference.md` keeps the agent's designs inside your actual architecture, not an idealized one. If the reference is stale or missing a key constraint, update it before the design session starts — the agent designs against whatever it finds.
 
 ---
 
 ## Stage 2 — Stage 0 concept
 
-You described the design problem. The agent ran `architect-design` in Stage 0 mode, producing a half-page concept framing the problem, naming constraints, and proposing a candidate approach with at least one alternative.
+You describe the design problem. The agent runs `architect-design` in Stage 0 mode, producing a half-page concept framing the problem, naming constraints, and proposing a candidate approach with at least one alternative.
 
-**You did:** Read the concept at the G-concept gate. If the framing missed the real constraint — for example, it proposed a new service when the constraint was "must run inside the existing Lambda" — redirect here, before the full write-up. The concept gate is the cheapest point to course-correct. If the alternatives section felt thin, ask for one more before approving.
+**You:** Read the concept at the G-concept gate. If the framing misses the real constraint — for example, it proposes a new service when the constraint is "must run inside the existing Lambda" — redirect here, before the full write-up. The concept gate is the cheapest point to course-correct. If the alternatives section feels thin, ask for one more before approving.
 
 ---
 
 ## Stage 3 — Full design document
 
-After concept approval, the agent wrote the full Stage 1 design document: problem statement, alternatives considered with rejection reasoning, proposed design, open questions, and success criteria. It grounded the design against the repo's `reference.md` throughout.
+After concept approval, the agent writes the full Stage 1 design document: problem statement, alternatives considered with rejection reasoning, proposed design, open questions, and success criteria. It grounds the design against the repo's `reference.md` throughout.
 
-**You did:** Watched the doc take shape. If the alternatives section omitted an approach the team had already discussed and ruled out, mention it — a design doc that doesn't address the alternatives an experienced reader would ask about is one that will generate questions in review. If the agent drifted from the approved concept, note it.
+**You:** Watch the doc take shape. If the alternatives section omits an approach the team has already discussed and ruled out, mention it — a design doc that doesn't address the alternatives an experienced reader would ask about generates questions in review. If the agent drifts from the approved concept, note it.
 
 ---
 
 ## Stage 4 — Independent review
 
-The agent ran `architect-review`, which dispatched the `design-reviewer` subagent in a forked context — a reviewer that had not seen the authoring session. The reviewer returned findings grouped by severity (Blockers, Concerns, Nits).
+The agent runs `architect-review`, which dispatches the `design-reviewer` subagent in a forked context — a reviewer that has not seen the authoring session. The reviewer returns findings grouped by severity (Blockers, Concerns, Nits).
 
-**You did:** Read the review findings at the G-review gate. For each Blocker, decide whether to fix it or provide a one-sentence reason it doesn't apply — "this is expected because the constraint was already accepted in the RFC." For Concerns and Nits, apply or defer with a reason. The independent read is the closest thing to "a colleague who just walked in" before the doc goes to stakeholders.
+**You:** Read the review findings at the G-review gate. For each Blocker, decide whether to fix it or provide a one-sentence reason it doesn't apply — "this is expected because the constraint was already accepted in the RFC." For Concerns and Nits, apply or defer with a reason. The independent read is the closest thing to "a colleague who just walked in" before the doc goes to stakeholders.

--- a/web/src/content/journeys/atlassian.md
+++ b/web/src/content/journeys/atlassian.md
@@ -68,22 +68,22 @@ relatedJourneys:
 
 ## Stage 1 — Configure credentials and scope
 
-Before any API call, the agent checked that a credential was configured via `credential-brokers`. It then asked you to confirm the JQL scope or Confluence target before running the first query.
+Before any API call, the agent checks that a credential is configured via `credential-brokers`. It then asks you to confirm the JQL scope or Confluence target before running the first query.
 
-**You did:** Confirmed the credential was in place — or set it up if this was the first run. Named the JQL scope explicitly: project key, issue type, status, and date range. A scoped query takes 10 seconds to define; an unscoped query returns thousands of issues and the agent has to guess which ones to include.
+**You:** Confirm the credential is in place — or set it up if this is the first run. Name the JQL scope explicitly: project key, issue type, status, and date range. A scoped query takes 10 seconds to define; an unscoped query returns thousands of issues and the agent has to guess which ones to include.
 
 ---
 
 ## Stage 2 — Fetch and process
 
-With credentials and scope confirmed, the agent ran the appropriate skill. For `jira`, it ran the JQL query with auto-pagination and returned the result set. For `flow-metrics`, it computed cycle time, throughput, and DORA metrics over the scoped data. For `jira-brief-intake`, it read the epic and structured it into a brief.
+With credentials and scope confirmed, the agent runs the appropriate skill. For `jira`, it runs the JQL query with auto-pagination and returns the result set. For `flow-metrics`, it computes cycle time, throughput, and DORA metrics over the scoped data. For `jira-brief-intake`, it reads the epic and structures it into a brief.
 
-**You did:** Watched the fetch complete. If the result set looked wrong — too many issues, too few, or issues from the wrong project — stop the agent and restate the scope. It's faster to re-scope than to post-process a wrong result set.
+**You:** Watch the fetch complete. If the result set looks wrong — too many issues, too few, or issues from the wrong project — stop the agent and restate the scope. It's faster to re-scope than to post-process a wrong result set.
 
 ---
 
 ## Stage 3 — Review before publish or act
 
-The agent presented its output — a metrics table, a structured brief, or a proposed Confluence page — for review before taking any write action.
+The agent presents its output — a metrics table, a structured brief, or a proposed Confluence page — for review before taking any write action.
 
-**You did:** Reviewed the output at the G-output gate before the agent published to Confluence, posted a Jira update, or shared metrics. Atlassian skills operate on live systems; there is no draft mode for Confluence publishes. Check the content is correct, the target is right, and any Jira transitions are the ones you intended before approving the write.
+**You:** Review the output at the G-output gate before the agent publishes to Confluence, posts a Jira update, or shares metrics. Atlassian skills operate on live systems; there is no draft mode for Confluence publishes. Check the content is correct, the target is right, and any Jira transitions are the ones you intended before approving the write.

--- a/web/src/content/journeys/contracts.md
+++ b/web/src/content/journeys/contracts.md
@@ -39,22 +39,22 @@ relatedJourneys:
 
 ## Stage 1 — Author the contract
 
-You described the API surface — the resources, actions, and consumers. The agent ran `api-contract` or `event-contract` with the pluggable house standard configured (Zalando guidelines by default). It produced a first-draft contract: endpoints, request/response schemas, error codes, and the consumer-perspective check.
+You describe the API surface — the resources, actions, and consumers. The agent runs `api-contract` or `event-contract` with the pluggable house standard configured (Zalando guidelines by default). It produces a first-draft contract: endpoints, request/response schemas, error codes, and the consumer-perspective check.
 
-**You did:** Watched the draft take shape and noted corrections as they arose — don't wait for the full draft to redirect on a naming convention or a missing error case. Small corrections mid-draft are faster than a full re-generate. If you knew the consumer would call this API in a specific way, say so before the agent finalizes the response schemas.
+**You:** Watch the draft take shape and note corrections as they arise — don't wait for the full draft to redirect on a naming convention or a missing error case. Small corrections mid-draft are faster than a full re-generate. If you know the consumer will call this API in a specific way, say so before the agent finalizes the response schemas.
 
 ---
 
 ## Stage 2 — Review from the consumer's perspective
 
-After the first complete draft, the agent ran a self-review against the house standard. You reviewed the contract at the G-contract gate — reading from the consumer's perspective, not the producer's.
+After the first complete draft, the agent runs a self-review against the house standard. You review the contract at the G-contract gate — reading from the consumer's perspective, not the producer's.
 
-**You did:** Read through the error responses first. The most common failure mode is a contract that specifies the happy path thoroughly but skips error cases — a 200 response with no corresponding 400, 404, or 500. If an error case was missing, name it explicitly: the agent can't infer which errors are real without domain knowledge. If the schema field names used inconsistent conventions (camelCase in some places, snake_case in others), correct them here before implementation begins.
+**You:** Read through the error responses first. The most common failure mode is a contract that specifies the happy path thoroughly but skips error cases — a 200 response with no corresponding 400, 404, or 500. If an error case is missing, name it explicitly: the agent can't infer which errors are real without domain knowledge. If the schema field names use inconsistent conventions (camelCase in some places, snake_case in others), correct them here before implementation begins.
 
 ---
 
 ## Stage 3 — Versioned output
 
-The ratified contract was emitted as a versioned OpenAPI 3.1 or AsyncAPI 2.x file, ready to commit alongside the implementation it governs.
+The ratified contract is emitted as a versioned OpenAPI 3.1 or AsyncAPI 2.x file, ready to commit alongside the implementation it governs.
 
-**You did:** Confirmed the contract file was placed alongside the service it governs — not in a separate repository or a documentation folder that would diverge from the service over time. A contract that lives apart from its implementation will drift silently until a consumer discovers the mismatch.
+**You:** Confirm the contract file is placed alongside the service it governs — not in a separate repository or a documentation folder that would diverge from the service over time. A contract that lives apart from its implementation drifts silently until a consumer discovers the mismatch.

--- a/web/src/content/journeys/converters.md
+++ b/web/src/content/journeys/converters.md
@@ -55,22 +55,22 @@ relatedJourneys:
 
 ## Stage 1 — Invoke the converter
 
-You named the source file and the target format. The agent invoked the appropriate skill: `file-to-markdown` for a PDF or Office document, `markdown-to-docx` or `markdown-to-pptx` for output artifacts, `mermaid-renderer` for diagrams embedded in a Markdown file.
+You name the source file and the target format. The agent invokes the appropriate skill: `file-to-markdown` for a PDF or Office document, `markdown-to-docx` or `markdown-to-pptx` for output artifacts, `mermaid-renderer` for diagrams embedded in a Markdown file.
 
-**You did:** Named the source file explicitly and confirmed the target format. For office output, also named which template to use — the agent cannot discover your organization's brand template without you pointing to it. If the source was a large PDF and you only needed a specific section, say so before the agent converts the whole document.
+**You:** Name the source file explicitly and confirm the target format. For office output, also name which template to use — the agent cannot discover your organization's brand template without you pointing to it. If the source is a large PDF and you only need a specific section, say so before the agent converts the whole document.
 
 ---
 
 ## Stage 2 — Tier selection (for file-to-markdown)
 
-For document extraction, the agent selected the appropriate capability tier: Tier 1 (no external tools — pure text extraction), Tier 2 (local tools like Pandoc or Poppler), or Tier 3 (agent vision for scanned or image-heavy documents). It reported which tier was used and why.
+For document extraction, the agent selects the appropriate capability tier: Tier 1 (no external tools — pure text extraction), Tier 2 (local tools like Pandoc or Poppler), or Tier 3 (agent vision for scanned or image-heavy documents). It reports which tier was used and why.
 
-**You did:** Confirmed the tier made sense for the document type. If the document was a scanned PDF and the agent selected Tier 1, the extracted Markdown would contain garbled text — redirect to Tier 3 or flag the document as needing OCR before extraction.
+**You:** Confirm the tier makes sense for the document type. If the document is a scanned PDF and the agent selects Tier 1, the extracted Markdown will contain garbled text — redirect to Tier 3 or flag the document as needing OCR before extraction.
 
 ---
 
 ## Stage 3 — Review the output
 
-The agent reported where the output landed and emitted a brief summary of what it converted.
+The agent reports where the output lands and emits a brief summary of what it converted.
 
-**You did:** Opened the output file and reviewed it at the G-output gate. The agent's report says "conversion complete" — what it cannot tell you is whether the resulting file is what you needed. Checked for truncation, structure loss, and template application. If a section was missing, re-run with an explicit instruction to include it.
+**You:** Open the output file and review it at the G-output gate. The agent's report says "conversion complete" — what it cannot tell you is whether the resulting file is what you needed. Check for truncation, structure loss, and template application. If a section is missing, re-run with an explicit instruction to include it.

--- a/web/src/content/journeys/credential-brokers.md
+++ b/web/src/content/journeys/credential-brokers.md
@@ -35,22 +35,22 @@ relatedJourneys:
 
 ## Stage 1 — Identify the credential needed
 
-You decided to install a credentialed pack — figma, atlassian, or another service that requires an API key or personal access token. The agent walked you through identifying what credential type the service required and which resolution path to use.
+You decide to install a credentialed pack — figma, atlassian, or another service that requires an API key or personal access token. The agent walks you through identifying what credential type the service requires and which resolution path to use.
 
-**You did:** Decided where the credential would live — environment variable, OS keyring, or dotfile — based on your environment and security preferences. Read the `credential-setup` output to confirm the resolution path made sense. For most developer workstations, the OS keyring is the right choice: it persists across terminal sessions and is encrypted at rest. For CI environments, an environment variable is the right choice.
+**You:** Decide where the credential will live — environment variable, OS keyring, or dotfile — based on your environment and security preferences. Read the `credential-setup` output to confirm the resolution path makes sense. For most developer workstations, the OS keyring is the right choice: it persists across terminal sessions and is encrypted at rest. For CI environments, an environment variable is the right choice.
 
 ---
 
 ## Stage 2 — Set up and verify
 
-The agent ran `credential-setup`, prompted for the token value (which was never logged), and stored it via the configured resolution chain. It then ran a test invocation to confirm the credential resolved correctly before ending the session.
+The agent runs `credential-setup`, prompts for the token value (which is never logged), and stores it via the configured resolution chain. It then runs a test invocation to confirm the credential resolves correctly before ending the session.
 
-**You did:** Provided the token value when prompted — this is the one moment the credential passes through your clipboard or input. Verified the test invocation succeeded. If it failed, worked through the resolution chain with the agent: is the environment variable exported in the current shell? Is the keyring unlocked? Is the dotfile in the expected location and readable?
+**You:** Provide the token value when prompted — this is the one moment the credential passes through your clipboard or input. Verify the test invocation succeeded. If it fails, work through the resolution chain with the agent: is the environment variable exported in the current shell? Is the keyring unlocked? Is the dotfile in the expected location and readable?
 
 ---
 
 ## Stage 3 — Credential available to all sessions
 
-After setup, the credential resolved automatically in every subsequent session that needed it. No repeat entry. The token value was stored in the configured location and never passed through the model again.
+After setup, the credential resolves automatically in every subsequent session that needs it. No repeat entry. The token value is stored in the configured location and never passes through the model again.
 
-**You did:** Confirmed that the first real invocation of the credentialed skill worked end-to-end. The most common post-setup failure is a scope mismatch — the token was set up correctly but lacks the permissions the skill needs. If a skill returns an auth error after a successful setup, the first check is always: does this token have the right scope for this operation?
+**You:** Confirm that the first real invocation of the credentialed skill works end-to-end. The most common post-setup failure is a scope mismatch — the token was set up correctly but lacks the permissions the skill needs. If a skill returns an auth error after a successful setup, the first check is always: does this token have the right scope for this operation?

--- a/web/src/content/journeys/discovery.md
+++ b/web/src/content/journeys/discovery.md
@@ -11,6 +11,9 @@ skills:
   - name: frame-intent
     description: "Establishes product framing — problem, user, outcome — before the loop begins."
     humanTouches: 1
+  - name: frame-domain
+    description: "Grounds the product in the real-world activity it serves and bounds the MVP — produces Domain Framing and Scope Boundary artifacts before the convergent design loop."
+    humanTouches: 1
   - name: de-risk-intent
     description: "Surfaces the riskiest assumption and designs a prototype approach to de-risk it before committing to build."
     humanTouches: 1
@@ -89,46 +92,46 @@ relatedJourneys:
 
 ## Stage 1 — Shape intent
 
-You described a product idea or problem to the `discovery-lead` agent. The agent activated `discovery-loop`, ran `frame-intent` to establish product framing (problem, user, outcome), and emitted an intent document.
+You describe a product idea or problem to the `discovery-lead` agent. The agent activates `discovery-loop`, runs `frame-intent` to establish product framing (problem, user, outcome), and emits an intent document.
 
-**You did:** Read the intent document — the framing is only a page. Gave concrete corrections if the problem statement was too vague ("users want to collaborate faster" → "the PM can't see which stories are blocked without checking three tools"). Provided the G0 consent once the framing was specific enough to eliminate candidates from. This gate sets the direction for everything that follows.
+**You:** Read the intent document — the framing is only a page. Give concrete corrections if the problem statement is too vague ("users want to collaborate faster" → "the PM can't see which stories are blocked without checking three tools"). Give G0 consent once the framing is specific enough to eliminate candidates from. This gate sets the direction for everything that follows.
 
 ---
 
 ## Stage 2 — Diverge
 
-The agent ran `explore-options` to generate candidate product shapes with distinct tradeoff profiles. Each candidate represented a meaningfully different approach to the problem.
+The agent runs `explore-options` to generate candidate product shapes with distinct tradeoff profiles. Each candidate represents a meaningfully different approach to the problem.
 
-**You did:** Watched as candidates appeared. If a candidate was obviously out-of-scope or repeated a prior approach, say so before the lens roster runs — it saves a review cycle. Otherwise, let the diverge step complete.
+**You:** Watch as candidates appear. If a candidate is obviously out-of-scope or repeats a prior approach, say so before the lens roster runs — it saves a review cycle. Otherwise, let the diverge step complete.
 
 ---
 
 ## Stage 3 — Lens roster
 
-After generating candidates, the agent ran two discovery reviewers — threat and reliability — against each candidate. Each reviewer read cold and returned findings. Candidates that failed the reviewers were eliminated.
+After generating candidates, the agent runs two discovery reviewers — threat and reliability — against each candidate. Each reviewer reads cold and returns findings. Candidates that fail the reviewers are eliminated.
 
-**You did:** Monitored the review output. If a candidate you wanted to keep was eliminated, read the finding that killed it — sometimes the finding is correct and you needed to hear it; sometimes it rests on a false premise you can correct with one sentence.
+**You:** Monitor the review output. If a candidate you want to keep is eliminated, read the finding that killed it — sometimes the finding is correct and you need to hear it; sometimes it rests on a false premise you can correct with one sentence.
 
 ---
 
 ## Stage 4 — Mid-discovery check
 
-The agent surfaced the surviving candidates for a mid-course human check. You reviewed which candidates remained and whether the field felt right.
+The agent surfaces the surviving candidates for a mid-course human check. You review which candidates remain and whether the field feels right.
 
-**You did:** At G1.5 you made a call. If only one candidate survived and it felt too easy, ask the agent to re-explore from a different angle. If the survivors felt genuinely distinct, confirm and let the loop converge. This is the last moment to expand the option space cheaply.
+**You:** At G1.5, make a call. If only one candidate survives and it feels too easy, ask the agent to re-explore from a different angle. If the survivors feel genuinely distinct, confirm and let the loop converge. This is the last moment to expand the option space cheaply.
 
 ---
 
 ## Stage 5 — Converge
 
-The agent ran `de-risk-intent` to surface the riskiest assumption and design a prototype approach to test it. It then ran `decompose-intent` to decompose the chosen direction into specs and briefs for the delivery loop.
+The agent runs `de-risk-intent` to surface the riskiest assumption and design a prototype approach to test it. It then runs `decompose-intent` to decompose the chosen direction into specs and briefs for the delivery loop.
 
-**You did:** Watched the assumption-test take shape. If the prototype approach the agent proposed was too expensive or wouldn't actually test the assumption, redirect. A bad de-risk approach means the brief reaches the delivery loop with an untested assumption at its core.
+**You:** Watch the assumption-test take shape. If the prototype approach the agent proposes is too expensive or won't actually test the assumption, redirect. A bad de-risk approach means the brief reaches the delivery loop with an untested assumption at its core.
 
 ---
 
 ## Stage 6 — Reconcile and commit
 
-The agent presented the full discovery sidecar — intent, assumption-test, validated candidate, decomposition. You reviewed the G2 reconciliation record and confirmed the decision brief was build-ready.
+The agent presents the full discovery sidecar — intent, assumption-test, validated candidate, decomposition. You review the G2 reconciliation record and confirm the decision brief is build-ready.
 
-**You did:** Read the full brief — all sections. At G2 you ratified the reconciliation record; at G3 you committed the brief to the delivery loop. These are two distinct decisions: G2 is "is this brief complete?" and G3 is "am I ready to build this?" A brief can be complete but still wrong.
+**You:** Read the full brief — all sections. At G2 you ratify the reconciliation record; at G3 you commit the brief to the delivery loop. These are two distinct decisions: G2 is "is this brief complete?" and G3 is "am I ready to build this?" A brief can be complete but still wrong.

--- a/web/src/content/journeys/experience.md
+++ b/web/src/content/journeys/experience.md
@@ -85,38 +85,38 @@ relatedJourneys:
 
 ## Stage 1 — Map the customer journey
 
-You described the feature, user, and outcome. The agent ran `map-customer-journey` to produce the customer journey map — the current state (what happens today), the desired state (what should happen after this feature), and the key moments where the current journey breaks down.
+You describe the feature, user, and outcome. The agent runs `map-customer-journey` to produce the customer journey map — the current state (what happens today), the desired state (what should happen after this feature), and the key moments where the current journey breaks down.
 
-**You did:** Read the journey map and approved it at the G-journey gate. This is the most important gate in the experience thread — the screen list flows directly from it. If the map describes what the current product does rather than what the user is trying to achieve, redirect before the screen flow is derived. A one-sentence correction here saves a full design cycle.
+**You:** Read the journey map and approve it at the G-journey gate. This is the most important gate in the experience thread — the screen list flows directly from it. If the map describes what the current product does rather than what the user is trying to achieve, redirect before the screen flow is derived. A one-sentence correction here saves a full design cycle.
 
 ---
 
 ## Stage 2 — Derive the screen flow
 
-With the journey approved, the agent ran `map-screen-flow` to derive the screen inventory: what screens exist, what state each one handles (empty, loading, populated, error), and what the transitions between them are. Each screen got a per-screen brief: the user's goal, the information they need, the states to handle.
+With the journey approved, the agent runs `map-screen-flow` to derive the screen inventory: what screens exist, what state each one handles (empty, loading, populated, error), and what the transitions between them are. Each screen gets a per-screen brief: the user's goal, the information they need, the states to handle.
 
-**You did:** Checked that the screen list felt right — that it didn't add screens not implied by the journey, and didn't miss screens the journey required. If the agent added a screen that looked useful but wasn't derived from the journey, remove it here.
+**You:** Check that the screen list feels right — that it doesn't add screens not implied by the journey, and doesn't miss screens the journey requires. If the agent adds a screen that looks useful but isn't derived from the journey, remove it here.
 
 ---
 
 ## Stage 3 — Establish design intent
 
-Before designing any screen, the agent ran `aesthetic-direction` to establish the visual character of the surface — palette, typography, spacing — as a named aesthetic reference. It then ran `design-system-foundations` to derive the design token set.
+Before designing any screen, the agent runs `aesthetic-direction` to establish the visual character of the surface — palette, typography, spacing — as a named aesthetic reference. It then runs `design-system-foundations` to derive the design token set.
 
-**You did:** Approved the aesthetic direction at the G-aesthetic gate. An aesthetic direction that says "clean and professional" is not an aesthetic direction — it needs to name a specific visual character with enough specificity to say whether a given design decision is consistent or not. If the tokens introduced hardcoded values outside the semantic token system, reject them.
+**You:** Approve the aesthetic direction at the G-aesthetic gate. An aesthetic direction that says "clean and professional" is not an aesthetic direction — it needs to name a specific visual character with enough specificity to say whether a given design decision is consistent or not. If the tokens introduce hardcoded values outside the semantic token system, reject them.
 
 ---
 
 ## Stage 4 — Design each screen
 
-The agent ran `layout-and-information-architecture` and `interaction-design` on each screen in the flow, working from each screen's per-screen brief. It then ran `design-critique` on each screen before the independent review — a self-check against the quality floor.
+The agent runs `layout-and-information-architecture` and `interaction-design` on each screen in the flow, working from each screen's per-screen brief. It then runs `design-critique` on each screen before the independent review — a self-check against the quality floor.
 
-**You did:** Watched each screen take shape. If a screen was missing a state — no empty state for a list that could be empty, no loading state for an async action — name it. The agent will miss states not explicitly mentioned in the brief; that's what the experience-reviewer catches, but catching it here is cheaper.
+**You:** Watch each screen take shape. If a screen is missing a state — no empty state for a list that could be empty, no loading state for an async action — name it. The agent will miss states not explicitly mentioned in the brief; that's what the experience-reviewer catches, but catching it here is cheaper.
 
 ---
 
 ## Stage 5 — Independent review
 
-The agent ran the `experience-reviewer` subagent in a forked context — a reviewer that had not seen the authoring session. The reviewer returned findings on the full screen set: handle-all-states violations, accessibility failures, aesthetic inconsistencies.
+The agent runs the `experience-reviewer` subagent in a forked context — a reviewer that has not seen the authoring session. The reviewer returns findings on the full screen set: handle-all-states violations, accessibility failures, aesthetic inconsistencies.
 
-**You did:** Read the review findings at the G-experience-review gate. Handle-all-states violations are the most common finding — a screen that works for the happy path but has no designed error state. WCAG findings affect all users. Apply Blockers before the design intent feeds the build loop; they represent the floor the spec says all screens must clear.
+**You:** Read the review findings at the G-experience-review gate. Handle-all-states violations are the most common finding — a screen that works for the happy path but has no designed error state. WCAG findings affect all users. Apply Blockers before the design intent feeds the build loop; they represent the floor the spec says all screens must clear.

--- a/web/src/content/journeys/figma.md
+++ b/web/src/content/journeys/figma.md
@@ -49,22 +49,22 @@ relatedJourneys:
 
 ## Stage 1 — Configure the credential
 
-Before the first API call, you confirmed the Figma Personal Access Token was configured in credential-brokers. The agent checked the credential resolved and would reach the target file.
+Before the first API call, you confirm the Figma Personal Access Token is configured in credential-brokers. The agent checks that the credential resolves and reaches the target file.
 
-**You did:** Ran `credential-brokers` setup if this was the first session, or confirmed the existing token was still valid. Named the file key or file URL you wanted the agent to work with. This is a one-time setup per service — once the token is in place, every subsequent figma session resolves it automatically.
+**You:** Run `credential-brokers` setup if this is the first session, or confirm the existing token is still valid. Name the file key or file URL you want the agent to work with. This is a one-time setup per service — once the token is in place, every subsequent figma session resolves it automatically.
 
 ---
 
 ## Stage 2 — Read the design artifact
 
-With the credential confirmed, the agent invoked the `figma` skill. It fetched the file structure, navigated to the target frame or component, and returned the design data — rendered image, node properties, variable values, or connector graph, depending on what you asked for.
+With the credential confirmed, the agent invokes the `figma` skill. It fetches the file structure, navigates to the target frame or component, and returns the design data — rendered image, node properties, variable values, or connector graph, depending on what you asked for.
 
-**You did:** Watched the fetch complete. If the agent returned data from the wrong frame — because a component name matched multiple instances in the file — redirected with the specific node ID or frame path. Figma's file tree uses human-readable names that aren't always unique; the node ID is the authoritative identifier.
+**You:** Watch the fetch complete. If the agent returns data from the wrong frame — because a component name matches multiple instances in the file — redirect with the specific node ID or frame path. Figma's file tree uses human-readable names that aren't always unique; the node ID is the authoritative identifier.
 
 ---
 
 ## Stage 3 — Review and use
 
-The agent presented the extracted artifact — a rendered frame image, a CSS variable set, a Mermaid connector diagram, or a structured property dump. You reviewed it at the G-output gate before passing it to the next step in your workflow.
+The agent presents the extracted artifact — a rendered frame image, a CSS variable set, a Mermaid connector diagram, or a structured property dump. You review it at the G-output gate before passing it to the next step in your workflow.
 
-**You did:** Checked that the extracted artifact matched the design you intended to capture. For FigJam diagrams, verified that all connectors and labels were preserved. For variable values, confirmed they matched the published (not draft) design system state. Passed the reviewed artifact to the next step — typically a design implementation task using the `experience` or `core` pack.
+**You:** Check that the extracted artifact matches the design you intended to capture. For FigJam diagrams, verify that all connectors and labels are preserved. For variable values, confirm they match the published (not draft) design system state. Pass the reviewed artifact to the next step — typically a design implementation task using the `experience` or `core` pack.

--- a/web/src/content/journeys/governance-extras.md
+++ b/web/src/content/journeys/governance-extras.md
@@ -66,22 +66,22 @@ relatedJourneys:
 
 ## Stage 1 — Identify the change and open an RFC
 
-You recognized a cross-cutting change — something that would affect more than one person, more than one package, or an established convention. The agent activated `new-rfc`, drafted the problem statement, and structured the proposer and objector perspectives.
+You recognize a cross-cutting change — something that affects more than one person, more than one package, or an established convention. The agent activates `new-rfc`, drafts the problem statement, and structures the proposer and objector perspectives.
 
-**You did:** Read the RFC draft at the G-draft gate. The most common error at this stage is confusing the solution with the problem — the RFC should name what's broken or missing, not what you want to adopt. If the draft led with the solution, redirected the agent to reframe around the underlying need. Circulated the draft to the relevant stakeholders after the draft gate passed.
+**You:** Read the RFC draft at the G-draft gate. The most common error at this stage is confusing the solution with the problem — the RFC should name what's broken or missing, not what you want to adopt. If the draft leads with the solution, redirect the agent to reframe around the underlying need. Circulate the draft to the relevant stakeholders after the draft gate passes.
 
 ---
 
 ## Stage 2 — Comment period and objection handling
 
-Stakeholders reviewed the RFC and raised objections. The agent helped document each objection and draft responses, keeping the RFC's objector section updated as the conversation evolved.
+Stakeholders review the RFC and raise objections. The agent helps document each objection and draft responses, keeping the RFC's objector section updated as the conversation evolves.
 
-**You did:** Managed the comment period — keeping it time-boxed, ensuring genuine objections got genuine responses, and preventing the RFC from accumulating comments without resolution. An RFC that's "still being discussed" with no decision date is a governance failure, not a process success.
+**You:** Manage the comment period — keep it time-boxed, ensure genuine objections get genuine responses, and prevent the RFC from accumulating comments without resolution. An RFC that's "still being discussed" with no decision date is a governance failure, not a process success.
 
 ---
 
 ## Stage 3 — Decision and follow-on ADR
 
-Once the comment period closed, you made the decision — Accept, Reject, or Defer — and the agent updated the RFC status. If accepted, the agent ran `new-adr` to record the architectural decision that resulted from the RFC.
+Once the comment period closes, you make the decision — Accept, Reject, or Defer — and the agent updates the RFC status. If accepted, the agent runs `new-adr` to record the architectural decision that resulted from the RFC.
 
-**You did:** Made the call at the G-accept gate. Verified the ADR at the G-merge gate: checked that it captured the actual decision and the honest forces behind it, not a post-hoc rationalization. Merged the ADR as part of the same PR or a directly following one — decisions and their documentation belong together.
+**You:** Make the call at the G-accept gate. Verify the ADR at the G-merge gate: check that it captures the actual decision and the honest forces behind it, not a post-hoc rationalization. Merge the ADR as part of the same PR or a directly following one — decisions and their documentation belong together.

--- a/web/src/content/journeys/monorepo-extras.md
+++ b/web/src/content/journeys/monorepo-extras.md
@@ -35,22 +35,22 @@ relatedJourneys:
 
 ## Stage 1 — Name the package and describe its role
 
-You decided to add a new package to the monorepo and described its purpose. The agent activated `new-package`, asked for the package name and a brief description, and checked whether any existing packages in the repo served as the closest structural analogue.
+You decide to add a new package to the monorepo and describe its purpose. The agent activates `new-package`, asks for the package name and a brief description, and checks whether any existing packages in the repo serve as the closest structural analogue.
 
-**You did:** Named the package precisely — using the project's naming convention (kebab-case, domain-qualified, etc.). Described the package's role in one sentence: what it does and who uses it. If the agent suggested looking at an existing package as a template, confirmed whether that package was actually the right model or just the closest match.
+**You:** Name the package precisely — using the project's naming convention (kebab-case, domain-qualified, etc.). Describe the package's role in one sentence: what it does and who uses it. If the agent suggests looking at an existing package as a template, confirm whether that package is actually the right model or just the closest match.
 
 ---
 
 ## Stage 2 — Scaffold and wire
 
-The agent produced the package skeleton: directory structure, `package.json` (or equivalent), `AGENTS.md`, build configuration, and test directory. It populated the AGENTS.md with the package name, a description, and the correct build and test commands.
+The agent produces the package skeleton: directory structure, `package.json` (or equivalent), `AGENTS.md`, build configuration, and test directory. It populates the AGENTS.md with the package name, a description, and the correct build and test commands.
 
-**You did:** Reviewed the scaffolded package at the G-review gate. The two things most likely to be wrong: the AGENTS.md still has placeholder text, and the test command points to the wrong root. Both are easy to catch and easy to fix at this gate; neither is easy to fix after other packages have extended the scaffolded pattern.
+**You:** Review the scaffolded package at the G-review gate. The two things most likely to be wrong: the AGENTS.md still has placeholder text, and the test command points to the wrong root. Both are easy to catch and easy to fix at this gate; neither is easy to fix after other packages have extended the scaffolded pattern.
 
 ---
 
 ## Stage 3 — First commit and CI verification
 
-After the review gate passed, the agent committed the scaffold, pushed the branch, and verified that CI ran the new package's tests correctly.
+After the review gate passes, the agent commits the scaffold, pushes the branch, and verifies that CI runs the new package's tests correctly.
 
-**You did:** Watched the CI run complete. If the new package's tests didn't appear in the CI output, the test wiring was incomplete — the CI configuration didn't know about the new package. Added the explicit CI step if needed. The most common cause: the CI config uses a hard-coded list of packages rather than a glob.
+**You:** Watch the CI run complete. If the new package's tests don't appear in the CI output, the test wiring is incomplete — the CI configuration doesn't know about the new package. Add the explicit CI step if needed. The most common cause: the CI config uses a hard-coded list of packages rather than a glob.

--- a/web/src/content/journeys/release.md
+++ b/web/src/content/journeys/release.md
@@ -35,22 +35,22 @@ relatedJourneys:
 
 ## Stage 1 — Trigger release loop
 
-A completed inner build loop (work-loop + adversarial review clean) triggered the release loop. The `release-lead` agent activated `release-loop` and deployed the integrated whole to an ephemeral environment.
+A completed inner build loop (work-loop + adversarial review clean) triggers the release loop. The `release-lead` agent activates `release-loop` and deploys the integrated whole to an ephemeral environment.
 
-**You did:** Watched the initial deploy log in the chat to confirm the right environment was targeted. You do not intervene in the deploy itself, but reading the first deploy confirms the agent is operating on the right branch and config. If the deploy target looks wrong, stop it early — it's cheaper than a mid-cycle redirect.
+**You:** Watch the initial deploy log in the chat to confirm the right environment is targeted. You do not intervene in the deploy itself, but reading the first deploy confirms the agent is operating on the right branch and config. If the deploy target looks wrong, stop it early — it's cheaper than a mid-cycle redirect.
 
 ---
 
 ## Stage 2 — E2E validation and convergence
 
-The agent ran end-to-end tests against the deployed environment, observed telemetry, and fed deployed findings back to the inner loop — no human relay. It redeployed after each inner-loop fix. It iterated until the deployed whole converged: e2e clean, telemetry stable.
+The agent runs end-to-end tests against the deployed environment, observes telemetry, and feeds deployed findings back to the inner loop — no human relay. It redeploys after each inner-loop fix. It iterates until the deployed whole converges: e2e clean, telemetry stable.
 
-**You did:** Checked in at the end of each outer loop iteration — after each redeploy, skim the e2e results and the telemetry snapshot. You're looking for anomalies the agent might not flag: a test that passes but whose assertion is too weak to catch a real failure, or a telemetry spike the agent marked as noise. The agent handles the mechanical convergence; you provide the judgment on what "stable" means for your service.
+**You:** Check in at the end of each outer loop iteration — after each redeploy, skim the e2e results and the telemetry snapshot. Look for anomalies the agent might not flag: a test that passes but whose assertion is too weak to catch a real failure, or a telemetry spike the agent marked as noise. The agent handles the mechanical convergence; you provide the judgment on what "stable" means for your service.
 
 ---
 
 ## Stage 3 — Release readiness record
 
-After the deployed whole converged, the agent generated a release readiness record: e2e results, telemetry snapshot, security review on the deployed diff, what was deferred, and any borderline gates.
+After the deployed whole converges, the agent generates a release readiness record: e2e results, telemetry snapshot, security review on the deployed diff, what was deferred, and any borderline gates.
 
-**You did:** At G5, read the full release readiness record — not just the summary. The borderline gates section is the one that matters most: these are cases where the agent decided "close enough" and you may decide differently. Ratified if satisfied. Rejected with a one-line reason if not — the agent will re-enter the loop. This gate is the only one between the ephemeral environment and production.
+**You:** At G5, read the full release readiness record — not just the summary. The borderline gates section is the one that matters most: these are cases where the agent decided "close enough" and you may decide differently. Ratify if satisfied. Reject with a one-line reason if not — the agent re-enters the loop. This gate is the only one between the ephemeral environment and production.

--- a/web/src/content/journeys/research.md
+++ b/web/src/content/journeys/research.md
@@ -78,22 +78,22 @@ relatedJourneys:
 
 ## Stage 1 — Scope the question
 
-You gave the agent a question and selected a depth mode. For a single-session query, the agent activated `/research` and ran a scoping pass — identifying what kind of question this was (factual, comparative, historical, open-ended) and which sources it should consult. For a project-mode investigation, it ran `research-project-start` to create a corpus folder and an initial source list.
+You give the agent a question and select a depth mode. For a single-session query, the agent activates `/research` and runs a scoping pass — identifying what kind of question this is (factual, comparative, historical, open-ended) and which sources to consult. For a project-mode investigation, it runs `research-project-start` to create a corpus folder and an initial source list.
 
-**You did:** Read the scope statement the agent produced before it began fetching. A bad scope leads to a confident answer to the wrong question — the cheapest fix is here, not after the synthesis returns. If the agent's framing missed the real question, redirect with one sentence before the retrieval subagents run.
+**You:** Read the scope statement the agent produces before it begins fetching. A bad scope leads to a confident answer to the wrong question — the cheapest fix is here, not after the synthesis returns. If the agent's framing misses the real question, redirect with one sentence before the retrieval subagents run.
 
 ---
 
 ## Stage 2 — Source curation
 
-The agent ran `source-map` or its equivalent, identifying the canonical sources for the question domain. Two retrieval subagents — `evidence-retriever` and `source-extractor` — fetched and synthesized source material without polluting the main session context.
+The agent runs `source-map` or its equivalent, identifying the canonical sources for the question domain. Two retrieval subagents — `evidence-retriever` and `source-extractor` — fetch and synthesize source material without polluting the main session context.
 
-**You did:** Watched the source list take shape. If a key source was missing — a specific industry report, a primary author's original paper, an internal standard you know exists — name it explicitly. The agent doesn't know what you know about your domain. A one-sentence nudge here is faster than a post-synthesis correction.
+**You:** Watch the source list take shape. If a key source is missing — a specific industry report, a primary author's original paper, an internal standard you know exists — name it explicitly. The agent doesn't know what you know about your domain. A one-sentence nudge here is faster than a post-synthesis correction.
 
 ---
 
 ## Stage 3 — Synthesis and grading
 
-After sources were captured, the agent synthesized a brief graded by confidence (GRADE A–D). Each claim cited its source. Unsupported claims were marked explicitly as gaps, not silently omitted.
+After sources are captured, the agent synthesizes a brief graded by confidence (GRADE A–D). Each claim cites its source. Unsupported claims are marked explicitly as gaps, not silently omitted.
 
-**You did:** Reviewed the synthesis at the G-synthesis gate. The confidence grades are the first thing to read — a GRADE-C synthesis needs a different follow-on action (narrow the question, run another retrieval pass, seek a domain expert) than a GRADE-A synthesis (act on it). If a claim lacked a source citation, check whether it's an inference the agent labeled correctly or an assertion it presented as fact.
+**You:** Review the synthesis at the G-synthesis gate. The confidence grades are the first thing to read — a GRADE-C synthesis needs a different follow-on action (narrow the question, run another retrieval pass, seek a domain expert) than a GRADE-A synthesis (act on it). If a claim lacks a source citation, check whether it's an inference the agent labeled correctly or an assertion it presented as fact.

--- a/web/src/content/journeys/user-guide-diataxis.md
+++ b/web/src/content/journeys/user-guide-diataxis.md
@@ -48,22 +48,22 @@ relatedJourneys:
 
 ## Stage 1 — Identify the documentation need and classify it
 
-You identified a gap in the project's documentation — something users needed to know that wasn't written down, or was written in the wrong form. The agent activated `new-guide`, asked what the guide needed to cover, and helped classify it into the correct Diátaxis category.
+You identify a gap in the project's documentation — something users need to know that isn't written down, or is written in the wrong form. The agent activates `new-guide`, asks what the guide needs to cover, and helps classify it into the correct Diátaxis category.
 
-**You did:** Made the classification decision at the G-classify gate. This is the most consequential decision in the documentation session — the wrong category means the wrong structure, the wrong voice, and the wrong reader. If you were unsure between how-to and tutorial, asked: is this reader learning, or is this reader doing? Learning → tutorial. Doing → how-to.
+**You:** Make the classification decision at the G-classify gate. This is the most consequential decision in the documentation session — the wrong category means the wrong structure, the wrong voice, and the wrong reader. If you're unsure between how-to and tutorial, ask: is this reader learning, or is this reader doing? Learning → tutorial. Doing → how-to.
 
 ---
 
 ## Stage 2 — Draft the guide
 
-With the category confirmed, the agent scaffolded the guide in the correct `guides/` subdirectory and drafted the content — entry conditions, steps or information organized by category structure, and exit conditions.
+With the category confirmed, the agent scaffolds the guide in the correct `guides/` subdirectory and drafts the content — entry conditions, steps or information organized by category structure, and exit conditions.
 
-**You did:** Watched the draft take shape. For how-tos: checked that every step was an action, not a paragraph of explanation. Explanation belongs in a linked explanation document. For tutorials: confirmed the reader could follow the steps sequentially and arrive at a working outcome, not just a theoretical understanding.
+**You:** Watch the draft take shape. For how-tos: check that every step is an action, not a paragraph of explanation. Explanation belongs in a linked explanation document. For tutorials: confirm the reader can follow the steps sequentially and arrive at a working outcome, not just a theoretical understanding.
 
 ---
 
 ## Stage 3 — Review and merge
 
-After the draft completed, you reviewed at the G-review gate for structure consistency and category fidelity, then the agent opened a PR.
+After the draft completes, you review at the G-review gate for structure consistency and category fidelity, then the agent opens a PR.
 
-**You did:** Read the guide as a first-time reader — not as the author who knows what it means. If you had to re-read a sentence twice to understand what action it was asking for, it needed rewriting. If a paragraph of background explanation appeared in the middle of a how-to, flagged it for extraction into a linked explanation document. Merged after the review gate passed.
+**You:** Read the guide as a first-time reader — not as the author who knows what it means. If you have to re-read a sentence twice to understand what action it's asking for, it needs rewriting. If a paragraph of background explanation appears in the middle of a how-to, flag it for extraction into a linked explanation document. Merge after the review gate passes.


### PR DESCRIPTION
## Summary

- Rewrites all 13 remaining journey markdown files to match the present-tense, active-voice pattern established by `core.md` in #524
- Replaces `**You did:**` with `**You:**` throughout all stage descriptions
- Converts past-tense stage narratives ("the agent ran", "you described") to present tense ("the agent runs", "you describe")
- Fixes a frontmatter skills mismatch in `discovery.md`: the `product-engineering` pack ships 9 skills; the journey was listing 8 — `frame-domain` was missing

## Files changed

All 13 files in `web/src/content/journeys/` except `core.md` (already done in #524):
architect, atlassian, contracts, converters, credential-brokers, discovery, experience, figma, governance-extras, monorepo-extras, release, research, user-guide-diataxis.

## Test plan

- [x] `npm run build` in `web/` passes — all 34 pages generated including all 14 journey pages
- [x] No `**You did:**` pattern remains in any journey file (`grep -r "You did:" web/src/content/journeys/` — empty)
- [x] No past-tense narrative verbs remain (`the agent ran`, `the agent checked`, etc.)
- [x] `discovery.md` skill count matches `packs/product-engineering/.apm/skills/` (9 skills each)