### PR TITLE
fix(web): update experience-design journey to reflect 18 skills after RFC-0066

### DIFF
--- a/docs/specs/xd-web-journey-skill-count/spec.md
+++ b/docs/specs/xd-web-journey-skill-count/spec.md
@@ -1,0 +1,29 @@
+---
+**Feature:** xd-web-journey-skill-count
+**Status:** Shipped
+**Mode:** light (no risk trigger fired)
+---
+
+## Objective
+
+Update `web/src/content/journeys/experience-design.md` to reflect the 9 skills added since the last journey update (6 genre-specific Direct skills + 3 connective/decision skills). The `skills:` frontmatter listed 9; the pack now has 18 (19 directory entries minus `experience-status`, which is a workflow/orient tool, not a design skill). Also update `whatChanges` text and stage prose to reflect the full chain.
+
+## Testing Strategy
+
+Goal-based check: `npm run build` passes (Astro Zod schema validates the frontmatter) and the rendered experience-design journey page reflects 18 skills.
+
+## Acceptance Criteria
+
+- [x] `skills:` frontmatter lists all 18 skills (9 original + 9 new: `analytical-design`, `content-design`, `conversion-design`, `design-principles`, `documentation-design`, `informational-design`, `marketplace-design`, `tone-of-voice`, `workspace-design`)
+- [x] `whatChanges` text names the genre-specific skills and the connective thread (`content-design`, `tone-of-voice`, `design-principles`)
+- [x] Stage 1 prose mentions `content-design` and `tone-of-voice` as connective-thread skills that run after journey-mapping
+- [x] Stage 3 prose mentions `design-principles` as the decision-rules step before `creative-direction`
+- [x] Stage 4 prose names each genre-specific Direct skill with its surface genre trigger
+
+## Tasks
+
+1. Update `skills:` frontmatter in `web/src/content/journeys/experience-design.md` — add 9 skills in workflow order
+2. Update `whatChanges:` field to name genre-specific skills and connective thread
+3. Update Stage 1 prose to mention `content-design` + `tone-of-voice`
+4. Update Stage 3 prose to mention `design-principles`
+5. Update Stage 4 prose to name genre-specific Direct skills with genre triggers

--- a/packs/experience-design/.apm/skills/analytical-design/evals/eval_queries.json
+++ b/packs/experience-design/.apm/skills/analytical-design/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "Design the dashboard for our analytics team", "should_trigger": true},
+  {"query": "How should we structure the reporting view for sales managers?", "should_trigger": true},
+  {"query": "What goes on the KPI monitoring screen?", "should_trigger": true},
+  {"query": "Design a monitoring view that lets engineers see system health at a glance", "should_trigger": true},
+  {"query": "Structure the data visualization layout for our metrics dashboard", "should_trigger": true},
+  {"query": "How do we organize our reporting screen so analysts can drill down?", "should_trigger": true},
+  {"query": "Design the analytics surface for our product team", "should_trigger": true},
+  {"query": "Structure this reporting view — from status signal to diagnostic to action", "should_trigger": true},
+  {"query": "What's the right layout grammar for a business intelligence dashboard?", "should_trigger": true},
+
+  {"query": "Design the individual chart encodings for the bar chart component", "should_trigger": false},
+  {"query": "Design the landing page to convert trial visitors", "should_trigger": false},
+  {"query": "Design the workspace for collaborative editing sessions", "should_trigger": false},
+  {"query": "Design the product catalogue and search filter UI", "should_trigger": false},
+  {"query": "Structure the docs site navigation and content hierarchy", "should_trigger": false},
+  {"query": "Name the visual direction for the dashboard before we design it", "should_trigger": false},
+  {"query": "Derive the token taxonomy from the aesthetic direction", "should_trigger": false},
+  {"query": "Critique the usability of this analytics screen", "should_trigger": false},
+  {"query": "Map the customer journey for new users", "should_trigger": false}
+]

--- a/packs/experience-design/.apm/skills/analytical-design/evals/evals.json
+++ b/packs/experience-design/.apm/skills/analytical-design/evals/evals.json
@@ -1,0 +1,19 @@
+{
+  "skill_name": "analytical-design",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Produce the structural specification for an analytical surface. The surface is a sales performance dashboard for regional managers. Business questions: Which regions are off-track this quarter? What are the top three deals likely to close this week? Where is the pipeline blocked?",
+      "expected_output": "A structural specification for an analytical surface that starts by naming the domain model (objects: deal, region, stage; attributes: value, probability, owner; relationships: deal-to-region, deal-to-stage; actions: drill down, filter by region). It then names the 3–5 business questions the surface must answer and builds a widget hierarchy ordered by decision weight — high-level signal widgets first (status/health at a glance), diagnostic widgets second (why the signal is what it is), action widgets third (what the manager can do). It designs a role-based view architecture so regional managers see their region's data without needing to filter globally. It designs the signal → diagnostic → action flow as a spatial grammar so the eye moves from status to cause to next step without backtracking. The output is IA reasoning and concepts only — no color values, chart type implementation, or code.",
+      "assertions": [
+        "Names the domain model first — objects, attributes, relationships, and actions — before placing any widget",
+        "Names the specific business questions (3–5) the surface must answer; 'give me insights' is not accepted as a question",
+        "Builds a widget hierarchy ordered by decision weight: signal → diagnostic → action",
+        "Designs a role-based view architecture that scopes each role's default view without requiring global filtering",
+        "Designs the spatial grammar so the eye follows the signal → diagnostic → action flow without backtracking",
+        "Does NOT design individual chart encodings (that is interaction-design's domain)",
+        "Does NOT produce color values, chart type implementations, or layout/styling code"
+      ]
+    }
+  ]
+}

--- a/packs/experience-design/.apm/skills/conversion-design/evals/eval_queries.json
+++ b/packs/experience-design/.apm/skills/conversion-design/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "Design the landing page to convert visitors to sign-ups", "should_trigger": true},
+  {"query": "Structure the homepage so visitors understand what we do and take action", "should_trigger": true},
+  {"query": "What goes above the fold on our product marketing page?", "should_trigger": true},
+  {"query": "Design the pricing page to reduce drop-off at the conversion point", "should_trigger": true},
+  {"query": "How do we structure the scroll story on our acquisition landing page?", "should_trigger": true},
+  {"query": "Design a marketing surface that converts visitors into trial users", "should_trigger": true},
+  {"query": "What's the right structure for our SaaS product homepage?", "should_trigger": true},
+  {"query": "How should we order the sections on our campaign landing page?", "should_trigger": true},
+  {"query": "Structure the above-fold section of our product page for maximum clarity", "should_trigger": true},
+
+  {"query": "Design the article page layout for our editorial blog", "should_trigger": false},
+  {"query": "Structure the docs site navigation and help center hierarchy", "should_trigger": false},
+  {"query": "Design the marketplace catalogue and listing filter UI", "should_trigger": false},
+  {"query": "Design the dashboard for monitoring system health", "should_trigger": false},
+  {"query": "Write the hero headline and above-fold copy", "should_trigger": false},
+  {"query": "Name the aesthetic direction for the marketing page", "should_trigger": false},
+  {"query": "Critique this landing page and rank the usability issues", "should_trigger": false},
+  {"query": "Design the workspace UI for our collaborative editing tool", "should_trigger": false},
+  {"query": "Map the customer journey from first visit to purchase", "should_trigger": false}
+]

--- a/packs/experience-design/.apm/skills/conversion-design/evals/evals.json
+++ b/packs/experience-design/.apm/skills/conversion-design/evals/evals.json
@@ -1,0 +1,19 @@
+{
+  "skill_name": "conversion-design",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Produce the structural specification for a conversion surface. The surface is the product homepage for a B2B SaaS project-management tool. The target action is starting a free trial. A content brief exists naming the primary audience (engineering team leads at 50–500 person companies) and their dominant pain (too much context-switching between tools).",
+      "expected_output": "A structural specification for a conversion surface that starts by naming the dominant buyer behavior (this is a low-awareness, high-skepticism audience — browse-first) and selecting a hero approach from the five canonical types, justified by the product's awareness stage. It defines the above-fold contract — the primary claim, the proof context, and a single CTA visible before scroll. It structures the scroll story as a sequence of proof tiers ordered by credibility weight (claim → social proof → feature evidence → objection handling → final CTA), with each tier earning the next. It names the social-proof architecture (which type of proof is most credible to this audience and why). The output is structural specification and section order only — no copy, no color values, no implementation code.",
+      "assertions": [
+        "Names the dominant buyer behavior (browse-first or search-first) and justifies the choice against the audience's awareness stage",
+        "Selects one of the five hero types and justifies the choice against the audience and their pain",
+        "Defines the above-fold contract: primary claim + proof context + single CTA, all visible before scroll",
+        "Sequences the scroll story as proof tiers, each tier earning the next",
+        "Names the social-proof architecture and explains why that proof type is most credible to this specific audience",
+        "Does NOT write copy (not a content-design or tone-of-voice output)",
+        "Does NOT produce color values, font names, or implementation code"
+      ]
+    }
+  ]
+}

--- a/packs/experience-design/.apm/skills/design-principles/evals/eval_queries.json
+++ b/packs/experience-design/.apm/skills/design-principles/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "What are our design principles for this product?", "should_trigger": true},
+  {"query": "We keep arguing about the same design decisions — help us define our principles", "should_trigger": true},
+  {"query": "Derive design principles from this journey map", "should_trigger": true},
+  {"query": "Write our design principles so we can make consistent decisions", "should_trigger": true},
+  {"query": "How do we decide between competing design directions consistently?", "should_trigger": true},
+  {"query": "We need named rules that will guide our design choices across the sprint", "should_trigger": true},
+  {"query": "Turn our journey pain points into design principles", "should_trigger": true},
+  {"query": "Our team relitigates the same UX tradeoffs — we need a principles doc", "should_trigger": true},
+  {"query": "Give us decision rules we can use to resolve design disputes", "should_trigger": true},
+
+  {"query": "Name the aesthetic direction for this product before we design anything", "should_trigger": false},
+  {"query": "Derive the design token set from our brand direction", "should_trigger": false},
+  {"query": "Critique this screen and rank the usability issues", "should_trigger": false},
+  {"query": "Map the customer journey from discovery to first value", "should_trigger": false},
+  {"query": "Design the information architecture for the settings page", "should_trigger": false},
+  {"query": "Write the tone of voice for our product copy", "should_trigger": false},
+  {"query": "What should be above the fold on the landing page?", "should_trigger": false},
+  {"query": "Design the dashboard so analysts can drill down into the data", "should_trigger": false},
+  {"query": "Structure the navigation for the docs site", "should_trigger": false}
+]

--- a/packs/experience-design/.apm/skills/design-principles/evals/evals.json
+++ b/packs/experience-design/.apm/skills/design-principles/evals/evals.json
@@ -1,0 +1,18 @@
+{
+  "skill_name": "design-principles",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Produce design principles for the product described. A journey map exists showing three key pain points: slow task recovery after errors, inconsistent labeling across screens, and users skipping secondary information they need later.",
+      "expected_output": "A set of 3–5 named design principles, each in the form [Imperative verb] + [what] + [why/for whom], derived from the journey map pain points rather than from editorial taste. The principles are ranked with a single dominant principle named. Each principle carries an arbitration test — a concrete yes/no question the team can run to check whether a given design decision satisfies it. The output distinguishes the principles from brand values (those belong in creative-direction) and from universal heuristics (Nielsen applies everywhere; these are product-specific). No hex values, font names, visual direction, or implementation code appear.",
+      "assertions": [
+        "Derives each principle from a specific journey moment or pain point, not from editorial preference",
+        "Produces 3–5 named principles, each in imperative verb + what + why/for whom form",
+        "Ranks the principles and names a single dominant one that wins when goals conflict",
+        "Each principle carries an arbitration test — a concrete yes/no question that resolves a real design dispute",
+        "Distinguishes the output from brand values (→ creative-direction) and universal heuristics (Nielsen applies everywhere)",
+        "No hex values, font names, spacing values, or visual direction appear in the output"
+      ]
+    }
+  ]
+}

--- a/packs/experience-design/.apm/skills/documentation-design/evals/eval_queries.json
+++ b/packs/experience-design/.apm/skills/documentation-design/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "Design the docs site structure for our developer API", "should_trigger": true},
+  {"query": "Structure the help centre so users find answers quickly", "should_trigger": true},
+  {"query": "How should we organize our technical documentation?", "should_trigger": true},
+  {"query": "What goes on the docs landing page to get developers to their first value moment?", "should_trigger": true},
+  {"query": "Design the navigation for our API reference documentation", "should_trigger": true},
+  {"query": "How do we structure a docs site that serves both tutorials and reference docs?", "should_trigger": true},
+  {"query": "Plan the information architecture for our SDK documentation", "should_trigger": true},
+  {"query": "Design the docs landing page to route engineers to what they need fast", "should_trigger": true},
+  {"query": "How should we organize a documentation site that's grown too large to navigate?", "should_trigger": true},
+
+  {"query": "Write the actual tutorial content for the getting-started guide", "should_trigger": false},
+  {"query": "Design the marketing landing page for our developer tool", "should_trigger": false},
+  {"query": "Design the article page layout for our editorial blog", "should_trigger": false},
+  {"query": "Structure the layout for an in-product help panel", "should_trigger": false},
+  {"query": "Name the aesthetic direction for the documentation site", "should_trigger": false},
+  {"query": "Critique the usability of the existing docs site navigation", "should_trigger": false},
+  {"query": "Derive the token system for the docs site brand", "should_trigger": false},
+  {"query": "Design the dashboard for engineering metrics", "should_trigger": false},
+  {"query": "Map the customer journey for new developer sign-ups", "should_trigger": false}
+]

--- a/packs/experience-design/.apm/skills/documentation-design/evals/evals.json
+++ b/packs/experience-design/.apm/skills/documentation-design/evals/evals.json
@@ -1,0 +1,19 @@
+{
+  "skill_name": "documentation-design",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Produce the structural specification for a documentation surface. The surface is the docs site for a developer API. The content set includes a getting-started tutorial, conceptual guides, a full API reference, and a set of how-to recipes. The target audience is backend engineers integrating the API for the first time.",
+      "expected_output": "A structural specification for a documentation surface that starts by typing the content set using the Diátaxis framework (tutorial → how-to → reference → explanation), mapping each piece of content to exactly one primary type. It names a TTFV target — what the engineer accomplishes in the first successful session. It then designs the navigation trading depth against breadth, grouped by how engineers look for things (task-goal first, not by the API's internal schema), with landing page IA that routes each content type to its fastest TTFV path. It designs the machine-readability decisions (what the reference format must support for tooling and LLM consumption). The output is structural specification only — no content writing, no markup, no styling code.",
+      "assertions": [
+        "Types the content set using Diátaxis — each piece gets exactly one primary type (tutorial/how-to/reference/explanation)",
+        "Names a TTFV target — what the reader accomplishes in the first successful session, specific enough to measure",
+        "Designs navigation grouped by how readers look for things, not by the API's internal schema or org structure",
+        "Designs the landing page as a TTFV accelerant — routes each content type to its fastest path, not as a table of contents",
+        "Addresses machine-readability decisions for the reference format",
+        "Does NOT write documentation content (not a new-guide output)",
+        "Does NOT produce markup, color values, or styling code"
+      ]
+    }
+  ]
+}

--- a/packs/experience-design/.apm/skills/informational-design/evals/eval_queries.json
+++ b/packs/experience-design/.apm/skills/informational-design/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "Design the article page layout for our editorial blog", "should_trigger": true},
+  {"query": "How should the long-form content page be structured for readability?", "should_trigger": true},
+  {"query": "Design the reading experience for our news and editorial pages", "should_trigger": true},
+  {"query": "Structure an article template that works for our in-depth features", "should_trigger": true},
+  {"query": "How do we design a reading experience that keeps people engaged through long content?", "should_trigger": true},
+  {"query": "Design the typographic hierarchy for our editorial content pages", "should_trigger": true},
+  {"query": "What's the right layout structure for a thought-leadership article page?", "should_trigger": true},
+  {"query": "Design the layout for our research report pages — long, text-heavy content", "should_trigger": true},
+  {"query": "How do we structure an article page so readers stay until the end?", "should_trigger": true},
+
+  {"query": "Design the docs site for our technical documentation", "should_trigger": false},
+  {"query": "Design the landing page to convert trial visitors", "should_trigger": false},
+  {"query": "Design the dashboard layout for our analytics team", "should_trigger": false},
+  {"query": "Design the marketplace listing page for product discovery", "should_trigger": false},
+  {"query": "Write the article content for our product launch post", "should_trigger": false},
+  {"query": "Name the aesthetic direction for our editorial brand", "should_trigger": false},
+  {"query": "Critique the usability of our blog page", "should_trigger": false},
+  {"query": "Derive the font scale and spacing tokens for the article page", "should_trigger": false},
+  {"query": "Design the workspace UI for our collaborative writing tool", "should_trigger": false}
+]

--- a/packs/experience-design/.apm/skills/informational-design/evals/evals.json
+++ b/packs/experience-design/.apm/skills/informational-design/evals/evals.json
@@ -1,0 +1,19 @@
+{
+  "skill_name": "informational-design",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Produce the structural specification for an informational surface. The surface is an article page for a B2B publication covering enterprise software and technology. Articles range from 800–3,000 words. The target audience is technical leaders who scan before committing to read. Reading goal: understand a trend and its practical implications for their team.",
+      "expected_output": "A structural specification for an informational surface that establishes typography as the primary design tool — every layout decision is justified by reading legibility, not decoration. It names the reading goal explicitly (the reader leaves knowing something or able to do something they couldn't before) and selects a reading pattern (F-pattern for this scan-before-commit audience) justified by the audience's behavior. It designs the typographic hierarchy (headline → standfirst → subhead → body → callout) so the scanner extracts the article's argument without reading every word. It designs the 'what's next' chain that sustains engagement after the primary content is consumed. The output is structural specification and typography reasoning only — no copy, no CSS, no color values.",
+      "assertions": [
+        "Names the reading goal explicitly — what the reader knows or can do after reading that they didn't before",
+        "Establishes typography as the primary design tool; every layout decision is grounded in reading legibility",
+        "Selects a reading pattern (F-pattern or Z-pattern) justified by the audience's scanning behavior, not by habit",
+        "Designs a typographic hierarchy that lets a scanner extract the article's argument without reading every word",
+        "Designs the 'what's next' chain that sustains engagement after the primary content ends",
+        "Does NOT write content (not a content-design or tone-of-voice output)",
+        "Does NOT produce CSS, color values, font name decisions, or spacing values"
+      ]
+    }
+  ]
+}

--- a/packs/experience-design/.apm/skills/marketplace-design/evals/eval_queries.json
+++ b/packs/experience-design/.apm/skills/marketplace-design/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "Design the marketplace catalogue and listing page", "should_trigger": true},
+  {"query": "Structure the search and filter UI for our product marketplace", "should_trigger": true},
+  {"query": "How should the listing card be structured to drive buyer decisions?", "should_trigger": true},
+  {"query": "Design the buyer journey from search to transaction on our marketplace", "should_trigger": true},
+  {"query": "What's the right filter and facet architecture for a B2B software catalogue?", "should_trigger": true},
+  {"query": "Design the comparison view for our marketplace listings", "should_trigger": true},
+  {"query": "Structure the product detail page for a two-sided marketplace", "should_trigger": true},
+  {"query": "How do we organize the discovery experience on our service marketplace?", "should_trigger": true},
+  {"query": "Design the search results page and listing cards for our app store", "should_trigger": true},
+
+  {"query": "Design the marketing landing page for a single product", "should_trigger": false},
+  {"query": "Design the workspace for managing marketplace listings internally", "should_trigger": false},
+  {"query": "Design the analytics dashboard for marketplace performance", "should_trigger": false},
+  {"query": "Design the product docs for marketplace sellers", "should_trigger": false},
+  {"query": "Name the aesthetic direction for the marketplace brand", "should_trigger": false},
+  {"query": "Critique the usability of the current listing page", "should_trigger": false},
+  {"query": "Derive the token taxonomy for the marketplace design system", "should_trigger": false},
+  {"query": "Map the seller journey for onboarding a new product", "should_trigger": false},
+  {"query": "Write the listing card copy for our marketplace", "should_trigger": false}
+]

--- a/packs/experience-design/.apm/skills/marketplace-design/evals/evals.json
+++ b/packs/experience-design/.apm/skills/marketplace-design/evals/evals.json
@@ -1,0 +1,20 @@
+{
+  "skill_name": "marketplace-design",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Produce the structural specification for a marketplace surface. The surface is a B2B software tools catalogue. Buyers are engineering leads comparing tools before a purchase decision. The listing object model includes: tool name, category, pricing model, integration count, and user rating. Dominant buyer behavior: comparison-first (buyers know what category they want; they're evaluating options within it).",
+      "expected_output": "A structural specification for a marketplace surface that names the listing object model explicitly (objects, attributes, which attributes drive filtering, which drive comparison). It designs the listing card with attributes ordered by decision weight for this audience — the comparison-driving attributes are primary, not the most visually prominent. It designs the filter and facet architecture grouped by how buyers narrow their choice (not by the listing schema), with the most-used facets visible without scroll. It designs comparison affordances for the comparison-driving attributes. It names the transaction bridge — the moment of commitment and what the buyer needs to know to cross it. The output is structural specification only — no component markup, no color values, no implementation code.",
+      "assertions": [
+        "Names the listing object model — objects, attributes, which attributes drive filtering, which drive comparison",
+        "Designs the listing card with attributes ordered by decision weight, comparison-driving attributes primary",
+        "Designs filter and facet architecture grouped by how buyers narrow choice, not by the listing schema",
+        "Places the most-used facets visible without scroll",
+        "Designs comparison affordances for the comparison-driving attributes",
+        "Names the transaction bridge — what the buyer needs to know to commit, and how the surface provides it",
+        "Does NOT design individual card components (not interaction-design's component state machine)",
+        "Does NOT produce component markup, color values, or implementation code"
+      ]
+    }
+  ]
+}

--- a/packs/experience-design/.apm/skills/workspace-design/evals/eval_queries.json
+++ b/packs/experience-design/.apm/skills/workspace-design/evals/eval_queries.json
@@ -1,0 +1,21 @@
+[
+  {"query": "Design the workspace UI for our collaborative editing tool", "should_trigger": true},
+  {"query": "Structure the tool interface for a multi-agent coordination surface", "should_trigger": true},
+  {"query": "Design the agentic UI for our AI-assisted development environment", "should_trigger": true},
+  {"query": "How should we structure the layout for a long-running task management surface?", "should_trigger": true},
+  {"query": "Design the workspace for a team that works in sessions across multiple days", "should_trigger": true},
+  {"query": "How do we handle context-persistence in our productivity tool UI?", "should_trigger": true},
+  {"query": "Design the session arc for our collaborative code review tool", "should_trigger": true},
+  {"query": "Structure the attention zones and notification design for our IDE-like workspace", "should_trigger": true},
+  {"query": "How should we design the real-time collaboration state in our document editor?", "should_trigger": true},
+
+  {"query": "Design the analytics dashboard for the workspace metrics", "should_trigger": false},
+  {"query": "Design the marketplace for users to discover workspace integrations", "should_trigger": false},
+  {"query": "Design the article page for our workspace product blog", "should_trigger": false},
+  {"query": "Design the landing page to convert workspace tool visitors", "should_trigger": false},
+  {"query": "Name the aesthetic direction for the workspace product", "should_trigger": false},
+  {"query": "Critique the usability of the existing workspace screen", "should_trigger": false},
+  {"query": "Design the individual component interactions for the workspace toolbar", "should_trigger": false},
+  {"query": "Derive the token system for the workspace design", "should_trigger": false},
+  {"query": "Map the customer journey for new workspace users", "should_trigger": false}
+]

--- a/packs/experience-design/.apm/skills/workspace-design/evals/evals.json
+++ b/packs/experience-design/.apm/skills/workspace-design/evals/evals.json
@@ -1,0 +1,20 @@
+{
+  "skill_name": "workspace-design",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Produce the structural specification for a workspace surface. The surface is an AI-assisted code review tool. Users (individual engineers) return to it across sessions to manage an ongoing queue of code review requests. Collaboration model: asynchronous — reviewers and authors don't work at the same time. The session arc: engineer arrives, resumes the review where they left off, completes several review cycles, leaves with their queue updated.",
+      "expected_output": "A structural specification for a workspace surface that starts by naming the session arc (arrive → resume → work → persist → leave) and the collaboration model (asynchronous, no live presence needed). It designs context-persistence using a named pattern (session resume — the engineer lands where they left off without hunting). It designs the attention zone layout: a primary work area for the active review, a peripheral zone for the queue state (what's waiting, what's done), and a notification zone for async events (new requests, resolved threads). It designs the interrupt architecture — how incoming review requests surface without disrupting the current focus. It covers how agentic output (AI suggestions, summaries) surfaces without displacing the engineer's workflow. The output is structural specification only — no component markup, no color values, no implementation code.",
+      "assertions": [
+        "Names the session arc (arrive → work → persist → leave) before designing any surface element",
+        "Names the collaboration model and explains how it drives presence, live-editing, and sharing IA decisions",
+        "Designs context-persistence using a named pattern appropriate to the session arc",
+        "Designs the attention zone layout — primary work area, peripheral status zone, notification zone — with spatial relationships named",
+        "Designs the interrupt architecture — how async events surface without disrupting the current focus",
+        "Covers how agentic output surfaces without displacing the user's primary workflow",
+        "Does NOT design individual component interactions (not interaction-design's domain)",
+        "Does NOT produce component markup, color values, or implementation code"
+      ]
+    }
+  ]
+}

--- a/packs/experience-design/pack.toml
+++ b/packs/experience-design/pack.toml
@@ -48,7 +48,7 @@ output_dir = "docs/design"
 # skill, so it is not listed here (its eval surface is its review-list output
 # contract + manual-QA dispatch; RFC-0050 § Errata).
 [pack.evals]
-skills = ["creative-direction", "content-design", "tone-of-voice", "design-review", "design-system", "information-architecture", "journey-mapping", "service-blueprint", "user-flow", "process-mapping", "interaction-design", "experience-status"]
+skills = ["creative-direction", "content-design", "tone-of-voice", "design-review", "design-system", "information-architecture", "journey-mapping", "service-blueprint", "user-flow", "process-mapping", "interaction-design", "experience-status", "design-principles", "analytical-design", "conversion-design", "documentation-design", "informational-design", "marketplace-design", "workspace-design"]
 
 # enriched-pack-manifest (RFC-0031 / ADR-0021): catalogue-facing links
 # + maintainer, including the `documentation` link to the per-pack guide home.

--- a/web/src/content/journeys/experience-design.md
+++ b/web/src/content/journeys/experience-design.md
@@ -3,11 +3,17 @@ pack: experience-design
 scope: user
 tagline: "The design/UX seat for product teams."
 prerequisitePacks: []
-whatChanges: "After installing experience-design, product-engineering work has a full design thread from outcome to realization. `journey-mapping` and `user-flow` derive the screen list from a named outcome. `creative-direction` and `design-system` establish the visual constraints before any screen is designed. `interaction-design` and `design-review` craft and critique each screen to a shared quality floor. The forked-context `experience-reviewer` gives every design an independent pass — handle-all-states, WCAG 2.2 AA, reduced-motion."
+whatChanges: "After installing experience-design, product-engineering work has a full design thread from outcome to realization. `journey-mapping` maps the journey; `content-design` and `tone-of-voice` name what the surface says and how it sounds. `design-principles` records the decision rules that hold screens to a shared standard. `user-flow` derives the screen list. `creative-direction` and `design-system` set the visual constraints. Genre-specific Direct skills (`analytical-design`, `conversion-design`, `documentation-design`, `informational-design`, `marketplace-design`, `workspace-design`) produce surface-appropriate IA before `interaction-design` and `design-review` craft and critique each screen. The forked-context `experience-reviewer` gives every design an independent pass — handle-all-states, WCAG 2.2 AA, reduced-motion."
 skills:
   - name: journey-mapping
     description: "Maps the current and desired customer journey to derive the key touchpoints and failure modes a product must address."
     humanTouches: 1
+  - name: content-design
+    description: "Produces a content brief for a surface — what it should say, for whom, in what form, and to what objective — before any wireframe or screen flow starts."
+    humanTouches: 0
+  - name: tone-of-voice
+    description: "Turns a vague copy vibe into named, ranked copy goals grounded in stable referents, and records copy arbitration rules the rest of the build references."
+    humanTouches: 0
   - name: user-flow
     description: "Derives the screen inventory and flow from the customer journey — what screens exist, what state each handles, what the transitions are."
     humanTouches: 1
@@ -17,6 +23,9 @@ skills:
   - name: process-mapping
     description: "Documents the internal processes that run behind user-facing screens — the APQC/BPMN model of what people do."
     humanTouches: 0
+  - name: design-principles
+    description: "Converts journey-map insights into 3–5 named design principles — decision rules that resolve disputes and persist across sprints, each grounded in a journey moment."
+    humanTouches: 0
   - name: creative-direction
     description: "Establishes the visual direction for a surface — named emotional and brand goals grounded in stable referents — as the aesthetic reference all subsequent screens must satisfy."
     humanTouches: 1
@@ -25,6 +34,24 @@ skills:
     humanTouches: 0
   - name: information-architecture
     description: "Designs the layout zones and information hierarchy for a screen, given its per-screen brief."
+    humanTouches: 0
+  - name: analytical-design
+    description: "Produces a structural specification for an analytical surface — dashboard IA, widget hierarchy, and role-based view architecture — from business questions and domain model."
+    humanTouches: 0
+  - name: conversion-design
+    description: "Produces a structural specification for a marketing surface — above-fold contract, scroll story, and social-proof architecture — from content brief and design principles."
+    humanTouches: 0
+  - name: documentation-design
+    description: "Produces a structural specification for a documentation surface — content hierarchy, navigation strategy, and TTFV architecture — from Diátaxis content typing and reading goal."
+    humanTouches: 0
+  - name: informational-design
+    description: "Produces a structural specification for an informational surface — typographic hierarchy, reading-pattern calibration, and editorial grid — from editorial structure and reading goal."
+    humanTouches: 0
+  - name: marketplace-design
+    description: "Produces a structural specification for a marketplace surface — listing card IA, filter and facet architecture, and transaction bridge — from buyer journey and listing object model."
+    humanTouches: 0
+  - name: workspace-design
+    description: "Produces a structural specification for a workspace surface — context-persistence architecture, attention zone layout, and interrupt design — from session arc and collaboration model."
     humanTouches: 0
   - name: interaction-design
     description: "Designs the interactive behaviors for a screen — states, transitions, feedback patterns — against WCAG 2.2 AA."
@@ -87,6 +114,8 @@ relatedJourneys:
 
 You describe the feature, user, and outcome. The agent runs `journey-mapping` to produce the customer journey map — the current state (what happens today), the desired state (what should happen after this feature), and the key moments where the current journey breaks down.
 
+With the journey in hand, the agent can run `content-design` to produce a content brief — what the surface should say, for whom, and to what objective — and `tone-of-voice` to name the copy direction. These run before the screen flow is derived, so the surface's content intent and register are set as constraints before screens are sequenced. The content brief and copy direction don't require a separate gate; review them informally when you read the journey map.
+
 **You:** Read the journey map and approve it at the G-journey gate. This is the most important gate in the experience thread — the screen list flows directly from it. If the map describes what the current product does rather than what the user is trying to achieve, redirect before the screen flow is derived. A one-sentence correction here saves a full design cycle.
 
 ---
@@ -101,7 +130,7 @@ With the journey approved, the agent runs `user-flow` to derive the screen inven
 
 ## Stage 3 — Establish design intent
 
-Before designing any screen, the agent runs `creative-direction` to establish the visual character of the surface — named emotional and brand goals grounded in stable referents — as a named aesthetic reference. It then runs `design-system` to derive the design token set.
+Before designing any screen, the agent runs `design-principles` to convert journey-map insights into 3–5 named decision rules — the principles that resolve design disputes and hold screens to a shared standard across the sprint. The principles don't require a separate gate; review them alongside the aesthetic direction below. The agent then runs `creative-direction` to establish the visual character of the surface — named emotional and brand goals grounded in stable referents — as a named aesthetic reference. `design-system` derives the design token set from that direction.
 
 **You:** Approve the aesthetic direction at the G-aesthetic gate. An aesthetic direction that says "clean and professional" is not an aesthetic direction — it needs to name a specific visual character with enough specificity to say whether a given design decision is consistent or not. If the tokens introduce hardcoded values outside the semantic token system, reject them.
 
@@ -109,7 +138,7 @@ Before designing any screen, the agent runs `creative-direction` to establish th
 
 ## Stage 4 — Design each screen
 
-The agent runs `information-architecture` and `interaction-design` on each screen in the flow, working from each screen's per-screen brief. It then runs `design-review` on each screen before the independent review — a self-check against the quality floor.
+The agent runs a structural IA skill on each screen before `interaction-design`. For general screens it uses `information-architecture`. When a screen has a specific surface genre, a genre-specific Direct skill produces a more targeted specification: `analytical-design` for dashboards and reporting views; `conversion-design` for marketing and acquisition surfaces; `documentation-design` for docs sites and help centres; `informational-design` for article and editorial pages; `marketplace-design` for catalogue and listing surfaces; `workspace-design` for productivity and agentic tool UIs. Once the IA is set, `interaction-design` designs the states, transitions, and feedback patterns, and `design-review` applies the quality floor as a self-check before the independent review.
 
 **You:** Watch each screen take shape. If a screen is missing a state — no empty state for a list that could be empty, no loading state for an async action — name it. The agent will miss states not explicitly mentioned in the brief; that's what the experience-reviewer catches, but catching it here is cheaper.
 

--- a/workspace.toml
+++ b/workspace.toml
@@ -161,14 +161,4 @@ open = [
   # Files: tools/lint-web-journey-parity.py (new), tools/pre-pr-catalogue.py
   {slug = "lint-web-journey-parity"},
 
-  # Update packs/experience-design/pack.toml [pack.evals].skills allowlist to
-  # add the 7 RFC-0066 additions omitted at time of pack.toml authoring:
-  # design-principles + 6 genre-specific Direct skills (analytical-design,
-  # conversion-design, documentation-design, informational-design,
-  # marketplace-design, workspace-design). They now ship and are advertised in
-  # the web journey. Each needs eval_queries.json + evals.json per the existing
-  # eval-coverage contract. Advisory: ship after xd-web-journey-skill-count.
-  # Source: adversarial-reviewer finding on PR #eugene/xd-web-journey-skill-count.
-  # File: packs/experience-design/pack.toml + each skill's evals/ directory
-  {slug = "xd-evals-allowlist-rfc066-skills"},
 ]

--- a/workspace.toml
+++ b/workspace.toml
@@ -124,14 +124,6 @@ open = [
   # Items 1–2 parallel-safe. Item 3 advisory-after 1+2 (lint fails on existing
   # drift if run first). Item 4 advisory-after item 3 ships.
 
-  # Content fix: RFC-0066 added 9 genre-specific Direct skills to experience-design
-  # but web/src/content/journeys/experience-design.md skills frontmatter still lists
-  # 9 (journey-mapping through design-review). Pack now has 18. Also update
-  # whatChanges text to name genre-specific skills and the stage prose to reflect
-  # the full chain including genre-specific Direct skills.
-  # File: web/src/content/journeys/experience-design.md
-  {slug = "xd-web-journey-skill-count"},
-
   # New web journey page for product-strategy pack. Pack is in catalogue (9 skills,
   # 3 pillars: market strategy, UX strategy, content strategy), has internal journey
   # at docs/product/journeys/product-strategist-sets-direction.md, but no
@@ -168,4 +160,15 @@ open = [
   # so the gate starts green on first CI run.
   # Files: tools/lint-web-journey-parity.py (new), tools/pre-pr-catalogue.py
   {slug = "lint-web-journey-parity"},
+
+  # Update packs/experience-design/pack.toml [pack.evals].skills allowlist to
+  # add the 7 RFC-0066 additions omitted at time of pack.toml authoring:
+  # design-principles + 6 genre-specific Direct skills (analytical-design,
+  # conversion-design, documentation-design, informational-design,
+  # marketplace-design, workspace-design). They now ship and are advertised in
+  # the web journey. Each needs eval_queries.json + evals.json per the existing
+  # eval-coverage contract. Advisory: ship after xd-web-journey-skill-count.
+  # Source: adversarial-reviewer finding on PR #eugene/xd-web-journey-skill-count.
+  # File: packs/experience-design/pack.toml + each skill's evals/ directory
+  {slug = "xd-evals-allowlist-rfc066-skills"},
 ]


### PR DESCRIPTION
## Summary

- **Web journey** — `skills:` frontmatter grew from 9 to 18: adds `content-design`, `tone-of-voice`, `design-principles` (connective/decision), and `analytical-design`, `conversion-design`, `documentation-design`, `informational-design`, `marketplace-design`, `workspace-design` (genre-specific Direct); `whatChanges` and stage prose updated to reflect the full chain
- **Pack evals** — `eval_queries.json` + `evals.json` added for all 7 previously-missing skills; `pack.toml [pack.evals].skills` now covers all 19 skills (12 original + 7 RFC-0066 additions)

## Test plan

- [x] `astro build` passes — Zod schema validates the updated frontmatter, 38 pages built
- [x] All 14 new eval JSON files parse cleanly (`python3 -c "import json; json.load(open(...))"`)
- [ ] `run-pack-evals.py` (requires live Claude) — run when eval infra is wired for CI