### PR TITLE
fix(atlassian): repair broken links, missing nav entries, and mobile scroll

### DIFF
--- a/docs/guides/atlassian/explanation/ai-adoption-measurement.md
+++ b/docs/guides/atlassian/explanation/ai-adoption-measurement.md
@@ -57,7 +57,7 @@ Understanding the limits is part of understanding the model:
 
 - **Code quality.** Test coverage, cyclomatic complexity, static-analysis findings — use your CI quality gates for these. They're not in Jira changelogs.
 
-- **Adoption breadth at enterprise scale, in a single command.** `flow-metrics` runs one scope at a time. Measuring 100 teams requires 100 invocations. The `program` mode of `ai-adoption-report` handles the rollup, but the data collection step must be scripted at that scale. See [Report AI adoption as a delivery lead](../how-to/report-ai-adoption-as-a-delivery-lead.md#roll-up-to-program--value-stream-level) for the scripted pattern.
+- **Adoption breadth at enterprise scale, in a single command.** `flow-metrics` runs one scope at a time. Measuring 100 teams requires 100 invocations. The `program` mode of `ai-adoption-report` handles the rollup, but the data collection step must be scripted at that scale. See [Report AI adoption as a delivery lead](../how-to/report-ai-adoption-as-a-delivery-lead.md#roll-up-to-program-value-stream-level) for the scripted pattern.
 
 - **Real-time or live metrics.** Each run is a point-in-time snapshot with a defined window. There is no streaming or live-dashboard mode.
 

--- a/site/AGENTS.md
+++ b/site/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS.md — `site/` (MkDocs documentation site)
+
+The documentation site served at `/docs/`, built with MkDocs Material.
+Source files live in `docs/guides/` at the repo root; `make site-sync`
+copies them to `site/docs/` before the build.
+
+## Mobile viewport
+
+MkDocs Material handles responsive layout automatically. Do not add a custom
+viewport meta — the theme owns it.
+
+**What to verify on every change:** Open the rendered page at a 375 px width
+(browser dev-tools device emulation) and confirm no code block or table causes
+horizontal scroll of the page body. Code blocks scroll internally — that is
+intentional and correct.
+
+## Broken links
+
+Run `mkdocs build --strict --config-file site/mkdocs.yml` (or `make build-check`)
+before committing. In strict mode, any broken link or unresolved anchor is a
+build error.
+
+**Anchor slugging rule.** MkDocs slugifies headings by stripping non-word
+characters and collapsing whitespace/hyphens into a single `-`. The heading
+`## Roll up to program / value stream level` becomes
+`#roll-up-to-program-value-stream-level` (single hyphen around `/`), not
+`#roll-up-to-program--value-stream-level` (double hyphen). Verify anchors
+against the actual heading text before linking.
+
+## Navigation cohesion
+
+Every file under `docs/guides/<pack>/` must appear in the `nav:` section of
+`site/mkdocs.yml`. Files missing from nav are reachable by direct URL but are
+not discoverable through navigation — treat that as a broken surface.
+
+When adding a guide file, add a nav entry in the same PR.

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -252,10 +252,12 @@ nav:
         - Authenticate with SSO: guides/atlassian/how-to/authenticate-jira-confluence-with-sso-cookies.md
         - Crawl Confluence: guides/atlassian/how-to/crawl-and-publish-confluence.md
         - DORA Metrics: guides/atlassian/how-to/measure-flow-and-dora-metrics.md
+        - Report AI Adoption: guides/atlassian/how-to/report-ai-adoption-as-a-delivery-lead.md
       - Reference:
         - Atlassian Skills: guides/atlassian/reference/atlassian-skills.md
       - Explanation:
         - The Atlassian Pack: guides/atlassian/explanation/atlassian-pack.md
+        - Measuring AI Adoption: guides/atlassian/explanation/ai-adoption-measurement.md
     - Figma:
       - guides/figma/README.md
       - How-to:

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -40,6 +40,33 @@ astro dev --background
 
 Manage the background server with `astro dev stop`, `astro dev status`, and `astro dev logs`.
 
+## Mobile viewport
+
+The viewport meta tag (`width=device-width, initial-scale=1`) is set in
+`src/components/layout/SiteLayout.astro`. Do not add it elsewhere or duplicate it.
+
+**What to verify on every change:** check that no element causes horizontal
+scroll of the page body at 375 px width. Code blocks inside `<Content />`
+rendered markdown use the base `pre { overflow-x: auto }` rule — they scroll
+internally, not the page.
+
+## Links in markdown content
+
+Links inside markdown files rendered via `<Content />` (pack and journey bodies)
+**cannot** use Astro's `withBase()` — they are plain HTML after rendering.
+
+- Use **relative paths** for cross-site links (e.g., `../../docs/guides/atlassian/`).
+- Absolute paths starting with `/` are resolved against the origin root, not the
+  subpath base (`/agent-ready-repo`), and will 404 on GitHub Pages.
+- The `docsUrl` and `journeyUrl` frontmatter fields are the canonical navigation
+  entry points and are already processed through `withBase()` by the template.
+
+## Navigation cohesion
+
+Every pack that has documentation must set `docsUrl` in its frontmatter. Every
+pack with a journey narrative must set `journeyUrl`. These are the two navigation
+entry points the pack template exposes; leave neither empty if the content exists.
+
 ## Documentation
 
 Full documentation: https://docs.astro.build

--- a/web/src/content/packs/atlassian.md
+++ b/web/src/content/packs/atlassian.md
@@ -40,16 +40,13 @@ What you'll get:
 
 ```
 Scope: APP and API · Sprint 24 + open backlog · 12 issues (complete)
-───────────────────────────────────────────────────────
 Ready to pull: 3  ·  Needs story work: 3  ·  Blocked: 2  ·  In progress: 2
-───────────────────────────────────────────────────────
 Top 5 to discuss:
  APP-203  Add rate limiting to API gateway       Ready · Standard
  API-98   Paginate GET /users endpoint            Ready · Quick
  APP-206  Improve performance                     Needs story work
  APP-215  Migrate auth service                    Blocked — security review
  API-104  Fix search results                      Needs story work
-───────────────────────────────────────────────────────
 Jira was not changed.
 ```
 
@@ -113,4 +110,4 @@ always read-only.
 ### Skills included — under the hood
 
 The skills below activate from natural-language requests. You don't need to name
-them to use them. See the [skills reference](/docs/guides/atlassian/reference/atlassian-skills/) for exact contracts and limits.
+them to use them. See the [skills reference](../../docs/guides/atlassian/reference/atlassian-skills/) for exact contracts and limits.

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -86,6 +86,10 @@ pre {
   line-height: var(--ds-lead-mono);
 }
 
+pre {
+  overflow-x: auto;
+}
+
 img,
 picture,
 svg {


### PR DESCRIPTION
## Summary

- **Broken anchor** in `ai-adoption-measurement.md` — double hyphen `#roll-up-to-program--value-stream-level` → single hyphen (MkDocs slugify collapses ` / ` to one `-`)
- **Missing nav entries** in `site/mkdocs.yml` — `report-ai-adoption-as-a-delivery-lead.md` and `ai-adoption-measurement.md` now listed under How-to and Explanation
- **Broken absolute link** in pack content (`/docs/guides/…`) — changed to relative path; absolute paths in `<Content />` body can't use `withBase()` and 404 on GitHub Pages
- **Horizontal scroll** in pack code block — removed `───` separator lines (same fix applied to docs guides last PR); added `pre { overflow-x: auto }` to `web/src/styles/base.css` so wide code blocks scroll internally rather than causing page scroll on mobile
- **AGENTS.md** — created `site/AGENTS.md`; extended `web/AGENTS.md` with mobile viewport, link, and nav cohesion rules

## Test plan

- [x] `make build-check` passes locally (exit 0)
- [ ] CI build (Astro + MkDocs strict) passes
- [ ] MkDocs nav includes both new Atlassian How-to and Explanation pages
- [ ] Pack page skills reference link resolves correctly on GitHub Pages
- [ ] No horizontal page scroll on Atlassian pack page at 375 px width