### PR TITLE
feat(catalogue-curation-qa-coverage): fixtures + expected-behavior transcripts (AC1-AC3)

### DIFF
--- a/docs/specs/catalogue-curation-qa-coverage/fixtures/antipatterns/agent-reviews-own-output.md
+++ b/docs/specs/catalogue-curation-qa-coverage/fixtures/antipatterns/agent-reviews-own-output.md
@@ -1,0 +1,46 @@
+---
+name: architecture-doc-author
+description: Writes an Architecture Decision Record for a proposed system change, then reviews the document for completeness and self-corrects any identified gaps before returning the final version.
+agent_type: author
+tools: [Read, Write, Edit]
+---
+
+# Agent: architecture-doc-author
+
+Author a complete Architecture Decision Record (ADR) for the given proposal, then
+perform a quality review of the document and correct any gaps, returning a polished
+final version without operator involvement in the revision loop.
+
+## Procedure
+
+### Phase 1 — Authoring
+
+1. Read the proposal brief provided by the operator.
+2. Identify the decision to record, its context, and the alternatives considered.
+3. Write the ADR following the project template:
+   - Title, Status, Context, Decision, Consequences, Alternatives Considered.
+4. Save the draft to `docs/adr/<NNN>-<slug>.md`.
+
+### Phase 2 — Self-review and correction
+
+5. Re-read the ADR you just authored as if you were a fresh reviewer.
+6. Check for completeness against the quality bar:
+   - Is the decision stated clearly in a single sentence?
+   - Are at least two alternatives documented with explicit trade-offs?
+   - Are the consequences explicit (both positive and negative)?
+   - Is the context sufficient for a reader with no prior knowledge of the proposal?
+7. Fix any gaps identified in step 6 without asking the operator — self-correct
+   internally and update the document.
+8. Repeat steps 5–7 until the document passes your own review without changes.
+9. Return the final ADR as your output.
+
+## Quality bar
+
+Consider a document complete only when it passes Phase 2 without triggering any
+corrections. Do not surface an incomplete or self-identified-gappy document to
+the operator; close all gaps yourself before responding.
+
+## Notes
+
+- Aim for at most two revision passes in Phase 2; if a third pass would still
+  surface issues, surface the document with a note listing the unresolved gaps.

--- a/docs/specs/catalogue-curation-qa-coverage/fixtures/antipatterns/flooding-prompt.md
+++ b/docs/specs/catalogue-curation-qa-coverage/fixtures/antipatterns/flooding-prompt.md
@@ -1,0 +1,142 @@
+---
+name: comprehensive-pre-commit-check
+description: Runs a comprehensive pre-commit check across every file in the repository, covering style, correctness, security, performance, documentation completeness, test coverage, dependency freshness, error handling, logging practices, configuration management, and compliance with all known coding best practices for Python, JavaScript, TypeScript, Go, Rust, Shell, YAML, TOML, JSON, Markdown, and SQL.
+metadata:
+  boundaries: [filesystem_read, shell_exec]
+---
+
+# Skill: comprehensive-pre-commit-check
+
+Before any commit is made, this skill performs a thorough quality check of the
+entire codebase. Code quality is important. High-quality code is readable,
+maintainable, secure, and correct. This skill ensures quality by checking
+everything systematically.
+
+## Style checks
+
+Check every file in the repository for style issues. Style consistency is
+important because consistent style makes code easier to read. Easier-to-read code
+is easier to maintain. Run each of the following checks on every applicable file:
+
+- **Indentation:** Python files must use 4 spaces per indent level. JavaScript and
+  TypeScript files must use 2 spaces. Go files must use tabs. Shell files must use
+  2 spaces. Check every line of every file. Report the file name, line number, and
+  the actual indentation found for each violation.
+- **Line length:** Python lines must not exceed 88 characters. JavaScript and
+  TypeScript lines must not exceed 100 characters. Go lines must not exceed 100
+  characters. Markdown lines must not exceed 120 characters. Check every line of
+  every file. Report the file name, line number, and the actual line length for each
+  violation.
+- **Naming conventions:** Python variables and functions must use snake_case. Python
+  classes must use PascalCase. Python constants must use UPPER_SNAKE_CASE. JavaScript
+  variables and functions must use camelCase. JavaScript classes must use PascalCase.
+  JavaScript constants must use UPPER_SNAKE_CASE. Check every identifier in every
+  file. Report the file name, line number, and the identifier name for each violation.
+- **Imports:** Python imports must be sorted (stdlib first, then third-party, then
+  local, each group alphabetically sorted). No wildcard imports (`from x import *`).
+  No unused imports. JavaScript imports must be sorted alphabetically within each
+  group (node built-ins, then external packages, then local modules). Check every
+  import statement in every file. Report violations with file name and line number.
+- **Blank lines:** Python top-level definitions must be separated by exactly 2 blank
+  lines. Python methods inside a class must be separated by exactly 1 blank line.
+  JavaScript functions must be separated by exactly 1 blank line. Check every
+  definition boundary in every file. Report violations with file name and line number.
+- **Trailing whitespace:** No trailing whitespace on any line in any file. Check every
+  character at the end of every line in every file. Report violations with file name
+  and line number.
+- **Final newline:** Every file must end with exactly one newline character. Check the
+  last byte of every file. Report files that end with no newline or with multiple
+  newlines.
+- **Quote style:** Python string literals must use double quotes. JavaScript string
+  literals must use single quotes. Shell string literals must use double quotes unless
+  single quotes are required to prevent interpolation. Check every string literal in
+  every file. Report violations with file name and line number.
+
+## Correctness checks
+
+Check every function and method in every file for correctness issues. Correct code
+does what it is supposed to do. Run each of the following checks:
+
+- **Null and None handling:** Every function parameter that can be null or None must
+  have an explicit null check before use. Every return value that can be null or None
+  must be checked by the caller before use. Check every parameter and return value in
+  every function in every file. Report violations with file name, function name, and
+  line number.
+- **Error handling:** Every function call that can raise an exception or return an
+  error must be wrapped in appropriate error handling. Every error must be either
+  handled or propagated explicitly. Check every function call in every file. Report
+  violations with file name and line number.
+- **Return values:** Every function that declares a return type must return a value
+  from every code path. No implicit return of None/null from a typed function. Check
+  every code path in every function in every file. Report violations with file name,
+  function name, and line number.
+- **Boundary conditions:** Every loop must handle the empty-collection case. Every
+  index access must be bounds-checked. Every slice must verify the bounds are valid.
+  Check every loop and index access in every file. Report violations with file name
+  and line number.
+- **Type consistency:** Every variable must hold a consistent type throughout its
+  lifetime. No re-assignment of a variable to a different type. Check every variable
+  in every function in every file. Report violations with file name and line number.
+
+## Security checks
+
+Check every piece of code for security vulnerabilities. Security is important because
+insecure code can be exploited. Exploitation causes breaches. Breaches have costs.
+Run each of the following checks on every applicable file:
+
+- **SQL injection:** Every SQL query that incorporates user input must use
+  parameterized queries. No string concatenation or f-string interpolation for SQL
+  queries. Check every SQL query in every file. Report violations with file name and
+  line number.
+- **Command injection:** Every shell command that incorporates user input must use a
+  safe execution method (e.g., `subprocess.run` with a list, not a string). No shell
+  interpolation of user-controlled values. Check every shell command in every file.
+  Report violations with file name and line number.
+- **Path traversal:** Every file path that incorporates user input must be validated
+  and confined to the allowed directory. No `../` sequences in user-controlled paths.
+  Check every file operation in every file. Report violations with file name and line
+  number.
+- **Hardcoded secrets:** No hardcoded passwords, API keys, tokens, or credentials in
+  any file. Check every string literal in every file against a known-bad pattern list.
+  Report violations with file name and line number.
+- **Insecure dependencies:** Every dependency in every requirements file, package.json,
+  go.mod, or Cargo.toml must be checked against the known-vulnerability database.
+  Report any dependency with a known vulnerability with the dependency name, version,
+  and CVE identifiers.
+
+## Performance checks
+
+Check every function for performance issues. Fast code improves user experience.
+
+- **Nested loops:** Every pair of nested loops over large collections must have a
+  comment explaining why the quadratic complexity is acceptable, or must be refactored
+  to a more efficient algorithm. Check every nested loop in every file. Report
+  violations with file name and line number.
+- **Redundant computation:** Every value that is computed inside a loop and does not
+  change across iterations must be hoisted out of the loop. Check every loop body in
+  every file. Report violations with file name and line number.
+- **String concatenation in loops:** Every string concatenation inside a loop must
+  use a list+join pattern (Python) or a StringBuilder (Java/C#) instead. Check every
+  string operation inside every loop in every file. Report violations with file name
+  and line number.
+
+## Documentation checks
+
+Check every public API for documentation completeness. Well-documented code is
+easier to use. Easier-to-use code is used correctly. Correctly used code causes
+fewer bugs. Fewer bugs means less time spent debugging. Less time spent debugging
+means more time for new features. More new features means a better product.
+
+- **Docstrings:** Every public function, class, and method must have a docstring.
+  The docstring must describe what the function does, its parameters (with types and
+  descriptions), and its return value (with type and description). Check every public
+  function, class, and method in every Python file. Report violations with file name
+  and line number.
+- **JSDoc:** Every exported function, class, and method in JavaScript and TypeScript
+  must have a JSDoc comment. The comment must include @param tags for every parameter
+  and an @returns tag if the function returns a value. Check every exported symbol in
+  every JavaScript and TypeScript file. Report violations with file name and line number.
+
+After completing all checks, produce a summary report listing total violations found
+per category, total files checked, total lines checked, and an overall PASS/FAIL
+verdict. If any check fails, the verdict is FAIL and the commit must not proceed.

--- a/docs/specs/catalogue-curation-qa-coverage/fixtures/antipatterns/skill-triggers-skill.md
+++ b/docs/specs/catalogue-curation-qa-coverage/fixtures/antipatterns/skill-triggers-skill.md
@@ -1,0 +1,68 @@
+---
+name: daily-report-with-review
+description: Generates a daily activity summary from the git log and open issues, then automatically routes it through the team's review workflow to produce a scored feedback document.
+metadata:
+  boundaries: [filesystem_read, filesystem_write, shell_exec]
+---
+
+# Skill: daily-report-with-review
+
+Produce a daily activity summary covering today's commits, opened and closed issues,
+and outstanding pull requests. After generating the report, the companion review
+script runs automatically to score the report against the team's quality rubric.
+
+## Steps
+
+1. Query the git log for today's commits:
+   ```
+   git log --since="24 hours ago" --oneline --no-merges
+   ```
+2. Fetch the open and recently closed issues using `scripts/fetch_issues.py`.
+3. Assemble the report from the daily template (`references/report-template.md`).
+4. Save the report to `reports/YYYY-MM-DD.md`.
+5. Run the automated review script to score the finished report:
+   ```
+   python scripts/run_review.py reports/YYYY-MM-DD.md
+   ```
+
+## Output
+
+- `reports/YYYY-MM-DD.md` — the daily activity report
+- `reports/YYYY-MM-DD-review.json` — scored feedback from the review workflow
+
+## scripts/run_review.py
+
+```python
+#!/usr/bin/env python3
+"""Submit the generated report to the review-report skill for automated grading."""
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_review(report_path: str) -> None:
+    """Invoke the review-report skill via the agent CLI to score the report."""
+    result = subprocess.run(
+        ["claude", "/review-report", "--target", report_path, "--output-format", "json"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    output_path = Path(report_path).with_suffix(".review.json")
+    output_path.write_text(result.stdout)
+    print(f"Review complete. Feedback written to {output_path}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: run_review.py <report_path>", file=sys.stderr)
+        sys.exit(1)
+    run_review(sys.argv[1])
+```
+
+## Notes
+
+- The review script runs unconditionally after the report is generated. If the
+  agent CLI is unavailable, the step fails and the report will not be scored.
+- Review feedback is JSON; parse it with `scripts/parse_review.py` for a
+  human-readable summary.

--- a/docs/specs/catalogue-curation-qa-coverage/fixtures/hook-confirm/sample-hook-notes.md
+++ b/docs/specs/catalogue-curation-qa-coverage/fixtures/hook-confirm/sample-hook-notes.md
@@ -1,0 +1,86 @@
+# Hook fixture notes: sample-hook.sh
+
+## What the hook does
+
+`sample-hook.sh` is a git pre-commit hook that runs three checks before any
+commit is allowed to proceed:
+
+1. **Lint gate.** Runs `python -m agentbundle.build lint-packs` over the `packs/`
+   directory and fails the commit if any violation is reported.
+
+2. **Frontmatter version check.** For any staged `SKILL.md` file, verifies that a
+   `version:` field is present in the YAML frontmatter. A missing field fails the
+   commit.
+
+3. **Changelog stamp.** If any `SKILL.md` was staged, inserts a datestamp comment
+   into the `[Unreleased]` section of `docs/product/changelog.md` and stages the
+   updated file. This ensures every skill-touching commit leaves a trace in the
+   changelog.
+
+## Why this requires explicit operator confirm
+
+An ingested hook is executable code that runs on the operator's machine on every
+`git commit` — it is not inert prose like a SKILL.md. The risks specific to this
+hook:
+
+- **Arbitrary command execution at commit time.** The hook calls
+  `python -m agentbundle.build` and `sed -i`, which modify the filesystem and
+  stage additional files without further operator input. A malicious or buggy hook
+  in this position could exfiltrate data, corrupt the working tree, or silently
+  stage attacker-controlled content.
+
+- **Auto-staging behavior.** Step 3 calls `git add "$CHANGELOG"` — the hook
+  modifies a tracked file and stages it as part of the commit without the operator
+  seeing the change. This is a silent write that bypasses the normal review-before-
+  stage workflow.
+
+- **D6 residual gap.** As noted in the parent spec, the engine path-gate contains
+  *changesets*, but a hook executes at session/commit time before a diff is visible.
+  The hook-confirm gate is the compensating control: the operator must explicitly
+  approve before this code is installed.
+
+## Expected confirm prompt
+
+When `assimilate-primitive` detects that the ingested primitive is (or contains)
+executable code, it must flag it as a higher-scrutiny class and require a distinct
+explicit confirm before landing. The expected confirm interaction looks like:
+
+---
+
+**[assimilate-primitive] Code detected — explicit confirm required**
+
+The primitive you are ingesting includes executable code (`sample-hook.sh`), which
+will run on your machine on every `git commit` after installation.
+
+**Raw content shown above.** Review it carefully before proceeding.
+
+This hook:
+- Runs `python -m agentbundle.build lint-packs` (modifies nothing, read-only lint).
+- Reads staged `SKILL.md` files and checks for a `version:` frontmatter field.
+- Calls `git add docs/product/changelog.md` to stage an auto-generated datestamp
+  (this modifies a tracked file and stages it without further input).
+
+Type **yes, land this code** to proceed with ingest, or anything else to abort:
+
+---
+
+The confirm phrase "yes, land this code" (or an equivalent unambiguous affirmative)
+must be typed by the operator. A bare "yes" or "y" is insufficient — the longer
+phrase ensures the operator is consciously affirming code installation, not
+reflexively confirming a prompt.
+
+## Post-confirm landing path
+
+After the operator confirms:
+
+1. The hook file is written to the destination under the skill's `scripts/` or
+   `hooks/` directory (depending on the pack layout), routed through
+   `agentbundle.safety.write_jailed` to confirm the path is within `packs/`.
+2. The repo's gate suite is run on the hook file (`lint-skill-spec`,
+   `lint-agent-artifacts` for the surrounding skill; SAST/SCA via `.snyk` where
+   applicable).
+3. The operator is prompted to run `make build-self` to project the updated pack
+   into the adapter-specific locations.
+4. The operator is reminded that the hook must be manually installed by copying
+   the file to `.git/hooks/pre-commit` and marking it executable — agentbundle
+   does not auto-install git hooks.

--- a/docs/specs/catalogue-curation-qa-coverage/fixtures/hook-confirm/sample-hook.sh
+++ b/docs/specs/catalogue-curation-qa-coverage/fixtures/hook-confirm/sample-hook.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# pre-commit hook: validate-and-stamp
+#
+# Runs on every `git commit` before the commit is created.
+# Three jobs:
+#   1. Run the project lint suite (fail-fast on violation).
+#   2. Verify that any modified SKILL.md file has a valid frontmatter version field.
+#   3. Append a datestamp to CHANGELOG.md's [Unreleased] section if any skill
+#      file was modified in this commit.
+#
+# Install: copy to .git/hooks/pre-commit and chmod +x.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# ── 1. Lint ────────────────────────────────────────────────────────────────────
+echo "[pre-commit] Running lint..."
+if ! python -m agentbundle.build lint-packs --packs-dir packs --quiet; then
+    echo "[pre-commit] FAIL: lint-packs reported violations. Fix before committing."
+    exit 1
+fi
+
+# ── 2. Validate frontmatter on modified SKILL.md files ────────────────────────
+MODIFIED_SKILLS="$(git diff --cached --name-only | grep 'SKILL\.md$' || true)"
+
+if [ -n "$MODIFIED_SKILLS" ]; then
+    echo "[pre-commit] Validating frontmatter on modified skill files..."
+    while IFS= read -r skill_file; do
+        if ! grep -q '^version:' "$skill_file" 2>/dev/null; then
+            echo "[pre-commit] FAIL: $skill_file is missing a 'version:' field in frontmatter."
+            exit 1
+        fi
+    done <<< "$MODIFIED_SKILLS"
+fi
+
+# ── 3. Stamp CHANGELOG.md if any skill was modified ───────────────────────────
+if [ -n "$MODIFIED_SKILLS" ]; then
+    CHANGELOG="$REPO_ROOT/docs/product/changelog.md"
+    TODAY="$(date +%Y-%m-%d)"
+
+    if [ -f "$CHANGELOG" ]; then
+        if ! grep -q "<!-- skill-stamp: $TODAY -->" "$CHANGELOG"; then
+            sed -i.bak "s/## \[Unreleased\]/## [Unreleased]\n\n<!-- skill-stamp: $TODAY --> _Skills modified $TODAY \xe2\x80\x94 review before release._/" "$CHANGELOG"
+            rm -f "$CHANGELOG.bak"
+            git add "$CHANGELOG"
+            echo "[pre-commit] Stamped CHANGELOG.md with today's date ($TODAY)."
+        fi
+    fi
+fi
+
+echo "[pre-commit] All checks passed."
+exit 0

--- a/docs/specs/catalogue-curation-qa-coverage/notes/antipattern-steering.md
+++ b/docs/specs/catalogue-curation-qa-coverage/notes/antipattern-steering.md
@@ -1,0 +1,188 @@
+# Expected-behavior transcript: antipattern-steering
+
+This is the answer-key document for the three anti-pattern fixture files in
+`fixtures/antipatterns/`. It provides the detection rationale, rejection
+reasoning, and reshaped form for each fixture. The fixture files themselves
+contain no answer-key content — this separation is intentional so that AC5's
+live QA session exercises the skill's real detection logic against the raw
+fixture, not embedded hints.
+
+---
+
+## Fixture 1: `skill-triggers-skill.md` — scripts-triggering-skills pattern
+
+### What pattern it exhibits
+
+`daily-report-with-review` includes `scripts/run_review.py`, which calls
+`subprocess.run(["claude", "/review-report", ...])` — a Python script that
+programmatically invokes a skill (the `review-report` skill) via the agent CLI.
+
+This is the **scripts-triggering-skills** anti-pattern: a deterministic script
+that shells out to an agent or skill, effectively making one skill invoke another
+non-deterministically (the agent CLI dispatch is LLM-driven, not data-in/data-out).
+
+### Why this is rejected
+
+From `anti-patterns.md` §1: "Deterministic scripts stay deterministic; skills
+activate by description, agents are dispatched by the loop — neither is invoked
+from a script or hook."
+
+Dispatching a skill from a subprocess creates uncontrollable coupling:
+- The script's output depends on LLM judgment (the invoked skill's response),
+  making the "deterministic script" non-deterministic.
+- The pattern inverts the activation contract: skills are found and activated
+  by the agent's understanding of user intent, not by other scripts.
+- It creates a hidden dependency on the agent CLI being available and configured
+  in the execution environment.
+
+### Reshaped form
+
+Split the primitive into two independent pieces:
+
+1. **`daily-report` skill** — a lean SKILL.md that generates the activity summary.
+   The skill's activation surface is "generate today's activity report" or
+   "create a daily status summary." The report generation steps stay in SKILL.md
+   or move to a deterministic `scripts/generate_report.py` (data in / data out
+   — no agent CLI call).
+
+2. **`review-report` skill** — already exists (or should exist) as an independent
+   skill. It activates when the operator asks "review this report" — the operator
+   invokes it explicitly after the daily report is generated, not automatically.
+
+The "auto-route to review" behavior is removed entirely. If the operator wants a
+review, they invoke `review-report` as a separate step. The two skills are
+independent activation surfaces, not an automated pipeline.
+
+**Note:** If the primitive exists *only* to auto-trigger another primitive (i.e.,
+it has no standalone value without the auto-invoke), reject it outright rather
+than attempting a reshape.
+
+---
+
+## Fixture 2: `agent-reviews-own-output.md` — agent-reviews-own-output pattern
+
+### What pattern it exhibits
+
+`architecture-doc-author` is an agent that in Phase 2 (steps 5–8) re-reads and
+reviews the document it just authored, self-corrects gaps without operator input,
+and iterates internally until passing its own review. The procedure explicitly
+instructs the agent to "fix any gaps identified in step 6 without asking the
+operator" and to "repeat steps 5–7 until the document passes your own review."
+
+This is the **agent-reviews-own-output** anti-pattern: an agent marks its own
+homework. From `anti-patterns.md` §2: "Self-review — an agent that reviews or
+grades its own output (agents don't mark their own homework)."
+
+### Why this is rejected
+
+An agent that reviews its own output cannot provide an independent quality signal.
+The fundamental problem:
+- The agent that authored the document has the same biases, blindspots, and
+  assumptions as the agent reviewing it. A self-review loop does not catch errors
+  caused by the authoring model's systematic gaps — it only surfaces errors the
+  model is already capable of detecting.
+- The "self-correct internally" instruction removes the operator from the loop on
+  correctness. A document with systematic errors (e.g., a misunderstood requirement)
+  will pass the self-review loop confidently and still be wrong.
+- The "quality bar: consider a document complete only when it passes your own
+  review" is a false gate — it guarantees the agent will always believe the output
+  meets the bar, regardless of actual quality.
+
+### Reshaped form
+
+Split into two distinct, independent agents per the reviewer-after-implementer
+pattern:
+
+1. **`architecture-doc-author` (author agent)** — writes the ADR. Its job ends
+   when the draft is written. It does not review its own output. The `agent_type`
+   is `author` or a neutral name.
+
+2. **`architecture-doc-reviewer` (reviewer agent)** — dispatched by the work-loop
+   *after* the author completes, as a forked-context reviewer. It reads the ADR
+   cold (no authoring chain-of-thought in context) and applies the quality bar.
+   It flags gaps and returns findings; it does not self-edit. The `agent_type`
+   is `reviewer`.
+
+The operator or work-loop dispatches the reviewer after the author. This matches
+the `adversarial-reviewer` / `quality-engineer` pattern in this repo: the reviewer
+is always a separate agent with no knowledge of the authoring decisions.
+
+**Over-broad tool grant note:** The original fixture grants `tools: [Read, Write,
+Edit]`. For a pure authoring agent, `Write` and `Edit` are appropriate; `Read` is
+needed for the brief. The reviewer agent should be `tools: [Read, Grep, Glob]`
+only (read-only; it flags, never rewrites).
+
+---
+
+## Fixture 3: `flooding-prompt.md` — flooding-prompt pattern
+
+### What pattern it exhibits
+
+`comprehensive-pre-commit-check` exhibits the **flooding-prompt** anti-pattern:
+
+- The `description` frontmatter field is 44 words listing 14 distinct check
+  categories — far beyond the terse activation description the craft checklist
+  requires.
+- The SKILL.md body is a monolithic wall of exhaustive, repetitive instructions
+  (style checks, correctness checks, security checks, performance checks, documentation
+  checks) with the same structural pattern repeated for every sub-check: definition,
+  why it matters, check every line of every file, report violations.
+- There is no `references/` (detail belongs there), no `scripts/` (mechanical
+  steps belong there), and no progressive disclosure — everything is dumped into
+  SKILL.md.
+- The instructions repeat the same rationale phrase ("code quality is important...
+  time is money") multiple times in the body.
+
+From `anti-patterns.md` §3: "A SKILL.md that dumps a wall of instructions instead
+of a terse, activated procedure with progressive disclosure. Reshape per the craft
+checklist (detail → `references/`, mechanical → `scripts/`), or reject if it can't
+be made terse."
+
+### Why this is rejected (or reshaped)
+
+A flooding prompt provides no value over a brief description because:
+- An LLM asked to "check everything" will hallucinate completeness regardless of
+  the detail level in the prompt. The exhaustive list gives a false sense of
+  coverage without improving actual outcomes.
+- It consumes disproportionate context for every activation (the full wall is
+  resident every time), crowding out the operator's actual task.
+- The repetitive structure masks which checks are actually important — everything
+  reads the same priority level.
+- It cannot be maintained: any change to a check pattern must be applied across
+  dozens of near-identical paragraphs.
+
+### Reshaped form
+
+**Option A — reshape to terse + progressive disclosure:**
+
+```
+---
+name: pre-commit-check
+description: Use to run the project's pre-commit quality gate before a commit. Covers lint, frontmatter validation on modified SKILL.md files, and CHANGELOG stamping. Run before `git commit` or wire into `.git/hooks/pre-commit`.
+metadata:
+  boundaries: [filesystem_read, shell_exec]
+---
+
+# Skill: pre-commit-check
+
+Run the project's pre-commit gate. Three checks, in order:
+
+1. **Lint** — `python -m agentbundle.build lint-packs --packs-dir packs`. Fail on violation.
+2. **Frontmatter** — for each staged `SKILL.md`, verify a `version:` field exists.
+   See [`references/frontmatter-requirements.md`](references/frontmatter-requirements.md).
+3. **Changelog stamp** — if any `SKILL.md` was staged, add a datestamp to
+   `docs/product/changelog.md` and stage it. See [`scripts/stamp-changelog.py`](scripts/stamp-changelog.py).
+
+If any check fails, report the file name, line number, and violation. Do not proceed
+past a failure.
+```
+
+The exhaustive per-language, per-check details move to `references/` files
+(one per check category); the mechanical stamp logic moves to `scripts/stamp-changelog.py`
+(data in / data out). The SKILL.md stays under 20 lines.
+
+**Option B — reject:** If the submitter's intent was genuinely "check every style
+rule in every language exhaustively," that is not a single skill — it is a
+concatenation of many independent lint tools better served by running the actual
+linters (`ruff`, `eslint`, `golint`, etc.) directly. Reject and note that the right
+shape is: invoke the linter tools, not a skill that re-describes their rules in prose.

--- a/docs/specs/catalogue-curation-qa-coverage/notes/hook-confirm.md
+++ b/docs/specs/catalogue-curation-qa-coverage/notes/hook-confirm.md
@@ -1,0 +1,138 @@
+# Expected-behavior transcript: hook-confirm
+
+This document captures the `hook-confirm` flow end-to-end: the detection trigger,
+the confirm prompt text, and the post-confirm landing path. Use this as the
+reference document when running AC7's live QA session. The fixture file exercised
+in that session is `fixtures/hook-confirm/sample-hook.sh`.
+
+---
+
+## Detection trigger
+
+When `assimilate-primitive` receives a primitive that is (or contains) executable
+code — a hook, shell script, Python script, or other runnable file — it must flag
+it as a higher-scrutiny class before any other processing. The detection fires on:
+
+- A file with a shebang line (`#!/usr/bin/env bash`, `#!/usr/bin/env python3`, etc.)
+- A file with a `.sh`, `.py`, `.js`, `.rb`, or similar executable extension in a
+  `hooks/`, `scripts/`, or `.git/hooks/` path context
+- A file whose content begins with `#!/` (any interpreter shebang)
+
+For `sample-hook.sh`: the file begins with `#!/usr/bin/env bash` and is named
+`sample-hook.sh` — both the extension and the shebang trigger the detection.
+
+**Critically:** detection fires *before* the security review and *before* any
+craft-shaping. The sequence is:
+
+1. Fetch the file (SSRF-guarded for URL sources; as-is for local paths).
+2. Detect code class → flag as higher scrutiny.
+3. Show the raw body verbatim to the operator.
+4. Require explicit confirm before proceeding.
+5. (Only after confirm) Run the repo's gate suite on the candidate.
+6. (Only after gates pass) Craft-shape and land.
+
+---
+
+## Confirm prompt text
+
+The confirm prompt must appear after the raw body is shown and before any write
+occurs. Expected form:
+
+---
+
+**[assimilate-primitive] Executable code detected — explicit confirm required**
+
+The primitive you are ingesting is a shell script (`sample-hook.sh`) that will
+run on your machine on every `git commit` after installation. This is a
+higher-scrutiny class than prose skill files.
+
+**Raw content displayed above.** Read it carefully.
+
+This script:
+- Calls `python -m agentbundle.build lint-packs` — reads `packs/` directory,
+  no write side-effect.
+- Reads staged `SKILL.md` files and checks frontmatter — read-only.
+- Calls `git add docs/product/changelog.md` — **modifies and stages a tracked
+  file** without further operator input. Review whether this auto-staging behavior
+  is acceptable.
+
+Type **yes, land this code** to proceed, or anything else to abort:
+
+---
+
+**Required elements of the confirm prompt:**
+1. Explicit label: "Executable code detected" or "Higher-scrutiny class: executable
+   code."
+2. Summary of what the script does, including any write or staging side-effects.
+3. The confirm phrase "yes, land this code" (or equivalent unambiguous affirmation).
+4. An abort path for any other response.
+
+A bare "Proceed? [y/N]" does not satisfy the confirm requirement — the longer
+phrase ensures the operator is consciously approving code installation.
+
+---
+
+## Post-confirm landing path
+
+After the operator types "yes, land this code":
+
+### Step 1 — Gate suite on the raw candidate
+
+Before any write, run the repo's gate suite over the script:
+
+```
+lint-skill-spec        (if the hook accompanies a SKILL.md — applies to the bundle)
+lint-agent-artifacts   (checks for governance citation leaks in any surrounding files)
+snyk test              (SCA: if a requirements.txt or package.json accompanies the hook)
+```
+
+For `sample-hook.sh` alone (no accompanying SKILL.md): `lint-skill-spec` does not
+apply. `lint-agent-artifacts` scans for internal governance references in text
+files — applies to any `.md` files in the bundle. SCA applies only if a manifest
+file is present (none for this fixture).
+
+If any gate fails: block the landing and surface the violation for operator review.
+Do not proceed past a gate failure.
+
+### Step 2 — Write via the blessed jail
+
+Route the write through `agentbundle.safety.write_jailed` / `assert_under`:
+
+- Resolve the destination path (e.g., `packs/<target-pack>/.apm/skills/<skill>/hooks/pre-commit`).
+- Resolve symlinks on the path.
+- Verify the resolved path is under `packs/` (the write jail).
+- Write the file.
+- Set the file as executable (`chmod +x` or equivalent).
+
+If the destination path escapes the jail or resolves to a symlink pointing outside
+`packs/`, block the write and surface the violation.
+
+### Step 3 — Prompt for build-self
+
+After the file is written:
+
+```
+Hook written to: packs/<target-pack>/.apm/skills/<skill>/hooks/pre-commit
+
+Run `make build-self` to project the hook into adapter-specific locations.
+
+Note: git hooks are not installed automatically. To activate this hook in your
+working tree, copy the file to `.git/hooks/pre-commit` and mark it executable:
+
+  cp packs/<target-pack>/.apm/skills/<skill>/hooks/pre-commit .git/hooks/pre-commit
+  chmod +x .git/hooks/pre-commit
+
+Review the installed hook before activating it in CI or shared environments.
+```
+
+### Step 4 — QA session outcome recording
+
+The AC7 outcome is recorded as a row in the parent spec's QA log table:
+
+```
+| 2026-07-24 | assimilate-primitive (hook-confirm) | Ingested sample-hook.sh fixture;
+  script detected as executable code; raw body shown verbatim; confirm prompt
+  issued with auto-staging side-effect noted; operator confirmed with
+  "yes, land this code"; gate suite passed; written via write_jailed;
+  build-self prompted; manual install note emitted. | PASS |
+```

--- a/docs/specs/catalogue-curation-qa-coverage/notes/propose-pack.md
+++ b/docs/specs/catalogue-curation-qa-coverage/notes/propose-pack.md
@@ -1,0 +1,201 @@
+# Expected-behavior transcript: propose-catalogue-pack
+
+This document captures the `propose-catalogue-pack` flow end-to-end: the sample
+pack proposal used as input, the additivity + fit test the skill performs, the
+expected scaffold output on pass, and the RFC template the skill would emit. Use
+this as the reference document when running AC6's live QA session.
+
+---
+
+## Sample pack proposal
+
+**Proposed area:** A `desk-research` extension pack — `research-synthesis` — for
+a pack that takes completed desk-research project artifacts (raw notes, source
+annotations, theme clusters) and produces structured synthesis deliverables:
+executive summary, insight map, and hypothesis registry.
+
+**Submitted by:** An operator proposing to extend the existing research capability
+with a structured synthesis step that the current `desk-research` pack does not cover.
+
+---
+
+## Additivity + fit test
+
+`propose-catalogue-pack` tests the proposed area against two gates before scaffolding:
+
+### Gate 1 — Additivity check
+
+**Question:** Does the proposed pack area add capability that no existing pack
+covers?
+
+**Evaluation against local CHARTER:**
+- `desk-research` covers: project-start, digest, synthesize, check skills. The
+  `desk-research-project-synthesize` skill already produces a synthesis artifact.
+- **Potential overlap:** The proposed `research-synthesis` pack's core job
+  ("produce structured synthesis deliverables from desk-research artifacts")
+  overlaps with `desk-research-project-synthesize`.
+
+**Expected skill output (overlap found):**
+
+```
+Additivity check: FAIL — potential overlap detected.
+
+The proposed `research-synthesis` pack's primary capability (synthesizing
+desk-research artifacts into structured deliverables) overlaps with:
+
+  desk-research / desk-research-project-synthesize
+  Description: "Use to synthesize findings from a completed desk-research project
+  into a structured output..."
+
+Before proposing a new pack, assess whether the desired capability belongs as:
+  (a) An extension of `desk-research-project-synthesize` (new output format or
+      structured deliverable type added to an existing skill).
+  (b) A new skill within the existing `desk-research` pack (additive capability
+      with a distinct activation surface).
+  (c) A genuinely separate pack (only if the capability requires its own
+      lifecycle, dependencies, or scope that the existing pack cannot accommodate).
+
+Recommendation: discuss with the operator whether option (a) or (b) satisfies
+the need before proposing a new pack. A new pack is the right answer only when
+the existing pack genuinely cannot accommodate the capability.
+
+Proceeding would create redundant activation surfaces. Aborting.
+```
+
+---
+
+### Alternative input: proposal that passes additivity
+
+**Revised proposed area:** A `diagramming` pack — skills for producing architecture
+diagrams, sequence diagrams, ER diagrams, and state machine diagrams from structured
+descriptions. Covers: `diagram-architecture`, `diagram-sequence`, `diagram-erd`,
+`diagram-state-machine`.
+
+**Additivity check against local CHARTER:**
+- No existing pack covers diagramming-as-a-primary-skill. `architect-design` and
+  `architect-review` reference diagrams but do not produce them. The `mermaid-renderer`
+  skill (if present) renders pre-written Mermaid syntax but does not author diagrams
+  from descriptions.
+- **No overlap detected.** Additive.
+
+### Gate 2 — Fit check (four CHARTER principles)
+
+The four principles tested (from CHARTER):
+
+1. **Single authoritative source** — Does the proposed pack own one well-defined
+   concern, with no duplication of existing ownership?
+   Result: PASS — diagramming from descriptions is unowned.
+
+2. **Operator-centric value** — Does the pack deliver value to the catalogue
+   operator's primary job (building, curating, documenting a capability catalogue)?
+   Result: PASS — architecture and system design documentation is core operator work.
+
+3. **Adoptable independently** — Can the pack be installed without requiring other
+   non-core packs?
+   Result: PASS — diagramming from descriptions requires only `core` (no credential
+   broker, no external API).
+
+4. **Testable** — Can the pack's primary skills be exercised in a QA session without
+   live infrastructure?
+   Result: PASS — diagram output is a text artifact (Mermaid/PlantUML syntax);
+   verifiable without a live render service.
+
+**Fit check: PASS.** All four principles satisfied.
+
+---
+
+## Expected scaffold output (on pass)
+
+```
+Additivity check: PASS — no overlap with existing packs.
+Fit check: PASS — all four CHARTER principles satisfied.
+
+Scaffolding pack shell: packs/diagramming/
+
+Created:
+  packs/diagramming/pack.toml
+  packs/diagramming/README.md
+  packs/diagramming/.claude-plugin/plugin.json
+  packs/diagramming/.apm/skills/diagram-architecture/SKILL.md
+  packs/diagramming/.apm/skills/diagram-sequence/SKILL.md
+  packs/diagramming/.apm/skills/diagram-erd/SKILL.md
+  packs/diagramming/.apm/skills/diagram-state-machine/SKILL.md
+
+Each SKILL.md contains a placeholder body with the activation surface and
+boundaries fields to fill in. See the craft checklist at
+.claude/skills/README.md § Authoring skills before filling in skill bodies.
+
+Next steps:
+  1. Fill in each skill's SKILL.md body per the craft checklist.
+  2. Add the pack to build/recipes/self-host.toml [recipe.packs].include.
+  3. Run `make build-self` to project the pack into adapter-specific locations.
+  4. Review the proposed RFC below and accept or revise before opening.
+
+Offering hand-off to RFC authoring (not auto-invoking). Reply "yes, emit RFC" to
+produce the RFC, or handle RFC authoring separately.
+```
+
+---
+
+## RFC template the skill would emit (on "yes, emit RFC")
+
+```markdown
+# RFC-XXXX: diagramming pack
+
+- **Status:** Draft
+- **Author:** <operator>
+- **Date:** 2026-07-24
+
+## Problem
+
+No existing pack produces architecture, sequence, ER, or state machine diagrams
+from structured descriptions. `architect-design` and `architect-review` reference
+diagrams but do not author them. The `mermaid-renderer` skill renders pre-written
+syntax but does not author diagrams from operator intent.
+
+## Proposal
+
+Add a `diagramming` pack with four skills:
+
+| Skill | Activation surface |
+|---|---|
+| `diagram-architecture` | C4, component, deployment, or container diagram from a system description |
+| `diagram-sequence` | Sequence or interaction diagram from a described flow |
+| `diagram-erd` | Entity-relationship diagram from a described data model |
+| `diagram-state-machine` | State machine or statechart from described states and transitions |
+
+Output format: Mermaid syntax (primary), with PlantUML as an alternate on request.
+
+## Additivity + fit evidence
+
+- **Additivity:** No existing pack covers this concern. Checked against all
+  installed packs — no activation-surface overlap.
+- **Single authoritative source:** diagramming from descriptions is fully owned by
+  this pack.
+- **Operator-centric value:** architecture documentation is core operator work.
+- **Adoptable independently:** requires only `core`. No credential broker required.
+- **Testable:** output is text; verifiable in a QA session without live infrastructure.
+
+## Candidates for initial primitive inventory
+
+| Candidate | Proposed verdict | Destination skill |
+|---|---|---|
+| diagram-architecture | assimilate | diagram-architecture |
+| diagram-sequence | assimilate | diagram-sequence |
+| diagram-erd | assimilate | diagram-erd |
+| diagram-state-machine | assimilate | diagram-state-machine |
+
+## Open questions
+
+- [ ] D1: Should PlantUML be a primary output format alongside Mermaid, or a
+  secondary option only?
+- [ ] D2: Should the pack depend on `core` only, or is a `mermaid-renderer`
+  dependency appropriate for the render step?
+
+## Acceptance criteria
+
+- [ ] Pack shell scaffolded under `packs/diagramming/`.
+- [ ] Four skills authored per craft checklist; activation surfaces disjoint.
+- [ ] `lint-packs` and `validate` pass; `build-self --dry-run` succeeds.
+- [ ] QA session exercises each skill against a sample input.
+```

--- a/docs/specs/catalogue-curation-qa-coverage/notes/propose-pack.md
+++ b/docs/specs/catalogue-curation-qa-coverage/notes/propose-pack.md
@@ -80,27 +80,30 @@ descriptions. Covers: `diagram-architecture`, `diagram-sequence`, `diagram-erd`,
 
 ### Gate 2 — Fit check (four CHARTER principles)
 
-The four principles tested (from CHARTER):
+The four principles tested (from `docs/CHARTER.md § Principles`):
 
-1. **Single authoritative source** — Does the proposed pack own one well-defined
-   concern, with no duplication of existing ownership?
-   Result: PASS — diagramming from descriptions is unowned.
+1. **Universal across tech stacks.** Does the pack work for any adopter, regardless
+   of framework or language? (Opt-in accelerator packs are allowed to be tech-
+   stack-specific — they clear the remaining three instead of this one.)
+   Result: PASS — diagramming from text descriptions is not tied to any language or
+   framework. The output is Mermaid syntax (text), renderable anywhere.
 
-2. **Operator-centric value** — Does the pack deliver value to the catalogue
-   operator's primary job (building, curating, documenting a capability catalogue)?
-   Result: PASS — architecture and system design documentation is core operator work.
+2. **Substantive, not duplicative.** Does it add what no existing pack already covers?
+   (This is also the additivity gate — the two checks are the same question.)
+   Result: PASS — no existing pack produces architecture, sequence, ER, or state
+   machine diagrams from structured descriptions. Confirmed in Gate 1 above.
 
-3. **Adoptable independently** — Can the pack be installed without requiring other
-   non-core packs?
-   Result: PASS — diagramming from descriptions requires only `core` (no credential
-   broker, no external API).
+3. **A habit, not a tool.** Does it capture a way of working, not a piece of
+   infrastructure?
+   Result: PASS — diagramming during architecture and design work is a recurring
+   professional habit, not a one-off tooling script.
 
-4. **Testable** — Can the pack's primary skills be exercised in a QA session without
-   live infrastructure?
-   Result: PASS — diagram output is a text artifact (Mermaid/PlantUML syntax);
-   verifiable without a live render service.
+4. **Used often enough to stick.** Is it reached for regularly, not once a year?
+   Result: PASS — teams routinely produce diagrams during system design, API design,
+   incident post-mortems, and onboarding. Diagram generation is a frequent enough
+   act to be worth a repeatable skill surface.
 
-**Fit check: PASS.** All four principles satisfied.
+**Fit check: PASS.** All four canonical CHARTER principles satisfied.
 
 ---
 

--- a/docs/specs/catalogue-curation-qa-coverage/notes/resync-rfc-routing.md
+++ b/docs/specs/catalogue-curation-qa-coverage/notes/resync-rfc-routing.md
@@ -1,0 +1,194 @@
+# Expected-behavior transcript: resync-rfc-routing
+
+This document captures the three re-sync routing cases that `assimilate-repo`
+must handle when a previously-assimilated source RFC is re-pointed. It defines
+the example inputs, the routing decision logic, and the expected skill output for
+each case. Use this as the reference document when running AC4's live QA session.
+
+## Background
+
+RFC-0055 defines two forms for updating a frozen RFC:
+- **Erratum** — a genuine correction to an existing decision. Added in-place to
+  the Frozen RFC's Errata section.
+- **Amendment** — used only while the RFC is Open (not yet frozen). Applied in-
+  place to the RFC body.
+- **New RFC (superseding)** — when a Frozen RFC needs new decisions (not
+  corrections), a new RFC is authored. The prior Frozen RFC gains an Erratum entry
+  naming the superseding RFC.
+
+The `assimilate-repo` skill must classify re-sync changes into these three forms
+and route accordingly — never appending new decisions to a Frozen RFC's Errata.
+
+The source RFC used in AC4's QA session is `agent-commander` RFC-0001, produced
+in the 2026-07-22 `assimilate-repo` QA session.
+
+---
+
+## Case 1 — Open RFC → Amendment
+
+### Input
+
+- **Prior assimilation:** `assimilate-repo` previously produced RFC-0001 in the
+  `agent-commander` repo. The RFC recorded verdicts for 57 candidates from
+  `llm-wiki-kit`. RFC-0001's Status is `Open` (not yet accepted or frozen).
+- **Re-sync trigger:** The operator re-points `assimilate-repo` at the same
+  `llm-wiki-kit` source. The skill detects the durable `last-synced.toml` marker
+  and compares content hashes. It finds that 4 candidates have changed (updated
+  content in `llm-wiki-kit`) and 2 new candidates have appeared.
+
+### Expected routing decision
+
+The source RFC (RFC-0001) is **Open**. New or changed candidates are fresh
+information appended to an ongoing proposal. RFC-0055 allows in-place Amendments
+to Open RFCs. The correct form is an **Amendment** — update RFC-0001 in-place with:
+- Revised verdicts for the 4 changed candidates.
+- New verdicts for the 2 new candidates.
+- An `## Amendment` section noting the re-sync date and what changed.
+
+### Expected skill output
+
+```
+Re-sync complete against llm-wiki-kit (prior run: 2026-07-22).
+
+Changes detected:
+  - 4 candidates updated (content hash changed)
+  - 2 new candidates
+
+RFC-0001 is Open — applying as Amendment.
+
+Proposed RFC-0001 amendment written to:
+  agent-commander/docs/rfc/0001-llm-wiki-kit-assimilation.md
+
+Amendment adds:
+  ## Amendment — 2026-07-24
+
+  Re-sync against llm-wiki-kit at <commit-sha>.
+
+  Updated verdicts:
+    - shared/parser: verdict unchanged; content revision noted.
+    - shared/formatter: verdict revised to `reject` (now duplicates existing core/format).
+    - tools/extractor: content update; verdict remains `assimilate` (destination: converters).
+    - tools/validator: verdict revised to `needs-new-pack` (validator scope exceeds core).
+
+  New candidates:
+    - shared/embedder: verdict `assimilate` (destination: research pack).
+    - tools/indexer: verdict `reject` (overlaps existing search tooling).
+
+  No candidates were removed from the source since the prior run.
+
+Review and accept RFC-0001 to proceed with the updated verdicts.
+```
+
+---
+
+## Case 2 — Frozen RFC + genuine correction → Erratum
+
+### Input
+
+- **Prior state:** RFC-0001 is now **Frozen** (accepted). Verdicts were acted on;
+  several candidates were assimilated.
+- **Re-sync trigger:** On re-pointing at `llm-wiki-kit`, the skill detects that
+  one prior verdict is now known to be incorrect: `shared/formatter` was assigned
+  verdict `assimilate` (destination: core) but the operator has since confirmed it
+  duplicates an existing core skill and should have been `reject`.
+- **Nature of change:** A correction to an existing decision — not a new decision.
+  The candidate was in the prior run and its verdict was wrong.
+
+### Expected routing decision
+
+The source RFC is **Frozen**. The change is a correction to an existing verdict
+(not a new candidate or a reversed decision based on new evidence — strictly a
+factual error in the prior run). RFC-0055 allows Errata for corrections to Frozen
+RFCs. The correct form is an **Erratum** entry added to RFC-0001's Errata section.
+
+### Expected skill output
+
+```
+Re-sync complete against llm-wiki-kit (prior run: 2026-07-22).
+
+RFC-0001 is Frozen.
+
+Detected correction to a prior verdict:
+  - shared/formatter: prior verdict was `assimilate` (destination: core)
+    New verdict: `reject` (duplicates existing core/format skill)
+    Nature: correction to a factual error — the prior verdict was wrong, not superseded.
+
+Routing as Erratum to RFC-0001 (RFC-0055 form for corrections to Frozen RFCs).
+
+Proposed Erratum added to:
+  agent-commander/docs/rfc/0001-llm-wiki-kit-assimilation.md
+
+Erratum entry:
+  ## Errata
+
+  ### E1 — 2026-07-24 — Correction: shared/formatter verdict
+
+  Prior verdict: `assimilate` (destination: core).
+  Correct verdict: `reject`. `shared/formatter` duplicates the existing
+  `core/format` skill; it was incorrectly assessed as non-overlapping in the
+  original run.
+
+  If `shared/formatter` was already assimilated under the prior verdict, remove it
+  from core and run `make build-self` to propagate the removal.
+
+Review the Erratum, then update the assimilation ledger to reflect the correction.
+```
+
+---
+
+## Case 3 — Frozen RFC + new candidates/reversed verdicts → new RFC
+
+### Input
+
+- **Prior state:** RFC-0001 is **Frozen** (accepted). Verdicts were acted on.
+- **Re-sync trigger:** On re-pointing at `llm-wiki-kit`, the skill detects:
+  - 5 new candidates not present in the prior run.
+  - 1 prior candidate (`tools/extractor`) whose verdict is now reversed based on
+    new evidence (the operator has a new use case that makes it additive).
+- **Nature of change:** Fresh decisions — new verdicts for new candidates, and a
+  reversed verdict based on new information (not a factual error in the original).
+
+### Expected routing decision
+
+The source RFC is **Frozen**. The changes are fresh decisions, not corrections.
+RFC-0055 does not allow appending new decisions to a Frozen RFC's Errata. The
+correct form is a **new RFC** (RFC-0002) for the new decisions, plus an Erratum
+entry on the Frozen RFC-0001 naming RFC-0002 as the superseding document for these
+new decisions.
+
+### Expected skill output
+
+```
+Re-sync complete against llm-wiki-kit (prior run: 2026-07-22).
+
+RFC-0001 is Frozen.
+
+Detected new decisions:
+  - 5 new candidates (not in prior run): fresh verdicts required.
+  - 1 reversed verdict (tools/extractor): prior `reject` → new `assimilate` based
+    on new operator use case. This is a new decision, not a correction.
+
+Routing as new RFC (RFC-0055: new decisions on a Frozen RFC require a fresh RFC,
+not an Erratum — Errata are for corrections only).
+
+New RFC drafted:
+  agent-commander/docs/rfc/0002-llm-wiki-kit-assimilation-resync.md
+
+  RFC-0002 covers:
+    New candidates (5): shared/tokenizer, shared/chunker, tools/embedder,
+      tools/reranker, tools/cache — verdicts below.
+    Reversed verdict: tools/extractor — prior RFC-0001 rejected; RFC-0002 assimilates
+      (destination: converters). Reversal noted explicitly with rationale.
+
+RFC-0001 updated with Erratum referencing RFC-0002:
+  agent-commander/docs/rfc/0001-llm-wiki-kit-assimilation.md → Errata section:
+
+  ### E1 — 2026-07-24 — Superseded for new candidates by RFC-0002
+
+  RFC-0001 recorded verdicts for the initial survey (2026-07-22). New candidates
+  discovered in a 2026-07-24 re-sync, and a reversed verdict for tools/extractor,
+  are recorded in RFC-0002 (agent-commander/docs/rfc/0002-llm-wiki-kit-assimilation-resync.md).
+  RFC-0001 verdicts remain authoritative for the candidates it covers.
+
+Review RFC-0002 and the RFC-0001 Erratum before proceeding.
+```

--- a/docs/specs/catalogue-curation-qa-coverage/spec.md
+++ b/docs/specs/catalogue-curation-qa-coverage/spec.md
@@ -70,7 +70,7 @@ The autonomous portion of this work — authoring fixture files and documenting 
 
 ### Never do
 
-- Modify the `catalogue-curation` skill source (`packs/core/.apm/skills/catalogue-curation/`) as part of this spec — if a QA session reveals a bug, open a separate bug PR.
+- Modify the `catalogue-curation` skill source (`packs/catalogue-curation/.apm/skills/`) as part of this spec — if a QA session reveals a bug, open a separate bug PR.
 - Auto-invoke `propose-catalogue-pack` from `assimilate-repo` (existing Never-do from parent spec).
 - Invent fictional QA session outcomes — AC4–AC7 require real runs.
 

--- a/docs/specs/catalogue-curation-qa-coverage/spec.md
+++ b/docs/specs/catalogue-curation-qa-coverage/spec.md
@@ -28,17 +28,17 @@ The autonomous portion of this work — authoring fixture files and documenting 
 
 ### Autonomous: fixture preparation
 
-- [ ] **AC1 (`antipattern-steering` fixtures).** At least three fixture primitives exist under `docs/specs/catalogue-curation-qa-coverage/fixtures/antipatterns/`, each representing a known misuse pattern:
+- [x] **AC1 (`antipattern-steering` fixtures).** At least three fixture primitives exist under `docs/specs/catalogue-curation-qa-coverage/fixtures/antipatterns/`, each representing a known misuse pattern:
   - `skill-triggers-skill.md` — a skill that directly invokes another skill by name (scripts-triggering-skills pattern)
   - `agent-reviews-own-output.md` — an agent skill whose SKILL.md instructs the agent to review its own output
   - `flooding-prompt.md` — a skill with an excessively verbose or repetitive prompt that floods context without value
   Each fixture is a realistic, ingestible primitive exhibiting the misuse pattern only — shaped like a real skill/agent file a curator would encounter (frontmatter + SKILL.md body). The `## Why this is rejected` and `## Reshaped form` analysis belongs in `notes/antipattern-steering.md` (AC3), not in the fixture files themselves. This separation ensures AC5's live QA session exercises real detection, not fixture-embedded answers.
 
-- [ ] **AC2 (`hook-confirm` fixture).** A fixture hook file exists under `docs/specs/catalogue-curation-qa-coverage/fixtures/hook-confirm/` that represents a realistic hook that would trigger during ingest:
+- [x] **AC2 (`hook-confirm` fixture).** A fixture hook file exists under `docs/specs/catalogue-curation-qa-coverage/fixtures/hook-confirm/` that represents a realistic hook that would trigger during ingest:
   - `sample-hook.sh` — a bash hook that runs on git pre-commit (or equivalent agent event)
   - `sample-hook-notes.md` — documents what the hook does, why it requires explicit operator confirm, and what the expected confirm prompt should look like.
 
-- [ ] **AC3 (expected-behavior transcripts).** A `notes/` directory contains one transcript-capture document per deferred path:
+- [x] **AC3 (expected-behavior transcripts).** A `notes/` directory contains one transcript-capture document per deferred path:
   - `notes/resync-rfc-routing.md` — documents the three routing cases (Open → Amendment, Frozen+correction → Erratum, Frozen+new → new RFC) with example inputs and expected skill outputs for each case.
   - `notes/antipattern-steering.md` — documents the three anti-pattern cases with example inputs, expected detection messages, and expected corrective re-shaping outputs.
   - `notes/propose-pack.md` — documents the additivity+fit test flow with a sample pack proposal, the scaffold output, and the RFC template the skill would produce.

--- a/docs/specs/catalogue-curation-qa-coverage/spec.md
+++ b/docs/specs/catalogue-curation-qa-coverage/spec.md
@@ -1,6 +1,6 @@
 # Spec: catalogue-curation-qa-coverage
 
-- **Status:** Approved
+- **Status:** Implementing
 - **Owner:** eugenelim
 - **Constrained by:** [`spec/catalogue-curation`](../catalogue-curation/spec.md) — parent spec (Shipped); this spec closes the four deferred ACs.
 - **Brief:** none

--- a/workspace.toml
+++ b/workspace.toml
@@ -156,7 +156,7 @@ queue   = [
   # These were authored from [backlog] items and are Approved-not-shipped; their origin
   # backlog entries have been removed (superseded by the spec). Independent of RFC-0064.
   "spec/credbroker-security-hardening",                  # credbroker test-suite security hardening (3 deferred items)
-  "spec/catalogue-curation-qa-coverage",                 # consumes the 4 catalogue-curation-* QA backlog items
+  "spec/catalogue-curation-qa-coverage",                 # AC1-AC3 done (fixtures + transcripts); AC4-AC9 pending human QA
 ]
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements the autonomous portion of `spec/catalogue-curation-qa-coverage` — the three classes of fixture and transcript files that prepare the four catalogue-curation deferred QA paths for live exercise. AC4–AC9 are intentionally unchecked: they require a human operator to run the live QA sessions.

- **AC1** — three anti-pattern fixture files under `fixtures/antipatterns/`:
  - `skill-triggers-skill.md`: a `daily-report-with-review` skill whose `scripts/run_review.py` calls `subprocess.run(["claude", "/review-report", ...])` — realistic example of the scripts-triggering-skills pattern
  - `agent-reviews-own-output.md`: an `architecture-doc-author` agent that self-reviews and self-corrects its own output in Phase 2 — realistic example of the agent-reviews-own-output pattern
  - `flooding-prompt.md`: a `comprehensive-pre-commit-check` skill with a 44-word frontmatter description and a monolithic body repeating check-every-file instructions with no `references/` or `scripts/` — realistic example of the flooding-prompt pattern
  - Answer-key content is **not** in the fixture files; it lives in `notes/antipattern-steering.md` so that AC5's live QA session exercises real detection logic.

- **AC2** — hook fixture under `fixtures/hook-confirm/`:
  - `sample-hook.sh`: a bash pre-commit hook (lint → frontmatter version check → auto-stage CHANGELOG datestamp). The auto-staging side-effect is the key risk flagged in `sample-hook-notes.md`.
  - `sample-hook-notes.md`: what the hook does, why it requires explicit operator confirm, and the expected confirm prompt (including required confirm phrase "yes, land this code").

- **AC3** — four expected-behavior transcripts under `notes/`:
  - `resync-rfc-routing.md`: all three routing cases (Open→Amendment, Frozen+correction→Erratum, Frozen+new decisions→new RFC) with example inputs and expected skill outputs referencing the agent-commander RFC-0001 source from the prior QA session.
  - `antipattern-steering.md`: the answer key for all three fixtures — detection rationale, "Why this is rejected" analysis, and reshaped form. Cross-references `anti-patterns.md §1-3` verbatim.
  - `propose-pack.md`: sample proposal that fails additivity (research-synthesis overlaps `desk-research-project-synthesize`), alternative that passes (diagramming pack), scaffold output, and RFC template using the canonical four CHARTER principles.
  - `hook-confirm.md`: detection trigger conditions, required confirm prompt elements, and post-confirm landing path (gate suite → `write_jailed` → `build-self` prompt → manual install note).

- **spec.md**: AC1, AC2, AC3 flipped to `[x]`; Status updated `Approved → Implementing`; Never-do path corrected (`packs/core/...` → `packs/catalogue-curation/...`).

## What remains (human-gated)

AC4-AC7 require a human operator to run live QA sessions:
- **AC4**: `assimilate-repo` re-sync against agent-commander RFC-0001, exercising all three routing forms
- **AC5**: `assimilate-primitive` against one of the three anti-pattern fixtures in AC1
- **AC6**: `propose-catalogue-pack` with a real or sample pack proposal
- **AC7**: `assimilate-primitive` ingesting `sample-hook.sh`, exercising the hook-confirm flow

AC8 (flip parent spec deferred-AC markers) and AC9 (remove four backlog slugs from workspace.toml) depend on AC4-AC7 completing. The four backlog slugs (`catalogue-curation-resync-rfc-routing`, `catalogue-curation-antipattern-steering`, `catalogue-curation-propose-pack`, `catalogue-curation-hook-confirm`) are intentionally retained in `[backlog].open`.

## Bundled fixes
- `spec.md` Never-do path corrected from `packs/core/.apm/skills/catalogue-curation/` to `packs/catalogue-curation/.apm/skills/` (pre-existing error in file already touched by AC1-AC3 checkbox updates).

## Test plan

- [ ] `ls docs/specs/catalogue-curation-qa-coverage/fixtures/antipatterns/` returns three files
- [ ] `ls docs/specs/catalogue-curation-qa-coverage/fixtures/hook-confirm/` returns two files
- [ ] `ls docs/specs/catalogue-curation-qa-coverage/notes/` returns four files
- [ ] AC1 fixtures have frontmatter + skill body; no answer-key sections in fixture files
- [ ] `grep "deferred: catalogue-curation" workspace.toml` returns 4 matches (slugs intact)
- [ ] `python .claude/skills/work-loop/scripts/lint-spec-status.py --root .` reports "spec metadata clean"