### PR TITLE
docs(journeys): consolidate shipped journeys; add dual-path to work-loop

### DIFF
--- a/docs/product/journeys/README.md
+++ b/docs/product/journeys/README.md
@@ -64,7 +64,7 @@ The adoption journey is the prerequisite for everything else. It covers two path
 
 | Journey | Persona | Status | Initiative links |
 |---|---|---|---|
-| [Engineering team evaluates and adopts](team-evaluates-and-adopts.md) | Any team evaluating the platform — self-serve (senior engineer installs and ships first spec) or sponsored (enterprise champion demos to CTO, platform team rolls out) | planned | INI-002 M1 (what the team adopts); M6 (tutorial, rollout playbook, live-demo guide) |
+| [Engineering team evaluates and adopts](team-evaluates-and-adopts.md) | Any team evaluating the platform — self-serve (senior engineer installs and ships first spec) or sponsored (enterprise champion demos to CTO, platform team rolls out) | planned | INI-002 M1 (delivered — what the team adopts); M6 (pending — tutorial, rollout playbook, live-demo guide) |
 
 ---
 
@@ -74,9 +74,9 @@ All four journeys converge on the work queue — different actors, same `work-lo
 
 | Journey | Persona | Status | Initiative links |
 |---|---|---|---|
-| [Engineer adopts AI-native coordination](engineer-adopts-coordination.md) | Engineer installing Platform Core and operating it end-to-end for the first time | planned | INI-002 M1–M6 (primary) |
-| [Engineer runs the work-loop](engineer-runs-work-loop.md) | Interactive implementer using `work-loop` day-to-day; human in the loop for plan review and gate navigation | planned | INI-002 M1 (primary); M2–M6 (ongoing improvements) |
-| [Agent executes spec autonomously](agent-executes-spec.md) | Headless agent cold-starting, orienting, executing, and shipping without human intervention | planned | INI-002 M1 (primary); INI-003 M1+ (extends) |
+| [Engineer adopts AI-native coordination](engineer-adopts-coordination.md) | Engineer installing Platform Core and operating it end-to-end for the first time | planned | INI-002 M1–M6 (primary); M1 delivered |
+| [Engineer runs the work-loop](engineer-runs-work-loop.md) | Interactive implementer using `work-loop` day-to-day; human in the loop for plan review and gate navigation. Two paths: initiative (workspace.toml) and ad-hoc. | shipped | INI-002 M1 (delivered) |
+| [Agent executes spec autonomously](agent-executes-spec.md) | Headless agent cold-starting, orienting, executing, and shipping without human intervention | shipped | INI-002 M1 (delivered); INI-003 M1+ (pending) |
 | [Engineer scales to coordinated agent swarm](engineer-scales-to-swarm.md) | Team with INI-002 M1 in place, scaling to headless CLI agent pipelines across multiple specs in parallel | shaping | INI-003 M1+ (primary); INI-002 M1 (prerequisite) |
 
 ---
@@ -85,11 +85,12 @@ All four journeys converge on the work queue — different actors, same `work-lo
 
 ## Specialist pack journeys
 
-These journeys cover the end-to-end experience of a specific optional pack, including its integration with the loop arc (work-loop + release-loop) and day-2 operations. They sit inside the build room — they are specialised variants of the `engineer-runs-work-loop` path for a specific domain.
+These journeys cover the end-to-end experience of a specific optional pack. They sit inside the build room — specialised variants of the `engineer-runs-work-loop` path for a specific domain.
 
 | Journey | Pack | Status | RFC |
 |---|---|---|---|
-| [Engineer provisions infrastructure](engineer-provisions-infrastructure.md) | `iac-terraform` — repo scope | planned | [RFC-0065](../../rfc/0065-iac-terraform-pack.md) |
+| [Engineer provisions infrastructure](engineer-provisions-infrastructure.md) | `iac-terraform` — repo scope | shipped | [RFC-0065](../../rfc/0065-iac-terraform-pack.md) |
+| [Designer designs a surface](designer-designs-surface.md) | `experience` — user scope; genre-aware design chain (0.5.0 current; 0.6.0 planned) | planned | [RFC-0066](../../rfc/0066-experience-pack-surface-genre-uplift.md) |
 
 ---
 
@@ -106,6 +107,7 @@ flowchart TB
     AG["Agent (autonomous)\nagent-executes-spec"]
     SW["Swarm\nengineer-scales-to-swarm"]
     ADO["Adopting engineer\nengineer-adopts-coordination"]
+    D["Designer\ndesigner-designs-surface"]
 
     S -->|"OKR gaps → shaping_queue"| PE
     PE -->|"bet + capability map"| BQ
@@ -114,6 +116,8 @@ flowchart TB
     WQ --> E
     WQ --> AG
     WQ --> SW
+    WQ -->|"spec with surface-genre brief"| D
+    D -->|"handoff to frontend-engineering"| E
     ADO -. "cross-cutting view" .-> BQ
     ADO -. "cross-cutting view" .-> WQ
 ```

--- a/docs/product/journeys/agent-executes-spec.md
+++ b/docs/product/journeys/agent-executes-spec.md
@@ -4,17 +4,17 @@ slug: agent-executes-spec
 persona: ai-agent
 outcome: spec-executed-and-shipped-autonomously
 surface: cross-platform
-status: planned
+status: shipped
 initiative_links:
   - id: INI-002
     name: Platform Core
-    milestones: M1 (primary — check-workspace M1.5, work-loop M1.7)
+    milestones: M1 (delivered — check-workspace M1.5, work-loop M1.7)
     role: primary
   - id: INI-003
     name: Coding CLI Adapter Pack
-    milestones: M1+ (headless dispatch variant)
+    milestones: M1+ (headless dispatch variant — pending)
     role: extends
-updated: 2026-07-18
+updated: 2026-07-19
 ---
 
 # Journey: Agent executes a spec autonomously
@@ -35,7 +35,7 @@ updated: 2026-07-18
 
 | Pack | Scope | Status | Provides |
 |---|---|---|---|
-| core | repo | current | `check-workspace` (M1.5), `work-loop` (M1.7), `new-spec` |
+| core | repo | current | `check-workspace`, `work-loop` (workspace integration), `new-spec` |
 | coding CLI adapter pack | user | planned (INI-003) | Harness-specific invocation, write-back contract implementation; one adapter per harness (Claude Code, Codex CLI, Kiro, etc.) |
 
 **One-time setup:**
@@ -49,33 +49,6 @@ updated: 2026-07-18
 ---
 
 ## Interaction model
-
-### Current state — before M1.5 / M1.7
-
-```mermaid
-sequenceDiagram
-    participant A as Agent
-    participant F as Repo files (RFC, roadmap, briefs/)
-    participant WL as work-loop skill
-    participant R as Repo (spec branch)
-
-    Note over A,R: Session start today — manual orientation
-    A->>F: Read docs/rfc/0064-ini-001-ai-native-ecosystem.md
-    A->>F: Read docs/product/roadmap.md
-    A->>F: Read docs/product/briefs/ (scan for in-progress)
-    A->>F: Read AGENTS.md
-    F-->>A: Context assembled — uncertain what is next
-    A-->>A: Infer active spec from context (may be wrong)
-
-    Note over A,R: Execution — no workspace write-back
-    A->>WL: work-loop [inferred spec]
-    Note over A: plan → build → verify → review
-    A->>R: Submit PR
-    A-->>A: Spec done — workspace not updated
-    Note over A: Next agent starts cold — same manual orientation
-```
-
-### To-be state — M1.5 + M1.7 shipped
 
 ```mermaid
 sequenceDiagram
@@ -111,31 +84,21 @@ sequenceDiagram
 
 ## Stage 1: Orient
 
-### Now
-
 | Row | Content |
 |-----|---------|
-| **Actions** | Reads RFC, roadmap, briefs directory, AGENTS.md. Assembles context from 4+ files. Infers what spec to work on. |
-| **Emotions** | N/A (agent has no emotions). **Failure modes:** context assembled incorrectly (wrong spec inferred); context outdated (stale RFC or roadmap); spec already in progress by another agent (no visibility). |
-| **Pains** | "Four files to read, and the answer is still uncertain." "If the RFC was updated since the last session, the agent may be working from stale context." "No way to know if another agent is already working on the same spec." "Reading 4+ files consumes significant context window before any work starts." |
-| **Opportunities** | `check-workspace` as a single orientation command that surfaces active initiative, queued specs, DAG state, blocked reasons, and parallel candidates. Orientation in one command; context window preserved for actual work. |
-
-> **With M1.5** — `check-workspace` ships: orientation is one command; DAG state surfaces parallel candidates and blocked items; context window saved for work.
+| **Actions** | Runs `check-workspace`. Reads `workspace.toml`, resolves DAG across all queues, surfaces the active initiative, ready specs, blocked items with reasons, and parallel candidates. |
+| **Failure modes** | Context assembled incorrectly (wrong spec inferred — rare with `check-workspace`); spec already claimed by another agent (no atomic claiming until INI-003 adapter ships); stale `workspace.toml` if a prior agent did not write back on ship. |
+| **Remaining pains** | "I can see the spec is ready but I can't confirm no other agent has claimed it — atomic claiming is an INI-003 adapter concern." |
 
 ---
 
 ## Stage 2: Validate Spec Context
 
-### Now
-
 | Row | Content |
 |-----|---------|
-| **Actions** | Reads the inferred spec file (if it exists). Reads the brief it decomposes. Tries to understand what is in scope and what has already been done. |
-| **Emotions** | N/A. **Failure modes:** spec file doesn't exist yet (no new-spec has been run); brief is ambiguous; prior session's work is not committed (agent starts from scratch on uncommitted state). |
-| **Pains** | "The spec file may not exist — I have to run new-spec first, but I don't know if that's been done." "The brief doesn't tell me what has already been implemented — I might redo work." "If a prior agent made decisions mid-session that weren't committed, I have no way to see them." |
-| **Opportunities** | `work-loop` at step 0 reads `workspace.toml` to confirm the spec is in `[work].active` (or moves it there). Gate-boundary handoff notes committed by the prior session (post-M1 backlog — feeds INI-005). |
-
-> **With M1.7** — `work-loop` reads `workspace.toml` at step 0 to confirm spec context; partial-progress capture (gate-boundary handoff) is a Known Unknown deferred to INI-005 design.
+| **Actions** | Reads the spec file. `work-loop` reads `workspace.toml` at step 0 to confirm the spec is in `[work].active` (or moves it there). Reads the brief it decomposes to understand scope. |
+| **Failure modes** | Spec file doesn't exist yet (no `new-spec` has been run — agent runs `new-spec` first); brief is ambiguous; prior session's decisions were not committed (agent starts from scratch on uncommitted state). |
+| **Remaining pains** | "If a prior agent made decisions mid-session that weren't committed, I have no way to see them." Partial-progress capture (gate-boundary handoff notes) is a post-M1 backlog item deferred to INI-005. |
 
 ---
 
@@ -167,16 +130,11 @@ sequenceDiagram
 
 ## Stage 5: Ship & Exit
 
-### Now
-
 | Row | Content |
 |-----|---------|
-| **Actions** | Submits PR. Does not update `workspace.toml`. Exits. Next agent starts cold. |
-| **Emotions** | N/A. **Failure modes:** PR submitted but workspace not updated; next agent re-picks the same spec (thinking it's not done); `roadmap.md` not updated (prompt never surfaced). |
-| **Pains** | "I submitted the PR but `workspace.toml` still shows the spec as active — the next agent might pick it up again." "I have no way to surface the `roadmap.md` update reminder." "The next agent starts with the same uncertain orientation I had — nothing I did makes their session easier." |
-| **Opportunities** | Post-ship automation: `workspace.toml` updated (active → shipped) on PR submission; next ready item surfaced; `roadmap.md` update prompted; exit state is a clean known-good `workspace.toml` that the next agent can orient from in one command. |
-
-> **With M1.7** — `work-loop` moves spec active → shipped on ship; surfaces next ready item; prompts `roadmap.md` update. Exit state is committed to `workspace.toml` — next agent orients in one `check-workspace` call.
+| **Actions** | Submits PR. `work-loop` moves spec `active → shipped` in `workspace.toml` on ship; surfaces next ready item; prompts `roadmap.md` update. Exit state is committed — next agent orients in one `check-workspace` call. |
+| **Failure modes** | PR submitted but write-back skipped (agent interrupted before `work-loop` completes write-back); `roadmap.md` update skipped. Next agent should run `check-workspace` to confirm state before starting. |
+| **Remaining pains** | Partial-progress capture if the agent was interrupted mid-build (not committed). Full session continuity feeds INI-005. |
 
 ---
 
@@ -196,11 +154,9 @@ sequenceDiagram
 
 ## Failure mode arc (replaces emotional arc for agent persona)
 
-Most critical failure: **Stage 1 (Orient)** — wrong spec inferred, or spec already claimed by another agent. Everything downstream is wasted work if the orientation is wrong.
+Most critical failure: **Stage 1 (Orient)** — spec already claimed by another agent, or `workspace.toml` stale because a prior agent didn't write back. `check-workspace` catches the second; atomic claiming (INI-003) closes the first.
 
-Second most critical: **Stage 5 (Ship & Exit)** — PR submitted but workspace not updated. The next agent re-picks the same spec, producing a duplicate PR or conflicting work.
-
-Primary design response: M1.5 `check-workspace` (orientation accuracy) + M1.7 `work-loop` write-back (exit state integrity). The combination means orientation is reliable and exit state is committed — the two highest-risk failure points are both closed by M1.
+Second most critical: **Stage 5 (Ship & Exit)** — PR submitted but `work-loop` write-back interrupted. Next agent re-picks the same spec. Mitigation: always run `check-workspace` at session start to confirm state before claiming.
 
 Remaining failure modes (partial-progress capture, budget tracking, gate diagnostics) are post-M1 backlog items — some feed INI-005 design.
 

--- a/docs/product/journeys/designer-designs-surface.md
+++ b/docs/product/journeys/designer-designs-surface.md
@@ -38,50 +38,51 @@ Two paths share this journey:
 
 | Pack | Scope | Status | Provides |
 |---|---|---|---|
-| experience | user | current (0.5.0) | 11 skills covering the design chain |
-| experience | user | planned (0.6.0 — RFC-0066) | + 7 new skills, 6 existing skills extended (7 additions), 9 renames, surface-genre contract + genre-specific brief sections |
+| experience | user | current (0.5.0) | `map-customer-journey`, `service-blueprint`, `aesthetic-direction`, `layout-and-information-architecture`, `map-screen-flow`, `interaction-design`, `design-critique`, `design-system-foundations`, `content-design`, `copy-direction`, `map-internal-process` |
+| experience | user | planned (0.6.0) | 16 skills covering the genre-aware design chain: `journey-mapping`, `service-blueprint`, `design-principles`, `creative-direction`, `information-architecture`, `user-flow`, `interaction-design`, `design-review`, `design-system`, `content-design` + 6 genre-specific Direct skills (`conversion-design`, `documentation-design`, `analytical-design`, `marketplace-design`, `informational-design`, `workspace-design`) |
 
-**As-is setup (experience 0.5.0):**
+**Setup (current — 0.5.0):**
 1. Install experience pack at user scope.
-2. Begin with `map-customer-journey` or `map-screen-flow` depending on entry point.
-3. No genre awareness in the chain; designer must manually route to relevant patterns.
+2. Begin with `map-customer-journey` → `aesthetic-direction` → `layout-and-information-architecture` → `map-screen-flow` → `interaction-design` → `design-critique`.
 
-**To-be setup (experience 0.6.0):**
+**Setup (to-be — 0.6.0):**
 1. Install experience pack at user scope.
 2. Begin with `journey-mapping` → `design-principles` → genre-specific Direct skill → `user-flow` → `interaction-design` → `design-review`.
 3. Surface genre declared once at `user-flow` (or elicited inline); flows to all downstream skills automatically.
 
 ---
 
-## Interaction model
-
-### Current state — experience 0.5.0 (before RFC-0066)
+## Current state — experience 0.5.0
 
 ```mermaid
 sequenceDiagram
     participant D as Designer
-    participant JM as map-customer-journey
-    participant SF as map-screen-flow
-    participant IA as layout-and-IA
+    participant MCJ as map-customer-journey
+    participant AD as aesthetic-direction
+    participant LIA as layout-and-information-architecture
+    participant MSF as map-screen-flow
     participant ID as interaction-design
     participant DC as design-critique
 
-    Note over D,DC: Genre-blind chain — same patterns for every surface type
-    D->>JM: Maps journey (no peak moments, no evidence level)
-    JM-->>D: Journey artefact (flat pains, no genre axis)
-    Note over D: No design-principles step — jumps straight to screens
-    D->>SF: Screen flow (no genre field in briefs)
-    SF-->>D: Briefs (generic template — no genre sections)
-    D->>IA: IA design (no genre routing, no success metric)
-    IA-->>D: Generic hierarchy
-    D->>ID: Interaction design (no wizard/table/destructive/save-state patterns)
-    ID-->>D: Limited pattern families
-    D->>DC: Critique (no design-principles reference — relitigates same debates)
-    DC-->>D: Findings (unanchored to principles)
-    Note over D: A/B: Different surface type? Same chain, no routing.
+    Note over D,DC: 0.5.0 — no genre routing, no design-principles phase
+    D->>MCJ: Maps customer journey (stages, pains, opportunities)
+    MCJ-->>D: Journey artefact (no peak moment ID, no evidence-level)
+    D->>AD: Sets visual personality and brand goals
+    AD-->>D: Named aesthetic goals + arbitration rules
+    Note over D: No dedicated Define phase — principles in session context only
+    D->>LIA: Structures screen hierarchy and reading flow
+    LIA-->>D: IA + layout reasoning doc (no genre routing)
+    D->>MSF: Sequences screens and navigation routes
+    MSF-->>D: Screen-flow briefs (no surface-genre field)
+    D->>ID: Designs component behavior and interaction states
+    ID-->>D: Interaction patterns (no genre pattern families)
+    D->>DC: Evaluates surface against quality + aesthetic standards
+    DC-->>D: Findings list (no principle anchoring, no genre rubric)
 ```
 
-### To-be state — experience 0.6.0 (after RFC-0066)
+---
+
+## To-be state — experience 0.6.0 (RFC-0066)
 
 ```mermaid
 sequenceDiagram
@@ -116,130 +117,112 @@ sequenceDiagram
 
 ## Stage 1: Discover
 
-### Now (experience 0.5.0)
+### Now (0.5.0)
 
-| Row | Content |
-|-----|---------|
-| **Actions** | Runs `map-customer-journey` (produces journey map) and `blueprint-service` (produces service blueprint). Populates frontstage actions, emotions, pains, opportunities. |
-| **Emotions** | Methodical but uncertain (neutral). The artefact exists but pains are flat — no signal about where to invest design effort first. |
-| **Pains** | "The journey map shows every pain equally. I don't know which one matters most." "There's no way to tell if this map is based on real research or assumptions." "The service blueprint doesn't show the artefacts customers actually receive — just the actors." |
-| **Opportunities** | Mark peak moments (highest negative and highest positive) explicitly; carry Kahneman peak-end rule into the map. Declare evidence level so downstream designers know confidence. Add evidence-of-service row to the service blueprint. |
+Uses `map-customer-journey` — produces stages, actions, emotions, pains, and opportunities. No peak moment identification or evidence-level declaration. No genre-stage templates. `service-blueprint` is available but produces no evidence-of-service row or fail-point prioritisation. Designer leaves Stage 1 with a journey artefact but without a focused design mandate.
 
-> **With RFC-0066 (D5a + D5c)** — `journey-mapping` gains: peak moment identification (the 1–3 stages with the steepest negative dip + the single most-positive peak, explicit in the artefact); evidence-level declaration (`observational` / `survey-backed` / `assumption-based` in frontmatter); surface-genre stage templates (canonical stage scaffolds for each of the 7 genres). `service-blueprint` gains: evidence-of-service row (physical/digital artefacts customers encounter at each frontstage touchpoint — notifications, receipts, error screens) and fail-point marking with design priority (critical / high / medium). Designer now leaves Stage 1 knowing **where to focus** and **how confident to be**.
+### With 0.6.0
+
+`journey-mapping` produces a journey artefact with peak moment identification (the 1–3 stages with the steepest negative dip + the single most-positive peak, explicit in the artefact), evidence-level declaration (`observational` / `survey-backed` / `assumption-based` in frontmatter), and surface-genre stage templates (canonical stage scaffolds for each of the 7 genres). `service-blueprint` produces an evidence-of-service row (physical/digital artefacts customers encounter at each frontstage touchpoint — notifications, receipts, error screens) and fail-point marking with design priority (critical / high / medium). Designer leaves Stage 1 knowing **where to focus** and **how confident to be**.
 
 ---
 
 ## Stage 2: Define
 
-### Now (experience 0.5.0)
+### Now (0.5.0)
 
-| Row | Content |
-|-----|---------|
-| **Actions** | None. The chain jumps directly from journey map to screen flows. No intermediate synthesis step. |
-| **Emotions** | Skipped (negative). The design team jumps from "we have research" to "let's make screens" without naming what should govern the screens. |
-| **Pains** | "Every design review re-litigates the same trade-offs — we never agreed on what to optimise for." "We have twelve insights from the research but nothing that tells us which direction to go." "Design reviews turn into opinion sessions because we have no shared criteria." |
-| **Opportunities** | A dedicated step that synthesises insights into 3–5 named design principles. These principles are decision arbiters: every later design choice is evaluated against them. One session of principle derivation replaces months of repeated debate. |
+No dedicated Define phase. Principles are set informally within `aesthetic-direction` or skipped entirely. There is no committed `docs/design/principles/` artefact — principles do not survive the session. Direction debates recur at every `design-critique` pass.
 
-> **With RFC-0066 (D3)** — New `design-principles` skill fills the absent Define phase. Consumes journey-mapping's peak moments and highest-opportunity pains; derives 3–5 named, actionable principles using the NNGroup four-step model (identify core values → articulate user impact → surface tradeoffs → draft + converge). Output: `docs/design/principles/<slug>.md`. Every downstream skill references these principles when making trade-off decisions. `design-review` maps each finding to the principle it was judged against. **This is the single highest-leverage gap the RFC closes** — the Define phase prevents relitigating at every review.
+### With 0.6.0
+
+The `design-principles` skill fills the Define phase between discovery and screen design. Consumes `journey-mapping`'s peak moments and highest-opportunity pains; derives 3–5 named, actionable principles using the NNGroup four-step model (identify core values → articulate user impact → surface tradeoffs → draft + converge). Output: `docs/design/principles/<slug>.md`. Every downstream skill references these principles when making trade-off decisions. `design-review` maps each finding to the principle it was judged against. **This is the highest-leverage stage in the chain** — principles produced here prevent relitigating direction at every review.
 
 ---
 
 ## Stage 3: Direct
 
-### Now (experience 0.5.0)
+### Now (0.5.0)
 
-| Row | Content |
-|-----|---------|
-| **Actions** | Runs `aesthetic-direction` (visual personality), `layout-and-information-architecture` (hierarchy), `content-design` (copy strategy). No concept of surface genre — all three skills produce the same outputs regardless of whether the surface is a marketing page, a dashboard, or a documentation site. |
-| **Emotions** | Competent but constrained (neutral → negative). The skills work but they don't tell the designer what's different about this kind of surface. Marketing-specific conversion patterns, documentation-specific density calibration, and analytical dashboard IA have to be sourced externally. |
-| **Pains** | "IA for a marketing page is completely different from IA for a docs site, but the skill treats them the same." "I know our hero needs to demo the product but the skill doesn't have any guidance for how to structure a marketing hero." "I'm designing a dashboard — the skill gives me a generic hierarchy but nothing about three-tier widget IA or Shneiderman's mantra." |
-| **Opportunities** | Genre-specific Direct skills for all six addressable genres. `information-architecture` with genre routing that reads the genre-specific skill output. |
+Uses `aesthetic-direction` (sets visual personality and brand goals) and `layout-and-information-architecture` (structures screen hierarchy and reading flow). No genre routing — all surface types follow the same generic patterns. `creative-direction` and genre-specific Direct skills are not available.
 
-> **With RFC-0066 (D4 + D5d + D5f)** — Six new genre-specific Direct skills ship:
-> - **`conversion-design`** (marketing): hero approach selection (5 patterns), above-fold 6-element spec, IC-first principle for developer tools, scroll story 7-zone structure, social proof 6-tier hierarchy calibrated to maturity stage.
-> - **`documentation-design`** (documentation): Diátaxis type mapping + density calibration, nav-at-scale strategy selection (3 strategies by complexity tier), TTFV as design target, onboarding path as numbered Start Here spine, machine-readability requirements.
-> - **`analytical-design`** (analytical): domain-model-first approach, business-question anchoring (3–5 explicit questions), three-tier widget hierarchy, Shneiderman's mantra (overview → zoom/filter → details on demand), role-based views, spatial layout grammar, per-widget state handling.
-> - **`marketplace-design`** (marketplace): listing card IA, filter/facet architecture, comparison affordances, browse-first vs. search-first routing, cart/transaction bridge to interaction-design wizard patterns.
-> - **`informational-design`** (informational): typography as primary design tool (type scale, line length 45–75 chars, line height 1.4–1.6×), F/Z reading flow calibration (heavy headlines + pull quotes for scanners; body density for committed readers), editorial grid (asymmetric column), article page structure, "what's next" chain design, content entry point diversity.
-> - **`workspace-design`** (workspace): context-persistence patterns, session arc design (arrive → orient → work → persist → collaborate), collaboration state IA (presence indicators, live-editing, following mode), interrupt and notification design (low-interruption default), permission/sharing model IA, ambient vs. focal attention zones. **Agentic UI patterns** — task queue surface, agent status indicators, human-in-the-loop confirmation surfaces (impossible to accidentally bypass), output review and revision patterns, agent history and auditability, multi-agent coordination visibility.
-> - **`information-architecture`** gains genre routing (step 1): reads the genre-specific skill output for all six genres; applies progressive disclosure for `transactional-journey`. Also gains success metric binding (before designing hierarchy, name the measurable outcome the surface serves).
-> - **`creative-direction`** gains genre canonical references (D5f): for each genre, the canonical aesthetic reference tier to study (developer tool marketing sites for `marketing`; Stripe/Vercel/Django Docs for `documentation`; Notion/Linear/Figma for `workspace`; etc.).
+### With 0.6.0
+
+Six genre-specific Direct skills route each surface to the right patterns:
+
+- **`conversion-design`** (marketing): hero approach selection (5 patterns), above-fold 6-element spec, IC-first principle for developer tools, scroll story 7-zone structure, social proof 6-tier hierarchy calibrated to maturity stage.
+- **`documentation-design`** (documentation): Diátaxis type mapping + density calibration, nav-at-scale strategy selection (3 strategies by complexity tier), TTFV as design target, onboarding path as numbered Start Here spine, machine-readability requirements.
+- **`analytical-design`** (analytical): domain-model-first approach, business-question anchoring (3–5 explicit questions), three-tier widget hierarchy, Shneiderman's mantra (overview → zoom/filter → details on demand), role-based views, spatial layout grammar, per-widget state handling.
+- **`marketplace-design`** (marketplace): listing card IA, filter/facet architecture, comparison affordances, browse-first vs. search-first routing, cart/transaction bridge to interaction-design wizard patterns.
+- **`informational-design`** (informational): typography as primary design tool (type scale, line length 45–75 chars, line height 1.4–1.6×), F/Z reading flow calibration (heavy headlines + pull quotes for scanners; body density for committed readers), editorial grid (asymmetric column), article page structure, "what's next" chain design, content entry point diversity.
+- **`workspace-design`** (workspace): context-persistence patterns, session arc design (arrive → orient → work → persist → collaborate), collaboration state IA (presence indicators, live-editing, following mode), interrupt and notification design (low-interruption default), permission/sharing model IA, ambient vs. focal attention zones. **Agentic UI patterns** — task queue surface, agent status indicators, human-in-the-loop confirmation surfaces (impossible to accidentally bypass), output review and revision patterns, agent history and auditability, multi-agent coordination visibility.
+
+`information-architecture` applies genre routing at step 1 (reads the genre-specific skill output for all six genres; applies progressive disclosure for `transactional-journey`) and success metric binding (before designing hierarchy, name the measurable outcome the surface serves). `creative-direction` carries genre canonical references: for each genre, the canonical aesthetic reference tier to study (developer tool marketing sites for `marketing`; Stripe/Vercel/Django Docs for `documentation`; Notion/Linear/Figma for `workspace`; etc.).
 
 ---
 
 ## Stage 4: Design
 
-### Now (experience 0.5.0)
+### Now (0.5.0)
 
-| Row | Content |
-|-----|---------|
-| **Actions** | Runs `map-screen-flow` (screen sequencing + per-screen briefs) and `interaction-design` (pattern selection). Screen briefs have no genre field. Interaction-design has two pattern families (onboarding + search). No wizard/stepper, data table, destructive action, save-state, or analytical patterns. |
-| **Emotions** | Constrained then resourceful (neutral → negative). The designer knows what patterns are needed but has to look them up outside the skill. Each new surface type requires external research. |
-| **Pains** | "The screen brief template is the same for every surface — a marketplace brief needs different sections than a workspace brief." "Interaction-design has no guidance on multi-step wizards. I have to look it up every time." "There are no destructive action patterns in the skill — I'm re-deriving the 5-tier escalation from scratch for every project." "The analytical dashboard I'm designing needs widget-state patterns — the skill doesn't cover it." |
-| **Opportunities** | Surface-genre field in the screen brief contract (declared once, flows to all downstream skills). Five new interaction-design pattern families covering the most-absent patterns. |
+Uses `map-screen-flow` (screen sequencing and navigation routes) and `interaction-design` (component behavior, states). Screen briefs carry no `surface-genre:` field. Five interaction pattern families are available (wizard, data table, destructive action, save-state, analytical widgets) but no genre-to-pattern routing. Engineering receives generic briefs.
 
-> **With RFC-0066 (D1 + D5b)** — `user-flow` (renamed from `map-screen-flow`) adds `surface-genre:` to every per-screen brief frontmatter, a new confirmation step (confirm genre before drafting briefs; elicit inline when absent), and a `## Genre-specific notes` conditional section at the end of each brief template. Downstream skills read the field automatically. `interaction-design` gains five new pattern families in `references/pattern-families.md`:
-> 1. **Wizard and stepper**: linear stepper validation-on-exit, save-and-resume, conditional disclosure.
-> 2. **Data table**: four filter types, bulk operations, row-detail disclosure (5 options), alignment rules.
-> 3. **Destructive action 5-tier escalation**: inline confirmation → toast+undo → modal → typed confirmation → two-person/2FA.
-> 4. **Save-state**: autosave with three indicator states, unsaved-changes guard (Save primary, Discard secondary), draft vs. published distinction.
-> 5. **Analytical dashboard widgets**: KPI card anatomy (≤9 primary), alert/signal design (text-paired, timestamped), drill-down affordance (drawer = default).
->
-> The genre-specific brief sections cover all 7 genres: marketing (scroll zone, conversion goal, above-fold elements), documentation (Diátaxis type, density target), informational (content type, what's-next chain), analytical (business question, domain objects, widget-state contract), marketplace (entry path, filter state, comparison affordance), workspace (session arc position, collaboration state, agentic UI elements), transactional-journey (gate position, validation timing, save-state).
+### With 0.6.0
+
+`user-flow` adds `surface-genre:` to every per-screen brief frontmatter, a confirmation step (confirm genre before drafting briefs; elicit inline when absent), and a `## Genre-specific notes` conditional section at the end of each brief template. Downstream skills read the field automatically. `interaction-design` carries five pattern families in `references/pattern-families.md`:
+
+1. **Wizard and stepper**: linear stepper validation-on-exit, save-and-resume, conditional disclosure.
+2. **Data table**: four filter types, bulk operations, row-detail disclosure (5 options), alignment rules.
+3. **Destructive action 5-tier escalation**: inline confirmation → toast+undo → modal → typed confirmation → two-person/2FA.
+4. **Save-state**: autosave with three indicator states, unsaved-changes guard (Save primary, Discard secondary), draft vs. published distinction.
+5. **Analytical dashboard widgets**: KPI card anatomy (≤9 primary), alert/signal design (text-paired, timestamped), drill-down affordance (drawer = default).
+
+The genre-specific brief sections cover all 7 genres: marketing (scroll zone, conversion goal, above-fold elements), documentation (Diátaxis type, density target), informational (content type, what's-next chain), analytical (business question, domain objects, widget-state contract), marketplace (entry path, filter state, comparison affordance), workspace (session arc position, collaboration state, agentic UI elements), transactional-journey (gate position, validation timing, save-state).
 
 ---
 
 ## Stage 5: Validate
 
-### Now (experience 0.5.0)
+### Now (0.5.0)
 
-| Row | Content |
-|-----|---------|
-| **Actions** | Runs `design-critique` against the screens. Critique covers: handle-all-states, accessibility floor, reduced-motion, JTBD alignment. |
-| **Emotions** | Exposed (neutral → negative). The critique is valuable but it cannot anchor findings to shared design principles — the team relitigates which direction to take on every finding. |
-| **Pains** | "We produce a list of critique findings but half of them become debates about direction. We have no agreed criteria." "The critique doesn't check documentation-specific concerns — density, sidebar depth, heading hierarchy." "Design principles we agreed on at the start of the project aren't referenced anywhere in the review." |
-| **Opportunities** | Design-review that explicitly references the design-principles artefact. Genre-specific review rubrics (documentation density targets, marketing conversion checks, analytical widget-state completeness). |
+Uses `design-critique` — quality-floor pass (states, a11y, motion), heuristic evaluation (Nielsen's 10), marketing clarity pass, aesthetic critique. Findings are severity-rated but not anchored to named principles. No genre-specific rubrics — reviewers apply ad-hoc external checklists.
 
-> **With RFC-0066 (D7 rename + D5e + D5g)** — `design-critique` is renamed to `design-review`. D5(e) makes design-principles integration a mandatory first procedure step: load the design-principles artefact; map each finding to the principle it was judged against. Findings that can't be mapped either (a) identify a quality-floor violation, or (b) surface a new directional call. D5(g) adds genre-specific rubrics:
->
-> - **documentation:** density matches Diátaxis type, TTFV path navigable, sidebar ≤ 3 levels, unique page descriptions, semantic heading hierarchy.
-> - **marketing:** all six above-fold elements present, CTA hierarchy unambiguous, first proof signal above fold, hero matches product type.
-> - **analytical:** every primary widget has a drill-down destination, handles all four states independently, KPIs ≤9, every alert text-paired.
-> - **informational:** line length 45–75 chars, declared what's-next path, pull quotes at scan intervals.
-> - **marketplace:** listing cards consistent tier, filter state visible on load, zero-results state designed.
-> - **workspace:** session restoration present, collaboration state signals ambient not dominant, agentic actions recoverable or auditable.
->
-> **Stage 5 now closes the full Define→Validate chain**: principles produced at Stage 2 are formally required at Stage 5 by procedure, and genre-specific validation replaces ad-hoc external checklists.
+### With 0.6.0
+
+`design-review` (renamed from `design-critique`) makes design-principles integration a mandatory first procedure step: load the design-principles artefact; map each finding to the principle it was judged against. Findings that can't be mapped either (a) identify a quality-floor violation, or (b) surface a new directional call. Genre-specific rubrics:
+
+- **documentation:** density matches Diátaxis type, TTFV path navigable, sidebar ≤ 3 levels, unique page descriptions, semantic heading hierarchy.
+- **marketing:** all six above-fold elements present, CTA hierarchy unambiguous, first proof signal above fold, hero matches product type.
+- **analytical:** every primary widget has a drill-down destination, handles all four states independently, KPIs ≤9, every alert text-paired.
+- **informational:** line length 45–75 chars, declared what's-next path, pull quotes at scan intervals.
+- **marketplace:** listing cards consistent tier, filter state visible on load, zero-results state designed.
+- **workspace:** session restoration present, collaboration state signals ambient not dominant, agentic actions recoverable or auditable.
+
+Stage 5 closes the full Define→Validate chain: principles produced at Stage 2 are formally required at Stage 5 by procedure, and genre-specific validation replaces ad-hoc external checklists.
 
 ---
 
 ## Stage 6: Deliver
 
-### Now (experience 0.5.0)
+### Now (0.5.0)
 
-| Row | Content |
-|-----|---------|
-| **Actions** | Runs `map-screen-flow` handover step — produces a design-tool handover template for `frontend-engineering`. |
-| **Emotions** | Relieved (positive). The handoff is mechanical; the artefact exists. |
-| **Pains** | "The handover template is generic — it doesn't tell engineering which patterns we decided on for the transactional flow." "Engineering asks me the same questions about interaction state that should already be in the briefs." |
-| **Opportunities** | Handoff that references the surface-genre and interaction patterns used, reducing back-and-forth with engineering. |
+Uses `map-screen-flow` handover template. Delivers screen briefs without `surface-genre:` field — engineering infers the pattern family from context. No explicit reference to which interaction-design patterns were selected.
 
-> **With RFC-0066** — `user-flow` handover is unchanged in procedure but the briefs it produces now carry `surface-genre:` and reference the interaction-design patterns applied per genre. Engineering reads the brief and knows which pattern families were selected. Fewer "how does this wizard work?" conversations.
+### With 0.6.0
+
+`user-flow` handover produces a design-tool handover template for `frontend-engineering`. Briefs carry `surface-genre:` and reference the interaction-design patterns applied per genre. Engineering reads the brief and knows which pattern families were selected — fewer "how does this wizard work?" conversations.
 
 ---
 
-## Remaining gaps
+## What experience 0.6.0 added (RFC-0066)
 
-All six gaps identified in the original gap analysis are addressed in RFC-0066:
-
-| # | Gap | Resolved by | Notes |
-|---|---|---|---|
-| G1 | workspace-design skill absent | D4 (sixth genre-specific skill) | workspace-design skill covers session arc, collaboration state IA, and agentic UI patterns. |
-| G2 | design-review → design-principles chain | D5(e) | Made a mandatory first procedure step in `design-review`, not a recommendation. |
-| G3 | informational genre: no dedicated Direct skill | D4 (fifth genre-specific skill) | `informational-design` covers typography, F/Z reading flow, editorial grid, what's-next chain. |
-| G4 | design-review not extended with genre rubrics | D5(g) | Genre-specific rubrics for all six addressable genres added to `design-review` procedure. |
-| G5 | user-flow genre-specific brief sections absent | D1 expansion | `## Genre-specific notes` conditional section added to screen-brief template; covers all 7 genres. |
-| G6 | creative-direction not extended | D5(f) | Genre canonical reference tier added for all 7 genres. |
+| # | Capability | Stage |
+|---|---|---|
+| G1 | `workspace-design` skill — session arc, collaboration state IA, agentic UI patterns | Stage 3 |
+| G2 | `design-review` mandatory design-principles integration at step 1 | Stage 5 |
+| G3 | `informational-design` skill — typography, F/Z reading flow, editorial grid, what's-next chain | Stage 3 |
+| G4 | `design-review` genre-specific rubrics for all six addressable genres | Stage 5 |
+| G5 | `user-flow` `## Genre-specific notes` conditional section in every screen brief (all 7 genres) | Stage 4 |
+| G6 | `creative-direction` genre canonical reference tier for all 7 genres | Stage 3 |
 
 ---
 
@@ -308,11 +291,9 @@ Design quality signals that indicate the skill chain is working. These are proce
 
 **Feature design path:** The lowest point is Stage 1 (Discover) when the journey map has no peak moments — the designer knows there are problems but doesn't know which one to solve. The second lowest point is Stage 5 (Validate) when review findings have no criteria to anchor them to.
 
-**With RFC-0066:** All genres now have dedicated Direct skills. The remaining friction for the first-time user is Stage 3 (Direct) cognitive load — six new genre-specific skills mean more choices, more reading. The tradeoff is deliberate: depth over simplicity.
+All genres now have dedicated Direct skills. The remaining friction for the first-time user is Stage 3 (Direct) cognitive load — six genre-specific skills mean more choices, more reading. The tradeoff is deliberate: depth over simplicity.
 
-**Peak moment (to-be):** Stage 2 (Define) — the first time a designer derives design principles and runs the arbitration test ("given two wireframes, which does this principle prefer?"), the value of the Define phase becomes immediate. Designers who have run it once do not skip it.
-
-**Highest-opportunity pain (current):** "Every design review turns into a debate about what we're optimising for. We all agree the design has problems but we can't agree on which direction to go. We had the conversation at the start of the project and then never wrote it down."
+**Peak moment:** Stage 2 (Define) — the first time a designer derives design principles and runs the arbitration test ("given two wireframes, which does this principle prefer?"), the value of the Define phase becomes immediate. Designers who have run it once do not skip it.
 
 **Primary design response:** `design-principles` closes this pain directly. One session of principle derivation replaces repeated direction debates.
 
@@ -332,8 +313,6 @@ All original open design questions are resolved in RFC-0066. No open design ques
 
 ## Handoff notes
 
-**For RFC-0066 implementation PR:** All open questions are resolved in the RFC — no decisions remain for the implementation PR. The implementation PR implements exactly what the RFC specifies: 7 new skills, 7 extensions across 6 existing skills, D1 genre-specific notes template, D5(e/f/g) design-review + creative-direction extensions, D7 rename sweep (including content-design cross-refs at step 9), D8 0.5.0 → 0.6.0 bump.
+**For marketing site update:** The skill list in `web/` names skills by their slugs. Verify the 9 renames from 0.5.0 → 0.6.0 are reflected in the marketing site copy.
 
-**For marketing site update (post RFC-0066 implementation):** The skill list in `web/` names skills by their current slugs. After the 9 renames land, the marketing site must be updated — old skill names in the site copy will mismatch the installed pack. See RFC-0066 follow-on artifacts.
-
-**For docs site update (post RFC-0066 implementation):** `docs/guides/experience/` (4 files) contains user-facing guides that name skills by old slugs. These are explicitly in-scope for the D7 rename sweep but must also be verified as user-readable after the rename. New skills (`design-principles`, `conversion-design`, `documentation-design`, `analytical-design`, `marketplace-design`, `informational-design`, `workspace-design`) need guide stubs — these can ride with the implementation PR or follow as a separate PR.
+**For docs site update:** `docs/guides/experience/` (4 files) should be verified against the post-rename skill slugs. New skills (`design-principles`, `conversion-design`, `documentation-design`, `analytical-design`, `marketplace-design`, `informational-design`, `workspace-design`) may need guide stubs.

--- a/docs/product/journeys/engineer-adopts-coordination.md
+++ b/docs/product/journeys/engineer-adopts-coordination.md
@@ -10,7 +10,7 @@ initiative_links:
     name: Platform Core
     milestones: M1–M6
     role: primary
-updated: 2026-07-18
+updated: 2026-07-19
 ---
 
 # Journey: Engineer adopts AI-native coordination
@@ -42,37 +42,6 @@ updated: 2026-07-18
 ---
 
 ## Interaction model
-
-### Current state — before INI-002 M1
-
-```mermaid
-sequenceDiagram
-    participant H as Engineer
-    participant A as Agent
-    participant F as Repo files
-
-    Note over H,F: Session start (today)
-    H->>A: Continue working on the platform
-    A->>F: Read RFC, roadmap.md, briefs/, AGENTS.md
-    F-->>A: Context assembled from 4+ files
-    A-->>H: Best guess at current state
-
-    Note over H,F: Brief intake (today)
-    H->>A: [pastes email or Linear description]
-    A-->>H: Which template fields are needed?
-    H->>A: [manually reformats content field by field]
-    A->>F: Write docs/product/briefs/slug.md
-    A-->>H: Brief created — run receive-brief?
-
-    Note over H,F: Execute and ship (today)
-    H->>A: Work on spec X
-    A->>F: Read brief, infer spec list
-    Note over A: plan → build → verify → review
-    A-->>H: Spec done — what is next?
-    H->>F: Manually update brief coverage + roadmap.md
-```
-
-### To-be state — INI-002 M1 shipped
 
 ```mermaid
 sequenceDiagram
@@ -106,16 +75,11 @@ sequenceDiagram
 
 ## Stage 1: Install & Orient
 
-### Now
-
 | Row | Content |
 |-----|---------|
-| **Actions** | Discovers the platform. Installs agentbundle. Reads AGENTS.md. Tries to run something and asks "where do I start?" |
-| **Emotions** | Curious then disoriented (neutral → negative). Many skills, no obvious first action. |
-| **Pains** | "I installed the pack but nothing changed." "I don't understand the vocabulary — Brief vs Spec vs Project." "Skills are documented individually; I can't see how they connect." |
-| **Opportunities** | A session-start path that makes the first action obvious. A vocabulary page that maps to the tracker terms the team already uses. |
-
-> **With M1.5** — `check-workspace` ships: first action becomes `check-workspace`; it orients from `workspace.toml` and surfaces the next item without reading any other file.
+| **Actions** | Discovers the platform. Installs agentbundle. Reads AGENTS.md. Runs `check-workspace` — orients from `workspace.toml` and surfaces the next item without reading any other file. |
+| **Emotions** | Curious then oriented (neutral → positive). First action is clear. |
+| **Remaining pains** | "I don't understand the vocabulary — Brief vs Spec vs Project." The vocabulary page (M6) is not yet available; the glossary in `docs/CONVENTIONS.md` is the current reference. |
 
 ---
 
@@ -136,46 +100,31 @@ sequenceDiagram
 
 ## Stage 3: Brief & Queue
 
-### Now
-
 | Row | Content |
 |-----|---------|
-| **Actions** | Receives a brief externally (email, Linear Issue, verbal). Manually reformats it into the brief template. Runs `receive-brief` to decompose into specs. Tracks which spec is next in their head. |
-| **Emotions** | Frustrated (negative). Conversion is manual. DoR criteria are not signposted. Post-decomposition specs are not in any queue. |
-| **Pains** | "I have a brief in my inbox but have to manually reformat it." "I don't know which DoR fields are mandatory for Ready." "After decomposition my specs exist but aren't in any queue." "If someone else picks this up in a new session, they won't know where I left off." |
-| **Opportunities** | `author-brief` elicits DoR fields interactively and queues the brief. `receive-brief` writes specs into `[work].queue`. Visible DoR checklist on the brief template. |
-
-> **With M1** — `author-brief` + `receive-brief` extension ship: external input → DoR elicitation → brief file → `[brief_queue].draft` in one skill invocation; `receive-brief` moves brief to ready and writes specs into `[work].queue`.
+| **Actions** | Receives a brief externally (email, Linear Issue, verbal). Runs `author-brief` — elicits DoR fields interactively, creates brief file, writes to `[brief_queue].draft`. Runs `receive-brief` — moves brief to ready and writes specs into `[work].queue`. |
+| **Emotions** | Efficient (positive). External input → queued specs in one flow; no manual reformatting. |
+| **Remaining pains** | "Linear issues still need the `author-brief` step — there is no automatic intake from the tracker until M5." |
 
 ---
 
 ## Stage 4: Execute & Ship
 
-### Now
-
 | Row | Content |
 |-----|---------|
-| **Actions** | Picks up a spec (from memory or re-reading the brief). Runs `work-loop`. Completes the spec. Submits PR. Asks "what is next?" by re-reading. |
-| **Emotions** | Satisfied then adrift (positive → neutral). Spec shipped cleanly but post-ship orientation is manual. |
-| **Pains** | "After the spec ships I don't know what's next without re-reading the brief." "Brief coverage doesn't update when I ship." "`roadmap.md` needs updating but nothing surfaces that." "No explicit DAG — I decide priority on the fly." |
-| **Opportunities** | Post-ship automation: spec marked shipped in `workspace.toml`, next ready item surfaced, `roadmap.md` update prompted. DAG makes priority explicit. |
-
-> **With M1.7** — `work-loop` extension ships: on ship, moves spec `active → shipped` in `workspace.toml`; surfaces next ready item from the DAG; prompts `roadmap.md` update (edit goes through a PR per CONVENTIONS — not auto-written).
+| **Actions** | Picks up a spec from `check-workspace`. Runs `work-loop`. Completes the spec. Submits PR. `work-loop` moves spec `active → shipped` in `workspace.toml`; surfaces next ready item from the DAG; prompts `roadmap.md` update. |
+| **Emotions** | Satisfied and oriented (positive). Spec shipped and the queue reflects it. |
+| **Remaining pains** | "`roadmap.md` update is prompted but still requires a manual PR — it is not auto-written (per CONVENTIONS)." |
 
 ---
 
 ## Stage 5: Session Continuity
 
-### Now
-
 | Row | Content |
 |-----|---------|
-| **Actions** | Session ends. New session — next day, a colleague, or a new agent. Reads RFC, roadmap, briefs directory to re-orient. Resumes. |
-| **Emotions** | Anxious then uncertain (negative). Re-reading four files takes time and still leaves gaps. |
-| **Pains** | "I have to read four files to know where I am — and still feel uncertain." "A blocked item shows up but I don't know which dep is the blocker." "An agent starting fresh has no context about mid-session decisions." |
-| **Opportunities** | `check-workspace` as the single cold-start command. Reads `workspace.toml` from the local working directory — consistent on any branch after M1 Batch 2 (file lives on `main`). Rich blocked-reason explanations. |
-
-> **With M1.5** — `check-workspace` ships: one command surfaces active initiative, queued specs, DAG state, blocked reasons. Reads `workspace.toml` from the local working directory (file lives on `main`; always present after M1 Batch 2).
+| **Actions** | Session ends. New session — next day, a colleague, or a new agent. Runs `check-workspace`. One command surfaces active initiative, queued specs, DAG state, blocked reasons. Reads `workspace.toml` from the local working directory (file lives on `main`; consistent on any branch). |
+| **Emotions** | Confident (positive). Context is committed; orientation is immediate. |
+| **Remaining pains** | "An agent starting fresh still has no context about mid-session decisions that weren't committed." Partial-progress capture feeds INI-005. |
 
 ---
 
@@ -198,11 +147,9 @@ sequenceDiagram
 
 ## Emotional arc
 
-Lowest point: **Stage 3 (Brief & Queue)** — frustrated — because the gap between an external brief and a queued, system-readable work item is entirely manual. Every field requires translation and the result is not connected to anything the system can orient from.
+The M1 flow — Stage 1 through Stage 5 — is now positive end-to-end. The remaining friction lives in Stage 2 (Shape Work) where M2 skills are still pending, and in Stage 3 where tracker intake (M5) is still manual.
 
-Highest-opportunity pain: "I have a brief in my inbox but I have to manually reformat it, decompose it, and track it in my head — the system doesn't hold any of it for me."
-
-Primary design response: `author-brief` (M1) closes the creation gap. `receive-brief` extension (M1.8) closes the queue write-back gap. Together they make brief intake a one-skill operation that ends with the queue updated.
+**Remaining gap:** "My shaping output doesn't survive the session." Committed shaping artifacts (`frame-situation`, `place-bet`, `map-capabilities`) and `[shaping_queue]` write-back are M2 scope.
 
 ---
 

--- a/docs/product/journeys/engineer-provisions-infrastructure.md
+++ b/docs/product/journeys/engineer-provisions-infrastructure.md
@@ -4,12 +4,12 @@ slug: engineer-provisions-infrastructure
 persona: engineer-implementer
 outcome: governed-terraform-shipped-and-drift-managed
 surface: cross-platform
-status: planned
+status: shipped
 rfc_links:
   - id: RFC-0065
     name: iac-terraform pack
     role: primary
-updated: 2026-07-18
+updated: 2026-07-19
 ---
 
 # Journey: Engineer provisions infrastructure with iac-terraform
@@ -45,29 +45,6 @@ updated: 2026-07-18
 ---
 
 ## Interaction model
-
-### Without iac-terraform (now)
-
-```mermaid
-sequenceDiagram
-    participant E as Engineer
-    participant A as Agent
-    participant TF as Terraform toolchain
-
-    Note over E,TF: Before iac-terraform — hand-derived scaffolding
-    E->>A: I need a hardened object store with private ingestion
-    A->>A: Re-derive layered Terraform structure from memory
-    Note over A: No ADR gate, no vocabulary firewall
-    A->>TF: Write HCL (guessed resource args)
-    TF-->>A: validate error — wrong attribute name
-    A->>TF: Fix and retry (multiple rounds)
-    A-->>E: Terraform written — review?
-    Note over E: No policy-as-code pass, no digest pin
-    E-->>E: Manually applies via CI or locally
-    Note over E: No drift audit schedule — drift accumulates undetected
-```
-
-### With iac-terraform (to-be, RFC-0065)
 
 ```mermaid
 sequenceDiagram
@@ -118,16 +95,7 @@ sequenceDiagram
 
 **RFC anchor:** [§2 Hard rules — Stage 0 is mandatory](../../rfc/0065-iac-terraform-pack.md#stage-0-is-mandatory)
 
-### Without iac-terraform (now)
-
-| Row | Content |
-|-----|---------|
-| **Actions** | Engineer invokes the agent and asks for Terraform. Agent proceeds directly to authoring. No ADR check. No governance index. No record of which decisions were made or why. |
-| **Emotions** | Efficient (short-term positive). Unconstrained authoring feels fast. |
-| **Pains** | "The Terraform was written correctly but there was no record of why we chose S3 over GCS, or why we used workspaces instead of separate accounts." "Three months later someone changes the state backend and doesn't know they're reversing a deliberate decision." "Security audit asks for decision records for infra choices; we have none." |
-| **Opportunities** | A mandatory pre-authoring gate that loads the governance index, identifies the bound decision records, and surfaces any uncovered decision domain before a line of Terraform is written. |
-
-> **With iac-terraform** — `generate-iac` makes Stage 0 mandatory and non-bypassable: before any authoring, the governance index is loaded and the intent is mapped to decision records. If a domain is uncovered, the skill stops and surfaces it. First-time use: if no governance-index.toml exists, the skill bootstraps one from existing ADRs and confirms with the human before proceeding.
+`generate-iac` makes Stage 0 mandatory and non-bypassable: before any authoring, the governance index is loaded and the intent is mapped to decision records. If a domain is uncovered, the skill stops and surfaces it. First-time use: if no `governance-index.toml` exists, the skill bootstraps one from existing ADRs and confirms with the human before proceeding.
 
 ---
 
@@ -135,16 +103,7 @@ sequenceDiagram
 
 **RFC anchor:** [§2 Hard rules — Vocabulary firewall at SPECIFY](../../rfc/0065-iac-terraform-pack.md#vocabulary-firewall)
 
-### Without iac-terraform (now)
-
-| Row | Content |
-|-----|---------|
-| **Actions** | Agent writes a spec (or skips it) in cloud-specific terms. "Use S3 for the object store." "Route via an ALB." Cloud service names leak into the spec and lock in the provider before any architecture decision is made. |
-| **Emotions** | Concrete (neutral). Cloud-specific names feel precise. |
-| **Pains** | "The spec says S3 — three months later someone asks why we didn't evaluate GCS and there's no record." "The spec and the implementation are in different services because the scope drifted between spec and plan." |
-| **Opportunities** | A vocabulary firewall that forces generic terms ('managed database', 'object storage') in the spec and reserves cloud-specific names for PLAN and later. Cloud-agnosticism by construction. |
-
-> **With iac-terraform** — `generate-iac` enforces the vocabulary firewall: spec uses generic terms; cloud-specific service names appear only from PLAN onward. The agent also collects the account/tenant isolation model as an input (shared workspaces vs. separate account per environment) and records the decision, since it drives OIDC trust-policy scoping and the state backend key structure.
+`generate-iac` enforces the vocabulary firewall: spec uses generic terms (`managed database`, `object storage`); cloud-specific service names appear only from PLAN onward. The agent also collects the account/tenant isolation model as an input (shared workspaces vs. separate account per environment) and records the decision, since it drives OIDC trust-policy scoping and the state backend key structure.
 
 ---
 
@@ -152,16 +111,7 @@ sequenceDiagram
 
 **RFC anchor:** [§2 — It is a loop, not a straight line](../../rfc/0065-iac-terraform-pack.md#inner-authoring-loop) · [§2 Hard rules — Ground every resource in the live provider schema](../../rfc/0065-iac-terraform-pack.md#ground-every-resource)
 
-### Without iac-terraform (now)
-
-| Row | Content |
-|-----|---------|
-| **Actions** | Agent writes Terraform from training data. Resource types and argument names are guessed. `terraform validate` errors surface multiple rounds of schema hallucination fixes. State backend, provider pin, and `.terraform.lock.hcl` discipline are inconsistently applied. |
-| **Emotions** | Intermittently frustrated (neutral-to-negative). The validate → fix cycle is tedious and unpredictable. |
-| **Pains** | "The agent guessed the wrong attribute name for the S3 server-side encryption block. Fixed it in round 3." "The provider was unpinned — `init` pulled a minor version with a breaking argument change." "The state backend was configured without a lock — concurrent applies clobber each other." |
-| **Opportunities** | Schema-grounded generation that acquires the live provider schema before emitting any resource block. Tier-ordered task decomposition that prevents dependency-ordering apply failures. Lockfile and provider version pinning by default. |
-
-> **With iac-terraform** — `generate-iac` acquires the live provider schema via `core`'s `contract-acquisition` oracle (`terraform providers schema -json`) before emitting any resource block. No resource type, argument, or attribute is guessed. Tasks are tier-ordered (Foundation → Network → Compute/Data → App → Polish) to prevent apply-time dependency failures. `.terraform.lock.hcl` is committed by default. Parallel tasks are marked `[P]` only where resources have no shared dependency.
+`generate-iac` acquires the live provider schema via `core`'s `contract-acquisition` oracle (`terraform providers schema -json`) before emitting any resource block. No resource type, argument, or attribute is guessed. Tasks are tier-ordered (Foundation → Network → Compute/Data → App → Polish) to prevent apply-time dependency failures. `.terraform.lock.hcl` is committed by default. Parallel tasks are marked `[P]` only where resources have no shared dependency.
 
 ---
 
@@ -169,18 +119,9 @@ sequenceDiagram
 
 **RFC anchor:** [§2 — Loop diagram (step 6, plan CLEAN = G4 hand-off)](../../rfc/0065-iac-terraform-pack.md#loop-diagram) · [§2a — Verification modes](../../rfc/0065-iac-terraform-pack.md#verification-modes) · [§7 — Policy companions](../../rfc/0065-iac-terraform-pack.md#policy-companions)
 
-### Without iac-terraform (now)
+The inner loop runs a full static preflight before G4: OPA/Conftest evaluates the plan JSON (checked resource types, tags, encryption, no hardcoded credentials), `security-reviewer` runs with `security-checklists/config-misconfig` inlined, `adversarial-reviewer` reads the diff cold. Optional: Infracost produces a cost delta. The G4 handoff artifact is explicit: deploy-ready Terraform + pinned plan digest + policy-pass evidence + security review summary + reversibility hints.
 
-| Row | Content |
-|-----|---------|
-| **Actions** | Engineer manually runs `terraform validate` and `plan`. No policy-as-code pass. No security review of the generated configs. PR is opened with an unverified diff. |
-| **Emotions** | Uncertain (neutral). "I think it's correct." No objective signal. |
-| **Pains** | "The plan was clean but the IAM policy was wildcard — no policy gate to catch it." "We didn't scan the generated configs for hardcoded credentials — one made it to prod." "No plan digest: the deploy step applied a newer, unreviewed plan." |
-| **Opportunities** | A pre-G4 static preflight sequence: OPA/Conftest on plan JSON (not HCL), security reviewer with config-misconfig modules, adversarial reviewer cold-read, cost delta (Infracost), then a pinned plan digest as the G4 handoff artifact. |
-
-> **With iac-terraform** — the inner loop runs a full static preflight before G4: OPA/Conftest evaluates the plan JSON (checked resource types, tags, encryption, no hardcoded credentials), `security-reviewer` runs with `security-checklists/config-misconfig` inlined, `adversarial-reviewer` reads the diff cold. Optional: Infracost produces a cost delta. The G4 handoff artifact is explicit: deploy-ready Terraform + pinned plan digest + policy-pass evidence + security review summary + reversibility hints.
->
-> **G4 handoff artifacts (explicit):** deploy-ready Terraform directory · pinned plan file (`terraform plan -out=tfplan` + digest) · OPA/Conftest exit-0 log · Trivy/Checkov exit-0 log · reversibility hints on stateful resources · (optional) Infracost cost delta JSON.
+**G4 handoff artifacts (explicit):** deploy-ready Terraform directory · pinned plan file (`terraform plan -out=tfplan` + digest) · OPA/Conftest exit-0 log · Trivy/Checkov exit-0 log · reversibility hints on stateful resources · (optional) Infracost cost delta JSON.
 
 ---
 
@@ -188,7 +129,7 @@ sequenceDiagram
 
 **RFC anchor:** [§1b — Loop integration (outer deploy loop)](../../rfc/0065-iac-terraform-pack.md#loop-integration) · [§2 — Two operating modes](../../rfc/0065-iac-terraform-pack.md#two-operating-modes)
 
-### Without release-loop (degraded mode — common today)
+### Degraded mode (no release-loop)
 
 | Row | Content |
 |-----|---------|
@@ -197,7 +138,7 @@ sequenceDiagram
 | **Pains** | "IAM propagation took 30 seconds — the pipeline timed out and left a partial state." "The dependency ordering was wrong — the subnet referenced the VPC before it was created." "Each apply failure needed a new PR and a new CI run." |
 | **Opportunities** | A release-loop outer cycle that iterates autonomously on apply-time failures against ephemeral envs, feeds them back to the inner loop, and converges before surfacing for G5. |
 
-### With release-loop (full mode)
+### Full mode (with release-loop)
 
 | Row | Content |
 |-----|---------|
@@ -214,8 +155,6 @@ sequenceDiagram
 
 **RFC anchor:** [§1b — G5 + minimum-regret consent gates](../../rfc/0065-iac-terraform-pack.md#minimum-regret-consent)
 
-### Now (any mode)
-
 | Row | Content |
 |-----|---------|
 | **Actions** | In degraded mode: Engineer reviews the CI apply log and approves the GitHub Environments protection. In full mode: `release-loop` produces the release readiness record; engineer reads it and ratifies. |
@@ -231,18 +170,9 @@ sequenceDiagram
 
 **RFC anchor:** [§2 — Two skills (generate-iac + reconcile-iac)](../../rfc/0065-iac-terraform-pack.md#two-skills) · [§2 Known blind spot: unmanaged resources](../../rfc/0065-iac-terraform-pack.md#unmanaged-resources)
 
-### Without iac-terraform (now)
+`reconcile-iac` runs on three triggers: (1) **before every follow-on change** (mandatory preflight), (2) **weekly minimum** on a scheduled basis, and (3) **immediately after a known out-of-band event** (break-glass, console action, provider-managed service update). Each run produces a drift audit with per-resource disposition proposals and an explicit scope boundary notice (resources with no state entry are outside the audit). The skill never applies autonomously — every disposition requires human approval.
 
-| Row | Content |
-|-----|---------|
-| **Actions** | Drift accumulates undetected. A follow-on change runs `terraform plan` and reveals unexpected diffs. Engineer investigates manually. No structured disposition. |
-| **Emotions** | Reactive and surprised (negative). "Why does this have a diff? I didn't change anything." |
-| **Pains** | "Drift is discovered only when something breaks or when a follow-on PR runs plan." "There's no structured way to record the decision: should we codify this drift back into IaC, or add ignore_changes?" "We can't tell if a ClickOps change was intentional or accidental." |
-| **Opportunities** | A scheduled `reconcile-iac` run that produces a per-resource drift audit with cause class, blast radius, and proposed disposition — and that explicitly surfaces its own scope boundary (unmanaged resources are invisible). |
-
-> **With iac-terraform** — `reconcile-iac` runs on three triggers: (1) **before every follow-on change** (mandatory preflight), (2) **weekly minimum** on a scheduled basis, and (3) **immediately after a known out-of-band event** (break-glass, console action, provider-managed service update). Each run produces a drift audit with per-resource disposition proposals and an explicit scope boundary notice (resources with no state entry are outside the audit). The skill never applies autonomously — every disposition requires human approval.
->
-> **reconcile-iac scope boundary (honesty):** `terraform plan` sees only state-tracked resources. Resources created entirely outside Terraform (ClickOps, console actions, auto-provisioned resources) are invisible. The skill documents this limit explicitly in its output rather than implying full drift coverage.
+**reconcile-iac scope boundary (honesty):** `terraform plan` sees only state-tracked resources. Resources created entirely outside Terraform (ClickOps, console actions, auto-provisioned resources) are invisible. The skill documents this limit explicitly in its output rather than implying full drift coverage.
 
 ---
 
@@ -271,17 +201,17 @@ Primary design response: `reconcile-iac` as a first-class skill on a scheduled +
 
 ---
 
-## How the journey changes with RFC-0065
+## What the iac-terraform pack provides
 
-| Stage | Before RFC-0065 | After RFC-0065 |
-|---|---|---|
-| **0 — Governance** | No gate; authoring starts immediately | Mandatory governance-index load; uncovered domains stop the skill |
-| **1 — Specify** | Cloud-specific names in spec | Vocabulary firewall; cloud names deferred to PLAN |
-| **2 — Generate** | Schema guessed from training data | Live schema acquired before every resource block |
-| **3 — Preflight** | Manual validate/plan only | OPA/Conftest + security reviewer + adversarial reviewer + digest pin |
-| **4 — Deploy** | Manual CI pipeline trigger; engineer debugs apply failures | `release-loop` outer cycle iterates autonomously on ephemeral envs (full mode) |
-| **5 — G5** | GitHub Environments approval of CI apply | Full release readiness record with IaC-specific fields |
-| **6 — Drift** | Drift discovered reactively | `reconcile-iac` on schedule + preflight + event-triggered |
+| Stage | Capability |
+|---|---|
+| **0 — Governance** | Mandatory governance-index load before any authoring; uncovered decision domains stop the skill |
+| **1 — Specify** | Vocabulary firewall; cloud-specific names deferred to PLAN; isolation model recorded |
+| **2 — Generate** | Live provider schema acquired before every resource block; tier-ordered tasks; lockfile committed |
+| **3 — Preflight** | OPA/Conftest + security reviewer + adversarial reviewer + digest pin |
+| **4 — Deploy** | Degraded: generated human-gated pipeline. Full: `release-loop` outer cycle on ephemeral envs |
+| **5 — G5** | IaC-specific release readiness record (plan digest, policy-pass evidence, apply log, cost delta) |
+| **6 — Drift** | `reconcile-iac` on schedule + preflight + event-triggered; per-resource disposition; explicit scope boundary |
 
 ---
 

--- a/docs/product/journeys/engineer-runs-work-loop.md
+++ b/docs/product/journeys/engineer-runs-work-loop.md
@@ -4,13 +4,13 @@ slug: engineer-runs-work-loop
 persona: engineer-implementer
 outcome: spec-executed-and-shipped-with-human-in-the-loop
 surface: cross-platform
-status: planned
+status: shipped
 initiative_links:
   - id: INI-002
     name: Platform Core
-    milestones: M1 (primary — work-loop workspace integration M1.7); M2–M6 (ongoing improvements)
+    milestones: M1 (delivered); M2–M6 (ongoing improvements)
     role: primary
-updated: 2026-07-18
+updated: 2026-07-19
 ---
 
 # Journey: Engineer runs the work-loop
@@ -41,34 +41,20 @@ updated: 2026-07-18
 
 ---
 
-## Interaction model
+## Two approaches
 
-### Current state — before M1.5 / M1.7
+`work-loop` supports two usage patterns that differ in how the engineer orients and what state is updated on ship:
 
-```mermaid
-sequenceDiagram
-    participant E as Engineer
-    participant A as Agent
-    participant WL as work-loop skill
-    participant R as Repo (branch)
+| | Initiative path | Ad-hoc path |
+|---|---|---|
+| **Orient** | `check-workspace` — DAG-resolved queue, parallel candidates, blocked reasons | Memory, ticket, issue, or team message |
+| **Step 0** | `work-loop` reads `workspace.toml` for initiative context, milestone, DAG constraints | `work-loop` reads spec file in isolation |
+| **Ship** | Spec marked `active → shipped` in `workspace.toml`; next item surfaced; `roadmap.md` prompt | PR submitted; no queue state updated |
+| **When to use** | Coordinated initiative work; multiple engineers or agents on same queue | One-off tasks — bug fixes, quick features, housekeeping |
 
-    Note over E,R: Before M1 — work-loop with no initiative context
-    E->>A: I want to work on [spec-slug]
-    A->>WL: work-loop [spec-slug]
-    Note over WL: Reads spec file
-    Note over WL: Writes plan inline
-    E->>A: Review plan (back-and-forth)
-    A->>WL: Execute tasks
-    Note over WL: plan → build → verify → review
-    A->>R: Submit PR
-    E-->>E: PR submitted — now what?
-    E->>A: What should I work on next?
-    A->>R: Read RFC, roadmap, briefs/ (manual re-orient)
-    A-->>E: [best guess at next item]
-    Note over E: No committed queue — next item is inferred
-```
+Both paths share the same plan → build → verify → review loop (Stages 3–4). The paths diverge at Orient, Start, and Ship.
 
-### To-be state — M1.7 shipped (initiative work)
+## Interaction model — initiative path
 
 ```mermaid
 sequenceDiagram
@@ -109,37 +95,44 @@ sequenceDiagram
 
 ## Stage 1: Orient — What Should I Work On?
 
-### Now
+### Initiative path
 
 | Row | Content |
 |-----|---------|
-| **Actions** | Decides what to work on from memory, a Linear ticket, a GitHub issue, or a message from a teammate. May read the RFC or roadmap to orient. Knows roughly what's next but has no structured queue. |
-| **Emotions** | Confident but contextually thin (neutral). The engineer knows what they need to do but their orientation is brittle — it depends on memory of the last session and on no one else having claimed the same spec. |
-| **Pains** | "I have to remember where I left off." "I don't know if someone else has started the spec I want." "The roadmap and RFC aren't structured enough to answer 'what's next in priority order with no dependencies blocked'." "If I've been away for a few days, re-orientation takes 10 minutes of reading." |
-| **Opportunities** | `check-workspace` as a single command that surfaces the active initiative, ready specs in DAG order, blocked reasons, and parallel candidates — and that answers "is this spec already claimed?" |
+| **Actions** | Runs `check-workspace`. DAG-resolved queue surfaces the active initiative, ready specs in priority order, blocked items with reasons, and parallel candidates. Answers "is this spec already claimed?" |
+| **Emotions** | Oriented immediately (positive). One command, committed state. |
+| **Remaining pains** | "I see a parallel candidate but if another engineer also runs check-workspace at the same time, we might both pick it up." Atomic claiming is an INI-003 design concern. |
 
-> **With M1.5** — `check-workspace` ships: orientation in one command; DAG-resolved queue shows ready vs. blocked; parallel candidates visible for swarm dispatch.
+### Ad-hoc path
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Decides what to work on from memory, a Linear ticket, a GitHub issue, or a message from a teammate. |
+| **Emotions** | Comfortable (neutral). For a well-defined one-off task, memory and tickets are sufficient. |
 
 ---
 
 ## Stage 2: Start the Work-Loop
 
-### Now
+### Initiative path
 
 | Row | Content |
 |-----|---------|
-| **Actions** | Runs `work-loop [spec-slug]`. The skill reads the spec file and produces a plan. The engineer is already in the right context — they just typed it. |
-| **Emotions** | Immediately productive (positive). The work-loop is already the right tool. |
-| **Pains** | "work-loop doesn't know which initiative or milestone this spec belongs to." "The plan doesn't include workspace context — it just reads the spec file in isolation." "If the spec has dependencies I don't know about, work-loop doesn't surface them." |
-| **Opportunities** | `work-loop` at step 0 reads `workspace.toml` to load initiative context — the plan is now contextualised against the milestone, other active specs, and DAG constraints. |
+| **Actions** | Runs `work-loop [spec-slug]`. At step 0, `work-loop` reads `workspace.toml` — loads initiative context, milestone, and DAG constraints. Plan is contextualised; dependency violations surfaced before build begins. |
+| **Emotions** | Immediately productive (positive). The plan knows what this spec is part of. |
 
-> **With M1.7** — `work-loop` reads `workspace.toml` at step 0; plan is contextualised against initiative milestone and DAG state; dependency violations surfaced before build begins.
+### Ad-hoc path
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Runs `work-loop [description]` or `work-loop [spec-slug]`. The skill reads the spec file in isolation. No initiative context loaded. |
+| **Emotions** | Immediately productive (positive). For a one-off task, isolation is fine. |
 
 ---
 
 ## Stage 3: Plan Review
 
-### Now (unchanged — work-loop already handles this as a human gate)
+### Both paths (human gate — unchanged)
 
 | Row | Content |
 |-----|---------|
@@ -152,7 +145,7 @@ sequenceDiagram
 
 ## Stage 4: Build and Gate Navigation
 
-### Now (unchanged — work-loop already handles build; human handles gate failures)
+### Both paths (human handles gate failures — unchanged)
 
 | Row | Content |
 |-----|---------|
@@ -165,29 +158,21 @@ sequenceDiagram
 
 ## Stage 5: Ship and Hand Off
 
-### Now
+### Initiative path
 
 | Row | Content |
 |-----|---------|
-| **Actions** | Reviews the final diff before PR submission. Approves PR creation. Realises workspace.toml has not been updated — does it manually, or skips it because it's not yet wired. |
-| **Emotions** | Relieved but incomplete (positive → neutral). The spec is shipped but the queue doesn't reflect it. The engineer has to remember to update things. |
-| **Pains** | "The PR is submitted but nothing tells the next person (or agent) this spec is done." "`workspace.toml` isn't updated — I have to do it manually if I remember." "No prompt to update `roadmap.md` — I always forget, and it drifts." "I don't know what to pick up next without re-reading the RFC." |
-| **Opportunities** | Post-ship automation: work-loop marks spec active → shipped in `workspace.toml`; surfaces next ready item; prompts `roadmap.md` update. The engineer ends the session knowing exactly what comes next. |
+| **Actions** | Reviews the final diff. Approves PR creation. `work-loop` moves spec `active → shipped` in `workspace.toml`; surfaces the next ready item; prompts `roadmap.md` update. |
+| **Emotions** | Complete (positive). The spec is shipped and the queue reflects it. The next person or agent can orient in one `check-workspace` call. |
 
-> **With M1.7** — work-loop moves spec to shipped on PR creation; next ready item surfaced; `roadmap.md` update prompted. Engineer exits with committed state visible to the next person or agent.
+### Ad-hoc path
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Reviews the final diff. Approves PR creation. No queue state is updated. |
+| **Emotions** | Relieved (positive). The task is done; there is no queue to update. |
 
 ---
-
-## Stage 6: Non-Initiative Work (no workspace.toml)
-
-### Now and to-be (this path unchanged)
-
-| Row | Content |
-|-----|---------|
-| **Actions** | Engineer has a task that's not part of an initiative — a one-off bug fix, a quick feature, a housekeeping task. Runs `work-loop [description]` directly. No `workspace.toml` involved. |
-| **Emotions** | Comfortable (positive). This path is already clean — work-loop is designed to handle it. |
-| **Pains** | "Nothing changes here. work-loop works fine for non-initiative work. The only missing piece is knowing whether a task should be in the queue versus an ad-hoc invocation — and check-workspace can help surface that distinction." |
-| **Opportunities** | `check-workspace` surfacing whether the task overlaps with a queued spec (preventing duplicate work); non-initiative tasks as a first-class concept (ad-hoc vs. queued). Post-M1 design question. |
 
 ---
 
@@ -206,28 +191,19 @@ sequenceDiagram
 
 ## Emotional arc
 
-Highest point: **Stage 3 (Plan Review)** — engaged — the engineer is visibly in control and the agent is doing the structured work under their direction. This gate is already working well.
+Highest point: **Stage 3 (Plan Review)** — engaged — the engineer is visibly in control and the agent is doing the structured work under their direction.
 
-Lowest point: **Stage 5 (Ship and Hand Off)** — incomplete — the spec is done but the system doesn't reflect it. The engineer has to manually update state, and they often don't. This is the friction that breaks coordination across sessions and across engineers.
+**Initiative path:** Stage 5 (Ship and Hand Off) is now complete — spec ships, queue updates, next item surfaces. The engineer ends the session with committed state visible to whoever comes next.
 
-Highest-opportunity pain: "I shipped the spec. But the next person who opens the repo doesn't know that. The roadmap doesn't know. The queue doesn't know. I have to remember to tell everything, and I usually don't."
-
-Primary design response: M1.7 post-ship automation — work-loop marks shipped, surfaces next, prompts roadmap update. The engineer's last action becomes the system's source of truth automatically.
+**Ad-hoc path:** Stage 5 is lighter — PR submitted, done. No queue to update. The tradeoff is that the next session has no committed record of what shipped.
 
 ---
 
-## How this journey changes with M1
+## Choosing between paths
 
-The core `work-loop` experience — plan gate, build, gate navigation, PR — is **unchanged**. M1 adds two integration points that change the start and end of the session:
+Use the initiative path any time a spec lives in `[work].queue` — the coordination overhead is near-zero and the post-ship write-back makes the next session (by you, a colleague, or an agent) free. Use the ad-hoc path for tasks that are genuinely standalone — one-off fixes, experiments, housekeeping that would never appear in a brief.
 
-| Session point | Before M1 | After M1.7 |
-|---|---|---|
-| **Start — orient** | Read RFC, roadmap, briefs manually (10+ min) | `check-workspace` → oriented in one command |
-| **Start — work-loop step 0** | Reads spec file in isolation | Reads spec file + workspace.toml initiative context |
-| **End — mark shipped** | Manual (often skipped) | Automatic on PR creation |
-| **End — what's next** | Inferred from memory or re-reading | Surfaced by work-loop post-ship |
-
-Everything in between (Stage 3 plan review, Stage 4 build and gate navigation) is unaffected.
+If you're unsure, run `check-workspace` first. If the task overlaps a queued spec, use the initiative path. If it's not in the queue and wouldn't belong there, go ad-hoc.
 
 ---
 

--- a/docs/product/journeys/team-evaluates-and-adopts.md
+++ b/docs/product/journeys/team-evaluates-and-adopts.md
@@ -10,7 +10,7 @@ initiative_links:
     name: Platform Core
     milestones: M1 (what the team is adopting), M6 (onboarding guides — tutorial, rollout playbook, live-demo guide)
     role: primary
-updated: 2026-07-18
+updated: 2026-07-19
 ---
 
 # Journey: Engineering team evaluates and adopts
@@ -58,33 +58,31 @@ Two distinct paths share this journey:
 
 ## Interaction model
 
-### Current state — before M1 / M6
+### Current state — M1 shipped, M6 pending
 
 ```mermaid
 sequenceDiagram
     participant ENG as Engineer (self-serve)
     participant CH as Champion (enterprise)
     participant DM as Decision Maker
-    participant DOCS as README / docs
     participant CLI as Terminal
 
-    Note over ENG,CLI: Self-serve today — config friction
-    ENG->>DOCS: Reads README
-    Note over DOCS: Harness-specific setup unclear
-    ENG->>CLI: Installs (trial and error)
-    ENG->>CLI: Runs work-loop (uncertain outcome)
-    Note over ENG: Value unclear without guided first-use path
+    Note over ENG,CLI: Self-serve today — platform works, no guided path
+    ENG->>CLI: Installs agentbundle
+    ENG->>CLI: work-loop [spec] → ships successfully
+    ENG->>CLI: check-workspace → oriented
+    Note over ENG: Value is real but first-use path is self-discovered
 
-    Note over CH,DM: Enterprise today — live-demo gap
+    Note over CH,DM: Enterprise today — live-demo gap persists
     CH->>DM: "We should use this platform"
     DM-->>CH: Show me
-    Note over CH: No demo script · improvises 90+ min session
+    Note over CH: No demo script · improvises 60+ min session
     DM-->>CH: Maybe · check with the platform team
     Note over DM: Platform team has no rollout playbook
     Note over DM: Engineers onboarded ad-hoc · revert within weeks
 ```
 
-### To-be state — M1 + M6 shipped
+### To-be state — M6 shipped
 
 ```mermaid
 sequenceDiagram
@@ -126,9 +124,8 @@ sequenceDiagram
 | Row | Content |
 |-----|---------|
 | **Actions** | Engineer discovers via peer recommendation, blog, or GitHub. Champion is assigned by an AI adoption lead. Both read README and documentation. |
-| **Emotions** | Curious but cautious (neutral). The proposition (structured AI-native workflow) is compelling but abstract without a concrete entry point. |
-| **Pains** | "The README explains what it does but not how to get started on a real project." "I can't tell from the docs whether this fits our workflow or replaces it." "Every team member will ask me what this is before they try it — I need a one-sentence answer and a demo." |
-| **Opportunities** | A clear one-sentence positioning statement at the top of the README: what it is, who it's for, what problem it solves, and what the first step is. A `your-first-workspace` tutorial that gets a real spec shipped in under an hour. |
+| **Emotions** | Curious but cautious (neutral). The platform exists and works — but the entry point is not obvious from the README. |
+| **Pains** | "The README explains what it does but not how to get started on a real project." "Every team member will ask me what this is before they try it — I need a one-sentence answer." |
 
 > **With M6** — `your-first-workspace` tutorial ships: guided path from install to first shipped spec; one-sentence positioning in README; clear separation of "try it yourself" (self-serve) from "roll it out to your team" (rollout playbook).
 
@@ -140,12 +137,11 @@ sequenceDiagram
 
 | Row | Content |
 |-----|---------|
-| **Actions** | Engineer installs manually, following README. Hits config friction (harness-specific setup, skill discovery path varies). Tries `work-loop` on a spec — outcome depends on prior context knowledge. |
-| **Emotions** | Determined but frustrated (neutral → negative). The tool is clearly capable once running but the path to "first success" is poorly marked. |
-| **Pains** | "I installed it but I'm not sure if skills are loading correctly." "I don't know if I should use an existing spec or create a new one." "I got through one spec but I'm not sure if I did it right — there was no confirmation." "The value was visible but I can't reproduce it reliably yet." |
-| **Opportunities** | `your-first-workspace` tutorial with a concrete task: seed `workspace.toml`, pick a real pending spec, run `work-loop`, see it ship. No toy examples — real work from the first minute. |
+| **Actions** | Engineer installs manually, following README. Seeds `workspace.toml` (or uses the existing one if the repo already has it). Runs `work-loop` on a real spec. Runs `check-workspace` to confirm state. |
+| **Emotions** | Determined (neutral → positive once the spec ships). The tool works and the confirmation is concrete — `check-workspace` shows "shipped" and what's next. |
+| **Pains** | "I installed it but I'm not sure if skills are loading correctly." "I don't know if I should use an existing spec or create a new one — there's no tutorial to guide me." "The value was visible but I can't reproduce it reliably yet because I'm self-discovering the path." |
 
-> **With M6** — Tutorial uses a real spec, not a toy. First session ends with a shipped spec and a `workspace.toml` that reflects it. Confirmation is explicit: `check-workspace` shows "shipped" and what's next.
+> **With M6** — `your-first-workspace` tutorial ships: guided path from install to first shipped spec; no self-discovery needed; first session is explicitly confirmed via `check-workspace`.
 
 ---
 
@@ -181,16 +177,15 @@ sequenceDiagram
 
 ## Stage 5: Embedding
 
-### Now (and to-be — human behaviour, not skill-scope)
+### Now
 
 | Row | Content |
 |-----|---------|
-| **Actions** | After initial success, engineers continue using `work-loop` — or revert to old workflow when they hit friction on a non-standard case. |
-| **Emotions** | Habitual (neutral). The platform works for the cases it was tried on. Reversion happens when a new case (no spec, ambiguous brief, unfamiliar harness) is encountered and there is no guidance. |
-| **Pains** | "It works well when I know what spec to run. When I don't, I go back to winging it." "I use `work-loop` for implementation but still manage briefs in Notion because I don't trust the queue yet." "New engineers joining the team don't know about `check-workspace` — they discover it weeks in." |
-| **Opportunities** | `check-workspace` as the session-start habit replaces "open Notion, check Slack, figure out what to work on." New-engineer onboarding includes a `your-first-workspace` session on their first day. The platform is embedded, not bolted on. |
+| **Actions** | After initial success, engineers continue using `work-loop` and `check-workspace` — or revert to old workflow when they hit friction on a non-standard case. |
+| **Emotions** | Building toward habitual (neutral). `check-workspace` is a real tool they can form a habit around. Reversion happens when a new case (no spec, ambiguous brief, unfamiliar harness) is encountered and there is no guidance. |
+| **Pains** | "It works well when I know what spec to run. When I don't, I go back to winging it." "New engineers joining the team don't know about `check-workspace` — they discover it weeks in." |
 
-> **Embedded state** — `check-workspace` is the first command every engineer runs. `workspace.toml` is the team's source of truth for what's in flight. New engineers are onboarded to it on day one. Reversion stops because the habit is established before friction arises.
+> **Embedded state (M6)** — `check-workspace` is the first command every engineer runs. `workspace.toml` is the team's source of truth for what's in flight. New engineers are onboarded to it on day one via the `your-first-workspace` tutorial. Reversion stops because the habit is established before friction arises.
 
 ---
 


### PR DESCRIPTION
## Summary

- **engineer-runs-work-loop** → `shipped`; restructured to show initiative path (workspace.toml-driven: check-workspace → work-loop with context, post-ship write-back) and ad-hoc path side-by-side at Orient, Start, and Ship stages; removed legacy Stage 6 one-off section
- **agent-executes-spec** → `shipped`; M1 (check-workspace M1.5 + work-loop workspace integration M1.7) promoted to current state
- **engineer-provisions-infrastructure** → `shipped`; before/after framing removed now that iac-terraform is the only path; capabilities table replaces change narrative
- **engineer-adopts-coordination** → kept `planned`; M1 current state promoted throughout; M2/M5 future-state callouts retained
- **team-evaluates-and-adopts** → kept `planned`; M1 delivered note added; M6 future-state callouts retained
- **designer-designs-surface** → corrected back to `planned` (was prematurely set to `shipped` — RFC-0066 RFC doc is merged but implementation has not landed; `packs/experience/.apm/skills/` still on 0.5.0 names); current-state 0.5.0 interaction model and `### Now` sections restored for all 6 stages
- **README**: status column and descriptions updated to match

## Test plan

- [ ] All 7 journey files open without broken Mermaid syntax
- [ ] README status column matches each journey's frontmatter `status` field
- [ ] designer-designs-surface.md shows both current-state (0.5.0) and to-be (0.6.0) diagrams
- [ ] engineer-runs-work-loop.md shows initiative vs ad-hoc paths at Stages 1, 2, and 5