### PR TITLE
chore(workspace): encode P5 authoring-gate dependency on adopter-persona

### DIFF
--- a/workspace.toml
+++ b/workspace.toml
@@ -165,9 +165,13 @@ queue   = [
   # and the three pilot transcripts (portfolio-first-run-pilot-architect/figma/
   # governance-extras) as evidence base. Do not author P5 specs before those work
   # items complete — the evidence does not yet exist.
-  "spec/m6-astro-project-index",          # Astro site: PM-facing project index from docs/product/projects/
-  "spec/m6-live-demo-guide",              # ≥3 team types; ≤30-min shaping→brief→spec narration on org's own repo
-  "spec/m6-enterprise-rollout-playbook",  # champion→CTO→platform→engineers; staged rollout + retro template
+  # `needs` encodes the P5 authoring gate above: the adopter-persona research must
+  # complete first (its findings are the evidence base). The three pilot transcripts
+  # (portfolio-first-run-pilot-architect/figma/governance-extras) are already Shipped,
+  # so they are omitted here — adopter-persona is the only open edge.
+  {path = "spec/m6-astro-project-index",         needs = "research:adopter-persona"},  # Astro site: PM-facing project index from docs/product/projects/
+  {path = "spec/m6-live-demo-guide",             needs = "research:adopter-persona"},  # ≥3 team types; ≤30-min shaping→brief→spec narration on org's own repo
+  {path = "spec/m6-enterprise-rollout-playbook", needs = "research:adopter-persona"},  # champion→CTO→platform→engineers; staged rollout + retro template
 
   # ---- RFC-0064 Amendment #4: Cross-pack first-value overlay ----
   # Complements P1–P5 phases; may progress in parallel where dependencies allow;


### PR DESCRIPTION
## What

The three P5 `m6-*` queue entries in `workspace.toml` were bare strings with no `needs`, so `workspace-status` surfaced them as **ready to start**:

- `spec/m6-astro-project-index`
- `spec/m6-live-demo-guide`
- `spec/m6-enterprise-rollout-playbook`

But the **P5 authoring gate** (queue phase-header comment) requires each of these to consume the `adopter-persona` research findings as evidence base — and that research is still in `ini-002.shaping_queue.active` (not complete). The dependency lived only in prose, invisible to the DAG resolver.

## Change

Convert the three entries to inline objects carrying `needs = "research:adopter-persona"`, making the gate machine-readable. The three pilot transcripts the gate also names (`portfolio-first-run-pilot-architect/figma/governance-extras`) are already `Shipped`, so `adopter-persona` is the only open edge.

## Known residual (deferred)

The `research:` prefix resolver treats a research entry as *satisfied once it leaves the backlog* — and `adopter-persona` is currently in `active`, not backlog. So this edge records the dependency but does **not** yet flip the three items to `blocked` in `workspace-status`. Making in-flight research actually block its dependents is a `workspace-status` skill change (resolver tightening), out of scope for this data-only PR.