### PR TITLE
fix(lint+workspace): make docs/backlog.md purely historical

### DIFF
--- a/.agents/skills/work-loop/scripts/lint-spec-status.py
+++ b/.agents/skills/work-loop/scripts/lint-spec-status.py
@@ -37,9 +37,8 @@ header `- **Status:**` field is checked; `plan.md` status is out of v1 scope.
         exit code); promoting it to a hard invariant stays deferred pending
         the observed warn rate.
   (iv)  deferral anchors resolve — every real `(deferred: <slug>)` marker
-        resolves against the **union** of (a) `workspace.toml [backlog].open`
-        slug fields and (b) `docs/backlog.md` heading anchors (tombstone
-        backward-compat). HARD (exit non-zero).
+        resolves against `workspace.toml [backlog].open` slug fields.
+        HARD (exit non-zero).
   (v)   spec↔contract traceability — a spec's
         `- **Contract:**` header (forward ref) names contract file(s) under
         `contracts/<type>/`; each must exist and carry a backward pointer — an
@@ -88,8 +87,6 @@ _CONTRACT_TOKEN_RE = re.compile(r"contracts/[A-Za-z0-9._/-]+")
 # Vendor-extension-bearing contract formats (carry `x-spec` inline); other
 # formats (e.g. .proto, .graphql) use the REGISTRY.md back-ref channel.
 _XSPEC_FORMATS = (".yaml", ".yml", ".json")
-# Markdown heading line.
-_HEADING_RE = re.compile(r"^#{1,6}\s+(.*?)\s*#*\s*$")
 # AC checklist items.
 _AC_OPEN_RE = re.compile(r"^\s*-\s*\[ \]\s")
 _AC_DONE_RE = re.compile(r"^\s*-\s*\[[xX]\]\s")
@@ -118,27 +115,6 @@ def parse_status(spec_text: str) -> str | None:
             return extract_status_token(m.group(1))
     return None
 
-
-def slugify(heading: str) -> str:
-    """GitHub-style heading anchor slug: lowercase, drop punctuation
-    other than spaces/hyphens, spaces → hyphens."""
-    text = heading.strip().lower()
-    # Strip inline markdown emphasis/code markers before slugging.
-    text = text.replace("`", "")
-    text = re.sub(r"[^\w\s-]", "", text)
-    # GitHub does NOT collapse consecutive hyphens: a stripped `/` between
-    # two spaces yields a double hyphen (`a / b` → `a--b`). Match that —
-    # only spaces become hyphens; existing/produced hyphen runs are kept.
-    return text.replace(" ", "-")
-
-
-def backlog_anchors(backlog_text: str) -> set[str]:
-    anchors: set[str] = set()
-    for line in backlog_text.splitlines():
-        m = _HEADING_RE.match(line)
-        if m:
-            anchors.add(slugify(m.group(1)))
-    return anchors
 
 
 def _regex_backlog_slugs(workspace_text: str) -> set[str]:
@@ -329,13 +305,8 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
     hard: list[str] = []
     warn: list[str] = []
 
-    backlog_path = root / "docs" / "backlog.md"
     workspace_path = root / "workspace.toml"
-    anchors = (
-        backlog_anchors(backlog_path.read_text(encoding="utf-8", errors="replace"))
-        if backlog_path.is_file()
-        else set()
-    ) | backlog_open_slugs(workspace_path)
+    anchors = backlog_open_slugs(workspace_path)
 
     base_resolvable = base_ref is not None
     if not base_resolvable:
@@ -364,7 +335,7 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
             if anchor not in anchors:
                 hard.append(
                     f"{rel}:{lineno}: invariant (iv) — (deferred: {anchor}) "
-                    f"does not resolve in workspace.toml [backlog].open or docs/backlog.md"
+                    f"does not resolve in workspace.toml [backlog].open"
                 )
 
         # (ii) ACs at the ship transition (diff-triggered)

--- a/.agents/skills/work-loop/scripts/test-lint-spec-status.py
+++ b/.agents/skills/work-loop/scripts/test-lint-spec-status.py
@@ -38,6 +38,16 @@ def write_backlog(root: Path, headings: list[str]) -> None:
     p.write_text(body, encoding="utf-8")
 
 
+def write_workspace_backlog(root: Path, slugs: list[str]) -> None:
+    p = root / "workspace.toml"
+    if slugs:
+        lines = "\n".join(f'  {{slug = "{s}"}},' for s in slugs)
+        body = f"[backlog]\nopen = [\n{lines}\n]\n"
+    else:
+        body = "[backlog]\nopen = []\n"
+    p.write_text(body, encoding="utf-8")
+
+
 def run_lint(root: Path, base_ref: str | None = None) -> tuple[int, str, str]:
     argv = [sys.executable, str(LINTER), "--root", str(root)]
     if base_ref is not None:
@@ -110,7 +120,7 @@ def case_invariant_ii_transition_fails() -> None:
 def case_invariant_ii_transition_ok_when_deferred() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
-        write_backlog(root, ["later-work"])
+        write_workspace_backlog(root, ["later-work"])
         write_spec(root, "shipping", "Draft", "- [ ] AC1 open\n")
         git_init_commit(root)
         write_spec(
@@ -155,28 +165,15 @@ def case_invariant_i_missing_status() -> None:
         expect("no `- **Status:**`" in err, f"expected missing-status msg: {err}")
 
 
-def case_invariant_iv_resolves_multiword_anchor() -> None:
+def case_invariant_iv_resolves_workspace_slug() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
-        # A real multi-word, punctuated heading must slugify and resolve.
-        write_backlog(root, ["Cross Spec Work!"])
+        # A slug in workspace.toml [backlog].open must resolve a (deferred:) marker.
+        write_workspace_backlog(root, ["some-deferred-item"])
         write_spec(root, "deferring", "Draft",
-                   "- [ ] AC1 (deferred: cross-spec-work)\n")
+                   "- [ ] AC1 (deferred: some-deferred-item)\n")
         rc, _, err = run_lint(root)
-        expect(rc == 0, f"deferral to slugified heading should resolve, got {rc}: {err}")
-
-
-def case_invariant_iv_github_double_hyphen_anchor() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
-        root = Path(tmp)
-        # GitHub turns `## A / b` into anchor `a--b` (double hyphen, no
-        # collapse). The lint must match that to keep its "GitHub slug
-        # rules" promise.
-        write_backlog(root, ["Cross-spec / outside"])
-        write_spec(root, "deferring", "Draft",
-                   "- [ ] AC1 (deferred: cross-spec--outside)\n")
-        rc, _, err = run_lint(root)
-        expect(rc == 0, f"double-hyphen GitHub anchor should resolve, got {rc}: {err}")
+        expect(rc == 0, f"deferral to workspace.toml slug should resolve, got {rc}: {err}")
 
 
 def case_invariant_ii_born_shipped_fails() -> None:
@@ -408,8 +405,7 @@ def main() -> int:
         case_invariant_ii_no_base,
         case_invariant_i_missing_status,
         case_invariant_ii_born_shipped_fails,
-        case_invariant_iv_resolves_multiword_anchor,
-        case_invariant_iv_github_double_hyphen_anchor,
+        case_invariant_iv_resolves_workspace_slug,
         case_invariant_iv_missing_anchor,
         case_invariant_iv_placeholder_ignored,
         case_invariant_iii_warn_only,

--- a/.claude/agents/adversarial-reviewer.md
+++ b/.claude/agents/adversarial-reviewer.md
@@ -151,8 +151,8 @@ checklists; verification-mode awareness applies to every review.
      `(deferred: <anchor>)` marker. An unchecked, undeferred AC on a shipping
      spec is a Blocker.
    - (c) **Deferred items recorded in the register.** Every `(deferred: <anchor>)`
-     points to a real heading in `docs/backlog.md`. A deferral that lives only in
-     the PR description rots — flag it.
+     resolves to a slug entry in `workspace.toml [backlog].open`. A deferral that
+     lives only in the PR description rots — flag it.
    - (d) **Intra-repo references resolve.** Doc links and `<spec>/<anchor>`
      references the diff touches actually resolve. Dangling refs are drift.
 6. **Security and privacy.** What data does this touch? Is access

--- a/.claude/skills/work-loop/scripts/lint-spec-status.py
+++ b/.claude/skills/work-loop/scripts/lint-spec-status.py
@@ -37,9 +37,8 @@ header `- **Status:**` field is checked; `plan.md` status is out of v1 scope.
         exit code); promoting it to a hard invariant stays deferred pending
         the observed warn rate.
   (iv)  deferral anchors resolve — every real `(deferred: <slug>)` marker
-        resolves against the **union** of (a) `workspace.toml [backlog].open`
-        slug fields and (b) `docs/backlog.md` heading anchors (tombstone
-        backward-compat). HARD (exit non-zero).
+        resolves against `workspace.toml [backlog].open` slug fields.
+        HARD (exit non-zero).
   (v)   spec↔contract traceability — a spec's
         `- **Contract:**` header (forward ref) names contract file(s) under
         `contracts/<type>/`; each must exist and carry a backward pointer — an
@@ -88,8 +87,6 @@ _CONTRACT_TOKEN_RE = re.compile(r"contracts/[A-Za-z0-9._/-]+")
 # Vendor-extension-bearing contract formats (carry `x-spec` inline); other
 # formats (e.g. .proto, .graphql) use the REGISTRY.md back-ref channel.
 _XSPEC_FORMATS = (".yaml", ".yml", ".json")
-# Markdown heading line.
-_HEADING_RE = re.compile(r"^#{1,6}\s+(.*?)\s*#*\s*$")
 # AC checklist items.
 _AC_OPEN_RE = re.compile(r"^\s*-\s*\[ \]\s")
 _AC_DONE_RE = re.compile(r"^\s*-\s*\[[xX]\]\s")
@@ -118,27 +115,6 @@ def parse_status(spec_text: str) -> str | None:
             return extract_status_token(m.group(1))
     return None
 
-
-def slugify(heading: str) -> str:
-    """GitHub-style heading anchor slug: lowercase, drop punctuation
-    other than spaces/hyphens, spaces → hyphens."""
-    text = heading.strip().lower()
-    # Strip inline markdown emphasis/code markers before slugging.
-    text = text.replace("`", "")
-    text = re.sub(r"[^\w\s-]", "", text)
-    # GitHub does NOT collapse consecutive hyphens: a stripped `/` between
-    # two spaces yields a double hyphen (`a / b` → `a--b`). Match that —
-    # only spaces become hyphens; existing/produced hyphen runs are kept.
-    return text.replace(" ", "-")
-
-
-def backlog_anchors(backlog_text: str) -> set[str]:
-    anchors: set[str] = set()
-    for line in backlog_text.splitlines():
-        m = _HEADING_RE.match(line)
-        if m:
-            anchors.add(slugify(m.group(1)))
-    return anchors
 
 
 def _regex_backlog_slugs(workspace_text: str) -> set[str]:
@@ -329,13 +305,8 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
     hard: list[str] = []
     warn: list[str] = []
 
-    backlog_path = root / "docs" / "backlog.md"
     workspace_path = root / "workspace.toml"
-    anchors = (
-        backlog_anchors(backlog_path.read_text(encoding="utf-8", errors="replace"))
-        if backlog_path.is_file()
-        else set()
-    ) | backlog_open_slugs(workspace_path)
+    anchors = backlog_open_slugs(workspace_path)
 
     base_resolvable = base_ref is not None
     if not base_resolvable:
@@ -364,7 +335,7 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
             if anchor not in anchors:
                 hard.append(
                     f"{rel}:{lineno}: invariant (iv) — (deferred: {anchor}) "
-                    f"does not resolve in workspace.toml [backlog].open or docs/backlog.md"
+                    f"does not resolve in workspace.toml [backlog].open"
                 )
 
         # (ii) ACs at the ship transition (diff-triggered)

--- a/.claude/skills/work-loop/scripts/test-lint-spec-status.py
+++ b/.claude/skills/work-loop/scripts/test-lint-spec-status.py
@@ -38,6 +38,16 @@ def write_backlog(root: Path, headings: list[str]) -> None:
     p.write_text(body, encoding="utf-8")
 
 
+def write_workspace_backlog(root: Path, slugs: list[str]) -> None:
+    p = root / "workspace.toml"
+    if slugs:
+        lines = "\n".join(f'  {{slug = "{s}"}},' for s in slugs)
+        body = f"[backlog]\nopen = [\n{lines}\n]\n"
+    else:
+        body = "[backlog]\nopen = []\n"
+    p.write_text(body, encoding="utf-8")
+
+
 def run_lint(root: Path, base_ref: str | None = None) -> tuple[int, str, str]:
     argv = [sys.executable, str(LINTER), "--root", str(root)]
     if base_ref is not None:
@@ -110,7 +120,7 @@ def case_invariant_ii_transition_fails() -> None:
 def case_invariant_ii_transition_ok_when_deferred() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
-        write_backlog(root, ["later-work"])
+        write_workspace_backlog(root, ["later-work"])
         write_spec(root, "shipping", "Draft", "- [ ] AC1 open\n")
         git_init_commit(root)
         write_spec(
@@ -155,28 +165,15 @@ def case_invariant_i_missing_status() -> None:
         expect("no `- **Status:**`" in err, f"expected missing-status msg: {err}")
 
 
-def case_invariant_iv_resolves_multiword_anchor() -> None:
+def case_invariant_iv_resolves_workspace_slug() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
-        # A real multi-word, punctuated heading must slugify and resolve.
-        write_backlog(root, ["Cross Spec Work!"])
+        # A slug in workspace.toml [backlog].open must resolve a (deferred:) marker.
+        write_workspace_backlog(root, ["some-deferred-item"])
         write_spec(root, "deferring", "Draft",
-                   "- [ ] AC1 (deferred: cross-spec-work)\n")
+                   "- [ ] AC1 (deferred: some-deferred-item)\n")
         rc, _, err = run_lint(root)
-        expect(rc == 0, f"deferral to slugified heading should resolve, got {rc}: {err}")
-
-
-def case_invariant_iv_github_double_hyphen_anchor() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
-        root = Path(tmp)
-        # GitHub turns `## A / b` into anchor `a--b` (double hyphen, no
-        # collapse). The lint must match that to keep its "GitHub slug
-        # rules" promise.
-        write_backlog(root, ["Cross-spec / outside"])
-        write_spec(root, "deferring", "Draft",
-                   "- [ ] AC1 (deferred: cross-spec--outside)\n")
-        rc, _, err = run_lint(root)
-        expect(rc == 0, f"double-hyphen GitHub anchor should resolve, got {rc}: {err}")
+        expect(rc == 0, f"deferral to workspace.toml slug should resolve, got {rc}: {err}")
 
 
 def case_invariant_ii_born_shipped_fails() -> None:
@@ -408,8 +405,7 @@ def main() -> int:
         case_invariant_ii_no_base,
         case_invariant_i_missing_status,
         case_invariant_ii_born_shipped_fails,
-        case_invariant_iv_resolves_multiword_anchor,
-        case_invariant_iv_github_double_hyphen_anchor,
+        case_invariant_iv_resolves_workspace_slug,
         case_invariant_iv_missing_anchor,
         case_invariant_iv_placeholder_ignored,
         case_invariant_iii_warn_only,

--- a/.codex/agents/adversarial-reviewer.toml
+++ b/.codex/agents/adversarial-reviewer.toml
@@ -152,8 +152,8 @@ checklists; verification-mode awareness applies to every review.
      `(deferred: <anchor>)` marker. An unchecked, undeferred AC on a shipping
      spec is a Blocker.
    - (c) **Deferred items recorded in the register.** Every `(deferred: <anchor>)`
-     points to a real heading in `docs/backlog.md`. A deferral that lives only in
-     the PR description rots — flag it.
+     resolves to a slug entry in `workspace.toml [backlog].open`. A deferral that
+     lives only in the PR description rots — flag it.
    - (d) **Intra-repo references resolve.** Doc links and `<spec>/<anchor>`
      references the diff touches actually resolve. Dangling refs are drift.
 6. **Security and privacy.** What data does this touch? Is access

--- a/docs/specs/adversarial-reviewer-deferral-resolution-update/spec.md
+++ b/docs/specs/adversarial-reviewer-deferral-resolution-update/spec.md
@@ -1,0 +1,45 @@
+# Spec: adversarial-reviewer-deferral-resolution-update
+
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Mode:** light (no risk trigger fired)
+- **Plan:** inline below
+
+> **Spec contract:** this document defines what "done" means.
+
+## Objective
+
+Make `docs/backlog.md` purely historical. The m3-backlog-absorption migration
+moved all open work to `workspace.toml [backlog].open`, leaving `docs/backlog.md`
+as a tombstone for Frozen RFC anchor links only. However, `lint-spec-status.py`
+still resolves `(deferred:)` markers against the union of `workspace.toml
+[backlog].open` AND `docs/backlog.md` headings, and `adversarial-reviewer.md`
+check (c) still instructs reviewers to look for `(deferred:)` anchors in
+`docs/backlog.md`. Both need updating so the workspace.toml register is the single
+authoritative source.
+
+## Acceptance Criteria
+
+- [x] `lint-spec-status.py` resolves `(deferred:)` anchors only against
+  `workspace.toml [backlog].open` slugs — no `docs/backlog.md` read in the
+  deferral check.
+- [x] Dead helper code removed from `lint-spec-status.py`: `backlog_anchors()`,
+  `slugify()`, `_HEADING_RE`, `backlog_path` local variable.
+- [x] `adversarial-reviewer.md` check (c) reads: "resolves to a slug entry in
+  `workspace.toml [backlog].open`" (not "points to a real heading in
+  `docs/backlog.md`").
+- [x] `lint-spec-status.py` run against the live repo produces no new hard
+  violations — all existing `(deferred:)` markers already resolve against
+  `workspace.toml [backlog].open`.
+- [x] Projections synced: `.claude/agents/adversarial-reviewer.md` and
+  `.claude/skills/work-loop/scripts/lint-spec-status.py` match their pack
+  sources after `make build-self`.
+
+## Tasks
+
+1. Edit `packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py` — remove
+   `docs/backlog.md` union from `check()`, remove dead helpers, update docstring
+   and error message.
+2. Edit `packs/core/.apm/agents/adversarial-reviewer.md` — update check (c).
+3. Run `make build-self` to sync projections.
+4. Run `lint-spec-status.py` to confirm no new violations.

--- a/packs/core/.apm/agents/adversarial-reviewer.md
+++ b/packs/core/.apm/agents/adversarial-reviewer.md
@@ -151,8 +151,8 @@ checklists; verification-mode awareness applies to every review.
      `(deferred: <anchor>)` marker. An unchecked, undeferred AC on a shipping
      spec is a Blocker.
    - (c) **Deferred items recorded in the register.** Every `(deferred: <anchor>)`
-     points to a real heading in `docs/backlog.md`. A deferral that lives only in
-     the PR description rots — flag it.
+     resolves to a slug entry in `workspace.toml [backlog].open`. A deferral that
+     lives only in the PR description rots — flag it.
    - (d) **Intra-repo references resolve.** Doc links and `<spec>/<anchor>`
      references the diff touches actually resolve. Dangling refs are drift.
 6. **Security and privacy.** What data does this touch? Is access

--- a/packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py
+++ b/packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py
@@ -37,9 +37,8 @@ header `- **Status:**` field is checked; `plan.md` status is out of v1 scope.
         exit code); promoting it to a hard invariant stays deferred pending
         the observed warn rate.
   (iv)  deferral anchors resolve — every real `(deferred: <slug>)` marker
-        resolves against the **union** of (a) `workspace.toml [backlog].open`
-        slug fields and (b) `docs/backlog.md` heading anchors (tombstone
-        backward-compat). HARD (exit non-zero).
+        resolves against `workspace.toml [backlog].open` slug fields.
+        HARD (exit non-zero).
   (v)   spec↔contract traceability — a spec's
         `- **Contract:**` header (forward ref) names contract file(s) under
         `contracts/<type>/`; each must exist and carry a backward pointer — an
@@ -88,8 +87,6 @@ _CONTRACT_TOKEN_RE = re.compile(r"contracts/[A-Za-z0-9._/-]+")
 # Vendor-extension-bearing contract formats (carry `x-spec` inline); other
 # formats (e.g. .proto, .graphql) use the REGISTRY.md back-ref channel.
 _XSPEC_FORMATS = (".yaml", ".yml", ".json")
-# Markdown heading line.
-_HEADING_RE = re.compile(r"^#{1,6}\s+(.*?)\s*#*\s*$")
 # AC checklist items.
 _AC_OPEN_RE = re.compile(r"^\s*-\s*\[ \]\s")
 _AC_DONE_RE = re.compile(r"^\s*-\s*\[[xX]\]\s")
@@ -118,27 +115,6 @@ def parse_status(spec_text: str) -> str | None:
             return extract_status_token(m.group(1))
     return None
 
-
-def slugify(heading: str) -> str:
-    """GitHub-style heading anchor slug: lowercase, drop punctuation
-    other than spaces/hyphens, spaces → hyphens."""
-    text = heading.strip().lower()
-    # Strip inline markdown emphasis/code markers before slugging.
-    text = text.replace("`", "")
-    text = re.sub(r"[^\w\s-]", "", text)
-    # GitHub does NOT collapse consecutive hyphens: a stripped `/` between
-    # two spaces yields a double hyphen (`a / b` → `a--b`). Match that —
-    # only spaces become hyphens; existing/produced hyphen runs are kept.
-    return text.replace(" ", "-")
-
-
-def backlog_anchors(backlog_text: str) -> set[str]:
-    anchors: set[str] = set()
-    for line in backlog_text.splitlines():
-        m = _HEADING_RE.match(line)
-        if m:
-            anchors.add(slugify(m.group(1)))
-    return anchors
 
 
 def _regex_backlog_slugs(workspace_text: str) -> set[str]:
@@ -329,13 +305,8 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
     hard: list[str] = []
     warn: list[str] = []
 
-    backlog_path = root / "docs" / "backlog.md"
     workspace_path = root / "workspace.toml"
-    anchors = (
-        backlog_anchors(backlog_path.read_text(encoding="utf-8", errors="replace"))
-        if backlog_path.is_file()
-        else set()
-    ) | backlog_open_slugs(workspace_path)
+    anchors = backlog_open_slugs(workspace_path)
 
     base_resolvable = base_ref is not None
     if not base_resolvable:
@@ -364,7 +335,7 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
             if anchor not in anchors:
                 hard.append(
                     f"{rel}:{lineno}: invariant (iv) — (deferred: {anchor}) "
-                    f"does not resolve in workspace.toml [backlog].open or docs/backlog.md"
+                    f"does not resolve in workspace.toml [backlog].open"
                 )
 
         # (ii) ACs at the ship transition (diff-triggered)

--- a/packs/core/.apm/skills/work-loop/scripts/test-lint-spec-status.py
+++ b/packs/core/.apm/skills/work-loop/scripts/test-lint-spec-status.py
@@ -38,6 +38,16 @@ def write_backlog(root: Path, headings: list[str]) -> None:
     p.write_text(body, encoding="utf-8")
 
 
+def write_workspace_backlog(root: Path, slugs: list[str]) -> None:
+    p = root / "workspace.toml"
+    if slugs:
+        lines = "\n".join(f'  {{slug = "{s}"}},' for s in slugs)
+        body = f"[backlog]\nopen = [\n{lines}\n]\n"
+    else:
+        body = "[backlog]\nopen = []\n"
+    p.write_text(body, encoding="utf-8")
+
+
 def run_lint(root: Path, base_ref: str | None = None) -> tuple[int, str, str]:
     argv = [sys.executable, str(LINTER), "--root", str(root)]
     if base_ref is not None:
@@ -110,7 +120,7 @@ def case_invariant_ii_transition_fails() -> None:
 def case_invariant_ii_transition_ok_when_deferred() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
-        write_backlog(root, ["later-work"])
+        write_workspace_backlog(root, ["later-work"])
         write_spec(root, "shipping", "Draft", "- [ ] AC1 open\n")
         git_init_commit(root)
         write_spec(
@@ -155,28 +165,15 @@ def case_invariant_i_missing_status() -> None:
         expect("no `- **Status:**`" in err, f"expected missing-status msg: {err}")
 
 
-def case_invariant_iv_resolves_multiword_anchor() -> None:
+def case_invariant_iv_resolves_workspace_slug() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
-        # A real multi-word, punctuated heading must slugify and resolve.
-        write_backlog(root, ["Cross Spec Work!"])
+        # A slug in workspace.toml [backlog].open must resolve a (deferred:) marker.
+        write_workspace_backlog(root, ["some-deferred-item"])
         write_spec(root, "deferring", "Draft",
-                   "- [ ] AC1 (deferred: cross-spec-work)\n")
+                   "- [ ] AC1 (deferred: some-deferred-item)\n")
         rc, _, err = run_lint(root)
-        expect(rc == 0, f"deferral to slugified heading should resolve, got {rc}: {err}")
-
-
-def case_invariant_iv_github_double_hyphen_anchor() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
-        root = Path(tmp)
-        # GitHub turns `## A / b` into anchor `a--b` (double hyphen, no
-        # collapse). The lint must match that to keep its "GitHub slug
-        # rules" promise.
-        write_backlog(root, ["Cross-spec / outside"])
-        write_spec(root, "deferring", "Draft",
-                   "- [ ] AC1 (deferred: cross-spec--outside)\n")
-        rc, _, err = run_lint(root)
-        expect(rc == 0, f"double-hyphen GitHub anchor should resolve, got {rc}: {err}")
+        expect(rc == 0, f"deferral to workspace.toml slug should resolve, got {rc}: {err}")
 
 
 def case_invariant_ii_born_shipped_fails() -> None:
@@ -408,8 +405,7 @@ def main() -> int:
         case_invariant_ii_no_base,
         case_invariant_i_missing_status,
         case_invariant_ii_born_shipped_fails,
-        case_invariant_iv_resolves_multiword_anchor,
-        case_invariant_iv_github_double_hyphen_anchor,
+        case_invariant_iv_resolves_workspace_slug,
         case_invariant_iv_missing_anchor,
         case_invariant_iv_placeholder_ignored,
         case_invariant_iii_warn_only,

--- a/workspace.toml
+++ b/workspace.toml
@@ -58,7 +58,9 @@ ready     = []
 draft     = []
 
 ["ini-002".work]
-active  = []
+active  = [
+  "spec/catalogue-curation",  # in progress — pending manual-QA live tests (assimilate-primitive, export-catalogue, assimilate-repo dry runs)
+]
 shipped = [
   "spec/m2-frame-situation",     # frame-situation PE skill
   "spec/m1-workspace-core",      # Batch 2
@@ -128,8 +130,6 @@ queue   = [
   "spec/m6-live-demo-guide",              # ≥3 team types; ≤30-min shaping→brief→spec narration on org's own repo
   "spec/m6-enterprise-rollout-playbook",  # champion→CTO→platform→engineers; staged rollout + retro template
 
-  # ---------------- Independent track (not RFC-0064) ----------------
-  "spec/catalogue-curation",
 ]
 
 # Repo-level backlog — open work not scoped to any active initiative.
@@ -144,16 +144,6 @@ queue   = [
 open = [
   # ── Quick wins ───────────────────────────────────────────────────────────────
   # (single focused session; no external environment; small diff)
-
-  # packs/core/.apm/skills/adversarial-reviewer.md line ~154 references
-  # docs/backlog.md as the deferral register. After m3-backlog-absorption ships,
-  # deferrals resolve to workspace.toml [backlog].open instead. The stale reference
-  # actively misdirects reviewers checking deferral resolution.
-  # Fix: update the deferral-resolution description in adversarial-reviewer.md to
-  #   reference workspace.toml [backlog].open instead of docs/backlog.md.
-  # Unblocks when: m3-backlog-absorption ships; this is a one-file follow-on.
-  {slug = "adversarial-reviewer-deferral-resolution-update"},
-
 
   # The credential-brokers pack's shipped .apm/** carries RFC-0023/RFC-0006 citations
   # in credential-setup/scripts/setup.py and user-libs/credbroker/ (files:
@@ -434,18 +424,8 @@ open = [
   # (RFC-0062) produces the artifact; the reviewer's scope extension is a follow-on RFC.
   # Fix: open a follow-on RFC extending RFC-0062 to add content-brief to
   #   experience-reviewer's reviewable artifact set.
-  # Unblocks when: RFC-0062 content-design skill spec ships.
+  # Ready — RFC-0062 content-design-skill spec is Shipped; this item is now actionable.
   {slug = "experience-reviewer-content-brief-scope"},
-
-  # RFC-0062 opened 2026-07-18. Implementing copy-direction skill in experience pack
-  # (experience 0.5.0) — the copy twin of aesthetic-direction. Same interrogation
-  # structure (vibe → named goals → grounding → arbitration) applied to copy voice
-  # and positioned copy; produces copy-direction.md grounded in persona, copy
-  # precedents, and persuasion standards (painkiller-first, tweet test, 5-second scan).
-  # RFC must address: scope boundary relative to voice-and-microcopy; whether
-  # conversion architecture belongs here or in a future growth-pack track.
-  # Unblocks when: RFC-0062 is Accepted and the implementing spec is approved.
-  {slug = "copy-direction-skill-rfc"},
 
   # RFC-0059 Non-goals. The honest counterpart to catalogue assimilation: cleanly
   # retire a skill/agent/hook or deprecate a pack with tombstones. Deferred as rare;


### PR DESCRIPTION
## Summary

- **workspace.toml:** Backlog triage — moves `catalogue-curation` to `[work].active` (in-progress, pending live tests), drops `copy-direction-skill-rfc` (spec Shipped), updates stale "Unblocks when" comment on `experience-reviewer-content-brief-scope`, and removes the self-referential `adversarial-reviewer-deferral-resolution-update` entry (shipped here).
- **lint-spec-status.py:** Removes `docs/backlog.md` from invariant (iv) deferral-anchor resolution. `workspace.toml [backlog].open` is now the sole authoritative register. Dead helpers removed: `backlog_anchors()`, `slugify()`, `_HEADING_RE`, `backlog_path`.
- **adversarial-reviewer.md** check (c): updated from "points to a real heading in `docs/backlog.md`" to "resolves to a slug entry in `workspace.toml [backlog].open`".
- All four projections synced via `make build-self`.

## Test plan

- [ ] `lint-spec-status.py --root .` exits 0 with `spec metadata clean.` — verified locally; no existing `(deferred:)` markers broken
- [ ] `make lint-packs` clean
- [ ] `make build-self` drift-free (projections committed in this PR)