### PR TITLE
feat(work-loop): echo resolved spec path in Branch 1 orientation block

### DIFF
--- a/.agents/skills/work-loop/SKILL.md
+++ b/.agents/skills/work-loop/SKILL.md
@@ -136,7 +136,9 @@ Before PLAN begins, orient to the current initiative and work queue:
        (e.g. `"M1 · Workspace Foundation"`).
      - **Active spec (argless only — skip when a spec path is given):**
        Collect every path in `["ini-NNN".work].active` across all active
-       initiatives. Exactly one → begin on that spec without asking. Zero
+       initiatives. Exactly one → state the resolved spec path in the
+       orientation block (e.g., "Beginning on `docs/specs/<slug>/spec.md`")
+       and begin on that spec without asking. Zero
        → surface "No active spec found — run `workspace-status` to see
        what's ready to start." More than one (single initiative or across
        initiatives) → list all and ask the user to pick.
@@ -166,10 +168,11 @@ build items only."
 
 If `workspace.toml` was absent or an explicit spec path was passed,
 proceed to step 1 (PLAN) immediately. Otherwise a path must be resolved:
-if exactly one active item, strip the `spec/` prefix, then read
-`docs/specs/<slug>/spec.md` and `plan.md` as step 1 of PLAN. In the
-zero and multi-item branches, stop after surfacing the message or list
-and do not proceed until the user picks.
+if exactly one active item, state the resolved path (e.g.,
+"Beginning on `docs/specs/<slug>/spec.md`") in the orientation block, strip
+the `spec/` prefix, then read `docs/specs/<slug>/spec.md` and `plan.md` as
+step 1 of PLAN. In the zero and multi-item branches, stop after surfacing
+the message or list and do not proceed until the user picks.
 
 ### 1. PLAN — think before acting
 

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -136,7 +136,9 @@ Before PLAN begins, orient to the current initiative and work queue:
        (e.g. `"M1 · Workspace Foundation"`).
      - **Active spec (argless only — skip when a spec path is given):**
        Collect every path in `["ini-NNN".work].active` across all active
-       initiatives. Exactly one → begin on that spec without asking. Zero
+       initiatives. Exactly one → state the resolved spec path in the
+       orientation block (e.g., "Beginning on `docs/specs/<slug>/spec.md`")
+       and begin on that spec without asking. Zero
        → surface "No active spec found — run `workspace-status` to see
        what's ready to start." More than one (single initiative or across
        initiatives) → list all and ask the user to pick.
@@ -166,10 +168,11 @@ build items only."
 
 If `workspace.toml` was absent or an explicit spec path was passed,
 proceed to step 1 (PLAN) immediately. Otherwise a path must be resolved:
-if exactly one active item, strip the `spec/` prefix, then read
-`docs/specs/<slug>/spec.md` and `plan.md` as step 1 of PLAN. In the
-zero and multi-item branches, stop after surfacing the message or list
-and do not proceed until the user picks.
+if exactly one active item, state the resolved path (e.g.,
+"Beginning on `docs/specs/<slug>/spec.md`") in the orientation block, strip
+the `spec/` prefix, then read `docs/specs/<slug>/spec.md` and `plan.md` as
+step 1 of PLAN. In the zero and multi-item branches, stop after surfacing
+the message or list and do not proceed until the user picks.
 
 ### 1. PLAN — think before acting
 

--- a/docs/specs/spec-C-workloop-argless-resume/spec.md
+++ b/docs/specs/spec-C-workloop-argless-resume/spec.md
@@ -42,7 +42,7 @@ A user who invokes `work-loop` without a spec path argument — or who types "re
 ## Testing Strategy
 
 All criteria use **goal-based check**: the SKILL.md body is read against the spec's three-branch contract and the removed first-path language. The change is to a markdown skill body; no compiled artifact. **Manual QA** — five invocation scenarios:
-1. `workspace.toml` present, one active spec → loop begins without asking.
+1. `workspace.toml` present, one active spec → resolved path stated in orientation block, loop begins without asking.
 2. `workspace.toml` present, zero active specs → "No active spec found…" message.
 3. `workspace.toml` present, two active specs in one initiative → list presented, user asked to pick.
 4. `workspace.toml` present, two active specs across two initiatives → list presented (same Branch 3 path as scenario 3).
@@ -53,7 +53,7 @@ All criteria use **goal-based check**: the SKILL.md body is read against the spe
 
 - [x] **AC1.** `work-loop` SKILL.md `description:` field includes all five RFC-0067 §C trigger phrases: "resume", "continue", "keep going", "pick up where I left off", "let's get going".
 - [x] **AC2.** The three-branch logic governs only the **argless invocation path** (no spec path argument passed to `work-loop`). When `workspace.toml` is absent, the existing skip behavior is preserved: Step 0 exits silently and PLAN begins immediately, as today. When `workspace.toml` is present and the active array logic runs, the three branches are:
-  - Branch 1 (exactly one active item across all `["ini-NNN"]` sections with `status = "active"`): begin the loop on that spec without asking.
+  - Branch 1 (exactly one active item across all `["ini-NNN"]` sections with `status = "active"`): state the resolved path in the orientation block (e.g., "Beginning on `docs/specs/<slug>/spec.md`") before beginning.
   - Branch 2 (zero active items, `workspace.toml` present): surface "No active spec found — run `workspace-status` to see what's ready to start."
   - Branch 3 (more than one active item, from a single initiative's multi-element `.active` array or across multiple initiatives): list all active paths and ask the user to pick before beginning.
 - [x] **AC3.** The first-path auto-pick language is removed: the phrase "the first path in `[\"<slug>\".work].active`" (or equivalent) no longer appears in Step 0.

--- a/docs/specs/work-loop-step0-branch1-echo-resolved-path/plan.md
+++ b/docs/specs/work-loop-step0-branch1-echo-resolved-path/plan.md
@@ -1,0 +1,102 @@
+# Plan: work-loop-step0-branch1-echo-resolved-path
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Draft
+
+## Constraints
+
+- Source file is `packs/core/.apm/skills/work-loop/SKILL.md`; projected copy is `.claude/skills/work-loop/SKILL.md`. Edit source; propagate via `make build-self FORCE=1`.
+- `docs/specs/spec-C-workloop-argless-resume/spec.md` is a shipped spec — update it in-place; no new file needed.
+
+## Risks
+
+- `make build-self FORCE=1` may fail if source and projected copy are already out of sync from other in-progress changes. Mitigate: run `git status` before editing; if dirty, stash first.
+
+## Tasks
+
+### Task 1 — Edit SKILL.md source: Branch 1 bullet
+
+**Mode:** Goal-based check
+**Depends on:** none
+
+In `packs/core/.apm/skills/work-loop/SKILL.md`, find the Active spec bullet block:
+
+```
+Exactly one → begin on that spec without asking.
+```
+
+Change to:
+
+```
+Exactly one → state the resolved spec path in the orientation block
+(e.g., "Beginning on `docs/specs/<slug>/spec.md`") and begin on that spec.
+```
+
+**Done when:** `grep -n "state the resolved spec path" packs/core/.apm/skills/work-loop/SKILL.md` exits 0.
+
+---
+
+### Task 2 — Edit SKILL.md source: closing resolution paragraph
+
+**Mode:** Goal-based check
+**Depends on:** Task 1
+
+In `packs/core/.apm/skills/work-loop/SKILL.md`, find the closing paragraph starting with:
+
+```
+if exactly one active item, strip the `spec/` prefix, then read
+```
+
+Update to include the echo instruction before "read":
+
+```
+if exactly one active item, state the resolved path (e.g.,
+"Beginning on `docs/specs/<slug>/spec.md`") in the orientation block, strip
+the `spec/` prefix, then read
+```
+
+**Done when:** The closing paragraph includes both "state the resolved path" and "then read" in the updated order.
+
+---
+
+### Task 3 — Edit spec-C AC2 Branch 1 clause
+
+**Mode:** Goal-based check
+**Depends on:** none
+
+In `docs/specs/spec-C-workloop-argless-resume/spec.md`, find AC2 Branch 1:
+
+```
+begin the loop on that spec without asking.
+```
+
+Change to:
+
+```
+state the resolved path in the orientation block (e.g.,
+"Beginning on `docs/specs/<slug>/spec.md`") before beginning.
+```
+
+**Done when:** `grep -n "state the resolved path" docs/specs/spec-C-workloop-argless-resume/spec.md` exits 0.
+
+---
+
+### Task 4 — Propagate source change
+
+**Mode:** Goal-based check
+**Depends on:** Tasks 1, 2
+
+Run `make build-self FORCE=1`.
+
+**Done when:** Command exits 0.
+
+---
+
+### Task 5 — Full gate
+
+**Mode:** Goal-based check
+**Depends on:** Tasks 3, 4
+
+Run `make build-check`.
+
+**Done when:** Command exits 0.

--- a/docs/specs/work-loop-step0-branch1-echo-resolved-path/spec.md
+++ b/docs/specs/work-loop-step0-branch1-echo-resolved-path/spec.md
@@ -1,0 +1,77 @@
+# Spec: work-loop-step0-branch1-echo-resolved-path
+
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** RFC-0067 §Change C (spec-C-workloop-argless-resume)
+- **Brief:** none
+- **Discovery:** none
+- **Contract:** none
+- **Shape:** mixed
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+Mode: light (no risk trigger fired)
+
+## Objective
+
+When `work-loop`'s argless Step 0 resolves to Branch 1 (exactly one active
+spec across all active initiatives), the agent silently begins without stating
+which spec it resolved to. A stale `.active` entry pointing at the wrong spec
+goes undetected until PLAN is well under way. This spec adds a one-line
+resolved-path echo to the Branch 1 orientation block, matching the explicitness
+Branch 3 already provides when it lists all active paths.
+
+The fix touches: `packs/core/.apm/skills/work-loop/SKILL.md` (the source)
+and `docs/specs/spec-C-workloop-argless-resume/spec.md` (AC2). Running
+`make build-self FORCE=1` propagates the source change to the projected copy.
+
+## Boundaries
+
+### Always do
+
+- Edit the work-loop source in `packs/core/.apm/skills/work-loop/SKILL.md`; run `make build-self FORCE=1` to propagate.
+- Update `docs/specs/spec-C-workloop-argless-resume/spec.md` AC2 Branch 1 clause to reflect the echo.
+- Keep the echo line concise: one line in the orientation block, e.g. "Beginning on `docs/specs/<slug>/spec.md`".
+
+### Ask first
+
+- Any change to how the path is formatted (e.g. including `plan.md` alongside `spec.md` in the echo).
+
+### Never do
+
+- Change Branch 2 or Branch 3 behavior.
+- Add new output fields to the orientation block beyond the path echo.
+- Change how the argless invocation path resolves the spec (resolution logic is unchanged).
+
+## Testing Strategy
+
+**Goal-based check** — the change is a content edit to a Markdown skill file.
+No runtime logic changes; verification is: (a) the correct text appears in
+the source SKILL.md and the shipped spec AC2, and (b) `make build-self FORCE=1`
+and `make build-check` exit 0.
+
+## Acceptance Criteria
+
+- [x] **AC1.** `packs/core/.apm/skills/work-loop/SKILL.md` Step 0 Branch 1 bullet
+  (the "Exactly one →" bullet inside the Active spec point) instructs the agent
+  to state the resolved spec path in the orientation block — e.g.
+  "Beginning on `docs/specs/<slug>/spec.md`" — before proceeding to PLAN.
+- [x] **AC2.** The closing resolution paragraph in Step 0
+  (`"if exactly one active item, strip the \`spec/\` prefix, then read..."`)
+  is updated to include the same echo instruction, keeping the bullet and the
+  paragraph consistent.
+- [x] **AC3.** `docs/specs/spec-C-workloop-argless-resume/spec.md` AC2 Branch 1
+  clause is updated to reflect that the resolved path is stated in the orientation
+  block before beginning (replacing "begin the loop on that spec without asking"
+  with language that includes the echo).
+- [x] **AC4.** `make build-self FORCE=1` exits 0 (the projected
+  `.claude/skills/work-loop/SKILL.md` matches the updated source).
+- [x] **AC5.** `make build-check` exits 0.
+
+## Assumptions
+
+- Technical: the work-loop SKILL.md source is at `packs/core/.apm/skills/work-loop/SKILL.md`; `make build-self FORCE=1` propagates it to `.claude/skills/work-loop/SKILL.md` (source: CONVENTIONS §Pack source-of-truth split, verified by prior specs).
+- Technical: no test file asserts on the SKILL.md text content; the only gate is `build-check`, which checks the projected copy for drift (source: `make build-check` chain in `tools/build_gate_chain.py`).
+- Process: the quality-engineer flagged this gap (stale `.active` entry undetected) in the `spec-C-workloop-argless-resume` review; the fix is a prose-only clarification, no new activation surface (source: `workspace.toml [backlog].open` entry `work-loop-step0-branch1-echo-resolved-path`).

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -136,7 +136,9 @@ Before PLAN begins, orient to the current initiative and work queue:
        (e.g. `"M1 · Workspace Foundation"`).
      - **Active spec (argless only — skip when a spec path is given):**
        Collect every path in `["ini-NNN".work].active` across all active
-       initiatives. Exactly one → begin on that spec without asking. Zero
+       initiatives. Exactly one → state the resolved spec path in the
+       orientation block (e.g., "Beginning on `docs/specs/<slug>/spec.md`")
+       and begin on that spec without asking. Zero
        → surface "No active spec found — run `workspace-status` to see
        what's ready to start." More than one (single initiative or across
        initiatives) → list all and ask the user to pick.
@@ -166,10 +168,11 @@ build items only."
 
 If `workspace.toml` was absent or an explicit spec path was passed,
 proceed to step 1 (PLAN) immediately. Otherwise a path must be resolved:
-if exactly one active item, strip the `spec/` prefix, then read
-`docs/specs/<slug>/spec.md` and `plan.md` as step 1 of PLAN. In the
-zero and multi-item branches, stop after surfacing the message or list
-and do not proceed until the user picks.
+if exactly one active item, state the resolved path (e.g.,
+"Beginning on `docs/specs/<slug>/spec.md`") in the orientation block, strip
+the `spec/` prefix, then read `docs/specs/<slug>/spec.md` and `plan.md` as
+step 1 of PLAN. In the zero and multi-item branches, stop after surfacing
+the message or list and do not proceed until the user picks.
 
 ### 1. PLAN — think before acting
 


### PR DESCRIPTION
## Summary

- When `work-loop`'s argless Step 0 resolves to exactly one active spec (Branch 1), it now emits the resolved path in the orientation block (e.g. "Beginning on `docs/specs/<slug>/spec.md`") before proceeding to PLAN
- The "without asking" phrase is restored/explicit, preserving Branch 1's frictionless behavior relative to Branch 3's list-and-ask path
- `docs/specs/spec-C-workloop-argless-resume/spec.md` AC2 Branch 1 clause and scenario 1 updated to reflect the echo

**Why:** A stale `.active` entry in `workspace.toml` pointing at the wrong spec would go undetected when Branch 1 auto-started silently. The echo gives the agent one observable line to confirm before PLAN begins.

**Files changed:**
- `packs/core/.apm/skills/work-loop/SKILL.md` — Branch 1 bullet + closing paragraph (source)
- `.claude/skills/work-loop/SKILL.md`, `.agents/skills/work-loop/SKILL.md` — propagated via `make build-self FORCE=1`
- `docs/specs/spec-C-workloop-argless-resume/spec.md` — AC2 Branch 1 + scenario 1
- `docs/specs/work-loop-step0-branch1-echo-resolved-path/` — lean light-mode spec + plan

## Test plan

- [x] `make build-self FORCE=1` exits 0 (projected copies match source)
- [x] `make build-check` exits 0 (all pre-SAST and SAST gates pass)
- [x] Adversarial reviewer: no Blockers; Concerns addressed (restored "without asking"; scenario 1 updated)