### PR TITLE
docs(atlassian): delivery lead guide for AI adoption reporting + self-certification model

### DIFF
--- a/docs/guides/atlassian/README.md
+++ b/docs/guides/atlassian/README.md
@@ -4,13 +4,17 @@ Jira, Jira Align, and Confluence over their REST APIs — plus the flow metrics 
 
 New here? Read [The `atlassian` pack as a system](explanation/atlassian-pack.md) first — it's the map. Then [work with Jira](how-to/work-with-jira.md) to search and mutate issues.
 
+Delivery leads looking to measure AI adoption: start with [Measuring AI adoption with flow metrics](explanation/ai-adoption-measurement.md) for the model, then [Report AI adoption as a delivery lead](how-to/report-ai-adoption-as-a-delivery-lead.md) for the step-by-step guide.
+
 ## How-to
 
 Task-oriented recipes for a problem you already have.
 
 - [Work with Jira](how-to/work-with-jira.md) — JQL search with auto-pagination, plus fetch, create, and update issues through the `jira` skill.
 - [Measure flow and DORA metrics](how-to/measure-flow-and-dora-metrics.md) — compute cycle time, throughput, and the rest over a Jira scope, then compare runs into a report.
+- [Report AI adoption as a delivery lead](how-to/report-ai-adoption-as-a-delivery-lead.md) — set up the labeling convention, run team-level and program-level adoption reports, and convert to a shareable format.
 - [Crawl and publish Confluence](how-to/crawl-and-publish-confluence.md) — mirror a space to Markdown and push Markdown back to a page.
+- [Authenticate Jira and Confluence with SSO cookies](how-to/authenticate-jira-confluence-with-sso-cookies.md) — for Data Center instances that block API tokens.
 
 ## Reference
 
@@ -23,6 +27,7 @@ Information-oriented, dry and complete.
 Understanding-oriented — the *why* behind the design.
 
 - [The `atlassian` pack as a system](explanation/atlassian-pack.md) — how the skills compose over the Atlassian REST APIs and the credentialed-skill auth model.
+- [Measuring AI adoption with flow metrics](explanation/ai-adoption-measurement.md) — the self-certification model, what the metrics tell you, and the limits of Jira-based AI adoption measurement.
 
 ---
 

--- a/docs/guides/atlassian/explanation/ai-adoption-measurement.md
+++ b/docs/guides/atlassian/explanation/ai-adoption-measurement.md
@@ -1,0 +1,64 @@
+# Measuring AI adoption with flow metrics
+
+The `flow-metrics` and `ai-adoption-report` skills answer one question: **are the teams that use AI coding assistants delivering differently from the teams that aren't?** This doc explains the measurement model, why self-certification produces trustworthy data, what the metrics actually tell you, and where the limits of this approach sit.
+
+## The two-skill workflow
+
+`flow-metrics` reads Jira changelogs to compute how long issues took (cycle time), how many shipped (throughput), and how work was distributed across types. It never modifies Jira. It writes canonical JSON.
+
+`ai-adoption-report` takes two or more `flow-metrics` JSON files and renders a comparison report. It never reads Jira — it only reads the files `flow-metrics` already produced. The split between the two skills is intentional: computing metrics and interpreting change are separate jobs, and keeping them separate means you can re-run the report against historical snapshots without going back to Jira.
+
+**Three comparison patterns:**
+
+| Pattern | Mode | Use when |
+|---|---|---|
+| Before vs after AI rollout | `baseline` | Proving ROI over time — same scope, two time windows |
+| AI-tagged vs untagged, same window | `cohort` | Ongoing sprint-over-sprint tracking |
+| Multiple teams, single window | `program` | Rolling up to program or value stream level |
+
+## The self-certification model
+
+There is no automatic way to know from Jira whether an engineer used an AI tool on a given story. Jira doesn't know which IDE they opened or whether Copilot drafted the implementation. The person who knows is the engineer.
+
+Self-certification makes that knowledge visible. Engineers apply a Jira label — `ai-assisted` — to stories where AI made a material contribution. `flow-metrics` then splits stories on that label: `--cohort-jql 'labels = ai-assisted'`. The cohort (labeled) and control (unlabeled) sides are measured identically and placed side by side in the report.
+
+**What crosses the "material contribution" bar:** AI drafted the core logic, debugged a non-obvious problem, wrote tests or documentation that would have taken significant manual effort, or proposed the design that the engineer adopted. One-line autocomplete does not cross the bar.
+
+**Why the ownership sits with engineers, not tooling:** Measurement imposed top-down gets gamed. Self-certification treats engineers as the experts they are — they know better than any automated tool whether the AI contributed — and gives them a positive signal to surface rather than a metric imposed on them. Teams that label consistently get better data and a clearer case for the tooling investment. Teams that don't label have a smaller cohort, which is its own signal worth discussing.
+
+**Trust horizon:** A single sprint of labeling is too small for reliable percentiles. Two to three sprints of consistent labeling produces a usable cohort. Delivery leads should focus on making the labeling habit stick; the data quality follows from the habit, not from auditing individual stories.
+
+## The metrics and what they tell you
+
+`flow-metrics` computes ten metrics. Not all of them show a clean AI-cohort signal. The five with the most consistent signal:
+
+**Cycle time (p50 / p75 / p90)**
+Time from first active-state transition to delivery. The three percentiles matter differently: p50 is the typical story, p90 is the hard tail. AI assistance tends to compress p90 most — the hardest, most uncertain stories are the ones where AI makes the biggest difference. If you can report only one metric, this is it.
+
+**Throughput**
+Count of issues delivered in the window. Higher throughput in the AI cohort is a positive signal, but read it alongside cycle time: if AI-assisted stories skew systematically smaller or simpler, the throughput advantage may partly reflect scope, not speed. Use throughput as supporting evidence, not a primary claim.
+
+**Defect ratio**
+Defects as a fraction of all delivered work. A lower ratio means more time on new value, less on rework. If the AI cohort's defect ratio is higher than the control's, that's a flag: it may mean AI-assisted code is generating downstream bugs. Worth investigating before attributing the difference to anything else.
+
+**Rework rate**
+Stories reopened or returned after being marked done. Lower means "done" actually means done. Teams report that AI assistance during development — particularly for test generation and edge-case review — tends to reduce rework.
+
+**Flow distribution**
+Breakdown of delivered work by type: features, defects, technical debt, risk. If AI is helping teams move faster on the mechanical parts of their work, the distribution shifts toward features over time. This metric is better for showing a trend over quarters than for a single-window comparison.
+
+## What the model does not measure
+
+Understanding the limits is part of understanding the model:
+
+- **Change Failure Rate and MTTR.** These DORA metrics require deployment event data from CI/CD pipelines. Jira status transitions don't carry that signal. If you need these, you need a separate data source (your deployment tooling, an observability platform).
+
+- **Individual engineer productivity.** The skills measure work at the story level. There is intentionally no per-engineer breakdown. Building one from this data would misrepresent what the data says and create the wrong incentives.
+
+- **Code quality.** Test coverage, cyclomatic complexity, static-analysis findings — use your CI quality gates for these. They're not in Jira changelogs.
+
+- **Adoption breadth at enterprise scale, in a single command.** `flow-metrics` runs one scope at a time. Measuring 100 teams requires 100 invocations. The `program` mode of `ai-adoption-report` handles the rollup, but the data collection step must be scripted at that scale. See [Report AI adoption as a delivery lead](../how-to/report-ai-adoption-as-a-delivery-lead.md#roll-up-to-program--value-stream-level) for the scripted pattern.
+
+- **Real-time or live metrics.** Each run is a point-in-time snapshot with a defined window. There is no streaming or live-dashboard mode.
+
+- **Unmeasured adoption.** Stories where AI was used but not labeled are in the control group. The model measures what teams declare, not what they actually do. Better labeling produces better data; the model cannot compensate for inconsistent labeling after the fact.

--- a/docs/guides/atlassian/how-to/measure-flow-and-dora-metrics.md
+++ b/docs/guides/atlassian/how-to/measure-flow-and-dora-metrics.md
@@ -4,6 +4,8 @@ Compute cycle time, lead time, throughput, WIP, and the rest of the Flow Framewo
 
 `flow-metrics` is read-only. It reads through the `jira` skill, joins `jira-align` for program and portfolio scope, and never transitions, comments, or mutates Jira.
 
+> **Delivery lead?** The [Report AI adoption as a delivery lead](report-ai-adoption-as-a-delivery-lead.md) guide covers the full journey — credential setup, labeling convention, team and program rollup, and shareable report formats. This page covers the CLI in depth.
+
 ## Before you start
 
 `flow-metrics` composes the `jira` skill, so verify Jira first:

--- a/docs/guides/atlassian/how-to/report-ai-adoption-as-a-delivery-lead.md
+++ b/docs/guides/atlassian/how-to/report-ai-adoption-as-a-delivery-lead.md
@@ -1,0 +1,256 @@
+# Report AI adoption as a delivery lead
+
+This guide is for delivery leads who run two to eight teams, need to report AI adoption impact upward to program or value stream leadership, and are not responsible for running the CLI themselves — the agent does that. It covers the full journey from first-time setup through a stakeholder-ready report.
+
+For the conceptual background on the measurement model and self-certification, read [Measuring AI adoption with flow metrics](../explanation/ai-adoption-measurement.md) first.
+
+## Before you start
+
+### Install the pack and set up credentials
+
+Ask your agent to install the atlassian pack if it is not already installed:
+
+> "Install the atlassian pack and set up my Jira credentials."
+
+The agent installs the pack and walks you through credential setup interactively. You will need:
+
+- A Jira API token — generated from your Atlassian account at `id.atlassian.com` under Security → API tokens.
+- Your Jira Cloud URL, for example `https://yourorg.atlassian.net`.
+
+The token is stored in your OS keychain and never written to a file the agent can read. The agent tells you when credential setup is complete.
+
+For Jira Data Center or Server instances that block API tokens (common in enterprise environments with SSO enforcement), see [Authenticate Jira and Confluence with SSO cookies](authenticate-jira-confluence-with-sso-cookies.md).
+
+For program-level reports that join Jira Align for team structure, you also need Jira Align credentials:
+
+> "Set up my Jira Align credentials."
+
+### Confirm credentials are working
+
+> "Check my Jira credentials."
+
+The agent runs a credential check. Exit 0 means you're ready. If it fails, the agent will prompt you to re-run credential setup — it will not retry automatically.
+
+For the technical credential model, see [The `atlassian` pack as a system](../explanation/atlassian-pack.md#the-auth-model).
+
+## Set up the labeling convention with your teams
+
+Before you can run a cohort comparison, your teams need to apply the `ai-assisted` Jira label to stories where AI made a material contribution. Establish this as a team habit before your first reporting window.
+
+### Agree on a definition
+
+Define "AI-assisted" with your teams before the sprint starts. A workable bar: **AI materially contributed to the solution** — not just autocomplete for a variable name. Stories that cross the bar include:
+
+- The agent drafted the core logic or the implementation approach the engineer adopted.
+- AI debugged a non-obvious problem that would otherwise have taken significant investigation.
+- The agent generated tests or documentation that would have taken an hour or more of manual work.
+
+One-line autocomplete, auto-formatting, and spell-checking do not cross the bar.
+
+### Who applies the label and when
+
+The engineer — or their AI agent in an agentic workflow — applies the label when marking the story done, or earlier in development if AI's involvement is clear from the start. In an agentic workflow where the agent writes the solution and transitions the ticket, the agent can apply the label in the same step:
+
+> "Fix issue PROJ-1234, transition it to Done, and add the label 'ai-assisted'."
+
+### What to do with unlabeled stories
+
+Do not retroactively label stories en masse — that introduces noise. Let unlabeled stories remain the control group. The cohort comparison works because the control and cohort are measured against the same window. An unlabeled story is not a problem; it is the baseline.
+
+### Trust horizon
+
+One sprint of consistent labeling produces a small, potentially noisy cohort. Two to three sprints produces enough stories for reliable percentile metrics. If the cohort has fewer than ten stories in a window, the cycle time p50/p75/p90 figures will be unreliable. Continue collecting before drawing conclusions; the report will flag a small cohort.
+
+## Measure at team level
+
+### Option A — Within-window cohort split (recommended for ongoing tracking)
+
+Run metrics for a single window and split stories into AI-assisted (labeled) and control (unlabeled) within it. This is the right approach for sprint-over-sprint tracking because it holds the window and scope constant.
+
+> "Run Q1 2026 flow metrics for project PROJ with an AI-assisted cohort split, and produce the adoption report."
+
+The agent runs:
+
+```bash
+flow-metrics \
+  --project PROJ \
+  --from 2026-01-01 --to 2026-03-31 \
+  --cohort-jql 'labels = ai-assisted' \
+  --format json \
+  --output outputs/PROJ-2026Q1-cohort.json
+
+ai-adoption-report cohort \
+  --input outputs/PROJ-2026Q1-cohort.json \
+  --output reports/PROJ-2026Q1-adoption.md
+```
+
+The report shows cycle time, throughput, defect ratio, rework rate, and flow distribution side-by-side for the AI cohort and the control group.
+
+### Option B — Before/after comparison (for proving ROI over time)
+
+Compare the same project across two windows — before the AI rollout and after. This shows aggregate improvement for the whole team, whether or not stories are individually labeled.
+
+> "Compare our Q1 2024 metrics against Q1 2026 metrics for project PROJ to show AI adoption impact."
+
+The agent runs:
+
+```bash
+flow-metrics --project PROJ --from 2024-01-01 --to 2024-03-31 \
+  --format json --output outputs/PROJ-2024Q1.json
+
+flow-metrics --project PROJ --from 2026-01-01 --to 2026-03-31 \
+  --format json --output outputs/PROJ-2026Q1.json
+
+ai-adoption-report baseline \
+  --baseline outputs/PROJ-2024Q1.json \
+  --current outputs/PROJ-2026Q1.json \
+  --output reports/PROJ-baseline-comparison.md
+```
+
+The `baseline` window must end on or before the `current` window starts. Use `--include-cohort-breakdown` if both runs included `--cohort-jql` and you want to see the cohort delta alongside the window delta in one report.
+
+### Narrowing the scope
+
+By default, `flow-metrics` includes all issues in the project that transitioned to a delivered state within the window. Narrow the scope with a JQL filter if you want to exclude components, specific teams, or issue types:
+
+> "Run flow metrics for project PROJ, Q1 2026, only the Mobile component, with cohort split."
+
+The agent adds `--jql 'component = "Mobile"'`. Your JQL expression is ANDed onto the scope query automatically — the cohort JQL is separate and does not interfere with the scope filter.
+
+## Roll up to program / value stream level
+
+### With Jira Align
+
+If your organisation uses Jira Align to manage the program structure (teams, ARTs, value streams), you can collect program-level metrics in a single invocation. You need the Jira Align program ID — ask your Jira Align administrator — and the name of the Jira custom field that links Jira issues to Jira Align (called the "join field").
+
+> "Run flow metrics for program 42 in Jira Align, Q1 2026, with AI-assisted cohort split."
+
+The agent runs:
+
+```bash
+flow-metrics \
+  --program-id 42 \
+  --align-join-field "Program ID" \
+  --cohort-jql 'labels = ai-assisted' \
+  --from 2026-01-01 --to 2026-03-31 \
+  --format json \
+  --output outputs/program-42-2026Q1.json
+
+ai-adoption-report cohort \
+  --input outputs/program-42-2026Q1.json \
+  --output reports/program-42-2026Q1-adoption.md
+```
+
+The JSON output includes a `per_team` block with team-by-team breakdowns. The adoption report surfaces which teams have the highest AI adoption cohort share and how their metrics compare.
+
+### Without Jira Align (project-by-project rollup)
+
+If your teams don't use Jira Align, collect metrics for each project individually, then roll them up using `ai-adoption-report program` mode:
+
+> "Run Q1 2026 flow metrics for PROJ1, PROJ2, and PROJ3 with cohort split, then produce a program-level adoption report."
+
+The agent runs:
+
+```bash
+mkdir -p outputs/q1-2026
+
+for proj in PROJ1 PROJ2 PROJ3; do
+  flow-metrics \
+    --project "$proj" \
+    --cohort-jql 'labels = ai-assisted' \
+    --from 2026-01-01 --to 2026-03-31 \
+    --format json \
+    --output "outputs/q1-2026/${proj}.json"
+done
+
+ai-adoption-report program \
+  --inputs outputs/q1-2026/ \
+  --window 2026-01-01..2026-03-31 \
+  --include-cohort-breakdown \
+  --output reports/program-2026Q1-adoption.md
+```
+
+The program-mode report includes per-scope rows (one per project) plus aggregated totals across all included scopes.
+
+### Scale: what this looks like for many teams
+
+For three to ten projects, the approach above is the right one. For larger programs:
+
+**10–30 projects:** Script the `flow-metrics` loop. Each invocation takes 30–90 seconds depending on issue volume. Ask your agent to write a script:
+
+> "Write a script that runs flow-metrics for each project in this list with Q1 2026 dates and ai-assisted cohort split, writing each output to outputs/q1-2026/."
+
+**100+ teams:** This is at the edge of what you can do interactively in a session. The data collection step scales linearly with project count and must be scripted. The rollup step (`ai-adoption-report program`) handles any number of JSON files in the directory with no additional effort — it's the collection that's serial. Consider scheduling the collection script as a nightly or weekly job and keeping the outputs directory as a standing dataset.
+
+What is not currently possible in a single command: running `flow-metrics` across hundreds of projects simultaneously. Each invocation is one Jira project or one Jira Align program — there is no "all projects" mode, and parallelising the invocations within one agent session is constrained by the Jira API rate limits on your instance.
+
+## Convert the report to a shareable format
+
+The report is a Markdown file with a predictable section order: Summary, Metric deltas, Per-scope rows (program mode), Cohort breakdown (if requested), Notes, Provenance. Several paths to stakeholder-ready content:
+
+### Publish to Confluence
+
+The fastest path if your organisation uses Confluence for async reporting:
+
+> "Publish the Q1 adoption report to Confluence in the ENG space under 'AI Adoption Tracking'."
+
+The agent uses `confluence-publisher` to push the Markdown directly. The page renders with formatted tables, code-highlighted metric values, and the full provenance section so readers can see which Jira projects and windows the data covers.
+
+### Paste into a doc or slide deck
+
+The Markdown tables render in most tools without additional formatting:
+
+- **Microsoft Teams posts or Wiki pages** — paste the Markdown directly; Teams renders tables.
+- **Google Docs** — paste into a blank doc; the table rows carry over. Reformat the heading levels as needed.
+- **PowerPoint or Keynote** — take the `## Summary` paragraph and the key metric rows from `## Metric deltas` for your headline slide. Three numbers are better than ten for an exec audience: cycle time p50 delta, throughput delta, defect ratio delta, each expressed as a percentage change.
+- **Notion or Linear** — both render Markdown tables natively.
+
+### Work with the JSON sidecar for dashboards
+
+By default, `ai-adoption-report` writes both a Markdown report and a JSON sidecar. The sidecar contains the same delta data in structured form:
+
+```bash
+ai-adoption-report cohort \
+  --input outputs/PROJ-2026Q1-cohort.json \
+  --output reports/PROJ-2026Q1-adoption.md \
+  --format both
+```
+
+The file `reports/PROJ-2026Q1-adoption.json` holds `deltas`, `cohort_breakdown`, `per_scope` (program mode), and full provenance. Feed it into Power BI, Tableau, or a Python script to produce a dashboard or trend chart.
+
+### Write an executive summary from the report
+
+For a brief to leadership (three bullets, no tables):
+
+> "Summarise the Q1 adoption report in three sentences suitable for a leadership update. Lead with cycle time improvement, then throughput, then quality."
+
+The agent reads the report and drafts the summary. Review it — the agent cannot tell you whether the numbers match leadership's expectations or prior commitments.
+
+## What the key metrics mean
+
+**Cycle time (p50 / p75 / p90)**
+Time from when work started to when it was delivered. The three percentiles tell different stories: p50 is the typical story; p90 is the hard tail — the 90th-percentile story took at least this long. AI assistance tends to compress p90 the most, because the hardest stories benefit most from AI helping unblock the engineer. If you can lead with one metric, lead with cycle time p50 and p90, and the percentage change between the AI cohort and the control.
+
+**Throughput**
+Count of issues delivered in the window. Higher in the AI cohort is a good signal, but read it with context: if AI-assisted stories systematically skew smaller or simpler (which is sometimes the case as engineers reach for AI on well-defined tasks), the throughput advantage partly reflects scope, not speed. Support the throughput claim with cycle time data.
+
+**Defect ratio**
+Defects as a fraction of all delivered work. Lower means more time on new value, less on bug-fixing. A rising defect ratio in the AI cohort — compared to control — is a red flag worth investigating before attributing the difference to AI. It can mean AI-assisted code is introducing defects downstream, or that the labeling convention is capturing a different population of work than expected.
+
+**Rework rate**
+Stories reopened or returned after being marked done. Lower rework means "done" actually means done. AI assistance during development — test generation, edge-case reasoning — tends to reduce rework. This metric also reflects the reliability of your definition of done, so interpret it alongside team process context.
+
+**Flow distribution**
+Breakdown of delivered work by type: features, defects, technical debt, risk. A healthy distribution is feature-heavy. If AI is accelerating the mechanical parts of technical debt and defect resolution, the distribution shifts toward features over time. This is better as a quarterly trend metric than a single-window comparison.
+
+## What this does not cover
+
+- **Change Failure Rate and MTTR** — These DORA metrics require deployment event data from your CI/CD tooling. Jira status transitions don't carry that signal; the atlassian pack doesn't see your deployment pipeline.
+
+- **Individual engineer productivity** — The skills measure work at the story level, not at the engineer level. There is intentionally no per-engineer breakdown.
+
+- **Code quality metrics** — Test coverage, complexity, static-analysis findings — use your CI quality gates. These are not in Jira changelogs.
+
+- **Automatically detected AI usage** — The `ai-assisted` label is self-reported. Stories where AI was used but not labeled appear in the control group. No automation can recover those stories after the fact. The model measures what teams declare; better labeling produces better data.
+
+For more on the measurement model's design and its limits, see [Measuring AI adoption with flow metrics](../explanation/ai-adoption-measurement.md).

--- a/web/src/content/journeys/atlassian.md
+++ b/web/src/content/journeys/atlassian.md
@@ -21,7 +21,7 @@ skills:
     description: "Drives a defect from triage through root-cause analysis to fix, with the Jira issue updated at each stage."
     humanTouches: 2
   - name: flow-metrics
-    description: "Computes cycle time, throughput, and DORA metrics (deployment frequency, lead time, MTTR, change failure rate) over a scoped Jira project."
+    description: "Computes cycle time, lead time, throughput, WIP, defect ratio, and the rest of the Flow Framework / DORA set over a Jira project or Jira Align program. Split AI-tagged stories from the control with --cohort-jql 'labels = ai-assisted'."
     humanTouches: 1
   - name: confluence-crawler
     description: "Mirrors a Confluence space or page tree to Markdown for local analysis or ingestion into another workflow."
@@ -30,35 +30,37 @@ skills:
     description: "Publishes a Markdown artifact to a Confluence page — creates or updates the page in place."
     humanTouches: 1
   - name: ai-adoption-report
-    description: "Generates an AI adoption report across a portfolio of Jira projects, measuring agent usage and impact."
+    description: "Pairs flow-metrics JSON outputs and renders a Markdown comparison report. Three modes: baseline (before/after two windows), cohort (AI-tagged vs control within one window), program (roll up across multiple teams or projects). No Jira calls — reads only local JSON files."
     humanTouches: 1
 humanGates:
   - id: G-scope
     globalGate: null
-    label: "Set the JQL scope and confirm the credential"
+    label: "Set the scope, confirm the credential, and agree the labeling convention"
     trigger: "Before any Jira query or Confluence operation is executed"
-    duration: "2–5 minutes"
+    duration: "5–10 minutes"
     whatToCheck:
-      - "Is the JQL scope specific enough to return the right issues — not the entire backlog or workspace?"
-      - "Is the credential configured for credential-brokers? (The agent will fail with a confusing error if the credential is absent or expired.)"
-      - "For flow-metrics: is the date range and project scope set to a meaningful period — not just 'all time'?"
-      - "For confluence-publisher: is the target space and parent page confirmed before any write operation?"
-    whatGoodLooksLike: "A scoped JQL query confirmed against the Jira project, a valid credential in place, and a named date range for time-based metrics."
-    whatBadLooksLike: "A JQL query that returns all issues in the workspace — the agent guessing scope instead of you defining it. Or a credential check skipped because 'it worked last time' — credentials expire."
-    consequence: "A miscoped JQL query produces metrics over the wrong population. For flow metrics this is a silent error — the numbers look plausible but measure the wrong thing. A missing credential stops the session mid-run."
+      - "Is the credential configured via credential-brokers? The agent fails with a clear error if the credential is absent or expired — but you want to catch this before starting a long metrics run."
+      - "Is the JQL scope specific enough? Project key, date range, and any label or component filters should be named explicitly. An unscoped query returns every issue in the project and the metrics will be meaningless."
+      - "For cohort reports: have teams been applying the 'ai-assisted' label consistently for at least two sprints? A cohort of fewer than ten stories produces unreliable percentiles."
+      - "For program rollups: do you have the Jira Align program ID and join field name, or the list of project keys to collect individually?"
+      - "For Confluence publish: is the target space and parent page confirmed before any write?"
+    whatGoodLooksLike: "Credential check passes. Scope is a specific project key with a named date range. Cohort label has been applied consistently for the reporting period. Confluence target confirmed if publishing."
+    whatBadLooksLike: "Credential check skipped because 'it worked last time' — credentials expire. A JQL query with no project filter. A cohort report requested for a window where the team hasn't been labeling yet."
+    consequence: "A miscoped query produces metrics over the wrong population — the numbers look plausible but measure the wrong thing. An expired credential stops the run mid-collection. An inconsistently labeled cohort produces a report that understates AI adoption and can't be trusted by leadership."
   - id: G-output
     globalGate: null
-    label: "Review the output before it is published or acted on"
-    trigger: "After flow-metrics, jira-brief-intake, or confluence-publisher completes"
-    duration: "5–15 minutes"
+    label: "Review the report before it is published or shared"
+    trigger: "After flow-metrics and ai-adoption-report complete, or after confluence-publisher completes"
+    duration: "10–20 minutes"
     whatToCheck:
-      - "For metrics: do the computed values match your informal expectation? An MTTR of 15 seconds or 15 months are both suspicious."
-      - "For briefs: does the engineering brief reflect the actual intent of the epic — or the most recent comment in the Jira thread, which may be noise?"
+      - "Do the metric values match your informal expectation? Cycle times of 15 minutes or 15 months are both suspicious — check the state-config mapping and window bounds."
+      - "Is the cohort size large enough to trust the percentiles? The report notes section will flag a small cohort."
+      - "Are cancelled or out-of-scope issues included? Check the notes section — the skill records cancelled-in-window issues and permission undercounts."
+      - "For program mode: are the right projects included? Check the per-scope rows to confirm no unexpected projects were picked up from the inputs directory."
       - "For Confluence publish: is the page in the right space and under the right parent page?"
-      - "Are there cancelled or out-of-scope issues in the metrics scope that should have been excluded?"
-    whatGoodLooksLike: "Metrics that match your intuition (or have a clear explanation when they don't). A brief that a senior engineer could implement from. A Confluence page that landed in the right place with the right parent."
-    whatBadLooksLike: "Metrics that are technically correct but meaningless — computed over a scope that wasn't cleaned up to exclude cancelled issues or unrelated projects. Or a Confluence page that published to the wrong space."
-    consequence: "Atlassian skills operate on live systems. A Confluence publish goes to the live wiki immediately. A flow metrics report shared with leadership is acted on. Review before the output leaves the session — there is no undo for a published Confluence page."
+    whatGoodLooksLike: "Metric deltas that match your intuition, or have a clear explanation when they don't. Cohort size is at least ten stories. Notes section is empty or contains only expected caveats. Confluence target is correct."
+    whatBadLooksLike: "A large positive cycle time delta that turns out to be caused by a single long-running outlier story. A cohort so small that the p90 is the same story as the p50. A Confluence page published to the wrong space."
+    consequence: "A flow metrics report shared with leadership is acted on. Delivery leads have walked into program reviews with incorrect data because the scope included cancelled work or the cohort was too small to be statistically meaningful. Review before the output leaves the session."
 typicalSession:
   agentTurns: "5–10"
   humanTouches: 2
@@ -71,22 +73,22 @@ relatedJourneys:
 
 ## Stage 1 — Configure credentials and scope
 
-Before any API call, the agent checks that a credential is configured via `credential-brokers`. It then asks you to confirm the JQL scope or Confluence target before running the first query.
+Before any API call, the agent checks that a credential is configured via `credential-brokers`. For first-time setup, it walks you through generating a Jira API token and storing it in your OS keychain — the token never appears in a file the agent can read. It then asks you to confirm the JQL scope or Confluence target before running the first query.
 
-**You:** Confirm the credential is in place — or set it up if this is the first run. Name the JQL scope explicitly: project key, issue type, status, and date range. A scoped query takes 10 seconds to define; an unscoped query returns thousands of issues and the agent has to guess which ones to include.
-
----
-
-## Stage 2 — Fetch and process
-
-With credentials and scope confirmed, the agent runs the appropriate skill. For `jira`, it runs the JQL query with auto-pagination and returns the result set. For `flow-metrics`, it computes cycle time, throughput, and DORA metrics over the scoped data. For `jira-brief-intake`, it reads the epic and structures it into a brief.
-
-**You:** Watch the fetch complete. If the result set looks wrong — too many issues, too few, or issues from the wrong project — stop the agent and restate the scope. It's faster to re-scope than to post-process a wrong result set.
+**You:** Confirm the credential is in place — or tell the agent to set it up. Name the scope explicitly: project key, date range, and any filters (component, label, team). For AI adoption reports, decide whether you're running a cohort split within one window (`labels = ai-assisted` vs unlabeled) or a before/after comparison across two windows. A scoped query takes 10 seconds to define; an unscoped query returns every issue in the project and the numbers will be meaningless.
 
 ---
 
-## Stage 3 — Review before publish or act
+## Stage 2 — Collect and compute
 
-The agent presents its output — a metrics table, a structured brief, or a proposed Confluence page — for review before taking any write action.
+With credentials and scope confirmed, the agent runs the appropriate skill. For `flow-metrics`, it reads Jira changelogs — never the issues themselves — and computes cycle time, throughput, defect ratio, rework rate, and flow distribution for the scoped period. For a cohort split, it measures the AI-labeled and unlabeled stories against the same window and records both sides in the JSON output. For a program-level rollup, it runs one invocation per project and then passes all JSON files to `ai-adoption-report program`.
 
-**You:** Review the output at the G-output gate before the agent publishes to Confluence, posts a Jira update, or shares metrics. Atlassian skills operate on live systems; there is no draft mode for Confluence publishes. Check the content is correct, the target is right, and any Jira transitions are the ones you intended before approving the write.
+**You:** Watch the collection complete. If the agent reports an unmapped status or an empty cohort, address it before continuing — an unmapped status exits with the offending name, and an empty cohort means no stories were labeled in that window. It's faster to fix the scope or labeling than to interpret a report built on incomplete data.
+
+---
+
+## Stage 3 — Review the report and share
+
+The agent presents the adoption report — a Markdown file with metric deltas, a per-scope table (program mode), and a JSON sidecar — for your review before any further action.
+
+**You:** Check that the numbers match your informal expectations. An unexpectedly large or small cohort, a metric that looks implausible, or a scope that accidentally included cancelled work are all worth investigating before the report leaves the session. Once you're satisfied, tell the agent how to share it: publish to Confluence, paste into a Teams update, or extract the headline numbers for a slide. The JSON sidecar is available for dashboards or Power BI if you need a structured feed rather than a formatted document.

--- a/web/src/content/packs/atlassian.md
+++ b/web/src/content/packs/atlassian.md
@@ -17,4 +17,4 @@ docsUrl: /docs/guides/atlassian/
 journeyUrl: /journeys/atlassian/
 ---
 
-Atlassian installs Jira and Confluence primitives (credentialed CLI with SSO-cookie auth) plus four workflow skills: `flow-metrics` (DORA + cycle time), `ai-adoption-report` (measuring agent adoption across a portfolio), `jira-defect-flow` (triage to fix), and `jira-brief-intake` (turning Jira tickets into structured engineering briefs). Credentials resolved via `credential-brokers` — cleartext never reaches the model.
+Atlassian installs credentialed CLIs for Jira, Jira Align, and Confluence — plus the workflow skills built on top. `flow-metrics` computes cycle time, throughput, and DORA metrics over a Jira project or Jira Align program. `ai-adoption-report` pairs those outputs to show how AI-tagged stories compare to the control: before/after a rollout, cohort vs control within a window, or rolled up across a program. `jira-defect-flow` handles defects end-to-end from Jira to PR. `jira-brief-intake` turns a Jira epic into a structured engineering brief. Credentials resolved via `credential-brokers` — cleartext never reaches the model.


### PR DESCRIPTION
## Summary

- **New explanation** — `docs/guides/atlassian/explanation/ai-adoption-measurement.md`: the two-skill measurement model, the self-certification concept (why ownership sits with engineers, the material-contribution bar, trust horizon), the five metrics with the clearest AI-cohort signal, and what the toolkit cannot measure (CFR/MTTR, per-engineer views, 100+ teams in one command, real-time dashboards).
- **New how-to** — `docs/guides/atlassian/how-to/report-ai-adoption-as-a-delivery-lead.md`: full delivery lead journey from credential setup through a stakeholder-ready report. Covers team-level cohort and baseline reports, Jira Align and project-by-project program rollup, scale guidance (10–30 teams vs 100+), shareable formats (Confluence publish, paste, JSON sidecar, executive 3-number summary), and a plain-language metric glossary.
- **Updated guide index** — delivery lead entry point surfaced at the top of `README.md`; SSO how-to added to the how-to list (it existed but wasn't indexed).
- **Updated marketing site** — journey stages and human gates rewritten around the delivery lead AI adoption arc; `flow-metrics` and `ai-adoption-report` skill descriptions now name specific flags and modes; pack card body rewritten to explain the two skills together.

## Deferred

- MkDocs `site/` nav entry for the new files — that site's nav is auto-generated from the `docs/` tree so no change needed, but a manual nav pin for the delivery lead guide is a follow-up if it doesn't surface prominently.
- A reference entry for the `ai-adoption-report` skill in `reference/atlassian-skills.md` — the existing reference page predates this skill's documentation; a full reference row is a small follow-up.

## Test plan

- [ ] Both new Markdown files render without broken links in MkDocs preview
- [ ] Journey page on the marketing site builds without schema validation errors (`npm run build` in `web/`)
- [ ] Cross-links between the two new files and the existing `explanation/atlassian-pack.md` and `how-to/measure-flow-and-dora-metrics.md` resolve correctly