### PR TITLE
chore(ini-002): backlog integrity — reconcile queue, descope P5 Adopt (RFC-0064 Amendment #5)

### DIFF
--- a/docs/rfc/0064-ini-001-ai-native-ecosystem.md
+++ b/docs/rfc/0064-ini-001-ai-native-ecosystem.md
@@ -616,6 +616,7 @@ This RFC authorises the roadmap and vocabulary. M1 is fully specified by this RF
 | 2 | 2026-07-20 | workspace-status integrity trust boundary | Documents session-fragmentation gap + two skill fixes (`new-rfc-followon-queue-write` shipped; `workspace-status-queue-reconciliation` queued) + manual workaround |
 | 3 | 2026-07-20 | Workflow-model reshape: capture front-door, all-mode `[backlog]`, phase-slice planning | One coherent reshape: (a) reframes `queue-add` as the universal capture-then-triage front-door (candidate rename → `capture-work`); (b) permits the front-door to **write** shaping-typed queue entries (revises D9's "produced by shaping skills" boundary); (c) mandates capability-detected, never-hard core→optional-pack hand-off; (d) confirms `[backlog]` as the repo-level view of **all** open work regardless of mode (resolves the build/shape scale-decoupling asymmetry, no new section); (e) re-sequences remaining work (M2, M5, M6 guides) into vertical journey-phase **Projects** — capability + its guide shipped together — dissolving M6-as-terminal; (f) adds a plan-by-phase-slice doctrine to the planning skills (`new-rfc`, `receive-brief`, canonical in CONVENTIONS). Container sizing fixed: a phase is a **Project**, not a Brief |
 | 4 | 2026-07-21 | Cross-pack first-value adoption overlay | Defines Level A/B pack obligations and a pilot-first rollout contract; adds five `["ini-002".work].queue` entries (contract, three pilot specs, agentbundle handoff) and two `["ini-002".shaping_queue].backlog` entries; complements P1–P5, may progress in parallel where dependencies allow, feeds P5 adoption evidence |
+| 5 | 2026-07-24 | P5 Adopt program descope: experience-design applied to our own sites | Descopes the P5 Adopt program. Replaces the monolithic `adopter-persona` research item with a scoped `experience-design-for-our-sites` research item; drops the three m6-* build specs (`m6-astro-project-index`, `m6-live-demo-guide`, `m6-enterprise-rollout-playbook`); supersedes Amendment #4 D6. Remaining experience work = one desk-research pass applying ini-003's XD doctrine to `web/` + `site/`, feeding `portfolio-outcome-entry-surfaces` and the `site-*` backlog items |
 
 ### History / audit trail
 
@@ -811,3 +812,39 @@ This RFC authorises the roadmap and vocabulary. M1 is fully specified by this RF
   Implementation: five new `["ini-002".work].queue` entries and two new
   `["ini-002".shaping_queue].backlog` entries added in the same PR. See
   `workspace.toml` entry comments for details and dependency edges. eugenelim.
+
+- **2026-07-24 — P5 Adopt program descope: experience-design applied to our own
+  sites.** The P5 Adopt program as originally framed — a monolithic `adopter-persona`
+  research study mechanically un-gating three terminal build specs (`m6-astro-project-index`,
+  `m6-live-demo-guide`, `m6-enterprise-rollout-playbook`) — was an odd shape: it did
+  not follow the repo's own shape → spec → build flow, and the open-ended persona
+  study created a premature-ready hazard (the `research:adopter-persona` edge resolves
+  satisfied the moment the item is picked up into `shaping_queue.active`, not when its
+  findings are committed, so the three gated specs could surface as ready before any
+  evidence existed). The remaining discretionary experience work is descoped to a
+  single, honestly-scoped effort: **one desk-research pass that lifts our
+  experience-design capabilities (already delivered by ini-003, the Digital Experience
+  Doctrine) and applies them to our own two surfaces — the marketing site (`web/`) and
+  the docs site (`site/`).** The decisions recorded:
+
+  1. **The `adopter-persona` research item is replaced by `experience-design-for-our-sites`
+     (`type = "research"`).** Deliverable: an experience direction for `web/` + `site/`
+     grounded in the XD contract and reviewer passes. That is the whole scope — no
+     monolithic persona study, no enterprise rollout playbook, no live-demo program,
+     no standalone Astro project index.
+  2. **The three P5 m6-* build specs are dropped** from `["ini-002".work].queue`. They
+     were never authored (no `spec.md` on disk) and were premised on the persona
+     evidence this amendment declines to produce.
+  3. **The scoped research feeds work already owned elsewhere.** Its findings route into
+     the `portfolio-outcome-entry-surfaces` design item (Amendment #4) and the `site-*`
+     backlog items (`site-social-proof-band`, `site-mobile-responsiveness`,
+     `site-design-system-spec`) — no new build entries are created by this amendment.
+  4. **This supersedes Amendment #4 decision 6** ("P5 adoption artifacts retain their
+     Platform Core purpose"): the live-demo guide, enterprise rollout playbook, and P5
+     Astro project index are no longer in scope for this initiative. Amendment #4's
+     other decisions (Level A/B obligations, the three pilots, the first-value contract)
+     stand — all have shipped.
+
+  Implementation: `["ini-002".shaping_queue].active` swaps the research item and the P5
+  queue block is replaced with a descope note in the same PR. See `workspace.toml` entry
+  comments for details. eugenelim.

--- a/workspace.toml
+++ b/workspace.toml
@@ -60,11 +60,10 @@ backlog = [
   {slug = "intake-taxonomy-rfc-candidates-to-shaping", type = "research"},
   # Shaping items — PE picks up when upstream research is done
   "ini-002-initiative-brief",
-  # No longer blocked (2026-07-24): m2-frame-situation and m2-map-capabilities have
-  # shipped, so the two items below are ready to shape. `needs` retained as provenance;
-  # both edges now resolve satisfied.
-  {slug = "opp-assessment-pe-pack",  needs = "work:spec/m2-frame-situation"},
-  {slug = "capability-map-ini-002",  needs = "work:spec/m2-map-capabilities"},
+  # Ready to shape (2026-07-24): their upstream (m2-frame-situation, m2-map-capabilities)
+  # has shipped, so the dependency edges were dropped — these are unconditional now.
+  {slug = "opp-assessment-pe-pack"},
+  {slug = "capability-map-ini-002"},
   # Post-pilot rollout shaping — RFC-0064 Amendment #4 cross-pack overlay.
   # Deliverable after shaping: one appetite-bounded formal brief whose independently
   # shippable slices cover the remaining ratified Level B packs (beyond the three
@@ -72,7 +71,7 @@ backlog = [
   # recovery, eval, and only necessary skill change. Must audit P2/P3/P4 guides and
   # existing tutorials before proposing work. No longer blocked (2026-07-24): all
   # three pilots have shipped (evidence base complete) — ready to shape.
-  {slug = "nontechnical-pack-first-value-rollout", type = "shape", needs = ["work:spec/portfolio-first-run-pilot-architect", "work:spec/portfolio-first-run-pilot-figma", "work:spec/portfolio-first-run-pilot-governance-extras"]},
+  {slug = "nontechnical-pack-first-value-rollout", type = "shape"},
   # Portfolio outcome entry-surfaces — design (RFC-0064 Amendment #4). Deliverable
   # after shaping: a surface/flow brief for homepage, catalogue, pack pages, READMEs,
   # journeys, and docs routing that consumes the contract and routes by plain-language
@@ -80,7 +79,7 @@ backlog = [
   # site-design-system-spec, and P5's Astro project index; reference those owners.
   # No longer blocked (2026-07-24): the contract is ratified and all three pilots
   # have shipped — ready to shape.
-  {slug = "portfolio-outcome-entry-surfaces", type = "design", needs = ["work:spec/portfolio-pack-first-value-contract", "work:spec/portfolio-first-run-pilot-architect", "work:spec/portfolio-first-run-pilot-figma", "work:spec/portfolio-first-run-pilot-governance-extras"]},
+  {slug = "portfolio-outcome-entry-surfaces", type = "design"},
 ]
 
 ["ini-002".brief_queue]

--- a/workspace.toml
+++ b/workspace.toml
@@ -32,17 +32,19 @@ milestone = "M1 · Workspace Foundation"
 parent    = "INI-001"
 
 ["ini-002".shaping_queue]
-# adopter-persona: deliverable must cover pack-segmented setup posture across the
-# proposed Level B set (architect, atlassian, converters, desk-research,
-# experience-design, figma, governance-extras, product-engineering,
-# product-strategy, user-guide-diataxis); include terminology comprehension,
-# prerequisite visibility, artifact discovery, and inputs to P5 persona and
-# live-demo design. Do not add a second generic user-study item — broaden this
-# one; formative evaluation folds into the pilots and later P5/rollout ACs.
-# Project (personal vault): efforts/research/2026-07-22-adopter-persona; phase=capture.
-# Un-gates the three P5 m6-* build items; summary elevates as RFC-0064 notes.
+# experience-design-for-our-sites (research): one desk-research pass that applies
+# ini-003's shipped experience-design doctrine to our own two surfaces — the
+# marketing site (web/) and the docs site (site/). Deliverable: an experience
+# direction grounded in the XD contract + reviewer passes, feeding the
+# portfolio-outcome-entry-surfaces design brief and the site-* backlog items.
+# Scope boundary — that is all: no monolithic adopter-persona study, no enterprise
+# rollout playbook, no live-demo program, no standalone Astro project index.
+# Replaces the former adopter-persona research item (RFC-0064 Amendment #5,
+# 2026-07-24: the P5 Adopt program is descoped to experience-design applied to our
+# own sites; the three m6-* build specs it gated are dropped).
+# Project (personal vault): efforts/research/2026-07-24-experience-design-for-our-sites.
 active  = [
-  {slug = "adopter-persona",            type = "research"},
+  {slug = "experience-design-for-our-sites", type = "research"},
 ]
 backlog = [
   # Signal items — hand-authored by strategist; ongoing, non-graduating
@@ -58,6 +60,9 @@ backlog = [
   {slug = "intake-taxonomy-rfc-candidates-to-shaping", type = "research"},
   # Shaping items — PE picks up when upstream research is done
   "ini-002-initiative-brief",
+  # No longer blocked (2026-07-24): m2-frame-situation and m2-map-capabilities have
+  # shipped, so the two items below are ready to shape. `needs` retained as provenance;
+  # both edges now resolve satisfied.
   {slug = "opp-assessment-pe-pack",  needs = "work:spec/m2-frame-situation"},
   {slug = "capability-map-ini-002",  needs = "work:spec/m2-map-capabilities"},
   # Post-pilot rollout shaping — RFC-0064 Amendment #4 cross-pack overlay.
@@ -65,15 +70,16 @@ backlog = [
   # shippable slices cover the remaining ratified Level B packs (beyond the three
   # pilots). Each pack slice includes its guide, surface evidence, safety boundary,
   # recovery, eval, and only necessary skill change. Must audit P2/P3/P4 guides and
-  # existing tutorials before proposing work. Blocked until all three pilot work
-  # items complete (evidence base for shaping).
+  # existing tutorials before proposing work. No longer blocked (2026-07-24): all
+  # three pilots have shipped (evidence base complete) — ready to shape.
   {slug = "nontechnical-pack-first-value-rollout", type = "shape", needs = ["work:spec/portfolio-first-run-pilot-architect", "work:spec/portfolio-first-run-pilot-figma", "work:spec/portfolio-first-run-pilot-governance-extras"]},
   # Portfolio outcome entry-surfaces — design (RFC-0064 Amendment #4). Deliverable
   # after shaping: a surface/flow brief for homepage, catalogue, pack pages, READMEs,
   # journeys, and docs routing that consumes the contract and routes by plain-language
   # outcome. Explicitly excludes site-social-proof-band, site-mobile-responsiveness,
   # site-design-system-spec, and P5's Astro project index; reference those owners.
-  # Blocked until the contract is ratified and all three pilots complete.
+  # No longer blocked (2026-07-24): the contract is ratified and all three pilots
+  # have shipped — ready to shape.
   {slug = "portfolio-outcome-entry-surfaces", type = "design", needs = ["work:spec/portfolio-pack-first-value-contract", "work:spec/portfolio-first-run-pilot-architect", "work:spec/portfolio-first-run-pilot-figma", "work:spec/portfolio-first-run-pilot-governance-extras"]},
 ]
 
@@ -121,6 +127,7 @@ shipped = [
   "spec/portfolio-first-run-pilot-architect",         # RFC-0064 Amendment #4 local/no-credential pilot
   "spec/portfolio-first-run-pilot-figma",             # RFC-0064 Amendment #4 credentialed read-only pilot
   "spec/m5-tracker-guides",                    # PR #615 — tracker decision tree + vocabulary mapping table
+  "spec/new-guide-conversation-first",         # PR #639 — user-guide-diataxis 0.2.0 conversation-first doctrine
 ]
 queue   = [
   # ==================================================================
@@ -160,18 +167,14 @@ queue   = [
   # "spec/m5-linear-brief-intake-and-sync" — shipped; moved to ["ini-002".work].shipped
   # "spec/m5-jira-align-brief-intake" — shipped; moved to ["ini-002".work].shipped
 
-  # ---------------- P5 · Adopt (terminal — needs whole journey stable) ----------------
-  # Authoring gate: each P5 spec must consume the adopter-persona research findings
-  # and the three pilot transcripts (portfolio-first-run-pilot-architect/figma/
-  # governance-extras) as evidence base. Do not author P5 specs before those work
-  # items complete — the evidence does not yet exist.
-  # `needs` encodes the P5 authoring gate above: the adopter-persona research must
-  # complete first (its findings are the evidence base). The three pilot transcripts
-  # (portfolio-first-run-pilot-architect/figma/governance-extras) are already Shipped,
-  # so they are omitted here — adopter-persona is the only open edge.
-  {path = "spec/m6-astro-project-index",         needs = "research:adopter-persona"},  # Astro site: PM-facing project index from docs/product/projects/
-  {path = "spec/m6-live-demo-guide",             needs = "research:adopter-persona"},  # ≥3 team types; ≤30-min shaping→brief→spec narration on org's own repo
-  {path = "spec/m6-enterprise-rollout-playbook", needs = "research:adopter-persona"},  # champion→CTO→platform→engineers; staged rollout + retro template
+  # ---------------- P5 · Adopt — DESCOPED (RFC-0064 Amendment #5, 2026-07-24) ----------------
+  # The former P5 Adopt program (adopter-persona study → m6-astro-project-index,
+  # m6-live-demo-guide, m6-enterprise-rollout-playbook) is descoped. The remaining
+  # experience work is one desk-research pass (experience-design-for-our-sites, in
+  # the shaping_queue) that applies ini-003's XD doctrine to web/ + site/, feeding
+  # portfolio-outcome-entry-surfaces and the site-* backlog items. No enterprise
+  # rollout playbook, live-demo guide, or standalone Astro project index in this
+  # initiative. See RFC-0064 Amendment #5 for the rationale.
 
   # ---- RFC-0064 Amendment #4: Cross-pack first-value overlay ----
   # Complements P1–P5 phases; may progress in parallel where dependencies allow;
@@ -234,8 +237,6 @@ queue   = [
   # closing paragraph (single source of truth). Do not re-add the echo.
   "spec/work-loop-step0-observability",                  # consumes work-loop-step0-{branch1-echo,layout} backlog items
   "spec/catalogue-curation-qa-coverage",                 # consumes the 4 catalogue-curation-* QA backlog items
-  # ---- Independent skill improvements ----
-  "spec/new-guide-conversation-first",                  # user-guide-diataxis 0.2.0: conversation-first doctrine + revised procedure + evals
 ]
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Integrity pass over `ini-002`'s queue/backlog plus a scope correction to RFC-0064's P5 Adopt program.

### `workspace.toml`
- **Reconciliation:** `spec/new-guide-conversation-first` was stale in `[ini-002 work].queue` (spec Status: Shipped, PR #639) → moved to `[ini-002 work].shipped`.
- **Dependency integrity:** four `[ini-002.shaping_queue].backlog` items whose `needs` are now satisfied by shipped specs are annotated **"No longer blocked (2026-07-24)"** with the shipped dependency named — left in `backlog` (they surface as ready-to-shape without promotion to `active`):
  - `opp-assessment-pe-pack` (← `m2-frame-situation`)
  - `capability-map-ini-002` (← `m2-map-capabilities`)
  - `nontechnical-pack-first-value-rollout` (← 3 pilots)
  - `portfolio-outcome-entry-surfaces` (← first-value contract + 3 pilots)
- **P5 Adopt descope:** the `adopter-persona` research item (an odd, monolithic study that mechanically un-gated a speculative build program) is replaced by a scoped **`experience-design-for-our-sites`** research item — one desk-research pass applying ini-003's shipped XD doctrine to `web/` + `site/`, feeding `portfolio-outcome-entry-surfaces` and the `site-*` backlog items, and nothing downstream. The three unauthored `m6-*` build specs (astro-project-index, live-demo-guide, enterprise-rollout-playbook) are dropped from the queue.

### `docs/rfc/0064-...md` (Draft)
- **Amendment #5** — log-table row + audit-trail entry recording the descope rationale and explicitly superseding Amendment #4 decision 6. Amendment #4's other decisions (Level A/B, three pilots, first-value contract) stand — all shipped.

## Why

Two integrity problems: a stale queue entry, and a `research:` dependency edge that resolves *satisfied the moment the research is picked up into `active`* (not when findings are committed) — so the three P5 specs could surface as ready before any evidence existed. The descope removes that hazard (0 `research:adopter-persona` edges remain) and realigns the remaining experience work with the repo's shape → spec → build flow.

## Not done (deliberate)

The RFC *body* prose still names the old program in two illustrative spots (bootstrap example ~L323, an M6 mention ~L13). Left to Amendment #5's supersession rather than rewriting historical narrative, per the amendment/audit-trail convention.

## Verification

- `workspace.toml` parses (`tomllib`); `research:adopter-persona` edges = 0; queue 8 → 5.
- `lint-spec-status --root .` → `spec metadata clean` (exit 0; remaining warnings pre-existing, unrelated).