### PR TITLE
docs(specs): RFC-0062 content-design and copy-direction skill specs + plans

### DIFF
--- a/docs/specs/content-design-skill/plan.md
+++ b/docs/specs/content-design-skill/plan.md
@@ -1,0 +1,263 @@
+# Plan: content-design-skill
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Drafting <!-- Drafting | Executing | Done -->
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn. When it changes substantially
+> (a different approach, not just a re-ordering), note why in the changelog
+> at the bottom.
+
+## Approach
+
+Pure-markdown skill authoring. No runtime code, no new dependencies, no
+application logic. The change lives entirely under
+`packs/experience/.apm/skills/content-design/` plus a one-line `pack.toml`
+update.
+
+The riskiest part is SKILL.md authoring: a skill that looks compliant but
+(a) reprints framework text verbatim (ADR-0024 Guardrail A violation caught by
+`lint-experience-agnostic.py`) or (b) under-specifies the procedure to the point
+that cold-prompting produces structurally incomplete content briefs. The
+mitigation is writing the procedure against the RFC-0062 proposal's specificity
+level and verifying with a manual cold-prompt in both surface-type modes before
+declaring done.
+
+Order of operations: scaffold the directory first (T1), then author the SKILL.md
+body in full (T2) — this locks the procedure and anti-patterns that drive
+everything else. References files expand what the procedure names (T3); the asset
+template makes the content brief artifact concrete (T4); evals and pack.toml
+update (T5) close the mechanical gates.
+
+**Declined patterns:**
+- Tempted to write a combined spec covering both `content-design` and
+  `copy-direction` — declining because RFC-0062 explicitly specifies two separate
+  spec directories, allowing each skill to be tracked, reviewed, and shipped
+  independently.
+- Tempted to extend the acquisition sub-path to cover email and mobile onboarding
+  — declining per RFC-0062: the sub-path is web-optimized by design; a
+  cross-platform extension is deferred to a follow-on amendment.
+- Tempted to add a `content-review` step that calls `experience-reviewer` inline
+  — declining per RFC-0062 OQ1 resolution: experience-reviewer scope extension is
+  a follow-on RFC, not this spec.
+- Tempted to author a new ADR for the content-design skill addition — RFC-0062's
+  follow-on artifacts list one, but the add-a-skill bar is already governed by
+  ADR-0024 + RFC-0050 D6; a new ADR would duplicate without adding a decision. The
+  RFC's ADR mention will be resolved by the implementing PR note (drop the item as
+  subsumed) rather than authoring an empty record.
+
+**Co-shipping constraint:** This plan ships in the same PR as `copy-direction-skill`.
+Landing content-design alone adds a public skill with no semver bump and no backlog
+record. The version bump (0.4.2 → 0.5.0), `plugin.json` update, `build-self` run,
+and all three backlog entries — `copy-direction-skill-rfc`,
+`content-strategy-and-marketing-copy-lens`, and
+`experience-reviewer-content-brief-scope` (the OQ1 deferral anchor required by
+content-design AC "Experience-reviewer scope extension") — are all created in
+copy-direction T7, which carries a cross-spec dependency on this plan's T5.
+
+## Constraints
+
+- **RFC-0062** D1–D5 — binding decisions: `content-design` name (D1), surface-type
+  routing with `surface-type` flag (D2), conversion architecture inside the
+  acquisition sub-path (D3), no SEO in either skill (D5).
+- **ADR-0024** — Guardrails A (point to standards, never reprint values) and B
+  (concepts, not platform primitives). Enforced by `tools/lint-experience-agnostic.py`.
+- **RFC-0050** — experience pack design-thread completeness bar; `content-brief`
+  artifact extends the pack's discover-by-marker set per D6's layout contract.
+- **ADR-0028 / RFC-0037** — pack-activation-eval coverage shape (`eval_queries.json`
+  + `evals.json`).
+
+## Construction tests
+
+**Integration tests:**
+- `tools/lint-experience-agnostic.py` exits 0 on `packs/experience/` after every
+  new file lands — the standing guard that no SKILL.md edit leaked a values table or
+  stack token.
+
+**Manual verification:**
+- Cold-prompt `content-design` (acquisition surface mode) with: persona = "technical
+  team leads at growth-stage SaaS companies, most-aware audience." Confirm the output
+  content brief includes surface type declaration, audience awareness level (Most
+  Aware, Schwartz stage 5), narrative arc (CCD — bottom-of-funnel applicability),
+  scroll sections with per-section jobs, above-fold structure (headline + subheadline
+  contract), primary CTA, success metric, and artifact path.
+- Cold-prompt `content-design` (product/reference surface mode) with: persona =
+  "developers integrating the API for the first time." Confirm user task elicitation,
+  format selection (steps — procedural task type), content hierarchy
+  (must-say → probably-say → might-say), and completion metric (task completion rate).
+
+## Tasks
+
+### T1: Content-design skill directory scaffolded
+
+**Depends on:** none
+
+**Tests:**
+- `find packs/experience/.apm/skills/content-design/ -type f | sort` returns at
+  minimum: `SKILL.md`, `references/.gitkeep` (or first reference file),
+  `assets/.gitkeep` (or template), `evals/.gitkeep` (or eval files)
+- `python3 tools/lint-experience-agnostic.py` exits 0 (empty stub has no violations)
+
+**Approach:**
+- Create `packs/experience/.apm/skills/content-design/` with subdirectories
+  `references/`, `assets/`, `evals/`
+- Create `SKILL.md` stub with frontmatter `name: content-design` and
+  `description:` placeholder; add section heading stubs (When to invoke, Procedure,
+  Anti-patterns) with no body content yet
+
+**Done when:** Directory tree exists; lint exits 0 on empty stub.
+
+---
+
+### T2: SKILL.md fully authored
+
+**Depends on:** T1
+
+**Tests:**
+- `python3 tools/lint-experience-agnostic.py` exits 0
+- `awk '/^## Procedure/,/^## [^#]/' packs/experience/.apm/skills/content-design/SKILL.md | grep -c "^[0-9]\+\."` returns ≥5 (numbered procedure steps scoped to the Procedure section only)
+- `grep "Anti-patterns" packs/experience/.apm/skills/content-design/SKILL.md` matches
+- Manual cold-prompt: acquisition mode produces content brief with all six acquisition
+  components (awareness level, arc, scroll sections, above-fold, CTAs, success metric)
+- Manual cold-prompt: product/reference mode produces content brief with all four
+  components (user task, format, hierarchy, completion metric)
+
+**Approach:**
+- Write frontmatter `description:` matching RFC-0062 D1 naming rationale ("Use when a
+  designer or product person needs to decide what a surface should say, for whom, in
+  what form, and to what objective — before any wireframe or screen flow is opened…")
+- Write **When to invoke** with four pre-conditions: (1) real surface with a defined
+  purpose, (2) no content brief already exists for this surface, (3) you are deciding
+  direction not writing final copy, (4) you know or can elicit the target audience
+- Write **Procedure** (5 steps):
+  1. Confirm `surface-type` (acquisition | product-or-reference); `docs` surfaces
+     route as product-or-reference
+  2. Elicit or confirm persona and outcome; consume `map-customer-journey` output if
+     available; elicit inline if not
+  3. Route to sub-path; run elicitation questions for that type (load references)
+  4. Resolve and write the content brief to `docs/design/content/<slug>.md`
+  5. Hand off: name `copy-direction` (for copy voice), `map-screen-flow` (for screen
+     sequencing) as downstream consumers; note OQ1 deferral for experience-reviewer
+- Write **Anti-patterns**: refuse reprinting frameworks verbatim, producing copy
+  templates, producing analytics, running user research, producing SEO plans,
+  substituting a single "global" brief for per-surface briefs
+
+**Done when:** Cold-prompt in both surface-type modes produces structurally complete
+briefs (per manual verification above); lint clean.
+
+---
+
+### T3: References directory authored
+
+**Depends on:** T2 (SKILL.md procedure defines which references are named)
+
+**Tests:**
+- `ls packs/experience/.apm/skills/content-design/references/` shows ≥4 files
+- Each file cited in SKILL.md procedure (`references/*.md`) exists (no dangling
+  references)
+- `python3 tools/lint-experience-agnostic.py` exits 0 after each file is added
+
+**Approach:**
+- `references/surface-routing.md` — the two sub-paths with their elicitation
+  question sequences; acquisition elicitation covers: business objective, target
+  audience, audience awareness level (Schwartz 1–5), primary action; product/reference
+  elicitation covers: user task, completion definition, content format, known gaps in
+  existing help material
+- `references/narrative-arc.md` — names StoryBrand (seven-element arc: Character +
+  Problem + Guide + Plan + CTA + Stakes + Success) and CCD (seven principles:
+  Attention, Context, Clarity, Congruence, Credibility, Closing, Continuance) by
+  name with applicability conditions: StoryBrand for cold/warm audiences (awareness
+  levels 1–3); CCD for bottom-of-funnel audiences (levels 4–5). Names each principle
+  without reprinting the framework text verbatim
+- `references/content-hierarchy.md` — the must-say → probably-say → might-say
+  prioritisation method per Nava PBC text-prototype model; definition of each tier
+  (must-say = no-page-without-it; probably-say = helps most readers; might-say =
+  edge-case detail); application to scroll section sequencing for acquisition surfaces
+- `references/agentbundle-layout.md` — the RFC-0050 D6 three-tier path resolution for
+  `content-brief` artifacts: config key `[experience] content_brief_dir`, default
+  `docs/design/content/`, discover-by-marker `type: content-brief`; `content-brief`
+  named as an extension to the pack's existing marker set
+
+**Done when:** All referenced files exist; lint clean across all new files.
+
+---
+
+### T4: Content-brief asset template authored
+
+**Depends on:** T3
+
+**Tests:**
+- `ls packs/experience/.apm/skills/content-design/assets/` shows
+  `content-brief-template.md`
+- `grep "type: content-brief" packs/experience/.apm/skills/content-design/assets/content-brief-template.md`
+  returns a match
+- `python3 tools/lint-experience-agnostic.py` exits 0
+
+**Approach:**
+- Mirror the shape of `packs/experience/.apm/skills/aesthetic-direction/assets/aesthetic-direction-template.md`
+- Frontmatter: `type: content-brief`, `surface-type:`, `persona:`, `date:`
+- Sections (acquisition variant): Surface Objective, Audience Awareness Level,
+  Narrative Arc Selection, Scroll Sections (table: section | job | copy notes),
+  Above-Fold Structure (headline contract, subheadline contract), CTAs
+  (primary | label | action), Success Metric, Open Questions
+- Sections (product/reference variant): Surface Objective, User Task, Content Format,
+  Content Hierarchy (must-say / probably-say / might-say), Completion Metric,
+  Open Questions
+- Template uses placeholder text in square brackets `[…]` — no pre-written values
+  or copy strings
+
+**Done when:** Template exists with correct frontmatter and both variant section
+sets; lint clean.
+
+---
+
+### T5: Evals authored; content-design added to pack.toml
+
+**Depends on:** T2
+
+**Tests:**
+- `cat packs/experience/pack.toml | grep "content-design"` returns a match in
+  `[pack.evals] skills`
+- `ls packs/experience/.apm/skills/content-design/evals/` shows `eval_queries.json`
+  and `evals.json`
+- `python3 tools/lint-experience-agnostic.py` exits 0 on full `packs/experience/` tree
+
+**Approach:**
+- `eval_queries.json`: activation trigger phrases for pack-activation-evals
+  (e.g. "what should this landing page say", "write a content brief for our onboarding
+  flow", "what's the narrative arc for this marketing page", "what does this feature
+  page need to communicate", "help me decide the above-fold structure")
+- `evals.json`: Tier-4 LLM-judge rubric per ADR-0028 / RFC-0037; rubric checks:
+  surface type declared, awareness level named (acquisition), narrative arc selected
+  with applicability rationale, artifact path named, no copy strings produced (only
+  direction)
+- Add `"content-design"` to the `[pack.evals] skills` list in
+  `packs/experience/pack.toml` (append — order is not semantically load-bearing for
+  the evals list, but keep alphabetically adjacent to existing entries)
+
+**Done when:** Lint clean; grep confirms pack.toml updated; both eval files present.
+
+## Rollout
+
+Pure-markdown skill addition — no infrastructure, no data migration, no
+deployment sequencing. Ships as a normal PR to main; no flag or canary required.
+The one reversibility concern: if `content-design`'s procedure violates ADR-0024
+post-merge, the agnosticism lint catches it in CI and the fix is a follow-up PR
+removing the violation — fully reversible.
+
+## Risks
+
+- **Procedure under-specifies the acquisition sub-path** — producing content briefs
+  that are structurally complete but too vague to drive `map-screen-flow`. Mitigation:
+  manual QA cold-prompt gate before T2 is declared done.
+- **D3 boundary drift** — the acquisition sub-path creeps toward conversion analytics
+  ("track CTA click-through"). Mitigation: anti-patterns explicitly refuse analytics
+  outputs; the lint checks for values-table shape (a CRO measurement framework would
+  likely produce one).
+- **Eval phrases too narrow** — the activation evals only trigger on exact phrases,
+  missing paraphrase variants. Mitigation: eval_queries.json covers 5+ distinct
+  trigger phrasings.
+
+## Changelog
+
+- 2026-07-18: initial plan

--- a/docs/specs/content-design-skill/spec.md
+++ b/docs/specs/content-design-skill/spec.md
@@ -1,0 +1,149 @@
+# Spec: content-design-skill
+
+- **Status:** Approved <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** RFC-0062 (D1–D5), ADR-0024 (guardrails A+B, framework-agnosticism), RFC-0050 (experience pack design-thread completeness bar)
+- **Brief:** none
+- **Contract:** none — pure-markdown skill + asset template; no API/event/RPC interface. The content brief is a markdown artifact template (skill `assets/`), not a versioned interface contract.
+- **Shape:** integration — a new skill directory under `packs/experience/.apm/skills/`; method-authoring, not application code.
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+A `content-design` skill is added to the `experience` pack. Designers, product
+people, and solo builders use it to produce a per-surface content brief — a
+text-first document answering "what does this surface need to say, for whom, in
+what form, to achieve what objective" — before any wireframe or screen flow is
+started. The skill fills the first missing link in the experience pack's design
+thread: it runs after `map-customer-journey` (or elicits inline when no journey
+exists) and before `map-screen-flow`. It routes across two surface types:
+**acquisition surfaces** (marketing pages, landing pages, web onboarding flows)
+and **product/reference surfaces** (help pages, feature reference, in-product
+wayfinding). Success means a designer can invoke `content-design` cold, answer a
+structured elicitation sequence, and receive a content brief that the
+`map-screen-flow` copy slot can reference directly, with no ad-hoc page strategy
+required.
+
+## Boundaries
+
+### Always do
+
+- Author `SKILL.md` + `references/` + `assets/` + `evals/` under
+  `packs/experience/.apm/skills/content-design/`
+- Keep every file pure-markdown per ADR-0024: point to named standards (Schwartz
+  five-stage awareness ladder, StoryBrand seven-element arc, Conversion-Centered
+  Design seven principles, Nava PBC text-prototype model) — never reprint their
+  framework text verbatim
+- Resolve the artifact path via RFC-0050 D6's config→default→discover-by-marker
+  contract: default `docs/design/content/<slug>.md` with `type: content-brief` in
+  frontmatter; document this in SKILL.md and a `references/agentbundle-layout.md`
+- Add `content-design` to `[pack.evals] skills` in `packs/experience/pack.toml`
+  and ship `evals/eval_queries.json` + `evals/evals.json` under the skill directory
+- Run `tools/lint-experience-agnostic.py` after every SKILL.md edit; keep it clean
+
+### Ask first
+
+- Any edit to frozen governance (RFC-0033, ADR-0024, the Shipped `design-craft-pack`
+  spec, or README index rows that name `design-craft` as historical record)
+- Widening the acquisition sub-path beyond structural direction (what to say in what
+  order) into analytics, CRO tooling, or SEO keyword targeting
+- Extending surface-type routing beyond the two chartered types (acquisition,
+  product/reference) — e.g. email, native mobile onboarding, or print — which are
+  deferred per RFC-0062
+
+### Never do
+
+- Reprint the Schwartz ladder, StoryBrand arc, or CCD principles verbatim — name
+  and reference them; never quote them wholesale
+- Produce a copy template, values table, or pre-written copy strings
+- Produce an analytics framework, CRO measurement guide, or SEO keyword plan
+- Add hooks, engines, validators, or in-pack linters — the agnosticism lint in
+  `tools/` is the enforcement surface (ADR-0024)
+
+## Testing Strategy
+
+All verification is goal-based or manual QA — there is no testable runtime logic.
+
+- **Goal-based:** `tools/lint-experience-agnostic.py` exits 0 on `packs/experience/`
+  after the skill lands (stack-token / values-table cleanliness).
+- **Goal-based:** `grep` confirms required frontmatter fields (`name:`,
+  `description:`) and numbered procedure steps (≥5) present in SKILL.md.
+- **Goal-based:** `cat packs/experience/pack.toml` confirms `content-design` is
+  present in the `[pack.evals] skills` list.
+- **Goal-based:** `find packs/experience/.apm/skills/content-design/evals/ -name "*.json"`
+  returns both eval files.
+- **Manual QA:** Cold-prompt `content-design` with a sample persona and acquisition
+  surface. Confirm the output content brief includes: surface type declaration,
+  audience awareness level, narrative arc selection (with named framework and
+  applicability rationale — verifying RFC-0062 D1 "GOV.UK / Nava PBC canonical
+  discipline name" maps to the description's stated purpose), scroll section
+  assignments with per-section job, above-fold structure (headline + subheadline),
+  primary CTA and transitional CTA, success metric, and the
+  `docs/design/content/<slug>.md` artifact path. Repeat for a product/reference
+  surface: confirm user task, format selection (prose/steps/table/diagram), content
+  hierarchy (must-say → probably-say → might-say), and completion metric appear.
+
+## Acceptance Criteria
+
+- [ ] `packs/experience/.apm/skills/content-design/SKILL.md` exists; frontmatter
+  includes `name: content-design` and a non-empty `description:` field; Procedure
+  section has ≥5 numbered steps (verified by counting only within `## Procedure`,
+  not the full file); Anti-patterns section present.
+- [ ] Acquisition sub-path procedure names: the Schwartz five-stage awareness ladder
+  as the audience-level elicitation reference; StoryBrand and CCD as the two
+  narrative-arc choices with their applicability conditions (audience awareness level
+  drives the selection); scroll section assignment (each section gets one job:
+  problem, guide proof, plan, stakes, CTA); above-fold structure contract (headline +
+  subheadline answering what/who/why); primary and transitional CTA definition;
+  success metric naming.
+- [ ] Product/reference sub-path procedure names: user task elicitation; content
+  format selection (prose / steps / table / diagram, matched to task type); content
+  hierarchy prioritisation using the Nava PBC must-say → probably-say → might-say
+  model; completion metric (task completion rate or search resolution).
+- [ ] Artifact path `docs/design/content/<slug>.md` with `type: content-brief` is
+  documented in SKILL.md and resolves via the three-tier layout contract (config →
+  default → discover-by-marker) per RFC-0050 D6; `content-brief` is named as an
+  extension to the pack's existing marker set.
+- [ ] `tools/lint-experience-agnostic.py` exits 0 on `packs/experience/` after the
+  skill lands; no stack token or values-table shape violation introduced.
+- [ ] `content-design` is listed in `[pack.evals] skills` in
+  `packs/experience/pack.toml`; `evals/eval_queries.json` and `evals/evals.json`
+  exist under `packs/experience/.apm/skills/content-design/evals/`.
+- [ ] The skill is standalone-useful: it elicits persona and outcome inline when no
+  `map-customer-journey` output is provided; no upstream artifact is required to
+  invoke it.
+- [ ] The skill's hand-off step names `copy-direction` (for copy voice grounding) and
+  `map-screen-flow` (for screen sequencing) as the downstream consumers of the
+  content brief.
+- [ ] SEO keyword targeting, CRO tooling, and user research production are explicitly
+  listed as out of scope in the SKILL.md Anti-patterns or a clearly marked scope note.
+- [ ] Experience-reviewer scope extension (OQ1) is deferred to a follow-on RFC;
+  the SKILL.md hand-off step notes this explicitly; a `docs/backlog.md` entry
+  under `### experience-reviewer-content-brief-scope` tracks the deferral with a
+  reference to RFC-0062 OQ1 as the open question.
+- [ ] This spec ships in the same PR as `copy-direction-skill` (the two skills
+  share a single pack version bump at 0.4.2 → 0.5.0 and a single `build-self` run;
+  landing content-design alone would add a public skill with no semver record).
+
+## Assumptions
+
+- **Technical:** `tools/lint-experience-agnostic.py` already enforces ADR-0024
+  guardrails on all Markdown under `packs/experience/` and will catch any
+  values-table or stack-token leak without additional tooling.
+  (source: tool inspection 2026-07-18)
+- **Technical:** Pack evals follow the shape established by `aesthetic-direction`:
+  `evals/eval_queries.json` (activation trigger phrases) + `evals/evals.json`
+  (Tier-4 LLM-judge rubric per ADR-0028/RFC-0037).
+  (source: file inspection 2026-07-18)
+- **Product:** RFC-0062 D1–D5 are accepted as binding decisions governing this spec's
+  scope, naming, surface-type routing, and the conversion-architecture inclusion
+  argument (D3: CTA placement and scroll sections are structural direction, not
+  analytics). The RFC has not been formally closed but the spec authoring proceeds on
+  the Draft decisions pending adversarial review.
+  (source: RFC-0062 Draft + user engagement 2026-07-18)
+- **Product:** OQ1 (experience-reviewer scope extension) is resolved as deferred —
+  extend experience-reviewer in a follow-on RFC rather than blocking this spec.
+  (source: RFC-0062 OQ1 recommendation)

--- a/docs/specs/copy-direction-skill/plan.md
+++ b/docs/specs/copy-direction-skill/plan.md
@@ -1,0 +1,336 @@
+# Plan: copy-direction-skill
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Drafting <!-- Drafting | Executing | Done -->
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn. When it changes substantially
+> (a different approach, not just a re-ordering), note why in the changelog
+> at the bottom.
+
+## Approach
+
+Pure-markdown skill authoring, mirroring `aesthetic-direction`'s structure closely
+to minimize novelty and make the discipline boundary legible by structural analogy.
+The change lives under `packs/experience/.apm/skills/copy-direction/`, a one-line
+edit to `packs/product-engineering/.apm/skills/voice-and-microcopy/SKILL.md`, a
+`pack.toml` version bump, and two backlog entry updates.
+
+**Cross-spec sequencing:** This plan depends on `content-design-skill` being
+implemented (spec:content-design-skill). `copy-direction`'s hand-off step
+references the `content-design` artifact; the pack.toml version bump (T7) must
+come after both `content-design` and `copy-direction` are in the evals list. If
+implementing both specs in a single PR, run `content-design-skill`'s tasks first.
+
+The riskiest part is the SKILL.md 8-step procedure (T2): the procedure must mirror
+`aesthetic-direction`'s rhythm closely enough that a user familiar with the visual
+skill can orient immediately, while substituting the copy-specific interrogation
+sequence. The `voice-and-microcopy` cross-reference (T6) carries the risk of
+accidentally narrowing voice-and-microcopy's scope note — the note must be additive,
+not restrictive.
+
+Order of operations: scaffold (T1) → full SKILL.md authoring (T2) → references that
+expand the procedure (T3) → asset template (T4) → evals (T5) → cross-reference note
+(T6) → pack close-out: version bump, backlog updates, full lint (T7).
+
+**Declined patterns:**
+- Tempted to add a VoC research step to the procedure — declining per RFC-0062 OQ2:
+  VoC is optional input, not produced; the skill takes the same posture as
+  `aesthetic-direction` takes on persona.
+- Tempted to fold copy-direction into aesthetic-direction (RFC-0062 Option B) —
+  declining because that would overload a skill with a clear single visual job and
+  there is no prior art for conflating visual and copy direction in one artifact.
+- Tempted to write a combined plan with content-design-skill — declining because the
+  RFC specifies two separate spec directories for independent tracking and review.
+- Tempted to add a managed `copy-direction` → `voice-and-microcopy` trigger (a hook
+  or runtime coupling) — declining per ADR-0024: no hooks, no engines; hand-off is
+  a prose instruction in the procedure, not a runtime dependency.
+
+## Constraints
+
+- **RFC-0062** D1–D5 — `copy-direction` name (D1), `voice-and-microcopy` boundary
+  via surface type (D4), SEO explicitly out of scope (D5).
+- **ADR-0024** — Guardrails A and B; enforced by `tools/lint-experience-agnostic.py`.
+- **RFC-0030** — `voice-and-microcopy`'s home stays in `product-engineering`;
+  this spec adds a cross-reference note only, no home change.
+- **RFC-0050** — experience pack design-thread; `copy-direction` artifact extends
+  the discover-by-marker set alongside `content-brief`.
+- **ADR-0028 / RFC-0037** — pack-activation-eval coverage shape.
+
+## Construction tests
+
+**Integration tests:**
+- `tools/lint-experience-agnostic.py` exits 0 on `packs/experience/` after every
+  new file lands.
+- `grep "copy-direction" packs/product-engineering/.apm/skills/voice-and-microcopy/SKILL.md`
+  returns a match after T6 completes.
+
+**Manual verification:**
+- Cold-prompt `copy-direction` with persona = "technical founders and their teams,"
+  felt vibe = "direct but warm — we're the guide, not the expert." Confirm: ≥2
+  named copy goals (short noun phrases), each grounded in ≥1 stable referent; a
+  dominant goal named; ≥1 arbitration rule recorded; no copy strings or formula
+  tables produced; artifact path named.
+- Confirm the procedure degrades gracefully when no `content-design` output is
+  present: elicits persona, surface type, and felt vibe inline without error.
+
+## Tasks
+
+### T1: Copy-direction skill directory scaffolded
+
+**Depends on:** none
+
+**Tests:**
+- `find packs/experience/.apm/skills/copy-direction/ -type f | sort` returns
+  `SKILL.md` and the four subdirectory placeholders
+- `python3 tools/lint-experience-agnostic.py` exits 0
+
+**Approach:**
+- Create `packs/experience/.apm/skills/copy-direction/` with subdirectories
+  `references/`, `assets/`, `evals/`
+- Create `SKILL.md` stub: frontmatter `name: copy-direction`, `description:`
+  placeholder; section heading stubs (When to invoke, Procedure, Anti-patterns)
+
+**Done when:** Directory tree exists; lint exits 0 on empty stub.
+
+---
+
+### T2: SKILL.md fully authored (8-step procedure)
+
+**Depends on:** T1
+
+**Tests:**
+- `python3 tools/lint-experience-agnostic.py` exits 0
+- `awk '/^## Procedure/,/^## [^#]/' packs/experience/.apm/skills/copy-direction/SKILL.md | grep -c "^[0-9]\+\."` returns 8 (numbered steps scoped to Procedure section only)
+- `grep "Anti-patterns" packs/experience/.apm/skills/copy-direction/SKILL.md` matches
+- Manual cold-prompt confirms: ≥2 named copy goals with referents; dominant goal;
+  ≥1 arbitration rule; no copy strings
+
+**Approach:**
+- `description:` — triggers on "what voice should our copy have", "write a
+  copy-direction doc", "what should our headlines sound like", "how do we sound
+  different from competitors", "copy vibe check"; explicitly does NOT use for UI
+  microcopy states (use voice-and-microcopy), full brand identity specs (wider scope),
+  or SEO content (deferred)
+- **When to invoke** — four pre-conditions mirroring aesthetic-direction's gate:
+  (1) real copy vibe to name, (2) no copy-direction doc already owns this surface,
+  (3) naming direction not writing final copy, (4) persona or surface type known
+  or elicitable
+- **Procedure** — 8 steps:
+  1. **Map the audience** — name each distinct reader type, write one copy JTBD
+     sentence per type ("When {situation}, I want to {action}, so that {goal}"),
+     rank them; load `references/copy-jtbd.md`
+  2. **Run the interrogation** — felt vibe → named copy goals (short noun phrases:
+     "direct," "warm-but-not-cute," "earned authority"); sharpen each against its
+     opposite; load `references/interrogation-sequence.md`
+  3. **Ground each goal** — take VoC findings as optional input: if provided, cite
+     the audience's own language; if absent, elicit inline ("what words does your
+     audience use when describing this problem?") and flag the resulting goals as
+     "directional — not backed by VoC research." For each named goal, cite ≥1 stable
+     referent: persona language, copy precedents (named examples — Stripe, Linear —
+     as grounding; not as templates), persuasion standards (painkiller-first framing,
+     tweet test, five-second evaluator scan); load `references/copy-grounding.md`
+  4. **Rank the goals** — order so ties break; name the dominant goal
+  5. **Record arbitration** — for each likely conflict (urgency vs. warmth;
+     brevity vs. completeness), name which goal wins and why; load
+     `references/copy-arbitration.md`
+  6. **Capture the doc** — copy `assets/copy-direction-template.md` to
+     `docs/design/copy/<slug>.md`; fill: reader map, named goals with referents,
+     what each means and what would violate it, dominant goal, arbitration rules,
+     open questions
+  7. **Hold the plain-language floor** — verify direction against: no jargon the
+     reader didn't bring, no idioms that don't translate, no assumptions about
+     who the reader is
+  8. **Hand off** — reference `voice-and-microcopy` for per-surface UI copy;
+     reference `content-design` output as upstream context; note OQ1 scope
+     extension for experience-reviewer deferred
+- **Anti-patterns**: refuse naming goals without grounding them in a referent;
+  refuse unranked goals; refuse reprinting copy precedents as templates; refuse
+  producing SEO content or advertising copy briefs; refuse re-deriving copy
+  direction mid-build (amend the doc deliberately, don't drift)
+
+**Done when:** Manual cold-prompt produces output matching spec ACs; lint clean.
+
+---
+
+### T3: References directory authored
+
+**Depends on:** T2
+
+**Tests:**
+- `ls packs/experience/.apm/skills/copy-direction/references/` shows ≥5 files
+  (copy-jtbd.md, interrogation-sequence.md, copy-grounding.md, copy-arbitration.md,
+  plain-language-floor.md)
+- Each file cited in SKILL.md procedure exists; no dangling references
+- `python3 tools/lint-experience-agnostic.py` exits 0
+
+**Approach:**
+- `references/copy-jtbd.md` — the copy JTBD sentence template and reader-type
+  ranking method, mirroring `references/audience-jtbd.md` in aesthetic-direction;
+  explains the difference between a copy JTBD (a "hire-this-copy-for" progress
+  statement) and a generic persona description
+- `references/plain-language-floor.md` — names the governing standards: GOV.UK
+  Content Design plain-language guidance and the US Federal Plain Language
+  Guidelines; defines the three step-7 checks (no jargon the reader didn't bring,
+  no idioms that don't translate, no reader-identity assumptions); never reprints
+  the standard text verbatim (ADR-0024 Guardrail A)
+- `references/interrogation-sequence.md` — the interrogation question sequence for
+  copy voice: what three words would describe this brand's copy? What would the
+  corporate-bad version sound like? What does it feel like reading the headline in
+  3 seconds? What would the over-friendly version get wrong?
+- `references/copy-grounding.md` — the three referent types: (1) persona language
+  (vocabulary the audience actually uses — mined from support tickets, sales calls,
+  community posts); (2) copy precedents (named examples as quality anchors —
+  Stripe "The new standard in online payments," Linear "The issue tracker you'll
+  enjoy using"; named, not reprinted as formulas); (3) persuasion standards
+  (painkiller-first framing, tweet test, five-second evaluator scan — each defined
+  functionally, not as a reprint of the original framework)
+- `references/copy-arbitration.md` — the common conflict types and arbitration
+  structure: urgency vs. warmth, brevity vs. completeness, authority vs.
+  approachability, specificity vs. universality; the dominant-goal arbitration rule;
+  how to record a new conflict type
+
+**Done when:** All referenced files exist; lint clean across all new files.
+
+---
+
+### T4: Copy-direction asset template authored
+
+**Depends on:** T3
+
+**Tests:**
+- `ls packs/experience/.apm/skills/copy-direction/assets/` shows
+  `copy-direction-template.md`
+- `grep "type: copy-direction" packs/experience/.apm/skills/copy-direction/assets/copy-direction-template.md`
+  matches
+- `python3 tools/lint-experience-agnostic.py` exits 0
+
+**Approach:**
+- Mirror `aesthetic-direction-template.md` structure
+- Frontmatter: `type: copy-direction`, `surface:`, `persona:`, `date:`
+- Sections: Reader Map (table: reader type | JTBD sentence | rank), Named Copy
+  Goals (table: goal | what it means | what would violate it | referent(s)), Dominant
+  Goal, Copy Arbitration Rules (table: conflict | winner | reason), Plain-Language
+  Floor Notes, Open Questions
+- Placeholder text in square brackets `[…]`; no pre-written copy strings
+
+**Done when:** Template exists with correct frontmatter; lint clean.
+
+---
+
+### T5: Evals authored; copy-direction added to pack.toml
+
+**Depends on:** T2
+
+**Tests:**
+- `cat packs/experience/pack.toml | grep "copy-direction"` returns a match in
+  `[pack.evals] skills`
+- `ls packs/experience/.apm/skills/copy-direction/evals/` shows `eval_queries.json`
+  and `evals.json`
+- `python3 tools/lint-experience-agnostic.py` exits 0
+
+**Approach:**
+- `eval_queries.json`: trigger phrases — "what voice should our copy have", "write
+  a copy direction doc", "how do we sound different from our competitors",
+  "what should our hero headline feel like", "copy vibe check"
+- `evals.json`: Tier-4 LLM-judge rubric; rubric checks: ≥2 named copy goals
+  present as short noun phrases, each with ≥1 referent; dominant goal named;
+  ≥1 arbitration rule recorded; no copy strings or formula tables produced
+- Add `"copy-direction"` to `[pack.evals] skills` in `packs/experience/pack.toml`
+  (do NOT bump version yet — version bump is T7, after both skills are in the list)
+
+**Done when:** Lint clean; grep confirms pack.toml updated; both eval files present.
+
+---
+
+### T6: voice-and-microcopy cross-reference scope note added
+
+**Depends on:** T2 (scope boundary language finalized in SKILL.md step 8)
+
+**Tests:**
+- `grep -c "copy-direction" packs/product-engineering/.apm/skills/voice-and-microcopy/SKILL.md`
+  returns ≥1
+- The note does not remove or qualify any existing voice-and-microcopy procedure
+  text — additive only
+- `python3 tools/lint-experience-agnostic.py` exits 0 (the experience lint doesn't
+  scan product-engineering, but confirm the note itself contains no stack tokens)
+
+**Approach:**
+- Locate the preamble or "When to invoke" section in
+  `packs/product-engineering/.apm/skills/voice-and-microcopy/SKILL.md`
+- Add cross-reference scope note: "For marketing/acquisition copy voice and positioned
+  copy (hero headlines, above-fold narrative, taglines) use the `experience` pack's
+  `copy-direction` skill; `voice-and-microcopy` covers product UI copy states (error,
+  empty state, button labels, form labels) — surface type is the boundary. **Onboarding
+  tri-point:** onboarding narrative arc + structure → `content-design`; onboarding
+  copy voice and register → `copy-direction`; onboarding UI-state strings
+  (loading, error, empty) → `voice-and-microcopy`."
+- Add as a blockquote or note callout consistent with the existing SKILL.md's style;
+  do not edit existing procedure steps
+
+**Done when:** Grep confirms note present; voice-and-microcopy procedure is unchanged
+in behavior.
+
+---
+
+### T7: Pack version bumped to 0.5.0; backlog updated; full lint clean
+
+**Depends on:** T1–T6, spec:content-design-skill/T5
+
+**Tests:**
+- `cat packs/experience/pack.toml | grep "^version"` returns `0.5.0`
+- `grep '"version"' packs/experience/.claude-plugin/plugin.json` returns `0.5.0`
+- `python3 tools/lint-experience-agnostic.py` exits 0 on the full `packs/experience/`
+  tree (both new skills included)
+- `grep "RFC-0062" docs/backlog.md` returns matches under both
+  `copy-direction-skill-rfc` and `content-strategy-and-marketing-copy-lens` headings
+- `grep "experience-reviewer-content-brief-scope" docs/backlog.md` returns a match
+
+**Approach:**
+- Bump `version` in `packs/experience/pack.toml` from `0.4.2` to `0.5.0`
+- Bump `version` in `packs/experience/.claude-plugin/plugin.json` from `0.4.2` to
+  `0.5.0` (both files must match; bumping only pack.toml drifts the plugin manifest)
+- Run `make build-self` to re-aggregate `marketplace.json` with the updated version
+- In `docs/backlog.md` under `### copy-direction-skill-rfc`: add "**In-progress:**
+  RFC-0062 opened 2026-07-18. Implementing as `copy-direction` skill in the
+  `experience` pack."
+- In `docs/backlog.md` under `### content-strategy-and-marketing-copy-lens`:
+  add "**In-progress (structural direction half):** RFC-0062 opened 2026-07-18.
+  `content-design` skill implements the content-first / narrative-arc thread;
+  SEO remains deferred per D5."
+- In `docs/backlog.md` add `### experience-reviewer-content-brief-scope` entry:
+  "**Deferred (RFC-0062 OQ1):** Extend `experience-reviewer`'s scope to include
+  content briefs (`type: content-brief`) as a reviewable artifact type. The current
+  skill produces the artifact; the reviewer's scope extension is a follow-on RFC.
+  Decide-by: spec authoring for `content-design` skill. Owner: eugenelim."
+- Run `python3 tools/lint-experience-agnostic.py` and verify clean exit on full tree
+
+**Done when:** Version is 0.5.0; lint exits 0 on full tree; both backlog entries
+reference RFC-0062.
+
+## Rollout
+
+Pure-markdown skill addition + a one-line informational edit to
+`voice-and-microcopy`. No infrastructure, no data migration, no deployment
+sequencing. Ships as a normal PR to main alongside the `content-design-skill`
+implementation. Reversible: if `copy-direction`'s procedure violates ADR-0024
+post-merge, the lint catches it in CI and a follow-up PR removes the violation;
+the `voice-and-microcopy` scope note can be removed in the same PR.
+
+## Risks
+
+- **Procedure drifts from aesthetic-direction's rhythm** — making the two skills
+  feel like different design disciplines rather than parallel methods. Mitigation:
+  the 8-step structure is authoritative; step names are locked to the spec ACs;
+  the manual cold-prompt gate checks structural symmetry before T2 is declared done.
+- **voice-and-microcopy cross-reference note restricts rather than redirects** —
+  accidentally narrowing voice-and-microcopy's scope. Mitigation: T6 test explicitly
+  checks that no existing procedure text is removed or qualified; the note is additive.
+- **Version bump ahead of content-design-skill** — pack ships at 0.5.0 with only
+  one of the two skills. Mitigation: T7 has an explicit cross-spec dependency on
+  spec:content-design-skill/T5; the bump cannot run until both evals entries are
+  present.
+
+## Changelog
+
+- 2026-07-18: initial plan

--- a/docs/specs/copy-direction-skill/spec.md
+++ b/docs/specs/copy-direction-skill/spec.md
@@ -1,0 +1,189 @@
+# Spec: copy-direction-skill
+
+- **Status:** Approved <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** RFC-0062 (D1–D5), ADR-0024 (guardrails A+B, framework-agnosticism), RFC-0050 (experience pack design-thread), RFC-0030 (voice-and-microcopy home stays in product-engineering)
+- **Brief:** none
+- **Contract:** none — pure-markdown skill + asset template; no API/event/RPC interface. The copy-direction doc is a markdown artifact template (skill `assets/`), not a versioned interface contract.
+- **Shape:** integration — a new skill directory under `packs/experience/.apm/skills/`; a one-line cross-reference edit to `packs/product-engineering/.apm/skills/voice-and-microcopy/SKILL.md`; a pack version bump; method-authoring, not application code.
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+A `copy-direction` skill is added to the `experience` pack — the copy twin of
+`aesthetic-direction`. Designers, copywriters, and solo builders use it to turn a
+vague "copy vibe" into a small set of named, ranked copy goals grounded in stable
+referents (persona language, copy precedents, persuasion standards), and to record
+copy arbitration rules the rest of the build references when writing any copy for the
+surface. The skill fills the second missing link in the experience pack's design
+thread: it rides alongside `aesthetic-direction`, takes inputs from `content-design`
+(or elicits inline), and feeds `voice-and-microcopy` when per-surface UI copy is
+being written.
+
+A scope-boundary cross-reference is added to `voice-and-microcopy` in the
+product-engineering pack making the surface-type split explicit: `copy-direction` owns
+marketing/acquisition copy voice and positioned copy (hero headlines, above-fold
+narrative, taglines, announcement copy); `voice-and-microcopy` owns product UI copy
+states (error messages, empty states, button labels, form labels). Surface type is the
+boundary; both files carry the cross-reference.
+
+Success means a designer can invoke `copy-direction` cold, answer an 8-step
+interrogation sequence mirroring `aesthetic-direction`'s structure, and receive a
+`copy-direction.md` doc the rest of the build references without re-litigating copy
+voice. The experience pack version bumps to 0.5.0 to reflect two new public-interface
+skills (this skill and `content-design` from its companion spec).
+
+## Boundaries
+
+### Always do
+
+- Author `SKILL.md` + `references/` + `assets/` + `evals/` under
+  `packs/experience/.apm/skills/copy-direction/`
+- Mirror `aesthetic-direction`'s 8-step procedure structure applied to copy voice:
+  audience map → interrogation → grounding → ranking → arbitration → capture →
+  plain-language floor check → hand-off
+- Keep every file pure-markdown per ADR-0024: name copy precedents and persuasion
+  standards as references, never reprint them wholesale; produce named goals and
+  arbitration rules, not a copy template or formula table
+- Artifact path `docs/design/copy/<slug>.md` with `type: copy-direction`, resolved
+  via RFC-0050 D6's three-tier layout contract; `copy-direction` extends the pack's
+  discover-by-marker set
+- Add `copy-direction` to `[pack.evals] skills` in `packs/experience/pack.toml`;
+  ship `evals/eval_queries.json` + `evals/evals.json`
+- Add a one-line cross-reference scope note to
+  `packs/product-engineering/.apm/skills/voice-and-microcopy/SKILL.md` (scope note
+  only — no behavior change to voice-and-microcopy)
+- Bump `packs/experience/pack.toml` version from 0.4.2 → 0.5.0 when both
+  `content-design` and `copy-direction` are in the evals list
+- Mark `docs/backlog.md` entries `copy-direction-skill-rfc` and
+  `content-strategy-and-marketing-copy-lens` as in-progress (RFC opened) with
+  reference to RFC-0062
+- Run `tools/lint-experience-agnostic.py` after every edit; keep it clean
+
+### Ask first
+
+- Any change to `voice-and-microcopy`'s procedure or behavior beyond the one-line
+  cross-reference scope note
+- Moving `voice-and-microcopy`'s home from `product-engineering` to `experience`
+  (RFC-0030 constraint; confirmed as "Ask first" in the experience-pack spec Boundaries)
+- Widening scope to include VoC research production — VoC findings are optional
+  input, not produced by this skill
+- Widening scope to include full brand identity documentation, advertising copy
+  templates, or SEO content guidelines
+
+### Never do
+
+- Reprint copy precedents (Stripe, Linear, etc.) as prescriptive copy — name them
+  as reference examples that ground a goal; never quote the headline and say
+  "write copy like this"
+- Produce a copy template, formula table, or pre-written copy strings
+- Add hooks, engines, validators, or in-pack linters
+- Edit `voice-and-microcopy`'s existing procedure steps — scope note only
+
+## Testing Strategy
+
+All verification is goal-based or manual QA — there is no testable runtime logic.
+
+- **Goal-based:** `tools/lint-experience-agnostic.py` exits 0 on `packs/experience/`
+  after the skill lands.
+- **Goal-based:** `grep "copy-direction" packs/product-engineering/.apm/skills/voice-and-microcopy/SKILL.md`
+  returns a match (cross-reference note present).
+- **Goal-based:** `grep "not backed by VoC research" packs/experience/.apm/skills/copy-direction/SKILL.md`
+  returns a match confirming the VoC-absent flag phrase is present in the procedure.
+- **Goal-based:** `cat packs/experience/pack.toml | grep -E "^version|copy-direction"` confirms
+  version 0.5.0 and `copy-direction` in the evals list.
+- **Goal-based:** `grep -c "copy-direction-skill-rfc\|content-strategy-and-marketing-copy-lens" docs/backlog.md`
+  combined with `grep "RFC-0062" docs/backlog.md` confirms both backlog entries reference RFC-0062.
+- **Manual QA:** Cold-prompt `copy-direction` with persona = "technical founders and
+  their teams" and felt copy vibe = "direct but warm — we're the guide, not the
+  expert." Confirm output names ≥2 copy goals as short noun phrases, grounds each in
+  ≥1 stable referent (persona language, a copy precedent, or a persuasion standard),
+  records a dominant goal, and states ≥1 arbitration rule. Confirm no copy strings
+  or formula tables are produced.
+
+## Acceptance Criteria
+
+- [ ] `packs/experience/.apm/skills/copy-direction/SKILL.md` exists; frontmatter
+  includes `name: copy-direction`; Procedure section has exactly 8 numbered steps
+  (verified by counting within `## Procedure` only, not the full file); the step
+  structure mirrors `aesthetic-direction`'s audience-map → interrogation → grounding
+  → ranking → arbitration → capture → floor-check → hand-off; Anti-patterns section
+  present.
+- [ ] Step 1 (audience map): maps each distinct reader type with a copy JTBD sentence
+  and ranks them; feeds the ranked map into Step 2.
+- [ ] Step 2 (interrogation): converts felt vibe to named copy goals (short noun
+  phrases); sharpens each against its opposite.
+- [ ] Step 3 (grounding): grounds each goal in ≥1 stable referent from: persona
+  language (words the audience actually uses), copy precedents (cited as named
+  examples, not reprinted), persuasion standards (painkiller-first framing, tweet
+  test, five-second evaluator scan for above-fold copy).
+- [ ] Step 4 (ranking): orders goals so a tie can break; names the dominant goal.
+- [ ] Step 5 (arbitration): records which goal wins each named conflict type
+  (urgency vs. warmth; brevity vs. completeness).
+- [ ] Step 7 (plain-language floor): verifies direction against named plain-language
+  and inclusivity standards; a `references/plain-language-floor.md` file names the
+  governing standards (GOV.UK Content Design plain-language guidance and the US
+  Federal Plain Language Guidelines as the two stable named references) and defines
+  the three specific checks the step applies: no jargon the reader didn't bring, no
+  idioms that don't translate, no assumptions about the reader's identity.
+- [ ] VoC findings are taken as optional input: the SKILL.md procedure explicitly
+  states that when VoC is absent the skill elicits audience language inline (a short
+  "what words does your audience use?" prompt) and flags the resulting goals as
+  "directional — not backed by VoC research" — consistent with `aesthetic-direction`'s
+  posture on persona as optional input.
+- [ ] Artifact path `docs/design/copy/<slug>.md` with `type: copy-direction` is
+  documented in SKILL.md; `copy-direction` is named as an extension to the pack's
+  discover-by-marker set alongside `content-brief`.
+- [ ] One-line cross-reference scope note added to
+  `packs/product-engineering/.apm/skills/voice-and-microcopy/SKILL.md`; note states
+  the surface-type boundary: `copy-direction` owns marketing/acquisition copy voice
+  and positioned copy (hero headlines, above-fold narrative, taglines);
+  `voice-and-microcopy` owns product UI copy states (error, empty state, button
+  labels, form labels). Onboarding is explicitly carved: the onboarding narrative
+  arc and structure → `content-design`; the onboarding copy voice and register →
+  `copy-direction`; onboarding UI-state strings → `voice-and-microcopy`.
+- [ ] `copy-direction` is listed in `[pack.evals] skills` in
+  `packs/experience/pack.toml`; `evals/eval_queries.json` and `evals/evals.json`
+  exist under `packs/experience/.apm/skills/copy-direction/evals/`.
+- [ ] `packs/experience/pack.toml` version is `0.5.0` (minor bump from 0.4.2,
+  reflecting two new public-interface skills); `packs/experience/.claude-plugin/plugin.json`
+  version is also `0.5.0`; `make build-self` has been run to re-aggregate
+  `marketplace.json` with the updated version.
+- [ ] `tools/lint-experience-agnostic.py` exits 0 on `packs/experience/` with both
+  new skills present.
+- [ ] `docs/backlog.md` entries `copy-direction-skill-rfc` and
+  `content-strategy-and-marketing-copy-lens` carry an in-progress marker referencing
+  RFC-0062.
+- [ ] SEO keyword targeting, advertising copy templates, and brand identity
+  documentation production are explicitly listed as out of scope in the SKILL.md
+  Anti-patterns or a clearly marked scope note (RFC-0062 D5 governs both skills).
+- [ ] The skill is standalone-useful: it elicits persona, surface type, and felt copy
+  vibe inline when no `content-design` output is provided; no upstream artifact is
+  required to invoke it.
+- [ ] `docs/backlog.md` has an entry under `### experience-reviewer-content-brief-scope`
+  recording that experience-reviewer's scope extension to include content briefs is
+  deferred (RFC-0062 OQ1), with a decide-by of "spec authoring for content-design."
+
+## Assumptions
+
+- **Technical:** `voice-and-microcopy` lives in `packs/product-engineering/.apm/skills/voice-and-microcopy/SKILL.md`
+  and a one-line cross-reference addition does not require RFC-0030 approval —
+  cross-reference scope notes are informational edits, not behavior changes.
+  (source: experience-pack spec Boundaries "Ask first" confirms home change requires
+  sign-off; adding a note does not)
+- **Technical:** The experience pack version follows semver minor bumps for new
+  public-interface additions (two new skills = 0.4.2 → 0.5.0). The major version
+  (0.x) reflects pre-1.0 maturity, not a breaking change.
+  (source: pack.toml version history inspection 2026-07-18)
+- **Product:** RFC-0062 D4 (surface type as the `copy-direction` / `voice-and-microcopy`
+  boundary) and OQ2 (VoC as optional input) are accepted as the binding decisions
+  governing this spec's scope boundary and input posture.
+  (source: RFC-0062 D4, OQ2 recommendations)
+- **Product:** The `copy-direction-skill` spec depends on `content-design-skill` being
+  implemented first in the same PR or a prior PR — copy-direction's hand-off step
+  references the content-design artifact. If shipped separately, the hand-off step
+  references the artifact path as a future upstream.
+  (source: RFC-0062 skill chain diagram)


### PR DESCRIPTION
## Summary

- Approved specs and plans for the two new `experience` pack skills from RFC-0062
- `docs/specs/content-design-skill/` — per-surface content brief skill; fills the design-thread gap before `map-screen-flow`; routes across acquisition (Schwartz ladder / StoryBrand / CCD) and product/reference surfaces (Nava PBC must-say → probably-say → might-say)
- `docs/specs/copy-direction-skill/` — the copy twin of `aesthetic-direction`; 8-step procedure producing named, ranked copy goals with stable referents; includes `voice-and-microcopy` cross-reference, plain-language floor reference, pack version bump to 0.5.0 (pack.toml + plugin.json + build-self), and three backlog entry updates

Both specs are adversarial-reviewed clean (three reviewer passes; all Blockers, Concerns, and Nits resolved).

## Test plan

- [ ] Specs are Status: Approved with complete Acceptance Criteria and Testing Strategy
- [ ] Both plans have numbered tasks with explicit `Depends on:` and `Done when:` fields
- [ ] No implementation changes — docs-only PR; CI gates are docs/lint checks only

## Deferred

- ADR for skill addition: subsumed by existing ADR-0024 + RFC-0050 add-a-skill bar — no new ADR needed
- Experience-reviewer scope extension to include content briefs: deferred to follow-on RFC (RFC-0062 OQ1); tracked in `docs/backlog.md` under `experience-reviewer-content-brief-scope` (added in copy-direction-skill T7)