### PR TITLE
feat(workspace): RFC-0064 M1 Batch 2 — workspace.toml + check-workspace skill (core 0.12.0)

### DIFF
--- a/.agents/skills/check-workspace/SKILL.md
+++ b/.agents/skills/check-workspace/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: check-workspace
+description: Use this skill to orient at session start, check initiative queue state, or see what's ready to work on next. Reads workspace.toml and surfaces ready-to-start items, blocked items with reason, parallel candidates, and active signals. Triggers on "check workspace", "what should I work on", "orient me", "session start", "what's ready", "show the queue", "workspace status", "what's next", or any cold-start orientation request. Offers to initialise workspace.toml if absent.
+---
+
+# Skill: check-workspace
+
+Read the local `workspace.toml` and surface the current queue state across all active initiatives. Run this at every session start — it replaces reading multiple product docs by hand.
+
+## When to invoke
+
+Any time you need to orient: which initiative is active, what specs are ready to start, what is blocked and why, what signals the strategist has flagged. Also the right skill if workspace.toml does not yet exist and you want to initialise it.
+
+## Procedure
+
+### 1. Read workspace.toml
+
+Open `workspace.toml` from the repo root. Parse it as TOML (`tomllib.loads()` in Python 3.11+ / `tomli.loads()` backport for earlier).
+
+**If absent:** offer to initialise — ask the user whether to create a blank file or bootstrap with their first initiative. A blank file contains only the one-line comment:
+
+```toml
+# workspace.toml — add ["<initiative-slug>"] sections to declare initiatives
+```
+
+**If present and unparseable:** surface the TOML parse error and stop — do not proceed with partial data.
+
+### 2. Resolve the DAG
+
+For each initiative's `[work]` and `[shaping_queue]`:
+
+- A queue entry is **ready** when all its `needs` entries are satisfied (see below).
+- A queue entry is **blocked** when one or more `needs` entries are not yet satisfied.
+- An entry with no `needs` field is unconditionally ready (unless already in `active` or `shipped`).
+
+**Needs resolution:**
+
+`needs` is a string or list of strings using queue-prefix notation:
+
+| Prefix | Resolves against |
+|--------|-----------------|
+| `work:<path>` | `[work].shipped` (or `[work].active` counts as in-progress) |
+| `shape:<slug>` | `[shaping_queue].active` or treated as shipped if not present |
+| `research:<slug>` | `[shaping_queue]` entries of `type = "research"` — ready when that entry is not in the backlog |
+| `brief:<path>` | `[brief_queue].ready` or `executing` |
+| `<ini-slug>:work:<path>` | Cross-initiative: `["<ini-slug>".work].shipped` |
+
+An entry is satisfied when its referenced item is in the appropriate shipped/done list. When `needs` is a list, ALL entries must be satisfied.
+
+### 3. Surface results
+
+Format output in four sections (omit sections with no entries):
+
+---
+
+**Active initiatives:** `<ini-slug>` — `<name>` (milestone: `<milestone>`)
+
+**Active context — signals** _(ongoing; do not need action):_
+- `<slug>` (`signal`) — no action needed; informs shaping decisions
+
+**Ready to start:**
+- `[work]` `<path>` — run `work-loop` on `docs/specs/<path>/`
+- `[shaping_queue]` `<slug>` (`shape`) — run `frame-intent`
+- `[shaping_queue]` `<slug>` (`research`) — run `research-project-start`
+- `[shaping_queue]` `<slug>` (`strategy`) — run product-strategy pack skill (requires product-strategy pack)
+- `[brief_queue]` `<path>` (Ready) — run `receive-brief` on `docs/product/briefs/<path>.md`
+
+**Parallel candidates:** _(all of the above with no inter-dependencies can start concurrently)_
+
+**Blocked:**
+- `<path>` — waiting on `<needs-entry>` (status: `<queued|in-progress>`)
+
+**Brief queue:**
+- Executing: `<path>` (or "none")
+- Ready: `<count>` item(s)
+- Draft: `<count>` item(s)
+
+**Closeout check:** if `[work].queue` is empty and `[work].active` is empty and `[work].shipped` is non-empty → surface: "`<ini-slug>`: all specs shipped — ready to close out? Run closeout to remove this section (git history preserves the record)."
+
+---
+
+### 4. Skill prompts by type
+
+When surfacing shaping_queue entries, append the right skill invocation based on what's installed:
+
+| Entry type | Skill to suggest |
+|-----------|-----------------|
+| `shape` (default) | `frame-intent` (available now); `frame-situation` (M2, when available) |
+| `research` | `research-project-start` (requires desk-research pack) |
+| `strategy` | product-strategy pack skill (requires product-strategy pack — M4) |
+| `signal` | no action — surface in "active context" section only |
+
+If the required pack is not installed, surface: "requires `<pack-name>` pack — install to work this item."
+
+### 5. Missing fields
+
+`workspace.toml` evolves: older entries may lack a `type` field (treat as `shape`), a `milestone` field (omit from output), or a `parent` field (omit). Never fail on missing optional fields.
+
+## See also
+
+- `references/agentbundle-layout.md` — the `[product]` table: configurable `projects/` and `shaping/` paths used by product-facing skills

--- a/.agents/skills/check-workspace/evals/eval_queries.json
+++ b/.agents/skills/check-workspace/evals/eval_queries.json
@@ -1,0 +1,23 @@
+[
+  {"query": "What should I work on next?", "should_trigger": true},
+  {"query": "Orient me to the current workspace state", "should_trigger": true},
+  {"query": "check-workspace", "should_trigger": true},
+  {"query": "Show me what's ready to start in the queue", "should_trigger": true},
+  {"query": "What's blocking the work queue?", "should_trigger": true},
+  {"query": "Initialise workspace.toml for our new initiative", "should_trigger": true},
+  {"query": "What signals does the strategist have flagged?", "should_trigger": true},
+  {"query": "Give me a session-start orientation", "should_trigger": true},
+  {"query": "What's the current initiative status?", "should_trigger": true},
+  {"query": "Show me all queued specs and their dependencies", "should_trigger": true},
+
+  {"query": "Start a new spec for a rate-limiting feature", "should_trigger": false},
+  {"query": "Fix this failing test in the parser", "should_trigger": false},
+  {"query": "Write a new RFC for our authentication changes", "should_trigger": false},
+  {"query": "Record an architecture decision about our queue choice", "should_trigger": false},
+  {"query": "Run the work loop on this spec", "should_trigger": false},
+  {"query": "Decompose this product brief into specs", "should_trigger": false},
+  {"query": "Update the roadmap with the new milestone", "should_trigger": false},
+  {"query": "What does the CHARTER say about our scope?", "should_trigger": false},
+  {"query": "Adapt the installed packs to this repo", "should_trigger": false},
+  {"query": "Create a new ADR for the database schema decision", "should_trigger": false}
+]

--- a/.agents/skills/check-workspace/references/agentbundle-layout.md
+++ b/.agents/skills/check-workspace/references/agentbundle-layout.md
@@ -1,0 +1,66 @@
+# `agentbundle-layout.toml` — the `[product]` section
+
+`agentbundle-layout.toml` is a single, **adopter-owned** file that controls where
+output-producing packs write their durable work. It is never shipped into a
+projected path; you create it by hand (or an `agentbundle install` step appends a
+default section to one you already have — **append-if-exists / never-create /
+never-overwrite**). On the rare append of a *missing* section, the installer
+re-emits the file and does **not** preserve freeform comments or off-schema keys;
+an existing section is left byte-identical (the re-emit runs only when your
+section is absent). This page documents the `[product]` section that
+product-facing skills read to locate the `projects/` and `shaping/` directories.
+
+## The `[product]` table
+
+Two configurable keys; `briefs` is intentionally absent (pinned):
+
+```toml
+[product]
+projects = "docs/product/projects"   # one file per project; seeded from _template.md
+shaping  = "docs/product/shaping"    # vision docs, opportunity assessments, capability maps
+# briefs path is pinned at docs/product/briefs/ — not configurable here
+```
+
+- **`projects`** is the base directory for project-index files (one `.md` per
+  time-bounded project). Skills that read or write project entries resolve paths
+  as `<projects>/<slug>.md`.
+- **`shaping`** is the base directory for upstream shaping artifacts: product
+  vision docs, opportunity assessments, capability maps, initiative briefs. Produced
+  by the PE six-step shaping sequence and the product-strategy pack.
+- **`briefs`** stays pinned at `docs/product/briefs/`. It is the hand-off point
+  to core's `receive-brief` skill and must not be redirected — moving briefs breaks
+  the `Brief:` back-link chain and coverage rollup.
+
+## Two locations, repo overrides user
+
+Skills read the **repo-root `./agentbundle-layout.toml`** `[product]` table if
+present, else the **user-profile `~/.agentbundle/agentbundle-layout.toml`** table.
+When both define `[product]`, the repo file's table wins; a table present only in
+the user file still applies.
+
+## Path anchoring
+
+- A **repo-root** file's paths are **repo-root-relative**. An absolute path is
+  allowed but flagged non-portable.
+- A **user-profile** file's paths **must be explicit absolute paths**
+  (`~`-anchored is fine). A relative path there is an *Ask-first* deviation —
+  never silently resolved against the ambient working directory.
+
+## Default and posture
+
+When no `[product]` section resolves, skills fall back to the conventional
+defaults: `docs/product/projects` for `projects` and `docs/product/shaping`
+for `shaping`. These match the structure seeded by the core pack and documented
+in `docs/CONVENTIONS.md §5b`.
+
+`core` ships **no `[pack.layout.user]` default** for this section — product
+output is per-repo and there is no sensible cross-repo absolute path. For a
+personal cross-repo default, write a `[product]` section into your user-profile
+file by hand:
+
+```toml
+# ~/.agentbundle/agentbundle-layout.toml
+[product]
+# projects = "/abs/path/to/projects"   # uncomment + set an absolute path
+# shaping  = "/abs/path/to/shaping"    # uncomment + set an absolute path
+```

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -92,7 +92,7 @@
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",
       "category": "governance",
-      "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix, frontend-engineering, contract-acquisition skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds.",
+      "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix, frontend-engineering, contract-acquisition, check-workspace skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds.",
       "displayName": "Core",
       "homepage": "https://github.com/eugenelim/agent-ready-repo",
       "keywords": [
@@ -104,7 +104,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "core",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.11.0"
+      "version": "0.12.0"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -17,6 +17,7 @@ tool, used often enough to stick — live in
 
 | Skill | What it does |
 | ----- | ------------ |
+| [`check-workspace`](check-workspace/SKILL.md) | Orient at session start — reads `workspace.toml`, resolves the queue DAG, and surfaces ready/blocked/parallel items and active signals |
 | [`work-loop`](work-loop/SKILL.md) | The standard plan → execute → verify → review loop for non-trivial work. Start here for any feature, fix, or refactor. |
 | [`new-spec`](new-spec/SKILL.md) | Scaffold a new spec directory, surface assumptions, then fill `spec.md` and `plan.md` |
 | [`bug-fix`](bug-fix/SKILL.md) | Fix a defect — reproduce → failing test → root cause → minimum fix → root-vs-symptom verify → commit body documents *why* |

--- a/.claude/skills/check-workspace/SKILL.md
+++ b/.claude/skills/check-workspace/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: check-workspace
+description: Use this skill to orient at session start, check initiative queue state, or see what's ready to work on next. Reads workspace.toml and surfaces ready-to-start items, blocked items with reason, parallel candidates, and active signals. Triggers on "check workspace", "what should I work on", "orient me", "session start", "what's ready", "show the queue", "workspace status", "what's next", or any cold-start orientation request. Offers to initialise workspace.toml if absent.
+---
+
+# Skill: check-workspace
+
+Read the local `workspace.toml` and surface the current queue state across all active initiatives. Run this at every session start — it replaces reading multiple product docs by hand.
+
+## When to invoke
+
+Any time you need to orient: which initiative is active, what specs are ready to start, what is blocked and why, what signals the strategist has flagged. Also the right skill if workspace.toml does not yet exist and you want to initialise it.
+
+## Procedure
+
+### 1. Read workspace.toml
+
+Open `workspace.toml` from the repo root. Parse it as TOML (`tomllib.loads()` in Python 3.11+ / `tomli.loads()` backport for earlier).
+
+**If absent:** offer to initialise — ask the user whether to create a blank file or bootstrap with their first initiative. A blank file contains only the one-line comment:
+
+```toml
+# workspace.toml — add ["<initiative-slug>"] sections to declare initiatives
+```
+
+**If present and unparseable:** surface the TOML parse error and stop — do not proceed with partial data.
+
+### 2. Resolve the DAG
+
+For each initiative's `[work]` and `[shaping_queue]`:
+
+- A queue entry is **ready** when all its `needs` entries are satisfied (see below).
+- A queue entry is **blocked** when one or more `needs` entries are not yet satisfied.
+- An entry with no `needs` field is unconditionally ready (unless already in `active` or `shipped`).
+
+**Needs resolution:**
+
+`needs` is a string or list of strings using queue-prefix notation:
+
+| Prefix | Resolves against |
+|--------|-----------------|
+| `work:<path>` | `[work].shipped` (or `[work].active` counts as in-progress) |
+| `shape:<slug>` | `[shaping_queue].active` or treated as shipped if not present |
+| `research:<slug>` | `[shaping_queue]` entries of `type = "research"` — ready when that entry is not in the backlog |
+| `brief:<path>` | `[brief_queue].ready` or `executing` |
+| `<ini-slug>:work:<path>` | Cross-initiative: `["<ini-slug>".work].shipped` |
+
+An entry is satisfied when its referenced item is in the appropriate shipped/done list. When `needs` is a list, ALL entries must be satisfied.
+
+### 3. Surface results
+
+Format output in four sections (omit sections with no entries):
+
+---
+
+**Active initiatives:** `<ini-slug>` — `<name>` (milestone: `<milestone>`)
+
+**Active context — signals** _(ongoing; do not need action):_
+- `<slug>` (`signal`) — no action needed; informs shaping decisions
+
+**Ready to start:**
+- `[work]` `<path>` — run `work-loop` on `docs/specs/<path>/`
+- `[shaping_queue]` `<slug>` (`shape`) — run `frame-intent`
+- `[shaping_queue]` `<slug>` (`research`) — run `research-project-start`
+- `[shaping_queue]` `<slug>` (`strategy`) — run product-strategy pack skill (requires product-strategy pack)
+- `[brief_queue]` `<path>` (Ready) — run `receive-brief` on `docs/product/briefs/<path>.md`
+
+**Parallel candidates:** _(all of the above with no inter-dependencies can start concurrently)_
+
+**Blocked:**
+- `<path>` — waiting on `<needs-entry>` (status: `<queued|in-progress>`)
+
+**Brief queue:**
+- Executing: `<path>` (or "none")
+- Ready: `<count>` item(s)
+- Draft: `<count>` item(s)
+
+**Closeout check:** if `[work].queue` is empty and `[work].active` is empty and `[work].shipped` is non-empty → surface: "`<ini-slug>`: all specs shipped — ready to close out? Run closeout to remove this section (git history preserves the record)."
+
+---
+
+### 4. Skill prompts by type
+
+When surfacing shaping_queue entries, append the right skill invocation based on what's installed:
+
+| Entry type | Skill to suggest |
+|-----------|-----------------|
+| `shape` (default) | `frame-intent` (available now); `frame-situation` (M2, when available) |
+| `research` | `research-project-start` (requires desk-research pack) |
+| `strategy` | product-strategy pack skill (requires product-strategy pack — M4) |
+| `signal` | no action — surface in "active context" section only |
+
+If the required pack is not installed, surface: "requires `<pack-name>` pack — install to work this item."
+
+### 5. Missing fields
+
+`workspace.toml` evolves: older entries may lack a `type` field (treat as `shape`), a `milestone` field (omit from output), or a `parent` field (omit). Never fail on missing optional fields.
+
+## See also
+
+- `references/agentbundle-layout.md` — the `[product]` table: configurable `projects/` and `shaping/` paths used by product-facing skills

--- a/.claude/skills/check-workspace/evals/eval_queries.json
+++ b/.claude/skills/check-workspace/evals/eval_queries.json
@@ -1,0 +1,23 @@
+[
+  {"query": "What should I work on next?", "should_trigger": true},
+  {"query": "Orient me to the current workspace state", "should_trigger": true},
+  {"query": "check-workspace", "should_trigger": true},
+  {"query": "Show me what's ready to start in the queue", "should_trigger": true},
+  {"query": "What's blocking the work queue?", "should_trigger": true},
+  {"query": "Initialise workspace.toml for our new initiative", "should_trigger": true},
+  {"query": "What signals does the strategist have flagged?", "should_trigger": true},
+  {"query": "Give me a session-start orientation", "should_trigger": true},
+  {"query": "What's the current initiative status?", "should_trigger": true},
+  {"query": "Show me all queued specs and their dependencies", "should_trigger": true},
+
+  {"query": "Start a new spec for a rate-limiting feature", "should_trigger": false},
+  {"query": "Fix this failing test in the parser", "should_trigger": false},
+  {"query": "Write a new RFC for our authentication changes", "should_trigger": false},
+  {"query": "Record an architecture decision about our queue choice", "should_trigger": false},
+  {"query": "Run the work loop on this spec", "should_trigger": false},
+  {"query": "Decompose this product brief into specs", "should_trigger": false},
+  {"query": "Update the roadmap with the new milestone", "should_trigger": false},
+  {"query": "What does the CHARTER say about our scope?", "should_trigger": false},
+  {"query": "Adapt the installed packs to this repo", "should_trigger": false},
+  {"query": "Create a new ADR for the database schema decision", "should_trigger": false}
+]

--- a/.claude/skills/check-workspace/references/agentbundle-layout.md
+++ b/.claude/skills/check-workspace/references/agentbundle-layout.md
@@ -1,0 +1,66 @@
+# `agentbundle-layout.toml` — the `[product]` section
+
+`agentbundle-layout.toml` is a single, **adopter-owned** file that controls where
+output-producing packs write their durable work. It is never shipped into a
+projected path; you create it by hand (or an `agentbundle install` step appends a
+default section to one you already have — **append-if-exists / never-create /
+never-overwrite**). On the rare append of a *missing* section, the installer
+re-emits the file and does **not** preserve freeform comments or off-schema keys;
+an existing section is left byte-identical (the re-emit runs only when your
+section is absent). This page documents the `[product]` section that
+product-facing skills read to locate the `projects/` and `shaping/` directories.
+
+## The `[product]` table
+
+Two configurable keys; `briefs` is intentionally absent (pinned):
+
+```toml
+[product]
+projects = "docs/product/projects"   # one file per project; seeded from _template.md
+shaping  = "docs/product/shaping"    # vision docs, opportunity assessments, capability maps
+# briefs path is pinned at docs/product/briefs/ — not configurable here
+```
+
+- **`projects`** is the base directory for project-index files (one `.md` per
+  time-bounded project). Skills that read or write project entries resolve paths
+  as `<projects>/<slug>.md`.
+- **`shaping`** is the base directory for upstream shaping artifacts: product
+  vision docs, opportunity assessments, capability maps, initiative briefs. Produced
+  by the PE six-step shaping sequence and the product-strategy pack.
+- **`briefs`** stays pinned at `docs/product/briefs/`. It is the hand-off point
+  to core's `receive-brief` skill and must not be redirected — moving briefs breaks
+  the `Brief:` back-link chain and coverage rollup.
+
+## Two locations, repo overrides user
+
+Skills read the **repo-root `./agentbundle-layout.toml`** `[product]` table if
+present, else the **user-profile `~/.agentbundle/agentbundle-layout.toml`** table.
+When both define `[product]`, the repo file's table wins; a table present only in
+the user file still applies.
+
+## Path anchoring
+
+- A **repo-root** file's paths are **repo-root-relative**. An absolute path is
+  allowed but flagged non-portable.
+- A **user-profile** file's paths **must be explicit absolute paths**
+  (`~`-anchored is fine). A relative path there is an *Ask-first* deviation —
+  never silently resolved against the ambient working directory.
+
+## Default and posture
+
+When no `[product]` section resolves, skills fall back to the conventional
+defaults: `docs/product/projects` for `projects` and `docs/product/shaping`
+for `shaping`. These match the structure seeded by the core pack and documented
+in `docs/CONVENTIONS.md §5b`.
+
+`core` ships **no `[pack.layout.user]` default** for this section — product
+output is per-repo and there is no sensible cross-repo absolute path. For a
+personal cross-repo default, write a `[product]` section into your user-profile
+file by hand:
+
+```toml
+# ~/.agentbundle/agentbundle-layout.toml
+[product]
+# projects = "/abs/path/to/projects"   # uncomment + set an absolute path
+# shaping  = "/abs/path/to/shaping"    # uncomment + set an absolute path
+```

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`check-workspace` skill added to core pack (core 0.12.0).** A new session-start skill reads the repo-level `workspace.toml` and surfaces ready-to-start items, blocked items with reason, parallel candidates, and active signals — all in one command. Resolves the dependency DAG across all queues and initiatives using `needs` prefix notation (`work:`, `shape:`, `research:`, `brief:`, and cross-initiative `ini-xxx:work:` prefixes). Surfaces `type = "signal"` entries as "active context" separately from actionable "ready to start" items; surfaces each shaping entry with the matching skill invocation for the installed packs. Offers to initialise `workspace.toml` when absent. Run `check-workspace` at every session start from Batch 2 onward.
+- **`workspace.toml` committed to `main` as the repo-level declared-intent coordination artifact.** Pre-populated with the INI-002 (Platform Core) M1 bootstrap queue: three queues (`shaping_queue`, `brief_queue`, `work`) with all Batch 3–5 specs pre-seeded and their `needs` wiring in place. `spec/m1-workspace-core` is marked shipped (this PR). The `agentbundle-layout.toml [product]` table is documented in `check-workspace`'s reference file: `projects` and `shaping` paths are configurable; `briefs` stays pinned.
+
 ### Changed
 
 - **`voice-and-microcopy` human-craft check gains vocabulary tells, an editorial methodology, and voice authenticity tests (product-engineering 0.11.0).** `human-craft-check.md` now covers three additional layers beyond its existing structural tells: a vocabulary-tell section (hollow verbs, inflated adjectives, abstract container nouns, hedging openers — each with a concrete replacement rule); a three-pass editorial methodology (vocabulary scan → delete the opening → specificity audit); and three voice authenticity tests (pub test, founder test, one-person test). Scoped to the same context as before — longer copy: onboarding text, feature descriptions, help text — not short UI strings.

--- a/docs/rfc/0064-ini-001-ai-native-ecosystem.md
+++ b/docs/rfc/0064-ini-001-ai-native-ecosystem.md
@@ -385,14 +385,14 @@ The `[shaping_queue]` sits upstream of `[brief_queue]`. It holds all pre-brief u
 ACs are grouped by delivery batch (see spec map above). Each batch ships as one PR; batches within a group are independent.
 
 **Batch 1 — Foundation docs**
-- [ ] ADR authored recording D2 (`workspace.toml` TOML format) and revised D4 (`workspace.toml` on `main`; no umbrella branch; spec branches target `main` directly)
-- [ ] `CONVENTIONS.md §5b` amended: admit `projects/`, `shaping/`, `findings/`, `initiatives/`, `research/` under `docs/product/`
+- [x] ADR authored recording D2 (`workspace.toml` TOML format) and revised D4 (`workspace.toml` on `main`; no umbrella branch; spec branches target `main` directly)
+- [x] `CONVENTIONS.md §5b` amended: admit `projects/`, `shaping/`, `findings/`, `initiatives/`, `research/` under `docs/product/`
 
 **Batch 2 — Workspace core** ← *unlock; ship as one PR*
-- [ ] `workspace.toml` schema seed committed to `main` — repo-level artifact; per-initiative named sections (`["ini-002"]`, etc.); multi-initiative parallel sections supported; blank-file valid; closeout = remove the section when shipped
-- [ ] `agentbundle-layout.toml [product]` table: configurable paths (`projects/`, `shaping/`; briefs path stays pinned)
-- [ ] `check-workspace` skill: reads local `workspace.toml`; resolves DAG across all sections using `needs` fields and cross-initiative prefix (`ini-002:work:...`); surfaces (a) ready to start, (b) blocked with reason, (c) parallel candidates; surfaces each `[shaping_queue]` entry by `type` (`shape`/`research`/`strategy`/`signal`) with the matching skill prompt for the user's installed packs; `signal` entries surfaced as "active context" distinct from project-bound "ready to start" items (D9); offers to initialise if file absent; surfaces closeout prompt when all specs shipped
-- [ ] Pre-populated INI-002 queue committed in the same PR as the seed — all Batch 3–5 specs pre-seeded so `check-workspace` is immediately useful
+- [x] `workspace.toml` schema seed committed to `main` — repo-level artifact; per-initiative named sections (`["ini-002"]`, etc.); multi-initiative parallel sections supported; blank-file valid; closeout = remove the section when shipped
+- [x] `agentbundle-layout.toml [product]` table: configurable paths (`projects/`, `shaping/`; briefs path stays pinned)
+- [x] `check-workspace` skill: reads local `workspace.toml`; resolves DAG across all sections using `needs` fields and cross-initiative prefix (`ini-002:work:...`); surfaces (a) ready to start, (b) blocked with reason, (c) parallel candidates; surfaces each `[shaping_queue]` entry by `type` (`shape`/`research`/`strategy`/`signal`) with the matching skill prompt for the user's installed packs; `signal` entries surfaced as "active context" distinct from project-bound "ready to start" items (D9); offers to initialise if file absent; surfaces closeout prompt when all specs shipped
+- [x] Pre-populated INI-002 queue committed in the same PR as the seed — all Batch 3–5 specs pre-seeded so `check-workspace` is immediately useful
 
 **Batch 3 — Work queue end-to-end** (after Batch 2)
 - [ ] `work-loop` extended: reads `workspace.toml` at step 0 for initiative/milestone context; on ship, edits `workspace.toml` in working directory (`[work].active → [work].shipped`) and surfaces `roadmap.md` update reminder; degrades gracefully if file absent

--- a/packs/core/.apm/skills/check-workspace/SKILL.md
+++ b/packs/core/.apm/skills/check-workspace/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: check-workspace
+description: Use this skill to orient at session start, check initiative queue state, or see what's ready to work on next. Reads workspace.toml and surfaces ready-to-start items, blocked items with reason, parallel candidates, and active signals. Triggers on "check workspace", "what should I work on", "orient me", "session start", "what's ready", "show the queue", "workspace status", "what's next", or any cold-start orientation request. Offers to initialise workspace.toml if absent.
+---
+
+# Skill: check-workspace
+
+Read the local `workspace.toml` and surface the current queue state across all active initiatives. Run this at every session start — it replaces reading multiple product docs by hand.
+
+## When to invoke
+
+Any time you need to orient: which initiative is active, what specs are ready to start, what is blocked and why, what signals the strategist has flagged. Also the right skill if workspace.toml does not yet exist and you want to initialise it.
+
+## Procedure
+
+### 1. Read workspace.toml
+
+Open `workspace.toml` from the repo root. Parse it as TOML (`tomllib.loads()` in Python 3.11+ / `tomli.loads()` backport for earlier).
+
+**If absent:** offer to initialise — ask the user whether to create a blank file or bootstrap with their first initiative. A blank file contains only the one-line comment:
+
+```toml
+# workspace.toml — add ["<initiative-slug>"] sections to declare initiatives
+```
+
+**If present and unparseable:** surface the TOML parse error and stop — do not proceed with partial data.
+
+### 2. Resolve the DAG
+
+For each initiative's `[work]` and `[shaping_queue]`:
+
+- A queue entry is **ready** when all its `needs` entries are satisfied (see below).
+- A queue entry is **blocked** when one or more `needs` entries are not yet satisfied.
+- An entry with no `needs` field is unconditionally ready (unless already in `active` or `shipped`).
+
+**Needs resolution:**
+
+`needs` is a string or list of strings using queue-prefix notation:
+
+| Prefix | Resolves against |
+|--------|-----------------|
+| `work:<path>` | `[work].shipped` (or `[work].active` counts as in-progress) |
+| `shape:<slug>` | `[shaping_queue].active` or treated as shipped if not present |
+| `research:<slug>` | `[shaping_queue]` entries of `type = "research"` — ready when that entry is not in the backlog |
+| `brief:<path>` | `[brief_queue].ready` or `executing` |
+| `<ini-slug>:work:<path>` | Cross-initiative: `["<ini-slug>".work].shipped` |
+
+An entry is satisfied when its referenced item is in the appropriate shipped/done list. When `needs` is a list, ALL entries must be satisfied.
+
+### 3. Surface results
+
+Format output in four sections (omit sections with no entries):
+
+---
+
+**Active initiatives:** `<ini-slug>` — `<name>` (milestone: `<milestone>`)
+
+**Active context — signals** _(ongoing; do not need action):_
+- `<slug>` (`signal`) — no action needed; informs shaping decisions
+
+**Ready to start:**
+- `[work]` `<path>` — run `work-loop` on `docs/specs/<path>/`
+- `[shaping_queue]` `<slug>` (`shape`) — run `frame-intent`
+- `[shaping_queue]` `<slug>` (`research`) — run `research-project-start`
+- `[shaping_queue]` `<slug>` (`strategy`) — run product-strategy pack skill (requires product-strategy pack)
+- `[brief_queue]` `<path>` (Ready) — run `receive-brief` on `docs/product/briefs/<path>.md`
+
+**Parallel candidates:** _(all of the above with no inter-dependencies can start concurrently)_
+
+**Blocked:**
+- `<path>` — waiting on `<needs-entry>` (status: `<queued|in-progress>`)
+
+**Brief queue:**
+- Executing: `<path>` (or "none")
+- Ready: `<count>` item(s)
+- Draft: `<count>` item(s)
+
+**Closeout check:** if `[work].queue` is empty and `[work].active` is empty and `[work].shipped` is non-empty → surface: "`<ini-slug>`: all specs shipped — ready to close out? Run closeout to remove this section (git history preserves the record)."
+
+---
+
+### 4. Skill prompts by type
+
+When surfacing shaping_queue entries, append the right skill invocation based on what's installed:
+
+| Entry type | Skill to suggest |
+|-----------|-----------------|
+| `shape` (default) | `frame-intent` (available now); `frame-situation` (M2, when available) |
+| `research` | `research-project-start` (requires desk-research pack) |
+| `strategy` | product-strategy pack skill (requires product-strategy pack — M4) |
+| `signal` | no action — surface in "active context" section only |
+
+If the required pack is not installed, surface: "requires `<pack-name>` pack — install to work this item."
+
+### 5. Missing fields
+
+`workspace.toml` evolves: older entries may lack a `type` field (treat as `shape`), a `milestone` field (omit from output), or a `parent` field (omit). Never fail on missing optional fields.
+
+## See also
+
+- `references/agentbundle-layout.md` — the `[product]` table: configurable `projects/` and `shaping/` paths used by product-facing skills

--- a/packs/core/.apm/skills/check-workspace/evals/eval_queries.json
+++ b/packs/core/.apm/skills/check-workspace/evals/eval_queries.json
@@ -1,0 +1,23 @@
+[
+  {"query": "What should I work on next?", "should_trigger": true},
+  {"query": "Orient me to the current workspace state", "should_trigger": true},
+  {"query": "check-workspace", "should_trigger": true},
+  {"query": "Show me what's ready to start in the queue", "should_trigger": true},
+  {"query": "What's blocking the work queue?", "should_trigger": true},
+  {"query": "Initialise workspace.toml for our new initiative", "should_trigger": true},
+  {"query": "What signals does the strategist have flagged?", "should_trigger": true},
+  {"query": "Give me a session-start orientation", "should_trigger": true},
+  {"query": "What's the current initiative status?", "should_trigger": true},
+  {"query": "Show me all queued specs and their dependencies", "should_trigger": true},
+
+  {"query": "Start a new spec for a rate-limiting feature", "should_trigger": false},
+  {"query": "Fix this failing test in the parser", "should_trigger": false},
+  {"query": "Write a new RFC for our authentication changes", "should_trigger": false},
+  {"query": "Record an architecture decision about our queue choice", "should_trigger": false},
+  {"query": "Run the work loop on this spec", "should_trigger": false},
+  {"query": "Decompose this product brief into specs", "should_trigger": false},
+  {"query": "Update the roadmap with the new milestone", "should_trigger": false},
+  {"query": "What does the CHARTER say about our scope?", "should_trigger": false},
+  {"query": "Adapt the installed packs to this repo", "should_trigger": false},
+  {"query": "Create a new ADR for the database schema decision", "should_trigger": false}
+]

--- a/packs/core/.apm/skills/check-workspace/references/agentbundle-layout.md
+++ b/packs/core/.apm/skills/check-workspace/references/agentbundle-layout.md
@@ -1,0 +1,66 @@
+# `agentbundle-layout.toml` — the `[product]` section
+
+`agentbundle-layout.toml` is a single, **adopter-owned** file that controls where
+output-producing packs write their durable work. It is never shipped into a
+projected path; you create it by hand (or an `agentbundle install` step appends a
+default section to one you already have — **append-if-exists / never-create /
+never-overwrite**). On the rare append of a *missing* section, the installer
+re-emits the file and does **not** preserve freeform comments or off-schema keys;
+an existing section is left byte-identical (the re-emit runs only when your
+section is absent). This page documents the `[product]` section that
+product-facing skills read to locate the `projects/` and `shaping/` directories.
+
+## The `[product]` table
+
+Two configurable keys; `briefs` is intentionally absent (pinned):
+
+```toml
+[product]
+projects = "docs/product/projects"   # one file per project; seeded from _template.md
+shaping  = "docs/product/shaping"    # vision docs, opportunity assessments, capability maps
+# briefs path is pinned at docs/product/briefs/ — not configurable here
+```
+
+- **`projects`** is the base directory for project-index files (one `.md` per
+  time-bounded project). Skills that read or write project entries resolve paths
+  as `<projects>/<slug>.md`.
+- **`shaping`** is the base directory for upstream shaping artifacts: product
+  vision docs, opportunity assessments, capability maps, initiative briefs. Produced
+  by the PE six-step shaping sequence and the product-strategy pack.
+- **`briefs`** stays pinned at `docs/product/briefs/`. It is the hand-off point
+  to core's `receive-brief` skill and must not be redirected — moving briefs breaks
+  the `Brief:` back-link chain and coverage rollup.
+
+## Two locations, repo overrides user
+
+Skills read the **repo-root `./agentbundle-layout.toml`** `[product]` table if
+present, else the **user-profile `~/.agentbundle/agentbundle-layout.toml`** table.
+When both define `[product]`, the repo file's table wins; a table present only in
+the user file still applies.
+
+## Path anchoring
+
+- A **repo-root** file's paths are **repo-root-relative**. An absolute path is
+  allowed but flagged non-portable.
+- A **user-profile** file's paths **must be explicit absolute paths**
+  (`~`-anchored is fine). A relative path there is an *Ask-first* deviation —
+  never silently resolved against the ambient working directory.
+
+## Default and posture
+
+When no `[product]` section resolves, skills fall back to the conventional
+defaults: `docs/product/projects` for `projects` and `docs/product/shaping`
+for `shaping`. These match the structure seeded by the core pack and documented
+in `docs/CONVENTIONS.md §5b`.
+
+`core` ships **no `[pack.layout.user]` default** for this section — product
+output is per-repo and there is no sensible cross-repo absolute path. For a
+personal cross-repo default, write a `[product]` section into your user-profile
+file by hand:
+
+```toml
+# ~/.agentbundle/agentbundle-layout.toml
+[product]
+# projects = "/abs/path/to/projects"   # uncomment + set an absolute path
+# shaping  = "/abs/path/to/shaping"    # uncomment + set an absolute path
+```

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "0.11.0",
-  "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix, frontend-engineering, contract-acquisition skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
+  "version": "0.12.0",
+  "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix, frontend-engineering, contract-acquisition, check-workspace skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 }

--- a/packs/core/README.md
+++ b/packs/core/README.md
@@ -42,6 +42,7 @@ for the design rationale.
 
 `core` is the loop itself. Ask your agent, for example:
 
+- "What should I work on next?" (`check-workspace` — orient at session start)
 - "Start a new spec for a rate-limiting feature." (`new-spec`)
 - "Implement this spec with the work-loop." (`work-loop`)
 - "Fix this bug: the importer drops the last row." (`bug-fix`)

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "0.11.0"
+version = "0.12.0"
 description = "Core agent-ready-repo: work-loop, new-spec, bug-fix, frontend-engineering, contract-acquisition skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 readme = "README.md"
 display_name = "Core"
@@ -43,7 +43,7 @@ allowed-scopes = ["repo"]
 #   - work-loop — loaded broadly by the plan→execute→review discipline, not by
 #     a narrow user-prompt surface; a clean negative set isn't writable for it.
 [pack.evals]
-skills = ["new-spec", "bug-fix", "receive-brief", "init-project", "adapt-to-project"]
+skills = ["new-spec", "bug-fix", "receive-brief", "init-project", "adapt-to-project", "check-workspace"]
 
 # enriched-pack-manifest (RFC-0031 / ADR-0021): catalogue-facing links
 # + maintainer, including the `documentation` link to the per-pack guide home.

--- a/workspace.toml
+++ b/workspace.toml
@@ -1,0 +1,53 @@
+# workspace.toml
+#
+# Declared-intent coordination artifact for this repo.
+# Each initiative gets its own named section. Skills read this file at session
+# start to orient to the current queue state — run `check-workspace` to surface
+# ready items, blocked items, and active signals.
+#
+# Queue entries are strings (no dependencies) or inline objects {path/slug, needs}
+# (with dependencies). `needs` uses queue-prefix notation:
+#   "work:<path>"      — depends on a work queue entry
+#   "shape:<slug>"     — depends on a shaping queue entry
+#   "research:<slug>"  — depends on a research entry
+#   "brief:<path>"     — depends on a brief queue entry
+# Cross-initiative deps prefix the initiative slug: "ini-002:work:spec/..."
+
+["ini-002"]
+name      = "Platform Core"
+status    = "active"
+milestone = "M1 · Workspace Foundation"
+parent    = "INI-001"
+
+["ini-002".shaping_queue]
+active  = []
+backlog = [
+  # Signal items — hand-authored by strategist; ongoing, non-graduating
+  {slug = "ai-native-regulatory-watch", type = "signal"},
+  # Research items — any user with the desk-research pack can pick these up
+  {slug = "adopter-persona",            type = "research"},
+  # Shaping items — PE picks up when upstream research is done
+  "ini-002-initiative-brief",
+  {slug = "opp-assessment-pe-pack",  needs = "work:spec/m2-frame-situation"},
+  {slug = "capability-map-ini-002",  needs = "work:spec/m2-map-capabilities"},
+]
+
+["ini-002".brief_queue]
+executing = ""
+ready     = []
+draft     = []
+
+["ini-002".work]
+active  = []
+shipped = ["spec/m1-workspace-core"]  # Batch 2 — workspace core ships with this file
+queue   = [
+  # Batch 3 — work queue end-to-end (after workspace-core)
+  {path = "spec/m1-work-queue",
+   needs = "work:spec/m1-workspace-core"},
+  # Batch 4 — brief queue end-to-end (after workspace-core, independent of Batch 3)
+  {path = "spec/m1-brief-queue",
+   needs = "work:spec/m1-workspace-core"},
+  # Batch 5 — governance + shaping (after Batch 1; independent of Batches 2–4)
+  "spec/m1-governance-integration",
+  "spec/m1-shaping-seeds",
+]


### PR DESCRIPTION
## Summary

Implements the Batch 2 "unlock" batch from RFC-0064 § M1 delivery — the three deliverables that ship together so `check-workspace` is immediately useful from the first session after merge:

- **`workspace.toml`** committed at repo root, pre-populated with the INI-002 (Platform Core) M1 bootstrap queue. Three queues wired: `shaping_queue` (signal, research, and shape entries with deps), `brief_queue` (empty), `work` (1 shipped + 4 queued Batch 3–5 specs). `spec/m1-workspace-core` marked shipped in this PR.
- **`agentbundle-layout.toml [product]` table** documented: `projects` and `shaping` paths configurable (defaults `docs/product/projects` and `docs/product/shaping`); `briefs` pinned.
- **`check-workspace` skill** (core 0.12.0): reads `workspace.toml`, resolves the DAG with queue-prefix `needs` notation, surfaces ready/blocked/parallel, distinguishes `signal` entries as "active context," offers init when absent, prompts closeout when all shipped. Activation evals included.

RFC-0064 ACs: Batch 1 ✓ (prior PR), Batch 2 ✓ (this PR).

## Test plan

- [ ] Run `check-workspace` — confirms skill is available and reads `workspace.toml`
- [ ] Output surfaces `spec/m1-work-queue` and `spec/m1-brief-queue` as blocked (needs `spec/m1-workspace-core`), `spec/m1-governance-integration` and `spec/m1-shaping-seeds` as ready to start
- [ ] Output surfaces `ai-native-regulatory-watch` (signal) in "active context," not "ready to start"
- [ ] Output surfaces `adopter-persona` (research) as ready to start with `research-project-start` prompt
- [ ] `make build-check` passes (all 18 gates ✓, confirmed locally)