### PR TITLE
fix(agentbundle): drop nested symlinks in direct-directory projection for all adapters

### DIFF
--- a/packages/agentbundle/agentbundle/build/adapters/claude_code.py
+++ b/packages/agentbundle/agentbundle/build/adapters/claude_code.py
@@ -107,6 +107,17 @@ def _project_single(pack_path: Path, contract: dict, output_root: Path) -> None:
             raise ValueError(f"claude-code: unhandled mode {mode!r} for {primitive_name}")
 
 
+def _ignore_symlinks(directory: str, names: list[str]) -> set[str]:
+    """`shutil.copytree` ignore callback: skip every symlink member.
+
+    Drops nested symlinks so they are never reproduced in the output
+    tree. The top-level `is_symlink()` skip in `_project_direct_directory`
+    covers the skill root; this covers the subtree.
+    """
+    base = Path(directory)
+    return {name for name in names if (base / name).is_symlink()}
+
+
 def _project_direct_directory(source_dir: Path, target_dir: Path) -> None:
     for entry in sorted(source_dir.iterdir()):
         # Defense-in-depth — `lint-packs` rejects packs that ship
@@ -125,10 +136,10 @@ def _project_direct_directory(source_dir: Path, target_dir: Path) -> None:
                 destination.unlink()
             elif destination.exists():
                 shutil.rmtree(destination)
-            # symlinks=True preserves symlinks rather than dereferencing
-            # them — a malicious pack with a symlink to /etc/passwd
-            # cannot exfiltrate the target into the projection.
-            shutil.copytree(entry, destination, symlinks=True)
+            # `ignore=_ignore_symlinks` drops nested symlinks so they are
+            # never reproduced in the output tree. A malicious pack with a
+            # symlink to /etc/passwd cannot exfiltrate the target.
+            shutil.copytree(entry, destination, ignore=_ignore_symlinks)
 
 
 def _project_direct_file(source_dir: Path, output_root: Path, target_prefix: str) -> None:

--- a/packages/agentbundle/agentbundle/build/adapters/codex.py
+++ b/packages/agentbundle/agentbundle/build/adapters/codex.py
@@ -29,6 +29,17 @@ from agentbundle.build.projections.codex_agent_toml import (
 )
 
 
+def _ignore_symlinks(directory: str, names: list[str]) -> set[str]:
+    """`shutil.copytree` ignore callback: skip every symlink member.
+
+    Drops nested symlinks so they are never reproduced in the output
+    tree. The top-level `is_symlink()` skip in `project_packs` covers
+    the skill root; this covers the subtree.
+    """
+    base = Path(directory)
+    return {name for name in names if (base / name).is_symlink()}
+
+
 def _iter_primitives(contract: dict) -> Iterator[str]:
     """Yield Codex's projected primitive names in phase order."""
     adapter_block = contract["adapter"]["codex"]
@@ -131,11 +142,11 @@ def project_packs(pack_paths: list[Path], contract: dict, output_root: Path) -> 
                             destination.unlink()
                         elif destination.exists():
                             shutil.rmtree(destination)
-                        # symlinks=True keeps source symlinks as
-                        # symlinks — never dereferences. A malicious
-                        # pack with a symlink to /etc/passwd cannot
-                        # exfiltrate.
-                        shutil.copytree(entry, destination, symlinks=True)
+                        # `ignore=_ignore_symlinks` drops nested symlinks
+                        # entirely — never reproduced in the output tree.
+                        # A malicious pack with a symlink to /etc/passwd
+                        # cannot exfiltrate.
+                        shutil.copytree(entry, destination, ignore=_ignore_symlinks)
             # Bound to `skill` only per spec § Never do. Other
             # direct-directory primitives opt in explicitly.
             if primitive_name == "skill":

--- a/packages/agentbundle/agentbundle/build/adapters/copilot.py
+++ b/packages/agentbundle/agentbundle/build/adapters/copilot.py
@@ -34,6 +34,17 @@ from agentbundle.build.projections.copilot_hooks_json import (
 )
 
 
+def _ignore_symlinks(directory: str, names: list[str]) -> set[str]:
+    """`shutil.copytree` ignore callback: skip every symlink member.
+
+    Drops nested symlinks so they are never reproduced in the output
+    tree. The top-level `is_symlink()` skip in `_project_direct_directory`
+    covers the skill root; this covers the subtree.
+    """
+    base = Path(directory)
+    return {name for name in names if (base / name).is_symlink()}
+
+
 def _iter_primitives(contract: dict) -> Iterator[str]:
     """Yield Copilot's projected primitive names in phase order."""
     adapter_block = contract["adapter"]["copilot"]
@@ -86,13 +97,13 @@ def _project_direct_directory(
     """Copy each `<name>/` source tree to the target directory verbatim, then
     sweep orphaned target dirs no longer backed by a source.
 
-    Mirrors codex's `direct-directory` branch: `symlinks=True` keeps source
-    symlinks as symlinks (never dereferenced), a symlink at the entry root is
-    skipped (defense-in-depth — `lint-packs` already refuses symlinked packs,
-    but a direct `project()` caller bypasses that gate), and a destination
-    symlink is `unlink`ed (never `rmtree`d) before the copy. The orphan sweep is
-    **bounded to the `skill` primitive's** expected source names, so it can
-    never delete sibling `.github/agents/` or `.github/hooks/` content.
+    A symlink at the entry root is skipped (defense-in-depth — `lint-packs`
+    already refuses symlinked packs, but a direct `project()` caller bypasses
+    that gate). `ignore=_ignore_symlinks` drops nested symlinks so they are
+    never reproduced in the output tree. A destination symlink is `unlink`ed
+    (never `rmtree`d) before the copy. The orphan sweep is **bounded to the
+    `skill` primitive's** expected source names, so it can never delete sibling
+    `.github/agents/` or `.github/hooks/` content.
     """
     target_dir = output_root / rule["target-path"].rstrip("/")
     target_dir.mkdir(parents=True, exist_ok=True)
@@ -107,6 +118,6 @@ def _project_direct_directory(
                 destination.unlink()
             elif destination.exists():
                 shutil.rmtree(destination)
-            shutil.copytree(entry, destination, symlinks=True)
+            shutil.copytree(entry, destination, ignore=_ignore_symlinks)
     if primitive_name == "skill":
         sweep_orphans(target_dir, expected_names)

--- a/packages/agentbundle/agentbundle/build/adapters/cursor.py
+++ b/packages/agentbundle/agentbundle/build/adapters/cursor.py
@@ -143,8 +143,8 @@ def _ignore_symlinks(directory: str, names: list[str]) -> set[str]:
     secret the symlink points at) into the projection. The top-level
     `is_symlink()` skip in `_project_direct_directory` only covers the skill
     root; this covers the subtree. (Build runs on trusted `packs/`; this is
-    the install-from-untrusted-catalogue defense — see docs/backlog.md for the
-    cross-adapter shared-helper follow-on.)
+    the install-from-untrusted-catalogue defense — mirrored in all five
+    direct-directory adapters.)
     """
     base = Path(directory)
     return {name for name in names if (base / name).is_symlink()}

--- a/packages/agentbundle/agentbundle/build/adapters/kiro.py
+++ b/packages/agentbundle/agentbundle/build/adapters/kiro.py
@@ -369,6 +369,17 @@ def _project_hook_wiring_to_agent_json(
 # ---------------------------------------------------------------------------
 
 
+def _ignore_symlinks(directory: str, names: list[str]) -> set[str]:
+    """`shutil.copytree` ignore callback: skip every symlink member.
+
+    Drops nested symlinks so they are never reproduced in the output
+    tree. The top-level `is_symlink()` skip in `_project_direct_directory`
+    covers the skill root; this covers the subtree.
+    """
+    base = Path(directory)
+    return {name for name in names if (base / name).is_symlink()}
+
+
 def _project_direct_directory(source_dir: Path, target_dir: Path) -> None:
     for entry in sorted(source_dir.iterdir()):
         # Defense-in-depth — `lint-packs` rejects packs that ship
@@ -386,7 +397,9 @@ def _project_direct_directory(source_dir: Path, target_dir: Path) -> None:
                 destination.unlink()
             elif destination.exists():
                 shutil.rmtree(destination)
-            shutil.copytree(entry, destination, symlinks=True)
+            # `ignore=_ignore_symlinks` drops nested symlinks so they are
+            # never reproduced in the output tree.
+            shutil.copytree(entry, destination, ignore=_ignore_symlinks)
 
 
 def _project_direct_file(source_dir: Path, output_root: Path, target_prefix: str) -> None:

--- a/packages/agentbundle/tests/unit/test_nested_symlink_hardening.py
+++ b/packages/agentbundle/tests/unit/test_nested_symlink_hardening.py
@@ -1,0 +1,146 @@
+"""Nested-symlink-install-hardening regression guard.
+
+A malicious pack shipping `.apm/skills/x/link -> /etc/passwd` must not
+reproduce that symlink in any adapter's projection. cursor.py was hardened
+first; this file pins the same protection for the four remaining adapters:
+kiro, claude_code, codex, and copilot.
+
+Each test: create a skill dir with a nested symlink → call the adapter's
+`_project_direct_directory` (or `project_packs` for codex) → assert the
+symlink is absent from the output.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def _make_skill_source(tmp: Path) -> tuple[Path, Path]:
+    """Return (source_dir, target_dir) with a nested symlink fixture.
+
+    source_dir/
+        my-skill/
+            SKILL.md     ← regular file (must be copied)
+            secret-link  → /etc/passwd (symlink — must be dropped)
+    """
+    source_dir = tmp / "source"
+    source_skill = source_dir / "my-skill"
+    source_skill.mkdir(parents=True)
+    (source_skill / "SKILL.md").write_text("# My Skill\n", encoding="utf-8")
+    (source_skill / "secret-link").symlink_to("/etc/passwd")
+
+    target_dir = tmp / "target"
+    target_dir.mkdir()
+    return source_dir, target_dir
+
+
+class TestKiroNestedSymlinkDropped(unittest.TestCase):
+    def test_nested_symlink_not_reproduced(self) -> None:
+        from agentbundle.build.adapters.kiro import _project_direct_directory
+
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = Path(raw_tmp)
+            source_dir, target_dir = _make_skill_source(tmp)
+            _project_direct_directory(source_dir, target_dir)
+
+            skill_out = target_dir / "my-skill"
+            self.assertTrue(skill_out.exists(), "skill dir must be projected")
+            self.assertTrue((skill_out / "SKILL.md").exists(), "SKILL.md must be copied")
+            self.assertFalse(
+                (skill_out / "secret-link").exists(),
+                "nested symlink must NOT be reproduced",
+            )
+            self.assertFalse(
+                (skill_out / "secret-link").is_symlink(),
+                "nested symlink must NOT appear as symlink in output",
+            )
+
+
+class TestClaudeCodeNestedSymlinkDropped(unittest.TestCase):
+    def test_nested_symlink_not_reproduced(self) -> None:
+        from agentbundle.build.adapters.claude_code import _project_direct_directory
+
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = Path(raw_tmp)
+            source_dir, target_dir = _make_skill_source(tmp)
+            _project_direct_directory(source_dir, target_dir)
+
+            skill_out = target_dir / "my-skill"
+            self.assertTrue(skill_out.exists())
+            self.assertTrue((skill_out / "SKILL.md").exists())
+            self.assertFalse((skill_out / "secret-link").exists())
+            self.assertFalse((skill_out / "secret-link").is_symlink())
+
+
+class TestCopilotNestedSymlinkDropped(unittest.TestCase):
+    def test_nested_symlink_not_reproduced(self) -> None:
+        from agentbundle.build.adapters.copilot import _project_direct_directory
+
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = Path(raw_tmp)
+            source_dir, _ = _make_skill_source(tmp)
+
+            output_root = tmp / "output"
+            output_root.mkdir()
+            rule = {"target-path": ".github/skills/"}
+            _project_direct_directory(source_dir, output_root, rule, "skill")
+
+            skill_out = output_root / ".github" / "skills" / "my-skill"
+            self.assertTrue(skill_out.exists())
+            self.assertTrue((skill_out / "SKILL.md").exists())
+            self.assertFalse((skill_out / "secret-link").exists())
+            self.assertFalse((skill_out / "secret-link").is_symlink())
+
+
+class TestCodexNestedSymlinkDropped(unittest.TestCase):
+    def test_nested_symlink_not_reproduced(self) -> None:
+        from agentbundle.build.adapters.codex import project_packs
+
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = Path(raw_tmp)
+
+            # Minimal pack with a nested symlink in a skill subdir.
+            pack = tmp / "pack"
+            skill_dir = pack / ".apm" / "skills" / "my-skill"
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text("# My Skill\n", encoding="utf-8")
+            (skill_dir / "secret-link").symlink_to("/etc/passwd")
+
+            output = tmp / "output"
+            output.mkdir()
+
+            contract: dict = {
+                "adapter": {
+                    "codex": {
+                        "projection": [
+                            {
+                                "primitive": "skill",
+                                "mode": "direct-directory",
+                                "target-path": ".agents/skills/",
+                            }
+                        ]
+                    }
+                },
+                "primitive": {
+                    "skill": {"source-path": ".apm/skills/"}
+                },
+            }
+            project_packs([pack], contract, output)
+
+            skill_out = output / ".agents" / "skills" / "my-skill"
+            self.assertTrue(skill_out.exists(), "skill dir must be projected")
+            self.assertTrue((skill_out / "SKILL.md").exists(), "SKILL.md must be copied")
+            self.assertFalse(
+                (skill_out / "secret-link").exists(),
+                "nested symlink must NOT be reproduced",
+            )
+            self.assertFalse(
+                (skill_out / "secret-link").is_symlink(),
+                "nested symlink must NOT appear as symlink in output",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/workspace.toml
+++ b/workspace.toml
@@ -251,16 +251,6 @@ open = [
   # Unblocks when: someone takes a spec scoping the cross-adapter hardening.
   {slug = "untrusted-catalogue-symlink-exfiltration"},
 
-  # Security. cursor.py's _project_direct_directory was hardened to drop nested
-  # symlinks (ignore=_ignore_symlinks), but kiro.py, codex, copilot, and claude-code
-  # still use copytree(symlinks=True). A nested symlink inside a skill dir in a
-  # malicious pack can be reproduced to an adopter's disk via those four adapters.
-  # Fix: lift cursor's symlink-skipping copy helper into
-  #   packages/agentbundle/agentbundle/projections/direct_directory.py and adopt it
-  #   in all four remaining adapters.
-  # Unblocks when: someone takes a focused cross-adapter hardening PR.
-  {slug = "nested-symlink-install-hardening"},
-
   # Security. packs/converters/.apm/skills/file-to-markdown/convert.py
   # _prescale_image disables PIL's decompression-bomb guard (Image.MAX_IMAGE_PIXELS
   # = None) with no dimension ceiling before decode. A pixel-flood image is fully


### PR DESCRIPTION
## Summary

- **Security fix** ([backlog:nested-symlink-install-hardening]): `cursor.py` was already hardened with an `_ignore_symlinks` copytree callback; `kiro`, `claude_code`, `codex`, and `copilot` still used `symlinks=True`, which reproduced nested symlinks in the output tree. A malicious pack shipping `.apm/skills/x/leak → /etc/passwd` could plant that symlink where the install walker's `read_bytes()` would later dereference it.
- Ports `cursor.py`'s `_ignore_symlinks` callback (a `shutil.copytree` ignore function that drops any symlinked entry) to all four remaining adapters and replaces `symlinks=True` with `ignore=_ignore_symlinks` in each `_project_direct_directory` / inline `copytree` call.
- Updates `cursor.py`'s docstring to remove the stale `see docs/backlog.md for the cross-adapter shared-helper follow-on` note.
- Adds `test_nested_symlink_hardening.py`: one regression test per adapter — creates a pack with a nested symlink inside a skill dir, projects it, asserts the symlink is absent from the output.

**Deferred:** extracting `_ignore_symlinks` into `direct_directory.py` as a shared helper (the original backlog suggestion) conflicts with the existing spec's `Never do` constraint on that module. Local-per-adapter duplication follows the established pattern for `_project_direct_directory` and `_skill_direct_directory_target`.

## Test plan

- [ ] `pytest packages/agentbundle/tests/unit/test_nested_symlink_hardening.py` — 4 passed
- [ ] Full unit suite (`pytest packages/agentbundle/tests/unit/`) — pre-existing `test_desk_research_project_start_elicitation` failure is unrelated to this change (confirmed on base branch)