### PR TITLE
fix(core): extend work-loop done-step to handle queue→shipped; add stale-queue warning; fix path-resolution bug

### DIFF
--- a/.agents/skills/work-loop/SKILL.md
+++ b/.agents/skills/work-loop/SKILL.md
@@ -166,6 +166,15 @@ Before PLAN begins, orient to the current initiative and work queue:
      - **Active spec:** the first path in `["<slug>".work].active`, if the
        array is non-empty (e.g. `"spec/m1-work-queue"`). If the array is
        empty, surface the initiative name and milestone only — no error.
+     - **Stale-queue check.** For each active initiative, for each entry in
+       `["<slug>".work].queue` and `["<slug>".work].active`: resolve the
+       path (bare string → as-is; inline object → `path` field; `slug` is
+       shaping-queue only), strip the `spec/` prefix, and read
+       `docs/specs/<slug>/spec.md`. If `**Status:**` is `Shipped` (ignoring
+       trailing `<!-- -->` comments), emit this warning and proceed — non-blocking:
+       > Warning: workspace.toml drift: `<path>` is in `<queue|active>` but
+       > spec.md shows Status: Shipped — move it to shipped in workspace.toml.
+       A path in both lists: warn once, name both. No spec.md or other Status: skip.
    - **If absent:** skip this step entirely. PLAN begins immediately with no
      error, no diagnostic, and no behavioral change.
 
@@ -174,7 +183,8 @@ Before PLAN begins, orient to the current initiative and work queue:
 
 After orienting (or immediately, if `workspace.toml` is absent), proceed
 to step 1 (PLAN). The active spec path tells you which spec you are
-expected to be working on — read `docs/specs/<path>/spec.md` and `plan.md`
+expected to be working on — strip the `spec/` prefix from the stored path
+to get the slug, then read `docs/specs/<slug>/spec.md` and `plan.md`
 as step 1 of PLAN.
 
 ### 1. PLAN — think before acting
@@ -811,14 +821,14 @@ mode below, then evaluate the terminal-state bullet last.
     Python, run `scripts/lint-spec-status.py` (this skill's sibling to
     `loop-cohort.py`) to check these mechanically — it's the agent-invoked
     companion to the judgment check; no-ops without Python.
-  - **If `workspace.toml` is present** in the working directory and
-    `["<slug>".work].active` contains the current spec's path, edit
-    `workspace.toml` in the working directory: move that path from
-    `["<slug>".work].active` to `["<slug>".work].shipped`, and stage the
-    file as part of the shipping PR diff. Use a comment-preserving edit
-    (targeted insertion or `tomlkit` if available; never a full `tomllib` +
-    `tomli_w` round-trip that strips comments). If `workspace.toml` is
-    absent, skip this step — no edit, no error.
+  - **If `workspace.toml` is present**, search each active initiative's
+    `["<slug>".work].active` then `["<slug>".work].queue` for the current
+    spec's path (stop at the first match; entries are bare strings or inline
+    objects with a `path` field — `slug` is shaping-queue only). If found,
+    move that path to `["<slug>".work].shipped` as a bare string (dropping
+    `needs` and other fields), stage the edit in this PR's diff, and use a
+    comment-preserving edit (targeted insertion or `tomlkit`; never a full
+    `tomllib` + `tomli_w` round-trip). Not found, or absent: skip — no error.
   - **Reminder:** update `docs/product/roadmap.md` to reflect the shipped
     spec (one line; the roadmap is the human-readable companion to the queue).
     If `workspace.toml` is absent, skip this reminder.

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -166,6 +166,15 @@ Before PLAN begins, orient to the current initiative and work queue:
      - **Active spec:** the first path in `["<slug>".work].active`, if the
        array is non-empty (e.g. `"spec/m1-work-queue"`). If the array is
        empty, surface the initiative name and milestone only — no error.
+     - **Stale-queue check.** For each active initiative, for each entry in
+       `["<slug>".work].queue` and `["<slug>".work].active`: resolve the
+       path (bare string → as-is; inline object → `path` field; `slug` is
+       shaping-queue only), strip the `spec/` prefix, and read
+       `docs/specs/<slug>/spec.md`. If `**Status:**` is `Shipped` (ignoring
+       trailing `<!-- -->` comments), emit this warning and proceed — non-blocking:
+       > Warning: workspace.toml drift: `<path>` is in `<queue|active>` but
+       > spec.md shows Status: Shipped — move it to shipped in workspace.toml.
+       A path in both lists: warn once, name both. No spec.md or other Status: skip.
    - **If absent:** skip this step entirely. PLAN begins immediately with no
      error, no diagnostic, and no behavioral change.
 
@@ -174,7 +183,8 @@ Before PLAN begins, orient to the current initiative and work queue:
 
 After orienting (or immediately, if `workspace.toml` is absent), proceed
 to step 1 (PLAN). The active spec path tells you which spec you are
-expected to be working on — read `docs/specs/<path>/spec.md` and `plan.md`
+expected to be working on — strip the `spec/` prefix from the stored path
+to get the slug, then read `docs/specs/<slug>/spec.md` and `plan.md`
 as step 1 of PLAN.
 
 ### 1. PLAN — think before acting
@@ -811,14 +821,14 @@ mode below, then evaluate the terminal-state bullet last.
     Python, run `scripts/lint-spec-status.py` (this skill's sibling to
     `loop-cohort.py`) to check these mechanically — it's the agent-invoked
     companion to the judgment check; no-ops without Python.
-  - **If `workspace.toml` is present** in the working directory and
-    `["<slug>".work].active` contains the current spec's path, edit
-    `workspace.toml` in the working directory: move that path from
-    `["<slug>".work].active` to `["<slug>".work].shipped`, and stage the
-    file as part of the shipping PR diff. Use a comment-preserving edit
-    (targeted insertion or `tomlkit` if available; never a full `tomllib` +
-    `tomli_w` round-trip that strips comments). If `workspace.toml` is
-    absent, skip this step — no edit, no error.
+  - **If `workspace.toml` is present**, search each active initiative's
+    `["<slug>".work].active` then `["<slug>".work].queue` for the current
+    spec's path (stop at the first match; entries are bare strings or inline
+    objects with a `path` field — `slug` is shaping-queue only). If found,
+    move that path to `["<slug>".work].shipped` as a bare string (dropping
+    `needs` and other fields), stage the edit in this PR's diff, and use a
+    comment-preserving edit (targeted insertion or `tomlkit`; never a full
+    `tomllib` + `tomli_w` round-trip). Not found, or absent: skip — no error.
   - **Reminder:** update `docs/product/roadmap.md` to reflect the shipped
     spec (one line; the roadmap is the human-readable companion to the queue).
     If `workspace.toml` is absent, skip this reminder.

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -18,6 +18,8 @@ file as stale and ask before relying on it.
 
 **M1 · Workspace Foundation.** `workspace.toml` seed + `workspace-status` skill + brief template DoR fields (Status, Rabbit holes, Instrumentation, Design artifacts) + work-loop / receive-brief / new-rfc extensions + agentbundle-layout.toml `[product]` table + ADR for D2/D4 architectural decisions. [RFC-0064](../rfc/0064-ini-001-ai-native-ecosystem.md)
 
+**M1 fix — work-loop done-step lifecycle.** Extended done-step to find the current spec in `queue` (not just `active`), add Step 0 stale-queue warning, and fix the `spec/` prefix path-resolution bug. [spec/work-loop-queue-shipped-fix]
+
 ## Next
 
 **M2 · Strategic Shaping.** Five new PE pack skills grounding the six-step sequence (Outcome → Problem → Diverge → Validate → Bet → Spec) at initiative altitude. `frame-situation` (bottom-up signal → typed finding → six-step route; embeds Wardley capability maturity for situational awareness). `identify-opportunities` (step-2 opportunity assessment; embeds JTBD framing — functional / emotional / social jobs). `diverge-solutions` (step-3 option generation; must resolve overlap with existing `explore-options` skill). `place-bet` (step-5 human commitment gate; betting table surface). `map-capabilities` (product vision → all capability areas in one structured pass). Initiative brief artifact + Lean Canvas template as altitude-0/1 framing. Three-altitude model grounded: Company (years; PRFAQ, OKR) → Initiative (quarters; vision, capability map, initiative brief) → Project (weeks; brief, spec, plan). [RFC-00XX · pe-pack-strategic-shaping, opens when M1 ships]

--- a/docs/specs/queue-add/spec.md
+++ b/docs/specs/queue-add/spec.md
@@ -1,6 +1,6 @@
 # Spec: queue-add — bridge session-surfaced items into the work queue
 
-- **Status:** Implementing <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** RFC-0064 (workspace.toml schema, D2–D9), ADR-0054 (skill-naming taxonomy — utility write-skill branch)
@@ -245,59 +245,59 @@ against the observable file diff.
 
 ## Acceptance Criteria
 
-- [ ] **Activation.** The skill triggers on "add these to the queue" / "capture
+- [x] **Activation.** The skill triggers on "add these to the queue" / "capture
   these as queue items" (and close paraphrases) when a bulleted or numbered list
   is present in context.
-- [ ] **Slug derivation & collision.** Derives a kebab-case `spec/<slug>` from
+- [x] **Slug derivation & collision.** Derives a kebab-case `spec/<slug>` from
   each item's text and confirms with the user; on collision with an existing
   `docs/specs/<slug>/` or an existing `queue`/`active`/`[backlog].open` entry,
   prompts before proceeding — never overwrites.
-- [ ] **Dependency inference.** Infers `needs` **only** from explicit sequencing
+- [x] **Dependency inference.** Infers `needs` **only** from explicit sequencing
   language, mapping to queue-prefix notation (`work:spec/<slug>`,
   `backlog:<slug>`); independent items get no `needs`.
-- [ ] **Cold-start-sufficient comments.** Every appended entry carries a comment
+- [x] **Cold-start-sufficient comments.** Every appended entry carries a comment
   block covering problem, fix, affected file/skill, and key decisions —
   sufficient for a fresh session to write the full spec. One-liners are rejected.
-- [ ] **Target initiative.** Appends to the single active initiative's
+- [x] **Target initiative.** Appends to the single active initiative's
   `[work].queue`; when more than one initiative is `active`, prompts for
   selection; never guesses.
-- [ ] **Comment-preserving write.** Uses targeted text insertion / `tomlkit`;
+- [x] **Comment-preserving write.** Uses targeted text insertion / `tomlkit`;
   existing comments in `workspace.toml` survive the write.
-- [ ] **Graceful degradation.** A missing, unparseable, or queue-less
+- [x] **Graceful degradation.** A missing, unparseable, or queue-less
   `workspace.toml` yields a named diagnostic and continues (no throw): the user
   is told the derived entries and how to add them manually.
-- [ ] **Schema respect.** Writes only the keys the schema defines for each entry
+- [x] **Schema respect.** Writes only the keys the schema defines for each entry
   shape — `path` + optional `needs` for `[work].queue` entries; `slug` +
   optional `needs`/`source` for `[backlog].open` entries — and introduces no new
   key and no numeric priority field.
-- [ ] **Prioritization.** When two or more mutually independent items are added,
+- [x] **Prioritization.** When two or more mutually independent items are added,
   elicits priority (offering a rubric — RICE / value-vs-effort / Torres /
   custom — as a prompt, not a gate) and records it as queue order + a one-line
   rationale in the group comment; skips elicitation when deps determine order or
   only one item is added.
-- [ ] **Grouping.** Appends an independent batch under a single labeled comment
+- [x] **Grouping.** Appends an independent batch under a single labeled comment
   header; folds a must-ship-together set into one atomic-bundle entry; detects a
   shaped-unit batch (shared outcome + plausible appetite) and *suggests*
   `author-brief`. Introduces no grouping field.
-- [ ] **Confirmation before write.** Presents the complete proposed change and
+- [x] **Confirmation before write.** Presents the complete proposed change and
   obtains user sign-off before writing.
-- [ ] **No spec files.** The skill writes `workspace.toml` only.
-- [ ] **Naming gate.** The skill name follows sibling-of-`author-brief`/`receive-brief`
+- [x] **No spec files.** The skill writes `workspace.toml` only.
+- [x] **Naming gate.** The skill name follows sibling-of-`author-brief`/`receive-brief`
   write-skill naming (a utility write-skill, outside the ADR-0054 session-arc
   verb taxonomy), and its activation phrases route to it end-to-end without
   colliding with `author-brief`, `receive-brief`, or `workspace-status`.
-- [ ] **Destination routing.** The skill writes only to the two homes it owns —
+- [x] **Destination routing.** The skill writes only to the two homes it owns —
   an active initiative's `[work].queue` and the repo-level `[backlog].open` —
   choosing between them by initiative scope. For any item that fits neither, it
   runs the § Grouping escalation rubric and *suggests* the right destination
   (`author-brief`, `roadmap-intents.md`, `rfc-candidates.md`, a new RFC, or a
   new initiative), deferring that write to the owning skill — never force-fitting
   an ill-matching initiative or auto-creating one.
-- [ ] **Parallelism preserved.** The skill never writes a `needs` to express a
+- [x] **Parallelism preserved.** The skill never writes a `needs` to express a
   mere priority preference; independent items remain independent so
   `workspace-status` still surfaces them as parallel candidates. Parallel-safe
   sets may be annotated in the group comment as advisory guidance.
-- [ ] **Atomic bundling.** When two or more items must ship together to avoid a
+- [x] **Atomic bundling.** When two or more items must ship together to avoid a
   broken intermediate state (e.g. a shared HARD-gate / dangling-anchor hazard),
   the skill records them as a *single* queue entry whose comment enumerates the
   coupled parts and the coupling hazard — not as separate `needs`-linked

--- a/docs/specs/work-loop-queue-shipped-fix/plan.md
+++ b/docs/specs/work-loop-queue-shipped-fix/plan.md
@@ -1,0 +1,162 @@
+# Plan: work-loop queue-to-shipped fix
+
+**Trio:**
+- Files touched: `packs/core/.apm/skills/work-loop/SKILL.md` (source), two projections, `workspace.toml`, this spec
+- Done when: updated prose handles all cases A–L2 in the spec without ambiguity; three SKILL.md copies are byte-identical; `adversarial-reviewer` returns Clean
+- Not changing: workspace-status skill, `spec/workspace-status-queue-reconciliation` queue entry, pack version numbers
+
+**Declined:**
+- Tempted to add "surface next queue item" to Step 0 — declining; done-step fix makes this a UX nice-to-have, not a correctness fix, and it duplicates workspace-status output.
+- Tempted to make Fix 2 a hard halt — declining; Step 0 is a non-blocking orientation step by contract; halting on a previous session's stale drift would gate unrelated work and is a heavier imposition than a contained diff edit.
+- Tempted to auto-move stale entries in Fix 2 — declining; auto-mutating workspace.toml in Step 0 contaminates the current session's PR diff with an out-of-scope edit.
+- Tempted to treat Archived as Shipped-equivalent — declining; Archived can mean abandoned/withdrawn and mislabels incomplete work.
+- Tempted to also fix workspace-status in the same PR — declining; separate skill, separate scope.
+
+---
+
+## Task 1 — Fix done-step in pack source (Fix 1)
+
+**Depends on:** none
+**Verification mode:** manual QA
+
+**Tests:** read the revised done-step bullet against Cases A, B, C, D, G, J, K.
+- Case A: path in queue (not active) → moved to shipped ✓
+- Case B: path in active → moved to shipped (unchanged) ✓
+- Case C/D/J: path in neither → skip, no edit ✓
+- Case G: path in active AND queue → active checked first, moved from active ✓
+- Case K: this spec's own path is in queue (added by Task 4a) → Fix 1 moves it to shipped and stages the edit in this PR's diff ✓
+
+**Approach:** in `packs/core/.apm/skills/work-loop/SKILL.md`, replace the
+done-step bullet beginning "If `workspace.toml` is present…" (~line 814).
+
+Replace:
+```
+  - **If `workspace.toml` is present** in the working directory and
+    `["<slug>".work].active` contains the current spec's path, edit
+    `workspace.toml` in the working directory: move that path from
+    `["<slug>".work].active` to `["<slug>".work].shipped`, and stage the
+    file as part of the shipping PR diff. Use a comment-preserving edit
+    (targeted insertion or `tomlkit` if available; never a full `tomllib` +
+    `tomli_w` round-trip that strips comments). If `workspace.toml` is
+    absent, skip this step — no edit, no error.
+```
+
+With:
+```
+  - **If `workspace.toml` is present** in the working directory, search each
+    active initiative's `["<slug>".work].active` and `["<slug>".work].queue`
+    for the current spec's path (check `active` before `queue` in each
+    initiative; stop at the first match). Each `[work]` entry is either a bare
+    string or an inline object with a `path` field (`slug` is a shaping-queue
+    field only and never appears in `[work]`). If found, edit `workspace.toml`:
+    move that path to `["<slug>".work].shipped` as a bare string (dropping
+    `needs` and any other fields from an object entry), and stage the file as
+    part of the shipping PR diff. Use a comment-preserving edit (targeted
+    insertion or `tomlkit` if available; never a full `tomllib` + `tomli_w`
+    round-trip that strips comments). If the path is in no initiative's lists,
+    or if `workspace.toml` is absent, skip this step — no edit, no error.
+```
+
+**Bundled fix (same file, same concern):** line 177 reads `read docs/specs/<path>/spec.md` where `<path>` is the stored active-spec value in the form `spec/<slug>` — producing a non-existent `docs/specs/spec/<slug>/spec.md` path. Fix it to: strip the `spec/` prefix from the stored path to get `<slug>`, then read `docs/specs/<slug>/spec.md`. Instruction to add inline: "(strip the leading `spec/` from the stored path to get the slug)".
+
+**Done when:** diff shows the done-step bullet change, the line-177 bundled fix, and nothing else.
+
+---
+
+## Task 2 — Add Step 0 stale-queue warning in pack source (Fix 2)
+
+**Depends on:** Task 1 (both tasks edit the same file; must be sequential to avoid a parallel-dispatch collision on `packs/core/.apm/skills/work-loop/SKILL.md`)
+**Verification mode:** manual QA
+
+**Tests:** read the reconciliation prose against Cases E, F, G (dangling queue), H, I.
+- Case E (stale queue from previous session): warning emitted, PLAN proceeds ✓
+- Case F (stale active from previous session): warning emitted, PLAN proceeds ✓
+- Case G (dangling queue entry left by Fix 1): flagged as stale on next session, PLAN proceeds ✓
+- Case H (no spec.md): silently skipped ✓
+- Case I (Status: Implementing): silently skipped ✓
+- Non-blocking confirmed: warning appears in orientation output, then PLAN begins normally ✓
+
+**Approach:** in `packs/core/.apm/skills/work-loop/SKILL.md`, inside the
+"If present" branch of Step 0 (the indented bullet block at ~lines 160–168),
+add the following as the last bullet in that block, after the Active spec line.
+The stale-check iterates every active initiative (matching the Step 0 multi-
+initiative note at `SKILL.md:172-174`):
+
+```
+     - **Stale-queue check.** For each active initiative, for each entry in
+       `["<slug>".work].queue` and `["<slug>".work].active`: resolve the entry's
+       path (bare string, or the `path` field of an inline object — `slug` is a
+       shaping-queue field only, never in `[work]`), then
+       strip its `spec/` prefix to get the slug and look up
+       `docs/specs/<slug>/spec.md`. If that file exists and its `**Status:**`
+       value is `Shipped` (ignoring any trailing `<!-- ... -->` comment), surface
+       a warning (then continue — this check is non-blocking):
+       > Warning: workspace.toml drift: `<path>` is in `<queue|active>` but
+       > spec.md shows Status: Shipped — move it to shipped in workspace.toml
+       > before starting work.
+       If a path appears in both lists, surface it once and name both. If
+       `spec.md` is absent or Status is anything other than `Shipped`, skip
+       silently.
+```
+
+This bullet sits inside the "If present" conditional, so it only runs when
+`workspace.toml` exists — matching the surrounding block's guard.
+
+**Done when:** prose handles all cases; the new bullet is inside the "If
+present" indented block and not at the outer numbered-item level.
+
+---
+
+## Task 3 — Sync projections (byte-identity)
+
+**Depends on:** Task 2 (pack source must be fully edited before projecting)
+**Verification mode:** goal-based
+
+```bash
+diff packs/core/.apm/skills/work-loop/SKILL.md .claude/skills/work-loop/SKILL.md
+diff packs/core/.apm/skills/work-loop/SKILL.md .agents/skills/work-loop/SKILL.md
+# both silent (exit 0)
+```
+
+**Done when:** both diffs exit 0.
+
+**Approach:** run `make build-self` (the canonical projection command; add `FORCE=1` if the tree is dirty). Do not hand-copy bytes — `make build-self` is the sanctioned mechanism and will catch any normalization the projection applies beyond verbatim copy.
+
+---
+
+## Task 4a — Add this spec to workspace.toml queue
+
+**Depends on:** none
+**Verification mode:** goal-based
+
+Add `"spec/work-loop-queue-shipped-fix"` to `["ini-002".work].queue`. This is
+self-validation (Case K): Fix 1 will find this entry and move it to `shipped`
+as part of the done-step at ship time, staging the move in this PR's diff.
+
+**Done when:**
+```bash
+grep "work-loop-queue-shipped-fix" workspace.toml
+# shows the entry in the queue array
+```
+
+---
+
+## Task 4b — Done-step fires in-session at ship time
+
+**Depends on:** Tasks 1, 3, 4a (done-step needs the updated skill projected and the spec in queue)
+**Verification mode:** goal-based
+
+When this PR is ready to ship, the done-step runs in-session and stages four
+changes as part of this PR's diff (all atomic):
+1. Moves `spec/work-loop-queue-shipped-fix` from `queue → shipped` in workspace.toml.
+2. Flips `- **Status:** Implementing` → `- **Status:** Shipped` in this spec file.
+3. Marks all ACs `- [x]` in this spec file.
+4. Adds a one-line entry to `docs/product/roadmap.md` per the done-step roadmap reminder.
+
+No automation post-merge, no manual edit. Leaving any one undone is a doc-drift
+invariant violation.
+
+**Done when:** final `workspace.toml` has `spec/work-loop-queue-shipped-fix` in
+`shipped` and absent from `queue`. The add-to-queue (Task 4a) and the done-step
+move land as separate commits; the aggregate diff from `main` shows the entry
+only in `shipped`.

--- a/docs/specs/work-loop-queue-shipped-fix/spec.md
+++ b/docs/specs/work-loop-queue-shipped-fix/spec.md
@@ -1,0 +1,144 @@
+# Spec: work-loop queue-to-shipped fix
+
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Mode:** full (governance boundary — modifies a core skill's observable behaviour)
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** RFC-0064 (workspace.toml schema), workspace.toml ini-002
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+Two complementary fixes to the work-loop lifecycle so a spec is never left
+dangling in `[work].queue` after its PR merges, plus a bundled fix for a
+pre-existing path-resolution bug in Step 0.
+
+**Root cause (observed with `spec/queue-add`, PR #566):** the done-step moves
+a path from `active → shipped` only when `active` holds that path. When a
+session starts work on a spec that was never moved from `queue → active`, the
+done-step condition is false and `workspace.toml` is never updated.
+
+**Fix 1 — done-step:** for each active initiative, extend the condition to
+check `active` *or* `queue`. Move from whichever list (in whichever initiative)
+holds the current spec's path. `active` is checked before `queue`. Queue
+entries in `[work]` are bare strings or inline objects with a `path` field
+(RFC-0064 `[work]` schema; `slug` is a shaping-queue field only); when an
+object entry is moved, it collapses to a bare path string in `shipped`
+(dropping `needs` and other fields).
+
+**Fix 2 — Step 0 stale-queue warning:** after reading `workspace.toml`, check
+every entry in `queue` and `active` for a `spec.md` that already reads
+`Status: Shipped`. Surface a warning line for each stale entry and **proceed
+to PLAN** — Fix 2 is advisory and non-blocking. The stale-check resolves entry
+paths for lookup and naming purposes only; it never writes to `shipped`.
+
+**Bundled fix — Step 0 line 177 path-resolution:** the existing Active-spec
+orientation line reads `docs/specs/<path>/spec.md` where `<path>` is the
+stored `spec/<slug>` value — producing the non-existent path
+`docs/specs/spec/<slug>/spec.md`. Fix: strip the `spec/` prefix before
+constructing the path, yielding `docs/specs/<slug>/spec.md`. Same resolution
+rule as Fix 2; co-located under Task 1 as a same-file, same-concern
+mechanical ride-along.
+
+**Out of scope (not in this spec):**
+- Step 0 surfacing the next unblocked queue item when `active` is empty.
+- The `spec/workspace-status-queue-reconciliation` queue entry (different
+  check, different direction — remains in the queue for separate implementation).
+
+## State transitions
+
+```
+queue ──────────────────────────────────────► shipped   (Fix 1: done-step, new path)
+queue ──► active ──────────────────────────► shipped   (existing path, unchanged)
+queue / active → stale (Shipped) ──────────► warning   (Fix 2: Step 0 warns, proceeds)
+```
+
+### Case analysis (pressure-test)
+
+| Case | Before | After Fix 1 | After Fix 2 |
+|------|--------|-------------|-------------|
+| A. Spec starts in `queue`, session works it, done-step fires | queue stays; workspace.toml not updated ❌ | moved to shipped ✓ | — |
+| B. Spec moved to `active` before work (existing behaviour) | moved to shipped ✓ | unchanged ✓ | — |
+| C. Spec in neither `active` nor `queue` | done-step skipped ✓ | unchanged ✓ | — |
+| D. `workspace.toml` absent | done-step skipped ✓ | unchanged ✓ | — |
+| E. Stale `queue` entry from a previous session | stays in queue across sessions ❌ | not caught at Step 0 | warning emitted; PLAN proceeds; user cleans up ✓ |
+| F. Stale `active` entry from a previous session | stays in active across sessions ❌ | not caught at Step 0 | warning emitted; PLAN proceeds; user cleans up ✓ |
+| G. Spec in both `active` and `queue` (invariant violation) | active → shipped; queue dangling | active checked first → moved from active; queue entry remains | dangling queue entry flagged by stale-queue warning on next session ✓ |
+| H. Path in queue but no `spec.md` exists yet | — | — | silently skipped (spec not yet started) ✓ |
+| I. Path in queue, `spec.md` exists, Status: Implementing | — | — | silently skipped (still in-flight) ✓ |
+| J. Done-step fires, spec already in `shipped` | done-step skips (not in active) ✓ | not in active or queue → skips ✓ | — |
+| K. This spec itself (`spec/work-loop-queue-shipped-fix`) ships | n/a | Fix 1 finds it in `queue` (added by Task 4a) → moves to shipped ✓ | — |
+| L1. Current spec stored as inline object `{path = "spec/work-loop-queue-shipped-fix", needs = ...}` | — | path extracted from `path` field; moved to `shipped` as bare string; `needs` dropped ✓ | — |
+| L2. Stale inline-object entry from a previous session `{path = "spec/foo", needs = ...}` | — | — (not the current spec) | warning emitted using resolved path from `path` field ✓ |
+
+Case K is deliberate self-validation: this spec's path is added to
+`workspace.toml` queue (Task 4a) so Fix 1 moves it to `shipped` as part of
+this PR's diff, proving the fix works end-to-end.
+
+## Acceptance Criteria
+
+- [x] AC1. Done-step: if the current spec's path is in `["<slug>".work].queue`
+  (and not in `active`), the done-step moves it from `queue → shipped` and
+  stages the edit as part of this PR's diff (Cases A, K).
+- [x] AC2. Done-step: existing `active → shipped` path is unchanged (Case B).
+- [x] AC3. Done-step: if the path is in neither list, the step is skipped with
+  no edit and no error (Cases C, D, J).
+- [x] AC4. Done-step: `active` is checked before `queue`; a path found in
+  `active` is moved from there (Case G partial cleanup).
+- [x] AC5. Step 0: for each active initiative, any entry in `queue` or `active`
+  whose corresponding spec.md already has `Status: Shipped` produces a
+  non-blocking `Warning:` line naming the path and which list(s) it was found
+  in; PLAN proceeds immediately after. Entries with no spec.md, or any other
+  Status value, produce no output. The resolution algorithm (how queue entry
+  paths map to filesystem paths, bare-string vs inline-object handling,
+  trailing-comment stripping) is in plan Task 2.
+- [x] AC6. Done-step: when an inline object entry (`{path = ..., needs = ...}`)
+  is moved to `shipped` by the done-step, it is written as a bare path string
+  (dropping `needs` and other fields), consistent with existing `shipped`
+  entries (Cases L1).
+- [x] AC7. Bundled fix: Step 0's Active-spec orientation correctly resolves
+  `docs/specs/<slug>/spec.md` by stripping the `spec/` prefix from the stored
+  path value (e.g. stored `spec/m1-work-queue` → reads `docs/specs/m1-work-queue/spec.md`).
+- [x] AC8. All three `SKILL.md` copies are byte-identical after the change:
+  `.claude/skills/work-loop/SKILL.md`, `.agents/skills/work-loop/SKILL.md`,
+  `packs/core/.apm/skills/work-loop/SKILL.md`.
+
+## Boundaries
+
+**Touches:**
+- `packs/core/.apm/skills/work-loop/SKILL.md` (source of truth; includes bundled fix to line 177 path-resolution)
+- `docs/product/roadmap.md` (one line added by the done-step roadmap reminder when this spec ships)
+- `.claude/skills/work-loop/SKILL.md` (projection — sync from pack source)
+- `.agents/skills/work-loop/SKILL.md` (projection — sync from pack source)
+- `workspace.toml` — add `spec/work-loop-queue-shipped-fix` to queue (Task 4a); done-step moves it to shipped in this PR's diff (Task 4b)
+- `docs/specs/queue-add/spec.md` — Status flipped to Shipped, all ACs checked; this is the spec that triggered the bug (PR #566 merged without workspace.toml update). Closing out that drift is an intentional dogfood cleanup of the exact failure mode this PR fixes — not a new scope item.
+- This spec file and plan.md
+
+**Never:**
+- Block PLAN or halt the session based on stale-queue findings (Fix 2 is advisory)
+- Auto-move any workspace.toml entry in Step 0 (warn only; stale-check never writes)
+- Add a new bucket to `[work]` (no `archived` or `stale` array)
+- Add a new dependency to the pack
+
+**Ask first:**
+- Any change to the workspace-status skill
+- Any change to `spec/workspace-status-queue-reconciliation` queue entry
+- Pack version bump (doc-only change here; release is a separate decision)
+
+## Testing strategy
+
+Manual QA — there are no unit tests for skill markdown. Verification:
+1. Walk each Case A–L2 against the updated skill prose. Every case must be
+   handled unambiguously by the text. L1 verifies inline-object field-dropping
+   (AC6); L2 verifies stale-check path resolution from an object's `path` field
+   without writing (Fix 2 warn-only boundary).
+2. Walk Step 0's orientation prose: confirm the bundled fix makes stored path
+   `spec/<slug>` resolve to `docs/specs/<slug>/spec.md`, not
+   `docs/specs/spec/<slug>/spec.md` (AC7).
+3. `diff` the three SKILL.md copies to confirm byte-identity (exit 0).
+4. Confirm `spec/work-loop-queue-shipped-fix` is in `workspace.toml` `shipped`
+   and absent from `queue` in the final merged state (Case K self-validation).
+   The add-to-queue and queue→shipped move land as separate commits; the
+   aggregate diff from `main` shows the entry only in `shipped`.

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -166,6 +166,15 @@ Before PLAN begins, orient to the current initiative and work queue:
      - **Active spec:** the first path in `["<slug>".work].active`, if the
        array is non-empty (e.g. `"spec/m1-work-queue"`). If the array is
        empty, surface the initiative name and milestone only — no error.
+     - **Stale-queue check.** For each active initiative, for each entry in
+       `["<slug>".work].queue` and `["<slug>".work].active`: resolve the
+       path (bare string → as-is; inline object → `path` field; `slug` is
+       shaping-queue only), strip the `spec/` prefix, and read
+       `docs/specs/<slug>/spec.md`. If `**Status:**` is `Shipped` (ignoring
+       trailing `<!-- -->` comments), emit this warning and proceed — non-blocking:
+       > Warning: workspace.toml drift: `<path>` is in `<queue|active>` but
+       > spec.md shows Status: Shipped — move it to shipped in workspace.toml.
+       A path in both lists: warn once, name both. No spec.md or other Status: skip.
    - **If absent:** skip this step entirely. PLAN begins immediately with no
      error, no diagnostic, and no behavioral change.
 
@@ -174,7 +183,8 @@ Before PLAN begins, orient to the current initiative and work queue:
 
 After orienting (or immediately, if `workspace.toml` is absent), proceed
 to step 1 (PLAN). The active spec path tells you which spec you are
-expected to be working on — read `docs/specs/<path>/spec.md` and `plan.md`
+expected to be working on — strip the `spec/` prefix from the stored path
+to get the slug, then read `docs/specs/<slug>/spec.md` and `plan.md`
 as step 1 of PLAN.
 
 ### 1. PLAN — think before acting
@@ -811,14 +821,14 @@ mode below, then evaluate the terminal-state bullet last.
     Python, run `scripts/lint-spec-status.py` (this skill's sibling to
     `loop-cohort.py`) to check these mechanically — it's the agent-invoked
     companion to the judgment check; no-ops without Python.
-  - **If `workspace.toml` is present** in the working directory and
-    `["<slug>".work].active` contains the current spec's path, edit
-    `workspace.toml` in the working directory: move that path from
-    `["<slug>".work].active` to `["<slug>".work].shipped`, and stage the
-    file as part of the shipping PR diff. Use a comment-preserving edit
-    (targeted insertion or `tomlkit` if available; never a full `tomllib` +
-    `tomli_w` round-trip that strips comments). If `workspace.toml` is
-    absent, skip this step — no edit, no error.
+  - **If `workspace.toml` is present**, search each active initiative's
+    `["<slug>".work].active` then `["<slug>".work].queue` for the current
+    spec's path (stop at the first match; entries are bare strings or inline
+    objects with a `path` field — `slug` is shaping-queue only). If found,
+    move that path to `["<slug>".work].shipped` as a bare string (dropping
+    `needs` and other fields), stage the edit in this PR's diff, and use a
+    comment-preserving edit (targeted insertion or `tomlkit`; never a full
+    `tomllib` + `tomli_w` round-trip). Not found, or absent: skip — no error.
   - **Reminder:** update `docs/product/roadmap.md` to reflect the shipped
     spec (one line; the roadmap is the human-readable companion to the queue).
     If `workspace.toml` is absent, skip this reminder.

--- a/workspace.toml
+++ b/workspace.toml
@@ -59,29 +59,11 @@ shipped = [
   "spec/m1-governance-integration", # Batch 5
   "spec/spec-A-workspace-status-rename", # RFC-0067 Change A
   "spec/new-rfc-followon-queue-write",
+  "spec/queue-add",              # PR #566
+  "spec/work-loop-queue-shipped-fix", # Fix done-step + stale-queue warning + line-177 path bug
 ]
 queue   = [
-  # Independent track — no deps; ship in parallel with spec-A now
-
-  # New skill in core pack. Gap: no skill bridges items surfaced in a session
-  # (follow-ons, findings, recommendations) to workspace.toml without a manual
-  # prompt to another session. Activation phrase: "add these to the queue" or
-  # "capture these as queue items" + a bulleted/numbered list in context.
-  # Behaviour: derive spec/<slug> paths from list item text, infer needs deps
-  # from explicit sequencing language in the list ("after X", "depends on Y"),
-  # append to [work].queue of the active initiative (or ask if >1 active).
-  # Verb: queue-add follows core pack write-skill convention (author-brief,
-  # receive-brief). Does not create spec files — writes workspace.toml only.
-  # CRITICAL output constraint: comments written per entry must be rich enough
-  # for a cold-start session to write a full spec without revisiting the
-  # originating session — problem, fix, affected file/skill, key decisions.
-  # One-liner comments are not sufficient (observed: this session's initial
-  # entries needed expansion before a new session could act on them).
-  # Canonical naming gate: before shipping, verify skill name against ADR-0054
-  # verb taxonomy (session-arc skills) or core pack write-skill convention
-  # (utility skills); verify activation phrases trigger correctly end-to-end.
-  # User reviews all entries before committing.
-  "spec/queue-add",
+  # Independent track — no deps
 
   # Errata entry in docs/rfc/0064-ini-001-ai-native-ecosystem.md. Doc only.
   # Trust boundary: workspace-status is only as complete as queue population.


### PR DESCRIPTION
## Summary

- **Root cause:** `work-loop` done-step only checked `[work].active`, so specs worked directly from `queue` (never moved to `active`) were silently left dangling in workspace.toml after merge. `spec/queue-add` (PR #566) was the observed instance.
- **Fix 1 — done-step:** search each active initiative's `active` *then* `queue`; stop at first match; move to `shipped` as bare string (dropping `needs` from inline-object entries).
- **Fix 2 — Step 0 stale-queue warning:** non-blocking warning when a queued/active entry's `spec.md` already shows `Status: Shipped`; PLAN proceeds immediately after.
- **Bundled fix:** strip `spec/` prefix from stored active-spec path before constructing `docs/specs/<slug>/spec.md` (was producing non-existent `docs/specs/spec/<slug>/spec.md`).

Three SKILL.md copies are byte-identical. Case K self-validation: `spec/work-loop-queue-shipped-fix` was added to `queue` (Task 4a) and this diff moves it to `shipped`, proving Fix 1 works end-to-end.

Also closes out the queue-add spec drift (`docs/specs/queue-add/spec.md`) — the deliberate dogfood cleanup of the PR #566 lifecycle gap that triggered this fix.

**Spec:** `docs/specs/work-loop-queue-shipped-fix/spec.md` (Status: Shipped, all 8 ACs ✓)
**Adversarial review:** passed (12 passes over previous session; final clean pass this session after Task 4b).

## Test plan

- [ ] Walk Cases A–L2 from `docs/specs/work-loop-queue-shipped-fix/spec.md` against updated SKILL.md done-step and stale-queue prose — all cases handled unambiguously
- [ ] Three SKILL.md copies byte-identical: `diff packs/core/.apm/skills/work-loop/SKILL.md .claude/skills/work-loop/SKILL.md` exits 0; same for `.agents/` copy
- [ ] `spec/work-loop-queue-shipped-fix` appears in `["ini-002".work].shipped` and is absent from `queue` in workspace.toml (Case K)
- [ ] `make build-check` green (skill-spec lint passes, spec metadata clean)

## Deferred

- `spec/workspace-status-queue-reconciliation` — detects the opposite direction (Approved/Implementing specs absent from queue entirely); remains in queue for separate implementation.