### PR TITLE
fix(web,docs): resolve three P0 mobile/config bugs

### DIFF
--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: agent-ready-repo
 site_description: The complete AI operating model for software teams — from first idea to production.
-site_url: https://eugenelim.github.io/agent-ready-repo/
+site_url: https://eugenelim.github.io/agent-ready-repo/docs/
 repo_url: https://github.com/eugenelim/agent-ready-repo
 repo_name: eugenelim/agent-ready-repo
 edit_uri: ""

--- a/web/src/components/marketing/InstallTerminal.astro
+++ b/web/src/components/marketing/InstallTerminal.astro
@@ -172,6 +172,13 @@ const tabs = [
   .tabs {
     display: flex;
     flex-wrap: wrap;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+  }
+
+  .tabs::-webkit-scrollbar {
+    display: none;
   }
 
   /* Radios stay in the tab order for keyboard use, but are visually hidden. */

--- a/web/src/pages/catalogue/index.astro
+++ b/web/src/pages/catalogue/index.astro
@@ -209,7 +209,7 @@ const packs = allPacks
   /* ── Grid ──────────────────────────────────────────────────────────── */
   .cat-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
     gap: var(--ds-space-5);
     margin-bottom: var(--ds-space-9);
   }


### PR DESCRIPTION
Fixes three P0 bugs — two mobile-viewport CSS overflows and one MkDocs config error.

## Changes

**1. Catalogue grid overflow on narrow mobile** — `web/src/pages/catalogue/index.astro`
`.cat-grid` `minmax(340px, 1fr)` → `minmax(280px, 1fr)`. The 340px minimum exceeded the ~335px usable width on a 375px viewport, causing horizontal overflow on every card row.

**2. Install terminal tab bar overflow on mobile** — `web/src/components/marketing/InstallTerminal.astro`
Added `overflow-x: auto; -webkit-overflow-scrolling: touch;` to `.tabs`, plus `scrollbar-width: none;` and a `::-webkit-scrollbar { display: none }` rule to hide the scrollbar while keeping the scroll affordance. Four tab labels at 24px side padding require ~360px — overflow at 375px with no scroll affordance previously.

**3. MkDocs site_url wrong path** — `site/mkdocs.yml`
`site_url` → `.../agent-ready-repo/docs/`. Docs deploy to the `/docs/` subdirectory; the wrong `site_url` corrupted canonical URLs in the sitemap, og:url metadata, and Material navigation footer links on every doc page.

## Verification

Literal one-line / single-rule changes matching surrounding style; no other code touched.