### PR TITLE
feat(security): wire gitleaks, actionlint, zizmor CI gate + hash-pin deps

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -1,0 +1,120 @@
+name: ci-security
+
+# CI security gate (secret-scanner-for-api-key-workflows backlog item).
+#
+# Three tools:
+#   gitleaks   — secret scanner; fails on detected secrets (exit 1)
+#   actionlint — GitHub Actions linter; fails on workflow errors
+#   zizmor     — GitHub Actions security analyzer; --min-severity high
+#
+# Posture (security-load-bearing; asserted by tools/test-ci-security-workflow.py):
+#   - pull_request + push ONLY — pull_request_target absent (would expose secrets
+#     to fork PRs in a repository that has managed secrets).
+#   - Top-level permissions: contents: read — no job-level escalation.
+#   - gitleaks shell body: env-var injection pattern (no ${{ }} in run: body).
+#   - gitleaks --redact: matched secret values never reach (public) CI logs.
+#   - Binary checksums: SHA-256 hardcoded in this file (not fetched from the same
+#     origin as the binary) — upstream tampering fails the gate at-rest.
+#   - cancel-in-progress: gated to pull_request events only — push-to-main scans
+#     run to completion.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-security-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  secret-scan:
+    name: gitleaks (secret scan)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4  # v4.2.2
+        with:
+          # Full history required: gitleaks detects secrets in git log, not just
+          # the working tree. On pull_request, the range scan (BASE..HEAD) needs
+          # all commits since the base to be present locally.
+          fetch-depth: 0
+
+      - name: Install gitleaks v8.30.1
+        run: |
+          set -euo pipefail
+          VERSION=8.30.1
+          TARBALL="gitleaks_${VERSION}_linux_x64.tar.gz"
+          BASE_URL="https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}"
+          curl -sfL "${BASE_URL}/${TARBALL}" -o gl.tar.gz
+          # SHA-256 hardcoded at pin time — repo-committed, so upstream re-tagging
+          # or release tampering fails this check rather than auto-passing.
+          echo "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb  gl.tar.gz" | sha256sum -c
+          tar xzf gl.tar.gz -C /usr/local/bin gitleaks
+          rm gl.tar.gz
+          gitleaks version
+
+      - name: Scan for secrets
+        # All GitHub-context values are passed via env: — never interpolated directly
+        # into the shell body (injection sink pattern from pack-evals.yml).
+        # On pull_request: scan only new commits (BASE_SHA..HEAD).
+        # On push:        scan commits since the previous HEAD (BEFORE_SHA..HEAD).
+        # Fallback:       scan the full history if either SHA is absent or zeroed.
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          ZEROS="0000000000000000000000000000000000000000"
+          if [ -n "$BASE_SHA" ] && [ "$BASE_SHA" != "$ZEROS" ]; then
+            gitleaks detect --source . --log-opts="${BASE_SHA}..HEAD" \
+              --redact --verbose --exit-code 1
+          else
+            gitleaks detect --source . --redact --verbose --exit-code 1
+          fi
+
+  workflow-security:
+    name: actionlint + zizmor
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4  # v4.2.2
+
+      - name: Install actionlint v1.7.7
+        run: |
+          set -euo pipefail
+          VERSION=1.7.7
+          TARBALL="actionlint_${VERSION}_linux_amd64.tar.gz"
+          BASE_URL="https://github.com/rhysd/actionlint/releases/download/v${VERSION}"
+          curl -sfL "${BASE_URL}/${TARBALL}" -o al.tar.gz
+          # SHA-256 hardcoded at pin time — repo-committed, so upstream re-tagging
+          # or release tampering fails this check rather than auto-passing.
+          echo "023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757  al.tar.gz" | sha256sum -c
+          tar xzf al.tar.gz -C /usr/local/bin actionlint
+          rm al.tar.gz
+          actionlint --version
+
+      - uses: actions/setup-python@v5  # v5.6.0
+        with:
+          python-version: "3.11"
+
+      - name: Install zizmor 1.27.0
+        # Hash-pinned: same pattern as PyYAML in pack-evals.yml — a tampered or
+        # yanked-and-retagged wheel cannot silently defeat the gate.
+        run: pip install --require-hashes -r tools/requirements-ci-security-locked.txt
+
+      - name: actionlint
+        # Lints all workflow files in .github/workflows/ for syntax and
+        # common issues (shellcheck integration, expression type checks).
+        # Exit code 1 on any error.
+        run: actionlint -color
+
+      - name: zizmor (min-severity high)
+        # Scans workflow files for high-severity GitHub Actions vulnerabilities:
+        # template-injection, cache-poisoning, dangerous-triggers, artipacked, etc.
+        # unpinned-uses (HIGH in zizmor 1.27.0) is suppressed via .github/zizmor.yml —
+        # the repo accepts @vN tag-pinning as current posture (SHA pinning is backlog).
+        run: zizmor --min-severity high .github/workflows/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -148,7 +148,6 @@ jobs:
           base="${{ github.event.pull_request.base.sha }}"
           head="${{ github.event.pull_request.head.sha }}"
           changed=$(git diff --name-only "$base" "$head" -- 'docs/adr/*.md' || true)
-          fail=0
           for f in $changed; do
             # skip new files
             if ! git cat-file -e "$base:$f" 2>/dev/null; then continue; fi
@@ -158,9 +157,7 @@ jobs:
               body_diff=$(git diff "$base" "$head" -- "$f" | tail -n +12 | grep -E '^[+-]' | grep -vE '^\+\+\+|^---|Status:' || true)
               if [[ -n "$body_diff" ]]; then
                 echo "::warning file=$f::This ADR was Accepted on base. Body edits are not allowed; supersede it with a new ADR instead. (Status-only edits are fine.)"
-                fail=1
               fi
             fi
           done
-          # We warn but don't fail — reviewers make the call. Set to 'exit $fail' to make blocking.
-          exit 0
+          # Non-blocking: warns but always exits 0 — reviewers make the call.

--- a/.github/workflows/pack-evals.yml
+++ b/.github/workflows/pack-evals.yml
@@ -46,7 +46,10 @@ jobs:
       - name: Install agentbundle (projection path) + tool deps
         run: |
           pip install -e packages/agentbundle/
-          pip install -r tools/requirements.txt
+          # Hash-pinned: pack-evals.yml is the repo's first managed-secret workflow;
+          # --require-hashes ensures the sdist/wheel bytes match PyPI's published digests.
+          # Regenerate with: pip-compile --generate-hashes tools/requirements.txt
+          pip install --require-hashes -r tools/requirements-evals-locked.txt
 
       - name: Install the claude CLI (activation detector)
         # Pinned: the activation event's stream shape is version-sensitive, so

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,28 @@
+# zizmor configuration — suppress audits that represent accepted repo posture.
+#
+# unpinned-uses (HIGH in zizmor 1.27.0): the repo uses @vN tag pinning for
+# GitHub-owned actions (checkout, setup-python, upload-artifact, codeql,
+# pages/configure-pages/deploy-pages). SHA pinning is the correct long-term
+# posture and is tracked in backlog item `github-actions-sha-pin`;
+# suppressing here avoids gate noise while that work is planned.
+#
+# To suppress for a newly-added workflow: add its basename to the ignore list.
+# CONSTRAINT: only list workflows whose every `uses:` is a GitHub-owned action at @vN
+# (e.g. actions/checkout@v4, github/codeql-action@v3). Third-party or mutable-ref
+# actions (org/action@main, org/action@sha) must NOT be suppressed here — those are
+# exactly the cases unpinned-uses exists to catch.
+rules:
+  unpinned-uses:
+    ignore:
+      - build-check-windows.yml
+      - build-check.yml
+      - ci-security.yml
+      - codeql.yml
+      - docs.yml
+      - iac-release-loop-canary.yml
+      - iac-staleness.yml
+      - pack-evals.yml
+      - pages.yml
+      - publish-claude-plugins.yml
+      - release-agentbundle.yml
+      - release-credbroker.yml

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,41 @@
+# .gitleaksignore — gitleaks false-positive fingerprints for the full git history.
+#
+# Format: <commit>:<file>:<rule>:<line>   (one fingerprint per line; comments with #)
+#
+# All entries below are historical false positives confirmed during the initial
+# gitleaks scan (secret-scanner-for-api-key-workflows spec, T6).
+# Each group explains why the hit is not a real secret.
+
+# ── Keyword-argument false positives in Atlassian/Jira/Confluence skill scripts ──
+# gitleaks flags keyword arguments like `api_key=credentials.api_key` passed to
+# JiraClient / ConfluenceClient constructors. The matched value is a live
+# credential object reference (from the credbroker), not a hardcoded secret.
+441856ef38b8e21668acc68cf62c89dc3a5bea82:packs/atlassian/.apm/skills/jira/scripts/jira.py:generic-api-key:724
+85bdb3d423d4758d4fe431b90ac8e452fb57f287:packs/atlassian/.apm/skills/confluence-publisher/scripts/publish_page.py:generic-api-key:370
+85bdb3d423d4758d4fe431b90ac8e452fb57f287:.claude/skills/confluence-publisher/scripts/publish_page.py:generic-api-key:370
+2a96d31a2bc5716c7c9a57a6e88bfd013c7b3dab:.claude/skills/jira-align/scripts/jira_align.py:generic-api-key:468
+2a96d31a2bc5716c7c9a57a6e88bfd013c7b3dab:.claude/skills/jira/scripts/jira.py:generic-api-key:624
+2a96d31a2bc5716c7c9a57a6e88bfd013c7b3dab:packs/atlassian/.apm/skills/jira-align/scripts/jira_align.py:generic-api-key:468
+2a96d31a2bc5716c7c9a57a6e88bfd013c7b3dab:packs/atlassian/.apm/skills/jira/scripts/jira.py:generic-api-key:624
+
+# ── test_exit_codes.py fixture assignments (# noqa: S105) ──
+# `secret = "placeholder-value"  # noqa: S105` is a deliberate test fixture
+# used to exercise the credbroker's exit-code behavior. The value is a
+# placeholder string, never a real credential. The S105 suppression confirms
+# the team was aware of the variable name at write time.
+687919086f447c1dc6789805364dededa09c7fbd:packs/atlassian/.apm/skills/confluence-crawler/scripts/test_exit_codes.py:generic-api-key:60
+687919086f447c1dc6789805364dededa09c7fbd:packs/atlassian/.apm/skills/confluence-publisher/scripts/test_exit_codes.py:generic-api-key:59
+f036b2f0a03709193ee128ca9fb1d4d3b79ab2ca:packs/figma/.apm/skills/figma/scripts/test_exit_codes.py:generic-api-key:41
+f036b2f0a03709193ee128ca9fb1d4d3b79ab2ca:packs/atlassian/.apm/skills/jira-align/scripts/test_exit_codes.py:generic-api-key:41
+f036b2f0a03709193ee128ca9fb1d4d3b79ab2ca:packs/atlassian/.apm/skills/jira/scripts/test_exit_codes.py:generic-api-key:49
+
+# ── Keychain integration test fixture ──
+# `credential("fixture_t4", "API_TOKEN", "placeholder")` is a test fixture
+# seeding the macOS Keychain test harness with a known-safe placeholder.
+1839388e8f928e4b40dd54fb69d6831ed65ac1e8:packages/agentbundle/tests/integration/test_keychain_macos.py:generic-api-key:65
+
+# ── HTTP reference doc example header ──
+# `Idempotency-Key: <value>` in a Markdown reference document illustrating
+# standard HTTP request headers. Not a secret; a standard RFC header name.
+3033f71d3f500714a644e4d169080339d58908df:.claude/skills/api-contract/references/http-methods-and-status-codes.md:generic-api-key:120
+3033f71d3f500714a644e4d169080339d58908df:packs/contracts/.apm/skills/api-contract/references/http-methods-and-status-codes.md:generic-api-key:120

--- a/docs/specs/secret-scanner-for-api-key-workflows/plan.md
+++ b/docs/specs/secret-scanner-for-api-key-workflows/plan.md
@@ -1,0 +1,176 @@
+# Plan: secret-scanner-for-api-key-workflows
+
+## Assumption trio
+
+- **Files touched:** `.github/workflows/ci-security.yml` (new),
+  `.github/workflows/pack-evals.yml` (edit), `tools/requirements-evals-locked.txt` (new),
+  `tools/test-ci-security-workflow.py` (new); possibly inline
+  `# actionlint:ignore` or `zizmor.yml` suppressions for pre-existing issues.
+- **Tests that demonstrate done:** `python tools/test-pack-evals-workflow.py` exits 0;
+  `python tools/test-ci-security-workflow.py` exits 0;
+  `actionlint -color` exits 0 on all workflows;
+  `zizmor --min-severity high .github/workflows/` exits 0.
+- **Not changing:** existing workflow logic (build-check, codeql, docs, pack-evals
+  logic), SAST setup, Makefile, any package code. Only CI infrastructure files and
+  new tooling are in scope.
+
+## Declined patterns
+
+- Dependabot config — separate backlog item (`ast07-sca-scanner-agentbundle`).
+- SHA-pinning all existing workflows' GitHub Actions — large unrelated diff; the
+  repo's `@vN` tag-pinning pattern is accepted posture; `unpinned-uses` (HIGH in
+  zizmor 1.27.0) is suppressed via `.github/zizmor.yml`, not via severity threshold.
+- trufflehog in addition to gitleaks — one scanner is enough for a first gate.
+- GPG/cosign signature verification on gitleaks/actionlint binaries — checksum
+  verification against publisher's `checksums.txt` is the pragmatic floor; cosign
+  is the gold standard and a natural follow-on.
+- npm lockfile integrity for `pack-evals.yml` — requires a separate RFC; documented
+  as accepted risk in spec Objective.
+
+## Self-coverage disposition record
+
+| Item | Disposition |
+|------|-------------|
+| gitleaks binary version | Resolved: fetch via API during T1; pin exact version in workflow |
+| actionlint binary version | Resolved: pin 1.7.7 (from Assumption 3 in original spec) |
+| PyYAML exact version + hash | Resolved: fetch from PyPI JSON API during T2 |
+| zizmor severity for unpinned-uses | Resolved: HIGH (not medium as assumed) — suppressed via `.github/zizmor.yml` config listing all existing workflows |
+| Pre-existing actionlint errors | Surfaced (value origination): run locally in T4; fix or suppress |
+| Pre-existing zizmor high+ findings | Surfaced (value origination): run locally in T5; fix or suppress |
+| npm supply-chain risk | Surfaced (irreducible risk — requires separate RFC): documented in spec |
+| checksum verification approach | Resolved: verify tarball hash against publisher checksums.txt before extraction |
+
+## Tasks
+
+### T1 — Resolve pinned tool versions
+
+Mode: goal-based check  
+Depends on: none
+
+1. Fetch latest stable gitleaks version from GitHub releases API:
+   `curl -s https://api.github.com/repos/gitleaks/gitleaks/releases/latest | python3 -c "import sys,json; print(json.load(sys.stdin)['tag_name'])"`
+2. Confirm actionlint version 1.7.7 is available; fetch its linux-amd64 checksums.txt URL.
+3. Determine zizmor version to pin: `pip install zizmor` then `pip show zizmor | grep Version`.
+4. Fetch PyYAML hashes from PyPI:
+   `curl -s https://pypi.org/pypi/PyYAML/json | python3 -c "..."`
+   — extract version, sdist sha256, cp311 manylinux wheel sha256.
+
+Done when: four version strings and two PyYAML hashes (sdist + cp311 manylinux wheel) confirmed.
+
+### T2 — Create tools/requirements-evals-locked.txt and update pack-evals.yml
+
+Mode: goal-based check  
+Depends on: T1
+
+1. Create `tools/requirements-evals-locked.txt` with pinned PyYAML:
+   ```
+   # Hash-pinned for pack-evals.yml (the repo's first managed-secret workflow).
+   # Regenerate: pip-compile --generate-hashes tools/requirements.txt
+   PyYAML==<version> \
+       --hash=sha256:<sdist-hash> \
+       --hash=sha256:<cp311-manylinux-wheel-hash>
+   ```
+2. In `.github/workflows/pack-evals.yml`, replace:
+   `pip install -r tools/requirements.txt`
+   with:
+   `pip install --require-hashes -r tools/requirements-evals-locked.txt`
+
+Done when: `pip install --require-hashes -r tools/requirements-evals-locked.txt` exits 0.
+
+### T3 — Create tools/test-ci-security-workflow.py
+
+Mode: goal-based check  
+Depends on: none (write test before file exists — TDD red-first)
+
+Write `tools/test-ci-security-workflow.py` asserting the security-load-bearing posture
+of `ci-security.yml` (mirrors `tools/test-pack-evals-workflow.py` pattern):
+
+- Triggers: `pull_request` and `push` present; `pull_request_target` absent.
+- Permissions: top-level `{contents: read}`; no job-level broader permissions.
+- gitleaks checkout: `fetch-depth: 0` in the secret-scan job's checkout step.
+- gitleaks shell body: no `${{ }}` interpolation (env-var pattern).
+- gitleaks step: `--redact` flag present in run body.
+- Binary installs: `sha256sum` (or equivalent) appears in each binary-install step
+  before the `tar xz` extraction command.
+- Concurrency: `cancel-in-progress` expression contains `github.event_name == 'pull_request'`.
+
+Done when: test written and script exits non-zero cleanly (file not found) against
+the absent `ci-security.yml` — confirmed green in T7 once T4 creates the file.
+
+### T4 — Create .github/workflows/ci-security.yml
+
+Mode: goal-based check  
+Depends on: T1
+
+Create `.github/workflows/ci-security.yml` with:
+
+```
+on: pull_request (main) + push (main)
+permissions: contents: read
+concurrency: cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  secret-scan:
+    steps:
+      - checkout (fetch-depth: 0)
+      - install gitleaks: download tarball + checksums.txt, verify hash, extract
+      - run gitleaks detect via env-var pattern (BASE_SHA, EVENT_NAME), --redact
+
+  workflow-security:
+    steps:
+      - checkout
+      - install actionlint: download tarball + checksums.txt, verify hash, extract
+      - install zizmor: pip install 'zizmor==<pinned>'
+      - run actionlint -color
+      - run zizmor --min-severity high .github/workflows/
+```
+
+Done when: `actionlint -color .github/workflows/ci-security.yml` exits 0.
+
+Depends on: T1
+
+### T5 — Triage pre-existing actionlint + zizmor findings
+
+Mode: goal-based check  
+Depends on: T4
+
+1. Run `actionlint -color .github/workflows/*.yml` on all workflows.
+   - For each error: fix inline (if mechanical, e.g., quoting) or add
+     `# actionlint:ignore <rule>` with a one-line justification.
+2. Run `zizmor --min-severity high .github/workflows/`.
+   - Verify `unpinned-uses` does NOT appear (should be medium, below threshold).
+   - For any high+ finding: fix or add suppression to `.github/zizmor.yml`.
+
+Done when: both commands exit 0 on all workflows.
+
+### T6 — Initial gitleaks history scan
+
+Mode: goal-based check  
+Depends on: T1
+
+1. Install gitleaks locally using the version and checksum from T1:
+   ```
+   VERSION=<from T1>
+   curl -sfL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" -o gl.tar.gz
+   curl -sfL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/checksums.txt" -o gl-checksums.txt
+   grep "gitleaks_${VERSION}_linux_x64.tar.gz" gl-checksums.txt | sha256sum -c
+   tar xzf gl.tar.gz -C /tmp gitleaks
+   ```
+   (macOS: use `darwin_arm64` tarball and `shasum -a 256 -c`.)
+2. Run `/tmp/gitleaks detect --source . --verbose --redact` on the full repo history.
+3. If findings: investigate each; if legitimately historical/rotated, add to `.gitleaksignore`.
+4. If `.gitleaksignore` is created, document why in a header comment.
+
+Done when: `/tmp/gitleaks detect --source . --redact` exits 0 (clean or with `.gitleaksignore`).
+
+### T7 — Verify all gates
+
+Mode: goal-based check  
+Depends on: T2, T3, T4, T5, T6
+
+1. `python tools/test-pack-evals-workflow.py` exits 0.
+2. `python tools/test-ci-security-workflow.py` exits 0.
+3. `actionlint -color` exits 0 on all workflows.
+4. `pip install --require-hashes -r tools/requirements-evals-locked.txt` exits 0.
+
+Done when: all four commands exit 0.

--- a/docs/specs/secret-scanner-for-api-key-workflows/spec.md
+++ b/docs/specs/secret-scanner-for-api-key-workflows/spec.md
@@ -1,0 +1,137 @@
+# Secret Scanner for API-Key Workflows
+
+- **Status:** Shipped
+- **Backlog slug:** `secret-scanner-for-api-key-workflows`
+- **Constrained by:** CI-only tooling additions — no ADR required; three new CI dependencies
+  (gitleaks, actionlint, zizmor) are recorded here as the authoritative registry entry per
+  AGENTS.md § Check before acting.
+- **Created:** 2026-07-20
+- **Mode:** full (security boundary + new dependency)
+
+## Objective
+
+Wire a secret scanner (gitleaks), a workflow linter (actionlint), and a workflow security
+analyzer (zizmor) into CI as a new `ci-security.yml` workflow. Pin the external pip dependency
+in `pack-evals.yml` (the repo's first managed-secret workflow) with SHA-256 hashes.
+
+The npm install in `pack-evals.yml` (`@anthropic-ai/claude-code@2.1.185`) is version-pinned
+but not hash-verified; it is the larger supply-chain surface next to ANTHROPIC_API_KEY. This
+spec narrows its PyYAML-pinning AC to honest scope: it pins the one direct external pip dep
+and documents the npm vector as a known accepted risk (npm has no practical per-package hash
+verification in `install -g` mode without a lockfile; it requires a separate hardening RFC).
+
+## Acceptance Criteria
+
+- [x] AC1. A new `.github/workflows/ci-security.yml` runs on `pull_request`
+        (targeting `main`) and `push` to `main`.
+- [x] AC2. `ci-security.yml` declares `permissions: contents: read` at workflow
+        level (least-privilege default) with no job-level permission escalation.
+- [x] AC3. A `secret-scan` job in `ci-security.yml` installs gitleaks using a
+        version-pinned binary download; the SHA-256 is hardcoded in the workflow
+        (repo-committed, not fetched from the same origin) so upstream re-tagging
+        fails the gate. The job uses `fetch-depth: 0` on checkout. On
+        `pull_request` it scans `${BASE_SHA}..HEAD` commits; on `push` it scans
+        `${BEFORE_SHA}..HEAD` (incremental range); full-history fallback only when
+        the SHA is the zero SHA (new branch push) or absent. All GitHub-context
+        values are passed via env vars — not interpolated directly into the shell
+        body. `--redact` is passed so matched values are never echoed to (public)
+        CI logs. `set -euo pipefail` guards each install step. Exit code 1 fails
+        the job when secrets are detected.
+- [x] AC4. A `workflow-security` job in `ci-security.yml` installs actionlint
+        using a version-pinned binary download; the SHA-256 is hardcoded in the
+        workflow (same repo-committed pattern as AC3). actionlint exits 0 on all
+        `.github/workflows/*.yml` files.
+- [x] AC5. The `workflow-security` job also installs zizmor (via pip, exact version
+        pin). `zizmor --min-severity high .github/workflows/` runs and exits 0;
+        severity `high`+ findings fail the job. `unpinned-uses` (HIGH in zizmor
+        1.27.0) is suppressed via a `.github/zizmor.yml` config file — the repo
+        accepts `@vN` tag-pinning as current posture (SHA pinning is backlog). All
+        remaining `high`+ findings — including any in pre-existing workflows — are
+        addressed in AC11.
+- [x] AC6. All GitHub Actions used in `ci-security.yml` follow the repo's existing
+        `@vN` tag-pinning pattern with a `# vN.x.y` version comment for auditability.
+- [x] AC7. `pack-evals.yml`'s `pip install -r tools/requirements.txt` step is
+        replaced by `pip install --require-hashes -r tools/requirements-evals-locked.txt`;
+        the new `tools/requirements-evals-locked.txt` pins PyYAML to an exact version
+        with SHA-256 hashes for the sdist and the `cp311-manylinux_2_17_x86_64`
+        wheel (the specific artifact installed on `ubuntu-latest` / Python 3.11).
+- [x] AC8. `tools/test-pack-evals-workflow.py` continues to pass after the
+        `pack-evals.yml` edit (posture invariants unchanged).
+- [x] AC9. A new `tools/test-ci-security-workflow.py` asserts the security-load-bearing
+        posture of `ci-security.yml`: `pull_request`+`push` triggers only (no
+        `pull_request_target`), `permissions: contents: read` at workflow level with
+        no broader job-level permissions, `fetch-depth: 0` present in the gitleaks
+        checkout step, absence of `${{ }}` interpolation in the gitleaks shell body
+        (env-var pattern), presence of `--redact` in the gitleaks step, and presence
+        of a `sha256sum` or equivalent checksum command before each binary extraction.
+- [x] AC10. `actionlint -color` exits 0 on all `.github/workflows/*.yml` files
+         including pre-existing ones; any pre-existing error is either fixed inline
+         or suppressed with an `# actionlint:ignore <rule>` comment with a one-line
+         justification.
+- [x] AC11. `zizmor --min-severity high` exits 0 on all `.github/workflows/*.yml`
+         files. `unpinned-uses` (ALL 44 pre-existing findings) is suppressed via
+         `.github/zizmor.yml` with a justification comment (accepted tag-pinning
+         posture). No other high+ findings exist in the current workflow set.
+- [x] AC12. `ci-security.yml`'s `concurrency` block uses `cancel-in-progress: true`
+         for `pull_request` events only; `push`-to-`main` scans run to completion
+         (implemented via `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`).
+
+## Boundaries
+
+### Always do
+
+- Pass all GitHub-context values in the shell via env vars, never `${{ }}` interpolation
+  in `run:` bodies (injection sink pattern from pack-evals.yml).
+- Verify binary checksums before execution (gitleaks, actionlint).
+- Use `--redact` on gitleaks so matched values never reach CI logs.
+- Keep `permissions: contents: read` at workflow level.
+
+### Ask first
+
+- Making `ci-security.yml` a required status check (requires a repo settings change —
+  not a code change; out of scope for this PR but the natural follow-on).
+- Pinning the npm global install with a lockfile (requires a separate RFC on npm global
+  install integrity; accepted risk documented in Objective above).
+
+### Never do
+
+- Interpolate `${{ github.event.* }}` or any user-controlled value directly into a
+  `run:` shell body — always route through env vars.
+- Remove `--redact` from the gitleaks step.
+- Broaden `ci-security.yml` permissions to write access.
+- Change the gitleaks job trigger to `pull_request_target` (would expose secrets to
+  fork PRs).
+- Add gitleaks to the Makefile `sast` target (keep CI concerns in `.github/`).
+
+## Testing Strategy
+
+Verification mode: goal-based check.
+
+| AC | Verification |
+|----|-------------|
+| AC1 | `python tools/test-ci-security-workflow.py` asserts triggers |
+| AC2 | `python tools/test-ci-security-workflow.py` asserts permissions |
+| AC3 | Same — asserts env-var pattern, --redact presence |
+| AC4 | `actionlint -color` exits 0 on `ci-security.yml` |
+| AC5 | `pip install zizmor==<version>` + `zizmor --min-severity high .github/workflows/` exits 0 |
+| AC6 | Code review |
+| AC7 | `pip install --require-hashes -r tools/requirements-evals-locked.txt` exits 0 |
+| AC8 | `python tools/test-pack-evals-workflow.py` exits 0 |
+| AC9 | `python tools/test-ci-security-workflow.py` exits 0 |
+| AC10 | `actionlint -color` exits 0 on `.github/workflows/*.yml` |
+| AC11 | `zizmor --min-severity high .github/workflows/` exits 0 |
+| AC12 | Code review + test-ci-security-workflow.py |
+
+## Assumptions
+
+1. The repo is public — gitleaks binary is usable without a commercial license.
+2. PyYAML is pinned to a specific exact version (e.g., 6.0.2) with hashes fetched
+   from PyPI JSON API during EXECUTE.
+3. zizmor 1.27.0 classifies `unpinned-uses` as HIGH severity (not medium as
+   originally assumed). Suppressed via `.github/zizmor.yml` config (not
+   `--min-severity` threshold) — all existing workflows listed as accepted posture.
+4. The repo has no pre-existing leaked secrets in git history; if any are found
+   during T4, they are addressed before the gate goes live.
+5. The npm `install -g` supply-chain risk is a known accepted trade-off, recorded as
+   backlog item `pack-evals-npm-lockfile-integrity`; the Objective above is the durable
+   record.

--- a/tools/requirements-ci-security-locked.txt
+++ b/tools/requirements-ci-security-locked.txt
@@ -1,0 +1,9 @@
+# Hash-pinned dependencies for ci-security.yml (workflow-security job).
+# Generated from: pip index versions zizmor → 1.27.0; hashes from PyPI JSON API.
+# To regenerate: pip-compile --generate-hashes with zizmor==1.27.0 in a requirements file.
+#
+# ubuntu-latest resolves the manylinux_2_28_x86_64 wheel (any-Python binary wheel);
+# sdist covers source-build fallback. Other platform wheels are not pinned here.
+zizmor==1.27.0 \
+    --hash=sha256:ffaf8e1bb39447e643592d669761bfbc2aa636875db9079614f6a6c81cec60c8 \
+    --hash=sha256:afb28123882d2b8248f1e480bf6cc6d1af102e0d3fbe22a40f7f795b1aa9d435

--- a/tools/requirements-evals-locked.txt
+++ b/tools/requirements-evals-locked.txt
@@ -1,0 +1,11 @@
+# Hash-pinned dependencies for pack-evals.yml (the repo's first managed-secret workflow).
+# Generated from tools/requirements.txt (pyyaml>=6.0).
+# To regenerate: pip-compile --generate-hashes tools/requirements.txt
+#
+# Only the sdist and the cp311-manylinux_2_17_x86_64 wheel are pinned here —
+# pack-evals.yml runs on ubuntu-latest / Python 3.11, which resolves to the
+# manylinux wheel; the sdist covers source-build fallback. Other platform wheels
+# are not pinned to keep --require-hashes from accepting unexpected artifacts.
+PyYAML==6.0.2 \
+    --hash=sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e \
+    --hash=sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85

--- a/tools/test-ci-security-workflow.py
+++ b/tools/test-ci-security-workflow.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Posture check for .github/workflows/ci-security.yml.
+
+Security-load-bearing invariants (parallel to tools/test-pack-evals-workflow.py):
+  - Triggers: pull_request + push only; pull_request_target absent.
+  - Permissions: top-level contents:read; no broader job-level permissions.
+  - gitleaks checkout: fetch-depth: 0 in the secret-scan job.
+  - gitleaks shell body: no ${{ }} interpolation (env-var pattern).
+  - gitleaks step: --redact flag present.
+  - Binary installs: sha256sum check appears before tar extraction.
+  - Concurrency: cancel-in-progress uses the pull_request gate expression.
+
+Pure-stdlib + PyYAML (already a tools/ dependency).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import yaml
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci-security.yml"
+
+
+def fail(msg: str) -> None:
+    print(f"✖ ci-security.yml: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def main() -> int:
+    if not WORKFLOW.exists():
+        fail(f"not found at {WORKFLOW}")
+
+    text = WORKFLOW.read_text(encoding="utf-8")
+    try:
+        doc = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        fail(f"does not parse as YAML: {exc}")
+
+    # PyYAML parses the bareword `on:` key as the boolean True.
+    triggers = doc.get("on", doc.get(True))
+    if not isinstance(triggers, dict):
+        fail("`on:` must be a mapping of trigger types")
+    if "pull_request" not in triggers or "push" not in triggers:
+        fail("must trigger on both `pull_request` and `push`")
+    if "pull_request_target" in triggers:
+        fail("must NOT trigger on `pull_request_target` — fork PRs could reach secrets")
+
+    # Least-privilege permissions at workflow level.
+    perms = doc.get("permissions")
+    if perms != {"contents": "read"}:
+        fail(f"top-level permissions must be {{contents: read}}, got {perms!r}")
+
+    jobs = doc.get("jobs", {})
+    if not jobs:
+        fail("no jobs found")
+
+    # No job-level permission escalation beyond workflow-level.
+    for job_name, job in jobs.items():
+        job_perms = job.get("permissions")
+        if job_perms is not None:
+            fail(
+                f"job `{job_name}` sets explicit permissions {job_perms!r}; "
+                f"workflow-level contents:read is sufficient — no escalation allowed"
+            )
+
+    # Concurrency: cancel-in-progress must be conditional on pull_request only.
+    concurrency = doc.get("concurrency", {})
+    cancel = str(concurrency.get("cancel-in-progress", ""))
+    if "pull_request" not in cancel:
+        fail(
+            "concurrency.cancel-in-progress must be conditional on github.event_name == "
+            "'pull_request' so push-to-main scans complete; "
+            f"got: {cancel!r}"
+        )
+
+    # secret-scan job: fetch-depth: 0 for gitleaks history range.
+    secret_job = jobs.get("secret-scan")
+    if secret_job is None:
+        fail("no `secret-scan` job found")
+    checkout_steps = [
+        s for s in secret_job.get("steps", [])
+        if "checkout" in str(s.get("uses", ""))
+    ]
+    if not checkout_steps:
+        fail("secret-scan job: no checkout step found")
+    for step in checkout_steps:
+        with_block = step.get("with", {})
+        if with_block.get("fetch-depth") != 0:
+            fail("secret-scan checkout: fetch-depth must be 0 for history range scan")
+
+    # gitleaks detect step: env-var pattern (no ${{ }} in shell body).
+    gitleaks_steps = [
+        s for s in secret_job.get("steps", [])
+        if "gitleaks" in str(s.get("run", "")).lower()
+        and "detect" in str(s.get("run", "")).lower()
+    ]
+    if not gitleaks_steps:
+        fail("secret-scan job: no gitleaks detect step found")
+    for step in gitleaks_steps:
+        run_body = step.get("run", "")
+        if "${{" in run_body:
+            fail(
+                "gitleaks detect step: ${{ }} found in shell body — "
+                "use env: block to pass GitHub-context values (injection sink pattern)"
+            )
+        if "--redact" not in run_body:
+            fail(
+                "gitleaks detect step: --redact flag missing — "
+                "matched secret values must never reach (public) CI logs"
+            )
+
+    # Binary install steps: sha256sum check before tar extraction.
+    install_steps = [
+        s for s in (secret_job.get("steps", []) + sum(
+            (j.get("steps", []) for j in jobs.values()), []
+        ))
+        if "tar xz" in str(s.get("run", "")) or "tar xzf" in str(s.get("run", ""))
+    ]
+    # Deduplicate by id
+    seen_ids: set[int] = set()
+    deduped = []
+    for s in install_steps:
+        sid = id(s)
+        if sid not in seen_ids:
+            seen_ids.add(sid)
+            deduped.append(s)
+    for step in deduped:
+        run_body = step.get("run", "")
+        if "sha256sum" not in run_body and "shasum" not in run_body:
+            name = step.get("name", "(unnamed)")
+            fail(
+                f"install step '{name}': no sha256sum/shasum verification found before "
+                f"tar extraction — binary must be verified against checksums.txt"
+            )
+
+    print(
+        "✓ ci-security.yml: pull_request+push only (no pull_request_target), "
+        "contents:read, no job-level escalation, fetch-depth:0 in secret-scan, "
+        "env-var injection pattern, --redact on gitleaks, "
+        "sha256sum before all binary extractions, "
+        "cancel-in-progress conditional on pull_request. YAML parses."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/workspace.toml
+++ b/workspace.toml
@@ -261,6 +261,26 @@ open = [
   # Unblocks when: someone takes CI security hardening as its own PR.
   {slug = "secret-scanner-for-api-key-workflows"},
 
+  # Security. pack-evals.yml runs `npm install -g @anthropic-ai/claude-code@2.1.185`
+  # in the same job that exposes ANTHROPIC_API_KEY. The install is version-pinned but
+  # has no npm lockfile or per-package integrity hash — a compromised npm CDN or a
+  # re-tagged release could deliver malicious JS that exfiltrates the API key.
+  # Fix: research whether `npm install -g` supports `--integrity` or a lockfile
+  #   approach; if not, vendor the tarball or use an alternative install path.
+  # File: .github/workflows/pack-evals.yml
+  # Unblocks when: a concrete path to npm global-install integrity verification is found.
+  {slug = "pack-evals-npm-lockfile-integrity", source = "spec/secret-scanner-for-api-key-workflows AC Assumption 5"},
+
+  # Security. All .github/workflows/*.yml use @vN tag pinning (e.g. actions/checkout@v4).
+  # Tag pinning is a TOFU posture — a re-tagged release is not detected.
+  # SHA pinning (actions/checkout@<sha>) is immune to tag mutation attacks.
+  # zizmor's unpinned-uses audit (HIGH) is suppressed for existing workflows via
+  # .github/zizmor.yml; SHA pinning retires that suppression.
+  # Fix: pin each action to a commit SHA in each .github/workflows/*.yml;
+  #   update zizmor.yml to remove per-file ignore once all actions are SHA-pinned.
+  # Unblocks when: someone takes a SHA-pin sweep PR for all existing workflows.
+  {slug = "github-actions-sha-pin", source = "spec/secret-scanner-for-api-key-workflows zizmor.yml Concern"},
+
   # spec/shared-prefix-aware-multi-adapter-install follow-on (reviewer Concern).
   # install routes state RMW through statelock.persist_state_locked (concurrency AC).
   # uninstall and upgrade write state via bare safety.write_jailed, so a concurrent

--- a/workspace.toml
+++ b/workspace.toml
@@ -253,14 +253,6 @@ open = [
   # CI security. spec/pack-activation-evals introduces the repo's first long-lived
   # API-key workflow secret (ANTHROPIC_API_KEY for pack-evals.yml). No secret scanner
   # is wired today (only CodeQL + Bandit/Semgrep). Adjacent gaps: actionlint + zizmor
-  # for GitHub Actions script-injection class; pinned/locked install deps for the eval
-  # job (the agentbundle install runs in the same job that exposes the secret).
-  # Fix: wire gitleaks or trufflehog-class scanner into CI as its own PR (repo-wide
-  #   gate); add actionlint + zizmor; pin install deps.
-  # File: .github/workflows/ (new CI workflow or step).
-  # Unblocks when: someone takes CI security hardening as its own PR.
-  {slug = "secret-scanner-for-api-key-workflows"},
-
   # Security. pack-evals.yml runs `npm install -g @anthropic-ai/claude-code@2.1.185`
   # in the same job that exposes ANTHROPIC_API_KEY. The install is version-pinned but
   # has no npm lockfile or per-package integrity hash — a compromised npm CDN or a


### PR DESCRIPTION
## Summary

Implements `spec/secret-scanner-for-api-key-workflows` (full-mode; security boundary + new dependency). All 12 ACs ship in this PR.

- **New `.github/workflows/ci-security.yml`**: gitleaks v8.30.1 secret scanner + actionlint v1.7.7 workflow linter + zizmor 1.27.0 security analyzer. Binary SHA-256 hardcoded in-repo (not fetched from same release origin — closes the TOFU gap). `set -euo pipefail` on all install steps. Least-privilege (`contents: read`), no `pull_request_target`, `cancel-in-progress` conditional on PR only.
- **`pack-evals.yml`**: `pip install --require-hashes -r tools/requirements-evals-locked.txt` (PyYAML 6.0.2 hash-pinned — sdist + cp311-manylinux_2_17_x86_64). This is the repo's first managed-secret workflow; the hash pin closes its external pip supply-chain gap.
- **`tools/requirements-ci-security-locked.txt`**: zizmor 1.27.0 hash-pinned (sdist + manylinux_2_28_x86_64) — same pattern as PyYAML, so a compromised/retagged wheel can't silently defeat the gate.
- **`.github/zizmor.yml`**: suppresses `unpinned-uses` (HIGH in zizmor 1.27.0) for all existing workflows — repo accepts `@vN` tag-pinning posture. New constraint documented: only list workflows whose every `uses:` is a GitHub-owned `@vN` action.
- **`.gitleaksignore`**: 15 historical false positives (test-fixture `secret = "..."` assignments, keyword-arg patterns in Atlassian skill scripts, keychain integration test, `Idempotency-Key:` example header). Fingerprint-scoped — new secrets in the same files still fail.
- **`tools/test-ci-security-workflow.py`**: posture test asserting all security-load-bearing invariants of `ci-security.yml` (triggers, permissions, env-var injection pattern, `--redact`, sha256sum before extract, cancel-in-progress condition).
- **`docs.yml`**: remove dead `fail=0/fail=1` variables (shellcheck SC2034 — AC10 fix).

## New backlog items

- `pack-evals-npm-lockfile-integrity` — `npm install -g @anthropic-ai/claude-code@2.1.185` next to `ANTHROPIC_API_KEY`; version-pinned but no npm integrity hash. Needs separate RFC.
- `github-actions-sha-pin` — retire the `unpinned-uses` blanket suppression by SHA-pinning all `@vN` actions across all workflows.

## Local gates

All pass on `ubuntu-latest`-equivalent checks:
- `python tools/test-pack-evals-workflow.py` ✓
- `python tools/test-ci-security-workflow.py` ✓
- `actionlint -color` ✓ (all 12 workflows)
- `pip install --require-hashes -r tools/requirements-evals-locked.txt` ✓
- `pip install --require-hashes -r tools/requirements-ci-security-locked.txt` ✓
- `zizmor --min-severity high .github/workflows/` ✓ (no findings after `.github/zizmor.yml`)
- gitleaks full-history scan (826 commits): no leaks after `.gitleaksignore` ✓

## Deferred (out of scope)

- SHA-pinning existing workflows' GitHub Actions (`github-actions-sha-pin` backlog) — large unrelated diff
- GPG/cosign verification on gitleaks/actionlint — hardcoded SHA is the pragmatic floor; cosign is follow-on
- npm lockfile integrity for `pack-evals.yml` (`pack-evals-npm-lockfile-integrity` backlog) — requires separate RFC