### PR TITLE
feat(core): work-loop argless resume with three-branch active-spec routing (RFC-0067 Change C)

### DIFF
--- a/.agents/skills/work-loop/SKILL.md
+++ b/.agents/skills/work-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: work-loop
-description: Use this skill whenever you're implementing a non-trivial change -- a feature, a multi-file bug fix, a refactor, a migration, a framework or dependency upgrade, a schema or API change, performance work, an infrastructure or build-system edit, or anything spec-driven. It enforces the project's plan -> execute -> self-review -> fix loop with mechanical gates (lint, typecheck, tests) and adversarial review. Default to this skill for any task larger than a one-line edit.
+description: Use this skill whenever you're implementing a non-trivial change -- a feature, a multi-file bug fix, a refactor, a migration, a framework or dependency upgrade, a schema or API change, performance work, an infrastructure or build-system edit, or anything spec-driven. Also triggered by argless resume phrases -- "resume", "continue", "keep going", "pick up where I left off", "let's get going" (bare phrases only; "resume the X project" or "resume the X investigation" routes to desk-research-project-status). It enforces the project's plan -> execute -> self-review -> fix loop with mechanical gates (lint, typecheck, tests) and adversarial review. Default to this skill for any task larger than a one-line edit.
 ---
 
 # Skill: work-loop
@@ -159,15 +159,18 @@ Before PLAN begins, orient to the current initiative and work queue:
 1. Look for `workspace.toml` in the working directory.
    - **If present:** read it and surface the following in a clearly labelled
      orientation block at the top of your response:
-     - **Initiative:** the `name` value from `["<slug>"]`
+     - **Initiative:** the `name` value from `["ini-NNN"]`
        (e.g. `"Platform Core"`).
-     - **Milestone:** the `milestone` value from `["<slug>"]`
+     - **Milestone:** the `milestone` value from `["ini-NNN"]`
        (e.g. `"M1 · Workspace Foundation"`).
-     - **Active spec:** the first path in `["<slug>".work].active`, if the
-       array is non-empty (e.g. `"spec/m1-work-queue"`). If the array is
-       empty, surface the initiative name and milestone only — no error.
+     - **Active spec (argless only — skip when a spec path is given):**
+       Collect every path in `["ini-NNN".work].active` across all active
+       initiatives. Exactly one → begin on that spec without asking. Zero
+       → surface "No active spec found — run `workspace-status` to see
+       what's ready to start." More than one (single initiative or across
+       initiatives) → list all and ask the user to pick.
      - **Stale-queue check.** For each active initiative, for each entry in
-       `["<slug>".work].queue` and `["<slug>".work].active`: resolve the
+       `["ini-NNN".work].queue` and `["ini-NNN".work].active`: resolve the
        path (bare string → as-is; inline object → `path` field; `slug` is
        shaping-queue only), strip the `spec/` prefix, and read
        `docs/specs/<slug>/spec.md`. If `**Status:**` is `Shipped` (ignoring
@@ -190,11 +193,12 @@ research→`desk-research-project-start`; strategy→`frame-situation`/`frame-in
 design→`experience-status`.) Signal: "Monitoring signal — `work-loop` is for
 build items only."
 
-After orienting (or immediately, if `workspace.toml` is absent), proceed
-to step 1 (PLAN). The active spec path tells you which spec you are
-expected to be working on — strip the `spec/` prefix from the stored path
-to get the slug, then read `docs/specs/<slug>/spec.md` and `plan.md`
-as step 1 of PLAN.
+If `workspace.toml` was absent or an explicit spec path was passed,
+proceed to step 1 (PLAN) immediately. Otherwise a path must be resolved:
+if exactly one active item, strip the `spec/` prefix, then read
+`docs/specs/<slug>/spec.md` and `plan.md` as step 1 of PLAN. In the
+zero and multi-item branches, stop after surfacing the message or list
+and do not proceed until the user picks.
 
 ### 1. PLAN — think before acting
 

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: work-loop
-description: Use this skill whenever you're implementing a non-trivial change -- a feature, a multi-file bug fix, a refactor, a migration, a framework or dependency upgrade, a schema or API change, performance work, an infrastructure or build-system edit, or anything spec-driven. It enforces the project's plan -> execute -> self-review -> fix loop with mechanical gates (lint, typecheck, tests) and adversarial review. Default to this skill for any task larger than a one-line edit.
+description: Use this skill whenever you're implementing a non-trivial change -- a feature, a multi-file bug fix, a refactor, a migration, a framework or dependency upgrade, a schema or API change, performance work, an infrastructure or build-system edit, or anything spec-driven. Also triggered by argless resume phrases -- "resume", "continue", "keep going", "pick up where I left off", "let's get going" (bare phrases only; "resume the X project" or "resume the X investigation" routes to desk-research-project-status). It enforces the project's plan -> execute -> self-review -> fix loop with mechanical gates (lint, typecheck, tests) and adversarial review. Default to this skill for any task larger than a one-line edit.
 ---
 
 # Skill: work-loop
@@ -159,15 +159,18 @@ Before PLAN begins, orient to the current initiative and work queue:
 1. Look for `workspace.toml` in the working directory.
    - **If present:** read it and surface the following in a clearly labelled
      orientation block at the top of your response:
-     - **Initiative:** the `name` value from `["<slug>"]`
+     - **Initiative:** the `name` value from `["ini-NNN"]`
        (e.g. `"Platform Core"`).
-     - **Milestone:** the `milestone` value from `["<slug>"]`
+     - **Milestone:** the `milestone` value from `["ini-NNN"]`
        (e.g. `"M1 · Workspace Foundation"`).
-     - **Active spec:** the first path in `["<slug>".work].active`, if the
-       array is non-empty (e.g. `"spec/m1-work-queue"`). If the array is
-       empty, surface the initiative name and milestone only — no error.
+     - **Active spec (argless only — skip when a spec path is given):**
+       Collect every path in `["ini-NNN".work].active` across all active
+       initiatives. Exactly one → begin on that spec without asking. Zero
+       → surface "No active spec found — run `workspace-status` to see
+       what's ready to start." More than one (single initiative or across
+       initiatives) → list all and ask the user to pick.
      - **Stale-queue check.** For each active initiative, for each entry in
-       `["<slug>".work].queue` and `["<slug>".work].active`: resolve the
+       `["ini-NNN".work].queue` and `["ini-NNN".work].active`: resolve the
        path (bare string → as-is; inline object → `path` field; `slug` is
        shaping-queue only), strip the `spec/` prefix, and read
        `docs/specs/<slug>/spec.md`. If `**Status:**` is `Shipped` (ignoring
@@ -190,11 +193,12 @@ research→`desk-research-project-start`; strategy→`frame-situation`/`frame-in
 design→`experience-status`.) Signal: "Monitoring signal — `work-loop` is for
 build items only."
 
-After orienting (or immediately, if `workspace.toml` is absent), proceed
-to step 1 (PLAN). The active spec path tells you which spec you are
-expected to be working on — strip the `spec/` prefix from the stored path
-to get the slug, then read `docs/specs/<slug>/spec.md` and `plan.md`
-as step 1 of PLAN.
+If `workspace.toml` was absent or an explicit spec path was passed,
+proceed to step 1 (PLAN) immediately. Otherwise a path must be resolved:
+if exactly one active item, strip the `spec/` prefix, then read
+`docs/specs/<slug>/spec.md` and `plan.md` as step 1 of PLAN. In the
+zero and multi-item branches, stop after surfacing the message or list
+and do not proceed until the user picks.
 
 ### 1. PLAN — think before acting
 

--- a/docs/specs/spec-C-workloop-argless-resume/notes/review-r1.md
+++ b/docs/specs/spec-C-workloop-argless-resume/notes/review-r1.md
@@ -1,0 +1,13 @@
+# Adversarial Review — Round 1
+
+## Blockers
+
+**1. Control flow proceeds to PLAN even in zero/multi branches.** `packs/core/.apm/skills/work-loop/SKILL.md:187-191`. The closing paragraph stated "proceed to step 1 (PLAN)" unconditionally; an agent in Branch 3 could proceed without waiting for user input — exactly the auto-pick the spec forbids. Fix: gate proceed-to-PLAN on a path having been resolved; in zero and multi-item branches, stop after surfacing and wait for user.
+
+## Concerns
+
+**2. Spec/plan metadata stale.** `docs/specs/spec-C-workloop-argless-resume/spec.md:3`, `:48-59`, `plan.md:4`. Status still `Approved`, all ACs unchecked, plan Status `Drafting`. Must flip atomically with merge.
+
+## Nits
+
+**3. Branch 1 action in surface-list bullet.** `packs/core/.apm/skills/work-loop/SKILL.md:160-171`. Control-flow action ("begin on that spec without asking") mixed into a data-surface list. Harmless; restructuring is a design call beyond spec scope. Deferred.

--- a/docs/specs/spec-C-workloop-argless-resume/notes/review-r2.md
+++ b/docs/specs/spec-C-workloop-argless-resume/notes/review-r2.md
@@ -1,0 +1,9 @@
+# Adversarial Review — Round 2
+
+## Blockers
+
+**1. Closing paragraph strips the workspace.toml-absent proceed guarantee.** `packs/core/.apm/skills/work-loop/SKILL.md:187-192`. The round-1 fix replaced "proceed to step 1 (PLAN)" with "a path must be resolved before PLAN begins." The absent case enters this paragraph but has no path, is not in zero/multi branches (those are present-state), and falls through with no proceed instruction — contradicting lines 181-182 and AC2/AC6. Fix: lead with the two fast-path cases (absent + explicit path → proceed immediately), then the resolution gate.
+
+## Concerns / Nits
+
+None new. Prior deferrals (spec metadata → commit-time; Branch-1 layout → backlog) unchanged.

--- a/docs/specs/spec-C-workloop-argless-resume/notes/review-r3.md
+++ b/docs/specs/spec-C-workloop-argless-resume/notes/review-r3.md
@@ -1,0 +1,11 @@
+# Adversarial Review — Round 3
+
+Both prior Blockers confirmed fixed. No new Blockers.
+
+## Concerns
+
+**1. Shipping spec carries pre-implementation metadata.** `docs/specs/spec-C-workloop-argless-resume/spec.md:3`, `:48-59`. Status still `Approved`, ACs unchecked. Must flip Status→Shipped and check AC1–AC9 in the same commit per CONVENTIONS §4. (Deferred to commit-time as agreed — must not be a follow-up.)
+
+## Result
+
+Clean — ready to commit (after metadata update applied in same commit).

--- a/docs/specs/spec-C-workloop-argless-resume/plan.md
+++ b/docs/specs/spec-C-workloop-argless-resume/plan.md
@@ -1,7 +1,7 @@
 # Plan: spec-C-workloop-argless-resume
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Drafting
+- **Status:** Shipped
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
 > document is allowed to change as you learn. When it changes substantially

--- a/docs/specs/spec-C-workloop-argless-resume/spec.md
+++ b/docs/specs/spec-C-workloop-argless-resume/spec.md
@@ -1,6 +1,6 @@
 # Spec: spec-C-workloop-argless-resume
 
-- **Status:** Approved
+- **Status:** Shipped
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:**
@@ -41,22 +41,28 @@ A user who invokes `work-loop` without a spec path argument — or who types "re
 
 ## Testing Strategy
 
-All criteria use **goal-based check**: the SKILL.md body is read against the spec's three-branch contract and the removed first-path language. The change is to a markdown skill body; no compiled artifact. One **manual QA** step: invoke `work-loop` in a repo with each of the three `workspace.toml` active-item states (zero, one, multiple) and confirm the correct branch fires.
+All criteria use **goal-based check**: the SKILL.md body is read against the spec's three-branch contract and the removed first-path language. The change is to a markdown skill body; no compiled artifact. **Manual QA** — five invocation scenarios:
+1. `workspace.toml` present, one active spec → loop begins without asking.
+2. `workspace.toml` present, zero active specs → "No active spec found…" message.
+3. `workspace.toml` present, two active specs in one initiative → list presented, user asked to pick.
+4. `workspace.toml` present, two active specs across two initiatives → list presented (same Branch 3 path as scenario 3).
+5. `workspace.toml` absent → PLAN begins immediately, no error (AC6).
+6. Explicit spec path passed (e.g. `work-loop docs/specs/foo/spec.md`) → three-branch logic skipped entirely (AC5).
 
 ## Acceptance Criteria
 
-- [ ] **AC1.** `work-loop` SKILL.md `description:` field includes all five RFC-0067 §C trigger phrases: "resume", "continue", "keep going", "pick up where I left off", "let's get going".
-- [ ] **AC2.** The three-branch logic governs only the **argless invocation path** (no spec path argument passed to `work-loop`). When `workspace.toml` is absent, the existing skip behavior is preserved: Step 0 exits silently and PLAN begins immediately, as today. When `workspace.toml` is present and the active array logic runs, the three branches are:
+- [x] **AC1.** `work-loop` SKILL.md `description:` field includes all five RFC-0067 §C trigger phrases: "resume", "continue", "keep going", "pick up where I left off", "let's get going".
+- [x] **AC2.** The three-branch logic governs only the **argless invocation path** (no spec path argument passed to `work-loop`). When `workspace.toml` is absent, the existing skip behavior is preserved: Step 0 exits silently and PLAN begins immediately, as today. When `workspace.toml` is present and the active array logic runs, the three branches are:
   - Branch 1 (exactly one active item across all `["ini-NNN"]` sections with `status = "active"`): begin the loop on that spec without asking.
   - Branch 2 (zero active items, `workspace.toml` present): surface "No active spec found — run `workspace-status` to see what's ready to start."
   - Branch 3 (more than one active item, from a single initiative's multi-element `.active` array or across multiple initiatives): list all active paths and ask the user to pick before beginning.
-- [ ] **AC3.** The first-path auto-pick language is removed: the phrase "the first path in `[\"<slug>\".work].active`" (or equivalent) no longer appears in Step 0.
-- [ ] **AC4.** The singular framing ("The active spec path tells you which spec you are expected to be working on") is updated to handle the pending-user-pick state (zero or multi-item cases) — the language no longer implies exactly one active spec always exists.
-- [ ] **AC5.** Explicit spec-path argument invocations (user passes a path to `work-loop`) are unaffected — the three-branch logic is conditional on no path argument being provided.
-- [ ] **AC6.** The `workspace.toml`-absent skip behavior is explicitly preserved in the Step 0 prose: when no `workspace.toml` is present in the working directory, Step 0 does not error and PLAN begins immediately.
-- [ ] **AC7.** The work-loop `description:` field or evals near-miss cases distinguish bare "resume" / "continue" (routes to `work-loop`) from named-project phrasing "resume the X project" / "resume the X investigation" (routes to `desk-research-project-status`, not `work-loop`).
-- [ ] **AC8.** The projected copy of `work-loop` SKILL.md (`.claude/skills/work-loop/SKILL.md` and any adapter-projected equivalents) is updated via `make build-self`; `make build-check` exits 0.
-- [ ] **AC9.** `scripts/lint-spec-status.py` exits 0 on this spec.
+- [x] **AC3.** The first-path auto-pick language is removed: the phrase "the first path in `[\"<slug>\".work].active`" (or equivalent) no longer appears in Step 0.
+- [x] **AC4.** The singular framing ("The active spec path tells you which spec you are expected to be working on") is updated to handle the pending-user-pick state (zero or multi-item cases) — the language no longer implies exactly one active spec always exists.
+- [x] **AC5.** Explicit spec-path argument invocations (user passes a path to `work-loop`) are unaffected — the three-branch logic is conditional on no path argument being provided.
+- [x] **AC6.** The `workspace.toml`-absent skip behavior is explicitly preserved in the Step 0 prose: when no `workspace.toml` is present in the working directory, Step 0 does not error and PLAN begins immediately.
+- [x] **AC7.** The work-loop `description:` field or evals near-miss cases distinguish bare "resume" / "continue" (routes to `work-loop`) from named-project phrasing "resume the X project" / "resume the X investigation" (routes to `desk-research-project-status`, not `work-loop`).
+- [x] **AC8.** The projected copy of `work-loop` SKILL.md (`.claude/skills/work-loop/SKILL.md` and any adapter-projected equivalents) is updated via `make build-self`; `make build-check` exits 0.
+- [x] **AC9.** `scripts/lint-spec-status.py` exits 0 on this spec.
 
 ## Assumptions
 

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: work-loop
-description: Use this skill whenever you're implementing a non-trivial change -- a feature, a multi-file bug fix, a refactor, a migration, a framework or dependency upgrade, a schema or API change, performance work, an infrastructure or build-system edit, or anything spec-driven. It enforces the project's plan -> execute -> self-review -> fix loop with mechanical gates (lint, typecheck, tests) and adversarial review. Default to this skill for any task larger than a one-line edit.
+description: Use this skill whenever you're implementing a non-trivial change -- a feature, a multi-file bug fix, a refactor, a migration, a framework or dependency upgrade, a schema or API change, performance work, an infrastructure or build-system edit, or anything spec-driven. Also triggered by argless resume phrases -- "resume", "continue", "keep going", "pick up where I left off", "let's get going" (bare phrases only; "resume the X project" or "resume the X investigation" routes to desk-research-project-status). It enforces the project's plan -> execute -> self-review -> fix loop with mechanical gates (lint, typecheck, tests) and adversarial review. Default to this skill for any task larger than a one-line edit.
 ---
 
 # Skill: work-loop
@@ -159,15 +159,18 @@ Before PLAN begins, orient to the current initiative and work queue:
 1. Look for `workspace.toml` in the working directory.
    - **If present:** read it and surface the following in a clearly labelled
      orientation block at the top of your response:
-     - **Initiative:** the `name` value from `["<slug>"]`
+     - **Initiative:** the `name` value from `["ini-NNN"]`
        (e.g. `"Platform Core"`).
-     - **Milestone:** the `milestone` value from `["<slug>"]`
+     - **Milestone:** the `milestone` value from `["ini-NNN"]`
        (e.g. `"M1 · Workspace Foundation"`).
-     - **Active spec:** the first path in `["<slug>".work].active`, if the
-       array is non-empty (e.g. `"spec/m1-work-queue"`). If the array is
-       empty, surface the initiative name and milestone only — no error.
+     - **Active spec (argless only — skip when a spec path is given):**
+       Collect every path in `["ini-NNN".work].active` across all active
+       initiatives. Exactly one → begin on that spec without asking. Zero
+       → surface "No active spec found — run `workspace-status` to see
+       what's ready to start." More than one (single initiative or across
+       initiatives) → list all and ask the user to pick.
      - **Stale-queue check.** For each active initiative, for each entry in
-       `["<slug>".work].queue` and `["<slug>".work].active`: resolve the
+       `["ini-NNN".work].queue` and `["ini-NNN".work].active`: resolve the
        path (bare string → as-is; inline object → `path` field; `slug` is
        shaping-queue only), strip the `spec/` prefix, and read
        `docs/specs/<slug>/spec.md`. If `**Status:**` is `Shipped` (ignoring
@@ -190,11 +193,12 @@ research→`desk-research-project-start`; strategy→`frame-situation`/`frame-in
 design→`experience-status`.) Signal: "Monitoring signal — `work-loop` is for
 build items only."
 
-After orienting (or immediately, if `workspace.toml` is absent), proceed
-to step 1 (PLAN). The active spec path tells you which spec you are
-expected to be working on — strip the `spec/` prefix from the stored path
-to get the slug, then read `docs/specs/<slug>/spec.md` and `plan.md`
-as step 1 of PLAN.
+If `workspace.toml` was absent or an explicit spec path was passed,
+proceed to step 1 (PLAN) immediately. Otherwise a path must be resolved:
+if exactly one active item, strip the `spec/` prefix, then read
+`docs/specs/<slug>/spec.md` and `plan.md` as step 1 of PLAN. In the
+zero and multi-item branches, stop after surfacing the message or list
+and do not proceed until the user picks.
 
 ### 1. PLAN — think before acting
 

--- a/workspace.toml
+++ b/workspace.toml
@@ -76,6 +76,7 @@ shipped = [
   "spec/workspace-status-queue-reconciliation", # PR #573 — reconciliation step
   "spec/m3-backlog-absorption",                # Migrate docs/backlog.md → workspace.toml [backlog]
   "spec/capture-work",                         # Rename queue-add → capture-work; classify/triage + mode tags + work-loop guard
+  "spec/spec-C-workloop-argless-resume",       # RFC-0067 Change C: argless resume + three-branch active-spec routing
 ]
 queue   = [
   # ==================================================================
@@ -132,7 +133,6 @@ queue   = [
   "spec/m6-enterprise-rollout-playbook",  # champion→CTO→platform→engineers; staged rollout + retro template
 
   # ---------------- Independent track (not RFC-0064) ----------------
-  {path = "spec/spec-C-workloop-argless-resume",        needs = "work:spec/spec-B-pack-status-skills"},
   "spec/catalogue-curation",
 ]
 
@@ -655,6 +655,33 @@ open = [
   #   spec.
   # Unblocks when: a Tier-B grading RFC or cassette harness spec is accepted.
   {slug = "behavior-check-for-backend-skills"},
+
+  # spec/spec-C-workloop-argless-resume adversarial-reviewer Nit. The Active spec
+  # bullet mixes a control-flow action ("begin on that spec without asking") into
+  # the surface-list of orientation fields (Initiative/Milestone/Active spec) under
+  # "surface the following in a clearly labelled orientation block." Harmless; fixing
+  # it requires restructuring Step 0 — lifting the three-branch resolution out of the
+  # bullet list into its own labeled paragraph after the orientation block.
+  # quality-engineer Nit (Finding 4): same root — branch outcomes stated in two places
+  #   (bullet at line ~168 and closing paragraph at line ~188) that must stay aligned.
+  # Fix: restructure Step 0 in work-loop SKILL.md to separate data-surface fields
+  #   from control-flow resolution, collapsing to a single source of truth for branch
+  #   outcomes; edit source + run make build-self FORCE=1.
+  # File: packs/core/.apm/skills/work-loop/SKILL.md (Step 0 layout).
+  # Unblocks when: someone does a focused Step 0 readability pass.
+  {slug = "work-loop-step0-branch-layout-restructure", source = "spec/spec-C-workloop-argless-resume"},
+
+  # spec/spec-C-workloop-argless-resume quality-engineer Concern (Finding 2).
+  # Branch 1 (exactly one active item) starts the loop silently without echoing
+  # the resolved spec path. A stale .active entry pointing at the wrong spec goes
+  # undetected until PLAN is well under way.
+  # Fix: require the one-item branch to state the resolved path (e.g., "Beginning
+  #   on `<path>`") in the orientation block before proceeding — matches the
+  #   explicitness Branch 3 already provides. Needs AC2 text update + SKILL.md edit.
+  # File: packs/core/.apm/skills/work-loop/SKILL.md (Step 0 Branch 1) and
+  #   docs/specs/spec-C-workloop-argless-resume/spec.md (AC2).
+  # Unblocks when: a focused observability pass on Step 0 Branch 1.
+  {slug = "work-loop-step0-branch1-echo-resolved-path", source = "spec/spec-C-workloop-argless-resume"},
 
   # spec/adapt-to-project AC4b — deferred manual-QA rows (tombstone anchor for
   # RFC-0007 links). Repo-scope class-2/3/4 transcripts (rows 8–16): Claude-simulated


### PR DESCRIPTION
## Summary

- Adds argless invocation to `work-loop`: bare "resume", "continue", "keep going", "pick up where I left off", "let's get going" now trigger the skill and resolve the active spec from `workspace.toml` — no manual path lookup required
- Three-branch routing: exactly one active spec → begin immediately; zero → surface `workspace-status` nudge; more than one → list and ask; explicit spec-path argument is unaffected
- Removes the old "first path in `.active`" auto-pick; unifies `["<slug>"]` → `["ini-NNN"]` placeholder across Step 0 orientation bullets (mechanical same-area ride-along)

## Spec

`docs/specs/spec-C-workloop-argless-resume/` — Status: **Shipped**, AC1–AC9 all met.

Constrained by RFC-0067 §Change C, RFC-0025 (no new skill), ADR-0054 (resume is an activation phrase).

## Review record

- Adversarial: 3 rounds — R1 fixed gateway blocker (zero/multi branches could proceed to PLAN), R2 fixed follow-on blocker (workspace.toml-absent case lost its proceed guarantee), R3 **Clean**
- Quality-engineer: no Blockers; Finding 1 (QA scenario coverage) addressed in spec; Finding 3 (placeholder unification) addressed as mechanical ride-along; Findings 2 + 4 deferred to backlog

## Deferred (backlog entries added)

- `work-loop-step0-branch-layout-restructure`: restructure Step 0 to separate data-surface fields from control-flow resolution (adversarial Nit + QE Finding 4 — same root)
- `work-loop-step0-branch1-echo-resolved-path`: Branch 1 should echo the resolved spec path before beginning (QE Finding 2 — observability)

## Test plan

- [ ] `make build-check` exits 0
- [ ] `tools/lint-skill-spec.py` exits 0 (0 errors; pre-existing warnings only)
- [ ] `scripts/lint-spec-status.py docs/specs/spec-C-workloop-argless-resume/spec.md` exits 0
- [ ] Manual QA scenario 1: `workspace.toml` with one active spec → loop begins without asking
- [ ] Manual QA scenario 2: `workspace.toml` with zero active specs → "No active spec found — run `workspace-status`…" message
- [ ] Manual QA scenario 3: `workspace.toml` with two or more active specs → list presented, user asked to pick