### PR TITLE
feat(atlassian): jira-align-brief-intake skill — Jira Align Feature → brief (RFC-0064 M5)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -37,7 +37,7 @@
         "name": "eugenelim"
       },
       "category": "integrations",
-      "description": "Atlassian primitives: jira / jira-align / confluence-crawler (credentialed CLI), plus the flow-metrics, ai-adoption-report, jira-defect-flow, and jira-brief-intake workflows that compose them.",
+      "description": "Atlassian primitives: jira / jira-align / confluence-crawler (credentialed CLI), plus the flow-metrics, ai-adoption-report, jira-defect-flow, jira-brief-intake, and jira-align-brief-intake workflows that compose them.",
       "displayName": "Atlassian",
       "homepage": "https://github.com/eugenelim/agent-ready-repo",
       "keywords": [
@@ -55,7 +55,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.3.2"
+      "version": "0.4.0"
     },
     {
       "author": {

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -68,7 +68,7 @@ catalogue listing — see [`pack-manifest.md`](pack-manifest.md).
 | `monorepo-extras` | repo only | `new-package` skill + `packages/_example/` template. Requires `core`. |
 | `contracts` | user (default) or repo | `api-contract` (OpenAPI 3.1) and `event-contract` (AsyncAPI). |
 | `converters` | user (default) or repo | Document/image → Markdown, Markdown → styled HTML, Outlook `.msg` → Markdown. |
-| `atlassian` | user (default) or repo | `jira`, `jira-align`, `confluence-crawler` (credentialed CLIs) + the `flow-metrics`, `ai-adoption-report`, `jira-defect-flow`, `jira-brief-intake` workflows that compose them. |
+| `atlassian` | user (default) or repo | `jira`, `jira-align`, `confluence-crawler` (credentialed CLIs) + the `flow-metrics`, `ai-adoption-report`, `jira-defect-flow`, `jira-brief-intake`, `jira-align-brief-intake` workflows that compose them. |
 | `figma` | user (default) or repo | `figma` credentialed CLI (REST API reads, frame renders, FigJam → Mermaid). |
 | `research` | user (default) or repo | Seven research skills (scoping → synthesis → decision support) + two read-only retrieval subagents. |
 | `architect` | user (default) or repo | `architect-design`, `architect-diagram`, `architect-review` (Mermaid + Google-style design docs). |

--- a/docs/guides/atlassian/README.md
+++ b/docs/guides/atlassian/README.md
@@ -1,6 +1,6 @@
 # `atlassian` — guides
 
-Jira, Jira Align, and Confluence over their REST APIs — plus the flow metrics and intake workflows you build on top of them. The pack ships `jira` and `jira-align` for issue and portfolio data, `confluence-crawler` and `confluence-publisher` for wiki content, `jira-defect-flow` for end-to-end defect handling, `jira-brief-intake` to turn a Jira epic into a product brief, and `flow-metrics` + `ai-adoption-report` for DORA / Flow Framework measurement. The four API-touching skills are credentialed: the secret resolves in-process and never reaches the model.
+Jira, Jira Align, and Confluence over their REST APIs — plus the flow metrics and intake workflows you build on top of them. The pack ships `jira` and `jira-align` for issue and portfolio data, `confluence-crawler` and `confluence-publisher` for wiki content, `jira-defect-flow` for end-to-end defect handling, `jira-brief-intake` to turn a Jira epic into a product brief, `jira-align-brief-intake` to turn a Jira Align Feature into a product brief, and `flow-metrics` + `ai-adoption-report` for DORA / Flow Framework measurement. The four API-touching skills are credentialed: the secret resolves in-process and never reaches the model.
 
 New here? Read [The `atlassian` pack as a system](explanation/atlassian-pack.md) first — it's the map. Then [work with Jira](how-to/work-with-jira.md) to search and mutate issues.
 

--- a/docs/guides/atlassian/explanation/atlassian-pack.md
+++ b/docs/guides/atlassian/explanation/atlassian-pack.md
@@ -19,6 +19,7 @@ Several skills compose the surfaces above instead of touching the API directly:
 - **[`ai-adoption-report`](../../../../packs/atlassian/.apm/skills/ai-adoption-report/)** pairs `flow-metrics` JSON outputs and renders a Markdown comparison report. It makes no upstream calls; its only inputs are local JSON files.
 - **[`jira-defect-flow`](../../../../packs/atlassian/.apm/skills/jira-defect-flow/)** handles a Jira defect end-to-end: pulls the ticket via `jira`, hands the fix to the `bug-fix` skill, opens a PR, then comments and transitions the ticket.
 - **[`jira-brief-intake`](../../../../packs/atlassian/.apm/skills/jira-brief-intake/)** turns a Jira epic (or a board / JQL selection) into shippable specs: pulls the epic and its children via `jira`, maps them onto a Shape B product brief, and hands off to the `receive-brief` skill to elicit gaps, decompose, and build. Read-only against Jira; degrades gracefully when `receive-brief` is absent.
+- **[`jira-align-brief-intake`](../../../../packs/atlassian/.apm/skills/jira-align-brief-intake/)** turns a Jira Align Feature into shippable specs: fetches the Feature and its child stories, tasks, and defects via `jira-align`, maps them onto a Shape B product brief using a configuration-guided field mapping reference (customised for org-specific workflow states and PI cadences), and hands off to `receive-brief`. 1-way intake only — never writes to Jira Align. Degrades gracefully when `receive-brief` is absent.
 
 ## The auth model
 

--- a/docs/guides/atlassian/reference/atlassian-skills.md
+++ b/docs/guides/atlassian/reference/atlassian-skills.md
@@ -54,6 +54,14 @@ Credentialed skills resolve secrets in-process through the tier ladder (environm
 - **Required credentials.** None — consumes local JSON files only.
 - **Source.** [`ai-adoption-report`](../../../../packs/atlassian/.apm/skills/ai-adoption-report/)
 
+## `jira-align-brief-intake`
+
+- **Purpose.** Turn a Jira Align Feature into a product brief and shippable specs. Fetches the Feature and its child stories, tasks, and defects via the `jira-align` skill, maps them onto a Shape B product brief (Feature title/description → Outcome, children → `US-n` user stories tagged with their Jira Align IDs, Feature ID → `Epic:` provenance pointer), writes it to `docs/product/briefs/<slug>.md`, and hands off to the `receive-brief` skill to elicit gaps, decompose, and build. 1-way intake only — never writes to Jira Align. Requires one-time customisation of the field mapping reference (`references/field-mapping.md`) for org-specific workflow state names and Program Increment cadences.
+- **Primary inputs.** A Jira Align Feature ID. Composes sibling and host skills by name: `jira-align` (reads only — `check`, `get features`, `list stories`/`tasks`/`defects` with `featureID eq` filter) and `receive-brief` (soft dependency — degrades gracefully when absent).
+- **Outputs.** A Shape B product brief at `docs/product/briefs/<slug>.md`, then a hand-off to `receive-brief` (or an inlined decompose/execute instruction in the degraded path).
+- **Required credentials.** None of its own — Jira Align access is inherited through the `jira-align` skill (`JIRAALIGN_BASE_URL`, `JIRAALIGN_API_TOKEN`).
+- **Source.** [`jira-align-brief-intake`](../../../../packs/atlassian/.apm/skills/jira-align-brief-intake/)
+
 ## `jira-defect-flow`
 
 - **Purpose.** Handle a Jira defect end-to-end. Pulls the ticket via the `jira` skill, hands the fix to the `bug-fix` skill, opens a PR linking back to Jira, then comments and transitions the ticket. Stops at PR-opened by default; runs a dev-deploy step only when the consumer repo provides one. For defects, not stories, tasks, or feature work.

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`jira-align-brief-intake` skill (atlassian pack 0.4.0).** Turns a Jira Align Feature into a product brief and shippable specs: fetches the Feature and its child stories, tasks, and defects via the `jira-align` skill, maps them onto a Shape B product brief using a configuration-guided field mapping reference (customised for org-specific workflow state names and Program Increment cadences), and hands off to `receive-brief` to elicit gaps, decompose, and build. 1-way intake only — never writes to Jira Align. Mirrors the `jira-brief-intake` choreography pattern for Jira Align's program-level delivery unit. ([RFC-0064 M5](../rfc/0064-ini-001-ai-native-ecosystem.md))
+
 ### Fixed
 
 - **Claude plugin marketplace manifest now passes `claude plugin validate` (Claude Code 2.1.209).** Three generator defects caused 35 errors: (1) marketplace missing top-level `name` field, (2) plugin `author` emitted as a plain string instead of a `{name, email}` object, (3) plugin `source` field absent entirely. All three are fixed in the build pipeline (`derive_projectable_subset`, `_run_aggregate`, `_aggregate_marketplace`). The `.claude-plugin/marketplace.json` in the working tree now validates with 0 errors.

--- a/docs/specs/m5-jira-align-brief-intake/plan.md
+++ b/docs/specs/m5-jira-align-brief-intake/plan.md
@@ -1,0 +1,102 @@
+# Plan: m5-jira-align-brief-intake
+
+## Constraints
+
+- Pure choreography skill — no new scripts or executable logic. Gates are
+  `lint-packs` + `agentbundle validate` + `make build` + package pytest.
+- Version bump: atlassian pack 0.3.2 → 0.4.0 (minor — new skill = new
+  published interface).
+- All `jira-align` subcommand names verified against
+  `packs/atlassian/.apm/skills/jira-align/SKILL.md` before use in the skill
+  body — no assumed subcommands.
+
+## Risks
+
+- None identified. This is a read-only choreography skill over an existing
+  primitive (`jira-align`). The only novel element is the config-guided field
+  mapping reference; no runtime parsing, no new dependencies.
+
+## Changelog
+
+- atlassian pack 0.4.0: `jira-align-brief-intake` skill added.
+
+## Tasks
+
+### Task 1: Author `SKILL.md` and `manifest.json`
+
+**Verification mode:** goal-based check
+**Done when:** `lint-packs` passes against the new skill directory; the
+`SKILL.md` frontmatter parses; the `manifest.json` is valid JSON with
+required fields; `agentbundle validate` reports the pack as valid.
+
+**Approach:** Create `packs/atlassian/.apm/skills/jira-align-brief-intake/`
+with `SKILL.md` and `manifest.json`. The skill body follows
+`jira-brief-intake`'s choreography pattern, adapted for the Jira Align
+entity model (Feature instead of Epic; `jira-align` primitive instead of
+`jira`; config-guided field mapping).
+
+### Task 2: Author `references/field-mapping.md`
+
+**Verification mode:** goal-based check
+**Done when:** The reference table covers all five AC items: (a) standard
+Jira Align Feature field → brief field mapping; (b) org-specific state
+vocabulary section with placeholder rows; (c) PI/Program Increment mapping;
+(d) child → `US-n` provenance format; (e) setup note for new instances.
+
+**Approach:** Create `packs/atlassian/.apm/skills/jira-align-brief-intake/references/field-mapping.md`.
+Adopt a tabular format the adopter can annotate in-place. Include "Customize
+for your org" headings on sections that require instance-specific values.
+
+### Task 3: Update pack metadata
+
+**Verification mode:** goal-based check
+**Done when:** `packs/atlassian/pack.toml` shows version `0.4.0`, updated
+`description`, and `jira-align-brief-intake` in `[pack.evals].skills`.
+`packs/atlassian/.claude-plugin/plugin.json` matches. `make build` produces
+an updated `marketplace.json` that includes the new skill.
+
+**Approach:** Edit `pack.toml` and `plugin.json` in place.
+
+### Task 4: Update enumeration docs
+
+**Verification mode:** goal-based check
+**Done when:** `grep -r "jira-align-brief-intake"` returns hits in all five
+target docs: `packs/atlassian/README.md`,
+`docs/guides/atlassian/README.md`,
+`docs/guides/atlassian/reference/atlassian-skills.md`,
+`docs/guides/atlassian/explanation/atlassian-pack.md`,
+`docs/architecture/overview.md`.
+
+**Approach:** Add the new skill to each doc's enumeration prose. De-count
+hardcoded skill counts where the edit already touches the line (no-brittle-
+counts convention).
+
+### Task 5: Changelog entry + spec Status
+
+**Verification mode:** goal-based check
+**Done when:** `docs/product/changelog.md` has a `[Unreleased]` entry naming
+the new skill. `spec.md` Status field is updated to `Shipped`. `workspace.toml`
+moves the spec path from `queue` to `shipped`.
+
+**Approach:** Add one entry under `[Unreleased] → Added`. Update spec.md and
+workspace.toml in the same commit.
+
+## Manual verification
+
+Trace the skill's documented procedure against a representative Jira Align
+Feature (using real subcommand names from `jira-align` SKILL.md) and confirm:
+
+1. `jira-align: check` — maps to the real `check` subcommand. Exit 0 = proceed.
+2. `jira-align get features <ID> --expand ownerUser,milestones` — maps to
+   real `get` subcommand with a real resource path.
+3. `jira-align list stories --filter "featureID eq <ID>"` — maps to real
+   `list` subcommand with real OData filter syntax (verified in SKILL.md
+   Step 3).
+4. `jira-align list tasks --filter "featureID eq <ID>"` — same.
+5. `jira-align list defects --filter "featureID eq <ID>"` — same.
+6. Brief produced at `docs/product/briefs/<slug>.md` conforms to the Shape B
+   template: heading, `Epic:` pointer, Outcome, user stories each tagged
+   `(stories/<id>)`.
+7. Hand-off to `receive-brief` by name fires in the core-present path.
+8. Core-absent path: inlined compact brief shape + decompose/execute
+   instruction is clear and actionable without `receive-brief` installed.

--- a/docs/specs/m5-jira-align-brief-intake/spec.md
+++ b/docs/specs/m5-jira-align-brief-intake/spec.md
@@ -1,0 +1,248 @@
+# Spec: m5-jira-align-brief-intake
+
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** RFC-0064 M5 <!-- 1-way intake only; configuration-guided field mapping; generic portable sync explicitly not a goal (Known Unknowns — Unknowable) -->
+- **Brief:** none
+- **Contract:** none
+- **Shape:** integration <!-- composes the jira-align credentialed CLI + receive-brief; ships choreography prose, not code; plan's `## Design (LLD)` intentionally empty -->
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+Teams that plan delivery at the program level in **Jira Align** keep the
+*what/why* of a body of work in a Jira Align **Feature** (and its child
+stories, tasks, and defects), not in a written product brief. The
+`receive-brief` skill is the front door to spec-driven delivery, but it
+has no knowledge of Jira Align: it ingests a brief, elicits what's missing,
+decomposes into specs, and hands each to `new-spec` → `work-loop`.
+`jira-align-brief-intake` is the missing adapter between the two.
+
+It pulls a Jira Align Feature (plus its child stories, tasks, and defects)
+via the `jira-align` skill, maps the Jira Align–native shape onto a product
+brief — Feature title/description → **Outcome**, child items → **Shape B
+user stories** (`US-n`), Feature ID → **`Epic:`** provenance pointer —
+writes a draft brief to `docs/product/briefs/<slug>.md`, and hands off to
+`receive-brief` by name to elicit gaps, decompose, and build.
+
+The mapping is **configuration-guided**: Jira Align workflow state names and
+Program Increment cadences are org-specific. The skill carries a reference
+table (`references/field-mapping.md`) the adopter annotates with their
+instance's vocabulary before first use. This is the boundary RFC-0064 M5
+drew explicitly — a generic portable sync is not a goal, and the 1-way
+intake direction is intentional.
+
+Like `jira-brief-intake` for Jira epics and `jira-defect-flow` for Jira
+defects, this skill is choreography, not invention. It never writes a raw
+Jira Align REST call (the `jira-align` skill owns that) and never
+reimplements elicitation, decomposition, or spec authoring (`receive-brief`
+and its downstream own that). Its sole contribution is the Jira Align →
+brief mapping that neither side can do alone.
+
+## Boundaries
+
+### Always do
+
+- Pull all Jira Align data through the `jira-align` skill addressed **by
+  name**, never by path and never via a raw REST call.
+- Fetch the Feature using `jira-align get features <ID> --expand
+  ownerUser,milestones` to capture ownership and PI context.
+- Enumerate a Feature's children by resource type with
+  `jira-align list stories --filter "featureID eq <ID>"` (and optionally
+  `list tasks` / `list defects` with the same filter) — never assume all
+  children are stories; surface whichever types are present.
+- Map Feature fields onto the brief using the config-guided reference table
+  in `references/field-mapping.md`: Feature title → brief heading; Feature
+  description + notes → Outcome; Feature ID → `Epic:` provenance pointer
+  (full URL: `<JIRAALIGN_BASE_URL>/features/<ID>`); children → Shape B
+  user stories.
+- Tag each `US-n` with its Jira Align resource ID in parentheses so
+  traceability is bidirectional (Jira Align ID ↔ `US-n` ↔ spec AC). Format:
+  `- **US-n.** (stories/<id>) <story text>` (substitute `tasks/` or
+  `defects/` per resource type).
+- Stamp the source Feature ID into the brief's `Epic:` provenance pointer.
+- Probe the `jira-align` skill before any read (`jira-align: check`): exit
+  0 → proceed; exit 2 → tell the user to authenticate via `credential-setup`
+  themselves (interactive) and stop. (`jira-align` is a hard runtime
+  dependency — there is no degraded path without it.)
+- Hand off elicitation, decomposition, and spec authoring to `receive-brief`
+  by name; it is the owner of those stages.
+- Gracefully degrade: when `receive-brief` is not installed, inline a
+  compact decompose-and-execute instruction the agent can act on directly,
+  using the brief shape the skill carries.
+- Tell the adopter to customise `references/field-mapping.md` for their
+  instance's workflow state vocabulary and PI cadence **before first use** —
+  surface this as a one-time setup step, not a blocker.
+
+### Ask first
+
+- Before writing over an existing `docs/product/briefs/<slug>.md` — confirm
+  the slug and whether to merge or replace.
+- Before treating a **single Feature with no children** as a brief — a
+  Feature with no child items is unusually thin; confirm the user's intent
+  and recommend checking for subtasks or related stories before proceeding.
+
+### Never do
+
+- Never write a raw Jira Align REST call, or reimplement any `jira-align`
+  subcommand, inside this skill.
+- Never invoke any Jira Align **write** verb (`create`, `update`, `delete`,
+  `raw` with a mutating method). Intake is **read-only** (`check`, `get`,
+  `list`, `search` only).
+- Never reimplement `receive-brief`'s Elicit stage — do not interrogate the
+  user for missing Outcome/Scope; that is `receive-brief`'s job (and its
+  degraded-path instruction is a *handoff of that job to the agent*, not a
+  reimplementation here).
+- Never invent an Outcome, Scope, or story the Jira Align source does not
+  support — surface the gap and let `receive-brief` elicit it.
+- Never reference a sibling skill, or the brief template, by hardcoded path.
+- Never modify the `core` pack (or any pack other than `atlassian`), and
+  never add a pack dependency or new module — scope is the atlassian pack
+  only, and this skill is pure choreography over skills that already exist.
+- Never become a cross-repo coordination hub: carry the Feature ID as an
+  `Epic:` provenance pointer only; do not reimplement a tracker or
+  coordinate work above this repo's slice (RFC-0064 boundary, same as
+  `jira-brief-intake`).
+- Never claim generic portability or attempt to produce a field mapping that
+  works across all Jira Align instances without adopter configuration —
+  RFC-0064 explicitly designates this Unknowable.
+
+## Testing Strategy
+
+This change ships **prose primitives** (a `SKILL.md`, a `manifest.json`,
+a `references/field-mapping.md`) plus catalogue metadata — there is no new
+executable logic, so no TDD-mode tasks.
+
+- **Skill content + pack metadata: goal-based check.** The skill is
+  well-formed and the pack still builds. Verified by `lint-packs`,
+  `agentbundle validate`, `make build` (regenerates
+  `.claude-plugin/marketplace.json`), and the agentbundle package pytest —
+  the standing gate for a non-projected, user-scope-default pack.
+- **Doc-drift: goal-based check.** Every place that enumerates the atlassian
+  skill set names the new skill. Verified by `grep`.
+- **Skill behavior: manual QA.** The skill is an agent-invoked artifact; its
+  "happy path" is a reading-level dry-run — trace the documented procedure
+  against a representative Jira Align Feature and confirm each step
+  dispatches a real `jira-align` subcommand that exists, produces a brief
+  conforming to the carried shape, and hands off correctly in both the
+  core-present and core-absent paths. Recorded in the plan's Manual
+  verification.
+
+## Acceptance Criteria
+
+- [x] A `jira-align-brief-intake` skill exists at
+  `packs/atlassian/.apm/skills/jira-align-brief-intake/` with a `SKILL.md`
+  whose frontmatter `description` triggers on turning a Jira Align Feature
+  into a product brief, and a `manifest.json` declaring its `jira-align` and
+  `receive-brief` dependencies by name (runtime-by-name contract, `source`
+  as install hint only).
+- [x] The skill's procedure pulls Jira Align data **only** through named
+  `jira-align` subcommands that exist in the `jira-align` skill (`check`,
+  `get`, `list`, `search`), and invokes **none** of the write verbs
+  (`create`, `update`, `delete`, or `raw` with a mutating method) anywhere
+  in the skill directory (`SKILL.md` **and** `references/`) — including in
+  "don't do this" examples.
+- [x] The skill fetches the Feature with
+  `jira-align get features <ID> --expand ownerUser,milestones` and enumerates
+  its children by resource type (`list stories`, `list tasks`, `list defects`)
+  using `--filter "featureID eq <ID>"` for each — never assuming all children
+  are stories, never using a Feature-type–specific workaround that would break
+  for tasks or defects.
+- [x] The skill maps Feature fields onto the brief using the config-guided
+  reference table in `references/field-mapping.md`: Feature title → brief
+  heading; Feature description + notes → Outcome; Feature ID → `Epic:`
+  pointer (full URL); children → Shape B user stories.
+- [x] The Jira Align child → `US-n` mapping has a **pinned, single format**
+  the downstream `Satisfies: US-n` trace can consume: each story line is
+  `- **US-n.** (<resource-type>/<id>) <story text>`, where the resource type
+  and ID are a parenthetical immediately after the id (e.g.
+  `(stories/4521)`) and `<story text>` is the child's title reshaped into
+  the template's *As a … I want … so that …* grammar **when the source
+  supports it**, else the child title carried verbatim for `receive-brief`
+  to refine during Elicit — the skill never invents a role/benefit the child
+  item does not state.
+- [x] The skill probes `jira-align` (`jira-align: check`) as a Prerequisite
+  before any read and defines the exit-2 (unauthenticated) path — tell the
+  user to run `credential-setup` themselves and stop — mirroring
+  `jira-defect-flow`'s and `jira-brief-intake`'s Prerequisites; `jira-align`
+  is a hard dependency with no degraded path.
+- [x] The skill hands off to `receive-brief` **by name** for Elicit /
+  Decompose / Execute, and does **not** reimplement elicitation.
+- [x] **Graceful degradation:** the skill's Prerequisites probe detects
+  `receive-brief`'s absence (by-name dispatch unavailable / not installed),
+  and in that case the `SKILL.md` carries a clearly-labelled core-absent
+  branch holding (a) a compact brief shape and (b) a decompose-and-execute
+  instruction the agent acts on directly — so the flow proceeds rather than
+  stopping — and notes that downstream `new-spec` / `work-loop` may likewise
+  be absent.
+- [x] The skill carries a `references/field-mapping.md` that documents: (a)
+  a standard Jira Align Feature field → brief field mapping table; (b) a
+  clearly-labelled **"Customize for your org"** section on workflow state
+  vocabulary (adopter fills in their instance's state names); (c) a section
+  on PI / Program Increment mapping with common naming patterns; (d) the
+  child → `US-n` provenance format; (e) a note that this mapping must be
+  reviewed and annotated before first use on a new Jira Align instance.
+- [x] Every doc that enumerates the atlassian skill set names the new skill:
+  `packs/atlassian/README.md`, `docs/guides/atlassian/README.md`,
+  `docs/guides/atlassian/reference/atlassian-skills.md` (a section mirroring
+  the skill's frontmatter), `docs/guides/atlassian/explanation/atlassian-pack.md`,
+  and `docs/architecture/overview.md` (the per-pack skill table). Each doc's
+  count and role-grouping prose is kept internally consistent; hardcoded
+  numbers are de-counted per the no-brittle-counts convention where the edit
+  already touches the line.
+- [x] `packs/atlassian/pack.toml` version is bumped (0.3.2 → 0.4.0) and its
+  `description` reflects the new workflow skill; the skill is added to
+  `[pack.evals].skills`; `packs/atlassian/.claude-plugin/plugin.json` is
+  kept in sync (version + description); and `.claude-plugin/marketplace.json`
+  is regenerated by `make build` to match (no build-drift).
+- [x] A `docs/product/changelog.md` `[Unreleased]` entry records the new
+  skill.
+- [x] The pack gate is green: `lint-packs`, `agentbundle validate`,
+  `make build`, and the agentbundle package pytest all pass.
+
+## Assumptions
+
+- Technical: the `jira-align` skill exposes read verbs `check`, `get`,
+  `list`, and `search` against the `features`, `stories`, `tasks`, and
+  `defects` resources, and these suffice to pull a Feature, its children,
+  and ownership/PI context via `--expand` (source: read
+  `packs/atlassian/.apm/skills/jira-align/SKILL.md`, probe 2026-07-21).
+- Technical: Jira Align Feature responses include `state` (workflow state
+  string), `acceptanceCriteria` (free-text ACs), and `points` (story
+  points) as standard REST API 2.0 fields. These are adopted from the
+  Jira Align field model and are expected on most instances; custom
+  instances may omit or rename them. When absent, the skill's missing-
+  field handling (leave placeholder, skip, note) applies per
+  `references/field-mapping.md §What to do when fields are missing`
+  (source: Jira Align REST API 2.0 documentation; adopter-verified per
+  their instance's Swagger UI at `<base_url>/rest/align/api/docs`).
+- Technical: Jira Align's OData `$filter` supports `featureID eq <ID>` for
+  stories, tasks, and defects, making child enumeration uniform across
+  resource types (source: jira-align SKILL.md Step 3 / OData filter table,
+  probe 2026-07-21).
+- Technical: `receive-brief` is robust to a sparse/incomplete brief — its
+  Elicit stage ingests a file and elicits missing Outcome/Scope rather than
+  rejecting (source: read `packs/core/.apm/skills/receive-brief/SKILL.md`,
+  same assumption as `jira-brief-intake`).
+- Technical: a Jira Align Feature's children are the natural source for
+  `receive-brief` Shape B stories, and the brief template's `Epic:` field
+  is defined for exactly this kind of external-tracker provenance pointer
+  (source: read `packs/core/seeds/docs/product/briefs/_template.md`).
+- Process: atlassian is a user-scope-default pack; adding a skill + bumping
+  its version drifts `.claude-plugin/marketplace.json`, so the gate is
+  `lint-packs` + `validate` + `build` + package pytest, not `build-self`/
+  `pre-pr` (source: project memory + `packs/atlassian/pack.toml`).
+- Product: a new composition skill (not a mode bolted onto `jira-align`) is
+  the chosen shape — mirrors `jira-brief-intake`'s precedent for Jira and is
+  the pattern the RFC-0064 M5 AC names explicitly.
+- Product: scope stays in the atlassian pack; `receive-brief` (core) is not
+  modified; 1-way intake only — no write verbs, no delta sync, no PI
+  cadence mutation (source: RFC-0064 M5 AC + Known Unknowns — Unknowable).
+- Product: RFC-0064 intentionally scopes this to Jira Align Feature → brief
+  with configuration-guided field mapping; the integration surface is
+  org-specific (custom workflow state names, PI cadences), and a generic
+  portable sync is impossible — this is the Unknowable boundary the RFC drew
+  (source: RFC-0064 Known Unknowns section, probe 2026-07-21).

--- a/packs/atlassian/.apm/skills/jira-align-brief-intake/SKILL.md
+++ b/packs/atlassian/.apm/skills/jira-align-brief-intake/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: jira-align-brief-intake
+description: Use this skill when the user points at a Jira Align Feature and asks you to turn it into a product brief or shippable specs — "intake Feature 1234", "turn JA feature 789 into specs", "pull this Jira Align feature into a brief". The skill fetches the Feature and its child stories/tasks/defects via the `jira-align` skill, maps them onto a Shape B product brief (Feature title/description → Outcome, children → `US-n` user stories tagged with their Jira Align IDs, Feature ID → `Epic:` provenance pointer), writes it to `docs/product/briefs/<slug>.md`, and hands off to `receive-brief` to elicit gaps, decompose, and build. 1-way intake only — never writes back to Jira Align. Use the field mapping in `references/field-mapping.md` (customize for your org before first use). Do NOT use for defects (use `jira-defect-flow` for Jira defects) or for individual Jira issues (use `jira-brief-intake` for Jira epics).
+metadata:
+  version: "1.0"
+---
+
+# Skill: jira-align-brief-intake
+
+This is choreography, not invention. It composes two things that already exist:
+
+- **`jira-align` skill** (sibling in this pack) — all Jira Align reads.
+  You never write a raw Jira Align REST call here and never invoke a write
+  verb.
+- **`receive-brief` skill** (shipped by the host repo; resolved by name
+  through the harness) — owns Elicit (fill missing Outcome/Scope
+  conversationally), Decompose (cut into shippable slices), and Execute
+  (chain `new-spec` → `work-loop`). This skill does **not** reimplement
+  elicitation; it hands off the assembled brief and steps back.
+
+If you find yourself writing a Jira Align REST call or interrogating the
+user for missing Outcome/Scope fields, stop — the right place is one of
+the two above.
+
+## One-time setup: customise the field mapping
+
+Before first use on a new Jira Align instance, open
+`references/field-mapping.md` and fill in:
+
+1. **Workflow state vocabulary** — your instance's state names in the
+   "Customize for your org" table. Standard names (`Planned`, `In Progress`,
+   `Completed`) are pre-filled; replace or extend them.
+2. **PI naming pattern** — the cadence label format your org uses (e.g.,
+   `PI 2026-Q1`, `PI 24`).
+
+This is a one-time step per instance. The brief this skill produces will be
+wrong in the State context sentence if the state names don't match.
+
+## Cross-skill invocation — name, not path
+
+This skill names sibling skills (`jira-align`) and host skills
+(`receive-brief`) **by their `name:` field, never by path**. Install
+locations vary by IDE and scope. The contract: when this skill says *"via
+the `jira-align` skill: `get features <ID> …`"*, the agent uses its native
+skill-dispatch mechanism to invoke the skill registered under that name
+with those arguments.
+
+Install guidance for the named dependencies lives in `manifest.json` under
+`deps.skills` — that's a *where to get them* hint, not a runtime path.
+
+## Prerequisites
+
+Before Stage 1, confirm:
+
+1. The `jira-align` skill is installed and reachable. Invoke it:
+   `jira-align: check`. Exit 0 → proceed. Exit 2 → tell the user to run
+   `credential-setup` themselves (interactive — they run it, not you) and
+   stop. `jira-align` is a hard dependency; there is no degraded path
+   without it.
+2. The `receive-brief` skill is installed (from `agent-ready-repo` or
+   wherever the consumer keeps it). If not, note the absence — **do not
+   stop**. The core-absent branch in Stage 4 handles this gracefully.
+
+## Lifecycle
+
+### Stage 1 — Intake
+
+Fetch the Feature with all fields needed to populate the brief, via the
+`jira-align` skill:
+
+```
+jira-align: get features <ID> --expand ownerUser,milestones
+```
+
+Check for the **three intake requirements** of a Feature:
+
+| Requirement | Where it lives in Jira Align |
+|---|---|
+| Title (what this feature delivers) | `title` field |
+| Description or scope notes | `description` and/or `notes` fields |
+| Owner / program context | `ownerUser` (expanded), `programID` |
+
+When any requirement is missing or empty, note the gap — don't stop.
+`receive-brief` elicits what's missing in Stage 4.
+
+### Stage 2 — Enumerate children
+
+Fetch the Feature's child items by resource type:
+
+```
+jira-align: list stories --filter "featureID eq <ID>"
+jira-align: list tasks --filter "featureID eq <ID>"
+jira-align: list defects --filter "featureID eq <ID>"
+```
+
+Collect whichever resource types return results. A Feature with no children
+is valid but thin — ask the user before proceeding (see Boundaries: Ask
+first).
+
+For each child item, record:
+- Resource type: `stories`, `tasks`, or `defects`
+- `id`
+- `title` (the story text)
+
+### Stage 3 — Map fields to brief
+
+Using `references/field-mapping.md` as your guide, map the fetched data
+onto the Shape B brief template.
+
+**Heading and provenance:**
+
+```
+# Brief: <Feature title>
+
+- **Slug:** `<kebab-case-slug>` (derive from the Feature title)
+- **Received:** <today's date>
+- **Owner:** <owner from ownerUser, or ask>
+- **Status:** Draft
+- **Epic:** <JIRAALIGN_BASE_URL>/features/<ID>
+```
+
+**Outcome** (load-bearing — do not leave empty):
+
+Combine `description` and `notes` into one paragraph. When both are present,
+lead with the description and append notes as context. When only one is
+present, use it. When neither is present, write `[Outcome not provided —
+receive-brief will elicit]` as a placeholder; do not invent.
+
+Then append a one-line state context sentence using the mapping in
+`references/field-mapping.md`'s state vocabulary table:
+
+```
+*(Current state: <state value> — <Brief handling from your org's mapping>)*
+```
+
+Example: `*(Current state: In Progress — active delivery)*`. When `state`
+is absent from the Feature response, omit the line.
+
+**Scope / In scope:**
+
+When `acceptanceCriteria` is present on the Feature, use it as the In scope
+prose. Otherwise leave the heading with an empty placeholder; `receive-brief`
+elicits it.
+
+**User stories (Shape B):**
+
+Map each child to a `US-n` story line. The format is pinned:
+
+```
+- **US-n.** (stories/<id>) <story text>
+```
+
+Substitute `tasks/` or `defects/` for the resource type. For `<story text>`:
+- Reshape the child's `title` into the *As a … / I want … / so that …*
+  grammar **when the title itself contains a role and benefit** (e.g. "As a
+  PM, track sprint velocity…"). Do not invent a role that isn't in the title.
+- Carry the title verbatim when a role/benefit cannot be inferred — do not
+  invent. `receive-brief` refines during Elicit.
+
+The `US-n` index is sequential across all resource types, ordered by:
+stories first, then tasks, then defects.
+
+**Program Increment context (optional):**
+
+When `milestones` expands to a PI record, add a one-line note in the brief's
+`## Context` section (add the heading if absent):
+
+```
+> **Program Increment:** <PI name from milestones> — carry forward as
+> appetite signal; confirm with `receive-brief`.
+```
+
+### Stage 4 — Write brief and hand off
+
+Write the assembled brief to `docs/product/briefs/<slug>.md`. If the file
+already exists, ask the user whether to merge or replace before writing.
+
+**Core-present path (receive-brief installed):**
+
+Hand off to `receive-brief` by name:
+
+```
+receive-brief: docs/product/briefs/<slug>.md
+```
+
+`receive-brief` elicits missing fields (Outcome gaps, Scope, Success
+metrics, Appetite), runs DoR, decomposes, and chains into `new-spec` →
+`work-loop`. Your role ends at the hand-off.
+
+**Core-absent path (receive-brief not installed):**
+
+When `receive-brief` is unavailable, inline the following instruction and
+act on it directly:
+
+> **Core-absent brief — act on this directly:**
+>
+> The brief at `docs/product/briefs/<slug>.md` is assembled from Jira Align
+> data. Proceed as follows:
+>
+> 1. **Elicit missing fields.** Ask the user to fill in any empty headings
+>    in the brief (Outcome gaps, Success metrics, Scope, Appetite).
+> 2. **Decompose.** For each `US-n` story that warrants its own spec,
+>    open `docs/specs/<feature-slug>/spec.md` and ask the user to confirm
+>    the decomposition before proceeding.
+> 3. **Execute.** For each confirmed spec, invoke `new-spec` by name (if
+>    installed), then `work-loop`. If neither is installed, tell the user
+>    which packs to install and stop.
+
+## Don't
+
+- Don't read `~/.agentbundle/credentials.env` from the skill body.
+- Don't write a raw Jira Align REST call — use the `jira-align` skill.
+- Don't invoke `create`, `update`, `delete`, or `raw` with a mutating
+  method on the `jira-align` skill. Intake is read-only.
+- Don't re-run `credential-setup` for the user or pipe the token into it.
+- Don't reimplement `receive-brief`'s elicitation — hand off and step back.
+- Don't invent Outcome, Scope, or story text the Jira Align source doesn't
+  support. Surface the gap; let `receive-brief` elicit it.
+- Don't reference this skill, `jira-align`, or `receive-brief` by path —
+  always by name.
+- Don't claim portability across all Jira Align instances without asking the
+  adopter to customise `references/field-mapping.md` first.
+
+## Edge cases
+
+- **Feature not found (404):** the `jira-align` CLI exits 3 and prints the
+  server message. Surface it to the user and stop — do not guess or
+  substitute.
+- **Credentials missing / expired (exit 2):** tell the user to re-run
+  `credential-setup` and regenerate their API token on the Jira Align
+  Profile page.
+- **Feature with no children:** confirm with the user before assembling a
+  brief from title + description alone — a Feature with no stories is
+  unusual and may indicate the wrong ID or incomplete Jira Align data.
+- **Custom fields:** Jira Align instances expose org-specific fields in
+  responses. When a field named in `references/field-mapping.md`'s
+  "Customize for your org" section is present in the Feature response, use
+  it. When it is absent, skip it and note the gap in the brief.
+- **Large child sets (> 100):** the `jira-align` CLI paginates transparently
+  up to `--limit`. For features with many children, consider scoping the
+  intake to a representative subset and noting the total count in the brief;
+  confirm with the user.

--- a/packs/atlassian/.apm/skills/jira-align-brief-intake/evals/eval_queries.json
+++ b/packs/atlassian/.apm/skills/jira-align-brief-intake/evals/eval_queries.json
@@ -1,0 +1,20 @@
+[
+  {"query": "Intake Feature 1234 from Jira Align as a product brief", "should_trigger": true},
+  {"query": "Turn this Jira Align feature into shippable specs", "should_trigger": true},
+  {"query": "Pull JA feature 789 into a brief", "should_trigger": true},
+  {"query": "We track delivery in Jira Align — turn Feature 456 into specs", "should_trigger": true},
+  {"query": "Convert this Jira Align Feature and its stories into a product brief", "should_trigger": true},
+  {"query": "Decompose Jira Align Feature 1001 into work items", "should_trigger": true},
+  {"query": "Map this Jira Align Feature onto a brief and hand it off to receive-brief", "should_trigger": true},
+  {"query": "Intake this Jira Align Feature — it has child stories I want as user stories", "should_trigger": true},
+
+  {"query": "Create a Jira Align feature for this initiative", "should_trigger": false},
+  {"query": "Fetch the details of Feature 1234 from Jira Align", "should_trigger": false},
+  {"query": "Fix the Jira defect PROJ-123 end to end", "should_trigger": false},
+  {"query": "Turn this Jira epic PROJ-100 into shippable specs", "should_trigger": false},
+  {"query": "Write a spec for a single new feature", "should_trigger": false},
+  {"query": "What's the cycle time for this program's features?", "should_trigger": false},
+  {"query": "Pull flow metrics for program 42", "should_trigger": false},
+  {"query": "Shape the intent behind this initiative", "should_trigger": false},
+  {"query": "Decompose this 40-page PRD from the client", "should_trigger": false}
+]

--- a/packs/atlassian/.apm/skills/jira-align-brief-intake/manifest.json
+++ b/packs/atlassian/.apm/skills/jira-align-brief-intake/manifest.json
@@ -1,0 +1,38 @@
+{
+  "id": "jira-align-brief-intake",
+  "name": "Jira Align Brief Intake",
+  "version": "1.0.0",
+  "description": "Turn a Jira Align Feature into a product brief and shippable specs: fetch the Feature and its child stories/tasks/defects via the `jira-align` skill, map them onto a Shape B product brief (Feature title/description -> Outcome, children -> `US-n` user stories tagged with their Jira Align IDs, Feature ID -> `Epic:` provenance pointer), write it to `docs/product/briefs/<slug>.md`, and hand off to `receive-brief` to elicit gaps, decompose, and build. 1-way intake only — never writes to Jira Align. Configuration-guided field mapping (customize `references/field-mapping.md` for your org's workflow states and PI cadences before first use). Pure choreography — composes existing skills by name, never by path.",
+  "category": "workflows",
+  "tags": ["jira-align", "brief", "receive-brief", "intake", "feature", "workflow", "orchestration", "read-only", "portfolio"],
+  "license": "MIT",
+  "deps": {
+    "_runtime_contract": "Sibling skills are addressed BY NAME at runtime. The agent's harness resolves the name to whatever install location the user picked. `source` below is install guidance only — never a runtime path.",
+    "skills": [
+      {
+        "name": "jira-align",
+        "source": "this pack — packs/atlassian/.apm/skills/jira-align/",
+        "purpose": "All Jira Align reads: check, get (features), list (stories, tasks, defects with featureID filter). The intake skill never makes a raw Jira Align REST call and never invokes a write verb (no create, update, delete). Hard dependency — there is no degraded path without it."
+      },
+      {
+        "name": "receive-brief",
+        "source": "host repo — core pack — .apm/skills/receive-brief/ (projected to .claude/skills/receive-brief/)",
+        "purpose": "Owns Elicit (fill missing Outcome/Scope conversationally), Decompose (cut into shippable slices), and Execute (chain new-spec -> work-loop). The intake skill hands off the assembled brief and never reimplements elicitation. SOFT dependency: when absent, the skill degrades gracefully, producing the brief and inlining a decompose/execute instruction for the agent to act on."
+      }
+    ],
+    "system": []
+  },
+  "input": {
+    "arguments": "a Jira Align Feature ID (integer or string). A Feature is the mid-level planning unit in Jira Align (below an Epic, above Stories). Not for Portfolio Epics (too large) or individual Stories (use new-spec instead).",
+    "env": {}
+  },
+  "output": {
+    "artifacts": [
+      "docs/product/briefs/<slug>.md — a Shape B product brief: Outcome from the Feature title/description, one `US-n` story per child item tagged with its Jira Align resource ID and type (e.g. `(stories/4521)`), the Feature ID as the `Epic:` provenance pointer. Gaps (Success metrics, Appetite, silent Scope) are left for `receive-brief` to elicit.",
+      "a hand-off to the `receive-brief` skill (normal flow), or an inlined decompose/execute instruction (degraded flow when `receive-brief` is absent)."
+    ]
+  },
+  "targets": {
+    "default": { "file": "SKILL.md" }
+  }
+}

--- a/packs/atlassian/.apm/skills/jira-align-brief-intake/references/field-mapping.md
+++ b/packs/atlassian/.apm/skills/jira-align-brief-intake/references/field-mapping.md
@@ -1,0 +1,103 @@
+# Jira Align → Brief field mapping
+
+> **Before first use on a new Jira Align instance:** fill in the
+> "Customize for your org" sections below. Jira Align workflow state names
+> and Program Increment cadences are org-specific — the defaults here are
+> common but are not guaranteed to match your instance. A wrong state name
+> will produce a misleading brief context sentence.
+
+## Standard Feature fields → Brief fields
+
+| Jira Align field | Brief field | Notes |
+|---|---|---|
+| `title` | Brief heading (`# Brief: <title>`) | Direct |
+| `description` | `## Outcome` (lead paragraph) | |
+| `notes` | `## Outcome` (appended context) | Combine with `description`; lead with `description` |
+| `acceptanceCriteria` | `## Scope / In scope` | Carry verbatim; `receive-brief` refines |
+| `id` | `Epic:` provenance pointer | Full URL: `<JIRAALIGN_BASE_URL>/features/<id>` |
+| `programID` | Context note (not a brief field) | Include in `## Context` if useful |
+| `points` | `## Success metrics` (optional) | Surface as size signal, not a target |
+| `ownerUser` (expanded) | `- **Owner:**` header field | Use `name` from expanded record |
+| `milestones` (expanded) | `## Context` — PI note | See PI section below |
+
+Fields absent or empty in the API response → leave the corresponding brief
+heading empty (do not invent). `receive-brief` elicits missing values during
+Elicit.
+
+## Customize for your org — workflow state vocabulary
+
+Jira Align state names are configured per instance. Replace or extend the
+table below with your instance's actual state names. The `Brief handling`
+column tells the skill what to surface in the Outcome context sentence.
+
+| Jira Align state (your instance) | Standard equivalent | Brief handling |
+|---|---|---|
+| `Planned` | Not started | Mention in Outcome as context: "currently Planned" |
+| `In Progress` | Active delivery | Mention in Outcome as context: "currently In Progress" |
+| `Completed` | Done | Note: verify scope is accurate before intake; mention in Outcome |
+| `Not Started` | Not started | Mention in Outcome as context: "not yet started" |
+| *(add your org's custom states here)* | | |
+
+**How to find your states:** In Jira Align, go to Administration → Workflow
+States (or check with your Jira Align administrator). Each state name must
+match exactly what appears in the `state` field of a Feature API response.
+
+## Customize for your org — Program Increment (PI) cadence
+
+Program Increment names follow your org's naming convention. Common patterns:
+
+| Pattern | Example | When to use |
+|---|---|---|
+| Quarterly (`YYYY-Qn`) | `PI 2026-Q1` | Most common for Scaled Agile orgs |
+| Numbered | `PI 24`, `PI 25` | Sequential numbering since program start |
+| Named | `PI Orion`, `PI Atlas` | Thematic or project-specific naming |
+| Custom | *(your format)* | Fill in your org's convention |
+
+When the Feature's `milestones` expand to a PI record, extract the PI `name`
+field and include it in the brief's `## Context` section as an appetite
+signal. Example:
+
+```
+> **Program Increment:** PI 2026-Q2 — carry forward as appetite signal;
+> confirm with `receive-brief`.
+```
+
+When `milestones` is absent or empty, omit the PI note.
+
+## Child → US-n provenance format
+
+Each child item (story, task, or defect) maps to one Shape B user story
+line. The format is pinned — downstream `Satisfies: US-n` traces depend on
+it:
+
+```
+- **US-n.** (<resource-type>/<id>) <story text>
+```
+
+Where:
+- `<resource-type>` is `stories`, `tasks`, or `defects`
+- `<id>` is the integer ID from the Jira Align response
+- `<story text>` is the child's `title` reshaped into *As a … / I want … /
+  so that …* grammar **only when the title itself states a role**; otherwise
+  the title carried verbatim — do not invent a role from `ownerID` alone
+  (an integer ID yields no name)
+
+Examples:
+```
+- **US-1.** (stories/4521) As a PM, track PI velocity to forecast capacity.
+- **US-2.** (tasks/892) Update onboarding documentation to reflect Q2 process changes.
+- **US-3.** (defects/301) Critical authentication timeout not surfaced to users on session expiry.
+```
+
+Index (`US-n`) is sequential across all resource types, ordered: stories →
+tasks → defects.
+
+## What to do when fields are missing
+
+| Situation | Action |
+|---|---|
+| `description` and `notes` both empty | Write `[Outcome not provided — receive-brief will elicit]`; do not invent |
+| `acceptanceCriteria` absent | Leave `## Scope / In scope` heading with empty placeholder |
+| `milestones` absent or empty | Omit the PI context note |
+| Custom field present in response but not in this table | Include it in `## Context` with the raw field name; note it needs mapping |
+| Custom field mentioned here but absent from API response | Skip it; note the gap in the brief if material |

--- a/packs/atlassian/.claude-plugin/plugin.json
+++ b/packs/atlassian/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "atlassian",
-  "version": "0.3.2",
-  "description": "Atlassian primitives: jira / jira-align / confluence-crawler (credentialed CLI), plus the flow-metrics, ai-adoption-report, jira-defect-flow, and jira-brief-intake workflows that compose them."
+  "version": "0.4.0",
+  "description": "Atlassian primitives: jira / jira-align / confluence-crawler (credentialed CLI), plus the flow-metrics, ai-adoption-report, jira-defect-flow, jira-brief-intake, and jira-align-brief-intake workflows that compose them."
 }

--- a/packs/atlassian/README.md
+++ b/packs/atlassian/README.md
@@ -2,15 +2,16 @@
 
 Atlassian primitives plus the workflows that compose them. Credentialed CLIs —
 `jira`, `jira-align`, and `confluence-crawler`/`-publisher` — and workflow
-skills: `flow-metrics`, `ai-adoption-report`, `jira-defect-flow`, and
-`jira-brief-intake`.
+skills: `flow-metrics`, `ai-adoption-report`, `jira-defect-flow`,
+`jira-brief-intake`, and `jira-align-brief-intake`.
 
 ## What's inside
 
 - Credentialed CLI primitives for Jira, Jira Align, and Confluence.
 - Workflow skills that turn those primitives into flow metrics, an
-  AI-adoption report, a Jira defect-flow analysis, and a Jira-epic →
-  product-brief intake that feeds `receive-brief`.
+  AI-adoption report, a Jira defect-flow analysis, a Jira epic → product-brief
+  intake, and a Jira Align Feature → product-brief intake — all feeding
+  `receive-brief`.
 
 ## Install
 

--- a/packs/atlassian/pack.toml
+++ b/packs/atlassian/pack.toml
@@ -1,7 +1,7 @@
 [pack]
 name = "atlassian"
-version = "0.3.2"
-description = "Atlassian primitives: jira / jira-align / confluence-crawler (credentialed CLI), plus the flow-metrics, ai-adoption-report, jira-defect-flow, and jira-brief-intake workflows that compose them."
+version = "0.4.0"
+description = "Atlassian primitives: jira / jira-align / confluence-crawler (credentialed CLI), plus the flow-metrics, ai-adoption-report, jira-defect-flow, jira-brief-intake, and jira-align-brief-intake workflows that compose them."
 readme = "README.md"
 display_name = "Atlassian"
 license = "Apache-2.0 OR MIT"
@@ -32,7 +32,7 @@ allowed-adapters = ["claude-code", "kiro-ide", "codex", "copilot", "cursor", "ge
 # fires — no Atlassian credentials are needed to measure these (Tier-A only;
 # behavior testing of a backend skill is future-Tier-B-RFC scope, see the spec).
 [pack.evals]
-skills = ["jira", "jira-align", "jira-brief-intake", "jira-defect-flow", "flow-metrics", "confluence-crawler", "confluence-publisher", "ai-adoption-report"]
+skills = ["jira", "jira-align", "jira-brief-intake", "jira-align-brief-intake", "jira-defect-flow", "flow-metrics", "confluence-crawler", "confluence-publisher", "ai-adoption-report"]
 
 # enriched-pack-manifest (RFC-0031 / ADR-0021): catalogue-facing links
 # + maintainer, including the `documentation` link to the per-pack guide home.

--- a/web/src/content/journeys/atlassian.md
+++ b/web/src/content/journeys/atlassian.md
@@ -14,6 +14,9 @@ skills:
   - name: jira-brief-intake
     description: "Converts a Jira epic into a structured engineering brief: problem, user, success criteria, and constraints — the input to a work-loop spec."
     humanTouches: 1
+  - name: jira-align-brief-intake
+    description: "Pulls a Jira Align Feature and its child stories/tasks/defects via the jira-align primitive, maps them to a Shape B product brief using a configuration-guided field mapping reference, and hands off to receive-brief."
+    humanTouches: 1
   - name: jira-defect-flow
     description: "Drives a defect from triage through root-cause analysis to fix, with the Jira issue updated at each stage."
     humanTouches: 2

--- a/web/src/content/packs/atlassian.md
+++ b/web/src/content/packs/atlassian.md
@@ -6,6 +6,7 @@ skills:
   - jira
   - jira-align
   - jira-brief-intake
+  - jira-align-brief-intake
   - jira-defect-flow
   - flow-metrics
   - confluence-crawler

--- a/workspace.toml
+++ b/workspace.toml
@@ -109,6 +109,7 @@ shipped = [
   "spec/m2-identify-opportunities",            # identify-opportunities PE skill + template + example + guide
   "spec/m2-map-capabilities",                  # map-capabilities PE skill + template + examples + how-to guide
   "spec/m2-frame-intent-jtbd",                 # PR #599 — JTBD three-tier elicitation into frame-intent; back-compat assessed in spec
+  "spec/m5-jira-align-brief-intake",           # atlassian pack 0.4.0; jira-align-brief-intake skill; 1-way intake, config-guided field map
 ]
 queue   = [
   # ==================================================================
@@ -145,7 +146,7 @@ queue   = [
   # field mapping). Each ships with its guide slice.
   "spec/m5-github-brief-intake",          # GitHub Issue/Milestone → brief with Epic: pointer
   "spec/m5-linear-brief-intake-and-sync", # first-time intake + delta sync; refuse when brief Executing
-  "spec/m5-jira-align-brief-intake",      # atlassian pack; 1-way intake only, config-guided field map
+  # "spec/m5-jira-align-brief-intake" — shipped; moved to ["ini-002".work].shipped
   "spec/m5-tracker-guides",               # tracker decision tree + vocabulary mapping table
 
   # ---------------- P5 · Adopt (terminal — needs whole journey stable) ----------------


### PR DESCRIPTION
## Summary

- Adds `jira-align-brief-intake` to the atlassian pack (0.4.0): turns a Jira Align Feature into a Shape B product brief and hands off to `receive-brief`
- Configuration-guided field mapping (`references/field-mapping.md`) covers standard Feature fields plus "Customize for your org" sections for org-specific workflow state vocabulary and PI cadences
- 1-way intake only — never writes to Jira Align; mirrors the `jira-brief-intake` choreography pattern for the Jira Align program-level entity

## Motivation

RFC-0064 M5 requires `jira-align-brief-intake` (atlassian pack) as the Jira Align adapter for the P4 intake-edges phase. Enterprise teams that plan at the program level in Jira Align have no path from a Feature to a product brief without this skill.

## What changed

**New files:**
- `docs/specs/m5-jira-align-brief-intake/spec.md` + `plan.md`
- `packs/atlassian/.apm/skills/jira-align-brief-intake/SKILL.md`
- `packs/atlassian/.apm/skills/jira-align-brief-intake/manifest.json`
- `packs/atlassian/.apm/skills/jira-align-brief-intake/references/field-mapping.md`
- `packs/atlassian/.apm/skills/jira-align-brief-intake/evals/eval_queries.json`

**Modified:** `pack.toml` (0.3.2 to 0.4.0), `plugin.json`, `README.md`, atlassian guides, `docs/architecture/overview.md`, `docs/product/changelog.md`, `workspace.toml`

## Test plan

- [x] `lint-packs` — clean (exit 0)
- [x] `make build PACK=atlassian` — clean; `jira-align-brief-intake` in marketplace.json
- [x] `agentbundle` package pytest — exit 0 (three runs confirmed)
- [x] `lint-skill-spec.py` — clean (exit 0)
- [x] Adversarial review — two Concerns fixed (state vocab wired into Stage 3; ownerID role-inference removed); one Nit fixed (unverified fields added to Assumptions)
- [ ] Manual QA trace against a real Jira Align Feature — requires credentialed instance; deferred per Testing Strategy

## Design notes

The key RFC-0064 constraint is the "Unknowable" designation: generic portable sync across Jira Align instances is impossible because workflow state names and PI cadences are org-specific. The config-guided approach is intentional — adopters annotate `references/field-mapping.md` once per instance.

Feature (not Portfolio Epic) is the right source entity: it maps cleanly to a multi-feature brief scope, and its children enumerate via `featureID eq` OData filter that `jira-align` already supports.