### PR TITLE
feat(iac-terraform): add validated Azure worked example

### DIFF
--- a/packs/iac-terraform/.apm/skills/generate-iac/references/examples/azure/backend.hcl.example
+++ b/packs/iac-terraform/.apm/skills/generate-iac/references/examples/azure/backend.hcl.example
@@ -1,0 +1,5 @@
+resource_group_name  = "<state-rg>"
+storage_account_name = "<state-storage-account>"
+container_name       = "tfstate"
+key                  = "<system>/<env>/terraform.tfstate"
+use_oidc             = true

--- a/packs/iac-terraform/.apm/skills/generate-iac/references/examples/azure/backend.tf
+++ b/packs/iac-terraform/.apm/skills/generate-iac/references/examples/azure/backend.tf
@@ -1,0 +1,3 @@
+terraform {
+  backend "azurerm" {}
+}

--- a/packs/iac-terraform/.apm/skills/generate-iac/references/examples/azure/provider.tf
+++ b/packs/iac-terraform/.apm/skills/generate-iac/references/examples/azure/provider.tf
@@ -1,0 +1,16 @@
+locals {
+  standard_tags = {
+    environment           = var.environment
+    owner                 = var.owner
+    "cost-center"         = var.cost_center
+    "managed-by"          = "terraform"
+    system                = var.system
+    "data-classification" = var.data_classification
+  }
+}
+
+provider "azurerm" {
+  features {}
+
+  subscription_id = var.subscription_id
+}

--- a/packs/iac-terraform/.apm/skills/generate-iac/references/examples/azure/variables.tf
+++ b/packs/iac-terraform/.apm/skills/generate-iac/references/examples/azure/variables.tf
@@ -1,0 +1,30 @@
+variable "subscription_id" {
+  description = "Azure subscription ID"
+  type        = string
+}
+
+variable "environment" {
+  description = "Deployment environment (dev, staging, prod)"
+  type        = string
+}
+
+variable "system" {
+  description = "System or service name — used in resource naming"
+  type        = string
+}
+
+variable "owner" {
+  description = "Team or individual owning this resource"
+  type        = string
+}
+
+variable "cost_center" {
+  description = "Cost center code for billing attribution"
+  type        = string
+}
+
+variable "data_classification" {
+  description = "Data classification level (public, internal, confidential, restricted)"
+  type        = string
+  default     = "internal"
+}

--- a/packs/iac-terraform/.apm/skills/generate-iac/references/examples/azure/versions.tf
+++ b/packs/iac-terraform/.apm/skills/generate-iac/references/examples/azure/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/packs/iac-terraform/.apm/skills/generate-iac/references/providers/azure.md
+++ b/packs/iac-terraform/.apm/skills/generate-iac/references/providers/azure.md
@@ -1,12 +1,4 @@
-# Azure provider reference — experimental, not validated in v1
-
-> **experimental — not validated in v1.** This reference is `contract-complete`
-> but no worked example has passed `init -backend=false && fmt -check &&
-> validate`. Treat as a starting point; verify the four-file contract produces
-> valid HCL for your Azure configuration before relying on it.
->
-> Named maintainer: eugenelim. Deprecation path: if this reference is not
-> validated by v1.1, it will be marked deprecated.
+# Azure provider reference
 
 ## Four-file contract
 


### PR DESCRIPTION
## Summary

- Add five-file worked example under `references/examples/azure/` (versions, variables, provider, backend, backend.hcl.example) matching the shape of the existing aws/ and gcp/ examples
- All three validation gates pass: `terraform init -backend=false`, `terraform fmt -check`, `terraform validate` (azurerm 4.81.0)
- Remove the experimental callout from `providers/azure.md` now that the example is validated

## Test plan

- [x] `terraform init -backend=false` — success
- [x] `terraform fmt -check` — clean (fmt applied to align map values)
- [x] `terraform validate` — "The configuration is valid"