### PR TITLE
fix(web): 10 mobile/polish fixes for marketing site

### DIFF
--- a/web/src/components/layout/SiteNav.astro
+++ b/web/src/components/layout/SiteNav.astro
@@ -160,6 +160,28 @@ const installHref = withBase('/#install');
     top: 7px;
   }
 
+  /* X state: move icon regardless of motion preference; transition is motion-only. */
+  .nav__mobile[open] .nav__burger {
+    background-color: transparent;
+  }
+
+  .nav__mobile[open] .nav__burger::before {
+    transform: translateY(7px) rotate(45deg);
+  }
+
+  .nav__mobile[open] .nav__burger::after {
+    transform: translateY(-7px) rotate(-45deg);
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .nav__burger,
+    .nav__burger::before,
+    .nav__burger::after {
+      transition: transform var(--ds-dur-quick) var(--ds-ease-std),
+                  background-color var(--ds-dur-quick) var(--ds-ease-std);
+    }
+  }
+
   .nav__drawer {
     display: flex;
     flex-direction: column;
@@ -186,6 +208,12 @@ const installHref = withBase('/#install');
       border-top: 1px solid var(--ds-hero-border);
       padding: var(--ds-space-5) var(--ds-content-pad-x) var(--ds-space-6);
       z-index: var(--ds-z-overlay);
+    }
+
+    .nav__drawer .nav__cta {
+      display: block;
+      text-align: center;
+      margin-top: var(--ds-space-2);
     }
   }
 </style>

--- a/web/src/components/marketing/Hero.astro
+++ b/web/src/components/marketing/Hero.astro
@@ -10,9 +10,9 @@ import { withBase } from '../../lib/paths';
   <div class="hero__inner">
     <h1 class="hero__headline">The supervised AI operating model for software teams.</h1>
     <p class="hero__subhead">
-      Your agent grades its own homework — and ships its own bugs unless the loop
-      stops it. Hard mechanical gates, cold-read specialist reviewers, and human
-      checkpoints at every handoff so nothing self-certifies.
+      Three supervised peer loops across the full SDLC — mechanical gates the agent
+      cannot bypass, cold-read specialist reviewers, and human checkpoints it cannot
+      self-certify past.
     </p>
     <div class="hero__actions">
       <a class="hero__cta hero__cta--primary" href={withBase('/#install')}>
@@ -22,6 +22,7 @@ import { withBase } from '../../lib/paths';
         Browse the catalogue <span aria-hidden="true">→</span>
       </a>
     </div>
+    <p class="hero__friction">Reversible. One command to try, one to remove.</p>
   </div>
 </section>
 
@@ -39,7 +40,7 @@ import { withBase } from '../../lib/paths';
   .hero__inner {
     max-width: var(--ds-content-max);
     margin-inline: auto;
-    padding: var(--ds-space-9) var(--ds-content-pad-x) var(--ds-space-8);
+    padding: clamp(3.5rem, 8vw, 6rem) var(--ds-content-pad-x) var(--ds-space-8);
   }
 
   .hero__headline {
@@ -111,5 +112,12 @@ import { withBase } from '../../lib/paths';
     to {
       opacity: 1;
     }
+  }
+
+  .hero__friction {
+    font-size: var(--ds-type-xs);
+    color: var(--ds-hero-fg-muted);
+    margin-top: var(--ds-space-3);
+    margin-bottom: 0;
   }
 </style>

--- a/web/src/components/marketing/StatStrip.astro
+++ b/web/src/components/marketing/StatStrip.astro
@@ -76,5 +76,10 @@ const stats = [
     .stats__item:nth-child(odd) {
       border-left: 0;
     }
+
+    .stats__item:last-child {
+      flex: 1 1 100%;
+      border-left: 0;
+    }
   }
 </style>

--- a/web/src/components/marketing/TheProblem.astro
+++ b/web/src/components/marketing/TheProblem.astro
@@ -30,6 +30,5 @@ import Section from '../layout/Section.astro';
   .problem__body {
     font-size: var(--ds-type-body-lg);
     color: var(--ds-on-surface-2);
-    max-width: 62ch;
   }
 </style>

--- a/web/src/components/pack/PackHero.astro
+++ b/web/src/components/pack/PackHero.astro
@@ -63,7 +63,7 @@ const { name, scope, tagline, skillCount } = Astro.props;
   .pack-hero__name {
     font-size: var(--ds-type-display);
     font-weight: var(--ds-weight-heavy);
-    color: var(--ds-accent-deep);
+    color: var(--ds-on-surface);
     letter-spacing: var(--ds-track-display);
     line-height: var(--ds-lead-display);
     margin-bottom: var(--ds-space-4);

--- a/web/src/content.config.ts
+++ b/web/src/content.config.ts
@@ -51,6 +51,7 @@ const journeys = defineCollection({
     docsUrl: z.string(),
     packUrl: z.string(),
     relatedJourneys: z.array(z.string()).default([]),
+    goodOutputDescription: z.string().optional(),
   }),
 });
 

--- a/web/src/pages/catalogue/index.astro
+++ b/web/src/pages/catalogue/index.astro
@@ -50,9 +50,6 @@ const packs = allPacks
         the CLI path, or as a Claude plugin for Claude Code and Claude
         Desktop — no extra configuration either way.
       </p>
-      <p class="cat-hero__count">
-        {packs.length} packs available
-      </p>
     </div>
   </section>
 
@@ -197,13 +194,6 @@ const packs = allPacks
     font-size: var(--ds-type-mono-sm);
     color: var(--ds-accent);
     background: none;
-  }
-
-  .cat-hero__count {
-    font-family: var(--ds-font-mono);
-    font-size: var(--ds-type-sm);
-    color: var(--ds-hero-fg-muted);
-    margin: 0;
   }
 
   /* ── Grid ──────────────────────────────────────────────────────────── */

--- a/web/src/pages/journeys/[journey].astro
+++ b/web/src/pages/journeys/[journey].astro
@@ -119,15 +119,15 @@ const installCommand =
     </div>
   </Section>
 
-  <!-- Section 6: What good output looks like -->
-  <Section tone="surface">
-    <div class="content-body">
-      <h2 class="section-h2">What good output looks like</h2>
-      <p class="placeholder-note">
-        <em>Content authored progressively. A well-completed session produces: clean mechanical gates (lint, typecheck, tests), a reviewer report marked <code>Clean — ready to commit.</code>, a PR description that names what changed, what was deferred, and what was found mid-implementation, and a spec that matches the implementation.</em>
-      </p>
-    </div>
-  </Section>
+  <!-- Section 6: What good output looks like (only when data is present) -->
+  {data.goodOutputDescription && (
+    <Section tone="surface">
+      <div class="content-body">
+        <h2 class="section-h2">What good output looks like</h2>
+        <p class="good-output">{data.goodOutputDescription}</p>
+      </div>
+    </Section>
+  )}
 
   <!-- Section 7: Typical session shape -->
   <Section tone="surface-alt">
@@ -322,23 +322,10 @@ const installCommand =
   }
 
   /* Section 6 */
-  .placeholder-note {
-    font-size: var(--ds-type-body);
-    color: var(--ds-on-surface-muted);
+  .good-output {
+    font-size: var(--ds-type-body-lg);
+    color: var(--ds-on-surface-2);
     line-height: var(--ds-lead-body);
-    padding: var(--ds-space-5) var(--ds-space-6);
-    background-color: var(--ds-surface-alt);
-    border-radius: var(--ds-radius-md);
-    border: 1px solid var(--ds-border);
-  }
-
-  .placeholder-note :global(code) {
-    font-family: var(--ds-font-mono);
-    font-size: var(--ds-type-mono-sm);
-    background-color: var(--ds-accent-subtle);
-    color: var(--ds-accent-deep);
-    padding: 0.1rem 0.3rem;
-    border-radius: var(--ds-radius-sm);
   }
 
   /* Section 7 */

--- a/web/src/pages/journeys/index.astro
+++ b/web/src/pages/journeys/index.astro
@@ -37,18 +37,26 @@ const items = displayOrder.map((j) => ({
   title="Journeys — agent-ready-repo"
   description="Staged walkthroughs of what it's like to use each pack — plan approval, execution, review, and merge gates explained."
 >
-  <Section tone="surface" labelledby="journeys-heading">
-    <h1 id="journeys-heading" class="journeys__headline">Journeys.</h1>
-    <p class="journeys__subhead">
-      Each journey is a staged walkthrough of a real usage session — what the agent
-      does, what you do, and what each human gate asks of you.
-    </p>
+  <!-- ── Hero ──────────────────────────────────────────────────────────── -->
+  <section class="journeys-hero" aria-labelledby="journeys-heading">
+    <div class="journeys-hero__inner">
+      <span class="journeys-hero__eyebrow">Journeys</span>
+      <h1 id="journeys-heading" class="journeys-hero__heading">Journeys.</h1>
+      <p class="journeys-hero__body">
+        Each journey is a staged walkthrough of a real usage session — what the agent
+        does, what you do, and what each human gate asks of you.
+      </p>
+    </div>
+  </section>
 
+  <!-- ── Grid ──────────────────────────────────────────────────────────── -->
+  <Section tone="surface" labelledby="journeys-grid-heading">
+    <h2 id="journeys-grid-heading" class="visually-hidden">All journeys</h2>
     <ul class="journeys-grid">
       {items.map((j) => (
         <li class="journey-card">
           <a class="journey-card__link" href={withBase(`/journeys/${j.slug}/`)}>
-            <h2 class="journey-card__name">{j.name}</h2>
+            <h3 class="journey-card__name">{j.name}</h3>
             {j.tagline && (
               <p class="journey-card__tagline">{j.tagline}</p>
             )}
@@ -61,18 +69,58 @@ const items = displayOrder.map((j) => ({
 </SiteLayout>
 
 <style>
-  .journeys__headline {
-    margin-bottom: var(--ds-space-3);
+  /* ── Hero ──────────────────────────────────────────────────────────── */
+  .journeys-hero {
+    background-color: var(--ds-hero-bg);
+    color: var(--ds-hero-fg);
+    padding: clamp(4rem, 10vw, 7rem) var(--ds-content-pad-x) clamp(3rem, 6vw, 5rem);
   }
 
-  .journeys__subhead {
+  .journeys-hero__inner {
+    max-width: var(--ds-content-max);
+    margin-inline: auto;
+  }
+
+  .journeys-hero__eyebrow {
+    display: inline-block;
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--ds-track-label);
+    color: var(--ds-accent);
+    margin-bottom: var(--ds-space-4);
+  }
+
+  .journeys-hero__heading {
+    font-size: var(--ds-type-display);
+    font-weight: var(--ds-weight-heavy);
+    letter-spacing: var(--ds-track-display);
+    line-height: var(--ds-lead-display);
+    margin-bottom: var(--ds-space-5);
+    color: var(--ds-hero-fg);
+  }
+
+  .journeys-hero__body {
     font-size: var(--ds-type-body-lg);
-    color: var(--ds-on-surface-2);
-    max-width: 60ch;
-    margin-bottom: var(--ds-space-8);
+    color: var(--ds-hero-fg-2);
+    max-width: 62ch;
     line-height: var(--ds-lead-body);
   }
 
+  /* ── Accessibility ──────────────────────────────────────────────────── */
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+  }
+
+  /* ── Grid ──────────────────────────────────────────────────────────── */
   .journeys-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));


### PR DESCRIPTION
## Summary

10 targeted CSS/HTML fixes across `web/src/` (P1 + P2 from the audit brief). Three previously-reported P0 items (#548) and the `/packs/` redirect were already shipped.

## Fixes

| # | File | What was wrong | Fix | Traces to |
|---|------|---------------|-----|-----------|
| 3 | `SiteNav.astro` | Mobile nav CTA was an `inline-block` in the drawer — no full-width stretch | Added `.nav__drawer .nav__cta { display: block; text-align: center; margin-top: var(--ds-space-2); }` inside `@media (max-width: 768px)` | audit P1 / `homepage-screen-flow.md` §nav |
| 4 | `journeys/index.astro` | Journeys index opened with a bare `<h1>` in a light `<Section>` — inconsistent with `/catalogue/` which has a proper dark hero band | Added dark hero section matching catalogue's `cat-hero` pattern; split grid into a separate `<Section>`; updated heading hierarchy (h2 visually-hidden, card names h3) | `homepage-screen-flow.md` §hero / `information-architecture.md` §secondary-index |
| 5 | `Hero.astro` | `padding-top: var(--ds-space-9)` (~96 px) consumed too much viewport on mobile | Changed to `clamp(3.5rem, 8vw, 6rem)` | audit P2 / `design-system-foundations.md` §responsive |
| 6 | `SiteNav.astro` | Burger icon stayed three bars while drawer was open — no visual state change | Added `.nav__mobile[open] .nav__burger*` X transform (end-state unconditional); `transition` only inside `@media (prefers-reduced-motion: no-preference)` | audit P2 / `homepage-screen-flow.md` §mobile-nav |
| 7 | `StatStrip.astro` | 3 stats at 45% flex basis wraps to 2+1 on mobile — 3rd item orphans in its own row with a left border | Added `.stats__item:last-child { flex: 1 1 100%; border-left: 0; }` inside `@media (max-width: 640px)` | audit P2 / `design-system-foundations.md` §stat-strip |
| 8 | `PackHero.astro` | Pack display h1 used `var(--ds-accent-deep)` (amber) — aesthetic direction specifies amber only for chips/labels/icons, not display headings | Changed to `var(--ds-on-surface)` | `aesthetic-direction.md` §colour |
| 9 | `[journey].astro` + `content.config.ts` | Section 6 "What good output looks like" always rendered placeholder text | Gated behind `data.goodOutputDescription`; added optional field to Zod schema; replaced `placeholder-note` class with `good-output` (body-prose, not muted callout) | audit P2 / journey content authoring notes |
| 10 | `catalogue/index.astro` | Hero had both body text and a separate `.cat-hero__count` paragraph showing the pack count | Removed `<p class="cat-hero__count">` + its CSS rule (bundled ride-along) | audit P2 / `information-architecture.md` §catalogue-hero |
| 12 | `TheProblem.astro` | `.problem__body` had `max-width: 62ch` — parent `.problem` is `max-width: 42ch`, so the rule was a no-op | Removed the dead declaration | audit P2 / `design-system-foundations.md` §prose |
| 13+14 | `Hero.astro` | (13) No friction microcopy below CTA pair. (14) Subhead was problem-agitation copy; hero slot should be conviction-building | Added `<p class="hero__friction">Reversible. One command to try, one to remove.</p>`; replaced subhead with outcome/capability framing | `homepage-screen-flow.md` §hero-copy / audit findings A + C |

## Already-shipped items (not in this PR)

- Fix 1 (catalogue grid `280px`) — shipped in #548
- Fix 2 (install terminal tab overflow) — shipped in #548
- Fix 11 (`/packs/` redirect page) — already present at `web/src/pages/packs/index.astro`

## Gates

- `npm run build` from `web/` — 35 pages, zero errors ✓
- Adversarial review — one Concern (burger X hidden from reduced-motion users) fixed before commit ✓

## Bundled fixes

- Removed orphaned `.cat-hero__count` CSS rule alongside HTML element removal (same file, same concern)
- Renamed `placeholder-note` → `good-output` in both HTML and CSS (same file, class now misdescribed real content)