### PR TITLE
feat(ini-003): cross-pack eval LLM judge pass (Wave 4H)

### DIFF
--- a/docs/specs/cross-pack-experience-eval/spec.md
+++ b/docs/specs/cross-pack-experience-eval/spec.md
@@ -101,7 +101,7 @@ The phantom-handoff check finds every backtick-quoted name in the `description:`
 ## Deferred
 
 - **CI workflow** (`cross-pack-eval-ci-gate`): Once calibration confirms the deterministic checks are stable, wire `check-xd-chain.py --gate` into a CI workflow. The `--gate` flag is the hook point. (shipped: cross-pack-eval-ci-gate)
-- **LLM-judge rubric** (`cross-pack-eval-llm-judge`): The golden-path fixtures describe scenarios in structured form but carry no `evals.json`-style LLM judge rubric. (deferred: cross-pack-eval-llm-judge)
+- **LLM-judge rubric** (`cross-pack-eval-llm-judge`): The golden-path fixtures describe scenarios in structured form but carry no `evals.json`-style LLM judge rubric. (shipped: cross-pack-eval-llm-judge)
 
 ## Acceptance Criteria
 

--- a/tools/llm-judge-cross-pack-eval.py
+++ b/tools/llm-judge-cross-pack-eval.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""LLM judge pass for cross-pack XD eval fixtures (ini-003 Wave 4H / spec/cross-pack-experience-eval).
+
+Advisory complement to the deterministic check-xd-chain.py checker.
+Covers semantic invariants the deterministic checker cannot catch:
+
+  1. DEC section coherence   — chain skill output sections are internally
+                               consistent with one another across the chain
+  2. Persona consistency     — strategy-level persona framing (from
+                               journey-mapping, creative-direction) carries
+                               through coherently to experience-design outputs
+  3. Handoff completeness    — all expected fields described in
+                               handoff_completeness_criteria are present and
+                               sufficient for a practitioner to move forward
+
+This tool is ADVISORY ONLY and does NOT gate CI on its own (exit 0 means all
+judged fixtures passed; it is never a mandatory PR gate). It calls the
+Anthropic Messages API; do not invoke in unattended CI without explicit API
+cost controls.
+
+Usage:
+    python3 tools/llm-judge-cross-pack-eval.py [--root .] [--fixture-id <id>]
+
+Flags:
+    --root <dir>         Repo root (default: git toplevel or CWD)
+    --fixture-id <id>    Run only the fixture with this id (e.g. gp-01)
+
+Exit codes:
+  0 — all evaluated fixtures pass (advisory)
+  1 — at least one fixture failed the judge
+  2 — tool error (missing API key, unreadable fixture file, invalid root)
+
+Environment:
+  ANTHROPIC_API_KEY — required; the tool exits 2 if absent
+  ANTHROPIC_MODEL   — override the judge model (default: claude-haiku-4-5)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+
+FIXTURES_REL = "packs/experience-design/.apm/evals/cross-pack-fixtures.json"
+
+# All fixture sections that carry judge-relevant fields.
+FIXTURE_SECTIONS = ["golden_path", "multi_intent_routing", "boundary_violations", "weak_regression"]
+
+# Default judge model — haiku-class for cost efficiency on an advisory pass.
+DEFAULT_MODEL = "claude-haiku-4-5"
+
+# System prompt for the semantic judge.
+JUDGE_SYSTEM = """\
+You are an expert experience-design (XD) chain evaluator. You assess whether
+a described cross-pack XD skill-chain scenario is semantically coherent and
+complete. Given a fixture that describes a scenario (including expected skill
+sequence, handoff criteria, and coherence indicators), evaluate three dimensions:
+
+1. DEC coherence — Are the handoff_completeness_criteria internally consistent
+   with the Digital Experience Contract (DEC) framework and with one another?
+   Do adjacent skills' input/output descriptions align?
+
+2. Persona consistency — Does the scenario maintain consistent persona framing
+   from strategy inputs (e.g. journey-mapping, creative-direction) through to
+   experience-design outputs? Are the coherence_indicators persona-aware?
+
+3. Handoff completeness — Are all required handoff fields described for every
+   skill transition in the expected sequence? Would a practitioner following
+   this chain have sufficient input at each step?
+
+Respond with EXACTLY these three lines (no other text):
+  DEC coherence: PASS -- <one concise sentence>
+  Persona consistency: PASS -- <one concise sentence>
+  Handoff completeness: PASS -- <one concise sentence>
+
+Replace PASS with FAIL if the dimension has a problem. Be specific.
+"""
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _repo_root(root_arg: str | None) -> Path:
+    if root_arg:
+        p = Path(root_arg).resolve()
+        if not p.is_dir():
+            print(f"error: --root {root_arg!r} is not a directory", file=sys.stderr)
+            sys.exit(2)
+        return p
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True, text=True, check=False,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return Path(result.stdout.strip())
+    return Path.cwd()
+
+
+def _load_fixtures(root: Path) -> dict[str, Any]:
+    fixtures_path = root / FIXTURES_REL
+    try:
+        return json.loads(fixtures_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print(f"error: fixture file not found at {fixtures_path}", file=sys.stderr)
+        sys.exit(2)
+    except json.JSONDecodeError as exc:
+        print(f"error: invalid JSON in {fixtures_path}: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+
+def _collect_fixtures(
+    fixtures: dict[str, Any], fixture_id: str | None
+) -> list[tuple[str, dict[str, Any]]]:
+    """Return (section_type, fixture_dict) pairs, optionally filtered by id."""
+    results: list[tuple[str, dict[str, Any]]] = []
+    for section in FIXTURE_SECTIONS:
+        for entry in fixtures.get(section, []):
+            if fixture_id is None or entry.get("id") == fixture_id:
+                results.append((section, entry))
+    if fixture_id and not results:
+        print(f"error: no fixture with id {fixture_id!r} found", file=sys.stderr)
+        sys.exit(2)
+    return results
+
+
+def _build_user_prompt(section: str, fixture: dict[str, Any]) -> str:
+    """Construct the judge prompt for a single fixture."""
+    parts: list[str] = []
+    parts.append(f"Fixture id: {fixture.get('id', '?')}")
+    parts.append(f"Fixture type: {section}")
+    parts.append(f"Name: {fixture.get('name', '?')}")
+
+    if scenario := fixture.get("scenario"):
+        parts.append(f"\nScenario:\n{scenario}")
+
+    if description := fixture.get("description"):
+        parts.append(f"\nDescription:\n{description}")
+
+    if seq := fixture.get("expected_skill_sequence"):
+        parts.append("\nExpected skill sequence:\n" + " -> ".join(seq))
+
+    if routing := fixture.get("expected_routing"):
+        routing_lines = "\n".join(
+            f"  {r['skill']}: {r['role']}" for r in routing
+        )
+        parts.append(f"\nExpected routing:\n{routing_lines}")
+
+    if criteria := fixture.get("handoff_completeness_criteria"):
+        parts.append("\nHandoff completeness criteria:")
+        for c in criteria:
+            parts.append(f"  - {c}")
+
+    if indicators := fixture.get("coherence_indicators"):
+        parts.append("\nCoherence indicators:")
+        for i in indicators:
+            parts.append(f"  - {i}")
+
+    if persona := fixture.get("persona_lens"):
+        parts.append(f"\nPersona lens:\n{persona}")
+
+    if failure_mode := fixture.get("failure_mode"):
+        parts.append(f"\nFailure mode:\n{failure_mode}")
+
+    if detection := fixture.get("detection_criterion"):
+        parts.append(f"\nDetection criterion:\n{detection}")
+
+    parts.append(
+        "\nEvaluate this fixture on the three dimensions (DEC coherence, "
+        "Persona consistency, Handoff completeness) and respond with exactly "
+        "three PASS/FAIL lines as instructed."
+    )
+    return "\n".join(parts)
+
+
+def _parse_judge_response(text: str) -> dict[str, tuple[str, str]]:
+    """Parse the three judge verdict lines into {dimension: (verdict, rationale)}.
+
+    Returns a dict with keys 'DEC coherence', 'Persona consistency',
+    'Handoff completeness'. Each value is (verdict, rationale) where
+    verdict is 'PASS' or 'FAIL'.
+    """
+    results: dict[str, tuple[str, str]] = {}
+    dimension_prefixes = [
+        "DEC coherence",
+        "Persona consistency",
+        "Handoff completeness",
+    ]
+    for line in text.strip().splitlines():
+        line = line.strip()
+        for dim in dimension_prefixes:
+            if line.lower().startswith(dim.lower() + ":"):
+                rest = line[len(dim) + 1:].strip()
+                upper_rest = rest.upper()
+                if upper_rest.startswith("PASS"):
+                    verdict = "PASS"
+                    rationale = rest[4:].lstrip(" —-").strip()
+                elif upper_rest.startswith("FAIL"):
+                    verdict = "FAIL"
+                    rationale = rest[4:].lstrip(" —-").strip()
+                else:
+                    verdict = "UNKNOWN"
+                    rationale = rest
+                results[dim] = (verdict, rationale)
+    return results
+
+
+def _call_judge(client: Any, user_prompt: str, model: str) -> str:
+    """Call the Anthropic Messages API and return the text response."""
+    message = client.messages.create(
+        model=model,
+        max_tokens=512,
+        system=JUDGE_SYSTEM,
+        messages=[{"role": "user", "content": user_prompt}],
+    )
+    return message.content[0].text
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "LLM judge pass for cross-pack XD eval fixtures. "
+            "Advisory only -- never gates CI on its own."
+        ),
+    )
+    parser.add_argument(
+        "--root",
+        metavar="DIR",
+        default=None,
+        help="Repo root (default: git toplevel or CWD).",
+    )
+    parser.add_argument(
+        "--fixture-id",
+        metavar="ID",
+        default=None,
+        help="Run only the fixture with this id (e.g. gp-01).",
+    )
+    args = parser.parse_args()
+
+    # Load and validate fixtures before the API key check so that
+    # structural errors (bad fixture id, missing file) are caught early
+    # without requiring credentials.
+    root = _repo_root(args.root)
+    fixtures = _load_fixtures(root)
+    to_evaluate = _collect_fixtures(fixtures, args.fixture_id)
+
+    # API key check -- exit 2 after fixture validation so bad ids get
+    # their own clear error first.
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if not api_key:
+        print(
+            "error: ANTHROPIC_API_KEY is not set. "
+            "This tool calls the Anthropic API.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    model = os.environ.get("ANTHROPIC_MODEL", DEFAULT_MODEL)
+
+    try:
+        import anthropic  # noqa: PLC0415
+    except ImportError:
+        print(
+            "error: 'anthropic' package is not installed. "
+            "Run: pip install anthropic",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    client = anthropic.Anthropic(api_key=api_key)
+
+    print(f"\n[llm-judge-cross-pack-eval] model={model}")
+    print(f"[llm-judge-cross-pack-eval] fixtures={FIXTURES_REL}")
+    if args.fixture_id:
+        print(f"[llm-judge-cross-pack-eval] filter=--fixture-id {args.fixture_id}")
+
+    all_failures: list[str] = []
+
+    for section, fixture in to_evaluate:
+        fid = fixture.get("id", "?")
+        fname = fixture.get("name", "?")
+        print(f"\n[llm-judge-cross-pack-eval] [{section}] {fid}: {fname}")
+
+        user_prompt = _build_user_prompt(section, fixture)
+        try:
+            response_text = _call_judge(client, user_prompt, model)
+        except Exception as exc:  # noqa: BLE001
+            print(f"  ✖ API error for fixture {fid}: {exc}", file=sys.stderr)
+            all_failures.append(f"{fid}: API error -- {exc}")
+            continue
+
+        verdicts = _parse_judge_response(response_text)
+
+        dimensions = ["DEC coherence", "Persona consistency", "Handoff completeness"]
+        fixture_passed = True
+        for dim in dimensions:
+            if dim not in verdicts:
+                print(f"  ? {dim}: (no verdict parsed from response)")
+                continue
+            verdict, rationale = verdicts[dim]
+            symbol = "✓" if verdict == "PASS" else "✖"
+            rationale_short = rationale[:120] if rationale else "(no rationale)"
+            print(f"  {symbol} {dim}: {verdict} -- {rationale_short}")
+            if verdict != "PASS":
+                fixture_passed = False
+                all_failures.append(f"{fid} {dim}: {rationale_short}")
+
+        if fixture_passed:
+            print(f"  -> fixture {fid} passed all dimensions")
+        else:
+            print(f"  -> fixture {fid} FAILED one or more dimensions")
+
+    print()
+    total = len(to_evaluate)
+    failed_ids = {f.split()[0] for f in all_failures}
+    n_failed = len(failed_ids)
+
+    if not all_failures:
+        print(f"[llm-judge-cross-pack-eval] All {total} fixture(s) passed (advisory).")
+        return 0
+
+    print(f"[llm-judge-cross-pack-eval] {n_failed}/{total} fixture(s) with failures:")
+    for failure in all_failures:
+        print(f"  ::warning ::[llm-judge] {failure}")
+    print("[llm-judge-cross-pack-eval] Advisory only -- not a CI gate.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -2,3 +2,4 @@
 # linters parse YAML frontmatter via PyYAML. CI installs from this file;
 # contributors run `pip install -r tools/requirements.txt` once.
 pyyaml>=6.0
+anthropic>=0.20.0

--- a/tools/test-all.py
+++ b/tools/test-all.py
@@ -46,6 +46,7 @@ TESTS: list[tuple[str, list[str]]] = [
     ("lint-catalogue-seeds", [sys.executable, "tools/test-lint-catalogue-seeds.py"]),
     ("lint-knowledge",       ["bash", "tools/test-lint-knowledge.sh"]),
     ("lint-skill-spec",      [sys.executable, "tools/test-lint-skill-spec.py"]),
+    ("llm-judge-cross-pack-eval", [sys.executable, "tools/test-llm-judge-cross-pack-eval.py"]),
     ("loop-cohort",          ["bash", "tools/test-loop-cohort.sh"]),
     ("pre-pr",               ["bash", "tools/test-pre-pr.sh"]),
     ("session-start",        ["bash", "tools/test-session-start.sh"]),

--- a/tools/test-llm-judge-cross-pack-eval.py
+++ b/tools/test-llm-judge-cross-pack-eval.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Self-test for tools/llm-judge-cross-pack-eval.py (ini-003 Wave 4H).
+
+Does NOT call the real Anthropic API. Tests:
+  A — argument parsing: --root and --fixture-id flags are accepted
+  B — fixture loading: loads cross-pack-fixtures.json from the real repo
+  C — fixture filtering: --fixture-id selects the correct fixture
+  D — fixture filtering: unknown --fixture-id exits 2
+  E — no API key exits 2 with a clear message
+  F — _build_user_prompt: includes expected content for golden_path fixture
+  G — _parse_judge_response: parses PASS/FAIL verdicts correctly
+  H — _parse_judge_response: handles FAIL verdict with rationale
+  I — mocked API: all-pass run exits 0, summary mentions 'passed'
+  J — mocked API: fixture with FAIL exits 1, ::warning prefix in output
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import types
+import unittest.mock as mock
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+TOOL = REPO_ROOT / "tools" / "llm-judge-cross-pack-eval.py"
+FIXTURES_PATH = (
+    REPO_ROOT
+    / "packs/experience-design/.apm/evals/cross-pack-fixtures.json"
+)
+
+
+# ── Load the module under test without running main() ─────────────────────────
+
+def _load_tool(name: str = "llm_judge_cross_pack_eval") -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(name, TOOL)
+    mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+_tool = _load_tool()
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def fail(label: str, msg: str, detail: str = "") -> None:
+    print(f"✖ {label}: {msg}", file=sys.stderr)
+    if detail:
+        print("---", file=sys.stderr)
+        print(detail[:600], file=sys.stderr)
+        print("---", file=sys.stderr)
+    sys.exit(1)
+
+
+def _run_tool(*extra_args: str, env: dict | None = None) -> tuple[int, str]:
+    """Run the tool as a subprocess and return (exit_code, combined_output)."""
+    run_env = os.environ.copy()
+    run_env.pop("ANTHROPIC_API_KEY", None)
+    if env:
+        run_env.update(env)
+    result = subprocess.run(
+        [sys.executable, str(TOOL), *extra_args],
+        capture_output=True,
+        text=True,
+        env=run_env,
+    )
+    return result.returncode, result.stdout + result.stderr
+
+
+def _run_main_mocked(
+    response_text: str,
+    extra_argv: list[str] | None = None,
+) -> tuple[int, str]:
+    """Run main() with a mocked Anthropic client; return (exit_code, stdout)."""
+    mock_message = mock.MagicMock()
+    mock_message.content = [mock.MagicMock(text=response_text)]
+    mock_client = mock.MagicMock()
+    mock_client.messages.create.return_value = mock_message
+    mock_anthropic_module = mock.MagicMock()
+    mock_anthropic_module.Anthropic.return_value = mock_client
+
+    argv = [str(TOOL), "--root", str(REPO_ROOT)]
+    if extra_argv:
+        argv.extend(extra_argv)
+
+    captured = io.StringIO()
+    mod = _load_tool(f"llm_judge_mock_{id(response_text)}")
+
+    # Inject single fixture so the run is deterministic and fast.
+    fixtures_data = json.loads(FIXTURES_PATH.read_text(encoding="utf-8"))
+    single = [("golden_path", fixtures_data["golden_path"][0])]
+    mod._collect_fixtures = lambda f, fid: single  # type: ignore[assignment]
+
+    with (
+        mock.patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key-not-real"}),
+        mock.patch.dict(sys.modules, {"anthropic": mock_anthropic_module}),
+        mock.patch("sys.argv", argv),
+        mock.patch("sys.stdout", captured),
+    ):
+        exit_code = mod.main()
+
+    return exit_code, captured.getvalue()
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────────
+
+def test_a_argument_parsing() -> None:
+    label = "A (argument parsing: --root and --fixture-id accepted; exits 2 for missing API key)"
+    # With a valid fixture id but no API key, the tool should exit 2 (after
+    # fixture validation passes).
+    code, out = _run_tool("--root", str(REPO_ROOT), "--fixture-id", "gp-01")
+    if code != 2:
+        fail(label, f"expected exit 2 (no API key), got {code}", out)
+    if "ANTHROPIC_API_KEY" not in out:
+        fail(label, "expected API key message in output", out)
+    print(f"✓ {label}")
+
+
+def test_b_fixture_loading() -> None:
+    label = "B (fixture loading: fixtures file exists and is valid JSON)"
+    if not FIXTURES_PATH.exists():
+        fail(label, f"fixture file not found at {FIXTURES_PATH}")
+    try:
+        data = json.loads(FIXTURES_PATH.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(label, f"fixture file is not valid JSON: {exc}")
+    for section in ["golden_path", "multi_intent_routing", "boundary_violations", "weak_regression"]:
+        if section not in data:
+            fail(label, f"expected section '{section}' not found in fixture file")
+    print(f"✓ {label}")
+
+
+def test_c_fixture_filtering_known_id() -> None:
+    label = "C (_collect_fixtures: --fixture-id gp-01 returns exactly one fixture)"
+    fixtures = json.loads(FIXTURES_PATH.read_text(encoding="utf-8"))
+    results = _tool._collect_fixtures(fixtures, "gp-01")
+    if len(results) != 1:
+        fail(label, f"expected 1 fixture, got {len(results)}")
+    section, fixture = results[0]
+    if fixture.get("id") != "gp-01":
+        fail(label, f"expected id 'gp-01', got {fixture.get('id')!r}")
+    if section != "golden_path":
+        fail(label, f"expected section 'golden_path', got {section!r}")
+    print(f"✓ {label}")
+
+
+def test_d_fixture_filtering_unknown_id() -> None:
+    label = "D (unknown --fixture-id exits 2 with error message)"
+    code, out = _run_tool("--root", str(REPO_ROOT), "--fixture-id", "does-not-exist-xyz")
+    if code != 2:
+        fail(label, f"expected exit 2, got {code}", out)
+    if "does-not-exist-xyz" not in out:
+        fail(label, "expected unknown id in error output", out)
+    print(f"✓ {label}")
+
+
+def test_e_no_api_key_exits_2() -> None:
+    label = "E (no ANTHROPIC_API_KEY exits 2 with clear message)"
+    # Pass a valid fixture id so we get past fixture validation to the key check.
+    code, out = _run_tool("--root", str(REPO_ROOT), "--fixture-id", "gp-01")
+    if code != 2:
+        fail(label, f"expected exit 2, got {code}", out)
+    if "ANTHROPIC_API_KEY" not in out:
+        fail(label, "expected ANTHROPIC_API_KEY mention in error output", out)
+    print(f"✓ {label}")
+
+
+def test_f_build_user_prompt() -> None:
+    label = "F (_build_user_prompt: includes fixture id, name, skill sequence, handoff criteria)"
+    fixtures = json.loads(FIXTURES_PATH.read_text(encoding="utf-8"))
+    fixture = fixtures["golden_path"][0]  # gp-01
+    prompt = _tool._build_user_prompt("golden_path", fixture)
+    if "gp-01" not in prompt:
+        fail(label, "expected fixture id 'gp-01' in prompt")
+    if "Public marketing" not in prompt:
+        fail(label, "expected fixture name in prompt")
+    if "creative-direction" not in prompt:
+        fail(label, "expected skill name 'creative-direction' in prompt")
+    if "handoff" not in prompt.lower():
+        fail(label, "expected handoff criteria in prompt")
+    print(f"✓ {label}")
+
+
+def test_g_parse_judge_response_all_pass() -> None:
+    label = "G (_parse_judge_response: parses three PASS verdicts)"
+    response = (
+        "DEC coherence: PASS -- Handoff criteria align with DEC framework.\n"
+        "Persona consistency: PASS -- Persona framing is consistent throughout.\n"
+        "Handoff completeness: PASS -- All required fields are described.\n"
+    )
+    verdicts = _tool._parse_judge_response(response)
+    for dim in ["DEC coherence", "Persona consistency", "Handoff completeness"]:
+        if dim not in verdicts:
+            fail(label, f"dimension '{dim}' not parsed")
+        verdict, rationale = verdicts[dim]
+        if verdict != "PASS":
+            fail(label, f"expected PASS for '{dim}', got {verdict!r}")
+        if not rationale:
+            fail(label, f"expected rationale for '{dim}'")
+    print(f"✓ {label}")
+
+
+def test_h_parse_judge_response_fail() -> None:
+    label = "H (_parse_judge_response: parses FAIL verdict with rationale)"
+    response = (
+        "DEC coherence: PASS -- All criteria align.\n"
+        "Persona consistency: FAIL -- Persona is not carried forward to outputs.\n"
+        "Handoff completeness: PASS -- All fields present.\n"
+    )
+    verdicts = _tool._parse_judge_response(response)
+    verdict, rationale = verdicts.get("Persona consistency", ("?", ""))
+    if verdict != "FAIL":
+        fail(label, f"expected FAIL for 'Persona consistency', got {verdict!r}")
+    if not rationale:
+        fail(label, "expected rationale to be non-empty")
+    print(f"✓ {label}")
+
+
+def test_i_summary_all_pass() -> None:
+    label = "I (mocked API: all-pass run exits 0, summary mentions 'passed')"
+    response_text = (
+        "DEC coherence: PASS -- Criteria are internally consistent.\n"
+        "Persona consistency: PASS -- Persona framing is maintained.\n"
+        "Handoff completeness: PASS -- All fields described.\n"
+    )
+    exit_code, output = _run_main_mocked(response_text, ["--fixture-id", "gp-01"])
+    if exit_code != 0:
+        fail(label, f"expected exit 0, got {exit_code}", output)
+    if "passed" not in output.lower():
+        fail(label, "expected 'passed' in summary output", output)
+    print(f"✓ {label}")
+
+
+def test_j_summary_with_failure() -> None:
+    label = "J (mocked API: fixture with FAIL exits 1, ::warning prefix in output)"
+    response_text = (
+        "DEC coherence: PASS -- Criteria are consistent.\n"
+        "Persona consistency: FAIL -- No persona framing in outputs.\n"
+        "Handoff completeness: PASS -- All fields present.\n"
+    )
+    exit_code, output = _run_main_mocked(response_text, ["--fixture-id", "gp-01"])
+    if exit_code != 1:
+        fail(label, f"expected exit 1, got {exit_code}", output)
+    if "::warning" not in output:
+        fail(label, "expected '::warning' prefix in failure output", output)
+    print(f"✓ {label}")
+
+
+def main() -> int:
+    print("Running test-llm-judge-cross-pack-eval.py...")
+    test_a_argument_parsing()
+    test_b_fixture_loading()
+    test_c_fixture_filtering_known_id()
+    test_d_fixture_filtering_unknown_id()
+    test_e_no_api_key_exits_2()
+    test_f_build_user_prompt()
+    test_g_parse_judge_response_all_pass()
+    test_h_parse_judge_response_fail()
+    test_i_summary_all_pass()
+    test_j_summary_with_failure()
+    print("\n✓ All tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/workspace.toml
+++ b/workspace.toml
@@ -867,13 +867,6 @@ open = [
 
 
 
-  # ini-003 M5 deferred: the golden-path fixtures describe scenarios in structured form
-  # but carry no evals.json-style LLM judge rubric. Separate concern from the deterministic
-  # checker. Unblocks when: LLM judge rubric format is standardized across packs.
-  {slug = "cross-pack-eval-llm-judge", source = "spec/cross-pack-experience-eval"},
-
-
-
 
   # RFC-0062 OQ1. Extend experience-reviewer's scope to include content briefs
   # (type: content-brief) as a reviewable artifact type. The content-design skill


### PR DESCRIPTION
## Summary

- Adds `tools/llm-judge-cross-pack-eval.py`: advisory LLM judge that complements the deterministic `check-xd-chain.py` checker. Covers three semantic invariants the deterministic checker cannot catch: (1) DEC section coherence across packs, (2) persona consistency from strategy → experience, (3) handoff completeness between chain skills.
- Adds `tools/test-llm-judge-cross-pack-eval.py`: 10 tests covering argument parsing, fixture loading/filtering, prompt construction, response parsing, and end-to-end mocked API runs. No real API calls.
- Wires `llm-judge-cross-pack-eval` into `tools/test-all.py` TESTS list (alphabetical order, between `lint-skill-spec` and `loop-cohort`).
- Adds `anthropic>=0.20.0` to `tools/requirements.txt`.
- Removes `cross-pack-eval-llm-judge` backlog entry from `workspace.toml` (the item is now shipped).
- Updates `docs/specs/cross-pack-experience-eval/spec.md` deferred marker for `cross-pack-eval-llm-judge` to shipped.

## Tool design notes

- Advisory only — exits 0 if all judged fixtures pass; exits 1 on any failure. Never gates CI on its own.
- Fixtures are loaded and validated **before** the API key check, so a bad `--fixture-id` gives a clear error without needing credentials.
- `ANTHROPIC_MODEL` env var overrides the judge model (default: `claude-haiku-4-5`).
- Judge prompt is structured and concise; response format is three strict `PASS/FAIL` lines, one per dimension.

## Test plan

- [x] `python3 tools/test-llm-judge-cross-pack-eval.py` — all 10 tests pass (no real API calls)
- [x] `python3 -c "import tomllib; tomllib.load(open('workspace.toml','rb')); print('OK')"` — TOML valid

## Deferred

None.