### PR TITLE
docs(guides): external skills journey — writing, assimilation, and convergence guide set

### DIFF
--- a/docs/guides/_shared/how-to/README.md
+++ b/docs/guides/_shared/how-to/README.md
@@ -30,3 +30,17 @@ A good how-to:
 ## Maintenance
 
 How-tos drift when the product changes underneath them. Make doc updates part of the spec workflow: when a spec ships, check whether any how-to references the changed behavior, and update in the same PR.
+
+## Pages in this directory
+
+- [`author-a-skill.md`](author-a-skill.md) — frontmatter, body structure, naming, directory layout, dependency tiers, and eval authoring for skills in any pack.
+- [`build-an-org-stack-pack.md`](build-an-org-stack-pack.md) — scaffold and populate a pack for an org's own tools and conventions.
+- [`configure-adapter.md`](configure-adapter.md) — set up or change the active adapter for a pack.
+- [`design-a-profile.md`](design-a-profile.md) — four design tests for a profile, worked examples from the three shipped profiles, and how to propose a new one via RFC.
+- [`install-a-profile.md`](install-a-profile.md) — install a named profile in one command.
+- [`install-agentbundle-from-clone.md`](install-agentbundle-from-clone.md) — install from a local clone instead of the registry.
+- [`install-user-scope-pack-into-codex.md`](install-user-scope-pack-into-codex.md) — user-scope pack install on the Codex adapter.
+- [`install-user-scope-pack-into-kiro.md`](install-user-scope-pack-into-kiro.md) — user-scope pack install on the Kiro adapter.
+- [`preview-install-or-upgrade.md`](preview-install-or-upgrade.md) — dry-run an install or upgrade before committing.
+- [`run-a-full-inception.md`](run-a-full-inception.md) — run the inception sequence on a new repo.
+- [`upgrade-packs.md`](upgrade-packs.md) — upgrade one or all installed packs to the latest version.

--- a/docs/guides/_shared/how-to/design-a-profile.md
+++ b/docs/guides/_shared/how-to/design-a-profile.md
@@ -1,0 +1,122 @@
+# How to design a profile
+
+A profile is a curated, single-scope set of packs that installs in one command:
+
+```bash
+agentbundle install --profile solution-architect <catalogue>
+```
+
+This guide covers how to decide what belongs in a profile, the design tests every profile must pass, worked examples from the three shipped profiles, and how to propose a new one.
+
+## What a profile is (and is not)
+
+A profile is a `profiles/<name>.toml` manifest.
+It declares a scope (user or repo) and a list of packs, in dependency order.
+That is all it is.
+
+It is **not a meta-pack.**
+A meta-pack would be a pack whose only content is a dependency list — a profile already does this job without the overhead of a pack.
+If you are tempted to create a pack whose only purpose is to depend on other packs, you want a profile.
+
+It is **not a comprehensive install set.**
+A profile that installs ten packs for ten different use cases is a catalogue install, not a profile.
+Profiles are for cohesive archetypes, not comprehensive coverage.
+
+## The four design tests
+
+Before proposing a new profile, check it against four tests.
+All four must pass.
+
+**Test 1: Scope homogeneous.**
+Every pack in the profile must allow the profile's declared scope.
+A user-scope profile cannot include a repo-scope-only pack.
+A repo-scope profile can include packs that allow both scopes, but it signals to the installer that a committed repo is required.
+The lint tool enforces this — a scope mismatch blocks the PR.
+
+**Test 2: Dependency-complete.**
+If pack B depends on pack A, pack A must appear before pack B in the manifest.
+The lint tool resolves the dependency graph and rejects incomplete declarations.
+A missing dependency causes installation to fail or silently skip a pack.
+
+**Test 3: Habit, not toolbox.**
+The packs form a habit — a set the target persona reaches for together, repeatedly, because their work naturally involves all of them at once.
+A profile whose packs a persona might someday need is a toolbox.
+Toolboxes install things people don't use; habits install exactly what's needed.
+A useful pressure test: could the persona work without any one of these packs for a full week?
+If yes, that pack may not belong.
+
+**Test 4: Fits a real adopter archetype.**
+There is a named persona who would install this profile on day one and use all of it regularly.
+Name them.
+If the persona description is vague ("anyone who does technical work"), the profile is too broad.
+The archetype must be specific enough to make a scope decision obvious.
+
+## Worked examples
+
+### `solution-architect` (user scope)
+
+Packs: `architect`, `desk-research`, `contracts`.
+
+A solution architect designs systems, researches domains, and works with API contracts.
+All three packs are user-scope — the architect carries their kit across repos and often works before a repo exists.
+Each pack is used on every engagement: `architect` for design artifacts and reference architectures, `desk-research` for market and technical research, `contracts` for API-driven integration work.
+The three packs are never used independently — a solution architect who has one wants all three.
+Scope choice is obvious from the persona: user, because the work is cross-repo.
+
+### `full-ceremony` (repo scope)
+
+Packs: `core`, `governance-extras`, `user-guide-diataxis`, `monorepo-extras`.
+
+A team that wants the full coordination and governance discipline in one install.
+All four packs are repo-scope — they write to the repo (spec files, ADRs, RFCs, guide structure, workspace state).
+The persona is a team lead or platform engineer setting up a new repo for a team that will run the full coordination system.
+`monorepo-extras` depends on `core`; it appears after `core` in the manifest (Test 2).
+Scope is obvious: repo, because all four packs require a committed repo to be useful.
+
+### `inception` (user scope)
+
+Packs: `desk-research`, `product-engineering`, `architect`.
+
+A discovery-phase practitioner who needs research, situation framing, and architecture tools before a repo exists.
+User scope — the work happens in the shaping room, not in a committed repo.
+The three packs form the shaping room toolkit: research → situation framing → architectural concept.
+The persona installs this once and carries it across engagements.
+
+## Profiles are first-party today
+
+All profiles in this catalogue are authored and maintained by the catalogue team.
+They ship through the RFC process: the RFC states the persona, the packs (with justification for each), the scope, and how the profile clears all four design tests.
+The RFC review is the gate.
+
+Adopter-authored profiles — where an org creates a local `profiles/<name>.toml` that is not part of the upstream catalogue — are not yet supported by the install tooling.
+If you want a new profile in the catalogue, open an RFC.
+
+## Running the lint
+
+`python3 tools/lint-profiles.py` enforces three structural invariants before a profile can ship:
+
+- **Scope-homogeneous:** every pack allows the profile's declared scope.
+- **Dependency-complete:** all pack dependencies appear in the manifest.
+- **Deps-first ordered:** dependencies appear before the packs that depend on them.
+
+Run it before opening a PR against any profile manifest.
+The lint is fast and the output names exactly which invariant failed and which pack caused it.
+
+## When a profile is the wrong answer
+
+**Mixed scopes required.**
+A profile that would need both user-scope and repo-scope packs cannot exist as a single manifest.
+Design two profiles (one per scope), or reconsider whether the packs actually belong together.
+
+**One-time install set.**
+A profile for "install everything we might need for this migration" is not a habit.
+Document the individual `agentbundle install` commands instead and note the context in a how-to.
+
+**Transitive-dependency-only pack.**
+If the only reason to list a pack in the profile is because another listed pack depends on it, the dependency is already declared in that pack's own manifest.
+The profile only needs to list the top-level packs the persona explicitly wants — not every transitive dependency.
+(The lint will catch if you miss a transitive dep, so err on the side of omitting it and let the lint tell you if it's needed.)
+
+## See also
+
+[Install a profile](./install-a-profile.md) — the user-facing install flow.

--- a/docs/guides/_shared/reference/README.md
+++ b/docs/guides/_shared/reference/README.md
@@ -5,6 +5,7 @@
 ## Pages
 
 - [`agentbundle.md`](agentbundle.md) — install the CLI, install a pack, configure the default adapter.
+- [`agentskills-io-standard.md`](agentskills-io-standard.md) — the agentskills.io specification applied: frontmatter keys, description rules, directory layout, independent installation, and OWASP AST01–AST10 mapping.
 - [`adapter-support.md`](adapter-support.md) — the per-tool support matrix: which primitives each agent tool receives (skill / subagent / command / hook) and the runtime caveats, sourced from the adapter contract.
 - [`product-brief-fields.md`](../../core/reference/product-brief-fields.md) — the product-brief field list and the linkage fields it stamps on derived specs.
 - [`research-pack.md`](../../research/reference/research-pack.md) — every primitive in the `research` pack (skills, retrieval subagents).

--- a/docs/guides/_shared/reference/agentskills-io-standard.md
+++ b/docs/guides/_shared/reference/agentskills-io-standard.md
@@ -1,0 +1,153 @@
+# agentskills.io specification — applied reference
+
+The [agentskills.io](https://agentskills.io) specification is the external standard every skill in this catalogue follows.
+This page is the applied reference: what the spec requires, how this catalogue adds to it, and how the enforcement tools verify it.
+The authoritative specification lives at agentskills.io; this page covers the catalogue-local application.
+
+For how to author a skill from scratch, see [How to author a skill](../how-to/author-a-skill.md).
+
+## Frontmatter keys
+
+Six top-level keys are allowed; all others are rejected by the linter.
+
+| Key | Required | Purpose |
+|---|---|---|
+| `name` | yes | Kebab-case identifier. Must be unique within the catalogue. |
+| `description` | yes | One-line trigger sentence. The activation signal the agent reads. |
+| `license` | yes | SPDX identifier (`MIT`, `Apache-2.0`, etc.). |
+| `compatibility` | yes | Agent platforms this skill is validated on. |
+| `metadata` | no | Project-specific fields — the escape hatch. |
+| `allowed-tools` | no | The tools the skill instructs the agent to invoke. Omit if none. |
+
+Everything project-specific that doesn't belong at the top level goes under `metadata:`.
+
+## The `metadata:` escape hatch
+
+The `metadata:` key is the catalogue's extension point within the spec.
+Project-specific fields that don't belong at the top level live here:
+
+```yaml
+metadata:
+  type: skill           # skill | hook | command
+  boundaries:
+    - filesystem_write
+    - network_fetch
+```
+
+The linter enforces that `metadata:` is a YAML mapping (not a scalar or list).
+Its sub-keys are not validated by the spec — they are the catalogue's own domain and must be self-consistent across the pack.
+
+## Description rules
+
+The `description:` field drives activation — it is the single field the agent reads when deciding whether to invoke the skill.
+Getting it wrong means the skill either fires on the wrong prompts or fails to fire on the right ones.
+
+Four rules the linter enforces:
+
+1. **Single-line scalar.** No YAML folded (`>`) or literal (`|`) blocks.
+   No continuation lines (an indented next line).
+   These parse as valid YAML but break on some adapter targets.
+2. **No structural YAML characters unquoted.** A bare `: ` mid-description, a leading `#`, `&`, `*`, or `[`, or whitespace-then-`#` change the parse.
+   Wrap the whole value in double quotes if you need any of these characters.
+3. **Trigger-phrased.** Start with "Use when…" or name the trigger condition explicitly.
+   Describe when to activate, not what the implementation does.
+4. **Under 1024 characters.** Some adapter targets truncate beyond this.
+
+Run `python3 tools/lint-skill-spec.py` — it checks all four rules and is the authoritative source.
+Do not memorise the rules from this page; run the linter.
+
+## Directory layout
+
+A skill is a directory with `SKILL.md` and four optional subdirectories.
+The linter only blesses these four:
+
+| Subdirectory | Contents |
+|---|---|
+| `scripts/` | Helper code the skill invokes — `python scripts/foo.py`. One level deep only. |
+| `references/` | Detail the skill loads on demand when the workflow reaches it. Not pre-loaded. |
+| `assets/` | Templates and fixtures the skill copies or fills in at runtime. |
+| `evals/` | Activation and output-quality evals. Canonical nesting: `evals/eval_queries.json` (Tier-A), `evals/evals.json` + `evals/files/` (Tier-B). |
+
+### How `references/` works — context on demand
+
+Context that a skill needs but does not use on every invocation belongs in `references/`, not in the skill body.
+The skill body loads a reference file at the moment the workflow reaches the branch that needs it — "load `references/strategy-X.md` now" — and routes to exactly one branch per run.
+
+This has two effects: the skill body stays lean at the point of activation, and the agent carries only the context relevant to the current invocation rather than all possible branches.
+A skill body that exceeds 500 lines is a signal that detail is embedded that should be in `references/`.
+A skill that pre-loads all its reference files unconditionally, or embeds large knowledge blocks inline in the body, violates this pattern.
+
+### Path discipline
+
+All paths within a skill (scripts, references, assets) are relative to the skill's own directory.
+A skill must not reference:
+
+- Absolute filesystem paths
+- Paths outside the pack's source tree (`packs/<pack>/.apm/skills/<name>/`)
+- Paths that are only valid in a particular repo checkout or deployment
+- Hardcoded org-specific locations or knowledge stores
+
+Context the skill needs from the workspace (the CHARTER, the active adapter, the pack inventory) is read by the skill's own procedures at runtime from the workspace's standard structure — not embedded as a hardcoded path.
+This is what makes a skill portable: any team can install it and have it behave consistently, without configuring input locations.
+
+## Independent installation
+
+Skills are self-contained by design.
+A skill that requires a tool, package, or sibling skill declares its dependencies explicitly, detects their presence at the start of its workflow, and fails with a clear remediation message if they are absent.
+No installation happens silently.
+
+Three tiers govern how dependencies are handled:
+
+**Tier 1 — Declare, detect, fail clean (the default for all dependencies).**
+Name the dependency in `## Prerequisites`.
+Detect it with `shutil.which()` for binaries or a library import probe for packages.
+On absence: stop and emit the exact install command from Prerequisites — nothing more.
+This is the correct tier for almost all skill dependencies.
+The user's environment is not the skill's to modify without explicit consent.
+
+**Tier 2 — Opt-in, gated, idempotent (allowed, not the default).**
+A skill may install a dependency only when: the install is a single deterministic command, it needs no root, and it uses a package manager the user demonstrably already has.
+The pattern is always: detect → ask for consent → install → re-verify.
+Silent install and assumed PATH after install are both disallowed even in Tier 2.
+
+**Tier 3 — Banned.**
+Silent auto-install.
+Assumed root or sudo.
+Pipe-to-shell installers without explicit consent.
+Trusting PATH without re-verifying after install.
+None of these are acceptable regardless of convenience.
+
+The three tiers are what make independent installation safe: any team member can install any profile and have every skill work — or fail clean with a precise remediation — without coordinating a shared environment or configuring shared file locations.
+
+## OWASP Agentic Skills Top 10 v1.0 — mapping to the agentskills.io surface
+
+The OWASP Agentic Skills Top 10 v1.0 (AST01–AST10) is a public security standard for skill-file authoring, distribution, and installation.
+The checks map directly onto the agentskills.io surface:
+
+| Check | Surface | What to verify |
+|---|---|---|
+| AST01 Malicious content | Skill body and agent definitions | No instructions that benefit the author at the expense of the user's agent |
+| AST03 Over-privileged tools | `allowed-tools` | Every listed tool is necessary; high-impact tools scoped to the narrowest action set |
+| AST04 Insecure metadata | Frontmatter fields | Validated against schema; no zero-width Unicode or base64 payloads in display fields |
+| AST05 External references | Body instructions that fetch URLs | References pinned; fetched content treated as data, not instructions |
+| AST06 Isolation | Body instructions for code execution | Containment mechanism declared, not implied |
+| AST07 Version drift | Dependencies in manifests | All pinned; no open ranges or `latest` |
+| AST09 Governance | Installation and execution record | Skill appears in an auditable inventory with name, version, content hash, and source |
+| AST10 Cross-platform | Security metadata | Risk tier and permission manifest survive projection across all adapter targets |
+
+AST02 (supply chain) is handled by the supply-chain security module.
+AST08 is addressed structurally by the `tool`/`hybrid`/`reason` review taxonomy built into the adversarial review process.
+
+Every skill converged into this catalogue is reviewed against AST01–AST10 before landing.
+Every skill authored here is reviewed against the same checks in the adversarial review step of the work-loop.
+
+## Enforcement tools
+
+| Tool | When to run | What it checks |
+|---|---|---|
+| `python3 tools/lint-skill-spec.py` | Before every PR | Top-level key whitelist, description syntax, `allowed-tools` shape, `evals/` structure — on source under `packs/` |
+| `python3 tools/lint-agent-artifacts.py` | After `make build-self` | Spec-compliant shape preserved across all adapter projections |
+| `security-checklists` skill, agentic-skills module | During adversarial review and skill assimilation | Full AST01–AST10 check reference |
+
+The linters are the mechanical authority.
+Where this page conflicts with the linters or the specification at agentskills.io, the linters and the upstream spec are correct.

--- a/docs/guides/catalogue-curation/README.md
+++ b/docs/guides/catalogue-curation/README.md
@@ -1,26 +1,72 @@
 # `catalogue-curation` — guides
 
 The operator's toolkit for **growing and maintaining** an agent-skill catalogue:
-stand up a new pack, bring good work in from outside (shaped to our craft),
-survey a whole repo, and export a redistributable copy for another org or
-domain. Domain-agnostic — the same toolkit serves a non-SDLC catalogue.
+write new skills to standard, bring good work in from outside (shaped to our craft),
+survey a whole repo, and export a redistributable copy for another org or domain.
+Domain-agnostic — the same toolkit serves a non-SDLC catalogue.
 
-New here? Start with the [tutorial](tutorials/first-assimilation.md) — your first
-end-to-end assimilation of one external skill — then reach for the how-tos as the
-jobs come up.
+---
 
-## Tutorials
-- [Your first assimilation](tutorials/first-assimilation.md) — bring one external skill in, safely and to convention.
+## Step 1 — Standards (read this first)
 
-## How-to
-- [Survey a repo for what to adopt](how-to/survey-a-repo.md) — inventory a whole source into a reviewable RFC, resumably.
-- [Export a white-label or domain fork](how-to/export-a-fork.md) — produce a redistributable derivative, fail-closed.
+[**Skill standards**](explanation/skill-standards.md) — one page. The three standards every skill is measured against, whether you write it or bring it in. Gives you the reading order for what follows.
 
-## Reference
-- [The ledger and the engine guard](reference/ledger-and-guard.md) — where assimilation state lives, and what the guard blocks.
+---
 
-## Explanation
-- [Why curation is its own pack](explanation/why-catalogue-curation.md) — the single-authoritative-source model and the fail-closed posture.
+## Step 2 — Choose your path
+
+### Main journey: writing a new skill
+
+Building a skill from scratch — frontmatter to PR.
+
+1. [Skill standards](explanation/skill-standards.md) — what you'll be measured against *(Step 1 above)*
+2. [Your first skill](tutorials/your-first-skill.md) — the end-to-end tutorial: workspace design, standards inline at each step, definition of done
+3. [How to author a skill](../_shared/how-to/author-a-skill.md) — the deep reference once you've done the tutorial
+
+### Side journey: assimilating an existing skill or repo
+
+Bringing external work into the catalogue — safely, and shaped to convention.
+
+1. [Skill standards](explanation/skill-standards.md) — know what you're measuring incoming material against *(Step 1 above)*
+2. Choose the entry point for your material:
+   - [Your first assimilation](tutorials/first-assimilation.md) — one skill from a URL
+   - [Your first subagent](tutorials/your-first-subagent.md) — one subagent definition; where the OWASP AST review shifts focus
+   - [Survey a repo](how-to/survey-a-repo.md) — a whole source at once, resumably
+3. [The convergence model](explanation/the-convergence-model.md) — why assimilation shapes rather than pastes; the three convergence layers in full
+
+---
+
+## Step 3 — Go deeper (when you're ready)
+
+- [The convergence model](explanation/the-convergence-model.md) — three layers, two primitive types, the no-merge-back principle, and the pack arc
+- [Catalogue operator journey](explanation/catalogue-operator-journey.md) — how org-stack engineers, catalogue maintainers, and catalogue authors use the pack at their altitude
+- [Why curation is its own pack](explanation/why-catalogue-curation.md) — the single-authoritative-source model and the fail-closed posture
+
+---
+
+## Full reference
+
+### Tutorials
+
+- [Your first skill](tutorials/your-first-skill.md) — write a new skill from scratch; workspace design, standards inline, definition of done
+- [Your first assimilation](tutorials/first-assimilation.md) — bring one external skill in, safely and to convention
+- [Your first subagent](tutorials/your-first-subagent.md) — bring in an external subagent definition; where the OWASP AST review shifts focus
+
+### How-to
+
+- [Survey a repo for what to adopt](how-to/survey-a-repo.md) — inventory a whole source into a reviewable RFC, resumably
+- [Export a white-label or domain fork](how-to/export-a-fork.md) — produce a redistributable derivative, fail-closed
+
+### Reference
+
+- [The ledger and the engine guard](reference/ledger-and-guard.md) — where assimilation state lives, and what the guard blocks
+
+### Explanation
+
+- [Skill standards](explanation/skill-standards.md) — the three standards, the definition of done for both paths, and the reading order
+- [The convergence model](explanation/the-convergence-model.md) — the three convergence layers (agentskills.io, catalogue craft, OWASP AST), two primitive types, and the no-merge-back principle
+- [Catalogue operator journey](explanation/catalogue-operator-journey.md) — how org-stack engineers, catalogue maintainers, and catalogue authors use the pack at their altitude
+- [Why curation is its own pack](explanation/why-catalogue-curation.md) — the single-authoritative-source model and the fail-closed posture
 
 ---
 

--- a/docs/guides/catalogue-curation/explanation/catalogue-operator-journey.md
+++ b/docs/guides/catalogue-curation/explanation/catalogue-operator-journey.md
@@ -1,0 +1,144 @@
+# Catalogue operator journey
+
+How the three operator sub-personas — org-stack engineer, catalogue maintainer, and catalogue author — use the curation pack at their operating altitude.
+
+## First install and orientation
+
+If you have not yet installed the pack, run `agentbundle install catalogue-curation --scope repo`.
+The pack requires core and governance-extras at repo scope.
+After install, run `agentbundle show catalogue-curation` to confirm all four skills are present with their activation phrases.
+
+The pack is off every default profile by design: it is for people who build catalogues, not for people who use them.
+If you are installing skills from a catalogue, you do not need this pack.
+
+This guide picks up after first install.
+It explains how each sub-persona fits into the system, what their primary touchpoints are, and where to go next.
+
+Before diving into the personas, read [Skill standards](skill-standards.md) — it names the three standards every skill is measured against and gives the reading order for the full guide set.
+Both paths covered here (writing a new skill, assimilating an existing one) are governed by those same standards.
+
+---
+
+## Org-stack engineer
+
+An org-stack engineer maintains an org's own pack — a fork of `core`, an org-specific skill set, or a domain pack for the team's tools.
+They have found one external skill or subagent they want in their kit: a utility, a review agent, a domain-specific search skill.
+
+### Single-primitive intake
+
+The org-stack engineer's path skips the survey and RFC.
+They run `assimilate-primitive` directly, pointing at the source URL or local path.
+The skill shows the raw body verbatim before anything is written — this is the security review gate.
+The OWASP Agentic Skills Top 10 v1.0 (AST01–AST10) review runs on the candidate.
+The skill reshapes the candidate to agentskills.io standard and catalogue craft, then writes it through the path-jail to the destination pack.
+
+The skill reads workspace context (the CHARTER, the pack directory layout) automatically from the repo's own structure.
+The engineer does not configure input file paths; the skill discovers what it needs.
+
+No ledger is opened on a direct assimilation — the assimilation is its own record.
+The engineer reviews the diff before the PR is merged; the PR is the governance artifact for a single-primitive adoption.
+
+After landing, run `python tools/run-pack-evals.py --pack <name>` to verify the new skill activates on the right prompts and stays quiet on near-misses.
+
+**Primary touchpoints:** `assimilate-primitive`.
+
+**Where to go next:** [Your first assimilation](../tutorials/first-assimilation.md) walks the full single-primitive skill flow end to end.
+For subagent-specific concerns, see [Your first subagent](../tutorials/your-first-subagent.md).
+
+---
+
+## Catalogue maintainer
+
+A catalogue maintainer manages a full derived catalogue — a fork, a domain-specific adaptation, or an org-wide catalogue that multiple teams install from.
+Their work is a recurring loop: survey external sources, evaluate candidates, propose packs, assimilate approved primitives, and publish updates.
+
+### Pack arc: the four-stage progression
+
+The four skills form a natural arc:
+
+| Stage | Skill | Output |
+|---|---|---|
+| Discover | `assimilate-repo` | Ledger of candidates with verdicts |
+| Scaffold | `propose-catalogue-pack` | Pack shell + RFC draft |
+| Fill | `assimilate-primitive` × N | Shaped skills and subagents in the pack |
+| Publish | `export-catalogue` | Redistributable fork or profile update |
+
+Each stage's output is the input to the next.
+The survey's ledger determines what gets proposed.
+The proposed pack's shell determines where primitives land.
+The filled pack is what gets exported or profiled.
+
+A single-primitive intake enters at Fill, skipping Discover and Scaffold entirely.
+A maintenance update skips Scaffold (the pack already exists) and re-fills from a re-run survey.
+The arc describes the full flow; each operator enters at the stage their situation requires.
+
+### Survey and evaluate
+
+The survey phase uses `assimilate-repo` to inventory a source into a resumable ledger.
+The ledger lives at a deterministic path derived from the run-id, so an interrupted survey can be resumed without re-fetching.
+Each candidate gets a verdict: `assimilate`, `reject`, or `needs-new-pack`.
+
+For `needs-new-pack` candidates, `propose-catalogue-pack` tests the proposed pack against the catalogue's charter before scaffolding anything.
+The charter test is the gate — if the proposed pack doesn't clear all four principles, scaffolding does not happen and the reason is named.
+
+### Assimilate and shape
+
+Each approved primitive goes through `assimilate-primitive`.
+Context for the assimilation is read from the workspace's own structure — the CHARTER, the pack directory layout — not from user-supplied file paths.
+This means the skill's behavior is consistent across any workspace that has the catalogue installed and does not depend on operator-configured knowledge locations.
+
+The security review at this step runs the full OWASP AST01–AST10 check against the candidate.
+The operator is the last human gate before the skill lands: the raw body is always shown verbatim, and any code (hooks, scripts) requires explicit confirmation.
+
+### Workspace queue integration
+
+Survey and evaluation work lives in `[shaping_queue]` — it is shaping work, not build work.
+Once an RFC is accepted and a pack shell exists, individual primitive assimilations move to `[work].queue` as build tasks: one spec per primitive.
+Running `workspace-status` at session start surfaces the current assimilation queue without reading any other file.
+Between sessions, a new agent or a colleague can pick up exactly where the previous session left off.
+
+### Profile and publish
+
+A catalogue that has grown through assimilation can be published two ways.
+
+The first is a **profile update**: the maintained catalogue proposes a new profile (via RFC) so the adopted set installs in one command.
+A profile is a curated, single-scope manifest — see [Design a profile](../../_shared/how-to/design-a-profile.md) for the four design tests and worked examples.
+
+The second is an **export**: `export-catalogue` produces a redistributable fork in white-label mode (all upstream identity stripped) or attributed mode (upstream credit preserved in the declared attribution surface).
+The export's verify step is fail-closed — any surviving identity anchor stops the export.
+
+**Primary touchpoints:** `assimilate-repo`, `propose-catalogue-pack`, `assimilate-primitive`, `export-catalogue`.
+
+**Where to go next:**
+[Survey a repo](../how-to/survey-a-repo.md) ·
+[Export a fork](../how-to/export-a-fork.md) ·
+[The convergence model](the-convergence-model.md) ·
+[Design a profile](../../_shared/how-to/design-a-profile.md)
+
+---
+
+## Catalogue author
+
+A catalogue author contributes back upstream — either to the parent catalogue their fork derived from, or to an open catalogue they participate in.
+
+### Contributing upstream
+
+The author's path is the inverse of assimilation.
+They have shaped a skill to their catalogue's craft and want to upstream it.
+The path is a PR against the upstream repo: take the shaped skill from `packs/<pack>/.apm/skills/<name>/`, open a PR against the upstream, and let the upstream's own assimilation review run.
+
+The upstream will run its own OWASP AST review and activation evals — it treats the contribution as a fresh primitive.
+The author can pre-clear these by running `python tools/lint-skill-spec.py` and `python tools/run-pack-evals.py --pack <name>` locally before opening the PR.
+
+There is no `export-to-upstream` skill — the upstream PR is intentionally a manual, human-reviewed act.
+The no-merge-back principle means the upstream reviews the contribution as new work, not as a trusted sync.
+This is the correct posture: bidirectional sync between a catalogue and its derivatives is where divergence accumulates and identity-leak accidents happen.
+
+**Primary touchpoints:** The upstream repo's own assimilation review; `lint-skill-spec.py` and `run-pack-evals.py` for pre-clearance.
+
+**Where to go next:** [The convergence model](the-convergence-model.md) — the no-merge-back principle explained.
+
+---
+
+**Source journey maps:**
+[catalogue-engineer-converges-skills](../../../product/journeys/catalogue-engineer-converges-skills.md)

--- a/docs/guides/catalogue-curation/explanation/skill-standards.md
+++ b/docs/guides/catalogue-curation/explanation/skill-standards.md
@@ -1,0 +1,112 @@
+# Skill standards
+
+Every skill in this catalogue — whether you write it from scratch or bring it in from outside — is measured against the same three standards.
+The only difference between writing and assimilating is *when* the measurement happens: when writing, you build to the standard from the start; when assimilating, you review incoming material against the standard before it lands.
+
+Read this page before starting either path.
+
+## Reading order
+
+1. **This page first.** Names the three standards and what each is checking.
+2. **Choose your path:**
+   - Writing a new skill → [Your first skill](../tutorials/your-first-skill.md)
+   - Assimilating a skill from outside → [Your first assimilation](../tutorials/first-assimilation.md)
+   - Assimilating a subagent from outside → [Your first subagent](../tutorials/your-first-subagent.md)
+3. **After the tutorial, reach for the deep references:**
+   - [agentskills.io specification — applied reference](../../_shared/reference/agentskills-io-standard.md) — complete frontmatter, directory layout, enforcement details
+   - [The convergence model](the-convergence-model.md) — the three convergence layers in full, and the no-merge-back principle
+
+---
+
+## Standard 1: agentskills.io structural
+
+The [agentskills.io](https://agentskills.io) specification defines the file format every skill must follow.
+
+Six allowed top-level frontmatter keys (`name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools`).
+Four allowed subdirectory names (`scripts/`, `references/`, `assets/`, `evals/`).
+A `description:` that is a single-line scalar, trigger-phrased ("Use when…"), under 1024 characters.
+
+**Why it matters:** skills project across three adapter targets (Claude Code, Kiro, Codex).
+Anything outside the spec breaks on at least one of them silently.
+The linters (`lint-skill-spec.py`, `lint-agent-artifacts.py`) enforce this before a skill can project.
+
+**Critical field — `allowed-tools`:** declare only the tools the skill actually instructs the agent to invoke.
+Over-declaring here to "avoid breaking things" expands the blast radius of any prompt injection that reaches this skill.
+Every tool listed must be justified by the skill's stated purpose.
+(This is OWASP AST03 — see Standard 3.)
+
+**What the linter checks:** top-level key whitelist, description syntax, `allowed-tools` shape, `evals/` structure.
+Run `python3 tools/lint-skill-spec.py` — it is the authority, not this page.
+
+---
+
+## Standard 2: Catalogue craft
+
+The agentskills.io spec ensures the file is structurally valid.
+Catalogue craft ensures the skill is actually useful.
+
+Three rules govern craft:
+
+**Activation accuracy.**
+The `description:` field is the activation signal — the agent reads it to decide whether the skill applies.
+A description that fires on the wrong prompts, or misses the right ones, is a broken skill regardless of how well the body is written.
+Write trigger-phrased descriptions and verify them with activation evals.
+
+**Progressive disclosure.**
+Detail that is only needed in specific branches of the workflow goes in `references/` files — loaded by the skill body at the moment the workflow reaches that branch.
+The body routes to references; it does not replicate them inline.
+A body that embeds large context blocks, or grows past 500 lines, is carrying detail that should be in `references/`.
+Context the skill needs from the workspace is discovered at runtime from the workspace's own structure — not hardcoded as a path in the body.
+
+**Anti-pattern avoidance.**
+The catalogue's anti-pattern list is earned knowledge about what fails in production.
+Checked at assimilation time (the convergence model's Layer 2 captures them); checked at authoring time through the adversarial review.
+Common ones: a skill that calls another skill from within a script; a subagent that reviews its own output; a skill that treats fetched URL content as instructions.
+
+---
+
+## Standard 3: OWASP Agentic Skills Top 10 v1.0 security
+
+The OWASP Agentic Skills Top 10 v1.0 (AST01–AST10) is the public security standard for skill-file authoring and distribution.
+
+A skill is instruction prose that runs in users' agents.
+That makes it a trust surface that deserves systematic review — the same way you review a dependency before pulling it into production code.
+
+**Which checks are most critical depends on your path:**
+
+When **writing a new skill**, the primary checks are:
+
+- **AST03 — Over-privileged tools.** Every tool in `allowed-tools` must be necessary. Scoped as narrowly as the skill's purpose allows.
+- **AST06 — Isolation declaration.** If the skill instructs code execution, the containment boundary must be declared. "The agent will have access" without naming the scope is the miss.
+- **AST09 — Governance gap.** The skill must be inventoried — registered in an auditable record. Landing in a pack, with an activation eval, and appearing in `agentbundle show <pack>` is this record.
+
+When **assimilating an external skill or subagent**, the additional primary check is:
+
+- **AST01 — Malicious content.** The incoming body is untrusted prose. Read it for instructions that benefit the author at the expense of the user's agent: identity-overwrite instructions, credential-access requests dressed as prerequisites, conditional misdirection. For subagents — which have no frontmatter, only prose — this is the first and highest-weight check.
+
+All other checks (AST04, AST05, AST07, AST08, AST10) apply to both paths and are covered in the deep references.
+
+**Where the checks live in full detail:**
+[agentskills.io specification — applied reference](../../_shared/reference/agentskills-io-standard.md) has the OWASP-to-surface mapping table.
+The `security-checklists` skill's agentic-skills module has the full AST01–AST10 review procedure, loaded during adversarial review.
+
+---
+
+## The definition of done — both paths
+
+Both writing and assimilation arrive at the same finish line.
+Assimilation has two additional human-gate criteria because the material arrives from outside.
+
+| Criterion | Writing | Assimilation |
+|---|---|---|
+| `lint-skill-spec.py` clean | ✓ | ✓ |
+| `make build-self` clean; `lint-agent-artifacts.py` clean | ✓ | ✓ |
+| Activation evals authored; all trigger rates pass | ✓ | ✓ |
+| Output-quality evals authored (`evals/evals.json`) | ✓ | ✓ |
+| `agentbundle show <pack>` lists the skill | ✓ | ✓ |
+| Raw body confirmed safe (human review) | — | ✓ |
+| OWASP AST review ran and clean | — | ✓ (automatic via `assimilate-primitive`) |
+| PR opened; adversarial review returns `Clean — ready to commit.` | ✓ | ✓ |
+
+The tutorials end with a path-specific checklist drawn from this table.
+Come back here to verify nothing was missed before opening the PR.

--- a/docs/guides/catalogue-curation/explanation/the-convergence-model.md
+++ b/docs/guides/catalogue-curation/explanation/the-convergence-model.md
@@ -1,0 +1,147 @@
+# The convergence model
+
+Convergence is not import.
+Importing copies bytes from one repo to another.
+Convergence reviews the bytes for safety, evaluates them against standards, reshapes them to craft, and only then writes them — through a path-confined jail — into the catalogue.
+An imported skill carries its origin's conventions and anti-patterns.
+A converged skill has been deliberately shaped to yours.
+
+## Two primitive types
+
+The catalogue recognises two primitive types for convergence.
+
+**Skills** carry a YAML frontmatter block.
+The frontmatter's `description:` field drives activation — the agent reads it when deciding whether the skill applies to the user's prompt.
+A skill that activates on the wrong prompts, or fails to activate on the right ones, is broken regardless of how well its body is written.
+The convergence process rewrites the description for the catalogue's activation conventions and verifies it against agentskills.io format rules before landing.
+The skill body routes to `references/` files on demand — deep content is loaded at the moment the workflow reaches it, not pre-loaded into every context.
+
+**Subagents** are instruction prose with no frontmatter activation description.
+They are dispatched directly by skills or by the user — not selected by an activation match.
+The convergence review for a subagent shifts focus: there is no description to tune, but there is instruction prose that will run in the user's agent, and that prose is a prompt-injection surface.
+The OWASP AST01–AST10 review applies with sharper weight on malicious content (AST01), tool grant breadth (AST03), and isolation declaration (AST06).
+
+Both types go through the same fetch path (SSRF-guarded, allowlisted schemes only), the same raw-body review, and the same path-jail on write.
+The `assimilate-primitive` skill handles both.
+
+## The curation pack's own arc
+
+The four skills in the pack form a natural progression:
+
+| Stage | Skill | Output |
+|---|---|---|
+| Discover | `assimilate-repo` | Ledger of candidates with verdicts |
+| Scaffold | `propose-catalogue-pack` | Pack shell + RFC draft |
+| Fill | `assimilate-primitive` × N | Shaped skills and subagents in the pack |
+| Publish | `export-catalogue` | Redistributable fork or profile update |
+
+Each stage's output is the input to the next.
+The survey's ledger determines what gets proposed.
+The proposed pack's shell determines where primitives land.
+The filled pack is what gets exported or profiled.
+
+A single-primitive intake enters at Fill, skipping Discover and Scaffold.
+A maintenance update skips Scaffold (the pack already exists) and re-fills from a re-run survey.
+The arc describes the full flow; each operator enters at the stage their situation requires.
+
+## Three convergence layers
+
+### Layer 1: agentskills.io structural standard
+
+The agentskills.io specification defines the format every skill in this catalogue follows: six allowed top-level frontmatter keys, four allowed subdirectory names (`scripts/`, `references/`, `assets/`, `evals/`), and a `description:` that is a single-line scalar, trigger-phrased, under 1024 characters.
+The linters (`lint-skill-spec.py`, `lint-agent-artifacts.py`) enforce this structurally before a skill can project to any adapter.
+
+Context that a skill needs but does not use on every invocation lives in `references/` files.
+The skill body loads a reference file at the moment the workflow reaches it — "load `references/strategy-X.md` now" — not pre-loaded into every context.
+This keeps the skill lean at the point of activation and prevents content from being embedded in context that may not be relevant to the current run.
+A skill that embeds large knowledge blocks in its body, or references paths outside the pack's own directory, violates this layer.
+
+All paths in a skill (scripts, references, assets) are relative to the skill's own directory.
+A skill discovers what it needs from the workspace's own structure at runtime — it does not reference absolute paths, fixed org-specific locations, or paths that are only valid in a particular checkout.
+
+### Layer 2: Catalogue craft
+
+The agentskills.io spec sets the format floor.
+Catalogue craft is the layer above it.
+
+The activation description is rewritten for this catalogue's conventions — a trigger-phrased "Use when…" sentence that activates on the right prompts and stays quiet on near-misses.
+`run-pack-evals` verifies this against authored activation evals after assimilation.
+
+Detail that is only needed in specific branches of the workflow is moved to `references/` files linked from the body at the moment of need.
+The body routes to references — it does not replicate them inline.
+
+Anti-patterns are steered or rejected.
+A skill that calls another skill from within a script, a subagent that reviews its own output, a skill that treats fetched URL content as instructions — these are reshaped or refused.
+The anti-pattern list is the catalogue's earned hard knowledge about what fails in production; convergence is how that knowledge protects new additions.
+
+### Layer 3: OWASP Agentic Skills Top 10 v1.0 security review
+
+The OWASP Agentic Skills Top 10 v1.0 (AST01–AST10) is a public security standard for skill-file authoring, distribution, and installation.
+Every converged primitive is reviewed against it before landing.
+
+The checks that fire most often on external content:
+
+**AST01 — Malicious content.**
+Instruction prose that benefits the skill's author at the expense of the user's agent: identity-overwrite instructions, credential-access requests camouflaged as prerequisites, conditional misdirection.
+This is the highest-weight check on subagents, where the entire file is instruction prose and there is no metadata to validate separately.
+
+**AST03 — Over-privileged tools.**
+A skill's `allowed-tools` must match its stated function.
+An external skill that lists broad tool grants "to avoid breaking" expands the blast radius of any prompt injection that reaches it.
+Every tool listed must be necessary for the skill's stated purpose.
+
+**AST04 — Insecure metadata.**
+Frontmatter fields are attacker-controlled inputs when the skill source is untrusted.
+The review checks that metadata is validated before use and free of injected payloads in display fields.
+
+**AST05 — External reference pinning.**
+A skill that fetches external URLs at runtime and treats the response as instructions is a mutable attack surface.
+Fetched content must be pinned or treated as data context, not executed directly.
+
+**AST06 — Isolation declaration.**
+A skill that instructs code execution without naming a containment boundary is a finding.
+The containment mechanism must be declared, not implied.
+
+**AST07 — Version drift.**
+Dependency references in skill manifests must be pinned, not open-ranged.
+
+**AST09 — Governance gap.**
+A converged skill must be inventoried — registered in an auditable record with name, version, content hash, and install source.
+The pack's ledger and `agentbundle show` inventory are this record.
+A skill with no inventory entry is ungoverned regardless of its content.
+
+**AST10 — Cross-platform metadata survival.**
+Security metadata (risk tier, permission manifest) must survive projection across adapters.
+The projection pipeline and `lint-agent-artifacts.py` enforce this.
+
+AST02 (supply chain) defers to the supply-chain security module.
+AST08 is addressed structurally by the `tool`/`hybrid`/`reason` review taxonomy built into the security review process.
+
+The full AST01–AST10 check detail lives in the `security-checklists` skill's agentic-skills reference module, loaded during any security review pass.
+
+## Why shaping, not pasting
+
+External work carries the conventions of the project it came from.
+An activation description written for a different catalogue's trigger patterns may collide with this catalogue's existing skills.
+A skill body that calls another skill by path rather than by name will break on projection to a different adapter layout.
+A subagent with no stated tool constraints is functionally over-permissioned from the moment it lands.
+
+Convergence catches these before they become production problems.
+The shaping step is not reformatting — it is craft review with jurisdiction over what enters the catalogue.
+
+## No merge-back
+
+The canonical direction of data flow is: upstream source → catalogue.
+There is no "sync my fork's edits back upstream" flow.
+
+If a skill in the catalogue is improved, that improvement can be submitted as a PR to the upstream repo.
+The upstream will run its own convergence review on the contribution — it treats the contribution as a fresh primitive, not a trusted sync from a known derivative.
+This is deliberate: bidirectional sync between a catalogue and its derivatives is where divergence accumulates silently and identity-leak accidents happen.
+One source is authoritative; derivatives are derived, not collaborative branches of it.
+
+## Where to go next
+
+[agentskills.io specification — applied reference](../../_shared/reference/agentskills-io-standard.md) ·
+[Catalogue operator journey](catalogue-operator-journey.md) ·
+[Your first assimilation](../tutorials/first-assimilation.md) ·
+[Your first subagent](../tutorials/your-first-subagent.md)

--- a/docs/guides/catalogue-curation/tutorials/first-assimilation.md
+++ b/docs/guides/catalogue-curation/tutorials/first-assimilation.md
@@ -4,6 +4,10 @@
 our craft — end to end. By the end you'll have adopted a skill from a URL and
 seen where every guardrail fires.
 
+**Before you start.** Read [Skill standards](../explanation/skill-standards.md) — it tells you what you're measuring incoming material against.
+When assimilating, the three standards apply in reverse: you review the incoming skill against them rather than building to them.
+Standard 3 (OWASP AST) applies with extra weight here because the material arrives from outside.
+
 You need the `catalogue-curation` pack installed (it requires `core` +
 `governance-extras`).
 
@@ -56,5 +60,20 @@ source.
 
 Every step had a guardrail: scheme allowlist, raw-content review, code confirm,
 repo lints/scanners, collision check, anti-pattern steering, path-jail. That's
-the difference between *adopting* a skill and *pasting* one. Next: survey a whole
-repo at once — see [Survey a repo](../how-to/survey-a-repo.md).
+the difference between *adopting* a skill and *pasting* one.
+
+## Definition of done
+
+Before the skill is fully landed, verify:
+
+- [ ] Raw body confirmed safe (human review of the verbatim fetch output)
+- [ ] OWASP AST review ran and returned clean (handled by `assimilate-primitive`)
+- [ ] `make build-self` ran without error after landing
+- [ ] `agentbundle show <pack>` lists the assimilated skill by name
+- [ ] Activation evals authored and passing (`evals/eval_queries.json`)
+- [ ] PR open; adversarial review returned `Clean — ready to commit.`
+
+The [full definition-of-done table](../explanation/skill-standards.md#the-definition-of-done--both-paths) in the standards file covers both assimilation and writing paths side by side.
+
+Next: survey a whole repo at once — see [Survey a repo](../how-to/survey-a-repo.md).
+Or bring in a subagent — see [Your first subagent](./your-first-subagent.md).

--- a/docs/guides/catalogue-curation/tutorials/your-first-skill.md
+++ b/docs/guides/catalogue-curation/tutorials/your-first-skill.md
@@ -1,0 +1,406 @@
+# Your first skill
+
+**Goal:** write one standard-compliant skill from scratch and land it in the catalogue.
+By the end you'll have a skill with valid frontmatter, a shaped body, activation evals, and a definition of done you can verify.
+
+This is the main journey. The side journey — bringing in skills and repos from outside — starts at [Your first assimilation](./first-assimilation.md) after you've completed this one.
+
+**Before you start.** Read [Skill standards](../explanation/skill-standards.md) — one page that names the three standards and tells you what each is checking.
+This tutorial introduces each standard at the point where it applies; the standards file is where you verify the full picture before opening your PR.
+
+**Prerequisites:**
+- `agentbundle`, `core`, `governance-extras`, and `catalogue-curation` packs installed
+- A clear pair in hand: what this skill does, and one situation where using it would be the wrong choice
+
+---
+
+## 1. Understand the workspace your skill lives in
+
+Before writing a line, know where your skill sits in the workspace design.
+
+The workspace has two rooms:
+
+```
+Shaping room → [shaping_queue]              Build room → [work].queue
+───────────────────────────────             ─────────────────────────
+Decide what the skill does.                 Write it. That's this tutorial.
+Shape it as a brief with rationale.
+```
+
+If you've come from the shaping room with a spec, your `workspace.toml` already has your work item:
+
+```toml
+[[work.queue]]
+id = "skill-<your-skill-name>"
+spec = "docs/specs/<pack>/<your-skill-name>.md"
+status = "In Progress"
+```
+
+If you're starting ad-hoc — no workspace set up yet — that's fine.
+Skills must handle both: a skill that only works when the full arc has already run is fragile.
+You'll handle this in Step 3.
+
+Run `workspace-status` at any point to see what the queue currently looks like.
+
+**Where the skill lives on disk:**
+
+```
+packs/<pack>/
+└── .apm/
+    └── skills/
+        └── <your-skill-name>/
+            ├── SKILL.md                ← write this first
+            ├── scripts/                ← cross-platform scripts (add if needed)
+            ├── references/             ← context loaded on demand (add if needed)
+            └── evals/
+                ├── eval_queries.json   ← activation evals (Step 5)
+                └── evals.json          ← output-quality evals (Step 6)
+```
+
+**Workspace vocabulary** — the verbs you'll see in other skills and in the workspace design:
+
+| Verb | What it does |
+|---|---|
+| `capture-work` | Captures a new work item into the queue |
+| `workspace-status` | Surfaces the current queue state without modifying it |
+| `receive-brief` | Pulls a shaped brief from `[brief_queue]` into `[work].queue` |
+
+Name your skill for what it does, not for internal mechanism.
+If a skill in the codebase already uses a similar verb, align with it.
+
+---
+
+## 2. Write the frontmatter
+
+Create `packs/<pack>/.apm/skills/<your-skill-name>/SKILL.md`.
+
+```yaml
+---
+name: <your-skill-name>
+description: >
+  Use when <specific trigger situation>.
+  Do NOT use when <the near-miss situation that shares keywords but belongs in a different skill>.
+license: Apache-2.0
+compatibility:
+  claude_code: ">=0.2.0"
+  kiro: ">=0.10.0"
+metadata:
+  boundary: filesystem_read
+  scope: repo
+allowed-tools:
+  - Read
+  - Bash
+---
+```
+
+**[Standard 1 — agentskills.io structural]**
+Six keys, no others: `name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools`.
+`description:` is a single-line scalar (or a `>` block scalar that collapses to one line), under 1024 characters.
+`lint-skill-spec.py` enforces this — it's the authority, not this page.
+
+**[Standard 2 — Catalogue craft] `description:` is the activation signal.**
+This is the most important sentence you will write.
+The agent reads it to decide whether your skill applies to the user's prompt.
+Write it as two sentences: "Use when [specific situation]." and "Do NOT use when [near-miss]."
+The second sentence separates your skill from the two or three others that sound similar at first glance.
+
+**[Standard 3 — OWASP AST03] `allowed-tools:` must be minimal.**
+List only the tools your skill body actually instructs the agent to invoke.
+Start with the smallest plausible set and add only when a step in the body genuinely requires it.
+Every tool listed must be justified by the skill's stated purpose.
+Over-declaring expands the blast radius of any prompt injection that reaches this skill.
+
+**[Standard 3 — OWASP AST06] `metadata.boundary:`**
+If your skill instructs code execution or file writes, declare the containment boundary here.
+Accepted values: `filesystem_read`, `filesystem_write`, `network_fetch`, `shell_exec`.
+"The agent will have access" without naming the scope is a finding.
+
+---
+
+## 3. Write the body
+
+The body is the procedure the agent follows. Four named sections.
+
+### Opening clause
+
+One to three sentences. What this skill does — and one clear "not": the situation where using it would be the wrong choice.
+
+```markdown
+Summarises a thread of agent messages into a human-readable session report.
+Does NOT generate new analysis or suggest next actions — use `synthesise-findings` for that.
+```
+
+The "not" sentence primes the agent to route correctly when a near-miss prompt arrives.
+
+### Prerequisites
+
+List what must exist before the skill can proceed. Use the three-tier policy:
+
+- **T1 — Declare and detect.** Check for the dependency; if absent, stop cleanly.
+- **T2 — Optional, gated, idempotent.** Install only if the user opts in.
+- **T3 — Banned.** Never install this from a skill.
+
+**[Craft: graceful ad-hoc handling]**
+
+A skill that silently breaks when an earlier arc step hasn't run is fragile.
+Write T1 prerequisites to handle direct invocation gracefully:
+detect what's missing, name it explicitly, and stop with a clear message.
+
+```markdown
+**Prerequisites**
+
+- Python 3.11+ on PATH.
+- `jq` on PATH — detected via `shutil.which("jq")`.
+  If absent: stop and tell the user. Do not attempt to install it.
+- If a `workspace.toml` exists in the working directory, read the current queue item.
+  If no `workspace.toml` is found: note that workspace tracking is inactive and continue
+  without updating the queue. Tell the user they can run `capture-work` to set it up.
+```
+
+The workspace-absent case shows the pattern: detect, name, proceed-with-note or stop — never silently ignore.
+
+### Instructions
+
+Numbered steps. Each step is one concrete action the agent takes.
+
+**[Craft: progressive disclosure]**
+Detail that only matters in one branch of the workflow goes in a `references/` file.
+Load it at the point the workflow reaches that branch — not pre-loaded for every invocation.
+
+```markdown
+3. Determine the thread format. Load `references/thread-format.md` now.
+4. Parse the messages using the shape described in the reference.
+5. ...
+```
+
+The `references/` file is not in context until Step 3 loads it.
+Every invocation that doesn't reach Step 3 never pays for that context.
+
+**[Craft: path discipline]**
+Discover context from the workspace's own structure at runtime.
+Do not hardcode paths that are only valid in your environment.
+
+Wrong:
+```markdown
+3. Read from `/Users/yourname/projects/myproject/.agentbundle/state/`.
+```
+
+Right:
+```markdown
+3. Find `.agentbundle/` by walking up from the current working directory.
+   If not found, stop: the skill requires an installed pack.
+```
+
+This is what makes the skill portable — any workspace with the pack installed gets consistent behavior.
+
+### Arc handoff
+
+When the skill's main work is done, suggest the next step in the arc.
+Do not invoke the next skill automatically — name it and let the user choose.
+
+```markdown
+## Next steps
+
+The summary has been saved to `<output-file>`.
+
+When you're ready:
+- Review the summary, then run `export-catalogue` to produce the redistributable bundle.
+- Or run `workspace-status` to see the full queue before deciding what's next.
+```
+
+The arc handoff pattern is what makes a series of skills feel like a coherent journey
+rather than a collection of unrelated commands.
+Each skill knows about the next step in its arc and surfaces it — but leaves the choice to the user.
+
+### Status pairing
+
+If your skill modifies shared state — writes to a ledger, updates a queue, creates a record —
+pair it with a `<subsystem>-status` skill.
+
+The status skill reads the current state and reports it.
+It does not modify state.
+It lets the user check where things stand without triggering a side-effect.
+
+Example: `assimilate-primitive` writes to the assimilation ledger.
+`catalogue-curation-status` reads that ledger and reports what's been assimilated, what's pending, what failed.
+
+If your skill creates or mutates shared state, check whether a status skill for the subsystem already exists.
+If it does, update it to include the new state.
+If it doesn't, create one named `<subsystem>-status`.
+
+---
+
+## 4. Write cross-platform scripts (if needed)
+
+Scripts go in `scripts/`. Always Python — not shell scripts.
+
+```python
+#!/usr/bin/env python3
+"""Format a message thread into a session report."""
+from __future__ import annotations
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    tool = shutil.which("jq")
+    if not tool:
+        print("jq not found on PATH. Install it and retry.", file=sys.stderr)
+        sys.exit(1)
+
+    thread = Path("thread.json")
+    if not thread.exists():
+        print(f"Expected thread file not found: {thread}", file=sys.stderr)
+        sys.exit(1)
+
+    result = subprocess.run(
+        [tool, ".messages[]", str(thread)],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    if result.returncode != 0:
+        print(result.stderr, file=sys.stderr)
+        sys.exit(result.returncode)
+
+    print(result.stdout)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+Rules: `pathlib` for all paths; `encoding="utf-8"` on every file and subprocess; `subprocess` as a list, never `shell=True`; `shutil.which()` for tool detection, not `command -v`.
+
+---
+
+## 5. Author activation evals
+
+This step verifies your `description:` field actually works as an activation trigger.
+Run it before you think you're done — description problems caught here cost far less than ones caught in production.
+
+Create `evals/eval_queries.json`:
+
+```json
+[
+  {
+    "query": "summarise the messages from last session into a report",
+    "should_trigger": true
+  },
+  {
+    "query": "what patterns appear across these agent runs",
+    "should_trigger": false,
+    "note": "cross-run analysis — use synthesise-findings"
+  },
+  {
+    "query": "format the conversation thread for the team to review",
+    "should_trigger": true
+  },
+  {
+    "query": "generate action items from the session",
+    "should_trigger": false,
+    "note": "action generation, not summarisation"
+  }
+]
+```
+
+Write 8–10 `should_trigger: true` cases (the prompts that should activate this skill) and
+8–10 `should_trigger: false` near-misses (prompts that share keywords but should route to a different skill).
+
+Register the skill in `pack.toml`:
+```toml
+[pack.evals]
+skills = ["<your-skill-name>"]
+```
+
+Run:
+```bash
+python3 tools/run-pack-evals.py --pack <pack>
+```
+
+**Reading the results:**
+- `should_trigger: true` query scoring < 0.5: the description is too narrow or too specific — broaden the "Use when" clause.
+- `should_trigger: false` query scoring > 0.5: the description bleeds into another skill's territory — strengthen or add the "Do NOT use when" clause.
+
+Both kinds of failures tell you the same thing: the description and the test cases are your primary documentation of what this skill is for. They have to agree.
+
+---
+
+## 6. Author output-quality evals
+
+Create `evals/evals.json` with at least one eval per major workflow branch:
+
+```json
+[
+  {
+    "name": "produces formatted session report",
+    "input": "summarise the last session thread",
+    "expected_output": "A markdown report with a header, a summary paragraph, and bulleted key points. No action list, no recommendations.",
+    "assertions": [
+      "Output contains a markdown H1 or H2 header",
+      "Output contains a bullet list",
+      "Output does not contain a section headed 'Next steps' or 'Actions'"
+    ]
+  }
+]
+```
+
+Assertions must be falsifiable behavior-level statements.
+"Agent does the right thing" is not an assertion — name what the output contains or does not contain.
+
+---
+
+## 7. Run the gates
+
+All four must pass before the PR.
+
+```bash
+python3 tools/lint-skill-spec.py              # Standard 1: agentskills.io structural
+make build-self                                # project source → adapters
+python3 tools/lint-agent-artifacts.py         # verify projection is clean
+python3 tools/run-pack-evals.py --pack <pack> # Standard 2: activation evals
+```
+
+After `make build-self`, confirm the skill appears:
+```bash
+agentbundle show <pack>
+```
+
+It should list your new skill by name.
+If it doesn't appear, the pack registration is missing — check `pack.toml`.
+
+---
+
+## 8. Open the PR via work-loop
+
+The adversarial review is the last gate and the one that catches what linters cannot:
+scope creep, description drift against the spec, missing edge cases, and Standard 3 (OWASP AST) findings.
+
+Load the `work-loop` skill and run the PR flow.
+The adversarial review must return `Clean — ready to commit.` before merge.
+
+---
+
+## Definition of done
+
+Check every item before asking for review.
+The [full table](../explanation/skill-standards.md#the-definition-of-done--both-paths) is in the standards file;
+this is the writing-path subset:
+
+- [ ] `lint-skill-spec.py` passes — no errors; warnings reviewed
+- [ ] `make build-self` clean; `lint-agent-artifacts.py` passes
+- [ ] Activation evals: all `should_trigger: true` queries > 0.5; all `should_trigger: false` < 0.5
+- [ ] `evals/evals.json` exists with at least one output-quality eval
+- [ ] `agentbundle show <pack>` lists the skill by name
+- [ ] `workspace-status` shows the work item as `Done` (if workspace tracking is active)
+- [ ] PR open; adversarial review returned `Clean — ready to commit.`
+
+---
+
+Your skill is live in the catalogue.
+
+The side journey — bringing existing skills and repos from outside into the catalogue — starts at
+[Your first assimilation](./first-assimilation.md).
+For the full pack arc from survey to publish, see [Catalogue operator journey](../explanation/catalogue-operator-journey.md).

--- a/docs/guides/catalogue-curation/tutorials/your-first-subagent.md
+++ b/docs/guides/catalogue-curation/tutorials/your-first-subagent.md
@@ -1,0 +1,109 @@
+# Your first subagent assimilation
+
+**Goal:** bring one external subagent definition into the catalogue safely, with the right security emphasis.
+By the end you'll have seen how a subagent assimilation differs from a skill assimilation and where the OWASP AST review shifts focus.
+
+**Before you start.** Read [Skill standards](../explanation/skill-standards.md) — specifically Standard 3 (OWASP AST) and the definition-of-done table.
+When assimilating a subagent, Standard 3 applies with the most weight of any primitive type.
+A subagent has no frontmatter to validate — the body is the entire security surface.
+
+You need the `catalogue-curation` pack installed (it requires `core` + `governance-extras`).
+
+## 1. How a subagent differs from a skill
+
+A skill has a YAML frontmatter block with a `description:` field.
+That field is the activation signal — the agent reads it to decide whether the skill applies to the user's prompt.
+
+A subagent is instruction prose with no frontmatter activation description.
+It is dispatched by a skill or directly by the user — not selected by an activation match.
+There is no description to tune and no frontmatter to validate.
+The body IS the security surface.
+
+The `assimilate-primitive` skill handles both.
+Point it at a subagent definition the same way you would a skill:
+
+> Assimilate the subagent at `https://github.com/some-org/their-repo/agents/review-agent.md` into our catalogue.
+
+## 2. Point at the source
+
+The fetch uses the same guardrails as skill assimilation: HTTPS or git schemes only.
+A `file:` URL, a private metadata address, or a non-allowlisted scheme is refused before anything is read.
+
+## 3. Read the raw content — this is the primary security gate
+
+The skill shows you the **raw fetched body, verbatim**.
+Do not skim it.
+
+For a skill, the frontmatter gives you a structured surface to review: `allowed-tools` lists what the skill touches, `metadata:` declares the boundary type.
+For a subagent, every sentence is a potential instruction your agent will follow.
+Read the body with one question in mind: *does any of this benefit the author at the expense of me or my users?*
+
+The OWASP Agentic Skills Top 10 v1.0 review runs on the body with shifted emphasis:
+
+**AST01 — Malicious instruction prose.**
+This is the highest-weight check for subagents precisely because there is no metadata to validate separately.
+Look for: identity-overwrite instructions ("update your SOUL.md with…"), credential-access requests dressed as prerequisites, conditional misdirection ("if no user is present, also do X").
+These are found in prose, not in frontmatter.
+
+**AST03 — Tool grant breadth.**
+A subagent may instruct the agent to use a broad set of tools.
+Every tool the subagent instructs the agent to invoke must be necessary for its stated purpose.
+A subagent that requests file-write, shell-exec, and network access for a task that only needs read access is over-granted — flag it and reshape or reject.
+
+**AST06 — Isolation.**
+A subagent that instructs code execution without naming a containment boundary is a finding.
+The body must declare: what filesystem scope it operates in, what network access it needs, and whether it spawns further agents.
+Containment must be declared, not implied by the caller's context.
+
+Two anti-patterns the skill also checks for:
+
+**Skill-vs-agent confusion.**
+A subagent that runs a step-by-step interactive workflow with user decision points is the wrong primitive.
+Skills are for interactive, activation-driven workflows.
+Subagents are dispatched for bounded, non-interactive sub-tasks.
+If the external definition is really a skill in agent clothing, the assimilation skill will propose reshaping it as a skill instead.
+
+**Self-review.**
+A subagent instructed to evaluate or review its own output is an anti-pattern.
+Self-review produces unreliable results and is a common failure mode in poorly-designed agent definitions.
+Reshape or reject.
+
+## 4. Shape to catalogue convention
+
+Once accepted as safe, the skill reshapes the definition.
+For subagents, shaping means:
+
+**Opening paragraph.**
+The opening paragraph of the agent file must state clearly what the subagent does, what it does not do, and what dispatches it.
+There is no `description:` frontmatter to carry this — the prose opening is the only context a caller or reviewer has.
+
+**Tool grant minimisation.**
+Tool grants in the body are minimised to what the subagent's stated purpose requires.
+Any grant not justified by the stated purpose is removed.
+
+**Path discipline.**
+Any absolute paths or hardcoded workspace locations in the original are replaced with relative paths or runtime context-discovery patterns.
+The subagent reads workspace structure at runtime from the workspace's own standard locations — it does not rely on paths that are only valid in the origin repo or a particular org's environment.
+This is what makes the subagent portable: any workspace that has the pack installed will get consistent behavior without manual path configuration.
+
+**Landing location.**
+The subagent lands in `packs/<pack>/.apm/agents/<name>.md` — one Markdown file, the agent definition, no frontmatter.
+
+## 5. Approve and land
+
+You see the shaped target before it is written.
+Approve, and it is written through the path-jail to the destination pack.
+The skill prompts you to run `make build-self` so the projection tracks the new source.
+
+After landing, verify: the shaped file is in `packs/<pack>/.apm/agents/`, `make build-self` has run without error, and `agentbundle show <pack>` lists the new agent.
+
+## What you just relied on
+
+Every step had a guardrail: scheme allowlist, raw-body display before any reformatting, OWASP AST01/AST03/AST06 review with subagent-specific emphasis, skill-vs-agent confusion check, self-review anti-pattern detection, tool grant minimisation, path discipline enforcement, and the path-jail on write.
+
+The difference between a skill assimilation and a subagent assimilation is not the mechanism — it is where the security weight falls.
+For a skill, the frontmatter gives structure to review.
+For a subagent, the body is the attack surface — read it as untrusted prose.
+
+Next: understand why assimilation shapes rather than pastes — see [The convergence model](../explanation/the-convergence-model.md).
+For the parallel skill flow, see [Your first assimilation](./first-assimilation.md).

--- a/docs/product/journeys/README.md
+++ b/docs/product/journeys/README.md
@@ -91,6 +91,7 @@ These journeys cover the end-to-end experience of a specific optional pack. They
 |---|---|---|---|
 | [Engineer provisions infrastructure](engineer-provisions-infrastructure.md) | `iac-terraform` — repo scope | shipped | [RFC-0065](../../rfc/0065-iac-terraform-pack.md) |
 | [Designer designs a surface](designer-designs-surface.md) | `experience-design` — user scope; genre-aware design chain (1.0.0) | shipped | [RFC-0066](../../rfc/0066-experience-pack-surface-genre-and-skill-uplift.md) |
+| [Catalogue engineer converges skills](catalogue-engineer-converges-skills.md) | `catalogue-curation` — repo scope; external skills and subagents converged to catalogue-native | planned | [RFC-0059](../../rfc/0059-catalogue-curation-pack.md) |
 
 ---
 

--- a/docs/product/journeys/catalogue-engineer-converges-skills.md
+++ b/docs/product/journeys/catalogue-engineer-converges-skills.md
@@ -1,0 +1,190 @@
+---
+type: customer-journey
+slug: catalogue-engineer-converges-skills
+persona: catalogue-maintainer-or-platform-engineer
+outcome: external-skills-and-agents-converged-to-catalogue-native
+surface: cross-platform
+status: planned
+initiative_links:
+  - id: RFC-0059
+    name: Catalogue Curation Pack
+    milestones: all stages — skills shipped; manual QA of agent-behaviour ACs in progress
+    role: primary
+updated: 2026-07-22
+---
+
+# Journey: Catalogue engineer converges skills
+
+**Persona:** A platform engineer or catalogue maintainer who manages a derived catalogue or an org-stack pack.
+They have an existing catalogue (or are starting one) and a set of external skills, subagents, or hooks they want to bring in safely.
+They are not a solo adopter installing from the public catalogue — they are the person who decides what goes *into* a catalogue.
+
+Two paths share this journey:
+
+- **Single-primitive intake:** The engineer identifies one external skill or subagent they want in their org's kit and runs `assimilate-primitive` directly, without a survey or RFC.
+  This is the org-stack engineer's path.
+- **Full convergence:** The engineer surveys a whole external repo, evaluates candidates, proposes new packs, assimilates multiple primitives in sequence, and publishes a profile or fork.
+  This is the catalogue maintainer's path.
+
+**Outcome:** External skills and subagents are safely reviewed against the OWASP Agentic Skills Top 10 v1.0 (AST01–AST10), shaped to agentskills.io standard and catalogue craft, catalogued in an auditable pack inventory, and bundled into a profile or redistributable fork that teams can install in one command.
+
+**Surface:** cross-platform — CLI/terminal, agent-assisted.
+Assimilation outputs (shaped skills, pack shells, RFC drafts) are files committed to the repo under the pack's source directory.
+
+**Trigger:**
+- Single-primitive: an engineer finds an external skill or agent definition they want in their org's kit.
+- Full convergence: a platform team wants to grow the catalogue from an external source, or evaluate whether a public catalogue contains skills worth adopting.
+
+**End state:** Every adopted primitive is in `packs/<pack>/.apm/` in canonical form (skill under `skills/` or subagent under `agents/`), OWASP AST-reviewed, agentskills.io-compliant, activation evals authored, inventory entry present, and a clear revocation path established.
+A profile or redistributable fork makes the adopted set installable by any team in one command.
+The assimilation ledger records what was surveyed, what was adopted, and what was rejected.
+
+---
+
+## Prerequisites
+
+| Pack | Scope | Status | Provides |
+|---|---|---|---|
+| core | repo | current | `work-loop`, `new-spec`, governance gate |
+| governance-extras | repo | current | RFC tooling, spec mechanisms |
+| catalogue-curation | repo | current | `assimilate-repo`, `assimilate-primitive`, `propose-catalogue-pack`, `export-catalogue` |
+
+**Setup:**
+1. Install core and governance-extras at repo scope first — catalogue-curation requires both.
+2. Install catalogue-curation at repo scope: `agentbundle install catalogue-curation --scope repo`.
+3. Verify: `agentbundle show catalogue-curation` lists all four skills with their activation phrases.
+
+The catalogue-curation pack is repo-scope and off every default profile by design.
+It is an operator's tool, not a builder's tool.
+
+---
+
+## Full convergence chain
+
+```mermaid
+sequenceDiagram
+    participant E as Engineer
+    participant AR as assimilate-repo
+    participant PP as propose-catalogue-pack
+    participant AP as assimilate-primitive
+    participant EV as Pack evals
+    participant EC as export-catalogue
+
+    Note over E,EC: Stage 1 — Orient and survey
+    E->>AR: survey-a-repo <source-url>
+    AR-->>E: Ledger opened · candidates with verdict per primitive
+
+    Note over E,EC: Stage 2 — Evaluate candidates
+    E->>PP: propose-catalogue-pack (for needs-new-pack verdicts)
+    PP-->>E: Charter check passed · RFC draft · pack shell scaffolded
+
+    Note over E,EC: Stage 3 — Assimilate primitives
+    E->>AP: assimilate-primitive <skill-or-agent-url>
+    AP-->>E: Raw body shown · OWASP AST01–AST10 review · shaped to agentskills.io · written to pack
+
+    Note over E,EC: Stage 4 — Verify and sharpen
+    E->>EV: run-pack-evals --pack <name>
+    EV-->>E: Activation eval results · sharpen description on miss
+
+    Note over E,EC: Stage 5 — Profile and publish
+    E->>EC: export-catalogue --mode white-label or attributed
+    EC-->>E: Redistributable fork · four-anchor verify clean
+```
+
+---
+
+## Stage 1: Orient and Survey
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Identifies a source (a repo URL, a known catalogue, a community project). Runs `assimilate-repo` pointing at the source. The skill fetches over an allowlisted scheme (HTTPS or git only), opens a ledger at a deterministic path (`~/.agentbundle/catalogue-curation/<run-id>/ledger.toml`), and inventories candidates with a verdict for each: `assimilate`, `reject`, or `needs-new-pack`. The engineer reviews the ledger — it is the audit record of what was seen and what decision was made. An interrupted survey resumes from the ledger without re-fetching. |
+| **Emotions** | Oriented (neutral → positive). The ledger gives a structured view of a potentially large source without reading every file manually. |
+| **Remaining pains** | No progress indicator during the survey beyond ledger entries being written. The survey correctly reads workspace context from the repo's own structure — the engineer does not need to supply file paths or configure input locations manually. |
+
+---
+
+## Stage 2: Evaluate Candidates
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Reviews ledger entries marked `needs-new-pack`. Runs `propose-catalogue-pack` — the skill tests the candidate set against four charter principles (universal across stacks, substantive not duplicative, a habit not a tool, used often enough to stick) and stops if any fails with the reason named. On pass: scaffolds a pack shell (`pack.toml`, `plugin.json`, `README.md`, empty `.apm/`), emits an RFC draft with per-primitive inventory. The RFC routes through the governance path before assimilation begins. |
+| **Emotions** | Deliberate (neutral). The charter test is an explicit gate — the engineer either proceeds with a justified pack or stops. There is no accidental pack creation. |
+| **Remaining pains** | The "used often enough to stick" principle is the hardest to evaluate mechanically — it requires Approver-level judgment about the org's actual habits. The skill offers its recommendation; the final call is human. |
+
+---
+
+## Stage 3: Assimilate Primitives
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | For each approved candidate (skill or subagent), runs `assimilate-primitive`. The skill shows the raw fetched body **verbatim** — this is the primary security gate; no reformatting before review. For code (hooks, scripts): explicit confirmation required before landing. The OWASP Agentic Skills Top 10 v1.0 (AST01–AST10) review runs on every candidate. AST01 checks for malicious instruction prose; AST03 checks tool grant breadth; AST04 checks metadata parsing safety; AST05 checks external reference pinning; AST06 checks isolation declaration; AST07 checks version drift; AST09 checks governance traceability; AST10 checks cross-platform metadata survival. The skill reshapes the candidate — rewrites the description for activation, moves detail to `references/`, steers or rejects anti-patterns — and writes the result through the path-jail to the destination pack. The skill reads workspace structure and charter context automatically; the operator does not supply file paths. |
+| **Emotions** | Careful then confident (neutral → positive). The raw-body review is deliberate friction; after it, the guardrail stack gives confidence the result is safe. |
+| **Remaining pains** | Each primitive is assimilated individually. There is no batch mode for pre-approved sets from the same source. A pre-approval shortlist for highly-trusted sources is not yet supported. |
+
+---
+
+## Stage 4: Verify and Sharpen
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Runs `python tools/run-pack-evals.py --pack <name>` to verify activation coverage. Each skill declared in the pack's `[pack.evals].skills` list is tested against its `evals/eval_queries.json` — trigger queries and near-miss non-trigger queries. A miss is a signal to sharpen the skill's `description:` field; the eval runner names which queries are failing and the observed trigger rate. Tier-B output-quality evals are authored (`evals/evals.json` records what good output looks like) but automated grading of Tier B is a future mechanism. |
+| **Emotions** | Methodical (neutral). Eval misses are actionable signals, not vague quality concerns. |
+| **Remaining pains** | Tier-B LLM-judge grading and pass-rate deltas are deferred to a future mechanism. The engineer can author Tier-B evals now, but automated validation against them is not yet available. |
+
+---
+
+## Stage 5: Profile and Publish
+
+### Now
+
+| Row | Content |
+|-----|---------|
+| **Actions** | Decides the publication path. **Profile route:** update or propose a profile so the adopted set installs in one command via `agentbundle install --profile <name>`. A new profile requires an RFC (profiles are first-party and catalogue-owned today). **Export route:** `export-catalogue` produces a redistributable fork in white-label mode (all upstream identity stripped) or attributed mode (upstream credit preserved in the declared attribution surface). The export's verify step is fail-closed — any surviving identity anchor stops the export before it completes. |
+| **Emotions** | Satisfied (positive). The adopted primitives are packaged for reuse and the work persists beyond this session. |
+| **Remaining pains** | Adopter-authored profiles (where an org creates its own profile without an RFC) are deferred to a future design. Today, a new profile requires the RFC path. The export path produces a full catalogue fork — partial-pack export (shipping only a subset of packs) is not yet supported. |
+
+---
+
+## Workspace and queue arc
+
+Catalogue curation work fits into the workspace's two-room model.
+
+Survey and evaluation (Stages 1–2) are shaping work — the output is a bet (adopt this?) and a brief (here is what to build).
+These live in `[shaping_queue]` before the RFC is accepted.
+Once the RFC is accepted and a pack shell exists, individual primitive assimilations are build tasks: one spec per primitive or per pack, in `[work].queue`.
+
+The assimilation ledger (at `~/.agentbundle/catalogue-curation/<run-id>/ledger.toml`) is the curation-specific state that complements `workspace.toml`.
+`workspace.toml` tracks which specs are queued and shipped; the ledger tracks which primitives from the source have been reviewed and what verdict each received.
+
+Running `workspace-status` after Stage 2 shows the scaffolded pack's spec tasks in `[work].queue`.
+Each assimilation task (Stage 3) is one `work-loop` round — plan (which primitive?) → assimilate → verify activation evals → ship.
+The pack arc — survey → scaffold → fill → ship — is the high-level arc; the workspace queue is how individual assimilation tasks are tracked and handed off between sessions or agents.
+
+---
+
+## Frontstage actions
+
+- **Skill:** `assimilate-repo` — survey a source into a resumable ledger
+- **Skill:** `propose-catalogue-pack` — charter test and RFC draft
+- **Skill:** `assimilate-primitive` — bring in one skill or subagent
+- **Tool:** `python tools/run-pack-evals.py --pack <name>` — activation eval run
+- **Skill:** `export-catalogue` — produce a redistributable fork
+- **Skill:** `workspace-status` — orient at session start; surface next assimilation task
+
+---
+
+## Handoff notes
+
+**For `map-screen-flow`:** Stage 3 (raw-body review + OWASP AST check) and Stage 2 (charter test) carry the highest-opportunity friction.
+The raw-body display (external prose shown verbatim before acceptance) and the charter-test interaction (four questions with a pass/fail gate and a named rejection reason) are the highest-priority screen-level inputs for any future web surface.
+
+**For `blueprint-service`:** Backstage dependencies include the assimilation ledger at a deterministic run-id-keyed path, the path-jail (`agentbundle.safety.write_jailed`), the pack lint pipeline, and the OWASP AST review module in the `security-checklists` skill.
+The ledger schema and the four-anchor export verify step are the state-carrying services the surface needs to read.


### PR DESCRIPTION
## Summary

- Adds the complete guide set for `catalogue-curation` across both developer paths: writing a new skill from scratch (main journey) and assimilating external skills/subagents (side journey)
- Introduces `skill-standards.md` as the unified entry point for the three standards (agentskills.io structural, catalogue craft, OWASP AST v1.0), with a reading-order navigation section and a definition-of-done table covering both paths side by side
- `your-first-skill.md` (main journey tutorial) takes the developer progressively through workspace design, common verbs (`capture-work`, `workspace-status`, `receive-brief`), frontmatter with AST03/AST06 inline, arc handoff pattern, graceful ad-hoc handling, `xxx-status` pairing convention, progressive disclosure and path discipline, activation evals with feedback loop, and a DoD checklist
- `catalogue-curation/README.md` restructured with explicit Step 1 → 2 → 3 navigation; main journey and side journey are clearly separated

## New files

| File | Purpose |
|---|---|
| `explanation/skill-standards.md` | Unified standards entry point; reading order; DoD table |
| `tutorials/your-first-skill.md` | Main journey — write a skill from scratch |
| `tutorials/your-first-subagent.md` | Side journey — assimilate a subagent |
| `explanation/the-convergence-model.md` | Three convergence layers, primitive types, no-merge-back |
| `explanation/catalogue-operator-journey.md` | Three operator sub-personas; workspace queue integration |
| `_shared/reference/agentskills-io-standard.md` | Applied spec reference; OWASP AST mapping table |
| `_shared/how-to/design-a-profile.md` | Profile design tests, worked examples, RFC route |
| `product/journeys/catalogue-engineer-converges-skills.md` | Specialist pack journey map |

## Test plan

- [x] `lint-skill-spec.py` — 133 skills, 0 errors (unchanged)
- [x] `lint-agent-artifacts.py` — clean (docs-only change)
- [x] `lint-profiles.py` — 3 profiles OK (unchanged)
- [x] Cross-links verified — all 51 links in new/modified files resolve