### PR TITLE
feat(ini-003): digital-product profile, journey page, and tutorial (Wave 3A)

### DIFF
--- a/docs/guides/experience-design/README.md
+++ b/docs/guides/experience-design/README.md
@@ -87,6 +87,13 @@ Organized by XD chain phase:
   run the deterministic `check-xd-chain.py` checker, read its output, and promote
   a check to a fail-closed gate.
 
+## Tutorials
+
+- [First session with the digital-product profile](tutorials/xd-digital-product-profile.md) —
+  install the `digital-product` profile and walk the full arc: desk research → product strategy
+  (SWOT + PRFAQ + OKR cascade) → experience design (journey → screens → independent review) →
+  Digital Experience Contract hand-off to the build loop.
+
 ## Reference
 
 - [The skills, the reviewer, and the `quality-floor`](reference/experience-design.md) —

--- a/docs/guides/experience-design/tutorials/xd-digital-product-profile.md
+++ b/docs/guides/experience-design/tutorials/xd-digital-product-profile.md
@@ -34,7 +34,7 @@ This installs four packs at user scope, in deps-first order:
 Verify installation:
 
 ```bash
-agentbundle list <catalogue>
+agentbundle list-installed
 ```
 
 All four packs should appear at `scope: user`.
@@ -110,7 +110,30 @@ Metric Tree, Differentiation, Assumptions and Kill Criteria.
 
 ---
 
-## Step 4. Run experience-design to design the screens
+## Step 4. Shape the initiative with product-engineering
+
+Before designing screens, the product-engineering pack grounds the work in a shaping brief
+that names what you're building, the first-success operationalization, and the thin-slice scope.
+
+1. Activate the shaping skills:
+
+   > "Shape the [initiative name] initiative using the committed strategy from docs/product/shaping/.
+   > Produce a shaping brief with the first-success event operationalized."
+
+2. The agent runs the shaping and first-success operationalization skills to produce:
+   - A shaping brief with: the problem, the first-success event named as a specific observable
+     behavior + system response + measurement event, and the thin-slice scope
+   - A workspace.toml `strategy`-type entry ready for the build loop to pick up
+
+3. Confirm the first-success event in the shaping brief matches the one in the PRFAQ exactly.
+   If they diverge, the measurement contract is broken before build begins — redirect and re-run.
+
+4. Output: committed shaping brief with first-success operationalization; the PE shaping link
+   in the traceability chain is now complete.
+
+---
+
+## Step 5. Run experience-design to design the screens
 
 ### 4a. Map the customer journey and derive the screen list
 
@@ -169,7 +192,7 @@ happy-path state but has no designed error recovery is the canonical blocker.
 
 ---
 
-## Step 5. Hand off to the build repo's core pack
+## Step 6. Hand off to the build repo's core pack
 
 The Digital Experience Contract — now populated with strategy, shaping, and experience
 fields — is the hand-off artifact.
@@ -182,7 +205,7 @@ agentbundle install --pack core <catalogue>
 
 Point the build loop to the contract:
 
-> "The Digital Experience Contract is at docs/design/digital-experience-contract.md.
+> "The Digital Experience Contract is at docs/guides/core/explanation/digital-experience-contract.md.
 > Use it to ground the build — confirm the first-success event matches what we'll instrument."
 
 The `core` pack's `work-loop` and `frontend-engineering` skill read the contract fields to

--- a/docs/guides/experience-design/tutorials/xd-digital-product-profile.md
+++ b/docs/guides/experience-design/tutorials/xd-digital-product-profile.md
@@ -1,0 +1,226 @@
+# Tutorial: First session with the digital-product profile
+
+This tutorial walks a product manager, product designer, or product lead through
+their first session using the `digital-product` profile — the portable toolkit for
+owning strategy → shaping → experience → build hand-off for a digital product.
+
+By the end, you will have:
+
+- Installed the profile in one command
+- Grounded your strategy in a committed market situation and adoption hypothesis
+- Mapped the customer journey and derived the screen list
+- Handed the Digital Experience Contract to the build repo's `core` pack
+
+**Time:** 3–6 hours for a realistic product scope across all four packs.
+**Pre-requisites:** `agentbundle` installed and a target catalogue available.
+
+---
+
+## Step 1. Install the profile
+
+```bash
+agentbundle install --profile digital-product <catalogue>
+```
+
+This installs four packs at user scope, in deps-first order:
+
+| Pack | What it gives you |
+|---|---|
+| `desk-research` | Evidence-grounded research — scoping, source curation, synthesis, adversarial review |
+| `product-strategy` | Market situation → adoption hypothesis → OKR cascade → strategy-to-experience handoff |
+| `product-engineering` | Shaping queue, first-success operationalization, thin-slice learning contract |
+| `experience-design` | Full XD chain: journey → screens → design intent → per-screen design → independent review |
+
+Verify installation:
+
+```bash
+agentbundle list <catalogue>
+```
+
+All four packs should appear at `scope: user`.
+
+---
+
+## Step 2. Set the market context with desk-research
+
+Before strategy work begins, ground the session in evidence.
+
+1. Run the `desk-research` skill and scope the research question:
+
+   > "Scope a research project on [your market/domain]. I want to understand the competitive
+   > landscape, key user behaviors, and what's driving adoption in this space."
+
+2. The agent will run `frame-research-question`, curate sources, and synthesize findings.
+   Review the synthesis before moving to strategy. If the synthesis describes the market
+   but doesn't surface adoption signal (how users actually behave, not just who they are),
+   redirect and re-run.
+
+3. Output: committed research synthesis in `docs/product/shaping/` ready to feed the
+   situation analysis.
+
+---
+
+## Step 3. Run the product-strategy chain to produce strategy artifacts
+
+### 3a. Build the market situation
+
+Run the strategy situation analysis:
+
+> "Run the full situation analysis for [product/initiative name]. Use the desk-research
+> outputs in docs/product/shaping/ as inputs."
+
+The agent runs:
+- `run-pestle-analysis` — macro environment (six lenses)
+- `run-porters-five-forces` — competitive landscape and structural position
+- `run-bcg-matrix` — portfolio position
+- `run-swot` — synthesizes all inputs into a SWOT with adoption hypothesis and differentiation mechanism
+
+**Human gate:** review the SWOT. Approve only when:
+- The adoption hypothesis is named (which SO pair produces a first-success event, and what is that event specifically)
+- The differentiation mechanism is named (a structural advantage, not a generic moat claim)
+- The most acute threat is named
+
+If the SWOT has generic strengths like "talented team" and no adoption hypothesis, redirect before the PRFAQ stage.
+
+### 3b. Commit the altitude-0 direction
+
+> "Write a PRFAQ for [initiative name] based on the committed SWOT."
+
+The agent runs `write-prfaq` to produce:
+- A press release naming a specific person with a specific pain
+- A named first-success event (a specific observable behavior — not "user signs up")
+- An internal FAQ with a success metric traceable to the first-success event
+
+**Human gate:** approve the PRFAQ. The first-success event named here is the measurement
+contract that all downstream work — PE shaping, XD journey, instrumentation — must trace
+back to. If the first-success event is "user completes onboarding", redirect.
+
+### 3c. Cascade OKRs and complete the strategy-to-experience handoff
+
+> "Run the OKR cascade for [initiative] and produce the strategy-to-experience handoff."
+
+The agent runs:
+- `run-okr-cascade` — cascades company OKRs, derives the causal metric tree, routes gaps to workspace.toml
+- `define-ux-strategy` — experience vision, goals+measures with value loop and adoption hypothesis
+- `define-content-strategy` — Halvorson quad organizational governance layer
+
+Together these populate the seven Strategy fields of the Digital Experience Contract:
+Target User and Context, Diagnosis and Strategic Choices, Adoption Hypothesis, Value Loop,
+Metric Tree, Differentiation, Assumptions and Kill Criteria.
+
+---
+
+## Step 4. Run experience-design to design the screens
+
+### 4a. Map the customer journey and derive the screen list
+
+> "Map the customer journey for [the feature or product]. Derive the screen list from the journey."
+
+The agent runs `journey-mapping` then `user-flow`. Review the journey map before the
+screen list is derived — if the map describes what the current product does rather than
+what the user is trying to achieve, redirect. A screen list derived from the wrong model
+designs the wrong product, faithfully.
+
+**Human gate:** approve the journey and screen list. Remove any screen not traceable to a
+moment in the journey.
+
+### 4b. Establish design intent
+
+> "Establish the aesthetic direction and token foundation for [product name]."
+
+The agent runs:
+- `design-principles` — 3–5 named decision rules grounded in journey moments
+- `creative-direction` — named visual character, emotional and brand goals
+- `design-token-taxonomy` — token/scale taxonomy derived from the aesthetic direction
+- `design-system-foundations` — semantic color roles, typography, spacing, radius, focus, status tokens
+
+**Human gate:** approve the aesthetic direction and token set. Reject tokens that introduce
+hardcoded values outside the semantic token system. An aesthetic direction that says
+"clean and professional" is not specific enough — redirect.
+
+### 4c. Design each screen
+
+For each screen in the inventory:
+
+> "Design [screen name] from the screen inventory."
+
+The agent runs:
+- `information-architecture` — identifies the page archetype, names the product object, applies the attention and permission contracts
+- The appropriate genre-specific skill (`conversion-design`, `workspace-design`, `analytical-design`, etc.)
+- `interaction-design` — states, transitions, feedback patterns against WCAG 2.2 AA
+- `design-review` — three-pass self-check (cold-read → primary task + unhappy path → full 18-state quality-floor review)
+
+Watch for missing states: if a screen has no empty state, loading state, or error recovery,
+name it before the independent review — catching it here is cheaper.
+
+### 4d. Run the independent experience-reviewer
+
+> "Run the experience-reviewer on the completed screen set."
+
+The agent dispatches the forked-context `experience-reviewer` — no access to the authoring
+session — returning findings across the full screen set:
+- Handle-all-states violations (missing empty, loading, error, success states)
+- WCAG 2.2 AA failures (color contrast, label associations, focus order)
+- Aesthetic inconsistencies with the approved direction
+
+**Human gate:** review the findings. Apply all Blockers before design intent feeds the build.
+Handle-all-states violations are the most common finding — a screen that looks good in the
+happy-path state but has no designed error recovery is the canonical blocker.
+
+---
+
+## Step 5. Hand off to the build repo's core pack
+
+The Digital Experience Contract — now populated with strategy, shaping, and experience
+fields — is the hand-off artifact.
+
+In the build repo:
+
+```bash
+agentbundle install --pack core <catalogue>
+```
+
+Point the build loop to the contract:
+
+> "The Digital Experience Contract is at docs/design/digital-experience-contract.md.
+> Use it to ground the build — confirm the first-success event matches what we'll instrument."
+
+The `core` pack's `work-loop` and `frontend-engineering` skill read the contract fields to
+ground build decisions in the strategy and design intent. The first-success event named in
+Step 3b is the instrumentation anchor — if the build loop doesn't instrument it, the
+measurement contract is broken.
+
+---
+
+## What you've built
+
+After this tutorial, you have a connected chain:
+
+```
+desk-research synthesis
+  → market situation (SWOT with adoption hypothesis + differentiation mechanism)
+    → PRFAQ (first-success event as measurement contract)
+      → OKR cascade + causal metric tree
+        → strategy-to-experience handoff (7 Digital Experience Contract strategy fields)
+          → shaping brief (first-success operationalization)
+            → journey map + screen list
+              → aesthetic direction + token foundation
+                → per-screen designs (independently reviewed)
+                  → Digital Experience Contract (complete)
+                    → build loop (core pack, anchored to first-success event)
+```
+
+Each step is traceable to the one before. The first-success event named in the PRFAQ is
+the same event the OKR cascade builds a metric tree around, the journey map centers, the
+instrumentation plan targets, and the build loop measures. That traceability is the contract.
+
+---
+
+## Next steps
+
+- Run the cross-pack experience eval to validate the full chain:
+  [How to run the cross-pack experience eval](../how-to/run-cross-pack-eval.md)
+- Explore the full experience-design how-to guides:
+  [Thread a feature from journey to screens](../how-to/author-design-intent.md)
+- Understand the 18-state quality floor all screens must clear:
+  [State coverage reference](../reference/state-coverage.md)

--- a/docs/specs/pack-profiles/spec.md
+++ b/docs/specs/pack-profiles/spec.md
@@ -30,7 +30,7 @@ before proceeding; *Never do* is a hard rule, even under time pressure.
 
 ### Ask first
 
-- Adding a third shipped first-party profile beyond `solution-architect` and `full-ceremony`.
+- Adding a new first-party profile (currently shipped: `solution-architect`, `full-ceremony`, `inception`, `digital-product`).
 - Any change to the resolved behavior of the existing single-pack `install`/`upgrade`/`uninstall` paths (the profile orchestrator sits above them).
 - Introducing a new on-disk schema field beyond `scope`, `description`, and the ordered `packs` list.
 

--- a/docs/specs/pack-profiles/spec.md
+++ b/docs/specs/pack-profiles/spec.md
@@ -71,7 +71,7 @@ before proceeding; *Never do* is a hard rule, even under time pressure.
 - [x] `--profile` and `--pack` are mutually exclusive (a required mutex group); `--scope` is rejected when combined with `--profile`.
 - [x] No profile is recorded in state; per-pack rows are written at the profile's scope exactly as a manual per-pack install would; `STATE_SCHEMA_VERSION` is unchanged.
 - [x] `install_route` on each profile-installed pack's state row reads `"profile"` (RFC-0034 OQ3, accepted); the adapter contract version is unchanged.
-- [x] Two first-party profiles ship: `profiles/solution-architect.toml` (`scope = "user"`) and `profiles/full-ceremony.toml` (`scope = "repo"`), each installing cleanly against the live catalogue.
+- [x] Four first-party profiles ship: `profiles/solution-architect.toml` (`scope = "user"`), `profiles/full-ceremony.toml` (`scope = "repo"`), `profiles/inception.toml` (`scope = "user"`), and `profiles/digital-product.toml` (`scope = "user"`), each installing cleanly against the live catalogue.
 - [x] No change to `.claude-plugin/marketplace.json`, the build pipeline, or self-host. Verified by a name-only `git diff --name-only origin/main` over the feature's diff showing none of those paths are touched — sufficient for this additive, CLI-route-only PR (`profiles/` is a new top-level dir outside `packs/`, so `build-self` never aggregates it into `marketplace.json`). Wiring profiles into any of those surfaces would be a separate change with its own review; this AC asserts this PR does not.
 
 ## Assumptions

--- a/profiles/digital-product.toml
+++ b/profiles/digital-product.toml
@@ -1,0 +1,45 @@
+# Pack profile: digital-product (ini-003)
+#
+# The portable, user-scope toolkit for a digital product maker — someone who
+# owns strategy → shaping → experience → build for a digital product end to
+# end. Covers the full practitioner arc: desk research the space, shape the
+# product strategy and adoption hypothesis, design the experience, and shape
+# the build — so the same person can hold the whole thread in one installed
+# toolkit, carried across every repo they work in.
+#
+# Positions vs. the other user-scope profiles:
+#   inception       — tech founder / solo dev carrying an idea to a buildable
+#                     repo; architect-focused; pre-team. Use it when the job
+#                     is "design the system", not "own the product".
+#   solution-architect — architecture + desk research + contracts; no product
+#                     strategy or experience design. Use it when the job is
+#                     "design and govern the technical solution".
+#   digital-product — product manager, product designer, or product lead on a
+#                     cross-functional team owning a digital product end to end.
+#                     Use it when the job spans strategy through experience with
+#                     a build hand-off.
+#
+# The build loop itself is the repo-scope `core` pack, installed into each
+# repo. This profile gives the practitioner the thinking and design toolkit;
+# core handles the build layer.
+#
+# Installs in one command:
+#   agentbundle install --profile digital-product <catalogue>
+#
+# Lint invariants (tools/lint-profiles.py): scope-homogeneous (every pack
+# allows user scope), dependency-complete, deps-first ordered.
+
+scope = "user"
+description = "Digital product maker's portable user-scope toolkit: desk research the space, shape the product strategy and adoption hypothesis, design the experience, and prepare the build hand-off — end to end."
+
+[[packs]]
+pack = "desk-research"
+
+[[packs]]
+pack = "product-strategy"
+
+[[packs]]
+pack = "product-engineering"
+
+[[packs]]
+pack = "experience-design"

--- a/tools/lint-web-journey-parity.py
+++ b/tools/lint-web-journey-parity.py
@@ -13,10 +13,16 @@ A skill added to a pack without a corresponding journey update trips the
 invariant; a journey entry added without a matching skill directory also trips
 it. Either way the author is forced to reconcile.
 
+Profile pages: journey files whose `pack:` value resolves to a profile TOML
+at profiles/<pack>.toml (rather than a pack directory) are skipped — they
+represent persona journeys spanning multiple packs and have no single skill
+directory to count against.
+
 Exit 0 when every journey is in parity; exit 1 on any drift.
 
-Fixture mode (used by the paired self-test): set WJP_JOURNEY_DIR and
-WJP_PACKS_DIR to point to fixture directories instead of the real tree.
+Fixture mode (used by the paired self-test): set WJP_JOURNEY_DIR,
+WJP_PACKS_DIR, and WJP_PROFILES_DIR to point to fixture directories instead
+of the real tree.
 """
 
 from __future__ import annotations
@@ -84,6 +90,9 @@ def main() -> int:
     packs_dir = pathlib.Path(
         os.environ.get("WJP_PACKS_DIR", root / "packs")
     )
+    profiles_dir = pathlib.Path(
+        os.environ.get("WJP_PROFILES_DIR", root / "profiles")
+    )
 
     if not journey_dir.exists():
         print(
@@ -105,6 +114,11 @@ def main() -> int:
 
         skills_dir = packs_dir / pack / ".apm" / "skills"
         if not skills_dir.exists():
+            # Profile pages reference a profiles/<pack>.toml rather than a pack
+            # directory — skip them; they span multiple packs and have no single
+            # skill directory to count against.
+            if (profiles_dir / f"{pack}.toml").exists():
+                continue
             findings.append(
                 f"  {journey_file.name}: pack `{pack}` has no .apm/skills/ directory"
             )

--- a/tools/test-lint-web-journey-parity.py
+++ b/tools/test-lint-web-journey-parity.py
@@ -19,8 +19,14 @@ import tempfile
 _SCRIPT = pathlib.Path(__file__).parent / "lint-web-journey-parity.py"
 
 
-def _run(journey_dir: pathlib.Path, packs_dir: pathlib.Path) -> subprocess.CompletedProcess[str]:
+def _run(
+    journey_dir: pathlib.Path,
+    packs_dir: pathlib.Path,
+    profiles_dir: pathlib.Path | None = None,
+) -> subprocess.CompletedProcess[str]:
     env = {**os.environ, "WJP_JOURNEY_DIR": str(journey_dir), "WJP_PACKS_DIR": str(packs_dir)}
+    if profiles_dir is not None:
+        env["WJP_PROFILES_DIR"] = str(profiles_dir)
     return subprocess.run(
         [sys.executable, str(_SCRIPT)],
         capture_output=True, text=True, env=env, check=False,
@@ -93,6 +99,22 @@ def test_missing_skills_dir() -> None:
         _assert(r.returncode == 1, f"expected exit 1 when pack directory is absent; got {r.returncode}")
 
 
+def test_profile_page_skipped() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        j = pathlib.Path(tmp) / "journeys"
+        p = pathlib.Path(tmp) / "packs"
+        pr = pathlib.Path(tmp) / "profiles"
+        j.mkdir()
+        pr.mkdir()
+        _make_journey(j, "my-profile.md", "my-profile", [])
+        (pr / "my-profile.toml").write_text("scope = \"user\"\n")
+        _make_journey(j, "real.md", "real-pack", ["s1"])
+        _make_pack_skills(p, "real-pack", ["s1"])
+        r = _run(j, p, pr)
+        _assert(r.returncode == 0, f"expected exit 0 when profile page is present; got {r.returncode}\n{r.stderr}")
+        _assert("my-profile" not in r.stderr, f"profile page should not appear in stderr; got:\n{r.stderr}")
+
+
 def test_multiple_journeys_one_drifted() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         j = pathlib.Path(tmp) / "journeys"
@@ -114,6 +136,7 @@ def main() -> None:
         test_drift_detected,
         test_missing_pack_field,
         test_missing_skills_dir,
+        test_profile_page_skipped,
         test_multiple_journeys_one_drifted,
     ]
     for t in tests:

--- a/web/src/components/journey/JourneyHero.astro
+++ b/web/src/components/journey/JourneyHero.astro
@@ -11,7 +11,7 @@ interface Props {
   skillCount: number;
   humanTouches: number;
   wallClockMinutes: string;
-  packUrl: string;
+  packUrl?: string;
   docsUrl: string;
 }
 
@@ -33,7 +33,7 @@ const { name, scope, tagline, skillCount, humanTouches, wallClockMinutes, packUr
       <span class="stat"><strong>{wallClockMinutes}</strong> min/session</span>
     </div>
     <div class="journey-hero__actions">
-      <a class="btn-primary" href={withBase(packUrl)}>Install this pack <span aria-hidden="true">→</span></a>
+      {packUrl && <a class="btn-primary" href={withBase(packUrl)}>Install this pack <span aria-hidden="true">→</span></a>}
       <a class="btn-ghost" href={withBase(docsUrl)}>Read the reference <span aria-hidden="true">↗</span></a>
     </div>
   </div>

--- a/web/src/content.config.ts
+++ b/web/src/content.config.ts
@@ -57,7 +57,7 @@ const journeys = defineCollection({
       wallClockMinutes: z.string(),
     }),
     docsUrl: z.string(),
-    packUrl: z.string(),
+    packUrl: z.string().optional(),
     relatedJourneys: z.array(z.string()).default([]),
     goodOutputDescription: z.string().optional(),
   }),

--- a/web/src/content/journeys/digital-product.md
+++ b/web/src/content/journeys/digital-product.md
@@ -1,0 +1,144 @@
+---
+pack: digital-product
+scope: user
+tagline: "Strategy → shaping → experience → build hand-off — one toolkit, end to end."
+prerequisitePacks: []
+contract:
+  useItWhen: "You're a product manager, product designer, or product lead on a cross-functional team who owns a digital product from strategy through to build — and you want a single user-scope toolkit that covers the full arc."
+  youProvide: "Company OKRs, market context, and the scope of the product or initiative you're working on."
+  youReceive: "A connected chain from market situation through committed strategy artifacts, shaping briefs, and independently-reviewed experience designs — all feeding the Digital Experience Contract that the build repo's core pack reads from."
+  yourDecisions:
+    - "Approve the market situation picture and differentiation mechanism (product-strategy)"
+    - "Approve the adoption hypothesis, PRFAQ, and OKR cascade (product-strategy)"
+    - "Approve the customer journey, screen list, and aesthetic direction (experience-design)"
+    - "Review designs after the independent experience-reviewer pass (experience-design)"
+whatChanges: "After installing the digital-product profile, a single `agentbundle install --profile digital-product <catalogue>` gives you four packs at user scope: desk-research (eleven research skills + retrieval subagents for grounded evidence), product-strategy (fourteen-point output structure from market situation through strategy-to-experience handoff, filling the seven Strategy fields of the Digital Experience Contract), product-engineering (shaping queue, first-success operationalization, thin-slice learning contract), and experience-design (full XD chain: journey mapping → screen flow → aesthetic direction → per-screen design → three-pass self-review → independent experience-reviewer). The full chain produces a Digital Experience Contract — the shared schema connecting strategy intent to rendered evidence — that your build repo's core pack reads from. The profile is user-scope; each repo gets its own core (build loop) installed separately."
+skills:
+  - name: desk-research
+    description: "Scopes and executes evidence-grounded research projects. Eleven skills covering research scoping, source curation, synthesis, adversarial review, and a four-skill project-mode lifecycle for sustained investigations. Upstream of strategy and experience work."
+    humanTouches: 1
+  - name: run-swot
+    description: "Synthesizes the market situation into a SWOT and names the adoption hypothesis and differentiation mechanism. The capstone of the product-strategy situation analysis stage."
+    humanTouches: 1
+  - name: write-prfaq
+    description: "Authors the altitude-0 forcing function: press release + adoption hypothesis (first-success event, repeat-value behavior) + internal FAQ. The PRFAQ's first-success event is the measurement contract that all downstream work — PE shaping, XD journey, instrumentation — traces back to."
+    humanTouches: 1
+  - name: journey-mapping
+    description: "Maps the current and desired customer journey to derive the key touchpoints and failure modes a product must address. The connective thread that drives the screen list."
+    humanTouches: 1
+  - name: user-flow
+    description: "Derives the screen inventory and flow from the customer journey — what screens exist, what state each handles, and what the transitions are. Each screen becomes a per-screen brief for downstream design."
+    humanTouches: 1
+  - name: design-review
+    description: "Runs a three-pass authoring-time self-check on each screen (cold-read → primary task + unhappy path → full 18-state quality-floor contract review) before the independent experience-reviewer pass."
+    humanTouches: 0
+humanGates:
+  - id: G-situation
+    globalGate: null
+    label: "Approve the market situation picture and differentiation mechanism"
+    trigger: "After run-swot synthesizes the market environment, competitive landscape, and portfolio inputs"
+    duration: "10–15 minutes"
+    whatToCheck:
+      - "Does the SWOT name an adoption hypothesis — which SO pair produces a first-success event, and what is that event specifically?"
+      - "Is the differentiation mechanism named — a structural advantage, not a generic moat claim?"
+      - "Is the most acute threat named — the thing that could invalidate the strategy?"
+    whatGoodLooksLike: "A SWOT where every quadrant is traceable to a specific finding from the situation analysis, with an adoption hypothesis and a named differentiation mechanism."
+    whatBadLooksLike: "Generic strengths like 'talented team', no adoption hypothesis, and a moat claim with no mechanism."
+    consequence: "The SWOT anchors all downstream artifacts. A SWOT without an adoption hypothesis means first-success goes unspecified; a SWOT without a differentiation mechanism means the moat is assumed, not named."
+  - id: G-prfaq
+    globalGate: null
+    label: "Approve the PRFAQ and adoption hypothesis"
+    trigger: "After write-prfaq produces the press release, adoption hypothesis, and FAQ draft"
+    duration: "10–20 minutes"
+    whatToCheck:
+      - "Is the first-success event a specific observable behavior — not 'user signs up' or 'user completes onboarding'?"
+      - "Does the internal FAQ success metric trace back to the first-success event?"
+      - "Does the FAQ address the hardest objection a skeptical stakeholder would raise?"
+    whatGoodLooksLike: "A press release that names a specific person and first-success event, with a success metric traceable to that event."
+    whatBadLooksLike: "A press release in corporate voice with no specific person, no named first-success event, and a success metric of 'grow user base'."
+    consequence: "The first-success event named here is the measurement contract that PE shaping, XD journey mapping, and instrumentation all trace back to. An unspecific first-success event means every discipline forms its own theory of adoption."
+  - id: G-journey
+    globalGate: null
+    label: "Approve the customer journey and derived screen list"
+    trigger: "After journey-mapping and user-flow complete"
+    duration: "10–15 minutes"
+    whatToCheck:
+      - "Does the journey capture the outcome the user is trying to achieve — not just the tasks they perform in the current product?"
+      - "Is every screen in the list implied by the journey?"
+      - "Are the key failure modes named — the moments the current journey breaks down?"
+    whatGoodLooksLike: "A journey map that names the outcome and failure modes, with a screen list where each screen is traceable to a journey moment."
+    whatBadLooksLike: "A screen list that maps to the current implementation screen-by-screen — the agent documented the status quo instead of designing for the outcome."
+    consequence: "The screen list is the contract for all design work that follows. A screen list derived from the wrong model designs the wrong product — faithfully."
+  - id: G-experience-review
+    globalGate: null
+    label: "Review the designs after the independent experience-reviewer pass"
+    trigger: "After the experience-reviewer subagent returns findings on the completed screen designs"
+    duration: "15–25 minutes"
+    whatToCheck:
+      - "Did the reviewer flag any handle-all-states violations? (Missing empty, loading, error, or success states are the most common finding.)"
+      - "Are all WCAG 2.2 AA requirements met?"
+      - "Are the screens consistent with the approved aesthetic direction?"
+    whatGoodLooksLike: "A design set the independent reviewer marks clean — all states handled, accessibility floor met, aesthetic direction consistently applied."
+    whatBadLooksLike: "Screens that look good in the happy-path state but have no designed empty state, loading state, or error recovery."
+    consequence: "The experience-reviewer is the design analogue of adversarial-reviewer in the build loop. An unreviewed design is a set of unverified assumptions about how the product behaves when things go wrong."
+typicalSession:
+  agentTurns: "20–40"
+  humanTouches: 4
+  wallClockMinutes: "180–360"
+docsUrl: /docs/guides/experience-design/tutorials/xd-digital-product-profile/
+relatedJourneys:
+  - desk-research
+  - product-strategy
+  - experience-design
+  - core
+---
+
+### 1. Research the market context
+
+- **You provide:** the market or domain you're working in, the competitive landscape you know, and any existing research or organizational context.
+- **Agent does:** runs `desk-research` skills to scope the research question, curate sources, and synthesize evidence into committed artifacts — competitive signal, user behavior patterns, and any prior stakeholder research inputs.
+- **You do:** review the research synthesis before moving to strategy; if the synthesis doesn't surface adoption signal (evidence of how users behave, not just who they are), redirect — a strategy built on market description alone doesn't produce an adoption hypothesis.
+- **Output:** grounded research synthesis ready to feed the situation analysis.
+
+---
+
+### 2. Build and gate the market situation
+
+- **Agent does:** runs `synthesize-stakeholder-research` if prior research outputs exist; then runs `run-pestle-analysis`, `run-porters-five-forces`, and `run-bcg-matrix`; synthesizes all inputs into a committed SWOT — including the adoption hypothesis (which SO pair produces a first-success event) and the differentiation mechanism; commits each artifact to `docs/product/shaping/`.
+- **You do:** before moving forward, confirm the SWOT names an adoption hypothesis and a differentiation mechanism — not just four quadrants.
+- **You decide:** approve the market situation picture and differentiation mechanism.
+- **Output:** committed situation picture — the grounded anchor all downstream artifacts build on.
+
+---
+
+### 3. Commit the altitude-0 direction and adoption hypothesis
+
+- **Agent does:** runs `write-prfaq` to draft the press release + adoption hypothesis — naming the specific person, the first-success event (the one action that proves first value), the repeat-value behavior, and the internal FAQ with a success metric traceable to the first-success event; then runs `run-okr-cascade` to cascade company OKRs, derive the causal metric tree, and route gaps into `workspace.toml`; then runs `define-ux-strategy` and `define-content-strategy` to complete the strategy-to-experience handoff. Together these fill the seven Strategy fields of the Digital Experience Contract.
+- **You do:** read the PRFAQ; if the first-success event is not a specific observable behavior, redirect before the cascade sets metrics against an unspecific adoption target.
+- **You decide:** approve the PRFAQ and adoption hypothesis; approve the OKR cascade, causal metric tree, and gap routing.
+- **Output:** committed `prfaq.md`, `okr-cascade.md`, `ux-strategy.md`, `content-strategy.md`; the Strategy section of the Digital Experience Contract is populated.
+
+---
+
+### 4. Shape the initiative and first-success operationalization
+
+- **Agent does:** using the product-engineering pack, runs the shaping skills to produce a shaping brief (problem, first-success event operationalization, thin-slice scope) and routes it as a `strategy`-type entry in `workspace.toml`; applies the first-success operationalization to name the specific user action, the observable system response, and the measurement event.
+- **You do:** confirm the shaping brief names the same first-success event as the PRFAQ — if they diverge, the measurement contract is broken before build begins.
+- **Output:** committed shaping brief with first-success operationalization; workspace entry ready for the build loop.
+
+---
+
+### 5. Map the customer journey and design the experience
+
+- **Agent does:** runs `journey-mapping` and `user-flow` to derive the screen list from the customer journey; establishes design intent via `design-principles`, `creative-direction`, `design-token-taxonomy`, and `design-system-foundations`; designs each screen through `information-architecture`, the appropriate genre-specific skill, `interaction-design`, and the three-pass `design-review` self-check; then runs the forked-context `experience-reviewer` for an independent pass.
+- **You do:** approve the customer journey and screen list before screens are designed — a screen list derived from the wrong model designs the wrong product; approve the aesthetic direction and token set; review the independent reviewer's findings before design intent feeds the build.
+- **You decide:** approve the journey and screen list; approve the aesthetic direction; review designs after the independent pass.
+- **Output:** a review-clean design set — journey map, screen inventory, per-screen briefs, design principles, token foundation, and independently-reviewed screens — ready to feed the build loop.
+
+---
+
+### 6. Hand off to the build loop
+
+- **Agent does:** the Digital Experience Contract — now populated with strategy, shaping, and experience fields — is the hand-off artifact the build repo's `core` pack reads from. The core pack's `work-loop` and `frontend-engineering` skill read the contract fields to ground build decisions in the strategy and design intent.
+- **You do:** install `core` in the target repo (`agentbundle install --pack core <catalogue>`), point it to the contract, and confirm the first-success event named in the contract matches what the build loop will instrument.
+- **Output:** build loop launched with grounded strategy and design intent; instrumentation anchored to the first-success event named upstream.

--- a/web/src/content/journeys/digital-product.md
+++ b/web/src/content/journeys/digital-product.md
@@ -90,6 +90,7 @@ relatedJourneys:
   - desk-research
   - product-strategy
   - experience-design
+  - product-engineering
   - core
 ---
 

--- a/workspace.toml
+++ b/workspace.toml
@@ -409,6 +409,7 @@ shipped = [
   "xd-reference-guide-description-sync",             # Shipped 2026-07-24 — synced 21-skill descriptions to SKILL.md frontmatter; added copy-direction, design-token-taxonomy, design-system-foundations, experience-status; removed design-system
   "spec/xd-cross-pack-intent-index",               # Shipped 2026-07-24 — cross-pack "I want to…" intent index: adopter jobs → pack + skill + guide
   "spec/xd-cross-pack-tutorial",                    # Shipped 2026-07-24 — cross-pack tutorial: full XD chain on SaaS onboarding surface
+  "digital-product-profile",                          # Shipped 2026-07-24 — digital-product profile + journey page + tutorial (Wave 3A)
 ]
 
 ["ini-003".shaping_queue]
@@ -947,7 +948,6 @@ open = [
   # File: profiles/digital-product.toml (new); web/src/pages/journeys/; docs/guides/.
   # Unblocks when: all ini-003 specs ship (the skill set must be final before the
   #   profile's guide content is authored; premature guide content will drift).
-  {slug = "digital-product-profile", needs = "ini-003:work:spec/digital-product-guides-update"},
 
   # Pack strategy. The digital-experience-contract (spec/digital-experience-contract)
   # anchors its Frontend Engineering section to the `frontend-engineering` skill inside

--- a/workspace.toml
+++ b/workspace.toml
@@ -963,7 +963,7 @@ open = [
   # Fix: when the gate fires — open an RFC for the pack; scope it to the nine FE-section
   #   fields in the contract + the migration of the anchor path.
   # Unblocks when: `digital-product-profile` spec explicitly decides in-scope or deferred.
-  {slug = "frontend-engineering-pack-split", needs = "backlog:digital-product-profile"},
+  {slug = "frontend-engineering-pack-split", needs = "ini-003:work:digital-product-profile"},
 
   # RFC-0059 Non-goals. The honest counterpart to catalogue assimilation: cleanly
   # retire a skill/agent/hook or deprecate a pack with tombstones. Deferred as rare;


### PR DESCRIPTION
## Summary

Wave 3A of the ini-003 Digital Experience Doctrine initiative. Adds the `digital-product` first-party profile — the portable user-scope toolkit for a digital product maker (PM, product designer, product lead) who owns strategy → shaping → experience → build end to end.

- **`profiles/digital-product.toml`** — new user-scope profile bundling desk-research + product-strategy + product-engineering + experience-design, deps-first ordered. Positions vs. `inception` (tech founder / architect-focused) and `solution-architect` (architecture + contracts, no experience design).
- **`web/src/content/journeys/digital-product.md`** — persona journey page with full frontmatter (contract, 6 skills, 4 human gates, typicalSession) covering the full arc.
- **`docs/guides/experience-design/tutorials/xd-digital-product-profile.md`** — Diátaxis tutorial showing the first-session workflow across all four packs: install → desk-research → product-strategy chain → product-engineering shaping → experience-design → Digital Experience Contract hand-off.
- **`docs/guides/experience-design/README.md`** — adds Tutorials section linking the new tutorial.
- **`docs/specs/pack-profiles/spec.md`** — updates "Ask first" AC boundary to enumerate all four shipped profiles; updates AC14 count (two → four).
- **`workspace.toml`** — removes `digital-product-profile` from `[backlog].open`; adds it to `["ini-003".work].shipped`; updates `frontend-engineering-pack-split` needs to reference the shipped item.
- **`web/src/content.config.ts`** — makes `packUrl` optional so profile-type journeys without a `/packs/<name>/` page are representable.
- **`web/src/components/journey/JourneyHero.astro`** — conditionally renders the "Install this pack" button only when `packUrl` is present.

## Acceptance criteria met

- [x] `profiles/digital-product.toml` exists and validates (`python3 -c "import tomllib; tomllib.load(open('profiles/digital-product.toml','rb'))"`)
- [x] `tools/lint-profiles.py` passes (4 profiles OK)
- [x] `tools/check-contract-drift.py --root .` exits 0
- [x] Journey page `web/src/content/journeys/digital-product.md` exists with full frontmatter
- [x] Tutorial `docs/guides/experience-design/tutorials/xd-digital-product-profile.md` exists (6 steps, all four packs exercised)
- [x] Pack-profiles spec "Ask first" AC updated; AC14 updated to reflect four profiles
- [x] `workspace.toml`: `digital-product-profile` moved to shipped; dangling backlog reference resolved
- [x] `packUrl` schema made optional; `JourneyHero.astro` conditionally renders install button

## Bundled fixes

- `web/src/content.config.ts`: `packUrl: z.string().optional()` — required to support persona-type journey pages that have no `/packs/<name>/` equivalent
- `web/src/components/journey/JourneyHero.astro`: conditional `packUrl` render
- `docs/specs/pack-profiles/spec.md`: AC14 count corrected from two to four shipped profiles
- `workspace.toml`: `frontend-engineering-pack-split` `needs` updated from dangling `backlog:digital-product-profile` to `ini-003:work:digital-product-profile`