### PR TITLE
feat(product-engineering): frame-situation skill — M2 strategic shaping step 1

### DIFF
--- a/docs/guides/product-engineering/how-to/frame-a-situation.md
+++ b/docs/guides/product-engineering/how-to/frame-a-situation.md
@@ -1,0 +1,96 @@
+# How to frame a situation
+
+**Goal:** You have a raw signal — a market observation, an OKR gap, user pain
+patterns, an engineering finding — and you need to decide what kind of thing
+it is and where to take it next.
+
+**Skill:** `frame-situation` (PE pack, user scope)
+
+---
+
+## When to use `frame-situation` vs `frame-intent`
+
+| Question | Answer | Skill |
+|---|---|---|
+| Is this affecting a whole capability area or initiative? | Yes | `frame-situation` |
+| Is this a specific feature or screen request? | Yes | `frame-intent` |
+| Do I know what outcome I want, just not how? | Yes | `frame-intent` |
+| Do I have a signal but not yet know what to do with it? | Yes | `frame-situation` |
+| Am I unsure of the altitude? | Ambiguous | Ask the skill — it will prompt you |
+
+**Rule of thumb:** if you can write "I want to build X so that Y" immediately,
+that is `frame-intent` territory. If you are holding an observation that
+something is wrong or an opportunity is emerging and you do not yet know how to
+respond — that is `frame-situation`.
+
+---
+
+## What makes a well-formed signal
+
+A well-formed signal gives the skill enough to classify. It has:
+
+- **A subject** — what domain or capability area the observation concerns.
+- **An observation** — something measured, seen, or reported (not a proposed solution).
+- **A symptom or consequence** — why it matters; what is happening because of it.
+
+**Good:** "Three teams hand-roll their own skill discovery mechanism. No shared
+standard is emerging. Onboarding takes longer each quarter as a result."
+
+**Too thin:** "Skill discovery is a problem." (No subject specificity, no
+consequence.) → The skill will ask for more detail.
+
+**Pre-solved:** "We should build a skill registry." → This is already a solution;
+frame-situation cannot classify a solution. Describe the underlying observation instead.
+
+---
+
+## How to use the Wardley assessment to choose your entry point
+
+The Wardley capability maturity table tells you how evolved each relevant
+capability area is. Use it to calibrate where to enter the PE six-step sequence:
+
+| What the assessment shows | Recommended entry |
+|---|---|
+| Capability is Genesis or early Custom-built; problem space not well-documented | Step 2 — `identify-opportunities` (map the jobs first) |
+| Capability is mid Custom-built; problem is understood; solution options unexplored | Step 3 — `diverge-solutions` |
+| Capability is late Custom-built or Product; options are known; need a committed bet | Step 5 — `place-bet` |
+
+**When to override:** The entry point is a recommendation, not a lock. If your
+team has already done extensive job-mapping on this problem area (it is documented
+somewhere), you may enter at step 3 or later. State why when you do.
+
+**When capabilities land as residual assumptions:** If the agent cannot confidently
+place a capability on the curve, it flags it as a residual assumption. Before
+entering the shaping sequence, consider a quick spike (a `desk-research` run or
+team knowledge session) to ground the placement — a misread maturity can lead to
+over-investing in a capability already commoditized, or under-investing in one that
+is differentiating.
+
+---
+
+## What to do with the workspace.toml suggestion
+
+After `frame-situation` completes, the skill prints a TOML snippet like:
+
+```toml
+{slug = "agent-skill-discovery-gap", type = "shape"},
+```
+
+Add this to your active initiative's `[shaping_queue]` backlog in `workspace.toml`.
+Two ways:
+
+1. **`queue-add`** — run the `queue-add` skill and it will prompt you through the
+   entry and write it to the right place.
+2. **Manual edit** — open `workspace.toml`, find `[ini-NNN.shaping_queue]`, and
+   add the entry to the `backlog` array.
+
+Once added, `workspace-status` will surface it as a ready `shape`-typed item and
+suggest running `identify-opportunities` (or the appropriate entry-point skill).
+
+---
+
+## See also
+
+- `frame-intent` — for feature-scoped or known-outcome work
+- `identify-opportunities` — step 2 of the shaping sequence
+- `queue-add` — for adding entries to `workspace.toml [shaping_queue]`

--- a/docs/specs/m2-frame-situation/plan.md
+++ b/docs/specs/m2-frame-situation/plan.md
@@ -1,0 +1,326 @@
+# Plan: m2-frame-situation
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Done
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn. When it changes substantially
+> (a different approach, not just a re-ordering), note why in the changelog
+> at the bottom.
+
+## Approach
+
+The whole deliverable is a single new **prompt-only skill** —
+`packs/product-engineering/.apm/skills/frame-situation/SKILL.md` — plus its
+worked example, a how-to guide, and lint/build verification. There is no
+engine, script, or contract file (Charter Principle 3).
+
+The shape mirrors `frame-domain` (same pack, same pattern): skill body defines
+the procedure and artifact schema; the agent following it produces the typed
+artifact; path resolution is config-driven three-tier. The key difference:
+`frame-domain` wraps `desk-research` applied mode; `frame-situation` wraps
+**embedded Wardley maturity reasoning** — no sub-skill delegation; the
+maturity model is documented inline and applied by the executing agent.
+
+`make build-self` is **not** a verification gate for this spec — the PE pack is
+user-scope and excluded from `_DEFAULT_SELF_HOST_PACKS`. Verification uses
+`lint-packs`, `validate`, and `build` instead, matching the sibling pattern
+from `frame-domain`.
+
+Order of operations: author SKILL.md (T1), author worked example (T2) and
+how-to guide (T3) in parallel after T1, then lint/build (T4).
+
+## Constraints
+
+- **RFC-0064 D9** — `frame-situation` consumes raw input signals and routes them
+  as `shape`-typed queue entries. Input-signal = raw triggering event; `type = "signal"`
+  in workspace.toml = standing non-graduating landscape concern — distinct.
+- **RFC-0064 M2.1** — frame-situation embeds Wardley capability maturity; output =
+  typed finding + six-step route anchor.
+- **RFC-0064 Amendment #3 + `docs/specs/queue-add/`** — workspace.toml write-back is
+  the `queue-add` front door's responsibility; `capture-work` is the proposed rename,
+  not yet accepted; this skill suggests verbally.
+- **Known Unknowns resolved 2026-07-18** — frame-intent vs frame-situation coexist.
+- **Charter Principle 3** — prompt-only; no runtime engine, script, or file-path
+  generator wired here.
+- **PE pack style** — SKILL.md <100 lines; depth in `references/` only if needed.
+- **Phase-slice doctrine** — skill ships WITH its guide (AC11).
+- **File-per-slug path** — `<output_dir>/shaping/<slug>/situation-framing.md`;
+  slug in the path prevents collision on multiple runs.
+
+## Tasks
+
+### T1 — Author SKILL.md
+
+**Depends on:** none
+
+**Verification:** goal-based — file at correct path, <100 lines, frontmatter
+passes `tools/lint-skill-spec.py`, `lint-packs` passes.
+
+**Approach:**
+
+Author `packs/product-engineering/.apm/skills/frame-situation/SKILL.md` with:
+
+**Frontmatter:**
+- `name: frame-situation`
+- `description:` one sentence — when to invoke (initiative/capability-level
+  signal → situation framing → six-step route anchor), what it produces
+  (Situation Framing artifact + Wardley maturity assessment + shaping route),
+  what NOT to use it for (feature-scope → frame-intent; assumption testing →
+  de-risk-intent; breaking down → decompose-intent).
+
+**When to invoke (5–7 lines):**
+- Confirm signal is initiative/capability-scope, not feature-scope.
+- Feature-scope → redirect to `frame-intent`; ambiguous altitude → ask.
+- Unclassifiable signal (too thin) → elicit more detail before proceeding.
+
+**Procedure (the six steps, inline):**
+
+1. **Intake** — read the signal (free text or pointer to an existing artifact);
+   infer altitude (initiative vs capability); confirm. If feature-scoped, redirect
+   to `frame-intent`. If ambiguous, ask.
+
+2. **Classify the finding type** — assess which of the five types fits:
+   `opportunity` | `risk` | `gap` | `threat` | `emergent-capability`. If the
+   signal is underdetermined, name the ambiguity and elicit. State the chosen
+   type and one-line rationale in the artifact.
+
+3. **Wardley maturity assessment** — identify up to three capability areas
+   implicated. For each, place on the four-stage curve with evidence and
+   strategic implication. Inline the stage definitions (one line each) so
+   Wardley-unfamiliar users can follow:
+   - *Genesis*: novel, uncertain, no best practice; explore/experiment.
+   - *Custom-built*: hand-crafted for specific needs; invest to differentiate or
+     watch for emerging standards.
+   - *Product*: widely available and improving; buy/adopt over build.
+   - *Commodity*: standardized utility; use off-the-shelf; competing here is waste.
+   When confident placement is not possible, mark as residual assumption. When
+   zero capabilities are placeable, emit an all-residual-assumptions table.
+
+4. **Recommend six-step entry point** — decide based on signal richness:
+   - Unknown problem → step 2 (`identify-opportunities`, default).
+   - Known problem, unknown options → step 3 (`diverge-solutions`).
+   - Known options, need bet committed → step 5 (`place-bet`).
+   State the recommendation and one-sentence rationale.
+
+5. **Emit `situation-framing.md`** — resolve `output_dir` via config-driven
+   three-tier procedure (same as `frame-intent`): repo-scope
+   `agentbundle-layout.toml [product]` → user-scope → two-branch elicitation.
+   After resolving: realpath-expand, symlink-resolve, reject `..` escapes and
+   any symlink that exits the root. Surface the resolved absolute path before
+   writing. Write to `<output_dir>/shaping/<slug>/situation-framing.md`.
+
+   Degrade: if `identify-opportunities` is not in the available skills, note
+   this in the artifact under "Step 2 readiness" and explain what the skill
+   provides. Do not block artifact emission.
+
+6. **Suggest `workspace.toml` entry** — print the TOML snippet:
+   ```toml
+   {slug = "<slug>", type = "shape"},
+   ```
+   Direct the user to add it to `[ini-NNN.shaping_queue]` backlog via
+   `queue-add` or manual edit. Do not write to `workspace.toml`.
+
+**Anti-patterns to refuse** (inline, 3–4 lines):
+- Writing to workspace.toml. Writing to a literal path. Producing a brief.
+  Forcing a Wardley stage when confidence is too low.
+
+Inline the `situation-framing.md` artifact schema (frontmatter + body sections)
+so the agent knows exactly what to emit (do not put this in a `references/` file —
+the skill must fit in <100 lines and the schema is short enough to inline).
+
+**Done when:** `tools/lint-skill-spec.py .../frame-situation/SKILL.md` exits 0,
+`lint-packs` green, `wc -l` ≤ 100.
+
+---
+
+### T2 — Author worked example
+
+**Depends on:** T1
+
+**Verification:** manual QA — read the example; confirm it walks an end-to-end
+pass and produces a recognizable `situation-framing.md` artifact.
+
+**Approach:**
+
+Author
+`packs/product-engineering/.apm/skills/frame-situation/examples/signal-to-finding.md`
+using a synthetic but realistic signal:
+
+> "Engineering reported that every team in the org hand-rolls its own agent
+> skill discovery mechanism — three implementations found, no standard emerging."
+
+Demonstrate:
+- **Signal classification:** gap (coordination overhead rising, convergence
+  opportunity)
+- **Wardley assessment:** agent skill discovery (Custom-built, with evidence);
+  inter-team coordination overhead (Genesis, no established pattern)
+- **Route recommendation:** step 2 (`identify-opportunities`) — problem is
+  confirmed but functional/emotional/social jobs not yet documented
+- **Artifact stub** showing the `situation-framing.md` shape with frontmatter
+- **workspace.toml suggestion** TOML snippet
+
+**Done when:** example file exists, is adopter-clean (no RFC-NNNN, no
+`agent-ready-repo`), reads as a coherent end-to-end narrative.
+
+---
+
+### T3 — Author Diátaxis how-to guide
+
+**Depends on:** T1
+
+**Verification:** goal-based for file existence; manual QA that it accurately
+describes the shipped skill.
+
+**Approach:**
+
+`docs/guides/product-engineering/how-to/` exists (the Diátaxis `how-to/`
+bucket under the PE pack guide). Author
+`docs/guides/product-engineering/how-to/frame-a-situation.md` as a
+Diátaxis how-to (task-oriented; reader knows what goal they want).
+
+Cover:
+1. When to reach for `frame-situation` vs `frame-intent` — the altitude
+   decision: initiative/capability-level signal vs feature-scope request.
+2. What makes a well-formed signal (enough to classify, not pre-solved).
+3. How to use the Wardley assessment to choose the six-step entry point.
+4. What to do with the workspace.toml suggestion (add via `queue-add` or
+   manually).
+
+Length: ~1–2 pages. No internal-catalogue references (RFC-NNNN, `agent-ready-repo`).
+
+**Done when:** file exists at the correct Diátaxis path.
+
+---
+
+### T4 — Lint and build verification
+
+**Depends on:** T1, T2, T3
+
+**Verification:** goal-based — all commands exit 0.
+
+**Approach:**
+
+```bash
+# From repo root
+make lint-packs        # source-side frontmatter/description/body-shape
+make validate          # pack manifest validation
+make build             # build artifacts
+pytest packages/agentbundle  # pack/contract tests (same gate as frame-domain)
+# Adopter-cleanliness grep (lint-agent-artifacts.py covers projected packs,
+# not user-scope PE pack — verify directly):
+grep -rn "RFC-0064\|agent-ready-repo\|RFC-00" \
+  packs/product-engineering/.apm/skills/frame-situation/
+# Goal-based greps for degrade/redirect branches (AC8, AC9) — pinned to
+# unique phrases; count-only OR-grep would pass vacuously on other matches:
+grep -F "Step 2 readiness" \
+  packs/product-engineering/.apm/skills/frame-situation/SKILL.md   # AC8 degrade
+grep -F "altitude mismatch" \
+  packs/product-engineering/.apm/skills/frame-situation/SKILL.md   # AC9 redirect
+grep -F "genuinely ambiguous" \
+  packs/product-engineering/.apm/skills/frame-situation/SKILL.md   # AC9 ask
+# Line count
+wc -l packs/product-engineering/.apm/skills/frame-situation/SKILL.md
+```
+
+Note: `make build-self` still runs as a drift check (confirms no unexpected
+change to self-host projection), but does **not** project this skill — the PE
+pack is user-scope (`_DEFAULT_SELF_HOST_PACKS` = core / governance-extras /
+user-guide-diataxis; `product-engineering` excluded). `lint-seeds` is
+irrelevant (this skill ships no seeds). `lint-agent-artifacts.py` covers
+projected packs only, not user-scope packs; adopter-cleanliness is verified
+by the direct grep above.
+
+**Done when:** lint-packs + validate + build exit 0; adopter-cleanliness grep
+is clean; AC8/AC9 greps return ≥1 match each; SKILL.md ≤ 100 lines.
+
+## Design (LLD)
+
+**Shape:** mixed. Pruned sub-sections: no service interface, no UI, no
+NFR-with-a-bar. Retaining: design decisions, data & schema, dependencies.
+
+### Design decisions
+
+- **Wardley assessment is inline, not delegated.** No `wardley-assess` sub-skill;
+  the model is embedded in the SKILL.md procedure. Four-stage definitions inline
+  so Wardley-unfamiliar adopters can follow without prior reading.
+- **File-per-slug path prevents collision.** `<output_dir>/shaping/<slug>/situation-framing.md`
+  — each signal produces its own path; a second run never overwrites the first.
+  This matches `frame-domain`'s per-initiative subfolder pattern (not
+  `frame-intent`'s flat file-per-slug) because situation framing may later
+  accumulate sibling artifacts (opportunity assessment, etc.) under the same slug.
+- **One typed artifact.** `frame-domain` emits two because they have separate
+  downstream lifecycles. `frame-situation` emits one — all components (classification,
+  Wardley, route) feed the same shaping chain step together.
+- **Three capability areas cap.** Beyond three, the assessment becomes a strategy
+  document rather than a framing artifact; three forces prioritization.
+- **No workspace.toml write.** Deferred to `capture-work`. This skill is scope-
+  bounded to analysis + artifact; workspace coordination belongs to its owner.
+- **config-driven path (same as frame-intent).** Re-uses the established three-tier
+  convention; no second path-resolution model in the pack.
+
+### Data & schema
+
+`situation-framing.md` — the one typed artifact:
+
+```markdown
+---
+type: situation-framing
+slug: <derived-from-signal-subject>
+signal: "<one-line signal description>"
+finding-type: opportunity | risk | gap | threat | emergent-capability
+date: <ISO date>
+shaping-entry: identify-opportunities | diverge-solutions | place-bet
+---
+
+# Situation Framing: <slug>
+
+## Signal
+<The raw signal, quoted or paraphrased>
+
+## Finding
+**Type:** <finding-type>
+**Rationale:** <one-paragraph reasoning>
+
+## Wardley Capability Assessment
+
+| Capability | Stage | Evidence | Strategic implication |
+|---|---|---|---|
+| <name> | Genesis / Custom-built / Product / Commodity | <evidence> | <implication> |
+
+> **Residual assumptions:** <capability(ies) that could not be confidently placed>
+
+## Recommended Entry Point
+**Step:** <shaping-entry> (`<skill-name>`)
+**Rationale:** <one sentence>
+
+## Step 2 readiness
+<When identify-opportunities is absent: name the missing skill and describe
+what step 2 requires. Omit when skill is present.>
+
+## Suggested workspace.toml entry
+Add to `[ini-NNN.shaping_queue]` backlog:
+```toml
+{slug = "<slug>", type = "shape"},
+```
+Use `queue-add` or edit `workspace.toml` manually.
+```
+```
+
+### Dependencies
+
+- **`frame-intent`** — sibling skill; altitude redirect target. No import;
+  redirect is verbal.
+- **`identify-opportunities`** — step 2; detect-and-degrade if absent (AC8).
+- **`agentbundle-layout.toml`** — config-tier read; same three-tier as
+  `frame-intent`.
+- **`queue-add` / `capture-work`** — downstream workspace.toml write; named in
+  the suggested-entry output; not a runtime dependency.
+
+## Changelog
+
+| Date | Change | Reason |
+|---|---|---|
+| 2026-07-20 | Initial plan + spec authored | First pass |
+| 2026-07-20 | Fixed artifact path to file-per-slug; fixed guide path to `how-to/`; fixed projection gates (lint-packs/validate/build, not build-self); added AC8/AC9 greps; aligned constraint to RFC-0064 Amendment #3; resolved ambiguous-signal handling | Adversarial review Blockers 1–4 + Concerns 5–9 + Nits 10–11 |
+| 2026-07-20 | Pinned AC8/AC9 greps to unique phrases (Step 2 readiness / altitude mismatch / genuinely ambiguous); added packages/agentbundle pytest leg; fixed capture-work reference to docs/specs/queue-add/ | Adversarial re-review Blocker 1 + Concerns 2–3 |

--- a/docs/specs/m2-frame-situation/spec.md
+++ b/docs/specs/m2-frame-situation/spec.md
@@ -1,0 +1,230 @@
+# Spec: m2-frame-situation
+
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** RFC-0064 (M2 · Strategic Shaping; D9 typed shaping queue entries); known-unknowns resolved 2026-07-18 (frame-intent vs frame-situation: coexist, different output contracts); RFC-0064 Amendment #3 + `docs/specs/queue-add/` (workspace.toml write-back is the `queue-add` / proposed `capture-work` front door's responsibility — frame-situation suggests the entry verbally only; `capture-work` is the proposed rename of `queue-add`, not yet accepted). Sub-RFC pe-pack-strategic-shaping (RFC-00XX) is not yet accepted — this spec proceeds under resolved constraints and may require minor revision on sub-RFC acceptance.
+- **Brief:** none
+- **Contract:** none — prompt-only skill (Charter Principle 3); no machine interface
+- **Shape:** mixed
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+A product engineer or PM working a `strategy`-typed shaping queue item — or
+holding a raw signal (market observation, OKR gap, user pain pattern,
+engineering finding, competitive signal, technology shift) — runs
+`frame-situation` and gets a **Situation Framing** typed artifact that:
+(1) classifies the signal into a typed finding,
+(2) assesses the maturity of up to three relevant capability areas on the
+Wardley evolution curve (Genesis → Custom-built → Product → Commodity),
+and (3) anchors the situation to the **PE six-step shaping sequence**
+(`frame-situation` → `identify-opportunities` → `diverge-solutions` →
+validate → `place-bet` → `map-capabilities`) with a recommended entry
+point and rationale.
+
+The artifact is committed to `<output_dir>/shaping/<slug>/situation-framing.md`
+(the designed default for output_dir is `docs/product/`; resolved via
+config-driven three-tier procedure) and becomes the traceable starting point
+for the shaping chain. The skill then suggests (but does not write) a
+`shape`-typed `[shaping_queue]` entry for `workspace.toml`; the user adds
+it via `queue-add` or manually.
+
+**Scope:** initiative-level and capability-level signals. Feature-scope
+requests are redirected to `frame-intent`. This is step 1 of the PE
+shaping loop, not a brief factory.
+
+## Boundaries
+
+### Always do
+
+- **Classify the input signal** into one of the defined finding types:
+  `opportunity` | `risk` | `gap` | `threat` | `emergent-capability`. When
+  the signal is ambiguous or too thin to confidently classify, name the
+  ambiguity and elicit more detail before forcing a type — never assign a
+  type to an underdetermined signal.
+- **Assess Wardley maturity** for up to three capability areas the signal
+  implicates. Place each on the Genesis → Custom-built → Product → Commodity
+  curve, state the evidence for the placement, and state the strategic
+  implication (e.g. "Custom-built → invest to differentiate or adopt an
+  emerging standard; Product → buy or adopt to commoditize"). Where the
+  agent cannot confidently place a capability, name it as a residual
+  assumption. When no capabilities can be placed, emit an all-residual-
+  assumptions table and explain why placement is deferred.
+- **Recommend a six-step entry point** based on the signal type and what
+  is already known: if the problem space is well-understood, start at step
+  3 or later; if speculative, default to step 2. State the reasoning
+  explicitly so the PE can override.
+- **Emit `situation-framing.md`** — written to
+  `<output_dir>/shaping/<slug>/situation-framing.md`, with stable marker
+  (`type: situation-framing`) carrying: signal classification, Wardley
+  assessment per capability, six-step entry-point recommendation, and named
+  residual assumptions. The slug is derived from the signal's subject.
+- **Resolve the write path via config-driven three-tier procedure**
+  (repo-scope `agentbundle-layout.toml [product]` → user-scope →
+  two-branch elicitation). After resolving, realpath-expand and
+  symlink-resolve the path; reject any `..` escape **and** any symlink
+  chain that exits the intended root. Surface the resolved absolute path to
+  the adopter before writing.
+- **Suggest a `workspace.toml` [shaping_queue] entry** — print the TOML
+  snippet for the user to add (a `shape`-typed entry with the derived slug);
+  direct the user to `queue-add` or manual edit. Do not write to
+  `workspace.toml`.
+- **Redirect feature-scoped requests to `frame-intent`** — when the signal
+  is clearly a single feature request (a specific screen, endpoint, or
+  interaction below the capability level), name the altitude mismatch and
+  offer to redirect. When altitude is genuinely ambiguous (could be a
+  feature or a capability), ask — never force one altitude.
+- **Detect absence of `identify-opportunities`** and degrade cleanly: name
+  the missing skill in the artifact and explain what step 2 of the sequence
+  requires; framing and artifact emission continue unblocked.
+
+### Ask first
+
+- Before skipping all six steps and treating the signal as already-bet
+  (signals are framing inputs; bets require `place-bet` to be on record).
+- Before adding a second typed artifact to this skill.
+- Before any write path that resolves outside the repo tree or via a
+  realpath-escaped symlink (untrusted-origin — confirm the resolved absolute
+  path before writing).
+
+### Never do
+
+- **Never** write to `workspace.toml` directly — the skill suggests the
+  entry; the user commits the workspace change.
+- **Never** write to a literal hardcoded path — always resolve via the
+  three-tier config procedure; `docs/product/` is the designed default, not
+  a constant.
+- **Never** mandate Wardley vocabulary on a user who has not adopted it —
+  offer the maturity framing with brief stage definitions, but do not block
+  if the user prefers plain-language descriptions.
+- **Never** produce a brief directly — step 5 (`place-bet`) and then
+  `decompose-intent`/`author-brief` own the brief hand-off.
+- **Never** exceed 100 lines in `SKILL.md`.
+- **Never** ship an engine, script, runtime hook, or validator in this skill.
+
+## Testing Strategy
+
+This is a prompt-only skill (Charter Principle 3) — no compressible
+invariant logic. Verification is goal-based for structure and
+manual-QA for judgment.
+
+- **Skill file and lint gates: goal-based.** File exists at the conventional
+  path, `tools/lint-skill-spec.py` passes, `lint-packs` passes, <100 lines,
+  valid frontmatter.
+- **Skill behavior (signal classification, Wardley assessment, route
+  recommendation, artifact emission): manual QA.** Walk the worked example
+  end to end; record the observed artifact content in the implementing PR.
+- **Degrade branch (AC8) and redirect branch (AC9): goal-based grep.** The
+  SKILL.md body must contain prose specifying both branches. Pinned assertions
+  (phrases unique to each branch; must return ≥1 match each):
+  AC8 degrade: `grep -F "Step 2 readiness"` (the artifact section that names the
+  missing skill); AC9 redirect: `grep -F "altitude mismatch"` (redirect branch);
+  AC9 ambiguous-ask: `grep -F "genuinely ambiguous"` (ask-don't-force branch).
+  A count-only OR-grep would pass vacuously; pin to unique phrases.
+- **Diátaxis guide: goal-based for file existence, manual QA for accuracy.**
+  Guide at `docs/guides/product-engineering/how-to/frame-a-situation.md`;
+  reads accurately against the shipped skill (review recorded in PR).
+- **Projection: goal-based.** `lint-packs`, `validate`, and `build` exit 0.
+  Adopter-cleanliness verified by grep over the SKILL body (no RFC-NNNN, no
+  `agent-ready-repo`). `make build-self` is not used — the PE pack is
+  user-scope and excluded from self-host projection.
+
+## Acceptance Criteria
+
+- [x] **AC1.** `frame-situation` ships at
+  `packs/product-engineering/.apm/skills/frame-situation/SKILL.md`
+  — <100 lines, valid frontmatter, passes `tools/lint-skill-spec.py` and
+  `lint-packs`.
+
+- [x] **AC2.** The skill classifies the input signal into one of the defined
+  finding types (`opportunity` | `risk` | `gap` | `threat` |
+  `emergent-capability`) and surfaces the classification with a one-line
+  rationale in the artifact. When the signal is underdetermined, the skill
+  names the ambiguity and elicits more detail before assigning a type.
+
+- [x] **AC3.** The skill produces a Wardley maturity assessment for up to
+  three relevant capability areas named in or implied by the signal, placing
+  each on the Genesis → Custom-built → Product → Commodity curve with evidence
+  and strategic implication. Where confidence is low, the placement is a
+  residual assumption. When zero capabilities can be confidently placed, the
+  artifact emits an all-residual-assumptions table and explains the deferral.
+
+- [x] **AC4.** The skill recommends a PE six-step entry-point
+  (`identify-opportunities`, `diverge-solutions`, or `place-bet`) with a
+  one-sentence rationale. The default is step 2 (`identify-opportunities`);
+  richer signals with a documented problem and vetted options may enter at
+  step 3 or step 5.
+
+- [x] **AC5.** The skill emits a file at
+  `<output_dir>/shaping/<slug>/situation-framing.md` — slug derived from
+  the signal's subject — with stable marker (`type: situation-framing`)
+  carrying: signal classification, Wardley assessment per capability,
+  recommended six-step entry point, and named residual assumptions.
+  A second run for a different signal writes to a different slug path; no
+  collision.
+
+- [x] **AC6.** The skill resolves the write path via the config-driven
+  three-tier procedure (repo-scope → user-scope → two-branch elicitation);
+  realpath-expands and symlink-resolves the path; rejects `..` escapes and
+  any symlink chain that exits the intended root; surfaces the resolved
+  absolute path to the adopter before writing.
+
+- [x] **AC7.** After the artifact is written, the skill suggests a
+  `shape`-typed `[shaping_queue]` workspace.toml entry for the user to add
+  — without writing to `workspace.toml` itself. The suggestion includes the
+  derived slug and directs the user to `queue-add` or manual edit.
+
+- [x] **AC8.** When `identify-opportunities` is not detected in the available
+  skills, the skill degrades cleanly: the artifact notes the missing skill
+  and describes what step 2 of the sequence requires; framing and artifact
+  emission continue unblocked. The SKILL.md body contains explicit prose
+  specifying this degrade behavior (goal-based grep).
+
+- [x] **AC9.** When the input is feature-scoped (clearly below the capability
+  level), the skill names the altitude mismatch and offers to redirect to
+  `frame-intent`. When altitude is genuinely ambiguous, the skill asks rather
+  than forcing one level. The SKILL.md body contains explicit prose specifying
+  both paths (goal-based grep).
+
+- [x] **AC10.** A worked example ships at
+  `packs/product-engineering/.apm/skills/frame-situation/examples/`
+  demonstrating the happy path: raw signal → typed finding → Wardley
+  assessment → route recommendation → `situation-framing.md` artifact.
+  The example is adopter-clean (no RFC-NNNN references, no
+  `agent-ready-repo` references).
+
+- [x] **AC11.** A Diátaxis how-to guide ships at
+  `docs/guides/product-engineering/how-to/frame-a-situation.md` covering:
+  when to use `frame-situation` vs `frame-intent` (altitude decision); what
+  a well-formed signal looks like; and how to use the Wardley assessment
+  output to choose the six-step entry point.
+
+- [x] **AC12.** `lint-packs`, `validate`, `build`, and the `packages/agentbundle`
+  pack/contract tests exit 0. Grep over the SKILL.md body confirms no
+  adopter-facing internal-catalogue references. `make build-self` stays
+  drift-free (the PE pack is user-scope, excluded from `_DEFAULT_SELF_HOST_PACKS`,
+  so build-self does not project the skill; confirmed by noting it in the plan).
+
+## Assumptions
+
+- **A1.** RFC-00XX · pe-pack-strategic-shaping has not been accepted. This
+  spec proceeds under the boundary decisions already resolved in RFC-0064
+  (2026-07-18): frame-intent vs frame-situation coexist with different
+  scopes and output contracts. This spec may require revision on sub-RFC
+  acceptance, but no new boundary decisions are made here.
+- **A2.** The six-step PE sequence is anchored in RFC-0064 and stable enough
+  to name in the skill body without the sub-RFC.
+- **A3.** Wardley Evolution curve vocabulary (Genesis / Custom-built / Product /
+  Commodity) is the canonical maturity model; the skill body briefly defines
+  each stage so Wardley-unfamiliar adopters can follow without prior reading.
+- **A4.** `docs/guides/product-engineering/` exists and carries Diátaxis
+  sub-buckets (`how-to/`, `reference/`, `tutorials/`, `explanation/`). The
+  guide file at `how-to/frame-a-situation.md` does not yet exist.
+- **A5.** Workspace.toml write-back (auto-adding the [shaping_queue] entry)
+  is the `queue-add` front door's responsibility per RFC-0064 Amendment #3
+  (`docs/specs/queue-add/`). `capture-work` is the proposed rename, not yet
+  accepted; the shipped skill and spec are `queue-add`. This skill suggests
+  the entry verbally.

--- a/packs/product-engineering/.apm/skills/frame-situation/SKILL.md
+++ b/packs/product-engineering/.apm/skills/frame-situation/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: frame-situation
+description: Use when holding a raw signal (market observation, OKR gap, user pain pattern, engineering finding, competitive signal) at initiative or capability level — turning it into a typed finding, a Wardley capability maturity assessment, and an anchor into the PE six-step shaping sequence. Triggers on "frame this situation", "what do we do with this signal", "is this an opportunity or a risk", "where should we start", "map this to the shaping sequence". Do NOT use for a feature-scoped request (use `frame-intent`), testing an assumption (use `de-risk-intent`), or breaking down a shaped intent (use `decompose-intent`).
+---
+
+# Skill: frame-situation
+
+Classify a raw signal, assess relevant capability maturities, and anchor the
+situation to the PE shaping sequence — so the team knows *what kind of thing
+this is* and *where to enter the six-step loop* before any shaping work begins.
+
+## When to invoke
+
+Confirm the signal is **initiative or capability level** (affects a whole
+product area or initiative). If it is clearly a single screen or endpoint,
+name the altitude mismatch and redirect: *"This looks feature-scoped;
+`frame-intent` is the right entry point."*
+If altitude is **genuinely ambiguous**, ask — never force one level.
+If the signal is **too thin to classify**, elicit more context first.
+
+## Procedure
+
+**1. Intake.** Read the signal. Confirm altitude in one sentence; proceed once confirmed.
+
+**2. Classify.** Choose: `opportunity` | `risk` | `gap` | `threat` |
+`emergent-capability`. State type + one-line rationale. If underdetermined,
+name the ambiguity and elicit — do not force a type.
+
+**3. Wardley maturity.** Identify up to three implicated capability areas.
+For each, place on the four stages — *Genesis* (novel/uncertain; explore);
+*Custom-built* (hand-crafted; invest to differentiate); *Product* (widely
+available; buy/adopt over build); *Commodity* (utility; competing here wastes
+energy) — with evidence and strategic implication. Mark unplaceable capabilities
+as residual assumptions. When zero can be placed, emit an all-residual table.
+
+**4. Recommend entry point.** PE six-step sequence: `frame-situation` →
+`identify-opportunities` → `diverge-solutions` → validate → `place-bet` →
+`map-capabilities`. Recommend where to enter:
+- Unknown problem → step 2 (`identify-opportunities`, default).
+- Known problem, unknown options → step 3 (`diverge-solutions`).
+- Known options, need committed bet → step 5 (`place-bet`).
+State the entry point and one-sentence rationale so the PE can override.
+
+**5. Emit `situation-framing.md`.** Resolve `output_dir` via the three-tier
+config procedure (repo-scope `agentbundle-layout.toml [product]` → user-scope
+→ two-branch elicitation). Realpath-expand; reject `..` and symlinks that exit
+the root; surface the resolved path before writing. Write to
+`<output_dir>/shaping/<slug>/situation-framing.md`.
+
+**Step 2 readiness:** if `identify-opportunities` is absent from available
+skills, note this under a "Step 2 readiness" section and describe what step 2
+provides. Do not block artifact emission. Apply the same degrade if
+`diverge-solutions` or `place-bet` is the recommended entry and is also absent
+— those skills are not yet shipped.
+
+Artifact shape: frontmatter (`type: situation-framing`, `slug`, `signal`, `date`,
+`finding-type`, `shaping-entry`), then sections — Signal, Finding, Wardley
+Assessment table, Recommended Entry Point, Step 2 readiness (when absent),
+Suggested workspace.toml entry (TOML snippet + direction to add via `queue-add`
+or manually).
+
+**6. Suggest workspace.toml entry.** Print the `{slug = "<slug>", type = "shape"}`
+TOML snippet. Direct the user to add it to `[ini-NNN.shaping_queue]` backlog.
+Do **not** write to `workspace.toml`.
+
+## Anti-patterns to refuse
+
+- Writing to `workspace.toml` or a literal hardcoded path.
+- Producing a brief (that is `place-bet` + `author-brief`'s job).
+- Forcing a Wardley stage when evidence is insufficient — name it as a residual
+  assumption instead.
+- Forcing an altitude when it is **genuinely ambiguous** — ask instead.

--- a/packs/product-engineering/.apm/skills/frame-situation/examples/signal-to-finding.md
+++ b/packs/product-engineering/.apm/skills/frame-situation/examples/signal-to-finding.md
@@ -1,0 +1,130 @@
+# Example: signal → situation framing
+
+A product engineer holds a signal surfaced by `work-loop` during a
+maintenance PR and runs `frame-situation` to decide whether and where to
+route it into the shaping sequence.
+
+---
+
+## The raw signal
+
+> "Engineering reported that every team in the org hand-rolls its own agent
+> skill discovery mechanism — three separate implementations found across two
+> squads, no standard emerging. Symptoms: onboarding friction, duplicate
+> maintenance overhead, subtle incompatibilities when sharing skills."
+
+---
+
+## Step 1 — Intake and altitude confirmation
+
+The signal affects multiple teams and their shared agent skill infrastructure.
+That is initiative/capability level — proceed.
+
+*(If a team had asked "can we add a skill discovery flag to our CLI?" that
+would be feature-scoped → altitude mismatch → redirect to `frame-intent`.)*
+
+---
+
+## Step 2 — Classify the finding
+
+**Type: gap**
+
+Three independent implementations exist, no standard is emerging, and
+coordination overhead is growing. This is a convergence gap — the org is
+spending custom-build budget where a shared standard would serve it better.
+
+---
+
+## Step 3 — Wardley maturity assessment
+
+| Capability | Stage | Evidence | Strategic implication |
+|---|---|---|---|
+| Agent skill discovery | Custom-built | Three hand-rolled implementations; no shared protocol or registry | Approaching the Product boundary — watch for emerging standards (e.g., SKILL.md frontmatter conventions becoming a de-facto norm). Invest in a lightweight shared convention rather than a full product; avoid over-engineering at this stage. |
+| Inter-team skill coordination | Genesis | No established pattern; teams resort to Slack DMs and manual copying | Explore first; no standard exists to adopt yet. A lightweight convention (stable marker + registry) may be sufficient before committing to a heavier coordination mechanism. |
+
+*(Third capability area: not identified — only two strongly implicated.)*
+
+> **Residual assumptions:** "Approaching the Product boundary" for skill discovery
+> rests on the assumption that the SKILL.md convention is gaining traction
+> beyond this org. If it is still isolated internal practice, the placement
+> may be early Custom-built rather than late Custom-built. Confirm via external
+> signals (GitHub stars, adapter adoption) before over-investing.
+
+---
+
+## Step 4 — Recommended entry point
+
+**Step 2 — `identify-opportunities`**
+
+The problem is confirmed (coordination overhead, duplicate implementations),
+but the functional, emotional, and social jobs of the engineers and adopters
+affected have not been documented. Start at step 2 to map the jobs before
+diverging on solutions — the gap's root cause may be deeper than "we need a
+registry."
+
+---
+
+## Artifact written
+
+Path: `docs/product/shaping/agent-skill-discovery-gap/situation-framing.md`
+
+```markdown
+---
+type: situation-framing
+slug: agent-skill-discovery-gap
+signal: "Three hand-rolled skill discovery mechanisms found; no standard emerging; growing coordination overhead"
+finding-type: gap
+date: 2026-07-20
+shaping-entry: identify-opportunities
+---
+
+## Signal
+Engineering reported that every team hand-rolls its own agent skill discovery
+mechanism — three implementations found across two squads, no standard emerging.
+Symptoms: onboarding friction, duplicate maintenance, subtle incompatibilities.
+
+## Finding
+**Type:** gap · **Rationale:** A convergence gap — the org is spending
+custom-build budget where a shared standard would serve it better. The problem
+is confirmed; the solution space is open.
+
+## Wardley Capability Assessment
+
+| Capability | Stage | Evidence | Strategic implication |
+|---|---|---|---|
+| Agent skill discovery | Custom-built | Three hand-rolled impls; no shared protocol | Watch for emerging standards; invest in a lightweight convention now |
+| Inter-team skill coordination | Genesis | No established pattern | Explore first; no standard to adopt yet |
+
+> **Residual assumptions:** "Approaching Product boundary" for skill discovery
+> requires confirmation via external signals (GitHub/adapter adoption).
+
+## Recommended Entry Point
+**Step:** identify-opportunities · **Rationale:** Problem confirmed; jobs not yet mapped.
+
+## Step 2 readiness
+`identify-opportunities` is not yet detected in available skills. Step 2 maps
+the functional, emotional, and social jobs of the people affected by the signal
+— grounding solution divergence in real user needs. Resume shaping there when
+the skill becomes available.
+
+## Suggested workspace.toml entry
+```toml
+{slug = "agent-skill-discovery-gap", type = "shape"},
+```
+Add to `[ini-NNN.shaping_queue]` backlog via `queue-add` or manually.
+```
+
+---
+
+## Step 6 — Workspace.toml suggestion printed
+
+The agent prints:
+
+```toml
+{slug = "agent-skill-discovery-gap", type = "shape"},
+```
+
+> Add this to your active initiative's `[shaping_queue]` backlog in
+> `workspace.toml`. Use `queue-add` or edit manually. Once added,
+> `workspace-status` will surface it as a ready shaping item pointing to
+> `identify-opportunities`.

--- a/web/src/content/journeys/discovery.md
+++ b/web/src/content/journeys/discovery.md
@@ -14,6 +14,9 @@ skills:
   - name: frame-domain
     description: "Grounds the product in the real-world activity it serves and bounds the MVP — produces Domain Framing and Scope Boundary artifacts before the convergent design loop."
     humanTouches: 1
+  - name: frame-situation
+    description: "Classifies an initiative-level signal into a typed finding, assesses Wardley capability maturities, and anchors the team to the right entry point in the PE six-step shaping sequence."
+    humanTouches: 1
   - name: de-risk-intent
     description: "Surfaces the riskiest assumption and designs a prototype approach to de-risk it before committing to build."
     humanTouches: 1

--- a/workspace.toml
+++ b/workspace.toml
@@ -60,6 +60,7 @@ draft     = []
 ["ini-002".work]
 active  = []
 shipped = [
+  "spec/m2-frame-situation",     # frame-situation PE skill
   "spec/m1-workspace-core",      # Batch 2
   "spec/m1-work-queue",          # Batch 3
   "spec/m1-brief-queue",         # Batch 4


### PR DESCRIPTION
## Summary

- Adds `frame-situation` skill to the PE pack (`packs/product-engineering/.apm/skills/frame-situation/SKILL.md`, 72 lines) — step 1 of the RFC-0064 M2 six-step strategic shaping sequence
- Skill classifies raw signals into typed findings (`opportunity | risk | gap | threat | emergent-capability`), embeds inline Wardley capability maturity assessment, and anchors the team to the right PE shaping entry point
- Ships with a worked example (`examples/signal-to-finding.md`) and a Diátaxis how-to guide (`docs/guides/product-engineering/how-to/frame-a-situation.md`)
- Marks `spec/m2-frame-situation` Shipped in `workspace.toml`

## Spec

`docs/specs/m2-frame-situation/` — all 12 ACs verified:
- AC1/AC10/AC11/AC12: file existence + lint/build gates (lint-packs ✓, agentbundle pytest ✓)
- AC8: `grep -F "Step 2 readiness"` → 3 matches in SKILL.md
- AC9: `grep -F "altitude mismatch"` and `grep -F "genuinely ambiguous"` each match
- Adopter-clean: no RFC-NNNN or internal-catalogue references in skill/example/guide

## Constraints respected

- Charter Principle 3: prompt-only — no engine, script, or runtime validator
- PE pack is user-scope (`_DEFAULT_SELF_HOST_PACKS` excludes it); `make build-self` is a no-op here
- Sub-RFC pe-pack-strategic-shaping not yet accepted; proceeds under RFC-0064 Known Unknowns resolved 2026-07-18 (A1)
- Wardley stages defined inline (A3) — Wardley-unfamiliar adopters can follow without prior reading

## Deferred

- `identify-opportunities` (step 2), `diverge-solutions` (step 3), `place-bet` (step 5) — not yet shipped; skill degrades cleanly and names absence in the readiness section