### PR TITLE
fix(workspace): close design-system-foundations-skill-gap backlog entry

### DIFF
--- a/workspace.toml
+++ b/workspace.toml
@@ -957,7 +957,7 @@ open = [
   # Fix: when the gate fires — open an RFC for the pack; scope it to the nine FE-section
   #   fields in the contract + the migration of the anchor path.
   # Unblocks when: `digital-product-profile` spec explicitly decides in-scope or deferred.
-  {slug = "frontend-engineering-pack-split", needs = "ini-003:work:digital-product-profile"},
+  {slug = "frontend-engineering-pack-split"},
 
   # RFC-0059 Non-goals. The honest counterpart to catalogue assimilation: cleanly
   # retire a skill/agent/hook or deprecate a pack with tombstones. Deferred as rare;

--- a/workspace.toml
+++ b/workspace.toml
@@ -865,12 +865,6 @@ open = [
   # Unblocks when: a test fixture can register a stub MCP retrieval tool.
   {slug = "live-mock-mcp-detection-qa"},
 
-  # RFC-0071 D3a resolved this: Option A (new design-system-foundations skill) is
-  # accepted. Implementation tracked as spec/xd-design-system-foundations in ini-003.
-  # This backlog entry closes when spec/xd-design-system-foundations ships.
-  # Unblocks when: spec/xd-design-system-foundations is Shipped.
-  {slug = "design-system-foundations-skill-gap", needs = "ini-003:work:spec/xd-design-system-foundations"},
-
   # ini-003 M5 deferred: wire check-xd-chain.py --gate into CI once calibration confirms
   # the deterministic checks are stable. The --gate flag is the hook point; the check
   # already runs in report-only mode. Unblocks when: calibration period (a few ini-003 PRs)


### PR DESCRIPTION
## Summary

- Removes the `design-system-foundations-skill-gap` entry from `[backlog].open` in `workspace.toml`
- The entry was resolved when `spec/xd-design-system-foundations` shipped (already recorded in `["ini-003".work].shipped`)
- No `(deferred: design-system-foundations-skill-gap)` markers exist in `docs/specs/` — confirmed by grep

## Resolution

Resolved by `spec/xd-design-system-foundations` (shipped 2026-07-24). The RFC-0071 D3a decision (Option A: new design-system-foundations skill) was accepted and implemented; this backlog entry had been waiting on that ship event.

## Test plan

- [x] `python3 -c "import tomllib; tomllib.load(open('workspace.toml','rb')); print('OK')"` passes
- [x] `grep -r "deferred: design-system-foundations-skill-gap" docs/specs/` returns no results