### PR TITLE
chore(release): agentbundle 0.12.1

### DIFF
--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -6,10 +6,16 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 — a minor bump on a 0.x release MAY be breaking.
 
-## [Unreleased]
+## [0.12.1] — 2026-07-23
 
 ### Changed
 
+- **`install --dry-run` now previews governance seed files alongside the
+  projected adapter files.** Seeds (AGENTS.md, docs/CHARTER.md,
+  CONVENTIONS.md, and companions) are classified read-only and included in
+  the plan output — `create tier-1`, `companion tier-2`, or skipped — so
+  the dry-run is a complete picture of what a real install would write, not
+  just the adapter projection.
 - **`assert_projection_jailed` centralises the two-step path-jail check.**
   A new read-only helper in `agentbundle/safety.py` unifies the root-escape
   (`assert_under`) and prefix-match checks that were duplicated across

--- a/packages/agentbundle/agentbundle/version.py
+++ b/packages/agentbundle/agentbundle/version.py
@@ -14,7 +14,7 @@ import tomllib
 from importlib.resources import files
 from pathlib import Path
 
-CLI_VERSION = "0.12.0"
+CLI_VERSION = "0.12.1"
 
 _HERE = Path(__file__).resolve().parent
 

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentbundle"
-version = "0.12.0"
+version = "0.12.1"
 description = "npm for your coding agent. Install packs of skills, subagents, and hooks into any repo, for every major agent."
 requires-python = ">=3.11"
 dependencies = []


### PR DESCRIPTION
## Summary

Release 0.12.1 — three agentbundle refactors since 0.12.0:

- **`install --dry-run` previews governance seeds** (PR #628): seeds (AGENTS.md, docs/CHARTER.md, CONVENTIONS.md, companions) are now classified read-only and included in the dry-run plan output — `create tier-1`, `companion tier-2`, or skipped.
- **`assert_projection_jailed` centralises path-jail logic** (PR #629): new read-only helper in `safety.py` unifies the root-escape + prefix-match check across install Step 8, upgrade dry-run, and `write_jailed`'s inline block.
- **`upgrade` pre-flight before write** (PR #629): non-dry-run upgrade now probes all paths first; a prefix violation aborts with zero files written.

## Changes

- `packages/agentbundle/pyproject.toml`: `0.12.0` → `0.12.1`
- `packages/agentbundle/agentbundle/version.py`: `CLI_VERSION` `0.12.0` → `0.12.1`
- `packages/agentbundle/CHANGELOG.md`: `[Unreleased]` → `[0.12.1] — 2026-07-23`

## Test plan

- [ ] CI passes (build-check, release-agentbundle)
- [ ] Merge with squash
- [ ] Tag `agentbundle-v0.12.1` on the merge commit to trigger PyPI publish