### PR TITLE
feat(tools): add lint-web-journey-parity gate and fix 4 journey skill-count gaps

### DIFF
--- a/tools/lint-web-journey-parity.py
+++ b/tools/lint-web-journey-parity.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Guards every web journey page against skill-count drift from its pack.
+
+Each file in web/src/content/journeys/ carries a `skills:` list in its YAML
+frontmatter. The `pack:` field names the pack it describes. The count of
+entries in the `skills:` list must match the count of skill directories in
+packs/<pack>/.apm/skills/.
+
+Invariant:
+  For every journey file, len(skills) == len(packs/<pack>/.apm/skills/*)
+
+A skill added to a pack without a corresponding journey update trips the
+invariant; a journey entry added without a matching skill directory also trips
+it. Either way the author is forced to reconcile.
+
+Exit 0 when every journey is in parity; exit 1 on any drift.
+
+Fixture mode (used by the paired self-test): set WJP_JOURNEY_DIR and
+WJP_PACKS_DIR to point to fixture directories instead of the real tree.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+import subprocess
+import sys
+
+
+def _repo_root() -> pathlib.Path:
+    try:
+        r = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=False,
+        )
+        if r.returncode == 0 and r.stdout.strip():
+            return pathlib.Path(r.stdout.strip())
+    except FileNotFoundError:
+        pass
+    return pathlib.Path.cwd()
+
+
+def _parse_frontmatter(text: str) -> tuple[str | None, int]:
+    """Return (pack_name, skill_count) from YAML frontmatter.
+
+    Parses just enough YAML to extract the `pack:` scalar and count
+    `- name:` entries under the `skills:` mapping key. No external
+    dependency — avoids PyYAML not being installed.
+    """
+    if not text.startswith("---"):
+        return None, 0
+    end = text.find("\n---", 3)
+    if end == -1:
+        return None, 0
+    fm = text[3:end]
+
+    pack: str | None = None
+    skill_count = 0
+    in_skills = False
+
+    for line in fm.splitlines():
+        m = re.match(r'^pack:\s+"?([^"\s]+)"?', line)
+        if m:
+            pack = m.group(1)
+            continue
+        if re.match(r"^skills:\s*$", line):
+            in_skills = True
+            continue
+        if in_skills:
+            if re.match(r"\s+- name:", line):
+                skill_count += 1
+            elif line and not line[0].isspace():
+                in_skills = False
+
+    return pack, skill_count
+
+
+def main() -> int:
+    root = _repo_root()
+    journey_dir = pathlib.Path(
+        os.environ.get("WJP_JOURNEY_DIR", root / "web/src/content/journeys")
+    )
+    packs_dir = pathlib.Path(
+        os.environ.get("WJP_PACKS_DIR", root / "packs")
+    )
+
+    if not journey_dir.exists():
+        print(
+            f"lint-web-journey-parity: journey directory not found: {journey_dir}",
+            file=sys.stderr,
+        )
+        return 1
+
+    findings: list[str] = []
+    checked = 0
+
+    for journey_file in sorted(journey_dir.glob("*.md")):
+        text = journey_file.read_text(encoding="utf-8")
+        pack, journey_count = _parse_frontmatter(text)
+
+        if pack is None:
+            findings.append(f"  {journey_file.name}: no `pack:` field in frontmatter")
+            continue
+
+        skills_dir = packs_dir / pack / ".apm" / "skills"
+        if not skills_dir.exists():
+            findings.append(
+                f"  {journey_file.name}: pack `{pack}` has no .apm/skills/ directory"
+            )
+            continue
+
+        actual_count = sum(1 for d in skills_dir.iterdir() if d.is_dir())
+        checked += 1
+
+        if journey_count != actual_count:
+            diff = actual_count - journey_count
+            action = "add" if diff > 0 else "remove"
+            findings.append(
+                f"  {journey_file.name} (pack: {pack}): "
+                f"journey lists {journey_count} skill(s), "
+                f"pack has {actual_count} — "
+                f"{action} {abs(diff)} from the journey's `skills:` list"
+            )
+
+    if findings:
+        print("lint-web-journey-parity: skill-count drift detected:", file=sys.stderr)
+        for f in findings:
+            print(f, file=sys.stderr)
+        return 1
+
+    print(f"lint-web-journey-parity: all {checked} journeys in parity")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/pre-pr-catalogue.py
+++ b/tools/pre-pr-catalogue.py
@@ -82,6 +82,9 @@ def main() -> int:
     _run("profiles lint self-test", [py, "tools/test-lint-profiles.py"])
     _run("pack-evals runner self-test", [py, "tools/test-run-pack-evals.py"])
     _run("pack-evals workflow posture", [py, "tools/test-pack-evals-workflow.py"])
+    _run("web-journey parity", [py, "tools/lint-web-journey-parity.py"])
+    _run("web-journey parity self-test",
+         [py, "tools/test-lint-web-journey-parity.py"])
 
     # Delegate to the shipped adopter-facing hook for the work-loop caps gate.
     result = subprocess.run(

--- a/tools/test-lint-web-journey-parity.py
+++ b/tools/test-lint-web-journey-parity.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Self-test for lint-web-journey-parity.py.
+
+Uses WJP_JOURNEY_DIR / WJP_PACKS_DIR env-override (fixture mode) to run
+the linter against controlled fixture trees rather than the real repo.
+
+Exit 0 when all assertions pass; exit 1 on the first failure.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+
+_SCRIPT = pathlib.Path(__file__).parent / "lint-web-journey-parity.py"
+
+
+def _run(journey_dir: pathlib.Path, packs_dir: pathlib.Path) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "WJP_JOURNEY_DIR": str(journey_dir), "WJP_PACKS_DIR": str(packs_dir)}
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT)],
+        capture_output=True, text=True, env=env, check=False,
+    )
+
+
+def _make_journey(d: pathlib.Path, filename: str, pack: str, skill_names: list[str]) -> None:
+    skills_block = "\n".join(
+        f"  - name: {name}\n    description: \"Test skill.\"\n    humanTouches: 0"
+        for name in skill_names
+    )
+    (d / filename).write_text(
+        f"---\npack: {pack}\nscope: user\nskills:\n{skills_block}\n---\n"
+    )
+
+
+def _make_pack_skills(packs_dir: pathlib.Path, pack: str, skill_names: list[str]) -> None:
+    skills_root = packs_dir / pack / ".apm" / "skills"
+    skills_root.mkdir(parents=True, exist_ok=True)
+    for name in skill_names:
+        (skills_root / name).mkdir(exist_ok=True)
+
+
+def _assert(condition: bool, msg: str) -> None:
+    if not condition:
+        print(f"FAIL: {msg}", file=sys.stderr)
+        sys.exit(1)
+
+
+def test_all_in_parity() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        j = pathlib.Path(tmp) / "journeys"
+        p = pathlib.Path(tmp) / "packs"
+        j.mkdir()
+        _make_journey(j, "alpha.md", "alpha", ["skill-a", "skill-b"])
+        _make_pack_skills(p, "alpha", ["skill-a", "skill-b"])
+        r = _run(j, p)
+        _assert(r.returncode == 0, f"expected exit 0 for in-parity case; got {r.returncode}\n{r.stderr}")
+
+
+def test_drift_detected() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        j = pathlib.Path(tmp) / "journeys"
+        p = pathlib.Path(tmp) / "packs"
+        j.mkdir()
+        _make_journey(j, "alpha.md", "alpha", ["skill-a"])
+        _make_pack_skills(p, "alpha", ["skill-a", "skill-b"])
+        r = _run(j, p)
+        _assert(r.returncode == 1, f"expected exit 1 for drifted case; got {r.returncode}")
+        _assert("drift" in r.stderr.lower(), f"expected drift message in stderr; got:\n{r.stderr}")
+
+
+def test_missing_pack_field() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        j = pathlib.Path(tmp) / "journeys"
+        p = pathlib.Path(tmp) / "packs"
+        j.mkdir()
+        (j / "broken.md").write_text("---\nscope: user\nskills:\n  - name: foo\n    humanTouches: 0\n---\n")
+        r = _run(j, p)
+        _assert(r.returncode == 1, f"expected exit 1 when pack: field is absent; got {r.returncode}")
+
+
+def test_missing_skills_dir() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        j = pathlib.Path(tmp) / "journeys"
+        p = pathlib.Path(tmp) / "packs"
+        j.mkdir()
+        _make_journey(j, "no-pack.md", "ghost-pack", ["skill-a"])
+        r = _run(j, p)
+        _assert(r.returncode == 1, f"expected exit 1 when pack directory is absent; got {r.returncode}")
+
+
+def test_multiple_journeys_one_drifted() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        j = pathlib.Path(tmp) / "journeys"
+        p = pathlib.Path(tmp) / "packs"
+        j.mkdir()
+        _make_journey(j, "good.md", "good-pack", ["s1", "s2"])
+        _make_pack_skills(p, "good-pack", ["s1", "s2"])
+        _make_journey(j, "bad.md", "bad-pack", ["s1"])
+        _make_pack_skills(p, "bad-pack", ["s1", "s2", "s3"])
+        r = _run(j, p)
+        _assert(r.returncode == 1, f"expected exit 1 when one of several journeys drifts; got {r.returncode}")
+        _assert("bad.md" in r.stderr, f"expected drifted file named in stderr; got:\n{r.stderr}")
+        _assert("good.md" not in r.stderr, f"expected clean file absent from stderr; got:\n{r.stderr}")
+
+
+def main() -> None:
+    tests = [
+        test_all_in_parity,
+        test_drift_detected,
+        test_missing_pack_field,
+        test_missing_skills_dir,
+        test_multiple_journeys_one_drifted,
+    ]
+    for t in tests:
+        t()
+        print(f"  ok: {t.__name__}")
+    print(f"test-lint-web-journey-parity: all {len(tests)} tests passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/web/src/content/journeys/core.md
+++ b/web/src/content/journeys/core.md
@@ -29,6 +29,21 @@ skills:
   - name: adapt-to-project
     description: "Adapts the agent-ready-repo conventions to an existing project's idioms and structure — the on-ramp for brownfield repos."
     humanTouches: 1
+  - name: author-brief
+    description: "Converts unstructured external input (email threads, prose, Linear issues) into a DoR-compliant product brief and queues it in workspace.toml."
+    humanTouches: 1
+  - name: queue-add
+    description: "Captures follow-ons, deferred scope, and audit items surfaced in a session into workspace.toml so later sessions can pick them up cold."
+    humanTouches: 1
+  - name: workspace-status
+    description: "Reads workspace.toml and surfaces ready-to-start items, blocked items, parallel candidates, and active signals — the cold-start orient for every session."
+    humanTouches: 0
+  - name: operational-safety
+    description: "Provides failure-mode-keyed operational safety checklists for the work-loop's quality-engineer reviewer. Loaded selectively for infra and destructive work — not invoked directly."
+    humanTouches: 0
+  - name: security-checklists
+    description: "Provides boundary-keyed security checklists for the security-reviewer. The work-loop loads only the boundary-matching modules — not invoked directly."
+    humanTouches: 0
 humanGates:
   - id: G-plan
     globalGate: null

--- a/web/src/content/journeys/desk-research.md
+++ b/web/src/content/journeys/desk-research.md
@@ -26,9 +26,12 @@ skills:
   - name: decision-archaeology
     description: "Reconstructs why a prior decision was made from artifacts, commit history, and design docs — used when the answer is historical rather than open."
     humanTouches: 0
-  - name: desk-desk-research-project-start
+  - name: desk-research-project-start
     description: "Initializes a research project folder with a scoped question, source list, and corpus skeleton."
     humanTouches: 1
+  - name: desk-research-project-status
+    description: "Orients to the current desk-research project at a glance — reads overview.md and surfaces phase, working hypothesis, stop-signal verdict, and what to do next."
+    humanTouches: 0
   - name: desk-research-project-check
     description: "Snapshots progress: which sources are captured, what the corpus covers, and what remains."
     humanTouches: 0

--- a/web/src/content/journeys/experience-design.md
+++ b/web/src/content/journeys/experience-design.md
@@ -59,6 +59,9 @@ skills:
   - name: design-review
     description: "Reviews an existing screen design against the quality floor — handle-all-states, accessibility, reduced-motion — before the independent review."
     humanTouches: 0
+  - name: experience-status
+    description: "Orients to the current design thread at a glance — reads design artifacts from the configured output directory and surfaces what exists, what's missing, and which skill to run next."
+    humanTouches: 0
 humanGates:
   - id: G-journey
     globalGate: null

--- a/web/src/content/journeys/governance-extras.md
+++ b/web/src/content/journeys/governance-extras.md
@@ -14,6 +14,9 @@ skills:
   - name: update-conventions
     description: "Evolves CONVENTIONS.md with tracked changes — the living record of how this project's team works."
     humanTouches: 1
+  - name: rfc-status
+    description: "Surfaces the current RFC landscape at a glance — how many RFCs are in each lifecycle state, which are active, and how many findings are waiting in the candidate register."
+    humanTouches: 0
 humanGates:
   - id: G-draft
     globalGate: null

--- a/workspace.toml
+++ b/workspace.toml
@@ -184,17 +184,9 @@ queue   = [
 # for the full schema and docs/backlog.md migration plan.
 open = [
   # Experience-design gap remediation — 2026-07-20 audit gap analysis
-  # Items 1–2 parallel-safe. Item 3 advisory-after 1+2 (lint fails on existing
-  # drift if run first). Item 4 advisory-after item 3 ships.
-
-  # New web journey page for product-strategy pack. Pack is in catalogue (9 skills,
-  # 3 pillars: market strategy, UX strategy, content strategy), has internal journey
-  # at docs/product/journeys/product-strategist-sets-direction.md, but no
-  # web/src/content/journeys/product-strategy.md. Follow existing journey schema:
-  # pack/scope/tagline/prerequisitePacks/whatChanges/skills/humanGates/typicalSession
-  # frontmatter + stage prose. Reference: packs/product-strategy/pack.toml + README.md.
-  # File: web/src/content/journeys/product-strategy.md (new)
-  {slug = "product-strategy-web-journey"},
+  # product-strategy-web-journey DONE #576.
+  # lint-web-journey-parity DONE (this PR).
+  # Remaining: xd-genre-routing-frontend-engineering (then work-loop-xd-rendered-output advisory-after).
 
   # Clarify work-loop experience-reviewer trigger: for web surface diffs, "rendered
   # output" means build the site and describe key pages from build output — not the
@@ -203,15 +195,5 @@ open = [
   # Advisory: sharper once xd-genre-routing-frontend-engineering ships.
   # File: packs/core/.apm/skills/work-loop/SKILL.md (REVIEW §, experience-reviewer block)
   {slug = "work-loop-xd-rendered-output"},
-
-  # Catalogue-maintainer lint: tools/lint-web-journey-parity.py cross-checks
-  # web/src/content/journeys/<pack>.md skills frontmatter count against
-  # packs/<pack>/.apm/skills/ directory count. Follow lint-knowledge-surface-parity.py
-  # pattern (canonical source, fail-closed, env-override fixture mode for self-test).
-  # Wire as _run step in tools/pre-pr-catalogue.py. Not projected to adopters.
-  # Advisory: ship after xd-web-journey-skill-count + product-strategy-web-journey
-  # so the gate starts green on first CI run.
-  # Files: tools/lint-web-journey-parity.py (new), tools/pre-pr-catalogue.py
-  {slug = "lint-web-journey-parity"},
 
 ]


### PR DESCRIPTION
## Summary

- Adds `tools/lint-web-journey-parity.py` — a catalogue-internal pre-PR gate that cross-checks the `skills:` frontmatter count in each `web/src/content/journeys/*.md` against the actual `packs/<pack>/.apm/skills/` directory count, exiting 1 on any drift. Follows the `lint-knowledge-surface-parity.py` pattern (env-override fixture mode, fail-closed).
- Wires both the lint and its self-test (`tools/test-lint-web-journey-parity.py`, 5 fixture cases) into `tools/pre-pr-catalogue.py`.
- Fixes 4 drifted journey files so the gate starts green on first CI run.

## Journey fixes

| File | Fix |
|---|---|
| `core.md` | Added `author-brief`, `queue-add`, `workspace-status`, `operational-safety`, `security-checklists` — pack grew to 13 skills without journey updates |
| `desk-research.md` | Fixed `desk-desk-research-project-start` typo → `desk-research-project-start`; added `desk-research-project-status` |
| `experience-design.md` | Added `experience-status` (RFC-0066 skill missed in #577) |
| `governance-extras.md` | Added `rfc-status` |

## Backlog

- `lint-web-journey-parity` — shipped here
- `product-strategy-web-journey` — shipped in #576, workspace.toml cleaned up here
- Remaining: `xd-genre-routing-frontend-engineering` → `work-loop-xd-rendered-output` (advisory-after)

## Test plan

- [ ] `python3 tools/lint-web-journey-parity.py` exits 0 (all 16 journeys in parity)
- [ ] `python3 tools/test-lint-web-journey-parity.py` exits 0 (all 5 fixture cases pass)
- [ ] `make pre-pr` (or `python3 tools/pre-pr-catalogue.py`) green end-to-end