### PR TITLE
docs(specs): ADR-0054 + four Approved specs for RFC-0067

### DIFF
--- a/docs/adr/0054-session-arc-verb-taxonomy-and-pack-type-classification.md
+++ b/docs/adr/0054-session-arc-verb-taxonomy-and-pack-type-classification.md
@@ -1,0 +1,109 @@
+# ADR-0054: Session-arc verb taxonomy and pack-type classification for skill naming
+
+- **Status:** Accepted
+- **Date:** 2026-07-20
+- **Decision-makers:** eugenelim
+- **Supersedes:** none
+- **Related:** RFC-0067 (driving RFC — all decisions); RFC-0025 (work-loop light mode — no-new-skill precedent for Change C); RFC-0050 (clean-retire rename precedent: design-craft → experience-design rename with no install-time alias); ADR-0051 (workspace-toml format — check-workspace named as historical record); ADR-0053 (product-strategy pack — check-workspace routing record)
+
+## Decision summary
+
+- **Decision:** We will adopt a canonical five-verb taxonomy (`status`, `start`, `check`, `init`, `resume`) and a four-type pack classification (episodic / sustained-project / sustained-derived / stateless) as the naming and design framework for session-arc skills across all catalogue packs.
+- **Because:** Three packs already span sessions (desk-research, experience-design, product-strategy), and without a shared vocabulary pack authors independently solve the same arc-design questions — producing inconsistent naming, missing orient skills, and repeated reviewer cycles catching the same gaps.
+- **Applies to:** All catalogue packs that carry durable work across sessions; every future pack RFC that adds a status skill, a project-start skill, or a config-driven output path.
+- **Tradeoff accepted:** Clean retire of `check-workspace` → `workspace-status` creates a brief breaking-change window for adopters who invoke the old name; there is no backward-compatible shim.
+- **Revisit if:** A new pack type emerges that doesn't fit the four-type classification, or the verb taxonomy accumulates enough exceptions that the banned-label list must be revised.
+
+## Context
+
+RFC-0067 (accepted 2026-07-20) identified that the catalogue had three packs producing durable work across sessions (desk-research, experience-design, product-strategy) but no shared vocabulary for naming the skills that let a user cold-start orientation. The workspace-level orient skill was named `check-workspace` — an action verb, not the information it provides. Pack authors had no documented framework for deciding whether their pack needs a status skill, a project-start skill, or a vault-path pattern. As more packs landed, pack authors would independently solve the same arc-design questions without a shared vocabulary, leading to inconsistent naming, missing orient skills, and repeated reviewer cycles.
+
+The session-arc vocabulary (Arrive → Orient → Work → Persist → Collaborate) already existed in the `workspace-design` skill. RFC-0067 applied it to pack authoring by establishing the verb taxonomy and pack-type classification this ADR records.
+
+## Decision
+
+We will maintain the following as authoritative conventions for session-arc skill naming and pack design across the catalogue:
+
+### Verb taxonomy (operative skill names)
+
+| Verb | Meaning | Activation phrasing |
+| --- | --- | --- |
+| `status` | Orient — "where am I / what's next?" | Cold-start phrases, "what's on today", "orient me" |
+| `start` | Create/begin a sustained project | "start a research project", "kick off an investigation" |
+| `check` | Quality/health read — "is it good / saturated / done?" | "is this ready", "should I keep gathering" |
+| `init` | Repo-scaffold only | `init-project`, `adapt-to-project`; cf. `git init` |
+| `resume` | Return to prior work | Activation phrase — not a skill name; see work-loop's argless trigger |
+
+**Banned as skill names:** `arrive`, `orient`, `onboard`, `return`, `onboarding` — these are UX-stage labels (from the `workspace-design` session-arc vocabulary), not user-facing commands.
+
+### Pack-type classification
+
+| Type | Description | Examples |
+| --- | --- | --- |
+| **Episodic** | No persistent state between sessions; each invocation is standalone | architect, product-strategy, converters, iac-terraform |
+| **Sustained-project** | Creates and manages a durable project that persists across sessions | desk-research |
+| **Sustained-derived** | Reads from and builds upon a durable project created elsewhere | experience-design (reads from journey maps, screen flows, blueprints) |
+| **Stateless** | Pure workflow transformation; no file-system output | (hypothetical utility packs) |
+
+Episodic packs do not require a `*-status` skill — there is no persistent thread state to orient to.
+
+### Rename: `check-workspace` → `workspace-status` (clean retire)
+
+The `workspace-status` skill is the canonical cold-start orient skill for workspace-level orientation. The old name `check-workspace` is removed entirely from operative references in one PR; all operative references are swept in the same PR. No alias is maintained. The clean-retire approach follows RFC-0050 precedent.
+
+Historical-record files (frozen ADR bodies, changelog entries, shipped spec bodies) are left as-is per CONVENTIONS §2 — a mechanical rename is not a decision reversal and does not require a superseding ADR or erratum.
+
+### Argless work-loop resume: list-and-ask disambiguation
+
+When `work-loop` is invoked without a spec path argument, Step 0 collects all active spec paths across all `["ini-NNN"]` sections with `status = "active"`. The behavior is:
+
+1. **Exactly one active item** → begin the loop on that spec without asking.
+2. **Zero active items** → "No active spec found — run `workspace-status` to see what's ready to start."
+3. **More than one active item** (whether from a single initiative's multi-element `.active` array or across multiple initiatives) → list all active paths and ask the user to pick before beginning.
+
+This replaces the existing "auto-pick the first path" behavior. The change is a description + body edit to `work-loop` SKILL.md per RFC-0025 no-new-skill precedent; no new skill is needed.
+
+## Decision drivers
+
+1. **Naming consistency** — users predict skill names across packs; inconsistency erodes trust and generates support load.
+2. **Pack-author framework** — a documented design framework prevents repeated reviewer cycles on future pack RFCs; the cost of authoring it now is lower than N future rounds of review.
+3. **No alias debt** — clean retire avoids permanently maintaining two names that undermine the taxonomy; RFC-0050 established this as the catalogue's rename convention.
+4. **Non-surprising disambiguation** — list-and-ask is consistent with `workspace-status` disambiguation behavior; auto-picking the first path is silent and surprising when a user has two initiatives in flight.
+
+## Consequences
+
+**Positive:**
+- Future pack authors have a documented decision framework before writing their first skill, reducing reviewer cycles.
+- Users predict skill names from the taxonomy; `*-status` is the canonical cold-start pattern.
+- The workspace-level orient skill name (`workspace-status`) matches the taxonomy it defines.
+- Argless `work-loop` resume is non-surprising and handles multi-initiative workspaces correctly.
+
+**Negative:**
+- Clean retire creates a brief breaking-change window; adopters invoking `check-workspace` by name will get a "skill not found" error until they update. Mitigation: the rename is announced in the changelog; the new description triggers include all phrasing the old skill responded to.
+- The four-type classification is a first-principles taxonomy with no external prior art; it may not cover future pack archetypes. Mitigation: `Revisit if` trigger above.
+
+**Revisit if:** A new pack type emerges that doesn't fit the four-type classification, or the verb taxonomy accumulates enough exceptions that the banned-label list needs to be revised.
+
+## Confirmation
+
+- **Mode:** lint/CI + reviewer-checked
+- **Signal:** The operative-reference lint gate (`grep -rn "check-workspace"` over `git ls-files`, excluding the explicit historical set) returns zero hits after Spec A ships. Future pack RFCs are reviewed against this ADR's verb taxonomy and pack-type classification by `adversarial-reviewer`.
+- **Owner:** eugenelim (lint gate); `adversarial-reviewer` at spec-stage review (taxonomy conformance).
+
+## Alternatives considered
+
+**Alias `check-workspace` → `workspace-status` (two names permanently):** Zero breaking change; permanently maintains two names and undermines the taxonomy. Rejected — alias never cleanly removes itself; RFC-0050 established clean retire as the catalogue's rename convention.
+
+**New `workspace-resume` skill for argless work-loop:** Creates a second activation surface; duplicates work-loop triggers; "resume" becomes ambiguous between two skills. Rejected per RFC-0025 no-new-skill precedent: a description + body change to work-loop is sufficient when no new activation surface is needed.
+
+**Separate guide per pack archetype (four guides instead of one):** Zero staleness per pack; high maintenance N-way duplication. Rejected — archetype membership changes slowly; one shared framework at archetype level is the stable shape.
+
+**Status skills for episodic packs:** Episodic packs have no persistent thread state to orient to. A `*-status` skill on an episodic pack would have nothing to read. Rejected — the pack-type classification is the principled boundary.
+
+## References
+
+- RFC-0067: `docs/rfc/0067-session-arc-conventions-and-pack-workflow-guide.md`
+- RFC-0025 (no-new-skill precedent): `docs/rfc/0025-work-loop-light-mode-and-risk-based-escalation.md`
+- RFC-0050 (`docs/rfc/0050-the-experience-pack.md`): clean-retire precedent — design-craft → experience-design rename with no install-time alias. Note: RFC-0067 §Evidence cites "RFC-0048 (Scope-decouple and renames)" for this precedent, but RFC-0048 in this repo is the autonomous-product-team RFC; the actual rename precedent is RFC-0050.
+- `packs/experience-design/.apm/skills/workspace-design/SKILL.md` — session-arc vocabulary (Arrive → Orient → Work → Persist → Collaborate) this ADR builds on
+- `packs/governance-extras/.apm/skills/rfc-status/SKILL.md` — `*-status` orient precedent

--- a/docs/specs/spec-A-workspace-status-rename/plan.md
+++ b/docs/specs/spec-A-workspace-status-rename/plan.md
@@ -1,0 +1,204 @@
+# Plan: spec-A-workspace-status-rename
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Drafting
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn. When it changes substantially
+> (a different approach, not just a re-ordering), note why in the changelog
+> at the bottom.
+
+## Approach
+
+Pure rename-and-sweep, with no logic changes. The shape: rename the skill directory in source, update frontmatter, update all operative references derived from `git ls-files | xargs grep -l "check-workspace"`, add the verb taxonomy section to `author-a-skill.md`, then run `make build-self` to regenerate the projected tree. The lint gate (zero `grep` hits over the operative set) is the hard acceptance criterion; everything else is in service of passing it.
+
+The riskiest part is the operative-reference sweep: the RFC identifies ~46 tracked files. The implementation must derive the exact list at runtime (`git ls-files | xargs grep -l "check-workspace"`) rather than using the RFC's illustrative list, which may be stale. Classification (operative vs. historical) follows the RFC-0067 §Change A rules exactly.
+
+Order of operations: rename source → update frontmatter → sweep references → add taxonomy section → build-self → lint gate → open PR.
+
+## Constraints
+
+- RFC-0067 §Change A: no alias; clean retire only; operative/historical classification rules are normative.
+- ADR-0054: verb taxonomy table content is normative; the `## Naming your skill` section must reproduce it accurately.
+- CONVENTIONS §2: frozen ADR bodies and shipped spec bodies are never edited.
+- CONVENTIONS §Pack source-of-truth split: `make build-self` must be run after source edits; direct edits to projected paths are caught by `make build-check` and rejected.
+
+## Construction tests
+
+**Integration tests:** none beyond per-task goal-based checks.
+
+**Lint gate (cross-cutting, runs at T6):**
+```bash
+git ls-files | xargs grep -rn "check-workspace" | \
+  grep -v "docs/adr/0051-" | \
+  grep -v "docs/adr/0053-" | \
+  grep -v "docs/product/changelog.md" | \
+  grep -v "docs/specs/" | \
+  grep -v "docs/rfc/0067-"
+# Must return zero hits.
+```
+
+**Build gate (cross-cutting, runs at T7):**
+```bash
+make build-check
+# Must exit 0.
+```
+
+## Tasks
+
+### T1: Rename skill directory and update pack manifest
+
+**Depends on:** none
+**Touches:** packs/core/.apm/skills/, packs/core/pack.toml, packs/core/.claude-plugin/plugin.json, .claude-plugin/marketplace.json
+
+**Tests:**
+- Goal-based (AC1): `ls packs/core/.apm/skills/workspace-status/` succeeds; `ls packs/core/.apm/skills/check-workspace/` fails.
+- Goal-based (AC2): `name: workspace-status` present in frontmatter; `description:` contains "workspace status", "where am I", "orient me", "session start", "what's ready", "show the queue", "what's next".
+- Goal-based (AC3): `grep "workspace-status" packs/core/pack.toml` returns a hit; `grep "check-workspace" packs/core/pack.toml` returns nothing.
+- Goal-based (AC4): `grep "workspace-status" packs/core/.claude-plugin/plugin.json` returns a hit.
+
+**Approach:**
+- `git mv packs/core/.apm/skills/check-workspace packs/core/.apm/skills/workspace-status`
+- Update `name:` in `packs/core/.apm/skills/workspace-status/SKILL.md` from `check-workspace` to `workspace-status`.
+- Update `description:` to add RFC-0067 §A1 trigger phrases (cold-start phrasing, "workspace status", "where am I", "orient me", "session start", "what's ready", "show the queue", "what's next").
+- Update `packs/core/pack.toml` skills array entry.
+- Update `packs/core/.claude-plugin/plugin.json` skill entry name.
+
+**Done when:** AC1, AC3, AC4 hold; `git mv` recorded cleanly in `git status`.
+
+---
+
+### T2: Derive and classify all operative references
+
+**Depends on:** T1
+
+**Tests:**
+- Goal-based: `git ls-files | xargs grep -l "check-workspace"` produces a list; every hit is classified as operative or historical using RFC-0067 §Change A rules; no hit is left unclassified.
+
+**Approach:**
+- Run `git ls-files | xargs grep -l "check-workspace"` to get the live file list.
+- For each file, apply the RFC-0067 §Change A classification:
+  - **Historical (leave as-is):** `docs/adr/0051-*.md`, `docs/adr/0053-*.md`, `docs/product/changelog.md`, `docs/specs/**`, `docs/rfc/0067-*.md`, this RFC's own body.
+  - **Operative (rewrite):** everything else — skill body, AGENTS.md files, seeds, pack manifests, plugin.json, marketplace.json, README files, cross-pack routing references, guides, product docs, site/, web/, docs/rfc/README.md, docs/rfc/0064-*.md (Draft).
+- Produce a working list of operative files for T3.
+
+**Done when:** Every file in the grep output has an operative/historical classification. Working list is noted in .context/ for T3.
+
+---
+
+### T3: Sweep all operative references to `workspace-status`
+
+**Depends on:** T2
+**Touches:** operative files derived in T2
+
+**Tests:**
+- Goal-based (AC9): after editing, `grep -rn "check-workspace"` on each operative file returns zero hits.
+
+**Approach:**
+- Edit each operative file from T2's list, replacing `check-workspace` with `workspace-status` where it appears as an operative reference.
+- Special care for `docs/rfc/0064-ini-001-ai-native-ecosystem.md` (Draft — the ADR-0009/strategy-pack reference in D9 names `check-workspace`; update it).
+- For seed files (`packs/core/seeds/AGENTS.md`, workspace.toml seed comment), update the prose reference.
+- For `docs/CONVENTIONS.md`, update the routing-table entry if it names `check-workspace` by skill name.
+- Confirm no operative file retains `check-workspace` after edits.
+
+**Done when:** Zero operative hits; historical files untouched.
+
+---
+
+### T4: Add `## Naming your skill` section to `author-a-skill.md`
+
+**Depends on:** none
+**Touches:** docs/guides/_shared/how-to/author-a-skill.md
+
+**Tests:**
+- Goal-based (AC7): the file gains a `## Naming your skill` section after `## Body structure` with the verb table (5 rows: status, start, check, init, resume) and the banned-label list (arrive, orient, onboard, return, onboarding).
+- Goal-based (AC8): the file's intro section gains the sentence linking to `pack-workflow-design.md`.
+
+**Approach:**
+- Read `author-a-skill.md` to find the `## Body structure` section.
+- Insert `## Naming your skill` after that section with:
+  - The verb taxonomy table from ADR-0054 §Decision (status/start/check/init/resume with Meaning and Activation phrasing columns).
+  - The banned-label list sentence: "Banned as skill names: `arrive`, `orient`, `onboard`, `return`, `onboarding` — these are UX-stage labels, not user-facing commands."
+- Add the intro sentence to the guide's intro paragraph (or as a callout before the first section): "If you're authoring the first skill in a new pack, read [Pack workflow design](../explanation/pack-workflow-design.md) first — it tells you how to design the pack's arc before writing individual skills." (Note: `author-a-skill.md` is at `docs/guides/_shared/how-to/`; `explanation/` is one level up and across, so the correct relative path is `../explanation/`, not `../../explanation/`.)
+
+**Done when:** AC7 + AC8 hold; the verb table matches ADR-0054 exactly.
+
+---
+
+### T5: Add `[Unreleased]` changelog entry
+
+**Depends on:** T1
+**Touches:** docs/product/changelog.md
+
+**Tests:**
+- Goal-based (AC11): `docs/product/changelog.md` has an `[Unreleased]` entry noting the `check-workspace` → `workspace-status` rename and the skill addition (verb taxonomy section in author-a-skill.md).
+
+**Approach:**
+- Add an `[Unreleased]` section (or append to it if one exists) noting:
+  - Renamed: `check-workspace` → `workspace-status` (clean retire — no alias).
+  - Added: Verb taxonomy (`## Naming your skill`) section to `docs/guides/_shared/how-to/author-a-skill.md`.
+
+**Done when:** AC11 holds.
+
+---
+
+### T6: Run lint gate — zero operative hits
+
+**Depends on:** T1, T2, T3, T4, T5
+
+**Tests:**
+- Goal-based (AC5): the lint command returns zero hits.
+
+**Approach:**
+- Run the cross-cutting lint gate from § Construction tests above.
+- If any hits remain, re-classify and fix; they are either missed operative references (fix in T3) or misclassified files.
+
+**Done when:** AC5 holds — zero hits.
+
+---
+
+### T7: Rebuild projected tree and verify build gate
+
+**Depends on:** T6
+**Touches:** .claude/skills/workspace-status/, all adapter-projected skill paths
+
+**Tests:**
+- Goal-based (AC6): `.claude/skills/workspace-status/` exists; `.claude/skills/check-workspace/` does not.
+- Goal-based (AC10): `make build-check` exits 0.
+
+**Approach:**
+- Run `make build-self` (with `FORCE=1` if the working tree is dirty from prior source edits).
+- Confirm `.claude/skills/workspace-status/` is created and `.claude/skills/check-workspace/` is absent.
+- Stage the regenerated projected tree.
+- Run `make build-check` to confirm no drift.
+
+**Done when:** AC6 + AC10 hold.
+
+---
+
+### T8: Final gates and adversarial review
+
+**Depends on:** T7
+
+**Tests:**
+- Goal-based (AC1–AC11 all): run the full lint gate + build check; confirm all ACs hold.
+
+**Approach:**
+- Run `scripts/lint-spec-status.py` on this spec.
+- Confirm `git status` is clean except intended files.
+- Run adversarial review; address any Blockers.
+
+**Done when:** All ACs checked; adversarial-reviewer returns `Clean — ready to commit.`
+
+## Rollout
+
+Pure repo-internal change: skill directory rename + source edits + projected tree rebuild. No external-system dependency. The rename is announced in `[Unreleased]` changelog (T5); adopters invoking `check-workspace` by name will get a "skill not found" signal after the PR merges. The new `workspace-status` description triggers cover all phrasing the old skill responded to.
+
+## Risks
+
+- The operative-reference sweep may miss a file if `git ls-files` output differs between the time the RFC was written (~46 files) and implementation time. Mitigation: the lint gate (T6) is the hard acceptance criterion — zero hits is objective.
+- `make build-self` may require `FORCE=1` if the working tree has unstaged source edits. Mitigation: use `FORCE=1` explicitly in T7.
+
+## Changelog
+
+- 2026-07-20: initial plan, authored alongside the spec for RFC-0067 spec/plan/ADR follow-on work.

--- a/docs/specs/spec-A-workspace-status-rename/spec.md
+++ b/docs/specs/spec-A-workspace-status-rename/spec.md
@@ -1,0 +1,69 @@
+# Spec: spec-A-workspace-status-rename
+
+- **Status:** Approved
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:**
+  - [RFC-0067](../../rfc/0067-session-arc-conventions-and-pack-workflow-guide.md) — driving RFC; Change A defines the rename scope, operative/historical classification, and lint gate
+  - [ADR-0054](../../adr/0054-session-arc-verb-taxonomy-and-pack-type-classification.md) — verb taxonomy and clean-retire decision
+  - [RFC-0050](../../rfc/0050-the-experience-pack.md) — clean-retire rename precedent: no install-time alias for skill/pack renames; operative references swept in the same PR (established for the design-craft → experience-design rename)
+- **Contract:** none — skill directory rename and documentation changes; no API contract.
+- **Shape:** mixed
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+A user reading or invoking the workspace-level cold-start orient skill encounters it only under its new name, `workspace-status`. Every operative reference in the repo has been updated; historical records (frozen ADR bodies, changelog entries, shipped spec bodies) are preserved as-is. The `docs/guides/_shared/how-to/author-a-skill.md` guide gains a `## Naming your skill` section embedding the verb taxonomy from ADR-0054. A lint gate over operative files returns zero `check-workspace` hits. Pack authors opening `author-a-skill.md` see the taxonomy and an intro pointer to the pack workflow design guide (Spec D).
+
+## Boundaries
+
+### Always do
+
+- Derive the full operative reference list from `git ls-files | xargs grep -l "check-workspace"` before editing, not from the RFC's illustrative list (~46 files).
+- Classify each hit as operative or historical using the RFC-0067 §Change A classification rules before rewriting.
+- Update `packs/core/pack.toml` skills array, `packs/core/.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json` in the same commit as the directory rename.
+- Rebuild projected paths via `make build-self` after all source edits, and commit the regenerated projected tree in the same PR.
+- Run the lint gate (`grep -rn "check-workspace"` scoped to the operative path set, excluding the explicit historical set) and confirm zero hits before opening the PR.
+
+### Ask first
+
+- Removing or reordering entries in the `description:` trigger list beyond the RFC-specified additions.
+- Changing the wording of the verb taxonomy table (beyond correcting a typo); the table is ADR-0054-normative.
+- Any operative file that, after inspection, appears to carry both an operative and a historical reference in the same location.
+
+### Never do
+
+- Edit frozen ADR bodies (ADR-0051, ADR-0053): their `check-workspace` references are historical records per CONVENTIONS §2.
+- Edit `docs/product/changelog.md` shipping entries that named `check-workspace` — those are dated release history.
+- Edit files under `docs/specs/` for this purpose — spec prose is excluded from the lint as spec content, not as a projected surface. (The new Draft specs spec-A..D legitimately reference `check-workspace` in their prose and are correct to exclude.)
+- Edit this RFC's own body (`docs/rfc/0067-*.md`): it is the source of the classification rules, not a target of the rename.
+- Add an alias or backward-compatibility shim for `check-workspace` — the clean retire is the decision (ADR-0054).
+
+## Testing Strategy
+
+All criteria use **goal-based check**: each corrected reference is verifiable by running a grep or diff against the oracle (the renamed source path, the verb taxonomy, or the lint gate output). No production code changes; no TDD-mode tasks.
+
+One **manual QA** step: after `make build-self`, confirm the skill appears in the projected `.claude/skills/workspace-status/` directory and is absent from `.claude/skills/check-workspace/`.
+
+## Acceptance Criteria
+
+- [ ] **AC1.** `packs/core/.apm/skills/workspace-status/SKILL.md` exists; `packs/core/.apm/skills/check-workspace/` does not.
+- [ ] **AC2.** `SKILL.md` frontmatter `name:` field reads `workspace-status`; `description:` includes all RFC-0067 §A1 trigger phrases: "workspace status", "where am I", "orient me", "session start", "what's ready", "show the queue", "what's next", and any cold-start orientation phrasing.
+- [ ] **AC3.** `packs/core/pack.toml` skills array entry updated from `check-workspace` to `workspace-status`.
+- [ ] **AC4.** `packs/core/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` updated.
+- [ ] **AC5.** Lint gate: `grep -rn "check-workspace"` over all `git ls-files` output, excluding the explicit historical set (frozen ADR-0051, ADR-0053, `docs/product/changelog.md`, `docs/specs/`, `docs/rfc/0067-*.md`), returns zero hits.
+- [ ] **AC6.** Projected path `.claude/skills/workspace-status/` exists; `.claude/skills/check-workspace/` does not.
+- [ ] **AC7.** `docs/guides/_shared/how-to/author-a-skill.md` gains a `## Naming your skill` section (after `## Body structure`) with the verb table from ADR-0054 §Decision and the banned-label list.
+- [ ] **AC8.** `author-a-skill.md` intro gains the sentence: "If you're authoring the first skill in a new pack, read [Pack workflow design](../explanation/pack-workflow-design.md) first — it tells you how to design the pack's arc before writing individual skills."
+- [ ] **AC9.** All operative references in `AGENTS.md`, `packs/core/seeds/AGENTS.md`, `packs/core/README.md`, `.claude/skills/README.md`, `docs/CONVENTIONS.md`, `docs/product/journeys/`, `docs/product/roadmap.md`, `docs/product/workspace-toml-deps.md`, `docs/product/projects/_template.md`, `docs/product/findings/README.md`, cross-pack routing references, `site/docs/`, `web/`, `docs/rfc/README.md`, and `docs/rfc/0064-ini-001-ai-native-ecosystem.md` (Draft — body editable) are updated to `workspace-status`.
+- [ ] **AC10.** `make build-check` exits 0 (no projected-path drift detected).
+- [ ] **AC11.** `docs/product/changelog.md` gains an `[Unreleased]` entry noting the rename.
+
+## Assumptions
+
+- Technical: the repo has approximately 30–46 operative `check-workspace` references at time of implementation; the exact list is derived from `git ls-files | xargs grep -l "check-workspace"` at implementation time (source: RFC-0067 §Change A).
+- Technical: `make build-self` regenerates all projected paths including `.claude/skills/`, adapter skill directories, `plugin.json`, and `marketplace.json` (source: CONVENTIONS §Pack source-of-truth split).
+- Process: frozen ADR bodies (ADR-0051, ADR-0053) contain `check-workspace` as historical record; they must not be edited (source: CONVENTIONS §2).
+- Process: `docs/rfc/0064-ini-001-ai-native-ecosystem.md` is Draft status and its body is editable (source: RFC-0067 §Change A operative reference list).

--- a/docs/specs/spec-B-pack-status-skills/plan.md
+++ b/docs/specs/spec-B-pack-status-skills/plan.md
@@ -1,0 +1,155 @@
+# Plan: spec-B-pack-status-skills
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Drafting
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn. When it changes substantially
+> (a different approach, not just a re-ordering), note why in the changelog
+> at the bottom.
+
+## Approach
+
+Pure SKILL.md authoring plus two manifest updates and one config-comment addition. No compiled code. The shape: read the existing skills in each pack to understand their SKILL.md structure, then author two new SKILL.md files following the same conventions. The riskiest task is `experience-status`'s steel-thread check logic (AC9) — it depends on all three writing skills' frontmatter conventions being verified before the skill body claims to read them.
+
+The three-task ordering: `desk-research-project-status` (T1, independent), `experience-status` (T2, reads verified frontmatter conventions), then the workspace-status routing + config update (T3, requires T2 to exist). All three can be included in one PR; T3 explicitly depends on T2.
+
+## Constraints
+
+- RFC-0067 §Change B: both skills are strictly read-only; `experience-status` uses the `agentbundle-layout.toml` config chain, no elicitation fallback.
+- ADR-0054: `status` verb = read-only orient; no state advancement.
+- CONVENTIONS §Pack source-of-truth split: SKILL.md files live under `packs/<pack>/.apm/skills/<name>/`; `make build-self` regenerates projected paths.
+- Implementation sequencing: B3 (`design` type routing) must land in the same PR as B2 (`experience-status`) so the routing entry is valid on merge.
+
+## Construction tests
+
+**Integration tests:** none beyond per-task goal-based checks.
+
+**Manual QA (cross-cutting, runs at T4):** after `make build-self`, confirm both skills appear at their projected paths and are absent if the pack is not installed.
+
+**Build gate (cross-cutting, runs at T4):** `make build-check` exits 0.
+
+## Tasks
+
+### T1: Author `desk-research-project-status` SKILL.md
+
+**Depends on:** none
+**Touches:** packs/desk-research/.apm/skills/desk-research-project-status/SKILL.md, packs/desk-research/pack.toml
+
+**Tests:**
+- Goal-based (AC1): file exists at `packs/desk-research/.apm/skills/desk-research-project-status/SKILL.md`; `name: desk-research-project-status`.
+- Goal-based (AC2): SKILL.md body reads `[research] output_dir` from the config chain; no-project branch surfaces the RFC-specified message; no phase-advancement logic present.
+- Goal-based (AC3): SKILL.md body surfaces phase, working_hypothesis, stop-signal verdict, and next-step recommendation.
+- Goal-based (AC4): `description:` field includes the required trigger phrases.
+- Goal-based (AC5): `packs/desk-research/pack.toml` `[pack.evals].skills` array includes `desk-research-project-status`.
+
+**Approach:**
+- Read `packs/desk-research/.apm/skills/desk-research-project-start/SKILL.md` to confirm the `overview.md` format (phase, working_hypothesis, stop_signal fields).
+- Read an existing `*-status` skill (`packs/governance-extras/.apm/skills/rfc-status/SKILL.md`) for structural reference.
+- Author `desk-research-project-status/SKILL.md`:
+  - `name: desk-research-project-status`
+  - `description:` with all AC4 trigger phrases
+  - Body: (1) read config chain for `[research] output_dir`; (2) check for `overview.md`; (3) no-project branch → RFC-specified message; (4) project-found branch → surface phase/working_hypothesis/stop-signal/next-step per AC3.
+- Add `desk-research-project-status` to `packs/desk-research/pack.toml` `[pack.evals].skills` array.
+
+**Done when:** AC1–AC5 hold.
+
+---
+
+### T2: Author `experience-status` SKILL.md
+
+**Depends on:** none
+**Touches:** packs/experience-design/.apm/skills/experience-status/SKILL.md, packs/experience-design/pack.toml
+
+**Tests:**
+- Goal-based (AC6): file exists; `name: experience-status`.
+- Goal-based (AC7): SKILL.md resolves `[design] output_dir` read-only; not-configured branch surfaces the RFC-specified message; no elicitation present.
+- Goal-based (AC8): SKILL.md reads frontmatter from journeys/*.md, screens/*-flow.md, blueprints/*.md.
+- Goal-based (AC9): steel-thread check logic present — journey-map → screen-flow → per-screen briefs coverage.
+- Goal-based (AC10): no-artifacts branch surfaces the journey-mapping pointer.
+- Goal-based (AC11): `description:` includes all AC11 trigger phrases.
+- Goal-based (AC12): `[pack.evals].skills` updated.
+
+**Approach:**
+- Read `packs/experience-design/.apm/skills/journey-mapping/SKILL.md`, `user-flow/SKILL.md`, `service-blueprint/SKILL.md` to confirm the `type:` frontmatter field values (customer-journey, screen-flow, service-blueprint) — these are the oracle for AC8.
+- Author `experience-status/SKILL.md`:
+  - `name: experience-status`
+  - `description:` with all AC11 trigger phrases
+  - Body: (1) resolve `[design] output_dir` from config chain (no elicitation); (2) not-configured branch → RFC-specified message; (3) found branch → read frontmatter from journeys/screens/blueprints paths; (4) steel-thread check (journey → flow → briefs coverage); (5) no-artifacts branch → journey-mapping pointer.
+- Add `experience-status` to `packs/experience-design/pack.toml` `[pack.evals].skills` array.
+
+**Done when:** AC6–AC12 hold.
+
+---
+
+### T3: Update workspace-status routing + workspace.toml schema
+
+**Depends on:** T2
+**Touches:** packs/core/.apm/skills/workspace-status/SKILL.md (or check-workspace if Spec A not yet merged), packs/core/seeds/ (workspace.toml seed comment), docs/product/workspace-toml-deps.md
+
+**Tests:**
+- Goal-based (AC13): `workspace-status` routing table contains an entry for `{type = "design"}` → `experience-status` (fallback `journey-mapping`).
+- Goal-based (AC14): workspace.toml seed comment documents `design` as a valid `shaping_queue` type.
+- Goal-based (AC15): `docs/product/workspace-toml-deps.md` updated to list `design` type.
+
+**Approach:**
+- Locate the routing table in `workspace-status` SKILL.md (or `check-workspace` if Spec A is not yet merged; note the dependency).
+- Add `design` entry to the routing table: `{type = "design"}` → `experience-status`; if experience-design pack not installed: `journey-mapping`.
+- Update the workspace.toml seed comment to document `design` alongside the existing type enum.
+- Update `docs/product/workspace-toml-deps.md`.
+
+**Done when:** AC13–AC15 hold.
+
+---
+
+### T4: Build-self + manual QA + gates
+
+**Depends on:** T1, T2, T3
+
+**Tests:**
+- Goal-based (AC16): `make build-self` exits 0; both skills appear at projected paths; `make build-check` exits 0.
+- Manual QA: projected `.claude/skills/desk-research-project-status/` and `.claude/skills/experience-status/` (or adapter-equivalent) exist after build-self.
+
+**Approach:**
+- Run `make build-self` (with `FORCE=1` if needed).
+- Confirm both skills appear at projected paths; confirm `make build-check` exits 0.
+- Run `scripts/lint-spec-status.py`; confirm `git status` clean.
+- Run adversarial review; address any Blockers.
+
+**Done when:** AC16 holds; adversarial-reviewer returns `Clean — ready to commit.`
+
+## Design (LLD)
+
+### Behavior & rules
+
+**`desk-research-project-status` resolution chain:**
+1. Read `[research] output_dir` from `agentbundle-layout.toml` (repo-root first, then user-profile).
+2. If no `output_dir` or no `<output_dir>/overview.md`: surface no-project message (AC2).
+3. If `overview.md` exists: parse `phase:`, `working_hypothesis:`, `stop_signal:` fields and surface them per AC3.
+4. Compute next-step recommendation based on current phase: capture → "run `desk-research-project-digest`", digest → "run `desk-research-project-synthesize`", synthesize → "run `desk-research-project-feedback`", feedback → "project complete."
+
+**`experience-status` resolution chain:**
+1. Read `[design] output_dir` from `agentbundle-layout.toml` (repo-root first, then user-profile).
+2. If no `output_dir`: surface not-configured message (AC7).
+3. Glob `<output_dir>/journeys/*.md`, `<output_dir>/screens/*-flow.md`, `<output_dir>/screens/<slug>/*.md` (matching `- **Type:** screen-brief` bold-body marker), `<output_dir>/blueprints/*.md`.
+4. Read `type:` frontmatter from screen-flow files; match `- **Type:** screen-brief` marker from screen-brief files.
+5. If no files at all: surface no-artifacts message (AC10).
+6. Steel-thread check (AC9):
+   - Journey map exists? (any file with `type: customer-journey`)
+   - Screen flow exists? (any file with `type: screen-flow`)
+   - Per-screen brief files exist? (any `screens/<slug>/*.md` with `- **Type:** screen-brief` marker)
+   - Journey stage action → screen-brief coverage: report as "manual check required" (deep cross-reference; not resolvable from markers alone)
+7. Report what exists, what's missing, next skill to run.
+
+## Rollout
+
+Pure source edits + build-self regeneration. No external-system dependency. B2 and B3 land in the same PR (spec Assumption, RFC-0067 §Drawbacks); B1 can ship independently or in the same PR. The `design` type is additive and backwards-compatible with existing `workspace.toml` files.
+
+## Risks
+
+- The steel-thread check in `experience-status` (AC9) may not be fully automatable if journey-stage action cross-referencing requires deep parsing. Mitigation: the spec deliberately phrases AC9 as "reports gaps" — the skill surfaces what it can check and notes what requires manual verification; it does not fail silently.
+- `desk-research-project-status` phase labels (capture/digest/synthesize/feedback) must match the phases documented in `desk-research-project-start`. Mitigation: T1 approach step 1 reads the source SKILL.md before authoring.
+
+## Changelog
+
+- 2026-07-20: initial plan, authored alongside the spec for RFC-0067 spec/plan/ADR follow-on work.

--- a/docs/specs/spec-B-pack-status-skills/spec.md
+++ b/docs/specs/spec-B-pack-status-skills/spec.md
@@ -1,0 +1,71 @@
+# Spec: spec-B-pack-status-skills
+
+- **Status:** Approved
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:**
+  - [RFC-0067](../../rfc/0067-session-arc-conventions-and-pack-workflow-guide.md) — driving RFC; Change B defines both skill contracts and the `design` type addition
+  - [ADR-0054](../../adr/0054-session-arc-verb-taxonomy-and-pack-type-classification.md) — verb taxonomy (`status` = read-only orient) and pack-type classification
+  - [Spec A](../spec-A-workspace-status-rename/spec.md) — `workspace-status` must be renamed before the routing table in this spec's B3 task is meaningful (implementation sequencing, not a hard blocker)
+- **Contract:** none — skill SKILL.md authoring; no API contract.
+- **Shape:** mixed
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+Two new `*-status` skills exist in the catalogue — `desk-research-project-status` in the desk-research pack and `experience-status` in the experience-design pack — each giving a user instant cold-start orientation into their current sustained work thread. The `design` type is recognized as a valid `shaping_queue` entry in `workspace.toml`, and the `workspace-status` routing table routes `{type = "design"}` entries to `experience-status` (falling back to `journey-mapping` if experience-design is not installed). Both new skills are read-only orient skills per ADR-0054 — they never advance state, never elicit configuration, and they surface what's missing rather than silently returning empty output.
+
+## Boundaries
+
+### Always do
+
+- Keep both skills strictly read-only: no state advancement, no config elicitation, no file writes.
+- Follow the vault-path resolution chain for each skill: `agentbundle-layout.toml` → user-profile → stop (no elicitation fallback).
+- Add each new skill to its pack's `[pack.evals].skills` allowlist in `pack.toml`.
+- Implement B2 (`experience-status`) and B3 (`design` type) in the same PR so `workspace-status` can route `design` entries to a skill that exists.
+- Run `make build-self` after source edits to regenerate projected paths.
+
+### Ask first
+
+- Changing the steel-thread check logic in `experience-status` beyond what RFC-0067 §B2 specifies (journey-map → screen-flow → per-screen briefs).
+- Changing the phase labels used by `desk-research-project-status` (capture/digest/synthesize/feedback) — these must match `desk-research-project-start`'s documented phases.
+- Adding a fallback behavior other than a "not configured" message for `experience-status` when no `[design] output_dir` is set.
+
+### Never do
+
+- Elicit config in either skill body — `experience-status` reads `[design] output_dir` read-only and surfaces "not configured" when absent; it does not prompt.
+- Advance the desk-research phase in `desk-research-project-status` — it reports the current phase, it does not call `desk-research-project-digest` or `desk-research-project-synthesize`.
+- Add a `design` workspace.toml type that routes to a skill other than `experience-status` (or its `journey-mapping` fallback) — the routing contract is RFC-0067 §B3 normative.
+- Create a standalone `workspace-resume` skill for work-loop invocation — that is Change C's scope, not this spec.
+
+## Testing Strategy
+
+All criteria use **goal-based check**: each SKILL.md is verified against the spec's behavior contract by reading it against the documented `overview.md` / artifact frontmatter / config chain. No TDD-mode tasks (skills are markdown, not compiled code). One **manual QA** step: after `make build-self`, confirm both skills appear in their projected locations.
+
+## Acceptance Criteria
+
+- [ ] **AC1.** `packs/desk-research/.apm/skills/desk-research-project-status/SKILL.md` exists with `name: desk-research-project-status`.
+- [ ] **AC2.** `desk-research-project-status` reads `overview.md` at the configured `[research] output_dir`. When no project exists (no folder + `overview.md` at `output_dir`): surfaces "No research project found — run `desk-research-project-start` for a sustained project, or `desk-research` for a one-off lookup." Does NOT advance phase.
+- [ ] **AC3.** `desk-research-project-status` surfaces: phase (capture/digest/synthesize/feedback), working hypothesis (the `working_hypothesis:` field from `overview.md` — may be empty), stop-signal verdict, and what the next step is given the current phase.
+- [ ] **AC4.** `desk-research-project-status` activation triggers include: "where are we on the X research", "status of the Y investigation", "resume the Z project", and any return-to-a-named-research-project phrasing.
+- [ ] **AC5.** `desk-research-project-status` is added to `packs/desk-research/pack.toml`'s `[pack.evals].skills` allowlist.
+- [ ] **AC6.** `packs/experience-design/.apm/skills/experience-status/SKILL.md` exists with `name: experience-status`.
+- [ ] **AC7.** `experience-status` resolves `[design] output_dir` read-only (config chain: `agentbundle-layout.toml` → user-profile → stop; no elicitation). When not configured: surfaces "No `[design] output_dir` configured — run `journey-mapping` to create your first artifact (it will set the path)."
+- [ ] **AC8.** `experience-status` reads artifact frontmatter from: `<output_dir>/journeys/*.md` (type: customer-journey), `<output_dir>/screens/*-flow.md` (type: screen-flow), `<output_dir>/screens/<slug>/*.md` (matching `- **Type:** screen-brief` bold-body marker — per-screen briefs written by `user-flow`), `<output_dir>/blueprints/*.md` (type: service-blueprint). Reports what exists, what's missing, and which skill to run next.
+- [ ] **AC9.** `experience-status` steel-thread check: does a journey map exist? Does a screen flow exist? Do per-screen brief files exist under `screens/<slug>/`? The third clause (whether all journey stage actions are covered by screen briefs) requires cross-referencing and is reported as "manual check required" if the skill cannot resolve it from frontmatter alone. Reports gaps on all three checks.
+- [ ] **AC10.** `experience-status` no-artifacts case: "No design artifacts found — run `journey-mapping` to start the design thread."
+- [ ] **AC11.** `experience-status` activation triggers include: "where are we with the design", "what experience artifacts do we have", "status of the design thread", "what's next in the design".
+- [ ] **AC12.** `experience-status` is added to `packs/experience-design/pack.toml`'s `[pack.evals].skills` allowlist.
+- [ ] **AC13.** `packs/core/.apm/skills/workspace-status/SKILL.md` routing table updated: `{type = "design"}` entries route to `experience-status` (or `journey-mapping` if experience-design is not installed).
+- [ ] **AC14.** The workspace.toml seed comment in `packs/core/seeds/` (or equivalent source) updated to include `design` as a valid `shaping_queue` type alongside the existing enum (`shape`, `research`, `strategy`, `signal`).
+- [ ] **AC15.** `docs/product/workspace-toml-deps.md` updated to reflect the `design` type addition.
+- [ ] **AC16.** `make build-self` exits 0; both skills appear at their projected paths; `make build-check` exits 0.
+
+## Assumptions
+
+- Technical: `desk-research-project-start` already writes an `overview.md` at `[research] output_dir` with `phase:`, `working_hypothesis:`, and `stop_signal:` fields — the field is `working_hypothesis:`, not `hypothesis:` (source: `packs/desk-research/.apm/skills/desk-research-project-start/SKILL.md` line 51, verified at spec-authoring time).
+- Technical: the three experience-design writing skills (`journey-mapping`, `user-flow`, `service-blueprint`) already write `type:` frontmatter: `customer-journey`, `screen-flow`, `service-blueprint` respectively — verified against their SKILL.md bodies per RFC-0067 §Evidence.
+- Technical: `agentbundle-layout.toml` is the adopter config file with `[design] output_dir` (one `[section]` per pack, one `output_dir` key per section) — the same config chain as writing skills (source: RFC-0067 §B2 and the existing vault-path pattern).
+- Process: B2 (`experience-status`) and B3 (`design` type in workspace.toml) are implemented together in one PR so the routing table addition is valid on merge (source: RFC-0067 §Drawbacks).

--- a/docs/specs/spec-C-workloop-argless-resume/plan.md
+++ b/docs/specs/spec-C-workloop-argless-resume/plan.md
@@ -1,0 +1,121 @@
+# Plan: spec-C-workloop-argless-resume
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Drafting
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn. When it changes substantially
+> (a different approach, not just a re-ordering), note why in the changelog
+> at the bottom.
+
+## Approach
+
+Two focused edits to a single SKILL.md: the `description:` frontmatter and the Step 0 body. The shape: read the current `work-loop` SKILL.md, locate the precise line ranges for the first-path auto-pick language, replace them with the three-branch logic, and update the description. Then run `make build-self` to propagate the change to the projected copy.
+
+The riskiest part is finding the exact first-path auto-pick language in the live SKILL.md (RFC-0067 references "line ~166" and "lines ~176–177", but these may have shifted since the RFC was written). The approach step must read the file before editing, not rely on the RFC's line numbers.
+
+## Constraints
+
+- RFC-0067 §Change C: the three-branch logic is normative; the "more than one active item" branch uses list-and-ask, not auto-pick by any heuristic.
+- RFC-0025: no new skill; description + body change only.
+- ADR-0054: "resume" is an activation phrase, not a skill name; this change makes `work-loop` respond to it.
+- CONVENTIONS §Pack source-of-truth split: edit the source file (`packs/core/.apm/skills/work-loop/SKILL.md` or equivalent), not the projected copy; `make build-self` propagates.
+
+## Construction tests
+
+**Integration tests:** none beyond per-task goal-based checks.
+
+**Manual QA (cross-cutting, runs at T3):**
+Three invocation scenarios to verify the three branches:
+1. `workspace.toml` with one active spec → loop begins without asking.
+2. `workspace.toml` with zero active specs → "No active spec found — run `workspace-status`..." message.
+3. `workspace.toml` with two or more active specs (or one initiative with a multi-element `.active` array) → list presented, user asked to pick.
+
+## Tasks
+
+### T1: Locate source file and exact first-path language
+
+**Depends on:** none
+**Touches:** packs/core/.apm/skills/work-loop/SKILL.md (read-only in this task)
+
+**Tests:**
+- Goal-based (precondition): the source SKILL.md file path is confirmed; the first-path auto-pick language and the singular-framing language are located at their exact line numbers before any edit.
+
+**Approach:**
+- Find the work-loop SKILL.md source path: `find packs/ -path "*/work-loop/SKILL.md"`.
+- Read Step 0 in the SKILL.md to locate:
+  - The "first path" auto-pick language (RFC-0067 references ~line 166).
+  - The singular framing language ("The active spec path tells you which spec you are expected to be working on", RFC-0067 references ~lines 176–177).
+- Note the exact line numbers for use in T2.
+
+**Done when:** source path confirmed; first-path and singular-framing language located by line number.
+
+---
+
+### T2: Edit `description:` and Step 0 body
+
+**Depends on:** T1
+**Touches:** packs/core/.apm/skills/work-loop/SKILL.md (write)
+
+**Tests:**
+- Goal-based (AC1): `description:` field includes "resume", "continue", "keep going", "pick up where I left off", "let's get going" and explicitly notes that "resume the X project" (named-project phrasing) routes to `desk-research-project-status` rather than `work-loop`.
+- Goal-based (AC2): Step 0 body contains the three-branch logic with the RFC-specified messages, gated on the argless invocation path.
+- Goal-based (AC3): the first-path auto-pick language is absent from Step 0.
+- Goal-based (AC4): the singular framing is updated to handle zero/multi-active states.
+- Goal-based (AC5): the explicit spec-path argument path is unaffected (verify by reading that conditional branch).
+- Goal-based (AC6): when `workspace.toml` is absent, Step 0 prose states the skip behavior ("no workspace.toml → PLAN begins immediately, no error").
+- Goal-based (AC7): the description or evals note that "resume the X project" (named-project phrasing) disambiguates to `desk-research-project-status`, not `work-loop`.
+
+**Approach:**
+1. **Description update:** add the five trigger phrases to the `description:` frontmatter field (integrate with existing description text; do not replace existing triggers). Add a disambiguation note: bare "resume" / "continue" / "keep going" → this skill; "resume the X project" / "resume the X investigation" (named project) → `desk-research-project-status`.
+2. **Step 0 body update:**
+   - Add explicit `workspace.toml`-absent skip prose: "If no `workspace.toml` is present in the working directory, skip this step — PLAN begins immediately with no error."
+   - Replace the existing Step 0 active-item logic (argless path only) with the three-branch implementation:
+     ```
+     Collect all active spec paths: for every ["ini-NNN"] section whose status =
+     "active", collect every path in [work].active. Then:
+     - Exactly one active item → begin the loop on that spec without asking.
+     - Zero active items → "No active spec found — run `workspace-status` to see
+       what's ready to start."
+     - More than one active item → list all active paths and ask the user to pick
+       before beginning.
+     ```
+   - Remove the first-path auto-pick language (the "first path in..." phrase).
+   - Update the singular framing to acknowledge the multi/zero-item states (e.g., "When exactly one spec is active, the active spec path tells you which spec you are expected to be working on. When zero or more than one exist, Step 0 resolves which to begin before the rest of PLAN proceeds.").
+3. Confirm the explicit-path-argument conditional (the branch where a user passes a spec path directly) is untouched.
+
+**Done when:** AC1–AC7 hold when re-reading the edited SKILL.md.
+
+---
+
+### T3: Build-self + manual QA + gates
+
+**Depends on:** T2
+**Touches:** .claude/skills/work-loop/SKILL.md (generated)
+
+**Tests:**
+- Goal-based (AC8): `make build-self` exits 0; `.claude/skills/work-loop/SKILL.md` description and Step 0 reflect the edits; `make build-check` exits 0.
+- Goal-based (AC9): `scripts/lint-spec-status.py` exits 0 on this spec.
+- Manual QA: three-scenario verification (zero/one/multi active items) as specified in Construction tests above.
+
+**Approach:**
+- Run `make build-self` (with `FORCE=1` if needed).
+- Read `.claude/skills/work-loop/SKILL.md` (projected) and confirm description and Step 0 match the source edits.
+- Run `make build-check`.
+- Run `scripts/lint-spec-status.py`.
+- Run adversarial review; address any Blockers.
+
+**Done when:** AC8 + AC9 hold; adversarial-reviewer returns `Clean — ready to commit.`
+
+## Rollout
+
+Edit to a single source SKILL.md + projected-tree rebuild. No pack manifest change (no new skill added to the skills array). No external dependency. Backward-compatible: existing `work-loop skill <path>` invocations with an explicit path argument are unaffected; only the argless (no-path-argument) case gains the three-branch behavior.
+
+## Risks
+
+- Line numbers in the RFC (~166, ~176–177) may have shifted since RFC-0067 was written. Mitigation: T1 reads the current file before editing and locates the language by content, not line number.
+- The description field update may interact with the existing `description:` content in unexpected ways if the SKILL.md uses a multi-line YAML description block. Mitigation: T1 includes reading the description field format before T2 edits it.
+
+## Changelog
+
+- 2026-07-20: initial plan, authored alongside the spec for RFC-0067 spec/plan/ADR follow-on work.

--- a/docs/specs/spec-C-workloop-argless-resume/spec.md
+++ b/docs/specs/spec-C-workloop-argless-resume/spec.md
@@ -1,0 +1,65 @@
+# Spec: spec-C-workloop-argless-resume
+
+- **Status:** Approved
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:**
+  - [RFC-0067](../../rfc/0067-session-arc-conventions-and-pack-workflow-guide.md) — driving RFC; Change C defines the description triggers, the three-branch Step 0 behavior, and the reconciliation with existing Step 0 text
+  - [RFC-0025](../../rfc/0025-work-loop-light-mode-and-risk-based-escalation.md) — no-new-skill precedent: description + body changes to `work-loop` are sufficient when no new activation surface is needed
+  - [ADR-0054](../../adr/0054-session-arc-verb-taxonomy-and-pack-type-classification.md) — "resume" is an activation phrase, not a skill name; argless work-loop resume is the correct implementation surface
+  - [Spec B](../spec-B-pack-status-skills/spec.md) — implementation sequencing: AC7's near-miss routing references `desk-research-project-status`, which Spec B creates; Spec C should ship after or with Spec B so the named skill exists
+- **Contract:** none — SKILL.md body and description edit only; no API contract.
+- **Shape:** mixed
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+A user who invokes `work-loop` without a spec path argument — or who types "resume", "continue", "keep going", "pick up where I left off", or "let's get going" — gets context-appropriate guidance without manual lookup. When exactly one spec is active across all initiatives, the loop begins on that spec. When zero specs are active, the user is pointed to `workspace-status`. When more than one spec is active, the loop lists them all and asks the user to pick. The existing "auto-pick the first path" behavior is removed. No new skill is created.
+
+## Boundaries
+
+### Always do
+
+- Implement as a description + body change to the `work-loop` SKILL.md only — per RFC-0025 no-new-skill precedent.
+- Replace the first-path auto-pick language at the affected Step 0 lines (SKILL.md ~line 166 "the first path in `["<slug>".work].active`" and lines ~176–177 singular framing) with the three-branch logic defined in RFC-0067 §Change C.
+- Apply the disambiguation behavior consistently: "more than one active item" fires whether from a single initiative's multi-element `.active` array or across multiple initiatives.
+- Keep the projected copy of `work-loop` SKILL.md in sync via `make build-self`.
+
+### Ask first
+
+- Changing the exact wording of the zero-active-items message (beyond correcting a typo relative to RFC-0067 §C).
+- Changing the disambiguation behavior for the "more than one" branch (e.g., auto-pick by initiative priority rather than list-and-ask).
+- Adding a fourth branch (e.g., handling malformed `workspace.toml` sections).
+
+### Never do
+
+- Create a new `workspace-resume` skill or any other new skill for this change — per RFC-0025 precedent and ADR-0054 (resume is an activation phrase, not a skill name).
+- Auto-pick the first path when multiple active items exist — list-and-ask is the ADR-0054-normative behavior.
+- Remove the explicit spec-path argument behavior — argless resume is an additive Step 0 branch; explicit spec arguments continue to work unchanged.
+
+## Testing Strategy
+
+All criteria use **goal-based check**: the SKILL.md body is read against the spec's three-branch contract and the removed first-path language. The change is to a markdown skill body; no compiled artifact. One **manual QA** step: invoke `work-loop` in a repo with each of the three `workspace.toml` active-item states (zero, one, multiple) and confirm the correct branch fires.
+
+## Acceptance Criteria
+
+- [ ] **AC1.** `work-loop` SKILL.md `description:` field includes all five RFC-0067 §C trigger phrases: "resume", "continue", "keep going", "pick up where I left off", "let's get going".
+- [ ] **AC2.** The three-branch logic governs only the **argless invocation path** (no spec path argument passed to `work-loop`). When `workspace.toml` is absent, the existing skip behavior is preserved: Step 0 exits silently and PLAN begins immediately, as today. When `workspace.toml` is present and the active array logic runs, the three branches are:
+  - Branch 1 (exactly one active item across all `["ini-NNN"]` sections with `status = "active"`): begin the loop on that spec without asking.
+  - Branch 2 (zero active items, `workspace.toml` present): surface "No active spec found — run `workspace-status` to see what's ready to start."
+  - Branch 3 (more than one active item, from a single initiative's multi-element `.active` array or across multiple initiatives): list all active paths and ask the user to pick before beginning.
+- [ ] **AC3.** The first-path auto-pick language is removed: the phrase "the first path in `[\"<slug>\".work].active`" (or equivalent) no longer appears in Step 0.
+- [ ] **AC4.** The singular framing ("The active spec path tells you which spec you are expected to be working on") is updated to handle the pending-user-pick state (zero or multi-item cases) — the language no longer implies exactly one active spec always exists.
+- [ ] **AC5.** Explicit spec-path argument invocations (user passes a path to `work-loop`) are unaffected — the three-branch logic is conditional on no path argument being provided.
+- [ ] **AC6.** The `workspace.toml`-absent skip behavior is explicitly preserved in the Step 0 prose: when no `workspace.toml` is present in the working directory, Step 0 does not error and PLAN begins immediately.
+- [ ] **AC7.** The work-loop `description:` field or evals near-miss cases distinguish bare "resume" / "continue" (routes to `work-loop`) from named-project phrasing "resume the X project" / "resume the X investigation" (routes to `desk-research-project-status`, not `work-loop`).
+- [ ] **AC8.** The projected copy of `work-loop` SKILL.md (`.claude/skills/work-loop/SKILL.md` and any adapter-projected equivalents) is updated via `make build-self`; `make build-check` exits 0.
+- [ ] **AC9.** `scripts/lint-spec-status.py` exits 0 on this spec.
+
+## Assumptions
+
+- Technical: `work-loop` SKILL.md's Step 0 contains the exact first-path auto-pick language at approximately lines 166 and 176–177 (source: RFC-0067 §Change C "Reconciliation" paragraph); the implementing agent must read the current SKILL.md to find the exact lines before editing.
+- Technical: the `work-loop` SKILL.md is a source file under `packs/core/.apm/skills/work-loop/` (or equivalent source path); its projected copy is regenerated by `make build-self` (source: CONVENTIONS §Pack source-of-truth split).
+- Process: no new skill is needed — per RFC-0025 precedent, a description + body change is sufficient when the change adds no new activation surface beyond work-loop itself (source: RFC-0067 §Options considered, Change C axis).

--- a/docs/specs/spec-D-pack-workflow-guide/plan.md
+++ b/docs/specs/spec-D-pack-workflow-guide/plan.md
@@ -1,0 +1,196 @@
+# Plan: spec-D-pack-workflow-guide
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Drafting
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn. When it changes substantially
+> (a different approach, not just a re-ordering), note why in the changelog
+> at the bottom.
+
+## Approach
+
+Three documentation writes: (1) the new explanation guide, (2) the CONTRIBUTING.md step 0 addition, and (3) confirming the author-a-skill.md intro link (which is Spec A's AC8 — verify Spec A has not already shipped this change before T3 runs). All three are independent — they can be done in any order and landed in one PR.
+
+The riskiest part is the guide itself: it must be written at archetype level (no individual skill name enumeration beyond examples), use the session-arc vocabulary consistently, and cover all five arc-design decisions without becoming a catalogue reference page. The ADR-0054 archetypes and verb taxonomy are the normative source for sections 2, 3, and 7.
+
+CONTRIBUTING.md step numbering: the existing steps must be renumbered (current "step 1" becomes "step 2", etc.) if the file uses numbered steps — or the step 0 is inserted as "Step 0:" if the file uses headers. Verify the file's numbering scheme before editing.
+
+## Constraints
+
+- RFC-0067 §D1: seven sections normative; section content described per RFC.
+- RFC-0067 §D2: step 0 paragraph verbatim (or equivalent); step 1 amendment sentence.
+- ADR-0054: four-type classification and verb taxonomy are normative content for sections 2 and 3.
+- No governance citations in the guide body: adopter-surface convention.
+- Spec A owns AC7 (`## Naming your skill`) and AC8 (intro link) in `author-a-skill.md`. This spec does not touch those; it authors the guide that the intro link points to.
+
+## Construction tests
+
+**Integration tests:** none.
+
+**Manual QA (cross-cutting, runs at T4):** A hypothetical new pack — e.g., a `ticketing` pack that manages issues across sessions — can be classified through the decision tree (Step 1), arc-mapped (Step 2), named (Step 3), and registered (Step 5) using only the guide. No reviewer consultation needed.
+
+## Tasks
+
+### T1: Author `pack-workflow-design.md`
+
+**Depends on:** none
+**Touches:** docs/guides/_shared/explanation/pack-workflow-design.md
+
+**Tests:**
+- Goal-based (AC1): file exists at the specified path.
+- Goal-based (AC2): all seven sections present with correct headings.
+- Goal-based (AC3): decision tree in section 2 leads to one of the four ADR-0054 types.
+- Goal-based (AC4): section 3 walks all five arc stages with guiding questions.
+- Goal-based (AC5): section 4 references verb taxonomy + banned labels; cross-links to author-a-skill.md.
+- Goal-based (AC6): section 5 covers single `output_dir` + subdirectories + cites journey-mapping.
+- Goal-based (AC7): section 6 covers `shaping_queue` type + routing + fallback.
+- Goal-based (AC8): section 7 has three worked archetypes (Episodic — product-strategy; Sustained-project — desk-research; Sustained-derived — experience-design) plus a stateless reserved-category note (no current catalogue member); no pack incorrectly labelled as stateless.
+- Goal-based (AC11): no RFC/ADR/spec citations in the guide body.
+
+**Approach:**
+
+Author the guide with the following structure:
+
+```
+# Pack workflow design
+
+## What a pack is
+[One paragraph on cohesive skill set for a role's work. Session-arc vocabulary:
+Arrive → Orient → Work → Persist → Collaborate.]
+
+## Step 1 — Characterize your workflow type
+[Decision tree: Does the pack create durable files? → Does it own those files
+or derive from them? → Is work episodic or ongoing? → Which of four types?]
+
+| Type | Description |
+| episodic | ... |
+| sustained-project | ... |
+| sustained-derived | ... |
+| stateless | ... |
+
+## Step 2 — Map the arc for your pack
+[For each arc stage, guiding questions:
+- Arrive: how does a user start a session with this pack?
+- Orient: does this pack need a *-status skill?
+- Work: which skills drive the core workflow?
+- Persist: does this pack write durable artifacts? Where?
+- Collaborate: how do artifacts from this pack feed other packs?]
+
+## Step 3 — Name your skills
+[Reference to verb taxonomy; banned labels; description-driven activation;
+cross-link to author-a-skill.md for the full table.]
+
+## Step 4 — Decide your vault-path shape
+[If your pack writes files: single output_dir base per pack (configured via
+agentbundle-layout.toml). Skill-specific subdirectories under the base.
+Canonical example: journey-mapping writes to <output_dir>/journeys/.]
+
+## Step 5 — Register with workspace-status
+[shaping_queue type for your pack's shaping items. Routing contract:
+workspace-status routes {type = "<your-type>"} to your pack's *-status skill.
+Fallback if pack not installed.]
+
+## Reference: worked archetypes
+[Three real examples per ADR-0054:
+1. Episodic — product-strategy: each skill invocation standalone; no status skill needed.
+   (converters and architect also Episodic — noted as additional examples.)
+2. Sustained-project — desk-research: project-start → check → digest → synthesize; status skill reads overview.md.
+3. Sustained-derived — experience-design: reads journeys/screens/blueprints; experience-status.
+Stateless: reserved category per ADR-0054; no current catalogue pack fits — guide notes it exists for future hypothetical packs with pure-transformation shape.]
+```
+
+**Done when:** AC1–AC8 + AC11 hold.
+
+---
+
+### T2: Add step 0 to `CONTRIBUTING.md`
+
+**Depends on:** none
+**Touches:** CONTRIBUTING.md
+
+**Tests:**
+- Goal-based (AC9): CONTRIBUTING.md gains step 0 before the current step 1 in the "Adding a new pack" section.
+- Goal-based (AC10): step 1 (now step 2, or step 1 if the file uses a different scheme) gains the arc-mapping sentence.
+
+**Approach:**
+- Read `CONTRIBUTING.md` to find the "Adding a new pack" section and its current step structure.
+- Insert step 0 before the current step 1 with the RFC-0067 §D2 paragraph content (adapted to the file's voice and formatting convention):
+  > **0. Design the pack's workflow arc first.** A pack is a set of cohesive workflows for a role's work — not a list of features. Before writing any SKILL.md, work through the pack workflow design framework at `docs/guides/_shared/explanation/pack-workflow-design.md`. It takes you through: characterizing whether your pack is episodic, sustained-project, or sustained-derived; mapping the Arrive → Orient → Work → Persist → Collaborate arc to your pack's skill set; naming your skills against the verb taxonomy; and deciding whether your pack needs a status skill, a `*-project-start` skill, and config-driven output paths. The RFC reviewers will ask these questions; answering them before you write the skill bodies saves a review cycle.
+- Add to the "Open an RFC" step: "The RFC should include your arc mapping from step 0 — which skills cover which arc stages, and why."
+- If the file uses numbered steps, renumber existing steps (step 1 → step 2, etc.) for consistency.
+
+**Done when:** AC9 + AC10 hold.
+
+---
+
+### T3: Confirm author-a-skill.md intro link exists (read-only precondition check)
+
+**Depends on:** none
+**Touches:** docs/guides/_shared/how-to/author-a-skill.md (read-only)
+
+**Tests:**
+- Coordination check: verify that Spec A has landed its AC8 (the intro link to `../explanation/pack-workflow-design.md` in `author-a-skill.md`). If Spec A is not yet shipped, this spec's PR should be sequenced after it, or Spec A and this spec ship in the same PR with Spec A owning the `author-a-skill.md` edit.
+
+**Approach:**
+- Read `docs/guides/_shared/how-to/author-a-skill.md`.
+- If the intro-link sentence is present: task is complete — Spec A has delivered AC8.
+- If absent: do NOT add it here — it is Spec A's AC8. Note in the PR description that Spec A must ship before or with this PR for the link to resolve.
+- This spec does NOT modify `author-a-skill.md`.
+
+**Done when:** The intro link exists (by Spec A's delivery). If Spec D ships before Spec A, the link is a dangling reference until Spec A lands — document this sequencing requirement in the PR.
+
+---
+
+### T4: Gates and adversarial review
+
+**Depends on:** T1, T2, T3
+
+**Tests:**
+- Goal-based (AC12): `scripts/lint-spec-status.py` exits 0; `git status` clean except intended files.
+
+**Approach:**
+- Run `scripts/lint-spec-status.py` on this spec.
+- Verify all ACs hold by re-reading the authored files.
+- Run adversarial review; address any Blockers.
+
+**Done when:** AC12 holds; adversarial-reviewer returns `Clean — ready to commit.`
+
+## Design (LLD)
+
+### Behavior & rules
+
+**Guide tone:** second-person, imperative ("Decide", "Map", "Name"), not passive. Each step produces one concrete output (a type classification, an arc map, a skill name list, a config decision, a registration entry) so the reader can check their work.
+
+**Decision tree (Step 1) structure:**
+
+```
+Does the pack create durable files that persist across sessions?
+  No → Stateless (pure transformation) or Episodic (per-invocation complete)
+       └── Does each invocation produce a standalone artifact?
+             Yes → Episodic
+             No → Stateless
+  Yes → Does this pack own those files, or derive from files another pack created?
+         Own → Sustained-project (creates and manages the project)
+         Derive → Sustained-derived (reads and extends the project)
+```
+
+**Arc-mapping questions (Step 2):**
+- Arrive: "What does a user type to open this pack's first session?"
+- Orient: "When a user returns after a break, what do they need to know? → If the answer is non-trivial, the pack needs a `*-status` skill."
+- Work: "Which one or two skills are the core workflows this pack enables?"
+- Persist: "Does the pack write files? Where? → vault-path design."
+- Collaborate: "What does the next pack in the user's workflow consume from this one?"
+
+## Rollout
+
+Pure documentation write; no pack manifest changes; no projected-tree rebuild needed. Can be merged independently of Specs A, B, and C. The CONTRIBUTING.md step 0 takes effect as soon as the PR merges — any new pack RFC opened after merge should include the arc mapping.
+
+## Risks
+
+- CONTRIBUTING.md may not have a structured "Adding a new pack" section with numbered steps. Mitigation: T2 reads the file first and adapts the step 0 insertion to the file's existing structure.
+- The guide's archetype examples reference specific pack names (product-strategy, desk-research, experience-design, converters) that may change in the future. Mitigation: the guide's archetype section labels by type name, not pack name; pack examples are illustrative ("e.g., product-strategy"), not normative.
+
+## Changelog
+
+- 2026-07-20: initial plan, authored alongside the spec for RFC-0067 spec/plan/ADR follow-on work.

--- a/docs/specs/spec-D-pack-workflow-guide/spec.md
+++ b/docs/specs/spec-D-pack-workflow-guide/spec.md
@@ -1,0 +1,66 @@
+# Spec: spec-D-pack-workflow-guide
+
+- **Status:** Approved
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:**
+  - [RFC-0067](../../rfc/0067-session-arc-conventions-and-pack-workflow-guide.md) — driving RFC; Change D defines the guide's seven sections, the CONTRIBUTING.md step 0, and the author-a-skill.md intro link
+  - [ADR-0054](../../adr/0054-session-arc-verb-taxonomy-and-pack-type-classification.md) — four-type pack classification and verb taxonomy are the normative content for the guide's archetype section
+  - [Spec A](../spec-A-workspace-status-rename/spec.md) — `author-a-skill.md` changes are Spec A's scope: AC7 is the `## Naming your skill` section; AC8 is the intro link to the guide. This spec authors the guide itself and the CONTRIBUTING.md step 0; it does not touch `author-a-skill.md`.
+- **Contract:** none — documentation authoring only; no API contract.
+- **Shape:** mixed
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+A pack author who reads `docs/guides/_shared/explanation/pack-workflow-design.md` before writing their first skill can make all five arc-design decisions (workflow type, arc-stage mapping, skill naming, vault-path shape, workspace-status registration) without consulting a reviewer. `CONTRIBUTING.md`'s "Adding a new pack" section has a step 0 that directs authors to the guide before opening an RFC. The guide is framed at archetype level (episodic/sustained-project/sustained-derived/stateless from ADR-0054) so it remains stable as new packs land.
+
+## Boundaries
+
+### Always do
+
+- Structure the guide's seven sections as specified in RFC-0067 §D1.
+- Frame every section at archetype level (ADR-0054 four-type classification), not at individual skill level — individual skill names within archetypes may change; the archetype shape does not.
+- Use the `workspace-design` session-arc vocabulary (Arrive → Orient → Work → Persist → Collaborate) as the design language throughout.
+- Cite `journey-mapping` as the canonical vault-path pattern example (RFC-0067 §D1 Step 4).
+- Add the CONTRIBUTING.md step 0 exactly as RFC-0067 §D2 specifies (verbatim paragraph + step 1 amendment).
+
+### Ask first
+
+- Restructuring the guide into more or fewer sections than the RFC-0067 §D1 seven.
+- Adding a fifth pack archetype to the guide's reference section.
+- Changing the step 0 paragraph wording in CONTRIBUTING.md beyond correcting a typo.
+
+### Never do
+
+- Touch `author-a-skill.md` in any way — all changes to that file belong to Spec A (AC7: naming section; AC8: intro link). This spec authors only the guide and the CONTRIBUTING.md step 0.
+- Include RFC/ADR/spec references in the guide body — the guide is adopter-surface content; governance citations belong in ADRs and specs (source: `feedback_no_governance_citations_in_shipped_pack_content.md`).
+- Enumerate individual skill names in the guide (beyond examples) — archetype-level framing is the stability guarantee.
+
+## Testing Strategy
+
+All criteria use **goal-based check**: each section's presence and content are verifiable by reading the guide. No compiled artifact. One **manual QA** step: a reader unfamiliar with the catalogue should be able to follow the five steps in the guide and classify a hypothetical new pack without external help.
+
+## Acceptance Criteria
+
+- [ ] **AC1.** `docs/guides/_shared/explanation/pack-workflow-design.md` exists.
+- [ ] **AC2.** The guide contains all seven RFC-0067 §D1 sections: (1) What a pack is + session-arc vocabulary, (2) Step 1 — Characterize workflow type (decision tree), (3) Step 2 — Map the arc, (4) Step 3 — Name your skills, (5) Step 4 — Decide vault-path shape, (6) Step 5 — Register with workspace-status, (7) Reference: three worked archetypes (Episodic, Sustained-project, Sustained-derived) plus a stateless reserved-category note.
+- [ ] **AC3.** Section 2 (Step 1) contains a decision tree leading to one of the four ADR-0054 types: episodic, sustained-project, sustained-derived, stateless.
+- [ ] **AC4.** Section 3 (Step 2) walks each arc stage (Arrive, Orient, Work, Persist, Collaborate) with guiding questions for the pack author.
+- [ ] **AC5.** Section 4 (Step 3) references the verb taxonomy from ADR-0054 and cites the banned-label list; it cross-links to `docs/guides/_shared/how-to/author-a-skill.md` for the full taxonomy table.
+- [ ] **AC6.** Section 5 (Step 4) covers: single `output_dir` base per pack, skill-specific subdirectories, and cites `journey-mapping` as the canonical vault-path example.
+- [ ] **AC7.** Section 6 (Step 5) covers: `shaping_queue` type, routing to `workspace-status`, and the fallback if experience-design is not installed.
+- [ ] **AC8.** Section 7 (Reference) contains worked archetypes for: Episodic (product-strategy), Sustained-project (desk-research), Sustained-derived (experience-design). Stateless: ADR-0054 classifies no current catalogue pack as stateless (converters and architect are Episodic); the guide notes this as a reserved category for hypothetical future packs with no current worked example.
+- [ ] **AC9.** `CONTRIBUTING.md` "Adding a new pack" section gains step 0 (before the current step 1) with the RFC-0067 §D2 paragraph verbatim (or equivalent in the file's voice).
+- [ ] **AC10.** `CONTRIBUTING.md` step 1 ("Open an RFC") gains the sentence: "The RFC should include your arc mapping from step 0 — which skills cover which arc stages, and why."
+- [ ] **AC11.** The guide contains no governance citations (no RFC/ADR/spec references in the guide body text) — per Diátaxis link-out discipline: explanation pages link out to reference/how-to content, not to internal governance artifacts. (Governance provenance lives in this spec's `Constrained by:` header, not in the guide.)
+- [ ] **AC12.** `scripts/lint-spec-status.py` exits 0 on this spec; `git status` clean.
+
+## Assumptions
+
+- Technical: `CONTRIBUTING.md` has an "Adding a new pack" section with numbered steps; the step 0 addition prepends before the current step 1 (source: RFC-0067 §D2 assumes this structure).
+- Technical: `docs/guides/_shared/explanation/` directory exists (source: `ls docs/guides/_shared/explanation/` confirmed at spec-authoring time — directory contains README.md, file-safety-contract.md, install-routes.md, pack-catalogue.md, shaping-a-new-engagement.md, the-three-loops.md).
+- Process: no governance citations in the guide body — the guide is adopter-surface explanation content; ADR/RFC provenance belongs in this spec's "Constrained by" header, not in the guide itself (source: `feedback_no_governance_citations_in_shipped_pack_content.md`).
+- Product: the four-type classification (ADR-0054) is stable enough to anchor the guide at archetype level; new pack archetypes will trigger an ADR-0054 revision before the guide needs updating.

--- a/workspace.toml
+++ b/workspace.toml
@@ -38,15 +38,18 @@ ready     = []
 draft     = []
 
 ["ini-002".work]
-active  = []
-shipped = ["spec/m1-workspace-core"]  # Batch 2 — workspace core ships with this file
+active  = [
+  "spec/spec-A-workspace-status-rename",
+]
+shipped = [
+  "spec/m1-workspace-core",      # Batch 2
+  "spec/m1-work-queue",          # Batch 3
+  "spec/m1-brief-queue",         # Batch 4
+  "spec/m1-governance-integration", # Batch 5
+]
 queue   = [
-  # Batch 3 — work queue end-to-end (after workspace-core)
-  {path = "spec/m1-work-queue",
-   needs = "work:spec/m1-workspace-core"},
-  # Batch 4 — brief queue end-to-end (after workspace-core, independent of Batch 3)
-  {path = "spec/m1-brief-queue",
-   needs = "work:spec/m1-workspace-core"},
-  # Batch 5 — governance integration (after Batch 1; independent of Batches 2–4)
-  "spec/m1-governance-integration",
+  # RFC-0067 follow-ons — session-arc naming + pack workflow guide
+  {path = "spec/spec-B-pack-status-skills",       needs = "work:spec/spec-A-workspace-status-rename"},
+  {path = "spec/spec-C-workloop-argless-resume",  needs = "work:spec/spec-B-pack-status-skills"},
+  {path = "spec/spec-D-pack-workflow-guide",      needs = "work:spec/spec-A-workspace-status-rename"},
 ]


### PR DESCRIPTION
## Summary

- **ADR-0054** — records the session-arc verb taxonomy (status/start/check/init/resume), four-type pack classification (episodic/sustained-project/sustained-derived/stateless), clean-retire rename decision, and argless work-loop resume routing
- **Spec A** (`spec-A-workspace-status-rename`) — renames `check-workspace` → `workspace-status` with lint gate and `author-a-skill.md` taxonomy section
- **Spec B** (`spec-B-pack-status-skills`) — adds `desk-research-project-status` and `experience-status` skills; adds `design` type to workspace.toml routing
- **Spec C** (`spec-C-workloop-argless-resume`) — adds three-branch argless resume logic to `work-loop` (zero/one/many active items); no new skill
- **Spec D** (`spec-D-pack-workflow-guide`) — authors `docs/guides/_shared/explanation/pack-workflow-design.md` and CONTRIBUTING.md step 0
- **workspace.toml** — batch 3/4/5 specs moved to `shipped`; spec-A activated; B/C/D queued with dependency gates

All four specs are `Approved` (adversarial-reviewed to clean; lint-spec-status exits 0).

## Deferred to follow-on PRs

- Implementation of each spec (tracked in workspace.toml queue/active)
- RFC-0067 §B3 `docs/product/workspace-toml-deps.md` update (covered by Spec B's AC15)

## Test plan

- [ ] `scripts/lint-spec-status.py --root .` exits 0
- [ ] `docs/adr/0054-*.md` exists and is well-formed
- [ ] All four `docs/specs/spec-{A,B,C,D}-*/spec.md` have `Status: Approved`
- [ ] `workspace.toml` `active` contains `spec-A`; B/C/D in `queue` with correct `needs` entries