### PR TITLE
fix(docs): move overflow-x: hidden to html — fixes mobile viewport stretch

### DIFF
--- a/site/docs/stylesheets/extra.css
+++ b/site/docs/stylesheets/extra.css
@@ -71,8 +71,10 @@
 }
 
 /* Prevent 100vw hero from producing a horizontal scrollbar on Windows/Linux
- * (scrollbar width is included in 100vw, causing body-level overflow). */
-body {
+ * (scrollbar width is included in 100vw, causing body-level overflow).
+ * Must target html, not just body — setting it on body alone makes html the
+ * scroll container, which on iOS allows the page to scroll horizontally. */
+html {
   overflow-x: hidden;
 }
 


### PR DESCRIPTION
## Summary

Regression hotfix for #550.

`body { overflow-x: hidden }` introduced in #550 makes the `<html>` element become the scroll container on iOS/mobile browsers. When `html` has no overflow rule, the page can be scrolled horizontally, making all content appear to stretch beyond the mobile viewport.

Changing the target to `html` clips at the correct level and prevents `html` from becoming a secondary scroll container.

## Fix

```diff
-body {
+html {
   overflow-x: hidden;
 }
```

## Test plan

- [x] `make site-build --strict` passes
- [ ] Visual QA: packs pages (core, etc.) do not stretch horizontally on mobile viewport
- [ ] Visual QA: hero full-bleed still works on desktop (no horizontal scrollbar on Windows/Linux)