### PR TITLE
feat(work-loop): step-0 single source of truth for branch outcomes

### DIFF
--- a/.agents/skills/work-loop/SKILL.md
+++ b/.agents/skills/work-loop/SKILL.md
@@ -136,12 +136,7 @@ Before PLAN begins, orient to the current initiative and work queue:
        (e.g. `"M1 · Workspace Foundation"`).
      - **Active spec (argless only — skip when a spec path is given):**
        Collect every path in `["ini-NNN".work].active` across all active
-       initiatives. Exactly one → state the resolved spec path in the
-       orientation block (e.g., "Beginning on `docs/specs/<slug>/spec.md`")
-       and begin on that spec without asking. Zero
-       → surface "No active spec found — run `workspace-status` to see
-       what's ready to start." More than one (single initiative or across
-       initiatives) → list all and ask the user to pick.
+       initiatives.
      - **Stale-queue check.** For each active initiative, for each entry in
        `["ini-NNN".work].queue` and `["ini-NNN".work].active`: resolve the
        path (bare string → as-is; inline object → `path` field; `slug` is
@@ -171,8 +166,10 @@ proceed to step 1 (PLAN) immediately. Otherwise a path must be resolved:
 if exactly one active item, state the resolved path (e.g.,
 "Beginning on `docs/specs/<slug>/spec.md`") in the orientation block, strip
 the `spec/` prefix, then read `docs/specs/<slug>/spec.md` and `plan.md` as
-step 1 of PLAN. In the zero and multi-item branches, stop after surfacing
-the message or list and do not proceed until the user picks.
+step 1 of PLAN. Zero active items → surface "No active spec found — run
+`workspace-status` to see what's ready to start." and stop. More than one
+(single initiative or across initiatives) → list all and ask the user to
+pick; stop after surfacing the list and do not proceed until the user picks.
 
 ### 1. PLAN — think before acting
 

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -136,12 +136,7 @@ Before PLAN begins, orient to the current initiative and work queue:
        (e.g. `"M1 · Workspace Foundation"`).
      - **Active spec (argless only — skip when a spec path is given):**
        Collect every path in `["ini-NNN".work].active` across all active
-       initiatives. Exactly one → state the resolved spec path in the
-       orientation block (e.g., "Beginning on `docs/specs/<slug>/spec.md`")
-       and begin on that spec without asking. Zero
-       → surface "No active spec found — run `workspace-status` to see
-       what's ready to start." More than one (single initiative or across
-       initiatives) → list all and ask the user to pick.
+       initiatives.
      - **Stale-queue check.** For each active initiative, for each entry in
        `["ini-NNN".work].queue` and `["ini-NNN".work].active`: resolve the
        path (bare string → as-is; inline object → `path` field; `slug` is
@@ -171,8 +166,10 @@ proceed to step 1 (PLAN) immediately. Otherwise a path must be resolved:
 if exactly one active item, state the resolved path (e.g.,
 "Beginning on `docs/specs/<slug>/spec.md`") in the orientation block, strip
 the `spec/` prefix, then read `docs/specs/<slug>/spec.md` and `plan.md` as
-step 1 of PLAN. In the zero and multi-item branches, stop after surfacing
-the message or list and do not proceed until the user picks.
+step 1 of PLAN. Zero active items → surface "No active spec found — run
+`workspace-status` to see what's ready to start." and stop. More than one
+(single initiative or across initiatives) → list all and ask the user to
+pick; stop after surfacing the list and do not proceed until the user picks.
 
 ### 1. PLAN — think before acting
 

--- a/docs/specs/work-loop-step0-observability/spec.md
+++ b/docs/specs/work-loop-step0-observability/spec.md
@@ -1,6 +1,6 @@
 # Spec: work-loop-step0-observability
 
-- **Status:** Approved
+- **Status:** Shipped
 - **Owner:** eugenelim
 - **Constrained by:** `spec/spec-C-workloop-argless-resume` (defines Branch-1 behavior; Status: Shipped — body not modified by this spec); RFC-0067 §Change C
 
@@ -32,24 +32,24 @@ the closing paragraph.
 
 ## Acceptance Criteria
 
-- [ ] **AC1.** The closing paragraph of Step 0 in the source SKILL.md
+- [x] **AC1.** The closing paragraph of Step 0 in the source SKILL.md
   (`packs/core/.apm/skills/work-loop/SKILL.md`) directs Branch 1 to echo
   "Beginning on `<resolved-path>`" (or equivalent phrasing) before
   proceeding to PLAN — so the resolved path is explicitly visible to the
   user. This instruction lives in the closing paragraph, not in the
   "Active spec" bullet.
-- [ ] **AC2.** Branch 3 (more than one active item) already lists all active
+- [x] **AC2.** Branch 3 (more than one active item) already lists all active
   paths — verified that no change to its behavior is needed.
-- [ ] **AC3.** The three data-surface fields (Initiative / Milestone / Active
+- [x] **AC3.** The three data-surface fields (Initiative / Milestone / Active
   spec) in the orientation block's bullet list do not contain embedded
   control-flow action text — the "Exactly one → begin on that spec without
   asking. Zero → surface… More than one → list…" clause is removed from the
   "Active spec" bullet.
-- [ ] **AC4.** Branch-outcome resolution is stated once (in the closing
+- [x] **AC4.** Branch-outcome resolution is stated once (in the closing
   paragraph), not at both the "Active spec" bullet and the closing paragraph.
-- [ ] **AC5.** `make build-self FORCE=1` exits 0 and the projected
+- [x] **AC5.** `make build-self FORCE=1` exits 0 and the projected
   `.claude/skills/work-loop/SKILL.md` reflects all changes.
-- [ ] **AC6.** The closing paragraph's Branch 1 instruction directs the echo,
+- [x] **AC6.** The closing paragraph's Branch 1 instruction directs the echo,
   and Branch 2's exact message ("No active spec found — run `workspace-status`
   to see what's ready to start.") and Branch 3's "list all and ask" phrasing
   are relocated verbatim from the "Active spec" bullet into the closing

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -136,12 +136,7 @@ Before PLAN begins, orient to the current initiative and work queue:
        (e.g. `"M1 · Workspace Foundation"`).
      - **Active spec (argless only — skip when a spec path is given):**
        Collect every path in `["ini-NNN".work].active` across all active
-       initiatives. Exactly one → state the resolved spec path in the
-       orientation block (e.g., "Beginning on `docs/specs/<slug>/spec.md`")
-       and begin on that spec without asking. Zero
-       → surface "No active spec found — run `workspace-status` to see
-       what's ready to start." More than one (single initiative or across
-       initiatives) → list all and ask the user to pick.
+       initiatives.
      - **Stale-queue check.** For each active initiative, for each entry in
        `["ini-NNN".work].queue` and `["ini-NNN".work].active`: resolve the
        path (bare string → as-is; inline object → `path` field; `slug` is
@@ -171,8 +166,10 @@ proceed to step 1 (PLAN) immediately. Otherwise a path must be resolved:
 if exactly one active item, state the resolved path (e.g.,
 "Beginning on `docs/specs/<slug>/spec.md`") in the orientation block, strip
 the `spec/` prefix, then read `docs/specs/<slug>/spec.md` and `plan.md` as
-step 1 of PLAN. In the zero and multi-item branches, stop after surfacing
-the message or list and do not proceed until the user picks.
+step 1 of PLAN. Zero active items → surface "No active spec found — run
+`workspace-status` to see what's ready to start." and stop. More than one
+(single initiative or across initiatives) → list all and ask the user to
+pick; stop after surfacing the list and do not proceed until the user picks.
 
 ### 1. PLAN — think before acting
 

--- a/workspace.toml
+++ b/workspace.toml
@@ -127,6 +127,7 @@ shipped = [
   "spec/portfolio-first-run-pilot-figma",             # RFC-0064 Amendment #4 credentialed read-only pilot
   "spec/m5-tracker-guides",                    # PR #615 — tracker decision tree + vocabulary mapping table
   "spec/new-guide-conversation-first",         # PR #639 — user-guide-diataxis 0.2.0 conversation-first doctrine
+  "spec/work-loop-step0-observability",         # consumes work-loop-step0-{branch1-echo,layout} backlog items
 ]
 queue   = [
   # ==================================================================
@@ -230,11 +231,6 @@ queue   = [
   "spec/credbroker-security-hardening",                  # credbroker test-suite security hardening (3 deferred items)
   "spec/site-design-system-spec",                        # site token spec + zone-violation lint
   "spec/atlassian-sso-cookie-selector-integration-test", # end-to-end test for the auth selector branch
-  # work-loop-step0-observability: AC1 echo already landed ad-hoc in main (commit
-  # fb7435e9); remaining work is AC3/AC4/AC6 — trim the "Active spec" bullet's
-  # duplicated branch-outcome text and relocate Branch 2's verbatim message to the
-  # closing paragraph (single source of truth). Do not re-add the echo.
-  "spec/work-loop-step0-observability",                  # consumes work-loop-step0-{branch1-echo,layout} backlog items
   "spec/catalogue-curation-qa-coverage",                 # consumes the 4 catalogue-curation-* QA backlog items
 ]
 


### PR DESCRIPTION
## Summary

- Trims the **Active spec** bullet in Step 0 to data-surface only — removes the inline branch-outcome text ("Exactly one → … Zero → … More than one → …") so the bullet lists what to *collect*, not what to *do*.
- Expands the closing paragraph to be the **single canonical statement** of all three branch outcomes: Branch 1 (echo resolved path + proceed), Branch 2 ("No active spec found — run \`workspace-status\` to see what's ready to start." + stop), Branch 3 (list all + ask + stop). Branch 2's message is relocated verbatim.
- Re-projects via \`make build-self FORCE=1\` — `.claude/skills/` and `.agents/skills/` copies updated identically.
- Marks spec Shipped, all 6 ACs checked; moves queue entry to shipped in \`workspace.toml\`.

AC1 (Branch 1 echo) landed ad-hoc in `fb7435e9`; this PR ships the remaining ACs (AC3/AC4/AC6 — single source of truth restructure).

**Backlog items consumed:** `work-loop-step0-branch1-echo-resolved-path`, `work-loop-step0-branch-layout-restructure`

## Test plan

- [x] "Active spec" bullet contains no branch control-flow text (AC3)
- [x] Branch outcomes appear only in the closing paragraph, not the bullet (AC4)
- [x] Branch 2's verbatim message and Branch 3's "list all and ask" phrasing relocated to closing paragraph (AC6)
- [x] `make build-self FORCE=1` exits 0; `.claude/` and `.agents/` copies match source (AC5)
- [x] Adversarial review: Clean
- [x] `lint-spec-status.py`: spec metadata clean