### PR TITLE
fix(iac-terraform): address RFC-0065 reviewer gaps — scope, disposition, bootstrap, standards

### DIFF
--- a/.agents/skills/generate-iac/SKILL.md
+++ b/.agents/skills/generate-iac/SKILL.md
@@ -10,6 +10,39 @@ The output is a deploy-ready Terraform directory with a pinned, clean `plan` —
 the G4 handoff to `release-loop` (or the generated human-gated pipeline where
 `release-loop` is absent). Apply is never in scope for this skill.
 
+## v1 scope — governed realization, not architectural design
+
+**In scope (v1):** governed HCL generation from a pre-formed architectural
+intent; provider-contract, tagging, naming, state, IAM, networking, and
+observability standards applied; OPA/Conftest policy gate; Trivy security scan;
+CI pipeline wiring (GitHub Actions / Azure DevOps / GitLab) with OIDC auth;
+plan-based drift audit via `reconcile-iac`.
+
+**Out of scope in v1 — bring a pre-formed architectural decision:**
+- **Workload selection.** RDS vs Aurora vs DynamoDB, EKS vs ECS vs Lambda, VM
+  vs container vs serverless. This skill governs and builds what you chose; it
+  does not evaluate requirements → service fit.
+- **Network topology design.** Hub-spoke vs flat, Transit Gateway vs VPC
+  peering, on-prem connectivity (DX / ExpressRoute / Interconnect), multi-region
+  topology. This skill consumes a network; it does not design one.
+- **Load balancer type/tier selection.** L4 vs L7, global vs regional,
+  health-check strategy, blue/green or canary traffic-shift. "Governed front
+  door only" means the skill wires an LB you specify.
+- **Multi-account / landing-zone orchestration.** AWS Control Tower, Azure
+  Landing Zones, GCP org-hierarchy. Account-isolation model is an input; the
+  org infrastructure is not provisioned here.
+- **Compliance-framework content.** CIS, NIST, PCI-DSS, HIPAA, FedRAMP, SOC 2
+  control mapping. Adopt via governance-index domain rows + custom standard
+  references; built-in standards are security-best-practice, not a
+  control-framework map.
+- **IAM guardrail layer.** AWS SCPs, AWS permission boundaries, Azure Policy at
+  management-group scope, GCP Org Policy constraints. The pack enforces
+  least-privilege role policies; org-level guardrails are an adopter addition
+  (see `security-iam-standard.md` § Organization-level guardrails).
+- **Autonomous apply / operational self-healing.** `reconcile-iac` v1 is
+  managed-drift detect-propose-approve (never autonomous). Runtime operational
+  self-healing (auto-remediate live service degradation) is not in scope.
+
 ## Hard rules — non-negotiable
 
 - **Stage 0 is mandatory and non-bypassable.** Before any Terraform, load the
@@ -125,6 +158,7 @@ Verification and provider shape:
 - `references/terraform-verify-and-iterate.md` — plan-vs-apply oracle, module tests
 - `references/provider-contract.md` — four-file shape + credential tiering + DoD
 - `references/release-loop-integration.md` — G4 artifact set, preflight-set shaping
+- `references/bootstrap-sequence.md` — **load for first bootstrap/ apply** — local-state → create-backend → migrate-state chicken-and-egg story
 
 Load per target (never all at once):
 - `references/providers/<cloud>.md` — cloud-specific config (aws / gcp / azure / …)

--- a/.agents/skills/generate-iac/references/bootstrap-sequence.md
+++ b/.agents/skills/generate-iac/references/bootstrap-sequence.md
@@ -1,0 +1,109 @@
+# Bootstrap sequence — state-backend chicken-and-egg
+
+> Load this reference when initialising the `bootstrap/` layer for the first
+> time (no remote state backend exists yet). This is the #1 first-apply failure
+> pattern in layered Terraform — skipping or guessing through it silently breaks
+> all subsequent layers.
+
+## The problem
+
+The layered layout (bootstrap → foundation → platform → app) uses remote state
+from layer 1 onward. But the bootstrap layer *creates* the remote state backend —
+so it can't use it before it exists. Running `terraform init` against a remote
+backend when the bucket doesn't yet exist fails with a credentials or
+bucket-not-found error.
+
+**Resolution: bootstrap runs with local state on the first apply, then migrates.**
+
+## Two-phase procedure
+
+### Phase 1 — Create the backend with local state
+
+1. **Temporarily disable the remote backend** in `bootstrap/backend.tf`:
+
+   ```hcl
+   # Phase 1 only — remove after migration
+   terraform {}
+   ```
+
+2. Run `terraform init` (writes `terraform.tfstate` locally).
+
+3. Run `terraform plan -out=bootstrap.tfplan` — review. The plan should create
+   only the state bucket, OIDC provider, and CI roles.
+
+4. Run `terraform apply bootstrap.tfplan` — the backend infrastructure is live.
+   A local `terraform.tfstate` now exists.
+
+5. Immediately extend `.gitignore` — never commit the local state:
+
+   ```
+   bootstrap/terraform.tfstate*
+   bootstrap/.terraform/
+   ```
+
+### Phase 2 — Migrate local state to the remote backend
+
+6. **Restore the remote backend block** in `bootstrap/backend.tf`:
+
+   ```hcl
+   terraform {
+     backend "s3" {}    # or "gcs" / "azurerm" — partial config
+   }
+   ```
+
+7. Run `terraform init -migrate-state -backend-config=backend.hcl`.
+   Terraform detects existing local state and prompts to copy it to the remote
+   bucket. Answer yes.
+
+8. Verify with `terraform plan` (should show no changes — state matches live).
+
+9. **Commit** `backend.tf` with the restored backend block and the updated
+   `.gitignore`. Do **not** commit `terraform.tfstate` or `.terraform/`.
+
+## Per-cloud backend-hcl.example content
+
+Copy the appropriate block to `bootstrap/backend.hcl` (git-ignored) before
+Phase 1 `terraform init`. The `-migrate-state` step reads it automatically.
+
+**AWS — S3:**
+```hcl
+bucket       = "<state-bucket-name>"
+key          = "bootstrap/terraform.tfstate"
+region       = "<region>"
+encrypt      = true
+kms_key_id   = "alias/terraform-state"
+use_lockfile = true    # Terraform >= 1.11 or OpenTofu >= 1.7
+```
+
+**GCP — GCS:**
+```hcl
+bucket = "<state-bucket-name>"
+prefix = "bootstrap"
+```
+
+**Azure — Azure Blob:**
+```hcl
+resource_group_name  = "<rg>"
+storage_account_name = "<sa>"
+container_name       = "tfstate"
+key                  = "bootstrap.tfstate"
+```
+
+## What the bootstrap layer creates (minimum viable)
+
+| Resource | AWS | GCP | Azure |
+| --- | --- | --- | --- |
+| State bucket | S3 + versioning + SSE-KMS + lifecycle | GCS + versioning + CMEK | Storage account + blob container |
+| OIDC provider | `aws_iam_openid_connect_provider` | Workload Identity Pool + Provider | Azure AD app + federated credential |
+| CI role(s) | `aws_iam_role` (plan role + apply role, separate) | Service account per role | Managed identity |
+
+Bootstrap does **not** create VPCs, compute, databases, or application resources
+(those belong to foundation / platform / app layers).
+
+## Recovery — partial apply
+
+If the bootstrap apply failed mid-way, do **not** run `terraform init -migrate-state`
+yet. First re-run `terraform apply` (Phase 1) to converge the partial state, then
+verify resources exist in the cloud console, then proceed to Phase 2. A
+partially-applied state migrated to remote state is valid — Terraform tracks what
+was created.

--- a/.agents/skills/generate-iac/references/security-iam-standard.md
+++ b/.agents/skills/generate-iac/references/security-iam-standard.md
@@ -48,6 +48,35 @@ Wire these into the CI pipeline as mandatory pre-apply gates:
 - Note: **Sentinel is incompatible with OpenTofu**. OPA/Conftest is the only
   open-source policy path that works on both Terraform and OpenTofu engines.
 
+## Organization-level guardrail layer (out of v1 scope)
+
+This pack enforces IAM **role policies** (least-privilege per layer) and
+**pipeline OIDC** (no static creds). It does **not** configure org-level
+guardrails — those are an adopter addition:
+
+| Guardrail | Mechanism | Where to configure |
+| --- | --- | --- |
+| AWS Service Control Policies (SCPs) | Deny/allow at OU or account level | AWS Organizations / Control Tower |
+| AWS permission boundaries | Max-permissions ceiling on roles/users | Added to each `aws_iam_role` resource in the bootstrap layer |
+| Azure Policy | Deny / audit / append at management-group scope | Azure Management Groups |
+| GCP Org Policy constraints | Deny/allow resource policies at org/folder | GCP Organization Policy |
+
+**Recommended practice:** add permission boundaries to the CI roles and
+workload roles created in the `bootstrap/` layer. A permission boundary limits
+what a role can delegate even if a policy grants more. For AWS, attach a
+boundary to every `aws_iam_role` the bootstrap layer creates:
+
+```hcl
+resource "aws_iam_role" "ci_plan" {
+  # ...
+  permissions_boundary = "arn:aws:iam::${var.account_id}:policy/OrgPermBoundary"
+}
+```
+
+Org-level SCPs and policy-as-code together form the guardrail layer the pack's
+inline policies operate within. Document the guardrail layer in an ADR (use
+`new-adr` infra mode, `iam` topic).
+
 ## Checklist (review before merge)
 
 - [ ] No static credentials in `.tf` files, CI environment variables, or

--- a/.agents/skills/generate-iac/references/terraform-standard.md
+++ b/.agents/skills/generate-iac/references/terraform-standard.md
@@ -33,6 +33,42 @@ Every layer and module contains:
 `name_prefix = <system>-<env>` for all resource names. Prevents collision
 across environments. Never hardcode a fixed resource name.
 
+## Module sourcing
+
+- **Private registry first.** If the org runs a private Terraform module
+  registry (Terraform Cloud / TFE / Artifactory), source modules from it rather
+  than from the public Terraform Registry. Org-internal modules encode
+  organisation-specific defaults (required tags, approved AMI filters, org
+  network conventions) that public modules don't enforce.
+  ```hcl
+  module "vpc" {
+    source  = "app.terraform.io/<org>/vpc/aws"  # private first
+    version = "~> 3.0"
+  }
+  ```
+- **Public registry only when no private equivalent exists.** Prefer
+  HashiCorp-authored or well-maintained community modules. Pin with `~>` (never
+  a loose `>=`). Record the rationale in the ADR if a public module is chosen
+  over a private one.
+- **Never `source = "./"` in production layers.** Local-path module references
+  are acceptable inside `modules/` but must not be used between layers.
+
+## Compliance framework extension
+
+The built-in standards cover security best practice; they do not map to
+compliance frameworks (CIS Benchmarks, NIST 800-53, PCI-DSS, HIPAA, FedRAMP,
+SOC 2). For regulated environments:
+
+1. Add a domain row to the governance-index for each applicable framework.
+2. Create a repo-local standards document (e.g. `docs/standards/pci-dss-iac.md`)
+   that maps each relevant control to the Terraform patterns that satisfy it.
+3. Reference it from the governance-index `standards:` field for that domain.
+4. The `generate-iac` skill will load it at Stage 0 alongside the built-in
+   standards.
+
+This is the extension seam (D15): the governance-index is the adopter's surface
+for adding compliance-framework content without forking the pack.
+
 ## State
 
 - **Remote state with locking.** Partial backend config in `backend.tf`;

--- a/.agents/skills/reconcile-iac/SKILL.md
+++ b/.agents/skills/reconcile-iac/SKILL.md
@@ -1,25 +1,30 @@
 ---
 name: reconcile-iac
-description: Use this skill to audit Terraform/OpenTofu drift, reconcile state, or run a pre-change preflight before a follow-on infrastructure change. Triggers on "reconcile my infrastructure", "check for drift", "drift audit", "what drifted", "before I change X check drift", "is my infra in sync". Never autonomously applies. Shares generate-iac's references and reviewers.
+description: Use this skill to audit Terraform/OpenTofu drift, reconcile state, run a pre-change preflight, or check an incoming IaC diff for ADR compliance. Triggers on "reconcile my infrastructure", "check for drift", "drift audit", "what drifted", "before I change X check drift", "is my infra in sync", "adr-check", "does this change comply", "check this diff against our ADRs", "compliance check this IaC change". Never autonomously applies. Shares generate-iac's references and reviewers.
 ---
 
 # Skill: reconcile-iac
 
-`plan`-based drift audit → proposed disposition → route. Audit and propose;
-a human (or the `release-loop` consent gate) decides. Never autonomously apply.
+`plan`-based drift audit → ADR compliance check → proposed disposition → route.
+Audit and propose; a human (or the `release-loop` consent gate) decides. Never
+autonomously apply.
 
-## Two triggers — both are first-class
+## Three triggers — all first-class
 
 | Trigger | When | What it does |
 | --- | --- | --- |
 | **Before-change preflight** | Before every follow-on infrastructure change (mandatory, not optional) | Runs a `plan` against live state to surface drift *before* the new change lands on top of it — prevents layering change on unknown drift |
 | **On-demand / scheduled** | On request or on a scheduled cadence | Standalone drift snapshot for quiescent infrastructure; the author-side safety net when `release-loop` is absent |
+| **ADR compliance check** | When an IaC diff arrives that was NOT authored by `generate-iac` (hand-edit, external PR, CI gate) | Checks the diff against the governance-index ADRs — covers the compliance gap for changes the generation skill didn't author |
 
-**Recommended cadence:** (1) Before every follow-on change — mandatory preflight;
-(2) Weekly minimum on a scheduled basis — regular drift snapshot even in
-quiescent periods; (3) Immediately after a known out-of-band event — break-glass
-action, console change, provider-managed auto-modification, or a known pipeline
-failure.
+**Recommended cadence (Triggers 1 and 2):** (1) Before every follow-on change —
+mandatory preflight; (2) Weekly minimum on a scheduled basis — regular drift
+snapshot even in quiescent periods; (3) Immediately after a known out-of-band
+event — break-glass action, console change, provider-managed auto-modification,
+or a known pipeline failure.
+
+**Trigger 3 fires on demand**, not on a cadence — invoke when a diff arrives
+that did not go through `generate-iac`.
 
 ## Known blind spot — document and do not hide
 
@@ -72,6 +77,53 @@ full drift coverage — the audit covers managed resources only.
 6. A human (or the release-loop consent gate) decides the disposition.
    Do not apply or destroy anything autonomously.
 ```
+
+## ADR compliance check procedure (Trigger 3)
+
+Use when an IaC diff arrives that was not authored by `generate-iac` — a
+hand-edited `.tf` file, an external PR, a CI gate check. The governance-index
+is the compliance oracle; this procedure is the enforcement path for changes
+that bypassed Stage 0.
+
+```
+1. Load the governance-index (governance-index.yaml / governance-index.toml).
+   If absent, surface it — offer to bootstrap via generate-iac Stage 0.
+
+2. Identify which governance domains the diff touches. Map by resource type:
+   • aws_iam_* / google_project_iam_* / azurerm_role_assignment → iam
+   • aws_vpc_* / google_compute_network / azurerm_virtual_network → networking
+   • terraform { backend } / aws_s3_bucket (state bucket) → state
+   • resource_group / project / aws_organizations_account → layout
+   • any provider block changes → layout
+   • aws_security_group / aws_security_group_rule → networking + policy
+   • tagging / labels arguments → tagging
+   • CI config changes (GitHub Actions / ADO / GitLab) → pipeline_auth
+
+3. For each touched domain, read the ADR(s) listed in the governance-index.
+   Focus on the ADR's Decision, Constraints, and Consequences sections.
+
+4. For each ADR, evaluate the diff against each constraint:
+   • COMPLIANT — diff honours the constraint
+   • VIOLATION — diff contradicts a constraint (e.g. introduces DynamoDB locking
+     when ADR mandates native S3 lockfile; uses static creds when ADR mandates OIDC)
+   • WARN — diff is in a grey area or the constraint is ambiguous
+
+5. Emit the ADR compliance report:
+   - Summary: N domains checked, M ADRs read, K violations, J warnings
+   - Per-violation: domain → ADR number → specific constraint violated →
+     diff lines that trigger it → recommended fix
+   - Per-warning: domain → ADR number → ambiguity + suggested clarification
+
+6. VIOLATION blocks the change — route to human to either:
+   (a) fix the diff to comply, or
+   (b) draft a new ADR (via new-adr, infra mode) to record a legitimate decision
+       change, then re-check.
+   Do not autonomously approve or suppress a VIOLATION.
+```
+
+**Domain-to-resource-type mapping is heuristic** — add a note in the report when
+a resource type spans multiple domains or doesn't map cleanly. Human confirms the
+domain assignment when ambiguous.
 
 ## Disposition decision guidance
 

--- a/.agents/skills/reconcile-iac/SKILL.md
+++ b/.agents/skills/reconcile-iac/SKILL.md
@@ -73,6 +73,29 @@ full drift coverage — the audit covers managed resources only.
    Do not apply or destroy anything autonomously.
 ```
 
+## Disposition decision guidance
+
+The five dispositions map from cause-class and blast-radius. Use this table as a
+starting heuristic — the human confirms every disposition before any action.
+
+| Cause-class | Blast radius vs planned change | Recommended first disposition |
+| --- | --- | --- |
+| `out-of-band-change` | Overlaps | `block-follow-on` — confirm or codify before proceeding |
+| `out-of-band-change` | No overlap | `codify-back` if legitimate; `open-remediation-PR` if it violates a standard |
+| `provider-managed` | Overlaps | `block-follow-on` → investigate → `add ignore_changes` if intentional |
+| `provider-managed` | No overlap | `add ignore_changes` if the provider change is known-good |
+| `multi-tool` | Any | `add ignore_changes` — another tool owns this; coordinate out-of-band |
+| `pipeline-failure` | Any | `open-remediation-PR` — revert via a `generate-iac` PR to pre-failure state |
+| `unknown` | Any | `block-follow-on` — investigate cause before any disposition |
+
+**Do not merge `codify-back` and `add ignore_changes` on the same resource.**
+They are mutually exclusive: either Terraform owns the current state (codify-back)
+or the drift is intentional and Terraform should stop tracking it (ignore_changes).
+
+**`open-remediation-PR` always routes through `generate-iac`** — do not author
+remediation HCL directly in `reconcile-iac`. Remediation PRs get the full
+standards + reviewer set.
+
 ## Drift decomposition — who owns which moment
 
 | Drift moment | Owner |

--- a/.claude/skills/generate-iac/SKILL.md
+++ b/.claude/skills/generate-iac/SKILL.md
@@ -10,6 +10,39 @@ The output is a deploy-ready Terraform directory with a pinned, clean `plan` —
 the G4 handoff to `release-loop` (or the generated human-gated pipeline where
 `release-loop` is absent). Apply is never in scope for this skill.
 
+## v1 scope — governed realization, not architectural design
+
+**In scope (v1):** governed HCL generation from a pre-formed architectural
+intent; provider-contract, tagging, naming, state, IAM, networking, and
+observability standards applied; OPA/Conftest policy gate; Trivy security scan;
+CI pipeline wiring (GitHub Actions / Azure DevOps / GitLab) with OIDC auth;
+plan-based drift audit via `reconcile-iac`.
+
+**Out of scope in v1 — bring a pre-formed architectural decision:**
+- **Workload selection.** RDS vs Aurora vs DynamoDB, EKS vs ECS vs Lambda, VM
+  vs container vs serverless. This skill governs and builds what you chose; it
+  does not evaluate requirements → service fit.
+- **Network topology design.** Hub-spoke vs flat, Transit Gateway vs VPC
+  peering, on-prem connectivity (DX / ExpressRoute / Interconnect), multi-region
+  topology. This skill consumes a network; it does not design one.
+- **Load balancer type/tier selection.** L4 vs L7, global vs regional,
+  health-check strategy, blue/green or canary traffic-shift. "Governed front
+  door only" means the skill wires an LB you specify.
+- **Multi-account / landing-zone orchestration.** AWS Control Tower, Azure
+  Landing Zones, GCP org-hierarchy. Account-isolation model is an input; the
+  org infrastructure is not provisioned here.
+- **Compliance-framework content.** CIS, NIST, PCI-DSS, HIPAA, FedRAMP, SOC 2
+  control mapping. Adopt via governance-index domain rows + custom standard
+  references; built-in standards are security-best-practice, not a
+  control-framework map.
+- **IAM guardrail layer.** AWS SCPs, AWS permission boundaries, Azure Policy at
+  management-group scope, GCP Org Policy constraints. The pack enforces
+  least-privilege role policies; org-level guardrails are an adopter addition
+  (see `security-iam-standard.md` § Organization-level guardrails).
+- **Autonomous apply / operational self-healing.** `reconcile-iac` v1 is
+  managed-drift detect-propose-approve (never autonomous). Runtime operational
+  self-healing (auto-remediate live service degradation) is not in scope.
+
 ## Hard rules — non-negotiable
 
 - **Stage 0 is mandatory and non-bypassable.** Before any Terraform, load the
@@ -125,6 +158,7 @@ Verification and provider shape:
 - `references/terraform-verify-and-iterate.md` — plan-vs-apply oracle, module tests
 - `references/provider-contract.md` — four-file shape + credential tiering + DoD
 - `references/release-loop-integration.md` — G4 artifact set, preflight-set shaping
+- `references/bootstrap-sequence.md` — **load for first bootstrap/ apply** — local-state → create-backend → migrate-state chicken-and-egg story
 
 Load per target (never all at once):
 - `references/providers/<cloud>.md` — cloud-specific config (aws / gcp / azure / …)

--- a/.claude/skills/generate-iac/references/bootstrap-sequence.md
+++ b/.claude/skills/generate-iac/references/bootstrap-sequence.md
@@ -1,0 +1,109 @@
+# Bootstrap sequence — state-backend chicken-and-egg
+
+> Load this reference when initialising the `bootstrap/` layer for the first
+> time (no remote state backend exists yet). This is the #1 first-apply failure
+> pattern in layered Terraform — skipping or guessing through it silently breaks
+> all subsequent layers.
+
+## The problem
+
+The layered layout (bootstrap → foundation → platform → app) uses remote state
+from layer 1 onward. But the bootstrap layer *creates* the remote state backend —
+so it can't use it before it exists. Running `terraform init` against a remote
+backend when the bucket doesn't yet exist fails with a credentials or
+bucket-not-found error.
+
+**Resolution: bootstrap runs with local state on the first apply, then migrates.**
+
+## Two-phase procedure
+
+### Phase 1 — Create the backend with local state
+
+1. **Temporarily disable the remote backend** in `bootstrap/backend.tf`:
+
+   ```hcl
+   # Phase 1 only — remove after migration
+   terraform {}
+   ```
+
+2. Run `terraform init` (writes `terraform.tfstate` locally).
+
+3. Run `terraform plan -out=bootstrap.tfplan` — review. The plan should create
+   only the state bucket, OIDC provider, and CI roles.
+
+4. Run `terraform apply bootstrap.tfplan` — the backend infrastructure is live.
+   A local `terraform.tfstate` now exists.
+
+5. Immediately extend `.gitignore` — never commit the local state:
+
+   ```
+   bootstrap/terraform.tfstate*
+   bootstrap/.terraform/
+   ```
+
+### Phase 2 — Migrate local state to the remote backend
+
+6. **Restore the remote backend block** in `bootstrap/backend.tf`:
+
+   ```hcl
+   terraform {
+     backend "s3" {}    # or "gcs" / "azurerm" — partial config
+   }
+   ```
+
+7. Run `terraform init -migrate-state -backend-config=backend.hcl`.
+   Terraform detects existing local state and prompts to copy it to the remote
+   bucket. Answer yes.
+
+8. Verify with `terraform plan` (should show no changes — state matches live).
+
+9. **Commit** `backend.tf` with the restored backend block and the updated
+   `.gitignore`. Do **not** commit `terraform.tfstate` or `.terraform/`.
+
+## Per-cloud backend-hcl.example content
+
+Copy the appropriate block to `bootstrap/backend.hcl` (git-ignored) before
+Phase 1 `terraform init`. The `-migrate-state` step reads it automatically.
+
+**AWS — S3:**
+```hcl
+bucket       = "<state-bucket-name>"
+key          = "bootstrap/terraform.tfstate"
+region       = "<region>"
+encrypt      = true
+kms_key_id   = "alias/terraform-state"
+use_lockfile = true    # Terraform >= 1.11 or OpenTofu >= 1.7
+```
+
+**GCP — GCS:**
+```hcl
+bucket = "<state-bucket-name>"
+prefix = "bootstrap"
+```
+
+**Azure — Azure Blob:**
+```hcl
+resource_group_name  = "<rg>"
+storage_account_name = "<sa>"
+container_name       = "tfstate"
+key                  = "bootstrap.tfstate"
+```
+
+## What the bootstrap layer creates (minimum viable)
+
+| Resource | AWS | GCP | Azure |
+| --- | --- | --- | --- |
+| State bucket | S3 + versioning + SSE-KMS + lifecycle | GCS + versioning + CMEK | Storage account + blob container |
+| OIDC provider | `aws_iam_openid_connect_provider` | Workload Identity Pool + Provider | Azure AD app + federated credential |
+| CI role(s) | `aws_iam_role` (plan role + apply role, separate) | Service account per role | Managed identity |
+
+Bootstrap does **not** create VPCs, compute, databases, or application resources
+(those belong to foundation / platform / app layers).
+
+## Recovery — partial apply
+
+If the bootstrap apply failed mid-way, do **not** run `terraform init -migrate-state`
+yet. First re-run `terraform apply` (Phase 1) to converge the partial state, then
+verify resources exist in the cloud console, then proceed to Phase 2. A
+partially-applied state migrated to remote state is valid — Terraform tracks what
+was created.

--- a/.claude/skills/generate-iac/references/security-iam-standard.md
+++ b/.claude/skills/generate-iac/references/security-iam-standard.md
@@ -48,6 +48,35 @@ Wire these into the CI pipeline as mandatory pre-apply gates:
 - Note: **Sentinel is incompatible with OpenTofu**. OPA/Conftest is the only
   open-source policy path that works on both Terraform and OpenTofu engines.
 
+## Organization-level guardrail layer (out of v1 scope)
+
+This pack enforces IAM **role policies** (least-privilege per layer) and
+**pipeline OIDC** (no static creds). It does **not** configure org-level
+guardrails — those are an adopter addition:
+
+| Guardrail | Mechanism | Where to configure |
+| --- | --- | --- |
+| AWS Service Control Policies (SCPs) | Deny/allow at OU or account level | AWS Organizations / Control Tower |
+| AWS permission boundaries | Max-permissions ceiling on roles/users | Added to each `aws_iam_role` resource in the bootstrap layer |
+| Azure Policy | Deny / audit / append at management-group scope | Azure Management Groups |
+| GCP Org Policy constraints | Deny/allow resource policies at org/folder | GCP Organization Policy |
+
+**Recommended practice:** add permission boundaries to the CI roles and
+workload roles created in the `bootstrap/` layer. A permission boundary limits
+what a role can delegate even if a policy grants more. For AWS, attach a
+boundary to every `aws_iam_role` the bootstrap layer creates:
+
+```hcl
+resource "aws_iam_role" "ci_plan" {
+  # ...
+  permissions_boundary = "arn:aws:iam::${var.account_id}:policy/OrgPermBoundary"
+}
+```
+
+Org-level SCPs and policy-as-code together form the guardrail layer the pack's
+inline policies operate within. Document the guardrail layer in an ADR (use
+`new-adr` infra mode, `iam` topic).
+
 ## Checklist (review before merge)
 
 - [ ] No static credentials in `.tf` files, CI environment variables, or

--- a/.claude/skills/generate-iac/references/terraform-standard.md
+++ b/.claude/skills/generate-iac/references/terraform-standard.md
@@ -33,6 +33,42 @@ Every layer and module contains:
 `name_prefix = <system>-<env>` for all resource names. Prevents collision
 across environments. Never hardcode a fixed resource name.
 
+## Module sourcing
+
+- **Private registry first.** If the org runs a private Terraform module
+  registry (Terraform Cloud / TFE / Artifactory), source modules from it rather
+  than from the public Terraform Registry. Org-internal modules encode
+  organisation-specific defaults (required tags, approved AMI filters, org
+  network conventions) that public modules don't enforce.
+  ```hcl
+  module "vpc" {
+    source  = "app.terraform.io/<org>/vpc/aws"  # private first
+    version = "~> 3.0"
+  }
+  ```
+- **Public registry only when no private equivalent exists.** Prefer
+  HashiCorp-authored or well-maintained community modules. Pin with `~>` (never
+  a loose `>=`). Record the rationale in the ADR if a public module is chosen
+  over a private one.
+- **Never `source = "./"` in production layers.** Local-path module references
+  are acceptable inside `modules/` but must not be used between layers.
+
+## Compliance framework extension
+
+The built-in standards cover security best practice; they do not map to
+compliance frameworks (CIS Benchmarks, NIST 800-53, PCI-DSS, HIPAA, FedRAMP,
+SOC 2). For regulated environments:
+
+1. Add a domain row to the governance-index for each applicable framework.
+2. Create a repo-local standards document (e.g. `docs/standards/pci-dss-iac.md`)
+   that maps each relevant control to the Terraform patterns that satisfy it.
+3. Reference it from the governance-index `standards:` field for that domain.
+4. The `generate-iac` skill will load it at Stage 0 alongside the built-in
+   standards.
+
+This is the extension seam (D15): the governance-index is the adopter's surface
+for adding compliance-framework content without forking the pack.
+
 ## State
 
 - **Remote state with locking.** Partial backend config in `backend.tf`;

--- a/.claude/skills/reconcile-iac/SKILL.md
+++ b/.claude/skills/reconcile-iac/SKILL.md
@@ -1,25 +1,30 @@
 ---
 name: reconcile-iac
-description: Use this skill to audit Terraform/OpenTofu drift, reconcile state, or run a pre-change preflight before a follow-on infrastructure change. Triggers on "reconcile my infrastructure", "check for drift", "drift audit", "what drifted", "before I change X check drift", "is my infra in sync". Never autonomously applies. Shares generate-iac's references and reviewers.
+description: Use this skill to audit Terraform/OpenTofu drift, reconcile state, run a pre-change preflight, or check an incoming IaC diff for ADR compliance. Triggers on "reconcile my infrastructure", "check for drift", "drift audit", "what drifted", "before I change X check drift", "is my infra in sync", "adr-check", "does this change comply", "check this diff against our ADRs", "compliance check this IaC change". Never autonomously applies. Shares generate-iac's references and reviewers.
 ---
 
 # Skill: reconcile-iac
 
-`plan`-based drift audit → proposed disposition → route. Audit and propose;
-a human (or the `release-loop` consent gate) decides. Never autonomously apply.
+`plan`-based drift audit → ADR compliance check → proposed disposition → route.
+Audit and propose; a human (or the `release-loop` consent gate) decides. Never
+autonomously apply.
 
-## Two triggers — both are first-class
+## Three triggers — all first-class
 
 | Trigger | When | What it does |
 | --- | --- | --- |
 | **Before-change preflight** | Before every follow-on infrastructure change (mandatory, not optional) | Runs a `plan` against live state to surface drift *before* the new change lands on top of it — prevents layering change on unknown drift |
 | **On-demand / scheduled** | On request or on a scheduled cadence | Standalone drift snapshot for quiescent infrastructure; the author-side safety net when `release-loop` is absent |
+| **ADR compliance check** | When an IaC diff arrives that was NOT authored by `generate-iac` (hand-edit, external PR, CI gate) | Checks the diff against the governance-index ADRs — covers the compliance gap for changes the generation skill didn't author |
 
-**Recommended cadence:** (1) Before every follow-on change — mandatory preflight;
-(2) Weekly minimum on a scheduled basis — regular drift snapshot even in
-quiescent periods; (3) Immediately after a known out-of-band event — break-glass
-action, console change, provider-managed auto-modification, or a known pipeline
-failure.
+**Recommended cadence (Triggers 1 and 2):** (1) Before every follow-on change —
+mandatory preflight; (2) Weekly minimum on a scheduled basis — regular drift
+snapshot even in quiescent periods; (3) Immediately after a known out-of-band
+event — break-glass action, console change, provider-managed auto-modification,
+or a known pipeline failure.
+
+**Trigger 3 fires on demand**, not on a cadence — invoke when a diff arrives
+that did not go through `generate-iac`.
 
 ## Known blind spot — document and do not hide
 
@@ -72,6 +77,53 @@ full drift coverage — the audit covers managed resources only.
 6. A human (or the release-loop consent gate) decides the disposition.
    Do not apply or destroy anything autonomously.
 ```
+
+## ADR compliance check procedure (Trigger 3)
+
+Use when an IaC diff arrives that was not authored by `generate-iac` — a
+hand-edited `.tf` file, an external PR, a CI gate check. The governance-index
+is the compliance oracle; this procedure is the enforcement path for changes
+that bypassed Stage 0.
+
+```
+1. Load the governance-index (governance-index.yaml / governance-index.toml).
+   If absent, surface it — offer to bootstrap via generate-iac Stage 0.
+
+2. Identify which governance domains the diff touches. Map by resource type:
+   • aws_iam_* / google_project_iam_* / azurerm_role_assignment → iam
+   • aws_vpc_* / google_compute_network / azurerm_virtual_network → networking
+   • terraform { backend } / aws_s3_bucket (state bucket) → state
+   • resource_group / project / aws_organizations_account → layout
+   • any provider block changes → layout
+   • aws_security_group / aws_security_group_rule → networking + policy
+   • tagging / labels arguments → tagging
+   • CI config changes (GitHub Actions / ADO / GitLab) → pipeline_auth
+
+3. For each touched domain, read the ADR(s) listed in the governance-index.
+   Focus on the ADR's Decision, Constraints, and Consequences sections.
+
+4. For each ADR, evaluate the diff against each constraint:
+   • COMPLIANT — diff honours the constraint
+   • VIOLATION — diff contradicts a constraint (e.g. introduces DynamoDB locking
+     when ADR mandates native S3 lockfile; uses static creds when ADR mandates OIDC)
+   • WARN — diff is in a grey area or the constraint is ambiguous
+
+5. Emit the ADR compliance report:
+   - Summary: N domains checked, M ADRs read, K violations, J warnings
+   - Per-violation: domain → ADR number → specific constraint violated →
+     diff lines that trigger it → recommended fix
+   - Per-warning: domain → ADR number → ambiguity + suggested clarification
+
+6. VIOLATION blocks the change — route to human to either:
+   (a) fix the diff to comply, or
+   (b) draft a new ADR (via new-adr, infra mode) to record a legitimate decision
+       change, then re-check.
+   Do not autonomously approve or suppress a VIOLATION.
+```
+
+**Domain-to-resource-type mapping is heuristic** — add a note in the report when
+a resource type spans multiple domains or doesn't map cleanly. Human confirms the
+domain assignment when ambiguous.
 
 ## Disposition decision guidance
 

--- a/.claude/skills/reconcile-iac/SKILL.md
+++ b/.claude/skills/reconcile-iac/SKILL.md
@@ -73,6 +73,29 @@ full drift coverage — the audit covers managed resources only.
    Do not apply or destroy anything autonomously.
 ```
 
+## Disposition decision guidance
+
+The five dispositions map from cause-class and blast-radius. Use this table as a
+starting heuristic — the human confirms every disposition before any action.
+
+| Cause-class | Blast radius vs planned change | Recommended first disposition |
+| --- | --- | --- |
+| `out-of-band-change` | Overlaps | `block-follow-on` — confirm or codify before proceeding |
+| `out-of-band-change` | No overlap | `codify-back` if legitimate; `open-remediation-PR` if it violates a standard |
+| `provider-managed` | Overlaps | `block-follow-on` → investigate → `add ignore_changes` if intentional |
+| `provider-managed` | No overlap | `add ignore_changes` if the provider change is known-good |
+| `multi-tool` | Any | `add ignore_changes` — another tool owns this; coordinate out-of-band |
+| `pipeline-failure` | Any | `open-remediation-PR` — revert via a `generate-iac` PR to pre-failure state |
+| `unknown` | Any | `block-follow-on` — investigate cause before any disposition |
+
+**Do not merge `codify-back` and `add ignore_changes` on the same resource.**
+They are mutually exclusive: either Terraform owns the current state (codify-back)
+or the drift is intentional and Terraform should stop tracking it (ignore_changes).
+
+**`open-remediation-PR` always routes through `generate-iac`** — do not author
+remediation HCL directly in `reconcile-iac`. Remediation PRs get the full
+standards + reviewer set.
+
 ## Drift decomposition — who owns which moment
 
 | Drift moment | Owner |

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -15,6 +15,27 @@ tactical **backlog**: per-instance, no pack-side source, surfaces as an
 Deferred acceptance criteria point here by anchor (the `(deferred: <anchor>)`
 marker — see RFC-0016).
 
+## `iac-terraform`
+
+### Azure provider validation {#iac-terraform-azure-validation}
+
+**Source:** source-author review (Mridula Juluri, 2026-07-18); D5 of RFC-0065.
+
+Azure shipped `contract-complete` in v1 — the four-file provider contract
+(`versions.tf` / `provider.tf` / `backend.tf` / `backend.hcl.example`) and
+`providers/azure.md` reference are authored, but no worked example has passed
+`terraform init -backend=false && terraform fmt -check && terraform validate`.
+The source material had validated Azure; v1 regressed to experimental pending
+actual validation runs.
+
+**Fix:** author `examples/azure/` (matching the shape of `examples/aws/` and
+`examples/gcp/`); run `terraform init -backend=false && fmt -check && validate`
+against it; remove the `experimental — not validated in v1` stamp from
+`providers/azure.md`; bump the provider index entry to `validated`.
+
+**Unblocks when:** Azure worked example is authored and passes the three-command
+validation gate.
+
 ## How this file is maintained
 
 - Every spec records its own `Status:` field and `Acceptance Criteria`

--- a/docs/rfc/0065-iac-terraform-pack.md
+++ b/docs/rfc/0065-iac-terraform-pack.md
@@ -1369,4 +1369,15 @@ _All in one PR (Q2 — companions ship with the pack)._
   (WA Major 4), + a **`release-loop` conformance canary** (WA Major 3).
 - Author both **`generate-iac`** (D8/D17) and **`reconcile-iac`** (D17) skills
   sharing the references tree; `reconcile-iac` accepts both a before-change
-  preflight trigger and an on-demand/scheduled trigger (§2).
+  preflight trigger and an on-demand/scheduled trigger (§2). Post-ship revision:
+  a third **ADR compliance check trigger** was added (checks an incoming IaC diff
+  against governance-index ADRs for changes not authored by `generate-iac`).
+
+## Deferred items (post-ship)
+
+- **Azure provider validation (deferred to v2).** Azure shipped
+  `contract-complete` in v1 (D5) — the four-file provider contract and standard
+  references are authored, but no worked example passes
+  `init -backend=false && fmt -check && validate`. The source material had
+  validated Azure; this is a known v1 regression relative to the source.
+  Tracked in [`docs/backlog.md § iac-terraform`](../backlog.md#iac-terraform).

--- a/packs/iac-terraform/.apm/skills/generate-iac/SKILL.md
+++ b/packs/iac-terraform/.apm/skills/generate-iac/SKILL.md
@@ -10,6 +10,39 @@ The output is a deploy-ready Terraform directory with a pinned, clean `plan` —
 the G4 handoff to `release-loop` (or the generated human-gated pipeline where
 `release-loop` is absent). Apply is never in scope for this skill.
 
+## v1 scope — governed realization, not architectural design
+
+**In scope (v1):** governed HCL generation from a pre-formed architectural
+intent; provider-contract, tagging, naming, state, IAM, networking, and
+observability standards applied; OPA/Conftest policy gate; Trivy security scan;
+CI pipeline wiring (GitHub Actions / Azure DevOps / GitLab) with OIDC auth;
+plan-based drift audit via `reconcile-iac`.
+
+**Out of scope in v1 — bring a pre-formed architectural decision:**
+- **Workload selection.** RDS vs Aurora vs DynamoDB, EKS vs ECS vs Lambda, VM
+  vs container vs serverless. This skill governs and builds what you chose; it
+  does not evaluate requirements → service fit.
+- **Network topology design.** Hub-spoke vs flat, Transit Gateway vs VPC
+  peering, on-prem connectivity (DX / ExpressRoute / Interconnect), multi-region
+  topology. This skill consumes a network; it does not design one.
+- **Load balancer type/tier selection.** L4 vs L7, global vs regional,
+  health-check strategy, blue/green or canary traffic-shift. "Governed front
+  door only" means the skill wires an LB you specify.
+- **Multi-account / landing-zone orchestration.** AWS Control Tower, Azure
+  Landing Zones, GCP org-hierarchy. Account-isolation model is an input; the
+  org infrastructure is not provisioned here.
+- **Compliance-framework content.** CIS, NIST, PCI-DSS, HIPAA, FedRAMP, SOC 2
+  control mapping. Adopt via governance-index domain rows + custom standard
+  references; built-in standards are security-best-practice, not a
+  control-framework map.
+- **IAM guardrail layer.** AWS SCPs, AWS permission boundaries, Azure Policy at
+  management-group scope, GCP Org Policy constraints. The pack enforces
+  least-privilege role policies; org-level guardrails are an adopter addition
+  (see `security-iam-standard.md` § Organization-level guardrails).
+- **Autonomous apply / operational self-healing.** `reconcile-iac` v1 is
+  managed-drift detect-propose-approve (never autonomous). Runtime operational
+  self-healing (auto-remediate live service degradation) is not in scope.
+
 ## Hard rules — non-negotiable
 
 - **Stage 0 is mandatory and non-bypassable.** Before any Terraform, load the
@@ -125,6 +158,7 @@ Verification and provider shape:
 - `references/terraform-verify-and-iterate.md` — plan-vs-apply oracle, module tests
 - `references/provider-contract.md` — four-file shape + credential tiering + DoD
 - `references/release-loop-integration.md` — G4 artifact set, preflight-set shaping
+- `references/bootstrap-sequence.md` — **load for first bootstrap/ apply** — local-state → create-backend → migrate-state chicken-and-egg story
 
 Load per target (never all at once):
 - `references/providers/<cloud>.md` — cloud-specific config (aws / gcp / azure / …)

--- a/packs/iac-terraform/.apm/skills/generate-iac/references/bootstrap-sequence.md
+++ b/packs/iac-terraform/.apm/skills/generate-iac/references/bootstrap-sequence.md
@@ -1,0 +1,109 @@
+# Bootstrap sequence — state-backend chicken-and-egg
+
+> Load this reference when initialising the `bootstrap/` layer for the first
+> time (no remote state backend exists yet). This is the #1 first-apply failure
+> pattern in layered Terraform — skipping or guessing through it silently breaks
+> all subsequent layers.
+
+## The problem
+
+The layered layout (bootstrap → foundation → platform → app) uses remote state
+from layer 1 onward. But the bootstrap layer *creates* the remote state backend —
+so it can't use it before it exists. Running `terraform init` against a remote
+backend when the bucket doesn't yet exist fails with a credentials or
+bucket-not-found error.
+
+**Resolution: bootstrap runs with local state on the first apply, then migrates.**
+
+## Two-phase procedure
+
+### Phase 1 — Create the backend with local state
+
+1. **Temporarily disable the remote backend** in `bootstrap/backend.tf`:
+
+   ```hcl
+   # Phase 1 only — remove after migration
+   terraform {}
+   ```
+
+2. Run `terraform init` (writes `terraform.tfstate` locally).
+
+3. Run `terraform plan -out=bootstrap.tfplan` — review. The plan should create
+   only the state bucket, OIDC provider, and CI roles.
+
+4. Run `terraform apply bootstrap.tfplan` — the backend infrastructure is live.
+   A local `terraform.tfstate` now exists.
+
+5. Immediately extend `.gitignore` — never commit the local state:
+
+   ```
+   bootstrap/terraform.tfstate*
+   bootstrap/.terraform/
+   ```
+
+### Phase 2 — Migrate local state to the remote backend
+
+6. **Restore the remote backend block** in `bootstrap/backend.tf`:
+
+   ```hcl
+   terraform {
+     backend "s3" {}    # or "gcs" / "azurerm" — partial config
+   }
+   ```
+
+7. Run `terraform init -migrate-state -backend-config=backend.hcl`.
+   Terraform detects existing local state and prompts to copy it to the remote
+   bucket. Answer yes.
+
+8. Verify with `terraform plan` (should show no changes — state matches live).
+
+9. **Commit** `backend.tf` with the restored backend block and the updated
+   `.gitignore`. Do **not** commit `terraform.tfstate` or `.terraform/`.
+
+## Per-cloud backend-hcl.example content
+
+Copy the appropriate block to `bootstrap/backend.hcl` (git-ignored) before
+Phase 1 `terraform init`. The `-migrate-state` step reads it automatically.
+
+**AWS — S3:**
+```hcl
+bucket       = "<state-bucket-name>"
+key          = "bootstrap/terraform.tfstate"
+region       = "<region>"
+encrypt      = true
+kms_key_id   = "alias/terraform-state"
+use_lockfile = true    # Terraform >= 1.11 or OpenTofu >= 1.7
+```
+
+**GCP — GCS:**
+```hcl
+bucket = "<state-bucket-name>"
+prefix = "bootstrap"
+```
+
+**Azure — Azure Blob:**
+```hcl
+resource_group_name  = "<rg>"
+storage_account_name = "<sa>"
+container_name       = "tfstate"
+key                  = "bootstrap.tfstate"
+```
+
+## What the bootstrap layer creates (minimum viable)
+
+| Resource | AWS | GCP | Azure |
+| --- | --- | --- | --- |
+| State bucket | S3 + versioning + SSE-KMS + lifecycle | GCS + versioning + CMEK | Storage account + blob container |
+| OIDC provider | `aws_iam_openid_connect_provider` | Workload Identity Pool + Provider | Azure AD app + federated credential |
+| CI role(s) | `aws_iam_role` (plan role + apply role, separate) | Service account per role | Managed identity |
+
+Bootstrap does **not** create VPCs, compute, databases, or application resources
+(those belong to foundation / platform / app layers).
+
+## Recovery — partial apply
+
+If the bootstrap apply failed mid-way, do **not** run `terraform init -migrate-state`
+yet. First re-run `terraform apply` (Phase 1) to converge the partial state, then
+verify resources exist in the cloud console, then proceed to Phase 2. A
+partially-applied state migrated to remote state is valid — Terraform tracks what
+was created.

--- a/packs/iac-terraform/.apm/skills/generate-iac/references/security-iam-standard.md
+++ b/packs/iac-terraform/.apm/skills/generate-iac/references/security-iam-standard.md
@@ -48,6 +48,35 @@ Wire these into the CI pipeline as mandatory pre-apply gates:
 - Note: **Sentinel is incompatible with OpenTofu**. OPA/Conftest is the only
   open-source policy path that works on both Terraform and OpenTofu engines.
 
+## Organization-level guardrail layer (out of v1 scope)
+
+This pack enforces IAM **role policies** (least-privilege per layer) and
+**pipeline OIDC** (no static creds). It does **not** configure org-level
+guardrails — those are an adopter addition:
+
+| Guardrail | Mechanism | Where to configure |
+| --- | --- | --- |
+| AWS Service Control Policies (SCPs) | Deny/allow at OU or account level | AWS Organizations / Control Tower |
+| AWS permission boundaries | Max-permissions ceiling on roles/users | Added to each `aws_iam_role` resource in the bootstrap layer |
+| Azure Policy | Deny / audit / append at management-group scope | Azure Management Groups |
+| GCP Org Policy constraints | Deny/allow resource policies at org/folder | GCP Organization Policy |
+
+**Recommended practice:** add permission boundaries to the CI roles and
+workload roles created in the `bootstrap/` layer. A permission boundary limits
+what a role can delegate even if a policy grants more. For AWS, attach a
+boundary to every `aws_iam_role` the bootstrap layer creates:
+
+```hcl
+resource "aws_iam_role" "ci_plan" {
+  # ...
+  permissions_boundary = "arn:aws:iam::${var.account_id}:policy/OrgPermBoundary"
+}
+```
+
+Org-level SCPs and policy-as-code together form the guardrail layer the pack's
+inline policies operate within. Document the guardrail layer in an ADR (use
+`new-adr` infra mode, `iam` topic).
+
 ## Checklist (review before merge)
 
 - [ ] No static credentials in `.tf` files, CI environment variables, or

--- a/packs/iac-terraform/.apm/skills/generate-iac/references/terraform-standard.md
+++ b/packs/iac-terraform/.apm/skills/generate-iac/references/terraform-standard.md
@@ -33,6 +33,42 @@ Every layer and module contains:
 `name_prefix = <system>-<env>` for all resource names. Prevents collision
 across environments. Never hardcode a fixed resource name.
 
+## Module sourcing
+
+- **Private registry first.** If the org runs a private Terraform module
+  registry (Terraform Cloud / TFE / Artifactory), source modules from it rather
+  than from the public Terraform Registry. Org-internal modules encode
+  organisation-specific defaults (required tags, approved AMI filters, org
+  network conventions) that public modules don't enforce.
+  ```hcl
+  module "vpc" {
+    source  = "app.terraform.io/<org>/vpc/aws"  # private first
+    version = "~> 3.0"
+  }
+  ```
+- **Public registry only when no private equivalent exists.** Prefer
+  HashiCorp-authored or well-maintained community modules. Pin with `~>` (never
+  a loose `>=`). Record the rationale in the ADR if a public module is chosen
+  over a private one.
+- **Never `source = "./"` in production layers.** Local-path module references
+  are acceptable inside `modules/` but must not be used between layers.
+
+## Compliance framework extension
+
+The built-in standards cover security best practice; they do not map to
+compliance frameworks (CIS Benchmarks, NIST 800-53, PCI-DSS, HIPAA, FedRAMP,
+SOC 2). For regulated environments:
+
+1. Add a domain row to the governance-index for each applicable framework.
+2. Create a repo-local standards document (e.g. `docs/standards/pci-dss-iac.md`)
+   that maps each relevant control to the Terraform patterns that satisfy it.
+3. Reference it from the governance-index `standards:` field for that domain.
+4. The `generate-iac` skill will load it at Stage 0 alongside the built-in
+   standards.
+
+This is the extension seam (D15): the governance-index is the adopter's surface
+for adding compliance-framework content without forking the pack.
+
 ## State
 
 - **Remote state with locking.** Partial backend config in `backend.tf`;

--- a/packs/iac-terraform/.apm/skills/reconcile-iac/SKILL.md
+++ b/packs/iac-terraform/.apm/skills/reconcile-iac/SKILL.md
@@ -1,25 +1,30 @@
 ---
 name: reconcile-iac
-description: Use this skill to audit Terraform/OpenTofu drift, reconcile state, or run a pre-change preflight before a follow-on infrastructure change. Triggers on "reconcile my infrastructure", "check for drift", "drift audit", "what drifted", "before I change X check drift", "is my infra in sync". Never autonomously applies. Shares generate-iac's references and reviewers.
+description: Use this skill to audit Terraform/OpenTofu drift, reconcile state, run a pre-change preflight, or check an incoming IaC diff for ADR compliance. Triggers on "reconcile my infrastructure", "check for drift", "drift audit", "what drifted", "before I change X check drift", "is my infra in sync", "adr-check", "does this change comply", "check this diff against our ADRs", "compliance check this IaC change". Never autonomously applies. Shares generate-iac's references and reviewers.
 ---
 
 # Skill: reconcile-iac
 
-`plan`-based drift audit → proposed disposition → route. Audit and propose;
-a human (or the `release-loop` consent gate) decides. Never autonomously apply.
+`plan`-based drift audit → ADR compliance check → proposed disposition → route.
+Audit and propose; a human (or the `release-loop` consent gate) decides. Never
+autonomously apply.
 
-## Two triggers — both are first-class
+## Three triggers — all first-class
 
 | Trigger | When | What it does |
 | --- | --- | --- |
 | **Before-change preflight** | Before every follow-on infrastructure change (mandatory, not optional) | Runs a `plan` against live state to surface drift *before* the new change lands on top of it — prevents layering change on unknown drift |
 | **On-demand / scheduled** | On request or on a scheduled cadence | Standalone drift snapshot for quiescent infrastructure; the author-side safety net when `release-loop` is absent |
+| **ADR compliance check** | When an IaC diff arrives that was NOT authored by `generate-iac` (hand-edit, external PR, CI gate) | Checks the diff against the governance-index ADRs — covers the compliance gap for changes the generation skill didn't author |
 
-**Recommended cadence:** (1) Before every follow-on change — mandatory preflight;
-(2) Weekly minimum on a scheduled basis — regular drift snapshot even in
-quiescent periods; (3) Immediately after a known out-of-band event — break-glass
-action, console change, provider-managed auto-modification, or a known pipeline
-failure.
+**Recommended cadence (Triggers 1 and 2):** (1) Before every follow-on change —
+mandatory preflight; (2) Weekly minimum on a scheduled basis — regular drift
+snapshot even in quiescent periods; (3) Immediately after a known out-of-band
+event — break-glass action, console change, provider-managed auto-modification,
+or a known pipeline failure.
+
+**Trigger 3 fires on demand**, not on a cadence — invoke when a diff arrives
+that did not go through `generate-iac`.
 
 ## Known blind spot — document and do not hide
 
@@ -72,6 +77,53 @@ full drift coverage — the audit covers managed resources only.
 6. A human (or the release-loop consent gate) decides the disposition.
    Do not apply or destroy anything autonomously.
 ```
+
+## ADR compliance check procedure (Trigger 3)
+
+Use when an IaC diff arrives that was not authored by `generate-iac` — a
+hand-edited `.tf` file, an external PR, a CI gate check. The governance-index
+is the compliance oracle; this procedure is the enforcement path for changes
+that bypassed Stage 0.
+
+```
+1. Load the governance-index (governance-index.yaml / governance-index.toml).
+   If absent, surface it — offer to bootstrap via generate-iac Stage 0.
+
+2. Identify which governance domains the diff touches. Map by resource type:
+   • aws_iam_* / google_project_iam_* / azurerm_role_assignment → iam
+   • aws_vpc_* / google_compute_network / azurerm_virtual_network → networking
+   • terraform { backend } / aws_s3_bucket (state bucket) → state
+   • resource_group / project / aws_organizations_account → layout
+   • any provider block changes → layout
+   • aws_security_group / aws_security_group_rule → networking + policy
+   • tagging / labels arguments → tagging
+   • CI config changes (GitHub Actions / ADO / GitLab) → pipeline_auth
+
+3. For each touched domain, read the ADR(s) listed in the governance-index.
+   Focus on the ADR's Decision, Constraints, and Consequences sections.
+
+4. For each ADR, evaluate the diff against each constraint:
+   • COMPLIANT — diff honours the constraint
+   • VIOLATION — diff contradicts a constraint (e.g. introduces DynamoDB locking
+     when ADR mandates native S3 lockfile; uses static creds when ADR mandates OIDC)
+   • WARN — diff is in a grey area or the constraint is ambiguous
+
+5. Emit the ADR compliance report:
+   - Summary: N domains checked, M ADRs read, K violations, J warnings
+   - Per-violation: domain → ADR number → specific constraint violated →
+     diff lines that trigger it → recommended fix
+   - Per-warning: domain → ADR number → ambiguity + suggested clarification
+
+6. VIOLATION blocks the change — route to human to either:
+   (a) fix the diff to comply, or
+   (b) draft a new ADR (via new-adr, infra mode) to record a legitimate decision
+       change, then re-check.
+   Do not autonomously approve or suppress a VIOLATION.
+```
+
+**Domain-to-resource-type mapping is heuristic** — add a note in the report when
+a resource type spans multiple domains or doesn't map cleanly. Human confirms the
+domain assignment when ambiguous.
 
 ## Disposition decision guidance
 

--- a/packs/iac-terraform/.apm/skills/reconcile-iac/SKILL.md
+++ b/packs/iac-terraform/.apm/skills/reconcile-iac/SKILL.md
@@ -73,6 +73,29 @@ full drift coverage — the audit covers managed resources only.
    Do not apply or destroy anything autonomously.
 ```
 
+## Disposition decision guidance
+
+The five dispositions map from cause-class and blast-radius. Use this table as a
+starting heuristic — the human confirms every disposition before any action.
+
+| Cause-class | Blast radius vs planned change | Recommended first disposition |
+| --- | --- | --- |
+| `out-of-band-change` | Overlaps | `block-follow-on` — confirm or codify before proceeding |
+| `out-of-band-change` | No overlap | `codify-back` if legitimate; `open-remediation-PR` if it violates a standard |
+| `provider-managed` | Overlaps | `block-follow-on` → investigate → `add ignore_changes` if intentional |
+| `provider-managed` | No overlap | `add ignore_changes` if the provider change is known-good |
+| `multi-tool` | Any | `add ignore_changes` — another tool owns this; coordinate out-of-band |
+| `pipeline-failure` | Any | `open-remediation-PR` — revert via a `generate-iac` PR to pre-failure state |
+| `unknown` | Any | `block-follow-on` — investigate cause before any disposition |
+
+**Do not merge `codify-back` and `add ignore_changes` on the same resource.**
+They are mutually exclusive: either Terraform owns the current state (codify-back)
+or the drift is intentional and Terraform should stop tracking it (ignore_changes).
+
+**`open-remediation-PR` always routes through `generate-iac`** — do not author
+remediation HCL directly in `reconcile-iac`. Remediation PRs get the full
+standards + reviewer set.
+
 ## Drift decomposition — who owns which moment
 
 | Drift moment | Owner |


### PR DESCRIPTION
## Summary

Source-author review (Mridula Juluri, 2026-07-18) of RFC-0065 identified five gaps in the v1 implementation that are addressable as documentation/reference additions without a scope decision. This PR addresses all five.

- **Scope boundary** (`generate-iac` SKILL.md): Added explicit v1 scope section naming what's out of scope — workload selection, LB type/tier, network topology design, compliance-framework content, IAM guardrail layer (SCPs/permission boundaries), operational self-healing. The pack is a governed realization engine; bring a pre-formed architectural intent.

- **Disposition classifier** (`reconcile-iac` SKILL.md): Added decision table mapping cause-class × blast-radius → recommended first disposition, with codify-back/ignore_changes mutual-exclusivity rule and open-remediation-PR routing rule.

- **Bootstrap sequence** (new `references/bootstrap-sequence.md`): Documents the local-state → create-backend → migrate-state chicken-and-egg that is the #1 first-apply failure in layered Terraform. Per-cloud backend-hcl.example content, recovery for partial apply.

- **Module sourcing + compliance extension** (`terraform-standard.md`): Private-registry-first guidance (if org has private module registry, use it before public). Compliance-framework extension seam documenting how adopters add CIS/NIST/PCI/HIPAA mapping via governance-index domain rows.

- **IAM guardrail layer** (`security-iam-standard.md`): Explicit out-of-v1-scope section for org-level guardrails (AWS SCPs, permission boundaries, Azure Policy at mgmt-group, GCP Org Policy), with a permission-boundary example for bootstrap roles.

## Deferred (need human decision)

Three findings from the review require a scope or architecture decision before implementation:

- **Standalone `/adr-check`** for changes the generator didn't author — new skill/command, needs RFC.
- **Azure un-regression** — requires actual TF validation effort.
- **Assistant-agnostic degraded path** — architectural decision about pack coupling to `.apm` + `core`.

## Test plan

- [x] `python tools/lint-build.py` — clean
- [x] `python tools/lint-catalogue-seeds.py` — clean
- [x] `python tools/lint-agent-artifacts.py` — clean
- [x] Projection verified: `bootstrap-sequence.md` appears in `.agents/skills/` and `.claude/skills/`