### PR TITLE
chore(workspace): reconcile shipped tracker-guides; activate adopter-persona research

### DIFF
--- a/workspace.toml
+++ b/workspace.toml
@@ -32,19 +32,22 @@ milestone = "M1 · Workspace Foundation"
 parent    = "INI-001"
 
 ["ini-002".shaping_queue]
-active  = []
+# adopter-persona: deliverable must cover pack-segmented setup posture across the
+# proposed Level B set (architect, atlassian, converters, desk-research,
+# experience-design, figma, governance-extras, product-engineering,
+# product-strategy, user-guide-diataxis); include terminology comprehension,
+# prerequisite visibility, artifact discovery, and inputs to P5 persona and
+# live-demo design. Do not add a second generic user-study item — broaden this
+# one; formative evaluation folds into the pilots and later P5/rollout ACs.
+# Project (personal vault): efforts/research/2026-07-22-adopter-persona; phase=capture.
+# Un-gates the three P5 m6-* build items; summary elevates as RFC-0064 notes.
+active  = [
+  {slug = "adopter-persona",            type = "research"},
+]
 backlog = [
   # Signal items — hand-authored by strategist; ongoing, non-graduating
   {slug = "ai-native-regulatory-watch", type = "signal"},
   # Research items — any user with the desk-research pack can pick these up
-  # adopter-persona: deliverable must cover pack-segmented setup posture across the
-  # proposed Level B set (architect, atlassian, converters, desk-research,
-  # experience-design, figma, governance-extras, product-engineering,
-  # product-strategy, user-guide-diataxis); include terminology comprehension,
-  # prerequisite visibility, artifact discovery, and inputs to P5 persona and
-  # live-demo design. Do not add a second generic user-study item — broaden this
-  # one; formative evaluation folds into the pilots and later P5/rollout ACs.
-  {slug = "adopter-persona",            type = "research"},
   # Research (RFC-0064 M3 AC): should rfc-candidates.md graduate into the
   # shaping_queue (as research/strategy entries) rather than remain a separate
   # findings register? Assess the whole intake taxonomy — findings registers
@@ -116,6 +119,7 @@ shipped = [
   "spec/m5-linear-brief-intake-and-sync",            # first-time intake + delta sync
   "spec/portfolio-first-run-pilot-architect",         # RFC-0064 Amendment #4 local/no-credential pilot
   "spec/portfolio-first-run-pilot-figma",             # RFC-0064 Amendment #4 credentialed read-only pilot
+  "spec/m5-tracker-guides",                    # PR #615 — tracker decision tree + vocabulary mapping table
 ]
 queue   = [
   # ==================================================================
@@ -154,7 +158,6 @@ queue   = [
   # "spec/m5-github-brief-intake" — shipped; moved to ["ini-002".work].shipped
   # "spec/m5-linear-brief-intake-and-sync" — shipped; moved to ["ini-002".work].shipped
   # "spec/m5-jira-align-brief-intake" — shipped; moved to ["ini-002".work].shipped
-  "spec/m5-tracker-guides",               # tracker decision tree + vocabulary mapping table
 
   # ---------------- P5 · Adopt (terminal — needs whole journey stable) ----------------
   # Authoring gate: each P5 spec must consume the adopter-persona research findings


### PR DESCRIPTION
## What

Two `workspace.toml` coordination edits surfaced during a `workspace-status` cold-start:

1. **Reconciliation** — `spec/m5-tracker-guides` shows Status: Shipped (PR #615) but was still sitting in `[ini-002 work].queue`. Moved it to `.shipped` as a bare string.
2. **Activate research** — promoted `adopter-persona` (`[ini-002 shaping_queue]`) from `backlog` to `active` and kicked off the desk-research project (project mode, `phase=capture`). The project folder lives in a personal vault, not this repo — only the distilled summary will elevate here as RFC-0064 notes. This item un-gates the three P5 `m6-*` build specs, whose authoring gate requires the adopter-persona findings.

## Why

Keeps the declared-intent queue honest with on-disk spec status, and records that the P5 evidence-gathering is now in flight.

## Scope

Docs/coordination only — no code, no adopter-facing surface. TOML re-parses clean.