### PR TITLE
feat(tools): wire manifest validator into build-check; add APM skill leak guard

### DIFF
--- a/docs/specs/local-claude-manifest-validator-gate/spec.md
+++ b/docs/specs/local-claude-manifest-validator-gate/spec.md
@@ -1,0 +1,27 @@
+# Spec: local-claude-manifest-validator-gate
+
+- **Status:** Implementing <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+
+Mode: light (no risk trigger fired)
+
+## Objective
+
+Wire the existing `tools/validate-claude-plugin-manifests.py` into `make build-check` / `python tools/build_gate_chain.py build-check` so a manifest contract failure is caught locally, matching what `publish-claude-plugins.yml` catches in CI.
+
+## Acceptance Criteria
+
+- [x] `tools/build_gate_chain.py build_check()` includes a `validate-claude-plugin-manifests` step immediately after the `build` step.
+- [x] `build_gate_chain.py` module docstring and `build_check` docstring name the new step.
+- [x] The validator step runs AFTER `build` so `dist/claude-plugins/` exists.
+
+## Tasks
+
+1. Add `_script_step("validate-claude-plugin-manifests", "tools", "validate-claude-plugin-manifests.py")` after the `build` step in `build_check()`.
+2. Update `build_check()` docstring and module-level docstring to name the new step.
+
+**Verification:** goal-based — `grep "validate-claude-plugin-manifests" tools/build_gate_chain.py` returns ≥1 hit inside the `steps` list.
+
+**Declined:**
+- Adding a dedicated self-test — the validator has its own tests; the gate-chain step is trivially verified by grep and the build-check run.
+- Moving the validator before build — it requires `dist/` to exist.

--- a/docs/specs/product-brief-intake-leak-guard/spec.md
+++ b/docs/specs/product-brief-intake-leak-guard/spec.md
@@ -1,0 +1,32 @@
+# Spec: product-brief-intake-leak-guard
+
+- **Status:** Implementing <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+
+Mode: light (no risk trigger fired)
+
+## Objective
+
+Extend `tools/lint-agent-artifacts.py` to cover SKILL.md bodies and `examples/` files under `packs/core/.apm/skills/`, applying the adopter-facing leak guard (no `agent-ready-repo`, `RFC-NNNN`, or `K-NNNN`) as a regression guard. Files are currently clean; the check prevents future leaks.
+
+## Acceptance Criteria
+
+- [x] `lint-agent-artifacts.py` defines `_APM_SKILL_BLOCKLIST` with three patterns.
+- [x] `lint-agent-artifacts.py` scans `packs/core/.apm/skills/*/SKILL.md` bodies and `packs/core/.apm/skills/*/examples/*.md` for the three blocklist patterns.
+- [x] A file containing `agent-ready-repo`, `RFC-00XX`, or `K-00XX` causes the linter to exit non-zero and name the offending file and pattern.
+- [x] A `LINT_APM_ROOT` env var overrides the default path, enabling fixture-based self-tests.
+- [x] Negative fixture tests covering all three patterns are added to `tools/test-lint-agent-artifacts.sh`.
+- [x] The check passes clean on the current `packs/core/.apm/skills/` tree.
+
+## Tasks
+
+1. Add `_APM_SKILL_BLOCKLIST` constant to `lint-agent-artifacts.py`.
+2. Add the APM scan loop in `main()` with `LINT_APM_ROOT` env override.
+3. Add negative fixture test cases to `tools/test-lint-agent-artifacts.sh`.
+
+**Verification:** goal-based — `LINT_APM_ROOT=<tmp-dir-with-leak> python3 tools/lint-agent-artifacts.py` exits non-zero; `python3 tools/lint-agent-artifacts.py` on the real repo exits 0.
+
+**Declined:**
+- Extending to all packs (not just core) — backlog item scopes to `packs/core/.apm/skills/`.
+- Checking frontmatter — body content is the higher-risk surface.
+- Deduplicating patterns with `lint-catalogue-seeds.py` — avoiding cross-tool coupling for a small closed set.

--- a/tools/build_gate_chain.py
+++ b/tools/build_gate_chain.py
@@ -7,8 +7,9 @@ and remember the order. This script chains the same steps so the whole gate runs
 in one command on any platform:
 
     python tools/build_gate_chain.py build-self     # lint-packs -> self
-    python tools/build_gate_chain.py build-check    # lint-packs -> build -> check
-                                                     # -> pre-pr-catalogue
+    python tools/build_gate_chain.py build-check    # lint-packs -> build
+                                                     # -> validate-claude-plugin-manifests
+                                                     # -> check -> pre-pr-catalogue
                                                      # -> spec-status (self-test+lint)
                                                      # -> brief-coverage (self-test+lint)
                                                      # -> traceability (self-test+lint)
@@ -123,13 +124,24 @@ def build_self(args: argparse.Namespace) -> int:
 def build_check(args: argparse.Namespace) -> int:
     """`build-check` chain: every Windows-clean step of `make build-check`.
 
-    lint-packs → build → check → pre-pr-catalogue → lint-spec-status
-    (self-test + lint) → brief-coverage (self-test + lint) → traceability
-    (self-test + lint), in that order. The
-    SAST leg is intentionally omitted (Semgrep has no Windows support and is
-    conditional) — it stays Makefile-appended after this chain.
+    lint-packs → build → validate-claude-plugin-manifests → check →
+    pre-pr-catalogue → lint-spec-status (self-test + lint) →
+    brief-coverage (self-test + lint) → traceability (self-test + lint),
+    in that order. The SAST leg is intentionally omitted (Semgrep has no
+    Windows support and is conditional) — it stays Makefile-appended after
+    this chain.
     """
     packs_dir = args.packs_dir
+    # validate-claude-plugin-manifests always reads dist/claude-plugins/ (hardcoded
+    # in the validator). Warn when --output-dir differs so the user knows the
+    # validator will inspect that directory rather than the freshly-built tree.
+    if Path(args.output_dir).resolve() != (REPO_ROOT / "dist").resolve():
+        print(
+            f"build chain: ⚠  validate-claude-plugin-manifests reads "
+            f"dist/claude-plugins/ regardless of --output-dir ({args.output_dir!r}); "
+            "it will validate the dist/ tree, not the custom output dir.",
+            file=sys.stderr,
+        )
     steps: list[Step] = [
         _handler_step("lint-packs", cmd_lint_packs, packs_dir=packs_dir),
         _handler_step(
@@ -140,6 +152,7 @@ def build_check(args: argparse.Namespace) -> int:
             recipe=None,
             pack=None,
         ),
+        _script_step("validate-claude-plugin-manifests", "tools", "validate-claude-plugin-manifests.py"),
         _handler_step("check", cmd_check, packs_dir=packs_dir, output_dir="."),
         _script_step("pre-pr-catalogue", "tools", "pre-pr-catalogue.py"),
         _script_step(

--- a/tools/lint-agent-artifacts.py
+++ b/tools/lint-agent-artifacts.py
@@ -133,6 +133,14 @@ ALLOWED_AUTH_BROKERS = ("env", "cli", "creds", "sso-cookie")
 ALLOWED_AGENT_KEYS = {"name", "description", "tools", "model"}
 ALLOWED_COMMAND_KEYS = {"description", "allowed-tools", "model", "argument-hint"}
 
+# Patterns that must not appear in shipped .apm/ skill bodies (adopter-facing
+# leak guard for source skills, mirroring lint-catalogue-seeds.BLOCKLIST_PATTERNS).
+_APM_SKILL_BLOCKLIST: tuple[tuple[str, str], ...] = (
+    (r"agent-ready-repo", "catalogue name 'agent-ready-repo'"),
+    (r"RFC-00\d\d", "catalogue RFC reference (RFC-NNNN)"),
+    (r"K-00\d\d", "catalogue knowledge entry (K-NNNN)"),
+)
+
 
 def main() -> int:
     os.chdir(_repo_root())
@@ -457,6 +465,31 @@ def main() -> int:
         f"Artifacts checked: {skill_count} skill(s), "
         f"{agent_count} subagent(s), {command_count} command(s)."
     )
+
+    # ── Adopter-facing leak guard for source .apm/ skill bodies ──────────
+    # Scans all *.md files under packs/core/.apm/skills/ (SKILL.md,
+    # examples/, references/, assets/) for catalogue-internal strings that
+    # must not reach adopters. Scoped to core only per the backlog item;
+    # other packs are a follow-on (see backlog:product-brief-intake-leak-guard).
+    # Override the scan root via LINT_APM_ROOT (used by the self-test).
+    apm_skills_dir = pathlib.Path(
+        os.environ.get("LINT_APM_ROOT", "packs/core/.apm/skills")
+    ).resolve()
+    apm_body_count = 0
+    if apm_skills_dir.exists():
+        for skill_dir in sorted(p for p in apm_skills_dir.iterdir()
+                                if p.is_dir()):
+            for target in sorted(skill_dir.rglob("*.md")):
+                apm_body_count += 1
+                text = target.read_text(encoding="utf-8")
+                for pat, label in _APM_SKILL_BLOCKLIST:
+                    for lineno, line in enumerate(text.splitlines(), 1):
+                        if re.search(pat, line):
+                            err(target, f"leaked {label} in shipped skill body",
+                                line=lineno)
+        print(f"Skill-body leak guard: {apm_body_count} file(s) checked.")
+    else:
+        warn(f"apm/skills root not found: {apm_skills_dir} — skipping leak guard")
 
     if error_count:
         print()

--- a/tools/test-lint-agent-artifacts.sh
+++ b/tools/test-lint-agent-artifacts.sh
@@ -508,3 +508,103 @@ if ! grep -qF -- "'model' must be a string" <<< "$out_norway_model"; then
 fi
 
 echo "✓ Self-test (Norway-scalar required-string fields): passed (description + model both refused cleanly)."
+
+# ── APM skill-body leak guard ─────────────────────────────────────────────
+#
+# Negative: SKILL.md body contains a catalogue-internal reference (agent-ready-repo).
+# LINT_APM_ROOT points the linter at a temp skills dir; LINT_ROOT points at an
+# empty dir so the .claude/ scan produces no false errors.
+
+TMP_APM_LEAK="$(mktemp -d)"
+TMP_APM_CLEAN="$(mktemp -d)"  # empty — linter warns but exits 0 for .claude/ part
+trap 'rm -rf "$TMP" "$TMP_CRED_OK" "$TMP_CRED_BAD_BOOL" "$TMP_CRED_BAD_CLASS" "$TMP_DEEP" "$TMP_FOLDED" "$TMP_NORWAY_BOOL" "$TMP_NORWAY_NAME" "$TMP_NORWAY_DESC" "$TMP_NORWAY_MODEL" "$TMP_APM_LEAK" "$TMP_APM_CLEAN"' EXIT
+
+# Leak: catalogue name in SKILL.md body.
+mkdir -p "$TMP_APM_LEAK/leaky-skill"
+cat > "$TMP_APM_LEAK/leaky-skill/SKILL.md" <<'EOF'
+---
+name: leaky-skill
+description: Skill that leaks an internal catalogue reference.
+---
+
+See agent-ready-repo for context on how this skill was designed.
+EOF
+
+set +e
+out_leak="$(LINT_APM_ROOT="$TMP_APM_LEAK" LINT_ROOT="$TMP_APM_CLEAN" \
+  python3 "$REPO_ROOT/tools/lint-agent-artifacts.py" 2>&1)"
+exit_leak=$?
+set -e
+
+if (( exit_leak == 0 )); then
+  echo "✖ apm-leak-catalogue-name: lint exited 0; expected non-zero." >&2
+  echo "---" >&2
+  echo "$out_leak" >&2
+  echo "---" >&2
+  exit 1
+fi
+if ! grep -qF "agent-ready-repo" <<< "$out_leak"; then
+  echo "✖ apm-leak-catalogue-name: output missing 'agent-ready-repo'." >&2
+  echo "---" >&2
+  echo "$out_leak" >&2
+  echo "---" >&2
+  exit 1
+fi
+
+# Leak: RFC reference in an examples/ file.
+mkdir -p "$TMP_APM_LEAK/leaky-skill/examples"
+cat > "$TMP_APM_LEAK/leaky-skill/examples/example.md" <<'EOF'
+# Example
+
+This example was designed per RFC-0042 requirements.
+EOF
+
+set +e
+out_rfc="$(LINT_APM_ROOT="$TMP_APM_LEAK" LINT_ROOT="$TMP_APM_CLEAN" \
+  python3 "$REPO_ROOT/tools/lint-agent-artifacts.py" 2>&1)"
+exit_rfc=$?
+set -e
+
+if (( exit_rfc == 0 )); then
+  echo "✖ apm-leak-rfc-ref: lint exited 0; expected non-zero." >&2
+  echo "---" >&2
+  echo "$out_rfc" >&2
+  echo "---" >&2
+  exit 1
+fi
+if ! grep -qF "catalogue RFC reference" <<< "$out_rfc"; then
+  echo "✖ apm-leak-rfc-ref: output missing 'catalogue RFC reference'." >&2
+  echo "---" >&2
+  echo "$out_rfc" >&2
+  echo "---" >&2
+  exit 1
+fi
+
+# Positive: clean skill passes.
+TMP_APM_OK="$(mktemp -d)"
+trap 'rm -rf "$TMP" "$TMP_CRED_OK" "$TMP_CRED_BAD_BOOL" "$TMP_CRED_BAD_CLASS" "$TMP_DEEP" "$TMP_FOLDED" "$TMP_NORWAY_BOOL" "$TMP_NORWAY_NAME" "$TMP_NORWAY_DESC" "$TMP_NORWAY_MODEL" "$TMP_APM_LEAK" "$TMP_APM_CLEAN" "$TMP_APM_OK"' EXIT
+mkdir -p "$TMP_APM_OK/clean-skill"
+cat > "$TMP_APM_OK/clean-skill/SKILL.md" <<'EOF'
+---
+name: clean-skill
+description: A skill with no catalogue leaks.
+---
+
+This skill body contains no internal governance references.
+EOF
+
+set +e
+out_clean="$(LINT_APM_ROOT="$TMP_APM_OK" LINT_ROOT="$TMP_APM_CLEAN" \
+  python3 "$REPO_ROOT/tools/lint-agent-artifacts.py" 2>&1)"
+exit_clean=$?
+set -e
+
+if (( exit_clean != 0 )); then
+  echo "✖ apm-clean: lint exited $exit_clean; expected 0." >&2
+  echo "---" >&2
+  echo "$out_clean" >&2
+  echo "---" >&2
+  exit 1
+fi
+
+echo "✓ Self-test (APM skill-body leak guard): passed (catalogue-name + RFC-ref refused; clean skill accepted)."

--- a/tools/test_build_gate_chain.py
+++ b/tools/test_build_gate_chain.py
@@ -119,10 +119,11 @@ class BuildCheckChainTest(unittest.TestCase):
             rc = gc.build_check(args)
 
         self.assertEqual(rc, 0)
-        # Handlers first three, then nine spawned scripts — Makefile order, no SAST.
+        # Handlers: lint-packs, build, check; one spawned script between build and
+        # check (validate-claude-plugin-manifests); nine more after check — ten total.
         self.assertEqual(
             order,
-            ["lint-packs", "build", "check"] + ["script"] * 9,
+            ["lint-packs", "build", "script", "check"] + ["script"] * 9,
         )
 
         self.assertEqual(ns_by_label["lint-packs"].packs_dir, "packs")
@@ -135,11 +136,12 @@ class BuildCheckChainTest(unittest.TestCase):
         self.assertEqual(check_ns.packs_dir, "packs")
         self.assertEqual(check_ns.output_dir, ".")  # working tree, not dist
 
-        # The nine spawned scripts, in Makefile order.
+        # The ten spawned scripts, in Makefile order.
         spawned = [Path(argv[1]).as_posix() for argv in script_argvs]
         self.assertEqual(
             spawned,
             [
+                "tools/validate-claude-plugin-manifests.py",
                 "tools/pre-pr-catalogue.py",
                 ".claude/skills/work-loop/scripts/test-lint-spec-status.py",
                 ".claude/skills/work-loop/scripts/lint-spec-status.py",


### PR DESCRIPTION
## Summary

- **local-claude-manifest-validator-gate**: wires `validate-claude-plugin-manifests.py` into `build_gate_chain.py build-check` immediately after the `build` step. CI caught manifest failures but local `make build-check` / `python tools/build_gate_chain.py build-check` did not. Also adds a warning when `--output-dir` deviates from the default `dist/` (the validator's hardcoded path).

- **product-brief-intake-leak-guard**: extends `lint-agent-artifacts.py` with `_APM_SKILL_BLOCKLIST` — scans `packs/core/.apm/skills/**/*.md` for catalogue-internal strings (`agent-ready-repo`, `RFC-NNNN`, `K-NNNN`) that must not ship to adopters. `LINT_APM_ROOT` env override enables fixture-based self-tests. Negative fixture tests added to `tools/test-lint-agent-artifacts.sh`.

Both spec files at `docs/specs/*/spec.md`; all gates green.

## Deferred
- Extending leak guard to all packs (not just core) — backlog item scopes to `packs/core/.apm/skills/`.
- Checking frontmatter for leaked strings — body content is the higher-risk surface.

## Test plan
- [x] `bash tools/test-lint-agent-artifacts.sh` — all 6 test blocks pass
- [x] `python3 tools/lint-agent-artifacts.py` — 49 files checked, passes clean
- [x] `python3 tools/build_gate_chain.py build-check` — full gate chain green