### PR TITLE
docs(atlassian): embed sample cohort, baseline, and program reports into delivery lead guide

### DIFF
--- a/docs/guides/atlassian/how-to/report-ai-adoption-as-a-delivery-lead.md
+++ b/docs/guides/atlassian/how-to/report-ai-adoption-as-a-delivery-lead.md
@@ -84,7 +84,56 @@ ai-adoption-report cohort \
   --output reports/PROJ-2026Q1-adoption.md
 ```
 
-The report shows cycle time, throughput, defect ratio, rework rate, and flow distribution side-by-side for the AI cohort and the control group.
+The report looks like this:
+
+```markdown
+# AI-adoption report — cohort
+
+PLATFORM · 2026-01-01..2026-03-31 · cohort (`labels = ai-assisted`) vs control
+
+## Summary
+
+34 stories were labeled `ai-assisted` in the window; 89 were not. The AI cohort
+shows a 45% reduction in cycle time p50 and a 57% reduction at p90 — the
+hard-tail compression is the strongest signal. Defect ratio and rework rate are
+both lower in the cohort. Flow distribution has shifted 21 percentage points
+toward features.
+
+## Metric deltas
+
+| Metric | AI cohort | Control | Delta |
+|---|---|---|---|
+| Cycle time p50 (days) | 3.2 | 5.8 | −2.6 (−45%) |
+| Cycle time p75 (days) | 6.1 | 11.4 | −5.3 (−47%) |
+| Cycle time p90 (days) | 9.8 | 22.6 | −12.8 (−57%) |
+| Throughput (issues) | 34 | 89 | — |
+| Defect ratio | 8.8% | 18.0% | −9.2 pp |
+| Rework rate | 2.9% | 11.2% | −8.3 pp |
+| Flow efficiency | 62.3% | 41.7% | +20.6 pp |
+| Flow distribution — features | 79.4% | 58.4% | +21.0 pp |
+| Flow distribution — defects | 8.8% | 18.0% | −9.2 pp |
+| Flow distribution — debt | 11.8% | 21.3% | −9.5 pp |
+| Flow distribution — risk | 0.0% | 2.2% | −2.2 pp |
+
+## Notes
+
+- 6 issues cancelled in-window; excluded from delivery metrics.
+- 3 issues closed directly from backlog; counted in throughput, excluded from
+  cycle time.
+- Cohort size (34) is above the 10-story reliability floor for p50/p75/p90.
+
+## Provenance
+
+| Field | Value |
+|---|---|
+| Input | PLATFORM-2026Q1-cohort.json |
+| Scope | project: PLATFORM |
+| Window | 2026-01-01..2026-03-31 |
+| Cohort JQL | `labels = ai-assisted` |
+| Generated at | 2026-04-03T09:14:22Z |
+| Skill version | 1.0 |
+| State config SHA | a3f8c21d |
+```
 
 ### Option B — Before/after comparison (for proving ROI over time)
 
@@ -108,6 +157,58 @@ ai-adoption-report baseline \
 ```
 
 The `baseline` window must end on or before the `current` window starts. Use `--include-cohort-breakdown` if both runs included `--cohort-jql` and you want to see the cohort delta alongside the window delta in one report.
+
+The report looks like this:
+
+```markdown
+# AI-adoption report — baseline
+
+PLATFORM · baseline 2024-01-01..2024-03-31 → current 2026-01-01..2026-03-31
+
+## Summary
+
+Whole-team metrics across the two-year span show cycle time p50 falling from
+9.1 to 4.4 days (−52%) and throughput rising from 61 to 123 issues. Defect
+ratio has declined from 26.2% to 14.6%. Not all improvement is attributable to
+AI tooling — the team also changed its sprint cadence in late 2024 — but the
+direction and magnitude are consistent with AI-assisted delivery.
+
+## Metric deltas
+
+| Metric | Baseline (2024 Q1) | Current (2026 Q1) | Delta |
+|---|---|---|---|
+| Cycle time p50 (days) | 9.1 | 4.4 | −4.7 (−52%) |
+| Cycle time p75 (days) | 17.3 | 8.2 | −9.1 (−53%) |
+| Cycle time p90 (days) | 38.6 | 14.1 | −24.5 (−63%) |
+| Lead time p50 (days) | 22.4 | 9.8 | −12.6 (−56%) |
+| Throughput (issues / window) | 61 | 123 | +62 (+102%) |
+| Defect ratio | 26.2% | 14.6% | −11.6 pp |
+| Rework rate | 18.7% | 7.3% | −11.4 pp |
+| Flow efficiency | 33.1% | 58.9% | +25.8 pp |
+| Flow distribution — features | 49.2% | 72.4% | +23.2 pp |
+| Flow distribution — defects | 26.2% | 14.6% | −11.6 pp |
+| Flow distribution — debt | 22.9% | 13.0% | −9.9 pp |
+| Flow distribution — risk | 1.6% | 0.0% | −1.6 pp |
+
+## Notes
+
+- Scopes match: project PLATFORM in both inputs.
+- Windows are non-overlapping: baseline ends 2024-03-31, current starts
+  2026-01-01 (641-day gap).
+- No cohort JQL in either input; cohort breakdown section omitted.
+
+## Provenance
+
+| Field | Value |
+|---|---|
+| Baseline input | PLATFORM-2024Q1.json |
+| Current input | PLATFORM-2026Q1.json |
+| Scope | project: PLATFORM |
+| Baseline window | 2024-01-01..2024-03-31 |
+| Current window | 2026-01-01..2026-03-31 |
+| Generated at | 2026-04-03T09:21:07Z |
+| Skill version | 1.0 |
+```
 
 ### Narrowing the scope
 
@@ -170,7 +271,65 @@ ai-adoption-report program \
   --output reports/program-2026Q1-adoption.md
 ```
 
-The program-mode report includes per-scope rows (one per project) plus aggregated totals across all included scopes.
+The program-mode report includes per-scope rows (one per project) plus aggregated totals across all included scopes. It looks like this:
+
+```markdown
+# AI-adoption report — program
+
+5 scopes · 2026-01-01..2026-03-31 · cohort (`labels = ai-assisted`) vs control
+
+## Summary
+
+423 stories across five teams; 141 (33%) labeled `ai-assisted`. Aggregate cycle
+time p50 is 37% lower in the AI cohort. Three teams (PLATFORM, CHECKOUT, DATA)
+show strong cohort signal; two teams (MOBILE, INFRA) have cohorts below 10
+stories — their percentile figures are flagged as unreliable and excluded from
+the aggregate.
+
+## Per-scope rows
+
+| Scope | Cohort | Control | Cycle p50 Δ | Defect ratio Δ | Rework rate Δ |
+|---|---|---|---|---|---|
+| PLATFORM | 34 | 89 | −45% | −9.2 pp | −8.3 pp |
+| CHECKOUT | 52 | 71 | −38% | −6.1 pp | −5.9 pp |
+| DATA | 41 | 68 | −29% | −4.4 pp | −3.1 pp |
+| MOBILE | 8 | 44 | ⚠ n < 10 | −2.1 pp | −1.8 pp |
+| INFRA | 6 | 31 | ⚠ n < 10 | +1.3 pp | +0.4 pp |
+| **Aggregate** (3 reliable scopes) | **127** | **228** | **−37%** | **−6.6 pp** | **−5.8 pp** |
+
+## Metric deltas — aggregate (PLATFORM + CHECKOUT + DATA)
+
+| Metric | AI cohort | Control | Delta |
+|---|---|---|---|
+| Cycle time p50 (days) | 4.1 | 6.5 | −2.4 (−37%) |
+| Cycle time p90 (days) | 12.6 | 26.3 | −13.7 (−52%) |
+| Throughput — cohort share | 35.7% | 64.3% | — |
+| Defect ratio | 11.2% | 17.8% | −6.6 pp |
+| Rework rate | 4.9% | 10.7% | −5.8 pp |
+| Flow efficiency | 58.1% | 43.3% | +14.8 pp |
+
+## Notes
+
+- MOBILE and INFRA cohort sizes (8 and 6 stories) are below the 10-story
+  reliability floor. Cycle time percentiles are omitted; they are excluded from
+  the aggregate.
+- INFRA defect ratio is +1.3 pp in the AI cohort — worth a follow-up with the
+  team about labeling consistency and story type before drawing a conclusion.
+- Aggregate uses throughput-weighted rework_rate and
+  distribution-denominator-weighted defect_ratio per program-mode aggregation
+  rules.
+
+## Provenance
+
+| Scope | Input file | Window | Cohort JQL |
+|---|---|---|---|
+| PLATFORM | PLATFORM-2026Q1.json | 2026-01-01..2026-03-31 | `labels = ai-assisted` |
+| CHECKOUT | CHECKOUT-2026Q1.json | 2026-01-01..2026-03-31 | `labels = ai-assisted` |
+| DATA | DATA-2026Q1.json | 2026-01-01..2026-03-31 | `labels = ai-assisted` |
+| MOBILE | MOBILE-2026Q1.json | 2026-01-01..2026-03-31 | `labels = ai-assisted` |
+| INFRA | INFRA-2026Q1.json | 2026-01-01..2026-03-31 | `labels = ai-assisted` |
+| Generated at | 2026-04-03T09:28:44Z | Skill version | 1.0 |
+```
 
 ### Scale: what this looks like for many teams
 


### PR DESCRIPTION
## Summary

Adds three sample `ai-adoption-report` outputs directly into the delivery lead how-to guide, each positioned immediately after the command block that produces it:

- **Cohort sample** — within-window AI cohort vs control for PLATFORM/Q1 2026; shows the metric delta table, notes (small-cohort floor, cancelled issues), and provenance block.
- **Baseline sample** — before/after comparison across 2024 Q1 → 2026 Q1; shows the full metric table including lead time and flow distribution, with a note that the summary appropriately hedges non-AI causes.
- **Program sample** — five-team rollup; shows the per-scope rows table with ⚠ n < 10 flags for under-threshold teams, the aggregate metric table excluding those teams, and the INFRA +1.3 pp defect anomaly flagged in notes.