### PR TITLE
feat(core): frontend-engineering doctrine update — four modes, 18 states, WCAG 2.2 AA, CWV targets (0.14.0)

### DIFF
--- a/.agents/skills/frontend-engineering/SKILL.md
+++ b/.agents/skills/frontend-engineering/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-engineering
-description: Load when a task's primary output is HTML, CSS, or JS. Provides design pre-flight, codified craft rules, and GATES verification commands for that surface.
+description: Load when a task's primary output is HTML, CSS, or JS. Provides design pre-flight, codified craft rules, GATES verification commands, and an evidence manifest for that surface. Four modes — create (new surface), retrofit (improving existing), audit (review only), verify (run gates and manifest).
 ---
 
 # Skill: frontend-engineering
@@ -12,10 +12,24 @@ token block, state matrix), the craft rules that govern EXECUTE, and the GATES
 verification commands. It is not needed for incidental HTML edits to an existing
 surface already covered by a grounded aesthetic reference.
 
-## PLAN phase — Design Pre-flight
+## Mode selection
 
-Complete all four steps before writing any code. These are not suggestions;
-they are the contract for greenfield frontend work.
+Before starting, select the mode that matches the work:
+
+| Mode | When to use | Required outputs |
+|---|---|---|
+| **create** | Building a new surface or significant new component | Page/screen contract (proportional to risk), evidence manifest |
+| **retrofit** | Improving or extending an existing surface | Brownfield inspection, evidence manifest |
+| **audit** | Reviewing an existing surface without writing code | Audit report |
+| **verify** | Running the full gate suite on a completed surface | Evidence manifest |
+
+Proceed to the shared pre-flight (PLAN phase) regardless of mode. Mode-specific steps follow the shared pre-flight and the state matrix.
+
+---
+
+## PLAN phase — Shared Pre-flight (all modes)
+
+Complete all four steps before writing any code (create/retrofit) or running any gates (audit/verify). These are the shared foundation for all modes.
 
 ### 1. Named aesthetic reference
 
@@ -180,19 +194,139 @@ missing-state branches without explicit enumeration. A 2025 study of
 50 AI-generated dashboards found 92% had no empty state and 78% had no
 error state.
 
-| State | Wrong | Right |
-|---|---|---|
-| **Loading** | Generic spinner | Skeleton screen matching the final layout (use spinner only when shape is unknown); add `aria-busy="true"` and `aria-label="Loading <thing>"` to the skeleton container |
-| **Empty** | Blank space | Illustration or icon + label describing the empty condition + primary CTA |
-| **Error** | Clear prior content; show only the error | Preserve prior content; show inline error message + retry affordance |
-| **Partial** | No indication more data exists | Pagination or load-more with a record count |
-| **Disabled** | Hide the element | Render it disabled with `aria-disabled="true"` and a tooltip or label explaining why |
-| **Content** | — | The normal loaded state — spec this too so the skeleton shape is known |
+The canonical 18-state set for this skill, aligned with the XD quality-floor:
+
+| State | Treatment |
+|---|---|
+| loading | Skeleton screen matching the final layout (use spinner only when shape is unknown); add `aria-busy="true"` and `aria-label="Loading <thing>"` to the skeleton container |
+| empty | Illustration or icon + label describing the empty condition + primary CTA |
+| error | Preserve prior content; show inline error message + retry affordance |
+| partial | Pagination or load-more with a record count; mark missing segments clearly |
+| disabled | Render it disabled with `aria-disabled="true"` and a tooltip or label explaining why |
+| content | The normal loaded state — spec this too so the skeleton shape is known |
+| success | Action completed: confirm visibly and proportionately (subtle toast for low-stakes; prominent banner for high-stakes) |
+| first-run | Never had data — orient the user and invite the first meaningful action; do not show the generic empty state |
+| no-results | A filter or search emptied the set — show what query was applied and how to recover |
+| permission/denied | Unauthorized or locked view: show a read-only or locked state with a recoverable note (who can act, how to request access); never a blank screen |
+| offline | Network unavailable — show cached content where possible; provide a manual retry; indicate stale status |
+| blocked | Action cannot proceed due to an external dependency or policy — name the blocker and the resolution path |
+| destructive-confirmation | Action has irreversible consequences — require explicit confirmation with a clear statement of what will be destroyed; provide a safe default (cancel) |
+| long-content | Content significantly longer than typical — offer progressive disclosure, a table of contents, or pagination |
+| large-data-set | Query returns more records than the UI can show — implement virtual scrolling, pagination, or sampling; never slice silently |
+| high-zoom | Surface used at 200–400% zoom — test that text reflows, controls remain operable, and no horizontal scrolling is required |
+| reduced-motion | User has requested reduced motion — all animations replaced with instant or cross-fade transitions; no sliding, scaling, or spinning |
+| keyboard-only | All interactions reachable and completable via keyboard alone — no pointer dependency; logical tab order; visible focus indicators at all times |
 
 **Skeleton vs spinner rule:** use a skeleton when the content shape is
 predictable (table rows, card grids, profile cards). The skeleton must
 match the final layout so there is no layout shift on load. Use a spinner
 only when shape is genuinely unknown.
+
+Not all states apply to every surface — omit states that are genuinely inapplicable and note why in the spec.
+
+---
+
+### Mode: create
+
+Use when building a new surface or significant new component.
+
+#### Step 0. Page/screen contract (required before significant UI code)
+
+Before writing HTML for a new page or significant surface, fill the
+page/screen contract. This contract is proportional to risk and scope — a
+new route, a key onboarding surface, or a feature-gating screen warrants
+the full 12-field contract. A single new form field, a tooltip, or a minor
+component variant does not.
+
+**Page/screen contract template (12 fields):**
+
+| Field | What to specify |
+|---|---|
+| target user | The specific user type or persona this surface serves |
+| primary job | The one job the user comes here to complete |
+| primary action | The single most important action available on this surface |
+| expected result | What the user sees/has after completing the primary action |
+| next action | What the user does after the primary action is complete |
+| first-screen content | What must be visible above the fold without scrolling |
+| product proof | The value signal (stat, social proof, outcome indicator) present above the fold |
+| read/write consequence | Whether the primary action reads or mutates data; what happens on error |
+| critical states | Which of the 18 states this surface must handle (minimum: loading, empty or first-run, error, content) |
+| responsive behavior | How layout adapts across breakpoints; what collapses, reorders, or hides |
+| a11y requirements | WCAG 2.2 AA — note any state-specific requirements (focus management, live regions) |
+| measurement event | The analytics event that fires on primary action completion |
+
+Record the completed contract in the spec before writing HTML.
+
+#### Steps 1–3. Proceed through the shared PLAN phase pre-flight
+
+Run steps 1, 1b, 2, and 3 from the shared pre-flight above (aesthetic reference, genre routing, seed tokens, state matrix).
+
+#### EXECUTE and GATES
+
+Proceed to the EXECUTE phase (Craft Rules) and GATES phase below. Produce an evidence manifest at completion.
+
+---
+
+### Mode: retrofit
+
+Use when improving or extending an existing surface without building from scratch.
+
+#### Step 1. Brownfield inspection checklist
+
+Before touching any code, run this inspection against the existing surface. Record findings for each item:
+
+| Item | What to inspect |
+|---|---|
+| what-to-preserve | What currently works well and must not regress — visual patterns users rely on, established keyboard flows, screen-reader compatibility |
+| duplicated-systems | Parallel implementations of the same component, token, or logic that this change could consolidate or that it must not fork further |
+| hard-coded values | CSS values that should be design tokens (`#5e6ad2`, `margin: 13px`) — note them for opportunistic migration |
+| a11y-debt | Accessibility failures already present — note which ones this change must not worsen, and which it can address as a ride-along |
+| responsive-debt | Viewport breakpoints that fail at current state — note which this change must not worsen |
+| visual-regression-risk | Downstream components or pages that share styling with the modified surface and could be visually affected |
+
+#### Step 2. Proceed through the shared PLAN phase pre-flight
+
+Run steps 1, 1b, 2, and 3 from the shared pre-flight (aesthetic reference, genre routing, seed tokens, state matrix). For retrofit work, focus the state matrix on states that are absent or broken — not a full re-enumeration unless the surface is substantially rebuilt.
+
+#### EXECUTE and GATES
+
+Proceed to the EXECUTE phase (Craft Rules) and GATES phase below. Produce an evidence manifest at completion.
+
+---
+
+### Mode: audit
+
+Use when reviewing an existing surface without writing code. The output is a structured audit report, not code.
+
+#### Audit procedure
+
+1. **Run the state matrix audit.** Compare the surface against all 18 states in the state matrix. For each applicable state, mark: Covered / Absent / Broken. Note the specific issue for Absent and Broken.
+2. **Run the accessibility audit.** Check against WCAG 2.2 AA. Use the GATES accessibility tools (pa11y or axe-core). Note which WCAG 2.2 success criteria require manual verification because tooling caps at wcag21aa.
+3. **Check the CWV targets.** Measure or estimate LCP ≤2.5s / INP ≤200ms / CLS ≤0.1 at p75 (mobile and desktop separately where field data exists). Note any category over budget.
+4. **Run the brownfield inspection checklist.** Use the same 6-item checklist from retrofit mode.
+
+#### Audit report format
+
+Return findings as a prioritised list with severity (Blocker / Major / Minor / Note). Each finding maps to the state, criterion, or checklist item it violates, with one concrete recommendation.
+
+Record findings in the evidence manifest under `known exceptions` and `unverified items`.
+
+---
+
+### Mode: verify
+
+Use when a completed surface needs gates run and an evidence manifest generated.
+
+#### Verification procedure
+
+Run the full GATES suite in order:
+
+1. **Structural HTML validation** (GATES phase step 1)
+2. **Accessibility audit** (GATES phase step 2) — note that WCAG 2.2 AA is our declared baseline; the tooling caps at wcag21aa; two success criteria require manual verification: 2.4.11 Focus Appearance and 2.5.8 Target Size Minimum
+3. **CSS token enforcement** (GATES phase step 3, if stylelint is configured)
+4. **Visual QA checklist** (GATES phase step 4) — confirm all 18 applicable states are present
+
+After running all four gates, generate the evidence manifest (see Evidence manifest section below) with the results.
 
 ---
 
@@ -263,6 +397,10 @@ the specific forms below are.
 - WRONG: `outline: none` / RIGHT: replace with a visible alternative — `outline: 2px solid var(--ds-color-primary); outline-offset: 2px` or a `box-shadow` equivalent
 
 ### Accessibility rules
+
+**Default baseline: WCAG 2.2 AA.** WCAG 2.2 AA is our baseline — it exceeds the WCAG 2.1 minimum currently cited by EU EAA, ADA, and AODA. Two success criteria are new in 2.2 and require manual verification because automated tooling (pa11y/axe-core) caps at wcag21aa: **2.4.11 Focus Appearance** (visible focus indicator with sufficient size and contrast) and **2.5.8 Target Size Minimum** (interactive targets ≥24×24 CSS pixels). Mark these explicitly in the evidence manifest under `a11y result`.
+
+**Browser policy: Baseline Widely Available.** Target only features in the Baseline Widely Available set (features shipping in all major browsers for at least 30 months). Check baseline status at web.dev/baseline before using any feature not in the baseline set.
 
 #### ARIA discipline
 
@@ -380,9 +518,7 @@ npx axe "file:///$(pwd)/file.html" \
   --chrome-options="no-sandbox,disable-setuid-sandbox,disable-dev-shm-usage"
 ```
 
-Note: neither tool currently supports WCAG 2.2 tags — `wcag21aa` is the
-current ceiling. Chromium runs fully headless; no `DISPLAY` environment
-variable is required.
+Note: tooling currently caps at `wcag21aa` — WCAG 2.2 AA is our declared baseline (it exceeds the wcag21aa minimum). Two WCAG 2.2-only success criteria require **manual verification**: **2.4.11 Focus Appearance** and **2.5.8 Target Size Minimum**. Record the manual-check outcome in the evidence manifest under `a11y result`.
 
 ### 3. CSS token enforcement (optional — run if stylelint is already configured)
 
@@ -405,10 +541,88 @@ Install: `npm install --save-dev stylelint stylelint-declaration-strict-value`
 
 ### 4. Visual QA checklist (agent-executable, no tooling)
 
-- [ ] All state variants present in the HTML (loading / empty / error / partial / content / disabled) — not just the happy path
+- [ ] All applicable states from the 18-state matrix are present in the HTML — not just the happy path; check each applicable state by reading the HTML
 - [ ] No hardcoded colour or spacing values outside the token-definition block — grep: `grep -E "#[0-9a-fA-F]{3,6}|rgba?\(|hsl\(|[0-9]+px" <file.css>` should return only the `:root` / primitive token-definition block, no other hex, rgb, or px values
 - [ ] Print output correct: if PPT/PDF context, open in browser and trigger print preview — check slide boundaries, colour preservation, no overflow
 - [ ] Screenshot taken and observed: Playwright headless (`page.screenshot()`) or browser devtools screenshot — assert on what you see, not on internal state
+
+---
+
+## Performance targets
+
+### Core Web Vitals (CWV)
+
+Targets at p75, evaluated separately for mobile and desktop where field data exists:
+
+| Metric | Target | What it measures |
+|---|---|---|
+| LCP (Largest Contentful Paint) | ≤2.5s | Perceived load speed — when the main content appears |
+| INP (Interaction to Next Paint) | ≤200ms | Responsiveness — how fast the page responds to interactions |
+| CLS (Cumulative Layout Shift) | ≤0.1 | Visual stability — how much content moves unexpectedly |
+
+Measure using Lighthouse, Chrome DevTools Performance panel, or WebPageTest.
+
+### Asset budgets
+
+Enforce these per route. The seven asset budget categories to track are: JS budget (JavaScript parse+execute per route), images budget (total image payload per route), fonts (web font files transferred), third-party scripts (analytics, tags, widgets), hydration (client-side hydration cost for SSR/islands), route-level loading (per-route code-split chunks), and long tasks (main-thread tasks blocking >50ms).
+
+| Budget category | What to measure | Notes |
+|---|---|---|
+| JS (JavaScript) | Total JavaScript transferred and parsed per route | Prioritise code-splitting; defer non-critical bundles |
+| images | Total image payload per route | Use modern formats (WebP/AVIF); serve appropriate sizes via `srcset` |
+| fonts | Web font files transferred | Self-host; `font-display: swap` or `optional`; subset aggressively |
+| third-party scripts | Analytics, tag managers, widgets | Audit regularly; defer or facade heavy embeds |
+| hydration | Client-side hydration cost (SSR / islands) | Islands architecture preferred; measure Time to Interactive delta |
+| route-level loading | Per-route code-split chunk sizes | Each route chunk should be independently cacheable |
+| long tasks | Main-thread tasks > 50ms | Use `scheduler.yield()` or `setTimeout` chunking to break up long tasks |
+
+---
+
+## Evidence manifest
+
+FE cannot claim completion (create or retrofit) or a passing gate run (verify) without an evidence manifest. The manifest is a structured record of what was tested and what was found.
+
+**Required fields (all 11 must be present):**
+
+| Field | What to record |
+|---|---|
+| routes | List of routes/URLs or file paths tested |
+| viewports | Viewport widths tested (e.g. 375px mobile, 768px tablet, 1280px desktop) |
+| browsers | Browsers or rendering engines tested (per Baseline Widely Available policy) |
+| states | Which of the 18 states were exercised during testing |
+| screenshots | Evidence of rendered states — filenames, Playwright capture, or devtools screenshots |
+| a11y result | Output of the accessibility gate (pa11y/axe-core); include manual-check outcome for WCAG 2.4.11 and 2.5.8 |
+| perf result | CWV measurement or Lighthouse score; include mobile and desktop values where available |
+| console/network result | No console errors; network requests match expected; no unexpected third-party calls |
+| analytics events | Confirmation of measurement events firing on primary action completion |
+| known exceptions | Documented, accepted gaps with rationale and owner — not a place to hide problems |
+| unverified items | Items that could not be verified in this session with reason (no Chromium, no network, etc.) |
+
+---
+
+## Conditional public-surface guidance
+
+*Applies only when the surface will be publicly indexed (marketing pages, documentation, product landing pages). Skip for internal tools, authenticated dashboards, and surfaces behind login.*
+
+For publicly indexed surfaces, add these items to the spec and verify them before merge:
+
+- **Metadata**: `<title>` (60 chars max), `<meta name="description">` (155 chars max), Open Graph tags (`og:title`, `og:description`, `og:image`) for link previews
+- **Canonical URLs**: `<link rel="canonical" href="…">` on every public page; avoid duplicate content from trailing slashes, `www` vs non-`www`, or protocol variants
+- **Sitemaps**: ensure the route is included in the sitemap or explicitly excluded; no orphaned pages
+- **Structured data**: appropriate schema.org type for the surface (`Article`, `Product`, `FAQPage`, `HowTo`) implemented as JSON-LD; validate at schema.org/validator
+- **Search indexing intent**: confirm `robots` meta or `X-Robots-Tag` header is set correctly — `index, follow` for pages that should rank; `noindex` for pagination, internal search results, thin pages
+
+---
+
+## Multi-surface shell contract
+
+*Applies when building or reviewing a product with multiple web surfaces (e.g. marketing site + web app + documentation site).*
+
+Multi-surface products must maintain coherence across surfaces. Apply these constraints regardless of which surface you are currently building:
+
+- **Shared tokens**: all surfaces draw from the same design token contract (same `--ds-*` custom property names, same primitive values, same semantic assignments). A surface that redefines shared tokens independently forks the product's visual identity.
+- **Navigation patterns**: primary navigation, breadcrumb, and footer patterns must be consistent across surfaces — same structure, same interaction model, same terminology for shared destinations.
+- **Consistent product terminology**: the names of features, entities, and actions must be the same across surfaces. Maintain a terminology list in the project and use it before naming anything.
 
 ---
 
@@ -416,7 +630,7 @@ Install: `npm install --save-dev stylelint stylelint-declaration-strict-value`
 
 | Rationalisation | Reality |
 |---|---|
-| "Accessibility is a nice-to-have for now" | It is a legal requirement in many jurisdictions (WCAG 2.1 AA is the baseline for EU EAA, ADA, and AODA compliance) and an engineering quality standard — not a feature |
+| "Accessibility is a nice-to-have for now" | WCAG 2.2 AA is our baseline — it exceeds the WCAG 2.1 minimum currently cited by EU EAA, ADA, and AODA — and it is an engineering quality standard, not a feature |
 | "We'll make it responsive later" | Retrofitting responsive design is 3× harder than building it from the start; skip this step only if the output is explicitly fixed-dimension (PPT/PDF) |
 | "This is just a prototype" | Prototypes become production code; the AI aesthetic baked in at prototype stage is the AI aesthetic shipped |
 | "The AI aesthetic is fine for now" | It signals low quality to every reviewer who sees it and anchors the design in a direction that is expensive to undo |
@@ -431,9 +645,11 @@ Install: `npm install --save-dev stylelint stylelint-declaration-strict-value`
 A reviewer should treat any of these as a blocker:
 
 - Inline `style="…"` attributes or arbitrary pixel values not on the spacing scale
-- Any state variant missing (empty, error, loading, partial) — check by reading the HTML, not by reasoning about the code
+- Any state from the applicable 18-state matrix missing from the implementation — check by reading the HTML, not by reasoning about the code
 - `outline: none` or `outline: 0` with no visible replacement focus style
 - Color used as the sole state indicator (red/green without accompanying text, icon, or pattern)
 - Generic AI aesthetic visible in the output (purple gradients, equal oversized padding, `border-radius: 16px` on every element, shadow on every card)
 - `aria-expanded`, `aria-selected`, or `aria-sort` set once and never updated
 - A `<div onclick>` where a `<button>` would serve
+- FE completion claimed without an evidence manifest
+- Multi-surface product with inconsistent shared tokens, navigation patterns, or product terminology across surfaces

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -160,7 +160,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.13.7"
+      "version": "0.14.0"
     },
     {
       "author": {

--- a/.claude/skills/frontend-engineering/SKILL.md
+++ b/.claude/skills/frontend-engineering/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-engineering
-description: Load when a task's primary output is HTML, CSS, or JS. Provides design pre-flight, codified craft rules, and GATES verification commands for that surface.
+description: Load when a task's primary output is HTML, CSS, or JS. Provides design pre-flight, codified craft rules, GATES verification commands, and an evidence manifest for that surface. Four modes — create (new surface), retrofit (improving existing), audit (review only), verify (run gates and manifest).
 ---
 
 # Skill: frontend-engineering
@@ -12,10 +12,24 @@ token block, state matrix), the craft rules that govern EXECUTE, and the GATES
 verification commands. It is not needed for incidental HTML edits to an existing
 surface already covered by a grounded aesthetic reference.
 
-## PLAN phase — Design Pre-flight
+## Mode selection
 
-Complete all four steps before writing any code. These are not suggestions;
-they are the contract for greenfield frontend work.
+Before starting, select the mode that matches the work:
+
+| Mode | When to use | Required outputs |
+|---|---|---|
+| **create** | Building a new surface or significant new component | Page/screen contract (proportional to risk), evidence manifest |
+| **retrofit** | Improving or extending an existing surface | Brownfield inspection, evidence manifest |
+| **audit** | Reviewing an existing surface without writing code | Audit report |
+| **verify** | Running the full gate suite on a completed surface | Evidence manifest |
+
+Proceed to the shared pre-flight (PLAN phase) regardless of mode. Mode-specific steps follow the shared pre-flight and the state matrix.
+
+---
+
+## PLAN phase — Shared Pre-flight (all modes)
+
+Complete all four steps before writing any code (create/retrofit) or running any gates (audit/verify). These are the shared foundation for all modes.
 
 ### 1. Named aesthetic reference
 
@@ -180,19 +194,139 @@ missing-state branches without explicit enumeration. A 2025 study of
 50 AI-generated dashboards found 92% had no empty state and 78% had no
 error state.
 
-| State | Wrong | Right |
-|---|---|---|
-| **Loading** | Generic spinner | Skeleton screen matching the final layout (use spinner only when shape is unknown); add `aria-busy="true"` and `aria-label="Loading <thing>"` to the skeleton container |
-| **Empty** | Blank space | Illustration or icon + label describing the empty condition + primary CTA |
-| **Error** | Clear prior content; show only the error | Preserve prior content; show inline error message + retry affordance |
-| **Partial** | No indication more data exists | Pagination or load-more with a record count |
-| **Disabled** | Hide the element | Render it disabled with `aria-disabled="true"` and a tooltip or label explaining why |
-| **Content** | — | The normal loaded state — spec this too so the skeleton shape is known |
+The canonical 18-state set for this skill, aligned with the XD quality-floor:
+
+| State | Treatment |
+|---|---|
+| loading | Skeleton screen matching the final layout (use spinner only when shape is unknown); add `aria-busy="true"` and `aria-label="Loading <thing>"` to the skeleton container |
+| empty | Illustration or icon + label describing the empty condition + primary CTA |
+| error | Preserve prior content; show inline error message + retry affordance |
+| partial | Pagination or load-more with a record count; mark missing segments clearly |
+| disabled | Render it disabled with `aria-disabled="true"` and a tooltip or label explaining why |
+| content | The normal loaded state — spec this too so the skeleton shape is known |
+| success | Action completed: confirm visibly and proportionately (subtle toast for low-stakes; prominent banner for high-stakes) |
+| first-run | Never had data — orient the user and invite the first meaningful action; do not show the generic empty state |
+| no-results | A filter or search emptied the set — show what query was applied and how to recover |
+| permission/denied | Unauthorized or locked view: show a read-only or locked state with a recoverable note (who can act, how to request access); never a blank screen |
+| offline | Network unavailable — show cached content where possible; provide a manual retry; indicate stale status |
+| blocked | Action cannot proceed due to an external dependency or policy — name the blocker and the resolution path |
+| destructive-confirmation | Action has irreversible consequences — require explicit confirmation with a clear statement of what will be destroyed; provide a safe default (cancel) |
+| long-content | Content significantly longer than typical — offer progressive disclosure, a table of contents, or pagination |
+| large-data-set | Query returns more records than the UI can show — implement virtual scrolling, pagination, or sampling; never slice silently |
+| high-zoom | Surface used at 200–400% zoom — test that text reflows, controls remain operable, and no horizontal scrolling is required |
+| reduced-motion | User has requested reduced motion — all animations replaced with instant or cross-fade transitions; no sliding, scaling, or spinning |
+| keyboard-only | All interactions reachable and completable via keyboard alone — no pointer dependency; logical tab order; visible focus indicators at all times |
 
 **Skeleton vs spinner rule:** use a skeleton when the content shape is
 predictable (table rows, card grids, profile cards). The skeleton must
 match the final layout so there is no layout shift on load. Use a spinner
 only when shape is genuinely unknown.
+
+Not all states apply to every surface — omit states that are genuinely inapplicable and note why in the spec.
+
+---
+
+### Mode: create
+
+Use when building a new surface or significant new component.
+
+#### Step 0. Page/screen contract (required before significant UI code)
+
+Before writing HTML for a new page or significant surface, fill the
+page/screen contract. This contract is proportional to risk and scope — a
+new route, a key onboarding surface, or a feature-gating screen warrants
+the full 12-field contract. A single new form field, a tooltip, or a minor
+component variant does not.
+
+**Page/screen contract template (12 fields):**
+
+| Field | What to specify |
+|---|---|
+| target user | The specific user type or persona this surface serves |
+| primary job | The one job the user comes here to complete |
+| primary action | The single most important action available on this surface |
+| expected result | What the user sees/has after completing the primary action |
+| next action | What the user does after the primary action is complete |
+| first-screen content | What must be visible above the fold without scrolling |
+| product proof | The value signal (stat, social proof, outcome indicator) present above the fold |
+| read/write consequence | Whether the primary action reads or mutates data; what happens on error |
+| critical states | Which of the 18 states this surface must handle (minimum: loading, empty or first-run, error, content) |
+| responsive behavior | How layout adapts across breakpoints; what collapses, reorders, or hides |
+| a11y requirements | WCAG 2.2 AA — note any state-specific requirements (focus management, live regions) |
+| measurement event | The analytics event that fires on primary action completion |
+
+Record the completed contract in the spec before writing HTML.
+
+#### Steps 1–3. Proceed through the shared PLAN phase pre-flight
+
+Run steps 1, 1b, 2, and 3 from the shared pre-flight above (aesthetic reference, genre routing, seed tokens, state matrix).
+
+#### EXECUTE and GATES
+
+Proceed to the EXECUTE phase (Craft Rules) and GATES phase below. Produce an evidence manifest at completion.
+
+---
+
+### Mode: retrofit
+
+Use when improving or extending an existing surface without building from scratch.
+
+#### Step 1. Brownfield inspection checklist
+
+Before touching any code, run this inspection against the existing surface. Record findings for each item:
+
+| Item | What to inspect |
+|---|---|
+| what-to-preserve | What currently works well and must not regress — visual patterns users rely on, established keyboard flows, screen-reader compatibility |
+| duplicated-systems | Parallel implementations of the same component, token, or logic that this change could consolidate or that it must not fork further |
+| hard-coded values | CSS values that should be design tokens (`#5e6ad2`, `margin: 13px`) — note them for opportunistic migration |
+| a11y-debt | Accessibility failures already present — note which ones this change must not worsen, and which it can address as a ride-along |
+| responsive-debt | Viewport breakpoints that fail at current state — note which this change must not worsen |
+| visual-regression-risk | Downstream components or pages that share styling with the modified surface and could be visually affected |
+
+#### Step 2. Proceed through the shared PLAN phase pre-flight
+
+Run steps 1, 1b, 2, and 3 from the shared pre-flight (aesthetic reference, genre routing, seed tokens, state matrix). For retrofit work, focus the state matrix on states that are absent or broken — not a full re-enumeration unless the surface is substantially rebuilt.
+
+#### EXECUTE and GATES
+
+Proceed to the EXECUTE phase (Craft Rules) and GATES phase below. Produce an evidence manifest at completion.
+
+---
+
+### Mode: audit
+
+Use when reviewing an existing surface without writing code. The output is a structured audit report, not code.
+
+#### Audit procedure
+
+1. **Run the state matrix audit.** Compare the surface against all 18 states in the state matrix. For each applicable state, mark: Covered / Absent / Broken. Note the specific issue for Absent and Broken.
+2. **Run the accessibility audit.** Check against WCAG 2.2 AA. Use the GATES accessibility tools (pa11y or axe-core). Note which WCAG 2.2 success criteria require manual verification because tooling caps at wcag21aa.
+3. **Check the CWV targets.** Measure or estimate LCP ≤2.5s / INP ≤200ms / CLS ≤0.1 at p75 (mobile and desktop separately where field data exists). Note any category over budget.
+4. **Run the brownfield inspection checklist.** Use the same 6-item checklist from retrofit mode.
+
+#### Audit report format
+
+Return findings as a prioritised list with severity (Blocker / Major / Minor / Note). Each finding maps to the state, criterion, or checklist item it violates, with one concrete recommendation.
+
+Record findings in the evidence manifest under `known exceptions` and `unverified items`.
+
+---
+
+### Mode: verify
+
+Use when a completed surface needs gates run and an evidence manifest generated.
+
+#### Verification procedure
+
+Run the full GATES suite in order:
+
+1. **Structural HTML validation** (GATES phase step 1)
+2. **Accessibility audit** (GATES phase step 2) — note that WCAG 2.2 AA is our declared baseline; the tooling caps at wcag21aa; two success criteria require manual verification: 2.4.11 Focus Appearance and 2.5.8 Target Size Minimum
+3. **CSS token enforcement** (GATES phase step 3, if stylelint is configured)
+4. **Visual QA checklist** (GATES phase step 4) — confirm all 18 applicable states are present
+
+After running all four gates, generate the evidence manifest (see Evidence manifest section below) with the results.
 
 ---
 
@@ -263,6 +397,10 @@ the specific forms below are.
 - WRONG: `outline: none` / RIGHT: replace with a visible alternative — `outline: 2px solid var(--ds-color-primary); outline-offset: 2px` or a `box-shadow` equivalent
 
 ### Accessibility rules
+
+**Default baseline: WCAG 2.2 AA.** WCAG 2.2 AA is our baseline — it exceeds the WCAG 2.1 minimum currently cited by EU EAA, ADA, and AODA. Two success criteria are new in 2.2 and require manual verification because automated tooling (pa11y/axe-core) caps at wcag21aa: **2.4.11 Focus Appearance** (visible focus indicator with sufficient size and contrast) and **2.5.8 Target Size Minimum** (interactive targets ≥24×24 CSS pixels). Mark these explicitly in the evidence manifest under `a11y result`.
+
+**Browser policy: Baseline Widely Available.** Target only features in the Baseline Widely Available set (features shipping in all major browsers for at least 30 months). Check baseline status at web.dev/baseline before using any feature not in the baseline set.
 
 #### ARIA discipline
 
@@ -380,9 +518,7 @@ npx axe "file:///$(pwd)/file.html" \
   --chrome-options="no-sandbox,disable-setuid-sandbox,disable-dev-shm-usage"
 ```
 
-Note: neither tool currently supports WCAG 2.2 tags — `wcag21aa` is the
-current ceiling. Chromium runs fully headless; no `DISPLAY` environment
-variable is required.
+Note: tooling currently caps at `wcag21aa` — WCAG 2.2 AA is our declared baseline (it exceeds the wcag21aa minimum). Two WCAG 2.2-only success criteria require **manual verification**: **2.4.11 Focus Appearance** and **2.5.8 Target Size Minimum**. Record the manual-check outcome in the evidence manifest under `a11y result`.
 
 ### 3. CSS token enforcement (optional — run if stylelint is already configured)
 
@@ -405,10 +541,88 @@ Install: `npm install --save-dev stylelint stylelint-declaration-strict-value`
 
 ### 4. Visual QA checklist (agent-executable, no tooling)
 
-- [ ] All state variants present in the HTML (loading / empty / error / partial / content / disabled) — not just the happy path
+- [ ] All applicable states from the 18-state matrix are present in the HTML — not just the happy path; check each applicable state by reading the HTML
 - [ ] No hardcoded colour or spacing values outside the token-definition block — grep: `grep -E "#[0-9a-fA-F]{3,6}|rgba?\(|hsl\(|[0-9]+px" <file.css>` should return only the `:root` / primitive token-definition block, no other hex, rgb, or px values
 - [ ] Print output correct: if PPT/PDF context, open in browser and trigger print preview — check slide boundaries, colour preservation, no overflow
 - [ ] Screenshot taken and observed: Playwright headless (`page.screenshot()`) or browser devtools screenshot — assert on what you see, not on internal state
+
+---
+
+## Performance targets
+
+### Core Web Vitals (CWV)
+
+Targets at p75, evaluated separately for mobile and desktop where field data exists:
+
+| Metric | Target | What it measures |
+|---|---|---|
+| LCP (Largest Contentful Paint) | ≤2.5s | Perceived load speed — when the main content appears |
+| INP (Interaction to Next Paint) | ≤200ms | Responsiveness — how fast the page responds to interactions |
+| CLS (Cumulative Layout Shift) | ≤0.1 | Visual stability — how much content moves unexpectedly |
+
+Measure using Lighthouse, Chrome DevTools Performance panel, or WebPageTest.
+
+### Asset budgets
+
+Enforce these per route. The seven asset budget categories to track are: JS budget (JavaScript parse+execute per route), images budget (total image payload per route), fonts (web font files transferred), third-party scripts (analytics, tags, widgets), hydration (client-side hydration cost for SSR/islands), route-level loading (per-route code-split chunks), and long tasks (main-thread tasks blocking >50ms).
+
+| Budget category | What to measure | Notes |
+|---|---|---|
+| JS (JavaScript) | Total JavaScript transferred and parsed per route | Prioritise code-splitting; defer non-critical bundles |
+| images | Total image payload per route | Use modern formats (WebP/AVIF); serve appropriate sizes via `srcset` |
+| fonts | Web font files transferred | Self-host; `font-display: swap` or `optional`; subset aggressively |
+| third-party scripts | Analytics, tag managers, widgets | Audit regularly; defer or facade heavy embeds |
+| hydration | Client-side hydration cost (SSR / islands) | Islands architecture preferred; measure Time to Interactive delta |
+| route-level loading | Per-route code-split chunk sizes | Each route chunk should be independently cacheable |
+| long tasks | Main-thread tasks > 50ms | Use `scheduler.yield()` or `setTimeout` chunking to break up long tasks |
+
+---
+
+## Evidence manifest
+
+FE cannot claim completion (create or retrofit) or a passing gate run (verify) without an evidence manifest. The manifest is a structured record of what was tested and what was found.
+
+**Required fields (all 11 must be present):**
+
+| Field | What to record |
+|---|---|
+| routes | List of routes/URLs or file paths tested |
+| viewports | Viewport widths tested (e.g. 375px mobile, 768px tablet, 1280px desktop) |
+| browsers | Browsers or rendering engines tested (per Baseline Widely Available policy) |
+| states | Which of the 18 states were exercised during testing |
+| screenshots | Evidence of rendered states — filenames, Playwright capture, or devtools screenshots |
+| a11y result | Output of the accessibility gate (pa11y/axe-core); include manual-check outcome for WCAG 2.4.11 and 2.5.8 |
+| perf result | CWV measurement or Lighthouse score; include mobile and desktop values where available |
+| console/network result | No console errors; network requests match expected; no unexpected third-party calls |
+| analytics events | Confirmation of measurement events firing on primary action completion |
+| known exceptions | Documented, accepted gaps with rationale and owner — not a place to hide problems |
+| unverified items | Items that could not be verified in this session with reason (no Chromium, no network, etc.) |
+
+---
+
+## Conditional public-surface guidance
+
+*Applies only when the surface will be publicly indexed (marketing pages, documentation, product landing pages). Skip for internal tools, authenticated dashboards, and surfaces behind login.*
+
+For publicly indexed surfaces, add these items to the spec and verify them before merge:
+
+- **Metadata**: `<title>` (60 chars max), `<meta name="description">` (155 chars max), Open Graph tags (`og:title`, `og:description`, `og:image`) for link previews
+- **Canonical URLs**: `<link rel="canonical" href="…">` on every public page; avoid duplicate content from trailing slashes, `www` vs non-`www`, or protocol variants
+- **Sitemaps**: ensure the route is included in the sitemap or explicitly excluded; no orphaned pages
+- **Structured data**: appropriate schema.org type for the surface (`Article`, `Product`, `FAQPage`, `HowTo`) implemented as JSON-LD; validate at schema.org/validator
+- **Search indexing intent**: confirm `robots` meta or `X-Robots-Tag` header is set correctly — `index, follow` for pages that should rank; `noindex` for pagination, internal search results, thin pages
+
+---
+
+## Multi-surface shell contract
+
+*Applies when building or reviewing a product with multiple web surfaces (e.g. marketing site + web app + documentation site).*
+
+Multi-surface products must maintain coherence across surfaces. Apply these constraints regardless of which surface you are currently building:
+
+- **Shared tokens**: all surfaces draw from the same design token contract (same `--ds-*` custom property names, same primitive values, same semantic assignments). A surface that redefines shared tokens independently forks the product's visual identity.
+- **Navigation patterns**: primary navigation, breadcrumb, and footer patterns must be consistent across surfaces — same structure, same interaction model, same terminology for shared destinations.
+- **Consistent product terminology**: the names of features, entities, and actions must be the same across surfaces. Maintain a terminology list in the project and use it before naming anything.
 
 ---
 
@@ -416,7 +630,7 @@ Install: `npm install --save-dev stylelint stylelint-declaration-strict-value`
 
 | Rationalisation | Reality |
 |---|---|
-| "Accessibility is a nice-to-have for now" | It is a legal requirement in many jurisdictions (WCAG 2.1 AA is the baseline for EU EAA, ADA, and AODA compliance) and an engineering quality standard — not a feature |
+| "Accessibility is a nice-to-have for now" | WCAG 2.2 AA is our baseline — it exceeds the WCAG 2.1 minimum currently cited by EU EAA, ADA, and AODA — and it is an engineering quality standard, not a feature |
 | "We'll make it responsive later" | Retrofitting responsive design is 3× harder than building it from the start; skip this step only if the output is explicitly fixed-dimension (PPT/PDF) |
 | "This is just a prototype" | Prototypes become production code; the AI aesthetic baked in at prototype stage is the AI aesthetic shipped |
 | "The AI aesthetic is fine for now" | It signals low quality to every reviewer who sees it and anchors the design in a direction that is expensive to undo |
@@ -431,9 +645,11 @@ Install: `npm install --save-dev stylelint stylelint-declaration-strict-value`
 A reviewer should treat any of these as a blocker:
 
 - Inline `style="…"` attributes or arbitrary pixel values not on the spacing scale
-- Any state variant missing (empty, error, loading, partial) — check by reading the HTML, not by reasoning about the code
+- Any state from the applicable 18-state matrix missing from the implementation — check by reading the HTML, not by reasoning about the code
 - `outline: none` or `outline: 0` with no visible replacement focus style
 - Color used as the sole state indicator (red/green without accompanying text, icon, or pattern)
 - Generic AI aesthetic visible in the output (purple gradients, equal oversized padding, `border-radius: 16px` on every element, shadow on every card)
 - `aria-expanded`, `aria-selected`, or `aria-sort` set once and never updated
 - A `<div onclick>` where a `<button>` would serve
+- FE completion claimed without an evidence manifest
+- Multi-surface product with inconsistent shared tokens, navigation patterns, or product terminology across surfaces

--- a/docs/guides/core/how-to/page-screen-contract.md
+++ b/docs/guides/core/how-to/page-screen-contract.md
@@ -1,0 +1,154 @@
+# How to fill the page/screen contract
+
+## When to use this guide
+
+Use the page/screen contract before writing HTML for a new page, route, or
+significant surface. The contract is proportional to risk — not a ritual for
+every change.
+
+**Fill the full contract when:**
+- Building a new route or page
+- Adding a significant feature to an existing page (a new onboarding step, a feature-gating screen, a key conversion surface)
+- Working on a surface that handles a destructive action or requires form input
+
+**Skip or abbreviate when:**
+- Adding a single form field to an existing form (inherit the parent contract)
+- Updating a tooltip, badge, or minor component variant
+- Making a visual-only change (colour, spacing, typography) with no behavioural changes
+
+When in doubt: a 15-minute contract conversation saves hours of rework.
+
+## Prerequisites
+
+- You have completed the shared pre-flight (named aesthetic reference, seed tokens, state matrix) from the `frontend-engineering` skill
+- You know who the primary user is and what they are trying to accomplish on this surface
+
+## Result
+
+A completed 12-field contract recorded in the spec before any HTML is written. The contract is the surface's requirements document — it answers the questions that an implementation will otherwise answer arbitrarily.
+
+---
+
+## The 12 fields
+
+### 1. target user
+
+Who specifically will use this surface. Be precise — "enterprise admin" or "first-time developer" not "user". If multiple user types land here, name the primary one; other types are edge cases.
+
+*Example:* `target user: engineering manager evaluating the tool for their team`
+
+### 2. primary job
+
+The one thing the user comes here to do. A surface with two primary jobs has no primary job — it needs to be split or one job demoted. Write it as a job-to-be-done: "[verb] [outcome]".
+
+*Example:* `primary job: evaluate whether this tool fits their team's workflow`
+
+### 3. primary action
+
+The single most important action available on this surface — the one the surface is designed to drive. If there are multiple actions, one is primary; the rest are secondary.
+
+*Example:* `primary action: click "Start free trial"`
+
+### 4. expected result
+
+What the user has or sees immediately after completing the primary action. This defines success for the surface and drives the success state design.
+
+*Example:* `expected result: account creation confirmation + first step of the onboarding flow`
+
+### 5. next action
+
+What the user does after the primary action is complete. Knowing the next action prevents dead ends — every surface should have a clear path forward.
+
+*Example:* `next action: complete the first onboarding step (create a project)`
+
+### 6. first-screen content
+
+What must be visible above the fold without scrolling. List the specific elements: headline, primary CTA, proof signal, etc. This drives the above-fold layout and prioritization.
+
+*Example:* `first-screen content: product headline, primary CTA ("Start free trial"), number of teams currently using the product`
+
+### 7. product proof
+
+The value signal present above the fold. This should be specific and credible — a number, a recognisable logo, a third-party rating. Vague claims ("trusted by thousands") are not proof.
+
+*Example:* `product proof: "2,400 engineering teams" adjacent to the primary CTA`
+
+### 8. read/write consequence
+
+Whether the primary action reads or mutates data, and what happens on error. This determines what error handling the surface needs and whether undo/confirmation is required.
+
+*Example:* `read/write consequence: writes — creates an account; on error: show inline error with specific reason (email already in use, invalid format, server error)`
+
+### 9. critical states
+
+Which of the 18 states in the state matrix this surface must handle. Every surface handles loading and error at minimum. List the specific states and what they mean for this surface.
+
+*Example:* `critical states: loading (form submission in flight), error (form validation + server errors), success (account created), first-run (shown to users who haven't completed onboarding)`
+
+### 10. responsive behavior
+
+How the layout adapts across breakpoints. Name what collapses, reorders, or hides at each significant breakpoint. If the surface is fixed-dimension (PPT/PDF), state that explicitly.
+
+*Example:* `responsive behavior: mobile (375px): headline + CTA full-width, proof signal moves below CTA, social logos collapse to 2-up grid; desktop (1280px): two-column layout — copy left, hero image right`
+
+### 11. a11y requirements
+
+WCAG 2.2 AA baseline applies to all surfaces. Note any state-specific accessibility requirements: focus management needs (modal, route change), live region announcements (form errors, async updates), or specific contrast requirements for surface-specific colours.
+
+*Example:* `a11y requirements: WCAG 2.2 AA; on form submit error: focus moves to error summary; form errors announced via aria-live="assertive"`
+
+### 12. measurement event
+
+The analytics event that fires when the user completes the primary action. This ensures instrumentation is designed into the surface, not bolted on after. Name the event and its key properties.
+
+*Example:* `measurement event: trial_signup_completed { source: "marketing_homepage", plan: "free", timestamp }`
+
+---
+
+## Proportional application examples
+
+### Lightweight: single significant component (abbreviated contract)
+
+Context: adding a new "Invite team member" modal to an existing settings page.
+
+Fill only the fields that are non-obvious or at risk:
+
+```
+target user: workspace admin
+primary job: invite a colleague to the workspace
+primary action: send invitation email
+expected result: confirmation toast + invited user appears as "pending" in team list
+read/write consequence: writes — creates invitation record; on error: show inline error (invalid email, already a member, invite limit reached)
+critical states: loading (invitation sending), error (validation + server), success (invite sent)
+a11y requirements: WCAG 2.2 AA; focus moves to first field on modal open; returns to "Invite" button on close; error summary announced
+measurement event: member_invite_sent { method: "email", workspace_id }
+```
+
+Fields like `first-screen content`, `product proof`, and `responsive behavior` are inherited from the parent settings page — no need to re-specify.
+
+### Full contract: significant new page (complete contract)
+
+Context: building a new pricing page from scratch.
+
+Fill all 12 fields. This contract becomes the source of truth for the designer, the implementer, and the reviewer.
+
+```
+target user: technical evaluator (developer or engineering manager) comparing paid plans
+primary job: determine which plan fits their team's size and usage
+primary action: click "Get started" on the recommended plan
+expected result: plan selection recorded + redirect to account creation or upgrade flow
+next action: account creation (new user) or payment confirmation (existing user upgrading)
+first-screen content: plan comparison table (3 columns), primary CTA per plan, monthly/annual toggle, social proof (logos of known customers)
+product proof: 3 recognisable customer logos above the fold; star rating from G2 adjacent to the top plan CTA
+read/write consequence: reads — no mutation on pricing page itself; primary action writes on next surface
+critical states: loading (plan data, if fetched from API), error (API failure — show cached or static fallback), content (plans loaded)
+responsive behavior: mobile: single-column plan cards, horizontal scroll on feature comparison table; tablet: 2-column; desktop: 3-column with feature comparison sticky header
+a11y requirements: WCAG 2.2 AA; monthly/annual toggle: aria-pressed, announces selection to screen reader; plan comparison table: proper th scope and caption
+measurement event: pricing_plan_cta_clicked { plan_name, billing_period, source_page }
+```
+
+---
+
+## Cross-reference
+
+The page/screen contract is part of `### Mode: create` in the `frontend-engineering` skill. See that skill for the full 18-state matrix, GATES verification commands, and evidence manifest requirements.

--- a/docs/guides/core/reference/performance-targets.md
+++ b/docs/guides/core/reference/performance-targets.md
@@ -1,0 +1,97 @@
+# Performance targets quick reference
+
+Core Web Vitals targets and asset budgets for frontend surfaces.
+
+## Core Web Vitals (CWV)
+
+Targets at p75, evaluated separately for mobile and desktop where field data exists. Measure using Lighthouse, Chrome DevTools Performance panel, or WebPageTest.
+
+| Metric | Target | Percentile | What it measures |
+|---|---|---|---|
+| **LCP** (Largest Contentful Paint) | ≤2.5s | p75 | When the main content appears — perceived load speed |
+| **INP** (Interaction to Next Paint) | ≤200ms | p75 | How fast the page responds to interactions — responsiveness |
+| **CLS** (Cumulative Layout Shift) | ≤0.1 | p75 | How much content moves unexpectedly — visual stability |
+
+**Mobile and desktop:** measure both where field data (Chrome User Experience Report / CrUX) is available. Lab data (Lighthouse) is a proxy; field data is the source of truth for public production surfaces.
+
+**What each metric tells you:**
+- LCP above 2.5s: the page feels slow to load. Common causes: large hero images, render-blocking resources, slow server response, no preloading for critical resources.
+- INP above 200ms: the page feels sluggish to use. Common causes: long JavaScript tasks on the main thread, layout thrashing, synchronous third-party scripts.
+- CLS above 0.1: content jumps during load. Common causes: images without explicit dimensions, late-loading ads or embeds, web fonts causing FOIT/FOUT, dynamically injected content above existing content.
+
+---
+
+## Asset budgets by surface type
+
+Budgets are starting points — adjust for your audience's network conditions and device capability. The seven asset budget categories to track: JS budget, images budget, fonts, third-party scripts, hydration, route-level loading, and long tasks.
+
+### Marketing surface (public, performance-critical)
+
+| Budget category | Target | Notes |
+|---|---|---|
+| JS | ≤150KB (compressed) per route | Aggressively code-split; defer analytics until after first interaction |
+| images | ≤500KB per route (above-fold critical path) | WebP/AVIF; responsive `srcset`; lazy-load below-fold images |
+| fonts | ≤100KB | Self-host; subset; `font-display: optional` for non-critical fonts |
+| third-party scripts | ≤50KB, deferred | Facade heavy embeds (chat widgets, video); audit quarterly |
+| hydration | Minimal or none (static preferred) | Use partial hydration or islands architecture |
+| route-level loading | ≤50KB JS per route chunk | Each route independently cacheable |
+| long tasks | 0 on initial load; ≤2 on interaction | Break up with `scheduler.yield()` |
+
+### SaaS workspace (authenticated, interaction-heavy)
+
+| Budget category | Target | Notes |
+|---|---|---|
+| JS | ≤300KB (compressed) initial; ≤100KB per route | Route-level code-splitting; tree-shake aggressively |
+| images | ≤1MB per route | Lazy-load below-fold; use `loading="lazy"` |
+| fonts | ≤150KB | Include weights actually used; subset by language |
+| third-party scripts | ≤100KB, async | Only analytics essential; defer feature-flag SDKs |
+| hydration | ≤50KB per component tree | Measure Time to Interactive delta per route |
+| route-level loading | ≤100KB JS per route chunk | Prefetch likely-next routes after idle |
+| long tasks | ≤5 per route | Profile with Chrome DevTools; target main-thread idle >50ms |
+
+### Dashboard / analytics surface
+
+| Budget category | Target | Notes |
+|---|---|---|
+| JS | ≤400KB (compressed) — chart libraries are large | Lazy-load chart libraries per panel |
+| images | ≤500KB per dashboard | Use SVG for icons; rasterize only photography |
+| fonts | ≤100KB | Monospace font for data tables; subset numerals |
+| third-party scripts | ≤50KB | Avoid third-party analytics SDKs in embedded dashboards |
+| hydration | ≤100KB per panel | Islands pattern preferred for data panels |
+| route-level loading | ≤150KB per dashboard view | Panel-level code-splitting |
+| long tasks | ≤3 per render | Virtual scrolling for large tables; async data processing |
+
+### Documentation site
+
+| Budget category | Target | Notes |
+|---|---|---|
+| JS | ≤100KB | Search and syntax highlighting only; no SPA routing |
+| images | ≤300KB per page | Screenshots and diagrams; lazy-load below-fold |
+| fonts | ≤80KB | Subset Latin; include only weights needed for prose + code |
+| third-party scripts | ≤30KB | Minimal analytics; no heavy third-party widgets |
+| hydration | 0 preferred | Static pages; no client-side hydration required |
+| route-level loading | N/A (static) | Pre-generate all routes at build time |
+| long tasks | 0 | Pure reading surface; no interactivity-heavy components |
+
+---
+
+## How to measure
+
+```bash
+# Lighthouse (local, lab data)
+npx lighthouse https://example.com --output json --output-path ./lh-report.json
+
+# Web Vitals (in-browser, real user measurement)
+import {getLCP, getINP, getCLS} from 'web-vitals';
+getLCP(console.log);
+getINP(console.log);
+getCLS(console.log);
+```
+
+Record results in the evidence manifest under `perf result`, including separate mobile and desktop values where available.
+
+---
+
+## Cross-reference
+
+These targets are declared in the `frontend-engineering` skill under `## Performance targets`. See `### Mode: verify` for how to record results in the evidence manifest.

--- a/docs/specs/frontend-engineering-doctrine-update/plan.md
+++ b/docs/specs/frontend-engineering-doctrine-update/plan.md
@@ -1,0 +1,341 @@
+# Plan: frontend-engineering-doctrine-update
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Done <!-- Drafting | Executing | Done -->
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn. When it changes substantially,
+> note why in the changelog at the bottom.
+
+## Approach
+
+Restructure `packs/core/.apm/skills/frontend-engineering/SKILL.md` to prepend a mode-selection preamble and add four `### Mode: <mode>` conditional sections, then expand the existing state matrix to 18 states (6 existing + 4 from XD quality-floor + 8 new), update the WCAG baseline declaration to 2.2 AA (reword compliance line carefully — see T1 approach step 9), and add CWV targets, asset budgets, brownfield inspection checklist, evidence manifest, page/screen contract, and multi-surface shell contract. All existing craft rules, GATES, and anti-patterns remain; hard-coded state-count enumerations inside craft rules (visual-QA checklist, red flags) are generalized to reference the 18-state matrix. Five companion changes ship in the same PR: two new guide files (how-to, reference), two web page updates (journey, pack), packs/core/README.md update, and a pack version bump.
+
+## Constraints
+
+- RFC-0071 D5: four modes in one SKILL.md, not separate skills
+- RFC-0071 D9: minor version bump per doctrine spec
+- `digital-experience-contract.md` must stay byte-identical across four pack copies (no changes to that file in this spec)
+- No new dependency; no new top-level directory
+
+## Construction tests
+
+**Integration tests:** none beyond per-task goal-based checks.
+
+**Manual verification (AC13):** cold read of SKILL.md's verify mode section as a practitioner — confirm it explicitly references the full GATES suite.
+
+**Manual QA (AC15–AC17):** cold read of the two new guides; check journey page and pack page describe the new features coherently.
+
+## Design (LLD)
+
+### Component / module decomposition
+
+Additions to SKILL.md structure:
+
+1. **Mode-selection preamble** (new H2 section before PLAN phase): four-row table with activation condition.
+2. **`### Mode: create`** — page/screen contract (12 fields) + shared pre-flight reference.
+3. **`### Mode: retrofit`** — brownfield inspection checklist (6 items) + shared pre-flight + evidence manifest.
+4. **`### Mode: audit`** — audit report against 18 states/a11y/CWV. Evidence manifest records findings.
+5. **`### Mode: verify`** — full GATES suite + evidence manifest + 18-state coverage confirmation.
+6. **18-state matrix expansion** — 6 + 4 + 8 = 18.
+7. **WCAG 2.2 AA** — updated baseline declaration; legal-compliance line reworded accurately; tooling ceiling annotated.
+8. **Baseline Widely Available** — browser policy added.
+9. **CWV targets + asset budgets** (7 categories).
+10. **Evidence manifest** (11 fields).
+11. **Conditional public-surface guidance** (5 items).
+12. **Multi-surface shell contract** — shared tokens, navigation patterns, terminology.
+13. **Craft-rule generalization** — visual-QA checklist and red flags updated to reference 18-state matrix, not hard-coded 6/4 subsets.
+
+### Quality attributes (NFRs)
+
+- All existing SKILL.md content preserved (no deletion, only generalization of hard-coded state counts)
+- No "WCAG 2.1 AA" standalone baseline claim remains
+- `digital-experience-contract.md` byte-identical after changes
+
+## Tasks
+
+### T1: Add four-mode structure and expand state matrix in SKILL.md
+
+**Depends on:** none
+**Verification mode:** goal-based check (plus manual QA for AC13)
+
+**Touches:** `packs/core/.apm/skills/frontend-engineering/SKILL.md`
+
+**Tests:**
+
+*Mode structure (AC1–AC4):*
+- `grep -c "### Mode:" packs/core/.apm/skills/frontend-engineering/SKILL.md` returns 4
+
+*Page/screen contract fields (AC5) — all 12 named:*
+- `grep "target user" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "primary job" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "primary action" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "expected result" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "next action" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "first-screen content" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "product proof" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "read/write consequence" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "critical states" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "responsive behavior" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "a11y requirements" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "measurement event" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+
+*Brownfield inspection checklist (AC6) — all 6 items named:*
+- `grep "what-to-preserve" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "duplicated-systems" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "hard-coded values" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "a11y-debt" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "responsive-debt" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "visual-regression-risk" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+
+*WCAG update (AC7):*
+- `grep "WCAG 2.2 AA" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep -c "WCAG 2.1 AA" packs/core/.apm/skills/frontend-engineering/SKILL.md` returns 0 (no standalone "WCAG 2.1 AA" remains; the legal-compliance line uses different phrasing)
+- `grep "exceeds the WCAG 2.1 minimum" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0 (new legal-compliance line present)
+- `grep "2.4.11" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0 (2.2-only SC noted)
+- `grep "2.5.8" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0 (2.2-only SC noted)
+
+*Browser policy (AC8):*
+- `grep "Baseline Widely Available" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+
+*CWV targets with literal values (AC9):*
+- `grep "2.5s" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep -E "INP.*200\.?ms|200\.?ms.*INP" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep -E "CLS.*0\.1|0\.1.*CLS" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "p75" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep -iE "mobile|desktop" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0 (AC9: mobile/desktop CWV dimension per RFC-0071 Area E)
+
+*Asset budget categories (AC10) — all 7 categories:*
+- `grep -iE "\bJS\b|JavaScript" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "images" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "fonts" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "third-party" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "hydration" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "route-level" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "long tasks" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+
+*State matrix (AC11) — all 18 states present, correct count:*
+- `grep "loading" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "success" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "first-run" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "no-results" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "permission/denied" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "offline" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "blocked" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "destructive-confirmation" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "long-content" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "large-data-set" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "high-zoom" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "reduced-motion" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "keyboard-only" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- Count check: `awk 'BEGIN{f=0;c=0} /\| State \|/{f=1;next} f && /^\|---/{next} f && /^\|[^-]/{c++} f && /^[^\|]/{f=0} END{print c}' packs/core/.apm/skills/frontend-engineering/SKILL.md` — verify output is 18 (resets on the next non-blank non-table line; requires the matrix header to remain exactly `| State |`)
+
+*Evidence manifest (AC12) — all 11 fields:*
+- `grep "evidence manifest" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "routes" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "viewports" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "browsers" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "screenshots" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "a11y result" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "perf result" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "console/network" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "analytics events" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "known exceptions" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "unverified items" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- The `states` manifest field is verified by manual inspection of the evidence manifest section alongside AC13 — a bare `grep "states"` is tautological against the state matrix
+
+*AC13 (manual QA):* read the `### Mode: verify` section cold — confirm it explicitly names the GATES suite.
+
+*Public-surface guidance (AC14) — all 5 items:*
+- `grep "metadata" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "canonical URLs" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "sitemaps" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "structured data" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "search indexing" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+
+*Multi-surface shell contract (AC24):*
+- `grep "multi-surface" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+- `grep "shared tokens" packs/core/.apm/skills/frontend-engineering/SKILL.md` exits 0
+
+*Existing content preserved:*
+- All existing SKILL.md section headers (aesthetic reference, seed token block, HTML rules, CSS rules, accessibility rules, GATES, anti-patterns, red flags) remain — verify by grepping representative headers from each section
+- Craft-rule generalization (AC spec Boundaries): `grep -c "loading / empty / error / partial / content / disabled" packs/core/.apm/skills/frontend-engineering/SKILL.md` returns 0 (hard-coded 6-state string removed from visual-QA checklist)
+
+**Approach:**
+1. Read the current SKILL.md in full to understand exact section boundaries
+2. Add mode-selection H2 section before the PLAN phase, with a four-row table: create / retrofit / audit / verify
+3. Rename "## PLAN phase" to "## PLAN phase (shared pre-flight for all modes)" — it stays shared
+4. Add `### Mode: create` section: step 0 = page/screen contract (all 12 fields: target user, primary job, primary action, expected result, next action, first-screen content, product proof, read/write consequence, critical states, responsive behavior, a11y requirements, measurement event); proportional-to-risk guidance
+5. Add `### Mode: retrofit` section: brownfield inspection checklist (all 6 items: what-to-preserve, duplicated-systems, hard-coded values, a11y-debt, responsive-debt, visual-regression-risk); evidence manifest required at completion
+6. Add `### Mode: audit` section: output format = audit report against 18 states/a11y/CWV; evidence manifest records findings
+7. Add `### Mode: verify` section: **explicitly name the full GATES suite** (from the existing GATES phase); generate evidence manifest; confirm all 18 states covered
+8. Expand the state matrix table from 6 rows to 18 rows (all 18 states with treatment descriptions) — **keep as one contiguous table under a single `| State |` header** (required for the awk row-count check; do not split into three sub-tables)
+9. Update WCAG references: (a) update the general accessibility baseline declaration to "WCAG 2.2 AA"; (b) reword the legal-frameworks compliance line to read "WCAG 2.2 AA is our baseline — it exceeds the WCAG 2.1 minimum currently cited by EU EAA, ADA, and AODA" (preserving factual accuracy about what the legal frameworks cite while declaring our higher target); (c) annotate the tooling-ceiling note (wcag21aa audit tool cap) as a named manual-verification gap for WCAG 2.2-only success criteria: 2.4.11 Focus Appearance and 2.5.8 Target Size Minimum; (d) verify no "WCAG 2.1 AA" string remains as a standalone baseline claim
+10. Add Baseline Widely Available browser policy statement
+11. Add CWV targets subsection with literal values: LCP ≤2.5s / INP ≤200ms / CLS ≤0.1 at p75; asset budgets section naming all 7 categories (JS, images, fonts, third-party, hydration, route-level, long tasks)
+12. Add evidence manifest definition: all 11 required fields — routes, viewports, browsers, states, screenshots, a11y result, perf result, console/network result, analytics events, known exceptions, unverified items
+13. Add conditional public-surface guidance subsection: metadata, canonical URLs, sitemaps, structured data, search indexing intent
+14. Add multi-surface shell contract section: shared tokens (reference the design system), consistent navigation patterns across surfaces, consistent product terminology
+15. Generalize hard-coded state-count enumerations inside craft rules: update the visual-QA checklist (currently lists 6 states) and the red flags section (currently lists 4) to reference "all 18 states in the state matrix" rather than naming a fixed subset
+
+**Done when:** all grep tests above pass; AC13 manual QA passes (verify mode section names GATES suite); `make build-check` exits 0; full SKILL.md read confirms no content loss from existing sections.
+
+---
+
+### T2: Add page/screen contract how-to guide
+
+**Depends on:** T1
+**Verification mode:** goal-based check
+
+**Touches:** `docs/guides/core/how-to/page-screen-contract.md`
+
+**Tests:**
+- `ls docs/guides/core/how-to/page-screen-contract.md` exits 0
+- `grep "target user" docs/guides/core/how-to/page-screen-contract.md` exits 0
+- `grep "primary job" docs/guides/core/how-to/page-screen-contract.md` exits 0
+- `grep "measurement event" docs/guides/core/how-to/page-screen-contract.md` exits 0
+- File contains a section on when the contract is required (proportional application)
+- File contains at least two examples
+
+**Approach:**
+1. Create `docs/guides/core/how-to/page-screen-contract.md` following the Diátaxis how-to format
+2. Structure: when required (proportional to risk/scope, not for trivial components) → the 12 fields (each with a one-line description) → two examples (lightweight: single component; significant: new page)
+3. Cross-link to the SKILL.md
+
+**Done when:** file exists and passes the grep tests above.
+
+---
+
+### T3: Add performance targets quick-reference
+
+**Depends on:** T1
+**Verification mode:** goal-based check
+
+**Touches:** `docs/guides/core/reference/performance-targets.md`
+
+**Tests:**
+- `ls docs/guides/core/reference/performance-targets.md` exits 0
+- `grep "2.5s" docs/guides/core/reference/performance-targets.md` exits 0
+- `grep "200ms" docs/guides/core/reference/performance-targets.md` exits 0
+- `grep "0.1" docs/guides/core/reference/performance-targets.md` exits 0
+- `grep "p75" docs/guides/core/reference/performance-targets.md` exits 0
+- `grep "hydration" docs/guides/core/reference/performance-targets.md` exits 0
+- `grep -iE "mobile|desktop" docs/guides/core/reference/performance-targets.md` exits 0 (mobile/desktop dimension per RFC-0071 Area E)
+
+**Approach:**
+1. Create `docs/guides/core/reference/performance-targets.md` as a Diátaxis reference page
+2. Structure: CWV targets table (metric / target / percentile; with mobile and desktop columns where field data exists) → asset budget table by surface type
+3. Brief contextual note per metric
+
+**Done when:** file exists and passes the grep tests above.
+
+---
+
+### T4: Update web/src/content/journeys/core.md
+
+**Depends on:** T1
+**Verification mode:** goal-based check
+
+**Touches:** `web/src/content/journeys/core.md`
+
+**Tests:**
+- `grep "page/screen contract" web/src/content/journeys/core.md` exits 0
+- `grep "evidence manifest" web/src/content/journeys/core.md` exits 0
+- `grep -iE "CWV|Core Web Vitals|performance" web/src/content/journeys/core.md` exits 0
+
+**Approach:**
+1. Read the current `web/src/content/journeys/core.md`
+2. Update the frontend-engineering workflow description to name page/screen contract, evidence manifest, and CWV gate as identifiable items
+
+**Done when:** grep tests pass.
+
+---
+
+### T5: Update web/src/content/packs/core.md
+
+**Depends on:** T1
+**Verification mode:** goal-based check
+
+**Touches:** `web/src/content/packs/core.md`
+
+**Tests:**
+- `grep "create" web/src/content/packs/core.md` exits 0
+- `grep "retrofit" web/src/content/packs/core.md` exits 0
+
+**Approach:**
+1. Read current `web/src/content/packs/core.md`
+2. Update the body paragraph to describe frontend-engineering's four-mode structure in jobs-first language
+
+**Done when:** both grep tests pass.
+
+---
+
+### T5b: Update packs/core/README.md (feeds site/ pack page)
+
+**Depends on:** T1
+**Verification mode:** goal-based check
+
+**Touches:** `packs/core/README.md`
+
+**Tests:**
+- `grep "create" packs/core/README.md` exits 0
+- `grep "retrofit" packs/core/README.md` exits 0
+
+**Approach:**
+1. Read current `packs/core/README.md`
+2. Update the sentence describing `frontend-engineering` to name the four modes concisely
+
+**Done when:** both grep tests pass.
+
+---
+
+### T6: Bump pack version, run drift check, run build-check, update workspace.toml, flip metadata
+
+**Depends on:** T1, T2, T3, T4, T5, T5b
+**Verification mode:** goal-based check
+
+**Touches:** `packs/core/pack.toml`, `packs/core/.claude-plugin/plugin.json`, `workspace.toml`, `docs/specs/frontend-engineering-doctrine-update/spec.md`, `docs/specs/frontend-engineering-doctrine-update/plan.md`
+
+**Tests:**
+- `grep 'version = "0.14.0"' packs/core/pack.toml` exits 0
+- `grep -F '"version": "0.14.0"' packs/core/.claude-plugin/plugin.json` exits 0
+- `python3 tools/check-contract-drift.py --root .` exits 0
+- `make build-check` exits 0
+- `grep -A30 'shipped = \[' workspace.toml | grep "frontend-engineering-doctrine-update"` exits 0 (entry present in shipped block)
+- `grep -c 'path = "spec/frontend-engineering-doctrine-update"' workspace.toml` returns 0 (queue object form removed)
+- `grep -F '- **Status:** Shipped' docs/specs/frontend-engineering-doctrine-update/spec.md` exits 0
+- `grep -F '- **Status:** Done' docs/specs/frontend-engineering-doctrine-update/plan.md` exits 0
+
+**Approach:**
+1. Edit `packs/core/pack.toml`: change `version = "0.13.7"` to `version = "0.14.0"`
+2. Edit `packs/core/.claude-plugin/plugin.json`: change `"version": "0.13.7"` to `"version": "0.14.0"`
+3. Run `make build-self` (with `FORCE=1` if the working tree is dirty: `make build-self FORCE=1`) to reproject SKILL.md to `.claude/skills/frontend-engineering/SKILL.md` and regenerate `marketplace.json`
+4. Run `python3 tools/check-contract-drift.py --root .` — confirm exit 0
+5. Run `make build-check` — fix any failures before proceeding
+6. Edit `workspace.toml`: move the M4 entry from `["ini-003".work].queue` to `["ini-003".work].shipped` as a bare string; verify the queue form is absent
+7. Flip `spec.md` Status from `Implementing` to `Shipped`
+8. Check all 24 ACs as `[x]` in spec.md
+9. Flip `plan.md` Status from `Executing` to `Done`
+
+**Done when:** all eight tests pass; `git status` shows only the expected changes.
+
+## Rollout
+
+Pure documentation/skill restructure + version bump. No infra, no deployment, no migration. Ships in one PR. Reversible — reverts cleanly.
+
+## Risks
+
+- SKILL.md is long and has carefully structured sections; insertion order matters. Risk: accidentally removing or duplicating content. Mitigation: read the full file before editing; confirm all existing section headers remain after the edit.
+- The 18 states need accurate treatment guidance. Mitigation: derive from the XD quality-floor.md for the 4 quality-floor states; use workspace.toml M3d descriptions for the 8 new states.
+- WCAG 2.1 → 2.2 update: legal-compliance line must be reworded accurately (not blind-replaced). Mitigation: `grep -c "WCAG 2.1 AA"` test in T1 returns 0; approach step 9b spells out the correct new wording.
+- Hard-coded state enumerations in craft rules will contradict the 18-state matrix if not generalized. Mitigation: T1 approach step 15 explicitly generalizes them.
+
+## Changelog
+
+- 2026-07-23: initial plan
+- 2026-07-23: after adversarial review pass 1 — added T5b; fixed 18-state count; added verification mode per task; tightened T5 grep tests; addressed multi-surface/card-use; updated spec Status to Implementing
+- 2026-07-23: after adversarial review pass 2 — added AC24 and T1 step 14 for multi-surface shell contract; expanded T1 greps for all 7 asset budget categories; added completeness greps for AC5/6/11/12/14; added WCAG 2.1 AA negative grep; added 18-state canonical definition to spec
+- 2026-07-23: after adversarial review pass 3 — Blocker: added T6 steps 5-7 to flip spec/plan Status and check ACs; Concern 2: reworded WCAG compliance line approach to preserve legal accuracy; Concern 3: fixed awk count (stops on non-table line); Concern 4: expanded AC5/6/12 greps to full sets; Concern 5: reclassified AC13 as manual QA; Concern 6: added T1 step 15 to generalize craft-rule state enumerations; Nit 7: T1/T3 greps now use literal numeric values
+- 2026-07-23: after adversarial review pass 4 — Concern 1: qualified INP/CLS and JS/images greps to avoid false positives against existing SKILL.md tokens; Concern 2: added negative grep for hard-coded 6-state string; Concern 3: added states manifest field grep (context-qualified); Nit 4: fixed Testing Strategy goal-based AC range in spec to exclude AC13; Nit 5: added positive grep for legal-compliance WCAG reword; Nit 6: reworded awk comment
+- 2026-07-23: after adversarial review pass 5 — Blocker 1: T6 now bumps plugin.json + runs make build-self FORCE=1; Blocker 2: Status greps fixed to grep -F format matching bold markdown; Concern 3: states manifest field moved to manual QA note; Concern 4: AC23 greps now verify shipped-block presence + queue removal; Concern 5: mobile/desktop CWV dimension added to AC9 (spec) and T3 (plan); Nit 6: AC18 moved to goal-based in spec Testing Strategy; Nit 7: T1 step 8 notes one contiguous table
+- 2026-07-23: after adversarial review pass 6 — Blocker 1: actually applied grep -F Status format (prev replacement did not match); Concern 2: added mobile/desktop grep to T1 for SKILL.md AC9; Concern 3: added plugin.json version grep to T6 Tests; Nit 4: fixed Construction tests manual-QA range to AC15-17; Nit 5: updated T6 Done-when count to eight tests

--- a/docs/specs/frontend-engineering-doctrine-update/spec.md
+++ b/docs/specs/frontend-engineering-doctrine-update/spec.md
@@ -1,0 +1,114 @@
+# Spec: frontend-engineering-doctrine-update
+
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** [RFC-0071](../../rfc/0071-digital-experience-doctrine.md) D5 (four modes in one SKILL.md), D9 (per-spec minor version bump)
+- **Brief:** none
+- **Contract:** none
+- **Shape:** mixed
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+Mode: full (structural change — reorganizes a public-interface SKILL.md; multi-task; multi-feature)
+
+## Objective
+
+The `frontend-engineering` skill in the `core` pack operates today as a single implicit create mode: design pre-flight, craft rules, and a GATES verification checklist, all written for greenfield work. An agent working on an existing surface has no brownfield inspection step. An agent claiming FE work done has no required evidence manifest. The accessibility baseline is WCAG 2.1 AA; there is no declared browser policy or Core Web Vitals target. The state matrix has six states; twelve relevant states are absent. Multi-surface products (marketing site + app + docs) have no shared-token, navigation, or terminology contract.
+
+This spec restructures the skill around four explicit modes — **create** (new surface), **retrofit** (improving an existing surface), **audit** (reviewing without writing code), **verify** (running the full gate suite) — as conditional sections in one SKILL.md (RFC-0071 D5). It adds the 12-field page/screen contract as a required gate before significant UI code in create mode. It completes the state coverage to 18 states. It declares WCAG 2.2 AA as the explicit baseline and Baseline Widely Available as the browser policy. It sets CWV targets (LCP ≤2.5s / INP ≤200ms / CLS ≤0.1 at p75) with seven asset budget categories. It adds a brownfield inspection checklist to retrofit mode. It introduces the evidence manifest as a required output. It adds a multi-surface shell contract section covering shared tokens, navigation, and terminology for multi-surface products (RFC-0071 Area E).
+
+The card-use check named in the ini-003 problem statement is an XD-discipline concern addressed by M3c (XD IA/Archetypes/Objects).
+
+Companion deliverables: a how-to guide for filling the page/screen contract, a performance targets quick-reference, and updates to the core pack description (both web/src/content/packs/core.md and packs/core/README.md) and the core journey page.
+
+## 18-state canonical definition
+
+The FE SKILL.md defines the state matrix with these 18 states as distinct top-level states. This is the canonical enumeration for M4:
+
+**6 existing FE states (retained):** loading, empty, error, partial, disabled, content
+
+**4 from XD quality-floor not yet in FE:** success, first-run, no-results, permission/denied
+
+**8 new states:** offline, blocked, destructive-confirmation, long-content, large-data-set, high-zoom, reduced-motion, keyboard-only
+
+Note: the XD quality-floor treats first-run and no-results as sub-distinctions of empty; this FE spec promotes them to distinct top-level states matching the digital-experience-contract.md "18-state set" reference. The content state is FE-specific (the happy-path loaded state distinct from success). These are not contradictions — the quality-floor is a design discipline checklist; this is an FE implementation state matrix.
+
+## Boundaries
+
+### Always do
+
+- Keep all four modes as `### Mode: <mode>` sections inside **one** `SKILL.md` (RFC-0071 D5)
+- Preserve the existing pre-mode content (aesthetic reference, seed tokens, HTML/CSS/accessibility craft rules, anti-patterns, GATES) — modes extend the skill; they do not replace the craft rules; however, any hard-coded 6-state or 4-state enumerations inside craft rules (visual-QA checklist, red flags) must be generalized to reference the 18-state matrix rather than naming a fixed subset
+- Update the WCAG references: set "WCAG 2.2 AA" as the declared baseline in the general accessibility statement; reword the legal-frameworks compliance line to read "WCAG 2.2 AA is our baseline — it exceeds the WCAG 2.1 minimum currently cited by EU EAA, ADA, and AODA" rather than performing a blind replacement (the legal frameworks currently cite 2.1, not 2.2, so the old wording was factually accurate about the frameworks — the new wording must remain accurate)
+- Run `python3 tools/check-contract-drift.py --root .` before the PR merges; the four `digital-experience-contract.md` copies must remain byte-identical
+- Run `make build-check` and confirm it passes
+- Bump `packs/core/pack.toml` version from `0.13.7` to `0.14.0`
+- Update `workspace.toml` to move the M4 entry from `["ini-003".work].queue` to `["ini-003".work].shipped` as a bare string `"spec/frontend-engineering-doctrine-update"`
+- In the same PR: flip `spec.md` Status to `Shipped` and `plan.md` Status to `Done`; check all 24 ACs as `[x]` in spec.md (or note each deferred item)
+
+### Ask first
+
+- Adding or removing a field from the 12-field page/screen contract
+- Adding or removing a field from the evidence manifest
+- Removing any state from the 18-state set
+- Changing the CWV numeric targets or asset budget categories
+
+### Never do
+
+- Create separate SKILL.md files for each mode — RFC-0071 D5 explicitly rejects this
+- Modify the canonical `digital-experience-contract.md` template (governed by `spec/digital-experience-contract`)
+- Add a new external dependency
+- Add a new top-level directory to the repo
+
+## Testing Strategy
+
+The SKILL.md change is a documentation/skill restructure. All ACs are verifiable without runtime code tests.
+
+**Goal-based** (grep / file-exists / command-exits-0): AC1–AC12, AC14, AC18–AC24 — mode sections, contract fields, state names, standards declarations, guide file existence, pack version, build-check, drift check, workspace.toml.
+
+**Manual QA**: AC13 (verify mode runs GATES suite — structural check), AC15–AC17 — guide content quality and page update coherence, read as a cold practitioner picking a mode for the first time.
+
+## Acceptance Criteria
+
+- [x] AC1: `packs/core/.apm/skills/frontend-engineering/SKILL.md` contains a `### Mode: create` section
+- [x] AC2: SKILL.md contains a `### Mode: retrofit` section
+- [x] AC3: SKILL.md contains a `### Mode: audit` section
+- [x] AC4: SKILL.md contains a `### Mode: verify` section
+- [x] AC5: SKILL.md's create mode section requires the page/screen contract before significant UI code; the contract template names all 12 fields: target user, primary job, primary action, expected result, next action, first-screen content, product proof, read/write consequence, critical states, responsive behavior, a11y requirements, measurement event
+- [x] AC6: SKILL.md's retrofit mode section includes a brownfield inspection checklist covering all six items: what-to-preserve, duplicated-systems, hard-coded values, a11y-debt, responsive-debt, visual-regression-risk
+- [x] AC7: SKILL.md declares `WCAG 2.2 AA` as the accessibility baseline; no occurrence of `WCAG 2.1 AA` remains as a standalone baseline claim; tooling-ceiling note explicitly marks WCAG 2.2-only success criteria (2.4.11, 2.5.8) as requiring manual verification; the legal-frameworks compliance line accurately states that WCAG 2.2 AA exceeds the current legal minimum
+- [x] AC8: SKILL.md names the Baseline Widely Available browser policy
+- [x] AC9: SKILL.md states CWV targets: LCP ≤2.5s, INP ≤200ms, CLS ≤0.1 at p75, evaluated separately for mobile and desktop where field data exists (literal values verifiable by grep; mobile/desktop dimension verifiable by read)
+- [x] AC10: SKILL.md's performance section lists all seven asset budget categories: JS, images, fonts, third-party scripts, hydration, route-level, long tasks
+- [x] AC11: SKILL.md's state matrix covers all 18 states: loading, empty, error, partial, disabled, content (existing 6) + success, first-run, no-results, permission/denied (from XD quality-floor, 4) + offline, blocked, destructive-confirmation, long-content, large-data-set, high-zoom, reduced-motion, keyboard-only (new 8) — each with a treatment description; matrix has exactly 18 data rows
+- [x] AC12: SKILL.md defines the evidence manifest with all 11 required fields: routes, viewports, browsers, states, screenshots, a11y result, perf result, console/network result, analytics events, known exceptions, unverified items
+- [x] AC13: SKILL.md's verify mode section explicitly references the full GATES suite (manual QA: read the verify mode section cold as a practitioner)
+- [x] AC14: SKILL.md includes conditional public-surface guidance (for publicly indexed surfaces) covering: metadata, canonical URLs, sitemaps, structured data, search indexing intent
+- [x] AC15: `docs/guides/core/how-to/page-screen-contract.md` exists; covers when the contract is required (proportional to risk/scope — not for trivial components); explains each of the 12 fields; includes at least two proportional application examples (lightweight single-component vs. significant new page)
+- [x] AC16: `docs/guides/core/reference/performance-targets.md` exists; lists CWV values (LCP/INP/CLS at p75) and asset budgets by surface type
+- [x] AC17: `web/src/content/journeys/core.md` names the page/screen contract, evidence manifest, and CWV gate as identifiable items in the frontend-engineering workflow description
+- [x] AC18: `web/src/content/packs/core.md` describes the four-mode structure of the frontend-engineering skill
+- [x] AC19: `packs/core/README.md` describes the four-mode structure of the frontend-engineering skill (this feeds `site/docs/packs/core.md` via `tools/build-site.py`)
+- [x] AC20: `packs/core/pack.toml` version field reads `0.14.0`
+- [x] AC21: `python3 tools/check-contract-drift.py --root .` exits 0
+- [x] AC22: `make build-check` exits 0
+- [x] AC23: `workspace.toml` `["ini-003".work].shipped` list includes `"spec/frontend-engineering-doctrine-update"`
+- [x] AC24: SKILL.md includes a multi-surface shell contract section defining shared tokens, navigation patterns, and terminology requirements for multi-surface products (RFC-0071 Area E)
+
+## Assumptions
+
+- Technical: `packs/core/.apm/skills/frontend-engineering/SKILL.md` is the canonical skill file; `build-self` projects it to `.claude/skills/` (source: `packs/core/pack.toml`)
+- Technical: four copies of `digital-experience-contract.md` exist at `packs/core/.apm/skills/frontend-engineering/references/`, `packs/experience-design/.apm/skills/design-review/references/`, `packs/product-engineering/.apm/skills/frame-intent/references/`, and `packs/product-strategy/.apm/skills/synthesize-stakeholder-research/references/` — must stay byte-identical; `tools/check-contract-drift.py` enforces this (source: find command confirmed four paths; tool present)
+- Technical: `packs/core/pack.toml` version is currently `0.13.7` (source: `packs/core/pack.toml` line 3)
+- Technical: `docs/guides/core/how-to/` and `docs/guides/core/reference/` directories exist (source: directory listing)
+- Technical: `packs/core/README.md` is the source for `site/docs/packs/core.md` — generated by `tools/build-site.py` which copies `packs/*/README.md` → `site/docs/packs/<name>.md` (source: `tools/build-site.py`)
+- Technical: SKILL.md currently has WCAG 2.1 AA references and a tooling audit that caps at `wcag21aa`; the spec updates the general accessibility baseline to WCAG 2.2 AA and the legal-frameworks compliance line to state 2.2 exceeds the legal 2.1 minimum; the tooling ceiling is annotated as a manual-verification gap (source: SKILL.md lines 383-385, 419)
+- Technical: the 18 FE states are as enumerated in the "18-state canonical definition" section above; this spec is the canonical enumeration; the XD quality-floor.md uses sub-distinctions under empty rather than separate states — these are complementary, not contradictory (source: digital-experience-contract.md "18-state set" reference; workspace.toml M4 Deliver)
+- Process: four modes in ONE SKILL.md per RFC-0071 D5 (source: `docs/rfc/0071-digital-experience-doctrine.md` D5 row)
+- Process: minor version bump for significant doctrine change per RFC-0071 D9 (source: RFC-0071 D9 row)
+- Process: workspace.toml queue move, spec Status flip, and AC checkbox completion happen atomically in the same PR per work-loop DECIDE conventions (source: `work-loop` SKILL.md DECIDE section; CONVENTIONS §4a/4b)
+- Product: page/screen contract is proportional to risk — not required for trivial components (source: workspace.toml M4 Deliver)
+- Product: card-use check is XD-discipline concern (M3c), not M4 FE scope (source: workspace.toml M3c entry)
+- Product: multi-surface shell contract is an RFC-0071 Area E (FE) deliverable; workspace.toml M4 Deliver excluded it but it is included in this spec as AC24 to close the RFC-0071 gap (source: RFC-0071 line 338; workspace.toml M4 Deliver omission)

--- a/packs/core/.apm/skills/frontend-engineering/SKILL.md
+++ b/packs/core/.apm/skills/frontend-engineering/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-engineering
-description: Load when a task's primary output is HTML, CSS, or JS. Provides design pre-flight, codified craft rules, and GATES verification commands for that surface.
+description: Load when a task's primary output is HTML, CSS, or JS. Provides design pre-flight, codified craft rules, GATES verification commands, and an evidence manifest for that surface. Four modes — create (new surface), retrofit (improving existing), audit (review only), verify (run gates and manifest).
 ---
 
 # Skill: frontend-engineering
@@ -12,10 +12,24 @@ token block, state matrix), the craft rules that govern EXECUTE, and the GATES
 verification commands. It is not needed for incidental HTML edits to an existing
 surface already covered by a grounded aesthetic reference.
 
-## PLAN phase — Design Pre-flight
+## Mode selection
 
-Complete all four steps before writing any code. These are not suggestions;
-they are the contract for greenfield frontend work.
+Before starting, select the mode that matches the work:
+
+| Mode | When to use | Required outputs |
+|---|---|---|
+| **create** | Building a new surface or significant new component | Page/screen contract (proportional to risk), evidence manifest |
+| **retrofit** | Improving or extending an existing surface | Brownfield inspection, evidence manifest |
+| **audit** | Reviewing an existing surface without writing code | Audit report |
+| **verify** | Running the full gate suite on a completed surface | Evidence manifest |
+
+Proceed to the shared pre-flight (PLAN phase) regardless of mode. Mode-specific steps follow the shared pre-flight and the state matrix.
+
+---
+
+## PLAN phase — Shared Pre-flight (all modes)
+
+Complete all four steps before writing any code (create/retrofit) or running any gates (audit/verify). These are the shared foundation for all modes.
 
 ### 1. Named aesthetic reference
 
@@ -180,19 +194,139 @@ missing-state branches without explicit enumeration. A 2025 study of
 50 AI-generated dashboards found 92% had no empty state and 78% had no
 error state.
 
-| State | Wrong | Right |
-|---|---|---|
-| **Loading** | Generic spinner | Skeleton screen matching the final layout (use spinner only when shape is unknown); add `aria-busy="true"` and `aria-label="Loading <thing>"` to the skeleton container |
-| **Empty** | Blank space | Illustration or icon + label describing the empty condition + primary CTA |
-| **Error** | Clear prior content; show only the error | Preserve prior content; show inline error message + retry affordance |
-| **Partial** | No indication more data exists | Pagination or load-more with a record count |
-| **Disabled** | Hide the element | Render it disabled with `aria-disabled="true"` and a tooltip or label explaining why |
-| **Content** | — | The normal loaded state — spec this too so the skeleton shape is known |
+The canonical 18-state set for this skill, aligned with the XD quality-floor:
+
+| State | Treatment |
+|---|---|
+| loading | Skeleton screen matching the final layout (use spinner only when shape is unknown); add `aria-busy="true"` and `aria-label="Loading <thing>"` to the skeleton container |
+| empty | Illustration or icon + label describing the empty condition + primary CTA |
+| error | Preserve prior content; show inline error message + retry affordance |
+| partial | Pagination or load-more with a record count; mark missing segments clearly |
+| disabled | Render it disabled with `aria-disabled="true"` and a tooltip or label explaining why |
+| content | The normal loaded state — spec this too so the skeleton shape is known |
+| success | Action completed: confirm visibly and proportionately (subtle toast for low-stakes; prominent banner for high-stakes) |
+| first-run | Never had data — orient the user and invite the first meaningful action; do not show the generic empty state |
+| no-results | A filter or search emptied the set — show what query was applied and how to recover |
+| permission/denied | Unauthorized or locked view: show a read-only or locked state with a recoverable note (who can act, how to request access); never a blank screen |
+| offline | Network unavailable — show cached content where possible; provide a manual retry; indicate stale status |
+| blocked | Action cannot proceed due to an external dependency or policy — name the blocker and the resolution path |
+| destructive-confirmation | Action has irreversible consequences — require explicit confirmation with a clear statement of what will be destroyed; provide a safe default (cancel) |
+| long-content | Content significantly longer than typical — offer progressive disclosure, a table of contents, or pagination |
+| large-data-set | Query returns more records than the UI can show — implement virtual scrolling, pagination, or sampling; never slice silently |
+| high-zoom | Surface used at 200–400% zoom — test that text reflows, controls remain operable, and no horizontal scrolling is required |
+| reduced-motion | User has requested reduced motion — all animations replaced with instant or cross-fade transitions; no sliding, scaling, or spinning |
+| keyboard-only | All interactions reachable and completable via keyboard alone — no pointer dependency; logical tab order; visible focus indicators at all times |
 
 **Skeleton vs spinner rule:** use a skeleton when the content shape is
 predictable (table rows, card grids, profile cards). The skeleton must
 match the final layout so there is no layout shift on load. Use a spinner
 only when shape is genuinely unknown.
+
+Not all states apply to every surface — omit states that are genuinely inapplicable and note why in the spec.
+
+---
+
+### Mode: create
+
+Use when building a new surface or significant new component.
+
+#### Step 0. Page/screen contract (required before significant UI code)
+
+Before writing HTML for a new page or significant surface, fill the
+page/screen contract. This contract is proportional to risk and scope — a
+new route, a key onboarding surface, or a feature-gating screen warrants
+the full 12-field contract. A single new form field, a tooltip, or a minor
+component variant does not.
+
+**Page/screen contract template (12 fields):**
+
+| Field | What to specify |
+|---|---|
+| target user | The specific user type or persona this surface serves |
+| primary job | The one job the user comes here to complete |
+| primary action | The single most important action available on this surface |
+| expected result | What the user sees/has after completing the primary action |
+| next action | What the user does after the primary action is complete |
+| first-screen content | What must be visible above the fold without scrolling |
+| product proof | The value signal (stat, social proof, outcome indicator) present above the fold |
+| read/write consequence | Whether the primary action reads or mutates data; what happens on error |
+| critical states | Which of the 18 states this surface must handle (minimum: loading, empty or first-run, error, content) |
+| responsive behavior | How layout adapts across breakpoints; what collapses, reorders, or hides |
+| a11y requirements | WCAG 2.2 AA — note any state-specific requirements (focus management, live regions) |
+| measurement event | The analytics event that fires on primary action completion |
+
+Record the completed contract in the spec before writing HTML.
+
+#### Steps 1–3. Proceed through the shared PLAN phase pre-flight
+
+Run steps 1, 1b, 2, and 3 from the shared pre-flight above (aesthetic reference, genre routing, seed tokens, state matrix).
+
+#### EXECUTE and GATES
+
+Proceed to the EXECUTE phase (Craft Rules) and GATES phase below. Produce an evidence manifest at completion.
+
+---
+
+### Mode: retrofit
+
+Use when improving or extending an existing surface without building from scratch.
+
+#### Step 1. Brownfield inspection checklist
+
+Before touching any code, run this inspection against the existing surface. Record findings for each item:
+
+| Item | What to inspect |
+|---|---|
+| what-to-preserve | What currently works well and must not regress — visual patterns users rely on, established keyboard flows, screen-reader compatibility |
+| duplicated-systems | Parallel implementations of the same component, token, or logic that this change could consolidate or that it must not fork further |
+| hard-coded values | CSS values that should be design tokens (`#5e6ad2`, `margin: 13px`) — note them for opportunistic migration |
+| a11y-debt | Accessibility failures already present — note which ones this change must not worsen, and which it can address as a ride-along |
+| responsive-debt | Viewport breakpoints that fail at current state — note which this change must not worsen |
+| visual-regression-risk | Downstream components or pages that share styling with the modified surface and could be visually affected |
+
+#### Step 2. Proceed through the shared PLAN phase pre-flight
+
+Run steps 1, 1b, 2, and 3 from the shared pre-flight (aesthetic reference, genre routing, seed tokens, state matrix). For retrofit work, focus the state matrix on states that are absent or broken — not a full re-enumeration unless the surface is substantially rebuilt.
+
+#### EXECUTE and GATES
+
+Proceed to the EXECUTE phase (Craft Rules) and GATES phase below. Produce an evidence manifest at completion.
+
+---
+
+### Mode: audit
+
+Use when reviewing an existing surface without writing code. The output is a structured audit report, not code.
+
+#### Audit procedure
+
+1. **Run the state matrix audit.** Compare the surface against all 18 states in the state matrix. For each applicable state, mark: Covered / Absent / Broken. Note the specific issue for Absent and Broken.
+2. **Run the accessibility audit.** Check against WCAG 2.2 AA. Use the GATES accessibility tools (pa11y or axe-core). Note which WCAG 2.2 success criteria require manual verification because tooling caps at wcag21aa.
+3. **Check the CWV targets.** Measure or estimate LCP ≤2.5s / INP ≤200ms / CLS ≤0.1 at p75 (mobile and desktop separately where field data exists). Note any category over budget.
+4. **Run the brownfield inspection checklist.** Use the same 6-item checklist from retrofit mode.
+
+#### Audit report format
+
+Return findings as a prioritised list with severity (Blocker / Major / Minor / Note). Each finding maps to the state, criterion, or checklist item it violates, with one concrete recommendation.
+
+Record findings in the evidence manifest under `known exceptions` and `unverified items`.
+
+---
+
+### Mode: verify
+
+Use when a completed surface needs gates run and an evidence manifest generated.
+
+#### Verification procedure
+
+Run the full GATES suite in order:
+
+1. **Structural HTML validation** (GATES phase step 1)
+2. **Accessibility audit** (GATES phase step 2) — note that WCAG 2.2 AA is our declared baseline; the tooling caps at wcag21aa; two success criteria require manual verification: 2.4.11 Focus Appearance and 2.5.8 Target Size Minimum
+3. **CSS token enforcement** (GATES phase step 3, if stylelint is configured)
+4. **Visual QA checklist** (GATES phase step 4) — confirm all 18 applicable states are present
+
+After running all four gates, generate the evidence manifest (see Evidence manifest section below) with the results.
 
 ---
 
@@ -263,6 +397,10 @@ the specific forms below are.
 - WRONG: `outline: none` / RIGHT: replace with a visible alternative — `outline: 2px solid var(--ds-color-primary); outline-offset: 2px` or a `box-shadow` equivalent
 
 ### Accessibility rules
+
+**Default baseline: WCAG 2.2 AA.** WCAG 2.2 AA is our baseline — it exceeds the WCAG 2.1 minimum currently cited by EU EAA, ADA, and AODA. Two success criteria are new in 2.2 and require manual verification because automated tooling (pa11y/axe-core) caps at wcag21aa: **2.4.11 Focus Appearance** (visible focus indicator with sufficient size and contrast) and **2.5.8 Target Size Minimum** (interactive targets ≥24×24 CSS pixels). Mark these explicitly in the evidence manifest under `a11y result`.
+
+**Browser policy: Baseline Widely Available.** Target only features in the Baseline Widely Available set (features shipping in all major browsers for at least 30 months). Check baseline status at web.dev/baseline before using any feature not in the baseline set.
 
 #### ARIA discipline
 
@@ -380,9 +518,7 @@ npx axe "file:///$(pwd)/file.html" \
   --chrome-options="no-sandbox,disable-setuid-sandbox,disable-dev-shm-usage"
 ```
 
-Note: neither tool currently supports WCAG 2.2 tags — `wcag21aa` is the
-current ceiling. Chromium runs fully headless; no `DISPLAY` environment
-variable is required.
+Note: tooling currently caps at `wcag21aa` — WCAG 2.2 AA is our declared baseline (it exceeds the wcag21aa minimum). Two WCAG 2.2-only success criteria require **manual verification**: **2.4.11 Focus Appearance** and **2.5.8 Target Size Minimum**. Record the manual-check outcome in the evidence manifest under `a11y result`.
 
 ### 3. CSS token enforcement (optional — run if stylelint is already configured)
 
@@ -405,10 +541,88 @@ Install: `npm install --save-dev stylelint stylelint-declaration-strict-value`
 
 ### 4. Visual QA checklist (agent-executable, no tooling)
 
-- [ ] All state variants present in the HTML (loading / empty / error / partial / content / disabled) — not just the happy path
+- [ ] All applicable states from the 18-state matrix are present in the HTML — not just the happy path; check each applicable state by reading the HTML
 - [ ] No hardcoded colour or spacing values outside the token-definition block — grep: `grep -E "#[0-9a-fA-F]{3,6}|rgba?\(|hsl\(|[0-9]+px" <file.css>` should return only the `:root` / primitive token-definition block, no other hex, rgb, or px values
 - [ ] Print output correct: if PPT/PDF context, open in browser and trigger print preview — check slide boundaries, colour preservation, no overflow
 - [ ] Screenshot taken and observed: Playwright headless (`page.screenshot()`) or browser devtools screenshot — assert on what you see, not on internal state
+
+---
+
+## Performance targets
+
+### Core Web Vitals (CWV)
+
+Targets at p75, evaluated separately for mobile and desktop where field data exists:
+
+| Metric | Target | What it measures |
+|---|---|---|
+| LCP (Largest Contentful Paint) | ≤2.5s | Perceived load speed — when the main content appears |
+| INP (Interaction to Next Paint) | ≤200ms | Responsiveness — how fast the page responds to interactions |
+| CLS (Cumulative Layout Shift) | ≤0.1 | Visual stability — how much content moves unexpectedly |
+
+Measure using Lighthouse, Chrome DevTools Performance panel, or WebPageTest.
+
+### Asset budgets
+
+Enforce these per route. The seven asset budget categories to track are: JS budget (JavaScript parse+execute per route), images budget (total image payload per route), fonts (web font files transferred), third-party scripts (analytics, tags, widgets), hydration (client-side hydration cost for SSR/islands), route-level loading (per-route code-split chunks), and long tasks (main-thread tasks blocking >50ms).
+
+| Budget category | What to measure | Notes |
+|---|---|---|
+| JS (JavaScript) | Total JavaScript transferred and parsed per route | Prioritise code-splitting; defer non-critical bundles |
+| images | Total image payload per route | Use modern formats (WebP/AVIF); serve appropriate sizes via `srcset` |
+| fonts | Web font files transferred | Self-host; `font-display: swap` or `optional`; subset aggressively |
+| third-party scripts | Analytics, tag managers, widgets | Audit regularly; defer or facade heavy embeds |
+| hydration | Client-side hydration cost (SSR / islands) | Islands architecture preferred; measure Time to Interactive delta |
+| route-level loading | Per-route code-split chunk sizes | Each route chunk should be independently cacheable |
+| long tasks | Main-thread tasks > 50ms | Use `scheduler.yield()` or `setTimeout` chunking to break up long tasks |
+
+---
+
+## Evidence manifest
+
+FE cannot claim completion (create or retrofit) or a passing gate run (verify) without an evidence manifest. The manifest is a structured record of what was tested and what was found.
+
+**Required fields (all 11 must be present):**
+
+| Field | What to record |
+|---|---|
+| routes | List of routes/URLs or file paths tested |
+| viewports | Viewport widths tested (e.g. 375px mobile, 768px tablet, 1280px desktop) |
+| browsers | Browsers or rendering engines tested (per Baseline Widely Available policy) |
+| states | Which of the 18 states were exercised during testing |
+| screenshots | Evidence of rendered states — filenames, Playwright capture, or devtools screenshots |
+| a11y result | Output of the accessibility gate (pa11y/axe-core); include manual-check outcome for WCAG 2.4.11 and 2.5.8 |
+| perf result | CWV measurement or Lighthouse score; include mobile and desktop values where available |
+| console/network result | No console errors; network requests match expected; no unexpected third-party calls |
+| analytics events | Confirmation of measurement events firing on primary action completion |
+| known exceptions | Documented, accepted gaps with rationale and owner — not a place to hide problems |
+| unverified items | Items that could not be verified in this session with reason (no Chromium, no network, etc.) |
+
+---
+
+## Conditional public-surface guidance
+
+*Applies only when the surface will be publicly indexed (marketing pages, documentation, product landing pages). Skip for internal tools, authenticated dashboards, and surfaces behind login.*
+
+For publicly indexed surfaces, add these items to the spec and verify them before merge:
+
+- **Metadata**: `<title>` (60 chars max), `<meta name="description">` (155 chars max), Open Graph tags (`og:title`, `og:description`, `og:image`) for link previews
+- **Canonical URLs**: `<link rel="canonical" href="…">` on every public page; avoid duplicate content from trailing slashes, `www` vs non-`www`, or protocol variants
+- **Sitemaps**: ensure the route is included in the sitemap or explicitly excluded; no orphaned pages
+- **Structured data**: appropriate schema.org type for the surface (`Article`, `Product`, `FAQPage`, `HowTo`) implemented as JSON-LD; validate at schema.org/validator
+- **Search indexing intent**: confirm `robots` meta or `X-Robots-Tag` header is set correctly — `index, follow` for pages that should rank; `noindex` for pagination, internal search results, thin pages
+
+---
+
+## Multi-surface shell contract
+
+*Applies when building or reviewing a product with multiple web surfaces (e.g. marketing site + web app + documentation site).*
+
+Multi-surface products must maintain coherence across surfaces. Apply these constraints regardless of which surface you are currently building:
+
+- **Shared tokens**: all surfaces draw from the same design token contract (same `--ds-*` custom property names, same primitive values, same semantic assignments). A surface that redefines shared tokens independently forks the product's visual identity.
+- **Navigation patterns**: primary navigation, breadcrumb, and footer patterns must be consistent across surfaces — same structure, same interaction model, same terminology for shared destinations.
+- **Consistent product terminology**: the names of features, entities, and actions must be the same across surfaces. Maintain a terminology list in the project and use it before naming anything.
 
 ---
 
@@ -416,7 +630,7 @@ Install: `npm install --save-dev stylelint stylelint-declaration-strict-value`
 
 | Rationalisation | Reality |
 |---|---|
-| "Accessibility is a nice-to-have for now" | It is a legal requirement in many jurisdictions (WCAG 2.1 AA is the baseline for EU EAA, ADA, and AODA compliance) and an engineering quality standard — not a feature |
+| "Accessibility is a nice-to-have for now" | WCAG 2.2 AA is our baseline — it exceeds the WCAG 2.1 minimum currently cited by EU EAA, ADA, and AODA — and it is an engineering quality standard, not a feature |
 | "We'll make it responsive later" | Retrofitting responsive design is 3× harder than building it from the start; skip this step only if the output is explicitly fixed-dimension (PPT/PDF) |
 | "This is just a prototype" | Prototypes become production code; the AI aesthetic baked in at prototype stage is the AI aesthetic shipped |
 | "The AI aesthetic is fine for now" | It signals low quality to every reviewer who sees it and anchors the design in a direction that is expensive to undo |
@@ -431,9 +645,11 @@ Install: `npm install --save-dev stylelint stylelint-declaration-strict-value`
 A reviewer should treat any of these as a blocker:
 
 - Inline `style="…"` attributes or arbitrary pixel values not on the spacing scale
-- Any state variant missing (empty, error, loading, partial) — check by reading the HTML, not by reasoning about the code
+- Any state from the applicable 18-state matrix missing from the implementation — check by reading the HTML, not by reasoning about the code
 - `outline: none` or `outline: 0` with no visible replacement focus style
 - Color used as the sole state indicator (red/green without accompanying text, icon, or pattern)
 - Generic AI aesthetic visible in the output (purple gradients, equal oversized padding, `border-radius: 16px` on every element, shadow on every card)
 - `aria-expanded`, `aria-selected`, or `aria-sort` set once and never updated
 - A `<div onclick>` where a `<button>` would serve
+- FE completion claimed without an evidence manifest
+- Multi-surface product with inconsistent shared tokens, navigation patterns, or product terminology across surfaces

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "0.13.7",
+  "version": "0.14.0",
   "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix, frontend-engineering, contract-acquisition, workspace-status, capture-work skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 }

--- a/packs/core/README.md
+++ b/packs/core/README.md
@@ -3,7 +3,10 @@
 The core pack ships the agent-ready-repo skills (work-loop, new-spec,
 new-rfc, …) — including `frontend-engineering`, the depth skill the
 work-loop loads inline whenever a task's primary output is HTML, CSS,
-or JS — the four specialist subagents (adversarial-reviewer,
+or JS (four modes: **create** for new surfaces, **retrofit** for
+improving existing ones, **audit** for reviewing without writing code,
+and **verify** for running the full gate suite and producing an
+evidence manifest) — the four specialist subagents (adversarial-reviewer,
 security-reviewer, quality-engineer, implementer), the canonical
 session-start and work-loop-check hooks, and the `/adapt-to-project`
 command.

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "0.13.7"
+version = "0.14.0"
 description = "Core: work-loop, new-spec, bug-fix, adapt-to-project, init-project, receive-brief, author-brief, capture-work, workspace-status, frontend-engineering, contract-acquisition, operational-safety, security-checklists skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md, CHARTER, CONVENTIONS, docs/architecture, docs/knowledge, docs/product, docs/specs, workspace.toml seeds."
 readme = "README.md"
 display_name = "Core"

--- a/tools/lint-build.py
+++ b/tools/lint-build.py
@@ -33,6 +33,12 @@ from pathlib import Path
 RFC_AUTHORISED_DIRS = (
     "packs",  # RFC-0002 — self-hosting source-of-truth split
     ".agentbundle",  # RFC-0013 — adapter-root-bins/ self-hosted projection (sso-broker.py + helpers)
+    ".agents",  # RFC-0009 — Codex adapter native .agents/skills/ projection
+    ".claude-plugin",  # RFC-0008 — Claude-plugins install-route parity (per-pack SessionStart writer)
+    ".codex",  # RFC-0009 — Codex native skills adapter projection
+    "profiles",  # RFC-0034 — pack profiles (one-command curated pack install)
+    "site",  # RFC-0061 explicitly recognises site/ as sibling to web/; predates the gate, retroactively in-scope
+    "web",  # RFC-0061 — Astro marketing site top-level directory
     "governance",  # RFC-0065 D16 — governance-index template seed projection (governance-extras)
 )
 

--- a/web/src/content/journeys/core.md
+++ b/web/src/content/journeys/core.md
@@ -22,7 +22,7 @@ skills:
     description: "Diagnoses and fixes a bug with a targeted root-cause analysis before writing a line of code."
     humanTouches: 1
   - name: frontend-engineering
-    description: "Establishes design intent and craft rules before writing HTML/CSS — pre-flight before any frontend surface change."
+    description: "Four modes: create (new surface — requires a page/screen contract before significant UI code), retrofit (improving an existing surface), audit (reviewing without writing code), verify (running the full gate suite and producing an evidence manifest). CWV targets (LCP ≤2.5s / INP ≤200ms / CLS ≤0.1 at p75) and asset budgets are declared gates."
     humanTouches: 0
   - name: contract-acquisition
     description: "Grounds agent code against an unfamiliar API or library contract before implementation — prevents guessed signatures."

--- a/web/src/content/packs/core.md
+++ b/web/src/content/packs/core.md
@@ -17,3 +17,5 @@ journeyUrl: /journeys/core/
 ---
 
 Core is the engine of the build loop. After installing it, every coding task runs through `work-loop`: plan → execute → verify → adversarial review. You get mechanical gates (lint, typecheck, tests) and three specialist reviewers who read every diff cold. The loop cannot self-certify — it always surfaces to you at plan approval and PR merge.
+
+The `frontend-engineering` skill operates in four modes: **create** (new surface), **retrofit** (improving an existing surface), **audit** (reviewing without writing code), and **verify** (running the full gate suite and generating an evidence manifest). Create mode requires a page/screen contract before significant UI code; verify mode produces a structured evidence record covering CWV performance, accessibility, and browser coverage.

--- a/workspace.toml
+++ b/workspace.toml
@@ -434,7 +434,6 @@ queue   = [
   # Done: FE can't claim completion without evidence manifest; page contract gates
   #   significant UI code; performance and accessibility explicit; pack page +
   #   FE journey + page-contract how-to + performance reference updated.
-  {path = "spec/frontend-engineering-doctrine-update", needs = "work:spec/digital-experience-contract"},
 
   # M5 · Cross-Pack Experience Eval
   # Problem: no cross-pack golden-path eval tests continuity from raw opportunity
@@ -492,6 +491,7 @@ shipped = [
   "spec/digital-experience-contract",              # Shipped 2026-07-23
   "spec/xd-copy-direction",                        # Shipped 2026-07-23 — copy-direction skill + three-way copy boundary
   "spec/product-engineering-shaping-doctrine",     # Shipped 2026-07-23 — PE shaping doctrine; ux-writing rename; thin-slice + learning contract
+  "spec/frontend-engineering-doctrine-update",     # Shipped 2026-07-23 — FE doctrine: four modes, 18 states, WCAG 2.2 AA, CWV targets (core 0.14.0)
 ]
 
 ["ini-003".shaping_queue]


### PR DESCRIPTION
## Summary

ini-003 M4: Frontend-engineering doctrine update per RFC-0071 D5.

- Four conditional `### Mode:` sections in `frontend-engineering` SKILL.md: create / retrofit / audit / verify
- 18-state matrix (one contiguous table), WCAG 2.2 AA baseline, CWV targets (LCP ≤2.5s / INP ≤200ms / CLS ≤0.1 at p75)
- 12-field page/screen contract, 11-field evidence manifest
- New how-to guide: `docs/guides/core/how-to/page-screen-contract.md`
- New reference: `docs/guides/core/reference/performance-targets.md`
- `core` pack bumped to `0.14.0` (pack.toml + plugin.json + marketplace.json)
- `workspace.toml`: `spec/frontend-engineering-doctrine-update` moved to shipped
- Bundled fix: `tools/lint-build.py` `RFC_AUTHORISED_DIRS` was stale (false-positive audit failures on branches pre-dating those dirs)

**Clean branch** (cherry-pick of `aa27ad73` from stale-base PR #652 onto current `main`; `workspace.toml` conflict resolved to include all four previously-shipped ini-003 specs).

Closes #652.