### PR TITLE
fix(agentbundle,docs): repair claude plugin marketplace manifests for 2.1.209

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,10 +1,14 @@
 {
+  "name": "agent-ready-repo",
   "owner": {
     "name": "eugenelim"
   },
   "plugins": [
     {
-      "author": "eugenelim <eugenelim@users.noreply.github.com>",
+      "author": {
+        "email": "eugenelim@users.noreply.github.com",
+        "name": "eugenelim"
+      },
       "category": "architecture",
       "description": "Solution-architecture skills (architect-design, architect-diagram, architect-review) plus a forked-context design-reviewer subagent. Workspace-agnostic, user-scope by default, no required configuration.",
       "displayName": "Architect",
@@ -18,10 +22,19 @@
       "license": "Apache-2.0 OR MIT",
       "name": "architect",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
+      "source": {
+        "branch": "claude-plugins-dist",
+        "directory": "architect",
+        "repo": "eugenelim/agent-ready-repo",
+        "source": "github"
+      },
       "version": "0.13.1"
     },
     {
-      "author": "eugenelim <eugenelim@users.noreply.github.com>",
+      "author": {
+        "email": "eugenelim@users.noreply.github.com",
+        "name": "eugenelim"
+      },
       "category": "integrations",
       "description": "Atlassian primitives: jira / jira-align / confluence-crawler (credentialed CLI), plus the flow-metrics, ai-adoption-report, jira-defect-flow, and jira-brief-intake workflows that compose them.",
       "displayName": "Atlassian",
@@ -35,10 +48,19 @@
       "license": "Apache-2.0 OR MIT",
       "name": "atlassian",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
+      "source": {
+        "branch": "claude-plugins-dist",
+        "directory": "atlassian",
+        "repo": "eugenelim/agent-ready-repo",
+        "source": "github"
+      },
       "version": "0.3.2"
     },
     {
-      "author": "eugenelim <eugenelim@users.noreply.github.com>",
+      "author": {
+        "email": "eugenelim@users.noreply.github.com",
+        "name": "eugenelim"
+      },
       "category": "governance",
       "description": "Catalogue-operator skills: assimilate external primitives, survey repos, propose packs, and export white-label / attributed derivatives of the catalogue.",
       "displayName": "Catalogue Curation",
@@ -52,10 +74,19 @@
       "license": "Apache-2.0 OR MIT",
       "name": "catalogue-curation",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
+      "source": {
+        "branch": "claude-plugins-dist",
+        "directory": "catalogue-curation",
+        "repo": "eugenelim/agent-ready-repo",
+        "source": "github"
+      },
       "version": "0.1.1"
     },
     {
-      "author": "eugenelim <eugenelim@users.noreply.github.com>",
+      "author": {
+        "email": "eugenelim@users.noreply.github.com",
+        "name": "eugenelim"
+      },
       "category": "api-design",
       "description": "Contract-authoring skills: OpenAPI 3.1 (api-contract) and AsyncAPI events (event-contract).",
       "displayName": "Contracts",
@@ -69,10 +100,19 @@
       "license": "Apache-2.0 OR MIT",
       "name": "contracts",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
+      "source": {
+        "branch": "claude-plugins-dist",
+        "directory": "contracts",
+        "repo": "eugenelim/agent-ready-repo",
+        "source": "github"
+      },
       "version": "0.3.3"
     },
     {
-      "author": "eugenelim <eugenelim@users.noreply.github.com>",
+      "author": {
+        "email": "eugenelim@users.noreply.github.com",
+        "name": "eugenelim"
+      },
       "category": "file-conversion",
       "description": "File-format conversion skills: documents and images \u2192 Markdown; Markdown \u2192 styled HTML and to branded Word, PowerPoint, and Excel; Outlook .msg and MIME .eml email \u2192 Markdown.",
       "displayName": "Converters",
@@ -87,10 +127,19 @@
       "license": "Apache-2.0 OR MIT",
       "name": "converters",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
+      "source": {
+        "branch": "claude-plugins-dist",
+        "directory": "converters",
+        "repo": "eugenelim/agent-ready-repo",
+        "source": "github"
+      },
       "version": "0.9.0"
     },
     {
-      "author": "eugenelim <eugenelim@users.noreply.github.com>",
+      "author": {
+        "email": "eugenelim@users.noreply.github.com",
+        "name": "eugenelim"
+      },
       "category": "governance",
       "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix, frontend-engineering, contract-acquisition, workspace-status, queue-add skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds.",
       "displayName": "Core",
@@ -104,10 +153,19 @@
       "license": "Apache-2.0 OR MIT",
       "name": "core",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.13.3"
+      "source": {
+        "branch": "claude-plugins-dist",
+        "directory": "core",
+        "repo": "eugenelim/agent-ready-repo",
+        "source": "github"
+      },
+      "version": "0.13.2"
     },
     {
-      "author": "eugenelim <eugenelim@users.noreply.github.com>",
+      "author": {
+        "email": "eugenelim@users.noreply.github.com",
+        "name": "eugenelim"
+      },
       "category": "credentials",
       "description": "User-scope credential brokering: the credbroker library (pip-installed, in-process resolver for auth: creds skills), sso-broker (subprocess at ~/.agentbundle/bin/ for auth: sso-cookie skills), plus one LLM-cooperative credential-setup skill.",
       "displayName": "Credential Brokers",
@@ -121,10 +179,19 @@
       "license": "Apache-2.0 OR MIT",
       "name": "credential-brokers",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
+      "source": {
+        "branch": "claude-plugins-dist",
+        "directory": "credential-brokers",
+        "repo": "eugenelim/agent-ready-repo",
+        "source": "github"
+      },
       "version": "0.2.0"
     },
     {
-      "author": "eugenelim <eugenelim@users.noreply.github.com>",
+      "author": {
+        "email": "eugenelim@users.noreply.github.com",
+        "name": "eugenelim"
+      },
       "category": "research",
       "description": "Evidence-grounded research portable across every repo. Eleven skills (scoping, source curation, synthesis, adversarial review, decision support, rationale reconstruction, plus a four-skill project-mode lifecycle for sustained multi-week investigations) plus two retrieval subagents; methodology grounded in seven convergent disciplines (STORM, PRISMA, ACH, Wikipedia V/RS/NPOV, OSINT, GIJN, GRADE).",
       "displayName": "Desk Research",
@@ -138,10 +205,19 @@
       "license": "Apache-2.0 OR MIT",
       "name": "desk-research",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
+      "source": {
+        "branch": "claude-plugins-dist",
+        "directory": "desk-research",
+        "repo": "eugenelim/agent-ready-repo",
+        "source": "github"
+      },
       "version": "1.1.0"
     },
     {
-      "author": "eugenelim <eugenelim@users.noreply.github.com>",
+      "author": {
+        "email": "eugenelim@users.noreply.github.com",
+        "name": "eugenelim"
+      },
       "category": "design",
       "description": "The design/UX seat for product teams \u2014 the grown-up successor to design-craft. Connective skills walk the thread from outcome to realization (journey-mapping \u2192 user-flow \u2192 service-blueprint) and map the inside-out sibling (process-mapping); craft skills design each screen (creative-direction, design-system, information-architecture, interaction-design) and critique it (design-review), all held to one shared quality-floor (handle-all-states, accessibility floor, reduced-motion). A forked-context experience-reviewer gives the design step an independent design-time review. Pure method: no stack, no values tables, no pixel comps \u2014 points to WCAG / W3C Design Tokens / Apple HIG / Material 3 / APQC / BPMN, never reprints them.",
       "displayName": "Experience Design",
@@ -156,10 +232,19 @@
       "license": "Apache-2.0 OR MIT",
       "name": "experience-design",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
+      "source": {
+        "branch": "claude-plugins-dist",
+        "directory": "experience-design",
+        "repo": "eugenelim/agent-ready-repo",
+        "source": "github"
+      },
       "version": "1.1.0"
     },
     {
-      "author": "eugenelim <eugenelim@users.noreply.github.com>",
+      "author": {
+        "email": "eugenelim@users.noreply.github.com",
+        "name": "eugenelim"
+      },
       "category": "integrations",
       "description": "Figma REST API primitive (credentialed CLI). Reads files / nodes / metadata / versions / comments / variables / dev resources, renders frame images, posts comments, and converts FigJam connector graphs to Mermaid.",
       "displayName": "Figma",
@@ -173,10 +258,19 @@
       "license": "Apache-2.0 OR MIT",
       "name": "figma",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
+      "source": {
+        "branch": "claude-plugins-dist",
+        "directory": "figma",
+        "repo": "eugenelim/agent-ready-repo",
+        "source": "github"
+      },
       "version": "0.1.4"
     },
     {
-      "author": "eugenelim <eugenelim@users.noreply.github.com>",
+      "author": {
+        "email": "eugenelim@users.noreply.github.com",
+        "name": "eugenelim"
+      },
       "category": "governance",
       "description": "Governance skills (new-rfc, new-adr, update-conventions, rfc-status) and RFC/ADR templates + seed READMEs.",
       "displayName": "Governance Extras",
@@ -189,10 +283,19 @@
       "license": "Apache-2.0 OR MIT",
       "name": "governance-extras",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
+      "source": {
+        "branch": "claude-plugins-dist",
+        "directory": "governance-extras",
+        "repo": "eugenelim/agent-ready-repo",
+        "source": "github"
+      },
       "version": "0.8.0"
     },
     {
-      "author": "eugenelim <eugenelim@users.noreply.github.com>",
+      "author": {
+        "email": "eugenelim@users.noreply.github.com",
+        "name": "eugenelim"
+      },
       "category": "infrastructure",
       "description": "Opt-in Terraform/OpenTofu IaC generator: turn a plain-language intent into governed, best-practice, cloud-agnostic Terraform plus a human-gated CI/CD pipeline. Decision-record-gated; stops at `terraform plan`; reuses core's infra-verification + operational-safety depth.",
       "displayName": "IaC (Terraform)",
@@ -207,10 +310,19 @@
       "license": "Apache-2.0 OR MIT",
       "name": "iac-terraform",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
+      "source": {
+        "branch": "claude-plugins-dist",
+        "directory": "iac-terraform",
+        "repo": "eugenelim/agent-ready-repo",
+        "source": "github"
+      },
       "version": "0.1.0"
     },
     {
-      "author": "eugenelim <eugenelim@users.noreply.github.com>",
+      "author": {
+        "email": "eugenelim@users.noreply.github.com",
+        "name": "eugenelim"
+      },
       "category": "devops",
       "description": "Monorepo scaffolding: new-package skill, packages/ seed README, packages/_example/ template.",
       "displayName": "Monorepo Extras",
@@ -223,10 +335,19 @@
       "license": "Apache-2.0 OR MIT",
       "name": "monorepo-extras",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
+      "source": {
+        "branch": "claude-plugins-dist",
+        "directory": "monorepo-extras",
+        "repo": "eugenelim/agent-ready-repo",
+        "source": "github"
+      },
       "version": "0.1.2"
     },
     {
-      "author": "eugenelim <eugenelim@users.noreply.github.com>",
+      "author": {
+        "email": "eugenelim@users.noreply.github.com",
+        "name": "eugenelim"
+      },
       "category": "product-management",
       "description": "Shape product intent into shippable specs \u2014 and into the words users read. Habits \u2014 frame-intent, de-risk-intent, decompose-intent \u2014 over a recursive, level-tagged `intent` (product-vision, product-strategy, capability, and feature intents are the same artifact at different levels \u2014 Level is an open recognized set decoupled from Scale): outcome+opportunity framing, a choosable prototype-approach to de-risk the riskiest assumption, and decomposition into the briefs/specs your delivery loop already builds \u2014 at app scale, or sliced per component across a business-unit value stream coordinated by `align-value-stream`. `voice-and-microcopy` adds the content layer: characterize a product's voice and write blame-free, actionable UI copy. Upstream of the build loop, the `discovery-loop` (run by the `discovery-lead` agent) turns a raw idea into a build-ready decision brief \u2014 diverging across candidate product shapes, converging through a lens roster with two discovery reviewers, and emitting a connected hypothesis with validation hooks \u2014 no engine. Markdown skills + agent definitions, user-scope.",
       "displayName": "Product Engineering",
@@ -240,10 +361,19 @@
       "license": "Apache-2.0 OR MIT",
       "name": "product-engineering",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
+      "source": {
+        "branch": "claude-plugins-dist",
+        "directory": "product-engineering",
+        "repo": "eugenelim/agent-ready-repo",
+        "source": "github"
+      },
       "version": "0.11.1"
     },
     {
-      "author": "eugenelim <eugenelim@users.noreply.github.com>",
+      "author": {
+        "email": "eugenelim@users.noreply.github.com",
+        "name": "eugenelim"
+      },
       "category": "product-management",
       "description": "The strategy seat upstream of product engineering and experience design \u2014 SWOT, Porter's Five Forces, PESTLE, BCG Matrix, OKR cascade, PRFAQ, stakeholder-research synthesis (Pillar 1); UX strategy with NN/g three-layer model, Jaime Levy four tenets, and Gothelf/Seiden OKR-linked UX framing (Pillar 2); content strategy via the Halvorson quad: Purpose + Process + Structure + Governance (Pillar 3). Pure method: no growth tooling, no primary research production, no stack tokens.",
       "displayName": "Product Strategy",
@@ -258,10 +388,19 @@
       "license": "Apache-2.0 OR MIT",
       "name": "product-strategy",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
+      "source": {
+        "branch": "claude-plugins-dist",
+        "directory": "product-strategy",
+        "repo": "eugenelim/agent-ready-repo",
+        "source": "github"
+      },
       "version": "0.1.0"
     },
     {
-      "author": "eugenelim <eugenelim@users.noreply.github.com>",
+      "author": {
+        "email": "eugenelim@users.noreply.github.com",
+        "name": "eugenelim"
+      },
       "category": "devops",
       "description": "The SRE/ops outer loop \u2014 deployed end-to-end validation above work-loop's inner build loop. Ships the `release-lead` agent and the `release-loop` skill: deploy the integrated whole to an ephemeral environment, run e2e, observe telemetry, feed deployed findings back to the inner loop (no human relay), redeploy, and iterate until the deployed whole converges \u2014 then stop at the human consent gate for the prod ship (G5), surfaced as a release-readiness record to ratify rather than a bare go/no-go. Autonomy is carved by minimum-regret: the agent runs the inner and outer loops on reversible ephemeral envs unwatched; humans gate the irreversible exits (first real users or data, data migrations, spend over threshold, security/auth-boundary changes, anything irreversible, and the prod ship). Reuses core's operational-safety depth modules + quality-engineer + security-reviewer, consumes the discovery sidecar schema by convention, and ships no new runtime engine and no new reviewer. Completes the company OS: product (discovery) \u2192 engineering (build) \u2192 SRE/ops (release). Markdown skill + agent definition, repo-scope.",
       "displayName": "Release Engineering",
@@ -276,10 +415,19 @@
       "license": "Apache-2.0 OR MIT",
       "name": "release-engineering",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
+      "source": {
+        "branch": "claude-plugins-dist",
+        "directory": "release-engineering",
+        "repo": "eugenelim/agent-ready-repo",
+        "source": "github"
+      },
       "version": "0.1.1"
     },
     {
-      "author": "eugenelim <eugenelim@users.noreply.github.com>",
+      "author": {
+        "email": "eugenelim@users.noreply.github.com",
+        "name": "eugenelim"
+      },
       "category": "documentation",
       "description": "Di\u00e1taxis-shaped user-guide skeleton: guides/ + tutorials/how-to/reference/explanation seed READMEs, new-guide skill.",
       "displayName": "User Guide (Di\u00e1taxis)",
@@ -293,6 +441,12 @@
       "license": "Apache-2.0 OR MIT",
       "name": "user-guide-diataxis",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
+      "source": {
+        "branch": "claude-plugins-dist",
+        "directory": "user-guide-diataxis",
+        "repo": "eugenelim/agent-ready-repo",
+        "source": "github"
+      },
       "version": "0.1.6"
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -159,7 +159,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.13.2"
+      "version": "0.13.3"
     },
     {
       "author": {

--- a/README.md
+++ b/README.md
@@ -25,11 +25,14 @@ agentbundle install --pack core
 
 ## Quick start
 
-**Install via Claude Code / Claude Desktop** (no extra tooling required):
+**Install via Claude Code** (no extra tooling required):
 
 ```bash
-# Install any pack directly — no CLI to set up
-claude plugin install https://github.com/eugenelim/agent-ready-repo/tree/claude-plugins-dist/core
+# Add the marketplace once
+claude plugin marketplace add eugenelim/agent-ready-repo
+
+# Install any pack by name
+claude plugin install core@agent-ready-repo
 
 # Browse all available packs with install commands
 # → https://eugenelim.github.io/agent-ready-repo/plugins/

--- a/docs/contracts/plugin-manifest.derived.schema.json
+++ b/docs/contracts/plugin-manifest.derived.schema.json
@@ -14,7 +14,14 @@
       "type": "array",
       "items": {"type": "string"}
     },
-    "author": {"type": "string"},
+    "author": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": {"type": "string"},
+        "email": {"type": "string"}
+      }
+    },
     "license": {"type": "string"},
     "homepage": {"type": "string"},
     "repository": {"type": "string"},
@@ -24,6 +31,16 @@
     },
     "category": {"type": "string"},
     "displayName": {"type": "string"},
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "source": {"type": "string"},
+        "repo": {"type": "string"},
+        "branch": {"type": "string"},
+        "directory": {"type": "string"}
+      }
+    },
     "hooks": {
       "type": "object",
       "properties": {

--- a/docs/contracts/plugin-manifest.schema.json
+++ b/docs/contracts/plugin-manifest.schema.json
@@ -14,7 +14,14 @@
       "type": "array",
       "items": {"type": "string"}
     },
-    "author": {"type": "string"},
+    "author": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": {"type": "string"},
+        "email": {"type": "string"}
+      }
+    },
     "license": {"type": "string"},
     "homepage": {"type": "string"},
     "repository": {"type": "string"},
@@ -23,6 +30,16 @@
       "items": {"type": "string"}
     },
     "category": {"type": "string"},
-    "displayName": {"type": "string"}
+    "displayName": {"type": "string"},
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "source": {"type": "string"},
+        "repo": {"type": "string"},
+        "branch": {"type": "string"},
+        "directory": {"type": "string"}
+      }
+    }
   }
 }

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -17,11 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Claude plugin marketplace manifest now passes `claude plugin validate` (Claude Code 2.1.209).** Three generator defects caused 35 errors: (1) marketplace missing top-level `name` field, (2) plugin `author` emitted as a plain string instead of a `{name, email}` object, (3) plugin `source` field absent entirely. All three are fixed in the build pipeline (`derive_projectable_subset`, `_run_aggregate`, `_aggregate_marketplace`). The `.claude-plugin/marketplace.json` in the working tree now validates with 0 errors.
+
 ### Changed
 
 - **`workspace-status` skill (core pack 0.13.3) — Findings step shows inline tables.** When either `docs/product/findings/rfc-candidates.md` or `docs/product/findings/roadmap-intents.md` has data rows, `workspace-status` now prints both tables inline rather than a bare count. When both registers are empty, a single summary line is shown (`0 rfc candidates · 0 roadmap intents — both registers empty`) instead of silently omitting the section.
 
 - **`work-loop` skill (core pack 0.13.2) — experience-reviewer rendered-output clarification for web surfaces.** The `experience-reviewer` bullet in the REVIEW section now explicitly states that for web surfaces (HTML/CSS/JS), "rendered output" means the built site — run the build and describe key pages from the output; the code diff alone cannot serve as the rendered artifact for genre-rubric or cross-page consistency checks. Backlog item `work-loop-xd-rendered-output`.
+- **Claude plugin install command updated to use marketplace format.** The documented install flow in `README.md` and the web catalogue now uses `claude plugin marketplace add eugenelim/agent-ready-repo` followed by `claude plugin install <pack>@agent-ready-repo`, replacing the deprecated repository-tree-URL form (`claude plugin install https://github.com/…/tree/claude-plugins-dist/<pack>`).
 
 - **`check-workspace` renamed to `workspace-status` (core pack — clean retire, no alias).** The workspace-level cold-start orient skill is now invoked as `workspace-status`. All operative references swept in one PR. Adopters invoking `check-workspace` by name will receive a "skill not found" signal; update to `workspace-status`. The new description triggers cover all phrasing the old skill responded to, plus "workspace status", "where am I", "orient me", "session start". ([RFC-0067](../rfc/0067-session-arc-conventions-and-pack-workflow-guide.md), [ADR-0054](../adr/0054-session-arc-verb-taxonomy-and-pack-type-classification.md))
 

--- a/packages/agentbundle/agentbundle/_data/plugin-manifest.derived.schema.json
+++ b/packages/agentbundle/agentbundle/_data/plugin-manifest.derived.schema.json
@@ -14,7 +14,14 @@
       "type": "array",
       "items": {"type": "string"}
     },
-    "author": {"type": "string"},
+    "author": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": {"type": "string"},
+        "email": {"type": "string"}
+      }
+    },
     "license": {"type": "string"},
     "homepage": {"type": "string"},
     "repository": {"type": "string"},
@@ -24,6 +31,16 @@
     },
     "category": {"type": "string"},
     "displayName": {"type": "string"},
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "source": {"type": "string"},
+        "repo": {"type": "string"},
+        "branch": {"type": "string"},
+        "directory": {"type": "string"}
+      }
+    },
     "hooks": {
       "type": "object",
       "properties": {

--- a/packages/agentbundle/agentbundle/_data/plugin-manifest.schema.json
+++ b/packages/agentbundle/agentbundle/_data/plugin-manifest.schema.json
@@ -14,7 +14,14 @@
       "type": "array",
       "items": {"type": "string"}
     },
-    "author": {"type": "string"},
+    "author": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": {"type": "string"},
+        "email": {"type": "string"}
+      }
+    },
     "license": {"type": "string"},
     "homepage": {"type": "string"},
     "repository": {"type": "string"},
@@ -23,6 +30,16 @@
       "items": {"type": "string"}
     },
     "category": {"type": "string"},
-    "displayName": {"type": "string"}
+    "displayName": {"type": "string"},
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "source": {"type": "string"},
+        "repo": {"type": "string"},
+        "branch": {"type": "string"},
+        "directory": {"type": "string"}
+      }
+    }
   }
 }

--- a/packages/agentbundle/agentbundle/build/main.py
+++ b/packages/agentbundle/agentbundle/build/main.py
@@ -18,6 +18,7 @@ paths.
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import sys
 import tomllib
@@ -32,6 +33,16 @@ from agentbundle.build.validate import validate as validate_instance
 PACKAGE_ROOT = Path(__file__).resolve().parent
 RECIPES_DIR = PACKAGE_ROOT / "recipes"
 REPO_ROOT = PACKAGE_ROOT.parent.parent.parent.parent
+
+# Canonical branch name for the published Claude-plugins distribution.
+# All marketplace entries' source.branch must match this value so `claude plugin
+# install` fetches from the right branch.
+_DIST_BRANCH = "claude-plugins-dist"
+
+# Match https://github.com/owner/repo (optional trailing .git and slash).
+_GITHUB_URL_RE = re.compile(
+    r"^https?://github\.com/([^/]+/[^/]+?)(?:\.git)?/?$"
+)
 
 
 def _bundled_or_repo(name: str) -> Path:
@@ -187,8 +198,11 @@ def derive_projectable_subset(pack_toml: dict) -> dict:
     subset into the claude-plugins + apm routes (the ``plugin.json`` /
     ``marketplace.json`` entry). Fixed mapping:
 
-      - ``author``      ← first ``[[pack.maintainers]]``, rendered
-        ``"Name <email>"`` (name alone when no email).
+      - ``author``      ← first ``[[pack.maintainers]]``, as object
+        ``{"name": ..., "email": ...}`` (email omitted when absent).
+      - ``source``      ← derived from ``[pack.links].repository`` when it is a
+        GitHub URL: ``{"source": "github", "repo": "owner/name",
+        "branch": _DIST_BRANCH, "directory": pack.name}``.
       - ``license``     ← ``[pack].license`` (verbatim).
       - ``homepage``    ← ``[pack.links].homepage`` (verbatim).
       - ``repository``  ← ``[pack.links].repository`` (verbatim).
@@ -214,10 +228,10 @@ def derive_projectable_subset(pack_toml: dict) -> dict:
             name = first.get("name")
             email = first.get("email")
             if isinstance(name, str) and name:
+                author_obj: dict = {"name": name}
                 if isinstance(email, str) and email:
-                    out["author"] = f"{name} <{email}>"
-                else:
-                    out["author"] = name
+                    author_obj["email"] = email
+                out["author"] = author_obj
 
     license_ = pack.get("license")
     if isinstance(license_, str) and license_:
@@ -231,6 +245,18 @@ def derive_projectable_subset(pack_toml: dict) -> dict:
         repository = links.get("repository")
         if isinstance(repository, str) and repository:
             out["repository"] = repository
+            # Derive source field: tells Claude Code where to fetch the plugin
+            # from the canonical distribution branch.
+            pack_name = pack.get("name", "")
+            if isinstance(pack_name, str) and pack_name:
+                m = _GITHUB_URL_RE.match(repository)
+                if m:
+                    out["source"] = {
+                        "source": "github",
+                        "repo": m.group(1),
+                        "branch": _DIST_BRANCH,
+                        "directory": pack_name,
+                    }
 
     keywords = pack.get("keywords")
     if isinstance(keywords, list):
@@ -628,8 +654,30 @@ def _run_aggregate(recipe: Recipe, output_dir: Path) -> dict:
     output_path = output_dir / recipe.output_file
     _assert_under(output_path, output_dir)
     output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Derive marketplace name and owner from the first entry that carries a
+    # source.repo field (populated by derive_projectable_subset).
+    marketplace_name: str | None = None
+    marketplace_owner: dict | None = None
+    for entry in entries:
+        src = entry.get("source")
+        if isinstance(src, dict):
+            repo = src.get("repo", "")
+            if isinstance(repo, str) and "/" in repo:
+                owner_part, name_part = repo.split("/", 1)
+                marketplace_name = name_part
+                marketplace_owner = {"name": owner_part}
+                break
+
+    payload: dict = {}
+    if marketplace_name:
+        payload["name"] = marketplace_name
+    if marketplace_owner:
+        payload["owner"] = marketplace_owner
+    payload["plugins"] = entries
+
     output_path.write_text(
-        json.dumps({"plugins": entries}, indent=2, sort_keys=True) + "\n",
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
         encoding="utf-8", newline="\n",
     )
     return {"recipe": recipe.name, "type": recipe.type, "entries": len(entries)}

--- a/packages/agentbundle/agentbundle/build/self_host.py
+++ b/packages/agentbundle/agentbundle/build/self_host.py
@@ -557,12 +557,13 @@ def _aggregate_marketplace(
     packs_dir: Path,
     output_root: Path,
     owner: str = "eugenelim",
+    name: str = "agent-ready-repo",
 ) -> Path:
     """Aggregate `packs/*/.claude-plugin/plugin.json` into
     `output_root/.claude-plugin/marketplace.json` so this repo is itself
-    a usable marketplace at HEAD. `owner` defaults to this repo's
-    concrete value but `run_self_host` overrides it from
-    `.adapt-discovery.toml[adapt].owner` so adopters get their own."""
+    a usable marketplace at HEAD. `owner` and `name` default to this repo's
+    concrete values but `run_self_host` overrides them from
+    `.adapt-discovery.toml` so adopters get their own."""
     entries: list[dict] = []
     for pack_path in sorted(packs_dir.iterdir()):
         if not pack_path.is_dir() or not (pack_path / "pack.toml").exists():
@@ -571,9 +572,9 @@ def _aggregate_marketplace(
         if manifest.exists():
             entry = json.loads(manifest.read_text(encoding="utf-8"))
             # enriched-pack-manifest: surface the projectable metadata subset
-            # (author / license / links / keywords / category / displayName)
-            # derived from pack.toml, so the catalogue entry is described
-            # richly. Emit-only-when-present keeps legacy entries byte-identical.
+            # (author / license / links / keywords / category / displayName /
+            # source) derived from pack.toml. Emit-only-when-present keeps
+            # legacy entries byte-identical.
             pack_meta = tomllib.loads(
                 (pack_path / "pack.toml").read_text(encoding="utf-8")
             )
@@ -582,6 +583,7 @@ def _aggregate_marketplace(
     target = output_root / ".claude-plugin" / "marketplace.json"
     target.parent.mkdir(parents=True, exist_ok=True)
     payload = {
+        "name": name,
         "owner": {"name": owner},
         "plugins": entries,
     }
@@ -1079,6 +1081,7 @@ def run_self_host(
         return 3
     discovery_flat = dict(discovery.markers)
     owner = discovery_flat.get("owner", "eugenelim")
+    marketplace_name = discovery_flat.get("project-name", "agent-ready-repo")
 
     if dry_run:
         with tempfile.TemporaryDirectory(prefix="agentbundle-shadow-") as shadow_str:
@@ -1096,7 +1099,7 @@ def run_self_host(
             except ValueError as exc:
                 print(f"self-host: {exc}", file=sys.stderr)
                 return 4
-            _aggregate_marketplace(packs_dir, shadow, owner=owner)
+            _aggregate_marketplace(packs_dir, shadow, owner=owner, name=marketplace_name)
             _recreate_claude_symlink(shadow, force_copy=no_symlink)
             extra_marker_paths = list(seed_map.keys()) + [
                 Path(".claude-plugin") / "marketplace.json",
@@ -1152,7 +1155,7 @@ def run_self_host(
     except ValueError as exc:
         print(f"self-host: {exc}", file=sys.stderr)
         return 4
-    _aggregate_marketplace(packs_dir, working_tree, owner=owner)
+    _aggregate_marketplace(packs_dir, working_tree, owner=owner, name=marketplace_name)
     _recreate_claude_symlink(working_tree, force_copy=no_symlink)
     extra_marker_paths = list(seed_map.keys()) + [
         Path(".claude-plugin") / "marketplace.json",

--- a/packages/agentbundle/agentbundle/build/tests/test_marketplace_manifest_regression.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_marketplace_manifest_regression.py
@@ -1,0 +1,316 @@
+"""Regression tests for claude plugin validate failures fixed in 2026-07.
+
+Three defects caused 35 errors from `claude plugin validate` against
+`.claude-plugin/marketplace.json` on Claude Code 2.1.209:
+
+  1. marketplace missing `name` field at the top level
+  2. plugin `author` emitted as string instead of `{name, email}` object
+  3. plugin `source` field absent entirely
+
+These tests pin the generator contracts so the same failures cannot silently
+re-appear in future changes to `derive_projectable_subset`, `_run_aggregate`,
+or `_aggregate_marketplace`.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+
+# Minimal pack.toml with full enriched metadata (maintainers + links).
+_PACK_WITH_METADATA = {
+    "pack": {
+        "name": "research",
+        "version": "0.2.0",
+        "description": "Research skills.",
+        "maintainers": [
+            {"name": "Eugene Lim", "email": "eugenelim@users.noreply.github.com"}
+        ],
+        "links": {
+            "repository": "https://github.com/eugenelim/agent-ready-repo",
+        },
+    }
+}
+
+# Same but no email — author object must still be emitted (name only).
+_PACK_NAME_ONLY = {
+    "pack": {
+        "name": "research",
+        "version": "0.2.0",
+        "description": "Research skills.",
+        "maintainers": [{"name": "Eugene Lim"}],
+        "links": {
+            "repository": "https://github.com/eugenelim/agent-ready-repo",
+        },
+    }
+}
+
+# Pack with no maintainers or links — neither author nor source should appear.
+_PACK_BARE = {
+    "pack": {
+        "name": "bare",
+        "version": "0.1.0",
+        "description": "Bare pack with no enriched metadata.",
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# derive_projectable_subset — unit-level pins
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveProjectableSubsetAuthor:
+    """author must be emitted as an object, never as a string."""
+
+    def test_author_is_object_when_maintainers_present(self):
+        from agentbundle.build.main import derive_projectable_subset
+
+        result = derive_projectable_subset(_PACK_WITH_METADATA)
+        author = result.get("author")
+        assert isinstance(author, dict), (
+            f"author must be an object ({{name, email}}), got {author!r}"
+        )
+
+    def test_author_contains_name_key(self):
+        from agentbundle.build.main import derive_projectable_subset
+
+        result = derive_projectable_subset(_PACK_WITH_METADATA)
+        assert result["author"]["name"] == "Eugene Lim"
+
+    def test_author_contains_email_key_when_present(self):
+        from agentbundle.build.main import derive_projectable_subset
+
+        result = derive_projectable_subset(_PACK_WITH_METADATA)
+        assert result["author"]["email"] == "eugenelim@users.noreply.github.com"
+
+    def test_author_omits_email_key_when_absent(self):
+        from agentbundle.build.main import derive_projectable_subset
+
+        result = derive_projectable_subset(_PACK_NAME_ONLY)
+        assert result["author"] == {"name": "Eugene Lim"}
+        assert "email" not in result["author"]
+
+    def test_author_absent_when_no_maintainers(self):
+        from agentbundle.build.main import derive_projectable_subset
+
+        result = derive_projectable_subset(_PACK_BARE)
+        assert "author" not in result
+
+
+class TestDeriveProjectableSubsetSource:
+    """source must be emitted as a github-shaped object when repository is a GitHub URL."""
+
+    def test_source_is_object_when_github_repository_present(self):
+        from agentbundle.build.main import derive_projectable_subset
+
+        result = derive_projectable_subset(_PACK_WITH_METADATA)
+        source = result.get("source")
+        assert isinstance(source, dict), (
+            f"source must be an object, got {source!r}"
+        )
+
+    def test_source_scheme_is_github(self):
+        from agentbundle.build.main import derive_projectable_subset
+
+        result = derive_projectable_subset(_PACK_WITH_METADATA)
+        assert result["source"]["source"] == "github"
+
+    def test_source_repo_is_owner_slash_name(self):
+        from agentbundle.build.main import derive_projectable_subset
+
+        result = derive_projectable_subset(_PACK_WITH_METADATA)
+        assert result["source"]["repo"] == "eugenelim/agent-ready-repo"
+
+    def test_source_branch_is_dist_branch(self):
+        from agentbundle.build.main import derive_projectable_subset
+
+        result = derive_projectable_subset(_PACK_WITH_METADATA)
+        assert result["source"]["branch"] == "claude-plugins-dist"
+
+    def test_source_directory_is_pack_name(self):
+        from agentbundle.build.main import derive_projectable_subset
+
+        result = derive_projectable_subset(_PACK_WITH_METADATA)
+        assert result["source"]["directory"] == "research"
+
+    def test_source_absent_when_no_repository(self):
+        from agentbundle.build.main import derive_projectable_subset
+
+        result = derive_projectable_subset(_PACK_BARE)
+        assert "source" not in result
+
+    def test_source_absent_for_non_github_url(self):
+        from agentbundle.build.main import derive_projectable_subset
+
+        pack = {
+            "pack": {
+                "name": "internal",
+                "version": "0.1.0",
+                "description": "Internal pack.",
+                "links": {"repository": "https://gitlab.com/example/internal"},
+            }
+        }
+        result = derive_projectable_subset(pack)
+        assert "source" not in result
+
+    def test_author_is_never_emitted_as_string(self):
+        """author must never be emitted as a plain string — regression of the 2026-07 defect."""
+        from agentbundle.build.main import derive_projectable_subset
+
+        result = derive_projectable_subset(_PACK_WITH_METADATA)
+        assert not isinstance(result.get("author"), str), (
+            "author was emitted as string — regression of the 2026-07 defect"
+        )
+
+
+# ---------------------------------------------------------------------------
+# _run_aggregate — marketplace name derivation unit pin
+# ---------------------------------------------------------------------------
+
+
+class TestRunAggregateMarketplaceName:
+    """The aggregated marketplace.json must carry a top-level `name` field."""
+
+    def _build_dist_marketplace(self, tmp_path: Path) -> dict:
+        """Run `agentbundle build` against the real packs and return marketplace.json."""
+        packs_shadow = tmp_path / "packs"
+        shutil.copytree(REPO_ROOT / "packs", packs_shadow, symlinks=True)
+        for pycache in packs_shadow.rglob("__pycache__"):
+            if pycache.is_dir():
+                shutil.rmtree(pycache, ignore_errors=True)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "agentbundle.build",
+                "build",
+                "--packs-dir",
+                str(packs_shadow),
+                "--output-dir",
+                str(tmp_path / "dist"),
+            ],
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+        )
+        assert result.returncode == 0, (
+            f"agentbundle build failed:\n{result.stdout}\n{result.stderr}"
+        )
+        marketplace = tmp_path / "dist" / "claude-plugins" / "marketplace.json"
+        return json.loads(marketplace.read_text(encoding="utf-8"))
+
+    def test_dist_marketplace_has_name_field(self, tmp_path):
+        m = self._build_dist_marketplace(tmp_path)
+        assert "name" in m, (
+            "dist marketplace.json is missing the top-level `name` field — "
+            "regression of the 2026-07 defect"
+        )
+
+    def test_dist_marketplace_name_is_repo_name(self, tmp_path):
+        m = self._build_dist_marketplace(tmp_path)
+        assert m["name"] == "agent-ready-repo"
+
+    def test_dist_marketplace_has_owner_field(self, tmp_path):
+        m = self._build_dist_marketplace(tmp_path)
+        assert isinstance(m.get("owner"), dict), "owner must be an object"
+
+    def test_dist_marketplace_every_plugin_has_object_author(self, tmp_path):
+        m = self._build_dist_marketplace(tmp_path)
+        missing = [p["name"] for p in m["plugins"] if "author" not in p]
+        assert not missing, f"Plugins missing author: {missing}"
+        string_authors = [
+            p["name"]
+            for p in m["plugins"]
+            if isinstance(p.get("author"), str)
+        ]
+        assert not string_authors, (
+            f"Plugins with string author — regression of the 2026-07 defect: {string_authors}"
+        )
+
+    def test_dist_marketplace_every_plugin_has_source(self, tmp_path):
+        m = self._build_dist_marketplace(tmp_path)
+        missing = [p["name"] for p in m["plugins"] if "source" not in p]
+        assert not missing, (
+            f"Plugins missing source — regression of the 2026-07 defect: {missing}"
+        )
+
+    def test_dist_marketplace_source_shapes_are_valid(self, tmp_path):
+        m = self._build_dist_marketplace(tmp_path)
+        for plugin in m["plugins"]:
+            src = plugin.get("source")
+            if src is None:
+                continue
+            assert isinstance(src, dict), f"{plugin['name']}.source must be object"
+            assert src.get("source") == "github", (
+                f"{plugin['name']}.source.source must be 'github'"
+            )
+            assert "/" in src.get("repo", ""), (
+                f"{plugin['name']}.source.repo must be 'owner/name'"
+            )
+            assert src.get("branch"), f"{plugin['name']}.source.branch must be set"
+            assert src.get("directory"), f"{plugin['name']}.source.directory must be set"
+
+
+# ---------------------------------------------------------------------------
+# self-host aggregate — working-tree marketplace.json pins
+# ---------------------------------------------------------------------------
+
+
+class TestSelfHostMarketplace:
+    """The working-tree .claude-plugin/marketplace.json must satisfy all three
+    shape invariants that caused the 2026-07 validation failures."""
+
+    @pytest.fixture(scope="class")
+    def marketplace(self):
+        path = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+        assert path.exists(), f"missing {path} — run make build-self first"
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def test_has_name_field(self, marketplace):
+        assert "name" in marketplace, (
+            ".claude-plugin/marketplace.json missing `name` — 2026-07 regression"
+        )
+
+    def test_name_is_agent_ready_repo(self, marketplace):
+        assert marketplace["name"] == "agent-ready-repo"
+
+    def test_has_owner_field(self, marketplace):
+        assert isinstance(marketplace.get("owner"), dict)
+
+    def test_every_plugin_has_object_author(self, marketplace):
+        """Every plugin entry must have an object author — not a string, not absent."""
+        missing = [p["name"] for p in marketplace["plugins"] if "author" not in p]
+        assert not missing, f"Plugins missing author: {missing}"
+        string_authors = [
+            p["name"]
+            for p in marketplace["plugins"]
+            if isinstance(p.get("author"), str)
+        ]
+        assert not string_authors, (
+            f"String author (not object) — regression of 2026-07 defect: {string_authors}"
+        )
+
+    def test_every_plugin_has_source(self, marketplace):
+        """Every plugin entry must carry a source field — not just some entries."""
+        missing = [p["name"] for p in marketplace["plugins"] if "source" not in p]
+        assert not missing, (
+            f"Plugins missing source — regression of 2026-07 defect: {missing}"
+        )
+
+    def test_every_source_is_valid_object(self, marketplace):
+        for plugin in marketplace["plugins"]:
+            src = plugin.get("source")
+            if src is None:
+                continue
+            assert isinstance(src, dict), (
+                f"{plugin['name']}.source must be object, got {src!r}"
+            )

--- a/packages/agentbundle/agentbundle/build/tests/test_plugin_manifest_schema.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_plugin_manifest_schema.py
@@ -167,13 +167,19 @@ class PluginManifestSchemaProjectableSubsetTests(unittest.TestCase):
     """
 
     _SUBSET = {
-        "author": "Eugene Lim <eugenelim@users.noreply.github.com>",
+        "author": {"name": "Eugene Lim", "email": "eugenelim@users.noreply.github.com"},
         "license": "Apache-2.0",
         "homepage": "https://example.com",
         "repository": "https://github.com/example/repo",
         "keywords": ["osint", "synthesis"],
         "category": "research",
         "displayName": "Research",
+        "source": {
+            "source": "github",
+            "repo": "example/repo",
+            "branch": "claude-plugins-dist",
+            "directory": "research",
+        },
     }
 
     def test_source_schema_admits_projectable_subset(self) -> None:

--- a/packages/agentbundle/agentbundle/build/tests/test_projectable_subset.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_projectable_subset.py
@@ -59,13 +59,19 @@ class DeriveProjectableSubsetTests(unittest.TestCase):
         self.assertEqual(
             subset,
             {
-                "author": "Eugene Lim <eugenelim@users.noreply.github.com>",
+                "author": {"name": "Eugene Lim", "email": "eugenelim@users.noreply.github.com"},
                 "license": "Apache-2.0",
                 "homepage": "https://example.com",
                 "repository": "https://github.com/example/repo",
                 "keywords": ["osint", "synthesis", "citations"],
                 "category": "research",
                 "displayName": "Research",
+                "source": {
+                    "source": "github",
+                    "repo": "example/repo",
+                    "branch": "claude-plugins-dist",
+                    "directory": "research",
+                },
             },
         )
 
@@ -100,7 +106,7 @@ name = "Solo Maintainer"
 """
         self.assertEqual(
             derive_projectable_subset(tomllib.loads(toml)),
-            {"author": "Solo Maintainer"},
+            {"author": {"name": "Solo Maintainer"}},
         )
 
     def test_category_is_first_of_categories(self) -> None:

--- a/packages/agentbundle/tests/integration/test_marketplace_manifest_regression.py
+++ b/packages/agentbundle/tests/integration/test_marketplace_manifest_regression.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 import pytest
 
-REPO_ROOT = Path(__file__).resolve().parents[5]
+REPO_ROOT = Path(__file__).resolve().parents[4]
 
 # Minimal pack.toml with full enriched metadata (maintainers + links).
 _PACK_WITH_METADATA = {

--- a/web/src/pages/catalogue/index.astro
+++ b/web/src/pages/catalogue/index.astro
@@ -4,8 +4,7 @@ import SiteLayout from '../../components/layout/SiteLayout.astro';
 import Section from '../../components/layout/Section.astro';
 import { withBase } from '../../lib/paths';
 
-const PLUGIN_BRANCH = 'claude-plugins-dist';
-const REPO = 'eugenelim/agent-ready-repo';
+const MARKETPLACE = 'agent-ready-repo';
 
 // SDLC value-stream order (RFC-0064 three-altitude model + the three loops):
 // core anchors first, then strategy → research → shaping → design →
@@ -44,7 +43,6 @@ const packs = allPacks
   })
   .map((e) => {
     const slug = e.id.replace(/\.md$/, '');
-    const pluginUrl = `https://github.com/${REPO}/tree/${PLUGIN_BRANCH}/${slug}`;
     return {
       slug,
       name: e.data.name,
@@ -52,7 +50,7 @@ const packs = allPacks
       tagline: e.data.tagline,
       skillCount: e.data.skills.length,
       cliCmd: e.data.installCommand,
-      pluginCmd: `claude plugin install ${pluginUrl}`,
+      pluginCmd: `claude plugin install ${slug}@${MARKETPLACE}`,
       detailUrl: withBase(`/packs/${slug}/`),
     };
   });

--- a/web/src/pages/packs/[pack].astro
+++ b/web/src/pages/packs/[pack].astro
@@ -19,10 +19,9 @@ const { Content } = await render(entry);
 
 const hasJourney = !!data.journeyUrl;
 
-const PLUGIN_BRANCH = 'claude-plugins-dist';
-const REPO = 'eugenelim/agent-ready-repo';
+const MARKETPLACE = 'agent-ready-repo';
 const packSlug = entry.id.replace(/\.md$/, '');
-const pluginInstallCmd = `claude plugin install https://github.com/${REPO}/tree/${PLUGIN_BRANCH}/${packSlug}`;
+const pluginInstallCmd = `claude plugin install ${packSlug}@${MARKETPLACE}`;
 ---
 
 <SiteLayout


### PR DESCRIPTION
## Summary

- **Root cause**: Three generator defects caused 35 errors from `claude plugin validate` against `.claude-plugin/marketplace.json` on Claude Code 2.1.209:
  1. Marketplace missing top-level `name` field
  2. Plugin `author` emitted as string `"Name <email>"` instead of `{name, email}` object
  3. Plugin `source` field absent entirely

- **Fix**: All three repaired in the generator — no hand-edits to generated artifacts:
  - `derive_projectable_subset` in `main.py`: author → object; source derived from `[pack.links].repository` when GitHub URL
  - `_run_aggregate` in `main.py`: derives marketplace `name`/`owner` from first entry's `source.repo`
  - `_aggregate_marketplace` in `self_host.py`: takes `name` param from `.adapt-discovery.toml`, includes in payload

- **Schemas** (`docs/contracts/` + agentbundle `_data/`): `author` changed to object shape; `source` property added with `additionalProperties: false`

- **Generated artifact**: `.claude-plugin/marketplace.json` regenerated via `make build-self --force`; `claude plugin validate` → 0 errors, 1 optional warning (no marketplace `description`)

- **Install docs**: README, `web/src/pages/packs/[pack].astro`, `web/src/pages/catalogue/index.astro` updated from deprecated tree-URL install form to `claude plugin marketplace add eugenelim/agent-ready-repo` + `claude plugin install <pack>@agent-ready-repo`

- **Regression coverage**: 25 new tests in `test_marketplace_manifest_regression.py` pin every-entry presence of object `author` and `source` at both unit level (`derive_projectable_subset`) and integration level (dist build + working-tree manifest)

## Note on dist branch drift

`claude-plugins-dist` branch may not yet carry all current packs — `concern` flagged by adversarial reviewer. This PR does not touch the dist branch (per task brief: "do not publish, release, push, or modify the distribution branch unless explicitly authorized"). The dist branch needs a separate regeneration pass.

## Test plan

- [ ] `claude plugin validate .claude-plugin/marketplace.json` → 0 errors
- [ ] `python -m pytest packages/agentbundle/agentbundle/build/tests/` → 600 passed
- [ ] 25 new regression tests in `test_marketplace_manifest_regression.py` all pass
- [ ] README install commands use `claude plugin marketplace add` + `install core@agent-ready-repo`