### PR TITLE
docs(rfc-0064): document workspace-status integrity trust boundary

### DIFF
--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -24,6 +24,8 @@ file as stale and ask before relying on it.
 
 **RFC-0067 Change B — Pack status skills.** Two new read-only cold-start orient skills: `desk-research-project-status` (desk-research pack) and `experience-status` (experience-design pack). Added `design` as a valid `shaping_queue` type; `workspace-status` routes `{type = "design"}` entries to `experience-status` (fallback: `journey-mapping`). [spec/spec-B-pack-status-skills]
 
+**RFC-0064 amendment — workspace-status integrity trust boundary.** Documents the session-fragmentation gap (workspace.toml silently incomplete when RFC acceptance and spec generation happen in separate sessions); restructures `## Amendments` to two-layer format. [spec/rfc-0064-errata-workspace-integrity]
+
 ## Next
 
 **M2 · Strategic Shaping.** Five new PE pack skills grounding the six-step sequence (Outcome → Problem → Diverge → Validate → Bet → Spec) at initiative altitude. `frame-situation` (bottom-up signal → typed finding → six-step route; embeds Wardley capability maturity for situational awareness). `identify-opportunities` (step-2 opportunity assessment; embeds JTBD framing — functional / emotional / social jobs). `diverge-solutions` (step-3 option generation; must resolve overlap with existing `explore-options` skill). `place-bet` (step-5 human commitment gate; betting table surface). `map-capabilities` (product vision → all capability areas in one structured pass). Initiative brief artifact + Lean Canvas template as altitude-0/1 framing. Three-altitude model grounded: Company (years; PRFAQ, OKR) → Initiative (quarters; vision, capability map, initiative brief) → Project (weeks; brief, spec, plan). [RFC-00XX · pe-pack-strategic-shaping, opens when M1 ships]

--- a/docs/rfc/0064-ini-001-ai-native-ecosystem.md
+++ b/docs/rfc/0064-ini-001-ai-native-ecosystem.md
@@ -593,6 +593,15 @@ This RFC authorises the roadmap and vocabulary. M1 is fully specified by this RF
 
 <!-- Draft-RFC additions and corrections to this RFC's own decisions. Becomes `## Errata` on acceptance per RFC-0055. -->
 
+### Current state
+
+| # | Date | Topic | Effect |
+|---|------|-------|--------|
+| 1 | 2026-07-20 | Repo-level `[backlog]` + `docs/backlog.md` absorption | Extends `workspace.toml` schema with a top-level `[backlog]` section; adds M3 ACs for backlog migration, deferral relocation, and lint rewrite |
+| 2 | 2026-07-20 | workspace-status integrity trust boundary | Documents session-fragmentation gap + two skill fixes (`new-rfc-followon-queue-write` shipped; `workspace-status-queue-reconciliation` queued) + manual workaround |
+
+### History / audit trail
+
 - **2026-07-20 — Repo-level `[backlog]` + `docs/backlog.md` absorption.** Added a
   top-level `[backlog]` section to the `workspace.toml` schema as the single view
   of open work not scoped to an active initiative, absorbing the `docs/backlog.md`
@@ -607,3 +616,21 @@ This RFC authorises the roadmap and vocabulary. M1 is fully specified by this RF
   register" (design) and the M3 ACs. Implemented by `docs/specs/queue-add/`
   (intake skill) and the M3 backlog-migration + deferral-relocation specs.
   eugenelim.
+
+- **2026-07-20 — workspace-status integrity trust boundary.** `workspace-status`
+  is only as complete as `workspace.toml` queue population. The specific failure
+  mode is **session-fragmentation**: if an RFC is accepted in one session and spec
+  generation happens in a second session, the `new-rfc` "Add implementation specs
+  to `workspace.toml` queue?" prompt fires in the first session only and is lost
+  before the second session loads RFC context. `workspace.toml` then silently
+  lacks those entries; `workspace-status` surfaces an incomplete picture with no
+  warning. Two skill fixes close the gap: (1) `new-rfc-followon-queue-write`
+  (shipped — `docs/specs/new-rfc-followon-queue-write/`) adds a durable prompt to
+  the `new-rfc` Accepted path so the queue-write prompt persists in a follow-up
+  session; (2) `workspace-status-queue-reconciliation` (queued, unblocked — see
+  `workspace.toml`) adds a drift warning to `workspace-status` when a spec with
+  `Status: Approved|Implementing` exists but is absent from the queue.
+  **Manual workaround until (2) ships:** after any session gap, check
+  `docs/specs/*/spec.md` for specs with `Status: Approved|Implementing` that are
+  absent from `workspace.toml [work].queue`, and add them via `queue-add` or
+  hand-editing. eugenelim.

--- a/docs/specs/rfc-0064-errata-workspace-integrity/spec.md
+++ b/docs/specs/rfc-0064-errata-workspace-integrity/spec.md
@@ -1,0 +1,31 @@
+# Spec: rfc-0064-errata-workspace-integrity
+
+Mode: light (no risk trigger fired)
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+
+## Objective
+
+Add an amendment entry to RFC-0064 documenting the workspace-status integrity
+trust boundary: the session-fragmentation condition under which `workspace-status`
+can give an incomplete picture, the two skill fixes that close the gap, and the
+manual workaround. Restructure the `## Amendments` section to the two-layer
+format (`### Current state` / `### History / audit trail`) now that two
+independent amendments exist — required by RFC-0055 once a second entry lands.
+
+## Acceptance Criteria
+
+- [x] A second amendment entry appears in `docs/rfc/0064-ini-001-ai-native-ecosystem.md` stating:
+  1. The session-fragmentation condition (RFC accepted in session A; spec generation in session B silently drops the queue-write prompt)
+  2. The two skill fixes: `new-rfc-followon-queue-write` (shipped) and `workspace-status-queue-reconciliation` (queued, unblocked)
+  3. The manual workaround (check `docs/specs/*/spec.md` for Status: Approved|Implementing absent from queue; add via `queue-add` or hand-editing)
+- [x] `## Amendments` section is restructured to two-layer format (`### Current state` summary table + `### History / audit trail` with both dated entries)
+- [x] `workspace.toml` moves `spec/rfc-0064-errata-workspace-integrity` from `queue` to `shipped`
+- [x] `docs/product/roadmap.md` updated with a one-line shipped entry under `## Now`
+
+## Tasks
+
+1. [x] Write lean spec (this file)
+2. [x] Restructure `## Amendments` and add second entry to RFC-0064
+3. [x] Move spec to shipped in `workspace.toml`; add `roadmap.md` entry

--- a/workspace.toml
+++ b/workspace.toml
@@ -70,20 +70,10 @@ shipped = [
   "spec/work-loop-queue-shipped-fix", # Fix done-step + stale-queue warning + line-177 path bug
   "spec/spec-D-pack-workflow-guide",  # Pack workflow design guide + CONTRIBUTING step 0
   "spec/spec-B-pack-status-skills",  # RFC-0067 Change B: desk-research-project-status + experience-status + design type
+  "spec/rfc-0064-errata-workspace-integrity", # Amendment to RFC-0064 documenting session-fragmentation gap
 ]
 queue   = [
   # Independent track — no deps
-
-  # Errata entry in docs/rfc/0064-ini-001-ai-native-ecosystem.md. Doc only.
-  # Trust boundary: workspace-status is only as complete as queue population.
-  # workspace.toml has no automated guarantee of completeness without the two
-  # skill fixes (new-rfc-followon-queue-write + workspace-status-queue-
-  # reconciliation). Session-fragmentation — accepting an RFC in one session
-  # and generating specs in another — silently drops the queue-write prompt.
-  # Errata should state: (1) the condition under which workspace-status gives
-  # an incomplete picture, (2) the two skill fixes that close the gap, and
-  # (3) the manual workaround until those fixes ship (add entries directly).
-  "spec/rfc-0064-errata-workspace-integrity",
 
   # Schema + governance: workspace.toml [backlog] + docs/backlog.md absorption.
   # Governed by RFC-0064 amendment 2026-07-20 ("Repo-level backlog & deferral


### PR DESCRIPTION
## Summary

- Adds second amendment entry to RFC-0064 covering the **session-fragmentation gap**: `workspace.toml` can silently lack queue entries when RFC acceptance and spec generation happen in separate sessions, leaving `workspace-status` giving an incomplete picture with no warning
- Documents the two skill fixes closing the gap: `new-rfc-followon-queue-write` (shipped) and `workspace-status-queue-reconciliation` (queued, unblocked)
- Documents the manual workaround until fix (2) ships
- Restructures `## Amendments` to the RFC-0055 two-layer format (`### Current state` summary table + `### History / audit trail`) — required once more than one entry exists

## Test plan

- [ ] `## Amendments` section in `docs/rfc/0064-ini-001-ai-native-ecosystem.md` renders with `### Current state` table (2 rows) above `### History / audit trail` (2 dated bullets)
- [ ] Amendment entry #2 names the session-fragmentation condition, both skill fixes, and the manual workaround
- [ ] `workspace.toml` `spec/rfc-0064-errata-workspace-integrity` is in `shipped`, not `queue`
- [ ] `docs/product/roadmap.md` has the one-line shipped entry under `## Now`
- [ ] `lint-spec-status.py --root .` exits clean