### PR TITLE
feat(core): clarify experience-reviewer rendered-output for web surfaces (core 0.13.2)

### DIFF
--- a/.agents/skills/work-loop/SKILL.md
+++ b/.agents/skills/work-loop/SKILL.md
@@ -717,12 +717,12 @@ note in the summary, not a blocker.
   [`references/infra-verification.md`](references/infra-verification.md).
 - Match `experience-reviewer` — for diffs that change what a reader or adopter
   sees (a new page, a redesigned screen, a pack card, a docs page) **in full-mode
-  work**. This is a design/experience lens, distinct from the three core
-  code-review lenses. Pass the **rendered output** (a described screen state, a
-  screenshot, or a path to the built artifact) **plus the grounded aesthetic
-  reference and constraints** (persona, outcome, platform surface) — not the
-  code diff; experience-reviewer reviews design artifacts, not code diffs, and
-  its confirm-before-reviewing gate requires the grounded reference. Fallback if
+  work**. Pass the **rendered output** (a described screen state, a screenshot, or
+  a path to the built artifact) **plus the grounded aesthetic reference and
+  constraints** (persona, outcome, platform surface) — not the code diff; its
+  confirm-before-reviewing gate requires the grounded reference. **For web surfaces
+  (HTML/CSS/JS), "rendered output" means the built site** — run the build and describe
+  key pages from the output, not the code diff. Fallback if
   no `experience-reviewer` is installed (experience-design pack absent): proceed and
   note it — absence of the experience-design pack is a named skip, not a silent pass.
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -104,7 +104,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "core",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.13.1"
+      "version": "0.13.2"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -717,12 +717,12 @@ note in the summary, not a blocker.
   [`references/infra-verification.md`](references/infra-verification.md).
 - Match `experience-reviewer` — for diffs that change what a reader or adopter
   sees (a new page, a redesigned screen, a pack card, a docs page) **in full-mode
-  work**. This is a design/experience lens, distinct from the three core
-  code-review lenses. Pass the **rendered output** (a described screen state, a
-  screenshot, or a path to the built artifact) **plus the grounded aesthetic
-  reference and constraints** (persona, outcome, platform surface) — not the
-  code diff; experience-reviewer reviews design artifacts, not code diffs, and
-  its confirm-before-reviewing gate requires the grounded reference. Fallback if
+  work**. Pass the **rendered output** (a described screen state, a screenshot, or
+  a path to the built artifact) **plus the grounded aesthetic reference and
+  constraints** (persona, outcome, platform surface) — not the code diff; its
+  confirm-before-reviewing gate requires the grounded reference. **For web surfaces
+  (HTML/CSS/JS), "rendered output" means the built site** — run the build and describe
+  key pages from the output, not the code diff. Fallback if
   no `experience-reviewer` is installed (experience-design pack absent): proceed and
   note it — absence of the experience-design pack is a named skip, not a silent pass.
 

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`work-loop` skill (core pack 0.13.2) — experience-reviewer rendered-output clarification for web surfaces.** The `experience-reviewer` bullet in the REVIEW section now explicitly states that for web surfaces (HTML/CSS/JS), "rendered output" means the built site — run the build and describe key pages from the output; the code diff alone cannot serve as the rendered artifact for genre-rubric or cross-page consistency checks. Backlog item `work-loop-xd-rendered-output`.
+
 - **`check-workspace` renamed to `workspace-status` (core pack — clean retire, no alias).** The workspace-level cold-start orient skill is now invoked as `workspace-status`. All operative references swept in one PR. Adopters invoking `check-workspace` by name will receive a "skill not found" signal; update to `workspace-status`. The new description triggers cover all phrasing the old skill responded to, plus "workspace status", "where am I", "orient me", "session start". ([RFC-0067](../rfc/0067-session-arc-conventions-and-pack-workflow-guide.md), [ADR-0054](../adr/0054-session-arc-verb-taxonomy-and-pack-type-classification.md))
 
 ### Added

--- a/docs/specs/work-loop-xd-rendered-output/spec.md
+++ b/docs/specs/work-loop-xd-rendered-output/spec.md
@@ -1,0 +1,32 @@
+# Spec: work-loop — XD rendered-output clarification
+
+- **Status:** Shipped
+- **Mode:** light (no risk trigger fired)
+- **RFC:** RFC-0064 (experience-design gap remediation)
+
+## Objective
+
+Add a one-sentence clarification to the `experience-reviewer` bullet in the
+work-loop REVIEW section: for web surface diffs, "rendered output" means the
+built site (describe key pages from build output), not the code diff. Without
+the built artifact, genre rubrics and cross-page consistency checks cannot be
+applied.
+
+## Acceptance Criteria
+
+- [x] The experience-reviewer bullet in the REVIEW section of
+  `packs/core/.apm/skills/work-loop/SKILL.md` includes a sentence clarifying
+  that for web surfaces (HTML/CSS/JS), "rendered output" means the built site —
+  run the build and describe key pages from the output, not the code diff.
+- [x] The same clarification is present in the two projected copies:
+  `.claude/skills/work-loop/SKILL.md` and `.agents/skills/work-loop/SKILL.md`.
+- [x] The backlog item `work-loop-xd-rendered-output` is removed from
+  `[backlog].open` in `workspace.toml`.
+- [x] `packs/core` version is bumped to 0.13.2 in `pack.toml` and
+  `packs/core/.claude-plugin/plugin.json`.
+
+## Tasks
+
+1. Edit experience-reviewer block in pack source + two projections (goal-based).
+2. Bump pack version to 0.13.2.
+3. Remove backlog item from workspace.toml.

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -717,12 +717,12 @@ note in the summary, not a blocker.
   [`references/infra-verification.md`](references/infra-verification.md).
 - Match `experience-reviewer` — for diffs that change what a reader or adopter
   sees (a new page, a redesigned screen, a pack card, a docs page) **in full-mode
-  work**. This is a design/experience lens, distinct from the three core
-  code-review lenses. Pass the **rendered output** (a described screen state, a
-  screenshot, or a path to the built artifact) **plus the grounded aesthetic
-  reference and constraints** (persona, outcome, platform surface) — not the
-  code diff; experience-reviewer reviews design artifacts, not code diffs, and
-  its confirm-before-reviewing gate requires the grounded reference. Fallback if
+  work**. Pass the **rendered output** (a described screen state, a screenshot, or
+  a path to the built artifact) **plus the grounded aesthetic reference and
+  constraints** (persona, outcome, platform surface) — not the code diff; its
+  confirm-before-reviewing gate requires the grounded reference. **For web surfaces
+  (HTML/CSS/JS), "rendered output" means the built site** — run the build and describe
+  key pages from the output, not the code diff. Fallback if
   no `experience-reviewer` is installed (experience-design pack absent): proceed and
   note it — absence of the experience-design pack is a named skip, not a silent pass.
 

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix, frontend-engineering, contract-acquisition, workspace-status, queue-add skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "0.13.1"
+version = "0.13.2"
 description = "Core agent-ready-repo: work-loop, new-spec, bug-fix, frontend-engineering, contract-acquisition, workspace-status, queue-add skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 readme = "README.md"
 display_name = "Core"

--- a/workspace.toml
+++ b/workspace.toml
@@ -183,17 +183,10 @@ queue   = [
 # workspace-status alongside initiative queues. See spec/m3-backlog-absorption
 # for the full schema and docs/backlog.md migration plan.
 open = [
-  # Experience-design gap remediation — 2026-07-20 audit gap analysis
+  # Experience-design gap remediation — 2026-07-20 audit gap analysis — ALL DONE.
   # product-strategy-web-journey DONE #576.
-  # lint-web-journey-parity DONE (this PR).
-  # Remaining: xd-genre-routing-frontend-engineering (then work-loop-xd-rendered-output advisory-after).
-
-  # Clarify work-loop experience-reviewer trigger: for web surface diffs, "rendered
-  # output" means build the site and describe key pages from build output — not the
-  # code diff. Without the built artifact the reviewer cannot apply genre rubrics or
-  # check cross-page consistency. One-liner clarification in REVIEW section.
-  # Advisory: sharper once xd-genre-routing-frontend-engineering ships.
-  # File: packs/core/.apm/skills/work-loop/SKILL.md (REVIEW §, experience-reviewer block)
-  {slug = "work-loop-xd-rendered-output"},
+  # lint-web-journey-parity DONE #579.
+  # xd-genre-routing-frontend-engineering DONE #580.
+  # work-loop-xd-rendered-output DONE (this PR, core 0.13.2).
 
 ]


### PR DESCRIPTION
## Summary

- Adds a one-sentence clarification to the `experience-reviewer` bullet in the work-loop REVIEW section: for web surface diffs (HTML/CSS/JS), **"rendered output" means the built site** — run the build and describe key pages from the output, not the code diff.
- Closes backlog item `work-loop-xd-rendered-output` (XD gap remediation — all four items from the 2026-07-20 audit are now done).
- Core pack bumped to **0.13.2**.

## Why

The existing guidance said "pass the rendered output … not the code diff" but didn't define what "rendered output" means for web surfaces. Without the built artifact the `experience-reviewer` cannot apply genre rubrics or check cross-page consistency — passing a code diff was the common failure mode. The advisory waited until `xd-genre-routing-frontend-engineering` shipped (#580) so the genre-routing context is in place.

Two redundant phrases were removed to hold the file at the 1000 body-line cap enforced by the skill-spec lint:
- "This is a design/experience lens, distinct from the three core code-review lenses" — restated more precisely by the new web-surface sentence.
- "experience-reviewer reviews design artifacts, not code diffs, and" — redundant after the explicit clarification.

## Test plan

- [ ] `make pre-pr` passes (skill-spec lint, web-journey parity, all checks green)
- [ ] `make build-check` exits 0
- [ ] experience-reviewer block in all three SKILL.md copies is identical
- [ ] `packs/core` version is 0.13.2 in `pack.toml`, `plugin.json`, and `marketplace.json`
- [ ] `workspace.toml [backlog].open` entry removed