### PR TITLE
fix(docs): repair broken Mermaid in journey current-state diagrams

### DIFF
--- a/docs/product/journeys/engineer-provisions-infrastructure.md
+++ b/docs/product/journeys/engineer-provisions-infrastructure.md
@@ -64,7 +64,7 @@ sequenceDiagram
     A-->>E: Terraform written — review?
     Note over E: No policy-as-code pass, no digest pin
     E-->>E: Manually applies via CI or locally
-    Note over E: No drift audit schedule; drift accumulates undetected
+    Note over E: No drift audit schedule — drift accumulates undetected
 ```
 
 ### With iac-terraform (to-be, RFC-0065)
@@ -80,11 +80,11 @@ sequenceDiagram
     Note over E,GI: Stage 0 — mandatory governance gate
     E->>SK: I need a hardened object store with private ingestion
     SK->>GI: Load governance index (read only bound ADRs)
-    GI-->>E: ADRs cited; decision domains: state-backend, IAM, tagging, encryption
+    GI-->>E: ADRs cited — decision domains: state-backend, IAM, tagging, encryption
     E->>SK: Confirm governance gate (+ bootstrap if no index)
 
     Note over E,GI: Stage 1 — vocabulary-firewalled spec
-    SK-->>E: Spec in generic terms; inputs collected (cloud, engine, isolation model)
+    SK-->>E: Spec in generic terms — inputs collected (cloud, engine, isolation model)
     E->>SK: Confirm spec and isolation model
 
     Note over E,GI: Stage 2 — tier-ordered plan + schema-grounded generation

--- a/docs/product/journeys/engineer-runs-work-loop.md
+++ b/docs/product/journeys/engineer-runs-work-loop.md
@@ -65,7 +65,7 @@ sequenceDiagram
     E->>A: What should I work on next?
     A->>R: Read RFC, roadmap, briefs/ (manual re-orient)
     A-->>E: [best guess at next item]
-    Note over E: No committed queue; next item is inferred
+    Note over E: No committed queue — next item is inferred
 ```
 
 ### To-be state — M1.7 shipped (initiative work)

--- a/docs/product/journeys/product-engineer-shapes-initiative.md
+++ b/docs/product/journeys/product-engineer-shapes-initiative.md
@@ -63,7 +63,7 @@ sequenceDiagram
     A-->>PE: Here is the framing and risk register
     Note over A: Session closes — artifacts in context only
     PE->>F: Manually write brief from memory
-    PE-->>PE: No committed shaping chain; no graduation signal
+    PE-->>PE: No committed shaping chain — no graduation signal
 ```
 
 ### To-be state — M2 shipped

--- a/docs/product/journeys/product-strategist-sets-direction.md
+++ b/docs/product/journeys/product-strategist-sets-direction.md
@@ -60,7 +60,7 @@ sequenceDiagram
     A-->>S: Ad-hoc analysis in session context
     Note over A: Session closes — analysis lost
     S-->>S: Copy insights manually into initiative briefs
-    Note over S: No committed artifact; no cascade into shaping queue
+    Note over S: No committed artifact — no cascade into shaping queue
 ```
 
 ### To-be state — M4 shipped


### PR DESCRIPTION
## Problem

The current-state sequence diagrams in `docs/product/journeys/` render as nothing on GitHub.

## Root cause

Mermaid treats `;` as a **statement separator**. Six diagram lines had a semicolon inside sequence-diagram note/message text (e.g. `Note over E: No drift audit schedule; drift accumulates undetected`). Mermaid split each line at the `;` and tried to parse the trailing fragment as a new statement — an actor with no arrow — throwing a parse error.

## Fix

Replaced each illegal `;` with an em dash (`—`), matching the em-dash style already used throughout these files. Purely a punctuation swap — no diagram semantics changed.

| File | Diagrams affected |
|------|-------------------|
| `engineer-provisions-infrastructure.md` | current-state + to-be (3 lines) |
| `engineer-runs-work-loop.md` | current-state |
| `product-engineer-shapes-initiative.md` | current-state |
| `product-strategist-sets-direction.md` | current-state |

## Verification

Extracted and validated **all 20 mermaid blocks** across the 10 journey files with `mmdc` (the mermaid-cli engine GitHub uses): before → 5 failing, after → all 20 parse cleanly.