### PR TITLE
docs(ini-003): cross-pack I-want-to intent index for experience-design

### DIFF
--- a/docs/guides/experience-design/README.md
+++ b/docs/guides/experience-design/README.md
@@ -88,6 +88,9 @@ Organized by XD chain phase:
 - [State coverage reference — the 18-state set](reference/state-coverage.md) —
   the canonical 18-state set shared by `design-review` (at design time) and
   `frontend-engineering` (at build time), aligned so design and build vocabulary match.
+- [I want to… intent index](reference/intent-index.md) —
+  cross-pack lookup: map a starting job to the right pack, skill, and guide.
+  Covers single-skill jobs, multi-skill chains, and out-of-scope redirects.
 
 ---
 

--- a/docs/guides/experience-design/reference/intent-index.md
+++ b/docs/guides/experience-design/reference/intent-index.md
@@ -1,0 +1,109 @@
+# `experience-design` — I want to… intent index
+
+> **Reference** — look up which pack, skill, and guide to reach for by starting job.
+>
+> Read left to right: state what you want to achieve, and follow the row to the
+> right skill. **Chains** span multiple skills in sequence — each skill's output
+> feeds the next; run them in the order listed. **Out-of-scope** rows are included
+> explicitly so you know where *not* to reach and what to use instead.
+
+---
+
+## Set up visual identity and brand direction
+
+| I want to… | Pack | Skill | Guide |
+|---|---|---|---|
+| Name the look and feel — converge a vague vibe into ranked, grounded goals | experience-design | `creative-direction` | [Design system chain](../how-to/design-system-chain.md) |
+| Name our marketing copy voice for a specific surface | experience-design | `copy-direction` | [The three-way copy boundary](../how-to/copy-layer-boundary.md) |
+| Define our brand voice across all surfaces (formal vs. casual, tone rules) | experience-design | `tone-of-voice` | [The three-way copy boundary](../how-to/copy-layer-boundary.md) |
+| Derive a token taxonomy — name tokens by semantic role and organize scales | experience-design | `design-token-taxonomy` | [Design system chain](../how-to/design-system-chain.md) |
+| Apply a token foundation to our design system — semantic color, typography, spacing | experience-design | `design-system-foundations` | [Design system chain](../how-to/design-system-chain.md) |
+| **Chain:** Full design-system — aesthetic direction → token taxonomy → working foundation | experience-design | `creative-direction` → `design-token-taxonomy` → `design-system-foundations` | [Design system chain](../how-to/design-system-chain.md) |
+
+---
+
+## Discover and define the experience
+
+| I want to… | Pack | Skill | Guide |
+|---|---|---|---|
+| Map a customer journey — stages, touchpoints, pain points, opportunities | experience-design | `journey-mapping` | [Thread a feature from journey to screens](../how-to/author-design-intent.md) |
+| Map an internal process — as-is and to-be swimlanes, no customer-facing layer | experience-design | `process-mapping` | [The skills and the quality floor](experience-design.md) |
+| Derive design principles from journey insights and product values | experience-design | `design-principles` | [Thread a feature from journey to screens](../how-to/author-design-intent.md) |
+| Derive the screen flow and per-screen briefs from a journey map | experience-design | `user-flow` | [Thread a feature from journey to screens](../how-to/author-design-intent.md) |
+| Blueprint the services behind the screens — frontstage, backstage, support | experience-design | `service-blueprint` | [Thread a feature from journey to screens](../how-to/author-design-intent.md) |
+| **Chain:** Full design-intent thread — journey → screen flow → service blueprint | experience-design | `journey-mapping` → `user-flow` → `service-blueprint` | [Thread a feature from journey to screens](../how-to/author-design-intent.md) |
+
+---
+
+## Design screens by surface genre
+
+Declare the surface genre in the per-screen brief's `surface-genre:` field; the
+right skill applies genre-appropriate methodology for that genre.
+
+| I want to… | Pack | Skill | Guide |
+|---|---|---|---|
+| Design a marketing or landing page — above-fold conversion surface | experience-design | `conversion-design` | [Page archetypes: when to use which](../how-to/page-archetypes.md) |
+| Design a dashboard, KPI view, or monitoring screen | experience-design | `analytical-design` | [The skills and the quality floor](experience-design.md) |
+| Design a marketplace — listing grid, filters, buying flow | experience-design | `marketplace-design` | [The skills and the quality floor](experience-design.md) |
+| Design a documentation site or help centre | experience-design | `documentation-design` | [The skills and the quality floor](experience-design.md) |
+| Design an article, editorial, or long-form content page | experience-design | `informational-design` | [The skills and the quality floor](experience-design.md) |
+| Design a collaborative workspace, agentic UI, or task management surface | experience-design | `workspace-design` | [The skills and the quality floor](experience-design.md) |
+
+---
+
+## Screen craft — structure, behavior, and copy
+
+| I want to… | Pack | Skill | Guide |
+|---|---|---|---|
+| Structure a screen's information hierarchy — reading flow, progressive disclosure | experience-design | `information-architecture` | [Page archetypes: when to use which](../how-to/page-archetypes.md) |
+| Design how a screen behaves — feedback loops, state machines, motion | experience-design | `interaction-design` | [The skills and the quality floor](experience-design.md) |
+| Write the copy for a screen — labels, CTAs, error messages, empty states | experience-design | `content-design` | [The three-way copy boundary](../how-to/copy-layer-boundary.md) |
+
+---
+
+## Review and quality-check
+
+| I want to… | Pack | Skill | Guide |
+|---|---|---|---|
+| Critique a design in the current session — heuristic eval against the quality floor | experience-design | `design-review` | [Run a design review before the independent pass](../how-to/design-review.md) |
+| Check all 18 quality-floor states across every screen | experience-design | `design-review` | [State coverage — the 18-state set](state-coverage.md) |
+| Run an independent, forked-context design review of the full screen set | experience-design | `experience-reviewer` (agent) | [Run a design review before the independent pass](../how-to/design-review.md) |
+| Run the cross-pack deterministic experience eval checker | experience-design | `check-xd-chain.py` (script) | [How to run the cross-pack experience eval](../how-to/run-cross-pack-eval.md) |
+
+---
+
+## Understand the chain and orient
+
+| I want to… | Pack | Skill | Guide |
+|---|---|---|---|
+| Orient to the current design thread — see what artifacts exist and which skill to run next | experience-design | `experience-status` | [The skills and the quality floor](experience-design.md) |
+| Decide which copy skill to run — copy-direction vs. content-design vs. tone-of-voice | experience-design | — | [The three-way copy boundary](../how-to/copy-layer-boundary.md) |
+| Pick the right page archetype before designing a screen | experience-design | — | [Page archetypes: when to use which](../how-to/page-archetypes.md) |
+
+---
+
+## Discover, research, and set strategy (cross-pack)
+
+These jobs involve skills from other packs. The chain row shows the full arc
+across packs; each individual row covers a single starting job.
+
+| I want to… | Pack | Skill | Guide |
+|---|---|---|---|
+| Set up a sustained market or domain research project | desk-research | `desk-research-project-start` | [Your first research project](../../desk-research/tutorials/your-first-research-project.md) |
+| Synthesize existing stakeholder research into strategic themes | product-strategy | `synthesize-stakeholder-research` | [Set UX and content strategy](../../product-strategy/how-to/set-ux-and-content-strategy.md) |
+| Write a PRFAQ — the press release before the product exists | product-strategy | `write-prfaq` | [Run your first SWOT](../../product-strategy/tutorials/run-your-first-swot.md) |
+| Define the UX strategy before design begins | product-strategy | `define-ux-strategy` | [Set UX and content strategy](../../product-strategy/how-to/set-ux-and-content-strategy.md) |
+| **Chain:** Full digital product thread — strategy → journey → screens → review | product-strategy + experience-design | `define-ux-strategy` → `journey-mapping` → `user-flow` → [surface skill] → `design-review` → `experience-reviewer` | [Thread a feature from journey to screens](../how-to/author-design-intent.md) |
+
+---
+
+## Out of scope — use the right pack
+
+| I want to… | Resolution |
+|---|---|
+| Generate CI/CD pipelines or infrastructure scaffolding | Out of scope — use the **core** pack |
+| Write application code | Out of scope — use the **core** or **product-engineering** pack |
+| Build or wire a design into a frontend framework | Out of scope — use the **product-engineering** pack (`frontend-engineering` skill) |
+| Conduct qualitative user interviews or usability testing | Out of scope — `desk-research` covers secondary research; primary research facilitation is not covered by any current pack |
+| Run competitor keyword research or SEO analysis | Out of scope — use `desk-research` for secondary research; SEO tooling setup is not in scope |
+| Build or maintain the agentbundle CLI or pack machinery | Out of scope — see the **core** pack and [AGENTS.local.md](../../../../AGENTS.local.md) |

--- a/docs/specs/digital-product-guides-update/spec.md
+++ b/docs/specs/digital-product-guides-update/spec.md
@@ -91,7 +91,7 @@ Mixed: **goal-based checks** for most behaviors; **manual QA** for the organizat
 - [x] `web/src/content/packs/experience-design.md` skill list includes `experience-status`; prose description updated to "21 skills" (not "20 skills").
 - [x] `workspace.toml` updated: `spec/digital-product-guides-update` absent from `queue`, present in `shipped`; backlog entries added for `xd-cross-pack-tutorial` and `xd-cross-pack-intent-index`; `digital-product-profile` needs-reference intact; `tomllib.load` exits 0; spec `Status: Shipped`; ACs #1–#9 set to `[x]`.
 - [ ] End-to-end cross-pack tutorial (strategy→PE→XD→FE→review→measurement example). (deferred: xd-cross-pack-tutorial)
-- [ ] Cross-pack intent index ("I want to…" → pack + skill + guide). (deferred: xd-cross-pack-intent-index)
+- [x] Cross-pack intent index (“I want to…” → pack + skill + guide). Shipped as Wave 3C — docs/guides/experience-design/reference/intent-index.md
 
 ## Assumptions
 

--- a/workspace.toml
+++ b/workspace.toml
@@ -390,7 +390,7 @@ queue   = [
   #   "work:spec/frontend-engineering-doctrine-update",
   # ]},
 
-  # M6 · Cross-Pack Integrative Guides — shipped 2026-07-24; deferred items (xd-cross-pack-tutorial, xd-cross-pack-intent-index) → [backlog].open below.
+  # M6 · Cross-Pack Integrative Guides — shipped 2026-07-24; deferred item (xd-cross-pack-tutorial) → [backlog].open below.
 ]
 shipped = [
   "spec/rfc-digital-product-experience-doctrine",  # Shipped 2026-07-23 — governance gate; unlocks all 11 downstream ini-003 specs
@@ -407,6 +407,7 @@ shipped = [
   "spec/digital-product-guides-update",             # Shipped 2026-07-24 — M6 integrative XD guides: README index, Start here walkthrough, cross-links, web/ skill inventory
   "xd-pack-page-trigger-language-update",            # Shipped 2026-07-24 — Wave 3D: pack + journey page near-miss guards for design-token-taxonomy, design-system-foundations, copy-direction
   "xd-reference-guide-description-sync",             # Shipped 2026-07-24 — synced 21-skill descriptions to SKILL.md frontmatter; added copy-direction, design-token-taxonomy, design-system-foundations, experience-status; removed design-system
+  "spec/xd-cross-pack-intent-index",               # Shipped 2026-07-24 — cross-pack "I want to…" intent index: adopter jobs → pack + skill + guide
 ]
 
 ["ini-003".shaping_queue]
@@ -653,10 +654,6 @@ open = [
   # full strategy→PE→XD→FE→review→measurement arc using a realistic digital product
   # example (marketing site or SaaS onboarding). Unblocks when all M1–M6 specs ship.
   {slug = "xd-cross-pack-tutorial", source = "spec/digital-product-guides-update AC10"},
-  # Cross-pack intent index deferred from ini-003 M6. "I want to…" → which pack +
-  # skill + guide for each common adopter starting job. Unblocks when all M1–M6 specs ship.
-  {slug = "xd-cross-pack-intent-index", source = "spec/digital-product-guides-update AC11"},
-
   # ── Quick wins ───────────────────────────────────────────────────────────────
   # (single focused session; no external environment; small diff)
 


### PR DESCRIPTION
## Summary

- Adds `docs/guides/experience-design/reference/intent-index.md` — a reference table mapping adopter starting jobs ("I want to…") to the right pack, skill, and guide
- Links the new index from the experience-design guide `README.md` under the Reference section
- Moves `xd-cross-pack-intent-index` from `[backlog].open` to `["ini-003".work].shipped` in `workspace.toml`

## Acceptance criteria met

- [x] `docs/guides/experience-design/reference/intent-index.md` exists with ≥20 entries (33 non-header rows, 6 additional out-of-scope rows)
- [x] Cross-pack jobs covered — chain rows across `experience-design`, `desk-research`, and `product-strategy`; individual cross-pack rows for `desk-research-project-start`, `synthesize-stakeholder-research`, `write-prfaq`, `define-ux-strategy`
- [x] Single-skill jobs covered — one row per skill across all 21 experience-design skills
- [x] Out-of-scope jobs marked — 6 explicit out-of-scope redirects (core pack, product-engineering, desk-research)
- [x] Grouped by theme — 7 themes: visual identity, discover/define, screen genre, screen craft, review, orient, cross-pack
- [x] Linked from `docs/guides/experience-design/README.md` under Reference
- [x] `workspace.toml`: `xd-cross-pack-intent-index` removed from `[backlog].open`, added to `["ini-003".work].shipped`; TOML validated with `tomllib`

## Entry count breakdown

| Theme | Rows (incl. chains) |
|---|---|
| Set up visual identity and brand direction | 6 (1 chain) |
| Discover and define the experience | 6 (1 chain) |
| Design screens by surface genre | 6 |
| Screen craft — structure, behavior, copy | 3 |
| Review and quality-check | 4 |
| Understand the chain and orient | 3 |
| Discover, research, and set strategy (cross-pack) | 5 (1 chain) |
| Out of scope | 6 |
| **Total** | **39** |