### PR TITLE
feat(experience-design): cross-pack XD chain eval + deterministic checker (1.6.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -239,7 +239,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "1.5.0"
+      "version": "1.6.0"
     },
     {
       "author": {

--- a/docs/guides/experience-design/how-to/run-cross-pack-eval.md
+++ b/docs/guides/experience-design/how-to/run-cross-pack-eval.md
@@ -1,0 +1,107 @@
+# How to run the cross-pack experience eval
+
+The cross-pack experience eval (`check-xd-chain.py`) is a deterministic checker that validates five structural invariants of the XD skill chain — without running an LLM. It runs in seconds and requires no API key.
+
+This guide covers: running the checker, reading its output, and promoting a check to a fail-closed gate.
+
+## What the checker validates
+
+The XD skill chain runs in this order: **design-token-taxonomy → design-system-foundations → information-architecture → copy-direction → design-review**. The checker enforces five structural invariants:
+
+1. **Chain completeness** — all five chain skills exist at their expected paths under `packs/experience-design/.apm/skills/`.
+2. **No phantom handoffs** — every skill name backtick-quoted in a `Do NOT use` guard resolves to an existing skill in the pack. Cross-pack references (e.g., `ux-writing` in the `product-engineering` pack) are correctly exempted.
+3. **Boundary guards present** — each chain skill's `description:` frontmatter references its required neighbors per the adjacency map. For example, `information-architecture` must reference `` `copy-direction` `` to make clear where copy work belongs.
+4. **Contract copies present** — the Digital Experience Contract exists as a copy in each of the four packs (product-strategy, product-engineering, experience-design, core).
+5. **Description within cap** — each chain skill's description is ≤1024 characters (the agentbundle description-length cap; over-cap descriptions are silently truncated on some adapters).
+
+## Running the checker
+
+From the repo root:
+
+```
+python3 tools/check-xd-chain.py --root .
+```
+
+This runs in **report-only mode**: all checks run, findings are printed, and the tool exits 0 regardless of findings. Use report-only mode to observe the current state without blocking a workflow.
+
+Example output when all checks pass:
+
+```
+[check-xd-chain] Check 1: chain completeness
+  ✓ chain skill exists: design-token-taxonomy
+  ✓ chain skill exists: design-system-foundations
+  ...
+
+[check-xd-chain] All checks passed.
+```
+
+## Interpreting report-only output
+
+Each check prints one line per item:
+
+- `✓` — the item passed.
+- `✖` — the item failed. The message names what failed and where.
+
+A finding in report-only mode is a warning — it documents a structural issue but does not stop the workflow. Use the finding to plan a fix, then verify the fix by re-running the checker.
+
+**Finding format:**
+
+```
+  ::warning ::[check-name] message describing what failed
+```
+
+The check name tells you which invariant was violated:
+- `chain-completeness` — a chain skill is missing from the pack.
+- `phantom-handoff` — a guard references a skill that does not exist.
+- `boundary-guards` — a chain skill's description is missing a required neighbor reference.
+- `contract-copies` — a DEC contract copy is missing from a pack.
+- `description-length` — a skill description exceeds 1024 characters.
+
+## Running as a gate
+
+To run the checker as a fail-closed gate (exit 1 on any failure):
+
+```
+python3 tools/check-xd-chain.py --gate --root .
+```
+
+Use `--gate` when you want the checker to block a workflow — for example, as a pre-push hook or in CI. The `--gate` flag is the hook point for wiring this checker into a CI workflow once calibration is complete.
+
+When run with `--gate`, findings use the `::error ::` prefix (compatible with GitHub Actions annotation syntax):
+
+```
+  ::error ::[boundary-guards] 'information-architecture' description is missing required guard reference(s): ['copy-direction']
+```
+
+## Promoting a fixture to a gate
+
+The cross-pack eval fixtures (`packs/experience-design/.apm/evals/cross-pack-fixtures.json`) describe golden-path scenarios, boundary violations, and weak regression patterns. These are currently documentation-form only — they describe what to look for, not a runnable test.
+
+To promote a deterministic structural check to a gate:
+
+1. Verify the check passes consistently on the live repo in report-only mode.
+2. Run `python3 tools/check-xd-chain.py --gate --root .` and confirm exit 0.
+3. Wire the `--gate` invocation into your pre-push hook or CI workflow.
+
+To promote an LLM-based fixture scenario to a runnable eval:
+
+1. Author an `evals.json` rubric for the scenario (following the pattern in `packs/experience-design/.apm/skills/design-review/evals/evals.json`).
+2. Run the eval via `python3 tools/run-pack-evals.py` in report-only mode to observe actual model behavior.
+3. After calibration (confirming the rubric discriminates coherent from weak responses), file a follow-on PR to promote to a gate or add to CI.
+
+## Adding a new check
+
+To add a structural invariant to the checker:
+
+1. Write a `check_<name>(root)` function in `tools/check-xd-chain.py` that returns a list of `(check_name, message)` findings.
+2. Call it in `main()` after the existing checks, with a `print` header.
+3. Add a corresponding test in `tools/test-check-xd-chain.py` that injects a failure and verifies `--gate` exits 1.
+4. Update the spec's acceptance criteria to include the new check.
+
+## Related
+
+- Deterministic checker: `tools/check-xd-chain.py`
+- Self-test: `tools/test-check-xd-chain.py`
+- Cross-pack fixtures: `packs/experience-design/.apm/evals/cross-pack-fixtures.json`
+- Digital Experience Contract drift check: `tools/check-contract-drift.py`
+- Per-skill activation evals: `packs/experience-design/.apm/skills/<skill>/evals/`

--- a/docs/specs/cross-pack-experience-eval/plan.md
+++ b/docs/specs/cross-pack-experience-eval/plan.md
@@ -1,0 +1,110 @@
+# Plan: cross-pack-experience-eval
+
+**Spec:** docs/specs/cross-pack-experience-eval/spec.md
+
+## Tasks
+
+### T1 — Create cross-pack-fixtures.json
+**Depends on:** none
+**Mode:** goal-based
+**Done when:** `python3 -c "import json; json.load(open('packs/experience-design/.apm/evals/cross-pack-fixtures.json'))"` exits 0 and file has ≥4 golden_path, ≥3 multi_intent_routing, ≥3 boundary_violations, ≥3 weak_regression entries.
+
+Create `packs/experience-design/.apm/evals/` directory and `cross-pack-fixtures.json` with structured scenario fixtures covering:
+- 4 golden-path types: public marketing+docs, SaaS onboarding+workspace, internal dashboard, transactional service
+- 3 multi-intent routing examples: audit-and-rebuild, full-stack-from-opportunity, unify-marketing-docs-onboarding
+- 3 boundary violation cases: design-system-foundations doing IA's job, IA doing copy-direction's job, copy-direction doing design-review's job
+- 3 weak regression fixtures: locally-polished-but-globally-weak, chain-ordering-violation, phantom-handoff
+
+Tests: no stub (goal-based)
+
+---
+
+### T2 — Create check-xd-chain.py
+**Depends on:** none
+**Mode:** goal-based
+**Done when:** `python3 tools/check-xd-chain.py --gate --root /tmp/xd-cpe` exits 0 and reports all five checks.
+
+Create `tools/check-xd-chain.py` implementing five deterministic checks, stdlib only (no third-party libraries):
+1. Chain completeness — all 5 chain skills exist at expected SKILL.md paths
+2. Phantom-handoff — backtick-quoted skill names in `Do NOT use` guards resolve to existing skills (cross-pack references exempted)
+3. Boundary guards — each chain skill's description references its required neighbors per the adjacency map in spec.md
+4. Contract copies — Digital Experience Contract files exist in all 4 packs
+5. Description length — each chain skill description ≤1024 chars
+
+Report-only default (exit 0 always); `--gate` flag enables fail-closed mode (exit 1 on any failure).
+
+Tests: no stub (goal-based)
+
+---
+
+### T3 — Create test-check-xd-chain.py
+**Depends on:** T2
+**Mode:** goal-based
+**Done when:** `python3 tools/test-check-xd-chain.py` exits 0.
+
+Create `tools/test-check-xd-chain.py` with tests:
+- A: Real repo in report-only mode → exit 0
+- B: Real repo in `--gate` mode → exit 0 (all checks pass)
+- C: Injected missing chain skill → `--gate` exits 1
+- D: Injected phantom skill reference → `--gate` exits 1
+- E: Injected missing boundary guard → `--gate` exits 1
+- F: Injected missing DEC contract copy → `--gate` exits 1
+- G: Injected description over 1024 chars → `--gate` exits 1
+
+Tests: no stub (goal-based)
+
+---
+
+### T4 — Create how-to guide
+**Depends on:** T2
+**Mode:** goal-based
+**Done when:** `docs/guides/experience-design/how-to/run-cross-pack-eval.md` exists and covers: how to run the checker, how to interpret report-only output, and how to promote to a gate.
+
+Tests: no stub (goal-based)
+
+---
+
+### T5 — Bump pack version to 1.6.0
+**Depends on:** none
+**Mode:** goal-based
+**Done when:** `grep '"1.6.0"' packs/experience-design/pack.toml` and `grep '"1.6.0"' packs/experience-design/.claude-plugin/plugin.json` both exit 0.
+
+Approach: Update `version = "1.5.0"` → `"1.6.0"` in `pack.toml` and `"version": "1.5.0"` → `"1.6.0"` in `.claude-plugin/plugin.json`.
+
+Tests: no stub (goal-based)
+
+---
+
+### T6 — Wire test-check-xd-chain into test-all.py
+**Depends on:** T3
+**Mode:** goal-based
+**Done when:** `grep "test-check-xd-chain" tools/test-all.py` exits 0.
+
+Approach: Add `("test-check-xd-chain", [sys.executable, "tools/test-check-xd-chain.py"])` to the TESTS list in alphabetical order.
+
+Tests: no stub (goal-based)
+
+---
+
+### T7 — Update workspace.toml
+**Depends on:** T1, T2, T3, T4, T5, T6
+**Mode:** goal-based
+**Done when:** `python3 -c "import tomllib; tomllib.load(open('workspace.toml','rb'))"` exits 0 and `spec/cross-pack-experience-eval` is absent from `["ini-003".work].queue` and present in `["ini-003".work].shipped`.
+
+Approach: Remove the `{path = "spec/cross-pack-experience-eval", needs = [...]}` block from queue and append `"spec/cross-pack-experience-eval"` to the shipped list. Keep the comment block above the removed entry (commented out, not deleted). Do NOT truncate the file — it is over 1350 lines.
+
+Tests: no stub (goal-based)
+
+---
+
+### T8 — Run gates and build verification
+**Depends on:** T1, T2, T3, T4, T5, T6, T7
+**Mode:** goal-based
+**Done when:**
+- `python3 tools/check-xd-chain.py --gate --root .` exits 0
+- `python3 tools/test-check-xd-chain.py` exits 0
+- `python3 tools/check-contract-drift.py --root .` exits 0
+- `python3 tools/build_gate_chain.py build-self --force --packs-dir packs` exits 0
+- `python3 tools/build_gate_chain.py build-self --dry-run --packs-dir packs` exits 0
+
+Tests: no stub (goal-based)

--- a/docs/specs/cross-pack-experience-eval/spec.md
+++ b/docs/specs/cross-pack-experience-eval/spec.md
@@ -1,0 +1,123 @@
+# Spec: cross-pack-experience-eval
+
+**Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+**Mode:** full (risk triggers: structural — new eval surface + new standalone tool; cross-pack impact across four packs)
+**Owner:** eugenelim
+**Plan:** [`plan.md`](plan.md)
+**Constrained by:** [RFC-0071](../../rfc/0071-digital-experience-doctrine.md) (ini-003 M5), [spec/xd-state-reviewer-doctrine](../xd-state-reviewer-doctrine/spec.md) (1.5.0 upstream — three-pass design-review doctrine must be validatable at chain level)
+**Contract:** tools/check-xd-chain.py; packs/experience-design/.apm/evals/cross-pack-fixtures.json; docs/guides/experience-design/how-to/run-cross-pack-eval.md; tools/test-all.py (wired); pack version 1.5.0 → 1.6.0
+
+> **Spec contract:** this document defines what "done" means. The implementing PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+No cross-pack eval coverage validates that the full XD skill chain (design-token-taxonomy → design-system-foundations → information-architecture → copy-direction → design-review) fires in the right sequence and that pack boundaries stay clean. Skills can drift — a `Do NOT use` guard can reference a non-existent neighbor, or a chain skill can disappear after a rename — without any sentinel catching it.
+
+This spec delivers:
+
+1. **Deterministic checks** (`tools/check-xd-chain.py`) — five structural invariants validated without an LLM: chain completeness, no phantom handoffs, boundary guards present, Digital Experience Contract copies present, and description-length check (each chain skill description within the 1024-char agentbundle cap).
+2. **Cross-pack eval fixtures** (`packs/experience-design/.apm/evals/cross-pack-fixtures.json`) — four golden-path scenario types, three multi-intent routing examples, three boundary violation cases, and three weak regression fixtures — all in report-only mode (calibrate before promoting to gates).
+3. **Integration with existing toolchain** — the deterministic checker produces report output in the same style as existing linters; exits 0 in report-only mode (the default); a `--gate` flag promotes it to a fail-closed gate when calibration is complete. The self-test is wired into `tools/test-all.py`.
+4. **How-to guide** (`docs/guides/experience-design/how-to/run-cross-pack-eval.md`) — how to run the checker, interpret report-only output, and promote to a gate.
+
+**Done when:** the deterministic checks pass (`check-xd-chain.py --gate --root .` exits 0 against the live repo); fixture file is valid and has the required coverage breadth; the how-to guide is published.
+
+## Boundary guard adjacency map
+
+The checker uses an **explicit adjacency map** derived from the actual frontmatter of the five chain skills (not a theoretical bidirectional chain). Each skill must backtick-reference its designated neighbors in its `description:` frontmatter field:
+
+| Skill | Must backtick-reference |
+|-------|------------------------|
+| design-token-taxonomy | `design-system-foundations` |
+| design-system-foundations | `design-token-taxonomy`, `information-architecture` |
+| information-architecture | `copy-direction` |
+| copy-direction | `content-design`, `tone-of-voice` |
+| design-review | `copy-direction` |
+
+`design-review` also guards `creative-direction`, `design-token-taxonomy`, and `information-architecture` using unquoted references — these are present and correct but outside the backtick-check scope (the spec does not require a format change in SKILL.md content).
+
+## Phantom handoff exemption
+
+The phantom-handoff check finds every backtick-quoted name in the `description:` frontmatter field and verifies each resolves to an existing SKILL.md within the experience-design pack. It **exempts cross-pack references**: a backtick name accompanied by explicit pack-qualification in the surrounding sentence (e.g., `ux-writing` in the `product-engineering` pack) is not a phantom. Pack names themselves (e.g., `` `product-engineering` ``) are also exempt. Scanning the full description (not only `Do NOT use` sentences) means future additions of backtick-quoted terms outside guard clauses are also checked.
+
+## Boundaries
+
+**In scope:**
+- `tools/check-xd-chain.py` — standalone deterministic checker (stdlib only; no new dependencies)
+- `tools/test-check-xd-chain.py` — self-test for the checker (same pattern as existing `test-*.py` tools in `tools/`)
+- `tools/test-all.py` — add `test-check-xd-chain.py` to the TESTS list
+- `packs/experience-design/.apm/evals/cross-pack-fixtures.json` — cross-pack eval fixture file (new directory `packs/experience-design/.apm/evals/`; source-only, not projected by build-self)
+- `docs/guides/experience-design/how-to/run-cross-pack-eval.md` — how-to guide (Diátaxis how-to format)
+- `packs/experience-design/pack.toml` + `packs/experience-design/.claude-plugin/plugin.json` — version bump 1.5.0 → 1.6.0
+- `workspace.toml` — move `spec/cross-pack-experience-eval` from queue to shipped
+- `.claude-plugin/marketplace.json` — regenerated by `build-self`
+
+**Out of scope:**
+- Modifying any existing SKILL.md content (the checker validates the current boundary language; it does not correct it)
+- Modifying `run-pack-evals.py` (the per-skill activation eval runner)
+- Adding `eval_queries.json` or `evals.json` to individual skills
+- Creating a CI workflow (report-only mode is the starting state; CI wiring is a follow-on tracked in `cross-pack-eval-ci-gate`)
+- Any file outside the in-scope list above
+
+## Testing Strategy
+
+| AC | Mode | Mechanism |
+|----|------|-----------|
+| AC1 — Chain completeness | goal-based | `--gate --root .` reports all 5 chain skills found |
+| AC2 — Phantom handoff detection | goal-based | Checker reports no phantom skill references (cross-pack refs exempted) |
+| AC3 — Boundary guards present | goal-based | Checker reports guards found per adjacency map for all 5 chain skills |
+| AC4 — Contract copies present | goal-based | Checker reports DEC copies found in all 4 packs |
+| AC5 — Description within cap | goal-based | Checker reports all chain skill descriptions ≤1024 chars |
+| AC6 — Gate mode passes on live repo | goal-based | `python3 tools/check-xd-chain.py --gate --root .` exits 0 |
+| AC7 — Report-only default exits 0 | goal-based | `python3 tools/check-xd-chain.py --root .` exits 0 (no `--gate`) |
+| AC8 — Gate rejects injected failures | goal-based | Self-test: `--gate` exits 1 on injected missing skill, phantom ref, missing guard, missing contract, long description |
+| AC9 — Fixtures valid JSON | goal-based | `python3 -c "import json; json.load(open('packs/experience-design/.apm/evals/cross-pack-fixtures.json'))"` exits 0 |
+| AC10 — Fixture coverage | goal-based | fixtures.json has ≥4 `golden_path`, ≥3 `multi_intent_routing`, ≥3 `boundary_violations`, ≥3 `weak_regression` entries |
+| AC11 — Self-test passes | goal-based | `python3 tools/test-check-xd-chain.py` exits 0 |
+| AC12 — Contract drift gate | goal-based | `python3 tools/check-contract-drift.py --root .` exits 0 |
+| AC13 — How-to guide published | goal-based | `docs/guides/experience-design/how-to/run-cross-pack-eval.md` exists |
+| AC14 — Version bump | goal-based | `pack.toml` and `plugin.json` both read `"1.6.0"` |
+| AC15 — workspace.toml updated | goal-based | `spec/cross-pack-experience-eval` absent from queue, present in shipped |
+| AC16 — test-all wired | goal-based | `test-check-xd-chain` appears in `tools/test-all.py` TESTS list |
+
+## Assumptions
+
+1. The five XD chain skills (design-token-taxonomy, design-system-foundations, information-architecture, copy-direction, design-review) are all present at 1.5.0 on main (confirmed).
+2. The Digital Experience Contract copies exist in all four packs (confirmed — `check-contract-drift.py` passes on main).
+3. MINOR version bump (1.5.0 → 1.6.0) is appropriate for adding new eval capability per RFC-0071 D9.
+4. Python 3.8+ is available (stdlib only — the checker uses no third-party libraries; `re`, `pathlib`, `argparse`, `subprocess` are the only imports).
+5. The fixture file format (JSON with top-level sections by fixture type) is unconstrained by existing schemas — this is a new artifact type.
+6. `packs/experience-design/.apm/evals/` is source-only: `build_gate_chain.py build-self` treats any non-SKILL.md content under `.apm/` as unclassified and does not project it — confirmed by dry-run (exit 0, [info] unclassified for pack-level files).
+7. All five chain skill descriptions are ≤1024 chars on main (confirmed by adversarial review: all ≤981 chars).
+8. The adjacency map in the "Boundary guard adjacency map" section above is correct as of 1.5.0 (confirmed against actual frontmatter).
+
+## Temptations declined
+
+- Tempted to modify `run-pack-evals.py` to add cross-pack modes — declining; a standalone tool has clearer boundaries and does not risk breaking per-skill activation eval behavior.
+- Tempted to add cross-pack routing queries to individual skill `eval_queries.json` files — declining; cross-pack routing tests belong in the cross-pack fixture, not per-skill evals whose runner only sees one pack at a time.
+- Tempted to create a CI workflow in this PR — declining; M5 brief explicitly says all new evals start report-only.
+- Tempted to require bidirectional backtick guards in all chain skill pairs — declining; `design-review`'s existing unquoted guard references are correct and present; a format change to SKILL.md content is out of scope.
+
+## Deferred
+
+- **CI workflow** (`cross-pack-eval-ci-gate`): Once calibration confirms the deterministic checks are stable, wire `check-xd-chain.py --gate` into a CI workflow. The `--gate` flag is the hook point. (deferred: cross-pack-eval-ci-gate)
+- **LLM-judge rubric** (`cross-pack-eval-llm-judge`): The golden-path fixtures describe scenarios in structured form but carry no `evals.json`-style LLM judge rubric. (deferred: cross-pack-eval-llm-judge)
+
+## Acceptance Criteria
+
+- [x] **AC1** — `python3 tools/check-xd-chain.py --gate --root .` reports all 5 chain skills found.
+- [x] **AC2** — `python3 tools/check-xd-chain.py --gate --root .` reports no phantom skill references (cross-pack references are correctly exempted).
+- [x] **AC3** — `python3 tools/check-xd-chain.py --gate --root .` reports boundary guards present for all 5 chain skills per the adjacency map.
+- [x] **AC4** — `python3 tools/check-xd-chain.py --gate --root .` reports Digital Experience Contract copies found in all 4 packs.
+- [x] **AC5** — `python3 tools/check-xd-chain.py --gate --root .` reports all chain skill descriptions ≤1024 chars.
+- [x] **AC6** — `python3 tools/check-xd-chain.py --gate --root .` exits 0 (all five checks pass against the current repo state).
+- [x] **AC7** — `python3 tools/check-xd-chain.py --root .` (without `--gate`) exits 0.
+- [x] **AC8** — `python3 tools/test-check-xd-chain.py` exits 0 and exercises `--gate` failure paths on injected fixtures.
+- [x] **AC9** — `python3 -c "import json; json.load(open('packs/experience-design/.apm/evals/cross-pack-fixtures.json'))"` exits 0.
+- [x] **AC10** — `cross-pack-fixtures.json` contains ≥4 `golden_path` entries, ≥3 `multi_intent_routing` entries, ≥3 `boundary_violations` entries, ≥3 `weak_regression` entries.
+- [x] **AC11** — `python3 tools/test-check-xd-chain.py` exits 0.
+- [x] **AC12** — `python3 tools/check-contract-drift.py --root .` exits 0.
+- [x] **AC13** — `docs/guides/experience-design/how-to/run-cross-pack-eval.md` exists.
+- [x] **AC14** — `packs/experience-design/pack.toml` version is `"1.6.0"` and `packs/experience-design/.claude-plugin/plugin.json` version is `"1.6.0"`.
+- [x] **AC15** — `workspace.toml` has `"spec/cross-pack-experience-eval"` in `["ini-003".work].shipped` and not in `queue`.
+- [x] **AC16** — `tools/test-all.py` TESTS list includes an entry for `test-check-xd-chain`.

--- a/packs/experience-design/.apm/evals/cross-pack-fixtures.json
+++ b/packs/experience-design/.apm/evals/cross-pack-fixtures.json
@@ -1,0 +1,238 @@
+{
+  "schema_version": "1.0",
+  "description": "Cross-pack XD skill chain eval fixtures (ini-003 M5 / spec/cross-pack-experience-eval). All fixtures are report-only — use check-xd-chain.py with --gate to promote deterministic checks to a CI gate. See docs/guides/experience-design/how-to/run-cross-pack-eval.md.",
+
+  "golden_path": [
+    {
+      "id": "gp-01",
+      "name": "Public marketing + documentation site",
+      "scenario": "A product team launching a developer tool needs to establish the end-to-end experience for their marketing site and documentation portal simultaneously. The team has a strategy artifact and a PE shaping brief.",
+      "expected_skill_sequence": [
+        "creative-direction",
+        "design-token-taxonomy",
+        "design-system-foundations",
+        "information-architecture",
+        "copy-direction",
+        "tone-of-voice",
+        "content-design",
+        "design-review"
+      ],
+      "handoff_completeness_criteria": [
+        "creative-direction output (aesthetic direction artifact) is the input to design-token-taxonomy",
+        "design-token-taxonomy output (token taxonomy) is the input to design-system-foundations",
+        "design-system-foundations output (token foundation) grounds information-architecture layout decisions",
+        "information-architecture output (hierarchy, reading flow, wayfinding) sets the surface for copy-direction",
+        "copy-direction output (named ranked copy goals, arbitration rules) guides tone-of-voice and content-design",
+        "design-review pass evaluates the assembled surface against the quality floor and heuristics"
+      ],
+      "coherence_indicators": [
+        "Token taxonomy naming conventions appear in the design-system-foundations output",
+        "Copy goals from copy-direction are traceable in the content-design output",
+        "Design-review findings reference the grounded aesthetic direction from creative-direction",
+        "At least one finding in design-review is flagged as a cross-surface integration issue (marketing vs. docs)"
+      ],
+      "weak_indicators": [
+        "copy-direction references no stable precedent or persona language (directional flag absent)",
+        "design-review does not run the marketing clarity pass on above-fold copy",
+        "Token taxonomy is derived without an aesthetic direction input"
+      ]
+    },
+    {
+      "id": "gp-02",
+      "name": "SaaS onboarding + workspace",
+      "scenario": "A SaaS team redesigning their onboarding flow and in-app workspace. The primary goal is first-success continuity: a new user should reach their first value moment without confusion.",
+      "expected_skill_sequence": [
+        "journey-mapping",
+        "creative-direction",
+        "design-token-taxonomy",
+        "design-system-foundations",
+        "information-architecture",
+        "interaction-design",
+        "copy-direction",
+        "user-flow",
+        "design-review"
+      ],
+      "handoff_completeness_criteria": [
+        "journey-mapping identifies the first-success event that grounds the onboarding scope",
+        "creative-direction is grounded in the persona from the journey map",
+        "information-architecture structures the onboarding screens and workspace layout",
+        "interaction-design patterns reference the design-system-foundations token foundation",
+        "copy-direction names goals for the onboarding surface specifically (not the whole product)",
+        "user-flow captures the step sequence including unhappy paths and recovery states",
+        "design-review runs the full three-pass structure (cold-read, primary task + unhappy path, contract review)"
+      ],
+      "coherence_indicators": [
+        "The first-success event from journey-mapping appears as a design intent in information-architecture",
+        "Interaction patterns from interaction-design reference the token foundation (semantic role names, not values)",
+        "Design-review findings for the onboarding surface reference both the aesthetic direction and the product-object mapping",
+        "State coverage covers the loading, empty, error, and success states at minimum"
+      ],
+      "weak_indicators": [
+        "Copy direction is set at brand level (tone-of-voice) instead of surface-specific level (copy-direction)",
+        "User flow does not include unhappy paths or recovery states",
+        "Design-review runs only a single pass rather than the three-pass structure"
+      ]
+    },
+    {
+      "id": "gp-03",
+      "name": "Internal analytics dashboard",
+      "scenario": "A data team building an internal analytics dashboard for operational KPI tracking. No public-facing surfaces; the primary concern is information density, business-question traceability, and accessibility.",
+      "expected_skill_sequence": [
+        "design-token-taxonomy",
+        "design-system-foundations",
+        "information-architecture",
+        "analytical-design",
+        "design-review"
+      ],
+      "handoff_completeness_criteria": [
+        "design-token-taxonomy establishes a token taxonomy appropriate for data-dense surfaces (including status and categorical tokens)",
+        "design-system-foundations applies the token foundation with full component anatomy for analytical components",
+        "information-architecture structures the dashboard hierarchy so Tier 1 KPIs are above the fold",
+        "analytical-design applies the business-question traceability rubric and widget-tier structure",
+        "design-review runs the analytical genre rubric in Pass 3"
+      ],
+      "coherence_indicators": [
+        "Information-architecture output names the 3-5 business questions the dashboard answers",
+        "Analytical-design output maps each widget to at least one named business question",
+        "Design-review's analytical genre rubric confirms Tier 1 KPIs are within the 9-widget ceiling",
+        "No marketing clarity pass fires (internal tool, no persuasion goal)"
+      ],
+      "weak_indicators": [
+        "Dashboard design proceeds without naming the business questions first",
+        "Tier 1 KPIs include more than 9 widgets or lack comparison baselines",
+        "design-review does not apply the analytical genre rubric"
+      ]
+    },
+    {
+      "id": "gp-04",
+      "name": "Transactional service surface",
+      "scenario": "A fintech product adding a transactional flow (funds transfer, confirmation, receipt) to an existing product. The primary concern is error handling, state completeness, and accessibility at the WCAG floor.",
+      "expected_skill_sequence": [
+        "design-token-taxonomy",
+        "design-system-foundations",
+        "information-architecture",
+        "interaction-design",
+        "copy-direction",
+        "design-review"
+      ],
+      "handoff_completeness_criteria": [
+        "design-system-foundations includes error, warning, and status token roles in the foundation",
+        "information-architecture maps the transaction flow including confirmation, error, and receipt states",
+        "interaction-design specifies focus management and keyboard navigation for the transaction steps",
+        "copy-direction names goals for transactional copy (error messages, confirmations, receipts) as a distinct surface",
+        "design-review quality-floor pass confirms all 18 states are addressed and accessibility floor is met"
+      ],
+      "coherence_indicators": [
+        "Error and warning token roles from design-system-foundations appear in the interaction-design output",
+        "The transaction flow from information-architecture includes all states (loading, processing, success, error, retry)",
+        "Copy direction artifact is scoped to the transactional surface, not the whole product",
+        "Design-review accessibility misses are flagged starting at major severity"
+      ],
+      "weak_indicators": [
+        "State coverage in design-review omits processing, timeout, or retry states",
+        "Copy direction is set at brand level without a transactional surface artifact",
+        "Interaction-design does not address keyboard navigation or focus management"
+      ]
+    }
+  ],
+
+  "multi_intent_routing": [
+    {
+      "id": "mir-01",
+      "name": "Audit and rebuild",
+      "prompt_pattern": "Our current onboarding is broken — users are dropping off before they see value. Audit it and tell me what to rebuild.",
+      "expected_routing": [
+        {"skill": "design-review", "role": "Audit the existing surface — identify what is broken, severity-rated"},
+        {"skill": "information-architecture", "role": "Restructure the hierarchy after the audit identifies IA failures"},
+        {"skill": "copy-direction", "role": "Name copy goals for the rebuilt surface if copy problems are found"},
+        {"skill": "design-review", "role": "Second pass on the rebuilt surface to verify improvements"}
+      ],
+      "routing_rationale": "The prompt has two jobs: evaluate the existing state (design-review) and rebuild it (IA + copy-direction). A coherent response names both jobs and routes to the right skill for each. A weak response either runs only the audit or only the rebuild without the other."
+    },
+    {
+      "id": "mir-02",
+      "name": "Full-stack from opportunity",
+      "prompt_pattern": "We have a validated opportunity: small-business owners need faster invoice approval. Take it all the way to a design-ready brief.",
+      "expected_routing": [
+        {"skill": "creative-direction", "role": "Establish the aesthetic direction for the surface"},
+        {"skill": "design-token-taxonomy", "role": "Derive the token taxonomy from the direction"},
+        {"skill": "design-system-foundations", "role": "Apply the token foundation"},
+        {"skill": "information-architecture", "role": "Structure the invoice approval flow"},
+        {"skill": "copy-direction", "role": "Name copy goals for the approval surface"},
+        {"skill": "user-flow", "role": "Capture the step sequence including approval, rejection, and escalation states"},
+        {"skill": "design-review", "role": "Review the assembled flow before handing to implementation"}
+      ],
+      "routing_rationale": "A full-stack-from-opportunity prompt requires the complete XD chain. A coherent response routes through all chain skills in order and produces handoff artifacts at each step. A weak response skips chain steps or conflates multiple skills' jobs into a single response."
+    },
+    {
+      "id": "mir-03",
+      "name": "Unify marketing, docs, and onboarding",
+      "prompt_pattern": "Our marketing site, docs, and in-app onboarding all feel like different products. Unify them.",
+      "expected_routing": [
+        {"skill": "creative-direction", "role": "Establish a single grounded aesthetic direction that spans all three surfaces"},
+        {"skill": "information-architecture", "role": "Structure each surface's hierarchy independently, then map cross-surface wayfinding"},
+        {"skill": "copy-direction", "role": "Name surface-specific copy goals for marketing, docs, and onboarding as three separate artifacts"},
+        {"skill": "tone-of-voice", "role": "Establish brand-level register that the three surface copy directions align to"},
+        {"skill": "design-review", "role": "Run a multi-surface pass with explicit cross-surface integration check"}
+      ],
+      "routing_rationale": "A unification prompt spans three surfaces. A coherent response treats each surface separately (separate information-architecture and copy-direction artifacts) while grounding them in a shared creative direction and tone-of-voice. A weak response produces a single undifferentiated copy direction for all three surfaces."
+    }
+  ],
+
+  "boundary_violations": [
+    {
+      "id": "bv-01",
+      "name": "design-system-foundations doing information-architecture's job",
+      "violating_skill": "design-system-foundations",
+      "violated_skill": "information-architecture",
+      "description": "A response where design-system-foundations output includes page layout decisions, hierarchy structure, or reading flow — work that belongs to information-architecture.",
+      "detection_signal": "design-system-foundations output prescribes which sections appear above or below the fold, names the navigation structure, or specifies reading flow order.",
+      "guard": "design-system-foundations SKILL.md: 'Near-misses — do not use to ... structure hierarchy and reading flow (use `information-architecture`)'",
+      "example_violation": "A design-system-foundations response that says 'place the hero section above the fold with the token palette below' — layout prescriptions belong in information-architecture, not the token foundation."
+    },
+    {
+      "id": "bv-02",
+      "name": "information-architecture doing copy-direction's job",
+      "violating_skill": "information-architecture",
+      "violated_skill": "copy-direction",
+      "description": "A response where information-architecture output includes copy voice goals, named tone attributes, or prescribed headline language — work that belongs to copy-direction.",
+      "detection_signal": "information-architecture output names copy goals ('the hero headline should be direct and warm'), tone adjectives for sections, or prescribes specific wording for navigation labels as voice rather than structural choices.",
+      "guard": "information-architecture SKILL.md: 'Do NOT use to name copy voice goals — use `copy-direction` for a specific surface or `tone-of-voice` for brand-level register.'",
+      "example_violation": "An information-architecture response that includes 'Copy voice for the navigation should be conversational and outcome-focused' — copy voice goals belong in copy-direction, not IA."
+    },
+    {
+      "id": "bv-03",
+      "name": "copy-direction doing design-review's job",
+      "violating_skill": "copy-direction",
+      "violated_skill": "design-review",
+      "description": "A response where copy-direction output includes heuristic evaluation findings, severity-rated usability issues, or quality-floor pass results — work that belongs to design-review.",
+      "detection_signal": "copy-direction output includes a prioritized findings list, severity ratings, or heuristic evaluations of the surface.",
+      "guard": "copy-direction is a goal-naming skill (named, ranked copy goals + arbitration rules), not an evaluation skill. Evaluation belongs to design-review.",
+      "example_violation": "A copy-direction response that rates the hero copy as '3/4 severity: painkiller-first structure violated' — severity-rated findings belong in design-review's marketing clarity pass, not copy-direction output."
+    }
+  ],
+
+  "weak_regression": [
+    {
+      "id": "wr-01",
+      "name": "Locally polished but globally weak — chain skipped",
+      "description": "A response that produces high-quality output for one skill in the chain but skips the upstream skills the output depends on. The result looks complete but is ungrounded.",
+      "failure_mode": "design-review runs and produces severity-rated findings, but no design-token-taxonomy, design-system-foundations, or copy-direction artifacts exist. The findings cannot reference a grounded aesthetic direction or copy goals.",
+      "detection_criterion": "design-review's taste critique and marketing clarity findings reference no grounded aesthetic direction artifact (no creative-direction output) and no copy goals artifact (no copy-direction output). Findings are unanchored opinions, not referent-grounded judgments."
+    },
+    {
+      "id": "wr-02",
+      "name": "Chain ordering violation — token foundation before taxonomy",
+      "description": "A response where design-system-foundations is applied before design-token-taxonomy has named the token taxonomy. The foundation has no semantic naming convention to implement.",
+      "failure_mode": "design-system-foundations output names semantic roles (e.g., 'color-primary', 'spacing-md') without a prior design-token-taxonomy artifact that established those names and their rationale. The naming choices are arbitrary.",
+      "detection_criterion": "design-system-foundations output references token names, but no design-token-taxonomy artifact exists in the session or workspace. Alternatively, design-system-foundations uses generic placeholder names ('color1', 'size2') that suggest no taxonomy was derived."
+    },
+    {
+      "id": "wr-03",
+      "name": "Phantom handoff — skill references a non-existent successor",
+      "description": "A skill's output explicitly hands off to a skill that does not exist in the pack or has been renamed. The user is given an instruction they cannot follow.",
+      "failure_mode": "A skill's output says 'hand this off to design-token-system to apply values' but the skill is named 'design-token-taxonomy'. Or a skill references 'ux-writing' for product UI strings without clarifying this is in the product-engineering pack, leaving the user unable to find the skill.",
+      "detection_criterion": "The checker's phantom-handoff check (check-xd-chain.py) reports a backtick-quoted skill name in a Do-NOT-use guard that does not resolve to an existing SKILL.md in the pack, and is not exempted as a cross-pack reference."
+    }
+  ]
+}

--- a/packs/experience-design/.claude-plugin/plugin.json
+++ b/packs/experience-design/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "experience-design",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "The design/UX seat for product teams \u2014 the grown-up successor to design-craft. Connective skills walk the thread from outcome to realization (journey-mapping \u2192 user-flow \u2192 service-blueprint) and map the inside-out sibling (process-mapping); copy and content skills name surface voice goals (copy-direction, tone-of-voice) and content structure (content-design); craft skills design each screen (creative-direction, design-token-taxonomy, design-system-foundations, information-architecture, interaction-design) and critique it (design-review), all held to one shared quality-floor (handle-all-states, accessibility floor, reduced-motion). A forked-context experience-reviewer gives the design step an independent design-time review. Pure method: no stack, no values tables, no pixel comps \u2014 points to WCAG / Design Tokens Community Group (DTCG) / Apple HIG / Material 3 / APQC / BPMN, never reprints them."
 }

--- a/packs/experience-design/pack.toml
+++ b/packs/experience-design/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "experience-design"
-version = "1.5.0"
+version = "1.6.0"
 description = "The design/UX seat for product teams — the grown-up successor to design-craft. Connective skills walk the thread from outcome to realization (journey-mapping → content-design → copy-direction → tone-of-voice → user-flow → service-blueprint) and map the inside-out sibling (process-mapping); craft skills design each screen (creative-direction, design-token-taxonomy, design-system-foundations, information-architecture, interaction-design) and critique it (design-review), all held to one shared quality-floor (handle-all-states, accessibility floor, reduced-motion). A forked-context experience-reviewer gives the design step an independent design-time review. Pure method: no stack, no values tables, no pixel comps — points to WCAG / Design Tokens Community Group (DTCG) / Apple HIG / Material 3 / APQC / BPMN, never reprints them."
 readme = "README.md"
 display_name = "Experience Design"

--- a/tools/check-xd-chain.py
+++ b/tools/check-xd-chain.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""Cross-pack XD chain deterministic checker (ini-003 M5 / spec/cross-pack-experience-eval).
+
+Validates five structural invariants of the XD skill chain without running an LLM:
+
+  1. Chain completeness   — all five chain skills exist at their expected SKILL.md paths
+  2. Phantom-handoff      — every backtick-quoted name in the description resolves to an
+                             existing SKILL.md within the pack; cross-pack references
+                             (a name qualified with "in the <pack> pack" nearby) are exempt,
+                             as are pack names themselves
+  3. Boundary guards      — each chain skill's description backtick-references its
+                             required neighbors per the spec adjacency map
+  4. Contract copies      — Digital Experience Contract copies exist in all four packs
+  5. Description length   — each chain skill description is ≤1024 chars (agentbundle cap)
+
+Report-only by default: exits 0 regardless of findings so the checker can ship alongside
+new evals without becoming a gate immediately. Pass --gate to make it fail-closed (exit 1
+on any failure), matching the lint tools' convention. See docs/guides/experience-design/
+how-to/run-cross-pack-eval.md.
+
+Usage:
+    python3 tools/check-xd-chain.py [--root .] [--gate]
+
+Exit codes:
+  0 — clean in report-only mode; or all checks passed with --gate
+  1 — at least one check failed (only when --gate is set)
+  2 — tool error (unreadable SKILL.md, malformed frontmatter, invalid root)
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+# ── Chain definition ──────────────────────────────────────────────────────────
+
+CHAIN_SKILLS: list[str] = [
+    "design-token-taxonomy",
+    "design-system-foundations",
+    "information-architecture",
+    "copy-direction",
+    "design-review",
+]
+
+# Explicit adjacency map: each skill's description must backtick-reference
+# these neighbor skills. Derived from actual 1.5.0 frontmatter; see spec.md
+# "Boundary guard adjacency map" section.
+CHAIN_GUARD_REQUIREMENTS: dict[str, list[str]] = {
+    "design-token-taxonomy":     ["design-system-foundations"],
+    "design-system-foundations": ["design-token-taxonomy", "information-architecture"],
+    "information-architecture":  ["copy-direction"],
+    "copy-direction":            ["content-design", "tone-of-voice"],
+    "design-review":             ["copy-direction"],
+}
+
+# Digital Experience Contract anchor paths (same as check-contract-drift.py).
+CONTRACT_ANCHORS: dict[str, str] = {
+    "product-strategy": (
+        "packs/product-strategy/.apm/skills/"
+        "synthesize-stakeholder-research/references/digital-experience-contract.md"
+    ),
+    "product-engineering": (
+        "packs/product-engineering/.apm/skills/"
+        "frame-intent/references/digital-experience-contract.md"
+    ),
+    "experience-design": (
+        "packs/experience-design/.apm/skills/"
+        "design-review/references/digital-experience-contract.md"
+    ),
+    "core": (
+        "packs/core/.apm/skills/"
+        "frontend-engineering/references/digital-experience-contract.md"
+    ),
+}
+
+# Description-length cap (agentbundle max).
+DESC_MAX_CHARS: int = 1024
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
+_BACKTICK_NAME_RE = re.compile(r"`([a-z][a-z0-9-]+)`")
+
+
+def _repo_root(root_arg: str | None) -> Path:
+    if root_arg:
+        p = Path(root_arg).resolve()
+        if not p.is_dir():
+            print(f"error: --root {root_arg!r} is not a directory", file=sys.stderr)
+            sys.exit(2)
+        return p
+    import subprocess
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True, text=True, check=False,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return Path(result.stdout.strip())
+    return Path.cwd()
+
+
+def _skill_path(root: Path, pack: str, skill: str) -> Path:
+    return root / "packs" / pack / ".apm" / "skills" / skill / "SKILL.md"
+
+
+def _read_description(skill_path: Path) -> str:
+    """Return the raw `description:` value from SKILL.md YAML frontmatter.
+
+    Handles both quoted (`description: "..."`) and bare (`description: ...`) forms
+    via regex extraction. SKILL.md frontmatter is YAML, not TOML, so parsing is
+    regex-based rather than library-based.
+    Exits 2 on unreadable file or missing frontmatter.
+    """
+    try:
+        text = skill_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"error: cannot read {skill_path}: {exc}", file=sys.stderr)
+        sys.exit(2)
+    m = _FRONTMATTER_RE.match(text)
+    if not m:
+        print(f"error: no YAML frontmatter found in {skill_path}", file=sys.stderr)
+        sys.exit(2)
+    frontmatter = m.group(1)
+    # Quoted form: description: "..."
+    dm = re.search(
+        r'^description:\s*"((?:[^"\\]|\\.)*)"\s*$',
+        frontmatter,
+        re.MULTILINE | re.DOTALL,
+    )
+    if dm:
+        return dm.group(1).replace('\\"', '"')
+    # Bare form: description: some text without quotes
+    dm = re.search(r"^description:\s*(.+)$", frontmatter, re.MULTILINE)
+    if dm:
+        return dm.group(1).strip()
+    return ""
+
+
+def _is_cross_pack_ref(name: str, description: str) -> bool:
+    """Return True if `name` is a cross-pack reference in `description`.
+
+    A cross-pack reference is one where the backtick-quoted name is accompanied
+    by a phrase like "in the `product-engineering` pack" or "in the product-engineering
+    pack" nearby in the same context window.
+    """
+    for match in re.finditer(r"`" + re.escape(name) + r"`", description):
+        start = max(0, match.start() - 120)
+        end = min(len(description), match.end() + 120)
+        context = description[start:end]
+        if re.search(r"in the `?[\w-]+`? pack", context):
+            return True
+    return False
+
+
+def _all_pack_skills(root: Path, pack: str = "experience-design") -> set[str]:
+    """Return the set of skill names in the pack (based on directory names)."""
+    skills_dir = root / "packs" / pack / ".apm" / "skills"
+    if not skills_dir.is_dir():
+        return set()
+    return {
+        d.name
+        for d in skills_dir.iterdir()
+        if d.is_dir() and (d / "SKILL.md").exists()
+    }
+
+
+# ── Checks ────────────────────────────────────────────────────────────────────
+
+Finding = tuple[str, str]  # (check_name, message)
+
+
+def check_chain_completeness(root: Path) -> list[Finding]:
+    """Check 1 — each chain skill has a SKILL.md at its expected path."""
+    findings: list[Finding] = []
+    for skill in CHAIN_SKILLS:
+        path = _skill_path(root, "experience-design", skill)
+        if path.exists():
+            print(f"  ✓ chain skill exists: {skill}")
+        else:
+            findings.append(("chain-completeness", f"missing SKILL.md for chain skill '{skill}' at {path}"))
+            print(f"  ✖ chain skill missing: {skill} (expected {path})")
+    return findings
+
+
+def check_phantom_handoff(root: Path, pack_skills: set[str]) -> list[Finding]:
+    """Check 2 — every backtick-quoted name in the description resolves to an
+    existing skill in the pack.
+
+    Cross-pack references (name accompanied by 'in the <pack> pack') are exempt.
+    Pack names themselves are also exempt.
+    """
+    findings: list[Finding] = []
+    pack_names = {
+        "product-strategy", "product-engineering", "experience-design",
+        "core", "architect", "desk-research",
+    }
+    for skill in CHAIN_SKILLS:
+        path = _skill_path(root, "experience-design", skill)
+        if not path.exists():
+            continue
+        description = _read_description(path)
+        backtick_names = _BACKTICK_NAME_RE.findall(description)
+        skill_ok = True
+        for name in backtick_names:
+            if name == skill:
+                continue  # self-reference is fine
+            if name in pack_names:
+                continue  # pack name, not a skill reference
+            if _is_cross_pack_ref(name, description):
+                continue  # cross-pack reference is explicitly exempt
+            if name not in pack_skills:
+                findings.append((
+                    "phantom-handoff",
+                    f"'{skill}' description references `{name}` but no such skill exists in the pack",
+                ))
+                print(f"  ✖ phantom reference in {skill}: `{name}` not found in pack")
+                skill_ok = False
+        if skill_ok:
+            print(f"  ✓ no phantom references in: {skill}")
+    return findings
+
+
+def check_boundary_guards(root: Path) -> list[Finding]:
+    """Check 3 — each chain skill's description backtick-references its required neighbors."""
+    findings: list[Finding] = []
+    for skill, required_neighbors in CHAIN_GUARD_REQUIREMENTS.items():
+        path = _skill_path(root, "experience-design", skill)
+        if not path.exists():
+            continue
+        description = _read_description(path)
+        backtick_names = set(_BACKTICK_NAME_RE.findall(description))
+        missing = [n for n in required_neighbors if n not in backtick_names]
+        if missing:
+            findings.append((
+                "boundary-guards",
+                f"'{skill}' description is missing required guard reference(s): {missing}",
+            ))
+            print(f"  ✖ missing guard(s) in {skill}: {missing}")
+        else:
+            print(f"  ✓ boundary guards present in: {skill}")
+    return findings
+
+
+def check_contract_copies(root: Path) -> list[Finding]:
+    """Check 4 — Digital Experience Contract files exist in all four packs."""
+    findings: list[Finding] = []
+    for pack, rel_path in CONTRACT_ANCHORS.items():
+        full = root / rel_path
+        if full.exists():
+            print(f"  ✓ DEC copy present: {pack}")
+        else:
+            findings.append((
+                "contract-copies",
+                f"Digital Experience Contract missing in {pack} pack at {rel_path}",
+            ))
+            print(f"  ✖ DEC copy missing: {pack} (expected {rel_path})")
+    return findings
+
+
+def check_description_length(root: Path) -> list[Finding]:
+    """Check 5 — each chain skill description is ≤1024 chars (agentbundle cap)."""
+    findings: list[Finding] = []
+    for skill in CHAIN_SKILLS:
+        path = _skill_path(root, "experience-design", skill)
+        if not path.exists():
+            continue
+        description = _read_description(path)
+        length = len(description)
+        if length > DESC_MAX_CHARS:
+            findings.append((
+                "description-length",
+                f"'{skill}' description is {length} chars (cap is {DESC_MAX_CHARS})",
+            ))
+            print(f"  ✖ description over cap in {skill}: {length}/{DESC_MAX_CHARS} chars")
+        else:
+            print(f"  ✓ description within cap: {skill} ({length}/{DESC_MAX_CHARS} chars)")
+    return findings
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="XD chain structural-invariant checker (report-only by default).",
+    )
+    parser.add_argument(
+        "--root",
+        metavar="DIR",
+        default=None,
+        help="Repo root (default: git toplevel or CWD).",
+    )
+    parser.add_argument(
+        "--gate",
+        action="store_true",
+        help="Exit 1 on any failure (fail-closed gate mode).",
+    )
+    args = parser.parse_args()
+
+    root = _repo_root(args.root)
+    pack_skills = _all_pack_skills(root)
+
+    all_findings: list[Finding] = []
+
+    print("\n[check-xd-chain] Check 1: chain completeness")
+    all_findings.extend(check_chain_completeness(root))
+
+    print("\n[check-xd-chain] Check 2: phantom-handoff detection")
+    all_findings.extend(check_phantom_handoff(root, pack_skills))
+
+    print("\n[check-xd-chain] Check 3: boundary guards")
+    all_findings.extend(check_boundary_guards(root))
+
+    print("\n[check-xd-chain] Check 4: contract copies")
+    all_findings.extend(check_contract_copies(root))
+
+    print("\n[check-xd-chain] Check 5: description length")
+    all_findings.extend(check_description_length(root))
+
+    print()
+    if not all_findings:
+        print("[check-xd-chain] All checks passed.")
+        return 0
+
+    print(f"[check-xd-chain] {len(all_findings)} finding(s):")
+    for check_name, msg in all_findings:
+        prefix = "::warning ::" if not args.gate else "::error ::"
+        print(f"  {prefix}[{check_name}] {msg}")
+
+    if args.gate:
+        return 1
+    print("[check-xd-chain] Report-only mode — run with --gate to fail-close.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test-all.py
+++ b/tools/test-all.py
@@ -41,6 +41,7 @@ def _repo_root() -> Path:
 # self-tests prefer `sys.executable` over a bare `python3` so the
 # child runs with the same interpreter as the umbrella.
 TESTS: list[tuple[str, list[str]]] = [
+    ("check-xd-chain",     [sys.executable, "tools/test-check-xd-chain.py"]),
     ("lint-agent-artifacts", ["bash", "tools/test-lint-agent-artifacts.sh"]),
     ("lint-catalogue-seeds", [sys.executable, "tools/test-lint-catalogue-seeds.py"]),
     ("lint-knowledge",       ["bash", "tools/test-lint-knowledge.sh"]),

--- a/tools/test-check-xd-chain.py
+++ b/tools/test-check-xd-chain.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Self-test for tools/check-xd-chain.py (spec/cross-pack-experience-eval, AC8/AC11).
+
+Pattern: build fixture trees in a tempdir, run the checker via subprocess
+against each tree, assert exit code and output marker substrings. Follows the
+pattern in tools/test-check-contract-drift.py.
+
+The minimal fixture tree writes all five chain skills PLUS their non-chain
+pack neighbors (content-design, tone-of-voice, creative-direction, etc.) so
+that the baseline passes --gate cleanly before each injection is applied.
+This ensures each failure-path test is discriminating: the assertion fails
+only when the specific injected fault causes the specific expected finding.
+
+Trees:
+  A — real repo in report-only mode (no --gate) → exit 0
+  B — real repo with --gate → exit 0 (all checks pass)
+  C — missing chain skill → --gate exits 1, [chain-completeness] in output
+  D — phantom skill reference → --gate exits 1, [phantom-handoff] in output
+  E — missing boundary guard → --gate exits 1, [boundary-guards] in output
+  F — missing DEC contract copy → --gate exits 1, [contract-copies] in output
+  G — description over 1024 chars → --gate exits 1, [description-length] in output
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+CHECKER = REPO_ROOT / "tools" / "check-xd-chain.py"
+
+CONTRACT_ANCHORS = {
+    "product-strategy": pathlib.Path(
+        "packs/product-strategy/.apm/skills/"
+        "synthesize-stakeholder-research/references/digital-experience-contract.md"
+    ),
+    "product-engineering": pathlib.Path(
+        "packs/product-engineering/.apm/skills/"
+        "frame-intent/references/digital-experience-contract.md"
+    ),
+    "experience-design": pathlib.Path(
+        "packs/experience-design/.apm/skills/"
+        "design-review/references/digital-experience-contract.md"
+    ),
+    "core": pathlib.Path(
+        "packs/core/.apm/skills/"
+        "frontend-engineering/references/digital-experience-contract.md"
+    ),
+}
+
+DUMMY_CONTRACT = "---\nschema-version: \"1.0\"\n---\n# Digital Experience Contract\n"
+
+# Descriptions for the five chain skills that satisfy the adjacency map.
+CHAIN_DESCRIPTIONS: dict[str, str] = {
+    "design-token-taxonomy": (
+        "Name the token taxonomy. Do NOT use to set up the token foundation — "
+        "use `design-system-foundations` for that. Do NOT use to lay out hierarchy "
+        "(use `information-architecture`). Do NOT use to evaluate (use `design-review`)."
+    ),
+    "design-system-foundations": (
+        "Apply the token foundation. Do NOT use to derive the taxonomy (use `design-token-taxonomy`). "
+        "Do NOT use to structure hierarchy (use `information-architecture`). "
+        "Do NOT use to evaluate (use `design-review`)."
+    ),
+    "information-architecture": (
+        "Structure a screen or flow. Do NOT use to name copy voice goals — "
+        "use `copy-direction` for a specific surface."
+    ),
+    "copy-direction": (
+        "Name copy goals. Do NOT use for content structure — use `content-design`. "
+        "Do NOT use for general brand tone — use `tone-of-voice`."
+    ),
+    "design-review": (
+        "Evaluate a screen. Do NOT use to name copy voice goals — use `copy-direction`. "
+        "Do NOT use to name a felt direction — use `creative-direction`."
+    ),
+}
+
+# Non-chain skills referenced in the chain descriptions above.
+# These must exist in the fixture tree so the phantom-handoff check passes.
+NEIGHBOR_STUBS: list[str] = [
+    "content-design",
+    "tone-of-voice",
+    "creative-direction",
+]
+
+
+def _run(root: pathlib.Path, gate: bool = False) -> tuple[int, str]:
+    cmd = [sys.executable, str(CHECKER), "--root", str(root)]
+    if gate:
+        cmd.append("--gate")
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+def _write_minimal_skill(
+    root: pathlib.Path, pack: str, skill: str, description: str
+) -> None:
+    """Write a minimal SKILL.md with the given description."""
+    path = root / "packs" / pack / ".apm" / "skills" / skill / "SKILL.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f'---\nname: {skill}\ndescription: "{description}"\n---\n\n# Skill: {skill}\n',
+        encoding="utf-8",
+    )
+
+
+def _write_contracts(root: pathlib.Path) -> None:
+    """Write all four DEC contract copies to the fixture tree."""
+    for rel_path in CONTRACT_ANCHORS.values():
+        full = root / rel_path
+        full.parent.mkdir(parents=True, exist_ok=True)
+        full.write_text(DUMMY_CONTRACT, encoding="utf-8")
+
+
+def _write_minimal_chain(root: pathlib.Path) -> None:
+    """Write all chain skills plus neighbor stubs so the baseline passes --gate."""
+    for skill, desc in CHAIN_DESCRIPTIONS.items():
+        _write_minimal_skill(root, "experience-design", skill, desc)
+    # Write neighbor stubs — referenced in chain descriptions; must exist in pack
+    # so the phantom-handoff check doesn't flag them as phantoms.
+    for stub in NEIGHBOR_STUBS:
+        _write_minimal_skill(root, "experience-design", stub, f"Stub for {stub}.")
+
+
+def fail(label: str, msg: str, output: str = "") -> None:
+    print(f"✖ {label}: {msg}", file=sys.stderr)
+    if output:
+        print("---", file=sys.stderr)
+        print(output[:800], file=sys.stderr)
+        print("---", file=sys.stderr)
+    sys.exit(1)
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+def test_a_real_repo_report_only() -> None:
+    label = "A (real repo, report-only → exit 0)"
+    code, out = _run(REPO_ROOT, gate=False)
+    if code != 0:
+        fail(label, f"expected exit 0, got {code}", out)
+    if "All checks passed" not in out:
+        fail(label, "expected 'All checks passed' in output", out)
+    print(f"✓ {label}")
+
+
+def test_b_real_repo_gate() -> None:
+    label = "B (real repo, --gate → exit 0)"
+    code, out = _run(REPO_ROOT, gate=True)
+    if code != 0:
+        fail(label, f"expected exit 0, got {code}", out)
+    if "All checks passed" not in out:
+        fail(label, "expected 'All checks passed' in output", out)
+    print(f"✓ {label}")
+
+
+def test_c_missing_chain_skill() -> None:
+    label = "C (missing chain skill → --gate exits 1, [chain-completeness] in output)"
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        _write_minimal_chain(root)
+        _write_contracts(root)
+        # Pre-check: baseline should pass --gate cleanly.
+        code0, out0 = _run(root, gate=True)
+        if code0 != 0:
+            fail(label, f"baseline unexpectedly failed --gate (pre-injection): exit {code0}", out0)
+        # Inject: remove design-system-foundations.
+        import shutil
+        shutil.rmtree(root / "packs" / "experience-design" / ".apm" / "skills" / "design-system-foundations")
+        code, out = _run(root, gate=True)
+        if code != 1:
+            fail(label, f"expected exit 1, got {code}", out)
+        if "::error ::[chain-completeness]" not in out:
+            fail(label, "expected '::error ::[chain-completeness]' marker in output", out)
+    print(f"✓ {label}")
+
+
+def test_d_phantom_skill_reference() -> None:
+    label = "D (phantom skill reference → --gate exits 1, [phantom-handoff] in output)"
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        _write_minimal_chain(root)
+        _write_contracts(root)
+        # Pre-check: baseline should pass --gate cleanly.
+        code0, out0 = _run(root, gate=True)
+        if code0 != 0:
+            fail(label, f"baseline unexpectedly failed --gate (pre-injection): exit {code0}", out0)
+        # Inject: overwrite design-token-taxonomy with a phantom reference.
+        phantom_desc = (
+            "Name the token taxonomy. Do NOT use to set up the token foundation — "
+            "use `nonexistent-phantom-skill` for that. Do NOT use to lay out hierarchy "
+            "(use `information-architecture`). Do NOT use to evaluate (use `design-review`)."
+        )
+        _write_minimal_skill(root, "experience-design", "design-token-taxonomy", phantom_desc)
+        code, out = _run(root, gate=True)
+        if code != 1:
+            fail(label, f"expected exit 1, got {code}", out)
+        if "::error ::[phantom-handoff]" not in out:
+            fail(label, "expected '::error ::[phantom-handoff]' marker in output", out)
+        if "nonexistent-phantom-skill" not in out:
+            fail(label, "expected phantom skill name in output", out)
+    print(f"✓ {label}")
+
+
+def test_e_missing_boundary_guard() -> None:
+    label = "E (missing boundary guard → --gate exits 1, [boundary-guards] in output)"
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        _write_minimal_chain(root)
+        _write_contracts(root)
+        # Pre-check: baseline should pass --gate cleanly.
+        code0, out0 = _run(root, gate=True)
+        if code0 != 0:
+            fail(label, f"baseline unexpectedly failed --gate (pre-injection): exit {code0}", out0)
+        # Inject: overwrite information-architecture without the copy-direction guard.
+        no_guard_desc = (
+            "Structure a screen or flow. Do NOT use to choose mood (use `creative-direction`). "
+            "Do NOT use to evaluate (use `design-review`)."
+            # Intentionally omits `copy-direction` reference.
+        )
+        _write_minimal_skill(root, "experience-design", "information-architecture", no_guard_desc)
+        code, out = _run(root, gate=True)
+        if code != 1:
+            fail(label, f"expected exit 1, got {code}", out)
+        if "::error ::[boundary-guards]" not in out:
+            fail(label, "expected '::error ::[boundary-guards]' marker in output", out)
+    print(f"✓ {label}")
+
+
+def test_f_missing_contract_copy() -> None:
+    label = "F (missing DEC contract copy → --gate exits 1, [contract-copies] in output)"
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        _write_minimal_chain(root)
+        _write_contracts(root)
+        # Pre-check: baseline should pass --gate cleanly.
+        code0, out0 = _run(root, gate=True)
+        if code0 != 0:
+            fail(label, f"baseline unexpectedly failed --gate (pre-injection): exit {code0}", out0)
+        # Inject: remove the core contract copy.
+        (root / CONTRACT_ANCHORS["core"]).unlink()
+        code, out = _run(root, gate=True)
+        if code != 1:
+            fail(label, f"expected exit 1, got {code}", out)
+        if "::error ::[contract-copies]" not in out:
+            fail(label, "expected '::error ::[contract-copies]' marker in output", out)
+    print(f"✓ {label}")
+
+
+def test_g_description_over_cap() -> None:
+    label = "G (description over 1024 chars → --gate exits 1, [description-length] in output)"
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        _write_minimal_chain(root)
+        _write_contracts(root)
+        # Pre-check: baseline should pass --gate cleanly.
+        code0, out0 = _run(root, gate=True)
+        if code0 != 0:
+            fail(label, f"baseline unexpectedly failed --gate (pre-injection): exit {code0}", out0)
+        # Inject: overwrite copy-direction with a description over 1024 chars.
+        long_desc = (
+            "Name copy goals. Do NOT use for content structure — use `content-design`. "
+            "Do NOT use for general brand tone — use `tone-of-voice`. "
+            + ("Extra filler text to exceed the cap. " * 30)
+        )
+        assert len(long_desc) > 1024, f"test setup error: desc is {len(long_desc)} chars"
+        _write_minimal_skill(root, "experience-design", "copy-direction", long_desc)
+        code, out = _run(root, gate=True)
+        if code != 1:
+            fail(label, f"expected exit 1, got {code}", out)
+        if "::error ::[description-length]" not in out:
+            fail(label, "expected '::error ::[description-length]' marker in output", out)
+    print(f"✓ {label}")
+
+
+def main() -> int:
+    print("Running test-check-xd-chain.py...")
+    test_a_real_repo_report_only()
+    test_b_real_repo_gate()
+    test_c_missing_chain_skill()
+    test_d_phantom_skill_reference()
+    test_e_missing_boundary_guard()
+    test_f_missing_contract_copy()
+    test_g_description_over_cap()
+    print("\n✓ All tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/workspace.toml
+++ b/workspace.toml
@@ -975,6 +975,17 @@ open = [
   # Unblocks when: spec/xd-design-system-foundations is Shipped.
   {slug = "design-system-foundations-skill-gap", needs = "ini-003:work:spec/xd-design-system-foundations"},
 
+  # ini-003 M5 deferred: wire check-xd-chain.py --gate into CI once calibration confirms
+  # the deterministic checks are stable. The --gate flag is the hook point; the check
+  # already runs in report-only mode. Unblocks when: calibration period (a few ini-003 PRs)
+  # shows no false positives.
+  {slug = "cross-pack-eval-ci-gate", source = "spec/cross-pack-experience-eval"},
+
+  # ini-003 M5 deferred: the golden-path fixtures describe scenarios in structured form
+  # but carry no evals.json-style LLM judge rubric. Separate concern from the deterministic
+  # checker. Unblocks when: LLM judge rubric format is standardized across packs.
+  {slug = "cross-pack-eval-llm-judge", source = "spec/cross-pack-experience-eval"},
+
   # spec/xd-skill-boundaries deferred: experience-design pack page needs trigger language
   # and near-miss guards updated (web/ + site/). Deferred from M3a PR — pack-page changes
   # require web/ edits outside the pack scope gate. Unblocks when ini-003 M3 is complete.

--- a/workspace.toml
+++ b/workspace.toml
@@ -459,15 +459,16 @@ queue   = [
   # Done: one cross-pack eval discriminates coherent from locally-polished-but-
   #   globally-weak; deterministic checks pass; report-only mode green; eval
   #   how-to guide published.
-  {path = "spec/cross-pack-experience-eval", needs = [
-    "work:spec/product-strategy-adoption-doctrine",
-    "work:spec/product-engineering-shaping-doctrine",
-    "work:spec/xd-skill-boundaries",
-    "work:spec/xd-design-system-foundations",
-    "work:spec/xd-ia-archetypes-objects",
-    "work:spec/xd-state-reviewer-doctrine",
-    "work:spec/frontend-engineering-doctrine-update",
-  ]},
+  # spec/cross-pack-experience-eval — Shipped 2026-07-24; moved to shipped below.
+  # {path = "spec/cross-pack-experience-eval", needs = [
+  #   "work:spec/product-strategy-adoption-doctrine",
+  #   "work:spec/product-engineering-shaping-doctrine",
+  #   "work:spec/xd-skill-boundaries",
+  #   "work:spec/xd-design-system-foundations",
+  #   "work:spec/xd-ia-archetypes-objects",
+  #   "work:spec/xd-state-reviewer-doctrine",
+  #   "work:spec/frontend-engineering-doctrine-update",
+  # ]},
 
   # M6 · Cross-Pack Integrative Guides (phase-slice doctrine: per-discipline
   #   guides ship with their discipline spec above; this spec covers only the
@@ -500,6 +501,7 @@ shipped = [
   "spec/xd-ia-archetypes-objects",                   # Shipped 2026-07-23 — page archetypes, product-object mapping, card-use test, attention + permission contracts (1.3.0)
   "spec/xd-design-system-foundations",               # Shipped 2026-07-24 — design-token-taxonomy rename + design-system-foundations skill (1.4.0)
   "spec/xd-state-reviewer-doctrine",                # Shipped 2026-07-24 — 18-state quality floor + three-pass design-review + severity tiers (1.5.0)
+  "spec/cross-pack-experience-eval",               # Shipped 2026-07-24 — XD chain deterministic checker + cross-pack fixtures + how-to guide (1.6.0)
 ]
 
 ["ini-003".shaping_queue]


### PR DESCRIPTION
## Summary

- Delivers ini-003 M5 (`spec/cross-pack-experience-eval`): cross-pack XD skill chain eval suite and deterministic structural checker.
- `tools/check-xd-chain.py` — five structural invariants validated without an LLM (chain completeness, phantom-handoff detection, boundary guards, DEC contract copies, description ≤1024 chars). Report-only default; `--gate` flag for fail-closed mode. All checks pass on the live repo.
- `packs/experience-design/.apm/evals/cross-pack-fixtures.json` — 4 golden-path scenarios, 3 multi-intent routing examples, 3 boundary violation cases, 3 weak regression fixtures (all report-only).
- `docs/guides/experience-design/how-to/run-cross-pack-eval.md` — how to run, interpret, and promote to a gate.
- `tools/test-check-xd-chain.py` — 7 discriminating tests (baseline pre-check before each injection; `::error ::[check-name]` marker assertions).
- `tools/test-all.py` — `test-check-xd-chain` wired in alphabetical order.
- Pack 1.5.0 → 1.6.0 (minor: new eval capability). `workspace.toml` updated.

## Test plan

- [x] `python3 tools/check-xd-chain.py --gate --root .` exits 0 (all 5 checks pass)
- [x] `python3 tools/test-check-xd-chain.py` exits 0 (all 7 tests pass with discriminating assertions)
- [x] `python3 -c "import json; json.load(open('packs/experience-design/.apm/evals/cross-pack-fixtures.json'))"` exits 0
- [x] `python3 tools/check-contract-drift.py --root .` exits 0
- [x] `python3 tools/build_gate_chain.py build-self --force --packs-dir packs` exits 0
- [x] `python3 tools/build_gate_chain.py build-self --dry-run --packs-dir packs` exits 0 (no drift)

## Deferred

- `cross-pack-eval-ci-gate` — wire `check-xd-chain.py --gate` into a CI workflow once calibration is complete. The `--gate` flag is the hook point.
- `cross-pack-eval-llm-judge` — add `evals.json`-style LLM judge rubrics for golden-path fixtures once the fixture format is validated in practice.