### PR TITLE
feat(iac-terraform): HCP Terraform and Scalr remote exec platform support (RFC-0070)

### DIFF
--- a/docs/rfc/0065-iac-terraform-pack.md
+++ b/docs/rfc/0065-iac-terraform-pack.md
@@ -1373,6 +1373,16 @@ _All in one PR (Q2 — companions ship with the pack)._
   a third **ADR compliance check trigger** was added (checks an incoming IaC diff
   against governance-index ADRs for changes not authored by `generate-iac`).
 
+## Errata
+
+- **2026-07-23 — Remote execution platform support (RFC-0070).** RFC-0065 §8
+  deferred "commercial platform configs" (HCP Terraform, Scalr, Atlantis, etc.)
+  as a follow-on reference. [RFC-0070](0070-iac-terraform-remote-exec-platforms.md)
+  fulfils the HCP Terraform and Scalr portion of that deferral: it adds
+  `references/remote-exec/hcp-terraform.md` + `references/remote-exec/scalr.md`,
+  a new `remote_exec_platform` clarify input to `generate-iac`, a generated
+  `REMOTE_EXEC_SETUP.md`, and backend-type detection in `reconcile-iac`.
+
 ## Deferred items (post-ship)
 
 - **Azure provider validation (deferred to v2).** Azure shipped

--- a/docs/rfc/0070-iac-terraform-remote-exec-platforms.md
+++ b/docs/rfc/0070-iac-terraform-remote-exec-platforms.md
@@ -1,0 +1,471 @@
+# RFC-0070: Remote execution platforms for `iac-terraform`
+
+<!-- Written for a cold reader who has not read RFC-0065. Coined terms are
+glossed on first use inline. -->
+
+- **Status:** Accepted
+- **Author:** eugenelim
+- **Approver:** eugenelim
+- **Date opened:** 2026-07-23
+- **Date closed:** 2026-07-23
+- **Decision weight:** standard <!-- credential guidance crosses a security-adjacent
+  boundary, but the credentials themselves are never generated or stored by the
+  pack — it only documents what the adopter must set. The spike (OQ1) is deferred
+  with a documented justification. `heavy` was considered and declined: the change
+  is reversible (platform = none default), no frozen ADR is reversed, and no
+  long-lived secret is generated. -->
+- **Related:** [RFC-0065](0065-iac-terraform-pack.md) (the `iac-terraform` pack —
+  the accepted RFC that introduced the pack and explicitly deferred remote
+  execution platform support as a follow-on in §8)
+
+---
+
+## Reviewer brief
+
+- **Decision:** Extend the `iac-terraform` pack (an opt-in Terraform/OpenTofu
+  code-generation pack — "the pack") to support HCP Terraform and Scalr as
+  remote execution backends alongside the existing cloud-native state backends.
+- **Recommended outcome:** Accept — all five decisions below were confirmed
+  by the author in the same session.
+- **Change if accepted:**
+  - New `references/remote-exec/` directory with two platform references
+    (`hcp-terraform.md`, `scalr.md`) — each covers config block, auth, dynamic
+    credential guidance, bootstrap, and CI trigger notes.
+  - `generate-iac` skill gains a new `remote_exec_platform` clarify input
+    (`none | hcp-terraform | scalr`); `hcp-terraform` is blocked when
+    `engine = opentofu`.
+  - `generate-iac` emits a `REMOTE_EXEC_SETUP.md` for remote-exec targets,
+    leading with dynamic provider credentials / OIDC federation as the preferred
+    credential model.
+  - `reconcile-iac` gains backend-type detection and flags legacy
+    `backend "remote" { hostname = "app.terraform.io" }` for migration.
+- **Affected surface:** `packs/iac-terraform` only — skill files and new
+  reference files. No change to `core`, `governance-extras`, or any other pack.
+  (`core` and `governance-extras` are the two packs `iac-terraform` depends on;
+  naming them confirms they are out of scope.)
+- **Stakes:** Reversible — `platform = none` is the default; adopters not on
+  these platforms are unaffected.
+- **Review focus:** Credential guidance model (§3) — leads with dynamic
+  credentials / OIDC federation, not static keys.
+- **Not in scope:** Atlantis, Spacelift, env0, Terrateam; autonomous apply;
+  direct API scripting; multi-workspace fan-out.
+
+---
+
+## The ask
+
+**Recommendation (BLUF — Bottom Line Up Front):** Add `hcp-terraform` and
+`scalr` as first-class remote execution platform options to `generate-iac` and
+`reconcile-iac`. The change is additive — `platform = none` (vanilla CI with
+cloud-native state backend) remains the default and is unchanged.
+
+**Why now (SCQA — Situation / Complication / Question / Answer):** The pack
+generates Terraform/OpenTofu with cloud-native state backends (S3, GCS, Azure
+Blob) and vanilla CI pipelines. Many adopter organisations run **HCP Terraform**
+(HashiCorp's managed remote-execution SaaS, formerly Terraform Cloud) or
+**Scalr** (a compatible open-alternative SaaS with a hierarchical policy model)
+as their execution platform. Without pack support, adopters on these platforms
+either generate the wrong backend config or manually patch the output — neither
+is safe. RFC-0065 §8 explicitly called this out as a planned follow-on. The
+design decisions have now been researched and confirmed.
+
+**Decisions requested — all confirmed by Approver in the authoring session:**
+
+| ID | Question | Decision | Rationale |
+| -- | -------- | --------- | --------- |
+| D1 | RFC form — new RFC or errata on RFC-0065? | New RFC-0070 + Errata entry on RFC-0065 §8 | Errata = corrections to a frozen RFC; this is a new feature. RFC-0065 §8 anticipated it as a follow-on. |
+| D2 | Reference structure — 2 files in `references/remote-exec/` (config+CI+bootstrap combined) vs 4 files split across `remote-exec/` + `pipeline/`? | 2 files in `references/remote-exec/` | Platform IS the execution layer; the CI trigger is a thin delta, not a full pipeline. Mirrors `providers/` pattern (one file per target, loaded conditionally). |
+| D3 | Credential guidance — generated `REMOTE_EXEC_SETUP.md` vs inline comments? | Generated `REMOTE_EXEC_SETUP.md` | Mirrors `backend.hcl.example` precedent (a file generated alongside `backend.tf` for vanilla CI); credentials-not-forwarded is the top foot-gun for remote exec. |
+| D4 | Bootstrap narrative — inline in each platform reference vs new `bootstrap-sequence.md` section? | Inline in each platform reference | Remote-exec bootstrap differs per platform and is short (≤5 steps); `bootstrap-sequence.md` stays scoped to the object-store case. |
+| D5 | `reconcile-iac` scope — detect backend type and flag legacy TFC config for migration? | In scope | One detection case; excluding it means a follow-on RFC for a 5-line addition. |
+
+---
+
+## Problem & goals
+
+### Problem
+
+The pack generates a `backend.tf` that always points to a cloud-native object
+store (S3, GCS, Azure Blob). When an adopter's organisation uses HCP Terraform
+or Scalr as its execution platform:
+
+1. The generated backend config is wrong — neither platform uses an object-store
+   backend block.
+2. The correct config form differs between platforms: HCP Terraform uses a
+   `cloud {}` block (Terraform ≥ 1.1); Scalr uses a `backend "remote"` block
+   with `hostname = "<account>.scalr.io"`.
+3. **Credentials for the cloud provider (AWS, GCP, etc.) must be set as workspace
+   environment variables inside the platform — they are not forwarded from the
+   local or CI runner environment.** This is the most common foot-gun.
+4. HCP Terraform's `cloud {}` block is incompatible with OpenTofu (the alternative
+   open-source Terraform fork); Scalr's `backend "remote"` is compatible with both
+   engines. Without an enforced gate, an adopter can generate an HCP Terraform
+   config for an OpenTofu target and discover the incompatibility only at
+   `terraform init`.
+
+### Goals
+
+- Extend `generate-iac` with a `remote_exec_platform` clarify input
+  (`none | hcp-terraform | scalr`), defaulting to `none`.
+- When `platform = hcp-terraform`, emit a `cloud {}` block and enforce that
+  `engine` must be `terraform` (not `opentofu`).
+- When `platform = scalr`, emit a `backend "remote"` block and surface the
+  `organization` = environment-name trap (see Proposal §1).
+- For both platforms, emit a `REMOTE_EXEC_SETUP.md` that leads with dynamic
+  provider credentials / OIDC federation (the preferred model) and names static
+  workspace variables only as a fallback.
+- Extend `reconcile-iac` to detect the backend type and flag legacy
+  `backend "remote" { hostname = "app.terraform.io" }` for migration to
+  `cloud {}`.
+
+### Non-goals
+
+- **Atlantis, Spacelift, env0, Terrateam** — deferred. RFC-0065 §8 deferred
+  commercial platform configs generically; this RFC delivers the HCP Terraform
+  and Scalr portion. GitOps platforms (Atlantis emits `atlantis.yaml`, not a
+  `backend.tf`) warrant their own RFC.
+- **API-driven run scripting** — the pack generates Terraform HCL; the
+  `terraform` / `tofu` CLI handles platform API calls transparently when the
+  correct block is present.
+- **Multi-workspace fan-out** — one `generate-iac` invocation targets one
+  workspace. Fan-out is a `release-loop` concern. (`release-loop` is a separate
+  pack that orchestrates deploy → converge cycles; it is not modified by this RFC.)
+- **Autonomous apply** — unchanged; the G4 handoff (the fourth gate in the
+  project's loop arc, a digest-pinned `terraform plan`) and human-gated apply
+  are pack invariants regardless of platform.
+- **Platform workspace creation** — the pack documents what to configure in an
+  existing workspace; it does not provision the workspace via the `hashicorp/tfe`
+  or `scalr/scalr` Terraform providers.
+
+---
+
+## Proposal
+
+### 1. New reference directory: `references/remote-exec/`
+
+Two new files under
+`packs/iac-terraform/.apm/skills/generate-iac/references/remote-exec/`.
+(`.apm/` is the skills directory consumed by the agent bundle installer; all
+pack skill content lives under it.)
+
+Each file is a **progressive reference** — `generate-iac` loads it on demand
+during the PLAN stage when the platform is selected; adopters who choose
+`platform = none` never see it.
+
+**`hcp-terraform.md`** covers:
+
+- **Config block** — the `cloud {}` block (all fields + env-var overrides):
+  - `TF_TOKEN_app_terraform_io` — the API token for `app.terraform.io`
+    (replaces interactive `terraform login`)
+  - `TF_CLOUD_ORGANIZATION` — org name, overrides `cloud.organization`
+  - `TF_CLOUD_HOSTNAME` — for Terraform Enterprise (self-hosted HCP); defaults
+    to `app.terraform.io`
+  - `TF_WORKSPACE`, `TF_CLOUD_PROJECT` — workspace and project name overrides
+- **Token-type scoping guard** — organisation tokens cannot trigger runs or create
+  configuration versions; team or user token required. Generates a named warning
+  in `REMOTE_EXEC_SETUP.md`.
+- **Dynamic Provider Credentials** — HCP Terraform's OIDC (OpenID Connect —
+  identity federation) integration with cloud providers; lets the remote runner
+  exchange a short-lived JWT for cloud credentials without any static key. This
+  is the preferred credential model (aligns with the pack's no-long-lived-keys
+  invariant). Named alongside the workspace-variable fallback.
+- **Remote operations model** — local env vars not forwarded; the static-key
+  fallback requires workspace environment variables set inside HCP Terraform.
+- **Run states** — `needs_confirmation` and `policy_override` require agent or
+  human action; documented so adopters know to handle them.
+- **Policy enforcement** — OPA (Open Policy Agent, the pack's mandated open-source
+  policy tool, used via Conftest) is separate from HCP Terraform's native policy
+  evaluation. Both can coexist: Conftest runs in the CI pipeline before the
+  remote run; HCP Terraform can also run OPA natively (paid tier). Sentinel
+  (HCP Terraform's proprietary policy language) is Terraform + paid-tier only
+  and must NOT be emitted by this pack.
+- **CI trigger notes** — when `cloud {}` is present, `terraform plan` run in CI
+  proxies to HCP Terraform; CI emits no OIDC to a state backend (state lives in
+  the platform). Cloud-provider OIDC trust policy is still required if Dynamic
+  Provider Credentials is not configured. The remote-exec reference provides the
+  *platform delta* only; it composes with the existing
+  `references/pipeline/<ci>.md` which remains the source of truth for the
+  CI pipeline structure.
+- **Bootstrap narrative** — create workspace → configure Dynamic Provider
+  Credentials (or set workspace variables as fallback) → run `terraform init` →
+  first plan runs remotely.
+
+**`scalr.md`** covers:
+
+- **Config block** — `backend "remote"` block:
+  ```hcl
+  terraform {
+    backend "remote" {
+      hostname     = "<account-name>.scalr.io"
+      organization = "<environment-name>"   # NOTE: not the account name
+      workspaces { name = "<workspace-name>" }
+    }
+  }
+  ```
+  Critical naming trap: the `organization` field takes the **Scalr environment
+  name** (not the account name). The account name is encoded in `hostname`. This
+  is the most common misconfiguration when porting TFC configs to Scalr.
+- **Auth** — `TF_TOKEN_<account-name>_scalr_io` (dots → underscores, same
+  `TF_TOKEN_*` pattern as HCP Terraform). Service-account or personal token; no
+  equivalent of HCP Terraform's organisation-token restriction.
+- **Provider integrations** (preferred credential model) — Scalr's native
+  cloud-provider credential management injects credentials at run time via OIDC
+  federation, without workspace environment variables. This is the preferred
+  model; workspace env vars are the fallback for organisations that have not yet
+  configured provider integrations.
+- **Three-tier hierarchy** — **account** (top-level; manages RBAC — Role-Based
+  Access Control — and OPA policies) → **environment** (team-level grouping,
+  e.g. `production` / `dev`) → **workspace** (execution unit). Variables, OPA
+  policies, and credentials cascade downward; any level can mark a value `final`
+  to prevent override by lower scopes. This hierarchical governance model is a
+  structural differentiator from HCP Terraform's flat org/workspace model.
+- **OpenTofu compatibility** — `backend "remote"` is a standard Terraform backend
+  protocol, not a HashiCorp proprietary extension; Scalr is the recommended
+  remote execution option when `engine = opentofu`.
+- **OPA policy enforcement** — pre-plan and post-plan; Sentinel is not supported
+  by Scalr.
+- **CI trigger notes** — same pattern as HCP Terraform; the platform delta
+  composes with `references/pipeline/<ci>.md`.
+- **Bootstrap narrative** — create account → create environment → create workspace
+  → configure provider integrations (or set env-level variables as fallback) →
+  run `terraform init`.
+
+### 2. `generate-iac` skill changes
+
+**Background:** `generate-iac` is the pack's authoring skill. It runs in stages:
+ADR gate → SPECIFY → CLARIFY (collect inputs) → PLAN (load references, draft
+layout) → WRITE TF (emit HCL files) → VERIFY (fmt/validate/plan/policy) → G4
+handoff. An **ADR** (Architecture Decision Record) is a short document recording
+a team's infrastructure decision; the pack gates generation on these to ensure
+every Terraform config has a governance record.
+
+**CLARIFY stage — new input row:**
+
+| Input | Default | Note |
+| ----- | ------- | ---- |
+| Remote execution platform | `none` | `none \| hcp-terraform \| scalr`. If `engine = opentofu`, only `none` and `scalr` are valid — `hcp-terraform` requires the `cloud {}` block, which is Terraform-only. |
+
+The `engine` input already exists in the CLARIFY table (Terraform or OpenTofu).
+The constraint is enforced: if `engine = opentofu` and `platform = hcp-terraform`
+is requested, the skill surfaces the incompatibility and re-asks.
+
+**PLAN stage:** when `platform ≠ none`, load
+`references/remote-exec/<platform>.md` alongside `references/providers/<cloud>.md`
+and `references/pipeline/<ci>.md`.
+
+**WRITE TF stage — backend generation branching:**
+
+| Platform | Generated files |
+| -------- | --------------- |
+| `none` (default) | `backend.tf` with cloud-native backend + `backend.hcl.example` (a template for per-environment backend values, populated by the adopter at `terraform init`) |
+| `hcp-terraform` | `versions.tf` with `cloud {}` block; no `backend.hcl.example` (unused); no `backend.tf` |
+| `scalr` | `backend.tf` with `backend "remote"` block; `hostname = "<account>.scalr.io"`; `organization = "<env-name>"`; no `backend.hcl.example` |
+
+**WRITE OUTPUT stage:** when `platform ≠ none`, emit `REMOTE_EXEC_SETUP.md`
+(§3 below).
+
+**Hard rules to add to the never-emit list** (the existing list of patterns the
+skill must not generate under any circumstance):
+- Never emit `backend "remote"` pointing to `app.terraform.io` (deprecated TFC
+  form; generate `cloud {}` for HCP Terraform targets instead).
+- Never emit an HCP Terraform config for an `engine = opentofu` target.
+- Never emit Sentinel policy guidance (already banned; reinforce with a
+  remote-exec callout — Sentinel is Terraform + HCP paid tier only).
+
+### 3. Generated `REMOTE_EXEC_SETUP.md`
+
+Emitted into the project root when `platform ≠ none`. Six sections, leading
+with the dynamic / OIDC-federated credential model to align with the pack's
+no-long-lived-keys invariant:
+
+1. **Platform auth token** — how to set `TF_TOKEN_app_terraform_io` (HCP
+   Terraform) or `TF_TOKEN_<account>_scalr_io` (Scalr) so `terraform login` is
+   not needed in CI.
+2. **Dynamic provider credentials (preferred)** — for HCP Terraform: Dynamic
+   Provider Credentials (OIDC trust between HCP Terraform and the cloud provider;
+   no static keys). For Scalr: provider integrations (equivalent OIDC mechanism).
+   Named with setup links. This is the model that satisfies the pack's invariant.
+3. **Static workspace variables (fallback)** — named list of the workspace
+   environment variables to set in the platform for the target cloud if dynamic
+   credentials are not yet configured (e.g. AWS: `AWS_ACCESS_KEY_ID` +
+   `AWS_SECRET_ACCESS_KEY`; GCP: `GOOGLE_CREDENTIALS`). Labelled as a fallback
+   and marked for migration to dynamic credentials.
+4. **Platform-specific traps** — HCP Terraform: organisation tokens cannot
+   trigger runs (use team/user token). Scalr: `organization` field = Scalr
+   environment name, not account name; `final` flag prevents workspace-level
+   override of environment/account-scoped values.
+5. **Variable inheritance (Scalr only)** — account → environment → workspace
+   cascade; prefer setting shared credentials at environment level so all
+   workspaces in the environment inherit them.
+6. **OpenTofu note** — `hcp-terraform` is not available for OpenTofu targets;
+   Scalr's `backend "remote"` is compatible with both `terraform` and `opentofu`.
+
+### 4. `reconcile-iac` skill additions
+
+`reconcile-iac` is the pack's drift-audit skill. It runs `terraform plan
+-detailed-exitcode` and audits the result. A **backend-type detection step** is
+added to its pre-audit preamble (the initial read of the project before running
+`plan`):
+
+1. Inspect `versions.tf` for a `cloud {}` block → platform = `hcp-terraform`.
+2. Inspect `backend.tf` for `backend "remote"` → inspect `hostname`:
+   - `app.terraform.io` → legacy TFC config; flag for migration to `cloud {}`
+     and surface a migration note.
+   - `*.scalr.io` → platform = `scalr`.
+   - Anything else → unknown remote backend; note in report.
+3. No `cloud {}` and no `backend "remote"` → platform = `none`.
+
+The platform type is recorded in the audit report header. For remote-exec
+platforms, a note is added: "plan runs remotely on `<platform>`; resources
+created entirely outside Terraform are invisible to `plan` — the blind-spot
+caveat applies as with local execution."
+
+**Cross-reference:** `references/providers/hashicorp-platform.md` documents the
+`hashicorp/hcp` Terraform provider for provisioning HCP resources (Vault, Consul,
+HCP Terraform workspaces) as infrastructure. That is distinct from this RFC's
+concern, which is using HCP Terraform as the *execution backend* for the
+`iac-terraform` pack itself. The two files serve different purposes and should
+not be conflated.
+
+---
+
+## Options considered
+
+### D2: Reference file structure (axis: granularity of new files)
+
+| Option | Files | Trade-off |
+| ------ | ----- | --------- |
+| **`references/remote-exec/<platform>.md` (confirmed)** | 2 new | Mirrors `providers/` pattern. Platform IS the execution layer; CI trigger is a thin platform delta, not a full pipeline. |
+| Split: `remote-exec/` (config) + `pipeline/` (CI trigger) | 4 new | Splits a tight concern; the CI trigger for remote-exec is too thin to warrant a separate reference file per platform. |
+| Conditional sections in existing `pipeline/github-actions.md` etc. | 0 new | Wrong categorisation — platform is orthogonal to CI trigger system. |
+| Do nothing | 0 | Adopters generate wrong configs; RFC-0065 §8 already deferred this once. |
+
+### D3: Credential guidance form (axis: discoverability vs. file count)
+
+| Option | Form | Trade-off |
+| ------ | ---- | --------- |
+| **`REMOTE_EXEC_SETUP.md` (confirmed)** | 1 generated file | Mirrors `backend.hcl.example` precedent; table-formatted, shows up in directory listing. |
+| Inline comments in `versions.tf` / `backend.tf` | 0 new files | Too truncated for structured variable lists. |
+| No guidance | 0 | Credentials-not-forwarded is the top foot-gun; omitting it is a known-bad outcome. |
+
+### D4: Bootstrap narrative location (axis: cohesion vs. file count)
+
+| Option | Where | Trade-off |
+| ------ | ----- | --------- |
+| **Inline in each `references/remote-exec/<platform>.md` (confirmed)** | Platform reference | Platform-specific, short (≤5 steps); keeps `bootstrap-sequence.md` scoped to the object-store case. |
+| New section in `bootstrap-sequence.md` | Existing file | Conflates the object-store bootstrap with the SaaS platform bootstrap. |
+| New `references/remote-exec/bootstrap.md` | 1 new file | Overengineered for ≤10 lines per platform. |
+
+### D5: `reconcile-iac` scope (axis: include vs. defer)
+
+| Option | Trade-off |
+| ------ | --------- |
+| **In scope (confirmed)** | One detection case (grep + hostname check); excluding it means a follow-on RFC for a 5-line addition. |
+| Out of scope / follow-on RFC | Cleaner scope boundary; smaller RFC; the migration nudge is low-urgency. |
+| Do nothing | Legacy TFC adopters get no migration nudge; silent misconfiguration persists. |
+
+---
+
+## Risks & what would make this wrong
+
+**Pre-mortem:**
+
+1. **Scalr `cloud {}` support ships.** If Scalr adds `cloud {}` support, the
+   `backend "remote"` recommendation becomes a legacy path. *Mitigation:*
+   reference files are versioned; a future pack bump can update `scalr.md`
+   without changing the RFC.
+2. **HCP Terraform token scoping changes.** If HashiCorp adds run-triggering
+   capability to organisation tokens, the org-token warning becomes stale.
+   *Mitigation:* low probability (architectural restriction); the staleness CI
+   job (a weekly scheduled GitHub Actions workflow that re-runs `terraform
+   validate` on the pack's worked examples against the latest provider release)
+   already re-validates provider contracts.
+3. **Scalr `organization` field semantics change.** If Scalr renames environments
+   to organisations, the named trap becomes confusing. *Mitigation:* `reconcile-iac`
+   would surface the misconfiguration.
+4. **Dynamic Provider Credentials / provider integrations not yet available to all
+   adopters.** If an adopter's HCP Terraform or Scalr plan tier doesn't support
+   dynamic credentials, they must fall back to static workspace vars — exactly
+   what §3 documents. *Mitigation:* the fallback path is present; the preferred
+   path is clearly marked as preferred, not mandatory.
+
+**Key assumptions (falsifiable):**
+
+- Scalr does not support the `cloud {}` block — only `backend "remote"`. *Evidence:*
+  Scalr documentation uses `backend "remote"` exclusively; no `cloud {}` examples
+  found. ([docs.scalr.io/docs/cli](https://docs.scalr.io/docs/cli))
+- `backend "remote"` works with OpenTofu. *Evidence:* `opentofu-differences.md`
+  lists only `cloud {}` blocks (not `backend "remote"`) as Terraform-only;
+  OpenTofu's compatibility documentation confirms standard backends are supported.
+  ([Scalr introduction](https://docs.scalr.io/docs/introduction) confirms OpenTofu
+  support.)
+
+**Drawbacks:**
+
+- Adds a new CLARIFY input — adopters who don't use remote execution platforms
+  see one more question; the default (`none`) means zero friction unless they
+  read the options.
+- `REMOTE_EXEC_SETUP.md` requires manual action from the adopter; the pack
+  cannot automate credential injection.
+
+---
+
+## Evidence & prior art
+
+**Spike / de-risk result:** Both key assumptions verified against live
+documentation. A live-account Scalr spike is retained as OQ1 with a documented
+justification for proceeding without it.
+
+**Repo precedent:**
+- RFC-0065 §8 — defers "commercial platform configs" as a planned follow-on.
+- `references/opentofu-differences.md` line 75 — "HCP Terraform cloud blocks —
+  OpenTofu uses standard backends" — the `cloud {}` incompatibility is already
+  documented; this RFC enforces it as a CLARIFY gate.
+- `references/terraform-standard.md` lines 38–48 — private module registry
+  (`app.terraform.io/<org>/…`) — the only existing TFC reference in generated
+  output; orthogonal to this RFC's backend-and-execution concern.
+- `references/providers/hashicorp-platform.md` — documents the `hashicorp/hcp`
+  provider for provisioning HCP resources. Orthogonal to this RFC; see §4
+  cross-reference note.
+
+**External prior art (citations fetched and confirmed):**
+- [HCP Terraform `cloud {}` block settings](https://developer.hashicorp.com/terraform/cli/cloud/settings) — `cloud {}` current since Terraform 1.1; `backend "remote"` deprecated.
+- [HCP Terraform API token types](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/api-tokens) — organisation tokens cannot start runs.
+- [HCP Terraform remote operations](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/run/remote-operations) — local env vars not forwarded.
+- [Scalr CLI workspace docs](https://docs.scalr.io/docs/cli) — `backend "remote"` with Scalr hostname; `organization` = environment name.
+- [Scalr introduction](https://docs.scalr.io/docs/introduction) — confirms OpenTofu support.
+- [Scalr OPA policy enforcement](https://scalr.com/learning-center/policy-enforcement-for-terraform-opentofu-with-opa-and-scalr/) — OPA only; no Sentinel.
+
+---
+
+## Open questions
+
+1. **Live-account spike for Scalr.** Both the `backend "remote"` form and the
+   `organization` = environment-name mapping were verified from documentation, not
+   a live account. *Recommended default:* proceed without; a wrong backend block
+   produces a clear `terraform init` error rather than silent misbehaviour.
+   · owner: eugenelim · decide-by: before merging `scalr.md`.
+
+2. **HCP Terraform Dynamic Provider Credentials tier availability.** Dynamic
+   Provider Credentials may require a paid HCP Terraform plan. *Recommended
+   default:* document in `hcp-terraform.md` that it requires HCP Terraform Plus
+   or higher; workspace env vars are the free-tier fallback. Confirm against the
+   current [HCP Terraform pricing page](https://developer.hashicorp.com/terraform/cloud-docs/overview) before merging.
+   · owner: eugenelim · decide-by: before merging `hcp-terraform.md`.
+
+3. **Scalr provider integrations scope.** Scalr's provider integrations (preferred
+   dynamic credential model) may not be available for all cloud providers on all
+   plan tiers. *Recommended default:* document the supported providers and tiers
+   in `scalr.md`; fall back to workspace env vars for unsupported combinations.
+   Confirm against the current [Scalr provider integrations docs](https://docs.scalr.io) before merging.
+   · owner: eugenelim · decide-by: before merging `scalr.md`.
+
+---
+
+## Follow-on artifacts
+
+- **ADR:** Record the remote-exec platform support decision (engine/platform gate,
+  reference structure, `REMOTE_EXEC_SETUP.md` convention).
+- **Implementation:** `packs/iac-terraform` changes per Proposal above.
+- **Errata on RFC-0065:** One-line entry pointing to RFC-0070 (already added in
+  the same PR as this RFC).

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -75,6 +75,7 @@
 | [0067](0067-session-arc-conventions-and-pack-workflow-guide.md) | Session-arc naming conventions and pack workflow guide — rename `workspace-status` → `workspace-status` (clean retire + verb taxonomy), add `desk-research-project-status` and `experience-status`, wire argless work-loop resume, and create a pack workflow design guide for future pack authors | Accepted | 2026-07-20 | 2026-07-20 |
 | [0068](0068-linear-pack.md) | `linear` pack — Linear Issue intake + delta-sync skills for the brief pipeline: `linear` primitive (GraphQL, credential-brokers `creds` path), `linear-brief-intake` (Issue/Project → brief, Shape A/B, 10-Issue cap), `linear-brief-sync` (PE-approval gate, protected-field fixed convention, Executing lock); D3 section-level before/after approval; D4 `push-acs-to-linear` deferred to backlog | Accepted | 2026-07-21 | 2026-07-21 |
 | [0069](0069-workspace-toml-adopter-seeding.md) | workspace.toml adopter seeding — add workspace.toml as a minimal core-pack seed (comments + [backlog] section) delivered on install; EXCLUDED_PATTERNS protection; REQUIRED_PLACEHOLDERS lint | Draft | 2026-07-22 | — |
+| [0070](0070-iac-terraform-remote-exec-platforms.md) | Remote execution platforms for `iac-terraform` — HCP Terraform (`cloud {}` block) and Scalr (`backend "remote"`) support: new `references/remote-exec/` directory, `remote_exec_platform` clarify input, generated `REMOTE_EXEC_SETUP.md`, `reconcile-iac` backend-type detection. Follow-on to RFC-0065 §8. | Accepted | 2026-07-23 | 2026-07-23 |
 
 ## Adding a new RFC
 

--- a/docs/specs/iac-terraform-remote-exec/plan.md
+++ b/docs/specs/iac-terraform-remote-exec/plan.md
@@ -1,0 +1,71 @@
+# Plan: iac-terraform-remote-exec
+
+- **Spec:** [`spec.md`](spec.md)
+- **RFC:** [RFC-0070](../../rfc/0070-iac-terraform-remote-exec-platforms.md)
+- **Status:** Done
+- **Verification mode:** goal-based check (Markdown files — no test runner)
+
+## Assumptions
+
+1. The existing `generate-iac` SKILL.md structure (Inputs table, Stage sequence
+   code block, References section, Anti-patterns section) is stable — confirmed
+   by reading the file.
+2. `references/remote-exec/` directory does not yet exist — confirmed.
+3. Both platforms use `backend "remote"` / `cloud {}` transparently via the
+   `terraform` / `tofu` CLI — no API scripting needed in the skill.
+
+## Tasks
+
+### T1 — New `references/remote-exec/hcp-terraform.md`
+
+**Depends on:** none
+
+**Done when:** file exists with all 8 required sections (config block, auth/token guard, dynamic credentials, remote operations, run states, policy enforcement, CI trigger notes, bootstrap).
+
+**Approach:** write per RFC-0070 Proposal §1 and the pre-researched detail from the authoring session.
+
+### T2 — New `references/remote-exec/scalr.md`
+
+**Depends on:** none
+
+**Done when:** file exists with all 8 required sections (config block + naming trap, auth, provider integrations, three-tier hierarchy, OpenTofu compat, OPA enforcement, CI trigger notes, bootstrap).
+
+**Approach:** write per RFC-0070 Proposal §1.
+
+### T3 — Update `generate-iac` SKILL.md (5 edits)
+
+**Depends on:** none
+
+**Done when:**
+1. Inputs table has `Remote execution platform` row with constraint note
+2. Stage 3 loads `references/remote-exec/<platform>.md` when `platform ≠ none`
+3. Stage 5 has backend branching section
+4. Stage 5 or new WRITE OUTPUT step emits `REMOTE_EXEC_SETUP.md`
+5. References section lists `references/remote-exec/<platform>.md`
+6. Anti-patterns has 2 new never-emit rules
+
+**Approach:** targeted Edit calls to the existing SKILL.md.
+
+### T4 — Update `reconcile-iac` SKILL.md (1 edit)
+
+**Depends on:** none
+
+**Done when:** Procedure section has backend-type detection step before existing step 1; ADR compliance domain map includes `terraform { cloud {} }` → `state`.
+
+**Approach:** Edit the Procedure code block.
+
+### T5 — Update `opentofu-differences.md` (1 edit)
+
+**Depends on:** none
+
+**Done when:** the "HCP Terraform cloud blocks" bullet includes a Scalr recommendation note for OpenTofu + remote exec.
+
+**Approach:** Edit that single bullet.
+
+## Dependency order
+
+T1, T2, T3, T4, T5 are all independent — no data dependencies. Execute in parallel.
+
+## Deferred
+
+None.

--- a/docs/specs/iac-terraform-remote-exec/spec.md
+++ b/docs/specs/iac-terraform-remote-exec/spec.md
@@ -1,0 +1,110 @@
+# Spec: iac-terraform-remote-exec
+
+<!-- Mode: full (structural change — new reference directory, new public clarify input) -->
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** [RFC-0070](../../rfc/0070-iac-terraform-remote-exec-platforms.md) — Remote execution platforms for `iac-terraform`
+- **Brief:** none
+- **Discovery:** none
+- **Shape:** mixed — new `remote_exec_platform` clarify input + two new reference files + backend branching in generate-iac + backend-type detection in reconcile-iac
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+The `iac-terraform` pack generates cloud-native state backends (S3/GCS/Azure
+Blob) only. Adopters running HCP Terraform (HashiCorp's managed remote execution
+SaaS) or Scalr (a Terraform-compatible commercial SaaS alternative) get wrong backend configs.
+
+This spec adds `hcp-terraform` and `scalr` as first-class options for the
+`remote_exec_platform` clarify input in `generate-iac`. The change is additive —
+`platform = none` (vanilla CI) remains the default and is unchanged.
+
+## Boundaries
+
+### Always do
+
+- Add `Remote execution platform` row to `generate-iac` Inputs table
+- Load `references/remote-exec/<platform>.md` in PLAN stage when `platform ≠ none`
+- Branch backend generation in WRITE TF stage per platform
+- Emit `REMOTE_EXEC_SETUP.md` when `platform ≠ none`
+- Add 2 new never-emit rules (deprecated `backend "remote"` to TFC; `cloud {}` for OpenTofu)
+- Add `backend "remote"` platform-type detection step to `reconcile-iac` Procedure
+- Add Scalr OpenTofu recommendation to `opentofu-differences.md`
+- Ship two new reference files: `references/remote-exec/hcp-terraform.md` and `references/remote-exec/scalr.md`
+
+### Ask first
+
+- Adding a remote-exec platform beyond `hcp-terraform` / `scalr` — requires a
+  new reference file and a new RFC or ADR.
+- Bumping the pack version (`pack.toml` / `plugin.json`) for these reference
+  files — the no-bump is a documented decision (see Never do); reverse it with
+  a human confirmation first.
+
+### Never do
+
+- Modify `pack.toml`, `plugin.json`, or any CI workflow — the reference files
+  are skill-internal; the published pack interface has not changed. A version
+  bump is deferred to the next pack release cycle. **This is an intentional
+  no-bump decision**: governance docs (RFC, spec) are excepted from the
+  `packs/iac-terraform/` scope constraint below.
+- Change any code or pack file outside `packs/iac-terraform/` (governance docs
+  in `docs/rfc/` and `docs/specs/` are explicitly excepted)
+- Add seeds or agents
+- Emit `cloud {}` for OpenTofu targets (already banned, now doubly enforced)
+- Emit Sentinel (already banned)
+
+## Acceptance criteria
+
+- [x] `generate-iac` SKILL.md Inputs table has a `Remote execution platform` row with `none | hcp-terraform | scalr` and the OpenTofu constraint note
+- [x] `generate-iac` SKILL.md Stage 3 (PLAN) mentions loading `references/remote-exec/<platform>.md` when `platform ≠ none`
+- [x] `generate-iac` SKILL.md Stage 5 (WRITE TF) has backend branching section covering `none` / `hcp-terraform` / `scalr`
+- [x] `generate-iac` SKILL.md has emission of `REMOTE_EXEC_SETUP.md` when `platform ≠ none`
+- [x] `generate-iac` SKILL.md Anti-patterns has 2 new never-emit rules
+- [x] `generate-iac` SKILL.md References section lists `references/remote-exec/<platform>.md` as a conditional load
+- [x] `reconcile-iac` SKILL.md Procedure has a backend-type detection step before the existing step 1
+- [x] `opentofu-differences.md` Terraform-only features bullet for HCP Terraform cloud blocks has a Scalr recommendation note
+- [x] `references/remote-exec/hcp-terraform.md` exists with: config block + env vars, token scoping guard, dynamic provider credentials + fallback, remote operations model, run states, policy enforcement, CI trigger notes, bootstrap narrative
+- [x] `references/remote-exec/scalr.md` exists with: config block + naming trap, auth, provider integrations + fallback, three-tier hierarchy, OpenTofu compatibility, OPA enforcement, CI trigger notes, bootstrap narrative
+
+## Testing strategy
+
+Goal-based verification — grep for key strings that confirm each acceptance criterion:
+
+```bash
+# AC1 — Inputs table has Remote execution platform row
+grep -q "Remote execution platform" packs/iac-terraform/.apm/skills/generate-iac/SKILL.md
+
+# AC2 — Stage 3 PLAN loads remote-exec/<platform>.md
+grep -q "remote-exec/<platform>" packs/iac-terraform/.apm/skills/generate-iac/SKILL.md
+
+# AC3 — Stage 5 WRITE TF has backend branching for all three platforms
+grep -q "platform = none" packs/iac-terraform/.apm/skills/generate-iac/SKILL.md && \
+grep -q "platform = hcp-terraform" packs/iac-terraform/.apm/skills/generate-iac/SKILL.md && \
+grep -q "platform = scalr" packs/iac-terraform/.apm/skills/generate-iac/SKILL.md
+
+# AC4 — REMOTE_EXEC_SETUP.md emission when platform != none
+grep -q "REMOTE_EXEC_SETUP.md" packs/iac-terraform/.apm/skills/generate-iac/SKILL.md
+
+# AC5 — never-emit anti-pattern: deprecated backend "remote" to TFC
+grep -q "app.terraform.io" packs/iac-terraform/.apm/skills/generate-iac/SKILL.md
+
+# AC6 — References section lists remote-exec/<platform>.md as conditional load
+grep -q "references/remote-exec/<platform>.md" packs/iac-terraform/.apm/skills/generate-iac/SKILL.md
+
+# AC5 (second rule) — never-emit anti-pattern: cloud {} for OpenTofu
+grep -qi "cloud.*opentofu\|opentofu.*cloud" packs/iac-terraform/.apm/skills/generate-iac/SKILL.md
+
+# AC7 — reconcile-iac detection
+grep -q "backend-type\|remote.*exec.*platform\|cloud.*block\|backend.*remote" packs/iac-terraform/.apm/skills/reconcile-iac/SKILL.md
+
+# AC8 — opentofu-differences
+grep -q "scalr\|Scalr" packs/iac-terraform/.apm/skills/generate-iac/references/opentofu-differences.md
+
+# AC9/10 — reference files exist
+test -f packs/iac-terraform/.apm/skills/generate-iac/references/remote-exec/hcp-terraform.md
+test -f packs/iac-terraform/.apm/skills/generate-iac/references/remote-exec/scalr.md
+```

--- a/packs/iac-terraform/.apm/skills/generate-iac/SKILL.md
+++ b/packs/iac-terraform/.apm/skills/generate-iac/SKILL.md
@@ -97,7 +97,8 @@ plan-based drift audit via `reconcile-iac`.
 | Region | **ask** | |
 | Decision-record source | repo's `docs/adr/` | |
 | CI system | `github-actions` | `github-actions \| azure-devops \| gitlab` |
-| State backend | derive from cloud | S3 (AWS), GCS (GCP), Azure Blob |
+| Remote execution platform | `none` | `none \| hcp-terraform \| scalr`; when `engine = opentofu`, only `none` and `scalr` are valid — `cloud {}` is Terraform-only and incompatible with OpenTofu |
+| State backend | derive from cloud | S3 (AWS), GCS (GCP), Azure Blob — **only when `remote_exec_platform = none`**; remote exec platforms own the state |
 | Account/tenant isolation model | separate account per env | drives OIDC trust-policy scoping and state backend key structure |
 
 ## Stage sequence
@@ -111,6 +112,7 @@ Stage 2: CLARIFY
   → collect all inputs; ask for missing; confirm engine + cloud + region
 Stage 3: PLAN
   → load provider reference for target cloud; load CI reference for target CI
+  → when platform ≠ none: load references/remote-exec/<platform>.md
   → draft: ADR-compliance table + standards-mapping table + layered layout
   → networking design + pipeline design + reversibility hints per stateful resource
   → ADR-compliance table must have zero ❌/⚠️ rows before proceeding to Stage 4
@@ -121,8 +123,16 @@ Stage 4: TASKS
   → [P] only when files are disjoint with no resource/data dependency
 Stage 5: WRITE TF
   → ground every resource type in live schema via contract-acquisition
-  → emit the four-file provider config (versions.tf / provider.tf /
-    backend.tf / backend.hcl.example) per references/provider-contract.md
+  → emit provider config files (versions.tf / provider.tf) per
+    references/provider-contract.md; backend config branches on platform:
+    • platform = none (default): backend.tf + backend.hcl.example
+      (cloud-native object store: S3 / GCS / Azure Blob)
+    • platform = hcp-terraform: cloud {} block in versions.tf;
+      no backend.tf, no backend.hcl.example
+    • platform = scalr: backend.tf with backend "remote" block;
+      no backend.hcl.example
+  → when platform ≠ none: emit REMOTE_EXEC_SETUP.md (credential guidance,
+    token setup, traps) per references/remote-exec/<platform>.md
   → apply all mandatory tagging (references/tagging-standard.md)
   → tag stateful resources with reversibility-class annotations
     (reversible | costly-to-reverse | one-way-door)
@@ -164,6 +174,7 @@ Load per target (never all at once):
 - `references/providers/<cloud>.md` — cloud-specific config (aws / gcp / azure / …)
 - `references/opentofu-differences.md` — **load ONLY when engine = opentofu**
 - `references/pipeline/<ci>.md` — CI pipeline shape (github-actions / azure-devops / gitlab)
+- `references/remote-exec/<platform>.md` — **load ONLY when platform ≠ none** — config block, auth, credential model, CI trigger delta, bootstrap narrative (hcp-terraform / scalr)
 
 Policy and plan shape:
 - `references/policy-on-plan.md` — starter Rego rules + Trivy/Checkov guidance
@@ -230,3 +241,9 @@ unavailable. The RFC does not claim full mode as the default.
 - Committing `*.tfvars` with real values or raw credentials.
 - Emitting a Sentinel policy (incompatible with OpenTofu — use OPA/Conftest
   for the open-source policy path that works on both engines).
+- Emitting `backend "remote" { hostname = "app.terraform.io" ... }` for an HCP
+  Terraform target — this is the deprecated form; generate a `cloud {}` block
+  in `versions.tf` instead.
+- Emitting a `cloud {}` block for an `engine = opentofu` target — it is
+  Terraform-only and incompatible; offer `platform = scalr` with
+  `backend "remote"` as the OpenTofu-compatible remote execution alternative.

--- a/packs/iac-terraform/.apm/skills/generate-iac/references/opentofu-differences.md
+++ b/packs/iac-terraform/.apm/skills/generate-iac/references/opentofu-differences.md
@@ -72,7 +72,11 @@ only the extension differs.
 
 - **Ephemeral values / write-only arguments** (Terraform 1.10+) — no equivalent in OpenTofu
 - **Terraform Stacks** — no equivalent in OpenTofu
-- **HCP Terraform cloud blocks** — OpenTofu uses standard backends
+- **HCP Terraform cloud blocks** — OpenTofu uses standard backends. When a
+  remote execution platform is required for an OpenTofu target, use **Scalr**
+  with `backend "remote"` — it is OpenTofu-compatible and is the pack's
+  recommended `platform` option for `engine = opentofu`. See
+  `references/remote-exec/scalr.md`.
 
 ## The `.tofu` override-file mechanism
 

--- a/packs/iac-terraform/.apm/skills/generate-iac/references/remote-exec/hcp-terraform.md
+++ b/packs/iac-terraform/.apm/skills/generate-iac/references/remote-exec/hcp-terraform.md
@@ -1,0 +1,199 @@
+# HCP Terraform remote execution — reference
+
+> **Load ONLY when `platform = hcp-terraform`** — not valid for OpenTofu targets
+> (`cloud {}` is a Terraform-only feature; use `scalr.md` for OpenTofu).
+>
+> This file provides the platform *delta*: config block, auth, credential model,
+> CI trigger notes, and bootstrap narrative. It composes with
+> `references/pipeline/<ci>.md` (CI pipeline source of truth) and
+> `references/providers/<cloud>.md` (cloud provider config). Those files do not
+> change; this file documents what to add or omit for HCP Terraform.
+
+## Config block — `cloud {}`
+
+The `cloud {}` block replaces `backend.tf` and `backend.hcl.example` entirely.
+It lives inside the `terraform {}` block in `versions.tf` (alongside
+`required_providers`). Requires Terraform ≥ 1.1.
+
+```hcl
+terraform {
+  required_version = ">= 1.1.0"
+  required_providers { /* ... */ }
+
+  cloud {
+    organization = "<org-name>"        # or TF_CLOUD_ORGANIZATION
+    # hostname = "..."  # omit for SaaS (app.terraform.io); set only for Terraform Enterprise (self-hosted)
+
+    workspaces {
+      name    = "<workspace-name>"   # or TF_WORKSPACE
+      # Alternatively: tags = ["<tag>"]
+      # project = "<project-name>"  # or TF_CLOUD_PROJECT
+    }
+  }
+}
+```
+
+**Files to emit when `platform = hcp-terraform`:**
+- `versions.tf` — with `cloud {}` block above
+- `provider.tf` — unchanged from vanilla shape
+- **No `backend.tf`** — the `cloud {}` block replaces it
+- **No `backend.hcl.example`** — unused with `cloud {}`
+
+**Environment variable overrides** — all `cloud {}` fields can be set via env
+vars, making the HCL environment-agnostic:
+
+| Env var | Overrides | Note |
+| --- | --- | --- |
+| `TF_TOKEN_app_terraform_io` | — | API token (dots → underscores). Required in CI. |
+| `TF_CLOUD_ORGANIZATION` | `cloud.organization` | |
+| `TF_CLOUD_HOSTNAME` | `cloud.hostname` | For Terraform Enterprise (self-hosted); leave unset for `app.terraform.io` SaaS |
+| `TF_WORKSPACE` | `workspaces.name` | |
+| `TF_CLOUD_PROJECT` | `workspaces.project` | |
+
+With all values in env vars (`TF_CLOUD_ORGANIZATION`, `TF_WORKSPACE`, `TF_TOKEN_app_terraform_io`), a minimal `versions.tf` config is:
+
+```hcl
+terraform {
+  cloud {}
+}
+```
+
+## Auth — token types and capabilities
+
+**Critical guard:** organisation tokens cannot trigger runs or create
+configuration versions. CI workflows must use a **team token** or **user token**.
+
+| Token type | Trigger runs? | Create config versions? | Correct for CI? |
+| --- | --- | --- | --- |
+| User token | ✓ | ✓ | ✓ (scoped to user perms) |
+| Team token | ✓ | ✓ | ✓ (recommended for CI) |
+| **Organisation token** | **✗** | **✗** | **✗ — fails silently or 403** |
+
+Set `TF_TOKEN_app_terraform_io` in the CI secrets store to a **team token**
+scoped to the target workspace(s). Never use an organisation token in CI.
+
+## Credential model
+
+### Preferred: Dynamic Provider Credentials (OIDC federation)
+
+HCP Terraform's Dynamic Provider Credentials (verify current tier requirements
+with HashiCorp — historically Plus and above; tier gating may have changed)
+use OIDC to federate with the cloud provider. The remote runner exchanges a
+short-lived JWT for a cloud credential at run time — no static key stored or
+rotated.
+
+Configure in HCP Terraform workspace settings → **Provider Credentials**:
+
+| Cloud | Dynamic credential mechanism |
+| --- | --- |
+| AWS | OIDC trust policy in AWS IAM; no `AWS_ACCESS_KEY_ID` needed |
+| GCP | Workload Identity Federation; no `GOOGLE_CREDENTIALS` needed |
+| Azure | Workload Identity with federated credential; no `ARM_CLIENT_SECRET` needed |
+
+This is the preferred model — it aligns with the pack's no-long-lived-keys
+invariant. Document the tier requirement in `REMOTE_EXEC_SETUP.md`.
+
+### Fallback: workspace environment variables
+
+When Dynamic Provider Credentials are not available or not yet configured, set
+cloud provider credentials as **workspace environment variables** inside HCP
+Terraform. These are injected into the remote runner at run time. They are
+**not** read from the local shell, CI runner environment, or credential files.
+
+| Cloud | Workspace env vars (minimum) |
+| --- | --- |
+| AWS | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION` |
+| GCP | `GOOGLE_CREDENTIALS` (JSON service-account key; mark sensitive) |
+| Azure | `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, `ARM_SUBSCRIPTION_ID`, `ARM_TENANT_ID` |
+
+Mark any secret-valued variable as **sensitive** in the workspace UI — it becomes
+write-only and is never displayed in logs or the API.
+
+## Remote operations model
+
+In CLI-driven mode (`terraform plan` / `terraform apply` run in CI with `cloud {}`
+present):
+- Local environment variables are **not forwarded** to the remote runner
+- Local credential files (`~/.aws/credentials`, `~/.config/gcloud/`, etc.) are
+  **not forwarded**
+- The plan and apply run on a HCP Terraform-managed ephemeral VM; logs stream
+  back to the terminal
+- Cloud-provider credentials are **not** sourced from the CI runner — they come
+  from Dynamic Provider Credentials (OIDC on the remote VM) or workspace env
+  vars set in the HCP Terraform UI. No cloud-provider OIDC role assumption is
+  needed in the CI workflow.
+
+## Run states to handle
+
+| State | Meaning | Action |
+| --- | --- | --- |
+| `pending` | Queued | Poll |
+| `planning` | Running plan | Poll |
+| `cost_estimating` | Estimating cost | Poll |
+| `policy_checking` | OPA / Sentinel policies evaluating | Poll |
+| **`needs_confirmation`** | Plan clean; apply waiting for approval | Human reviews plan then confirms or discards |
+| **`policy_override`** | Soft-mandatory policy failed | Authorised user overrides or discards; hard-mandatory blocks unconditionally |
+| `applying` | Running apply | Poll |
+| `applied` | Complete | Success |
+| `planned_and_finished` | Plan-only run done | Success (no apply requested) |
+| `plan_errored` | Plan failed | Surface error; stop |
+| `apply_errored` | Apply failed | Surface error; stop |
+| `discarded` / `canceled` | Aborted | Surface to human |
+
+## Policy enforcement
+
+HCP Terraform supports OPA and Sentinel natively. This pack uses **OPA/Conftest**
+in the CI pipeline — not HCP Terraform's native policy evaluation. The two
+coexist independently:
+
+- **Conftest in CI (pack's mandated path):** runs in the CI pipeline as a step,
+  before or after the remote plan, using the same `.rego` rules from `policy/`.
+  Unaffected by HCP Terraform's policy tier.
+- **HCP Terraform native OPA (optional, paid tier):** runs post-plan inside the
+  platform; surfaces via `policy_checking` run state. Can augment the Conftest
+  pass but does not replace it.
+
+**Never emit Sentinel** — it is Terraform-only, requires an HCP Terraform paid
+tier, and is incompatible with the pack's engine-neutral and open-source-policy
+invariants.
+
+## CI trigger notes — platform delta
+
+When `cloud {}` is present, `terraform plan` and `terraform apply` in CI proxy
+to HCP Terraform. The CI YAML becomes simpler:
+
+**Removed vs vanilla CI:**
+- No OIDC role assumption to the state backend (state lives in HCP Terraform)
+- No `-backend-config backend.hcl` flag to `terraform init`
+- No cloud-provider OIDC role assumption in CI — cloud auth is handled on the
+  remote runner via Dynamic Provider Credentials or workspace env vars
+
+**Unchanged vs vanilla CI:**
+- Human approval gate before apply (GitHub environment protection /
+  Azure DevOps approval / GitLab manual job)
+- `fmt -check` → `validate` → `plan` → Conftest → Trivy steps
+
+**Composing with `references/pipeline/<ci>.md`:** that file is the pipeline
+source of truth and defines the full YAML structure. This file provides the
+HCP Terraform delta only — omit the backend OIDC step, remove
+`-backend-config`, add `TF_TOKEN_app_terraform_io` to CI secrets.
+
+## Bootstrap narrative
+
+For a new HCP Terraform workspace (no pre-existing remote state to migrate):
+
+1. **Create the workspace** in the HCP Terraform UI or via the `hashicorp/tfe`
+   Terraform provider (if provisioning the workspace itself via Terraform).
+2. **Configure credentials** in workspace settings:
+   - Preferred: enable Dynamic Provider Credentials for the target cloud.
+   - Fallback: add workspace environment variables for cloud provider credentials.
+3. **Set the platform token** in the CI secret store:
+   `TF_TOKEN_app_terraform_io = <team-token>` (never an organisation token).
+4. **Run `terraform init`** with `cloud {}` in `versions.tf` — connects to HCP
+   Terraform and registers the workspace.
+5. **First `terraform plan`** runs remotely on HCP Terraform. The plan runs on
+   the platform's infrastructure, not the CI runner.
+
+There is no object-store chicken-and-egg problem (`bootstrap-sequence.md` covers
+the object-store case). The backend IS the SaaS platform — no bucket to provision
+before init.

--- a/packs/iac-terraform/.apm/skills/generate-iac/references/remote-exec/scalr.md
+++ b/packs/iac-terraform/.apm/skills/generate-iac/references/remote-exec/scalr.md
@@ -1,0 +1,198 @@
+# Scalr remote execution — reference
+
+> **Load ONLY when `platform = scalr`** — valid for both `engine = terraform`
+> and `engine = opentofu`. Scalr is the pack's recommended remote execution
+> option for OpenTofu targets.
+>
+> This file provides the platform *delta*: config block, auth, credential model,
+> CI trigger notes, and bootstrap narrative. It composes with
+> `references/pipeline/<ci>.md` (CI pipeline source of truth) and
+> `references/providers/<cloud>.md` (cloud provider config). Those files do not
+> change; this file documents what to add or omit for Scalr.
+
+## Config block — `backend "remote"`
+
+Scalr uses the standard `backend "remote"` block — **not** `cloud {}`.
+The block lives in `backend.tf`.
+
+```hcl
+terraform {
+  backend "remote" {
+    hostname     = "<account-name>.scalr.io"
+    organization = "<environment-name>"    # ← Scalr ENVIRONMENT name, not account
+
+    workspaces {
+      name = "<workspace-name>"
+      # Alternatively: tags = ["<tag>"]
+    }
+  }
+}
+```
+
+**Critical naming trap:** the `organization` field takes the **Scalr environment
+name** (e.g. `production`, `staging`, `dev`) — **not the account name**. The
+account name is encoded in `hostname` (`<account>.scalr.io`). Using the account
+name in `organization` produces a confusing authentication error; it is the most
+common misconfiguration when porting TFC configs to Scalr. Surface this warning
+in `REMOTE_EXEC_SETUP.md`.
+
+**Files to emit when `platform = scalr`:**
+- `backend.tf` — with `backend "remote"` block above
+- `versions.tf` — standard, no `cloud {}` block
+- `provider.tf` — unchanged from vanilla shape
+- **No `backend.hcl.example`** — unused (hostname and org are in `backend.tf`)
+
+**Environment variable overrides:**
+
+| Env var | Purpose |
+| --- | --- |
+| `TF_TOKEN_<account>_scalr_io` | API token. Encoding: dots → `_`, hyphens → `__`. E.g. account `myorg` (no hyphens): `TF_TOKEN_myorg_scalr_io`; hyphenated account `my-org`: `TF_TOKEN_my__org_scalr_io`. The double-underscore encoding ensures the name is a valid bash identifier. Required in CI. |
+| `SCALR_TOKEN` | Scalr CLI-specific alternative to `TF_TOKEN_*` |
+| `SCALR_HOSTNAME` | Scalr CLI: hostname |
+| `SCALR_ACCOUNT` | Scalr CLI: account name |
+
+**OpenTofu compatibility:** `backend "remote"` is a standard Terraform backend
+protocol — not a HashiCorp-proprietary extension. Scalr accepts both the
+`terraform` and `tofu` binaries via this backend. The `cloud {}` block
+(Terraform-only) is never used with Scalr.
+
+## Auth — token types
+
+Scalr uses **personal tokens** and **service account tokens**. There is no
+equivalent of HCP Terraform's organisation-token restriction — Scalr tokens are
+user-scoped or service-account-scoped and can trigger runs within their
+assigned permissions.
+
+In CI, set `TF_TOKEN_<account>_scalr_io` to a **service account token** scoped
+to the relevant environments and workspaces.
+
+## Three-tier hierarchy
+
+Scalr's hierarchy determines where variables, policies, and credentials live:
+
+```
+account            ← top-level; manages RBAC and OPA policies; hosts module registry
+  └── environment  ← team-level grouping (maps to the "organization" field in backend block)
+        └── workspace  ← execution unit; runs plans and applies
+```
+
+Variables, OPA policies, and credentials cascade downward (account →
+environment → workspace). Any level can mark a value `final` to prevent
+override by a lower scope — this enables a central security team to lock
+credentials at account level and prevent teams from substituting their own.
+
+## Credential model
+
+### Preferred: provider integrations (OIDC federation)
+
+Scalr's native cloud-provider credential management injects credentials into the
+remote runner via OIDC federation at run time — no static key stored or rotated.
+
+Configure in the Scalr UI under the environment → **Credentials**:
+
+| Cloud | Provider integration |
+| --- | --- |
+| AWS | AWS provider integration (OIDC trust auto-managed by Scalr) |
+| GCP | GCP provider integration (Workload Identity Federation) |
+| Azure | Azure provider integration |
+
+Set integrations at the **environment level** so all workspaces under that
+environment inherit the credentials automatically.
+
+This is the preferred model — it satisfies the pack's no-long-lived-keys
+invariant. **Availability:** provider integrations are a paid-tier feature in
+Scalr; verify your plan before relying on this model.
+
+### Fallback: workspace / environment variables
+
+When provider integrations are not available or not yet configured, set cloud
+provider credentials as Scalr variables at the environment or workspace level.
+Variable inheritance follows the three-tier cascade.
+
+| Cloud | Variables (minimum) |
+| --- | --- |
+| AWS | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION` |
+| GCP | `GOOGLE_CREDENTIALS` (JSON service-account key; mark sensitive) |
+| Azure | `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, `ARM_SUBSCRIPTION_ID`, `ARM_TENANT_ID` |
+
+Mark secret-valued variables as **sensitive** — they become write-only.
+Set at the **environment level** (not workspace level) so all workspaces in the
+environment inherit them automatically.
+
+**Variable `final` flag:** a parent scope can set a variable as `final` to
+prevent workspace-level override — useful for enforcing a shared credential
+across a team's workspaces.
+
+## Remote operations model
+
+In CLI-driven mode (`terraform plan` / `terraform apply` run in CI with
+`backend "remote"` pointing to Scalr):
+- Local environment variables are **not forwarded** to the remote runner
+- Local credential files are **not forwarded**
+- Scalr injects provider-integration credentials (or workspace variables) at run
+  time
+- Logs stream back to the terminal
+
+## OPA policy enforcement
+
+Scalr supports OPA only — no Sentinel. Policies are written in Rego and
+registered via **policy groups** in the Scalr UI (linked to a VCS repository
+containing `.rego` files) or through the Scalr API.
+
+**Two enforcement points:**
+- **Pre-plan:** runs before the plan is generated; input includes workspace
+  metadata and user/VCS info. Blocks before any cloud API calls.
+- **Post-plan:** runs after the plan; input includes the full plan JSON
+  (`tfplan`). Can evaluate resource-level changes.
+
+**Three enforcement levels:**
+- `hard-mandatory` — blocks unconditionally; no override path
+- `soft-mandatory` — blocks but an authorised user can override
+- `advisory` — warning only; run proceeds
+
+Policies are defined at account level, assigned to environments, and cascade to
+workspaces. The same Rego rules in `policy/` used by Conftest in CI can also be
+deployed to Scalr — a single policy corpus covers both paths.
+
+## CI trigger notes — platform delta
+
+When `backend "remote"` points to a Scalr hostname, `terraform plan` and
+`terraform apply` in CI proxy to Scalr. The CI YAML becomes simpler, same
+pattern as HCP Terraform:
+
+**Removed vs vanilla CI:**
+- No OIDC role assumption to the state backend (state lives in Scalr)
+- No `-backend-config backend.hcl` flag to `terraform init` (backend is in
+  `backend.tf`)
+- No cloud-provider OIDC role assumption in CI — cloud auth is handled on the
+  remote runner via provider integrations (OIDC) or environment/workspace
+  variables
+
+**Unchanged vs vanilla CI:**
+- Human approval gate before apply
+- `fmt -check` → `validate` → `plan` → Conftest → Trivy steps
+
+**Composing with `references/pipeline/<ci>.md`:** that file is the pipeline
+source of truth. This file provides the Scalr delta only — omit the backend
+OIDC step, remove `-backend-config`, add `TF_TOKEN_<account>_scalr_io` to CI
+secrets.
+
+## Bootstrap narrative
+
+For a new Scalr workspace (no pre-existing remote state to migrate):
+
+1. **Create the hierarchy:** account already exists → create an environment
+   (e.g. `dev`) in the Scalr UI → create a workspace under the environment.
+2. **Configure credentials** at the environment level:
+   - Preferred: set up provider integrations for the target cloud.
+   - Fallback: add cloud provider variables at the environment level.
+3. **Set the platform token** in the CI secret store:
+   `TF_TOKEN_<account>_scalr_io = <service-account-token>`
+4. **Verify `backend.tf`** uses the **environment name** (not the account name)
+   in the `organization` field.
+5. **Run `terraform init`** (or `tofu init`) — connects to Scalr and registers
+   the workspace.
+6. **First `terraform plan`** runs remotely on Scalr.
+
+There is no object-store chicken-and-egg problem. The backend IS the SaaS
+platform — no bucket to provision before init.

--- a/packs/iac-terraform/.apm/skills/reconcile-iac/SKILL.md
+++ b/packs/iac-terraform/.apm/skills/reconcile-iac/SKILL.md
@@ -40,6 +40,20 @@ full drift coverage — the audit covers managed resources only.
 ## Procedure
 
 ```
+0. Detect the remote execution platform by scanning all *.tf files in the
+   project root (and workspace subdirectory if one is in use):
+   • Any .tf file with terraform { cloud { ... } }
+     → platform = hcp-terraform; plan runs remotely on HCP Terraform
+   • Any .tf file with terraform { backend "remote" { ... } }; check hostname:
+     - "app.terraform.io" → legacy TFC config; flag for migration to cloud {}
+       and surface a migration note before proceeding
+     - "*.scalr.io"       → platform = scalr; plan runs remotely on Scalr
+     - other              → unknown remote backend; note in report; proceed
+   • Neither found in any .tf file → platform = none (plan runs locally)
+   Record the platform in the audit report header. For remote-exec platforms, add:
+   "plan runs remotely on <platform>; resources created entirely outside Terraform
+   are invisible to plan — the blind-spot caveat applies as with local execution."
+
 1. Confirm the repo's governance-index is loaded (Stage 0 of generate-iac).
    If the index is absent, offer to bootstrap it before proceeding.
 
@@ -92,7 +106,7 @@ that bypassed Stage 0.
 2. Identify which governance domains the diff touches. Map by resource type:
    • aws_iam_* / google_project_iam_* / azurerm_role_assignment → iam
    • aws_vpc_* / google_compute_network / azurerm_virtual_network → networking
-   • terraform { backend } / aws_s3_bucket (state bucket) → state
+   • terraform { backend } / terraform { cloud {} } / aws_s3_bucket (state bucket) → state
    • resource_group / project / aws_organizations_account → layout
    • any provider block changes → layout
    • aws_security_group / aws_security_group_rule → networking + policy


### PR DESCRIPTION
## Summary

- Adds `remote_exec_platform` clarify input (`none | hcp-terraform | scalr`) to `generate-iac`, with the OpenTofu constraint (`cloud {}` is Terraform-only; only `none` and `scalr` are valid for OpenTofu targets)
- Ships two new reference files: `references/remote-exec/hcp-terraform.md` and `references/remote-exec/scalr.md`, covering config blocks, auth/token scoping, Dynamic Provider Credentials / Scalr provider integrations (preferred OIDC model), workspace env var fallback, remote operations model, CI trigger delta, and bootstrap narrative
- Branches backend generation in Stage 5: `cloud {}` for HCP Terraform, `backend "remote"` for Scalr, `backend.tf` for vanilla CI — with `REMOTE_EXEC_SETUP.md` emitted when `platform ≠ none`
- Adds backend-type detection (all `*.tf` files) as Step 0 in `reconcile-iac`, with platform recorded in the audit report header
- Adds two anti-patterns to `generate-iac`: never emit deprecated `backend "remote" { hostname = "app.terraform.io" }` for HCP Terraform; never emit `cloud {}` for OpenTofu targets
- Updates `opentofu-differences.md` to recommend Scalr as the OpenTofu-compatible remote exec option
- Adds RFC-0070 (Accepted) and an errata note to RFC-0065 §8

## Scope decisions deferred

- `pack.toml` / `plugin.json` version bump — reference files are skill-internal; published pack interface unchanged; deferred to next pack release cycle (recorded in spec Boundaries)
- A third remote-exec platform would require a new RFC

## Test plan

- [x] All 10 acceptance criteria pass goal-based grep checks (see `docs/specs/iac-terraform-remote-exec/spec.md` Testing Strategy)
- [x] Adversarial review passed clean (iterated through multiple passes; all blockers and concerns resolved)
- [x] Key invariants verified: OIDC/DPC preferred over static keys; `cloud {}` banned for OpenTofu; deprecated `backend "remote"` to TFC banned; Scalr `organization`-field naming trap documented; `TF_TOKEN_*` encoding (dots→`_`, hyphens→`__`); CI-side cloud OIDC not required for remote exec (auth on remote runner only); HCP org-token restriction documented