### PR TITLE
feat(capture-work): capture backlog dependencies as machine needs, not prose (core 0.13.7)

### DIFF
--- a/.agents/skills/capture-work/SKILL.md
+++ b/.agents/skills/capture-work/SKILL.md
@@ -155,6 +155,16 @@ to write the full spec: **the problem, the fix, the affected file or skill, and
 any key decisions already taken.** One-liners are not enough — write what a fresh
 session would otherwise have to reconstruct.
 
+For a `[backlog]` entry, also state the **unblock condition** — what must become
+true before the item is workable ("Unblocks when: …"). Then cross-check it against
+step 4: **if that condition is the completion of another *tracked* item — a
+`[backlog]` slug or a `[work]` spec — as a hard prerequisite, add the matching
+`needs` edge so the dependency is machine-readable, not prose only.** Do *not* add
+a `needs` when the condition is disjunctive (satisfied by A *or* B — `needs` is
+AND-only), names an entity not tracked in `workspace.toml`, or is an external event
+(credentials provisioned, hardware available, a real-adopter session, "someone
+takes the PR"). Those stay prose-only.
+
 ### 9. Confirm
 
 Present the complete proposed change — entries (with their classification),
@@ -225,6 +235,10 @@ now, and at what scale?*
 
 - **Creating spec files.** This skill writes `workspace.toml` only.
 - **Inventing a dependency.** Add `needs` only from explicit sequencing language.
+- **Leaving a tracked hard-dependency as prose only.** If a `[backlog]` entry's
+  unblock condition is the completion of another tracked item, it needs a `needs`
+  edge (step 8) — not just an "Unblocks when" line. (Disjunctive, untracked, or
+  external unblocks stay prose.)
 - **Encoding a priority preference as a `needs`.** Preference is order + comment.
 - **Writing a numeric priority or a new schema field.** Priority is order +
   comment; the schema is not extended beyond the `type` field for shaping entries.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -160,7 +160,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.13.6"
+      "version": "0.13.7"
     },
     {
       "author": {

--- a/.claude/skills/capture-work/SKILL.md
+++ b/.claude/skills/capture-work/SKILL.md
@@ -155,6 +155,16 @@ to write the full spec: **the problem, the fix, the affected file or skill, and
 any key decisions already taken.** One-liners are not enough — write what a fresh
 session would otherwise have to reconstruct.
 
+For a `[backlog]` entry, also state the **unblock condition** — what must become
+true before the item is workable ("Unblocks when: …"). Then cross-check it against
+step 4: **if that condition is the completion of another *tracked* item — a
+`[backlog]` slug or a `[work]` spec — as a hard prerequisite, add the matching
+`needs` edge so the dependency is machine-readable, not prose only.** Do *not* add
+a `needs` when the condition is disjunctive (satisfied by A *or* B — `needs` is
+AND-only), names an entity not tracked in `workspace.toml`, or is an external event
+(credentials provisioned, hardware available, a real-adopter session, "someone
+takes the PR"). Those stay prose-only.
+
 ### 9. Confirm
 
 Present the complete proposed change — entries (with their classification),
@@ -225,6 +235,10 @@ now, and at what scale?*
 
 - **Creating spec files.** This skill writes `workspace.toml` only.
 - **Inventing a dependency.** Add `needs` only from explicit sequencing language.
+- **Leaving a tracked hard-dependency as prose only.** If a `[backlog]` entry's
+  unblock condition is the completion of another tracked item, it needs a `needs`
+  edge (step 8) — not just an "Unblocks when" line. (Disjunctive, untracked, or
+  external unblocks stay prose.)
 - **Encoding a priority preference as a `needs`.** Preference is order + comment.
 - **Writing a numeric priority or a new schema field.** Priority is order +
   comment; the schema is not extended beyond the `type` field for shaping entries.

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`capture-work` captures machine-readable dependencies for backlog items (core pack 0.13.7).** When a `[backlog]` entry's unblock condition is the completion of another tracked item (a `[backlog]` slug or a `[work]` spec) as a hard prerequisite, `capture-work` now adds the matching `needs` edge instead of recording the dependency in prose only — so `workspace-status` can resolve it. Disjunctive ("A or B"), untracked-target, and external ("credentials provisioned", "someone takes the PR") unblocks deliberately stay prose. The `workspace.toml` seed and `[backlog]` schema header now state the same rule.
+
 ### Added
 
 - **First-value handoff block in `agentbundle install` (agentbundle 0.12.0).** A successful `agentbundle install` now prints a guidance block after the `installed:` line. Level B packs (non-technical audience, `level-b = true`) show four labelled lines — `Verify:`, `Try:`, `Expected:`, and optionally `Next:` — drawn from the pack's `[pack.first-value]` schema. Level A packs show `Verify:` only. Packs without `[pack.first-value]` are unchanged. Dry-run, upgrade, and profile-install paths are not affected. ([RFC-0064 Amendment #4](../rfc/0064-ini-001-ai-native-ecosystem.md) · [spec](../specs/agentbundle-first-value-handoff/spec.md))

--- a/packs/core/.apm/skills/capture-work/SKILL.md
+++ b/packs/core/.apm/skills/capture-work/SKILL.md
@@ -155,6 +155,16 @@ to write the full spec: **the problem, the fix, the affected file or skill, and
 any key decisions already taken.** One-liners are not enough — write what a fresh
 session would otherwise have to reconstruct.
 
+For a `[backlog]` entry, also state the **unblock condition** — what must become
+true before the item is workable ("Unblocks when: …"). Then cross-check it against
+step 4: **if that condition is the completion of another *tracked* item — a
+`[backlog]` slug or a `[work]` spec — as a hard prerequisite, add the matching
+`needs` edge so the dependency is machine-readable, not prose only.** Do *not* add
+a `needs` when the condition is disjunctive (satisfied by A *or* B — `needs` is
+AND-only), names an entity not tracked in `workspace.toml`, or is an external event
+(credentials provisioned, hardware available, a real-adopter session, "someone
+takes the PR"). Those stay prose-only.
+
 ### 9. Confirm
 
 Present the complete proposed change — entries (with their classification),
@@ -225,6 +235,10 @@ now, and at what scale?*
 
 - **Creating spec files.** This skill writes `workspace.toml` only.
 - **Inventing a dependency.** Add `needs` only from explicit sequencing language.
+- **Leaving a tracked hard-dependency as prose only.** If a `[backlog]` entry's
+  unblock condition is the completion of another tracked item, it needs a `needs`
+  edge (step 8) — not just an "Unblocks when" line. (Disjunctive, untracked, or
+  external unblocks stay prose.)
 - **Encoding a priority preference as a `needs`.** Preference is order + comment.
 - **Writing a numeric priority or a new schema field.** Priority is order +
   comment; the schema is not extended beyond the `type` field for shaping entries.

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix, frontend-engineering, contract-acquisition, workspace-status, capture-work skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "0.13.6"
+version = "0.13.7"
 description = "Core: work-loop, new-spec, bug-fix, adapt-to-project, init-project, receive-brief, author-brief, capture-work, workspace-status, frontend-engineering, contract-acquisition, operational-safety, security-checklists skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md, CHARTER, CONVENTIONS, docs/architecture, docs/knowledge, docs/product, docs/specs, workspace.toml seeds."
 readme = "README.md"
 display_name = "Core"

--- a/packs/core/seeds/workspace.toml
+++ b/packs/core/seeds/workspace.toml
@@ -15,6 +15,8 @@
 #
 # The [backlog] section below tracks open work not yet scoped to an initiative.
 # Add items as: {slug = "my-deferred-item"}
+# When a backlog item is blocked by another tracked item, encode it as a `needs`
+# edge (e.g. {slug = "b", needs = "backlog:a"}) — not just a prose comment.
 # Run `workspace-status` to see all open backlog items.
 
 [backlog]

--- a/workspace.toml
+++ b/workspace.toml
@@ -243,6 +243,8 @@ queue   = [
 #   source — deferred-AC provenance, e.g. "spec/foo AC3"
 #   needs  — same prefix notation as queue entries ("backlog:<slug>", "work:spec/...")
 # Per-entry TOML comments must be cold-start-sufficient: problem, fix, file/skill, unblock.
+# When the unblock condition is another tracked item (a hard AND dependency), also
+# add a `needs` edge — not prose alone. Disjunctive/untracked/external unblocks stay prose.
 # Distinct from [ini-NNN.shaping_queue].backlog (per-initiative non-active tier).
 [backlog]
 open = [


### PR DESCRIPTION
## Why

`capture-work` already infers `needs` from an input list's sequencing language (step 4), but **step 8 composes the `Unblocks when:` prose independently** — so a dependency that surfaces only at comment-writing time never becomes a machine-readable `needs` edge. That decoupling is why the current `[backlog]` carries ~50 prose-only blockers and only 3 `needs` edges (surfaced while reconciling the queue in #632/#633).

## Change

Add a cross-check to **step 8**: when a `[backlog]` entry's unblock condition is the completion of another *tracked* item (a `[backlog]` slug or a `[work]` spec) as a hard prerequisite, also add the matching `needs` edge.

**Guarded against over-reach** — these deliberately stay prose (the exact cases found in the audit):
- disjunctive ("A **or** B" — `needs` is AND-only), e.g. `credbroker-frozen-pack-ref-sweep`
- untracked target, e.g. `role-journey-agent-swarm-section`
- external event ("credentials provisioned", "someone takes the PR")

Mirrored the rule in the `workspace.toml` **seed header** (so future adopter repos get it) and the **live `[backlog]` schema header**, plus a new anti-pattern entry.

## Mechanics

- Source: `packs/core/.apm/skills/capture-work/SKILL.md`
- core pack **0.13.6 → 0.13.7** (`pack.toml` + `plugin.json` + `marketplace.json`)
- Re-projected via `make build-self FORCE=1` (`.claude/` + `.agents/`)
- Changelog `[Unreleased]` entry
- `make build-check` green locally