### PR TITLE
feat(agentbundle): organization-artifactory-bootstrap — Layer 3 org Artifactory source (RFC-0072 D2)

### DIFF
--- a/packages/agentbundle/agentbundle/_data/install-defaults.toml
+++ b/packages/agentbundle/agentbundle/_data/install-defaults.toml
@@ -1,10 +1,19 @@
-# Packaged install default — layer 4 of the catalogue-source resolution chain
+# Optional organisation Artifactory bootstrap — layer 3 of the catalogue-source
+# resolution chain (RFC-0072 D2 / ADR-0036). When the ``enabled`` boolean is
+# set to ``true``, agentbundle constructs the URL:
+#   catalogue+<base-url>/<repository>/catalogues/<bundle>/channels/<channel>.json
+# as the default source for developers installing from this fork.
+# Public default ships ``enabled = false``; no real org endpoints are stored here.
+[organization.artifactory]
+enabled = false
+
+# Packaged install default — layer 5 of the catalogue-source resolution chain
 # (RFC-0046 / ADR-0036). When `agentbundle install`/`upgrade` is run with no
-# `catalogue` positional and layers 1–3 (explicit arg, user config, editable
-# detection) yield nothing, this source is used.
+# `catalogue` positional and layers 1–4 (explicit arg, user config, org
+# Artifactory bootstrap, editable detection) yield nothing, this source is used.
 #
 # Private-fork pattern: blank the `source` value below (or delete this file
-# entirely) to disable the packaged GitHub default — layers 1–3 still apply, so
+# entirely) to disable the packaged GitHub default — layers 1–4 still apply, so
 # an editable clone or a `config set source` still resolves.
 [defaults]
 source = "git+https://github.com/eugenelim/agent-ready-repo"

--- a/packages/agentbundle/agentbundle/source_defaults.py
+++ b/packages/agentbundle/agentbundle/source_defaults.py
@@ -1,13 +1,14 @@
 """Default catalogue-source resolution for ``install`` / ``upgrade`` (RFC-0046).
 
 When the ``catalogue`` positional is omitted, the install/upgrade handlers
-resolve a default source through a four-layer, trusted-by-construction,
+resolve a default source through a five-layer, trusted-by-construction,
 first-match-wins chain (ADR-0036):
 
-  1. the explicit ``catalogue`` arg — passed through verbatim (layer 1);
-  2. the user ``[settings].source`` config value (layer 2);
-  3. editable-install detection via PEP 610 ``direct_url.json`` (layer 3);
-  4. the packaged ``_data/install-defaults.toml`` default (layer 4).
+  1. the explicit ``catalogue`` arg — passed through verbatim;
+  2. the user ``[settings].source`` config value;
+  3. package-shipped org Artifactory bootstrap (RFC-0072 D2);
+  4. editable-install detection via PEP 610 ``direct_url.json``;
+  5. the packaged ``_data/install-defaults.toml`` default.
 
 ``resolve_catalogue`` (``catalogue.py``) stays a thin fetcher with no
 path/marker validation; **all** validation lives here. Resolution is
@@ -39,6 +40,8 @@ _SHA256_FRAGMENT_RE = _re.compile(r"^sha256=[0-9a-f]{64}$")
 # colon, then a separator. Checked *before* the urlsplit scheme test because
 # ``urlsplit("C:/x").scheme`` is ``"c"`` and would otherwise read as a URL.
 _WIN_DRIVE_RE = re.compile(r"^[A-Za-z]:[\\/]")
+# Segment grammar for org-bootstrap path components (repository, bundle, channel).
+_ORG_SEGMENT_RE = re.compile(r"[A-Za-z0-9._-]+")
 
 _MARKER_DIR = "packs"
 _MARKER_FILE = (".claude-plugin", "marketplace.json")
@@ -53,12 +56,12 @@ _NO_SOURCE_MSG = (
 )
 
 # Sentinel: distinguishes "caller did not pass a distribution" (load it
-# lazily) from "caller passed None" (no distribution — skip layer 3).
+# lazily) from "caller passed None" (no distribution — skip layer 4).
 _UNSET: object = object()
 
 
 # ---------------------------------------------------------------------------
-# Validation gate (layers 2 and 4)
+# Validation gate (layers 2 and 5)
 # ---------------------------------------------------------------------------
 
 
@@ -79,7 +82,7 @@ def _local_path_has_markers(value: str) -> bool:
 
 
 def _is_valid_source(value: str) -> bool:
-    """The scheme/marker gate applied to layer-2 and layer-4 sources.
+    """The scheme/marker gate applied to layer-2 and layer-5 sources.
 
     Exact allowlist discriminator (spec validation AC), in order:
       1. literal ``git+https://`` prefix (case-sensitive, matching
@@ -116,7 +119,169 @@ def _is_valid_source(value: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# Layer 3 — editable-install detection
+# Layer 3 — org Artifactory bootstrap (RFC-0072 D2)
+# ---------------------------------------------------------------------------
+
+
+def _source_from_org_bootstrap(text: str, *, config_path: str) -> str | None:
+    """Parse ``[organization.artifactory]`` from ``install-defaults.toml`` text.
+
+    Returns ``None`` when the bootstrap is disabled: absent table, absent or
+    ``false`` ``enabled`` key, or unparseable TOML (the file cannot reveal
+    ``enabled``, so fall-through is the only safe choice — AC2b).
+
+    When ``enabled = true`` (TOML boolean), applies all validation rules before
+    constructing the URL. On any validation failure raises ``CatalogueError``
+    naming the malformed field and the ``config_path`` — fail-closed, never
+    falls through to Layer 4.
+
+    Returns a ``catalogue+https://…`` URI string when all fields are valid.
+    """
+    try:
+        data = tomllib.loads(text)
+    except tomllib.TOMLDecodeError:
+        return None
+
+    # Two-step isinstance-guarded nesting access — avoids AttributeError when
+    # an intermediate key holds a non-dict TOML value (e.g. `organization = "typo"`).
+    org = data.get("organization")
+    if not isinstance(org, dict):
+        return None
+    org_block = org.get("artifactory")
+    if not isinstance(org_block, dict):
+        return None
+
+    enabled = org_block.get("enabled")
+    if enabled is None or enabled is False:
+        return None
+    if enabled is not True:
+        raise CatalogueError(
+            f"organization.artifactory.enabled: must be a boolean (true/false) "
+            f"in {config_path}"
+        )
+
+    # --- enabled is True: fail-closed from here on ---
+
+    # Validate base-url
+    base_url = org_block.get("base-url")
+    if base_url is None:
+        raise CatalogueError(
+            f"organization.artifactory.base-url: required field missing in {config_path}"
+        )
+    if not isinstance(base_url, str) or not base_url.strip():
+        raise CatalogueError(
+            f"organization.artifactory.base-url: must be a non-empty string "
+            f"in {config_path}"
+        )
+    # Case-sensitive prefix check before urlsplit so uppercase schemes are
+    # rejected here, guaranteeing the constructed URL starts with lower-case
+    # `catalogue+https://` as required by _is_valid_source.
+    if not base_url.startswith("https://"):
+        raise CatalogueError(
+            f"organization.artifactory.base-url: must start with 'https://' "
+            f"in {config_path}"
+        )
+    parsed = urlsplit(base_url)
+    if not parsed.netloc:
+        raise CatalogueError(
+            f"organization.artifactory.base-url: netloc must not be empty "
+            f"in {config_path}"
+        )
+    if "@" in parsed.netloc:
+        # Do NOT include the raw base_url in the message — it may contain credentials.
+        raise CatalogueError(
+            f"organization.artifactory.base-url: netloc must not contain '@' "
+            f"in {config_path}"
+        )
+    if parsed.query:
+        raise CatalogueError(
+            f"organization.artifactory.base-url: must not contain a query string "
+            f"in {config_path}"
+        )
+    if parsed.fragment:
+        raise CatalogueError(
+            f"organization.artifactory.base-url: must not contain a fragment "
+            f"in {config_path}"
+        )
+
+    # Normalize trailing slash before joining path segments.
+    base_url = base_url.rstrip("/")
+
+    # Validate repository, bundle, channel
+    segments: dict[str, str] = {}
+    for fname in ("repository", "bundle", "channel"):
+        val = org_block.get(fname)
+        if val is None:
+            raise CatalogueError(
+                f"organization.artifactory.{fname}: required field missing "
+                f"in {config_path}"
+            )
+        if not isinstance(val, str) or not val.strip():
+            raise CatalogueError(
+                f"organization.artifactory.{fname}: must be a non-empty string "
+                f"in {config_path}"
+            )
+        # Defense-in-depth: explicit reject before regex (both `.` chars are
+        # individually valid but the combination is a path-traversal pattern).
+        if val == "..":
+            raise CatalogueError(
+                f"organization.artifactory.{fname}: must not be '..' "
+                f"in {config_path}"
+            )
+        if not _ORG_SEGMENT_RE.fullmatch(val):
+            raise CatalogueError(
+                f"organization.artifactory.{fname}: contains invalid characters "
+                f"(expected [A-Za-z0-9._-]+) in {config_path}"
+            )
+        segments[fname] = val
+
+    return (
+        f"catalogue+{base_url}"
+        f"/{segments['repository']}/catalogues/{segments['bundle']}"
+        f"/channels/{segments['channel']}.json"
+    )
+
+
+def read_org_bootstrap(
+    read_text: "Callable[[], tuple[str, str] | None] | None" = None,
+) -> str | None:
+    """Return the org Artifactory bootstrap source URI, or ``None``.
+
+    When ``read_text`` is ``None`` (production path): reads the packaged
+    ``_data/install-defaults.toml`` via ``importlib.resources``; absorbs
+    ``(FileNotFoundError, ModuleNotFoundError, OSError)`` as ``None``; passes
+    ``config_path=str(resource)`` for error messages.
+
+    When ``read_text`` is provided (test injection path): calls it; if it
+    returns ``None``, returns ``None``; otherwise unpacks ``(text, config_path)``
+    and delegates to ``_source_from_org_bootstrap``.
+
+    Returns ``None`` when the bootstrap is disabled.  Raises ``CatalogueError``
+    when ``enabled = true`` and any field is malformed (fail-closed).
+    """
+    if read_text is not None:
+        result = read_text()
+        if result is None:
+            return None
+        text, config_path = result
+        return _source_from_org_bootstrap(text, config_path=config_path)
+
+    # Production path: read from the packaged resource.
+    try:
+        from importlib.resources import files
+
+        resource = files("agentbundle").joinpath("_data/install-defaults.toml")
+        if not resource.is_file():
+            return None
+        text = resource.read_text(encoding="utf-8")
+        config_path = str(resource)
+    except (FileNotFoundError, ModuleNotFoundError, OSError):
+        return None
+    return _source_from_org_bootstrap(text, config_path=config_path)
+
+
+# ---------------------------------------------------------------------------
+# Layer 4 — editable-install detection
 # ---------------------------------------------------------------------------
 
 
@@ -218,7 +383,7 @@ def _detect_editable_source(dist: object, *, stream: TextIO | None = None) -> st
 
 
 # ---------------------------------------------------------------------------
-# Layer 4 — packaged default
+# Layer 5 — packaged default
 # ---------------------------------------------------------------------------
 
 
@@ -246,7 +411,7 @@ def read_packaged_default() -> str | None:
     ``_data/install-defaults.toml``, or ``None``.
 
     An absent file, an empty/blanked ``source``, or malformed TOML all yield
-    ``None`` (no layer-4 default) — the private-fork pattern.
+    ``None`` (no layer-5 default) — the private-fork pattern.
     """
     try:
         from importlib.resources import files
@@ -324,7 +489,7 @@ def _load_distribution() -> object | None:
     the venv's ``.dist-info`` after an editable install; a plain
     ``metadata.distribution("agentbundle")`` may then return the egg-info
     (which has no ``direct_url.json``), silently defeating editable detection —
-    exactly the gateway-bound-fork case layer 3 exists for. Scanning and
+    exactly the gateway-bound-fork case layer 4 exists for. Scanning and
     preferring the record-bearing distribution makes detection robust to that
     shadowing.
     """
@@ -367,18 +532,24 @@ def resolve_default_source(
     config_source: str | None = None,
     dist: object = _UNSET,
     read_packaged: Callable[[], str | None] | None = None,
+    read_org: Callable[[], str | None] | None = None,
     stream: TextIO | None = None,
 ) -> str:
-    """Resolve the catalogue source through the four-layer chain.
+    """Resolve the catalogue source through the five-layer chain.
 
     First-match-wins, highest-first: explicit arg (verbatim, unvalidated —
-    today's behaviour) › validated ``config_source`` › editable detection ›
-    validated packaged default. Raises ``CatalogueError`` naming all recovery
-    paths when no layer yields a source. Writes nothing on any path.
+    today's behaviour) › validated ``config_source`` › org Artifactory
+    bootstrap (RFC-0072 D2) › editable detection › validated packaged default.
+    Raises ``CatalogueError`` naming all recovery paths when no layer yields a
+    source. Writes nothing on any path.
+
+    Layer 3 (org Artifactory bootstrap) raises ``CatalogueError`` fail-closed
+    when ``enabled = true`` and any field is malformed — it does not fall
+    through to Layer 4.
 
     Pure over its injected environment (``config_source``, ``dist``,
-    ``read_packaged``) so the precedence and validation logic is unit-testable
-    without touching the real filesystem or installed metadata.
+    ``read_packaged``, ``read_org``) so the precedence and validation logic is
+    unit-testable without touching the real filesystem or installed metadata.
     """
     if stream is None:
         stream = sys.stderr
@@ -397,14 +568,21 @@ def resolve_default_source(
             file=stream,
         )
 
-    # Layer 3 — editable detection.
+    # Layer 3 — org Artifactory bootstrap (RFC-0072 D2).
+    if read_org is None:
+        read_org = read_org_bootstrap
+    org = read_org()  # None when disabled; raises CatalogueError on fail-closed
+    if org is not None:
+        return org
+
+    # Layer 4 — editable detection.
     if dist is _UNSET:
         dist = _load_distribution()
     editable = _detect_editable_source(dist, stream=stream)
     if editable is not None:
         return editable
 
-    # Layer 4 — packaged default, validated.
+    # Layer 5 — packaged default, validated.
     if read_packaged is None:
         read_packaged = read_packaged_default
     packaged = read_packaged()

--- a/packages/agentbundle/tests/unit/test_org_bootstrap.py
+++ b/packages/agentbundle/tests/unit/test_org_bootstrap.py
@@ -1,0 +1,673 @@
+"""Unit tests for the organization Artifactory bootstrap — Layer 3 of the
+catalogue-source resolution chain (RFC-0072 D2).
+
+Covers:
+- T1: install-defaults.toml ships [organization.artifactory] disabled by default (AC1)
+- T2: _source_from_org_bootstrap validation rules (AC2–AC16, AC21–AC22)
+- T2: read_org_bootstrap public API (AC4, AC5, AC19 prerequisite)
+- T3: Integration — Layer 3 position in resolve_default_source (AC17, AC18, AC19)
+"""
+from __future__ import annotations
+
+import importlib.resources
+import tomllib
+
+import pytest
+
+from agentbundle.catalogue import CatalogueError
+from agentbundle.source_defaults import (
+    _is_valid_source,
+    _source_from_org_bootstrap,
+    read_org_bootstrap,
+    resolve_default_source,
+)
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+_VALID_ORG_TOML = """\
+[organization.artifactory]
+enabled = true
+base-url = "https://example.test/art"
+repository = "repo-local"
+bundle = "engineering"
+channel = "stable"
+"""
+
+_DISABLED_ORG_TOML = """\
+[organization.artifactory]
+enabled = false
+"""
+
+_CONSTRUCTED_URL = (
+    "catalogue+https://example.test/art"
+    "/repo-local/catalogues/engineering/channels/stable.json"
+)
+
+# ---------------------------------------------------------------------------
+# T1 — install-defaults.toml ships [organization.artifactory] disabled
+# ---------------------------------------------------------------------------
+
+
+def test_install_defaults_org_bootstrap_disabled_by_default():
+    """AC1: Packaged file ships [organization.artifactory] with enabled = false only."""
+    resource = importlib.resources.files("agentbundle").joinpath(
+        "_data/install-defaults.toml"
+    )
+    text = resource.read_text(encoding="utf-8")
+    data = tomllib.loads(text)
+    assert data["organization"]["artifactory"]["enabled"] is False
+    assert set(data["organization"]["artifactory"].keys()) == {"enabled"}
+
+
+# ---------------------------------------------------------------------------
+# T2 — _source_from_org_bootstrap: disabled paths (return None)
+# ---------------------------------------------------------------------------
+
+
+def test_org_bootstrap_absent_table_returns_none():
+    """AC2: No [organization] section → None."""
+    text = '[defaults]\nsource = "git+https://example.test/repo"\n'
+    assert _source_from_org_bootstrap(text, config_path="test-path") is None
+
+
+def test_org_bootstrap_absent_artifactory_key_returns_none():
+    """AC2: [organization] present but no [organization.artifactory] → None."""
+    text = '[organization]\nname = "myorg"\n'
+    assert _source_from_org_bootstrap(text, config_path="test-path") is None
+
+
+def test_org_bootstrap_organization_scalar_returns_none():
+    """AC2: organization = 'typo' (non-dict TOML value) → None, not AttributeError."""
+    text = 'organization = "typo"\n'
+    assert _source_from_org_bootstrap(text, config_path="test-path") is None
+
+
+def test_org_bootstrap_artifactory_scalar_returns_none():
+    """AC2: [organization] with artifactory = true (non-dict) → None, not AttributeError."""
+    text = "[organization]\nartifactory = true\n"
+    assert _source_from_org_bootstrap(text, config_path="test-path") is None
+
+
+def test_org_bootstrap_toml_decode_error_returns_none():
+    """AC2b: Unparseable TOML → None (not CatalogueError; cannot read enabled)."""
+    text = "not = valid = toml\n"
+    assert _source_from_org_bootstrap(text, config_path="test-path") is None
+
+
+def test_org_bootstrap_absent_enabled_returns_none():
+    """AC3: [organization.artifactory] present but no enabled key → None."""
+    text = '[organization.artifactory]\nbase-url = "https://example.test/art"\n'
+    assert _source_from_org_bootstrap(text, config_path="test-path") is None
+
+
+def test_org_bootstrap_enabled_false_returns_none():
+    """AC4: enabled = false → None; other fields not inspected."""
+    assert _source_from_org_bootstrap(_DISABLED_ORG_TOML, config_path="test-path") is None
+
+
+# ---------------------------------------------------------------------------
+# T2 — _source_from_org_bootstrap: non-boolean enabled raises (AC3b)
+# ---------------------------------------------------------------------------
+
+
+def test_org_bootstrap_enabled_string_nontrue_raises():
+    """AC3b: enabled = 'true' (TOML string, not boolean) → CatalogueError naming enabled."""
+    text = '[organization.artifactory]\nenabled = "true"\n'
+    with pytest.raises(CatalogueError) as exc:
+        _source_from_org_bootstrap(text, config_path="sentinel-path")
+    msg = str(exc.value)
+    assert "enabled" in msg
+    assert "sentinel-path" in msg
+
+
+def test_org_bootstrap_enabled_integer_raises():
+    """AC3b: enabled = 1 (TOML integer) → CatalogueError naming enabled."""
+    text = "[organization.artifactory]\nenabled = 1\n"
+    with pytest.raises(CatalogueError) as exc:
+        _source_from_org_bootstrap(text, config_path="sentinel-path")
+    msg = str(exc.value)
+    assert "enabled" in msg
+
+
+# ---------------------------------------------------------------------------
+# T2 — _source_from_org_bootstrap: URL construction (AC5, AC6)
+# ---------------------------------------------------------------------------
+
+
+def test_org_bootstrap_valid_config_constructs_url():
+    """AC5: Valid enabled = true config → correct catalogue+https:// URL."""
+    url = _source_from_org_bootstrap(_VALID_ORG_TOML, config_path="test-path")
+    assert url == _CONSTRUCTED_URL
+
+
+def test_org_bootstrap_trailing_slash_on_base_url_normalized():
+    """AC6: Trailing slash on base-url stripped — no double-slash in constructed URL."""
+    text = """\
+[organization.artifactory]
+enabled = true
+base-url = "https://example.test/art/"
+repository = "repo-local"
+bundle = "engineering"
+channel = "stable"
+"""
+    url = _source_from_org_bootstrap(text, config_path="test-path")
+    assert url == _CONSTRUCTED_URL
+    # Verify no double-slash after the scheme
+    after_scheme = url.split("catalogue+https://", 1)[1]
+    assert "//" not in after_scheme
+
+
+def test_org_bootstrap_no_trailing_slash_on_base_url_unchanged():
+    """AC6: No trailing slash → same URL as trailing-slash variant."""
+    url = _source_from_org_bootstrap(_VALID_ORG_TOML, config_path="test-path")
+    assert url == _CONSTRUCTED_URL
+
+
+# ---------------------------------------------------------------------------
+# T2 — base-url validation raises (AC7–AC11)
+# ---------------------------------------------------------------------------
+
+
+def test_org_bootstrap_http_base_url_raises():
+    """AC7: http:// base-url → CatalogueError naming base-url."""
+    text = (
+        '[organization.artifactory]\nenabled = true\n'
+        'base-url = "http://example.test/art"\n'
+        'repository = "r"\nbundle = "b"\nchannel = "c"\n'
+    )
+    with pytest.raises(CatalogueError) as exc:
+        _source_from_org_bootstrap(text, config_path="test-path")
+    assert "base-url" in str(exc.value)
+
+
+def test_org_bootstrap_ftp_base_url_raises():
+    """AC7: ftp:// base-url → CatalogueError naming base-url."""
+    text = (
+        '[organization.artifactory]\nenabled = true\n'
+        'base-url = "ftp://example.test/art"\n'
+        'repository = "r"\nbundle = "b"\nchannel = "c"\n'
+    )
+    with pytest.raises(CatalogueError) as exc:
+        _source_from_org_bootstrap(text, config_path="test-path")
+    assert "base-url" in str(exc.value)
+
+
+def test_org_bootstrap_uppercase_https_base_url_raises():
+    """AC7: HTTPS:// base-url (uppercase scheme) → CatalogueError (case-sensitive prefix check)."""
+    text = (
+        '[organization.artifactory]\nenabled = true\n'
+        'base-url = "HTTPS://example.test/art"\n'
+        'repository = "r"\nbundle = "b"\nchannel = "c"\n'
+    )
+    with pytest.raises(CatalogueError) as exc:
+        _source_from_org_bootstrap(text, config_path="test-path")
+    assert "base-url" in str(exc.value)
+
+
+def test_org_bootstrap_user_info_colon_in_base_url_raises():
+    """AC8: user:pass@host in base-url → CatalogueError; message must not contain credential."""
+    text = (
+        '[organization.artifactory]\nenabled = true\n'
+        'base-url = "https://user:pass@example.test/art"\n'
+        'repository = "r"\nbundle = "b"\nchannel = "c"\n'
+    )
+    with pytest.raises(CatalogueError) as exc:
+        _source_from_org_bootstrap(text, config_path="test-path")
+    msg = str(exc.value)
+    assert "base-url" in msg
+    assert "user" not in msg
+    assert "pass" not in msg
+
+
+def test_org_bootstrap_bare_user_in_base_url_raises():
+    """AC8: user@host in base-url → CatalogueError; message must not contain the username."""
+    text = (
+        '[organization.artifactory]\nenabled = true\n'
+        'base-url = "https://user@example.test/art"\n'
+        'repository = "r"\nbundle = "b"\nchannel = "c"\n'
+    )
+    with pytest.raises(CatalogueError) as exc:
+        _source_from_org_bootstrap(text, config_path="test-path")
+    msg = str(exc.value)
+    assert "base-url" in msg
+    assert "user" not in msg
+
+
+def test_org_bootstrap_query_string_in_base_url_raises():
+    """AC9: Query string in base-url → CatalogueError naming base-url."""
+    text = (
+        '[organization.artifactory]\nenabled = true\n'
+        'base-url = "https://example.test/art?foo=bar"\n'
+        'repository = "r"\nbundle = "b"\nchannel = "c"\n'
+    )
+    with pytest.raises(CatalogueError) as exc:
+        _source_from_org_bootstrap(text, config_path="test-path")
+    assert "base-url" in str(exc.value)
+
+
+def test_org_bootstrap_fragment_in_base_url_raises():
+    """AC10: Fragment in base-url → CatalogueError naming base-url."""
+    text = (
+        '[organization.artifactory]\nenabled = true\n'
+        'base-url = "https://example.test/art#section"\n'
+        'repository = "r"\nbundle = "b"\nchannel = "c"\n'
+    )
+    with pytest.raises(CatalogueError) as exc:
+        _source_from_org_bootstrap(text, config_path="test-path")
+    assert "base-url" in str(exc.value)
+
+
+def test_org_bootstrap_empty_base_url_raises():
+    """AC11: Empty base-url → CatalogueError naming base-url."""
+    text = (
+        '[organization.artifactory]\nenabled = true\n'
+        'base-url = ""\n'
+        'repository = "r"\nbundle = "b"\nchannel = "c"\n'
+    )
+    with pytest.raises(CatalogueError) as exc:
+        _source_from_org_bootstrap(text, config_path="test-path")
+    assert "base-url" in str(exc.value)
+
+
+def test_org_bootstrap_empty_netloc_in_base_url_raises():
+    """AC11: Empty netloc (https:///path) → CatalogueError naming base-url."""
+    text = (
+        '[organization.artifactory]\nenabled = true\n'
+        'base-url = "https:///path"\n'
+        'repository = "r"\nbundle = "b"\nchannel = "c"\n'
+    )
+    with pytest.raises(CatalogueError) as exc:
+        _source_from_org_bootstrap(text, config_path="test-path")
+    assert "base-url" in str(exc.value)
+
+
+def test_org_bootstrap_integer_base_url_raises():
+    """Type-check: base-url = 123 (TOML integer) → CatalogueError naming base-url."""
+    text = (
+        '[organization.artifactory]\nenabled = true\n'
+        'base-url = 123\n'
+        'repository = "r"\nbundle = "b"\nchannel = "c"\n'
+    )
+    with pytest.raises(CatalogueError) as exc:
+        _source_from_org_bootstrap(text, config_path="test-path")
+    assert "base-url" in str(exc.value)
+
+
+def test_org_bootstrap_missing_base_url_key_raises():
+    """AC15: Missing base-url when enabled = true → CatalogueError naming base-url."""
+    text = (
+        '[organization.artifactory]\nenabled = true\n'
+        'repository = "r"\nbundle = "b"\nchannel = "c"\n'
+    )
+    with pytest.raises(CatalogueError) as exc:
+        _source_from_org_bootstrap(text, config_path="test-path")
+    assert "base-url" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# T2 — path-segment validation raises (AC12–AC15)
+# ---------------------------------------------------------------------------
+
+
+def test_org_bootstrap_repository_slash_raises():
+    """AC12: repository with / → CatalogueError naming repository."""
+    text = (
+        '[organization.artifactory]\nenabled = true\n'
+        'base-url = "https://example.test/art"\n'
+        'repository = "my/repo"\nbundle = "b"\nchannel = "c"\n'
+    )
+    with pytest.raises(CatalogueError) as exc:
+        _source_from_org_bootstrap(text, config_path="test-path")
+    assert "repository" in str(exc.value)
+
+
+def test_org_bootstrap_repository_dotdot_raises():
+    """AC12 defense-in-depth: repository = '..' → CatalogueError naming repository."""
+    text = (
+        '[organization.artifactory]\nenabled = true\n'
+        'base-url = "https://example.test/art"\n'
+        'repository = ".."\nbundle = "b"\nchannel = "c"\n'
+    )
+    with pytest.raises(CatalogueError) as exc:
+        _source_from_org_bootstrap(text, config_path="test-path")
+    assert "repository" in str(exc.value)
+
+
+def test_org_bootstrap_repository_percent_raises():
+    """AC12: repository with % → CatalogueError naming repository."""
+    text = (
+        '[organization.artifactory]\nenabled = true\n'
+        'base-url = "https://example.test/art"\n'
+        'repository = "my%20repo"\nbundle = "b"\nchannel = "c"\n'
+    )
+    with pytest.raises(CatalogueError) as exc:
+        _source_from_org_bootstrap(text, config_path="test-path")
+    assert "repository" in str(exc.value)
+
+
+def test_org_bootstrap_repository_space_raises():
+    """AC12: repository with space → CatalogueError naming repository."""
+    text = (
+        '[organization.artifactory]\nenabled = true\n'
+        'base-url = "https://example.test/art"\n'
+        'repository = "my repo"\nbundle = "b"\nchannel = "c"\n'
+    )
+    with pytest.raises(CatalogueError) as exc:
+        _source_from_org_bootstrap(text, config_path="test-path")
+    assert "repository" in str(exc.value)
+
+
+def test_org_bootstrap_repository_empty_raises():
+    """AC12/AC15: Empty repository → CatalogueError naming repository."""
+    text = (
+        '[organization.artifactory]\nenabled = true\n'
+        'base-url = "https://example.test/art"\n'
+        'repository = ""\nbundle = "b"\nchannel = "c"\n'
+    )
+    with pytest.raises(CatalogueError) as exc:
+        _source_from_org_bootstrap(text, config_path="test-path")
+    assert "repository" in str(exc.value)
+
+
+def test_org_bootstrap_repository_integer_raises():
+    """Type-check: repository = 42 (TOML integer) → CatalogueError naming repository."""
+    text = (
+        '[organization.artifactory]\nenabled = true\n'
+        'base-url = "https://example.test/art"\n'
+        'repository = 42\nbundle = "b"\nchannel = "c"\n'
+    )
+    with pytest.raises(CatalogueError) as exc:
+        _source_from_org_bootstrap(text, config_path="test-path")
+    assert "repository" in str(exc.value)
+
+
+def test_org_bootstrap_bundle_invalid_raises():
+    """AC13: bundle with space → CatalogueError naming bundle."""
+    text = (
+        '[organization.artifactory]\nenabled = true\n'
+        'base-url = "https://example.test/art"\n'
+        'repository = "r"\nbundle = "my bundle"\nchannel = "c"\n'
+    )
+    with pytest.raises(CatalogueError) as exc:
+        _source_from_org_bootstrap(text, config_path="test-path")
+    assert "bundle" in str(exc.value)
+
+
+def test_org_bootstrap_bundle_dotdot_raises():
+    """AC13 defense-in-depth: bundle = '..' → CatalogueError naming bundle."""
+    text = (
+        '[organization.artifactory]\nenabled = true\n'
+        'base-url = "https://example.test/art"\n'
+        'repository = "r"\nbundle = ".."\nchannel = "c"\n'
+    )
+    with pytest.raises(CatalogueError) as exc:
+        _source_from_org_bootstrap(text, config_path="test-path")
+    assert "bundle" in str(exc.value)
+
+
+def test_org_bootstrap_channel_slash_raises():
+    """AC14: channel with / → CatalogueError naming channel."""
+    text = (
+        '[organization.artifactory]\nenabled = true\n'
+        'base-url = "https://example.test/art"\n'
+        'repository = "r"\nbundle = "b"\nchannel = "my/channel"\n'
+    )
+    with pytest.raises(CatalogueError) as exc:
+        _source_from_org_bootstrap(text, config_path="test-path")
+    assert "channel" in str(exc.value)
+
+
+def test_org_bootstrap_channel_dotdot_raises():
+    """AC14 defense-in-depth: channel = '..' → CatalogueError naming channel."""
+    text = (
+        '[organization.artifactory]\nenabled = true\n'
+        'base-url = "https://example.test/art"\n'
+        'repository = "r"\nbundle = "b"\nchannel = ".."\n'
+    )
+    with pytest.raises(CatalogueError) as exc:
+        _source_from_org_bootstrap(text, config_path="test-path")
+    assert "channel" in str(exc.value)
+
+
+def test_org_bootstrap_missing_repository_raises():
+    """AC15: Missing repository when enabled = true → CatalogueError naming repository."""
+    text = (
+        '[organization.artifactory]\nenabled = true\n'
+        'base-url = "https://example.test/art"\n'
+        'bundle = "b"\nchannel = "c"\n'
+    )
+    with pytest.raises(CatalogueError) as exc:
+        _source_from_org_bootstrap(text, config_path="test-path")
+    assert "repository" in str(exc.value)
+
+
+def test_org_bootstrap_missing_bundle_raises():
+    """AC15: Missing bundle → CatalogueError naming bundle."""
+    text = (
+        '[organization.artifactory]\nenabled = true\n'
+        'base-url = "https://example.test/art"\n'
+        'repository = "r"\nchannel = "c"\n'
+    )
+    with pytest.raises(CatalogueError) as exc:
+        _source_from_org_bootstrap(text, config_path="test-path")
+    assert "bundle" in str(exc.value)
+
+
+def test_org_bootstrap_missing_channel_raises():
+    """AC15: Missing channel → CatalogueError naming channel."""
+    text = (
+        '[organization.artifactory]\nenabled = true\n'
+        'base-url = "https://example.test/art"\n'
+        'repository = "r"\nbundle = "b"\n'
+    )
+    with pytest.raises(CatalogueError) as exc:
+        _source_from_org_bootstrap(text, config_path="test-path")
+    assert "channel" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# T2 — error message contract (AC16, AC8)
+# ---------------------------------------------------------------------------
+
+
+def test_org_bootstrap_error_message_contains_field_and_config_path():
+    """AC16: Error messages name the malformed field and the config path."""
+    text = (
+        '[organization.artifactory]\nenabled = true\n'
+        'base-url = "http://example.test/art"\n'
+        'repository = "r"\nbundle = "b"\nchannel = "c"\n'
+    )
+    with pytest.raises(CatalogueError) as exc:
+        _source_from_org_bootstrap(text, config_path="sentinel-path")
+    msg = str(exc.value)
+    assert "base-url" in msg
+    assert "sentinel-path" in msg
+
+
+def test_org_bootstrap_error_message_never_contains_raw_value():
+    """AC8, AC16: Credential in base-url must not appear in error message."""
+    text = (
+        '[organization.artifactory]\nenabled = true\n'
+        'base-url = "https://user:pass@example.test/art"\n'
+        'repository = "r"\nbundle = "b"\nchannel = "c"\n'
+    )
+    with pytest.raises(CatalogueError) as exc:
+        _source_from_org_bootstrap(text, config_path="test-path")
+    msg = str(exc.value)
+    assert "user" not in msg
+    assert "pass" not in msg
+    assert "user:pass" not in msg
+
+
+# ---------------------------------------------------------------------------
+# T2 — valid character acceptance and single-dot edge case
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("repo,bundle,channel", [
+    ("my-repo", "my.bundle", "my_channel"),
+    ("Repo123", "Bundle", "Channel"),
+    ("a", "b", "c"),
+    ("repo.name", "bundle-name", "channel_name"),
+])
+def test_org_bootstrap_valid_chars_accepted(repo, bundle, channel):
+    """Valid [A-Za-z0-9._-]+ values for all segments produce a URL."""
+    text = (
+        f'[organization.artifactory]\nenabled = true\n'
+        f'base-url = "https://example.test/art"\n'
+        f'repository = "{repo}"\nbundle = "{bundle}"\nchannel = "{channel}"\n'
+    )
+    url = _source_from_org_bootstrap(text, config_path="test-path")
+    assert url is not None
+    assert url.startswith("catalogue+https://example.test/art/")
+
+
+def test_org_bootstrap_single_dot_component_accepted():
+    """Single '.' is valid — not '..' so the dotdot guard does not fire."""
+    text = (
+        '[organization.artifactory]\nenabled = true\n'
+        'base-url = "https://example.test/art"\n'
+        'repository = "."\nbundle = "b"\nchannel = "c"\n'
+    )
+    url = _source_from_org_bootstrap(text, config_path="test-path")
+    assert url is not None
+
+
+# ---------------------------------------------------------------------------
+# T2 — security invariants (AC22, AC17)
+# ---------------------------------------------------------------------------
+
+
+def test_org_bootstrap_constructed_url_has_no_user_info():
+    """AC22: Constructed URL contains no '@' (no user-info in netloc)."""
+    url = _source_from_org_bootstrap(_VALID_ORG_TOML, config_path="test-path")
+    assert url is not None
+    assert "@" not in url
+
+
+def test_org_bootstrap_is_valid_source_accepts_constructed_url():
+    """AC17: Constructed catalogue+https:// URL is accepted by _is_valid_source.
+
+    Wave 2b (spec/https-catalogue-channels) has shipped; _is_valid_source now
+    accepts catalogue+https:// URLs. This is a normal passing test (not xfail).
+    """
+    url = _source_from_org_bootstrap(_VALID_ORG_TOML, config_path="test-path")
+    assert url is not None
+    assert _is_valid_source(url) is True
+
+
+# ---------------------------------------------------------------------------
+# T2 — read_org_bootstrap via injected reader
+# ---------------------------------------------------------------------------
+
+
+def test_read_org_bootstrap_disabled_returns_none():
+    """AC4 via public API: disabled TOML → None."""
+    result = read_org_bootstrap(read_text=lambda: (_DISABLED_ORG_TOML, "mock-path"))
+    assert result is None
+
+
+def test_read_org_bootstrap_valid_returns_url():
+    """AC5 via public API: valid enabled = true TOML → constructed URL."""
+    result = read_org_bootstrap(read_text=lambda: (_VALID_ORG_TOML, "mock-path"))
+    assert result == _CONSTRUCTED_URL
+
+
+def test_read_org_bootstrap_invalid_raises():
+    """AC19 prerequisite: invalid base-url propagates CatalogueError."""
+    bad_toml = (
+        '[organization.artifactory]\nenabled = true\n'
+        'base-url = "http://example.test/art"\n'
+        'repository = "r"\nbundle = "b"\nchannel = "c"\n'
+    )
+    with pytest.raises(CatalogueError):
+        read_org_bootstrap(read_text=lambda: (bad_toml, "mock-path"))
+
+
+def test_read_org_bootstrap_reader_returns_none_returns_none():
+    """read_text returning None → read_org_bootstrap returns None."""
+    result = read_org_bootstrap(read_text=lambda: None)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# T3 — Integration: Layer 3 position in resolve_default_source
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_layer3_fires_when_layers1_and_2_absent():
+    """AC18: Layer 3 wins when Layer 1 (explicit) and Layer 2 (config_source) absent."""
+    layer3_url = (
+        "catalogue+https://example.test/art/r/catalogues/b/channels/stable.json"
+    )
+    out = resolve_default_source(
+        None,
+        config_source=None,
+        dist=None,
+        read_org=lambda: layer3_url,
+        read_packaged=lambda: None,
+    )
+    assert out == layer3_url
+
+
+def test_resolve_layer2_beats_layer3():
+    """AC18: Layer 2 config_source wins over Layer 3; read_org is never called."""
+    called: list[bool] = []
+
+    def _read_org_spy() -> str | None:
+        called.append(True)
+        return "catalogue+https://example.test/art/r/catalogues/b/channels/stable.json"
+
+    out = resolve_default_source(
+        None,
+        config_source="git+https://example.test/user-config",
+        dist=None,
+        read_org=_read_org_spy,
+        read_packaged=lambda: None,
+    )
+    assert out == "git+https://example.test/user-config"
+    assert called == [], "read_org must not have been called"
+
+
+def test_resolve_layer3_fail_closed_does_not_fall_through():
+    """AC19: CatalogueError from Layer 3 propagates; Layers 4 and 5 are not reached."""
+
+    class _SentinelDist:
+        def __getattr__(self, name: str):  # type: ignore[override]
+            raise AssertionError(
+                f"Layer 4 editable detection reached (attr: {name!r})"
+            )
+
+    sentinel_dist = _SentinelDist()
+
+    with pytest.raises(CatalogueError, match="org config invalid"):
+        resolve_default_source(
+            None,
+            config_source=None,
+            dist=sentinel_dist,
+            read_org=lambda: (_ for _ in ()).throw(CatalogueError("org config invalid")),
+            read_packaged=lambda: (_ for _ in ()).throw(
+                AssertionError("Layer 5 reached")
+            ),
+        )
+
+
+def test_resolve_layer1_beats_layer3():
+    """AC18 extension: Layer 1 explicit arg wins; read_org is never called."""
+    called: list[bool] = []
+
+    def _read_org_spy() -> str | None:
+        called.append(True)
+        raise AssertionError("read_org must not be called when explicit arg given")
+
+    out = resolve_default_source(
+        "explicit-arg",
+        config_source=None,
+        dist=None,
+        read_org=_read_org_spy,
+        read_packaged=lambda: None,
+    )
+    assert out == "explicit-arg"
+    assert called == [], "read_org must not have been called"


### PR DESCRIPTION
## Summary

- Adds Layer 3 to the five-layer source precedence chain in `source_defaults.py`
- New `[organization.artifactory]` block in `_data/install-defaults.toml` (ships `enabled = false`; no real org endpoints committed)
- `_source_from_org_bootstrap(toml_text, config_path)` — pure function; validates `base-url` (must be `https://`, no user-info, no query/fragment), `repository`/`bundle`/`channel` (`[A-Za-z0-9._-]+`, no `..`), constructs `catalogue+https://` URI; fails closed on `enabled = true` with invalid config
- `read_org_bootstrap()` — reads `install-defaults.toml` via importlib.resources, calls `_source_from_org_bootstrap`
- Layer 3 is evaluated only when Layer 1 (`--catalogue`) and Layer 2 (user config) are both absent
- All error messages name the malformed field and the config path; raw field values containing credentials are never echoed
- 54 unit tests covering all AC2–AC24

## Test plan
- [ ] `make build-check` CI passes
- [ ] `test_org_bootstrap.py` (54 tests)