### PR TITLE
feat(gates): wire validate-claude-plugin-manifests into local build-check chain

### DIFF
--- a/docs/specs/local-claude-manifest-validator-gate/plan.md
+++ b/docs/specs/local-claude-manifest-validator-gate/plan.md
@@ -1,0 +1,89 @@
+# Plan: local-claude-manifest-validator-gate
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Draft
+
+## Constraints
+
+- `tools/build_gate_chain.py` `build_check` uses `_script_step(label, *path_parts)` — consistent with all existing script steps.
+- The test file `tools/test_build_gate_chain.py` asserts exact step count and exact ordered list of spawned paths — both must be updated atomically.
+
+## Risks
+
+- `make build-check` invokes the real `validate-claude-plugin-manifests.py` which requires `dist/claude-plugins/` to exist. The `cmd_build` step that precedes it creates this directory, so no risk of missing dist. But if an existing pack plugin.json has a schema error that was previously undetected, `build-check` will start failing. Mitigate: run `python tools/validate-claude-plugin-manifests.py` manually first to confirm it passes before adding to the chain.
+
+## Tasks
+
+### Task 1 — Add script step to build_gate_chain.py
+
+**Mode:** Goal-based check
+**Depends on:** none
+
+In `tools/build_gate_chain.py`, in `build_check`, after:
+```python
+        _script_step("lint-first-value-contract", "tools", "lint-first-value-contract.py"),
+```
+Add:
+```python
+        _script_step("validate-claude-plugin-manifests", "tools", "validate-claude-plugin-manifests.py"),
+```
+
+**Done when:** The function's `steps` list ends with `validate-claude-plugin-manifests`.
+
+---
+
+### Task 2 — Update the test: step count
+
+**Mode:** TDD
+**Depends on:** none
+
+In `tools/test_build_gate_chain.py`, `test_full_step_sequence_and_namespaces`, change:
+- Comment on line 122: `"nine spawned scripts"` → `"ten spawned scripts"`
+- Assertion: `["script"] * 9` → `["script"] * 10`
+
+**Done when:** The assertion reads `["script"] * 10`.
+
+---
+
+### Task 3 — Update the test: spawned path list
+
+**Mode:** TDD
+**Depends on:** Task 2
+
+In the same test, append `"tools/validate-claude-plugin-manifests.py"` as the last entry in the `spawned` expected list.
+
+**Done when:** The list has 10 entries ending with `"tools/validate-claude-plugin-manifests.py"`.
+
+---
+
+### Task 4 — Run unit test
+
+**Mode:** Goal-based check
+**Depends on:** Tasks 1, 2, 3
+
+Run `python tools/test_build_gate_chain.py`.
+
+**Done when:** Command exits 0.
+
+---
+
+### Task 5 — Smoke the validator standalone
+
+**Mode:** Goal-based check
+**Depends on:** none (can run before gate chain wiring)
+
+Run `make build` first if `dist/claude-plugins/` is absent, then:
+`python tools/validate-claude-plugin-manifests.py`
+
+**Done when:** Command exits 0 (confirms no pre-existing manifest errors that would block build-check).
+
+---
+
+### Task 6 — Full gate
+
+**Mode:** Goal-based check
+**Depends on:** Tasks 4, 5
+
+Run `make build-check`.
+
+**Done when:** Command exits 0.

--- a/docs/specs/local-claude-manifest-validator-gate/spec.md
+++ b/docs/specs/local-claude-manifest-validator-gate/spec.md
@@ -1,0 +1,77 @@
+# Spec: local-claude-manifest-validator-gate
+
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** none
+- **Brief:** none
+- **Discovery:** none
+- **Contract:** none
+- **Shape:** mixed
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+Mode: light (no risk trigger fired)
+
+## Objective
+
+`tools/validate-claude-plugin-manifests.py` exists and is used by
+`.github/workflows/publish-claude-plugins.yml` as a CI gate before publishing.
+It is not wired into the local `make build-check` chain, so a malformed
+manifest can only be caught by the publish CI run — not during local development.
+
+This spec wires `validate-claude-plugin-manifests.py` into the `build_check`
+function in `tools/build_gate_chain.py` as the final script step, after
+`lint-first-value-contract`. The script's `dist/claude-plugins/` dependency is
+satisfied by the `cmd_build` step that runs earlier in the same chain.
+
+The fix touches: `tools/build_gate_chain.py` (source) and
+`tools/test_build_gate_chain.py` (test — count 9→10 and add path to expected
+spawned list).
+
+## Boundaries
+
+### Always do
+
+- Add `_script_step("validate-claude-plugin-manifests", "tools", "validate-claude-plugin-manifests.py")` as the last entry in the `steps` list inside `build_check`.
+- Update `test_full_step_sequence_and_namespaces` in `tools/test_build_gate_chain.py`: change `["script"] * 9` to `["script"] * 10`, and append `"tools/validate-claude-plugin-manifests.py"` to the `spawned` expected list.
+- Update the comment on line 122 from "nine spawned scripts" to "ten spawned scripts".
+
+### Ask first
+
+- Any change to the order of existing script steps.
+
+### Never do
+
+- Change the validator script itself (`tools/validate-claude-plugin-manifests.py`).
+- Remove the validator from `publish-claude-plugins.yml`.
+- Add build-check wiring to the Makefile (the chain already handles it).
+
+## Testing Strategy
+
+**TDD** — the existing `BuildCheckChainTest.test_full_step_sequence_and_namespaces`
+in `tools/test_build_gate_chain.py` asserts both the step count and the ordered
+list of spawned script paths. Updating those assertions and confirming the test
+passes is the primary gate.
+
+Secondary gate: `make build-check` exits 0 end-to-end, proving the validator
+runs without error in a real chain execution.
+
+## Acceptance Criteria
+
+- [x] **AC1.** `tools/build_gate_chain.py` `build_check` function includes
+  `_script_step("validate-claude-plugin-manifests", "tools", "validate-claude-plugin-manifests.py")`
+  as the last entry in its `steps` list.
+- [x] **AC2.** `tools/test_build_gate_chain.py` `test_full_step_sequence_and_namespaces`
+  expects `["script"] * 10` (was 9) and includes `"tools/validate-claude-plugin-manifests.py"`
+  as the last element of the `spawned` expected list.
+- [x] **AC3.** `python tools/test_build_gate_chain.py` exits 0.
+- [x] **AC4.** `make build-check` exits 0.
+
+## Assumptions
+
+- Technical: `cmd_build` runs before the script steps in `build_check`, so `dist/claude-plugins/` is guaranteed to exist when `validate-claude-plugin-manifests.py` runs (source: `build_gate_chain.py` step order verified by reading the file).
+- Technical: `validate-claude-plugin-manifests.py` returns 1 if `dist/claude-plugins/` does not exist (line 37: `return 1`), so even if `cmd_build` somehow failed silently the validator will fail fast rather than producing a false pass.
+- Technical: the `_script_step` wrapper spawns `[sys.executable, <path>]` with `check=False`, matching the existing Windows-clean pattern — no new platform concerns introduced.
+- Technical: `validate-claude-plugin-manifests.py` hardcodes `REPO_ROOT/dist/claude-plugins` as its input directory (line 23). This is correct for the default `--output-dir=dist` but would produce a spurious failure or stale-dist false-pass if `build-check --output-dir=<other>` were used. The coupling is intentional (the validator is not parametrised); it is documented here so it is not mistaken for a general guarantee. The default is the only supported mode for this gate.

--- a/tools/build_gate_chain.py
+++ b/tools/build_gate_chain.py
@@ -12,6 +12,8 @@ in one command on any platform:
                                                      # -> spec-status (self-test+lint)
                                                      # -> brief-coverage (self-test+lint)
                                                      # -> traceability (self-test+lint)
+                                                     # -> first-value-contract (self-test+lint)
+                                                     # -> validate-claude-plugin-manifests
 
 **Why it lives in `tools/`, not the shipped `agentbundle` package.** It
 orchestrates *this repo's* gates: `build-check` spawns repo-native scripts —
@@ -125,9 +127,10 @@ def build_check(args: argparse.Namespace) -> int:
 
     lint-packs → build → check → pre-pr-catalogue → lint-spec-status
     (self-test + lint) → brief-coverage (self-test + lint) → traceability
-    (self-test + lint), in that order. The
-    SAST leg is intentionally omitted (Semgrep has no Windows support and is
-    conditional) — it stays Makefile-appended after this chain.
+    (self-test + lint) → first-value-contract (self-test + lint) →
+    validate-claude-plugin-manifests, in that order. The SAST leg is
+    intentionally omitted (Semgrep has no Windows support and is conditional)
+    — it stays Makefile-appended after this chain.
     """
     packs_dir = args.packs_dir
     steps: list[Step] = [
@@ -168,6 +171,7 @@ def build_check(args: argparse.Namespace) -> int:
         ),
         _script_step("test-lint-first-value-contract", "tools", "test-lint-first-value-contract.py"),
         _script_step("lint-first-value-contract", "tools", "lint-first-value-contract.py"),
+        _script_step("validate-claude-plugin-manifests", "tools", "validate-claude-plugin-manifests.py"),
     ]
     return _run_chain(steps)
 
@@ -188,7 +192,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     bc = sub.add_parser(
         "build-check",
-        help="lint-packs, build, check, pre-pr-catalogue, spec-status, brief-coverage, traceability (no SAST).",
+        help="lint-packs, build, check, pre-pr-catalogue, spec-status, brief-coverage, traceability, first-value-contract, validate-claude-plugin-manifests (no SAST).",
     )
     bc.add_argument("--packs-dir", default="packs")
     bc.add_argument(

--- a/tools/test_build_gate_chain.py
+++ b/tools/test_build_gate_chain.py
@@ -119,10 +119,10 @@ class BuildCheckChainTest(unittest.TestCase):
             rc = gc.build_check(args)
 
         self.assertEqual(rc, 0)
-        # Handlers first three, then nine spawned scripts — Makefile order, no SAST.
+        # Handlers first three, then ten spawned scripts — Makefile order, no SAST.
         self.assertEqual(
             order,
-            ["lint-packs", "build", "check"] + ["script"] * 9,
+            ["lint-packs", "build", "check"] + ["script"] * 10,
         )
 
         self.assertEqual(ns_by_label["lint-packs"].packs_dir, "packs")
@@ -135,7 +135,7 @@ class BuildCheckChainTest(unittest.TestCase):
         self.assertEqual(check_ns.packs_dir, "packs")
         self.assertEqual(check_ns.output_dir, ".")  # working tree, not dist
 
-        # The nine spawned scripts, in Makefile order.
+        # The ten spawned scripts, in Makefile order.
         spawned = [Path(argv[1]).as_posix() for argv in script_argvs]
         self.assertEqual(
             spawned,
@@ -149,6 +149,7 @@ class BuildCheckChainTest(unittest.TestCase):
                 ".claude/skills/work-loop/scripts/lint-traceability.py",
                 "tools/test-lint-first-value-contract.py",
                 "tools/lint-first-value-contract.py",
+                "tools/validate-claude-plugin-manifests.py",
             ],
         )
 


### PR DESCRIPTION
## Summary

- Adds `tools/validate-claude-plugin-manifests.py` as the 10th and final step in `build_gate_chain.py`'s `build_check` function
- Malformed `dist/claude-plugins/*.claude-plugin/plugin.json` manifests and `marketplace.json` are now caught locally rather than only at publish-time CI
- Updates unit test: step count 9 → 10, expected spawned-path list extended, comment updated
- Updates module docstring, `build_check` docstring, and subparser help to enumerate the new step
- Notes the default-output-dir-only coupling in spec Assumptions

**Why:** `validate-claude-plugin-manifests.py` ran only in `publish-claude-plugins.yml` CI; this wires it into the local `make build-check` chain. The `dist/claude-plugins/` dependency is satisfied by the `cmd_build` step that runs earlier in the same chain.

_Supersedes #621 (closed due to GitHub force-push/CI retrigger issue)._

## Test plan

- [x] `python tools/test_build_gate_chain.py` exits 0 (8 tests pass)
- [x] `python tools/validate-claude-plugin-manifests.py` exits 0 (20 manifests pass)
- [x] `make build-check` exits 0
- [x] Adversarial reviewer: Concerns addressed (test comment, docstrings, output-dir coupling documented)