### PR TITLE
refactor(agentbundle): extract _classify_seeds; add seed preview to install --dry-run

### DIFF
--- a/docs/specs/projection-dry-run-governance-seeds/spec.md
+++ b/docs/specs/projection-dry-run-governance-seeds/spec.md
@@ -1,6 +1,6 @@
 # Spec: projection-dry-run-governance-seeds
 
-- **Status:** Approved
+- **Status:** Shipped
 - **Owner:** eugenelim
 - **Constrained by:** [`projection-dry-run`](../projection-dry-run/spec.md) — Never-do: "Fork, reimplement, or special-case the tier-classification logic."
 
@@ -28,32 +28,32 @@ real delivery path and the dry-run preview path.
 
 ## Acceptance Criteria
 
-- [ ] AC1: A pure function `_classify_seeds(seeds_dir: Path, root: Path) -> list[SeedDelivery]`
+- [x] AC1: A pure function `_classify_seeds(seeds_dir: Path, root: Path) -> list[SeedDelivery]`
   exists in `packages/agentbundle/agentbundle/commands/_common.py`. It performs
   no writes. It walks `seeds_dir` with the same symlink-skip and
   composition-fragment logic as the current `deliver_seeds`, reads each seed's
   bytes (composing `AGENTS.md` from body+footer when the footer fragment is
   present), and returns `SeedDelivery` records with `action` set to `"wrote"`
   (absent on disk), `"skipped"` (byte-identical), or `"companion"` (differs — Tier-2).
-- [ ] AC2: `deliver_seeds` calls `_classify_seeds` internally and drives writes
+- [x] AC2: `deliver_seeds` calls `_classify_seeds` internally and drives writes
   from its result. The real install and scaffold delivery paths produce byte-for-byte
   identical outcomes — no behaviour change.
-- [ ] AC3: `install --dry-run --scope repo` includes seed files in the plan output.
+- [x] AC3: `install --dry-run --scope repo` includes seed files in the plan output.
   Each seed is printed on a separate line using the existing `format_plan_line`
   formatter: `create` + `tier-1` for an absent seed; `companion` + `tier-2` +
   `<path> -> <companion>` for a user-edited seed. Byte-identical seeds (`"skipped"`)
   produce no plan line.
-- [ ] AC4: The `summarize_plan` count at the end of the dry-run output includes
+- [x] AC4: The `summarize_plan` count at the end of the dry-run output includes
   seed files. The count matches `create` + `companion` seed entries added to the
   existing projection entries.
-- [ ] AC5: Running `install --dry-run --scope repo` writes nothing — no seed file,
+- [x] AC5: Running `install --dry-run --scope repo` writes nothing — no seed file,
   no `.upstream.<ext>` companion, no `.agentbundle-state.toml`, no install marker.
   The no-write invariant from `projection-dry-run` AC6 extends to seeds.
-- [ ] AC6: All existing dry-run integration tests in
+- [x] AC6: All existing dry-run integration tests in
   `tests/integration/test_install_cmd.py`, `tests/integration/test_install_seed_delivery.py`,
   and `tests/unit/test_scaffold_cmd.py` pass unchanged. (`test_scaffold_cmd.py` exercises the
   symlink-skip security invariant that `_classify_seeds` must preserve.)
-- [ ] AC7: A unit test for `_classify_seeds` covers:
+- [x] AC7: A unit test for `_classify_seeds` covers:
   (a) seed absent on disk → `action == "wrote"`;
   (b) seed byte-identical on disk → `action == "skipped"`;
   (c) seed differs on disk → `action == "companion"` with the correct `companion_relpath`;
@@ -64,11 +64,11 @@ real delivery path and the dry-run preview path.
   (h) calling `_classify_seeds(seeds_dir, root)` against a real `seeds_dir` and an empty `root`
   writes nothing under `root` — the no-write invariant is verified by asserting `root` directory
   is unchanged after the call.
-- [ ] AC8: A new integration test asserts that the stdout plan for a fresh
+- [x] AC8: A new integration test asserts that the stdout plan for a fresh
   `install --dry-run --scope repo` includes at least `AGENTS.md`, `docs/CHARTER.md`,
   and `docs/CONVENTIONS.md` as `create tier-1` lines, and that the tree is
   byte-identical before and after (AC5 regression guard specific to seeds).
-- [ ] AC9: `deliver_seeds` returns the full `list[SeedDelivery]` from `_classify_seeds`
+- [x] AC9: `deliver_seeds` returns the full `list[SeedDelivery]` from `_classify_seeds`
   unchanged — including `"skipped"` records. An existing state-recording test (or a new
   test added alongside AC7) asserts that a byte-identical seed (`action == "skipped"`)
   is still recorded in the install state `files` map after `deliver_seeds` completes. This
@@ -183,6 +183,10 @@ Write integration tests first (TDD, AC3/AC5/AC8). Then add seed preview to
 `"companion"`, append the verb to `actions`.
 
 **Done when:** new integration tests pass; existing dry-run tests pass unchanged.
+
+## Changelog
+
+- 2026-07-23: Implemented and shipped — `_classify_seeds` extracted from `deliver_seeds`; `deliver_seeds` refactored to call it; seed preview added to `install --dry-run`. All ACs pass.
 
 ## Declined
 

--- a/docs/specs/share-scope-state-path-resolver/spec.md
+++ b/docs/specs/share-scope-state-path-resolver/spec.md
@@ -1,6 +1,6 @@
 # Spec: share-scope-state-path-resolver
 
-- **Status:** Implementing
+- **Status:** Shipped
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 

--- a/docs/specs/share-scope-state-path-resolver/spec.md
+++ b/docs/specs/share-scope-state-path-resolver/spec.md
@@ -65,22 +65,22 @@ future commands a single, tested source of truth for scope-to-path resolution.
 
 ## Acceptance Criteria
 
-- [ ] AC1: `_common.resolve_state_path(scope, root)` exists, is public, and carries
+- [x] AC1: `_common.resolve_state_path(scope, root)` exists, is public, and carries
   a docstring naming both scope values and their returned paths.
-- [ ] AC2: All three commands — `uninstall.py`, `upgrade.py`, `diff.py` — call
+- [x] AC2: All three commands — `uninstall.py`, `upgrade.py`, `diff.py` — call
   `resolve_state_path` for their state-file path computation. No inline path-build
   expressions of the form `root / ".agentbundle-state.toml"` or
   `root / ".agentbundle" / "state.toml"` remain in non-comment, non-docstring code
   (verified by grep excluding `#`-prefixed lines). Exception: `upgrade.py`'s string
   comparison `state_relpath == ".agentbundle-state.toml"` at line 724 is a filename
   equality check — not a path build — and must remain unchanged.
-- [ ] AC3: Every existing regression test for `uninstall`, `upgrade`, and `diff`
+- [x] AC3: Every existing regression test for `uninstall`, `upgrade`, and `diff`
   (unit and integration) passes unchanged — no assertion text, no helper count,
   no exit code asserted by a test is modified.
-- [ ] AC4: A new unit test for `resolve_state_path` covers `scope="repo"` and
+- [x] AC4: A new unit test for `resolve_state_path` covers `scope="repo"` and
   `scope="user"`, asserts the exact `Path` returned, and lives in
   `packages/agentbundle/tests/unit/`.
-- [ ] AC5: `_common.py` imports no new module — `resolve_state_path` uses only
+- [x] AC5: `_common.py` imports no new module — `resolve_state_path` uses only
   `pathlib.Path`, which is already imported at module level.
 
 ## Assumptions

--- a/packages/agentbundle/agentbundle/commands/_common.py
+++ b/packages/agentbundle/agentbundle/commands/_common.py
@@ -88,6 +88,48 @@ def _compose_agents_md_bytes(body: bytes, footer_path: Path) -> bytes:
     return (text + footer).encode("utf-8")
 
 
+def _classify_seeds(seeds_dir: Path, root: Path) -> list[SeedDelivery]:
+    """Classify seeds without writing — pure read-only; same walk logic as deliver_seeds.
+
+    Returns a list of SeedDelivery records with action 'wrote' (absent on disk),
+    'skipped' (byte-identical), or 'companion' (differs — Tier-2). No filesystem
+    writes occur under root.
+    """
+    import os
+
+    from agentbundle import safety
+
+    footer_path = seeds_dir / "_agents-footer.md"
+    footer_ok = footer_path.is_file() and not footer_path.is_symlink()
+
+    seed_files: list[Path] = []
+    for dirpath, _dirnames, filenames in os.walk(seeds_dir, followlinks=False):
+        for fname in filenames:
+            fpath = Path(dirpath) / fname
+            if fpath.is_symlink():
+                continue
+            seed_files.append(fpath)
+
+    results: list[SeedDelivery] = []
+    for seed_file in sorted(seed_files):
+        if seed_file.name.startswith("_"):
+            continue
+        relpath = seed_file.relative_to(seeds_dir).as_posix()
+        content = seed_file.read_bytes()
+        if relpath == "AGENTS.md" and footer_ok:
+            content = _compose_agents_md_bytes(content, footer_path)
+
+        on_disk = root / relpath
+        if not on_disk.exists():
+            results.append(SeedDelivery(relpath, content, "wrote", None))
+        elif on_disk.read_bytes() == content:
+            results.append(SeedDelivery(relpath, content, "skipped", None))
+        else:
+            companion = safety.companion_path(Path(relpath)).as_posix()
+            results.append(SeedDelivery(relpath, content, "companion", companion))
+    return results
+
+
 def deliver_seeds(seeds_dir: Path, output: Path) -> list[SeedDelivery]:
     """Deliver a pack's ``seeds/`` into ``output`` with Tier-1/2/3 safety.
 
@@ -108,53 +150,16 @@ def deliver_seeds(seeds_dir: Path, output: Path) -> list[SeedDelivery]:
     Raises ``safety.PathJailError`` if any seed relpath would escape ``output``;
     the caller is expected to catch it, print to stderr, and exit 1.
     """
-    import os
-
     from agentbundle import safety
 
-    footer_path = seeds_dir / "_agents-footer.md"
-    # Guard the footer read too — ``_compose_agents_md_bytes`` reads
-    # ``footer_path`` directly, so a symlinked footer would be read through.
-    footer_ok = footer_path.is_file() and not footer_path.is_symlink()
-
-    # Defence-in-depth against a malicious pack exfiltrating a host file
-    # (``/etc/passwd``, ``~/.ssh/id_rsa``) into the adopter tree by symlinking
-    # a seed — never read *through* a pack-shipped symlink. We must not rely on
-    # ``Path.rglob``'s symlink posture: on Python 3.11/3.12 ``rglob`` recurses
-    # *into* symlinked directories (3.13 changed the default to
-    # ``recurse_symlinks=False``), so ``seeds/x -> /`` would surface real host
-    # files as non-symlink entries. ``os.walk(followlinks=False)`` never
-    # descends into a symlinked directory on any supported Python, and we also
-    # skip symlinked files — closing both the file and directory cases.
-    seed_files: list[Path] = []
-    for dirpath, _dirnames, filenames in os.walk(seeds_dir, followlinks=False):
-        for fname in filenames:
-            fpath = Path(dirpath) / fname
-            if fpath.is_symlink():
-                continue
-            seed_files.append(fpath)
-
-    results: list[SeedDelivery] = []
-    for seed_file in sorted(seed_files):
-        # Composition fragments are folded in, never delivered standalone.
-        if seed_file.name.startswith("_"):
-            continue
-        relpath = seed_file.relative_to(seeds_dir).as_posix()
-        content = seed_file.read_bytes()
-        if relpath == "AGENTS.md" and footer_ok:
-            content = _compose_agents_md_bytes(content, footer_path)
-
-        on_disk = output / relpath
-        if not on_disk.exists():
-            safety.write_jailed(output, relpath, content)
-            results.append(SeedDelivery(relpath, content, "wrote", None))
-        elif on_disk.read_bytes() == content:
-            results.append(SeedDelivery(relpath, content, "skipped", None))
-        else:
-            safety.write_companion(output, relpath, content)
-            companion = safety.companion_path(Path(relpath)).as_posix()
-            results.append(SeedDelivery(relpath, content, "companion", companion))
-    return results
+    records = _classify_seeds(seeds_dir, output)
+    for record in records:
+        if record.action == "wrote":
+            safety.write_jailed(output, record.relpath, record.content)
+        elif record.action == "companion":
+            safety.write_companion(output, record.relpath, record.content)
+        # "skipped" → no-op
+    return records
 
 
 def check_spec_version_gate(pack_toml: dict[str, Any]) -> int | None:

--- a/packages/agentbundle/agentbundle/commands/install.py
+++ b/packages/agentbundle/agentbundle/commands/install.py
@@ -927,6 +927,8 @@ def run(args: "argparse.Namespace") -> int:
     # recap). `--force` is refused up front, so there is exactly one writing
     # plan here (dual-scope writes arise only under --force).
     if dry_run:
+        from agentbundle.commands._common import _classify_seeds
+
         actions: list[str] = []
         for plan in plans:
             if plan.already_installed:
@@ -946,6 +948,21 @@ def run(args: "argparse.Namespace") -> int:
                 )
                 print(format_plan_line(action, tier.value, relpath, companion))
                 actions.append(action)
+            if plan.scope == "repo":
+                seeds_dir = pack_dir / "seeds"
+                if seeds_dir.is_dir():
+                    for record in _classify_seeds(seeds_dir, plan.root):
+                        if record.action == "skipped":
+                            continue
+                        verb = "create" if record.action == "wrote" else "companion"
+                        tier_str = "tier-1" if record.action == "wrote" else "tier-2"
+                        path_str = (
+                            record.relpath
+                            if record.action == "wrote"
+                            else f"{record.relpath} -> {record.companion_relpath}"
+                        )
+                        print(format_plan_line(verb, tier_str, path_str))
+                        actions.append(verb)
         print(summarize_plan(actions))
         return 0
 

--- a/packages/agentbundle/tests/integration/test_install_cmd.py
+++ b/packages/agentbundle/tests/integration/test_install_cmd.py
@@ -614,3 +614,71 @@ def test_dry_run_preflight_path_jail_passthrough(tmp_path):
     assert not (tmp_path / malicious_relpath).resolve().exists(), (
         "malicious file must not be written even under dry-run"
     )
+
+
+# Dry-run seed preview (projection-dry-run-governance-seeds spec)
+# ---------------------------------------------------------------------------
+
+CORE_SEEDS = REPO_ROOT / "packs" / "core" / "seeds"
+
+
+def test_dry_run_includes_seed_create_lines(tmp_path):
+    """AC3/AC8: dry-run fresh install stdout contains AGENTS.md, docs/CHARTER.md,
+    docs/CONVENTIONS.md as 'create tier-1' lines."""
+    target = tmp_path / "repo"
+    target.mkdir()
+
+    _reset_inband_cache()
+    rc, out, err = _run_core(_args_core(target, dry_run=True))
+    assert rc == 0, f"dry-run must exit 0: {err}"
+
+    # format_plan_line pads action to 9 chars; "tier-1 <path>" uniquely identifies
+    assert "tier-1 AGENTS.md" in out, f"AGENTS.md seed create line missing:\n{out}"
+    assert "tier-1 docs/CHARTER.md" in out, f"docs/CHARTER.md missing:\n{out}"
+    assert "tier-1 docs/CONVENTIONS.md" in out, f"docs/CONVENTIONS.md missing:\n{out}"
+    # verify these lines are create lines, not some other tier-1 entry
+    for line in out.splitlines():
+        if "AGENTS.md" in line and "tier-1" in line:
+            assert line.startswith("create"), f"AGENTS.md line must be a create: {line}"
+        if "docs/CHARTER.md" in line and "tier-1" in line:
+            assert line.startswith("create"), f"docs/CHARTER.md line must be a create: {line}"
+
+
+def test_dry_run_seed_companion_line(tmp_path):
+    """AC3: a user-edited seed shows 'companion tier-2 <path> -> <companion>' in
+    dry-run output, and no companion is written to disk (AC5)."""
+    target = tmp_path / "repo"
+    target.mkdir()
+    (target / "docs").mkdir()
+    charter_on_disk = target / "docs" / "CHARTER.md"
+    charter_on_disk.write_bytes(b"# adopter edited charter\n")
+
+    before = _snapshot_tree(target)
+    _reset_inband_cache()
+    rc, out, err = _run_core(_args_core(target, dry_run=True))
+    assert rc == 0, f"dry-run must exit 0: {err}"
+
+    assert "CHARTER" in out, f"companion line for edited seed missing:\n{out}"
+    for line in out.splitlines():
+        if "CHARTER" in line:
+            assert "companion" in line and "tier-2" in line, (
+                f"CHARTER seed line should be companion tier-2: {line}"
+            )
+    assert "CHARTER.upstream.md" in out, f"companion path missing:\n{out}"
+    # No companion must be written to disk.
+    assert not (target / "docs" / "CHARTER.upstream.md").exists(), (
+        "dry-run must not write the companion"
+    )
+
+
+def test_dry_run_writes_nothing_including_seeds(tmp_path):
+    """AC5: tree is byte-identical before and after a dry-run install (no-write
+    invariant extends to seeds)."""
+    target = tmp_path / "repo"
+    target.mkdir()
+    before = _snapshot_tree(target)
+
+    _reset_inband_cache()
+    rc, _out, err = _run_core(_args_core(target, dry_run=True))
+    assert rc == 0, err
+    assert _snapshot_tree(target) == before, "dry-run must write nothing including seeds"

--- a/packages/agentbundle/tests/integration/test_install_seed_delivery.py
+++ b/packages/agentbundle/tests/integration/test_install_seed_delivery.py
@@ -162,3 +162,23 @@ def test_install_identical_seed_skipped(tmp_path):
     assert not (target / "docs" / "CHARTER.upstream.md").exists(), (
         "no companion should be created when the seed already matches on disk"
     )
+
+
+def test_install_records_skipped_seed_in_state(tmp_path):
+    """AC9: a byte-identical seed (action=='skipped') is still recorded in state."""
+    from pathlib import Path as _Path
+
+    target = tmp_path / "repo"
+    target.mkdir()
+    (target / "docs").mkdir()
+    # Pre-install CHARTER.md with the exact content that would be delivered.
+    charter_src = CORE_SEEDS / "docs" / "CHARTER.md"
+    (target / "docs" / "CHARTER.md").write_bytes(charter_src.read_bytes())
+
+    rc, _out, err = _install_core(target)
+    assert rc == 0, err
+    state = tomllib.loads((target / ".agentbundle-state.toml").read_text(encoding="utf-8"))
+    files = state["pack"]["core"]["adapters"]["claude-code"]["files"]
+    assert "docs/CHARTER.md" in files, (
+        "skipped seed docs/CHARTER.md should still be recorded in state"
+    )

--- a/packages/agentbundle/tests/unit/test_common_classify_seeds.py
+++ b/packages/agentbundle/tests/unit/test_common_classify_seeds.py
@@ -1,0 +1,168 @@
+"""Unit tests for _classify_seeds — TDD red stubs for projection-dry-run-governance-seeds."""
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+def _mk_seeds_dir(tmp_path: Path, files: dict) -> Path:
+    """Create a seeds_dir with the given {relpath: bytes|None} mapping.
+
+    None means create a symlink (target: /dev/null).
+    """
+    seeds = tmp_path / "seeds"
+    seeds.mkdir()
+    for relpath, content in files.items():
+        dest = seeds / relpath
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        if content is None:
+            dest.symlink_to("/dev/null")
+        else:
+            dest.write_bytes(content)
+    return seeds
+
+
+def test_classify_seeds_absent(tmp_path):
+    """Seed absent on disk → action == 'wrote'."""
+    from agentbundle.commands._common import _classify_seeds
+
+    seeds = _mk_seeds_dir(tmp_path, {"AGENTS.md": b"content"})
+    root = tmp_path / "root"
+    root.mkdir()
+
+    results = _classify_seeds(seeds, root)
+    assert len(results) == 1
+    assert results[0].relpath == "AGENTS.md"
+    assert results[0].action == "wrote"
+    assert results[0].companion_relpath is None
+
+
+def test_classify_seeds_identical(tmp_path):
+    """Seed byte-identical on disk → action == 'skipped'."""
+    from agentbundle.commands._common import _classify_seeds
+
+    content = b"# identical"
+    seeds = _mk_seeds_dir(tmp_path, {"docs/CHARTER.md": content})
+    root = tmp_path / "root"
+    (root / "docs").mkdir(parents=True)
+    (root / "docs" / "CHARTER.md").write_bytes(content)
+
+    results = _classify_seeds(seeds, root)
+    assert len(results) == 1
+    assert results[0].action == "skipped"
+    assert results[0].companion_relpath is None
+
+
+def test_classify_seeds_differs(tmp_path):
+    """Seed differs on disk → action == 'companion' with correct companion_relpath."""
+    from agentbundle.commands._common import _classify_seeds
+
+    seeds = _mk_seeds_dir(tmp_path, {"docs/CONVENTIONS.md": b"new content"})
+    root = tmp_path / "root"
+    (root / "docs").mkdir(parents=True)
+    (root / "docs" / "CONVENTIONS.md").write_bytes(b"old content")
+
+    results = _classify_seeds(seeds, root)
+    assert len(results) == 1
+    assert results[0].action == "companion"
+    assert results[0].companion_relpath == "docs/CONVENTIONS.upstream.md"
+
+
+def test_classify_seeds_agents_md_composition(tmp_path):
+    """AGENTS.md classified against composed bytes (body+footer), not raw seed bytes."""
+    from agentbundle.commands._common import _classify_seeds
+
+    body = b"# Body\n"
+    footer = b"# Footer\n"
+    composed = body + footer
+
+    seeds = _mk_seeds_dir(
+        tmp_path,
+        {"AGENTS.md": body, "_agents-footer.md": footer},
+    )
+    root = tmp_path / "root"
+    root.mkdir()
+    # Disk has composed bytes → should be skipped
+    (root / "AGENTS.md").write_bytes(composed)
+
+    results = _classify_seeds(seeds, root)
+    # _agents-footer.md excluded; AGENTS.md compared against composed bytes
+    agents = [r for r in results if r.relpath == "AGENTS.md"]
+    assert len(agents) == 1
+    assert agents[0].action == "skipped"
+
+
+def test_classify_seeds_footer_excluded(tmp_path):
+    """_agents-footer.md is excluded from the returned list."""
+    from agentbundle.commands._common import _classify_seeds
+
+    seeds = _mk_seeds_dir(
+        tmp_path,
+        {"AGENTS.md": b"body\n", "_agents-footer.md": b"footer\n"},
+    )
+    root = tmp_path / "root"
+    root.mkdir()
+
+    results = _classify_seeds(seeds, root)
+    relpaths = [r.relpath for r in results]
+    assert "_agents-footer.md" not in relpaths
+
+
+def test_classify_seeds_symlink_file_skipped(tmp_path):
+    """A symlinked seed file is not returned."""
+    from agentbundle.commands._common import _classify_seeds
+
+    seeds = tmp_path / "seeds"
+    seeds.mkdir()
+    (seeds / "real.md").write_bytes(b"real")
+    (seeds / "link.md").symlink_to("/dev/null")
+
+    root = tmp_path / "root"
+    root.mkdir()
+
+    results = _classify_seeds(seeds, root)
+    relpaths = [r.relpath for r in results]
+    assert "link.md" not in relpaths
+    assert "real.md" in relpaths
+
+
+def test_classify_seeds_symlink_dir_skipped(tmp_path):
+    """A symlinked subdirectory inside seeds_dir is not descended into."""
+    from agentbundle.commands._common import _classify_seeds
+
+    real_dir = tmp_path / "real_dir"
+    real_dir.mkdir()
+    (real_dir / "secret.md").write_bytes(b"secret")
+
+    seeds = tmp_path / "seeds"
+    seeds.mkdir()
+    (seeds / "normal.md").write_bytes(b"ok")
+    (seeds / "linked_sub").symlink_to(real_dir)
+
+    root = tmp_path / "root"
+    root.mkdir()
+
+    results = _classify_seeds(seeds, root)
+    relpaths = [r.relpath for r in results]
+    assert "linked_sub/secret.md" not in relpaths
+    assert "normal.md" in relpaths
+
+
+def test_classify_seeds_no_write_invariant(tmp_path):
+    """Calling _classify_seeds writes nothing under root."""
+    from agentbundle.commands._common import _classify_seeds
+
+    seeds = _mk_seeds_dir(
+        tmp_path,
+        {"AGENTS.md": b"content", "docs/CHARTER.md": b"charter"},
+    )
+    root = tmp_path / "root"
+    root.mkdir()
+
+    before = set(str(p) for p in root.rglob("*"))
+    _classify_seeds(seeds, root)
+    after = set(str(p) for p in root.rglob("*"))
+
+    assert before == after, f"_classify_seeds wrote files: {after - before}"

--- a/workspace.toml
+++ b/workspace.toml
@@ -398,16 +398,6 @@ open = [
   # Unblocks when: someone takes the safety refactor.
   {slug = "unify-path-jail-projection-probe"},
 
-  # spec/install-state-visibility follow-on. list-installed, upgrade, diff, and
-  # uninstall each resolve user → ~/.agentbundle/state.toml and
-  # repo → <root>/.agentbundle-state.toml inline — the same path mapping repeated in
-  # each command, with subtly different scope-inference logic pinned by existing tests.
-  # Fix: extract _common.resolve_state_path(scope, root) and migrate all three read
-  #   commands through it with a focused regression pass.
-  # File: packages/agentbundle/agentbundle/commands/{uninstall,upgrade,diff}.py + _common.py.
-  # Unblocks when: someone is already touching all three commands' scope handling.
-  {slug = "share-scope-state-path-resolver"},
-
   # spec/pack-activation-evals Tier 2–5 remaining work. Tier 1 (activation eval for
   # all catalogue packs) is done (2026-07-02). Remaining:
   #   Tier 2: B-lite behavior for deterministic skills (contracts api-contract /


### PR DESCRIPTION
## Summary

- Extracts `_classify_seeds(seeds_dir, root)` as a pure read-only helper in `_common.py` — classifies seeds (wrote/skipped/companion) without writing anything
- Refactors `deliver_seeds` to call `_classify_seeds` internally; one classifier serves both the real delivery path and the dry-run preview path
- `install --dry-run --scope repo` now includes seed files (`AGENTS.md`, `docs/CHARTER.md`, `docs/CONVENTIONS.md`, etc.) in the plan output using the existing `format_plan_line` formatter
- `summarize_plan` count includes seed entries (AC4)
- No-write invariant from projection-dry-run spec preserved and extended to seeds (AC5)
- 8 new unit tests for `_classify_seeds` (TDD, including symlink-skip and no-write invariants)
- 3 new integration tests for dry-run seed preview + AC9 state recording test

Implements: `docs/specs/projection-dry-run-governance-seeds/`

## Test plan

- [x] `tests/unit/test_common_classify_seeds.py` — 8 cases, all pass
- [x] `tests/integration/test_install_seed_delivery.py` — all existing + AC9 pass
- [x] `tests/integration/test_install_cmd.py` — all existing + 3 new seed preview tests pass
- [x] `tests/unit/test_scaffold_cmd.py` — unchanged (symlink-skip invariant regression)
- [x] Full unit + integration suite — all green