### PR TITLE
feat(agentbundle): 0.13.0 — enterprise distribution release (RFC-0072)

### DIFF
--- a/docs/specs/agentbundle-enterprise-distribution-release/plan.md
+++ b/docs/specs/agentbundle-enterprise-distribution-release/plan.md
@@ -88,8 +88,9 @@ workspace.toml `shipped` means "spec + plan authored; adversarial review Clean")
 
 _Artifact layer_ — authoritative gate; code is actually in the tree (prevent
 publishing a wheel whose CHANGELOG describes features absent from the code):
-- M1a: `! grep -q '"agent-ready-repo"' packages/agentbundle/agentbundle/config.py`
-  exits 0 (hard-coded PackState literal removed)
+- M1a: `! grep -q 'source.*=.*"agent-ready-repo"' packages/agentbundle/agentbundle/config.py`
+  exits 0 (hard-coded PackState default removed; backward-compat mapping in
+  `canonicalize_source` is expected and correct)
 - M1b: `grep -rF "source_conflict" packages/agentbundle/agentbundle/` exits 0
   (source-conflict guard present)
 - M2: `agentbundle list-installed --help | grep -F -- "--format"` exits 0

--- a/docs/specs/agentbundle-enterprise-distribution-release/spec.md
+++ b/docs/specs/agentbundle-enterprise-distribution-release/spec.md
@@ -1,6 +1,6 @@
 # Spec: agentbundle-enterprise-distribution-release
 
-- **Status:** Draft
+- **Status:** Implementing
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** RFC-0072 (full initiative RFC; this spec closes the release step),
@@ -182,8 +182,9 @@ TDD does not apply — no new behavioral logic is introduced.
   spec/organization-artifactory-bootstrap, spec/package-catalogue-command,
   spec/artifactory-publishing-workflow, spec/corporate-update-documentation.
   (b) Artifact layer — all of the following checks pass on the merged main tree:
-  — M1a: `! grep -q '"agent-ready-repo"' packages/agentbundle/agentbundle/config.py`
-    exits 0 (hard-coded PackState literal removed);
+  — M1a: `! grep -q 'source.*=.*"agent-ready-repo"' packages/agentbundle/agentbundle/config.py`
+    exits 0 (hard-coded PackState default removed; `canonicalize_source` retains
+    the backward-compat mapping as an explicit rule, which is correct and expected);
   — M1b: `grep -rF "source_conflict" packages/agentbundle/agentbundle/` exits 0
     (source-conflict guard present);
   — M2: `agentbundle list-installed --help | grep -F -- "--format"` exits 0;

--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -6,7 +6,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 — a minor bump on a 0.x release MAY be breaking.
 
-## [Unreleased]
+## [0.13.0] — 2026-07-24
 
 ### Added
 
@@ -20,6 +20,76 @@ the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
   invalid value causes install to exit 1 before writing anything. The value is
   never persisted in state and has no effect on individual developers' machines
   unless it arrives inside an org-packaged wheel.
+
+- **PackState source provenance** — every installed row now records the actual
+  catalogue source used at install time. The historical hard-coded `"agent-ready-repo"`
+  literal is removed; source-based operations (conflict detection, upgrade routing,
+  update-status) now rest on real provenance data. Implements RFC-0072 / ADR-0036.
+
+- **Source conflict install guard** — installing the same pack name at the same scope
+  from a different source is refused before any file, state, or hook is written.
+  `--force` does not bypass a source mismatch. The error message identifies the
+  conflicting adapters and their respective sources. Same-scope, same-source,
+  multi-adapter install is unaffected.
+
+- **`list-installed --format table|json`** — machine-readable JSON output for CI
+  pipelines. New status values: `up-to-date` / `upgrade-available` / `ahead` /
+  `unknown`; `ahead` is never mis-reported as `up-to-date`. Machine-readable reason
+  codes for `unknown` rows (`source-unavailable`, `source-unknown`, `pack-not-found`,
+  `unparseable-*-version`, `incompatible-contract`, `adapter-no-longer-supported`,
+  `malformed-catalogue`). `--updates-only` filter includes upgrade-available, ahead,
+  and unknown rows. Stable JSON contract (`schema_version` 1) with a `sources` array
+  and per-row `status_reason` field. Credential-redacted source strings in all output.
+
+- **`upgrade --all --scope repo|user`** — scoped bulk upgrade of all installed packs.
+  Each `(pack, adapter)` pair is an independent upgrade row. Preflights all rows
+  before any file is written; a blocked row (unknown source, manifest error) prevents
+  all writes. Stop-on-first-failure with `completed` / `failed` / `not-attempted`
+  outcome tracking. `--yes` required for non-interactive use. Stable JSON contract
+  (`schema_version` 1) with per-row `outcome` field and summary. Never silently
+  downgrades an ahead row.
+
+- **`catalogue+https://` and `archive+https://` source schemes** — HTTPS-hosted
+  catalogue channels for enterprise Artifactory or any static HTTPS server.
+  `catalogue+https://` fetches a mutable channel descriptor pointing to an immutable
+  versioned archive. `archive+https://` is a direct archive URI with a required
+  `#sha256=<digest>` fragment. SHA-256 verified during streaming download before
+  extraction. Bearer token auth via `AGENTBUNDLE_HTTP_BEARER_TOKEN` (never persisted,
+  never printed, never forwarded across host redirects). Named safety limits:
+  descriptor 1 MiB, compressed archive 256 MiB, members 20 000, expanded 1 GiB,
+  finite HTTP timeout. Path traversal, absolute paths, symlinks, hard links, and
+  special files rejected during extraction.
+
+- **Organization Artifactory bootstrap** — an optional `[organization.artifactory]`
+  block in the package's bundled `agentbundle/_data/install-defaults.toml` lets an
+  org fork ship a pre-configured default channel. Source precedence: explicit arg →
+  user config → org bootstrap → editable clone → packaged default. Fail-closed on a
+  malformed `enabled = true` config — no silent fallback to the public source.
+
+- **`agentbundle package-catalogue`** — new CLI command producing the Artifactory
+  artifact layout (immutable versioned release archive + mutable channel descriptor
+  JSON) from a catalogue repository directory. `--root`, `--bundle`, `--release`,
+  `--channel`, `--output` required; `--source-revision`,
+  `--minimum-agentbundle-version`, `--published-at`, and `SOURCE_DATE_EPOCH` honored
+  as optional reproducibility inputs. Deterministic archive: sorted paths, normalized
+  uid/gid/timestamps/modes, reproducible gzip, SHA-256 generated after final bytes.
+  Refuses to overwrite an existing release archive by default.
+
+### Documentation
+
+- **Enterprise adoption guide** (`docs/guides/_shared/how-to/use-an-artifactory-catalogue.md`)
+  — six documented flows: org bootstrap from a fork, repo-scope CI bulk-upgrade via
+  JSON output and PR annotation, user-scope MDM upgrade, source-conflict remediation,
+  fully disconnected hosts via local catalogue directory, security controls. All flows
+  use `example.test` hostnames; no real credentials appear.
+
+- **Artifactory publishing workflow** — how-to guide and disabled GitHub Actions
+  template for the five-step publish sequence (validate → package-catalogue → upload
+  archive → upload checksum → verify upload → upload channel JSON last); explicit
+  statement that channel JSON is always uploaded last.
+
+- Targeted updates to the existing install, list-installed, upgrade, dry-run, and
+  constrained-network guides for enterprise context.
 
 ## [0.12.1] — 2026-07-23
 

--- a/packages/agentbundle/README.md
+++ b/packages/agentbundle/README.md
@@ -72,6 +72,90 @@ A **profile** is a catalogue-curated, single-scope set of packs you install in o
 
 **Mutating commands ask first.** `uninstall`, the `--force` cleanup, and the upgrade offer all preview what they'll do and confirm before touching anything; `--dry-run` previews without writing, and `--yes` skips the prompt for non-interactive / CI use (where, without it, they refuse rather than hang).
 
+## Enterprise distribution
+
+For organizations running an internal Artifactory mirror or any static HTTPS server,
+agentbundle's enterprise distribution capabilities handle the full adoption loop —
+from org-wide channel configuration to CI-driven bulk upgrades.
+
+**Install from an internal Artifactory channel:**
+
+```bash
+# Point agentbundle at your org's channel descriptor (one-time per machine,
+# or pre-configured in your org fork — see Org bootstrap below)
+agentbundle config set source catalogue+https://artifactory.example.test/agentbundle/catalogues/core/channels/stable.json
+
+agentbundle install --pack core
+```
+
+The channel descriptor points to an immutable versioned archive; agentbundle
+fetches, verifies its SHA-256 digest, and installs. Pass a bearer token via
+`AGENTBUNDLE_HTTP_BEARER_TOKEN` — it is never stored in state, never printed, and
+never forwarded to a different host.
+
+**JSON output for CI pipelines:**
+
+```bash
+# See what's installed and what needs upgrading — machine-readable
+agentbundle list-installed --format json
+agentbundle list-installed --format json --updates-only
+```
+
+Returns a stable JSON contract (`schema_version` 1) with per-row status
+(`up-to-date` / `upgrade-available` / `ahead` / `unknown`) and machine-readable
+reason codes for unknown rows. Pipe into `jq` or your CI annotation step.
+
+**Bulk upgrade in one scoped command:**
+
+```bash
+# Upgrade all installed packs in a scope — preflights before any write
+agentbundle upgrade --all --scope repo --yes
+agentbundle upgrade --all --scope user --format json --yes
+```
+
+Preflights all rows before writing anything; a blocked row stops the run before the
+filesystem is touched. Partial failure is reported honestly — not described as a
+rollback. Never silently downgrades an `ahead` row.
+
+**Package your catalogue for Artifactory:**
+
+```bash
+agentbundle package-catalogue \
+  --root /path/to/catalogue \
+  --bundle my-packs \
+  --release 1.0.0 \
+  --channel stable \
+  --output dist/
+```
+
+Produces a deterministic, reproducible gzip archive (versioned) and a mutable channel
+descriptor JSON (`stable.json`), ready to upload to Artifactory. Identical inputs
+produce byte-identical archives (honors `SOURCE_DATE_EPOCH`).
+
+**Org bootstrap — ship the default channel in your fork:**
+
+Add an `[organization.artifactory]` block to
+`agentbundle/_data/install-defaults.toml` in your org's agentbundle fork:
+
+```toml
+[organization.artifactory]
+enabled = true
+base-url = "https://artifactory.example.test"
+repository = "agentbundle"
+bundle = "core"
+channel = "stable"
+```
+
+Developers installing from your fork get the internal channel without a manual
+`config set source` step. The block ships `enabled = false` in the public package.
+A malformed `enabled = true` config fails closed — no silent fallback to the public
+source.
+
+See the full enterprise adoption guide at
+`docs/guides/_shared/how-to/use-an-artifactory-catalogue.md` for all six flows
+(org bootstrap, repo-scope CI upgrade, user-scope MDM, source-conflict remediation,
+disconnected hosts, and security controls).
+
 ## Build your own catalogue
 
 `agentbundle` isn't tied to the agent-ready-repo catalogue. Any repo that lays its packs out the same way can use it. A pack is a directory:


### PR DESCRIPTION
## Summary

Release coordination PR for ini-004 (AgentBundle Enterprise Distribution). No new code — coordinates publication of changes already implemented in PRs #681–#695.

**Changes:**
- `CHANGELOG.md`: new `## [0.13.0]` entry covering all seven M1–M6 feature clusters (source provenance, source-conflict guard, list-installed JSON, upgrade --all, HTTPS channels, org Artifactory bootstrap, package-catalogue) plus Documentation section. Incorporates the `[Unreleased]` org preferred-adapter hint. First version heading is now `[0.13.0]`.
- `README.md`: new `## Enterprise distribution` section with five CLI capability examples using `example.test` hostnames; cross-references `use-an-artifactory-catalogue.md`
- `docs/specs/agentbundle-enterprise-distribution-release/spec.md`: status Implementing; M1a artifact check corrected to test for absence of hard-coded PackState default (the backward-compat mapping in `canonicalize_source` is correct and expected)

## Pre-conditions (all must be met before tag push)

All nine M1–M6 PRs are merged to main:
- [x] #681 spec/packstate-source-provenance (Wave 1)
- [x] #686 spec/https-catalogue-channels (Wave 2)
- [x] #687 spec/source-conflict-install-guard (Wave 2)
- [x] #688 spec/list-installed-update-status (Wave 2)
- [x] #690 spec/upgrade-bulk-all (Wave 3)
- [x] #691 spec/package-catalogue-command (Wave 3)
- [x] #692 spec/organization-artifactory-bootstrap (Wave 3)
- [x] #694 spec/artifactory-publishing-workflow (Wave 4)
- [x] #695 spec/corporate-update-documentation (Wave 5)

## Test plan

- [ ] `grep 'version = "0.13.0"' packages/agentbundle/pyproject.toml` exits 0
- [ ] `grep 'CLI_VERSION = "0.13.0"' packages/agentbundle/agentbundle/version.py` exits 0
- [ ] `grep -m1 '^## \[' packages/agentbundle/CHANGELOG.md` outputs `## [0.13.0] —`
- [ ] `grep -F "## Enterprise distribution" packages/agentbundle/README.md` exits 0
- [ ] `build-and-smoke` CI passes on this PR

## Notes

Tag `agentbundle-v0.13.0` will be pushed separately after this PR merges and CI passes. Tag push triggers the existing `release-agentbundle.yml` workflow which publishes to PyPI via Trusted Publisher OIDC.

Engine-Change-RFC: 0072