### PR TITLE
docs(atlassian): rename Atlas→Acme; fix code block scroll

### DIFF
--- a/docs/guides/atlassian/how-to/work-with-jira.md
+++ b/docs/guides/atlassian/how-to/work-with-jira.md
@@ -24,7 +24,7 @@ only writes to Jira after you approve the exact change.
 **YOU SAY**
 
 ```
-Show me the whole Atlas team backlog across APP and API.
+Show me the whole Acme team backlog across APP and API.
 
 Include the current sprint, open backlog, unassigned work, and blocked issues.
 Group everything into:
@@ -40,7 +40,7 @@ Do not change Jira.
 
 **WHAT HAPPENS**
 
-The agent checks Jira credentials, resolves the Atlas team scope (it may ask
+The agent checks Jira credentials, resolves the Acme team scope (it may ask
 which scope to use if two match — board or team field), then reads all open issues
 across APP and API. Read-only. Scope and coverage are disclosed.
 
@@ -53,16 +53,13 @@ Example:
 
 ```
 Scope: APP and API · Sprint 24 + open backlog · 12 issues (complete result)
-─────────────────────────────────────────────────────
 Ready to pull: 3 · Needs story work: 3 · Blocked: 2 · In progress: 2
-─────────────────────────────────────────────────────
 Top 5 to discuss:
 1. APP-203  Add rate limiting to API gateway       Ready to pull · Standard
 2. API-98   Paginate GET /users endpoint            Ready to pull · Quick
 3. APP-206  Improve performance                     Needs story work
 4. APP-215  Migrate auth service                    Blocked — security review
 5. API-104  Fix search results                      Needs story work
-─────────────────────────────────────────────────────
 APP-220, API-107 unassigned — no sprint assigned.
 Jira was not changed.
 ```
@@ -80,7 +77,7 @@ Take the items that need story work and show me why each fails.
 **YOU SAY**
 
 ```
-What can the Atlas team pick up next in APP and API?
+What can the Acme team pick up next in APP and API?
 ```
 
 **SCOPE ASSUMPTIONS**
@@ -115,7 +112,7 @@ Show me the Quick items with no assignee.
 **YOU SAY**
 
 ```
-What is blocked in the Atlas backlog?
+What is blocked in the Acme backlog?
 What items haven't been updated this week?
 ```
 
@@ -216,7 +213,6 @@ Issues to update:  APP-206, APP-219, API-104
 Field to change:   description
 Protected fields:  status, assignee, priority, sprint, labels
 Total writes:      3
-─────────────────────────────────────────────────────
 [Cancel]   [Apply all three]
 ```
 
@@ -231,10 +227,10 @@ with a retry path.
 **YOU SAY**
 
 ```
-Give me a stand-up summary for the Atlas team.
+Give me a stand-up summary for the Acme team.
 Include progress, blockers, risks, and what is ready next.
 
-Then prepare a concise weekly version suitable for the Atlas Confluence space.
+Then prepare a concise weekly version suitable for the Acme Confluence space.
 Do not publish until I approve it.
 ```
 

--- a/docs/guides/atlassian/reference/atlassian-skills.md
+++ b/docs/guides/atlassian/reference/atlassian-skills.md
@@ -52,9 +52,9 @@ next, what is blocked, what is unassigned, and a stand-up or sprint summary.
 
 **Natural requests**
 
-- "What can the Atlas team pick up next in APP and API?"
+- "What can the Acme team pick up next in APP and API?"
 - "Give me a team status for stand-up."
-- "Show me the whole Atlas team backlog — current sprint, open backlog, unassigned, and blocked."
+- "Show me the whole Acme team backlog — current sprint, open backlog, unassigned, and blocked."
 - "What's blocked in APP this week?"
 
 **Required scope**
@@ -336,7 +336,7 @@ engineering brief.
 **Natural requests**
 
 - "Turn APP-epic-42 into a product brief."
-- "Pull the Atlas board sprint into a brief."
+- "Pull the Acme board sprint into a brief."
 
 **Required scope**
 

--- a/docs/guides/atlassian/tutorials/review-your-team-backlog.md
+++ b/docs/guides/atlassian/tutorials/review-your-team-backlog.md
@@ -1,6 +1,6 @@
 # Review your team's Jira backlog from start to finish
 
-**What you'll do:** Ask the agent to show you everything the Atlas team has in their
+**What you'll do:** Ask the agent to show you everything the Acme team has in their
 Jira backlog, identify what's ready to pick up and what needs work, draft story
 improvements, approve three targeted Jira updates, and prepare a stand-up summary.
 
@@ -18,9 +18,7 @@ means you're ready.
 
 ## Progress
 
-```
-1. See the work   →   2. Improve weak stories   →   3. Apply approved changes   →   4. Share the result
-```
+1. See the work → 2. Improve weak stories → 3. Apply approved changes → 4. Share the result
 
 This tutorial walks all four stages once, in order.
 
@@ -47,7 +45,7 @@ For the full credential model, see [Credentialed skills](../../credential-broker
 
 ## Stage 1 — See the work
 
-**Goal:** get a complete, read-only snapshot of everything the Atlas team has
+**Goal:** get a complete, read-only snapshot of everything the Acme team has
 across APP and API.
 
 ### Step 1.1 — The opening request
@@ -55,7 +53,7 @@ across APP and API.
 Say this to your agent:
 
 ```
-Show me the whole Atlas team backlog across APP and API.
+Show me the whole Acme team backlog across APP and API.
 
 Include the current sprint, open backlog, unassigned work, and blocked issues.
 Group everything into:
@@ -73,14 +71,14 @@ Do not change Jira.
 
 When two matching scopes exist, the agent asks before proceeding:
 
-> "I found two possible Atlas scopes:
+> "I found two possible Acme scopes:
 >
-> 1. The Atlas Jira board
-> 2. Issues whose Team field is Atlas
+> 1. The Acme Jira board
+> 2. Issues whose Team field is Acme
 >
 > Which should I use?"
 
-Reply with your preference. If you don't have a Team field configured, say "the Atlas board."
+Reply with your preference. If you don't have a Team field configured, say "the Acme board."
 
 ### Step 1.3 — What you receive
 
@@ -90,13 +88,11 @@ The agent returns a **summary**, not a raw issue dump:
 Scope searched:    APP and API, current sprint (Sprint 24) + open backlog
 Time horizon:      Sprint 24 (active) + all open backlog items
 Issues inspected:  12 issues — complete result, no truncation
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Ready to pull:     3
 Needs story work:  3
 Blocked:           2
 In progress:       2
 Unassigned:        2
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Top 5 candidates for team discussion:
 
 1. APP-203 — Add rate limiting to API gateway (Ready to pull · Standard)
@@ -162,7 +158,6 @@ One block per issue, draft only:
 
 ```
 APP-206 — "Improve performance"
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 What is missing:   Q2 — no service or file scope. Q3 — no metric or baseline.
 Why it prevents action: An engineer can't locate the change or know when done.
 Proposed improvement:
@@ -176,7 +171,6 @@ Ready after change?   Yes — all five questions would pass.
 Jira not changed.
 
 APP-219 — "SSO changes for new IdP"
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 What is missing:   Q2 — no service or config path. Q3 — no ACs. Q4 — open
                    design question: which IdP fields to map.
 Why it prevents action: An engineer doesn't know what to change or how to
@@ -192,14 +186,13 @@ Ready after change?   Gated — passes once PO confirms tenant ID.
 Jira not changed.
 
 API-104 — "Fix search results"
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 What is missing:   Q2 — no endpoint or file. Q3 — "fixed" is not checkable.
 Why it prevents action: "Fix" says nothing actionable about the expected
                         behavior or scope.
 Proposed improvement:
   "GET /api/search?q= returns results ranked by title-match score first,
   then recency. Scope: api/search.py and tests. ACs: query 'atlas' returns
-  Atlas project first; empty query returns 400; tests cover ranking and
+  Acme project first; empty query returns 400; tests cover ranking and
   edge cases."
 Unresolved question:  None — ranking behavior is derivable from existing
                        documentation.
@@ -232,13 +225,11 @@ Before anything is written, the agent shows you exactly what will change:
 
 ```
 Write confirmation — review before applying
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Issues to update:    APP-206, APP-219, API-104
 Field to change:     description (and acceptance criteria sub-field)
 Fields protected:    status, assignee, priority, sprint, labels,
                      issuetype — none of these change
 Total writes:        3 (one update-issue call per issue)
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 [Cancel]   [Apply all three]
 ```
 
@@ -249,13 +240,11 @@ Total writes:        3 (one update-issue call per issue)
 
 ```
 Result
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Changed:   APP-206 (description updated)
            APP-219 (description updated — Gated; remind PO to confirm tenant ID)
            API-104 (description updated)
 Unchanged: All other issues in APP and API
 Links:     APP-206 · APP-219 · API-104
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
 **Failure handling:** If one write fails (a 409 conflict or a permission error),
@@ -273,19 +262,18 @@ publishing until you say so.
 ### Step 4.1 — Stand-up summary
 
 ```
-Give me a stand-up summary for the Atlas team.
+Give me a stand-up summary for the Acme team.
 
 Include progress, blockers, risks, and what is ready next.
 
-Then prepare a concise weekly version suitable for the Atlas Confluence space.
+Then prepare a concise weekly version suitable for the Acme Confluence space.
 Do not publish until I approve it.
 ```
 
 ### Step 4.2 — What you receive
 
 ```
-Atlas team stand-up — Sprint 24
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Acme team stand-up — Sprint 24
 In progress:  APP-198 (OAuth token refresh), API-92 (Webhook retry)
 Completed:    —
 Ready next:   APP-203 (rate limiting), APP-211 (error messages), API-98 (pagination)
@@ -294,11 +282,8 @@ Risks:        APP-219 — needs PO to confirm Okta tenant ID before starting
 Notes:        3 stories updated this session (APP-206, APP-219, API-104).
               APP-220 and API-107 unassigned — team to triage.
 
-───
-
-Atlas weekly update (draft — not published)
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-This week, the Atlas team progressed OAuth token refresh (APP-198) and webhook
+Acme weekly update (draft — not published)
+This week, the Acme team progressed OAuth token refresh (APP-198) and webhook
 delivery retry (API-92). Three backlog stories were sharpened to be ready for
 engineering. Three items are ready to pull next sprint: rate limiting, error
 message standardisation, and user endpoint pagination. One item (APP-215) is
@@ -314,7 +299,7 @@ The agent will not publish automatically.
 
 ## What you built
 
-You walked the complete Atlas team backlog from end to end:
+You walked the complete Acme team backlog from end to end:
 
 - Oriented to the full backlog state without changing anything
 - Applied the five-question bar to surface exactly what was missing

--- a/docs/specs/atlassian-docs-retrofit/spec.md
+++ b/docs/specs/atlassian-docs-retrofit/spec.md
@@ -29,7 +29,7 @@ writes, and communicate the result.
 - [x] AC12. Journey page presents four connected stages before generated skill cards.
 - [x] AC13. Reference page provides exact inputs, reads, writes, outputs, limits, coverage, and approval behavior.
 - [x] AC14. Explanation page teaches workflow composition without repeating a procedural guide.
-- [x] AC15. Six pages use consistent terminology, sample data (Team Atlas), and visual states.
+- [x] AC15. Six pages use consistent terminology, sample data (Team Acme), and visual states.
 - [x] AC16. MkDocs and Astro surfaces feel like parts of the same product.
 - [x] AC17. Public URLs and links remain valid.
 - [x] AC18. Tutorial is added to MkDocs nav.
@@ -46,7 +46,7 @@ writes, and communicate the result.
 
 ## Shared example dataset
 
-Team: Atlas · Projects: APP and API · Sprint 24
+Team: Acme · Projects: APP and API · Sprint 24
 - Ready to pull (3): APP-203, APP-211, API-98
 - In progress (2): APP-198, API-92
 - Needs story work (3): APP-206, APP-219, API-104

--- a/web/src/content/journeys/atlassian.md
+++ b/web/src/content/journeys/atlassian.md
@@ -110,8 +110,8 @@ goodOutputDescription: "A grouped backlog summary showing 12 issues across APP a
 
 ### 1. See the work
 
-- **You say:** "Show me the whole Atlas team backlog across APP and API. Include the current sprint, open backlog, unassigned work, and blocked issues. Group everything into ready to pull, needs story work, blocked, in progress. Do not change Jira."
-- **Agent does:** Checks credentials. Resolves scope — if two Atlas scopes exist (board and team field), asks which to use. Reads all open issues across APP and API. Discloses scope searched, time horizon, issue count, and whether the result is complete or filtered.
+- **You say:** "Show me the whole Acme team backlog across APP and API. Include the current sprint, open backlog, unassigned work, and blocked issues. Group everything into ready to pull, needs story work, blocked, in progress. Do not change Jira."
+- **Agent does:** Checks credentials. Resolves scope — if two Acme scopes exist (board and team field), asks which to use. Reads all open issues across APP and API. Discloses scope searched, time horizon, issue count, and whether the result is complete or filtered.
 - **You get:** A summary: 12 issues inspected, 3 ready to pull, 3 needs story work, 2 blocked, 2 in progress, 2 unassigned. Top 5 candidates listed with readiness state. Jira not changed.
 - **You decide:** Does the ready count look right? If an item is missing or mislabelled, ask why — the agent will explain what signal it couldn't read.
 
@@ -137,7 +137,7 @@ goodOutputDescription: "A grouped backlog summary showing 12 issues across APP a
 
 ### 4. Share the result
 
-- **You say:** "Give me a stand-up summary for the Atlas team. Include progress, blockers, risks, and what is ready next. Then prepare a concise weekly version suitable for the Atlas Confluence space. Do not publish until I approve it."
+- **You say:** "Give me a stand-up summary for the Acme team. Include progress, blockers, risks, and what is ready next. Then prepare a concise weekly version suitable for the Acme Confluence space. Do not publish until I approve it."
 - **Agent does:** Produces a stand-up block (in-progress, ready, blocked, risks) and a Confluence draft. Does not publish.
 - **You get:** A stand-up summary and a Confluence draft to review. The draft shows the target page and space.
 - **You decide:** Review the Confluence draft. When satisfied, say "Publish." The agent will not publish without your instruction.

--- a/web/src/content/packs/atlassian.md
+++ b/web/src/content/packs/atlassian.md
@@ -30,7 +30,7 @@ names.
 ### Try this first
 
 ```
-Show me the whole Atlas team backlog across APP and API.
+Show me the whole Acme team backlog across APP and API.
 Include the current sprint, open backlog, unassigned work, and blocked issues.
 Group everything into ready to pull · needs story work · blocked · in progress.
 Do not change Jira.
@@ -61,7 +61,7 @@ Jira was not changed.
 Ask for the whole backlog, a sprint status, what's blocked, or what's unassigned.
 The agent reads Jira and returns a grouped summary. Nothing is written.
 
-> "What can the Atlas team pick up next?"
+> "What can the Acme team pick up next?"
 > "What is blocked in APP?"
 > "What's sitting unassigned this sprint?"
 


### PR DESCRIPTION
## Summary

- Renames the fictional example team from **Atlas** to **Acme** across all six Atlassian guide pages (tutorial, how-to, reference, journey, pack, spec)
- Removes long `━━━━` and `─────` separator lines from code blocks in the tutorial and how-to — these caused horizontal scroll on the center text blocks in the rendered guides

## Files changed

- `docs/guides/atlassian/tutorials/review-your-team-backlog.md`
- `docs/guides/atlassian/how-to/work-with-jira.md`
- `docs/guides/atlassian/reference/atlassian-skills.md`
- `web/src/content/packs/atlassian.md`
- `web/src/content/journeys/atlassian.md`
- `docs/specs/atlassian-docs-retrofit/spec.md`

## Note on git history

The previous PR (#642) introduced the `Atlas` team name in commits already on `main`. This PR fixes the content going forward. If you also want to rewrite the history of those commits on `main` to never have contained `Atlas`, that requires a force-push to `main` — confirm and I'll do it.