### PR TITLE
docs(rfc): RFC-0064 INI-001 AI-Native Ecosystem — Platform Core

### DIFF
--- a/docs/product/journeys/README.md
+++ b/docs/product/journeys/README.md
@@ -1,0 +1,130 @@
+# Journey maps
+
+Customer and agent journeys for the INI-001 AI-Native Ecosystem. Each map covers one persona moving through a meaningful outcome — showing the current state (how it works today) and the to-be state (what each initiative milestone delivers). Journeys are living documents: when a milestone ships, the relevant stage is updated to reflect the new current state and the to-be callout is removed or replaced.
+
+## How adoption, shaping, and build relate
+
+Work in this ecosystem moves through two rooms before it ships — and adoption is the prerequisite that must happen first:
+
+```mermaid
+flowchart LR
+    adopt["Adoption\n(self-serve or sponsored)"]
+    alt0["Altitude-0 direction\n(strategy, OKRs)"]
+    shape["Shaping room\n(PE six-step sequence)"]
+    ext["External intake\n(tracker, email)"]
+    bq["[brief_queue]"]
+    build["Build room\n(spec → execute → ship)"]
+
+    adopt --> shape
+    adopt --> build
+    alt0 --> shape
+    shape --> bq
+    ext --> bq
+    bq --> build
+```
+
+**Shaping room** — where strategy, product thinking, and external signals are transformed into a shaped brief with a committed rationale. The output is a DoR-compliant brief in `[brief_queue]`. The personas here are the product strategist, the product engineer, and any PM bridging from a tracker.
+
+**Build room** — where a brief becomes specs, then code. The work queue (`[work]`) holds specs; `work-loop` executes them; the engineer or agent is the actor. Headless agents (INI-003) are a scaling variant of the build room, not a separate room.
+
+**The brief queue is the handoff point.** A brief passes the DoR gate (`Status: Ready`) and enters `[brief_queue].ready`. The build room picks it up via `receive-brief`, decomposes it into specs, and those land in `[work].queue`. From there, `check-workspace` drives the session.
+
+Journeys below are grouped by room. The three shaping journeys are distinct personas who all write to the brief queue through different paths. The four build journeys are distinct execution modes for the same work-loop pattern.
+
+---
+
+## Status lifecycle
+
+| Status | Meaning |
+|---|---|
+| `proposed` | Identified as a journey worth mapping; current state not yet fully captured |
+| `shaping` | Current state mapped; future state design in progress |
+| `planned` | Both states mapped; future-state stages tied to initiative milestones |
+| `shipped` | To-be state is now current state; journey updated to reflect live product |
+
+A journey can be partially shipped — some stages updated to current, others still showing to-be.
+
+---
+
+## Shaping room journeys
+
+These journeys all converge on the brief queue — each persona takes a different path in but writes to the same `[brief_queue].draft` output.
+
+| Journey | Persona | Status | Initiative links |
+|---|---|---|---|
+| [Product strategist sets direction](product-strategist-sets-direction.md) | Strategist / CPO anchoring initiative clusters in altitude-0 artifacts (PRFAQ, OKR cascade, market analysis) | proposed | INI-002 M4 (primary); M2 (prerequisite) |
+| [Product engineer shapes initiative](product-engineer-shapes-initiative.md) | PE or PM running the six-step shaping sequence (situation → opportunities → diverge → validate → bet → brief) | proposed | INI-002 M2 (primary); M1 (prerequisite) |
+| [PM intakes from tracker](pm-intakes-from-tracker.md) | PM bridging Linear / Jira / GitHub issues into the brief queue without manual reformatting | proposed | INI-002 M5 (primary); M1 (prerequisite) |
+
+---
+
+## Adoption journey
+
+The adoption journey is the prerequisite for everything else. It covers two paths — self-serve (solo or startup) and sponsored (enterprise with a champion, live demo, and rollout playbook).
+
+| Journey | Persona | Status | Initiative links |
+|---|---|---|---|
+| [Engineering team evaluates and adopts](team-evaluates-and-adopts.md) | Any team evaluating the platform — self-serve (senior engineer installs and ships first spec) or sponsored (enterprise champion demos to CTO, platform team rolls out) | planned | INI-002 M1 (what the team adopts); M6 (tutorial, rollout playbook, live-demo guide) |
+
+---
+
+## Build room journeys
+
+All four journeys converge on the work queue — different actors, same `work-loop` infrastructure. The core loop (plan → build → verify → ship) is the same; what changes is the orientation source and the degree of human involvement.
+
+| Journey | Persona | Status | Initiative links |
+|---|---|---|---|
+| [Engineer adopts AI-native coordination](engineer-adopts-coordination.md) | Engineer installing Platform Core and operating it end-to-end for the first time | planned | INI-002 M1–M6 (primary) |
+| [Engineer runs the work-loop](engineer-runs-work-loop.md) | Interactive implementer using `work-loop` day-to-day; human in the loop for plan review and gate navigation | planned | INI-002 M1 (primary); M2–M6 (ongoing improvements) |
+| [Agent executes spec autonomously](agent-executes-spec.md) | Headless agent cold-starting, orienting, executing, and shipping without human intervention | planned | INI-002 M1 (primary); INI-003 M1+ (extends) |
+| [Engineer scales to coordinated agent swarm](engineer-scales-to-swarm.md) | Team with INI-002 M1 in place, scaling to headless CLI agent pipelines across multiple specs in parallel | shaping | INI-003 M1+ (primary); INI-002 M1 (prerequisite) |
+
+---
+
+## How the journeys tie together
+
+```mermaid
+flowchart TB
+    S["Product Strategist\nproduct-strategist-sets-direction"]
+    PE["Product Engineer\nproduct-engineer-shapes-initiative"]
+    PM["PM\npm-intakes-from-tracker"]
+    BQ["[brief_queue].draft"]
+    WQ["[work].queue"]
+    E["Engineer (interactive)\nengineer-runs-work-loop"]
+    AG["Agent (autonomous)\nagent-executes-spec"]
+    SW["Swarm\nengineer-scales-to-swarm"]
+    ADO["Adopting engineer\nengineer-adopts-coordination"]
+
+    S -->|"OKR gaps → shaping_queue"| PE
+    PE -->|"bet + capability map"| BQ
+    PM -->|"intake skill"| BQ
+    BQ -->|"receive-brief"| WQ
+    WQ --> E
+    WQ --> AG
+    WQ --> SW
+    ADO -. "cross-cutting view" .-> BQ
+    ADO -. "cross-cutting view" .-> WQ
+```
+
+The `engineer-adopts-coordination` journey is the cross-cutting adopter view — it covers install, shaping, brief, and build in sequence. The other journeys zoom in on specific personas and rooms. Use the specialised journeys for design input into sub-RFCs; use the adopter journey as the overall product narrative.
+
+---
+
+## Convention — updating a journey when a milestone ships
+
+1. Open the journey file for the affected persona.
+2. For each stage that changed, replace the **Now** section with what was previously the **With [Milestone]** section.
+3. If the milestone introduced a new future state beyond what was mapped, add a new **With [Next milestone]** section.
+4. Update the `status` frontmatter if appropriate (e.g., `shaping` → `planned` when future stages are tied to milestones; `planned` → `shipped` when all future-state stages reflect live product).
+5. Update the `updated` date in frontmatter.
+6. Update this README's status column if the journey's status changed.
+
+---
+
+## Relationship to initiatives
+
+Initiative names are linkages inside each journey file — not journey names. A journey is named for the persona and outcome it represents, which stays stable even when the underlying initiative structure changes. Multiple initiatives may deliver changes to stages within one journey; a single initiative milestone may touch multiple journeys.
+
+## Relationship to other shaping artifacts
+
+Journey maps sit between product vision (why we're building this) and screen flows (how specific interactions are designed). A journey stage with a high-opportunity pain is the input for `map-screen-flow`. Backstage services implied by journey actions are the input for `blueprint-service`. Findings that surface across multiple stages are candidates for `docs/product/findings/`.

--- a/docs/product/journeys/agent-executes-spec.md
+++ b/docs/product/journeys/agent-executes-spec.md
@@ -1,0 +1,213 @@
+---
+type: customer-journey
+slug: agent-executes-spec
+persona: ai-agent
+outcome: spec-executed-and-shipped-autonomously
+surface: cross-platform
+status: planned
+initiative_links:
+  - id: INI-002
+    name: Platform Core
+    milestones: M1 (primary — check-workspace M1.5, work-loop M1.7)
+    role: primary
+  - id: INI-003
+    name: Coding CLI Adapter Pack
+    milestones: M1+ (headless dispatch variant)
+    role: extends
+updated: 2026-07-18
+---
+
+# Journey: Agent executes a spec autonomously
+
+**Persona:** An AI agent — Claude Code, Codex CLI, Kiro CLI, or any headless harness — starting a fresh session with no persistent memory of prior sessions. The agent has no human in the loop for the execution phase. It must orient itself, pick up the right spec, execute it through the work-loop, navigate gates, submit a PR, mark the spec shipped, and exit cleanly.
+
+**Outcome:** The spec is in `[work].shipped`. A PR is submitted and passing. `workspace.toml` reflects the new state. The next ready item is surfaced. The next agent starting a session can orient immediately without reading any prior session's context.
+
+**Surface:** cross-platform — runs identically across Claude Code (`claude`), Codex CLI (`codex`), Kiro CLI (`kiro`), GitHub Copilot CLI, Gemini CLI. The skill surface (`check-workspace`, `work-loop`) is harness-agnostic; harness-specific conventions (MCP vs static `.md`, context window limits) are adapter concerns (INI-003).
+
+**Trigger:** Agent session starts — invoked by a human running `claude`, by a CI/CD job dispatching a headless agent, or by a swarm supervisor allocating a spec.
+
+**End state:** Spec shipped. PR submitted. `[work].active` updated to `[work].shipped`. Next ready item surfaced. Session exits cleanly with committed state — the next agent picks up from a known-good position.
+
+---
+
+## Prerequisites
+
+| Pack | Scope | Status | Provides |
+|---|---|---|---|
+| core | repo | current | `check-workspace` (M1.5), `work-loop` (M1.7), `new-spec` |
+| coding CLI adapter pack | user | planned (INI-003) | Harness-specific invocation, write-back contract implementation; one adapter per harness (Claude Code, Codex CLI, Kiro, etc.) |
+
+**One-time setup:**
+1. Install core pack at repo scope.
+2. Install the harness-specific coding CLI adapter pack at user scope (when INI-003 ships).
+3. `workspace.toml` must be committed to `main` and pre-populated (M1 Batch 2); no branch configuration needed — headless agents read it from the local working directory.
+4. Agent must have write access to the spec branch — edits to `workspace.toml` commit with the spec PR (resolved write protocol; RFC-0064 Known Unknowns).
+
+**Scale:** all harness shapes (interactive Claude Code, headless CI, remote agents via INI-004) use the same write protocol: edit `workspace.toml` locally in the working directory and commit in the same spec PR. Adapter-specific concerns (CLI invocation, tool surface, context window) are INI-003's scope.
+
+---
+
+## Interaction model
+
+### Current state — before M1.5 / M1.7
+
+```mermaid
+sequenceDiagram
+    participant A as Agent
+    participant F as Repo files (RFC, roadmap, briefs/)
+    participant WL as work-loop skill
+    participant R as Repo (spec branch)
+
+    Note over A,R: Session start today — manual orientation
+    A->>F: Read docs/rfc/0064-ini-001-ai-native-ecosystem.md
+    A->>F: Read docs/product/roadmap.md
+    A->>F: Read docs/product/briefs/ (scan for in-progress)
+    A->>F: Read AGENTS.md
+    F-->>A: Context assembled — uncertain what is next
+    A-->>A: Infer active spec from context (may be wrong)
+
+    Note over A,R: Execution — no workspace write-back
+    A->>WL: work-loop [inferred spec]
+    Note over A: plan → build → verify → review
+    A->>R: Submit PR
+    A-->>A: Spec done — workspace not updated
+    Note over A: Next agent starts cold — same manual orientation
+```
+
+### To-be state — M1.5 + M1.7 shipped
+
+```mermaid
+sequenceDiagram
+    participant A as Agent
+    participant SK as Skills
+    participant WS as workspace.toml
+    participant WL as work-loop (extended M1.7)
+    participant R as Repo (spec branch)
+
+    Note over A,WS: Session start — M1.5+
+    A->>SK: check-workspace
+    SK->>WS: Read [shaping_queue]+[brief_queue]+[work], resolve DAG
+    WS-->>SK: Active initiative · spec/m1-work-loop is ready · spec/m1-receive-brief blocked (needs brief-template)
+    SK-->>A: Oriented · next action: work-loop spec/m1-work-loop
+
+    Note over A,WS: Claim spec (atomic — M1 convention / INI-003 adapter enforces)
+    A->>WS: Confirm spec/m1-work-loop in [work].queue (not already active)
+
+    Note over A,R: Execution — M1.7
+    A->>WL: work-loop spec/m1-work-loop
+    WL->>WS: Read workspace.toml at step 0 (context: initiative, milestone, spec)
+    Note over A: plan → build → verify → review
+    WL->>WS: On ship: active → shipped · surface next ready item
+    WL-->>A: Shipped · next: spec/m1-receive-brief · Update roadmap.md?
+    A->>R: Submit PR
+
+    Note over A,WS: Exit — next agent starts from known-good state
+    A->>SK: check-workspace (final — confirms shipped state visible)
+    SK-->>A: spec/m1-work-loop: shipped · spec/m1-receive-brief: ready
+```
+
+---
+
+## Stage 1: Orient
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Reads RFC, roadmap, briefs directory, AGENTS.md. Assembles context from 4+ files. Infers what spec to work on. |
+| **Emotions** | N/A (agent has no emotions). **Failure modes:** context assembled incorrectly (wrong spec inferred); context outdated (stale RFC or roadmap); spec already in progress by another agent (no visibility). |
+| **Pains** | "Four files to read, and the answer is still uncertain." "If the RFC was updated since the last session, the agent may be working from stale context." "No way to know if another agent is already working on the same spec." "Reading 4+ files consumes significant context window before any work starts." |
+| **Opportunities** | `check-workspace` as a single orientation command that surfaces active initiative, queued specs, DAG state, blocked reasons, and parallel candidates. Orientation in one command; context window preserved for actual work. |
+
+> **With M1.5** — `check-workspace` ships: orientation is one command; DAG state surfaces parallel candidates and blocked items; context window saved for work.
+
+---
+
+## Stage 2: Validate Spec Context
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Reads the inferred spec file (if it exists). Reads the brief it decomposes. Tries to understand what is in scope and what has already been done. |
+| **Emotions** | N/A. **Failure modes:** spec file doesn't exist yet (no new-spec has been run); brief is ambiguous; prior session's work is not committed (agent starts from scratch on uncommitted state). |
+| **Pains** | "The spec file may not exist — I have to run new-spec first, but I don't know if that's been done." "The brief doesn't tell me what has already been implemented — I might redo work." "If a prior agent made decisions mid-session that weren't committed, I have no way to see them." |
+| **Opportunities** | `work-loop` at step 0 reads `workspace.toml` to confirm the spec is in `[work].active` (or moves it there). Gate-boundary handoff notes committed by the prior session (post-M1 backlog — feeds INI-005). |
+
+> **With M1.7** — `work-loop` reads `workspace.toml` at step 0 to confirm spec context; partial-progress capture (gate-boundary handoff) is a Known Unknown deferred to INI-005 design.
+
+---
+
+## Stage 3: Plan
+
+### Now and to-be (unchanged — work-loop already handles this)
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Runs `new-spec` if spec file doesn't exist, or reads existing spec. Writes or validates plan. Surfaces assumptions. |
+| **Emotions** | N/A. **Failure modes:** plan makes assumptions that conflict with prior decisions; spec AC is too vague to plan against. |
+| **Pains** | "The spec AC doesn't tell me what 'done' looks like precisely enough — I have to make assumptions that may conflict with the reviewer's expectations." "If the plan has multiple parallel tasks, I have no way to know which can run in parallel and which must sequence." |
+| **Opportunities** | Spec AC written precisely enough for an agent to plan without ambiguity; `work-loop` plan step surfaces assumptions explicitly before build starts. Already partially addressed by work-loop's plan gate. |
+
+---
+
+## Stage 4: Build & Verify
+
+### Now and to-be (unchanged — work-loop already handles this)
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Executes plan tasks. Runs gates: lint, typecheck, tests, traceability lint. Iterates on failures. |
+| **Emotions** | N/A. **Failure modes:** gate failure not diagnosed (agent retries blindly); budget exceeded (too many tokens spent on a failing gate); traceability lint fails because spec or brief is missing a marker. |
+| **Pains** | "A gate fails and I retry the same approach three times before trying something different." "I don't know how much budget I've consumed or how close I am to the limit." "The traceability lint fails but the error message doesn't tell me which marker is missing where." |
+| **Opportunities** | Gate failure diagnostics that name the specific cause and suggest a corrective action; budget tracking surfaced to the agent mid-execution; traceability lint error messages that name the missing marker and the file. |
+
+---
+
+## Stage 5: Ship & Exit
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Submits PR. Does not update `workspace.toml`. Exits. Next agent starts cold. |
+| **Emotions** | N/A. **Failure modes:** PR submitted but workspace not updated; next agent re-picks the same spec (thinking it's not done); `roadmap.md` not updated (prompt never surfaced). |
+| **Pains** | "I submitted the PR but `workspace.toml` still shows the spec as active — the next agent might pick it up again." "I have no way to surface the `roadmap.md` update reminder." "The next agent starts with the same uncertain orientation I had — nothing I did makes their session easier." |
+| **Opportunities** | Post-ship automation: `workspace.toml` updated (active → shipped) on PR submission; next ready item surfaced; `roadmap.md` update prompted; exit state is a clean known-good `workspace.toml` that the next agent can orient from in one command. |
+
+> **With M1.7** — `work-loop` moves spec active → shipped on ship; surfaces next ready item; prompts `roadmap.md` update. Exit state is committed to `workspace.toml` — next agent orients in one `check-workspace` call.
+
+---
+
+## Frontstage actions
+
+- **Action:** run-check-workspace
+- **Action:** validate-spec-in-active-queue
+- **Action:** run-new-spec-if-needed
+- **Action:** write-plan
+- **Action:** execute-plan-tasks
+- **Action:** run-gates
+- **Action:** submit-pr
+- **Action:** update-workspace-on-ship
+- **Action:** run-check-workspace-exit-state
+
+---
+
+## Failure mode arc (replaces emotional arc for agent persona)
+
+Most critical failure: **Stage 1 (Orient)** — wrong spec inferred, or spec already claimed by another agent. Everything downstream is wasted work if the orientation is wrong.
+
+Second most critical: **Stage 5 (Ship & Exit)** — PR submitted but workspace not updated. The next agent re-picks the same spec, producing a duplicate PR or conflicting work.
+
+Primary design response: M1.5 `check-workspace` (orientation accuracy) + M1.7 `work-loop` write-back (exit state integrity). The combination means orientation is reliable and exit state is committed — the two highest-risk failure points are both closed by M1.
+
+Remaining failure modes (partial-progress capture, budget tracking, gate diagnostics) are post-M1 backlog items — some feed INI-005 design.
+
+---
+
+## Handoff notes
+
+**For `blueprint-service`:** backstage services include `workspace.toml` on `main` (spec claiming — INI-003 adapter concern; write-back on ship via resolved write protocol: agent edits locally and commits with the spec PR), spec branch (plan and build), gates (lint, typecheck, tests, traceability lint), PR submission. Atomic claiming across concurrent headless agents is an open INI-003 design question.
+
+**For INI-003:** the headless dispatch variant of this journey (agent invoked via `claude -p` or equivalent) adds the adapter layer between Stage 1 (Orient) and Stage 2 (Validate Spec Context). The adapter reads `workspace.toml`, formats the invocation, and handles write-back. Stages 3–5 are identical.

--- a/docs/product/journeys/agent-executes-spec.md
+++ b/docs/product/journeys/agent-executes-spec.md
@@ -182,15 +182,15 @@ sequenceDiagram
 
 ## Frontstage actions
 
-- **Action:** run-check-workspace
-- **Action:** validate-spec-in-active-queue
-- **Action:** run-new-spec-if-needed
-- **Action:** write-plan
-- **Action:** execute-plan-tasks
-- **Action:** run-gates
-- **Action:** submit-pr
-- **Action:** update-workspace-on-ship
-- **Action:** run-check-workspace-exit-state
+- **Skill:** run-check-workspace
+- **Skill:** validate-spec-in-active-queue
+- **Skill:** run-new-spec-if-needed
+- **Skill:** write-plan
+- **Skill:** execute-plan-tasks
+- **Skill:** run-gates
+- **Skill:** submit-pr
+- **Skill:** update-workspace-on-ship
+- **Skill:** run-check-workspace-exit-state
 
 ---
 

--- a/docs/product/journeys/engineer-adopts-coordination.md
+++ b/docs/product/journeys/engineer-adopts-coordination.md
@@ -181,18 +181,18 @@ sequenceDiagram
 
 ## Frontstage actions
 
-- **Action:** install-agentbundle
-- **Action:** read-agents-md
-- **Action:** run-frame-intent
-- **Action:** run-de-risk-intent
-- **Action:** receive-external-brief
-- **Action:** run-author-brief
-- **Action:** run-receive-brief
-- **Action:** pick-spec-from-queue
-- **Action:** run-work-loop
-- **Action:** submit-pr
-- **Action:** run-check-workspace
-- **Action:** resume-from-session-start
+- **Skill:** install-agentbundle
+- **Skill:** read-agents-md
+- **Skill:** run-frame-intent
+- **Skill:** run-de-risk-intent
+- **Skill:** receive-external-brief
+- **Skill:** run-author-brief
+- **Skill:** run-receive-brief
+- **Skill:** pick-spec-from-queue
+- **Skill:** run-work-loop
+- **Skill:** submit-pr
+- **Skill:** run-check-workspace
+- **Skill:** resume-from-session-start
 
 ---
 

--- a/docs/product/journeys/engineer-adopts-coordination.md
+++ b/docs/product/journeys/engineer-adopts-coordination.md
@@ -1,0 +1,213 @@
+---
+type: customer-journey
+slug: engineer-adopts-coordination
+persona: engineering-team-adopter
+outcome: run-coordinated-ai-native-operations
+surface: cross-platform
+status: planned
+initiative_links:
+  - id: INI-002
+    name: Platform Core
+    milestones: M1–M6
+    role: primary
+updated: 2026-07-18
+---
+
+# Journey: Engineer adopts AI-native coordination
+
+**Persona:** A platform-oriented engineering team — internal tooling, multi-component systems, or a developer platform group — that already runs one or two AI agents but has no coordination layer. Sessions expire and context is lost. A second agent knows nothing about the first. The team has no visibility into what is in flight.
+
+**Outcome:** Any agent can cold-start a session, run `check-workspace`, know exactly what to work on, and the team lead only reviews what diverged. Multiple specs execute in parallel without collision. Shaping artifacts survive sessions. The team operates at Step 2 maturity reliably.
+
+**Surface:** cross-platform — CLI/terminal, harness-agnostic.
+
+**Trigger:** The team hits the coordination gap — session context lost, duplicate work, or a colleague joins and has no idea what is in flight.
+
+**End state:** `check-workspace` is the standard session-start command. Briefs flow through the queue from any source. Specs are coordinated via `workspace.toml`. The team lead reviews exceptions, not every action.
+
+---
+
+## Prerequisites
+
+| Pack | Scope | Status | Provides |
+|---|---|---|---|
+| core | repo | current | `work-loop`, `new-spec`, `receive-brief`, `check-workspace` (M1.5), `author-brief` (M1 Batch 4) |
+
+**One-time setup:**
+1. Install core pack at repo scope.
+2. After M1 Batch 2 ships: `workspace.toml` is committed to `main` pre-populated with the INI-002 queue — no branch setup needed. Run `check-workspace` to verify.
+
+**Scale:** the full journey (shaping + brief + build) requires all M1 ACs. If the team only needs build-room coordination (Stages 3–5), core pack + `work-loop` alone is sufficient; `workspace.toml` and `check-workspace` add queue visibility.
+
+---
+
+## Interaction model
+
+### Current state — before INI-002 M1
+
+```mermaid
+sequenceDiagram
+    participant H as Engineer
+    participant A as Agent
+    participant F as Repo files
+
+    Note over H,F: Session start (today)
+    H->>A: Continue working on the platform
+    A->>F: Read RFC, roadmap.md, briefs/, AGENTS.md
+    F-->>A: Context assembled from 4+ files
+    A-->>H: Best guess at current state
+
+    Note over H,F: Brief intake (today)
+    H->>A: [pastes email or Linear description]
+    A-->>H: Which template fields are needed?
+    H->>A: [manually reformats content field by field]
+    A->>F: Write docs/product/briefs/slug.md
+    A-->>H: Brief created — run receive-brief?
+
+    Note over H,F: Execute and ship (today)
+    H->>A: Work on spec X
+    A->>F: Read brief, infer spec list
+    Note over A: plan → build → verify → review
+    A-->>H: Spec done — what is next?
+    H->>F: Manually update brief coverage + roadmap.md
+```
+
+### To-be state — INI-002 M1 shipped
+
+```mermaid
+sequenceDiagram
+    participant H as Engineer
+    participant A as Agent
+    participant SK as Skills (packs)
+    participant WS as workspace.toml
+
+    Note over H,WS: Session start (M1.5+)
+    H->>SK: check-workspace
+    SK->>WS: Read [shaping_queue]+[brief_queue]+[work], resolve DAG
+    WS-->>SK: Active initiative · parallel candidates · blocked items
+    SK-->>H: spec/m1-work-loop is ready · spec/m1-receive-brief blocked on brief-template
+
+    Note over H,WS: Brief intake (M1 — author-brief)
+    H->>SK: author-brief [pastes external brief text]
+    SK-->>H: Appetite? Rabbit holes? Instrumentation?
+    H->>SK: [answers DoR prompts]
+    SK->>WS: [brief_queue].draft += briefs/new-brief.md
+    SK-->>H: Brief queued — run receive-brief to decompose into specs
+
+    Note over H,WS: Execute and ship (M1.7)
+    H->>SK: work-loop · spec/m1-work-loop
+    SK->>WS: Confirm spec in [work].active
+    Note over SK: plan → build → verify → review
+    SK->>WS: active → shipped · surface next ready item
+    SK-->>H: Shipped · Next: spec/m1-receive-brief · Update roadmap.md?
+```
+
+---
+
+## Stage 1: Install & Orient
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Discovers the platform. Installs agentbundle. Reads AGENTS.md. Tries to run something and asks "where do I start?" |
+| **Emotions** | Curious then disoriented (neutral → negative). Many skills, no obvious first action. |
+| **Pains** | "I installed the pack but nothing changed." "I don't understand the vocabulary — Brief vs Spec vs Project." "Skills are documented individually; I can't see how they connect." |
+| **Opportunities** | A session-start path that makes the first action obvious. A vocabulary page that maps to the tracker terms the team already uses. |
+
+> **With M1.5** — `check-workspace` ships: first action becomes `check-workspace`; it orients from `workspace.toml` and surfaces the next item without reading any other file.
+
+---
+
+## Stage 2: Shape Work
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Uses `frame-intent` and `de-risk-intent` to scope an initiative. Produces framing artifacts in-session. Tries to figure out when shaping is done enough to write a brief. |
+| **Emotions** | Engaged but uncertain (neutral). Output lives in session context, not the repo. |
+| **Pains** | "My shaping output doesn't survive the session." "I don't know when shaping is done enough to graduate to a brief." "I have no artifact I can hand to someone else." |
+| **Opportunities** | Committed shaping artifacts in `docs/product/shaping/` with a visible graduation criterion (Outcome + Appetite + ≥1 Rabbit hole = ready to brief). |
+
+> **With M2** — `frame-situation`, `place-bet`, `map-capabilities` ship: skills write committed artifacts to `docs/product/shaping/`; `[shaping_queue]` items move through the six-step sequence with write-back; graduation criterion: `author-brief` creates the brief from the bet + capability map and writes to `[brief_queue].draft`.
+
+---
+
+## Stage 3: Brief & Queue
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Receives a brief externally (email, Linear Issue, verbal). Manually reformats it into the brief template. Runs `receive-brief` to decompose into specs. Tracks which spec is next in their head. |
+| **Emotions** | Frustrated (negative). Conversion is manual. DoR criteria are not signposted. Post-decomposition specs are not in any queue. |
+| **Pains** | "I have a brief in my inbox but have to manually reformat it." "I don't know which DoR fields are mandatory for Ready." "After decomposition my specs exist but aren't in any queue." "If someone else picks this up in a new session, they won't know where I left off." |
+| **Opportunities** | `author-brief` elicits DoR fields interactively and queues the brief. `receive-brief` writes specs into `[work].queue`. Visible DoR checklist on the brief template. |
+
+> **With M1** — `author-brief` + `receive-brief` extension ship: external input → DoR elicitation → brief file → `[brief_queue].draft` in one skill invocation; `receive-brief` moves brief to ready and writes specs into `[work].queue`.
+
+---
+
+## Stage 4: Execute & Ship
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Picks up a spec (from memory or re-reading the brief). Runs `work-loop`. Completes the spec. Submits PR. Asks "what is next?" by re-reading. |
+| **Emotions** | Satisfied then adrift (positive → neutral). Spec shipped cleanly but post-ship orientation is manual. |
+| **Pains** | "After the spec ships I don't know what's next without re-reading the brief." "Brief coverage doesn't update when I ship." "`roadmap.md` needs updating but nothing surfaces that." "No explicit DAG — I decide priority on the fly." |
+| **Opportunities** | Post-ship automation: spec marked shipped in `workspace.toml`, next ready item surfaced, `roadmap.md` update prompted. DAG makes priority explicit. |
+
+> **With M1.7** — `work-loop` extension ships: on ship, moves spec `active → shipped` in `workspace.toml`; surfaces next ready item from the DAG; prompts `roadmap.md` update (edit goes through a PR per CONVENTIONS — not auto-written).
+
+---
+
+## Stage 5: Session Continuity
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Session ends. New session — next day, a colleague, or a new agent. Reads RFC, roadmap, briefs directory to re-orient. Resumes. |
+| **Emotions** | Anxious then uncertain (negative). Re-reading four files takes time and still leaves gaps. |
+| **Pains** | "I have to read four files to know where I am — and still feel uncertain." "A blocked item shows up but I don't know which dep is the blocker." "An agent starting fresh has no context about mid-session decisions." |
+| **Opportunities** | `check-workspace` as the single cold-start command. Reads `workspace.toml` from the local working directory — consistent on any branch after M1 Batch 2 (file lives on `main`). Rich blocked-reason explanations. |
+
+> **With M1.5** — `check-workspace` ships: one command surfaces active initiative, queued specs, DAG state, blocked reasons. Reads `workspace.toml` from the local working directory (file lives on `main`; always present after M1 Batch 2).
+
+---
+
+## Frontstage actions
+
+- **Action:** install-agentbundle
+- **Action:** read-agents-md
+- **Action:** run-frame-intent
+- **Action:** run-de-risk-intent
+- **Action:** receive-external-brief
+- **Action:** run-author-brief
+- **Action:** run-receive-brief
+- **Action:** pick-spec-from-queue
+- **Action:** run-work-loop
+- **Action:** submit-pr
+- **Action:** run-check-workspace
+- **Action:** resume-from-session-start
+
+---
+
+## Emotional arc
+
+Lowest point: **Stage 3 (Brief & Queue)** — frustrated — because the gap between an external brief and a queued, system-readable work item is entirely manual. Every field requires translation and the result is not connected to anything the system can orient from.
+
+Highest-opportunity pain: "I have a brief in my inbox but I have to manually reformat it, decompose it, and track it in my head — the system doesn't hold any of it for me."
+
+Primary design response: `author-brief` (M1) closes the creation gap. `receive-brief` extension (M1.8) closes the queue write-back gap. Together they make brief intake a one-skill operation that ends with the queue updated.
+
+---
+
+## Handoff notes
+
+**For `map-screen-flow`:** Stage 3 (Brief & Queue) and Stage 5 (Session Continuity) carry the highest-opportunity pains. The `author-brief` flow (external input → DoR elicitation → queue write) and the `check-workspace` output view are the highest-priority screen-level inputs for any future web surface.
+
+**For `blueprint-service`:** backstage dependencies include `workspace.toml` on `main` (skills edit locally and commit in the same spec PR per the resolved write protocol — RFC-0064 Known Unknowns), `docs/product/briefs/` (brief file store), `docs/product/shaping/` (shaping artifact store), agentbundle skill loader.

--- a/docs/product/journeys/engineer-runs-work-loop.md
+++ b/docs/product/journeys/engineer-runs-work-loop.md
@@ -193,14 +193,14 @@ sequenceDiagram
 
 ## Frontstage actions
 
-- **Action:** run-check-workspace
-- **Action:** run-work-loop
-- **Action:** review-plan
-- **Action:** approve-plan
-- **Action:** handle-gate-failure
-- **Action:** review-final-diff
-- **Action:** approve-pr-submission
-- **Action:** check-workspace-exit-state
+- **Skill:** run-check-workspace
+- **Skill:** run-work-loop
+- **Skill:** review-plan
+- **Skill:** approve-plan
+- **Skill:** handle-gate-failure
+- **Skill:** review-final-diff
+- **Skill:** approve-pr-submission
+- **Skill:** check-workspace-exit-state
 
 ---
 

--- a/docs/product/journeys/engineer-runs-work-loop.md
+++ b/docs/product/journeys/engineer-runs-work-loop.md
@@ -1,0 +1,238 @@
+---
+type: customer-journey
+slug: engineer-runs-work-loop
+persona: engineer-implementer
+outcome: spec-executed-and-shipped-with-human-in-the-loop
+surface: cross-platform
+status: planned
+initiative_links:
+  - id: INI-002
+    name: Platform Core
+    milestones: M1 (primary — work-loop workspace integration M1.7); M2–M6 (ongoing improvements)
+    role: primary
+updated: 2026-07-18
+---
+
+# Journey: Engineer runs the work-loop
+
+**Persona:** A software engineer who uses the `work-loop` skill day-to-day to implement specs. They may or may not be on the RFC path — this journey covers anyone running the core build cycle: plan → build → verify → review. In smaller orgs this is the same person as the product engineer; in larger orgs it is a distinct implementer role. They are always in the loop — reviewing plans, handling gate failures, making judgment calls — unlike the agent-executes-spec journey where execution is headless.
+
+**Outcome:** The spec is shipped. A PR is submitted and passing gates. The spec is marked done. The engineer knows exactly what to pick up next.
+
+**Surface:** cross-platform — CLI/terminal. The engineer invokes skills; the agent handles the structured work under the engineer's direction.
+
+**Trigger:** Engineer wants to pick up a unit of work — from a GitHub issue, a Linear ticket, a brief, a team discussion, or from `check-workspace` surfacing the next ready spec.
+
+**End state:** Spec in `[work].shipped` (or equivalent for non-initiative work). PR submitted and passing. Next item surfaced. Engineer exits with a clear picture of what comes next.
+
+---
+
+## Prerequisites
+
+| Pack | Scope | Status | Provides |
+|---|---|---|---|
+| core | repo | current | `work-loop`, `new-spec`, `check-workspace` (M1.5+) |
+
+**One-time setup:**
+1. Install core pack at repo scope.
+2. For initiative work (M1.5+): `workspace.toml` must be committed to `main` (M1 Batch 2); no branch configuration needed — `check-workspace` reads it from the local working directory.
+
+**Scale:** this journey is the same at all team sizes. At scale, `check-workspace` surfaces parallel candidates so multiple engineers can pick different specs without collision — no additional packs needed.
+
+---
+
+## Interaction model
+
+### Current state — before M1.5 / M1.7
+
+```mermaid
+sequenceDiagram
+    participant E as Engineer
+    participant A as Agent
+    participant WL as work-loop skill
+    participant R as Repo (branch)
+
+    Note over E,R: Before M1 — work-loop with no initiative context
+    E->>A: I want to work on [spec-slug]
+    A->>WL: work-loop [spec-slug]
+    Note over WL: Reads spec file
+    Note over WL: Writes plan inline
+    E->>A: Review plan (back-and-forth)
+    A->>WL: Execute tasks
+    Note over WL: plan → build → verify → review
+    A->>R: Submit PR
+    E-->>E: PR submitted — now what?
+    E->>A: What should I work on next?
+    A->>R: Read RFC, roadmap, briefs/ (manual re-orient)
+    A-->>E: [best guess at next item]
+    Note over E: No committed queue; next item is inferred
+```
+
+### To-be state — M1.7 shipped (initiative work)
+
+```mermaid
+sequenceDiagram
+    participant E as Engineer
+    participant SK as Skills
+    participant WS as workspace.toml
+    participant WL as work-loop (M1.7 extended)
+    participant R as Repo (spec branch)
+
+    Note over E,R: M1.5+ — orient first
+    E->>SK: check-workspace
+    SK->>WS: Read queues, resolve DAG
+    WS-->>E: Active: spec/m1-work-loop (ready) · spec/m1-receive-brief (blocked: brief-template)
+    E->>WL: work-loop spec/m1-work-loop
+
+    Note over WL,WS: work-loop step 0 — context from workspace
+    WL->>WS: Read workspace.toml (initiative, milestone, spec-context)
+    WL-->>E: Context loaded — ready to plan
+
+    Note over E,R: Plan gate — human reviews and approves
+    WL-->>E: Here is the proposed plan
+    E->>WL: Looks good / adjust this task
+    WL-->>E: Plan accepted — beginning build
+
+    Note over E,R: Build + verify
+    WL->>R: Implement tasks
+    WL-->>E: Gate: lint passing · tests 2 failing
+    E->>WL: The test failure is an env issue — here's the fix
+    WL->>R: Fix + re-run gates — passing
+
+    Note over E,R: Ship
+    WL->>R: Submit PR
+    WL->>WS: spec/m1-work-loop: active → shipped
+    WL-->>E: Shipped · next ready: spec/m1-receive-brief · Update roadmap.md?
+```
+
+---
+
+## Stage 1: Orient — What Should I Work On?
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Decides what to work on from memory, a Linear ticket, a GitHub issue, or a message from a teammate. May read the RFC or roadmap to orient. Knows roughly what's next but has no structured queue. |
+| **Emotions** | Confident but contextually thin (neutral). The engineer knows what they need to do but their orientation is brittle — it depends on memory of the last session and on no one else having claimed the same spec. |
+| **Pains** | "I have to remember where I left off." "I don't know if someone else has started the spec I want." "The roadmap and RFC aren't structured enough to answer 'what's next in priority order with no dependencies blocked'." "If I've been away for a few days, re-orientation takes 10 minutes of reading." |
+| **Opportunities** | `check-workspace` as a single command that surfaces the active initiative, ready specs in DAG order, blocked reasons, and parallel candidates — and that answers "is this spec already claimed?" |
+
+> **With M1.5** — `check-workspace` ships: orientation in one command; DAG-resolved queue shows ready vs. blocked; parallel candidates visible for swarm dispatch.
+
+---
+
+## Stage 2: Start the Work-Loop
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Runs `work-loop [spec-slug]`. The skill reads the spec file and produces a plan. The engineer is already in the right context — they just typed it. |
+| **Emotions** | Immediately productive (positive). The work-loop is already the right tool. |
+| **Pains** | "work-loop doesn't know which initiative or milestone this spec belongs to." "The plan doesn't include workspace context — it just reads the spec file in isolation." "If the spec has dependencies I don't know about, work-loop doesn't surface them." |
+| **Opportunities** | `work-loop` at step 0 reads `workspace.toml` to load initiative context — the plan is now contextualised against the milestone, other active specs, and DAG constraints. |
+
+> **With M1.7** — `work-loop` reads `workspace.toml` at step 0; plan is contextualised against initiative milestone and DAG state; dependency violations surfaced before build begins.
+
+---
+
+## Stage 3: Plan Review
+
+### Now (unchanged — work-loop already handles this as a human gate)
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Reads the proposed plan. Pushes back on tasks that are out of scope, too large, or sequenced wrong. Approves the plan and signals build start. |
+| **Emotions** | Engaged (positive). The plan gate is already a strong interaction point — the engineer is visibly in control of what the agent builds. |
+| **Pains** | "Some plan tasks reference functions or APIs that don't exist — the agent assumed they were there." "The plan sometimes decomposes the spec more finely than I want, leading to unnecessary back-and-forth." "No structured way to approve a partial plan (approve tasks 1–3, defer task 4 to a follow-on)." |
+| **Opportunities** | API verification at plan time (grep before proposing a task that imports a function); partial-plan approval; task-level deferral notation. These are work-loop improvements, not M1 scope — they go to the post-M1 work-loop backlog. |
+
+---
+
+## Stage 4: Build and Gate Navigation
+
+### Now (unchanged — work-loop already handles build; human handles gate failures)
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Monitors build progress. Intervenes on gate failures — reads the error, identifies the cause, provides the corrective direction. For complex failures, takes over temporarily and hands back. |
+| **Emotions** | Actively engaged on gate failures (positive when they catch something real; frustrated when failures are environment-specific noise). |
+| **Pains** | "Gate failures are often false positives — flaky tests, CI environment differences, test-order sensitivity." "The agent retries the same approach on a failing gate before trying something new." "Traceability lint error messages don't point to the specific missing marker — I have to grep for it myself." |
+| **Opportunities** | Gate failure diagnostics that distinguish between real failures (broken code) and environment noise (flaky test, missing dep, wrong branch). Traceability lint errors that name the missing marker and the file line. These are post-M1 backlog items. |
+
+---
+
+## Stage 5: Ship and Hand Off
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Reviews the final diff before PR submission. Approves PR creation. Realises workspace.toml has not been updated — does it manually, or skips it because it's not yet wired. |
+| **Emotions** | Relieved but incomplete (positive → neutral). The spec is shipped but the queue doesn't reflect it. The engineer has to remember to update things. |
+| **Pains** | "The PR is submitted but nothing tells the next person (or agent) this spec is done." "`workspace.toml` isn't updated — I have to do it manually if I remember." "No prompt to update `roadmap.md` — I always forget, and it drifts." "I don't know what to pick up next without re-reading the RFC." |
+| **Opportunities** | Post-ship automation: work-loop marks spec active → shipped in `workspace.toml`; surfaces next ready item; prompts `roadmap.md` update. The engineer ends the session knowing exactly what comes next. |
+
+> **With M1.7** — work-loop moves spec to shipped on PR creation; next ready item surfaced; `roadmap.md` update prompted. Engineer exits with committed state visible to the next person or agent.
+
+---
+
+## Stage 6: Non-Initiative Work (no workspace.toml)
+
+### Now and to-be (this path unchanged)
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Engineer has a task that's not part of an initiative — a one-off bug fix, a quick feature, a housekeeping task. Runs `work-loop [description]` directly. No `workspace.toml` involved. |
+| **Emotions** | Comfortable (positive). This path is already clean — work-loop is designed to handle it. |
+| **Pains** | "Nothing changes here. work-loop works fine for non-initiative work. The only missing piece is knowing whether a task should be in the queue versus an ad-hoc invocation — and check-workspace can help surface that distinction." |
+| **Opportunities** | `check-workspace` surfacing whether the task overlaps with a queued spec (preventing duplicate work); non-initiative tasks as a first-class concept (ad-hoc vs. queued). Post-M1 design question. |
+
+---
+
+## Frontstage actions
+
+- **Action:** run-check-workspace
+- **Action:** run-work-loop
+- **Action:** review-plan
+- **Action:** approve-plan
+- **Action:** handle-gate-failure
+- **Action:** review-final-diff
+- **Action:** approve-pr-submission
+- **Action:** check-workspace-exit-state
+
+---
+
+## Emotional arc
+
+Highest point: **Stage 3 (Plan Review)** — engaged — the engineer is visibly in control and the agent is doing the structured work under their direction. This gate is already working well.
+
+Lowest point: **Stage 5 (Ship and Hand Off)** — incomplete — the spec is done but the system doesn't reflect it. The engineer has to manually update state, and they often don't. This is the friction that breaks coordination across sessions and across engineers.
+
+Highest-opportunity pain: "I shipped the spec. But the next person who opens the repo doesn't know that. The roadmap doesn't know. The queue doesn't know. I have to remember to tell everything, and I usually don't."
+
+Primary design response: M1.7 post-ship automation — work-loop marks shipped, surfaces next, prompts roadmap update. The engineer's last action becomes the system's source of truth automatically.
+
+---
+
+## How this journey changes with M1
+
+The core `work-loop` experience — plan gate, build, gate navigation, PR — is **unchanged**. M1 adds two integration points that change the start and end of the session:
+
+| Session point | Before M1 | After M1.7 |
+|---|---|---|
+| **Start — orient** | Read RFC, roadmap, briefs manually (10+ min) | `check-workspace` → oriented in one command |
+| **Start — work-loop step 0** | Reads spec file in isolation | Reads spec file + workspace.toml initiative context |
+| **End — mark shipped** | Manual (often skipped) | Automatic on PR creation |
+| **End — what's next** | Inferred from memory or re-reading | Surfaced by work-loop post-ship |
+
+Everything in between (Stage 3 plan review, Stage 4 build and gate navigation) is unaffected.
+
+---
+
+## Handoff notes
+
+**For `agent-executes-spec` journey:** that journey covers the same stages from the agent's perspective — no human in the loop. The failure modes are different (the agent can't make judgment calls on gate failures; the human can), but the infrastructure changes (M1.5, M1.7) are identical. The two journeys share the same before/after at Stages 1, 2, and 5; they diverge at Stages 3 and 4.
+
+**For INI-003:** headless dispatch (agent-executes-spec) is a specialised variant of this journey with the human loop removed and an adapter layer added between Orient and work-loop. The core work-loop stages (3, 4) are identical.

--- a/docs/product/journeys/engineer-scales-to-swarm.md
+++ b/docs/product/journeys/engineer-scales-to-swarm.md
@@ -186,16 +186,16 @@ sequenceDiagram
 
 ## Frontstage actions
 
-- **Action:** install-ini-003-adapter-pack
-- **Action:** configure-adapter-per-harness
-- **Action:** verify-skill-loading-dry-run
-- **Action:** trigger-dispatch-job
-- **Action:** claim-spec-atomically
-- **Action:** execute-work-loop-headless
-- **Action:** write-completion-to-workspace
-- **Action:** run-check-workspace-as-supervisor
-- **Action:** detect-stalled-spec
-- **Action:** reassign-spec-to-new-agent
+- **Skill:** install-ini-003-adapter-pack
+- **Skill:** configure-adapter-per-harness
+- **Skill:** verify-skill-loading-dry-run
+- **Skill:** trigger-dispatch-job
+- **Skill:** claim-spec-atomically
+- **Skill:** execute-work-loop-headless
+- **Skill:** write-completion-to-workspace
+- **Skill:** run-check-workspace-as-supervisor
+- **Skill:** detect-stalled-spec
+- **Skill:** reassign-spec-to-new-agent
 
 ---
 

--- a/docs/product/journeys/engineer-scales-to-swarm.md
+++ b/docs/product/journeys/engineer-scales-to-swarm.md
@@ -1,0 +1,225 @@
+---
+type: customer-journey
+slug: engineer-scales-to-swarm
+persona: engineering-team-scaling-to-swarm
+outcome: run-coordinated-headless-cli-agent-swarm
+surface: cross-platform
+status: shaping
+initiative_links:
+  - id: INI-003
+    name: Coding CLI Adapter Pack
+    milestones: M1+
+    role: primary
+  - id: INI-002
+    name: Platform Core
+    milestones: M1
+    role: prerequisite
+updated: 2026-07-18
+---
+
+# Journey: Engineer scales to coordinated agent swarm
+
+**Persona:** An engineering team that has INI-002 M1 installed — `workspace.toml` is their session-start artifact, briefs flow through the queue, work-loop is their execution pattern. They want to scale from 1–2 manually dispatched agent sessions to N headless CLI agents running in CI/CD, each claiming specs from the queue and executing without collision.
+
+**Outcome:** A CI/CD job dispatches N headless CLI agents. Each reads `workspace.toml`, claims an unblocked spec, executes via work-loop, marks it shipped, and exits. The team lead monitors via `check-workspace` and only intervenes when a spec stalls or fails. Throughput scales with agents, not with engineers watching.
+
+**Surface:** cross-platform — CI/CD pipelines and CLI invocation across multiple harnesses (Claude Code `-p`, Codex CLI, Kiro CLI, GitHub Copilot CLI, Gemini CLI).
+
+**Trigger:** INI-002 M1 ships — `workspace.toml` schema is the stable contract. The team has more ready specs than engineers to manually dispatch.
+
+**End state:** The queue drains autonomously. Blocked specs stay blocked. Stalled specs surface to the team lead within a threshold. The team's time shifts from dispatch and monitoring to brief authoring and exception review.
+
+---
+
+## Prerequisites
+
+| Pack | Scope | Status | Provides |
+|---|---|---|---|
+| core | repo | current | `check-workspace`, `work-loop`, `new-spec` |
+| coding CLI adapter pack | user | planned (INI-003) | Harness-specific invocation, atomic claiming, write-back; one adapter per harness type (Claude Code, Codex CLI, Kiro, etc.) |
+
+**One-time setup:**
+1. Install core pack at repo scope.
+2. Install the adapter pack for each harness in the swarm at user scope (when INI-003 ships). Mixed-harness swarms need one adapter per harness type — adapters come in different shapes.
+3. `workspace.toml` must be committed to `main` and pre-populated (M1 Batch 2); no branch configuration needed — headless agents read it from the local working directory.
+4. Atomic claiming protocol configured via adapter — prevents two agents picking the same spec; exact mechanism is adapter-specific and is an open design question for the INI-003 sub-RFC.
+
+**Scale:** adapters are the scaling surface. A Claude Code swarm uses one adapter shape; a Codex CLI swarm uses another; a mixed swarm needs both. Core skills (`work-loop`, `check-workspace`) are identical across adapter shapes.
+
+---
+
+## Interaction model
+
+### Current state — INI-002 M1, no swarm adapter
+
+```mermaid
+sequenceDiagram
+    participant H as Engineer
+    participant A1 as Agent 1
+    participant A2 as Agent 2
+    participant WS as workspace.toml
+
+    Note over H,WS: Manual dispatch today
+    H->>A1: Work on spec-A (verbal or in-session instruction)
+    H->>A2: Work on spec-B (verbal or in-session instruction)
+    Note over A1,A2: No collision detection — possible overlap
+    A1-->>WS: (update if remembered — manual)
+    A2-->>WS: (update if remembered — manual)
+    H-->>H: Tracks progress in head or separate doc
+
+    Note over H,WS: Session ends — context lost
+    Note over A1: Session closes — partial work not captured
+    H->>WS: Manually reconcile workspace.toml with what shipped
+```
+
+### To-be state — INI-003 M1 shipped
+
+```mermaid
+sequenceDiagram
+    participant H as Supervisor
+    participant AD as Adapter layer (INI-003)
+    participant A1 as Agent 1 (headless)
+    participant A2 as Agent 2 (headless)
+    participant WS as workspace.toml
+
+    Note over H,WS: Swarm dispatch (INI-003 M1+)
+    H->>AD: Dispatch N agents
+    AD->>WS: check-workspace — find ready specs and DAG state
+    WS-->>AD: spec-A ready · spec-B ready · spec-C blocked (needs spec-A)
+    AD->>WS: Atomic claim: active += {spec-A, agent: A1}
+    AD->>WS: Atomic claim: active += {spec-B, agent: A2}
+    AD->>A1: claude -p "work on spec-A"
+    AD->>A2: codex "work on spec-B"
+
+    Note over A1,WS: Agent 1 executes
+    A1->>WS: Read workspace.toml — confirm spec-A context
+    Note over A1: work-loop: plan → build → verify → review
+    A1->>WS: spec-A: active → shipped
+
+    Note over AD,WS: spec-C unblocks after spec-A ships
+    AD->>WS: check-workspace — spec-C now ready
+    AD->>A1: Dispatch spec-C to idle Agent 1
+
+    Note over H,WS: Exception — Agent 2 stalls
+    Note over A2: Session timeout · spec-B still in active
+    H->>WS: check-workspace — spec-B stale (active, no progress N min)
+    H->>WS: Move spec-B: active → queue (manual reassign)
+    AD->>A2: Re-dispatch fresh agent for spec-B
+```
+
+---
+
+## Stage 1: Adapter Setup
+
+### Now (INI-002 M1, no adapter)
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Wants to run headless agents but has no adapter. Each agent is dispatched manually with a bespoke prompt. Skill loading must be verified per harness by trial and error. |
+| **Emotions** | Determined but frustrated (neutral → negative). Each harness is its own setup problem. |
+| **Pains** | "Skill discovery path differs by harness — `.claude/` for Claude Code, `.kiro/` for Kiro, different for Codex. I verify each separately." "MCP-capable harnesses need registered tool definitions; others need static `.md` files. I don't know which without reading adapter source." "No dry-run mode — I can only verify adapter wiring by running a real job." |
+| **Opportunities** | An adapter capability matrix: one row per harness, columns for skill-discovery path, tool surface (MCP vs static), context window, known quirks. A dry-run mode that verifies skill loading and workspace resolution without executing any spec work. |
+
+> **With INI-003 M1** — adapter pack ships: capability matrix is a first-class deliverable; dry-run mode validates harness wiring before first live dispatch.
+
+---
+
+## Stage 2: First Dispatch
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Manually triggers N agent sessions. Each told verbally which spec to work on. No coordination layer. |
+| **Emotions** | Anxious (negative). No way to know if two agents claim the same spec until one comes back with a conflict or duplicate work. |
+| **Pains** | "Two agents might both pick up the same spec — nothing prevents it." "I don't know which spec each agent claimed until I read their output." "Agents need repo read credentials in CI — credential management is undefined." "If the queue has one ready spec and three agents, two agents need to exit cleanly — currently undefined." |
+| **Opportunities** | Atomic spec-claiming protocol: claim = move spec from `queue` to `active` with agent identity tag in one commit; second agent reads the updated file and sees it is taken. Clear credential contract for CI reads of `workspace.toml` on `main`. Agent idle-and-exit behaviour when no ready spec is available. |
+
+> **With INI-003 M1** — atomic claim protocol defined in adapter contract; agent identity written to `[work].active` entries; CI credential requirements documented; idle-and-exit behaviour specified.
+
+---
+
+## Stage 3: Parallel Execution
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Agents execute in parallel. Each does its work, submits PR. Updates to `workspace.toml` happen if the engineer remembers after the session. |
+| **Emotions** | Satisfied at throughput (positive) but uncertain about coordination (neutral). |
+| **Pains** | "The queue shrinks but I can't tell which agent shipped which spec." "DAG is display-only — an agent could pick a blocked spec." "If an agent times out mid-spec, the spec stays in `active` with no stale detection." "Gate outcomes are in each agent's logs, not in `workspace.toml`." |
+| **Opportunities** | Agent identity on `[work].active` entries. Enforced DAG: adapter reads check-workspace output before claiming, only claims ready items. Stale-active detection: spec in `active` with no commit activity for N minutes flagged. Gate outcome summary written to `workspace.toml` on ship. |
+
+> **With INI-003 M1** — agent identity on active entries; adapter enforces DAG at claim time; stale-active threshold configurable; gate outcome summary on ship.
+
+---
+
+## Stage 4: Coordination & Handoff
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | A spec ships. Its dependents are now unblocked. The team lead manually checks and re-dispatches. Cross-queue unblocking (work ships → shaping item unblocks) is invisible. |
+| **Emotions** | Uncertain (neutral). Coordination requires constant manual checking. |
+| **Pains** | "A newly unblocked spec doesn't get picked up automatically — agents have finished and someone has to trigger a new dispatch." "Cross-queue unblocking is invisible without explicitly running check-workspace." "No event signal when DAG state changes." "Mixed human + headless agent concurrency on the same workspace.toml is undefined — a human running work-loop and a headless agent could conflict." |
+| **Opportunities** | Dispatcher re-evaluates DAG on each ship event and triggers fresh agents for newly unblocked specs. Cross-queue DAG visibility in a single check-workspace call. Protocol for mixed human + agent concurrency. |
+
+> **To-be state not yet fully shaped.** DAG-reactive dispatch feeds INI-005 (telemetry events) and INI-006 (dispatch UI). Mixed-concurrency protocol is a Known Unknown for the INI-003 sub-RFC.
+
+---
+
+## Stage 5: Exception & Recovery
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | An agent stalls. Team lead finds out by chance or periodic manual check. Manually edits `workspace.toml` to move spec back to queue. Re-dispatches. |
+| **Emotions** | Concerned then relieved (negative → neutral). Recovery works but is lossy and manual. |
+| **Pains** | "check-workspace shows active specs but not how long they have been active." "Recovery requires manually editing workspace.toml — there is no reassign skill." "The new agent starts the spec from scratch — no handoff from the stalled agent." "If the stalled agent committed bad decisions, the next agent builds on a corrupted state." |
+| **Opportunities** | Stale-active detection with configurable threshold. A `reassign-spec` skill: moves spec active → queue, optionally captures handoff note. Partial-progress capture committed by work-loop at each gate — readable by next agent. |
+
+> **To-be state not yet shaped.** Stale-active detection and partial-progress capture are direct INI-005 (state persistence) requirements surfaced here. Exception surfacing feeds INI-006 (control plane). Feeds the INI-003 sub-RFC as explicit open design questions.
+
+---
+
+## Frontstage actions
+
+- **Action:** install-ini-003-adapter-pack
+- **Action:** configure-adapter-per-harness
+- **Action:** verify-skill-loading-dry-run
+- **Action:** trigger-dispatch-job
+- **Action:** claim-spec-atomically
+- **Action:** execute-work-loop-headless
+- **Action:** write-completion-to-workspace
+- **Action:** run-check-workspace-as-supervisor
+- **Action:** detect-stalled-spec
+- **Action:** reassign-spec-to-new-agent
+
+---
+
+## Emotional arc
+
+Lowest point: **Stage 5 (Exception & Recovery)** — concerned — because a stalled agent is invisible until someone manually checks, recovery is lossy (partial work not preserved), and the next agent starts cold with no context from the previous one.
+
+Highest-opportunity pain: "An agent stalled mid-spec and I only found out by chance. When I reassigned it, the new agent started from scratch and may have made conflicting decisions."
+
+Primary design response: stale-active detection (INI-003 M1), `reassign-spec` skill (INI-003 M1), partial-progress capture (INI-005). The exception surface (INI-006) is where the team lead receives the alert without polling.
+
+---
+
+## Open design questions (feeds INI-003 sub-RFC)
+
+- **Atomic claiming over git:** `workspace.toml` is a git-committed file. Two agents claiming simultaneously could produce a merge conflict on the active list. What is the atomic claim protocol — optimistic locking with retry, a claim lock file, or a sidecar claim registry?
+- **Mixed human + headless concurrency:** what prevents a human running `work-loop` interactively and a headless agent picking the same spec from `[work].active`?
+- **Stale-active threshold:** what is the right default N for stale detection — 30 minutes, 2 hours? Is it per-spec or per-project?
+- **Partial-progress capture format:** what does a work-loop gate-boundary handoff artifact look like? Where does it live — `workspace.toml` inline, a sidecar file, or a branch-committed note?
+
+---
+
+## Handoff notes
+
+**For `map-screen-flow`:** Stage 2 (First Dispatch) and Stage 5 (Exception & Recovery) carry the highest-opportunity pains. The supervisor's view of `check-workspace` output — showing agent identity on active items, stale-active flags, and DAG state — is the primary screen-level input for INI-006's control plane.
+
+**For `blueprint-service`:** backstage services include `workspace.toml` on `main` (atomic read/write for spec claiming per INI-003 sub-RFC), CI/CD dispatch trigger, per-harness adapter layer (skill loading, CLI invocation, output parsing), gate-outcome log capture. Atomic claiming and stale-active detection are unresolved backstage design decisions — both feed INI-005 (telemetry) and INI-006 (exception surfacing).

--- a/docs/product/journeys/pm-intakes-from-tracker.md
+++ b/docs/product/journeys/pm-intakes-from-tracker.md
@@ -1,0 +1,207 @@
+---
+type: customer-journey
+slug: pm-intakes-from-tracker
+persona: pm-tracker-user
+outcome: tracker-issue-becomes-queued-brief
+surface: cross-platform
+status: proposed
+initiative_links:
+  - id: INI-002
+    name: Platform Core
+    milestones: M5 (primary); M1 (prerequisite — brief_queue must exist)
+    role: primary
+updated: 2026-07-18
+---
+
+# Journey: PM intakes work from tracker
+
+**Persona:** A PM who lives in Linear, Jira, or GitHub Issues. They create and manage issues in their tracker of choice and need them to flow into the platform's brief queue without manual reformatting. They are not primarily a terminal user — they think in tracker terms (Linear Issue, Jira Story, Epic, Sprint) and want the platform to speak their language, not the other way around.
+
+**Outcome:** An issue or story in the PM's tracker of choice becomes a DoR-compliant brief in `[brief_queue].draft`, with all fields populated and the tracker issue linked bidirectionally. When the spec ships, the tracker issue closes automatically via PR convention. The PM never needs to leave their tracker to manage the brief lifecycle.
+
+**Surface:** cross-platform — tracker UI → CLI intake skill → `workspace.toml`.
+
+**Trigger:** PM marks an issue as ready for engineering work in their tracker, or reaches a sprint/cycle planning session where issues need to become specs.
+
+**End state:** Brief in `[brief_queue].ready` (passed DoR gate), linked back to tracker issue via `Epic:` field. When the spec ships: "Fixes LIN-123" / "Closes #456" in the PR body auto-closes the tracker issue.
+
+---
+
+## Prerequisites
+
+| Pack | Scope | Status | Provides |
+|---|---|---|---|
+| core | repo | M1 required | Brief template (M1 Batch 4), `receive-brief`, `[brief_queue]` schema; `github-brief-intake` (M5 first delivery, ships before linear pack) |
+| linear pack | user | planned (M5) | `linear-brief-intake`; requires Linear API key at user scope (per personal Linear account) |
+| atlassian pack | user | planned (M5) | `jira-align-brief-intake`; requires Jira credentials at user scope; org-specific field mapping configured per repo |
+
+**One-time setup:**
+1. Install core pack at repo scope — brief template and `[brief_queue]` must be in place before any intake skill writes to the queue.
+2. For Linear: install linear pack at user scope + configure Linear API key in credential broker.
+3. For Jira Align: install atlassian pack at user scope + configure Jira credentials + set configuration-guided field mapping for org-specific workflow states and PI cadences.
+4. `workspace.toml` must be committed to `main` (M1 Batch 2 of the target repo) — no branch configuration needed; brief queue writes commit with the intake skill PR.
+
+**Scale:** tracker packs are always user-scoped (personal credentials). The brief queue they write to is repo-scoped. Multiple PMs with different tracker accounts can all write to the same repo's brief queue — pack install is per-person, queue is per-repo.
+
+---
+
+## Interaction model
+
+### Current state — before M5
+
+```mermaid
+sequenceDiagram
+    participant PM as PM
+    participant TR as Tracker (Linear / Jira / GitHub)
+    participant A as Agent
+    participant F as Repo files
+
+    Note over PM,F: Tracker-to-brief today — manual
+    PM->>TR: Create issue with title + description
+    TR-->>PM: Issue created (LIN-123)
+    PM->>F: Open brief template manually
+    PM->>A: Help me reformat this Linear issue as a brief
+    A-->>PM: [reformatted content]
+    PM->>F: Write docs/product/briefs/slug.md (copy-paste)
+    PM->>A: Run receive-brief
+    Note over PM: Tracker issue and brief immediately drift
+    Note over PM: No link back — PM must manually close issue on ship
+```
+
+### To-be state — M5 shipped
+
+```mermaid
+sequenceDiagram
+    participant PM as PM
+    participant TR as Tracker (Linear / Jira / GitHub)
+    participant LBI as linear-brief-intake
+    participant LBS as linear-brief-sync
+    participant WS as workspace.toml
+    participant PR as Pull Request
+
+    Note over PM,WS: Intake — M5+
+    PM->>TR: Create issue (LIN-123)
+    PM->>LBI: linear-brief-intake LIN-123
+    LBI->>TR: Fetch issue metadata
+    TR-->>LBI: Issue data
+    LBI-->>PM: Appetite? [label not set] · Any Rabbit holes?
+    PM->>LBI: Appetite: 2 weeks · Rabbit hole: auth edge case
+    LBI->>WS: [brief_queue].draft += briefs/lin-123.md · Epic: LIN-123
+    LBI-->>PM: Brief queued
+
+    Note over PM,TR: Spec written · ACs pasted into LIN-123 for review
+    PM->>TR: Paste ACs into story description
+
+    Note over TR,WS: Review round — story updated by reviewers
+    TR-->>PM: Story fields updated
+    PM->>LBS: linear-brief-sync LIN-123
+    LBS->>TR: Re-fetch LIN-123
+    TR-->>LBS: Updated fields
+    LBS-->>PM: Delta: title changed · scope note added · apply?
+    PM->>LBS: Approve delta
+    LBS->>WS: Update briefs/lin-123.md with approved changes
+
+    Note over WS: Brief moves to Executing → sync locked
+    WS-->>LBS: Status: Executing · updates refused
+
+    Note over PR,TR: On spec ship
+    PR->>TR: Fixes LIN-123 in PR body → issue auto-closes
+```
+
+---
+
+## Stage 1: Issue Authoring (in Tracker)
+
+### Now (and to-be — tracker-side unchanged)
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Creates or updates an issue in Linear / Jira / GitHub. Writes a title, description, labels. Assigns to a milestone or sprint. |
+| **Emotions** | Natural and comfortable (positive). This is the PM's native environment. |
+| **Pains** | None at this stage — this is where the PM lives. |
+| **Opportunities** | None needed here — the PM should stay in their tracker. The platform adapts to the tracker, not the other way around. |
+
+---
+
+## Stage 2: Intake
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Opens the brief template in the repo. Copy-pastes the issue title and description. Reformats fields manually. Runs `receive-brief` to decompose. |
+| **Emotions** | Frustrated (negative). This is pure translation work — same content, different format, with no automation. |
+| **Pains** | "I've already written this in Linear — why am I writing it again?" "The template fields (Appetite, Rabbit holes, Instrumentation) don't map cleanly to Linear fields — I have to guess." "I lose context between the Linear issue and the brief the moment I close the window." "If the Linear issue is updated after I create the brief, the brief is immediately stale." |
+| **Opportunities** | `github-brief-intake` / `linear-brief-intake`: fetch issue metadata, map to brief fields, present a gap-fill prompt for DoR fields not in the tracker, and write the brief file in one invocation. |
+
+> **With M5 (github-brief-intake)** — ships first, independently: GitHub Issue → brief with `Epic:` pointer; DoR gap-fill prompt for Appetite, Rabbit holes, Instrumentation. Pattern established before Linear pack.
+>
+> **With M5 (linear-brief-intake)** — ships after linear-pack sub-RFC accepted: Linear Issue / Project → brief; same DoR gap-fill pattern; `Epic: LIN-123` recorded on brief.
+
+---
+
+## Stage 3: DoR Gap Fill
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Realises the tracker issue doesn't have an Appetite or Rabbit holes field. Adds them to the brief manually from memory. |
+| **Emotions** | Annoyed then resigned (negative → neutral). The DoR fields are valuable but require extra work that feels disconnected from how the PM normally thinks. |
+| **Pains** | "Appetite isn't a Jira field — I have to remember to add it every time." "Rabbit holes require me to think about what could go wrong, but the tracker issue was written before that conversation happened." "Different PMs fill in DoR fields differently — no consistency." |
+| **Opportunities** | Intake skill prompts specifically for missing DoR fields, with context from the tracker issue to make the prompts meaningful ("Based on this issue's scope, what is the Appetite? 1 week / 2 weeks / 1 month?"). DoR gap-fill becomes a lightweight conversation, not a blank-form exercise. |
+
+> **With M5** — intake skills prompt interactively for missing DoR fields using issue context; consistent DoR format enforced across all intake sources.
+
+---
+
+## Stage 4: Queue & Track
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Brief is written but not connected to the tracker issue. PM manually closes the tracker issue when the spec ships. Discovers a month later that the brief and issue have drifted. |
+| **Emotions** | Disconnected (neutral → negative). Two systems, neither authoritative, both incomplete. |
+| **Pains** | "My Linear issue and the brief are two separate things — they drift immediately." "I have to remember to close the Linear issue when the PR ships — it's a manual step that gets forgotten." "If someone updates the Linear issue, the brief doesn't update. If someone updates the brief, the Linear issue doesn't update." "I can't see brief queue status from Linear — I have to open the repo to check." |
+| **Opportunities** | `Epic:` field on brief links back to tracker; "Fixes LIN-123" in PR body auto-closes the issue on ship (write direction). Read direction is a PE-triggered delta re-sync (`linear-brief-sync`) — no webhook infrastructure (resolved: RFC-0064 Known Unknowns). Brief DoR status surfaced as a tracker label or comment if API permits. |
+
+> **With M5** — iterative delta model: (1) first intake via `linear-brief-intake`; (2) `receive-brief` → spec with ACs; (3) ACs pasted back into Linear story for review (manual; `push-acs-to-linear` is a sub-RFC stretch goal); (4) review changes story → `linear-brief-sync` re-fetches, presents delta for PM/PE approval, updates brief; (5) brief locks at `Status: Executing` — no further tracker updates flow in. PR body "Fixes LIN-123" closes story on ship. Zero infrastructure — all PE-triggered.
+
+---
+
+## Frontstage actions
+
+- **Action:** create-or-update-tracker-issue
+- **Action:** run-github-brief-intake
+- **Action:** run-linear-brief-intake
+- **Action:** run-jira-align-brief-intake
+- **Action:** answer-dor-gap-fill-prompts
+- **Action:** confirm-brief-queued
+- **Action:** verify-tracker-issue-closes-on-ship
+
+---
+
+## Emotional arc
+
+Lowest point: **Stage 2 (Intake)** — frustrated — because the PM has already done the work of writing the issue in the tracker and is now doing it a second time in a different format. This is pure translation labour with no added value.
+
+Highest-opportunity pain: "I've already written this in Linear. I shouldn't have to write it again. And once I have, it immediately falls out of sync."
+
+Primary design response: brief-intake skills that treat the tracker as the authoritative source, map its metadata to DoR fields, and interactively elicit only what is genuinely missing — reducing the PM's work from a full rewrite to answering 2–3 prompts.
+
+---
+
+## Open design questions (feeds M5 sub-RFC)
+
+- **Read direction (Linear → brief):** resolved as PE-triggered delta re-sync (no webhook, no running infrastructure). Sub-RFC governs: delta diff model details, AC export scope (`push-acs-to-linear` stretch goal), and field mapping between Linear fields and brief DoR fields.
+- **Jira field mapping:** `jira-align-brief-intake` requires configuration-guided field mapping for org-specific workflow state names and PI cadences. How is the mapping configured — a config file per org, a one-time elicitation, or a TOML section in `agentbundle-layout.toml [jira]`?
+- **Brief-to-tracker status push:** should brief `Status: Ready` be reflected as a tracker label or comment? Requires tracker write permissions and API rate-limit consideration.
+
+---
+
+## Handoff notes
+
+**For `map-screen-flow`:** Stage 2 (Intake) and Stage 4 (Queue & Track) carry the highest-opportunity pains. The intake flow (issue URL → DoR gap-fill → brief queued) and the tracker-linked brief status view are the highest-priority screen-level inputs for any future PM-facing surface.
+
+**For `blueprint-service`:** backstage services include tracker API (Linear / Jira / GitHub — read for intake, write for status push), `workspace.toml` brief queue, `docs/product/briefs/` (brief file store). The write-direction settlement (PR convention) and the read-direction open question (webhook vs. polling) are the primary backstage design decisions for the M5 sub-RFC.

--- a/docs/product/journeys/pm-intakes-from-tracker.md
+++ b/docs/product/journeys/pm-intakes-from-tracker.md
@@ -172,13 +172,13 @@ sequenceDiagram
 
 ## Frontstage actions
 
-- **Action:** create-or-update-tracker-issue
-- **Action:** run-github-brief-intake
-- **Action:** run-linear-brief-intake
-- **Action:** run-jira-align-brief-intake
-- **Action:** answer-dor-gap-fill-prompts
-- **Action:** confirm-brief-queued
-- **Action:** verify-tracker-issue-closes-on-ship
+- **Skill:** create-or-update-tracker-issue
+- **Skill:** run-github-brief-intake
+- **Skill:** run-linear-brief-intake
+- **Skill:** run-jira-align-brief-intake
+- **Skill:** answer-dor-gap-fill-prompts
+- **Skill:** confirm-brief-queued
+- **Skill:** verify-tracker-issue-closes-on-ship
 
 ---
 

--- a/docs/product/journeys/product-engineer-shapes-initiative.md
+++ b/docs/product/journeys/product-engineer-shapes-initiative.md
@@ -1,0 +1,247 @@
+---
+type: customer-journey
+slug: product-engineer-shapes-initiative
+persona: product-engineer
+outcome: shaped-brief-committed-and-queued
+surface: cross-platform
+status: proposed
+initiative_links:
+  - id: INI-002
+    name: Platform Core
+    milestones: M2 (primary); M1 (prerequisite — brief queue must exist)
+    role: primary
+updated: 2026-07-18
+---
+
+# Journey: Product engineer shapes an initiative
+
+**Persona:** A product engineer (or PM with technical depth) responsible for shaping an initiative — moving from a raw signal or strategic gap through the six-step sequence (Outcome → Problem → Diverge → Validate → Bet → Spec) to produce a shaped brief that can enter the build queue. In smaller orgs this is one person; in larger orgs this role is distinct from both the product strategist (altitude-0) and the engineer executing specs (build room).
+
+**Outcome:** A shaped brief — with Outcome, Appetite, Rabbit holes, and Instrumentation — committed to `docs/product/briefs/` and queued in `[brief_queue].draft`. Backed by a chain of committed shaping artifacts (situation finding → opportunity assessment → solution options → capability map → bet) that any agent or reviewer can trace.
+
+**Surface:** cross-platform — CLI/terminal, agent-assisted. The PE does the judgment calls; the agent does the structured artifact generation under the PE's direction.
+
+**Trigger:** A signal arrives — a user pain, a market observation, an engineering finding surfaced by `work-loop`, or a shaping queue item becoming active. Alternatively: a strategic gap identified by the altitude-0 layer (product-strategist journey) routes into frame-situation.
+
+**End state:** Brief passes the DoR gate (`Status: Ready`), enters `[brief_queue].ready`, and is assigned to an engineer or agent for spec decomposition via `receive-brief`.
+
+---
+
+## Prerequisites
+
+| Pack | Scope | Status | Provides |
+|---|---|---|---|
+| PE pack | user | current (M1 skills); M2 skills planned | `frame-intent`, `de-risk-intent` (current); `frame-situation`, `identify-opportunities`, `diverge-solutions`, `place-bet`, `map-capabilities` (M2) |
+| core | repo | M1 required for queue write-back | `check-workspace`, `author-brief`, `receive-brief`; `[shaping_queue]` and `[brief_queue]` schema |
+
+**One-time setup:**
+1. Install PE pack at user scope — PEs shape across repos, so user scope is the right level.
+2. Install core pack at repo scope for the repo where briefs will be committed.
+3. `workspace.toml` is committed to `main` as part of M1 Batch 2 — no branch configuration needed; core pack install at repo scope is sufficient.
+
+**Scale:** PE pack is user-scoped because the PE shapes across multiple repos. Core pack is repo-scoped because queue state is per-repo. In orgs where the same person does PE and engineering work, both scopes are needed — this is the common small-team case.
+
+---
+
+## Interaction model
+
+### Current state — PE pack M1 skills only (before M2)
+
+```mermaid
+sequenceDiagram
+    participant PE as Product Engineer
+    participant A as Agent
+    participant SK as Skills (frame-intent, de-risk-intent)
+    participant F as Repo files
+
+    Note over PE,F: Shaping today — session-bound
+    PE->>A: Shape the X initiative
+    A->>SK: frame-intent [intent description]
+    SK-->>A: Intent framed — altitude 1
+    A->>SK: de-risk-intent
+    SK-->>A: Risks surfaced
+    A-->>PE: Here is the framing and risk register
+    Note over A: Session closes — artifacts in context only
+    PE->>F: Manually write brief from memory
+    PE-->>PE: No committed shaping chain; no graduation signal
+```
+
+### To-be state — M2 shipped
+
+```mermaid
+sequenceDiagram
+    participant SIG as Signal / queue item
+    participant PE as Product Engineer
+    participant CW as check-workspace
+    participant FS as frame-situation
+    participant IO as identify-opportunities
+    participant DS as diverge-solutions
+    participant DRI as de-risk-intent
+    participant PB as place-bet
+    participant MC as map-capabilities
+    participant AB as author-brief
+    participant SA as docs/product/shaping/
+    participant WS as workspace.toml
+
+    Note over SIG,PE: Trigger — signal arrives or queue item surfaces
+    SIG->>PE: User pain / OKR gap / engineering finding / metric drop
+    PE->>CW: check-workspace
+    CW->>WS: Read [shaping_queue]
+    WS-->>CW: opp-assessment-X ready · backlog: [...]
+    CW-->>PE: Ready to start: opp-assessment-X · run frame-situation
+
+    PE->>FS: frame-situation [signal description]
+    FS->>SA: situation-finding.md (typed finding + six-step route)
+    FS->>WS: [shaping_queue].active = opp-assessment-X
+    FS-->>PE: Signal typed: user-pain · route → identify-opportunities
+
+    PE->>IO: identify-opportunities
+    IO->>SA: opportunity-assessment.md (JTBD: functional / emotional / social)
+    IO-->>PE: Highest-opportunity pain ranked · proceed to diverge?
+
+    PE->>DS: diverge-solutions
+    DS->>SA: solution-options.md (≥3 structured comparable options)
+    DS-->>PE: Options framed · identify riskiest assumption?
+
+    PE->>DRI: de-risk-intent [option set]
+    DRI-->>PE: Riskiest assumption: X · prototype approach: Y · what to validate
+
+    Note over PE: Validate — prototype / research / user contact (human judgment)
+
+    PE->>PB: place-bet [validated option + notes]
+    PB->>SA: bet.md (committed bet + accepted risks)
+    PB-->>PE: Bet committed · map capabilities?
+
+    PE->>MC: map-capabilities
+    MC->>SA: capability-map.md (vision → all capability areas)
+    MC->>WS: Graduate → [brief_queue].draft
+    MC-->>PE: Capability map done · author brief?
+
+    PE->>AB: author-brief [bet + capability map]
+    AB-->>PE: Outcome? Appetite? Rabbit holes?
+    PE->>AB: [fills DoR fields]
+    AB->>WS: [brief_queue].draft += briefs/initiative-X.md
+    AB-->>PE: Brief queued · receive-brief to decompose into specs
+```
+
+---
+
+## Stage 1: Signal → Situation
+
+### Now (frame-intent only)
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Receives a signal (user pain, metric drop, strategic gap). Runs `frame-intent` to articulate the intent. Produces a session-bound framing. |
+| **Emotions** | Engaged but uncertain (neutral). The framing is useful but ephemeral — it doesn't survive the session and has no structured route to next steps. |
+| **Pains** | "I've framed the intent but I don't know what kind of problem this is or which step of the six-step sequence to run next." "The framing lives in session context — if I close the terminal, it's gone." "No structured way to classify signals (user pain vs. market gap vs. strategic gap vs. engineering finding)." |
+| **Opportunities** | A situation-framing skill that classifies the signal type, produces a typed finding, and routes to the right next step. Committed output that survives the session. |
+
+> **With M2** — `frame-situation` ships: typed finding committed to `docs/product/shaping/`; signal classification routes directly to the next six-step skill; `[shaping_queue]` updated with the active item.
+
+---
+
+## Stage 2: Opportunity Assessment
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Tries to articulate what job-to-be-done or opportunity underlies the signal. Runs `frame-intent` for framing, but it doesn't surface JTBD structure. Works it out manually. |
+| **Emotions** | Frustrated (negative). Without a structured opportunity-assessment skill, the work is ad-hoc and the output varies wildly in quality and structure. |
+| **Pains** | "I know there's an opportunity here but I can't structure it consistently." "No JTBD framing — I miss the emotional and social jobs behind the functional one." "Different PEs produce incomparable opportunity assessments." |
+| **Opportunities** | `identify-opportunities` producing a structured assessment with functional / emotional / social job framing. Committed artifact that any reviewer can compare across initiatives. |
+
+> **With M2** — `identify-opportunities` ships: JTBD-structured opportunity assessment committed to `docs/product/shaping/`; highest-opportunity pain ranked and handed to diverge.
+
+---
+
+## Stage 3: Diverge Solutions
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Brainstorms solution options mentally or in a doc. May reach for `explore-options` but it produces freeform output — no structured comparison, no forcing function. |
+| **Emotions** | Creative but unstructured (neutral). No clear signal about when divergence is "enough" or whether the options are comparable. |
+| **Pains** | "I don't know if I've diverged enough or if I've just listed variations of the same idea." "My solution options aren't structured enough to compare — no forcing function." "I often skip this step and jump to a preferred solution." |
+| **Opportunities** | `diverge-solutions`: step-3 of the six-step sequence, produces ≥3 structured comparable options that `place-bet` can reason against. Distinct from `explore-options` (freeform, any context) — different output contracts, both stay. |
+
+> **With M2** — `diverge-solutions` ships as a distinct structured skill (not a wrapper over `explore-options`): forces ≥3 comparable options with a structured format that `place-bet` can reason against; committed to `docs/product/shaping/`. Use `explore-options` for freeform brainstorming outside the six-step sequence; use `diverge-solutions` when you're in step-3.
+
+---
+
+## Stage 4: Validate
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Selects a preferred option from the brainstorm. Runs `de-risk-intent` to surface the riskiest assumption. Validates through research, user contact, or internal review — with no structured handoff from the options artifact. |
+| **Emotions** | Uncertain (neutral). No clear signal about what specifically to validate or when enough is enough. |
+| **Pains** | "I know I should validate but I'm not sure what the riskiest assumption actually is." "Validation findings live in email threads or Notion — the next person picking this up doesn't know what was checked." "No minimum bar for 'validated enough' — I commit when I feel ready, not when I've hit a defined threshold." |
+| **Opportunities** | `de-risk-intent` as structured validate-step entry: identifies the riskiest assumption in the option set and suggests a prototype approach — gives the PE a concrete thing to go test rather than validating blindly. A `validation-notes.md` seed (convention, not a skill) captures findings for the next person. |
+
+> **With M2** — `de-risk-intent` positions as step-3.5: called after `diverge-solutions`, before the human validation work; surfaces riskiest assumption + prototype approach so the PE knows exactly what to test. The actual validation (prototype, research, user contact) remains human-judgment territory. `validation-notes.md` convention decision (M2 or M3) is deferred to the M2 sub-RFC.
+
+---
+
+## Stage 5: Place Bet
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Makes a gut-feel decision on which solution to pursue after validation. No structured betting table — rationale stays in the PE's head. |
+| **Emotions** | Decisive but unaccountable (positive surface / neutral underneath). The decision is made but not committed — there is no artifact that forces the PE to write down the rationale. |
+| **Pains** | "My bet is in my head — I can't hand it to someone else to review." "No betting table forcing me to weigh options explicitly." "When the initiative ships and someone asks 'why did we pick this solution?', there's no committed answer." |
+| **Opportunities** | `place-bet` producing a committed bet artifact with a betting table (option, confidence, rationale, risks accepted). The human gate is explicit and committed; the next agent reading it knows exactly what was decided and why. |
+
+> **With M2** — `place-bet` ships: betting table committed to `docs/product/shaping/`; rationale and accepted risks recorded; bet links to option that was validated.
+
+---
+
+## Stage 6: Brief
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Writes a brief from memory (the framing, options, and bet all lived in sessions). Runs `receive-brief` to decompose into specs. Brief is created but not traceable to any committed shaping chain. |
+| **Emotions** | Relieved to be done (positive) but aware the brief has no provenance — it can't be reviewed against the original signal. |
+| **Pains** | "My brief is not traceable to the shaping work — someone reviewing it can't check whether the bet was well-reasoned." "I had to reconstruct the context from memory — the brief may miss something from the shaping chain." "No capability map — I don't know if the brief covers all the relevant capability areas." |
+| **Opportunities** | `map-capabilities` producing a capability map before brief authoring; `author-brief` creating the brief from the bet + capability map with full provenance; `[brief_queue]` updated automatically. |
+
+> **With M2** — `map-capabilities` ships first, then `author-brief` creates the brief from the committed shaping chain; traceability lint links brief → bet → situation finding; brief enters `[brief_queue].draft` with full provenance.
+
+---
+
+## Frontstage actions
+
+- **Action:** receive-signal-or-gap
+- **Action:** run-frame-situation
+- **Action:** run-identify-opportunities
+- **Action:** run-diverge-solutions
+- **Action:** validate-preferred-option
+- **Action:** run-place-bet
+- **Action:** run-map-capabilities
+- **Action:** run-author-brief
+- **Action:** run-receive-brief
+
+---
+
+## Emotional arc
+
+Lowest point: **Stage 4 (Validate)** — uncertain — because there is no structured handoff into or out of validation. The PE is making a judgment call with no committed artifact capturing what was checked and what was not.
+
+Highest-opportunity pain: "My shaping work lives in session context. When the brief is written, its provenance is gone — the reviewer can't trace the bet back to the original signal, and neither can the agent picking up the spec six weeks later."
+
+Primary design response: committed shaping artifact chain (situation → opportunity → options → bet → capability map → brief) that survives sessions and gives reviewers and future agents a traceable line from signal to shipped spec.
+
+---
+
+## Handoff notes
+
+**For `map-screen-flow`:** Stage 5 (Place Bet) and Stage 6 (Brief) carry the highest-opportunity pains. The betting table view and the brief-with-provenance view are the highest-priority screen-level inputs for any future PM-facing web surface (INI-006).
+
+**For `blueprint-service`:** backstage services implied by the shaping chain include `docs/product/shaping/` (artifact store per initiative), `workspace.toml` (shaping queue state), and the traceability lint (brief → bet → situation link enforcement). The validation-notes gap (Stage 4) is an unresolved design question for the M2 sub-RFC.

--- a/docs/product/journeys/product-engineer-shapes-initiative.md
+++ b/docs/product/journeys/product-engineer-shapes-initiative.md
@@ -218,15 +218,15 @@ sequenceDiagram
 
 ## Frontstage actions
 
-- **Action:** receive-signal-or-gap
-- **Action:** run-frame-situation
-- **Action:** run-identify-opportunities
-- **Action:** run-diverge-solutions
-- **Action:** validate-preferred-option
-- **Action:** run-place-bet
-- **Action:** run-map-capabilities
-- **Action:** run-author-brief
-- **Action:** run-receive-brief
+- **Skill:** receive-signal-or-gap
+- **Skill:** run-frame-situation
+- **Skill:** run-identify-opportunities
+- **Skill:** run-diverge-solutions
+- **Skill:** validate-preferred-option
+- **Skill:** run-place-bet
+- **Skill:** run-map-capabilities
+- **Skill:** run-author-brief
+- **Skill:** run-receive-brief
 
 ---
 

--- a/docs/product/journeys/product-strategist-sets-direction.md
+++ b/docs/product/journeys/product-strategist-sets-direction.md
@@ -167,13 +167,13 @@ sequenceDiagram
 
 ## Frontstage actions
 
-- **Action:** run-pestle-analysis
-- **Action:** run-porters-five-forces
-- **Action:** run-bcg-matrix
-- **Action:** run-swot
-- **Action:** write-prfaq
-- **Action:** run-okr-cascade
-- **Action:** prioritise-initiative-portfolio
+- **Skill:** run-pestle-analysis
+- **Skill:** run-porters-five-forces
+- **Skill:** run-bcg-matrix
+- **Skill:** run-swot
+- **Skill:** write-prfaq
+- **Skill:** run-okr-cascade
+- **Skill:** prioritise-initiative-portfolio
 
 ---
 

--- a/docs/product/journeys/product-strategist-sets-direction.md
+++ b/docs/product/journeys/product-strategist-sets-direction.md
@@ -1,0 +1,194 @@
+---
+type: customer-journey
+slug: product-strategist-sets-direction
+persona: product-strategist
+outcome: altitude-0-direction-committed-and-cascaded
+surface: cross-platform
+status: proposed
+initiative_links:
+  - id: INI-002
+    name: Platform Core
+    milestones: M4 (primary); M2 (prerequisite — frame-situation must exist for cascade routing)
+    role: primary
+updated: 2026-07-18
+---
+
+# Journey: Product strategist sets altitude-0 direction
+
+**Persona:** A product strategist, CPO, or senior PM working at altitude-0 — company or multi-product level. They set the strategic direction that all initiatives must align to. Their time horizon is years, not quarters. In smaller orgs this may be the same person as the product engineer; in larger orgs it is a distinct role with a distinct artifact vocabulary (OKRs, PRFAQs, market analysis, portfolio position).
+
+**Outcome:** A set of committed altitude-0 artifacts — PRFAQ, OKR cascade, market context, portfolio position — that translate company direction into initiative-level shaping inputs. Gaps identified by the OKR cascade feed directly into `frame-situation` as shape-typed shaping items, closing the loop between altitude-0 direction and altitude-1 shaping.
+
+**Surface:** cross-platform — CLI/terminal, agent-assisted.
+
+**Trigger:** Annual or quarterly planning cycle; a significant market event requiring strategic re-evaluation; or a new initiative cluster being scoped and the strategist needs to anchor it in altitude-0 thinking.
+
+**End state:** Altitude-0 artifacts committed to `docs/product/shaping/`. OKR gaps routed to `[shaping_queue]` as `shape`-typed items for the product engineer to pick up via `frame-situation`. The initiative portfolio has a visible, justified strategic rationale that any team member can read.
+
+---
+
+## Prerequisites
+
+| Pack | Scope | Status | Provides |
+|---|---|---|---|
+| product-strategy pack | user | planned (M4) | SWOT, Porter's Five Forces, PESTLE, BCG Matrix, OKR cascade, PRFAQ |
+| PE pack | user | M2 required for cascade routing | `frame-situation` — target of the OKR cascade cross-pack routing |
+
+**One-time setup (when M4 ships):**
+1. Install product-strategy pack at user scope — altitude-0 direction applies across repos and orgs.
+2. Install PE pack at user scope as a co-install — required for OKR cascade routing to `frame-situation`; absent PE pack produces a "frame-situation not found — install PE pack" diagnostic rather than a silent failure.
+3. For each repo where OKR gaps will be routed to the shaping queue: install core pack at repo scope — `workspace.toml` is committed to `main` as part of M1 Batch 2; no branch configuration needed.
+
+**Scale:** both packs are user-scoped. In smaller orgs the strategist and PE may be the same person with both packs already installed. The cross-pack dependency (OKR cascade → `frame-situation`) is agent-mediated — the strategist invokes both in sequence; no mechanical cross-pack wiring is assumed.
+
+---
+
+## Interaction model
+
+### Current state — before M4
+
+```mermaid
+sequenceDiagram
+    participant S as Product Strategist
+    participant A as Agent
+    participant F as External tools (Notion, slides, spreadsheets)
+
+    Note over S,F: Altitude-0 work today — disconnected
+    S->>F: Write OKRs in Notion / Google Docs
+    S->>F: Build market analysis in slides
+    S->>A: Help me think through portfolio position
+    A-->>S: Ad-hoc analysis in session context
+    Note over A: Session closes — analysis lost
+    S-->>S: Copy insights manually into initiative briefs
+    Note over S: No committed artifact; no cascade into shaping queue
+```
+
+### To-be state — M4 shipped
+
+```mermaid
+sequenceDiagram
+    participant S as Product Strategist
+    participant A as Agent
+    participant SK as Skills (product-strategy pack)
+    participant SA as docs/product/shaping/
+    participant WS as workspace.toml
+
+    Note over S,WS: Altitude-0 direction — M4+
+    S->>SK: PESTLE + Porter's Five Forces [context brief]
+    SK->>SA: Write market-context.md (macro + competitive landscape)
+    S->>SK: BCG Matrix + SWOT [portfolio snapshot]
+    SK->>SA: Write portfolio-position.md
+    S->>SK: PRFAQ [press release draft for the initiative cluster]
+    SK->>SA: Write prfaq.md (altitude-0 forcing function)
+    S->>SK: OKR cascade [company OKRs]
+    SK->>SA: Write okr-cascade.md (company → team → initiative gaps)
+    SK-->>S: Gaps identified: [gap-A, gap-B] → route to frame-situation?
+    S->>WS: [shaping_queue].backlog += {slug: gap-A, needs: nothing}
+    Note over WS: Product engineer picks up gap-A via check-workspace
+    Note over WS: frame-situation routes gap into six-step sequence
+```
+
+---
+
+## Stage 1: Market Context
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Gathers market signals manually from news, analyst reports, competitors. Synthesises in slides or Notion. Shares in planning meetings. |
+| **Emotions** | Informed but scattered (neutral). The synthesis is good but lives outside the platform — it can't be referenced by shape-room skills. |
+| **Pains** | "My market analysis is in a Notion page that no one else in the team reads." "No structured format — each strategist does it differently." "The agent running `frame-situation` has no way to access the market context I've already done." |
+| **Opportunities** | Committed market-context artifact in `docs/product/shaping/` that `frame-situation` can reference when routing a signal; PESTLE and Porter's Five Forces as the structuring framework. |
+
+> **With M4** — PESTLE + Porter's Five Forces skills ship: structured market-context artifact committed; feeds directly into `frame-situation`'s Wardley capability-maturity situational-awareness input.
+
+---
+
+## Stage 2: Portfolio Position
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Assesses where each initiative sits in the portfolio relative to market position and growth. Uses BCG Matrix and SWOT mentally or in slides. |
+| **Emotions** | Strategic but isolated (neutral). The portfolio view is valuable but disconnected from what teams are actually building. |
+| **Pains** | "My BCG Matrix is a static slide — it doesn't update when initiatives ship." "No link between portfolio position and which shaping items get prioritised." "SWOT lives in planning decks, not in the committed tree — teams building the product can't access it." |
+| **Opportunities** | Committed portfolio-position artifact that updates alongside the initiative structure; SWOT linked to shaping queue prioritisation so strategic position drives what gets shaped next. |
+
+> **With M4** — BCG Matrix + SWOT skills ship: portfolio-position.md committed; links to `[shaping_queue]` backlog priority (higher portfolio urgency → moves higher in backlog).
+
+---
+
+## Stage 3: Direction Setting (PRFAQ)
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Writes a press release or product narrative for major bets in slide decks or documents. Shares in leadership reviews. Rarely committed to the repo. |
+| **Emotions** | Purposeful but aware of the gap (positive → neutral). The PRFAQ discipline is valuable but exists only in meetings — it doesn't anchor the shaping room. |
+| **Pains** | "I write a great press release in PowerPoint and then it disappears. Six months later no one knows what the original vision was." "The shaping room has no altitude-0 anchor — PEs shape without knowing what the company is trying to achieve." "PRFAQ is an Amazon thing — no structured tool for it here." |
+| **Opportunities** | PRFAQ template committed to `docs/product/shaping/` as the altitude-0 forcing function; linked from initiative briefs as the "why this initiative?" artifact; any agent or reviewer can trace a brief back to the PRFAQ that motivated it. |
+
+> **With M4** — PRFAQ template ships: strategist writes press release, commits it to `docs/product/shaping/`; initiative briefs link to PRFAQ via `## Design artifacts`; traceability lint can enforce the link.
+
+---
+
+## Stage 4: OKR Cascade
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Sets company OKRs in Notion / Google Sheets. Cascades to team OKRs in planning meetings. Hopes the cascade reaches the product team's shaping backlog. Rarely does. |
+| **Emotions** | Resigned (negative). The cascade is a planning ritual, not a live connection. By the time an engineer writes a spec, the OKR that motivated it is invisible. |
+| **Pains** | "Company OKRs are in Notion; team OKRs are in a spreadsheet; the shaping queue has no idea either exists." "Gaps between current state and OKR targets are identified in planning meetings and then lost." "No mechanism for OKR gaps to flow into `frame-situation` as shaping inputs." |
+| **Opportunities** | OKR cascade skill that (a) takes company OKRs, derives team-level OKRs, and identifies gaps; (b) routes each gap as a `shape`-typed shaping item into `frame-situation`; (c) writes the cascade as a committed artifact. The altitude-0 → altitude-1 handoff becomes a skill invocation, not a meeting. |
+
+> **With M4** — OKR cascade skill ships: company OKRs → gap analysis → `frame-situation` routing; gaps added to `[shaping_queue].backlog` as typed items; product engineer picks them up via `check-workspace`. Cross-pack dependency: PE pack (frame-situation, M2) must be installed.
+
+---
+
+## Stage 5: Initiative Prioritisation
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Decides which initiatives get resourced in the planning cycle. Decision is made in meetings with no committed rationale. |
+| **Emotions** | Confident in the room (positive) but aware the rationale will be lost (neutral). Six months later the team doesn't know why initiative X was picked over initiative Y. |
+| **Pains** | "Initiative prioritisation is a meeting outcome — it's not committed anywhere." "No structured betting table at altitude-0 — I can't show stakeholders the trade-offs I considered." "The shaping queue doesn't reflect strategic priority — PEs pick whatever is interesting, not whatever is most urgent." |
+| **Opportunities** | Portfolio-level bet committed to `docs/product/shaping/`; shaping queue backlog ordered by strategic priority; stakeholders can see the trade-offs the strategist weighed. |
+
+> **With M4** — Portfolio bet artifact ships alongside OKR cascade; `[shaping_queue].backlog` ordering reflects strategic priority; altitude-0 rationale is committed and traceable.
+
+---
+
+## Frontstage actions
+
+- **Action:** run-pestle-analysis
+- **Action:** run-porters-five-forces
+- **Action:** run-bcg-matrix
+- **Action:** run-swot
+- **Action:** write-prfaq
+- **Action:** run-okr-cascade
+- **Action:** prioritise-initiative-portfolio
+
+---
+
+## Emotional arc
+
+Lowest point: **Stage 4 (OKR Cascade)** — resigned — because the altitude-0 → altitude-1 handoff is a ritual that does not produce a committed artifact or a live connection to the shaping queue. OKR gaps identified in planning disappear before they reach a product engineer's workspace.
+
+Highest-opportunity pain: "I set company OKRs and cascade them to team OKRs. By the time an engineer is writing a spec, neither exists in their context. There is no committed handoff — just hope."
+
+Primary design response: OKR cascade skill routing gaps to `[shaping_queue]` as `shape`-typed items; PRFAQ and portfolio-position committed to `docs/product/shaping/` as traceable altitude-0 anchors.
+
+---
+
+## Handoff notes
+
+**For `map-screen-flow`:** Stage 4 (OKR Cascade) and Stage 5 (Initiative Prioritisation) carry the highest-opportunity pains. A portfolio-level dashboard showing which initiatives are resourced and why — with links to the committed altitude-0 artifacts — is the highest-priority screen-level input for INI-006 (control plane).
+
+**For `blueprint-service`:** backstage services include `docs/product/shaping/` (altitude-0 artifact store), `workspace.toml` (shaping queue state), PE pack's `frame-situation` (cross-pack routing target). The cross-pack dependency (OKR cascade → frame-situation) is the primary integration point and requires agent-mediated invocation — not a mechanical cross-pack call.

--- a/docs/product/journeys/team-evaluates-and-adopts.md
+++ b/docs/product/journeys/team-evaluates-and-adopts.md
@@ -298,15 +298,15 @@ Until INI-005 ships, measure manually via periodic `check-workspace` output, per
 
 ## Frontstage actions
 
-- **Action:** discover-platform (peer / blog / GitHub)
-- **Action:** read-readme-and-assess-fit
-- **Action:** complete-your-first-workspace-tutorial
-- **Action:** seed-workspace-toml (first real spec)
-- **Action:** run-work-loop-first-spec
-- **Action:** prepare-demo-scenario (enterprise)
-- **Action:** deliver-live-demo (enterprise)
-- **Action:** execute-rollout-playbook (enterprise)
-- **Action:** run-check-workspace-at-session-start (habit)
+- **Skill:** discover-platform (peer / blog / GitHub)
+- **Skill:** read-readme-and-assess-fit
+- **Skill:** complete-your-first-workspace-tutorial
+- **Skill:** seed-workspace-toml (first real spec)
+- **Skill:** run-work-loop-first-spec
+- **Skill:** prepare-demo-scenario (enterprise)
+- **Skill:** deliver-live-demo (enterprise)
+- **Skill:** execute-rollout-playbook (enterprise)
+- **Skill:** run-check-workspace-at-session-start (habit)
 
 ---
 

--- a/docs/product/journeys/team-evaluates-and-adopts.md
+++ b/docs/product/journeys/team-evaluates-and-adopts.md
@@ -1,0 +1,340 @@
+---
+type: customer-journey
+slug: team-evaluates-and-adopts
+persona: adopting-team
+outcome: work-loop-is-the-teams-default-workflow
+surface: cross-platform
+status: planned
+initiative_links:
+  - id: INI-002
+    name: Platform Core
+    milestones: M1 (what the team is adopting), M6 (onboarding guides — tutorial, rollout playbook, live-demo guide)
+    role: primary
+updated: 2026-07-18
+---
+
+# Journey: Engineering team evaluates and adopts
+
+**Persona:** An engineering team evaluating the platform for adoption — ranging from a solo senior engineer at a startup trying it on a real spec, to an enterprise champion building an internal case for a CTO before a platform team rolls it out across multiple teams.
+
+Two distinct paths share this journey:
+
+- **Self-serve** (solo / startup / small team): The evaluator is the installer. Value is demonstrated by running the tool on a real spec. No gatekeepers, no live demo required. The tool sells itself once it runs.
+- **Sponsored** (enterprise / AI adoption programme): The evaluator is not the installer. An internal champion must demonstrate value to a decision maker (CTO, engineering director, AI CoE lead), coordinate with a platform team, then onboard engineers at scale. Live demonstration on the org's own codebase is the critical gate — documentation alone does not move enterprise decisions.
+
+**Outcome:** The team ships their first spec using `work-loop`. `workspace.toml` is seeded on `main`. Engineers open sessions with `check-workspace`. The platform is the default workflow, not a pilot.
+
+**Surface:** cross-platform — CLI/terminal, agent-assisted. Enterprise path includes a live-demo session in front of decision makers.
+
+**Trigger:**
+- Self-serve: Peer recommendation, blog post, conference mention, or GitHub discovery. Engineer has already been using Claude Code or similar and wants more structure.
+- Sponsored: Organisation has an AI adoption initiative. A champion is tasked with evaluating tools. Platform is identified as a candidate and escalated for a buy-in conversation.
+
+**End state:** `workspace.toml` seeded on `main`. At least one spec shipped via `work-loop`. Engineers run `check-workspace` at session start without being told to. For the sponsored path: rollout playbook executed, platform team owns the install, engineers have completed a guided first-use tutorial.
+
+---
+
+## Prerequisites
+
+| Pack | Scope | Status | Provides |
+|---|---|---|---|
+| core | repo | current | `work-loop`, `check-workspace`, `new-spec`, `receive-brief`, `workspace.toml` schema |
+| PE pack | user | optional for evaluation | `frame-intent`, `de-risk-intent` — not needed to evaluate or demonstrate the build room |
+
+**Self-serve setup:**
+1. Install core pack at repo scope.
+2. Seed `workspace.toml` with one real spec entry (not a toy example — use an actual pending task).
+3. Run `work-loop` on that spec. Ship it.
+
+**Enterprise setup (platform team):**
+1. Champion completes the self-serve path first on their own repo — live demo requires personal fluency, not familiarity.
+2. Champion selects demo scenario: a real pending spec from the org's own codebase, sized to ship in 30 minutes.
+3. Champion prepares live-demo guide (M6) for the specific codebase and harness.
+4. After buy-in: platform team runs rollout playbook (M6); engineers complete `your-first-workspace` tutorial.
+
+**Scale:** Core pack is repo-scoped — one install per repo. Enterprise rollout requires a platform team decision on harness (Claude Code, Codex CLI, Kiro, etc.) and which repos/teams roll out first. Mixed-harness orgs need one adapter pack per harness type (INI-003).
+
+---
+
+## Interaction model
+
+### Current state — before M1 / M6
+
+```mermaid
+sequenceDiagram
+    participant ENG as Engineer (self-serve)
+    participant CH as Champion (enterprise)
+    participant DM as Decision Maker
+    participant DOCS as README / docs
+    participant CLI as Terminal
+
+    Note over ENG,CLI: Self-serve today — config friction
+    ENG->>DOCS: Reads README
+    Note over DOCS: Harness-specific setup unclear
+    ENG->>CLI: Installs (trial and error)
+    ENG->>CLI: Runs work-loop (uncertain outcome)
+    Note over ENG: Value unclear without guided first-use path
+
+    Note over CH,DM: Enterprise today — live-demo gap
+    CH->>DM: "We should use this platform"
+    DM-->>CH: Show me
+    Note over CH: No demo script · improvises 90+ min session
+    DM-->>CH: Maybe · check with the platform team
+    Note over DM: Platform team has no rollout playbook
+    Note over DM: Engineers onboarded ad-hoc · revert within weeks
+```
+
+### To-be state — M1 + M6 shipped
+
+```mermaid
+sequenceDiagram
+    participant ENG as Engineer (self-serve)
+    participant TUT as your-first-workspace (M6)
+    participant WS as workspace.toml
+    participant CH as Champion (enterprise)
+    participant DM as Decision Maker
+    participant PT as Platform Team
+    participant ENGS as Engineers
+
+    Note over ENG,WS: Self-serve — M1 + M6
+    ENG->>TUT: your-first-workspace tutorial
+    TUT->>WS: Seed workspace.toml (one real spec)
+    TUT->>ENG: run work-loop [spec]
+    ENG->>WS: check-workspace (session 2)
+    WS-->>ENG: Spec shipped · queue next?
+    Note over ENG: Aha moment — workflow established
+
+    Note over CH,ENGS: Enterprise — M1 + M6
+    CH->>CH: Self-serve path first (personal fluency)
+    CH->>CH: Prepare demo scenario (real org spec)
+    CH->>DM: 30-min live demo · real spec → work-loop → shipped
+    DM-->>CH: Buy-in · proceed
+    CH->>PT: Enterprise rollout playbook (M6)
+    PT->>PT: Install core pack · configure harness · seed workspace.toml
+    PT->>ENGS: your-first-workspace tutorial (M6)
+    ENGS->>WS: check-workspace (first session)
+    WS-->>ENGS: Active spec · run work-loop
+    Note over ENGS: First spec shipped · workflow embedded
+```
+
+---
+
+## Stage 1: Awareness
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Engineer discovers via peer recommendation, blog, or GitHub. Champion is assigned by an AI adoption lead. Both read README and documentation. |
+| **Emotions** | Curious but cautious (neutral). The proposition (structured AI-native workflow) is compelling but abstract without a concrete entry point. |
+| **Pains** | "The README explains what it does but not how to get started on a real project." "I can't tell from the docs whether this fits our workflow or replaces it." "Every team member will ask me what this is before they try it — I need a one-sentence answer and a demo." |
+| **Opportunities** | A clear one-sentence positioning statement at the top of the README: what it is, who it's for, what problem it solves, and what the first step is. A `your-first-workspace` tutorial that gets a real spec shipped in under an hour. |
+
+> **With M6** — `your-first-workspace` tutorial ships: guided path from install to first shipped spec; one-sentence positioning in README; clear separation of "try it yourself" (self-serve) from "roll it out to your team" (rollout playbook).
+
+---
+
+## Stage 2: Proof of Value
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Engineer installs manually, following README. Hits config friction (harness-specific setup, skill discovery path varies). Tries `work-loop` on a spec — outcome depends on prior context knowledge. |
+| **Emotions** | Determined but frustrated (neutral → negative). The tool is clearly capable once running but the path to "first success" is poorly marked. |
+| **Pains** | "I installed it but I'm not sure if skills are loading correctly." "I don't know if I should use an existing spec or create a new one." "I got through one spec but I'm not sure if I did it right — there was no confirmation." "The value was visible but I can't reproduce it reliably yet." |
+| **Opportunities** | `your-first-workspace` tutorial with a concrete task: seed `workspace.toml`, pick a real pending spec, run `work-loop`, see it ship. No toy examples — real work from the first minute. |
+
+> **With M6** — Tutorial uses a real spec, not a toy. First session ends with a shipped spec and a `workspace.toml` that reflects it. Confirmation is explicit: `check-workspace` shows "shipped" and what's next.
+
+---
+
+## Stage 3: Internal Case / Live Demo Gap
+
+### Now (enterprise path only — highest-pain stage)
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Champion is asked to demonstrate value to decision makers. Has no demo script. Improvises a live session using their own knowledge of the platform. Session runs 60–90 minutes, outcome is uncertain. Decision maker is unconvinced or asks to see it on their own codebase. |
+| **Emotions** | Anxious then exhausted (negative). The platform is genuinely good but the champion cannot reliably transfer that conviction to a decision maker who hasn't used it. |
+| **Pains** | "I can demonstrate it but I need 90 minutes and it might not go right." "Decision makers want to see it on our code, not a toy example." "If the demo goes wrong — wrong spec, environment issue, unclear output — I lose the room." "I've done three of these live sessions and every one felt like starting from scratch." |
+| **Opportunities** | A live-demo guide (M6): a prepared scenario using a real pending spec from the org's own codebase, sized to ship in under 30 minutes; a script of what to narrate at each step; a pre-flight checklist (harness installed, skills loading, spec ready); a fallback if something goes wrong. The champion needs to be able to run this reliably without improvising. |
+
+> **With M6** — Live-demo guide ships as part of M6: scenario selection criteria (what makes a good demo spec), pre-flight checklist, narration script, 30-minute target. Champion who has completed the self-serve path can deliver this reliably. Decision maker sees real work on their codebase, not a toy.
+
+---
+
+## Stage 4: Rollout
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | After buy-in (enterprise) or after personal success (self-serve), tries to extend to the team. No rollout playbook. Each engineer re-encounters the same config friction the champion did. |
+| **Emotions** | Optimistic then managing (positive → neutral). The champion is excited but the onboarding experience does not carry the excitement forward to team members. |
+| **Pains** | "Every engineer asks the same setup questions I already answered for myself." "No way to share my workspace.toml setup — each person starts from scratch." "The platform team wants a rollout plan but I don't have one." "Some engineers tried it once, hit friction, and went back to their old workflow." |
+| **Opportunities** | Enterprise rollout playbook (M6): install core pack at org scope, pre-seed `workspace.toml` for the first pilot project, configure harness, run `your-first-workspace` tutorial with each engineer. Self-serve: shareable `workspace.toml` template so team members start from a known-good state, not from blank. |
+
+> **With M6** — Rollout playbook ships: step-by-step platform team guide; pre-seeded `workspace.toml` template for the pilot project; guided first-use session for each engineer using the tutorial. Rollout friction drops from "re-discover everything" to "follow the playbook."
+
+---
+
+## Stage 5: Embedding
+
+### Now (and to-be — human behaviour, not skill-scope)
+
+| Row | Content |
+|-----|---------|
+| **Actions** | After initial success, engineers continue using `work-loop` — or revert to old workflow when they hit friction on a non-standard case. |
+| **Emotions** | Habitual (neutral). The platform works for the cases it was tried on. Reversion happens when a new case (no spec, ambiguous brief, unfamiliar harness) is encountered and there is no guidance. |
+| **Pains** | "It works well when I know what spec to run. When I don't, I go back to winging it." "I use `work-loop` for implementation but still manage briefs in Notion because I don't trust the queue yet." "New engineers joining the team don't know about `check-workspace` — they discover it weeks in." |
+| **Opportunities** | `check-workspace` as the session-start habit replaces "open Notion, check Slack, figure out what to work on." New-engineer onboarding includes a `your-first-workspace` session on their first day. The platform is embedded, not bolted on. |
+
+> **Embedded state** — `check-workspace` is the first command every engineer runs. `workspace.toml` is the team's source of truth for what's in flight. New engineers are onboarded to it on day one. Reversion stops because the habit is established before friction arises.
+
+---
+
+## Adoption metrics
+
+The metrics that matter — and how to measure them at each adoption stage. Source of truth is `workspace.toml` where possible; champion reporting for enterprise-path qualitative gates. INI-005 (Infra & Observability) is the future home for automated instrumentation; until then, these are measured manually.
+
+### Time to first value (TTFV)
+
+**What it measures:** How long from install to first shipped spec. The single most important leading indicator of whether adoption will stick.
+
+| Path | Target | How to measure |
+|---|---|---|
+| Self-serve | < 1 hour (install → first spec shipped) | Timestamp: pack install → first `shipped` entry in `workspace.toml` |
+| Enterprise live demo | < 30 min (demo start → spec shipped in front of decision maker) | Champion reports: did the spec ship within the window? |
+| Enterprise rollout | < 2 weeks (CTO buy-in → first engineer ships a spec) | Champion reports: date of buy-in, date of first team spec shipped |
+
+### Activation rate
+
+**What it measures:** What % of engineers who install actually ship a spec within the first 7 days. Low activation = onboarding friction or unclear first step.
+
+| Target | How to measure |
+|---|---|
+| > 80% of installed engineers ship ≥1 spec within 7 days | Count engineers with ≥1 `shipped` entry in `workspace.toml` within 7 days of install |
+
+### Session-start habit
+
+**What it measures:** Are engineers running `check-workspace` at the start of sessions? This is the embedding metric — once it's habitual, reversion is unlikely.
+
+| Target | How to measure |
+|---|---|
+| `check-workspace` is the first command in > 70% of sessions by week 4 | Self-reported (survey) until INI-005 session instrumentation ships; proxy: `workspace.toml` `active` entries moving to `shipped` within single sessions |
+
+### 30-day retention
+
+**What it measures:** Are engineers still using `work-loop` 30 days after their first spec? Reversion is the dominant failure mode — engineers try it, hit friction on a non-standard case, and go back to winging it.
+
+| Target | How to measure |
+|---|---|
+| > 70% of engineers who shipped a first spec are still shipping specs at day 30 | Count engineers with ≥1 `shipped` entry in weeks 3–4 who also had one in week 1 |
+
+### Spec throughput lift
+
+**What it measures:** How many specs ship per engineer per week, before vs. after adoption. This is the productivity metric decision makers care about — and the one that builds the internal case for broader rollout.
+
+| Target | How to measure |
+|---|---|
+| ≥ 2× specs shipped per engineer per week within 60 days of rollout | `workspace.toml` `shipped` count per engineer, compared to prior sprint velocity in tracker |
+
+### Brief queue flow rate
+
+**What it measures:** Time from brief `draft` to `executing`. A stalling brief queue means the shaping → build handoff is broken — briefs are being written but not acted on.
+
+| Target | How to measure |
+|---|---|
+| Median < 5 days from `brief_queue.draft` to `work.active` | Timestamp delta: brief queued date → first spec enters `active` |
+
+### Enterprise demo success rate
+
+**What it measures:** Can the champion ship a spec reliably in the 30-minute live-demo window without improvising? Binary: yes (spec shipped on screen) / no.
+
+| Target | How to measure |
+|---|---|
+| 100% — every demo attempt ships the spec in the window | Champion self-report post-demo; pre-flight checklist completion rate |
+
+### Reversion rate (enterprise)
+
+**What it measures:** What % of engineers who completed onboarding reverted to their old workflow within 30 days. Enterprise adoption fails here most often — not at buy-in, but at embedding.
+
+| Target | How to measure |
+|---|---|
+| < 15% reversion at 30 days | `workspace.toml` activity: engineers with no `shipped` entry in weeks 3–4 despite having one in week 1 |
+
+### Portfolio / org-level metrics — across many teams, value streams, and repos
+
+At enterprise scale, adoption is not measured per-repo — it is measured across an entire engineering organisation: multiple teams, multiple value streams, multiple repos each with their own `workspace.toml`. The per-repo metrics above are necessary but not sufficient. A CTO or AI adoption lead needs an aggregated view.
+
+| Metric | What it measures | How to measure |
+|---|---|---|
+| **Org activation rate** | % of repos with ≥1 spec shipped via `work-loop` out of all target repos | Count repos with non-empty `shipped` in `workspace.toml` / target repo count (manual until INI-006) |
+| **Team adoption coverage** | % of teams / value streams running at least one active initiative in `workspace.toml` | Count teams with `status = "active"` section / total teams (manual until INI-006) |
+| **Cross-repo throughput** | Total specs shipped per week, aggregated across all repos | Sum of `shipped` delta per `workspace.toml` per week — requires scraping or manual reporting |
+| **Cross-repo brief queue health** | Aggregate count of briefs stalled in `draft` or `ready` > N days across all repos | Manual: each team reports; automated: INI-005 per-repo telemetry rolled up to INI-006 dashboard |
+| **Initiative portfolio progress** | For orgs running parallel initiatives (each in separate repos), what % of specs are shipped vs. queued vs. blocked? | Requires a portfolio-level registry — not yet designed; feeds Unknown #8 (portfolio pack) |
+| **Value stream latency** | End-to-end time from brief `draft` to spec `shipped`, aggregated per value stream | Timestamp delta aggregated across repos in one value stream — requires INI-005 |
+| **30-day org-wide retention** | % of engineers across all teams who are still shipping specs at day 30 vs. day 7 | Per-engineer metric aggregated across repos — requires INI-005 instrumentation |
+
+**The core gap:** `workspace.toml` is per-repo by design (D4). There is no native org-level view. Aggregation today requires either manual roll-up (each team reports to a shared tracker) or a portfolio registry (an "org workspace" at a higher level). Until INI-005 (telemetry) and INI-006 (control plane) ship, enterprise-scale measurement is a manual process.
+
+**What this means for design:** the portfolio pack (Unknown #8) is not just about research bridging — it is also the mechanism for org-level `workspace.toml` aggregation and cross-repo initiative tracking. This is a design input to Unknown #8: a portfolio-level artifact (perhaps `portfolio.toml` or a lightweight registry) that aggregates per-repo `workspace.toml` status for the CTO dashboard. Feeds directly to INI-006 control plane scope.
+
+---
+
+### What INI-005 needs to automate
+
+Currently all metrics above require manual measurement or champion reporting. The instrumentation needed:
+- Timestamps on `workspace.toml` state transitions (draft, active, shipped) — enables TTFV, flow rate, and throughput without manual tracking per-repo
+- Per-repo telemetry push to a central aggregator — enables org-level metrics without manual roll-up
+- Session-start detection (first command per session) — enables session-start habit metric
+- Per-engineer spec counts — enables activation rate and 30-day retention
+
+Until INI-005 ships, measure manually via periodic `check-workspace` output, per-team reporting, and champion aggregation. Prioritise TTFV (leading indicator) and 30-day org-wide retention (lagging indicator) — they bracket the adoption arc.
+
+---
+
+## Frontstage actions
+
+- **Action:** discover-platform (peer / blog / GitHub)
+- **Action:** read-readme-and-assess-fit
+- **Action:** complete-your-first-workspace-tutorial
+- **Action:** seed-workspace-toml (first real spec)
+- **Action:** run-work-loop-first-spec
+- **Action:** prepare-demo-scenario (enterprise)
+- **Action:** deliver-live-demo (enterprise)
+- **Action:** execute-rollout-playbook (enterprise)
+- **Action:** run-check-workspace-at-session-start (habit)
+
+---
+
+## Emotional arc
+
+**Self-serve path:** Lowest point is Stage 2 (proof of value) — friction before the first success. Highest point is the moment the first spec ships and `check-workspace` shows "shipped" — immediate, visible, concrete.
+
+**Enterprise path:** Lowest point is Stage 3 (internal case / live demo) — the champion knows the platform is good but cannot transfer that conviction reliably to decision makers without a demo script. The platform is the best it has ever been and the champion is still losing rooms.
+
+**Highest-opportunity pain (enterprise):** "I've done three live demos and every one felt like I was improvising. The platform is genuinely good — the demo isn't."
+
+**Primary design response:** M6 live-demo guide closes Stage 3. The champion needs a 30-minute scripted scenario on real org code, not a toy example, with a pre-flight checklist and a narration script. Everything else in M6 (tutorial, rollout playbook) depends on Stage 3 being solved first — without decision-maker buy-in, there is no rollout.
+
+---
+
+## Open design questions (feeds M6)
+
+- **Demo scenario selection:** what makes a spec a good demo candidate? Criteria: small enough to ship in 30 min, real enough to be credible, simple enough that environment issues don't derail it.
+- **Pre-flight checklist:** what must be verified before a live demo? (Harness installed, skills loading, workspace.toml seeded, spec exists, no uncommitted changes that would confuse `work-loop`.)
+- **Harness portability of the demo:** does the demo script need harness-specific variants, or is the work-loop experience uniform enough across Claude Code / Codex CLI / Kiro that one script covers all?
+- **New-engineer onboarding integration:** should `your-first-workspace` be a standalone tutorial or embedded in a broader "new-engineer setup guide" that orgs already have?
+
+---
+
+## Handoff notes
+
+**For M6 spec authoring:** Stage 3 (Live Demo Gap) is the highest-priority M6 design problem. The live-demo guide is a prerequisite for the rollout playbook — enterprise can't roll out without buy-in, and buy-in requires a reliable demo. Sequence: live-demo guide → rollout playbook → your-first-workspace tutorial.
+
+**For `check-workspace` design (M1):** Stage 5 (Embedding) reveals that `check-workspace` is the session-start habit that prevents reversion. The M1 `check-workspace` AC should explicitly design for "first command in a session" UX — the output should answer "what do I work on next?" not just "what is in the queue?"
+
+**For INI-003 (Coding CLI Adapter Pack):** Stage 4 (Rollout) in mixed-harness orgs requires one adapter per harness type. The rollout playbook must handle harness selection as its first decision — the platform team cannot onboard engineers until they know which CLI everyone is using.

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -1,54 +1,67 @@
 # Roadmap
 
-> **Template.** Scaffolded by the bundle — replace the `<theme>` placeholders
-> and the `YYYY-MM-DD` dates with your project's real roadmap and review dates
-> before relying on it.
-
 > Direction for the next 2-4 quarters. **Not** commitments. The whole point
 > of writing this down is that it can change.
 
-**Last updated:** YYYY-MM-DD
-**Reviewed:** quarterly. Next review: YYYY-MM-DD.
+**Last updated:** 2026-07-18
+**Reviewed:** quarterly. Next review: 2026-10-18.
 
 If the current date is more than 90 days past "Last updated", treat this
 file as stale and ask before relying on it.
 
-## Now (current quarter)
+> **Orientation:** This roadmap tracks INI-002 (Platform Core) — this repo's
+> slice of INI-001 (AI-Native Ecosystem). For the governing RFC and full AC
+> list, read [`docs/rfc/0064-ini-001-ai-native-ecosystem.md`](../rfc/0064-ini-001-ai-native-ecosystem.md).
+> For the product vision, read [`docs/product/shaping/product-vision-INI-001.md`](shaping/product-vision-INI-001.md).
 
-What we're actively working on. Each item should link to a spec in
-`docs/specs/` once one exists.
+## Now
 
-- **<theme>.** <one-sentence description.> [spec: link]
-- **<theme>.** ...
+**M1 · Workspace Foundation.** `workspace.toml` seed + `check-workspace` skill + brief template DoR fields (Status, Rabbit holes, Instrumentation, Design artifacts) + work-loop / receive-brief / new-rfc extensions + agentbundle-layout.toml `[product]` table + ADR for D2/D4 architectural decisions. [RFC-0064](../rfc/0064-ini-001-ai-native-ecosystem.md)
 
-## Next (following 1-2 quarters)
+## Next
 
-What we expect to pick up after Now. These are intentions, not promises.
-Items here should have at least an RFC or a one-paragraph problem
-statement somewhere — if there's nothing written down, it's not yet
-ready to be on the roadmap.
+**M2 · Strategic Shaping.** Five new PE pack skills grounding the six-step sequence (Outcome → Problem → Diverge → Validate → Bet → Spec) at initiative altitude. `frame-situation` (bottom-up signal → typed finding → six-step route; embeds Wardley capability maturity for situational awareness). `identify-opportunities` (step-2 opportunity assessment; embeds JTBD framing — functional / emotional / social jobs). `diverge-solutions` (step-3 option generation; must resolve overlap with existing `explore-options` skill). `place-bet` (step-5 human commitment gate; betting table surface). `map-capabilities` (product vision → all capability areas in one structured pass). Initiative brief artifact + Lean Canvas template as altitude-0/1 framing. Three-altitude model grounded: Company (years; PRFAQ, OKR) → Initiative (quarters; vision, capability map, initiative brief) → Project (weeks; brief, spec, plan). [RFC-00XX · pe-pack-strategic-shaping, opens when M1 ships]
 
-- **<theme>.** <description.> [RFC: link, or "intent only"]
-- **<theme>.** ...
+**M3 · Findings & RFC Management.** `rfc-status` skill in governance-extras. `research-project-start` `.context/` bug fix. Findings register seeds (`rfc-candidates.md`, `roadmap-intents.md`). Pack renames: `research` → `desk-research` (canonical consulting/design-UX term); `experience` → `experience-design` (canonical agency term; used by frog, Fjord, AKQA). [No sub-RFC needed — direct implementation]
 
 ## Later
 
-Things we believe matter but aren't actively planning. Items here serve
-two purposes: signal to contributors that we'd accept a PR, and let us
-say "not now" without saying "never."
+**M4 · Product Strategy Layer.** Full build-out of the `product-strategy` pack (RFC-0063, already open as draft — M4 begins on acceptance). OKR cascade skill: company OKRs → gap analysis → `frame-situation` routing (bottom-up and top-down meet). PRFAQ template as the Amazon-style altitude-0 forcing function ("write the press release before the product"). Market analysis skills: Porter's Five Forces (competitive landscape), PESTLE (macro environment), BCG Matrix (portfolio position), SWOT (situation synthesis). Each skill produces a structured artifact that feeds the six-step sequence at initiative altitude. [RFC-0063 · product-strategy-pack]
 
-- <theme>
-- <theme>
+**M5 · Tracker Integration.** `github-brief-intake`, `linear` pack + `linear-brief-intake`, `jira-align-brief-intake`. [RFC-00XX · linear-pack]
 
-## Not in scope
+**M6 · Documentation Wave.** Full documentation channel sweep for workspace.toml and PE pack. Diátaxis guides (tutorials, how-tos, reference, explanation). Astro site project index view. [No sub-RFC needed]
 
-Things that have come up and that we've explicitly decided are *not*
-in scope. This is the most valuable section for AI agents and new
-contributors — it prevents wasted exploration of dead ends.
+## Shaping queue — research threads
 
-- **<thing we won't do>.** <why, briefly. link to ADR or RFC if there
-  was one.>
-- **<thing>.** ...
+Topics surfaced in the INI-001 design session that need further investigation before sister initiative RFCs can be written. Not M1–M6 scope. Captured here so they aren't lost.
+
+**Remote agent session pickup protocol.** How `workspace.toml` is consumed at session start by each major harness — Claude Code (reads from git, stateless), Devin (reads from VM snapshot), Manus (reads from TiDB record), Copilot Agent (platform-managed context). What the handoff contract looks like; what state beyond `workspace.toml` must transfer. Feeds INI-003 RFC.
+
+**Harness adapter pattern.** Whether a single adapter contract is feasible across the four execution models, or whether each harness needs a purpose-built adapter. MCP vs. static skill-file installation per harness. How the adapter handles skill invocation, gate presentation, and completion write-back. Feeds INI-003 RFC.
+
+**Cross-harness skill compatibility.** Ensuring `work-loop`, `check-workspace`, and `receive-brief` produce equivalent outcomes regardless of harness. What the test surface looks like for a skill that must behave identically in a local Claude Code session and a remote Devin VM. Feeds INI-003 RFC.
+
+**State persistence schema.** What specific agent state must survive session boundaries: `workspace.toml` (declared intent), spec execution progress (plan step, current file, intermediate artifacts), gate outcomes, agent context (decisions made mid-task not yet committed). Format and storage choices for each harness's model. Feeds INI-005 RFC.
+
+**Telemetry events schema.** What events matter for exception-based review: `spec-started`, `gate-reached`, `gate-passed`, `gate-failed`, `gate-waived`, `budget-exceeded`, `spec-stalled`, `spec-shipped`. What metadata each event carries; how events map to alert thresholds configurable per project. Feeds INI-005 RFC.
+
+**Brief-to-agent dispatch patterns.** Pull model (agents claim from `[brief_queue].ready`) vs. push model (team lead assigns). How agents signal capacity. What the dispatch API surface looks like for INI-003 to expose and INI-004 to consume. Feeds INI-004 RFC.
+
+**Adopter persona research.** Validate the Step-1 hypothesis (most teams are at Step 1 — our working assumption). Who adopts INI-002 first: solo engineer, startup PM, enterprise platform team. What their onboarding journey looks like at each altitude. Closes the known-unknown in RFC-0064.
+
+**Portfolio pack design.** How a portfolio-level pack bridges research from a private vault or team repo into this repo's shaping queue. Multi-repo initiative coordination above `workspace.toml` level — what the data model looks like when an initiative spans three repos. Feeds post-M3 RFC.
+
+**Linear 2-way sync mechanics.** The write direction (spec ships → Linear Issue closes via `Fixes LIN-123` in PR body) is settled. The read direction — Linear Issue updated / closed externally → `workspace.toml` updated — needs webhook handler design and event schema. Feeds M5 sub-RFC (linear-pack).
+
+## Not in scope (this repo)
+
+Things governed by sister initiatives — each has its own RFC when its trigger fires. See `docs/product/shaping/ecosystem-overview.md` for the full picture.
+
+- **INI-003 Coding CLI Adapter Pack.** Headless CLI adapters for Claude Code `-p`, Codex CLI, Kiro CLI, Copilot CLI, Gemini CLI; swarm orchestration via `workspace.toml`. Trigger: INI-002 M1 ships.
+- **INI-004 Remote Agent Runtime.** Cloud/VM-hosted and orchestration harnesses: Devin (VM-snapshot), Manus (TiDB-backed), Omnigent (meta-harness / pluggable sandbox providers: Modal, E2B, Daytona, Databricks), GitHub Copilot Coding Agent. Trigger: INI-002 M2 ships.
+- **INI-005 Infra & Observability.** State persistence, telemetry (spec-started / gate-failed / spec-stalled / spec-shipped events), exception detection, monitoring feedback loop. Trigger: INI-004 M1 ships.
+- **INI-006 Control Plane.** UI dashboards, brief-to-agent dispatch, exception-surfacing UI; extends INI-002 M6 Astro site. Trigger: INI-005 M1 ships.
 
 ## How this file is maintained
 

--- a/docs/product/shaping/ecosystem-overview.md
+++ b/docs/product/shaping/ecosystem-overview.md
@@ -1,0 +1,169 @@
+---
+initiative: INI-001
+type: overview
+status: draft
+shaped: 2026-07-18
+---
+
+# INI-001 AI-Native Ecosystem — Initiative Overview
+
+Six initiatives that together enable AI-native engineering maturity. INI-002 starts now. Each subsequent initiative is triggered by a specific milestone in the prior one; none starts speculatively.
+
+## The six initiatives
+
+| ID | Name | Scope | Status |
+|---|---|---|---|
+| INI-001 | AI-Native Ecosystem | Umbrella — coordinates the others; never directly built | Active (umbrella) |
+| INI-002 | Platform Core | Skills, packs, governance, workspace coordination, PE capabilities | Active — M1 |
+| INI-003 | Coding CLI Adapter Pack | Headless CLI adapters: Claude Code `-p`, Codex CLI, Kiro CLI, Copilot CLI, Gemini CLI | Not started |
+| INI-004 | Remote Agent Runtime | Cloud/VM-hosted and orchestration harnesses: Devin, Manus, Omnigent, and pluggable sandbox providers | Not started |
+| INI-005 | Infra & Observability | State persistence, telemetry, monitoring, alerting | Not started |
+| INI-006 | Control Plane | Dashboards, brief-to-agent dispatch, exception-surfacing UI | Not started |
+
+### INI-002 · Platform Core
+
+The foundation the others build on. An open, harness-agnostic catalogue of skills and packs that any team can install — from a solo engineer to a hundred-person platform team.
+
+**Already shipped:** three loops that form the operational heartbeat — the discovery loop (G0→G3: raw idea → ratified decision brief), the work loop (G3→G5: spec → plan → build → verify → review), and the release loop (G4→G5: verified build → shipped). All three are proven in production.
+
+**Pack architecture:** a multi-pack catalogue — core (workspace coordination, brief lifecycle, foundational skills), PE pack (product engineering: frame-intent, frame-domain, explore-options, de-risk-intent, decompose-intent), governance-extras (ADR, RFC, rfc-status), research pack (structured research lifecycle), experience pack (journey maps, screen flows, aesthetic direction), architect pack (C4 diagrams, ADRs, architecture review), and connector packs (atlassian, linear). Teams compose from the catalogue; no pack is mandatory.
+
+**Harness-agnostic design:** the skill surface runs unchanged across Claude Code (local), Devin (VM-snapshot), Manus (database-backed), Copilot Agent (cloud-session), and Kiro today — each harness reads the same `.md` skill files; MCP-capable harnesses consume them as registered tools. INI-003 and INI-004 wire this more deeply; INI-002 already works with manual session pickup.
+
+**Governance machinery:** ADRs (immutable architectural decisions), RFCs (reviewed decisions with full lifecycle), specs (technical decomposition with traceability lint). The traceability lint enforces that every spec links to a brief and every brief links to an intent — structural orphans are caught at CI.
+
+**Delivers:** the shaping room (six-step product thinking at initiative altitude — Outcome → Problem → Diverge → Validate → Bet → Spec), the work queue (`workspace.toml` + brief queues), and the vocabulary (Project / Milestone / Brief / Spec mapped to Linear, Jira, GitHub, Azure DevOps, Asana).
+
+### INI-003 · Coding CLI Adapter Pack
+
+The first harness tier. Adapters for headless CLI-invoked agents — the execution model where a language model is called as a subprocess, reads a task, executes work, and writes back. No persistent session, no cloud VM — a CLI invocation orchestrated by CI/CD, a supervisor agent, or a human running a command.
+
+**Target harnesses:**
+
+| Harness | CLI invocation | Key characteristic |
+|---|---|---|
+| Claude Code | `claude -p "<prompt>"` | Reads `.claude/` skills; MCP tool integration |
+| Codex CLI | `codex "<task>"` | OpenAI function calling; sandbox isolation |
+| Kiro CLI | `kiro "<task>"` | Spec-driven; reads `.kiro/` steering files |
+| GitHub Copilot CLI | `gh copilot suggest` / agent mode | GitHub-integrated; PR-aware |
+| Gemini CLI | `gemini "<task>"` | Google Workspace integration; long-context |
+
+**What each adapter does:**
+1. Reads `workspace.toml` active work item at session start
+2. Formats the task as the harness-specific CLI invocation with appropriate context
+3. Captures output and maps it back to `workspace.toml` (progress, gate outcomes, completion)
+4. Handles harness-specific quirks: tool format, context window limits, output parsing, skill discovery path
+
+**Swarm capability:** INI-003 enables running a coordinated swarm of headless CLI agents in parallel — each agent reads from `[work].active` and takes an unblocked spec. `workspace.toml` is the collision-free coordination layer: each spec has exactly one active agent. A CI/CD supervisor (or a human) launches N agents; `workspace.toml` determines who works on what.
+
+**Why separate from INI-004:** CLI adapters are stateless (each invocation is fresh), portable (run locally, in CI/CD, or on any compute), and straightforward to write (thin wrapper around a CLI command). Cloud runtimes (INI-004) have stateful session management, proprietary execution environments, and more complex integration surfaces.
+
+Trigger: INI-002 M1 shipped (`workspace.toml` schema is the stable contract the adapters target).
+
+### INI-004 · Remote Agent Runtime
+
+The cloud and orchestration harness tier. Wires INI-002's skill surface into runtimes that own their own execution environment and session lifecycle — agents that persist state across sessions without manual `workspace.toml` reads.
+
+**Execution models in scope:**
+
+| Harness | Category | Execution model | State persistence |
+|---|---|---|---|
+| Devin | Standalone cloud agent | Sandboxed cloud VM, long-running | VM snapshots; session resumes from snapshot |
+| Manus | Cloud "digital worker" | Per-task sandboxed Ubuntu VM | TiDB; structured state across sessions |
+| GitHub Copilot Coding Agent | Cloud coding session | Platform-managed, GitHub-integrated | Session-scoped; GitHub context |
+| Omnigent | Meta-harness / orchestration | Pluggable sandbox providers; routes to underlying agents | Omnigent server state; delegates to Modal, E2B, Daytona, Databricks Sandboxes, Kubernetes |
+
+**Omnigent in detail:** Released by Databricks in June 2026 (Apache 2.0). Omnigent is an orchestration layer that sits *above* other agents (Claude Code, Codex, Cursor, Pi) and routes work to pluggable sandbox providers. Key capabilities: swap harnesses without rewriting, enforce policies and sandboxing, collaborate in real time. A managed Databricks enterprise tier (currently Beta) provisions sandboxes inside a Databricks workspace with Unity AI Gateway integration. Omnigent is not a peer of Devin/Manus — it orchestrates them. For this initiative, Omnigent is interesting as the **dispatch and routing layer** that INI-002's `workspace.toml` can feed: Omnigent reads intent, selects the appropriate underlying agent and sandbox, and executes. This aligns naturally with the `workspace.toml` coordination model.
+
+**The harness adapter pattern:** a thin, harness-specific wrapper that maps INI-002 skill invocations (via agent-readable `.md` + MCP tool registration) to each runtime's tool surface. Handles: reading `workspace.toml` at session start, identifying active work, orienting the agent, executing via the work-loop, and writing completion state back.
+
+**Session pickup protocol:** on session start — (1) read `workspace.toml` from the initiative umbrella branch, (2) identify `[work].active` specs and `blocked_on` dependencies, (3) orient the agent to the current task, (4) execute via INI-002 work-loop, (5) write completion state back.
+
+**MCP as the cross-harness bridge:** harnesses that support Model Context Protocol consume INI-002 skills as registered MCP tools, enabling dynamic skill discovery without per-harness packaging.
+
+Trigger: INI-002 M2 shipped (shaping + coordination surface is stable enough that wiring it into cloud runtimes is the right next investment).
+
+### INI-005 · Infra & Observability
+
+The observability floor. Closes the gap between INI-002's declared intent (`workspace.toml`) and actual execution continuity — state that survives session boundaries, telemetry that makes exceptions visible, and alerting that surfaces them upward.
+
+**State persistence:** the specific state that must survive session boundaries — `workspace.toml` (declared intent), spec execution progress (plan step, current file, intermediate artifacts), agent context (decisions made mid-task not yet committed), and gate outcomes (what passed, what failed, what was waived). Without INI-005, this state resets at every session end; with INI-003/INI-004's session pickup it is read from git; with INI-005 it is persisted with full fidelity.
+
+**Telemetry events:** the schema matters for exception-based review. Core events: `spec-started`, `gate-reached`, `gate-passed`, `gate-failed`, `gate-waived`, `budget-exceeded` (time or token), `spec-stalled` (no progress past a threshold), `spec-shipped`. Each event carries: spec slug, milestone, agent identity, timestamp, gate name (where applicable), and outcome metadata.
+
+**Exception detection:** anomaly patterns that trigger alerts — repeated gate failures on the same step, budget overrun beyond a threshold, spec stalled for N consecutive sessions, dependency cycle detected in `blocked_on`. Detection logic reads the telemetry stream; thresholds are configurable per project.
+
+**The monitoring feedback loop:** telemetry stream → INI-005 pattern detection → anomaly event → INI-006 surfaces to team lead → human decision (resume / redirect / reassign) → feedback written back to `workspace.toml` → agent picks up on next session.
+
+Trigger: INI-004 M1 shipped — the remote runtime must exist before persistent state and telemetry have an execution surface to observe.
+
+### INI-006 · Control Plane
+
+The dispatch and monitoring surface. Translates INI-005's telemetry and INI-002's intent model into a human-facing interface so a team lead can manage ~100 agents by exception rather than by constant review.
+
+**Three user roles and what each needs:**
+
+| Role | Primary need | Key view |
+|---|---|---|
+| PM / product lead | Shaping progress visibility; brief queue health | Shaping queue status, brief DoR, milestone burndown |
+| Team lead | Exception review; agent dispatch decisions | Exception alerts, active spec map, reassignment controls |
+| Engineer | Spec assignment clarity; code review surface | My active specs, gate outcomes, PR queue |
+
+**Brief-to-agent dispatch:** reads `workspace.toml [brief_queue].ready` → presents available specs → team lead or system assigns to an available agent session in the harness (via INI-004's dispatch API). Pull model (agents claim work) and push model (team lead assigns) both supported. Omnigent's routing layer is a natural integration point here — INI-006 dispatch can delegate to Omnigent, which selects the appropriate underlying agent and sandbox.
+
+**Multi-agent visibility:** a real-time view of every active spec across all agent sessions — what step each is on, what gate is pending, what has stalled. Data model: `workspace.toml` + INI-005 telemetry.
+
+**Exception routing flow:** INI-005 anomaly event → INI-006 surfaces alert to team lead with context (spec slug, what failed, how many times, budget consumed) → team lead chooses: resume as-is / redirect with new context / reassign to different agent / escalate → decision written back to `workspace.toml` as a `blocked_on` or context note → agent picks up on next session.
+
+**Web surface:** INI-002 M6 builds the Astro project index (non-engineer PM visibility). INI-006 extends this with real-time dispatch and monitoring — the Astro site is the natural UI foundation.
+
+Trigger: INI-005 M1 shipped — the control plane is only meaningful when the observability floor it reads from exists.
+
+## How the initiatives connect
+
+The dependency chain is linear by design:
+
+```
+INI-002 (now)
+  ↓ M1 ships
+INI-003 starts (Coding CLI Adapters)
+  ↓ M2 ships
+INI-004 starts (Remote Agent Runtime)
+  ↓ M1 ships
+INI-005 starts (Infra & Observability)
+  ↓ M1 ships
+INI-006 starts (Control Plane)
+```
+
+Each step adds one capability layer. INI-003 and INI-004 can run concurrently once INI-002 M2 ships — CLI adapters (INI-003) can start after M1, and both are independent of each other after that.
+
+| Initiatives active | Maturity ceiling |
+|---|---|
+| INI-002 only | Step 2 foundation; disciplined teams can approach Step 3 manually |
+| INI-002 + INI-003 | Step 2 with CLI-driven agent swarms; multiple headless agents coordinated via `workspace.toml` |
+| INI-002 + INI-003 + INI-004 | Structured session handoff across cloud runtimes; agents resume automatically; Omnigent dispatch |
+| + INI-005 | Observable exceptions; Step 3 with monitoring |
+| All six | Step 4: intent-steered, monitored by exception, 1000+ agent scale |
+
+## How INI-002 ties to each sister initiative
+
+**→ INI-003 (Coding CLI Adapters):** INI-003 wraps INI-002's skill surface for CLI invocation. The adapter reads `workspace.toml`, invokes the harness-specific CLI command with the appropriate context, and writes back. INI-002's `workspace.toml` schema (M1) is the stable contract INI-003 targets.
+
+**→ INI-004 (Remote Agent Runtime):** INI-004 wraps INI-002's skills for cloud/VM-hosted runtimes. It handles session pickup, harness-specific tool surface mapping (MCP or static), and completion write-back. INI-002 M2 (stable shaping + coordination surface) is the trigger.
+
+**→ INI-005 (Infra & Observability):** INI-005 reads INI-002's declared intent (`workspace.toml`, brief status, spec outcomes) and persists it across session boundaries into telemetry. INI-002 writes the intent; INI-005 ensures it survives and is measurable.
+
+**→ INI-006 (Control Plane):** INI-006 surfaces INI-002's brief queue and workspace state as a dashboard. The project index (`docs/product/projects/`) and `workspace.toml` are the read model. INI-002 provides the data structure; INI-006 provides the human-facing UI.
+
+## INI-002 independence
+
+INI-002 is fully self-contained. Nothing in this repo depends on INI-003, INI-004, INI-005, or INI-006 existing.
+
+**Without the sister initiatives, INI-002 alone delivers:**
+
+- **Step 1 → Step 2, fully.** Multiple specs executing in parallel, coordinated through `workspace.toml`, with structured shaping and human review at each gate.
+- **Disciplined approach toward Step 3.** The three loops and shaping room create the structural conditions for exception-based human oversight. Without automated telemetry, exceptions are surfaced manually — a team lead reads workspace state and reviews only what diverged. Demanding but achievable for disciplined teams.
+- **Step 3 true completion: blocked on INI-004 + INI-005.** Automated session pickup and observable telemetry are required for exception-based review to work at ~100-agent scale.
+- **Step 4: blocked on all six initiatives.**
+
+The practical ceiling for INI-002 alone is **Step 2, reliably, with disciplined operation toward Step 2.5** — many agents in parallel, coordinated intent, structured shaping, human review at gates. This is independently valuable and the correct starting point for any team not yet at Step 2.

--- a/docs/product/shaping/product-vision-INI-001.md
+++ b/docs/product/shaping/product-vision-INI-001.md
@@ -1,0 +1,69 @@
+---
+initiative: INI-001
+type: vision
+status: draft
+shaped: 2026-07-18
+---
+
+# Product Vision — INI-001 AI-Native Ecosystem
+
+## Headline
+
+A product OS for engineering teams — the coordination layer that closes the gap between one AI assistant and a thousand coordinated agents.
+
+## The problem
+
+Most engineering teams today are at Step 1 — our working hypothesis, to be validated by adopter-persona research. Models capable of sustained multi-step engineering work became widely available in 2024–2025. The bottleneck is no longer individual capability. It is coordination.
+
+When a session ends, the context is gone. When a second agent starts, it knows nothing of the first. When ten engineers each run their own AI assistant, there is no coordination layer: duplicate work, conflicting decisions, no visibility into what is in flight. The gap between what a single agent can do and what a hundred coordinated agents could do — Step 3, the ecosystem-level first target — is not a model capability gap. It is a product OS gap.
+
+The maturity ladder makes this concrete:
+
+| Step | Mode | Scale | Characteristic |
+|---|---|---|---|
+| 0 | Gated | — | No AI; waiting for approval or tooling |
+| 1 | Assisted | ~1 agent | Human-in-loop for every action; the most common starting point |
+| 2 | Parallel | ~10 agents | Batch review; fast-moving startups |
+| 3 | Supervised | ~100 agents | Exception-based review; leading AI-native orgs |
+| 4 | AI-native | 1000+ agents | Intent-steered, monitored by exception |
+
+The cliff between Step 1 and Step 4 is not a capability cliff — it is the same infrastructure gap that separated individual programmers from scalable engineering organizations in the 1990s. What built the latter was not better individual programmers. It was the OS, the toolchain, and the coordination patterns.
+
+## The solution
+
+An open, harness-agnostic product OS platform. A multi-pack catalogue that any team can install and compose — from a solo engineer to a hundred-person platform team. The platform provides four interlocking layers:
+
+**The three loops.** The heartbeat of an AI-native organization. A discovery loop (G0→G3) that turns raw product ideas into ratified, build-ready decisions. A work loop (G3→G5) that executes specs through plan → build → verify → review. A release loop (G4→G5) that ships. All three loops are proven and shipped. Gate density decreases as teams mature: the loops provide the structure; exception-based review at Step 3 requires INI-003 (harness runtime), INI-005 (observability), and INI-004 (control plane) — in that dependency order.
+
+**The shaping room.** Structured product thinking before any agent touches code. The six-step sequence (Outcome → Problem → Diverge → Validate → Bet → Spec) is applied at each altitude, producing a hierarchy of artifacts: product vision → strategy → capability map → initiative brief → brief. The brief is the shaped work unit — problem statement, appetite, rabbit holes, instrumentation — that hands off to the work loop. **The shaping room is where human judgment is injected into the pipeline; the build room** (the work and release loops) **is where agents execute under it.**
+
+**The work queue.** `workspace.toml` — the coordination layer. A committed file on an initiative umbrella branch that declares what is being shaped, what is ready to build, what specs are executing, and what has shipped. Not execution state (that lives in the platform); declared intent that any agent can read to orient itself at session start.
+
+**The vocabulary.** A common language that maps to every team's existing tools. Brief ≈ Linear Issue ≈ Jira Story ≈ GitHub Issue. Project ≈ Linear Project ≈ Jira Epic. Milestone ≈ Linear Milestone ≈ GitHub Milestone. Initiative ≈ Linear Initiative ≈ Jira Initiative. Spec ≈ Sub-issue ≈ Sub-task. Teams do not abandon their trackers; the platform connects to them.
+
+## The adopter
+
+Any engineering team that wants to run more agents than it has engineers. INI-002 is useful at Step 1 (one engineer, one agent, structured specs) and lays the foundation for the INI-001 ecosystem to scale to Step 4. Primary early adopters are platform-oriented engineering teams — internal tooling, developer platforms, multi-component systems — because they feel the coordination gap most acutely. Consumer product teams are secondary adopters, where the structured shaping machinery is the primary draw. Solo engineers are a long-tail but real cohort: the platform's discipline pays dividends even at one-agent scale.
+
+## Why now
+
+Models capable of sustained multi-step engineering work became widely available in 2024–2025 — the bottleneck shifted from model capability to coordination infrastructure. Every team has the ingredients; almost no team has the infrastructure to combine them. The three-loop OS pattern is proven. The `workspace.toml` coordination layer is the last missing primitive at the project level. The strategy and planning layer is the next wave.
+
+## What this is not
+
+Not a harness or agent runtime. Not a UI or dashboard. Not a cloud service — the platform runs wherever the agent runs, across any harness. Not a tracker replacement — it integrates with Linear, GitHub, Jira, and Jira Align. Not prescriptive about which AI model is used. Not a manager of execution state — platforms manage their own execution; this platform manages intent.
+
+## Time horizon
+
+At twelve months, teams using INI-002 have structured shaping workflows, coordinated brief queues, and `workspace.toml` as the session-start orientation artifact — the foundation for Step 2: parallel autonomy with ~10 agents coordinated. Reaching Step 3 (supervised autonomy, exception-based review, ~100 agents) requires INI-003, INI-005, and INI-004 — in that dependency order. The full Step 4 stack — intent-steered, monitored by exception, 1000+ agent scale — requires all five initiatives. The thirty-six-month horizon is the full INI-001 ecosystem, not this repo alone.
+
+## Initiative structure
+
+| ID | Name | Scope | Trigger |
+|---|---|---|---|
+| INI-001 | AI-Native Ecosystem | Umbrella initiative — never directly built | — |
+| INI-002 | Platform Core | Skills, packs, governance, workspace management, PE capabilities (this repo) | Now |
+| INI-003 | Coding CLI Adapter Pack | Headless CLI adapters: Claude Code `-p`, Codex CLI, Kiro CLI, Copilot CLI, Gemini CLI | INI-002 M1 shipped |
+| INI-004 | Remote Agent Runtime | Cloud/VM-hosted and orchestration harnesses: Devin, Manus, Omnigent + sandbox providers | INI-002 M2 shipped |
+| INI-005 | Infra & Observability | State persistence, telemetry, monitoring | INI-004 M1 shipped |
+| INI-006 | Control Plane | UI dashboards, management interfaces, dispatch surface | INI-005 M1 shipped |

--- a/docs/rfc/0064-ini-001-ai-native-ecosystem.md
+++ b/docs/rfc/0064-ini-001-ai-native-ecosystem.md
@@ -1,0 +1,531 @@
+# RFC-0064: INI-001 AI-Native Ecosystem — Platform Core
+
+- **Status:** Draft
+- **Author:** eugenelim
+- **Approver:** eugenelim
+- **Date opened:** 2026-07-18
+- **Date closed:** —
+- **Decision weight:** heavy
+- **Related:**
+  - [docs/product/shaping/product-vision-INI-001.md](../product/shaping/product-vision-INI-001.md) — initiative vision and maturity model
+  - [docs/product/shaping/ecosystem-overview.md](../product/shaping/ecosystem-overview.md) — six-initiative dependency map
+  - **Journey maps** — `docs/product/journeys/` — eight living journey maps covering adoption, all personas, and both shaping and build rooms; see [README](../product/journeys/README.md) for the full index and status lifecycle
+    - [team-evaluates-and-adopts.md](../product/journeys/team-evaluates-and-adopts.md) — planned; prerequisite journey covering self-serve and enterprise adoption paths; surfaces live-demo gap and org-level measurement gap as primary pains; feeds M6 (tutorial, rollout playbook, live-demo guide) and Unknown #8 (portfolio pack)
+    - [engineer-adopts-coordination.md](../product/journeys/engineer-adopts-coordination.md) — planned; install through session continuity; surfaces `author-brief` gap and brief queue creation problem
+    - [engineer-runs-work-loop.md](../product/journeys/engineer-runs-work-loop.md) — planned; core build cycle before and after M1.7 workspace integration; surfaces post-ship state gap as primary pain
+    - [agent-executes-spec.md](../product/journeys/agent-executes-spec.md) — planned; headless autonomous execution; surfaces orientation accuracy and exit-state integrity as primary failure modes
+    - [engineer-scales-to-swarm.md](../product/journeys/engineer-scales-to-swarm.md) — shaping; adapter setup through exception recovery; surfaces atomic claiming, stale-active, partial-progress, and mixed-concurrency open design questions for INI-003 sub-RFC
+    - [product-engineer-shapes-initiative.md](../product/journeys/product-engineer-shapes-initiative.md) — proposed; six-step shaping sequence; surfaces session-bound shaping chain as primary pain; feeds M2 sub-RFC
+    - [product-strategist-sets-direction.md](../product/journeys/product-strategist-sets-direction.md) — proposed; altitude-0 artifacts and OKR cascade; surfaces altitude-0 → altitude-1 handoff gap; feeds M4 sub-RFC
+    - [pm-intakes-from-tracker.md](../product/journeys/pm-intakes-from-tracker.md) — proposed; tracker-to-brief intake; surfaces duplicate-write friction and tracker-brief drift; feeds M5 sub-RFC
+
+## How to orient at session start
+
+**Until `check-workspace` (M1.5) exists:** read this file + `docs/product/roadmap.md` + `docs/product/shaping/product-vision-INI-001.md` + `docs/product/shaping/ecosystem-overview.md`. Then check `docs/product/briefs/` for any in-progress brief stubs.
+
+**Once `check-workspace` exists (after M1.5 ships):** run `check-workspace` — it reads `workspace.toml` and surfaces the current queue state and next action. This is the single cold-start command from M1.5 onward.
+
+**Once `rfc-status` (M3 AC 3) exists:** run `rfc-status` — it will surface active sub-RFCs and milestone status.
+
+**Queue unlock progression** — M1.5 unlocks visibility of all three queues; full operational wiring arrives in steps:
+
+| Queue | Visible | Fully wired | What wires it |
+|---|---|---|---|
+| `[work]` | M1.5 | M1.7 | `work-loop` reads queue at step 0; marks spec shipped on complete |
+| `[brief_queue]` | M1.5 | M1.8 + `author-brief` | `receive-brief` moves draft → ready; `author-brief` creates briefs from external input |
+| `[shaping_queue]` | M1.5 | M2 | New PE skills (`frame-situation`, `map-capabilities`, `place-bet`) write to/from shaping queue; existing skills (`frame-intent`, `de-risk-intent`) work items but do not write back |
+
+Between M1.5 and M1.7: you can see the work queue but `work-loop` does not yet auto-read it at session start. Between M1.5 and M2: shaping queue items can be manually placed and worked with existing PE skills but state is not written back automatically.
+
+**Batch ↔ milestone label crosswalk** (journey files and the queue-unlock table above use the M1.x labels; the AC section uses the Batch labels):
+
+| AC label | Milestone label | Key delivery |
+|---|---|---|
+| Batch 2 | M1.5 | `check-workspace` ships; all three queues become visible |
+| Batch 3 | M1.7 | `work-loop` workspace integration; work queue fully wired |
+| Batch 4 | M1.8 | `receive-brief` + `author-brief`; brief queue fully wired |
+| Batch 5 | M1.9 | `new-rfc` workspace prompt; governance integration |
+
+M1 is the initial implementation scope. M2–M6 begin sequentially when the prior milestone ships. Sub-RFCs govern net-new design decisions within M2, M4, and M5. Post-acceptance corrections to this RFC's own decisions are recorded as **Errata** per RFC-0055.
+
+## Implementation guide
+
+Each spec is one work-loop round (`new-spec` → plan → build → verify → review). Each milestone contains multiple specs. This section gives the spec dependency graph and recommended order so a cold session can start immediately without re-reading the full design history.
+
+### M1 delivery batches — estimated 2–3 weeks
+
+M1 is organised into five functional delivery batches. Each batch ships as one PR (or two tightly-coupled PRs where noted). No batch leaves dangling work — each is a self-contained, non-breaking improvement. Batches 1 and 2 must ship first in sequence; Batches 3, 4, and 5 can overlap once Batch 2 lands.
+
+**Batch 1 — Foundation docs** (ship first; no code; pure additions)
+
+| Delivers | Notes |
+|---|---|
+| ADR: D2 (TOML format) + revised D4 (workspace.toml on main, no umbrella branch) | Doc only. Records the decisions before any implementation begins. |
+| CONVENTIONS.md §5b: admit `projects/`, `shaping/`, `findings/`, `initiatives/`, `research/` under `docs/product/` | Small amendment. Clears the path for Batch 5 seeds and M3 research output. |
+
+**Batch 2 — Workspace core** ← *unlock batch; ship as one PR*)
+
+| Delivers | Notes |
+|---|---|
+| `workspace.toml` schema seed committed to `main`, pre-populated with INI-002 queue | New file on main. Non-breaking — nothing reads it yet. |
+| `agentbundle-layout.toml [product]` table: configurable `projects/` and `shaping/` paths | Config extension alongside the seed. |
+| `check-workspace` skill in core pack | Reads local `workspace.toml`; resolves DAG across all three queues; surfaces ready/blocked/parallel across all active initiatives. Offers to initialise if file absent. |
+
+After this batch merges, **run `check-workspace` at every session start** — it orients in one command from here on.
+
+**Batch 3 — Work queue end-to-end** (after Batch 2; one PR)
+
+| Delivers | Notes |
+|---|---|
+| `work-loop` workspace integration | Reads `workspace.toml` at step 0 for initiative context; on ship, moves spec `active → shipped` and surfaces `roadmap.md` update reminder. Degrades gracefully if file absent (existing behavior unchanged). |
+
+After this batch: specs are claimed, executed, marked shipped, and the next ready item surfaces — all automatically. The work queue is live end-to-end.
+
+**Batch 4 — Brief queue end-to-end** (after Batch 2; one PR; independent of Batch 3)
+
+| Delivers | Notes |
+|---|---|
+| Brief template DoR fields: `Status`, `Rabbit holes`, `Instrumentation`, `## Design artifacts` | Grandfathered for existing briefs — new fields optional retroactively; `receive-brief` handles both shapes. |
+| `receive-brief` workspace integration | Sets `Status: Ready` after decomposition; writes `workspace.toml` (brief `draft → ready`). Degrades if absent. |
+| `author-brief` skill | Takes unstructured external input (email, prose, Linear text); elicits missing DoR fields; creates brief file; writes to `[brief_queue].draft`. |
+
+After this batch: any input source (external email, shaped artifact, tracker copy-paste) becomes a queued brief in one invocation. The brief queue is live end-to-end.
+
+**Batch 5 — Governance integration + shaping home** (safe to ship any time after Batch 1; `new-rfc` queue-write is a no-op until Batch 2 lands — degrades gracefully)
+
+| Delivers | Notes |
+|---|---|
+| `new-rfc` workspace prompt | Accepted-RFC path prompts "Add implementation specs to `workspace.toml` queue?" Degrades if absent. |
+| `docs/product/projects/_template.md` seed | Project index template. Batch 1 CONVENTIONS amendment should land first. |
+| Shaping + initiative artifact seeds (`docs/product/shaping/`, `findings/`, `initiatives/`) | Seed files for shaping artifacts. Bundle with the template — same PR. |
+
+**Recommended session order:** Batch 1 → Batch 2 (same or next session) → Batches 3, 4, 5 in any order or concurrently.
+
+### M2 JIT scenario — build the skill, then use it
+
+M2 skills should be built and used in sequence: each skill ships, then is immediately used to produce a shaping artifact or brief that feeds the next spec. This is the JIT build-then-use pattern.
+
+| Step | Build | Then use it to |
+|---|---|---|
+| M2.1 | `frame-situation` (signal → typed finding → six-step route; embeds Wardley) | Run `frame-situation` on the current INI-002 shaping queue — produce a typed finding that validates the M2 opportunity assessment and updates the shaping queue in `workspace.toml` |
+| M2.2 | `identify-opportunities` (JTBD framing: functional / emotional / social jobs) | Run `identify-opportunities` on the PE pack gap — produces an opportunity assessment artifact in `docs/product/shaping/` that shapes the `diverge-solutions` brief |
+| M2.3 | `diverge-solutions` (step-3 option generation; resolve overlap with `explore-options`) | Run `diverge-solutions` on the workspace coordination design — generates solution options for M3+ shaping work |
+| M2.4 | `place-bet` (human commitment gate; betting table surface) | Run `place-bet` on the validated option from the M2.3 diverge-solutions output — produces a committed bet artifact that anchors the capability map |
+| M2.5 | `map-capabilities` (product vision → all capability areas) | Run `map-capabilities` on INI-002 using the M2.4 bet — produces a capability map in `docs/product/shaping/` that becomes the shaping anchor for M3–M6 |
+| M2.6 | Initiative brief artifact + `docs/product/initiatives/_template.md` + Lean Canvas | Use the bet from M2.5 to author the INI-002 initiative brief using the new template |
+| M2.7 | JTBD framing embedded in `frame-intent` (shipped skill modification — own spec, not bundled with M2.6) | Run `frame-intent` on an existing project after the JTBD extension ships — verify functional / emotional / social job output appears in the frame-intent artifact |
+
+If implementing a skill reveals the RFC's AC was wrong or too narrow, write an **Errata** to RFC-0064 in the same PR per RFC-0055. Do not silently diverge.
+
+### M3–M6 ordering notes
+
+- **M3** covers four groups: findings register seeds, `rfc-status` skill, `research-project-start` bug fix, and two pack renames (`research` → `desk-research`; `experience` → `experience-design`). No sub-RFC. The renames and bug fix are independent and can ship in parallel PRs; seeds and `rfc-status` form one PR.
+- **M4** (product-strategy pack full build-out) — RFC-0063 is already open as a draft; M4 begins on RFC-0063 acceptance. No new RFC to open.
+- **M5** (tracker integration) similarly opens RFC-00XX · linear-pack. The github-brief-intake skill can ship independently of the linear pack; do it first as a confidence-building spec.
+- **M6** (documentation wave) is parallelisable — skills docs, seeds docs, and the Astro site project index are independent. Run three parallel specs if bandwidth allows.
+
+## Reviewer brief
+
+- **Decision:** Establish INI-001 (AI-Native Ecosystem) as the governing initiative, define INI-002 (Platform Core) as this repo's scope, adopt `workspace.toml` as the in-repo coordination artifact, adopt a standard vocabulary (Project / Milestone / Brief / Spec), introduce the shaping queue concept, and authorise a six-milestone implementation roadmap.
+- **Recommended outcome:** accept.
+- **Immediate change if accepted (M1 — begins on acceptance):**
+  - New `workspace.toml` file format and seed in the core pack.
+  - New `check-workspace` skill in the core pack.
+  - New `[shaping_queue]` section in `workspace.toml` (upstream of the existing `[brief_queue]` concept).
+  - Extended brief template: adds `Status`, `Rabbit holes`, `Instrumentation`, and `## Design artifacts` fields.
+  - Extended `work-loop`: reads `workspace.toml` at step 0; pops queue and updates brief Coverage post-ship.
+  - Extended `receive-brief`: sets `Status: Ready`; optionally writes `workspace.toml`.
+  - Extended `new-rfc`: Accepted path prompts to add implementation specs to the queue.
+  - New initiative and shaping artifact seeds.
+  - `CONVENTIONS.md § 5b` amended for new `docs/product/` subdirectories.
+  - ADR authored recording D2 (workspace.toml TOML format) and revised D4 (workspace.toml on main, no umbrella branch, spec branches target main directly).
+  - Sub-RFCs govern M2, M4, and M5 implementation (see § Sub-RFCs).
+- **Affected surface:** core pack (skills + seeds), governance-extras pack (rfc-status skill), PE pack (new skills), adopter-facing `workspace.toml` convention; M3 pack renames: `research` → `desk-research` and `experience` → `experience-design` (pack manifests, `plugin.json`, `agentbundle-layout.toml`, deprecation aliases, build-self).
+- **Stakes:** high — introduces new adopter-facing file format and vocabulary; reversible at pack level (no database, no breaking schema change to existing artifacts).
+- **Review focus:** (1) vocabulary choices (Project / Milestone / Brief / Spec) and tracker mapping; (2) `workspace.toml` schema and the three-section split (shaping / brief / work) with typed shaping queue entries; (3) workspace.toml on main as the git coordination pattern (revised D4 — no umbrella branch); (4) scope boundary between INI-002 and sister initiatives.
+- **Not in scope:** INI-003 (Coding CLI Adapter Pack), INI-004 (Remote Agent Runtime), INI-005 (Infra & Observability), INI-006 (Control Plane) — separate initiatives, mentioned for ecosystem context only. This RFC ships when M1–M6 in-repo ACs are complete, regardless of whether sister initiatives have started.
+
+## The ask
+
+- **Recommendation (BLUF):** Adopt `workspace.toml` as the in-repo declared-intent coordination artifact, establish the three-queue model (shaping → brief → work), standardise vocabulary, and authorise six milestones of implementation work within INI-002.
+- **Why now (SCQA):**
+  - *Situation.* The three loops (discovery, work, release) are shipped and proven. Teams can run individual specs end-to-end.
+  - *Complication.* There is no coordination layer above the spec. Strategic context lives in session logs that expire. No structured mechanism exists to queue briefs, track initiative scope, or orient an agent at session start without manual file-reading.
+  - *Question.* What is the minimal in-repo structure that enables a team to declare intent, queue work, and orient any agent at any session start — without locking into a specific harness or tracker?
+- **Decisions requested:**
+
+  | ID | Question | Recommendation | Why | Decide by | Reviewer action |
+  |---|---|---|---|---|---|
+  | D1 | Standard vocabulary? | **Project / Milestone / Brief / Spec** | Cross-tool consensus; maps cleanly to Linear, Jira, GitHub, Azure DevOps; carries more semantic weight than "Issue" at the brief level | RFC acceptance | Accept or propose alternate term set |
+  | D2 | Coordination artifact format? | **`workspace.toml` (TOML)** committed on `main` | Declared intent only; TOML's structured-data strengths (nested sections, typed lists, co-located comments) fit a file agents read programmatically; execution state lives in the platform | RFC acceptance | Accept or propose Markdown+frontmatter |
+  | D3 | Three-queue split? | **`[shaping_queue]` + `[brief_queue]` + `[work]`** | Maps to the six-step development sequence: shaping (upstream) → brief (step 5) → spec (step 6); different skills operate on each queue; `[shaping_queue]` handles all upstream work via typed entries (`research`, `strategy`, `shape`, `signal`) so non-technical users (researchers, product strategists) have queue visibility without separate sections | RFC acceptance | Accept or propose separate `[research_queue]` / `[strategy_queue]` sections |
+  | D4 | Git coordination pattern? | **`workspace.toml` on `main`** — spec branches target `main` directly; each spec PR updates `workspace.toml` in the same diff; no umbrella branch | Fast-merge, no-long-lived-branch model. Concurrent specs touch different TOML entries; rebase conflicts are trivially resolved. Umbrella branches solve a coordination problem that only exists with long-lived in-flight work — unnecessary here. | RFC acceptance | Accept or propose umbrella branch |
+  | D5 | Shaping artifacts in-repo? | **Yes — vision, capability maps, opportunity assessments committed to `docs/product/shaping/`** | Strategic shaping artifacts are decisions, not corpora; they belong in the committed tree | RFC acceptance | Accept or propose external-only |
+  | D6 | Brief-level `Status` field? | **Explicit hand-set field** (Draft → Ready → Executing → Shipped) distinct from spec-level Coverage | Spec Coverage is auto-derived from each spec's own `Status:` field (CONVENTIONS); brief-level Status is declared intent, hand-set at DoR gate and at ship — two different fields on two different artifact levels. DoR "Ready" gate: brief has Outcome, Appetite, ≥1 Rabbit hole, and a Spec map skeleton | RFC acceptance | Accept or propose auto-derive brief Status from spec rollup |
+  | D7 | Dependency model for queue entries? | **Inline `needs` field on queue entries** — entry is a string (no deps) or `{path/slug, needs}` (with deps); `needs` uses a queue-prefix notation (`work:`, `shape:`, `brief:`) to express cross-queue deps; cross-initiative deps prefix the initiative slug: `"ini-002:work:spec/..."` | Flat lists can't express "these three run in parallel, this one waits for that one." The JIT build-then-use pattern (build a skill → use it to do shaping work) requires cross-queue deps. Cross-initiative prefix enables `check-workspace` to resolve deps that span parallel initiatives in the same file. Enforcement stays with `check-workspace` (display); work-loop enforcement deferred | RFC acceptance | Accept or propose a separate `[deps]` table |
+  | D8 | Research output path? | **`docs/product/research/<slug>/`** (repo-scoped default); personal workspace is user-configured (e.g. Obsidian ACE vault at `<vault>/efforts/research/<slug>/`) | `.context/research/` (current pack.toml default) is gitignored ephemeral scratch — not durable across sessions, not committed, not team-visible. Research artifacts are decisions that belong in the committed tree alongside `docs/product/shaping/`. `research/` is separate from `findings/` (structured registers: `rfc-candidates.md`, `roadmap-intents.md`). No universal Obsidian vault default path exists — personal branch of the elicitation prompts for the vault path explicitly. Dropped as part of M3 `research-project-start` fix. | RFC acceptance | Accept `docs/product/findings/` (mixes artifacts with registers) or external-only |
+  | D9 | Typed shaping_queue entries? | **`type` field on shaping_queue entries** — `research` (desk-research pack), `strategy` (product-strategy pack), `shape` (PE six-step, default), `signal` (ongoing landscape monitoring — does not graduate to a brief; surfaced by `check-workspace` as "active context," not "ready to start"; subtypes deferred — e.g., regulatory, market, technology, risk; hand-authored in `workspace.toml` by the strategist — no skill produces a `signal` entry); `check-workspace` surfaces each type with the right skill prompt; cross-type deps use the queue prefix: `needs = "research:<slug>"`. **Terminology note:** `frame-situation` consumes raw input signals (market events, OKR gaps) and routes them into the six-step sequence as `shape`-typed queue entries — distinct from `type = "signal"` entries. Input-signal = raw triggering event; `type = "signal"` = standing non-graduating landscape concern. | Research and altitude-0 strategy are upstream of PE shaping but are done by different people (researchers, product strategists). `signal` entries represent ongoing landscape concerns (regulatory surveillance, competitive monitoring, technology watch) whose lifecycle is fundamentally different — they inform shaping decisions without producing a brief; the canonical term is from strategic foresight practice (STEEP, horizon scanning). Typed entries give all roles queue visibility without adding separate sections. Default `shape` means existing entries require no migration. | RFC acceptance | Accept separate `[research_queue]` + `[strategy_queue]` sections |
+
+## Problem & goals
+
+### Problem
+
+Teams operating at Step 1–2 of AI-native maturity have no structured way to:
+1. Declare which initiative a body of work belongs to and what its outcome is.
+2. Queue briefs in priority order and track their readiness (Draft → Ready → Executing → Shipped).
+3. Queue specs for execution and have an agent orient to them at session start.
+4. Capture product vision, strategy, and capability maps as committed artifacts that survive session boundaries.
+5. Connect work in a component repo to an initiative that may span multiple repos.
+6. Express dependencies between work items within and across queues — what can run in parallel, what must sequence, and where a build ship unlocks shape work or a shape output unlocks the next brief.
+
+### Goals
+
+- Any agent can open a session and, with one skill invocation, know: current initiative → shaping queue → brief queue → active specs → what to work on next.
+- `check-workspace` resolves the dependency graph and surfaces parallel candidates (what can start now) separately from blocked items (what is waiting and why).
+- A team can bootstrap `workspace.toml` from an RFC or roadmap — pre-seeded with all known work items and cross-queue deps — so cold-start is immediately useful from the first session after `check-workspace` ships.
+- `workspace.toml` works without any particular harness, tracker, or CI system.
+- The vocabulary maps to every major tracker so no team abandons their existing tools.
+
+### Non-goals
+
+- Real-time execution state in git (that lives in the harness platform).
+- Cross-repo coordination above the initiative level, CLI/cloud harness adapters, session management, UI/dashboards, or observability infrastructure — these are sister initiatives (INI-003/004/005/006) painted in `docs/product/shaping/ecosystem-overview.md` for context; none are in scope here.
+- Prescribing which harness or model is used.
+
+## Proposed design
+
+### Vocabulary
+
+| Our term | Definition | Maps to |
+|---|---|---|
+| **Initiative** | Cross-repo, multi-quarter strategic goal | Linear Initiative / Jira Initiative (Premium) / Jira Align Theme |
+| **Project** | Per-repo, time-bounded outcome (3–8 weeks) | Linear Project / Jira Epic / GitHub Milestone / Asana Project |
+| **Milestone** | Named checkpoint within a project (set of briefs) | Linear Milestone / GitHub Milestone / GitLab Milestone |
+| **Brief** | Shaped work unit — problem + appetite + rabbit holes + instrumentation | Linear Issue / Jira Story / GitHub Issue / Shape Up Pitch |
+| **Spec** | Technical decomposition of a brief | Linear Sub-issue / Jira Sub-task / GitHub Sub-issue |
+
+### `workspace.toml` schema
+
+`workspace.toml` lives on `main`. It is a **repo-level artifact** that persists with the repo across initiatives — not scoped to any one initiative's lifetime. Each initiative gets its own named section. Multiple initiatives can run in parallel. When an initiative ships, its section is removed; git history preserves the record. Blank file (or empty-sections file) = no active initiatives.
+
+Queue entries are **strings** (no dependencies) or **inline objects** `{path/slug, needs}` (with dependencies). `needs` is a string or list; prefix with the queue: `"work:path"`, `"shape:slug"`, `"brief:path"`. Cross-initiative deps prefix the initiative slug: `"ini-002:work:spec/m1-check-workspace"`. `check-workspace` reads all sections, resolves the DAG across all active initiatives, and surfaces (a) items ready to start now, (b) blocked items with reason, (c) parallel candidates.
+
+**Schema — per-initiative named section:**
+
+```toml
+["<initiative-slug>"]
+name      = "<human name>"
+status    = "active"          # active | shipped
+milestone = "<current milestone name>"
+parent    = "<INI-ID or URL>"
+
+["<initiative-slug>".shaping_queue]
+# All upstream work. Entries are strings or {slug, type?, needs?} objects.
+# type: "shape" (default — PE six-step), "research" (desk-research pack), "strategy" (product-strategy pack), "signal" (ongoing monitoring — does not graduate to brief)
+# check-workspace surfaces each type with the right skill prompt for the user's packs.
+# signal entries surface as "active context" (not "ready to start"). Cross-type deps: needs = "research:<slug>" or "strategy:<slug>"
+active  = []
+backlog = []
+
+["<initiative-slug>".brief_queue]
+# Status lifecycle: Draft → Ready (DoR gate) → Executing → Shipped
+# Skills: receive-brief, author-brief, new-rfc
+executing = ""
+ready     = []
+draft     = []
+
+["<initiative-slug>".work]
+# Entries are strings or {path, needs} objects.
+# needs resolves within any queue or across initiatives.
+# work-loop updates this file on ship (edit in working directory, committed in same PR).
+active  = []
+shipped = []
+queue   = []
+```
+
+**Blank state** — no active initiatives:
+
+```toml
+# workspace.toml — add ["<initiative-slug>"] sections to declare initiatives
+```
+
+**Closeout** — when all specs reach `shipped` and `active = []`, `check-workspace` surfaces: "ini-002: all specs shipped — run closeout?" Closeout removes the `["ini-002"]` section block. Git history preserves the record; no archive file needed.
+
+**Multi-initiative example** — two parallel initiatives with a cross-initiative dependency:
+
+```toml
+["ini-002"]
+name      = "Platform Core"
+status    = "active"
+milestone = "M1 · Workspace Foundation"
+parent    = "INI-001"
+
+["ini-002".work]
+active  = []
+shipped = ["spec/m1-workspace-core", "spec/m1-work-queue"]
+queue   = []  # all shipped — closeout pending
+
+["ini-003"]
+name   = "Coding CLI Adapters"
+status = "active"
+parent = "INI-001"
+
+["ini-003".work]
+active  = []
+shipped = []
+queue   = [
+  # ini-003 cannot start until ini-002 workspace-core ships
+  {path = "spec/ini003-adapter-foundation",
+   needs = "ini-002:work:spec/m1-workspace-core"},
+]
+```
+
+**Bootstrap example — INI-002 M1, committed to `main` with the workspace-core batch (Batch 2):**
+
+```toml
+# workspace.toml
+
+["ini-002"]
+name      = "Platform Core"
+status    = "active"
+milestone = "M1 · Workspace Foundation"
+parent    = "INI-001"
+
+["ini-002".shaping_queue]
+active  = []
+backlog = [
+  # Signal items — hand-authored by strategist; ongoing, non-graduating
+  {slug = "ai-native-regulatory-watch", type = "signal"},
+  # Research items — any user with the desk-research pack can pick these up
+  {slug = "adopter-persona",   type = "research"},
+  # Shaping items — PE picks up when upstream research is done
+  "ini-002-initiative-brief",
+  {slug = "opp-assessment-pe-pack",  needs = "work:spec/m2-frame-situation"},
+  {slug = "capability-map-ini-002",  needs = "work:spec/m2-map-capabilities"},
+]
+
+["ini-002".brief_queue]
+executing = ""
+ready     = []
+draft     = []
+
+["ini-002".work]
+active  = []
+shipped = ["spec/m1-workspace-core"]  # Batch 2 — workspace core ships with this file
+queue   = [
+  # Batch 3 — work queue end-to-end (after workspace-core)
+  {path = "spec/m1-work-queue",
+   needs = "work:spec/m1-workspace-core"},
+  # Batch 4 — brief queue end-to-end (after workspace-core, independent of Batch 3)
+  {path = "spec/m1-brief-queue",
+   needs = "work:spec/m1-workspace-core"},
+  # Batch 5 — governance + shaping (independent)
+  "spec/m1-governance-integration",
+  "spec/m1-shaping-seeds",
+]
+```
+
+Note: Batches 1 and 2 (foundation docs + workspace core) need no spec entries — they are the infrastructure. `spec/m1-workspace-core` covers the workspace.toml seed, layout config, and check-workspace skill shipped as one unit.
+
+Once the workspace-core batch ships, run `check-workspace` — it reads this file and surfaces what is ready to start next.
+
+**Scale — start minimal, add sections as the team grows:**
+
+| Team size | Start with | Add when |
+|---|---|---|
+| Solo / 1–5 | `["slug".work]` only | More specs in flight than you can track mentally |
+| 5–20 | Add `["slug".brief_queue]` | PMs write briefs; engineers pick them up |
+| 20–50 | All three sections per initiative | A dedicated PE role works the shaping queue |
+| 50+ / multi-repo | One `workspace.toml` per repo; cross-repo initiative tracking via external tracker | Multiple repos contributing to one initiative |
+
+### Three-altitude model
+
+The six-step development sequence (Outcome → Problem → Diverge → Validate → Bet → Spec) operates at every altitude with different time horizons:
+
+| Altitude | Scope | Skills | Artifacts |
+|---|---|---|---|
+| 0 — Company | Years; C-suite | product-strategy pack (future) | PRFAQ, OKR, Wardley Map |
+| 1 — Initiative | Quarters; PM + senior eng | frame-situation, frame-intent, de-risk-intent (existing); identify-opportunities, map-capabilities (M2) | Vision, capability map, initiative brief, briefs |
+| 2 — Project | Weeks; product trio | receive-brief, new-spec, work-loop | Brief, spec, plan |
+
+### Shaping queue concept
+
+The `[shaping_queue]` sits upstream of `[brief_queue]`. It holds all pre-brief upstream work via typed entries (D9):
+
+- **`type = "shape"`** (default) — PE six-step sequence: `frame-situation` → `identify-opportunities` → `diverge-solutions` → validate → `place-bet` → `map-capabilities`. Produces shaping artifacts in `docs/product/shaping/`.
+- **`type = "research"`** — desk-research pack: `research-project-start <slug>`. Produces findings in `docs/product/research/<slug>/` (or user-configured personal workspace). Non-technical users can pick these up without PE skills.
+- **`type = "strategy"`** — product-strategy pack (M4): altitude-0 analysis (SWOT, PESTLE, OKR cascade, PRFAQ). Non-technical product strategists pick these up. Artifacts committed to `docs/product/shaping/`.
+- **`type = "signal"`** — ongoing landscape monitoring (regulatory, competitive, technology, risk — subtypes deferred). Does not graduate to a brief. `check-workspace` surfaces signals as "active context" separately from project-bound "ready to start" items; the strategist acknowledges and notes shaping implications rather than promoting to a brief. Canonical term from strategic foresight practice (STEEP, horizon scanning at EU JRC and product strategy firms).
+
+`check-workspace` surfaces each type with the appropriate skill prompt. A shaping item can depend on a research item: `needs = "research:adopter-persona"` — the shaping item becomes ready only when the research project's findings are committed.
+
+### INI-002 milestone map
+
+| Milestone | Scope |
+|---|---|
+| M1 · Workspace Foundation | workspace.toml seed, check-workspace, brief template DoR fields, work-loop / receive-brief / new-rfc extensions |
+| M2 · Strategic Shaping | frame-situation, identify-opportunities, diverge-solutions, place-bet, map-capabilities, JTBD + Wardley in PE pack |
+| M3 · Findings & RFC Management | findings register seeds, rfc-status skill, research-project-start .context/ bug fix |
+| M4 · Product Strategy Layer | product-strategy pack, OKR → gap analysis routing, PRFAQ template |
+| M5 · Tracker Integration | github-brief-intake, linear pack + linear-brief-intake, jira-align-brief-intake |
+| M6 · Documentation Wave | workspace-toml guides, PE pack Diátaxis guides, Astro site project index |
+
+> **Ecosystem context (not in scope):** INI-003 (Coding CLI Adapter Pack), INI-004 (Remote Agent Runtime), INI-005 (Infra & Observability), and INI-006 (Control Plane) are separate initiatives in their own repos, each with its own RFC when triggered. They are painted in the product vision and `docs/product/shaping/ecosystem-overview.md` to complete the picture; they are not part of this RFC's scope or completion condition.
+>
+> **INI-004 note — remote agent runtime and non-technical users:** Two execution paths for non-local harnesses. **Path A — skill adaptation (INI-003 scope):** skills become MCP tools or system-prompt injections in the remote agent session; stateless single-pass skills port cleanly to the Claude Agents SDK; orchestration-heavy skills (e.g., `work-loop` supervisor mode) require re-plumbing because the SDK's "agent as tool" multi-agent pattern differs from Claude Code's `Agent` dispatch. **Path B — ephemeral box (INI-004 scope):** spin up a full Claude Code sandbox on demand (Modal, E2B, Daytona, Databricks), pass in `workspace.toml` and the task, execute the complete skill ecosystem natively; nothing to port, at the cost of cold-start latency and per-session sandbox overhead. `workspace.toml` is harness-agnostic under either path — it is a local file the agent reads and writes regardless of execution environment. **Non-technical user story (agentic UI):** for non-technical users on a hosted agentic UI (researcher, product strategist), `check-workspace` output is the natural session entry point; `type = "research"` and `type = "strategy"` entries surface the right skill prompt with no CLI required; the harness provides the environment. INI-004 RFC governs path selection, sandbox provider choice, and non-technical user onboarding.
+
+## Acceptance criteria
+
+> **Shipped when:** all M1–M6 ACs below are complete. Sister initiatives are not a completion condition for this RFC.
+>
+> **Implementation sequence:** M1 begins immediately on acceptance. Each subsequent milestone begins when the prior one ships. Sub-RFCs for M2, M4, and M5 are opened at the start of each milestone and govern decisions not yet made. M3 and M6 are direct implementations from this RFC's design; no sub-RFC needed.
+
+### M1 · Workspace Foundation — initial implementation, begins on acceptance
+
+ACs are grouped by delivery batch (see spec map above). Each batch ships as one PR; batches within a group are independent.
+
+**Batch 1 — Foundation docs**
+- [ ] ADR authored recording D2 (`workspace.toml` TOML format) and revised D4 (`workspace.toml` on `main`; no umbrella branch; spec branches target `main` directly)
+- [ ] `CONVENTIONS.md §5b` amended: admit `projects/`, `shaping/`, `findings/`, `initiatives/`, `research/` under `docs/product/`
+
+**Batch 2 — Workspace core** ← *unlock; ship as one PR*
+- [ ] `workspace.toml` schema seed committed to `main` — repo-level artifact; per-initiative named sections (`["ini-002"]`, etc.); multi-initiative parallel sections supported; blank-file valid; closeout = remove the section when shipped
+- [ ] `agentbundle-layout.toml [product]` table: configurable paths (`projects/`, `shaping/`; briefs path stays pinned)
+- [ ] `check-workspace` skill: reads local `workspace.toml`; resolves DAG across all sections using `needs` fields and cross-initiative prefix (`ini-002:work:...`); surfaces (a) ready to start, (b) blocked with reason, (c) parallel candidates; surfaces each `[shaping_queue]` entry by `type` (`shape`/`research`/`strategy`/`signal`) with the matching skill prompt for the user's installed packs; `signal` entries surfaced as "active context" distinct from project-bound "ready to start" items (D9); offers to initialise if file absent; surfaces closeout prompt when all specs shipped
+- [ ] Pre-populated INI-002 queue committed in the same PR as the seed — all Batch 3–5 specs pre-seeded so `check-workspace` is immediately useful
+
+**Batch 3 — Work queue end-to-end** (after Batch 2)
+- [ ] `work-loop` extended: reads `workspace.toml` at step 0 for initiative/milestone context; on ship, edits `workspace.toml` in working directory (`[work].active → [work].shipped`) and surfaces `roadmap.md` update reminder; degrades gracefully if file absent
+
+**Batch 4 — Brief queue end-to-end** (after Batch 2; independent of Batch 3)
+- [ ] Brief template updated: `Status`, `Rabbit holes`, `Instrumentation`, `## Design artifacts` fields; existing briefs grandfathered — new fields not required retroactively; `receive-brief` handles both shapes
+- [ ] `receive-brief` extended: sets `Status: Ready` after decomposition; edits `workspace.toml` in working directory (brief `draft → ready`); degrades if absent
+- [ ] `author-brief` skill: takes unstructured external input (email, prose, Linear Issue text); elicits missing DoR fields interactively; creates a compliant brief file; writes to `[brief_queue].draft` in `workspace.toml`
+
+**Batch 5 — Governance integration + shaping home** (after Batch 1; independent of Batches 2–4)
+- [ ] `new-rfc` extended: Accepted path prompts "Add implementation specs to `workspace.toml` queue?"; degrades if absent
+- [ ] `docs/product/projects/_template.md` seed + shaping/findings/initiatives artifact seeds — one PR
+- [ ] `workspace.toml` dependency model documented: inline `{path/slug, needs}` format; cross-queue prefix notation; cross-initiative prefix; `check-workspace` is the display surface; `work-loop` enforcement of DAG deferred to post-M1 backlog
+
+### M2 · Strategic Shaping
+
+- [ ] RFC-00XX · pe-pack-strategic-shaping sub-RFC opened and accepted before any M2 skill implementation begins; boundaries for all overlap pairs are already decided (Known Unknowns, resolved 2026-07-18): `frame-intent` vs `frame-situation` — coexist (different scopes and output contracts); `explore-options` vs `diverge-solutions` — coexist (different output contracts); `de-risk-intent` vs `place-bet` — sequential, not overlapping (steps 3.5 and 5 respectively). Sub-RFC documents implementation guidance (when to reach for each skill) and governs remaining implementation details; it does not re-open boundary decisions. After sub-RFC is accepted, use `new-rfc` extension (M1.9) to prompt adding M2 implementation specs to `[work].queue` in `workspace.toml`.
+- [ ] `frame-situation` skill in PE pack: signal → typed finding → six-step route; Wardley capability maturity embedded
+- [ ] `identify-opportunities` skill in PE pack + opportunity assessment artifact seed; JTBD framing (functional / emotional / social jobs) embedded
+- [ ] `diverge-solutions` skill in PE pack; overlap with `explore-options` resolved per sub-RFC before this spec is authored
+- [ ] `place-bet` skill in PE pack: human commitment gate, betting table surface; overlap with `de-risk-intent` resolved per sub-RFC before this spec is authored
+- [ ] `map-capabilities` skill in PE pack: product vision → all capability areas in one pass
+- [ ] Initiative brief artifact + `docs/product/initiatives/_template.md` seed
+- [ ] JTBD framing embedded in `frame-intent` — this is a modification to a shipped skill; backward-compatibility impact assessed in its own spec (not bundled with other M2.6 items); existing `frame-intent` outputs remain valid
+- [ ] Lean Canvas initiative framing template
+
+### M3 · Findings & RFC Management
+
+- [ ] `docs/product/findings/rfc-candidates.md` seed with schema: `| Problem | Source | Surfaced by | Date | Priority | Disposition |` — one row per candidate RFC; entries added by convention when `work-loop` defers something out of scope, or when `frame-situation` escalates a finding
+- [ ] `docs/product/findings/roadmap-intents.md` seed with same schema adapted for roadmap items
+- [ ] `rfc-status` skill in governance-extras: scans `docs/rfc/*.md` grouped by lifecycle state (valid states per CONVENTIONS.md §3 RFC lifecycle: `Draft | Open | Final Comment Period | Accepted | Rejected | Withdrawn | Experimental | Superseded`; CONVENTIONS.md already defines this closed set — no update needed; `Shipped` is a spec status, not an RFC status); also scans `rfc-candidates.md` and surfaces candidate count separately
+- [ ] `rfc-status` surfaced in `check-workspace` output as a count line: "N rfc candidates · M roadmap intents"
+- [ ] `work-loop` convention documented: on spec ship, if anything is deferred out of scope, agent prompts "Add to rfc-candidates.md or roadmap-intents.md?"
+- [ ] `research-project-start` bug fix (D8): remove `parent = ".context/research"` from resolution order in the skill — `.context/` is gitignored ephemeral scratch; the M3 fix also adds `[research] output_dir` key to `agentbundle-layout.toml` (new key — does not exist before this fix); resolution order: (1) user-scope `~/.agentbundle/agentbundle-layout.toml [research] output_dir` — personal workspace; (2) repo-scope `agentbundle-layout.toml [research] output_dir` — team convention; (3) neither → two-branch elicitation: repo branch ("Commit to this repo? [`docs/product/research/`]" → writes repo-scope config) or personal branch ("Write to personal workspace? Enter path:" → writes user-scope config; no default — Obsidian has no universal vault path; skill uses `~/Documents/<VaultName>/efforts/research/` as illustrative example only); output always at `<output_dir>/<research-project-slug>/`; co-land a test asserting elicitation fires rather than `.context/` fallback
+- [ ] `research` pack renamed to `desk-research` — canonical practitioner term (desk research in consulting / secondary research in design-UX practice); scope: AI-assisted synthesis of existing sources, finding summary schema, research project scaffolding; pack manifest, `plugin.json`, and `agentbundle-layout.toml` updated; build-self run; deprecation alias for the old pack name assessed before ship; migration path documented in pack `AGENTS.md`
+- [ ] `experience` pack renamed to `experience-design` — canonical agency term (Experience Design, abbreviated XD; used by frog, Fjord/Accenture Song, AKQA, Huge); zero-ambiguity alignment with practitioner taxonomy; same migration-alias assessment as desk-research rename
+
+### M4 · Product Strategy Layer
+
+- [ ] RFC-0063 · product-strategy-pack is already open as a draft; M4 implementation begins when RFC-0063 is accepted; RFC-0063 governs framework skill designs, pack scope (fully building out the product-strategy pack), and the cross-pack dependency contract with PE pack
+- [ ] ADR recorded before implementation begins: decision to add `product-strategy` as a new pack, recorded in `docs/adr/` and in this repo's `AGENTS.md` (per CONVENTIONS — new dependencies recorded before adding)
+- [ ] `product-strategy` pack (new): SWOT, Porter's Five Forces, PESTLE, BCG Matrix, OKR cascade; `agentbundle-layout.toml` updated to register the pack; `plugin.json` updated; build-self run to propagate
+- [ ] OKR cascade skill routes to `frame-situation` (PE pack) — cross-pack dependency documented in `product-strategy` pack's `AGENTS.md`: PE pack is a required co-install; skill invocation is agent-mediated (not mechanical cross-pack call), so absent PE pack produces a graceful "frame-situation not found — install PE pack" diagnostic rather than a silent failure
+- [ ] PRFAQ template as altitude-0 initiative framing artifact
+
+### M5 · Tracker Integration
+
+- [ ] `github-brief-intake` skill: GitHub Issue / Milestone → brief with `Epic:` pointer (implement first — independent of linear pack, builds pattern confidence)
+- [ ] RFC-00XX · linear-pack sub-RFC opened and accepted before implementation begins; sub-RFC governs: (a) `linear-brief-sync` delta model (diff fields, PE-approval gate before write, lock when brief is `executing`); (b) AC export direction (`push-acs-to-linear` skill — write ACs back to Linear story for review round; stretch goal, sub-RFC decides scope); (c) field mapping between Linear and brief DoR fields
+- [ ] `linear` pack + `linear-brief-intake` skill: Linear Issue / Project → brief (first-time intake); `linear-brief-sync [LIN-123]` skill: re-fetch issue, diff against current brief, present delta for PE approval, write approved changes; refuse to update if brief `Status: Executing` (spec locked)
+- [ ] `jira-align-brief-intake` skill (atlassian pack): Jira Align Feature → brief; **1-way intake only** with configuration-guided field mapping for org-specific workflow states and PI cadences; generic portable sync is not a goal (see Known Unknowns — Unknowable)
+- [ ] Tracker decision tree and vocabulary mapping table in guides
+
+### M6 · Documentation Wave
+
+- [ ] `workspace.toml` Diátaxis guides: 1 tutorial (your-first-workspace), 2 how-tos (start-a-project, orient-at-session-start), 1 reference (workspace-toml schema), 1 explanation (two-room model — shaping vs. build)
+- [ ] PE pack Diátaxis guides: 2 tutorials, 4 how-tos, 2 reference, 2 explanation — named artifact list to be confirmed at M6 spec authoring time
+- [ ] `author-brief` documentation: how-to (intake-an-external-brief) + reference (DoR field definitions)
+- [ ] Astro site: project index view for non-engineer (PM) visibility — requires `docs/product/projects/` as a data source registered in the Astro build config; AC is complete when the index page renders project entries from committed `_template.md`-shaped files
+- [ ] Role journey section committed to `docs/guides/`: PM / engineer / agent — how each uses the system at their altitude; derived from `docs/product/journeys/` living maps
+- [ ] Live-demo guide: scenario selection criteria (≥3 representative team types); pre-flight checklist (installs, auth, repo state); narration script targeting the full shaping → brief → spec flow on the org's own codebase in ≤30 minutes — primary M6 deliverable from the enterprise adoption path (surfaced by `team-evaluates-and-adopts` journey Stage 3)
+- [ ] Enterprise rollout playbook: champion → CTO → platform team → engineers adoption path; staged rollout phases (pilot team → wave → org-wide); rollout checklist and retrospective template
+
+## Sub-RFCs
+
+This RFC authorises the roadmap and vocabulary. M1 is fully specified by this RFC's design and ACs. Detailed implementation governance for M2, M4, and M5 is delegated to sub-RFCs opened when each milestone begins:
+
+| Sub-RFC | Milestone | Governs |
+|---|---|---|
+| RFC-00XX · pe-pack-strategic-shaping | M2 | frame-situation, identify-opportunities, diverge-solutions, place-bet, map-capabilities; must resolve overlap with existing PE skills (see Known unknowns) |
+| RFC-0063 · product-strategy-pack | M4 | Full build-out of the product-strategy pack; framework skill designs and cross-pack dependency contract with PE pack; already open as draft — M4 begins on acceptance |
+| RFC-00XX · linear-pack | M5 | Linear integration and 2-way sync design |
+
+## Evidence and prior art
+
+**Six-step sequence validated across eight methodologies** (Shape Up, Amazon PRFAQ, SVPG dual-track, Torres Opportunity Solution Tree, OKR-driven planning, modern SaaS startups, Design Sprint, Lean Startup). All converge on: Outcome → Problem → Diverge → Validate → Bet → Spec. Primary disagreement is sequential vs. parallel discovery/delivery; both are supported by the `[shaping_queue]` / `[brief_queue]` split.
+
+**Platform-owns-execution-state confirmed** (Devin: VM snapshots; Manus: TiDB database; GitHub Copilot Coding Agent: platform session). All store execution state in the platform; git is the output boundary. This validates `workspace.toml` as declared intent only.
+
+**Vocabulary cross-tool consensus** (Linear, Jira Standard, Jira Premium, Jira Align, Azure DevOps, GitHub, Asana, SAFe): "Project" and "Brief" (≈ Issue / Story) have the widest cross-tool agreement. "Initiative" is widely used but inconsistently defined; its use here (cross-repo, multi-quarter) matches Linear and Jira Premium.
+
+**Initiative umbrella branch** is an established git coordination pattern (kernel topic branches, Shopify release cycles, large OSS feature work) — considered and rejected for this use case; see Alternatives Considered. The coordination problem umbrella branches solve only exists with long-lived in-flight work; the fast-merge model avoids that. `workspace.toml` on `main` (D4) is adopted instead.
+
+## Alternatives considered
+
+**State branch for `workspace.toml`:** A dedicated `state/<slug>` branch storing live execution state. Rejected — no established git precedent; breaks rebase, merge, and PR workflows; conflicts with how Devin / Manus / GitHub Copilot all handle state (platform-owned, not git-owned).
+
+**Option B — brief as directory containing supporting info:** Brief becomes a folder (`docs/product/briefs/<slug>/`) containing the brief plus upstream research, journey maps, and screen flows. Rejected — the brief is an independent shaped artifact; supporting material lives in its own location and is linked from the brief's `## Design artifacts` section.
+
+**Configurable `[container]` type field:** Allow `type = "epic" | "initiative" | "theme"` in the container section. Rejected — adds complexity without benefit; the `name` field and external tracker fields carry org-specific vocabulary; the standard vocabulary is fixed as Project.
+
+**Research registry in the build repo:** `docs/product/findings/research-registry.md` tracking research project folders. Rejected — research corpora belong outside the build repo (private vault or private team repo); only governance briefs bridge back. The research pack manages its own project registry wherever it is configured.
+
+**Initiative umbrella branch:** Keep spec branches targeting a long-lived initiative umbrella branch; batch-merge to `main` on ship. Considered and rejected — the umbrella solves a coordination problem that only exists when specs are long-lived in-flight. With fast-merge, each spec's `workspace.toml` update is a different TOML entry; rebase conflicts are trivially resolved; no umbrella needed. `workspace.toml` on `main` is simpler, removes branch management overhead, and is consistent with the no-long-lived-branches principle. Adopted as D4.
+
+**Markdown+frontmatter for `workspace.toml`:** Use `workspace.md` with YAML frontmatter, matching every other product artifact in the repo. Considered — frontmatter works for flat key-value but requires a custom parser for the three nested sections with per-section comments. TOML was chosen because `workspace.toml` is read by skills programmatically and its nested structure is a first-class use case for TOML. Human readability is comparable.
+
+## Known unknowns
+
+**Resolved (2026-07-18):** Adopter persona — persona is pack-segmented, not monolithic. (1) Core pack alone: primary adopter is a senior engineer / tech lead at a 2–20 person team, already using AI agents, frustrated by session amnesia and lack of structure; self-serve install, no demo required. Enterprise variant: same technical depth, but adoption lands as part of an org-wide AI adoption strategy — enterprise requires live demonstration and champion sponsorship, not documentation-only onboarding. (2) Full stack (PE pack + shaping sequence): primary adopter is a technical PM or PE with both product and engineering depth. (3) Desk-research pack / product-strategy pack: non-technical researchers and product strategists — these now have first-class queue visibility via `type = "research"` / `type = "strategy"` / `type = "signal"` entries in `[shaping_queue]` (D9). Adopter-persona research project added to bootstrap `workspace.toml` as `{slug = "adopter-persona", type = "research"}` — findings will refine M6 onboarding guide design and the enterprise live-demo gap. The enterprise adoption dynamics (live-demo dependency, champion sponsorship) are an open design input to M6.
+
+**Known-unknown (Unknown #8): Portfolio pack design and pack taxonomy.** Four related problems investigated during INI-001 design; three partially resolved.
+
+*(1) Pack taxonomy — resolved.* Research types are professional disciplines, each warranting a dedicated pack rather than overloading a single research pack. Pack renames and new packs planned (see M3 ACs and future items):
+
+| Pack | Canonical discipline | Canonical term | Status |
+|---|---|---|---|
+| `desk-research` (rename from `research`) | Secondary / desk research | Desk research (consulting); secondary research (design/UX) | M3 rename |
+| `design-research` (future, no timeline) | Primary user research | Design Research (IDEO, frog, Fjord); UX Research (product companies) | Future RFC |
+| `experience-design` (rename from `experience`) | Experience Design (XD) | Experience Design — frog, Fjord/Accenture Song, AKQA, Huge | M3 rename |
+| `product-strategy` (RFC-0063) | Strategy + market intelligence + UX strategy + stakeholder research + content strategy | Strategic Design / Experience Strategy | Draft |
+| `regulatory-intelligence` (future, no timeline) | Regulatory landscape monitoring | Regulatory Intelligence | Future RFC |
+
+`design-research` is a sibling of `experience-design` (research → insights → design artifacts), not nested within it. Small teams use experience-design pack only (T1 research primers built in); larger teams with dedicated researchers install both, experience-design declaring a T2 prereq on design-research where primary research depth is needed.
+
+*(2) Evidence lifecycle — partially resolved.* Fast-moving teams run a two-layer model: **Layer 1 — atomic evidence** (interview transcript, competitive observation, regulatory document); **Layer 2 — synthesis artifact** (finding summary with six-part schema: context → key learning → root cause → motivation → consequences → next steps; JTBD opportunity score as portfolio handoff format). Genesis/extension hierarchy: a foundational genesis research project anchors a domain; extension projects refine or add to specific findings without restarting. Layer-2 artifacts bridge from personal vault / private repo into the team repo's shaping queue — the specific bridging mechanism is the open portfolio coordination question below.
+
+*(3) Non-graduating shaping items — resolved.* Regulatory intelligence, competitive monitoring, technology watch, and risk surveillance have a lifecycle incompatible with the shape→brief graduation path — they are ongoing, inform shaping from the sidelines, and never "complete." Resolved by `type = "signal"` in `[shaping_queue]` (D9 addition). "Signal" is the canonical term in strategic foresight practice (STEEP, horizon scanning); subtypes (regulatory / market / technology / risk) are deferred — the generic `signal` type is the catch-all, taxonomy follows practitioner need.
+
+*(4) Portfolio coordination — open.* How does a portfolio-level pack move Layer-2 synthesis artifacts from a private research repo into shaping queues across multiple build repos? `workspace.toml` is per-repo; a CTO or AI adoption lead also needs aggregate adoption metrics (org activation rate, cross-repo throughput, value stream latency). Both may require a portfolio-level artifact (`portfolio.toml` or lightweight registry) aggregating per-repo `workspace.toml` status. **Feeds INI-006** (control plane) directly. Would be closed by: a follow-on RFC after M3 ships; org-level measurement requirements surface from the `team-evaluates-and-adopts` journey and the `adopter-persona` research project.
+
+**Resolved:** `check-workspace` absent-file behaviour — reads local `workspace.toml` from the current working directory (file lives on `main`; always present after Batch 2 ships). If absent: interactive sessions offer to initialise (copy seed); headless/CI sessions fail loudly with a named diagnostic. No `git show`, no branch detection needed.
+
+**Resolved:** Write protocol — `workspace.toml` is a local file on the working branch. Skills (`work-loop`, `receive-brief`, `author-brief`) edit the file in the working directory and stage it as part of the spec diff; it commits to `main` with the spec PR. No worktree, no sidecar, no cross-branch write. Headless and remote-agent adapters (INI-003, INI-004) follow the same pattern — they edit the local file before committing; adapter-specific invocation details are each initiative's own concern.
+
+**Resolved (N/A):** Umbrella branch merge cadence. The umbrella branch model was superseded by D4 revision — `workspace.toml` on `main`, spec branches target `main` directly. No umbrella branch; no merge cadence to decide.
+
+**Resolved (pre-M3 check, 2026-07-18):** `rfc-status` lifecycle vocabulary — CONVENTIONS.md §3 already defines the closed set: `Draft | Open | Final Comment Period | Accepted | Rejected | Withdrawn | Experimental | Superseded`. No CONVENTIONS.md update needed. `Shipped` is a spec status, not an RFC status. `Superseded` is a valid post-accepted transition per CONVENTIONS.md line 103. The M3 AC now references the CONVENTIONS.md set directly.
+
+**Resolved (2026-07-18):** `research-project-start` elicitation behaviour — see D8. Repo default: `docs/product/research/<slug>/` (committed, team-visible, separate from structured registers in `findings/`). Personal workspace: user-configured path, no default (Obsidian has no universal vault path; ACE convention `<vault>/efforts/research/<slug>/` is illustrative). Resolution order: user-scope config → repo-scope config → two-branch elicitation. Pack.toml line `parent = ".context/research"` is the line the M3 fix removes.
+
+**Resolved (2026-07-18):** M2 skill boundary — PE pack has 9 skills; M2 adds 5. All four overlap pairs resolved by output contract and scope: (a) `frame-intent` vs `frame-situation` — not overlapping: `frame-intent` is any-level quick framing, no committed artifact; `frame-situation` is initiative-scope six-step entry, committed typed-finding artifact. (b) `de-risk-intent` vs `place-bet` — sequential, different steps: `de-risk-intent` is validate-step support — identifies the riskiest assumption and prototype approach before the PE conducts validation; `place-bet` is the bet-commitment step after validation. (c) `decompose-intent` vs `receive-brief` — different levels (intent → briefs vs brief → specs); not overlapping. (d) `explore-options` vs `diverge-solutions` — distinct skills with different output contracts: `explore-options` is freeform brainstorm, no minimum, no forced structure, any context; `diverge-solutions` is formal step-3 requiring ≥3 structured comparable options that `place-bet` can reason against — the structured output is the point, making `diverge-solutions` a wrapper over `explore-options` would be wrong. Both stay; the M2 sub-RFC documents when to reach for each but does not decide the boundary (already decided here).
+
+**Resolved (2026-07-18):** M5 — tracker sync model. No webhook, no running infrastructure. The lifecycle is iterative: (1) first intake: `linear-brief-intake` creates brief from story; (2) spec written, ACs pasted back into tracker story for review round (write direction 2 — manual now; `push-acs-to-linear` is a sub-RFC stretch goal); (3) review round changes the story; (4) delta catch-up: `linear-brief-sync` re-fetches, diffs against current brief, presents delta for PE approval before writing — PE-authored brief fields (Appetite, Rabbit holes, Instrumentation) are protected; (5) lock: brief `Status: Executing` (spec building) → sync skill refuses further updates. Zero infrastructure at every step — all PE-triggered, no event subscription. Sub-RFC governs: delta model details, AC export scope, field mapping. `github-brief-intake` establishes the pattern first (M5 AC unchanged).
+
+**Unknowable:** Exact adoption journey for enterprise teams with Jira Align mandates. The integration surface is org-specific (custom workflow state names, program increment cadences); a generic portable sync is impossible — this will always require harness-layer configuration. The M5 `jira-align-brief-intake` AC is intentionally scoped to 1-way intake (Jira Align Feature → brief) with configuration-guided field mapping; it does not claim generic portability.

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -70,6 +70,7 @@
 | [0061](0061-web-top-level-directory.md) | Add `web/` top-level directory for the Astro marketing site — a sibling to `site/` housing the platform-site Astro project, built as a single npm package into one shared GitHub Pages artifact (Astro at `/`, MkDocs at `/docs/`). Records the top-level-directory approval AGENTS.md requires; content/aesthetics ratified in the platform-site spec. | Accepted | 2026-07-16 | 2026-07-16 |
 | [0062](0062-content-design-and-copy-direction-skills.md) | Add `content-design` and `copy-direction` skills to the experience pack — filling the upstream gap between product intent and screen design for acquisition and product/reference surfaces. | Draft | 2026-07-18 | |
 | [0063](0063-product-strategy-pack.md) | Create a `product-strategy` pack housing upstream strategy disciplines: market/competitive strategy (SWOT, Porter, PESTLE, BCG, OKR cascade), UX strategy, and content strategy — sitting above the experience and product-engineering packs. | Draft | 2026-07-18 | |
+| [0064](0064-ini-001-ai-native-ecosystem.md) | INI-001 AI-Native Ecosystem — Platform Core: `workspace.toml` coordination artifact, three-queue model (shaping → brief → work), standard vocabulary (Project / Milestone / Brief / Spec), and six-milestone implementation roadmap (M1–M6). | Draft | 2026-07-18 | |
 
 ## Adding a new RFC
 


### PR DESCRIPTION
## Summary

- **RFC-0064** — INI-001 AI-Native Ecosystem Platform Core: six-milestone roadmap introducing `workspace.toml` as the in-repo coordination artifact, three-queue model (shaping → brief → work), standard vocabulary (Project / Milestone / Brief / Spec), and `check-workspace` as the single cold-start skill
- **Eight journey maps** — all personas across shaping room (product strategist, product engineer, PM) and build room (engineer interactive, agent autonomous, swarm, adopter cross-cutting) plus the adoption journey; includes README and mermaid flowchart of how journeys connect
- **Product vision and ecosystem overview** shaping artifacts committed to `docs/product/shaping/`
- **Pack taxonomy decisions** — `research` → `desk-research` and `experience` → `experience-design` renames planned for M3; `design-research` and `regulatory-intelligence` as future packs (no timeline); `product-strategy` pack (RFC-0063) absorbs market intelligence, UX strategy, stakeholder research
- **`type = "signal"`** added to D9 typed shaping queue entries — covers ongoing non-graduating landscape concerns (regulatory, competitive, technology, risk); canonical term from strategic foresight practice (STEEP, horizon scanning); disambiguated from `frame-situation`'s input-signal concept
- **INI-004 two-path note** — adaptation (MCP/system-prompt) vs. ephemeral box (full Claude Code sandbox on demand); `workspace.toml` harness-agnostic under either path; non-technical user story documented

## Deferred (noted in PR description per AGENTS.md)

- Portfolio coordination across repos (Unknown #8 sub-problem 4) — follow-on RFC after M3 ships
- `design-research` and `regulatory-intelligence` pack RFCs — no timeline; taxonomy table in Unknown #8
- `work-loop` DAG enforcement — deferred post-M1 per D7

## Test plan

- [ ] RFC renders cleanly (no broken markdown tables or mermaid)
- [ ] All journey files reference `workspace.toml` on main (no umbrella branch references)
- [ ] `docs/rfc/README.md` row for RFC-0064 links correctly
- [ ] `docs/product/roadmap.md` M3 entry includes pack renames