### PR TITLE
feat(docs): persistent ← Platform back-link in docs header

### DIFF
--- a/docs/specs/platform-site/spec.md
+++ b/docs/specs/platform-site/spec.md
@@ -176,6 +176,14 @@ This spec uses goal-based checks and visual/manual QA. The Astro marketing site 
 - [x] Every Astro page has a complete `<head>`: `<meta name="description">`, `<meta property="og:title">`, `<meta property="og:description">`, `<meta property="og:image">`; og:image is a static `social.png` in `web/public/`
 - [x] `<link rel="canonical">` on every Astro page resolving to the correct GitHub Pages URL
 
+### Docs ↔ Platform navigation (post-Phase 4 amendment)
+
+- [x] A "← Platform" link is present in the docs header on every MkDocs page, implemented via `site/overrides/main.html` (announce block override)
+- [x] The link targets the marketing site root (`https://eugenelim.github.io/agent-ready-repo/`)
+- [x] The link uses the `.platform-back-link` class styled with JetBrains Mono, `#e8952b` amber, and `#f5bc6a` hover
+- [x] `make site-build` exits 0 with the override in place
+- [x] `build/docs/index.html` contains `class=platform-back-link` (confirmed grep count=1)
+
 ### CI + deploy (Phase 1 prerequisite)
 
 - [x] GitHub Actions workflow: Astro builds first → MkDocs builds second → artifact uploaded from `build/` (verified locally end-to-end: `build/index.html` and `build/docs/index.html` coexist, proving Astro's outDir clean does not wipe MkDocs output)

--- a/site/docs/stylesheets/extra.css
+++ b/site/docs/stylesheets/extra.css
@@ -474,7 +474,30 @@ article.md-content__inner:has(> .hero-section) {
 /* ── Announcement bar ────────────────────────────────────────────────────── */
 
 .md-banner {
+  background-color: #0b0e12;  /* dark zone — cohesion with header (Rubric 1) */
   font-size: 0.875rem;
+}
+
+/* ── Platform back-link — cross-surface nav to marketing site ────────────── */
+
+.platform-back-link {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8125rem;
+  color: #e8952b;
+  text-decoration: none;
+  letter-spacing: 0.08em;
+}
+
+.platform-back-link:hover {
+  color: #f5bc6a;
+  text-decoration: none;
+}
+
+.platform-back-link:focus-visible {
+  color: #f5bc6a;
+  outline: 2px solid rgba(232, 149, 43, 0.7);
+  outline-offset: 3px;
+  border-radius: 2px;
 }
 
 /* ── Reduce-motion: honour system preference ────────────────────────────── */

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -13,6 +13,7 @@ site_dir: ../build/docs
 
 theme:
   name: material
+  custom_dir: overrides
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default

--- a/site/overrides/main.html
+++ b/site/overrides/main.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+
+{% block announce %}
+  <a href="https://eugenelim.github.io/agent-ready-repo/" class="platform-back-link"><span aria-hidden="true">&#8592;</span> Platform</a>
+{% endblock %}


### PR DESCRIPTION
## Summary

- Adds a persistent "← Platform" link on every MkDocs docs page that returns the reader to the marketing site root
- Implements via Material for MkDocs `{% block announce %}` override — zero copying of Material internals; survive version bumps
- Closes the only missing cross-surface navigation path (spec requirement: `docs/specs/platform-site/information-architecture.md:126`)

## Changes

| File | What |
|---|---|
| `site/overrides/main.html` | New — fills announce block with the back-link |
| `site/mkdocs.yml` | `custom_dir: overrides` added under `theme:` |
| `site/docs/stylesheets/extra.css` | `.md-banner` bg `#0b0e12`; `.platform-back-link` + hover + focus-visible styles |
| `docs/specs/platform-site/spec.md` | New AC section (post-Phase 4 amendment); all ACs `[x]` |

## Decision surfaced

The announce bar renders **above** the sticky header — the "← Platform" link is visible at page top and persists across all docs surfaces, but scrolls out of view as the user scrolls down (only the sticky header tab bar remains). Moving the link into the sticky header requires copying `partials/header.html` from Material's internals, which creates a version-coupling risk. Staying with the announce-block override is the safer seam for now.

## Deferred

The marketing site URL (`https://eugenelim.github.io/agent-ready-repo/`) is hardcoded — `mkdocs serve` follows the link to production. A root-relative path would help local preview but doesn't resolve cleanly on GitHub Pages sub-path deployments. Kept as-is per spec AC sanction.

## Test plan

- [x] `make site-build` exits 0 (strict mode)
- [x] `build/docs/index.html` contains `class=platform-back-link` (grep count = 1)
- [x] Same confirmed on `getting-started/index.html` and `guides/core/how-to/bug-fix/index.html`
- [x] Adversarial review: clean after applying accessibility fixes (aria-hidden on arrow glyph, focus-visible ring, banner bg cohesion)