### PR TITLE
feat(atlassian): _select_auth_path selector + integration tests (AC1-AC7)

### DIFF
--- a/docs/specs/atlassian-sso-cookie-selector-integration-test/spec.md
+++ b/docs/specs/atlassian-sso-cookie-selector-integration-test/spec.md
@@ -1,6 +1,6 @@
 # Spec: atlassian-sso-cookie-selector-integration-test
 
-- **Status:** Approved
+- **Status:** Shipped
 - **Owner:** eugenelim
 - **Constrained by:** `atlassian-sso-cookie` (parent spec, Shipped; AC13 asserted the selector; tests for each component exist; the wiring is the gap)
 - **Brief:** none
@@ -19,20 +19,20 @@ The fix is a targeted extraction: add a directly-testable `_select_auth_path(con
 
 ## Acceptance Criteria
 
-- [ ] **AC1.** `_select_auth_path(config_path: Path | None = None) -> tuple[str, SsoConfig | None]` exists in `_sso_config.py` in **both** jira/ and confluence-crawler/ `scripts/`. The function:
+- [x] **AC1.** `_select_auth_path(config_path: Path | None = None) -> tuple[str, SsoConfig | None]` exists in `_sso_config.py` in **both** jira/ and confluence-crawler/ `scripts/`. The function:
   - Returns `("token", None)` when `load_sso_config(config_path)` returns `None` (config absent or `auth_default = "creds"`).
   - Returns `("sso-cookie", sso_config)` when `load_sso_config(config_path)` returns an `SsoConfig` (valid `auth_default = "sso-cookie"` config).
   - Propagates any exception from `load_sso_config()` without catching it — callers map this to `EXIT_USER_ACTION`.
   - Is underscore-prefixed (internal helper, not part of any public surface).
-- [ ] **AC2.** `_run()` in `jira/scripts/jira.py` calls `_select_auth_path()` (imported from `._sso_config`) instead of calling `load_sso_config()` inline. The surrounding `try/except Exception → EXIT_USER_ACTION` block remains. The `if sso_config is not None:` branch (the current condition) is replaced by branching on the returned tuple: the `"sso-cookie"` path calls `JiraClient.from_sso_cookies(sso_config)`; the `"token"` path calls `load_credentials()` + `JiraClient(credentials, ...)`. Behavior is identical to today's code.
-- [ ] **AC3.** `main_async()` in `confluence-crawler/scripts/crawl_space.py` applies the same delegation — calls `_select_auth_path()` instead of inline `load_sso_config()`, with equivalent surrounding structure.
-- [ ] **AC4.** A new `test_auth_selector.py` file exists in **both** skills' `scripts/` directories (byte-identical per the parity constraint). The file opens with `pytest.importorskip("credbroker")` and then `from credbroker import SsoConfigError` (mirroring `test_sso_config.py:18-19`). It contains three tests:
+- [x] **AC2.** `_run()` in `jira/scripts/jira.py` calls `_select_auth_path()` (imported from `._sso_config`) instead of calling `load_sso_config()` inline. The surrounding `try/except Exception → EXIT_USER_ACTION` block remains. The `if sso_config is not None:` branch (the current condition) is replaced by branching on the returned tuple: the `"sso-cookie"` path calls `JiraClient.from_sso_cookies(sso_config)`; the `"token"` path calls `load_credentials()` + `JiraClient(credentials, ...)`. Behavior is identical to today's code.
+- [x] **AC3.** `main_async()` in `confluence-crawler/scripts/crawl_space.py` applies the same delegation — calls `_select_auth_path()` instead of inline `load_sso_config()`, with equivalent surrounding structure.
+- [x] **AC4.** A new `test_auth_selector.py` file exists in **both** skills' `scripts/` directories (byte-identical per the parity constraint). The file opens with `pytest.importorskip("credbroker")` and then `from credbroker import SsoConfigError` (mirroring `test_sso_config.py:18-19`). It contains three tests:
   - **absent → token**: `_select_auth_path(tmp_path / "no-such.toml")` returns `("token", None)`.
   - **valid sso-cookie → sso-cookie**: `_select_auth_path(path_to_valid_fixture)` returns `("sso-cookie", <SsoConfig instance>)`.
   - **malformed → raises**: `_select_auth_path(path_to_malformed_fixture)` raises `SsoConfigError`.
-- [ ] **AC5.** `tools/test-lint-sso-config.py`'s `_DUPLICATED` list is extended to include `"test_auth_selector.py"`, and the parity check passes (both copies byte-identical).
-- [ ] **AC6.** All existing sso-cookie tests still pass: `test_sso_config.py`, `test_sso_client.py`, `test_setup_sso.py`, `test_exit_codes.py` in both skills; `tools/test-lint-sso-config.py` passes (parity + schema-parity + upstream-file lint).
-- [ ] **AC7.** The `_ALLOWED_SSO_KEYS` set in `_sso_config.py` is unchanged (no schema drift; adding `_select_auth_path` must not cause the `lint._ALLOWED_SSO_KEYS != loader._ALLOWED_SSO_KEYS` parity check to fail).
+- [x] **AC5.** `tools/test-lint-sso-config.py`'s `_DUPLICATED` list is extended to include `"test_auth_selector.py"`, and the parity check passes (both copies byte-identical).
+- [x] **AC6.** All existing sso-cookie tests still pass: `test_sso_config.py`, `test_sso_client.py`, `test_setup_sso.py`, `test_exit_codes.py` in both skills; `tools/test-lint-sso-config.py` passes (parity + schema-parity + upstream-file lint).
+- [x] **AC7.** The `_ALLOWED_SSO_KEYS` set in `_sso_config.py` is unchanged (no schema drift; adding `_select_auth_path` must not cause the `lint._ALLOWED_SSO_KEYS != loader._ALLOWED_SSO_KEYS` parity check to fail).
 
 ## Boundaries
 

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/_sso_config.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/_sso_config.py
@@ -161,3 +161,21 @@ def load_sso_config(config_path: Path | None = None) -> SsoConfig | None:
         session_filename=session_filename,
         ttl_hint_minutes=sso.get("ttl_hint_minutes"),
     )
+
+
+def _select_auth_path(
+    config_path: Path | None = None,
+) -> tuple[str, SsoConfig | None]:
+    """Resolve the auth path and return a typed selector tuple.
+
+    :returns: ``("token", None)`` when :func:`load_sso_config` returns ``None``
+        (config absent or ``auth_default = "creds"``); ``("sso-cookie", sso_config)``
+        when an :class:`SsoConfig` is returned (valid ``auth_default = "sso-cookie"``).
+    :raises: any exception from :func:`load_sso_config` is propagated unchanged —
+        the caller maps this to ``EXIT_USER_ACTION``.
+    """
+    sso_config = load_sso_config(config_path)
+    if sso_config is not None:
+        return ("sso-cookie", sso_config)
+    return ("token", None)
+

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/crawl_space.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/crawl_space.py
@@ -77,7 +77,7 @@ try:
     )
     from ._convert import to_markdown  # noqa: E402
     from ._links import LinkTargets  # noqa: E402
-    from ._sso_config import load_sso_config  # noqa: E402
+    from ._sso_config import _select_auth_path  # noqa: E402
 except ModuleNotFoundError as _import_exc:  # noqa: E402
     # A missing module here is a non-secret dependency (e.g. httpx);
     # `credbroker` is imported lazily inside load_credentials(), so its
@@ -391,13 +391,13 @@ async def main_async(args: argparse.Namespace) -> int:
     # Auth selector: sso-config.toml with auth_default = "sso-cookie"
     # routes to the cookie path; absent or "creds" → today's token path unchanged.
     try:
-        sso_config = load_sso_config()
+        auth_path, sso_config = _select_auth_path()
     except Exception as exc:  # noqa: BLE001 — malformed SSO config → fail closed
         log.error("%s", exc)
         return EXIT_USER_ACTION
 
     try:
-        if sso_config is not None:
+        if auth_path == "sso-cookie":
             client = ConfluenceClient.from_sso_cookies(
                 sso_config,
                 concurrency=args.concurrency,

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/test_auth_selector.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/test_auth_selector.py
@@ -1,0 +1,54 @@
+"""Integration tests for the auth-path selector (AC4).
+
+Drives ``_select_auth_path`` end-to-end: the three selector outcomes
+(absent → token, valid sso-cookie → sso-cookie, malformed → raises) each
+get a test. Requires ``credbroker`` on the path — pip-installed in CI.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("credbroker")
+from credbroker import SsoConfigError  # noqa: E402
+
+from _sso_config import SsoConfig, _select_auth_path  # noqa: E402
+
+
+_VALID_SSO_COOKIE = textwrap.dedent(
+    """
+    auth_default = "sso-cookie"
+
+    [sso]
+    profile = "jira"
+    base_url = "https://jira.corp.example.com"
+    login_url = "https://sso.corp.example.com/login"
+    success_url_pattern = "https://jira.corp.example.com/secure/Dashboard.jspa"
+    cookie_domains = ["jira.corp.example.com"]
+    validation_endpoint = "/rest/api/2/myself"
+    """
+)
+
+
+def test_select_auth_path_absent_is_token(tmp_path: Path) -> None:
+    path, cfg = _select_auth_path(tmp_path / "no-such.toml")
+    assert path == "token"
+    assert cfg is None
+
+
+def test_select_auth_path_valid_sso_cookie(tmp_path: Path) -> None:
+    fixture = tmp_path / "sso-config.toml"
+    fixture.write_text(_VALID_SSO_COOKIE, encoding="utf-8")
+    path, cfg = _select_auth_path(fixture)
+    assert path == "sso-cookie"
+    assert isinstance(cfg, SsoConfig)
+
+
+def test_select_auth_path_malformed_raises(tmp_path: Path) -> None:
+    fixture = tmp_path / "sso-config.toml"
+    fixture.write_text('auth_default = "sso-cookie"\n', encoding="utf-8")
+    with pytest.raises(SsoConfigError):
+        _select_auth_path(fixture)

--- a/packs/atlassian/.apm/skills/jira/scripts/_sso_config.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/_sso_config.py
@@ -161,3 +161,21 @@ def load_sso_config(config_path: Path | None = None) -> SsoConfig | None:
         session_filename=session_filename,
         ttl_hint_minutes=sso.get("ttl_hint_minutes"),
     )
+
+
+def _select_auth_path(
+    config_path: Path | None = None,
+) -> tuple[str, SsoConfig | None]:
+    """Resolve the auth path and return a typed selector tuple.
+
+    :returns: ``("token", None)`` when :func:`load_sso_config` returns ``None``
+        (config absent or ``auth_default = "creds"``); ``("sso-cookie", sso_config)``
+        when an :class:`SsoConfig` is returned (valid ``auth_default = "sso-cookie"``).
+    :raises: any exception from :func:`load_sso_config` is propagated unchanged —
+        the caller maps this to ``EXIT_USER_ACTION``.
+    """
+    sso_config = load_sso_config(config_path)
+    if sso_config is not None:
+        return ("sso-cookie", sso_config)
+    return ("token", None)
+

--- a/packs/atlassian/.apm/skills/jira/scripts/jira.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/jira.py
@@ -85,7 +85,7 @@ try:
         JiraError,
         load_credentials,
     )
-    from ._sso_config import load_sso_config  # noqa: E402
+    from ._sso_config import _select_auth_path  # noqa: E402
 except ModuleNotFoundError as _import_exc:  # noqa: E402
     # A missing module here is a non-secret dependency (e.g. httpx);
     # `credbroker` is imported lazily inside load_credentials(), so its
@@ -711,13 +711,13 @@ async def _run(args: argparse.Namespace) -> int:
     # Auth selector: an sso-config.toml with auth_default = "sso-cookie"
     # routes to the cookie path; absent or "creds" → today's token path unchanged.
     try:
-        sso_config = load_sso_config()
+        auth_path, sso_config = _select_auth_path()
     except Exception as exc:  # noqa: BLE001 — malformed SSO config → fail closed
         print(f"error: {exc}", file=sys.stderr)
         return EXIT_USER_ACTION
 
     try:
-        if sso_config is not None:
+        if auth_path == "sso-cookie":
             client = JiraClient.from_sso_cookies(sso_config)
         else:
             credentials = load_credentials()

--- a/packs/atlassian/.apm/skills/jira/scripts/test_auth_selector.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/test_auth_selector.py
@@ -1,0 +1,54 @@
+"""Integration tests for the auth-path selector (AC4).
+
+Drives ``_select_auth_path`` end-to-end: the three selector outcomes
+(absent → token, valid sso-cookie → sso-cookie, malformed → raises) each
+get a test. Requires ``credbroker`` on the path — pip-installed in CI.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("credbroker")
+from credbroker import SsoConfigError  # noqa: E402
+
+from _sso_config import SsoConfig, _select_auth_path  # noqa: E402
+
+
+_VALID_SSO_COOKIE = textwrap.dedent(
+    """
+    auth_default = "sso-cookie"
+
+    [sso]
+    profile = "jira"
+    base_url = "https://jira.corp.example.com"
+    login_url = "https://sso.corp.example.com/login"
+    success_url_pattern = "https://jira.corp.example.com/secure/Dashboard.jspa"
+    cookie_domains = ["jira.corp.example.com"]
+    validation_endpoint = "/rest/api/2/myself"
+    """
+)
+
+
+def test_select_auth_path_absent_is_token(tmp_path: Path) -> None:
+    path, cfg = _select_auth_path(tmp_path / "no-such.toml")
+    assert path == "token"
+    assert cfg is None
+
+
+def test_select_auth_path_valid_sso_cookie(tmp_path: Path) -> None:
+    fixture = tmp_path / "sso-config.toml"
+    fixture.write_text(_VALID_SSO_COOKIE, encoding="utf-8")
+    path, cfg = _select_auth_path(fixture)
+    assert path == "sso-cookie"
+    assert isinstance(cfg, SsoConfig)
+
+
+def test_select_auth_path_malformed_raises(tmp_path: Path) -> None:
+    fixture = tmp_path / "sso-config.toml"
+    fixture.write_text('auth_default = "sso-cookie"\n', encoding="utf-8")
+    with pytest.raises(SsoConfigError):
+        _select_auth_path(fixture)

--- a/tools/test-lint-sso-config.py
+++ b/tools/test-lint-sso-config.py
@@ -87,7 +87,7 @@ _CONF = _REPO / "packs/atlassian/.apm/skills/confluence-crawler/scripts"
 # The per-skill SSO files RFC-0023 forbids sharing as a projected module, so they
 # are duplicated byte-for-byte across the two skills. Pin them equal here so a
 # one-sided edit to the security-control loader fails loudly instead of drifting.
-_DUPLICATED = ("_sso_config.py", "setup_sso.py", "test_sso_config.py", "test_setup_sso.py")
+_DUPLICATED = ("_sso_config.py", "setup_sso.py", "test_sso_config.py", "test_setup_sso.py", "test_auth_selector.py")
 
 
 def _load_module(path: Path, name: str):

--- a/workspace.toml
+++ b/workspace.toml
@@ -230,7 +230,6 @@ queue   = [
   # backlog entries have been removed (superseded by the spec). Independent of RFC-0064.
   "spec/credbroker-security-hardening",                  # credbroker test-suite security hardening (3 deferred items)
   "spec/site-design-system-spec",                        # site token spec + zone-violation lint
-  "spec/atlassian-sso-cookie-selector-integration-test", # end-to-end test for the auth selector branch
   "spec/catalogue-curation-qa-coverage",                 # consumes the 4 catalogue-curation-* QA backlog items
 ]
 


### PR DESCRIPTION
## Summary

- Extracts a directly-testable `_select_auth_path(config_path=None) -> tuple[str, SsoConfig | None]` helper into `_sso_config.py` for both jira and confluence-crawler (byte-identical), enabling integration tests without importing the CLI entrypoints.
- Updates `_run()` in `jira.py` and `main_async()` in `crawl_space.py` to delegate to `_select_auth_path()` — behavior is identical to today's code.
- Adds `test_auth_selector.py` (byte-identical across both skills) with three tests: absent→token, valid sso-cookie→sso-cookie, malformed→raises.
- Extends `tools/test-lint-sso-config.py`'s `_DUPLICATED` list to enforce parity of `test_auth_selector.py`.

## Test plan

- [x] `pytest test_auth_selector.py` passes in both `jira/scripts/` and `confluence-crawler/scripts/` (3 tests each)
- [x] Full per-skill test suites: 48 jira + 45 confluence-crawler tests all green
- [x] `python tools/test-lint-sso-config.py` — ok, 7 cases + repo scan passed
- [x] `make build-check` — EXIT: 0

## Acceptance criteria

All AC1–AC7 from `docs/specs/atlassian-sso-cookie-selector-integration-test/spec.md` verified and checked.

Spec: `docs/specs/atlassian-sso-cookie-selector-integration-test/`