### PR TITLE
feat(user-guide-diataxis): conversation-first doctrine + substantial-revise trigger (0.2.0)

### DIFF
--- a/.agents/skills/new-guide/SKILL.md
+++ b/.agents/skills/new-guide/SKILL.md
@@ -1,264 +1,207 @@
 ---
 name: new-guide
-description: Use this skill to draft a new user-facing guide under `docs/guides/<quadrant>/<slug>.md` (or `docs/guides/<pack>/<quadrant>/<slug>.md` when guides are organized by pack) following the Diátaxis framework. Triggers on "write a guide for X", "new tutorial", "new how-to", "new reference page", "new explanation". Settles the audience contract before any body is written, then scaffolds from the matching per-quadrant template. Do NOT use for feature contracts (use `new-spec`), cross-cutting proposals (use `new-rfc`), or recording decisions (use `new-adr`).
+description: "Create or substantially revise user guides, pack pages, and journey pages using Diátaxis plus conversation-first UX. Use when asked to write, simplify, restructure, audit, or modernize tutorials, how-to guides, reference pages, explanations, pack pages, or journey pages so readers can start from a natural-language goal, see what to say, understand what happens next, and reach an outcome without learning internal skill names first. Do NOT use for feature contracts (use `new-spec`), cross-cutting proposals (use `new-rfc`), recording decisions (use `new-adr`), minor single-line edits (normal PR), contributor docs, docstrings, release notes, or blog posts."
 ---
 
-# Skill: new-guide
+# Guide authoring
 
-Create a new user-facing guide under `docs/guides/<quadrant>/<slug>.md`
-— or `docs/guides/<pack>/<quadrant>/<slug>.md` in a repo that organizes
-its guides by pack — following the [Diátaxis framework](https://diataxis.fr/).
-The framework itself is documented in this repo at `docs/guides/README.md`
-and the per-quadrant README — read those for the *what*; this skill is the
-*procedure* for landing a new piece on the right side of the line.
+**Diátaxis determines where information lives. User intent determines how readers
+enter it.**
 
-The load-bearing rule is **link out, don't blend**. When mid-draft you
-find yourself wanting to add theory inside a tutorial, or steps inside an
-explanation, that's the cue to write the adjacent piece separately and
-link. Mixing quadrants is the most common reason user docs frustrate
-everyone.
+A reader who does not know any pack or skill names must still be able to begin a
+real task from the first screen.
 
-## When to invoke
+Create or substantially revise one user-facing documentation surface. Use Diátaxis
+to determine the page's job. Use conversation-first design to determine what the
+reader encounters first.
 
-Before invoking, confirm:
+## Prerequisites
 
-1. The topic is *user-facing* — the reader is someone using the product,
-   not a contributor reading the code. Contributor-facing material lives
-   in `docs/architecture/` (current state) or `docs/adr/` (decisions).
-   If it's spec-shaped, use `new-spec`.
-2. The behavior being documented *already ships* — guides are living
-   docs that must match current product behavior. If you're proposing a
-   change, you want an RFC or a spec, not a guide.
-3. You can name a real reader. "Someone might want to know X" isn't a
-   reader; "an operator whose API token expires tomorrow and needs to
-   rotate it before the next deploy" is.
-
-If any check fails, push back rather than proceeding.
+- Read the actual skills, commands, or workflows the page documents.
+- Identify one primary reader and one primary job.
+- Preserve verified commands, permissions, defaults, and side effects.
+- For generated pages, edit their source data or template — not the rendered output.
 
 ## Procedure
 
-1. **Settle the audience contract — gated checkpoint.** With nothing
-   scaffolded yet, stop and surface the contract *in chat*. This is the
-   skill's analogue to `new-spec`'s assumptions checkpoint: the body is
-   gated until the contract is signed off. A guide that doesn't name its
-   reader ends up serving none of them.
+### Step 1 — Choose mode
 
-   Emit the contract under exactly this shape:
+**Create** a new guide, or **revise** an existing one.
 
-   ```markdown
-   AUDIENCE CONTRACT:
+Revise mode applies to substantial changes: restructuring the page's flow,
+correcting the quadrant, major rewrites, adding conversation-first structure, or
+auditing for inventory-first writing.
 
-   ## Reader profile
-   - **Right now they are:** <on rails, attentive | has a specific problem | scanning for an authoritative fact | reflecting, away from active use>
-   - **They leave with:** <a confident "I did it" + working artifact | their problem solved | the precise answer | a clearer mental model of why>
+Minor edits — a typo fix, a single updated command, a broken link, a version
+number — are a **normal PR against the existing file**. Stop here and redirect to
+that path; do not proceed with this skill for minor edits.
 
-   ## Quadrant pick
-   - **Quadrant:** <tutorials | how-to | reference | explanation>
-   - **Why this one (not the adjacent quadrants):** <one sentence>
+### Step 2 — Pick the slug or confirm the file
 
-   ## Title (working)
-   - **Title:** <draft>
-   - **What the reader would have typed into search:** <phrase>
-   ```
+- **Create:** choose a kebab-case slug matching what the reader would have searched
+  for. `rotate-credential-token`, not `how-to-rotate-your-token-step-by-step`.
+  The quadrant subdir carries the "how-to" / "tutorial" framing; do not repeat it
+  in the filename.
+- **Revise:** confirm the path to the existing file before proceeding.
 
-   Diátaxis distinguishes the four pieces by reader *posture*, not by
-   reader *skill*. The same person, expert at the product, can land in
-   any of the four quadrants on different days — what places them is
-   what they're doing right now. Use the posture-to-quadrant mapping:
+### Step 3 — Write the conversation contract (gated)
 
-   | Reader's posture right now | Quadrant |
-   | --- | --- |
-   | On rails, attentive, wants a guaranteed working result | **Tutorials** |
-   | Has a named problem, wants the recipe | **How-to** |
-   | In a hurry, scanning for the authoritative answer | **Reference** |
-   | Away from the keyboard, wants to understand *why* | **Explanation** |
+Before any prose is drafted, produce the contract and wait for human confirmation.
+This is the skill's gate — the body is blocked until the contract is signed off.
 
-   Then **wait for human confirmation or revision.** Don't write into
-   the body until the contract is signed off — even if the original
-   prompt sounded definitive. Two outcomes from confirmation:
+```
+CONVERSATION CONTRACT:
 
-   - The contract is accepted → proceed to step 2.
-   - The contract splits into two readers or two postures → that's two
-     guides, not one. Surface this and ask the user to pick the
-     first; the second goes to follow-up.
+reader: <role and context — not "all users"; who is reading right now>
+job: <the specific thing they are trying to accomplish>
+natural_start: <the exact words they would use to begin>
+minimum_scope:
+  - <the minimum the agent needs to start — team, board, time horizon, etc.>
+first_result: <the concrete thing the reader gets back>
+write_boundary: <what the agent reads vs. what it may change>
+next_request: <the most likely follow-up after the first result lands>
+```
 
-2. **Pick a kebab-case slug.** Keep it short and noun-y, matching what
-   the reader would have searched for: `rotate-credentialed-skill-token`,
-   not `how-to-rotate-your-token-step-by-step`. The quadrant subdir
-   carries the "how-to" / "tutorial" framing; don't repeat it in the
-   filename.
+Wait for human confirmation or revision. Two outcomes:
 
-3. **Scaffold from the matching template.** The quadrant token maps to
-   one asset filename and one destination directory — use the mapping
-   table below verbatim, don't interpolate by hand:
+- Contract accepted → proceed to Step 4.
+- Contract splits into two readers or two jobs → two pages. Surface this and ask
+  the user to pick the first; the second goes to a follow-up.
 
-   | Quadrant | Asset to copy | Destination |
-   | --- | --- | --- |
-   | `tutorials` | `assets/tutorials.md` | `docs/guides/tutorials/<slug>.md` |
-   | `how-to` | `assets/how-to.md` | `docs/guides/how-to/<slug>.md` |
-   | `reference` | `assets/reference.md` | `docs/guides/reference/<slug>.md` |
-   | `explanation` | `assets/explanation.md` | `docs/guides/explanation/<slug>.md` |
+### Step 4 — Choose the page contract type
 
-   (Paths are skill-relative — the `assets/` folder lives next to this
-   `SKILL.md` wherever your IDE installed the skill.) The four
-   templates carry the minimal section structure for each quadrant; they
-   are starting scaffolds, not strict forms.
+Determine which of the six surface types applies. For the four Diátaxis types,
+choose by reader posture — what the reader is doing right now, not what topic
+they are reading about.
 
-   **If the repo organizes guides by pack** — a `docs/guides/<pack>/<quadrant>/`
-   layout — prefix the destination with the owning pack, or `_shared/` for a
-   cross-cutting guide that isn't specific to one pack: e.g.
-   `docs/guides/core/how-to/<slug>.md`. Write where the repo's existing
-   guides already live; match the surrounding structure rather than imposing
-   one.
+| Reader's posture right now | Surface type |
+| --- | --- |
+| On rails, attentive, wants a guaranteed working result | Tutorial |
+| Has a named problem, wants the recipe | How-to |
+| In a hurry, scanning for the authoritative answer | Reference |
+| Away from the keyboard, wants to understand *why* | Explanation |
 
-4. **Draft, applying the per-quadrant rules.** The source of truth for
-   *what goes in* each quadrant is the per-quadrant README under
-   `docs/guides/<quadrant>/README.md` (or `docs/guides/_shared/<quadrant>/README.md`
-   in a per-pack repo). Read the relevant one before drafting. The condensed write-time rules, with the named anti-patterns
-   the canonical framework warns about:
+Pack pages describe what a pack does and how to start — choose by context.
+Journey pages walk a complete user flow from first request to final outcome —
+choose by context.
 
-   - **Tutorials.** Concrete, complete, one path, no digression. Each
-     step says what to do, shows what to expect, reassures the reader
-     they're on track. Refuse the [*anti-pedagogical
-     temptations*](https://diataxis.fr/tutorials/) Procida names:
-     *abstraction, generalisation*, *explanation*, *choices*,
-     *information*. Tutorials must produce the result they promise —
-     broken reliability is the worst failure. Open with the guaranteed
-     outcome ("At the end you'll have a running X"), not "you will
-     learn".
-   - **How-to.** Solves one named problem for an already-competent
-     reader. Title is the problem. Skip backstory, skip "turn on the
-     power switch"–level steps, skip reteaching basics. Cover the
-     realistic variations and the common pitfalls — that's what makes a
-     how-to worth the click over the reference page.
-   - **Reference.** Authoritative, complete, consistently structured,
-     **neutral**. Procida: ["Neutral description is the key imperative
-     of technical reference"](https://diataxis.fr/reference/) — austere,
-     factual, no editorializing, no narrative. If the section is
-     auto-generated, mark it at the top so the next person doesn't
-     hand-edit it. Reference rots when the code drifts; "code change →
-     reference update in the same PR" is the discipline.
-   - **Explanation.** Discursive, illuminating, allowed to be opinionated
-     and to wander a little. Frame the scope with an *"About <topic>"*
-     question to keep it bounded — open-ended explanations sprawl. No
-     step-by-step instructions, no parameter lists. Make connections to
-     adjacent topics. ADRs vs. architecture docs vs. explanation: ADRs
-     are *frozen decisions for the team*, architecture is *how the code
-     is organized now for contributors*, explanation is *what the
-     concept means for someone using the product*.
+### Step 5 — Load the relevant contract from `references/page-contracts.md`
 
-   On voice and tone — apply Google's developer-docs rule of thumb:
-   "Sound like a knowledgeable friend who understands what the developer
-   wants to do." Second person, active voice, present tense. Two
-   separate anti-patterns to avoid:
+Read only the section that matches the surface type chosen in Step 4. Apply its
+required content and "move lower" rules throughout drafting.
 
-   - **Don't gaslight stuck readers.** Drop *simply*, *just*, *easy*,
-     *quickly*, *obviously* — every one of those words makes a reader
-     who got stuck feel dumb.
-   - **Don't soften imperatives.** Drop *please* in instructions ("please
-     click", "please run") — it makes commands sound optional. Just
-     write the imperative.
-   - **Don't narrate the product's history.** Write as if the product
-     always worked this way — the *retcon* discipline. Drop "will be
-     added", "previously X, now Y", "deprecated in 2.0", and
-     version-stamped history from the guide body. A guide is a living doc
-     describing current behavior; the reader wants what is true now, not a
-     changelog. Evolution belongs in release notes, the changelog, or an
-     ADR — link to it instead of narrating it inline.
+### Step 6 — Scaffold (create mode, four Diátaxis types only)
 
-   Efficiency is a form of respect — the reader is in a hurry.
+For create mode and the four Diátaxis quadrants, scaffold from the matching asset
+template and write to the standard destination:
 
-   Beyond word choice, the draft should read like a person wrote it, not a
-   machine. Cut the tells that make prose feel generated: hedges ("it's
-   worth noting"), uniform sentence rhythm, em-dash overuse, throat-clearing
-   openers ("In this guide we will explore…"), inflated verbs ("leverage",
-   "utilize", "delve"), and sentences that restate the heading. Vary sentence
-   length, keep one claim per sentence, and prefer a concrete number or
-   example over an adjective. Read the full checklist in
-   [`references/clear-prose.md`](references/clear-prose.md) while you draft and
-   edit, not before.
+| Surface type | Asset to copy | Destination |
+| --- | --- | --- |
+| Tutorial | `assets/tutorials.md` | `docs/guides/tutorials/<slug>.md` |
+| How-to | `assets/how-to.md` | `docs/guides/how-to/<slug>.md` |
+| Reference | `assets/reference.md` | `docs/guides/reference/<slug>.md` |
+| Explanation | `assets/explanation.md` | `docs/guides/explanation/<slug>.md` |
 
-5. **Apply the link-out rule as you draft.** When you find yourself
-   reaching for content from the adjacent quadrant, stop and write a
-   link instead:
+(Paths are skill-relative — the `assets/` folder lives next to this `SKILL.md`.)
 
-   - Tempted to explain *why* mid-tutorial → link to (or create) an
-     explanation page.
-   - Tempted to list every option mid-how-to → link to the reference.
-   - Tempted to walk a beginner through setup mid-explanation → link to
-     the tutorial.
-   - Tempted to recommend a best practice mid-reference → link to the
-     explanation.
+For pack pages and journey pages in create mode, there is no fixed destination;
+write where the repo's existing guides already live. Match the surrounding
+structure.
 
-   The link can be a placeholder (`<!-- TODO: link to … -->`) if the
-   adjacent piece doesn't exist yet; surface those placeholders in the
-   final summary so the next guide gets written.
+If the repo organizes guides by pack — a `docs/guides/<pack>/<quadrant>/` layout
+— prefix the destination with the owning pack, or `_shared/` for a cross-cutting
+guide.
 
-6. **Self-check before announcing the draft.** Walk this list against
-   the chosen quadrant; every "yes" is a finding to fix:
+### Step 7 — Draft using conversation-first structure
 
-   - Tutorial: does any step lack a "you should see…" check? Did I
-     offer the reader a choice anywhere? Did I sneak in *why* instead of
-     linking out?
-   - How-to: does the title name the reader's problem in their words?
-     Did I reteach a basic the reader already knows? Did I cover only
-     the linear path and ignore realistic variations?
-   - Reference: did I editorialize anywhere ("this is the recommended
-     option…")? Is any entry of the same kind shaped differently from
-     its siblings? Did I skip an option?
-   - Explanation: is there a step-by-step block that belongs in a
-     how-to? Did I drift past the *"About <topic>"* scope? Did I avoid
-     opinion — explanation is *allowed* a voice?
+Put the first useful example before inventories, architecture, terminology, or
+exhaustive options. A reader who reaches word 120 without seeing a prompt,
+command, or concrete result has waited too long.
 
-   Then run a prose pass against
-   [`references/clear-prose.md`](references/clear-prose.md). When your
-   environment provides subagents, hand the draft plus that checklist to a
-   read-only subagent and ask it to flag machine-shaped prose; that keeps the
-   style read off your main context. Without subagents, read the draft cold
-   yourself against the checklist. The quadrant self-check above is the floor;
-   the prose pass is the polish.
+Structure the core task flow using:
 
-7. **Cross-link the siblings — only the ones that exist.** A new guide
-   rarely stands alone. From the new file, add a `See also` section.
-   For each candidate sibling — the tutorial that introduces the
-   concept, the how-to that uses what reference describes (and vice
-   versa), the explanation that says *why* — check whether the file
-   exists. If it does, link it. If it doesn't, surface the gap in the
-   final summary as a follow-up TODO; don't write a broken link, and
-   don't synthesize a plausible-sounding path. From each existing
-   sibling, add a reverse link to the new piece. Cross-links are a
-   maintenance pact: when one rots, the others surface the drift.
+- **Say this** — the exact words the reader uses
+- **What happens** — what the agent does in response
+- **You get** — the concrete result
+- **What to ask next** — the likely follow-up
 
-   Don't touch the per-quadrant `README.md` (`docs/guides/<quadrant>/README.md`,
-   or `docs/guides/_shared/<quadrant>/README.md` in a per-pack repo) — those
-   READMEs are the framework's per-quadrant explainer, not a piece index.
-   Adopters who want an index of pieces add one separately; the skill
-   doesn't invent one.
+### Step 8 — Apply conversation-first rules
+
+Load [`references/conversation-first.md`](references/conversation-first.md) and
+apply its eight sequencing rules. Key checks:
+
+- Realistic user request within the first 120 words
+- No more than two product-specific terms before that request
+- User language before implementation names
+- Read/write boundary explicit
+- Next request shown
+
+### Step 9 — Edit for density
+
+Load [`references/clear-prose.md`](references/clear-prose.md) and edit. Pay
+particular attention to the `## Conversation-first structure` section at the end
+— it covers page-level structural tells that a word-level pass will miss.
+
+When your environment provides subagents, hand the draft and the checklist to a
+read-only subagent; that keeps the style read off your main context. The cold
+self-read is the floor without subagents.
+
+### Step 10 — Run the usability review
+
+Load [`references/usability-review.md`](references/usability-review.md) and run
+the six-item checklist. Each "yes" is a finding to fix before declaring the draft
+ready. Also verify the conversation contract is reflected in the draft.
+
+### Step 11 — Check links and cross-link siblings
+
+Apply the link-out rule as you finalize:
+
+- Tempted to explain *why* mid-tutorial → link to an explanation page
+- Tempted to list every option mid-how-to → link to the reference
+- Tempted to walk a beginner through setup mid-explanation → link to the tutorial
+- Tempted to recommend a best practice mid-reference → link to the explanation
+
+The link can be a placeholder (`<!-- TODO: link to … -->`) if the adjacent piece
+does not exist yet; surface those placeholders in the final summary.
+
+From the new or revised file, add a `See also` section linking existing siblings
+only. From each existing sibling, add a reverse link. Check whether each file
+exists before linking — do not write broken links and do not synthesize
+plausible-sounding paths.
+
+Do not touch the per-quadrant `README.md` files — those are the framework's
+per-quadrant explainer, not a piece index.
+
+## Verification
+
+Before announcing the draft, confirm:
+
+- [ ] The first actionable example appears within the first 120 words.
+- [ ] The reader does not need to know a skill name to begin.
+- [ ] Read and write behavior is explicit.
+- [ ] The page shows at least one realistic follow-up.
+- [ ] Skill inventory appears after user outcomes.
+- [ ] A complete task has a visible start and finish.
 
 ## Anti-patterns to refuse
 
-- **Writing the body before the audience contract is confirmed.** The
-  body is gated. The contract is the cheapest place to catch a
-  mismatched quadrant; once draft prose is on the page, rework costs
-  compound.
-- **Picking the quadrant by *topic* instead of by *reader posture*.**
-  "Authentication" is a topic; *learning* authentication, *configuring*
-  it, *looking up its parameters*, and *understanding why it's
-  cookie-based* are four different pieces — possibly all four.
-- **Blending quadrants because "the reader will appreciate the
-  context".** They won't. The framework's whole thesis is that mixing
-  modes is what makes docs frustrating; the link-out rule is
-  non-negotiable.
-- **Drafting a tutorial without running the steps end-to-end.** A
-  tutorial that doesn't produce the promised result is worse than no
-  tutorial. If the steps can't be run, you're writing a how-to or an
-  explanation — re-open the audience contract.
-- **Writing reference in narrative voice.** "You'll want to set this
-  to…" is explanation leaking into reference. Reference says *what*;
-  recommendations live in explanation.
-- **Writing explanation without an *About <X>* frame.** Open-ended
-  explanation absorbs adjacent material and sprawls. Name the question
-  the page answers; if you can't, the page isn't ready.
-- **Editing an existing guide via this skill.** `new-guide` is for new
-  pieces. Edits are normal PRs against the existing file; the rules in
-  step 4 still apply, but the skill's checkpoint and scaffold don't.
+- **Drafting before the conversation contract is confirmed.** The body is gated.
+  The contract is the cheapest place to catch a mismatched scope; once draft
+  prose is on the page, rework compounds.
+- **Using this skill for minor edits.** A typo fix, a single updated command, a
+  broken link — these are normal PRs. This skill's procedure adds ceremony that
+  minor edits do not warrant.
+- **Picking the surface type by topic instead of by reader posture.** "Authentication"
+  is a topic; *learning* it, *configuring* it, *looking up its parameters*, and
+  *understanding why it is cookie-based* are four different pieces.
+- **Blending surface types because "the reader will appreciate the context."** They
+  will not. The link-out rule is non-negotiable.
+- **Drafting a tutorial without running the steps end-to-end.** A tutorial that
+  does not produce the promised result is worse than no tutorial. If the steps
+  cannot be run, you are writing a how-to or an explanation — re-open the contract.
+- **Writing reference in narrative voice.** Reference says *what*; recommendations
+  live in explanation.
+- **Writing explanation without an *About <X>* frame.** Open-ended explanation
+  absorbs adjacent material and sprawls. Name the question the page answers.
+- **Leading with a skill or pack inventory.** The reader came with a goal. The
+  inventory belongs after the first task completes.

--- a/.agents/skills/new-guide/evals/eval_queries.json
+++ b/.agents/skills/new-guide/evals/eval_queries.json
@@ -19,5 +19,17 @@
   {"query": "Write the release notes for the 2.0 release", "should_trigger": false},
   {"query": "Fix the broken link in the installation guide", "should_trigger": false},
   {"query": "Write the empty-state and error microcopy for the upload screen", "should_trigger": false},
-  {"query": "Write a blog post announcing our new export feature", "should_trigger": false}
+  {"query": "Write a blog post announcing our new export feature", "should_trigger": false},
+
+  {"query": "Rewrite this Jira guide so the reader sees what to ask first", "should_trigger": true},
+  {"query": "Turn this skill-list page into a task-led pack page", "should_trigger": true},
+  {"query": "Make this Diátaxis how-to less dense", "should_trigger": true},
+  {"query": "Add a realistic multi-turn conversation to this guide", "should_trigger": true},
+  {"query": "Audit these docs for inventory-first writing", "should_trigger": true},
+  {"query": "Revise this journey page to show a complete user flow", "should_trigger": true},
+
+  {"query": "Create a Jira story for password reset", "should_trigger": false},
+  {"query": "Show me the Atlas team's blockers", "should_trigger": false},
+  {"query": "Fix spelling in this README", "should_trigger": false},
+  {"query": "What is Diátaxis and how does it work", "should_trigger": false}
 ]

--- a/.agents/skills/new-guide/evals/evals.json
+++ b/.agents/skills/new-guide/evals/evals.json
@@ -13,6 +13,25 @@
         "Prose reads human and task-respecting: second person, active voice, present tense; no reader-blaming fillers (simply/just/easy/obviously), no softened imperatives (please), no inline version-history narration",
         "Cross-links (\"See also\") point only to sibling pages that exist — no fabricated or broken links"
       ]
+    },
+    {
+      "id": 2,
+      "prompt": "Create or revise a user-facing guide following the conversation-first doctrine.",
+      "expected_output": "A guide that states the reader and their job early, shows a natural-language request near the top (within the first 120 words), explains the first result the reader gets, shows at least one realistic follow-up request, makes read/write boundaries explicit, puts skill/command inventory after user outcomes rather than before, and keeps reference material out of the primary flow. It does not open with product architecture or a skill list. The reader can begin a task without knowing any skill or pack name. The page shows a visible start and finish for at least one complete task.",
+      "assertions": [
+        "States the reader and their job — the page has an implied or explicit audience",
+        "Shows a natural-language request near the top, within the first 120 words",
+        "Explains the first result — the reader knows what they will get before the detail starts",
+        "Shows at least one realistic follow-up request, not only the entry request",
+        "Makes read/write boundaries explicit — separates what the agent reads from what it may change",
+        "Puts skill/command inventory after user outcomes, not before",
+        "Keeps reference material (exhaustive options, parameter tables) out of the primary flow",
+        "Does not open with product architecture or an internal component diagram",
+        "Does not begin by presenting a list of available skills, packs, or commands before the reader's first task",
+        "Does not require the reader to know any skill or pack name to begin",
+        "Is not a collection of isolated prompt snippets — shows what the agent returns and not just what the user says",
+        "Does not indiscriminately mix Diátaxis quadrants — tutorial material is not blended with reference"
+      ]
     }
   ]
 }

--- a/.agents/skills/new-guide/references/clear-prose.md
+++ b/.agents/skills/new-guide/references/clear-prose.md
@@ -105,3 +105,35 @@ will miss:
 When your environment has subagents, the skill's optional copyedit pass hands
 the draft and this checklist to a fresh reader so the style read stays off your
 main context. The cold self-read is the floor either way.
+
+## Conversation-first structure
+
+These are page-level structural rules. They complement the word-level checklist
+above — a draft can pass every vocabulary check and still fail these. Run them
+after the prose pass, not instead of it. For the full framing and sequencing
+rationale, see [`references/conversation-first.md`](conversation-first.md).
+
+- **Put one observable outcome before the first conceptual explanation.** The
+  reader needs to see what they will get before they are asked to understand
+  why. An outcome is a command, a result, or a concrete next step — not a
+  category name.
+- **Put a realistic user request within the first 120 words.** The reader
+  scanning for "how do I begin?" should find it without scrolling.
+- **Introduce no more than two product-specific terms before that request.**
+  Every term introduced before the first example is a term the reader must
+  carry before they can act.
+- **Do not lead with a component, skill, command, or pack inventory.** Leading
+  with what the product contains is inventory-first. The reader came with a
+  goal, not a browse session. The inventory belongs after the first task
+  completes.
+- **Use user language first and implementation names second.** "Show me the
+  team's open work" before `jira-team-status`. The page can use both; the
+  user term opens the sentence.
+- **Show the next likely request, not only the initial request.** A guide
+  that ends with the first task done leaves the reader stranded. Name where
+  they go next.
+- **Separate read-only exploration from remote writes.** State clearly when an
+  action reads data vs. when it changes something. Never leave the read/write
+  boundary implicit.
+- **Put exhaustive options in reference, not in the main procedure.** Embed a
+  link; do not embed the reference page.

--- a/.agents/skills/new-guide/references/conversation-first.md
+++ b/.agents/skills/new-guide/references/conversation-first.md
@@ -1,0 +1,48 @@
+# Conversation-first structure
+
+Diátaxis determines where information lives. User intent determines how readers
+enter it. These are page-level sequencing rules — they sit above the word-level
+checklist in `clear-prose.md` and govern the order of what the reader encounters
+before the detail starts.
+
+A reader who does not know any pack or skill names must still be able to begin a
+real task from the first screen.
+
+## Rules
+
+1. **Put one observable outcome before the first conceptual explanation.** The
+   reader needs to see what they will get before they are asked to understand why
+   it works. An observable outcome is a command, a result, a screenshot, or a
+   concrete next step — not a category name or a feature list.
+
+2. **Put a realistic user request within the first 120 words.** The request shows
+   the reader how to start. It does not have to be the opener; it has to be early
+   enough that a reader scanning for "how do I begin?" finds it without scrolling.
+
+3. **Introduce no more than two product-specific terms before that request.** Terms
+   introduced before the first example are terms the reader must carry before they
+   can act. Two is the ceiling; one is better; zero is possible and often right.
+
+4. **Do not lead with a component, skill, command, or pack inventory.** Leading with
+   a list of what the product contains is inventory-first writing. The reader came
+   with a goal, not a browse session. The inventory belongs after the first task
+   completes.
+
+5. **Use user language first and implementation names second.** "Show me the team's
+   open work" before `jira-team-status`. "Create a decision record" before `new-adr`.
+   The page can use both; the user term opens the sentence.
+
+6. **Show the next likely request, not only the initial request.** A guide that ends
+   with the first task done leaves the reader stranded. Name where they go next —
+   a follow-up prompt, a related page, or the decision they face after the first
+   result lands.
+
+7. **Separate read-only exploration from remote writes.** State clearly when an
+   action reads data vs. when it changes something. A reader deciding whether to
+   run a command needs to know which side of that line it falls on. Do not leave
+   the read/write boundary implicit.
+
+8. **Put exhaustive options in reference, not in the main procedure.** A how-to
+   that enumerates every flag, a tutorial that lists every configuration key — both
+   interrupt the reader's task with detail they did not ask for. Link to the
+   reference; do not embed it.

--- a/.agents/skills/new-guide/references/page-contracts.md
+++ b/.agents/skills/new-guide/references/page-contracts.md
@@ -1,0 +1,164 @@
+# Page contracts
+
+Each section below is the contract for one surface type. Load only the section
+that matches the page you are writing or revising. The contract answers three
+questions for each type: what the first screen must make obvious, what content
+is required, and what to move lower or link out.
+
+## Choosing the right surface type
+
+For the four Diátaxis types, choose by reader posture — what the reader is doing
+right now, not what topic they are reading about. The same person, on different
+days, will land in different quadrants.
+
+| Reader's posture right now | Surface |
+| --- | --- |
+| On rails, attentive, wants a guaranteed working result | **Tutorial** |
+| Has a named problem, wants the recipe | **How-to** |
+| In a hurry, scanning for the authoritative answer | **Reference** |
+| Away from the keyboard, wants to understand *why* | **Explanation** |
+
+Pack pages and journey pages are chosen by context: if the page describes what a
+pack does and how to start, it is a Pack page. If the page walks through a
+complete user flow from first request to final outcome, it is a Journey page.
+
+---
+
+## Tutorial
+
+**First screen must answer:** "How do I complete my first real journey?"
+
+**Required content:**
+- The exact first request to send — copyable, not paraphrased
+- The expected result after that first request
+- Checkpoints along the way ("you should see…")
+- A complete outcome at the end — the reader finishes with something real
+- Each step says what to do and what the reader should observe
+
+**Move lower or link out:**
+- Alternatives and variations (→ How-to)
+- Architecture and design decisions (→ Explanation)
+- Exhaustive option lists (→ Reference)
+- Prerequisites beyond the minimum needed to start
+
+**Anti-patterns to refuse:**
+- Offering the reader a choice mid-tutorial
+- Inserting explanation of *why* without linking out
+- Steps that produce no observable result
+- A result the reader cannot verify
+
+---
+
+## How-to
+
+**First screen must answer:** "How do I accomplish this one goal?"
+
+**Required content:**
+- A copyable request or command that starts the task
+- The scope of what the skill reads and what it may change
+- A minimal procedure covering the common path
+- Common variations the reader is likely to hit
+- The most likely follow-up request after the task completes
+
+**Move lower or link out:**
+- Theory and background (→ Explanation)
+- Exhaustive field-by-field reference (→ Reference)
+- Step-by-step setup a beginner needs (→ Tutorial)
+- Options the reader will never vary
+
+**Anti-patterns to refuse:**
+- A title that names a topic rather than the reader's problem
+- Reteaching basics the competent reader already knows
+- Covering only the linear happy path with no realistic variations
+
+---
+
+## Reference
+
+**First screen must answer:** "What exactly does this skill accept and do?"
+
+**Required content:**
+- An intent index — what the reader can accomplish with this skill
+- Inputs: what the reader provides
+- Outputs: what the skill returns
+- Reads: what the skill reads without asking
+- Writes: what the skill may change
+- Limits: caps, timeouts, pagination, rate limits
+
+**Move lower or link out:**
+- Narrative walkthroughs (→ How-to or Tutorial)
+- Explanation of why the design works this way (→ Explanation)
+- Getting-started instructions (→ Tutorial)
+
+**Anti-patterns to refuse:**
+- Editorializing ("this is the recommended option…")
+- Entries of the same kind shaped differently from their siblings
+- Skipping an option because it is "rarely used"
+
+**Sync discipline:** Reference rots when the code drifts. A code change → reference update in the same PR is the rule, not a nice-to-have. For auto-generated sections, mark them with a comment pointing to the source data so readers know not to hand-edit the copy.
+
+---
+
+## Explanation
+
+**First screen must answer:** "How do these pieces fit together and why?"
+
+**Required content:**
+- A mental model the reader can hold in their head
+- How the components compose — what connects to what
+- Trade-offs and the reasoning behind key design choices
+- Boundaries — what this concept is and is not
+
+**Move lower or link out:**
+- Step-by-step procedures (→ How-to)
+- Exhaustive parameter lists (→ Reference)
+- Guaranteed-outcome walkthroughs (→ Tutorial)
+
+**Anti-patterns to refuse:**
+- Step-by-step instructions embedded in the explanation
+- Open-ended scope with no "About <topic>" frame
+- Refusing to take a position where the design is opinionated
+
+---
+
+## Pack page
+
+**First screen must answer:** "What can this help me do?"
+
+**Required content:**
+- Job cards — what a reader with a concrete goal can accomplish
+- Natural-language prompts — the exact words to use, not skill names
+- Result previews — what the agent returns for each task
+- The common journey — a start-to-finish sequence for the primary use case
+
+**Move lower or link out:**
+- The full skill inventory (names, flags, schema)
+- Installation and setup details
+- Architecture of how the pack is composed
+
+**Anti-patterns to refuse:**
+- Opening with a skill or command list
+- Requiring the reader to know a skill name to begin the first task
+- Describing capabilities in abstract terms without a concrete prompt
+
+---
+
+## Journey page
+
+**First screen must answer:** "What happens from start to finish?"
+
+**Required content (one block per stage):**
+- **You say** — the natural-language request the reader sends
+- **Agent does** — what the agent reads, fetches, or computes
+- **You get** — the concrete result
+- **Decision** — what the reader decides or confirms before the next stage
+
+**Move lower or link out:**
+- Skill cards and implementation vocabulary
+- Configuration and permission details
+- Error-handling reference
+
+**Anti-patterns to refuse:**
+- Describing what the skill does without showing what the reader says and gets
+- Stages without a visible decision or outcome
+- Mixing implementation vocabulary into the user-facing flow

--- a/.agents/skills/new-guide/references/usability-review.md
+++ b/.agents/skills/new-guide/references/usability-review.md
@@ -1,0 +1,49 @@
+# Usability review
+
+Run this checklist before finalizing any guide or pack page. Each "yes" is a
+finding to fix. Read the draft cold — the sentences you have to read twice are
+the ones that need work.
+
+## Conversation-first checks
+
+1. **Does a first actionable example appear within the first 120 words?**
+   Count from the first word of body text (after the title). If the reader
+   reaches word 120 without seeing a prompt, a command, or a concrete result,
+   the page opens too late.
+
+2. **Can the reader begin a real task without knowing any skill or pack name?**
+   Cover the title, the nav, and the first paragraph. If what the reader must
+   type to start is a skill name rather than a natural-language goal, the page
+   is skill-first, not reader-first.
+
+3. **Is read/write behavior explicit?** The reader should know, before they
+   act, whether the agent will only read data or whether it may change something.
+   If the page leaves the read/write boundary implicit, name it.
+
+4. **Does the page show at least one realistic follow-up request?** A guide
+   that ends when the first task completes leaves the reader without a next
+   step. Name the most likely follow-up — a prompt, a decision, or a link.
+
+5. **Does skill/command inventory appear after user outcomes, not before?**
+   Scan the page top to bottom. If the first substantive block is a list of
+   skills, commands, or flags rather than a goal or an example, the structure
+   is inventory-first. Move the inventory below the first task completion.
+
+6. **Does the guide show a visible start AND finish for at least one complete
+   task?** A complete task has a first request the reader can copy and a final
+   result the reader can verify. If either is missing, the task is incomplete.
+
+## Contract verification
+
+Before declaring the guide ready, confirm the conversation contract fields are
+all present and accurate:
+
+- **reader** — who is reading this right now (role + context, not "all users")
+- **job** — the specific thing they are trying to accomplish
+- **natural_start** — the exact words they would use to begin
+- **minimum_scope** — the minimum the agent needs to start (team, board, time horizon, etc.)
+- **first_result** — the concrete first thing the reader receives
+- **write_boundary** — what the agent reads vs. what it may change
+- **next_request** — the most likely follow-up after the first result lands
+
+If any field is empty or vague, the guide cannot meet the reader's real need.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -501,7 +501,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.1.7"
+      "version": "0.2.0"
     }
   ]
 }

--- a/.claude/skills/new-guide/SKILL.md
+++ b/.claude/skills/new-guide/SKILL.md
@@ -1,264 +1,207 @@
 ---
 name: new-guide
-description: Use this skill to draft a new user-facing guide under `docs/guides/<quadrant>/<slug>.md` (or `docs/guides/<pack>/<quadrant>/<slug>.md` when guides are organized by pack) following the Diátaxis framework. Triggers on "write a guide for X", "new tutorial", "new how-to", "new reference page", "new explanation". Settles the audience contract before any body is written, then scaffolds from the matching per-quadrant template. Do NOT use for feature contracts (use `new-spec`), cross-cutting proposals (use `new-rfc`), or recording decisions (use `new-adr`).
+description: "Create or substantially revise user guides, pack pages, and journey pages using Diátaxis plus conversation-first UX. Use when asked to write, simplify, restructure, audit, or modernize tutorials, how-to guides, reference pages, explanations, pack pages, or journey pages so readers can start from a natural-language goal, see what to say, understand what happens next, and reach an outcome without learning internal skill names first. Do NOT use for feature contracts (use `new-spec`), cross-cutting proposals (use `new-rfc`), recording decisions (use `new-adr`), minor single-line edits (normal PR), contributor docs, docstrings, release notes, or blog posts."
 ---
 
-# Skill: new-guide
+# Guide authoring
 
-Create a new user-facing guide under `docs/guides/<quadrant>/<slug>.md`
-— or `docs/guides/<pack>/<quadrant>/<slug>.md` in a repo that organizes
-its guides by pack — following the [Diátaxis framework](https://diataxis.fr/).
-The framework itself is documented in this repo at `docs/guides/README.md`
-and the per-quadrant README — read those for the *what*; this skill is the
-*procedure* for landing a new piece on the right side of the line.
+**Diátaxis determines where information lives. User intent determines how readers
+enter it.**
 
-The load-bearing rule is **link out, don't blend**. When mid-draft you
-find yourself wanting to add theory inside a tutorial, or steps inside an
-explanation, that's the cue to write the adjacent piece separately and
-link. Mixing quadrants is the most common reason user docs frustrate
-everyone.
+A reader who does not know any pack or skill names must still be able to begin a
+real task from the first screen.
 
-## When to invoke
+Create or substantially revise one user-facing documentation surface. Use Diátaxis
+to determine the page's job. Use conversation-first design to determine what the
+reader encounters first.
 
-Before invoking, confirm:
+## Prerequisites
 
-1. The topic is *user-facing* — the reader is someone using the product,
-   not a contributor reading the code. Contributor-facing material lives
-   in `docs/architecture/` (current state) or `docs/adr/` (decisions).
-   If it's spec-shaped, use `new-spec`.
-2. The behavior being documented *already ships* — guides are living
-   docs that must match current product behavior. If you're proposing a
-   change, you want an RFC or a spec, not a guide.
-3. You can name a real reader. "Someone might want to know X" isn't a
-   reader; "an operator whose API token expires tomorrow and needs to
-   rotate it before the next deploy" is.
-
-If any check fails, push back rather than proceeding.
+- Read the actual skills, commands, or workflows the page documents.
+- Identify one primary reader and one primary job.
+- Preserve verified commands, permissions, defaults, and side effects.
+- For generated pages, edit their source data or template — not the rendered output.
 
 ## Procedure
 
-1. **Settle the audience contract — gated checkpoint.** With nothing
-   scaffolded yet, stop and surface the contract *in chat*. This is the
-   skill's analogue to `new-spec`'s assumptions checkpoint: the body is
-   gated until the contract is signed off. A guide that doesn't name its
-   reader ends up serving none of them.
+### Step 1 — Choose mode
 
-   Emit the contract under exactly this shape:
+**Create** a new guide, or **revise** an existing one.
 
-   ```markdown
-   AUDIENCE CONTRACT:
+Revise mode applies to substantial changes: restructuring the page's flow,
+correcting the quadrant, major rewrites, adding conversation-first structure, or
+auditing for inventory-first writing.
 
-   ## Reader profile
-   - **Right now they are:** <on rails, attentive | has a specific problem | scanning for an authoritative fact | reflecting, away from active use>
-   - **They leave with:** <a confident "I did it" + working artifact | their problem solved | the precise answer | a clearer mental model of why>
+Minor edits — a typo fix, a single updated command, a broken link, a version
+number — are a **normal PR against the existing file**. Stop here and redirect to
+that path; do not proceed with this skill for minor edits.
 
-   ## Quadrant pick
-   - **Quadrant:** <tutorials | how-to | reference | explanation>
-   - **Why this one (not the adjacent quadrants):** <one sentence>
+### Step 2 — Pick the slug or confirm the file
 
-   ## Title (working)
-   - **Title:** <draft>
-   - **What the reader would have typed into search:** <phrase>
-   ```
+- **Create:** choose a kebab-case slug matching what the reader would have searched
+  for. `rotate-credential-token`, not `how-to-rotate-your-token-step-by-step`.
+  The quadrant subdir carries the "how-to" / "tutorial" framing; do not repeat it
+  in the filename.
+- **Revise:** confirm the path to the existing file before proceeding.
 
-   Diátaxis distinguishes the four pieces by reader *posture*, not by
-   reader *skill*. The same person, expert at the product, can land in
-   any of the four quadrants on different days — what places them is
-   what they're doing right now. Use the posture-to-quadrant mapping:
+### Step 3 — Write the conversation contract (gated)
 
-   | Reader's posture right now | Quadrant |
-   | --- | --- |
-   | On rails, attentive, wants a guaranteed working result | **Tutorials** |
-   | Has a named problem, wants the recipe | **How-to** |
-   | In a hurry, scanning for the authoritative answer | **Reference** |
-   | Away from the keyboard, wants to understand *why* | **Explanation** |
+Before any prose is drafted, produce the contract and wait for human confirmation.
+This is the skill's gate — the body is blocked until the contract is signed off.
 
-   Then **wait for human confirmation or revision.** Don't write into
-   the body until the contract is signed off — even if the original
-   prompt sounded definitive. Two outcomes from confirmation:
+```
+CONVERSATION CONTRACT:
 
-   - The contract is accepted → proceed to step 2.
-   - The contract splits into two readers or two postures → that's two
-     guides, not one. Surface this and ask the user to pick the
-     first; the second goes to follow-up.
+reader: <role and context — not "all users"; who is reading right now>
+job: <the specific thing they are trying to accomplish>
+natural_start: <the exact words they would use to begin>
+minimum_scope:
+  - <the minimum the agent needs to start — team, board, time horizon, etc.>
+first_result: <the concrete thing the reader gets back>
+write_boundary: <what the agent reads vs. what it may change>
+next_request: <the most likely follow-up after the first result lands>
+```
 
-2. **Pick a kebab-case slug.** Keep it short and noun-y, matching what
-   the reader would have searched for: `rotate-credentialed-skill-token`,
-   not `how-to-rotate-your-token-step-by-step`. The quadrant subdir
-   carries the "how-to" / "tutorial" framing; don't repeat it in the
-   filename.
+Wait for human confirmation or revision. Two outcomes:
 
-3. **Scaffold from the matching template.** The quadrant token maps to
-   one asset filename and one destination directory — use the mapping
-   table below verbatim, don't interpolate by hand:
+- Contract accepted → proceed to Step 4.
+- Contract splits into two readers or two jobs → two pages. Surface this and ask
+  the user to pick the first; the second goes to a follow-up.
 
-   | Quadrant | Asset to copy | Destination |
-   | --- | --- | --- |
-   | `tutorials` | `assets/tutorials.md` | `docs/guides/tutorials/<slug>.md` |
-   | `how-to` | `assets/how-to.md` | `docs/guides/how-to/<slug>.md` |
-   | `reference` | `assets/reference.md` | `docs/guides/reference/<slug>.md` |
-   | `explanation` | `assets/explanation.md` | `docs/guides/explanation/<slug>.md` |
+### Step 4 — Choose the page contract type
 
-   (Paths are skill-relative — the `assets/` folder lives next to this
-   `SKILL.md` wherever your IDE installed the skill.) The four
-   templates carry the minimal section structure for each quadrant; they
-   are starting scaffolds, not strict forms.
+Determine which of the six surface types applies. For the four Diátaxis types,
+choose by reader posture — what the reader is doing right now, not what topic
+they are reading about.
 
-   **If the repo organizes guides by pack** — a `docs/guides/<pack>/<quadrant>/`
-   layout — prefix the destination with the owning pack, or `_shared/` for a
-   cross-cutting guide that isn't specific to one pack: e.g.
-   `docs/guides/core/how-to/<slug>.md`. Write where the repo's existing
-   guides already live; match the surrounding structure rather than imposing
-   one.
+| Reader's posture right now | Surface type |
+| --- | --- |
+| On rails, attentive, wants a guaranteed working result | Tutorial |
+| Has a named problem, wants the recipe | How-to |
+| In a hurry, scanning for the authoritative answer | Reference |
+| Away from the keyboard, wants to understand *why* | Explanation |
 
-4. **Draft, applying the per-quadrant rules.** The source of truth for
-   *what goes in* each quadrant is the per-quadrant README under
-   `docs/guides/<quadrant>/README.md` (or `docs/guides/_shared/<quadrant>/README.md`
-   in a per-pack repo). Read the relevant one before drafting. The condensed write-time rules, with the named anti-patterns
-   the canonical framework warns about:
+Pack pages describe what a pack does and how to start — choose by context.
+Journey pages walk a complete user flow from first request to final outcome —
+choose by context.
 
-   - **Tutorials.** Concrete, complete, one path, no digression. Each
-     step says what to do, shows what to expect, reassures the reader
-     they're on track. Refuse the [*anti-pedagogical
-     temptations*](https://diataxis.fr/tutorials/) Procida names:
-     *abstraction, generalisation*, *explanation*, *choices*,
-     *information*. Tutorials must produce the result they promise —
-     broken reliability is the worst failure. Open with the guaranteed
-     outcome ("At the end you'll have a running X"), not "you will
-     learn".
-   - **How-to.** Solves one named problem for an already-competent
-     reader. Title is the problem. Skip backstory, skip "turn on the
-     power switch"–level steps, skip reteaching basics. Cover the
-     realistic variations and the common pitfalls — that's what makes a
-     how-to worth the click over the reference page.
-   - **Reference.** Authoritative, complete, consistently structured,
-     **neutral**. Procida: ["Neutral description is the key imperative
-     of technical reference"](https://diataxis.fr/reference/) — austere,
-     factual, no editorializing, no narrative. If the section is
-     auto-generated, mark it at the top so the next person doesn't
-     hand-edit it. Reference rots when the code drifts; "code change →
-     reference update in the same PR" is the discipline.
-   - **Explanation.** Discursive, illuminating, allowed to be opinionated
-     and to wander a little. Frame the scope with an *"About <topic>"*
-     question to keep it bounded — open-ended explanations sprawl. No
-     step-by-step instructions, no parameter lists. Make connections to
-     adjacent topics. ADRs vs. architecture docs vs. explanation: ADRs
-     are *frozen decisions for the team*, architecture is *how the code
-     is organized now for contributors*, explanation is *what the
-     concept means for someone using the product*.
+### Step 5 — Load the relevant contract from `references/page-contracts.md`
 
-   On voice and tone — apply Google's developer-docs rule of thumb:
-   "Sound like a knowledgeable friend who understands what the developer
-   wants to do." Second person, active voice, present tense. Two
-   separate anti-patterns to avoid:
+Read only the section that matches the surface type chosen in Step 4. Apply its
+required content and "move lower" rules throughout drafting.
 
-   - **Don't gaslight stuck readers.** Drop *simply*, *just*, *easy*,
-     *quickly*, *obviously* — every one of those words makes a reader
-     who got stuck feel dumb.
-   - **Don't soften imperatives.** Drop *please* in instructions ("please
-     click", "please run") — it makes commands sound optional. Just
-     write the imperative.
-   - **Don't narrate the product's history.** Write as if the product
-     always worked this way — the *retcon* discipline. Drop "will be
-     added", "previously X, now Y", "deprecated in 2.0", and
-     version-stamped history from the guide body. A guide is a living doc
-     describing current behavior; the reader wants what is true now, not a
-     changelog. Evolution belongs in release notes, the changelog, or an
-     ADR — link to it instead of narrating it inline.
+### Step 6 — Scaffold (create mode, four Diátaxis types only)
 
-   Efficiency is a form of respect — the reader is in a hurry.
+For create mode and the four Diátaxis quadrants, scaffold from the matching asset
+template and write to the standard destination:
 
-   Beyond word choice, the draft should read like a person wrote it, not a
-   machine. Cut the tells that make prose feel generated: hedges ("it's
-   worth noting"), uniform sentence rhythm, em-dash overuse, throat-clearing
-   openers ("In this guide we will explore…"), inflated verbs ("leverage",
-   "utilize", "delve"), and sentences that restate the heading. Vary sentence
-   length, keep one claim per sentence, and prefer a concrete number or
-   example over an adjective. Read the full checklist in
-   [`references/clear-prose.md`](references/clear-prose.md) while you draft and
-   edit, not before.
+| Surface type | Asset to copy | Destination |
+| --- | --- | --- |
+| Tutorial | `assets/tutorials.md` | `docs/guides/tutorials/<slug>.md` |
+| How-to | `assets/how-to.md` | `docs/guides/how-to/<slug>.md` |
+| Reference | `assets/reference.md` | `docs/guides/reference/<slug>.md` |
+| Explanation | `assets/explanation.md` | `docs/guides/explanation/<slug>.md` |
 
-5. **Apply the link-out rule as you draft.** When you find yourself
-   reaching for content from the adjacent quadrant, stop and write a
-   link instead:
+(Paths are skill-relative — the `assets/` folder lives next to this `SKILL.md`.)
 
-   - Tempted to explain *why* mid-tutorial → link to (or create) an
-     explanation page.
-   - Tempted to list every option mid-how-to → link to the reference.
-   - Tempted to walk a beginner through setup mid-explanation → link to
-     the tutorial.
-   - Tempted to recommend a best practice mid-reference → link to the
-     explanation.
+For pack pages and journey pages in create mode, there is no fixed destination;
+write where the repo's existing guides already live. Match the surrounding
+structure.
 
-   The link can be a placeholder (`<!-- TODO: link to … -->`) if the
-   adjacent piece doesn't exist yet; surface those placeholders in the
-   final summary so the next guide gets written.
+If the repo organizes guides by pack — a `docs/guides/<pack>/<quadrant>/` layout
+— prefix the destination with the owning pack, or `_shared/` for a cross-cutting
+guide.
 
-6. **Self-check before announcing the draft.** Walk this list against
-   the chosen quadrant; every "yes" is a finding to fix:
+### Step 7 — Draft using conversation-first structure
 
-   - Tutorial: does any step lack a "you should see…" check? Did I
-     offer the reader a choice anywhere? Did I sneak in *why* instead of
-     linking out?
-   - How-to: does the title name the reader's problem in their words?
-     Did I reteach a basic the reader already knows? Did I cover only
-     the linear path and ignore realistic variations?
-   - Reference: did I editorialize anywhere ("this is the recommended
-     option…")? Is any entry of the same kind shaped differently from
-     its siblings? Did I skip an option?
-   - Explanation: is there a step-by-step block that belongs in a
-     how-to? Did I drift past the *"About <topic>"* scope? Did I avoid
-     opinion — explanation is *allowed* a voice?
+Put the first useful example before inventories, architecture, terminology, or
+exhaustive options. A reader who reaches word 120 without seeing a prompt,
+command, or concrete result has waited too long.
 
-   Then run a prose pass against
-   [`references/clear-prose.md`](references/clear-prose.md). When your
-   environment provides subagents, hand the draft plus that checklist to a
-   read-only subagent and ask it to flag machine-shaped prose; that keeps the
-   style read off your main context. Without subagents, read the draft cold
-   yourself against the checklist. The quadrant self-check above is the floor;
-   the prose pass is the polish.
+Structure the core task flow using:
 
-7. **Cross-link the siblings — only the ones that exist.** A new guide
-   rarely stands alone. From the new file, add a `See also` section.
-   For each candidate sibling — the tutorial that introduces the
-   concept, the how-to that uses what reference describes (and vice
-   versa), the explanation that says *why* — check whether the file
-   exists. If it does, link it. If it doesn't, surface the gap in the
-   final summary as a follow-up TODO; don't write a broken link, and
-   don't synthesize a plausible-sounding path. From each existing
-   sibling, add a reverse link to the new piece. Cross-links are a
-   maintenance pact: when one rots, the others surface the drift.
+- **Say this** — the exact words the reader uses
+- **What happens** — what the agent does in response
+- **You get** — the concrete result
+- **What to ask next** — the likely follow-up
 
-   Don't touch the per-quadrant `README.md` (`docs/guides/<quadrant>/README.md`,
-   or `docs/guides/_shared/<quadrant>/README.md` in a per-pack repo) — those
-   READMEs are the framework's per-quadrant explainer, not a piece index.
-   Adopters who want an index of pieces add one separately; the skill
-   doesn't invent one.
+### Step 8 — Apply conversation-first rules
+
+Load [`references/conversation-first.md`](references/conversation-first.md) and
+apply its eight sequencing rules. Key checks:
+
+- Realistic user request within the first 120 words
+- No more than two product-specific terms before that request
+- User language before implementation names
+- Read/write boundary explicit
+- Next request shown
+
+### Step 9 — Edit for density
+
+Load [`references/clear-prose.md`](references/clear-prose.md) and edit. Pay
+particular attention to the `## Conversation-first structure` section at the end
+— it covers page-level structural tells that a word-level pass will miss.
+
+When your environment provides subagents, hand the draft and the checklist to a
+read-only subagent; that keeps the style read off your main context. The cold
+self-read is the floor without subagents.
+
+### Step 10 — Run the usability review
+
+Load [`references/usability-review.md`](references/usability-review.md) and run
+the six-item checklist. Each "yes" is a finding to fix before declaring the draft
+ready. Also verify the conversation contract is reflected in the draft.
+
+### Step 11 — Check links and cross-link siblings
+
+Apply the link-out rule as you finalize:
+
+- Tempted to explain *why* mid-tutorial → link to an explanation page
+- Tempted to list every option mid-how-to → link to the reference
+- Tempted to walk a beginner through setup mid-explanation → link to the tutorial
+- Tempted to recommend a best practice mid-reference → link to the explanation
+
+The link can be a placeholder (`<!-- TODO: link to … -->`) if the adjacent piece
+does not exist yet; surface those placeholders in the final summary.
+
+From the new or revised file, add a `See also` section linking existing siblings
+only. From each existing sibling, add a reverse link. Check whether each file
+exists before linking — do not write broken links and do not synthesize
+plausible-sounding paths.
+
+Do not touch the per-quadrant `README.md` files — those are the framework's
+per-quadrant explainer, not a piece index.
+
+## Verification
+
+Before announcing the draft, confirm:
+
+- [ ] The first actionable example appears within the first 120 words.
+- [ ] The reader does not need to know a skill name to begin.
+- [ ] Read and write behavior is explicit.
+- [ ] The page shows at least one realistic follow-up.
+- [ ] Skill inventory appears after user outcomes.
+- [ ] A complete task has a visible start and finish.
 
 ## Anti-patterns to refuse
 
-- **Writing the body before the audience contract is confirmed.** The
-  body is gated. The contract is the cheapest place to catch a
-  mismatched quadrant; once draft prose is on the page, rework costs
-  compound.
-- **Picking the quadrant by *topic* instead of by *reader posture*.**
-  "Authentication" is a topic; *learning* authentication, *configuring*
-  it, *looking up its parameters*, and *understanding why it's
-  cookie-based* are four different pieces — possibly all four.
-- **Blending quadrants because "the reader will appreciate the
-  context".** They won't. The framework's whole thesis is that mixing
-  modes is what makes docs frustrating; the link-out rule is
-  non-negotiable.
-- **Drafting a tutorial without running the steps end-to-end.** A
-  tutorial that doesn't produce the promised result is worse than no
-  tutorial. If the steps can't be run, you're writing a how-to or an
-  explanation — re-open the audience contract.
-- **Writing reference in narrative voice.** "You'll want to set this
-  to…" is explanation leaking into reference. Reference says *what*;
-  recommendations live in explanation.
-- **Writing explanation without an *About <X>* frame.** Open-ended
-  explanation absorbs adjacent material and sprawls. Name the question
-  the page answers; if you can't, the page isn't ready.
-- **Editing an existing guide via this skill.** `new-guide` is for new
-  pieces. Edits are normal PRs against the existing file; the rules in
-  step 4 still apply, but the skill's checkpoint and scaffold don't.
+- **Drafting before the conversation contract is confirmed.** The body is gated.
+  The contract is the cheapest place to catch a mismatched scope; once draft
+  prose is on the page, rework compounds.
+- **Using this skill for minor edits.** A typo fix, a single updated command, a
+  broken link — these are normal PRs. This skill's procedure adds ceremony that
+  minor edits do not warrant.
+- **Picking the surface type by topic instead of by reader posture.** "Authentication"
+  is a topic; *learning* it, *configuring* it, *looking up its parameters*, and
+  *understanding why it is cookie-based* are four different pieces.
+- **Blending surface types because "the reader will appreciate the context."** They
+  will not. The link-out rule is non-negotiable.
+- **Drafting a tutorial without running the steps end-to-end.** A tutorial that
+  does not produce the promised result is worse than no tutorial. If the steps
+  cannot be run, you are writing a how-to or an explanation — re-open the contract.
+- **Writing reference in narrative voice.** Reference says *what*; recommendations
+  live in explanation.
+- **Writing explanation without an *About <X>* frame.** Open-ended explanation
+  absorbs adjacent material and sprawls. Name the question the page answers.
+- **Leading with a skill or pack inventory.** The reader came with a goal. The
+  inventory belongs after the first task completes.

--- a/.claude/skills/new-guide/evals/eval_queries.json
+++ b/.claude/skills/new-guide/evals/eval_queries.json
@@ -19,5 +19,17 @@
   {"query": "Write the release notes for the 2.0 release", "should_trigger": false},
   {"query": "Fix the broken link in the installation guide", "should_trigger": false},
   {"query": "Write the empty-state and error microcopy for the upload screen", "should_trigger": false},
-  {"query": "Write a blog post announcing our new export feature", "should_trigger": false}
+  {"query": "Write a blog post announcing our new export feature", "should_trigger": false},
+
+  {"query": "Rewrite this Jira guide so the reader sees what to ask first", "should_trigger": true},
+  {"query": "Turn this skill-list page into a task-led pack page", "should_trigger": true},
+  {"query": "Make this Diátaxis how-to less dense", "should_trigger": true},
+  {"query": "Add a realistic multi-turn conversation to this guide", "should_trigger": true},
+  {"query": "Audit these docs for inventory-first writing", "should_trigger": true},
+  {"query": "Revise this journey page to show a complete user flow", "should_trigger": true},
+
+  {"query": "Create a Jira story for password reset", "should_trigger": false},
+  {"query": "Show me the Atlas team's blockers", "should_trigger": false},
+  {"query": "Fix spelling in this README", "should_trigger": false},
+  {"query": "What is Diátaxis and how does it work", "should_trigger": false}
 ]

--- a/.claude/skills/new-guide/evals/evals.json
+++ b/.claude/skills/new-guide/evals/evals.json
@@ -13,6 +13,25 @@
         "Prose reads human and task-respecting: second person, active voice, present tense; no reader-blaming fillers (simply/just/easy/obviously), no softened imperatives (please), no inline version-history narration",
         "Cross-links (\"See also\") point only to sibling pages that exist — no fabricated or broken links"
       ]
+    },
+    {
+      "id": 2,
+      "prompt": "Create or revise a user-facing guide following the conversation-first doctrine.",
+      "expected_output": "A guide that states the reader and their job early, shows a natural-language request near the top (within the first 120 words), explains the first result the reader gets, shows at least one realistic follow-up request, makes read/write boundaries explicit, puts skill/command inventory after user outcomes rather than before, and keeps reference material out of the primary flow. It does not open with product architecture or a skill list. The reader can begin a task without knowing any skill or pack name. The page shows a visible start and finish for at least one complete task.",
+      "assertions": [
+        "States the reader and their job — the page has an implied or explicit audience",
+        "Shows a natural-language request near the top, within the first 120 words",
+        "Explains the first result — the reader knows what they will get before the detail starts",
+        "Shows at least one realistic follow-up request, not only the entry request",
+        "Makes read/write boundaries explicit — separates what the agent reads from what it may change",
+        "Puts skill/command inventory after user outcomes, not before",
+        "Keeps reference material (exhaustive options, parameter tables) out of the primary flow",
+        "Does not open with product architecture or an internal component diagram",
+        "Does not begin by presenting a list of available skills, packs, or commands before the reader's first task",
+        "Does not require the reader to know any skill or pack name to begin",
+        "Is not a collection of isolated prompt snippets — shows what the agent returns and not just what the user says",
+        "Does not indiscriminately mix Diátaxis quadrants — tutorial material is not blended with reference"
+      ]
     }
   ]
 }

--- a/.claude/skills/new-guide/references/clear-prose.md
+++ b/.claude/skills/new-guide/references/clear-prose.md
@@ -105,3 +105,35 @@ will miss:
 When your environment has subagents, the skill's optional copyedit pass hands
 the draft and this checklist to a fresh reader so the style read stays off your
 main context. The cold self-read is the floor either way.
+
+## Conversation-first structure
+
+These are page-level structural rules. They complement the word-level checklist
+above — a draft can pass every vocabulary check and still fail these. Run them
+after the prose pass, not instead of it. For the full framing and sequencing
+rationale, see [`references/conversation-first.md`](conversation-first.md).
+
+- **Put one observable outcome before the first conceptual explanation.** The
+  reader needs to see what they will get before they are asked to understand
+  why. An outcome is a command, a result, or a concrete next step — not a
+  category name.
+- **Put a realistic user request within the first 120 words.** The reader
+  scanning for "how do I begin?" should find it without scrolling.
+- **Introduce no more than two product-specific terms before that request.**
+  Every term introduced before the first example is a term the reader must
+  carry before they can act.
+- **Do not lead with a component, skill, command, or pack inventory.** Leading
+  with what the product contains is inventory-first. The reader came with a
+  goal, not a browse session. The inventory belongs after the first task
+  completes.
+- **Use user language first and implementation names second.** "Show me the
+  team's open work" before `jira-team-status`. The page can use both; the
+  user term opens the sentence.
+- **Show the next likely request, not only the initial request.** A guide
+  that ends with the first task done leaves the reader stranded. Name where
+  they go next.
+- **Separate read-only exploration from remote writes.** State clearly when an
+  action reads data vs. when it changes something. Never leave the read/write
+  boundary implicit.
+- **Put exhaustive options in reference, not in the main procedure.** Embed a
+  link; do not embed the reference page.

--- a/.claude/skills/new-guide/references/conversation-first.md
+++ b/.claude/skills/new-guide/references/conversation-first.md
@@ -1,0 +1,48 @@
+# Conversation-first structure
+
+Diátaxis determines where information lives. User intent determines how readers
+enter it. These are page-level sequencing rules — they sit above the word-level
+checklist in `clear-prose.md` and govern the order of what the reader encounters
+before the detail starts.
+
+A reader who does not know any pack or skill names must still be able to begin a
+real task from the first screen.
+
+## Rules
+
+1. **Put one observable outcome before the first conceptual explanation.** The
+   reader needs to see what they will get before they are asked to understand why
+   it works. An observable outcome is a command, a result, a screenshot, or a
+   concrete next step — not a category name or a feature list.
+
+2. **Put a realistic user request within the first 120 words.** The request shows
+   the reader how to start. It does not have to be the opener; it has to be early
+   enough that a reader scanning for "how do I begin?" finds it without scrolling.
+
+3. **Introduce no more than two product-specific terms before that request.** Terms
+   introduced before the first example are terms the reader must carry before they
+   can act. Two is the ceiling; one is better; zero is possible and often right.
+
+4. **Do not lead with a component, skill, command, or pack inventory.** Leading with
+   a list of what the product contains is inventory-first writing. The reader came
+   with a goal, not a browse session. The inventory belongs after the first task
+   completes.
+
+5. **Use user language first and implementation names second.** "Show me the team's
+   open work" before `jira-team-status`. "Create a decision record" before `new-adr`.
+   The page can use both; the user term opens the sentence.
+
+6. **Show the next likely request, not only the initial request.** A guide that ends
+   with the first task done leaves the reader stranded. Name where they go next —
+   a follow-up prompt, a related page, or the decision they face after the first
+   result lands.
+
+7. **Separate read-only exploration from remote writes.** State clearly when an
+   action reads data vs. when it changes something. A reader deciding whether to
+   run a command needs to know which side of that line it falls on. Do not leave
+   the read/write boundary implicit.
+
+8. **Put exhaustive options in reference, not in the main procedure.** A how-to
+   that enumerates every flag, a tutorial that lists every configuration key — both
+   interrupt the reader's task with detail they did not ask for. Link to the
+   reference; do not embed it.

--- a/.claude/skills/new-guide/references/page-contracts.md
+++ b/.claude/skills/new-guide/references/page-contracts.md
@@ -1,0 +1,164 @@
+# Page contracts
+
+Each section below is the contract for one surface type. Load only the section
+that matches the page you are writing or revising. The contract answers three
+questions for each type: what the first screen must make obvious, what content
+is required, and what to move lower or link out.
+
+## Choosing the right surface type
+
+For the four Diátaxis types, choose by reader posture — what the reader is doing
+right now, not what topic they are reading about. The same person, on different
+days, will land in different quadrants.
+
+| Reader's posture right now | Surface |
+| --- | --- |
+| On rails, attentive, wants a guaranteed working result | **Tutorial** |
+| Has a named problem, wants the recipe | **How-to** |
+| In a hurry, scanning for the authoritative answer | **Reference** |
+| Away from the keyboard, wants to understand *why* | **Explanation** |
+
+Pack pages and journey pages are chosen by context: if the page describes what a
+pack does and how to start, it is a Pack page. If the page walks through a
+complete user flow from first request to final outcome, it is a Journey page.
+
+---
+
+## Tutorial
+
+**First screen must answer:** "How do I complete my first real journey?"
+
+**Required content:**
+- The exact first request to send — copyable, not paraphrased
+- The expected result after that first request
+- Checkpoints along the way ("you should see…")
+- A complete outcome at the end — the reader finishes with something real
+- Each step says what to do and what the reader should observe
+
+**Move lower or link out:**
+- Alternatives and variations (→ How-to)
+- Architecture and design decisions (→ Explanation)
+- Exhaustive option lists (→ Reference)
+- Prerequisites beyond the minimum needed to start
+
+**Anti-patterns to refuse:**
+- Offering the reader a choice mid-tutorial
+- Inserting explanation of *why* without linking out
+- Steps that produce no observable result
+- A result the reader cannot verify
+
+---
+
+## How-to
+
+**First screen must answer:** "How do I accomplish this one goal?"
+
+**Required content:**
+- A copyable request or command that starts the task
+- The scope of what the skill reads and what it may change
+- A minimal procedure covering the common path
+- Common variations the reader is likely to hit
+- The most likely follow-up request after the task completes
+
+**Move lower or link out:**
+- Theory and background (→ Explanation)
+- Exhaustive field-by-field reference (→ Reference)
+- Step-by-step setup a beginner needs (→ Tutorial)
+- Options the reader will never vary
+
+**Anti-patterns to refuse:**
+- A title that names a topic rather than the reader's problem
+- Reteaching basics the competent reader already knows
+- Covering only the linear happy path with no realistic variations
+
+---
+
+## Reference
+
+**First screen must answer:** "What exactly does this skill accept and do?"
+
+**Required content:**
+- An intent index — what the reader can accomplish with this skill
+- Inputs: what the reader provides
+- Outputs: what the skill returns
+- Reads: what the skill reads without asking
+- Writes: what the skill may change
+- Limits: caps, timeouts, pagination, rate limits
+
+**Move lower or link out:**
+- Narrative walkthroughs (→ How-to or Tutorial)
+- Explanation of why the design works this way (→ Explanation)
+- Getting-started instructions (→ Tutorial)
+
+**Anti-patterns to refuse:**
+- Editorializing ("this is the recommended option…")
+- Entries of the same kind shaped differently from their siblings
+- Skipping an option because it is "rarely used"
+
+**Sync discipline:** Reference rots when the code drifts. A code change → reference update in the same PR is the rule, not a nice-to-have. For auto-generated sections, mark them with a comment pointing to the source data so readers know not to hand-edit the copy.
+
+---
+
+## Explanation
+
+**First screen must answer:** "How do these pieces fit together and why?"
+
+**Required content:**
+- A mental model the reader can hold in their head
+- How the components compose — what connects to what
+- Trade-offs and the reasoning behind key design choices
+- Boundaries — what this concept is and is not
+
+**Move lower or link out:**
+- Step-by-step procedures (→ How-to)
+- Exhaustive parameter lists (→ Reference)
+- Guaranteed-outcome walkthroughs (→ Tutorial)
+
+**Anti-patterns to refuse:**
+- Step-by-step instructions embedded in the explanation
+- Open-ended scope with no "About <topic>" frame
+- Refusing to take a position where the design is opinionated
+
+---
+
+## Pack page
+
+**First screen must answer:** "What can this help me do?"
+
+**Required content:**
+- Job cards — what a reader with a concrete goal can accomplish
+- Natural-language prompts — the exact words to use, not skill names
+- Result previews — what the agent returns for each task
+- The common journey — a start-to-finish sequence for the primary use case
+
+**Move lower or link out:**
+- The full skill inventory (names, flags, schema)
+- Installation and setup details
+- Architecture of how the pack is composed
+
+**Anti-patterns to refuse:**
+- Opening with a skill or command list
+- Requiring the reader to know a skill name to begin the first task
+- Describing capabilities in abstract terms without a concrete prompt
+
+---
+
+## Journey page
+
+**First screen must answer:** "What happens from start to finish?"
+
+**Required content (one block per stage):**
+- **You say** — the natural-language request the reader sends
+- **Agent does** — what the agent reads, fetches, or computes
+- **You get** — the concrete result
+- **Decision** — what the reader decides or confirms before the next stage
+
+**Move lower or link out:**
+- Skill cards and implementation vocabulary
+- Configuration and permission details
+- Error-handling reference
+
+**Anti-patterns to refuse:**
+- Describing what the skill does without showing what the reader says and gets
+- Stages without a visible decision or outcome
+- Mixing implementation vocabulary into the user-facing flow

--- a/.claude/skills/new-guide/references/usability-review.md
+++ b/.claude/skills/new-guide/references/usability-review.md
@@ -1,0 +1,49 @@
+# Usability review
+
+Run this checklist before finalizing any guide or pack page. Each "yes" is a
+finding to fix. Read the draft cold — the sentences you have to read twice are
+the ones that need work.
+
+## Conversation-first checks
+
+1. **Does a first actionable example appear within the first 120 words?**
+   Count from the first word of body text (after the title). If the reader
+   reaches word 120 without seeing a prompt, a command, or a concrete result,
+   the page opens too late.
+
+2. **Can the reader begin a real task without knowing any skill or pack name?**
+   Cover the title, the nav, and the first paragraph. If what the reader must
+   type to start is a skill name rather than a natural-language goal, the page
+   is skill-first, not reader-first.
+
+3. **Is read/write behavior explicit?** The reader should know, before they
+   act, whether the agent will only read data or whether it may change something.
+   If the page leaves the read/write boundary implicit, name it.
+
+4. **Does the page show at least one realistic follow-up request?** A guide
+   that ends when the first task completes leaves the reader without a next
+   step. Name the most likely follow-up — a prompt, a decision, or a link.
+
+5. **Does skill/command inventory appear after user outcomes, not before?**
+   Scan the page top to bottom. If the first substantive block is a list of
+   skills, commands, or flags rather than a goal or an example, the structure
+   is inventory-first. Move the inventory below the first task completion.
+
+6. **Does the guide show a visible start AND finish for at least one complete
+   task?** A complete task has a first request the reader can copy and a final
+   result the reader can verify. If either is missing, the task is incomplete.
+
+## Contract verification
+
+Before declaring the guide ready, confirm the conversation contract fields are
+all present and accurate:
+
+- **reader** — who is reading this right now (role + context, not "all users")
+- **job** — the specific thing they are trying to accomplish
+- **natural_start** — the exact words they would use to begin
+- **minimum_scope** — the minimum the agent needs to start (team, board, time horizon, etc.)
+- **first_result** — the concrete first thing the reader receives
+- **write_boundary** — what the agent reads vs. what it may change
+- **next_request** — the most likely follow-up after the first result lands
+
+If any field is empty or vague, the guide cannot meet the reader's real need.

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`new-guide` skill broadened to create or substantially revise guides (user-guide-diataxis 0.2.0).** The skill now triggers on rewrite, audit, simplify, and modernize requests in addition to new-guide creation — covering pack pages and journey pages alongside the four Diátaxis quadrants. The audience contract is replaced by a seven-field conversation contract (reader, job, natural_start, minimum_scope, first_result, write_boundary, next_request) as the gated checkpoint before any prose is drafted. Per-page-type contracts for all six surface types now live in a dedicated `references/page-contracts.md`. Three new reference files ship with the skill: `conversation-first.md` (sequencing rules), `page-contracts.md` (six surface contracts), and `usability-review.md` (pre-publish checklist). `clear-prose.md` gains a `## Conversation-first structure` section with eight page-level structural rules. Evals updated with revise/audit trigger cases and a conversation-first output-quality rubric. Key doctrine: *Diátaxis determines where information lives. User intent determines how readers enter it.* ([spec](../specs/new-guide-conversation-first/spec.md))
+
 ### Added
 
 - **Story quality gate on `jira: create-issue` (atlassian pack 0.5.0).** The `jira` skill now runs a pre-create quality gate before every `create-issue` call: it detects the invocation repo via `git remote -v` ("Invocation repo" label), then checks the candidate story against the five-question actionability bar (self-contained change, reachable repo scope, binary ACs, no mid-flight decision, right-sized for one PR — Q5 added because Jira stories are a legacy capacity-allocation mechanism and oversized stories cannot be handed to a single agent or engineer). Six concrete checks with story-points as the primary Q5 signal. Gate fires on `create-issue` only; `update-issue` is unaffected. ([spec](../specs/jira-story-actionability/spec.md))

--- a/docs/specs/new-guide-conversation-first/plan.md
+++ b/docs/specs/new-guide-conversation-first/plan.md
@@ -1,0 +1,349 @@
+# Plan: new-guide conversation-first
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Done
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn. When it changes substantially
+> (a different approach, not just a re-ordering), note why in the changelog
+> at the bottom.
+
+## Approach
+
+All changes are in `packs/user-guide-diataxis/.apm/skills/new-guide/` (the source copy). Tasks T1–T7 produce the source files; T8 bumps the version; T9 runs `build-self` to sync all three install copies. T1–T7 have no dependencies between them and can run in parallel; T8 gates on all of them; T9 gates on T8.
+
+The riskiest part is SKILL.md (T1): it must preserve three existing behaviors (gated checkpoint, posture→quadrant table, slug + template scaffolding) while restructuring the procedure around the conversation contract. The reference files (T2–T5) reduce SKILL.md's body size by receiving the per-page-type rules that currently live inline. The evals (T6–T7) are additive.
+
+Verification: manual QA by invoking the revised skill on one create and one revise request in Claude Code, observing the conversation contract gate, the page-type contract load, and the 120-word first-example criterion.
+
+## Constraints
+
+- Skill authoring rules: `.claude/skills/README.md` — skill-relative paths in SKILL.md bodies; no install-path prefixes.
+- Three-copy sync: always via `build-self`, never manual copy (byte-identical requirement).
+- Eval format: `evals.json` `{skill_name, evals: [{id, prompt, expected_output, assertions}]}`; `eval_queries.json` `[{query, should_trigger}]`.
+- `clear-prose.md` extension: product-behavioral rules excluded; prose/structural rules only.
+
+## Construction tests
+
+**Integration tests:** none beyond per-task goal-based checks.
+
+**Manual verification:**
+1. Invoke revised `new-guide` with "Rewrite this Jira guide so the reader sees what to ask first." Observe: conversation contract emitted and skill waits before drafting; contract contains all seven fields; appropriate page-type contract loaded.
+2. Invoke revised `new-guide` with "Write a new how-to guide for rotating an API token." Observe: conversation contract emitted; How-to page contract loaded; first useful example within 120 words of output.
+3. Check that "Fix the broken link in the installation guide" does NOT auto-trigger the skill (routes to normal PR guidance) — covers AC1.
+4. Explicitly invoke `new-guide` on "Fix the broken link in the installation guide" and observe that step 1 detects the minor scope and redirects to normal-PR guidance before emitting the conversation contract — covers AC5's explicit-invocation path.
+
+## Design (LLD)
+
+### Design decisions
+
+- **Conversation contract replaces audience contract** — the new contract has seven fields vs. the old three-field contract, and adds first_result, write_boundary, and next_request. The gated "wait for human confirmation" behavior is preserved. Traces to: AC4.
+- **Per-page-type rules move to `page-contracts.md`** — the long inline step 4 rules in current SKILL.md (per-quadrant write rules, anti-patterns) move to the reference file. SKILL.md procedure steps shrink to control flow only. Traces to: AC6.
+- **Pack page and journey page get no asset templates** — these surfaces don't have fixed quadrant-directory destinations, so `page-contracts.md` is sufficient. Asset templates remain only for the four Diátaxis quadrants. Traces to: AC6, spec Boundaries § Ask first.
+- **Two density rules excluded from `clear-prose.md`** — "state result-set coverage" and "summarize large result sets" are Atlassian skill behavioral rules. The remaining eight are page-level structural rules that complement the existing word/sentence-level rules. Traces to: AC9, spec Boundaries § Never do.
+- **Minor bump (0.2.0)** — new surface types + major procedure change, backward-compatible (existing usage still activates; no removal of prior capability). Traces to: AC12.
+
+## Tasks
+
+### T1: Rewrite SKILL.md source copy
+
+**Depends on:** none
+
+**Tests:**
+- Frontmatter description contains trigger phrases for revise/audit/modernize (AC1)
+- Doctrine sentence present near top of body (AC2)
+- Intent-first test sentence present in body (AC3)
+- Procedure step for conversation contract emits all seven fields (AC4)
+- Procedure step for revise mode names the "substantial" threshold and redirects minor edits (AC5)
+- Procedure references `references/page-contracts.md`, `references/conversation-first.md`, `references/clear-prose.md`, `references/usability-review.md` by skill-relative path (AC6–AC9)
+- Posture→quadrant table present (AC6)
+- Slug-pick and asset-template-scaffold steps present for 4 Diátaxis quadrants in create mode (spec Boundaries § Always do)
+- "Editing an existing guide" anti-pattern amended to distinguish minor edits (normal PR) from substantial revisions (in scope) (AC14)
+- All paths use skill-relative form (`references/X.md`, not `.claude/skills/new-guide/references/X.md`)
+
+**Approach:**
+- Open `packs/user-guide-diataxis/.apm/skills/new-guide/SKILL.md`
+- Replace frontmatter `description` with the expanded version that triggers on create AND revise/audit/modernize
+- Add doctrine sentence + intent-first test sentence at top of body (before `## Prerequisites` or as its own short paragraph)
+- Rewrite procedure steps:
+  - Step 1: Choose create or revise mode (define substantial-revision threshold inline)
+  - Step 2: Pick slug (create) or confirm target file (revise)
+  - Step 3: Write the conversation contract [all seven fields; gated — wait for human confirmation]
+  - Step 4: Choose the page contract type [include posture→quadrant table for four Diátaxis types; pack/journey pages by context]
+  - Step 5: Load the relevant contract from `references/page-contracts.md`
+  - Step 6: (Create + four Diátaxis types) Scaffold from the matching asset template
+  - Step 7: Draft using conversation-first structure (first useful example within 120 words; Say this / What happens / What you get / What to ask next)
+  - Step 8: Load `references/conversation-first.md` and apply
+  - Step 9: Load `references/clear-prose.md` and edit for density
+  - Step 10: Run `references/usability-review.md`
+  - Step 11: Check links and remove cross-quadrant material; cross-link existing siblings
+- Amend anti-patterns section: replace "Editing an existing guide via this skill" with a nuanced rule distinguishing minor edits from substantial revisions
+- Verification: `scripts/lint-skill-spec.py` passes (skill-relative paths, no install-path prefixes)
+
+**Done when:** `packs/user-guide-diataxis/.apm/skills/new-guide/SKILL.md` is saved; doctrine sentence, intent-first test, conversation contract, and revised anti-pattern are present; `python tools/lint-skill-spec.py` exits 0 for this skill.
+
+---
+
+### T2: Author `references/conversation-first.md`
+
+**Depends on:** none
+
+**Tests:**
+- File exists at `packs/user-guide-diataxis/.apm/skills/new-guide/references/conversation-first.md`
+- Contains the eight page-level conversation-first structure rules (AC7)
+- Does NOT contain the two product-behavioral rules (result-set coverage, truncation state) (spec Boundaries § Never do)
+
+**Approach:**
+- Create `packs/user-guide-diataxis/.apm/skills/new-guide/references/conversation-first.md`
+- Section heading: `# Conversation-first structure`
+- List the eight rules:
+  1. Put one observable outcome before the first conceptual explanation.
+  2. Put a realistic user request within the first 120 words.
+  3. Introduce no more than two product-specific terms before that request.
+  4. Do not lead with a component, skill, command, or pack inventory.
+  5. Use user language first and implementation names second.
+  6. Show the next likely request, not only the initial request.
+  7. Separate read-only exploration from remote writes.
+  8. Put exhaustive options in reference, not in the main procedure.
+- Add a brief framing paragraph explaining the purpose (not a prose style checklist — this is structural/sequencing discipline)
+
+**Done when:** file exists with all eight rules, no product-behavioral rules, prose is in clear-prose style.
+
+---
+
+### T3: Author `references/page-contracts.md`
+
+**Depends on:** none
+
+**Tests:**
+- File exists at `packs/user-guide-diataxis/.apm/skills/new-guide/references/page-contracts.md`
+- All six surface types are defined: Tutorial, How-to, Reference, Explanation, Pack page, Journey page (AC6)
+- Each contract covers: what the first screen must answer, required content, what to move lower
+- Per-quadrant write rules from current SKILL.md step 4 are incorporated for the four Diátaxis types
+- Pack page and journey page contracts capture the contract matrix from the proposal
+- Posture→quadrant table is present (may be duplicated from SKILL.md or cross-referenced)
+
+**Approach:**
+- Create `packs/user-guide-diataxis/.apm/skills/new-guide/references/page-contracts.md`
+- Section per surface type, each with three subsections: `### First screen`, `### Required content`, `### Move lower`
+- For the four Diátaxis types: incorporate the per-quadrant rules currently in SKILL.md step 4 (tutorials anti-pedagogical temptations; how-to problem-named title; reference neutral+complete; explanation About-frame)
+- For Pack page: "What can this help me do?" / job cards + natural prompts + result previews + common journey / full skill inventory
+- For Journey page: "What happens from start to finish?" / You say + Agent does + You get + Decision / skill cards + implementation vocabulary
+- Open with a brief intro explaining when to load only the relevant section
+- Include posture→quadrant table (copied from current SKILL.md) so it survives the SKILL.md restructure
+
+**Done when:** file exists with all six surface types, posture table present, per-quadrant rules transferred from current SKILL.md step 4.
+
+---
+
+### T4: Author `references/usability-review.md`
+
+**Depends on:** none
+
+**Tests:**
+- File exists at `packs/user-guide-diataxis/.apm/skills/new-guide/references/usability-review.md` (AC8)
+- All six checklist items from AC8 are present
+- Note: intent-first test sentence ("A reader who does not know any skill or pack name…") lives in SKILL.md, not in this file — do not add it here (AC3 not AC8)
+
+**Approach:**
+- Create `packs/user-guide-diataxis/.apm/skills/new-guide/references/usability-review.md`
+- Opening: "Run this checklist before finalizing any guide. Each 'yes' is a finding to fix."
+- Six items (each phrased as a yes/no question):
+  1. Does a first actionable example appear within the first 120 words?
+  2. Can the reader begin a real task without knowing any skill or pack name?
+  3. Is read/write behavior explicit (what the agent reads vs. what it may change)?
+  4. Does the page show at least one realistic follow-up request?
+  5. Does skill/command inventory appear after user outcomes, not before?
+  6. Does the guide show a visible start AND finish for at least one complete task?
+- Verification: verify section — a check on the seven-field conversation contract (reader, job, natural_start, minimum_scope, first_result, write_boundary, next_request all present)
+
+**Done when:** file exists with all six checklist items and the contract-verification section.
+
+---
+
+### T5: Extend `references/clear-prose.md`
+
+**Depends on:** none
+
+**Tests:**
+- File at `packs/user-guide-diataxis/.apm/skills/new-guide/references/clear-prose.md` has a new `## Conversation-first structure` section (AC9)
+- Eight rules present in the section
+- Two product-behavioral rules absent (AC9, spec Boundaries § Never do)
+- Existing content unchanged (additive only)
+
+**Approach:**
+- Append a new section `## Conversation-first structure` to the end of `packs/user-guide-diataxis/.apm/skills/new-guide/references/clear-prose.md`
+- Brief intro: "These are page-level structural rules that complement the word-level checklist above."
+- List the eight rules (same content as `conversation-first.md` but in checklist form, e.g., "Put one observable outcome before the first conceptual explanation.")
+- Note at the bottom: "For the full framing, see `references/conversation-first.md`."
+
+**Done when:** `clear-prose.md` has the new section appended; existing content byte-identical to before the change; `references/conversation-first.md` is the canonical version, `clear-prose.md` section is the in-checklist form.
+
+---
+
+### T6: Update `evals/eval_queries.json`
+
+**Depends on:** none
+
+**Tests:**
+- JSON syntax valid
+- 6 new `should_trigger: true` entries (revise/simplify/audit/restructure requests) (AC10)
+- 4 new `should_trigger: false` entries (Jira story, Atlas team blockers, README spelling, Diátaxis explanation) (AC10)
+- All existing entries unchanged
+
+**Approach:**
+- Open `packs/user-guide-diataxis/.apm/skills/new-guide/evals/eval_queries.json`
+- Append to the existing array (additive):
+
+  New `true` entries:
+  ```json
+  {"query": "Rewrite this Jira guide so the reader sees what to ask first", "should_trigger": true},
+  {"query": "Turn this skill-list page into a task-led pack page", "should_trigger": true},
+  {"query": "Make this Diátaxis how-to less dense", "should_trigger": true},
+  {"query": "Add a realistic multi-turn conversation to this guide", "should_trigger": true},
+  {"query": "Audit these docs for inventory-first writing", "should_trigger": true},
+  {"query": "Revise this journey page to show a complete user flow", "should_trigger": true}
+  ```
+
+  New `false` entries:
+  ```json
+  {"query": "Create a Jira story for password reset", "should_trigger": false},
+  {"query": "Show me the Atlas team's blockers", "should_trigger": false},
+  {"query": "Fix spelling in this README", "should_trigger": false},
+  {"query": "What is Diátaxis and how does it work", "should_trigger": false}
+  ```
+
+- Validate JSON syntax with `python -c "import json, sys; json.load(open(sys.argv[1]))" <path>`
+
+**Done when:** the 10 new query strings are present in the file and JSON is valid (assert on content, not a brittle total count).
+
+---
+
+### T7: Update `evals/evals.json` with output rubric
+
+**Depends on:** none
+
+**Tests:**
+- JSON syntax valid
+- Second eval (id: 2) present in the `evals` array (AC11)
+- Good-artifact assertions present: reader+job stated, natural-language request near top, first result explained, at least one follow-up, read/write boundaries explicit, inventory after outcomes, reference material out of primary flow
+- Exactly five discrete negative assertions present: (1) no architecture-first opener, (2) no skill-list before task, (3) reader needs no skill name to begin, (4) not isolated snippets only / shows agent response (compound), (5) no indiscriminate quadrant mixing — matches AC11's effective count of five
+- `skill_name` unchanged: `"new-guide"`
+
+**Approach:**
+- Open `packs/user-guide-diataxis/.apm/skills/new-guide/evals/evals.json`
+- Add second element to the `evals` array:
+  ```json
+  {
+    "id": 2,
+    "prompt": "Create or revise a user-facing guide following the conversation-first doctrine.",
+    "expected_output": "A guide that states the reader and their job early, shows a natural-language request near the top (within the first 120 words), explains the first result the reader gets, shows at least one realistic follow-up request, makes read/write boundaries explicit, puts skill/command inventory after user outcomes rather than before, and keeps reference material out of the primary flow. It does not open with product architecture or a skill list. The reader can begin a task without knowing any skill or pack name. The page shows a visible start and finish for at least one complete task.",
+    "assertions": [
+      "States the reader and their job — the page has an implied or explicit audience",
+      "Shows a natural-language request near the top, within the first 120 words",
+      "Explains the first result — the reader knows what they will get before the detail starts",
+      "Shows at least one realistic follow-up request, not only the entry request",
+      "Makes read/write boundaries explicit — separates what the agent reads from what it may change",
+      "Puts skill/command inventory after user outcomes, not before",
+      "Keeps reference material (exhaustive options, parameter tables) out of the primary flow",
+      "Does not open with product architecture, an internal component diagram, or a skill/pack list",
+      "Does not require the reader to know any skill or pack name to begin",
+      "Is not a collection of isolated prompt snippets — shows what the agent returns",
+      "Does not indiscriminately mix Diátaxis quadrants — tutorial material is not blended with reference"
+    ]
+  }
+  ```
+- Validate JSON syntax
+
+**Done when:** `evals.json` has 2 evals; JSON is valid; assertions cover all AC11 criteria.
+
+---
+
+### T8: Bump version in `pack.toml` and `plugin.json`
+
+**Depends on:** T1, T2, T3, T4, T5, T6, T7, T10, T11
+
+**Tests:**
+- `pack.toml` version field is `"0.2.0"` (AC12)
+- `.claude-plugin/plugin.json` version field is `"0.2.0"` (AC12)
+
+**Approach:**
+- Edit `packs/user-guide-diataxis/pack.toml`: change `version = "0.1.7"` → `version = "0.2.0"`
+- Edit `packs/user-guide-diataxis/.claude-plugin/plugin.json`: update version field to `"0.2.0"`
+- Verify with `grep '"0.2.0"' packs/user-guide-diataxis/pack.toml` and `grep '"0.2.0"' packs/user-guide-diataxis/.claude-plugin/plugin.json`
+
+**Done when:** both files show `0.2.0`; no other fields changed.
+
+---
+
+### T9: Run `build-self` and verify three-copy parity
+
+**Depends on:** T8
+
+**Tests:**
+- All three copies of SKILL.md byte-identical (AC13)
+- All three copies of each reference file byte-identical (AC13)
+- All three copies of each eval file byte-identical (AC13)
+
+**Approach:**
+- Run the project's `build-self` command (or `make build-self` — check `Makefile` for the correct target)
+- Verify parity with `diff packs/user-guide-diataxis/.apm/skills/new-guide/SKILL.md .claude/skills/new-guide/SKILL.md` and equivalent for `.agents/skills/new-guide/SKILL.md`
+- Verify reference files: `diff` for `clear-prose.md`, `conversation-first.md`, `page-contracts.md`, `usability-review.md` across the three install paths
+- Verify eval files: `diff` for `eval_queries.json`, `evals.json`
+- If any diff is non-empty, investigate the build-self output rather than hand-copying
+
+**Done when:** all `diff` calls return empty; `git status` shows changes under `packs/`, `.claude/skills/new-guide/`, `.agents/skills/new-guide/`, and `.claude-plugin/marketplace.json` (version propagated by `build-self`).
+
+---
+
+### T10: Write changelog entry
+
+**Depends on:** none
+
+**Tests:**
+- `docs/product/changelog.md` has a `user-guide-diataxis 0.2.0` entry under `## [Unreleased]` (AC15)
+- Entry names: broadened trigger (create + substantially revise), conversation contract (7 fields, gated), six page-type contracts in `page-contracts.md`, three new reference files
+
+**Approach:**
+- Open `docs/product/changelog.md` and locate `## [Unreleased]`
+- Add an entry following the existing format for pack version bumps in this file
+- Content: `user-guide-diataxis 0.2.0` — skill trigger broadened to cover create and substantially-revise requests; conversation contract (reader, job, natural_start, minimum_scope, first_result, write_boundary, next_request) replaces audience contract as the gated checkpoint; six page-type contracts in new `references/page-contracts.md`; three new reference files (`conversation-first.md`, `page-contracts.md`, `usability-review.md`); `clear-prose.md` extended with conversation-first structure rules; evals updated with revise/audit trigger cases and output-quality rubric.
+
+**Done when:** entry present under `## [Unreleased]` with the four named items; existing entries unchanged.
+
+---
+
+### T11: Review and update `pack.toml [pack.first-value]`
+
+**Depends on:** T1
+
+**Tests:**
+- `[pack.first-value]` in `pack.toml` accurately describes the revised skill's gate, or has a comment explaining why it intentionally describes only create-mode scaffold (AC16)
+
+**Approach:**
+- Read the current `[pack.first-value]` block in `packs/user-guide-diataxis/pack.toml`
+- Compare `safety-gate`, `starter-task`, `starter-prompt`, and `expected-result` against the revised T1 SKILL.md procedure
+- If `safety-gate` still describes only the create-mode scaffold preview (not the conversation-contract gate), update it to name the conversation contract as the first gate
+- If `starter-task`/`starter-prompt` are still scaffold-only, update or note that the first-value path is intentionally the create-mode scaffold (simpler entry point)
+- Minimal change — don't rewrite the whole block
+
+**Done when:** `[pack.first-value]` accurately reflects the conversation-contract gate for create mode, or carries a comment explaining why the create-scaffold path remains the install-time entry point.
+
+---
+
+## Rollout
+
+Pure skill-body and eval update. No infrastructure. No deployment sequencing. Ships as a normal PR; install copies are synced via `build-self` before commit. No data migration or published event. Reversible by reverting the PR.
+
+**Deferred:** `web/src/content/packs/user-guide-diataxis.md` and any matching journey content file still describe the skill as "scaffolds a new guide document." These are hand-maintained web files not regenerated by `build-self`. Updating them is a follow-on PR; the PR description will note this deferral.
+
+## Risks
+
+- **SKILL.md rewrite loses an existing behavior** — the three behaviors to preserve (gated checkpoint, posture table, slug + scaffold) are explicitly listed in the task T1 tests; the adversarial-reviewer pass should catch drift.
+- **`build-self` is slow or not available** — if `build-self` is unavailable, investigate `make build-self` or the equivalent; do not hand-copy files.
+- **`lint-skill-spec.py` fails on a skill-relative path** — verify that all new `references/` paths use the skill-relative form before running the linter.
+
+## Changelog
+
+- 2026-07-23: initial plan.
+- 2026-07-23: added T10 (changelog entry, AC15), T11 (pack.first-value review, AC16), marketplace.json to T9 expected changes (AC12), manual-QA step 4 for AC5 explicit-invocation redirect, fixed T7 assertion count to five discrete negatives, fixed T6 done-when to content-based check, fixed T4 mislabel on intent-first test, noted web-description deferral in Rollout — all from adversarial-reviewer pass.

--- a/docs/specs/new-guide-conversation-first/spec.md
+++ b/docs/specs/new-guide-conversation-first/spec.md
@@ -1,0 +1,77 @@
+# Spec: new-guide conversation-first
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** none
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+The `new-guide` skill in `packs/user-guide-diataxis` guides agents through authoring user-facing documentation. Today it covers only creating new guides and refuses revision work entirely. Two gaps limit its value: it has no mechanism to enforce conversation-first page structure (where the reader sees a natural-language task before any skill inventory), and its trigger set doesn't activate on rewrite or audit requests that need exactly the same discipline.
+
+This spec extends the skill in three ways. First, the trigger broadens from "create a new guide" to "create or substantially revise" — capturing rewrites, usability audits, and conversation-first retrofits. Second, the procedure gains a conversation contract as its gated checkpoint, replacing the existing audience contract: the contract makes visible the reader, their job, their natural first request, the minimum scope the agent needs, the expected first result, the read/write boundary, and the most likely follow-up. Third, page-type contracts — for all six surface types including pack pages and journey pages — move out of the SKILL.md body into `references/page-contracts.md`, with three companion references (`conversation-first.md`, `usability-review.md`, and an extension to `clear-prose.md`) making the conversation-first structure explicit and reviewable. Evals are updated to cover the new trigger surface and to grade output on the new quality bar.
+
+The key doctrine: **Diátaxis determines where information lives. User intent determines how readers enter it.** A reader who does not know any pack or skill name must still be able to begin a real task from the first screen.
+
+## Boundaries
+
+### Always do
+
+- Keep byte-identical copies across all three install paths (`packs/user-guide-diataxis/.apm/skills/new-guide/`, `.claude/skills/new-guide/`, `.agents/skills/new-guide/`) — sync via `build-self`, never manual copy.
+- Preserve the posture→quadrant mapping table (the Diátaxis load-bearing logic) in the rewritten SKILL.md.
+- Retain the gated checkpoint behavior — the skill must wait for human confirmation of the conversation contract before proceeding to draft.
+- Keep the slug-pick and asset-template-scaffold steps for the four Diátaxis quadrants in create mode.
+- Preserve all non-trivially-changed eval query entries (`eval_queries.json` additions are additive; no existing `true` case becomes `false`, and "Update the existing installation how-to to mention the new --force flag" stays `should_trigger: false`).
+
+### Ask first
+
+- Any change to the asset templates (`assets/tutorials.md`, `assets/how-to.md`, `assets/reference.md`, `assets/explanation.md`) — they are not in scope for this spec.
+- Adding asset templates for pack pages or journey pages — decided out of scope here; `page-contracts.md` is sufficient.
+- Any change to the version-bump magnitude (patch vs. minor) if the decision feels wrong at implementation time.
+
+### Never do
+
+- Write prose into any spec file that contradicts CONVENTIONS.md § 4.
+- Add product-behavioral rules to `clear-prose.md` (e.g., "state result-set coverage when the user asks for 'all'" — this is an Atlassian skill rule, not a documentation prose rule).
+- Touch `docs/guides/` content — this spec changes the skill, not the guides the skill has already produced.
+- Add new top-level directories to the pack.
+
+## Testing Strategy
+
+All changes are to skill-body text, reference files, and eval fixtures — no application code.
+
+- **Goal-based check** — JSON syntax validity for `evals.json` and `eval_queries.json`; version bump present in `pack.toml`, `.claude-plugin/plugin.json`, and propagated to `.claude-plugin/marketplace.json` via `build-self`; three install-copy files byte-identical after `build-self`; `tools/run-pack-evals.py --skill new-guide --mode activation` exercises the `eval_queries.json` cases (or its invocation is recorded in the manual-QA note if the ANTHROPIC_API_KEY secret is not configured in this run).
+- **Manual QA (visual / artifact exercise)** — invoke the revised skill in Claude Code on a real guide-authoring request; observe that: (a) the conversation contract is emitted and the skill waits before proceeding, (b) the correct page-type contract is loaded, (c) the first useful example appears within 120 words of the draft, (d) no skill or pack name is required to begin.
+
+## Acceptance Criteria
+
+- [x] AC1: The frontmatter `description` triggers on create AND substantially-revise requests (rewrite, restructure, audit, simplify, modernize a guide/pack-page/journey-page) and does NOT trigger on: Jira story creation, team-status queries, README spelling fixes, conceptual Diátaxis questions, or minor single-line updates to existing guides.
+- [x] AC2: The doctrine sentence "Diátaxis determines where information lives. User intent determines how readers enter it." appears at or near the top of the SKILL.md body.
+- [x] AC3: The intent-first test is stated in the skill: "A reader who does not know any pack or skill names must still be able to begin a real task from the first screen."
+- [x] AC4: The skill procedure produces a conversation contract with all seven fields (reader, job, natural_start, minimum_scope, first_result, write_boundary, next_request) **before** any prose is drafted, and the procedure explicitly waits for human confirmation of the contract before continuing.
+- [x] AC5: The procedure distinguishes create mode from revise mode. Revise mode requires the proposed change to be substantial (restructure, quadrant correction, major rewrite, conversation-first audit); minor edits (typo, single-line command update, link fix) are redirected to a normal PR. The redirect applies whether the skill is auto-triggered by the frontmatter description or explicitly invoked — when explicitly invoked on a minor edit, the skill detects the minor scope in step 1 and redirects before emitting the conversation contract.
+- [x] AC6: `references/page-contracts.md` exists and defines the required content and "move lower" rules for all six surface types: Tutorial, How-to, Reference, Explanation, Pack page, Journey page. The posture→quadrant table for the four Diátaxis types is present **in SKILL.md** (not delegated solely to `page-contracts.md`).
+- [x] AC7: `references/conversation-first.md` exists and contains the conversation-first structure rules (observable outcome before explanation, realistic request within 120 words, no inventory-first lead, user language before implementation names, next request shown, read/write boundary explicit, exhaustive options in reference).
+- [x] AC8: `references/usability-review.md` exists and contains a reviewable checklist including: first actionable example within 120 words; reader needs no skill name to begin; read/write behavior explicit; at least one realistic follow-up shown; skill inventory appears after user outcomes; a complete task has visible start and finish.
+- [x] AC9: `references/clear-prose.md` gains a new `## Conversation-first structure` section with the eight page-level usability rules (the two product-behavioral rules — result-set coverage and truncation-state — are excluded).
+- [x] AC10: `evals/eval_queries.json` includes the six new should-trigger queries (rewrite/simplify/audit/restructure requests for existing guides) and the four new should-not-trigger queries (Jira story, team-status query, README spelling, Diátaxis explanation).
+- [x] AC11: `evals/evals.json` includes a second eval (id: 2) grading output quality: the rubric asserts that a good artifact states reader and job, shows a natural-language request near the top, explains the first result, shows at least one follow-up, makes read/write boundaries explicit, puts inventory after outcomes, and keeps reference material out of the primary flow. It asserts against exactly six weak-artifact patterns: architecture-first opener; skill-list before task; reader must know a skill name to begin; isolated snippets only, no agent response; indiscriminate quadrant mixing. (Five discrete negatives — the sixth pattern "no agent response shown" is composed with "isolated snippets only" as a single compound assertion, reducing the effective count to five discrete checks; AC11 counts five.)
+- [x] AC12: `pack.toml` version is bumped to `0.2.0`; `.claude-plugin/plugin.json` version matches; `.claude-plugin/marketplace.json` reflects `0.2.0` after `build-self`.
+- [x] AC13: After `build-self`, the three install copies of SKILL.md, all reference files, and all eval files are byte-identical.
+- [x] AC14: The "Editing an existing guide via this skill" anti-pattern is amended — it no longer is a blanket refusal but redirects minor edits to a normal PR, while substantial revisions are in scope.
+- [x] AC15: `docs/product/changelog.md` gains a `user-guide-diataxis 0.2.0` entry under `## [Unreleased]` describing the broadened trigger, conversation contract, six page-type contracts, and three new reference files.
+- [x] AC16: `pack.toml [pack.first-value]` is reviewed against the revised procedure and either updated to reflect the conversation-contract gate or annotated with a comment explaining why it intentionally describes only the create-mode scaffold path.
+
+## Assumptions
+
+- Technical: three install copies (pack source, `.claude/skills/`, `.agents/skills/`) are byte-identical and synced via `build-self` (source: Explore agent inspection, 2026-07-23).
+- Technical: `references/clear-prose.md` exists in all three copies; new reference files follow the same pattern (source: Explore agent inspection, 2026-07-23).
+- Technical: `evals.json` uses `{skill_name, evals: [{id, prompt, expected_output, assertions}]}` format; `eval_queries.json` is `[{query, should_trigger}]` (source: file reads, 2026-07-23).
+- Technical: pack version bump requires `pack.toml` and `.claude-plugin/plugin.json` to both be updated, followed by `build-self` (source: project memory — pack-bump-needs-plugin-json).
+- Product: "journey page" and "pack page" are user-facing documentation surfaces (not design artifacts), describing a complete product journey or a pack's capabilities — distinct from the experience-design pack's journey mapping artifacts (source: proposal text + Explore agent inspection, 2026-07-23).
+- Product: the two product-behavioral density rules ("state coverage/truncation when user asks for 'all'" and "summarize large result sets before listing records") are Atlassian skill behavioral rules that do not belong in `clear-prose.md` (source: adversarial analysis, 2026-07-23).
+- Process: no RFC is required for this skill doctrine change; the change is additive and backward-compatible in adoption (source: user instruction — "do this in the work-loop").
+- Process: minor version bump (0.2.0) is appropriate — new surface types and major procedure change, no breaking change to existing usage (source: judgment call, may need confirmation at T8).

--- a/packs/user-guide-diataxis/.apm/skills/new-guide/SKILL.md
+++ b/packs/user-guide-diataxis/.apm/skills/new-guide/SKILL.md
@@ -1,264 +1,207 @@
 ---
 name: new-guide
-description: Use this skill to draft a new user-facing guide under `docs/guides/<quadrant>/<slug>.md` (or `docs/guides/<pack>/<quadrant>/<slug>.md` when guides are organized by pack) following the Diátaxis framework. Triggers on "write a guide for X", "new tutorial", "new how-to", "new reference page", "new explanation". Settles the audience contract before any body is written, then scaffolds from the matching per-quadrant template. Do NOT use for feature contracts (use `new-spec`), cross-cutting proposals (use `new-rfc`), or recording decisions (use `new-adr`).
+description: "Create or substantially revise user guides, pack pages, and journey pages using Diátaxis plus conversation-first UX. Use when asked to write, simplify, restructure, audit, or modernize tutorials, how-to guides, reference pages, explanations, pack pages, or journey pages so readers can start from a natural-language goal, see what to say, understand what happens next, and reach an outcome without learning internal skill names first. Do NOT use for feature contracts (use `new-spec`), cross-cutting proposals (use `new-rfc`), recording decisions (use `new-adr`), minor single-line edits (normal PR), contributor docs, docstrings, release notes, or blog posts."
 ---
 
-# Skill: new-guide
+# Guide authoring
 
-Create a new user-facing guide under `docs/guides/<quadrant>/<slug>.md`
-— or `docs/guides/<pack>/<quadrant>/<slug>.md` in a repo that organizes
-its guides by pack — following the [Diátaxis framework](https://diataxis.fr/).
-The framework itself is documented in this repo at `docs/guides/README.md`
-and the per-quadrant README — read those for the *what*; this skill is the
-*procedure* for landing a new piece on the right side of the line.
+**Diátaxis determines where information lives. User intent determines how readers
+enter it.**
 
-The load-bearing rule is **link out, don't blend**. When mid-draft you
-find yourself wanting to add theory inside a tutorial, or steps inside an
-explanation, that's the cue to write the adjacent piece separately and
-link. Mixing quadrants is the most common reason user docs frustrate
-everyone.
+A reader who does not know any pack or skill names must still be able to begin a
+real task from the first screen.
 
-## When to invoke
+Create or substantially revise one user-facing documentation surface. Use Diátaxis
+to determine the page's job. Use conversation-first design to determine what the
+reader encounters first.
 
-Before invoking, confirm:
+## Prerequisites
 
-1. The topic is *user-facing* — the reader is someone using the product,
-   not a contributor reading the code. Contributor-facing material lives
-   in `docs/architecture/` (current state) or `docs/adr/` (decisions).
-   If it's spec-shaped, use `new-spec`.
-2. The behavior being documented *already ships* — guides are living
-   docs that must match current product behavior. If you're proposing a
-   change, you want an RFC or a spec, not a guide.
-3. You can name a real reader. "Someone might want to know X" isn't a
-   reader; "an operator whose API token expires tomorrow and needs to
-   rotate it before the next deploy" is.
-
-If any check fails, push back rather than proceeding.
+- Read the actual skills, commands, or workflows the page documents.
+- Identify one primary reader and one primary job.
+- Preserve verified commands, permissions, defaults, and side effects.
+- For generated pages, edit their source data or template — not the rendered output.
 
 ## Procedure
 
-1. **Settle the audience contract — gated checkpoint.** With nothing
-   scaffolded yet, stop and surface the contract *in chat*. This is the
-   skill's analogue to `new-spec`'s assumptions checkpoint: the body is
-   gated until the contract is signed off. A guide that doesn't name its
-   reader ends up serving none of them.
+### Step 1 — Choose mode
 
-   Emit the contract under exactly this shape:
+**Create** a new guide, or **revise** an existing one.
 
-   ```markdown
-   AUDIENCE CONTRACT:
+Revise mode applies to substantial changes: restructuring the page's flow,
+correcting the quadrant, major rewrites, adding conversation-first structure, or
+auditing for inventory-first writing.
 
-   ## Reader profile
-   - **Right now they are:** <on rails, attentive | has a specific problem | scanning for an authoritative fact | reflecting, away from active use>
-   - **They leave with:** <a confident "I did it" + working artifact | their problem solved | the precise answer | a clearer mental model of why>
+Minor edits — a typo fix, a single updated command, a broken link, a version
+number — are a **normal PR against the existing file**. Stop here and redirect to
+that path; do not proceed with this skill for minor edits.
 
-   ## Quadrant pick
-   - **Quadrant:** <tutorials | how-to | reference | explanation>
-   - **Why this one (not the adjacent quadrants):** <one sentence>
+### Step 2 — Pick the slug or confirm the file
 
-   ## Title (working)
-   - **Title:** <draft>
-   - **What the reader would have typed into search:** <phrase>
-   ```
+- **Create:** choose a kebab-case slug matching what the reader would have searched
+  for. `rotate-credential-token`, not `how-to-rotate-your-token-step-by-step`.
+  The quadrant subdir carries the "how-to" / "tutorial" framing; do not repeat it
+  in the filename.
+- **Revise:** confirm the path to the existing file before proceeding.
 
-   Diátaxis distinguishes the four pieces by reader *posture*, not by
-   reader *skill*. The same person, expert at the product, can land in
-   any of the four quadrants on different days — what places them is
-   what they're doing right now. Use the posture-to-quadrant mapping:
+### Step 3 — Write the conversation contract (gated)
 
-   | Reader's posture right now | Quadrant |
-   | --- | --- |
-   | On rails, attentive, wants a guaranteed working result | **Tutorials** |
-   | Has a named problem, wants the recipe | **How-to** |
-   | In a hurry, scanning for the authoritative answer | **Reference** |
-   | Away from the keyboard, wants to understand *why* | **Explanation** |
+Before any prose is drafted, produce the contract and wait for human confirmation.
+This is the skill's gate — the body is blocked until the contract is signed off.
 
-   Then **wait for human confirmation or revision.** Don't write into
-   the body until the contract is signed off — even if the original
-   prompt sounded definitive. Two outcomes from confirmation:
+```
+CONVERSATION CONTRACT:
 
-   - The contract is accepted → proceed to step 2.
-   - The contract splits into two readers or two postures → that's two
-     guides, not one. Surface this and ask the user to pick the
-     first; the second goes to follow-up.
+reader: <role and context — not "all users"; who is reading right now>
+job: <the specific thing they are trying to accomplish>
+natural_start: <the exact words they would use to begin>
+minimum_scope:
+  - <the minimum the agent needs to start — team, board, time horizon, etc.>
+first_result: <the concrete thing the reader gets back>
+write_boundary: <what the agent reads vs. what it may change>
+next_request: <the most likely follow-up after the first result lands>
+```
 
-2. **Pick a kebab-case slug.** Keep it short and noun-y, matching what
-   the reader would have searched for: `rotate-credentialed-skill-token`,
-   not `how-to-rotate-your-token-step-by-step`. The quadrant subdir
-   carries the "how-to" / "tutorial" framing; don't repeat it in the
-   filename.
+Wait for human confirmation or revision. Two outcomes:
 
-3. **Scaffold from the matching template.** The quadrant token maps to
-   one asset filename and one destination directory — use the mapping
-   table below verbatim, don't interpolate by hand:
+- Contract accepted → proceed to Step 4.
+- Contract splits into two readers or two jobs → two pages. Surface this and ask
+  the user to pick the first; the second goes to a follow-up.
 
-   | Quadrant | Asset to copy | Destination |
-   | --- | --- | --- |
-   | `tutorials` | `assets/tutorials.md` | `docs/guides/tutorials/<slug>.md` |
-   | `how-to` | `assets/how-to.md` | `docs/guides/how-to/<slug>.md` |
-   | `reference` | `assets/reference.md` | `docs/guides/reference/<slug>.md` |
-   | `explanation` | `assets/explanation.md` | `docs/guides/explanation/<slug>.md` |
+### Step 4 — Choose the page contract type
 
-   (Paths are skill-relative — the `assets/` folder lives next to this
-   `SKILL.md` wherever your IDE installed the skill.) The four
-   templates carry the minimal section structure for each quadrant; they
-   are starting scaffolds, not strict forms.
+Determine which of the six surface types applies. For the four Diátaxis types,
+choose by reader posture — what the reader is doing right now, not what topic
+they are reading about.
 
-   **If the repo organizes guides by pack** — a `docs/guides/<pack>/<quadrant>/`
-   layout — prefix the destination with the owning pack, or `_shared/` for a
-   cross-cutting guide that isn't specific to one pack: e.g.
-   `docs/guides/core/how-to/<slug>.md`. Write where the repo's existing
-   guides already live; match the surrounding structure rather than imposing
-   one.
+| Reader's posture right now | Surface type |
+| --- | --- |
+| On rails, attentive, wants a guaranteed working result | Tutorial |
+| Has a named problem, wants the recipe | How-to |
+| In a hurry, scanning for the authoritative answer | Reference |
+| Away from the keyboard, wants to understand *why* | Explanation |
 
-4. **Draft, applying the per-quadrant rules.** The source of truth for
-   *what goes in* each quadrant is the per-quadrant README under
-   `docs/guides/<quadrant>/README.md` (or `docs/guides/_shared/<quadrant>/README.md`
-   in a per-pack repo). Read the relevant one before drafting. The condensed write-time rules, with the named anti-patterns
-   the canonical framework warns about:
+Pack pages describe what a pack does and how to start — choose by context.
+Journey pages walk a complete user flow from first request to final outcome —
+choose by context.
 
-   - **Tutorials.** Concrete, complete, one path, no digression. Each
-     step says what to do, shows what to expect, reassures the reader
-     they're on track. Refuse the [*anti-pedagogical
-     temptations*](https://diataxis.fr/tutorials/) Procida names:
-     *abstraction, generalisation*, *explanation*, *choices*,
-     *information*. Tutorials must produce the result they promise —
-     broken reliability is the worst failure. Open with the guaranteed
-     outcome ("At the end you'll have a running X"), not "you will
-     learn".
-   - **How-to.** Solves one named problem for an already-competent
-     reader. Title is the problem. Skip backstory, skip "turn on the
-     power switch"–level steps, skip reteaching basics. Cover the
-     realistic variations and the common pitfalls — that's what makes a
-     how-to worth the click over the reference page.
-   - **Reference.** Authoritative, complete, consistently structured,
-     **neutral**. Procida: ["Neutral description is the key imperative
-     of technical reference"](https://diataxis.fr/reference/) — austere,
-     factual, no editorializing, no narrative. If the section is
-     auto-generated, mark it at the top so the next person doesn't
-     hand-edit it. Reference rots when the code drifts; "code change →
-     reference update in the same PR" is the discipline.
-   - **Explanation.** Discursive, illuminating, allowed to be opinionated
-     and to wander a little. Frame the scope with an *"About <topic>"*
-     question to keep it bounded — open-ended explanations sprawl. No
-     step-by-step instructions, no parameter lists. Make connections to
-     adjacent topics. ADRs vs. architecture docs vs. explanation: ADRs
-     are *frozen decisions for the team*, architecture is *how the code
-     is organized now for contributors*, explanation is *what the
-     concept means for someone using the product*.
+### Step 5 — Load the relevant contract from `references/page-contracts.md`
 
-   On voice and tone — apply Google's developer-docs rule of thumb:
-   "Sound like a knowledgeable friend who understands what the developer
-   wants to do." Second person, active voice, present tense. Two
-   separate anti-patterns to avoid:
+Read only the section that matches the surface type chosen in Step 4. Apply its
+required content and "move lower" rules throughout drafting.
 
-   - **Don't gaslight stuck readers.** Drop *simply*, *just*, *easy*,
-     *quickly*, *obviously* — every one of those words makes a reader
-     who got stuck feel dumb.
-   - **Don't soften imperatives.** Drop *please* in instructions ("please
-     click", "please run") — it makes commands sound optional. Just
-     write the imperative.
-   - **Don't narrate the product's history.** Write as if the product
-     always worked this way — the *retcon* discipline. Drop "will be
-     added", "previously X, now Y", "deprecated in 2.0", and
-     version-stamped history from the guide body. A guide is a living doc
-     describing current behavior; the reader wants what is true now, not a
-     changelog. Evolution belongs in release notes, the changelog, or an
-     ADR — link to it instead of narrating it inline.
+### Step 6 — Scaffold (create mode, four Diátaxis types only)
 
-   Efficiency is a form of respect — the reader is in a hurry.
+For create mode and the four Diátaxis quadrants, scaffold from the matching asset
+template and write to the standard destination:
 
-   Beyond word choice, the draft should read like a person wrote it, not a
-   machine. Cut the tells that make prose feel generated: hedges ("it's
-   worth noting"), uniform sentence rhythm, em-dash overuse, throat-clearing
-   openers ("In this guide we will explore…"), inflated verbs ("leverage",
-   "utilize", "delve"), and sentences that restate the heading. Vary sentence
-   length, keep one claim per sentence, and prefer a concrete number or
-   example over an adjective. Read the full checklist in
-   [`references/clear-prose.md`](references/clear-prose.md) while you draft and
-   edit, not before.
+| Surface type | Asset to copy | Destination |
+| --- | --- | --- |
+| Tutorial | `assets/tutorials.md` | `docs/guides/tutorials/<slug>.md` |
+| How-to | `assets/how-to.md` | `docs/guides/how-to/<slug>.md` |
+| Reference | `assets/reference.md` | `docs/guides/reference/<slug>.md` |
+| Explanation | `assets/explanation.md` | `docs/guides/explanation/<slug>.md` |
 
-5. **Apply the link-out rule as you draft.** When you find yourself
-   reaching for content from the adjacent quadrant, stop and write a
-   link instead:
+(Paths are skill-relative — the `assets/` folder lives next to this `SKILL.md`.)
 
-   - Tempted to explain *why* mid-tutorial → link to (or create) an
-     explanation page.
-   - Tempted to list every option mid-how-to → link to the reference.
-   - Tempted to walk a beginner through setup mid-explanation → link to
-     the tutorial.
-   - Tempted to recommend a best practice mid-reference → link to the
-     explanation.
+For pack pages and journey pages in create mode, there is no fixed destination;
+write where the repo's existing guides already live. Match the surrounding
+structure.
 
-   The link can be a placeholder (`<!-- TODO: link to … -->`) if the
-   adjacent piece doesn't exist yet; surface those placeholders in the
-   final summary so the next guide gets written.
+If the repo organizes guides by pack — a `docs/guides/<pack>/<quadrant>/` layout
+— prefix the destination with the owning pack, or `_shared/` for a cross-cutting
+guide.
 
-6. **Self-check before announcing the draft.** Walk this list against
-   the chosen quadrant; every "yes" is a finding to fix:
+### Step 7 — Draft using conversation-first structure
 
-   - Tutorial: does any step lack a "you should see…" check? Did I
-     offer the reader a choice anywhere? Did I sneak in *why* instead of
-     linking out?
-   - How-to: does the title name the reader's problem in their words?
-     Did I reteach a basic the reader already knows? Did I cover only
-     the linear path and ignore realistic variations?
-   - Reference: did I editorialize anywhere ("this is the recommended
-     option…")? Is any entry of the same kind shaped differently from
-     its siblings? Did I skip an option?
-   - Explanation: is there a step-by-step block that belongs in a
-     how-to? Did I drift past the *"About <topic>"* scope? Did I avoid
-     opinion — explanation is *allowed* a voice?
+Put the first useful example before inventories, architecture, terminology, or
+exhaustive options. A reader who reaches word 120 without seeing a prompt,
+command, or concrete result has waited too long.
 
-   Then run a prose pass against
-   [`references/clear-prose.md`](references/clear-prose.md). When your
-   environment provides subagents, hand the draft plus that checklist to a
-   read-only subagent and ask it to flag machine-shaped prose; that keeps the
-   style read off your main context. Without subagents, read the draft cold
-   yourself against the checklist. The quadrant self-check above is the floor;
-   the prose pass is the polish.
+Structure the core task flow using:
 
-7. **Cross-link the siblings — only the ones that exist.** A new guide
-   rarely stands alone. From the new file, add a `See also` section.
-   For each candidate sibling — the tutorial that introduces the
-   concept, the how-to that uses what reference describes (and vice
-   versa), the explanation that says *why* — check whether the file
-   exists. If it does, link it. If it doesn't, surface the gap in the
-   final summary as a follow-up TODO; don't write a broken link, and
-   don't synthesize a plausible-sounding path. From each existing
-   sibling, add a reverse link to the new piece. Cross-links are a
-   maintenance pact: when one rots, the others surface the drift.
+- **Say this** — the exact words the reader uses
+- **What happens** — what the agent does in response
+- **You get** — the concrete result
+- **What to ask next** — the likely follow-up
 
-   Don't touch the per-quadrant `README.md` (`docs/guides/<quadrant>/README.md`,
-   or `docs/guides/_shared/<quadrant>/README.md` in a per-pack repo) — those
-   READMEs are the framework's per-quadrant explainer, not a piece index.
-   Adopters who want an index of pieces add one separately; the skill
-   doesn't invent one.
+### Step 8 — Apply conversation-first rules
+
+Load [`references/conversation-first.md`](references/conversation-first.md) and
+apply its eight sequencing rules. Key checks:
+
+- Realistic user request within the first 120 words
+- No more than two product-specific terms before that request
+- User language before implementation names
+- Read/write boundary explicit
+- Next request shown
+
+### Step 9 — Edit for density
+
+Load [`references/clear-prose.md`](references/clear-prose.md) and edit. Pay
+particular attention to the `## Conversation-first structure` section at the end
+— it covers page-level structural tells that a word-level pass will miss.
+
+When your environment provides subagents, hand the draft and the checklist to a
+read-only subagent; that keeps the style read off your main context. The cold
+self-read is the floor without subagents.
+
+### Step 10 — Run the usability review
+
+Load [`references/usability-review.md`](references/usability-review.md) and run
+the six-item checklist. Each "yes" is a finding to fix before declaring the draft
+ready. Also verify the conversation contract is reflected in the draft.
+
+### Step 11 — Check links and cross-link siblings
+
+Apply the link-out rule as you finalize:
+
+- Tempted to explain *why* mid-tutorial → link to an explanation page
+- Tempted to list every option mid-how-to → link to the reference
+- Tempted to walk a beginner through setup mid-explanation → link to the tutorial
+- Tempted to recommend a best practice mid-reference → link to the explanation
+
+The link can be a placeholder (`<!-- TODO: link to … -->`) if the adjacent piece
+does not exist yet; surface those placeholders in the final summary.
+
+From the new or revised file, add a `See also` section linking existing siblings
+only. From each existing sibling, add a reverse link. Check whether each file
+exists before linking — do not write broken links and do not synthesize
+plausible-sounding paths.
+
+Do not touch the per-quadrant `README.md` files — those are the framework's
+per-quadrant explainer, not a piece index.
+
+## Verification
+
+Before announcing the draft, confirm:
+
+- [ ] The first actionable example appears within the first 120 words.
+- [ ] The reader does not need to know a skill name to begin.
+- [ ] Read and write behavior is explicit.
+- [ ] The page shows at least one realistic follow-up.
+- [ ] Skill inventory appears after user outcomes.
+- [ ] A complete task has a visible start and finish.
 
 ## Anti-patterns to refuse
 
-- **Writing the body before the audience contract is confirmed.** The
-  body is gated. The contract is the cheapest place to catch a
-  mismatched quadrant; once draft prose is on the page, rework costs
-  compound.
-- **Picking the quadrant by *topic* instead of by *reader posture*.**
-  "Authentication" is a topic; *learning* authentication, *configuring*
-  it, *looking up its parameters*, and *understanding why it's
-  cookie-based* are four different pieces — possibly all four.
-- **Blending quadrants because "the reader will appreciate the
-  context".** They won't. The framework's whole thesis is that mixing
-  modes is what makes docs frustrating; the link-out rule is
-  non-negotiable.
-- **Drafting a tutorial without running the steps end-to-end.** A
-  tutorial that doesn't produce the promised result is worse than no
-  tutorial. If the steps can't be run, you're writing a how-to or an
-  explanation — re-open the audience contract.
-- **Writing reference in narrative voice.** "You'll want to set this
-  to…" is explanation leaking into reference. Reference says *what*;
-  recommendations live in explanation.
-- **Writing explanation without an *About <X>* frame.** Open-ended
-  explanation absorbs adjacent material and sprawls. Name the question
-  the page answers; if you can't, the page isn't ready.
-- **Editing an existing guide via this skill.** `new-guide` is for new
-  pieces. Edits are normal PRs against the existing file; the rules in
-  step 4 still apply, but the skill's checkpoint and scaffold don't.
+- **Drafting before the conversation contract is confirmed.** The body is gated.
+  The contract is the cheapest place to catch a mismatched scope; once draft
+  prose is on the page, rework compounds.
+- **Using this skill for minor edits.** A typo fix, a single updated command, a
+  broken link — these are normal PRs. This skill's procedure adds ceremony that
+  minor edits do not warrant.
+- **Picking the surface type by topic instead of by reader posture.** "Authentication"
+  is a topic; *learning* it, *configuring* it, *looking up its parameters*, and
+  *understanding why it is cookie-based* are four different pieces.
+- **Blending surface types because "the reader will appreciate the context."** They
+  will not. The link-out rule is non-negotiable.
+- **Drafting a tutorial without running the steps end-to-end.** A tutorial that
+  does not produce the promised result is worse than no tutorial. If the steps
+  cannot be run, you are writing a how-to or an explanation — re-open the contract.
+- **Writing reference in narrative voice.** Reference says *what*; recommendations
+  live in explanation.
+- **Writing explanation without an *About <X>* frame.** Open-ended explanation
+  absorbs adjacent material and sprawls. Name the question the page answers.
+- **Leading with a skill or pack inventory.** The reader came with a goal. The
+  inventory belongs after the first task completes.

--- a/packs/user-guide-diataxis/.apm/skills/new-guide/evals/eval_queries.json
+++ b/packs/user-guide-diataxis/.apm/skills/new-guide/evals/eval_queries.json
@@ -19,5 +19,17 @@
   {"query": "Write the release notes for the 2.0 release", "should_trigger": false},
   {"query": "Fix the broken link in the installation guide", "should_trigger": false},
   {"query": "Write the empty-state and error microcopy for the upload screen", "should_trigger": false},
-  {"query": "Write a blog post announcing our new export feature", "should_trigger": false}
+  {"query": "Write a blog post announcing our new export feature", "should_trigger": false},
+
+  {"query": "Rewrite this Jira guide so the reader sees what to ask first", "should_trigger": true},
+  {"query": "Turn this skill-list page into a task-led pack page", "should_trigger": true},
+  {"query": "Make this Diátaxis how-to less dense", "should_trigger": true},
+  {"query": "Add a realistic multi-turn conversation to this guide", "should_trigger": true},
+  {"query": "Audit these docs for inventory-first writing", "should_trigger": true},
+  {"query": "Revise this journey page to show a complete user flow", "should_trigger": true},
+
+  {"query": "Create a Jira story for password reset", "should_trigger": false},
+  {"query": "Show me the Atlas team's blockers", "should_trigger": false},
+  {"query": "Fix spelling in this README", "should_trigger": false},
+  {"query": "What is Diátaxis and how does it work", "should_trigger": false}
 ]

--- a/packs/user-guide-diataxis/.apm/skills/new-guide/evals/evals.json
+++ b/packs/user-guide-diataxis/.apm/skills/new-guide/evals/evals.json
@@ -13,6 +13,25 @@
         "Prose reads human and task-respecting: second person, active voice, present tense; no reader-blaming fillers (simply/just/easy/obviously), no softened imperatives (please), no inline version-history narration",
         "Cross-links (\"See also\") point only to sibling pages that exist — no fabricated or broken links"
       ]
+    },
+    {
+      "id": 2,
+      "prompt": "Create or revise a user-facing guide following the conversation-first doctrine.",
+      "expected_output": "A guide that states the reader and their job early, shows a natural-language request near the top (within the first 120 words), explains the first result the reader gets, shows at least one realistic follow-up request, makes read/write boundaries explicit, puts skill/command inventory after user outcomes rather than before, and keeps reference material out of the primary flow. It does not open with product architecture or a skill list. The reader can begin a task without knowing any skill or pack name. The page shows a visible start and finish for at least one complete task.",
+      "assertions": [
+        "States the reader and their job — the page has an implied or explicit audience",
+        "Shows a natural-language request near the top, within the first 120 words",
+        "Explains the first result — the reader knows what they will get before the detail starts",
+        "Shows at least one realistic follow-up request, not only the entry request",
+        "Makes read/write boundaries explicit — separates what the agent reads from what it may change",
+        "Puts skill/command inventory after user outcomes, not before",
+        "Keeps reference material (exhaustive options, parameter tables) out of the primary flow",
+        "Does not open with product architecture or an internal component diagram",
+        "Does not begin by presenting a list of available skills, packs, or commands before the reader's first task",
+        "Does not require the reader to know any skill or pack name to begin",
+        "Is not a collection of isolated prompt snippets — shows what the agent returns and not just what the user says",
+        "Does not indiscriminately mix Diátaxis quadrants — tutorial material is not blended with reference"
+      ]
     }
   ]
 }

--- a/packs/user-guide-diataxis/.apm/skills/new-guide/references/clear-prose.md
+++ b/packs/user-guide-diataxis/.apm/skills/new-guide/references/clear-prose.md
@@ -105,3 +105,35 @@ will miss:
 When your environment has subagents, the skill's optional copyedit pass hands
 the draft and this checklist to a fresh reader so the style read stays off your
 main context. The cold self-read is the floor either way.
+
+## Conversation-first structure
+
+These are page-level structural rules. They complement the word-level checklist
+above — a draft can pass every vocabulary check and still fail these. Run them
+after the prose pass, not instead of it. For the full framing and sequencing
+rationale, see [`references/conversation-first.md`](conversation-first.md).
+
+- **Put one observable outcome before the first conceptual explanation.** The
+  reader needs to see what they will get before they are asked to understand
+  why. An outcome is a command, a result, or a concrete next step — not a
+  category name.
+- **Put a realistic user request within the first 120 words.** The reader
+  scanning for "how do I begin?" should find it without scrolling.
+- **Introduce no more than two product-specific terms before that request.**
+  Every term introduced before the first example is a term the reader must
+  carry before they can act.
+- **Do not lead with a component, skill, command, or pack inventory.** Leading
+  with what the product contains is inventory-first. The reader came with a
+  goal, not a browse session. The inventory belongs after the first task
+  completes.
+- **Use user language first and implementation names second.** "Show me the
+  team's open work" before `jira-team-status`. The page can use both; the
+  user term opens the sentence.
+- **Show the next likely request, not only the initial request.** A guide
+  that ends with the first task done leaves the reader stranded. Name where
+  they go next.
+- **Separate read-only exploration from remote writes.** State clearly when an
+  action reads data vs. when it changes something. Never leave the read/write
+  boundary implicit.
+- **Put exhaustive options in reference, not in the main procedure.** Embed a
+  link; do not embed the reference page.

--- a/packs/user-guide-diataxis/.apm/skills/new-guide/references/conversation-first.md
+++ b/packs/user-guide-diataxis/.apm/skills/new-guide/references/conversation-first.md
@@ -1,0 +1,48 @@
+# Conversation-first structure
+
+Diátaxis determines where information lives. User intent determines how readers
+enter it. These are page-level sequencing rules — they sit above the word-level
+checklist in `clear-prose.md` and govern the order of what the reader encounters
+before the detail starts.
+
+A reader who does not know any pack or skill names must still be able to begin a
+real task from the first screen.
+
+## Rules
+
+1. **Put one observable outcome before the first conceptual explanation.** The
+   reader needs to see what they will get before they are asked to understand why
+   it works. An observable outcome is a command, a result, a screenshot, or a
+   concrete next step — not a category name or a feature list.
+
+2. **Put a realistic user request within the first 120 words.** The request shows
+   the reader how to start. It does not have to be the opener; it has to be early
+   enough that a reader scanning for "how do I begin?" finds it without scrolling.
+
+3. **Introduce no more than two product-specific terms before that request.** Terms
+   introduced before the first example are terms the reader must carry before they
+   can act. Two is the ceiling; one is better; zero is possible and often right.
+
+4. **Do not lead with a component, skill, command, or pack inventory.** Leading with
+   a list of what the product contains is inventory-first writing. The reader came
+   with a goal, not a browse session. The inventory belongs after the first task
+   completes.
+
+5. **Use user language first and implementation names second.** "Show me the team's
+   open work" before `jira-team-status`. "Create a decision record" before `new-adr`.
+   The page can use both; the user term opens the sentence.
+
+6. **Show the next likely request, not only the initial request.** A guide that ends
+   with the first task done leaves the reader stranded. Name where they go next —
+   a follow-up prompt, a related page, or the decision they face after the first
+   result lands.
+
+7. **Separate read-only exploration from remote writes.** State clearly when an
+   action reads data vs. when it changes something. A reader deciding whether to
+   run a command needs to know which side of that line it falls on. Do not leave
+   the read/write boundary implicit.
+
+8. **Put exhaustive options in reference, not in the main procedure.** A how-to
+   that enumerates every flag, a tutorial that lists every configuration key — both
+   interrupt the reader's task with detail they did not ask for. Link to the
+   reference; do not embed it.

--- a/packs/user-guide-diataxis/.apm/skills/new-guide/references/page-contracts.md
+++ b/packs/user-guide-diataxis/.apm/skills/new-guide/references/page-contracts.md
@@ -1,0 +1,164 @@
+# Page contracts
+
+Each section below is the contract for one surface type. Load only the section
+that matches the page you are writing or revising. The contract answers three
+questions for each type: what the first screen must make obvious, what content
+is required, and what to move lower or link out.
+
+## Choosing the right surface type
+
+For the four Diátaxis types, choose by reader posture — what the reader is doing
+right now, not what topic they are reading about. The same person, on different
+days, will land in different quadrants.
+
+| Reader's posture right now | Surface |
+| --- | --- |
+| On rails, attentive, wants a guaranteed working result | **Tutorial** |
+| Has a named problem, wants the recipe | **How-to** |
+| In a hurry, scanning for the authoritative answer | **Reference** |
+| Away from the keyboard, wants to understand *why* | **Explanation** |
+
+Pack pages and journey pages are chosen by context: if the page describes what a
+pack does and how to start, it is a Pack page. If the page walks through a
+complete user flow from first request to final outcome, it is a Journey page.
+
+---
+
+## Tutorial
+
+**First screen must answer:** "How do I complete my first real journey?"
+
+**Required content:**
+- The exact first request to send — copyable, not paraphrased
+- The expected result after that first request
+- Checkpoints along the way ("you should see…")
+- A complete outcome at the end — the reader finishes with something real
+- Each step says what to do and what the reader should observe
+
+**Move lower or link out:**
+- Alternatives and variations (→ How-to)
+- Architecture and design decisions (→ Explanation)
+- Exhaustive option lists (→ Reference)
+- Prerequisites beyond the minimum needed to start
+
+**Anti-patterns to refuse:**
+- Offering the reader a choice mid-tutorial
+- Inserting explanation of *why* without linking out
+- Steps that produce no observable result
+- A result the reader cannot verify
+
+---
+
+## How-to
+
+**First screen must answer:** "How do I accomplish this one goal?"
+
+**Required content:**
+- A copyable request or command that starts the task
+- The scope of what the skill reads and what it may change
+- A minimal procedure covering the common path
+- Common variations the reader is likely to hit
+- The most likely follow-up request after the task completes
+
+**Move lower or link out:**
+- Theory and background (→ Explanation)
+- Exhaustive field-by-field reference (→ Reference)
+- Step-by-step setup a beginner needs (→ Tutorial)
+- Options the reader will never vary
+
+**Anti-patterns to refuse:**
+- A title that names a topic rather than the reader's problem
+- Reteaching basics the competent reader already knows
+- Covering only the linear happy path with no realistic variations
+
+---
+
+## Reference
+
+**First screen must answer:** "What exactly does this skill accept and do?"
+
+**Required content:**
+- An intent index — what the reader can accomplish with this skill
+- Inputs: what the reader provides
+- Outputs: what the skill returns
+- Reads: what the skill reads without asking
+- Writes: what the skill may change
+- Limits: caps, timeouts, pagination, rate limits
+
+**Move lower or link out:**
+- Narrative walkthroughs (→ How-to or Tutorial)
+- Explanation of why the design works this way (→ Explanation)
+- Getting-started instructions (→ Tutorial)
+
+**Anti-patterns to refuse:**
+- Editorializing ("this is the recommended option…")
+- Entries of the same kind shaped differently from their siblings
+- Skipping an option because it is "rarely used"
+
+**Sync discipline:** Reference rots when the code drifts. A code change → reference update in the same PR is the rule, not a nice-to-have. For auto-generated sections, mark them with a comment pointing to the source data so readers know not to hand-edit the copy.
+
+---
+
+## Explanation
+
+**First screen must answer:** "How do these pieces fit together and why?"
+
+**Required content:**
+- A mental model the reader can hold in their head
+- How the components compose — what connects to what
+- Trade-offs and the reasoning behind key design choices
+- Boundaries — what this concept is and is not
+
+**Move lower or link out:**
+- Step-by-step procedures (→ How-to)
+- Exhaustive parameter lists (→ Reference)
+- Guaranteed-outcome walkthroughs (→ Tutorial)
+
+**Anti-patterns to refuse:**
+- Step-by-step instructions embedded in the explanation
+- Open-ended scope with no "About <topic>" frame
+- Refusing to take a position where the design is opinionated
+
+---
+
+## Pack page
+
+**First screen must answer:** "What can this help me do?"
+
+**Required content:**
+- Job cards — what a reader with a concrete goal can accomplish
+- Natural-language prompts — the exact words to use, not skill names
+- Result previews — what the agent returns for each task
+- The common journey — a start-to-finish sequence for the primary use case
+
+**Move lower or link out:**
+- The full skill inventory (names, flags, schema)
+- Installation and setup details
+- Architecture of how the pack is composed
+
+**Anti-patterns to refuse:**
+- Opening with a skill or command list
+- Requiring the reader to know a skill name to begin the first task
+- Describing capabilities in abstract terms without a concrete prompt
+
+---
+
+## Journey page
+
+**First screen must answer:** "What happens from start to finish?"
+
+**Required content (one block per stage):**
+- **You say** — the natural-language request the reader sends
+- **Agent does** — what the agent reads, fetches, or computes
+- **You get** — the concrete result
+- **Decision** — what the reader decides or confirms before the next stage
+
+**Move lower or link out:**
+- Skill cards and implementation vocabulary
+- Configuration and permission details
+- Error-handling reference
+
+**Anti-patterns to refuse:**
+- Describing what the skill does without showing what the reader says and gets
+- Stages without a visible decision or outcome
+- Mixing implementation vocabulary into the user-facing flow

--- a/packs/user-guide-diataxis/.apm/skills/new-guide/references/usability-review.md
+++ b/packs/user-guide-diataxis/.apm/skills/new-guide/references/usability-review.md
@@ -1,0 +1,49 @@
+# Usability review
+
+Run this checklist before finalizing any guide or pack page. Each "yes" is a
+finding to fix. Read the draft cold — the sentences you have to read twice are
+the ones that need work.
+
+## Conversation-first checks
+
+1. **Does a first actionable example appear within the first 120 words?**
+   Count from the first word of body text (after the title). If the reader
+   reaches word 120 without seeing a prompt, a command, or a concrete result,
+   the page opens too late.
+
+2. **Can the reader begin a real task without knowing any skill or pack name?**
+   Cover the title, the nav, and the first paragraph. If what the reader must
+   type to start is a skill name rather than a natural-language goal, the page
+   is skill-first, not reader-first.
+
+3. **Is read/write behavior explicit?** The reader should know, before they
+   act, whether the agent will only read data or whether it may change something.
+   If the page leaves the read/write boundary implicit, name it.
+
+4. **Does the page show at least one realistic follow-up request?** A guide
+   that ends when the first task completes leaves the reader without a next
+   step. Name the most likely follow-up — a prompt, a decision, or a link.
+
+5. **Does skill/command inventory appear after user outcomes, not before?**
+   Scan the page top to bottom. If the first substantive block is a list of
+   skills, commands, or flags rather than a goal or an example, the structure
+   is inventory-first. Move the inventory below the first task completion.
+
+6. **Does the guide show a visible start AND finish for at least one complete
+   task?** A complete task has a first request the reader can copy and a final
+   result the reader can verify. If either is missing, the task is incomplete.
+
+## Contract verification
+
+Before declaring the guide ready, confirm the conversation contract fields are
+all present and accurate:
+
+- **reader** — who is reading this right now (role + context, not "all users")
+- **job** — the specific thing they are trying to accomplish
+- **natural_start** — the exact words they would use to begin
+- **minimum_scope** — the minimum the agent needs to start (team, board, time horizon, etc.)
+- **first_result** — the concrete first thing the reader receives
+- **write_boundary** — what the agent reads vs. what it may change
+- **next_request** — the most likely follow-up after the first result lands
+
+If any field is empty or vague, the guide cannot meet the reader's real need.

--- a/packs/user-guide-diataxis/.claude-plugin/plugin.json
+++ b/packs/user-guide-diataxis/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "user-guide-diataxis",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "description": "Di\u00e1taxis-shaped user-guide skeleton: guides/ + tutorials/how-to/reference/explanation seed READMEs, new-guide skill."
 }

--- a/packs/user-guide-diataxis/pack.toml
+++ b/packs/user-guide-diataxis/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "user-guide-diataxis"
-version = "0.1.7"
+version = "0.2.0"
 description = "Di\u00e1taxis-shaped user-guide skeleton: guides/ + tutorials/how-to/reference/explanation seed READMEs, new-guide skill."
 readme = "README.md"
 display_name = "User Guide (Diátaxis)"
@@ -52,6 +52,9 @@ name = "eugenelim"
 email = "eugenelim@users.noreply.github.com"
 
 # Level B: non-technical audience (technical writers, PMs); docs scaffold is structural repo record with preview-confirm gate.
+# safety-gate describes the install-time scaffold creation preview (pack seeds → docs/guides/ directory),
+# not the new-guide skill's conversation-contract gate. The conversation contract fires when a guide page
+# is actually authored (new-guide Step 3); the starter-task here is the earlier scaffold step. Intentional.
 [pack.first-value]
 audience-posture = "non-technical"
 surfaces         = ["claude-code"]

--- a/workspace.toml
+++ b/workspace.toml
@@ -234,6 +234,8 @@ queue   = [
   # closing paragraph (single source of truth). Do not re-add the echo.
   "spec/work-loop-step0-observability",                  # consumes work-loop-step0-{branch1-echo,layout} backlog items
   "spec/catalogue-curation-qa-coverage",                 # consumes the 4 catalogue-curation-* QA backlog items
+  # ---- Independent skill improvements ----
+  "spec/new-guide-conversation-first",                  # user-guide-diataxis 0.2.0: conversation-first doctrine + revised procedure + evals
 ]
 
 # Repo-level backlog — open work not scoped to any active initiative.


### PR DESCRIPTION
## Summary

- **Broadened trigger**: `new-guide` now activates on create AND substantially-revise requests (rewrite, simplify, restructure, audit, modernize) — minor edits redirect to a normal PR at Step 1.
- **Conversation contract** (7-field gated checkpoint) replaces the old 3-field audience contract: reader, job, natural_start, minimum_scope, first_result, write_boundary, next_request — skill body is blocked until human confirms.
- **Three new reference files**: `conversation-first.md` (8 sequencing rules), `page-contracts.md` (6 surface-type contracts: Tutorial, How-to, Reference, Explanation, Pack page, Journey page), `usability-review.md` (6-item checklist).
- **`clear-prose.md` extended** with a `## Conversation-first structure` section (8 page-level structural rules; product-behavioral rules excluded per spec Boundaries).
- **Evals updated**: 10 new eval_queries entries (6 true, 4 false); second LLM-judge rubric eval with 12 assertions (7 positive, 5 discrete negative).
- **Version bump**: user-guide-diataxis 0.1.7 → 0.2.0 (pack.toml, plugin.json, marketplace.json).
- **Spec**: `docs/specs/new-guide-conversation-first/` — Status: Shipped, all 16 ACs verified.

Key doctrine added: *Diátaxis determines where information lives. User intent determines how readers enter it.* A reader who does not know any pack or skill names must still be able to begin a real task from the first screen.

## Deferred

`web/src/content/packs/user-guide-diataxis.md` still describes the skill as scaffold-only — updating the hand-maintained web description is a follow-on PR.

## Test plan

- [ ] Invoke `new-guide` with a rewrite request — conversation contract emitted and skill waits before drafting; all 7 fields present
- [ ] Invoke `new-guide` with a minor edit request — Step 1 redirects to normal PR before emitting contract
- [ ] Invoke `new-guide` with a new how-to request — How-to page contract loaded; first useful example within 120 words
- [ ] JSON syntax valid for both eval files: `python -c "import json; json.load(open('packs/user-guide-diataxis/.apm/skills/new-guide/evals/evals.json'))"` exits 0
- [ ] Three-copy parity: `diff packs/user-guide-diataxis/.apm/skills/new-guide/SKILL.md .claude/skills/new-guide/SKILL.md` empty