### PR TITLE
feat(web): surface all 17 packs with SDLC ordering + scaffold product-strategy guides

### DIFF
--- a/docs/guides/product-strategy/README.md
+++ b/docs/guides/product-strategy/README.md
@@ -1,0 +1,30 @@
+# `product-strategy` — guides
+
+The strategy seat **upstream** of product engineering and experience design:
+turn a market situation into committed artifacts, cascade company objectives
+into the shaping queue, and set the experience and content direction before
+anyone opens a wireframe. Nine skills across three pillars — market and
+competitive, UX strategy, content strategy — each writing to
+`docs/product/shaping/`.
+
+New here? Start with the [tutorial](tutorials/run-your-first-swot.md) — your
+first committed strategy artifact from one skill — then reach for the how-tos as
+the jobs come up.
+
+## Tutorials
+- [Run your first SWOT](tutorials/run-your-first-swot.md) — produce one committed strategy artifact end to end.
+
+## How-to
+- [Run a market and competitive analysis](how-to/run-a-market-and-competitive-analysis.md) — build the market picture with the four Pillar-1 analysis frameworks.
+- [Cascade OKRs into the shaping queue](how-to/cascade-okrs-into-the-shaping-queue.md) — turn company objectives into build-ready shaping-queue work.
+- [Set UX and content strategy](how-to/set-ux-and-content-strategy.md) — fix the experience and content direction before design begins.
+
+## Reference
+- [Frameworks and artifacts](reference/frameworks-and-artifacts.md) — every skill, its framework, and the file it writes.
+
+## Explanation
+- [Why strategy is its own seat](explanation/why-strategy-is-its-own-seat.md) — the three pillars, and why this pack sits upstream of the build packs.
+
+---
+
+Installing and upgrading live in [`../_shared/`](../_shared/).

--- a/docs/guides/product-strategy/explanation/why-strategy-is-its-own-seat.md
+++ b/docs/guides/product-strategy/explanation/why-strategy-is-its-own-seat.md
@@ -1,0 +1,85 @@
+# Why strategy is its own seat
+
+## About the strategy seat
+
+Most catalogue packs answer *how do we build this*. This one answers a question
+that comes before that: *what are we building, against whom, and why now*. It is
+a distinct seat because the work has a distinct shape. A SWOT, a Porter's Five
+Forces read, an OKR cascade — none of these produce code, and none of them are
+downstream of a decision brief. They produce the situation the decision brief
+argues from. Fold that work into the build packs and it quietly stops happening:
+the shaping queue fills with features nobody traced to a market position.
+
+The pack keeps that work visible by giving it its own artifacts, its own output
+directory, and its own place in the pack chain. It installs to user scope so the
+skills travel across every workspace — a strategist rarely lives in one repo.
+
+## Three pillars, one seat
+
+The seat covers three kinds of strategy that are usually done by different people
+and usually done badly when merged.
+
+**Market and competitive strategy** is the largest pillar. It holds the canonical
+analysis frameworks — SWOT, Porter's Five Forces, PESTLE, the BCG matrix — plus
+the forcing functions that turn analysis into commitment: the OKR cascade, the
+PRFAQ, and stakeholder-research synthesis. Each writes a named artifact you can
+point a stakeholder at. The frameworks are deliberately boring and canonical;
+the value is in committing the output, not in inventing a new lens.
+
+**UX strategy** is one skill, and it is not the same thing as design. It sets the
+experience vision, the goals and measures, and the plan — the altitude at which
+you decide *what kind of experience this product is* before anyone decides what a
+screen looks like. It draws on the NN/g three-layer model, Jaime Levy's four
+tenets, and the Gothelf/Seiden habit of linking UX outcomes to OKRs.
+
+**Content strategy** is also one skill, and it lives above per-surface content
+design. It is the organizational and governance layer — Halvorson's quad of
+Purpose, Process, Structure, and Governance — that decides how content gets made,
+kept true, and retired. It does not write the copy for any one surface. That is
+the `content-design` skill in the experience-design pack, and the boundary
+matters: strategy sets the system content lives in, design fills it.
+
+## Why upstream of the build packs
+
+The pack chain runs in one direction.
+
+```
+product-strategy (this pack)
+        ↓                          ↓                      ↓
+product-engineering          experience-design        content-design skill
+(product-vision intent)  (journey → screen → services)  (experience-design)
+```
+
+Strategy sits at the top because everything below it needs a situation to react
+to. `product-engineering` shapes intent and runs the discovery loop, but it
+shapes intent *about something* — a market gap, an objective, a competitive
+threat that strategy named first. `experience-design` maps journeys and draws
+screens, but toward an experience vision that UX strategy set. Content design
+fills surfaces whose governance content strategy defined. Run the build packs
+without the strategy seat and each one invents its own missing context, silently
+and inconsistently.
+
+The seam that makes this concrete is the OKR cascade. `run-okr-cascade` does not
+only write a document. It emits `{type = "strategy"}` gaps into the
+`shaping_queue` backlog in `workspace.toml`, and the product-engineering pack's
+`frame-situation` reads that backlog as its shaping queue. So a company objective
+that has no product answer yet becomes a typed entry that the downstream pack
+picks up as work to shape. The cascade is the wire; `workspace.toml` is the
+socket. That is how an upstream strategy decision reaches the build loop without
+a human copying it across by hand.
+
+## What the seat deliberately excludes
+
+A seat is defined as much by what it refuses. This one does not do growth
+strategy — AARRR, product-led growth, PMF testing — which is a follow-on pack
+concern, not a gap to paper over here. It does not produce primary research;
+`synthesize-stakeholder-research` consumes desk-research outputs rather than
+running interviews. It does not touch analytics or CRO tooling, which belong
+downstream of the strategy the seat sets. Each exclusion keeps the seat sharp:
+strategy names the situation and commits the direction, then hands off.
+
+## See also
+
+- [Frameworks and artifacts](../reference/frameworks-and-artifacts.md) — the full skill-to-artifact map.
+- [Cascade OKRs into the shaping queue](../how-to/cascade-okrs-into-the-shaping-queue.md) — the upstream-to-build seam in practice.
+- [Set UX and content strategy](../how-to/set-ux-and-content-strategy.md) — where the two smaller pillars live.

--- a/docs/guides/product-strategy/how-to/cascade-okrs-into-the-shaping-queue.md
+++ b/docs/guides/product-strategy/how-to/cascade-okrs-into-the-shaping-queue.md
@@ -1,0 +1,86 @@
+# Cascade OKRs into the shaping queue
+
+You have company objectives, and you need them to become work the build loop
+picks up — not a slide that stops at the leadership offsite. This guide covers
+the three Pillar-1 skills that carry an objective from altitude down to a typed
+shaping-queue entry: `run-okr-cascade`, `write-prfaq`, and
+`synthesize-stakeholder-research`.
+
+It assumes the pack is installed and that `workspace.toml` exists in the repo the
+downstream product-engineering pack reads. Skip the OKR primer; this is about
+wiring, not definitions.
+
+## Cascade the objectives: `run-okr-cascade`
+
+This is the skill that closes the gap between strategy and the build queue.
+
+> Cascade our FY objectives down to the shaping queue.
+
+`run-okr-cascade` walks company objectives down through team level and, at the
+bottom, identifies the gaps that have no product answer yet. It commits two
+things:
+
+- `okr-cascade.md` in `docs/product/shaping/` — the readable cascade, company to
+  team to gap.
+- `{type = "strategy"}` entries appended to `["ini-NNN".shaping_queue].backlog`
+  in `workspace.toml`.
+
+The `workspace.toml` write is the load-bearing part. The product-engineering
+pack's `frame-situation` reads that backlog as its shaping queue, so a
+`{type = "strategy"}` gap becomes work the downstream pack shapes without anyone
+copying it across by hand. Treat the cascade as the wire and `workspace.toml` as
+the socket the build packs plug into.
+
+Two things to get right:
+
+- **Only real gaps become entries.** An objective already covered by in-flight
+  work is not a gap. Cascading every objective into the backlog floods the queue
+  and trains `frame-situation` to ignore it. Emit an entry only where there is no
+  product answer yet.
+- **The `ini-NNN` initiative must match** the one the downstream pack reads. A
+  gap written under the wrong initiative id is invisible to `frame-situation` —
+  it will sit in `workspace.toml` doing nothing.
+
+## Force the altitude-0 commitment: `write-prfaq`
+
+An objective survives contact with reality when someone commits to its outcome in
+concrete terms. The PRFAQ is that forcing function.
+
+> Write a PRFAQ for the objective we cascaded.
+
+`write-prfaq` produces the press release plus FAQ — the artifact that states, at
+altitude 0, what the world looks like when the objective has landed and answers
+the hard questions in advance. It commits `prfaq.md` to `docs/product/shaping/`.
+Run it against a cascaded objective and the vagueness surfaces fast: a PRFAQ you
+can't write a credible press release for is an objective that isn't yet real. Use
+it as the pressure test on the cascade output, not as a launch document.
+
+## Fold in the stakeholder picture: `synthesize-stakeholder-research`
+
+Objectives don't exist in a vacuum; stakeholders have already said things that
+should shape the cascade.
+
+> Synthesize the stakeholder research into a strategic narrative.
+
+`synthesize-stakeholder-research` reads across stakeholder groups and builds a
+strategic narrative by theme, committing `stakeholder-synthesis.md`. It
+**consumes** existing research — desk-research pack outputs, interview notes you
+already have — it does not run interviews. If you have no source material, this
+skill has nothing to synthesize; gather first, then synthesize. Run it before the
+cascade when stakeholder input should inform which gaps matter, or after it to
+sanity-check that the cascaded gaps reflect what stakeholders actually raised.
+
+## A working order
+
+A common sequence: synthesize the stakeholder picture, cascade the objectives
+against it, then PRFAQ the top gap to pressure-test it. But the skills are
+independent — each commits its own artifact — so run only the ones the situation
+needs. The one that changes downstream behaviour is `run-okr-cascade`; the other
+two sharpen its input and output.
+
+## See also
+
+- [Run a market and competitive analysis](run-a-market-and-competitive-analysis.md) — the analysis half of Pillar 1 that frames the objectives.
+- [Set UX and content strategy](set-ux-and-content-strategy.md) — the experience and content direction that runs alongside the cascade.
+- [Frameworks and artifacts](../reference/frameworks-and-artifacts.md) — the complete skill-to-artifact map.
+- [Why strategy is its own seat](../explanation/why-strategy-is-its-own-seat.md) — how the cascade wires strategy into the build loop.

--- a/docs/guides/product-strategy/how-to/run-a-market-and-competitive-analysis.md
+++ b/docs/guides/product-strategy/how-to/run-a-market-and-competitive-analysis.md
@@ -1,0 +1,103 @@
+# Run a market and competitive analysis
+
+You need a defensible picture of where the product stands — internal position,
+competitive pressure, macro forces, portfolio mix — and you want each part
+committed as an artifact a stakeholder can read, not a slide that evaporates.
+Pillar 1 gives you four analysis frameworks, one per question. Run the ones the
+situation warrants; you rarely need all four in the same week.
+
+This guide assumes you have the pack installed and know what SWOT and Porter's
+Five Forces are. It covers which framework answers which question, what each
+writes, and where the analyses overlap.
+
+## Pick the framework by the question
+
+Each skill owns one question and writes one artifact to `docs/product/shaping/`.
+
+| The question you're asking | Skill | Artifact |
+| --- | --- | --- |
+| Where are we strong and exposed, and what's open to us? | `run-swot` | `swot-analysis.md` |
+| How much pressure is the competitive structure putting on us? | `run-porters-five-forces` | `competitive-landscape.md` |
+| What macro forces are moving under us? | `run-pestle-analysis` | `macro-environment.md` |
+| Where does each product sit in the portfolio? | `run-bcg-matrix` | `portfolio-position.md` |
+
+Reach for the full reference table — every Pillar-1, -2, and -3 skill in one
+place — at [Frameworks and artifacts](../reference/frameworks-and-artifacts.md).
+
+## Run the internal-and-immediate read: SWOT
+
+Start here when you need a fast, shared read on the product's own position.
+
+> Run a SWOT for the payments product.
+
+`run-swot` works the four quadrants — Strengths, Weaknesses, Opportunities,
+Threats — and commits `swot-analysis.md`. Strengths and Weaknesses are internal
+and present-tense; Opportunities and Threats are external and forward-looking.
+The common failure is a SWOT that lists adjectives. Push each entry to a concrete
+claim with a consequence: not "strong brand" but "brand recognition lets us
+charge a 15% premium in the enterprise segment." A quadrant of vague nouns
+produces a document nobody acts on.
+
+## Run the competitive-structure read: Porter's Five Forces
+
+Use this when the pressure is coming from the market's shape, not one rival.
+
+> Run Porter's Five Forces on the market we're entering.
+
+`run-porters-five-forces` assesses Supplier Power, Buyer Power, threat of New
+Entrants, threat of Substitutes, and the intensity of Rivalry, and commits
+`competitive-landscape.md`. It answers *how attractive is this market's
+structure* — a different question from *who are our competitors*. Rate each force
+and say what makes it high or low; a force marked "high" with no mechanism is an
+assertion, not an analysis. Where Porter and SWOT overlap — Threats in the SWOT,
+New Entrants and Substitutes in Porter — let the SWOT stay at the headline and
+the Five Forces carry the structural detail. Don't duplicate the same paragraph
+into both artifacts.
+
+## Run the macro read: PESTLE
+
+Use this when the forces that matter sit outside the market entirely.
+
+> Run a PESTLE scan for the regulated-markets expansion.
+
+`run-pestle-analysis` sweeps Political, Economic, Social, Technological, Legal,
+and Environmental factors and commits `macro-environment.md`. The pitfall is
+completeness theatre — filling all six categories evenly when only two actually
+move your product. Weight the categories to the decision. A fintech expansion is
+mostly Legal and Political; a consumer-hardware line is mostly Economic and
+Environmental. Note the thin categories as thin rather than padding them.
+
+## Run the portfolio read: BCG matrix
+
+Use this when the unit of analysis is a set of products, not one product.
+
+> Place our product line on a BCG matrix.
+
+`run-bcg-matrix` positions each product across Stars, Cash Cows, Question Marks,
+and Dogs on the growth-share grid, and commits `portfolio-position.md`. It needs
+more than one product to be meaningful — a single-product company gets little
+from it. Ground the placement in the two axes it actually uses (market growth and
+relative share); a placement with no numbers behind it is a guess dressed as a
+matrix.
+
+## Sequencing and overlap
+
+There is no fixed order, but a common flow is PESTLE and Porter to establish the
+outside, then SWOT to fold that into the product's own position, then the BCG
+matrix if a portfolio decision is on the table. Each artifact stands alone, so a
+reader can open `competitive-landscape.md` without having read the SWOT. When two
+frameworks touch the same fact, cite it once in the artifact that owns it and
+reference across rather than copying — drift between two copies of the same claim
+is worse than a cross-reference.
+
+These four are the *analysis* half of Pillar 1. The forcing functions that turn
+this picture into committed direction — the OKR cascade, the PRFAQ, stakeholder
+synthesis — are the other half; see
+[Cascade OKRs into the shaping queue](cascade-okrs-into-the-shaping-queue.md).
+
+## See also
+
+- [Run your first SWOT](../tutorials/run-your-first-swot.md) — the guided first pass at `run-swot`.
+- [Cascade OKRs into the shaping queue](cascade-okrs-into-the-shaping-queue.md) — turn the picture into build-ready work.
+- [Frameworks and artifacts](../reference/frameworks-and-artifacts.md) — the complete skill-to-artifact map.
+- [Why strategy is its own seat](../explanation/why-strategy-is-its-own-seat.md) — why these artifacts sit upstream of the build packs.

--- a/docs/guides/product-strategy/how-to/set-ux-and-content-strategy.md
+++ b/docs/guides/product-strategy/how-to/set-ux-and-content-strategy.md
@@ -1,0 +1,77 @@
+# Set UX and content strategy
+
+Design is about to start, and you want the experience and content direction fixed
+first — so the journey maps and screens that follow have a vision to serve rather
+than inventing one per surface. This guide covers the two skills that set that
+direction: `define-ux-strategy` and `define-content-strategy`.
+
+It assumes the pack is installed. It also assumes you know the line this guide
+draws hard: strategy here sets the *system*, not the surface. Per-surface content
+design is out of scope, and this guide says exactly where that boundary sits.
+
+## Set the experience direction: `define-ux-strategy`
+
+Run this before journey mapping, not after.
+
+> Define the UX strategy for the onboarding redesign.
+
+`define-ux-strategy` sets the experience vision, the goals and measures, and the
+plan to get there, committing `ux-strategy.md` to `docs/product/shaping/`. It
+draws on three sources at once:
+
+- the **NN/g three-layer model** — separating the durable experience vision from
+  the goals beneath it and the plan beneath those;
+- **Jaime Levy's four tenets** of UX strategy — the business-strategy,
+  value-innovation, validated-user-research, and killer-UX framing;
+- **Gothelf/Seiden** — linking UX outcomes to OKRs so the strategy has measures,
+  not aspirations alone.
+
+The failure mode is a UX strategy that is really a design brief — screen-level
+opinions dressed as vision. Keep it at the altitude of *what kind of experience
+this is and how we'll know it worked*. If the OKR cascade has run, link the UX
+measures to those objectives rather than inventing parallel ones; the point of
+the Gothelf/Seiden framing is that experience outcomes and company objectives
+share a spine.
+
+## Set the content system: `define-content-strategy`
+
+Run this alongside UX strategy when content is a first-class part of the product.
+
+> Define the content strategy for the help centre.
+
+`define-content-strategy` works Halvorson's content-strategy quad — **Purpose**,
+**Process**, **Structure**, **Governance** — and commits `content-strategy.md` to
+`docs/product/shaping/`. The quad is the whole point: it forces you to decide not
+only what content is *for* (Purpose) but how it gets *made* (Process), how it's
+*organized* (Structure), and how it stays true over time (Governance). A content
+strategy that only covers Purpose is a mission statement; the value is in the
+Process and Governance halves that most teams skip.
+
+## The boundary: this is not content design
+
+Be explicit with yourself and your reviewers about the line. `define-content-strategy`
+sets the organizational and governance layer — the system content lives in. It
+does **not** write the copy for any one surface. That is the `content-design`
+skill in the experience-design pack, which decides what a specific landing page or
+help article says.
+
+Same split on the UX side. `define-ux-strategy` sets the experience vision; the
+journey maps, screen flows, and service blueprints that realize it are the
+experience-design pack's work. If you find yourself specifying a screen or writing
+a headline, you've crossed out of this pack.
+
+## Sequencing with the rest of the seat
+
+UX and content strategy usually run after the market picture and the OKR cascade,
+because the experience vision should serve objectives strategy already committed.
+But they don't depend on those artifacts to run — each commits independently. Run
+them when design is the next thing that will happen and you want it pointed in one
+direction.
+
+## See also
+
+- [Cascade OKRs into the shaping queue](cascade-okrs-into-the-shaping-queue.md) — the objectives the UX measures should link to.
+- [Run a market and competitive analysis](run-a-market-and-competitive-analysis.md) — the market picture the experience vision serves.
+- [Frameworks and artifacts](../reference/frameworks-and-artifacts.md) — the complete skill-to-artifact map.
+- [Why strategy is its own seat](../explanation/why-strategy-is-its-own-seat.md) — the strategy-versus-design boundary in full.
+<!-- TODO: link the experience-design pack's content-design skill guide once it exists -->

--- a/docs/guides/product-strategy/reference/frameworks-and-artifacts.md
+++ b/docs/guides/product-strategy/reference/frameworks-and-artifacts.md
@@ -1,0 +1,68 @@
+# Reference: frameworks and artifacts
+
+Every `product-strategy` skill, the framework it applies, and the artifact it
+writes. All artifacts commit to `docs/product/shaping/` by default. The base path
+is configurable through the `[product-strategy]` section of the repo's
+`agentbundle-layout.toml`.
+
+The tables below are grouped by pillar. Every row follows the same structure:
+skill name, framework, artifact filename, output path.
+
+## Pillar 1 — Market and competitive strategy
+
+Seven skills.
+
+| Skill | Framework | Artifact | Output path |
+| --- | --- | --- | --- |
+| `run-swot` | SWOT — Strengths, Weaknesses, Opportunities, Threats | `swot-analysis.md` | `docs/product/shaping/` |
+| `run-porters-five-forces` | Porter's Five Forces — Supplier Power, Buyer Power, New Entrants, Substitutes, Rivalry | `competitive-landscape.md` | `docs/product/shaping/` |
+| `run-pestle-analysis` | PESTLE — Political, Economic, Social, Technological, Legal, Environmental | `macro-environment.md` | `docs/product/shaping/` |
+| `run-bcg-matrix` | BCG Matrix — Stars, Cash Cows, Question Marks, Dogs | `portfolio-position.md` | `docs/product/shaping/` |
+| `run-okr-cascade` | OKR cascade — company → team → shaping-queue gaps | `okr-cascade.md` plus `workspace.toml` entries | `docs/product/shaping/` (and `workspace.toml`) |
+| `write-prfaq` | PRFAQ — press release plus FAQ as altitude-0 forcing function | `prfaq.md` | `docs/product/shaping/` |
+| `synthesize-stakeholder-research` | Research synthesis — strategic narrative by theme across stakeholder groups | `stakeholder-synthesis.md` | `docs/product/shaping/` |
+
+`run-okr-cascade` writes two outputs: the `okr-cascade.md` artifact, and
+`{type = "strategy"}` entries appended to `["ini-NNN".shaping_queue].backlog` in
+`workspace.toml`.
+
+## Pillar 2 — UX strategy
+
+One skill.
+
+| Skill | Frameworks | Artifact | Output path |
+| --- | --- | --- | --- |
+| `define-ux-strategy` | NN/g three-layer model · Jaime Levy four tenets · Gothelf/Seiden OKR-linked UX framing | `ux-strategy.md` | `docs/product/shaping/` |
+
+## Pillar 3 — Content strategy
+
+One skill.
+
+| Skill | Framework | Artifact | Output path |
+| --- | --- | --- | --- |
+| `define-content-strategy` | Halvorson content strategy quad — Purpose + Process + Structure + Governance | `content-strategy.md` | `docs/product/shaping/` |
+
+## Output path configuration
+
+All artifacts default to `docs/product/shaping/`. The base path is set through the
+`[product-strategy]` section of the repo's `agentbundle-layout.toml`, which is
+adopter-owned and not shipped with the pack. Each skill documents the layout
+contract in its own `references/agentbundle-layout.md`.
+
+## Scope exclusions
+
+The following are not part of this pack:
+
+| Excluded | Where it belongs |
+| --- | --- |
+| Growth strategy — AARRR, product-led growth, PMF testing | A follow-on `growth` pack |
+| Primary research production — interview guides, discussion scripts, survey templates | Upstream of `synthesize-stakeholder-research`, which consumes desk-research outputs |
+| Per-surface content design | The `content-design` skill in the experience-design pack |
+| Analytics and CRO tooling | Downstream of strategy |
+
+## See also
+
+- [Run a market and competitive analysis](../how-to/run-a-market-and-competitive-analysis.md) — using the Pillar-1 analysis frameworks.
+- [Cascade OKRs into the shaping queue](../how-to/cascade-okrs-into-the-shaping-queue.md) — the Pillar-1 forcing functions.
+- [Set UX and content strategy](../how-to/set-ux-and-content-strategy.md) — the Pillar-2 and Pillar-3 skills.
+- [Why strategy is its own seat](../explanation/why-strategy-is-its-own-seat.md) — how the pillars fit together.

--- a/docs/guides/product-strategy/tutorials/run-your-first-swot.md
+++ b/docs/guides/product-strategy/tutorials/run-your-first-swot.md
@@ -1,0 +1,89 @@
+# Run your first SWOT
+
+By the end you'll have a committed `docs/product/shaping/swot-analysis.md` —
+a four-quadrant read of one product's position — and you'll have seen where it
+lands in the shaping surface the downstream build packs read. One skill,
+`run-swot`, from a standing start to a committed artifact.
+
+You need the `product-strategy` pack installed. It installs to user scope, so the
+skill loads in whatever workspace you're in.
+
+## 1. Pick the product and open the workspace
+
+Work in a repo that has a `docs/product/` tree, or where you're happy for one to
+be created. Have one product in mind — the thing the SWOT is about.
+
+You should see a normal working repo. Nothing has happened yet; this step only
+sets where the artifact will land.
+
+## 2. Ask for the SWOT
+
+In your agent, say what you want in plain language:
+
+> Run a SWOT for our payments product.
+
+`run-swot` activates. It works one quadrant at a time — Strengths, Weaknesses,
+Opportunities, Threats.
+
+You should see the skill begin the SWOT and start on the first quadrant, naming
+the product you gave it.
+
+## 3. Answer for the internal quadrants
+
+The skill works Strengths and Weaknesses first. These are internal and
+present-tense — what's true about the product today.
+
+Give concrete claims, not adjectives. "Brand recognition lets us charge a 15%
+premium with enterprise buyers" is a Strength; "good brand" is not.
+
+You should see each internal quadrant fill with specific, present-tense entries
+about the product itself.
+
+## 4. Answer for the external quadrants
+
+The skill moves to Opportunities and Threats. These are external and
+forward-looking — what the market opens or threatens.
+
+You should see the two external quadrants fill with forward-looking entries
+pointed at the market, distinct from the internal claims above them.
+
+## 5. Review the assembled analysis
+
+The skill shows you the full four-quadrant SWOT before it writes anything.
+
+Read it as a whole. Check that every entry is a claim with a consequence, not a
+lone noun. If a quadrant reads thin or vague, say so and the skill reworks it.
+
+You should see all four quadrants together, and you should be asked to confirm
+before it commits.
+
+## 6. Commit the artifact
+
+Approve. The skill writes `swot-analysis.md` into `docs/product/shaping/`.
+
+You should see a new file at `docs/product/shaping/swot-analysis.md` containing
+the four quadrants you reviewed.
+
+## 7. See where it landed
+
+Open `docs/product/shaping/`. Your `swot-analysis.md` sits alongside whatever
+other strategy artifacts the pack has produced. This directory is the shaping
+surface — the committed strategy artifacts the downstream product-engineering and
+experience-design packs draw on.
+
+You should see `swot-analysis.md` in `docs/product/shaping/`, committed and ready
+for a reviewer to open on its own.
+
+## What you did
+
+You took one product from a standing start to a committed, four-quadrant strategy
+artifact in the shaping surface — the same surface every other Pillar-1 skill
+writes to. The next market picture usually needs more than a SWOT: the
+competitive structure, the macro forces, the portfolio position. Reach for those
+in [Run a market and competitive analysis](../how-to/run-a-market-and-competitive-analysis.md).
+
+## See also
+
+- [Run a market and competitive analysis](../how-to/run-a-market-and-competitive-analysis.md) — the other three Pillar-1 analysis frameworks.
+- [Frameworks and artifacts](../reference/frameworks-and-artifacts.md) — every skill and the file it writes.
+- [Why strategy is its own seat](../explanation/why-strategy-is-its-own-seat.md) — why this artifact sits upstream of the build packs.

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -148,6 +148,18 @@ nav:
         - Spec Shape & LLD: guides/core/reference/spec-shape-and-lld.md
       - Tutorials:
         - Start a New Project: guides/core/tutorials/start-a-new-project.md
+    - "Product Strategy":
+      - guides/product-strategy/README.md
+      - Explanation:
+        - Why Strategy Is Its Own Seat: guides/product-strategy/explanation/why-strategy-is-its-own-seat.md
+      - How-to:
+        - Run a Market Analysis: guides/product-strategy/how-to/run-a-market-and-competitive-analysis.md
+        - Cascade OKRs: guides/product-strategy/how-to/cascade-okrs-into-the-shaping-queue.md
+        - Set UX & Content Strategy: guides/product-strategy/how-to/set-ux-and-content-strategy.md
+      - Reference:
+        - Frameworks & Artifacts: guides/product-strategy/reference/frameworks-and-artifacts.md
+      - Tutorials:
+        - Run Your First SWOT: guides/product-strategy/tutorials/run-your-first-swot.md
     - "Product Discovery":
       - guides/product-engineering/README.md
       - Explanation:

--- a/web/src/components/marketing/PackCatalogue.astro
+++ b/web/src/components/marketing/PackCatalogue.astro
@@ -1,7 +1,10 @@
 ---
 // Section 8 — THE CATALOGUE. Light zone. Progressive disclosure: the 3 loops
-// are always visible (large cards); the remaining 11 packs live behind a
-// <details> expander — zero JS. 3-always + 11-on-reveal (homepage-screen-flow.md).
+// are always visible (large cards); the remaining 14 packs live behind a
+// <details> expander — zero JS. 3-always + 14-on-reveal (homepage-screen-flow.md).
+// Within each scope group, packs follow the SDLC value-stream order used on the
+// /catalogue/ page (RFC-0064): strategy → research → design → architecture →
+// contracts → infra → governance → docs, then supporting tooling and connectors.
 import Section from '../layout/Section.astro';
 import { withBase } from '../../lib/paths';
 
@@ -30,20 +33,23 @@ const loops = [
 ];
 
 const userPacks = [
-  { name: 'Research', desc: 'Evidence-grounded research — surveys, source maps, competing-hypothesis analysis.' },
+  { name: 'Product Strategy', desc: 'The strategy seat — SWOT, Porter, PESTLE, OKR cascade, PRFAQ, plus UX and content strategy.' },
+  { name: 'Desk Research', desc: 'Evidence-grounded research — surveys, source maps, competing-hypothesis analysis.' },
+  { name: 'Experience Design', desc: 'The full design thread — journey to realization, WCAG-aware quality floor.' },
   { name: 'Architect', desc: 'System design — design docs, diagrams, architecture review.' },
-  { name: 'Experience', desc: 'The full design thread — journey to realization, WCAG-aware quality floor.' },
   { name: 'Contracts', desc: 'API-first design — OpenAPI 3.1 and AsyncAPI contracts.' },
   { name: 'Converters', desc: 'Document conversion — PDF/DOCX/PPTX ↔ Markdown, HTML, Office, Mermaid.' },
+  { name: 'Credential Brokers', desc: 'Credential resolution — env → OS keyring → dotfile. Cleartext never reaches the model.' },
   { name: 'Atlassian', desc: 'Jira and Confluence from the agent — flow and DORA metrics, SSO-cookie auth.' },
   { name: 'Figma', desc: 'Read and render Figma designs — files, nodes, variables, FigJam → Mermaid.' },
-  { name: 'Credential Brokers', desc: 'Credential resolution — env → OS keyring → dotfile. Cleartext never reaches the model.' },
 ];
 
 const repoPacks = [
+  { name: 'IaC (Terraform)', desc: 'Plain-language intent → governed, cloud-agnostic Terraform. Human-gated; stops at plan.' },
   { name: 'Governance Extras', desc: 'Decision trail — new-rfc, new-adr, update-conventions for long-lived repos.' },
-  { name: 'User Guide (Diataxis)', desc: 'Docs scaffold — Diátaxis skeleton with new-guide.' },
+  { name: 'User Guide (Diátaxis)', desc: 'Docs scaffold — Diátaxis skeleton with new-guide.' },
   { name: 'Monorepo Extras', desc: 'Package scaffolding — new-package, example package template.' },
+  { name: 'Catalogue Curation', desc: 'Grow the catalogue — assimilate primitives, survey repos, propose packs, export forks.' },
 ];
 ---
 
@@ -70,7 +76,7 @@ const repoPacks = [
 
   <details class="catalogue__more">
     <summary class="catalogue__summary">
-      <span>See all 14 packs</span>
+      <span>See all 17 packs</span>
       <span class="catalogue__summary-arrow" aria-hidden="true">→</span>
     </summary>
 

--- a/web/src/content/packs/catalogue-curation.md
+++ b/web/src/content/packs/catalogue-curation.md
@@ -1,0 +1,14 @@
+---
+name: Catalogue Curation
+scope: repo
+tagline: "Grow the catalogue — assimilate, survey, propose, export."
+skills:
+  - assimilate-primitive
+  - assimilate-repo
+  - propose-catalogue-pack
+  - export-catalogue
+installCommand: "agentbundle install --pack catalogue-curation"
+docsUrl: /docs/guides/catalogue-curation/
+---
+
+Catalogue Curation is the operator's seat — meta-tooling for growing and forking the catalogue itself, one level above governance-extras. `assimilate-primitive` folds an external skill or agent into a pack; `assimilate-repo` surveys a whole repo for reusable primitives; `propose-catalogue-pack` shapes a new pack proposal (emitting an RFC); and `export-catalogue` produces white-label or attributed derivatives of the catalogue. Repo-only ceremony; depends on `core` and `governance-extras`.

--- a/web/src/content/packs/iac-terraform.md
+++ b/web/src/content/packs/iac-terraform.md
@@ -1,0 +1,13 @@
+---
+name: IaC (Terraform)
+scope: repo
+tagline: "Intent → governed Terraform. Stops at plan."
+skills:
+  - generate-iac
+  - reconcile-iac
+installCommand: "agentbundle install --pack iac-terraform"
+docsUrl: /docs/guides/iac-terraform/
+journeyUrl: /journeys/iac-terraform/
+---
+
+IaC (Terraform) turns a plain-language infrastructure intent into governed, best-practice, cloud-agnostic Terraform plus a human-gated CI/CD pipeline. `generate-iac` runs a mandatory Stage-0 ADR gate, a vocabulary-firewalled spec, schema-grounded generation, and a policy-as-code and security preflight — then stops at a digest-pinnable `terraform plan` for G4 handoff. `reconcile-iac` audits plan-visible drift and proposes a per-resource disposition. The agent never runs `terraform apply`; it produces and pins the plan, and release-loop (or the generated pipeline) routes it to the real account. Depends on `core` and `governance-extras`.

--- a/web/src/content/packs/product-strategy.md
+++ b/web/src/content/packs/product-strategy.md
@@ -1,0 +1,19 @@
+---
+name: Product Strategy
+scope: user
+tagline: "The strategy seat — market, UX, and content strategy upstream of the build."
+skills:
+  - run-swot
+  - run-porters-five-forces
+  - run-pestle-analysis
+  - run-bcg-matrix
+  - run-okr-cascade
+  - write-prfaq
+  - synthesize-stakeholder-research
+  - define-ux-strategy
+  - define-content-strategy
+installCommand: "agentbundle install --pack product-strategy --scope user"
+docsUrl: /docs/guides/product-strategy/
+---
+
+Product Strategy is the seat upstream of product engineering and experience design. Three pillars: **market & competitive strategy** (SWOT, Porter's Five Forces, PESTLE, BCG Matrix, OKR cascade, PRFAQ, stakeholder-research synthesis) that produce committed artifacts in `docs/product/shaping/` and feed the PE pack's shaping queue; **UX strategy** (experience vision, goals/measures, plan) upstream of journey-mapping; and **content strategy** — the Halvorson quad (Purpose · Process · Structure · Governance) that sits above per-surface content design. Pure method: it references the canonical frameworks by name and applies them to your context — no growth tooling, no stack tokens.

--- a/web/src/pages/catalogue/index.astro
+++ b/web/src/pages/catalogue/index.astro
@@ -7,12 +7,36 @@ import { withBase } from '../../lib/paths';
 const PLUGIN_BRANCH = 'claude-plugins-dist';
 const REPO = 'eugenelim/agent-ready-repo';
 
+// SDLC value-stream order (RFC-0064 three-altitude model + the three loops):
+// core anchors first, then strategy → research → shaping → design →
+// architecture → contracts → infra → release → governance → docs, with
+// supporting tooling and connectors last. Packs not listed fall back to
+// alphabetical by name.
+const SDLC_ORDER = [
+  'core',
+  'product-strategy',
+  'desk-research',
+  'product-engineering',
+  'experience-design',
+  'architect',
+  'contracts',
+  'iac-terraform',
+  'release-engineering',
+  'governance-extras',
+  'user-guide-diataxis',
+  'converters',
+  'monorepo-extras',
+  'catalogue-curation',
+  'credential-brokers',
+  'atlassian',
+  'figma',
+];
+
 const allPacks = await getCollection('packs');
 const packs = allPacks
   .sort((a, b) => {
-    const order = ['core', 'product-engineering', 'release-engineering'];
-    const ai = order.indexOf(a.id.replace(/\.md$/, ''));
-    const bi = order.indexOf(b.id.replace(/\.md$/, ''));
+    const ai = SDLC_ORDER.indexOf(a.id.replace(/\.md$/, ''));
+    const bi = SDLC_ORDER.indexOf(b.id.replace(/\.md$/, ''));
     if (ai !== -1 && bi !== -1) return ai - bi;
     if (ai !== -1) return -1;
     if (bi !== -1) return 1;


### PR DESCRIPTION
## What & why

The marketing site (`web/`) had drifted from the real 17-pack catalogue: it listed only 14 packs and carried stale display names. This surfaces the full catalogue, orders it by the SDLC value stream, and scaffolds the missing `product-strategy` guide so its marketing docs link resolves. The docs site is otherwise unchanged.

## Marketing site (`web/`)

- **Missing packs added** — new content-collection entries for `product-strategy`, `iac-terraform`, and `catalogue-curation`. Their `/catalogue/` cards and `/packs/<slug>/` detail pages now render (the `iac-terraform` journey previously linked to a 404'ing pack page).
- **SDLC ordering** — both the data-driven `/catalogue/` grid and the hardcoded homepage catalogue now follow the SDLC value stream from RFC-0064 (three-altitude model + the three loops), with `core` pinned first:
  > core → product-strategy → desk-research → product-engineering → experience-design → architect → contracts → iac-terraform → release-engineering → governance-extras → user-guide-diataxis → converters → monorepo-extras → catalogue-curation → credential-brokers → atlassian → figma
- **Stale names fixed** on the homepage: `Research → Desk Research`, `Experience → Experience Design`, `User Guide (Diataxis) → User Guide (Diátaxis)`; `See all 14 packs → 17`.

## Docs (`docs/guides/product-strategy/`)

`product-strategy` shipped in #557 without a guide directory, so the marketing `docsUrl` had nowhere to land. Added a 7-file Diátaxis guide set (index, 1 tutorial, 3 how-tos, 1 reference, 1 explanation) via the `new-guide` skill, grounded in `packs/product-strategy/README.md`, and registered it in the `site/mkdocs.yml` Guides nav (after the build loop, before Product Discovery).

## Verification

- `npm run build` (Astro) passes — 38 pages, all 17 pack detail pages render; `/catalogue/` and homepage both show 17 in SDLC order with corrected names.
- `make site-build` (strict mkdocs) passes — new guides sync, nav resolves, all internal cross-links valid.

## Judgment calls / follow-ups

- **Non-product pack placement.** RFC-0064 gives an explicit order only for the product packs (strategy → research → shaping → build → release). Placement of architect, contracts, iac-terraform, experience-design, and the tooling/connector tail is my call — a one-line edit to the `SDLC_ORDER` array in `web/src/pages/catalogue/index.astro` if a different sequence is intended.
- **Docs pack catalogue gap (not touched — flagging).** The docs-side pack catalogue in `tools/build-site.py` (the `PACKS` list) is also missing `iac-terraform` and `catalogue-curation` and still reads "Fifteen curated packs." Out of scope for this PR (docs was reported as fine), but worth a follow-up.
- **One TODO cross-link** remains in the guides for the not-yet-existing experience-design `content-design` guide.