### PR TITLE
docs(guides): pack workflow design guide + CONTRIBUTING step 0 (RFC-0067 Change D)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,9 @@ A new pack is a coherent slice — a workflow, a reviewer lens, a document shape
 
 Steps:
 
-1. **Open an RFC.** New packs need RFC review — the contract surface is published, not internal. See [`docs/rfc/`](docs/rfc/) for the template and recent precedents (RFC-0004 added install-scope-per-pack; RFC-0007 added the user-scope converter pack).
+0. **Design the pack's workflow arc first.** A pack is a set of cohesive workflows for a role's work — not a list of features. Before writing any `SKILL.md`, work through the pack workflow design framework at [`docs/guides/_shared/explanation/pack-workflow-design.md`](docs/guides/_shared/explanation/pack-workflow-design.md). It takes you through: characterizing whether your pack is episodic, sustained-project, or sustained-derived; mapping the Arrive → Orient → Work → Persist → Collaborate arc to your pack's skill set; naming your skills against the verb taxonomy; and deciding whether your pack needs a status skill, a `*-project-start` skill, and config-driven output paths. The RFC reviewers will ask these questions; answering them before you write the skill bodies saves a review cycle.
+
+1. **Open an RFC.** New packs need RFC review — the contract surface is published, not internal. See [`docs/rfc/`](docs/rfc/) for the template and recent precedents (RFC-0004 added install-scope-per-pack; RFC-0007 added the user-scope converter pack). The RFC should include your arc mapping from step 0 — which skills cover which arc stages, and why.
 2. **Create `packs/<your-pack>/`** with the directory shape:
    - `pack.toml` — manifest. Conforms to [`docs/contracts/pack.schema.json`](docs/contracts/pack.schema.json). Required tables: `[pack]`, `[pack.adapter-contract]`, `[pack.install]`. Cross-field invariant `default-scope ∈ allowed-scopes` is schema-enforced.
    - `.apm/` — upstream for adapter-projected primitives (`skills/`, `agents/`, `hooks/`, `commands/`, `hook-wiring/`).

--- a/docs/guides/_shared/explanation/pack-workflow-design.md
+++ b/docs/guides/_shared/explanation/pack-workflow-design.md
@@ -1,5 +1,185 @@
 # Pack workflow design
 
-> **Stub — full content coming in Spec D (`spec-D-pack-workflow-guide`).**
->
-> This guide will document the session-arc framework for pack authors: how to decide whether your pack needs a `*-status` skill, a `*-start` skill, a vault-path pattern, or none of these — using the four-type pack classification from [ADR-0054](../../../adr/0054-session-arc-verb-taxonomy-and-pack-type-classification.md).
+## What a pack is
+
+A pack is a cohesive set of skills for a role's work — all the workflows one kind of specialist needs, bundled as a single installable unit. Before you write your first `SKILL.md`, work through the five steps below. Each one produces a concrete decision that feeds the next.
+
+The design vocabulary throughout is the **session arc**: the five stages every sustained professional tool must support —
+
+- **Arrive** — start a new session
+- **Orient** — understand where you are and what comes next
+- **Work** — drive the core workflow
+- **Persist** — save durable artifacts across sessions
+- **Collaborate** — hand off to the next stage or pack
+
+The arc is the skeleton your skills hang on. Not every pack covers every stage; the decision tree in Step 1 tells you which stages apply.
+
+## Step 1 — Characterize your workflow type
+
+Walk this decision tree to identify your pack's type:
+
+```
+Does the pack maintain a work-in-progress thread across sessions —
+tracking phases, a growing project, or cumulative state?
+│
+├─ No → Does each invocation produce a standalone artifact
+│        that the user takes away?
+│        ├─ Yes → Episodic
+│        └─ No  → Stateless
+│
+└─ Yes → Does this pack create and own the project thread,
+         or derive from a thread another pack owns?
+          ├─ Own    → Sustained-project
+          └─ Derive → Sustained-derived
+```
+
+| Type | Shape | Typical session |
+| --- | --- | --- |
+| **Episodic** | No persistent state between sessions | Each skill invocation is standalone; a completed artifact is the output |
+| **Sustained-project** | Creates and manages a durable project | Session opens a thread; a status skill orients the return; pack drives the thread to completion |
+| **Sustained-derived** | Reads from and builds on a project another pack owns | Session reads from a source project; adds derived artifacts |
+| **Stateless** | Pure workflow transformation; no file-system output | Input → transformation → output; nothing persists |
+
+**Output from this step:** your pack type. Write it down before moving to Step 2.
+
+## Step 2 — Map the arc for your pack
+
+For each arc stage, answer the guiding question. Your answers define which skills your pack needs and which it can safely skip.
+
+**Arrive — "What does a user type to open this pack's first session?"**
+Name the skill that kicks things off. For a sustained-project pack, this is your `*-project-start` skill. For an episodic pack, it is the first substantive skill — there is no session state to initialize.
+
+**Orient — "When a user returns after a break, what do they need to know?"**
+If the answer is non-trivial (where a project stands in its lifecycle, what was decided, what comes next), your pack needs a `*-status` skill. Episodic packs skip this stage: there is no persistent thread to orient to.
+
+**Work — "Which one or two skills are the core workflows this pack enables?"**
+Name them. These are the skills that do the pack's primary work — the reason a user installs it.
+
+**Persist — "Does the pack accumulate a project directory across sessions?"**
+If yes, design the vault-path shape in Step 4. An episodic pack may write a standalone artifact per invocation, but it does not build up a shared project directory over time — skip Step 4 for episodic and stateless packs.
+
+**Collaborate — "What does the next pack in the user's workflow consume from this one?"**
+Name the artifact type and file shape another pack might read. A sustained-derived pack depends on this being well-defined by the pack it derives from.
+
+**Output from this step:** an arc map — one row per stage, naming the skill (or "none") and the artifact (or "none").
+
+## Step 3 — Name your skills
+
+Skill activation is description-driven — users invoke skills by natural language, not exact names. But names appear in the catalogue and in `SKILL.md` frontmatter, and a consistent verb vocabulary lets users predict what to type.
+
+Use the five-verb taxonomy to pick the right name:
+
+| Verb | Meaning | Activation phrasing |
+| --- | --- | --- |
+| `status` | Orient — "where am I / what's next?" | Cold-start phrases, "what's on today", "orient me" |
+| `start` | Create/begin a sustained project | "start a research project", "kick off an investigation" |
+| `check` | Quality/health read — "is it good / saturated / done?" | "is this ready", "should I keep gathering" |
+| `init` | Repo-scaffold only | `init-project`, `adapt-to-project`; cf. `git init` |
+| `resume` | Return to prior work | Activation phrase — not a skill name |
+
+**Banned as skill names:** `arrive`, `orient`, `onboard`, `return`, `onboarding` — these are UX-stage labels, not user-facing commands. Using them as skill names causes activation collisions with the arc vocabulary users already know.
+
+For the full taxonomy table and naming rules, see [How to author a skill](../how-to/author-a-skill.md#naming-your-skill).
+
+**Output from this step:** a name for each skill in your arc map.
+
+## Step 4 — Decide your vault-path shape
+
+If your pack maintains a persistent project directory (sustained-project or sustained-derived), design the vault-path now. Skip this step if your pack is episodic (standalone output per invocation, no shared project state across sessions) or stateless.
+
+**One `output_dir` base per pack.** Configure it once in `agentbundle-layout.toml`:
+
+```toml
+[your-pack-section]
+output_dir = "~/your-output-dir"
+```
+
+Each pack has its own config section. Do not share a section with another pack.
+
+**Skill-specific subdirectories under the base.** Each skill that writes files owns one subdirectory under `output_dir`. Do not write all artifacts flat into the base — it makes a status skill's scanning harder and creates namespace collisions as the pack grows.
+
+The `journey-mapping` skill is the canonical example: it writes customer-journey artifacts to `<output_dir>/journeys/`. Other experience-design skills each own a sibling directory (`screens/`, `blueprints/`). The `experience-status` skill is the one skill that scans across all subdirectories — it reads the vault, not a single subpath.
+
+**Output from this step:** a directory layout diagram for your pack's output.
+
+## Step 5 — Register with workspace-status
+
+If your pack has a `*-status` skill, register it so that `workspace-status` can route to it when a user cold-starts a session.
+
+**How to register:**
+
+1. Choose a `shaping_queue` type string for your pack. This string appears in `workspace.toml` entries for your pack's shaping items (for example, `design` for the experience-design pack, `research` for the desk-research pack).
+
+2. Add a routing entry in the `workspace-status` skill's routing table: `type = "<your-type>"` → `<your-pack>-status`.
+
+3. Add a fallback. When your pack is not installed, `workspace-status` skips the routing entry rather than erroring. Document the fallback message in your `*-status` skill body — it tells the user what to run to get started (for example, when the experience-design pack is not installed, `workspace-status` falls back gracefully rather than routing to `experience-status`).
+
+**If your pack is episodic or stateless**, skip this step. There is no persistent thread to orient to, and a status skill for an episodic pack would have nothing to read.
+
+**Output from this step:** a `shaping_queue` type string and a routing entry.
+
+## Reference: worked archetypes
+
+### Episodic — product-strategy
+
+Each skill invocation is standalone. A product-strategy session runs a single skill — market analysis, competitive positioning, or user persona — and produces a complete artifact. There is no cross-session thread to track.
+
+**Arc map:**
+
+| Stage | Skill | Artifact |
+| --- | --- | --- |
+| Arrive | Any skill (e.g., `market-analysis`) | — |
+| Orient | None | — |
+| Work | Whichever skill the user invokes | Standalone analysis artifact |
+| Persist | Each skill writes a per-invocation standalone artifact | Strategy document (not accumulated across sessions) |
+| Collaborate | — | Artifact feeds adjacent workflows |
+
+**No status skill needed** — each invocation is complete; there is no thread to return to.
+
+Other catalogue packs that follow the episodic pattern: architect (each architecture review is standalone) and converters (each file conversion is standalone).
+
+---
+
+### Sustained-project — desk-research
+
+The desk-research pack creates and manages a research project that spans multiple sessions. A project opens with `desk-research-project-start`, advances through capture → digest → synthesize → feedback phases, and closes when the stop signal fires.
+
+**Arc map:**
+
+| Stage | Skill | Artifact |
+| --- | --- | --- |
+| Arrive | `desk-research-project-start` | Creates `overview.md`; initializes the project |
+| Orient | `desk-research-project-status` | Reads `overview.md`; reports phase and working hypothesis |
+| Work | `desk-research`, `desk-research-project-check`, `desk-research-project-digest` | Source captures, saturation check, synthesis |
+| Persist | All writing skills | Files under `<output_dir>/` (configured via `[research] output_dir`) |
+| Collaborate | — | Synthesized research feeds product-strategy or experience-design |
+
+The status skill reads `overview.md` at the configured `output_dir`. When no project exists, it surfaces a not-started message and points to `desk-research-project-start`.
+
+---
+
+### Sustained-derived — experience-design
+
+The experience-design pack reads from customer-journey artifacts and derives screen flows, service blueprints, and experience assessments. It builds on what `journey-mapping` creates; it does not create the initial project from scratch.
+
+**Arc map:**
+
+| Stage | Skill | Artifact |
+| --- | --- | --- |
+| Arrive | `journey-mapping` (creates the first journey artifact) | Customer-journey map in `<output_dir>/journeys/` |
+| Orient | `experience-status` | Reads frontmatter across `journeys/`, `screens/`, `blueprints/`; reports steel-thread completion |
+| Work | `user-flow`, `service-blueprint`, other experience skills | Screen flows, blueprints |
+| Persist | All writing skills | Files under `<output_dir>/journeys/`, `screens/`, `blueprints/` |
+| Collaborate | — | Derived artifacts feed content-design and development |
+
+When `[design] output_dir` is not configured, `experience-status` surfaces a not-configured message and points to `journey-mapping`, which sets the path on first run.
+
+---
+
+### Stateless — reserved category
+
+The stateless type is reserved for future packs whose shape is pure transformation: input arrives, output leaves, nothing persists. No current catalogue pack fits this classification.
+
+The converters pack and the architect pack are both **episodic** — each invocation produces a standalone artifact the user receives as output, not a transformation that feeds back into a pipeline without producing a visible artifact.
+
+If you are designing a pack that genuinely fits the stateless shape — pure transformation, no file output, no session state — this is the right type. Verify first: if each run produces a file the user saves, you are episodic, not stateless.

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -20,6 +20,8 @@ file as stale and ask before relying on it.
 
 **M1 fix — work-loop done-step lifecycle.** Extended done-step to find the current spec in `queue` (not just `active`), add Step 0 stale-queue warning, and fix the `spec/` prefix path-resolution bug. [spec/work-loop-queue-shipped-fix]
 
+**M1 · Session-arc conventions (RFC-0067, Change D).** Pack workflow design guide (`docs/guides/_shared/explanation/pack-workflow-design.md`) — five-step framework for pack authors: workflow-type classification, arc-stage mapping, skill naming, vault-path shape, workspace-status registration. CONTRIBUTING.md step 0 added. [spec/spec-D-pack-workflow-guide — Shipped; Changes A/B/C in queue]
+
 ## Next
 
 **M2 · Strategic Shaping.** Five new PE pack skills grounding the six-step sequence (Outcome → Problem → Diverge → Validate → Bet → Spec) at initiative altitude. `frame-situation` (bottom-up signal → typed finding → six-step route; embeds Wardley capability maturity for situational awareness). `identify-opportunities` (step-2 opportunity assessment; embeds JTBD framing — functional / emotional / social jobs). `diverge-solutions` (step-3 option generation; must resolve overlap with existing `explore-options` skill). `place-bet` (step-5 human commitment gate; betting table surface). `map-capabilities` (product vision → all capability areas in one structured pass). Initiative brief artifact + Lean Canvas template as altitude-0/1 framing. Three-altitude model grounded: Company (years; PRFAQ, OKR) → Initiative (quarters; vision, capability map, initiative brief) → Project (weeks; brief, spec, plan). [RFC-00XX · pe-pack-strategic-shaping, opens when M1 ships]

--- a/docs/specs/spec-D-pack-workflow-guide/plan.md
+++ b/docs/specs/spec-D-pack-workflow-guide/plan.md
@@ -1,7 +1,7 @@
 # Plan: spec-D-pack-workflow-guide
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Drafting
+- **Status:** Done
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
 > document is allowed to change as you learn. When it changes substantially
@@ -74,7 +74,7 @@ or derive from them? → Is work episodic or ongoing? → Which of four types?]
 - Arrive: how does a user start a session with this pack?
 - Orient: does this pack need a *-status skill?
 - Work: which skills drive the core workflow?
-- Persist: does this pack write durable artifacts? Where?
+- Persist: does this pack accumulate a project directory across sessions? Where?
 - Collaborate: how do artifacts from this pack feed other packs?]
 
 ## Step 3 — Name your skills
@@ -82,7 +82,7 @@ or derive from them? → Is work episodic or ongoing? → Which of four types?]
 cross-link to author-a-skill.md for the full table.]
 
 ## Step 4 — Decide your vault-path shape
-[If your pack writes files: single output_dir base per pack (configured via
+[If your pack maintains a persistent project directory across sessions: single output_dir base per pack (configured via
 agentbundle-layout.toml). Skill-specific subdirectories under the base.
 Canonical example: journey-mapping writes to <output_dir>/journeys/.]
 
@@ -147,10 +147,10 @@ Stateless: reserved category per ADR-0054; no current catalogue pack fits — gu
 **Depends on:** T1, T2, T3
 
 **Tests:**
-- Goal-based (AC12): `scripts/lint-spec-status.py` exits 0; `git status` clean except intended files.
+- Goal-based (AC12): `.claude/skills/work-loop/scripts/lint-spec-status.py --root .` exits 0; `git status` clean except intended files.
 
 **Approach:**
-- Run `scripts/lint-spec-status.py` on this spec.
+- Run `.claude/skills/work-loop/scripts/lint-spec-status.py --root .` on this spec.
 - Verify all ACs hold by re-reading the authored files.
 - Run adversarial review; address any Blockers.
 
@@ -165,21 +165,24 @@ Stateless: reserved category per ADR-0054; no current catalogue pack fits — gu
 **Decision tree (Step 1) structure:**
 
 ```
-Does the pack create durable files that persist across sessions?
-  No → Stateless (pure transformation) or Episodic (per-invocation complete)
-       └── Does each invocation produce a standalone artifact?
-             Yes → Episodic
-             No → Stateless
-  Yes → Does this pack own those files, or derive from files another pack created?
-         Own → Sustained-project (creates and manages the project)
+Does the pack maintain a work-in-progress thread across sessions —
+tracking phases, a growing project, or cumulative state?
+  No → Does each invocation produce a standalone artifact?
+        Yes → Episodic
+        No  → Stateless
+  Yes → Does this pack create and own the project thread,
+        or derive from a thread another pack owns?
+         Own    → Sustained-project (creates and manages the project)
          Derive → Sustained-derived (reads and extends the project)
 ```
+
+Note: an episodic pack *can* write a per-invocation artifact (e.g., a strategy document); the distinguishing question is whether it accumulates shared project state across sessions, not whether it writes any file at all.
 
 **Arc-mapping questions (Step 2):**
 - Arrive: "What does a user type to open this pack's first session?"
 - Orient: "When a user returns after a break, what do they need to know? → If the answer is non-trivial, the pack needs a `*-status` skill."
 - Work: "Which one or two skills are the core workflows this pack enables?"
-- Persist: "Does the pack write files? Where? → vault-path design."
+- Persist: "Does the pack accumulate a project directory across sessions? → vault-path design if yes; episodic packs that write standalone per-invocation artifacts skip Step 4."
 - Collaborate: "What does the next pack in the user's workflow consume from this one?"
 
 ## Rollout
@@ -194,3 +197,4 @@ Pure documentation write; no pack manifest changes; no projected-tree rebuild ne
 ## Changelog
 
 - 2026-07-20: initial plan, authored alongside the spec for RFC-0067 spec/plan/ADR follow-on work.
+- 2026-07-20: corrected decision tree first question from "creates durable files" to "maintains work-in-progress thread across sessions" — the original wording would misroute episodic packs that write standalone artifacts (e.g., product-strategy) to the sustained-project branch; the distinguishing criterion is cross-session accumulated project state, not file creation.

--- a/docs/specs/spec-D-pack-workflow-guide/spec.md
+++ b/docs/specs/spec-D-pack-workflow-guide/spec.md
@@ -1,6 +1,6 @@
 # Spec: spec-D-pack-workflow-guide
 
-- **Status:** Approved
+- **Status:** Shipped
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:**
@@ -45,18 +45,18 @@ All criteria use **goal-based check**: each section's presence and content are v
 
 ## Acceptance Criteria
 
-- [ ] **AC1.** `docs/guides/_shared/explanation/pack-workflow-design.md` exists.
-- [ ] **AC2.** The guide contains all seven RFC-0067 §D1 sections: (1) What a pack is + session-arc vocabulary, (2) Step 1 — Characterize workflow type (decision tree), (3) Step 2 — Map the arc, (4) Step 3 — Name your skills, (5) Step 4 — Decide vault-path shape, (6) Step 5 — Register with workspace-status, (7) Reference: three worked archetypes (Episodic, Sustained-project, Sustained-derived) plus a stateless reserved-category note.
-- [ ] **AC3.** Section 2 (Step 1) contains a decision tree leading to one of the four ADR-0054 types: episodic, sustained-project, sustained-derived, stateless.
-- [ ] **AC4.** Section 3 (Step 2) walks each arc stage (Arrive, Orient, Work, Persist, Collaborate) with guiding questions for the pack author.
-- [ ] **AC5.** Section 4 (Step 3) references the verb taxonomy from ADR-0054 and cites the banned-label list; it cross-links to `docs/guides/_shared/how-to/author-a-skill.md` for the full taxonomy table.
-- [ ] **AC6.** Section 5 (Step 4) covers: single `output_dir` base per pack, skill-specific subdirectories, and cites `journey-mapping` as the canonical vault-path example.
-- [ ] **AC7.** Section 6 (Step 5) covers: `shaping_queue` type, routing to `workspace-status`, and the fallback if experience-design is not installed.
-- [ ] **AC8.** Section 7 (Reference) contains worked archetypes for: Episodic (product-strategy), Sustained-project (desk-research), Sustained-derived (experience-design). Stateless: ADR-0054 classifies no current catalogue pack as stateless (converters and architect are Episodic); the guide notes this as a reserved category for hypothetical future packs with no current worked example.
-- [ ] **AC9.** `CONTRIBUTING.md` "Adding a new pack" section gains step 0 (before the current step 1) with the RFC-0067 §D2 paragraph verbatim (or equivalent in the file's voice).
-- [ ] **AC10.** `CONTRIBUTING.md` step 1 ("Open an RFC") gains the sentence: "The RFC should include your arc mapping from step 0 — which skills cover which arc stages, and why."
-- [ ] **AC11.** The guide contains no governance citations (no RFC/ADR/spec references in the guide body text) — per Diátaxis link-out discipline: explanation pages link out to reference/how-to content, not to internal governance artifacts. (Governance provenance lives in this spec's `Constrained by:` header, not in the guide.)
-- [ ] **AC12.** `scripts/lint-spec-status.py` exits 0 on this spec; `git status` clean.
+- [x] **AC1.** `docs/guides/_shared/explanation/pack-workflow-design.md` exists.
+- [x] **AC2.** The guide contains all seven RFC-0067 §D1 sections: (1) What a pack is + session-arc vocabulary, (2) Step 1 — Characterize workflow type (decision tree), (3) Step 2 — Map the arc, (4) Step 3 — Name your skills, (5) Step 4 — Decide vault-path shape, (6) Step 5 — Register with workspace-status, (7) Reference: three worked archetypes (Episodic, Sustained-project, Sustained-derived) plus a stateless reserved-category note.
+- [x] **AC3.** Section 2 (Step 1) contains a decision tree leading to one of the four ADR-0054 types: episodic, sustained-project, sustained-derived, stateless.
+- [x] **AC4.** Section 3 (Step 2) walks each arc stage (Arrive, Orient, Work, Persist, Collaborate) with guiding questions for the pack author.
+- [x] **AC5.** Section 4 (Step 3) references the verb taxonomy from ADR-0054 and cites the banned-label list; it cross-links to `docs/guides/_shared/how-to/author-a-skill.md` for the full taxonomy table.
+- [x] **AC6.** Section 5 (Step 4) covers: single `output_dir` base per pack, skill-specific subdirectories, and cites `journey-mapping` as the canonical vault-path example.
+- [x] **AC7.** Section 6 (Step 5) covers: `shaping_queue` type, routing to `workspace-status`, and the fallback if experience-design is not installed.
+- [x] **AC8.** Section 7 (Reference) contains worked archetypes for: Episodic (product-strategy), Sustained-project (desk-research), Sustained-derived (experience-design). Stateless: ADR-0054 classifies no current catalogue pack as stateless (converters and architect are Episodic); the guide notes this as a reserved category for hypothetical future packs with no current worked example.
+- [x] **AC9.** `CONTRIBUTING.md` "Adding a new pack" section gains step 0 (before the current step 1) with the RFC-0067 §D2 paragraph verbatim (or equivalent in the file's voice).
+- [x] **AC10.** `CONTRIBUTING.md` step 1 ("Open an RFC") gains the sentence: "The RFC should include your arc mapping from step 0 — which skills cover which arc stages, and why."
+- [x] **AC11.** The guide contains no governance citations (no RFC/ADR/spec references in the guide body text) — per Diátaxis link-out discipline: explanation pages link out to reference/how-to content, not to internal governance artifacts. (Governance provenance lives in this spec's `Constrained by:` header, not in the guide.)
+- [x] **AC12.** `.claude/skills/work-loop/scripts/lint-spec-status.py --root .` exits 0 on this spec; `git status` clean.
 
 ## Assumptions
 

--- a/workspace.toml
+++ b/workspace.toml
@@ -61,6 +61,7 @@ shipped = [
   "spec/new-rfc-followon-queue-write",
   "spec/queue-add",              # PR #566
   "spec/work-loop-queue-shipped-fix", # Fix done-step + stale-queue warning + line-177 path bug
+  "spec/spec-D-pack-workflow-guide",  # Pack workflow design guide + CONTRIBUTING step 0
 ]
 queue   = [
   # Independent track — no deps
@@ -132,6 +133,6 @@ queue   = [
   # here and not to workspace-status itself.
   {path = "spec/workspace-status-next-actions",         needs = "work:spec/spec-A-workspace-status-rename"},
   {path = "spec/spec-B-pack-status-skills",             needs = "work:spec/spec-A-workspace-status-rename"},
-  {path = "spec/spec-D-pack-workflow-guide",            needs = "work:spec/spec-A-workspace-status-rename"},
+  # spec/spec-D-pack-workflow-guide shipped — moved below
   {path = "spec/spec-C-workloop-argless-resume",        needs = "work:spec/spec-B-pack-status-skills"},
 ]


### PR DESCRIPTION
## Summary

- Adds `docs/guides/_shared/explanation/pack-workflow-design.md` — a five-step framework for pack authors covering workflow-type classification (episodic/sustained-project/sustained-derived/stateless), arc-stage mapping against the Arrive → Orient → Work → Persist → Collaborate arc, skill naming against the verb taxonomy, vault-path shape (single `output_dir` base, skill-specific subdirs, `journey-mapping` as canonical example), and `workspace-status` registration.
- Adds step 0 ("Design the pack's workflow arc first") to `CONTRIBUTING.md`'s "Adding a new pack" section and appends the arc-mapping sentence to step 1 ("Open an RFC"), so RFC reviewers receive arc-mapped proposals by default.
- Framed at archetype level (episodic/sustained-project/sustained-derived/stateless) so the guide stays stable as new packs land.

## Spec

`docs/specs/spec-D-pack-workflow-guide/` — Status: Shipped. All 12 ACs checked.

## Sequencing note

`author-a-skill.md` already has the intro link and `## Naming your skill` section (landed via Spec A). This PR authors the guide that link points to. Changes B and C (desk-research-project-status, experience-status, workspace.toml `design` type, argless work-loop resume) are independent and remain in queue.

## Test plan

- [ ] `docs/guides/_shared/explanation/pack-workflow-design.md` exists with all 7 sections
- [ ] Decision tree classifies episodic correctly (product-strategy, converters, architect are Episodic — not Stateless)
- [ ] Step 4 vault-path section correctly gates on "persistent project directory" not "writes files"
- [ ] No RFC/ADR/spec citations in the guide body
- [ ] `CONTRIBUTING.md` step 0 present before step 1; arc-mapping sentence on step 1
- [ ] `author-a-skill.md` untouched (Spec A boundary respected)
- [ ] `.claude/skills/work-loop/scripts/lint-spec-status.py --root .` exits 0
- [ ] `make build-self` no projected-file drift

## Bundled fixes

None.