### PR TITLE
feat(workspace-status): show findings tables inline, not just a count (core 0.13.2)

### DIFF
--- a/.agents/skills/workspace-status/SKILL.md
+++ b/.agents/skills/workspace-status/SKILL.md
@@ -165,13 +165,10 @@ Format output in four sections (omit sections with no entries):
 
 **Closeout check:** if `[work].queue` is empty and `[work].active` is empty and `[work].shipped` is non-empty → surface: "`<ini-slug>`: all specs shipped — ready to close out? Run closeout to remove this section (git history preserves the record)."
 
-**Findings:** count non-header rows in `docs/product/findings/rfc-candidates.md` and `docs/product/findings/roadmap-intents.md` if the files exist. Surface as a single count line:
+**Findings:** Read `docs/product/findings/rfc-candidates.md` and `docs/product/findings/roadmap-intents.md` if they exist. Count non-header rows in each (a non-header row is any `|…|` line after the header separator row — the `|---|...|` line of dashes).
 
-```
-N rfc candidates · M roadmap intents
-```
-
-Omit the line entirely when both counts are zero or the files are absent.
+- **When either file has data rows:** output a `**Findings:**` section with both tables printed inline — paste each file's full markdown table (column header row + separator + data rows) under a sub-label (`RFC candidates:` / `Roadmap intents:`). If one file is absent or has no data rows, output its sub-label followed by `_(empty)_`.
+- **When both are empty or absent:** emit a single line: `0 rfc candidates · 0 roadmap intents — both registers empty`
 
 ---
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -104,7 +104,7 @@
       "license": "Apache-2.0 OR MIT",
       "name": "core",
       "repository": "https://github.com/eugenelim/agent-ready-repo",
-      "version": "0.13.2"
+      "version": "0.13.3"
     },
     {
       "author": "eugenelim <eugenelim@users.noreply.github.com>",

--- a/.claude/skills/workspace-status/SKILL.md
+++ b/.claude/skills/workspace-status/SKILL.md
@@ -165,13 +165,10 @@ Format output in four sections (omit sections with no entries):
 
 **Closeout check:** if `[work].queue` is empty and `[work].active` is empty and `[work].shipped` is non-empty → surface: "`<ini-slug>`: all specs shipped — ready to close out? Run closeout to remove this section (git history preserves the record)."
 
-**Findings:** count non-header rows in `docs/product/findings/rfc-candidates.md` and `docs/product/findings/roadmap-intents.md` if the files exist. Surface as a single count line:
+**Findings:** Read `docs/product/findings/rfc-candidates.md` and `docs/product/findings/roadmap-intents.md` if they exist. Count non-header rows in each (a non-header row is any `|…|` line after the header separator row — the `|---|...|` line of dashes).
 
-```
-N rfc candidates · M roadmap intents
-```
-
-Omit the line entirely when both counts are zero or the files are absent.
+- **When either file has data rows:** output a `**Findings:**` section with both tables printed inline — paste each file's full markdown table (column header row + separator + data rows) under a sub-label (`RFC candidates:` / `Roadmap intents:`). If one file is absent or has no data rows, output its sub-label followed by `_(empty)_`.
+- **When both are empty or absent:** emit a single line: `0 rfc candidates · 0 roadmap intents — both registers empty`
 
 ---
 

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`workspace-status` skill (core pack 0.13.3) — Findings step shows inline tables.** When either `docs/product/findings/rfc-candidates.md` or `docs/product/findings/roadmap-intents.md` has data rows, `workspace-status` now prints both tables inline rather than a bare count. When both registers are empty, a single summary line is shown (`0 rfc candidates · 0 roadmap intents — both registers empty`) instead of silently omitting the section.
+
 - **`work-loop` skill (core pack 0.13.2) — experience-reviewer rendered-output clarification for web surfaces.** The `experience-reviewer` bullet in the REVIEW section now explicitly states that for web surfaces (HTML/CSS/JS), "rendered output" means the built site — run the build and describe key pages from the output; the code diff alone cannot serve as the rendered artifact for genre-rubric or cross-page consistency checks. Backlog item `work-loop-xd-rendered-output`.
 
 - **`check-workspace` renamed to `workspace-status` (core pack — clean retire, no alias).** The workspace-level cold-start orient skill is now invoked as `workspace-status`. All operative references swept in one PR. Adopters invoking `check-workspace` by name will receive a "skill not found" signal; update to `workspace-status`. The new description triggers cover all phrasing the old skill responded to, plus "workspace status", "where am I", "orient me", "session start". ([RFC-0067](../rfc/0067-session-arc-conventions-and-pack-workflow-guide.md), [ADR-0054](../adr/0054-session-arc-verb-taxonomy-and-pack-type-classification.md))

--- a/packs/core/.apm/skills/workspace-status/SKILL.md
+++ b/packs/core/.apm/skills/workspace-status/SKILL.md
@@ -165,13 +165,10 @@ Format output in four sections (omit sections with no entries):
 
 **Closeout check:** if `[work].queue` is empty and `[work].active` is empty and `[work].shipped` is non-empty → surface: "`<ini-slug>`: all specs shipped — ready to close out? Run closeout to remove this section (git history preserves the record)."
 
-**Findings:** count non-header rows in `docs/product/findings/rfc-candidates.md` and `docs/product/findings/roadmap-intents.md` if the files exist. Surface as a single count line:
+**Findings:** Read `docs/product/findings/rfc-candidates.md` and `docs/product/findings/roadmap-intents.md` if they exist. Count non-header rows in each (a non-header row is any `|…|` line after the header separator row — the `|---|...|` line of dashes).
 
-```
-N rfc candidates · M roadmap intents
-```
-
-Omit the line entirely when both counts are zero or the files are absent.
+- **When either file has data rows:** output a `**Findings:**` section with both tables printed inline — paste each file's full markdown table (column header row + separator + data rows) under a sub-label (`RFC candidates:` / `Roadmap intents:`). If one file is absent or has no data rows, output its sub-label followed by `_(empty)_`.
+- **When both are empty or absent:** emit a single line: `0 rfc candidates · 0 roadmap intents — both registers empty`
 
 ---
 

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix, frontend-engineering, contract-acquisition, workspace-status, queue-add skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "0.13.2"
+version = "0.13.3"
 description = "Core agent-ready-repo: work-loop, new-spec, bug-fix, frontend-engineering, contract-acquisition, workspace-status, queue-add skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 readme = "README.md"
 display_name = "Core"


### PR DESCRIPTION
## Summary

- **`workspace-status` Findings step** now prints both `rfc-candidates.md` and `roadmap-intents.md` tables inline when either register has data rows, instead of showing only a bare count.
- When both registers are empty, emits a single line (`0 rfc candidates · 0 roadmap intents — both registers empty`) rather than silently omitting the section.
- Two nit fixes from adversarial review: separator description tightened to "header separator row — the `|---|...|` line of dashes"; output section label corrected to `**Findings:**` to match sibling section convention.

## Test plan

- [ ] Run `workspace-status` on this repo — both registers are empty → single summary line appears
- [ ] Add a data row to `docs/product/findings/rfc-candidates.md` temporarily → both tables print inline; remove afterward
- [ ] Confirm all three SKILL.md copies are byte-identical at the changed lines