### PR TITLE
fix(docs): MkDocs design-token corrections and palette custom migration

### DIFF
--- a/site/docs/stylesheets/extra.css
+++ b/site/docs/stylesheets/extra.css
@@ -34,10 +34,11 @@
 
 /* ── Accent token — single source of truth ──────────────────────────────── */
 /*
- * MkDocs Material resolves links and focus rings through --md-accent-fg-color
- * and --md-typeset-a-color. Without these overrides, Material's default
- * indigo/cyan (from mkdocs.yml palette) would leak into body links, focus
- * rings, and the active-nav marker — violating Rubric 4.
+ * mkdocs.yml uses palette.primary/accent: custom, so Material emits no default
+ * color tokens. All token values are defined explicitly here; nothing leaks from
+ * a named palette. --md-accent-fg-color drives links, focus rings, and the
+ * active-nav marker (Rubric 4). --md-primary-fg-color drives the mobile nav
+ * drawer header and other primary-keyed components.
  */
 
 :root,
@@ -45,6 +46,16 @@
   --md-accent-fg-color:              #e8952b;
   --md-accent-fg-color--transparent: rgba(232, 149, 43, 0.10);
   --md-typeset-a-color:              #8b5e0a;  /* text-safe amber on light — 6:1 contrast */
+  --md-default-bg-color:             #fafaf9;  /* warm near-white surface (--prim-neutral-50) */
+  --md-default-bg-color--light:      #fafaf9;
+  /* Required when mkdocs.yml uses palette.primary: custom — Material emits no
+   * primary tokens for custom; these prevent mobile nav drawer / active-nav
+   * from rendering with transparent/invalid values. */
+  --md-primary-fg-color:             #0b0e12;  /* dark zone — brand primary */
+  --md-primary-fg-color--light:      rgba(11, 14, 18, 0.54);
+  --md-primary-fg-color--dark:       rgba(11, 14, 18, 0.87);
+  --md-primary-bg-color:             #f8fafc;  /* text on dark primary */
+  --md-primary-bg-color--light:      rgba(248, 250, 252, 0.70);
 }
 
 /* ── Dark mode surface ladder ───────────────────────────────────────────── */
@@ -57,6 +68,12 @@
   --md-accent-fg-color:              #e8952b;
   --md-accent-fg-color--transparent: rgba(232, 149, 43, 0.12);
   --md-typeset-a-color:              #f5bc6a;  /* amber-300 — readable on dark surface */
+}
+
+/* Prevent 100vw hero from producing a horizontal scrollbar on Windows/Linux
+ * (scrollbar width is included in 100vw, causing body-level overflow). */
+body {
+  overflow-x: hidden;
 }
 
 /* ── Header: dark unified zone matching the hero ────────────────────────── */
@@ -319,6 +336,12 @@ article.md-content__inner:has(> .hero-section) {
 .md-typeset h2 {
   margin-top: 3rem;
   letter-spacing: -0.015em;
+}
+
+/* Scope h2 border-bottom removal to hero pages only — not all content pages.
+ * Fallback class .hero-h2-style for browsers without :has() support. */
+.md-content__inner:has(.hero-section) .md-typeset h2,
+.md-typeset h2.hero-h2-style {
   border-bottom: none;
   padding-bottom: 0;
 }
@@ -326,14 +349,14 @@ article.md-content__inner:has(> .hero-section) {
 /* ── Cards — lifted tint + border reveal on hover ───────────────────────── */
 /*
  * Rubric: cards on pure white have no visual weight (same plane as background).
- * A tinted background (#f8fafc) lifts the card. Border (not shadow) names the
- * card edge precisely. On hover: border brightens to the accent color (#e8952b).
- * Shadow reserved for elevated overlays (modals, dropdowns), never cards.
+ * SURFACE-1 (#f0efed) lifts the card off the page background. Border (not shadow)
+ * names the card edge precisely. On hover: border brightens to the accent color
+ * (#e8952b). Shadow reserved for elevated overlays (modals, dropdowns), never cards.
  */
 
 .grid.cards > ul > li,
 .grid.cards > ol > li {
-  background: #f8fafc;
+  background: #f0efed;
   border-radius: 10px;
   border: 1px solid rgba(0, 0, 0, 0.09);
   box-shadow: none;
@@ -344,7 +367,6 @@ article.md-content__inner:has(> .hero-section) {
 .grid.cards > ol > li:hover {
   border-color: #e8952b;
   transform: translateY(-2px);
-  box-shadow: 0 4px 16px rgba(232, 149, 43, 0.12);
 }
 
 [data-md-color-scheme="slate"] .grid.cards > ul > li,
@@ -357,7 +379,6 @@ article.md-content__inner:has(> .hero-section) {
 [data-md-color-scheme="slate"] .grid.cards > ul > li:hover,
 [data-md-color-scheme="slate"] .grid.cards > ol > li:hover {
   border-color: rgba(232, 149, 43, 0.5);
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.5);
 }
 
 /* ── Code blocks ───────────────────────────────────────────────────────── */
@@ -393,12 +414,11 @@ article.md-content__inner:has(> .hero-section) {
   color: #f5bc6a;  /* amber-300 — readable on dark surface */
 }
 
-/* ── Global primary CTA — amber-gold, overrides Material's palette.primary: indigo ── */
+/* ── Global primary CTA — amber-gold ────────────────────────────────────── */
 /*
- * mkdocs.yml sets palette.primary: indigo, which maps --md-primary-fg-color to
- * indigo (#5e6ad2). Without this rule, .md-button--primary outside .hero-section
- * inherits that indigo default. This global rule sets the correct amber-gold base;
- * the more-specific .hero-section .md-button--primary rule below still takes
+ * mkdocs.yml uses palette.primary: custom so Material does not emit any CTA
+ * color. This rule sets the amber-gold fill for .md-button--primary everywhere;
+ * the more-specific .hero-section .md-button--primary rule still takes
  * precedence inside the hero (higher specificity + !important), so no conflict.
  */
 
@@ -428,8 +448,8 @@ article.md-content__inner:has(> .hero-section) {
 
 /* ── Tables ────────────────────────────────────────────────────────────── */
 /*
- * Table headers use a light neutral tint — the same family as cards (#f8fafc).
- * Dark canvas (#0b0e12) belongs only in the navbar/hero zone, not the content area.
+ * Table headers use a light neutral tint (#f0efed). Dark canvas (#0b0e12)
+ * belongs only in the navbar/hero zone, not the content area.
  */
 
 .md-typeset table:not([class]) {
@@ -437,7 +457,7 @@ article.md-content__inner:has(> .hero-section) {
 }
 
 .md-typeset table:not([class]) th {
-  background-color: #f0f4f8;
+  background-color: #f0efed;
   color: #1a202c;
   font-weight: 600;
   border-bottom: 2px solid #e2e8f0;

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -16,15 +16,15 @@ theme:
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default
-      primary: indigo
-      accent: cyan
+      primary: custom
+      accent: custom
       toggle:
         icon: material/weather-night
         name: Switch to dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
-      primary: indigo
-      accent: cyan
+      primary: custom
+      accent: custom
       toggle:
         icon: material/weather-sunny
         name: Switch to light mode


### PR DESCRIPTION
## Summary

Applies 8 targeted fixes to `site/` (CSS + YAML) to align the MkDocs `/docs/` site with `docs/specs/platform-site/design-system-foundations.md`. No changes to `web/` or `packs/`.

## Fix-by-fix trace

| # | Priority | Fix | Source |
|---|---|---|---|
| 1 | P0 | **site_url** — already correct (`/docs/`); no change needed | spec §site_url |
| 2 | P1 | **Card background** `#f8fafc` → `#f0efed` (SURFACE-1, warm neutral-100 from design system, not Tailwind slate-50) | design-system-foundations.md §Cards |
| 3 | P1 | **Light mode body surface** — added `--md-default-bg-color: #fafaf9` and `--md-default-bg-color--light: #fafaf9` to `[data-md-color-scheme="default"]` block | design-system-foundations.md §MkDocs alignment note 3 |
| 4 | P1 | **Table header** `#f0f4f8` → `#f0efed` (brings it onto the warm-neutral scale) | design-system-foundations.md §MkDocs alignment notes |
| 5 | P1 | **Card hover shadow removed** (light + dark mode). Design spec: shadow = overlay elevation only (modals/dropdowns); border-color transition and `translateY(-2px)` kept | design-system-foundations.md §Shadow (border-not-shadow philosophy) |
| 6 | P1 | **Palette** `primary: indigo` → `primary: custom`, `accent: cyan` → `accent: custom` (both light and dark scheme entries). Added required `--md-primary-fg-color` family to CSS so Material's mobile nav drawer and other primary-keyed components don't collapse to transparent. | design-system-foundations.md §MkDocs alignment note 1 |
| 7 | P2 | **h2 border-bottom** scoped to `:has(.hero-section)` pages only (was applied globally). Fallback class `.hero-h2-style` added for the rare browser without `:has()`. `margin-top`/`letter-spacing` preserved on all h2s. | audit finding / info-arch spec |
| 8 | P2 | **100vw hero scrollbar** — `overflow-x: hidden` on `body` (the ancestor that bounds the scroll container). The hero's `100vw` overflows the body by the scrollbar gutter width on Windows/Linux; `overflow: hidden` on the element itself would clip children, not stop the element from overflowing its parent. | audit finding |

## Design note — Fix #4 vs. token ladder

The task spec targets `#f0efed` for the table header. The design-system token map (`extra.css` header comment) lists table headers under SURFACE-2 (`#e0ddd9`) and cards under SURFACE-1 (`#f0efed`), which at face value would make them the same after this fix. The spec instruction is followed as written; if SURFACE-2 (`#e0ddd9`) was intended for table headers, a follow-up PR can correct it.

## Test plan

- [x] `make site-build --strict` passes with no new warnings (only pre-existing INFO-level nav/anchor notices)
- [x] All 7 changed properties verified in final file state before commit
- [ ] Visual QA: card hover amber border without shadow (both light and dark mode)
- [ ] Visual QA: mobile nav drawer title band dark with light text (no transparent collapse)
- [ ] Visual QA: h2 border-bottom visible on non-hero content pages, absent on hero page
- [ ] Visual QA: no horizontal scrollbar on Windows/Linux (persistent scrollbar browser)

## Bundled fixes

- Updated 5 stale comments that referenced `indigo`, `#f8fafc` card color, or the old palette rationale — all in `extra.css`, same area, same concern.