### PR TITLE
refactor(agentbundle): extract resolve_state_path; migrate diff/uninstall/upgrade

### DIFF
--- a/docs/specs/atlassian-sso-cookie-selector-integration-test/spec.md
+++ b/docs/specs/atlassian-sso-cookie-selector-integration-test/spec.md
@@ -1,0 +1,92 @@
+# Spec: atlassian-sso-cookie-selector-integration-test
+
+- **Status:** Approved
+- **Owner:** eugenelim
+- **Constrained by:** `atlassian-sso-cookie` (parent spec, Shipped; AC13 asserted the selector; tests for each component exist; the wiring is the gap)
+- **Brief:** none
+- **Contract:** none
+- **Shape:** quality
+
+Mode: light (named selector extraction + three tests; no new module boundary, no security-surface change, no public interface exposed)
+
+> **Spec contract:** this document defines what "done" means. The implementing PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+Close the coverage gap on the `_run()` / `main_async()` auth selector branch in `jira.py` and `crawl_space.py`. The three selector cases — config absent → token path; `auth_default = "sso-cookie"` + valid config → cookie path; malformed config → `EXIT_USER_ACTION` — are each unit-tested at the component level (`test_sso_config.py`, `test_sso_client.py`), but the wiring itself is untested. Driving `_run()` or `main_async()` from a test requires importing a module designed for `python <script>` invocation: its bootstrap block (`if __package__ in (None, "") and __spec__ is None:`) sets `__package__` only under script invocation, causing the relative imports (`from ._client import …`) to fail when pytest imports the file normally.
+
+The fix is a targeted extraction: add a directly-testable `_select_auth_path(config_path=None)` function to `_sso_config.py` in both atlassian skills (jira and confluence-crawler), have `_run()` and `main_async()` delegate to it, and add three integration tests covering the three selector outcomes. Because `_sso_config.py` uses only absolute imports, it is already importable from tests. No new module boundary, no wait for a CLI import-safe seam.
+
+## Acceptance Criteria
+
+- [ ] **AC1.** `_select_auth_path(config_path: Path | None = None) -> tuple[str, SsoConfig | None]` exists in `_sso_config.py` in **both** jira/ and confluence-crawler/ `scripts/`. The function:
+  - Returns `("token", None)` when `load_sso_config(config_path)` returns `None` (config absent or `auth_default = "creds"`).
+  - Returns `("sso-cookie", sso_config)` when `load_sso_config(config_path)` returns an `SsoConfig` (valid `auth_default = "sso-cookie"` config).
+  - Propagates any exception from `load_sso_config()` without catching it — callers map this to `EXIT_USER_ACTION`.
+  - Is underscore-prefixed (internal helper, not part of any public surface).
+- [ ] **AC2.** `_run()` in `jira/scripts/jira.py` calls `_select_auth_path()` (imported from `._sso_config`) instead of calling `load_sso_config()` inline. The surrounding `try/except Exception → EXIT_USER_ACTION` block remains. The `if sso_config is not None:` branch (the current condition) is replaced by branching on the returned tuple: the `"sso-cookie"` path calls `JiraClient.from_sso_cookies(sso_config)`; the `"token"` path calls `load_credentials()` + `JiraClient(credentials, ...)`. Behavior is identical to today's code.
+- [ ] **AC3.** `main_async()` in `confluence-crawler/scripts/crawl_space.py` applies the same delegation — calls `_select_auth_path()` instead of inline `load_sso_config()`, with equivalent surrounding structure.
+- [ ] **AC4.** A new `test_auth_selector.py` file exists in **both** skills' `scripts/` directories (byte-identical per the parity constraint). The file opens with `pytest.importorskip("credbroker")` and then `from credbroker import SsoConfigError` (mirroring `test_sso_config.py:18-19`). It contains three tests:
+  - **absent → token**: `_select_auth_path(tmp_path / "no-such.toml")` returns `("token", None)`.
+  - **valid sso-cookie → sso-cookie**: `_select_auth_path(path_to_valid_fixture)` returns `("sso-cookie", <SsoConfig instance>)`.
+  - **malformed → raises**: `_select_auth_path(path_to_malformed_fixture)` raises `SsoConfigError`.
+- [ ] **AC5.** `tools/test-lint-sso-config.py`'s `_DUPLICATED` list is extended to include `"test_auth_selector.py"`, and the parity check passes (both copies byte-identical).
+- [ ] **AC6.** All existing sso-cookie tests still pass: `test_sso_config.py`, `test_sso_client.py`, `test_setup_sso.py`, `test_exit_codes.py` in both skills; `tools/test-lint-sso-config.py` passes (parity + schema-parity + upstream-file lint).
+- [ ] **AC7.** The `_ALLOWED_SSO_KEYS` set in `_sso_config.py` is unchanged (no schema drift; adding `_select_auth_path` must not cause the `lint._ALLOWED_SSO_KEYS != loader._ALLOWED_SSO_KEYS` parity check to fail).
+
+## Boundaries
+
+### Always do
+
+- Edit `_sso_config.py` in **both** skills simultaneously and keep them byte-identical — the parity gate enforces this; a one-sided edit fails the self-test.
+- When `_select_auth_path()` raises an exception, propagate it unchanged — never catch it inside the function. The caller's existing `except Exception → EXIT_USER_ACTION` is the mapping point.
+- Keep `_select_auth_path` underscore-prefixed (internal helper) and out of any `__all__` or public surface.
+- Run `python tools/test-lint-sso-config.py` before declaring done — it verifies parity, schema-set equality between the lint and the loader, and the upstream reference files.
+
+### Never do
+
+- Never widen the function signature to accept the client factory (e.g., `_from_sso_cookies=`) or make it async.
+- Never change `_ALLOWED_SSO_KEYS` or `_REQUIRED_SSO_KEYS`.
+- Never modify `sso-broker.py` or any credbroker internals.
+- Never expose `_select_auth_path` through `credbroker`'s `__all__` or any package public surface.
+
+### Ask first
+
+- Adding `_select_auth_path` to the byte-equality list for any skill beyond jira and confluence-crawler.
+- Any change to the function's return type or exception contract.
+
+## Testing Strategy
+
+All three acceptance criteria resolve to running Python tests — no goal-based prose checks, no manual QA.
+
+- **AC4 (the three new test cases)**: run `pytest test_auth_selector.py` in each skill's `scripts/` directory. Each test is deterministic and network-free.
+- **AC6 (regression)**: run the full per-skill test suites for both jira and confluence-crawler.
+- **AC5, AC7 (parity + schema-set)**: `python tools/test-lint-sso-config.py` — already part of the repo's gate.
+
+## Assumptions
+
+- Technical: `_sso_config.py` in both jira/ and confluence-crawler/ uses only absolute imports at module level and defers `from credbroker import …` to inside the `load_sso_config()` function body — this is what makes it importable from tests without the bootstrap block.
+- Technical: `tools/test-lint-sso-config.py` pins the four duplicated files in `_DUPLICATED = ("_sso_config.py", "setup_sso.py", "test_sso_config.py", "test_setup_sso.py")` and checks byte-equality between jira/ and confluence-crawler/ scripts/ for each. Adding `"test_auth_selector.py"` to this list is AC5.
+- Technical: The parity gate also checks `lint._ALLOWED_SSO_KEYS == loader._ALLOWED_SSO_KEYS`. The new `_select_auth_path()` function does not modify `_ALLOWED_SSO_KEYS`.
+- Technical: `test_sso_config.py` already imports `_sso_config` as a module (for `_sso_config._DEFAULT_CONFIG_PATH`), so a test that does `from _sso_config import _select_auth_path` will work in the same test environment.
+- Process: This is light-mode work-loop. The function introduces no new security logic, no new entry point for untrusted data, and no change to how cookies or credentials are resolved.
+
+## Tasks
+
+1. **Add `_select_auth_path()` to `_sso_config.py` (both skills, byte-identical).** The function wraps `load_sso_config(config_path)`, returning the typed two-tuple or propagating any exception. Add it immediately after `load_sso_config()` in the file.
+
+2. **Update `_run()` in `jira/scripts/jira.py`.** Replace the `from ._sso_config import load_sso_config` import with `from ._sso_config import _select_auth_path` (remove `load_sso_config` from the import to avoid an unused-import ruff F401 error). Replace the inline `load_sso_config()` call with `_select_auth_path()`, destructure the returned `(path, sso_config)` tuple, and branch on `path`.
+
+3. **Update `main_async()` in `confluence-crawler/scripts/crawl_space.py`.** Same structural change as Task 2 — replace the import and the call site. Ensure `load_sso_config` is removed from the import line.
+
+4. **Add `test_auth_selector.py` to both skills' `scripts/` directories (byte-identical).** Three test functions: `test_select_auth_path_absent_is_token`, `test_select_auth_path_valid_sso_cookie`, `test_select_auth_path_malformed_raises`.
+
+5. **Update `tools/test-lint-sso-config.py`.** Add `"test_auth_selector.py"` to `_DUPLICATED`. No other changes.
+
+6. **Run gates.** `python tools/test-lint-sso-config.py`, `pytest` over both skill suites, `make build-check`.
+
+## Declined
+
+- **Import-safe seam for `jira.py` / `crawl_space.py`.** Making those CLI entrypoints importable from pytest would require restructuring the bootstrap block — that is the follow-on "wait until CLI entrypoints gain an import-safe seam" branch. Out of scope here.
+- **`--sso-config <path>` CLI argument.** Adds a CLI surface out of scope for a quality follow-on test extraction.
+- **Extracting the full selector + client factory wiring.** Would require the helper to import from `_client.py`, bringing in the full credential/HTTP stack — a structural refactoring, not a light-mode fix.

--- a/docs/specs/catalogue-curation-qa-coverage/spec.md
+++ b/docs/specs/catalogue-curation-qa-coverage/spec.md
@@ -1,0 +1,113 @@
+# Spec: catalogue-curation-qa-coverage
+
+- **Status:** Approved
+- **Owner:** eugenelim
+- **Constrained by:** [`spec/catalogue-curation`](../catalogue-curation/spec.md) — parent spec (Shipped); this spec closes the four deferred ACs.
+- **Brief:** none
+- **Shape:** quality
+
+Mode: light (QA exercise + fixture authoring for four deferred catalogue-curation paths; no code change to the skill itself)
+
+> **Spec contract:** this document defines what "done" means. The implementing PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+The `catalogue-curation` pack shipped with four acceptance-criteria paths not yet exercised in QA, each deferred explicitly in the parent spec with a backlog slug. This spec closes those four paths:
+
+1. **`resync-rfc-routing`** — When a previously-assimilated source RFC is re-synced, the skill must route the record correctly: Amendment (Open RFC), Erratum (Frozen + genuine correction), or new RFC (Frozen + new decisions). The routing logic is implemented but was not exercised in any QA session.
+
+2. **`antipattern-steering`** — Assimilation detects known misuse patterns in ingested primitives (scripts triggering other skills, agents reviewing their own output, flooding prompts) and either reshapes or rejects, naming the anti-pattern and its correction. Not yet exercised.
+
+3. **`propose-catalogue-pack`** — Given a proposed pack area, the skill tests additivity + fit against the local CHARTER and the four CHARTER principles, scaffolds a pack shell on pass, and emits an RFC. No QA session has been run.
+
+4. **`hook-confirm`** — An ingested hook or script (executable code) is flagged distinctly and requires explicit human confirm before landing. The QA session exercised skill ingest only; the hook-ingest path was not exercised.
+
+The autonomous portion of this work — authoring fixture files and documenting expected-behavior transcripts — can be done without a live session. The QA sessions themselves require a human operator running the skills interactively. This spec owns both: fixture authoring (implementable autonomously) and the QA session gate (requires human confirmation).
+
+## Acceptance Criteria
+
+### Autonomous: fixture preparation
+
+- [ ] **AC1 (`antipattern-steering` fixtures).** At least three fixture primitives exist under `docs/specs/catalogue-curation-qa-coverage/fixtures/antipatterns/`, each representing a known misuse pattern:
+  - `skill-triggers-skill.md` — a skill that directly invokes another skill by name (scripts-triggering-skills pattern)
+  - `agent-reviews-own-output.md` — an agent skill whose SKILL.md instructs the agent to review its own output
+  - `flooding-prompt.md` — a skill with an excessively verbose or repetitive prompt that floods context without value
+  Each fixture is a realistic, ingestible primitive exhibiting the misuse pattern only — shaped like a real skill/agent file a curator would encounter (frontmatter + SKILL.md body). The `## Why this is rejected` and `## Reshaped form` analysis belongs in `notes/antipattern-steering.md` (AC3), not in the fixture files themselves. This separation ensures AC5's live QA session exercises real detection, not fixture-embedded answers.
+
+- [ ] **AC2 (`hook-confirm` fixture).** A fixture hook file exists under `docs/specs/catalogue-curation-qa-coverage/fixtures/hook-confirm/` that represents a realistic hook that would trigger during ingest:
+  - `sample-hook.sh` — a bash hook that runs on git pre-commit (or equivalent agent event)
+  - `sample-hook-notes.md` — documents what the hook does, why it requires explicit operator confirm, and what the expected confirm prompt should look like.
+
+- [ ] **AC3 (expected-behavior transcripts).** A `notes/` directory contains one transcript-capture document per deferred path:
+  - `notes/resync-rfc-routing.md` — documents the three routing cases (Open → Amendment, Frozen+correction → Erratum, Frozen+new → new RFC) with example inputs and expected skill outputs for each case.
+  - `notes/antipattern-steering.md` — documents the three anti-pattern cases with example inputs, expected detection messages, and expected corrective re-shaping outputs.
+  - `notes/propose-pack.md` — documents the additivity+fit test flow with a sample pack proposal, the scaffold output, and the RFC template the skill would produce.
+  - `notes/hook-confirm.md` — documents the hook-ingest flow: detection trigger, confirm prompt text, post-confirm landing path.
+
+### Human-gated: live QA sessions
+
+- [ ] **AC4 (`resync-rfc-routing` QA).** A live QA session exercises all three routing forms against the `agent-commander` RFC-0001 produced in the 2026-07-22 `assimilate-repo` QA session (the prior-QA source RFC). Session outcome is recorded as a `| Date | Skill | Exercise | Outcome |` row in `docs/specs/catalogue-curation/spec.md`'s QA log table (matching the existing table column format exactly).
+
+- [ ] **AC5 (`antipattern-steering` QA).** A live QA session runs assimilation against at least one of the three anti-pattern fixture files (AC1). The skill detects the pattern and either reshapes or rejects with a named reason. Session outcome recorded in parent spec QA log.
+
+- [ ] **AC6 (`propose-catalogue-pack` QA).** A live QA session runs `propose-catalogue-pack` with a real or sample pack proposal. The skill tests additivity + fit and either rejects (non-additive) or passes and scaffolds a pack shell + RFC. Session outcome recorded in parent spec QA log.
+
+- [ ] **AC7 (`hook-confirm` QA).** A live QA session ingests the `sample-hook.sh` fixture (AC2). The skill flags it as executable code, issues the confirm prompt, and — on operator confirm — lands it. Session outcome recorded in parent spec QA log.
+
+### Gate
+
+- [ ] **AC8.** Once each QA session passes (AC4–AC7), the corresponding deferred-AC item in `docs/specs/catalogue-curation/spec.md` is flipped from `- [ ] … (deferred: <slug>)` to `- [x] …` with the `(deferred: <slug>)` annotation removed. All four deferred lines must be checked before this AC is complete.
+
+- [ ] **AC9.** The four backlog slugs (`catalogue-curation-resync-rfc-routing`, `catalogue-curation-antipattern-steering`, `catalogue-curation-propose-pack`, `catalogue-curation-hook-confirm`) are removed from `workspace.toml [backlog].open` in the same PR that flips the parent spec checkboxes (AC8). Leaving them in the register after the work is done creates the same drift the parent spec closure is meant to resolve.
+
+## Boundaries
+
+### Always do
+
+- Keep all fixture files under `docs/specs/catalogue-curation-qa-coverage/fixtures/` — not under `packs/` (fixtures are spec support material, not pack assets).
+- Record every QA session outcome in the parent spec's QA log, not in this spec.
+- Mark AC4–AC7 as done only after a human operator has confirmed the session ran and passed.
+
+### Never do
+
+- Modify the `catalogue-curation` skill source (`packs/core/.apm/skills/catalogue-curation/`) as part of this spec — if a QA session reveals a bug, open a separate bug PR.
+- Auto-invoke `propose-catalogue-pack` from `assimilate-repo` (existing Never-do from parent spec).
+- Invent fictional QA session outcomes — AC4–AC7 require real runs.
+
+### Ask first
+
+- Adding a fourth anti-pattern fixture type beyond the three specified.
+- Changing the fixture format if the skill's ingest format has evolved since the parent spec shipped.
+
+## Testing Strategy
+
+- **AC1–AC3 (fixtures + transcripts):** Goal-based — files exist and contain the required sections. Verification: `ls docs/specs/catalogue-curation-qa-coverage/fixtures/antipatterns/`, `ls fixtures/hook-confirm/`, `ls notes/`, spot-check headers.
+- **AC4–AC7 (live QA):** Manual QA — human operator runs each skill path; records outcome. Not automatable; the QA session is the verification.
+- **AC8 (parent spec checkboxes):** Goal-based two-part check: (1) `grep "deferred: catalogue-curation" docs/specs/catalogue-curation/spec.md` returns zero matches (all four `(deferred: <slug>)` annotations removed); (2) manually verify in the PR diff that each of the four affected lines now shows `- [x]` (checkbox flipped). Both parts must pass — part 1 confirms annotation removal; part 2 confirms the flip happened.
+- **AC9 (register cleanup):** Goal-based — `grep "catalogue-curation-resync-rfc-routing\|catalogue-curation-antipattern-steering\|catalogue-curation-propose-pack\|catalogue-curation-hook-confirm" workspace.toml` returns no matches. Each backlog entry's preceding comment block (the explanatory `# …` lines immediately above the `{slug = "…"}` line) is removed alongside the slug line — leaving stale comment blocks is the same drift AC9 exists to prevent.
+
+## Assumptions
+
+- Technical: The four deferred AC paths are implemented in the shipped `catalogue-curation` skill — the QA sessions exercise existing code, not new code. (Source: parent spec QA log, read 2026-07-23.)
+- Technical: `docs/specs/catalogue-curation-qa-coverage/fixtures/antipatterns/` and `fixtures/hook-confirm/` directories were created in a prior session — verify before creating.
+- Process: The parent spec's QA log table format is `| Date | Skill | Exercise | Outcome |` (four columns, no separate PASS/FAIL column — the Outcome cell carries PASS/FAIL). Follow this exactly when recording new sessions.
+- Process: AC4–AC7 require human in the loop; they cannot be completed autonomously in an unattended run.
+- Process: The parent spec (`docs/specs/catalogue-curation/spec.md`) is Shipped (Frozen). Editing its body to flip deferred-AC checkboxes and append QA-log rows is the sanctioned closure mechanism for deferred ACs — these are the defined update surfaces (Status field + spec body for QA-log rows) rather than general-purpose body edits. The four deferred ACs were explicitly marked `(deferred: <slug>)` to be closed by this follow-on spec; flipping them is the intended resolution path.
+
+## Tasks
+
+1. **Author anti-pattern fixtures** (AC1) — Write `fixtures/antipatterns/skill-triggers-skill.md`, `agent-reviews-own-output.md`, `flooding-prompt.md` as realistic ingestible primitives (no answer-key sections in the fixture files).
+   - **Depends on:** none
+2. **Author hook fixture** (AC2) — Write `fixtures/hook-confirm/sample-hook.sh` and `sample-hook-notes.md`.
+   - **Depends on:** none
+3. **Author expected-behavior transcripts** (AC3) — Write `notes/resync-rfc-routing.md`, `notes/antipattern-steering.md`, `notes/propose-pack.md`, `notes/hook-confirm.md`. The antipattern notes include the `## Why this is rejected` and `## Reshaped form` analysis (the answer key that must not appear in the fixture files).
+   - **Depends on:** none
+4. **Live QA sessions** (AC4–AC7) — Human-in-loop; depends on Tasks 1–3 being complete. Each session is a separate step.
+   - **Depends on:** Tasks 1–3
+5. **Mark parent spec ACs and clean register** (AC8, AC9) — Flip the four deferred lines in `docs/specs/catalogue-curation/spec.md` to `- [x]` (removing `(deferred: …)` annotation); remove the four slugs and their preceding comment blocks from `workspace.toml [backlog].open`.
+   - **Depends on:** Task 4
+
+## Declined
+
+- Automated regression tests for the four paths — these are human-judgment paths (routing decisions, anti-pattern detection, CHARTER fit assessment, hook risk evaluation); the QA session is the right verification modality.
+- Merging the four deferred paths into a single QA session — separate sessions give cleaner records and avoid conflating outcomes.

--- a/docs/specs/credbroker-security-hardening/plan.md
+++ b/docs/specs/credbroker-security-hardening/plan.md
@@ -1,0 +1,132 @@
+# Plan: credbroker-security-hardening
+
+> This plan is the implementation strategy. The contract is [`spec.md`](spec.md).
+
+## Approach
+
+Three tasks that can run in parallel (D3 AST walk, shim path anchor, and test parametrisation have no shared edits). T4 runs final gates after all three are done. D3 has the highest security impact and the most verification overhead (TDD with bypass-proof fixtures). The shim path anchor is a pure function guard with two unit tests. The test parametrisation is purely additive.
+
+## Design (LLD)
+
+### D3: `_check_dotfile_read`
+
+```python
+def _check_dotfile_read(py_path: Path) -> list[tuple[int, str]]:
+    """Walk AST, return (lineno, desc) for each dotfile-read call site."""
+    source = py_path.read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+    lines = source.splitlines()
+    findings = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if isinstance(node.func, ast.Name) and node.func.id == "open":
+            if node.args:
+                arg = node.args[0]
+                result = _path_chain_components(arg)
+                if result and _is_dotfile_chain(result):
+                    lineno = node.lineno
+                    if OPTOUT_MARKER not in lines[lineno - 1]:
+                        findings.append((lineno, "open() reads dotfile credentials"))
+        elif isinstance(node.func, ast.Attribute) and node.func.attr in {"read_text", "read_bytes"}:
+            result = _path_chain_components(node.func.value)
+            if result and _is_dotfile_chain(result):
+                lineno = node.lineno
+                if OPTOUT_MARKER not in lines[lineno - 1]:
+                    findings.append((lineno, f".{node.func.attr}() reads dotfile credentials"))
+    return findings
+
+def _is_dotfile_chain(result) -> bool:
+    _, components = result
+    return (len(components) >= 2
+            and components[-2] == DOTFILE_PARENT
+            and components[-1] == DOTFILE_BASENAME)
+```
+
+Replace the substring-scan block (lines 908–925) in `lint_credentialed_skills.py` with a call to `_check_dotfile_read(py_path)`.
+
+### `_is_canonical_shim` path anchor
+
+```python
+def _is_canonical_shim(py: pathlib.Path) -> bool:
+    if py.parent.name not in {"scripts", "shared-libs"}:  # ADD FIRST
+        return False
+    # ... existing byte-equality check ...
+```
+
+### `_load_cli_module` helper
+
+```python
+def _load_cli_module(py_path: pathlib.Path) -> types.ModuleType:
+    import importlib.util, sys
+    spec = importlib.util.spec_from_file_location("_loaded_module", py_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(py_path.parent))
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.pop(0)
+    return module
+```
+
+## Tasks
+
+### T1 — Rewrite D3 dotfile-read check as AST walk
+
+**Depends on:** none
+**Mode:** TDD (AC1–AC5)
+
+Write TDD fixtures first:
+- Fixture for AC2: inline part-composition `(Path.home() / ("." + "agentbundle") / ("credentials" + ".env")).read_text()` — verify it has no literal `.agentbundle/credentials.env` substring (AC2(a)), then confirm AST walk catches it.
+- Fixture for AC3: inline `.read_bytes()` form `(Path.home() / ".agentbundle" / "credentials.env").read_bytes()`.
+
+Then implement `_check_dotfile_read()` and `_is_dotfile_chain()`. Replace the substring-scan block with the AST walk.
+
+**Verification:**
+- `python3 tools/test-lint-credentialed-skills.py` exits 0 (AC1, AC4, AC5 regression)
+- New test cases for AC2 (bypass fixture) and AC3 (read_bytes) pass
+- `assert ".agentbundle/credentials.env" not in ac2_fixture_source` (AC2(a) inline assertion)
+
+### T2 — Add `_is_canonical_shim` path anchor
+
+**Depends on:** none (parallel with T1)
+**Mode:** Unit/TDD (AC6, AC7, AC8)
+
+Add `py.parent.name not in {"scripts", "shared-libs"}` early-return to `_is_canonical_shim`.
+
+**Verification:**
+- Unit test: canonical bytes at `arbitrary/credentials_shim.py` → `False` (AC7)
+- Unit test: canonical bytes at `scripts/credentials_shim.py` → `True` (AC8a)
+- Unit test: canonical bytes at `shared-libs/credentials_shim.py` → `True` (AC8b)
+- `python3 tools/test-lint-credentialed-skills.py` exits 0 (AC6/AC8 regression)
+
+### T3 — Add `_load_cli_module()` and parametrise integration tests
+
+**Depends on:** none (parallel with T1/T2)
+**Mode:** Integration (AC9, AC10, AC11)
+
+Add `_load_cli_module()` helper. Parametrise `broker` fixture in `test_sso_broker_verbs.py` over source + projected paths. Add projected-path variant to `test_entry_point_imports_resolve_under_user_scope_layout`.
+
+**Verification:**
+- `pytest packages/agentbundle/tests/unit/test_sso_broker_verbs.py` passes (AC10)
+- `pytest packages/agentbundle/tests/integration/test_credential_user_scope_invocation.py` passes (AC11)
+- If `dist/apm/` absent, projected variants report skip (not error)
+
+### T4 — Gate verification
+
+**Depends on:** T1, T2, T3
+**Mode:** Goal-based (AC12–AC16)
+
+Run all gates in order (AC13 must run before AC15 — `make build-self` produces the `dist/apm/` projected copies that AC11's projected variant checks; without it, AC11's projected parametrisation will always skip):
+1. `make build-self FORCE=1` → exits 0 (AC13 prerequisite for projected test variants)
+2. `git status --short` → shows no changes (AC13)
+3. `python3 tools/hooks/pre-pr.py` → exits 0 (AC14)
+4. `pytest packages/agentbundle/tests/ -x` → exits 0 (AC15; projected variants now have build output to test against)
+5. `python3 tools/test-lint-credentialed-skills.py` → exits 0 (AC16)
+
+## Changelog
+
+- 2026-07-23: Initial plan authored.

--- a/docs/specs/credbroker-security-hardening/spec.md
+++ b/docs/specs/credbroker-security-hardening/spec.md
@@ -1,0 +1,150 @@
+# Spec: credbroker-security-hardening
+
+- **Status:** Approved
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** `credential-broker-contract` spec (round-4 security review, Concerns 1 and 4 deferred)
+
+Mode: full (security boundary — credbroker test hardening)
+
+> **Spec contract:** this document defines what "done" means. The implementing PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+Close three deferred security-hardening items recorded in the `credential-broker-contract` spec's 2026-05-26 Changelog (round-4 security review, Concerns 1 and 4 — deferred by that PR, unblocked now):
+
+**D3 — substring scan is bypassable.** The dotfile-read detection in `tools/lint_credentialed_skills.py` (lines 908–925) is a line-by-line substring scan for `.agentbundle/credentials.env`. A consumer that constructs the path from concatenated string fragments — e.g. `Path.home() / (".agent" + "bundle") / ("credentials" + ".env")` then calls `.read_text()` — opens the dotfile without the literal substring `.agentbundle/credentials.env` ever appearing on any single source line. The fix rewrites D3 as an AST walk over `open()`, `.read_text()`, and `.read_bytes()` call sites, using the existing `_path_chain_components()` helper (already in the file) to reconstruct part-composed path chains before matching.
+
+**`_is_canonical_shim` — exemption is not path-anchored.** The current shim exemption (`_is_canonical_shim`) grants bypass treatment to any file whose basename is in `SHIM_BASENAMES` and whose bytes match the canonical source. This means a file named `credentials_shim.py` at an arbitrary location in the repo tree (e.g. `packs/evil-pack/.apm/some-dir/credentials_shim.py`) would be exempt if it carries canonical bytes — even though the build pipeline never places files in such a location. The fix adds a path-anchor requirement: the file must reside inside a directory named `scripts` (consumer skill projection target) or `shared-libs` (canonical source directory) for the exemption to apply. Byte-equality is kept as a secondary check.
+
+**`_load_cli_module()` — integration tests load from pack source only.** The SSO broker verb tests (`test_sso_broker_verbs.py`) load the broker exclusively from the pack source path. The user-scope invocation tests (`test_credential_user_scope_invocation.py`) stage consumer skills exclusively from the pack source. Neither test suite exercises the projected copies that `make build-self` emits (in `dist/apm/`) or that `agentbundle install` places in `~/.agentbundle/bin/`. The fix introduces a `_load_cli_module(path)` staging helper and parametrises affected tests over both the source path and the projected path, with `pytest.skip` when the projected copy is absent (unbuilt checkout).
+
+## Acceptance Criteria
+
+### D3: AST walk for dotfile-read detection
+
+- [ ] **AC1 (D3 — implementation):** The dotfile-read check in `tools/lint_credentialed_skills.py` is rewritten from a line-by-line substring scan to an AST walk implemented as a helper `_check_dotfile_read(py_path) -> list[tuple[int, str]]`. The walk visits every `ast.Call` node and raises a finding when: (a) the call is `open(<arg>)` (i.e. `func` is `ast.Name` with `id == "open"`) and the first positional argument resolves to the dotfile path; OR (b) the call is `<expr>.read_text(...)` or `<expr>.read_bytes(...)` (i.e. `func` is `ast.Attribute` with `attr` in `{"read_text", "read_bytes"}`) and the object expression `func.value` resolves to the dotfile path. Path resolution uses the existing `_path_chain_components()` helper; a finding is raised when the resolved components' last two entries match `(DOTFILE_PARENT, DOTFILE_BASENAME)` in order. The opt-out marker check is applied by reading the corresponding source line at the reported `lineno` and suppressing the finding when `OPTOUT_MARKER` appears on that line.
+
+- [ ] **AC2 (D3 — part-composition bypass caught):** A new test case in `tools/test-lint-credentialed-skills.py` supplies a fixture script that uses inline part-composition (fully inline in the method call, so `_path_chain_components()` can resolve it):
+  ```python
+  (Path.home() / ("." + "agentbundle") / ("credentials" + ".env")).read_text()
+  ```
+  The fixture verifies: (a) that no line in the fixture source contains `.agentbundle/credentials.env` as a contiguous substring (proving the old substring scan would miss it); and (b) the new AST walk catches the `.read_text()` call and reports a finding with the call's lineno. Note: `_path_chain_components()` resolves inline `BinOp(Add)` string concatenation within `BinOp(Div)` path chains, but cannot resolve identifiers bound to intermediate variables — the fixture must use the fully-inline form.
+
+- [ ] **AC3 (D3 — `Path.read_bytes()` form caught):** A second test case supplies a fixture script using the inline `.read_bytes()` form:
+  ```python
+  (Path.home() / ".agentbundle" / "credentials.env").read_bytes()
+  ```
+  The AST walk catches the `.read_bytes()` call on the inline-constructed path and reports a finding. (The cross-variable-assignment form — binding the path to a name then calling `.read_bytes()` on the name — is explicitly Declined; this AC covers the inline form only.)
+
+- [ ] **AC4 (D3 — opt-out still works):** The existing test case `dotfile-read-with-opt-out-allowed` continues to pass under the rewritten D3 check: a skill whose dotfile-read call is on the same line as `# credentialed-primitive: reads-creds-directly` exits the lint clean.
+
+- [ ] **AC5 (D3 — existing `dotfile-read-refused` test still passes):** The existing `dotfile-read-refused` case (a bare `open('.agentbundle/credentials.env').read()` call on one line) continues to be caught by the AST walk and exits non-zero.
+
+### `_is_canonical_shim`: path-anchor
+
+- [ ] **AC6 (`_is_canonical_shim` — path anchor added):** `_is_canonical_shim(py: pathlib.Path) -> bool` adds a path-anchor check before the byte-equality comparison: the function returns `False` immediately when `py.parent.name` is not in `{"scripts", "shared-libs"}`, even if the file's bytes match the canonical source. The anchor uses `py.parent.name` (a single path segment, not a substring match) per `feedback_credentialed_lint_substring_trap`. Note: `credentials_shim.py` also ships tracked at `.agentbundle/bin/credentials_shim.py` (parent `bin`), but the lint's scan roots (`packs/*/.apm/skills/*`, `.claude/skills/*`, `skills/*`) never reach `.agentbundle/bin/`, so `bin`-projected shims are intentionally outside the scanned set and are not affected by this anchor.
+
+- [ ] **AC7 (`_is_canonical_shim` — non-canonical path not exempt):** A unit test asserts that a copy of `credentials_shim.py` placed at a non-canonical parent directory (e.g. `some-pack/arbitrary/credentials_shim.py` where `parent.name == "arbitrary"`) returns `False` from `_is_canonical_shim` even when its bytes match the canonical source byte-for-byte.
+
+- [ ] **AC8 (`_is_canonical_shim` — canonical paths remain exempt):** A unit test asserts that `credentials_shim.py` under a `scripts/` parent and under a `shared-libs/` parent (with matching canonical bytes) each return `True`.
+
+### `_load_cli_module()`: parametrised integration tests
+
+- [ ] **AC9 (`_load_cli_module` helper added):** A helper `_load_cli_module(py_path: pathlib.Path) -> types.ModuleType` is added to the credbroker test suite (either as a module-level function in a new `packages/agentbundle/tests/unit/test_credbroker_lint_hardening.py` or as a shared helper imported from a new `packages/agentbundle/tests/_credbroker_helpers.py`). The implementation loads the file via `importlib.util.spec_from_file_location` with the file's directory prepended to `sys.path` for the duration of the load (the same pattern as the existing `_load_broker_module()` in `test_sso_broker_verbs.py`).
+
+- [ ] **AC10 (SSO broker verb tests — source + projected parametrisation):** The `broker` fixture in `packages/agentbundle/tests/unit/test_sso_broker_verbs.py` is parametrised over two paths:
+  - **source**: `packs/credential-brokers/.apm/adapter-root-bins/sso-broker.py` (existing behavior)
+  - **projected**: `REPO_ROOT / ".agentbundle" / "bin" / "sso-broker.py"` (the `make build-self` output in this checkout)
+
+  The projected variant uses `pytest.skip(f"{path} not present — run make build-self")` when the file is absent. Both variants must pass when the projected file exists.
+
+- [ ] **AC11 (user-scope invocation tests — source + projected parametrisation):** The `test_entry_point_imports_resolve_under_user_scope_layout` parametrisation in `packages/agentbundle/tests/integration/test_credential_user_scope_invocation.py` gains a second staging variant for each consumer skill:
+  - **source**: `packs/<pack>/.apm/skills/<skill>/scripts/` (existing `PACKS / skill_relpath` staging — unchanged)
+  - **projected**: `dist/apm/<pack>/.apm/skills/<skill>/scripts/` (the `make build-self` output)
+
+  The projected variant uses `pytest.skip` when `dist/apm/` is absent or the specific skill path does not exist. Both variants must pass when built. Note: `dist/` is gitignored, so the projected variant always skips in CI unless `make build-self` runs first; AC13 (`make build-self FORCE=1`) must be run before AC15 (`pytest`) in the same gate pass to give the projected variant a non-absent `dist/apm/` to test against (see `plan.md` T4 ordering).
+
+- [ ] **AC12 (all existing tests pass):** All test cases that existed before this PR continue to pass. No existing test may be deleted or have its assertions weakened to satisfy this spec.
+
+### Gates
+
+- [ ] **AC13:** `make build-self FORCE=1 && git status --short` shows no changes on the merged tree.
+- [ ] **AC14:** `python3 tools/hooks/pre-pr.py` exits 0.
+- [ ] **AC15:** `pytest packages/agentbundle/tests/ -x` exits 0 on the merged tree.
+- [ ] **AC16:** `python3 tools/test-lint-credentialed-skills.py` exits 0 on the merged tree.
+
+## Boundaries
+
+### Always do
+
+- **New checks land with a failing fixture.** Each new D3 test case (AC2, AC3) must be verified to produce no finding under the old substring scan before showing the finding under the new AST walk. This asymmetry is the load-bearing proof that the bypass existed.
+- **Path checks use `pathlib` parts, not substring matching.** The `_is_canonical_shim` path anchor uses `py.parent.name in {"scripts", "shared-libs"}` — a single-segment comparison via Python's standard attribute, not a string `in` substring check. This is consistent with `feedback_credentialed_lint_substring_trap`.
+- **AST walk reuses `_path_chain_components()`.** Do not re-implement path chain resolution for D3; reuse the existing helper that already handles `BinOp(Add)` part-composition inside `BinOp(Div)` path chains.
+- **Projected-path variants use `pytest.skip`, not `pytest.xfail`.** A missing projected copy is an expected state in an unbuilt checkout; `skip` is the correct disposition. `xfail` would imply the failure is a known bug.
+- **`_load_cli_module` respects the no-synthesised-import convention.** Per `feedback_test_real_invocation_not_synthesised_import`, tests that exercise verb behaviour use real `subprocess.run` invocation (as in `test_credential_user_scope_invocation.py`). `_load_cli_module` using `importlib` is appropriate only for tests that inspect the module's namespace (attribute checks) rather than drive it as a CLI.
+
+### Never do
+
+- **No changes to production pack files.** The scope is test and lint hardening only. `packs/credential-brokers/.apm/`, `packs/*/skills/*/scripts/`, consumer skill `.py` files, `pack.toml` manifests, the canonical shim sources, and `sso-broker.py` are all out of scope.
+- **No changes to `SHIM_BASENAMES` or `DOTFILE_PARENT`/`DOTFILE_BASENAME` constants.** The path anchor and AST walk use the existing named constants without widening them.
+- **Do not delete or weaken the existing byte-equality check in `_is_canonical_shim`.** The path anchor is an additional narrowing requirement; the byte-equality check remains to prevent a file at a canonical-looking path but with different bytes from being treated as canonical.
+- **No new third-party Python dependency** in `tools/lint_credentialed_skills.py` or in any new test file. The lint is stdlib-only (`ast`, `pathlib`); the tests use `pytest` and `unittest` (both already in dev dependencies).
+- **No sign-and-verify at build time.** That approach requires a key-management surface that does not exist in this repo.
+
+### Ask first
+
+- Widening `SHIM_BASENAMES` to include new filenames.
+- Adding a third canonical parent directory to the `_is_canonical_shim` path anchor.
+- Extending the D3 AST walk to track dotfile paths across variable assignments.
+
+## Testing Strategy
+
+| Behaviour | Verification mode | Why this mode |
+| --- | --- | --- |
+| D3 AST walk catches part-composition bypass | TDD — write bypass fixture first, prove old scan misses it, then write AST walk that catches it | The bypass is only proved by running the old code against the fixture and observing silence |
+| D3 AST walk catches `.read_bytes()` inline path | TDD — fixture + assertion | Same as above; different call form |
+| D3 opt-out marker still suppresses findings | Regression — existing test case, no change needed | Existing test covers it; must continue to pass |
+| `_is_canonical_shim` path anchor | Unit test — place canonical bytes at non-canonical parent, assert `False` | Pure function; deterministic over path position |
+| `_is_canonical_shim` canonical paths remain exempt | Unit test — place canonical bytes at `scripts/` and `shared-libs/`, assert `True` | Regression pin on the positive case |
+| `_load_cli_module` + SSO broker projected path | Integration — `pytest.skip` if absent, real file load if present | The projected file is real output of the build pipeline; load it as the real consumer does |
+| User-scope invocation from projected path | Integration — `pytest.skip` if `dist/apm/` absent, subprocess invocation if present | Matches the `feedback_test_real_invocation_not_synthesised_import` convention |
+
+## Assumptions
+
+- **Python ≥ 3.11** on all CI platforms (source: `packages/agentbundle/pyproject.toml`).
+- **`_path_chain_components()` resolves `BinOp(Add)` inside `BinOp(Div)` chains.** The existing helper calls `_literal_string()` on each right-hand side of the div chain; `_literal_string()` handles `BinOp(Add)` by recursion. This means `Path.home() / (".agent" + "bundle") / ("credentials" + ".env")` resolves to `(seed_kind="home", components=[".agentbundle", "credentials.env"])` — the AC2 bypass is provably caught.
+- **`dist/apm/` is the `make build-self` output in this checkout.** The projected path parametrisation uses `REPO_ROOT / "dist" / "apm"` as the root for projected consumer skills.
+- **`.agentbundle/bin/sso-broker.py` relative to `REPO_ROOT` is the local user-scope projection of the SSO broker.** This is confirmed by the presence of `pattaya-v2/.agentbundle/bin/sso-broker.py` in the working tree.
+- **The opt-out marker suppression check works at the AST level via lineno lookup.** After finding a Call node at a given `lineno`, the implementation reads the corresponding line from the source text to check for `OPTOUT_MARKER`.
+- **Two test roots exist.** Per `reference_agentbundle_two_test_roots`: `packages/agentbundle/tests/{unit,integration}/` and `packages/agentbundle/agentbundle/build/tests/`. The new tests go under `packages/agentbundle/tests/unit/`.
+
+## Tasks
+
+1. **D3: Rewrite dotfile-read check as AST walk** (`tools/lint_credentialed_skills.py`)
+   - Implement `_check_dotfile_read(py_path) -> list[tuple[int, str]]` using `_path_chain_components()` to detect `open()`, `.read_text()`, and `.read_bytes()` calls on the dotfile path.
+   - Replace the existing substring-scan block (lines 908–925) with a call to `_check_dotfile_read()`.
+   - Handle opt-out marker by lineno lookup.
+   - Construction tests: AC1, AC2 (bypass fixture), AC3 (read_bytes), AC4 (opt-out), AC5 (existing case).
+
+2. **`_is_canonical_shim`: add path anchor** (`tools/lint_credentialed_skills.py`)
+   - Add `py.parent.name not in {"scripts", "shared-libs"}` early-return guard in `_is_canonical_shim`.
+   - Construction tests: AC7 (non-canonical path → `False`), AC8 (canonical paths under `scripts/` and `shared-libs/` → `True`).
+
+3. **Integration: add `_load_cli_module()` and parametrise** (`packages/agentbundle/tests/unit/test_sso_broker_verbs.py`, `packages/agentbundle/tests/integration/test_credential_user_scope_invocation.py`)
+   - Add `_load_cli_module(py_path)` helper (generalises `_load_broker_module`).
+   - Parametrise `broker` fixture in `test_sso_broker_verbs.py` over source and projected SSO broker paths.
+   - Add projected-path variant to `test_entry_point_imports_resolve_under_user_scope_layout` parametrisation.
+   - Construction tests: AC9, AC10, AC11.
+
+4. **Gate verification**: confirm AC13–AC16 pass on the merged tree.
+
+## Declined
+
+- **Cross-variable assignment tracking in D3.** The bypass `dotfile = Path.home() / ".agentbundle" / "credentials.env"; dotfile.read_text()` is not caught by the AST walk. Tracking assignments across statements would require dataflow analysis. Deferred until a concrete false-negative surfaces.
+
+- **Keyword-arg `open(file=...)` form in D3.** `open(file=".agentbundle/credentials.env").read()` uses a keyword argument rather than a positional argument, so `node.args` is empty and the AST walk's `open()` branch (which reads `node.args[0]`) does not flag it. This form is out of scope — it is a second bypass pattern strictly simpler than the part-composition case this spec addresses. Deferred until a concrete false-negative surfaces.
+
+- **Sign-and-verify at build time for `_is_canonical_shim`.** Requires key-management infrastructure that doesn't exist in this repo. Path-anchoring (AC6) closes the immediate concern without new infrastructure.
+
+- **Extending projected-path parametrisation to `test_sso_broker_verbs.py` in-process verb tests.** Adding projected-path parametrisation to the full verb test matrix would multiply test count significantly with redundant coverage. AC10 covers the load-from-projected-path case for the broker.

--- a/docs/specs/projection-dry-run-governance-seeds/plan.md
+++ b/docs/specs/projection-dry-run-governance-seeds/plan.md
@@ -1,0 +1,98 @@
+# Plan: projection-dry-run-governance-seeds
+
+> This plan is the implementation strategy. The contract is [`spec.md`](spec.md).
+
+## Approach
+
+Two tasks in strict TDD order. T1 extracts `_classify_seeds` as a pure function and refactors `deliver_seeds` to call it. T2 adds seed preview to `install --dry-run`. T2 depends on T1; both are TDD tasks with compilable red stubs materialized before EXECUTE begins.
+
+**Red stubs:** Before EXECUTE begins, create:
+- `packages/agentbundle/tests/unit/test_common_classify_seeds.py` — stub with five test functions (`test_classify_seeds_absent`, `test_classify_seeds_identical`, `test_classify_seeds_differs`, `test_classify_seeds_agents_md_composition`, `test_classify_seeds_footer_excluded`, plus `test_classify_seeds_symlink_file_skipped`, `test_classify_seeds_symlink_dir_skipped`, `test_classify_seeds_no_write_invariant`). All should fail `ImportError` until T1 is complete.
+- Extend `packages/agentbundle/tests/integration/test_install_cmd.py` with three stub cases: `test_dry_run_includes_seed_create_lines`, `test_dry_run_seed_companion_line`, `test_dry_run_writes_nothing_including_seeds`. Should fail with `AssertionError` until T2 is complete.
+
+## Design (LLD)
+
+### `_classify_seeds` signature
+
+```python
+def _classify_seeds(seeds_dir: Path, root: Path) -> list[SeedDelivery]:
+    """Classify seeds without writing — same walk logic as deliver_seeds but read-only."""
+```
+
+Walk `seeds_dir` with `os.walk(followlinks=False)` (symlink-skip security invariant). For each seed file:
+- Skip `_agents-footer.md` (composition fragment, not delivered as a seed)
+- Skip symlinks (`Path.is_symlink()` check)
+- Compose `AGENTS.md` bytes from body + footer fragment when `_agents-footer.md` is present
+- Read `root / relpath` if it exists; compare bytes
+- Return `SeedDelivery(relpath=relpath, action="wrote"|"skipped"|"companion", companion_relpath=...)`
+
+No filesystem writes. No calls to `write_jailed`, `write_companion`, or `deliver_seeds`.
+
+### `deliver_seeds` refactor
+
+```python
+def deliver_seeds(seeds_dir: Path, output: Path, ...) -> list[SeedDelivery]:
+    records = _classify_seeds(seeds_dir, output)
+    for record in records:
+        if record.action == "wrote":
+            write_jailed(...)
+        elif record.action == "companion":
+            write_companion(...)
+        # "skipped" → no-op
+    return records  # full list including "skipped" records
+```
+
+Return the full list so callers (e.g. `install.py` state recorder) can record all seeds including byte-identical ones.
+
+### `install --dry-run` seed preview
+
+In `install.run`'s dry-run branch (around line 929), after the existing projection plan lines are emitted, add:
+
+```python
+if plan.scope == "repo" and seeds_dir.is_dir():
+    for record in _classify_seeds(seeds_dir, plan.root):
+        if record.action == "skipped":
+            continue
+        verb = "create" if record.action == "wrote" else "companion"
+        tier = "tier-1" if record.action == "wrote" else "tier-2"
+        path_str = record.relpath if record.action == "wrote" else f"{record.relpath} -> {record.companion_relpath}"
+        print(format_plan_line(verb, tier, path_str))
+        actions.append(verb)
+```
+
+The `summarize_plan` count at the end already uses `actions`; seed entries naturally add to the count (AC4).
+
+## Tasks
+
+### T1 — Extract `_classify_seeds` and refactor `deliver_seeds`
+
+**Depends on:** none
+**Mode:** TDD (AC7, AC9)
+
+Write red stubs (see above) first. Then implement:
+- Add `_classify_seeds(seeds_dir: Path, root: Path) -> list[SeedDelivery]` above `deliver_seeds` in `_common.py`
+- Refactor `deliver_seeds` to call `_classify_seeds(seeds_dir, output)` and drive writes from returned list; return full list to caller
+- Ensure `deliver_seeds` continues to record `"skipped"` records in state (AC9)
+
+**Done when:**
+- `test_common_classify_seeds.py` passes (8 cases: all three action types, AGENTS.md composition, footer exclusion, symlink-file skip, symlink-dir skip, no-write invariant)
+- `test_install_seed_delivery.py` passes unchanged (AC6 regression)
+- `test_scaffold_cmd.py` passes unchanged (AC6 regression — symlink-skip invariant)
+- `test_install_identical_seed_skipped` (or equivalent) asserts skipped seed is still recorded in state (AC9)
+
+### T2 — Extend `install --dry-run` to preview seeds
+
+**Depends on:** T1
+**Mode:** TDD (AC3, AC4, AC5, AC8)
+
+Write red stubs first. Then add seed preview to dry-run branch in `install.py`, guarded by `plan.scope == "repo"` and `seeds_dir.is_dir()`.
+
+**Done when:**
+- `test_dry_run_includes_seed_create_lines` passes: fresh install dry-run stdout contains `AGENTS.md`, `docs/CHARTER.md`, `docs/CONVENTIONS.md` as `create tier-1` lines
+- `test_dry_run_seed_companion_line` passes: user-edited seed shows `companion tier-2 ... -> ...` line; no companion written to disk
+- `test_dry_run_writes_nothing_including_seeds` passes: tree is byte-identical before and after dry-run
+- All existing dry-run tests in `test_install_cmd.py` pass unchanged (AC6)
+
+## Changelog
+
+- 2026-07-23: Initial plan authored (tasks extracted from spec.md).

--- a/docs/specs/projection-dry-run-governance-seeds/spec.md
+++ b/docs/specs/projection-dry-run-governance-seeds/spec.md
@@ -1,0 +1,194 @@
+# Spec: projection-dry-run-governance-seeds
+
+- **Status:** Approved
+- **Owner:** eugenelim
+- **Constrained by:** [`projection-dry-run`](../projection-dry-run/spec.md) — Never-do: "Fork, reimplement, or special-case the tier-classification logic."
+
+Mode: full (structural — extracts pure classify function; extends dry-run output)
+
+## Objective
+
+`agentbundle install --dry-run --scope repo` previews the rendered adapter
+projection but silently omits the governance seeds (AGENTS.md, docs/CHARTER.md,
+docs/CONVENTIONS.md, and the other files under `packs/<pack>/seeds/`) that a real
+repo-scope install delivers via `deliver_seeds`. An adopter reading the preview
+plan cannot tell which governance documents would be created or whose edits would
+be preserved as companions.
+
+The fix has two parts: (1) extract `deliver_seeds`' classification logic into a
+pure function `_classify_seeds(seeds_dir, root)` that returns what a real delivery
+would do without performing any write; and (2) call `_classify_seeds` from the
+`--dry-run` branch in `install.run` so the plan output includes seed entries in
+the same `<action> <tier> <path>` format as the projection entries.
+
+The predecessor spec (`projection-dry-run`) forbids forking the classifier. This
+spec satisfies that constraint: `deliver_seeds` is refactored to call
+`_classify_seeds` internally, so one piece of classification code serves both the
+real delivery path and the dry-run preview path.
+
+## Acceptance Criteria
+
+- [ ] AC1: A pure function `_classify_seeds(seeds_dir: Path, root: Path) -> list[SeedDelivery]`
+  exists in `packages/agentbundle/agentbundle/commands/_common.py`. It performs
+  no writes. It walks `seeds_dir` with the same symlink-skip and
+  composition-fragment logic as the current `deliver_seeds`, reads each seed's
+  bytes (composing `AGENTS.md` from body+footer when the footer fragment is
+  present), and returns `SeedDelivery` records with `action` set to `"wrote"`
+  (absent on disk), `"skipped"` (byte-identical), or `"companion"` (differs — Tier-2).
+- [ ] AC2: `deliver_seeds` calls `_classify_seeds` internally and drives writes
+  from its result. The real install and scaffold delivery paths produce byte-for-byte
+  identical outcomes — no behaviour change.
+- [ ] AC3: `install --dry-run --scope repo` includes seed files in the plan output.
+  Each seed is printed on a separate line using the existing `format_plan_line`
+  formatter: `create` + `tier-1` for an absent seed; `companion` + `tier-2` +
+  `<path> -> <companion>` for a user-edited seed. Byte-identical seeds (`"skipped"`)
+  produce no plan line.
+- [ ] AC4: The `summarize_plan` count at the end of the dry-run output includes
+  seed files. The count matches `create` + `companion` seed entries added to the
+  existing projection entries.
+- [ ] AC5: Running `install --dry-run --scope repo` writes nothing — no seed file,
+  no `.upstream.<ext>` companion, no `.agentbundle-state.toml`, no install marker.
+  The no-write invariant from `projection-dry-run` AC6 extends to seeds.
+- [ ] AC6: All existing dry-run integration tests in
+  `tests/integration/test_install_cmd.py`, `tests/integration/test_install_seed_delivery.py`,
+  and `tests/unit/test_scaffold_cmd.py` pass unchanged. (`test_scaffold_cmd.py` exercises the
+  symlink-skip security invariant that `_classify_seeds` must preserve.)
+- [ ] AC7: A unit test for `_classify_seeds` covers:
+  (a) seed absent on disk → `action == "wrote"`;
+  (b) seed byte-identical on disk → `action == "skipped"`;
+  (c) seed differs on disk → `action == "companion"` with the correct `companion_relpath`;
+  (d) `AGENTS.md` classified against composed bytes (body+footer), not raw seed bytes;
+  (e) `_agents-footer.md` excluded from the returned list;
+  (f) a symlinked seed file inside `seeds_dir` is not returned (symlink-skip invariant);
+  (g) a symlinked subdirectory inside `seeds_dir` is not descended into (symlink-skip invariant);
+  (h) calling `_classify_seeds(seeds_dir, root)` against a real `seeds_dir` and an empty `root`
+  writes nothing under `root` — the no-write invariant is verified by asserting `root` directory
+  is unchanged after the call.
+- [ ] AC8: A new integration test asserts that the stdout plan for a fresh
+  `install --dry-run --scope repo` includes at least `AGENTS.md`, `docs/CHARTER.md`,
+  and `docs/CONVENTIONS.md` as `create tier-1` lines, and that the tree is
+  byte-identical before and after (AC5 regression guard specific to seeds).
+- [ ] AC9: `deliver_seeds` returns the full `list[SeedDelivery]` from `_classify_seeds`
+  unchanged — including `"skipped"` records. An existing state-recording test (or a new
+  test added alongside AC7) asserts that a byte-identical seed (`action == "skipped"`)
+  is still recorded in the install state `files` map after `deliver_seeds` completes. This
+  ensures the Tier-2 companion safety is not silently dropped for seeds that were
+  already present byte-identically.
+
+## Boundaries
+
+### Always do
+
+- Keep `_classify_seeds` strictly read-only: read `seeds_dir` and `root`, return
+  `SeedDelivery` records, never touch the filesystem under `root`.
+- Call `_classify_seeds` from both `deliver_seeds` (real path) and the `--dry-run`
+  branch in `install.run` (preview path) — one classifier, two callers.
+- Reuse the existing `format_plan_line` and `summarize_plan` formatters for seed
+  plan lines. Verb mapping: `"wrote"` → `"create"` + `"tier-1"`;
+  `"companion"` → `"companion"` + `"tier-2"`; `"skipped"` → no line.
+- Guard the dry-run seed preview on `plan.scope == "repo"` and `seeds_dir.is_dir()`,
+  mirroring the real delivery guard at `install.py:1118`.
+
+### Never do
+
+- Write anything under `--dry-run`: no seed file, no `.upstream.<ext>` companion,
+  no state entry, no install marker.
+- Add a separate or parallel classification logic for seeds under `--dry-run`.
+  That would be the "forking" the predecessor spec forbids. `_classify_seeds`
+  must be the one source of truth for how seeds are classified, used identically
+  by both paths.
+- Change the observable behaviour of a non-`--dry-run` install, scaffold, or any
+  other write-path command.
+- Extend `--dry-run` to `scaffold` in this spec — out of scope.
+- Add `deliver_seeds` calls to `upgrade --dry-run` — seeds are a first-install-only
+  concern; `upgrade` never calls `deliver_seeds` today and must not start.
+- Add a new top-level directory or a new runtime dependency.
+
+### Ask first
+
+- Adding `--dry-run` to `scaffold` (a future follow-on; separate spec).
+- Changing the `SeedDelivery` action vocabulary (`"wrote"` / `"skipped"` /
+  `"companion"`) — any rename would break both paths that consume it.
+
+## Testing Strategy
+
+- **`_classify_seeds` unit test (AC7): TDD.** Write
+  `tests/unit/test_common_classify_seeds.py` before implementing the function.
+  Stub a temporary `seeds_dir` with: one seed absent from `root` (expects `"wrote"`),
+  one seed byte-identical on disk (expects `"skipped"`), one seed differing on disk
+  (expects `"companion"` with correct companion path). A case exercises AGENTS.md
+  composition (footer fragment present → composed bytes used for comparison).
+  A case confirms `_agents-footer.md` is excluded from the returned list.
+- **`deliver_seeds` regression (AC2, AC6): goal-based.** The existing
+  `tests/integration/test_install_seed_delivery.py` tests must pass without
+  modification after the refactor. Passing the existing suite is the bar.
+- **Dry-run seed preview integration (AC3, AC4, AC5, AC8): TDD.** Extend
+  `tests/integration/test_install_cmd.py`. Three cases: fresh-install preview shows
+  seeds as `create tier-1`; user-edited seed shows `companion tier-2` with no
+  companion written; byte-identical seed produces no plan line.
+
+## Assumptions
+
+- Technical: Seed relpaths (files under `seeds/` in a pack, delivered to repo root or
+  `docs/`) are disjoint from adapter-projection relpaths (files under `packs/<pack>/`
+  projected to `.claude/`, `tools/`, etc.). The two file sets do not overlap, so a seed
+  path never duplicates a projection path in the dry-run plan, and `summarize_plan` counts
+  them without double-counting. (Verified: grep of seed relpaths (`AGENTS.md`,
+  `docs/CHARTER.md`, `docs/CONVENTIONS.md`) against projection target paths confirms no
+  intersection in the current pack set.)
+- Technical: `deliver_seeds` in `_common.py` (lines 80–146) is a combined
+  classify+write function; no `_classify_seeds` exists today (read 2026-07-23).
+- Technical: the dry-run branch in `install.py` (lines 929–950) returns before
+  Step 9, so seeds are never previewed today (read 2026-07-23).
+- Technical: seeds are only delivered at repo scope, guarded by
+  `plan.scope == "repo"` at `install.py:1118` (read 2026-07-23).
+- Technical: `upgrade.py` never calls `deliver_seeds` — seeds are install-only
+  (grep confirmed 2026-07-23).
+- Technical: `scaffold.py` calls `deliver_seeds` directly; refactoring its
+  internals leaves scaffold's behaviour unchanged (`scaffold.py:56`, read 2026-07-23).
+- Technical: `safety.companion_path` is a pure path computation — no writes
+  (`safety.py:127`, read 2026-07-23).
+- Technical: `SeedDelivery.action` values (`"wrote"`, `"skipped"`, `"companion"`)
+  map cleanly to the plan verb set; `"overwrite"` does not exist in the seeds model
+  (source: `_common.py:80–146`, read 2026-07-23).
+
+## Tasks
+
+### T1 — Extract `_classify_seeds` and refactor `deliver_seeds`
+
+**Depends on:** none
+
+Write unit tests for `_classify_seeds` first (TDD, AC7). Then:
+
+- Add `_classify_seeds(seeds_dir: Path, root: Path) -> list[SeedDelivery]` above
+  `deliver_seeds` in `_common.py`. Copy the walk loop, symlink skip, fragment
+  exclusion, composition, and three-way comparison — but omit all write calls.
+  For the `"companion"` case, compute `companion_relpath` via
+  `safety.companion_path(Path(relpath)).as_posix()`.
+- Refactor `deliver_seeds` to call `_classify_seeds(seeds_dir, root)` and
+  drive writes from the returned list: `"wrote"` → `write_jailed`; `"companion"` →
+  `write_companion`; `"skipped"` → no-op. Return the full list (including `"skipped"` records) to the caller.
+
+**Done when:** unit tests pass; `test_install_seed_delivery.py` and
+`test_scaffold_cmd.py` pass unchanged.
+
+### T2 — Extend `install --dry-run` to preview seeds
+
+**Depends on:** T1
+
+Write integration tests first (TDD, AC3/AC5/AC8). Then add seed preview to
+`install.run`'s dry-run branch (around line 929), guarded by
+`plan.scope == "repo"` and `seeds_dir.is_dir()`. For each record from
+`_classify_seeds`, skip `"skipped"`, emit `format_plan_line` for `"wrote"` and
+`"companion"`, append the verb to `actions`.
+
+**Done when:** new integration tests pass; existing dry-run tests pass unchanged.
+
+## Declined
+
+- Seed preview for `scaffold --dry-run` — `scaffold` currently has no `--dry-run`
+  flag; separate feature, separate spec.
+- `"skipped"` plan lines for seeds — projection dry-run already omits no-op
+  files; consistent silence is cleaner.
+- Seed preview in `upgrade --dry-run` — seeds are not re-delivered at upgrade
+  time; if upgrade ever gains seed delivery, that spec should add the preview.

--- a/docs/specs/projection-dry-run/spec.md
+++ b/docs/specs/projection-dry-run/spec.md
@@ -74,7 +74,7 @@ before proceeding; *Never do* is a hard rule, even under time pressure.
 - Perform `--force`'s destructive cleanup (install Step 3c) under `--dry-run` —
   refuse the combination instead (see *Always do*), never silently skip *or*
   silently execute it.
-- Change the behavior of a non-`--dry-run` `install` / `upgrade` in any way.
+- Change the behavior of a non-`--dry-run` `install` / `upgrade` in any way. _(Superseded in part for `upgrade`'s non-dry-run path — see Erratum at bottom of this file.)_
 - Add a new top-level directory or a new runtime dependency.
 
 ## Testing Strategy
@@ -174,3 +174,13 @@ before proceeding; *Never do* is a hard rule, even under time pressure.
   changes no contract is spec-level, not RFC-level (source: `docs/CONVENTIONS.md`
   §3 "a new feature that fits cleanly within an existing package and doesn't
   change any interface — write a spec, not an RFC"; user confirmation 2026-06-11).
+
+<!-- Erratum 2026-07-23 — eugenelim
+  The Never-do "Change the behavior of a non-`--dry-run` `install` / `upgrade` in any way"
+  was scoped to the dry-run PR (the projection-dry-run spec). It is superseded in part by
+  `docs/specs/unify-path-jail-projection-probe/spec.md`, which adds a whole-projection pre-flight to
+  `upgrade`'s non-dry-run write loop — changing the failure mode from partial-write-then-fail
+  to probe-all-before-write. That behavioral change is intentional and in scope for the
+  follow-on refactoring spec. This erratum records the boundary revision; the Never-do
+  otherwise continues to apply to install's non-dry-run path.
+-->

--- a/docs/specs/share-scope-state-path-resolver/plan.md
+++ b/docs/specs/share-scope-state-path-resolver/plan.md
@@ -1,0 +1,128 @@
+# Plan: share-scope-state-path-resolver
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Draft
+
+## Approach
+
+Three small steps in strict TDD order. First, write the unit test for the
+not-yet-existing `resolve_state_path` helper (red). Second, add the helper to
+`_common.py` (green). Third, migrate the three call sites one file at a time,
+running the full test suite after each migration to confirm parity.
+
+The total diff: one new function (3 lines of body), one new test file (≤25
+lines), and three command files with their inline path formulas replaced by a
+single `resolve_state_path(scope, root)` call.
+
+## Constraints
+
+- `_common.py` is stdlib-only. `resolve_state_path` uses `pathlib.Path` (already
+  imported).
+- The path formulas (`".agentbundle-state.toml"` and `".agentbundle/state.toml"`)
+  must not change — these are the persisted on-disk layout.
+- No test assertion may change — the existing test suite is the regression baseline.
+
+## Design (LLD)
+
+### `resolve_state_path` signature
+
+```python
+def resolve_state_path(scope: str, root: Path) -> Path:
+    """Return the state-file Path for *scope* rooted at *root*.
+
+    ``scope == "repo"`` → ``root / ".agentbundle-state.toml"``;
+    ``scope == "user"`` → ``root / ".agentbundle" / "state.toml"``.
+    ``root`` must be the already-resolved scope root (absolute Path).
+    """
+    if scope == "user":
+        return root / ".agentbundle" / "state.toml"
+    return root / ".agentbundle-state.toml"
+```
+
+Pure, total function — no I/O, no exceptions.
+
+### Duplicated code locations (confirmed by reading source)
+
+`uninstall.py`:
+- Line 54: `state_path = root / ".agentbundle-state.toml"` — repo formula
+- Line 75: `user_state_path = user_root / ".agentbundle" / "state.toml"` — user formula
+
+`upgrade.py`:
+- Line 118: `repo_state_path = root / ".agentbundle-state.toml"` — repo formula
+- Lines 131–133: `user_state_path = user_root_resolved / ".agentbundle" / "state.toml"` — user formula
+- Lines 247–251: `state_path = root / ".agentbundle-state.toml"` in the `else` branch — repo formula (third occurrence)
+
+`diff.py`:
+- Line 60: `root / ".agentbundle-state.toml"` inline in `load_state()` call — repo formula
+- Lines 67–68: `user_root_resolved / ".agentbundle" / "state.toml"` inline in `load_state()` call — user formula
+
+## Tasks
+
+### T1 — Unit test for `resolve_state_path` (red)
+
+**Depends on:** none
+**Verification:** TDD (AC4)
+**Stub:** `packages/agentbundle/tests/unit/test_resolve_state_path.py` (materialized — fails ImportError until T2 adds the function)
+
+Write `packages/agentbundle/tests/unit/test_resolve_state_path.py`:
+- `resolve_state_path("repo", Path("/repo"))` → `Path("/repo/.agentbundle-state.toml")`
+- `resolve_state_path("user", Path("/home/alice"))` → `Path("/home/alice/.agentbundle/state.toml")`
+
+Run: must fail ImportError (function doesn't exist yet).
+
+---
+
+### T2 — Add `resolve_state_path` to `_common.py` (green)
+
+**Depends on:** T1
+**Verification:** goal-based (AC1, AC5)
+
+Add the function after the existing imports block. Run T1: must pass green.
+Verify: `grep -n "^import\|^from" _common.py` shows no new lines (AC5).
+
+---
+
+### T3 — Migrate `uninstall.py`
+
+**Depends on:** T2
+
+- Add a **function-local** `from agentbundle.commands._common import resolve_state_path` inside `run()` in `uninstall.py`. The existing `_common` imports at lines 144/244/262 are function-local to *other* functions; do not rely on module-level placement, as `uninstall.py` uses deliberate lazy imports for fast `--version` startup. The new import is inside `run()` alongside the existing scope-inference logic.
+- Line 54: `state_path = resolve_state_path("repo", root)`
+- Line 75: `user_state_path = resolve_state_path("user", user_root)`
+- Run: `pytest packages/agentbundle/tests/` focusing on uninstall tests. Must pass unchanged (AC3).
+- Verify (AC2): `grep -n '^\s*\S' uninstall.py | grep -v '^\s*#' | grep '/ "\.\(agentbundle-state\.toml\|agentbundle\)"'` → no hits.
+
+---
+
+### T4 — Migrate `upgrade.py`
+
+**Depends on:** T2
+
+- Add `resolve_state_path` to imports.
+- Line 118: `repo_state_path = resolve_state_path("repo", root)`
+- Lines 131–133: `user_state_path = resolve_state_path("user", user_root_resolved)`
+- Lines 247–251 `else` branch: `state_path = resolve_state_path("repo", root)`
+- Run upgrade tests. Must pass unchanged (AC3).
+- Verify (AC2): `grep -n '^\s*\S' upgrade.py | grep -v '^\s*#' | grep '/ "\.\(agentbundle-state\.toml\|agentbundle\)"'` → no hits on path-build lines; the `state_relpath == ".agentbundle-state.toml"` comparison at line 724 is the expected carve-out and must still be present.
+
+---
+
+### T5 — Migrate `diff.py`
+
+**Depends on:** T2
+
+- Add `resolve_state_path` to existing `_common` import.
+- Line 60: `load_state(resolve_state_path("repo", root), ...)`
+- Lines 67–68: `load_state(resolve_state_path("user", user_root_resolved), ...)`
+- Run diff tests. Must pass unchanged (AC3).
+- Verify (AC2): `grep -n '^\s*\S' diff.py | grep -v '^\s*#' | grep '/ "\.\(agentbundle-state\.toml\|agentbundle\)"'` → no hits.
+
+---
+
+### T6 — Full regression pass
+
+**Depends on:** T3, T4, T5
+
+`pytest packages/agentbundle/` green, all pre-existing tests pass (AC3).
+For each of `uninstall.py`, `upgrade.py`, `diff.py`: verify no non-comment path-build
+expressions match `/ "\.agentbundle` (excluding `#`-prefixed lines). The `state_relpath == ".agentbundle-state.toml"` comparison in `upgrade.py` is expected and does not fail this check (AC2 exception).

--- a/docs/specs/share-scope-state-path-resolver/spec.md
+++ b/docs/specs/share-scope-state-path-resolver/spec.md
@@ -117,3 +117,7 @@ See `plan.md`.
   spec (`unify-path-jail-projection-probe` covers the jail side; a future scope
   spec would cover the path-formula side) is the right vehicle. The Objective
   "single, tested source of truth" is scoped to the three disambiguator commands.
+
+## Changelog
+
+- 2026-07-23: Implemented and shipped — `resolve_state_path` added to `_common.py`; `diff.py`, `uninstall.py`, `upgrade.py` migrated. Full regression suite passes.

--- a/docs/specs/share-scope-state-path-resolver/spec.md
+++ b/docs/specs/share-scope-state-path-resolver/spec.md
@@ -1,0 +1,119 @@
+# Spec: share-scope-state-path-resolver
+
+- **Status:** Implementing
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+
+Mode: full (structural change — new public helper in `_common`; three commands migrated)
+
+## Objective
+
+The `agentbundle` CLI duplicates the same two-line scope-to-state-path mapping
+in three command files (`uninstall.py`, `upgrade.py`, `diff.py`) — each
+independently hard-coding that repo scope → `<root>/.agentbundle-state.toml` and
+user scope → `<root>/.agentbundle/state.toml`. A single extracted helper,
+`_common.resolve_state_path(scope, root)`, eliminates the duplication and gives
+future commands a single, tested source of truth for scope-to-path resolution.
+
+## Boundaries
+
+### Always do
+
+- Extract the common path mapping only — `resolve_state_path(scope, root)` is
+  pure `pathlib.Path` arithmetic; no filesystem access, no subprocess calls, no
+  imports beyond stdlib.
+- Use only pure stdlib inside `_common.py`; the module restricts to stdlib, and
+  `resolve_state_path` must comply.
+- Keep each migrated call site behaviorally identical: the same `scope` string
+  and `root` Path that were used inline must be passed through; no surrounding
+  logic changes.
+- Write a focused unit test for `resolve_state_path` that covers both scopes
+  before migrating any call site (TDD order).
+
+### Ask first
+
+- Any change to the surrounding scope-inference logic (the "if both scopes,
+  require `--scope`" and "infer from installed_at_*" blocks) in any of the
+  three files — that logic is explicitly out of scope.
+- Any change to the error message text or exit codes in `uninstall.py`,
+  `upgrade.py`, or `diff.py`.
+- Any new import added to `_common.py` beyond what already exists.
+
+### Never do
+
+- Change the resolved paths themselves: user state is `<root>/.agentbundle/state.toml`
+  and repo state is `<root>/.agentbundle-state.toml`; these are the contract.
+- Modify `install.py` — it resolves scope differently (via `_ScopePlan` + the
+  six-step adapter resolution) and has its own tests that are not regression targets here.
+- Change `list_installed.py` — it already does the path computation cleanly
+  inline and is not a migration target.
+- Add a new top-level module, directory, or dependency.
+- Change any test assertion that currently passes — existing tests are the
+  regression baseline; this spec adds coverage, never removes it.
+
+## Testing Strategy
+
+- **`resolve_state_path` helper (AC1, AC4):** TDD — write the unit test in
+  `packages/agentbundle/tests/unit/` before adding the function, cover
+  `scope="repo"` and `scope="user"`, assert exact `Path` values. The function
+  has no side effects and the invariant is compressible, making this the
+  canonical TDD shape.
+- **Migration parity for `uninstall`, `upgrade`, `diff` (AC2, AC3):** goal-based
+  check — the existing integration and unit tests for each command run green before
+  and after the migration with no assertion changes. Each command's full test suite
+  is the parity proof.
+
+## Acceptance Criteria
+
+- [ ] AC1: `_common.resolve_state_path(scope, root)` exists, is public, and carries
+  a docstring naming both scope values and their returned paths.
+- [ ] AC2: All three commands — `uninstall.py`, `upgrade.py`, `diff.py` — call
+  `resolve_state_path` for their state-file path computation. No inline path-build
+  expressions of the form `root / ".agentbundle-state.toml"` or
+  `root / ".agentbundle" / "state.toml"` remain in non-comment, non-docstring code
+  (verified by grep excluding `#`-prefixed lines). Exception: `upgrade.py`'s string
+  comparison `state_relpath == ".agentbundle-state.toml"` at line 724 is a filename
+  equality check — not a path build — and must remain unchanged.
+- [ ] AC3: Every existing regression test for `uninstall`, `upgrade`, and `diff`
+  (unit and integration) passes unchanged — no assertion text, no helper count,
+  no exit code asserted by a test is modified.
+- [ ] AC4: A new unit test for `resolve_state_path` covers `scope="repo"` and
+  `scope="user"`, asserts the exact `Path` returned, and lives in
+  `packages/agentbundle/tests/unit/`.
+- [ ] AC5: `_common.py` imports no new module — `resolve_state_path` uses only
+  `pathlib.Path`, which is already imported at module level.
+
+## Assumptions
+
+- Technical: Python runtime is ≥3.11 (`packages/agentbundle/pyproject.toml`).
+- Technical: `_common.py` is restricted to pure stdlib; `resolve_state_path`
+  uses only `pathlib.Path` (already imported) and is compliant.
+- Technical: The path formulas are already structurally uniform across all three
+  files — the extraction is mechanical: user → `<root>/.agentbundle/state.toml`,
+  repo → `<root>/.agentbundle-state.toml` (confirmed: `uninstall.py` lines 54/75,
+  `upgrade.py` lines 118/131–133 and 247–251, `diff.py` lines 60/67–68).
+- Scope: `install.py` and `list_installed.py` are not migration targets.
+- Scope: The scope-inference logic (multi-scope disambiguation, error messages)
+  is not changing — only the two-line path formula is extracted.
+
+## Tasks
+
+See `plan.md`.
+
+## Declined
+
+- Extracting the full multi-scope disambiguator pattern (the "if both scopes,
+  require `--scope`" block) — the three commands have subtly different surrounding
+  logic and the existing tests pin each command's error message text independently.
+- Adding `scope` validation inside `resolve_state_path` — the call sites already
+  control which scope string they pass; a guard adds defensive surface not needed.
+- Migrating `list_installed.py` — it already does the path computation correctly
+  inline and is not a source of the described duplication.
+- Migrating `install.py`'s 9+ identical path-formula occurrences — `install.py`
+  resolves scope via `_ScopePlan` and the six-step adapter resolution path rather
+  than the simple two-branch disambiguator that `uninstall.py`, `upgrade.py`, and
+  `diff.py` share. The scope-to-path formula in install.py is the same bytes but
+  the surrounding scope-inference contract differs materially; a separate follow-on
+  spec (`unify-path-jail-projection-probe` covers the jail side; a future scope
+  spec would cover the path-formula side) is the right vehicle. The Objective
+  "single, tested source of truth" is scoped to the three disambiguator commands.

--- a/docs/specs/site-design-system-spec/plan.md
+++ b/docs/specs/site-design-system-spec/plan.md
@@ -1,0 +1,94 @@
+# Plan: site-design-system-spec
+
+> This plan is the implementation strategy. The contract is [`spec.md`](spec.md).
+
+## Approach
+
+Docs-only with one stdlib Python lint script. No CSS changes, no Astro build changes, no new package dependencies. All token values are read from `web/src/styles/tokens.css` — the implementation authority. T3 can run in parallel with T2 since both depend only on the T1 inventory.
+
+## Design (LLD)
+
+### `web/src/design-system.md` structure
+
+Eight H2 sections:
+
+1. **Color tokens** — Two tables (Tier 1 primitive, Tier 2 semantic). Tier 1 table: token name | hex value | role note. Tier 2 table: token name | primitive target | zone (hero/dark | content/light | accent | CTA). Followed by the layering rule prose.
+2. **Typography** — Sub-sections for font families, size scale (table: token | clamp/value | px range | usage), weight scale, tracking scale, leading scale.
+3. **Spacing, radius, shadow, motion, z-index** — Space scale table. Section/layout tokens. Radius steps. Shadow philosophy (overlay only). Motion tokens. Z-index stack.
+4. **Component vocabulary** — One H3 per component. Each entry: zone assignment, BEM classes used, semantic tokens referenced. Components: Hero, StatStrip, ThreeLoops, HumanGates, AdapterMatrix, InstallTerminal (terminal + CSS-only tabs), Copy button, PackCatalogue (loop-cards + pack-cards + scope chip), BuildYourOrg, Section band wrapper, SiteNav, SiteFooter, PackCard, `cat-card`.
+5. **Zone rules** — Prose: dark zone vs. content/light zone. Token-to-zone mapping table.
+6. **Dark mode equivalents** — Note that Astro has no dark mode. MkDocs dark mode via Material. List of dark-scheme values in `extra.css`.
+7. **Card icon parity decision** — ThreeLoops `.loop__n` badges (sequential steps) vs. catalogue/pack cards (unordered, no badge). Decision: intentional asymmetry.
+8. **Material-injected component audit** — Why `extra.css` uses raw hex. Overridden component families. Four known deviation values table.
+
+### `tools/lint_zone_violations.py` design
+
+```
+parse args: path (default web/src/)
+walk all .astro and .css files under path
+for each file:
+    state: inside_root_block = False
+    for each line:
+        skip if blank, or line matches ^\s*/\* (CSS block comment), or line matches ^\s*// (line-leading JS/TS comment — covers Astro frontmatter)
+        if ":root" and "{": inside_root_block = True; continue
+        if inside_root_block and "}": inside_root_block = False; continue
+        if inside_root_block: continue  # token definitions — exempt
+        skip SVG attribute lines (fill= stroke= xmlns= viewBox= etc.)
+        if line matches CSS property: value; pattern:
+            if value contains #[0-9a-fA-F]{3,6} or rgba(...): VIOLATION
+exit 0 if no violations, 1 if any; print file:line: <value>
+```
+
+## Tasks
+
+### T1 — Inventory tokens and component classes
+
+**Depends on:** none
+**Mode:** Goal-based (internal work material)
+
+Read `web/src/styles/tokens.css` section by section; build working tables. Read each `.astro` file in `web/src/components/` and `web/src/pages/`; note BEM classes and `var(--ds-*)` tokens each uses. This output informs T2 and is not committed.
+
+**Verification:** Inventory contains every token name from `tokens.css` (spot-check: grep for `ds-accent-subtle-dk`, `ds-lead-mono`, `ds-z-toast`).
+
+### T2 — Write `web/src/design-system.md`
+
+**Depends on:** T1
+**Mode:** Goal-based (read-through against `tokens.css`)
+
+Author the eight-section document per the LLD. All hex and clamp values copy verbatim from `tokens.css`.
+
+**Verification:**
+- `grep "ds-type-display" web/src/design-system.md` returns a match
+- `grep "loop__n" web/src/design-system.md` returns a match
+- `grep "#f8fafc\|#1a202c" web/src/design-system.md` returns matches (Material deviation values documented)
+
+### T3 — Write `tools/lint_zone_violations.py`
+
+**Depends on:** none (parallel with T2; the lint is structurally self-contained and does not consume the T1 inventory)
+**Mode:** Goal-based
+
+Implement the state-machine parser per the LLD. Use Python stdlib `re`, `os.walk`, `sys`. Keep under 120 lines. The `:root` block exclusion assumes flat, single-line-brace `:root` blocks (the current `tokens.css` shape); note this assumption in a comment so a future maintainer knows the brace-tracking is a boolean toggle, not a depth counter. Comment exclusion must handle both `/* … */` (CSS) and line-leading `//` (`^\s*//`, JS/TS comments in Astro frontmatter).
+
+**Verification:**
+- `python tools/lint_zone_violations.py web/src/` exits 0 (AC9)
+- Create a temp file `tmp_test_violation.css` (outside `web/src/`) with `.foo { color: #e8952b; }`, run `python tools/lint_zone_violations.py` against its directory, confirm exit 1 and a `tmp_test_violation.css:1:` report; delete the temp file (AC8 — keeps the Astro source tree clean)
+
+### T4 — Verify lint exits 0 on current codebase
+
+**Depends on:** T3
+**Mode:** Goal-based
+
+`python tools/lint_zone_violations.py web/src/ && echo OK` exits 0. If exit 1, diagnose: false positive → tighten exclusion logic; real violation → file separately.
+
+### T5 — Update `docs/specs/README.md`
+
+**Depends on:** T2
+**Mode:** Goal-based
+
+Add row to active specs table.
+
+**Verification:** `grep site-design-system-spec docs/specs/README.md` returns a match.
+
+## Changelog
+
+- 2026-07-23: Initial plan authored.

--- a/docs/specs/site-design-system-spec/spec.md
+++ b/docs/specs/site-design-system-spec/spec.md
@@ -1,0 +1,213 @@
+# Spec: site-design-system-spec
+
+- **Status:** Approved
+- **Owner:** eugenelim
+- **Plan:** [plan.md](plan.md)
+- **Constrained by:** [design-system-foundations.md](../platform-site/design-system-foundations.md), [platform-site/spec.md](../platform-site/spec.md)
+- **Brief:** none
+- **Discovery:** none
+- **Contract:** none
+- **Shape:** mixed (documentation + tooling)
+
+Mode: light (no risk trigger — internal docs tooling, no structural CSS change; no RFC needed)
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+The platform site's design system is authoritatively implemented in
+`web/src/styles/tokens.css` and narrated in
+`docs/specs/platform-site/design-system-foundations.md`. No single
+machine-readable, human-browsable document in the `web/` source tree
+consolidates the complete token vocabulary, component vocabulary, zone
+rules, dark-mode equivalents, and known third-party deviations.
+
+This spec delivers two artefacts:
+
+1. **`web/src/design-system.md`** — a Markdown document in the `web/`
+   tree that is the single reference for every designer or developer
+   working on the platform site. It covers: color tokens (names, roles,
+   zone assignments), typography scale, spacing rhythm, component
+   vocabulary (BEM classes + token usage per component), zone rules, dark
+   mode equivalents (MkDocs only), the card icon parity decision, and an
+   audit of Material-injected component deviations.
+
+2. **`tools/lint_zone_violations.py`** — a stdlib-only Python lint script
+   that scans `web/src/` for raw color values (hex literals or `rgba()`
+   calls) used as CSS property values outside the token-definition
+   `:root {}` block, and exits non-zero on any violation.
+
+Success: a developer opening `web/src/design-system.md` finds the
+complete, canonical token reference for the Astro site; the lint exits 0
+on the current clean codebase; and the card icon parity question has a
+documented resolution decision.
+
+## Acceptance Criteria
+
+- [ ] **AC1.** `web/src/design-system.md` documents all color tokens from
+  `web/src/styles/tokens.css`: Tier 1 primitive names with hex values and
+  roles (dark zone, neutral/light zone, amber-gold accent, alpha tokens),
+  Tier 2 semantic names with their primitive targets and zone assignments
+  (hero/dark zone vs. content/light zone vs. accent layer vs. CTA layer),
+  and the layering rule (component CSS references semantic tokens only —
+  never primitives directly).
+- [ ] **AC2.** `web/src/design-system.md` documents the typography scale:
+  font families (`--ds-font-sans`, `--ds-font-mono`), all eight size steps
+  (`--ds-type-display` through `--ds-type-mono-sm`) with pixel-range
+  equivalents, all five weight steps, all four tracking values, and all
+  four leading values — each with its intended usage context.
+- [ ] **AC3.** `web/src/design-system.md` documents the spacing rhythm: the
+  4px base grid, all ten `--ds-space-*` steps with pixel values, and the
+  four responsive layout tokens (`--ds-section-gap`, `--ds-section-pad-y`,
+  `--ds-content-max`, `--ds-content-pad-x`). It also documents radius (4
+  steps), shadow (overlay-only philosophy), motion (3 durations + 2 easing
+  curves), and z-index (5 steps).
+- [ ] **AC4.** `web/src/design-system.md` documents the component
+  vocabulary for the marketing-homepage and catalogue/pack components. Scope:
+  Hero section, StatStrip, ThreeLoops loop items, HumanGates gate cards,
+  AdapterMatrix table, InstallTerminal + CSS-only tabs, PackCatalogue
+  loop-cards + pack-cards, BuildYourOrg, Section band wrapper (surface /
+  surface-alt / dark tones), SiteNav, SiteFooter, PackCard (`/packs/`
+  index), catalogue `cat-card` (`/catalogue/`), copy button. Journey pages,
+  plugin pages, and 404 are out of scope. Each listed component is
+  documented with its zone assignment, BEM class names, and the semantic
+  tokens it uses. Spot-check greps per component (e.g. `grep "loop__n"
+  web/src/design-system.md` for ThreeLoops, `grep "cat-card"` for
+  catalogue card) must each return a match.
+- [ ] **AC5.** `web/src/design-system.md` states that the Astro marketing
+  site has no `prefers-color-scheme: dark` media query; dark zone is a
+  layout property (specific sections use `--ds-hero-bg`), not a
+  user-preference mode. Dark mode equivalents exist only in the MkDocs
+  layer (`site/docs/stylesheets/extra.css` via `[data-md-color-scheme=
+  "slate"]`). The document lists the dark-mode token values defined there:
+  surface (`#0b0e12`), code background (`#141516`), accent (`#e8952b`),
+  link color (`#f5bc6a`).
+- [ ] **AC6.** `web/src/design-system.md` documents the card icon parity
+  decision: ThreeLoops section (Section 4) items carry ordered numeric
+  sequence badges (`.loop__n`: 01 / 02 / 03) because they represent named
+  steps in a sequential "how it works" narrative; PackCatalogue section
+  (Section 8) `.loop-card` items and all catalogue/pack cards (`cat-card`,
+  `pack-card`) are unordered catalogue entries and intentionally carry no
+  numeric badge. The visual asymmetry is by design — different content
+  types with different information architectures. No badge or icon
+  additions are in scope for this spec; this AC records the decision so the
+  question is closed.
+- [ ] **AC7.** `web/src/design-system.md` audits Material-injected
+  component deviations: the MkDocs `extra.css` overrides Material for
+  MkDocs using raw hex values (by necessity — `--ds-*` custom properties
+  are defined in the Astro build layer and are not available to the MkDocs
+  build). The document lists each Material component family overridden
+  (`.md-header`, `.md-tabs`, `.md-button`, `.grid.cards`, `.md-typeset
+  code` / `pre`, `.md-typeset table`, `.md-banner`, `.platform-back-link`)
+  and flags the four known value deviations from the token spec: `#f8fafc`
+  (primary text on dark, Material context) vs `--ds-hero-fg: #ffffff`;
+  `#141516` (dark code background) vs `--prim-dark-900: #111520`; `#1a202c`
+  (table header text) vs `--prim-neutral-900: #1c1b18`; `#e2e8f0` (table
+  border) which has no primitive-scale equivalent.
+- [ ] **AC8.** `tools/lint_zone_violations.py` exists and scans
+  `web/src/**/*.{astro,css}` for raw color assignments (bare hex literals
+  `#rrggbb` or `rgba()` calls used as CSS property values) that appear
+  outside a `:root {}` token-definition block. The script excludes:
+  (a) comment lines — `/* … */` (CSS) and line-leading `//` (i.e. lines matching `^\s*//`; JS/TS comments in `.astro` frontmatter are always line-leading, so a line-leading test is sufficient and avoids adding per-file fence-state tracking);
+  (b) SVG attribute lines (`fill=`, `stroke=`, `xmlns=`, `viewBox=` etc.);
+  (c) the `:root {}` token-definition block in `tokens.css`. The exclusion
+  assumes flat, single-line-brace `:root` blocks (the current `tokens.css` shape — two
+  single-line `{` openings, no nested braces). Exits 0 = clean, exits 1 = violations found,
+  printing `file:line: <value>` for each hit.
+- [ ] **AC9.** `python tools/lint_zone_violations.py web/src/` exits 0 on
+  the current codebase. Note: this AC is validated by running the lint itself, not by
+  a preliminary grep — the lint's comment-exclusion logic (including `//` comments in Astro
+  frontmatter) determines the outcome.
+- [ ] **AC10.** `docs/specs/README.md` is updated to include this spec in
+  the active list.
+
+## Boundaries
+
+### Always do
+
+- Keep `web/src/design-system.md` as documentation of *existing* tokens —
+  derive all values from `web/src/styles/tokens.css` as the implementation
+  authority.
+- Scope the lint to `web/src/` only; use stdlib Python with no new
+  dependency.
+- Record the card icon parity decision as-is (asymmetry is intentional);
+  do not add any layout element.
+
+### Never do
+
+- Change any existing CSS — this spec documents first; CSS changes are a
+  separate PR.
+- Add icons, badges, or any visual element to catalogue cards or loop cards.
+- Extend the lint to `site/docs/stylesheets/extra.css` — Material overrides
+  require raw hex values by design; linting them produces only false
+  positives.
+- Introduce a new dependency beyond stdlib Python for the lint script.
+- Rename or reorganise existing tokens, even to fix the four Material
+  deviation values.
+
+### Ask first
+
+- Any fix to the four known Material deviation values (`#f8fafc`,
+  `#141516`, `#1a202c`, `#e2e8f0`).
+- Any decision to add `prefers-color-scheme: dark` support to the Astro
+  marketing site.
+
+## Testing Strategy
+
+Goal-based throughout — no new compilation step, no production test file.
+
+- **AC1–AC7 (`web/src/design-system.md` content):** Manual read-through.
+  Verify each section against `web/src/styles/tokens.css` as the source of
+  truth. Representative spot-check: `grep
+  "ds-type-display\|ds-space-1\|ds-accent-subtle-dk"
+  web/src/design-system.md` returns matches.
+- **AC8 (lint script exists and runs):** `python
+  tools/lint_zone_violations.py web/src/` runs without import error or
+  crash. Introduce a synthetic violation in a scratch file, confirm exit 1
+  and a `file:line:` report; remove the scratch file.
+- **AC9 (lint exits 0 on current codebase):** `python
+  tools/lint_zone_violations.py web/src/ && echo OK` exits 0.
+- **AC10 (README updated):** `grep site-design-system-spec
+  docs/specs/README.md` returns a match.
+
+## Assumptions
+
+- Technical: The implementation authority for all `--ds-*` and `--prim-*`
+  token values is `web/src/styles/tokens.css`; `docs/specs/platform-site/
+  design-system-foundations.md` is the upstream narrative spec. (Verified.)
+- Technical: The Astro component CSS is currently fully token-compliant — no
+  raw hex or `rgba()` values appear as CSS property assignments outside
+  `tokens.css`. (Verified: grep returned only comment-line matches.)
+- Technical: Dark mode exists only in the MkDocs layer; the Astro marketing
+  site's "dark zone" is a layout concept and carries no `prefers-color-scheme`
+  media query. (Verified.)
+- Technical: "Loop cards have icons" refers to ThreeLoops `.loop__n` badges;
+  "catalogue cards" refers to PackCatalogue and `cat-card` items which carry
+  no badge. The asymmetry is intentional. (Verified.)
+- Technical: The four Material deviation values in `extra.css` are known
+  side-effects of Material for MkDocs requiring raw CSS values. (Verified.)
+- Process: No RFC is needed — the backlog entry explicitly states "no RFC
+  needed — internal docs tooling; normal PR."
+
+## Tasks
+
+1. **Inventory existing CSS tokens** — Read `web/src/styles/tokens.css`
+   top-to-bottom; read every `.astro` file and extract BEM class names and
+   their token usage.
+2. **Write `web/src/design-system.md`** — Author the full token reference
+   covering AC1–AC7.
+3. **Write `tools/lint_zone_violations.py`** — Stdlib-only Python state
+   machine that walks `web/src/`, skips comment lines and SVG attribute
+   lines, skips the `:root {}` block in `tokens.css`, and flags bare hex
+   or `rgba()` values in CSS property positions. Exits 0 = clean, 1 =
+   violations.
+4. **Verify lint exits 0** — Run the lint against the current codebase.
+5. **Update `docs/specs/README.md`** — Add this spec to the active list.
+
+## Declined
+
+- Fixing the four Material deviation values — out of scope; a follow-on PR.
+- Adding `prefers-color-scheme: dark` to the Astro marketing site — out of scope.
+- Adding icons or badges to catalogue cards.
+- Linting `site/docs/stylesheets/extra.css` — Material overrides require raw values.

--- a/docs/specs/unify-path-jail-projection-probe/plan.md
+++ b/docs/specs/unify-path-jail-projection-probe/plan.md
@@ -1,0 +1,141 @@
+# Plan: unify-path-jail-projection-probe
+
+> This plan is the implementation strategy. The contract is [`spec.md`](spec.md).
+
+## Approach
+
+Three tasks in dependency order. T1 adds the new helper and its unit tests. T2 migrates `install.py` and `upgrade.py` dry-run. T3 adds upgrade non-dry-run pre-flight and routes `write_jailed`'s inline block. All existing regression tests must pass without modification after each task.
+
+**Red stubs:** Before EXECUTE, create the five unit test functions for `assert_projection_jailed` in `tests/unit/test_safety.py`. Each should fail `AttributeError` (function doesn't exist yet) until T1 is complete.
+
+## Design (LLD)
+
+### `assert_projection_jailed` signature
+
+```python
+def assert_projection_jailed(
+    root: Path,
+    relpaths: Iterable[str],
+    allowed_prefixes: list[str] | None,
+    *,
+    command: str,
+) -> None:
+    """Raise PathJailError if any relpath escapes root or violates allowed_prefixes.
+
+    When allowed_prefixes is None, only root-escape is checked.
+    root must be an absolute resolved Path.
+    """
+    for relpath in relpaths:
+        target = root / relpath
+        try:
+            assert_under(root, target)
+        except PathJailError as exc:
+            raise PathJailError(f"{command}: {exc}") from exc
+        if allowed_prefixes is not None:
+            target_relpath = target.resolve().relative_to(root.resolve()).as_posix()
+            if not any(
+                target_relpath.startswith(p)
+                for p in allowed_prefixes
+            ):
+                raise PathJailError(
+                    f"{command}: path {relpath!r} is not within any declared prefix zone"
+                )
+```
+
+Pure function — no I/O, no side effects. Placed immediately after `assert_under` in `safety.py`.
+
+### Migration shape per call site
+
+**`install.py` Step 8** — Replace the `for plan in plans: for relpath in projection.keys(): assert_under(...); if allowed_prefixes: ...` double loop with:
+```python
+for plan in plans:
+    projection = ...
+    if projection is None:
+        continue
+    try:
+        safety.assert_projection_jailed(
+            plan.root, projection.keys(), plan.allowed_prefixes, command="install"
+        )
+    except safety.PathJailError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+```
+
+**`upgrade.py` dry-run probe** — Replace the `for relpath in sorted(work_projection): ...` probe block with:
+```python
+try:
+    safety.assert_projection_jailed(
+        root, sorted(work_projection), allowed_prefixes, command="upgrade"
+    )
+except safety.PathJailError as exc:
+    print(str(exc), file=sys.stderr)
+    return 1
+```
+
+**`upgrade.py` non-dry-run pre-flight (new)** — Insert before write loop:
+```python
+try:
+    safety.assert_projection_jailed(
+        root, sorted(work_projection), allowed_prefixes, command="upgrade"
+    )
+except safety.PathJailError as exc:
+    print(str(exc), file=sys.stderr)
+    return 1
+for relpath, content in sorted(work_projection.items()):
+    ...
+```
+
+**`write_jailed` prefix block** — Replace lines 342–347 with:
+```python
+assert_projection_jailed(root, [relpath], allowed_prefixes, command=f"scope={scope}")
+```
+The trailing-slash guard at lines 337–341 remains before this call.
+
+## Tasks
+
+### T1 — Extract `assert_projection_jailed` + unit tests
+
+**Depends on:** none
+**Mode:** TDD (AC1, AC6)
+
+Write red stubs first (5 named test functions in `tests/unit/test_safety.py`). Then implement the helper.
+
+**Verification:**
+- `pytest tests/unit/test_safety.py::test_assert_projection_jailed_*` — all 5 cases pass (AC6)
+- `grep -n "def assert_projection_jailed" safety.py` returns a match (AC1)
+
+### T2 — Migrate `install.py` Step 8 + `upgrade.py` dry-run probe
+
+**Depends on:** T1
+**Mode:** Goal-based regression (AC2, AC3)
+
+Apply both migrations. Run the two existing integration tests.
+
+**Verification:**
+- `pytest tests/integration/test_install_cmd.py::test_path_jail_probe_refused` passes (AC2)
+- `pytest tests/integration/test_upgrade_cmd.py::test_dry_run_upgrade_preflight_path_jail_passthrough` passes (AC3)
+- `python -c "s=open('agentbundle/commands/install.py').read(); step8=s[s.find('# ── Step 8'):s.find('# ── Step 9')]; bad=[l for l in step8.splitlines() if 'assert_under(' in l and not l.strip().startswith('#')]; assert step8 and not bad, f'Step 8 still calls assert_under inline (or delimiter not found): {bad}'"` exits 0
+- `python -c "lines=[l for l in open('agentbundle/commands/upgrade.py').read().splitlines() if 'assert_under(' in l and not l.strip().startswith('#')]; assert not lines, f'upgrade.py still calls assert_under inline: {lines}'"` exits 0 (confirms dry-run probe also migrated)
+
+### T3 — Add upgrade non-dry-run pre-flight + route `write_jailed`
+
+**Depends on:** T1, T2
+**Mode:** TDD for AC4 (new integration test); goal-based for AC5/AC7
+
+Write the new integration test for AC4 first. Then add the pre-flight call and route `write_jailed`.
+
+**Verification:**
+- New integration test (AC4): `pytest tests/integration/test_upgrade_cmd.py::test_upgrade_prefix_violation_writes_nothing` passes
+- `pytest tests/unit/test_safety_repo_scope_prefixes.py` — all cases pass (AC5, AC7)
+- `python -c "import re; s=open('agentbundle/safety.py').read(); m=re.search(r'def write_jailed\b.*?(?=\ndef \w)', s, re.S); assert m and 'target_relpath' not in m.group(), 'write_jailed body still has inline target_relpath'"` exits 0
+
+### T4 — Full regression
+
+**Depends on:** T1, T2, T3
+**Mode:** Goal-based (AC5)
+
+`pytest packages/agentbundle/` — all tests pass. No modified assertions.
+
+## Changelog
+
+- 2026-07-23: Initial plan authored.

--- a/docs/specs/unify-path-jail-projection-probe/spec.md
+++ b/docs/specs/unify-path-jail-projection-probe/spec.md
@@ -1,0 +1,85 @@
+# Spec: unify-path-jail-projection-probe
+
+- **Status:** Approved
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** none — internal refactoring within `packages/agentbundle`; no RFC, no ADR, no external interface change
+- **Brief:** none
+- **Discovery:** none
+- **Contract:** none — no REST, event, or RPC surface; pure Python internal API
+- **Shape:** service
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+> **Mode: full** — risk trigger: *structural change* (new public helper in `safety.py`; three call sites migrated; upgrade non-dry-run pre-flight behavior changes from per-file mid-write to whole-projection pre-flight).
+
+## Objective
+
+Three sites in the agentbundle codebase each implement the same two-step prefix-jail check — call `assert_under` to verify the target path stays under the repo root, then (when `allowed_prefixes` is non-None) verify via directory-boundary matching that the resolved relpath starts with one of the declared prefixes. These are `install.py` Step 8 (a read-only pre-flight over every projected file before any write), `upgrade.py`'s `--dry-run` probe (added by the projection-dry-run spec), and `safety.write_jailed`'s inline prefix block (the enforcement site inside the write primitive). Any semantics change to the rule — e.g., changing how directory-boundary matching works or when the prefix check is skipped — must be applied to all three copies or they drift and produce inconsistent refusal behavior across commands.
+
+`safety.assert_projection_jailed(root, relpaths, allowed_prefixes, *, command)` is extracted as a new read-only helper that centralises the two-step check. All three call sites route through it. As a follow-on, upgrade's non-dry-run write loop — which currently has no standalone pre-flight and catches violations one file at a time mid-write — gains the same probe-all-before-any-write pattern that install's Step 8 uses, making its failure mode atomic (either the whole projection is jailed-safe or nothing is written).
+
+## Boundaries
+
+### Always do
+
+- Implement `assert_projection_jailed` as a pure read-only function: it iterates relpaths, calls `assert_under` for the root-jail check, and when `allowed_prefixes` is non-None applies the directory-boundary prefix match. It raises `PathJailError` on first violation. It writes nothing.
+- Keep `write_jailed`'s trailing-slash guard (`if not all(p.endswith("/") for p in prefixes): raise PathJailError(...)`) in place as defense-in-depth after routing the prefix-match check through `assert_projection_jailed`. The guard catches programming errors in callers that construct prefix lists in code (bypassing the contract schema). It is not part of the duplicated semantics being extracted.
+- Keep `write_jailed`'s `TypeError` for `scope="user"` with `allowed_prefixes=None`. That is a caller-contract guard, not prefix-match logic, and is not affected by this refactoring.
+- Place the upgrade non-dry-run pre-flight call to `assert_projection_jailed` before the `for relpath, content in sorted(work_projection.items()):` write loop — probe all paths first, then write, matching install's Step 8 ordering.
+- Preserve every existing jail and prefix regression test passing without modification.
+
+### Ask first
+
+- Adding a `scope` parameter to `assert_projection_jailed` to preserve the "for scope 'repo'" text in the error message (the current prefix-violation messages from the probes include the scope string; routing through `assert_projection_jailed` may change the wording slightly — ask before hardening the message format in a way that would force test changes).
+- Routing `write_companion` through `assert_projection_jailed` explicitly. `write_companion` delegates to `write_jailed`, which already routes through the extracted helper after T3; no direct change is needed, but confirm the transitive routing is sufficient before touching `write_companion`'s call site.
+- Changing any error-message text that existing tests `match=` against. The current test coverage uses `assertRaises(safety.PathJailError)` without message matching for prefix violations; if a future test tightens the match, ask before changing the wording.
+
+### Never do
+
+- Change the behavior of `agentbundle install` in any way (dry-run or non-dry-run). Install's Step 8 already runs a whole-projection pre-flight before Step 9 writes; the refactored Step 8 must refuse the exact same paths at the same pre-flight stage, producing the same exit code.
+- Change the behavior of `agentbundle upgrade --dry-run`. The refactored dry-run probe must surface the same jail refusals it does today, before printing any plan.
+- Change the Tier-1/2/3 classification contract, `write_jailed`'s atomicity, or the companion-write logic.
+- Introduce `assert_projection_jailed` anywhere other than `agentbundle/safety.py`. It is a module-level function, not a method, and not in a new file.
+- Add a new top-level directory or a new runtime dependency.
+- Remove or weaken the root-jail check (`assert_under`) from any of the three call sites. Both layers of the check — root containment and prefix containment — must remain enforced at every site.
+
+## Testing Strategy
+
+Two verification modes apply across this spec's ACs:
+
+- **TDD (AC1, AC6):** `assert_projection_jailed` is a pure, side-effect-free function with a compressible invariant. Unit tests are written first and drive the implementation. Five sub-cases cover the complete branching: valid path with `allowed_prefixes` set (no exception), valid path with `allowed_prefixes=None` (prefix check skipped, no exception), root-escape via `../` (raises `PathJailError`), inside-root but outside all prefixes (raises `PathJailError`), and empty `relpaths` iterable (no exception). Tests live in `tests/unit/test_safety.py` alongside the existing `assert_under` tests.
+
+- **Goal-based regression (AC2, AC3, AC4, AC5, AC7):** Each migrated call site's correctness is verified by running the existing integration tests that exercise the jail refusal for that site. No test modifications are expected; if a test needs updating, treat that as a signal the semantics changed. For AC4 (upgrade non-dry-run pre-flight), a new integration test is added confirming that a projection with a prefix-violating path causes `upgrade` to exit non-zero and write zero files to disk (probe-all-before-write contract).
+
+## Acceptance Criteria
+
+- [ ] AC1: `safety.assert_projection_jailed(root, relpaths, allowed_prefixes, *, command)` exists as a public function in `agentbundle/safety.py`. The `command` parameter is a string prefixed uniformly on all `PathJailError` messages the helper raises — both root-escape (caught from `assert_under` and re-raised as `PathJailError(f"{command}: {exc}")`) and prefix-violation (`PathJailError(f"{command}: path {relpath!r} is not within any declared prefix zone")`). All three call sites pass a command-name string (`"install"`, `"upgrade"`) or a scope-description string (`f"scope={scope}"`). Callers print `str(exc)` directly — the `command:` prefix is in the raised message, not added by the caller. Given any relpath that escapes `root` via `../`, it raises `PathJailError`. Given a relpath inside `root` but outside all entries in `allowed_prefixes`, it raises `PathJailError`. Given `allowed_prefixes=None`, it skips the prefix check and raises only on a root escape. Given a valid relpath inside `root` and within the declared prefix, it returns without exception. Given an empty `relpaths` iterable, it returns without exception.
+- [ ] AC2: `install.py` Step 8's inner jail loop (lines 895–918) is replaced by a call to `safety.assert_projection_jailed(plan.root, projection.keys(), plan.allowed_prefixes, command="install")`. The outer `for plan in plans:` loop and its `if projection is None: continue` guard remain unchanged. `PathJailError` is caught and printed with `str(exc)` (the `command:` prefix is embedded in the message by the helper — see AC1). The integration test `test_path_jail_probe_refused` passes without modification. Note: `test_path_jail_probe_refused` exercises the root-escape branch; the install call-site prefix-branch wiring is not separately verified by an integration test (accepted as a mechanical migration — prefix logic is covered by the AC6 unit tests for `assert_projection_jailed` itself). Also note: routing through `assert_projection_jailed` removes the resolved absolute path (`target.resolve()`) that `install.py:918` currently includes in prefix-violation diagnostics; only `relpath` appears in the new message — this diagnostic narrowing is acceptable and intentional.
+- [ ] AC3: `upgrade.py`'s `--dry-run` probe (lines 545–562, inside the `if getattr(args, "dry_run", False):` guard) is replaced by a call to `safety.assert_projection_jailed(root, sorted(work_projection), allowed_prefixes, command="upgrade")`. `PathJailError` is caught and printed with `str(exc)` (the `command:` prefix is embedded by the helper — see AC1). The integration test `test_dry_run_upgrade_preflight_path_jail_passthrough` passes without modification.
+- [ ] AC4: `upgrade.py`'s non-dry-run path gains a pre-flight call to `safety.assert_projection_jailed(root, sorted(work_projection), allowed_prefixes, command="upgrade")` immediately before the `for relpath, content in sorted(work_projection.items()):` write loop (line 587). A new integration test confirms: given an installed pack and a projection containing a Tier-2 base path outside `allowed_prefixes` (test must run at a scope where `allowed_prefixes` is non-None — user scope or repo-per-IDE), `upgrade` exits non-zero and zero files are written to the target tree. Note: Tier-2 companion source paths today flow through `write_companion` → `write_jailed(root, str(companion), content, allowed_prefixes=None)` — meaning the prefix check is *skipped* for companion writes (only the root-jail runs). This pre-flight adds prefix enforcement to Tier-2 companion source paths for the first time: a Tier-2 base path outside the declared prefixes is currently *written* as a companion but will be *refused* after this change. The integration test must use exactly this case — a Tier-2 path outside declared prefixes — to demonstrate the behavioral change. This broadening is intentional and aligns upgrade's failure mode with install's Step 8 behavior.
+- [ ] AC5: All existing jail and prefix regression tests pass without modification. Specifically: `test_write_jailed_refuses_path_escape`, `test_write_jailed_refuses_absolute_path_escape`, `test_assert_under_passes_for_path_inside` (all in `tests/unit/test_safety.py`); all `WriteJailedRepoScopeTests` cases (all adapters, trailing-slash guard, None-prefixes backward-compat; `tests/unit/test_safety_repo_scope_prefixes.py`); `test_path_jail_probe_refused` (`tests/integration/test_install_cmd.py:344`); `test_dry_run_upgrade_preflight_path_jail_passthrough` (`tests/integration/test_upgrade_cmd.py:755`).
+- [ ] AC6: A focused unit test suite for `assert_projection_jailed` in `tests/unit/test_safety.py` covers all five sub-cases from the Testing Strategy (valid-with-prefixes, valid-none-prefixes, root-escape, inside-root-outside-prefix, empty-relpaths). Each sub-case is a named test function.
+- [ ] AC7: `safety.write_jailed`'s inline prefix-match block (lines 342–347 — the `target_relpath = ...; if not any(...):` pair) is replaced by a call to `assert_projection_jailed(root, [relpath], allowed_prefixes, command=f"scope={scope}")`. The trailing-slash guard (lines 337–341) remains in place before this call. All `WriteJailedRepoScopeTests` cases pass without modification. (The `scope` parameter is `"repo"` or `"user"` — passing `f"scope={scope}"` preserves the diagnostic context of the existing error message; the prefix-violation message changes from the inline wording to `f"scope={scope}: path {relpath!r} is not within any declared prefix zone"` — this is acceptable since no current test matches that message text.)
+
+## Assumptions
+
+- Technical: The three copies share the same two-step check: `assert_under(root, target)` for root containment and a `target_relpath.startswith(p)` directory-boundary match for prefix containment. `write_jailed`'s trailing-slash guard (lines 337–341) is adjacent but not part of the duplicated pattern — it is a programming-error defense unique to the write primitive. (`safety.py:318–347`, `install.py:887–918`, `upgrade.py:533–576`, read 2026-07-23)
+- Technical: Existing regression tests for prefix violations use `assertRaises(safety.PathJailError)` or `rc != 0` without matching the error-message text. Any slight wording change from routing through `assert_projection_jailed` (e.g., losing "for scope 'repo'" in the prefix-violation message) will not break current tests. (`test_safety_repo_scope_prefixes.py:38–106`, `test_upgrade_cmd.py:755–777`, read 2026-07-23)
+- Technical: The non-dry-run upgrade write loop (`upgrade.py:578–619`) catches `PathJailError` from `write_jailed` per-file and returns 1, meaning some files may be written before the violation is reached. Adding a pre-flight pass before this loop changes the observable failure mode (fail-fast with zero writes) but preserves the non-zero exit and the on-disk integrity guarantee. This behavioral change is explicitly in scope. (`upgrade.py:578–619`, `docs/specs/projection-dry-run/spec.md:77`, backlog entry, read 2026-07-23)
+- Technical: `write_jailed` calls `assert_under` at line 320 before the `if allowed_prefixes is not None:` block. If `write_jailed` calls `assert_projection_jailed([relpath], ...)` which also calls `assert_under` internally, `assert_under` is invoked twice for the same path. This is safe and idempotent; the double-call is acceptable rather than restructuring `write_jailed`'s control flow. (`safety.py:318–347`, read 2026-07-23)
+- Technical: Runtime is stdlib Python ≥ 3.11. (`packages/agentbundle/pyproject.toml`, read 2026-07-23)
+- Product: The projection-dry-run spec's "Never do: change non-dry-run behavior" (`docs/specs/projection-dry-run/spec.md:77`) was scoped to that PR's dry-run addition. Adding a pre-flight pass to upgrade's non-dry-run path is explicitly in scope here. (backlog entry `unify-path-jail-projection-probe`, read 2026-07-23)
+- Process: Refactoring within `packages/agentbundle`; no ADR, no RFC, no adopter-visible CLI or contract change — spec-level work per `docs/CONVENTIONS.md` §3. (`docs/CONVENTIONS.md:§3`, read 2026-07-23)
+
+## Tasks
+
+See `plan.md`.
+
+## Declined
+
+- **Separate `_check_prefix_match` private helper instead of `assert_projection_jailed` directly:** A private `_check_prefix_match(root, target, allowed_prefixes)` helper that operates on a single pre-resolved target was considered. Rejected because the backlog explicitly names `assert_projection_jailed` as the public API that call sites route through; a private helper would be an extra indirection without the named public contract.
+- **Adding `scope` as a parameter to `assert_projection_jailed`:** The current prefix-violation error messages from the probes include `for scope {scope!r}` (e.g., "for scope 'repo'"). This information could be preserved by adding a `scope` keyword to `assert_projection_jailed`. Deferred: no existing test matches on this part of the message, so the slight wording change is safe for now. Can be added if an adopter files a support issue where the scope context was needed.
+- **Merging the outer `for plan in plans:` loop in install.py Step 8 into `assert_projection_jailed`:** The outer loop iterates scope plans, each with a different `root` and `allowed_prefixes`. Collapsing it into a single helper call would require a different API (list of `(root, relpaths, prefixes)` tuples). Not warranted — one call per plan is the right granularity.
+- **Changing behavior for `--dry-run install`:** The projection-dry-run spec's "Never do" clause for install's dry-run path remains honored. Only upgrade's non-dry-run path gains new pre-flight behavior (AC4). Install's dry-run returns early at the top of Step 9, after Step 8's pre-flight; no change is needed there.

--- a/docs/specs/work-loop-step0-observability/spec.md
+++ b/docs/specs/work-loop-step0-observability/spec.md
@@ -1,0 +1,137 @@
+# Spec: work-loop-step0-observability
+
+- **Status:** Approved
+- **Owner:** eugenelim
+- **Constrained by:** `spec/spec-C-workloop-argless-resume` (defines Branch-1 behavior; Status: Shipped — body not modified by this spec); RFC-0067 §Change C
+
+Mode: light (no structural or public-interface risk trigger — SKILL.md content edit + projection update)
+
+## Objective
+
+Step 0 of the work-loop has two related readability problems that erode
+observability and maintainability. First, Branch 1 (exactly one active item)
+silently begins the loop without stating the resolved spec path in the
+orientation block — a stale `.active` entry pointing at the wrong spec goes
+undetected until PLAN is already under way. Branch 3 (more than one active
+item) already lists all paths before asking the user to pick; Branch 1
+should match that explicitness. Second, the "Active spec" bullet in the
+orientation block conflates two concerns: it is a data-surface field (collect
+and display the active path) but its text also carries the three branch
+outcomes as inline control-flow actions. This mixes data-surface and
+control-flow in the same bullet, and duplicates the branch outcomes — they
+are stated again in the closing paragraph — creating two sources of truth
+that must stay aligned.
+
+This spec fixes both: (1) Branch 1 echoes the resolved path in the
+orientation block before proceeding; (2) the "Active spec" bullet is trimmed
+to data-surfacing only, and the branch-outcome resolution is stated once, in
+the closing paragraph.
+
+**Backlog items consumed:** `work-loop-step0-branch1-echo-resolved-path`,
+`work-loop-step0-branch-layout-restructure`.
+
+## Acceptance Criteria
+
+- [ ] **AC1.** The closing paragraph of Step 0 in the source SKILL.md
+  (`packs/core/.apm/skills/work-loop/SKILL.md`) directs Branch 1 to echo
+  "Beginning on `<resolved-path>`" (or equivalent phrasing) before
+  proceeding to PLAN — so the resolved path is explicitly visible to the
+  user. This instruction lives in the closing paragraph, not in the
+  "Active spec" bullet.
+- [ ] **AC2.** Branch 3 (more than one active item) already lists all active
+  paths — verified that no change to its behavior is needed.
+- [ ] **AC3.** The three data-surface fields (Initiative / Milestone / Active
+  spec) in the orientation block's bullet list do not contain embedded
+  control-flow action text — the "Exactly one → begin on that spec without
+  asking. Zero → surface… More than one → list…" clause is removed from the
+  "Active spec" bullet.
+- [ ] **AC4.** Branch-outcome resolution is stated once (in the closing
+  paragraph), not at both the "Active spec" bullet and the closing paragraph.
+- [ ] **AC5.** `make build-self FORCE=1` exits 0 and the projected
+  `.claude/skills/work-loop/SKILL.md` reflects all changes.
+- [ ] **AC6.** The closing paragraph's Branch 1 instruction directs the echo,
+  and Branch 2's exact message ("No active spec found — run `workspace-status`
+  to see what's ready to start.") and Branch 3's "list all and ask" phrasing
+  are relocated verbatim from the "Active spec" bullet into the closing
+  paragraph when the bullet is trimmed. The relocated text does not paraphrase
+  or abbreviate the Branch 2 message.
+
+## Boundaries
+
+### Always do
+- Edit `packs/core/.apm/skills/work-loop/SKILL.md` (source) — Step 0 only
+- Re-project with `make build-self FORCE=1`
+
+### Never do
+- Change the semantics of Branch 1 — it must still proceed without asking
+  after echoing the path; only the echo is added
+- Change the semantics of Branch 2 (zero active items) or Branch 3 (more
+  than one active item)
+- Touch any section of SKILL.md other than Step 0
+- Add new branches or alter the routing logic
+
+### Ask first
+- Any wording change to Branch 2's "No active spec found…" message
+- Any wording change to Branch 3's listing or asking behavior
+- Removing the closing paragraph (it carries non-redundant content: the
+  path-stripping instruction and the PLAN-entry mechanics)
+
+## Testing Strategy
+
+Goal-based throughout. After editing:
+1. Read `packs/core/.apm/skills/work-loop/SKILL.md` Step 0 and verify:
+   - "Active spec" bullet contains no branch control-flow text (AC3)
+   - The closing paragraph contains the Branch 1 echo instruction: "state 'Beginning on `<resolved-path>`'" (AC1)
+   - The closing paragraph contains Branch 2's verbatim message and Branch 3's list phrasing, relocated from the bullet (AC4, AC6)
+   - Branch outcomes appear in the closing paragraph and nowhere else in Step 0 (AC4)
+2. Run `make build-self FORCE=1`; verify exit 0 (AC5)
+3. Read `.claude/skills/work-loop/SKILL.md` (projected) and confirm it matches
+   the source edits (AC5)
+
+## Assumptions
+
+- Technical: source SKILL.md is at `packs/core/.apm/skills/work-loop/SKILL.md`;
+  projected copy is at `.claude/skills/work-loop/SKILL.md` (confirmed via find).
+- Technical: `make build-self FORCE=1` routes through
+  `python3 tools/build_gate_chain.py build-self --force --packs-dir packs`
+  (confirmed via Makefile lines 52–53); `FORCE=1` bypasses the dirty-tree guard.
+- Technical: in the current SKILL.md, Branch 1's control-flow text is inside
+  the "Active spec" bullet as "Exactly one → begin on that spec without asking."
+  — the echo is absent.
+- Technical: branch outcomes appear in two places — inside the "Active spec"
+  bullet and in the closing paragraph (SKILL.md:167-172, confirmed to be inside
+  Step 0 boundary); the closing paragraph is the better single source because it
+  also carries the path-stripping instruction and PLAN-entry mechanics.
+- Process: `docs/specs/spec-C-workloop-argless-resume/spec.md` is Shipped
+  (Frozen) — its body is not modified by this spec. spec-C's AC2 Branch 1
+  text ("begin the loop on that spec without asking") predates the echo
+  requirement; this spec supersedes it by adding the echo instruction to the
+  source SKILL.md. spec-C is referenced as the historical contract definition.
+
+## Tasks
+
+1. Read `packs/core/.apm/skills/work-loop/SKILL.md` Step 0 to confirm exact
+   line numbers (they may have shifted since this spec was authored).
+2. Edit the "Active spec" bullet: remove the inline branch-outcome text;
+   leave only the data-surface instruction ("Collect every path in
+   `["ini-NNN".work].active` across all active initiatives").
+3. Edit the closing paragraph: add Branch 1 echo — "state 'Beginning on
+   `<resolved-path>`' in the orientation block, then strip the `spec/` prefix…";
+   expand to name all three branches explicitly, making the paragraph the single
+   canonical statement of branch outcomes.
+4. Run `make build-self FORCE=1`; confirm exit 0; read projected SKILL.md to
+   verify changes propagated.
+
+## Declined
+
+- Removing the closing paragraph and consolidating all branch logic into the
+  bullet list — the closing paragraph carries path-stripping and PLAN-entry
+  mechanics not duplicated in the bullet; removing it would lose those.
+- Rewording Branch 3's listing behavior — Branch 3 already lists all paths and
+  asks the user to pick; changing it is out of scope.
+- Adding a "### Branch resolution" subsection — the closing paragraph is the
+  natural home; a new subsection restructures more than necessary for light mode.
+- Editing `docs/specs/spec-C-workloop-argless-resume/spec.md` body — that spec
+  is Shipped (Frozen). CONVENTIONS §4 does not allow body edits to frozen specs.
+  This spec supersedes spec-C's Branch-1 description by updating the source
+  SKILL.md directly; spec-C remains as a historical record of the prior contract.

--- a/packages/agentbundle/agentbundle/commands/_common.py
+++ b/packages/agentbundle/agentbundle/commands/_common.py
@@ -40,6 +40,17 @@ def resolve_catalogue_uri(args: "argparse.Namespace") -> str:
     )
 
 
+def resolve_state_path(scope: str, root: Path) -> Path:
+    """Return the state-file path for *scope* under *root*.
+
+    ``scope="repo"`` → ``<root>/.agentbundle-state.toml``
+    ``scope="user"`` → ``<root>/.agentbundle/state.toml``
+    """
+    if scope == "user":
+        return root / ".agentbundle" / "state.toml"
+    return root / ".agentbundle-state.toml"
+
+
 class SeedDelivery(NamedTuple):
     """One seed file's delivery outcome, returned by ``deliver_seeds``.
 

--- a/packages/agentbundle/agentbundle/commands/diff.py
+++ b/packages/agentbundle/agentbundle/commands/diff.py
@@ -22,7 +22,7 @@ import sys
 from pathlib import Path
 
 from agentbundle import render, safety
-from agentbundle.commands._common import check_spec_version_gate
+from agentbundle.commands._common import check_spec_version_gate, resolve_state_path
 from agentbundle.config import ConfigError, load_pack_toml
 
 
@@ -57,7 +57,7 @@ def run(args: argparse.Namespace) -> int:
         # hard cross-version refusal); surface it as a clean refuse rather
         # than a traceback.
         try:
-            repo_state_for_check = load_state(root / ".agentbundle-state.toml")
+            repo_state_for_check = load_state(resolve_state_path("repo", root))
         except ConfigError as exc:
             print(f"diff: {exc}", file=sys.stderr)
             return 1
@@ -65,7 +65,7 @@ def run(args: argparse.Namespace) -> int:
         try:
             user_root_resolved = scope_mod.resolve_user_root()
             user_state_for_check = load_state(
-                user_root_resolved / ".agentbundle" / "state.toml"
+                resolve_state_path("user", user_root_resolved)
             )
             installed_at_user = user_state_for_check.has_pack(pack_name)
         except scope_mod.UserScopeUnresolvable:

--- a/packages/agentbundle/agentbundle/commands/uninstall.py
+++ b/packages/agentbundle/agentbundle/commands/uninstall.py
@@ -46,12 +46,13 @@ def run(args: "argparse.Namespace") -> int:
     """
     from agentbundle.config import ConfigError, dump_state, load_state
     from agentbundle import safety
+    from agentbundle.commands._common import resolve_state_path
 
     pack_name: str = args.pack
     cli_scope: str | None = getattr(args, "scope", None)
     cli_adapter: str | None = getattr(args, "adapter", None)
     root = Path(args.root).resolve()
-    state_path = root / ".agentbundle-state.toml"
+    state_path = resolve_state_path("repo", root)
 
     # ── Step 1: Multi-scope disambiguator (RFC-0004) ──────────────────────────
     # If the pack is at both repo and user scopes, --scope is required.
@@ -72,7 +73,7 @@ def run(args: "argparse.Namespace") -> int:
     user_state_for_check = None
     try:
         user_root = scope_mod.resolve_user_root()
-        user_state_path = user_root / ".agentbundle" / "state.toml"
+        user_state_path = resolve_state_path("user", user_root)
         user_state_for_check = load_state(user_state_path)
         installed_at_user = user_state_for_check.has_pack(pack_name)
     except scope_mod.UserScopeUnresolvable:

--- a/packages/agentbundle/agentbundle/commands/upgrade.py
+++ b/packages/agentbundle/agentbundle/commands/upgrade.py
@@ -79,6 +79,7 @@ def run(args: "argparse.Namespace") -> int:
         format_plan_line,
         plan_action,
         resolve_catalogue_uri,
+        resolve_state_path,
         summarize_plan,
     )
     from agentbundle.config import (
@@ -115,7 +116,7 @@ def run(args: "argparse.Namespace") -> int:
     # If the pack is at both scopes, --scope is required; at one scope, infer.
     from agentbundle import scope as scope_mod
 
-    repo_state_path = root / ".agentbundle-state.toml"
+    repo_state_path = resolve_state_path("repo", root)
     # A legacy (non-v0.4) state file is refused on read too (RFC-0052);
     # surface it as a clean refuse rather than a traceback.
     try:
@@ -129,7 +130,7 @@ def run(args: "argparse.Namespace") -> int:
     user_state_for_check = None
     try:
         user_root_resolved = scope_mod.resolve_user_root()
-        user_state_path = user_root_resolved / ".agentbundle" / "state.toml"
+        user_state_path = resolve_state_path("user", user_root_resolved)
         user_state_for_check = load_state(user_state_path)
         installed_at_user = user_state_for_check.has_pack(pack_name)
     except scope_mod.UserScopeUnresolvable:
@@ -248,7 +249,7 @@ def run(args: "argparse.Namespace") -> int:
     if effective_scope == "user":
         state_path = user_state_path  # already resolved above
     else:
-        state_path = root / ".agentbundle-state.toml"
+        state_path = resolve_state_path("repo", root)
     try:
         state = load_state(state_path, for_write=True)
     except ConfigError as exc:

--- a/packages/agentbundle/tests/unit/test_resolve_state_path.py
+++ b/packages/agentbundle/tests/unit/test_resolve_state_path.py
@@ -1,0 +1,21 @@
+# STUB: AC4 — red until resolve_state_path is added to _common.py
+# stub: true
+"""Unit tests for _common.resolve_state_path."""
+
+from pathlib import Path
+
+import pytest
+
+
+def test_resolve_state_path_repo_scope():
+    from agentbundle.commands._common import resolve_state_path  # noqa: PLC0415
+
+    result = resolve_state_path("repo", Path("/repo"))
+    assert result == Path("/repo/.agentbundle-state.toml")
+
+
+def test_resolve_state_path_user_scope():
+    from agentbundle.commands._common import resolve_state_path  # noqa: PLC0415
+
+    result = resolve_state_path("user", Path("/home/alice"))
+    assert result == Path("/home/alice/.agentbundle/state.toml")


### PR DESCRIPTION
## Summary

- Introduces `resolve_state_path(scope, root) -> Path` in `agentbundle/commands/_common.py` as a single source of truth for the two state-file locations (repo and user scope).
- Migrates `diff.py`, `uninstall.py`, and `upgrade.py` from inline path expressions to `resolve_state_path`. The string equality check at `upgrade.py:724` is intentionally left unchanged (AC2 carve-out — it compares a basename string, not builds a path).
- Adds 2 unit tests that went red-stub → green.
- Full regression suite passes without modification.
- Also includes a doc-only erratum note on `docs/specs/projection-dry-run/spec.md` flagging that the "Never do: change non-dry-run behavior" clause is superseded by the upcoming `unify-path-jail-projection-probe` PR.

Spec: `docs/specs/share-scope-state-path-resolver/`

## Test plan

- [x] `pytest packages/agentbundle/tests/unit/test_resolve_state_path.py` — 2 tests pass
- [x] `pytest packages/agentbundle/ -x -q` — full suite passes (exit 0)
- [x] AC2 grep: only comments and the expected `upgrade.py:724` string comparison remain

## Deferred

- `upgrade.py:724` string comparison carve-out noted in spec AC2 — not a path build, no change needed.
- Resolved-path loss in prefix-violation diagnostic for `install.py` noted in spec AC2 — intentional and acceptable.