### PR TITLE
fix(web): wrap long claude plugin command on mobile pack and catalogue pages

### DIFF
--- a/web/src/pages/catalogue/index.astro
+++ b/web/src/pages/catalogue/index.astro
@@ -326,9 +326,19 @@ const packs = allPacks
   }
 
   .install-block__cmd--truncate {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+  }
+
+  @media (max-width: 480px) {
+    .install-block__row {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .copy-btn {
+      align-self: flex-start;
+    }
   }
 
   /* ── Copy button ────────────────────────────────────────────────────── */

--- a/web/src/pages/packs/[pack].astro
+++ b/web/src/pages/packs/[pack].astro
@@ -200,9 +200,19 @@ const pluginInstallCmd = `claude plugin install https://github.com/${REPO}/tree/
   .install-block__code--light {
     flex: 1;
     min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+  }
+
+  @media (max-width: 480px) {
+    .install-block__plugin-row {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .install-copy-btn {
+      align-self: flex-start;
+    }
   }
 
   .install-copy-btn {


### PR DESCRIPTION
## Summary

- The `claude plugin install` command (~103 chars for `release-engineering`) was rendered with `white-space: nowrap` + `text-overflow: ellipsis` — on portrait mobile it collapsed to nothing, making the command unreadable and the Copy button useless
- Fixed by replacing the truncation rules with `white-space: pre-wrap; overflow-wrap: anywhere;` to match the agentbundle install block's existing behaviour
- Added a `@media (max-width: 480px)` stacking rule so the pre+button pair goes column on narrow portrait viewports (button stays below the command, not crowding it)

## Affected surfaces

| File | Selector fixed |
|---|---|
| `web/src/pages/packs/[pack].astro` | `.install-block__code--light` |
| `web/src/pages/catalogue/index.astro` | `.install-block__cmd--truncate` |

## Test plan

- [x] `astro build` exits 0 (35 pages)
- [x] Compiled `_astro/_pack_.*.css` contains `white-space:pre-wrap; overflow-wrap:anywhere` — `nowrap` is absent
- [x] Compiled `_astro/index.*.css` (catalogue) has the same; remaining `white-space:nowrap` is `visually-hidden` (accessibility, expected)