### PR TITLE
fix(converters): pin mermaid CDN to 11.16.0 with SRI integrity hash

### DIFF
--- a/docs/specs/cdn-sri-mermaid/spec.md
+++ b/docs/specs/cdn-sri-mermaid/spec.md
@@ -1,0 +1,36 @@
+# Spec: cdn-sri-mermaid
+
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+
+**Mode:** light (no risk trigger fired — additive attribute change, no logic change)
+
+## Objective
+
+Pin both mermaid CDN loads in `markdown-to-html` and `render-proof` from the
+floating `mermaid@11` specifier to `mermaid@11.16.0` with an SRI `integrity=`
+hash and `crossorigin="anonymous"`. Today a CDN compromise or MITM can inject
+arbitrary JS into any generated page's origin, bypassing DOMPurify entirely.
+Bundle: pin `@a2ui/web_core` to `^0.10.5` in render-proof's `package.json`
+to match what `@a2ui/react@0.10.2` now explicitly requires (upstream fix for
+the dep-chain pinning issue we raised — SSR fallback unchanged, still needed).
+
+## Acceptance Criteria
+
+- [x] AC1: `render.js` mermaidScript tag uses `mermaid@11.16.0` URL, adds
+  `integrity="sha384-T/0lMUdJpd2S1ZHtRiofG3htU3xPCrFVeAQ1UUE2TJwlEJSV5NUwn30kP28n238E"`,
+  and adds `crossorigin="anonymous"`.
+- [x] AC2: `render-proof.js` mermaidRuntime tag uses same pinned URL + same
+  integrity + crossorigin.
+- [x] AC3: SRI hash matches `mermaid@11.16.0/dist/mermaid.min.js` exactly —
+  verified by two independent methods (openssl + Python hashlib), both yielding
+  `T/0lMUdJpd2S1ZHtRiofG3htU3xPCrFVeAQ1UUE2TJwlEJSV5NUwn30kP28n238E`.
+- [x] AC4: `render-proof/package.json` pins `@a2ui/web_core` to `"^0.10.5"`.
+- [x] AC5: `node test/pipeline.test.js` passes in `render-proof/`.
+
+## Tasks
+
+1. Update `render.js` mermaidScript string — pin version + add integrity + crossorigin.
+2. Update `render-proof.js` mermaidRuntime string — pin version + add integrity + crossorigin.
+3. Update `render-proof/package.json` — bump `@a2ui/web_core` from `^0.10` to `^0.10.5`.
+4. Verify: grep rendered output for exact script tag; `node test/pipeline.test.js`.

--- a/docs/specs/mermaid-rendering-improvements/spec.md
+++ b/docs/specs/mermaid-rendering-improvements/spec.md
@@ -78,7 +78,5 @@ pan-zoom module across skills, SKILL.md prose updates.
   `textContent` recovers the original unescaped source for Mermaid's parser.
 - Mermaid CDN script is added to the page wrapper, not the DOMPurify-sanitized
   markdown body. `render-proof` FORBID_TAGS applies to the markdown body only.
-- **Deferred: CDN SRI pinning** — both skills load `mermaid@11` from jsDelivr without
-  an `integrity=` hash. Pinning to an exact patch version + adding SRI would harden
-  supply-chain risk but requires ongoing version maintenance. Tracked in backlog.
-  (deferred: cdn-sri-mermaid)
+- **Shipped: CDN SRI pinning** — both skills now load `mermaid@11.16.0` from jsDelivr
+  with `integrity="sha384-..."` and `crossorigin="anonymous"`. Shipped in `cdn-sri-mermaid`.

--- a/packs/converters/.apm/skills/markdown-to-html/scripts/render.js
+++ b/packs/converters/.apm/skills/markdown-to-html/scripts/render.js
@@ -261,7 +261,7 @@ function main() {
 
   const hasMermaid = args.mermaid && /<div class="mermaid">/.test(html);
   const mermaidScript = hasMermaid
-    ? '<script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>'
+    ? '<script src="https://cdn.jsdelivr.net/npm/mermaid@11.16.0/dist/mermaid.min.js" integrity="sha384-T/0lMUdJpd2S1ZHtRiofG3htU3xPCrFVeAQ1UUE2TJwlEJSV5NUwn30kP28n238E" crossorigin="anonymous"></script>'
     : '';
   const mermaidInit = hasMermaid ? `
 mermaid.initialize({

--- a/packs/converters/.apm/skills/render-proof/package.json
+++ b/packs/converters/.apm/skills/render-proof/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@a2ui/react": "^0.10",
-    "@a2ui/web_core": "^0.10",
+    "@a2ui/web_core": "^0.10.5",
     "react": "^19.0",
     "react-dom": "^19.0",
     "markdown-it": "^14.0",

--- a/packs/converters/.apm/skills/render-proof/scripts/render-proof.js
+++ b/packs/converters/.apm/skills/render-proof/scripts/render-proof.js
@@ -336,7 +336,7 @@ async function renderProof(md, opts) {
     : 'Proof';
 
   const mermaidRuntime = hasMermaid ? `
-  <script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@11.16.0/dist/mermaid.min.js" integrity="sha384-T/0lMUdJpd2S1ZHtRiofG3htU3xPCrFVeAQ1UUE2TJwlEJSV5NUwn30kP28n238E" crossorigin="anonymous"></script>
   <script>
   mermaid.initialize({
     startOnLoad: false, theme: 'neutral', securityLevel: 'antiscript',

--- a/packs/converters/.apm/skills/render-proof/test/renderer.test.js
+++ b/packs/converters/.apm/skills/render-proof/test/renderer.test.js
@@ -129,6 +129,7 @@ async function run() {
   const { renderProof } = require('../scripts/render-proof.js');
   const proofWith = await renderProof('# T\n\n```mermaid\ngraph TD\n  A --> B\n```\n', {});
   assert(proofWith.html.includes('cdn.jsdelivr.net/npm/mermaid@11'), 'renderProof: CDN not injected when diagram present');
+  assert(proofWith.html.includes('integrity="sha384-T/0lMUdJpd2S1ZHtRiofG3htU3xPCrFVeAQ1UUE2TJwlEJSV5NUwn30kP28n238E"'), 'renderProof: mermaid CDN tag missing SRI integrity hash');
   const proofWithout = await renderProof('# T\n\nHello world\n', {});
   assert(!proofWithout.html.includes('cdn.jsdelivr.net'), 'renderProof: CDN injected when no diagram present');
 

--- a/workspace.toml
+++ b/workspace.toml
@@ -240,16 +240,6 @@ open = [
   # Unblocks when: apm-leak-lint-rfc RFC is approved, or explicit approval obtained.
   {slug = "credbroker-frozen-pack-ref-sweep", source = "spec/apm-internal-ref-sweep"},
 
-  # Security. Both markdown-to-html and render-proof load mermaid@11 from jsDelivr
-  # with a floating major-range specifier and no integrity= hash. A CDN compromise
-  # or MITM could inject arbitrary JS into the generated page's origin, bypassing
-  # DOMPurify. Affects two script tags in each skill.
-  # Fix: pin an exact patch version (mermaid@11.a.b) and add integrity="sha384-..."
-  #   + crossorigin="anonymous" to both script tags, or vendor mermaid locally.
-  # File: packs/converters/.apm/skills/markdown-to-html + render-proof (script tags).
-  # Unblocks when: a specific Mermaid patch version is chosen and its SRI hash computed.
-  {slug = "cdn-sri-mermaid", source = "spec/mermaid-rendering-improvements"},
-
   # RFC-0065 D5 (source-author review 2026-07-18). Azure shipped contract-complete
   # in iac-terraform v1 (four provider files + providers/azure.md) but no worked
   # example has passed terraform init -backend=false && fmt -check && validate. The


### PR DESCRIPTION
## Summary

- Pins both mermaid CDN loads (markdown-to-html + render-proof) from floating `mermaid@11` to `mermaid@11.16.0` with `integrity="sha384-T/0lMUdJpd2S1ZHtRiofG3htU3xPCrFVeAQ1UUE2TJwlEJSV5NUwn30kP28n238E"` and `crossorigin="anonymous"` — eliminates CDN-compromise/MITM supply-chain vector (from `[backlog].open` item `cdn-sri-mermaid`)
- Adds a durable regression guard in `renderer.test.js`: the integrity hash is now a hard assertion that fails if the attribute is dropped

**Bundled fixes:**
- `render-proof/package.json`: pins `@a2ui/web_core` from `^0.10` to `^0.10.5` — matches what `@a2ui/react@0.10.2` (published 5 days ago) now explicitly requires, closing the dep-chain gap we raised upstream. SSR still throws (`useSyncExternalStore`/`getServerSnapshot`); `dangerouslySetInnerHTML` fallback is unchanged.

**Hash provenance:** `mermaid@11.16.0/dist/mermaid.min.js` (3,565,102 bytes) — computed independently by `openssl dgst -sha384 -binary | openssl base64 -A` and Python `hashlib.sha384`; both yield identical result.

## Test plan

- [x] `node test/pipeline.test.js` — passes (all pipeline tests)
- [x] `node test/renderer.test.js` — passes, including new `integrity=` assertion
- [x] `node test/security.test.js` — passes
- [x] `lint-packs` — clean (no violations)
- [x] Both rendered mermaid HTML outputs manually verified to contain the pinned URL + integrity + crossorigin attributes