### PR TITLE
perf(web): self-host Inter and JetBrains Mono via Fontsource

### DIFF
--- a/docs/specs/platform-site/self-hosted-fonts/spec.md
+++ b/docs/specs/platform-site/self-hosted-fonts/spec.md
@@ -1,0 +1,51 @@
+# Spec: Self-host Inter and JetBrains Mono
+
+Mode: light (user-directed; note — the "new dependency" risk trigger would
+normally route to full mode, but the change is a boring, well-understood
+self-hosting swap and the user explicitly chose light mode)
+
+Status: Shipped
+
+## Objective
+
+Remove the runtime dependency on `fonts.googleapis.com` / `fonts.gstatic.com`
+in the Astro marketing site (`web/`) by self-hosting Inter and JetBrains Mono
+via Fontsource. Every page currently makes an external network call for fonts;
+after this change fonts are bundled into the build and served from the same
+origin.
+
+## Acceptance Criteria
+
+- [x] `@fontsource-variable/inter` and `@fontsource/jetbrains-mono` are added
+      to `web/package.json` dependencies.
+- [x] `web/src/styles/global.css` imports the variable Inter `wght` axis and
+      the 400/500/700 JetBrains Mono weights from Fontsource.
+- [x] The `<link rel="preconnect">` (×2) and the `<link rel="stylesheet">` to
+      Google Fonts are removed from `web/src/components/layout/SiteLayout.astro`.
+- [x] `--ds-font-sans` in `tokens.css` resolves Inter from the local variable
+      family (`'Inter Variable'` — the family name Fontsource registers for the
+      variable package, distinct from the static `'Inter'`); `--ds-font-mono`
+      resolves JetBrains Mono locally. System fallbacks remain as backup.
+- [x] `npm run build` (from `web/`) passes and self-hosted font `.woff2` files
+      appear in the build output.
+- [x] The two new dependencies are recorded in `web/AGENTS.md` per the repo
+      convention (§ "Check before acting").
+
+## Boundaries
+
+- No visual redesign — same two typefaces, same weights the site already used.
+- No CSS framework introduced (platform-site spec Boundaries hold).
+- `web/` only.
+
+## Assumptions declined / temptations
+
+- Tempted to also self-host with `font-display` tuning or subsetting config;
+  declining — Fontsource ships all subsets (latin, latin-ext, cyrillic, greek,
+  vietnamese), each `@font-face` gated by `unicode-range`, so an English visitor
+  still only fetches the latin `.woff2` at runtime — equivalent to the prior
+  Google Fonts `css2` behavior. `font-display: swap` also matches the prior
+  `display=swap`. Boring is correct here. (Trimming the committed subset set is
+  possible via Fontsource subset imports if deployed asset count ever matters,
+  but runtime fetch cost is already minimal.)
+- Tempted to drop the static `'Inter'` from the fallback stack; declining —
+  harmless and cheap insurance if a static Inter is ever present.

--- a/docs/specs/platform-site/self-hosted-fonts/spec.md
+++ b/docs/specs/platform-site/self-hosted-fonts/spec.md
@@ -19,7 +19,8 @@ origin.
 - [x] `@fontsource-variable/inter` and `@fontsource/jetbrains-mono` are added
       to `web/package.json` dependencies.
 - [x] `web/src/styles/global.css` imports the variable Inter `wght` axis and
-      the 400/500/700 JetBrains Mono weights from Fontsource.
+      the JetBrains Mono weights the components actually use (400/500/600/700/800)
+      from Fontsource.
 - [x] The `<link rel="preconnect">` (×2) and the `<link rel="stylesheet">` to
       Google Fonts are removed from `web/src/components/layout/SiteLayout.astro`.
 - [x] `--ds-font-sans` in `tokens.css` resolves Inter from the local variable

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -15,6 +15,8 @@ dependencies are recorded here before they are added.
 | Node.js | `>=24.0.0` (see `package.json` `engines`) | Astro build/runtime toolchain |
 | [`astro`](https://astro.build) | pinned `7.1.0` (exact, not a range) | Static-site generator for the marketing pages; pinned for reproducible CI |
 | [`@astrojs/sitemap`](https://docs.astro.build/en/guides/integrations-guide/sitemap/) | pinned `3.7.3` (exact, not a range) | Generates `sitemap-index.xml` + `sitemap-0.xml` at build time for SEO (Phase 4) |
+| [`@fontsource-variable/inter`](https://fontsource.org/fonts/inter) | pinned `5.3.0` (exact, not a range) | Self-hosts the Inter variable font (wght 100–900), replacing the `fonts.googleapis.com` runtime call. Family registers as `'Inter Variable'` |
+| [`@fontsource/jetbrains-mono`](https://fontsource.org/fonts/jetbrains-mono) | pinned `5.3.0` (exact, not a range) | Self-hosts JetBrains Mono (weights 400/500/700) for code/mono type, replacing the `fonts.googleapis.com` runtime call |
 
 Build-time only. This is our own site infrastructure — not a primitive or
 framework prescribed to adopters (see RFC-0061's charter-neutrality analysis).

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -16,7 +16,7 @@ dependencies are recorded here before they are added.
 | [`astro`](https://astro.build) | pinned `7.1.0` (exact, not a range) | Static-site generator for the marketing pages; pinned for reproducible CI |
 | [`@astrojs/sitemap`](https://docs.astro.build/en/guides/integrations-guide/sitemap/) | pinned `3.7.3` (exact, not a range) | Generates `sitemap-index.xml` + `sitemap-0.xml` at build time for SEO (Phase 4) |
 | [`@fontsource-variable/inter`](https://fontsource.org/fonts/inter) | pinned `5.3.0` (exact, not a range) | Self-hosts the Inter variable font (wght 100–900), replacing the `fonts.googleapis.com` runtime call. Family registers as `'Inter Variable'` |
-| [`@fontsource/jetbrains-mono`](https://fontsource.org/fonts/jetbrains-mono) | pinned `5.3.0` (exact, not a range) | Self-hosts JetBrains Mono (weights 400/500/700) for code/mono type, replacing the `fonts.googleapis.com` runtime call |
+| [`@fontsource/jetbrains-mono`](https://fontsource.org/fonts/jetbrains-mono) | pinned `5.3.0` (exact, not a range) | Self-hosts JetBrains Mono (weights 400/500/600/700/800 — the set the components actually use) for code/mono type, replacing the `fonts.googleapis.com` runtime call |
 
 Build-time only. This is our own site infrastructure — not a primitive or
 framework prescribed to adopters (see RFC-0061's charter-neutrality analysis).

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/sitemap": "3.7.3",
+        "@fontsource-variable/inter": "5.3.0",
+        "@fontsource/jetbrains-mono": "5.3.0",
         "astro": "7.1.0"
       },
       "engines": {
@@ -957,6 +959,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.3.0.tgz",
+      "integrity": "sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.3.0.tgz",
+      "integrity": "sha512-fqDfB5I9f1p1TV486aUgB9t8zP84P0O1FtQR5Ol9vjwPy+S+EIGlVYm1cvj2W5shcZMTg2nZFdVMoH5wFu8a1A==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@img/colour": {

--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,8 @@
   },
   "dependencies": {
     "@astrojs/sitemap": "3.7.3",
+    "@fontsource-variable/inter": "5.3.0",
+    "@fontsource/jetbrains-mono": "5.3.0",
     "astro": "7.1.0"
   },
   "allowScripts": {

--- a/web/src/components/layout/SiteLayout.astro
+++ b/web/src/components/layout/SiteLayout.astro
@@ -45,12 +45,7 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).href;
     <meta property="og:image" content={ogImageUrl} />
     <meta property="og:url" content={canonicalUrl} />
 
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap"
-    />
+    <!-- Fonts are self-hosted via Fontsource — imported in src/styles/global.css. -->
   </head>
   <body>
     <a class="skip-nav" href="#main">Skip to content</a>

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -1,4 +1,13 @@
 /* Global entry point — order matters: tokens define the custom properties that
    base.css consumes. Imported once, from SiteLayout.astro. */
+
+/* Self-hosted fonts (Fontsource) — replaces the former fonts.googleapis.com
+   stylesheet. Variable Inter covers wght 100–900; JetBrains Mono at 400/500/700.
+   The variable Inter family registers as 'Inter Variable' (see tokens.css). */
+@import '@fontsource-variable/inter/wght.css';
+@import '@fontsource/jetbrains-mono/400.css';
+@import '@fontsource/jetbrains-mono/500.css';
+@import '@fontsource/jetbrains-mono/700.css';
+
 @import './tokens.css';
 @import './base.css';

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -2,12 +2,16 @@
    base.css consumes. Imported once, from SiteLayout.astro. */
 
 /* Self-hosted fonts (Fontsource) — replaces the former fonts.googleapis.com
-   stylesheet. Variable Inter covers wght 100–900; JetBrains Mono at 400/500/700.
+   stylesheet. Variable Inter covers wght 100–900; JetBrains Mono at the five
+   weights the components actually use (400/500/600/700/800 — see the
+   --ds-weight-* pairings with --ds-font-mono across src/components).
    The variable Inter family registers as 'Inter Variable' (see tokens.css). */
 @import '@fontsource-variable/inter/wght.css';
 @import '@fontsource/jetbrains-mono/400.css';
 @import '@fontsource/jetbrains-mono/500.css';
+@import '@fontsource/jetbrains-mono/600.css';
 @import '@fontsource/jetbrains-mono/700.css';
+@import '@fontsource/jetbrains-mono/800.css';
 
 @import './tokens.css';
 @import './base.css';

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -91,8 +91,10 @@
   --ds-cta-ghost-light-fg:     var(--prim-amber-700);
 
   /* ── Type family ────────────────────────────────────────────────── */
-  --ds-font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-    Helvetica, Arial, sans-serif;
+  /* 'Inter Variable' is the family name Fontsource registers for the variable
+     package; 'Inter' remains for any static Inter, then system fallbacks. */
+  --ds-font-sans: 'Inter Variable', 'Inter', -apple-system, BlinkMacSystemFont,
+    'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
   --ds-font-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', 'Cascadia Code',
     Menlo, Consolas, monospace;
 


### PR DESCRIPTION
## What

The Astro marketing site (`web/`) loaded both Inter and JetBrains Mono from `fonts.googleapis.com`, adding an external network round-trip on every page. This self-hosts both typefaces via [Fontsource](https://fontsource.org/), so fonts are bundled into the build and served from the same origin.

## Why

External font requests block text rendering behind a third-party DNS lookup + TLS handshake + fetch. Self-hosting removes that dependency and the associated privacy/availability coupling to Google's CDN.

## How

- Add `@fontsource-variable/inter` and `@fontsource/jetbrains-mono` (both `5.3.0`, exact-pinned per `web/AGENTS.md` convention).
- Import the variable Inter `wght` axis (100–900) and JetBrains Mono 400/500/600/700/800 in `src/styles/global.css`; remove the two `preconnect` links and the Google Fonts stylesheet `<link>` from `SiteLayout.astro`.
- Prepend `'Inter Variable'` to `--ds-font-sans` in `tokens.css` — the variable Fontsource package registers under that family name (**not** `'Inter'`); system fallbacks stay as backup. `--ds-font-mono` already matches JetBrains Mono's registered family.
- Record both deps in `web/AGENTS.md`.

## Mono weight coverage

The components pair `--ds-font-mono` with five weights: 400, 500, 600 (AdapterMatrix, journey detail), 700, and 800 (GateDetail, HumanGates, StatStrip, ThreeLoops, 404). All five Fontsource weight files are imported so each renders at its declared weight. (The prior Google Fonts request loaded only 400/500/700, so 600/800 previously snapped to 700 — this change also corrects that latent gap.)

## Verification

- `npm run build` passes; 27 `.woff2` files land in `build/_astro/` (7 Inter variable subsets + 20 JetBrains Mono = 5 weights × 4 subsets).
- Bundled CSS carries `'Inter Variable'` and `'JetBrains Mono'` `@font-face` rules at weights 400/500/600/700/800; **zero** residual `fonts.googleapis.com` / `fonts.gstatic.com` references in built HTML.
- Fontsource's `font-display: swap` matches the prior `display=swap`; all subsets ship but are `unicode-range`-gated, so an English visitor still only fetches the latin `.woff2` at runtime (equivalent to the prior Google Fonts `css2` behavior).

## Work-loop

Light mode (user-directed). The "new dependency" risk trigger would normally route to full mode, but the change is a boring, well-understood self-hosting swap. One bounded `adversarial-reviewer` pass: no Blockers.